### PR TITLE
fix(watcher): isolate @parcel/watcher in a forked process so native crashes can't kill the app (#7547)

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -106,6 +106,7 @@ module.exports = {
     'out/main/win32-utils.js',
     'out/main/daemon-entry.js',
     'out/main/computer-sidecar.js',
+    'out/main/parcel-watcher-process-entry.js',
     'out/main/chunks/**',
     'resources/**',
     'node_modules/ws/**',

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -69,6 +69,14 @@ describe('electron-builder config', () => {
     )
   })
 
+  // Why: without the unpacked entry the watcher client silently falls back to
+  // in-process @parcel/watcher, reintroducing the #7547 main-process crash.
+  it('unpacks the forked parcel-watcher process entry', () => {
+    expect(electronBuilderConfig.asarUnpack).toEqual(
+      expect.arrayContaining(['out/main/parcel-watcher-process-entry.js'])
+    )
+  })
+
   it('uses the multi-size icon source for Linux packages', () => {
     expect(electronBuilderConfig.linux.icon).toBe('resources/build/icon.icns')
   })

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -182,6 +182,9 @@ export default defineConfig({
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),
           'warp-theme-parser-worker': resolve('src/main/warp-themes/warp-theme-parser-worker.ts'),
           'file-watcher-worker': resolve('src/main/runtime/file-watcher-worker.ts'),
+          // Why: forked with ELECTRON_RUN_AS_NODE so @parcel/watcher faults
+          // can't take down the main process (issue #7547).
+          'parcel-watcher-process-entry': resolve('src/main/ipc/parcel-watcher-process-entry.ts'),
           // Why: electron-vite cleans out/main in dev. The dev CLI imports
           // this path for `orca agent hooks ...`, so it must survive rebuilds.
           'agent-hooks/managed-agent-hook-controls': resolve(

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -13,6 +13,7 @@ import { createWslWatcher } from './filesystem-watcher-wsl'
 import type { WatchedRoot } from './filesystem-watcher-wsl'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { MAX_BATCHED_WATCHER_EVENTS, queueWatcherEvents } from './filesystem-watcher-event-batch'
+import { disposeWatcherProcess, subscribeViaWatcherProcess } from './parcel-watcher-process'
 // Why: high-churn directories are suppressed at the native watcher level so
 // events never leave the OS/daemon. This list is separate from the File
 // Explorer display filter (which only hides rows). Directories like `dist`
@@ -278,10 +279,6 @@ function scheduleBatchFlush(rootKey: string, root: WatchedRoot): void {
 // ── Watcher creation ─────────────────────────────────────────────────
 
 async function createWatcher(rootKey: string, rootPath: string): Promise<WatchedRoot> {
-  // Why: @parcel/watcher is a native module that may not load in all
-  // environments. Dynamic import keeps the require() lazy.
-  const watcher = await import('@parcel/watcher')
-
   const root: WatchedRoot = {
     subscription: null!,
     listeners: new Map(),
@@ -303,7 +300,11 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
       ...(process.platform === 'win32' ? { backend: 'windows' as const } : {})
     }
 
-    root.subscription = await watcher.subscribe(
+    // Why: subscriptions run in a forked watcher process (issue #7547 —
+    // watcher.node teardown races fail-fast the hosting process). A watcher
+    // crash there is recovered by resubscribing; onInterruption marks the
+    // batch overflowed so the renderer refreshes past the event gap.
+    root.subscription = await subscribeViaWatcherProcess(
       rootPath,
       (err, events) => {
         if (err) {
@@ -334,7 +335,13 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
         queueWatcherEvents(root.batch, events)
         scheduleBatchFlush(rootKey, root)
       },
-      watcherOptions
+      watcherOptions,
+      () => {
+        // The watcher process crashed and this root was resubscribed; events
+        // during the gap are lost, so hand the renderer an overflow refresh.
+        root.batch.overflowed = true
+        scheduleBatchFlush(rootKey, root)
+      }
     )
 
     // Why: if the error callback already fired and cleaned up watchedRoots
@@ -929,6 +936,10 @@ export async function closeAllWatchers(): Promise<void> {
   }
   watchedRoots.clear()
   await Promise.allSettled(Array.from(pendingLocalUnsubscribes))
+  // Why: with every local subscription released, drop the forked watcher
+  // process outright — process death frees any remaining native handles
+  // without running watcher.node's crash-prone async teardown in this process.
+  disposeWatcherProcess()
 
   // Why: remote watchers are tracked separately from local @parcel/watcher
   // subscriptions. Without cleaning them up here, their unwatch callbacks

--- a/src/main/ipc/parcel-watcher-process-entry.ts
+++ b/src/main/ipc/parcel-watcher-process-entry.ts
@@ -1,0 +1,194 @@
+// Forked (ELECTRON_RUN_AS_NODE) child that hosts all local @parcel/watcher
+// subscriptions. Why: watcher.node has native teardown races that fail-fast
+// the hosting process (issue #7547, 0xc0000409 on Windows; same class as
+// #5377/#6635). Running the native module here turns a watcher fault into a
+// contained child crash the host can recover from, instead of killing the app
+// and every agent session in it.
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as ParcelWatcher from '@parcel/watcher'
+
+export type WatcherProcessEvent = {
+  type: 'create' | 'update' | 'delete'
+  path: string
+}
+
+export type WatcherProcessSubscribeOptions = {
+  ignore?: string[]
+  backend?: string
+}
+
+export type HostToWatcherMessage =
+  | { op: 'subscribe'; id: number; dir: string; opts: WatcherProcessSubscribeOptions }
+  | { op: 'unsubscribe'; id: number }
+
+export type WatcherToHostMessage =
+  | { op: 'subscribed'; id: number }
+  | { op: 'subscribe-failed'; id: number; message: string }
+  | { op: 'events'; id: number; events: WatcherProcessEvent[] }
+  | { op: 'watch-error'; id: number; message: string }
+  | { op: 'unsubscribed'; id: number }
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+// Canary self-check. Why: @parcel/watcher can wedge silently — a lock-order
+// inversion between Debounce::notify (debounce mutex → watcher mutex) and
+// Watcher teardown (watcher mutex → debounce mutex in ~Watcher) deadlocks the
+// single process-wide debounce thread, after which every subscription still
+// acks but no events are ever delivered. The canary watches a private temp
+// dir and touches a file in it; consecutive missed deliveries mean event
+// delivery is dead, so exit and let the host respawn a fresh process.
+const CANARY_INTERVAL_MS = 10_000
+const CANARY_EVENT_TIMEOUT_MS = 5_000
+const CANARY_MAX_MISSES = 2
+
+async function startCanary(hasLiveSubscriptions: () => boolean): Promise<void> {
+  let canaryDir: string
+  let lastEventAt = 0
+  try {
+    canaryDir = mkdtempSync(join(tmpdir(), 'orca-watcher-canary-'))
+    const watcher = await import('@parcel/watcher')
+    // Why: pin the Windows backend like the main subscriptions do, so the
+    // canary never probes for Watchman.
+    const opts = (
+      process.platform === 'win32' ? { backend: 'windows' } : {}
+    ) as ParcelWatcher.Options
+    await watcher.subscribe(
+      canaryDir,
+      (err) => {
+        if (!err) {
+          lastEventAt = Date.now()
+        }
+      },
+      opts
+    )
+  } catch (err) {
+    process.stderr.write(`[parcel-watcher-process] canary unavailable: ${errorMessage(err)}\n`)
+    return
+  }
+  process.on('exit', () => {
+    try {
+      rmSync(canaryDir, { recursive: true, force: true })
+    } catch {
+      // Temp dir cleanup is best-effort.
+    }
+  })
+
+  let misses = 0
+  setInterval(() => {
+    // An idle watcher process can't wedge anything visible; only probe while
+    // roots are subscribed so an idle child doesn't restart pointlessly.
+    if (!hasLiveSubscriptions()) {
+      misses = 0
+      return
+    }
+    const probedAt = Date.now()
+    try {
+      writeFileSync(join(canaryDir, 'canary.txt'), String(probedAt))
+    } catch {
+      return
+    }
+    setTimeout(() => {
+      if (lastEventAt >= probedAt) {
+        misses = 0
+        return
+      }
+      misses++
+      if (misses >= CANARY_MAX_MISSES) {
+        process.stderr.write(
+          '[parcel-watcher-process] event delivery wedged (canary starved); restarting watcher process\n'
+        )
+        process.exit(2)
+      }
+    }, CANARY_EVENT_TIMEOUT_MS)
+  }, CANARY_INTERVAL_MS)
+}
+
+function main(): void {
+  const send = (message: WatcherToHostMessage): void => {
+    try {
+      process.send?.(message)
+    } catch {
+      // Host is gone; the disconnect handler below exits this process.
+    }
+  }
+
+  // Subscribe promises are kept (not just subscriptions) so an unsubscribe
+  // that races a still-crawling subscribe awaits it instead of leaking the
+  // native handle — on Windows a leaked handle keeps the worktree dir locked.
+  const subscriptions = new Map<number, Promise<ParcelWatcher.AsyncSubscription | null>>()
+
+  const handleSubscribe = async (
+    id: number,
+    dir: string,
+    opts: WatcherProcessSubscribeOptions
+  ): Promise<ParcelWatcher.AsyncSubscription | null> => {
+    try {
+      const watcher = await import('@parcel/watcher')
+      const subscription = await watcher.subscribe(
+        dir,
+        (err, events) => {
+          if (err) {
+            send({ op: 'watch-error', id, message: errorMessage(err) })
+            return
+          }
+          if (events.length > 0) {
+            send({
+              op: 'events',
+              id,
+              events: events.map((event) => ({ type: event.type, path: event.path }))
+            })
+          }
+        },
+        opts as ParcelWatcher.Options
+      )
+      send({ op: 'subscribed', id })
+      return subscription
+    } catch (err) {
+      subscriptions.delete(id)
+      send({ op: 'subscribe-failed', id, message: errorMessage(err) })
+      return null
+    }
+  }
+
+  const handleUnsubscribe = async (id: number): Promise<void> => {
+    const pending = subscriptions.get(id)
+    subscriptions.delete(id)
+    try {
+      const subscription = await pending
+      await subscription?.unsubscribe()
+    } catch (err) {
+      process.stderr.write(
+        `[parcel-watcher-process] unsubscribe ${id} failed: ${errorMessage(err)}\n`
+      )
+    }
+    send({ op: 'unsubscribed', id })
+  }
+
+  process.on('message', (message: HostToWatcherMessage) => {
+    if (!message || typeof message !== 'object') {
+      return
+    }
+    if (message.op === 'subscribe') {
+      subscriptions.set(message.id, handleSubscribe(message.id, message.dir, message.opts))
+      return
+    }
+    if (message.op === 'unsubscribe') {
+      void handleUnsubscribe(message.id)
+    }
+  })
+
+  void startCanary(() => subscriptions.size > 0)
+
+  // Why: if the host dies (or kills us during shutdown), exit immediately —
+  // process death releases every native watcher handle without running the
+  // crash-prone napi teardown at all.
+  process.on('disconnect', () => {
+    process.exit(0)
+  })
+}
+
+main()

--- a/src/main/ipc/parcel-watcher-process.test.ts
+++ b/src/main/ipc/parcel-watcher-process.test.ts
@@ -1,0 +1,204 @@
+// Regression tests for issue #7547: local @parcel/watcher subscriptions run
+// in a forked watcher process, and a native watcher crash must be contained —
+// respawn, resubscribe, notify interruption — instead of killing the app.
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { forkMock, existsSyncMock, parcelSubscribeMock } = vi.hoisted(() => ({
+  forkMock: vi.fn(),
+  existsSyncMock: vi.fn(),
+  parcelSubscribeMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ fork: forkMock }))
+vi.mock('node:fs', () => ({ existsSync: existsSyncMock }))
+vi.mock('@parcel/watcher', () => ({ subscribe: parcelSubscribeMock }))
+
+import {
+  disposeWatcherProcess,
+  resetWatcherProcessForTest,
+  subscribeViaWatcherProcess
+} from './parcel-watcher-process'
+
+type SentMessage = { op: string; id: number; dir?: string }
+
+class FakeChild extends EventEmitter {
+  connected = true
+  sent: SentMessage[] = []
+  stderr = new EventEmitter()
+  kill = vi.fn(() => {
+    this.connected = false
+  })
+  send = vi.fn((message: SentMessage) => {
+    this.sent.push(message)
+    return true
+  })
+}
+
+function currentChild(): FakeChild {
+  const result = forkMock.mock.results.at(-1)
+  if (!result) {
+    throw new Error('fork was not called')
+  }
+  return result.value as FakeChild
+}
+
+function ackSubscribe(child: FakeChild, index = -1): number {
+  const message = child.sent.filter((m) => m.op === 'subscribe').at(index)
+  if (!message) {
+    throw new Error('no subscribe message sent')
+  }
+  child.emit('message', { op: 'subscribed', id: message.id })
+  return message.id
+}
+
+describe('subscribeViaWatcherProcess', () => {
+  beforeEach(() => {
+    resetWatcherProcessForTest()
+    // Why: the client deliberately runs in-process under vitest; these tests
+    // exercise the forked-process mode, so hide the vitest marker.
+    vi.stubEnv('VITEST', '')
+    existsSyncMock.mockReturnValue(true)
+    forkMock.mockImplementation(() => new FakeChild())
+  })
+
+  afterEach(() => {
+    disposeWatcherProcess()
+    vi.unstubAllEnvs()
+    vi.clearAllMocks()
+  })
+
+  it('subscribes through the watcher process and forwards events', async () => {
+    const callback = vi.fn()
+    const promise = subscribeViaWatcherProcess('/repo', callback, { ignore: ['**/.git'] })
+    const child = currentChild()
+    expect(child.sent[0]).toMatchObject({ op: 'subscribe', dir: '/repo' })
+    const id = ackSubscribe(child)
+    await promise
+
+    const events = [{ type: 'update', path: '/repo/a.txt' }]
+    child.emit('message', { op: 'events', id, events })
+    expect(callback).toHaveBeenCalledWith(null, events)
+  })
+
+  it('forwards watcher errors to the callback', async () => {
+    const callback = vi.fn()
+    const promise = subscribeViaWatcherProcess('/repo', callback, {})
+    const child = currentChild()
+    const id = ackSubscribe(child)
+    await promise
+
+    child.emit('message', { op: 'watch-error', id, message: 'boom' })
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ message: 'boom' }), [])
+  })
+
+  it('rejects the subscribe when the watcher process reports failure', async () => {
+    const promise = subscribeViaWatcherProcess('/gone', vi.fn(), {})
+    const child = currentChild()
+    const id = child.sent[0].id
+    child.emit('message', { op: 'subscribe-failed', id, message: 'Error opening directory' })
+    await expect(promise).rejects.toThrow('Error opening directory')
+  })
+
+  it('resolves unsubscribe on the child ack', async () => {
+    const promise = subscribeViaWatcherProcess('/repo', vi.fn(), {})
+    const child = currentChild()
+    const id = ackSubscribe(child)
+    const subscription = await promise
+
+    const unsubPromise = subscription.unsubscribe()
+    expect(child.sent.at(-1)).toEqual({ op: 'unsubscribe', id })
+    child.emit('message', { op: 'unsubscribed', id })
+    await expect(unsubPromise).resolves.toBeUndefined()
+  })
+
+  it('resolves a pending unsubscribe when the child dies', async () => {
+    const promise = subscribeViaWatcherProcess('/repo', vi.fn(), {})
+    const child = currentChild()
+    ackSubscribe(child)
+    const subscription = await promise
+
+    const unsubPromise = subscription.unsubscribe()
+    child.connected = false
+    child.emit('exit', 3221226505, null)
+    await expect(unsubPromise).resolves.toBeUndefined()
+  })
+
+  it('respawns after a crash, resubscribes, and reports the interruption', async () => {
+    const callback = vi.fn()
+    const onInterruption = vi.fn()
+    const promise = subscribeViaWatcherProcess('/repo', callback, {}, onInterruption)
+    const first = currentChild()
+    const id = ackSubscribe(first)
+    await promise
+
+    // Simulate the 0xc0000409 fail-fast: the watcher process dies.
+    first.connected = false
+    first.emit('exit', 3221226505, null)
+
+    const second = currentChild()
+    expect(second).not.toBe(first)
+    expect(second.sent[0]).toMatchObject({ op: 'subscribe', id, dir: '/repo' })
+    expect(onInterruption).not.toHaveBeenCalled()
+
+    second.emit('message', { op: 'subscribed', id })
+    expect(onInterruption).toHaveBeenCalledTimes(1)
+
+    const events = [{ type: 'create', path: '/repo/b.txt' }]
+    second.emit('message', { op: 'events', id, events })
+    expect(callback).toHaveBeenCalledWith(null, events)
+  })
+
+  it('completes an in-flight subscribe across a crash-respawn', async () => {
+    const promise = subscribeViaWatcherProcess('/repo', vi.fn(), {})
+    const first = currentChild()
+    expect(first.sent[0].op).toBe('subscribe')
+
+    first.connected = false
+    first.emit('exit', 3221226505, null)
+
+    const second = currentChild()
+    ackSubscribe(second)
+    await expect(promise).resolves.toMatchObject({ unsubscribe: expect.any(Function) })
+  })
+
+  it('disables watching after repeated crashes instead of fork-bombing', async () => {
+    const callback = vi.fn()
+    const promise = subscribeViaWatcherProcess('/repo', callback, {})
+    ackSubscribe(currentChild())
+    await promise
+
+    for (let crash = 0; crash < 2; crash++) {
+      const child = currentChild()
+      child.connected = false
+      child.emit('exit', 3221226505, null)
+      ackSubscribe(currentChild())
+    }
+    expect(forkMock).toHaveBeenCalledTimes(3)
+
+    const last = currentChild()
+    last.connected = false
+    last.emit('exit', 3221226505, null)
+
+    expect(forkMock).toHaveBeenCalledTimes(3)
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('crashed repeatedly') }),
+      []
+    )
+  })
+
+  it('uses the in-process watcher under vitest', async () => {
+    vi.stubEnv('VITEST', 'true')
+    const unsubscribe = vi.fn().mockResolvedValue(undefined)
+    parcelSubscribeMock.mockResolvedValue({ unsubscribe })
+    const callback = vi.fn()
+
+    const subscription = await subscribeViaWatcherProcess('/repo', callback, {
+      ignore: ['**/.git']
+    })
+    expect(forkMock).not.toHaveBeenCalled()
+    expect(parcelSubscribeMock).toHaveBeenCalledWith('/repo', callback, { ignore: ['**/.git'] })
+    await subscription.unsubscribe()
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/parcel-watcher-process.ts
+++ b/src/main/ipc/parcel-watcher-process.ts
@@ -1,0 +1,320 @@
+// Host side of the out-of-process @parcel/watcher (see
+// parcel-watcher-process-entry.ts). Why: native watcher teardown races
+// fail-fast the hosting process (issue #7547), so local subscriptions live in
+// a disposable forked child; when it crashes the host respawns it and
+// resubscribes every live root, and callers are told via onInterruption so
+// they can refresh state that changed during the gap.
+import { fork, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type * as ParcelWatcher from '@parcel/watcher'
+import type {
+  HostToWatcherMessage,
+  WatcherProcessEvent,
+  WatcherProcessSubscribeOptions,
+  WatcherToHostMessage
+} from './parcel-watcher-process-entry'
+
+export type { WatcherProcessEvent, WatcherProcessSubscribeOptions }
+
+export type WatcherProcessCallback = (err: Error | null, events: WatcherProcessEvent[]) => void
+export type WatcherProcessSubscription = { unsubscribe(): Promise<void> }
+
+// Why: a crash loop (e.g. a root that faults the native watcher on every
+// resubscribe) must degrade to "file watching disabled" rather than fork-bomb.
+const CRASH_WINDOW_MS = 30_000
+const MAX_CRASHES_PER_WINDOW = 3
+
+type SubscriptionRecord = {
+  id: number
+  dir: string
+  opts: WatcherProcessSubscribeOptions
+  callback: WatcherProcessCallback
+  onInterruption?: () => void
+  pendingSubscribe?: { resolve: () => void; reject: (err: Error) => void }
+}
+
+let child: ChildProcess | null = null
+let nextSubscriptionId = 1
+let crashTimes: number[] = []
+let shutdownRequested = false
+let loggedInProcessFallback = false
+const records = new Map<number, SubscriptionRecord>()
+const pendingUnsubscribes = new Map<number, () => void>()
+
+function loadElectronApp(): { getAppPath(): string; isPackaged: boolean } | null {
+  try {
+    return require('electron').app ?? null
+  } catch {
+    return null
+  }
+}
+
+function getWatcherProcessEntryPath(): string {
+  const app = loadElectronApp()
+  const appPath = app?.getAppPath() ?? process.cwd()
+  // Why: ELECTRON_RUN_AS_NODE bypasses Electron's asar integration, so the
+  // packaged entry must be forked from app.asar.unpacked.
+  const basePath = app?.isPackaged ? appPath.replace('app.asar', 'app.asar.unpacked') : appPath
+  return join(basePath, 'out', 'main', 'parcel-watcher-process-entry.js')
+}
+
+function shouldRunInProcess(entryPath: string): boolean {
+  // Why: vitest suites mock '@parcel/watcher' at the module level; a forked
+  // child would bypass those mocks (and could execute a stale build output),
+  // so tests keep the historical in-process path.
+  if (process.env.VITEST) {
+    return true
+  }
+  if (existsSync(entryPath)) {
+    return false
+  }
+  if (!loggedInProcessFallback) {
+    loggedInProcessFallback = true
+    console.warn(
+      `[parcel-watcher-process] entry not found at ${entryPath}; using in-process watcher (no crash isolation)`
+    )
+  }
+  return true
+}
+
+async function subscribeInProcess(
+  dir: string,
+  callback: WatcherProcessCallback,
+  opts: WatcherProcessSubscribeOptions
+): Promise<WatcherProcessSubscription> {
+  const watcher = await import('@parcel/watcher')
+  const subscription = await watcher.subscribe(
+    dir,
+    callback as ParcelWatcher.SubscribeCallback,
+    opts as ParcelWatcher.Options
+  )
+  return { unsubscribe: () => subscription.unsubscribe() }
+}
+
+function inCrashCooldown(): boolean {
+  const now = Date.now()
+  crashTimes = crashTimes.filter((time) => now - time < CRASH_WINDOW_MS)
+  return crashTimes.length >= MAX_CRASHES_PER_WINDOW
+}
+
+function sendToChild(proc: ChildProcess, message: HostToWatcherMessage): void {
+  try {
+    proc.send(message)
+  } catch {
+    // Channel already closed — the child's exit handler recovers.
+  }
+}
+
+function ensureWatcherProcess(): ChildProcess | null {
+  if (shutdownRequested) {
+    return null
+  }
+  if (child?.connected) {
+    return child
+  }
+  if (inCrashCooldown()) {
+    return null
+  }
+  let proc: ChildProcess
+  try {
+    proc = fork(getWatcherProcessEntryPath(), [], {
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+      ...(process.platform === 'win32' ? { windowsHide: true } : {})
+    })
+  } catch (err) {
+    console.error('[parcel-watcher-process] failed to fork watcher process:', err)
+    return null
+  }
+  proc.stderr?.on('data', (chunk: Buffer) => {
+    console.error('[parcel-watcher-process]', String(chunk).trimEnd())
+  })
+  proc.on('message', (message) => {
+    if (child === proc) {
+      handleChildMessage(message as WatcherToHostMessage)
+    }
+  })
+  proc.on('error', () => handleChildGone(proc))
+  proc.on('exit', (code, signal) => {
+    if (child === proc && (code !== 0 || signal)) {
+      console.error(
+        `[parcel-watcher-process] watcher process exited (code=${code}, signal=${signal})`
+      )
+    }
+    handleChildGone(proc)
+  })
+  child = proc
+  return proc
+}
+
+function handleChildMessage(message: WatcherToHostMessage): void {
+  if (!message || typeof message !== 'object') {
+    return
+  }
+  if (message.op === 'unsubscribed') {
+    const resolve = pendingUnsubscribes.get(message.id)
+    pendingUnsubscribes.delete(message.id)
+    resolve?.()
+    return
+  }
+  const record = records.get(message.id)
+  if (!record) {
+    return
+  }
+  if (message.op === 'subscribed') {
+    const pending = record.pendingSubscribe
+    record.pendingSubscribe = undefined
+    if (pending) {
+      pending.resolve()
+    } else {
+      // Reached after a crash-respawn resubscribe: events emitted while the
+      // watcher process was down are lost, so let the caller refresh.
+      record.onInterruption?.()
+    }
+    return
+  }
+  if (message.op === 'subscribe-failed') {
+    records.delete(message.id)
+    const pending = record.pendingSubscribe
+    record.pendingSubscribe = undefined
+    if (pending) {
+      pending.reject(new Error(message.message))
+    } else {
+      record.callback(new Error(message.message), [])
+    }
+    return
+  }
+  if (message.op === 'events') {
+    record.callback(null, message.events)
+    return
+  }
+  if (message.op === 'watch-error') {
+    record.callback(new Error(message.message), [])
+  }
+}
+
+function failAllSubscriptions(err: Error): void {
+  for (const record of records.values()) {
+    const pending = record.pendingSubscribe
+    record.pendingSubscribe = undefined
+    if (pending) {
+      pending.reject(err)
+    } else {
+      record.callback(err, [])
+    }
+  }
+  records.clear()
+}
+
+function handleChildGone(proc: ChildProcess): void {
+  if (child !== proc) {
+    return
+  }
+  child = null
+  // Why: process death released every native handle, so a pending unsubscribe
+  // is complete by definition — resolve rather than hang worktree deletion.
+  for (const resolve of pendingUnsubscribes.values()) {
+    resolve()
+  }
+  pendingUnsubscribes.clear()
+  if (shutdownRequested || records.size === 0) {
+    return
+  }
+  crashTimes.push(Date.now())
+  const replacement = ensureWatcherProcess()
+  if (!replacement) {
+    console.error(
+      '[parcel-watcher-process] watcher process crashed repeatedly; disabling file watching'
+    )
+    failAllSubscriptions(new Error('file watcher process crashed repeatedly'))
+    return
+  }
+  console.error(
+    `[parcel-watcher-process] watcher process crashed; resubscribing ${records.size} root(s)`
+  )
+  for (const record of records.values()) {
+    sendToChild(replacement, {
+      op: 'subscribe',
+      id: record.id,
+      dir: record.dir,
+      opts: record.opts
+    })
+  }
+}
+
+function makeSubscription(record: SubscriptionRecord): WatcherProcessSubscription {
+  return {
+    unsubscribe: (): Promise<void> => {
+      if (!records.delete(record.id)) {
+        return Promise.resolve()
+      }
+      const proc = child
+      if (!proc?.connected) {
+        return Promise.resolve()
+      }
+      return new Promise((resolve) => {
+        pendingUnsubscribes.set(record.id, resolve)
+        sendToChild(proc, { op: 'unsubscribe', id: record.id })
+      })
+    }
+  }
+}
+
+/** Subscribe to a directory tree via the isolated watcher process. Falls back
+ *  to an in-process @parcel/watcher subscription when the forked entry is not
+ *  available (tests, unbuilt trees). `onInterruption` fires after the watcher
+ *  process crashed and this subscription was transparently re-established —
+ *  events in the gap were lost, so callers should refresh. */
+export function subscribeViaWatcherProcess(
+  dir: string,
+  callback: WatcherProcessCallback,
+  opts: WatcherProcessSubscribeOptions,
+  onInterruption?: () => void
+): Promise<WatcherProcessSubscription> {
+  if (shouldRunInProcess(getWatcherProcessEntryPath())) {
+    return subscribeInProcess(dir, callback, opts)
+  }
+  const record: SubscriptionRecord = {
+    id: nextSubscriptionId++,
+    dir,
+    opts,
+    callback,
+    onInterruption
+  }
+  return new Promise((resolve, reject) => {
+    const proc = ensureWatcherProcess()
+    if (!proc) {
+      reject(new Error('file watcher process unavailable'))
+      return
+    }
+    records.set(record.id, record)
+    record.pendingSubscribe = {
+      resolve: () => resolve(makeSubscription(record)),
+      reject
+    }
+    sendToChild(proc, { op: 'subscribe', id: record.id, dir, opts })
+  })
+}
+
+/** Kill the watcher process at app shutdown. Process death releases native
+ *  handles without running watcher.node's crash-prone async teardown. */
+export function disposeWatcherProcess(): void {
+  shutdownRequested = true
+  const proc = child
+  child = null
+  for (const resolve of pendingUnsubscribes.values()) {
+    resolve()
+  }
+  pendingUnsubscribes.clear()
+  records.clear()
+  proc?.kill()
+}
+
+export function resetWatcherProcessForTest(): void {
+  disposeWatcherProcess()
+  shutdownRequested = false
+  crashTimes = []
+  loggedInProcessFallback = false
+  nextSubscriptionId = 1
+}

--- a/tools/repro-watcher-crash-7547/.gitignore
+++ b/tools/repro-watcher-crash-7547/.gitignore
@@ -1,0 +1,1 @@
+parcel-watcher-process.bundle.cjs

--- a/tools/repro-watcher-crash-7547/README.md
+++ b/tools/repro-watcher-crash-7547/README.md
@@ -1,0 +1,50 @@
+# Repro harness: watcher.node main-process crash (issue #7547)
+
+Manual, Windows-focused harness for the `@parcel/watcher` native crash class
+(`0xc0000409` fail-fast / `0xc0000005` AV in `watcher.node`; same family as
+macOS #5377 and Linux #6635). Not run in CI — it deliberately crashes
+processes and hammers the filesystem.
+
+All watched/churned directories live under `os.tmpdir()`, never the repo.
+
+## Reproduce the bug (in-process watcher, pre-fix architecture)
+
+```
+node tools/repro-watcher-crash-7547/run.cjs delete-root 3 15000
+```
+
+Spawns `child.cjs`, which uses `@parcel/watcher` **in-process** the way
+`filesystem-watcher.ts` did before the fix. Scenarios (arg 1):
+
+- `delete-root` — subscribe to worktree-like dirs, churn files, delete the
+  watched root mid-churn, unsubscribe (worktree deletion during agent writes).
+  Crashes in seconds on Windows.
+- `unsub-churn` — rapid subscribe/unsubscribe cycles against live churn.
+  Also crashes: the trigger is `unsubscribe()` racing active event delivery
+  (`CancelIo` from the wrong thread leaves a pending `ReadDirectoryChangesW`
+  completion pointing at a freed `Subscription`).
+- `worker-mix` — worker_threads sharing the process-global native `Watcher`.
+- `del-nounsub` / `del-nochurn` / `del-1lane` — minimisation variants
+  (deletion without unsubscribe does NOT crash; unsubscribe is the trigger).
+- `overflow`, `mixed`.
+
+A native crash surfaces as the child's exit code (`0xC0000409` = 3221226505,
+`0xC0000005` = 3221225477) and the runner stops.
+
+## Verify the fix (out-of-process watcher)
+
+Build first so the forked entry exists, then run from the repo root:
+
+```
+npx electron-vite build
+node tools/repro-watcher-crash-7547/fixed-child.cjs 15000
+```
+
+`fixed-child.cjs` esbuild-bundles the real `src/main/ipc/parcel-watcher-process.ts`
+client and runs the same `delete-root` + `unsub-churn` load through the forked
+`out/main/parcel-watcher-process-entry.js`. Expected output: contained watcher
+process crashes (counted, recovered by respawn+resubscribe, surfaced through
+`onInterruption`), a final health check that sees live events, and exit 0.
+
+Exit codes: 0 pass · 5 watcher not functional at end · 6 in-process fallback
+used (isolation not exercised) · 7 watchdog · 8 premature exit.

--- a/tools/repro-watcher-crash-7547/child.cjs
+++ b/tools/repro-watcher-crash-7547/child.cjs
@@ -1,0 +1,470 @@
+// Throwaway repro harness for issue #7547 — Windows main-process crash in
+// @parcel/watcher (watcher.node, 0xc0000409 fail-fast).
+//
+// Runs ONE scenario in THIS process (the parent runner spawns us in a loop and
+// watches our exit code). Each scenario mimics a real Orca usage pattern:
+//
+//   delete-root  — subscribe to worktree-like dirs, churn files, delete the
+//                  watched root mid-churn (worktree deletion during agent
+//                  writes). Exercises the WindowsBackend error path
+//                  (handleWatcherError -> Watcher::notifyError on the backend
+//                  thread).
+//   unsub-churn  — rapid subscribe/unsubscribe cycles on dirs with live churn
+//                  (worktree switching + 30s-grace teardown compressed).
+//                  Exercises pending-ReadDirectoryChangesW teardown.
+//   worker-mix   — worker_threads subscribe to the SAME dirs as the main env
+//                  (desktop explorer watch + runtime file-watcher worker on one
+//                  worktree). Workers exit cleanly, exit without unsubscribing,
+//                  or are terminate()d — then new workers subscribe again so
+//                  std::thread::id values recycle against the process-global
+//                  shared native Watcher.
+//   overflow     — one watched dir, massive delete/rename bursts with long
+//                  file names to force ERROR_NOTIFY_ENUM_DIR ("Buffer
+//                  overflow") on the backend thread.
+//   mixed        — all of the above concurrently.
+//
+// Exit code 0 = survived the scenario. A native crash surfaces as the child's
+// exit code (0xC0000409 = 3221226505) in the parent.
+'use strict'
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { Worker, isMainThread, workerData } = require('node:worker_threads')
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+// The exact bundled native module (@parcel/watcher 2.5.6 + watcher-win32-x64).
+const watcherPath = path.join(REPO_ROOT, 'node_modules', '@parcel', 'watcher')
+
+// Mirrors buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS) on win32 —
+// identical ignore set => identical native Watcher key => cross-env sharing.
+const IGNORE_DIRS = [
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.cache',
+  'target',
+  '.venv',
+  '__pycache__'
+]
+const IGNORE = IGNORE_DIRS.flatMap((dir) => [`**/${dir}`, `**/${dir}/**`])
+const OPTS = { ignore: IGNORE, backend: 'windows' }
+
+const stats = {
+  eventBatches: 0,
+  events: 0,
+  errors: 0,
+  errorMessages: new Map(),
+  subscribes: 0,
+  unsubscribes: 0,
+  workersSpawned: 0,
+  workersTerminated: 0
+}
+
+function log(msg) {
+  process.stderr.write(`[child ${process.pid}] ${msg}\n`)
+}
+
+function recordError(err) {
+  stats.errors++
+  const msg = String((err && err.message) || err)
+  stats.errorMessages.set(msg, (stats.errorMessages.get(msg) || 0) + 1)
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const rand = (n) => Math.floor(Math.random() * n)
+
+function makeTree(dir, files, subdirs, nameLen) {
+  fs.mkdirSync(dir, { recursive: true })
+  const dirs = [dir]
+  for (let d = 0; d < subdirs; d++) {
+    const sub = path.join(dir, `sub-${d}`)
+    fs.mkdirSync(sub, { recursive: true })
+    dirs.push(sub)
+  }
+  let made = 0
+  for (const d of dirs) {
+    for (let f = 0; f < Math.ceil(files / dirs.length); f++) {
+      const pad = 'x'.repeat(Math.max(0, nameLen - 12))
+      fs.writeFileSync(path.join(d, `f${f}-${pad}.txt`), 'seed')
+      made++
+    }
+  }
+  return made
+}
+
+function rmrf(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 })
+  } catch {
+    // Watched dirs can be locked mid-delete on Windows; partial deletes still
+    // generate the event storm we want.
+  }
+}
+
+// ── Churn worker (same file, worker_threads entry) ───────────────────
+
+if (!isMainThread && workerData && workerData.role === 'churn') {
+  // Tight synchronous churn: create/write/rename/delete inside dir until told
+  // to stop (dir disappearing is fine — keep going, that's the scenario).
+  const { dir, durationMs } = workerData
+  const end = Date.now() + durationMs
+  let i = 0
+  while (Date.now() < end) {
+    const a = path.join(dir, `churn-${i % 200}.txt`)
+    const b = path.join(dir, `churn-${i % 200}.renamed.txt`)
+    try {
+      fs.writeFileSync(a, `payload-${i}`)
+      fs.renameSync(a, b)
+      fs.rmSync(b, { force: true })
+    } catch {
+      // Root may be mid-delete; recreate it occasionally to keep churn alive.
+      if (i % 500 === 0) {
+        try {
+          fs.mkdirSync(dir, { recursive: true })
+        } catch {}
+      }
+    }
+    i++
+  }
+  process.exit(0)
+}
+
+if (!isMainThread && workerData && workerData.role === 'subscriber') {
+  // Mimics file-watcher-worker.ts: subscribe in a worker env to the SAME dir
+  // the main env watches, then tear down per `mode`.
+  const { dir, mode, holdMs } = workerData
+  const watcher = require(watcherPath)
+  ;(async () => {
+    let sub
+    try {
+      sub = await watcher.subscribe(dir, () => {}, OPTS)
+    } catch {
+      process.exit(0)
+    }
+    await sleep(holdMs)
+    if (mode === 'clean') {
+      try {
+        await sub.unsubscribe()
+      } catch {}
+      process.exit(0)
+    }
+    if (mode === 'dirty-exit') {
+      // Exit the worker env WITHOUT unsubscribing — leaves the callback ref
+      // registered in the process-global shared native Watcher.
+      process.exit(0)
+    }
+    // mode === 'wait-terminate': linger; the main thread terminate()s us,
+    // possibly while the subscription (or its unsubscribe) is in flight.
+    await sleep(60_000)
+  })()
+}
+
+// ── Scenarios (main thread) ──────────────────────────────────────────
+
+async function scenarioDeleteRoot(watcher, baseDir, durationMs, lane) {
+  const end = Date.now() + durationMs
+  let round = 0
+  while (Date.now() < end) {
+    const dir = path.join(baseDir, `wt-${lane}-${round}`)
+    makeTree(dir, 120, 4, 20)
+    let sub = null
+    let errored = false
+    try {
+      stats.subscribes++
+      sub = await watcher.subscribe(
+        dir,
+        (err, events) => {
+          if (err) {
+            recordError(err)
+            errored = true
+            // Orca's createWatcher error path: unsubscribe from inside the
+            // error callback.
+            if (sub) {
+              stats.unsubscribes++
+              sub.unsubscribe().catch(() => {})
+            }
+            return
+          }
+          stats.eventBatches++
+          stats.events += events.length
+        },
+        OPTS
+      )
+    } catch (err) {
+      recordError(err)
+      rmrf(dir)
+      round++
+      continue
+    }
+    // Churn briefly, then delete the watched root while events are flowing.
+    const churn = new Worker(__filename, {
+      workerData: { role: 'churn', dir, durationMs: 300 }
+    })
+    await sleep(50 + rand(100))
+    rmrf(dir)
+    await sleep(rand(60))
+    if (!errored && sub) {
+      stats.unsubscribes++
+      await sub.unsubscribe().catch(() => {})
+    }
+    await new Promise((r) => churn.once('exit', r))
+    rmrf(dir)
+    round++
+  }
+}
+
+async function scenarioUnsubChurn(watcher, baseDir, durationMs, lane) {
+  const dir = path.join(baseDir, `unsub-${lane}`)
+  makeTree(dir, 150, 3, 20)
+  const churn = new Worker(__filename, {
+    workerData: { role: 'churn', dir, durationMs }
+  })
+  const end = Date.now() + durationMs
+  while (Date.now() < end) {
+    let sub
+    try {
+      stats.subscribes++
+      sub = await watcher.subscribe(
+        dir,
+        (err, events) => {
+          if (err) {
+            recordError(err)
+            return
+          }
+          stats.eventBatches++
+          stats.events += events.length
+        },
+        OPTS
+      )
+    } catch (err) {
+      recordError(err)
+      continue
+    }
+    await sleep(rand(50))
+    stats.unsubscribes++
+    // Half the time don't await — overlapping unsubscribe with the next
+    // subscribe on the same dir, like racing grace-teardown vs re-watch.
+    if (rand(2) === 0) {
+      await sub.unsubscribe().catch(() => {})
+    } else {
+      sub.unsubscribe().catch(() => {})
+    }
+  }
+  await new Promise((r) => churn.once('exit', r))
+  rmrf(dir)
+}
+
+async function scenarioWorkerMix(watcher, baseDir, durationMs, lane) {
+  const dir = path.join(baseDir, `wmix-${lane}`)
+  makeTree(dir, 100, 3, 20)
+  // Main env holds a long-lived subscription (desktop explorer watch).
+  let mainSub = null
+  try {
+    stats.subscribes++
+    mainSub = await watcher.subscribe(
+      dir,
+      (err, events) => {
+        if (err) {
+          recordError(err)
+          return
+        }
+        stats.eventBatches++
+        stats.events += events.length
+      },
+      OPTS
+    )
+  } catch (err) {
+    recordError(err)
+  }
+  const churn = new Worker(__filename, {
+    workerData: { role: 'churn', dir, durationMs }
+  })
+  const end = Date.now() + durationMs
+  while (Date.now() < end) {
+    const mode = ['clean', 'dirty-exit', 'wait-terminate'][rand(3)]
+    const worker = new Worker(__filename, {
+      workerData: { role: 'subscriber', dir, mode, holdMs: rand(150) }
+    })
+    stats.workersSpawned++
+    const exited = new Promise((r) => worker.once('exit', r))
+    worker.once('error', () => {})
+    if (mode === 'wait-terminate') {
+      await sleep(rand(100))
+      stats.workersTerminated++
+      await worker.terminate().catch(() => {})
+    }
+    await Promise.race([exited, sleep(1000)])
+  }
+  await new Promise((r) => churn.once('exit', r))
+  if (mainSub) {
+    stats.unsubscribes++
+    await mainSub.unsubscribe().catch(() => {})
+  }
+  rmrf(dir)
+}
+
+async function scenarioOverflow(watcher, baseDir, durationMs, lane) {
+  const end = Date.now() + durationMs
+  let round = 0
+  while (Date.now() < end) {
+    const dir = path.join(baseDir, `ovf-${lane}-${round}`)
+    // Long names fill the 1MB ReadDirectoryChangesW buffer faster.
+    makeTree(dir, 4000, 8, 180)
+    let sub = null
+    try {
+      stats.subscribes++
+      sub = await watcher.subscribe(
+        dir,
+        (err, events) => {
+          if (err) {
+            recordError(err)
+            if (sub) {
+              stats.unsubscribes++
+              sub.unsubscribe().catch(() => {})
+            }
+            return
+          }
+          stats.eventBatches++
+          stats.events += events.length
+        },
+        OPTS
+      )
+    } catch (err) {
+      recordError(err)
+      rmrf(dir)
+      round++
+      continue
+    }
+    // Parallel delete storm: multiple churn workers + recursive delete produce
+    // a dense event burst while the backend thread stats each event.
+    const churners = Array.from(
+      { length: 3 },
+      () => new Worker(__filename, { workerData: { role: 'churn', dir, durationMs: 500 } })
+    )
+    rmrf(dir)
+    await Promise.all(churners.map((w) => new Promise((r) => w.once('exit', r))))
+    if (sub) {
+      stats.unsubscribes++
+      await sub.unsubscribe().catch(() => {})
+    }
+    rmrf(dir)
+    round++
+  }
+}
+
+// Minimisation variants of delete-root, to isolate which ingredient crashes:
+//   del-nounsub  — subscribe, churn, delete root; NEVER call unsubscribe.
+//   del-nochurn  — subscribe, delete root; no churn worker at all.
+//   del-1lane    — the full delete-root pattern but a single sequential lane.
+async function scenarioDeleteMinimal(watcher, baseDir, durationMs, lane, { churn, unsub }) {
+  const end = Date.now() + durationMs
+  let round = 0
+  while (Date.now() < end) {
+    const dir = path.join(baseDir, `min-${lane}-${round}`)
+    makeTree(dir, 120, 4, 20)
+    let sub = null
+    try {
+      stats.subscribes++
+      sub = await watcher.subscribe(
+        dir,
+        (err, events) => {
+          if (err) {
+            recordError(err)
+            return
+          }
+          stats.eventBatches++
+          stats.events += events.length
+        },
+        OPTS
+      )
+    } catch (err) {
+      recordError(err)
+      rmrf(dir)
+      round++
+      continue
+    }
+    let churnWorker = null
+    if (churn) {
+      churnWorker = new Worker(__filename, {
+        workerData: { role: 'churn', dir, durationMs: 300 }
+      })
+      await sleep(50 + rand(100))
+    }
+    rmrf(dir)
+    await sleep(100)
+    if (unsub && sub) {
+      stats.unsubscribes++
+      await sub.unsubscribe().catch(() => {})
+    }
+    if (churnWorker) {
+      await new Promise((r) => churnWorker.once('exit', r))
+    }
+    rmrf(dir)
+    round++
+  }
+}
+
+const SCENARIOS = {
+  'delete-root': { fn: scenarioDeleteRoot, lanes: 6 },
+  'del-nounsub': {
+    fn: (w, b, d, l) => scenarioDeleteMinimal(w, b, d, l, { churn: true, unsub: false }),
+    lanes: 6
+  },
+  'del-nochurn': {
+    fn: (w, b, d, l) => scenarioDeleteMinimal(w, b, d, l, { churn: false, unsub: false }),
+    lanes: 6
+  },
+  'del-1lane': {
+    fn: (w, b, d, l) => scenarioDeleteMinimal(w, b, d, l, { churn: true, unsub: true }),
+    lanes: 1
+  },
+  'unsub-churn': { fn: scenarioUnsubChurn, lanes: 6 },
+  'worker-mix': { fn: scenarioWorkerMix, lanes: 4 },
+  overflow: { fn: scenarioOverflow, lanes: 2 }
+}
+
+async function main() {
+  const scenarioName = process.argv[2] || 'mixed'
+  const durationMs = Number(process.argv[3] || 15000)
+  // Outside the repo worktree: a live Orca instance may be watching the repo,
+  // and this churn must not feed the production watcher.
+  const baseDir = path.join(os.tmpdir(), 'orca-7547-harness', `run-${process.pid}`)
+  fs.mkdirSync(baseDir, { recursive: true })
+
+  const watcher = require(watcherPath)
+  const jobs = []
+  const names = scenarioName === 'mixed' ? Object.keys(SCENARIOS) : [scenarioName]
+  for (const name of names) {
+    const s = SCENARIOS[name]
+    if (!s) {
+      log(`unknown scenario: ${name}`)
+      process.exit(2)
+    }
+    const lanes = scenarioName === 'mixed' ? Math.max(1, Math.floor(s.lanes / 2)) : s.lanes
+    for (let lane = 0; lane < lanes; lane++) {
+      jobs.push(s.fn(watcher, baseDir, durationMs, lane))
+    }
+  }
+  await Promise.all(jobs)
+
+  const errs = Array.from(stats.errorMessages.entries())
+    .map(([m, n]) => `${n}x "${m}"`)
+    .join(', ')
+  log(
+    `done: subs=${stats.subscribes} unsubs=${stats.unsubscribes} batches=${stats.eventBatches} ` +
+      `events=${stats.events} errors=${stats.errors} workers=${stats.workersSpawned} ` +
+      `terminated=${stats.workersTerminated}${errs ? ` errMsgs: ${errs}` : ''}`
+  )
+  rmrf(baseDir)
+  process.exit(0)
+}
+
+if (isMainThread) {
+  main().catch((err) => {
+    log(`harness error: ${err && err.stack}`)
+    process.exit(3)
+  })
+}

--- a/tools/repro-watcher-crash-7547/fixed-child.cjs
+++ b/tools/repro-watcher-crash-7547/fixed-child.cjs
@@ -1,0 +1,334 @@
+// Fixed-architecture harness for issue #7547: runs the SAME scenarios that
+// crash the in-process watcher (see child.cjs), but through the real
+// parcel-watcher-process client (esbuild-bundled from src/main/ipc) which
+// forks the real out/main/parcel-watcher-process-entry.js.
+//
+// Success = this process exits 0 (the app-process stand-in survived), the
+// watcher stayed functional (final health check receives a live event), and
+// no in-process fallback was used. Contained watcher-child crashes are
+// EXPECTED and counted — they prove the native bug still fires but no longer
+// reaches the host.
+//
+// Must be run with cwd = repo root (entry path resolves against cwd).
+'use strict'
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { Worker, isMainThread, workerData } = require('node:worker_threads')
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+
+// The real host client, bundled on demand so the harness always exercises the
+// current src/main/ipc/parcel-watcher-process.ts.
+const bundlePath = path.join(__dirname, 'parcel-watcher-process.bundle.cjs')
+if (isMainThread) {
+  const clientSrc = path.join(REPO_ROOT, 'src', 'main', 'ipc', 'parcel-watcher-process.ts')
+  if (
+    !fs.existsSync(bundlePath) ||
+    fs.statSync(bundlePath).mtimeMs < fs.statSync(clientSrc).mtimeMs
+  ) {
+    require('node:child_process').execSync(
+      `npx esbuild ${JSON.stringify(clientSrc)} --bundle --platform=node --format=cjs ` +
+        `--external:electron --external:@parcel/watcher --outfile=${JSON.stringify(bundlePath)}`,
+      { cwd: REPO_ROOT, stdio: 'inherit' }
+    )
+  }
+  const entry = path.join(process.cwd(), 'out', 'main', 'parcel-watcher-process-entry.js')
+  if (!fs.existsSync(entry)) {
+    process.stderr.write(
+      `[fixed-harness] missing ${entry}\nRun from the repo root after building (npx electron-vite build).\n`
+    )
+    process.exit(2)
+  }
+}
+const client = require(bundlePath)
+
+const IGNORE_DIRS = [
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.cache',
+  'target',
+  '.venv',
+  '__pycache__'
+]
+const OPTS = {
+  ignore: IGNORE_DIRS.flatMap((dir) => [`**/${dir}`, `**/${dir}/**`]),
+  backend: 'windows'
+}
+
+const stats = {
+  subscribes: 0,
+  unsubscribes: 0,
+  events: 0,
+  watchErrors: 0,
+  interruptions: 0,
+  containedCrashes: 0,
+  fallbackDetected: false
+}
+
+// The client reports child crashes / fallback via console.error|warn — hook
+// them to count contained crashes and detect a broken (in-process) setup.
+const realError = console.error.bind(console)
+console.error = (...args) => {
+  const line = args.map(String).join(' ')
+  if (line.includes('[parcel-watcher-process] watcher process exited')) {
+    stats.containedCrashes++
+  }
+  realError(...args)
+}
+const realWarn = console.warn.bind(console)
+console.warn = (...args) => {
+  const line = args.map(String).join(' ')
+  if (line.includes('using in-process watcher')) {
+    stats.fallbackDetected = true
+  }
+  realWarn(...args)
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const rand = (n) => Math.floor(Math.random() * n)
+
+function makeTree(dir, files, subdirs) {
+  fs.mkdirSync(dir, { recursive: true })
+  const dirs = [dir]
+  for (let d = 0; d < subdirs; d++) {
+    const sub = path.join(dir, `sub-${d}`)
+    fs.mkdirSync(sub, { recursive: true })
+    dirs.push(sub)
+  }
+  for (const d of dirs) {
+    for (let f = 0; f < Math.ceil(files / dirs.length); f++) {
+      fs.writeFileSync(path.join(d, `f${f}.txt`), 'seed')
+    }
+  }
+}
+
+function rmrf(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 })
+  } catch {}
+}
+
+if (!isMainThread && workerData && workerData.role === 'churn') {
+  const { dir, durationMs } = workerData
+  const end = Date.now() + durationMs
+  let i = 0
+  while (Date.now() < end) {
+    const a = path.join(dir, `churn-${i % 200}.txt`)
+    const b = path.join(dir, `churn-${i % 200}.renamed.txt`)
+    try {
+      fs.writeFileSync(a, `payload-${i}`)
+      fs.renameSync(a, b)
+      fs.rmSync(b, { force: true })
+    } catch {
+      if (i % 500 === 0) {
+        try {
+          fs.mkdirSync(dir, { recursive: true })
+        } catch {}
+      }
+    }
+    i++
+  }
+  process.exit(0)
+}
+
+function subscribeLikeOrca(dir) {
+  let subRef = { current: null }
+  stats.subscribes++
+  return client
+    .subscribeViaWatcherProcess(
+      dir,
+      (err, events) => {
+        if (err) {
+          stats.watchErrors++
+          // Orca's error path: unsubscribe from inside the error callback.
+          if (subRef.current) {
+            stats.unsubscribes++
+            subRef.current.unsubscribe().catch(() => {})
+            subRef.current = null
+          }
+          return
+        }
+        stats.events += events.length
+      },
+      OPTS,
+      () => {
+        stats.interruptions++
+      }
+    )
+    .then((sub) => {
+      subRef.current = sub
+      return subRef
+    })
+}
+
+async function deleteRootLane(baseDir, durationMs, lane) {
+  const end = Date.now() + durationMs
+  let round = 0
+  while (Date.now() < end) {
+    const dir = path.join(baseDir, `wt-${lane}-${round}`)
+    makeTree(dir, 120, 4)
+    let subRef
+    try {
+      subRef = await subscribeLikeOrca(dir)
+    } catch {
+      rmrf(dir)
+      round++
+      continue
+    }
+    const churn = new Worker(__filename, {
+      workerData: { role: 'churn', dir, durationMs: 300 }
+    })
+    // Attach at spawn: a listener added after the worker already exited never
+    // fires, which hangs the lane (or lets the process exit 0 mid-run).
+    const churnDone = new Promise((r) => churn.once('exit', r))
+    await sleep(50 + rand(100))
+    rmrf(dir)
+    await sleep(rand(60))
+    if (subRef.current) {
+      stats.unsubscribes++
+      await subRef.current.unsubscribe().catch(() => {})
+      subRef.current = null
+    }
+    await churnDone
+    rmrf(dir)
+    round++
+  }
+}
+
+async function unsubChurnLane(baseDir, durationMs, lane) {
+  const dir = path.join(baseDir, `unsub-${lane}`)
+  makeTree(dir, 150, 3)
+  const churn = new Worker(__filename, {
+    workerData: { role: 'churn', dir, durationMs }
+  })
+  const churnDone = new Promise((r) => churn.once('exit', r))
+  const end = Date.now() + durationMs
+  while (Date.now() < end) {
+    let subRef
+    try {
+      subRef = await subscribeLikeOrca(dir)
+    } catch {
+      await sleep(20)
+      continue
+    }
+    await sleep(rand(50))
+    if (subRef.current) {
+      stats.unsubscribes++
+      const p = subRef.current.unsubscribe().catch(() => {})
+      subRef.current = null
+      if (rand(2) === 0) {
+        await p
+      }
+    }
+  }
+  await churnDone
+  rmrf(dir)
+}
+
+// Health check must outlast the client's 30s crash-loop cooldown: if the
+// breaker tripped during the scenarios, watching is expected to recover on a
+// later subscribe, and THAT is what we verify.
+async function finalHealthCheck(baseDir) {
+  const deadline = Date.now() + 45_000
+  let attempt = 0
+  while (Date.now() < deadline) {
+    attempt++
+    const dir = path.join(baseDir, `health-${attempt}`)
+    makeTree(dir, 5, 0)
+    let gotEvent = false
+    let sub = null
+    try {
+      sub = await client.subscribeViaWatcherProcess(dir, (err, events) => {
+        if (!err && events.length > 0) {
+          gotEvent = true
+        }
+      }, OPTS)
+    } catch (err) {
+      process.stderr.write(`[fixed-harness] health subscribe attempt ${attempt} failed: ${err.message}\n`)
+      rmrf(dir)
+      await sleep(5000)
+      continue
+    }
+    const probeDeadline = Date.now() + 8000
+    while (!gotEvent && Date.now() < probeDeadline) {
+      fs.writeFileSync(path.join(dir, 'probe.txt'), `probe-${Date.now()}`)
+      await sleep(200)
+    }
+    await sub.unsubscribe().catch(() => {})
+    rmrf(dir)
+    if (gotEvent) {
+      return true
+    }
+    process.stderr.write(`[fixed-harness] health attempt ${attempt}: no events in 8s; retrying\n`)
+    await sleep(3000)
+  }
+  return false
+}
+
+let completed = false
+
+async function main() {
+  const durationMs = Number(process.argv[2] || 15000)
+  const baseDir = path.join(os.tmpdir(), 'orca-7547-harness-fixed', `run-${process.pid}`)
+  fs.mkdirSync(baseDir, { recursive: true })
+
+  // Watchdog: a stuck lane must fail loudly, and a premature natural exit
+  // (empty event loop) must not read as success.
+  const watchdog = setTimeout(() => {
+    process.stderr.write('[fixed-harness] FAIL: watchdog — scenarios did not complete\n')
+    process.exit(7)
+  }, durationMs * 4 + 60_000)
+  process.on('exit', (code) => {
+    if (!completed && code === 0) {
+      process.exitCode = 8
+      process.stderr.write('[fixed-harness] FAIL: premature exit before completion\n')
+    }
+  })
+
+  const lanes = []
+  for (let lane = 0; lane < 6; lane++) {
+    lanes.push(deleteRootLane(baseDir, durationMs, lane))
+  }
+  for (let lane = 0; lane < 6; lane++) {
+    lanes.push(unsubChurnLane(baseDir, durationMs, lane))
+  }
+  await Promise.all(lanes)
+
+  const healthy = await finalHealthCheck(baseDir)
+  client.disposeWatcherProcess()
+  rmrf(baseDir)
+  completed = true
+  clearTimeout(watchdog)
+
+  // Summary via stderr + exitCode (not process.exit): stdout writes to a pipe
+  // are async on Windows and process.exit() drops them.
+  process.stderr.write(
+    `[fixed-harness] subs=${stats.subscribes} unsubs=${stats.unsubscribes} events=${stats.events} ` +
+      `watchErrors=${stats.watchErrors} containedCrashes=${stats.containedCrashes} ` +
+      `interruptions=${stats.interruptions} healthy=${healthy} fallback=${stats.fallbackDetected}\n`
+  )
+  if (stats.fallbackDetected) {
+    process.stderr.write('[fixed-harness] FAIL: in-process fallback used — isolation not exercised\n')
+    process.exitCode = 6
+    return
+  }
+  if (!healthy) {
+    process.stderr.write('[fixed-harness] FAIL: watcher not functional after scenarios\n')
+    process.exitCode = 5
+    return
+  }
+  process.stderr.write('[fixed-harness] PASS: host survived; watcher functional\n')
+  process.exitCode = 0
+}
+
+if (isMainThread) {
+  main().catch((err) => {
+    console.error('[fixed-harness] harness error:', err)
+    process.exit(3)
+  })
+}

--- a/tools/repro-watcher-crash-7547/run.cjs
+++ b/tools/repro-watcher-crash-7547/run.cjs
@@ -1,0 +1,74 @@
+// Parent runner for the #7547 watcher.node crash harness. Spawns child.cjs in
+// a loop and reports native crash exit codes (0xC0000409 fail-fast, 0xC0000005
+// AV, etc.). Usage:
+//   node run.cjs <scenario|mixed|all> [iterations] [durationMs]
+'use strict'
+
+const { spawn } = require('node:child_process')
+const path = require('node:path')
+
+const CHILD = path.join(__dirname, 'child.cjs')
+const KNOWN = {
+  3221226505: 'STATUS_STACK_BUFFER_OVERRUN (0xC0000409) — fail-fast/abort  << TARGET',
+  3221225477: 'STATUS_ACCESS_VIOLATION (0xC0000005)',
+  3221225725: 'STATUS_STACK_OVERFLOW (0xC00000FD)',
+  3221226356: 'STATUS_HEAP_CORRUPTION (0xC0000374)',
+  134: 'SIGABRT (128+6)'
+}
+
+function hex(code) {
+  return code >= 0 ? `0x${code.toString(16).toUpperCase()}` : String(code)
+}
+
+function runOnce(scenario, durationMs) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CHILD, scenario, String(durationMs)], {
+      stdio: ['ignore', 'inherit', 'pipe']
+    })
+    let stderr = ''
+    child.stderr.on('data', (d) => {
+      stderr += d
+      process.stderr.write(d)
+    })
+    child.on('exit', (code, signal) => resolve({ code, signal, stderr }))
+  })
+}
+
+async function main() {
+  const scenario = process.argv[2] || 'mixed'
+  const iterations = Number(process.argv[3] || 10)
+  const durationMs = Number(process.argv[4] || 15000)
+  const scenarios =
+    scenario === 'all'
+      ? ['delete-root', 'unsub-churn', 'worker-mix', 'overflow', 'mixed']
+      : [scenario]
+
+  const results = []
+  let crashed = false
+  outer: for (const s of scenarios) {
+    for (let i = 1; i <= iterations; i++) {
+      const started = Date.now()
+      console.log(`\n=== [${s}] iteration ${i}/${iterations} (${durationMs}ms) ===`)
+      const { code, signal } = await runOnce(s, durationMs)
+      const elapsed = Date.now() - started
+      const meaning = KNOWN[code] || (code === 0 ? 'clean exit' : 'unexpected')
+      console.log(`=== [${s}] iter ${i}: exit=${code} (${hex(code ?? -1)}) signal=${signal} ${meaning} after ${elapsed}ms`)
+      results.push({ scenario: s, iteration: i, code, signal, elapsed })
+      if (code !== 0 && code !== null) {
+        crashed = true
+        console.log(`\n*** NATIVE CRASH REPRODUCED in scenario "${s}" (exit ${hex(code)}) ***`)
+        break outer
+      }
+    }
+  }
+
+  console.log('\n──── summary ────')
+  for (const r of results) {
+    console.log(
+      `${r.scenario.padEnd(12)} #${r.iteration} exit=${hex(r.code ?? -1)} ${r.signal || ''} ${r.elapsed}ms`
+    )
+  }
+  process.exit(crashed ? 1 : 0)
+}
+
+main()


### PR DESCRIPTION
Fixes #7547 (Windows main-process crash in `watcher.node`, `0xc0000409` fail-fast, 5x in ~25 min). Same crash class as #5377 (macOS) and #6635 (Linux serve).

## Root cause

`@parcel/watcher` 2.5.6 has native teardown races. A reproduction harness (included, see below) reproduced the crash **in under 3 seconds, 7/7 runs**, and minimisation isolated the trigger: **`unsubscribe()` while the backend thread is actively delivering events**.

- Deleting a watched worktree root alone: no crash.
- Heavy churn alone: no crash.
- Adding the `unsubscribe()` Orca must perform (worktree switch grace teardown, worktree deletion, error paths): crash within seconds.

Mechanism (`src/windows/WindowsBackend.cc`): `Subscription::stop()` runs on a non-backend thread; `CancelIo` only cancels the *calling* thread's I/O so the pending `ReadDirectoryChangesW` survives; `CloseHandle` + object free leave the kernel completing into a dangling `OVERLAPPED` on the backend thread → UAF → heap corruption. That surfaces as `0xC0000005` or, with heap reuse, the reporter's `0xc0000409` fail-fast. Since Orca cannot stop unsubscribing (Windows keeps watched dirs locked, blocking `git worktree remove`), no in-process usage pattern avoids this.

The harness also exposed a second failure mode: a lock-order inversion (`Debounce::notify` holds the debounce mutex and wants the watcher mutex; `~Watcher` under `unwatch`/`notifyError` holds the watcher mutex and wants the debounce mutex) deadlocks parcel's **single process-wide delivery thread** — subscriptions still ack but no events ever flow again.

## Fix (what the issue requested — VS Code-style isolation)

All local `filesystem-watcher.ts` subscriptions now run in a disposable forked child (`ELECTRON_RUN_AS_NODE`, mirroring the computer-sidecar/daemon pattern):

- **`parcel-watcher-process-entry.ts`** — hosts the native module; exits on host disconnect so process death releases handles without running the crash-prone napi teardown. Includes a **canary self-check** (watches a private temp dir, touches a probe file every 10s; two missed deliveries → self-exit) that converts the silent-wedge deadlock into a clean restart.
- **`parcel-watcher-process.ts`** — host client: lazy fork, crash → respawn + transparent resubscribe of every live root, `onInterruption` → overflow refresh so the renderer re-reads past the event gap, crash-loop breaker (3 crashes/30s → watching disabled, recovers after cooldown), in-process fallback when the built entry is absent (tests/unbuilt trees).
- `filesystem-watcher.ts` swaps the direct native subscribe for the client; app shutdown now just kills the child.
- Packaging: new vite entry + `asarUnpack` (locked by a config test — a missing unpack would silently reintroduce the in-process crash).

Out of scope, same crash family (possible follow-ups): runtime `file-watcher-worker.ts` (worker_threads, non-Windows paired-client path) and macOS `worktree-git-common-watch.ts` narrow watch; both could migrate to this client. Windows runtime file-explorer already avoids parcel. The UAF + deadlock are also clean upstream reports for parcel-bundler/watcher.

## Verification

Harness in `tools/repro-watcher-crash-7547/` (manual, Windows; all churn under `os.tmpdir()`):

- **Before**: `node tools/repro-watcher-crash-7547/run.cjs delete-root` → host process native crash in 0.6–3s, 7/7 runs (`0xC0000005`; the corruption also manifests as the reporter's `0xC0000409` depending on heap state).
- **After**: `node tools/repro-watcher-crash-7547/fixed-child.cjs` drives the identical load through the real client + real forked entry: **6/6 PASS** — contained watcher-child crashes observed (the native bug still fires), host survives every time, roots resubscribed, and a final health check confirms events still flow, including recovery after the crash-loop breaker trips.
- 9 new client regression tests (crash→respawn→resubscribe→interruption, in-flight subscribe across respawn, breaker, unsubscribe acks); all existing watcher suites pass unchanged via the in-process fallback (71 passed). Typecheck + oxlint clean.

Also addresses the issue's secondary effect: worktrees vanishing after relaunch were caused by the main process dying mid-write of workspace state — contained child crashes no longer take the state writer down.