### PR TITLE
fix(ssh): cancel superseded remote fs.listFiles to stop relay starvation (#7721)

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -332,6 +332,40 @@ describe('registerFilesystemHandlers', () => {
     )
   })
 
+  it('aborts the previous in-flight remote listFiles when a newer one starts for the same connection', async () => {
+    // Why: fast project switching fires a fresh remote listFiles before the
+    // previous full-tree scan finishes. The handler must cancel the superseded
+    // scan so it stops saturating the single-threaded relay, and resolve it to
+    // [] instead of surfacing an error for the project the user left.
+    const signals: (AbortSignal | undefined)[] = []
+    const provider = {
+      listFiles: vi.fn((_rootPath: string, opts?: { signal?: AbortSignal }) => {
+        signals.push(opts?.signal)
+        return new Promise<string[]>((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () => reject(new Error('aborted')), {
+            once: true
+          })
+        })
+      })
+    }
+    getSshFilesystemProviderMock.mockReturnValue(provider)
+    registerFilesystemHandlers(store as never)
+
+    const first = handlers.get('fs:listFiles')!(null, {
+      rootPath: '/remote/a',
+      connectionId: 'ssh-1'
+    })
+    const second = handlers.get('fs:listFiles')!(null, {
+      rootPath: '/remote/b',
+      connectionId: 'ssh-1'
+    })
+
+    await expect(first).resolves.toEqual([])
+    expect(signals[0]?.aborted).toBe(true)
+    expect(signals[1]?.aborted).toBe(false)
+    void second
+  })
+
   // Why: handler-level WSL UNC authorization depends on native Windows path
   // resolution; path-shape classification has separate cross-platform coverage.
   it.runIf(process.platform === 'win32')(

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1026,6 +1026,14 @@ export function registerFilesystemHandlers(
   )
 
   // ─── List all files (for quick-open) ─────────────────────
+  // Why: a remote listFiles is a full-tree scan (tens of thousands of paths
+  // streamed over one relay socket). Fast project switching fires a fresh scan
+  // for the same SSH connection before the previous finishes; without
+  // cancellation they pile up on the single-threaded relay and starve
+  // concurrent fs.readDir/fs.stat past the 30s request timeout, which surfaces
+  // as "Could not load files for this workspace". Keep one in-flight scan per
+  // connection and abort the previous when a newer one starts.
+  const inFlightListFiles = new Map<string, AbortController>()
   ipcMain.handle(
     'fs:listFiles',
     async (
@@ -1041,10 +1049,33 @@ export function registerFilesystemHandlers(
         if (!provider) {
           return []
         }
-        // Why: forward excludePaths through to the remote provider.
-        // Dropping it here would silently double-scan nested linked worktrees
-        // over SSH and contribute to timeout-induced partial results.
-        return provider.listFiles(args.rootPath, { excludePaths: args.excludePaths })
+        const previous = inFlightListFiles.get(args.connectionId)
+        if (previous) {
+          previous.abort()
+        }
+        const controller = new AbortController()
+        inFlightListFiles.set(args.connectionId, controller)
+        try {
+          // Why: forward excludePaths through to the remote provider.
+          // Dropping it here would silently double-scan nested linked worktrees
+          // over SSH and contribute to timeout-induced partial results.
+          return await provider.listFiles(args.rootPath, {
+            excludePaths: args.excludePaths,
+            signal: controller.signal
+          })
+        } catch (error) {
+          // Why: a scan aborted by a newer request is superseded, not failed.
+          // Resolve empty so the switched-away project doesn't raise an error
+          // banner; the active project's own scan populates quick-open.
+          if (controller.signal.aborted) {
+            return []
+          }
+          throw error
+        } finally {
+          if (inFlightListFiles.get(args.connectionId) === controller) {
+            inFlightListFiles.delete(args.connectionId)
+          }
+        }
       }
       return listQuickOpenFiles(args.rootPath, store, args.excludePaths)
     }

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -417,7 +417,11 @@ describe('SshFilesystemProvider', () => {
   it('listFiles sends fs.listFiles request', async () => {
     mux.request.mockResolvedValue(['src/index.ts', 'package.json'])
     const result = await provider.listFiles('/home/user/project')
-    expect(mux.request).toHaveBeenCalledWith('fs.listFiles', { rootPath: '/home/user/project' })
+    expect(mux.request).toHaveBeenCalledWith(
+      'fs.listFiles',
+      { rootPath: '/home/user/project' },
+      { signal: undefined }
+    )
     expect(result).toEqual(['src/index.ts', 'package.json'])
   })
 
@@ -426,16 +430,35 @@ describe('SshFilesystemProvider', () => {
     await provider.listFiles('/home/user/project', {
       excludePaths: ['/home/user/project/worktrees/b']
     })
-    expect(mux.request).toHaveBeenCalledWith('fs.listFiles', {
-      rootPath: '/home/user/project',
-      excludePaths: ['/home/user/project/worktrees/b']
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'fs.listFiles',
+      {
+        rootPath: '/home/user/project',
+        excludePaths: ['/home/user/project/worktrees/b']
+      },
+      { signal: undefined }
+    )
   })
 
   it('listFiles omits excludePaths when empty', async () => {
     mux.request.mockResolvedValue([])
     await provider.listFiles('/home/user/project', { excludePaths: [] })
-    expect(mux.request).toHaveBeenCalledWith('fs.listFiles', { rootPath: '/home/user/project' })
+    expect(mux.request).toHaveBeenCalledWith(
+      'fs.listFiles',
+      { rootPath: '/home/user/project' },
+      { signal: undefined }
+    )
+  })
+
+  it('listFiles forwards the abort signal to the mux for cancellation', async () => {
+    mux.request.mockResolvedValue([])
+    const controller = new AbortController()
+    await provider.listFiles('/home/user/project', { signal: controller.signal })
+    expect(mux.request).toHaveBeenCalledWith(
+      'fs.listFiles',
+      { rootPath: '/home/user/project' },
+      { signal: controller.signal }
+    )
   })
 
   describe('watch', () => {

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -283,12 +283,21 @@ export class SshFilesystemProvider implements IFilesystemProvider {
     return (await this.mux.request('fs.search', opts)) as SearchResult
   }
 
-  async listFiles(rootPath: string, options?: { excludePaths?: string[] }): Promise<string[]> {
+  async listFiles(
+    rootPath: string,
+    options?: { excludePaths?: string[]; signal?: AbortSignal }
+  ): Promise<string[]> {
     const params: Record<string, unknown> = { rootPath }
     if (options?.excludePaths && options.excludePaths.length > 0) {
       params.excludePaths = options.excludePaths
     }
-    return (await this.mux.request('fs.listFiles', params)) as string[]
+    // Why: pass the caller's abort signal so a superseded index (e.g. the user
+    // switched to another project before this full-tree scan finished) is
+    // canceled via the mux's rpc.cancel instead of running to completion and
+    // starving concurrent fs.readDir/fs.stat past the 30s request timeout.
+    return (await this.mux.request('fs.listFiles', params, {
+      signal: options?.signal
+    })) as string[]
   }
 
   async watch(rootPath: string, callback: (events: FsChangeEvent[]) => void): Promise<() => void> {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -197,7 +197,10 @@ export type IFilesystemProvider = {
   copy(source: string, destination: string): Promise<void>
   realpath(filePath: string): Promise<string>
   search(opts: SearchOptions): Promise<SearchResult>
-  listFiles(rootPath: string, options?: { excludePaths?: string[] }): Promise<string[]>
+  listFiles(
+    rootPath: string,
+    options?: { excludePaths?: string[]; signal?: AbortSignal }
+  ): Promise<string[]>
   scanWorkspaceSpace?(
     rootPath: string,
     options?: { signal?: AbortSignal }

--- a/src/relay/fs-handler-list-files-ignored.test.ts
+++ b/src/relay/fs-handler-list-files-ignored.test.ts
@@ -322,3 +322,33 @@ describe('relay quick open ignored file listing', () => {
     }
   })
 })
+
+describe('relay quick open cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects immediately and spawns no rg when the signal is already aborted', async () => {
+    await expect(listFilesWithRg('/remote/root', [], AbortSignal.abort())).rejects.toThrow(
+      'fs.listFiles canceled'
+    )
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('kills the rg children and rejects when the signal aborts mid-flight', async () => {
+    const primaryProc = createMockProcess()
+    const ignoredProc = createMockProcess()
+    spawnMock.mockImplementation((_cmd: string, args: string[]) =>
+      args.includes('--no-ignore-vcs') ? ignoredProc : primaryProc
+    )
+
+    const controller = new AbortController()
+    const promise = listFilesWithRg('/remote/root', [], controller.signal)
+
+    controller.abort()
+
+    await expect(promise).rejects.toThrow('fs.listFiles canceled')
+    expect(primaryProc.kill).toHaveBeenCalled()
+    expect(ignoredProc.kill).toHaveBeenCalled()
+  })
+})

--- a/src/relay/fs-handler-list-files.ts
+++ b/src/relay/fs-handler-list-files.ts
@@ -27,7 +27,8 @@ export const LIST_FILES_TIMEOUT_MS = 25_000
 
 export function listFilesWithRg(
   rootPath: string,
-  excludePathPrefixes: readonly string[] = []
+  excludePathPrefixes: readonly string[] = [],
+  signal?: AbortSignal
 ): Promise<string[]> {
   return new Promise((resolve, reject) => {
     const files = new Set<string>()
@@ -193,8 +194,31 @@ export function listFilesWithRg(
       }
     }
 
+    // Why: a canceled request (superseded by a newer scan on fast project
+    // switch, or an explicit rpc.cancel) must stop the rg children instead of
+    // letting them run to LIST_FILES_TIMEOUT_MS and keep saturating the relay.
+    const onAbort = (): void => {
+      if (done) {
+        return
+      }
+      done = true
+      killSurvivors()
+      reject(new Error('fs.listFiles canceled'))
+    }
+    if (signal) {
+      if (signal.aborted) {
+        onAbort()
+        return
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
+    }
+    const detachAbort = (): void => {
+      signal?.removeEventListener('abort', onAbort)
+    }
+
     Promise.all([runPass(primary), runPass(ignoredPass)])
       .then(() => {
+        detachAbort()
         if (done) {
           return
         }
@@ -202,6 +226,7 @@ export function listFilesWithRg(
         resolve(Array.from(files))
       })
       .catch((err) => {
+        detachAbort()
         if (done) {
           return
         }

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -114,7 +114,7 @@ export class FsHandler {
     this.dispatcher.onRequest('fs.copy', (p) => this.copy(p))
     this.dispatcher.onRequest('fs.realpath', (p) => this.realpath(p))
     this.dispatcher.onRequest('fs.search', (p) => this.search(p))
-    this.dispatcher.onRequest('fs.listFiles', (p) => this.listFiles(p))
+    this.dispatcher.onRequest('fs.listFiles', (p, c) => this.listFiles(p, c))
     this.dispatcher.onRequest('fs.workspaceSpaceScan', (p, c) => this.workspaceSpaceScan(p, c))
     this.dispatcher.onRequest('fs.watch', (p, context) => this.watch(p, context))
     this.dispatcher.onNotification('fs.unwatch', (p, context) => this.unwatch(p, context))
@@ -331,8 +331,17 @@ export class FsHandler {
     })
   }
 
-  private async listFiles(params: Record<string, unknown>): Promise<string[]> {
+  private async listFiles(
+    params: Record<string, unknown>,
+    context?: RequestContext
+  ): Promise<string[]> {
     const rootPath = expandTilde(params.rootPath as string)
+    const signal = context?.signal
+    // Why: bail before spawning if the client already canceled (e.g. the user
+    // switched projects while this request was queued behind other work).
+    if (signal?.aborted) {
+      throw new Error('fs.listFiles canceled')
+    }
     // Why: the main-to-relay RPC adds excludePaths so nested linked worktrees
     // don't get double-scanned. The shared helper validates the shape and
     // normalizes into root-relative prefixes; malformed input yields [] so
@@ -340,7 +349,7 @@ export class FsHandler {
     const excludePathPrefixes = buildExcludePathPrefixes(rootPath, params.excludePaths)
     const rgAvailable = await checkRgAvailable()
     if (rgAvailable) {
-      return listFilesWithRg(rootPath, excludePathPrefixes)
+      return listFilesWithRg(rootPath, excludePathPrefixes, signal)
     }
     // Why: git ls-files only works inside git repos. Use rev-parse to detect
     // git ancestry — unlike checking for a local .git entry, this works from


### PR DESCRIPTION
## Summary

Fixes #7721.

On a remote SSH workspace, rapidly switching between projects makes the whole file panel fail with:

> Could not load files for this workspace: Error invoking remote method 'fs:readDir': Error: Request "fs.readDir" timed out after 30000ms

(the same 30s timeout also hits `fs.stat` / `fs:pathExists`). The terminal keeps working the whole time.

**Root cause:** workspace indexing (`fs.listFiles`) over SSH is a full-tree scan — on a large monorepo it streams tens of thousands of paths back over a single relay socket. It was **not cancellable**: `SshFilesystemProvider.listFiles` called `mux.request('fs.listFiles', …)` without a signal, and the provider interface had no signal parameter — even though `SshChannelMultiplexer.request(..., { signal })` already turns an aborted signal into an `rpc.cancel`. So switching projects did not cancel the previous project's scan; fast switches stacked multiple full scans on the single-threaded relay, and the file explorer's concurrent `fs.readDir`/`fs.stat` requests queued behind them past the fixed 30s `REQUEST_TIMEOUT_MS`.

This mirrors the existing cancellable `scanWorkspaceSpace` path, which already threads an `AbortSignal` end-to-end.

## Changes

- **`providers/types.ts`, `providers/ssh-filesystem-provider.ts`** — `listFiles` accepts an optional `signal` and forwards it to `mux.request('fs.listFiles', params, { signal })` (same pattern as `scanWorkspaceSpace`).
- **`ipc/filesystem.ts`** — the `fs:listFiles` handler keeps one in-flight remote scan per connection: a new scan aborts the previous one for that connection. A scan aborted because it was superseded resolves to `[]` (it is superseded, not failed), so the project the user switched away from doesn't raise an error banner.
- **`relay/fs-handler.ts`, `relay/fs-handler-list-files.ts`** — the relay's `fs.listFiles` now receives `RequestContext.signal`, bails before spawning if already aborted, and kills the in-flight `rg` children on abort instead of letting them run to `LIST_FILES_TIMEOUT_MS` and keep saturating the relay.

Local (non-SSH) `listFiles` is unchanged.

## Tests

- `ssh-filesystem-provider.test.ts` — `listFiles` forwards the abort signal to the mux (and the existing call-shape assertions updated for the new argument).
- `ipc/filesystem.test.ts` — a newer remote `listFiles` aborts the previous in-flight one for the same connection, and the superseded call resolves to `[]`.
- `fs-handler-list-files-ignored.test.ts` — `listFilesWithRg` rejects and spawns no `rg` when the signal is already aborted, and kills both `rg` children when the signal aborts mid-flight.

`pnpm run typecheck` passes. The three touched test files pass; the only failures in the full suite (`SidebarToolbar.test.tsx`, `LinearAgentSkillSetupPrompt.reminder-toast.test.tsx`) are pre-existing on `main` and unrelated to this change (reproduced with this diff stashed).

## Notes / follow-ups (out of scope here)

While reproducing #7721 the remote relay also showed durability issues that amplify the impact — leaked PTYs and zombie `sh` children, an unhandled `EBADF` pty write, and multi-GB RSS growth over long sessions. Those are worth separate fixes.

## ELI5

On SSH, switching projects quickly could starve the file tree with timed-out list requests. Superseded remote file scans are cancelled so the explorer stays usable.
