### PR TITLE
Fix orchestration agent prompt injection

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1464,6 +1464,144 @@
       "demotionRule": "Cannot promote if standard-key behavior is inferred without PTY byte evidence."
     },
     {
+      "id": "terminal-input.agent-prompt-injection",
+      "title": "Orchestration agent prompts arrive as bracketed paste before submit",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-input",
+      "layer": "runtime-contract-and-cli-repro",
+      "surfaces": [
+        "terminal input",
+        "agent prompt injection",
+        "orchestration dispatch",
+        "PTY writes",
+        "bracketed paste"
+      ],
+      "platforms": [
+        "macos",
+        "linux",
+        "windows"
+      ],
+      "providers": [
+        "local",
+        "daemon",
+        "ssh",
+        "remote-runtime"
+      ],
+      "coveredPlatforms": [
+        "macos"
+      ],
+      "coveredProviders": [
+        "local"
+      ],
+      "coverageNotes": "Local macOS evidence covers the runtime PTY write contract and a live dev-runtime CLI repro. SSH, daemon, remote-runtime, Linux, and Windows remain provider/platform gaps; the product path stays provider-owned and does not add local filesystem or process assumptions.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/7226"
+      ],
+      "invariant": "Injected orchestration task prompts for recognized agent CLIs must send the prompt body inside one bracketed-paste frame, sanitize embedded ESC bytes, preserve chunk boundaries without losing the frame, and send Enter only after the paste frame completes.",
+      "oracle": "Runtime tests assert the exact PTY write sequence and failure cleanup; orchestration tests assert dispatch/coordinator use the agent prompt path; the live CLI harness dispatches a 32KB task to a fake Codex-like TUI and requires marker present, bracketed paste present, zero unframed line breaks, and submit observed.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/coordinator.test.ts",
+        "node tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000"
+      ],
+      "testFiles": [
+        "src/shared/agent-prompt-injection.test.ts",
+        "src/main/runtime/orca-runtime.test.ts",
+        "src/main/runtime/rpc/methods/orchestration.test.ts",
+        "src/main/runtime/orchestration/coordinator.test.ts",
+        "tools/repro-orchestration-long-prompt.mjs"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/shared/agent-prompt-injection.test.ts",
+          "assertions": [
+            "agent prompts are always framed as bracketed paste",
+            "submit stays separate from the paste frame",
+            "embedded ESC bytes are made inert before framing",
+            "chunk reconstruction preserves the paste frame"
+          ]
+        },
+        {
+          "file": "src/main/runtime/orca-runtime.test.ts",
+          "assertions": [
+            "runtime writes bracketed paste before a delayed submit",
+            "large prompt frames are chunked and reconstructed before submit",
+            "partial prompt write failure closes the paste frame and does not submit"
+          ]
+        },
+        {
+          "file": "src/main/runtime/rpc/methods/orchestration.test.ts",
+          "assertions": [
+            "orchestration.dispatch uses the agent prompt path for injected preambles",
+            "raw terminal.send is not called for injected task prompts",
+            "failed prompt injection rolls back the active dispatch"
+          ]
+        },
+        {
+          "file": "src/main/runtime/orchestration/coordinator.test.ts",
+          "assertions": [
+            "coordinator dispatch failures from prompt injection circuit-break through the DB",
+            "silent-skip paths do not attempt prompt injection"
+          ]
+        },
+        {
+          "file": "tools/repro-orchestration-long-prompt.mjs",
+          "assertions": [
+            "fake Codex-like worker observes submit after long orchestration dispatch",
+            "32KB task marker survives before submit",
+            "prompt bytes include a bracketed-paste frame with zero unframed line breaks"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/coordinator.test.ts",
+          "result": "passed",
+          "durationSeconds": 7.4,
+          "summary": "4 test files passed, 697 tests passed; covers framing, runtime PTY writes, orchestration RPC dispatch, and coordinator dispatch behavior."
+        },
+        {
+          "date": "2026-07-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "node tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000",
+          "result": "passed",
+          "durationSeconds": 2.2,
+          "summary": "Live dev-runtime repro passed: expectedSpecBytes=32830, hasSubmit=true, rawContainsMarker=true, hasBracketedPasteFrame=true, unframedLineBreaks=0, contractOk=true."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "runtime contract tests plus optional local dev-runtime CLI repro"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "First local macOS evidence only; needs repeated dev-runtime harness runs and provider matrix evidence before promotion."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The live harness reproduced the unsafe raw multiline contract before the fix and passes after the fix; intentional-break evidence is local only and not yet in CI."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Agent prompt dispatch remains O(prompt bytes), uses the existing 16KB terminal input chunking and one existing 500ms submit delay, and adds no polling, provider listing, subprocess churn, hidden-pane wakeups, or renderer work."
+      },
+      "promotionCriteria": [
+        "Run the live harness in soak with a self-starting dev runtime or provider-contract fixture.",
+        "Add daemon, SSH, remote-runtime, Linux, and Windows evidence or mark narrower provider scope.",
+        "Capture stable red/green intentional-break evidence in CI before blocking promotion."
+      ],
+      "knownGaps": [
+        "Live harness command currently expects an already-running dev runtime and generated out/bin/orca-dev wrapper.",
+        "No Windows ConPTY, Linux PTY, SSH, daemon, or remote-runtime live evidence yet.",
+        "Push-on-idle orchestration message banners remain outside this dispatch-prompt gate."
+      ],
+      "demotionRule": "Demote or quarantine if the live harness flakes without a product bug or harness bug filed to the terminal-input owner."
+    },
+    {
       "id": "terminal-render.windows-cjk-repaint",
       "title": "Windows ConPTY wide glyphs and cursor rewrites repaint without stale cells",
       "maturity": "experimental",

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -60,6 +60,11 @@ import {
   TERMINAL_INPUT_MAX_BYTES,
   TERMINAL_INPUT_TOO_LARGE_ERROR
 } from '../../shared/terminal-input'
+import {
+  AGENT_PROMPT_BRACKETED_PASTE_END,
+  AGENT_PROMPT_BRACKETED_PASTE_START,
+  buildAgentPromptPasteBytes
+} from '../../shared/agent-prompt-injection'
 import { CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS } from '../../shared/clipboard-text'
 import {
   registerSshFilesystemProvider,
@@ -9296,6 +9301,110 @@ describe('OrcaRuntimeService', () => {
     await runtime.sendTerminal(handle, { text: 'continue', enter: true })
 
     expect(writes).toEqual(['continue', '\r'])
+  })
+
+  it('sends agent prompts as bracketed paste before submit', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      const prompt = 'line one\nline two\x1b[201~'
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, prompt)
+      await vi.runAllTimersAsync()
+      const result = await sendPromise
+
+      const pasted = [
+        AGENT_PROMPT_BRACKETED_PASTE_START,
+        'line one\nline two<ESC>[201~',
+        AGENT_PROMPT_BRACKETED_PASTE_END
+      ].join('')
+      expect(result).toMatchObject({
+        handle,
+        accepted: true,
+        bytesWritten: Buffer.byteLength(`${pasted}\r`, 'utf8')
+      })
+      expect(writes).toEqual([pasted, '\r'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('chunks large agent prompt paste frames before delayed submit', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      const prompt = `${'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)}\ntail`
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, prompt)
+      await vi.runAllTimersAsync()
+      const result = await sendPromise
+
+      const pasteWrites = writes.slice(0, -1)
+      expect(result.bytesWritten).toBe(
+        Buffer.byteLength(`${buildAgentPromptPasteBytes(prompt)}\r`, 'utf8')
+      )
+      expect(writes.at(-1)).toBe('\r')
+      expect(pasteWrites.length).toBeGreaterThan(1)
+      expect(pasteWrites.join('')).toBe(buildAgentPromptPasteBytes(prompt))
+      expect(pasteWrites[0]).toContain(AGENT_PROMPT_BRACKETED_PASTE_START)
+      expect(pasteWrites.at(-1)).toContain(AGENT_PROMPT_BRACKETED_PASTE_END)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('closes an incomplete agent prompt paste when a later chunk write fails', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      let writeCount = 0
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writeCount += 1
+          writes.push(data)
+          return writeCount !== 2
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      const prompt = 'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES + 1)
+
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, prompt)
+      const sendRejection = expect(sendPromise).rejects.toThrow('terminal_not_writable')
+      await vi.runAllTimersAsync()
+
+      await sendRejection
+      expect(writes[0]).toContain(AGENT_PROMPT_BRACKETED_PASTE_START)
+      expect(writes.at(-1)).toBe(AGENT_PROMPT_BRACKETED_PASTE_END)
+      expect(writes).not.toContain('\r')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('chunks large terminal.send text before provider writes', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -34,6 +34,12 @@ import {
   TERMINAL_INPUT_TOO_LARGE_ERROR,
   iterateTerminalInputChunks
 } from '../../shared/terminal-input'
+import {
+  AGENT_PROMPT_BRACKETED_PASTE_END,
+  AGENT_PROMPT_SUBMIT,
+  AGENT_PROMPT_SUBMIT_DELAY_MS,
+  buildAgentPromptPasteBytes
+} from '../../shared/agent-prompt-injection'
 import { gitExecFileAsync, wslAwareSpawn } from '../git/runner'
 import {
   cleanupClaimedCloneTarget,
@@ -8827,6 +8833,35 @@ export class OrcaRuntimeService {
     }
   }
 
+  async sendTerminalAgentPrompt(
+    handle: string,
+    prompt: string,
+    options: {
+      beforeWrite?: (ptyId: string) => void | Promise<void>
+      suffixFailureError?: string
+    } = {}
+  ): Promise<RuntimeTerminalSend> {
+    const payload = buildAgentPromptPasteBytes(prompt)
+    const bytesWritten = Buffer.byteLength(`${payload}${AGENT_PROMPT_SUBMIT}`, 'utf8')
+    const pty = this.getLivePtyForHandle(handle)
+    if (pty) {
+      if (!pty.pty.connected) {
+        throw new Error('terminal_not_writable')
+      }
+      await assertTerminalInputWithinLimitWithYield(payload)
+      await this.writeTerminalAgentPrompt(pty.pty.ptyId, payload, options)
+      return { handle, accepted: true, bytesWritten }
+    }
+
+    const { leaf } = this.getLiveLeafForHandle(handle)
+    if (!leaf.writable || !leaf.ptyId) {
+      throw new Error('terminal_not_writable')
+    }
+    await assertTerminalInputWithinLimitWithYield(payload)
+    await this.writeTerminalAgentPrompt(leaf.ptyId, payload, options)
+    return { handle, accepted: true, bytesWritten }
+  }
+
   async getTerminalAgentStatus(handle: string): Promise<RuntimeTerminalAgentStatus> {
     const terminal = this.getTerminalAgentStatusSnapshot(handle)
     const explicitStatus = this.getFreshExplicitAgentStatusForHandle(handle)
@@ -9181,6 +9216,54 @@ export class OrcaRuntimeService {
       if (!chunk.done) {
         await new Promise((resolve) => setTimeout(resolve, 0))
       }
+    }
+  }
+
+  private async writeTerminalAgentPrompt(
+    ptyId: string,
+    pastePayload: string,
+    options: {
+      beforeWrite?: (ptyId: string) => void | Promise<void>
+      suffixFailureError?: string
+    } = {}
+  ): Promise<void> {
+    let wrotePasteBytes = false
+    let completedPaste = false
+    try {
+      const chunks = iterateTerminalInputChunks(pastePayload)
+      let chunk = chunks.next()
+      while (!chunk.done) {
+        await options.beforeWrite?.(ptyId)
+        const wrote = this.ptyController?.write(ptyId, chunk.value) ?? false
+        if (!wrote) {
+          throw new Error('terminal_not_writable')
+        }
+        wrotePasteBytes = true
+        chunk = chunks.next()
+        if (!chunk.done) {
+          await new Promise((resolve) => setTimeout(resolve, 0))
+        }
+      }
+      completedPaste = true
+    } catch (error) {
+      if (wrotePasteBytes && !completedPaste) {
+        this.ptyController?.write(ptyId, AGENT_PROMPT_BRACKETED_PASTE_END)
+      }
+      throw error
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, AGENT_PROMPT_SUBMIT_DELAY_MS))
+    try {
+      await options.beforeWrite?.(ptyId)
+    } catch (error) {
+      if (options.suffixFailureError) {
+        throw new Error(options.suffixFailureError)
+      }
+      throw error
+    }
+    const suffixWrote = this.ptyController?.write(ptyId, AGENT_PROMPT_SUBMIT) ?? false
+    if (!suffixWrote) {
+      throw new Error(options.suffixFailureError ?? 'terminal_not_writable')
     }
   }
 

--- a/src/main/runtime/orchestration/coordinator.test.ts
+++ b/src/main/runtime/orchestration/coordinator.test.ts
@@ -40,8 +40,8 @@ function createMockRuntime(): CoordinatorRuntime & {
     setProbeDrift(result: DriftResult): void {
       mock.probeDriftResult = result
     },
-    async sendTerminal(handle: string, action: { text?: string }) {
-      mock.sentMessages.push({ handle, text: action.text ?? '' })
+    async sendTerminalAgentPrompt(handle: string, prompt: string) {
+      mock.sentMessages.push({ handle, text: prompt })
       return { handle, accepted: true, bytesWritten: 0 }
     },
     async listTerminals() {
@@ -275,7 +275,7 @@ describe('Coordinator', () => {
     db = new OrchestrationDb(':memory:')
     const runtime = createMockRuntime()
     runtime.terminals = [{ handle: 'term_a', worktreeId: 'wt1', connected: true, writable: true }]
-    runtime.sendTerminal = async () => {
+    runtime.sendTerminalAgentPrompt = async () => {
       throw new Error('terminal_not_writable')
     }
 
@@ -690,8 +690,8 @@ describe('Coordinator', () => {
       const result = await runPromise
 
       // Why: silent-skip must NOT burn the circuit-breaker budget. Task must
-      // stay in `ready`; failDispatch must NOT be called; sendTerminal must
-      // NOT be called; no dispatch context should exist.
+      // stay in `ready`; failDispatch must NOT be called; no prompt injection
+      // should happen; no dispatch context should exist.
       expect(runtime.sentMessages).toHaveLength(0)
       expect(db.getTask(task.id)?.status).toBe('ready')
       expect(db.getDispatchContext(task.id)).toBeUndefined()

--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -5,7 +5,7 @@ import { buildDispatchPreamble } from './preamble'
 import { reconcileLifecycleMessage } from './lifecycle-reconciliation'
 
 export type CoordinatorRuntime = {
-  sendTerminal(handle: string, action: { text?: string; enter?: boolean }): Promise<unknown>
+  sendTerminalAgentPrompt(handle: string, prompt: string): Promise<unknown>
   listTerminals(
     worktreeSelector?: string,
     limit?: number
@@ -495,10 +495,7 @@ export class Coordinator {
     }
 
     try {
-      await this.runtime.sendTerminal(targetHandle, {
-        text: preamble + gateContext,
-        enter: true
-      })
+      await this.runtime.sendTerminalAgentPrompt(targetHandle, preamble + gateContext)
     } catch (err) {
       const updated = this.db.failDispatch(
         dispatch.id,

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1067,7 +1067,9 @@ describe('orchestration RPC methods', () => {
       setup()
       const task = db.createTask({ spec: 'work' })
       vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
-      vi.spyOn(runtime, 'sendTerminal').mockRejectedValue(new Error('terminal_not_writable'))
+      vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockRejectedValue(
+        new Error('terminal_not_writable')
+      )
 
       await expect(
         call('orchestration.dispatch', {
@@ -1085,7 +1087,7 @@ describe('orchestration RPC methods', () => {
       setup()
       const task = db.createTask({ spec: 'work' })
       vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
-      const send = vi.spyOn(runtime, 'sendTerminal').mockResolvedValue({
+      const send = vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
         handle: 'term_a',
         accepted: true,
         bytesWritten: 1
@@ -1098,7 +1100,35 @@ describe('orchestration RPC methods', () => {
         devMode: true
       })
 
-      expect(send.mock.calls[0]?.[1].text).toContain('orca-dev orchestration send')
+      expect(send).toHaveBeenCalledWith(
+        'term_a',
+        expect.stringContaining('orca-dev orchestration send')
+      )
+    })
+
+    it('injects preamble through the agent prompt path instead of raw terminal send', async () => {
+      setup()
+      const task = db.createTask({ spec: 'line one\nline two' })
+      vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
+      const agentPrompt = vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
+        handle: 'term_a',
+        accepted: true,
+        bytesWritten: 1
+      })
+      const rawSend = vi.spyOn(runtime, 'sendTerminal')
+
+      await call('orchestration.dispatch', {
+        task: task.id,
+        to: 'term_a',
+        inject: true,
+        from: 'term_coord'
+      })
+
+      expect(agentPrompt).toHaveBeenCalledWith(
+        'term_a',
+        expect.stringContaining('line one\nline two')
+      )
+      expect(rawSend).not.toHaveBeenCalled()
     })
 
     it('rejects inject to terminal without recognized agent', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -492,7 +492,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       let injected = false
       if (params.inject) {
         try {
-          await runtime.sendTerminal(to, { text: preamble, enter: true })
+          await runtime.sendTerminalAgentPrompt(to, preamble)
           injected = true
         } catch (err) {
           db.failDispatch(ctx.id, err instanceof Error ? err.message : String(err))

--- a/src/shared/agent-prompt-injection.test.ts
+++ b/src/shared/agent-prompt-injection.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_PROMPT_BRACKETED_PASTE_END,
+  AGENT_PROMPT_BRACKETED_PASTE_START,
+  buildAgentPromptPasteBytes,
+  buildAgentPromptSubmitBytes,
+  iterateAgentPromptPasteChunks,
+  sanitizeAgentPromptText
+} from './agent-prompt-injection'
+
+const BEGIN = AGENT_PROMPT_BRACKETED_PASTE_START
+const END = AGENT_PROMPT_BRACKETED_PASTE_END
+
+describe('agent prompt injection bytes', () => {
+  it('always bracket-pastes prompts so agent TUIs treat newlines as content', () => {
+    expect(buildAgentPromptPasteBytes('line one\nline two')).toBe(
+      `${BEGIN}line one\nline two${END}`
+    )
+  })
+
+  it('keeps submit separate from the paste frame', () => {
+    expect(buildAgentPromptPasteBytes('hello')).not.toContain('\r')
+    expect(buildAgentPromptSubmitBytes()).toBe('\r')
+  })
+
+  it('sanitizes embedded escape bytes before framing', () => {
+    const bytes = buildAgentPromptPasteBytes('before\x1b[201~after\x1b')
+    expect(bytes).toBe(`${BEGIN}before<ESC>[201~after<ESC>${END}`)
+    expect(bytes.slice(BEGIN.length, -END.length)).not.toContain('\x1b')
+  })
+
+  it('exposes the sanitizer for tests and diagnostics', () => {
+    expect(sanitizeAgentPromptText('a\x1bb')).toBe('a<ESC>b')
+  })
+
+  it('chunks without changing the reconstructed paste frame', () => {
+    const prompt = `header\n${'abc123'.repeat(200)}`
+    const chunks = [...iterateAgentPromptPasteChunks(prompt, 31)]
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.join('')).toBe(buildAgentPromptPasteBytes(prompt))
+    expect(chunks.join('')).toContain(`${BEGIN}header\n`)
+    expect(chunks.join('')).toContain(END)
+  })
+})

--- a/src/shared/agent-prompt-injection.ts
+++ b/src/shared/agent-prompt-injection.ts
@@ -1,0 +1,43 @@
+import { iterateTerminalInputChunks, TERMINAL_INPUT_CHUNK_MAX_BYTES } from './terminal-input'
+
+export const AGENT_PROMPT_BRACKETED_PASTE_START = '\x1b[200~'
+export const AGENT_PROMPT_BRACKETED_PASTE_END = '\x1b[201~'
+export const AGENT_PROMPT_SUBMIT = '\r'
+
+// Why: Codex/Claude can need a render turn after bracketed-paste end before
+// Enter is accepted as submit, not paste content. Match the proven runtime gap.
+export const AGENT_PROMPT_SUBMIT_DELAY_MS = 500
+
+const ESCAPE = '\x1b'
+const INERT_ESCAPE = '<ESC>'
+
+export function sanitizeAgentPromptText(text: string): string {
+  let escapeIndex = text.indexOf(ESCAPE)
+  if (escapeIndex === -1) {
+    return text
+  }
+
+  let sanitized = ''
+  let start = 0
+  while (escapeIndex !== -1) {
+    sanitized += `${text.slice(start, escapeIndex)}${INERT_ESCAPE}`
+    start = escapeIndex + ESCAPE.length
+    escapeIndex = text.indexOf(ESCAPE, start)
+  }
+  return sanitized + text.slice(start)
+}
+
+export function buildAgentPromptPasteBytes(prompt: string): string {
+  return `${AGENT_PROMPT_BRACKETED_PASTE_START}${sanitizeAgentPromptText(prompt)}${AGENT_PROMPT_BRACKETED_PASTE_END}`
+}
+
+export function buildAgentPromptSubmitBytes(): string {
+  return AGENT_PROMPT_SUBMIT
+}
+
+export function* iterateAgentPromptPasteChunks(
+  prompt: string,
+  maxChunkBytes = TERMINAL_INPUT_CHUNK_MAX_BYTES
+): Generator<string> {
+  yield* iterateTerminalInputChunks(buildAgentPromptPasteBytes(prompt), maxChunkBytes)
+}

--- a/tools/repro-orchestration-long-prompt.mjs
+++ b/tools/repro-orchestration-long-prompt.mjs
@@ -1,0 +1,504 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const SCRIPT_PATH = import.meta.filename
+const BEGIN = '\x1b[200~'
+const END = '\x1b[201~'
+
+const DEFAULT_SIZE_KB = 80
+const DEFAULT_TIMEOUT_MS = 20_000
+const DEFAULT_MODE = 'codex-like'
+
+function argValue(name, fallback = undefined) {
+  const prefix = `--${name}=`
+  const inline = process.argv.find((arg) => arg.startsWith(prefix))
+  if (inline) {
+    return inline.slice(prefix.length)
+  }
+  const index = process.argv.indexOf(`--${name}`)
+  if (index !== -1) {
+    return process.argv[index + 1] ?? fallback
+  }
+  return fallback
+}
+
+function hasFlag(name) {
+  return process.argv.includes(`--${name}`)
+}
+
+function parsePositiveInteger(name, fallback) {
+  const raw = argValue(name)
+  if (raw === undefined) {
+    return fallback
+  }
+  const value = Number(raw)
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`--${name} must be a positive integer`)
+  }
+  return value
+}
+
+function shellQuote(value) {
+  if (process.platform === 'win32') {
+    return `"${String(value).replace(/"/g, '\\"')}"`
+  }
+  return `'${String(value).replace(/'/g, "'\\''")}'`
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr })
+        return
+      }
+      const error = new Error(`${command} ${args.join(' ')} exited ${code}`)
+      error.stdout = stdout
+      error.stderr = stderr
+      error.code = code
+      reject(error)
+    })
+  })
+}
+
+function parseCliJson(output) {
+  const text = output.trim()
+  if (!text) {
+    throw new Error('CLI returned empty JSON output')
+  }
+  return JSON.parse(text)
+}
+
+async function callOrca(cli, args, options = {}) {
+  const result = await runCommand(cli, [...args, '--json'], options)
+  const parsed = parseCliJson(result.stdout)
+  if (parsed.ok === false) {
+    throw new Error(parsed.error?.message ?? JSON.stringify(parsed.error))
+  }
+  return parsed.result ?? parsed
+}
+
+function buildLongSpec(sizeKb, marker) {
+  const targetBytes = sizeKb * 1024
+  const header = [
+    `ORCA_LONG_PROMPT_REPRO_START ${marker}`,
+    'This task is intentionally long so orchestration dispatch crosses terminal input chunks.',
+    'The receiver expects the end marker to arrive before the submit byte.'
+  ].join('\n')
+  const lines = [header]
+  let index = 0
+  while (
+    Buffer.byteLength(`${lines.join('\n')}\nORCA_LONG_PROMPT_REPRO_END ${marker}`, 'utf8') <
+    targetBytes
+  ) {
+    lines.push(
+      `line ${String(index).padStart(5, '0')} ${marker} ${'abcdefghijklmnopqrstuvwxyz 0123456789 '.repeat(3)}`
+    )
+    index += 1
+  }
+  lines.push(`ORCA_LONG_PROMPT_REPRO_END ${marker}`)
+  return lines.join('\n')
+}
+
+function readNested(result, pathParts) {
+  let current = result
+  for (const part of pathParts) {
+    current = current?.[part]
+  }
+  return current
+}
+
+async function waitForReport(reportPath, timeoutMs) {
+  const startedAt = Date.now()
+  let lastError = null
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      return JSON.parse(await readFile(reportPath, 'utf8'))
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+  }
+  const error = new Error(`Timed out waiting for report: ${reportPath}`)
+  error.cause = lastError
+  throw error
+}
+
+async function tryCloseTerminal(cli, handle, cwd) {
+  if (!handle) {
+    return
+  }
+  try {
+    await callOrca(cli, ['terminal', 'close', '--terminal', handle], { cwd })
+  } catch {
+    // Best-effort cleanup; the report is more useful than a close failure.
+  }
+}
+
+async function parentMain() {
+  const cli = argValue('cli', process.env.ORCA_REPRO_CLI ?? 'orca')
+  const mode = argValue('mode', DEFAULT_MODE)
+  if (!new Set(['wire', 'codex-like']).has(mode)) {
+    throw new Error('--mode must be wire or codex-like')
+  }
+  const sizeKb = parsePositiveInteger('size-kb', DEFAULT_SIZE_KB)
+  const timeoutMs = parsePositiveInteger('timeout-ms', DEFAULT_TIMEOUT_MS)
+  const cwd = path.resolve(argValue('worktree', process.cwd()))
+  const keepTerminals = hasFlag('keep-terminals')
+  const discardReport = hasFlag('discard-report')
+  const marker = `marker_${randomUUID().replace(/-/g, '')}`
+  const spec = buildLongSpec(sizeKb, marker)
+  const tempDir = path.join(tmpdir(), `orca-orchestration-long-prompt-${process.pid}-${Date.now()}`)
+  await mkdir(tempDir, { recursive: true })
+  const workerReportPath = path.join(tempDir, 'worker-report.json')
+
+  console.log(`runtime: ${cli} status`)
+  await callOrca(cli, ['status'], { cwd })
+
+  const coordinator = await callOrca(
+    cli,
+    [
+      'terminal',
+      'create',
+      '--worktree',
+      `path:${cwd}`,
+      '--title',
+      'orchestration repro coordinator',
+      '--command',
+      `${shellQuote(process.execPath)} ${shellQuote(SCRIPT_PATH)} --fake-coordinator`
+    ],
+    { cwd }
+  )
+  const coordinatorHandle = readNested(coordinator, ['terminal', 'handle'])
+  if (!coordinatorHandle) {
+    throw new Error('Could not create coordinator terminal')
+  }
+
+  const workerCommand = [
+    shellQuote(process.execPath),
+    shellQuote(SCRIPT_PATH),
+    '--fake-worker',
+    '--cli',
+    shellQuote(cli),
+    '--mode',
+    shellQuote(mode),
+    '--report',
+    shellQuote(workerReportPath),
+    '--marker',
+    shellQuote(marker),
+    '--timeout-ms',
+    String(timeoutMs)
+  ].join(' ')
+  const worker = await callOrca(
+    cli,
+    [
+      'terminal',
+      'create',
+      '--worktree',
+      `path:${cwd}`,
+      '--title',
+      'orchestration repro fake codex',
+      '--command',
+      workerCommand
+    ],
+    { cwd }
+  )
+  const workerHandle = readNested(worker, ['terminal', 'handle'])
+  if (!workerHandle) {
+    throw new Error('Could not create worker terminal')
+  }
+
+  let taskId = null
+  try {
+    await callOrca(
+      cli,
+      [
+        'terminal',
+        'wait',
+        '--terminal',
+        workerHandle,
+        '--for',
+        'tui-idle',
+        '--timeout-ms',
+        '10000'
+      ],
+      { cwd }
+    )
+    const task = await callOrca(
+      cli,
+      [
+        'orchestration',
+        'task-create',
+        '--spec',
+        spec,
+        '--task-title',
+        'Long prompt repro',
+        '--display-name',
+        'Long prompt repro'
+      ],
+      { cwd }
+    )
+    taskId = readNested(task, ['task', 'id'])
+    if (!taskId) {
+      throw new Error('Could not create orchestration task')
+    }
+
+    const dispatch = await callOrca(
+      cli,
+      [
+        'orchestration',
+        'dispatch',
+        '--task',
+        taskId,
+        '--to',
+        workerHandle,
+        '--from',
+        coordinatorHandle,
+        '--inject'
+      ],
+      { cwd }
+    )
+    const dispatchId = readNested(dispatch, ['dispatch', 'id'])
+    const report = await waitForReport(workerReportPath, timeoutMs)
+    const summary = {
+      mode,
+      sizeKb,
+      taskId,
+      dispatchId,
+      coordinatorHandle,
+      workerHandle,
+      reportPath: workerReportPath,
+      expectedMarker: marker,
+      expectedSpecBytes: Buffer.byteLength(spec, 'utf8'),
+      ...report
+    }
+    console.log(JSON.stringify(summary, null, 2))
+    if (report.contractOk !== true) {
+      process.exitCode = 1
+    }
+  } finally {
+    if (!keepTerminals) {
+      await tryCloseTerminal(cli, workerHandle, cwd)
+      await tryCloseTerminal(cli, coordinatorHandle, cwd)
+    }
+    if (discardReport) {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  }
+}
+
+function countUnframedLineBreaks(text) {
+  let inPaste = false
+  let count = 0
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.startsWith(BEGIN, index)) {
+      inPaste = true
+      index += BEGIN.length - 1
+      continue
+    }
+    if (text.startsWith(END, index)) {
+      inPaste = false
+      index += END.length - 1
+      continue
+    }
+    const char = text[index]
+    if (!inPaste && (char === '\n' || char === '\r')) {
+      count += 1
+    }
+  }
+  return count
+}
+
+function buildReport(payload, mode, marker) {
+  const firstSubmit = payload.indexOf(0x0d)
+  const body = firstSubmit === -1 ? payload : payload.subarray(0, firstSubmit)
+  const text = body.toString('utf8')
+  const hasBracketedPasteFrame = text.includes(BEGIN) && text.includes(END)
+  const hasSubmit = firstSubmit !== -1
+  const rawContainsMarker = text.includes(marker)
+  const unframedLineBreaks = countUnframedLineBreaks(text)
+  const base = {
+    mode,
+    receivedBytesBeforeSubmit: body.length,
+    receivedSha256BeforeSubmit: createHash('sha256').update(body).digest('hex'),
+    hasSubmit,
+    rawContainsMarker,
+    hasBracketedPasteFrame,
+    unframedLineBreaks,
+    previewStart: text.slice(0, 120),
+    previewEnd: text.slice(-120)
+  }
+  if (mode === 'wire') {
+    return {
+      ...base,
+      contractOk: hasSubmit && rawContainsMarker
+    }
+  }
+  return {
+    ...base,
+    // Codex/Claude-like TUIs need generated multi-line prompts to arrive as
+    // one paste frame; unframed newlines are treated as live editor keys.
+    contractOk: hasSubmit && rawContainsMarker && hasBracketedPasteFrame && unframedLineBreaks === 0
+  }
+}
+
+function parseInjectedIds(text) {
+  return {
+    taskId: /Your task ID is:\s*(task_[A-Za-z0-9_]+)/.exec(text)?.[1] ?? null,
+    dispatchId: /--dispatch-id\s+(ctx_[A-Za-z0-9_]+)/.exec(text)?.[1] ?? null,
+    coordinatorHandle: /Your coordinator's terminal handle is:\s*([^\s]+)/.exec(text)?.[1] ?? null
+  }
+}
+
+async function fakeWorkerMain() {
+  const cli = argValue('cli', process.env.ORCA_REPRO_CLI ?? 'orca')
+  const mode = argValue('mode', DEFAULT_MODE)
+  const reportPath = argValue('report')
+  const marker = argValue('marker')
+  const timeoutMs = parsePositiveInteger('timeout-ms', DEFAULT_TIMEOUT_MS)
+  if (!reportPath || !marker) {
+    throw new Error('--fake-worker requires --report and --marker')
+  }
+
+  process.stdout.write('\x1b]0;codex ready\x07')
+  process.stdout.write('fake codex ready\n> ')
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+  }
+  process.stdin.resume()
+
+  const chunks = []
+  let finished = false
+  async function sendWorkerDone(ids, report) {
+    if (!ids.taskId || !ids.dispatchId || !ids.coordinatorHandle) {
+      return { attempted: false, reason: 'missing-dispatch-identifiers' }
+    }
+    try {
+      await callOrca(cli, [
+        'orchestration',
+        'send',
+        '--to',
+        ids.coordinatorHandle,
+        '--type',
+        'worker_done',
+        '--subject',
+        report.contractOk
+          ? 'Harness observed safe prompt delivery'
+          : 'Harness reproduced unsafe prompt delivery',
+        '--body',
+        [
+          `The fake worker received ${report.receivedBytesBeforeSubmit} bytes before submit.`,
+          `Bracketed paste frame present: ${String(report.hasBracketedPasteFrame)}.`,
+          `Unframed line breaks: ${String(report.unframedLineBreaks)}.`
+        ].join(' '),
+        '--task-id',
+        ids.taskId,
+        '--dispatch-id',
+        ids.dispatchId,
+        '--report-path',
+        reportPath
+      ])
+      return { attempted: true, ok: true }
+    } catch (error) {
+      return {
+        attempted: true,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  const finish = async (reason) => {
+    if (finished) {
+      return
+    }
+    finished = true
+    const payload = Buffer.concat(chunks)
+    const report = {
+      reason,
+      ...buildReport(payload, mode, marker)
+    }
+    const ids = parseInjectedIds(payload.toString('utf8'))
+    report.parsedTaskId = ids.taskId
+    report.parsedDispatchId = ids.dispatchId
+    report.parsedCoordinatorHandle = ids.coordinatorHandle
+    report.workerDone = await sendWorkerDone(ids, report)
+    await writeFile(reportPath, JSON.stringify(report, null, 2))
+    process.stdout.write(
+      `\nORCA_REPRO_REPORT ${report.contractOk ? 'ok' : 'failed'} ${reportPath}\n`
+    )
+    process.exit(report.contractOk ? 0 : 7)
+  }
+
+  const timer = setTimeout(() => {
+    finish('timeout').catch(() => process.exit(8))
+  }, timeoutMs)
+  process.stdin.on('data', (chunk) => {
+    chunks.push(Buffer.from(chunk))
+    if (Buffer.concat(chunks).includes(0x0d)) {
+      clearTimeout(timer)
+      finish('submit').catch(() => process.exit(8))
+    }
+  })
+}
+
+function fakeCoordinatorMain() {
+  process.stdout.write('\x1b]0;orchestration repro coordinator\x07')
+  process.stdout.write('orchestration repro coordinator ready\n')
+  setInterval(() => {}, 60_000)
+}
+
+async function main() {
+  if (hasFlag('help')) {
+    console.log(`Usage:
+  node tools/repro-orchestration-long-prompt.mjs [--mode codex-like|wire] [--size-kb 80]
+
+The parent mode requires a running Orca runtime and creates temporary Orca
+terminals. The fake worker records whether orchestration dispatch delivered a
+long prompt in a safe agent-input contract.
+
+Options:
+  --cli <path>         Orca CLI command (default: ORCA_REPRO_CLI or orca)
+  --worktree <path>   Worktree path for temporary terminals (default: cwd)
+  --timeout-ms <n>    Wait budget for terminal/report operations
+  --keep-terminals    Leave temporary terminals open for inspection
+  --discard-report    Delete the temporary JSON report after printing summary
+`)
+    return
+  }
+  if (hasFlag('fake-worker')) {
+    await fakeWorkerMain()
+    return
+  }
+  if (hasFlag('fake-coordinator')) {
+    fakeCoordinatorMain()
+    return
+  }
+  await parentMain()
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? (error.stack ?? error.message) : error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add a dedicated agent prompt injection path that bracket-pastes orchestration prompts and submits separately
- route orchestration dispatch and coordinator worker prompts through that path instead of raw terminal.send
- add a long-prompt repro harness and register the terminal-input.agent-prompt-injection reliability gate

Closes #7226

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/coordinator.test.ts
- node tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 32 --timeout-ms 20000
- node tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode wire --size-kb 32 --timeout-ms 20000
- node tools/repro-orchestration-long-prompt.mjs --cli out/bin/orca-dev --mode codex-like --size-kb 80 --timeout-ms 20000
- pnpm run typecheck:node
- pnpm exec oxlint tools/repro-orchestration-long-prompt.mjs src/shared/agent-prompt-injection.ts src/shared/agent-prompt-injection.test.ts src/main/runtime/rpc/methods/orchestration.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/runtime/orchestration/coordinator.ts src/main/runtime/orchestration/coordinator.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts
- pnpm run check:reliability-gates
- pnpm check:max-lines-ratchet
- node --check tools/repro-orchestration-long-prompt.mjs

## Reliability
- Class: terminal-input.agent-prompt-injection
- Invariant: injected orchestration task prompts for recognized agent CLIs arrive as one bracketed paste frame, with Enter sent only after the frame completes
- Oracle: runtime write-sequence tests plus live dev-runtime fake Codex-like 32KB dispatch harness
- Coverage: local macOS covered; daemon, SSH, remote-runtime, Linux, and Windows remain registered gaps
- Performance: O(prompt bytes) work using existing 16KB terminal input chunking and the existing 500ms submit gap; no polling, provider listing, subprocess churn, hidden-pane wakeups, or renderer work added

Made with [Orca](https://github.com/stablyai/orca) 🐋
