### PR TITLE
feat: keyboard shortcut to open workspace in last-used app

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1768,12 +1768,12 @@ function App(): React.JSX.Element {
       // Why: reuses whichever app the user last picked from the "Open in" menu
       // (tracked as index 0 of settings.openInApplications); no-op until one is picked.
       if (matchShortcut('workspace.openInLastUsedApp') && activeWorktreeId) {
-        input.preventDefault()
-        notifyTerminalCapture('workspace.openInLastUsedApp')
         const store = useAppStore.getState()
         const worktree = findWorktreeById(store.worktreesByRepo, activeWorktreeId)
         const lastUsedApp = store.settings?.openInApplications?.[0]
         if (worktree && lastUsedApp) {
+          input.preventDefault()
+          notifyTerminalCapture('workspace.openInLastUsedApp')
           void openWorktreePath({
             target: 'external-editor',
             worktreePath: worktree.path,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -41,6 +41,9 @@ import {
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 import { useAppStore } from './store'
+import { findWorktreeById } from './store/slices/worktree-helpers'
+import { getWorktreeConnectionId } from './store/slices/editor'
+import { openWorktreePath } from './components/sidebar/WorktreeOpenInMenu'
 import { useShallow } from 'zustand/react/shallow'
 import { isRemoteWorkspaceSnapshotApplyInProgress, useIpcEvents } from './hooks/useIpcEvents'
 import { useAutomationDispatchEvents } from './hooks/useAutomationDispatchEvents'
@@ -1759,6 +1762,26 @@ function App(): React.JSX.Element {
         const store = useAppStore.getState()
         store.setSidebarOpen(true)
         requestScrollToCurrentWorkspaceRevealAndRename()
+        return
+      }
+
+      // Why: reuses whichever app the user last picked from the "Open in" menu
+      // (tracked as index 0 of settings.openInApplications); no-op until one is picked.
+      if (matchShortcut('workspace.openInLastUsedApp') && activeWorktreeId) {
+        input.preventDefault()
+        notifyTerminalCapture('workspace.openInLastUsedApp')
+        const store = useAppStore.getState()
+        const worktree = findWorktreeById(store.worktreesByRepo, activeWorktreeId)
+        const lastUsedApp = store.settings?.openInApplications?.[0]
+        if (worktree && lastUsedApp) {
+          void openWorktreePath({
+            target: 'external-editor',
+            worktreePath: worktree.path,
+            connectionId: getWorktreeConnectionId(store, activeWorktreeId),
+            command: lastUsedApp.command,
+            appId: lastUsedApp.id
+          })
+        }
         return
       }
 

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
@@ -132,7 +132,7 @@ export async function openWorktreePath(args: {
     const current = store.settings?.openInApplications ?? []
     const reordered = moveOpenInApplicationToFront(current, args.appId)
     if (reordered !== current) {
-      store.updateSettings({ openInApplications: reordered })
+      void store.updateSettings({ openInApplications: reordered })
     }
   }
 }

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
@@ -12,6 +12,7 @@ import { useAppStore } from '@/store'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import { getLocalFileManagerLabel } from '@/lib/local-file-manager-label'
 import { OpenInApplicationIcon } from '@/lib/open-in-app-catalog'
+import { moveOpenInApplicationToFront } from '../../../../shared/open-in-applications'
 import type { ShellOpenLocalPathFailureReason } from '../../../../shared/shell-open-types'
 import type { OpenInApplication } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
@@ -105,6 +106,7 @@ export async function openWorktreePath(args: {
   worktreePath: string
   connectionId?: string | null
   command?: string
+  appId?: string
 }): Promise<void> {
   if (
     isLocalPathOpenBlocked(useAppStore.getState().settings, {
@@ -121,6 +123,17 @@ export async function openWorktreePath(args: {
       : await window.api.shell.openInExternalEditor(args.worktreePath, args.command)
   if (!result.ok) {
     showOpenFailureToast(result.reason)
+    return
+  }
+
+  // Why: "last used" for the open-in-last-used-app shortcut is just index 0.
+  if (args.target === 'external-editor' && args.appId) {
+    const store = useAppStore.getState()
+    const current = store.settings?.openInApplications ?? []
+    const reordered = moveOpenInApplicationToFront(current, args.appId)
+    if (reordered !== current) {
+      store.updateSettings({ openInApplications: reordered })
+    }
   }
 }
 
@@ -129,11 +142,12 @@ function useOpenInWorktreePath({
   connectionId
 }: WorktreeOpenInMenuItemsProps): (
   target: 'file-manager' | 'external-editor',
-  command?: string
+  command?: string,
+  appId?: string
 ) => Promise<void> {
   return useCallback(
-    async (target, command) => {
-      await openWorktreePath({ target, worktreePath, connectionId, command })
+    async (target, command, appId) => {
+      await openWorktreePath({ target, worktreePath, connectionId, command, appId })
     },
     [connectionId, worktreePath]
   )
@@ -157,7 +171,7 @@ export function WorktreeOpenInMenuItems({
           key={entry.id}
           onClick={stopMenuPropagation}
           onSelect={() => {
-            void openInWorktreePath(entry.target, entry.command)
+            void openInWorktreePath(entry.target, entry.command, entry.id)
           }}
           disabled={disabled}
         >

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -1311,7 +1311,7 @@ function shouldDeleteUntouchedUntitledFile(file: OpenFile | undefined, hasDraft:
   )
 }
 
-function getWorktreeConnectionId(state: AppState, worktreeId: string): string | undefined {
+export function getWorktreeConnectionId(state: AppState, worktreeId: string): string | undefined {
   const worktree = findWorktreeById(state.worktreesByRepo ?? {}, worktreeId)
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
   const repo = (state.repos ?? []).find((candidate) => candidate.id === repoId)

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -36,6 +36,7 @@ export type KeybindingActionId =
   | 'app.forceReload'
   | 'workspace.create'
   | 'workspace.rename'
+  | 'workspace.openInLastUsedApp'
   | 'workspace.delete'
   | 'workspace.openBoard'
   | 'workspace.selectByIndex'
@@ -265,6 +266,28 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     // taken, so users bind it explicitly in Settings.
     defaultBindings: {
       darwin: ['Mod+Alt+R'],
+      linux: [],
+      win32: []
+    }
+  },
+  {
+    id: 'workspace.openInLastUsedApp',
+    title: 'Open workspace in last-used app',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: [
+      'shortcut',
+      'global',
+      'worktree',
+      'workspace',
+      'open in',
+      'editor',
+      'zed',
+      'ide'
+    ],
+    // Why: no safe default chord to claim yet; user binds it explicitly in Settings.
+    defaultBindings: {
+      darwin: [],
       linux: [],
       win32: []
     }

--- a/src/shared/open-in-applications.test.ts
+++ b/src/shared/open-in-applications.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_OPEN_IN_APPLICATIONS, normalizeOpenInApplications } from './open-in-applications'
+import {
+  DEFAULT_OPEN_IN_APPLICATIONS,
+  moveOpenInApplicationToFront,
+  normalizeOpenInApplications
+} from './open-in-applications'
 
 describe('normalizeOpenInApplications', () => {
   it('trims fields, drops invalid rows, keeps first duplicate id, and caps list', () => {
@@ -50,5 +54,26 @@ describe('normalizeOpenInApplications', () => {
       DEFAULT_OPEN_IN_APPLICATIONS
     )
     expect(normalizeOpenInApplications([], { seedDefaults: true })).toEqual([])
+  })
+})
+
+describe('moveOpenInApplicationToFront', () => {
+  const apps = [
+    { id: 'a', label: 'A', command: 'a' },
+    { id: 'b', label: 'B', command: 'b' },
+    { id: 'c', label: 'C', command: 'c' }
+  ]
+
+  it('moves a matching non-first id to the front', () => {
+    expect(moveOpenInApplicationToFront(apps, 'c')).toEqual([
+      { id: 'c', label: 'C', command: 'c' },
+      { id: 'a', label: 'A', command: 'a' },
+      { id: 'b', label: 'B', command: 'b' }
+    ])
+  })
+
+  it('returns the same array reference when already first or not found', () => {
+    expect(moveOpenInApplicationToFront(apps, 'a')).toBe(apps)
+    expect(moveOpenInApplicationToFront(apps, 'missing')).toBe(apps)
   })
 })

--- a/src/shared/open-in-applications.ts
+++ b/src/shared/open-in-applications.ts
@@ -60,3 +60,18 @@ export function normalizeOpenInApplications(
 
   return normalized
 }
+
+// Why: "last used" is just index 0 — no separate lastUsedAppId field to keep in sync.
+export function moveOpenInApplicationToFront(
+  apps: OpenInApplication[],
+  id: string
+): OpenInApplication[] {
+  const index = apps.findIndex((app) => app.id === id)
+  if (index <= 0) {
+    return apps
+  }
+  const next = [...apps]
+  const [app] = next.splice(index, 1)
+  next.unshift(app)
+  return next
+}


### PR DESCRIPTION
Closes #7726

## Summary
Adds a `workspace.openInLastUsedApp` keybinding action that opens the currently focused workspace using whichever app was last picked from the sidebar "Open in" menu — no context menu round-trip.

- "Last used" is tracked as index 0 of `settings.openInApplications`; picking any app in the "Open in" menu moves it to the front (MRU), no separate state field.
- New keybinding action registered in `keybindings.ts` with no default chord (ships empty on all platforms) — user binds it explicitly in Settings > Keybindings, same pattern as `workspace.rename`.
- No-ops if no app has ever been picked (nothing to reuse yet).

## Scope
Per the issue's "Ideally per-workspace, falling back to a global default" — this ships global-only for now. No per-workspace override, since the issue phrased it as optional and there's no concrete need for it yet.

## Testing
- `pnpm run tc:web` — clean
- `pnpm lint` (oxlint on changed files) — clean
- Added unit tests for `moveOpenInApplicationToFront` (front-move, already-first, not-found cases)
- Existing `WorktreeOpenInMenu` tests still pass

## Platform notes
Follows AGENTS.md cross-platform keybinding rules — no hardcoded `metaKey`, default bindings are empty per-platform rather than guessing a safe chord.

No UI screenshot — this change only adds a keybinding action to the existing Settings > Keybindings list; no new UI surface.

## ELI5

A new keybinding opens the focused workspace in the last app you used from “Open in”. No default chord—bind it in Settings if you want one-key reopen in that app.
