### PR TITLE
fix(pty): stop daemon reattach/kill race from orphaning restored terminals (#7742 sub-issue B)

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2149,6 +2149,108 @@
       "demotionRule": "Cannot promote while restored daemon ids or routing operations can silently route to local fallback."
     },
     {
+      "id": "terminal-provider.startup-shutdown-authority",
+      "title": "Cold-start terminal shutdown targets the installed daemon provider",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-provider",
+      "layer": "main-provider-contract",
+      "surfaces": [
+        "daemon startup",
+        "renderer terminal close",
+        "runtime terminal stop",
+        "restored terminal teardown"
+      ],
+      "platforms": [
+        "macos",
+        "linux",
+        "windows"
+      ],
+      "providers": [
+        "local",
+        "daemon",
+        "ssh"
+      ],
+      "coveredPlatforms": [
+        "macos"
+      ],
+      "coveredProviders": [
+        "local",
+        "daemon",
+        "ssh"
+      ],
+      "coverageNotes": "A real daemon server over a local socket proves a fresh adapter can kill a live session before any prior client operation. Main-process tests prove renderer IPC, runtime kill, and runtime exact-stop wait for the provider swap and issue zero shutdowns to the fallback provider, while SSH spawn and kill bypass the local barrier. The same shared logic runs on Linux and Windows; live platform runs remain gaps.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/7742",
+        "https://github.com/stablyai/orca/pull/7836"
+      ],
+      "invariant": "A local PTY shutdown requested during desktop cold start must resolve its provider only after daemon startup settles, and a fresh daemon adapter must connect before issuing the destructive request; a fallback provider must never falsely acknowledge shutdown while the restored daemon session remains live, and SSH shutdown must not wait on local startup.",
+      "oracle": "Hold the desktop startup promise unresolved, request shutdown through renderer IPC and both runtime-controller entry points, install the daemon provider, and assert the fallback receives zero shutdowns while the daemon receives exactly the requested kill; prove an SSH spawn and kill complete without touching the barrier. Separately, spawn a session through one adapter, kill it through a fresh unconnected adapter, and assert the daemon no longer lists it.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/daemon/daemon-pty-adapter.test.ts"
+      ],
+      "testFiles": [
+        "src/main/ipc/pty.test.ts",
+        "src/main/daemon/daemon-pty-adapter.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/ipc/pty.test.ts",
+          "assertions": [
+            "renderer local kills issue zero fallback shutdowns before startup and target the installed daemon afterward",
+            "runtime fire-and-forget local kills issue zero fallback shutdowns before startup and target the installed daemon afterward",
+            "runtime exact local stops issue zero fallback shutdowns before startup and verify the installed daemon target stopped",
+            "SSH spawns and kills bypass the unresolved local startup barrier and target the SSH provider"
+          ]
+        },
+        {
+          "file": "src/main/daemon/daemon-pty-adapter.test.ts",
+          "assertions": [
+            "a fresh unconnected adapter kills a session hosted by the live daemon and the session disappears from daemon inventory",
+            "concurrent shutdowns through a fresh adapter share the lazy connection and remove both daemon sessions"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-17",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/daemon/daemon-pty-adapter.test.ts",
+          "result": "passed",
+          "durationSeconds": 3.28,
+          "summary": "2 files and 400 tests passed, including single and concurrent real-socket fresh-adapter shutdown, three deferred local provider-selection teardown paths, and SSH barrier bypass."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 10,
+        "scope": "focused main-process provider and IPC contract tests"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The focused deterministic gate passed locally once and needs CI soak history."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Removing the adapter connection reproduces DaemonProtocolError: Not connected, and removing the renderer startup barrier routes shutdown to the fallback. The new runtime-controller barrier assertions also fail against the prior provider-before-startup shape; saved CI red artifacts remain uncollected."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The new startup barrier and connection guard add no polling, timers, subprocesses, session inventories, or provider fanout; runtime exact-stop's existing post-stop verification inventory is unchanged. Each path awaits the existing startup promise once; DaemonClient.ensureConnected is an O(1) no-op when connected and deduplicates concurrent connection attempts when disconnected. Tests deterministically count zero fallback shutdowns and exactly one target shutdown per entry point."
+      },
+      "promotionCriteria": [
+        "Run the focused gate for at least 100 consecutive passes or 14 days across required CI platforms.",
+        "Collect a Windows cold-start close or exact-stop run against a preserved daemon PTY.",
+        "Attach saved red/green artifacts for all three provider-selection entry points."
+      ],
+      "knownGaps": [
+        "No live Electron restart-to-close journey is included; provider and IPC contracts cover the race deterministically.",
+        "The bounded daemon-startup fail-open to LocalPtyProvider remains an accepted boot-over-persistence tradeoff tracked by issue #5232.",
+        "Daemon process death and the resulting Windows ConPTY PowerShell FailFast are separate from provider-selection shutdown authority."
+      ],
+      "demotionRule": "Keep experimental or demote if the gate flakes without a product or harness bug, if any local shutdown reaches fallback before startup settles, or if shutdown adds inventory scans or retry loops."
+    },
+    {
       "id": "terminal-provider.ssh-remote-reattach-contract",
       "title": "SSH and remote terminal restore never turn unknown liveness into destructive cleanup",
       "maturity": "experimental",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2185,13 +2185,14 @@
         "https://github.com/stablyai/orca/pull/7836"
       ],
       "invariant": "A local PTY shutdown requested during desktop cold start must resolve its provider only after daemon startup settles, and a fresh daemon adapter must connect before issuing the destructive request; a fallback provider must never falsely acknowledge shutdown while the restored daemon session remains live, and SSH shutdown must not wait on local startup.",
-      "oracle": "Hold the desktop startup promise unresolved, request shutdown through renderer IPC and both runtime-controller entry points, install the daemon provider, and assert the fallback receives zero shutdowns while the daemon receives exactly the requested kill; prove an SSH spawn and kill complete without touching the barrier. Separately, spawn a session through one adapter, kill it through a fresh unconnected adapter, and assert the daemon no longer lists it.",
+      "oracle": "Hold the desktop provider-startup promise unresolved, request shutdown through renderer IPC and both runtime-controller entry points, install the daemon provider, and assert the fallback receives zero shutdowns while the daemon receives exactly the requested kill; prove the provider gate opens as soon as daemon authority settles even while optional hook startup remains unresolved, and prove an SSH spawn and kill complete without touching either local barrier. Separately, spawn a session through one adapter, kill it through a fresh unconnected adapter, and assert the daemon no longer lists it.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/daemon/daemon-pty-adapter.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/startup/first-window-startup-services.test.ts"
       ],
       "testFiles": [
         "src/main/ipc/pty.test.ts",
-        "src/main/daemon/daemon-pty-adapter.test.ts"
+        "src/main/daemon/daemon-pty-adapter.test.ts",
+        "src/main/startup/first-window-startup-services.test.ts"
       ],
       "assertionRefs": [
         {
@@ -2207,7 +2208,14 @@
           "file": "src/main/daemon/daemon-pty-adapter.test.ts",
           "assertions": [
             "a fresh unconnected adapter kills a session hosted by the live daemon and the session disappears from daemon inventory",
-            "concurrent shutdowns through a fresh adapter share the lazy connection and remove both daemon sessions"
+            "concurrent shutdowns through a fresh adapter perform exactly one control-plus-stream handshake and remove both daemon sessions"
+          ]
+        },
+        {
+          "file": "src/main/startup/first-window-startup-services.test.ts",
+          "assertions": [
+            "daemon provider authority opens before an unresolved optional hook startup while the broader local spawn gate remains closed",
+            "the provider authority gate shares the bounded 60-second fail-open when daemon startup hangs"
           ]
         }
       ],
@@ -2216,10 +2224,10 @@
           "date": "2026-07-17",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/daemon/daemon-pty-adapter.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/startup/first-window-startup-services.test.ts",
           "result": "passed",
-          "durationSeconds": 3.28,
-          "summary": "2 files and 400 tests passed, including single and concurrent real-socket fresh-adapter shutdown, three deferred local provider-selection teardown paths, and SSH barrier bypass."
+          "durationSeconds": 3.27,
+          "summary": "3 files and 406 tests passed, including single and concurrent real-socket fresh-adapter shutdown, one control-plus-stream handshake for burst shutdown, three deferred local provider-selection teardown paths, hook-independent provider authority, and SSH barrier bypass."
         }
       ],
       "runtimeBudget": {
@@ -2236,7 +2244,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The new startup barrier and connection guard add no polling, timers, subprocesses, session inventories, or provider fanout; runtime exact-stop's existing post-stop verification inventory is unchanged. Each path awaits the existing startup promise once; DaemonClient.ensureConnected is an O(1) no-op when connected and deduplicates concurrent connection attempts when disconnected. Tests deterministically count zero fallback shutdowns and exactly one target shutdown per entry point."
+        "evidence": "The provider-authority barrier and connection guard add no polling, timers, subprocesses, session inventories, or provider fanout; runtime exact-stop's existing post-stop verification inventory is unchanged. Shutdown does not wait for optional hook startup once daemon authority settles. Each path awaits one bounded provider promise; DaemonClient.ensureConnected is an O(1) no-op when connected and deduplicates concurrent connection attempts when disconnected. Tests deterministically count zero fallback shutdowns, exactly one target shutdown per entry point, and exactly one control-plus-stream handshake for concurrent fresh-adapter shutdowns."
       },
       "promotionCriteria": [
         "Run the focused gate for at least 100 consecutive passes or 14 days across required CI platforms.",

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -437,6 +437,23 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(lastSubprocess.kill).not.toHaveBeenCalled()
       expect(lastSubprocess.forceKill).toHaveBeenCalled()
     })
+
+    // Why: shutdown() was the only session op that skipped ensureConnected().
+    // After a renderer/app restart the adapter's client connects lazily, so the
+    // first PTY op can be a kill (startup sleep sweeps, closing a restored tab);
+    // it must connect like spawn/attach instead of throwing "Not connected" and
+    // leaving the live daemon session running detached (#7742).
+    it('kills a live session from a fresh adapter that has not connected yet', async () => {
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+
+      const freshAdapter = new DaemonPtyAdapter({ socketPath, tokenPath })
+      try {
+        await freshAdapter.shutdown(id, { immediate: true })
+      } finally {
+        freshAdapter.dispose()
+      }
+      expect(lastSubprocess.forceKill).toHaveBeenCalled()
+    })
   })
 
   describe('sessionsNeedingFullCheckpoint cleanup (leak regression)', () => {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -438,11 +438,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(lastSubprocess.forceKill).toHaveBeenCalled()
     })
 
-    // Why: shutdown() was the only session op that skipped ensureConnected().
-    // After a renderer/app restart the adapter's client connects lazily, so the
-    // first PTY op can be a kill (startup sleep sweeps, closing a restored tab);
-    // it must connect like spawn/attach instead of throwing "Not connected" and
-    // leaving the live daemon session running detached (#7742).
+    // Why: shutdown can be the first lazy-client operation after restart; it
+    // must connect before killing so a healthy session is not orphaned (#7742).
     it('kills a live session from a fresh adapter that has not connected yet', async () => {
       const { id } = await adapter.spawn({ cols: 80, rows: 24 })
 
@@ -453,6 +450,26 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         freshAdapter.dispose()
       }
       expect(lastSubprocess.forceKill).toHaveBeenCalled()
+      await expect(adapter.listProcesses()).resolves.not.toContainEqual(
+        expect.objectContaining({ id })
+      )
+    })
+
+    it('coalesces the lazy connection when a fresh adapter shuts down concurrent sessions', async () => {
+      const ids = await Promise.all(
+        ['concurrent-kill-a', 'concurrent-kill-b'].map(async (sessionId) =>
+          adapter.spawn({ cols: 80, rows: 24, sessionId }).then((result) => result.id)
+        )
+      )
+      const freshAdapter = new DaemonPtyAdapter({ socketPath, tokenPath })
+
+      try {
+        await Promise.all(ids.map((id) => freshAdapter.shutdown(id, { immediate: true })))
+      } finally {
+        freshAdapter.dispose()
+      }
+
+      await expect(adapter.listProcesses()).resolves.toEqual([])
     })
   })
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -11,6 +11,7 @@ import { HeadlessEmulator } from './headless-emulator'
 import { getHistorySessionDirName } from './history-paths'
 import type { HistoryReader } from './history-reader'
 import type { SubprocessHandle } from './session'
+import type { DaemonFileLog } from './daemon-file-log'
 import type * as DaemonHealthModule from './daemon-health'
 import { getDaemonSocketPath } from './daemon-spawner'
 
@@ -97,6 +98,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     command?: string
   } | null
   let subprocessDataOnSubscribe: string | undefined
+  let daemonLog: DaemonFileLog
+  let daemonLogEvents: string[]
 
   beforeEach(async () => {
     subprocessDataOnSubscribe = undefined
@@ -104,9 +107,15 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     socketPath = getDaemonSocketPath(dir)
     tokenPath = join(dir, 'test.token')
 
+    daemonLogEvents = []
+    daemonLog = {
+      log: (event) => daemonLogEvents.push(event),
+      close() {}
+    }
     server = new DaemonServer({
       socketPath,
       tokenPath,
+      log: daemonLog,
       spawnSubprocess: (opts) => {
         lastSpawnOpts = opts
         lastSubprocess = createMockSubprocess(subprocessDataOnSubscribe)
@@ -462,6 +471,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         )
       )
       const freshAdapter = new DaemonPtyAdapter({ socketPath, tokenPath })
+      daemonLogEvents.length = 0
 
       try {
         await Promise.all(ids.map((id) => freshAdapter.shutdown(id, { immediate: true })))
@@ -470,6 +480,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
 
       await expect(adapter.listProcesses()).resolves.toEqual([])
+      expect(daemonLogEvents.filter((event) => event === 'client-hello-accepted')).toHaveLength(2)
     })
   })
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -517,11 +517,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
-    // Why: the client connects lazily, so after an app restart a kill can be
-    // the first session op (startup sleep sweeps, closing a restored tab).
-    // Without connecting first, request('kill') throws "Not connected" while
-    // the daemon is healthy, and the live session survives as an orphaned
-    // PTY (#7742).
+    // Why: shutdown can be the first lazy-client operation after restart; connect
+    // before killing so a healthy daemon session is not orphaned (#7742).
     await this.ensureConnected()
     // Why: sleep/exact-stop kills the live PTY before the periodic checkpoint may run.
     // Force a final snapshot so wake can restore the pane users left.

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -517,6 +517,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
+    // Why: the client connects lazily, so after an app restart a kill can be
+    // the first session op (startup sleep sweeps, closing a restored tab).
+    // Without connecting first, request('kill') throws "Not connected" while
+    // the daemon is healthy, and the live session survives as an orphaned
+    // PTY (#7742).
+    await this.ensureConnected()
     // Why: sleep/exact-stop kills the live PTY before the periodic checkpoint may run.
     // Force a final snapshot so wake can restore the pane users left.
     if (opts.keepHistory) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -268,6 +268,7 @@ const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
 })
 let gpuFallbackActiveThisLaunch = false
 let localPtyStartupReady: Promise<void> = Promise.resolve()
+let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
 const isServeMode = process.argv.includes('--serve')
 const desktopActivationGate = createServeDesktopActivationGate({
@@ -743,6 +744,7 @@ function startTerminalRuntimeStartupServices(): Promise<void> {
   })
   firstWindowStartupServicesReady = startupServices.firstWindowReady
   localPtyStartupReady = startupServices.localPtyReady
+  localPtyProviderStartupReady = startupServices.localPtyProviderReady
   void firstWindowStartupServicesReady.then(() => {
     logStartupMilestone('first-window-startup-services-ready')
   })
@@ -1073,6 +1075,7 @@ function openMainWindow(): BrowserWindow {
     (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target),
     {
       awaitLocalPtyStartup: () => localPtyStartupReady,
+      awaitLocalPtyProviderStartup: () => localPtyProviderStartupReady,
       onBeforeRendererReload: ({ ignoreCache, webContentsId }) => {
         if (window.webContents.id === webContentsId) {
           markExpectedRendererReload(webContentsId)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3595,6 +3595,40 @@ describe('registerPtyHandlers', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
+  // Why: pty:kill had no startup barrier while pty:spawn did. A cold-start kill
+  // issued before the daemon provider swap resolved against the pre-daemon
+  // LocalPtyProvider, whose shutdown silently no-ops on unknown ids — the live
+  // daemon session survived while the handler's synthetic exit made the
+  // renderer clear its binding, permanently orphaning the PTY (#7742).
+  it('waits for the desktop startup barrier before renderer local kills resolve the provider', async () => {
+    const barrier = makeDeferred()
+    registerPtyHandlers(
+      mainWindow as never,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        awaitLocalPtyStartup: () => barrier.promise
+      }
+    )
+
+    const daemonSessionId = 'wt-1@@11111111-1111-1111-1111-111111111111'
+    const pendingKill = handlers.get('pty:kill')!(null, { id: daemonSessionId }) as Promise<void>
+
+    await Promise.resolve()
+    const daemon = installObservableDaemonTestProvider()
+    barrier.resolve()
+    await pendingKill
+
+    expect(daemon.spawn).not.toHaveBeenCalled()
+    expect(getLocalPtyProvider().shutdown).toHaveBeenCalledWith(
+      daemonSessionId,
+      expect.objectContaining({ immediate: true })
+    )
+  })
+
   it('rebinds local data and exit listeners after a late daemon provider install', async () => {
     vi.useFakeTimers()
     const barrier = makeDeferred()

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -587,6 +587,7 @@ describe('registerPtyHandlers', () => {
     const write = vi.fn()
     const pauseProducer = vi.fn()
     const resumeProducer = vi.fn()
+    const shutdown = vi.fn()
     let dataHandler: ((payload: { id: string; data: string }) => void) | null = null
     let exitHandler: ((payload: { id: string; code: number }) => void) | null = null
     let backgroundStreamHandler:
@@ -600,7 +601,7 @@ describe('registerPtyHandlers', () => {
       pauseProducer,
       resumeProducer,
       kill: vi.fn(),
-      shutdown: vi.fn(),
+      shutdown,
       sendSignal: vi.fn(),
       getCwd: vi.fn(),
       getInitialCwd: vi.fn(),
@@ -637,6 +638,7 @@ describe('registerPtyHandlers', () => {
       write,
       pauseProducer,
       resumeProducer,
+      shutdown,
       getBufferSnapshot,
       emitData: (id: string, data: string) => dataHandler?.({ id, data }),
       emitExit: (id: string, code = 0) => exitHandler?.({ id, code }),
@@ -3595,13 +3597,12 @@ describe('registerPtyHandlers', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
-  // Why: pty:kill had no startup barrier while pty:spawn did. A cold-start kill
-  // issued before the daemon provider swap resolved against the pre-daemon
-  // LocalPtyProvider, whose shutdown silently no-ops on unknown ids — the live
-  // daemon session survived while the handler's synthetic exit made the
-  // renderer clear its binding, permanently orphaning the PTY (#7742).
+  // Why: cold-start teardown must select the daemon after startup; fallback
+  // shutdown can falsely succeed and orphan the restored daemon PTY (#7742).
   it('waits for the desktop startup barrier before renderer local kills resolve the provider', async () => {
     const barrier = makeDeferred()
+    const awaitLocalPtyStartup = vi.fn(() => barrier.promise)
+    const fallbackShutdown = vi.spyOn(getLocalPtyProvider(), 'shutdown')
     registerPtyHandlers(
       mainWindow as never,
       undefined,
@@ -3610,7 +3611,7 @@ describe('registerPtyHandlers', () => {
       undefined,
       undefined,
       {
-        awaitLocalPtyStartup: () => barrier.promise
+        awaitLocalPtyStartup
       }
     )
 
@@ -3618,15 +3619,88 @@ describe('registerPtyHandlers', () => {
     const pendingKill = handlers.get('pty:kill')!(null, { id: daemonSessionId }) as Promise<void>
 
     await Promise.resolve()
+    expect(awaitLocalPtyStartup).toHaveBeenCalledTimes(1)
+    expect(fallbackShutdown).not.toHaveBeenCalled()
     const daemon = installObservableDaemonTestProvider()
     barrier.resolve()
     await pendingKill
 
     expect(daemon.spawn).not.toHaveBeenCalled()
-    expect(getLocalPtyProvider().shutdown).toHaveBeenCalledWith(
+    expect(daemon.shutdown).toHaveBeenCalledWith(
       daemonSessionId,
       expect.objectContaining({ immediate: true })
     )
+    expect(fallbackShutdown).not.toHaveBeenCalled()
+  })
+
+  it('waits for the desktop startup barrier before runtime local kills resolve the provider', async () => {
+    const barrier = makeDeferred()
+    const awaitLocalPtyStartup = vi.fn(() => barrier.promise)
+    const fallbackShutdown = vi.spyOn(getLocalPtyProvider(), 'shutdown')
+    const runtime = { setPtyController: vi.fn(), onPtyExit: vi.fn() }
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        awaitLocalPtyStartup
+      }
+    )
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+      kill: (ptyId: string) => boolean
+    }
+
+    expect(controller.kill('daemon-session')).toBe(true)
+    await Promise.resolve()
+    expect(awaitLocalPtyStartup).toHaveBeenCalledTimes(1)
+    expect(fallbackShutdown).not.toHaveBeenCalled()
+
+    const daemon = installObservableDaemonTestProvider()
+    barrier.resolve()
+    await vi.waitFor(() => expect(daemon.shutdown).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(runtime.onPtyExit).toHaveBeenCalledTimes(1))
+
+    expect(daemon.shutdown).toHaveBeenCalledWith('daemon-session', { immediate: false })
+    expect(fallbackShutdown).not.toHaveBeenCalled()
+  })
+
+  it('waits for the desktop startup barrier before runtime exact stops resolve the provider', async () => {
+    const barrier = makeDeferred()
+    const awaitLocalPtyStartup = vi.fn(() => barrier.promise)
+    const fallbackShutdown = vi.spyOn(getLocalPtyProvider(), 'shutdown')
+    const runtime = { setPtyController: vi.fn(), onPtyExit: vi.fn() }
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        awaitLocalPtyStartup
+      }
+    )
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+      stopAndWait: (ptyId: string) => Promise<boolean>
+    }
+
+    const pendingStop = controller.stopAndWait('daemon-session')
+    await Promise.resolve()
+    expect(awaitLocalPtyStartup).toHaveBeenCalledTimes(1)
+    expect(fallbackShutdown).not.toHaveBeenCalled()
+
+    const daemon = installObservableDaemonTestProvider()
+    barrier.resolve()
+    await expect(pendingStop).resolves.toBe(true)
+
+    expect(daemon.shutdown).toHaveBeenCalledWith('daemon-session', {
+      immediate: true,
+      keepHistory: false
+    })
+    expect(fallbackShutdown).not.toHaveBeenCalled()
   })
 
   it('rebinds local data and exit listeners after a late daemon provider install', async () => {
@@ -3784,15 +3858,16 @@ describe('registerPtyHandlers', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
-  it('does not wait on the desktop startup barrier for SSH spawns', async () => {
+  it('does not wait on the desktop startup barrier for SSH spawns or kills', async () => {
     const barrier = makeDeferred()
     const awaitLocalPtyStartup = vi.fn(() => barrier.promise)
     const sshSpawn = vi.fn(async () => ({ id: 'remote-pty' }))
+    const sshShutdown = vi.fn()
     registerSshPtyProvider('ssh-1', {
       spawn: sshSpawn,
       write: vi.fn(),
       resize: vi.fn(),
-      shutdown: vi.fn(),
+      shutdown: sshShutdown,
       sendSignal: vi.fn(),
       getCwd: vi.fn(),
       getInitialCwd: vi.fn(),
@@ -3828,9 +3903,14 @@ describe('registerPtyHandlers', () => {
         env: {}
       })
     ).resolves.toEqual(expect.objectContaining({ id: 'remote-pty' }))
+    await handlers.get('pty:kill')!(null, { id: 'remote-pty' })
 
     expect(awaitLocalPtyStartup).not.toHaveBeenCalled()
     expect(sshSpawn).toHaveBeenCalledTimes(1)
+    expect(sshShutdown).toHaveBeenCalledWith('remote-pty', {
+      immediate: true,
+      keepHistory: false
+    })
   })
 
   it('lists sessions from both local and SSH providers', async () => {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3601,7 +3601,8 @@ describe('registerPtyHandlers', () => {
   // shutdown can falsely succeed and orphan the restored daemon PTY (#7742).
   it('waits for the desktop startup barrier before renderer local kills resolve the provider', async () => {
     const barrier = makeDeferred()
-    const awaitLocalPtyStartup = vi.fn(() => barrier.promise)
+    const awaitLocalPtyStartup = vi.fn(() => new Promise<void>(() => {}))
+    const awaitLocalPtyProviderStartup = vi.fn(() => barrier.promise)
     const fallbackShutdown = vi.spyOn(getLocalPtyProvider(), 'shutdown')
     registerPtyHandlers(
       mainWindow as never,
@@ -3611,7 +3612,8 @@ describe('registerPtyHandlers', () => {
       undefined,
       undefined,
       {
-        awaitLocalPtyStartup
+        awaitLocalPtyStartup,
+        awaitLocalPtyProviderStartup
       }
     )
 
@@ -3619,7 +3621,8 @@ describe('registerPtyHandlers', () => {
     const pendingKill = handlers.get('pty:kill')!(null, { id: daemonSessionId }) as Promise<void>
 
     await Promise.resolve()
-    expect(awaitLocalPtyStartup).toHaveBeenCalledTimes(1)
+    expect(awaitLocalPtyStartup).not.toHaveBeenCalled()
+    expect(awaitLocalPtyProviderStartup).toHaveBeenCalledTimes(1)
     expect(fallbackShutdown).not.toHaveBeenCalled()
     const daemon = installObservableDaemonTestProvider()
     barrier.resolve()
@@ -3635,7 +3638,7 @@ describe('registerPtyHandlers', () => {
 
   it('waits for the desktop startup barrier before runtime local kills resolve the provider', async () => {
     const barrier = makeDeferred()
-    const awaitLocalPtyStartup = vi.fn(() => barrier.promise)
+    const awaitLocalPtyProviderStartup = vi.fn(() => barrier.promise)
     const fallbackShutdown = vi.spyOn(getLocalPtyProvider(), 'shutdown')
     const runtime = { setPtyController: vi.fn(), onPtyExit: vi.fn() }
     registerPtyHandlers(
@@ -3646,7 +3649,7 @@ describe('registerPtyHandlers', () => {
       undefined,
       undefined,
       {
-        awaitLocalPtyStartup
+        awaitLocalPtyProviderStartup
       }
     )
     const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
@@ -3655,7 +3658,7 @@ describe('registerPtyHandlers', () => {
 
     expect(controller.kill('daemon-session')).toBe(true)
     await Promise.resolve()
-    expect(awaitLocalPtyStartup).toHaveBeenCalledTimes(1)
+    expect(awaitLocalPtyProviderStartup).toHaveBeenCalledTimes(1)
     expect(fallbackShutdown).not.toHaveBeenCalled()
 
     const daemon = installObservableDaemonTestProvider()
@@ -3669,7 +3672,7 @@ describe('registerPtyHandlers', () => {
 
   it('waits for the desktop startup barrier before runtime exact stops resolve the provider', async () => {
     const barrier = makeDeferred()
-    const awaitLocalPtyStartup = vi.fn(() => barrier.promise)
+    const awaitLocalPtyProviderStartup = vi.fn(() => barrier.promise)
     const fallbackShutdown = vi.spyOn(getLocalPtyProvider(), 'shutdown')
     const runtime = { setPtyController: vi.fn(), onPtyExit: vi.fn() }
     registerPtyHandlers(
@@ -3680,7 +3683,7 @@ describe('registerPtyHandlers', () => {
       undefined,
       undefined,
       {
-        awaitLocalPtyStartup
+        awaitLocalPtyProviderStartup
       }
     )
     const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
@@ -3689,7 +3692,7 @@ describe('registerPtyHandlers', () => {
 
     const pendingStop = controller.stopAndWait('daemon-session')
     await Promise.resolve()
-    expect(awaitLocalPtyStartup).toHaveBeenCalledTimes(1)
+    expect(awaitLocalPtyProviderStartup).toHaveBeenCalledTimes(1)
     expect(fallbackShutdown).not.toHaveBeenCalled()
 
     const daemon = installObservableDaemonTestProvider()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -5103,6 +5103,15 @@ export function registerPtyHandlers(
     const ownedConnectionId = ptyOwnership.get(args.id)
     const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
     const connectionId = ownedConnectionId ?? parsedSshId?.connectionId
+    // Why: local kills must wait for the daemon provider swap like pty:spawn.
+    // A cold-start kill resolved against the pre-daemon LocalPtyProvider,
+    // whose shutdown silently no-ops on daemon session ids — the live session
+    // survived while the synthetic exit below cleared the renderer's binding,
+    // permanently orphaning the PTY (#7742).
+    const startupPromise = getLocalPtyStartupPromise(connectionId)
+    if (startupPromise) {
+      await startupPromise
+    }
     const provider = connectionId ? sshProviders.get(connectionId) : tryGetProviderForPty(args.id)
     if (!provider && connectionId) {
       // Why: detached SSH PTYs intentionally keep ownership after their

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1513,6 +1513,7 @@ export function registerPtyHandlers(
   store?: Store,
   options?: {
     awaitLocalPtyStartup?: () => Promise<void>
+    awaitLocalPtyProviderStartup?: () => Promise<void>
     // Why: returns true (once, consuming the flag) for the crash-recovery reload
     // so its did-finish-load skips the orphan sweep and keeps live PTYs (#5787).
     isRecoveryReloadInFlight?: (webContentsId: number) => boolean
@@ -1534,6 +1535,15 @@ export function registerPtyHandlers(
     // first paint. Local spawns must wait before resolving getProvider(), while
     // SSH/headless paths do not use the desktop daemon.
     return options?.awaitLocalPtyStartup?.()
+  }
+
+  const getLocalPtyProviderStartupPromise = (
+    connectionId?: string | null
+  ): Promise<void> | undefined => {
+    if (connectionId) {
+      return undefined
+    }
+    return options?.awaitLocalPtyProviderStartup?.() ?? options?.awaitLocalPtyStartup?.()
   }
 
   // Remove any previously registered handlers so we can re-register them
@@ -3444,7 +3454,7 @@ export function registerPtyHandlers(
           })
         return true
       }
-      const startupPromise = getLocalPtyStartupPromise(connectionId)
+      const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
       if (startupPromise) {
         // Why: provider selection must happen after the daemon swap; selecting
         // the fallback first can report success while orphaning a daemon PTY.
@@ -3462,7 +3472,7 @@ export function registerPtyHandlers(
       let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
       const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
       connectionId ??= parsedSshId?.connectionId
-      const startupPromise = getLocalPtyStartupPromise(connectionId)
+      const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
       if (startupPromise) {
         // Why: exact-stop must resolve the provider after daemon startup just
         // like renderer kills, or the fallback can falsely confirm teardown.
@@ -5119,7 +5129,7 @@ export function registerPtyHandlers(
     const connectionId = ownedConnectionId ?? parsedSshId?.connectionId
     // Why: select the local provider only after daemon startup; fallback shutdown
     // can otherwise falsely succeed and orphan a restored daemon PTY (#7742).
-    const startupPromise = getLocalPtyStartupPromise(connectionId)
+    const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
     if (startupPromise) {
       await startupPromise
     }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3396,65 +3396,79 @@ export function registerPtyHandlers(
       }
     },
     kill: (ptyId) => {
-      let provider: IPtyProvider
       let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
       const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
       connectionId ??= parsedSshId?.connectionId
-      try {
-        provider = connectionId ? getProvider(connectionId) : getProviderForPty(ptyId)
-      } catch {
-        if (connectionId) {
-          // Why: runtime/CLI close can target a detached SSH PTY after its
-          // provider was unregistered. Tombstone the lease so reconnect does
-          // not revive a terminal the user explicitly closed.
-          finishPtyShutdown(ptyId, connectionId, store)
-          runtime?.onPtyExit(ptyId, -1)
-          rememberSyntheticKillExit(ptyId)
-          sendPtyExitToRenderer({ id: ptyId, code: -1 })
-          return true
-        }
-        return false
-      }
-      // Why: shutdown() is async but the PtyController interface is sync. Defer
-      // cleanup until shutdown resolves so transient SSH/daemon failures don't
-      // hide a still-running remote process or local daemon session.
-      //
-      // Same synthetic-exit contract as the renderer pty:kill handler: when the
-      // provider emitted its own exit during shutdown, the exit listener already
-      // delivered runtime + renderer exits — synthesizing again would double-fire.
-      void shutdownProviderAndDetectExit(provider, ptyId, { immediate: false })
-        .then((providerExitObserved) => {
-          finishPtyShutdown(ptyId, connectionId, store)
-          if (!providerExitObserved) {
-            runtime?.onPtyExit(ptyId, -1)
-            rememberSyntheticKillExit(ptyId)
-            sendPtyExitToRenderer({ id: ptyId, code: -1 })
-          }
-        })
-        .catch((err) => {
-          if (isPtyAlreadyGoneError(err)) {
+      const killWithCurrentProvider = (): boolean => {
+        let provider: IPtyProvider
+        try {
+          provider = connectionId ? getProvider(connectionId) : getProviderForPty(ptyId)
+        } catch {
+          if (connectionId) {
+            // Why: runtime/CLI close can target a detached SSH PTY after its
+            // provider was unregistered. Tombstone the lease so reconnect does
+            // not revive a terminal the user explicitly closed.
             finishPtyShutdown(ptyId, connectionId, store)
             runtime?.onPtyExit(ptyId, -1)
             rememberSyntheticKillExit(ptyId)
             sendPtyExitToRenderer({ id: ptyId, code: -1 })
-            return
+            return true
           }
+          return false
+        }
+        // Why: the controller is synchronous, but ownership must remain until
+        // asynchronous shutdown proves whether the provider emitted an exit.
+        void shutdownProviderAndDetectExit(provider, ptyId, { immediate: false })
+          .then((providerExitObserved) => {
+            finishPtyShutdown(ptyId, connectionId, store)
+            if (!providerExitObserved) {
+              runtime?.onPtyExit(ptyId, -1)
+              rememberSyntheticKillExit(ptyId)
+              sendPtyExitToRenderer({ id: ptyId, code: -1 })
+            }
+          })
+          .catch((err) => {
+            if (isPtyAlreadyGoneError(err)) {
+              finishPtyShutdown(ptyId, connectionId, store)
+              runtime?.onPtyExit(ptyId, -1)
+              rememberSyntheticKillExit(ptyId)
+              sendPtyExitToRenderer({ id: ptyId, code: -1 })
+              return
+            }
+            console.warn(
+              `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
+            )
+            // Why: close runtime tails without clearing provider ownership, so
+            // a retry can still target a PTY that survived the failed shutdown.
+            runtime?.onPtyExit(ptyId, -1)
+          })
+        return true
+      }
+      const startupPromise = getLocalPtyStartupPromise(connectionId)
+      if (startupPromise) {
+        // Why: provider selection must happen after the daemon swap; selecting
+        // the fallback first can report success while orphaning a daemon PTY.
+        void startupPromise.then(killWithCurrentProvider).catch((err) => {
           console.warn(
             `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
           )
-          // Why: callers of controller.kill must observe a kill→exit pair so
-          // runtime tail buffers close and agents stop treating the pane as
-          // live. Preserve provider/lease state so a retry can still target
-          // the remote PTY if it survived the transient failure.
           runtime?.onPtyExit(ptyId, -1)
         })
-      return true
+        return true
+      }
+      return killWithCurrentProvider()
     },
     stopAndWait: async (ptyId, opts) => {
-      let provider: IPtyProvider
       let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
       const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
       connectionId ??= parsedSshId?.connectionId
+      const startupPromise = getLocalPtyStartupPromise(connectionId)
+      if (startupPromise) {
+        // Why: exact-stop must resolve the provider after daemon startup just
+        // like renderer kills, or the fallback can falsely confirm teardown.
+        await startupPromise
+      }
+      let provider: IPtyProvider
       try {
         provider = connectionId ? getProvider(connectionId) : getProviderForPty(ptyId)
       } catch {
@@ -5103,11 +5117,8 @@ export function registerPtyHandlers(
     const ownedConnectionId = ptyOwnership.get(args.id)
     const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
     const connectionId = ownedConnectionId ?? parsedSshId?.connectionId
-    // Why: local kills must wait for the daemon provider swap like pty:spawn.
-    // A cold-start kill resolved against the pre-daemon LocalPtyProvider,
-    // whose shutdown silently no-ops on daemon session ids — the live session
-    // survived while the synthetic exit below cleared the renderer's binding,
-    // permanently orphaning the PTY (#7742).
+    // Why: select the local provider only after daemon startup; fallback shutdown
+    // can otherwise falsely succeed and orphan a restored daemon PTY (#7742).
     const startupPromise = getLocalPtyStartupPromise(connectionId)
     if (startupPromise) {
       await startupPromise

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -13,6 +13,9 @@ describe('startup ordering', () => {
     const desktopStartup = source.slice(desktopStart, desktopEnd)
 
     expect(attachBlock).toContain('awaitLocalPtyStartup: () => localPtyStartupReady')
+    expect(attachBlock).toContain(
+      'awaitLocalPtyProviderStartup: () => localPtyProviderStartupReady'
+    )
     expect(source).toContain('firstWindowStartupServicesReady = startupServices.firstWindowReady')
     expect(source).toContain('localPtyStartupReady = startupServices.localPtyReady')
 

--- a/src/main/startup/first-window-startup-services.test.ts
+++ b/src/main/startup/first-window-startup-services.test.ts
@@ -41,7 +41,37 @@ describe('startFirstWindowStartupServices', () => {
     resolveHooks()
     await started.firstWindowReady
     await started.localPtyReady
+    await started.localPtyProviderReady
     expect(completed).toBe(true)
+  })
+
+  it('opens the provider gate when daemon startup finishes without waiting for hooks', async () => {
+    let resolveDaemon!: () => void
+    let resolveHooks!: () => void
+    const started = startFirstWindowStartupServices({
+      startDaemonPtyProvider: () =>
+        new Promise<void>((resolve) => {
+          resolveDaemon = resolve
+        }),
+      startAgentHookServer: () =>
+        new Promise<void>((resolve) => {
+          resolveHooks = resolve
+        }),
+      onDaemonError: vi.fn(),
+      onAgentHookServerError: vi.fn()
+    })
+    await Promise.resolve()
+
+    let allServicesReady = false
+    void started.localPtyReady.then(() => {
+      allServicesReady = true
+    })
+    resolveDaemon()
+    await expect(started.localPtyProviderReady).resolves.toBeUndefined()
+    expect(allServicesReady).toBe(false)
+
+    resolveHooks()
+    await started.localPtyReady
   })
 
   it('logs each service failure and still resolves the startup barrier', async () => {
@@ -57,6 +87,7 @@ describe('startFirstWindowStartupServices', () => {
 
     await expect(started.firstWindowReady).resolves.toBeUndefined()
     await expect(started.localPtyReady).resolves.toBeUndefined()
+    await expect(started.localPtyProviderReady).resolves.toBeUndefined()
 
     expect(onDaemonError).toHaveBeenCalledWith(expect.any(Error))
     expect(onAgentHookServerError).toHaveBeenCalledWith(expect.any(Error))
@@ -79,6 +110,7 @@ describe('startFirstWindowStartupServices', () => {
 
     await expect(started.firstWindowReady).resolves.toBeUndefined()
     await expect(started.localPtyReady).resolves.toBeUndefined()
+    await expect(started.localPtyProviderReady).resolves.toBeUndefined()
 
     expect(onDaemonError).toHaveBeenCalledWith(expect.any(Error))
     expect(onAgentHookServerError).toHaveBeenCalledWith(expect.any(Error))
@@ -119,6 +151,7 @@ describe('startFirstWindowStartupServices', () => {
 
       resolveDaemon()
       await expect(started.localPtyReady).resolves.toBeUndefined()
+      await expect(started.localPtyProviderReady).resolves.toBeUndefined()
       expect(daemonSignal?.aborted).toBe(false)
       expect(onDaemonError).not.toHaveBeenCalled()
     } finally {
@@ -147,6 +180,7 @@ describe('startFirstWindowStartupServices', () => {
       await vi.advanceTimersByTimeAsync(LOCAL_PTY_STARTUP_FAIL_OPEN_TIMEOUT_MS)
       await expect(started.firstWindowReady).resolves.toBeUndefined()
       await expect(started.localPtyReady).resolves.toBeUndefined()
+      await expect(started.localPtyProviderReady).resolves.toBeUndefined()
 
       expect(onDaemonError).toHaveBeenCalledWith(expect.any(Error))
       expect(onAgentHookServerError).not.toHaveBeenCalled()

--- a/src/main/startup/first-window-startup-services.ts
+++ b/src/main/startup/first-window-startup-services.ts
@@ -13,6 +13,7 @@ type StartupService = {
 type FirstWindowStartupServicesResult = {
   firstWindowReady: Promise<void>
   localPtyReady: Promise<void>
+  localPtyProviderReady: Promise<void>
 }
 
 export const FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS = 12_000
@@ -84,22 +85,23 @@ export function startFirstWindowStartupServices({
       clearTimeout(failOpenTimeout)
     }
   })
+  const failOpenReady = new Promise<void>((resolve) => {
+    failOpenTimeout = setTimeout(() => {
+      daemon.reportTimeout()
+      hooks.reportTimeout()
+      resolve()
+    }, LOCAL_PTY_STARTUP_FAIL_OPEN_TIMEOUT_MS)
+  })
   const firstWindowReady = Promise.race([
     servicesSettled,
     new Promise<void>((resolve) => {
       windowTimeout = setTimeout(resolve, FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS)
     })
   ])
-  const localPtyReady = Promise.race([
-    servicesSettled,
-    new Promise<void>((resolve) => {
-      failOpenTimeout = setTimeout(() => {
-        daemon.reportTimeout()
-        hooks.reportTimeout()
-        resolve()
-      }, LOCAL_PTY_STARTUP_FAIL_OPEN_TIMEOUT_MS)
-    })
-  ])
+  const localPtyReady = Promise.race([servicesSettled, failOpenReady])
+  // Why: destructive routing only needs daemon authority. A stalled optional
+  // hook server must not hold terminal close for the full fail-open window.
+  const localPtyProviderReady = Promise.race([daemon.ready, failOpenReady])
 
-  return { firstWindowReady, localPtyReady }
+  return { firstWindowReady, localPtyReady, localPtyProviderReady }
 }

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -75,6 +75,7 @@ export function attachMainWindowServices(
   ) => Promise<ClaudeRuntimeAuthPreparation>,
   options?: {
     awaitLocalPtyStartup?: () => Promise<void>
+    awaitLocalPtyProviderStartup?: () => Promise<void>
     onBeforeRendererReload?: (args: { webContentsId: number; ignoreCache: boolean }) => void
     // Why: lets the PTY orphan sweep skip the one crash-recovery reload (#5787).
     isRecoveryReloadInFlight?: (webContentsId: number) => boolean
@@ -97,6 +98,7 @@ export function attachMainWindowServices(
     store,
     {
       awaitLocalPtyStartup: options?.awaitLocalPtyStartup,
+      awaitLocalPtyProviderStartup: options?.awaitLocalPtyProviderStartup,
       isRecoveryReloadInFlight: options?.isRecoveryReloadInFlight
     }
   )


### PR DESCRIPTION
## What & why

Addresses the **PTY-orphaning-on-restart** half of #7742 (sub-issue B). After a renderer/app restart, terminal teardown could silently target the wrong provider or a healthy-but-unconnected daemon client. Orca then reported the PTY closed and cleared its persisted binding while the live daemon session survived detached.

The fix covers every desktop-local shutdown authority:

1. **Fresh daemon adapter:** `DaemonPtyAdapter.shutdown()` now establishes the lazy daemon connection before issuing `kill`.
2. **Renderer close:** `pty:kill` waits for the existing local PTY startup barrier before resolving the provider.
3. **Runtime/CLI/worktree teardown:** runtime `kill` and `stopAndWait` now use the same barrier. Review found these two paths still had the original provider-before-startup race.
4. **Burst cleanup:** concurrent shutdowns share `DaemonClient`'s existing in-flight connection promise.
5. **Close-latency budget:** destructive shutdown uses a daemon-provider authority gate, so an unrelated stalled agent-hook server cannot hold terminal close until the 60-second startup fail-open.

## Reliability proof

- **Invariant (`terminal-provider.startup-shutdown-authority`):** local shutdown during cold start resolves its provider only after daemon startup settles; a fresh daemon adapter connects before a destructive request; the fallback never falsely acknowledges a restored daemon PTY; SSH shutdown never waits on local startup.
- **Failure source:** #7742 and the reporter diagnostic showing `pty:kill: DaemonProtocolError: Not connected` shortly after launch.
- **Oracle:** hold provider startup unresolved, request renderer/runtime/exact shutdown, install the daemon provider, then prove zero fallback shutdowns and exactly one daemon shutdown. Separately prove daemon authority opens while optional hook startup remains unresolved. A real `DaemonServer` socket fixture kills sessions through a fresh adapter, confirms they disappear from inventory, and counts exactly one control-plus-stream handshake for two concurrent kills.
- **Gate:** new experimental gate in `config/reliability-gates.jsonc`.
- **Diagnostics:** existing daemon protocol error and PTY shutdown warnings retain the session id and failure message.
- **Red/green evidence:** removing the adapter connection reproduces `DaemonProtocolError: Not connected`; removing the startup barriers routes shutdown to the fallback or fails the new zero-fallback assertions.

## Testing

- [x] Focused gate: `3 files / 406 tests passed` in 3.27s
- [x] Follow-up lifecycle/provider/runtime regression set: `15 files / 1,438 tests passed`
- [x] Earlier broader daemon/startup/provider/window regression set: `100 files passed, 2 skipped; 1,462 tests passed, 5 skipped`
- [x] Full TypeScript typecheck
- [x] Changed-file oxlint and oxfmt
- [x] Reliability manifest validation
- [x] Max-lines ratchet; no new bypasses
- [ ] Full repo lint is currently blocked by an unrelated pre-existing switch-exhaustiveness error in `src/renderer/src/components/skills/skill-freshness-group.tsx`; changed files lint cleanly.

## Performance budget

No polling, retry loop, subprocess, provider fanout, or new session inventory was added. Each local shutdown awaits one bounded daemon-provider authority promise; it no longer waits for optional hook startup after daemon authority settles. `DaemonClient.ensureConnected()` is an O(1) return when connected and coalesces concurrent connection attempts when disconnected. Runtime exact-stop's existing post-stop verification inventory is unchanged. Tests count one provider barrier lookup and zero fallback shutdowns per local entry point, plus exactly one control-and-stream handshake for concurrent fresh-adapter shutdown.

## Provider/platform coverage

- **Local/daemon:** covered by deterministic provider-selection tests and a real local daemon socket fixture.
- **SSH:** covered; spawn and kill bypass an unresolved local startup barrier and retain SSH provider routing.
- **WSL:** shared desktop-local provider routing is affected; no platform-specific path was added. Live WSL validation remains uncollected.
- **Mobile/relay and remote runtime:** unaffected; their provider-owned close paths do not enter this local startup gate.
- **macOS/Linux/Windows:** shared main-process logic. Local evidence is macOS; live Linux/Windows cold-start runs remain gaps.

## Residual gaps

- The bounded daemon-startup fail-open to `LocalPtyProvider` can still strand daemon sessions by design (#5232 boot-over-persistence tradeoff).
- Daemon **process death** and the Windows ConPTY/PowerShell `0xE9` FailFast are separate from this provider-selection race.
- No live Electron restart-to-close journey or live Windows run is included; the race is covered at deterministic provider/IPC layers.

## Screenshots

Not applicable; this is main-process lifecycle behavior with no UI change.

## AI review report

CodeRabbit reported no actionable findings on the original four-file change. The follow-up manual reliability/performance audit expanded coverage to runtime shutdown authorities, concurrent connection coalescing, SSH bypass, and a registered reliability gate. A second deep audit found and fixed one material performance issue: shutdown had inherited the broader daemon-plus-hook startup gate, allowing a stalled optional hook server to delay close until fail-open.

## Security audit

No new command execution, filesystem access, credentials, network endpoint, or IPC surface. The fix reuses the existing authenticated daemon socket and startup promise.

## Not in scope

The renderer crash trigger and daemon-process-death mechanism remain separate work under #7742.

Made with [Orca](https://github.com/stablyai/orca) 🐋

