### PR TITLE
Default editors to the classic input path to fix intermittent typing loss

### DIFF
--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
 import { combinedDiffSectionScrollbarOptions } from './diff-editor-scrollbar-options'
+import { resolveEditorEditContextEnabled } from './monaco-input-mode'
 import type { DiffSection } from './diff-section-types'
 import { translate } from '@/i18n/i18n'
 import { LargeDiffFallback } from './LargeDiffFallback'
@@ -37,6 +38,7 @@ type DiffSectionBodyProps = {
   diffEditorFontSize: number
   diffWordWrap?: boolean
   terminalFontFamily?: string
+  experimentalInput?: boolean
   onCancelComment: () => void
   onSubmitComment: (body: string) => Promise<void>
   onRetrySection: (index: number) => void
@@ -62,6 +64,7 @@ export function DiffSectionBody({
   diffEditorFontSize,
   diffWordWrap,
   terminalFontFamily,
+  experimentalInput,
   onCancelComment,
   onSubmitComment,
   onRetrySection,
@@ -187,6 +190,7 @@ export function DiffSectionBody({
           options={{
             readOnly: !isEditable,
             originalEditable: false,
+            editContext: resolveEditorEditContextEnabled(experimentalInput),
             renderSideBySide: sideBySide,
             minimap: { enabled: false },
             scrollBeyondLastLine: false,

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -69,6 +69,7 @@ export function DiffSectionItem({
     terminalFontSize?: number
     terminalFontFamily?: string
     diffWordWrap?: boolean
+    editorExperimentalInput?: boolean
   } | null
   sectionHeight: number | undefined
   worktreeId?: string
@@ -427,6 +428,7 @@ export function DiffSectionItem({
           diffEditorFontSize={diffEditorFontSize}
           diffWordWrap={settings?.diffWordWrap}
           terminalFontFamily={settings?.terminalFontFamily}
+          experimentalInput={settings?.editorExperimentalInput}
           onCancelComment={() => setPopover(null)}
           onSubmitComment={handleSubmitComment}
           onRetrySection={retrySection}

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -24,6 +24,7 @@ import { useDiffViewerLargeDiffLifecycle } from './useDiffViewerLargeDiffLifecyc
 import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-action'
 import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
+import { resolveEditorEditContextEnabled } from './monaco-input-mode'
 
 export default function DiffViewer({
   modelKey,
@@ -445,6 +446,7 @@ export default function DiffViewer({
             options={{
               readOnly: !editable,
               originalEditable: false,
+              editContext: resolveEditorEditContextEnabled(settings?.editorExperimentalInput),
               renderSideBySide: sideBySide,
               minimap: { enabled: false },
               scrollBeyondLastLine: false,

--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -54,6 +54,7 @@ import { registerPendingEditorFlush } from './editor-pending-flush'
 import { editorShortcutMatches, installEditorSaveShortcut } from './editor-shortcuts'
 import { getIpynbCodeCellEditorHeight, getIpynbCodeCellPreviewLines } from './ipynb-code-cell-lines'
 import MonacoCodeExcerpt from './MonacoCodeExcerpt'
+import { resolveEditorEditContextEnabled } from './monaco-input-mode'
 import {
   deleteIpynbCell,
   insertIpynbCell,
@@ -403,6 +404,7 @@ function CodeCell({
         onChange={(value) => onChange(value ?? '')}
         options={{
           automaticLayout: true,
+          editContext: resolveEditorEditContextEnabled(settings?.editorExperimentalInput),
           fontFamily: settings?.terminalFontFamily || 'monospace',
           fontSize,
           glyphMargin: false,

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -33,6 +33,7 @@ import {
   type MarkdownDocLinkDecorationController
 } from './monaco-markdown-doc-link-decorations'
 import { buildGitConflictDecorations, hasGitConflictMarkers } from './monaco-conflict-decorations'
+import { resolveEditorEditContextEnabled } from './monaco-input-mode'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import type { DiffComment } from '../../../../shared/types'
 import { isMarkdownComment } from '@/lib/diff-comment-compat'
@@ -146,6 +147,7 @@ export default function MonacoEditor({
     settings?.terminalFontSize ?? 13,
     editorFontZoomLevel
   )
+  const editContextEnabled = resolveEditorEditContextEnabled(settings?.editorExperimentalInput)
   const estimatedAutoHeight = useMemo(() => {
     if (!autoHeight) {
       return null
@@ -713,9 +715,12 @@ export default function MonacoEditor({
     }
     editorRef.current.updateOptions({
       fontSize: editorFontSize,
-      fontFamily: settings.terminalFontFamily || 'monospace'
+      fontFamily: settings.terminalFontFamily || 'monospace',
+      // Why: Monaco swaps its input controller live when editContext changes,
+      // so toggling the setting recovers a wedged editor without a remount.
+      editContext: editContextEnabled
     })
-  }, [editorFontSize, settings])
+  }, [editContextEnabled, editorFontSize, settings])
 
   useEffect(() => {
     markdownDocLinkDecorationsRef.current?.refresh()
@@ -842,6 +847,7 @@ export default function MonacoEditor({
           automaticLayout: true,
           tabSize: 2,
           readOnly,
+          editContext: editContextEnabled,
           scrollbar: autoHeight
             ? {
                 vertical: autoHeightUsesInternalScroll ? 'auto' : 'hidden',

--- a/src/renderer/src/components/editor/monaco-input-mode.test.ts
+++ b/src/renderer/src/components/editor/monaco-input-mode.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDefaultSettings } from '../../../../shared/constants'
+
+import { resolveEditorEditContextEnabled } from './monaco-input-mode'
+
+describe('resolveEditorEditContextEnabled', () => {
+  it('defaults to the legacy textarea input path when unset', () => {
+    // Why: an unset value must NOT enable Chromium's EditContext; that path can
+    // wedge all editors' typing until restart, so off-by-default is the safety
+    // contract this whole change exists to guarantee.
+    expect(resolveEditorEditContextEnabled(undefined)).toBe(false)
+  })
+
+  it('honors an explicit opt-out', () => {
+    expect(resolveEditorEditContextEnabled(false)).toBe(false)
+  })
+
+  it('enables EditContext only when explicitly opted in', () => {
+    expect(resolveEditorEditContextEnabled(true)).toBe(true)
+  })
+
+  it('keeps the shipped default off so editors use the reliable input path', () => {
+    expect(getDefaultSettings('/home/test').editorExperimentalInput).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/monaco-input-mode.ts
+++ b/src/renderer/src/components/editor/monaco-input-mode.ts
@@ -1,0 +1,9 @@
+// Why: Monaco 0.53+ powers editor input through Chromium's experimental
+// EditContext API by default. That path can intermittently stop receiving
+// text-update events, leaving every editor unable to accept typed characters
+// until the app restarts (an upstream Chromium bug; the terminal is unaffected
+// because it uses a plain textarea). Orca keeps editors on the legacy textarea
+// input path unless the user explicitly opts into EditContext.
+export function resolveEditorEditContextEnabled(experimentalInput: boolean | undefined): boolean {
+  return experimentalInput ?? false
+}

--- a/src/renderer/src/components/settings/ExperimentalEditorInputSetting.tsx
+++ b/src/renderer/src/components/settings/ExperimentalEditorInputSetting.tsx
@@ -1,0 +1,44 @@
+import type React from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
+
+type ExperimentalEditorInputSettingProps = {
+  settings: Pick<GlobalSettings, 'editorExperimentalInput'>
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function ExperimentalEditorInputSetting({
+  settings,
+  updateSettings
+}: ExperimentalEditorInputSettingProps): React.JSX.Element {
+  const enabled = settings.editorExperimentalInput ?? false
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.30baaa4a0f',
+        'Experimental Editor Input'
+      )}
+      description={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.f5663213a9',
+        'Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.'
+      )}
+      keywords={['editcontext', 'input', 'typing', 'ime', 'keyboard', 'experimental']}
+    >
+      <SettingsSwitchRow
+        label={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.30baaa4a0f',
+          'Experimental Editor Input'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.f5663213a9',
+          'Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.'
+        )}
+        checked={enabled}
+        onChange={() => updateSettings({ editorExperimentalInput: !enabled })}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/ExperimentalEditorInputSetting.tsx
+++ b/src/renderer/src/components/settings/ExperimentalEditorInputSetting.tsx
@@ -23,7 +23,7 @@ export function ExperimentalEditorInputSetting({
       )}
       description={translate(
         'auto.components.settings.GeneralEditorSettingsSection.f5663213a9',
-        'Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.'
+        'Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable.'
       )}
       keywords={['editcontext', 'input', 'typing', 'ime', 'keyboard', 'experimental']}
     >
@@ -34,7 +34,7 @@ export function ExperimentalEditorInputSetting({
         )}
         description={translate(
           'auto.components.settings.GeneralEditorSettingsSection.f5663213a9',
-          'Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.'
+          'Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable.'
         )}
         checked={enabled}
         onChange={() => updateSettings({ editorExperimentalInput: !enabled })}

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -17,6 +17,7 @@ import {
 } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
+import { ExperimentalEditorInputSetting } from './ExperimentalEditorInputSetting'
 
 export type AutoSaveDelayDraftState = {
   sourceDelayMs: number
@@ -378,6 +379,8 @@ export function GeneralEditorSettingsSection({
           onChange={() => updateSettings({ editorMinimapEnabled: !settings.editorMinimapEnabled })}
         />
       </SearchableSetting>
+
+      <ExperimentalEditorInputSetting settings={settings} updateSettings={updateSettings} />
 
       <RichMarkdownSpellcheckSetting settings={settings} updateSettings={updateSettings} />
 

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -81,6 +81,30 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
   },
   {
     title: translate(
+      'auto.components.settings.general.search.86dc23cb35',
+      'Experimental Editor Input'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.be7ff2a967',
+      'Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.7bf4b9e46d',
+        'editcontext'
+      ),
+      ...translateSearchKeyword('auto.components.settings.general.search.713c107d7b', 'input'),
+      ...translateSearchKeyword('auto.components.settings.general.search.7fe71eb34c', 'typing'),
+      ...translateSearchKeyword('auto.components.settings.general.search.0b6c2fd17b', 'ime'),
+      ...translateSearchKeyword('auto.components.settings.general.search.47246d06a5', 'keyboard'),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.f1eb2a2473',
+        'experimental'
+      )
+    ]
+  },
+  {
+    title: translate(
       'auto.components.settings.general.search.d2d2d929c0',
       'Rich Markdown Spellcheck'
     ),

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -86,7 +86,7 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
     ),
     description: translate(
       'auto.components.settings.general.search.be7ff2a967',
-      'Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.'
+      'Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable.'
     ),
     keywords: [
       ...translateSearchKeyword(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7521,7 +7521,15 @@
             "defaultProjectRuntime": "Default Project Runtime",
             "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+            "86dc23cb35": "Experimental Editor Input",
+            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "7bf4b9e46d": "editcontext",
+            "713c107d7b": "input",
+            "7fe71eb34c": "typing",
+            "0b6c2fd17b": "ime",
+            "47246d06a5": "keyboard",
+            "f1eb2a2473": "experimental"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5220,7 +5220,9 @@
           "bf16ef0af2": "Off",
           "3f6892f307": "On",
           "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+          "30baaa4a0f": "Experimental Editor Input",
+          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5222,7 +5222,7 @@
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
           "30baaa4a0f": "Experimental Editor Input",
-          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
+          "f5663213a9": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -7523,7 +7523,7 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
             "86dc23cb35": "Experimental Editor Input",
-            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "be7ff2a967": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable.",
             "7bf4b9e46d": "editcontext",
             "713c107d7b": "input",
             "7fe71eb34c": "typing",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5222,7 +5222,7 @@
           "b82f86d7d2": "Corrector ortográfico de Rich Markdown",
           "5195f0b9ef": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
           "30baaa4a0f": "Experimental Editor Input",
-          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
+          "f5663213a9": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -7486,7 +7486,7 @@
             "d2d2d929c0": "Corrector ortográfico de Rich Markdown",
             "4497e2e2bb": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
             "86dc23cb35": "Experimental Editor Input",
-            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "be7ff2a967": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable.",
             "7bf4b9e46d": "editcontext",
             "713c107d7b": "input",
             "7fe71eb34c": "typing",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -7484,7 +7484,15 @@
             "defaultProjectRuntime": "Runtime de proyecto predeterminado",
             "defaultProjectRuntimeDescription": "Elige el runtime que heredarán los proyectos locales de Windows.",
             "d2d2d929c0": "Corrector ortográfico de Rich Markdown",
-            "4497e2e2bb": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown."
+            "4497e2e2bb": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
+            "86dc23cb35": "Experimental Editor Input",
+            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "7bf4b9e46d": "editcontext",
+            "713c107d7b": "input",
+            "7fe71eb34c": "typing",
+            "0b6c2fd17b": "ime",
+            "47246d06a5": "keyboard",
+            "f1eb2a2473": "experimental"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5220,7 +5220,9 @@
           "bf16ef0af2": "Desactivado",
           "3f6892f307": "Activado",
           "b82f86d7d2": "Corrector ortográfico de Rich Markdown",
-          "5195f0b9ef": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown."
+          "5195f0b9ef": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
+          "30baaa4a0f": "Experimental Editor Input",
+          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5205,7 +5205,9 @@
           "bf16ef0af2": "オフ",
           "3f6892f307": "オン",
           "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+          "30baaa4a0f": "Experimental Editor Input",
+          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "ローカルホスト、127.0.0.1、*.internal",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -7506,7 +7506,15 @@
             "defaultProjectRuntime": "Default Project Runtime",
             "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+            "86dc23cb35": "Experimental Editor Input",
+            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "7bf4b9e46d": "editcontext",
+            "713c107d7b": "input",
+            "7fe71eb34c": "typing",
+            "0b6c2fd17b": "ime",
+            "47246d06a5": "keyboard",
+            "f1eb2a2473": "experimental"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5207,7 +5207,7 @@
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
           "30baaa4a0f": "Experimental Editor Input",
-          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
+          "f5663213a9": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "ローカルホスト、127.0.0.1、*.internal",
@@ -7508,7 +7508,7 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
             "86dc23cb35": "Experimental Editor Input",
-            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "be7ff2a967": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable.",
             "7bf4b9e46d": "editcontext",
             "713c107d7b": "input",
             "7fe71eb34c": "typing",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5205,7 +5205,9 @@
           "bf16ef0af2": "끄다",
           "3f6892f307": "~에",
           "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+          "30baaa4a0f": "Experimental Editor Input",
+          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "로컬호스트, 127.0.0.1, *.internal",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5207,7 +5207,7 @@
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
           "30baaa4a0f": "Experimental Editor Input",
-          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
+          "f5663213a9": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "로컬호스트, 127.0.0.1, *.internal",
@@ -7471,7 +7471,7 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
             "86dc23cb35": "Experimental Editor Input",
-            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "be7ff2a967": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable.",
             "7bf4b9e46d": "editcontext",
             "713c107d7b": "input",
             "7fe71eb34c": "typing",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -7469,7 +7469,15 @@
             "defaultProjectRuntime": "기본 프로젝트 런타임",
             "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+            "86dc23cb35": "Experimental Editor Input",
+            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "7bf4b9e46d": "editcontext",
+            "713c107d7b": "input",
+            "7fe71eb34c": "typing",
+            "0b6c2fd17b": "ime",
+            "47246d06a5": "keyboard",
+            "f1eb2a2473": "experimental"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -7469,7 +7469,15 @@
             "defaultProjectRuntime": "默认项目运行时",
             "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。",
             "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。"
+            "4497e2e2bb": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
+            "86dc23cb35": "Experimental Editor Input",
+            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "7bf4b9e46d": "editcontext",
+            "713c107d7b": "input",
+            "7fe71eb34c": "typing",
+            "0b6c2fd17b": "ime",
+            "47246d06a5": "keyboard",
+            "f1eb2a2473": "experimental"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5207,7 +5207,7 @@
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
           "30baaa4a0f": "Experimental Editor Input",
-          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
+          "f5663213a9": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "本地主机，127.0.0.1，*.internal",
@@ -7471,7 +7471,7 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
             "86dc23cb35": "Experimental Editor Input",
-            "be7ff2a967": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable.",
+            "be7ff2a967": "Use a newer text-input engine (EditContext) for editors. If typing ever stops working, turn this off to use the classic input path, which is more reliable.",
             "7bf4b9e46d": "editcontext",
             "713c107d7b": "input",
             "7fe71eb34c": "typing",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5205,7 +5205,9 @@
           "bf16ef0af2": "关闭",
           "3f6892f307": "开启",
           "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。"
+          "5195f0b9ef": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
+          "30baaa4a0f": "Experimental Editor Input",
+          "f5663213a9": "Power editor typing with the Chromium EditContext API. Leave this off if typing ever stops working in the editor; the classic input path is more reliable."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "本地主机，127.0.0.1，*.internal",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -203,6 +203,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
     editorMinimapEnabled: false,
+    editorExperimentalInput: false,
     richMarkdownSpellcheckEnabled: true,
     markdownReviewToolsEnabled: true,
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2495,6 +2495,11 @@ export type GlobalSettings = {
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number
   editorMinimapEnabled: boolean
+  /** Opt-in to Monaco's experimental EditContext input path. Defaults off so
+   *  editors use the legacy textarea input, which is immune to a Chromium
+   *  EditContext bug that can intermittently make all editors ignore typing
+   *  until restart (the terminal is unaffected; it never used EditContext). */
+  editorExperimentalInput?: boolean
   /** Persisted opt-out for browser spellcheck noise in rich Markdown editing surfaces. */
   richMarkdownSpellcheckEnabled?: boolean
   /** Whether local markdown review note controls and the review panel are shown. */


### PR DESCRIPTION
## Summary

Addresses the intermittent, hard-to-reproduce reports where the code editor stops accepting keyboard input — the cursor still blinks and clicks work, but typed characters never land — until the app is restarted (#7418). The terminal keeps working the whole time.

The root cause is upstream, not in Orca. Since monaco-editor 0.53, editor typing is powered by Chromium's experimental **EditContext** API by default. A Chromium bug can leave that input path unable to deliver text-update events, which wedges every editor at once until the renderer reloads. The terminal is unaffected because it uses a plain textarea, never EditContext.

This PR moves Orca's editors back onto the long-standing textarea input path (`editContext: false`) across every Monaco surface, behind a new **Experimental Editor Input** setting that defaults **off**. Anyone who prefers EditContext — for example some IME setups it was designed to improve — can opt back in. Monaco swaps its input controller live when the option changes, so toggling the setting recovers a wedged editor without a restart.

## What changed

- New `editorExperimentalInput` global setting, default `false`, threaded into every Monaco editor surface (file editor, diff viewer, combined-diff sections, notebook cells) through a single shared `resolveEditorEditContextEnabled` helper.
- Live application via `MonacoEditor`'s existing `updateOptions` sync effect, so flipping the setting takes effect on already-open editors.
- Settings toggle under **General → Editor**, searchable.
- Unit test locking the default to the reliable input path.

## Testing

- `pnpm typecheck` ✅
- `pnpm vitest run` (affected suites) ✅
- `pnpm check:max-lines-ratchet`, `pnpm verify:localization-catalog` ✅
- Validated in a dev build:
  - **Default (off):** the editor renders the classic `textarea` input (no `native-edit-context` element) and typing inserts characters.
  - **Toggle on, live:** the same editor instance swaps to EditContext with no remount.
  - **Toggle off, live:** reverts to the textarea path and typing still works.

## Regression & CJK input validation

This flips the input path for **every** editor surface, so I audited where a behavior change could hide and specifically validated CJK/IME input.

**CJK IME — no regression (live-tested).** Drove this exact Monaco build with `editContext: false` vs `true`, simulating real Japanese/Chinese/Korean composition and asserting the resulting editor value. The textarea path is byte-for-byte identical to EditContext on every case:

| Case | `editContext: false` (default) | `editContext: true` |
| --- | --- | --- |
| JP hiragana `にほんご` | ✅ | ✅ |
| JP kanji `日本語` | ✅ | ✅ |
| CN phrase `你好世界` | ✅ (all chars, no drop) | ✅ |
| KR Hangul `한국어` | ✅ (not jamo-decomposed) | ✅ |
| JP stress `こんにちは世界` | ✅ | ✅ |

The two IME failure modes that most concern CJK users — multi-character phrase commit and Hangul jamo decomposition — both pass on the textarea path. Confirmed the option actually takes effect (not a silent no-op): `false` builds `textarea.inputarea`, `true` builds `.native-edit-context`. Caveat: simulated IME on a current Chromium exercises Monaco's composition pipeline faithfully, but not OS-IME candidate-window quirks (which this option does not govern).

**Other shared surfaces — no regression.**
- Multi-cursor paste metadata is written by both input controllers, so context-menu and keyboard paste keep per-cursor behavior.
- Focus / return-focus helpers target `.monaco-editor textarea`, which the default path guarantees; nothing depends on the EditContext element.
- Container-based handlers (large-paste bounds, contextual copy, save shortcut) use `getContainerDomNode()`, identical in both modes.
- No test references the input element.

## Notes

Users who hit the wedged state can now recover by toggling the setting (or reloading the window) instead of restarting. If Chromium fixes the underlying bug, we can flip the default back on.

Closes #7418

Made with [Orca](https://github.com/stablyai/orca) 🐋

