### PR TITLE
Fix PTY reattach after renderer restart

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -7092,6 +7092,73 @@ describe('Store', () => {
     })
   })
 
+  it('marks the worktree active when persisting a PTY binding for renderer recovery', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      activeWorktreeIdsOnShutdown: [],
+      tabsByWorktree: {
+        wt1: [makeTerminalTab({ id: 'tab1', ptyId: null, worktreeId: 'wt1' })]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: null,
+          activeLeafId: null,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    store.persistPtyBinding({
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      ptyId: 'daemon-pty'
+    })
+
+    expect(store.getWorkspaceSession().activeWorktreeIdsOnShutdown).toEqual(['wt1'])
+    const reloaded = await createStore()
+    expect(reloaded.getWorkspaceSession().activeWorktreeIdsOnShutdown).toEqual(['wt1'])
+  })
+
+  it('preserves fallback active worktrees when the shutdown list is not initialized yet', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [makeTerminalTab({ id: 'tab1', ptyId: 'existing-pty', worktreeId: 'wt1' })],
+        wt2: [makeTerminalTab({ id: 'tab2', ptyId: null, worktreeId: 'wt2' })]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: null,
+          activeLeafId: null,
+          expandedLeafId: null
+        },
+        tab2: {
+          root: null,
+          activeLeafId: null,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    store.persistPtyBinding({
+      worktreeId: 'wt2',
+      tabId: 'tab2',
+      leafId: TEST_LEAF_2,
+      ptyId: 'new-daemon-pty'
+    })
+
+    expect(store.getWorkspaceSession().activeWorktreeIdsOnShutdown).toEqual(['wt1', 'wt2'])
+    const reloaded = await createStore()
+    expect(reloaded.getWorkspaceSession().activeWorktreeIdsOnShutdown).toEqual(['wt1', 'wt2'])
+  })
+
   it('adds a missing split leaf to the durable root when a new pane spawns before layout debounce', async () => {
     const store = await createStore()
     store.setWorkspaceSession({

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -5842,6 +5842,18 @@ export class Store {
         [args.worktreeId]: session.activeTabIdByWorktree?.[args.worktreeId] ?? args.tabId
       }
     }
+    // Why: renderer recovery reloads hydrate from activeWorktreeIdsOnShutdown
+    // before panes remount, so the sync PTY binding must record this live
+    // worktree. Fall back to the ptyId-derived live set (which now includes the
+    // just-bound tab) when the list has not been initialized yet.
+    const activeWorktreeIds =
+      session.activeWorktreeIdsOnShutdown ??
+      Object.entries(session.tabsByWorktree)
+        .filter(([, tabs]) => tabs.some((tab) => tab.ptyId))
+        .map(([worktreeId]) => worktreeId)
+    session.activeWorktreeIdsOnShutdown = activeWorktreeIds.includes(args.worktreeId)
+      ? activeWorktreeIds
+      : [...activeWorktreeIds, args.worktreeId]
     if (!isTerminalLeafId(args.leafId)) {
       // Why: legacy renderer-local pane ids may arrive from older callers; keep
       // them out of durable leaf-keyed layout state after the UUID migration.


### PR DESCRIPTION
## Summary

Fixes #7742.

Terminal PTYs could fail to reattach after a renderer crash-recovery reload if the worktree they belonged to only became active *after* the app's last graceful shutdown. The renderer's recovery-reload hydration path treats `activeWorktreeIdsOnShutdown` as the authoritative list of which worktrees to reconnect PTYs for (`src/renderer/src/store/slices/terminals.ts`, `pendingReconnectWorktreeIds`), but that list was previously only refreshed on a clean app shutdown.

Concretely: open a new worktree tab mid-session, spawn a terminal in it, then have the renderer crash and recover in place (without a full app relaunch). That worktree was missing from the stale shutdown list, so its still-alive daemon-backed PTY was never reattached — the underlying shell was left running with nothing reading its output until the next console I/O call crashed it (e.g. PowerShell's FailFast on a severed ConPTY pipe on Windows).

`Store.persistPtyBinding()` now keeps `activeWorktreeIdsOnShutdown` in sync every time a PTY binding is persisted (i.e. on every terminal spawn), not just at shutdown, so a mid-session renderer restart still reconnects worktrees opened after the last clean exit.

## Screenshots

No visual change — this is backend session-persistence/reconnection logic with no UI surface.

## Testing

- [x] `pnpm lint` (pre-existing, unrelated failure: `switch-exhaustiveness-check` in `src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts`, last touched by #7461, not part of this change)
- [x] `pnpm typecheck`
- [x] `pnpm test` (pre-existing, unrelated local-environment failures only — see AI Review Report below; the affected file, `persistence.test.ts`, passes 341/341)
- [x] `pnpm build`
- [x] Added two new tests covering the initialized-list and uninitialized-fallback branches of the fix

## AI Review Report

Reviewed with an independent AI code-review pass focused on this repo's cross-platform/SSH/performance/security bar:

- **Cross-platform (macOS/Linux/Windows):** No risk — pure in-memory array/object manipulation on opaque `worktreeId` strings. No paths, shell invocations, shortcuts, or Electron-surface-specific APIs touched.
- **SSH/remote-worktree:** No regression — `worktreeId` is handled identically for local and SSH-backed worktrees; the fallback derivation matches the renderer's own SSH-aware fallback semantics.
- **Performance:** Not a concern. The expensive `O(worktrees × tabs)` derivation only runs once per session as a one-time upgrade path (guarded by `??`); the steady-state cost is a single `Array.includes()` on a small array, on a user-initiated action (opening a terminal), not a hot loop.
- **Correctness:** Verified this correctly interacts with the existing cleanup path (`removeWorkspaceSessionOwner`, which prunes `activeWorktreeIdsOnShutdown` when a worktree is removed) — no unbounded growth, no duplicate entries, and a closed worktree cannot wrongly stay "active" (defense in depth: `pendingReconnectTabByWorktree` only reconnects tabs with a live `ptyId`).
- Full local `pnpm test` run has 73 pre-existing failures unrelated to this change (Windows-local-environment gaps: symlink creation requires elevated privileges on Windows, no `/bin/sh` on Windows for ephemeral-vm/relay tests, and a WSL-path fixture mismatch in `rate-limits/service.test.ts`). None touch `persistence.ts`, `terminals.ts`, or any file this PR modifies. `persistence.test.ts` itself passes 341/341, both isolated and as part of the full suite.

Verdict: ship as-is.

## Security Audit

No new attack surface. No new IPC channel, no user-controlled path or command construction, no deserialization change. `worktreeId` values are treated as opaque identifiers — only compared and stored, never interpolated into a path or shell command. The persisted schema field (`activeWorktreeIdsOnShutdown`) already existed and is already optional/validated in the workspace-session schema, so no validation gap is introduced.

## Notes

No platform-specific behavior beyond what's already covered above. This is the first of two related PRs for #7742 — a second, separate fix addressing a different failure mode (the daemon process itself dying and not notifying the renderer of the old sessions on respawn) will follow as its own PR to keep each change independently reviewable.

@noahlisk
