### PR TITLE
feat(orchestration): add task-delete for single task cleanup

### DIFF
--- a/src/cli/handlers/orchestration.test.ts
+++ b/src/cli/handlers/orchestration.test.ts
@@ -13,6 +13,7 @@ vi.mock('../format', () => ({ printResult: vi.fn() }))
 vi.mock('../selectors', () => ({ getTerminalHandle: getTerminalHandleMock }))
 
 import { ORCHESTRATION_HANDLERS } from './orchestration'
+import { printResult } from '../format'
 import { RuntimeClientError } from '../runtime-client'
 
 function staleHandleError(): RuntimeClientError {
@@ -587,6 +588,41 @@ describe('orchestration task-create caller handle', () => {
       parent: undefined,
       callerTerminalHandle: 'term_live'
     })
+  })
+})
+
+describe('orchestration task-delete CLI handler', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    vi.mocked(printResult).mockReset()
+  })
+
+  const invoke = (flags: Map<string, string | boolean>) =>
+    ORCHESTRATION_HANDLERS['orchestration task-delete']({
+      flags,
+      client: { call: callMock },
+      json: true
+    } as never)
+
+  it('maps --task to orchestration.taskDelete and prints through printResult', async () => {
+    const response = {
+      id: 'req_task_delete',
+      ok: true,
+      result: {
+        task: { id: 'task_1', status: 'ready' }
+      },
+      _meta: {
+        runtimeId: 'runtime-1'
+      }
+    }
+    callMock.mockResolvedValueOnce(response)
+
+    await invoke(new Map([['task', 'task_1']]))
+
+    expect(callMock).toHaveBeenCalledWith('orchestration.taskDelete', {
+      task: 'task_1'
+    })
+    expect(vi.mocked(printResult)).toHaveBeenCalledWith(response, true, expect.any(Function))
   })
 })
 

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -527,6 +527,16 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, (r) => `Updated ${r.task.id} -> ${r.task.status}`)
   },
 
+  'orchestration task-delete': async ({ flags, client, json }) => {
+    const result = await client.call<{ task: { id: string; status: string } }>(
+      'orchestration.taskDelete',
+      {
+        task: getRequiredStringFlag(flags, 'task')
+      }
+    )
+    printResult(result, json, (r) => `Deleted ${r.task.id} [${r.task.status}]`)
+  },
+
   'orchestration dispatch': async ({ flags, client, cwd, json }) => {
     const from = await resolveCoordinatorTerminalHandle(flags, cwd, client)
     const dryRun = flags.has('dry-run') ? true : undefined

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -84,6 +84,7 @@ Orchestration:
   orchestration task-create Create an orchestration task
   orchestration task-list   List orchestration tasks
   orchestration task-update Update a task status
+  orchestration task-delete Delete an orchestration task
   orchestration dispatch    Dispatch a task to a terminal
   orchestration dispatch-show Show dispatch context for a task
   orchestration run         Start the coordinator loop

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -249,6 +249,18 @@ describe('orca root help', () => {
     expect(callMock).not.toHaveBeenCalled()
   })
 
+  it('advertises orchestration task-delete in command help', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    logSpy.mockClear()
+
+    await main(['orchestration', 'task-delete', '--help'], '/tmp/repo')
+
+    const help = String(logSpy.mock.calls[0][0])
+    expect(help).toContain('orca orchestration task-delete --task <task_id> [--json]')
+    expect(help).toContain('Delete an orchestration task')
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
   it('hides removed parent-workspace help and scopes create parent selectors', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     logSpy.mockClear()
@@ -3328,6 +3340,26 @@ describe('orca cli worktree awareness', () => {
       deps: undefined,
       parent: undefined,
       callerTerminalHandle: 'term_creator'
+    })
+  })
+
+  it('routes orchestration task-delete through the CLI', async () => {
+    callMock.mockResolvedValueOnce({
+      id: 'req_task_delete',
+      ok: true,
+      result: {
+        task: { id: 'task_1', status: 'ready' }
+      },
+      _meta: {
+        runtimeId: 'runtime-1'
+      }
+    })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['orchestration', 'task-delete', '--task', 'task_1', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith('orchestration.taskDelete', {
+      task: 'task_1'
     })
   })
 

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -88,6 +88,12 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     notes: ['Valid --status values: pending, ready, dispatched, completed, failed, blocked.']
   },
   {
+    path: ['orchestration', 'task-delete'],
+    summary: 'Delete an orchestration task',
+    usage: 'orca orchestration task-delete --task <task_id> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'task']
+  },
+  {
     path: ['orchestration', 'dispatch'],
     summary: 'Dispatch a task to a terminal',
     usage:

--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -267,6 +267,116 @@ describe('OrchestrationDb', () => {
       expect(d.listTasks()).toHaveLength(2)
     })
 
+    it('deleteTask returns undefined for missing task ids', () => {
+      const d = createDb()
+      expect(d.deleteTask('task_missing')).toBeUndefined()
+    })
+
+    it.each([
+      {
+        status: 'pending' as const,
+        prepare: () => undefined,
+        createTask: (d: OrchestrationDb) =>
+          d.createTask({ spec: 'pending task', deps: ['task_dependency'] })
+      },
+      {
+        status: 'ready' as const,
+        prepare: () => undefined,
+        createTask: (d: OrchestrationDb) => d.createTask({ spec: 'ready task' })
+      },
+      {
+        status: 'completed' as const,
+        prepare: (d: OrchestrationDb, taskId: string) => {
+          d.updateTaskStatus(taskId, 'completed')
+        },
+        createTask: (d: OrchestrationDb) => d.createTask({ spec: 'completed task' })
+      },
+      {
+        status: 'failed' as const,
+        prepare: (d: OrchestrationDb, taskId: string) => {
+          d.updateTaskStatus(taskId, 'failed')
+        },
+        createTask: (d: OrchestrationDb) => d.createTask({ spec: 'failed task' })
+      },
+      {
+        status: 'blocked' as const,
+        prepare: (d: OrchestrationDb, taskId: string) => {
+          d.createGate({ taskId, question: 'Block it?' })
+        },
+        createTask: (d: OrchestrationDb) => d.createTask({ spec: 'blocked task' })
+      }
+    ])(
+      'deleteTask deletes an eligible $status task and returns the pre-delete row',
+      ({ status, prepare, createTask }) => {
+        const d = createDb()
+        const task = createTask(d)
+        prepare(d, task.id)
+
+        const deleted = d.deleteTask(task.id)
+
+        expect(deleted?.id).toBe(task.id)
+        expect(deleted?.status).toBe(status)
+        expect(d.getTask(task.id)).toBeUndefined()
+        expect(d.listGates({ taskId: task.id })).toHaveLength(0)
+        expect(d.getDispatchContext(task.id)).toBeUndefined()
+      }
+    )
+
+    it('deleteTask rejects dispatched or pending/dispatched tasks', () => {
+      const d = createDb()
+      const dispatched = d.createTask({ spec: 'active task' })
+      const ctx = d.createDispatchContext(dispatched.id, 'term_worker')
+
+      expect(() => d.deleteTask(dispatched.id)).toThrow('dispatched')
+      expect(d.getTask(dispatched.id)?.status).toBe('dispatched')
+      expect(d.getDispatchContext(dispatched.id)?.id).toBe(ctx.id)
+
+      const pending = d.createTask({ spec: 'pending task' })
+      const sqlite = (d as unknown as { db: Database.Database }).db
+      sqlite
+        .prepare(
+          "INSERT INTO dispatch_contexts (id, task_id, assignee_handle, status, failure_count, dispatched_at) VALUES (?, ?, ?, 'pending', 0, NULL)"
+        )
+        .run('ctx_pending', pending.id, 'term_worker')
+
+      expect(() => d.deleteTask(pending.id)).toThrow('pending/dispatched')
+      expect(d.getTask(pending.id)?.status).toBe('ready')
+      expect(d.getDispatchContext(pending.id)?.status).toBe('pending')
+    })
+
+    it('deleteTask deletes only task-scoped rows and preserves adjacent task rows', () => {
+      const d = createDb()
+      const target = d.createTask({ spec: 'target' })
+      const targetCtx = d.createDispatchContext(target.id, 'term_target')
+
+      d.updateTaskStatus(target.id, 'completed')
+      d.createGate({ taskId: target.id, question: 'Proceed?' })
+
+      const adjacent = d.createTask({ spec: 'adjacent' })
+      const adjacentCtx = d.createDispatchContext(adjacent.id, 'term_adjacent')
+      const adjacentWithGate = d.createTask({ spec: 'adjacent gate' })
+      const adjacentGate = d.createGate({
+        taskId: adjacentWithGate.id,
+        question: 'Adjacent gate?'
+      })
+
+      const deleted = d.deleteTask(target.id)
+
+      expect(deleted?.id).toBe(target.id)
+      expect(deleted?.status).toBe('blocked')
+      expect(d.getTask(target.id)).toBeUndefined()
+      expect(d.getDispatchContext(target.id)).toBeUndefined()
+      expect(d.listGates({ taskId: target.id })).toHaveLength(0)
+      expect(targetCtx.id).toMatch(/^ctx_/)
+
+      expect(d.getTask(adjacent.id)?.status).toBe('dispatched')
+      expect(d.getDispatchContext(adjacent.id)?.id).toBe(adjacentCtx.id)
+      expect(d.getTask(adjacentWithGate.id)?.status).toBe('blocked')
+      expect(d.listGates({ taskId: adjacentWithGate.id }).map((gate) => gate.id)).toEqual([
+        adjacentGate.id
+      ])
+    })
+
     it('listTasksWithDispatch joins active dispatch metadata', () => {
       const d = createDb()
       const ready = d.createTask({ spec: 'ready task' })

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -465,6 +465,44 @@ export class OrchestrationDb {
     return this.db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow | undefined
   }
 
+  deleteTask(id: string): TaskRow | undefined {
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
+      const task = this.db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as
+        | TaskRow
+        | undefined
+      if (!task) {
+        this.db.exec('ROLLBACK')
+        return undefined
+      }
+      if (task.status === 'dispatched') {
+        throw new Error(`Task ${id} is dispatched; only inactive tasks can be deleted`)
+      }
+
+      const activeDispatch = this.db
+        .prepare(
+          "SELECT id FROM dispatch_contexts WHERE task_id = ? AND status IN ('pending', 'dispatched') LIMIT 1"
+        )
+        .get(id) as { id: string } | undefined
+      if (activeDispatch) {
+        throw new Error(
+          `Task ${id} has pending/dispatched dispatch contexts; only inactive tasks can be deleted`
+        )
+      }
+
+      this.db.prepare('DELETE FROM decision_gates WHERE task_id = ?').run(id)
+      this.db.prepare('DELETE FROM dispatch_contexts WHERE task_id = ?').run(id)
+      this.db.prepare('DELETE FROM tasks WHERE id = ?').run(id)
+      this.db.exec('COMMIT')
+      return task
+    } catch (error) {
+      try {
+        this.db.exec('ROLLBACK')
+      } catch {}
+      throw error
+    }
+  }
+
   listTasks(filter?: { status?: TaskStatus; ready?: boolean }): TaskRow[] {
     if (filter?.ready) {
       return this.db

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -56,7 +56,7 @@ describe('orchestration RPC methods', () => {
 
   it('registers all expected methods', () => {
     const registry = buildRegistry(ORCHESTRATION_METHODS)
-    expect(registry.size).toBe(16)
+    expect(registry.size).toBe(17)
     expect(registry.has('orchestration.send')).toBe(true)
     expect(registry.has('orchestration.check')).toBe(true)
     expect(registry.has('orchestration.reply')).toBe(true)
@@ -64,6 +64,7 @@ describe('orchestration RPC methods', () => {
     expect(registry.has('orchestration.taskCreate')).toBe(true)
     expect(registry.has('orchestration.taskList')).toBe(true)
     expect(registry.has('orchestration.taskUpdate')).toBe(true)
+    expect(registry.has('orchestration.taskDelete')).toBe(true)
     expect(registry.has('orchestration.dispatch')).toBe(true)
     expect(registry.has('orchestration.dispatchShow')).toBe(true)
     expect(registry.has('orchestration.ask')).toBe(true)
@@ -1033,6 +1034,41 @@ describe('orchestration RPC methods', () => {
       await expect(
         call('orchestration.taskUpdate', { id: 'task_fake', status: 'completed' })
       ).rejects.toThrow('Task not found')
+    })
+  })
+
+  describe('orchestration.taskDelete', () => {
+    it('deletes a task and returns the pre-delete row', async () => {
+      setup()
+      const task = db.createTask({ spec: 'cleanup work' })
+
+      const result = (await call('orchestration.taskDelete', {
+        task: task.id
+      })) as { task: { id: string; status: string } }
+
+      expect(result.task.id).toBe(task.id)
+      expect(result.task.status).toBe('ready')
+      expect(db.getTask(task.id)).toBeUndefined()
+    })
+
+    it('throws on nonexistent task', async () => {
+      setup()
+      await expect(call('orchestration.taskDelete', { task: 'task_fake' })).rejects.toThrow(
+        'Task not found'
+      )
+    })
+
+    it('propagates dispatched task rejection', async () => {
+      setup()
+      const task = db.createTask({ spec: 'in-flight work' })
+      db.createDispatchContext(task.id, 'term_worker')
+
+      await expect(call('orchestration.taskDelete', { task: task.id })).rejects.toThrow(
+        'dispatched'
+      )
+
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContext(task.id)).toBeDefined()
     })
   })
 

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -131,6 +131,10 @@ const TaskUpdateParams = z.object({
   result: OptionalString
 })
 
+const TaskDeleteParams = z.object({
+  task: requiredString('Missing --task')
+})
+
 const DispatchParams = z.object({
   task: requiredString('Missing --task'),
   // Why: --to is only required for real dispatches. When --dry-run is set the
@@ -418,6 +422,19 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       const task = db.updateTaskStatus(params.id, params.status, params.result)
       if (!task) {
         throw new Error(`Task not found: ${params.id}`)
+      }
+      return { task }
+    }
+  }),
+
+  defineMethod({
+    name: 'orchestration.taskDelete',
+    params: TaskDeleteParams,
+    handler: (params, { runtime }) => {
+      const db = runtime.getOrchestrationDb()
+      const task = db.deleteTask(params.task)
+      if (!task) {
+        throw new Error(`Task not found: ${params.task}`)
       }
       return { task }
     }


### PR DESCRIPTION
## Summary

- Add `orca orchestration task-delete --task <id>` for surgical removal of one orchestration task without resetting the full task graph.
- Wire the command through CLI, runtime RPC, and `OrchestrationDb`, with a DB-owned guard that rejects active dispatch state and deletes only task-scoped gate and dispatch rows.

Closes #7434.
Refs #7578.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated focused tests that cover DB cleanup, RPC registration, CLI wiring, and command parsing.

Focused validation:

- Passed: `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/db.test.ts -t "deleteTask"`
- Passed: `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration.test.ts -t "taskDelete|registers all expected methods"`
- Passed: `pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/orchestration.test.ts -t "task-delete"`
- Passed: `pnpm exec vitest run --config config/vitest.config.ts src/cli/index.test.ts -t "task-delete"`
- Passed: `pnpm run typecheck:node`
- Passed: `pnpm run typecheck:cli`

## AI Review Report

The change stays on the existing orchestration DB, RPC, and CLI surfaces. No UI, Electron, browser, mobile, SSH, remote, provider, or terminal rendering code changed.

Behavior review:

- The delete guard keys on `tasks.status` and `dispatch_contexts.status`.
- Deletion is task-scoped and leaves adjacent tasks alone.
- The command surface is explicit and matches the existing orchestration verbs.
- No new subprocesses or external integrations were added.

Cross-platform review:

- macOS, Linux, and Windows behavior stays provider-neutral.
- The code path is runtime and CLI only, so there is no platform-specific rendering or accessibility risk.
- Windows shell behavior does not change beyond the existing CLI flag parsing.

## Security Audit

The new RPC and DB path use prepared statements and task-scoped predicates only. The command accepts a single task id, does not expand paths, does not spawn subprocesses, and does not touch auth, secrets, or network surfaces. The only destructive action is deleting the targeted task after checking for active dispatch state.

## Notes

Scope stays narrow:

- No cascade reset behavior.
- No dependency rewrites.
- No lifecycle reconciliation beyond the delete guard.
- No UI, Electron, browser, mobile, SSH, remote, or release/version changes.

`task-update --deps` remains a separate path in #7578. This PR only adds single-task cleanup.

## ELI5

You can delete one orchestration task with `orca orchestration task-delete` without wiping the whole graph. Active dispatches are blocked so you don’t remove work mid-run.
