### PR TITLE
fix(pi): respect per-agent disabled state when installing status hook extensions

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1678,6 +1678,7 @@ describe('registerPtyHandlers', () => {
     getSettings?: () => {
       enableGitHubAttribution?: boolean
       agentStatusHooksEnabled?: boolean
+      disabledTuiAgents?: readonly string[]
       httpProxyUrl?: string
       httpProxyBypassRules?: string
     },
@@ -2596,6 +2597,42 @@ describe('registerPtyHandlers', () => {
         materializeDefaultHome: true
       })
       expect(env.ORCA_PI_SOURCE_AGENT_DIR).toBe('/tmp/default-pi-agent')
+    })
+
+    it('skips Pi managed extensions when Pi is disabled in Settings > Agents', async () => {
+      // Why: #7814 — global agentStatusHooksEnabled must not install orca-*.ts
+      // into ~/.pi when the user turned Pi off per-agent.
+      const env = await spawnAndGetEnv(
+        undefined,
+        { PI_CODING_AGENT_DIR: '/tmp/user-pi-agent' },
+        undefined,
+        () => ({ disabledTuiAgents: ['pi'] })
+      )
+      expect(piBuildPtyEnvMock).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.anything(),
+        'pi'
+      )
+      // OMP shadow prep still runs for non-omp launches unless omp is disabled.
+      expect(piBuildPtyEnvMock).toHaveBeenCalledWith(expect.any(String), undefined, 'omp')
+      expect(env.ORCA_PI_SOURCE_AGENT_DIR).toBeUndefined()
+    })
+
+    it('skips OMP managed extensions when OMP is disabled in Settings > Agents', async () => {
+      const env = await spawnAndGetEnv(
+        undefined,
+        { PI_CODING_AGENT_DIR: '/tmp/user-omp-agent' },
+        undefined,
+        () => ({ disabledTuiAgents: ['omp'] }),
+        'omp'
+      )
+      expect(piBuildPtyEnvMock).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.anything(),
+        'omp'
+      )
+      expect(env.ORCA_OMP_STATUS_EXTENSION).toBeUndefined()
+      expect(env.ORCA_OMP_SOURCE_AGENT_DIR).toBeUndefined()
     })
 
     it('threads command: "omp" through to piBuildPtyEnv and emits OMP status metadata', async () => {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2614,7 +2614,9 @@ describe('registerPtyHandlers', () => {
         'pi'
       )
       // OMP shadow prep still runs for non-omp launches unless omp is disabled.
-      expect(piBuildPtyEnvMock).toHaveBeenCalledWith(expect.any(String), undefined, 'omp')
+      expect(piBuildPtyEnvMock).toHaveBeenCalledWith(expect.any(String), undefined, 'omp', {
+        materializeDefaultHome: false
+      })
       expect(env.ORCA_PI_SOURCE_AGENT_DIR).toBeUndefined()
     })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -65,6 +65,7 @@ import {
   isPiCompatibleAgentType,
   type PiAgentKind
 } from '../../shared/pi-agent-kind'
+import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
 import { isPwshAvailable } from '../pwsh'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
@@ -1005,6 +1006,10 @@ export type BuildPtyHostEnvOptions = {
   /** Distro for WSL spawns (null = Windows default distro); drives the WSL hook relay + endpoint repoint. Only read when isWsl. */
   wslDistro?: string | null
   agentStatusHooksEnabled: boolean
+  /** Per-user disabled agents from Settings > Agents. Used to avoid installing
+   *  managed Pi/OMP extensions (writing orca-*.ts files into ~/.pi or ~/.omp)
+   *  for agents the user has explicitly disabled. */
+  disabledTuiAgents?: readonly unknown[] | null
   networkProxySettings?: NetworkProxySettings
   /** Keep indexed Git config off the sparse daemon wire; the daemon appends guard entries after merging its inherited env. */
   deferGitConfigGuardToDaemon?: boolean
@@ -1617,7 +1622,9 @@ export function buildPtyHostEnv(
     // (#10196). Only create default homes on an explicit Pi/OMP launch;
     // otherwise install only into an existing agent dir (or userData for OMP
     // status so a typed `omp` still gets the shell wrapper extension).
-    if (piAgentKind === 'pi') {
+    // Why: only install Orca-managed extensions for agents enabled in Settings >
+    // Agents so disabled agents do not get orca-*.ts pollution (#7814).
+    if (piAgentKind === 'pi' && isTuiAgentEnabled('pi', opts.disabledTuiAgents)) {
       const piEnv = piTitlebarExtensionService.buildPtyEnv(id, preexistingPiAgentDir, 'pi', {
         materializeDefaultHome: explicitPiAgentKind === 'pi'
       })
@@ -1625,7 +1632,7 @@ export function buildPtyHostEnv(
       exposePiManagedExtensionEnv(baseEnv, 'pi', piEnv)
     }
 
-    if (shouldPrepareOmpShadow) {
+    if (shouldPrepareOmpShadow && isTuiAgentEnabled('omp', opts.disabledTuiAgents)) {
       const ompEnv = piTitlebarExtensionService.buildPtyEnv(id, preexistingOmpAgentDir, 'omp', {
         materializeDefaultHome: explicitPiAgentKind === 'omp'
       })
@@ -2253,6 +2260,7 @@ export function registerPtyHandlers(
           isWsl: ctx?.isWsl,
           wslDistro: ctx?.wslDistro ?? null,
           agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
+          disabledTuiAgents: getSettings?.()?.disabledTuiAgents,
           networkProxySettings: getSettings?.()
         })
         // Why: agents need their terminal handle at process start to self-identify in orchestration messages without an extra RPC.
@@ -4417,6 +4425,7 @@ export function registerPtyHandlers(
           isWsl: shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, cwd),
           wslDistro: codexSelectionTarget.runtime === 'wsl' ? expectedWslDistro : null,
           agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
+          disabledTuiAgents: getSettings?.()?.disabledTuiAgents,
           networkProxySettings: getSettings?.(),
           deferGitConfigGuardToDaemon: provider.supportsGitCredentialGuardHost?.(sessionId) === true
         })
@@ -5804,6 +5813,7 @@ export function registerPtyHandlers(
               isWsl: shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, cwd),
               wslDistro: codexSelectionTarget.runtime === 'wsl' ? expectedWslDistro : null,
               agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
+              disabledTuiAgents: getSettings?.()?.disabledTuiAgents,
               networkProxySettings: getSettings?.(),
               deferGitConfigGuardToDaemon:
                 provider.supportsGitCredentialGuardHost?.(effectiveSessionId) === true

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1009,7 +1009,7 @@ export type BuildPtyHostEnvOptions = {
   /** Per-user disabled agents from Settings > Agents. Used to avoid installing
    *  managed Pi/OMP extensions (writing orca-*.ts files into ~/.pi or ~/.omp)
    *  for agents the user has explicitly disabled. */
-  disabledTuiAgents?: readonly unknown[] | null
+  disabledTuiAgents?: readonly TuiAgent[] | null
   networkProxySettings?: NetworkProxySettings
   /** Keep indexed Git config off the sparse daemon wire; the daemon appends guard entries after merging its inherited env. */
   deferGitConfigGuardToDaemon?: boolean


### PR DESCRIPTION
## Summary

When `agentStatusHooksEnabled` is true globally, Orca was still installing managed status hook extensions (`orca-*.ts`) into `~/.pi/agent/extensions` (and the OMP equivalent) even if the user disabled Pi/OMP under **Settings → Agents**.

`buildPtyHostEnv` now gates Pi and OMP extension install with `isTuiAgentEnabled(...)`, and all spawn call sites forward `disabledTuiAgents` from settings.

Fixes #7814

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - `vitest run src/main/ipc/pty.test.ts -t "skips Pi managed extensions|skips OMP managed extensions|installs Pi managed extensions"` (4 passed)

## AI Review Report

Scoped change in `buildPtyHostEnv` + settings plumbing. Checked:
- **macOS / Linux / Windows**: same Settings → Agents `disabledTuiAgents` list; no platform-specific branching.
- **SSH / remote / local**: uses existing `buildPtyHostEnv` on local, daemon, and related spawn paths that already pass settings.
- **Agents**: only Pi and OMP managed titlebar/status extension install is gated; other agents unchanged.
- **Performance**: one `isTuiAgentEnabled` check per spawn when hooks are enabled.

## Security Audit

- No new IPC surface; only forwards existing `disabledTuiAgents` settings into host env construction.
- Reduces unexpected filesystem writes into `~/.pi` / `~/.omp` when the user disabled those agents.
- No secrets, auth, or path traversal changes.

## Notes

- Current merge base: `origin/main@0b65d725c98d`.
- Platform-agnostic; follows per-agent disable list already used elsewhere in the app.

## ELI5

Even if you disabled Pi/OMP under Agents, Orca still installed status hook files for them. Hooks now respect the per-agent disabled setting when the global toggle is on.
