### PR TITLE
fix(cli): strip ELECTRON_RUN_AS_NODE from spawned claude env

### DIFF
--- a/src/cli/handlers/core.ts
+++ b/src/cli/handlers/core.ts
@@ -2,10 +2,17 @@ import { spawn } from 'node:child_process'
 import type { CommandHandler } from '../dispatch'
 import { formatCliStatus, formatStatus, printResult } from '../format'
 import { RuntimeClientError, serveOrcaApp } from '../runtime-client'
+import { stripElectronRunAsNode } from '../runtime/launch'
 
 function envRecord(): Record<string, string> {
+  // Why: the `orca` CLI launcher sets ELECTRON_RUN_AS_NODE=1 so Orca's Electron
+  // binary runs as plain Node for the CLI itself (cli-installer.ts). That flag
+  // must not leak into the `claude` child or nested Electron commands run as
+  // plain Node. Strip it here so both the prepareLaunch request and the spawn
+  // build a clean base env. Sibling of #2414's daemon→PTY fix (#7768).
+  const env = stripElectronRunAsNode(process.env)
   return Object.fromEntries(
-    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
+    Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined)
   )
 }
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -317,6 +317,7 @@ describe('orca cli worktree awareness', () => {
   const originalEnvironment = process.env.ORCA_ENVIRONMENT
   const originalWorkspaceId = process.env.ORCA_WORKSPACE_ID
   const originalWorktreeId = process.env.ORCA_WORKTREE_ID
+  const originalElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE
 
   beforeEach(() => {
     callMock.mockReset()
@@ -387,6 +388,11 @@ describe('orca cli worktree awareness', () => {
       delete process.env.ORCA_WORKTREE_ID
     } else {
       process.env.ORCA_WORKTREE_ID = originalWorktreeId
+    }
+    if (originalElectronRunAsNode === undefined) {
+      delete process.env.ELECTRON_RUN_AS_NODE
+    } else {
+      process.env.ELECTRON_RUN_AS_NODE = originalElectronRunAsNode
     }
   })
 
@@ -467,6 +473,40 @@ describe('orca cli worktree awareness', () => {
           TMUX_PANE: '%1'
         })
       })
+    }
+  )
+
+  // Why: the `orca` CLI launcher re-injects ELECTRON_RUN_AS_NODE=1 so the CLI
+  // itself runs as plain Node. If that flag leaks into the spawned `claude`
+  // child, any nested Electron command (e.g. `pnpm dev`) runs as plain Node and
+  // never opens a window. Regression for #7768, sibling of #2414's daemon→PTY fix.
+  it.skipIf(process.platform === 'win32')(
+    'does not leak ELECTRON_RUN_AS_NODE into the spawned claude process',
+    async () => {
+      process.env.ORCA_PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
+      process.env.ELECTRON_RUN_AS_NODE = '1'
+      queueFixtures(
+        callMock,
+        okFixture('req_agent_teams_prepare', {
+          launch: {
+            env: {
+              CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+              TMUX: '/tmp/orca-claude-agent-teams/team-1,0,1',
+              TMUX_PANE: '%1',
+              PATH: '/tmp/orca-shim:/usr/bin'
+            }
+          }
+        })
+      )
+
+      await main(['claude-teams'], '/tmp/repo')
+
+      const [, , { env }] = spawnMock.mock.calls[0] as unknown as [
+        string,
+        string[],
+        { env: Record<string, string> }
+      ]
+      expect(env).not.toHaveProperty('ELECTRON_RUN_AS_NODE')
     }
   )
 

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -232,7 +232,12 @@ function resolveForegroundOrcaExecutable(): string {
   )
 }
 
-function stripElectronRunAsNode(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+// Why: ELECTRON_RUN_AS_NODE is set by the `orca` CLI launcher so Orca's Electron
+// binary runs as plain Node for the CLI itself (see cli-installer.ts). That flag
+// must not leak into user-facing children (claude, the Orca app re-exec, serve)
+// or nested Electron commands run as plain Node. Exported so the claude-teams
+// handler reuses the same strip as the open/serve paths (#7768, sibling of #2414).
+export function stripElectronRunAsNode(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const next = { ...env }
   delete next.ELECTRON_RUN_AS_NODE
   return next


### PR DESCRIPTION
## Summary

- `ELECTRON_RUN_AS_NODE=1` was leaking from the `orca` CLI into the `claude` process spawned by `orca claude-teams`, and from there into every child process Claude launches (e.g. `pnpm dev` starting a separate Electron app). The leaked flag makes any nested Electron binary run as plain Node — no GPU init, no window — so nested Electron dev servers silently fail to open a window.
- Root cause: the `orca` CLI launcher re-injects `ELECTRON_RUN_AS_NODE=1` so Orca's Electron binary runs as plain Node for the CLI itself (`cli-installer.ts:905`). That flag is correct for the CLI process, but the `claude-teams` handler built the `claude` child env by spreading `process.env` verbatim via `envRecord()` and never stripped it (`src/cli/handlers/core.ts`). `agentTeams.prepareLaunch` returns an explicitly-enumerated env that does not include the flag, so it never overwrote the inherited one.
- Fix: export the existing `stripElectronRunAsNode` helper from `src/cli/runtime/launch.ts` (already used on the open/serve paths) and apply it inside `envRecord()`, so both the `prepareLaunch` request env and the `claude` spawn env are cleaned. The strip is unconditional — `claude` is a user-facing Node CLI, not an Electron-as-Node runtime, so the CLI has no legitimate reason to seed this flag into it.
- This is the sibling hop of the already-merged daemon→PTY fix (#2414 / #2415), applied at the `orca` CLI → `claude` boundary. Same shape, same unconditional-delete approach, same regression-test shape.

Fixes #7768.

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck:node` — clean
- [x] `pnpm exec oxlint src/cli/handlers/core.ts src/cli/runtime/launch.ts src/cli/index.test.ts` — clean
- [x] `pnpm check:max-lines-ratchet` — `OK — 355 grandfathered suppression(s), no new bypasses`
- [x] Added a regression test in `src/cli/index.test.ts` ("does not leak ELECTRON_RUN_AS_NODE into the spawned claude process") that sets `ELECTRON_RUN_AS_NODE=1` in `process.env`, runs `orca claude-teams`, and asserts the env handed to the spawned `claude` does not have the `ELECTRON_RUN_AS_NODE` property. Mirrors the shape of `src/main/daemon/pty-subprocess.test.ts:823` ("does not inherit ELECTRON_RUN_AS_NODE from the daemon process env").
- [x] Red/green verified: the new test **fails before the fix** (`AssertionError: expected { …(195) } to not have property "ELECTRON_RUN_AS_NODE"`, received `"1"`) and **passes after** the fix. This was checked by temporarily reverting the `envRecord()` strip, running the test, and restoring.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/cli/index.test.ts -t "ELECTRON_RUN_AS_NODE"` — 1 passed.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/cli/index.test.ts -t "Claude Agent Teams"` — existing claude-teams tests still pass (2 passed).
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/cli/` — all CLI tests pass (28 files, 374 tests).
- [x] `pnpm run build:desktop` — `✓ built in 25.32s` (typecheck + relay + cli + electron-vite + web). Confirms the TS changes (`launch.ts` export, `core.ts` import + `envRecord()` change) compile cleanly through the full desktop build.
- [x] `pnpm test` (full suite) — CLI suite fully green. 26 renderer-suite failures observed are pre-existing and environment-related: `ExperimentalWarning: localStorage is not available` from running on Node v26 instead of the project's pinned Node 24 (`package.json` engines `"node": "24"`). All failures are under `src/renderer/` with zero overlap with this PR's `src/cli/` changes; CI (on Node 24) does not reproduce them.

`build:native` (native module recompile) not run locally — it requires a C++ toolchain and compiles platform native modules (node-pty, etc.) with no input from this PR's pure-TS changes; `build:desktop` above already exercises the full TS pipeline these changes touch.

## AI Review Report

Reviewed with an AI coding agent (Claude Code). Risks checked:

- **Cross-platform (macOS/Linux/Windows)**: The variable has the same Electron meaning on all three platforms, and the `orca` CLI launcher re-injects it on all platforms (Unix `cli-installer.ts:905`, Windows `cli-installer.ts:927`). The strip is platform-agnostic, mirroring #2415 which was also argued as platform-agnostic. Windows is unaffected by the `it.skipIf(process.platform === 'win32')` guard on the regression test, which matches the existing claude-teams tests' platform skip convention (claude-teams native panes are not supported on Windows — see `core.ts` `claude-teams` handler `unsupported_platform` check).
- **SSH/remote compatibility**: Change is limited to the CLI handler that spawns the local `claude` binary. It does not touch SSH PTY relay, remote env handling, or host-local path injection. `stripElectronRunAsNode` only deletes one well-known Electron-internal key; it does not add or assume any local path.
- **Agent/integration compatibility**: `claude` is a Node CLI; it has no use for `ELECTRON_RUN_AS_NODE`. Other agents invoked through other CLI handlers are unaffected — this change is scoped to `envRecord()` inside the `claude-teams` handler's shared env builder.
- **Performance risk**: Negligible. One object spread + one delete per `envRecord()` call, called once per `orca claude-teams` invocation (not a hot path).
- **Regression risk**: The strip is additive (deleting a key that should never be present in a user-facing child env). Existing claude-teams tests confirm the rest of the env (CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, TMUX_PANE, ORCA_PANE_KEY) is unchanged.

## Security Audit

Reviewed with an AI coding agent. Findings:

- **Env leakage reduction, not a new trust boundary**: This change *removes* a leaked Electron-internal flag from a user-facing child env. It does not add a new command path, trust boundary, IPC surface, or dependency. Net security effect is positive (less parent-process env inheritance into user shells).
- **Command execution**: No change to what command is executed or how it is resolved — `claude` is still spawned via the same `spawn('claude', ...)` call with the same args. Only the env passed to it changes, and only by the removal of one key.
- **Path handling**: No path manipulation. `stripElectronRunAsNode` only deletes `ELECTRON_RUN_AS_NODE`; `PATH` and all other keys pass through unchanged.
- **Secrets/auth**: No secrets, tokens, or auth-related env touched. The `agentTeams.prepareLaunch` response env (which carries team tokens) is still merged on top of the cleaned base env, unchanged.
- **Follow-up**: None needed. The same `stripElectronRunAsNode` pattern is already sanctioned by `launch.ts` and #2415; applying it here closes the last known leakage hop for this flag.

## Notes

- Sibling of #2414 / #2415. That PR fixed the daemon→PTY hop (`removeInheritedElectronRunAsNode` in `pty-subprocess.ts`); this PR fixes the `orca` CLI→`claude` hop (`envRecord()` in `core.ts`). Together they cover both boundaries where the launcher-injected flag can escape into user-facing processes.
- The `orca` CLI launcher's `ELECTRON_RUN_AS_NODE=1` re-injection (`cli-installer.ts:905`) is intentionally left in place — it is required so Orca's Electron binary can serve as the Node runtime for the CLI. The fix is downstream of that, at the point where the CLI spawns a user-facing child.
- The regression test is skipped on Windows (`it.skipIf(process.platform === 'win32')`), matching the existing claude-teams tests, since `orca claude-teams` native panes are unsupported on Windows (`core.ts` `unsupported_platform`).
- Twitter handle: @sundevilyang