### PR TITLE
fix(build): skip spawn-helper check on Linux to avoid spurious node-pty rebuilds

### DIFF
--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -280,6 +280,7 @@ function getPatchedNodePtyRebuildReason() {
   // patch only lands in the source-built build/Release artifacts.
   const nodePtyDir = resolve(projectDir, 'node_modules', 'node-pty')
   const artifactPaths = [resolve(nodePtyDir, 'build', 'Release', 'pty.node')]
+  // Why: node-pty only builds spawn-helper on macOS; Linux builds only pty.node.
   if (process.platform === 'darwin') {
     artifactPaths.push(resolve(nodePtyDir, 'build', 'Release', 'spawn-helper'))
   }

--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -279,10 +279,11 @@ function getPatchedNodePtyRebuildReason() {
   // Why: a loadable upstream node-pty prebuild is not enough; Orca's Unix
   // patch only lands in the source-built build/Release artifacts.
   const nodePtyDir = resolve(projectDir, 'node_modules', 'node-pty')
-  const missingArtifact = [
-    resolve(nodePtyDir, 'build', 'Release', 'pty.node'),
-    resolve(nodePtyDir, 'build', 'Release', 'spawn-helper')
-  ].find((artifactPath) => !existsSync(artifactPath))
+  const artifactPaths = [resolve(nodePtyDir, 'build', 'Release', 'pty.node')]
+  if (process.platform === 'darwin') {
+    artifactPaths.push(resolve(nodePtyDir, 'build', 'Release', 'spawn-helper'))
+  }
+  const missingArtifact = artifactPaths.find((artifactPath) => !existsSync(artifactPath))
 
   if (!missingArtifact) {
     return null

--- a/config/scripts/ensure-native-runtime.test.mjs
+++ b/config/scripts/ensure-native-runtime.test.mjs
@@ -117,6 +117,40 @@ describe('ensure-native-runtime', () => {
       }
     }
   )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps the fast path when the platform-specific patched artifacts exist',
+    () => {
+      const projectDir = mkTempProject()
+
+      try {
+        const scriptPath = join(projectDir, 'config', 'scripts', 'ensure-native-runtime.mjs')
+        const logPath = join(projectDir, 'native-runtime.log')
+        const markerPath = join(projectDir, 'rebuilt.marker')
+        const binDir = join(projectDir, 'bin')
+        copyFileSync(sourceScriptPath, scriptPath)
+        writeLoadableNativeModules(projectDir, { nativeDir: '../build/Release/' })
+        writeNodePtyPatchFile(projectDir)
+        writePatchedNodePtyBuildArtifacts(projectDir)
+        writeFakePnpm(binDir)
+
+        const result = spawnSync(process.execPath, [scriptPath, '--runtime=node'], {
+          cwd: projectDir,
+          encoding: 'utf8',
+          env: envWithPrependedPath(binDir, {
+            ORCA_NATIVE_TEST_LOG: logPath,
+            ORCA_NATIVE_TEST_MARKER: markerPath
+          })
+        })
+
+        expect(result.status, result.stderr).toBe(0)
+        expect(result.stderr).not.toContain('Patched node-pty build artifacts are missing')
+        expect(readFileSync(logPath, 'utf8')).not.toContain('pnpm rebuild node-pty')
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
 function mkTempProject() {
@@ -161,7 +195,7 @@ exports.loadNativeModule = function loadNativeModule(nativeName) {
   )
 }
 
-function writeLoadableNativeModules(projectDir) {
+function writeLoadableNativeModules(projectDir, { nativeDir = null } = {}) {
   const nodePtyDir = join(projectDir, 'node_modules', 'node-pty')
   mkdirSync(join(nodePtyDir, 'lib'), { recursive: true })
 
@@ -173,7 +207,8 @@ const { appendFileSync, existsSync } = require('node:fs')
 
 exports.loadNativeModule = function loadNativeModule(nativeName) {
   const rebuilt = existsSync(process.env.ORCA_NATIVE_TEST_MARKER)
-  const dir = rebuilt ? '../build/Release/' : '../prebuilds/' + process.platform + '-' + process.arch + '/'
+  const dir = ${JSON.stringify(nativeDir)} ??
+    (rebuilt ? '../build/Release/' : '../prebuilds/' + process.platform + '-' + process.arch + '/')
   appendFileSync(process.env.ORCA_NATIVE_TEST_LOG, \`node-pty load \${nativeName} dir=\${dir}\\n\`)
   return { dir, module: {} }
 }
@@ -190,7 +225,9 @@ function writePatchedNodePtyBuildArtifacts(projectDir) {
   const buildDir = join(projectDir, 'node_modules', 'node-pty', 'build', 'Release')
   mkdirSync(buildDir, { recursive: true })
   writeFileSync(join(buildDir, 'pty.node'), '')
-  writeFileSync(join(buildDir, 'spawn-helper'), '')
+  if (process.platform === 'darwin') {
+    writeFileSync(join(buildDir, 'spawn-helper'), '')
+  }
 }
 
 function writeFakePnpm(binDir) {

--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -350,6 +350,7 @@ function getPatchedNodePtyRebuildReason() {
   // load successfully in Electron while missing the patched fd/error handling.
   const nodePtyDir = resolve(projectDir, 'node_modules', 'node-pty')
   const artifactPaths = [resolve(nodePtyDir, 'build', 'Release', 'pty.node')]
+  // Why: node-pty only builds spawn-helper on macOS; Linux builds only pty.node.
   if (process.platform === 'darwin') {
     artifactPaths.push(resolve(nodePtyDir, 'build', 'Release', 'spawn-helper'))
   }

--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -349,10 +349,11 @@ function getPatchedNodePtyRebuildReason() {
   // Why: Orca patches node-pty's native Unix spawn path; upstream prebuilds can
   // load successfully in Electron while missing the patched fd/error handling.
   const nodePtyDir = resolve(projectDir, 'node_modules', 'node-pty')
-  const missingArtifact = [
-    resolve(nodePtyDir, 'build', 'Release', 'pty.node'),
-    resolve(nodePtyDir, 'build', 'Release', 'spawn-helper')
-  ].find((artifactPath) => !existsSync(artifactPath))
+  const artifactPaths = [resolve(nodePtyDir, 'build', 'Release', 'pty.node')]
+  if (process.platform === 'darwin') {
+    artifactPaths.push(resolve(nodePtyDir, 'build', 'Release', 'spawn-helper'))
+  }
+  const missingArtifact = artifactPaths.find((artifactPath) => !existsSync(artifactPath))
 
   if (!missingArtifact) {
     return null

--- a/config/scripts/rebuild-native-deps.test.mjs
+++ b/config/scripts/rebuild-native-deps.test.mjs
@@ -412,5 +412,7 @@ function writePatchedNodePtyBuildArtifacts(projectDir) {
   const buildDir = join(projectDir, 'node_modules', 'node-pty', 'build', 'Release')
   mkdirSync(buildDir, { recursive: true })
   writeFileSync(join(buildDir, 'pty.node'), '')
-  writeFileSync(join(buildDir, 'spawn-helper'), '')
+  if (process.platform === 'darwin') {
+    writeFileSync(join(buildDir, 'spawn-helper'), '')
+  }
 }


### PR DESCRIPTION
## Description

`getPatchedNodePtyRebuildReason()` unconditionally checks for `build/Release/spawn-helper`, but `spawn-helper` is a **macOS-only** node-pty build target defined in `node_modules/node-pty/binding.gyp`. On Linux, `node-gyp` never generates this binary.

As a result, `missingArtifact` was always non-null on Linux, causing:
1. `ensure-native-runtime.mjs` always triggers a source rebuild every time.
2. `rebuild-native-deps.mjs` always reports artifacts missing even when `pty.node` is intact.

## Fix

Wrap the `spawn-helper` existence check in `if (process.platform === 'darwin')` in both files.

## Changes

- `config/scripts/ensure-native-runtime.mjs` — `getPatchedNodePtyRebuildReason()`
- `config/scripts/rebuild-native-deps.mjs` — `getPatchedNodePtyRebuildReason()`

Fixes #7760