### PR TITLE
fix(agent-hooks): install Droid & Copilot managed hooks over SSH (#7253)

### DIFF
--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -8,6 +8,7 @@ vi.mock('electron', () => ({
 }))
 
 import { CodexHookService } from '../codex/hook-service'
+import { DroidHookService } from '../droid/hook-service'
 import { CursorHookService } from '../cursor/hook-service'
 import { CommandCodeHookService } from '../command-code/hook-service'
 import { GeminiHookService } from '../gemini/hook-service'
@@ -20,6 +21,24 @@ import { HermesHookService } from '../hermes/hook-service'
 import { DevinHookService } from '../devin/hook-service'
 import { KimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
+import { ampHookService } from '../amp/hook-service'
+import { antigravityHookService } from '../antigravity/hook-service'
+import { claudeHookService } from '../claude/hook-service'
+import { codexHookService } from '../codex/hook-service'
+import { copilotHookService } from '../copilot/hook-service'
+import { cursorHookService } from '../cursor/hook-service'
+import { droidHookService } from '../droid/hook-service'
+import { commandCodeHookService } from '../command-code/hook-service'
+import { geminiHookService } from '../gemini/hook-service'
+import { devinHookService } from '../devin/hook-service'
+import { grokHookService } from '../grok/hook-service'
+import { hermesHookService } from '../hermes/hook-service'
+import { kimiHookService } from '../kimi/hook-service'
+import { MANAGED_AGENT_HOOK_INSTALLERS } from './managed-agent-hook-controls'
+import {
+  installRemoteManagedAgentHooks,
+  REMOTE_MANAGED_HOOK_INSTALLER_AGENTS
+} from './remote-managed-hook-installers'
 
 type FakeFs = {
   files: Map<string, string>
@@ -166,6 +185,10 @@ describe('remote hook service installers', () => {
         {
           path: '/home/dev/.orca/agent-hooks/devin-hook.sh',
           install: (sftp: SFTPWrapper) => new DevinHookService().installRemote(sftp, '/home/dev')
+        },
+        {
+          path: '/home/dev/.orca/agent-hooks/droid-hook.sh',
+          install: (sftp: SFTPWrapper) => new DroidHookService().installRemote(sftp, '/home/dev')
         }
       ]
 
@@ -580,6 +603,107 @@ describe('remote hook service installers', () => {
     expect(config.disableAllHooks).toBeUndefined()
     expect(fs.files.get('/home/dev/.orca/agent-hooks/copilot-hook.sh')).toContain('#!/bin/sh')
     expect(fs.modes.get('/home/dev/.orca/agent-hooks/copilot-hook.sh')).toBe(0o755)
+  })
+
+  // Why: Droid (and Copilot) each shipped a working installRemote but were never
+  // registered in REMOTE_MANAGED_HOOK_INSTALLERS, so their status silently never
+  // appeared over SSH (issue #7253). Guard the whole bug class, not one agent:
+  // every locally-managed hook service that implements installRemote MUST be
+  // wired into the remote installer.
+  it('registers every managed agent that implements installRemote in the remote installer (issue #7253)', () => {
+    const servicesByAgent = new Map<string, { installRemote?: unknown }>([
+      ['claude', claudeHookService],
+      ['openclaude', openClaudeHookService],
+      ['codex', codexHookService],
+      ['gemini', geminiHookService],
+      ['antigravity', antigravityHookService],
+      ['amp', ampHookService],
+      ['cursor', cursorHookService],
+      ['droid', droidHookService],
+      ['command-code', commandCodeHookService],
+      ['grok', grokHookService],
+      ['copilot', copilotHookService],
+      ['hermes', hermesHookService],
+      ['devin', devinHookService],
+      ['kimi', kimiHookService]
+    ])
+
+    // Guard against a service silently missing from the map above as new agents land.
+    for (const [agent] of MANAGED_AGENT_HOOK_INSTALLERS) {
+      expect(servicesByAgent.has(agent)).toBe(true)
+    }
+
+    const registered = new Set<string>(REMOTE_MANAGED_HOOK_INSTALLER_AGENTS)
+    const missing: string[] = []
+    for (const [agent, service] of servicesByAgent) {
+      if (typeof service.installRemote === 'function' && !registered.has(agent)) {
+        missing.push(agent)
+      }
+    }
+    expect(missing).toEqual([])
+  })
+
+  it('installs Droid and Copilot when running the aggregate remote installer (issue #7253)', async () => {
+    const { sftp } = createFakeSftp()
+    const results = await installRemoteManagedAgentHooks(sftp, '/home/dev')
+    const byAgent = new Map(results.map((r) => [r.agent, r.state]))
+    expect(byAgent.get('droid')).toBe('installed')
+    expect(byAgent.get('copilot')).toBe('installed')
+  })
+
+  it('installs remote Droid hooks into Factory settings.json (issue #7253)', async () => {
+    const { sftp, fs } = createFakeSftp()
+
+    const status = await new DroidHookService().installRemote(sftp, '/home/dev')
+
+    expect(status.state).toBe('installed')
+    expect(status.configPath).toBe('/home/dev/.factory/settings.json')
+    const config = JSON.parse(fs.files.get('/home/dev/.factory/settings.json')!) as {
+      hooks: Record<string, { matcher?: string; hooks?: { command: string }[] }[]>
+    }
+    for (const eventName of [
+      'SessionStart',
+      'UserPromptSubmit',
+      'Stop',
+      'SubagentStop',
+      'PreToolUse',
+      'PostToolUse',
+      'PermissionRequest',
+      'Notification'
+    ]) {
+      const definition = config.hooks[eventName]?.[0]
+      const command = definition?.hooks?.[0]?.command
+      expect(command).toContain('/home/dev/.orca/agent-hooks/droid-hook.sh')
+      expect(command).toMatch(/^if \[ -x /)
+    }
+    // Tool/permission events carry a `*` matcher; lifecycle events do not.
+    expect(config.hooks.PreToolUse?.[0]?.matcher).toBe('*')
+    expect(config.hooks.PostToolUse?.[0]?.matcher).toBe('*')
+    expect(config.hooks.PermissionRequest?.[0]?.matcher).toBe('*')
+    expect(config.hooks.Stop?.[0]?.matcher).toBeUndefined()
+    const script = fs.files.get('/home/dev/.orca/agent-hooks/droid-hook.sh')
+    expect(script).toContain('#!/bin/sh')
+    expect(script).toContain('/hook/droid')
+    expect(fs.modes.get('/home/dev/.orca/agent-hooks/droid-hook.sh')).toBe(0o755)
+  })
+
+  it('does not overwrite a malformed remote Factory settings.json', async () => {
+    const original = '{"hooks": }'
+    const { sftp, fs } = createFakeSftp({
+      '/home/dev/.factory/settings.json': original
+    })
+
+    const status = await new DroidHookService().installRemote(sftp, '/home/dev')
+
+    expect(status).toMatchObject({
+      agent: 'droid',
+      state: 'error',
+      configPath: '/home/dev/.factory/settings.json',
+      managedHooksPresent: false,
+      detail: 'Could not parse remote Factory settings.json'
+    })
+    expect(fs.files.get('/home/dev/.factory/settings.json')).toBe(original)
+    expect(fs.files.get('/home/dev/.orca/agent-hooks/droid-hook.sh')).toBeUndefined()
   })
 
   it('installs remote Hermes plugin files and enables the plugin', async () => {

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -7,7 +7,9 @@ import { geminiHookService } from '../gemini/hook-service'
 import { antigravityHookService } from '../antigravity/hook-service'
 import { cursorHookService } from '../cursor/hook-service'
 import { commandCodeHookService } from '../command-code/hook-service'
+import { copilotHookService } from '../copilot/hook-service'
 import { devinHookService } from '../devin/hook-service'
+import { droidHookService } from '../droid/hook-service'
 import { grokHookService } from '../grok/hook-service'
 import { hermesHookService } from '../hermes/hook-service'
 import { kimiHookService } from '../kimi/hook-service'
@@ -27,11 +29,19 @@ const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
   ['amp', (sftp, remoteHome) => ampHookService.installRemote(sftp, remoteHome)],
   ['cursor', (sftp, remoteHome) => cursorHookService.installRemote(sftp, remoteHome)],
   ['command-code', (sftp, remoteHome) => commandCodeHookService.installRemote(sftp, remoteHome)],
+  ['copilot', (sftp, remoteHome) => copilotHookService.installRemote(sftp, remoteHome)],
   ['grok', (sftp, remoteHome) => grokHookService.installRemote(sftp, remoteHome)],
+  ['droid', (sftp, remoteHome) => droidHookService.installRemote(sftp, remoteHome)],
   ['hermes', (sftp, remoteHome) => hermesHookService.installRemote(sftp, remoteHome)],
   ['devin', (sftp, remoteHome) => devinHookService.installRemote(sftp, remoteHome)],
   ['kimi', (sftp, remoteHome) => kimiHookService.installRemote(sftp, remoteHome)]
 ]
+
+/** Agents wired into the remote (SSH) hook installer. Exported so an invariant
+ *  test can assert every locally-managed agent that implements `installRemote`
+ *  is registered here — the omission that hid Droid/Copilot status over SSH. */
+export const REMOTE_MANAGED_HOOK_INSTALLER_AGENTS: readonly AgentHookInstallStatus['agent'][] =
+  REMOTE_MANAGED_HOOK_INSTALLERS.map(([agent]) => agent)
 
 export async function installRemoteManagedAgentHooks(
   sftp: SFTPWrapper,

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -1,5 +1,6 @@
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import {
   buildManagedCommandHook,
@@ -12,8 +13,14 @@ import {
   wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
-  type HookDefinition
+  type HookDefinition,
+  type HooksConfig
 } from '../agent-hooks/installer-utils'
+import {
+  readHooksJsonRemote,
+  writeHooksJsonRemote,
+  writeManagedScriptRemote
+} from '../agent-hooks/installer-utils-remote'
 
 // Why: SessionStart is installed (not just listened for) so that resuming a
 // droid session via `droid --resume` resets the per-pane prompt/tool caches
@@ -64,8 +71,8 @@ function getManagedCommand(scriptPath: string): string {
     : wrapPosixHookCommand(scriptPath)
 }
 
-function getManagedScript(): string {
-  if (process.platform === 'win32') {
+function getManagedScript(target: 'local' | 'posix' = 'local'): string {
+  if (target === 'local' && process.platform === 'win32') {
     return [
       '@echo off',
       'setlocal',
@@ -109,6 +116,45 @@ function getManagedScript(): string {
     'exit 0',
     ''
   ].join('\n')
+}
+
+// Why: local install() and installRemote() must produce byte-identical Factory
+// settings.json hook trees; sharing this mutation is what keeps the SSH install
+// from drifting off the local one (the exact class of bug that left Droid with
+// no remote installer at all — issue #7253).
+function buildInstalledDroidConfig(
+  config: HooksConfig,
+  command: string,
+  scriptFileName: string
+): void {
+  const nextHooks = { ...config.hooks }
+  const isManagedCommand = createManagedCommandMatcher(scriptFileName)
+  const managedEvents = new Set<string>(DROID_EVENTS.map((event) => event.eventName))
+
+  // Why: sweep managed entries out of events we no longer subscribe to.
+  for (const [eventName, definitions] of Object.entries(nextHooks)) {
+    if (managedEvents.has(eventName) || !Array.isArray(definitions)) {
+      continue
+    }
+    const cleaned = removeManagedCommands(definitions, isManagedCommand)
+    if (cleaned.length === 0) {
+      delete nextHooks[eventName]
+    } else {
+      nextHooks[eventName] = cleaned
+    }
+  }
+
+  for (const event of DROID_EVENTS) {
+    const current = Array.isArray(nextHooks[event.eventName]) ? nextHooks[event.eventName] : []
+    const cleaned = removeManagedCommands(current, isManagedCommand)
+    const definition: HookDefinition = {
+      ...event.definition,
+      hooks: [buildManagedCommandHook(command)]
+    }
+    nextHooks[event.eventName] = [...cleaned, definition]
+  }
+
+  config.hooks = nextHooks
 }
 
 export class DroidHookService {
@@ -189,41 +235,55 @@ export class DroidHookService {
       }
     }
 
-    const command = getManagedCommand(scriptPath)
-    const nextHooks = { ...config.hooks }
-    const isManagedCommand = createManagedCommandMatcher(getManagedScriptFileName())
-    const managedEvents = new Set<string>(DROID_EVENTS.map((event) => event.eventName))
-
-    // Why: sweep managed entries out of events we no longer subscribe to.
-    for (const [eventName, definitions] of Object.entries(nextHooks)) {
-      if (managedEvents.has(eventName)) {
-        continue
-      }
-      if (!Array.isArray(definitions)) {
-        continue
-      }
-      const cleaned = removeManagedCommands(definitions, isManagedCommand)
-      if (cleaned.length === 0) {
-        delete nextHooks[eventName]
-      } else {
-        nextHooks[eventName] = cleaned
-      }
-    }
-
-    for (const event of DROID_EVENTS) {
-      const current = Array.isArray(nextHooks[event.eventName]) ? nextHooks[event.eventName] : []
-      const cleaned = removeManagedCommands(current, isManagedCommand)
-      const definition: HookDefinition = {
-        ...event.definition,
-        hooks: [buildManagedCommandHook(command)]
-      }
-      nextHooks[event.eventName] = [...cleaned, definition]
-    }
-
-    config.hooks = nextHooks
+    buildInstalledDroidConfig(config, getManagedCommand(scriptPath), getManagedScriptFileName())
     writeManagedScript(scriptPath, getManagedScript())
     writeHooksJson(configPath, config)
     return this.getStatus()
+  }
+
+  // Why: SSH remotes run the Droid CLI on the remote host, so its hook config
+  // and managed script must be written into the remote ~/.factory + ~/.orca via
+  // SFTP. Without this, Droid never fires the managed hook over SSH and its
+  // status row is absent from the task tree (issue #7253). Mirrors the local
+  // install() but always emits POSIX script/paths — even from a Windows host.
+  async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
+    const home = remoteHome.replace(/\/$/, '')
+    const remoteConfigPath = `${home}/.factory/settings.json`
+    const remoteScriptPath = `${home}/.orca/agent-hooks/droid-hook.sh`
+    try {
+      const config = await readHooksJsonRemote(sftp, remoteConfigPath)
+      if (!config) {
+        return {
+          agent: 'droid',
+          state: 'error',
+          configPath: remoteConfigPath,
+          managedHooksPresent: false,
+          detail: 'Could not parse remote Factory settings.json'
+        }
+      }
+
+      buildInstalledDroidConfig(config, wrapPosixHookCommand(remoteScriptPath), 'droid-hook.sh')
+      // Why: script first, config last — a partial config write must never
+      // point Droid at a script that isn't on disk yet.
+      await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript('posix'))
+      await writeHooksJsonRemote(sftp, remoteConfigPath, config)
+
+      return {
+        agent: 'droid',
+        state: 'installed',
+        configPath: remoteConfigPath,
+        managedHooksPresent: true,
+        detail: null
+      }
+    } catch (err) {
+      return {
+        agent: 'droid',
+        state: 'error',
+        configPath: remoteConfigPath,
+        managedHooksPresent: false,
+        detail: err instanceof Error ? err.message : String(err)
+      }
+    }
   }
 
   remove(): AgentHookInstallStatus {


### PR DESCRIPTION
## Summary

Fixes #7253 — Codex, Amp & Droid agent status rows missing in the task tree over SSH (Claude/Hermes work).

**Root cause (structural, one bug class, two agents):** Agent status over SSH depends on `installRemoteManagedAgentHooks` SFTP-ing each agent's hook config + managed script onto the remote host. It only iterates the `REMOTE_MANAGED_HOOK_INSTALLERS` registry. **Droid** had no `installRemote` method and wasn't in the registry; **Copilot** shipped a full `installRemote` (and its own remote-install test) but was also never added to the registry. So for both agents, no hook config ever reached the remote → the CLI never fired the managed hook → no status row. Claude/Hermes/Codex/Amp were registered, which is why they worked over SSH.

> Note on Codex/Amp from the report: on the reporter's `1.4.120.0` **and** current `main`, Codex and Amp are registered with working remote installers, and I verified both install + round-trip correctly over real SSH. The still-reproducible structural miss is Droid (and, found during review, Copilot).

## Changes

- **`src/main/droid/hook-service.ts`** — add `DroidHookService.installRemote` (mirrors the grok/command-code sibling pattern). Extract `buildInstalledDroidConfig` so local `install()` and `installRemote` produce byte-identical `~/.factory/settings.json` hook trees. `getManagedScript('posix')` always emits POSIX script/paths even from a Windows host; local default (`'local'`) preserves existing Windows behavior.
- **`src/main/agent-hooks/remote-managed-hook-installers.ts`** — register `droid` **and** `copilot`; export `REMOTE_MANAGED_HOOK_INSTALLER_AGENTS` for the invariant test.
- **`src/main/agent-hooks/remote-hook-service-installers.test.ts`** — add a **class-level invariant test**: every locally-managed hook service that implements `installRemote` must be registered in the remote installer. This guards the whole bug class, not just these two agents. Plus a Droid config-shape test, a malformed-`settings.json` safety test, an aggregate droid+copilot install test, and Droid added to the POSIX-from-Windows loop.

## Testing

- **Reproduced over a real Docker SSH target** (throwaway Ubuntu container, `demo-project` cloned in): the production `installRemoteManagedAgentHooks` installed hook scripts/configs for claude/codex/amp/hermes + 10 others but wrote **nothing** for droid — no `~/.factory/settings.json`, no `droid-hook.sh`.
- **Proved the round-trip:** with the managed script staged, firing it (payload on stdin, endpoint env injected) POSTed to `/hook/droid` with the auth token and URL-encoded payload — confirming the only gap was the missing install.
- **Verified the fix over the same real SSH path:** the aggregate install now writes a well-formed `~/.factory/settings.json` (all 8 events, `if [ -x ]` guard, `timeout: 10`) plus an executable `droid-hook.sh`.
- **Invariant test proven to catch the bug:** temporarily un-registering copilot makes the new test fail with `expected [ 'copilot' ] to deeply equal []`.
- `pnpm tsgo` (node project) + `oxlint` clean; 62 tests pass across the touched suites.

## Cross-platform / scope notes

- Remote install is POSIX-only, matching every other agent (Windows-remote is out of scope for the relay's managed-hook path and is guarded upstream in `installManagedHooksOnRemote`). Local Windows/macOS/Linux behavior is unchanged.
- No GitLab-specific surface; mobile unaffected (this is desktop main-process ↔ remote relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
