### PR TITLE
fix(gitlab): load pipeline job details in the Checks panel

### DIFF
--- a/src/renderer/src/components/editor/check-run-details-tab.test.ts
+++ b/src/renderer/src/components/editor/check-run-details-tab.test.ts
@@ -38,6 +38,20 @@ describe('check-run-details-tab', () => {
     ).toBe('url:https://github.com/acme/widgets/actions/runs/1')
   })
 
+  it('keys GitLab jobs on the job id so same-named jobs across pipelines stay distinct', () => {
+    // Why: GitLab jobs share stage:name across pipeline runs and may have no
+    // url, so the name fallback would collide two distinct jobs onto one tab.
+    expect(
+      getCheckRunTabIdentity({
+        name: 'deploy: deploy',
+        status: 'completed',
+        conclusion: 'failure',
+        url: null,
+        gitlabJobId: 42
+      })
+    ).toBe('gitlab-job:42')
+  })
+
   it('uses the check name for the tab label', () => {
     expect(
       getCheckRunDetailsTabLabel({

--- a/src/renderer/src/components/editor/check-run-details-tab.ts
+++ b/src/renderer/src/components/editor/check-run-details-tab.ts
@@ -15,6 +15,11 @@ export function getCheckRunTabIdentity(check: PRCheckDetail): string {
   if (check.workflowRunId) {
     return `workflow-run:${check.workflowRunId}`
   }
+  // Why: GitLab jobs share names across pipelines and may have no url, so key
+  // on the job id first to avoid two distinct jobs colliding onto one tab.
+  if (check.gitlabJobId) {
+    return `gitlab-job:${check.gitlabJobId}`
+  }
   if (check.url) {
     return `url:${check.url}`
   }

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -62,6 +62,7 @@ import type {
   PRCheckRunDetails,
   PRComment
 } from '../../../../shared/types'
+import { loadGitLabCheckRunDetails } from './gitlab-check-details-loader'
 import { getConnectionId } from '@/lib/connection-context'
 import {
   buildResolvePullRequestConflictsPrompt,
@@ -1791,9 +1792,19 @@ export default function ChecksPanel(): React.JSX.Element {
   )
 
   const handleLoadCheckDetails = useCallback(
-    (check: PRCheckDetail) => {
+    async (check: PRCheckDetail): Promise<PRCheckRunDetails | null> => {
       if (!repo) {
-        return Promise.resolve(null)
+        return null
+      }
+      // GitLab pipeline jobs have no check-run/workflow ids; load their trace
+      // through `gitlab:jobTrace` instead of GitHub's check-details API.
+      if (check.gitlabJobId) {
+        return loadGitLabCheckRunDetails({
+          repoPath: repo.path,
+          repoId: repo.id,
+          settings,
+          check
+        })
       }
       return fetchPRCheckDetails(
         repo.path,
@@ -1807,7 +1818,7 @@ export default function ChecksPanel(): React.JSX.Element {
         { repoId: repo.id }
       )
     },
-    [fetchPRCheckDetails, pr?.prRepo, repo]
+    [fetchPRCheckDetails, pr?.prRepo, repo, settings]
   )
 
   useEffect(() => {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1649,7 +1649,9 @@ export default function ChecksPanel(): React.JSX.Element {
         const details = await fetchGitLabMRDetailsForChecks({
           repoPath: repo.path,
           repoId: repo.id,
-          settings,
+          // Why: route to the active worktree's runtime so the job list (and the
+          // trace fetch keyed off it) resolve against the same GitLab host.
+          settings: ownerSettings,
           iid: targetMRNumber
         })
         if (!isCurrentAsyncResult(requestKey)) {
@@ -1685,7 +1687,7 @@ export default function ChecksPanel(): React.JSX.Element {
       hostedReviewCacheKey,
       isCurrentAsyncResult,
       repo,
-      settings
+      ownerSettings
     ]
   )
 
@@ -1802,7 +1804,9 @@ export default function ChecksPanel(): React.JSX.Element {
         return loadGitLabCheckRunDetails({
           repoPath: repo.path,
           repoId: repo.id,
-          settings,
+          // Why: route to the active worktree's runtime, not the globally-active
+          // one, matching the other runtime-routed calls in this component.
+          settings: ownerSettings,
           check
         })
       }
@@ -1818,7 +1822,7 @@ export default function ChecksPanel(): React.JSX.Element {
         { repoId: repo.id }
       )
     },
-    [fetchPRCheckDetails, pr?.prRepo, repo, settings]
+    [fetchPRCheckDetails, ownerSettings, pr?.prRepo, repo]
   )
 
   useEffect(() => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -1045,7 +1045,12 @@ export function ChecksList({
       if (detailsByCheckKey[row.key]?.loading || detailsByCheckKey[row.key]?.details) {
         return
       }
-      if (!row.check.checkRunId && !row.check.workflowRunId && !row.check.url) {
+      if (
+        !row.check.checkRunId &&
+        !row.check.workflowRunId &&
+        !row.check.url &&
+        !row.check.gitlabJobId
+      ) {
         setDetailsByCheckKey((current) => ({
           ...current,
           [row.key]: {

--- a/src/renderer/src/components/right-sidebar/gitlab-check-details-loader.test.ts
+++ b/src/renderer/src/components/right-sidebar/gitlab-check-details-loader.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import type * as RuntimeRpcClient from '@/runtime/runtime-rpc-client'
+import { loadGitLabCheckRunDetails } from './gitlab-check-details-loader'
+import type { PRCheckDetail } from '../../../../shared/types'
+
+vi.mock('@/runtime/runtime-rpc-client', async () => {
+  const actual = await vi.importActual<typeof RuntimeRpcClient>('@/runtime/runtime-rpc-client')
+  return {
+    ...actual,
+    callRuntimeRpc: vi.fn()
+  }
+})
+
+const jobTrace = vi.fn()
+
+const CHECK: PRCheckDetail = {
+  name: 'test: unit',
+  status: 'completed',
+  conclusion: 'failure',
+  url: 'https://gitlab.com/acme/orca/-/jobs/1',
+  gitlabJobId: 1
+}
+
+describe('loadGitLabCheckRunDetails', () => {
+  beforeEach(() => {
+    vi.mocked(callRuntimeRpc).mockReset()
+    jobTrace.mockReset()
+    vi.stubGlobal('window', { api: { gl: { jobTrace } } })
+  })
+
+  afterEach(() => {
+    // Why: restore the real `window` so sibling suites relying on jsdom's
+    // localStorage/DOM aren't broken by this stub leaking across files.
+    vi.unstubAllGlobals()
+  })
+
+  it('returns null for a non-GitLab check without hitting any transport', async () => {
+    const { gitlabJobId: _omit, ...githubCheck } = CHECK
+
+    await expect(
+      loadGitLabCheckRunDetails({
+        repoPath: '/workspace/app',
+        repoId: 'repo-1',
+        settings: { activeRuntimeEnvironmentId: null },
+        check: githubCheck
+      })
+    ).resolves.toBeNull()
+    expect(jobTrace).not.toHaveBeenCalled()
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
+  })
+
+  it('fetches the trace over the local IPC bridge and adapts it', async () => {
+    jobTrace.mockResolvedValue({ ok: true, trace: 'boom' })
+
+    const details = await loadGitLabCheckRunDetails({
+      repoPath: '/workspace/app',
+      repoId: 'repo-1',
+      settings: { activeRuntimeEnvironmentId: null },
+      check: CHECK
+    })
+
+    expect(jobTrace).toHaveBeenCalledWith({
+      repoPath: '/workspace/app',
+      repoId: 'repo-1',
+      jobId: 1
+    })
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
+    expect(details?.jobs[0]).toMatchObject({ id: 1, logTail: 'boom' })
+  })
+
+  it('routes through runtime RPC when a runtime environment is active (SSH/remote)', async () => {
+    vi.mocked(callRuntimeRpc).mockResolvedValue({ ok: true, trace: 'remote log' })
+
+    const details = await loadGitLabCheckRunDetails({
+      repoPath: '/workspace/app',
+      repoId: 'repo-1',
+      settings: { activeRuntimeEnvironmentId: 'env-1' },
+      check: CHECK
+    })
+
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'gitlab.jobTrace',
+      { repo: 'repo-1', jobId: 1 },
+      { timeoutMs: 30_000 }
+    )
+    expect(jobTrace).not.toHaveBeenCalled()
+    expect(details?.jobs[0]?.logTail).toBe('remote log')
+  })
+
+  it('throws the GitLab error verbatim when the trace fetch fails', async () => {
+    jobTrace.mockResolvedValue({ ok: false, error: 'job log expired' })
+
+    await expect(
+      loadGitLabCheckRunDetails({
+        repoPath: '/workspace/app',
+        repoId: 'repo-1',
+        settings: { activeRuntimeEnvironmentId: null },
+        check: CHECK
+      })
+    ).rejects.toThrow('job log expired')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/gitlab-check-details-loader.ts
+++ b/src/renderer/src/components/right-sidebar/gitlab-check-details-loader.ts
@@ -1,0 +1,46 @@
+import type {
+  GitLabJobTraceResult,
+  PRCheckDetail,
+  PRCheckRunDetails
+} from '../../../../shared/types'
+import { gitLabJobTraceToCheckRunDetails } from '../../../../shared/gitlab-job-trace-check-details'
+import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+
+/**
+ * Loads inline details for a GitLab pipeline job by fetching its trace via
+ * `gitlab:jobTrace` and adapting it into the shared `PRCheckRunDetails` shape.
+ * Shared by the Checks panel and the full-details editor tab so both surfaces
+ * render GitLab jobs through the same GitHub-parity rendering path.
+ *
+ * Returns `null` when the check is not a GitLab job (no `gitlabJobId`); throws
+ * on a failed trace fetch so callers can surface the GitLab error verbatim.
+ */
+export async function loadGitLabCheckRunDetails(args: {
+  repoPath: string
+  repoId?: string
+  settings: Parameters<typeof getActiveRuntimeTarget>[0]
+  check: PRCheckDetail
+}): Promise<PRCheckRunDetails | null> {
+  const jobId = args.check.gitlabJobId
+  if (!jobId) {
+    return null
+  }
+  const target = getActiveRuntimeTarget(args.settings)
+  const result =
+    target.kind === 'environment'
+      ? await callRuntimeRpc<GitLabJobTraceResult>(
+          target,
+          'gitlab.jobTrace',
+          { repo: args.repoId ?? args.repoPath, jobId },
+          { timeoutMs: 30_000 }
+        )
+      : ((await window.api.gl.jobTrace({
+          repoPath: args.repoPath,
+          repoId: args.repoId,
+          jobId
+        })) as GitLabJobTraceResult)
+  if (!result.ok) {
+    throw new Error(result.error || 'Failed to load GitLab job log.')
+  }
+  return gitLabJobTraceToCheckRunDetails(args.check, result.trace)
+}

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -59,6 +59,7 @@ import {
   statRuntimePath
 } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
+import { loadGitLabCheckRunDetails } from '@/components/right-sidebar/gitlab-check-details-loader'
 import { notifyHostOfMirroredEditorClose } from '@/runtime/close-mirrored-editor-tab'
 import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -3223,17 +3224,26 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     }
     patch({ details: checkRunDetails.details, loading: true, error: null })
     try {
-      const details = await get().fetchPRCheckDetails(
-        repo.path,
-        {
-          checkRunId: check.checkRunId,
-          workflowRunId: check.workflowRunId,
-          checkName: check.name,
-          url: check.url,
-          prRepo: null
-        },
-        { repoId: repo.id }
-      )
+      // GitLab pipeline jobs have no check-run/workflow ids; reload their trace
+      // through `gitlab:jobTrace` instead of GitHub's check-details API.
+      const details = check.gitlabJobId
+        ? await loadGitLabCheckRunDetails({
+            repoPath: repo.path,
+            repoId: repo.id,
+            settings: settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId),
+            check
+          })
+        : await get().fetchPRCheckDetails(
+            repo.path,
+            {
+              checkRunId: check.checkRunId,
+              workflowRunId: check.workflowRunId,
+              checkName: check.name,
+              url: check.url,
+              prRepo: null
+            },
+            { repoId: repo.id }
+          )
       patch({
         details,
         loading: false,

--- a/src/shared/gitlab-job-trace-check-details.test.ts
+++ b/src/shared/gitlab-job-trace-check-details.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { gitLabJobTraceToCheckRunDetails } from './gitlab-job-trace-check-details'
+import type { PRCheckDetail } from './types'
+
+const CHECK: PRCheckDetail = {
+  name: 'test: unit',
+  status: 'completed',
+  conclusion: 'failure',
+  url: 'https://gitlab.com/acme/orca/-/jobs/1',
+  gitlabJobId: 1
+}
+
+describe('gitLabJobTraceToCheckRunDetails', () => {
+  it('adapts a trace into a single-job PRCheckRunDetails carrying the log tail', () => {
+    const details = gitLabJobTraceToCheckRunDetails(CHECK, 'line 1\nERROR: boom\nline 3')
+
+    expect(details.name).toBe('test: unit')
+    expect(details.status).toBe('completed')
+    expect(details.conclusion).toBe('failure')
+    expect(details.url).toBe('https://gitlab.com/acme/orca/-/jobs/1')
+    expect(details.detailsUrl).toBe('https://gitlab.com/acme/orca/-/jobs/1')
+    expect(details.annotations).toEqual([])
+    expect(details.jobs).toHaveLength(1)
+    expect(details.jobs[0]).toMatchObject({
+      id: 1,
+      name: 'test: unit',
+      logTail: 'line 1\nERROR: boom\nline 3',
+      steps: []
+    })
+  })
+
+  it('keeps only the trailing 200 lines of a large trace', () => {
+    const trace = Array.from({ length: 500 }, (_, index) => `line ${index}`).join('\n')
+
+    const [job] = gitLabJobTraceToCheckRunDetails(CHECK, trace).jobs
+    const tailLines = job.logTail?.split('\n') ?? []
+
+    expect(tailLines).toHaveLength(200)
+    expect(tailLines[0]).toBe('line 300')
+    expect(tailLines.at(-1)).toBe('line 499')
+  })
+
+  it('emits no job when the trace is empty so the panel shows its empty state', () => {
+    expect(gitLabJobTraceToCheckRunDetails(CHECK, '   \n  ').jobs).toEqual([])
+  })
+
+  it('falls back to a null job id when the check has no gitlabJobId', () => {
+    const { gitlabJobId: _omit, ...withoutId } = CHECK
+    const [job] = gitLabJobTraceToCheckRunDetails(withoutId, 'boom').jobs
+
+    expect(job.id).toBeNull()
+  })
+})

--- a/src/shared/gitlab-job-trace-check-details.ts
+++ b/src/shared/gitlab-job-trace-check-details.ts
@@ -1,0 +1,54 @@
+import type { PRCheckDetail, PRCheckRunDetails } from './types'
+
+// Why: GitLab job traces can be megabytes; the Checks panel only needs the tail
+// to surface the failure, matching the GitHub log-excerpt behavior.
+const GITLAB_TRACE_TAIL_LINES = 200
+
+function sliceTraceTail(trace: string): string {
+  const lines = trace.split(/\r?\n/)
+  if (lines.length <= GITLAB_TRACE_TAIL_LINES) {
+    return trace
+  }
+  return lines.slice(-GITLAB_TRACE_TAIL_LINES).join('\n')
+}
+
+/**
+ * Adapts a GitLab job trace into the shared `PRCheckRunDetails` shape so the
+ * Checks panel and full-details tab can reuse the GitHub rendering path. GitLab
+ * exposes a single flat trace per job rather than GitHub's step/annotation
+ * breakdown, so the trace lands in one synthetic job's `logTail`.
+ */
+export function gitLabJobTraceToCheckRunDetails(
+  check: PRCheckDetail,
+  trace: string
+): PRCheckRunDetails {
+  const logTail = sliceTraceTail(trace).trim()
+  return {
+    name: check.name,
+    status: check.status,
+    conclusion: check.conclusion,
+    url: check.url,
+    detailsUrl: check.url,
+    startedAt: null,
+    completedAt: null,
+    title: null,
+    summary: null,
+    text: null,
+    annotations: [],
+    jobs: logTail
+      ? [
+          {
+            id: check.gitlabJobId ?? null,
+            name: check.name,
+            status: check.status,
+            conclusion: check.conclusion,
+            startedAt: null,
+            completedAt: null,
+            url: check.url,
+            logTail,
+            steps: []
+          }
+        ]
+      : []
+  }
+}

--- a/src/shared/gitlab-pipeline-checks.test.ts
+++ b/src/shared/gitlab-pipeline-checks.test.ts
@@ -44,26 +44,51 @@ describe('gitLabPipelineJobsToPRChecks', () => {
         name: 'test: unit',
         status: 'completed',
         conclusion: 'failure',
-        url: 'https://gitlab.com/acme/orca/-/jobs/1'
+        url: 'https://gitlab.com/acme/orca/-/jobs/1',
+        gitlabJobId: 1
       },
       {
         name: 'deploy: deploy',
         status: 'completed',
         conclusion: 'neutral',
-        url: null
+        url: null,
+        gitlabJobId: 2
       },
       {
         name: 'deploy: delayed deploy',
         status: 'queued',
         conclusion: 'pending',
-        url: 'https://gitlab.com/acme/orca/-/jobs/3'
+        url: 'https://gitlab.com/acme/orca/-/jobs/3',
+        gitlabJobId: 3
       },
       {
         name: 'integration: external callback',
         status: 'queued',
         conclusion: 'pending',
-        url: 'https://gitlab.com/acme/orca/-/jobs/4'
+        url: 'https://gitlab.com/acme/orca/-/jobs/4',
+        gitlabJobId: 4
       }
     ])
+  })
+
+  it('omits gitlabJobId when the job has no id', () => {
+    const [row] = gitLabPipelineJobsToPRChecks([
+      {
+        id: 0,
+        name: 'orphan',
+        stage: '',
+        status: 'success',
+        webUrl: '',
+        duration: null
+      }
+    ])
+
+    expect(row).toEqual({
+      name: 'orphan',
+      status: 'completed',
+      conclusion: 'success',
+      url: null
+    })
+    expect(row).not.toHaveProperty('gitlabJobId')
   })
 })

--- a/src/shared/gitlab-pipeline-checks.ts
+++ b/src/shared/gitlab-pipeline-checks.ts
@@ -59,6 +59,9 @@ export function gitLabPipelineJobsToPRChecks(jobs: GitLabPipelineJob[]): PRCheck
     name: job.stage ? `${job.stage}: ${job.name}` : job.name,
     status: mapGitLabPipelineJobStatusToCheckStatus(job.status),
     conclusion: mapGitLabPipelineJobStatusToConclusion(job.status),
-    url: job.webUrl || null
+    url: job.webUrl || null,
+    // Why: lets the Checks panel fetch this job's trace via `gitlab:jobTrace`,
+    // since GitLab jobs have no GitHub-style check-run/workflow ids.
+    ...(job.id ? { gitlabJobId: job.id } : {})
   }))
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1270,6 +1270,9 @@ export type PRCheckDetail = {
   url: string | null
   checkRunId?: number
   workflowRunId?: number
+  // Why: GitLab pipeline jobs have no check-run/workflow ids; carry the raw job
+  // id so the Checks panel can load its trace via `gitlab:jobTrace`.
+  gitlabJobId?: number
 }
 
 export type PRCheckAnnotation = {

--- a/tests/e2e/gitlab-checks-job-details.spec.ts
+++ b/tests/e2e/gitlab-checks-job-details.spec.ts
@@ -1,0 +1,83 @@
+import type { Page } from '@stablyai/playwright-test'
+import { mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { openChecks } from './helpers/source-control-ai-generation'
+import {
+  GITLAB_CHECKS_FIXTURE,
+  installGitLabChecksBackend,
+  linkGitLabMRToWorktree
+} from './helpers/gitlab-checks-fixture'
+
+async function resolveActiveWorktreeId(page: Page): Promise<string> {
+  const worktreeId = await page.evaluate(() => window.__store?.getState().activeWorktreeId ?? null)
+  if (!worktreeId) {
+    throw new Error('E2E fixture did not expose an active worktree')
+  }
+  return worktreeId
+}
+
+test.describe('GitLab Checks panel job details', () => {
+  test('expands a failed pipeline job to show its log excerpt', async ({
+    orcaPage,
+    electronApp
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+
+    await installGitLabChecksBackend(electronApp)
+    const worktreeId = await resolveActiveWorktreeId(orcaPage)
+    await linkGitLabMRToWorktree(orcaPage, worktreeId, GITLAB_CHECKS_FIXTURE.mrNumber)
+
+    await openChecks(orcaPage, worktreeId)
+
+    // The pipeline job renders as a check row labelled "<stage>: <name>".
+    const rowLabel = `${GITLAB_CHECKS_FIXTURE.stage}: ${GITLAB_CHECKS_FIXTURE.jobName}`
+    const jobRow = orcaPage.getByText(rowLabel, { exact: true })
+    await expect(jobRow).toBeVisible({ timeout: 10_000 })
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `gitlab-checks-job-details-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '01-gitlab-checks-job-collapsed.png')
+    })
+
+    // Expand the job row → the fix loads the trace instead of showing
+    // "No inline details are available for this check." The inline panel keeps
+    // the full log behind "View full logs" (matching GitHub), so assert the
+    // failed-jobs section and the log-tail affordance render.
+    await jobRow.click()
+
+    await expect(orcaPage.getByText('No inline details are available for this check.')).toHaveCount(
+      0
+    )
+    const viewFullLogs = orcaPage.getByRole('button', { name: 'View full logs' })
+    await expect(viewFullLogs).toBeVisible({ timeout: 10_000 })
+    await expect(orcaPage.getByText('Log tail available in full details.')).toBeVisible()
+
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '02-gitlab-checks-job-expanded.png')
+    })
+
+    // Open the full-details tab → the actual trace renders in the editor.
+    await viewFullLogs.click()
+    await expect(orcaPage.getByText('AssertionError: expected refunded amount')).toBeVisible({
+      timeout: 10_000
+    })
+    await expect(orcaPage.getByText('ERROR: Job failed: exit code 1')).toBeVisible()
+
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '03-gitlab-checks-job-full-logs.png')
+    })
+  })
+})

--- a/tests/e2e/helpers/gitlab-checks-fixture.ts
+++ b/tests/e2e/helpers/gitlab-checks-fixture.ts
@@ -1,0 +1,131 @@
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+
+/**
+ * Synthetic GitLab MR + failed pipeline job used to drive the Checks panel
+ * without a live GitLab project. All values are fake so evidence screenshots
+ * carry no private data.
+ */
+export const GITLAB_CHECKS_FIXTURE = {
+  mrNumber: 4242,
+  jobId: 987654,
+  jobName: 'Purchase API Component Tests',
+  stage: 'Component Tests',
+  webUrl: 'https://gitlab.example.test/acme/orca/-/jobs/987654',
+  mrUrl: 'https://gitlab.example.test/acme/orca/-/merge_requests/4242',
+  headSha: 'e2ee2ee2ee2ee2ee2ee2ee2ee2ee2ee2ee2ee2e',
+  trace: [
+    '$ pnpm test:component --project purchase-api',
+    'Running 128 component tests across 6 shards…',
+    'PASS  src/purchase/cart.spec.ts (42 tests)',
+    'PASS  src/purchase/checkout.spec.ts (37 tests)',
+    'FAIL  src/purchase/refund.spec.ts',
+    '  ● refund flow › issues a partial refund for a split payment',
+    '    AssertionError: expected refunded amount 4200 to equal 4250',
+    '      at Object.<anonymous> (src/purchase/refund.spec.ts:118:32)',
+    'Tests: 1 failed, 127 passed, 128 total',
+    'ERROR: Job failed: exit code 1'
+  ].join('\n')
+} as const
+
+/**
+ * Re-registers the GitLab + hosted-review IPC handlers in the main process so
+ * the real renderer fetch path resolves to synthetic data. Returns nothing; the
+ * handlers stay installed for the lifetime of the app instance.
+ */
+export async function installGitLabChecksBackend(
+  electronApp: ElectronApplication,
+  fixture: typeof GITLAB_CHECKS_FIXTURE = GITLAB_CHECKS_FIXTURE
+): Promise<void> {
+  await electronApp.evaluate(({ ipcMain }, fx) => {
+    ipcMain.removeHandler('hostedReview:forBranch')
+    ipcMain.handle('hostedReview:forBranch', async () => ({
+      provider: 'gitlab',
+      number: fx.mrNumber,
+      title: 'Add purchase API component test coverage',
+      state: 'open',
+      url: fx.mrUrl,
+      status: 'failure',
+      updatedAt: '2026-07-07T12:00:00.000Z',
+      mergeable: 'MERGEABLE',
+      headSha: fx.headSha
+    }))
+
+    ipcMain.removeHandler('gitlab:workItemDetails')
+    ipcMain.handle('gitlab:workItemDetails', async () => ({
+      item: {
+        id: `gitlab-mr-${fx.mrNumber}`,
+        type: 'mr',
+        number: fx.mrNumber,
+        title: 'Add purchase API component test coverage',
+        state: 'opened',
+        url: fx.mrUrl,
+        labels: [],
+        updatedAt: '2026-07-07T12:00:00.000Z',
+        author: 'e2e-bot'
+      },
+      body: 'Synthetic MR used for Checks panel evidence.',
+      comments: [],
+      headSha: fx.headSha,
+      pipelineJobs: [
+        {
+          id: fx.jobId,
+          pipelineId: 55,
+          name: fx.jobName,
+          stage: fx.stage,
+          status: 'failed',
+          webUrl: fx.webUrl,
+          duration: 87
+        }
+      ],
+      reviewers: []
+    }))
+
+    ipcMain.removeHandler('gitlab:jobTrace')
+    ipcMain.handle('gitlab:jobTrace', async () => ({ ok: true, trace: fx.trace }))
+  }, fixture)
+}
+
+/**
+ * Links the synthetic GitLab MR to the given worktree and clears its git status
+ * so the Checks panel renders the review header + pipeline jobs.
+ */
+export async function linkGitLabMRToWorktree(
+  page: Page,
+  worktreeId: string,
+  mrNumber: number
+): Promise<void> {
+  await page.evaluate(
+    ({ worktreeId, mrNumber }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      store.setState((current) => ({
+        worktreesByRepo: Object.fromEntries(
+          Object.entries(current.worktreesByRepo).map(([repoId, worktrees]) => [
+            repoId,
+            worktrees.map((worktree) =>
+              worktree.id === worktreeId ? { ...worktree, linkedGitLabMR: mrNumber } : worktree
+            )
+          ])
+        ),
+        gitStatusByWorktree: {
+          ...current.gitStatusByWorktree,
+          [worktreeId]: []
+        }
+      }))
+    },
+    { worktreeId, mrNumber }
+  )
+  await expect
+    .poll(
+      () =>
+        page.evaluate((worktreeId) => {
+          const worktrees = Object.values(window.__store?.getState().worktreesByRepo ?? {}).flat()
+          return worktrees.find((entry) => entry.id === worktreeId)?.linkedGitLabMR ?? null
+        }, worktreeId),
+      { timeout: 5_000 }
+    )
+    .toBe(mrNumber)
+}


### PR DESCRIPTION
## Summary

GitLab pipeline jobs already show up in the Checks side panel with a status, but expanding a row always rendered **"No inline details are available for this check."** The expand path was wired only to GitHub's `getPRCheckDetails`, which needs an owner/repo plus a check-run/workflow id — none of which a GitLab job has — so it returned `null`.

This carries the raw GitLab job id through `gitLabPipelineJobsToPRChecks` and, when a check has one, loads its details via the existing `gitlab:jobTrace` IPC, adapting the trace into the shared `PRCheckRunDetails` shape so both the side panel and the full-details editor tab reuse the GitHub rendering path. The trace fetch routes through runtime RPC for SSH/remote workspaces, mirroring the existing GitLab MR-details fetch.

While wiring this up, the review surfaced two adjacent gaps that are fixed here too:
- `requestCheckDetails` now treats `gitlabJobId` as a valid detail source, so jobs with no `web_url` (e.g. manual/delayed jobs) still load instead of short-circuiting to the "no details" message.
- `getCheckRunTabIdentity` keys GitLab jobs on the job id so two same-named jobs across pipelines don't collide onto one full-details tab.

Closes #7732

## Screenshots

Verified against a real GitLab MR with a failing pipeline locally (expanding the failed job now renders its log instead of "No inline details are available"). Those shots contain private data, so the images attached to this PR conversation are generated by the new headless E2E spec (`tests/e2e/gitlab-checks-job-details.spec.ts`) against a **synthetic** MR + failed job — no real project, credentials, or private data.

The spec captures:
1. **Checks panel — failed job expanded:** the pipeline job renders with a `View full logs` button and log-tail hint (previously "No inline details are available for this check").
2. **Full-details tab:** clicking `View full logs` opens the job trace (`LOG EXCERPT`) in the editor, with the `Fix with AI` / `Refresh` actions.

_(Attaching the two PNGs to the conversation — not committing them, per the repo's evidence rule.)_

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm lint` (only failure is a pre-existing `switch-exhaustiveness` error in `source-control-manual-review-url.ts`, unrelated to this change — reproduces on a clean `main`)
- [x] `pnpm test` for the affected suites (`gitlab-pipeline-checks`, `gitlab-job-trace-check-details`, `gitlab-check-details-loader`, `check-run-details-tab`) — 14 passing
- [x] Added unit tests: trace→details adapter (truncation, empty trace, null id), local vs runtime-RPC routing, error propagation, `gitlabJobId` mapping, and GitLab tab-identity keying
- [x] Added headless Electron E2E spec (`tests/e2e/gitlab-checks-job-details.spec.ts`) driving the Checks panel against a synthetic GitLab MR + failed job — passing
- [x] Manually verified against a live GitLab MR with a failing pipeline (see Screenshots)

## AI Review Report

Ran a high-effort AI code review (parallel correctness + cross-file/removed-behavior finders, then verification). It confirmed two real bugs that are now fixed in this PR: the `requestCheckDetails` guard blocking no-URL GitLab jobs, and the `getCheckRunTabIdentity` collision for same-named jobs. It also flagged a defensive gap (undefined error message) now guarded with a fallback string. Lower-risk items (GitLab job id `0`, empty-trace→empty-state) were judged by-design and left as-is.

- **Cross-platform (macOS/Linux/Windows):** No platform-specific code, shortcuts, labels, or path handling touched. Logic is pure data transform + IPC routing.
- **SSH/remote/local:** Explicitly handled — the trace fetch routes through `callRuntimeRpc('gitlab.jobTrace', …)` when a runtime environment is active, and through the local `window.api.gl.jobTrace` bridge otherwise, with a test for each path.
- **Git provider compatibility:** GitHub behavior is unchanged (the GitLab branch only activates when a check carries `gitlabJobId`, which GitHub checks never have). Reuses the shared provider-neutral `PRCheckRunDetails` rendering path.
- **Performance:** No new hot-path work; the trace is fetched lazily on expand and truncated to the trailing 200 lines before rendering.
- **UI quality:** Reuses the existing "Log excerpt" surface; no new tokens or components.

## Security Audit

- **Input handling:** The GitLab trace is treated as text and rendered through the existing check-details log surface; no new HTML/markdown injection path (the log tail renders in a `<pre>`-style excerpt like the GitHub log tail).
- **Command execution / paths:** None introduced. The trace is fetched via the existing typed `gitlab:jobTrace` IPC / runtime RPC method; no new shell or filesystem access.
- **IPC:** Uses an already-registered IPC channel and RPC method with its existing repo-registration guard; no new channel added.
- **Secrets / auth:** None handled in this change.

## Notes

- The GitLab job-trace backend (`gitlab:jobTrace` IPC + `getJobTrace`) already existed and is used by `GitLabItemDialog`; this PR only wires it into the Checks panel + full-details tab.
- The E2E spec stubs data by re-registering the `hostedReview:forBranch` / `gitlab:workItemDetails` / `gitlab:jobTrace` IPC handlers in the main process (contextIsolation makes `window.api` non-writable), so the real renderer fetch + render path is exercised end-to-end.
- One architectural note: the editor store slice now imports a helper from `components/right-sidebar/` (verified no circular import). If maintainers prefer, the shared loader could move under `runtime/` or `lib/` — happy to relocate.

## ELI5

Expanding a GitLab pipeline job in Checks always said no details were available. Job details now load for GitLab the way check runs already do for GitHub.
