### PR TITLE
Prepare mobile 0.0.25

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.24",
+    "version": "0.0.25",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump `mobile/app.json` `expo.version` to **0.0.25** so the repo source of truth matches the release. Leaves `ios.buildNumber` / `android.versionCode` to CI (owned by the release workflows).

New in 0.0.25 (since 0.0.24 shipped 2026-07-06):
- Full workspace file tree on mobile (#7289, follow-ups #7599)
- Fix phone-size Restore buttons doing nothing (#7749)
- Keep mobile-created terminals alive when the desktop renderer is throttled/stalled (#7664)
- Cap the scheduled-notification map to bound memory (#7646)

## Verification
- `node -e` confirms `expo.version` = 0.0.25; diff is the single version line.
- `verify` mobile check (typecheck/test/lint/format) must be green before the release tag/dispatch.

Made with [Orca](https://github.com/stablyai/orca) 🐋
