### PR TITLE
feat: add a Prompt History right-sidebar tab

### DIFF
--- a/src/main/ai-vault/session-scanner-accumulator.ts
+++ b/src/main/ai-vault/session-scanner-accumulator.ts
@@ -15,11 +15,16 @@ import type {
 import {
   extractPreviewContentText,
   extractString,
+  extractUserPromptText,
   normalizePreviewText,
+  normalizeUserPromptText,
   timestampMs
 } from './session-scanner-values'
 
 const SESSION_PREVIEW_MESSAGE_LIMIT = 5
+// Per-session cap on retained user prompts (Prompt History). Bounds payload/memory
+// while keeping far more than the 5-message rolling preview.
+const USER_PROMPT_HISTORY_LIMIT = 25
 
 export function createAccumulator(args: {
   agent: AiVaultAgent
@@ -41,12 +46,18 @@ export function createAccumulator(args: {
     messageCount: 0,
     totalTokens: 0,
     previewMessages: [],
+    userPrompts: [],
     latestTimestampMs: 0
   }
 }
 
 export function cloneSessionAccumulator(accumulator: SessionAccumulator): SessionAccumulator {
-  return { ...accumulator, previewMessages: [...accumulator.previewMessages] }
+  return {
+    ...accumulator,
+    previewMessages: [...accumulator.previewMessages],
+    // Deep-copy so the resumable parse cache can't corrupt a handed-out snapshot.
+    userPrompts: [...accumulator.userPrompts]
+  }
 }
 
 // Resumable fold for parsers whose only parse state is the accumulator itself
@@ -110,6 +121,7 @@ export function finalizeSession(
     messageCount: accumulator.messageCount,
     totalTokens: accumulator.totalTokens,
     previewMessages: accumulator.previewMessages,
+    userPrompts: accumulator.userPrompts,
     resumeCommand: buildAiVaultResumeCommand({
       agent: accumulator.agent,
       sessionId,
@@ -142,32 +154,72 @@ export function addPreviewMessage(
     role: AiVaultSessionPreviewMessage['role']
     text: string | null
     timestamp?: unknown
+    // Full-fidelity user-prompt text for Prompt History; falls back to `text`.
+    fullPromptText?: string | null
+    // True when a role:'user' record is not a typed prompt (tool result, or
+    // injected/meta context) and must be kept out of Prompt History.
+    excludeFromPromptHistory?: boolean
   }
 ): void {
-  const text = normalizePreviewText(args.text ?? '')
-  if (!text) {
-    return
+  const timestamp = timestampIso(args.timestamp)
+  const previewText = normalizePreviewText(args.text ?? '')
+  if (previewText) {
+    accumulator.previewMessages.push({ role: args.role, text: previewText, timestamp })
+    if (accumulator.previewMessages.length > SESSION_PREVIEW_MESSAGE_LIMIT) {
+      accumulator.previewMessages.shift()
+    }
   }
-  accumulator.previewMessages.push({
-    role: args.role,
-    text,
-    timestamp: timestampIso(args.timestamp)
-  })
-  if (accumulator.previewMessages.length > SESSION_PREVIEW_MESSAGE_LIMIT) {
-    accumulator.previewMessages.shift()
+  // Retain the full run of genuine user prompts (excluding tool results and the
+  // preview's 220-char truncation) so Prompt History can copy them back verbatim.
+  if (args.role === 'user' && !args.excludeFromPromptHistory) {
+    const promptText = normalizeUserPromptText(args.fullPromptText ?? args.text ?? '')
+    if (promptText) {
+      accumulator.userPrompts.push({ text: promptText, timestamp })
+      if (accumulator.userPrompts.length > USER_PROMPT_HISTORY_LIMIT) {
+        accumulator.userPrompts.shift()
+      }
+    }
   }
+}
+
+// Claude and similar agents store tool results as role:'user' records.
+function isToolResultBlock(block: unknown): boolean {
+  return (
+    block != null &&
+    typeof block === 'object' &&
+    (block as { type?: unknown }).type === 'tool_result'
+  )
+}
+
+// A user turn that is nothing but tool results (no typed text) is not a prompt.
+function isToolResultContent(content: unknown): boolean {
+  return Array.isArray(content) && content.length > 0 && content.every(isToolResultBlock)
+}
+
+// Drop tool_result blocks so a mixed turn (tool output + typed text) contributes
+// only the user's text to Prompt History, never the tool output.
+function stripToolResultBlocks(content: unknown): unknown {
+  return Array.isArray(content) ? content.filter((block) => !isToolResultBlock(block)) : content
 }
 
 export function addPreviewContent(
   accumulator: SessionAccumulator,
   role: AiVaultSessionPreviewMessage['role'],
   content: unknown,
-  timestamp?: unknown
+  timestamp?: unknown,
+  options?: { excludeFromPromptHistory?: boolean }
 ): void {
+  const excludeFromPromptHistory =
+    options?.excludeFromPromptHistory === true || (role === 'user' && isToolResultContent(content))
   addPreviewMessage(accumulator, {
     role,
     text: extractPreviewContentText(content),
-    timestamp
+    timestamp,
+    fullPromptText:
+      role === 'user' && !excludeFromPromptHistory
+        ? extractUserPromptText(stripToolResultBlocks(content))
+        : undefined,
+    excludeFromPromptHistory
   })
 }
 

--- a/src/main/ai-vault/session-scanner-primary-parsers.ts
+++ b/src/main/ai-vault/session-scanner-primary-parsers.ts
@@ -11,6 +11,7 @@ import type {
 import {
   accumulatorFoldResumeState,
   addPreviewContent,
+  cloneSessionAccumulator,
   createAccumulator,
   finalizeSession,
   sessionIdFromFileName,
@@ -60,10 +61,10 @@ export function cloneClaudeSessionParseState(
   state: ClaudeSessionParseState
 ): ClaudeSessionParseState {
   return {
-    accumulator: {
-      ...state.accumulator,
-      previewMessages: [...state.accumulator.previewMessages]
-    },
+    // Use the shared clone so every accumulator array (previewMessages AND
+    // userPrompts) is deep-copied; a partial/failed resume must not mutate the
+    // cached state's arrays.
+    accumulator: cloneSessionAccumulator(state.accumulator),
     metaTitle: state.metaTitle,
     generatedTitle: state.generatedTitle,
     firstUserTitle: state.firstUserTitle
@@ -105,7 +106,11 @@ export function consumeClaudeSessionLine(state: ClaudeSessionParseState, line: s
   if (record.type === 'user') {
     accumulator.messageCount++
     const title = extractMessageText(record.message)
-    addPreviewContent(accumulator, 'user', asRecord(record.message)?.content, record.timestamp)
+    // Meta records are injected context (e.g. the local-command caveat), not the
+    // user's typed prompt, so keep them out of Prompt History.
+    addPreviewContent(accumulator, 'user', asRecord(record.message)?.content, record.timestamp, {
+      excludeFromPromptHistory: record.isMeta === true
+    })
     if (title) {
       // Meta prompts (injected context) only seed the last-resort title.
       if (record.isMeta === true) {

--- a/src/main/ai-vault/session-scanner-text-normalization.ts
+++ b/src/main/ai-vault/session-scanner-text-normalization.ts
@@ -1,5 +1,8 @@
 const SESSION_TITLE_TEXT_LIMIT = 96
 const SESSION_PREVIEW_TEXT_LIMIT = 220
+// Prompt History keeps far more than the 220-char preview so a copied prompt is
+// usable, but still bounds a single record.
+const USER_PROMPT_TEXT_LIMIT = 4000
 const ELLIPSIS = '...'
 const HIDDEN_BLOCK_CLOSE_SCAN_LIMIT = 256 * 1024
 const HIDDEN_BLOCK_OPEN_TAG_SCAN_LIMIT = 512
@@ -40,6 +43,16 @@ export function extractPreviewContentText(value: unknown): string | null {
 
 export function normalizePreviewText(value: string): string | null {
   return finalizeNormalizedText(normalizeStringText(value, SESSION_PREVIEW_TEXT_LIMIT))
+}
+
+// Full-fidelity user-prompt text for Prompt History (message content form).
+export function extractUserPromptText(value: unknown): string | null {
+  return normalizeContentText(value, USER_PROMPT_TEXT_LIMIT)
+}
+
+// Full-fidelity user-prompt text for Prompt History (already-extracted string).
+export function normalizeUserPromptText(value: string): string | null {
+  return finalizeNormalizedText(normalizeStringText(value, USER_PROMPT_TEXT_LIMIT))
 }
 
 function normalizeContentText(value: unknown, limit: number): string | null {

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -2,7 +2,8 @@ import type { AiVaultAgent } from '../../shared/ai-vault-types'
 import type {
   AiVaultScanIssue,
   AiVaultSession,
-  AiVaultSessionPreviewMessage
+  AiVaultSessionPreviewMessage,
+  AiVaultUserPrompt
 } from '../../shared/ai-vault-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
 
@@ -100,6 +101,7 @@ export type SessionAccumulator = {
   messageCount: number
   totalTokens: number
   previewMessages: AiVaultSessionPreviewMessage[]
+  userPrompts: AiVaultUserPrompt[]
   latestTimestampMs: number
 }
 

--- a/src/main/ai-vault/session-scanner-user-prompts.test.ts
+++ b/src/main/ai-vault/session-scanner-user-prompts.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addPreviewContent,
+  addPreviewMessage,
+  cloneSessionAccumulator,
+  createAccumulator,
+  finalizeSession
+} from './session-scanner-accumulator'
+
+function makeAccumulator() {
+  return createAccumulator({
+    agent: 'claude',
+    file: { path: '/tmp/session.jsonl', mtimeMs: 0, modifiedAt: new Date(0).toISOString() },
+    sessionId: 'session-1'
+  })
+}
+
+describe('session accumulator user prompts', () => {
+  it('retains every user prompt while the preview stays capped at 5 messages', () => {
+    const accumulator = makeAccumulator()
+    for (let index = 1; index <= 8; index += 1) {
+      addPreviewMessage(accumulator, { role: 'user', text: `prompt ${index}` })
+      addPreviewMessage(accumulator, { role: 'assistant', text: `reply ${index}` })
+    }
+    expect(accumulator.previewMessages.length).toBe(5)
+    expect(accumulator.userPrompts.map((prompt) => prompt.text)).toEqual([
+      'prompt 1',
+      'prompt 2',
+      'prompt 3',
+      'prompt 4',
+      'prompt 5',
+      'prompt 6',
+      'prompt 7',
+      'prompt 8'
+    ])
+    const session = finalizeSession(accumulator, 'darwin')
+    expect(session?.userPrompts?.length).toBe(8)
+  })
+
+  it('records only non-blank user messages', () => {
+    const accumulator = makeAccumulator()
+    addPreviewMessage(accumulator, { role: 'assistant', text: 'hi' })
+    addPreviewMessage(accumulator, { role: 'user', text: '   ' })
+    addPreviewMessage(accumulator, { role: 'user', text: 'real prompt' })
+    expect(accumulator.userPrompts.map((prompt) => prompt.text)).toEqual(['real prompt'])
+  })
+
+  it('deep-copies userPrompts when cloning so a cached snapshot cannot be mutated', () => {
+    const accumulator = makeAccumulator()
+    addPreviewMessage(accumulator, { role: 'user', text: 'a' })
+    const clone = cloneSessionAccumulator(accumulator)
+    addPreviewMessage(accumulator, { role: 'user', text: 'b' })
+    expect(clone.userPrompts.map((prompt) => prompt.text)).toEqual(['a'])
+    expect(accumulator.userPrompts.map((prompt) => prompt.text)).toEqual(['a', 'b'])
+  })
+
+  it('excludes tool_result records (stored as role:user) from user prompts', () => {
+    const accumulator = makeAccumulator()
+    // A real typed prompt (string content) is captured…
+    addPreviewContent(accumulator, 'user', 'please refactor this', 1)
+    // …but a Claude tool_result (array of tool_result blocks) is not.
+    addPreviewContent(accumulator, 'user', [{ type: 'tool_result', content: 'command stdout' }], 2)
+    expect(accumulator.userPrompts.map((prompt) => prompt.text)).toEqual(['please refactor this'])
+    // The tool result still appears in the rolling preview.
+    expect(accumulator.previewMessages.some((message) => message.text === 'command stdout')).toBe(
+      true
+    )
+  })
+
+  it('keeps the full prompt text (not the 220-char preview truncation)', () => {
+    const accumulator = makeAccumulator()
+    const longPrompt = 'x'.repeat(600)
+    addPreviewContent(accumulator, 'user', longPrompt, 1)
+    expect(accumulator.userPrompts[0]?.text.length).toBe(600)
+    // The preview is still truncated with an ellipsis.
+    expect(accumulator.previewMessages[0]?.text.endsWith('...')).toBe(true)
+    expect(accumulator.previewMessages[0]?.text.length).toBeLessThanOrEqual(220)
+  })
+
+  it('drops tool_result blocks from a mixed user turn so tool output does not leak', () => {
+    const accumulator = makeAccumulator()
+    addPreviewContent(
+      accumulator,
+      'user',
+      [
+        { type: 'tool_result', content: 'big command stdout' },
+        { type: 'text', text: 'now do X' }
+      ],
+      1
+    )
+    expect(accumulator.userPrompts.map((prompt) => prompt.text)).toEqual(['now do X'])
+  })
+
+  it('caps retained user prompts and evicts the oldest', () => {
+    const accumulator = makeAccumulator()
+    for (let index = 1; index <= 45; index += 1) {
+      addPreviewMessage(accumulator, { role: 'user', text: `p${index}` })
+    }
+    expect(accumulator.userPrompts.length).toBe(25)
+    expect(accumulator.userPrompts[0]?.text).toBe('p21')
+    expect(accumulator.userPrompts.at(-1)?.text).toBe('p45')
+  })
+})

--- a/src/main/ai-vault/session-scanner-values.ts
+++ b/src/main/ai-vault/session-scanner-values.ts
@@ -57,8 +57,10 @@ export {
   extractContentText,
   extractMessageText,
   extractPreviewContentText,
+  extractUserPromptText,
   normalizePreviewText,
-  normalizeTitleText
+  normalizeTitleText,
+  normalizeUserPromptText
 } from './session-scanner-text-normalization'
 
 export function extractGitBranch(value: unknown): string | null {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -805,6 +805,7 @@ function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['rightSide
     tab === 'explorer' ||
     tab === 'search' ||
     tab === 'vault' ||
+    tab === 'prompts' ||
     tab === 'workspaces' ||
     tab === 'source-control' ||
     tab === 'checks' ||

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -166,7 +166,7 @@ const UiUpdate = z
     sidebarWidth: z.number().finite().optional(),
     rightSidebarOpen: z.boolean().optional(),
     rightSidebarTab: z
-      .enum(['explorer', 'search', 'vault', 'source-control', 'checks', 'ports'])
+      .enum(['explorer', 'search', 'vault', 'prompts', 'source-control', 'checks', 'ports'])
       .optional(),
     rightSidebarExplorerView: z.enum(['files', 'search']).optional(),
     rightSidebarWidth: z.number().finite().optional(),

--- a/src/renderer/src/components/right-sidebar/PromptHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PromptHistoryPanel.tsx
@@ -1,0 +1,235 @@
+import { useMemo, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { Copy, MessageSquareText, RefreshCw, Search } from 'lucide-react'
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { useActiveWorktree, useActiveWorktreeId, useAllWorktrees } from '@/store/selectors'
+import { translate } from '@/i18n/i18n'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import { AI_VAULT_AGENT_LABELS, type AiVaultAgent } from '../../../../shared/ai-vault-types'
+import { deriveAiVaultWorkspaceScopePaths } from './ai-vault-scope-paths'
+import { isAiVaultSessionInWorkspacePath } from './ai-vault-session-filters'
+import { useAiVaultExecutionHostScope } from './ai-vault-host-scope'
+import { useAiVaultSessionRefresh } from './ai-vault-session-refresh'
+import { SessionTime } from './AiVaultSessionDetails'
+
+// Bound the DOM: even with the 500-session scan cap × up to 40 prompts each, we
+// only ever render the most recent slice (search narrows further).
+const MAX_VISIBLE_PROMPTS = 500
+
+type PromptHistoryRow = {
+  key: string
+  text: string
+  agent: AiVaultAgent
+  sessionTitle: string
+  cwd: string | null
+  timestamp: string | null
+  sortMs: number
+}
+
+export default function PromptHistoryPanel(): React.JSX.Element {
+  const activeWorktreeId = useActiveWorktreeId()
+  const activeWorktree = useActiveWorktree()
+  const allWorktrees = useAllWorktrees()
+  const resumeTargetState = useAppStore(
+    useShallow((state) => ({
+      folderWorkspaces: state.folderWorkspaces,
+      projectGroups: state.projectGroups,
+      repos: state.repos,
+      worktreesByRepo: state.worktreesByRepo
+    }))
+  )
+  const [query, setQuery] = useState('')
+  const [scope, setScope] = useState<'workspace' | 'all'>('workspace')
+
+  // Match the AI Vault: scope to the active worktree's execution host (so an SSH
+  // worktree scans its remote sessions instead of showing an empty local list).
+  const { executionHostScope } = useAiVaultExecutionHostScope({
+    activeWorktreeId: activeWorktreeId ?? null,
+    resumeTargetState
+  })
+  // Active worktree paths (incl. prior same-repo worktrees). Sent to the scanner
+  // so scoped views surface in-scope sessions older than the global recency cap.
+  const workspaceScopePaths = useMemo(
+    () => deriveAiVaultWorkspaceScopePaths(activeWorktree ?? null, allWorktrees),
+    [activeWorktree, allWorktrees]
+  )
+
+  const { error, loading, refresh, sessions } = useAiVaultSessionRefresh(
+    workspaceScopePaths,
+    executionHostScope
+  )
+
+  const rows = useMemo<PromptHistoryRow[]>(() => {
+    const collected: PromptHistoryRow[] = []
+    for (const session of sessions) {
+      const sessionTime = session.updatedAt ?? session.modifiedAt
+      for (const [index, prompt] of (session.userPrompts ?? []).entries()) {
+        const timestamp = prompt.timestamp ?? sessionTime
+        collected.push({
+          key: `${session.id}:${index}`,
+          text: prompt.text,
+          agent: session.agent,
+          sessionTitle: session.title,
+          cwd: session.cwd,
+          timestamp,
+          sortMs: timestamp ? Date.parse(timestamp) : 0
+        })
+      }
+    }
+    collected.sort((left, right) => (right.sortMs || 0) - (left.sortMs || 0))
+    return collected
+  }, [sessions])
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    const out: PromptHistoryRow[] = []
+    for (const row of rows) {
+      if (scope === 'workspace') {
+        // Fail closed: with no workspace paths (no active worktree) show nothing
+        // rather than every workspace's prompts.
+        if (
+          !workspaceScopePaths.some((path) => isAiVaultSessionInWorkspacePath(path, row.cwd ?? ''))
+        ) {
+          continue
+        }
+      }
+      if (needle && !row.text.toLowerCase().includes(needle)) {
+        continue
+      }
+      out.push(row)
+      if (out.length >= MAX_VISIBLE_PROMPTS) {
+        break
+      }
+    }
+    return out
+  }, [rows, query, scope, workspaceScopePaths])
+
+  const copyPrompt = (text: string): void => {
+    void window.api.ui
+      .writeClipboardText(text)
+      .then(() => {
+        toast.success(
+          translate('auto.components.right.sidebar.PromptHistoryPanel.copied', 'Prompt copied')
+        )
+      })
+      .catch(() => {
+        toast.error(
+          translate(
+            'auto.components.right.sidebar.PromptHistoryPanel.copyFailed',
+            'Could not copy the prompt'
+          )
+        )
+      })
+  }
+
+  const isInitialLoading = loading && rows.length === 0
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-col gap-2 border-b border-border p-2">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={translate(
+              'auto.components.right.sidebar.PromptHistoryPanel.searchPlaceholder',
+              'Search prompts…'
+            )}
+            className="h-7 pl-7 text-xs"
+          />
+        </div>
+        <div className="flex items-center gap-1">
+          {(['workspace', 'all'] as const).map((value) => (
+            <Button
+              key={value}
+              type="button"
+              size="xs"
+              variant={scope === value ? 'secondary' : 'ghost'}
+              onClick={() => setScope(value)}
+            >
+              {value === 'workspace'
+                ? translate(
+                    'auto.components.right.sidebar.PromptHistoryPanel.scopeWorkspace',
+                    'This workspace'
+                  )
+                : translate('auto.components.right.sidebar.PromptHistoryPanel.scopeAll', 'All')}
+            </Button>
+          ))}
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            className="ml-auto"
+            aria-label={translate(
+              'auto.components.right.sidebar.PromptHistoryPanel.refresh',
+              'Refresh'
+            )}
+            onClick={() => void refresh({ force: true })}
+          >
+            <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
+          </Button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
+        {error ? (
+          <p className="p-3 text-xs text-destructive">{error}</p>
+        ) : isInitialLoading ? (
+          <p className="p-3 text-xs text-muted-foreground">
+            {translate('auto.components.right.sidebar.PromptHistoryPanel.loading', 'Loading…')}
+          </p>
+        ) : filtered.length === 0 ? (
+          <p className="p-3 text-xs text-muted-foreground">
+            {translate(
+              'auto.components.right.sidebar.PromptHistoryPanel.empty',
+              'No prompts found for this scope yet.'
+            )}
+          </p>
+        ) : (
+          <ul className="flex flex-col">
+            {filtered.map((row) => (
+              <li
+                key={row.key}
+                className="group flex flex-col gap-1 border-b border-border/60 px-3 py-2 hover:bg-accent/40"
+              >
+                <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                  <span className="font-medium">{AI_VAULT_AGENT_LABELS[row.agent]}</span>
+                  <span>·</span>
+                  <SessionTime value={row.timestamp ?? ''} />
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    className="ml-auto opacity-0 group-hover:opacity-100"
+                    aria-label={translate(
+                      'auto.components.right.sidebar.PromptHistoryPanel.copy',
+                      'Copy prompt'
+                    )}
+                    onClick={() => copyPrompt(row.text)}
+                  >
+                    <Copy className="size-3" />
+                  </Button>
+                </div>
+                <p className="line-clamp-3 whitespace-pre-wrap break-words text-xs text-foreground">
+                  {row.text}
+                </p>
+                <span className="truncate text-[11px] text-muted-foreground">
+                  {row.sessionTitle}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5 border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
+        <MessageSquareText className="size-3" />
+        <span>{filtered.length}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.ts
@@ -235,7 +235,10 @@ function getFolderGroupKey(pathValue: string | null): string {
   return pathValue ? normalizeRuntimePathSeparators(pathValue).toLowerCase() : 'unknown'
 }
 
-function isAiVaultSessionInWorkspacePath(workspacePath: string, sessionCwd: string): boolean {
+export function isAiVaultSessionInWorkspacePath(
+  workspacePath: string,
+  sessionCwd: string
+): boolean {
   if (isPathInsideOrEqual(workspacePath, sessionCwd)) {
     return true
   }

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,6 +1,14 @@
 /* eslint-disable max-lines -- Why: the right sidebar owns activity-bar visibility, routing, and resize behavior as one interaction surface; splitting the tab table away would make hidden-tab fallbacks harder to audit. */
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Plug, Files, GitBranch, ListChecks, PanelRight, Workflow } from 'lucide-react'
+import {
+  Plug,
+  Files,
+  GitBranch,
+  ListChecks,
+  MessageSquareText,
+  PanelRight,
+  Workflow
+} from 'lucide-react'
 import { useAppStore } from '@/store'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 import { useRepoById } from '@/store/selectors'
@@ -97,6 +105,12 @@ function RightSidebarInner(): React.JSX.Element {
         id: 'vault',
         icon: AgentSessionHistoryIcon,
         title: translate('auto.components.right.sidebar.index.aiVaultSessionHistory', 'Agents'),
+        shortcut: ''
+      },
+      {
+        id: 'prompts',
+        icon: MessageSquareText,
+        title: translate('auto.components.right.sidebar.index.promptHistory', 'Prompt History'),
         shortcut: ''
       },
       {

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -7,6 +7,7 @@ const SourceControl = lazy(() => import('./SourceControl'))
 const ChecksPanel = lazy(() => import('./ChecksPanel'))
 const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
+const PromptHistoryPanel = lazy(() => import('./PromptHistoryPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
 
@@ -32,6 +33,7 @@ export function RightSidebarPanelContent({
           <PortsPanel isVisible={rightSidebarOpen && effectiveTab === 'ports'} />
         )}
         {effectiveTab === 'vault' && <AiVaultPanel />}
+        {effectiveTab === 'prompts' && <PromptHistoryPanel />}
         {effectiveTab === 'workspaces' && <FolderWorkspaceWorktreesPanel />}
         {effectiveTab === 'pr-checks' && (
           <FolderWorkspacePrChecksPanel

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9465,7 +9465,8 @@
             "fc3095d2ed": "explorer",
             "aiVaultSessionHistory": "Agents",
             "folderWorkspaces": "Attached worktrees",
-            "parentPrChecks": "PR Checks"
+            "parentPrChecks": "PR Checks",
+            "promptHistory": "Prompt History"
           },
           "right": {
             "panel": {
@@ -9816,6 +9817,17 @@
             "archivedJumpUnavailable": "This session is in an archived worktree.",
             "noActiveWorktreeMatch": "No active worktree matches this session.",
             "noActiveWorktreeTarget": "No active worktree is available."
+          },
+          "PromptHistoryPanel": {
+            "copied": "Prompt copied",
+            "searchPlaceholder": "Search prompts…",
+            "scopeWorkspace": "This workspace",
+            "scopeAll": "All",
+            "refresh": "Refresh",
+            "empty": "No prompts found for this scope yet.",
+            "copy": "Copy prompt",
+            "copyFailed": "Could not copy the prompt",
+            "loading": "Loading…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9465,7 +9465,8 @@
             "fc3095d2ed": "explorador",
             "aiVaultSessionHistory": "Agentes",
             "folderWorkspaces": "Worktrees adjuntos",
-            "parentPrChecks": "Checks de PR"
+            "parentPrChecks": "Checks de PR",
+            "promptHistory": "Historial de prompts"
           },
           "right": {
             "panel": {
@@ -9816,6 +9817,17 @@
             "archivedJumpUnavailable": "Esta sesión está en un worktree archivado.",
             "noActiveWorktreeMatch": "Ningún worktree activo coincide con esta sesión.",
             "noActiveWorktreeTarget": "No hay ningún worktree activo disponible."
+          },
+          "PromptHistoryPanel": {
+            "copied": "Prompt copiado",
+            "searchPlaceholder": "Buscar prompts…",
+            "scopeWorkspace": "Este espacio",
+            "scopeAll": "Todos",
+            "refresh": "Actualizar",
+            "empty": "Aún no hay prompts para este ámbito.",
+            "copy": "Copiar prompt",
+            "copyFailed": "No se pudo copiar el prompt",
+            "loading": "Cargando…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9465,7 +9465,8 @@
             "fc3095d2ed": "エクスプローラ",
             "aiVaultSessionHistory": "エージェント",
             "folderWorkspaces": "添付ワークツリー",
-            "parentPrChecks": "PR チェック"
+            "parentPrChecks": "PR チェック",
+            "promptHistory": "プロンプト履歴"
           },
           "right": {
             "panel": {
@@ -9816,6 +9817,17 @@
             "archivedJumpUnavailable": "このセッションはアーカイブされたワークツリーにあります。",
             "noActiveWorktreeMatch": "このセッションに一致するアクティブなワークツリーはありません。",
             "noActiveWorktreeTarget": "利用可能なアクティブなワークツリーはありません。"
+          },
+          "PromptHistoryPanel": {
+            "copied": "プロンプトをコピーしました",
+            "searchPlaceholder": "プロンプトを検索…",
+            "scopeWorkspace": "このワークスペース",
+            "scopeAll": "すべて",
+            "refresh": "更新",
+            "empty": "この範囲のプロンプトはまだありません。",
+            "copy": "プロンプトをコピー",
+            "copyFailed": "プロンプトをコピーできませんでした",
+            "loading": "読み込み中…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9465,7 +9465,8 @@
             "fc3095d2ed": "탐색기",
             "aiVaultSessionHistory": "에이전트",
             "folderWorkspaces": "연결된 워크트리",
-            "parentPrChecks": "PR 검사"
+            "parentPrChecks": "PR 검사",
+            "promptHistory": "프롬프트 기록"
           },
           "right": {
             "panel": {
@@ -9816,6 +9817,17 @@
             "archivedJumpUnavailable": "이 세션은 보관된 작업 트리에 있습니다.",
             "noActiveWorktreeMatch": "이 세션과 일치하는 활성 작업 트리가 없습니다.",
             "noActiveWorktreeTarget": "사용 가능한 활성 작업 트리가 없습니다."
+          },
+          "PromptHistoryPanel": {
+            "copied": "프롬프트 복사됨",
+            "searchPlaceholder": "프롬프트 검색…",
+            "scopeWorkspace": "이 워크스페이스",
+            "scopeAll": "전체",
+            "refresh": "새로고침",
+            "empty": "이 범위에 아직 프롬프트가 없습니다.",
+            "copy": "프롬프트 복사",
+            "copyFailed": "프롬프트를 복사하지 못했습니다",
+            "loading": "불러오는 중…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9465,7 +9465,8 @@
             "fc3095d2ed": "资源管理器",
             "aiVaultSessionHistory": "智能体",
             "folderWorkspaces": "已附加的工作树",
-            "parentPrChecks": "PR 检查"
+            "parentPrChecks": "PR 检查",
+            "promptHistory": "提示历史"
           },
           "right": {
             "panel": {
@@ -9816,6 +9817,17 @@
             "archivedJumpUnavailable": "此会话位于已归档的工作树中。",
             "noActiveWorktreeMatch": "没有与此会话匹配的活动工作树。",
             "noActiveWorktreeTarget": "没有可用的活动工作树。"
+          },
+          "PromptHistoryPanel": {
+            "copied": "已复制提示",
+            "searchPlaceholder": "搜索提示…",
+            "scopeWorkspace": "此工作区",
+            "scopeAll": "全部",
+            "refresh": "刷新",
+            "empty": "此范围内暂无提示。",
+            "copy": "复制提示",
+            "copyFailed": "无法复制提示",
+            "loading": "加载中…"
           }
         }
       },

--- a/src/renderer/src/store/right-sidebar-route.test.ts
+++ b/src/renderer/src/store/right-sidebar-route.test.ts
@@ -9,6 +9,13 @@ describe('normalizeRightSidebarRoute', () => {
     })
   })
 
+  it('preserves the Prompt History route', () => {
+    expect(normalizeRightSidebarRoute('prompts')).toEqual({
+      rightSidebarTab: 'prompts',
+      rightSidebarExplorerView: 'files'
+    })
+  })
+
   it('still normalizes invalid tabs to Explorer files', () => {
     expect(normalizeRightSidebarRoute('missing')).toEqual({
       rightSidebarTab: 'explorer',

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -20,6 +20,7 @@ export function normalizeRightSidebarRoute(
   if (
     tab === 'explorer' ||
     tab === 'vault' ||
+    tab === 'prompts' ||
     tab === 'workspaces' ||
     tab === 'pr-checks' ||
     tab === 'source-control' ||

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1950,6 +1950,7 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
       if (
         tab === 'explorer' ||
         tab === 'vault' ||
+        tab === 'prompts' ||
         tab === 'workspaces' ||
         tab === 'source-control' ||
         tab === 'checks' ||

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -54,6 +54,14 @@ export type AiVaultSessionPreviewMessage = {
   timestamp: string | null
 }
 
+// A single user-authored prompt extracted from a session transcript. Powers the
+// Prompt History panel; kept separate from the 5-message rolling preview so it
+// can retain the full run of prompts without changing the preview behavior.
+export type AiVaultUserPrompt = {
+  text: string
+  timestamp: string | null
+}
+
 export type AiVaultSession = {
   id: string
   executionHostId: ExecutionHostId
@@ -72,6 +80,9 @@ export type AiVaultSession = {
   messageCount: number
   totalTokens: number
   previewMessages: AiVaultSessionPreviewMessage[]
+  // The user's prompts in this session (oldest→newest, capped). Optional so
+  // session builders that don't extract them (e.g. remote/SSH scans) can omit it.
+  userPrompts?: AiVaultUserPrompt[]
   resumeCommand: string
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3163,6 +3163,7 @@ export type RightSidebarTab =
   | 'explorer'
   | 'search'
   | 'vault'
+  | 'prompts'
   | 'workspaces'
   | 'pr-checks'
   | 'source-control'


### PR DESCRIPTION
## Summary

Adds an opt-in **Prompt History** tab in the right sidebar that lists the prompts you've sent to agents, so you can re-locate and reuse them — the missing "where was that prompt I wrote?" view.

It reads from the agent transcripts the **AI Vault already scans** on disk, so there's no new capture path: every session now also retains the full run of the user's typed prompts.

- **Search** across your prompts + **This workspace / All** scope.
- **Copy** a prompt back to the clipboard.
- Per-agent label + relative time; grouped newest-first.

## How it works

- `AiVaultSession` gains an optional `userPrompts` field, populated in the shared session accumulator (`addPreviewMessage`/`addPreviewContent`). One capture point covers every agent the AI Vault parses.
- **Only genuine typed prompts** are kept: tool-result records (Claude stores these as `role:'user'`) are excluded, mixed turns strip their tool-result blocks, and injected/meta records are skipped.
- **Full fidelity**: prompts keep up to 4000 chars (not the 220-char preview) so a copied prompt is actually reusable; capped at 25 per session to bound payload/memory.
- The clone used by the resumable parse cache deep-copies `userPrompts`, so incremental re-scans can't corrupt cached state.
- The panel reuses the AI Vault's workspace matching (SSH host scoping + WSL path handling) and its scope-path cap-bypass, so scoped views surface in-scope sessions older than the recency cap.

New right-sidebar tab wired through the tab registry, the route normalizer, the persisted-UI validators, and the runtime `ui.set` schema; localized across en/es/ja/ko/zh.

## Scope / known limitations

- **Read-only, on demand**, off by default. Works for **local and SSH** worktrees and the agents the AI Vault parses.
- v1 action is **Copy**; "send into the active agent terminal" is a natural follow-up.
- OpenCode sessions are bounded by the existing SQLite preview query (5 newest), so fewer prompts are retained for OpenCode than for JSONL agents.

## Testing

- Accumulator unit tests: full-run retention beyond the 5-message preview, tool-result exclusion (pure + mixed), full-text (not truncated), deep-copy on clone, cap/eviction.
- Route normalizer regression test for the new tab.
- `typecheck`, `oxlint`, localization catalog + coverage, the full AI Vault suite, and the electron-vite + web builds all pass.
