### PR TITLE
fix(terminal): let remote desktop viewers own the shared PTY width

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4100,10 +4100,12 @@ describe('registerPtyHandlers', () => {
         createPreAllocatedTerminalHandle: vi.fn(() => null),
         registerPty: vi.fn(),
         getDriver: vi.fn(() => ({ kind: 'host' })),
+        isPtyResizeDrivenRemotely: vi.fn(() => false),
         isResizeSuppressed: vi.fn(() => false),
         onPtySpawned: vi.fn(),
         onPtyExit: vi.fn(),
         onPtyData: vi.fn(),
+        recordRemoteDesktopHostReclaimTarget: vi.fn(),
         onExternalPtyResize: vi.fn()
       }
       handlers.clear()
@@ -4132,10 +4134,12 @@ describe('registerPtyHandlers', () => {
         createPreAllocatedTerminalHandle: vi.fn(() => null),
         registerPty: vi.fn(),
         getDriver: vi.fn(() => ({ kind: 'host' })),
+        isPtyResizeDrivenRemotely: vi.fn(() => false),
         isResizeSuppressed: vi.fn(() => false),
         onPtySpawned: vi.fn(),
         onPtyExit: vi.fn(),
         onPtyData: vi.fn(),
+        recordRemoteDesktopHostReclaimTarget: vi.fn(),
         onExternalPtyResize: vi.fn()
       }
       handlers.clear()
@@ -4145,6 +4149,39 @@ describe('registerPtyHandlers', () => {
 
       resizeListener()(mainWindowIpcEvent, { id, cols: 120, rows: 30 })
 
+      expect(runtime.onExternalPtyResize).not.toHaveBeenCalled()
+    })
+
+    it('suppresses the host fit cascade while a remote viewer drives the width', async () => {
+      const resizeSpy = vi.fn()
+      setupProviderWithAppliedSize({ applied: { cols: 80, rows: 24 }, resize: resizeSpy })
+      const runtime = {
+        setPtyController: vi.fn(),
+        createPreAllocatedTerminalHandle: vi.fn(() => null),
+        registerPty: vi.fn(),
+        getDriver: vi.fn(() => ({ kind: 'idle' })),
+        // The whole point of the fix: a PTY with a remote viewer reports true,
+        // even though the presence-lock driver state stays idle/desktop.
+        isPtyResizeDrivenRemotely: vi.fn(() => true),
+        isResizeSuppressed: vi.fn(() => false),
+        onPtySpawned: vi.fn(),
+        onPtyExit: vi.fn(),
+        onPtyData: vi.fn(),
+        recordRemoteDesktopHostReclaimTarget: vi.fn(),
+        onExternalPtyResize: vi.fn()
+      }
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, runtime as never)
+      const spawn = await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, env: {} })
+      const id = (spawn as { id: string }).id
+      resizeSpy.mockClear()
+
+      // Host's own safeFit tries to widen the viewed PTY back to its window.
+      resizeListener()(mainWindowIpcEvent, { id, cols: 125, rows: 48 })
+
+      // It must not reach the PTY while the viewer owns the width.
+      expect(resizeSpy).not.toHaveBeenCalled()
+      expect(runtime.recordRemoteDesktopHostReclaimTarget).toHaveBeenCalledWith(id, 125, 48)
       expect(runtime.onExternalPtyResize).not.toHaveBeenCalled()
     })
   })
@@ -4218,6 +4255,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -4297,6 +4335,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -4328,6 +4367,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -4365,6 +4405,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -4461,6 +4502,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -4512,6 +4554,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -4998,6 +5041,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -5252,6 +5296,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -5360,6 +5405,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -5453,6 +5499,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()
@@ -5557,6 +5604,7 @@ describe('registerPtyHandlers', () => {
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn(),
       getDriver: vi.fn(() => ({ kind: 'host' })),
+      isPtyResizeDrivenRemotely: vi.fn(() => false),
       onPtySpawned: vi.fn(),
       onPtyExit: vi.fn(),
       onPtyData: vi.fn()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3522,14 +3522,18 @@ export function registerPtyHandlers(
     if (runtime?.isResizeSuppressed()) {
       return
     }
-    // Why: presence-lock defense-in-depth. While mobile is driving,
-    // desktop-side resizes (auto-fit on window resize, split drag) must
-    // not reach the PTY. The renderer guard checks the driver state too,
-    // but this is the load-bearing layer because the renderer mirror lags
-    // by one IPC hop. Note: BOTH guards apply — isResizeSuppressed handles
-    // the safeFit cascade after take-back; this driver check handles the
-    // ongoing locked state. See docs/mobile-presence-lock.md.
-    if (runtime?.getDriver(args.id).kind === 'mobile') {
+    // Why: presence-lock defense-in-depth. While a phone OR a remote desktop
+    // viewer drives the PTY width, the host's own desktop-side resizes
+    // (auto-fit on window resize, split drag, tab reveal, "+"-new-tab
+    // re-render) must not reach the PTY — otherwise they overwrite the remote
+    // viewer's grid and its alt-screen TUI garbles ("porridge"). The renderer
+    // guard checks the driver state too, but this is the load-bearing layer
+    // because the renderer mirror lags by one IPC hop. Note: BOTH guards apply
+    // — isResizeSuppressed handles the safeFit cascade after take-back; this
+    // driver check handles the ongoing locked state. See
+    // docs/mobile-presence-lock.md.
+    if (runtime?.isPtyResizeDrivenRemotely(args.id)) {
+      runtime.recordRemoteDesktopHostReclaimTarget(args.id, args.cols, args.rows)
       return
     }
     const provider = tryGetProviderForPty(args.id)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -7282,7 +7282,11 @@ export class OrcaRuntimeService {
     this.freshSubscribeGuard.add(ptyId)
     try {
       const result = await this.enqueueLayout(ptyId, layoutTarget)
-      if (reclaimingHost) {
+      // Why: only drop the recorded host size once the reclaim resize actually
+      // landed. If it failed, the PTY is still at the remote-viewer width, so
+      // keep the target for the next reclaim (otherwise it resolves via the
+      // stale remote width and never restores true host geometry).
+      if (reclaimingHost && result.ok) {
         this.remoteDesktopHostReclaimTargets.delete(ptyId)
       }
       return result.ok
@@ -7321,6 +7325,38 @@ export class OrcaRuntimeService {
     viewers.delete(subscriptionKey)
     if (viewers.size === 0) {
       this.remoteDesktopViewers.delete(ptyId)
+    }
+    return this.applyRemoteDesktopLayout(ptyId)
+  }
+
+  // Why: the one-shot `terminal.updateViewport` RPC has no disconnect hook, so
+  // it must never *create* a width floor (that floor would leak — nothing
+  // releases it, pinning the host at a stale width after the viewer is gone).
+  // It only refreshes the floor(s) this client already owns via its stream
+  // subscription, keyed by clientId. Mirrors the mobile `updateMobileViewport`
+  // no-op-without-subscription invariant. Returns false when the client owns no
+  // floor (passive/stream-less viewer) — a stream-less viewer must not lock host
+  // resize.
+  refreshRemoteDesktopViewer(
+    ptyId: string,
+    clientId: string,
+    cols: number,
+    rows: number
+  ): Promise<boolean> {
+    const viewers = this.remoteDesktopViewers.get(ptyId)
+    if (!viewers) {
+      return Promise.resolve(false)
+    }
+    const viewport = clampTerminalViewport(cols, rows)
+    let changed = false
+    for (const [subscriptionKey, viewer] of viewers) {
+      if (viewer.clientId === clientId) {
+        viewers.set(subscriptionKey, { clientId, cols: viewport.cols, rows: viewport.rows })
+        changed = true
+      }
+    }
+    if (!changed) {
+      return Promise.resolve(false)
     }
     return this.applyRemoteDesktopLayout(ptyId)
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1973,6 +1973,7 @@ export type DriverState = RuntimeTerminalDriverState
 export type PtyLayoutTarget =
   | { kind: 'desktop'; cols: number; rows: number }
   | { kind: 'phone'; cols: number; rows: number; ownerClientId: string }
+  | { kind: 'remote-desktop'; cols: number; rows: number }
 
 // Why: authoritative layout state with monotonic seq. Bumped on every
 // applyLayout success; emitted on mobile subscribe-stream events so clients
@@ -2197,6 +2198,15 @@ export class OrcaRuntimeService {
   // docs/mobile-presence-lock.md.
   private currentDriver = new Map<string, DriverState>()
   private currentBrowserDriver = new Map<string, RuntimeBrowserDriverState>()
+
+  // Why: remote (relay/shared-control) desktop viewers of a PTY are keyed by
+  // subscription, not client, because one client can open duplicate streams and
+  // each stream must release only the width floor it registered.
+  private remoteDesktopViewers = new Map<
+    string,
+    Map<string, { clientId: string; cols: number; rows: number }>
+  >()
+  private remoteDesktopHostReclaimTargets = new Map<string, { cols: number; rows: number }>()
 
   // Why: resubscribe-grace window. When the last mobile subscriber for a
   // PTY unsubscribes, we hold the driver=mobile{clientId} state and the
@@ -6960,7 +6970,11 @@ export class OrcaRuntimeService {
       // at phone dims after the phone disconnects; the desktop banner's
       // Restore button is the explicit return path. See
       // docs/mobile-fit-hold.md.
-      if (cur?.kind === 'phone' && this.getAutoRestoreFitMs() != null) {
+      if (this.hasRemoteDesktopViewers(ptyId)) {
+        this.setDriver(ptyId, { kind: 'idle' })
+        void this.applyRemoteDesktopLayout(ptyId)
+        continue
+      } else if (cur?.kind === 'phone' && this.getAutoRestoreFitMs() != null) {
         // Use the soft-leaver's snapshot baseline as a hint, falling
         // through to resolveDesktopRestoreTarget for missing values.
         const fallback = this.resolveDesktopRestoreTarget(ptyId)
@@ -6998,7 +7012,11 @@ export class OrcaRuntimeService {
     for (const { ptyId, baseline } of ptysToRestore) {
       const cur = this.layouts.get(ptyId)
       // Why: Indefinite hold gate — see soft-leaver branch above.
-      if (cur?.kind === 'phone' && this.getAutoRestoreFitMs() != null) {
+      if (this.hasRemoteDesktopViewers(ptyId)) {
+        this.setDriver(ptyId, { kind: 'idle' })
+        void this.applyRemoteDesktopLayout(ptyId)
+        continue
+      } else if (cur?.kind === 'phone' && this.getAutoRestoreFitMs() != null) {
         const fallback = this.resolveDesktopRestoreTarget(ptyId)
         const cols = baseline?.cols ?? fallback.cols
         const rows = baseline?.rows ?? fallback.rows
@@ -7123,6 +7141,8 @@ export class OrcaRuntimeService {
       this.currentDriver.delete(ptyId)
       this.notifier?.terminalDriverChanged(ptyId, { kind: 'idle' })
     }
+    this.remoteDesktopViewers.delete(ptyId)
+    this.remoteDesktopHostReclaimTargets.delete(ptyId)
     this.disposeHeadlessTerminal(ptyId)
     this.agentDetector?.onExit(ptyId)
     const pty = this.ptysById.get(ptyId)
@@ -7175,6 +7195,157 @@ export class OrcaRuntimeService {
       for (const listener of listeners) {
         listener(next)
       }
+    }
+  }
+
+  // Why: the host's own fit cascade (window resize, split drag, tab reveal,
+  // "+"-new-tab re-render) must not resize a PTY whose width a remote client
+  // owns — that is the remote "porridge" bug. True while a phone (mobile driver)
+  // OR a remote desktop viewer holds the PTY. Input is deliberately NOT gated
+  // here (see the `writePtyInput` mobile-only checks): shared-control desktop
+  // viewers may still type alongside the host.
+  // Note: this is intentionally NOT a driver kind. A remote desktop viewer needs
+  // only resize suppression, not the mobile driver machinery (input lock,
+  // phone-fit, driver-change banners), so it lives in its own registry and does
+  // not perturb the presence-lock state machine. It also coexists with mobile:
+  // while a phone drives, the registry still suppresses host resize, and when
+  // the phone leaves the surviving viewer keeps the PTY suppressed.
+  isPtyResizeDrivenRemotely(ptyId: string): boolean {
+    if (this.getDriver(ptyId).kind === 'mobile') {
+      return true
+    }
+    return this.hasRemoteDesktopViewers(ptyId)
+  }
+
+  private hasRemoteDesktopViewers(ptyId: string): boolean {
+    const viewers = this.remoteDesktopViewers.get(ptyId)
+    return viewers !== undefined && viewers.size > 0
+  }
+
+  // Why: the smallest attached viewer wins (tmux model). A wider viewer showing
+  // a few unused columns is fine; a narrower viewer receiving host-width frames
+  // garbles, so the PTY must never exceed the narrowest grid.
+  private minRemoteDesktopViewport(
+    viewers: Map<string, { cols: number; rows: number }>
+  ): { cols: number; rows: number } | null {
+    let cols = Infinity
+    let rows = Infinity
+    for (const viewport of viewers.values()) {
+      cols = Math.min(cols, viewport.cols)
+      rows = Math.min(rows, viewport.rows)
+    }
+    return Number.isFinite(cols) && Number.isFinite(rows) ? { cols, rows } : null
+  }
+
+  private resolveRemoteDesktopHostReclaimTarget(ptyId: string): { cols: number; rows: number } {
+    const target = this.remoteDesktopHostReclaimTargets.get(ptyId)
+    if (target) {
+      return target
+    }
+    const renderer = this.lastRendererSizes.get(ptyId)
+    if (renderer) {
+      return { cols: renderer.cols, rows: renderer.rows }
+    }
+    const size = this.getTerminalSize(ptyId)
+    if (size) {
+      return { cols: size.cols, rows: size.rows }
+    }
+    return { cols: 80, rows: 24 }
+  }
+
+  private ensureRemoteDesktopHostReclaimTarget(ptyId: string): void {
+    if (!this.remoteDesktopHostReclaimTargets.has(ptyId)) {
+      this.remoteDesktopHostReclaimTargets.set(
+        ptyId,
+        this.resolveRemoteDesktopHostReclaimTarget(ptyId)
+      )
+    }
+  }
+
+  recordRemoteDesktopHostReclaimTarget(ptyId: string, cols: number, rows: number): void {
+    if (cols <= 0 || rows <= 0) {
+      return
+    }
+    this.remoteDesktopHostReclaimTargets.set(ptyId, { cols, rows })
+  }
+
+  async applyRemoteDesktopLayout(ptyId: string): Promise<boolean> {
+    if (this.getDriver(ptyId).kind === 'mobile') {
+      return true
+    }
+    const viewers = this.remoteDesktopViewers.get(ptyId)
+    const target = viewers ? this.minRemoteDesktopViewport(viewers) : null
+    const reclaimingHost = !target
+    const layoutTarget: PtyLayoutTarget = target
+      ? { kind: 'remote-desktop', cols: target.cols, rows: target.rows }
+      : { kind: 'desktop', ...this.resolveRemoteDesktopHostReclaimTarget(ptyId) }
+    this.freshSubscribeGuard.add(ptyId)
+    try {
+      const result = await this.enqueueLayout(ptyId, layoutTarget)
+      if (reclaimingHost) {
+        this.remoteDesktopHostReclaimTargets.delete(ptyId)
+      }
+      return result.ok
+    } finally {
+      this.freshSubscribeGuard.delete(ptyId)
+    }
+  }
+
+  // Why: a remote (relay/shared-control) desktop viewer reporting a viewport
+  // takes/refreshes the width floor so the host's fit cascade stops fighting it.
+  // The source PTY is sized to the SMALLEST attached viewer so no viewer ever
+  // receives frames wider than its grid.
+  async updateRemoteDesktopViewer(
+    ptyId: string,
+    subscriptionKey: string,
+    clientId: string,
+    cols: number,
+    rows: number
+  ): Promise<boolean> {
+    const viewport = clampTerminalViewport(cols, rows)
+    this.ensureRemoteDesktopHostReclaimTarget(ptyId)
+    let viewers = this.remoteDesktopViewers.get(ptyId)
+    if (!viewers) {
+      viewers = new Map<string, { clientId: string; cols: number; rows: number }>()
+      this.remoteDesktopViewers.set(ptyId, viewers)
+    }
+    viewers.set(subscriptionKey, { clientId, cols: viewport.cols, rows: viewport.rows })
+    return this.applyRemoteDesktopLayout(ptyId)
+  }
+
+  unregisterRemoteDesktopViewer(ptyId: string, subscriptionKey: string): Promise<boolean> {
+    const viewers = this.remoteDesktopViewers.get(ptyId)
+    if (!viewers) {
+      return Promise.resolve(false)
+    }
+    viewers.delete(subscriptionKey)
+    if (viewers.size === 0) {
+      this.remoteDesktopViewers.delete(ptyId)
+    }
+    return this.applyRemoteDesktopLayout(ptyId)
+  }
+
+  async updateDesktopViewport(
+    ptyId: string,
+    viewport: { cols: number; rows: number }
+  ): Promise<boolean> {
+    const { cols, rows } = clampTerminalViewport(viewport.cols, viewport.rows)
+    if (this.terminalFitOverrides.has(ptyId) || this.getDriver(ptyId).kind === 'mobile') {
+      this.recordRendererGeometry(ptyId, cols, rows)
+      return true
+    }
+    if (this.isResizeSuppressed()) {
+      return false
+    }
+    this.freshSubscribeGuard.add(ptyId)
+    try {
+      const result = await this.enqueueLayout(ptyId, { kind: 'desktop', cols, rows })
+      if (result.ok) {
+        this.refreshRendererGeometry(ptyId, cols, rows)
+      }
+      return result.ok
+    } finally {
+      this.freshSubscribeGuard.delete(ptyId)
     }
   }
 
@@ -7276,37 +7447,6 @@ export class OrcaRuntimeService {
       }
     }
     return { updated: true, applied: result.ok }
-  }
-
-  // Why: remote desktop clients do not have the local `pty:resize` IPC path.
-  // Their measured xterm size still has to resize the source PTY so TUIs
-  // reflow to the visible client dimensions.
-  async updateDesktopViewport(
-    ptyId: string,
-    viewport: { cols: number; rows: number }
-  ): Promise<boolean> {
-    const { cols, rows } = clampTerminalViewport(viewport.cols, viewport.rows)
-    if (this.terminalFitOverrides.has(ptyId)) {
-      // Why: remote desktop panes do not have the local pty:reportGeometry
-      // IPC. While phone-fit holds the PTY, treat their viewport RPC as a
-      // measurement-only restore target, not a resize intent.
-      this.recordRendererGeometry(ptyId, cols, rows)
-      return true
-    }
-    if (this.isResizeSuppressed() || this.getDriver(ptyId).kind === 'mobile') {
-      return false
-    }
-    let resized = false
-    try {
-      resized = this.ptyController?.resize?.(ptyId, cols, rows) ?? false
-    } catch {
-      return false
-    }
-    if (!resized) {
-      return false
-    }
-    this.onExternalPtyResize(ptyId, cols, rows)
-    return true
   }
 
   // Why: invoked from `runtime:restoreTerminalFit` IPC (the desktop "Take
@@ -7711,7 +7851,7 @@ export class OrcaRuntimeService {
     // only if that invariant is ever violated, repairing the renderer instead
     // of stranding the held modal.
     const overrideChanged = (prevFitOverride != null) !== (target.kind === 'phone')
-    if (modeChanged || overrideChanged) {
+    if (target.kind !== 'remote-desktop' && (modeChanged || overrideChanged)) {
       // Why: phone→desktop arms the renderer-cascade suppress window
       // before the collateral safeFit IPCs arrive. See "Renderer cascade
       // suppression".
@@ -8032,6 +8172,9 @@ export class OrcaRuntimeService {
       this.pendingSoftLeavers.delete(ptyId)
       if (!this.mobileSubscribers.has(ptyId)) {
         this.setDriver(ptyId, { kind: 'idle' })
+        if (this.hasRemoteDesktopViewers(ptyId)) {
+          void this.applyRemoteDesktopLayout(ptyId)
+        }
       }
     }, SOFT_LEAVE_GRACE_MS)
     if (typeof softTimer.unref === 'function') {
@@ -8082,6 +8225,10 @@ export class OrcaRuntimeService {
         const timer = setTimeout(() => {
           this.pendingRestoreTimers.delete(ptyId)
           if (this.isMobileSubscriberActive(ptyId)) {
+            return
+          }
+          if (this.hasRemoteDesktopViewers(ptyId)) {
+            void this.applyRemoteDesktopLayout(ptyId)
             return
           }
           void this.enqueueLayout(ptyId, {

--- a/src/main/runtime/remote-desktop-driver.test.ts
+++ b/src/main/runtime/remote-desktop-driver.test.ts
@@ -194,6 +194,74 @@ describe('remote desktop viewer width driver', () => {
     expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 120, rows: 40 })
   })
 
+  it('refresh never creates a floor (one-shot viewport cannot leak host suppression)', async () => {
+    const { runtime } = createRuntime()
+    // A one-shot terminal.updateViewport (refresh) from a viewer with no stream
+    // floor must NOT register one — that floor would leak (nothing releases a
+    // one-shot RPC's state), pinning the host at a stale width forever.
+    const created = await runtime.refreshRemoteDesktopViewer('pty-1', 'viewer-A', 90, 30)
+    expect(created).toBe(false)
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(false)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 150, rows: 40 })
+
+    // Once the client's STREAM registers the floor (and owns its cleanup), a
+    // refresh updates that same floor by clientId.
+    await runtime.updateRemoteDesktopViewer('pty-1', 'stream:1', 'viewer-A', 100, 40)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 100, rows: 40 })
+    const refreshed = await runtime.refreshRemoteDesktopViewer('pty-1', 'viewer-A', 70, 25)
+    expect(refreshed).toBe(true)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 70, rows: 25 })
+
+    // A refresh for a DIFFERENT client that owns no floor is a no-op.
+    const other = await runtime.refreshRemoteDesktopViewer('pty-1', 'viewer-Z', 60, 20)
+    expect(other).toBe(false)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 70, rows: 25 })
+
+    // The stream cleanup releases the sole floor — the refresh left no orphan,
+    // so the host reclaims (suppression drops).
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'stream:1')
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(false)
+  })
+
+  it('keeps the host reclaim target when the reclaim resize fails', async () => {
+    const { runtime } = createRuntime()
+    const ptySizes = new Map<string, { cols: number; rows: number }>([
+      ['pty-1', { cols: 150, rows: 40 }]
+    ])
+    let resizeSucceeds = true
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      resize: (ptyId, cols, rows) => {
+        if (!resizeSucceeds) {
+          return false
+        }
+        ptySizes.set(ptyId, { cols, rows })
+        return true
+      },
+      getSize: (ptyId) => ptySizes.get(ptyId) ?? null
+    })
+
+    // Host reports its own 120-wide geometry; a viewer drives the PTY to 80.
+    runtime.recordRemoteDesktopHostReclaimTarget('pty-1', 120, 40)
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 80, 40)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 80, rows: 40 })
+
+    // The last viewer leaves but the reclaim resize fails: the PTY is stuck at
+    // 80, so the recorded host target (120) MUST be retained for a later retry.
+    resizeSucceeds = false
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'sub-A')
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 80, rows: 40 })
+
+    // A retry once resize works restores the TRUE host width (120), not the
+    // stale viewer width (80) that a dropped target would have resolved to.
+    resizeSucceeds = true
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-B', 'viewer-B', 80, 40)
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'sub-B')
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 120, rows: 40 })
+  })
+
   it('PTY exit clears the remote-desktop registry', async () => {
     const { runtime } = createRuntime()
     await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 40)

--- a/src/main/runtime/remote-desktop-driver.test.ts
+++ b/src/main/runtime/remote-desktop-driver.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for the remote-desktop viewer width driver.
+ *
+ * A remote (relay/shared-control) desktop viewer takes the PTY width floor so
+ * the host's own fit cascade stops resizing the viewed PTY out from under it
+ * (the remote alt-screen "porridge"). Mirrors the mobile presence lock but
+ * suppresses only RESIZE, never input. Covers:
+ *   - idle → remote-desktop on register; release to idle on last unregister
+ *   - multi-viewer: driver survives until the last viewer detaches
+ *   - a live mobile driver outranks a remote-desktop viewer
+ *   - isPtyResizeDrivenRemotely gates host resize for mobile AND remote-desktop
+ *   - PTY exit clears the remote-desktop registry
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type * as GitUsernameModule from '../git/git-username'
+import { OrcaRuntimeService } from './orca-runtime'
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: vi.fn().mockResolvedValue([]),
+  listWorktreesStrict: vi.fn().mockResolvedValue([])
+}))
+vi.mock('../hooks', () => ({
+  createSetupRunnerScript: vi.fn(),
+  getEffectiveHooks: vi.fn().mockReturnValue(null),
+  runHook: vi.fn().mockResolvedValue({ success: true, output: '' })
+}))
+vi.mock('../ipc/worktree-logic', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, computeWorktreePath: vi.fn(), ensurePathWithinWorkspace: vi.fn() }
+})
+vi.mock('../ipc/filesystem-auth', () => ({ invalidateAuthorizedRootsCache: vi.fn() }))
+vi.mock('../git/repo', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    getDefaultBaseRef: vi.fn().mockReturnValue('origin/main'),
+    getBranchConflictKind: vi.fn().mockResolvedValue(null)
+  }
+})
+vi.mock('../git/git-username', async () => {
+  const actual = await vi.importActual<typeof GitUsernameModule>('../git/git-username')
+  return { ...actual, resolveLocalGitUsername: vi.fn(async () => '') }
+})
+
+const store = {
+  getRepo: () => ({
+    id: 'repo-1',
+    path: '/tmp/repo',
+    displayName: 'repo',
+    badgeColor: 'blue',
+    addedAt: 1
+  }),
+  getRepos: () => [store.getRepo()],
+  addRepo: () => {},
+  updateRepo: () => undefined as never,
+  getAllWorktreeMeta: () => ({}),
+  getWorktreeMeta: () => undefined,
+  getGitHubCache: () => ({ pr: {}, issue: {} }),
+  setWorktreeMeta: () => undefined as never,
+  removeWorktreeMeta: () => {},
+  getSettings: () => ({
+    workspaceDir: '/tmp/workspaces',
+    nestWorkspaces: false,
+    refreshLocalBaseRefOnWorktreeCreate: false,
+    branchPrefix: 'none',
+    branchPrefixCustom: '',
+    mobileAutoRestoreFitMs: 5_000
+  })
+}
+
+function createRuntime() {
+  const runtime = new OrcaRuntimeService(store)
+  const ptySizes = new Map<string, { cols: number; rows: number }>([
+    ['pty-1', { cols: 150, rows: 40 }]
+  ])
+  const driverEvents: { ptyId: string; driver: { kind: string; clientId?: string } }[] = []
+  runtime.setPtyController({
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    resize: (ptyId, cols, rows) => {
+      ptySizes.set(ptyId, { cols, rows })
+      return true
+    },
+    getSize: (ptyId) => ptySizes.get(ptyId) ?? null
+  })
+  runtime.setNotifier({
+    worktreesChanged: vi.fn(),
+    reposChanged: vi.fn(),
+    activateWorktree: vi.fn(),
+    createTerminal: vi.fn(),
+    splitTerminal: vi.fn(),
+    renameTerminal: vi.fn(),
+    focusTerminal: vi.fn(),
+    closeTerminal: vi.fn(),
+    sleepWorktree: vi.fn(),
+    terminalFitOverrideChanged: vi.fn(),
+    terminalDriverChanged: (ptyId, driver) => {
+      driverEvents.push({ ptyId, driver: { ...driver } })
+    }
+  })
+  return { runtime, driverEvents }
+}
+
+describe('remote desktop viewer width driver', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('applying a viewport suppresses host resize without touching driver state', async () => {
+    const { runtime, driverEvents } = createRuntime()
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(false)
+
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 40)
+
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(true)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 100, rows: 40 })
+    // It is deliberately NOT a driver kind: the presence-lock state machine and
+    // its cross-layer driver-change notifications stay untouched.
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'idle' })
+    expect(driverEvents).toHaveLength(0)
+  })
+
+  it('sizes the PTY to the SMALLEST attached viewer (smallest client wins)', async () => {
+    const { runtime } = createRuntime()
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 40)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 100, rows: 40 })
+
+    // A narrower viewer joins — the PTY shrinks so its wider frames never
+    // overflow the narrow grid.
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-B', 'viewer-B', 80, 30)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 80, rows: 30 })
+
+    // The wide viewer growing does not widen the PTY past the narrow viewer.
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 140, 50)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 80, rows: 30 })
+
+    // The narrow viewer leaves — the PTY re-fits to the survivor's width.
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'sub-B')
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 140, rows: 50 })
+  })
+
+  it('stops suppressing host resize only when the LAST viewer detaches', async () => {
+    const { runtime } = createRuntime()
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 40)
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-B', 'viewer-B', 80, 40)
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(true)
+
+    // First viewer leaves — another remote viewer still holds the floor.
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'sub-A')
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(true)
+
+    // Last viewer leaves — the host reclaims its own width (next pty:resize applies).
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'sub-B')
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(false)
+  })
+
+  it('coexists with a mobile driver and outlives it (host stays suppressed)', async () => {
+    const { runtime } = createRuntime()
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-A' })
+
+    // A desktop viewer registering must NOT disturb the mobile driver.
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 40)
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-A' })
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(true)
+
+    // When the phone leaves, the surviving viewer keeps host resize suppressed
+    // (the registry is independent of the mobile driver state).
+    runtime.onClientDisconnected('phone-A')
+    vi.advanceTimersByTime(10_000)
+    expect(runtime.getDriver('pty-1').kind).not.toBe('mobile')
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(true)
+  })
+
+  it('isPtyResizeDrivenRemotely is false for idle and desktop drivers', async () => {
+    const { runtime } = createRuntime()
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(false)
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 40)
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'sub-A')
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(false)
+  })
+
+  it('reclaims the host width when the last viewer detaches', async () => {
+    const { runtime } = createRuntime()
+    // The host renderer reports its own 120-wide geometry (pty:reportGeometry).
+    runtime.recordRemoteDesktopHostReclaimTarget('pty-1', 120, 40)
+    // The viewer drives the source PTY to its own 80-wide viewport.
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 80, 40)
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 80, rows: 40 })
+
+    // Detaching the last viewer must actively resize the PTY back to the host's
+    // OWN width (120), not the departed viewer's polluted 80.
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'sub-A')
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 120, rows: 40 })
+  })
+
+  it('PTY exit clears the remote-desktop registry', async () => {
+    const { runtime } = createRuntime()
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 40)
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(true)
+
+    runtime.onPtyExit('pty-1', 0)
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(false)
+
+    // A fresh viewer on the same id re-establishes suppression cleanly (no stale set).
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-B', 'viewer-B', 100, 40)
+    expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(true)
+  })
+})

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -82,6 +82,12 @@ type TerminalMultiplexStream = {
   ptyId: string
   client: TerminalViewportClient | undefined
   isMobile: boolean
+  // Why: whether THIS stream registered a remote-desktop width driver, so
+  // detach only unregisters what it registered — a passive (viewport-less)
+  // stream sharing a client id must not release another stream's width floor.
+  registeredRemoteDesktopDriver: boolean
+  remoteDesktopSubscriptionKey: string
+  pendingRemoteDesktopViewport: { cols: number; rows: number } | null
   buffering: boolean
   pendingOutput: TerminalOutputChunk[]
   pendingOutputBytes: number
@@ -559,6 +565,7 @@ async function sendMobileResizeRestream(
 async function updateViewportForClient(
   runtime: OrcaRuntimeService,
   ptyId: string,
+  subscriptionKey: string,
   client: TerminalViewportClient,
   viewport: { cols: number; rows: number },
   defaultType: 'mobile' | 'desktop'
@@ -567,7 +574,16 @@ async function updateViewportForClient(
   if (type === 'mobile') {
     return runtime.updateMobileViewport(ptyId, client.id, viewport)
   }
-  const updated = await runtime.updateDesktopViewport(ptyId, viewport)
+  // Why: a remote desktop viewer's viewport drives the source PTY to the
+  // smallest attached viewer (tmux "smallest client wins") and registers it as
+  // a width owner so the host's fit cascade stops fighting it.
+  const updated = await runtime.updateRemoteDesktopViewer(
+    ptyId,
+    subscriptionKey,
+    client.id,
+    viewport.cols,
+    viewport.rows
+  )
   return { updated, applied: updated }
 }
 
@@ -1184,6 +1200,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       const viewportUpdate = await updateViewportForClient(
         runtime,
         leaf.ptyId,
+        `viewport:${params.client.id}`,
         params.client,
         params.viewport,
         'mobile'
@@ -1270,6 +1287,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         stream.exitWaiterAbort.abort()
         if (stream.isMobile && stream.client?.id) {
           runtime.handleMobileUnsubscribe(stream.ptyId, stream.client.id)
+        } else if (stream.registeredRemoteDesktopDriver && stream.client?.id) {
+          // Why: release the remote-desktop width floor so the host can reclaim
+          // its own width once the last remote viewer leaves — but only if THIS
+          // stream took it (a passive stream must not release a peer's floor).
+          runtime.unregisterRemoteDesktopViewer(stream.ptyId, stream.remoteDesktopSubscriptionKey)
         }
         if (emitEnd) {
           emit({ type: 'end', streamId })
@@ -1322,9 +1344,20 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           if (!viewport || typeof viewport.cols !== 'number' || typeof viewport.rows !== 'number') {
             return
           }
+          // Why: a desktop viewport update registers this stream as a width
+          // owner (even if it had no initial viewport at subscribe), so detach
+          // must later release it.
+          if (!stream.isMobile && stream.client?.id) {
+            stream.registeredRemoteDesktopDriver = true
+            if (stream.buffering) {
+              stream.pendingRemoteDesktopViewport = { cols: viewport.cols, rows: viewport.rows }
+              return
+            }
+          }
           void updateViewportForClient(
             runtime,
             stream.ptyId,
+            stream.remoteDesktopSubscriptionKey,
             stream.client,
             { cols: viewport.cols, rows: viewport.rows },
             stream.isMobile ? 'mobile' : 'desktop'
@@ -1462,6 +1495,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           ptyId,
           client: request.client,
           isMobile,
+          registeredRemoteDesktopDriver: false,
+          remoteDesktopSubscriptionKey: `multiplex:${request.streamId}`,
+          pendingRemoteDesktopViewport: null,
           buffering: true,
           pendingOutput: [],
           pendingOutputBytes: 0,
@@ -1507,12 +1543,29 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
 
           if (isMobile && request.client?.id) {
             await runtime.handleMobileSubscribe(ptyId, request.client.id, request.viewport)
-          } else if (request.viewport && request.client) {
+          } else if (request.client?.id && request.viewport) {
+            // Why: a remote desktop viewer that reports a viewport is driving
+            // the PTY width, so the runtime registers it as a
+            // width owner (host fit cascade suppressed) and sizes the PTY to the
+            // smallest attached viewer. A viewport-less subscriber is a passive
+            // watcher and must NOT lock host resize.
+            stream.registeredRemoteDesktopDriver = true
+            stream.pendingRemoteDesktopViewport = request.viewport
+          }
+          if (
+            !isMobile &&
+            request.client?.id &&
+            stream.registeredRemoteDesktopDriver &&
+            stream.pendingRemoteDesktopViewport
+          ) {
+            const viewport = stream.pendingRemoteDesktopViewport
+            stream.pendingRemoteDesktopViewport = null
             await updateViewportForClient(
               runtime,
               ptyId,
+              stream.remoteDesktopSubscriptionKey,
               request.client,
-              request.viewport,
+              viewport,
               'desktop'
             )
           }
@@ -1625,6 +1678,23 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           stream.pendingOutputBytes = 0
           stream.pendingOutputOverflowed = false
           stream.outputBatcher.flush()
+          if (
+            !stream.isMobile &&
+            stream.client?.id &&
+            stream.registeredRemoteDesktopDriver &&
+            stream.pendingRemoteDesktopViewport
+          ) {
+            const viewport = stream.pendingRemoteDesktopViewport
+            stream.pendingRemoteDesktopViewport = null
+            void updateViewportForClient(
+              runtime,
+              ptyId,
+              stream.remoteDesktopSubscriptionKey,
+              stream.client,
+              viewport,
+              'desktop'
+            ).catch(() => {})
+          }
 
           stream.unsubscribeResize = runtime.subscribeToTerminalResize(ptyId, (event) => {
             stream.outputBatcher.flush()
@@ -1759,6 +1829,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
 
       const ptyId = leaf.ptyId
       const clientId = params.client?.id
+      // Why: only unregister the width floor this subscription took (see the
+      // multiplex stream's registeredRemoteDesktopDriver note).
+      let registeredRemoteDesktopDriver = false
       if (!useBinaryStream) {
         const read = await runtime.readTerminal(params.terminal)
         const serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, false)
@@ -1826,9 +1899,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       }
 
       const streamId = nextTerminalStreamId++
+      const remoteDesktopSubscriptionKey = `stream:${streamId}`
       let cursor = 0
       let closed = false
       let buffering = true
+      let pendingRemoteDesktopViewport: { cols: number; rows: number } | null = null
       // Why: the cols the mobile client last rewrapped to; gate the
       // resize re-stream so it only fires on an actual width change.
       let lastResizeCols: number | undefined
@@ -1861,6 +1936,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           unregisterBinaryHandler()
           if (isMobile && clientId) {
             runtime.handleMobileUnsubscribe(ptyId, clientId)
+          } else if (registeredRemoteDesktopDriver && clientId) {
+            runtime.unregisterRemoteDesktopViewer(ptyId, remoteDesktopSubscriptionKey)
           }
           emit({ type: 'end' })
           resolveStream()
@@ -1929,9 +2006,17 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             ) {
               return
             }
+            if (clientId) {
+              registeredRemoteDesktopDriver = true
+              if (buffering) {
+                pendingRemoteDesktopViewport = { cols: viewport.cols, rows: viewport.rows }
+                return
+              }
+            }
             void updateViewportForClient(
               runtime,
               ptyId,
+              remoteDesktopSubscriptionKey,
               params.client,
               { cols: viewport.cols, rows: viewport.rows },
               'desktop'
@@ -1942,6 +2027,12 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       try {
         if (isMobile && clientId) {
           await runtime.handleMobileSubscribe(ptyId, clientId, params.viewport)
+        } else if (clientId && params.viewport) {
+          // Why: legacy remote desktop viewers that report a viewport also take
+          // the width floor (host fit cascade suppressed) and size the PTY to
+          // the smallest attached viewer. Viewport-less watchers do not lock.
+          registeredRemoteDesktopDriver = true
+          pendingRemoteDesktopViewport = params.viewport
         }
         if (closed) {
           return
@@ -1968,6 +2059,27 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           }
           outputBatcher?.push(data, meta)
         })
+
+        if (
+          clientId &&
+          params.client &&
+          registeredRemoteDesktopDriver &&
+          pendingRemoteDesktopViewport
+        ) {
+          const viewport = pendingRemoteDesktopViewport
+          pendingRemoteDesktopViewport = null
+          await updateViewportForClient(
+            runtime,
+            ptyId,
+            remoteDesktopSubscriptionKey,
+            params.client,
+            viewport,
+            'desktop'
+          )
+        }
+        if (closed) {
+          return
+        }
 
         let read = await runtime.readTerminal(params.terminal)
         let serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, isMobile)
@@ -2050,6 +2162,23 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         }
         pendingOutputBytes = 0
         outputBatcher.flush()
+        if (
+          clientId &&
+          params.client &&
+          registeredRemoteDesktopDriver &&
+          pendingRemoteDesktopViewport
+        ) {
+          const viewport = pendingRemoteDesktopViewport
+          pendingRemoteDesktopViewport = null
+          void updateViewportForClient(
+            runtime,
+            ptyId,
+            remoteDesktopSubscriptionKey,
+            params.client,
+            viewport,
+            'desktop'
+          ).catch(() => {})
+        }
 
         const sendResizedFrame = (event: {
           cols: number

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -568,7 +568,11 @@ async function updateViewportForClient(
   subscriptionKey: string,
   client: TerminalViewportClient,
   viewport: { cols: number; rows: number },
-  defaultType: 'mobile' | 'desktop'
+  defaultType: 'mobile' | 'desktop',
+  // Why: the one-shot `terminal.updateViewport` RPC has no disconnect hook, so
+  // it must only refresh a floor the client already owns via its stream (never
+  // create a leak-prone standalone one). Stream paths that own cleanup register.
+  registration: 'register' | 'refresh' = 'register'
 ): Promise<{ updated: boolean; applied: boolean }> {
   const type = client.type ?? defaultType
   if (type === 'mobile') {
@@ -577,13 +581,16 @@ async function updateViewportForClient(
   // Why: a remote desktop viewer's viewport drives the source PTY to the
   // smallest attached viewer (tmux "smallest client wins") and registers it as
   // a width owner so the host's fit cascade stops fighting it.
-  const updated = await runtime.updateRemoteDesktopViewer(
-    ptyId,
-    subscriptionKey,
-    client.id,
-    viewport.cols,
-    viewport.rows
-  )
+  const updated =
+    registration === 'refresh'
+      ? await runtime.refreshRemoteDesktopViewer(ptyId, client.id, viewport.cols, viewport.rows)
+      : await runtime.updateRemoteDesktopViewer(
+          ptyId,
+          subscriptionKey,
+          client.id,
+          viewport.cols,
+          viewport.rows
+        )
   return { updated, applied: updated }
 }
 
@@ -1203,7 +1210,10 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         `viewport:${params.client.id}`,
         params.client,
         params.viewport,
-        'mobile'
+        'mobile',
+        // Why: one-shot RPC with no disconnect hook — refresh the client's
+        // existing stream-owned floor only, never create a leak-prone one.
+        'refresh'
       )
       return { ...viewportUpdate, seq: runtime.getLayout(leaf.ptyId)?.seq }
     }
@@ -1457,6 +1467,26 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             stream.pendingOutputBytes = 0
             stream.pendingOutputOverflowed = false
             stream.outputBatcher.flush()
+            // Why: a viewer resize that arrived during the snapshot buffering
+            // window is parked in pendingRemoteDesktopViewport; apply it now or
+            // it is silently dropped until the viewer's next resize.
+            if (
+              !stream.isMobile &&
+              stream.client?.id &&
+              stream.registeredRemoteDesktopDriver &&
+              stream.pendingRemoteDesktopViewport
+            ) {
+              const viewport = stream.pendingRemoteDesktopViewport
+              stream.pendingRemoteDesktopViewport = null
+              void updateViewportForClient(
+                runtime,
+                stream.ptyId,
+                stream.remoteDesktopSubscriptionKey,
+                stream.client,
+                viewport,
+                'desktop'
+              ).catch(() => {})
+            }
           }
         }
       }
@@ -1496,7 +1526,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           client: request.client,
           isMobile,
           registeredRemoteDesktopDriver: false,
-          remoteDesktopSubscriptionKey: `multiplex:${request.streamId}`,
+          // Why: streamId is client-local, so two remote connections can both
+          // use stream 1 for the same PTY. Scope the width-floor key by
+          // connectionId (guaranteed present above) so they can't
+          // overwrite/release each other's floor.
+          remoteDesktopSubscriptionKey: `multiplex:${connectionId}:${request.streamId}`,
           pendingRemoteDesktopViewport: null,
           buffering: true,
           pendingOutput: [],

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -18,6 +18,9 @@ import {
 function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
   return {
     getRuntimeId: () => 'test-runtime',
+    updateRemoteDesktopViewer: vi.fn().mockResolvedValue(true),
+    unregisterRemoteDesktopViewer: vi.fn().mockResolvedValue(true),
+    isPtyResizeDrivenRemotely: vi.fn().mockReturnValue(false),
     ...overrides
   } as OrcaRuntimeService
 }
@@ -74,8 +77,7 @@ describe('terminal multiplex RPC', () => {
           cleanup?.()
         }),
         waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
-        sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
-        updateDesktopViewport: vi.fn().mockResolvedValue(true)
+        sendTerminal: vi.fn().mockResolvedValue({ accepted: true })
       })
       const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
 
@@ -130,10 +132,13 @@ describe('terminal multiplex RPC', () => {
           })
         ])
       )
-      expect(runtime.updateDesktopViewport).toHaveBeenCalledWith('pty-1', {
-        cols: 300,
-        rows: 150
-      })
+      expect(runtime.updateRemoteDesktopViewer).toHaveBeenCalledWith(
+        'pty-1',
+        'multiplex:5',
+        'desktop-1',
+        300,
+        150
+      )
       expect(handlers.has(5)).toBe(true)
 
       dataListenerRef.current?.('a')
@@ -176,10 +181,13 @@ describe('terminal multiplex RPC', () => {
         )!
       )
       await vi.waitFor(() =>
-        expect(runtime.updateDesktopViewport).toHaveBeenLastCalledWith('pty-1', {
-          cols: 100,
-          rows: 30
-        })
+        expect(runtime.updateRemoteDesktopViewer).toHaveBeenLastCalledWith(
+          'pty-1',
+          'multiplex:5',
+          'desktop-1',
+          100,
+          30
+        )
       )
 
       const snapshotStartFrame = binaryFrames

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -134,7 +134,7 @@ describe('terminal multiplex RPC', () => {
       )
       expect(runtime.updateRemoteDesktopViewer).toHaveBeenCalledWith(
         'pty-1',
-        'multiplex:5',
+        'multiplex:conn-1:5',
         'desktop-1',
         300,
         150
@@ -183,7 +183,7 @@ describe('terminal multiplex RPC', () => {
       await vi.waitFor(() =>
         expect(runtime.updateRemoteDesktopViewer).toHaveBeenLastCalledWith(
           'pty-1',
-          'multiplex:5',
+          'multiplex:conn-1:5',
           'desktop-1',
           100,
           30
@@ -241,6 +241,125 @@ describe('terminal multiplex RPC', () => {
       ).toBe('snapshot')
 
       runtime.cleanupSubscription('terminal-multiplex:conn-1')
+      await dispatchPromise
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('applies a viewer resize parked during a snapshot-request buffering window', async () => {
+    vi.useFakeTimers()
+    try {
+      const messages: string[] = []
+      const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+      const handlers = new Map<
+        number,
+        (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+      >()
+      const cleanups = new Map<string, () => void>()
+      const runtime = stubRuntime({
+        resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+        readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+        serializeTerminalBuffer: vi
+          .fn()
+          .mockResolvedValue({ data: 'snapshot', cols: 120, rows: 40 }),
+        getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
+        getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+        getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+        subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+        subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+        subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+        subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
+        getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+        registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+          cleanups.set(id, cleanup)
+        }),
+        cleanupSubscription: vi.fn((id: string) => {
+          const cleanup = cleanups.get(id)
+          cleanups.delete(id)
+          cleanup?.()
+        }),
+        waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+        sendTerminal: vi.fn().mockResolvedValue({ accepted: true })
+      })
+      const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+      const dispatchPromise = dispatcher.dispatchStreaming(
+        makeRequest('terminal.multiplex', {}),
+        (msg) => messages.push(msg),
+        {
+          connectionId: 'conn-snap',
+          sendBinary: (bytes) => binaryFrames.push(bytes),
+          registerBinaryStreamHandler: (streamId, handler) => {
+            handlers.set(streamId, handler)
+            return () => handlers.delete(streamId)
+          }
+        }
+      )
+
+      await vi.waitFor(() =>
+        expect(messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+      )
+      handlers.get(0)?.(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.Subscribe,
+            streamId: 0,
+            seq: 1,
+            payload: encodeTerminalStreamJson({
+              streamId: 9,
+              terminal: 'terminal-1',
+              client: { id: 'desktop-1', type: 'desktop' },
+              viewport: { cols: 300, rows: 150 }
+            })
+          })
+        )!
+      )
+      await vi.waitFor(() =>
+        expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+      )
+      // Ignore the subscribe-time floor registration; assert only the drained one.
+      vi.mocked(runtime.updateRemoteDesktopViewer).mockClear()
+
+      // A snapshot request opens the buffering window synchronously (buffering
+      // is set before the first await inside the handler)...
+      handlers.get(9)?.(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.SnapshotRequest,
+            streamId: 9,
+            seq: 2,
+            payload: encodeTerminalStreamJson({ requestId: 3, scrollbackRows: 1000 })
+          })
+        )!
+      )
+      // ...so a resize arriving now is PARKED, not applied inline.
+      handlers.get(9)?.(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.Resize,
+            streamId: 9,
+            seq: 3,
+            payload: encodeTerminalStreamJson({ cols: 88, rows: 33 })
+          })
+        )!
+      )
+      expect(runtime.updateRemoteDesktopViewer).not.toHaveBeenCalled()
+
+      // Once the snapshot completes and buffering clears, the parked resize is
+      // drained (previously it was silently dropped until the next resize).
+      await vi.waitFor(() =>
+        expect(runtime.updateRemoteDesktopViewer).toHaveBeenCalledWith(
+          'pty-1',
+          'multiplex:conn-snap:9',
+          'desktop-1',
+          88,
+          33
+        )
+      )
+
+      runtime.cleanupSubscription('terminal-multiplex:conn-snap')
       await dispatchPromise
     } finally {
       vi.useRealTimers()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -1275,6 +1275,62 @@ describe('createRemoteRuntimePtyTransport', () => {
     })
   })
 
+  it('replays a viewport that changed during the subscribe round-trip once the stream is current', async () => {
+    // Why: a resize landing while the subscribe is in flight takes the one-shot
+    // RPC fallback, which is refresh-only (no leak) and no-ops before the stream
+    // floor exists. The transport must replay the latest viewport over the
+    // now-current stream so the PTY does not stall at the subscribe-time width.
+    // Hold the multiplex "ready" to keep the round-trip open across the resize.
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: typeof subscriptionCallbacks) => {
+        subscriptionCallbacks = callbacks
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    // Drain microtasks WITHOUT advancing timers, so the 33ms viewport batcher
+    // cannot fire — the replayed Resize frame must come from the round-trip
+    // flush alone (this test fails if that flush is removed).
+    const flushMicrotasks = async (): Promise<void> => {
+      for (let i = 0; i < 20; i += 1) {
+        await Promise.resolve()
+      }
+    }
+
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:terminal-1',
+      cols: 80,
+      rows: 24,
+      callbacks: {}
+    })
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalled())
+
+    // Resize while the stream is not yet current (subscribe still pending).
+    expect(transport.resize(132, 43)).toBe(true)
+
+    // Release readiness and drain the resolution chain by microtasks only.
+    emitMultiplexReady()
+    await flushMicrotasks()
+
+    // The Subscribe frame still carries the subscribe-time viewport...
+    expect(latestSubscribePayload().viewport).toEqual({ cols: 80, rows: 24 })
+    // ...and the newer viewport is replayed as a Resize frame over the stream,
+    // before the batcher's 33ms timer could have produced it.
+    const resizeFrame = latestFrameForOpcode(TerminalStreamOpcode.Resize)
+    expect(resizeFrame && decodeTerminalStreamJson(resizeFrame.payload)).toEqual({
+      cols: 132,
+      rows: 43
+    })
+
+    transport.destroy?.()
+  })
+
   it('coalesces rapid remote terminal input before sending it to the runtime', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -377,6 +377,11 @@ export function createRemoteRuntimePtyTransport(
     }
     const subscribedHandle = handle
     const subscribedPtyId = remotePtyId
+    // Why: the viewport we hand the subscribe request. A resize landing during
+    // the round-trip falls back to the one-shot RPC, which is refresh-only (no
+    // leak) and no-ops before the stream floor exists — so replay the latest
+    // remembered viewport through the stream once it's current (below).
+    const subscribedViewport = desiredViewport
     const isCurrentSubscription = (): boolean =>
       isCurrentRemoteTerminal(subscribedHandle, subscribedPtyId)
     const nextStream = await getRemoteRuntimeTerminalMultiplexer(
@@ -384,7 +389,7 @@ export function createRemoteRuntimePtyTransport(
     ).subscribeTerminal({
       terminal: subscribedHandle,
       client: { id: clientId, type: 'desktop' },
-      viewport: desiredViewport ?? undefined,
+      viewport: subscribedViewport ?? undefined,
       callbacks: {
         onData: (data, meta) => {
           if (isCurrentSubscription()) {
@@ -473,6 +478,17 @@ export function createRemoteRuntimePtyTransport(
     closeMultiplexedStream()
     multiplexedStream = nextStream
     multiplexedStreamHandle = subscribedHandle
+    // Why: a viewport change that landed during the subscribe round-trip took
+    // the now-no-op one-shot fallback, so the stream floor is still at the
+    // subscribe-time size. Replay the latest remembered viewport so the PTY
+    // tracks the current width instead of stalling until the next resize.
+    if (
+      desiredViewport &&
+      (desiredViewport.cols !== subscribedViewport?.cols ||
+        desiredViewport.rows !== subscribedViewport?.rows)
+    ) {
+      nextStream.resize(desiredViewport.cols, desiredViewport.rows)
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Relates to **#7279** — that issue was closed by #7736 (which fixed an adjacent facet: query-reply corruption + a mid-escape snapshot repaint), but the **width-authority facet survived** and is what this PR fixes. Consider reopening #7279 or tracking here.

Fixes the remote alt-screen **"porridge"** bug: a remote (relay / shared-control) desktop viewer watching a host terminal saw garbled, cell-misaligned output (and a manual resize was needed to heal it).

**Real-world scenario.** I work on the same host through **Orca servers** from several computers with **different screen sizes** — e.g. a wide desktop as the host and a narrower laptop as the viewer. Whenever the two grids differed, the host would re-fit the shared PTY to its own (wider) width and the laptop's alt-screen TUI garbled until I manually resized. With this change the shared PTY follows the viewer (and the smallest viewer when more than one is attached), so a full-screen TUI stays readable on every machine, and the host reflows back to its own width once the last remote client disconnects.

Root cause: a remote desktop viewer resizes the host source PTY to its own width, but was never registered as a **width owner**. So the host's own fit cascade (window resize, split drag, tab reveal, "+"-new-tab re-render) freely resized the viewed PTY back to the host-local width with no signal to the viewer — the viewer kept its narrower grid while the host streamed wider alt-screen frames.

This mirrors the existing **mobile presence-lock** (which suppresses the host's `pty:resize` while a phone drives), but for remote desktop viewers — **without** joining the mobile driver state machine (a viewer needs only resize suppression, not input-lock / phone-fit / driver banners), and routing every PTY geometry change through the existing `enqueueLayout`/`applyLayout` serialization path.

Behavior:
- While ≥1 remote desktop viewer is attached, the host's own fit cascade no longer resizes the shared PTY. **Host input stays allowed** (shared control — host and viewers can both type), unlike mobile.
- **Smallest client wins** (tmux model): the PTY tracks the smallest attached viewer, so viewers with different screen sizes never overflow the narrowest grid.
- **Reclaim on disconnect**: when the last viewer leaves, the host reflows to full width automatically (no manual window jiggle).
- No snapshot/replay misalignment on connect: a viewport arriving during initial snapshot serialization is coalesced into one serialized resize before the snapshot is sent.

Upstream #7279 was closed by #7736, which fixed an adjacent facet (query-reply corruption + a mid-escape snapshot repaint); this width-authority fight survived. Diagnosed live and this PR addresses the surviving facet.

## Screenshots

Terminal rendering only — no UI-chrome change. Before: viewer alt-screen garbles on host-side refit / viewer-window resize. After: viewer stays correct, resizes synchronously, and the host reclaims full width on disconnect. (Live before/after captured during review; not committed as repo assets per contributor guidelines — happy to attach to the PR conversation.)

## Testing

- [x] `pnpm lint` (changed files clean; one pre-existing unrelated error in `source-control-manual-review-url.ts` on `main`)
- [x] `pnpm typecheck`
- [x] `pnpm test` (new `remote-desktop-driver.test.ts` + updated `pty.test.ts` / `terminal-multiplex.test.ts`; `mobile-presence-lock.test.ts` stays green)
- [x] `pnpm build`
- [x] Added high-quality tests: registry lifecycle (subscription-keyed), smallest-client-wins, reclaim-via-layout, mobile coexistence, and IPC-level host-resize suppression.
- [x] **Verified live** with two local desktop instances (host + viewer, different window widths): correct render on connect, no garble on viewer-window resize (synchronous), host reclaims full width on disconnect, and a fix-OFF/fix-ON counter-test that reproduces the garble without the change.

## AI Review Report

Reviewed with Codex (GPT-5) across multiple rounds. Main risks checked and outcomes:
- **Mobile regression**: input locks and `updateDesktopViewport` no-op gates confirmed still `mobile`-only; remote-desktop does not call `setDriver` and does not touch `terminalFitOverrides` (which stays mobile UI/restore state). `mobile-presence-lock.test.ts` green.
- **Correctness of the registry lifecycle**: keyed per **subscription** (not clientId) so duplicate streams of one client cannot release each other's width floor; a viewport-less passive watcher never locks host resize; detach only releases a floor this stream took.
- **Snapshot/replay race** (flagged and fixed): applying a viewer viewport during the subscribe→serialize sequence could bake a mid-repaint alt screen into the initial snapshot. Fixed by buffering the viewport and issuing exactly one serialized resize before serialization.
- **Serialization invariant**: all remote PTY geometry now goes through `enqueueLayout`/`applyLayout` (the codebase's documented sole PTY-dimension writer), not ad-hoc `ptyController.resize`, so resize/headless-mirror/snapshot ordering is consistent.
- **Cross-platform (macOS/Linux/Windows)**: main-process state/IPC logic only — no path, shell, shortcut, or Electron-platform-specific behavior touched. No `metaKey`/path/`\r\n` assumptions introduced.

Known edge (minor, non-blocking): a viewer viewport that arrives in the brief buffering window *after* the initial coalesced apply is deferred to the next resize frame; self-corrects on the viewer's next window change.

## Security Audit

Main-process IPC/state change. Reviewed:
- **IPC / input handling**: `pty:resize` gains only a width-suppression check plus recording the host's own requested dims for reclaim; no new untrusted input is executed. Remote viewport values pass through the existing `clampTerminalViewport` bounds.
- **Command execution / paths / secrets**: none touched.
- **Auth**: no change — remote desktop subscribers are already authenticated RPC clients; this only affects how their reported viewport drives PTY width. A subscriber must supply a viewport to become a width owner.
- No new dependencies.

## Notes

- **Design decisions worth a maintainer's eye**: (1) a new *internal* `PtyLayoutTarget` kind `remote-desktop` (the wire `RuntimeTerminalDriverState` is untouched); (2) the host reclaim width is captured at the `pty:resize` suppression point (the host's own resize attempts) — a source a remote viewport can't pollute, kept separate from the mobile-oriented `resolveDesktopRestoreTarget`.
- Remote/SSH/relay-specific: this is the shared-control (relay) viewer path; the mobile presence-lock is unchanged and coexists (a phone outranks a desktop viewer; when the phone leaves, a surviving viewer keeps the PTY).
- Provider-agnostic: no GitHub/GitLab-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
