### PR TITLE
Fix #7685: clamp inherited split cwd to worktree root

### DIFF
--- a/src/renderer/src/components/terminal-pane/resolve-split-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/resolve-split-cwd.test.ts
@@ -22,19 +22,19 @@ describe('resolveSplitCwd', () => {
   it('returns the confirmed OSC 7 entry without calling IPC', async () => {
     const getCwd = vi.fn()
     installGetCwd(getCwd as unknown as (id: string) => Promise<string>)
-    const paneCwdMap: PaneCwdMap = new Map([[1, { cwd: '/live/here', confirmed: true }]])
+    const paneCwdMap: PaneCwdMap = new Map([[1, { cwd: '/worktree/live/here', confirmed: true }]])
     const result = await resolveSplitCwd({
       paneCwdMap,
       sourcePaneId: 1,
       sourcePtyId: 'pty-1',
       fallbackCwd: '/worktree'
     })
-    expect(result).toBe('/live/here')
+    expect(result).toBe('/worktree/live/here')
     expect(getCwd).not.toHaveBeenCalled()
   })
 
   it('queries IPC when no confirmed entry exists', async () => {
-    installGetCwd(async () => '/tmp/ipc')
+    installGetCwd(async () => '/worktree/tmp/ipc')
     const paneCwdMap: PaneCwdMap = new Map()
     const result = await resolveSplitCwd({
       paneCwdMap,
@@ -42,19 +42,19 @@ describe('resolveSplitCwd', () => {
       sourcePtyId: 'pty-1',
       fallbackCwd: '/worktree'
     })
-    expect(result).toBe('/tmp/ipc')
+    expect(result).toBe('/worktree/tmp/ipc')
   })
 
   it('falls through to the unconfirmed cached entry when IPC returns empty', async () => {
     installGetCwd(async () => '')
-    const paneCwdMap: PaneCwdMap = new Map([[1, { cwd: '/replayed', confirmed: false }]])
+    const paneCwdMap: PaneCwdMap = new Map([[1, { cwd: '/worktree/replayed', confirmed: false }]])
     const result = await resolveSplitCwd({
       paneCwdMap,
       sourcePaneId: 1,
       sourcePtyId: 'pty-1',
       fallbackCwd: '/worktree'
     })
-    expect(result).toBe('/replayed')
+    expect(result).toBe('/worktree/replayed')
   })
 
   it('falls back to worktree root when OSC 7 and IPC both miss', async () => {
@@ -72,7 +72,7 @@ describe('resolveSplitCwd', () => {
     installGetCwd(
       () =>
         new Promise<string>((resolve) => {
-          setTimeout(() => resolve('/slow/ipc'), 900)
+          setTimeout(() => resolve('/worktree/slow/ipc'), 900)
         })
     )
     const promise = resolveSplitCwd({
@@ -82,7 +82,7 @@ describe('resolveSplitCwd', () => {
       fallbackCwd: '/worktree'
     })
     await vi.advanceTimersByTimeAsync(900)
-    expect(await promise).toBe('/slow/ipc')
+    expect(await promise).toBe('/worktree/slow/ipc')
   })
 
   it('times out and falls back when IPC hangs', async () => {
@@ -120,6 +120,21 @@ describe('resolveSplitCwd', () => {
       fallbackCwd: '/remote/worktree'
     })
     expect(result).toBe('/remote/worktree')
+    expect(getCwd).not.toHaveBeenCalled()
+  })
+
+  it('clamps a confirmed OSC 7 cwd outside the worktree to the worktree root (#7685)', async () => {
+    const getCwd = vi.fn()
+    installGetCwd(getCwd as unknown as (id: string) => Promise<string>)
+    // Why: shell did `cd ..` above the worktree root before the split.
+    const paneCwdMap: PaneCwdMap = new Map([[1, { cwd: '/outside/somewhere', confirmed: true }]])
+    const result = await resolveSplitCwd({
+      paneCwdMap,
+      sourcePaneId: 1,
+      sourcePtyId: 'pty-1',
+      fallbackCwd: '/worktree'
+    })
+    expect(result).toBe('/worktree')
     expect(getCwd).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/resolve-split-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/resolve-split-cwd.test.ts
@@ -126,7 +126,6 @@ describe('resolveSplitCwd', () => {
   it('clamps a confirmed OSC 7 cwd outside the worktree to the worktree root (#7685)', async () => {
     const getCwd = vi.fn()
     installGetCwd(getCwd as unknown as (id: string) => Promise<string>)
-    // Why: shell did `cd ..` above the worktree root before the split.
     const paneCwdMap: PaneCwdMap = new Map([[1, { cwd: '/outside/somewhere', confirmed: true }]])
     const result = await resolveSplitCwd({
       paneCwdMap,

--- a/src/renderer/src/components/terminal-pane/resolve-split-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/resolve-split-cwd.test.ts
@@ -137,4 +137,27 @@ describe('resolveSplitCwd', () => {
     expect(result).toBe('/worktree')
     expect(getCwd).not.toHaveBeenCalled()
   })
+
+  it('clamps an IPC-resolved cwd outside the worktree to the worktree root (#7685)', async () => {
+    installGetCwd(async () => '/outside/somewhere')
+    const result = await resolveSplitCwd({
+      paneCwdMap: new Map(),
+      sourcePaneId: 1,
+      sourcePtyId: 'pty-1',
+      fallbackCwd: '/worktree'
+    })
+    expect(result).toBe('/worktree')
+  })
+
+  it('clamps an unconfirmed cached cwd outside the worktree to the worktree root (#7685)', async () => {
+    installGetCwd(async () => '')
+    const paneCwdMap: PaneCwdMap = new Map([[1, { cwd: '/outside/somewhere', confirmed: false }]])
+    const result = await resolveSplitCwd({
+      paneCwdMap,
+      sourcePaneId: 1,
+      sourcePtyId: 'pty-1',
+      fallbackCwd: '/worktree'
+    })
+    expect(result).toBe('/worktree')
+  })
 })

--- a/src/renderer/src/components/terminal-pane/resolve-split-cwd.ts
+++ b/src/renderer/src/components/terminal-pane/resolve-split-cwd.ts
@@ -4,6 +4,7 @@
 // TUIs, minimal sh). Both layers can legitimately come back empty, so the
 // helper always finishes by returning the caller's worktree-root fallback.
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 
 export type PaneCwdEntry = { cwd: string; confirmed: boolean }
 
@@ -17,6 +18,15 @@ export type PaneCwdMap = Map<number, PaneCwdEntry>
 // for the next Cmd+D.
 const GET_CWD_TIMEOUT_MS = 1000
 
+// Why: a source shell can legitimately `cd` above the worktree root (e.g.
+// `cd ..`). Passing that cwd straight to pty.spawn hits the main-process
+// worktree guard and throws, leaving the new split as a dead pane with an
+// internal error (#7685). Clamp here so an out-of-worktree cwd degrades to
+// the worktree root instead of failing the split.
+export function clampCwdToWorktree(candidateCwd: string, worktreeRoot: string): string {
+  return isPathInsideOrEqual(worktreeRoot, candidateCwd) ? candidateCwd : worktreeRoot
+}
+
 export async function resolveSplitCwd(args: {
   paneCwdMap: PaneCwdMap
   sourcePaneId: number
@@ -28,7 +38,7 @@ export async function resolveSplitCwd(args: {
   // 1) Live OSC 7 wins — no IPC round-trip needed.
   const cached = paneCwdMap.get(sourcePaneId)
   if (cached?.confirmed && cached.cwd) {
-    return cached.cwd
+    return clampCwdToWorktree(cached.cwd, fallbackCwd)
   }
 
   // 2) Ask the PTY provider (/proc or lsof). Enforce a soft timeout
@@ -40,7 +50,7 @@ export async function resolveSplitCwd(args: {
         new Promise<null>((resolve) => setTimeout(() => resolve(null), GET_CWD_TIMEOUT_MS))
       ])
       if (ipcCwd) {
-        return ipcCwd
+        return clampCwdToWorktree(ipcCwd, fallbackCwd)
       }
     } catch {
       /* fall through */
@@ -49,7 +59,7 @@ export async function resolveSplitCwd(args: {
 
   // 3) Last-ditch: replayed OSC 7 that we couldn't confirm as live.
   if (cached?.cwd) {
-    return cached.cwd
+    return clampCwdToWorktree(cached.cwd, fallbackCwd)
   }
 
   return fallbackCwd

--- a/src/renderer/src/components/terminal-pane/resolve-split-cwd.ts
+++ b/src/renderer/src/components/terminal-pane/resolve-split-cwd.ts
@@ -18,11 +18,8 @@ export type PaneCwdMap = Map<number, PaneCwdEntry>
 // for the next Cmd+D.
 const GET_CWD_TIMEOUT_MS = 1000
 
-// Why: a source shell can legitimately `cd` above the worktree root (e.g.
-// `cd ..`). Passing that cwd straight to pty.spawn hits the main-process
-// worktree guard and throws, leaving the new split as a dead pane with an
-// internal error (#7685). Clamp here so an out-of-worktree cwd degrades to
-// the worktree root instead of failing the split.
+// Why: an inherited split cwd above the worktree root (e.g. after `cd ..`)
+// would hit the main-process spawn guard and leave a dead pane (#7685).
 export function clampCwdToWorktree(candidateCwd: string, worktreeRoot: string): string {
   return isPathInsideOrEqual(worktreeRoot, candidateCwd) ? candidateCwd : worktreeRoot
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
@@ -48,7 +48,6 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     splitTerminalPaneWithInheritedCwd({
       manager: makeManager(splitPane),
       paneTransports: new Map<number, PtyTransport>(),
-      // Why: shell did `cd ..` above the worktree root before the split.
       paneCwdMap: new Map([[1, { cwd: '/outside/somewhere', confirmed: true }]]),
       fallbackCwd: '/worktree',
       pane: { id: 1 } as ManagedPane,

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
@@ -13,9 +13,13 @@ vi.mock('@/runtime/web-runtime-session', () => ({
   splitWebRuntimeTerminal: mocks.splitWebRuntimeTerminal
 }))
 
-vi.mock('./resolve-split-cwd', () => ({
-  resolveSplitCwd: mocks.resolveSplitCwd
-}))
+vi.mock('./resolve-split-cwd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./resolve-split-cwd')>()
+  return {
+    ...actual,
+    resolveSplitCwd: mocks.resolveSplitCwd
+  }
+})
 
 vi.mock('./terminal-pane-split-completion', () => ({
   recordCreatedTerminalPaneSplit: mocks.recordCreatedTerminalPaneSplit
@@ -36,6 +40,23 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     mocks.resolveSplitCwd.mockReset()
     mocks.splitWebRuntimeTerminal.mockReset()
     mocks.splitWebRuntimeTerminal.mockReturnValue(false)
+  })
+
+  it('clamps a confirmed cached cwd outside the worktree to the worktree root (#7685)', () => {
+    const splitPane = vi.fn(() => ({ id: 2 }))
+
+    splitTerminalPaneWithInheritedCwd({
+      manager: makeManager(splitPane),
+      paneTransports: new Map<number, PtyTransport>(),
+      // Why: shell did `cd ..` above the worktree root before the split.
+      paneCwdMap: new Map([[1, { cwd: '/outside/somewhere', confirmed: true }]]),
+      fallbackCwd: '/worktree',
+      pane: { id: 1 } as ManagedPane,
+      direction: 'vertical',
+      source: 'context_menu'
+    })
+
+    expect(splitPane).toHaveBeenCalledWith(1, 'vertical', { cwd: '/worktree' })
   })
 
   it('uses the live manager after async cwd resolution', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
@@ -2,7 +2,7 @@ import type { TerminalPaneSplitSource } from '../../../../shared/feature-educati
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import { splitWebRuntimeTerminal } from '@/runtime/web-runtime-session'
 import type { PtyTransport } from './pty-transport'
-import { resolveSplitCwd, type PaneCwdMap } from './resolve-split-cwd'
+import { clampCwdToWorktree, resolveSplitCwd, type PaneCwdMap } from './resolve-split-cwd'
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 
 export function splitTerminalPaneWithInheritedCwd(args: {
@@ -21,7 +21,11 @@ export function splitTerminalPaneWithInheritedCwd(args: {
   }
   const cached = args.paneCwdMap.get(args.pane.id)
   if (cached?.confirmed && cached.cwd) {
-    const createdPane = args.manager.splitPane(args.pane.id, args.direction, { cwd: cached.cwd })
+    // Why: the source shell can `cd` above the worktree root; spawning there
+    // hits the main-process worktree guard and leaves a dead pane (#7685).
+    const createdPane = args.manager.splitPane(args.pane.id, args.direction, {
+      cwd: clampCwdToWorktree(cached.cwd, args.fallbackCwd)
+    })
     recordCreatedTerminalPaneSplit(createdPane, {
       source: args.source,
       direction: args.direction

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
@@ -21,8 +21,6 @@ export function splitTerminalPaneWithInheritedCwd(args: {
   }
   const cached = args.paneCwdMap.get(args.pane.id)
   if (cached?.confirmed && cached.cwd) {
-    // Why: the source shell can `cd` above the worktree root; spawning there
-    // hits the main-process worktree guard and leaves a dead pane (#7685).
     const createdPane = args.manager.splitPane(args.pane.id, args.direction, {
       cwd: clampCwdToWorktree(cached.cwd, args.fallbackCwd)
     })


### PR DESCRIPTION
## Summary
- Fixes #7685 — right-click split terminal created a dead pane with an internal error banner ("Terminal cwd must be inside the selected worktree.") instead of a working shell.
- Root cause: when a split inherits the source pane's cwd (via OSC 7 or the lsof/proc IPC fallback), an out-of-worktree cwd (e.g. after `cd ..` past the worktree root) was passed straight through to `pty.spawn`. The main-process worktree guard then throws, leaving the new split dead.
- Fix: clamp the resolved cwd to the worktree root at both call sites that produce a split cwd — the synchronous confirmed-cache fast path in `terminal-pane-split-with-inherited-cwd.ts` and the async `resolveSplitCwd` helper — reusing the existing `isPathInsideOrEqual` helper so the check matches the main-process guard's semantics.

## Testing
- Added/updated unit tests in `resolve-split-cwd.test.ts` and `terminal-pane-split-with-inherited-cwd.test.ts` covering the out-of-worktree clamp.
- `vitest run` on both files: 12/12 passing.
- Ran related existing tests (`terminal-startup-cwd.test.ts`, `cross-platform-path.test.ts`): 12/12 passing, no regressions.