### PR TITLE
fix(terminal): paste OS-copied files as full shell-escaped paths

### DIFF
--- a/src/main/window/clipboard-file-read.test.ts
+++ b/src/main/window/clipboard-file-read.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readClipboardFilePaths, type ClipboardFileReadDeps } from './clipboard-file-read'
+
+function makeDeps(overrides: Partial<ClipboardFileReadDeps> = {}): ClipboardFileReadDeps {
+  return {
+    platform: 'darwin',
+    desktop: undefined,
+    readFormat: vi.fn(() => ''),
+    readBuffer: vi.fn(() => Buffer.from('')),
+    runCommand: vi.fn(async () => ''),
+    ...overrides
+  }
+}
+
+const PLIST_HEADER = '<?xml version="1.0" encoding="UTF-8"?>'
+
+function filenamesPlist(paths: string[]): string {
+  const entries = paths.map((path) => `\t<string>${path}</string>`).join('\n')
+  return `${PLIST_HEADER}\n<plist version="1.0">\n<array>\n${entries}\n</array>\n</plist>`
+}
+
+describe('readClipboardFilePaths', () => {
+  it('reads real POSIX paths from the macOS NSFilenamesPboardType plist', async () => {
+    const readFormat = vi.fn((format: string) =>
+      format === 'NSFilenamesPboardType'
+        ? filenamesPlist(['/Users/me/a.png', '/Users/me/b.pdf'])
+        : ''
+    )
+    expect(await readClipboardFilePaths(makeDeps({ platform: 'darwin', readFormat }))).toEqual([
+      '/Users/me/a.png',
+      '/Users/me/b.pdf'
+    ])
+    // Prefer the plist over public.file-url, which can be an opaque reference.
+    expect(readFormat).toHaveBeenCalledWith('NSFilenamesPboardType')
+  })
+
+  it('XML-unescapes filenames from the plist', async () => {
+    const readFormat = vi.fn((format: string) =>
+      format === 'NSFilenamesPboardType' ? filenamesPlist(['/Users/me/a &amp; b.png']) : ''
+    )
+    expect(await readClipboardFilePaths(makeDeps({ platform: 'darwin', readFormat }))).toEqual([
+      '/Users/me/a & b.png'
+    ])
+  })
+
+  it('falls back to a macOS public.file-url path URL when the plist is absent', async () => {
+    const readFormat = vi.fn((format: string) =>
+      format === 'public.file-url' ? 'file:///Users/me/a%20b.png' : ''
+    )
+    expect(await readClipboardFilePaths(makeDeps({ platform: 'darwin', readFormat }))).toEqual([
+      '/Users/me/a b.png'
+    ])
+  })
+
+  it('returns [] for an unresolvable macOS /.file/ reference with no plist', async () => {
+    const readFormat = vi.fn((format: string) =>
+      format === 'public.file-url' ? 'file:///.file/id=6571367.321897404' : ''
+    )
+    expect(await readClipboardFilePaths(makeDeps({ platform: 'darwin', readFormat }))).toEqual([])
+  })
+
+  it('returns [] on macOS when no file reference is on the clipboard', async () => {
+    expect(
+      await readClipboardFilePaths(makeDeps({ platform: 'darwin', readFormat: () => '' }))
+    ).toEqual([])
+  })
+
+  it('never throws on macOS when the clipboard read fails', async () => {
+    const readFormat = vi.fn(() => {
+      throw new Error('clipboard unavailable')
+    })
+    await expect(
+      readClipboardFilePaths(makeDeps({ platform: 'darwin', readFormat }))
+    ).resolves.toEqual([])
+  })
+
+  it('returns [] on macOS for a non-file URL', async () => {
+    const readFormat = vi.fn((format: string) =>
+      format === 'public.file-url' ? 'https://example.com/x' : ''
+    )
+    expect(await readClipboardFilePaths(makeDeps({ platform: 'darwin', readFormat }))).toEqual([])
+  })
+
+  it('reads newline-separated FileDropList paths via PowerShell on Windows', async () => {
+    const runCommand = vi.fn(
+      async (_command: string, _args: string[]) =>
+        'C:\\Users\\me\\a.txt\r\nC:\\Users\\me\\b.txt\r\n'
+    )
+    const result = await readClipboardFilePaths(makeDeps({ platform: 'win32', runCommand }))
+    expect(result).toEqual(['C:\\Users\\me\\a.txt', 'C:\\Users\\me\\b.txt'])
+    const [command, args] = runCommand.mock.calls[0]
+    expect(command).toBe('powershell.exe')
+    expect(args.join(' ')).toContain('Get-Clipboard -Format FileDropList')
+  })
+
+  it('returns [] on Windows when the clipboard holds no files', async () => {
+    expect(
+      await readClipboardFilePaths(makeDeps({ platform: 'win32', runCommand: async () => '' }))
+    ).toEqual([])
+  })
+
+  it('never throws on Windows when PowerShell fails', async () => {
+    const runCommand = vi.fn(async () => {
+      throw new Error('powershell.exe not found')
+    })
+    await expect(
+      readClipboardFilePaths(makeDeps({ platform: 'win32', runCommand }))
+    ).resolves.toEqual([])
+  })
+
+  it('parses the GNOME copied-files payload and drops the copy verb', async () => {
+    const readBuffer = vi.fn((format: string) =>
+      format === 'x-special/gnome-copied-files'
+        ? Buffer.from('copy\nfile:///repo/a.png\nfile:///repo/b.png')
+        : Buffer.from('')
+    )
+    expect(
+      await readClipboardFilePaths(makeDeps({ platform: 'linux', desktop: 'GNOME', readBuffer }))
+    ).toEqual(['/repo/a.png', '/repo/b.png'])
+  })
+
+  it('parses the KDE text/uri-list payload', async () => {
+    const readBuffer = vi.fn((format: string) =>
+      format === 'text/uri-list' ? Buffer.from('file:///repo/a%20b.png\r\n') : Buffer.from('')
+    )
+    expect(
+      await readClipboardFilePaths(makeDeps({ platform: 'linux', desktop: 'KDE', readBuffer }))
+    ).toEqual(['/repo/a b.png'])
+  })
+
+  it('falls back to the other format when the preferred one is empty on Linux', async () => {
+    const readBuffer = vi.fn((format: string) =>
+      format === 'text/uri-list' ? Buffer.from('file:///repo/only.png') : Buffer.from('')
+    )
+    expect(
+      await readClipboardFilePaths(makeDeps({ platform: 'linux', desktop: 'GNOME', readBuffer }))
+    ).toEqual(['/repo/only.png'])
+  })
+
+  it('never throws on Linux when every clipboard read fails', async () => {
+    const readBuffer = vi.fn(() => {
+      throw new Error('no clipboard tool')
+    })
+    await expect(
+      readClipboardFilePaths(makeDeps({ platform: 'linux', readBuffer }))
+    ).resolves.toEqual([])
+  })
+})

--- a/src/main/window/clipboard-file-read.ts
+++ b/src/main/window/clipboard-file-read.ts
@@ -1,0 +1,148 @@
+import { fileUriToFilesystemPath } from '../../shared/file-uri-path'
+
+// Injected so the platform branching is unit-testable without the real OS
+// clipboard or spawning processes. The READ mirror of clipboard-file-copy.ts.
+export type ClipboardFileReadDeps = {
+  platform: NodeJS.Platform
+  // Linux only: the active desktop ($XDG_CURRENT_DESKTOP). KDE and GNOME-family
+  // file managers disagree on the clipboard format, so it picks the payload.
+  desktop?: string
+  readFormat: (format: string) => string
+  readBuffer: (format: string) => Buffer
+  runCommand: (command: string, args: string[]) => Promise<string>
+}
+
+// Read the OS-level file references currently on the clipboard and return their
+// absolute filesystem paths (empty when none). This is what lets a paste behave
+// like a drop: a file copied in Finder/Explorer/a file manager pastes its full
+// path, not the display name macOS synthesizes as clipboard text. Best-effort
+// on every platform — always resolves and never throws.
+export async function readClipboardFilePaths(deps: ClipboardFileReadDeps): Promise<string[]> {
+  if (deps.platform === 'darwin') {
+    // Why: Finder writes NSFilenamesPboardType — a plist array of the REAL POSIX
+    // paths — for every file copy, so prefer it. It also covers multi-select.
+    // public.file-url is only a fallback because Finder often puts an opaque
+    // `file:///.file/id=…` reference there that POSIX path resolution cannot
+    // resolve; the OS-synthesized display-name text is never a usable path.
+    try {
+      const names = parseFilenamesPlist(deps.readFormat('NSFilenamesPboardType'))
+      if (names.length > 0) {
+        return names
+      }
+    } catch {
+      // fall through to public.file-url
+    }
+    let fileUrl = ''
+    try {
+      fileUrl = deps.readFormat('public.file-url')
+    } catch {
+      return []
+    }
+    const path = fileUrl ? fileUrlToFilesystemPath(fileUrl) : null
+    // Why: an unresolved `/.file/id=` reference is not shell-usable, so skip it
+    // and let paste fall through rather than insert an opaque reference.
+    if (!path || path.startsWith('/.file/')) {
+      return []
+    }
+    return [path]
+  }
+
+  if (deps.platform === 'win32') {
+    // Read CF_HDROP via PowerShell (mirrors the Set-Clipboard write path). Guard
+    // the spawn so a missing/erroring PowerShell yields [] instead of throwing.
+    try {
+      const output = await deps.runCommand('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'Get-Clipboard -Format FileDropList | ForEach-Object { $_.FullName }'
+      ])
+      return parseNewlineSeparatedPaths(output)
+    } catch {
+      return []
+    }
+  }
+
+  // Linux: best-effort and desktop-dependent, mirroring the copy module's split.
+  // GNOME-family managers (Nautilus/Nemo/Caja) carry the "copied-files" payload
+  // (a leading copy/cut verb); KDE/Qt managers (Dolphin) use text/uri-list. Try
+  // the desktop's preferred format first, then fall back to the other.
+  const formats = /kde/i.test(deps.desktop ?? '')
+    ? ['text/uri-list', 'x-special/gnome-copied-files']
+    : ['x-special/gnome-copied-files', 'text/uri-list']
+  for (const format of formats) {
+    try {
+      const paths = parseFileUriLines(deps.readBuffer(format).toString('utf8'))
+      if (paths.length > 0) {
+        return paths
+      }
+    } catch {
+      // try the next format
+    }
+  }
+  return []
+}
+
+function fileUrlToFilesystemPath(fileUrl: string): string | null {
+  let url: URL
+  try {
+    url = new URL(fileUrl.trim())
+  } catch {
+    return null
+  }
+  return fileUriToFilesystemPath(url)
+}
+
+// NSFilenamesPboardType is an XML plist holding an <array> of <string> POSIX
+// paths. Node has no plist parser, but the shape is fixed, so pull the string
+// entries and XML-unescape them. Only absolute paths are kept.
+function parseFilenamesPlist(plist: string): string[] {
+  if (!plist) {
+    return []
+  }
+  const paths: string[] = []
+  const stringEntry = /<string>([\s\S]*?)<\/string>/g
+  let match: RegExpExecArray | null
+  while ((match = stringEntry.exec(plist)) !== null) {
+    const path = unescapeXml(match[1]).trim()
+    if (path.startsWith('/')) {
+      paths.push(path)
+    }
+  }
+  return paths
+}
+
+// Unescape the five XML predefined entities. `&amp;` is resolved last so an
+// escaped entity like `&amp;lt;` in a filename survives as the literal `&lt;`.
+function unescapeXml(value: string): string {
+  return value
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&')
+}
+
+function parseNewlineSeparatedPaths(output: string): string[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+// The "copied-files" payload's leading `copy`/`cut` verb and uri-list `#`
+// comments are not file URIs, so filtering to `file:` lines drops them.
+function parseFileUriLines(payload: string): string[] {
+  const paths: string[] = []
+  for (const line of payload.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('file:')) {
+      continue
+    }
+    const path = fileUrlToFilesystemPath(trimmed)
+    if (path) {
+      paths.push(path)
+    }
+  }
+  return paths
+}

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -29,6 +29,7 @@ import {
   type ClipboardFileDeps,
   type ClipboardFileResult
 } from './clipboard-file-copy'
+import { readClipboardFilePaths, type ClipboardFileReadDeps } from './clipboard-file-read'
 import {
   cleanupExpiredRemoteClipboardFiles,
   writeRemoteFileToClipboard
@@ -71,6 +72,23 @@ function runCommand(command: string, args: string[], stdin?: string): Promise<vo
   })
 }
 
+// Like runCommand, but captures stdout — the read path needs the helper's
+// output (e.g. PowerShell's newline-separated file paths). Resolves only on a
+// clean exit so callers can treat any failure as "no file on the clipboard".
+function runCommandForOutput(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'ignore'] })
+    let stdout = ''
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString('utf8')
+    })
+    child.on('error', reject)
+    child.on('exit', (code) =>
+      code === 0 ? resolve(stdout) : reject(new Error(`${command} exited with ${code}`))
+    )
+  })
+}
+
 export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:readText')
   ipcMain.removeHandler('clipboard:readSelectionText')
@@ -78,6 +96,7 @@ export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:writeSelectionText')
   ipcMain.removeHandler('clipboard:writeImage')
   ipcMain.removeHandler('clipboard:writeFile')
+  ipcMain.removeHandler('clipboard:readFilePaths')
   ipcMain.removeHandler('clipboard:saveImageAsTempFile')
 
   void cleanupExpiredRemoteClipboardFiles()
@@ -140,6 +159,15 @@ export function registerClipboardHandlers(store: Store): void {
       return writeFileToClipboard(request.filePath, deps)
     }
   )
+  // Why: a file OS-copied in Finder/Explorer/a file manager should paste its
+  // full shell-escaped path into a terminal (like a drop), not the display name
+  // the OS synthesizes as clipboard text. Returns the copied files' absolute
+  // paths, or [] when the clipboard holds no file reference. These are paths the
+  // user themselves copied, so no path-authorization is applied.
+  ipcMain.handle('clipboard:readFilePaths', (event): Promise<string[]> => {
+    assertTrustedClipboardSender(event)
+    return readClipboardFilePaths(makeClipboardFileReadDeps())
+  })
   ipcMain.handle('clipboard:writeText', async (event, text: string) => {
     assertTrustedClipboardSender(event)
     return clipboard.writeText(await assertClipboardTextWriteWithinLimitWithYield(text))
@@ -216,6 +244,16 @@ function makeClipboardFileDeps(
     resolveFilePath,
     writeBuffer: (format, buffer) => clipboard.writeBuffer(format, buffer),
     runCommand
+  }
+}
+
+function makeClipboardFileReadDeps(): ClipboardFileReadDeps {
+  return {
+    platform: process.platform,
+    desktop: process.env.XDG_CURRENT_DESKTOP,
+    readFormat: (format) => clipboard.read(format),
+    readBuffer: (format) => clipboard.readBuffer(format),
+    runCommand: runCommandForOutput
   }
 }
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2689,6 +2689,7 @@ export type PreloadApi = {
     onSystemResumed: (callback: () => void) => () => void
     readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
     readSelectionClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
+    readClipboardFilePaths: () => Promise<string[]>
     saveClipboardImageAsTempFile: (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3468,6 +3468,7 @@ const api = {
       ipcRenderer.invoke('clipboard:readText', options),
     readSelectionClipboardText: (options?: ReadClipboardTextOptions): Promise<string> =>
       ipcRenderer.invoke('clipboard:readSelectionText', options),
+    readClipboardFilePaths: (): Promise<string[]> => ipcRenderer.invoke('clipboard:readFilePaths'),
     saveClipboardImageAsTempFile: (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -158,6 +158,7 @@ import {
 import { formatTerminalPasteExecutionError } from './terminal-paste-errors'
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
+import { resolveTerminalPasteTargetShell } from './terminal-paste-target-shell'
 import {
   isTerminalPanePasteFocusCurrent,
   isTerminalPanePasteTargetCurrent
@@ -2072,7 +2073,9 @@ export default function TerminalPane({
       const activeElementAtDispatch = document.activeElement
       void pasteTerminalClipboard({
         readClipboardText: window.api.ui.readClipboardText,
+        readClipboardFilePaths: () => window.api.ui.readClipboardFilePaths(),
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
+        targetShell: resolveTerminalPasteTargetShell({ worktreeId, fallbackCwd: cwd }),
         connectionId,
         runtimeEnvironmentId,
         forceBracketedMultilineTextPaste,
@@ -2208,7 +2211,9 @@ export default function TerminalPane({
       )
       void pasteTerminalClipboard({
         readClipboardText: window.api.ui.readClipboardText,
+        readClipboardFilePaths: () => window.api.ui.readClipboardFilePaths(),
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
+        targetShell: resolveTerminalPasteTargetShell({ worktreeId, fallbackCwd: cwd }),
         connectionId,
         runtimeEnvironmentId,
         forceBracketedMultilineTextPaste,

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -6,18 +6,27 @@ import {
   pasteTerminalText
 } from './terminal-bracketed-paste'
 
+// Defaults so tests only spell out the deps they care about. The copied-file
+// read defaults to empty (no OS file on the clipboard) and the target shell to
+// posix, preserving the pre-existing text/image behavior for every case that
+// does not exercise the file-path branch.
+const noClipboardFilePaths = (): (() => Promise<string[]>) => vi.fn().mockResolvedValue([])
+const posix = 'posix' as const
+
 describe('terminal clipboard paste', () => {
   it('forces bracketed paste for generated image-only clipboard paths', async () => {
     const pasteText = vi.fn()
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue(
           '/var/folders/3l/b7w02vh17tg5r5s3nhhdf3kh0000gn/T/orca-paste-1760000000000-id.png'
         ),
-      pasteText
+      pasteText,
+      targetShell: posix
     })
 
     expect(pasteText).toHaveBeenCalledWith(
@@ -42,10 +51,12 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
-      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options),
+      targetShell: posix
     })
 
     expect(terminal.input).toHaveBeenCalledWith(
@@ -71,10 +82,12 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
-      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options),
+      targetShell: posix
     })
 
     expect(terminal.input).toHaveBeenCalledWith(
@@ -93,9 +106,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       connectionId: 'ssh-1',
-      pasteText
+      pasteText,
+      targetShell: posix
     })
 
     expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
@@ -116,9 +131,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       runtimeEnvironmentId: 'remote-host-1',
-      pasteText
+      pasteText,
+      targetShell: posix
     })
 
     expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
@@ -136,10 +153,12 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
-      pasteText
+      pasteText,
+      targetShell: posix
     })
 
     expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-id.png', {
@@ -156,8 +175,10 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockRejectedValue(new Error('No text clipboard permission')),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
-      pasteText
+      pasteText,
+      targetShell: posix
     })
 
     expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
@@ -177,8 +198,10 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText,
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
-      pasteText
+      pasteText,
+      targetShell: posix
     })
 
     expect(pasteText).toHaveBeenCalledWith('hello')
@@ -193,11 +216,13 @@ describe('terminal clipboard paste', () => {
 
     const result = await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText: vi.fn(() => {
         throw pasteError
       }),
-      onTextPasteError
+      onTextPasteError,
+      targetShell: posix
     })
 
     expect(onTextPasteError).toHaveBeenCalledWith(pasteError)
@@ -211,9 +236,11 @@ describe('terminal clipboard paste', () => {
 
     const result = await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText: vi.fn().mockResolvedValue(false),
-      onTextPasteError
+      onTextPasteError,
+      targetShell: posix
     })
 
     expect(onTextPasteError).not.toHaveBeenCalled()
@@ -230,9 +257,11 @@ describe('terminal clipboard paste', () => {
       readClipboardText: vi
         .fn()
         .mockRejectedValue(new Error('Clipboard text is too large for this paste target.')),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText,
-      onTextPasteError
+      onTextPasteError,
+      targetShell: posix
     })
 
     expect(onTextPasteError).toHaveBeenCalledWith(
@@ -249,11 +278,13 @@ describe('terminal clipboard paste', () => {
     const onImagePasteError = vi.fn()
     const result = await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
       pasteText: vi.fn().mockResolvedValue(false),
-      onImagePasteError
+      onImagePasteError,
+      targetShell: posix
     })
 
     expect(onImagePasteError).not.toHaveBeenCalled()
@@ -266,9 +297,11 @@ describe('terminal clipboard paste', () => {
     const onImagePasteError = vi.fn()
     const result = await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi.fn().mockRejectedValue(imageError),
       pasteText,
-      onImagePasteError
+      onImagePasteError,
+      targetShell: posix
     })
 
     expect(pasteText).not.toHaveBeenCalled()
@@ -282,9 +315,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('line one\nline two'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText,
-      forceBracketedMultilineTextPaste: true
+      forceBracketedMultilineTextPaste: true,
+      targetShell: posix
     })
 
     expect(pasteText).toHaveBeenCalledWith('line one\nline two', {
@@ -298,9 +333,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('line one\nline two'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi.fn(),
       pasteText,
-      forceBracketedMultilineTextPaste: true
+      forceBracketedMultilineTextPaste: true,
+      targetShell: posix
     })
 
     expect(pasteText).toHaveBeenCalledWith('line one\nline two', {
@@ -314,9 +351,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText,
-      forceBracketedMultilineTextPaste: true
+      forceBracketedMultilineTextPaste: true,
+      targetShell: posix
     })
 
     expect(pasteText).toHaveBeenCalledWith('hello', {
@@ -333,9 +372,11 @@ describe('terminal clipboard paste', () => {
     try {
       await pasteTerminalClipboard({
         readClipboardText: vi.fn().mockResolvedValue('x'.repeat(64)),
+        readClipboardFilePaths: noClipboardFilePaths(),
         saveClipboardImageAsTempFile,
         pasteText,
-        forceBracketedMultilineTextPaste: true
+        forceBracketedMultilineTextPaste: true,
+        targetShell: posix
       })
 
       expect(codePointAtSpy).not.toHaveBeenCalled()
@@ -365,12 +406,83 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('a69ce28e1d092e0c8825cd1a109ac36409962bc1'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
-      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options),
+      targetShell: posix
     })
 
     expect(terminal.paste).toHaveBeenCalledWith('a69ce28e1d092e0c8825cd1a109ac36409962bc1')
     expect(observedIgnoreBracketedPasteMode).toEqual([true])
     expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+  })
+
+  it('pastes OS-copied file paths shell-escaped, winning over synthesized clipboard text', async () => {
+    const pasteText = vi.fn()
+    const saveClipboardImageAsTempFile = vi.fn()
+    // macOS also puts the file's display name on the clipboard as text; the
+    // file-path branch must win so the full path is pasted, not the bare name.
+    const readClipboardText = vi.fn().mockResolvedValue('a file.txt')
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText,
+      readClipboardFilePaths: vi
+        .fn()
+        .mockResolvedValue(['/Users/me/a file.txt', '/Users/me/second.txt']),
+      saveClipboardImageAsTempFile,
+      pasteText,
+      targetShell: posix
+    })
+
+    expect(pasteText).toHaveBeenCalledWith("'/Users/me/a file.txt' /Users/me/second.txt ")
+    expect(readClipboardText).not.toHaveBeenCalled()
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'pasted', kind: 'file-path' })
+  })
+
+  it('quotes copied file paths for the target windows shell', async () => {
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: vi.fn().mockResolvedValue(['C:\\Users\\me\\a file.txt']),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText,
+      targetShell: 'windows'
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('"C:\\Users\\me\\a file.txt" ')
+  })
+
+  it('falls back to text/image paste when no OS file is on the clipboard', async () => {
+    const pasteText = vi.fn()
+    const readClipboardFilePaths = vi.fn().mockResolvedValue([])
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths,
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText,
+      targetShell: posix
+    })
+
+    expect(readClipboardFilePaths).toHaveBeenCalledTimes(1)
+    expect(pasteText).toHaveBeenCalledWith('hello')
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
+  })
+
+  it('ignores copied-file read failures and keeps normal text paste', async () => {
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths: vi.fn().mockRejectedValue(new Error('clipboard read failed')),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText,
+      targetShell: posix
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('hello')
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -2,6 +2,7 @@ import {
   isClipboardTextTooLargeError,
   type ReadClipboardTextOptions
 } from '../../../../shared/clipboard-text'
+import { shellEscapePath } from './pane-helpers'
 import {
   TERMINAL_PASTE_MAX_BYTES,
   type TerminalPasteTextOptions
@@ -14,11 +15,16 @@ type SaveClipboardImageAsTempFile = (args?: {
 
 type PasteTerminalClipboardDeps = {
   readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
+  readClipboardFilePaths: () => Promise<string[]>
   saveClipboardImageAsTempFile: SaveClipboardImageAsTempFile
   pasteText: (
     text: string,
     options?: TerminalPasteTextOptions
   ) => boolean | void | Promise<boolean | void>
+  // The shell receiving the paste, so copied-file paths are quoted the same way
+  // drops are (a Windows client onto a POSIX SSH worktree still needs POSIX
+  // quoting). Mirrors terminal-drop-path-writer's shellEscapePath call.
+  targetShell: 'posix' | 'windows'
   connectionId?: string | null
   runtimeEnvironmentId?: string | null
   forceBracketedMultilineTextPaste?: boolean
@@ -27,7 +33,7 @@ type PasteTerminalClipboardDeps = {
 }
 
 export type TerminalClipboardPasteResult =
-  | { status: 'pasted'; kind: 'image-path' | 'text' }
+  | { status: 'pasted'; kind: 'image-path' | 'text' | 'file-path' }
   | {
       status: 'skipped'
       reason:
@@ -41,14 +47,41 @@ export type TerminalClipboardPasteResult =
 
 export async function pasteTerminalClipboard({
   readClipboardText,
+  readClipboardFilePaths,
   saveClipboardImageAsTempFile,
   pasteText,
+  targetShell,
   connectionId,
   runtimeEnvironmentId,
   forceBracketedMultilineTextPaste = false,
   onTextPasteError,
   onImagePasteError
 }: PasteTerminalClipboardDeps): Promise<TerminalClipboardPasteResult> {
+  // Why: an OS-copied file also puts its display name on the clipboard as text,
+  // so the text branch below would paste the bare name. Reading the real file
+  // reference first makes paste behave like drop — full shell-escaped paths.
+  // Only take this branch when a file is actually present; ordinary text and
+  // image copies fall through unchanged.
+  let filePaths: string[] = []
+  try {
+    filePaths = await readClipboardFilePaths()
+  } catch {
+    // Best-effort: a failed file-reference read must not block text/image paste.
+  }
+  if (filePaths.length > 0) {
+    const escaped = `${filePaths.map((path) => shellEscapePath(path, targetShell)).join(' ')} `
+    try {
+      const result = await pasteText(escaped)
+      if (result === false) {
+        return { status: 'skipped', reason: 'text-paste-rejected' }
+      }
+      return { status: 'pasted', kind: 'file-path' }
+    } catch (error) {
+      onTextPasteError?.(error)
+      return { status: 'skipped', reason: 'text-paste-failed' }
+    }
+  }
+
   let text = ''
   try {
     text = await readClipboardText({ maxBytes: TERMINAL_PASTE_MAX_BYTES })

--- a/src/renderer/src/components/terminal-pane/terminal-paste-target-shell.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-target-shell.ts
@@ -1,0 +1,30 @@
+import { getConnectionId } from '@/lib/connection-context'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { useAppStore } from '@/store'
+import { resolveTerminalDropTargetShell, type TerminalTargetShell } from './terminal-drop-shell'
+import { resolveTerminalDropWorktreePath } from './terminal-drop-worktree-path'
+import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
+
+// Which shell a copied-file paste is quoted for. Reuses the exact drop
+// resolution (terminal-native-file-drop.ts) so paste and drop escape paths
+// identically for the same worktree — local, SSH, and runtime cases included.
+export function resolveTerminalPasteTargetShell({
+  worktreeId,
+  fallbackCwd
+}: {
+  worktreeId: string
+  fallbackCwd: string | undefined
+}): TerminalTargetShell {
+  const connectionId = getConnectionId(worktreeId) ?? null
+  const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
+    useAppStore.getState(),
+    worktreeId
+  )
+  const worktreePath = resolveTerminalDropWorktreePath(worktreeId, fallbackCwd)
+  return resolveTerminalDropTargetShell({
+    activeRuntimeEnvironmentId: runtimeEnvironmentId,
+    worktreePath,
+    connectionId,
+    remotePlatform: getTerminalPasteSshRemotePlatform(connectionId)
+  })
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -12,6 +12,7 @@ import { isTerminalAgentQuickCommand } from '../../../../shared/terminal-quick-c
 import { sendTerminalQuickCommandToPane } from './terminal-quick-command-dispatch'
 import { pasteTerminalText } from './terminal-bracketed-paste'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { resolveTerminalPasteTargetShell } from './terminal-paste-target-shell'
 import {
   executeTerminalPastePlan,
   planTerminalPasteWithYield,
@@ -299,7 +300,9 @@ export function useTerminalPaneContextMenu({
     )
     const result = await pasteTerminalClipboard({
       readClipboardText: window.api.ui.readClipboardText,
+      readClipboardFilePaths: () => window.api.ui.readClipboardFilePaths(),
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
+      targetShell: resolveTerminalPasteTargetShell({ worktreeId, fallbackCwd }),
       connectionId,
       runtimeEnvironmentId,
       forceBracketedMultilineTextPaste,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2139,6 +2139,9 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       ),
     readSelectionClipboardText: () =>
       Promise.reject(new Error('Selection clipboard is unavailable in the web client')),
+    // The browser clipboard exposes no OS file references, so a web paste can
+    // never carry copied-file paths.
+    readClipboardFilePaths: () => Promise.resolve([]),
     saveClipboardImageAsTempFile: async (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null


### PR DESCRIPTION
## Summary

Fixes #7777 — on macOS, copying a file in Finder (`Cmd+C`) and pasting into a terminal pane inserted only the **display name** instead of the file's full path.

**Root cause:** `terminal-clipboard-paste.ts` reads clipboard *text* first. When a file is OS-copied, macOS synthesizes the file's display name as clipboard text, so the text branch won before the real file reference was ever read. Drag-and-drop already inserts shell-escaped paths — paste now does the same.

## What changed

- **`src/main/window/clipboard-file-read.ts`** (new) — the READ mirror of the existing `clipboard-file-copy.ts`. Reads the OS file references on the clipboard and returns absolute paths, cross-platform:
  - **macOS**: prefers `NSFilenamesPboardType` (a plist array of real POSIX paths — also covers multi-select). Falls back to `public.file-url`, skipping opaque `file:///.file/id=…` reference URLs that POSIX path resolution can't resolve.
  - **Windows**: `Get-Clipboard -Format FileDropList` via PowerShell (mirrors the `Set-Clipboard` write path).
  - **Linux**: `text/uri-list` / `x-special/gnome-copied-files`, desktop-dependent, mirroring the copy module.
  - Injected deps so platform branching is unit-testable; never throws.
- **`clipboard-ipc-handlers.ts`** — new `clipboard:readFilePaths` IPC (trusted-sender gated).
- **preload / api-types / web stub** — expose `readClipboardFilePaths` (web returns `[]`, no OS file refs in a browser).
- **`terminal-clipboard-paste.ts`** — reads file references *before* the text branch; when present, pastes `paths.map(p => shellEscapePath(p, targetShell)).join(' ')` (reusing the drop path escaper) and returns a new `{ status:'pasted', kind:'file-path' }`. Ordinary text/image copies fall through unchanged.
- **`terminal-paste-target-shell.ts`** (new) — resolves the paste `targetShell` by delegating to the exact same resolver drag-and-drop uses, so paste and drop quote paths identically (local, SSH, runtime).

## Testing

- `pnpm typecheck` ✅, `pnpm oxlint` (changed files) ✅
- Unit tests: `clipboard-file-read.test.ts` (macOS plist/fallback/reference-skip, Windows, Linux) + extended `terminal-clipboard-paste.test.ts` — file-path branch wins over synthesized text; empty result keeps text/image behavior.
- Manually verified on macOS 26.2: Finder copy → paste yields the full shell-escaped path (spaces / non-ASCII quoted correctly), including multi-file selection.

## Notes

- Windows/Linux paths are covered by mocked-deps unit tests; CI on those OSes is the final gate.
- Web client can't read OS file references (browser sandbox), so paste falls through to text/image there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

On Mac, pasting a file copied from Finder only put the short name in the terminal. Paste now inserts the full shell-escaped path, same as drag-and-drop.
