### PR TITLE
fix(pty): detect agents running inside a user's tmux session

### DIFF
--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -9,6 +9,7 @@ vi.mock('child_process', () => ({
 }))
 
 import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot'
+import { resetTmuxActivePaneCacheForTests } from '../../shared/tmux-active-pane'
 import { resolveAgentForegroundProcess } from './agent-foreground-process'
 import { resetWindowsProcessRowsSnapshotForTests } from './windows-foreground-process-rows'
 
@@ -74,6 +75,7 @@ describe('resolveAgentForegroundProcess', () => {
   beforeEach(() => {
     execFileMock.mockReset()
     resetProcessTableSnapshotForTests()
+    resetTmuxActivePaneCacheForTests()
     // Why: the Windows rows reader caches across calls (500ms TTL), so each
     // case's execFile mock must not be answered by the previous case's rows.
     resetWindowsProcessRowsSnapshotForTests()
@@ -104,6 +106,47 @@ describe('resolveAgentForegroundProcess', () => {
     mockPs(['101 100 S+   node /Users/dev/.nvm/versions/node/bin/codex'].join('\n'))
 
     await expect(resolveAgentForegroundProcess(100, 'node')).resolves.toBe('codex')
+  })
+
+  it('detects an agent hosted inside a user tmux via the client hop', async () => {
+    // Pane shell (100) -> tmux client (200). The real claude (401) lives under
+    // the reparented tmux server (300, ppid 1), unreachable from the shell.
+    execFileMock.mockImplementation((cmd: string, args: string[], _opts: unknown, cb: unknown) => {
+      const callback = cb as (err: unknown, r: { stdout: string; stderr: string }) => void
+      if (cmd === 'tmux') {
+        expect(args).toContain('list-clients')
+        callback(null, { stdout: '200 400\n', stderr: '' })
+        return
+      }
+      callback(null, {
+        stdout: [
+          '100 99  Ss   bash -i',
+          '200 100 S+   tmux attach -t work',
+          '300 1   Ss   tmux: server',
+          '400 300 Ss   bash',
+          '401 400 S+   claude'
+        ].join('\n'),
+        stderr: ''
+      })
+    })
+
+    await expect(resolveAgentForegroundProcess(100, 'tmux')).resolves.toBe('claude')
+  })
+
+  it('falls back when the tmux client has no resolvable active pane', async () => {
+    execFileMock.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+      const callback = cb as (err: unknown, r: { stdout: string; stderr: string }) => void
+      if (cmd === 'tmux') {
+        callback(null, { stdout: '999 400\n', stderr: '' }) // different client pid
+        return
+      }
+      callback(null, {
+        stdout: ['100 99  Ss   bash -i', '200 100 S+   tmux attach'].join('\n'),
+        stderr: ''
+      })
+    })
+
+    await expect(resolveAgentForegroundProcess(100, 'tmux')).resolves.toBe('tmux')
   })
 
   it('does not report Claude print-mode hook descendants as foreground agents', async () => {

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -1,5 +1,6 @@
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import { getProcessTableSnapshot, type ProcessTableRow } from '../../shared/process-table-snapshot'
+import { isTmuxClientCommand, resolveTmuxActivePanePid } from '../../shared/tmux-active-pane'
 import {
   resolveWindowsAgentForegroundProcess,
   shouldInspectWindowsAgentForeground,
@@ -59,13 +60,47 @@ export async function resolveAgentForegroundProcess(
 
   try {
     const rows = await getProcessTableSnapshot()
-    return resolveAgentForegroundProcessFromPs(rows, shellPid) ?? fallbackProcess
+    return (
+      resolveAgentForegroundProcessFromPs(rows, shellPid) ??
+      (await resolveTmuxHostedAgentProcess(rows, shellPid)) ??
+      fallbackProcess
+    )
   } catch {
     // Fall through to node-pty's process name. Foreground process inspection is
     // best-effort because terminal identity should never break PTY operation.
   }
 
   return fallbackProcess
+}
+
+/**
+ * Agents launched inside a user's tmux are children of the reparented tmux
+ * server, not of the pane shell, so the subtree walk above never reaches them.
+ * If the shell's subtree holds a tmux client, hop to that client's active pane
+ * pid and re-run the same walk from there. Best-effort: null on any tmux miss.
+ */
+async function resolveTmuxHostedAgentProcess(
+  rows: ProcessTableRow[],
+  shellPid: number
+): Promise<string | null> {
+  const client = collectDescendants(rows, shellPid).find((row) => isTmuxClientCommand(row.command))
+  if (!client) {
+    return null
+  }
+  const panePid = await resolveTmuxActivePanePid(client.pid, client.command)
+  if (!panePid) {
+    return null
+  }
+  // The agent is usually a child of the pane's shell, but can be the pane's own
+  // top process (e.g. `tmux new-session claude`), which the subtree walk skips.
+  const inSubtree = resolveAgentForegroundProcessFromPs(rows, panePid)
+  if (inSubtree) {
+    return inSubtree
+  }
+  const paneRow = rows.find((row) => row.pid === panePid)
+  return paneRow
+    ? (recognizeAgentProcessFromCommandLine(paneRow.command)?.processName ?? null)
+    : null
 }
 
 function resolveAgentForegroundProcessFromPs(

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -12,6 +12,7 @@ import {
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import { getProcessTableSnapshot, type ProcessTableRow } from '../shared/process-table-snapshot'
 import { isShellProcess } from '../shared/shell-process-detection'
+import { isTmuxClientCommand, resolveTmuxActivePanePid } from '../shared/tmux-active-pane'
 import {
   resolveWindowsAgentForegroundProcess,
   shouldInspectWindowsAgentForeground
@@ -198,41 +199,72 @@ function candidateMatchesFallbackWrapper(
   return isExpectedAgentProcess(processCommandToken(candidate.command), fallbackProcess)
 }
 
+function recognizeAgentInSubtree(
+  rows: ProcessTableRow[],
+  pid: number,
+  fallbackProcess?: string | null
+): string | null {
+  const root = rows.find((row) => row.pid === pid)
+  const candidates = collectDescendants(rows, pid).sort(
+    (a, b) => candidateScore(b) - candidateScore(a)
+  )
+  // Why: SSH relays do not have the daemon's async wrapper cache. Inspect the
+  // remote process tree so node/python agent entrypoints become real agents.
+  const foregroundIsKnown =
+    root?.stat.includes('+') === true ||
+    candidates.some((candidate) => candidate.stat.includes('+'))
+  const foregroundCandidates = foregroundIsKnown
+    ? candidates.filter((candidate) => candidate.stat.includes('+'))
+    : candidates
+  const inspectionCandidates =
+    fallbackProcess && isAgentForegroundWrapperProcess(fallbackProcess)
+      ? foregroundCandidates.filter((candidate) =>
+          candidateMatchesFallbackWrapper(candidate, fallbackProcess)
+        )
+      : foregroundCandidates
+  if (
+    fallbackProcess &&
+    isAgentForegroundWrapperProcess(fallbackProcess) &&
+    inspectionCandidates.length !== 1
+  ) {
+    return null
+  }
+  for (const candidate of inspectionCandidates) {
+    const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
+    if (recognized) {
+      return recognized.processName
+    }
+  }
+  return null
+}
+
 async function getRecognizedForegroundDescendant(
   pid: number,
   fallbackProcess?: string | null
 ): Promise<string | null> {
   try {
     const rows = await getProcessTableSnapshot()
-    const root = rows.find((row) => row.pid === pid)
-    const candidates = collectDescendants(rows, pid).sort(
-      (a, b) => candidateScore(b) - candidateScore(a)
-    )
-    // Why: SSH relays do not have the daemon's async wrapper cache. Inspect the
-    // remote process tree so node/python agent entrypoints become real agents.
-    const foregroundIsKnown =
-      root?.stat.includes('+') === true ||
-      candidates.some((candidate) => candidate.stat.includes('+'))
-    const foregroundCandidates = foregroundIsKnown
-      ? candidates.filter((candidate) => candidate.stat.includes('+'))
-      : candidates
-    const inspectionCandidates =
-      fallbackProcess && isAgentForegroundWrapperProcess(fallbackProcess)
-        ? foregroundCandidates.filter((candidate) =>
-            candidateMatchesFallbackWrapper(candidate, fallbackProcess)
-          )
-        : foregroundCandidates
-    if (
-      fallbackProcess &&
-      isAgentForegroundWrapperProcess(fallbackProcess) &&
-      inspectionCandidates.length !== 1
-    ) {
-      return null
+    const recognized = recognizeAgentInSubtree(rows, pid, fallbackProcess)
+    if (recognized) {
+      return recognized
     }
-    for (const candidate of inspectionCandidates) {
-      const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
-      if (recognized) {
-        return recognized.processName
+    // Agents run inside a user's tmux are children of the reparented tmux
+    // server, not of the pane shell, so the subtree above misses them. If the
+    // shell holds a tmux client, hop to its active pane pid and re-walk.
+    const client = collectDescendants(rows, pid).find((row) => isTmuxClientCommand(row.command))
+    if (client) {
+      const panePid = await resolveTmuxActivePanePid(client.pid, client.command)
+      if (panePid) {
+        const inSubtree = recognizeAgentInSubtree(rows, panePid)
+        if (inSubtree) {
+          return inSubtree
+        }
+        // The agent can be the pane's own top process (e.g. `tmux new-session
+        // claude`), which the subtree walk skips.
+        const paneRow = rows.find((row) => row.pid === panePid)
+        return paneRow
+          ? (recognizeAgentProcessFromCommandLine(paneRow.command)?.processName ?? null)
+          : null
       }
     }
   } catch {

--- a/src/shared/tmux-active-pane.test.ts
+++ b/src/shared/tmux-active-pane.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isTmuxClientCommand,
+  parseTmuxSocketArgs,
+  resetTmuxActivePaneCacheForTests,
+  resolveTmuxActivePanePid
+} from './tmux-active-pane'
+
+describe('isTmuxClientCommand', () => {
+  it('recognizes plain and absolute-path tmux clients', () => {
+    expect(isTmuxClientCommand('tmux attach -t work')).toBe(true)
+    expect(isTmuxClientCommand('/opt/homebrew/bin/tmux a')).toBe(true)
+    expect(isTmuxClientCommand('tmux')).toBe(true)
+  })
+
+  it('does not match non-tmux commands or the status-line server row', () => {
+    expect(isTmuxClientCommand('claude')).toBe(false)
+    expect(isTmuxClientCommand('node index.js')).toBe(false)
+    expect(isTmuxClientCommand('tmuxinator start')).toBe(false)
+    expect(isTmuxClientCommand('tmux: server')).toBe(false)
+  })
+})
+
+describe('parseTmuxSocketArgs', () => {
+  it('extracts -L and -S in separated and glued forms', () => {
+    expect(parseTmuxSocketArgs('tmux -L mysock attach')).toEqual(['-L', 'mysock'])
+    expect(parseTmuxSocketArgs('tmux -S /tmp/foo attach')).toEqual(['-S', '/tmp/foo'])
+    expect(parseTmuxSocketArgs('tmux -Lmysock attach')).toEqual(['-L', 'mysock'])
+  })
+
+  it('returns [] for the default socket', () => {
+    expect(parseTmuxSocketArgs('tmux attach -t work')).toEqual([])
+    expect(parseTmuxSocketArgs('tmux')).toEqual([])
+  })
+})
+
+describe('resolveTmuxActivePanePid', () => {
+  beforeEach(() => resetTmuxActivePaneCacheForTests())
+
+  it('maps a client pid to its active pane pid via list-clients', async () => {
+    const runTmux = vi.fn().mockResolvedValue('999 111\n48034 48028\n1000 222\n')
+    const panePid = await resolveTmuxActivePanePid(48034, 'tmux attach', { runTmux })
+    expect(panePid).toBe(48028)
+    expect(runTmux).toHaveBeenCalledWith(['list-clients', '-F', '#{client_pid} #{pane_pid}'])
+  })
+
+  it('passes the socket selector through to tmux', async () => {
+    const runTmux = vi.fn().mockResolvedValue('42 7\n')
+    await resolveTmuxActivePanePid(42, 'tmux -L work attach', { runTmux })
+    expect(runTmux).toHaveBeenCalledWith([
+      '-L',
+      'work',
+      'list-clients',
+      '-F',
+      '#{client_pid} #{pane_pid}'
+    ])
+  })
+
+  it('returns null when the client pid is absent', async () => {
+    const runTmux = vi.fn().mockResolvedValue('999 111\n')
+    expect(await resolveTmuxActivePanePid(48034, 'tmux', { runTmux })).toBeNull()
+  })
+
+  it('returns null (never throws) when tmux fails', async () => {
+    const runTmux = vi.fn().mockRejectedValue(new Error('no server'))
+    expect(await resolveTmuxActivePanePid(1, 'tmux', { runTmux })).toBeNull()
+  })
+
+  it('serves a cached result within the TTL and refetches after it', async () => {
+    const runTmux = vi.fn().mockResolvedValue('5 55\n')
+    let clock = 1000
+    const now = () => clock
+
+    expect(await resolveTmuxActivePanePid(5, 'tmux', { runTmux, now })).toBe(55)
+    clock += 100
+    expect(await resolveTmuxActivePanePid(5, 'tmux', { runTmux, now })).toBe(55)
+    expect(runTmux).toHaveBeenCalledTimes(1)
+
+    clock += 500
+    expect(await resolveTmuxActivePanePid(5, 'tmux', { runTmux, now })).toBe(55)
+    expect(runTmux).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/shared/tmux-active-pane.ts
+++ b/src/shared/tmux-active-pane.ts
@@ -1,0 +1,111 @@
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import { getCommandTokenPathBasename, getFirstCommandToken } from './command-token-scanner'
+
+const execFile = promisify(execFileCb)
+
+const TMUX_TIMEOUT_MS = 2000
+// Why: mirrors the process-table snapshot TTL so a tmux-hosted pane polled on
+// the ~750ms foreground cadence forks `tmux` at most ~2x/sec instead of every
+// poll (same fork-pressure concern as the ps snapshot, issue #6288).
+const CACHE_TTL_MS = 500
+
+/**
+ * True when a ps command line is a tmux *client* we can hop through. Agents run
+ * inside tmux are children of the reparented tmux server (ppid 1), never of the
+ * pane shell — only the client appears in the shell's subtree, so this is what
+ * signals "an agent may be hidden behind tmux".
+ */
+export function isTmuxClientCommand(command: string): boolean {
+  // `tmux: server`/`tmux: client` status lines are not a plain `tmux` invocation.
+  return getCommandTokenPathBasename(getFirstCommandToken(command)) === 'tmux'
+}
+
+/**
+ * Extract the `-L <name>` / `-S <path>` socket selector from a tmux client
+ * command so we query the same server the client is attached to. Handles both
+ * separated (`-L name`) and glued (`-Lname`) forms; returns [] for the default
+ * socket.
+ */
+export function parseTmuxSocketArgs(command: string): string[] {
+  const tokens = command.trim().split(/\s+/).slice(1)
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]
+    for (const flag of ['-L', '-S'] as const) {
+      if (token === flag && tokens[i + 1]) {
+        return [flag, tokens[i + 1]]
+      }
+      if (token.startsWith(flag) && token.length > flag.length) {
+        return [flag, token.slice(flag.length)]
+      }
+    }
+  }
+  return []
+}
+
+type TmuxPaneCacheEntry = { panePid: number | null; capturedAtMs: number }
+// ponytail: unbounded Map, but keyed by client pid — only a handful of distinct
+// tmux clients ever exist in a session, and entries are tiny. Prune if it grows.
+const paneCache = new Map<number, TmuxPaneCacheEntry>()
+
+export type ResolveTmuxActivePanePidDeps = {
+  runTmux?: (args: string[]) => Promise<string>
+  now?: () => number
+}
+
+/**
+ * Given a tmux client (its pid + command line), return the pid of the pane
+ * process backing that client's active window/pane, or null. That pane process
+ * roots the subtree where the real agent (e.g. `claude`) lives. Best-effort:
+ * any failure resolves to null so foreground detection falls through unchanged.
+ */
+export async function resolveTmuxActivePanePid(
+  clientPid: number,
+  clientCommand: string,
+  deps: ResolveTmuxActivePanePidDeps = {}
+): Promise<number | null> {
+  const now = deps.now ?? (() => Date.now())
+  const cached = paneCache.get(clientPid)
+  if (cached && now() - cached.capturedAtMs < CACHE_TTL_MS) {
+    return cached.panePid
+  }
+
+  const runTmux =
+    deps.runTmux ??
+    (async (args: string[]) => {
+      const { stdout } = await execFile('tmux', args, {
+        encoding: 'utf-8',
+        timeout: TMUX_TIMEOUT_MS
+      })
+      return stdout
+    })
+
+  let panePid: number | null = null
+  try {
+    // `#{pane_pid}` resolves in the client's context to the active pane's pid,
+    // so one call maps client -> active pane without a second list-panes query.
+    const stdout = await runTmux([
+      ...parseTmuxSocketArgs(clientCommand),
+      'list-clients',
+      '-F',
+      '#{client_pid} #{pane_pid}'
+    ])
+    for (const line of stdout.split(/\r?\n/)) {
+      const match = line.trim().match(/^(\d+)\s+(\d+)$/)
+      if (match && Number(match[1]) === clientPid) {
+        panePid = Number(match[2])
+        break
+      }
+    }
+  } catch {
+    // Best-effort: no tmux / no server / socket gone -> fall through to null.
+  }
+
+  paneCache.set(clientPid, { panePid, capturedAtMs: now() })
+  return panePid
+}
+
+/** Test-only: clear the per-client pane cache between cases. */
+export function resetTmuxActivePaneCacheForTests(): void {
+  paneCache.clear()
+}


### PR DESCRIPTION
## What

Detect AI agents (e.g. `claude`, `codex`) that are running **inside a user's tmux session** so they show up as live/running on the pane, worktree, and project views.

Fixes #7797

## Why

Live foreground detection walks the process tree **downward from the pane's shell pid** and only inspects that subtree (`agent-foreground-process.ts` locally, `pty-shell-utils.ts` on the relay).

When a user runs `tmux` in an Orca pane, the process in the pane is the tmux **client**. tmux daemonizes a **server** (reparented to pid 1), and every pane process — including `claude` — is a child of that server, not of the pane's shell. So the descendant walk reaches only the tmux client (not a recognized agent) and the pane reads as `tmux`.

## How

When the shell's subtree contains a tmux client, hop to that client's active pane pid and re-run the same recognition walk:

1. Detect a tmux client among the descendants.
2. `tmux [-L/-S <sock>] list-clients -F '#{client_pid} #{pane_pid}'` → map our client pid to its active pane pid (one call; `#{pane_pid}` resolves in the client's context).
3. Re-run the existing recognition from that pane pid, and also consider the pane's own top process (covers `tmux new-session claude`).

- New shared module `src/shared/tmux-active-pane.ts` (`isTmuxClientCommand`, `parseTmuxSocketArgs`, `resolveTmuxActivePanePid` with a 500ms TTL cache so we don't fork `tmux` on every foreground poll).
- Mirrored in the **local** and **relay/SSH** paths.
- **Best-effort**: any tmux failure falls through to the previous behavior unchanged.
- **POSIX-only**; Windows path untouched.

## Testing

- New unit tests for `tmux-active-pane` (parsing, socket selector, client→pane mapping, cache TTL, failure fallback).
- New integration cases in `agent-foreground-process.test.ts` (client hop + fallback when no active pane).
- Existing relay `pty-shell-utils` tests still pass (recognition logic extracted to `recognizeAgentInSubtree`, reused).
- Verified end-to-end against real `tmux` 3.6 + real `ps`: agent detected both when it is a child of the pane shell and when it is the pane's top process.
- `oxlint` and `tsgo` typecheck clean.

## Notes

- The file-based Agent Session History (AI Vault) already surfaced these transcripts by `cwd`; this PR only fixes the **live/running** indicator.

## ELI5

Agents running inside your own tmux session didn’t show as live in Orca. Process detection now walks into tmux so Claude/Codex still appear as running.
