### PR TITLE
docs(computer-use): clarify get-app-state JSON tree field

### DIFF
--- a/config/scripts/computer-use-skill-guidance.test.mjs
+++ b/config/scripts/computer-use-skill-guidance.test.mjs
@@ -33,4 +33,11 @@ describe('computer-use skill guidance', () => {
     expect(skill).toContain('use `--restore-window` so another window does not cover')
     expect(skill).toContain('trust the tree over potentially occluded pixels')
   })
+
+  it('points JSON users to the public accessibility-tree field', () => {
+    const skill = readFileSync(skillPath, 'utf8')
+
+    expect(skill).toContain('`result.snapshot.treeText`')
+    expect(skill).not.toContain('`result.elements`')
+  })
 })

--- a/skills/computer-use/SKILL.md
+++ b/skills/computer-use/SKILL.md
@@ -37,6 +37,8 @@ orca computer click --app com.spotify.client --element-index 42 --json
 
 Use the fresh state returned by each action for the next element index. Element indexes are the numeric labels shown in the tree; they may be sparse when noisy sections are omitted, so never infer valid indexes from `elementCount` or "Visible elements." Element indexes are short-lived and go stale after delays, navigation, focus changes, scrolling, window changes, or app re-rendering.
 
+In `--json` output, read the accessibility tree and action indexes from `result.snapshot.treeText`; `elementCount` is only a count and must not be used to infer indexes.
+
 ## App Selectors
 
 Prefer bundle IDs from `list-apps`; names are acceptable when unambiguous. Use `pid:<number>` only when bundle ID or name matching is ambiguous.
@@ -101,22 +103,6 @@ action_y = screenshot_pixel_y / screenshot.scale
 Prefer element indexes or element frames from the tree when available. Use raw screenshot-derived coordinates only after checking the latest screenshot scale and window size.
 
 On Linux and Windows, screenshots may come from the visible desktop region for the target window bounds. If visual pixels matter, use `--restore-window` so another window does not cover the target region; if you cannot take focus, trust the tree over potentially occluded pixels.
-
-## Response Structure
-
-`get-app-state --json` returns the accessibility tree under `result.snapshot`:
-
-| Field | Content |
-|-------|---------|
-| `result.snapshot.elementCount` | Total AX elements in the tree |
-| `result.snapshot.treeText` | Indented text tree; each line starts with the element index usable in `--element-index` |
-| `result.snapshot.focusedElementId` | Element index of the currently focused element |
-| `result.screenshot.path` | Screenshot file path (bytes omitted from JSON) |
-| `result.screenshotStatus.state` | Screenshot capture status |
-| `result.elements` | May be empty; use `result.snapshot.*` for the actual tree |
-
-Read `treeText` for element indexes and roles. Use those indexes directly in
-`click --element-index`, `set-value --element-index`, etc.
 
 ## App Notes
 

--- a/skills/computer-use/SKILL.md
+++ b/skills/computer-use/SKILL.md
@@ -102,6 +102,22 @@ Prefer element indexes or element frames from the tree when available. Use raw s
 
 On Linux and Windows, screenshots may come from the visible desktop region for the target window bounds. If visual pixels matter, use `--restore-window` so another window does not cover the target region; if you cannot take focus, trust the tree over potentially occluded pixels.
 
+## Response Structure
+
+`get-app-state --json` returns the accessibility tree under `result.snapshot`:
+
+| Field | Content |
+|-------|---------|
+| `result.snapshot.elementCount` | Total AX elements in the tree |
+| `result.snapshot.treeText` | Indented text tree; each line starts with the element index usable in `--element-index` |
+| `result.snapshot.focusedElementId` | Element index of the currently focused element |
+| `result.screenshot.path` | Screenshot file path (bytes omitted from JSON) |
+| `result.screenshotStatus.state` | Screenshot capture status |
+| `result.elements` | May be empty; use `result.snapshot.*` for the actual tree |
+
+Read `treeText` for element indexes and roles. Use those indexes directly in
+`click --element-index`, `set-value --element-index`, etc.
+
 ## App Notes
 
 Browsers: for Edge, Chrome, Safari, and similar browser windows, set the address/search field directly, then press Return. Do not assume raw typing went to the address bar. Use `--restore-window` when the browser is not already frontmost. Large tab strips may show only the active tab plus an "inactive browser tabs omitted" marker; treat that as intentional noise reduction and operate on the current page/address bar unless the user asked to manage tabs.


### PR DESCRIPTION
## Summary

- Clarify that `get-app-state --json` exposes the accessibility tree and action indexes at `result.snapshot.treeText`
- Reinforce that `elementCount` is only a count and must not be used to infer element indexes
- Add a guidance regression test for the documented public field

## Investigation

The original description claimed that `result.elements` may be empty. That field is not part of the public `ComputerSnapshotResult` contract and was not present when computer-use shipped.

Verified against Orca 1.4.137 on macOS with Finder:

- `result` contained only `snapshot`, `screenshot`, and `screenshotStatus`
- `result.snapshot.treeText` was populated
- `result.snapshot.elementCount` was 304
- `result.elements` was absent

Linux and Windows providers maintain element records internally so later actions can target them, but the main process intentionally caches those records instead of duplicating them in the agent-facing response.

## Validation

- `config/scripts/computer-use-skill-guidance.test.mjs`: 4 tests passed
- `git diff --check`: passed

## Visual Change

None. Documentation and documentation-guidance tests only.