### PR TITLE
Fix Orca Mobile agent tabs opening as a plain shell instead of launching the agent

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16695,7 +16695,13 @@ describe('OrcaRuntimeService', () => {
       expect.objectContaining({ sessionId: 'serve-dead-pty', worktreeId: TEST_WORKTREE_ID })
     )
     expect(spawn.mock.calls[0]![0].command).toBeUndefined()
-    expect(activated.tabs[0]).toMatchObject({ type: 'terminal', status: 'ready' })
+    // Why: the disabled-agent fallback keeps the tab's agent identity; only the
+    // startup command is skipped.
+    expect(activated.tabs[0]).toMatchObject({
+      type: 'terminal',
+      status: 'ready',
+      launchAgent: 'claude'
+    })
   })
 
   it('collapses duplicate mobile terminal entries when renderer and headless leaf ids diverge for the same pty', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16553,6 +16553,151 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  function makePendingAgentTabActivationRuntime(opts: { disabledTuiAgents?: string[] } = {}): {
+    runtime: OrcaRuntimeService
+    spawn: ReturnType<typeof vi.fn>
+  } {
+    const spawn = vi.fn().mockResolvedValue({ id: 'serve-materialized-pty' })
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: 'serve-dead-pty',
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Terminal 1',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              launchAgent: 'claude'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: 'serve-dead-pty' })
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService({
+      ...runtimeStore,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: opts.disabledTuiAgents ?? []
+      })
+    } as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+    return { runtime, spawn }
+  }
+
+  it('launches the pending agent when mobile activation materializes an agent tab', async () => {
+    const { runtime, spawn } = makePendingAgentTabActivationRuntime()
+
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.tabs[0]).toMatchObject({
+      type: 'terminal',
+      launchAgent: 'claude',
+      status: 'pending-handle'
+    })
+
+    // Why notifyClients false: this mirrors the phone tapping the tab, which is
+    // the path that materializes pending tabs headlessly (#7587 aftermath).
+    const activated = await runtime.activateMobileSessionTab(
+      `id:${TEST_WORKTREE_ID}`,
+      `host-tab::${HEADLESS_LEAF_ID}`,
+      undefined,
+      { notifyClients: false }
+    )
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: expect.stringContaining('claude'),
+        sessionId: 'serve-dead-pty',
+        tabId: 'host-tab',
+        leafId: HEADLESS_LEAF_ID,
+        worktreeId: TEST_WORKTREE_ID
+      })
+    )
+    expect(activated.tabs[0]).toMatchObject({
+      type: 'terminal',
+      launchAgent: 'claude',
+      status: 'ready'
+    })
+  })
+
+  it('materializes a plain shell when the pending tab has no launch agent', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'serve-materialized-pty' })
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: 'serve-dead-pty',
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Terminal 1',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: 'serve-dead-pty' })
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+
+    await runtime.activateMobileSessionTab(
+      `id:${TEST_WORKTREE_ID}`,
+      `host-tab::${HEADLESS_LEAF_ID}`,
+      undefined,
+      { notifyClients: false }
+    )
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'serve-dead-pty', worktreeId: TEST_WORKTREE_ID })
+    )
+    expect(spawn.mock.calls[0]![0].command).toBeUndefined()
+  })
+
+  it('falls back to a plain shell when the pending tab agent is disabled', async () => {
+    const { runtime, spawn } = makePendingAgentTabActivationRuntime({
+      disabledTuiAgents: ['claude']
+    })
+
+    const activated = await runtime.activateMobileSessionTab(
+      `id:${TEST_WORKTREE_ID}`,
+      `host-tab::${HEADLESS_LEAF_ID}`,
+      undefined,
+      { notifyClients: false }
+    )
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'serve-dead-pty', worktreeId: TEST_WORKTREE_ID })
+    )
+    expect(spawn.mock.calls[0]![0].command).toBeUndefined()
+    expect(activated.tabs[0]).toMatchObject({ type: 'terminal', status: 'ready' })
+  })
+
   it('collapses duplicate mobile terminal entries when renderer and headless leaf ids diverge for the same pty', async () => {
     const rendererLeafId = HEADLESS_SECOND_LEAF_ID
     const ptyId = 'serve-persisted-pty'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4001,6 +4001,25 @@ export class OrcaRuntimeService {
         const targetGroupId = snapshot?.tabGroups?.find((group) =>
           group.tabOrder.includes(tab.parentTabId)
         )?.id
+        // Why: a pending agent tab may exist without its startup command ever
+        // having been delivered (the create's renderer stalled, #7587), so a
+        // bare materialize would put a plain shell under the agent icon.
+        // Re-resolve the launch like the create path; providers skip startup
+        // commands when attaching to live sessions, so this cannot double-launch.
+        let agentStartup: Awaited<
+          ReturnType<OrcaRuntimeService['resolveMobileSessionTerminalCommand']>
+        > = {}
+        if (tab.launchAgent) {
+          try {
+            const workspace = await this.resolveTerminalWorkspaceLaunchScope(`id:${worktreeId}`)
+            agentStartup = await this.resolveMobileSessionTerminalCommand(workspace, {
+              agent: tab.launchAgent
+            })
+          } catch {
+            // Why: a disabled or unresolvable agent must not make the tab
+            // untappable; fall back to the plain-shell materialize.
+          }
+        }
         try {
           await this.createHeadlessMobileSessionTerminal(worktreeId, true, undefined, {
             identity: {
@@ -4009,6 +4028,10 @@ export class OrcaRuntimeService {
               sessionId
             },
             cwd: tab.startupCwd,
+            command: agentStartup.command,
+            env: agentStartup.env,
+            startupCommandDelivery: agentStartup.startupCommandDelivery,
+            launchConfig: agentStartup.launchConfig,
             launchAgent: tab.launchAgent,
             targetGroupId
           })


### PR DESCRIPTION
Spawning a Claude (or any agent) tab from Orca Mobile could produce a tab that shows the agent icon but runs a plain shell — the agent never started. This PR makes the mobile activate path launch the tab's agent when it materializes a pending agent tab, so a tab labeled Claude actually runs Claude.

**What changes:** `activateMobileSessionTab` materializes pending terminal tabs headlessly (phone taps send `session.tabs.activate` with `notifyClients: false`). That call site passed `identity`/`cwd`/`launchAgent` to `createHeadlessMobileSessionTerminal` but dropped the startup command, unlike every other agent-tab path. It now resolves the agent launch plan exactly like the mobile create path (`resolveMobileSessionTerminalCommand`: platform/remote-aware quoting, agent-enablement check, workspace trust marking) and threads `command`/`env`/`startupCommandDelivery`/`launchConfig` into the materialize. If the agent is disabled or the plan can't be built, it falls back to the previous plain-shell behavior instead of failing the activation.

**What does not change:** the create-side flows (renderer, headless, timeout-materialize, #7664 rescue) already delivered the command and are untouched. Live sessions cannot double-launch: every provider (local daemon `createOrAttach`, degraded local provider, SSH relay attach) skips startup commands when attaching to an existing live session, and a live session means the tab is `ready`, which skips the materialize branch entirely.

## Root cause / reproduction

Reproduced end-to-end on the reporter's machine and deterministically on a dev instance:

1. A Claude tab created from the phone while the desktop renderer is stalled (locked screen/App Nap/occlusion) times out server-side and survives as a *pending* tab: `launchAgent: "claude"`, `status: "pending-handle"`, no PTY, title reverted to "Terminal N".
2. Tapping it on the phone materialized it without the command → fresh `serve-*` daemon session running a bare zsh under the Claude icon.

Evidence from the affected machine: both broken sessions' terminal-history logs contain zero command bytes (prompt only), spawned 12s apart matching two taps after the create's 10s+1s timeout cadence; the tabs persist in `orca-data.json` with `launchAgent: "claude"` and `serve-*` bindings. Deterministic repro rig: seed a Claude tab → exit it → SIGSTOP the renderer → `session.tabs.activate` with `notifyClients: false` → before the fix the daemon spawn received `command: null` and produced a plain shell; after the fix the same steps relaunch Claude (validated live, plus on the Android emulator through the real mobile UI).

## Validation

- New regression tests in `src/main/runtime/orca-runtime.test.ts`: pending agent tab activation spawns with the resolved claude command; pending tab without `launchAgent` still spawns a plain shell (no command); disabled agent falls back to plain shell without failing activation. Full `orca-runtime.test.ts` suite passes (580 tests).
- Live dev-rig validation of the exact reporter flow (stalled renderer → tap pending Claude tab): Claude launches, tab title becomes "✳ Claude Code".
- Android emulator (Orca Mobile) end-to-end: PASS on both scenarios (Pixel 7 API 36 emulator paired to a dev desktop build of this branch). Scenario A: "+" → Claude produced a tab with Claude Code running. Scenario B (the bug): a seeded pending tab (`status: "pending-handle"`, `launchAgent: "claude"`, no terminal handle, title "Terminal 10" with the Claude icon — the reporter's exact broken state) was tapped in the mobile tab bar and materialized **with Claude running**; server-side the tab flipped to `"✳ Claude Code"` / `"ready"` with a fresh terminal handle. Screenshot evidence captured for pairing, both scenarios, and the pre-tap pending state (kept locally under `/tmp/mobile-claude-fix-evidence/`; not committed per repo evidence policy).
- `pnpm tc` clean; oxlint/oxfmt clean.

## Risks / notes

- Deliberate behavior change: tapping a *dead* agent tab on mobile now relaunches the agent fresh (previously: plain shell under the agent icon). Desktop shows a dead pane with scrollback instead; mobile has no dead-pane rendering, so relaunching the labeled agent is the closest faithful behavior. Scrollback from the dead session is still cold-restored before the relaunch.
- Not a resume: hibernated/sleeping agent sessions materialized through this path get a fresh agent launch, not `--resume`; resume-on-activate remains a separate feature.
- SSH: command resolution and delivery reuse the create path's machinery (relay `commandDelivery`, attach paths never deliver); validated by code inspection and existing create-path coverage, not a live SSH rig.

Made with [Orca](https://github.com/stablyai/orca) 🐋
