### PR TITLE
feat(sidebar): tune active workspace contrast

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1202,8 +1202,18 @@ html.native-shell .app-layout {
 /* Why: the brighter border carries the selected state; a translucent wash keeps
    card text legible instead of lifting the surface toward the foreground color. */
 [data-worktree-card-surface][data-worktree-card-active='primary'] {
-  border-color: color-mix(in srgb, var(--worktree-sidebar-border) 40%, transparent);
-  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 8%, transparent);
+  /* Why: optional contrast steps raise the wash via --worktree-card-active-*-mix;
+     defaults keep the current quiet worktree-sidebar treatment. */
+  border-color: color-mix(
+    in srgb,
+    var(--worktree-sidebar-border) var(--worktree-card-active-border-mix, 40%),
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--worktree-sidebar-foreground) var(--worktree-card-active-bg-mix, 8%),
+    transparent
+  );
   box-shadow: 0 1px 2px color-mix(in srgb, var(--worktree-sidebar-foreground) 4%, transparent);
 }
 
@@ -1213,7 +1223,11 @@ html.native-shell .app-layout {
     var(--worktree-sidebar-foreground) 18%,
     var(--worktree-sidebar-border)
   );
-  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 10%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--worktree-sidebar-foreground) var(--worktree-card-active-dark-bg-mix, 10%),
+    transparent
+  );
   box-shadow: 0 1px 2px color-mix(in srgb, var(--worktree-sidebar-foreground) 3%, transparent);
 }
 

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1038,13 +1038,27 @@
 }
 
 [data-worktree-card-surface][data-worktree-card-active='primary'] {
-  border-color: color-mix(in srgb, var(--sidebar-border) 40%, transparent);
-  background: color-mix(in srgb, var(--sidebar-foreground) 8%, transparent);
+  /* Why: keep the original quiet card treatment, but raise the foreground wash
+     slightly so light sidebar appearances distinguish the current workspace. */
+  border-color: color-mix(
+    in srgb,
+    var(--sidebar-border) var(--worktree-card-active-border-mix, 45%),
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--sidebar-foreground) var(--worktree-card-active-bg-mix, 11%),
+    transparent
+  );
   box-shadow: 0 1px 2px color-mix(in srgb, var(--sidebar-foreground) 4%, transparent);
 }
 
 .dark [data-worktree-card-surface][data-worktree-card-active='primary'] {
-  background: color-mix(in srgb, var(--sidebar-foreground) 10%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--sidebar-foreground) var(--worktree-card-active-dark-bg-mix, 10%),
+    transparent
+  );
   box-shadow: 0 1px 2px color-mix(in srgb, var(--sidebar-foreground) 3%, transparent);
 }
 

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -350,6 +350,25 @@ describe('AppearancePane', () => {
     })
   })
 
+  it('updates active workspace contrast from sidebar appearance settings', async () => {
+    mocks.state.settingsSearchQuery = 'active workspace contrast'
+    const updateSettings = vi.fn()
+    const settings = getDefaultSettings('/tmp')
+
+    const container = await renderAppearancePane(settings, updateSettings)
+    const highButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[role="radio"]')
+    ).find((button) => button.textContent === 'High')
+
+    expect(highButton).toBeDefined()
+
+    await act(async () => {
+      highButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ activeWorkspaceContrast: 3 })
+  })
+
   it('restores the Automations sidebar button from the sidebar settings switch', async () => {
     const updateSettings = vi.fn()
     const settings = {

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -245,6 +245,25 @@ describe('AppearancePane', () => {
     })
   })
 
+  it('updates active workspace contrast from sidebar appearance settings', async () => {
+    mocks.state.settingsSearchQuery = 'active workspace contrast'
+    const updateSettings = vi.fn()
+    const settings = getDefaultSettings('/tmp')
+
+    const container = await renderAppearancePane(settings, updateSettings)
+    const highButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[role="radio"]')
+    ).find((button) => button.textContent === 'High')
+
+    expect(highButton).toBeDefined()
+
+    await act(async () => {
+      highButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ activeWorkspaceContrast: 3 })
+  })
+
   it('restores the Automations sidebar button from the sidebar settings switch', async () => {
     const updateSettings = vi.fn()
     const settings = {

--- a/src/renderer/src/components/settings/LeftSidebarAppearanceSetting.tsx
+++ b/src/renderer/src/components/settings/LeftSidebarAppearanceSetting.tsx
@@ -2,8 +2,11 @@ import type React from 'react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { LeftSidebarAppearanceMode } from '../../../../shared/ui-chrome-types'
 import {
+  DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
+  normalizeActiveWorkspaceContrast,
   DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
   DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,
+  MAX_ACTIVE_WORKSPACE_CONTRAST,
   MAX_LEFT_SIDEBAR_TINT_OPACITY
 } from '../../../../shared/left-sidebar-appearance'
 import { translate } from '@/i18n/i18n'
@@ -64,6 +67,50 @@ export function LeftSidebarAppearanceSetting({
                 label: translate(
                   'auto.components.settings.AppearancePane.leftSidebarAppearance.tinted',
                   'Tinted'
+                )
+              }
+            ]}
+          />
+        }
+      />
+      <SettingsRow
+        label={translate(
+          'auto.components.settings.AppearancePane.activeWorkspaceContrast.title',
+          'Active Workspace Contrast'
+        )}
+        description={translate(
+          'auto.components.settings.AppearancePane.activeWorkspaceContrast.description',
+          'Controls how strongly the current workspace card stands out in the sidebar.'
+        )}
+        control={
+          <SettingsSegmentedControl<number>
+            size="sm"
+            value={normalizeActiveWorkspaceContrast(settings.activeWorkspaceContrast)}
+            onChange={(activeWorkspaceContrast) => updateSettings({ activeWorkspaceContrast })}
+            ariaLabel={translate(
+              'auto.components.settings.AppearancePane.activeWorkspaceContrast.title',
+              'Active Workspace Contrast'
+            )}
+            options={[
+              {
+                value: DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
+                label: translate(
+                  'auto.components.settings.AppearancePane.activeWorkspaceContrast.default',
+                  'Default'
+                )
+              },
+              {
+                value: 2,
+                label: translate(
+                  'auto.components.settings.AppearancePane.activeWorkspaceContrast.more',
+                  'More'
+                )
+              },
+              {
+                value: MAX_ACTIVE_WORKSPACE_CONTRAST,
+                label: translate(
+                  'auto.components.settings.AppearancePane.activeWorkspaceContrast.high',
+                  'High'
                 )
               }
             ]}

--- a/src/renderer/src/components/settings/LeftSidebarAppearanceSetting.tsx
+++ b/src/renderer/src/components/settings/LeftSidebarAppearanceSetting.tsx
@@ -1,8 +1,11 @@
 import type React from 'react'
 import type { GlobalSettings, LeftSidebarAppearanceMode } from '../../../../shared/types'
 import {
+  DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
+  normalizeActiveWorkspaceContrast,
   DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
   DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,
+  MAX_ACTIVE_WORKSPACE_CONTRAST,
   MAX_LEFT_SIDEBAR_TINT_OPACITY
 } from '../../../../shared/left-sidebar-appearance'
 import { translate } from '@/i18n/i18n'
@@ -63,6 +66,50 @@ export function LeftSidebarAppearanceSetting({
                 label: translate(
                   'auto.components.settings.AppearancePane.leftSidebarAppearance.tinted',
                   'Tinted'
+                )
+              }
+            ]}
+          />
+        }
+      />
+      <SettingsRow
+        label={translate(
+          'auto.components.settings.AppearancePane.activeWorkspaceContrast.title',
+          'Active Workspace Contrast'
+        )}
+        description={translate(
+          'auto.components.settings.AppearancePane.activeWorkspaceContrast.description',
+          'Controls how strongly the current workspace card stands out in the sidebar.'
+        )}
+        control={
+          <SettingsSegmentedControl<number>
+            size="sm"
+            value={normalizeActiveWorkspaceContrast(settings.activeWorkspaceContrast)}
+            onChange={(activeWorkspaceContrast) => updateSettings({ activeWorkspaceContrast })}
+            ariaLabel={translate(
+              'auto.components.settings.AppearancePane.activeWorkspaceContrast.title',
+              'Active Workspace Contrast'
+            )}
+            options={[
+              {
+                value: DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
+                label: translate(
+                  'auto.components.settings.AppearancePane.activeWorkspaceContrast.default',
+                  'Default'
+                )
+              },
+              {
+                value: 2,
+                label: translate(
+                  'auto.components.settings.AppearancePane.activeWorkspaceContrast.more',
+                  'More'
+                )
+              },
+              {
+                value: MAX_ACTIVE_WORKSPACE_CONTRAST,
+                label: translate(
+                  'auto.components.settings.AppearancePane.activeWorkspaceContrast.high',
+                  'High'
                 )
               }
             ]}

--- a/src/renderer/src/components/settings/appearance-sidebar-search.ts
+++ b/src/renderer/src/components/settings/appearance-sidebar-search.ts
@@ -30,6 +30,22 @@ export const getLeftSidebarAppearanceEntry = createLocalizedCatalog(
       ...translateSearchKeyword(
         'auto.components.settings.appearance.search.leftSidebarAppearance.tint',
         'tint'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.contrast',
+        'contrast'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.activeWorkspace',
+        'active workspace'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.selectedWorkspace',
+        'selected workspace'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.leftSidebarAppearance.activeWorkspaceContrast',
+        'active workspace contrast'
       )
     ]
   })

--- a/src/renderer/src/lib/left-sidebar-appearance.test.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.test.ts
@@ -15,6 +15,16 @@ describe('resolveLeftSidebarStyleVariables', () => {
     expect(resolveLeftSidebarStyleVariables(settings(), true)).toBeUndefined()
   })
 
+  it('returns only active-workspace contrast variables for default sidebar contrast changes', () => {
+    const vars = resolveLeftSidebarStyleVariables(settings({ activeWorkspaceContrast: 3 }), true)
+
+    expect(vars).toEqual({
+      '--worktree-card-active-bg-mix': '26%',
+      '--worktree-card-active-dark-bg-mix': '19%',
+      '--worktree-card-active-border-mix': '78%'
+    })
+  })
+
   it('matches terminal background, foreground, and scoped text tokens', () => {
     const vars = resolveLeftSidebarStyleVariables(
       settings({

--- a/src/renderer/src/lib/left-sidebar-appearance.test.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.test.ts
@@ -76,6 +76,21 @@ describe('resolveLeftSidebarStyleVariables', () => {
     })
   })
 
+  it('clamps out-of-range active-workspace contrast before resolving variables', () => {
+    const highVars = resolveLeftSidebarStyleVariables(
+      settings({ activeWorkspaceContrast: 99 }),
+      true
+    )
+    const lowVars = resolveLeftSidebarStyleVariables(settings({ activeWorkspaceContrast: 0 }), true)
+
+    expect(highVars).toEqual({
+      '--worktree-card-active-bg-mix': '26%',
+      '--worktree-card-active-dark-bg-mix': '19%',
+      '--worktree-card-active-border-mix': '78%'
+    })
+    expect(lowVars).toBeUndefined()
+  })
+
   it('matches terminal background, foreground, and scoped text tokens', () => {
     const vars = resolveLeftSidebarStyleVariables(
       settings({

--- a/src/renderer/src/lib/left-sidebar-appearance.test.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.test.ts
@@ -25,6 +25,57 @@ describe('resolveLeftSidebarStyleVariables', () => {
     })
   })
 
+  it('returns the mid-step active-workspace contrast variables', () => {
+    const vars = resolveLeftSidebarStyleVariables(settings({ activeWorkspaceContrast: 2 }), true)
+
+    expect(vars).toEqual({
+      '--worktree-card-active-bg-mix': '18%',
+      '--worktree-card-active-dark-bg-mix': '15%',
+      '--worktree-card-active-border-mix': '60%'
+    })
+  })
+
+  it('merges active-workspace contrast variables into matched terminal surfaces', () => {
+    const vars = resolveLeftSidebarStyleVariables(
+      settings({
+        leftSidebarAppearanceMode: 'match-terminal',
+        activeWorkspaceContrast: 2,
+        terminalColorOverrides: {
+          background: '#101820',
+          foreground: '#f0f4f8'
+        }
+      }),
+      true
+    )
+
+    expect(vars).toMatchObject({
+      '--worktree-sidebar': '#101820',
+      '--sidebar-foreground': '#f0f4f8',
+      '--worktree-card-active-bg-mix': '18%',
+      '--worktree-card-active-dark-bg-mix': '15%',
+      '--worktree-card-active-border-mix': '60%'
+    })
+  })
+
+  it('merges active-workspace contrast variables into tinted surfaces', () => {
+    const vars = resolveLeftSidebarStyleVariables(
+      settings({
+        leftSidebarAppearanceMode: 'tinted',
+        activeWorkspaceContrast: 3,
+        leftSidebarTintColor: '336699',
+        leftSidebarTintOpacity: 0.125
+      }),
+      true
+    )
+
+    expect(vars).toMatchObject({
+      '--worktree-sidebar': 'color-mix(in srgb, #336699 12.5%, var(--background))',
+      '--worktree-card-active-bg-mix': '26%',
+      '--worktree-card-active-dark-bg-mix': '19%',
+      '--worktree-card-active-border-mix': '78%'
+    })
+  })
+
   it('matches terminal background, foreground, and scoped text tokens', () => {
     const vars = resolveLeftSidebarStyleVariables(
       settings({

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -1,6 +1,8 @@
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import { HEX_COLOR_RE } from '../../../shared/color-validation'
 import {
+  DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
+  normalizeActiveWorkspaceContrast,
   normalizeLeftSidebarTintColor,
   normalizeLeftSidebarTintOpacity
 } from '../../../shared/left-sidebar-appearance'
@@ -11,6 +13,7 @@ type LeftSidebarAppearanceSettings = Pick<
   | 'leftSidebarAppearanceMode'
   | 'leftSidebarTintColor'
   | 'leftSidebarTintOpacity'
+  | 'activeWorkspaceContrast'
   | 'theme'
   | 'terminalThemeDark'
   | 'terminalDividerColorDark'
@@ -113,6 +116,29 @@ function resolveTintedSurfaceVariables(
   return buildSurfaceVariables({ background, foreground: 'var(--foreground)' })
 }
 
+function resolveActiveWorkspaceContrastVariables(
+  value: number | undefined
+): LeftSidebarStyleVariables | undefined {
+  const contrast = normalizeActiveWorkspaceContrast(value)
+  if (contrast === DEFAULT_ACTIVE_WORKSPACE_CONTRAST) {
+    return undefined
+  }
+  // Why: the optional steps must be visibly distinct in light/tinted themes,
+  // while the default CSS fallback preserves the original subtle treatment.
+  if (contrast === 2) {
+    return {
+      '--worktree-card-active-bg-mix': '18%',
+      '--worktree-card-active-dark-bg-mix': '15%',
+      '--worktree-card-active-border-mix': '60%'
+    }
+  }
+  return {
+    '--worktree-card-active-bg-mix': '26%',
+    '--worktree-card-active-dark-bg-mix': '19%',
+    '--worktree-card-active-border-mix': '78%'
+  }
+}
+
 export function resolveLeftSidebarStyleVariables(
   settings: LeftSidebarAppearanceSettings | null | undefined,
   systemPrefersDark: boolean
@@ -120,12 +146,21 @@ export function resolveLeftSidebarStyleVariables(
   if (!settings) {
     return undefined
   }
+  const activeWorkspaceContrastVariables = resolveActiveWorkspaceContrastVariables(
+    settings.activeWorkspaceContrast
+  )
   switch (settings.leftSidebarAppearanceMode) {
     case 'default':
-      return undefined
+      return activeWorkspaceContrastVariables
     case 'match-terminal':
-      return resolveTerminalSurfaceVariables(settings, systemPrefersDark)
+      return {
+        ...resolveTerminalSurfaceVariables(settings, systemPrefersDark),
+        ...activeWorkspaceContrastVariables
+      }
     case 'tinted':
-      return resolveTintedSurfaceVariables(settings)
+      return {
+        ...resolveTintedSurfaceVariables(settings),
+        ...activeWorkspaceContrastVariables
+      }
   }
 }

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -1,6 +1,8 @@
 import type { GlobalSettings } from '../../../shared/types'
 import { HEX_COLOR_RE } from '../../../shared/color-validation'
 import {
+  DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
+  normalizeActiveWorkspaceContrast,
   normalizeLeftSidebarTintColor,
   normalizeLeftSidebarTintOpacity
 } from '../../../shared/left-sidebar-appearance'
@@ -11,6 +13,7 @@ type LeftSidebarAppearanceSettings = Pick<
   | 'leftSidebarAppearanceMode'
   | 'leftSidebarTintColor'
   | 'leftSidebarTintOpacity'
+  | 'activeWorkspaceContrast'
   | 'theme'
   | 'terminalThemeDark'
   | 'terminalDividerColorDark'
@@ -113,6 +116,29 @@ function resolveTintedSurfaceVariables(
   return buildSurfaceVariables({ background, foreground: 'var(--foreground)' })
 }
 
+function resolveActiveWorkspaceContrastVariables(
+  value: number | undefined
+): LeftSidebarStyleVariables | undefined {
+  const contrast = normalizeActiveWorkspaceContrast(value)
+  if (contrast === DEFAULT_ACTIVE_WORKSPACE_CONTRAST) {
+    return undefined
+  }
+  // Why: the optional steps must be visibly distinct in light/tinted themes,
+  // while the default CSS fallback preserves the original subtle treatment.
+  if (contrast === 2) {
+    return {
+      '--worktree-card-active-bg-mix': '18%',
+      '--worktree-card-active-dark-bg-mix': '15%',
+      '--worktree-card-active-border-mix': '60%'
+    }
+  }
+  return {
+    '--worktree-card-active-bg-mix': '26%',
+    '--worktree-card-active-dark-bg-mix': '19%',
+    '--worktree-card-active-border-mix': '78%'
+  }
+}
+
 export function resolveLeftSidebarStyleVariables(
   settings: LeftSidebarAppearanceSettings | null | undefined,
   systemPrefersDark: boolean
@@ -120,12 +146,21 @@ export function resolveLeftSidebarStyleVariables(
   if (!settings) {
     return undefined
   }
+  const activeWorkspaceContrastVariables = resolveActiveWorkspaceContrastVariables(
+    settings.activeWorkspaceContrast
+  )
   switch (settings.leftSidebarAppearanceMode) {
     case 'default':
-      return undefined
+      return activeWorkspaceContrastVariables
     case 'match-terminal':
-      return resolveTerminalSurfaceVariables(settings, systemPrefersDark)
+      return {
+        ...resolveTerminalSurfaceVariables(settings, systemPrefersDark),
+        ...activeWorkspaceContrastVariables
+      }
     case 'tinted':
-      return resolveTintedSurfaceVariables(settings)
+      return {
+        ...resolveTintedSurfaceVariables(settings),
+        ...activeWorkspaceContrastVariables
+      }
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -23,6 +23,7 @@ import { DEFAULT_DISABLED_TUI_AGENTS } from './tui-agent-selection'
 import { DEFAULT_TUI_AGENT_ARGS, DEFAULT_TUI_AGENT_ENV } from './tui-agent-launch-defaults'
 import { UI_LANGUAGE_SYSTEM } from './ui-language'
 import {
+  DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
   DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
   DEFAULT_LEFT_SIDEBAR_TINT_OPACITY
 } from './left-sidebar-appearance'
@@ -184,6 +185,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     leftSidebarAppearanceMode: 'default',
     leftSidebarTintColor: DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
     leftSidebarTintOpacity: DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,
+    activeWorkspaceContrast: DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
     uiLanguage: UI_LANGUAGE_SYSTEM,
     appIcon: DEFAULT_APP_ICON_ID,
     appFontFamily: DEFAULT_APP_FONT_FAMILY,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -25,6 +25,7 @@ import { DEFAULT_DISABLED_TUI_AGENTS } from './tui-agent-selection'
 import { DEFAULT_TUI_AGENT_ARGS, DEFAULT_TUI_AGENT_ENV } from './tui-agent-launch-defaults'
 import { UI_LANGUAGE_SYSTEM } from './ui-language'
 import {
+  DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
   DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
   DEFAULT_LEFT_SIDEBAR_TINT_OPACITY
 } from './left-sidebar-appearance'
@@ -197,6 +198,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     leftSidebarAppearanceMode: 'default',
     leftSidebarTintColor: DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
     leftSidebarTintOpacity: DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,
+    activeWorkspaceContrast: DEFAULT_ACTIVE_WORKSPACE_CONTRAST,
     uiLanguage: UI_LANGUAGE_SYSTEM,
     appIcon: DEFAULT_APP_ICON_ID,
     appFontFamily: DEFAULT_APP_FONT_FAMILY,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -78,6 +78,8 @@ export type GlobalSettings = {
   leftSidebarAppearanceMode: LeftSidebarAppearanceMode
   leftSidebarTintColor?: string
   leftSidebarTintOpacity?: number
+  /** Strength of the persistent active workspace highlight in the left sidebar. */
+  activeWorkspaceContrast?: number
   uiLanguage: UiLanguage
   appIcon: AppIconId
   appFontFamily: string

--- a/src/shared/left-sidebar-appearance.ts
+++ b/src/shared/left-sidebar-appearance.ts
@@ -3,6 +3,8 @@ import { HEX_COLOR_RE } from './color-validation'
 export const DEFAULT_LEFT_SIDEBAR_TINT_COLOR = '#18181b'
 export const DEFAULT_LEFT_SIDEBAR_TINT_OPACITY = 0.08
 export const MAX_LEFT_SIDEBAR_TINT_OPACITY = 0.35
+export const DEFAULT_ACTIVE_WORKSPACE_CONTRAST = 1
+export const MAX_ACTIVE_WORKSPACE_CONTRAST = 3
 
 export function normalizeLeftSidebarTintColor(value: unknown): string {
   if (typeof value !== 'string') {
@@ -20,4 +22,11 @@ export function normalizeLeftSidebarTintOpacity(value: unknown): number {
     return DEFAULT_LEFT_SIDEBAR_TINT_OPACITY
   }
   return Math.min(MAX_LEFT_SIDEBAR_TINT_OPACITY, Math.max(0, value))
+}
+
+export function normalizeActiveWorkspaceContrast(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_ACTIVE_WORKSPACE_CONTRAST
+  }
+  return Math.min(MAX_ACTIVE_WORKSPACE_CONTRAST, Math.max(1, Math.round(value)))
 }

--- a/src/shared/left-sidebar-appearance.ts
+++ b/src/shared/left-sidebar-appearance.ts
@@ -6,6 +6,8 @@ export const LEFT_SIDEBAR_APPEARANCE_MODES = ['default', 'match-terminal', 'tint
 export const DEFAULT_LEFT_SIDEBAR_TINT_COLOR = '#18181b'
 export const DEFAULT_LEFT_SIDEBAR_TINT_OPACITY = 0.08
 export const MAX_LEFT_SIDEBAR_TINT_OPACITY = 0.35
+export const DEFAULT_ACTIVE_WORKSPACE_CONTRAST = 1
+export const MAX_ACTIVE_WORKSPACE_CONTRAST = 3
 
 export function normalizeLeftSidebarAppearanceMode(value: unknown): LeftSidebarAppearanceMode {
   return LEFT_SIDEBAR_APPEARANCE_MODES.includes(value as LeftSidebarAppearanceMode)
@@ -29,4 +31,11 @@ export function normalizeLeftSidebarTintOpacity(value: unknown): number {
     return DEFAULT_LEFT_SIDEBAR_TINT_OPACITY
   }
   return Math.min(MAX_LEFT_SIDEBAR_TINT_OPACITY, Math.max(0, value))
+}
+
+export function normalizeActiveWorkspaceContrast(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_ACTIVE_WORKSPACE_CONTRAST
+  }
+  return Math.min(MAX_ACTIVE_WORKSPACE_CONTRAST, Math.max(1, Math.round(value)))
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2489,6 +2489,8 @@ export type GlobalSettings = {
   leftSidebarAppearanceMode: LeftSidebarAppearanceMode
   leftSidebarTintColor?: string
   leftSidebarTintOpacity?: number
+  /** Strength of the persistent active workspace highlight in the left sidebar. */
+  activeWorkspaceContrast?: number
   uiLanguage: UiLanguage
   appIcon: AppIconId
   appFontFamily: string


### PR DESCRIPTION
## Summary
- Slightly strengthens the default active workspace card treatment so the current workspace is easier to spot in light/tinted sidebar appearances.
- Adds an optional `Active Workspace Contrast` segmented setting with Default / More / High levels.
- Keeps the treatment token-driven so match-terminal and tinted sidebars adapt to the user’s configured colors.

Closes #7727

## Screenshots
<img width="1906" height="1556" alt="orca-7727-pr-focused-active-workspace-default-more-high" src="https://github.com/user-attachments/assets/789ca2ad-3aad-48c2-a41d-4b9df2cd1b79" />

- PR comparison artifact generated locally (not committed): `~/Desktop/orca-7727-pr-focused-active-workspace-default-more-high.png`
- Source captures/crops generated locally (not committed): `~/Desktop/orca-7727-pr-active-workspace-focused/`

## AI Review Report
- Verified the default remains subtle and close to the prior card style.
- Checked that the stronger options reuse sidebar CSS variables rather than fixed colors, so custom terminal/tint/sidebar colors continue to drive the visual treatment.
- Confirmed the setting is searchable via Settings search and lives with the existing Left Sidebar Appearance controls.
- Cross-platform compatibility: changes are renderer CSS/settings only, with no OS-specific shortcuts, paths, Electron APIs, shell commands, or filesystem behavior. The setting should behave the same on macOS, Linux, Windows, SSH, and local sessions.

## Security Audit
- No new network, filesystem, shell, or IPC surfaces.
- Adds only a numeric persisted UI preference, normalized to the supported 1–3 range before use.
- CSS variable values are generated from fixed percentages, not user-provided strings.

## Tests/Testing
- [x] Typecheck: `pnpm exec tsc --noEmit --pretty false`
- [x] Targeted tests: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/left-sidebar-appearance.test.ts src/renderer/src/components/settings/AppearancePane.test.tsx` — 24 tests passed
- [x] Visual review: captured focused comparison for Default / More / High across Default, Match Terminal, and Tinted sidebar appearances

## Notes
- Screenshot artifacts were intentionally kept out of git.

## ELI5

The active workspace card is a bit clearer by default, with optional More/High contrast. Easier to spot which workspace you’re in, especially on light or tinted sidebars.
