### PR TITLE
feat(worktree): copy .worktreeinclude ignored setup files into new worktrees

### DIFF
--- a/docs/reference/worktree-include-copy.md
+++ b/docs/reference/worktree-include-copy.md
@@ -1,0 +1,72 @@
+# `.worktreeinclude` — harness-level copy of gitignored local setup files
+
+## Problem
+
+Setup scripts are the only mechanism for materializing gitignored local files
+(`.env.local`, `.claude/settings.local.json`, `.entire/settings.local.json`, …)
+into a new worktree, and they have structural gaps:
+
+- A repo may have no setup script configured at all.
+- Setup can be skipped per-creation (`setupDecision: 'skip'`) or by repo policy.
+- Setup can fail partway through.
+- With `setupAgentStartupPolicy: 'start-immediately'`, an agent can start
+  before the script has copied local files.
+
+Real incident: a worktree was created for a repo before its setup script
+existed, so `.entire/settings.local.json` (which disables Entire) was never
+copied in. Entire ran enabled in the worktree and its hooks wedged
+`git commit` for 10+ minutes.
+
+## Contract (mirrors Codex)
+
+A repo-root `.worktreeinclude` file lists exact relative paths of gitignored
+local setup files, one per line; `#` starts a comment:
+
+```
+# local setup files
+.claude/settings.local.json
+.entire/settings.local.json
+apps/nugget/.env.local
+```
+
+During worktree creation the harness itself copies each listed file from the
+project's main checkout into the new worktree — after `git worktree add`,
+before the setup script is prepared and before any agent starts. It does not
+depend on a setup script being configured, launched, or succeeding.
+
+Rules:
+
+- Exact relative paths only — no globs, no directories. Malformed lines
+  (absolute paths, `..` traversal, `*?[]`) are warned about and skipped.
+- Only files that are gitignored in the source repo are copied. Tracked,
+  missing, or untracked-but-not-ignored entries are skipped and recorded.
+- Symlinks are refused, not followed: an entry whose source is a symlink, or
+  whose source/destination path crosses a symlinked directory, is skipped as
+  `not-a-file`. This stops a repo-committed symlink (e.g. `foo -> ~/.ssh`) from
+  exfiltrating host files into the worktree the agent then runs in. (Remote
+  hosts reject a symlinked source leaf via `lstat`; destination-parent
+  containment on the remote path is a follow-up — see below.)
+- An existing destination file is never overwritten.
+- Parent directories are created; file modes are preserved.
+- Absent or empty `.worktreeinclude` is a no-op. No failure in this step can
+  abort worktree creation — everything degrades to logs.
+
+## Implementation
+
+- `src/main/ipc/worktree-include-copy.ts` — parsing, validation, and the copy
+  orchestration; `src/main/ipc/worktree-include-host-ops.ts` — the local and
+  remote host implementations behind the shared host-ops interface.
+- Wired into all three creation flows, always ahead of setup preparation:
+  - desktop local: `createLocalWorktree` (`src/main/ipc/worktree-remote.ts`),
+    timed as the `copy_worktree_include` phase
+  - desktop/runtime SSH: `createRemoteWorktree` (same file)
+  - runtime/CLI local: `OrcaRuntimeService` create flow
+    (`src/main/runtime/orca-runtime.ts`)
+- Remote hosts: the source checkout and the new worktree live on the same
+  remote machine, so the copy runs host-side via the relay's no-clobber
+  `fs.copy` — file contents (which can hold secrets) never transit to the
+  local machine. Tracked/ignored checks go through the relay's allowlisted
+  `git ls-files` / `check-ignore`.
+- The outcome (`copied` / `skipped` with per-entry reasons) is logged with the
+  `[worktree-include]` prefix and returned to callers as
+  `CreateWorktreeResult.includeCopy`.

--- a/src/main/ipc/worktree-include-copy.test.ts
+++ b/src/main/ipc/worktree-include-copy.test.ts
@@ -1,0 +1,423 @@
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile, chmod } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { FileStat } from '../providers/types'
+import {
+  copyLocalWorktreeIncludeFiles,
+  copyRemoteWorktreeIncludeFiles,
+  parseWorktreeInclude
+} from './worktree-include-copy'
+
+const tempRoots: string[] = []
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix))
+  tempRoots.push(dir)
+  return dir
+}
+
+function git(repo: string, args: string[]): void {
+  execFileSync('git', args, { cwd: repo })
+}
+
+async function createRepo(): Promise<{ repo: string; worktree: string }> {
+  const repo = await makeTempDir('orca-include-repo-')
+  const worktree = await makeTempDir('orca-include-worktree-')
+  git(repo, ['init', '-q'])
+  git(repo, ['config', 'user.email', 'test@example.com'])
+  git(repo, ['config', 'user.name', 'Test User'])
+  await writeFile(
+    path.join(repo, '.gitignore'),
+    ['.env.local', '.claude/settings.local.json', 'ignored-dir/', 'apps/*/.env.local'].join('\n')
+  )
+  await writeFile(path.join(repo, 'tracked.txt'), 'tracked content')
+  git(repo, ['add', '.gitignore', 'tracked.txt'])
+  git(repo, ['commit', '-q', '-m', 'initial'])
+  return { repo, worktree }
+}
+
+async function writeIncludeFile(repo: string, lines: string[]): Promise<void> {
+  await writeFile(path.join(repo, '.worktreeinclude'), lines.join('\n'))
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('parseWorktreeInclude', () => {
+  it('ignores comments and blank lines and dedupes entries', () => {
+    const parsed = parseWorktreeInclude(
+      [
+        '# local setup files',
+        '',
+        '  ',
+        '.env.local',
+        '.env.local',
+        '  .claude/settings.local.json  '
+      ].join('\n')
+    )
+    expect(parsed.entries).toEqual(['.env.local', '.claude/settings.local.json'])
+    expect(parsed.malformed).toEqual([])
+  })
+
+  it('rejects absolute paths, traversal, and glob patterns as malformed', () => {
+    const parsed = parseWorktreeInclude(
+      [
+        '/etc/passwd',
+        'C:\\secrets\\key',
+        '../outside.txt',
+        'nested/../../outside.txt',
+        'apps/*/.env.local',
+        'what?.txt',
+        'good/.env.local'
+      ].join('\n')
+    )
+    expect(parsed.entries).toEqual(['good/.env.local'])
+    expect(parsed.malformed).toEqual([
+      '/etc/passwd',
+      'C:\\secrets\\key',
+      '../outside.txt',
+      'nested/../../outside.txt',
+      'apps/*/.env.local',
+      'what?.txt'
+    ])
+  })
+
+  it('normalizes backslash separators and redundant segments', () => {
+    const parsed = parseWorktreeInclude('.claude\\settings.local.json\n./sub/./.env.local\n')
+    expect(parsed.entries).toEqual(['.claude/settings.local.json', 'sub/.env.local'])
+    expect(parsed.malformed).toEqual([])
+  })
+
+  it('rejects git pathspec-magic entries that would make git exit fatally', () => {
+    const parsed = parseWorktreeInclude([':(icase).env.local', ':!secret', '.env.local'].join('\n'))
+    expect(parsed.entries).toEqual(['.env.local'])
+    expect(parsed.malformed).toEqual([':(icase).env.local', ':!secret'])
+  })
+})
+
+describe('copyLocalWorktreeIncludeFiles', () => {
+  it('returns undefined when no .worktreeinclude exists', async () => {
+    const { repo, worktree } = await createRepo()
+    await expect(copyLocalWorktreeIncludeFiles(repo, worktree)).resolves.toBeUndefined()
+  })
+
+  it('is a no-op for an empty .worktreeinclude', async () => {
+    const { repo, worktree } = await createRepo()
+    await writeIncludeFile(repo, ['# nothing yet', ''])
+    await expect(copyLocalWorktreeIncludeFiles(repo, worktree)).resolves.toEqual({
+      copied: [],
+      skipped: []
+    })
+  })
+
+  it('copies gitignored files, creating parent directories and preserving mode', async () => {
+    const { repo, worktree } = await createRepo()
+    await writeFile(path.join(repo, '.env.local'), 'SECRET=1')
+    await mkdir(path.join(repo, '.claude'), { recursive: true })
+    await writeFile(path.join(repo, '.claude', 'settings.local.json'), '{"enabled":false}')
+    await chmod(path.join(repo, '.env.local'), 0o700)
+    await writeIncludeFile(repo, ['.env.local', '.claude/settings.local.json'])
+
+    const result = await copyLocalWorktreeIncludeFiles(repo, worktree)
+
+    expect(result).toEqual({
+      copied: ['.env.local', '.claude/settings.local.json'],
+      skipped: []
+    })
+    await expect(readFile(path.join(worktree, '.env.local'), 'utf8')).resolves.toBe('SECRET=1')
+    await expect(
+      readFile(path.join(worktree, '.claude', 'settings.local.json'), 'utf8')
+    ).resolves.toBe('{"enabled":false}')
+    if (process.platform !== 'win32') {
+      const mode = (await stat(path.join(worktree, '.env.local'))).mode & 0o777
+      expect(mode).toBe(0o700)
+    }
+  })
+
+  it('refuses tracked files and untracked files that are not gitignored', async () => {
+    const { repo, worktree } = await createRepo()
+    await writeFile(path.join(repo, 'untracked.txt'), 'untracked')
+    await writeFile(path.join(repo, '.env.local'), 'SECRET=1')
+    await writeIncludeFile(repo, ['tracked.txt', 'untracked.txt', '.env.local'])
+
+    const result = await copyLocalWorktreeIncludeFiles(repo, worktree)
+
+    expect(result).toEqual({
+      copied: ['.env.local'],
+      skipped: [
+        { path: 'tracked.txt', reason: 'tracked' },
+        { path: 'untracked.txt', reason: 'not-ignored' }
+      ]
+    })
+    await expect(stat(path.join(worktree, 'tracked.txt'))).rejects.toThrow()
+    await expect(stat(path.join(worktree, 'untracked.txt'))).rejects.toThrow()
+  })
+
+  it('skips entries that match an ignore pattern but are missing on disk', async () => {
+    const { repo, worktree } = await createRepo()
+    await writeIncludeFile(repo, ['.env.local'])
+
+    await expect(copyLocalWorktreeIncludeFiles(repo, worktree)).resolves.toEqual({
+      copied: [],
+      skipped: [{ path: '.env.local', reason: 'missing' }]
+    })
+  })
+
+  it('never overwrites an existing destination file', async () => {
+    const { repo, worktree } = await createRepo()
+    await writeFile(path.join(repo, '.env.local'), 'SECRET=from-repo')
+    await writeFile(path.join(worktree, '.env.local'), 'SECRET=already-here')
+    await writeIncludeFile(repo, ['.env.local'])
+
+    const result = await copyLocalWorktreeIncludeFiles(repo, worktree)
+
+    expect(result).toEqual({
+      copied: [],
+      skipped: [{ path: '.env.local', reason: 'destination-exists' }]
+    })
+    await expect(readFile(path.join(worktree, '.env.local'), 'utf8')).resolves.toBe(
+      'SECRET=already-here'
+    )
+  })
+
+  it('skips directories listed as entries', async () => {
+    const { repo, worktree } = await createRepo()
+    await mkdir(path.join(repo, 'ignored-dir'))
+    await writeFile(path.join(repo, 'ignored-dir', 'file.txt'), 'x')
+    await writeIncludeFile(repo, ['ignored-dir'])
+
+    await expect(copyLocalWorktreeIncludeFiles(repo, worktree)).resolves.toEqual({
+      copied: [],
+      skipped: [{ path: 'ignored-dir', reason: 'not-a-file' }]
+    })
+  })
+
+  it('treats malformed lines and per-file copy failures as non-fatal', async () => {
+    const { repo, worktree } = await createRepo()
+    await writeFile(path.join(repo, '.env.local'), 'SECRET=1')
+    await mkdir(path.join(repo, '.claude'), { recursive: true })
+    await writeFile(path.join(repo, '.claude', 'settings.local.json'), '{}')
+    // Block the destination parent with a file so the nested copy fails.
+    await writeFile(path.join(worktree, '.claude'), 'not a directory')
+    await writeIncludeFile(repo, ['../escape.txt', '.claude/settings.local.json', '.env.local'])
+
+    const result = await copyLocalWorktreeIncludeFiles(repo, worktree)
+
+    expect(result?.copied).toEqual(['.env.local'])
+    expect(result?.skipped).toEqual([
+      { path: '../escape.txt', reason: 'malformed' },
+      { path: '.claude/settings.local.json', reason: 'copy-failed' }
+    ])
+    await expect(readFile(path.join(worktree, '.env.local'), 'utf8')).resolves.toBe('SECRET=1')
+  })
+
+  it('refuses a symlinked source instead of dereferencing it out of the repo', async () => {
+    // Symlink creation needs privilege on Windows; skip there.
+    if (process.platform === 'win32') {
+      return
+    }
+    const { repo, worktree } = await createRepo()
+    const secretDir = await makeTempDir('orca-include-secret-')
+    await writeFile(path.join(secretDir, 'id_rsa'), 'PRIVATE KEY')
+    // A repo-committed symlink pointing at a host file outside the repo; the
+    // manifest lists the link itself (a "leaf" symlink git will still
+    // check-ignore, unlike a symlinked parent which git rejects outright).
+    await symlink(path.join(secretDir, 'id_rsa'), path.join(repo, 'stolen-key'))
+    await writeFile(
+      path.join(repo, '.gitignore'),
+      [
+        '.env.local',
+        '.claude/settings.local.json',
+        'ignored-dir/',
+        'apps/*/.env.local',
+        'stolen-key'
+      ].join('\n')
+    )
+    await writeIncludeFile(repo, ['stolen-key'])
+
+    await expect(copyLocalWorktreeIncludeFiles(repo, worktree)).resolves.toEqual({
+      copied: [],
+      skipped: [{ path: 'stolen-key', reason: 'not-a-file' }]
+    })
+    await expect(stat(path.join(worktree, 'stolen-key'))).rejects.toThrow()
+  })
+
+  it('refuses to copy through a symlinked destination parent', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+    const { repo, worktree } = await createRepo()
+    await mkdir(path.join(repo, '.claude'), { recursive: true })
+    await writeFile(path.join(repo, '.claude', 'settings.local.json'), '{}')
+    // Attacker-shaped worktree: `.claude` is a symlink to somewhere outside.
+    const outside = await makeTempDir('orca-include-outside-')
+    await symlink(outside, path.join(worktree, '.claude'))
+    await writeIncludeFile(repo, ['.claude/settings.local.json'])
+
+    await expect(copyLocalWorktreeIncludeFiles(repo, worktree)).resolves.toEqual({
+      copied: [],
+      skipped: [{ path: '.claude/settings.local.json', reason: 'not-a-file' }]
+    })
+    await expect(stat(path.join(outside, 'settings.local.json'))).rejects.toThrow()
+  })
+})
+
+describe('copyRemoteWorktreeIncludeFiles', () => {
+  type RemoteHostStub = {
+    gitProvider: {
+      exec: ReturnType<typeof vi.fn>
+      checkIgnoredPaths: ReturnType<typeof vi.fn>
+    }
+    fsProvider: {
+      readFile: ReturnType<typeof vi.fn>
+      stat: ReturnType<typeof vi.fn>
+      lstat: ReturnType<typeof vi.fn>
+      createDir: ReturnType<typeof vi.fn>
+      copy: ReturnType<typeof vi.fn>
+    }
+  }
+
+  function createRemoteHostStub(options: {
+    includeContent?: string
+    tracked?: string[]
+    ignored?: string[]
+    stats?: Record<string, FileStat['type']>
+    copyError?: Error
+  }): RemoteHostStub {
+    // Why: the remote ops prefer lstat (to reject symlinked sources); it and
+    // stat share the same fixture map so a 'symlink' type can be expressed.
+    const statImpl = (filePath: string): Promise<FileStat> => {
+      const name = filePath.split('/').at(-1) ?? ''
+      const type = options.stats?.[name]
+      if (!type) {
+        return Promise.reject(new Error('ENOENT'))
+      }
+      return Promise.resolve({ size: 1, type, mtime: 0 } satisfies FileStat)
+    }
+    return {
+      gitProvider: {
+        exec: vi.fn().mockResolvedValue({
+          stdout: (options.tracked ?? []).join('\0'),
+          stderr: ''
+        }),
+        checkIgnoredPaths: vi.fn().mockResolvedValue(options.ignored ?? [])
+      },
+      fsProvider: {
+        readFile: vi.fn().mockImplementation(() => {
+          if (options.includeContent === undefined) {
+            return Promise.reject(new Error('ENOENT: no such file'))
+          }
+          return Promise.resolve({ content: options.includeContent, isBinary: false })
+        }),
+        stat: vi.fn().mockImplementation(statImpl),
+        lstat: vi.fn().mockImplementation(statImpl),
+        createDir: vi.fn().mockResolvedValue(undefined),
+        copy: vi.fn().mockImplementation(() => {
+          if (options.copyError) {
+            return Promise.reject(options.copyError)
+          }
+          return Promise.resolve()
+        })
+      }
+    }
+  }
+
+  function runRemoteCopy(stub: RemoteHostStub) {
+    return copyRemoteWorktreeIncludeFiles(
+      '/remote/repo',
+      '/remote/worktree',
+      stub.gitProvider as never,
+      stub.fsProvider as never
+    )
+  }
+
+  it('returns undefined when the remote include file is unreadable or absent', async () => {
+    const stub = createRemoteHostStub({})
+    await expect(runRemoteCopy(stub)).resolves.toBeUndefined()
+    expect(stub.gitProvider.exec).not.toHaveBeenCalled()
+  })
+
+  it('copies ignored files on the remote host, creating parent directories', async () => {
+    const stub = createRemoteHostStub({
+      includeContent: '.claude/settings.local.json\ntracked.txt\n',
+      tracked: ['tracked.txt'],
+      ignored: ['.claude/settings.local.json'],
+      stats: { 'settings.local.json': 'file' }
+    })
+
+    await expect(runRemoteCopy(stub)).resolves.toEqual({
+      copied: ['.claude/settings.local.json'],
+      skipped: [{ path: 'tracked.txt', reason: 'tracked' }]
+    })
+    expect(stub.gitProvider.exec).toHaveBeenCalledWith(
+      ['ls-files', '-z', '--', '.claude/settings.local.json', 'tracked.txt'],
+      '/remote/repo'
+    )
+    expect(stub.fsProvider.createDir).toHaveBeenCalledWith('/remote/worktree/.claude')
+    expect(stub.fsProvider.copy).toHaveBeenCalledWith(
+      '/remote/repo/.claude/settings.local.json',
+      '/remote/worktree/.claude/settings.local.json'
+    )
+  })
+
+  it('maps the relay no-clobber EEXIST error to destination-exists', async () => {
+    const stub = createRemoteHostStub({
+      includeContent: '.env.local\n',
+      ignored: ['.env.local'],
+      stats: { '.env.local': 'file' },
+      copyError: new Error('EEXIST: destination already exists')
+    })
+
+    await expect(runRemoteCopy(stub)).resolves.toEqual({
+      copied: [],
+      skipped: [{ path: '.env.local', reason: 'destination-exists' }]
+    })
+  })
+
+  it('skips all entries when the remote git checks fail', async () => {
+    const stub = createRemoteHostStub({
+      includeContent: '.env.local\n',
+      stats: { '.env.local': 'file' }
+    })
+    stub.gitProvider.exec.mockRejectedValue(new Error('relay disconnected'))
+
+    await expect(runRemoteCopy(stub)).resolves.toEqual({
+      copied: [],
+      skipped: [{ path: '.env.local', reason: 'check-failed' }]
+    })
+    expect(stub.fsProvider.copy).not.toHaveBeenCalled()
+  })
+
+  it('skips an ignored entry that is missing on the remote host', async () => {
+    const stub = createRemoteHostStub({
+      includeContent: '.env.local\n',
+      ignored: ['.env.local']
+      // no stats entry -> lstat rejects -> 'missing'
+    })
+
+    await expect(runRemoteCopy(stub)).resolves.toEqual({
+      copied: [],
+      skipped: [{ path: '.env.local', reason: 'missing' }]
+    })
+    expect(stub.fsProvider.copy).not.toHaveBeenCalled()
+  })
+
+  it('refuses a symlinked remote source via lstat instead of copying it', async () => {
+    const stub = createRemoteHostStub({
+      includeContent: '.env.local\n',
+      ignored: ['.env.local'],
+      stats: { '.env.local': 'symlink' }
+    })
+
+    await expect(runRemoteCopy(stub)).resolves.toEqual({
+      copied: [],
+      skipped: [{ path: '.env.local', reason: 'not-a-file' }]
+    })
+    expect(stub.fsProvider.lstat).toHaveBeenCalledWith('/remote/repo/.env.local')
+    expect(stub.fsProvider.copy).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/worktree-include-copy.ts
+++ b/src/main/ipc/worktree-include-copy.ts
@@ -1,0 +1,212 @@
+import type { WorktreeIncludeCopyResult, WorktreeIncludeCopySkipReason } from '../../shared/types'
+import type { GitRuntimeOptions } from '../git/git-runtime-options'
+import type { IFilesystemProvider } from '../providers/types'
+import {
+  WORKTREE_INCLUDE_FILENAME,
+  createLocalWorktreeIncludeOps,
+  createRemoteWorktreeIncludeOps,
+  type RemoteWorktreeIncludeGitOps,
+  type WorktreeIncludeHostOps
+} from './worktree-include-host-ops'
+
+export { WORKTREE_INCLUDE_FILENAME }
+
+export type ParsedWorktreeInclude = {
+  entries: string[]
+  malformed: string[]
+}
+
+export function parseWorktreeInclude(content: string): ParsedWorktreeInclude {
+  const entries: string[] = []
+  const malformed: string[] = []
+  const seen = new Set<string>()
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+    // Why: entries are exact repo-relative file paths. Absolute paths and
+    // `..` traversal could escape the repo root, glob characters signal an
+    // unsupported pattern, and a leading `:` is git pathspec magic (e.g.
+    // `:(icase)`) that would make `git ls-files`/`check-ignore` exit fatally
+    // and downgrade every entry to check-failed — all are rejected here
+    // (warned, never fatal) instead of guessed at.
+    const normalized = line
+      .replace(/\\/g, '/')
+      .replace(/\/+$/, '')
+      .split('/')
+      .filter((segment) => segment !== '' && segment !== '.')
+      .join('/')
+    if (
+      !normalized ||
+      line.startsWith('/') ||
+      line.startsWith('\\') ||
+      normalized.startsWith(':') ||
+      /^[a-zA-Z]:/.test(normalized) ||
+      normalized.split('/').includes('..') ||
+      /[*?[\]]/.test(normalized)
+    ) {
+      malformed.push(line)
+      continue
+    }
+    if (!seen.has(normalized)) {
+      seen.add(normalized)
+      entries.push(normalized)
+    }
+  }
+  return { entries, malformed }
+}
+
+async function runWorktreeIncludeCopy(
+  ops: WorktreeIncludeHostOps
+): Promise<WorktreeIncludeCopyResult | undefined> {
+  const content = await ops.readIncludeFile()
+  if (content === null) {
+    return undefined
+  }
+  const { entries, malformed } = parseWorktreeInclude(content)
+  const skipped: WorktreeIncludeCopyResult['skipped'] = []
+  for (const line of malformed) {
+    console.warn(
+      `[worktree-include] Skipping malformed ${WORKTREE_INCLUDE_FILENAME} entry "${line}" ` +
+        '(exact repo-relative file paths only — no globs, "..", or absolute paths)'
+    )
+    skipped.push({ path: line, reason: 'malformed' })
+  }
+  if (entries.length === 0) {
+    return { copied: [], skipped }
+  }
+
+  let tracked: Set<string>
+  let ignored: Set<string>
+  try {
+    tracked = new Set(await ops.listTrackedPaths(entries))
+    const candidates = entries.filter((entry) => !tracked.has(entry))
+    ignored = new Set(candidates.length > 0 ? await ops.listIgnoredPaths(candidates) : [])
+  } catch (error) {
+    // Why: without a trustworthy tracked/ignored answer we cannot tell setup
+    // secrets apart from repo content, so copy nothing rather than guess.
+    console.warn(
+      `[worktree-include] git tracked/ignored check failed; skipping all entries:`,
+      error
+    )
+    return {
+      copied: [],
+      skipped: [
+        ...skipped,
+        ...entries.map((path) => ({
+          path,
+          reason: 'check-failed' as WorktreeIncludeCopySkipReason
+        }))
+      ]
+    }
+  }
+
+  // Why: entries are independent once tracked/ignored status is known, so
+  // copy concurrently — on remote hosts each file costs several relay round
+  // trips. Outcomes are folded back in manifest order to keep results (and
+  // the tests that assert on them) deterministic.
+  const outcomes = await Promise.all(
+    entries.map((entry) => copyEntryToWorktree(entry, ops, tracked, ignored))
+  )
+  const copied: string[] = []
+  entries.forEach((entry, index) => {
+    const outcome = outcomes[index]
+    if (outcome === 'copied') {
+      copied.push(entry)
+    } else if (outcome) {
+      skipped.push({ path: entry, reason: outcome })
+    }
+  })
+  return { copied, skipped }
+}
+
+async function copyEntryToWorktree(
+  entry: string,
+  ops: WorktreeIncludeHostOps,
+  tracked: Set<string>,
+  ignored: Set<string>
+): Promise<'copied' | WorktreeIncludeCopySkipReason> {
+  if (tracked.has(entry)) {
+    console.log(
+      `[worktree-include] Skipping tracked entry "${entry}" (only gitignored files are copied)`
+    )
+    return 'tracked'
+  }
+  if (!ignored.has(entry)) {
+    console.log(`[worktree-include] Skipping "${entry}": not gitignored in the primary checkout`)
+    return 'not-ignored'
+  }
+  try {
+    const outcome = await ops.copyFileNoClobber(entry)
+    if (outcome === 'not-a-file') {
+      console.warn(
+        `[worktree-include] Skipping "${entry}": not a regular file (directories are not supported)`
+      )
+    }
+    return outcome
+  } catch (error) {
+    console.warn(`[worktree-include] Failed to copy "${entry}":`, error)
+    return 'copy-failed'
+  }
+}
+
+function logIncludeCopySummary(
+  worktreePath: string,
+  result: WorktreeIncludeCopyResult | undefined
+): void {
+  if (!result || (result.copied.length === 0 && result.skipped.length === 0)) {
+    return
+  }
+  const copiedSummary = result.copied.length > 0 ? result.copied.join(', ') : 'none'
+  const skippedSummary = result.skipped.map((skip) => `${skip.path} (${skip.reason})`).join(', ')
+  const skippedSuffix = skippedSummary ? `; skipped ${skippedSummary}` : ''
+  console.log(
+    `[worktree-include] ${worktreePath}: copied ${result.copied.length} — ${copiedSummary}${skippedSuffix}`
+  )
+}
+
+// Why: any failure must degrade to a log line — the git worktree already
+// exists at this point and a copy problem must not abort creation.
+async function copyWorktreeIncludeFilesSafely(
+  worktreePath: string,
+  ops: WorktreeIncludeHostOps
+): Promise<WorktreeIncludeCopyResult | undefined> {
+  try {
+    const result = await runWorktreeIncludeCopy(ops)
+    logIncludeCopySummary(worktreePath, result)
+    return result
+  } catch (error) {
+    console.warn(`[worktree-include] include copy failed for ${worktreePath}:`, error)
+    return undefined
+  }
+}
+
+/** Copy `.worktreeinclude`-listed gitignored files from the primary checkout
+ *  into a freshly created local worktree. Never throws; returns undefined
+ *  when no `.worktreeinclude` exists. */
+export async function copyLocalWorktreeIncludeFiles(
+  repoPath: string,
+  worktreePath: string,
+  gitOptions: GitRuntimeOptions = {}
+): Promise<WorktreeIncludeCopyResult | undefined> {
+  return copyWorktreeIncludeFilesSafely(
+    worktreePath,
+    createLocalWorktreeIncludeOps(repoPath, worktreePath, gitOptions)
+  )
+}
+
+/** Remote-host variant of {@link copyLocalWorktreeIncludeFiles}. The copy runs
+ *  entirely on the remote host via the relay's no-clobber fs.copy, so listed
+ *  files never leave the machine they already live on. */
+export async function copyRemoteWorktreeIncludeFiles(
+  repoPath: string,
+  worktreePath: string,
+  gitProvider: RemoteWorktreeIncludeGitOps,
+  fsProvider: IFilesystemProvider
+): Promise<WorktreeIncludeCopyResult | undefined> {
+  return copyWorktreeIncludeFilesSafely(
+    worktreePath,
+    createRemoteWorktreeIncludeOps(repoPath, worktreePath, gitProvider, fsProvider)
+  )
+}

--- a/src/main/ipc/worktree-include-host-ops.ts
+++ b/src/main/ipc/worktree-include-host-ops.ts
@@ -1,0 +1,211 @@
+import { constants } from 'node:fs'
+import { chmod, copyFile, lstat, mkdir, readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { GitRuntimeOptions } from '../git/git-runtime-options'
+import { gitOptionsForWorktree } from '../git/git-runtime-options'
+import { checkIgnoredPaths } from '../git/check-ignored-paths'
+import { gitExecFileAsync } from '../git/runner'
+import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
+import type { IFilesystemProvider, IGitProvider } from '../providers/types'
+import { isENOENT } from './filesystem-auth'
+
+/** Repo-root manifest of exact relative paths of gitignored local setup files
+ *  (e.g. `.env.local`, `.claude/settings.local.json`) that must exist in every
+ *  new worktree before any setup script or agent starts. Mirrors Codex's
+ *  `.worktreeinclude` contract: the harness itself honors it at creation time,
+ *  so it cannot be skipped, raced, or half-applied the way a setup script can. */
+export const WORKTREE_INCLUDE_FILENAME = '.worktreeinclude'
+
+const GIT_PATH_ARG_CHUNK_SIZE = 100
+
+export type CopyAttemptOutcome = 'copied' | 'missing' | 'not-a-file' | 'destination-exists'
+
+export type WorktreeIncludeHostOps = {
+  /** Contents of `<repoRoot>/.worktreeinclude`, or null when absent. */
+  readIncludeFile(): Promise<string | null>
+  listTrackedPaths(relativePaths: string[]): Promise<string[]>
+  listIgnoredPaths(relativePaths: string[]): Promise<string[]>
+  /** Copy one repo-relative file into the worktree, creating parent
+   *  directories and preserving mode; must never overwrite the destination. */
+  copyFileNoClobber(relativePath: string): Promise<CopyAttemptOutcome>
+}
+
+export type RemoteWorktreeIncludeGitOps = Pick<IGitProvider, 'exec' | 'checkIgnoredPaths'>
+
+async function listTrackedPathsChunked(
+  relativePaths: string[],
+  execGit: (args: string[]) => Promise<{ stdout: string }>
+): Promise<string[]> {
+  const trackedPaths: string[] = []
+  for (let i = 0; i < relativePaths.length; i += GIT_PATH_ARG_CHUNK_SIZE) {
+    const chunk = relativePaths.slice(i, i + GIT_PATH_ARG_CHUNK_SIZE)
+    const { stdout } = await execGit(['ls-files', '-z', '--', ...chunk])
+    trackedPaths.push(...stdout.split('\0').filter(Boolean))
+  }
+  return trackedPaths
+}
+
+/** True when any existing component of `relativePath` under `rootPath` is a
+ *  symlink. Copying through a symlinked parent would follow the link and write
+ *  the file outside the worktree, so callers reject such entries. Missing
+ *  components are fine — they will be created as real directories. */
+async function relativePathHasSymlinkedParent(
+  rootPath: string,
+  relativePath: string
+): Promise<boolean> {
+  const segments = relativePath.split('/').slice(0, -1)
+  let current = rootPath
+  for (const segment of segments) {
+    current = resolve(current, segment)
+    try {
+      if ((await lstat(current)).isSymbolicLink()) {
+        return true
+      }
+    } catch {
+      // Component does not exist yet — mkdir will create it as a real dir.
+      return false
+    }
+  }
+  return false
+}
+
+export function createLocalWorktreeIncludeOps(
+  repoPath: string,
+  worktreePath: string,
+  gitOptions: GitRuntimeOptions
+): WorktreeIncludeHostOps {
+  return {
+    async readIncludeFile() {
+      try {
+        return await readFile(resolve(repoPath, WORKTREE_INCLUDE_FILENAME), 'utf8')
+      } catch (error) {
+        if (isENOENT(error)) {
+          return null
+        }
+        throw error
+      }
+    },
+    async listTrackedPaths(relativePaths) {
+      return listTrackedPathsChunked(relativePaths, (args) =>
+        gitExecFileAsync(args, gitOptionsForWorktree(repoPath, gitOptions))
+      )
+    },
+    async listIgnoredPaths(relativePaths) {
+      return checkIgnoredPaths(repoPath, relativePaths, gitOptions)
+    },
+    async copyFileNoClobber(relativePath) {
+      const source = resolve(repoPath, relativePath)
+      const destination = resolve(worktreePath, relativePath)
+      // Why: reject a repo-committed symlink anywhere in the source path — the
+      // leaf (lstat below) or any parent component — so a link pointing outside
+      // the repo (e.g. `foo -> ~/.ssh`) cannot exfiltrate host files into the
+      // new worktree the agent then runs in. Same guard on the destination side
+      // stops a symlinked parent from redirecting the write out of the worktree.
+      if (
+        (await relativePathHasSymlinkedParent(repoPath, relativePath)) ||
+        (await relativePathHasSymlinkedParent(worktreePath, relativePath))
+      ) {
+        return 'not-a-file'
+      }
+      let sourceStat
+      try {
+        sourceStat = await lstat(source)
+      } catch (error) {
+        if (isENOENT(error)) {
+          return 'missing'
+        }
+        throw error
+      }
+      if (!sourceStat.isFile()) {
+        return 'not-a-file'
+      }
+      await mkdir(dirname(destination), { recursive: true })
+      try {
+        await copyFile(source, destination, constants.COPYFILE_EXCL)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException | undefined)?.code === 'EEXIST') {
+          return 'destination-exists'
+        }
+        throw error
+      }
+      // Why: copyFile only carries the source mode onto brand-new files on
+      // some platforms; stamp it explicitly so executable setup files stay
+      // executable in the worktree. A chmod failure must not undo a completed
+      // copy — the content is already in place, so keep the 'copied' outcome.
+      await chmod(destination, sourceStat.mode & 0o777).catch(() => undefined)
+      return 'copied'
+    }
+  }
+}
+
+export function createRemoteWorktreeIncludeOps(
+  repoPath: string,
+  worktreePath: string,
+  gitProvider: RemoteWorktreeIncludeGitOps,
+  fsProvider: IFilesystemProvider
+): WorktreeIncludeHostOps {
+  return {
+    async readIncludeFile() {
+      let result
+      try {
+        result = await fsProvider.readFile(
+          joinWorktreeRelativePath(repoPath, WORKTREE_INCLUDE_FILENAME)
+        )
+      } catch (error) {
+        // Why: the relay surfaces a missing file as a generic error; treat any
+        // read failure as "no include file" so creation is never blocked. Log
+        // it so a real relay/auth failure leaves a trace instead of looking
+        // identical to "not configured".
+        console.warn(
+          `[worktree-include] Could not read ${WORKTREE_INCLUDE_FILENAME} on remote host; treating as absent:`,
+          error
+        )
+        return null
+      }
+      return result.isBinary ? null : result.content
+    },
+    async listTrackedPaths(relativePaths) {
+      return listTrackedPathsChunked(relativePaths, (args) => gitProvider.exec(args, repoPath))
+    },
+    async listIgnoredPaths(relativePaths) {
+      return gitProvider.checkIgnoredPaths(repoPath, relativePaths)
+    },
+    async copyFileNoClobber(relativePath) {
+      // Why: source and destination both live on the remote host, so the copy
+      // happens host-side over the existing relay — file contents (which can
+      // include secrets) never transit to the local machine.
+      const source = joinWorktreeRelativePath(repoPath, relativePath)
+      const destination = joinWorktreeRelativePath(worktreePath, relativePath)
+      let sourceStat
+      try {
+        // Why: lstat when the relay exposes it so a symlinked source is rejected
+        // (type 'symlink') rather than dereferenced — fs.stat follows the link
+        // and would report a symlink-to-file as 'file', matching the local
+        // exfiltration vector. Fall back to stat on relays without lstat.
+        sourceStat = fsProvider.lstat
+          ? await fsProvider.lstat(source)
+          : await fsProvider.stat(source)
+      } catch {
+        return 'missing'
+      }
+      if (sourceStat.type !== 'file') {
+        return 'not-a-file'
+      }
+      const parent = relativePath.split('/').slice(0, -1).join('/')
+      if (parent) {
+        await fsProvider.createDir(joinWorktreeRelativePath(worktreePath, parent))
+      }
+      try {
+        // Why: the relay's fs.copy is no-clobber (errorOnExist) and preserves
+        // file mode, giving remote copies the same guarantees as local ones.
+        await fsProvider.copy(source, destination)
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('EEXIST')) {
+          return 'destination-exists'
+        }
+        throw error
+      }
+      return 'copied'
+    }
+  }
+}

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -96,6 +96,10 @@ import {
 } from './worktree-push-target-setup'
 import { isENOENT, registerWorktreeRootsForRepo } from './filesystem-auth'
 import { createWorktreeLinkedPaths } from './worktree-symlinks'
+import {
+  copyLocalWorktreeIncludeFiles,
+  copyRemoteWorktreeIncludeFiles
+} from './worktree-include-copy'
 import { normalizeSparseDirectories } from './sparse-checkout-directories'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import type { IFilesystemProvider } from '../providers/types'
@@ -1889,6 +1893,17 @@ export async function createRemoteWorktree(
   // local-only until that protocol work is in scope. Remote repos with
   // `symlinkPaths` configured have them silently ignored here.
 
+  // Why: `.worktreeinclude` must be honored before setup preparation and any
+  // agent starts, same as the local flow. The copy runs entirely on the
+  // remote host (relay fs.copy), so listed files — which can hold secrets —
+  // never transit to the local machine.
+  let includeCopy: CreateWorktreeResult['includeCopy']
+  if (fsProvider) {
+    includeCopy = await timing.time('copy_worktree_include', async () =>
+      copyRemoteWorktreeIncludeFiles(repo.path, created.path, provider, fsProvider)
+    )
+  }
+
   let setup: CreateWorktreeResult['setup']
   let defaultTabs: CreateWorktreeResult['defaultTabs']
   if (fsProvider) {
@@ -1941,6 +1956,7 @@ export async function createRemoteWorktree(
     ...(defaultTabs ? { defaultTabs } : {}),
     ...(localBaseRefRefresh ? { localBaseRefRefresh } : {}),
     ...(localBaseRefUpdateSuggestion ? { localBaseRefUpdateSuggestion } : {}),
+    ...(includeCopy ? { includeCopy } : {}),
     timing: timing.finish()
   }
 }
@@ -2521,6 +2537,14 @@ export async function createLocalWorktree(
     })
   }
 
+  // Why: `.worktreeinclude` is a harness-level contract — gitignored local
+  // setup files listed there must be in place before any setup script or
+  // agent starts, and must not depend on a setup script being configured,
+  // launched, or succeeding. Keep this step ahead of prepare_setup.
+  const includeCopy = await timing.time('copy_worktree_include', async () =>
+    copyLocalWorktreeIncludeFiles(repo.path, created.path, localWorktreeGitOptions)
+  )
+
   // Why: the worktree's own `orca.yaml` (at the tip of the base branch) is
   // authoritative for what runs post-creation. The repo-level trust already
   // granted by the user in the pre-create flow covers execution of that
@@ -2609,6 +2633,7 @@ export async function createLocalWorktree(
     ...(addResult.localBaseRefUpdateSuggestion
       ? { localBaseRefUpdateSuggestion: addResult.localBaseRefUpdateSuggestion }
       : {}),
+    ...(includeCopy ? { includeCopy } : {}),
     ...(stagedStartup.startupTerminal ? { startupTerminal: stagedStartup.startupTerminal } : {}),
     ...(stagedStartup.warning ? { warning: stagedStartup.warning } : {}),
     timing: timing.finish()

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -197,6 +197,18 @@ vi.mock('./worktree-logic', async (importOriginal) => {
   }
 })
 
+const { copyLocalWorktreeIncludeFilesMock, copyRemoteWorktreeIncludeFilesMock } = vi.hoisted(
+  () => ({
+    copyLocalWorktreeIncludeFilesMock: vi.fn(),
+    copyRemoteWorktreeIncludeFilesMock: vi.fn()
+  })
+)
+
+vi.mock('./worktree-include-copy', () => ({
+  copyLocalWorktreeIncludeFiles: copyLocalWorktreeIncludeFilesMock,
+  copyRemoteWorktreeIncludeFiles: copyRemoteWorktreeIncludeFilesMock
+}))
+
 const { deleteWorktreeHistoryDirMock } = vi.hoisted(() => ({
   deleteWorktreeHistoryDirMock: vi.fn()
 }))
@@ -336,10 +348,14 @@ describe('registerWorktreeHandlers', () => {
       clearProviderPtyStateMock,
       getLocalPtyProviderMock,
       deleteWorktreeHistoryDirMock,
-      advertisedUrlWatcherForgetWorktreeMock
+      advertisedUrlWatcherForgetWorktreeMock,
+      copyLocalWorktreeIncludeFilesMock,
+      copyRemoteWorktreeIncludeFilesMock
     ]) {
       m.mockReset()
     }
+    copyLocalWorktreeIncludeFilesMock.mockResolvedValue(undefined)
+    copyRemoteWorktreeIncludeFilesMock.mockResolvedValue(undefined)
     killAllProcessesForWorktreeMock.mockResolvedValue({
       runtimeStopped: 0,
       providerStopped: 0,
@@ -1043,6 +1059,118 @@ describe('registerWorktreeHandlers', () => {
         'spawn_startup_terminal'
       ])
     )
+  })
+
+  it('copies .worktreeinclude files after worktree add, before setup prep and agent startup', async () => {
+    addWorktreeMock.mockResolvedValue({})
+    listWorktreesMock.mockResolvedValueOnce([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'def',
+        branch: 'improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    loadHooksMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    getEffectiveHooksMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    getEffectiveHooksFromConfigMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    shouldRunSetupForCreateMock.mockReturnValue(true)
+    copyLocalWorktreeIncludeFilesMock.mockResolvedValue({
+      copied: ['.env.local'],
+      skipped: [{ path: 'tracked.txt', reason: 'tracked' }]
+    })
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard',
+      createdWithAgent: 'claude',
+      startup: {
+        command: 'claude --prefill test',
+        env: { ORCA_AGENT_MODE: 'direct' },
+        telemetry: {
+          agent_kind: 'claude',
+          launch_source: 'new_workspace_composer',
+          request_kind: 'new'
+        }
+      }
+    })) as {
+      includeCopy?: { copied: string[]; skipped: { path: string; reason: string }[] }
+      timing?: { phases: { phase: string }[] }
+    }
+
+    expect(copyLocalWorktreeIncludeFilesMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/improve-dashboard',
+      expect.any(Object)
+    )
+    const copyOrder = copyLocalWorktreeIncludeFilesMock.mock.invocationCallOrder[0]
+    const addOrder = addWorktreeMock.mock.invocationCallOrder[0]
+    const setupPrepOrder = createSetupRunnerScriptMock.mock.invocationCallOrder[0]
+    const agentSpawnOrder = runtimeStub.createTerminal.mock.invocationCallOrder[0]
+    expect(copyOrder).toBeGreaterThan(addOrder!)
+    expect(copyOrder).toBeLessThan(setupPrepOrder!)
+    expect(copyOrder).toBeLessThan(agentSpawnOrder!)
+    expect(result.includeCopy).toEqual({
+      copied: ['.env.local'],
+      skipped: [{ path: 'tracked.txt', reason: 'tracked' }]
+    })
+    expect(result.timing?.phases.map((phase) => phase.phase)).toEqual(
+      expect.arrayContaining(['copy_worktree_include', 'prepare_setup'])
+    )
+  })
+
+  it('copies .worktreeinclude files when no setup script is configured', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'abc123',
+        branch: 'refs/heads/improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    copyLocalWorktreeIncludeFilesMock.mockResolvedValue({ copied: ['.env.local'], skipped: [] })
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard'
+    })) as { includeCopy?: unknown }
+
+    expect(copyLocalWorktreeIncludeFilesMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/improve-dashboard',
+      expect.any(Object)
+    )
+    expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
+    expect(result.includeCopy).toEqual({ copied: ['.env.local'], skipped: [] })
+  })
+
+  it('copies .worktreeinclude files when setup is configured but skipped', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'abc123',
+        branch: 'refs/heads/improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    loadHooksMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    getEffectiveHooksMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    getEffectiveHooksFromConfigMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    shouldRunSetupForCreateMock.mockReturnValue(false)
+    copyLocalWorktreeIncludeFilesMock.mockResolvedValue({ copied: ['.env.local'], skipped: [] })
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard',
+      setupDecision: 'skip'
+    })) as { includeCopy?: unknown }
+
+    expect(copyLocalWorktreeIncludeFilesMock).toHaveBeenCalled()
+    expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
+    expect(result.includeCopy).toEqual({ copied: ['.env.local'], skipped: [] })
   })
 
   it('returns the wrapped setup command when startup spawned but setup creation failed', async () => {
@@ -2827,6 +2955,64 @@ describe('registerWorktreeHandlers', () => {
         manualOrder: 123_456
       })
     })
+  })
+
+  it('copies .worktreeinclude on the remote host after add, before setup prep', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi
+        .fn()
+        .mockImplementation(async (args: string[]) =>
+          args[0] === 'remote' ? { stdout: 'origin\n', stderr: '' } : { stdout: '', stderr: '' }
+        ),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/improve-dashboard',
+          head: 'abc123',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const fsProvider = { readFile: vi.fn().mockRejectedValue(new Error('ENOENT')) }
+    const mux = { request: vi.fn().mockResolvedValue(undefined), notify: vi.fn() }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getSshFilesystemProviderMock.mockReturnValue(fsProvider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+    copyRemoteWorktreeIncludeFilesMock.mockResolvedValue({
+      copied: ['.env.local'],
+      skipped: []
+    })
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'improve-dashboard'
+    })) as { includeCopy?: unknown }
+
+    expect(copyRemoteWorktreeIncludeFilesMock).toHaveBeenCalledWith(
+      '/remote/repo',
+      '/remote/improve-dashboard',
+      provider,
+      fsProvider
+    )
+    const addOrder = provider.addWorktree.mock.invocationCallOrder[0]
+    const copyOrder = copyRemoteWorktreeIncludeFilesMock.mock.invocationCallOrder[0]
+    expect(copyOrder).toBeGreaterThan(addOrder!)
+    expect(result.includeCopy).toEqual({ copied: ['.env.local'], skipped: [] })
   })
 
   it('returns SSH local base refresh skip status when the owning worktree is dirty', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -392,6 +392,20 @@ vi.mock('../ipc/filesystem-auth', () => ({
   resolveAuthorizedPath: vi.fn(async (pathValue: string) => pathValue)
 }))
 
+// Why: default undefined mirrors the real function's no-.worktreeinclude
+// result, so existing create tests are unaffected; the ordering test overrides
+// it per-run with mockResolvedValueOnce.
+const { copyLocalWorktreeIncludeFilesMock, copyRemoteWorktreeIncludeFilesMock } = vi.hoisted(
+  () => ({
+    copyLocalWorktreeIncludeFilesMock: vi.fn(),
+    copyRemoteWorktreeIncludeFilesMock: vi.fn()
+  })
+)
+vi.mock('../ipc/worktree-include-copy', () => ({
+  copyLocalWorktreeIncludeFiles: copyLocalWorktreeIncludeFilesMock,
+  copyRemoteWorktreeIncludeFiles: copyRemoteWorktreeIncludeFilesMock
+}))
+
 vi.mock('../worktree-root-preparation', () => ({
   prepareLocalWorktreeRootForRepo: prepareLocalWorktreeRootForRepoMock
 }))
@@ -2180,6 +2194,36 @@ describe('OrcaRuntimeService', () => {
       id: result.worktree.id,
       path: createdWorktree.path
     })
+  })
+
+  it('copies .worktreeinclude during runtime create and surfaces includeCopy', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const createdWorktree = {
+      path: '/tmp/workspaces/include-copy',
+      head: 'def',
+      branch: 'include-copy',
+      isBare: false,
+      isMainWorktree: false
+    }
+    computeWorktreePathMock.mockReturnValue(createdWorktree.path)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdWorktree.path)
+    vi.mocked(listWorktrees).mockResolvedValue([...MOCK_GIT_WORKTREES, createdWorktree])
+    copyLocalWorktreeIncludeFilesMock.mockResolvedValueOnce({ copied: ['.env.local'], skipped: [] })
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'include-copy'
+    })
+
+    expect(copyLocalWorktreeIncludeFilesMock).toHaveBeenCalledWith(
+      '/tmp/repo',
+      createdWorktree.path,
+      expect.any(Object)
+    )
+    const addOrder = vi.mocked(addWorktree).mock.invocationCallOrder.at(-1)
+    const copyOrder = copyLocalWorktreeIncludeFilesMock.mock.invocationCallOrder.at(-1)
+    expect(copyOrder).toBeGreaterThan(addOrder!)
+    expect(result.includeCopy).toEqual({ copied: ['.env.local'], skipped: [] })
   })
 
   it('creates additional workspace metadata for folder-mode repos through runtime create', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -634,6 +634,7 @@ import {
 } from '../../shared/constants'
 import { listRepoWorktrees } from '../repo-worktrees'
 import { createWorktreeLinkedPaths, removeWorktreeLinkedPaths } from '../ipc/worktree-symlinks'
+import { copyLocalWorktreeIncludeFiles } from '../ipc/worktree-include-copy'
 import { deleteWorktreeHistoryDir } from '../terminal-history'
 import {
   cleanupUnusedWorktreePushTargetRemote,
@@ -13896,6 +13897,15 @@ export class OrcaRuntimeService {
       await createWorktreeLinkedPaths(repo.path, created.path, repo.symlinkPaths)
     }
 
+    // Why: `.worktreeinclude` is a harness-level contract — gitignored local
+    // setup files listed there must be in place before any setup script or
+    // agent starts, independent of whether setup is configured or skipped.
+    const includeCopy = await copyLocalWorktreeIncludeFiles(
+      repo.path,
+      created.path,
+      localWorktreeGitOptions
+    )
+
     let setup: CreateWorktreeResult['setup']
     let warning: string | undefined
     // Why: CLI-created worktrees do not have a renderer preview to mismatch
@@ -14161,6 +14171,7 @@ export class OrcaRuntimeService {
       ...(addResult.localBaseRefUpdateSuggestion
         ? { localBaseRefUpdateSuggestion: addResult.localBaseRefUpdateSuggestion }
         : {}),
+      ...(includeCopy ? { includeCopy } : {}),
       ...(didSpawnStartup && startupTerminalHandle
         ? {
             startupTerminal: {

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -18,6 +18,7 @@ import type {
   TerminalLayoutSnapshot,
   TuiAgent,
   Worktree,
+  WorktreeIncludeCopyResult,
   WorktreeLineage,
   WorkspaceLineage,
   WorktreeLineageWarning
@@ -665,6 +666,7 @@ export type RuntimeWorktreeCreateResult = {
   workspaceLineage?: WorkspaceLineage | null
   warnings: WorktreeLineageWarning[]
   warning?: string
+  includeCopy?: WorktreeIncludeCopyResult
 }
 
 export type RuntimeWorktreeRemoveResult = RemoveWorktreeResult & {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2109,6 +2109,24 @@ export type CreateWorktreeArgs = {
   automationProvenanceRequest?: AutomationWorkspaceProvenanceRequest
 }
 
+export type WorktreeIncludeCopySkipReason =
+  | 'malformed'
+  | 'tracked'
+  | 'not-ignored'
+  | 'missing'
+  | 'not-a-file'
+  | 'destination-exists'
+  | 'copy-failed'
+  | 'check-failed'
+
+/** Outcome of the harness-level `.worktreeinclude` copy that materializes
+ *  gitignored local setup files from the primary checkout into a freshly
+ *  created worktree, before any setup script or agent starts. */
+export type WorktreeIncludeCopyResult = {
+  copied: string[]
+  skipped: { path: string; reason: WorktreeIncludeCopySkipReason }[]
+}
+
 export type CreateWorktreeResult = {
   worktree: Worktree & {
     parentWorktreeId?: string | null
@@ -2126,6 +2144,7 @@ export type CreateWorktreeResult = {
   initialBaseStatus?: WorktreeBaseStatusEvent
   localBaseRefRefresh?: LocalBaseRefRefreshResult
   localBaseRefUpdateSuggestion?: LocalBaseRefUpdateSuggestion
+  includeCopy?: WorktreeIncludeCopyResult
   startupTerminal?: {
     spawned: boolean
     handle?: string


### PR DESCRIPTION
## Summary

Repos can now declare a `.worktreeinclude` file at their root — a list of exact, gitignored local setup files — and Orca copies those files into every new worktree at creation time, before any setup script or agent starts. This mirrors [Codex's `.worktreeinclude` contract](https://developers.openai.com/codex/app/worktrees#copy-ignored-local-files-into-managed-worktrees): the harness itself honors the manifest, so materializing local setup files no longer depends on a setup script being configured, run, or successful.

## Why

A setup script is the only existing mechanism for getting gitignored local files (`.env.local`, `.claude/settings.local.json`, `.entire/settings.local.json`, …) into a new worktree, and it has structural gaps: a repo may have no setup script at all, setup can be skipped per-creation or fail partway, and with `setupAgentStartupPolicy: "start-immediately"` an agent can start *before* the script has copied anything.

This bit us for real: a worktree was created before its project had a setup script configured, so `.entire/settings.local.json` (which disables Entire) was never copied. Entire ran enabled in the worktree and its hooks wedged `git commit` for 10+ minutes. A declarative, harness-owned copy closes every one of those gaps.

## The contract

A repo-root `.worktreeinclude` lists exact relative paths, one per line (`#` starts a comment):

```
# local setup files
.claude/settings.local.json
.entire/settings.local.json
apps/nugget/.env.local
```

At creation time, after `git worktree add` and ahead of setup preparation, each listed file is copied from the project's main checkout into the new worktree under these rules:

| Rule | Behavior |
|------|----------|
| Only gitignored files | Tracked, missing, and untracked-but-not-ignored entries are skipped and recorded |
| Exact paths only | Globs, `..` traversal, absolute paths, and `:`-prefixed git pathspec magic are rejected as malformed (warned, never fatal) |
| No symlink following | A symlinked source, or a source/destination path crossing a symlinked directory, is refused — a repo-committed `foo -> ~/.ssh` can't exfiltrate host files into the worktree an agent then runs in |
| Never overwrite | An existing destination file is left untouched |
| Never abort creation | Absent/empty manifest is a no-op; any copy failure degrades to a log line |

The outcome (`{ copied, skipped: [{ path, reason }] }`) is logged with a `[worktree-include]` prefix and returned on `CreateWorktreeResult.includeCopy` (and the CLI/RPC `RuntimeWorktreeCreateResult`) so callers can see what happened.

## Design decisions

- **Harness-level, ahead of setup.** The copy runs in all three creation flows — desktop local, CLI/runtime local, and remote SSH — strictly after `git worktree add` and before both setup preparation and any agent-terminal spawn. It is independent of whether a setup script exists, is skipped, or fails.
- **Remote copies stay host-side.** For SSH hosts the source checkout and new worktree live on the same remote machine, so the copy runs entirely through the relay's no-clobber `fs.copy` and allowlisted `git ls-files` / `check-ignore`. Listed files — which can hold secrets — never transit to the local machine.
- **Fail-closed on ambiguity.** If the tracked/ignored check can't be trusted (git errors), nothing is copied rather than risk copying repo content that isn't actually a local secret.

## Validation

- `pnpm typecheck:node` clean; `oxlint` clean.
- New unit suite `worktree-include-copy.test.ts` (22 tests, real git repos in temp dirs): parsing/malformed/pathspec-magic, gitignored-only copying with mode preservation, tracked/missing/not-ignored skips, no-overwrite, directory and symlink rejection (source leaf + symlinked parent, both local and remote), and fail-closed behavior.
- Ordering tests across all three creation flows assert the copy runs after `git worktree add` and before setup prep / agent startup, and that `includeCopy` is surfaced. Full affected suites pass (696 tests across the worktree IPC, runtime, and module suites).

This change is backend/harness plumbing with no UI surface; the behavior is exercised by the test suites above rather than a visual demo.

## Follow-up

Remote destination-parent symlink containment (walking parents host-side via a relay realpath op) is left as a follow-up — it needs relay integration coverage this PR can't exercise. The local path guards both source and destination; the remote path currently guards the source leaf via `lstat`. Documented in `docs/reference/worktree-include-copy.md`.

Reference: https://developers.openai.com/codex/app/worktrees#copy-ignored-local-files-into-managed-worktrees

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

## ELI5

A project can list gitignored setup files in `.worktreeinclude` and Orca copies them into new worktrees. Local env files no longer depend only on a setup script to appear.
