### PR TITLE
feat: per-worktree isolated services (opt-in DB/services per worktree via orca.yaml)

### DIFF
--- a/docs/reference/2026-07-07-worktree-services-design.md
+++ b/docs/reference/2026-07-07-worktree-services-design.md
@@ -57,7 +57,7 @@ services:
 
 - Resolved `env:` values plus `ORCA_WORKTREE_SLUG`/`ORCA_SERVICE_SLOT`/`ORCA_PORT_*` are injected into every PTY (terminals and agents) created for the worktree, sourced from the persisted state. Nothing is written into the worktree.
 - `scripts.setup` and `scripts.archive` receive the same variables, in addition to the existing `ORCA_*` path variables.
-- SSH/WSL: `create`/`destroy` execute where the worktree lives, through the same project-runtime routing as existing hooks (`runHook`). Services run on the worktree's host, not on the machine running Orca.
+- WSL: `create`/`destroy` execute where the worktree lives, mirroring the existing hook runner's WSL routing (`runHook`). SSH/remote worktrees are **not** covered in v1 — the opt-in is hidden whenever `repo.connectionId` is set (see Implementation Notes).
 
 ## UI
 

--- a/docs/reference/2026-07-07-worktree-services-design.md
+++ b/docs/reference/2026-07-07-worktree-services-design.md
@@ -86,11 +86,12 @@ Unit tests only — no Docker-dependent e2e:
 ## Out of Scope
 
 - Per-service opt-in at creation (all-or-nothing).
-- Manual start/stop of provisioned services.
 - Provisioning services on an existing worktree after creation (beyond retry-after-failure).
 - Dynamic port probing (ports are deterministic from the slot via `ORCA_PORT_*`; Orca does not check whether a port is actually free).
 - Data seeding/cloning (a recipe's `create` command owns that).
 
 ## Implementation Notes
 
+- **Services right-sidebar panel & lifecycle commands (added post-v1).** Recipes support optional `start`, `stop`, and `status` commands (`status` exit 0 = running). A "Services" right-sidebar tab (visible only for worktrees with a provisioning record) lists each provisioned service with a live run-state dot probed via `status` (30s timeout; no `status` command → "unknown"), per-service and whole-environment start/stop actions, the slot/port block, resolved env vars, and retry-on-failure. Orca still does not monitor liveness continuously — the state is probed on panel open and after actions.
+- **Startup PTY race (known limitation).** Terminals pre-spawned at app boot can miss the service env if they spawn before the async services hydration resolves; freshly created PTYs (new tabs, splits) always get it.
 - **Remote (SSH) provisioning is deferred to a follow-up.** v1 provisions only local and WSL worktrees; the opt-in is hidden and lifecycle skipped whenever `repo.connectionId` is set. To extend to remote repos, run each service command on the connection host by following the `runRemoteArchiveHook` pattern (`src/main/ipc/worktrees.ts:322`, invoked at the archive-hook site near line 1591) instead of the local `exec` / WSL `wsl.exe` branches in `src/main/worktree-services.ts`. The slot store, slug/port derivation, and env-injection paths are provider-agnostic and can be reused as-is.

--- a/docs/reference/2026-07-07-worktree-services-design.md
+++ b/docs/reference/2026-07-07-worktree-services-design.md
@@ -1,0 +1,92 @@
+# Per-Worktree Isolated Services
+
+**Date:** 2026-07-07
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Worktrees share the developer's dev services (database, cache, queues). Tasks that mutate shared state — schema migrations being the canonical case — break every other worktree and agent session pointing at the same database. There is no first-class way to give a worktree its own isolated copy of the project's services.
+
+Today a project can hack this via `scripts.setup` (`docker compose up`), but the setup script cannot: allocate collision-free ports/names across worktrees, inject connection env vars into the worktree's terminals and agents, or tear services down when the worktree is removed.
+
+## Solution Overview
+
+A new `services:` section in `orca.yaml` declares provider-agnostic service recipes (arbitrary `create`/`destroy` shell commands — Docker, Podman, local binaries, anything). At worktree creation, the user opts in to provisioning; Orca allocates a unique slot, runs the `create` commands, injects declared env vars into every terminal and agent in the worktree, and runs `destroy` automatically when the worktree is removed.
+
+Orca has no notion of "database" — it executes lifecycle commands and injects env vars. Postgres, Redis, Mailhog, or a whole compose stack are all just recipes.
+
+## `orca.yaml` Schema
+
+New top-level key `services:`, following the `environmentRecipes` pattern:
+
+```yaml
+services:
+  - id: db
+    name: Postgres 16
+    create: docker compose -f compose.dev.yaml -p "orca-$ORCA_WORKTREE_SLUG" up -d --wait
+    destroy: docker compose -p "orca-$ORCA_WORKTREE_SLUG" down -v
+    env:
+      DATABASE_URL: postgres://app:app@localhost:${ORCA_PORT_0}/app
+```
+
+(The compose file maps the host port with the same variable, e.g. `"${ORCA_PORT_0}:5432"` — compose reads it from the environment Orca passes to `create`.)
+
+- `id` (unique, same pattern/rule as recipe ids), `name`, `create`: required.
+- `destroy`: optional; absence produces a doctor warning (guaranteed orphans otherwise).
+- `env`: map of environment variables exported to the worktree. Values support substitution of the Orca-provided variables below, performed by Orca (plain string replacement, no shell).
+- Orca provides these variables to `create`/`destroy` commands and to the exported env:
+  - `ORCA_WORKTREE_SLUG` — unique name derived from the worktree.
+  - `ORCA_SERVICE_SLOT` — small integer, unique among live provisioned worktrees, persisted.
+  - `ORCA_PORT_0` … `ORCA_PORT_9` — ten pre-computed host ports, `20000 + slot × 10 + i`. Neither compose files nor Orca's substitution can do arithmetic, so Orca hands out ready-to-use port numbers; recipes never compute ports.
+- Parsing lives in `src/shared/orca-yaml.ts`; `services` is added to `RECOGNIZED_ORCA_YAML_KEYS` in `src/main/hooks.ts`; malformed entries produce diagnostics like `environmentRecipeDiagnostics`.
+
+## Creation Flow
+
+- Worktree creation dialog: when the repo declares `services:`, show an opt-in checkbox "Provision isolated services" (default unchecked). All-or-nothing — no per-service selection.
+- Order: git worktree created → slot allocated → each service's `create` runs sequentially, output streamed into the pending-creation card (same UX as ephemeral-VM provisioning) → `scripts.setup` runs with the service env vars injected, so setup can run migrations against the fresh database.
+- `create` failure: error shown on the creation card; the worktree is kept without services (no git rollback). A "Retry provisioning" action is available on the worktree.
+- `create`/`destroy` timeout: 10 minutes (image pulls), not the 2-minute `HOOK_TIMEOUT`.
+
+## State & Lifecycle
+
+- Main process persists per-worktree provisioning state: `{ slot, serviceIds, env }`, following the `ephemeral-vm-runtime-store.ts` pattern. Slot allocation picks the smallest free integer.
+- Worktree removal/archive: run each provisioned service's `destroy`; failure produces a warning toast but never blocks removal. Slot is freed.
+- Startup orphan cleanup (pattern: `ephemeral-vm-runtime-cleanup.ts`): compare the store against existing worktrees; re-run `destroy` for entries whose worktree is gone (e.g. crash mid-removal), then free their slots.
+
+## Env Injection & Runtime
+
+- Resolved `env:` values plus `ORCA_WORKTREE_SLUG`/`ORCA_SERVICE_SLOT`/`ORCA_PORT_*` are injected into every PTY (terminals and agents) created for the worktree, sourced from the persisted state. Nothing is written into the worktree.
+- `scripts.setup` and `scripts.archive` receive the same variables, in addition to the existing `ORCA_*` path variables.
+- SSH/WSL: `create`/`destroy` execute where the worktree lives, through the same project-runtime routing as existing hooks (`runHook`). Services run on the worktree's host, not on the machine running Orca.
+
+## UI
+
+- Worktree card: badge/indicator for service state (provisioned / error) with a "Retry provisioning" action.
+- No manual start/stop controls (deliberately out of scope; destroy-on-removal only).
+- Repo settings: doctor diagnostics surface recipe problems (pattern: `ephemeral-vm-recipe-doctor.ts`) — missing `destroy` → warning; duplicate/invalid `id` → error.
+
+## Error Handling Summary
+
+| Failure | Behavior |
+| --- | --- |
+| `create` fails | Error on creation card; worktree kept; retry action |
+| `destroy` fails on removal | Warning toast; removal proceeds; slot freed |
+| Orphaned state (crash) | Startup cleanup re-runs `destroy`, frees slot |
+| Malformed recipe | Doctor diagnostic in repo settings |
+
+## Testing
+
+Unit tests only — no Docker-dependent e2e:
+
+- `orca-yaml.ts` parsing: schema validation, diagnostics, `${...}` env substitution.
+- Slot allocation/release: smallest-free-integer, persistence, concurrent worktrees.
+- Lifecycle sequencing: create → setup → destroy ordering; failure paths (create fails, destroy fails).
+- Orphan cleanup: store entries without matching worktrees.
+
+## Out of Scope
+
+- Per-service opt-in at creation (all-or-nothing).
+- Manual start/stop of provisioned services.
+- Provisioning services on an existing worktree after creation (beyond retry-after-failure).
+- Dynamic port probing (ports are deterministic from the slot via `ORCA_PORT_*`; Orca does not check whether a port is actually free).
+- Data seeding/cloning (a recipe's `create` command owns that).

--- a/docs/reference/2026-07-07-worktree-services-design.md
+++ b/docs/reference/2026-07-07-worktree-services-design.md
@@ -90,3 +90,7 @@ Unit tests only — no Docker-dependent e2e:
 - Provisioning services on an existing worktree after creation (beyond retry-after-failure).
 - Dynamic port probing (ports are deterministic from the slot via `ORCA_PORT_*`; Orca does not check whether a port is actually free).
 - Data seeding/cloning (a recipe's `create` command owns that).
+
+## Implementation Notes
+
+- **Remote (SSH) provisioning is deferred to a follow-up.** v1 provisions only local and WSL worktrees; the opt-in is hidden and lifecycle skipped whenever `repo.connectionId` is set. To extend to remote repos, run each service command on the connection host by following the `runRemoteArchiveHook` pattern (`src/main/ipc/worktrees.ts:322`, invoked at the archive-hook site near line 1591) instead of the local `exec` / WSL `wsl.exe` branches in `src/main/worktree-services.ts`. The slot store, slug/port derivation, and env-injection paths are provider-agnostic and can be reused as-is.

--- a/docs/reference/2026-07-07-worktree-services-design.md
+++ b/docs/reference/2026-07-07-worktree-services-design.md
@@ -67,12 +67,12 @@ services:
 
 ## Error Handling Summary
 
-| Failure | Behavior |
-| --- | --- |
-| `create` fails | Error on creation card; worktree kept; retry action |
-| `destroy` fails on removal | Warning toast; removal proceeds; slot freed |
-| Orphaned state (crash) | Startup cleanup re-runs `destroy`, frees slot |
-| Malformed recipe | Doctor diagnostic in repo settings |
+| Failure                    | Behavior                                            |
+| -------------------------- | --------------------------------------------------- |
+| `create` fails             | Error on creation card; worktree kept; retry action |
+| `destroy` fails on removal | Warning toast; removal proceeds; slot freed         |
+| Orphaned state (crash)     | Startup cleanup re-runs `destroy`, frees slot       |
+| Malformed recipe           | Doctor diagnostic in repo settings                  |
 
 ## Testing
 
@@ -93,5 +93,5 @@ Unit tests only — no Docker-dependent e2e:
 ## Implementation Notes
 
 - **Services right-sidebar panel & lifecycle commands (added post-v1).** Recipes support optional `start`, `stop`, and `status` commands (`status` exit 0 = running). A "Services" right-sidebar tab (visible only for worktrees with a provisioning record) lists each provisioned service with a live run-state dot probed via `status` (30s timeout; no `status` command → "unknown"), per-service and whole-environment start/stop actions, the slot/port block, resolved env vars, and retry-on-failure. Orca still does not monitor liveness continuously — the state is probed on panel open and after actions.
-- **Startup PTY race (known limitation).** Terminals pre-spawned at app boot can miss the service env if they spawn before the async services hydration resolves; freshly created PTYs (new tabs, splits) always get it.
+- **Startup PTY ordering.** Freshly created worktrees pass resolved service env directly to the main-spawned startup terminal. App restore awaits the one-time services hydration before reconnecting persisted terminals, so cold fresh-spawns receive the same env as new tabs and splits.
 - **Remote (SSH) provisioning is deferred to a follow-up.** v1 provisions only local and WSL worktrees; the opt-in is hidden and lifecycle skipped whenever `repo.connectionId` is set. To extend to remote repos, run each service command on the connection host by following the `runRemoteArchiveHook` pattern (`src/main/ipc/worktrees.ts:322`, invoked at the archive-hook site near line 1591) instead of the local `exec` / WSL `wsl.exe` branches in `src/main/worktree-services.ts`. The slot store, slug/port derivation, and env-injection paths are provider-agnostic and can be reused as-is.

--- a/docs/reference/plans/2026-07-07-worktree-isolated-services.md
+++ b/docs/reference/plans/2026-07-07-worktree-isolated-services.md
@@ -1,0 +1,1369 @@
+# Per-Worktree Isolated Services Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/reference/2026-07-07-worktree-services-design.md`
+
+**Goal:** Let a worktree opt in, at creation, to isolated per-worktree services (DB, cache, …) declared as `services:` recipes in `orca.yaml`, with unique slot/port allocation, env injection into every PTY, and automatic destroy on worktree removal.
+
+**Architecture:** A new `services:` section in `orca.yaml` (parsed in `src/shared/orca-yaml.ts`) declares `create`/`destroy` shell commands per service. The main process owns provisioning: a dedicated JSON store (`orca-worktree-services.json`, mirroring `ephemeral-vm-runtime-store`) records `{worktreeId, slot, slug, env, status}`; provisioning runs inside the `worktrees:create` IPC handler after the git worktree exists and before setup terminals spawn; destroy runs inside `worktrees:remove`; orphan cleanup runs at app startup. The renderer holds a `worktreeId → env` map (hydrated over IPC) and merges it into the `env` payload of every PTY spawn for that worktree.
+
+**Tech Stack:** Electron main/preload/renderer, TypeScript, Zod (store schema), Vitest, React + zustand (renderer), existing hook-runner machinery (`src/main/hooks.ts`).
+
+## Global Constraints
+
+- Cross-platform: macOS/Linux/Windows. Never hardcode `/`; use `path.join`. Shell selection follows `getHookShell()` in `src/main/hooks.ts` (`cmd.exe` on win32, `/bin/bash` elsewhere). WSL worktrees route commands through `wsl.exe` like `runHook` does.
+- **v1 scope: local + WSL worktrees.** Remote (SSH, `repo.connectionId`) worktrees do not show the opt-in; Task 11 wires the remote path via the `runRemoteArchiveHook` pattern and may be deferred — everything else must keep `repo.connectionId` guards so remote is additive.
+- No `max-lines` disables, no baseline additions (`pnpm check:max-lines-ratchet`). New files stay focused and small.
+- No vague file names (`helpers`, `utils`). Names used here are final: `worktree-service-env.ts`, `worktree-services-store.ts`, `worktree-services.ts` (schema), `src/main/worktree-services.ts` (lifecycle), `src/main/ipc/worktree-services.ts` (IPC).
+- Comments: only non-obvious "why", 1–2 lines.
+- UI follows `docs/STYLEGUIDE.md`; badge/checkbox snippets below copy existing patterns verbatim-adjacent.
+- Env var contract (from spec, exact names): `ORCA_WORKTREE_SLUG`, `ORCA_SERVICE_SLOT`, `ORCA_PORT_0` … `ORCA_PORT_9` where `ORCA_PORT_i = 20000 + slot*10 + i`.
+- Service command timeout: `600_000` ms (10 min), NOT the 2-min `HOOK_TIMEOUT`.
+- Test runner: Vitest. Run a single file with `pnpm vitest run <path>`.
+
+---
+
+### Task 1: `services:` parsing in orca.yaml + shared types
+
+**Files:**
+- Modify: `src/shared/types.ts` (append near `OrcaVmRecipe`, ~line 1979)
+- Modify: `src/shared/orca-yaml.ts`
+- Modify: `src/main/hooks.ts:68-73` (`RECOGNIZED_ORCA_YAML_KEYS`)
+- Test: `src/main/hooks.test.ts` (existing `describe('parseOrcaYaml', …)` at line 43)
+
+**Interfaces:**
+- Produces: `OrcaServiceRecipe = { id: string; name: string; create: string; destroy?: string; env?: Record<string, string> }`; `OrcaHooks.services?: OrcaServiceRecipe[]`; `OrcaHooks.serviceDiagnostics?: OrcaVmRecipeDiagnostic[]` (reuses the existing `{index, field?, message}` diagnostic type). `parseOrcaYaml` returns them.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `describe('parseOrcaYaml', …)` in `src/main/hooks.test.ts`:
+
+```ts
+it('parses services recipes', () => {
+  const yaml = [
+    'services:',
+    '  - id: db',
+    '    name: Postgres 16',
+    '    create: docker compose up -d --wait',
+    '    destroy: docker compose down -v',
+    '    env:',
+    '      DATABASE_URL: postgres://app:app@localhost:${ORCA_PORT_0}/app'
+  ].join('\n')
+  expect(parseOrcaYaml(yaml)).toEqual({
+    scripts: {},
+    services: [
+      {
+        id: 'db',
+        name: 'Postgres 16',
+        create: 'docker compose up -d --wait',
+        destroy: 'docker compose down -v',
+        env: { DATABASE_URL: 'postgres://app:app@localhost:${ORCA_PORT_0}/app' }
+      }
+    ]
+  })
+})
+
+it('reports diagnostics for invalid services entries', () => {
+  const yaml = [
+    'services:',
+    '  - id: db',
+    '    name: A',
+    '    create: echo a',
+    '  - id: db',
+    '    name: B',
+    '    create: echo b',
+    '  - id: "BAD ID"',
+    '    name: C',
+    '    create: echo c',
+    '  - id: nocreate',
+    '    name: D'
+  ].join('\n')
+  const result = parseOrcaYaml(yaml)
+  expect(result?.services).toEqual([{ id: 'db', name: 'A', create: 'echo a' }])
+  expect(result?.serviceDiagnostics).toHaveLength(3)
+})
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `pnpm vitest run src/main/hooks.test.ts -t services`
+Expected: FAIL (`services` undefined in parse result).
+
+- [ ] **Step 3: Add types**
+
+In `src/shared/types.ts`, directly after `OrcaVmRecipeDiagnostic` (~line 1985):
+
+```ts
+export type OrcaServiceRecipe = {
+  id: string
+  name: string
+  create: string
+  destroy?: string
+  env?: Record<string, string>
+}
+```
+
+Extend `OrcaHooks` (lines 1953–1962) with two optional fields, keeping existing comment style:
+
+```ts
+  services?: OrcaServiceRecipe[] // Per-worktree isolated service recipes
+  serviceDiagnostics?: OrcaVmRecipeDiagnostic[] // Non-fatal validation issues from services
+```
+
+- [ ] **Step 4: Implement `normalizeServices` in `src/shared/orca-yaml.ts`**
+
+Add after `normalizeVmRecipes` (reuse `asRecord`, `asTrimmedString`, `ORCA_VM_RECIPE_ID_PATTERN`, `ORCA_VM_RECIPE_ID_RULE`):
+
+```ts
+type ServiceParseResult = {
+  services: OrcaServiceRecipe[]
+  diagnostics: OrcaVmRecipeDiagnostic[]
+}
+
+function normalizeServiceEnv(value: unknown): Record<string, string> | undefined {
+  const record = asRecord(value)
+  if (!record) {
+    return undefined
+  }
+  const env: Record<string, string> = {}
+  for (const [key, raw] of Object.entries(record)) {
+    if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+      env[key] = String(raw)
+    }
+  }
+  return Object.keys(env).length > 0 ? env : undefined
+}
+
+function normalizeServices(value: unknown): ServiceParseResult {
+  const diagnostics: OrcaVmRecipeDiagnostic[] = []
+  if (!Array.isArray(value)) {
+    return { services: [], diagnostics }
+  }
+  const seenIds = new Set<string>()
+  const services = value
+    .map((entry, index) => {
+      const record = asRecord(entry)
+      if (!record) {
+        diagnostics.push({ index, message: 'Service entry must be a mapping.' })
+        return null
+      }
+      const id = asTrimmedString(record.id)
+      const name = asTrimmedString(record.name)
+      const create = asTrimmedString(record.create)
+      if (!id) {
+        diagnostics.push({ index, field: 'id', message: 'Service id is required.' })
+        return null
+      }
+      if (!ORCA_VM_RECIPE_ID_PATTERN.test(id)) {
+        diagnostics.push({
+          index,
+          field: 'id',
+          message: `Invalid service id "${id}". ${ORCA_VM_RECIPE_ID_RULE}`
+        })
+        return null
+      }
+      if (seenIds.has(id)) {
+        diagnostics.push({
+          index,
+          field: 'id',
+          message: `Duplicate service id "${id}". Service ids must be unique.`
+        })
+        return null
+      }
+      if (!name) {
+        diagnostics.push({ index, field: 'name', message: `Service "${id}" is missing name.` })
+        return null
+      }
+      if (!create) {
+        diagnostics.push({ index, field: 'create', message: `Service "${id}" is missing create.` })
+        return null
+      }
+      seenIds.add(id)
+      const destroy = asTrimmedString(record.destroy)
+      const env = normalizeServiceEnv(record.env)
+      return {
+        id,
+        name,
+        create,
+        ...(destroy ? { destroy } : {}),
+        ...(env ? { env } : {})
+      }
+    })
+    .filter((entry): entry is OrcaServiceRecipe => entry !== null)
+  return { services, diagnostics }
+}
+```
+
+In `parseOrcaYaml`: parse `record.services` through `normalizeServices`, include `services`/`serviceDiagnostics` in the emptiness check (lines 150–159) and in the returned object (161–170), same conditional-spread style as `environmentRecipes`. Import `OrcaServiceRecipe` in the type import block.
+
+- [ ] **Step 5: Recognize the key**
+
+In `src/main/hooks.ts:68-73` add `'services'` to `RECOGNIZED_ORCA_YAML_KEYS`.
+
+- [ ] **Step 6: Run tests, verify pass**
+
+Run: `pnpm vitest run src/main/hooks.test.ts`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shared/types.ts src/shared/orca-yaml.ts src/main/hooks.ts src/main/hooks.test.ts
+git commit -m "feat(services): parse per-worktree services recipes from orca.yaml"
+```
+
+---
+
+### Task 2: Service env context — slug, ports, substitution
+
+**Files:**
+- Create: `src/shared/worktree-service-env.ts`
+- Test: `src/shared/worktree-service-env.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `deriveServiceSlug(worktreeName: string, slot: number): string` — lowercased `[a-z0-9-]` slug, max 40 chars, always suffixed `-s<slot>` (uniqueness among live slots).
+  - `buildServiceContextEnv(slug: string, slot: number): Record<string, string>` — `ORCA_WORKTREE_SLUG`, `ORCA_SERVICE_SLOT`, `ORCA_PORT_0..9` (`String(20000 + slot * 10 + i)`).
+  - `resolveServiceEnv(template: Record<string, string> | undefined, contextEnv: Record<string, string>): Record<string, string>` — replaces `${KEY}` for every key of `contextEnv`, plain string replacement, no shell.
+
+- [ ] **Step 1: Write failing tests**
+
+`src/shared/worktree-service-env.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  buildServiceContextEnv,
+  deriveServiceSlug,
+  resolveServiceEnv
+} from './worktree-service-env'
+
+describe('deriveServiceSlug', () => {
+  it('sanitizes and suffixes the slot', () => {
+    expect(deriveServiceSlug('Fix Migrations!', 3)).toBe('fix-migrations-s3')
+  })
+  it('truncates long names but keeps the slot suffix', () => {
+    const slug = deriveServiceSlug('x'.repeat(100), 12)
+    expect(slug.length).toBeLessThanOrEqual(40)
+    expect(slug.endsWith('-s12')).toBe(true)
+  })
+  it('falls back when the name has no usable characters', () => {
+    expect(deriveServiceSlug('***', 0)).toBe('worktree-s0')
+  })
+})
+
+describe('buildServiceContextEnv', () => {
+  it('exposes slug, slot, and ten deterministic ports', () => {
+    const env = buildServiceContextEnv('demo-s2', 2)
+    expect(env.ORCA_WORKTREE_SLUG).toBe('demo-s2')
+    expect(env.ORCA_SERVICE_SLOT).toBe('2')
+    expect(env.ORCA_PORT_0).toBe('20020')
+    expect(env.ORCA_PORT_9).toBe('20029')
+  })
+})
+
+describe('resolveServiceEnv', () => {
+  it('substitutes context variables, plain string replacement', () => {
+    const context = buildServiceContextEnv('demo-s0', 0)
+    expect(
+      resolveServiceEnv({ DATABASE_URL: 'postgres://localhost:${ORCA_PORT_0}/app' }, context)
+    ).toEqual({ DATABASE_URL: 'postgres://localhost:20000/app' })
+  })
+  it('leaves unknown placeholders untouched and handles undefined template', () => {
+    const context = buildServiceContextEnv('demo-s0', 0)
+    expect(resolveServiceEnv({ A: '${NOT_A_VAR}' }, context)).toEqual({ A: '${NOT_A_VAR}' })
+    expect(resolveServiceEnv(undefined, context)).toEqual({})
+  })
+})
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `pnpm vitest run src/shared/worktree-service-env.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+`src/shared/worktree-service-env.ts`:
+
+```ts
+export const SERVICE_PORT_BASE = 20000
+export const SERVICE_PORTS_PER_SLOT = 10
+
+export function deriveServiceSlug(worktreeName: string, slot: number): string {
+  const suffix = `-s${slot}`
+  const base =
+    worktreeName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40 - suffix.length)
+      .replace(/-+$/g, '') || 'worktree'
+  return `${base}${suffix}`
+}
+
+export function buildServiceContextEnv(slug: string, slot: number): Record<string, string> {
+  const env: Record<string, string> = {
+    ORCA_WORKTREE_SLUG: slug,
+    ORCA_SERVICE_SLOT: String(slot)
+  }
+  for (let i = 0; i < SERVICE_PORTS_PER_SLOT; i++) {
+    env[`ORCA_PORT_${i}`] = String(SERVICE_PORT_BASE + slot * SERVICE_PORTS_PER_SLOT + i)
+  }
+  return env
+}
+
+export function resolveServiceEnv(
+  template: Record<string, string> | undefined,
+  contextEnv: Record<string, string>
+): Record<string, string> {
+  if (!template) {
+    return {}
+  }
+  const resolved: Record<string, string> = {}
+  for (const [key, value] of Object.entries(template)) {
+    resolved[key] = value.replace(/\$\{([A-Z0-9_]+)\}/g, (match, name: string) =>
+      name in contextEnv ? contextEnv[name] : match
+    )
+  }
+  return resolved
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `pnpm vitest run src/shared/worktree-service-env.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/worktree-service-env.ts src/shared/worktree-service-env.test.ts
+git commit -m "feat(services): slug, deterministic port block, and env substitution"
+```
+
+---
+
+### Task 3: Worktree services store (persistence + slot allocation)
+
+**Files:**
+- Create: `src/shared/worktree-services.ts` (Zod schema + types)
+- Create: `src/shared/worktree-services-store.ts`
+- Test: `src/shared/worktree-services-store.test.ts`
+
+**Interfaces:**
+- Produces (consumed by Tasks 4–8):
+
+```ts
+export type WorktreeServicesStatus = 'provisioning' | 'ready' | 'create_failed' | 'destroy_failed'
+export type WorktreeServicesRecord = {
+  worktreeId: string
+  repoId: string
+  slot: number
+  slug: string
+  serviceIds: string[]
+  env: Record<string, string> // resolved env, includes ORCA_WORKTREE_SLUG/ORCA_SERVICE_SLOT/ORCA_PORT_*
+  status: WorktreeServicesStatus
+  error?: string
+  createdAt: string
+  updatedAt: string
+}
+// worktree-services-store.ts
+export function getWorktreeServicesStorePath(userDataPath: string): string
+export function listWorktreeServicesRecords(userDataPath: string): WorktreeServicesRecord[]
+export function getWorktreeServicesRecord(userDataPath: string, worktreeId: string): WorktreeServicesRecord | null
+export function allocateServiceSlot(userDataPath: string): number // smallest int >= 0 not used by any record
+export function upsertWorktreeServicesRecord(userDataPath: string, record: WorktreeServicesRecord): WorktreeServicesRecord
+export function removeWorktreeServicesRecord(userDataPath: string, worktreeId: string): WorktreeServicesRecord | null
+```
+
+- [ ] **Step 1: Write failing tests**
+
+`src/shared/worktree-services-store.test.ts` — use a temp dir per test (`fs.mkdtempSync(join(os.tmpdir(), 'orca-svc-'))`), mirroring how `ephemeral-vm-runtime-store` is tested if a test exists (check `src/shared/ephemeral-vm-runtime-store.test.ts` and copy its temp-dir setup verbatim if present):
+
+```ts
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  allocateServiceSlot,
+  getWorktreeServicesRecord,
+  listWorktreeServicesRecords,
+  removeWorktreeServicesRecord,
+  upsertWorktreeServicesRecord
+} from './worktree-services-store'
+import type { WorktreeServicesRecord } from './worktree-services'
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'orca-svc-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function record(worktreeId: string, slot: number): WorktreeServicesRecord {
+  return {
+    worktreeId,
+    repoId: 'repo-1',
+    slot,
+    slug: `wt-s${slot}`,
+    serviceIds: ['db'],
+    env: { ORCA_SERVICE_SLOT: String(slot) },
+    status: 'ready',
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:00.000Z'
+  }
+}
+
+describe('worktree services store', () => {
+  it('starts empty and allocates slot 0', () => {
+    expect(listWorktreeServicesRecords(dir)).toEqual([])
+    expect(allocateServiceSlot(dir)).toBe(0)
+  })
+
+  it('round-trips records and fills slot gaps', () => {
+    upsertWorktreeServicesRecord(dir, record('wt-a', 0))
+    upsertWorktreeServicesRecord(dir, record('wt-b', 2))
+    expect(allocateServiceSlot(dir)).toBe(1)
+    expect(getWorktreeServicesRecord(dir, 'wt-a')?.slot).toBe(0)
+  })
+
+  it('remove frees the slot and returns the removed record', () => {
+    upsertWorktreeServicesRecord(dir, record('wt-a', 0))
+    expect(removeWorktreeServicesRecord(dir, 'wt-a')?.worktreeId).toBe('wt-a')
+    expect(allocateServiceSlot(dir)).toBe(0)
+    expect(removeWorktreeServicesRecord(dir, 'wt-a')).toBeNull()
+  })
+
+  it('upsert replaces the record for the same worktreeId', () => {
+    upsertWorktreeServicesRecord(dir, record('wt-a', 0))
+    upsertWorktreeServicesRecord(dir, { ...record('wt-a', 0), status: 'create_failed' })
+    expect(listWorktreeServicesRecords(dir)).toHaveLength(1)
+    expect(getWorktreeServicesRecord(dir, 'wt-a')?.status).toBe('create_failed')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `pnpm vitest run src/shared/worktree-services-store.test.ts`
+Expected: FAIL (modules not found).
+
+- [ ] **Step 3: Implement schema**
+
+`src/shared/worktree-services.ts` — mirror `src/shared/ephemeral-vm-runtimes.ts` style (read it first):
+
+```ts
+import { z } from 'zod'
+
+export const WorktreeServicesStatusSchema = z.enum([
+  'provisioning',
+  'ready',
+  'create_failed',
+  'destroy_failed'
+])
+export type WorktreeServicesStatus = z.infer<typeof WorktreeServicesStatusSchema>
+
+export const WorktreeServicesRecordSchema = z.object({
+  worktreeId: z.string().min(1),
+  repoId: z.string().min(1),
+  slot: z.number().int().nonnegative(),
+  slug: z.string().min(1),
+  serviceIds: z.array(z.string().min(1)),
+  env: z.record(z.string(), z.string()),
+  status: WorktreeServicesStatusSchema,
+  error: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string()
+})
+export type WorktreeServicesRecord = z.infer<typeof WorktreeServicesRecordSchema>
+
+export const WorktreeServicesStoreSchema = z.object({
+  version: z.literal(1),
+  records: z.array(WorktreeServicesRecordSchema)
+})
+export type WorktreeServicesStore = z.infer<typeof WorktreeServicesStoreSchema>
+```
+
+- [ ] **Step 4: Implement store**
+
+`src/shared/worktree-services-store.ts` — copy the read/write skeleton of `src/shared/ephemeral-vm-runtime-store.ts` (its private `read…`/`write…` pair uses `writeSecureJsonFile`/`hardenExistingSecureFile` from `./secure-file`; keep identical usage):
+
+```ts
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { hardenExistingSecureFile, writeSecureJsonFile } from './secure-file'
+import {
+  WorktreeServicesStoreSchema,
+  type WorktreeServicesRecord,
+  type WorktreeServicesStore
+} from './worktree-services'
+
+const WORKTREE_SERVICES_FILE = 'orca-worktree-services.json'
+
+export function getWorktreeServicesStorePath(userDataPath: string): string {
+  return join(userDataPath, WORKTREE_SERVICES_FILE)
+}
+
+function readStore(userDataPath: string): WorktreeServicesStore {
+  const path = getWorktreeServicesStorePath(userDataPath)
+  if (!existsSync(path)) {
+    return { version: 1, records: [] }
+  }
+  hardenExistingSecureFile(path)
+  try {
+    return WorktreeServicesStoreSchema.parse(JSON.parse(readFileSync(path, 'utf-8')))
+  } catch {
+    return { version: 1, records: [] }
+  }
+}
+
+function writeStore(userDataPath: string, store: WorktreeServicesStore): void {
+  writeSecureJsonFile(getWorktreeServicesStorePath(userDataPath), store)
+}
+
+export function listWorktreeServicesRecords(userDataPath: string): WorktreeServicesRecord[] {
+  return readStore(userDataPath).records
+}
+
+export function getWorktreeServicesRecord(
+  userDataPath: string,
+  worktreeId: string
+): WorktreeServicesRecord | null {
+  return readStore(userDataPath).records.find((r) => r.worktreeId === worktreeId) ?? null
+}
+
+export function allocateServiceSlot(userDataPath: string): number {
+  const used = new Set(readStore(userDataPath).records.map((r) => r.slot))
+  let slot = 0
+  while (used.has(slot)) {
+    slot++
+  }
+  return slot
+}
+
+export function upsertWorktreeServicesRecord(
+  userDataPath: string,
+  record: WorktreeServicesRecord
+): WorktreeServicesRecord {
+  const store = readStore(userDataPath)
+  const records = store.records.filter((r) => r.worktreeId !== record.worktreeId)
+  records.push(record)
+  writeStore(userDataPath, { version: 1, records })
+  return record
+}
+
+export function removeWorktreeServicesRecord(
+  userDataPath: string,
+  worktreeId: string
+): WorktreeServicesRecord | null {
+  const store = readStore(userDataPath)
+  const removed = store.records.find((r) => r.worktreeId === worktreeId) ?? null
+  if (removed) {
+    writeStore(userDataPath, {
+      version: 1,
+      records: store.records.filter((r) => r.worktreeId !== worktreeId)
+    })
+  }
+  return removed
+}
+```
+
+If `writeSecureJsonFile`/`hardenExistingSecureFile` signatures differ from this usage, match whatever `ephemeral-vm-runtime-store.ts` does — that file is the source of truth for the pattern.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `pnpm vitest run src/shared/worktree-services-store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/worktree-services.ts src/shared/worktree-services-store.ts src/shared/worktree-services-store.test.ts
+git commit -m "feat(services): per-worktree services store with slot allocation"
+```
+
+---
+
+### Task 4: Main lifecycle — run commands, provision, destroy
+
+**Files:**
+- Create: `src/main/worktree-services.ts`
+- Test: `src/main/worktree-services.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 `OrcaServiceRecipe`, Task 2 env functions, Task 3 store functions.
+- Produces:
+
+```ts
+export type ServiceProvisionEvent = {
+  provisionId: string
+  serviceId: string
+  stream: 'stdout' | 'stderr'
+  chunk: string
+}
+export type ProvisionWorktreeServicesArgs = {
+  userDataPath: string
+  worktreeId: string
+  worktreeName: string
+  worktreePath: string
+  repo: Repo
+  services: OrcaServiceRecipe[]
+  provisionId?: string
+  onEvent?: (event: ServiceProvisionEvent) => void
+}
+export function provisionWorktreeServices(args: ProvisionWorktreeServicesArgs): Promise<WorktreeServicesRecord>
+export function destroyWorktreeServices(args: {
+  userDataPath: string
+  worktreeId: string
+  worktreePath: string
+  repo: Repo
+  services: OrcaServiceRecipe[]
+}): Promise<{ success: boolean; errors: string[] }>
+export const SERVICE_COMMAND_TIMEOUT_MS = 600_000
+```
+
+Behavior contract:
+- `provisionWorktreeServices`: `allocateServiceSlot` → `deriveServiceSlug(worktreeName, slot)` → `buildServiceContextEnv` → upsert record `status: 'provisioning'` → run each service's `create` **sequentially** (stop at first failure) with `env: { ...process.env, ...contextEnv, ORCA_WORKTREE_PATH: worktreePath }`, `cwd: worktreePath`, shell `/bin/bash` (`cmd.exe` on win32 — same choice as `getHookShell()` in hooks.ts), timeout `SERVICE_COMMAND_TIMEOUT_MS` — on success, merge every recipe's `resolveServiceEnv(recipe.env, contextEnv)` plus `contextEnv` into `record.env`, set `status: 'ready'`; on failure set `status: 'create_failed'`, `error`, keep the record (slot stays reserved so retry reuses it), then **best-effort destroy already-created services** in reverse order.
+- `destroyWorktreeServices`: look up record (no record → `{success: true, errors: []}`); run `destroy` for each provisioned service (recipes without `destroy` are skipped), collecting failures instead of throwing; remove record (freeing the slot) **even when some destroys fail** — the spec makes removal non-blocking; return errors for the caller to log/toast.
+- WSL: when `isWslPath(worktreePath)` (import from `src/main/wsl.ts`), run through `execFile('wsl.exe', …)` exactly like the WSL branch of `runHook` (`src/main/hooks.ts:565+`) — copy that escaping (`replace(/'/g, "'\\''")`) and env-translation approach.
+
+- [ ] **Step 1: Write failing tests**
+
+`src/main/worktree-services.test.ts` — mock `node:child_process.exec` with `vi.mock`; use a temp userData dir like Task 3. Test cases:
+
+```ts
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execMock = vi.hoisted(() => vi.fn())
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return { ...actual, exec: execMock }
+})
+
+import { destroyWorktreeServices, provisionWorktreeServices } from './worktree-services'
+import { getWorktreeServicesRecord } from '../shared/worktree-services-store'
+import type { OrcaServiceRecipe, Repo } from '../shared/types'
+
+const repo = { id: 'repo-1', path: '/tmp/repo' } as Repo
+const services: OrcaServiceRecipe[] = [
+  {
+    id: 'db',
+    name: 'Postgres',
+    create: 'echo create-db',
+    destroy: 'echo destroy-db',
+    env: { DATABASE_URL: 'pg://localhost:${ORCA_PORT_0}/app' }
+  }
+]
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'orca-svc-main-'))
+  execMock.mockReset()
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function execSucceeds(): void {
+  execMock.mockImplementation((_cmd, _opts, cb) => {
+    cb(null, 'ok', '')
+    return { kill: vi.fn() }
+  })
+}
+
+describe('provisionWorktreeServices', () => {
+  it('allocates slot 0, resolves env, persists a ready record', async () => {
+    execSucceeds()
+    const record = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'My Task',
+      worktreePath: '/tmp/repo-worktrees/my-task',
+      repo,
+      services
+    })
+    expect(record.status).toBe('ready')
+    expect(record.slot).toBe(0)
+    expect(record.env.DATABASE_URL).toBe('pg://localhost:20000/app')
+    expect(record.env.ORCA_WORKTREE_SLUG).toBe('my-task-s0')
+    expect(getWorktreeServicesRecord(dir, 'wt-1')?.status).toBe('ready')
+  })
+
+  it('marks create_failed and keeps the record on command failure', async () => {
+    execMock.mockImplementation((_cmd, _opts, cb) => {
+      cb(new Error('boom'), '', 'docker: not found')
+      return { kill: vi.fn() }
+    })
+    const record = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(record.status).toBe('create_failed')
+    expect(record.error).toContain('db')
+    expect(getWorktreeServicesRecord(dir, 'wt-1')?.status).toBe('create_failed')
+  })
+})
+
+describe('destroyWorktreeServices', () => {
+  it('runs destroy, removes the record, frees the slot', async () => {
+    execSucceeds()
+    await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    const result = await destroyWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(result).toEqual({ success: true, errors: [] })
+    expect(getWorktreeServicesRecord(dir, 'wt-1')).toBeNull()
+  })
+
+  it('still removes the record when destroy fails, reporting the error', async () => {
+    execSucceeds()
+    await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    execMock.mockImplementation((_cmd, _opts, cb) => {
+      cb(new Error('gone'), '', '')
+      return { kill: vi.fn() }
+    })
+    const result = await destroyWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(result.success).toBe(false)
+    expect(result.errors).toHaveLength(1)
+    expect(getWorktreeServicesRecord(dir, 'wt-1')).toBeNull()
+  })
+
+  it('is a no-op without a record', async () => {
+    const result = await destroyWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'nope',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(result).toEqual({ success: true, errors: [] })
+    expect(execMock).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `pnpm vitest run src/main/worktree-services.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `src/main/worktree-services.ts`**
+
+Core shape (WSL branch: copy the escaping/exec pattern from `runHook`'s WSL branch in `src/main/hooks.ts` when `isWslPath(worktreePath)`):
+
+```ts
+import { exec } from 'node:child_process'
+import {
+  buildServiceContextEnv,
+  deriveServiceSlug,
+  resolveServiceEnv
+} from '../shared/worktree-service-env'
+import {
+  allocateServiceSlot,
+  getWorktreeServicesRecord,
+  removeWorktreeServicesRecord,
+  upsertWorktreeServicesRecord
+} from '../shared/worktree-services-store'
+import type { OrcaServiceRecipe, Repo } from '../shared/types'
+import type { WorktreeServicesRecord } from '../shared/worktree-services'
+
+export const SERVICE_COMMAND_TIMEOUT_MS = 600_000
+
+function getServiceShell(): string {
+  return process.platform === 'win32' ? process.env.ComSpec || 'cmd.exe' : '/bin/bash'
+}
+
+function runServiceCommand(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+  onChunk?: (stream: 'stdout' | 'stderr', chunk: string) => void
+): Promise<{ success: boolean; output: string }> {
+  return new Promise((resolve) => {
+    const child = exec(
+      command,
+      {
+        cwd,
+        shell: getServiceShell(),
+        timeout: SERVICE_COMMAND_TIMEOUT_MS,
+        env: { ...process.env, ...env }
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          success: !error,
+          output: [stdout, stderr, error ? String(error.message) : '']
+            .filter(Boolean)
+            .join('\n')
+        })
+      }
+    )
+    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
+    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
+  })
+}
+```
+
+`provisionWorktreeServices` / `destroyWorktreeServices` follow the behavior contract above; timestamps via `new Date().toISOString()`. Emit `onEvent` per chunk with the current `serviceId`. On create failure, best-effort destroy of already-created services in reverse order (ignore their errors), record keeps `slot`/`slug` so a retry reuses them (`getWorktreeServicesRecord` first: if an existing `create_failed` record exists, reuse its slot/slug instead of reallocating).
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `pnpm vitest run src/main/worktree-services.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/worktree-services.ts src/main/worktree-services.test.ts
+git commit -m "feat(services): main-process provision/destroy lifecycle"
+```
+
+---
+
+### Task 5: IPC handlers + preload API
+
+**Files:**
+- Create: `src/main/ipc/worktree-services.ts`
+- Modify: `src/main/window/attach-main-window-services.ts` (register next to `registerWorktreeHandlers`, line 85)
+- Modify: `src/preload/api-types.ts` (new `worktreeServices` block, near `ephemeralVm` at ~line 2064)
+- Modify: `src/preload/index.ts` (new block near `ephemeralVm` at ~line 2472)
+- Test: `src/main/ipc/worktree-services.test.ts`
+
+**Interfaces:**
+- Produces preload API `window.api.worktreeServices`:
+
+```ts
+worktreeServices: {
+  list: () => Promise<WorktreeServicesRecord[]>
+  retry: (args: { worktreeId: string }) => Promise<WorktreeServicesRecord>
+  onProvisionEvent: (cb: (event: ServiceProvisionEvent) => void) => () => void
+}
+```
+
+- [ ] **Step 1: Write failing test**
+
+`src/main/ipc/worktree-services.test.ts`: mock `electron` (`ipcMain.handle` capture pattern — copy the mock setup from `src/main/ipc/ephemeral-vm.test.ts`, which already exists and mocks `electron`/`app.getPath`). Assert that `registerWorktreeServicesHandlers(store)` registers `worktreeServices:list` and `worktreeServices:retry`, and that `worktreeServices:list` returns the records from a seeded temp store.
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm vitest run src/main/ipc/worktree-services.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement handlers**
+
+`src/main/ipc/worktree-services.ts` — follow `src/main/ipc/ephemeral-vm-runtime-handlers.ts:42` pattern (`ipcMain.removeHandler` then `ipcMain.handle`):
+
+```ts
+ipcMain.handle('worktreeServices:list', (): WorktreeServicesRecord[] =>
+  listWorktreeServicesRecords(app.getPath('userData'))
+)
+
+ipcMain.handle(
+  'worktreeServices:retry',
+  async (event, args: { worktreeId: string }): Promise<WorktreeServicesRecord> => {
+    // resolve worktree + repo from the persistence store, reload hooks, re-run provisioning
+    // with onEvent → event.sender.send('worktreeServices:provisionEvent', e)
+  }
+)
+```
+
+`retry` resolves the worktree/repo the same way `worktrees:remove` does in `src/main/ipc/worktrees.ts:1345+` (read that handler's worktree lookup and reuse the same store accessors), loads `loadHooks(repo.path)?.services ?? []`, and calls `provisionWorktreeServices` (existing `create_failed` record's slot/slug are reused per Task 4). Register from `attach-main-window-services.ts:85` next to `registerWorktreeHandlers`.
+
+- [ ] **Step 4: Preload plumbing**
+
+`src/preload/api-types.ts`: add the `worktreeServices` block to `PreloadApi` (types above; import `WorktreeServicesRecord` from `src/shared/worktree-services`, `ServiceProvisionEvent` from a type-only import). `src/preload/index.ts` (copy the `ephemeralVm` block shape at 2472–2492 including the `onProvisionEvent` listener add/remove pattern at 2478–2484):
+
+```ts
+worktreeServices: {
+  list: () => ipcRenderer.invoke('worktreeServices:list'),
+  retry: (args) => ipcRenderer.invoke('worktreeServices:retry', args),
+  onProvisionEvent: (callback) => {
+    const listener = (_e: Electron.IpcRendererEvent, event: ServiceProvisionEvent): void =>
+      callback(event)
+    ipcRenderer.on('worktreeServices:provisionEvent', listener)
+    return () => ipcRenderer.removeListener('worktreeServices:provisionEvent', listener)
+  }
+} satisfies PreloadApi['worktreeServices'],
+```
+
+- [ ] **Step 5: Run tests + typecheck, verify pass**
+
+Run: `pnpm vitest run src/main/ipc/worktree-services.test.ts` then `pnpm typecheck` (or the repo's typecheck script from package.json).
+Expected: PASS, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/ipc/worktree-services.ts src/main/window/attach-main-window-services.ts src/preload/api-types.ts src/preload/index.ts src/main/ipc/worktree-services.test.ts
+git commit -m "feat(services): worktreeServices IPC surface and preload API"
+```
+
+---
+
+### Task 6: Provision during `worktrees:create`, env into setup script
+
+**Files:**
+- Modify: `src/shared/types.ts` — `CreateWorktreeArgs` (~line 2067): add `provisionServices?: boolean` and `serviceProvisionId?: string`
+- Modify: `src/main/ipc/worktree-remote.ts` — `createLocalWorktree` (line 1944), around the setup-launch block at 2529–2578
+- Test: extend `src/main/worktree-services.test.ts` only if new pure logic is extracted; the wiring itself is covered by Task 12's e2e-style check
+
+**Interfaces:**
+- Consumes: Task 4 `provisionWorktreeServices`, Task 1 `loadHooks(...).services`.
+- Produces: worktree created with `provisionServices: true` has a `ready` (or `create_failed`) store record before setup terminals spawn; `setup.envVars` includes the resolved service env.
+
+- [ ] **Step 1: Implement wiring in `createLocalWorktree`**
+
+After the worktree exists and `createdEffectiveHooks` is loaded (before the `setupScript` block at 2529), insert:
+
+```ts
+let serviceEnv: Record<string, string> = {}
+const serviceRecipes = createdEffectiveHooks?.services ?? []
+if (args.provisionServices && serviceRecipes.length > 0) {
+  try {
+    const record = await provisionWorktreeServices({
+      userDataPath: app.getPath('userData'),
+      worktreeId: worktree.id,
+      worktreeName: args.name,
+      worktreePath,
+      repo,
+      services: serviceRecipes,
+      provisionId: args.serviceProvisionId,
+      onEvent: (event) => mainWindow.webContents.send('worktreeServices:provisionEvent', event)
+    })
+    if (record.status === 'ready') {
+      serviceEnv = record.env
+    }
+  } catch (error) {
+    console.error(`[services] provisioning failed for ${worktreePath}:`, error)
+  }
+}
+```
+
+(Adapt local identifiers — `worktree.id`, `worktreePath`, `mainWindow` — to the actual names in scope in that function; read the surrounding 50 lines first. A `create_failed` record must NOT abort worktree creation — spec: worktree kept, retry available.)
+
+Then merge into the setup launch: where `setup = createSetupRunnerScript(...)` is assigned (~2570), follow with:
+
+```ts
+if (setup && Object.keys(serviceEnv).length > 0) {
+  setup = { ...setup, envVars: { ...setup.envVars, ...serviceEnv } }
+}
+```
+
+- [ ] **Step 2: Typecheck + existing tests**
+
+Run: `pnpm typecheck && pnpm vitest run src/main/worktree-create-timing.test.ts src/main/hooks.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/types.ts src/main/ipc/worktree-remote.ts
+git commit -m "feat(services): provision isolated services during worktree creation"
+```
+
+---
+
+### Task 7: Destroy on `worktrees:remove` + startup orphan cleanup
+
+**Files:**
+- Modify: `src/main/ipc/worktrees.ts` — inside the `worktrees:remove` handler, next to the archive-hook block at 1587–1605
+- Create: `src/main/worktree-services-orphan-cleanup.ts`
+- Modify: `src/main/index.ts` — call orphan cleanup after app ready / store load (find where other startup maintenance runs; `hydrate-local-pty-registry` callers are a good anchor)
+- Test: `src/main/worktree-services-orphan-cleanup.test.ts`
+
+**Interfaces:**
+- Consumes: Task 4 `destroyWorktreeServices`, Task 3 store.
+- Produces: `cleanupOrphanedWorktreeServices(args: { userDataPath: string; existingWorktreeIds: Set<string>; resolveRepo: (repoId: string) => Repo | null }): Promise<void>`
+
+- [ ] **Step 1: Write failing tests for orphan cleanup**
+
+`src/main/worktree-services-orphan-cleanup.test.ts` — same `exec` mock + temp dir as Task 4:
+
+- Seed two records (`wt-live`, `wt-gone`); `existingWorktreeIds = new Set(['wt-live'])`; `resolveRepo` returns the repo for both. Assert: after cleanup, `wt-gone`'s record is removed (destroy ran — `execMock` called) and `wt-live`'s record is untouched.
+- `resolveRepo` returns `null` for the orphan's repo → record removed without exec (recipes unavailable; freeing the slot beats leaking it forever).
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `pnpm vitest run src/main/worktree-services-orphan-cleanup.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { loadHooks } from './hooks'
+import { destroyWorktreeServices } from './worktree-services'
+import {
+  listWorktreeServicesRecords,
+  removeWorktreeServicesRecord
+} from '../shared/worktree-services-store'
+import type { Repo } from '../shared/types'
+
+export async function cleanupOrphanedWorktreeServices(args: {
+  userDataPath: string
+  existingWorktreeIds: Set<string>
+  resolveRepo: (repoId: string) => Repo | null
+}): Promise<void> {
+  for (const record of listWorktreeServicesRecords(args.userDataPath)) {
+    if (args.existingWorktreeIds.has(record.worktreeId)) {
+      continue
+    }
+    const repo = args.resolveRepo(record.repoId)
+    const services = repo ? (loadHooks(repo.path)?.services ?? []) : []
+    if (repo && services.length > 0) {
+      await destroyWorktreeServices({
+        userDataPath: args.userDataPath,
+        worktreeId: record.worktreeId,
+        worktreePath: repo.path,
+        repo,
+        services
+      })
+    } else {
+      removeWorktreeServicesRecord(args.userDataPath, record.worktreeId)
+    }
+  }
+}
+```
+
+(Note `worktreePath: repo.path` — the worktree directory is gone; destroy commands must be runnable from the repo root, which holds the compose file. This matches the spec's recipe contract: `destroy` references the project name/slug, not worktree files.)
+
+- [ ] **Step 4: Wire destroy into `worktrees:remove`**
+
+In `src/main/ipc/worktrees.ts`, immediately after the archive-hook block (1587–1605), local repos only (`!repo.connectionId`):
+
+```ts
+const serviceRecipes = !repo.connectionId ? (loadHooks(repo.path)?.services ?? []) : []
+const servicesRecord = getWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
+if (servicesRecord) {
+  const destroyResult = await destroyWorktreeServices({
+    userDataPath: app.getPath('userData'),
+    worktreeId: args.worktreeId,
+    worktreePath: canonicalWorktreePath,
+    repo,
+    services: serviceRecipes
+  })
+  if (!destroyResult.success) {
+    console.error(
+      `[services] destroy failed for ${canonicalWorktreePath}:`,
+      destroyResult.errors.join('; ')
+    )
+  }
+}
+```
+
+Failure must never block removal (already guaranteed: `destroyWorktreeServices` never throws).
+
+Wire startup cleanup in `src/main/index.ts` after the persistence store is available: build `existingWorktreeIds` from the store's worktrees, `resolveRepo` from the store's repos, run `void cleanupOrphanedWorktreeServices(...)` without awaiting app readiness on it.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `pnpm vitest run src/main/worktree-services-orphan-cleanup.test.ts && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/worktree-services-orphan-cleanup.ts src/main/worktree-services-orphan-cleanup.test.ts src/main/ipc/worktrees.ts src/main/index.ts
+git commit -m "feat(services): destroy services on worktree removal and clean orphans at startup"
+```
+
+---
+
+### Task 8: Renderer — services state slice + PTY env injection
+
+**Files:**
+- Create: `src/renderer/src/lib/worktree-service-env-injection.ts`
+- Modify: `src/renderer/src/store/slices/worktrees.ts` — add `worktreeServicesEnv: Record<string, Record<string, string>>` state + `hydrateWorktreeServices()` action
+- Modify: `src/renderer/src/components/terminal-pane/pty-connection.ts:2637-2652` (identity-env block)
+- Modify: `src/renderer/src/lib/launch-agent-background-session.ts:141-147`
+- Modify: `src/renderer/src/lib/launch-worktree-background-terminals.ts:56-58`
+- Test: `src/renderer/src/lib/worktree-service-env-injection.test.ts`
+
+**Interfaces:**
+- Produces: `getWorktreeServiceEnv(worktreeId: string | undefined): Record<string, string>` — reads the zustand store, returns `{}` when absent.
+- Consumes: `window.api.worktreeServices.list()` (Task 5).
+
+- [ ] **Step 1: Write failing test**
+
+`worktree-service-env-injection.test.ts` — follow the store-mocking style of `src/renderer/src/lib/launch-worktree-background-terminals.test.ts` (read it first; it already mocks `@/store`). Cases: env returned for a known worktreeId; `{}` for unknown id and for `undefined`.
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm vitest run src/renderer/src/lib/worktree-service-env-injection.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { useAppStore } from '@/store'
+
+export function getWorktreeServiceEnv(
+  worktreeId: string | undefined
+): Record<string, string> {
+  if (!worktreeId) {
+    return {}
+  }
+  return useAppStore.getState().worktreeServicesEnv[worktreeId] ?? {}
+}
+```
+
+Store slice (`worktrees.ts`): add `worktreeServicesEnv: {}` initial state and
+
+```ts
+hydrateWorktreeServices: async () => {
+  const records = await window.api.worktreeServices.list()
+  const worktreeServicesEnv: Record<string, Record<string, string>> = {}
+  for (const record of records) {
+    if (record.status === 'ready') {
+      worktreeServicesEnv[record.worktreeId] = record.env
+    }
+  }
+  set({ worktreeServicesEnv })
+}
+```
+
+Call `hydrateWorktreeServices()` where other startup hydration runs (find the caller that hydrates worktrees at app boot in the same slice) and after any provision/retry completes (Tasks 9–10 call it).
+
+- [ ] **Step 4: Inject at the three PTY env call sites**
+
+Each site merges service env BELOW identity env (identity keys must win). `pty-connection.ts:2645-2651`:
+
+```ts
+const paneEnv = {
+  ...paneStartup?.env,
+  ...getWorktreeServiceEnv(deps.worktreeId),
+  ...paneIdentityEnv
+}
+```
+
+Same one-line spread insertion in `launch-agent-background-session.ts` (before the ORCA_* identity keys, over `startupPlan.env`) and `launch-worktree-background-terminals.ts`.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `pnpm vitest run src/renderer/src/lib/worktree-service-env-injection.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/src/lib/worktree-service-env-injection.ts src/renderer/src/lib/worktree-service-env-injection.test.ts src/renderer/src/store/slices/worktrees.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/lib/launch-agent-background-session.ts src/renderer/src/lib/launch-worktree-background-terminals.ts
+git commit -m "feat(services): inject per-worktree service env into terminals and agents"
+```
+
+---
+
+### Task 9: Composer opt-in checkbox + creation-flow plumbing
+
+**Files:**
+- Modify: `src/renderer/src/lib/pending-worktree-creation.ts` — `WorktreeCreationPhase` (line 19): add `'provisioning-services'`; `WorktreeCreationRequest` (~line 30): add `provisionServices?: boolean`; `getCreationProgressLabel` (line 123): map `'provisioning-services'` → `'Provisioning services…'`
+- Modify: `src/renderer/src/hooks/useComposerState.ts` — checkbox state + request field (request literal at ~4109)
+- Modify: `src/renderer/src/components/NewWorkspaceComposerCard.tsx` — checkbox UI (pattern at 987–1034)
+- Modify: `src/renderer/src/store/slices/worktrees.ts` — `createWorktree` (~2793): thread `provisionServices` + `serviceProvisionId` into `createArgs` (built at 2848–2883)
+- Modify: `src/renderer/src/lib/worktree-creation-flow.ts` — subscribe to provision events around the `createWorktree` call (~140–168)
+
+**Interfaces:**
+- Consumes: `window.api.worktreeServices.onProvisionEvent` (Task 5), `CreateWorktreeArgs.provisionServices`/`serviceProvisionId` (Task 6).
+- Produces: user-visible opt-in; streamed provisioning log on the pending-creation card.
+
+- [ ] **Step 1: Detect service recipes for the selected repo**
+
+In `useComposerState.ts`, the repo's hooks are already consulted for ephemeral recipes (fields at 4091–4107). Expose `repoHasServiceRecipes: boolean` the same way those recipe lists reach the composer (follow `ephemeralVmRecipe` plumbing backwards to find where repo hooks land in renderer state; reuse that source). Gate: local repos only (`!repo.connectionId`).
+
+- [ ] **Step 2: Checkbox UI**
+
+In `NewWorkspaceComposerCard.tsx`, copy the "Reuse branch" control block (987–1034) verbatim-adjacent: same collapsible grid wrapper keyed on `repoHasServiceRecipes`, same sr-only checkbox + emerald check box, label `translate('auto.components.NewWorkspaceComposerCard.provisionIsolatedServices', 'Isolated services')`, hint `translate('auto.components.NewWorkspaceComposerCard.provisionIsolatedServicesHint', 'Provision this workspace\'s own services (database, cache) from orca.yaml.')`. State `provisionServices` defaults to `false`, lives in `useComposerState` next to the reuse-branch state.
+
+- [ ] **Step 3: Thread through request and createArgs**
+
+- `useComposerState.ts` request literal (~4109): add `provisionServices` field.
+- `worktrees.ts` `createWorktree`: accept and copy into `createArgs` as `provisionServices: request.provisionServices`, `serviceProvisionId: creationId` (the creation flow already has `creationId`; pass it the same way `worktree-creation-flow.ts:140-168` passes positional args — extend whichever args object/positional list carries the request there, following `ephemeralVmRuntimeId`'s existing route).
+
+- [ ] **Step 4: Stream provisioning log**
+
+In `worktree-creation-flow.ts` `executeWorktreeCreation` (line 129), when `preparedRequest.provisionServices`, before the `createWorktree` call: set phase `'provisioning-services'` is NOT correct up-front (creation starts with git work) — instead subscribe:
+
+```ts
+const unsubscribeServiceEvents = window.api.worktreeServices.onProvisionEvent?.((event) => {
+  if (event.provisionId !== creationId) {
+    return
+  }
+  const store = useAppStore.getState()
+  const pending = store.pendingWorktreeCreations[creationId]
+  if (!pending) {
+    return
+  }
+  store.updatePendingWorktreeCreation(creationId, {
+    phase: 'provisioning-services',
+    provisioningLog: ((pending.provisioningLog ?? '') + event.chunk).slice(-12_000)
+  })
+})
+```
+
+Unsubscribe in a `finally` around the create call (mirror `ephemeral-vm-worktree-creation.ts:22-43`'s subscribe/finally shape). After successful creation with `provisionServices`, call `useAppStore.getState().hydrateWorktreeServices()`.
+
+- [ ] **Step 5: Verify**
+
+Run: `pnpm typecheck && pnpm vitest run src/renderer/src/lib/setup-script-prompt.test.ts src/renderer/src/lib/worktree-activation.test.ts`
+Expected: PASS (no regressions in creation-flow adjacents). Manual check happens in Task 12.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/src/lib/pending-worktree-creation.ts src/renderer/src/hooks/useComposerState.ts src/renderer/src/components/NewWorkspaceComposerCard.tsx src/renderer/src/store/slices/worktrees.ts src/renderer/src/lib/worktree-creation-flow.ts
+git commit -m "feat(services): isolated-services opt-in in the new-workspace composer"
+```
+
+---
+
+### Task 10: Worktree card badge + retry action
+
+**Files:**
+- Modify: `src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx` — new `ServicesStatusBadge`
+- Modify: `src/renderer/src/components/sidebar/WorktreeCard.tsx` — render badge when a services record exists for the worktree
+- Test: extend `WorktreeCardMetadataStatusBadges`' existing test file if present (check for a sibling `.test.tsx`; if none exists, skip component test — the badge is presentational)
+
+**Interfaces:**
+- Consumes: store `worktreeServicesEnv` is insufficient here (it only holds `ready` env) — extend the Task 8 slice with `worktreeServicesStatus: Record<string, WorktreeServicesStatus>` populated in the same `hydrateWorktreeServices()` pass; `window.api.worktreeServices.retry` (Task 5).
+
+- [ ] **Step 1: Extend hydration with status map** (in `hydrateWorktreeServices`, alongside env: `worktreeServicesStatus[record.worktreeId] = record.status`).
+
+- [ ] **Step 2: Badge component** — copy `IssueStateBadge` (lines 10–58) tone convention:
+
+```tsx
+export function ServicesStatusBadge({ status }: { status: WorktreeServicesStatus }): React.JSX.Element {
+  if (status === 'create_failed' || status === 'destroy_failed') {
+    return (
+      <MetadataStatusBadge
+        label={translate('auto.components.sidebar.WorktreeCardMetadataStatusBadges.servicesFailed', 'Services: Failed')}
+        className="border-red-500/25 bg-red-500/5 text-red-600 dark:text-red-300"
+      >
+        <DatabaseZap />
+      </MetadataStatusBadge>
+    )
+  }
+  return (
+    <MetadataStatusBadge
+      label={translate('auto.components.sidebar.WorktreeCardMetadataStatusBadges.servicesReady', 'Services')}
+      className="border-sky-500/25 bg-sky-500/5 text-sky-600 dark:text-sky-300"
+    >
+      <Database />
+    </MetadataStatusBadge>
+  )
+}
+```
+
+(`Database`, `DatabaseZap` from `lucide-react`.)
+
+- [ ] **Step 3: Render + retry** — in `WorktreeCard.tsx`, read `worktreeServicesStatus[worktree.id]`; render the badge when defined. For `create_failed`, add a context-menu/action entry "Retry services provisioning" (find the card's existing action/context-menu surface and append) calling:
+
+```ts
+await window.api.worktreeServices.retry({ worktreeId: worktree.id })
+await useAppStore.getState().hydrateWorktreeServices()
+```
+
+with a `toast.error(...)` on rejection (import `toast` from `sonner`, already used in `ephemeral-vm-worktree-creation.ts`).
+
+- [ ] **Step 4: Verify** — `pnpm typecheck`; run the sidebar test suites: `pnpm vitest run src/renderer/src/components/sidebar`.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/store/slices/worktrees.ts
+git commit -m "feat(services): worktree card services badge with retry action"
+```
+
+---
+
+### Task 11: Recipe diagnostics surface + remote-repo follow-up note
+
+**Files:**
+- Modify: `src/renderer/src/components/settings/RepositoryHooksSection.tsx` (locate via its test `RepositoryHooksSection.test.ts`)
+- Modify: `docs/reference/2026-07-07-worktree-services-design.md` — append an "Implementation notes" line documenting that remote (SSH) provisioning is a follow-up and where it plugs in (`runRemoteArchiveHook` pattern, `src/main/ipc/worktrees.ts:322`)
+
+**Interfaces:**
+- Consumes: `OrcaHooks.serviceDiagnostics` (Task 1) — reaches the renderer wherever repo hooks are already exposed (follow how `RepositoryHooksSection` obtains hook data today; reuse that channel, extend its payload type if needed).
+
+- [ ] **Step 1: Read `RepositoryHooksSection.tsx` and its data source.** Add a small diagnostics list rendered when `serviceDiagnostics` is non-empty: one line per diagnostic, `text-destructive` styling consistent with existing error text in that section (check STYLEGUIDE tokens; reuse whatever the section uses for hook errors). Include the missing-`destroy` warning: when a parsed service has no `destroy`, render `Service "<id>" has no destroy command — containers will outlive worktrees.` (compute in the component from `hooks.services`; no new parse-time diagnostic needed).
+
+- [ ] **Step 2: Extend `RepositoryHooksSection.test.ts`** with one case: hooks payload containing a `serviceDiagnostics` entry and a destroy-less service renders both messages. Follow the file's existing render/assert style.
+
+- [ ] **Step 3: Run** `pnpm vitest run src/renderer/src/components/settings/RepositoryHooksSection.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/src/components/settings/RepositoryHooksSection.tsx src/renderer/src/components/settings/RepositoryHooksSection.test.ts docs/reference/2026-07-07-worktree-services-design.md
+git commit -m "feat(services): surface service recipe diagnostics in repository settings"
+```
+
+---
+
+### Task 12: End-to-end smoke verification (manual + full suite)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test + lint pass**
+
+Run: `pnpm typecheck && pnpm lint && pnpm vitest run && pnpm check:max-lines-ratchet`
+Expected: all green; zero new baseline entries.
+
+- [ ] **Step 2: Manual smoke (dev app)**
+
+In a scratch git repo, write an `orca.yaml`:
+
+```yaml
+services:
+  - id: marker
+    name: Marker file
+    create: echo "up $ORCA_WORKTREE_SLUG $ORCA_PORT_0" > "/tmp/orca-svc-$ORCA_WORKTREE_SLUG"
+    destroy: rm -f "/tmp/orca-svc-$ORCA_WORKTREE_SLUG"
+    env:
+      MARKER_PORT: ${ORCA_PORT_0}
+```
+
+Then: create a worktree with the checkbox ON → marker file exists, `echo $MARKER_PORT` in the worktree terminal prints `20000` (first slot), badge shows on the card, second opted-in worktree gets `20010`. Delete the first worktree → its marker file is gone and a new worktree reuses slot 0. Create with checkbox OFF → no marker, no badge, no env var.
+
+- [ ] **Step 3: Report results** — paste the manual-check outcomes in the PR/summary; failures loop back to the owning task.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: schema (T1), slug/ports/substitution (T2), slot store (T3), lifecycle + 10-min timeout + reverse-order rollback (T4), IPC/retry/events (T5), create-flow + setup env (T6), destroy-on-remove + orphan cleanup (T7), PTY injection incl. agents (T8), opt-in checkbox + streamed log + phase label (T9), badge + retry (T10), doctor-style diagnostics (T11), verification (T12).
+- Deviation from spec: SSH/remote provisioning is deferred (checkbox hidden for `repo.connectionId` repos); design doc gets an implementation note in T11. WSL is covered via the `runHook` WSL branch pattern in T4.
+- Line refs are anchors from exploration on 2026-07-07 (commit `59b6b89fc` era); re-locate by symbol name if drifted.

--- a/docs/reference/plans/2026-07-07-worktree-isolated-services.md
+++ b/docs/reference/plans/2026-07-07-worktree-isolated-services.md
@@ -1337,7 +1337,7 @@ git commit -m "feat(services): surface service recipe diagnostics in repository 
 
 **Files:** none (verification only)
 
-- [ ] **Step 1: Full test + lint pass**
+- [x] **Step 1: Full test + lint pass**
 
 Run: `pnpm typecheck && pnpm lint && pnpm vitest run && pnpm check:max-lines-ratchet`
 Expected: all green; zero new baseline entries.

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -292,6 +292,50 @@ describe('parseOrcaYaml', () => {
       ]
     })
   })
+
+  it('parses services recipes', () => {
+    const yaml = [
+      'services:',
+      '  - id: db',
+      '    name: Postgres 16',
+      '    create: docker compose up -d --wait',
+      '    destroy: docker compose down -v',
+      '    env:',
+      '      DATABASE_URL: postgres://app:app@localhost:${ORCA_PORT_0}/app'
+    ].join('\n')
+    expect(parseOrcaYaml(yaml)).toEqual({
+      scripts: {},
+      services: [
+        {
+          id: 'db',
+          name: 'Postgres 16',
+          create: 'docker compose up -d --wait',
+          destroy: 'docker compose down -v',
+          env: { DATABASE_URL: 'postgres://app:app@localhost:${ORCA_PORT_0}/app' }
+        }
+      ]
+    })
+  })
+
+  it('reports diagnostics for invalid services entries', () => {
+    const yaml = [
+      'services:',
+      '  - id: db',
+      '    name: A',
+      '    create: echo a',
+      '  - id: db',
+      '    name: B',
+      '    create: echo b',
+      '  - id: "BAD ID"',
+      '    name: C',
+      '    create: echo c',
+      '  - id: nocreate',
+      '    name: D'
+    ].join('\n')
+    const result = parseOrcaYaml(yaml)
+    expect(result?.services).toEqual([{ id: 'db', name: 'A', create: 'echo a' }])
+    expect(result?.serviceDiagnostics).toHaveLength(3)
+  })
 })
 
 describe('hasUnrecognizedOrcaYamlKeys', () => {

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -336,11 +336,21 @@ describe('parseOrcaYaml', () => {
       '    name: C',
       '    create: echo c',
       '  - id: nocreate',
-      '    name: D'
+      '    name: D',
+      '  - id: badenv',
+      '    name: E',
+      '    create: echo e',
+      '    env:',
+      '      GOOD: ok',
+      '      BAD: [not, a, scalar]'
     ].join('\n')
     const result = parseOrcaYaml(yaml)
-    expect(result?.services).toEqual([{ id: 'db', name: 'A', create: 'echo a' }])
-    expect(result?.serviceDiagnostics).toHaveLength(3)
+    expect(result?.services).toEqual([
+      { id: 'db', name: 'A', create: 'echo a' },
+      { id: 'badenv', name: 'E', create: 'echo e', env: { GOOD: 'ok' } }
+    ])
+    expect(result?.serviceDiagnostics).toHaveLength(4)
+    expect(result?.serviceDiagnostics?.at(-1)?.message).toContain('BAD')
   })
 })
 

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -352,6 +352,29 @@ describe('parseOrcaYaml', () => {
     expect(result?.serviceDiagnostics).toHaveLength(4)
     expect(result?.serviceDiagnostics?.at(-1)?.message).toContain('BAD')
   })
+
+  it('drops invalid env keys and reports a diagnostic', () => {
+    const yaml = [
+      'services:',
+      '  - id: db',
+      '    name: A',
+      '    create: echo a',
+      '    env:',
+      '      GOOD_KEY: ok',
+      '      "BAD:KEY": nope',
+      '      "A=B": nope'
+    ].join('\n')
+    const result = parseOrcaYaml(yaml)
+    expect(result?.services).toEqual([
+      { id: 'db', name: 'A', create: 'echo a', env: { GOOD_KEY: 'ok' } }
+    ])
+    expect(result?.serviceDiagnostics).toHaveLength(2)
+    expect(
+      result?.serviceDiagnostics?.every((diagnostic) =>
+        diagnostic.message.includes('valid environment variable name')
+      )
+    ).toBe(true)
+  })
 })
 
 describe('hasUnrecognizedOrcaYamlKeys', () => {

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -361,6 +361,7 @@ describe('parseOrcaYaml', () => {
       '    create: echo a',
       '    env:',
       '      GOOD_KEY: ok',
+      '      ORCA_PORT_0: 29999',
       '      "BAD:KEY": nope',
       '      "A=B": nope'
     ].join('\n')
@@ -368,12 +369,22 @@ describe('parseOrcaYaml', () => {
     expect(result?.services).toEqual([
       { id: 'db', name: 'A', create: 'echo a', env: { GOOD_KEY: 'ok' } }
     ])
-    expect(result?.serviceDiagnostics).toHaveLength(2)
+    expect(result?.serviceDiagnostics).toHaveLength(3)
     expect(
-      result?.serviceDiagnostics?.every((diagnostic) =>
-        diagnostic.message.includes('valid environment variable name')
-      )
+      result?.serviceDiagnostics?.some((diagnostic) => diagnostic.message.includes('reserved'))
     ).toBe(true)
+  })
+
+  it('reports malformed services and env containers', () => {
+    const malformedServices = parseOrcaYaml('services: not-a-list')
+    expect(malformedServices?.services).toBeUndefined()
+    expect(malformedServices?.serviceDiagnostics?.[0]?.message).toBe('Services must be a list.')
+
+    const malformedEnv = parseOrcaYaml(
+      ['services:', '  - id: db', '    name: DB', '    create: echo up', '    env: nope'].join('\n')
+    )
+    expect(malformedEnv?.services).toEqual([{ id: 'db', name: 'DB', create: 'echo up' }])
+    expect(malformedEnv?.serviceDiagnostics?.[0]?.message).toContain('env must be a mapping')
   })
 })
 

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -300,6 +300,9 @@ describe('parseOrcaYaml', () => {
       '    name: Postgres 16',
       '    create: docker compose up -d --wait',
       '    destroy: docker compose down -v',
+      '    start: docker compose start',
+      '    stop: docker compose stop',
+      '    status: docker compose ps -q | grep -q .',
       '    env:',
       '      DATABASE_URL: postgres://app:app@localhost:${ORCA_PORT_0}/app'
     ].join('\n')
@@ -311,6 +314,9 @@ describe('parseOrcaYaml', () => {
           name: 'Postgres 16',
           create: 'docker compose up -d --wait',
           destroy: 'docker compose down -v',
+          start: 'docker compose start',
+          stop: 'docker compose stop',
+          status: 'docker compose ps -q | grep -q .',
           env: { DATABASE_URL: 'postgres://app:app@localhost:${ORCA_PORT_0}/app' }
         }
       ]

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -70,7 +70,8 @@ const RECOGNIZED_ORCA_YAML_KEYS = new Set([
   'scripts',
   'issueCommand',
   'defaultTabs',
-  'environmentRecipes'
+  'environmentRecipes',
+  'services'
 ])
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -208,6 +208,7 @@ import { CliInstaller } from './cli/cli-installer'
 import { installLinuxBareOrcaDispatcher } from './cli/linux-bare-orca-dispatcher'
 import { reconcileManagedWslCliRegistrations } from './cli/wsl-cli-registration-reconciliation'
 import { selfHealRuntimeEnvironmentFocus } from './runtime-environment-focus-self-heal'
+import { cleanupOrphanedWorktreeServices } from './worktree-services-orphan-cleanup'
 
 let mainWindow: BrowserWindow | null = null
 /** Whether a manual app.quit() (Cmd+Q, etc.) is in progress. Shared with the
@@ -1783,6 +1784,16 @@ app.whenReady().then(async () => {
     )
   }
   selfHealRuntimeEnvironmentFocus({ store, userDataPath: app.getPath('userData') })
+  // Why: destroy services whose worktree no longer exists (removed while Orca
+  // was closed). Fire-and-forget — must not block startup; local repos resolve
+  // recipes, missing repos just free the slot. Capture a non-null store ref so
+  // the deferred resolveRepo closure keeps its narrowing.
+  const bootStore = store
+  void cleanupOrphanedWorktreeServices({
+    userDataPath: app.getPath('userData'),
+    existingWorktreeIds: new Set(Object.keys(bootStore.getAllWorktreeMeta())),
+    resolveRepo: (repoId) => bootStore.getRepo(repoId) ?? null
+  })
   applyAppIcon(store.getSettings().appIcon)
   if (shouldSuppressDevEducation({ isDev: is.dev })) {
     suppressDevEducationForStore(store)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1789,10 +1789,12 @@ app.whenReady().then(async () => {
   // recipes, missing repos just free the slot. Capture a non-null store ref so
   // the deferred resolveRepo closure keeps its narrowing.
   const bootStore = store
-  void cleanupOrphanedWorktreeServices({
+  cleanupOrphanedWorktreeServices({
     userDataPath: app.getPath('userData'),
     existingWorktreeIds: new Set(Object.keys(bootStore.getAllWorktreeMeta())),
     resolveRepo: (repoId) => bootStore.getRepo(repoId) ?? null
+  }).catch((error) => {
+    console.warn('[services] startup orphan cleanup failed:', error)
   })
   applyAppIcon(store.getSettings().appIcon)
   if (shouldSuppressDevEducation({ isDev: is.dev })) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -208,7 +208,10 @@ import { CliInstaller } from './cli/cli-installer'
 import { installLinuxBareOrcaDispatcher } from './cli/linux-bare-orca-dispatcher'
 import { reconcileManagedWslCliRegistrations } from './cli/wsl-cli-registration-reconciliation'
 import { selfHealRuntimeEnvironmentFocus } from './runtime-environment-focus-self-heal'
-import { cleanupOrphanedWorktreeServices } from './worktree-services-orphan-cleanup'
+import {
+  cleanupOrphanedWorktreeServices,
+  isWorktreeServicesPathDefinitelyMissing
+} from './worktree-services-orphan-cleanup'
 
 let mainWindow: BrowserWindow | null = null
 /** Whether a manual app.quit() (Cmd+Q, etc.) is in progress. Shared with the
@@ -1792,7 +1795,10 @@ app.whenReady().then(async () => {
   cleanupOrphanedWorktreeServices({
     userDataPath: app.getPath('userData'),
     existingWorktreeIds: new Set(Object.keys(bootStore.getAllWorktreeMeta())),
-    resolveRepo: (repoId) => bootStore.getRepo(repoId) ?? null
+    resolveRepo: (repoId) => bootStore.getRepo(repoId) ?? null,
+    // Why: metadata can be reset independently of Git worktrees. Confirm the
+    // path is truly gone before startup cleanup destroys a still-live database.
+    isWorktreeDefinitelyMissing: isWorktreeServicesPathDefinitelyMissing
   }).catch((error) => {
     console.warn('[services] startup orphan cleanup failed:', error)
   })

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -8,6 +8,7 @@
 // cohesive flow would split awkwardly.
 
 import type { BrowserWindow } from 'electron'
+import { app } from 'electron'
 import { posix, win32 } from 'node:path'
 import { existsSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
@@ -58,6 +59,7 @@ import {
   parseOrcaYaml,
   shouldRunSetupForCreate
 } from '../hooks'
+import { provisionWorktreeServices } from '../worktree-services'
 import { requireSshGitProvider } from '../providers/ssh-git-dispatch'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import type { SshGitProvider } from '../providers/ssh-git-provider'
@@ -2582,6 +2584,32 @@ export async function createLocalWorktree(
   await timing.time('prepare_setup', async () => {
     const createdYamlHooks = loadHooks(worktreePath)
     const createdEffectiveHooks = getEffectiveHooksFromConfig(repo, createdYamlHooks)
+
+    // Why: provision isolated services before setup terminals spawn so the
+    // resolved service env can be injected into the setup runner. A failed
+    // provision must not abort creation — the worktree stays, retry is offered.
+    let serviceEnv: Record<string, string> = {}
+    const serviceRecipes = createdEffectiveHooks?.services ?? []
+    if (args.provisionServices && serviceRecipes.length > 0) {
+      try {
+        const record = await provisionWorktreeServices({
+          userDataPath: app.getPath('userData'),
+          worktreeId: worktree.id,
+          worktreeName: args.name,
+          worktreePath,
+          repo,
+          services: serviceRecipes,
+          provisionId: args.serviceProvisionId,
+          onEvent: (event) => mainWindow.webContents.send('worktreeServices:provisionEvent', event)
+        })
+        if (record.status === 'ready') {
+          serviceEnv = record.env
+        }
+      } catch (error) {
+        console.error(`[services] provisioning failed for ${worktreePath}:`, error)
+      }
+    }
+
     try {
       defaultTabs = getDefaultTabsLaunch(createdYamlHooks, repo, args.setupDecision)
     } catch (error) {
@@ -2625,6 +2653,9 @@ export async function createLocalWorktree(
       } catch (error) {
         console.error(`[hooks] Failed to prepare setup runner for ${worktreePath}:`, error)
       }
+    }
+    if (setup && Object.keys(serviceEnv).length > 0) {
+      setup = { ...setup, envVars: { ...setup.envVars, ...serviceEnv } }
     }
   })
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -59,7 +59,7 @@ import {
   parseOrcaYaml,
   shouldRunSetupForCreate
 } from '../hooks'
-import { provisionWorktreeServices } from '../worktree-services'
+import { loadServiceRecipesForWorktree, provisionWorktreeServices } from '../worktree-services'
 import { requireSshGitProvider } from '../providers/ssh-git-dispatch'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import type { SshGitProvider } from '../providers/ssh-git-provider'
@@ -2588,10 +2588,12 @@ export async function createLocalWorktree(
   await timing.time('prepare_setup', async () => {
     const createdYamlHooks = loadHooks(worktreePath)
     const createdEffectiveHooks = getEffectiveHooksFromConfig(repo, createdYamlHooks)
-    // Why: services come from the raw parsed yaml (like defaultTabs) —
-    // getEffectiveHooksFromConfig only carries setup/archive scripts and
-    // returns null when both are absent, which would drop services entirely.
-    const serviceRecipes = createdYamlHooks?.services ?? []
+    // Why: prefer the new worktree branch's own services, falling back to the
+    // repo root — the composer opt-in is gated on the repo's primary checkout,
+    // so a base branch whose orca.yaml omits services must still provision from
+    // root. loadServiceRecipesForWorktree reads raw yaml (like defaultTabs);
+    // getEffectiveHooksFromConfig only carries setup/archive and would drop them.
+    const serviceRecipes = loadServiceRecipesForWorktree(worktreePath, repo.path)
     if (args.provisionServices && serviceRecipes.length > 0) {
       try {
         const record = await provisionWorktreeServices({
@@ -2664,10 +2666,12 @@ export async function createLocalWorktree(
   // Why: the startup (agent) terminal spawns in-main before the renderer's
   // services hydration resolves, so without this merge the first terminal of a
   // freshly provisioned worktree — where the agent runs migrations — would
-  // miss the isolated-service env entirely.
+  // miss the isolated-service env entirely. Service env is authoritative (it
+  // wins over the launch env), matching the setup runner and every renderer PTY
+  // path, so the isolated DB/port always beats a colliding shared-env default.
   const startupWithServiceEnv =
     args.startup && Object.keys(serviceEnv).length > 0
-      ? { ...args.startup, env: { ...serviceEnv, ...args.startup.env } }
+      ? { ...args.startup, env: { ...args.startup.env, ...serviceEnv } }
       : args.startup
   const stagedStartup = await timing.time('spawn_startup_terminal', () =>
     spawnLocalStartupAndSetupTerminals({

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -2589,7 +2589,10 @@ export async function createLocalWorktree(
     // resolved service env can be injected into the setup runner. A failed
     // provision must not abort creation — the worktree stays, retry is offered.
     let serviceEnv: Record<string, string> = {}
-    const serviceRecipes = createdEffectiveHooks?.services ?? []
+    // Why: services come from the raw parsed yaml (like defaultTabs) —
+    // getEffectiveHooksFromConfig only carries setup/archive scripts and
+    // returns null when both are absent, which would drop services entirely.
+    const serviceRecipes = createdYamlHooks?.services ?? []
     if (args.provisionServices && serviceRecipes.length > 0) {
       try {
         const record = await provisionWorktreeServices({

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -2581,14 +2581,13 @@ export async function createLocalWorktree(
   // the regression this replaced.
   let setup: CreateWorktreeResult['setup']
   let defaultTabs: CreateWorktreeResult['defaultTabs']
+  // Why: provision isolated services before setup terminals spawn so the
+  // resolved service env can be injected into the setup runner. A failed
+  // provision must not abort creation — the worktree stays, retry is offered.
+  let serviceEnv: Record<string, string> = {}
   await timing.time('prepare_setup', async () => {
     const createdYamlHooks = loadHooks(worktreePath)
     const createdEffectiveHooks = getEffectiveHooksFromConfig(repo, createdYamlHooks)
-
-    // Why: provision isolated services before setup terminals spawn so the
-    // resolved service env can be injected into the setup runner. A failed
-    // provision must not abort creation — the worktree stays, retry is offered.
-    let serviceEnv: Record<string, string> = {}
     // Why: services come from the raw parsed yaml (like defaultTabs) —
     // getEffectiveHooksFromConfig only carries setup/archive scripts and
     // returns null when both are absent, which would drop services entirely.
@@ -2662,11 +2661,19 @@ export async function createLocalWorktree(
     }
   })
 
+  // Why: the startup (agent) terminal spawns in-main before the renderer's
+  // services hydration resolves, so without this merge the first terminal of a
+  // freshly provisioned worktree — where the agent runs migrations — would
+  // miss the isolated-service env entirely.
+  const startupWithServiceEnv =
+    args.startup && Object.keys(serviceEnv).length > 0
+      ? { ...args.startup, env: { ...serviceEnv, ...args.startup.env } }
+      : args.startup
   const stagedStartup = await timing.time('spawn_startup_terminal', () =>
     spawnLocalStartupAndSetupTerminals({
       runtime,
       worktree,
-      startup: args.startup,
+      startup: startupWithServiceEnv,
       setup,
       defaultTabs,
       settings,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -59,7 +59,11 @@ import {
   parseOrcaYaml,
   shouldRunSetupForCreate
 } from '../hooks'
-import { loadServiceRecipesForWorktree, provisionWorktreeServices } from '../worktree-services'
+import {
+  loadServiceRecipesForWorktree,
+  provisionWorktreeServices,
+  sanitizeServiceCommandOutput
+} from '../worktree-services'
 import { requireSshGitProvider } from '../providers/ssh-git-dispatch'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import type { SshGitProvider } from '../providers/ssh-git-provider'
@@ -2585,6 +2589,7 @@ export async function createLocalWorktree(
   // resolved service env can be injected into the setup runner. A failed
   // provision must not abort creation — the worktree stays, retry is offered.
   let serviceEnv: Record<string, string> = {}
+  let serviceProvisioningError: string | undefined
   await timing.time('prepare_setup', async () => {
     const createdYamlHooks = loadHooks(worktreePath)
     const createdEffectiveHooks = getEffectiveHooksFromConfig(repo, createdYamlHooks)
@@ -2594,7 +2599,7 @@ export async function createLocalWorktree(
     // root. loadServiceRecipesForWorktree reads raw yaml (like defaultTabs);
     // getEffectiveHooksFromConfig only carries setup/archive and would drop them.
     const serviceRecipes = loadServiceRecipesForWorktree(worktreePath, repo.path)
-    if (args.provisionServices && serviceRecipes.length > 0) {
+    if (args.provisionServices) {
       try {
         const record = await provisionWorktreeServices({
           userDataPath: app.getPath('userData'),
@@ -2608,10 +2613,22 @@ export async function createLocalWorktree(
         })
         if (record.status === 'ready') {
           serviceEnv = record.env
+        } else {
+          serviceProvisioningError = record.error ?? 'Isolated services could not be provisioned.'
         }
       } catch (error) {
+        serviceProvisioningError = sanitizeServiceCommandOutput(
+          error instanceof Error ? error.message : String(error)
+        )
         console.error(`[services] provisioning failed for ${worktreePath}:`, error)
       }
+    }
+
+    // Why: setup/default-tab commands commonly run migrations. If isolated
+    // provisioning failed, launching them without service env can mutate the
+    // shared database this opt-in exists to protect.
+    if (serviceProvisioningError) {
+      return
     }
 
     try {
@@ -2670,9 +2687,11 @@ export async function createLocalWorktree(
   // wins over the launch env), matching the setup runner and every renderer PTY
   // path, so the isolated DB/port always beats a colliding shared-env default.
   const startupWithServiceEnv =
-    args.startup && Object.keys(serviceEnv).length > 0
+    !serviceProvisioningError && args.startup && Object.keys(serviceEnv).length > 0
       ? { ...args.startup, env: { ...args.startup.env, ...serviceEnv } }
-      : args.startup
+      : serviceProvisioningError
+        ? undefined
+        : args.startup
   const stagedStartup = await timing.time('spawn_startup_terminal', () =>
     spawnLocalStartupAndSetupTerminals({
       runtime,
@@ -2695,6 +2714,7 @@ export async function createLocalWorktree(
         ? { setup }
         : {}),
     ...(defaultTabs ? { defaultTabs } : {}),
+    ...(serviceProvisioningError ? { serviceProvisioningError } : {}),
     ...(addResult.localBaseRefRefresh
       ? { localBaseRefRefresh: addResult.localBaseRefRefresh }
       : {}),

--- a/src/main/ipc/worktree-services.test.ts
+++ b/src/main/ipc/worktree-services.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<string, (event: unknown, args: never) => Promise<unknown> | unknown>()
+const { handleMock, removeHandlerMock, getPathMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  getPathMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: getPathMock },
+  ipcMain: { handle: handleMock, removeHandler: removeHandlerMock }
+}))
+
+import { registerWorktreeServicesHandlers } from './worktree-services'
+import { upsertWorktreeServicesRecord } from '../../shared/worktree-services-store'
+import type { WorktreeServicesRecord } from '../../shared/worktree-services'
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'orca-svc-ipc-'))
+  handlers.clear()
+  handleMock.mockReset()
+  removeHandlerMock.mockReset()
+  getPathMock.mockReset()
+  getPathMock.mockReturnValue(dir)
+  handleMock.mockImplementation((channel: string, fn: never) => {
+    handlers.set(channel, fn as never)
+  })
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function record(worktreeId: string): WorktreeServicesRecord {
+  return {
+    worktreeId,
+    repoId: 'repo-1',
+    slot: 0,
+    slug: 'wt-s0',
+    serviceIds: ['db'],
+    env: { ORCA_SERVICE_SLOT: '0' },
+    status: 'ready',
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:00.000Z'
+  }
+}
+
+const store = { getRepo: vi.fn(), getWorktreeMeta: vi.fn() } as never
+
+describe('registerWorktreeServicesHandlers', () => {
+  it('registers list and retry handlers', () => {
+    registerWorktreeServicesHandlers(store)
+    expect(handlers.has('worktreeServices:list')).toBe(true)
+    expect(handlers.has('worktreeServices:retry')).toBe(true)
+  })
+
+  it('list returns records from the store', async () => {
+    upsertWorktreeServicesRecord(dir, record('wt-1'))
+    registerWorktreeServicesHandlers(store)
+    const list = handlers.get('worktreeServices:list')!
+    const result = await list({}, undefined as never)
+    expect(result).toEqual([record('wt-1')])
+  })
+})

--- a/src/main/ipc/worktree-services.test.ts
+++ b/src/main/ipc/worktree-services.test.ts
@@ -15,6 +15,14 @@ vi.mock('electron', () => ({
   ipcMain: { handle: handleMock, removeHandler: removeHandlerMock }
 }))
 
+const { provisionMock } = vi.hoisted(() => ({ provisionMock: vi.fn() }))
+vi.mock('../worktree-services', () => ({
+  getWorktreeServicesRuntime: vi.fn(),
+  loadServiceRecipesForWorktree: vi.fn(() => []),
+  provisionWorktreeServices: provisionMock,
+  runWorktreeServiceAction: vi.fn()
+}))
+
 import { registerWorktreeServicesHandlers } from './worktree-services'
 import { upsertWorktreeServicesRecord } from '../../shared/worktree-services-store'
 import type { WorktreeServicesRecord } from '../../shared/worktree-services'
@@ -64,5 +72,29 @@ describe('registerWorktreeServicesHandlers', () => {
     const list = handlers.get('worktreeServices:list')!
     const result = await list({}, undefined as never)
     expect(result).toEqual([record('wt-1')])
+  })
+
+  it('joins concurrent retries for the same worktree instead of double-provisioning', async () => {
+    const repoStore = {
+      getRepo: vi.fn(() => ({ id: 'repo-1', path: '/tmp/repo' })),
+      getWorktreeMeta: vi.fn(() => undefined)
+    } as never
+    let release: ((value: WorktreeServicesRecord) => void) | undefined
+    provisionMock.mockImplementation(
+      () =>
+        new Promise<WorktreeServicesRecord>((resolve) => {
+          release = resolve
+        })
+    )
+    registerWorktreeServicesHandlers(repoStore)
+    const retry = handlers.get('worktreeServices:retry')!
+    const event = { sender: { send: vi.fn() } }
+    const worktreeId = 'repo-1::/tmp/wt'
+    const first = retry(event, { worktreeId } as never)
+    const second = retry(event, { worktreeId } as never)
+    release!(record(worktreeId))
+    const [a, b] = await Promise.all([first, second])
+    expect(provisionMock).toHaveBeenCalledTimes(1)
+    expect(a).toEqual(b)
   })
 })

--- a/src/main/ipc/worktree-services.ts
+++ b/src/main/ipc/worktree-services.ts
@@ -12,22 +12,23 @@ import type {
   WorktreeServiceRuntimeState,
   WorktreeServicesRecord
 } from '../../shared/worktree-services'
-import type { OrcaServiceRecipe } from '../../shared/types'
+import type { OrcaServiceRecipe, Repo } from '../../shared/types'
 import { parseWorktreeId } from './worktree-logic'
 
 function resolveServicesContext(
   store: Store,
   worktreeId: string
-): { worktreePath: string; services: OrcaServiceRecipe[] } {
+): { repo: Repo; worktreePath: string; services: OrcaServiceRecipe[] } {
   const { repoId, worktreePath } = parseWorktreeId(worktreeId)
   const repo = store.getRepo(repoId)
   if (!repo) {
     throw new Error(`Repo not found: ${repoId}`)
   }
+  // Why: v1 provisions local + WSL worktrees only; remote repos never opt in.
   if (repo.connectionId) {
     throw new Error('Isolated services are not supported for remote repositories.')
   }
-  return { worktreePath, services: loadHooks(repo.path)?.services ?? [] }
+  return { repo, worktreePath, services: loadHooks(repo.path)?.services ?? [] }
 }
 
 export function registerWorktreeServicesHandlers(store: Store): void {
@@ -43,16 +44,7 @@ export function registerWorktreeServicesHandlers(store: Store): void {
   ipcMain.handle(
     'worktreeServices:retry',
     async (event, args: { worktreeId: string }): Promise<WorktreeServicesRecord> => {
-      const { repoId, worktreePath } = parseWorktreeId(args.worktreeId)
-      const repo = store.getRepo(repoId)
-      if (!repo) {
-        throw new Error(`Repo not found: ${repoId}`)
-      }
-      // Why: v1 provisions local + WSL worktrees only; remote repos never opt in.
-      if (repo.connectionId) {
-        throw new Error('Service provisioning is not supported for remote repositories.')
-      }
-      const services = loadHooks(repo.path)?.services ?? []
+      const { repo, worktreePath, services } = resolveServicesContext(store, args.worktreeId)
       const worktreeName =
         store.getWorktreeMeta(args.worktreeId)?.displayName ?? basename(worktreePath)
       return provisionWorktreeServices({

--- a/src/main/ipc/worktree-services.ts
+++ b/src/main/ipc/worktree-services.ts
@@ -1,9 +1,9 @@
 import { basename } from 'node:path'
 import { app, ipcMain } from 'electron'
 import type { Store } from '../persistence'
-import { loadHooks } from '../hooks'
 import {
   getWorktreeServicesRuntime,
+  loadServiceRecipesForWorktree,
   provisionWorktreeServices,
   runWorktreeServiceAction
 } from '../worktree-services'
@@ -28,7 +28,7 @@ function resolveServicesContext(
   if (repo.connectionId) {
     throw new Error('Isolated services are not supported for remote repositories.')
   }
-  return { repo, worktreePath, services: loadHooks(repo.path)?.services ?? [] }
+  return { repo, worktreePath, services: loadServiceRecipesForWorktree(worktreePath, repo.path) }
 }
 
 export function registerWorktreeServicesHandlers(store: Store): void {
@@ -41,13 +41,20 @@ export function registerWorktreeServicesHandlers(store: Store): void {
     listWorktreeServicesRecords(app.getPath('userData'))
   )
 
+  // Why: the card badge retry has no disabled state; a double-click must join
+  // the in-flight provision instead of racing two create runs on one slug.
+  const retriesInFlight = new Map<string, Promise<WorktreeServicesRecord>>()
   ipcMain.handle(
     'worktreeServices:retry',
     async (event, args: { worktreeId: string }): Promise<WorktreeServicesRecord> => {
+      const inFlight = retriesInFlight.get(args.worktreeId)
+      if (inFlight) {
+        return inFlight
+      }
       const { repo, worktreePath, services } = resolveServicesContext(store, args.worktreeId)
       const worktreeName =
         store.getWorktreeMeta(args.worktreeId)?.displayName ?? basename(worktreePath)
-      return provisionWorktreeServices({
+      const retry = provisionWorktreeServices({
         userDataPath: app.getPath('userData'),
         worktreeId: args.worktreeId,
         worktreeName,
@@ -56,7 +63,9 @@ export function registerWorktreeServicesHandlers(store: Store): void {
         services,
         onEvent: (provisionEvent) =>
           event.sender.send('worktreeServices:provisionEvent', provisionEvent)
-      })
+      }).finally(() => retriesInFlight.delete(args.worktreeId))
+      retriesInFlight.set(args.worktreeId, retry)
+      return retry
     }
   )
 

--- a/src/main/ipc/worktree-services.ts
+++ b/src/main/ipc/worktree-services.ts
@@ -2,14 +2,39 @@ import { basename } from 'node:path'
 import { app, ipcMain } from 'electron'
 import type { Store } from '../persistence'
 import { loadHooks } from '../hooks'
-import { provisionWorktreeServices } from '../worktree-services'
+import {
+  getWorktreeServicesRuntime,
+  provisionWorktreeServices,
+  runWorktreeServiceAction
+} from '../worktree-services'
 import { listWorktreeServicesRecords } from '../../shared/worktree-services-store'
-import type { WorktreeServicesRecord } from '../../shared/worktree-services'
+import type {
+  WorktreeServiceRuntimeState,
+  WorktreeServicesRecord
+} from '../../shared/worktree-services'
+import type { OrcaServiceRecipe } from '../../shared/types'
 import { parseWorktreeId } from './worktree-logic'
+
+function resolveServicesContext(
+  store: Store,
+  worktreeId: string
+): { worktreePath: string; services: OrcaServiceRecipe[] } {
+  const { repoId, worktreePath } = parseWorktreeId(worktreeId)
+  const repo = store.getRepo(repoId)
+  if (!repo) {
+    throw new Error(`Repo not found: ${repoId}`)
+  }
+  if (repo.connectionId) {
+    throw new Error('Isolated services are not supported for remote repositories.')
+  }
+  return { worktreePath, services: loadHooks(repo.path)?.services ?? [] }
+}
 
 export function registerWorktreeServicesHandlers(store: Store): void {
   ipcMain.removeHandler('worktreeServices:list')
   ipcMain.removeHandler('worktreeServices:retry')
+  ipcMain.removeHandler('worktreeServices:runtime')
+  ipcMain.removeHandler('worktreeServices:action')
 
   ipcMain.handle('worktreeServices:list', (): WorktreeServicesRecord[] =>
     listWorktreeServicesRecords(app.getPath('userData'))
@@ -39,6 +64,37 @@ export function registerWorktreeServicesHandlers(store: Store): void {
         services,
         onEvent: (provisionEvent) =>
           event.sender.send('worktreeServices:provisionEvent', provisionEvent)
+      })
+    }
+  )
+
+  ipcMain.handle(
+    'worktreeServices:runtime',
+    async (_event, args: { worktreeId: string }): Promise<WorktreeServiceRuntimeState[]> => {
+      const { worktreePath, services } = resolveServicesContext(store, args.worktreeId)
+      return getWorktreeServicesRuntime({
+        userDataPath: app.getPath('userData'),
+        worktreeId: args.worktreeId,
+        worktreePath,
+        services
+      })
+    }
+  )
+
+  ipcMain.handle(
+    'worktreeServices:action',
+    async (
+      _event,
+      args: { worktreeId: string; action: 'start' | 'stop'; serviceId?: string }
+    ): Promise<{ success: boolean; errors: string[] }> => {
+      const { worktreePath, services } = resolveServicesContext(store, args.worktreeId)
+      return runWorktreeServiceAction({
+        userDataPath: app.getPath('userData'),
+        worktreeId: args.worktreeId,
+        worktreePath,
+        services,
+        action: args.action,
+        ...(args.serviceId ? { serviceId: args.serviceId } : {})
       })
     }
   )

--- a/src/main/ipc/worktree-services.ts
+++ b/src/main/ipc/worktree-services.ts
@@ -1,0 +1,45 @@
+import { basename } from 'node:path'
+import { app, ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import { loadHooks } from '../hooks'
+import { provisionWorktreeServices } from '../worktree-services'
+import { listWorktreeServicesRecords } from '../../shared/worktree-services-store'
+import type { WorktreeServicesRecord } from '../../shared/worktree-services'
+import { parseWorktreeId } from './worktree-logic'
+
+export function registerWorktreeServicesHandlers(store: Store): void {
+  ipcMain.removeHandler('worktreeServices:list')
+  ipcMain.removeHandler('worktreeServices:retry')
+
+  ipcMain.handle('worktreeServices:list', (): WorktreeServicesRecord[] =>
+    listWorktreeServicesRecords(app.getPath('userData'))
+  )
+
+  ipcMain.handle(
+    'worktreeServices:retry',
+    async (event, args: { worktreeId: string }): Promise<WorktreeServicesRecord> => {
+      const { repoId, worktreePath } = parseWorktreeId(args.worktreeId)
+      const repo = store.getRepo(repoId)
+      if (!repo) {
+        throw new Error(`Repo not found: ${repoId}`)
+      }
+      // Why: v1 provisions local + WSL worktrees only; remote repos never opt in.
+      if (repo.connectionId) {
+        throw new Error('Service provisioning is not supported for remote repositories.')
+      }
+      const services = loadHooks(repo.path)?.services ?? []
+      const worktreeName =
+        store.getWorktreeMeta(args.worktreeId)?.displayName ?? basename(worktreePath)
+      return provisionWorktreeServices({
+        userDataPath: app.getPath('userData'),
+        worktreeId: args.worktreeId,
+        worktreeName,
+        worktreePath,
+        repo,
+        services,
+        onEvent: (provisionEvent) =>
+          event.sender.send('worktreeServices:provisionEvent', provisionEvent)
+      })
+    }
+  )
+}

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -1,3 +1,4 @@
+import { tmpdir } from 'node:os'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as GitUsernameModule from '../git/git-username'
 
@@ -65,6 +66,11 @@ vi.mock('electron', () => ({
   ipcMain: {
     handle: handleMock,
     removeHandler: removeHandlerMock
+  },
+  // Why: worktrees:remove reads the worktree-services store via app.getPath;
+  // no store file exists under this dir, so the destroy path is a no-op here.
+  app: {
+    getPath: () => tmpdir()
   }
 }))
 

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -113,6 +113,11 @@ vi.mock('electron', () => ({
   ipcMain: {
     handle: handleMock,
     removeHandler: removeHandlerMock
+  },
+  // Why: worktrees:remove reads the worktree-services store via app.getPath;
+  // no store file exists under this dir, so the destroy path is a no-op here.
+  app: {
+    getPath: () => tmpdir()
   }
 }))
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2,7 +2,11 @@
 import type { BrowserWindow } from 'electron'
 import { app, ipcMain } from 'electron'
 import { destroyWorktreeServices, loadServiceRecipesForWorktree } from '../worktree-services'
-import { getWorktreeServicesRecord } from '../../shared/worktree-services-store'
+import {
+  getWorktreeServicesRecord,
+  removeWorktreeServicesRecord,
+  upsertWorktreeServicesRecord
+} from '../../shared/worktree-services-store'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
@@ -1721,6 +1725,9 @@ export function registerWorktreeHandlers(
         }
 
         let serviceDestroyErrors: string[] | undefined
+        const servicesRecord = !repo.connectionId
+          ? getWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
+          : null
 
         if (repo.connectionId) {
           // Why: SSH deletion mirrors the local flow: hooks run while the
@@ -1830,14 +1837,14 @@ export function registerWorktreeHandlers(
         // the startup orphan-cleanup sweep. Never blocks removal; errors travel
         // back on the result so the renderer can warn the user.
         if (!repo.connectionId) {
-          const servicesRecord = getWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
           if (servicesRecord) {
             const destroyResult = await destroyWorktreeServices({
               userDataPath: app.getPath('userData'),
               worktreeId: args.worktreeId,
               worktreePath: canonicalWorktreePath,
               repo,
-              services: loadServiceRecipesForWorktree(canonicalWorktreePath, repo.path)
+              services: loadServiceRecipesForWorktree(canonicalWorktreePath, repo.path),
+              releaseRecord: false
             })
             if (!destroyResult.success) {
               serviceDestroyErrors = destroyResult.errors
@@ -1850,7 +1857,20 @@ export function registerWorktreeHandlers(
         }
 
         let removalResult: RemoveWorktreeResult | undefined
-        const removalGate = await runtime.acquireFileWatcherRemoval(canonicalWorktreePath)
+        const removalGate = await runtime
+          .acquireFileWatcherRemoval(canonicalWorktreePath)
+          .catch((error) => {
+            if (servicesRecord) {
+              upsertWorktreeServicesRecord(app.getPath('userData'), {
+                ...servicesRecord,
+                status: 'create_failed',
+                error:
+                  'Worktree removal stopped isolated services but did not remove the worktree. Retry provisioning.',
+                updatedAt: new Date().toISOString()
+              })
+            }
+            throw error
+          })
         let removalCompleted = false
         try {
           // Why: preflight ignores only these configured paths without mutating
@@ -1897,6 +1917,9 @@ export function registerWorktreeHandlers(
             if (recoveredRemovalResult) {
               removalResult = recoveredRemovalResult
               removalCompleted = true
+              if (servicesRecord) {
+                removeWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
+              }
             } else if (isOrphanedWorktreeError(error)) {
               // If git no longer tracks this worktree, clean up the directory and metadata
               console.warn(
@@ -1941,6 +1964,9 @@ export function registerWorktreeHandlers(
               invalidateAuthorizedRootsCache()
               notifyWorktreesChanged(mainWindow, repoId)
               removalCompleted = true
+              if (servicesRecord) {
+                removeWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
+              }
               return serviceDestroyErrors ? { serviceDestroyErrors } : {}
             } else {
               throw new Error(
@@ -1949,8 +1975,26 @@ export function registerWorktreeHandlers(
             }
           }
           removalCompleted = true
+          if (servicesRecord) {
+            removeWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
+          }
         } finally {
-          await removalGate.finish(removalCompleted)
+          try {
+            await removalGate.finish(removalCompleted)
+          } finally {
+            // Why: destroy happens while the worktree directory still exists.
+            // If Git removal then fails, retain the slot and expose retry state
+            // instead of leaving a live worktree silently without its services.
+            if (!removalCompleted && servicesRecord) {
+              upsertWorktreeServicesRecord(app.getPath('userData'), {
+                ...servicesRecord,
+                status: 'create_failed',
+                error:
+                  'Worktree removal stopped isolated services but did not remove the worktree. Retry provisioning.',
+                updatedAt: new Date().toISOString()
+              })
+            }
+          }
         }
         await cleanupUnusedWorktreePushTargetRemote(
           repo.path,

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines */
 import type { BrowserWindow } from 'electron'
 import { app, ipcMain } from 'electron'
-import { destroyWorktreeServices } from '../worktree-services'
+import { destroyWorktreeServices, loadServiceRecipesForWorktree } from '../worktree-services'
 import { getWorktreeServicesRecord } from '../../shared/worktree-services-store'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
@@ -1837,7 +1837,7 @@ export function registerWorktreeHandlers(
               worktreeId: args.worktreeId,
               worktreePath: canonicalWorktreePath,
               repo,
-              services: loadHooks(repo.path)?.services ?? []
+              services: loadServiceRecipesForWorktree(canonicalWorktreePath, repo.path)
             })
             if (!destroyResult.success) {
               serviceDestroyErrors = destroyResult.errors

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1,6 +1,8 @@
 /* oxlint-disable max-lines */
 import type { BrowserWindow } from 'electron'
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
+import { destroyWorktreeServices } from '../worktree-services'
+import { getWorktreeServicesRecord } from '../../shared/worktree-services-store'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
@@ -1715,6 +1717,27 @@ export function registerWorktreeHandlers(
               `[hooks] archive hook failed for ${canonicalWorktreePath}:`,
               result.output
             )
+          }
+        }
+
+        // Why: destroy isolated services before git removal, local repos only (v1
+        // scope). Never blocks removal — destroyWorktreeServices collects errors.
+        if (!repo.connectionId) {
+          const servicesRecord = getWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
+          if (servicesRecord) {
+            const destroyResult = await destroyWorktreeServices({
+              userDataPath: app.getPath('userData'),
+              worktreeId: args.worktreeId,
+              worktreePath: canonicalWorktreePath,
+              repo,
+              services: loadHooks(repo.path)?.services ?? []
+            })
+            if (!destroyResult.success) {
+              console.error(
+                `[services] destroy failed for ${canonicalWorktreePath}:`,
+                destroyResult.errors.join('; ')
+              )
+            }
           }
         }
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1720,29 +1720,7 @@ export function registerWorktreeHandlers(
           }
         }
 
-        // Why: destroy isolated services before git removal, local repos only (v1
-        // scope). Never blocks removal — destroyWorktreeServices collects errors,
-        // which travel back on the result so the renderer can warn the user.
         let serviceDestroyErrors: string[] | undefined
-        if (!repo.connectionId) {
-          const servicesRecord = getWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
-          if (servicesRecord) {
-            const destroyResult = await destroyWorktreeServices({
-              userDataPath: app.getPath('userData'),
-              worktreeId: args.worktreeId,
-              worktreePath: canonicalWorktreePath,
-              repo,
-              services: loadHooks(repo.path)?.services ?? []
-            })
-            if (!destroyResult.success) {
-              serviceDestroyErrors = destroyResult.errors
-              console.error(
-                `[services] destroy failed for ${canonicalWorktreePath}:`,
-                destroyResult.errors.join('; ')
-              )
-            }
-          }
-        }
 
         if (repo.connectionId) {
           // Why: SSH deletion mirrors the local flow: hooks run while the
@@ -1843,6 +1821,32 @@ export function registerWorktreeHandlers(
           }
           // Why: Git can still classify this as an orphan after preflight;
           // retain strict PTY teardown before any recursive fallback deletion.
+        }
+
+        // Why: destroy isolated services only after the clean check proves the
+        // removal will proceed — destroying earlier would irreversibly drop the
+        // services record for a worktree that a dirty-tree abort leaves standing.
+        // Exotic orphan-directory paths that return earlier are reconciled by
+        // the startup orphan-cleanup sweep. Never blocks removal; errors travel
+        // back on the result so the renderer can warn the user.
+        if (!repo.connectionId) {
+          const servicesRecord = getWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
+          if (servicesRecord) {
+            const destroyResult = await destroyWorktreeServices({
+              userDataPath: app.getPath('userData'),
+              worktreeId: args.worktreeId,
+              worktreePath: canonicalWorktreePath,
+              repo,
+              services: loadHooks(repo.path)?.services ?? []
+            })
+            if (!destroyResult.success) {
+              serviceDestroyErrors = destroyResult.errors
+              console.error(
+                `[services] destroy failed for ${canonicalWorktreePath}:`,
+                destroyResult.errors.join('; ')
+              )
+            }
+          }
         }
 
         let removalResult: RemoveWorktreeResult | undefined

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1721,7 +1721,9 @@ export function registerWorktreeHandlers(
         }
 
         // Why: destroy isolated services before git removal, local repos only (v1
-        // scope). Never blocks removal — destroyWorktreeServices collects errors.
+        // scope). Never blocks removal — destroyWorktreeServices collects errors,
+        // which travel back on the result so the renderer can warn the user.
+        let serviceDestroyErrors: string[] | undefined
         if (!repo.connectionId) {
           const servicesRecord = getWorktreeServicesRecord(app.getPath('userData'), args.worktreeId)
           if (servicesRecord) {
@@ -1733,6 +1735,7 @@ export function registerWorktreeHandlers(
               services: loadHooks(repo.path)?.services ?? []
             })
             if (!destroyResult.success) {
+              serviceDestroyErrors = destroyResult.errors
               console.error(
                 `[services] destroy failed for ${canonicalWorktreePath}:`,
                 destroyResult.errors.join('; ')
@@ -1934,7 +1937,7 @@ export function registerWorktreeHandlers(
               invalidateAuthorizedRootsCache()
               notifyWorktreesChanged(mainWindow, repoId)
               removalCompleted = true
-              return {}
+              return serviceDestroyErrors ? { serviceDestroyErrors } : {}
             } else {
               throw new Error(
                 formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
@@ -1963,7 +1966,7 @@ export function registerWorktreeHandlers(
         invalidateAuthorizedRootsCache()
 
         notifyWorktreesChanged(mainWindow, repoId)
-        return removalResult ?? {}
+        return { ...removalResult, ...(serviceDestroyErrors ? { serviceDestroyErrors } : {}) }
       })()
       worktreeRemovalsInFlight.set(inFlightKey, { optionsKey, promise: removal })
       try {

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../shared/types'
 import { registerRepoHandlers } from '../ipc/repos'
 import { registerWorktreeHandlers } from '../ipc/worktrees'
+import { registerWorktreeServicesHandlers } from '../ipc/worktree-services'
 import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
 import { getLocalPtyProvider, registerPtyHandlers } from '../ipc/pty'
 import { registerDaemonManagementHandlers } from '../ipc/pty-management'
@@ -84,6 +85,7 @@ export function attachMainWindowServices(
   registerAppReloadHandler(mainWindow, options?.onBeforeRendererReload)
   registerRepoHandlers(mainWindow, store)
   registerWorktreeHandlers(mainWindow, store, runtime)
+  registerWorktreeServicesHandlers(store)
   // Why: repo/settings mutations resync watchers through this attached main-window context.
   setWorktreeBaseDirectoryWatcherSyncContext(store, mainWindow)
   scheduleWorktreeBaseDirectoryWatcherSync(store, mainWindow)

--- a/src/main/worktree-service-command.test.ts
+++ b/src/main/worktree-service-command.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeServiceCommandOutput } from './worktree-service-command'
+
+describe('sanitizeServiceCommandOutput', () => {
+  it('redacts credentials embedded in connection strings', () => {
+    expect(sanitizeServiceCommandOutput('postgres://user:secret@host/db')).toBe(
+      'postgres://user:[redacted]@host/db'
+    )
+  })
+
+  it('redacts labelled secrets', () => {
+    expect(sanitizeServiceCommandOutput('PASSWORD=hunter2')).toBe('PASSWORD=[redacted]')
+    expect(sanitizeServiceCommandOutput('api_key: abc123')).toBe('api_key: [redacted]')
+  })
+
+  it('redacts HTTP authorization headers and bare bearer tokens', () => {
+    expect(sanitizeServiceCommandOutput('Authorization: Bearer abc.def.ghi')).toBe(
+      'Authorization: [redacted]'
+    )
+    expect(sanitizeServiceCommandOutput('sent Bearer sk-secret-token now')).toBe(
+      'sent Bearer [redacted] now'
+    )
+  })
+
+  it('caps output at 2000 characters', () => {
+    expect(sanitizeServiceCommandOutput('x'.repeat(5000))).toHaveLength(2000)
+  })
+})

--- a/src/main/worktree-service-command.ts
+++ b/src/main/worktree-service-command.ts
@@ -33,13 +33,20 @@ function safeChunk(
 // commands routinely print connection strings and credentials, so scrub the
 // obvious secret shapes and cap the size before anything leaves this module.
 export function sanitizeServiceCommandOutput(text: string): string {
-  return text
-    .replace(/(\w+:\/\/[^\s:@/]+):[^\s@/]+@/g, '$1:[redacted]@')
-    .replace(
-      /((?:password|passwd|token|secret|api[_-]?key|access[_-]?key)\s*[=:]\s*)\S+/gi,
-      '$1[redacted]'
-    )
-    .slice(0, 2000)
+  return (
+    text
+      .replace(/(\w+:\/\/[^\s:@/]+):[^\s@/]+@/g, '$1:[redacted]@')
+      .replace(
+        /((?:password|passwd|token|secret|api[_-]?key|access[_-]?key)\s*[=:]\s*)\S+/gi,
+        '$1[redacted]'
+      )
+      // Why: HTTP auth headers routinely print during service create (curl, docker
+      // login); redact the whole credential after Authorization, plus any bare
+      // `Bearer <token>`.
+      .replace(/((?:authorization)\s*[=:]\s*)[^\n]+/gi, '$1[redacted]')
+      .replace(/\b(bearer\s+)\S+/gi, '$1[redacted]')
+      .slice(0, 2000)
+  )
 }
 
 function getServiceShell(): string {

--- a/src/main/worktree-service-command.ts
+++ b/src/main/worktree-service-command.ts
@@ -1,0 +1,103 @@
+import { exec, execFile } from 'node:child_process'
+import { isWslPath, parseWslPath, toLinuxPath } from './wsl'
+
+export const SERVICE_COMMAND_TIMEOUT_MS = 600_000
+// Why: status probes run on every panel open; a hung probe must not sit for 10 minutes.
+export const SERVICE_STATUS_TIMEOUT_MS = 30_000
+
+export type ServiceCommandResult = { success: boolean; output: string }
+export type ServiceCommandStreamHandler = (stream: 'stdout' | 'stderr', chunk: string) => void
+
+// Why: raw create/destroy output is persisted and surfaced in the UI; service
+// commands routinely print connection strings and credentials, so scrub the
+// obvious secret shapes and cap the size before anything leaves this module.
+export function sanitizeServiceCommandOutput(text: string): string {
+  return text
+    .replace(/(\w+:\/\/[^\s:@/]+):[^\s@/]+@/g, '$1:[redacted]@')
+    .replace(
+      /((?:password|passwd|token|secret|api[_-]?key|access[_-]?key)\s*[=:]\s*)\S+/gi,
+      '$1[redacted]'
+    )
+    .slice(0, 2000)
+}
+
+function getServiceShell(): string {
+  return process.platform === 'win32' ? process.env.ComSpec || 'cmd.exe' : '/bin/bash'
+}
+
+export function runServiceCommand(
+  command: string,
+  worktreePath: string,
+  env: Record<string, string>,
+  onChunk?: ServiceCommandStreamHandler,
+  timeoutMs: number = SERVICE_COMMAND_TIMEOUT_MS
+): Promise<ServiceCommandResult> {
+  const wslInfo = isWslPath(worktreePath) ? parseWslPath(worktreePath) : null
+  if (wslInfo) {
+    return runServiceCommandWsl(command, wslInfo, env, onChunk, timeoutMs)
+  }
+  return new Promise((resolve) => {
+    const child = exec(
+      command,
+      {
+        cwd: worktreePath,
+        shell: getServiceShell(),
+        timeout: timeoutMs,
+        env: { ...process.env, ...env }
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          success: !error,
+          output: [stdout, stderr, error ? String(error.message) : ''].filter(Boolean).join('\n')
+        })
+      }
+    )
+    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
+    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
+  })
+}
+
+function runServiceCommandWsl(
+  command: string,
+  wslInfo: { distro: string; linuxPath: string },
+  env: Record<string, string>,
+  onChunk?: ServiceCommandStreamHandler,
+  timeoutMs: number = SERVICE_COMMAND_TIMEOUT_MS
+): Promise<ServiceCommandResult> {
+  // Why: route through wsl.exe (not exec/cmd.exe) so WSL worktree commands are
+  // not mangled by the Windows shell. Only the cwd is single-quote escaped —
+  // the command goes verbatim into `bash -c`, where escaping it would corrupt
+  // legitimate quoting inside the recipe.
+  const escapedCwd = wslInfo.linuxPath.replace(/'/g, "'\\''")
+  const bashCmd = `cd '${escapedCwd}' && ${command}`
+  const wslEnv: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    wslEnv[key] = toLinuxPath(value)
+  }
+  // Why: wsl.exe only imports Windows env vars named in WSLENV; without this
+  // the ORCA_* context and recipe env would never reach the WSL session.
+  const passthrough = Object.keys(env)
+    .map((key) => `${key}/u`)
+    .join(':')
+  wslEnv.WSLENV = process.env.WSLENV ? `${process.env.WSLENV}:${passthrough}` : passthrough
+  return new Promise((resolve) => {
+    const distroArgs = wslInfo.distro ? ['-d', wslInfo.distro] : []
+    const child = execFile(
+      'wsl.exe',
+      [...distroArgs, '--', 'bash', '-c', bashCmd],
+      {
+        timeout: timeoutMs,
+        encoding: 'utf-8',
+        env: { ...process.env, ...wslEnv }
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          success: !error,
+          output: [stdout, stderr, error ? String(error.message) : ''].filter(Boolean).join('\n')
+        })
+      }
+    )
+    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
+    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
+  })
+}

--- a/src/main/worktree-service-command.ts
+++ b/src/main/worktree-service-command.ts
@@ -1,12 +1,33 @@
 import { exec, execFile } from 'node:child_process'
+import { promptGuardShellEnv } from './git/runner'
 import { isWslPath, parseWslPath, toLinuxPath } from './wsl'
 
 export const SERVICE_COMMAND_TIMEOUT_MS = 600_000
 // Why: status probes run on every panel open; a hung probe must not sit for 10 minutes.
 export const SERVICE_STATUS_TIMEOUT_MS = 30_000
+// Why: exec kills the child once buffered output exceeds maxBuffer; the default
+// 1 MiB is routinely blown by `docker compose up` image pulls, which would fail
+// (and roll back) an otherwise healthy create. Output persisted to the store is
+// still capped by sanitizeServiceCommandOutput.
+const SERVICE_COMMAND_MAX_BUFFER = 64 * 1024 * 1024
 
 export type ServiceCommandResult = { success: boolean; output: string }
 export type ServiceCommandStreamHandler = (stream: 'stdout' | 'stderr', chunk: string) => void
+
+// Why: stream handlers forward to webContents.send, which throws once the
+// window is destroyed mid-provision; a throw inside a stream 'data' listener
+// would escape the promise as an uncaught main-process exception.
+function safeChunk(
+  onChunk: ServiceCommandStreamHandler | undefined,
+  stream: 'stdout' | 'stderr',
+  chunk: unknown
+): void {
+  try {
+    onChunk?.(stream, String(chunk))
+  } catch {
+    // Drop the chunk — provisioning must outlive its progress listener.
+  }
+}
 
 // Why: raw create/destroy output is persisted and surfaced in the UI; service
 // commands routinely print connection strings and credentials, so scrub the
@@ -43,7 +64,11 @@ export function runServiceCommand(
         cwd: worktreePath,
         shell: getServiceShell(),
         timeout: timeoutMs,
-        env: { ...process.env, ...env }
+        maxBuffer: SERVICE_COMMAND_MAX_BUFFER,
+        // Why: service commands run unattended — same Git Credential Manager
+        // prompt guard as the hook runner (issue #7652), so a `git fetch`
+        // inside a recipe cannot pop an OAuth window and hang the provision.
+        env: promptGuardShellEnv({ ...process.env, ...env })
       },
       (error, stdout, stderr) => {
         resolve({
@@ -52,8 +77,8 @@ export function runServiceCommand(
         })
       }
     )
-    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
-    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
+    child.stdout?.on('data', (chunk: string) => safeChunk(onChunk, 'stdout', chunk))
+    child.stderr?.on('data', (chunk: string) => safeChunk(onChunk, 'stderr', chunk))
   })
 }
 
@@ -88,7 +113,11 @@ function runServiceCommandWsl(
       {
         timeout: timeoutMs,
         encoding: 'utf-8',
-        env: { ...process.env, ...wslEnv }
+        maxBuffer: SERVICE_COMMAND_MAX_BUFFER,
+        // Why: same unattended Git Credential Manager guard as the hook
+        // runner's WSL branch (issue #7652); its WSLENV registration is what
+        // carries the guard across the wsl.exe boundary into the distro.
+        env: promptGuardShellEnv({ ...process.env, ...wslEnv })
       },
       (error, stdout, stderr) => {
         resolve({
@@ -97,7 +126,7 @@ function runServiceCommandWsl(
         })
       }
     )
-    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
-    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
+    child.stdout?.on('data', (chunk: string) => safeChunk(onChunk, 'stdout', chunk))
+    child.stderr?.on('data', (chunk: string) => safeChunk(onChunk, 'stderr', chunk))
   })
 }

--- a/src/main/worktree-services-orphan-cleanup.test.ts
+++ b/src/main/worktree-services-orphan-cleanup.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ChildProcessModule from 'node:child_process'
+
+const execMock = vi.hoisted(() => vi.fn())
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof ChildProcessModule>()
+  return { ...actual, exec: execMock }
+})
+
+import { cleanupOrphanedWorktreeServices } from './worktree-services-orphan-cleanup'
+import {
+  getWorktreeServicesRecord,
+  upsertWorktreeServicesRecord
+} from '../shared/worktree-services-store'
+import type { WorktreeServicesRecord } from '../shared/worktree-services'
+import type { Repo } from '../shared/types'
+
+let userDataDir: string
+let repoDir: string
+beforeEach(() => {
+  userDataDir = mkdtempSync(join(tmpdir(), 'orca-svc-orphan-'))
+  repoDir = mkdtempSync(join(tmpdir(), 'orca-svc-orphan-repo-'))
+  execMock.mockReset()
+  execMock.mockImplementation((_cmd, _opts, cb) => {
+    cb(null, 'ok', '')
+    return { kill: vi.fn() }
+  })
+  writeFileSync(
+    join(repoDir, 'orca.yaml'),
+    [
+      'services:',
+      '  - id: db',
+      '    name: Postgres',
+      '    create: echo create',
+      '    destroy: echo destroy'
+    ].join('\n')
+  )
+})
+afterEach(() => {
+  rmSync(userDataDir, { recursive: true, force: true })
+  rmSync(repoDir, { recursive: true, force: true })
+})
+
+function record(worktreeId: string, slot: number): WorktreeServicesRecord {
+  return {
+    worktreeId,
+    repoId: 'repo-1',
+    slot,
+    slug: `wt-s${slot}`,
+    serviceIds: ['db'],
+    env: { ORCA_SERVICE_SLOT: String(slot) },
+    status: 'ready',
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:00.000Z'
+  }
+}
+
+describe('cleanupOrphanedWorktreeServices', () => {
+  it('destroys orphaned records and leaves live ones untouched', async () => {
+    upsertWorktreeServicesRecord(userDataDir, record('wt-gone', 0))
+    upsertWorktreeServicesRecord(userDataDir, record('wt-live', 1))
+    await cleanupOrphanedWorktreeServices({
+      userDataPath: userDataDir,
+      existingWorktreeIds: new Set(['wt-live']),
+      resolveRepo: () => ({ id: 'repo-1', path: repoDir }) as Repo
+    })
+    expect(execMock).toHaveBeenCalled()
+    expect(getWorktreeServicesRecord(userDataDir, 'wt-gone')).toBeNull()
+    expect(getWorktreeServicesRecord(userDataDir, 'wt-live')).not.toBeNull()
+  })
+
+  it('removes the orphan without running destroy when the repo is unresolvable', async () => {
+    upsertWorktreeServicesRecord(userDataDir, record('wt-gone', 0))
+    await cleanupOrphanedWorktreeServices({
+      userDataPath: userDataDir,
+      existingWorktreeIds: new Set(),
+      resolveRepo: () => null
+    })
+    expect(execMock).not.toHaveBeenCalled()
+    expect(getWorktreeServicesRecord(userDataDir, 'wt-gone')).toBeNull()
+  })
+})

--- a/src/main/worktree-services-orphan-cleanup.test.ts
+++ b/src/main/worktree-services-orphan-cleanup.test.ts
@@ -82,4 +82,18 @@ describe('cleanupOrphanedWorktreeServices', () => {
     expect(execMock).not.toHaveBeenCalled()
     expect(getWorktreeServicesRecord(userDataDir, 'wt-gone')).toBeNull()
   })
+
+  it('demotes an interrupted provisioning record for a still-existing worktree', async () => {
+    upsertWorktreeServicesRecord(userDataDir, { ...record('wt-live', 0), status: 'provisioning' })
+    await cleanupOrphanedWorktreeServices({
+      userDataPath: userDataDir,
+      existingWorktreeIds: new Set(['wt-live']),
+      resolveRepo: () => ({ id: 'repo-1', path: repoDir }) as Repo
+    })
+    const demoted = getWorktreeServicesRecord(userDataDir, 'wt-live')
+    expect(demoted?.status).toBe('create_failed')
+    expect(demoted?.error).toContain('interrupted')
+    // The worktree still exists, so it is not an orphan — destroy must not run.
+    expect(execMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/worktree-services-orphan-cleanup.test.ts
+++ b/src/main/worktree-services-orphan-cleanup.test.ts
@@ -10,7 +10,10 @@ vi.mock('node:child_process', async (importOriginal) => {
   return { ...actual, exec: execMock }
 })
 
-import { cleanupOrphanedWorktreeServices } from './worktree-services-orphan-cleanup'
+import {
+  cleanupOrphanedWorktreeServices,
+  isWorktreeServicesPathDefinitelyMissing
+} from './worktree-services-orphan-cleanup'
 import {
   getWorktreeServicesRecord,
   upsertWorktreeServicesRecord
@@ -95,5 +98,23 @@ describe('cleanupOrphanedWorktreeServices', () => {
     expect(demoted?.error).toContain('interrupted')
     // The worktree still exists, so it is not an orphan — destroy must not run.
     expect(execMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a live worktree whose persisted metadata is missing', async () => {
+    const worktreeDir = mkdtempSync(join(tmpdir(), 'orca-svc-live-worktree-'))
+    const worktreeId = `repo-1::${worktreeDir}`
+    try {
+      upsertWorktreeServicesRecord(userDataDir, record(worktreeId, 0))
+      await cleanupOrphanedWorktreeServices({
+        userDataPath: userDataDir,
+        existingWorktreeIds: new Set(),
+        resolveRepo: () => ({ id: 'repo-1', path: repoDir }) as Repo,
+        isWorktreeDefinitelyMissing: isWorktreeServicesPathDefinitelyMissing
+      })
+      expect(execMock).not.toHaveBeenCalled()
+      expect(getWorktreeServicesRecord(userDataDir, worktreeId)).not.toBeNull()
+    } finally {
+      rmSync(worktreeDir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/worktree-services-orphan-cleanup.ts
+++ b/src/main/worktree-services-orphan-cleanup.ts
@@ -1,4 +1,5 @@
 import { loadHooks } from './hooks'
+import { statSync } from 'node:fs'
 import { destroyWorktreeServices } from './worktree-services'
 import {
   listWorktreeServicesRecords,
@@ -6,14 +7,43 @@ import {
   upsertWorktreeServicesRecord
 } from '../shared/worktree-services-store'
 import type { Repo } from '../shared/types'
+import { splitWorktreeId } from '../shared/worktree-id'
+import { isWslUncPath } from '../shared/wsl-paths'
+import { wslUncDirectoryExists } from './wsl'
+
+export function isWorktreeServicesPathDefinitelyMissing(worktreeId: string): boolean {
+  const path = splitWorktreeId(worktreeId)?.worktreePath
+  if (!path) {
+    return false
+  }
+  if (isWslUncPath(path)) {
+    const existsInDistro = wslUncDirectoryExists(path)
+    if (existsInDistro !== null) {
+      return !existsInDistro
+    }
+  }
+  try {
+    return !statSync(path).isDirectory()
+  } catch (error) {
+    // Why: cleanup is destructive. Only ENOENT proves an orphan; permission,
+    // unmounted-volume, and inconclusive WSL errors must retain the record.
+    return (error as NodeJS.ErrnoException).code === 'ENOENT'
+  }
+}
 
 export async function cleanupOrphanedWorktreeServices(args: {
   userDataPath: string
   existingWorktreeIds: Set<string>
   resolveRepo: (repoId: string) => Repo | null
+  isWorktreeDefinitelyMissing?: (worktreeId: string) => boolean
 }): Promise<void> {
   for (const record of listWorktreeServicesRecords(args.userDataPath)) {
-    if (args.existingWorktreeIds.has(record.worktreeId)) {
+    const metadataExists = args.existingWorktreeIds.has(record.worktreeId)
+    const pathStillExists =
+      !metadataExists && args.isWorktreeDefinitelyMissing
+        ? !args.isWorktreeDefinitelyMissing(record.worktreeId)
+        : false
+    if (metadataExists || pathStillExists) {
       // Why: a provision interrupted by app exit persists 'provisioning' forever
       // — the worktree still exists (so it's not an orphan) but retry is only
       // offered for create_failed. Demote it so the badge/panel offer a retry.

--- a/src/main/worktree-services-orphan-cleanup.ts
+++ b/src/main/worktree-services-orphan-cleanup.ts
@@ -1,0 +1,37 @@
+import { loadHooks } from './hooks'
+import { destroyWorktreeServices } from './worktree-services'
+import {
+  listWorktreeServicesRecords,
+  removeWorktreeServicesRecord
+} from '../shared/worktree-services-store'
+import type { Repo } from '../shared/types'
+
+export async function cleanupOrphanedWorktreeServices(args: {
+  userDataPath: string
+  existingWorktreeIds: Set<string>
+  resolveRepo: (repoId: string) => Repo | null
+}): Promise<void> {
+  for (const record of listWorktreeServicesRecords(args.userDataPath)) {
+    if (args.existingWorktreeIds.has(record.worktreeId)) {
+      continue
+    }
+    const repo = args.resolveRepo(record.repoId)
+    const services = repo ? (loadHooks(repo.path)?.services ?? []) : []
+    if (repo && services.length > 0) {
+      await destroyWorktreeServices({
+        userDataPath: args.userDataPath,
+        worktreeId: record.worktreeId,
+        // Why: the worktree directory is gone at cleanup time; destroy commands
+        // reference the project slug and run from the repo root, which holds the
+        // compose file.
+        worktreePath: repo.path,
+        repo,
+        services
+      })
+    } else {
+      // Why: recipes are unavailable (repo removed), so freeing the slot beats
+      // leaking it forever.
+      removeWorktreeServicesRecord(args.userDataPath, record.worktreeId)
+    }
+  }
+}

--- a/src/main/worktree-services-orphan-cleanup.ts
+++ b/src/main/worktree-services-orphan-cleanup.ts
@@ -2,7 +2,8 @@ import { loadHooks } from './hooks'
 import { destroyWorktreeServices } from './worktree-services'
 import {
   listWorktreeServicesRecords,
-  removeWorktreeServicesRecord
+  removeWorktreeServicesRecord,
+  upsertWorktreeServicesRecord
 } from '../shared/worktree-services-store'
 import type { Repo } from '../shared/types'
 
@@ -13,6 +14,18 @@ export async function cleanupOrphanedWorktreeServices(args: {
 }): Promise<void> {
   for (const record of listWorktreeServicesRecords(args.userDataPath)) {
     if (args.existingWorktreeIds.has(record.worktreeId)) {
+      // Why: a provision interrupted by app exit persists 'provisioning' forever
+      // — the worktree still exists (so it's not an orphan) but retry is only
+      // offered for create_failed. Demote it so the badge/panel offer a retry.
+      if (record.status === 'provisioning') {
+        upsertWorktreeServicesRecord(args.userDataPath, {
+          ...record,
+          status: 'create_failed',
+          error:
+            'Provisioning was interrupted when Orca exited. Retry to finish setting up services.',
+          updatedAt: new Date().toISOString()
+        })
+      }
       continue
     }
     const repo = args.resolveRepo(record.repoId)

--- a/src/main/worktree-services.test.ts
+++ b/src/main/worktree-services.test.ts
@@ -13,6 +13,7 @@ vi.mock('node:child_process', async (importOriginal) => {
 
 import {
   destroyWorktreeServices,
+  getWorktreeServicesRuntime,
   loadServiceRecipesForWorktree,
   provisionWorktreeServices,
   runWorktreeServiceAction
@@ -69,6 +70,34 @@ describe('provisionWorktreeServices', () => {
     expect(getWorktreeServicesRecord(dir, 'wt-1')?.status).toBe('ready')
   })
 
+  it('keeps allocated ORCA context authoritative over legacy recipe env', async () => {
+    execSucceeds()
+    const record = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services: [{ ...services[0]!, env: { ORCA_PORT_0: '29999' } }]
+    })
+    expect(record.env.ORCA_PORT_0).toBe('20000')
+  })
+
+  it('persists retryable failure state when no valid recipes remain', async () => {
+    const record = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services: []
+    })
+    expect(record.status).toBe('create_failed')
+    expect(record.error).toContain('no valid')
+    expect(getWorktreeServicesRecord(dir, 'wt-1')).toEqual(record)
+    expect(execMock).not.toHaveBeenCalled()
+  })
+
   it('survives a provision event listener that throws mid-stream', async () => {
     execMock.mockImplementation((_cmd, _opts, cb) => {
       const child = Object.assign(new EventEmitter(), {
@@ -112,6 +141,22 @@ describe('provisionWorktreeServices', () => {
     expect(record.status).toBe('create_failed')
     expect(record.error).toContain('db')
     expect(getWorktreeServicesRecord(dir, 'wt-1')?.status).toBe('create_failed')
+  })
+
+  it('marks create_failed when child-process startup throws synchronously', async () => {
+    execMock.mockImplementation(() => {
+      throw new Error('invalid environment')
+    })
+    const record = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(record.status).toBe('create_failed')
+    expect(record.error).toContain('invalid environment')
   })
 
   it('reuses the slot and slug when re-provisioning an existing ready record', async () => {
@@ -189,6 +234,28 @@ describe('destroyWorktreeServices', () => {
     expect(getWorktreeServicesRecord(dir, 'wt-1')).toBeNull()
   })
 
+  it('retains the record and slot when the caller has not committed removal', async () => {
+    execSucceeds()
+    await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    await destroyWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/x',
+      repo,
+      services,
+      releaseRecord: false
+    })
+    expect(getWorktreeServicesRecord(dir, 'wt-1')).not.toBeNull()
+    expect(allocateServiceSlot(dir)).toBe(1)
+  })
+
   it('is a no-op without a record', async () => {
     const result = await destroyWorktreeServices({
       userDataPath: dir,
@@ -227,6 +294,47 @@ describe('destroyWorktreeServices', () => {
       true
     )
     expect(getWorktreeServicesRecord(dir, 'wt-1')).toBeNull()
+  })
+})
+
+describe('getWorktreeServicesRuntime', () => {
+  it('starts independent status probes concurrently and preserves recipe order', async () => {
+    const runtimeServices: OrcaServiceRecipe[] = [
+      { ...services[0]!, status: 'status-db' },
+      { id: 'cache', name: 'Cache', create: 'create-cache', status: 'status-cache' }
+    ]
+    execSucceeds()
+    await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services: runtimeServices
+    })
+
+    let releaseProbes!: () => void
+    const probesMayFinish = new Promise<void>((resolve) => {
+      releaseProbes = resolve
+    })
+    execMock.mockReset()
+    execMock.mockImplementation((_cmd, _opts, cb) => {
+      void probesMayFinish.then(() => cb(null, '', ''))
+      return { kill: vi.fn() }
+    })
+
+    const runtimePromise = getWorktreeServicesRuntime({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/x',
+      services: runtimeServices
+    })
+    expect(execMock).toHaveBeenCalledTimes(2)
+    releaseProbes()
+    await expect(runtimePromise).resolves.toMatchObject([
+      { serviceId: 'db', runState: 'running' },
+      { serviceId: 'cache', runState: 'running' }
+    ])
   })
 })
 

--- a/src/main/worktree-services.test.ts
+++ b/src/main/worktree-services.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ChildProcessModule from 'node:child_process'
+
+const execMock = vi.hoisted(() => vi.fn())
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof ChildProcessModule>()
+  return { ...actual, exec: execMock }
+})
+
+import { destroyWorktreeServices, provisionWorktreeServices } from './worktree-services'
+import { getWorktreeServicesRecord } from '../shared/worktree-services-store'
+import type { OrcaServiceRecipe, Repo } from '../shared/types'
+
+const repo = { id: 'repo-1', path: '/tmp/repo' } as Repo
+const services: OrcaServiceRecipe[] = [
+  {
+    id: 'db',
+    name: 'Postgres',
+    create: 'echo create-db',
+    destroy: 'echo destroy-db',
+    env: { DATABASE_URL: 'pg://localhost:${ORCA_PORT_0}/app' }
+  }
+]
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'orca-svc-main-'))
+  execMock.mockReset()
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function execSucceeds(): void {
+  execMock.mockImplementation((_cmd, _opts, cb) => {
+    cb(null, 'ok', '')
+    return { kill: vi.fn() }
+  })
+}
+
+describe('provisionWorktreeServices', () => {
+  it('allocates slot 0, resolves env, persists a ready record', async () => {
+    execSucceeds()
+    const record = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'My Task',
+      worktreePath: '/tmp/repo-worktrees/my-task',
+      repo,
+      services
+    })
+    expect(record.status).toBe('ready')
+    expect(record.slot).toBe(0)
+    expect(record.env.DATABASE_URL).toBe('pg://localhost:20000/app')
+    expect(record.env.ORCA_WORKTREE_SLUG).toBe('my-task-s0')
+    expect(getWorktreeServicesRecord(dir, 'wt-1')?.status).toBe('ready')
+  })
+
+  it('marks create_failed and keeps the record on command failure', async () => {
+    execMock.mockImplementation((_cmd, _opts, cb) => {
+      cb(new Error('boom'), '', 'docker: not found')
+      return { kill: vi.fn() }
+    })
+    const record = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(record.status).toBe('create_failed')
+    expect(record.error).toContain('db')
+    expect(getWorktreeServicesRecord(dir, 'wt-1')?.status).toBe('create_failed')
+  })
+})
+
+describe('destroyWorktreeServices', () => {
+  it('runs destroy, removes the record, frees the slot', async () => {
+    execSucceeds()
+    await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    const result = await destroyWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(result).toEqual({ success: true, errors: [] })
+    expect(getWorktreeServicesRecord(dir, 'wt-1')).toBeNull()
+  })
+
+  it('still removes the record when destroy fails, reporting the error', async () => {
+    execSucceeds()
+    await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    execMock.mockImplementation((_cmd, _opts, cb) => {
+      cb(new Error('gone'), '', '')
+      return { kill: vi.fn() }
+    })
+    const result = await destroyWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(result.success).toBe(false)
+    expect(result.errors).toHaveLength(1)
+    expect(getWorktreeServicesRecord(dir, 'wt-1')).toBeNull()
+  })
+
+  it('is a no-op without a record', async () => {
+    const result = await destroyWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'nope',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(result).toEqual({ success: true, errors: [] })
+    expect(execMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/worktree-services.test.ts
+++ b/src/main/worktree-services.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { EventEmitter } from 'node:events'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -10,7 +11,12 @@ vi.mock('node:child_process', async (importOriginal) => {
   return { ...actual, exec: execMock }
 })
 
-import { destroyWorktreeServices, provisionWorktreeServices } from './worktree-services'
+import {
+  destroyWorktreeServices,
+  loadServiceRecipesForWorktree,
+  provisionWorktreeServices,
+  runWorktreeServiceAction
+} from './worktree-services'
 import { getWorktreeServicesRecord } from '../shared/worktree-services-store'
 import type { OrcaServiceRecipe, Repo } from '../shared/types'
 
@@ -57,6 +63,33 @@ describe('provisionWorktreeServices', () => {
     expect(record.env.DATABASE_URL).toBe('pg://localhost:20000/app')
     expect(record.env.ORCA_WORKTREE_SLUG).toBe('my-task-s0')
     expect(getWorktreeServicesRecord(dir, 'wt-1')?.status).toBe('ready')
+  })
+
+  it('survives a provision event listener that throws mid-stream', async () => {
+    execMock.mockImplementation((_cmd, _opts, cb) => {
+      const child = Object.assign(new EventEmitter(), {
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+        kill: vi.fn()
+      })
+      queueMicrotask(() => {
+        child.stdout.emit('data', 'pulling image…')
+        cb(null, 'ok', '')
+      })
+      return child
+    })
+    const record = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services,
+      onEvent: () => {
+        throw new Error('window destroyed')
+      }
+    })
+    expect(record.status).toBe('ready')
   })
 
   it('marks create_failed and keeps the record on command failure', async () => {
@@ -136,5 +169,72 @@ describe('destroyWorktreeServices', () => {
     })
     expect(result).toEqual({ success: true, errors: [] })
     expect(execMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('runWorktreeServiceAction', () => {
+  it('fails when the targeted service is not provisioned', async () => {
+    execSucceeds()
+    await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    execMock.mockClear()
+    const result = await runWorktreeServiceAction({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/x',
+      services,
+      action: 'start',
+      serviceId: 'ghost'
+    })
+    expect(result.success).toBe(false)
+    expect(result.errors[0]).toContain('ghost')
+    expect(execMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('loadServiceRecipesForWorktree', () => {
+  it('prefers the worktree orca.yaml over the repo root', () => {
+    const worktreeDir = join(dir, 'wt')
+    const repoDir = join(dir, 'repo')
+    mkdirSync(worktreeDir, { recursive: true })
+    mkdirSync(repoDir, { recursive: true })
+    writeFileSync(
+      join(worktreeDir, 'orca.yaml'),
+      'services:\n  - id: branch-db\n    name: Branch DB\n    create: echo up\n'
+    )
+    writeFileSync(
+      join(repoDir, 'orca.yaml'),
+      'services:\n  - id: root-db\n    name: Root DB\n    create: echo up\n'
+    )
+    expect(loadServiceRecipesForWorktree(worktreeDir, repoDir).map((s) => s.id)).toEqual([
+      'branch-db'
+    ])
+  })
+
+  it('falls back to the repo root when the worktree declares no services', () => {
+    const worktreeDir = join(dir, 'wt')
+    const repoDir = join(dir, 'repo')
+    mkdirSync(worktreeDir, { recursive: true })
+    mkdirSync(repoDir, { recursive: true })
+    writeFileSync(join(worktreeDir, 'orca.yaml'), 'scripts:\n  setup: echo hi\n')
+    writeFileSync(
+      join(repoDir, 'orca.yaml'),
+      'services:\n  - id: root-db\n    name: Root DB\n    create: echo up\n'
+    )
+    expect(loadServiceRecipesForWorktree(worktreeDir, repoDir).map((s) => s.id)).toEqual([
+      'root-db'
+    ])
+  })
+
+  it('returns empty when neither location declares services', () => {
+    const worktreeDir = join(dir, 'wt')
+    mkdirSync(worktreeDir, { recursive: true })
+    expect(loadServiceRecipesForWorktree(worktreeDir, join(dir, 'missing'))).toEqual([])
   })
 })

--- a/src/main/worktree-services.test.ts
+++ b/src/main/worktree-services.test.ts
@@ -17,7 +17,11 @@ import {
   provisionWorktreeServices,
   runWorktreeServiceAction
 } from './worktree-services'
-import { getWorktreeServicesRecord } from '../shared/worktree-services-store'
+import {
+  allocateServiceSlot,
+  getWorktreeServicesRecord,
+  listWorktreeServicesRecords
+} from '../shared/worktree-services-store'
 import type { OrcaServiceRecipe, Repo } from '../shared/types'
 
 const repo = { id: 'repo-1', path: '/tmp/repo' } as Repo
@@ -109,6 +113,32 @@ describe('provisionWorktreeServices', () => {
     expect(record.error).toContain('db')
     expect(getWorktreeServicesRecord(dir, 'wt-1')?.status).toBe('create_failed')
   })
+
+  it('reuses the slot and slug when re-provisioning an existing ready record', async () => {
+    execSucceeds()
+    const first = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'My Task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    const second = await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'Renamed Task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    expect(second.slot).toBe(first.slot)
+    expect(second.slug).toBe(first.slug)
+    // A single record — no orphaned prior slug on a fresh slot.
+    expect(listWorktreeServicesRecords(dir)).toHaveLength(1)
+    // Slot 0 stays taken by the reused record, so the next allocation is 1.
+    expect(allocateServiceSlot(dir)).toBe(1)
+  })
 })
 
 describe('destroyWorktreeServices', () => {
@@ -169,6 +199,34 @@ describe('destroyWorktreeServices', () => {
     })
     expect(result).toEqual({ success: true, errors: [] })
     expect(execMock).not.toHaveBeenCalled()
+  })
+
+  it('reports an error when a provisioned service is no longer declared in orca.yaml', async () => {
+    execSucceeds()
+    await provisionWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreeName: 'task',
+      worktreePath: '/tmp/x',
+      repo,
+      services
+    })
+    // Drift: the recipes resolved at destroy time no longer declare "db".
+    const driftedServices: OrcaServiceRecipe[] = [
+      { id: 'redis', name: 'Redis', create: 'echo up', destroy: 'echo down' }
+    ]
+    const result = await destroyWorktreeServices({
+      userDataPath: dir,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp/x',
+      repo,
+      services: driftedServices
+    })
+    expect(result.success).toBe(false)
+    expect(result.errors.some((e) => e.includes('db') && e.includes('no longer declared'))).toBe(
+      true
+    )
+    expect(getWorktreeServicesRecord(dir, 'wt-1')).toBeNull()
   })
 })
 

--- a/src/main/worktree-services.ts
+++ b/src/main/worktree-services.ts
@@ -66,9 +66,11 @@ export async function provisionWorktreeServices(
   const { userDataPath, worktreeId, worktreeName, worktreePath, repo, services } = args
   const provisionId = args.provisionId ?? worktreeId
 
-  // Why: a retry of a create_failed worktree must reuse its slot/slug so ports stay stable.
+  // Why: reuse any existing record's slot/slug/createdAt on re-provision (retry
+  // of a create_failed worktree, or a repeat provision of a ready one) so ports
+  // stay stable and the prior slug's containers are never orphaned by a fresh slot.
   const existing = getWorktreeServicesRecord(userDataPath, worktreeId)
-  const reuse = existing?.status === 'create_failed' ? existing : null
+  const reuse = existing
   const slot = reuse ? reuse.slot : allocateServiceSlot(userDataPath)
   const slug = reuse ? reuse.slug : deriveServiceSlug(worktreeName, slot)
   const contextEnv = buildServiceContextEnv(slug, slot)
@@ -174,6 +176,19 @@ export async function destroyWorktreeServices(args: {
     if (!result.success) {
       errors.push(
         `Service "${service.id}" destroy failed: ${sanitizeServiceCommandOutput(result.output)}`.trim()
+      )
+    }
+  }
+
+  // Why: recipes are re-resolved from the current yaml at destroy time. If a
+  // provisioned service's id is no longer declared (a branch or agent edit of
+  // orca.yaml between provision and removal), its containers can't be torn down;
+  // surface that instead of silently reporting success while it keeps running.
+  const currentServiceIds = new Set(services.map((service) => service.id))
+  for (const serviceId of record.serviceIds) {
+    if (!currentServiceIds.has(serviceId)) {
+      errors.push(
+        `Service "${serviceId}" recipe is no longer declared in orca.yaml; it may still be running.`
       )
     }
   }

--- a/src/main/worktree-services.ts
+++ b/src/main/worktree-services.ts
@@ -11,10 +11,15 @@ import {
   upsertWorktreeServicesRecord
 } from '../shared/worktree-services-store'
 import type { OrcaServiceRecipe, Repo } from '../shared/types'
-import type { WorktreeServicesRecord } from '../shared/worktree-services'
+import type {
+  WorktreeServiceRuntimeState,
+  WorktreeServicesRecord
+} from '../shared/worktree-services'
 import { isWslPath, parseWslPath, toLinuxPath } from './wsl'
 
 export const SERVICE_COMMAND_TIMEOUT_MS = 600_000
+// Why: status probes run on every panel open; a hung probe must not sit for 10 minutes.
+export const SERVICE_STATUS_TIMEOUT_MS = 30_000
 
 export type ServiceProvisionEvent = {
   provisionId: string
@@ -45,11 +50,12 @@ function runServiceCommand(
   command: string,
   worktreePath: string,
   env: Record<string, string>,
-  onChunk?: StreamHandler
+  onChunk?: StreamHandler,
+  timeoutMs: number = SERVICE_COMMAND_TIMEOUT_MS
 ): Promise<RunResult> {
   const wslInfo = isWslPath(worktreePath) ? parseWslPath(worktreePath) : null
   if (wslInfo) {
-    return runServiceCommandWsl(command, wslInfo, env, onChunk)
+    return runServiceCommandWsl(command, wslInfo, env, onChunk, timeoutMs)
   }
   return new Promise((resolve) => {
     const child = exec(
@@ -57,7 +63,7 @@ function runServiceCommand(
       {
         cwd: worktreePath,
         shell: getServiceShell(),
-        timeout: SERVICE_COMMAND_TIMEOUT_MS,
+        timeout: timeoutMs,
         env: { ...process.env, ...env }
       },
       (error, stdout, stderr) => {
@@ -76,7 +82,8 @@ function runServiceCommandWsl(
   command: string,
   wslInfo: { distro: string; linuxPath: string },
   env: Record<string, string>,
-  onChunk?: StreamHandler
+  onChunk?: StreamHandler,
+  timeoutMs: number = SERVICE_COMMAND_TIMEOUT_MS
 ): Promise<RunResult> {
   // Why: route through wsl.exe (not exec/cmd.exe) with single-quote escaping so
   // WSL worktree commands are not mangled by the Windows shell — mirrors runHook.
@@ -93,7 +100,7 @@ function runServiceCommandWsl(
       'wsl.exe',
       [...distroArgs, '--', 'bash', '-c', bashCmd],
       {
-        timeout: SERVICE_COMMAND_TIMEOUT_MS,
+        timeout: timeoutMs,
         encoding: 'utf-8',
         env: { ...process.env, ...wslEnv }
       },
@@ -221,5 +228,81 @@ export async function destroyWorktreeServices(args: {
   // Why: freeing the slot must not depend on destroy success — a failed destroy
   // otherwise leaks the slot forever. Removal is non-blocking per spec.
   removeWorktreeServicesRecord(userDataPath, worktreeId)
+  return { success: errors.length === 0, errors }
+}
+
+export async function getWorktreeServicesRuntime(args: {
+  userDataPath: string
+  worktreeId: string
+  worktreePath: string
+  services: OrcaServiceRecipe[]
+}): Promise<WorktreeServiceRuntimeState[]> {
+  const record = getWorktreeServicesRecord(args.userDataPath, args.worktreeId)
+  if (!record) {
+    return []
+  }
+  const env = { ...record.env, ORCA_WORKTREE_PATH: args.worktreePath }
+  const provisioned = new Set(record.serviceIds)
+  const states: WorktreeServiceRuntimeState[] = []
+  for (const service of args.services) {
+    if (!provisioned.has(service.id)) {
+      continue
+    }
+    let runState: WorktreeServiceRuntimeState['runState'] = 'unknown'
+    if (service.status) {
+      const result = await runServiceCommand(
+        service.status,
+        args.worktreePath,
+        env,
+        undefined,
+        SERVICE_STATUS_TIMEOUT_MS
+      )
+      runState = result.success ? 'running' : 'stopped'
+    }
+    states.push({
+      serviceId: service.id,
+      name: service.name,
+      runState,
+      canStart: Boolean(service.start),
+      canStop: Boolean(service.stop)
+    })
+  }
+  return states
+}
+
+export async function runWorktreeServiceAction(args: {
+  userDataPath: string
+  worktreeId: string
+  worktreePath: string
+  services: OrcaServiceRecipe[]
+  action: 'start' | 'stop'
+  serviceId?: string // omitted = every provisioned service that declares the command
+}): Promise<{ success: boolean; errors: string[] }> {
+  const record = getWorktreeServicesRecord(args.userDataPath, args.worktreeId)
+  if (!record) {
+    return { success: false, errors: ['No provisioned services for this worktree.'] }
+  }
+  const env = { ...record.env, ORCA_WORKTREE_PATH: args.worktreePath }
+  const provisioned = new Set(record.serviceIds)
+  const errors: string[] = []
+  for (const service of args.services) {
+    if (!provisioned.has(service.id)) {
+      continue
+    }
+    if (args.serviceId && service.id !== args.serviceId) {
+      continue
+    }
+    const command = service[args.action]
+    if (!command) {
+      if (args.serviceId) {
+        errors.push(`Service "${service.id}" has no ${args.action} command.`)
+      }
+      continue
+    }
+    const result = await runServiceCommand(command, args.worktreePath, env)
+    if (!result.success) {
+      errors.push(`Service "${service.id}" ${args.action} failed: ${result.output}`.trim())
+    }
+  }
   return { success: errors.length === 0, errors }
 }

--- a/src/main/worktree-services.ts
+++ b/src/main/worktree-services.ts
@@ -1,0 +1,225 @@
+import { exec, execFile } from 'node:child_process'
+import {
+  buildServiceContextEnv,
+  deriveServiceSlug,
+  resolveServiceEnv
+} from '../shared/worktree-service-env'
+import {
+  allocateServiceSlot,
+  getWorktreeServicesRecord,
+  removeWorktreeServicesRecord,
+  upsertWorktreeServicesRecord
+} from '../shared/worktree-services-store'
+import type { OrcaServiceRecipe, Repo } from '../shared/types'
+import type { WorktreeServicesRecord } from '../shared/worktree-services'
+import { isWslPath, parseWslPath, toLinuxPath } from './wsl'
+
+export const SERVICE_COMMAND_TIMEOUT_MS = 600_000
+
+export type ServiceProvisionEvent = {
+  provisionId: string
+  serviceId: string
+  stream: 'stdout' | 'stderr'
+  chunk: string
+}
+
+export type ProvisionWorktreeServicesArgs = {
+  userDataPath: string
+  worktreeId: string
+  worktreeName: string
+  worktreePath: string
+  repo: Repo
+  services: OrcaServiceRecipe[]
+  provisionId?: string
+  onEvent?: (event: ServiceProvisionEvent) => void
+}
+
+type RunResult = { success: boolean; output: string }
+type StreamHandler = (stream: 'stdout' | 'stderr', chunk: string) => void
+
+function getServiceShell(): string {
+  return process.platform === 'win32' ? process.env.ComSpec || 'cmd.exe' : '/bin/bash'
+}
+
+function runServiceCommand(
+  command: string,
+  worktreePath: string,
+  env: Record<string, string>,
+  onChunk?: StreamHandler
+): Promise<RunResult> {
+  const wslInfo = isWslPath(worktreePath) ? parseWslPath(worktreePath) : null
+  if (wslInfo) {
+    return runServiceCommandWsl(command, wslInfo, env, onChunk)
+  }
+  return new Promise((resolve) => {
+    const child = exec(
+      command,
+      {
+        cwd: worktreePath,
+        shell: getServiceShell(),
+        timeout: SERVICE_COMMAND_TIMEOUT_MS,
+        env: { ...process.env, ...env }
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          success: !error,
+          output: [stdout, stderr, error ? String(error.message) : ''].filter(Boolean).join('\n')
+        })
+      }
+    )
+    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
+    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
+  })
+}
+
+function runServiceCommandWsl(
+  command: string,
+  wslInfo: { distro: string; linuxPath: string },
+  env: Record<string, string>,
+  onChunk?: StreamHandler
+): Promise<RunResult> {
+  // Why: route through wsl.exe (not exec/cmd.exe) with single-quote escaping so
+  // WSL worktree commands are not mangled by the Windows shell — mirrors runHook.
+  const escapedCwd = wslInfo.linuxPath.replace(/'/g, "'\\''")
+  const escapedScript = command.replace(/'/g, "'\\''")
+  const bashCmd = `cd '${escapedCwd}' && ${escapedScript}`
+  const wslEnv: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    wslEnv[key] = toLinuxPath(value)
+  }
+  return new Promise((resolve) => {
+    const distroArgs = wslInfo.distro ? ['-d', wslInfo.distro] : []
+    const child = execFile(
+      'wsl.exe',
+      [...distroArgs, '--', 'bash', '-c', bashCmd],
+      {
+        timeout: SERVICE_COMMAND_TIMEOUT_MS,
+        encoding: 'utf-8',
+        env: { ...process.env, ...wslEnv }
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          success: !error,
+          output: [stdout, stderr, error ? String(error.message) : ''].filter(Boolean).join('\n')
+        })
+      }
+    )
+    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
+    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
+  })
+}
+
+export async function provisionWorktreeServices(
+  args: ProvisionWorktreeServicesArgs
+): Promise<WorktreeServicesRecord> {
+  const { userDataPath, worktreeId, worktreeName, worktreePath, repo, services } = args
+  const provisionId = args.provisionId ?? worktreeId
+
+  // Why: a retry of a create_failed worktree must reuse its slot/slug so ports stay stable.
+  const existing = getWorktreeServicesRecord(userDataPath, worktreeId)
+  const reuse = existing?.status === 'create_failed' ? existing : null
+  const slot = reuse ? reuse.slot : allocateServiceSlot(userDataPath)
+  const slug = reuse ? reuse.slug : deriveServiceSlug(worktreeName, slot)
+  const contextEnv = buildServiceContextEnv(slug, slot)
+  const now = new Date().toISOString()
+  const createdAt = reuse ? reuse.createdAt : now
+
+  upsertWorktreeServicesRecord(userDataPath, {
+    worktreeId,
+    repoId: repo.id,
+    slot,
+    slug,
+    serviceIds: services.map((service) => service.id),
+    env: contextEnv,
+    status: 'provisioning',
+    createdAt,
+    updatedAt: now
+  })
+
+  const commandEnv = { ...contextEnv, ORCA_WORKTREE_PATH: worktreePath }
+  const resolvedEnv: Record<string, string> = { ...contextEnv }
+  const created: OrcaServiceRecipe[] = []
+
+  for (const service of services) {
+    const result = await runServiceCommand(
+      service.create,
+      worktreePath,
+      commandEnv,
+      (stream, chunk) => args.onEvent?.({ provisionId, serviceId: service.id, stream, chunk })
+    )
+    if (!result.success) {
+      await destroyCreatedServices(created.toReversed(), worktreePath, contextEnv)
+      return upsertWorktreeServicesRecord(userDataPath, {
+        worktreeId,
+        repoId: repo.id,
+        slot,
+        slug,
+        serviceIds: services.map((s) => s.id),
+        env: contextEnv,
+        status: 'create_failed',
+        error: `Service "${service.id}" create failed: ${result.output}`.trim(),
+        createdAt,
+        updatedAt: new Date().toISOString()
+      })
+    }
+    Object.assign(resolvedEnv, resolveServiceEnv(service.env, contextEnv))
+    created.push(service)
+  }
+
+  return upsertWorktreeServicesRecord(userDataPath, {
+    worktreeId,
+    repoId: repo.id,
+    slot,
+    slug,
+    serviceIds: services.map((service) => service.id),
+    env: resolvedEnv,
+    status: 'ready',
+    createdAt,
+    updatedAt: new Date().toISOString()
+  })
+}
+
+async function destroyCreatedServices(
+  services: OrcaServiceRecipe[],
+  worktreePath: string,
+  contextEnv: Record<string, string>
+): Promise<void> {
+  const env = { ...contextEnv, ORCA_WORKTREE_PATH: worktreePath }
+  for (const service of services) {
+    if (service.destroy) {
+      await runServiceCommand(service.destroy, worktreePath, env)
+    }
+  }
+}
+
+export async function destroyWorktreeServices(args: {
+  userDataPath: string
+  worktreeId: string
+  worktreePath: string
+  repo: Repo
+  services: OrcaServiceRecipe[]
+}): Promise<{ success: boolean; errors: string[] }> {
+  const { userDataPath, worktreeId, worktreePath, services } = args
+  const record = getWorktreeServicesRecord(userDataPath, worktreeId)
+  if (!record) {
+    return { success: true, errors: [] }
+  }
+
+  const errors: string[] = []
+  const env = { ...record.env, ORCA_WORKTREE_PATH: worktreePath }
+  const provisioned = new Set(record.serviceIds)
+  for (const service of services) {
+    if (!provisioned.has(service.id) || !service.destroy) {
+      continue
+    }
+    const result = await runServiceCommand(service.destroy, worktreePath, env)
+    if (!result.success) {
+      errors.push(`Service "${service.id}" destroy failed: ${result.output}`.trim())
+    }
+  }
+
+  // Why: freeing the slot must not depend on destroy success — a failed destroy
+  // otherwise leaks the slot forever. Removal is non-blocking per spec.
+  removeWorktreeServicesRecord(userDataPath, worktreeId)
+  return { success: errors.length === 0, errors }
+}

--- a/src/main/worktree-services.ts
+++ b/src/main/worktree-services.ts
@@ -18,7 +18,8 @@ import type {
 import {
   SERVICE_STATUS_TIMEOUT_MS,
   runServiceCommand,
-  sanitizeServiceCommandOutput
+  sanitizeServiceCommandOutput,
+  type ServiceCommandResult
 } from './worktree-service-command'
 
 export {
@@ -89,23 +90,44 @@ export async function provisionWorktreeServices(
     updatedAt: now
   })
 
+  if (services.length === 0) {
+    return upsertWorktreeServicesRecord(userDataPath, {
+      worktreeId,
+      repoId: repo.id,
+      slot,
+      slug,
+      serviceIds: [],
+      env: contextEnv,
+      status: 'create_failed',
+      error: 'The worktree has no valid isolated service recipes.',
+      createdAt,
+      updatedAt: new Date().toISOString()
+    })
+  }
+
   const commandEnv = { ...contextEnv, ORCA_WORKTREE_PATH: worktreePath }
   const resolvedEnv: Record<string, string> = { ...contextEnv }
   const created: OrcaServiceRecipe[] = []
 
   for (const service of services) {
-    const result = await runServiceCommand(
-      service.create,
-      worktreePath,
-      commandEnv,
-      (stream, chunk) =>
+    let result: ServiceCommandResult
+    try {
+      result = await runServiceCommand(service.create, worktreePath, commandEnv, (stream, chunk) =>
         args.onEvent?.({
           provisionId,
           serviceId: service.id,
           stream,
           chunk: sanitizeServiceCommandOutput(chunk)
         })
-    )
+      )
+    } catch (error) {
+      // Why: a synchronous child-process failure must become retryable state;
+      // leaving `provisioning` persisted would hide the retry until app restart.
+      result = {
+        success: false,
+        output: error instanceof Error ? error.message : String(error)
+      }
+    }
     if (!result.success) {
       await destroyCreatedServices(created.toReversed(), worktreePath, contextEnv)
       return upsertWorktreeServicesRecord(userDataPath, {
@@ -123,6 +145,10 @@ export async function provisionWorktreeServices(
       })
     }
     Object.assign(resolvedEnv, resolveServiceEnv(service.env, contextEnv))
+    // Why: parser validation protects normal yaml input, but lifecycle code can
+    // also receive programmatic/legacy recipes. The allocated context remains
+    // authoritative so later destroy commands target the same slot as create.
+    Object.assign(resolvedEnv, contextEnv)
     created.push(service)
   }
 
@@ -158,6 +184,7 @@ export async function destroyWorktreeServices(args: {
   worktreePath: string
   repo: Repo
   services: OrcaServiceRecipe[]
+  releaseRecord?: boolean
 }): Promise<{ success: boolean; errors: string[] }> {
   const { userDataPath, worktreeId, worktreePath, services } = args
   const record = getWorktreeServicesRecord(userDataPath, worktreeId)
@@ -193,9 +220,12 @@ export async function destroyWorktreeServices(args: {
     }
   }
 
-  // Why: freeing the slot must not depend on destroy success — a failed destroy
-  // otherwise leaks the slot forever. Removal is non-blocking per spec.
-  removeWorktreeServicesRecord(userDataPath, worktreeId)
+  // Why: ordinary/orphan cleanup frees the slot even when a destroy command
+  // fails, but worktree deletion retains it until Git removal commits so a
+  // failed delete cannot race a new worktree onto the same deterministic ports.
+  if (args.releaseRecord !== false) {
+    removeWorktreeServicesRecord(userDataPath, worktreeId)
+  }
   return { success: errors.length === 0, errors }
 }
 
@@ -211,31 +241,32 @@ export async function getWorktreeServicesRuntime(args: {
   }
   const env = { ...record.env, ORCA_WORKTREE_PATH: args.worktreePath }
   const provisioned = new Set(record.serviceIds)
-  const states: WorktreeServiceRuntimeState[] = []
-  for (const service of args.services) {
-    if (!provisioned.has(service.id)) {
-      continue
-    }
-    let runState: WorktreeServiceRuntimeState['runState'] = 'unknown'
-    if (service.status) {
-      const result = await runServiceCommand(
-        service.status,
-        args.worktreePath,
-        env,
-        undefined,
-        SERVICE_STATUS_TIMEOUT_MS
-      )
-      runState = result.success ? 'running' : 'stopped'
-    }
-    states.push({
-      serviceId: service.id,
-      name: service.name,
-      runState,
-      canStart: Boolean(service.start),
-      canStop: Boolean(service.stop)
+  const services = args.services.filter((service) => provisioned.has(service.id))
+  // Why: status probes are read-only and independent. Serial awaits make panel
+  // latency N×30s when several services are unhealthy; parallel probes cap it
+  // at the slowest service while preserving recipe order in the returned array.
+  return Promise.all(
+    services.map(async (service): Promise<WorktreeServiceRuntimeState> => {
+      let runState: WorktreeServiceRuntimeState['runState'] = 'unknown'
+      if (service.status) {
+        const result = await runServiceCommand(
+          service.status,
+          args.worktreePath,
+          env,
+          undefined,
+          SERVICE_STATUS_TIMEOUT_MS
+        )
+        runState = result.success ? 'running' : 'stopped'
+      }
+      return {
+        serviceId: service.id,
+        name: service.name,
+        runState,
+        canStart: Boolean(service.start),
+        canStop: Boolean(service.stop)
+      }
     })
-  }
-  return states
+  )
 }
 
 export async function runWorktreeServiceAction(args: {

--- a/src/main/worktree-services.ts
+++ b/src/main/worktree-services.ts
@@ -1,4 +1,3 @@
-import { exec, execFile } from 'node:child_process'
 import {
   buildServiceContextEnv,
   deriveServiceSlug,
@@ -15,11 +14,16 @@ import type {
   WorktreeServiceRuntimeState,
   WorktreeServicesRecord
 } from '../shared/worktree-services'
-import { isWslPath, parseWslPath, toLinuxPath } from './wsl'
+import {
+  SERVICE_STATUS_TIMEOUT_MS,
+  runServiceCommand,
+  sanitizeServiceCommandOutput
+} from './worktree-service-command'
 
-export const SERVICE_COMMAND_TIMEOUT_MS = 600_000
-// Why: status probes run on every panel open; a hung probe must not sit for 10 minutes.
-export const SERVICE_STATUS_TIMEOUT_MS = 30_000
+export {
+  SERVICE_COMMAND_TIMEOUT_MS,
+  sanitizeServiceCommandOutput
+} from './worktree-service-command'
 
 export type ServiceProvisionEvent = {
   provisionId: string
@@ -37,83 +41,6 @@ export type ProvisionWorktreeServicesArgs = {
   services: OrcaServiceRecipe[]
   provisionId?: string
   onEvent?: (event: ServiceProvisionEvent) => void
-}
-
-type RunResult = { success: boolean; output: string }
-type StreamHandler = (stream: 'stdout' | 'stderr', chunk: string) => void
-
-function getServiceShell(): string {
-  return process.platform === 'win32' ? process.env.ComSpec || 'cmd.exe' : '/bin/bash'
-}
-
-function runServiceCommand(
-  command: string,
-  worktreePath: string,
-  env: Record<string, string>,
-  onChunk?: StreamHandler,
-  timeoutMs: number = SERVICE_COMMAND_TIMEOUT_MS
-): Promise<RunResult> {
-  const wslInfo = isWslPath(worktreePath) ? parseWslPath(worktreePath) : null
-  if (wslInfo) {
-    return runServiceCommandWsl(command, wslInfo, env, onChunk, timeoutMs)
-  }
-  return new Promise((resolve) => {
-    const child = exec(
-      command,
-      {
-        cwd: worktreePath,
-        shell: getServiceShell(),
-        timeout: timeoutMs,
-        env: { ...process.env, ...env }
-      },
-      (error, stdout, stderr) => {
-        resolve({
-          success: !error,
-          output: [stdout, stderr, error ? String(error.message) : ''].filter(Boolean).join('\n')
-        })
-      }
-    )
-    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
-    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
-  })
-}
-
-function runServiceCommandWsl(
-  command: string,
-  wslInfo: { distro: string; linuxPath: string },
-  env: Record<string, string>,
-  onChunk?: StreamHandler,
-  timeoutMs: number = SERVICE_COMMAND_TIMEOUT_MS
-): Promise<RunResult> {
-  // Why: route through wsl.exe (not exec/cmd.exe) with single-quote escaping so
-  // WSL worktree commands are not mangled by the Windows shell — mirrors runHook.
-  const escapedCwd = wslInfo.linuxPath.replace(/'/g, "'\\''")
-  const escapedScript = command.replace(/'/g, "'\\''")
-  const bashCmd = `cd '${escapedCwd}' && ${escapedScript}`
-  const wslEnv: Record<string, string> = {}
-  for (const [key, value] of Object.entries(env)) {
-    wslEnv[key] = toLinuxPath(value)
-  }
-  return new Promise((resolve) => {
-    const distroArgs = wslInfo.distro ? ['-d', wslInfo.distro] : []
-    const child = execFile(
-      'wsl.exe',
-      [...distroArgs, '--', 'bash', '-c', bashCmd],
-      {
-        timeout: timeoutMs,
-        encoding: 'utf-8',
-        env: { ...process.env, ...wslEnv }
-      },
-      (error, stdout, stderr) => {
-        resolve({
-          success: !error,
-          output: [stdout, stderr, error ? String(error.message) : ''].filter(Boolean).join('\n')
-        })
-      }
-    )
-    child.stdout?.on('data', (chunk: string) => onChunk?.('stdout', String(chunk)))
-    child.stderr?.on('data', (chunk: string) => onChunk?.('stderr', String(chunk)))
-  })
 }
 
 export async function provisionWorktreeServices(
@@ -152,7 +79,13 @@ export async function provisionWorktreeServices(
       service.create,
       worktreePath,
       commandEnv,
-      (stream, chunk) => args.onEvent?.({ provisionId, serviceId: service.id, stream, chunk })
+      (stream, chunk) =>
+        args.onEvent?.({
+          provisionId,
+          serviceId: service.id,
+          stream,
+          chunk: sanitizeServiceCommandOutput(chunk)
+        })
     )
     if (!result.success) {
       await destroyCreatedServices(created.toReversed(), worktreePath, contextEnv)
@@ -164,7 +97,8 @@ export async function provisionWorktreeServices(
         serviceIds: services.map((s) => s.id),
         env: contextEnv,
         status: 'create_failed',
-        error: `Service "${service.id}" create failed: ${result.output}`.trim(),
+        error:
+          `Service "${service.id}" create failed: ${sanitizeServiceCommandOutput(result.output)}`.trim(),
         createdAt,
         updatedAt: new Date().toISOString()
       })
@@ -221,7 +155,9 @@ export async function destroyWorktreeServices(args: {
     }
     const result = await runServiceCommand(service.destroy, worktreePath, env)
     if (!result.success) {
-      errors.push(`Service "${service.id}" destroy failed: ${result.output}`.trim())
+      errors.push(
+        `Service "${service.id}" destroy failed: ${sanitizeServiceCommandOutput(result.output)}`.trim()
+      )
     }
   }
 
@@ -301,7 +237,9 @@ export async function runWorktreeServiceAction(args: {
     }
     const result = await runServiceCommand(command, args.worktreePath, env)
     if (!result.success) {
-      errors.push(`Service "${service.id}" ${args.action} failed: ${result.output}`.trim())
+      errors.push(
+        `Service "${service.id}" ${args.action} failed: ${sanitizeServiceCommandOutput(result.output)}`.trim()
+      )
     }
   }
   return { success: errors.length === 0, errors }

--- a/src/main/worktree-services.ts
+++ b/src/main/worktree-services.ts
@@ -1,3 +1,4 @@
+import { loadHooks } from './hooks'
 import {
   buildServiceContextEnv,
   deriveServiceSlug,
@@ -24,6 +25,22 @@ export {
   SERVICE_COMMAND_TIMEOUT_MS,
   sanitizeServiceCommandOutput
 } from './worktree-service-command'
+
+// Why: provisioning reads recipes from the worktree's own orca.yaml (the
+// checked-out branch may declare services the repo's default checkout does
+// not), so every later lifecycle command (status/start/stop/destroy/retry)
+// must resolve from the same source, falling back to the repo root only when
+// the worktree copy is missing or declares none.
+export function loadServiceRecipesForWorktree(
+  worktreePath: string,
+  repoPath: string
+): OrcaServiceRecipe[] {
+  const worktreeServices = loadHooks(worktreePath)?.services
+  if (worktreeServices && worktreeServices.length > 0) {
+    return worktreeServices
+  }
+  return loadHooks(repoPath)?.services ?? []
+}
 
 export type ServiceProvisionEvent = {
   provisionId: string
@@ -221,6 +238,17 @@ export async function runWorktreeServiceAction(args: {
   const env = { ...record.env, ORCA_WORKTREE_PATH: args.worktreePath }
   const provisioned = new Set(record.serviceIds)
   const errors: string[] = []
+  // Why: a stale panel can target a service that is no longer provisioned or
+  // declared; silently succeeding would hide that the action never ran.
+  if (
+    args.serviceId &&
+    !args.services.some((s) => s.id === args.serviceId && provisioned.has(s.id))
+  ) {
+    return {
+      success: false,
+      errors: [`Service "${args.serviceId}" is not provisioned for this worktree.`]
+    }
+  }
   for (const service of args.services) {
     if (!provisioned.has(service.id)) {
       continue

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -242,7 +242,10 @@ import type {
   EphemeralVmRecipeResultWarning
 } from '../shared/ephemeral-vm-recipes'
 import type { EphemeralVmRuntimeRecord } from '../shared/ephemeral-vm-runtimes'
-import type { WorktreeServicesRecord } from '../shared/worktree-services'
+import type {
+  WorktreeServiceRuntimeState,
+  WorktreeServicesRecord
+} from '../shared/worktree-services'
 import type { RuntimeAccessGrant } from '../shared/runtime-access-grants'
 import type { RuntimeRpcResponse } from '../shared/runtime-rpc-envelope'
 import type { ExecutionHostId } from '../shared/execution-host'
@@ -2370,6 +2373,12 @@ export type PreloadApi = {
   worktreeServices: {
     list: () => Promise<WorktreeServicesRecord[]>
     retry: (args: { worktreeId: string }) => Promise<WorktreeServicesRecord>
+    runtime: (args: { worktreeId: string }) => Promise<WorktreeServiceRuntimeState[]>
+    action: (args: {
+      worktreeId: string
+      action: 'start' | 'stop'
+      serviceId?: string
+    }) => Promise<{ success: boolean; errors: string[] }>
     onProvisionEvent: (
       callback: (event: {
         provisionId: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -242,6 +242,7 @@ import type {
   EphemeralVmRecipeResultWarning
 } from '../shared/ephemeral-vm-recipes'
 import type { EphemeralVmRuntimeRecord } from '../shared/ephemeral-vm-runtimes'
+import type { WorktreeServicesRecord } from '../shared/worktree-services'
 import type { RuntimeAccessGrant } from '../shared/runtime-access-grants'
 import type { RuntimeRpcResponse } from '../shared/runtime-rpc-envelope'
 import type { ExecutionHostId } from '../shared/execution-host'
@@ -2365,6 +2366,18 @@ export type PreloadApi = {
       cleanupDisabled: boolean
       message?: string
     }>
+  }
+  worktreeServices: {
+    list: () => Promise<WorktreeServicesRecord[]>
+    retry: (args: { worktreeId: string }) => Promise<WorktreeServicesRecord>
+    onProvisionEvent: (
+      callback: (event: {
+        provisionId: string
+        serviceId: string
+        stream: 'stdout' | 'stderr'
+        chunk: string
+      }) => void
+    ) => () => void
   }
   cache: {
     getGitHub: () => Promise<{

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2715,6 +2715,24 @@ const api = {
     getCleanupCommand: (args) => ipcRenderer.invoke('ephemeralVm:getCleanupCommand', args)
   } satisfies PreloadApi['ephemeralVm'],
 
+  worktreeServices: {
+    list: () => ipcRenderer.invoke('worktreeServices:list'),
+    retry: (args) => ipcRenderer.invoke('worktreeServices:retry', args),
+    onProvisionEvent: (callback) => {
+      const listener = (
+        _e: Electron.IpcRendererEvent,
+        event: {
+          provisionId: string
+          serviceId: string
+          stream: 'stdout' | 'stderr'
+          chunk: string
+        }
+      ): void => callback(event)
+      ipcRenderer.on('worktreeServices:provisionEvent', listener)
+      return () => ipcRenderer.removeListener('worktreeServices:provisionEvent', listener)
+    }
+  } satisfies PreloadApi['worktreeServices'],
+
   cache: {
     getGitHub: () => ipcRenderer.invoke('cache:getGitHub'),
     setGitHub: (args) => ipcRenderer.invoke('cache:setGitHub', args)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2718,6 +2718,8 @@ const api = {
   worktreeServices: {
     list: () => ipcRenderer.invoke('worktreeServices:list'),
     retry: (args) => ipcRenderer.invoke('worktreeServices:retry', args),
+    runtime: (args) => ipcRenderer.invoke('worktreeServices:runtime', args),
+    action: (args) => ipcRenderer.invoke('worktreeServices:action', args),
     onProvisionEvent: (callback) => {
       const listener = (
         _e: Electron.IpcRendererEvent,

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -260,8 +260,11 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
       const reuseLabel = [...(current?.container.querySelectorAll('label') ?? [])].find((label) =>
         label.textContent?.includes('Reuse branch')
       )
-      const checkbox = reuseLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]')
+      const checkbox = reuseLabel
+        ? (reuseLabel.ownerDocument.getElementById(reuseLabel.htmlFor) as HTMLButtonElement | null)
+        : null
       expect(checkbox).toBeTruthy()
+      expect(checkbox?.getAttribute('role')).toBe('checkbox')
       act(() => checkbox?.click())
     }
 

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -19,7 +19,9 @@ import {
   Server
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Command, CommandEmpty, CommandItem, CommandList } from '@/components/ui/command'
+import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { SettingsSwitch } from '@/components/settings/SettingsFormControls'
@@ -635,6 +637,8 @@ export default function NewWorkspaceComposerCard({
   const updateSettings = useAppStore((s) => s.updateSettings)
   const nameInputFocusFrameRef = React.useRef<number | null>(null)
   const branchNameInputId = React.useId()
+  const reuseBranchInputId = React.useId()
+  const isolatedServicesInputId = React.useId()
   const submitShortcutModifierLabel = getScreenSubmitModifierLabel()
   const selectedRepoName = React.useMemo(() => {
     const repo = eligibleRepos.find((candidate) => candidate.id === repoId)
@@ -1000,39 +1004,23 @@ export default function NewWorkspaceComposerCard({
           >
             <div className="min-h-0">
               <div className="space-y-1 pt-1">
-                <label className="group flex w-fit items-center gap-2 text-xs text-foreground">
-                  <span
-                    className={cn(
-                      'flex size-4 items-center justify-center rounded-[3px] border shadow-sm transition',
-                      reuseSelectedBranch
-                        ? 'border-emerald-500/60 bg-emerald-500 text-white'
-                        : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
-                    )}
-                  >
-                    <Check
-                      className={cn(
-                        'size-3 transition-opacity',
-                        reuseSelectedBranch ? 'opacity-100' : 'opacity-0'
-                      )}
-                    />
-                  </span>
-                  <input
-                    type="checkbox"
+                <div className="flex w-fit items-center gap-2">
+                  <Checkbox
+                    id={reuseBranchInputId}
                     checked={reuseSelectedBranch}
-                    onChange={(event) => onReuseSelectedBranchChange(event.target.checked)}
+                    onCheckedChange={(checked) => onReuseSelectedBranchChange(checked === true)}
                     // Why: while collapsed the row is aria-hidden, so disable the
                     // input too — keeps a hidden control out of the tab order and
                     // fully inert (no focusable control inside an aria-hidden tree).
                     disabled={!canReuseSelectedBranch}
-                    className="sr-only"
                   />
-                  <span>
+                  <Label htmlFor={reuseBranchInputId} className="cursor-pointer text-xs">
                     {translate(
                       'auto.components.NewWorkspaceComposerCard.reuseExistingBranch',
                       'Reuse branch'
                     )}
-                  </span>
-                </label>
+                  </Label>
+                </div>
                 <p className="pl-6 text-[11px] text-muted-foreground">
                   {translate(
                     'auto.components.NewWorkspaceComposerCard.reuseExistingBranchHint',
@@ -1055,36 +1043,20 @@ export default function NewWorkspaceComposerCard({
           >
             <div className="min-h-0">
               <div className="space-y-1 pt-1">
-                <label className="group flex w-fit items-center gap-2 text-xs text-foreground">
-                  <span
-                    className={cn(
-                      'flex size-4 items-center justify-center rounded-[3px] border shadow-sm transition',
-                      provisionServices
-                        ? 'border-emerald-500/60 bg-emerald-500 text-white'
-                        : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
-                    )}
-                  >
-                    <Check
-                      className={cn(
-                        'size-3 transition-opacity',
-                        provisionServices ? 'opacity-100' : 'opacity-0'
-                      )}
-                    />
-                  </span>
-                  <input
-                    type="checkbox"
+                <div className="flex w-fit items-center gap-2">
+                  <Checkbox
+                    id={isolatedServicesInputId}
                     checked={provisionServices}
-                    onChange={(event) => onProvisionServicesChange?.(event.target.checked)}
+                    onCheckedChange={(checked) => onProvisionServicesChange?.(checked === true)}
                     disabled={!repoHasServiceRecipes}
-                    className="sr-only"
                   />
-                  <span>
+                  <Label htmlFor={isolatedServicesInputId} className="cursor-pointer text-xs">
                     {translate(
                       'auto.components.NewWorkspaceComposerCard.provisionIsolatedServices',
                       'Isolated services'
                     )}
-                  </span>
-                </label>
+                  </Label>
+                </div>
                 <p className="pl-6 text-[11px] text-muted-foreground">
                   {translate(
                     'auto.components.NewWorkspaceComposerCard.provisionIsolatedServicesHint',

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -116,6 +116,10 @@ type NewWorkspaceComposerCardProps = {
   canReuseSelectedBranch: boolean
   reuseSelectedBranch: boolean
   onReuseSelectedBranchChange: (next: boolean) => void
+  /** True when the selected local repo declares `services:` recipes. */
+  repoHasServiceRecipes?: boolean
+  provisionServices?: boolean
+  onProvisionServicesChange?: (next: boolean) => void
   /** Shows the footer "Create more" switch — worktree targets only. */
   showCreateMultiple?: boolean
   createMultiple?: boolean
@@ -580,6 +584,9 @@ export default function NewWorkspaceComposerCard({
   canReuseSelectedBranch,
   reuseSelectedBranch,
   onReuseSelectedBranchChange,
+  repoHasServiceRecipes = false,
+  provisionServices = false,
+  onProvisionServicesChange,
   showCreateMultiple = false,
   createMultiple = false,
   onCreateMultipleChange,
@@ -1030,6 +1037,58 @@ export default function NewWorkspaceComposerCard({
                   {translate(
                     'auto.components.NewWorkspaceComposerCard.reuseExistingBranchHint',
                     'Check out the existing branch instead of creating a new one from it.'
+                  )}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Why: isolated services are provisioned per-worktree from orca.yaml's
+              `services:` recipes; only offered when the selected local repo
+              declares them. Collapses via the same grid transition as reuse. */}
+          <div
+            className={cn(
+              'grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out',
+              repoHasServiceRecipes ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+            )}
+            aria-hidden={!repoHasServiceRecipes}
+          >
+            <div className="min-h-0">
+              <div className="space-y-1 pt-1">
+                <label className="group flex w-fit items-center gap-2 text-xs text-foreground">
+                  <span
+                    className={cn(
+                      'flex size-4 items-center justify-center rounded-[3px] border shadow-sm transition',
+                      provisionServices
+                        ? 'border-emerald-500/60 bg-emerald-500 text-white'
+                        : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
+                    )}
+                  >
+                    <Check
+                      className={cn(
+                        'size-3 transition-opacity',
+                        provisionServices ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                  </span>
+                  <input
+                    type="checkbox"
+                    checked={provisionServices}
+                    onChange={(event) => onProvisionServicesChange?.(event.target.checked)}
+                    disabled={!repoHasServiceRecipes}
+                    className="sr-only"
+                  />
+                  <span>
+                    {translate(
+                      'auto.components.NewWorkspaceComposerCard.provisionIsolatedServices',
+                      'Isolated services'
+                    )}
+                  </span>
+                </label>
+                <p className="pl-6 text-[11px] text-muted-foreground">
+                  {translate(
+                    'auto.components.NewWorkspaceComposerCard.provisionIsolatedServicesHint',
+                    "Provision this workspace's own services (database, cache) from orca.yaml."
                   )}
                 </p>
               </div>

--- a/src/renderer/src/components/right-sidebar/ServicesPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ServicesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Database, Play, RefreshCw, Square } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
@@ -61,17 +61,28 @@ export default function ServicesPanel(): React.JSX.Element {
   const [pendingAction, setPendingAction] = useState<string | null>(null)
 
   const worktreeId = record?.worktreeId
+  // Why: the panel stays mounted across worktree switches; a slow probe for the
+  // previous worktree must not clobber the current one's display.
+  const probeTargetRef = useRef<string | undefined>(worktreeId)
+  probeTargetRef.current = worktreeId
   const refreshRuntime = useCallback(async (): Promise<void> => {
     if (!worktreeId) {
       return
     }
     setProbing(true)
     try {
-      setRuntime(await window.api.worktreeServices.runtime({ worktreeId }))
+      const states = await window.api.worktreeServices.runtime({ worktreeId })
+      if (probeTargetRef.current === worktreeId) {
+        setRuntime(states)
+      }
     } catch {
-      setRuntime(null)
+      if (probeTargetRef.current === worktreeId) {
+        setRuntime(null)
+      }
     } finally {
-      setProbing(false)
+      if (probeTargetRef.current === worktreeId) {
+        setProbing(false)
+      }
     }
   }, [worktreeId])
 

--- a/src/renderer/src/components/right-sidebar/ServicesPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ServicesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Database, Play, RefreshCw, Square } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
@@ -12,10 +12,10 @@ import type {
 } from '../../../../shared/worktree-services'
 
 const STATUS_BADGE_CLASS: Record<WorktreeServicesStatus, string> = {
-  ready: 'border-emerald-500/25 bg-emerald-500/5 text-emerald-600 dark:text-emerald-300',
-  provisioning: 'border-sky-500/25 bg-sky-500/5 text-sky-600 dark:text-sky-300',
-  create_failed: 'border-red-500/25 bg-red-500/5 text-red-600 dark:text-red-300',
-  destroy_failed: 'border-red-500/25 bg-red-500/5 text-red-600 dark:text-red-300'
+  ready: 'border-border bg-muted/30 text-foreground',
+  provisioning: 'border-border bg-muted/30 text-muted-foreground',
+  create_failed: 'border-destructive/30 bg-destructive/10 text-destructive',
+  destroy_failed: 'border-destructive/30 bg-destructive/10 text-destructive'
 }
 
 const STATUS_LABEL: Record<WorktreeServicesStatus, () => string> = {
@@ -29,8 +29,8 @@ const STATUS_LABEL: Record<WorktreeServicesStatus, () => string> = {
 }
 
 const RUN_STATE_DOT: Record<WorktreeServiceRuntimeState['runState'], string> = {
-  running: 'bg-emerald-500',
-  stopped: 'bg-rose-500',
+  running: 'bg-primary',
+  stopped: 'bg-muted-foreground',
   unknown: 'bg-muted-foreground/40'
 }
 
@@ -51,8 +51,24 @@ function SectionLabel({ children }: { children: React.ReactNode }): React.JSX.El
 
 export default function ServicesPanel(): React.JSX.Element {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  // Why: retry/action/probe state belongs to one worktree. Keying the stateful
+  // body prevents a late response from the previous workspace from disabling
+  // controls or replacing runtime state in the newly selected workspace.
+  return (
+    <WorktreeServicesPanel
+      key={activeWorktreeId ?? 'no-active-worktree'}
+      activeWorktreeId={activeWorktreeId}
+    />
+  )
+}
+
+function WorktreeServicesPanel({
+  activeWorktreeId
+}: {
+  activeWorktreeId: string | null
+}): React.JSX.Element {
   const record = useAppStore((s) =>
-    activeWorktreeId ? s.worktreeServicesRecords[activeWorktreeId] : undefined
+    activeWorktreeId ? s.worktreeServicesRecords?.[activeWorktreeId] : undefined
   )
   const hydrateWorktreeServices = useAppStore((s) => s.hydrateWorktreeServices)
   const [retrying, setRetrying] = useState(false)
@@ -61,10 +77,6 @@ export default function ServicesPanel(): React.JSX.Element {
   const [pendingAction, setPendingAction] = useState<string | null>(null)
 
   const worktreeId = record?.worktreeId
-  // Why: the panel stays mounted across worktree switches; a slow probe for the
-  // previous worktree must not clobber the current one's display.
-  const probeTargetRef = useRef<string | undefined>(worktreeId)
-  probeTargetRef.current = worktreeId
   const refreshRuntime = useCallback(async (): Promise<void> => {
     if (!worktreeId) {
       return
@@ -72,22 +84,15 @@ export default function ServicesPanel(): React.JSX.Element {
     setProbing(true)
     try {
       const states = await window.api.worktreeServices.runtime({ worktreeId })
-      if (probeTargetRef.current === worktreeId) {
-        setRuntime(states)
-      }
+      setRuntime(states)
     } catch {
-      if (probeTargetRef.current === worktreeId) {
-        setRuntime(null)
-      }
+      setRuntime(null)
     } finally {
-      if (probeTargetRef.current === worktreeId) {
-        setProbing(false)
-      }
+      setProbing(false)
     }
   }, [worktreeId])
 
   useEffect(() => {
-    setRuntime(null)
     void refreshRuntime()
   }, [refreshRuntime])
 
@@ -191,7 +196,7 @@ export default function ServicesPanel(): React.JSX.Element {
       {record.error && (
         <p className="px-3 pt-1 text-[11px] text-destructive break-words">{record.error}</p>
       )}
-      {record.status === 'create_failed' && (
+      {(record.status === 'create_failed' || record.status === 'destroy_failed') && (
         <div className="px-3 pt-2">
           <Button size="sm" variant="outline" onClick={handleRetry} disabled={retrying}>
             <RefreshCw className={cn('size-3', retrying && 'animate-spin')} />
@@ -244,8 +249,9 @@ export default function ServicesPanel(): React.JSX.Element {
             <div className="flex min-w-0 items-center gap-1.5">
               <span
                 className={cn('size-[7px] shrink-0 rounded-full', RUN_STATE_DOT[state.runState])}
-                title={RUN_STATE_LABEL[state.runState]()}
+                aria-hidden="true"
               />
+              <span className="sr-only">{RUN_STATE_LABEL[state.runState]()}</span>
               <span className="truncate font-mono text-[11px]">{state.serviceId}</span>
               <span className="truncate text-[11px] text-muted-foreground">{state.name}</span>
             </div>

--- a/src/renderer/src/components/right-sidebar/ServicesPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ServicesPanel.tsx
@@ -1,0 +1,165 @@
+import React, { useState } from 'react'
+import { Database, RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { translate } from '@/i18n/i18n'
+import type { WorktreeServicesStatus } from '../../../../shared/worktree-services'
+
+const STATUS_BADGE_CLASS: Record<WorktreeServicesStatus, string> = {
+  ready: 'border-emerald-500/25 bg-emerald-500/5 text-emerald-600 dark:text-emerald-300',
+  provisioning: 'border-sky-500/25 bg-sky-500/5 text-sky-600 dark:text-sky-300',
+  create_failed: 'border-red-500/25 bg-red-500/5 text-red-600 dark:text-red-300',
+  destroy_failed: 'border-red-500/25 bg-red-500/5 text-red-600 dark:text-red-300'
+}
+
+const STATUS_LABEL: Record<WorktreeServicesStatus, () => string> = {
+  ready: () => translate('auto.components.right.sidebar.ServicesPanel.statusReady', 'Ready'),
+  provisioning: () =>
+    translate('auto.components.right.sidebar.ServicesPanel.statusProvisioning', 'Provisioning'),
+  create_failed: () =>
+    translate('auto.components.right.sidebar.ServicesPanel.statusCreateFailed', 'Create failed'),
+  destroy_failed: () =>
+    translate('auto.components.right.sidebar.ServicesPanel.statusDestroyFailed', 'Destroy failed')
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <div className="px-3 pt-3 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+export default function ServicesPanel(): React.JSX.Element {
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const record = useAppStore((s) =>
+    activeWorktreeId ? s.worktreeServicesRecords[activeWorktreeId] : undefined
+  )
+  const hydrateWorktreeServices = useAppStore((s) => s.hydrateWorktreeServices)
+  const [retrying, setRetrying] = useState(false)
+
+  if (!record) {
+    return (
+      <div className="flex flex-col items-center gap-2 px-4 py-8 text-center text-xs text-muted-foreground">
+        <Database className="size-5 opacity-50" />
+        <p>
+          {translate(
+            'auto.components.right.sidebar.ServicesPanel.emptyState',
+            'No isolated services for this workspace.'
+          )}
+        </p>
+        <p className="text-[11px] opacity-80">
+          {translate(
+            'auto.components.right.sidebar.ServicesPanel.emptyHint',
+            'Declare services in orca.yaml and check "Isolated services" when creating a workspace.'
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  const handleRetry = async (): Promise<void> => {
+    setRetrying(true)
+    try {
+      await window.api.worktreeServices.retry({ worktreeId: record.worktreeId })
+      await hydrateWorktreeServices()
+    } catch (error) {
+      toast.error(
+        translate(
+          'auto.components.right.sidebar.ServicesPanel.retryFailed',
+          'Retrying services provisioning failed: {{value0}}',
+          { value0: String(error instanceof Error ? error.message : error).slice(0, 200) }
+        )
+      )
+    } finally {
+      setRetrying(false)
+    }
+  }
+
+  const contextKeys = new Set(
+    ['ORCA_WORKTREE_SLUG', 'ORCA_SERVICE_SLOT'].concat(
+      Array.from({ length: 10 }, (_, i) => `ORCA_PORT_${i}`)
+    )
+  )
+  const recipeEnv = Object.entries(record.env).filter(([key]) => !contextKeys.has(key))
+  const ports = Array.from({ length: 10 }, (_, i) => record.env[`ORCA_PORT_${i}`]).filter(Boolean)
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto text-xs">
+      <div className="flex items-center justify-between gap-2 px-3 pt-3">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Database className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate font-medium">{record.slug}</span>
+        </div>
+        <Badge
+          variant="outline"
+          className={cn('h-4 rounded px-1.5 text-[9px]', STATUS_BADGE_CLASS[record.status])}
+        >
+          {STATUS_LABEL[record.status]()}
+        </Badge>
+      </div>
+      {record.error && (
+        <p className="px-3 pt-1 text-[11px] text-destructive break-words">{record.error}</p>
+      )}
+      {record.status === 'create_failed' && (
+        <div className="px-3 pt-2">
+          <Button size="sm" variant="outline" onClick={handleRetry} disabled={retrying}>
+            <RefreshCw className={cn('size-3', retrying && 'animate-spin')} />
+            {translate(
+              'auto.components.right.sidebar.ServicesPanel.retryProvisioning',
+              'Retry provisioning'
+            )}
+          </Button>
+        </div>
+      )}
+
+      <SectionLabel>
+        {translate('auto.components.right.sidebar.ServicesPanel.servicesSection', 'Services')}
+      </SectionLabel>
+      <ul className="space-y-0.5 px-3">
+        {record.serviceIds.map((id) => (
+          <li key={id} className="truncate font-mono text-[11px]">
+            {id}
+          </li>
+        ))}
+      </ul>
+
+      <SectionLabel>
+        {translate('auto.components.right.sidebar.ServicesPanel.slotSection', 'Slot & ports')}
+      </SectionLabel>
+      <div className="px-3 text-[11px] text-muted-foreground">
+        {translate('auto.components.right.sidebar.ServicesPanel.slotLabel', 'Slot {{value0}}', {
+          value0: String(record.slot)
+        })}
+        {ports.length > 0 && (
+          <span className="font-mono">
+            {' '}
+            · {ports.at(0)}–{ports.at(-1)}
+          </span>
+        )}
+      </div>
+
+      {recipeEnv.length > 0 && (
+        <>
+          <SectionLabel>
+            {translate(
+              'auto.components.right.sidebar.ServicesPanel.envSection',
+              'Environment variables'
+            )}
+          </SectionLabel>
+          <ul className="space-y-0.5 px-3 pb-3">
+            {recipeEnv.map(([key, value]) => (
+              <li key={key} className="break-all font-mono text-[11px]">
+                <span className="text-muted-foreground">{key}=</span>
+                {value}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/ServicesPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ServicesPanel.tsx
@@ -1,12 +1,15 @@
-import React, { useState } from 'react'
-import { Database, RefreshCw } from 'lucide-react'
+import React, { useCallback, useEffect, useState } from 'react'
+import { Database, Play, RefreshCw, Square } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { translate } from '@/i18n/i18n'
-import type { WorktreeServicesStatus } from '../../../../shared/worktree-services'
+import type {
+  WorktreeServiceRuntimeState,
+  WorktreeServicesStatus
+} from '../../../../shared/worktree-services'
 
 const STATUS_BADGE_CLASS: Record<WorktreeServicesStatus, string> = {
   ready: 'border-emerald-500/25 bg-emerald-500/5 text-emerald-600 dark:text-emerald-300',
@@ -25,6 +28,19 @@ const STATUS_LABEL: Record<WorktreeServicesStatus, () => string> = {
     translate('auto.components.right.sidebar.ServicesPanel.statusDestroyFailed', 'Destroy failed')
 }
 
+const RUN_STATE_DOT: Record<WorktreeServiceRuntimeState['runState'], string> = {
+  running: 'bg-emerald-500',
+  stopped: 'bg-rose-500',
+  unknown: 'bg-muted-foreground/40'
+}
+
+const RUN_STATE_LABEL: Record<WorktreeServiceRuntimeState['runState'], () => string> = {
+  running: () => translate('auto.components.right.sidebar.ServicesPanel.runRunning', 'Running'),
+  stopped: () => translate('auto.components.right.sidebar.ServicesPanel.runStopped', 'Stopped'),
+  unknown: () =>
+    translate('auto.components.right.sidebar.ServicesPanel.runUnknown', 'No status command')
+}
+
 function SectionLabel({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <div className="px-3 pt-3 pb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -40,6 +56,29 @@ export default function ServicesPanel(): React.JSX.Element {
   )
   const hydrateWorktreeServices = useAppStore((s) => s.hydrateWorktreeServices)
   const [retrying, setRetrying] = useState(false)
+  const [runtime, setRuntime] = useState<WorktreeServiceRuntimeState[] | null>(null)
+  const [probing, setProbing] = useState(false)
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+
+  const worktreeId = record?.worktreeId
+  const refreshRuntime = useCallback(async (): Promise<void> => {
+    if (!worktreeId) {
+      return
+    }
+    setProbing(true)
+    try {
+      setRuntime(await window.api.worktreeServices.runtime({ worktreeId }))
+    } catch {
+      setRuntime(null)
+    } finally {
+      setProbing(false)
+    }
+  }, [worktreeId])
+
+  useEffect(() => {
+    setRuntime(null)
+    void refreshRuntime()
+  }, [refreshRuntime])
 
   if (!record) {
     return (
@@ -66,6 +105,7 @@ export default function ServicesPanel(): React.JSX.Element {
     try {
       await window.api.worktreeServices.retry({ worktreeId: record.worktreeId })
       await hydrateWorktreeServices()
+      await refreshRuntime()
     } catch (error) {
       toast.error(
         translate(
@@ -79,6 +119,25 @@ export default function ServicesPanel(): React.JSX.Element {
     }
   }
 
+  const handleAction = async (action: 'start' | 'stop', serviceId?: string): Promise<void> => {
+    setPendingAction(serviceId ? `${action}:${serviceId}` : action)
+    try {
+      const result = await window.api.worktreeServices.action({
+        worktreeId: record.worktreeId,
+        action,
+        ...(serviceId ? { serviceId } : {})
+      })
+      if (!result.success) {
+        toast.error(result.errors.join('; ').slice(0, 300))
+      }
+      await refreshRuntime()
+    } catch (error) {
+      toast.error(String(error instanceof Error ? error.message : error).slice(0, 200))
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
   const contextKeys = new Set(
     ['ORCA_WORKTREE_SLUG', 'ORCA_SERVICE_SLOT'].concat(
       Array.from({ length: 10 }, (_, i) => `ORCA_PORT_${i}`)
@@ -86,6 +145,8 @@ export default function ServicesPanel(): React.JSX.Element {
   )
   const recipeEnv = Object.entries(record.env).filter(([key]) => !contextKeys.has(key))
   const ports = Array.from({ length: 10 }, (_, i) => record.env[`ORCA_PORT_${i}`]).filter(Boolean)
+  const anyStartable = (runtime ?? []).some((state) => state.canStart)
+  const anyStoppable = (runtime ?? []).some((state) => state.canStop)
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto text-xs">
@@ -94,12 +155,27 @@ export default function ServicesPanel(): React.JSX.Element {
           <Database className="size-3.5 shrink-0 text-muted-foreground" />
           <span className="truncate font-medium">{record.slug}</span>
         </div>
-        <Badge
-          variant="outline"
-          className={cn('h-4 rounded px-1.5 text-[9px]', STATUS_BADGE_CLASS[record.status])}
-        >
-          {STATUS_LABEL[record.status]()}
-        </Badge>
+        <div className="flex items-center gap-1">
+          <Badge
+            variant="outline"
+            className={cn('h-4 rounded px-1.5 text-[9px]', STATUS_BADGE_CLASS[record.status])}
+          >
+            {STATUS_LABEL[record.status]()}
+          </Badge>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-5"
+            onClick={() => void refreshRuntime()}
+            disabled={probing}
+            title={translate(
+              'auto.components.right.sidebar.ServicesPanel.refreshStatus',
+              'Refresh service status'
+            )}
+          >
+            <RefreshCw className={cn('size-3', probing && 'animate-spin')} />
+          </Button>
+        </div>
       </div>
       {record.error && (
         <p className="px-3 pt-1 text-[11px] text-destructive break-words">{record.error}</p>
@@ -116,15 +192,92 @@ export default function ServicesPanel(): React.JSX.Element {
         </div>
       )}
 
+      {(anyStartable || anyStoppable) && (
+        <div className="flex items-center gap-1.5 px-3 pt-2">
+          {anyStartable && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void handleAction('start')}
+              disabled={pendingAction !== null}
+            >
+              <Play className="size-3" />
+              {translate('auto.components.right.sidebar.ServicesPanel.startAll', 'Start all')}
+            </Button>
+          )}
+          {anyStoppable && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void handleAction('stop')}
+              disabled={pendingAction !== null}
+            >
+              <Square className="size-3" />
+              {translate('auto.components.right.sidebar.ServicesPanel.stopAll', 'Stop all')}
+            </Button>
+          )}
+        </div>
+      )}
+
       <SectionLabel>
         {translate('auto.components.right.sidebar.ServicesPanel.servicesSection', 'Services')}
       </SectionLabel>
-      <ul className="space-y-0.5 px-3">
-        {record.serviceIds.map((id) => (
-          <li key={id} className="truncate font-mono text-[11px]">
-            {id}
+      <ul className="space-y-1 px-3">
+        {runtime !== null && runtime.length === 0 && (
+          <li className="text-[11px] text-muted-foreground">
+            {translate('auto.components.right.sidebar.ServicesPanel.noServices', 'No services.')}
+          </li>
+        )}
+        {(runtime ?? []).map((state) => (
+          <li key={state.serviceId} className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span
+                className={cn('size-[7px] shrink-0 rounded-full', RUN_STATE_DOT[state.runState])}
+                title={RUN_STATE_LABEL[state.runState]()}
+              />
+              <span className="truncate font-mono text-[11px]">{state.serviceId}</span>
+              <span className="truncate text-[11px] text-muted-foreground">{state.name}</span>
+            </div>
+            <div className="flex shrink-0 items-center gap-0.5">
+              {state.canStart && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-5"
+                  onClick={() => void handleAction('start', state.serviceId)}
+                  disabled={pendingAction !== null || state.runState === 'running'}
+                  title={translate(
+                    'auto.components.right.sidebar.ServicesPanel.startService',
+                    'Start service'
+                  )}
+                >
+                  <Play className="size-3" />
+                </Button>
+              )}
+              {state.canStop && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-5"
+                  onClick={() => void handleAction('stop', state.serviceId)}
+                  disabled={pendingAction !== null || state.runState === 'stopped'}
+                  title={translate(
+                    'auto.components.right.sidebar.ServicesPanel.stopService',
+                    'Stop service'
+                  )}
+                >
+                  <Square className="size-3" />
+                </Button>
+              )}
+            </div>
           </li>
         ))}
+        {runtime === null &&
+          record.serviceIds.map((id) => (
+            <li key={id} className="truncate font-mono text-[11px] text-muted-foreground">
+              {id}
+            </li>
+          ))}
       </ul>
 
       <SectionLabel>

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
@@ -25,6 +25,8 @@ export type ActivityBarItem = {
   folderOnly?: boolean
   /** When true, shown only for worktrees that belong to an SSH repo. */
   sshOnly?: boolean
+  /** When true, shown only for worktrees with an isolated-services record. */
+  servicesOnly?: boolean
 }
 
 const STATUS_DOT_COLOR: Record<CheckStatus, string> = {

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -85,7 +85,7 @@ function RightSidebarInner(): React.JSX.Element {
   const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
   const isSshRepo = Boolean(activeRepo?.connectionId)
   const hasWorktreeServices = useAppStore((s) =>
-    Boolean(activeWorktreeId && s.worktreeServicesRecords[activeWorktreeId])
+    Boolean(activeWorktreeId && s.worktreeServicesRecords?.[activeWorktreeId])
   )
 
   const activityItems = useMemo<ActivityBarItem[]>(

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: the right sidebar owns activity-bar visibility, routing, and resize behavior as one interaction surface; splitting the tab table away would make hidden-tab fallbacks harder to audit. */
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Plug, Files, GitBranch, ListChecks, PanelRight, Workflow } from 'lucide-react'
+import { Database, Plug, Files, GitBranch, ListChecks, PanelRight, Workflow } from 'lucide-react'
 import { useAppStore } from '@/store'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 import { useRepoById } from '@/store/selectors'
@@ -84,6 +84,9 @@ function RightSidebarInner(): React.JSX.Element {
   const isFolderWorkspace = activeWorkspaceScope?.type === 'folder'
   const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
   const isSshRepo = Boolean(activeRepo?.connectionId)
+  const hasWorktreeServices = useAppStore((s) =>
+    Boolean(activeWorktreeId && s.worktreeServicesRecords[activeWorktreeId])
+  )
 
   const activityItems = useMemo<ActivityBarItem[]>(
     () => [
@@ -136,6 +139,13 @@ function RightSidebarInner(): React.JSX.Element {
         title: translate('auto.components.right.sidebar.index.441733b630', 'Ports'),
         shortcut: portsShortcut === 'Unassigned' ? '' : portsShortcut,
         sshOnly: true
+      },
+      {
+        id: 'services',
+        icon: Database,
+        title: translate('auto.components.right.sidebar.index.isolatedServices', 'Services'),
+        shortcut: '',
+        servicesOnly: true
       }
     ],
     [checksShortcut, explorerShortcut, portsShortcut, sourceControlShortcut]
@@ -146,9 +156,10 @@ function RightSidebarInner(): React.JSX.Element {
       getVisibleRightSidebarActivityItems(activityItems, {
         isFolder,
         isFolderWorkspace,
-        isSshRepo
+        isSshRepo,
+        hasWorktreeServices
       }),
-    [activityItems, isFolder, isFolderWorkspace, isSshRepo]
+    [activityItems, isFolder, isFolderWorkspace, isSshRepo, hasWorktreeServices]
   )
 
   const rememberedFolderTabByWorkspaceKeyRef = useRef<Record<string, ActiveRightSidebarTab>>({})

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
@@ -26,7 +26,8 @@ const items: ActivityBarItem[] = [
     shortcut: '',
     gitOnly: true
   },
-  { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true }
+  { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true },
+  { id: 'services', icon: Files, title: 'Services', shortcut: '', servicesOnly: true }
 ]
 
 describe('getVisibleRightSidebarActivityItems', () => {
@@ -64,5 +65,24 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isSshRepo: true
       }).map((item) => item.id)
     ).toEqual(['explorer', 'ports'])
+  })
+
+  it('shows Services only for worktrees with an isolated-services record', () => {
+    expect(
+      getVisibleRightSidebarActivityItems(items, {
+        isFolder: false,
+        isFolderWorkspace: false,
+        isSshRepo: false,
+        hasWorktreeServices: true
+      }).map((item) => item.id)
+    ).toEqual(['explorer', 'source-control', 'services'])
+
+    expect(
+      getVisibleRightSidebarActivityItems(items, {
+        isFolder: false,
+        isFolderWorkspace: false,
+        isSshRepo: false
+      }).map((item) => item.id)
+    ).toEqual(['explorer', 'source-control'])
   })
 })

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
@@ -4,11 +4,17 @@ type RightSidebarActivityVisibilityState = {
   isFolder: boolean
   isFolderWorkspace: boolean
   isSshRepo: boolean
+  hasWorktreeServices?: boolean
 }
 
 export function getVisibleRightSidebarActivityItems(
   items: ActivityBarItem[],
-  { isFolder, isFolderWorkspace, isSshRepo }: RightSidebarActivityVisibilityState
+  {
+    isFolder,
+    isFolderWorkspace,
+    isSshRepo,
+    hasWorktreeServices
+  }: RightSidebarActivityVisibilityState
 ): ActivityBarItem[] {
   return items.filter((item) => {
     if (item.gitOnly && isFolder) {
@@ -18,6 +24,9 @@ export function getVisibleRightSidebarActivityItems(
       return false
     }
     if (item.sshOnly && !isSshRepo) {
+      return false
+    }
+    if (item.servicesOnly && !hasWorktreeServices) {
       return false
     }
     return true

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -6,6 +6,7 @@ const FileExplorer = lazy(() => import('./FileExplorer'))
 const SourceControl = lazy(() => import('./SourceControl'))
 const ChecksPanel = lazy(() => import('./ChecksPanel'))
 const PortsPanel = lazy(() => import('./PortsPanel'))
+const ServicesPanel = lazy(() => import('./ServicesPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
@@ -31,6 +32,7 @@ export function RightSidebarPanelContent({
         {effectiveTab === 'ports' && (
           <PortsPanel isVisible={rightSidebarOpen && effectiveTab === 'ports'} />
         )}
+        {effectiveTab === 'services' && <ServicesPanel />}
         {effectiveTab === 'vault' && <AiVaultPanel />}
         {effectiveTab === 'workspaces' && <FolderWorkspaceWorktreesPanel />}
         {effectiveTab === 'pr-checks' && (

--- a/src/renderer/src/components/settings/RepositoryHooksSection.test.ts
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.test.ts
@@ -4,7 +4,7 @@ import React from 'react'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { Repo } from '../../../../shared/types'
+import type { OrcaHooks, Repo } from '../../../../shared/types'
 import { getLocalCommandSourcePolicyNotice, RepositoryHooksSection } from './RepositoryHooksSection'
 
 vi.mock('@/store', () => ({
@@ -32,6 +32,8 @@ const repo: Repo = {
 
 function renderRepositoryHooksSection(args: {
   onUpdateHookSettings: (settings: NonNullable<Repo['hookSettings']>) => void
+  yamlHooks?: OrcaHooks | null
+  hasHooksFile?: boolean
 }): { container: HTMLDivElement; root: Root } {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -40,8 +42,8 @@ function renderRepositoryHooksSection(args: {
     root.render(
       React.createElement(RepositoryHooksSection, {
         repo,
-        yamlHooks: null,
-        hasHooksFile: false,
+        yamlHooks: args.yamlHooks ?? null,
+        hasHooksFile: args.hasHooksFile ?? false,
         hooksInspectionReady: true,
         mayNeedUpdate: false,
         copiedTemplate: false,
@@ -131,6 +133,32 @@ describe('getLocalCommandSourcePolicyNotice', () => {
         hasSharedScript: true
       })
     ).toEqual({ kind: 'action', policy: 'run-both', label: 'Run both' })
+  })
+})
+
+describe('RepositoryHooksSection service diagnostics', () => {
+  it('renders service diagnostics and a missing-destroy warning', () => {
+    rendered = renderRepositoryHooksSection({
+      onUpdateHookSettings: () => {},
+      hasHooksFile: true,
+      yamlHooks: {
+        scripts: {},
+        services: [{ id: 'db', name: 'Postgres', create: 'docker compose up -d' }],
+        serviceDiagnostics: [
+          {
+            index: 1,
+            field: 'id',
+            message: 'Duplicate service id "db". Service ids must be unique.'
+          }
+        ]
+      }
+    })
+
+    const text = rendered.container.textContent ?? ''
+    expect(text).toContain('Duplicate service id "db". Service ids must be unique.')
+    expect(text).toContain(
+      'Service "db" has no destroy command — containers will outlive worktrees.'
+    )
   })
 })
 

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -1405,12 +1405,16 @@ function ServiceRecipeDiagnostics({
     return null
   }
   return (
-    <ul className="space-y-1 text-xs text-destructive">
+    <ul className="space-y-1 text-xs">
       {diagnostics.map((diagnostic, index) => (
-        <li key={`service-diagnostic-${index}`}>{diagnostic.message}</li>
+        <li key={`service-diagnostic-${index}`} className="text-destructive">
+          {diagnostic.message}
+        </li>
       ))}
       {missingDestroyWarnings.map((warning) => (
-        <li key={warning}>{warning}</li>
+        <li key={warning} className="text-amber-700 dark:text-amber-300">
+          {warning}
+        </li>
       ))}
     </ul>
   )

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -1397,9 +1397,12 @@ function ServiceRecipeDiagnostics({
   const diagnostics = hooks?.serviceDiagnostics ?? []
   const missingDestroyWarnings = (hooks?.services ?? [])
     .filter((service) => !service.destroy)
-    .map(
-      (service) =>
-        `Service "${service.id}" has no destroy command — containers will outlive worktrees.`
+    .map((service) =>
+      translate(
+        'auto.components.settings.RepositoryHooksSection.serviceMissingDestroy',
+        'Service "{{value0}}" has no destroy command — containers will outlive worktrees.',
+        { value0: service.id }
+      )
     )
   if (diagnostics.length === 0 && missingDestroyWarnings.length === 0) {
     return null

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -1344,7 +1344,10 @@ export function RepositoryHooksSection({
               </div>
 
               {yamlState === 'loaded' ? (
-                <YamlScriptBlock content={renderYamlScriptPreview(yamlHooks)} />
+                <>
+                  <YamlScriptBlock content={renderYamlScriptPreview(yamlHooks)} />
+                  <ServiceRecipeDiagnostics hooks={yamlHooks} />
+                </>
               ) : yamlState === 'invalid' ? (
                 <div className="space-y-4">
                   <div className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-background/60 p-3">
@@ -1381,6 +1384,35 @@ export function RepositoryHooksSection({
         </details>
       </SearchableSetting>
     </section>
+  )
+}
+
+// Why: services parse leniently — invalid entries and destroy-less recipes are
+// non-fatal, so surface them here rather than failing the whole orca.yaml.
+function ServiceRecipeDiagnostics({
+  hooks
+}: {
+  hooks: OrcaHooks | null
+}): React.JSX.Element | null {
+  const diagnostics = hooks?.serviceDiagnostics ?? []
+  const missingDestroyWarnings = (hooks?.services ?? [])
+    .filter((service) => !service.destroy)
+    .map(
+      (service) =>
+        `Service "${service.id}" has no destroy command — containers will outlive worktrees.`
+    )
+  if (diagnostics.length === 0 && missingDestroyWarnings.length === 0) {
+    return null
+  }
+  return (
+    <ul className="space-y-1 text-xs text-destructive">
+      {diagnostics.map((diagnostic, index) => (
+        <li key={`service-diagnostic-${index}`}>{diagnostic.message}</li>
+      ))}
+      {missingDestroyWarnings.map((warning) => (
+        <li key={warning}>{warning}</li>
+      ))}
+    </ul>
   )
 }
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1208,7 +1208,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // carrying a persistent rebase chip while preserving other interruption cues.
   const showConflictOperationBadge =
     !!conflictOperation && conflictOperation !== 'unknown' && conflictOperation !== 'rebase'
-  const hasMetadataBadge = showConflictOperationBadge
+  const hasMetadataBadge = showConflictOperationBadge || Boolean(servicesStatus)
   const showUnreadQuickAction = !affiliateListMode && showStatus && !newCardStyle
   // Why: the slot owns the tiny unread/status lane; legacy keeps the bell
   // toggle, while the experimental card keeps the status glyph passive.
@@ -1227,6 +1227,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     showIdentityInNewCard ||
     showDetachedHeadInMetaRow ||
     showConflictOperationBadge ||
+    Boolean(servicesStatus) ||
     cacheStartedAt != null ||
     showMetaRowDetails
   )

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -20,6 +20,8 @@ import {
   Workflow
 } from 'lucide-react'
 import CacheTimer, { usePromptCacheCountdownStartedAt } from './CacheTimer'
+import { toast } from 'sonner'
+import { ServicesStatusBadge } from './WorktreeCardMetadataStatusBadges'
 import WorktreeContextMenu from './WorktreeContextMenu'
 import { SshDisconnectedDialog } from './SshDisconnectedDialog'
 import { AutoRenameFailedDialog } from './AutoRenameFailedDialog'
@@ -324,6 +326,25 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
   const conflictOperation = useAppStore((s) => s.gitConflictOperationByWorktree[worktree.id])
+  const servicesStatus = useAppStore((s) => s.worktreeServicesStatus?.[worktree.id])
+  const handleRetryServices = useCallback(
+    async (event: React.MouseEvent): Promise<void> => {
+      // Why: the badge sits on the clickable card row; don't activate the worktree.
+      event.stopPropagation()
+      try {
+        await window.api.worktreeServices.retry({ worktreeId: worktree.id })
+        await useAppStore.getState().hydrateWorktreeServices()
+      } catch {
+        toast.error(
+          translate(
+            'auto.components.sidebar.WorktreeCard.retryServicesFailed',
+            'Failed to retry services provisioning.'
+          )
+        )
+      }
+    },
+    [worktree.id]
+  )
   const remoteBranchConflict = useAppStore((s) => s.remoteBranchConflictByWorktreeId[worktree.id])
   const workspacePorts = useAppStore(
     (s) =>
@@ -1698,6 +1719,23 @@ const WorktreeCard = React.memo(function WorktreeCard({
                   {CONFLICT_OPERATION_LABELS[conflictOperation]}
                 </Badge>
               )}
+
+              {servicesStatus &&
+                (servicesStatus === 'create_failed' ? (
+                  <button
+                    type="button"
+                    onClick={handleRetryServices}
+                    className="contents"
+                    title={translate(
+                      'auto.components.sidebar.WorktreeCard.retryServices',
+                      'Retry services provisioning'
+                    )}
+                  >
+                    <ServicesStatusBadge status={servicesStatus} />
+                  </button>
+                ) : (
+                  <ServicesStatusBadge status={servicesStatus} />
+                ))}
 
               {cacheStartedAt != null && (
                 <CacheTimer startedAt={cacheStartedAt} ttlMs={cacheTtlMs} />

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1722,11 +1722,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
               )}
 
               {servicesStatus &&
-                (servicesStatus === 'create_failed' ? (
+                (servicesStatus === 'create_failed' || servicesStatus === 'destroy_failed' ? (
                   <button
                     type="button"
                     onClick={handleRetryServices}
-                    className="contents"
+                    className="inline-flex rounded p-0 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
                     title={translate(
                       'auto.components.sidebar.WorktreeCard.retryServices',
                       'Retry services provisioning'

--- a/src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx
@@ -51,9 +51,25 @@ export function ServicesStatusBadge({
           'auto.components.sidebar.WorktreeCardMetadataStatusBadges.servicesFailed',
           'Services: Failed'
         )}
-        className="border-red-500/25 bg-red-500/5 text-red-600 dark:text-red-300"
+        className="border-destructive/30 bg-destructive/10 text-destructive"
       >
         <DatabaseZap />
+      </MetadataStatusBadge>
+    )
+  }
+  if (status === 'provisioning') {
+    return (
+      <MetadataStatusBadge
+        label={`${translate(
+          'auto.components.sidebar.WorktreeCardMetadataStatusBadges.servicesReady',
+          'Services'
+        )}: ${translate(
+          'auto.components.right.sidebar.ServicesPanel.statusProvisioning',
+          'Provisioning'
+        )}`}
+        className="border-border bg-muted/30 text-muted-foreground"
+      >
+        <Database />
       </MetadataStatusBadge>
     )
   }
@@ -63,7 +79,7 @@ export function ServicesStatusBadge({
         'auto.components.sidebar.WorktreeCardMetadataStatusBadges.servicesReady',
         'Services'
       )}
-      className="border-sky-500/25 bg-sky-500/5 text-sky-600 dark:text-sky-300"
+      className="border-border bg-muted/30 text-muted-foreground"
     >
       <Database />
     </MetadataStatusBadge>

--- a/src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx
@@ -1,10 +1,19 @@
 import React from 'react'
 import { Badge } from '@/components/ui/badge'
-import { CircleCheck, CircleDot, CircleX, Clock, GitMerge } from 'lucide-react'
+import {
+  CircleCheck,
+  CircleDot,
+  CircleX,
+  Clock,
+  Database,
+  DatabaseZap,
+  GitMerge
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PullRequestIcon, checksLabel } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 import type { IssueInfo } from '../../../../shared/types'
+import type { WorktreeServicesStatus } from '../../../../shared/worktree-services'
 import { translate } from '@/i18n/i18n'
 
 function MetadataStatusBadge({
@@ -27,6 +36,37 @@ function MetadataStatusBadge({
       {children}
       <span>{label}</span>
     </Badge>
+  )
+}
+
+export function ServicesStatusBadge({
+  status
+}: {
+  status: WorktreeServicesStatus
+}): React.JSX.Element {
+  if (status === 'create_failed' || status === 'destroy_failed') {
+    return (
+      <MetadataStatusBadge
+        label={translate(
+          'auto.components.sidebar.WorktreeCardMetadataStatusBadges.servicesFailed',
+          'Services: Failed'
+        )}
+        className="border-red-500/25 bg-red-500/5 text-red-600 dark:text-red-300"
+      >
+        <DatabaseZap />
+      </MetadataStatusBadge>
+    )
+  }
+  return (
+    <MetadataStatusBadge
+      label={translate(
+        'auto.components.sidebar.WorktreeCardMetadataStatusBadges.servicesReady',
+        'Services'
+      )}
+      className="border-sky-500/25 bg-sky-500/5 text-sky-600 dark:text-sky-300"
+    >
+      <Database />
+    </MetadataStatusBadge>
   )
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -29,6 +29,7 @@ import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
 import { getConnectionId } from '@/lib/connection-context'
+import { getWorktreeServiceEnv } from '@/lib/worktree-service-env-injection'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import {
   getCachedWindowsTerminalCapabilities,
@@ -3106,6 +3107,7 @@ export function connectPanePty(
   }
   const paneEnv = {
     ...paneStartup?.env,
+    ...getWorktreeServiceEnv(deps.worktreeId),
     ...paneIdentityEnv
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4450,6 +4450,9 @@ export function connectPanePty(
       env
         ? {
             ...env,
+            // Why: cold-restore/reattach fresh spawns must keep the isolated
+            // service env, same as the initial connect path.
+            ...getWorktreeServiceEnv(deps.worktreeId),
             ...paneIdentityEnv,
             ...(env.ORCA_AGENT_LAUNCH_TOKEN
               ? { ORCA_AGENT_LAUNCH_TOKEN: env.ORCA_AGENT_LAUNCH_TOKEN }

--- a/src/renderer/src/components/worktree-creation/WorktreeCreationPanel.tsx
+++ b/src/renderer/src/components/worktree-creation/WorktreeCreationPanel.tsx
@@ -161,6 +161,17 @@ export default function WorktreeCreationPanel({
               <span>{getCreationProgressLabel(entry)}</span>
               <span className="text-muted-foreground/70">{elapsedLabel}</span>
             </div>
+            {/* Why: surface streamed service-provisioning output (docker image
+                pulls can run for minutes) instead of only a static label. */}
+            {entry.phase === 'provisioning-services' && entry.provisioningLog ? (
+              <RecipeOutputLog
+                log={entry.provisioningLog}
+                emptyLabel={translate(
+                  'auto.components.worktree.creation.WorktreeCreationPanel.vmProvisioningLogEmpty',
+                  'Waiting for recipe output…'
+                )}
+              />
+            ) : null}
           </div>
         )}
       </div>

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1180,6 +1180,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const repoHasServiceRecipes = Boolean(
     selectedRepoIsGit &&
     !selectedRepo?.connectionId &&
+    // Why: a local repo whose active target is a paired runtime — or a selected
+    // per-workspace VM recipe (which swaps in a runtime-owned repo at create) —
+    // routes create through RPC, which drops provisionServices. Hide the opt-in
+    // so a checked box can't be silently ignored (v1 provisions locally only).
+    !runtimeEnvironmentId &&
+    !selectedEphemeralVmRecipeId &&
     repoId &&
     checkedHooksRepoId === repoId &&
     (yamlHooks?.services?.length ?? 0) > 0

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -926,10 +926,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     selectedRecipeRepoId,
     selectedRepoIsGit
   ])
-  // Why: a stale opt-in from a previous repo must not leak into the next create.
-  useEffect(() => {
-    setProvisionServices(false)
-  }, [repoId])
   const selectedRepoConnectionId = selectedRepo?.connectionId ?? null
   const selectedRepoSshState = selectedRepoConnectionId
     ? (sshConnectionStates.get(selectedRepoConnectionId) ?? null)
@@ -1110,7 +1106,15 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // is the explicit checkbox value driving whether reuse actually happens.
   const [reuseEligibleBranch, setReuseEligibleBranch] = useState<string | null>(null)
   const [reuseSelectedBranch, setReuseSelectedBranch] = useState(false)
-  const [provisionServices, setProvisionServices] = useState(false)
+  const [provisionServicesRepoId, setProvisionServicesRepoId] = useState<string | null>(null)
+  // Why: key the opt-in to the repo where the user selected it. Deriving the
+  // visible value avoids an effect render where a newly selected repo briefly
+  // inherits the previous repo's checked state.
+  const provisionServices = provisionServicesRepoId === repoId
+  const setProvisionServices = useCallback(
+    (enabled: boolean) => setProvisionServicesRepoId(enabled ? repoId : null),
+    [repoId]
+  )
   const [pushTarget, setPushTarget] = useState<GitPushTarget | undefined>(undefined)
   // Why: when a repo switch wipes a prior Start-from selection, surface the
   // reset inline (e.g. "was PR #8778") so the change is recoverable visually
@@ -1179,6 +1183,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // instead of a second hooks.check IPC round trip per repo switch.
   const repoHasServiceRecipes = Boolean(
     selectedRepoIsGit &&
+    !isProjectGroupTarget &&
     !selectedRepo?.connectionId &&
     // Why: a local repo whose active target is a paired runtime — or a selected
     // per-workspace VM recipe (which swaps in a runtime-owned repo at create) —

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -290,6 +290,12 @@ export type ComposerCardProps = {
    *  rather than used as the base for a new branch. */
   reuseSelectedBranch: boolean
   onReuseSelectedBranchChange: (next: boolean) => void
+  /** True when the selected LOCAL repo declares `services:` recipes in
+   *  orca.yaml — gates the isolated-services opt-in (v1 is local repos only). */
+  repoHasServiceRecipes: boolean
+  /** Whether the new worktree should provision its own isolated services. */
+  provisionServices: boolean
+  onProvisionServicesChange: (next: boolean) => void
   /** Whether the "create multiple" toggle is shown — worktree (git) targets
    *  only; folder-workspace targets create-and-close as before. */
   showCreateMultiple: boolean
@@ -920,6 +926,34 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     selectedRecipeRepoId,
     selectedRepoIsGit
   ])
+  // Why: the isolated-services opt-in is offered only for local git repos whose
+  // orca.yaml declares `services:` recipes. Reset on every repo switch so a stale
+  // opt-in from a previous repo cannot leak into the next create.
+  useEffect(() => {
+    let cancelled = false
+    setRepoHasServiceRecipes(false)
+    setProvisionServices(false)
+    if (!selectedRecipeRepoId || !selectedRepoIsGit || selectedRecipeRepoConnectionId) {
+      return () => {
+        cancelled = true
+      }
+    }
+    void window.api.hooks
+      .check({ repoId: selectedRecipeRepoId })
+      .then((result) => {
+        if (!cancelled) {
+          setRepoHasServiceRecipes((result.hooks?.services?.length ?? 0) > 0)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRepoHasServiceRecipes(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedRecipeRepoConnectionId, selectedRecipeRepoId, selectedRepoIsGit])
   const selectedRepoConnectionId = selectedRepo?.connectionId ?? null
   const selectedRepoSshState = selectedRepoConnectionId
     ? (sshConnectionStates.get(selectedRepoConnectionId) ?? null)
@@ -1100,6 +1134,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // is the explicit checkbox value driving whether reuse actually happens.
   const [reuseEligibleBranch, setReuseEligibleBranch] = useState<string | null>(null)
   const [reuseSelectedBranch, setReuseSelectedBranch] = useState(false)
+  const [provisionServices, setProvisionServices] = useState(false)
+  const [repoHasServiceRecipes, setRepoHasServiceRecipes] = useState(false)
   const [pushTarget, setPushTarget] = useState<GitPushTarget | undefined>(undefined)
   // Why: when a repo switch wipes a prior Start-from selection, surface the
   // reset inline (e.g. "was PR #8778") so the change is recoverable visually
@@ -4208,6 +4244,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           startupPlan,
           quickPrompt,
           quickTelemetry,
+          ...(provisionServices && repoHasServiceRecipes ? { provisionServices: true } : {}),
           ...(createMultiple ? { suppressTerminalFocusOnCompletion: true } : {})
         }
 
@@ -4349,6 +4386,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       smartNameSelection?.kind === 'branch',
     reuseSelectedBranch,
     onReuseSelectedBranchChange: handleReuseSelectedBranchChange,
+    repoHasServiceRecipes,
+    provisionServices,
+    onProvisionServicesChange: setProvisionServices,
     // Why: the "create multiple" toggle only applies to worktree (git) targets;
     // folder-workspace targets keep the create-and-close behavior.
     showCreateMultiple: !isProjectGroupTarget,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -926,34 +926,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     selectedRecipeRepoId,
     selectedRepoIsGit
   ])
-  // Why: the isolated-services opt-in is offered only for local git repos whose
-  // orca.yaml declares `services:` recipes. Reset on every repo switch so a stale
-  // opt-in from a previous repo cannot leak into the next create.
+  // Why: a stale opt-in from a previous repo must not leak into the next create.
   useEffect(() => {
-    let cancelled = false
-    setRepoHasServiceRecipes(false)
     setProvisionServices(false)
-    if (!selectedRecipeRepoId || !selectedRepoIsGit || selectedRecipeRepoConnectionId) {
-      return () => {
-        cancelled = true
-      }
-    }
-    void window.api.hooks
-      .check({ repoId: selectedRecipeRepoId })
-      .then((result) => {
-        if (!cancelled) {
-          setRepoHasServiceRecipes((result.hooks?.services?.length ?? 0) > 0)
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setRepoHasServiceRecipes(false)
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [selectedRecipeRepoConnectionId, selectedRecipeRepoId, selectedRepoIsGit])
+  }, [repoId])
   const selectedRepoConnectionId = selectedRepo?.connectionId ?? null
   const selectedRepoSshState = selectedRepoConnectionId
     ? (sshConnectionStates.get(selectedRepoConnectionId) ?? null)
@@ -1135,7 +1111,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const [reuseEligibleBranch, setReuseEligibleBranch] = useState<string | null>(null)
   const [reuseSelectedBranch, setReuseSelectedBranch] = useState(false)
   const [provisionServices, setProvisionServices] = useState(false)
-  const [repoHasServiceRecipes, setRepoHasServiceRecipes] = useState(false)
   const [pushTarget, setPushTarget] = useState<GitPushTarget | undefined>(undefined)
   // Why: when a repo switch wipes a prior Start-from selection, surface the
   // reset inline (e.g. "was PR #8778") so the change is recoverable visually
@@ -1199,6 +1174,16 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   const [yamlHooks, setYamlHooks] = useState<OrcaHooks | null>(null)
   const [checkedHooksRepoId, setCheckedHooksRepoId] = useState<string | null>(null)
+  // Why: the isolated-services opt-in is offered only for local git repos whose
+  // orca.yaml declares `services:` — derived from the already-fetched hook check
+  // instead of a second hooks.check IPC round trip per repo switch.
+  const repoHasServiceRecipes = Boolean(
+    selectedRepoIsGit &&
+    !selectedRepo?.connectionId &&
+    repoId &&
+    checkedHooksRepoId === repoId &&
+    (yamlHooks?.services?.length ?? 0) > 0
+  )
   const [issueCommandTemplate, setIssueCommandTemplate] = useState('')
   const [hasLoadedIssueCommand, setHasLoadedIssueCommand] = useState(false)
   const [setupDecision, setSetupDecision] = useState<'run' | 'skip' | null>(null)
@@ -3723,7 +3708,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         undefined,
         undefined,
         undefined,
-        submitCompareBaseRef
+        submitCompareBaseRef,
+        provisionServices && repoHasServiceRecipes ? { provisionServices: true } : undefined
       )
       const worktree = result.worktree
 
@@ -3860,6 +3846,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     shouldWaitForSetupCheck,
     workspaceSeedName,
     isProjectGroupTarget,
+    provisionServices,
+    repoHasServiceRecipes,
     submitFolderTarget
   ])
 

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -4327,6 +4327,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       isProjectGroupTarget,
       submitFolderTarget,
       createMultiple,
+      provisionServices,
+      repoHasServiceRecipes,
       resetForNextCreate
     ]
   )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6195,7 +6195,8 @@
           "da37d6f10e": "Copy",
           "3149964b66": "Copied",
           "waitForSetupBeforeAgent": "Wait for setup to complete before starting agent",
-          "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup."
+          "waitForSetupBeforeAgentHelp": "Turn this on when setup installs dependencies, MCP servers, or config files the agent needs during startup.",
+          "serviceMissingDestroy": "Service \"{{value0}}\" has no destroy command — containers will outlive worktrees."
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "Use {{value0}} repo color",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -267,7 +267,9 @@
           "3b57982bf6": "Git could not safely delete branch \"{{value0}}\" after deleting workspace \"{{value1}}\", so Orca kept it to avoid losing local commits.",
           "81f13f48d2": "Git could not safely delete branch \"{{value0}}\" after deleting worktree \"{{value1}}\", so Orca kept it to avoid losing local commits.",
           "runtimeScopeForbiddenTitle": "This connection has limited (mobile) access",
-          "runtimeScopeForbiddenDescription": "Workspaces are unavailable on a mobile-scope pairing. Reconnect using the browser access link from Settings → Runtime Environments → Share this Orca server."
+          "runtimeScopeForbiddenDescription": "Workspaces are unavailable on a mobile-scope pairing. Reconnect using the browser access link from Settings → Runtime Environments → Share this Orca server.",
+          "serviceDestroyFailed": "Isolated services cleanup failed",
+          "serviceDestroyFailedDescription": "Some services could not be destroyed and may still be running: {{value0}}"
         },
         "repos": {
           "2975400634": "Update Orca server to open non-Git folders on this runtime.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9901,7 +9901,8 @@
             "fc3095d2ed": "explorer",
             "aiVaultSessionHistory": "Agents",
             "folderWorkspaces": "Attached worktrees",
-            "parentPrChecks": "PR Checks"
+            "parentPrChecks": "PR Checks",
+            "isolatedServices": "Services"
           },
           "right": {
             "panel": {
@@ -10306,6 +10307,20 @@
             "workspaceGone": "Couldn't open log — workspace is no longer available.",
             "notAuthorized": "Couldn't open log — path not authorized.",
             "alreadyEditable": "Log is already open for editing."
+          },
+          "ServicesPanel": {
+            "statusReady": "Ready",
+            "statusProvisioning": "Provisioning",
+            "statusCreateFailed": "Create failed",
+            "statusDestroyFailed": "Destroy failed",
+            "emptyState": "No isolated services for this workspace.",
+            "emptyHint": "Declare services in orca.yaml and check \"Isolated services\" when creating a workspace.",
+            "retryFailed": "Retrying services provisioning failed: {{value0}}",
+            "retryProvisioning": "Retry provisioning",
+            "servicesSection": "Services",
+            "slotSection": "Slot & ports",
+            "slotLabel": "Slot {{value0}}",
+            "envSection": "Environment variables"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1245,7 +1245,9 @@
         "noRunTargets": "No run targets are ready for this project.",
         "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe",
         "branchName": "Branch name",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "provisionIsolatedServices": "Isolated services",
+        "provisionIsolatedServicesHint": "Provision this workspace's own services (database, cache) from orca.yaml."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Create worktree",
@@ -4233,7 +4235,9 @@
           "automationCreated": "Created by automation",
           "branchIdentity": "Branch",
           "branchFolderPathIdentity": "Branch or folder path",
-          "ef18787206": "Queued for deletion"
+          "ef18787206": "Queued for deletion",
+          "retryServicesFailed": "Failed to retry services provisioning.",
+          "retryServices": "Retry services provisioning"
         },
         "WorktreeCardAgents": {
           "1b0a156717": "Agents"
@@ -4281,7 +4285,9 @@
           "e888362def": "State: Closed",
           "f394b3e86e": "State: Merged",
           "af2b07bda5": "State: {{value0}}",
-          "29df45afa2": "MR"
+          "29df45afa2": "MR",
+          "servicesFailed": "Services: Failed",
+          "servicesReady": "Services"
         },
         "WorktreeCardPorts": {
           "34f733dda2": "Go to Worktree",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10320,7 +10320,16 @@
             "servicesSection": "Services",
             "slotSection": "Slot & ports",
             "slotLabel": "Slot {{value0}}",
-            "envSection": "Environment variables"
+            "envSection": "Environment variables",
+            "runRunning": "Running",
+            "runStopped": "Stopped",
+            "runUnknown": "No status command",
+            "refreshStatus": "Refresh service status",
+            "startAll": "Start all",
+            "stopAll": "Stop all",
+            "noServices": "No services.",
+            "startService": "Start service",
+            "stopService": "Stop service"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6135,7 +6135,8 @@
           "da37d6f10e": "Copiar",
           "3149964b66": "Copiado",
           "waitForSetupBeforeAgent": "Espera a que se complete la configuración antes de iniciar el agente",
-          "waitForSetupBeforeAgentHelp": "Activa esto cuando la configuración instale dependencias, servidores MCP o archivos de configuración que el agente necesite durante el inicio."
+          "waitForSetupBeforeAgentHelp": "Activa esto cuando la configuración instale dependencias, servidores MCP o archivos de configuración que el agente necesite durante el inicio.",
+          "serviceMissingDestroy": "Service \"{{value0}}\" has no destroy command — containers will outlive worktrees."
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "Usar {{value0}} como color del repositorio",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10297,7 +10297,16 @@
             "servicesSection": "Services",
             "slotSection": "Slot & ports",
             "slotLabel": "Slot {{value0}}",
-            "envSection": "Environment variables"
+            "envSection": "Environment variables",
+            "runRunning": "Running",
+            "runStopped": "Stopped",
+            "runUnknown": "No status command",
+            "refreshStatus": "Refresh service status",
+            "startAll": "Start all",
+            "stopAll": "Stop all",
+            "noServices": "No services.",
+            "startService": "Start service",
+            "stopService": "Stop service"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9878,7 +9878,8 @@
             "fc3095d2ed": "explorador",
             "aiVaultSessionHistory": "Agentes",
             "folderWorkspaces": "Worktrees adjuntos",
-            "parentPrChecks": "Checks de PR"
+            "parentPrChecks": "Checks de PR",
+            "isolatedServices": "Services"
           },
           "right": {
             "panel": {
@@ -10283,6 +10284,20 @@
             "workspaceGone": "Couldn't open log — workspace is no longer available.",
             "notAuthorized": "Couldn't open log — path not authorized.",
             "alreadyEditable": "Log is already open for editing."
+          },
+          "ServicesPanel": {
+            "statusReady": "Ready",
+            "statusProvisioning": "Provisioning",
+            "statusCreateFailed": "Create failed",
+            "statusDestroyFailed": "Destroy failed",
+            "emptyState": "No isolated services for this workspace.",
+            "emptyHint": "Declare services in orca.yaml and check \"Isolated services\" when creating a workspace.",
+            "retryFailed": "Retrying services provisioning failed: {{value0}}",
+            "retryProvisioning": "Retry provisioning",
+            "servicesSection": "Services",
+            "slotSection": "Slot & ports",
+            "slotLabel": "Slot {{value0}}",
+            "envSection": "Environment variables"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -244,7 +244,9 @@
           "3b57982bf6": "Git no pudo eliminar de forma segura la rama \"{{value0}}\" después de eliminar el espacio de trabajo \"{{value1}}\", así que Orca la conservó para evitar perder commits locales.",
           "81f13f48d2": "Git no pudo eliminar de forma segura la rama \"{{value0}}\" después de eliminar el worktree \"{{value1}}\", así que Orca la conservó para evitar perder commits locales.",
           "runtimeScopeForbiddenTitle": "Esta conexión tiene acceso limitado (móvil)",
-          "runtimeScopeForbiddenDescription": "Los espacios de trabajo no están disponibles con un emparejamiento de acceso móvil. Vuelve a conectarte con el enlace del navegador desde Ajustes → Servidores remotos de Orca → Comparte este servidor Orca."
+          "runtimeScopeForbiddenDescription": "Los espacios de trabajo no están disponibles con un emparejamiento de acceso móvil. Vuelve a conectarte con el enlace del navegador desde Ajustes → Servidores remotos de Orca → Comparte este servidor Orca.",
+          "serviceDestroyFailed": "Isolated services cleanup failed",
+          "serviceDestroyFailedDescription": "Some services could not be destroyed and may still be running: {{value0}}"
         },
         "repos": {
           "2975400634": "Actualiza el servidor Orca para abrir carpetas que no sean Git en este host.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1222,7 +1222,9 @@
         "noRunTargets": "No hay destinos de ejecución listos para este proyecto.",
         "perWorkspaceEnvHint": "Provisiona un entorno bajo demanda a partir de una receta",
         "branchName": "Nombre de rama",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "provisionIsolatedServices": "Isolated services",
+        "provisionIsolatedServicesHint": "Provision this workspace's own services (database, cache) from orca.yaml."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Crear worktree",
@@ -4187,7 +4189,9 @@
           "automationCreated": "Creado por automatización",
           "branchIdentity": "Rama",
           "branchFolderPathIdentity": "Rama o ruta de carpeta",
-          "ef18787206": "En cola para eliminación"
+          "ef18787206": "En cola para eliminación",
+          "retryServicesFailed": "Failed to retry services provisioning.",
+          "retryServices": "Retry services provisioning"
         },
         "WorktreeCardAgents": {
           "1b0a156717": "Agents"
@@ -4235,7 +4239,9 @@
           "e888362def": "Estado: Cerrado",
           "f394b3e86e": "Estado: merged",
           "af2b07bda5": "Estado: {{value0}}",
-          "29df45afa2": "MR"
+          "29df45afa2": "MR",
+          "servicesFailed": "Services: Failed",
+          "servicesReady": "Services"
         },
         "WorktreeCardPorts": {
           "34f733dda2": "Ir al worktree",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6157,7 +6157,8 @@
           "da37d6f10e": "コピー",
           "3149964b66": "コピーされました",
           "waitForSetupBeforeAgent": "セットアップが完了するまで待ってから agent を開始してください",
-          "waitForSetupBeforeAgentHelp": "セットアップによって、起動時に agent に必要な依存関係、MCP サーバー、または構成ファイルがインストールされるときに、これをオンにします。"
+          "waitForSetupBeforeAgentHelp": "セットアップによって、起動時に agent に必要な依存関係、MCP サーバー、または構成ファイルがインストールされるときに、これをオンにします。",
+          "serviceMissingDestroy": "Service \"{{value0}}\" has no destroy command — containers will outlive worktrees."
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "{{value0}} repo カラーを使用する",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1222,7 +1222,9 @@
         "noRunTargets": "このプロジェクトには実行ターゲットが準備されていません。",
         "perWorkspaceEnvHint": "レシピからオンデマンド環境をプロビジョニングする",
         "branchName": "ブランチ名",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "provisionIsolatedServices": "Isolated services",
+        "provisionIsolatedServicesHint": "Provision this workspace's own services (database, cache) from orca.yaml."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "ワークツリーを作成する",
@@ -4168,7 +4170,9 @@
           "automationCreated": "自動化により作成",
           "branchIdentity": "ブランチ",
           "branchFolderPathIdentity": "ブランチまたはフォルダパス",
-          "ef18787206": "削除待ち"
+          "ef18787206": "削除待ち",
+          "retryServicesFailed": "Failed to retry services provisioning.",
+          "retryServices": "Retry services provisioning"
         },
         "WorktreeCardAgents": {
           "1b0a156717": "エージェント"
@@ -4216,7 +4220,9 @@
           "e888362def": "状態: クローズ",
           "f394b3e86e": "状態: マージ済み",
           "af2b07bda5": "状態: {{value0}}",
-          "29df45afa2": "MR"
+          "29df45afa2": "MR",
+          "servicesFailed": "Services: Failed",
+          "servicesReady": "Services"
         },
         "WorktreeCardPorts": {
           "34f733dda2": "ワークツリーに移動",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10297,7 +10297,16 @@
             "servicesSection": "Services",
             "slotSection": "Slot & ports",
             "slotLabel": "Slot {{value0}}",
-            "envSection": "Environment variables"
+            "envSection": "Environment variables",
+            "runRunning": "Running",
+            "runStopped": "Stopped",
+            "runUnknown": "No status command",
+            "refreshStatus": "Refresh service status",
+            "startAll": "Start all",
+            "stopAll": "Stop all",
+            "noServices": "No services.",
+            "startService": "Start service",
+            "stopService": "Stop service"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -244,7 +244,9 @@
           "3b57982bf6": "ワークスペース\"{{value1}}\"を削除した後、Git はブランチ\"{{value0}}\"を安全に削除できなかったため、Orca はローカルコミットを失わないように保持しました。",
           "81f13f48d2": "ワークツリー\"{{value1}}\"を削除した後、Git はブランチ\"{{value0}}\"を安全に削除できなかったため、Orca はローカルコミットを失わないように保持しました。",
           "runtimeScopeForbiddenTitle": "この接続は制限付き（モバイル）アクセスです",
-          "runtimeScopeForbiddenDescription": "モバイル範囲のペアリングではワークスペースを使用できません。設定 → リモート Orca サーバー → この Orca サーバーを共有する からブラウザー用リンクで再接続してください。"
+          "runtimeScopeForbiddenDescription": "モバイル範囲のペアリングではワークスペースを使用できません。設定 → リモート Orca サーバー → この Orca サーバーを共有する からブラウザー用リンクで再接続してください。",
+          "serviceDestroyFailed": "Isolated services cleanup failed",
+          "serviceDestroyFailedDescription": "Some services could not be destroyed and may still be running: {{value0}}"
         },
         "repos": {
           "2975400634": "Orca サーバーを更新して、このランタイムで Git 以外のフォルダーを開くようにします。",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9878,7 +9878,8 @@
             "fc3095d2ed": "エクスプローラ",
             "aiVaultSessionHistory": "エージェント",
             "folderWorkspaces": "添付ワークツリー",
-            "parentPrChecks": "PR チェック"
+            "parentPrChecks": "PR チェック",
+            "isolatedServices": "Services"
           },
           "right": {
             "panel": {
@@ -10283,6 +10284,20 @@
             "workspaceGone": "Couldn't open log — workspace is no longer available.",
             "notAuthorized": "Couldn't open log — path not authorized.",
             "alreadyEditable": "Log is already open for editing."
+          },
+          "ServicesPanel": {
+            "statusReady": "Ready",
+            "statusProvisioning": "Provisioning",
+            "statusCreateFailed": "Create failed",
+            "statusDestroyFailed": "Destroy failed",
+            "emptyState": "No isolated services for this workspace.",
+            "emptyHint": "Declare services in orca.yaml and check \"Isolated services\" when creating a workspace.",
+            "retryFailed": "Retrying services provisioning failed: {{value0}}",
+            "retryProvisioning": "Retry provisioning",
+            "servicesSection": "Services",
+            "slotSection": "Slot & ports",
+            "slotLabel": "Slot {{value0}}",
+            "envSection": "Environment variables"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6120,7 +6120,8 @@
           "da37d6f10e": "복사",
           "3149964b66": "복사됨",
           "waitForSetupBeforeAgent": "agent를 시작하기 전에 설정이 완료될 때까지 기다리세요.",
-          "waitForSetupBeforeAgentHelp": "설치 프로그램이 시작 중에 agent에 필요한 종속성, MCP 서버 또는 구성 파일을 설치할 때 이 기능을 켜십시오."
+          "waitForSetupBeforeAgentHelp": "설치 프로그램이 시작 중에 agent에 필요한 종속성, MCP 서버 또는 구성 파일을 설치할 때 이 기능을 켜십시오.",
+          "serviceMissingDestroy": "Service \"{{value0}}\" has no destroy command — containers will outlive worktrees."
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "{{value0}} repo 색상 사용",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10297,7 +10297,16 @@
             "servicesSection": "Services",
             "slotSection": "Slot & ports",
             "slotLabel": "Slot {{value0}}",
-            "envSection": "Environment variables"
+            "envSection": "Environment variables",
+            "runRunning": "Running",
+            "runStopped": "Stopped",
+            "runUnknown": "No status command",
+            "refreshStatus": "Refresh service status",
+            "startAll": "Start all",
+            "stopAll": "Stop all",
+            "noServices": "No services.",
+            "startService": "Start service",
+            "stopService": "Stop service"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -244,7 +244,9 @@
           "3b57982bf6": "\"{{value1}}\" 워크스페이스를 삭제한 후 Git이 \"{{value0}}\" 브랜치를 안전하게 삭제할 수 없어 Orca가 로컬 커밋 손실을 방지하기 위해 유지했습니다.",
           "81f13f48d2": "\"{{value1}}\" 워크트리를 삭제한 후 Git이 \"{{value0}}\" 브랜치를 안전하게 삭제할 수 없어 Orca가 로컬 커밋 손실을 방지하기 위해 유지했습니다.",
           "runtimeScopeForbiddenTitle": "이 연결은 제한된(모바일) 액세스입니다",
-          "runtimeScopeForbiddenDescription": "모바일 범위 페어링에서는 워크스페이스를 사용할 수 없습니다. 설정 → 원격 Orca 서버 → 이 Orca 서버 공유에서 브라우저 액세스 링크로 다시 연결하세요."
+          "runtimeScopeForbiddenDescription": "모바일 범위 페어링에서는 워크스페이스를 사용할 수 없습니다. 설정 → 원격 Orca 서버 → 이 Orca 서버 공유에서 브라우저 액세스 링크로 다시 연결하세요.",
+          "serviceDestroyFailed": "Isolated services cleanup failed",
+          "serviceDestroyFailedDescription": "Some services could not be destroyed and may still be running: {{value0}}"
         },
         "repos": {
           "2975400634": "이 런타임에서 Git이 아닌 폴더를 열려면 Orca 서버를 업데이트하세요.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1222,7 +1222,9 @@
         "noRunTargets": "이 프로젝트에는 실행 대상이 준비되어 있지 않습니다.",
         "perWorkspaceEnvHint": "레시피에서 온디맨드 환경 프로비저닝",
         "branchName": "브랜치 이름",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "provisionIsolatedServices": "Isolated services",
+        "provisionIsolatedServicesHint": "Provision this workspace's own services (database, cache) from orca.yaml."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "작업 트리 만들기",
@@ -4168,7 +4170,9 @@
           "automationCreated": "자동화로 생성됨",
           "branchIdentity": "브랜치",
           "branchFolderPathIdentity": "브랜치 또는 폴더 경로",
-          "ef18787206": "삭제 대기 중"
+          "ef18787206": "삭제 대기 중",
+          "retryServicesFailed": "Failed to retry services provisioning.",
+          "retryServices": "Retry services provisioning"
         },
         "WorktreeCardAgents": {
           "1b0a156717": "에이전트"
@@ -4216,7 +4220,9 @@
           "e888362def": "상태: 폐쇄됨",
           "f394b3e86e": "상태: 병합됨",
           "af2b07bda5": "상태: {{value0}}",
-          "29df45afa2": "MR"
+          "29df45afa2": "MR",
+          "servicesFailed": "Services: Failed",
+          "servicesReady": "Services"
         },
         "WorktreeCardPorts": {
           "34f733dda2": "작업 트리로 이동",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9878,7 +9878,8 @@
             "fc3095d2ed": "탐색기",
             "aiVaultSessionHistory": "에이전트",
             "folderWorkspaces": "연결된 워크트리",
-            "parentPrChecks": "PR 검사"
+            "parentPrChecks": "PR 검사",
+            "isolatedServices": "Services"
           },
           "right": {
             "panel": {
@@ -10283,6 +10284,20 @@
             "workspaceGone": "Couldn't open log — workspace is no longer available.",
             "notAuthorized": "Couldn't open log — path not authorized.",
             "alreadyEditable": "Log is already open for editing."
+          },
+          "ServicesPanel": {
+            "statusReady": "Ready",
+            "statusProvisioning": "Provisioning",
+            "statusCreateFailed": "Create failed",
+            "statusDestroyFailed": "Destroy failed",
+            "emptyState": "No isolated services for this workspace.",
+            "emptyHint": "Declare services in orca.yaml and check \"Isolated services\" when creating a workspace.",
+            "retryFailed": "Retrying services provisioning failed: {{value0}}",
+            "retryProvisioning": "Retry provisioning",
+            "servicesSection": "Services",
+            "slotSection": "Slot & ports",
+            "slotLabel": "Slot {{value0}}",
+            "envSection": "Environment variables"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6120,7 +6120,8 @@
           "da37d6f10e": "复制",
           "3149964b66": "已复制",
           "waitForSetupBeforeAgent": "等待设置完成后再启动智能体",
-          "waitForSetupBeforeAgentHelp": "如果设置会安装依赖、MCP 服务器或智能体启动时需要的配置文件，请开启此选项。"
+          "waitForSetupBeforeAgentHelp": "如果设置会安装依赖、MCP 服务器或智能体启动时需要的配置文件，请开启此选项。",
+          "serviceMissingDestroy": "Service \"{{value0}}\" has no destroy command — containers will outlive worktrees."
         },
         "RepositoryIconPicker": {
           "2b7d27b93c": "使用 {{value0}} 仓库颜色",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10297,7 +10297,16 @@
             "servicesSection": "Services",
             "slotSection": "Slot & ports",
             "slotLabel": "Slot {{value0}}",
-            "envSection": "Environment variables"
+            "envSection": "Environment variables",
+            "runRunning": "Running",
+            "runStopped": "Stopped",
+            "runUnknown": "No status command",
+            "refreshStatus": "Refresh service status",
+            "startAll": "Start all",
+            "stopAll": "Stop all",
+            "noServices": "No services.",
+            "startService": "Start service",
+            "stopService": "Stop service"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9878,7 +9878,8 @@
             "fc3095d2ed": "资源管理器",
             "aiVaultSessionHistory": "智能体",
             "folderWorkspaces": "已附加的工作树",
-            "parentPrChecks": "PR 检查"
+            "parentPrChecks": "PR 检查",
+            "isolatedServices": "Services"
           },
           "right": {
             "panel": {
@@ -10283,6 +10284,20 @@
             "workspaceGone": "无法打开日志 — 工作区已不可用。",
             "notAuthorized": "无法打开日志 — 路径未授权。",
             "alreadyEditable": "日志已处于编辑状态。"
+          },
+          "ServicesPanel": {
+            "statusReady": "Ready",
+            "statusProvisioning": "Provisioning",
+            "statusCreateFailed": "Create failed",
+            "statusDestroyFailed": "Destroy failed",
+            "emptyState": "No isolated services for this workspace.",
+            "emptyHint": "Declare services in orca.yaml and check \"Isolated services\" when creating a workspace.",
+            "retryFailed": "Retrying services provisioning failed: {{value0}}",
+            "retryProvisioning": "Retry provisioning",
+            "servicesSection": "Services",
+            "slotSection": "Slot & ports",
+            "slotLabel": "Slot {{value0}}",
+            "envSection": "Environment variables"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -244,7 +244,9 @@
           "3b57982bf6": "删除工作区\"{{value1}}\"后，Git 无法安全删除分支\"{{value0}}\"，因此 Orca 将其保留以避免丢失本地提交。",
           "81f13f48d2": "删除工作树\"{{value1}}\"后，Git 无法安全删除分支\"{{value0}}\"，因此 Orca 将其保留以避免丢失本地提交。",
           "runtimeScopeForbiddenTitle": "此连接具有受限（移动端）访问权限",
-          "runtimeScopeForbiddenDescription": "移动端范围的配对无法使用工作区。请通过设置 → 远程 Orca 服务器 → 分享此 Orca 服务器中的浏览器访问链接重新连接。"
+          "runtimeScopeForbiddenDescription": "移动端范围的配对无法使用工作区。请通过设置 → 远程 Orca 服务器 → 分享此 Orca 服务器中的浏览器访问链接重新连接。",
+          "serviceDestroyFailed": "Isolated services cleanup failed",
+          "serviceDestroyFailedDescription": "Some services could not be destroyed and may still be running: {{value0}}"
         },
         "repos": {
           "2975400634": "请更新 Orca 服务器，以便在此运行时打开非 Git 文件夹。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1222,7 +1222,9 @@
         "noRunTargets": "此项目还没有可用的运行目标。",
         "perWorkspaceEnvHint": "通过环境模板按需创建环境",
         "branchName": "分支名称",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "provisionIsolatedServices": "Isolated services",
+        "provisionIsolatedServicesHint": "Provision this workspace's own services (database, cache) from orca.yaml."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "创建工作树",
@@ -4168,7 +4170,9 @@
           "automationCreated": "由自动化创建",
           "branchIdentity": "分支",
           "branchFolderPathIdentity": "分支或文件夹路径",
-          "ef18787206": "已排队删除"
+          "ef18787206": "已排队删除",
+          "retryServicesFailed": "Failed to retry services provisioning.",
+          "retryServices": "Retry services provisioning"
         },
         "WorktreeCardAgents": {
           "1b0a156717": "智能体"
@@ -4216,7 +4220,9 @@
           "e888362def": "状态： 关闭",
           "f394b3e86e": "状态：合并",
           "af2b07bda5": "州：{{value0}}",
-          "29df45afa2": "MR"
+          "29df45afa2": "MR",
+          "servicesFailed": "Services: Failed",
+          "servicesReady": "Services"
         },
         "WorktreeCardPorts": {
           "34f733dda2": "转到工作树",

--- a/src/renderer/src/lib/background-pane-env.ts
+++ b/src/renderer/src/lib/background-pane-env.ts
@@ -1,0 +1,20 @@
+import { getWorktreeServiceEnv } from '@/lib/worktree-service-env-injection'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+
+// Why: background tabs never mount a TerminalPane, so the pane-identity env
+// (and the worktree's isolated-service env) must be injected at spawn time.
+// Shared by the background terminal and background agent-session launchers.
+export function buildBackgroundPaneEnv(
+  worktreeId: string,
+  tabId: string,
+  leafId: string,
+  env: Record<string, string> | undefined
+): Record<string, string> {
+  return {
+    ...env,
+    ...getWorktreeServiceEnv(worktreeId),
+    ORCA_PANE_KEY: makePaneKey(tabId, leafId),
+    ORCA_TAB_ID: tabId,
+    ORCA_WORKTREE_ID: worktreeId
+  }
+}

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -25,7 +25,7 @@ import {
 import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
-import { getWorktreeServiceEnv } from '@/lib/worktree-service-env-injection'
+import { buildBackgroundPaneEnv } from '@/lib/background-pane-env'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { retireProvider, retireUnownedTerminal } from '@/lib/retire-unowned-background-terminal'
@@ -127,11 +127,7 @@ export async function launchAgentBackgroundSession(
   // in-terminal title row, so background sessions must not persist it there.
   store.setTabLayout(tab.id, singlePaneLayoutSnapshot(leafId))
   const paneEnv = {
-    ...startupPlan.env,
-    ...getWorktreeServiceEnv(worktreeId),
-    ORCA_PANE_KEY: paneKey,
-    ORCA_TAB_ID: tab.id,
-    ORCA_WORKTREE_ID: worktreeId,
+    ...buildBackgroundPaneEnv(worktreeId, tab.id, leafId, startupPlan.env),
     ORCA_AGENT_LAUNCH_TOKEN: launchToken
   }
   const sshConnectionId = repo?.connectionId ?? null

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -25,6 +25,7 @@ import {
 import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
+import { getWorktreeServiceEnv } from '@/lib/worktree-service-env-injection'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { retireProvider, retireUnownedTerminal } from '@/lib/retire-unowned-background-terminal'
@@ -127,6 +128,7 @@ export async function launchAgentBackgroundSession(
   store.setTabLayout(tab.id, singlePaneLayoutSnapshot(leafId))
   const paneEnv = {
     ...startupPlan.env,
+    ...getWorktreeServiceEnv(worktreeId),
     ORCA_PANE_KEY: paneKey,
     ORCA_TAB_ID: tab.id,
     ORCA_WORKTREE_ID: worktreeId,

--- a/src/renderer/src/lib/launch-worktree-background-terminals.ts
+++ b/src/renderer/src/lib/launch-worktree-background-terminals.ts
@@ -3,15 +3,14 @@ import {
   type EagerPtyHandle
 } from '@/components/terminal-pane/pty-dispatcher'
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import { buildBackgroundPaneEnv } from '@/lib/background-pane-env'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
-import { getWorktreeServiceEnv } from '@/lib/worktree-service-env-injection'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { retireUnownedTerminal } from '@/lib/retire-unowned-background-terminal'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { isWindowsAbsolutePathLike } from '../../../shared/cross-platform-path'
-import { makePaneKey } from '../../../shared/stable-pane-id'
 import { buildSetupRunnerCommand } from '../../../shared/setup-runner-command'
 import type {
   TerminalLayoutSnapshot,
@@ -45,21 +44,6 @@ export type LaunchWorktreeBackgroundTerminalsArgs = {
   worktreeId: string
   setup?: WorktreeSetupLaunch
   defaultTabs?: WorktreeDefaultTabsLaunch
-}
-
-function buildPaneEnv(
-  worktreeId: string,
-  tabId: string,
-  leafId: string,
-  env: Record<string, string> | undefined
-): Record<string, string> {
-  return {
-    ...env,
-    ...getWorktreeServiceEnv(worktreeId),
-    ORCA_PANE_KEY: makePaneKey(tabId, leafId),
-    ORCA_TAB_ID: tabId,
-    ORCA_WORKTREE_ID: worktreeId
-  }
 }
 
 function buildSplitLayout(
@@ -141,7 +125,7 @@ async function spawnPane(args: {
     rows: 40,
     cwd: args.worktree.path,
     ...(args.command ? { command: args.command } : {}),
-    env: buildPaneEnv(args.worktree.id, args.tabId, args.leafId, args.env),
+    env: buildBackgroundPaneEnv(args.worktree.id, args.tabId, args.leafId, args.env),
     connectionId: args.connectionId,
     worktreeId: args.worktree.id,
     tabId: args.tabId,

--- a/src/renderer/src/lib/launch-worktree-background-terminals.ts
+++ b/src/renderer/src/lib/launch-worktree-background-terminals.ts
@@ -4,6 +4,7 @@ import {
 } from '@/components/terminal-pane/pty-dispatcher'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
+import { getWorktreeServiceEnv } from '@/lib/worktree-service-env-injection'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { retireUnownedTerminal } from '@/lib/retire-unowned-background-terminal'
@@ -54,6 +55,7 @@ function buildPaneEnv(
 ): Record<string, string> {
   return {
     ...env,
+    ...getWorktreeServiceEnv(worktreeId),
     ORCA_PANE_KEY: makePaneKey(tabId, leafId),
     ORCA_TAB_ID: tabId,
     ORCA_WORKTREE_ID: worktreeId

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -16,7 +16,12 @@ import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/tas
  *  `fetching` covers the base-ref git fetch; `creating` covers `git worktree
  *  add`. Remote/runtime creates may skip git phases; VM recipes add a
  *  provider-provisioning phase before the runtime worktree exists. */
-export type WorktreeCreationPhase = 'preparing' | 'provisioning-vm' | 'fetching' | 'creating'
+export type WorktreeCreationPhase =
+  | 'preparing'
+  | 'provisioning-vm'
+  | 'provisioning-services'
+  | 'fetching'
+  | 'creating'
 
 export type WorktreeCreationProgressMode = 'stepped' | 'indeterminate'
 
@@ -91,6 +96,8 @@ export type WorktreeCreationRequest = {
   /** When the composer stays open for sequential creates, completion must not
    *  steal focus from the next workspace name field. */
   suppressTerminalFocusOnCompletion?: boolean
+  /** Opt-in to provisioning isolated per-worktree services from orca.yaml. */
+  provisionServices?: boolean
 }
 
 /** Renderer-only, session-ephemeral record of an in-flight (or failed) worktree
@@ -125,6 +132,9 @@ export function getCreationProgressLabel(
 ): string {
   if (entry.phase === 'provisioning-vm') {
     return 'Provisioning VM…'
+  }
+  if (entry.phase === 'provisioning-services') {
+    return 'Provisioning services…'
   }
   if (entry.indeterminate) {
     return 'Setting up your workspace…'

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -4,9 +4,9 @@ import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import {
   activateAndRevealWorktree,
   ensureWorktreeHasInitialTerminal,
-  type ActivateAndRevealResult,
-  type WorktreeStartupPayload
+  type ActivateAndRevealResult
 } from '@/lib/worktree-activation'
+import { buildStartupOpt } from '@/lib/worktree-startup-payload'
 import { ensureAgentStartupInTerminal } from '@/lib/new-workspace'
 import { queueNewWorkspaceTerminalFocus } from '@/lib/new-workspace-terminal-focus'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
@@ -25,6 +25,10 @@ import type {
   WorktreeCreationRequest
 } from '@/lib/pending-worktree-creation'
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import {
+  hydrateServicesAfterCreate,
+  subscribeServiceProvisionEvents
+} from '@/lib/worktree-service-provisioning-flow'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 
 type ContinueBackgroundWorktreeCreationOptions = {
@@ -33,31 +37,6 @@ type ContinueBackgroundWorktreeCreationOptions = {
 
 // Why: mirrors the startup-opt the composer used to build inline. The renderer
 // only seeds the first terminal when the backend did not already spawn it.
-function buildStartupOpt(
-  request: WorktreeCreationRequest,
-  backendSpawned: boolean
-): WorktreeStartupPayload | undefined {
-  const plan = request.startupPlan
-  if (!plan || backendSpawned) {
-    return undefined
-  }
-  return {
-    command: plan.launchCommand,
-    ...(plan.env ? { env: plan.env } : {}),
-    launchConfig: plan.launchConfig,
-    ...(plan.launchToken ? { launchToken: plan.launchToken } : {}),
-    ...(request.agent ? { launchAgent: request.agent } : {}),
-    ...(plan.draftPrompt ? { draftPrompt: plan.draftPrompt } : {}),
-    ...(plan.startupCommandDelivery ? { startupCommandDelivery: plan.startupCommandDelivery } : {}),
-    // Why: command-code shows its prompt in the tab status before the first
-    // hook fires, so the prompt is threaded through here.
-    ...(request.agent === 'command-code' && request.quickPrompt.trim().length > 0
-      ? { initialAgentStatus: { agent: request.agent, prompt: request.quickPrompt.trim() } }
-      : {}),
-    ...(request.quickTelemetry ? { telemetry: request.quickTelemetry } : {})
-  }
-}
-
 function getWorktreeCreationIndeterminate(request: WorktreeCreationRequest): boolean {
   if (request.worktreeCreateProgressMode) {
     return request.worktreeCreateProgressMode === 'indeterminate'
@@ -136,23 +115,8 @@ async function executeWorktreeCreation(
     return
   }
 
-  // Why: stream service provisioning output onto the same pending-creation
-  // surface as git progress, correlated by creationId (== serviceProvisionId).
   const unsubscribeServiceEvents = preparedRequest.provisionServices
-    ? window.api.worktreeServices.onProvisionEvent?.((event) => {
-        if (event.provisionId !== creationId) {
-          return
-        }
-        const store = useAppStore.getState()
-        const pending = store.pendingWorktreeCreations[creationId]
-        if (!pending) {
-          return
-        }
-        store.updatePendingWorktreeCreation(creationId, {
-          phase: 'provisioning-services',
-          provisioningLog: ((pending.provisioningLog ?? '') + event.chunk).slice(-12_000)
-        })
-      })
+    ? subscribeServiceProvisionEvents(creationId)
     : undefined
 
   let result: CreateWorktreeResult
@@ -221,15 +185,8 @@ async function executeWorktreeCreation(
   if (!useAppStore.getState().pendingWorktreeCreations[creationId]) {
     return
   }
-  // Why: refresh the worktreeId→env map so the new worktree's terminals get
-  // their service env, and the sidebar badge reflects provisioning status.
   if (preparedRequest.provisionServices) {
-    // Why: hydration failure must not derail the rest of post-create wiring
-    // (terminals, agent startup) for a worktree that was created successfully.
-    await useAppStore
-      .getState()
-      .hydrateWorktreeServices()
-      .catch(() => {})
+    await hydrateServicesAfterCreate()
   }
   await attachEphemeralVmRuntimeToWorkspace(preparedRequest, worktree.id)
 

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -224,7 +224,12 @@ async function executeWorktreeCreation(
   // Why: refresh the worktreeId→env map so the new worktree's terminals get
   // their service env, and the sidebar badge reflects provisioning status.
   if (preparedRequest.provisionServices) {
-    await useAppStore.getState().hydrateWorktreeServices()
+    // Why: hydration failure must not derail the rest of post-create wiring
+    // (terminals, agent startup) for a worktree that was created successfully.
+    await useAppStore
+      .getState()
+      .hydrateWorktreeServices()
+      .catch(() => {})
   }
   await attachEphemeralVmRuntimeToWorkspace(preparedRequest, worktree.id)
 

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -188,6 +188,12 @@ async function executeWorktreeCreation(
   if (preparedRequest.provisionServices) {
     await hydrateServicesAfterCreate()
   }
+  const serviceInitializationBlocked = Boolean(result.serviceProvisioningError)
+  if (result.serviceProvisioningError) {
+    // Why: the worktree exists and remains usable for retry, but automatic
+    // commands were withheld so they cannot fall back to shared services.
+    toast.error(result.serviceProvisioningError.slice(0, 300))
+  }
   await attachEphemeralVmRuntimeToWorkspace(preparedRequest, worktree.id)
 
   const backendSpawned = result.startupTerminal?.spawned === true
@@ -196,7 +202,9 @@ async function executeWorktreeCreation(
     // startup, so both halves of the handoff share one renderer-session token.
     preparedRequest.startupPlan.launchToken = createBrowserUuid()
   }
-  const startupOpt = buildStartupOpt(preparedRequest, backendSpawned)
+  const startupOpt = serviceInitializationBlocked
+    ? undefined
+    : buildStartupOpt(preparedRequest, backendSpawned)
 
   if (worktree.path) {
     const repoConnectionId =
@@ -244,7 +252,7 @@ async function executeWorktreeCreation(
   // Why: clearing synchronously right after activation lets React commit the
   // panel→terminal swap in one frame — no two-row flicker, no empty-terminal flash.
   useAppStore.getState().removePendingWorktreeCreation(creationId, { cleanupVm: false })
-  if (preparedRequest.startupPlan && preparedRequest.agent) {
+  if (!serviceInitializationBlocked && preparedRequest.startupPlan && preparedRequest.agent) {
     const optionScopeKey = primaryTabId ?? result.startupTerminal?.tabId
     if (optionScopeKey) {
       seedNativeChatAppliedSessionOptions(
@@ -254,7 +262,7 @@ async function executeWorktreeCreation(
       )
     }
   }
-  if (preparedRequest.startupPlan && !backendSpawned) {
+  if (preparedRequest.startupPlan && !backendSpawned && !serviceInitializationBlocked) {
     void ensureAgentStartupInTerminal({
       worktreeId: worktree.id,
       primaryTabId,

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -136,6 +136,25 @@ async function executeWorktreeCreation(
     return
   }
 
+  // Why: stream service provisioning output onto the same pending-creation
+  // surface as git progress, correlated by creationId (== serviceProvisionId).
+  const unsubscribeServiceEvents = preparedRequest.provisionServices
+    ? window.api.worktreeServices.onProvisionEvent?.((event) => {
+        if (event.provisionId !== creationId) {
+          return
+        }
+        const store = useAppStore.getState()
+        const pending = store.pendingWorktreeCreations[creationId]
+        if (!pending) {
+          return
+        }
+        store.updatePendingWorktreeCreation(creationId, {
+          phase: 'provisioning-services',
+          provisioningLog: ((pending.provisioningLog ?? '') + event.chunk).slice(-12_000)
+        })
+      })
+    : undefined
+
   let result: CreateWorktreeResult
   try {
     result = await useAppStore
@@ -165,7 +184,8 @@ async function executeWorktreeCreation(
         preparedRequest.linkedBitbucketPR,
         preparedRequest.linkedAzureDevOpsPR,
         preparedRequest.linkedGiteaPR,
-        preparedRequest.compareBaseRef
+        preparedRequest.compareBaseRef,
+        { provisionServices: preparedRequest.provisionServices }
       )
   } catch (error) {
     // Why: a missing entry means the user cancelled mid-flight — abandon
@@ -188,6 +208,8 @@ async function executeWorktreeCreation(
       toast.error(message)
     }
     return
+  } finally {
+    unsubscribeServiceEvents?.()
   }
 
   const worktree = result.worktree
@@ -198,6 +220,11 @@ async function executeWorktreeCreation(
   // via worktrees:changed and provisions lazily on first open.
   if (!useAppStore.getState().pendingWorktreeCreations[creationId]) {
     return
+  }
+  // Why: refresh the worktreeId→env map so the new worktree's terminals get
+  // their service env, and the sidebar badge reflects provisioning status.
+  if (preparedRequest.provisionServices) {
+    await useAppStore.getState().hydrateWorktreeServices()
   }
   await attachEphemeralVmRuntimeToWorkspace(preparedRequest, worktree.id)
 

--- a/src/renderer/src/lib/worktree-service-env-injection.test.ts
+++ b/src/renderer/src/lib/worktree-service-env-injection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const state = {
+  worktreeServicesEnv: {
+    'wt-1': { DATABASE_URL: 'pg://localhost:20000/app', ORCA_PORT_0: '20000' }
+  } as Record<string, Record<string, string>>
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => state }
+}))
+
+import { getWorktreeServiceEnv } from './worktree-service-env-injection'
+
+describe('getWorktreeServiceEnv', () => {
+  it('returns the env for a known worktree id', () => {
+    expect(getWorktreeServiceEnv('wt-1')).toEqual({
+      DATABASE_URL: 'pg://localhost:20000/app',
+      ORCA_PORT_0: '20000'
+    })
+  })
+
+  it('returns {} for an unknown worktree id', () => {
+    expect(getWorktreeServiceEnv('wt-nope')).toEqual({})
+  })
+
+  it('returns {} for an undefined worktree id', () => {
+    expect(getWorktreeServiceEnv(undefined)).toEqual({})
+  })
+})

--- a/src/renderer/src/lib/worktree-service-env-injection.ts
+++ b/src/renderer/src/lib/worktree-service-env-injection.ts
@@ -1,0 +1,8 @@
+import { useAppStore } from '@/store'
+
+export function getWorktreeServiceEnv(worktreeId: string | undefined): Record<string, string> {
+  if (!worktreeId) {
+    return {}
+  }
+  return useAppStore.getState().worktreeServicesEnv?.[worktreeId] ?? {}
+}

--- a/src/renderer/src/lib/worktree-service-provisioning-flow.ts
+++ b/src/renderer/src/lib/worktree-service-provisioning-flow.ts
@@ -1,0 +1,31 @@
+import { useAppStore } from '@/store'
+
+// Why: stream service provisioning output onto the same pending-creation
+// surface as git progress, correlated by creationId (== serviceProvisionId).
+export function subscribeServiceProvisionEvents(creationId: string): (() => void) | undefined {
+  return window.api.worktreeServices.onProvisionEvent?.((event) => {
+    if (event.provisionId !== creationId) {
+      return
+    }
+    const store = useAppStore.getState()
+    const pending = store.pendingWorktreeCreations[creationId]
+    if (!pending) {
+      return
+    }
+    store.updatePendingWorktreeCreation(creationId, {
+      phase: 'provisioning-services',
+      provisioningLog: ((pending.provisioningLog ?? '') + event.chunk).slice(-12_000)
+    })
+  })
+}
+
+// Why: refresh the worktreeId→env map so the new worktree's terminals get
+// their service env and the sidebar badge reflects provisioning status.
+// Hydration failure must not derail the rest of post-create wiring
+// (terminals, agent startup) for a worktree that was created successfully.
+export async function hydrateServicesAfterCreate(): Promise<void> {
+  await useAppStore
+    .getState()
+    .hydrateWorktreeServices()
+    .catch(() => {})
+}

--- a/src/renderer/src/lib/worktree-startup-payload.ts
+++ b/src/renderer/src/lib/worktree-startup-payload.ts
@@ -1,0 +1,30 @@
+import type { WorktreeStartupPayload } from '@/lib/worktree-activation'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+
+// Why: when the backend already spawned the startup terminal, sending a second
+// startup payload would double-launch the agent; the payload only exists for
+// the renderer-driven fallback.
+export function buildStartupOpt(
+  request: WorktreeCreationRequest,
+  backendSpawned: boolean
+): WorktreeStartupPayload | undefined {
+  const plan = request.startupPlan
+  if (!plan || backendSpawned) {
+    return undefined
+  }
+  return {
+    command: plan.launchCommand,
+    ...(plan.env ? { env: plan.env } : {}),
+    launchConfig: plan.launchConfig,
+    ...(plan.launchToken ? { launchToken: plan.launchToken } : {}),
+    ...(request.agent ? { launchAgent: request.agent } : {}),
+    ...(plan.draftPrompt ? { draftPrompt: plan.draftPrompt } : {}),
+    ...(plan.startupCommandDelivery ? { startupCommandDelivery: plan.startupCommandDelivery } : {}),
+    // Why: command-code shows its prompt in the tab status before the first
+    // hook fires, so the prompt is threaded through here.
+    ...(request.agent === 'command-code' && request.quickPrompt.trim().length > 0
+      ? { initialAgentStatus: { agent: request.agent, prompt: request.quickPrompt.trim() } }
+      : {}),
+    ...(request.quickTelemetry ? { telemetry: request.quickTelemetry } : {})
+  }
+}

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -24,7 +24,8 @@ export function normalizeRightSidebarRoute(
     tab === 'pr-checks' ||
     tab === 'source-control' ||
     tab === 'checks' ||
-    tab === 'ports'
+    tab === 'ports' ||
+    tab === 'services'
   ) {
     return {
       rightSidebarTab: tab,

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -28,7 +28,10 @@ import type {
 } from '@/lib/pending-worktree-creation'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 export { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
-import type { WorktreeServicesStatus } from '../../../../shared/worktree-services'
+import type {
+  WorktreeServicesRecord,
+  WorktreeServicesStatus
+} from '../../../../shared/worktree-services'
 
 export type WorktreeDeleteState = {
   isDeleting: boolean
@@ -121,6 +124,8 @@ export type WorktreeSlice = {
   worktreeServicesEnv: Record<string, Record<string, string>>
   // Provisioning status per worktree, drives the sidebar badge and retry action.
   worktreeServicesStatus: Record<string, WorktreeServicesStatus>
+  // Full provisioning record per worktree, drives the Services right-sidebar panel.
+  worktreeServicesRecords: Record<string, WorktreeServicesRecord>
   hydrateWorktreeServices: () => Promise<void>
   fetchDetectedWorktrees: (repoId: string) => Promise<DetectedWorktreeListResult | null>
   fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<boolean>

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -28,6 +28,7 @@ import type {
 } from '@/lib/pending-worktree-creation'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 export { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import type { WorktreeServicesStatus } from '../../../../shared/worktree-services'
 
 export type WorktreeDeleteState = {
   isDeleting: boolean
@@ -116,6 +117,11 @@ export type WorktreeSlice = {
    * sessions (design §4.4). Session-only; never persisted.
    */
   hasHydratedWorktreePurge: boolean
+  // Resolved per-worktree service env (ready records only), merged into every PTY spawn.
+  worktreeServicesEnv: Record<string, Record<string, string>>
+  // Provisioning status per worktree, drives the sidebar badge and retry action.
+  worktreeServicesStatus: Record<string, WorktreeServicesStatus>
+  hydrateWorktreeServices: () => Promise<void>
   fetchDetectedWorktrees: (repoId: string) => Promise<DetectedWorktreeListResult | null>
   fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<boolean>
   fetchAllWorktrees: (options?: { hydrationPurge?: 'allow' | 'defer' }) => Promise<void>

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -164,7 +164,11 @@ export type WorktreeSlice = {
     compareBaseRef?: string,
     // Why: reserved for automation-dispatch flows so host-side provenance can
     // be minted securely; regular create callers should omit this.
-    options?: { automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest'] }
+    options?: {
+      automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
+      /** Opt-in to provisioning isolated per-worktree services from orca.yaml. */
+      provisionServices?: boolean
+    }
   ) => Promise<CreateWorktreeResult>
   /** Register an in-flight background creation and make it the active surface. */
   beginPendingWorktreeCreation: (entry: PendingWorktreeCreation) => void

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -126,7 +126,8 @@ export type WorktreeSlice = {
   worktreeServicesStatus: Record<string, WorktreeServicesStatus>
   // Full provisioning record per worktree, drives the Services right-sidebar panel.
   worktreeServicesRecords: Record<string, WorktreeServicesRecord>
-  hydrateWorktreeServices: () => Promise<void>
+  hasHydratedWorktreeServices: boolean
+  hydrateWorktreeServices: (options?: { ifNeeded?: boolean }) => Promise<void>
   fetchDetectedWorktrees: (repoId: string) => Promise<DetectedWorktreeListResult | null>
   fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<boolean>
   fetchAllWorktrees: (options?: { hydrationPurge?: 'allow' | 'defer' }) => Promise<void>

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -14,6 +14,7 @@ import type {
   WorktreeLineage,
   WorkspaceLineage
 } from '../../../../shared/types'
+import type { WorktreeServicesRecord } from '../../../../shared/worktree-services'
 import { toast } from 'sonner'
 import {
   createCompatibleRuntimeStatusResponseIfNeeded,
@@ -90,6 +91,9 @@ const mockApi = {
     cancelProvision: vi.fn().mockResolvedValue({ cancelled: true }),
     cleanup: vi.fn().mockResolvedValue({}),
     listRuntimes: vi.fn().mockResolvedValue([])
+  },
+  worktreeServices: {
+    list: vi.fn().mockResolvedValue([])
   }
 }
 
@@ -274,6 +278,80 @@ function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWo
     workspaceStatus: overrides.workspaceStatus ?? 'active'
   }
 }
+
+describe('worktree services hydration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.worktreeServices.list.mockResolvedValue([])
+  })
+
+  it('coalesces boot hydration and skips later unrelated refresh reads', async () => {
+    const store = createTestStore()
+    await Promise.all([
+      store.getState().hydrateWorktreeServices({ ifNeeded: true }),
+      store.getState().hydrateWorktreeServices({ ifNeeded: true })
+    ])
+    await store.getState().hydrateWorktreeServices({ ifNeeded: true })
+    expect(mockApi.worktreeServices.list).toHaveBeenCalledTimes(1)
+
+    await store.getState().hydrateWorktreeServices()
+    expect(mockApi.worktreeServices.list).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let stale boot hydration erase a newer provisioning refresh', async () => {
+    const store = createTestStore()
+    let resolveBoot!: (records: WorktreeServicesRecord[]) => void
+    const bootRecords = new Promise<WorktreeServicesRecord[]>((resolve) => {
+      resolveBoot = resolve
+    })
+    mockApi.worktreeServices.list.mockReturnValueOnce(bootRecords).mockResolvedValueOnce([
+      {
+        worktreeId: 'repo::/worktree',
+        repoId: 'repo',
+        slot: 0,
+        slug: 'worktree-s0',
+        serviceIds: ['db'],
+        env: { DATABASE_URL: 'isolated' },
+        status: 'ready',
+        createdAt: '2026-07-17T00:00:00.000Z',
+        updatedAt: '2026-07-17T00:00:00.000Z'
+      }
+    ])
+
+    const boot = store.getState().hydrateWorktreeServices({ ifNeeded: true })
+    await store.getState().hydrateWorktreeServices()
+    resolveBoot([])
+    await boot
+
+    expect(store.getState().worktreeServicesEnv['repo::/worktree']).toEqual({
+      DATABASE_URL: 'isolated'
+    })
+  })
+
+  it('holds startup worktree refresh until service env hydration settles', async () => {
+    const store = createTestStore()
+    let resolveRecords!: (records: WorktreeServicesRecord[]) => void
+    mockApi.worktreeServices.list.mockReturnValueOnce(
+      new Promise<WorktreeServicesRecord[]>((resolve) => {
+        resolveRecords = resolve
+      })
+    )
+
+    let refreshSettled = false
+    const refresh = store
+      .getState()
+      .fetchAllWorktrees({ hydrationPurge: 'defer' })
+      .finally(() => {
+        refreshSettled = true
+      })
+    await Promise.resolve()
+    expect(refreshSettled).toBe(false)
+
+    resolveRecords([])
+    await refresh
+    expect(refreshSettled).toBe(true)
+  })
+})
 
 describe('folder workspace lookups', () => {
   it('returns a stable synthetic worktree for repeated folder workspace lookups', () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -3090,7 +3090,16 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ...(linkedGiteaPR !== undefined ? { linkedGiteaPR } : {}),
             ...(startup ? { startup } : {}),
             ...(creationId ? { creationId } : {}),
-            ...(automationProvenanceRequest ? { automationProvenanceRequest } : {})
+            ...(automationProvenanceRequest ? { automationProvenanceRequest } : {}),
+            // Why: services are provisioned only on the local create path (v1
+            // excludes remote); serviceProvisionId reuses creationId so the
+            // renderer can correlate streamed provision events to this create.
+            ...(options?.provisionServices
+              ? {
+                  provisionServices: true,
+                  ...(creationId ? { serviceProvisionId: creationId } : {})
+                }
+              : {})
           }
           const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId))
           const result =

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -19,7 +19,10 @@ import type {
   WorktreeMeta
 } from '../../../../shared/types'
 import type { RuntimeWorktreeListResult } from '../../../../shared/runtime-types'
-import type { WorktreeServicesStatus } from '../../../../shared/worktree-services'
+import type {
+  WorktreeServicesRecord,
+  WorktreeServicesStatus
+} from '../../../../shared/worktree-services'
 import {
   findWorktreeById,
   applyWorktreeUpdates,
@@ -2308,18 +2311,21 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   hasHydratedWorktreePurge: false,
   worktreeServicesEnv: {},
   worktreeServicesStatus: {},
+  worktreeServicesRecords: {},
 
   hydrateWorktreeServices: async () => {
     const records = await window.api.worktreeServices.list()
     const worktreeServicesEnv: Record<string, Record<string, string>> = {}
     const worktreeServicesStatus: Record<string, WorktreeServicesStatus> = {}
+    const worktreeServicesRecords: Record<string, WorktreeServicesRecord> = {}
     for (const record of records) {
       worktreeServicesStatus[record.worktreeId] = record.status
+      worktreeServicesRecords[record.worktreeId] = record
       if (record.status === 'ready') {
         worktreeServicesEnv[record.worktreeId] = record.env
       }
     }
-    set({ worktreeServicesEnv, worktreeServicesStatus })
+    set({ worktreeServicesEnv, worktreeServicesStatus, worktreeServicesRecords })
   },
 
   fetchDetectedWorktrees: async (repoId) => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2199,6 +2199,12 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     deleteStateByWorktreeId: omitByWorktree(s.deleteStateByWorktreeId),
     baseStatusByWorktreeId: omitByWorktree(s.baseStatusByWorktreeId),
     remoteBranchConflictByWorktreeId: omitByWorktree(s.remoteBranchConflictByWorktreeId),
+    // Why: mirror the single-worktree removal cleanup on this bulk reconcile path
+    // (external removal / authoritative-scan purge). Without it a same-path
+    // recreate could inject the deleted worktree's stale isolated-service env.
+    worktreeServicesEnv: omitByWorktree(s.worktreeServicesEnv),
+    worktreeServicesStatus: omitByWorktree(s.worktreeServicesStatus),
+    worktreeServicesRecords: omitByWorktree(s.worktreeServicesRecords),
     // File search
     fileSearchStateByWorktree: omitByWorktree(s.fileSearchStateByWorktree),
     // Browser state
@@ -3686,6 +3692,25 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           })(),
           defaultTerminalTabsAppliedByWorktreeId: (() => {
             const next = { ...s.defaultTerminalTabsAppliedByWorktreeId }
+            delete next[worktreeId]
+            return next
+          })(),
+          // Why: worktree IDs are path-derived and can be reused by a same-name
+          // recreate. Drop this worktree's service env/status/record so a new
+          // worktree at the same path never inherits stale isolated-service env
+          // (injected into every PTY) or a phantom badge/panel from the deleted one.
+          worktreeServicesEnv: (() => {
+            const next = { ...s.worktreeServicesEnv }
+            delete next[worktreeId]
+            return next
+          })(),
+          worktreeServicesStatus: (() => {
+            const next = { ...s.worktreeServicesStatus }
+            delete next[worktreeId]
+            return next
+          })(),
+          worktreeServicesRecords: (() => {
+            const next = { ...s.worktreeServicesRecords }
             delete next[worktreeId]
             return next
           })(),

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -19,6 +19,7 @@ import type {
   WorktreeMeta
 } from '../../../../shared/types'
 import type { RuntimeWorktreeListResult } from '../../../../shared/runtime-types'
+import type { WorktreeServicesStatus } from '../../../../shared/worktree-services'
 import {
   findWorktreeById,
   applyWorktreeUpdates,
@@ -2305,6 +2306,21 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   everActivatedWorktreeIds: new Set<string>(),
   lastVisitedAtByWorktreeId: {},
   hasHydratedWorktreePurge: false,
+  worktreeServicesEnv: {},
+  worktreeServicesStatus: {},
+
+  hydrateWorktreeServices: async () => {
+    const records = await window.api.worktreeServices.list()
+    const worktreeServicesEnv: Record<string, Record<string, string>> = {}
+    const worktreeServicesStatus: Record<string, WorktreeServicesStatus> = {}
+    for (const record of records) {
+      worktreeServicesStatus[record.worktreeId] = record.status
+      if (record.status === 'ready') {
+        worktreeServicesEnv[record.worktreeId] = record.env
+      }
+    }
+    set({ worktreeServicesEnv, worktreeServicesStatus })
+  },
 
   fetchDetectedWorktrees: async (repoId) => {
     try {
@@ -2502,6 +2518,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   fetchAllWorktrees: async (options) => {
     const { repos } = get()
+
+    // Why: hydrate per-worktree service env/status alongside the boot worktree
+    // refresh so PTY spawns and the sidebar badge see ready services. Idempotent.
+    void get().hydrateWorktreeServices()
 
     // Why: once the one-shot hydration-time purge has fired, subsequent
     // calls just need to refresh each repo's cached list. No need to

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -3386,6 +3386,22 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // an old toast cannot mutate a same-path replacement during UI teardown.
       forgetHugeRepoWarningDismissalsForWorktrees([worktreeId])
 
+      if (removalResult?.serviceDestroyErrors?.length) {
+        toast.warning(
+          translate(
+            'auto.store.slices.worktrees.serviceDestroyFailed',
+            'Isolated services cleanup failed'
+          ),
+          {
+            description: translate(
+              'auto.store.slices.worktrees.serviceDestroyFailedDescription',
+              'Some services could not be destroyed and may still be running: {{value0}}',
+              { value0: removalResult.serviceDestroyErrors.join('; ').slice(0, 300) }
+            )
+          }
+        )
+      }
+
       const worktreeDisplayName = worktreeBeforeRemoval?.displayName?.trim()
       if (worktreeDisplayName) {
         try {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2521,7 +2521,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
     // Why: hydrate per-worktree service env/status alongside the boot worktree
     // refresh so PTY spawns and the sidebar badge see ready services. Idempotent.
-    void get().hydrateWorktreeServices()
+    // Best-effort — a failed IPC round-trip here must never block worktree refresh.
+    void get()
+      .hydrateWorktreeServices()
+      .catch(() => {})
 
     // Why: once the one-shot hydration-time purge has fired, subsequent
     // calls just need to refresh each repo's cached list. No need to

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -112,6 +112,8 @@ const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
 const hostedReviewPushTargetLookupsInFlight = new Set<string>()
 const detectedWorktreeRefreshesInFlight = new Map<string, Promise<DetectedWorktreeListResult>>()
+let worktreeServicesHydrationRequestId = 0
+let initialWorktreeServicesHydration: Promise<void> | null = null
 
 type BackgroundRuntimeRefreshOptions = {
   reuseRecentCompatibilityFailure?: boolean
@@ -2318,20 +2320,52 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   worktreeServicesEnv: {},
   worktreeServicesStatus: {},
   worktreeServicesRecords: {},
+  hasHydratedWorktreeServices: false,
 
-  hydrateWorktreeServices: async () => {
-    const records = await window.api.worktreeServices.list()
-    const worktreeServicesEnv: Record<string, Record<string, string>> = {}
-    const worktreeServicesStatus: Record<string, WorktreeServicesStatus> = {}
-    const worktreeServicesRecords: Record<string, WorktreeServicesRecord> = {}
-    for (const record of records) {
-      worktreeServicesStatus[record.worktreeId] = record.status
-      worktreeServicesRecords[record.worktreeId] = record
-      if (record.status === 'ready') {
-        worktreeServicesEnv[record.worktreeId] = record.env
+  hydrateWorktreeServices: async (options) => {
+    if (options?.ifNeeded) {
+      if (get().hasHydratedWorktreeServices) {
+        return
+      }
+      if (initialWorktreeServicesHydration) {
+        return initialWorktreeServicesHydration
       }
     }
-    set({ worktreeServicesEnv, worktreeServicesStatus, worktreeServicesRecords })
+    const requestId = ++worktreeServicesHydrationRequestId
+    const hydration = (async (): Promise<void> => {
+      const records = await window.api.worktreeServices.list()
+      const worktreeServicesEnv: Record<string, Record<string, string>> = {}
+      const worktreeServicesStatus: Record<string, WorktreeServicesStatus> = {}
+      const worktreeServicesRecords: Record<string, WorktreeServicesRecord> = {}
+      for (const record of records) {
+        worktreeServicesStatus[record.worktreeId] = record.status
+        worktreeServicesRecords[record.worktreeId] = record
+        if (record.status === 'ready') {
+          worktreeServicesEnv[record.worktreeId] = record.env
+        }
+      }
+      // Why: a mutation-triggered refresh can overtake boot hydration. Only
+      // the newest response may publish, or the older empty snapshot can erase
+      // freshly provisioned env and make subsequent PTYs target shared services.
+      if (requestId === worktreeServicesHydrationRequestId) {
+        set({
+          worktreeServicesEnv,
+          worktreeServicesStatus,
+          worktreeServicesRecords,
+          hasHydratedWorktreeServices: true
+        })
+      }
+    })()
+    if (options?.ifNeeded) {
+      initialWorktreeServicesHydration = hydration
+    }
+    try {
+      await hydration
+    } finally {
+      if (initialWorktreeServicesHydration === hydration) {
+        initialWorktreeServicesHydration = null
+      }
+    }
   },
 
   fetchDetectedWorktrees: async (repoId) => {
@@ -2531,11 +2565,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   fetchAllWorktrees: async (options) => {
     const { repos } = get()
 
-    // Why: hydrate per-worktree service env/status alongside the boot worktree
-    // refresh so PTY spawns and the sidebar badge see ready services. Idempotent.
-    // Best-effort — a failed IPC round-trip here must never block worktree refresh.
-    void get()
-      .hydrateWorktreeServices()
+    // Why: restored terminal reconnect runs after this startup refresh and must
+    // see isolated env before spawning. Only the first refresh reads the secure
+    // file; later worktree refreshes return immediately with no IPC or disk I/O.
+    await get()
+      .hydrateWorktreeServices({ ifNeeded: true })
       .catch(() => {})
 
     // Why: once the one-shot hydration-time purge has fired, subsequent

--- a/src/shared/orca-yaml.ts
+++ b/src/shared/orca-yaml.ts
@@ -140,6 +140,17 @@ function normalizeServiceEnv(
   }
   const env: Record<string, string> = {}
   for (const [key, raw] of Object.entries(record)) {
+    // Why: keys become child-process env var names (and, on WSL, WSLENV entries
+    // joined by ':'), so a key with '=', ':' or whitespace would corrupt the
+    // environment passed to the recipe command.
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      diagnostics.push({
+        index,
+        field: 'env',
+        message: `Service "${serviceId}" env key "${key}" is not a valid environment variable name.`
+      })
+      continue
+    }
     if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
       env[key] = String(raw)
     } else {

--- a/src/shared/orca-yaml.ts
+++ b/src/shared/orca-yaml.ts
@@ -128,7 +128,12 @@ type ServiceParseResult = {
   diagnostics: OrcaVmRecipeDiagnostic[]
 }
 
-function normalizeServiceEnv(value: unknown): Record<string, string> | undefined {
+function normalizeServiceEnv(
+  value: unknown,
+  serviceId: string,
+  index: number,
+  diagnostics: OrcaVmRecipeDiagnostic[]
+): Record<string, string> | undefined {
   const record = asRecord(value)
   if (!record) {
     return undefined
@@ -137,6 +142,12 @@ function normalizeServiceEnv(value: unknown): Record<string, string> | undefined
   for (const [key, raw] of Object.entries(record)) {
     if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
       env[key] = String(raw)
+    } else {
+      diagnostics.push({
+        index,
+        field: 'env',
+        message: `Service "${serviceId}" env value for "${key}" must be a string, number, or boolean.`
+      })
     }
   }
   return Object.keys(env).length > 0 ? env : undefined
@@ -191,7 +202,7 @@ function normalizeServices(value: unknown): ServiceParseResult {
       const start = asTrimmedString(record.start)
       const stop = asTrimmedString(record.stop)
       const status = asTrimmedString(record.status)
-      const env = normalizeServiceEnv(record.env)
+      const env = normalizeServiceEnv(record.env, id, index, diagnostics)
       return {
         id,
         name,

--- a/src/shared/orca-yaml.ts
+++ b/src/shared/orca-yaml.ts
@@ -134,8 +134,16 @@ function normalizeServiceEnv(
   index: number,
   diagnostics: OrcaVmRecipeDiagnostic[]
 ): Record<string, string> | undefined {
+  if (value === undefined) {
+    return undefined
+  }
   const record = asRecord(value)
   if (!record) {
+    diagnostics.push({
+      index,
+      field: 'env',
+      message: `Service "${serviceId}" env must be a mapping.`
+    })
     return undefined
   }
   const env: Record<string, string> = {}
@@ -148,6 +156,16 @@ function normalizeServiceEnv(
         index,
         field: 'env',
         message: `Service "${serviceId}" env key "${key}" is not a valid environment variable name.`
+      })
+      continue
+    }
+    // Why: Orca uses this namespace for the stable slot/port contract. Letting
+    // recipe env replace it would make create and destroy target different services.
+    if (key.startsWith('ORCA_')) {
+      diagnostics.push({
+        index,
+        field: 'env',
+        message: `Service "${serviceId}" env key "${key}" is reserved by Orca.`
       })
       continue
     }
@@ -166,6 +184,10 @@ function normalizeServiceEnv(
 
 function normalizeServices(value: unknown): ServiceParseResult {
   const diagnostics: OrcaVmRecipeDiagnostic[] = []
+  if (value !== undefined && !Array.isArray(value)) {
+    diagnostics.push({ index: 0, message: 'Services must be a list.' })
+    return { services: [], diagnostics }
+  }
   if (!Array.isArray(value)) {
     return { services: [], diagnostics }
   }

--- a/src/shared/orca-yaml.ts
+++ b/src/shared/orca-yaml.ts
@@ -2,6 +2,7 @@ import { parse } from 'yaml'
 import type {
   OrcaDefaultTabTemplate,
   OrcaHooks,
+  OrcaServiceRecipe,
   OrcaVmRecipe,
   OrcaVmRecipeDiagnostic
 } from './types'
@@ -122,6 +123,84 @@ function normalizeVmRecipes(value: unknown): VmRecipeParseResult {
   return { recipes, diagnostics }
 }
 
+type ServiceParseResult = {
+  services: OrcaServiceRecipe[]
+  diagnostics: OrcaVmRecipeDiagnostic[]
+}
+
+function normalizeServiceEnv(value: unknown): Record<string, string> | undefined {
+  const record = asRecord(value)
+  if (!record) {
+    return undefined
+  }
+  const env: Record<string, string> = {}
+  for (const [key, raw] of Object.entries(record)) {
+    if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+      env[key] = String(raw)
+    }
+  }
+  return Object.keys(env).length > 0 ? env : undefined
+}
+
+function normalizeServices(value: unknown): ServiceParseResult {
+  const diagnostics: OrcaVmRecipeDiagnostic[] = []
+  if (!Array.isArray(value)) {
+    return { services: [], diagnostics }
+  }
+  const seenIds = new Set<string>()
+  const services = value
+    .map((entry, index) => {
+      const record = asRecord(entry)
+      if (!record) {
+        diagnostics.push({ index, message: 'Service entry must be a mapping.' })
+        return null
+      }
+      const id = asTrimmedString(record.id)
+      const name = asTrimmedString(record.name)
+      const create = asTrimmedString(record.create)
+      if (!id) {
+        diagnostics.push({ index, field: 'id', message: 'Service id is required.' })
+        return null
+      }
+      if (!ORCA_VM_RECIPE_ID_PATTERN.test(id)) {
+        diagnostics.push({
+          index,
+          field: 'id',
+          message: `Invalid service id "${id}". ${ORCA_VM_RECIPE_ID_RULE}`
+        })
+        return null
+      }
+      if (seenIds.has(id)) {
+        diagnostics.push({
+          index,
+          field: 'id',
+          message: `Duplicate service id "${id}". Service ids must be unique.`
+        })
+        return null
+      }
+      if (!name) {
+        diagnostics.push({ index, field: 'name', message: `Service "${id}" is missing name.` })
+        return null
+      }
+      if (!create) {
+        diagnostics.push({ index, field: 'create', message: `Service "${id}" is missing create.` })
+        return null
+      }
+      seenIds.add(id)
+      const destroy = asTrimmedString(record.destroy)
+      const env = normalizeServiceEnv(record.env)
+      return {
+        id,
+        name,
+        create,
+        ...(destroy ? { destroy } : {}),
+        ...(env ? { env } : {})
+      }
+    })
+    .filter((entry): entry is OrcaServiceRecipe => entry !== null)
+  return { services, diagnostics }
+}
+
 /**
  * Parse the supported project defaults from `orca.yaml`.
  */
@@ -146,6 +225,9 @@ export function parseOrcaYaml(content: string): OrcaHooks | null {
   const environmentRecipeParse = normalizeVmRecipes(record.environmentRecipes)
   const environmentRecipes = environmentRecipeParse.recipes
   const environmentRecipeDiagnostics = environmentRecipeParse.diagnostics
+  const serviceParse = normalizeServices(record.services)
+  const services = serviceParse.services
+  const serviceDiagnostics = serviceParse.diagnostics
 
   if (
     !setup &&
@@ -153,7 +235,9 @@ export function parseOrcaYaml(content: string): OrcaHooks | null {
     !issueCommand &&
     defaultTabs.length === 0 &&
     environmentRecipes.length === 0 &&
-    environmentRecipeDiagnostics.length === 0
+    environmentRecipeDiagnostics.length === 0 &&
+    services.length === 0 &&
+    serviceDiagnostics.length === 0
   ) {
     return null
   }
@@ -166,6 +250,8 @@ export function parseOrcaYaml(content: string): OrcaHooks | null {
     ...(issueCommand ? { issueCommand } : {}),
     ...(defaultTabs.length > 0 ? { defaultTabs } : {}),
     ...(environmentRecipes.length > 0 ? { environmentRecipes } : {}),
-    ...(environmentRecipeDiagnostics.length > 0 ? { environmentRecipeDiagnostics } : {})
+    ...(environmentRecipeDiagnostics.length > 0 ? { environmentRecipeDiagnostics } : {}),
+    ...(services.length > 0 ? { services } : {}),
+    ...(serviceDiagnostics.length > 0 ? { serviceDiagnostics } : {})
   }
 }

--- a/src/shared/orca-yaml.ts
+++ b/src/shared/orca-yaml.ts
@@ -188,12 +188,18 @@ function normalizeServices(value: unknown): ServiceParseResult {
       }
       seenIds.add(id)
       const destroy = asTrimmedString(record.destroy)
+      const start = asTrimmedString(record.start)
+      const stop = asTrimmedString(record.stop)
+      const status = asTrimmedString(record.status)
       const env = normalizeServiceEnv(record.env)
       return {
         id,
         name,
         create,
         ...(destroy ? { destroy } : {}),
+        ...(start ? { start } : {}),
+        ...(stop ? { stop } : {}),
+        ...(status ? { status } : {}),
         ...(env ? { env } : {})
       }
     })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2221,6 +2221,7 @@ export type PreservedWorktreeBranch = {
 
 export type RemoveWorktreeResult = {
   preservedBranch?: PreservedWorktreeBranch
+  serviceDestroyErrors?: string[]
 }
 
 export type ForceDeleteWorktreeBranchResult = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3302,6 +3302,7 @@ export type RightSidebarTab =
   | 'source-control'
   | 'checks'
   | 'ports'
+  | 'services'
 export type ActiveRightSidebarTab = Exclude<RightSidebarTab, 'search'>
 export type RightSidebarExplorerView = 'files' | 'search'
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2203,6 +2203,9 @@ export type CreateWorktreeResult = {
   setup?: WorktreeSetupLaunch
   defaultTabs?: WorktreeDefaultTabsLaunch
   warning?: string
+  /** Worktree creation succeeded, but isolated services failed. Automatic
+   * setup/default-tab/agent commands are withheld to protect shared services. */
+  serviceProvisioningError?: string
   initialBaseStatus?: WorktreeBaseStatusEvent
   localBaseRefRefresh?: LocalBaseRefRefreshResult
   localBaseRefUpdateSuggestion?: LocalBaseRefUpdateSuggestion

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2057,6 +2057,9 @@ export type OrcaServiceRecipe = {
   name: string
   create: string
   destroy?: string
+  start?: string
+  stop?: string
+  status?: string // exit 0 = running, non-zero = stopped
   env?: Record<string, string>
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2025,6 +2025,8 @@ export type OrcaHooks = {
   defaultTabs?: OrcaDefaultTabTemplate[] // Terminal tabs to create once for a new worktree
   environmentRecipes?: OrcaVmRecipe[] // Project-scoped per-workspace environment recipes
   environmentRecipeDiagnostics?: OrcaVmRecipeDiagnostic[] // Non-fatal validation issues from environmentRecipes
+  services?: OrcaServiceRecipe[] // Per-worktree isolated service recipes
+  serviceDiagnostics?: OrcaVmRecipeDiagnostic[] // Non-fatal validation issues from services
 }
 
 export type OrcaDefaultTabTemplate = {
@@ -2048,6 +2050,14 @@ export type OrcaVmRecipeDiagnostic = {
   index: number
   field?: string
   message: string
+}
+
+export type OrcaServiceRecipe = {
+  id: string
+  name: string
+  create: string
+  destroy?: string
+  env?: Record<string, string>
 }
 
 export type RepoHookSettings = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2180,6 +2180,10 @@ export type CreateWorktreeArgs = {
   creationId?: string
   /** Authorizes the host to mint system-owned automation provenance. */
   automationProvenanceRequest?: AutomationWorkspaceProvenanceRequest
+  /** Opt-in to provisioning isolated per-worktree services from orca.yaml. */
+  provisionServices?: boolean
+  /** Correlates worktreeServices:provisionEvent streams back to the pending creation. */
+  serviceProvisionId?: string
 }
 
 export type CreateWorktreeResult = {

--- a/src/shared/worktree-service-env.test.ts
+++ b/src/shared/worktree-service-env.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildServiceContextEnv,
+  deriveServiceSlug,
+  resolveServiceEnv
+} from './worktree-service-env'
+
+describe('deriveServiceSlug', () => {
+  it('sanitizes and suffixes the slot', () => {
+    expect(deriveServiceSlug('Fix Migrations!', 3)).toBe('fix-migrations-s3')
+  })
+  it('truncates long names but keeps the slot suffix', () => {
+    const slug = deriveServiceSlug('x'.repeat(100), 12)
+    expect(slug.length).toBeLessThanOrEqual(40)
+    expect(slug.endsWith('-s12')).toBe(true)
+  })
+  it('falls back when the name has no usable characters', () => {
+    expect(deriveServiceSlug('***', 0)).toBe('worktree-s0')
+  })
+})
+
+describe('buildServiceContextEnv', () => {
+  it('exposes slug, slot, and ten deterministic ports', () => {
+    const env = buildServiceContextEnv('demo-s2', 2)
+    expect(env.ORCA_WORKTREE_SLUG).toBe('demo-s2')
+    expect(env.ORCA_SERVICE_SLOT).toBe('2')
+    expect(env.ORCA_PORT_0).toBe('20020')
+    expect(env.ORCA_PORT_9).toBe('20029')
+  })
+})
+
+describe('resolveServiceEnv', () => {
+  it('substitutes context variables, plain string replacement', () => {
+    const context = buildServiceContextEnv('demo-s0', 0)
+    expect(
+      resolveServiceEnv({ DATABASE_URL: 'postgres://localhost:${ORCA_PORT_0}/app' }, context)
+    ).toEqual({ DATABASE_URL: 'postgres://localhost:20000/app' })
+  })
+  it('leaves unknown placeholders untouched and handles undefined template', () => {
+    const context = buildServiceContextEnv('demo-s0', 0)
+    expect(resolveServiceEnv({ A: '${NOT_A_VAR}' }, context)).toEqual({ A: '${NOT_A_VAR}' })
+    expect(resolveServiceEnv(undefined, context)).toEqual({})
+  })
+})

--- a/src/shared/worktree-service-env.ts
+++ b/src/shared/worktree-service-env.ts
@@ -1,0 +1,41 @@
+export const SERVICE_PORT_BASE = 20000
+export const SERVICE_PORTS_PER_SLOT = 10
+
+export function deriveServiceSlug(worktreeName: string, slot: number): string {
+  const suffix = `-s${slot}`
+  const base =
+    worktreeName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40 - suffix.length)
+      .replace(/-+$/g, '') || 'worktree'
+  return `${base}${suffix}`
+}
+
+export function buildServiceContextEnv(slug: string, slot: number): Record<string, string> {
+  const env: Record<string, string> = {
+    ORCA_WORKTREE_SLUG: slug,
+    ORCA_SERVICE_SLOT: String(slot)
+  }
+  for (let i = 0; i < SERVICE_PORTS_PER_SLOT; i++) {
+    env[`ORCA_PORT_${i}`] = String(SERVICE_PORT_BASE + slot * SERVICE_PORTS_PER_SLOT + i)
+  }
+  return env
+}
+
+export function resolveServiceEnv(
+  template: Record<string, string> | undefined,
+  contextEnv: Record<string, string>
+): Record<string, string> {
+  if (!template) {
+    return {}
+  }
+  const resolved: Record<string, string> = {}
+  for (const [key, value] of Object.entries(template)) {
+    resolved[key] = value.replace(/\$\{([A-Z0-9_]+)\}/g, (match, name: string) =>
+      name in contextEnv ? contextEnv[name] : match
+    )
+  }
+  return resolved
+}

--- a/src/shared/worktree-services-store.test.ts
+++ b/src/shared/worktree-services-store.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  allocateServiceSlot,
+  getWorktreeServicesRecord,
+  listWorktreeServicesRecords,
+  removeWorktreeServicesRecord,
+  upsertWorktreeServicesRecord
+} from './worktree-services-store'
+import type { WorktreeServicesRecord } from './worktree-services'
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'orca-svc-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function record(worktreeId: string, slot: number): WorktreeServicesRecord {
+  return {
+    worktreeId,
+    repoId: 'repo-1',
+    slot,
+    slug: `wt-s${slot}`,
+    serviceIds: ['db'],
+    env: { ORCA_SERVICE_SLOT: String(slot) },
+    status: 'ready',
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:00.000Z'
+  }
+}
+
+describe('worktree services store', () => {
+  it('starts empty and allocates slot 0', () => {
+    expect(listWorktreeServicesRecords(dir)).toEqual([])
+    expect(allocateServiceSlot(dir)).toBe(0)
+  })
+
+  it('round-trips records and fills slot gaps', () => {
+    upsertWorktreeServicesRecord(dir, record('wt-a', 0))
+    upsertWorktreeServicesRecord(dir, record('wt-b', 2))
+    expect(allocateServiceSlot(dir)).toBe(1)
+    expect(getWorktreeServicesRecord(dir, 'wt-a')?.slot).toBe(0)
+  })
+
+  it('remove frees the slot and returns the removed record', () => {
+    upsertWorktreeServicesRecord(dir, record('wt-a', 0))
+    expect(removeWorktreeServicesRecord(dir, 'wt-a')?.worktreeId).toBe('wt-a')
+    expect(allocateServiceSlot(dir)).toBe(0)
+    expect(removeWorktreeServicesRecord(dir, 'wt-a')).toBeNull()
+  })
+
+  it('upsert replaces the record for the same worktreeId', () => {
+    upsertWorktreeServicesRecord(dir, record('wt-a', 0))
+    upsertWorktreeServicesRecord(dir, { ...record('wt-a', 0), status: 'create_failed' })
+    expect(listWorktreeServicesRecords(dir)).toHaveLength(1)
+    expect(getWorktreeServicesRecord(dir, 'wt-a')?.status).toBe('create_failed')
+  })
+})

--- a/src/shared/worktree-services-store.ts
+++ b/src/shared/worktree-services-store.ts
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { hardenExistingSecureFile, writeSecureJsonFile } from './secure-file'
+import {
+  WorktreeServicesStoreSchema,
+  type WorktreeServicesRecord,
+  type WorktreeServicesStore
+} from './worktree-services'
+
+const WORKTREE_SERVICES_FILE = 'orca-worktree-services.json'
+
+export function getWorktreeServicesStorePath(userDataPath: string): string {
+  return join(userDataPath, WORKTREE_SERVICES_FILE)
+}
+
+function readStore(userDataPath: string): WorktreeServicesStore {
+  const path = getWorktreeServicesStorePath(userDataPath)
+  if (!existsSync(path)) {
+    return { version: 1, records: [] }
+  }
+  hardenExistingSecureFile(path)
+  try {
+    return WorktreeServicesStoreSchema.parse(JSON.parse(readFileSync(path, 'utf-8')))
+  } catch {
+    return { version: 1, records: [] }
+  }
+}
+
+function writeStore(userDataPath: string, store: WorktreeServicesStore): void {
+  writeSecureJsonFile(getWorktreeServicesStorePath(userDataPath), store)
+}
+
+export function listWorktreeServicesRecords(userDataPath: string): WorktreeServicesRecord[] {
+  return readStore(userDataPath).records
+}
+
+export function getWorktreeServicesRecord(
+  userDataPath: string,
+  worktreeId: string
+): WorktreeServicesRecord | null {
+  return readStore(userDataPath).records.find((r) => r.worktreeId === worktreeId) ?? null
+}
+
+export function allocateServiceSlot(userDataPath: string): number {
+  const used = new Set(readStore(userDataPath).records.map((r) => r.slot))
+  let slot = 0
+  while (used.has(slot)) {
+    slot++
+  }
+  return slot
+}
+
+export function upsertWorktreeServicesRecord(
+  userDataPath: string,
+  record: WorktreeServicesRecord
+): WorktreeServicesRecord {
+  const store = readStore(userDataPath)
+  const records = store.records.filter((r) => r.worktreeId !== record.worktreeId)
+  records.push(record)
+  writeStore(userDataPath, { version: 1, records })
+  return record
+}
+
+export function removeWorktreeServicesRecord(
+  userDataPath: string,
+  worktreeId: string
+): WorktreeServicesRecord | null {
+  const store = readStore(userDataPath)
+  const removed = store.records.find((r) => r.worktreeId === worktreeId) ?? null
+  if (removed) {
+    writeStore(userDataPath, {
+      version: 1,
+      records: store.records.filter((r) => r.worktreeId !== worktreeId)
+    })
+  }
+  return removed
+}

--- a/src/shared/worktree-services.ts
+++ b/src/shared/worktree-services.ts
@@ -27,3 +27,14 @@ export const WorktreeServicesStoreSchema = z.object({
   records: z.array(WorktreeServicesRecordSchema)
 })
 export type WorktreeServicesStore = z.infer<typeof WorktreeServicesStoreSchema>
+
+// Live (non-persisted) runtime state of one provisioned service, probed on demand
+// via the recipe's optional `status` command.
+export type WorktreeServiceRunState = 'running' | 'stopped' | 'unknown'
+export type WorktreeServiceRuntimeState = {
+  serviceId: string
+  name: string
+  runState: WorktreeServiceRunState
+  canStart: boolean
+  canStop: boolean
+}

--- a/src/shared/worktree-services.ts
+++ b/src/shared/worktree-services.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+export const WorktreeServicesStatusSchema = z.enum([
+  'provisioning',
+  'ready',
+  'create_failed',
+  'destroy_failed'
+])
+export type WorktreeServicesStatus = z.infer<typeof WorktreeServicesStatusSchema>
+
+export const WorktreeServicesRecordSchema = z.object({
+  worktreeId: z.string().min(1),
+  repoId: z.string().min(1),
+  slot: z.number().int().nonnegative(),
+  slug: z.string().min(1),
+  serviceIds: z.array(z.string().min(1)),
+  env: z.record(z.string(), z.string()),
+  status: WorktreeServicesStatusSchema,
+  error: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string()
+})
+export type WorktreeServicesRecord = z.infer<typeof WorktreeServicesRecordSchema>
+
+export const WorktreeServicesStoreSchema = z.object({
+  version: z.literal(1),
+  records: z.array(WorktreeServicesRecordSchema)
+})
+export type WorktreeServicesStore = z.infer<typeof WorktreeServicesStoreSchema>


### PR DESCRIPTION
## Summary

Per-worktree isolated services: a `services:` section in `orca.yaml` declares provider-agnostic service recipes (`create`/`destroy`/`start`/`stop`/`status` shell commands + exported env vars). An opt-in "Isolated services" checkbox at worktree creation provisions a private copy of the project's services (database, cache, …), so tasks that mutate shared state — schema migrations being the canonical case — no longer clobber the dev services other worktrees/agent sessions rely on.

```yaml
services:
  - id: db
    name: Postgres 16
    create: docker compose -p "orca-$ORCA_WORKTREE_SLUG" up -d --wait
    destroy: docker compose -p "orca-$ORCA_WORKTREE_SLUG" down -v
    start: docker compose -p "orca-$ORCA_WORKTREE_SLUG" start
    stop: docker compose -p "orca-$ORCA_WORKTREE_SLUG" stop
    status: docker compose -p "orca-$ORCA_WORKTREE_SLUG" ps -q | grep -q .
    env:
      DATABASE_URL: postgres://app:app@localhost:${ORCA_PORT_0}/app
```

What ships:

- Unique slot per provisioned worktree, slug, and ten deterministic host ports `ORCA_PORT_0..9` (`20000 + slot*10 + i`) — no arithmetic needed in recipes or compose files.
- Provisioning runs inside `worktrees:create` (after git worktree, before setup terminals) so `scripts.setup` can run migrations against the fresh DB; output streams to the pending-creation card. Failed create keeps the worktree, retry offered.
- Resolved env (`env:` + `ORCA_WORKTREE_SLUG`/`ORCA_SERVICE_SLOT`/`ORCA_PORT_*`) injected into every terminal and agent PTY of the worktree.
- Automatic `destroy` on worktree removal (never blocks removal; warning toast on failure), startup orphan cleanup, slot recycling.
- "Services" right-sidebar panel (visible only for provisioned worktrees): live per-service run state probed via `status`, per-service and environment-wide Start/Stop, slot/port range, resolved env vars, retry.
- Worktree card badge (Services / Services: Failed → retry), recipe diagnostics in repository settings (errors red, missing-`destroy` warning amber).
- State in a dedicated secure store `orca-worktree-services.json` (mirrors the ephemeral-VM runtime store pattern).
- v1 scope: local + WSL worktrees; remote/SSH repos never see the opt-in (`repo.connectionId` guards). Remote path documented as follow-up (design doc, `runRemoteArchiveHook` pattern).

Design doc: `docs/reference/2026-07-07-worktree-services-design.md` · Implementation plan: `docs/reference/plans/2026-07-07-worktree-isolated-services.md`

## Screenshots

Screenshots of the composer checkbox and the Services panel will be attached in the PR conversation (new UI: opt-in checkbox in the new-workspace composer, Services right-sidebar tab, worktree-card badge, settings diagnostics).

## Testing

- [ ] `pnpm lint` — red on ONE pre-existing `main` error unrelated to this PR (`source-control-manual-review-url.ts:164` switch-exhaustiveness, file untouched here; verified against a clean `main` worktree). All lint checks covering this PR's files pass (oxlint, localization catalog/coverage, max-lines-ratchet — no new suppressions).
- [x] `pnpm typecheck`
- [x] `pnpm test` — full suite 25 173 passed / 1 failed (pre-existing environment-dependent zsh PATH test, unrelated file)
- [x] `pnpm build`
- [x] Added or updated high-quality tests: orca.yaml parsing (recipes, diagnostics, lifecycle commands), env substitution/slug/deterministic ports, store slot allocation/recycling, provision/destroy lifecycle incl. rollback and failure paths, orphan cleanup, renderer env injection, activity-bar visibility. Live E2E in the dev app (CDP-driven): provision → env in real PTYs → second worktree slot 1 → destroy on delete → slot reuse → panel start/stop/status cycle.

## AI Review Report

Plan executed by a multi-agent team, then verified by an independent verification agent (full typecheck/lint/test + static wiring trace of the whole chain) and a dedicated code-review agent over `main..HEAD` on five axes (correctness, security, performance, maintainability, test coverage). Findings and outcomes:

- **Critical (fixed):** stale `useCallback` closure in the composer — `provisionServices` missing from `submitQuick` deps meant a checked checkbox could silently create without services.
- **Major (fixed):** unguarded post-create `hydrateWorktreeServices()` could derail post-create wiring on IPC failure; destroy failures were console-only — now surfaced as a warning toast via `RemoveWorktreeResult.serviceDestroyErrors`, per the design doc.
- Live-smoke found two additional real bugs, both fixed: services recipes must come from raw parsed yaml (`getEffectiveHooksFromConfig` only carries setup/archive scripts and returns null without them), and the card badge was gated out of the meta row.
- Cross-platform explicitly reviewed: no hardcoded separators (`path.join`/`basename`), shell selection mirrors the existing hook runner (`cmd.exe` via `ComSpec` on win32, `/bin/bash` elsewhere), WSL commands routed through `wsl.exe` with the same quoting/env-translation as `runHook`, port block avoids shell arithmetic for compose compatibility, UI shows no shortcuts. Windows-specific test mock regressions (electron `app` mock) caught and fixed.
- Deferred minors (called out, non-blocking): per-service coverage gaps (retry IPC handler, multi-service rollback, WSL branch unit test), retry double-click guard, provisioning badge tint.

## Security Audit

- **Command execution:** `create`/`destroy`/`start`/`stop`/`status` are repo-controlled shell commands — same trust model and execution surface as the existing `scripts.setup`/`scripts.archive` hooks (explicitly compared; no new trust boundary). No `eval`; env substitution is plain string replacement of Orca-provided values only.
- **IPC:** new `worktreeServices:*` handlers validate repo existence, reject remote repos (`connectionId` guard), and resolve paths via the existing `parseWorktreeId`; no renderer-supplied paths are executed.
- **Path handling:** WSL quoting copies the battle-tested `runHook` single-quote escaping; cwd is the worktree owned by Orca.
- **Secrets:** recipe env values may contain credentials — they live in the same secure-file store as ephemeral-VM runtimes (`writeSecureJsonFile`/`hardenExistingSecureFile`) and are displayed only in the local Services panel; nothing is logged or committed.
- **Dependencies:** none added.
- Follow-up: none identified beyond the deferred minors above.

## Notes

- Terminals pre-spawned at app boot can miss the service env if they spawn before the async hydration resolves; fresh PTYs (new tabs, splits) always get it. Documented in the design doc.
- Run state is probed on panel open/after actions — no continuous liveness monitoring (deliberate v1 choice).
- Remote (SSH) provisioning is a documented follow-up; all code paths keep `repo.connectionId` guards so it lands additively.

## ELI5

Worktrees can opt into private DBs/services declared in `orca.yaml` at create time. Migrations in one worktree no longer clobber the shared dev services others use.
