### PR TITLE
feat: add "Main agent only" filter to AI Vault

### DIFF
--- a/src/main/ai-vault/session-scanner-accumulator.ts
+++ b/src/main/ai-vault/session-scanner-accumulator.ts
@@ -41,6 +41,7 @@ export function createAccumulator(args: {
     messageCount: 0,
     totalTokens: 0,
     previewMessages: [],
+    entrypoint: null,
     latestTimestampMs: 0
   }
 }
@@ -110,6 +111,7 @@ export function finalizeSession(
     messageCount: accumulator.messageCount,
     totalTokens: accumulator.totalTokens,
     previewMessages: accumulator.previewMessages,
+    entrypoint: accumulator.entrypoint,
     resumeCommand: buildAiVaultResumeCommand({
       agent: accumulator.agent,
       sessionId,

--- a/src/main/ai-vault/session-scanner-primary-parsers.ts
+++ b/src/main/ai-vault/session-scanner-primary-parsers.ts
@@ -82,6 +82,13 @@ export function consumeClaudeSessionLine(state: ClaudeSessionParseState, line: s
   }
   updateTimeline(accumulator, extractString(record.timestamp))
   updateLatestLocation(accumulator, record)
+  // Track how the session is being driven ('cli' = interactive main agent,
+  // 'sdk-*' = SDK-spawned subagent/workflow) for the Main-agent-only filter.
+  // Last-wins so an SDK session later resumed interactively reads as main-agent.
+  const entrypoint = extractString(record.entrypoint)
+  if (entrypoint) {
+    accumulator.entrypoint = entrypoint
+  }
 
   if (record.type === 'custom-title') {
     accumulator.title = normalizeTitleText(extractString(record.customTitle) ?? '')

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -100,6 +100,7 @@ export type SessionAccumulator = {
   messageCount: number
   totalTokens: number
   previewMessages: AiVaultSessionPreviewMessage[]
+  entrypoint: string | null
   latestTimestampMs: number
 }
 

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -67,6 +67,7 @@ export default function AiVaultPanel(): React.JSX.Element {
   const [sort, setSort] = useState<AiVaultSort>('updated')
   const [group, setGroup] = useState<AiVaultGroup>('project')
   const [hideEmptySessions, setHideEmptySessions] = useState(true)
+  const [mainAgentOnly, setMainAgentOnly] = useState(true)
   const [agents, setAgents] = useState<AiVaultAgent[]>([...AI_VAULT_AGENTS])
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set())
   const userChangedScopeRef = useRef(false)
@@ -145,7 +146,8 @@ export default function AiVaultPanel(): React.JSX.Element {
     (hasAllAgentsSelected ? 0 : 1) +
     (sort === 'updated' ? 0 : 1) +
     (group === 'project' ? 0 : 1) +
-    (hideEmptySessions ? 0 : 1)
+    (hideEmptySessions ? 0 : 1) +
+    (mainAgentOnly ? 0 : 1)
 
   // Workspace is the preferred default, but unavailable context still falls back to All.
   useEffect(() => {
@@ -183,13 +185,15 @@ export default function AiVaultPanel(): React.JSX.Element {
         activeProjectKey,
         sessionProjectById,
         projectLabelByKey,
-        hideEmptySessions
+        hideEmptySessions,
+        mainAgentOnly
       }),
     [
       activeProjectKey,
       activeWorktreePaths,
       agents,
       hideEmptySessions,
+      mainAgentOnly,
       projectLabelByKey,
       query,
       scope,
@@ -274,6 +278,7 @@ export default function AiVaultPanel(): React.JSX.Element {
     setSort('updated')
     setGroup('project')
     setHideEmptySessions(true)
+    setMainAgentOnly(true)
   }, [])
 
   const handleScopeChange = useCallback((nextScope: AiVaultScope) => {
@@ -311,6 +316,7 @@ export default function AiVaultPanel(): React.JSX.Element {
         sort={sort}
         group={group}
         hideEmptySessions={hideEmptySessions}
+        mainAgentOnly={mainAgentOnly}
         adjustmentCount={viewAdjustmentCount}
         onQueryChange={setQuery}
         onScopeChange={handleScopeChange}
@@ -319,6 +325,7 @@ export default function AiVaultPanel(): React.JSX.Element {
         onSortChange={setSort}
         onGroupChange={setGroup}
         onHideEmptySessionsChange={setHideEmptySessions}
+        onMainAgentOnlyChange={setMainAgentOnly}
         onReset={resetViewOptions}
         onRefresh={() => void refresh({ force: true })}
       />

--- a/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
@@ -240,22 +240,26 @@ export function VaultViewMenu({
   sort,
   group,
   hideEmptySessions,
+  mainAgentOnly,
   adjustmentCount,
   onAgentEnabledChange,
   onSortChange,
   onGroupChange,
   onHideEmptySessionsChange,
+  onMainAgentOnlyChange,
   onReset
 }: {
   agents: readonly AiVaultAgent[]
   sort: AiVaultSort
   group: AiVaultGroup
   hideEmptySessions: boolean
+  mainAgentOnly: boolean
   adjustmentCount: number
   onAgentEnabledChange: (agent: AiVaultAgent, enabled: boolean) => void
   onSortChange: (sort: AiVaultSort) => void
   onGroupChange: (group: AiVaultGroup) => void
   onHideEmptySessionsChange: (hideEmptySessions: boolean) => void
+  onMainAgentOnlyChange: (mainAgentOnly: boolean) => void
   onReset: () => void
 }): React.JSX.Element {
   return (
@@ -357,6 +361,16 @@ export function VaultViewMenu({
           {translate(
             'auto.components.right.sidebar.AiVaultPanelControls.hideEmptySessions',
             'Hide empty sessions'
+          )}
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={mainAgentOnly}
+          onCheckedChange={(checked) => onMainAgentOnlyChange(checked === true)}
+          onSelect={(event) => event.preventDefault()}
+        >
+          {translate(
+            'auto.components.right.sidebar.AiVaultPanelControls.mainAgentOnly',
+            'Main agent only'
           )}
         </DropdownMenuCheckboxItem>
         {adjustmentCount > 0 ? (

--- a/src/renderer/src/components/right-sidebar/AiVaultPanelHeader.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanelHeader.tsx
@@ -25,6 +25,7 @@ type AiVaultPanelHeaderProps = {
   sort: AiVaultSort
   group: AiVaultGroup
   hideEmptySessions: boolean
+  mainAgentOnly: boolean
   adjustmentCount: number
   onQueryChange: (query: string) => void
   onScopeChange: (scope: AiVaultScope) => void
@@ -33,6 +34,7 @@ type AiVaultPanelHeaderProps = {
   onSortChange: (sort: AiVaultSort) => void
   onGroupChange: (group: AiVaultGroup) => void
   onHideEmptySessionsChange: (hideEmptySessions: boolean) => void
+  onMainAgentOnlyChange: (mainAgentOnly: boolean) => void
   onReset: () => void
   onRefresh: () => void
 }
@@ -52,6 +54,7 @@ export function AiVaultPanelHeader({
   sort,
   group,
   hideEmptySessions,
+  mainAgentOnly,
   adjustmentCount,
   onQueryChange,
   onScopeChange,
@@ -60,6 +63,7 @@ export function AiVaultPanelHeader({
   onSortChange,
   onGroupChange,
   onHideEmptySessionsChange,
+  onMainAgentOnlyChange,
   onReset,
   onRefresh
 }: AiVaultPanelHeaderProps): React.JSX.Element {
@@ -116,11 +120,13 @@ export function AiVaultPanelHeader({
             sort={sort}
             group={group}
             hideEmptySessions={hideEmptySessions}
+            mainAgentOnly={mainAgentOnly}
             adjustmentCount={adjustmentCount}
             onAgentEnabledChange={onAgentEnabledChange}
             onSortChange={onSortChange}
             onGroupChange={onGroupChange}
             onHideEmptySessionsChange={onHideEmptySessionsChange}
+            onMainAgentOnlyChange={onMainAgentOnlyChange}
             onReset={onReset}
           />
           <Button

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
@@ -6,6 +6,7 @@ import {
   folderLabel,
   groupAiVaultSessions,
   isAiVaultSessionFilterQueryTooLarge,
+  isMainAgentSession,
   parseVaultQuery
 } from './ai-vault-session-filters'
 import {
@@ -56,7 +57,8 @@ describe('filterAiVaultSessions', () => {
         scope: 'workspace',
         sort: 'updated',
         activeWorktreePaths: ['/Users/ada/repo'],
-        hideEmptySessions: true
+        hideEmptySessions: true,
+        mainAgentOnly: false
       }).map((session) => session.id)
     ).toEqual(['claude:1'])
   })
@@ -85,7 +87,8 @@ describe('filterAiVaultSessions', () => {
           '/Users/ada/workspaces/orca/fix-agent-history',
           '/Users/ada/workspaces/orca/bream'
         ],
-        hideEmptySessions: true
+        hideEmptySessions: true,
+        mainAgentOnly: false
       }).map((session) => session.id)
     ).toEqual(['claude:old-path'])
   })
@@ -98,7 +101,8 @@ describe('filterAiVaultSessions', () => {
         scope: 'workspace',
         sort: 'updated',
         activeWorktreePaths: [],
-        hideEmptySessions: true
+        hideEmptySessions: true,
+        mainAgentOnly: false
       })
     ).toEqual([])
   })
@@ -119,7 +123,8 @@ describe('filterAiVaultSessions', () => {
         scope: 'all',
         sort: 'updated',
         activeWorktreePaths: [],
-        hideEmptySessions: true
+        hideEmptySessions: true,
+        mainAgentOnly: false
       }).map((session) => session.id)
     ).toEqual(['claude:1'])
 
@@ -129,7 +134,8 @@ describe('filterAiVaultSessions', () => {
       scope: 'all',
       sort: 'updated',
       activeWorktreePaths: [],
-      hideEmptySessions: false
+      hideEmptySessions: false,
+      mainAgentOnly: false
     }).map((session) => session.id)
 
     expect(new Set(shownWhenAllowed)).toEqual(new Set(['claude:1', 'claude:empty']))
@@ -156,7 +162,8 @@ describe('filterAiVaultSessions', () => {
           scope: 'all',
           sort: 'updated',
           activeWorktreePaths: [],
-          hideEmptySessions: true
+          hideEmptySessions: true,
+          mainAgentOnly: false
         }
       ).map((session) => session.id)
     ).toEqual(['claude:1'])
@@ -188,7 +195,8 @@ describe('filterAiVaultSessions', () => {
           scope: 'all',
           sort: 'updated',
           activeWorktreePaths: [],
-          hideEmptySessions: true
+          hideEmptySessions: true,
+          mainAgentOnly: false
         }
       )
     ).toEqual([])
@@ -209,7 +217,8 @@ describe('filterAiVaultSessions', () => {
           scope: 'workspace',
           sort: 'updated',
           activeWorktreePaths: ['c:\\users\\ada\\repo'],
-          hideEmptySessions: true
+          hideEmptySessions: true,
+          mainAgentOnly: false
         }
       )
     ).toHaveLength(1)
@@ -230,7 +239,8 @@ describe('filterAiVaultSessions', () => {
           scope: 'workspace',
           sort: 'updated',
           activeWorktreePaths: [String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`],
-          hideEmptySessions: true
+          hideEmptySessions: true,
+          mainAgentOnly: false
         }
       )
     ).toHaveLength(1)
@@ -251,7 +261,8 @@ describe('filterAiVaultSessions', () => {
         scope: 'all',
         sort: 'updated',
         activeWorktreePaths: [],
-        hideEmptySessions: false
+        hideEmptySessions: false,
+        mainAgentOnly: false
       })
     ).toEqual([])
   })
@@ -273,7 +284,8 @@ describe('filterAiVaultSessions', () => {
         activeWorktreePaths: [],
         activeProjectKey: 'project:orca',
         sessionProjectById,
-        hideEmptySessions: true
+        hideEmptySessions: true,
+        mainAgentOnly: false
       }).map((session) => session.id)
     ).toEqual(['claude:project'])
   })
@@ -287,7 +299,8 @@ describe('filterAiVaultSessions', () => {
         sort: 'updated',
         activeWorktreePaths: [],
         activeProjectKey: null,
-        hideEmptySessions: true
+        hideEmptySessions: true,
+        mainAgentOnly: false
       })
     ).toEqual([])
   })
@@ -307,7 +320,8 @@ describe('filterAiVaultSessions', () => {
         activeWorktreePaths: [],
         sessionProjectById,
         projectLabelByKey,
-        hideEmptySessions: true
+        hideEmptySessions: true,
+        mainAgentOnly: false
       }).map((session) => session.id)
     ).toEqual(['claude:1'])
   })
@@ -656,5 +670,38 @@ describe('parseVaultQuery', () => {
 describe('folderLabel', () => {
   it('uses the last two path segments for compact labels', () => {
     expect(folderLabel('C:\\Users\\Ada\\repo\\app')).toBe('repo/app')
+  })
+})
+
+describe('main agent filter', () => {
+  it('treats sdk-spawned sessions as non-main and others as main', () => {
+    expect(isMainAgentSession({ ...baseSession, entrypoint: 'cli' })).toBe(true)
+    expect(isMainAgentSession({ ...baseSession, entrypoint: 'sdk-cli' })).toBe(false)
+    // No entrypoint (non-Claude agents, older transcripts) counts as main-agent.
+    expect(isMainAgentSession({ ...baseSession, entrypoint: null })).toBe(true)
+    expect(isMainAgentSession(baseSession)).toBe(true)
+  })
+
+  it('hides subagent/workflow sessions when mainAgentOnly is set', () => {
+    const sessions: AiVaultSession[] = [
+      { ...baseSession, id: 'main', entrypoint: 'cli' },
+      { ...baseSession, id: 'worker', sessionId: 'session-w', entrypoint: 'sdk-cli' }
+    ]
+    const filters = {
+      query: '',
+      agents: ['claude'] as const,
+      scope: 'all' as const,
+      sort: 'updated' as const,
+      activeWorktreePaths: [],
+      hideEmptySessions: false
+    }
+    expect(
+      filterAiVaultSessions(sessions, { ...filters, mainAgentOnly: true }).map((s) => s.id)
+    ).toEqual(['main'])
+    expect(
+      filterAiVaultSessions(sessions, { ...filters, mainAgentOnly: false })
+        .map((s) => s.id)
+        .sort()
+    ).toEqual(['main', 'worker'])
   })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.ts
@@ -25,6 +25,17 @@ export type AiVaultSessionFilterState = {
   sessionProjectById?: ReadonlyMap<string, AiVaultSessionProject>
   projectLabelByKey?: ReadonlyMap<string, string>
   hideEmptySessions: boolean
+  // When true, hide sessions the main agent spawned (subagents / workflows),
+  // keeping only the interactive main-agent conversations.
+  mainAgentOnly: boolean
+}
+
+// A session spawned by a subagent/workflow the main agent created, detected via
+// Claude Code's `entrypoint` ('sdk'-prefixed for SDK-spawned sessions). Sessions
+// launched or resumed interactively ('cli') and agents that don't record an
+// entrypoint are treated as main-agent conversations.
+export function isMainAgentSession(session: AiVaultSession): boolean {
+  return !(typeof session.entrypoint === 'string' && session.entrypoint.startsWith('sdk'))
 }
 
 export type AiVaultSessionGroup = {
@@ -62,6 +73,9 @@ export function filterAiVaultSessions(
   return sessions
     .filter((session) => {
       if (!agentSet.has(session.agent)) {
+        return false
+      }
+      if (filters.mainAgentOnly && !isMainAgentSession(session)) {
         return false
       }
       if (filters.hideEmptySessions && session.messageCount === 0) {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9683,7 +9683,8 @@
             "currentProjectLower": "current project",
             "project": "Project",
             "hostScopeAriaLabel": "Session History host: {{value0}}",
-            "host": "Host"
+            "host": "Host",
+            "mainAgentOnly": "Main agent only"
           },
           "AiVaultSessionDetails": {
             "originalAsk": "Original ask",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9683,7 +9683,8 @@
             "currentProjectLower": "proyecto actual",
             "project": "Proyecto",
             "hostScopeAriaLabel": "Host del historial de sesiones: {{value0}}",
-            "host": "Host"
+            "host": "Host",
+            "mainAgentOnly": "Solo agente principal"
           },
           "AiVaultSessionDetails": {
             "updated": "Actualizado",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9683,7 +9683,8 @@
             "currentProjectLower": "現在のプロジェクト",
             "project": "プロジェクト",
             "hostScopeAriaLabel": "Session History host: {{value0}}",
-            "host": "Host"
+            "host": "Host",
+            "mainAgentOnly": "メインエージェントのみ"
           },
           "AiVaultSessionDetails": {
             "updated": "更新日時",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9683,7 +9683,8 @@
             "currentProjectLower": "현재 프로젝트",
             "project": "프로젝트",
             "hostScopeAriaLabel": "Session History host: {{value0}}",
-            "host": "Host"
+            "host": "Host",
+            "mainAgentOnly": "메인 에이전트만"
           },
           "AiVaultSessionDetails": {
             "updated": "업데이트됨",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9683,7 +9683,8 @@
             "currentProjectLower": "当前项目",
             "project": "项目",
             "hostScopeAriaLabel": "Session History host: {{value0}}",
-            "host": "Host"
+            "host": "Host",
+            "mainAgentOnly": "仅主智能体"
           },
           "AiVaultSessionDetails": {
             "updated": "更新时间",

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -72,6 +72,11 @@ export type AiVaultSession = {
   messageCount: number
   totalTokens: number
   previewMessages: AiVaultSessionPreviewMessage[]
+  // How the session is being driven (Claude Code's transcript `entrypoint`):
+  // 'cli' for an interactive main-agent conversation, 'sdk'-prefixed for a
+  // subagent/workflow the main agent spawned. Undefined for agents that don't
+  // record it, which the filter then treats as main-agent sessions.
+  entrypoint?: string | null
   resumeCommand: string
 }
 


### PR DESCRIPTION
## What

Adds a **Main agent only** toggle to the AI Vault (Agent Sessions) view menu, next to *Hide empty sessions*. When on (the default), the list hides the subagent and workflow sessions the main agent spawns and keeps only the workspace's interactive conversations.

## Why

The Agent Sessions list mixes a workspace's own conversations with the SDK-spawned sessions the main agent creates (Task subagents, workflows, `claude -p` runs). When you open the vault to find a prompt *you* sent, those spawned sessions are noise. This toggle keeps the default view focused on the conversations you drive.

## How

- The Claude session scanner now captures each transcript's `entrypoint` (`'cli'` for an interactive main-agent conversation, `'sdk'`-prefixed for SDK-spawned subagents/workflows). Capture is **last-wins**, so an SDK session later resumed interactively (`'cli'`) is reclassified as a main-agent conversation.
- `isMainAgentSession()` treats a session as spawned only when its `entrypoint` is `'sdk'`-prefixed. Sessions launched/resumed interactively, and agents that don't record an entrypoint (Codex, Gemini, older transcripts, remote hosts), are always shown — the filter never hides a session it isn't confident is machine-spawned.
- The toggle defaults on; `filterAiVaultSessions` applies it alongside the existing agent/scope/empty filters. Reset view restores the default.

## Signal choice (validated against real transcripts)

I compared `entrypoint` against `promptSource: 'typed'` as the main-vs-spawned signal on the 60 most recent local transcripts. `promptSource: 'typed'` was present in only 6 of 60 (most transcripts omit it entirely), so a typed-prompt heuristic would have hidden real interactive sessions. `entrypoint` was present and reliable (54 `cli`, 1 `sdk-cli`, 5 none), so it's the signal used here.

**Known limitation:** `entrypoint` distinguishes SDK-launched from interactively-launched, which is not identical to spawned-vs-main. An orchestration worker launched as an interactive terminal (`entrypoint: 'cli'`) is not hidden. This is the safe direction — the filter errs toward showing rather than hiding a real conversation.

## Testing

- New unit tests for `isMainAgentSession` and the `mainAgentOnly` filter path.
- `typecheck`, `oxlint`, `verify:localization-coverage`, the AI Vault + filter test suites (121 tests), and both `electron-vite` and web builds pass.
- New `mainAgentOnly` label localized across all five locales (en/es/ja/ko/zh).

## ELI5

AI Vault can hide subagent and workflow sessions and show only main-agent chats. “Main agent only” is on by default so finding your own conversations is quieter.
