### PR TITLE
fix(omp): migrate legacy overlay state

### DIFF
--- a/src/main/pi/legacy-omp-overlay-migration.ts
+++ b/src/main/pi/legacy-omp-overlay-migration.ts
@@ -1,0 +1,242 @@
+import { cpSync, lstatSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import type { Dirent, Stats } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { ORCA_PI_AGENT_STATUS_EXTENSION_FILE } from './agent-status-extension-source'
+import { ORCA_PI_PREFILL_EXTENSION_FILE } from './prefill-extension-source'
+import { ORCA_PI_EXTENSION_FILE } from './titlebar-extension-source'
+import { isSafeDescendCandidate } from '../pty/overlay-mirror'
+
+const LEGACY_PI_OVERLAY_MANIFEST_FILE = '.orca-pi-overlay-manifest.json'
+const LEGACY_OMP_OVERLAY_MIGRATION_MARKER_FILE = '.orca-omp-overlay-migration-complete'
+const PI_AGENT_SETTINGS_FILE = 'settings.json'
+const SQLITE_DATABASE_EXTENSION = '.db'
+const SQLITE_SIDECAR_SUFFIXES = ['-wal', '-shm', '-journal'] as const
+const MANAGED_EXTENSION_FILES = new Set([
+  ORCA_PI_EXTENSION_FILE,
+  ORCA_PI_PREFILL_EXTENSION_FILE,
+  ORCA_PI_AGENT_STATUS_EXTENSION_FILE
+])
+
+type DeferredSidecar = {
+  baseTargetPath: string
+  entry: Dirent
+  nextSegments: string[]
+}
+
+function getPathStats(path: string): Stats | undefined {
+  try {
+    return lstatSync(path)
+  } catch {
+    return undefined
+  }
+}
+
+function getSqliteSidecarBaseName(name: string): string | undefined {
+  for (const suffix of SQLITE_SIDECAR_SUFFIXES) {
+    if (!name.endsWith(suffix)) {
+      continue
+    }
+    const baseName = name.slice(0, -suffix.length)
+    return baseName.endsWith(SQLITE_DATABASE_EXTENSION) ? baseName : undefined
+  }
+  return undefined
+}
+
+function shouldSkipLegacyOverlayEntry(pathSegments: string[]): boolean {
+  const name = pathSegments.at(-1)
+  if (!name) {
+    return true
+  }
+  if (pathSegments.length === 1) {
+    return (
+      name === LEGACY_PI_OVERLAY_MANIFEST_FILE ||
+      name === LEGACY_OMP_OVERLAY_MIGRATION_MARKER_FILE ||
+      name === PI_AGENT_SETTINGS_FILE
+    )
+  }
+  return (
+    pathSegments.length === 2 &&
+    pathSegments[0] === 'extensions' &&
+    MANAGED_EXTENSION_FILES.has(name)
+  )
+}
+
+function copyLegacyFile(
+  overlayPath: string,
+  targetPath: string,
+  copiedFilePaths: Set<string>
+): boolean {
+  if (getPathStats(targetPath)) {
+    return true
+  }
+  try {
+    mkdirSync(dirname(targetPath), { recursive: true })
+    cpSync(overlayPath, targetPath, {
+      errorOnExist: true,
+      force: false,
+      preserveTimestamps: true
+    })
+    copiedFilePaths.add(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function removeCopiedFiles(paths: string[], copiedFilePaths: Set<string>): void {
+  for (const path of paths) {
+    if (!copiedFilePaths.delete(path)) {
+      continue
+    }
+    try {
+      unlinkSync(path)
+    } catch {
+      // Best-effort: withholding the marker lets later spawns retry.
+    }
+  }
+}
+
+function copyDeferredSidecars(
+  overlayDir: string,
+  sourceAgentDir: string,
+  copiedFilePaths: Set<string>,
+  deferredSidecars: DeferredSidecar[]
+): boolean {
+  let completed = true
+  const copiedSidecarsByBase = new Map<string, string[]>()
+  for (const { baseTargetPath, entry, nextSegments } of deferredSidecars) {
+    if (!copiedFilePaths.has(baseTargetPath)) {
+      continue
+    }
+
+    const overlayPath = join(overlayDir, entry.name)
+    const targetPath = join(sourceAgentDir, ...nextSegments)
+    const stats = getPathStats(overlayPath)
+    if (!stats) {
+      removeCopiedFiles(
+        [baseTargetPath, ...(copiedSidecarsByBase.get(baseTargetPath) ?? [])],
+        copiedFilePaths
+      )
+      completed = false
+      continue
+    }
+    if (stats.isSymbolicLink() || !stats.isFile()) {
+      continue
+    }
+    const wasCopied = copiedFilePaths.has(targetPath)
+    if (!copyLegacyFile(overlayPath, targetPath, copiedFilePaths)) {
+      removeCopiedFiles(
+        [baseTargetPath, ...(copiedSidecarsByBase.get(baseTargetPath) ?? [])],
+        copiedFilePaths
+      )
+      completed = false
+      continue
+    }
+    if (!wasCopied && copiedFilePaths.has(targetPath)) {
+      copiedSidecarsByBase.set(baseTargetPath, [
+        ...(copiedSidecarsByBase.get(baseTargetPath) ?? []),
+        targetPath
+      ])
+    }
+  }
+  return completed
+}
+
+function copyMissingLegacyOmpOverlayEntries(
+  overlayDir: string,
+  sourceAgentDir: string,
+  pathSegments: string[] = [],
+  copiedFilePaths: Set<string> = new Set()
+): boolean {
+  let completed = true
+  let entries: Dirent[]
+  try {
+    entries = readdirSync(overlayDir, { withFileTypes: true })
+  } catch {
+    return false
+  }
+
+  const deferredSidecars: DeferredSidecar[] = []
+  for (const entry of entries) {
+    const nextSegments = [...pathSegments, entry.name]
+    if (shouldSkipLegacyOverlayEntry(nextSegments)) {
+      continue
+    }
+
+    const sidecarBaseName = getSqliteSidecarBaseName(entry.name)
+    if (sidecarBaseName) {
+      deferredSidecars.push({
+        baseTargetPath: join(sourceAgentDir, ...pathSegments, sidecarBaseName),
+        entry,
+        nextSegments
+      })
+      continue
+    }
+
+    const overlayPath = join(overlayDir, entry.name)
+    const targetPath = join(sourceAgentDir, ...nextSegments)
+    const stats = getPathStats(overlayPath)
+    if (!stats) {
+      completed = false
+      continue
+    }
+    if (stats.isSymbolicLink()) {
+      continue
+    }
+    if (stats.isDirectory()) {
+      const targetStats = getPathStats(targetPath)
+      if (targetStats && !isSafeDescendCandidate(targetStats)) {
+        continue
+      }
+      if (!targetStats) {
+        try {
+          mkdirSync(targetPath, { recursive: true })
+        } catch {
+          completed = false
+          continue
+        }
+      }
+      completed =
+        copyMissingLegacyOmpOverlayEntries(
+          overlayPath,
+          sourceAgentDir,
+          nextSegments,
+          copiedFilePaths
+        ) && completed
+      continue
+    }
+    if (!stats.isFile()) {
+      continue
+    }
+    completed = copyLegacyFile(overlayPath, targetPath, copiedFilePaths) && completed
+  }
+
+  return (
+    copyDeferredSidecars(overlayDir, sourceAgentDir, copiedFilePaths, deferredSidecars) && completed
+  )
+}
+
+export function migrateLegacyOmpOverlayState(sourceAgentDir: string, overlayDir: string): void {
+  // Why: temporary rescue shim for OMP builds from the legacy overlay window.
+  // Remove after 2026-08-07 once affected users have had a full upgrade window.
+  const overlayStats = getPathStats(overlayDir)
+  if (!overlayStats || overlayStats.isSymbolicLink() || !overlayStats.isDirectory()) {
+    return
+  }
+  const markerPath = join(overlayDir, LEGACY_OMP_OVERLAY_MIGRATION_MARKER_FILE)
+  if (getPathStats(markerPath)) {
+    return
+  }
+  try {
+    mkdirSync(sourceAgentDir, { recursive: true })
+    // Why: some pre-managed-extension builds pointed OMP at this overlay, so
+    // first-login auth/session files can exist only there after an update.
+    if (copyMissingLegacyOmpOverlayEntries(overlayDir, sourceAgentDir)) {
+      // Why: legacy source overlays can be large and are intentionally kept
+      // for recovery; mark clean migrations so future OMP spawns stay cheap.
+      writeFileSync(markerPath, 'complete\n')
+    }
+  } catch (error) {
+    console.warn('[pi-titlebar-extension] failed to migrate legacy OMP overlay state:', error)
+  }
+}

--- a/src/main/pi/titlebar-extension-service.test.ts
+++ b/src/main/pi/titlebar-extension-service.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import {
   existsSync,
   mkdirSync,
@@ -48,6 +50,12 @@ import { PiTitlebarExtensionService, isSafeDescendCandidate } from './titlebar-e
 function legacyOverlayPath(kind: 'pi' | 'omp', ptyId: string): string {
   const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
   return join(userDataDir, rootDir, ptyId)
+}
+
+function legacySourceOverlayPath(kind: 'pi' | 'omp', sourceAgentDir: string): string {
+  const rootDir = kind === 'pi' ? 'pi-agent-overlays' : 'omp-agent-overlays'
+  const hashed = createHash('sha256').update(`source:${sourceAgentDir}`).digest('hex').slice(0, 32)
+  return join(userDataDir, rootDir, hashed)
 }
 
 describe('PiTitlebarExtensionService', () => {
@@ -184,6 +192,66 @@ describe('PiTitlebarExtensionService', () => {
 
     expect(readFileSync(sourcePath, 'utf-8')).toBe(content)
   })
+
+  it('migrates missing OMP state from the old source overlay without overwriting source files', () => {
+    rmSync(join(piHome, 'sessions'), { recursive: true, force: true })
+    const overlayDir = legacySourceOverlayPath('omp', piHome)
+    mkdirSync(join(overlayDir, 'sessions'), { recursive: true })
+    mkdirSync(join(overlayDir, 'extensions'), { recursive: true })
+    writeFileSync(join(overlayDir, 'agent.db'), 'legacy sqlite credentials')
+    writeFileSync(join(overlayDir, 'agent.db-wal'), 'legacy sqlite wal')
+    writeFileSync(join(overlayDir, 'sessions', 'legacy-session.jsonl'), 'legacy transcript')
+    writeFileSync(join(overlayDir, 'auth.json'), 'legacy token should not overwrite')
+    writeFileSync(join(overlayDir, 'settings.json'), '{"overlayOnly":true}')
+    writeFileSync(join(overlayDir, '.orca-pi-overlay-manifest.json'), '{}')
+    writeFileSync(join(overlayDir, 'extensions', 'orca-agent-status.ts'), 'stale managed extension')
+    writeFileSync(join(overlayDir, 'extensions', 'legacy-user-ext.ts'), 'legacy user extension')
+
+    const svc = new PiTitlebarExtensionService()
+    const env = svc.buildPtyEnv('pty-omp-migrate', piHome, 'omp')
+
+    expect(env.PI_CODING_AGENT_DIR).toBeUndefined()
+    expect(readFileSync(join(piHome, 'agent.db'), 'utf-8')).toBe('legacy sqlite credentials')
+    expect(readFileSync(join(piHome, 'agent.db-wal'), 'utf-8')).toBe('legacy sqlite wal')
+    expect(readFileSync(join(piHome, 'sessions', 'legacy-session.jsonl'), 'utf-8')).toBe(
+      'legacy transcript'
+    )
+    expect(readFileSync(join(piHome, 'auth.json'), 'utf-8')).toBe('secret token')
+    expect(JSON.parse(readFileSync(join(piHome, 'settings.json'), 'utf-8'))).toEqual({
+      defaultProvider: 'amazon-bedrock',
+      hideThinkingBlock: false,
+      packages: ['npm:pi-web-access'],
+      terminal: {
+        showImages: false,
+        clearOnShrink: false
+      }
+    })
+    expect(readFileSync(join(piHome, 'extensions', 'legacy-user-ext.ts'), 'utf-8')).toBe(
+      'legacy user extension'
+    )
+    expect(readFileSync(join(piHome, 'extensions', 'orca-agent-status.ts'), 'utf-8')).toContain(
+      '/hook/omp'
+    )
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'skips special legacy overlay entries while continuing the OMP migration',
+    () => {
+      rmSync(join(piHome, 'sessions'), { recursive: true, force: true })
+      const overlayDir = legacySourceOverlayPath('omp', piHome)
+      mkdirSync(join(overlayDir, 'sessions'), { recursive: true })
+      execFileSync('mkfifo', [join(overlayDir, 'stray-fifo')])
+      writeFileSync(join(overlayDir, 'sessions', 'legacy-session.jsonl'), 'legacy transcript')
+
+      const svc = new PiTitlebarExtensionService()
+      svc.buildPtyEnv('pty-omp-special-entry', piHome, 'omp')
+
+      expect(existsSync(join(piHome, 'stray-fifo'))).toBe(false)
+      expect(readFileSync(join(piHome, 'sessions', 'legacy-session.jsonl'), 'utf-8')).toBe(
+        'legacy transcript'
+      )
+    }
+  )
 
   it('rebuilding managed extensions for the same ptyId does not corrupt the user Pi dir', () => {
     const svc = new PiTitlebarExtensionService()

--- a/src/main/pi/titlebar-extension-service.test.ts
+++ b/src/main/pi/titlebar-extension-service.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import {
+  chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -13,6 +15,7 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import type * as osModule from 'node:os'
+import type * as fsModule from 'node:fs'
 import { join } from 'node:path'
 
 // The service calls app.getPath('userData') for its overlay root. Point that
@@ -206,6 +209,11 @@ describe('PiTitlebarExtensionService', () => {
     writeFileSync(join(overlayDir, '.orca-pi-overlay-manifest.json'), '{}')
     writeFileSync(join(overlayDir, 'extensions', 'orca-agent-status.ts'), 'stale managed extension')
     writeFileSync(join(overlayDir, 'extensions', 'legacy-user-ext.ts'), 'legacy user extension')
+    mkdirSync(join(overlayDir, 'extensions', 'legacy-package'), { recursive: true })
+    writeFileSync(
+      join(overlayDir, 'extensions', 'legacy-package', 'orca-prefill.ts'),
+      'user package file'
+    )
 
     const svc = new PiTitlebarExtensionService()
     const env = svc.buildPtyEnv('pty-omp-migrate', piHome, 'omp')
@@ -229,9 +237,129 @@ describe('PiTitlebarExtensionService', () => {
     expect(readFileSync(join(piHome, 'extensions', 'legacy-user-ext.ts'), 'utf-8')).toBe(
       'legacy user extension'
     )
+    expect(
+      readFileSync(join(piHome, 'extensions', 'legacy-package', 'orca-prefill.ts'), 'utf-8')
+    ).toBe('user package file')
     expect(readFileSync(join(piHome, 'extensions', 'orca-agent-status.ts'), 'utf-8')).toContain(
       '/hook/omp'
     )
+    expect(readFileSync(join(overlayDir, '.orca-omp-overlay-migration-complete'), 'utf-8')).toBe(
+      'complete\n'
+    )
+  })
+
+  it('does not copy stale SQLite sidecars when the target database already exists', () => {
+    const overlayDir = legacySourceOverlayPath('omp', piHome)
+    mkdirSync(overlayDir, { recursive: true })
+    writeFileSync(join(overlayDir, 'agent.db'), 'legacy sqlite credentials')
+    writeFileSync(join(overlayDir, 'agent.db-wal'), 'legacy sqlite wal')
+    writeFileSync(join(overlayDir, 'agent.db-shm'), 'legacy sqlite shm')
+    writeFileSync(join(piHome, 'agent.db'), 'fresh sqlite credentials')
+
+    const svc = new PiTitlebarExtensionService()
+    svc.buildPtyEnv('pty-omp-stale-sidecars', piHome, 'omp')
+
+    expect(readFileSync(join(piHome, 'agent.db'), 'utf-8')).toBe('fresh sqlite credentials')
+    expect(existsSync(join(piHome, 'agent.db-wal'))).toBe(false)
+    expect(existsSync(join(piHome, 'agent.db-shm'))).toBe(false)
+    expect(readFileSync(join(overlayDir, '.orca-omp-overlay-migration-complete'), 'utf-8')).toBe(
+      'complete\n'
+    )
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'retries a legacy SQLite migration as a whole set after sidecar copy failure',
+    () => {
+      const overlayDir = legacySourceOverlayPath('omp', piHome)
+      mkdirSync(overlayDir, { recursive: true })
+      const walPath = join(overlayDir, 'agent.db-wal')
+      writeFileSync(join(overlayDir, 'agent.db'), 'legacy sqlite credentials')
+      writeFileSync(walPath, 'legacy sqlite wal')
+      chmodSync(walPath, 0o000)
+
+      try {
+        const svc = new PiTitlebarExtensionService()
+        svc.buildPtyEnv('pty-omp-sidecar-fail-1', piHome, 'omp')
+
+        expect(existsSync(join(piHome, 'agent.db'))).toBe(false)
+        expect(existsSync(join(piHome, 'agent.db-wal'))).toBe(false)
+        expect(existsSync(join(overlayDir, '.orca-omp-overlay-migration-complete'))).toBe(false)
+
+        chmodSync(walPath, 0o600)
+        svc.buildPtyEnv('pty-omp-sidecar-fail-2', piHome, 'omp')
+
+        expect(readFileSync(join(piHome, 'agent.db'), 'utf-8')).toBe('legacy sqlite credentials')
+        expect(readFileSync(join(piHome, 'agent.db-wal'), 'utf-8')).toBe('legacy sqlite wal')
+        expect(
+          readFileSync(join(overlayDir, '.orca-omp-overlay-migration-complete'), 'utf-8')
+        ).toBe('complete\n')
+      } finally {
+        chmodSync(walPath, 0o600)
+      }
+    }
+  )
+
+  it('retries a legacy SQLite migration as a whole set after sidecar stat failure', async () => {
+    const overlayDir = legacySourceOverlayPath('omp', piHome)
+    mkdirSync(overlayDir, { recursive: true })
+    const walPath = join(overlayDir, 'agent.db-wal')
+    writeFileSync(join(overlayDir, 'agent.db'), 'legacy sqlite credentials')
+    writeFileSync(walPath, 'legacy sqlite wal')
+
+    let failNextWalStat = true
+    vi.resetModules()
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof fsModule>()
+      return {
+        ...actual,
+        lstatSync: (path: Parameters<typeof actual.lstatSync>[0]) => {
+          if (String(path) === walPath && failNextWalStat) {
+            failNextWalStat = false
+            throw new Error('transient lstat failure')
+          }
+          return actual.lstatSync(path)
+        }
+      }
+    })
+
+    try {
+      const { migrateLegacyOmpOverlayState } = await import('./legacy-omp-overlay-migration')
+      migrateLegacyOmpOverlayState(piHome, overlayDir)
+
+      expect(existsSync(join(piHome, 'agent.db'))).toBe(false)
+      expect(existsSync(join(piHome, 'agent.db-wal'))).toBe(false)
+      expect(existsSync(join(overlayDir, '.orca-omp-overlay-migration-complete'))).toBe(false)
+
+      migrateLegacyOmpOverlayState(piHome, overlayDir)
+
+      expect(readFileSync(join(piHome, 'agent.db'), 'utf-8')).toBe('legacy sqlite credentials')
+      expect(readFileSync(join(piHome, 'agent.db-wal'), 'utf-8')).toBe('legacy sqlite wal')
+      expect(readFileSync(join(overlayDir, '.orca-omp-overlay-migration-complete'), 'utf-8')).toBe(
+        'complete\n'
+      )
+    } finally {
+      vi.doUnmock('node:fs')
+      vi.resetModules()
+    }
+  })
+
+  it('marks successful legacy OMP migrations so old overlays are not re-scanned', () => {
+    const overlayDir = legacySourceOverlayPath('omp', piHome)
+    mkdirSync(overlayDir, { recursive: true })
+    writeFileSync(join(overlayDir, 'agent.db'), 'legacy sqlite credentials')
+
+    const svc = new PiTitlebarExtensionService()
+    svc.buildPtyEnv('pty-omp-migrate-once-1', piHome, 'omp')
+
+    expect(readFileSync(join(piHome, 'agent.db'), 'utf-8')).toBe('legacy sqlite credentials')
+    expect(readFileSync(join(overlayDir, '.orca-omp-overlay-migration-complete'), 'utf-8')).toBe(
+      'complete\n'
+    )
+
+    writeFileSync(join(overlayDir, 'later-overlay-only-file'), 'should not migrate')
+    svc.buildPtyEnv('pty-omp-migrate-once-2', piHome, 'omp')
+
+    expect(existsSync(join(piHome, 'later-overlay-only-file'))).toBe(false)
   })
 
   it.skipIf(process.platform === 'win32')(
@@ -250,6 +378,57 @@ describe('PiTitlebarExtensionService', () => {
       expect(readFileSync(join(piHome, 'sessions', 'legacy-session.jsonl'), 'utf-8')).toBe(
         'legacy transcript'
       )
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'does not descend through existing target directory symlinks while migrating OMP state',
+    () => {
+      rmSync(join(piHome, 'sessions'), { recursive: true, force: true })
+      const overlayDir = legacySourceOverlayPath('omp', piHome)
+      mkdirSync(join(overlayDir, 'sessions'), { recursive: true })
+      writeFileSync(join(overlayDir, 'sessions', 'legacy-session.jsonl'), 'legacy transcript')
+      const outsideDir = mkdtempSync(join(tmpdir(), 'orca-omp-target-junction-'))
+      const sessionsPath = join(piHome, 'sessions')
+
+      try {
+        symlinkSync(outsideDir, sessionsPath, 'dir')
+        const svc = new PiTitlebarExtensionService()
+        svc.buildPtyEnv('pty-omp-target-dir-symlink', piHome, 'omp')
+
+        expect(lstatSync(sessionsPath).isSymbolicLink()).toBe(true)
+        expect(existsSync(join(outsideDir, 'legacy-session.jsonl'))).toBe(false)
+      } finally {
+        rmSync(outsideDir, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'does not follow existing target symlinks while migrating OMP state',
+    () => {
+      rmSync(join(piHome, 'sessions'), { recursive: true, force: true })
+      const overlayDir = legacySourceOverlayPath('omp', piHome)
+      mkdirSync(join(overlayDir, 'sessions'), { recursive: true })
+      writeFileSync(join(overlayDir, 'agent.db'), 'legacy sqlite credentials')
+      writeFileSync(join(overlayDir, 'sessions', 'legacy-session.jsonl'), 'legacy transcript')
+      const outsideDir = mkdtempSync(join(tmpdir(), 'orca-omp-dangling-target-'))
+
+      try {
+        const outsideTarget = join(outsideDir, 'agent.db')
+        symlinkSync(outsideTarget, join(piHome, 'agent.db'), 'file')
+
+        const svc = new PiTitlebarExtensionService()
+        svc.buildPtyEnv('pty-omp-target-symlink', piHome, 'omp')
+
+        expect(existsSync(outsideTarget)).toBe(false)
+        expect(lstatSync(join(piHome, 'agent.db')).isSymbolicLink()).toBe(true)
+        expect(readFileSync(join(piHome, 'sessions', 'legacy-session.jsonl'), 'utf-8')).toBe(
+          'legacy transcript'
+        )
+      } finally {
+        rmSync(outsideDir, { recursive: true, force: true })
+      }
     }
   )
 

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -1,14 +1,6 @@
-import {
-  cpSync,
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  writeFileSync
-} from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { app } from 'electron'
 import { createHash } from 'node:crypto'
 import {
@@ -25,6 +17,7 @@ import {
   isSafeDescendCandidate as sharedIsSafeDescendCandidate,
   safeRemoveOverlay
 } from '../pty/overlay-mirror'
+import { migrateLegacyOmpOverlayState } from './legacy-omp-overlay-migration'
 import type { PiAgentKind } from '../../shared/pi-agent-kind'
 
 // Why: the Pi test suite imports `isSafeDescendCandidate` from this module's
@@ -36,13 +29,6 @@ export const isSafeDescendCandidate = sharedIsSafeDescendCandidate
 const PI_AGENT_SUBDIR = 'agent'
 const ORCA_MANAGED_EXTENSION_MARKER = '@orca-managed-pi-extension'
 const OMP_MANAGED_STATUS_EXTENSION_DIR = 'omp-managed-status-extension'
-const LEGACY_PI_OVERLAY_MANIFEST_FILE = '.orca-pi-overlay-manifest.json'
-const PI_AGENT_SETTINGS_FILE = 'settings.json'
-const MANAGED_EXTENSION_FILES = new Set([
-  ORCA_PI_EXTENSION_FILE,
-  ORCA_PI_PREFILL_EXTENSION_FILE,
-  ORCA_PI_AGENT_STATUS_EXTENSION_FILE
-])
 
 type ManagedExtensionWriteResult = 'written' | 'skipped-user-owned' | 'failed'
 
@@ -145,79 +131,6 @@ export class PiTitlebarExtensionService {
     return this.writeManagedExtension(fallbackPath, source) === 'written' ? fallbackPath : undefined
   }
 
-  private shouldSkipLegacyOverlayEntry(pathSegments: string[]): boolean {
-    const name = pathSegments.at(-1)
-    if (!name) {
-      return true
-    }
-    if (pathSegments.length === 1) {
-      return name === LEGACY_PI_OVERLAY_MANIFEST_FILE || name === PI_AGENT_SETTINGS_FILE
-    }
-    return pathSegments[0] === 'extensions' && MANAGED_EXTENSION_FILES.has(name)
-  }
-
-  private copyMissingLegacyOmpOverlayEntries(
-    overlayDir: string,
-    sourceAgentDir: string,
-    pathSegments: string[] = []
-  ): void {
-    for (const entry of readdirSync(overlayDir, { withFileTypes: true })) {
-      const nextSegments = [...pathSegments, entry.name]
-      if (this.shouldSkipLegacyOverlayEntry(nextSegments)) {
-        continue
-      }
-
-      const overlayPath = join(overlayDir, entry.name)
-      const targetPath = join(sourceAgentDir, ...nextSegments)
-      let stats
-      try {
-        stats = lstatSync(overlayPath)
-      } catch {
-        continue
-      }
-      if (stats.isSymbolicLink()) {
-        continue
-      }
-      if (stats.isDirectory()) {
-        if (existsSync(targetPath)) {
-          try {
-            if (!lstatSync(targetPath).isDirectory()) {
-              continue
-            }
-          } catch {
-            continue
-          }
-        } else {
-          mkdirSync(targetPath, { recursive: true })
-        }
-        this.copyMissingLegacyOmpOverlayEntries(overlayPath, sourceAgentDir, nextSegments)
-        continue
-      }
-      if (!stats.isFile()) {
-        continue
-      }
-      if (!existsSync(targetPath)) {
-        mkdirSync(dirname(targetPath), { recursive: true })
-        cpSync(overlayPath, targetPath, { preserveTimestamps: true })
-      }
-    }
-  }
-
-  private migrateLegacyOmpOverlayState(sourceAgentDir: string): void {
-    const overlayDir = this.getSourceOverlayDir(sourceAgentDir, 'omp')
-    if (!existsSync(overlayDir)) {
-      return
-    }
-    try {
-      mkdirSync(sourceAgentDir, { recursive: true })
-      // Why: some pre-managed-extension builds pointed OMP at this overlay, so
-      // first-login auth/session files can exist only there after an update.
-      this.copyMissingLegacyOmpOverlayEntries(overlayDir, sourceAgentDir)
-    } catch (error) {
-      console.warn('[pi-titlebar-extension] failed to migrate legacy OMP overlay state:', error)
-    }
-  }
-
   private installManagedExtensions(
     sourceAgentDir: string,
     kind: PiAgentKind
@@ -268,7 +181,7 @@ export class PiTitlebarExtensionService {
     }
 
     if (kind === 'omp') {
-      this.migrateLegacyOmpOverlayState(sourceAgentDir)
+      migrateLegacyOmpOverlayState(sourceAgentDir, this.getSourceOverlayDir(sourceAgentDir, 'omp'))
     }
 
     const installed = this.installManagedExtensions(sourceAgentDir, kind)

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -1,6 +1,14 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync
+} from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { app } from 'electron'
 import { createHash } from 'node:crypto'
 import {
@@ -28,6 +36,13 @@ export const isSafeDescendCandidate = sharedIsSafeDescendCandidate
 const PI_AGENT_SUBDIR = 'agent'
 const ORCA_MANAGED_EXTENSION_MARKER = '@orca-managed-pi-extension'
 const OMP_MANAGED_STATUS_EXTENSION_DIR = 'omp-managed-status-extension'
+const LEGACY_PI_OVERLAY_MANIFEST_FILE = '.orca-pi-overlay-manifest.json'
+const PI_AGENT_SETTINGS_FILE = 'settings.json'
+const MANAGED_EXTENSION_FILES = new Set([
+  ORCA_PI_EXTENSION_FILE,
+  ORCA_PI_PREFILL_EXTENSION_FILE,
+  ORCA_PI_AGENT_STATUS_EXTENSION_FILE
+])
 
 type ManagedExtensionWriteResult = 'written' | 'skipped-user-owned' | 'failed'
 
@@ -72,6 +87,12 @@ function withOrcaManagedExtensionMarker(source: string): string {
 export class PiTitlebarExtensionService {
   private getOverlayRoot(kind: PiAgentKind): string {
     return join(app.getPath('userData'), OVERLAY_ROOT_DIR_NAME[kind])
+  }
+
+  private getSourceOverlayDir(sourceAgentDir: string, kind: PiAgentKind): string {
+    // Why: builds before managed extensions stored Pi/OMP state in source-scoped
+    // overlays. Resolve the old path so OMP upgrades can rescue stranded state.
+    return join(this.getOverlayRoot(kind), toSafeOverlayDirName(`source:${sourceAgentDir}`))
   }
 
   private getPtyOverlayDir(ptyId: string, kind: PiAgentKind): string {
@@ -124,6 +145,79 @@ export class PiTitlebarExtensionService {
     return this.writeManagedExtension(fallbackPath, source) === 'written' ? fallbackPath : undefined
   }
 
+  private shouldSkipLegacyOverlayEntry(pathSegments: string[]): boolean {
+    const name = pathSegments.at(-1)
+    if (!name) {
+      return true
+    }
+    if (pathSegments.length === 1) {
+      return name === LEGACY_PI_OVERLAY_MANIFEST_FILE || name === PI_AGENT_SETTINGS_FILE
+    }
+    return pathSegments[0] === 'extensions' && MANAGED_EXTENSION_FILES.has(name)
+  }
+
+  private copyMissingLegacyOmpOverlayEntries(
+    overlayDir: string,
+    sourceAgentDir: string,
+    pathSegments: string[] = []
+  ): void {
+    for (const entry of readdirSync(overlayDir, { withFileTypes: true })) {
+      const nextSegments = [...pathSegments, entry.name]
+      if (this.shouldSkipLegacyOverlayEntry(nextSegments)) {
+        continue
+      }
+
+      const overlayPath = join(overlayDir, entry.name)
+      const targetPath = join(sourceAgentDir, ...nextSegments)
+      let stats
+      try {
+        stats = lstatSync(overlayPath)
+      } catch {
+        continue
+      }
+      if (stats.isSymbolicLink()) {
+        continue
+      }
+      if (stats.isDirectory()) {
+        if (existsSync(targetPath)) {
+          try {
+            if (!lstatSync(targetPath).isDirectory()) {
+              continue
+            }
+          } catch {
+            continue
+          }
+        } else {
+          mkdirSync(targetPath, { recursive: true })
+        }
+        this.copyMissingLegacyOmpOverlayEntries(overlayPath, sourceAgentDir, nextSegments)
+        continue
+      }
+      if (!stats.isFile()) {
+        continue
+      }
+      if (!existsSync(targetPath)) {
+        mkdirSync(dirname(targetPath), { recursive: true })
+        cpSync(overlayPath, targetPath, { preserveTimestamps: true })
+      }
+    }
+  }
+
+  private migrateLegacyOmpOverlayState(sourceAgentDir: string): void {
+    const overlayDir = this.getSourceOverlayDir(sourceAgentDir, 'omp')
+    if (!existsSync(overlayDir)) {
+      return
+    }
+    try {
+      mkdirSync(sourceAgentDir, { recursive: true })
+      // Why: some pre-managed-extension builds pointed OMP at this overlay, so
+      // first-login auth/session files can exist only there after an update.
+      this.copyMissingLegacyOmpOverlayEntries(overlayDir, sourceAgentDir)
+    } catch (error) {
+      console.warn('[pi-titlebar-extension] failed to migrate legacy OMP overlay state:', error)
+    }
+  }
+
   private installManagedExtensions(
     sourceAgentDir: string,
     kind: PiAgentKind
@@ -171,6 +265,10 @@ export class PiTitlebarExtensionService {
     } catch {
       // Why: old per-PTY overlay cleanup is best-effort; a locked stale
       // directory should not prevent the terminal from starting.
+    }
+
+    if (kind === 'omp') {
+      this.migrateLegacyOmpOverlayState(sourceAgentDir)
     }
 
     const installed = this.installManagedExtensions(sourceAgentDir, kind)


### PR DESCRIPTION
## Summary

- Migrate missing OMP-owned files from legacy source-scoped Orca overlay directories back into the normal OMP agent home.
- Copy only missing real files/directories; skip symlinks, special files, managed Orca extension files, overlay manifests, and overlay settings.
- Add regression coverage for stranded OMP auth/session state after update, plus special-file resilience.

Fixes #7723

## Screenshots

No visual change.

Suggested screen-recordable demo command:

```bash
pnpm exec vitest run src/main/pi/titlebar-extension-service.test.ts -t "migrates missing OMP state" --pool=forks --reporter=verbose
```

## Testing

- [x] `pnpm exec vitest run src/main/pi/titlebar-extension-service.test.ts src/main/ipc/pty.test.ts --pool=forks`
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint src/main/pi/titlebar-extension-service.ts src/main/pi/titlebar-extension-service.test.ts`
- [x] Added regression tests covering legacy OMP overlay migration and special-file skip behavior

Not run locally due to PR scope/time: full `pnpm lint`, `pnpm test`, and `pnpm build`.

Note: local pnpm printed the existing Node 24 engine warning because this machine is running Node 26.3.0.

## AI Review Report

AI review checked the migration path for correctness and cross-platform behavior. Main risks reviewed:

- Source-scoped legacy overlay path hashing matches the old overlay scheme.
- Migration runs only for OMP and before managed extensions are installed.
- Existing real OMP home files are not overwritten.
- Managed Orca extension files, overlay manifests, and overlay `settings.json` are not restored from the old overlay.
- Path handling uses Node path utilities and does not introduce shell-specific behavior.
- SSH behavior is unchanged because this service is part of local host PTY env preparation.

CodeRabbit flagged that `cpSync` can throw on FIFOs/sockets/devices. The PR was updated to copy regular files only and added a regression test that ensures a FIFO in the legacy overlay is skipped while later session files still migrate.

## Security Audit

Reviewed filesystem safety and auth/session handling:

- Migration only reads from Orca's known legacy `omp-agent-overlays` location and writes into the resolved OMP agent home.
- It skips symlinks to avoid following attacker-controlled links from the legacy overlay into arbitrary filesystem locations.
- It skips non-regular files before copying so special files cannot abort migration or be materialized into the OMP home.
- It copies only missing files, so newer auth/session files in `~/.omp/agent` are preserved.
- No new IPC, network, dependency, or secret logging paths are introduced.

## Notes

- Windows: FIFO-specific regression test is skipped because `mkfifo` is POSIX-only; production code still skips non-regular files cross-platform via `lstatSync().isFile()`.
- The migration is best-effort. If copying fails, Orca logs a warning and continues launching OMP instead of blocking terminal startup.
