### PR TITLE
Keep your New GitHub issue draft after an accidental dismissal

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -199,6 +199,12 @@ import {
   type TaskPageRepoSourceState
 } from '@/components/task-page-cache-selectors'
 import { shouldHideTaskPageListChrome } from '@/components/task-page-list-chrome-visibility'
+import {
+  isNewIssueDraftContentful,
+  resolveNewIssueOpenSeed,
+  resolveUserRepoSwitchReset,
+  resolveVanishedNewIssueRepoReset
+} from '@/components/task-page-new-issue-draft'
 import { findTaskPageJiraIssue } from '@/components/task-page-jira-cache-selectors'
 import { getRepoBackedTaskEmptyState } from '@/components/task-page-empty-state'
 import {
@@ -4052,6 +4058,16 @@ export default function TaskPage(): React.JSX.Element {
   const [newIssueAssignees, setNewIssueAssignees] = useState<GitHubAssignableUser[]>([])
   const [newIssueSubmitting, setNewIssueSubmitting] = useState(false)
   const [newIssueRepoId, setNewIssueRepoId] = useState<string | null>(null)
+  // Why: session-only draft slice backs recovery of an in-progress issue after
+  // an accidental dismissal (outside click/Escape/Cancel) and across a Tasks
+  // view unmount. Component `useState` stays the inputs' immediate source; the
+  // store is the durable-across-remount backing. See task-page-new-issue-draft.
+  // The draft value is read imperatively at open time (getState) rather than
+  // subscribed: it's only consumed in the `+` open handler, and the write-through
+  // rewrites it on every keystroke — subscribing would re-render all of TaskPage
+  // per keystroke while the modal is open. Actions are stable refs (no churn).
+  const setNewIssueDraft = useAppStore((s) => s.setNewIssueDraft)
+  const clearNewIssueDraft = useAppStore((s) => s.clearNewIssueDraft)
 
   // Why: resolve the target repo from the user's choice, falling back to the
   // first selected repo if the chosen id drops out of the selection while the
@@ -4096,10 +4112,62 @@ export default function TaskPage(): React.JSX.Element {
     { runtimeEnvironmentId: newIssueOpen ? (newIssueRuntimeTarget?.environmentId ?? null) : null }
   )
 
+  // Why: repo-scoped labels/assignees can't cross repos. A reactive clear keyed
+  // on the derived target id can't tell a restore apart from a user switch, so
+  // it would wipe just-restored fields and corrupt the recovery draft via the
+  // write-through below. Decompose by cause instead: this guard only handles the
+  // "chosen repo vanished from the selection" case (removed/deselected). A
+  // genuine user switch clears imperatively in the repo Select's handler; a
+  // restore always seeds an in-selection repoId, so neither path fires here.
   useEffect(() => {
+    const reset = resolveVanishedNewIssueRepoReset(
+      newIssueRepoId,
+      selectedRepos.map((r) => r.id)
+    )
+    if (!reset) {
+      return
+    }
     setNewIssueLabels([])
     setNewIssueAssignees([])
-  }, [newIssueTargetRepo?.id])
+    setNewIssueRepoId(reset.repoId)
+  }, [newIssueRepoId, selectedRepos])
+
+  // Why: mirror the live fields into the session draft while the modal is open
+  // so an accidental dismissal doesn't lose input. Content-gate the write so an
+  // untouched open never pins a meaningless draft (repoId alone is not content),
+  // and clear any stale draft once the form is emptied back out.
+  useEffect(() => {
+    if (!newIssueOpen) {
+      return
+    }
+    if (
+      isNewIssueDraftContentful({
+        title: newIssueTitle,
+        body: newIssueBody,
+        labels: newIssueLabels,
+        assignees: newIssueAssignees
+      })
+    ) {
+      setNewIssueDraft({
+        title: newIssueTitle,
+        body: newIssueBody,
+        labels: newIssueLabels,
+        assignees: newIssueAssignees,
+        repoId: newIssueRepoId
+      })
+    } else {
+      clearNewIssueDraft()
+    }
+  }, [
+    newIssueOpen,
+    newIssueTitle,
+    newIssueBody,
+    newIssueLabels,
+    newIssueAssignees,
+    newIssueRepoId,
+    setNewIssueDraft,
+    clearNewIssueDraft
+  ])
 
   const [selectedLinearIssueId, setSelectedLinearIssueId] = useState<string | null>(null)
   const [selectedLinearIssueFallback, setSelectedLinearIssueFallback] =
@@ -6633,6 +6701,10 @@ export default function TaskPage(): React.JSX.Element {
       setNewIssueBody('')
       setNewIssueLabels([])
       setNewIssueAssignees([])
+      // Why: a successful submit is the only path that discards the recovery
+      // draft. Closing `newIssueOpen` in the same commit keeps the write-through
+      // effect (gated on it) from re-persisting the emptied fields.
+      clearNewIssueDraft()
       // Why: bump the nonce so the list refetches and shows the new issue.
       setTaskRefreshNonce((current) => current + 1)
 
@@ -6700,7 +6772,8 @@ export default function TaskPage(): React.JSX.Element {
     newIssueTargetRepo,
     newIssueTitle,
     openGitHubDetailPage,
-    setDialogWorkItem
+    setDialogWorkItem,
+    clearNewIssueDraft
   ])
 
   const handleCreateNewLinearProject = useCallback(async (): Promise<void> => {
@@ -8234,11 +8307,20 @@ export default function TaskPage(): React.JSX.Element {
                               variant="outline"
                               size="icon"
                               onClick={() => {
-                                setNewIssueTitle('')
-                                setNewIssueBody('')
-                                setNewIssueLabels([])
-                                setNewIssueAssignees([])
-                                setNewIssueRepoId(primaryRepo?.id ?? null)
+                                // Why: restore a content-non-empty draft instead
+                                // of resetting, so an accidental dismissal is
+                                // recoverable. The empty-default branch stays live
+                                // so a stale draft never hijacks a fresh open after
+                                // the user changed their primary/selected repo.
+                                const seed = resolveNewIssueOpenSeed({
+                                  draft: useAppStore.getState().newIssueDraft,
+                                  selectedRepoIds: selectedRepos.map((r) => r.id)
+                                })
+                                setNewIssueTitle(seed.title)
+                                setNewIssueBody(seed.body)
+                                setNewIssueLabels(seed.labels)
+                                setNewIssueAssignees(seed.assignees)
+                                setNewIssueRepoId(seed.repoId)
                                 setNewIssueOpen(true)
                               }}
                               disabled={!newIssueTargetRepo}
@@ -11057,7 +11139,15 @@ export default function TaskPage(): React.JSX.Element {
                 </label>
                 <Select
                   value={newIssueRepoId ?? undefined}
-                  onValueChange={(v) => setNewIssueRepoId(v)}
+                  onValueChange={(v) => {
+                    // Why: repo-scoped labels/assignees can't cross a genuine
+                    // user repo switch, so clear them imperatively here (co-located
+                    // with the cause). Restore never routes through this handler.
+                    setNewIssueRepoId(v)
+                    const reset = resolveUserRepoSwitchReset()
+                    setNewIssueLabels(reset.labels)
+                    setNewIssueAssignees(reset.assignees)
+                  }}
                   disabled={newIssueSubmitting}
                 >
                   <SelectTrigger>

--- a/src/renderer/src/components/task-page-new-issue-draft.test.ts
+++ b/src/renderer/src/components/task-page-new-issue-draft.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isNewIssueDraftContentful,
+  resolveNewIssueOpenSeed,
+  resolveUserRepoSwitchReset,
+  resolveVanishedNewIssueRepoReset
+} from './task-page-new-issue-draft'
+import type { NewIssueDraft } from '@/store/slices/new-issue-draft'
+import type { GitHubAssignableUser } from '../../../shared/types'
+
+const assignee: GitHubAssignableUser = { login: 'octocat', name: 'Octo', avatarUrl: '' }
+
+function draft(overrides: Partial<NewIssueDraft> = {}): NewIssueDraft {
+  return { title: '', body: '', labels: [], assignees: [], repoId: null, ...overrides }
+}
+
+describe('isNewIssueDraftContentful', () => {
+  it('is false for null and an all-empty draft', () => {
+    expect(isNewIssueDraftContentful(null)).toBe(false)
+    expect(isNewIssueDraftContentful(draft())).toBe(false)
+  })
+
+  it('is false for whitespace-only title/body', () => {
+    expect(isNewIssueDraftContentful(draft({ title: '   ', body: '\n\t' }))).toBe(false)
+  })
+
+  it('is false when only a repoId is set (repoId is not content)', () => {
+    expect(isNewIssueDraftContentful(draft({ repoId: 'repo-a' }))).toBe(false)
+  })
+
+  it('is true once a title, body, label, or assignee is present', () => {
+    expect(isNewIssueDraftContentful(draft({ title: 'Bug' }))).toBe(true)
+    expect(isNewIssueDraftContentful(draft({ body: 'details' }))).toBe(true)
+    expect(isNewIssueDraftContentful(draft({ labels: ['p1'] }))).toBe(true)
+    expect(isNewIssueDraftContentful(draft({ assignees: [assignee] }))).toBe(true)
+  })
+})
+
+describe('resolveNewIssueOpenSeed', () => {
+  it('takes the empty-default branch for no draft, targeting the first selected repo', () => {
+    expect(resolveNewIssueOpenSeed({ draft: null, selectedRepoIds: ['repo-a', 'repo-b'] })).toEqual(
+      { title: '', body: '', labels: [], assignees: [], repoId: 'repo-a' }
+    )
+  })
+
+  it('takes the default branch for a draft carrying only a repoId', () => {
+    expect(
+      resolveNewIssueOpenSeed({
+        draft: draft({ repoId: 'repo-b' }),
+        selectedRepoIds: ['repo-a', 'repo-b']
+      })
+    ).toEqual({ title: '', body: '', labels: [], assignees: [], repoId: 'repo-a' })
+  })
+
+  it('restores every field when the draft repo is still selected', () => {
+    expect(
+      resolveNewIssueOpenSeed({
+        draft: draft({
+          title: 'Bug',
+          body: 'details',
+          labels: ['p1'],
+          assignees: [assignee],
+          repoId: 'repo-b'
+        }),
+        selectedRepoIds: ['repo-a', 'repo-b']
+      })
+    ).toEqual({
+      title: 'Bug',
+      body: 'details',
+      labels: ['p1'],
+      assignees: [assignee],
+      repoId: 'repo-b'
+    })
+  })
+
+  it('drops repo-scoped labels/assignees and falls back when the draft repo vanished', () => {
+    expect(
+      resolveNewIssueOpenSeed({
+        draft: draft({
+          title: 'Bug',
+          body: 'details',
+          labels: ['p1'],
+          assignees: [assignee],
+          repoId: 'removed-repo'
+        }),
+        selectedRepoIds: ['repo-a', 'repo-b']
+      })
+    ).toEqual({
+      title: 'Bug',
+      body: 'details',
+      labels: [],
+      assignees: [],
+      repoId: 'repo-a'
+    })
+  })
+
+  it('resolves repoId to null only when nothing is selected', () => {
+    expect(
+      resolveNewIssueOpenSeed({ draft: draft({ title: 'Bug' }), selectedRepoIds: [] })
+    ).toEqual({ title: 'Bug', body: '', labels: [], assignees: [], repoId: null })
+  })
+})
+
+describe('store-retention P1 guard (restore of an in-selection non-fallback repo)', () => {
+  it('never routes a valid restore through a scoped-field clear, so nothing empty is mirrored back', () => {
+    // P1 guard: a draft targeting a selected repo that is NOT selectedRepoIds[0]
+    // (the multi-repo case) must restore its repo-scoped labels/assignees intact.
+    // If restore instead emptied them, the write-through effect would mirror the
+    // empty values back into the store and durably corrupt the recovery draft.
+    // Compose the real helpers to prove restore never hits a clear path.
+    const original = draft({
+      title: 'Bug',
+      body: 'details',
+      labels: ['p1', 'regression'],
+      assignees: [assignee],
+      repoId: 'repo-b'
+    })
+    const selectedRepoIds = ['repo-a', 'repo-b']
+
+    const seed = resolveNewIssueOpenSeed({ draft: original, selectedRepoIds })
+
+    // Restore keeps the scoped fields and targets the draft's own repo...
+    expect(seed.repoId).toBe('repo-b')
+    expect(seed.repoId).not.toBe(selectedRepoIds[0])
+    expect(seed.labels).toEqual(['p1', 'regression'])
+    expect(seed.assignees).toEqual([assignee])
+
+    // ...and the vanish-guard does NOT fire on the restored (in-selection) repo,
+    // so no imperative clear runs either.
+    expect(resolveVanishedNewIssueRepoReset(seed.repoId, selectedRepoIds)).toBeNull()
+
+    // Therefore the fields the write-through would persist equal the original
+    // draft's scoped fields — non-empty and unchanged (no corruption).
+    expect(seed.labels.length).toBeGreaterThan(0)
+    expect(seed.assignees.length).toBeGreaterThan(0)
+    expect(seed.labels).toEqual(original.labels)
+    expect(seed.assignees).toEqual(original.assignees)
+  })
+})
+
+describe('resolveUserRepoSwitchReset', () => {
+  it('clears both repo-scoped labels and assignees on a genuine user repo switch', () => {
+    expect(resolveUserRepoSwitchReset()).toEqual({ labels: [], assignees: [] })
+  })
+})
+
+describe('resolveVanishedNewIssueRepoReset', () => {
+  it('returns null when the chosen repo is still selected', () => {
+    expect(resolveVanishedNewIssueRepoReset('repo-b', ['repo-a', 'repo-b'])).toBeNull()
+  })
+
+  it('returns null when no repo is chosen', () => {
+    expect(resolveVanishedNewIssueRepoReset(null, ['repo-a'])).toBeNull()
+  })
+
+  it('resets to the first selected repo when the chosen repo vanished', () => {
+    expect(resolveVanishedNewIssueRepoReset('removed', ['repo-a', 'repo-b'])).toEqual({
+      repoId: 'repo-a'
+    })
+  })
+
+  it('resets to null when the chosen repo vanished and nothing remains selected', () => {
+    expect(resolveVanishedNewIssueRepoReset('removed', [])).toEqual({ repoId: null })
+  })
+})

--- a/src/renderer/src/components/task-page-new-issue-draft.ts
+++ b/src/renderer/src/components/task-page-new-issue-draft.ts
@@ -1,0 +1,93 @@
+import type { GitHubAssignableUser } from '../../../shared/types'
+import type { NewIssueDraft } from '@/store/slices/new-issue-draft'
+
+export type NewIssueOpenSeed = {
+  title: string
+  body: string
+  labels: string[]
+  assignees: GitHubAssignableUser[]
+  repoId: string | null
+}
+
+/** A draft is worth restoring only once it carries real user content — a typed
+ *  title/body or a picked label/assignee. A bare `repoId` (or an all-empty
+ *  form) is NOT content, so an "opened but never edited" modal never pins a
+ *  meaningless draft and never hijacks a fresh open. Shared by the write-through
+ *  gate and the restore-on-open decision so both agree on "has content". */
+export function isNewIssueDraftContentful(
+  draft: Pick<NewIssueDraft, 'title' | 'body' | 'labels' | 'assignees'> | null
+): boolean {
+  if (!draft) {
+    return false
+  }
+  return (
+    draft.title.trim().length > 0 ||
+    draft.body.trim().length > 0 ||
+    draft.labels.length > 0 ||
+    draft.assignees.length > 0
+  )
+}
+
+/** Pure "seed vs. restore on open" decision for the New GitHub issue modal.
+ *  - No content-non-empty draft → empty defaults targeting the first selected
+ *    repo (keeps a stale draft from hijacking a fresh open after the user
+ *    changed their primary/selected repo).
+ *  - Content draft whose repo is still selected → restore every field.
+ *  - Content draft whose repo vanished from the selection → restore title/body
+ *    only, drop the repo-scoped labels/assignees (they can't cross repos), and
+ *    fall back to the first selected repo.
+ *  Always resolves `repoId` to an explicit, in-selection id (never `null` while
+ *  a target exists) so the vanish-guard can never misfire during a restore. */
+export function resolveNewIssueOpenSeed(params: {
+  draft: NewIssueDraft | null
+  selectedRepoIds: readonly string[]
+}): NewIssueOpenSeed {
+  const { draft, selectedRepoIds } = params
+  const fallbackRepoId = selectedRepoIds[0] ?? null
+  if (!draft || !isNewIssueDraftContentful(draft)) {
+    return { title: '', body: '', labels: [], assignees: [], repoId: fallbackRepoId }
+  }
+  if (draft.repoId !== null && selectedRepoIds.includes(draft.repoId)) {
+    return {
+      title: draft.title,
+      body: draft.body,
+      labels: draft.labels,
+      assignees: draft.assignees,
+      repoId: draft.repoId
+    }
+  }
+  return {
+    title: draft.title,
+    body: draft.body,
+    labels: [],
+    assignees: [],
+    repoId: fallbackRepoId
+  }
+}
+
+/** The reset patch to apply when the user picks a different repo in the
+ *  selector: repo-scoped labels/assignees can't cross a genuine repo switch, so
+ *  both are dropped. Kept as a named helper so the imperative `Select` handler
+ *  and its test share one contract instead of an untested inline literal. */
+export function resolveUserRepoSwitchReset(): {
+  labels: string[]
+  assignees: GitHubAssignableUser[]
+} {
+  return { labels: [], assignees: [] }
+}
+
+/** Pure vanish-guard decision: when the chosen `newIssueRepoId` has left the
+ *  selection (repo removed/deselected while a draft is open), returns the
+ *  first-selected-repo fallback to reset the target to (the caller also drops
+ *  the repo-scoped labels/assignees). Returns `null` when the chosen repo is
+ *  still valid (or unset) — no reset needed. Because a restore always seeds an
+ *  in-selection `repoId`, this returns `null` during a valid restore. */
+export function resolveVanishedNewIssueRepoReset(
+  newIssueRepoId: string | null,
+  selectedRepoIds: readonly string[]
+): { repoId: string | null } | null {
+  if (newIssueRepoId === null || selectedRepoIds.includes(newIssueRepoId)) {
+    return null
+  }
+  return { repoId: selectedRepoIds[0] ?? null }
+}

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -34,6 +34,7 @@ import { createRuntimeStatusSlice } from './slices/runtime-status'
 import { createPullRequestGenerationSlice } from './slices/pull-request-generation'
 import { createCommitMessageGenerationSlice } from './slices/commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './slices/pinned-tab-close-confirm'
+import { createNewIssueDraftSlice } from './slices/new-issue-draft'
 import { e2eConfig } from '@/lib/e2e-config'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
@@ -71,7 +72,8 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createRuntimeStatusSlice(...a),
   ...createPullRequestGenerationSlice(...a),
   ...createCommitMessageGenerationSlice(...a),
-  ...createPinnedTabCloseConfirmSlice(...a)
+  ...createPinnedTabCloseConfirmSlice(...a),
+  ...createNewIssueDraftSlice(...a)
 }))
 
 registerHttpLinkStoreAccessor(() => useAppStore.getState())

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -139,6 +139,7 @@ import { createRuntimeStatusSlice } from './runtime-status'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
 import { createCommitMessageGenerationSlice } from './commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './pinned-tab-close-confirm'
+import { createNewIssueDraftSlice } from './new-issue-draft'
 
 function createTestStore() {
   return create<AppState>()((...a) => ({
@@ -175,7 +176,8 @@ function createTestStore() {
     ...createRuntimeStatusSlice(...a),
     ...createPullRequestGenerationSlice(...a),
     ...createCommitMessageGenerationSlice(...a),
-    ...createPinnedTabCloseConfirmSlice(...a)
+    ...createPinnedTabCloseConfirmSlice(...a),
+    ...createNewIssueDraftSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/new-issue-draft.test.ts
+++ b/src/renderer/src/store/slices/new-issue-draft.test.ts
@@ -1,0 +1,81 @@
+import { create } from 'zustand'
+import { describe, expect, it } from 'vitest'
+import { createNewIssueDraftSlice } from './new-issue-draft'
+import type { AppState } from '../types'
+import type { GitHubAssignableUser } from '../../../../shared/types'
+
+function makeStore() {
+  return create<Pick<AppState, 'newIssueDraft' | 'setNewIssueDraft' | 'clearNewIssueDraft'>>()(
+    (...args) => createNewIssueDraftSlice(...(args as Parameters<typeof createNewIssueDraftSlice>))
+  )
+}
+
+const assignee: GitHubAssignableUser = { login: 'octocat', name: 'Octo', avatarUrl: '' }
+
+describe('createNewIssueDraftSlice', () => {
+  it('starts with no draft', () => {
+    expect(makeStore().getState().newIssueDraft).toBeNull()
+  })
+
+  it('seeds a fresh empty draft with the patch when none exists', () => {
+    const store = makeStore()
+
+    store.getState().setNewIssueDraft({ title: 'Bug' })
+
+    expect(store.getState().newIssueDraft).toEqual({
+      title: 'Bug',
+      body: '',
+      labels: [],
+      assignees: [],
+      repoId: null
+    })
+  })
+
+  it('shallow-merges the patch into the current draft', () => {
+    const store = makeStore()
+    store.getState().setNewIssueDraft({
+      title: 'Bug',
+      body: 'details',
+      labels: ['p1'],
+      assignees: [assignee],
+      repoId: 'repo-a'
+    })
+
+    store.getState().setNewIssueDraft({ body: 'more details' })
+
+    expect(store.getState().newIssueDraft).toEqual({
+      title: 'Bug',
+      body: 'more details',
+      labels: ['p1'],
+      assignees: [assignee],
+      repoId: 'repo-a'
+    })
+  })
+
+  it('clears the draft back to null', () => {
+    const store = makeStore()
+    store.getState().setNewIssueDraft({ title: 'Bug', repoId: 'repo-a' })
+
+    store.getState().clearNewIssueDraft()
+
+    expect(store.getState().newIssueDraft).toBeNull()
+  })
+
+  it('seeds fresh label/assignee arrays per empty draft (no shared-constant aliasing)', () => {
+    // Regression: a module-level empty-draft constant would make partial patches
+    // that omit labels/assignees alias one shared array instance, so an in-place
+    // mutation of one draft would corrupt every subsequently-seeded empty draft.
+    const a = makeStore()
+    const b = makeStore()
+    a.getState().setNewIssueDraft({ title: 'A' })
+    b.getState().setNewIssueDraft({ title: 'B' })
+
+    expect(a.getState().newIssueDraft?.labels).not.toBe(b.getState().newIssueDraft?.labels)
+    expect(a.getState().newIssueDraft?.assignees).not.toBe(b.getState().newIssueDraft?.assignees)
+
+    a.getState().newIssueDraft?.labels.push('leak')
+    const c = makeStore()
+    c.getState().setNewIssueDraft({ title: 'C' })
+    expect(c.getState().newIssueDraft?.labels).toEqual([])
+  })
+})

--- a/src/renderer/src/store/slices/new-issue-draft.ts
+++ b/src/renderer/src/store/slices/new-issue-draft.ts
@@ -1,0 +1,41 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import type { GitHubAssignableUser } from '../../../../shared/types'
+
+/** In-progress "New GitHub issue" composer draft. Session-only (never
+ *  `persist`-wrapped, no disk surface): it exists so an accidental dismissal
+ *  (outside click / Escape / Cancel) doesn't discard the user's input, and is
+ *  cleared on a successful submit or app restart. */
+export type NewIssueDraft = {
+  title: string
+  body: string
+  labels: string[]
+  assignees: GitHubAssignableUser[]
+  repoId: string | null
+}
+
+export type NewIssueDraftSlice = {
+  newIssueDraft: NewIssueDraft | null
+  /** Shallow-merge the patch into the current draft, or into a fresh empty
+   *  draft when none exists yet. */
+  setNewIssueDraft: (patch: Partial<NewIssueDraft>) => void
+  clearNewIssueDraft: () => void
+}
+
+// Why: a factory (not a shared module constant) so a partial patch that omits
+// `labels`/`assignees` seeds fresh arrays rather than aliasing one singleton's —
+// an in-place mutation of an empty draft would otherwise corrupt every future one.
+function createEmptyNewIssueDraft(): NewIssueDraft {
+  return { title: '', body: '', labels: [], assignees: [], repoId: null }
+}
+
+export const createNewIssueDraftSlice: StateCreator<AppState, [], [], NewIssueDraftSlice> = (
+  set
+) => ({
+  newIssueDraft: null,
+  setNewIssueDraft: (patch) =>
+    set((state) => ({
+      newIssueDraft: { ...(state.newIssueDraft ?? createEmptyNewIssueDraft()), ...patch }
+    })),
+  clearNewIssueDraft: () => set({ newIssueDraft: null })
+})

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -42,6 +42,7 @@ import { createRuntimeStatusSlice } from './runtime-status'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
 import { createCommitMessageGenerationSlice } from './commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './pinned-tab-close-confirm'
+import { createNewIssueDraftSlice } from './new-issue-draft'
 import { translate } from '@/i18n/i18n'
 
 export const TEST_REPO = {
@@ -87,7 +88,8 @@ export function createTestStore() {
     ...createRuntimeStatusSlice(...a),
     ...createPullRequestGenerationSlice(...a),
     ...createCommitMessageGenerationSlice(...a),
-    ...createPinnedTabCloseConfirmSlice(...a)
+    ...createPinnedTabCloseConfirmSlice(...a),
+    ...createNewIssueDraftSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -32,6 +32,7 @@ import type { RuntimeStatusSlice } from './slices/runtime-status'
 import type { PullRequestGenerationSlice } from './slices/pull-request-generation'
 import type { CommitMessageGenerationSlice } from './slices/commit-message-generation'
 import type { PinnedTabCloseConfirmSlice } from './slices/pinned-tab-close-confirm'
+import type { NewIssueDraftSlice } from './slices/new-issue-draft'
 
 export type AppState = RepoSlice &
   SparsePresetsSlice &
@@ -66,4 +67,5 @@ export type AppState = RepoSlice &
   RuntimeStatusSlice &
   PullRequestGenerationSlice &
   CommitMessageGenerationSlice &
-  PinnedTabCloseConfirmSlice
+  PinnedTabCloseConfirmSlice &
+  NewIssueDraftSlice


### PR DESCRIPTION
## Summary

Dismissing the **New GitHub issue** dialog by clicking outside it (or pressing Escape, or clicking Cancel) no longer discards the in-progress issue. The **title, body, labels, assignees, and target repo** are kept in app state and restored when the dialog is reopened. The draft is cleared only after a **successful create**.

**Boundary (what does not change):** the draft is **session-only / in-memory** — not written to disk, so it does **not** survive an app restart. It survives close→reopen and navigating away from the Tasks view and back. Scope is the **New GitHub issue dialog only**; other create-modals are intentionally out of scope (see Notes). No confirmation prompt is added — recovery is silent.

**Approach:** the draft is lifted into a session-only store slice (`newIssueDraft`, not `persist`-wrapped), mirroring the existing `newWorkspaceDraft` slice. Reset-on-reopen was the data-loss point; the `+` open handler now **restores** a content-non-empty draft (a bare `repoId`/empty form is not "content", so an untouched open never pins a meaningless draft). A content-gated write-through effect mirrors live edits into the slice while the dialog is open. Repo-scoped **labels/assignees** are cleared only by a genuine user repo switch or when the chosen repo leaves the selection — a restore never routes through a clear path, so it can't wipe just-restored fields (this replaces a reactive "clear on target-id change" effect that couldn't tell a restore apart from a switch). `clearNewIssueDraft()` runs in the submit-success block, with `newIssueOpen` flipping false in the same commit so the write-through can't re-persist emptied fields. New logic lives in named modules: `store/slices/new-issue-draft.ts` and `components/task-page-new-issue-draft.ts` (pure helpers), wired in `TaskPage.tsx`.

## Screenshots

Live Electron validation captured full-window screenshots of each state; verified during review:

- **Typed** → title `DRAFT-RECOVERY-TEST: accidental dismissal should not lose my work` + a multi-line body.
- **Dismissed** (backdrop click) → dialog closes.
- **Restored on reopen** → title + body come back identically.
- **Escape + all fields** → title `ESCAPE-FRESH-EDIT…`, body, plus `browser` + `bug` label chips and the `brennanb2025` assignee all restored.
- **Created + cleared on submit** → filing a real issue against a private throwaway repo succeeds, and reopening the dialog afterward shows a **completely empty form** (title/body/labels/assignees all cleared) — confirming the draft clears only on a successful create.

Per repo policy, evidence images are not committed. Screenshots are attached to the PR conversation / shared with the reviewer rather than checked in.

## Testing

- [x] `pnpm typecheck` — clean
- [ ] `pnpm lint` — `oxlint` clean on all changed files; a full-repo `pnpm lint` fails only on one **pre-existing, unrelated** file (`right-sidebar/source-control-manual-review-url.ts`), not part of this diff
- [x] `pnpm test` — focused suites for the new slice + helpers pass (20/20): `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/new-issue-draft.test.ts src/renderer/src/components/task-page-new-issue-draft.test.ts` (plus affected store suites); full suite not run
- [x] Live clear-on-submit — a real issue was created against a private throwaway repo and the dialog came back empty on reopen (the draft clears only on successful create)
- [ ] `pnpm build` — not run (renderer-only change; typecheck + oxlint cover the touched surface)
- [x] Added high-quality regression tests (seed-vs-restore incl. content-gate and repo-vanished; vanish-guard; user-switch clear; a load-bearing store-retention P1 regression; and an array-aliasing regression that fails if the empty-draft factory is reverted)

## AI Review Report

Reviewed through Brennan's PR process end-to-end:

- **Design review** converged; an initial intricate "restore-suppression token" (correctness dependent on React batching) was rejected in self-review for the simpler, locally-verifiable cause-decomposition.
- **Perf audit** found and fixed one real issue: `newIssueDraft` was subscribed in the very large `TaskPage`, causing an extra full re-render per keystroke (the write-through changes object identity each keystroke). Fixed by reading it via `useAppStore.getState()` at click time (TaskPage is the only consumer) → zero extra re-renders. Write-through is an O(1) store set (no disk/IPC); the vanish-guard keys on a memoized `selectedRepos` so it doesn't thrash; no leaks/polling/subprocess churn.
- **Two-reviewer code-review loop**: 2 rounds. Round 1 flagged one P2 (a shared empty-draft array singleton that could alias `labels`/`assignees` under the `Partial` patch API) — fixed with a per-seed factory + regression test. Round 2: both reviewers clean.
- **Completeness verification**: all checks pass; no path where a restore triggers a scoped-field clear.
- **Cross-platform (macOS/Linux/Windows):** explicitly checked — this is a **renderer-only** React/store change with **no** keyboard-shortcut, path, shell, label-locale, or Electron-platform code touched. Behavior is platform-agnostic. The createIssue transport (local vs runtime RPC / SSH) is unchanged, so SSH/remote behavior is unaffected.

## Security Audit

- **Input handling:** the only new data flow is storing the user's own already-entered issue fields (title/body/labels/assignees/repoId) in an in-memory renderer store and reading them back into the same form. No parsing/deserialization of untrusted input.
- **Command execution / path handling:** none introduced.
- **Auth / secrets:** none touched; the GitHub create/auth path is unchanged.
- **IPC:** no new IPC or main-process surface; the slice is renderer-only and never persisted to disk.
- **Follow-up:** none.

## Notes

- **Cancel now preserves the draft** (all close paths preserve; the draft clears on submit). Deliberate. A "Cancel = discard" affordance would be a small follow-up.
- **Session-only:** in-memory, not persisted to disk — does not survive app restart. By design.
- **Deferred (approved non-goals):** other create-modals with the same latent loss (New Workspace composer — draft machinery currently disabled; New Linear project), confirm-before-close UX, and cross-restart persistence.
- **Broad app consistency:** brings the New GitHub issue dialog in line with the "modal draft survives accidental dismissal" behavior; neighboring create-modals are intentionally deferred; no cross-surface regression introduced.
- **Pre-existing lint:** the unrelated `pnpm lint` failure noted above is not introduced by this PR.
