### PR TITLE
feat(jira): support self-hosted Jira Server/DC with personal access tokens

### DIFF
--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -90,7 +90,8 @@ export function registerJiraHandlers(): void {
     const result = await connect({
       siteUrl: args.siteUrl,
       email: args.email,
-      apiToken: args.apiToken
+      apiToken: args.apiToken,
+      authType: args.authType === 'server' ? 'server' : 'cloud'
     })
     if (result.ok) {
       _resetPreflightCache()

--- a/src/main/jira/client.test.ts
+++ b/src/main/jira/client.test.ts
@@ -402,6 +402,100 @@ describe('Jira client credential storage', () => {
     expect(jira.isAuthError(new jira.JiraApiError('Forbidden', 403))).toBe(false)
   })
 
+  it('connects to self-hosted Jira with a Bearer PAT against REST v2', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: 'wquintal',
+          key: 'JIRAUSER10101',
+          displayName: 'William',
+          emailAddress: 'william@example.com'
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const jira = await loadClientModule()
+
+    await expect(
+      jira.connect({
+        siteUrl: 'jira.example.com',
+        email: '',
+        apiToken: 'pat-token',
+        authType: 'server'
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      // Server /myself has no accountId; the username stands in for it.
+      viewer: { displayName: 'William', accountId: 'wquintal' }
+    })
+
+    expect(netFetchMock).toHaveBeenCalledWith(
+      'https://jira.example.com/rest/api/2/myself',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    )
+    const headers = netFetchMock.mock.calls[0]?.[1]?.headers as Headers
+    expect(headers.get('Authorization')).toBe('Bearer pat-token')
+  })
+
+  it('requires a token but not an email for self-hosted connections', async () => {
+    const jira = await loadClientModule()
+
+    await expect(
+      jira.connect({
+        siteUrl: 'jira.example.com',
+        email: '',
+        apiToken: '',
+        authType: 'server'
+      })
+    ).resolves.toEqual({ ok: false, error: 'Personal access token is required.' })
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('uses Bearer auth and REST v2 for stored self-hosted sites', async () => {
+    const siteId = 'site-server'
+    const orcaDir = join(tempHome, '.orca')
+    mkdirSync(join(orcaDir, 'jira-tokens'), { recursive: true })
+    writeFileSync(
+      join(orcaDir, 'jira-sites.json'),
+      JSON.stringify({
+        version: 1,
+        activeSiteId: siteId,
+        selectedSiteId: siteId,
+        sites: [
+          {
+            id: siteId,
+            siteUrl: 'https://jira.example.com',
+            email: '',
+            displayName: 'William',
+            accountId: 'wquintal',
+            authType: 'server'
+          }
+        ]
+      }),
+      { encoding: 'utf-8' }
+    )
+    writeFileSync(tokenPathForSite(siteId), 'pat-token')
+    netFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ name: 'wquintal', displayName: 'William' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+    const jira = await loadClientModule()
+
+    await expect(jira.testConnection(siteId)).resolves.toMatchObject({
+      ok: true,
+      viewer: { displayName: 'William' }
+    })
+
+    expect(netFetchMock).toHaveBeenCalledWith(
+      'https://jira.example.com/rest/api/2/myself',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    )
+    const headers = netFetchMock.mock.calls[0]?.[1]?.headers as Headers
+    expect(headers.get('Authorization')).toBe('Bearer pat-token')
+  })
+
   it('bridges proxy environment settings before Jira connect requests', async () => {
     netFetchMock.mockResolvedValueOnce(
       new Response(

--- a/src/main/jira/client.ts
+++ b/src/main/jira/client.ts
@@ -14,6 +14,7 @@ import {
 import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
 import { withSpan } from '../observability/tracer'
 import type {
+  JiraAuthType,
   JiraConnectArgs,
   JiraConnectionStatus,
   JiraSite,
@@ -63,6 +64,13 @@ type JiraSiteFile = {
 export type JiraClientForSite = {
   site: JiraSite
   authorization: string
+}
+
+// Self-hosted Jira Server/Data Center only exposes REST v2; Cloud endpoints
+// in this codebase are written against v3. Callers build paths with this
+// prefix so one code path serves both deployments.
+export function apiBasePath(site: JiraSite): string {
+  return site.authType === 'server' ? '/rest/api/2' : '/rest/api/3'
 }
 
 export class JiraApiError extends Error {
@@ -143,7 +151,9 @@ function normalizeSite(input: unknown): JiraSite | null {
     siteUrl: record.siteUrl,
     email: record.email,
     displayName: record.displayName,
-    accountId: record.accountId
+    accountId: record.accountId,
+    // Sites saved before self-hosted support have no authType; they are Cloud.
+    authType: record.authType === 'server' ? 'server' : 'cloud'
   }
 }
 
@@ -284,8 +294,17 @@ function getSiteId(siteUrl: string, email: string): string {
 
 function toViewer(data: Record<string, unknown>, fallbackEmail: string): JiraViewer {
   const avatarUrls = data.avatarUrls as Record<string, unknown> | undefined
+  // Server/DC /myself has no accountId; its stable identifiers are name/key.
+  const accountId =
+    typeof data.accountId === 'string'
+      ? data.accountId
+      : typeof data.name === 'string'
+        ? data.name
+        : typeof data.key === 'string'
+          ? data.key
+          : ''
   return {
-    accountId: typeof data.accountId === 'string' ? data.accountId : '',
+    accountId,
     displayName: typeof data.displayName === 'string' ? data.displayName : fallbackEmail,
     email: typeof data.emailAddress === 'string' ? data.emailAddress : fallbackEmail,
     avatarUrl:
@@ -308,7 +327,12 @@ function siteToViewer(site: JiraSite | null): JiraViewer | null {
   }
 }
 
-function authHeader(email: string, apiToken: string): string {
+function authHeader(email: string, apiToken: string, authType?: JiraAuthType): string {
+  // Server/DC personal access tokens are Bearer credentials; Basic auth with
+  // a PAT in the password slot is what produces the 401s users report.
+  if (authType === 'server') {
+    return `Bearer ${apiToken}`
+  }
   return `Basic ${Buffer.from(`${email}:${apiToken}`).toString('base64')}`
 }
 
@@ -366,13 +390,14 @@ async function requestWithCredentials(
   email: string,
   apiToken: string,
   path: string,
-  init?: RequestInit
+  init?: RequestInit,
+  authType?: JiraAuthType
 ): Promise<unknown> {
   const headers = new Headers(init?.headers)
   headers.set('Accept', 'application/json')
   headers.set('Content-Type', 'application/json')
   headers.set('User-Agent', JIRA_API_USER_AGENT)
-  headers.set('Authorization', authHeader(email, apiToken))
+  headers.set('Authorization', authHeader(email, apiToken, authType))
   const response = await jiraFetch(`${siteUrl}${path}`, {
     ...init,
     headers
@@ -453,7 +478,7 @@ export function getClients(selection?: JiraSiteSelection | null): JiraClientForS
       }
       throw error
     }
-    return token ? [{ site, authorization: authHeader(site.email, token) }] : []
+    return token ? [{ site, authorization: authHeader(site.email, token, site.authType) }] : []
   })
 }
 
@@ -484,20 +509,30 @@ export async function connect(
     return { ok: false, error: 'Enter a valid Jira site URL.' }
   }
 
+  const authType: JiraAuthType = args.authType === 'server' ? 'server' : 'cloud'
   const email = args.email.trim()
   const apiToken = args.apiToken.trim()
-  if (!email || !apiToken) {
+  if (authType === 'server') {
+    if (!apiToken) {
+      return { ok: false, error: 'Personal access token is required.' }
+    }
+  } else if (!email || !apiToken) {
     return { ok: false, error: 'Email and API token are required.' }
   }
 
   await acquire()
   try {
+    const myselfPath = authType === 'server' ? '/rest/api/2/myself' : '/rest/api/3/myself'
     const viewer = toViewer(
-      (await requestWithCredentials(siteUrl, email, apiToken, '/rest/api/3/myself')) as Record<
-        string,
-        unknown
-      >,
-      email
+      (await requestWithCredentials(
+        siteUrl,
+        email,
+        apiToken,
+        myselfPath,
+        undefined,
+        authType
+      )) as Record<string, unknown>,
+      email || siteUrl
     )
     const id = getSiteId(siteUrl, email)
     const site: JiraSite = {
@@ -505,7 +540,8 @@ export async function connect(
       siteUrl,
       email,
       displayName: viewer.displayName,
-      accountId: viewer.accountId
+      accountId: viewer.accountId,
+      authType
     }
     saveToken(id, apiToken)
     const file = getSiteFile()
@@ -565,7 +601,7 @@ export async function testConnection(
   await acquire()
   try {
     const viewer = toViewer(
-      (await jiraRequest(client, '/rest/api/3/myself')) as Record<string, unknown>,
+      (await jiraRequest(client, `${apiBasePath(client.site)}/myself`)) as Record<string, unknown>,
       client.site.email
     )
     return { ok: true, viewer }

--- a/src/main/jira/issues.test.ts
+++ b/src/main/jira/issues.test.ts
@@ -12,6 +12,8 @@ const { clearTokenMock, getClientsMock, isAuthErrorMock, jiraRequestMock } = vi.
 vi.mock('./client', () => ({
   acquire: vi.fn().mockResolvedValue(undefined),
   release: vi.fn(),
+  apiBasePath: (site: { authType?: string }) =>
+    site.authType === 'server' ? '/rest/api/2' : '/rest/api/3',
   clearToken: (...args: unknown[]) => clearTokenMock(...args),
   getClients: (...args: unknown[]) => getClientsMock(...args),
   isAuthError: (...args: unknown[]) => isAuthErrorMock(...args),
@@ -28,6 +30,20 @@ function makeEntry(id = 'site-1'): JiraClientForSite {
       accountId: 'account-1'
     },
     authorization: 'Basic token'
+  }
+}
+
+function makeServerEntry(id = 'server-1'): JiraClientForSite {
+  return {
+    site: {
+      id,
+      siteUrl: 'https://jira.example.com',
+      email: '',
+      displayName: 'Self-hosted Jira',
+      accountId: 'wquintal',
+      authType: 'server'
+    },
+    authorization: 'Bearer pat-token'
   }
 }
 
@@ -58,6 +74,67 @@ describe('Jira issue operations', () => {
         title: 'Fix auth'
       })
     ).rejects.toThrow(error.message)
+  })
+
+  it('uses classic /search and REST v2 for self-hosted sites', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValueOnce({ issues: [] })
+    const { searchIssues } = await import('./issues')
+
+    await searchIssues('project = ALP', 20, 'server-1')
+
+    expect(jiraRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ site: expect.objectContaining({ authType: 'server' }) }),
+      '/rest/api/2/search',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('sends plain-text bodies and v2 paths for self-hosted issue creation', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValueOnce({ id: '1', key: 'ALP-1', self: '' })
+    const { createIssue } = await import('./issues')
+
+    await createIssue({
+      siteId: 'server-1',
+      projectId: '10000',
+      issueTypeId: '10001',
+      title: 'Fix auth',
+      description: 'Body text'
+    })
+
+    const [, path, init] = jiraRequestMock.mock.calls[0]
+    expect(path).toBe('/rest/api/2/issue')
+    const body = JSON.parse((init as { body: string }).body) as {
+      fields: { description: unknown }
+    }
+    // REST v2 rejects ADF documents; the description must stay a plain string.
+    expect(body.fields.description).toBe('Body text')
+  })
+
+  it('assigns by username on self-hosted sites', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValue(null)
+    const { updateIssue } = await import('./issues')
+
+    await updateIssue('ALP-1', { assigneeAccountId: 'wquintal' }, 'server-1')
+
+    expect(jiraRequestMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '/rest/api/2/issue/ALP-1/assignee',
+      expect.objectContaining({ body: JSON.stringify({ name: 'wquintal' }) })
+    )
+  })
+
+  it('lists self-hosted projects from the unpaged /project resource', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValueOnce([{ id: '1', key: 'ALP', name: 'Alpha' }])
+    const { listProjects } = await import('./issues')
+
+    const projects = await listProjects('server-1')
+
+    expect(jiraRequestMock).toHaveBeenCalledWith(expect.anything(), '/rest/api/2/project')
+    expect(projects).toMatchObject([{ key: 'ALP', name: 'Alpha' }])
   })
 
   it('rejects single-site search failures so the UI can surface them', async () => {

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -22,6 +22,7 @@ import type {
 } from '../../shared/types'
 import {
   acquire,
+  apiBasePath,
   clearToken,
   getClients,
   isAuthError,
@@ -183,7 +184,8 @@ function avatarUrl(value: unknown): string | undefined {
 
 function mapUser(value: unknown): JiraUser | undefined {
   const user = asRecord(value)
-  const accountId = asString(user.accountId)
+  // Server/DC users have no accountId; name (login) and key are its stable ids.
+  const accountId = asString(user.accountId) || asString(user.name) || asString(user.key)
   if (!accountId) {
     return undefined
   }
@@ -299,6 +301,11 @@ function issueUrl(site: JiraSite, key: string): string {
   return `${site.siteUrl}/browse/${encodeURIComponent(key)}`
 }
 
+// REST v2 (Server/DC) bodies are plain text; v3 (Cloud) requires ADF documents.
+function toBodyText(site: JiraSite, text: string): unknown {
+  return site.authType === 'server' ? text : textToAdf(text)
+}
+
 export function mapJiraIssue(site: JiraSite, raw: JiraRecord): JiraIssue {
   const fields = asRecord(raw.fields)
   const key = asString(raw.key)
@@ -346,7 +353,12 @@ async function searchIssuesForClient(
   jql: string,
   limit: number
 ): Promise<JiraIssue[]> {
-  const result = await jiraRequest<JiraSearchResponse>(entry, '/rest/api/3/search/jql', {
+  // Server/DC only has the classic /search resource; /search/jql is Cloud-only.
+  const searchPath =
+    entry.site.authType === 'server'
+      ? `${apiBasePath(entry.site)}/search`
+      : '/rest/api/3/search/jql'
+  const result = await jiraRequest<JiraSearchResponse>(entry, searchPath, {
     method: 'POST',
     body: JSON.stringify({
       jql,
@@ -421,7 +433,7 @@ export async function getIssue(
     try {
       const issue = await jiraRequest<JiraRecord>(
         entry,
-        `/rest/api/3/issue/${encodeURIComponent(key)}?fields=${encodeURIComponent(
+        `${apiBasePath(entry.site)}/issue/${encodeURIComponent(key)}?fields=${encodeURIComponent(
           ISSUE_FIELDS.join(',')
         )}`
       )
@@ -460,7 +472,7 @@ export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreate
       summary: title
     }
     if (args.description?.trim()) {
-      fields.description = textToAdf(args.description.trim())
+      fields.description = toBodyText(entry.site, args.description.trim())
     }
     for (const [fieldKey, value] of Object.entries(args.customFields ?? {})) {
       if (!fieldKey || value === undefined || value === null || value === '') {
@@ -470,7 +482,7 @@ export async function createIssue(args: JiraCreateIssueArgs): Promise<JiraCreate
     }
     const created = await jiraRequest<{ id: string; key: string; self: string }>(
       entry,
-      '/rest/api/3/issue',
+      `${apiBasePath(entry.site)}/issue`,
       {
         method: 'POST',
         body: JSON.stringify({ fields })
@@ -509,20 +521,27 @@ export async function updateIssue(
     if (updates.priorityId !== undefined) {
       fields.priority = updates.priorityId ? { id: updates.priorityId } : null
     }
+    const issueBase = `${apiBasePath(entry.site)}/issue/${encodeURIComponent(key)}`
     if (Object.keys(fields).length > 0) {
-      await jiraRequest(entry, `/rest/api/3/issue/${encodeURIComponent(key)}`, {
+      await jiraRequest(entry, issueBase, {
         method: 'PUT',
         body: JSON.stringify({ fields })
       })
     }
     if (updates.assigneeAccountId !== undefined) {
-      await jiraRequest(entry, `/rest/api/3/issue/${encodeURIComponent(key)}/assignee`, {
+      // Server/DC identifies assignees by username (`name`), not accountId;
+      // mapUser stores the Server username in the accountId slot.
+      const assigneeBody =
+        entry.site.authType === 'server'
+          ? { name: updates.assigneeAccountId }
+          : { accountId: updates.assigneeAccountId }
+      await jiraRequest(entry, `${issueBase}/assignee`, {
         method: 'PUT',
-        body: JSON.stringify({ accountId: updates.assigneeAccountId })
+        body: JSON.stringify(assigneeBody)
       })
     }
     if (updates.transitionId) {
-      await jiraRequest(entry, `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`, {
+      await jiraRequest(entry, `${issueBase}/transitions`, {
         method: 'POST',
         body: JSON.stringify({ transition: { id: updates.transitionId } })
       })
@@ -552,10 +571,10 @@ export async function addIssueComment(
   try {
     const comment = await jiraRequest<{ id: string }>(
       entry,
-      `/rest/api/3/issue/${encodeURIComponent(key)}/comment`,
+      `${apiBasePath(entry.site)}/issue/${encodeURIComponent(key)}/comment`,
       {
         method: 'POST',
-        body: JSON.stringify({ body: textToAdf(body) })
+        body: JSON.stringify({ body: toBodyText(entry.site, body) })
       }
     )
     return { ok: true, id: comment.id }
@@ -596,7 +615,7 @@ export async function getIssueComments(
         orderBy: 'created',
         startAt: String(startAt)
       })
-      return `/rest/api/3/issue/${encodeURIComponent(key)}/comment?${params.toString()}`
+      return `${apiBasePath(entry.site)}/issue/${encodeURIComponent(key)}/comment?${params.toString()}`
     })
     return comments.map(mapComment)
   } catch (error) {
@@ -620,13 +639,18 @@ export async function listProjects(siteId?: JiraSiteSelection | null): Promise<J
     entries.map(async (entry) => {
       await acquire()
       try {
-        const projects = await fetchPagedRecords(entry, 'values', (startAt, maxResults) => {
-          const params = new URLSearchParams({
-            maxResults: String(maxResults),
-            startAt: String(startAt)
-          })
-          return `/rest/api/3/project/search?${params.toString()}`
-        })
+        // Server/DC has no /project/search resource; /project returns the
+        // full list as a plain (unpaged) array.
+        const projects =
+          entry.site.authType === 'server'
+            ? await jiraRequest<JiraRecord[]>(entry, `${apiBasePath(entry.site)}/project`)
+            : await fetchPagedRecords(entry, 'values', (startAt, maxResults) => {
+                const params = new URLSearchParams({
+                  maxResults: String(maxResults),
+                  startAt: String(startAt)
+                })
+                return `/rest/api/3/project/search?${params.toString()}`
+              })
         return projects.map((project) => mapProject(project, entry.site))
       } catch (error) {
         if (isAuthError(error)) {
@@ -661,7 +685,8 @@ export async function listIssueTypes(
         maxResults: String(maxResults),
         startAt: String(startAt)
       })
-      return `/rest/api/3/issue/createmeta/${encodeURIComponent(
+      // Per-project createmeta paths exist on Server/DC from Jira 8.4 onward.
+      return `${apiBasePath(entry.site)}/issue/createmeta/${encodeURIComponent(
         projectIdOrKey
       )}/issuetypes?${params.toString()}`
     })
@@ -699,7 +724,7 @@ export async function listCreateFields(
       })
       const response = await jiraRequest<JiraPagedResponse<JiraRecord>>(
         entry,
-        `/rest/api/3/issue/createmeta/${encodeURIComponent(
+        `${apiBasePath(entry.site)}/issue/createmeta/${encodeURIComponent(
           projectIdOrKey
         )}/issuetypes/${encodeURIComponent(issueTypeId)}?${params.toString()}`
       )
@@ -734,7 +759,7 @@ export async function listPriorities(siteId?: string | null): Promise<JiraPriori
   }
   await acquire()
   try {
-    const response = await jiraRequest<JiraRecord[]>(entry, '/rest/api/3/priority')
+    const response = await jiraRequest<JiraRecord[]>(entry, `${apiBasePath(entry.site)}/priority`)
     return response.map(mapPriority).filter((priority): priority is JiraPriority => !!priority)
   } catch (error) {
     if (isAuthError(error)) {
@@ -757,15 +782,17 @@ export async function listAssignableUsers(
   if (!entry) {
     return []
   }
+  const isServer = entry.site.authType === 'server'
   const params = new URLSearchParams({ issueKey: key, maxResults: '50' })
   if (query?.trim()) {
-    params.set('query', query.trim())
+    // Server/DC filters assignable users by `username`; `query` is Cloud-only.
+    params.set(isServer ? 'username' : 'query', query.trim())
   }
   await acquire()
   try {
     const response = await jiraRequest<JiraRecord[]>(
       entry,
-      `/rest/api/3/user/assignable/search?${params.toString()}`
+      `${apiBasePath(entry.site)}/user/assignable/search?${params.toString()}`
     )
     return response.map(mapUser).filter((user): user is JiraUser => !!user)
   } catch (error) {
@@ -792,7 +819,7 @@ export async function listTransitions(
   try {
     const response = await jiraRequest<{ transitions?: JiraRecord[] }>(
       entry,
-      `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`
+      `${apiBasePath(entry.site)}/issue/${encodeURIComponent(key)}/transitions`
     )
     return (response.transitions ?? []).map((transition) => ({
       id: asString(transition.id),

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -17,8 +17,10 @@ const SiteSelection = z
 
 const Connect = z.object({
   siteUrl: requiredString('Site URL is required'),
-  email: requiredString('Email is required'),
-  apiToken: requiredString('API token is required')
+  // Self-hosted PAT auth needs no email; connect() enforces it for Cloud.
+  email: OptionalPlainString,
+  apiToken: requiredString('API token is required'),
+  authType: z.enum(['cloud', 'server']).optional()
 })
 
 const SelectSite = z.object({
@@ -95,8 +97,9 @@ export const JIRA_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) =>
       runtime.jiraConnect({
         siteUrl: params.siteUrl.trim(),
-        email: params.email.trim(),
-        apiToken: params.apiToken.trim()
+        email: params.email?.trim() ?? '',
+        apiToken: params.apiToken.trim(),
+        authType: params.authType
       })
   }),
   defineMethod({

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1797,6 +1797,7 @@ export type PreloadApi = {
       siteUrl: string
       email: string
       apiToken: string
+      authType?: 'cloud' | 'server'
     }) => Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }>
     disconnect: (args?: { siteId?: string }) => Promise<void>
     selectSite: (args: { siteId: JiraSiteSelection }) => Promise<JiraConnectionStatus>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1549,6 +1549,7 @@ const api = {
       siteUrl: string
       email: string
       apiToken: string
+      authType?: 'cloud' | 'server'
     }): Promise<{ ok: true; viewer: unknown } | { ok: false; error: string }> =>
       ipcRenderer.invoke('jira:connect', args),
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -27,7 +27,6 @@ import {
   GitPullRequestDraft,
   List,
   LoaderCircle,
-  Lock,
   Minus,
   Plus,
   RefreshCw,
@@ -90,6 +89,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import TaskProjectSourceCombobox from '@/components/task-project-source-combobox'
+import { JiraConnectDialog } from '@/components/jira-connect-dialog'
 import { LinearApiKeyDialog } from '@/components/linear-api-key-dialog'
 import { LinearScopeSelector } from '@/components/linear-scope-selector'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
@@ -3069,7 +3069,6 @@ export default function TaskPage(): React.JSX.Element {
   const jiraStatus = useAppStore((s) => s.jiraStatus)
   const jiraStatusChecked = useAppStore((s) => s.jiraStatusChecked)
   const jiraStatusContextKey = useAppStore((s) => s.jiraStatusContextKey)
-  const connectJira = useAppStore((s) => s.connectJira)
   const selectJiraSite = useAppStore((s) => s.selectJiraSite)
   const searchJiraIssues = useAppStore((s) => s.searchJiraIssues)
   const listJiraIssues = useAppStore((s) => s.listJiraIssues)
@@ -5616,11 +5615,6 @@ export default function TaskPage(): React.JSX.Element {
     Record<string, string>
   >({})
   const [jiraConnectOpen, setJiraConnectOpen] = useState(false)
-  const [jiraSiteUrlDraft, setJiraSiteUrlDraft] = useState('')
-  const [jiraEmailDraft, setJiraEmailDraft] = useState('')
-  const [jiraApiTokenDraft, setJiraApiTokenDraft] = useState('')
-  const [jiraConnectState, setJiraConnectState] = useState<'idle' | 'connecting' | 'error'>('idle')
-  const [jiraConnectError, setJiraConnectError] = useState<string | null>(null)
   const includeJiraSiteNameInProjectLabel = selectedJiraSiteId === 'all'
   const previousProviderRuntimeContextKeyRef = useRef(providerRuntimeContextKey)
 
@@ -7778,33 +7772,6 @@ export default function TaskPage(): React.JSX.Element {
     [openComposerForJiraItem]
   )
 
-  const handleJiraConnect = useCallback(async (): Promise<void> => {
-    const siteUrl = jiraSiteUrlDraft.trim()
-    const email = jiraEmailDraft.trim()
-    const apiToken = jiraApiTokenDraft.trim()
-    if (!siteUrl || !email || !apiToken) {
-      return
-    }
-    setJiraConnectState('connecting')
-    setJiraConnectError(null)
-    try {
-      const result = await connectJira({ siteUrl, email, apiToken })
-      if (result.ok) {
-        setJiraSiteUrlDraft('')
-        setJiraEmailDraft('')
-        setJiraApiTokenDraft('')
-        setJiraConnectState('idle')
-        setJiraConnectOpen(false)
-      } else {
-        setJiraConnectState('error')
-        setJiraConnectError(result.error)
-      }
-    } catch (error) {
-      setJiraConnectState('error')
-      setJiraConnectError(error instanceof Error ? error.message : 'Connection failed')
-    }
-  }, [connectJira, jiraApiTokenDraft, jiraEmailDraft, jiraSiteUrlDraft])
-
   const taskPageListChromeHidden = shouldHideTaskPageListChrome({
     taskSource,
     hasGitHubDetail: Boolean(dialogWorkItem),
@@ -9722,16 +9689,7 @@ export default function TaskPage(): React.JSX.Element {
                   )}
                 </p>
                 <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
-                  <Button
-                    onClick={() => {
-                      setJiraSiteUrlDraft('')
-                      setJiraEmailDraft('')
-                      setJiraApiTokenDraft('')
-                      setJiraConnectState('idle')
-                      setJiraConnectError(null)
-                      setJiraConnectOpen(true)
-                    }}
-                  >
+                  <Button onClick={() => setJiraConnectOpen(true)}>
                     {translate('auto.components.TaskPage.83bce6be5c', 'Connect Jira')}
                   </Button>
                   <Button variant="outline" onClick={() => hideTaskSource('jira', 'Jira')}>
@@ -12465,137 +12423,7 @@ export default function TaskPage(): React.JSX.Element {
         onConnected={handleLinearAccessConnected}
       />
 
-      <Dialog
-        open={jiraConnectOpen}
-        onOpenChange={(open) => {
-          if (jiraConnectState !== 'connecting') {
-            setJiraConnectOpen(open)
-          }
-        }}
-      >
-        <DialogContent
-          className="sm:max-w-md"
-          onKeyDown={(e) => {
-            if (
-              e.key === 'Enter' &&
-              jiraSiteUrlDraft.trim() &&
-              jiraEmailDraft.trim() &&
-              jiraApiTokenDraft.trim() &&
-              jiraConnectState !== 'connecting'
-            ) {
-              e.preventDefault()
-              void handleJiraConnect()
-            }
-          }}
-        >
-          <DialogHeader className="gap-3">
-            <DialogTitle className="leading-tight">
-              {translate('auto.components.TaskPage.60f806ce99', 'Connect Jira site')}
-            </DialogTitle>
-            <DialogDescription>
-              {translate(
-                'auto.components.TaskPage.33fc2bcb30',
-                'Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.'
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-3">
-            <Input
-              autoFocus
-              placeholder={translate(
-                'auto.components.TaskPage.163df31e0e',
-                'https://example.atlassian.net'
-              )}
-              value={jiraSiteUrlDraft}
-              onChange={(e) => {
-                setJiraSiteUrlDraft(e.target.value)
-                if (jiraConnectState === 'error') {
-                  setJiraConnectState('idle')
-                  setJiraConnectError(null)
-                }
-              }}
-              disabled={jiraConnectState === 'connecting'}
-            />
-            <Input
-              type="email"
-              placeholder={translate('auto.components.TaskPage.68df347677', 'you@example.com')}
-              value={jiraEmailDraft}
-              onChange={(e) => {
-                setJiraEmailDraft(e.target.value)
-                if (jiraConnectState === 'error') {
-                  setJiraConnectState('idle')
-                  setJiraConnectError(null)
-                }
-              }}
-              disabled={jiraConnectState === 'connecting'}
-            />
-            <Input
-              type="password"
-              placeholder={translate('auto.components.TaskPage.b95623e93f', 'Atlassian API token')}
-              value={jiraApiTokenDraft}
-              onChange={(e) => {
-                setJiraApiTokenDraft(e.target.value)
-                if (jiraConnectState === 'error') {
-                  setJiraConnectState('idle')
-                  setJiraConnectError(null)
-                }
-              }}
-              disabled={jiraConnectState === 'connecting'}
-            />
-            {jiraConnectState === 'error' && jiraConnectError && (
-              <p className="text-xs text-destructive">{jiraConnectError}</p>
-            )}
-            <p className="text-xs text-muted-foreground">
-              {translate('auto.components.TaskPage.59c14d34a2', 'Create a token in')}{' '}
-              <button
-                className="text-primary underline-offset-2 hover:underline"
-                onClick={() =>
-                  window.api.shell.openUrl(
-                    'https://id.atlassian.com/manage-profile/security/api-tokens'
-                  )
-                }
-              >
-                {translate('auto.components.TaskPage.246c2b3dd3', 'Atlassian account settings')}
-              </button>
-              .
-            </p>
-            <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
-              <Lock className="size-3 shrink-0" />
-              {translate(
-                'auto.components.TaskPage.2abe22ef76',
-                'Your token is encrypted via the OS keychain and stored locally.'
-              )}
-            </p>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setJiraConnectOpen(false)}
-              disabled={jiraConnectState === 'connecting'}
-            >
-              {translate('auto.components.TaskPage.ff69a30681', 'Cancel')}
-            </Button>
-            <Button
-              onClick={() => void handleJiraConnect()}
-              disabled={
-                !jiraSiteUrlDraft.trim() ||
-                !jiraEmailDraft.trim() ||
-                !jiraApiTokenDraft.trim() ||
-                jiraConnectState === 'connecting'
-              }
-            >
-              {jiraConnectState === 'connecting' ? (
-                <>
-                  <LoaderCircle className="size-4 animate-spin" />
-                  {translate('auto.components.TaskPage.513cddfa7a', 'Verifying…')}
-                </>
-              ) : (
-                translate('auto.components.TaskPage.887efe9140', 'Connect')
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <JiraConnectDialog open={jiraConnectOpen} onOpenChange={setJiraConnectOpen} />
     </div>
   )
 }

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -5566,6 +5566,7 @@ export default function TaskPage(): React.JSX.Element {
   }, [newLinearStates.data, newLinearIssueStateId])
 
   const [linearConnectOpen, setLinearConnectOpen] = useState(false)
+  const [jiraConnectOpen, setJiraConnectOpen] = useState(false)
   useContextualTour(
     'tasks',
     !dialogWorkItem &&
@@ -5575,6 +5576,7 @@ export default function TaskPage(): React.JSX.Element {
       !newLinearProjectOpen &&
       !newLinearIssueOpen &&
       !linearConnectOpen &&
+      !jiraConnectOpen &&
       activeModal === 'none',
     'tasks_open'
   )
@@ -5614,7 +5616,6 @@ export default function TaskPage(): React.JSX.Element {
   const [newJiraIssueCustomFieldValues, setNewJiraIssueCustomFieldValues] = useState<
     Record<string, string>
   >({})
-  const [jiraConnectOpen, setJiraConnectOpen] = useState(false)
   const includeJiraSiteNameInProjectLabel = selectedJiraSiteId === 'all'
   const previousProviderRuntimeContextKeyRef = useRef(providerRuntimeContextKey)
 

--- a/src/renderer/src/components/jira-connect-dialog.tsx
+++ b/src/renderer/src/components/jira-connect-dialog.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { cn } from '@/lib/utils'
 import { hasRemoteProviderRuntime } from '@/lib/provider-runtime-context'
 import { translate } from '@/i18n/i18n'
@@ -26,6 +27,7 @@ type JiraConnectDialogProps = {
 }
 
 type ConnectState = 'idle' | 'connecting' | 'error'
+type JiraInstanceType = 'cloud' | 'server'
 
 // Why: mirrors the inline Jira connect dialog in TaskPage so the onboarding
 // "Connect integrations" step can reuse the same site URL + email + API token
@@ -45,15 +47,17 @@ export function JiraConnectDialog({
   const tokenId = useId()
   const errorId = useId()
 
+  const [instanceType, setInstanceType] = useState<JiraInstanceType>('cloud')
   const [siteUrl, setSiteUrl] = useState('')
   const [email, setEmail] = useState('')
   const [apiToken, setApiToken] = useState('')
   const [connectState, setConnectState] = useState<ConnectState>('idle')
   const [connectError, setConnectError] = useState<string | null>(null)
 
+  const isServer = instanceType === 'server'
   const canSubmit =
     Boolean(siteUrl.trim()) &&
-    Boolean(email.trim()) &&
+    (isServer || Boolean(email.trim())) &&
     Boolean(apiToken.trim()) &&
     connectState !== 'connecting'
   const credentialStorageCopy = hasRemoteProviderRuntime(settings)
@@ -77,7 +81,12 @@ export function JiraConnectDialog({
     const trimmedSite = siteUrl.trim()
     const trimmedEmail = email.trim()
     const trimmedToken = apiToken.trim()
-    if (!trimmedSite || !trimmedEmail || !trimmedToken || connectState === 'connecting') {
+    if (
+      !trimmedSite ||
+      (!isServer && !trimmedEmail) ||
+      !trimmedToken ||
+      connectState === 'connecting'
+    ) {
       return
     }
     setConnectState('connecting')
@@ -86,7 +95,8 @@ export function JiraConnectDialog({
       const result = await connectJira({
         siteUrl: trimmedSite,
         email: trimmedEmail,
-        apiToken: trimmedToken
+        apiToken: trimmedToken,
+        authType: instanceType
       })
       if (!mountedRef.current) {
         return
@@ -95,6 +105,7 @@ export function JiraConnectDialog({
         setSiteUrl('')
         setEmail('')
         setApiToken('')
+        setInstanceType('cloud')
         setConnectState('idle')
         onOpenChange(false)
         onConnected?.()
@@ -121,10 +132,15 @@ export function JiraConnectDialog({
             {translate('auto.components.jira.connect.dialog.8388bdea2b', 'Connect Jira site')}
           </DialogTitle>
           <DialogDescription>
-            {translate(
-              'auto.components.jira.connect.dialog.d785c42b8b',
-              'Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.'
-            )}
+            {isServer
+              ? translate(
+                  'auto.components.jira.connect.dialog.2e2b69e48e',
+                  'Use a self-hosted Jira base URL and a personal access token to browse issues.'
+                )
+              : translate(
+                  'auto.components.jira.connect.dialog.d785c42b8b',
+                  'Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.'
+                )}
           </DialogDescription>
         </DialogHeader>
         <form
@@ -135,17 +151,52 @@ export function JiraConnectDialog({
           }}
         >
           <div className="flex flex-col gap-3">
+            <ToggleGroup
+              type="single"
+              variant="outline"
+              value={instanceType}
+              onValueChange={(value) => {
+                if (!value || connectState === 'connecting') {
+                  return
+                }
+                setInstanceType(value as JiraInstanceType)
+                clearErrorOnEdit()
+              }}
+              aria-label={translate(
+                'auto.components.jira.connect.dialog.b67e919bd5',
+                'Jira instance type'
+              )}
+            >
+              <ToggleGroupItem value="cloud" className="h-8 px-3 text-xs">
+                {translate('auto.components.jira.connect.dialog.17787d6e4b', 'Atlassian Cloud')}
+              </ToggleGroupItem>
+              <ToggleGroupItem value="server" className="h-8 px-3 text-xs">
+                {translate('auto.components.jira.connect.dialog.bc7a831773', 'Self-hosted')}
+              </ToggleGroupItem>
+            </ToggleGroup>
             <div className="space-y-2">
               <Label htmlFor={siteUrlId} className="text-xs">
-                {translate('auto.components.jira.connect.dialog.e176f9d0c5', 'Jira Cloud site URL')}
+                {isServer
+                  ? translate('auto.components.jira.connect.dialog.3489e186d6', 'Jira site URL')
+                  : translate(
+                      'auto.components.jira.connect.dialog.e176f9d0c5',
+                      'Jira Cloud site URL'
+                    )}
               </Label>
               <Input
                 id={siteUrlId}
                 autoFocus
-                placeholder={translate(
-                  'auto.components.jira.connect.dialog.70fcd360c4',
-                  'https://example.atlassian.net'
-                )}
+                placeholder={
+                  isServer
+                    ? translate(
+                        'auto.components.jira.connect.dialog.cbc27fa599',
+                        'https://jira.example.com'
+                      )
+                    : translate(
+                        'auto.components.jira.connect.dialog.70fcd360c4',
+                        'https://example.atlassian.net'
+                      )
+                }
                 value={siteUrl}
                 onChange={(event) => {
                   setSiteUrl(event.target.value)
@@ -154,36 +205,50 @@ export function JiraConnectDialog({
                 disabled={connectState === 'connecting'}
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor={emailId} className="text-xs">
-                {translate('auto.components.jira.connect.dialog.2849ddb295', 'Atlassian email')}
-              </Label>
-              <Input
-                id={emailId}
-                type="email"
-                placeholder={translate(
-                  'auto.components.jira.connect.dialog.e91b9a4073',
-                  'you@example.com'
-                )}
-                value={email}
-                onChange={(event) => {
-                  setEmail(event.target.value)
-                  clearErrorOnEdit()
-                }}
-                disabled={connectState === 'connecting'}
-              />
-            </div>
+            {!isServer ? (
+              <div className="space-y-2">
+                <Label htmlFor={emailId} className="text-xs">
+                  {translate('auto.components.jira.connect.dialog.2849ddb295', 'Atlassian email')}
+                </Label>
+                <Input
+                  id={emailId}
+                  type="email"
+                  placeholder={translate(
+                    'auto.components.jira.connect.dialog.e91b9a4073',
+                    'you@example.com'
+                  )}
+                  value={email}
+                  onChange={(event) => {
+                    setEmail(event.target.value)
+                    clearErrorOnEdit()
+                  }}
+                  disabled={connectState === 'connecting'}
+                />
+              </div>
+            ) : null}
             <div className="space-y-2">
               <Label htmlFor={tokenId} className="text-xs">
-                {translate('auto.components.jira.connect.dialog.3d81bf3ab3', 'API token')}
+                {isServer
+                  ? translate(
+                      'auto.components.jira.connect.dialog.730d973bae',
+                      'Personal access token'
+                    )
+                  : translate('auto.components.jira.connect.dialog.3d81bf3ab3', 'API token')}
               </Label>
               <Input
                 id={tokenId}
                 type="password"
-                placeholder={translate(
-                  'auto.components.jira.connect.dialog.7b3967c12f',
-                  'Atlassian API token'
-                )}
+                placeholder={
+                  isServer
+                    ? translate(
+                        'auto.components.jira.connect.dialog.8b9c7b9e7b',
+                        'Jira personal access token'
+                      )
+                    : translate(
+                        'auto.components.jira.connect.dialog.7b3967c12f',
+                        'Atlassian API token'
+                      )
+                }
                 value={apiToken}
                 onChange={(event) => {
                   setApiToken(event.target.value)
@@ -199,24 +264,33 @@ export function JiraConnectDialog({
                 {connectError}
               </p>
             ) : null}
-            <p className="text-xs text-muted-foreground">
-              {translate('auto.components.jira.connect.dialog.8090504a3e', 'Create a token in')}{' '}
-              <button
-                type="button"
-                className="text-primary underline-offset-2 hover:underline"
-                onClick={() =>
-                  window.api.shell.openUrl(
-                    'https://id.atlassian.com/manage-profile/security/api-tokens'
-                  )
-                }
-              >
+            {isServer ? (
+              <p className="text-xs text-muted-foreground">
                 {translate(
-                  'auto.components.jira.connect.dialog.fdd26d81cc',
-                  'Atlassian account settings'
+                  'auto.components.jira.connect.dialog.ccfb086d3e',
+                  'Create a personal access token in your Jira profile under Personal Access Tokens.'
                 )}
-              </button>
-              .
-            </p>
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                {translate('auto.components.jira.connect.dialog.8090504a3e', 'Create a token in')}{' '}
+                <button
+                  type="button"
+                  className="text-primary underline-offset-2 hover:underline"
+                  onClick={() =>
+                    window.api.shell.openUrl(
+                      'https://id.atlassian.com/manage-profile/security/api-tokens'
+                    )
+                  }
+                >
+                  {translate(
+                    'auto.components.jira.connect.dialog.fdd26d81cc',
+                    'Atlassian account settings'
+                  )}
+                </button>
+                .
+              </p>
+            )}
             <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
               <Lock className="size-3 shrink-0" />
               {credentialStorageCopy}

--- a/src/renderer/src/components/jira-connect-dialog.tsx
+++ b/src/renderer/src/components/jira-connect-dialog.tsx
@@ -94,7 +94,9 @@ export function JiraConnectDialog({
     try {
       const result = await connectJira({
         siteUrl: trimmedSite,
-        email: trimmedEmail,
+        // Drop any email typed before toggling to self-hosted: the value is
+        // ignored for PAT auth but would otherwise key/label the stored site.
+        email: isServer ? '' : trimmedEmail,
         apiToken: trimmedToken,
         authType: instanceType
       })

--- a/src/renderer/src/components/settings/jira-integration-card.tsx
+++ b/src/renderer/src/components/settings/jira-integration-card.tsx
@@ -38,8 +38,8 @@ export function JiraIntegrationCard(): React.JSX.Element {
   const siteCount = sites.length || (connected ? 1 : 0)
   const accountScope = getProviderAccountScope(settings)
   const credentialCopy = hasRemoteProviderRuntime(settings)
-    ? 'Connect a Jira Cloud site with your Atlassian email and an API token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.'
-    : 'Connect a Jira Cloud site with your Atlassian email and an API token. Credentials are stored locally and encrypted when local runtime storage supports it.'
+    ? 'Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.'
+    : 'Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are stored locally and encrypted when local runtime storage supports it.'
   const subordinateRowClass = useIntegrationSubordinateRowClass('flex items-center gap-3')
   const accountScopeRowClass = useIntegrationSubordinateRowClass('text-xs')
 

--- a/src/renderer/src/components/settings/jira-integration-card.tsx
+++ b/src/renderer/src/components/settings/jira-integration-card.tsx
@@ -38,8 +38,14 @@ export function JiraIntegrationCard(): React.JSX.Element {
   const siteCount = sites.length || (connected ? 1 : 0)
   const accountScope = getProviderAccountScope(settings)
   const credentialCopy = hasRemoteProviderRuntime(settings)
-    ? 'Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.'
-    : 'Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are stored locally and encrypted when local runtime storage supports it.'
+    ? translate(
+        'auto.components.settings.task.tracker.integration.cards.2d60ec7921',
+        'Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.'
+      )
+    : translate(
+        'auto.components.settings.task.tracker.integration.cards.977e360b71',
+        'Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are stored locally and encrypted when local runtime storage supports it.'
+      )
   const subordinateRowClass = useIntegrationSubordinateRowClass('flex items-center gap-3')
   const accountScopeRowClass = useIntegrationSubordinateRowClass('text-xs')
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12209,7 +12209,16 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud site URL",
             "d785c42b8b": "Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.",
-            "8388bdea2b": "Connect Jira site"
+            "8388bdea2b": "Connect Jira site",
+            "2e2b69e48e": "Use a self-hosted Jira base URL and a personal access token to browse issues.",
+            "b67e919bd5": "Jira instance type",
+            "17787d6e4b": "Atlassian Cloud",
+            "bc7a831773": "Self-hosted",
+            "3489e186d6": "Jira site URL",
+            "cbc27fa599": "https://jira.example.com",
+            "730d973bae": "Personal access token",
+            "8b9c7b9e7b": "Jira personal access token",
+            "ccfb086d3e": "Create a personal access token in your Jira profile under Personal Access Tokens."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8465,7 +8465,9 @@
                 "fe9231215b": "Checking Linear access before showing setup actions.",
                 "e1f5e6424c": "{{value0}} workspace{{value1}} connected",
                 "disconnect_all": "Disconnect",
-                "account_scope_prefix": "Account scope"
+                "account_scope_prefix": "Account scope",
+                "2d60ec7921": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
+                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are stored locally and encrypted when local runtime storage supports it."
               }
             }
           }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12209,7 +12209,16 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "URL del sitio de Jira Cloud",
             "d785c42b8b": "Usa una URL de Jira Cloud, email de Atlassian y token API para explorar issues.",
-            "8388bdea2b": "Conectar sitio de Jira"
+            "8388bdea2b": "Conectar sitio de Jira",
+            "2e2b69e48e": "Use a self-hosted Jira base URL and a personal access token to browse issues.",
+            "b67e919bd5": "Jira instance type",
+            "17787d6e4b": "Atlassian Cloud",
+            "bc7a831773": "Self-hosted",
+            "3489e186d6": "Jira site URL",
+            "cbc27fa599": "https://jira.example.com",
+            "730d973bae": "Personal access token",
+            "8b9c7b9e7b": "Jira personal access token",
+            "ccfb086d3e": "Create a personal access token in your Jira profile under Personal Access Tokens."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8457,7 +8457,9 @@
                 "fe9231215b": "Comprobando el acceso a Linear antes de mostrar las acciones de configuración.",
                 "e1f5e6424c": "Conexión completada para {{value0}} workspace{{value1}}",
                 "disconnect_all": "Desconectar todo",
-                "account_scope_prefix": "Alcance de la cuenta"
+                "account_scope_prefix": "Alcance de la cuenta",
+                "2d60ec7921": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
+                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are stored locally and encrypted when local runtime storage supports it."
               }
             }
           }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8457,7 +8457,9 @@
                 "fe9231215b": "Checking Linear access before showing setup actions.",
                 "e1f5e6424c": "{{value0}} workspace{{value1}} connected",
                 "disconnect_all": "切断",
-                "account_scope_prefix": "Account scope"
+                "account_scope_prefix": "Account scope",
+                "2d60ec7921": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
+                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are stored locally and encrypted when local runtime storage supports it."
               }
             }
           }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -12209,7 +12209,16 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud site URL",
             "d785c42b8b": "Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.",
-            "8388bdea2b": "Connect Jira site"
+            "8388bdea2b": "Connect Jira site",
+            "2e2b69e48e": "Use a self-hosted Jira base URL and a personal access token to browse issues.",
+            "b67e919bd5": "Jira instance type",
+            "17787d6e4b": "Atlassian Cloud",
+            "bc7a831773": "Self-hosted",
+            "3489e186d6": "Jira site URL",
+            "cbc27fa599": "https://jira.example.com",
+            "730d973bae": "Personal access token",
+            "8b9c7b9e7b": "Jira personal access token",
+            "ccfb086d3e": "Create a personal access token in your Jira profile under Personal Access Tokens."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -12209,7 +12209,16 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud 사이트 URL",
             "d785c42b8b": "Jira Cloud 사이트 URL, Atlassian 이메일, API 토큰을 사용해 이슈를 탐색합니다.",
-            "8388bdea2b": "Jira 사이트 연결"
+            "8388bdea2b": "Jira 사이트 연결",
+            "2e2b69e48e": "Use a self-hosted Jira base URL and a personal access token to browse issues.",
+            "b67e919bd5": "Jira instance type",
+            "17787d6e4b": "Atlassian Cloud",
+            "bc7a831773": "Self-hosted",
+            "3489e186d6": "Jira site URL",
+            "cbc27fa599": "https://jira.example.com",
+            "730d973bae": "Personal access token",
+            "8b9c7b9e7b": "Jira personal access token",
+            "ccfb086d3e": "Create a personal access token in your Jira profile under Personal Access Tokens."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8457,7 +8457,9 @@
                 "fe9231215b": "설정 작업을 표시하기 전에 Linear 액세스를 확인하는 중입니다.",
                 "e1f5e6424c": "{{value0}}개 워크스페이스{{value1}} 연결됨",
                 "disconnect_all": "연결 해제",
-                "account_scope_prefix": "계정 범위"
+                "account_scope_prefix": "계정 범위",
+                "2d60ec7921": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
+                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are stored locally and encrypted when local runtime storage supports it."
               }
             }
           }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -12209,7 +12209,16 @@
             "70fcd360c4": "https://example.atlassian.net",
             "e176f9d0c5": "Jira Cloud 站点 URL",
             "d785c42b8b": "使用 Jira Cloud 站点 URL、Atlassian 邮箱和 API token 来浏览议题。",
-            "8388bdea2b": "连接 Jira 站点"
+            "8388bdea2b": "连接 Jira 站点",
+            "2e2b69e48e": "Use a self-hosted Jira base URL and a personal access token to browse issues.",
+            "b67e919bd5": "Jira instance type",
+            "17787d6e4b": "Atlassian Cloud",
+            "bc7a831773": "Self-hosted",
+            "3489e186d6": "Jira site URL",
+            "cbc27fa599": "https://jira.example.com",
+            "730d973bae": "Personal access token",
+            "8b9c7b9e7b": "Jira personal access token",
+            "ccfb086d3e": "Create a personal access token in your Jira profile under Personal Access Tokens."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8457,7 +8457,9 @@
                 "fe9231215b": "在显示设置操作前正在检查 Linear 访问权限。",
                 "e1f5e6424c": "{{value0}} 个工作区{{value1}} 已连接",
                 "disconnect_all": "断开连接",
-                "account_scope_prefix": "账户范围"
+                "account_scope_prefix": "账户范围",
+                "2d60ec7921": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
+                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token. Credentials are stored locally and encrypted when local runtime storage supports it."
               }
             }
           }

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -56,7 +56,7 @@ export async function jiraStatus(settings: RuntimeJiraSettings): Promise<JiraCon
 
 export async function jiraConnect(
   settings: RuntimeJiraSettings,
-  args: { siteUrl: string; email: string; apiToken: string }
+  args: { siteUrl: string; email: string; apiToken: string; authType?: 'cloud' | 'server' }
 ): Promise<JiraConnectResult> {
   const target = getJiraRuntimeTarget(settings)
   return target.kind === 'environment'

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -1,5 +1,6 @@
 import type {
   GlobalSettings,
+  JiraAuthType,
   JiraComment,
   JiraConnectionStatus,
   JiraCreateField,
@@ -56,7 +57,7 @@ export async function jiraStatus(settings: RuntimeJiraSettings): Promise<JiraCon
 
 export async function jiraConnect(
   settings: RuntimeJiraSettings,
-  args: { siteUrl: string; email: string; apiToken: string; authType?: 'cloud' | 'server' }
+  args: { siteUrl: string; email: string; apiToken: string; authType?: JiraAuthType }
 ): Promise<JiraConnectResult> {
   const target = getJiraRuntimeTarget(settings)
   return target.kind === 'environment'

--- a/src/renderer/src/store/slices/jira.ts
+++ b/src/renderer/src/store/slices/jira.ts
@@ -4,6 +4,7 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type {
+  JiraAuthType,
   JiraConnectionStatus,
   JiraIssue,
   JiraIssueFilter,
@@ -163,7 +164,7 @@ export type JiraSlice = {
     siteUrl: string
     email: string
     apiToken: string
-    authType?: 'cloud' | 'server'
+    authType?: JiraAuthType
   }) => Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }>
   testJiraConnection: (
     siteId?: string | null

--- a/src/renderer/src/store/slices/jira.ts
+++ b/src/renderer/src/store/slices/jira.ts
@@ -163,6 +163,7 @@ export type JiraSlice = {
     siteUrl: string
     email: string
     apiToken: string
+    authType?: 'cloud' | 'server'
   }) => Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }>
   testJiraConnection: (
     siteId?: string | null

--- a/src/shared/jira-types.ts
+++ b/src/shared/jira-types.ts
@@ -1,9 +1,15 @@
+// 'cloud' = Atlassian Cloud (email + API token, Basic auth, REST v3).
+// 'server' = self-hosted Jira Server/Data Center (personal access token,
+// Bearer auth, REST v2). Older stored sites omit the field and mean 'cloud'.
+export type JiraAuthType = 'cloud' | 'server'
+
 export type JiraSite = {
   id: string
   siteUrl: string
   email: string
   displayName: string
   accountId: string
+  authType?: JiraAuthType
 }
 
 export type JiraViewer = {
@@ -126,8 +132,11 @@ export type JiraIssueFilter = 'assigned' | 'reported' | 'all' | 'done'
 
 export type JiraConnectArgs = {
   siteUrl: string
+  // Ignored for 'server' auth: self-hosted PATs authenticate via Bearer
+  // header alone, so the email field may be empty.
   email: string
   apiToken: string
+  authType?: JiraAuthType
 }
 
 export type JiraCreateIssueArgs = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1827,6 +1827,7 @@ export type {
 } from './gitlab-types'
 
 export type {
+  JiraAuthType,
   JiraComment,
   JiraConnectArgs,
   JiraConnectionStatus,


### PR DESCRIPTION
Fixes #6676

## Summary

Adds support for **self-hosted Jira Server / Data Center** authentication using a personal access token (PAT). Previously Orca assumed Atlassian Cloud everywhere — Basic auth (`email:apiToken`) against REST v3, ADF document bodies, `accountId`-based assignment, and Cloud-only endpoints (`/rest/api/3/search/jql`, `/project/search`). Self-hosted PATs must be sent as `Authorization: Bearer <PAT>` and those instances only expose REST v2, so connecting with a valid PAT failed with **401**.

The Jira connect dialog now has an **Atlassian Cloud / Self-hosted** toggle. Self-hosted hides the email field (PATs authenticate alone) and switches to Bearer auth + REST v2, with all endpoint/body/assignee differences gated on the new `authType`.

Key changes:
- New `authType: 'cloud' | 'server'` on `JiraSite` / `JiraConnectArgs`. Stored sites without the field keep meaning `'cloud'`, so existing connections are unaffected.
- Server sites: Bearer auth + `/rest/api/2`; classic `/search` (not `/search/jql`); plain-text bodies (not ADF); assignee by `{name}` (not `{accountId}`); unpaged `/project` listing; `username` param for assignable-user search; viewer falls back to `name`/`key` when `/myself` has no `accountId`.
- Connect dialog gains the Cloud/Self-hosted toggle; `TaskPage` now reuses the shared `JiraConnectDialog` instead of its own duplicated inline dialog (~130 lines removed).
- Runtime RPC `jira.connect` schema makes `email` optional and accepts `authType`, so remote/web clients get identical support.

## Screenshots

The connect dialog with the new instance-type toggle (screenshots attached in a PR comment below):

- **Atlassian Cloud** (unchanged): site URL + Atlassian email + API token.

<img width="1040" height="1120" alt="jira-connect-cloud" src="https://github.com/user-attachments/assets/3ad43cda-bdd7-44b4-97fe-913efbca1778" />

- **Self-hosted** (new): site URL + personal access token only; email field hidden; PAT-oriented help text.

<img width="1040" height="1120" alt="jira-connect-self-hosted" src="https://github.com/user-attachments/assets/2c382104-40e3-439a-b897-588fcf65f6e1" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New unit tests: Bearer + REST v2 connect, no-email validation, stored server-site auth, classic `/search` endpoint, plain-text create body, `{name}` assignee, unpaged `/project` listing (7 new tests; full Jira suite green — 32 tests). Localization catalog/coverage clean across en/es/ja/ko/zh.

**Live-tested against a real Jira Data Center instance** from both the desktop app and a paired browser (runtime RPC path): connect (PAT only), test-connection, browse filters (assigned/reported/all/done), JQL search, issue detail + comments, create issue, update title/labels/priority, reassign, status transition, add comment, and restart persistence.

## AI Review Report

Reviewed with an AI coding agent (Claude), which also caught and fixed follow-ups from CodeRabbit's review:

- **Cross-platform (macOS/Linux/Windows):** No platform-specific code paths added. No new keyboard shortcuts, accelerators, shortcut labels, filesystem paths, or shell invocations — the change is HTTP request shaping and React dialog state. Token storage reuses the existing `safeStorage` path. No `metaKey`/`ctrlKey` hardcoding introduced.
- **SSH / remote / local:** Support was added to both the Electron IPC path (local) and the runtime RPC path (`rpc/methods/jira.ts`), so paired/remote/SSH runtimes get the same behavior. Credentials continue to be stored on the runtime that owns the provider.
- **Provider neutrality:** Change is scoped to Jira; the Cloud-vs-Server branch is gated behind the explicit `authType` field rather than URL sniffing, and stored sites default to `'cloud'` for backward compatibility.
- **Performance:** No new hot-path work; request shaping is O(1) per call. The `/project` listing for Server is unpaged by necessity (no `/project/search` on Server/DC) — acceptable, matching the API's own contract.
- **UI quality:** Reused shadcn `ToggleGroup` and existing dialog primitives per the styleguide; verified the toggle, conditional fields, and help text render correctly (screenshots below). Removed a duplicated inline dialog in `TaskPage` and gated the tasks contextual tour while the Jira connect dialog is open (parity with the Linear dialog).

## Security Audit

- **Auth / secrets:** PATs are sent only as an `Authorization: Bearer` header to the user-configured Jira host, never logged. Tokens are stored via the existing encrypted `safeStorage` path — no new storage surface. When toggling from Cloud to Self-hosted, a previously-typed email is dropped (`email: isServer ? '' : trimmedEmail`) so it can't leak into the stored server site's identity/key.
- **Input handling:** The RPC `jira.connect` schema (zod) validates `authType` as an enum and treats `email` as optional; no free-form values reach request construction unvalidated.
- **IPC:** No new IPC channels; the existing `jira:connect` handler gains one enum field. No command execution or path handling introduced.
- **Dependencies:** No new dependencies.

Follow-up needed: none identified.

## Notes

- Per-project createmeta on Server requires **Jira 8.4+** (documented for reviewers). Older Server versions would need the global createmeta fallback, which is out of scope here.
- No release/version changes included, per the contributing guide.

X: @<your-handle-here>
