### PR TITLE
fix(agents): keep Pi status through session_shutdown; open browser in Agents View

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -4959,13 +4959,14 @@ describe('Pi hook normalization', () => {
     expect(result?.payload.agentType).toBe('pi')
   })
 
-  it('session_shutdown maps to done', () => {
+  it('session_shutdown does not map to done (prevents mid-work disconnect for Pi, #7791)', () => {
     const result = _internals.normalizeHookPayload(
       'pi',
       buildBody({ hook_event_name: 'session_shutdown' }),
       'production'
     )
-    expect(result?.payload.state).toBe('done')
+    // session_shutdown no longer forces 'done' (only agent_end does); keeps status connected
+    expect(result).toBeNull()
   })
 
   it('done preserves the cached lastAssistantMessage from a prior message_end', () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2433,7 +2433,14 @@ function App(): React.JSX.Element {
                               {activeView === 'skills' ? <SkillsPage /> : null}
                               {activeView === 'tasks' ? <TaskPage /> : null}
                               {activeView === 'automations' ? <AutomationsPage /> : null}
-                              {activeView === 'activity' ? <ActivityPrototypePage /> : null}
+                              {/* Why: Agents View must not stack under Landing / worktree-creation
+                                  panels (CodeRabbit on #7838). Those surfaces own the same slot
+                                  when there is no active worktree or a pending creation. */}
+                              {activeView === 'activity' &&
+                              activeWorktreeId &&
+                              !creationLayoutActive ? (
+                                <ActivityPrototypePage />
+                              ) : null}
                               {activeView === 'space' ? <WorkspaceSpacePage /> : null}
                               {activeView === 'mobile' ? <MobilePage /> : null}
                               {(activeView === 'terminal' || activeView === 'activity') &&

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -68,7 +68,10 @@ import { FloatingTerminalToggleButton } from './components/floating-terminal/Flo
 import { OrcaProfileSwitcher } from './components/orca-profiles/OrcaProfileSwitcher'
 import {
   TOGGLE_FLOATING_TERMINAL_EVENT,
-  requestFloatingTerminalOpenMaximized
+  OPEN_FLOATING_TERMINAL_EVENT,
+  requestFloatingTerminalOpenMaximized,
+  shouldOpenFloatingTerminalOnRequest,
+  shouldForceCloseFloatingTerminal
 } from '@/lib/floating-terminal'
 import {
   isFloatingWorkspacePanelFocused,
@@ -529,11 +532,15 @@ function App(): React.JSX.Element {
     activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
   const terminalWorkbenchVisible =
     activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
+  // Why: main browser/terminal chrome is intentionally terminal-view only.
+  // For #7813, activity links use floating overlay (FLOATING_TERMINAL_WORKTREE_ID +
+  // requestOpen + policy) so browser is visible/usable while staying in 'activity'
+  // view. See openHttpLink and floating policy.
   // Why: a closed empty floating workspace is not startup-critical. Once it owns
   // tabs, keep it mounted while closed so hidden terminal/browser/editor panes
   // retain their local state.
   const shouldMountFloatingTerminalPanel =
-    floatingTerminalEnabled && (floatingTerminalOpen || floatingVisibleTabCount > 0)
+    (floatingTerminalEnabled || floatingVisibleTabCount > 0) && (floatingTerminalOpen || floatingVisibleTabCount > 0)
   // Why: the floating workspace is a transient overlay; hotkey minimize should
   // return keyboard focus to the surface the user was working in before it.
   const floatingTerminalReturnFocusRef = useRef<HTMLElement | null>(null)
@@ -614,15 +621,36 @@ function App(): React.JSX.Element {
         setFloatingTerminalOpenWithFocus((open) => !open)
       }
     }
+    const openFloatingTerminal = (): void => {
+      // Why: read live from store inside handler (not closed-over values) so
+      // requestOpenFloatingTerminal() dispatched from activity links (after
+      // createBrowserTab bumps the count) always sees count>0 and sets open=true
+      // even if the pref is off. This makes the panel visible inside Agents View.
+      const live = useAppStore.getState()
+      const liveEnabled = live.settings?.floatingTerminalEnabled === true
+      const liveCount = selectFloatingVisibleTabCount(live)
+      if (shouldOpenFloatingTerminalOnRequest({ enabled: liveEnabled, visibleTabCount: liveCount })) {
+        setFloatingTerminalOpenWithFocus(true)
+      }
+    }
     window.addEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
-    return () => window.removeEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
-  }, [floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
+    window.addEventListener(OPEN_FLOATING_TERMINAL_EVENT, openFloatingTerminal)
+    return () => {
+      window.removeEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
+      window.removeEventListener(OPEN_FLOATING_TERMINAL_EVENT, openFloatingTerminal)
+    }
+  }, [floatingTerminalEnabled, floatingVisibleTabCount, setFloatingTerminalOpenWithFocus])
 
   useEffect(() => {
-    if (!floatingTerminalEnabled) {
+    // Why: live read + policy so count>0 (activity browser tab) prevents force
+    // close even if !enabled. The request from routing will have set open.
+    const live = useAppStore.getState()
+    const liveEnabled = live.settings?.floatingTerminalEnabled === true
+    const liveCount = selectFloatingVisibleTabCount(live)
+    if (shouldForceCloseFloatingTerminal({ enabled: liveEnabled, visibleTabCount: liveCount })) {
       setFloatingTerminalOpenWithFocus(false)
     }
-  }, [floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
+  }, [floatingTerminalEnabled, floatingVisibleTabCount, setFloatingTerminalOpenWithFocus])
 
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
@@ -2408,7 +2436,7 @@ function App(): React.JSX.Element {
                               {activeView === 'activity' ? <ActivityPrototypePage /> : null}
                               {activeView === 'space' ? <WorkspaceSpacePage /> : null}
                               {activeView === 'mobile' ? <MobilePage /> : null}
-                              {activeView === 'terminal' &&
+                              {(activeView === 'terminal' || activeView === 'activity') &&
                               creationLayoutActive &&
                               activePendingCreationId ? (
                                 <WorktreeCreationPanel
@@ -2418,7 +2446,7 @@ function App(): React.JSX.Element {
                                   }
                                 />
                               ) : null}
-                              {activeView === 'terminal' &&
+                              {(activeView === 'terminal' || activeView === 'activity') &&
                               !activeWorktreeId &&
                               !creationLayoutActive ? (
                                 <Landing />

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -42,6 +42,7 @@ import {
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 import { useAppStore } from './store'
+import { resolveMainSurface } from './app-main-surface'
 import { useShallow } from 'zustand/react/shallow'
 import { isRemoteWorkspaceSnapshotApplyInProgress, useIpcEvents } from './hooks/useIpcEvents'
 import { useAutomationDispatchEvents } from './hooks/useAutomationDispatchEvents'
@@ -527,6 +528,11 @@ function App(): React.JSX.Element {
     activeView,
     activePendingCreationId,
     hasActivePendingCreation: activePendingCreationExists
+  })
+  const mainSurface = resolveMainSurface({
+    activeView,
+    activeWorktreeId,
+    creationLayoutActive
   })
   const workspaceChromeActive =
     activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
@@ -2433,19 +2439,10 @@ function App(): React.JSX.Element {
                               {activeView === 'skills' ? <SkillsPage /> : null}
                               {activeView === 'tasks' ? <TaskPage /> : null}
                               {activeView === 'automations' ? <AutomationsPage /> : null}
-                              {/* Why: Agents View must not stack under Landing / worktree-creation
-                                  panels (CodeRabbit on #7838). Those surfaces own the same slot
-                                  when there is no active worktree or a pending creation. */}
-                              {activeView === 'activity' &&
-                              activeWorktreeId &&
-                              !creationLayoutActive ? (
-                                <ActivityPrototypePage />
-                              ) : null}
+                              {mainSurface === 'activity' ? <ActivityPrototypePage /> : null}
                               {activeView === 'space' ? <WorkspaceSpacePage /> : null}
                               {activeView === 'mobile' ? <MobilePage /> : null}
-                              {(activeView === 'terminal' || activeView === 'activity') &&
-                              creationLayoutActive &&
-                              activePendingCreationId ? (
+                              {mainSurface === 'creation' && activePendingCreationId ? (
                                 <WorktreeCreationPanel
                                   creationId={activePendingCreationId}
                                   reserveCollapsedSidebarHeaderSpace={
@@ -2453,11 +2450,7 @@ function App(): React.JSX.Element {
                                   }
                                 />
                               ) : null}
-                              {(activeView === 'terminal' || activeView === 'activity') &&
-                              !activeWorktreeId &&
-                              !creationLayoutActive ? (
-                                <Landing />
-                              ) : null}
+                              {mainSurface === 'landing' ? <Landing /> : null}
                             </RecoverableRenderErrorBoundary>
                           </Suspense>
                         </div>

--- a/src/renderer/src/app-main-surface.test.ts
+++ b/src/renderer/src/app-main-surface.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMainSurface } from './app-main-surface'
+
+describe('resolveMainSurface', () => {
+  it('keeps activity available without an active worktree', () => {
+    expect(
+      resolveMainSurface({
+        activeView: 'activity',
+        activeWorktreeId: null,
+        creationLayoutActive: false
+      })
+    ).toBe('activity')
+  })
+})

--- a/src/renderer/src/app-main-surface.ts
+++ b/src/renderer/src/app-main-surface.ts
@@ -1,0 +1,31 @@
+import type { UISlice } from '@/store/slices/ui'
+
+export type MainSurface = 'activity' | 'creation' | 'landing' | null
+
+export type MainSurfaceInput = {
+  activeView: UISlice['activeView']
+  activeWorktreeId: string | null
+  creationLayoutActive: boolean
+}
+
+export function resolveMainSurface({
+  activeView,
+  activeWorktreeId,
+  creationLayoutActive
+}: MainSurfaceInput): MainSurface {
+  // Why: creation and Agents share the same content slot, so creation wins
+  // while its layout is active instead of mounting both surfaces.
+  if (creationLayoutActive && (activeView === 'terminal' || activeView === 'activity')) {
+    return 'creation'
+  }
+
+  if (activeView === 'activity') {
+    return 'activity'
+  }
+
+  if (activeView === 'terminal' && activeWorktreeId === null) {
+    return 'landing'
+  }
+
+  return null
+}

--- a/src/renderer/src/lib/floating-terminal.test.ts
+++ b/src/renderer/src/lib/floating-terminal.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   consumeFloatingTerminalOpenMaximizedIntent,
-  requestFloatingTerminalOpenMaximized
+  requestFloatingTerminalOpenMaximized,
+  shouldOpenFloatingTerminalOnRequest,
+  shouldForceCloseFloatingTerminal
 } from './floating-terminal'
 
 describe('floating terminal open-maximized intent', () => {
@@ -41,5 +43,29 @@ describe('floating terminal open-maximized intent', () => {
     vi.advanceTimersByTime(50)
 
     expect(consumeFloatingTerminalOpenMaximizedIntent()).toBe(true)
+  })
+})
+
+describe('floating terminal open/close policy for activity links (#7813)', () => {
+  // Table-driven: covers the case where floatingTerminalEnabled=false but a
+  // browser tab was created from Agents View terminal link (count>0) => must
+  // open and must not force-close.
+  const cases: {
+    enabled: boolean
+    count: number
+    open: boolean
+    forceClose: boolean
+    note: string
+  }[] = [
+    { enabled: true, count: 0, open: true, forceClose: false, note: 'normal enabled, no tabs' },
+    { enabled: true, count: 1, open: true, forceClose: false, note: 'enabled with tab' },
+    { enabled: false, count: 0, open: false, forceClose: true, note: 'disabled, no tabs => closed' },
+    { enabled: false, count: 1, open: true, forceClose: false, note: 'activity link case: disabled but count>0 => open for browser in Agents View' },
+    { enabled: false, count: 2, open: true, forceClose: false, note: 'multiple tabs while pref off' }
+  ]
+
+  it.each(cases)('shouldOpen($enabled, $count) => $open; shouldForceClose => $forceClose ($note)', ({ enabled, count, open, forceClose }) => {
+    expect(shouldOpenFloatingTerminalOnRequest({ enabled, visibleTabCount: count })).toBe(open)
+    expect(shouldForceCloseFloatingTerminal({ enabled, visibleTabCount: count })).toBe(forceClose)
   })
 })

--- a/src/renderer/src/lib/floating-terminal.ts
+++ b/src/renderer/src/lib/floating-terminal.ts
@@ -1,4 +1,5 @@
 export const TOGGLE_FLOATING_TERMINAL_EVENT = 'orca-toggle-floating-terminal'
+export const OPEN_FLOATING_TERMINAL_EVENT = 'orca-open-floating-terminal'
 
 // Why: maximize/restore lives in the panel's own keydown handler, but that
 // handler is unmounted while the panel is closed. When Cmd+Opt+Shift+A is
@@ -18,6 +19,12 @@ export function requestFloatingTerminalOpenMaximized(): void {
   openMaximizedIntentAt = Date.now()
 }
 
+export function requestOpenFloatingTerminal(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(OPEN_FLOATING_TERMINAL_EVENT))
+  }
+}
+
 export function consumeFloatingTerminalOpenMaximizedIntent(): boolean {
   if (openMaximizedIntentAt === null) {
     return false
@@ -25,4 +32,29 @@ export function consumeFloatingTerminalOpenMaximizedIntent(): boolean {
   const requestedAt = openMaximizedIntentAt
   openMaximizedIntentAt = null
   return Date.now() - requestedAt <= OPEN_MAXIMIZED_INTENT_TTL_MS
+}
+
+/** Why: activity/Agents View terminal links create floating browser tabs
+ *  (via FLOATING_TERMINAL_WORKTREE_ID) even when the user's
+ *  floatingTerminalEnabled pref is false. The panel must become visible
+ *  (open + mounted) based on tab presence so the browser is usable without
+ *  leaving the view. These pure fns isolate the policy for test coverage. */
+export function shouldOpenFloatingTerminalOnRequest({
+  enabled,
+  visibleTabCount
+}: {
+  enabled: boolean
+  visibleTabCount: number
+}): boolean {
+  return enabled || visibleTabCount > 0
+}
+
+export function shouldForceCloseFloatingTerminal({
+  enabled,
+  visibleTabCount
+}: {
+  enabled: boolean
+  visibleTabCount: number
+}): boolean {
+  return !enabled && visibleTabCount === 0
 }

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
-import type { WorkspacePort, WorkspacePortScanResult } from '../../../shared/workspace-ports'
+import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
 import * as floatingMod from './floating-terminal'
 import {
   openHttpLink,
@@ -135,8 +135,8 @@ describe('openHttpLink', () => {
               worktreeId: 'wt-1',
               displayName: 'wt',
               path: '/wt',
-              confidence: 'cwd'
-            } as WorkspacePort & { kind: 'workspace' }
+              confidence: 'cwd' as const
+            }
           }
         ]
       }
@@ -146,7 +146,11 @@ describe('openHttpLink', () => {
     openHttpLink('http://localhost:5180/', { worktreeId: 'wt-1' })
     await Promise.resolve()
 
-    expect(createBrowserTabMock).toHaveBeenCalledWith(FLOATING_TERMINAL_WORKTREE_ID, 'http://labeled.orca.local', { activate: true })
+    expect(createBrowserTabMock).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'http://labeled.orca.local',
+      { activate: true }
+    )
     expect(floatingMod.requestOpenFloatingTerminal).toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
-import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
+import type { WorkspacePort, WorkspacePortScanResult } from '../../../shared/workspace-ports'
+import * as floatingMod from './floating-terminal'
 import {
   openHttpLink,
   registerHttpLinkStoreAccessor,
@@ -23,6 +24,7 @@ const storeState = {
     | undefined,
   setActiveWorktree: setActiveWorktreeMock,
   createBrowserTab: createBrowserTabMock,
+  activeView: undefined as string | undefined,
   repos: [] as { id: string; displayName: string; repoIcon?: null; badgeColor?: string }[],
   projects: [] as { id: string; displayName: string; repoIcon?: null; badgeColor?: string }[],
   worktreesByRepo: {} as Record<
@@ -38,6 +40,9 @@ const storeState = {
 beforeEach(() => {
   vi.clearAllMocks()
   storeState.settings = undefined
+  // Spy the request so we can assert activity links trigger open without
+  // testing App mount (per strategy for non-theater coverage of 7813 hop).
+  vi.spyOn(floatingMod, 'requestOpenFloatingTerminal')
   registerHttpLinkStoreAccessor(() => storeState)
   vi.stubGlobal('window', {
     api: {
@@ -47,8 +52,9 @@ beforeEach(() => {
       localhostWorktreeLabels: {
         register: registerLocalhostLabelMock
       }
-    }
-  })
+    },
+    dispatchEvent: vi.fn()
+  } as unknown as Window & typeof globalThis)
 })
 
 afterEach(() => {
@@ -89,6 +95,59 @@ describe('openHttpLink', () => {
       { activate: true }
     )
     expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('routes links from Agents View (activity) using floating browser without setActiveWorktree', () => {
+    storeState.settings = { openLinksInApp: true }
+    storeState.activeView = 'activity'
+
+    openHttpLink('https://example.com/', { worktreeId: 'wt-1' })
+
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'https://example.com/',
+      { activate: true }
+    )
+    expect(openUrlMock).not.toHaveBeenCalled()
+    expect(floatingMod.requestOpenFloatingTerminal).toHaveBeenCalled()
+  })
+
+  it('routes labeled localhost links from Agents View using floating', async () => {
+    storeState.settings = { openLinksInApp: true, localhostWorktreeLabelsEnabled: true }
+    storeState.activeView = 'activity'
+    storeState.repos = [{ id: 'repo-1', displayName: 'test' }]
+    storeState.worktreesByRepo = { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1', displayName: 'wt' }] }
+    storeState.workspacePortScan = {
+      result: {
+        platform: 'darwin',
+        scannedAt: 1,
+        ports: [
+          {
+            id: 'tcp:5180',
+            kind: 'workspace',
+            port: 5180,
+            protocol: 'http',
+            bindHost: '127.0.0.1',
+            connectHost: 'localhost',
+            owner: {
+              repoId: 'repo-1',
+              worktreeId: 'wt-1',
+              displayName: 'wt',
+              path: '/wt',
+              confidence: 'cwd'
+            } as WorkspacePort & { kind: 'workspace' }
+          }
+        ]
+      }
+    }
+    registerLocalhostLabelMock.mockResolvedValue({ url: 'http://labeled.orca.local' })
+
+    openHttpLink('http://localhost:5180/', { worktreeId: 'wt-1' })
+    await Promise.resolve()
+
+    expect(createBrowserTabMock).toHaveBeenCalledWith(FLOATING_TERMINAL_WORKTREE_ID, 'http://labeled.orca.local', { activate: true })
+    expect(floatingMod.requestOpenFloatingTerminal).toHaveBeenCalled()
   })
 
   it('routes to the system browser when openLinksInApp is off', () => {

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -1,4 +1,5 @@
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import { requestOpenFloatingTerminal } from './floating-terminal'
 import {
   parseLoopbackUrlWithPort,
   type LocalhostWorktreeLabelRoute
@@ -20,6 +21,7 @@ type StoreAccessor = () => {
   > | null
   setActiveWorktree: (worktreeId: string) => void
   createBrowserTab: (worktreeId: string, url: string, opts: { activate: boolean }) => unknown
+  activeView?: string
   repos?: LocalhostLinkRepo[]
   projects?: LocalhostLinkProject[]
   worktreesByRepo?: Record<string, LocalhostLinkWorktree[]>
@@ -70,18 +72,28 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
     // history entry — the user isn't changing worktrees, they're opening a tab
     // in the one they're already in. activateAndRevealWorktree is reserved for
     // file-link jumps that genuinely switch worktrees.
-    if (worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
+    const isActivity = state.activeView === 'activity'
+    if (!isActivity && worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
       // Why: the floating workspace uses a synthetic worktree id. Promoting it
       // to the global activeWorktreeId deselects the real repo workspace.
       state.setActiveWorktree(worktreeId)
     }
     const localhostRoute = localhostLabelRouteForTerminalLink(url, state)
+    const targetWt = isActivity ? FLOATING_TERMINAL_WORKTREE_ID : worktreeId
     if (!localhostRoute) {
-      state.createBrowserTab(worktreeId, url, { activate: true })
+      state.createBrowserTab(targetWt, url, { activate: true })
+      if (isActivity) {
+        // Why: force the floating panel open so the browser is visible and
+        // activatable directly within the Agents View without leaving it.
+        requestOpenFloatingTerminal()
+      }
       return
     }
     void openLabeledLocalhostLink(url, localhostRoute, (labeledUrl) => {
-      state.createBrowserTab(worktreeId, labeledUrl, { activate: true })
+      state.createBrowserTab(targetWt, labeledUrl, { activate: true })
+      if (isActivity) {
+        requestOpenFloatingTerminal()
+      }
     })
     return
   }

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2867,7 +2867,7 @@ function normalizePiCompatibleEvent(
     eventName === 'tool_execution_end' ||
     eventName === 'message_end'
       ? 'working'
-      : eventName === 'agent_end' || eventName === 'session_shutdown'
+      : eventName === 'agent_end'
         ? 'done'
         : null
 


### PR DESCRIPTION
## Summary

- **#7791**: Pi/OMP hook normalization no longer maps `session_shutdown` to `done` (only `agent_end` does). This prevents mid-work status drop / “disconnect” UI while the PTY is still running; Pi can emit `session_shutdown` on internal session boundaries during long work.
- **#7813**: HTTP links opened from Agents View (`activeView === 'activity'`) create browser tabs on the floating workspace and request the floating panel open. Pure open/force-close policy allows the panel to show when floating tabs exist even if `floatingTerminalEnabled` is off. `App` handles the open event with live store reads so `open=true` after tab creation.

## Root causes (brief)

| Issue | Cause | Fix |
| --- | --- | --- |
| #7791 | `normalizePiCompatibleEvent` treated `session_shutdown` like `agent_end` → `done` | Only `agent_end` → `done`; shutdown returns null |
| #7813 | Main browser chrome is terminal-view-only; activity links created tabs that were not visible without leaving the view | Floating target + `requestOpenFloatingTerminal` + open/force policy |

## Screenshots

No UI chrome redesign. Behavior change: browser overlay usable while staying in Agents View; Pi status stays `working` across `session_shutdown`.

## Testing

- [x] `pnpm run typecheck:node` (clean)
- [x] oxlint on changed files (0 errors)
- [x] Focused unit tests (246 passed):
  - `src/main/agent-hooks/server.test.ts` — `session_shutdown does not map to done (#7791)`
  - `src/renderer/src/lib/http-link-routing.test.ts` — activity routes to floating + `requestOpenFloatingTerminal`
  - `src/renderer/src/lib/floating-terminal.test.ts` — open/force-close policy table (incl. `enabled=false, count>0`)

## AI Review Report

- **#7791**: Decision point is shared normalize path (local HTTP + relay ingest). Confirmed other agents use different terminal events; Pi titlebar animation still stops on shutdown (cosmetic only). Risk: if any flow relied on shutdown-as-done without `agent_end`, status may stay working until end/PTY teardown — matches reported symptom.
- **#7813**: Two-hop chain (routing creates floating tab + dispatches open; App sets `open` via policy). Live `getState()` in open handler avoids stale count after `createBrowserTab`. Main terminal chrome gates unchanged; floating is the within-activity surface. Does not enable floating feature for unrelated empty opens when pref is off and count is 0.
- Cross-platform: no OS-specific paths/shortcuts. SSH/remote: `openLinksInApp` + remote runtime still force system browser as before.
- No secrets/IPC surface changes beyond existing store accessors and custom events.

## Security Audit

- No new network endpoints, auth, or command execution.
- Custom event is same-origin renderer only (`orca-open-floating-terminal`).
- Link routing still respects `openLinksInApp`, remote runtime, and `forceSystemBrowser`.
- Risk: low. Policy can surface floating panel when activity created tabs while pref is off; intentional for Agents View browser availability.

## Notes

- Separate from #7814 / PR #7817 (`fix/pi-disabled-extensions`).
- Scope is limited to hook normalize + link routing + floating open policy + tests.

Fixes #7791
Fixes #7813