### PR TITLE
fix(space): stream workspace space scans

### DIFF
--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   WorkspaceSpaceAnalysis,
@@ -57,10 +58,16 @@ function createAnalyzeResult(scannedAt: number): WorkspaceSpaceAnalyzeResult {
 }
 
 function createEvent() {
+  let destroyed = false
+  const sender = Object.assign(new EventEmitter(), {
+    isDestroyed: vi.fn(() => destroyed),
+    send: vi.fn()
+  })
   return {
-    sender: {
-      isDestroyed: vi.fn(() => false),
-      send: vi.fn()
+    sender,
+    destroy: () => {
+      destroyed = true
+      sender.emit('destroyed')
     }
   }
 }
@@ -106,6 +113,34 @@ describe('registerWorkspaceSpaceHandlers', () => {
 
     await expect(handler!(createEvent())).resolves.toEqual(createAnalyzeResult(2))
     expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts a fresh scan after the owning renderer is destroyed', async () => {
+    const store = {} as Store
+    analyzeWorkspaceSpaceMock
+      .mockImplementationOnce((_store, options) => {
+        return new Promise<WorkspaceSpaceAnalysis>((_resolve, reject) => {
+          options.signal.addEventListener(
+            'abort',
+            () => reject(new WorkspaceSpaceScanCancelledErrorMock()),
+            { once: true }
+          )
+        })
+      })
+      .mockResolvedValueOnce(createAnalysis(2))
+
+    registerWorkspaceSpaceHandlers(store)
+    const analyzeHandler = handlers.get('workspaceSpace:analyze')
+    const owner = createEvent()
+    const first = analyzeHandler!(owner)
+
+    owner.destroy()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const replacement = analyzeHandler!(createEvent())
+
+    expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledTimes(2)
+    await expect(first).resolves.toEqual({ ok: false, cancelled: true })
+    await expect(replacement).resolves.toEqual(createAnalyzeResult(2))
   })
 
   it('forwards scan progress to the requesting renderer', async () => {

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   WorkspaceSpaceAnalysis,
@@ -66,10 +67,16 @@ function createAnalyzeResult(scannedAt: number): WorkspaceSpaceAnalyzeResult {
 }
 
 function createEvent() {
+  let destroyed = false
+  const sender = Object.assign(new EventEmitter(), {
+    isDestroyed: vi.fn(() => destroyed),
+    send: vi.fn()
+  })
   return {
-    sender: {
-      isDestroyed: vi.fn(() => false),
-      send: vi.fn()
+    sender,
+    destroy: () => {
+      destroyed = true
+      sender.emit('destroyed')
     }
   }
 }
@@ -121,6 +128,34 @@ describe('registerWorkspaceSpaceHandlers', () => {
 
     await expect(handler!(createEvent())).resolves.toEqual(createAnalyzeResult(2))
     expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts a fresh scan after the owning renderer is destroyed', async () => {
+    const store = createStore()
+    analyzeWorkspaceSpaceMock
+      .mockImplementationOnce((_store, options) => {
+        return new Promise<WorkspaceSpaceAnalysis>((_resolve, reject) => {
+          options.signal.addEventListener(
+            'abort',
+            () => reject(new WorkspaceSpaceScanCancelledErrorMock()),
+            { once: true }
+          )
+        })
+      })
+      .mockResolvedValueOnce(createAnalysis(2))
+
+    registerWorkspaceSpaceHandlers(store)
+    const analyzeHandler = handlers.get('workspaceSpace:analyze')
+    const owner = createEvent()
+    const first = analyzeHandler!(owner)
+
+    owner.destroy()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const replacement = analyzeHandler!(createEvent())
+
+    expect(analyzeWorkspaceSpaceMock).toHaveBeenCalledTimes(2)
+    await expect(first).resolves.toEqual({ ok: false, cancelled: true })
+    await expect(replacement).resolves.toEqual(createAnalyzeResult(2))
   })
 
   it('forwards scan progress to the requesting renderer', async () => {

--- a/src/main/ipc/workspace-space.ts
+++ b/src/main/ipc/workspace-space.ts
@@ -33,6 +33,11 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
   ipcMain.handle('workspaceSpace:analyze', async (event): Promise<WorkspaceSpaceAnalyzeResult> => {
     if (!inFlightScan) {
       const controller = new AbortController()
+      const owner = event.sender
+      // Why: this scan is process-global, so a destroyed owner must release it
+      // or a later renderer can inherit an unreachable pending request.
+      const onOwnerDestroyed = (): void => controller.abort()
+      owner.once('destroyed', onOwnerDestroyed)
       const scanId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
       let latestProgress: WorkspaceSpaceScanProgress = {
         scanId,
@@ -108,6 +113,7 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
           throw error
         })
         .finally(() => {
+          owner.removeListener('destroyed', onOwnerDestroyed)
           inFlightScan = null
         })
     }

--- a/src/main/ipc/workspace-space.ts
+++ b/src/main/ipc/workspace-space.ts
@@ -25,6 +25,11 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
   ipcMain.handle('workspaceSpace:analyze', async (event): Promise<WorkspaceSpaceAnalyzeResult> => {
     if (!inFlightScan) {
       const controller = new AbortController()
+      const owner = event.sender
+      // Why: this scan is process-global, so a destroyed owner must release it
+      // or a later renderer can inherit an unreachable pending request.
+      const onOwnerDestroyed = (): void => controller.abort()
+      owner.once('destroyed', onOwnerDestroyed)
       const scanId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
       let latestProgress: WorkspaceSpaceScanProgress = {
         scanId,
@@ -86,6 +91,7 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
           throw error
         })
         .finally(() => {
+          owner.removeListener('destroyed', onOwnerDestroyed)
           inFlightScan = null
         })
     }

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -408,7 +408,7 @@ describe('SshFilesystemProvider', () => {
     expect(mux.request).toHaveBeenCalledWith(
       'fs.workspaceSpaceScan',
       { rootPath: '/home/user/project' },
-      { signal: controller.signal, timeoutMs: 130000 }
+      { signal: controller.signal, timeoutMs: 130_000 }
     )
   })
 

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -408,7 +408,7 @@ describe('SshFilesystemProvider', () => {
     expect(mux.request).toHaveBeenCalledWith(
       'fs.workspaceSpaceScan',
       { rootPath: '/home/user/project' },
-      { signal: controller.signal, timeoutMs: 130000 }
+      { signal: controller.signal, timeoutMs: null }
     )
   })
 

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -408,7 +408,7 @@ describe('SshFilesystemProvider', () => {
     expect(mux.request).toHaveBeenCalledWith(
       'fs.workspaceSpaceScan',
       { rootPath: '/home/user/project' },
-      { signal: controller.signal, timeoutMs: null }
+      { signal: controller.signal, timeoutMs: 130_000 }
     )
   })
 

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -251,7 +251,9 @@ export class SshFilesystemProvider implements IFilesystemProvider {
     return (await this.mux.request(
       'fs.workspaceSpaceScan',
       { rootPath },
-      { signal: options?.signal, timeoutMs: WORKSPACE_SPACE_SCAN_TIMEOUT_MS }
+      // Why: accurate remote du scans can legitimately outlive the default
+      // request deadline; explicit cancellation still sends rpc.cancel.
+      { signal: options?.signal, timeoutMs: null }
     )) as WorkspaceSpaceDirectoryScanResult
   }
 

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -25,7 +25,6 @@ import type { DirEntry, FsChangeEvent, SearchOptions, SearchResult } from '../..
 import { routeSshFilesystemWatchNotification } from './ssh-filesystem-watch-notifications'
 import type { WorkspaceSpaceDirectoryScanResult } from '../../shared/workspace-space-types'
 import { isWindowsRemoteHost, type RemoteHostPlatform } from '../ssh/ssh-remote-platform'
-const WORKSPACE_SPACE_SCAN_TIMEOUT_MS = 130_000
 
 export class SshFilesystemProvider implements IFilesystemProvider {
   private connectionId: string

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -26,6 +26,8 @@ import { routeSshFilesystemWatchNotification } from './ssh-filesystem-watch-noti
 import type { WorkspaceSpaceDirectoryScanResult } from '../../shared/workspace-space-types'
 import { isWindowsRemoteHost, type RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 
+const WORKSPACE_SPACE_SCAN_TIMEOUT_MS = 130_000
+
 export class SshFilesystemProvider implements IFilesystemProvider {
   private connectionId: string
   private mux: SshChannelMultiplexer
@@ -250,9 +252,7 @@ export class SshFilesystemProvider implements IFilesystemProvider {
     return (await this.mux.request(
       'fs.workspaceSpaceScan',
       { rootPath },
-      // Why: accurate remote du scans can legitimately outlive the default
-      // request deadline; explicit cancellation still sends rpc.cancel.
-      { signal: options?.signal, timeoutMs: null }
+      { signal: options?.signal, timeoutMs: WORKSPACE_SPACE_SCAN_TIMEOUT_MS }
     )) as WorkspaceSpaceDirectoryScanResult
   }
 

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -39,7 +39,9 @@ import {
   writeSshTerminalArtifact
 } from './ssh-filesystem-terminal-artifact'
 import { readSshDocPreviewFile } from './ssh-filesystem-doc-preview'
+
 const WORKSPACE_SPACE_SCAN_TIMEOUT_MS = 130_000
+
 export class SshFilesystemProvider implements IFilesystemProvider {
   private connectionId: string
   private mux: SshChannelMultiplexer

--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -190,6 +190,40 @@ describe('SshChannelMultiplexer', () => {
       await expect(promise).rejects.toThrow('timed out after 60000ms')
     })
 
+    it('can disable request timeout while preserving abort cancellation', async () => {
+      const controller = new AbortController()
+      const promise = mux.request(
+        'fs.workspaceSpaceScan',
+        {},
+        {
+          signal: controller.signal,
+          timeoutMs: null
+        }
+      )
+
+      for (let i = 0; i < 8; i++) {
+        vi.advanceTimersByTime(5_000)
+        transport.dataCallbacks[0](encodeKeepAliveFrame(i + 1, 0))
+      }
+      await Promise.resolve()
+      const requestWrites = transport.written.filter((frame) => frame[0] === MessageType.Regular)
+      expect(requestWrites).toHaveLength(1)
+
+      controller.abort()
+
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+      const cancelPayload = JSON.parse(
+        transport.written
+          .at(-1)!
+          .subarray(HEADER_LENGTH, HEADER_LENGTH + transport.written.at(-1)!.readUInt32BE(9))
+          .toString()
+      )
+      expect(cancelPayload).toMatchObject({
+        method: 'rpc.cancel',
+        params: { id: 1 }
+      })
+    })
+
     it('assigns unique request IDs', async () => {
       void mux.request('method1').catch(() => {})
       void mux.request('method2').catch(() => {})

--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -189,6 +189,40 @@ describe('SshChannelMultiplexer', () => {
       await expect(promise).rejects.toThrow('timed out after 60000ms')
     })
 
+    it('can disable request timeout while preserving abort cancellation', async () => {
+      const controller = new AbortController()
+      const promise = mux.request(
+        'fs.workspaceSpaceScan',
+        {},
+        {
+          signal: controller.signal,
+          timeoutMs: null
+        }
+      )
+
+      for (let i = 0; i < 8; i++) {
+        vi.advanceTimersByTime(5_000)
+        transport.dataCallbacks[0](encodeKeepAliveFrame(i + 1, 0))
+      }
+      await Promise.resolve()
+      const requestWrites = transport.written.filter((frame) => frame[0] === MessageType.Regular)
+      expect(requestWrites).toHaveLength(1)
+
+      controller.abort()
+
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+      const cancelPayload = JSON.parse(
+        transport.written
+          .at(-1)!
+          .subarray(HEADER_LENGTH, HEADER_LENGTH + transport.written.at(-1)!.readUInt32BE(9))
+          .toString()
+      )
+      expect(cancelPayload).toMatchObject({
+        method: 'rpc.cancel',
+        params: { id: 1 }
+      })
+    })
+
     it('assigns unique request IDs', async () => {
       void mux.request('method1').catch(() => {})
       void mux.request('method2').catch(() => {})

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -27,13 +27,13 @@ type PendingRequest = {
   resolve: (result: unknown) => void
   reject: (error: Error) => void
   beforeResolve?: (result: unknown) => void
-  timer: ReturnType<typeof setTimeout>
+  timer: ReturnType<typeof setTimeout> | null
   cleanup: () => void
 }
 
 export type SshMultiplexerRequestOptions = {
   signal?: AbortSignal
-  timeoutMs?: number
+  timeoutMs?: number | null
   beforeResolve?: (result: unknown) => void
 }
 
@@ -216,12 +216,14 @@ export class SshChannelMultiplexer {
       method,
       ...(params !== undefined ? { params } : {})
     }
-    const timeoutMs = options?.timeoutMs ?? REQUEST_TIMEOUT_MS
+    const timeoutMs = options?.timeoutMs === undefined ? REQUEST_TIMEOUT_MS : options.timeoutMs
 
     return new Promise((resolve, reject) => {
-      let timer: ReturnType<typeof setTimeout>
+      let timer: ReturnType<typeof setTimeout> | null = null
       const cleanup = (): void => {
-        clearTimeout(timer)
+        if (timer) {
+          clearTimeout(timer)
+        }
         if (options?.signal) {
           options.signal.removeEventListener('abort', onAbort)
         }
@@ -240,17 +242,19 @@ export class SshChannelMultiplexer {
         error.name = 'AbortError'
         pending.reject(error)
       }
-      timer = setTimeout(() => {
-        const pending = this.pendingRequests.get(id)
-        if (pending) {
-          pending.cleanup()
-          // Why: request timeouts should stop relay-side long-running work,
-          // not just detach the client from the eventual response.
-          this.notify('rpc.cancel', { id })
-        }
-        this.pendingRequests.delete(id)
-        reject(sshMuxRequestTimeoutError(method, timeoutMs))
-      }, timeoutMs)
+      if (timeoutMs !== null) {
+        timer = setTimeout(() => {
+          const pending = this.pendingRequests.get(id)
+          if (pending) {
+            pending.cleanup()
+            // Why: request timeouts should stop relay-side long-running work,
+            // not just detach the client from the eventual response.
+            this.notify('rpc.cancel', { id })
+          }
+          this.pendingRequests.delete(id)
+          reject(sshMuxRequestTimeoutError(method, timeoutMs))
+        }, timeoutMs)
+      }
 
       if (options?.signal) {
         options.signal.addEventListener('abort', onAbort, { once: true })

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -27,13 +27,13 @@ type PendingRequest = {
   resolve: (result: unknown) => void
   reject: (error: Error) => void
   beforeResolve?: (result: unknown) => void
-  timer: ReturnType<typeof setTimeout>
+  timer: ReturnType<typeof setTimeout> | null
   cleanup: () => void
 }
 
 export type SshMultiplexerRequestOptions = {
   signal?: AbortSignal
-  timeoutMs?: number
+  timeoutMs?: number | null
   beforeResolve?: (result: unknown) => void
 }
 
@@ -245,12 +245,14 @@ export class SshChannelMultiplexer {
       method,
       ...(params !== undefined ? { params } : {})
     }
-    const timeoutMs = options?.timeoutMs ?? REQUEST_TIMEOUT_MS
+    const timeoutMs = options?.timeoutMs === undefined ? REQUEST_TIMEOUT_MS : options.timeoutMs
 
     return new Promise((resolve, reject) => {
-      let timer: ReturnType<typeof setTimeout>
+      let timer: ReturnType<typeof setTimeout> | null = null
       const cleanup = (): void => {
-        clearTimeout(timer)
+        if (timer) {
+          clearTimeout(timer)
+        }
         if (options?.signal) {
           options.signal.removeEventListener('abort', onAbort)
         }
@@ -269,17 +271,19 @@ export class SshChannelMultiplexer {
         error.name = 'AbortError'
         pending.reject(error)
       }
-      timer = setTimeout(() => {
-        const pending = this.pendingRequests.get(id)
-        if (pending) {
-          pending.cleanup()
-          // Why: request timeouts should stop relay-side long-running work,
-          // not just detach the client from the eventual response.
-          this.notify('rpc.cancel', { id })
-        }
-        this.pendingRequests.delete(id)
-        reject(sshMuxRequestTimeoutError(method, timeoutMs))
-      }, timeoutMs)
+      if (timeoutMs !== null) {
+        timer = setTimeout(() => {
+          const pending = this.pendingRequests.get(id)
+          if (pending) {
+            pending.cleanup()
+            // Why: request timeouts should stop relay-side long-running work,
+            // not just detach the client from the eventual response.
+            this.notify('rpc.cancel', { id })
+          }
+          this.pendingRequests.delete(id)
+          reject(sshMuxRequestTimeoutError(method, timeoutMs))
+        }, timeoutMs)
+      }
 
       if (options?.signal) {
         options.signal.addEventListener('abort', onAbort, { once: true })

--- a/src/main/workspace-space-analysis-du-timeout.test.ts
+++ b/src/main/workspace-space-analysis-du-timeout.test.ts
@@ -1,18 +1,23 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { EventEmitter } from 'node:events'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as NodeProcess from 'node:process'
 import type { Repo } from '../shared/repo-types'
 import type { Store } from './persistence'
+import type * as WorkspaceSpaceScanBudgetModule from '../shared/workspace-space-scan-budget'
 
-const { execFileMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+const { budgetState, execFileMock, spawnMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+  budgetState: { created: 0, duMaxEntries: null as number | null },
   execFileMock: vi.fn(),
+  spawnMock: vi.fn(),
   listRepoWorktreesMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({
-  execFile: execFileMock
+  execFile: execFileMock,
+  spawn: spawnMock
 }))
 
 vi.mock('node:process', async () => {
@@ -39,6 +44,23 @@ vi.mock('./providers/ssh-git-dispatch', () => ({
   getSshGitProvider: vi.fn()
 }))
 
+vi.mock('../shared/workspace-space-scan-budget', async () => {
+  const actual = await vi.importActual<typeof WorkspaceSpaceScanBudgetModule>(
+    '../shared/workspace-space-scan-budget'
+  )
+  return {
+    ...actual,
+    createWorkspaceSpaceScanBudget: () => {
+      budgetState.created += 1
+      return actual.createWorkspaceSpaceScanBudget(
+        budgetState.created === 2 && budgetState.duMaxEntries
+          ? { maxEntries: budgetState.duMaxEntries }
+          : undefined
+      )
+    }
+  }
+})
+
 import { analyzeWorkspaceSpace } from './workspace-space-analysis'
 
 function createStore(repos: Repo[]): Store {
@@ -54,7 +76,10 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'orca-space-du-timeout-'))
     execFileMock.mockReset()
+    spawnMock.mockReset()
     listRepoWorktreesMock.mockReset()
+    budgetState.created = 0
+    budgetState.duMaxEntries = null
   })
 
   afterEach(async () => {
@@ -65,11 +90,7 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     }
   })
 
-  it('falls back when du never reports completion', async () => {
-    const repoPath = join(tempDir!, 'repo')
-    await mkdir(repoPath, { recursive: true })
-    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
-
+  function mockRepo(repoPath: string): Repo {
     const repo: Repo = {
       id: 'repo-1',
       path: repoPath,
@@ -86,33 +107,174 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
         isMainWorktree: true
       }
     ])
-    const killMock = vi.fn()
-    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    return repo
+  }
 
-    vi.useFakeTimers()
-    let settled = false
-    const scanPromise = analyzeWorkspaceSpace(createStore([repo])).then((scan) => {
-      settled = true
-      return scan
+  function createSpawnedDu() {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter
+      stderr: EventEmitter
+      kill: ReturnType<typeof vi.fn>
+    }
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+    child.kill = vi.fn()
+    return child
+  }
+
+  it('streams native du output instead of using execFile buffering', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(repoPath, { recursive: true })
+    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
+    const repo = mockRepo(repoPath)
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+    execFileMock.mockImplementation(() => {
+      throw new Error('execFile should not be used for workspace Space scans')
     })
 
-    await vi.waitFor(() =>
-      expect(execFileMock).toHaveBeenCalledWith(
-        'du',
-        ['-k', '-d', '1', repoPath],
-        expect.any(Object),
-        expect.any(Function)
-      )
-    )
-    await vi.advanceTimersByTimeAsync(120_000)
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]))
 
-    await vi.waitFor(() => expect(settled).toBe(true))
+    await vi.waitFor(() =>
+      expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', repoPath], {
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    )
+    child.stdout.emit('data', Buffer.from(`4\t${join(repoPath, 'app.ts')}\n`))
+    child.stdout.emit('data', Buffer.from(`12\t${repoPath}`))
+    child.stdout.emit('data', Buffer.from('\n'))
+    child.emit('close', 0)
+
     await expect(scanPromise).resolves.toMatchObject({
       scannedWorktreeCount: 1,
       unavailableWorktreeCount: 0,
-      worktrees: [expect.objectContaining({ status: 'ok', path: repoPath })]
+      worktrees: [
+        expect.objectContaining({
+          status: 'ok',
+          path: repoPath,
+          sizeBytes: 12 * 1024
+        })
+      ]
     })
-    expect(killMock).toHaveBeenCalled()
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves multibyte du paths split across stdout chunks', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    const dirname = '数据'
+    await mkdir(join(repoPath, dirname), { recursive: true })
+    await writeFile(join(repoPath, dirname, 'pkg.js'), Buffer.alloc(128))
+    const repo = mockRepo(repoPath)
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]))
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    const dirnameBytes = Buffer.from(dirname)
+    const duLine = Buffer.from(`24\t${join(repoPath, dirname)}\n`)
+    const splitAt = duLine.indexOf(dirnameBytes) + 1
+    child.stdout.emit('data', duLine.subarray(0, splitAt))
+    child.stdout.emit('data', duLine.subarray(splitAt))
+    child.stdout.emit('data', Buffer.from(`32\t${repoPath}\n`))
+    child.emit('close', 0)
+
+    await expect(scanPromise).resolves.toMatchObject({
+      worktrees: [
+        expect.objectContaining({
+          sizeBytes: 32 * 1024,
+          topLevelItems: [
+            expect.objectContaining({
+              name: dirname,
+              sizeBytes: 24 * 1024
+            })
+          ]
+        })
+      ]
+    })
+  })
+
+  it('bounds native du with a deadline before releasing the local scan slot', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(repoPath, { recursive: true })
+    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
+    const repo = mockRepo(repoPath)
+    const controller = new AbortController()
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    vi.useFakeTimers()
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]), { signal: controller.signal })
+
+    await vi.waitFor(() =>
+      expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', repoPath], {
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    )
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    controller.abort()
+    await expect(scanPromise).resolves.toMatchObject({
+      unavailableWorktreeCount: 1,
+      worktrees: [
+        expect.objectContaining({
+          status: 'unavailable',
+          error: 'du timed out after 120000ms'
+        })
+      ]
+    })
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('fails closed when streamed du rows exceed the retained entry budget', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(repoPath, { recursive: true })
+    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
+    const repo = mockRepo(repoPath)
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+    budgetState.duMaxEntries = 2
+
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]))
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    child.stdout.emit('data', Buffer.from(`1\t${join(repoPath, 'one')}\n`))
+    child.stdout.emit('data', Buffer.from(`1\t${join(repoPath, 'two')}\n`))
+    child.stdout.emit('data', Buffer.from(`1\t${join(repoPath, 'three')}\n`))
+    child.emit('close', 0)
+
+    await expect(scanPromise).resolves.toMatchObject({
+      unavailableWorktreeCount: 1,
+      worktrees: [expect.objectContaining({ status: 'unavailable' })]
+    })
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('falls back accurately when native du is unavailable', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(join(repoPath, 'node_modules'), { recursive: true })
+    await writeFile(join(repoPath, 'node_modules', 'pkg.js'), Buffer.alloc(512))
+    await writeFile(join(repoPath, 'app.ts'), Buffer.alloc(128))
+    const repo = mockRepo(repoPath)
+    spawnMock.mockImplementation(() => {
+      throw Object.assign(new Error('du not found'), { code: 'ENOENT' })
+    })
+
+    await expect(analyzeWorkspaceSpace(createStore([repo]))).resolves.toMatchObject({
+      scannedWorktreeCount: 1,
+      unavailableWorktreeCount: 0,
+      worktrees: [
+        expect.objectContaining({
+          status: 'ok',
+          path: repoPath,
+          topLevelItems: expect.arrayContaining([
+            expect.objectContaining({ name: 'node_modules', sizeBytes: expect.any(Number) }),
+            expect.objectContaining({ name: 'app.ts', sizeBytes: 128 })
+          ])
+        })
+      ]
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
   })
 
   it('runs one local du traversal at a time across repos', async () => {
@@ -137,28 +299,23 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     const completions: (() => void)[] = []
     let active = 0
     let peak = 0
-    execFileMock.mockImplementation(
-      (
-        _file: string,
-        args: string[],
-        _options: unknown,
-        callback: (error: Error | null, stdout: string) => void
-      ) => {
-        const rootPath = args.at(-1)!
-        active += 1
-        peak = Math.max(peak, active)
-        completions.push(() => {
-          active -= 1
-          callback(null, `1\t${rootPath}\n`)
-        })
-        return { kill: vi.fn() }
-      }
-    )
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      const rootPath = args.at(-1)!
+      const child = createSpawnedDu()
+      active += 1
+      peak = Math.max(peak, active)
+      completions.push(() => {
+        active -= 1
+        child.stdout.emit('data', Buffer.from(`1\t${rootPath}\n`))
+        child.emit('close', 0)
+      })
+      return child
+    })
 
     const scan = analyzeWorkspaceSpace(createStore(repos))
-    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
     completions.shift()?.()
-    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
     completions.shift()?.()
 
     await expect(scan).resolves.toMatchObject({ scannedWorktreeCount: 2 })

--- a/src/main/workspace-space-analysis-du-timeout.test.ts
+++ b/src/main/workspace-space-analysis-du-timeout.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { EventEmitter } from 'node:events'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -6,13 +7,15 @@ import type * as NodeProcess from 'node:process'
 import type { Repo } from '../shared/types'
 import type { Store } from './persistence'
 
-const { execFileMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+const { execFileMock, spawnMock, listRepoWorktreesMock } = vi.hoisted(() => ({
   execFileMock: vi.fn(),
+  spawnMock: vi.fn(),
   listRepoWorktreesMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({
-  execFile: execFileMock
+  execFile: execFileMock,
+  spawn: spawnMock
 }))
 
 vi.mock('node:process', async () => {
@@ -54,6 +57,7 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'orca-space-du-timeout-'))
     execFileMock.mockReset()
+    spawnMock.mockReset()
     listRepoWorktreesMock.mockReset()
   })
 
@@ -65,11 +69,7 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     }
   })
 
-  it('falls back when du never reports completion', async () => {
-    const repoPath = join(tempDir!, 'repo')
-    await mkdir(repoPath, { recursive: true })
-    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
-
+  function mockRepo(repoPath: string): Repo {
     const repo: Repo = {
       id: 'repo-1',
       path: repoPath,
@@ -86,33 +86,154 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
         isMainWorktree: true
       }
     ])
-    const killMock = vi.fn()
-    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    return repo
+  }
 
-    vi.useFakeTimers()
-    let settled = false
-    const scanPromise = analyzeWorkspaceSpace(createStore([repo])).then((scan) => {
-      settled = true
-      return scan
+  function createSpawnedDu() {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter
+      stderr: EventEmitter
+      kill: ReturnType<typeof vi.fn>
+    }
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+    child.kill = vi.fn()
+    return child
+  }
+
+  it('streams native du output instead of using execFile buffering', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(repoPath, { recursive: true })
+    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
+    const repo = mockRepo(repoPath)
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+    execFileMock.mockImplementation(() => {
+      throw new Error('execFile should not be used for workspace Space scans')
     })
 
-    await vi.waitFor(() =>
-      expect(execFileMock).toHaveBeenCalledWith(
-        'du',
-        ['-k', '-d', '1', repoPath],
-        expect.any(Object),
-        expect.any(Function)
-      )
-    )
-    await vi.advanceTimersByTimeAsync(120_000)
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]))
 
-    await vi.waitFor(() => expect(settled).toBe(true))
+    await vi.waitFor(() =>
+      expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', repoPath], {
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    )
+    child.stdout.emit('data', Buffer.from(`4\t${join(repoPath, 'app.ts')}\n`))
+    child.stdout.emit('data', Buffer.from(`12\t${repoPath}`))
+    child.stdout.emit('data', Buffer.from('\n'))
+    child.emit('close', 0)
+
     await expect(scanPromise).resolves.toMatchObject({
       scannedWorktreeCount: 1,
       unavailableWorktreeCount: 0,
-      worktrees: [expect.objectContaining({ status: 'ok', path: repoPath })]
+      worktrees: [
+        expect.objectContaining({
+          status: 'ok',
+          path: repoPath,
+          sizeBytes: 12 * 1024
+        })
+      ]
     })
-    expect(killMock).toHaveBeenCalled()
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves multibyte du paths split across stdout chunks', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    const dirname = '数据'
+    await mkdir(join(repoPath, dirname), { recursive: true })
+    await writeFile(join(repoPath, dirname, 'pkg.js'), Buffer.alloc(128))
+    const repo = mockRepo(repoPath)
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]))
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    const dirnameBytes = Buffer.from(dirname)
+    const duLine = Buffer.from(`24\t${join(repoPath, dirname)}\n`)
+    const splitAt = duLine.indexOf(dirnameBytes) + 1
+    child.stdout.emit('data', duLine.subarray(0, splitAt))
+    child.stdout.emit('data', duLine.subarray(splitAt))
+    child.stdout.emit('data', Buffer.from(`32\t${repoPath}\n`))
+    child.emit('close', 0)
+
+    await expect(scanPromise).resolves.toMatchObject({
+      worktrees: [
+        expect.objectContaining({
+          sizeBytes: 32 * 1024,
+          topLevelItems: [
+            expect.objectContaining({
+              name: dirname,
+              sizeBytes: 24 * 1024
+            })
+          ]
+        })
+      ]
+    })
+  })
+
+  it('keeps native du running past the old timeout and kills it on cancellation', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(repoPath, { recursive: true })
+    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
+    const repo = mockRepo(repoPath)
+    const controller = new AbortController()
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    vi.useFakeTimers()
+    let settled = false
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]), { signal: controller.signal })
+      .then((scan) => {
+        settled = true
+        return scan
+      })
+      .catch((error: unknown) => {
+        settled = true
+        throw error
+      })
+
+    await vi.waitFor(() =>
+      expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', repoPath], {
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    )
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(settled).toBe(false)
+    controller.abort()
+    await expect(scanPromise).rejects.toMatchObject({
+      name: 'WorkspaceSpaceScanCancelledError'
+    })
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('falls back accurately when native du is unavailable', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(join(repoPath, 'node_modules'), { recursive: true })
+    await writeFile(join(repoPath, 'node_modules', 'pkg.js'), Buffer.alloc(512))
+    await writeFile(join(repoPath, 'app.ts'), Buffer.alloc(128))
+    const repo = mockRepo(repoPath)
+    spawnMock.mockImplementation(() => {
+      throw Object.assign(new Error('du not found'), { code: 'ENOENT' })
+    })
+
+    await expect(analyzeWorkspaceSpace(createStore([repo]))).resolves.toMatchObject({
+      scannedWorktreeCount: 1,
+      unavailableWorktreeCount: 0,
+      worktrees: [
+        expect.objectContaining({
+          status: 'ok',
+          path: repoPath,
+          topLevelItems: expect.arrayContaining([
+            expect.objectContaining({ name: 'node_modules', sizeBytes: expect.any(Number) }),
+            expect.objectContaining({ name: 'app.ts', sizeBytes: 128 })
+          ])
+        })
+      ]
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
   })
 
   it('runs one local du traversal at a time across repos', async () => {
@@ -137,28 +258,23 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     const completions: (() => void)[] = []
     let active = 0
     let peak = 0
-    execFileMock.mockImplementation(
-      (
-        _file: string,
-        args: string[],
-        _options: unknown,
-        callback: (error: Error | null, stdout: string) => void
-      ) => {
-        const rootPath = args.at(-1)!
-        active += 1
-        peak = Math.max(peak, active)
-        completions.push(() => {
-          active -= 1
-          callback(null, `1\t${rootPath}\n`)
-        })
-        return { kill: vi.fn() }
-      }
-    )
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      const rootPath = args.at(-1)!
+      const child = createSpawnedDu()
+      active += 1
+      peak = Math.max(peak, active)
+      completions.push(() => {
+        active -= 1
+        child.stdout.emit('data', Buffer.from(`1\t${rootPath}\n`))
+        child.emit('close', 0)
+      })
+      return child
+    })
 
     const scan = analyzeWorkspaceSpace(createStore(repos))
-    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
     completions.shift()?.()
-    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
     completions.shift()?.()
 
     await expect(scan).resolves.toMatchObject({ scannedWorktreeCount: 2 })

--- a/src/main/workspace-space-analysis-du-timeout.test.ts
+++ b/src/main/workspace-space-analysis-du-timeout.test.ts
@@ -6,8 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as NodeProcess from 'node:process'
 import type { Repo } from '../shared/types'
 import type { Store } from './persistence'
+import type * as WorkspaceSpaceScanBudgetModule from '../shared/workspace-space-scan-budget'
 
-const { execFileMock, spawnMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+const { budgetState, execFileMock, spawnMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+  budgetState: { created: 0, duMaxEntries: null as number | null },
   execFileMock: vi.fn(),
   spawnMock: vi.fn(),
   listRepoWorktreesMock: vi.fn()
@@ -42,6 +44,23 @@ vi.mock('./providers/ssh-git-dispatch', () => ({
   getSshGitProvider: vi.fn()
 }))
 
+vi.mock('../shared/workspace-space-scan-budget', async () => {
+  const actual = await vi.importActual<typeof WorkspaceSpaceScanBudgetModule>(
+    '../shared/workspace-space-scan-budget'
+  )
+  return {
+    ...actual,
+    createWorkspaceSpaceScanBudget: () => {
+      budgetState.created += 1
+      return actual.createWorkspaceSpaceScanBudget(
+        budgetState.created === 2 && budgetState.duMaxEntries
+          ? { maxEntries: budgetState.duMaxEntries }
+          : undefined
+      )
+    }
+  }
+})
+
 import { analyzeWorkspaceSpace } from './workspace-space-analysis'
 
 function createStore(repos: Repo[]): Store {
@@ -59,6 +78,8 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     execFileMock.mockReset()
     spawnMock.mockReset()
     listRepoWorktreesMock.mockReset()
+    budgetState.created = 0
+    budgetState.duMaxEntries = null
   })
 
   afterEach(async () => {
@@ -173,7 +194,7 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     })
   })
 
-  it('keeps native du running past the old timeout and kills it on cancellation', async () => {
+  it('bounds native du with a deadline before releasing the local scan slot', async () => {
     const repoPath = join(tempDir!, 'repo')
     await mkdir(repoPath, { recursive: true })
     await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
@@ -183,16 +204,7 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     spawnMock.mockReturnValue(child)
 
     vi.useFakeTimers()
-    let settled = false
     const scanPromise = analyzeWorkspaceSpace(createStore([repo]), { signal: controller.signal })
-      .then((scan) => {
-        settled = true
-        return scan
-      })
-      .catch((error: unknown) => {
-        settled = true
-        throw error
-      })
 
     await vi.waitFor(() =>
       expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', repoPath], {
@@ -201,10 +213,39 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     )
     await vi.advanceTimersByTimeAsync(120_000)
 
-    expect(settled).toBe(false)
     controller.abort()
-    await expect(scanPromise).rejects.toMatchObject({
-      name: 'WorkspaceSpaceScanCancelledError'
+    await expect(scanPromise).resolves.toMatchObject({
+      unavailableWorktreeCount: 1,
+      worktrees: [
+        expect.objectContaining({
+          status: 'unavailable',
+          error: 'du timed out after 120000ms'
+        })
+      ]
+    })
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('fails closed when streamed du rows exceed the retained entry budget', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(repoPath, { recursive: true })
+    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
+    const repo = mockRepo(repoPath)
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+    budgetState.duMaxEntries = 2
+
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]))
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    child.stdout.emit('data', Buffer.from(`1\t${join(repoPath, 'one')}\n`))
+    child.stdout.emit('data', Buffer.from(`1\t${join(repoPath, 'two')}\n`))
+    child.stdout.emit('data', Buffer.from(`1\t${join(repoPath, 'three')}\n`))
+    child.emit('close', 0)
+
+    await expect(scanPromise).resolves.toMatchObject({
+      unavailableWorktreeCount: 1,
+      worktrees: [expect.objectContaining({ status: 'unavailable' })]
     })
     expect(child.kill).toHaveBeenCalled()
   })

--- a/src/main/workspace-space-analysis-fallback-concurrency.test.ts
+++ b/src/main/workspace-space-analysis-fallback-concurrency.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeProcess from 'node:process'
+import type { Repo } from '../shared/types'
+import type { Store } from './persistence'
+
+const { lstatMock, opendirMock, spawnMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  opendirMock: vi.fn(),
+  spawnMock: vi.fn(),
+  listRepoWorktreesMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  lstat: lstatMock,
+  opendir: opendirMock
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('node:process', async () => {
+  const actual = await vi.importActual<typeof NodeProcess>('node:process')
+  return { ...actual, platform: 'darwin' }
+})
+
+vi.mock('./repo-worktrees', () => ({
+  createFolderWorktree: (repo: Repo) => ({
+    path: repo.path,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: true
+  }),
+  listRepoWorktrees: listRepoWorktreesMock
+}))
+
+vi.mock('./providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn()
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: vi.fn()
+}))
+
+import { analyzeWorkspaceSpace } from './workspace-space-analysis'
+
+function createStore(repos: Repo[]): Store {
+  return {
+    getRepos: () => repos,
+    getWorktreeMeta: () => undefined
+  } as unknown as Store
+}
+
+function createDirStat(size = 16) {
+  return {
+    size,
+    isSymbolicLink: () => false,
+    isDirectory: () => true
+  }
+}
+
+function createFileStat(size: number) {
+  return {
+    size,
+    isSymbolicLink: () => false,
+    isDirectory: () => false
+  }
+}
+
+describe('analyzeWorkspaceSpace fallback concurrency', () => {
+  beforeEach(() => {
+    lstatMock.mockReset()
+    opendirMock.mockReset()
+    spawnMock.mockReset()
+    listRepoWorktreesMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('scans portable fallback entries concurrently without retaining a child tree', async () => {
+    const repoPath = '/repo'
+    const repo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: repoPath,
+        head: 'a',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    spawnMock.mockImplementation(() => {
+      throw Object.assign(new Error('du not found'), { code: 'ENOENT' })
+    })
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield { name: 'a.txt' }
+        yield { name: 'b.txt' }
+      }
+    })
+
+    let started = 0
+    let active = 0
+    let maxActive = 0
+    let released = false
+    const releases: (() => void)[] = []
+    const releaseAll = (): void => {
+      released = true
+      while (releases.length > 0) {
+        releases.shift()?.()
+      }
+    }
+    lstatMock.mockImplementation((targetPath: string) => {
+      if (targetPath === repoPath) {
+        return Promise.resolve(createDirStat())
+      }
+      started += 1
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      const finish = (): ReturnType<typeof createFileStat> => {
+        active -= 1
+        return createFileStat(targetPath.endsWith('a.txt') ? 128 : 256)
+      }
+      if (released) {
+        return Promise.resolve(finish())
+      }
+      return new Promise((resolve) => {
+        releases.push(() => resolve(finish()))
+      })
+    })
+
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]))
+    try {
+      await vi.waitFor(() => expect(started).toBeGreaterThanOrEqual(2), { timeout: 200 })
+    } finally {
+      releaseAll()
+    }
+
+    await expect(scanPromise).resolves.toMatchObject({
+      worktrees: [
+        expect.objectContaining({
+          status: 'ok',
+          topLevelItems: expect.arrayContaining([
+            expect.objectContaining({ name: 'a.txt', sizeBytes: 128 }),
+            expect.objectContaining({ name: 'b.txt', sizeBytes: 256 })
+          ])
+        })
+      ]
+    })
+    expect(maxActive).toBeGreaterThan(1)
+  })
+})

--- a/src/main/workspace-space-analysis-fallback-concurrency.test.ts
+++ b/src/main/workspace-space-analysis-fallback-concurrency.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeProcess from 'node:process'
+import type { Repo } from '../shared/repo-types'
+import type { Store } from './persistence'
+
+const { lstatMock, opendirMock, spawnMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  opendirMock: vi.fn(),
+  spawnMock: vi.fn(),
+  listRepoWorktreesMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  lstat: lstatMock,
+  opendir: opendirMock
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('node:process', async () => {
+  const actual = await vi.importActual<typeof NodeProcess>('node:process')
+  return { ...actual, platform: 'darwin' }
+})
+
+vi.mock('./repo-worktrees', () => ({
+  createFolderWorktree: (repo: Repo) => ({
+    path: repo.path,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: true
+  }),
+  listRepoWorktrees: listRepoWorktreesMock
+}))
+
+vi.mock('./providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn()
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: vi.fn()
+}))
+
+import { analyzeWorkspaceSpace } from './workspace-space-analysis'
+
+function createStore(repos: Repo[]): Store {
+  return {
+    getRepos: () => repos,
+    getWorktreeMeta: () => undefined
+  } as unknown as Store
+}
+
+function createDirStat(size = 16) {
+  return {
+    size,
+    isSymbolicLink: () => false,
+    isDirectory: () => true
+  }
+}
+
+function createFileStat(size: number) {
+  return {
+    size,
+    isSymbolicLink: () => false,
+    isDirectory: () => false
+  }
+}
+
+describe('analyzeWorkspaceSpace fallback concurrency', () => {
+  beforeEach(() => {
+    lstatMock.mockReset()
+    opendirMock.mockReset()
+    spawnMock.mockReset()
+    listRepoWorktreesMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('scans portable fallback entries concurrently without retaining a child tree', async () => {
+    const repoPath = '/repo'
+    const repo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: repoPath,
+        head: 'a',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    spawnMock.mockImplementation(() => {
+      throw Object.assign(new Error('du not found'), { code: 'ENOENT' })
+    })
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield { name: 'a.txt' }
+        yield { name: 'b.txt' }
+      }
+    })
+
+    let started = 0
+    let active = 0
+    let maxActive = 0
+    let released = false
+    const releases: (() => void)[] = []
+    const releaseAll = (): void => {
+      released = true
+      while (releases.length > 0) {
+        releases.shift()?.()
+      }
+    }
+    lstatMock.mockImplementation((targetPath: string) => {
+      if (targetPath === repoPath) {
+        return Promise.resolve(createDirStat())
+      }
+      started += 1
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      const finish = (): ReturnType<typeof createFileStat> => {
+        active -= 1
+        return createFileStat(targetPath.endsWith('a.txt') ? 128 : 256)
+      }
+      if (released) {
+        return Promise.resolve(finish())
+      }
+      return new Promise((resolve) => {
+        releases.push(() => resolve(finish()))
+      })
+    })
+
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo]))
+    try {
+      await vi.waitFor(() => expect(started).toBeGreaterThanOrEqual(2), { timeout: 200 })
+    } finally {
+      releaseAll()
+    }
+
+    await expect(scanPromise).resolves.toMatchObject({
+      worktrees: [
+        expect.objectContaining({
+          status: 'ok',
+          topLevelItems: expect.arrayContaining([
+            expect.objectContaining({ name: 'a.txt', sizeBytes: 128 }),
+            expect.objectContaining({ name: 'b.txt', sizeBytes: 256 })
+          ])
+        })
+      ]
+    })
+    expect(maxActive).toBeGreaterThan(1)
+  })
+})

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -1,10 +1,12 @@
 /* eslint-disable max-lines -- Why: this module keeps local and SSH directory-walk
    semantics paired so reclaimable-byte, symlink, and partial-failure behavior cannot drift. */
 import { lstat, opendir } from 'node:fs/promises'
-import { execFile } from 'node:child_process'
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
 import { posix, win32 } from 'node:path'
 import { platform } from 'node:process'
 import type { Dirent } from 'node:fs'
+import type { Readable } from 'node:stream'
+import { StringDecoder } from 'node:string_decoder'
 import type { Store } from './persistence'
 import { isFolderRepo } from '../shared/repo-kind'
 import type { DirEntry, GitWorktreeInfo, Repo, Worktree } from '../shared/types'
@@ -44,8 +46,7 @@ const LOCAL_WORKTREE_SCAN_CONCURRENCY = 1
 const REMOTE_FALLBACK_SCAN_CONCURRENCY = 2
 const LOCAL_FS_CONCURRENCY = 48
 const REMOTE_FS_CONCURRENCY = 10
-const DU_TIMEOUT_MS = 120_000
-const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
+const DU_STDERR_MAX_CHARS = 64 * 1024
 
 type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
 
@@ -174,54 +175,66 @@ function normalizeLocalDuPath(pathValue: string): string {
   return trimmed.length > 0 ? trimmed : pathValue
 }
 
-function parseDuDepthOneOutput(stdout: string): Map<string, number> {
-  const sizes = new Map<string, number>()
-  for (const line of stdout.split('\n')) {
-    const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
-    if (!normalizedLine) {
-      continue
-    }
-    const match = /^(\d+)\s+(.+)$/.exec(normalizedLine)
-    if (!match) {
-      continue
-    }
-    sizes.set(normalizeLocalDuPath(match[2]), Number(match[1]) * 1024)
+function parseDuDepthOneLine(line: string): [string, number] | null {
+  const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
+  if (!normalizedLine) {
+    return null
   }
-  return sizes
+  const match = /^(\d+)\s+(.+)$/.exec(normalizedLine)
+  if (!match) {
+    return null
+  }
+  return [normalizeLocalDuPath(match[2]), Number(match[1]) * 1024]
+}
+
+function consumeDuOutputChunk(
+  sizes: Map<string, number>,
+  bufferedLine: string,
+  chunkText: string
+): string {
+  const lines = `${bufferedLine}${chunkText}`.split('\n')
+  const nextBufferedLine = lines.pop() ?? ''
+  for (const line of lines) {
+    const parsed = parseDuDepthOneLine(line)
+    if (parsed) {
+      sizes.set(parsed[0], parsed[1])
+    }
+  }
+  return nextBufferedLine
 }
 
 async function readLocalDuDepthOne(
   rootPath: string,
   signal?: AbortSignal
 ): Promise<Map<string, number>> {
-  const stdout = await new Promise<string>((resolve, reject) => {
+  return new Promise<Map<string, number>>((resolve, reject) => {
     let settled = false
-    let child: ReturnType<typeof execFile> | undefined
+    let child: ChildProcessByStdio<null, Readable, Readable> | undefined
     let onAbort: (() => void) | null = null
-    let timer: ReturnType<typeof setTimeout> | null = null
+    let bufferedLine = ''
+    let stderr = ''
+    const stdoutDecoder = new StringDecoder('utf8')
+    const stderrDecoder = new StringDecoder('utf8')
+    const sizes = new Map<string, number>()
+    const appendStderr = (chunkText: string): void => {
+      if (stderr.length < DU_STDERR_MAX_CHARS) {
+        stderr = `${stderr}${chunkText}`.slice(0, DU_STDERR_MAX_CHARS)
+      }
+    }
     const settle = (callback: () => void): void => {
       if (settled) {
         return
       }
       settled = true
-      if (timer) {
-        clearTimeout(timer)
-      }
       if (onAbort) {
         signal?.removeEventListener('abort', onAbort)
       }
       callback()
     }
-    timer = setTimeout(() => {
-      settle(() => {
-        child?.kill()
-        reject(new Error(`du timed out after ${DU_TIMEOUT_MS}ms`))
-      })
-    }, DU_TIMEOUT_MS)
     onAbort = () => {
       settle(() => {
         child?.kill()
-        reject(new Error('Workspace space scan cancelled'))
+        reject(new WorkspaceSpaceScanCancelledError())
       })
     }
     signal?.addEventListener('abort', onAbort, { once: true })
@@ -230,31 +243,42 @@ async function readLocalDuDepthOne(
       return
     }
 
-    // Why: execFile's timeout only signals `du`; a wedged child that never
-    // calls back must not block the Space scan or its portable fallback.
     try {
-      child = execFile(
-        'du',
-        ['-k', '-d', '1', rootPath],
-        {
-          encoding: 'utf8',
-          maxBuffer: DU_MAX_BUFFER_BYTES,
-          signal,
-          timeout: DU_TIMEOUT_MS
-        },
-        (error, stdout) => {
-          if (error) {
-            settle(() => reject(error))
-            return
-          }
-          settle(() => resolve(String(stdout)))
-        }
-      )
+      // Why: large worktrees can produce more top-level du rows than
+      // execFile's fixed buffer allows; stream rows so accuracy has no cap.
+      child = spawn('du', ['-k', '-d', '1', rootPath], { stdio: ['ignore', 'pipe', 'pipe'] })
     } catch (error) {
       settle(() => reject(error))
+      return
     }
+    child.stdout.on('data', (chunk) => {
+      bufferedLine = consumeDuOutputChunk(sizes, bufferedLine, stdoutDecoder.write(chunk))
+    })
+    child.stderr.on('data', (chunk) => {
+      appendStderr(stderrDecoder.write(chunk))
+    })
+    child.once('error', (error) => {
+      settle(() => reject(error))
+    })
+    child.once('close', (code) => {
+      settle(() => {
+        const decodedTail = stdoutDecoder.end()
+        if (decodedTail) {
+          bufferedLine = consumeDuOutputChunk(sizes, bufferedLine, decodedTail)
+        }
+        appendStderr(stderrDecoder.end())
+        const parsed = parseDuDepthOneLine(bufferedLine)
+        if (parsed) {
+          sizes.set(parsed[0], parsed[1])
+        }
+        if (code === 0) {
+          resolve(sizes)
+          return
+        }
+        reject(new Error(stderr.trim() || `du exited with code ${code ?? 'null'}`))
+      })
+    })
   })
-  return parseDuDepthOneOutput(stdout)
 }
 
 function classifyError(error: unknown): {

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -28,6 +28,8 @@ import {
 import {
   collectWorkspaceSpaceDirectoryEntries,
   createWorkspaceSpaceScanBudget,
+  retainWorkspaceSpaceScanEntry,
+  type WorkspaceSpaceScanBudget,
   WorkspaceSpaceScanCapacityError
 } from '../shared/workspace-space-scan-budget'
 import type { IFilesystemProvider } from './providers/types'
@@ -46,6 +48,7 @@ const LOCAL_WORKTREE_SCAN_CONCURRENCY = 1
 const REMOTE_FALLBACK_SCAN_CONCURRENCY = 2
 const LOCAL_FS_CONCURRENCY = 48
 const REMOTE_FS_CONCURRENCY = 10
+const DU_TIMEOUT_MS = 120_000
 const DU_STDERR_MAX_CHARS = 64 * 1024
 
 type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
@@ -78,6 +81,13 @@ export class WorkspaceSpaceScanCancelledError extends Error {
   constructor() {
     super('Workspace space scan cancelled')
     this.name = 'WorkspaceSpaceScanCancelledError'
+  }
+}
+
+class WorkspaceSpaceDuTimeoutError extends Error {
+  constructor() {
+    super(`du timed out after ${DU_TIMEOUT_MS}ms`)
+    this.name = 'WorkspaceSpaceDuTimeoutError'
   }
 }
 
@@ -189,6 +199,7 @@ function parseDuDepthOneLine(line: string): [string, number] | null {
 
 function consumeDuOutputChunk(
   sizes: Map<string, number>,
+  budget: WorkspaceSpaceScanBudget,
   bufferedLine: string,
   chunkText: string
 ): string {
@@ -197,6 +208,9 @@ function consumeDuOutputChunk(
   for (const line of lines) {
     const parsed = parseDuDepthOneLine(line)
     if (parsed) {
+      if (!sizes.has(parsed[0])) {
+        retainWorkspaceSpaceScanEntry(budget, parsed[0], sizes.size)
+      }
       sizes.set(parsed[0], parsed[1])
     }
   }
@@ -211,11 +225,13 @@ async function readLocalDuDepthOne(
     let settled = false
     let child: ChildProcessByStdio<null, Readable, Readable> | undefined
     let onAbort: (() => void) | null = null
+    let timer: ReturnType<typeof setTimeout> | null = null
     let bufferedLine = ''
     let stderr = ''
     const stdoutDecoder = new StringDecoder('utf8')
     const stderrDecoder = new StringDecoder('utf8')
     const sizes = new Map<string, number>()
+    const budget = createWorkspaceSpaceScanBudget()
     const appendStderr = (chunkText: string): void => {
       if (stderr.length < DU_STDERR_MAX_CHARS) {
         stderr = `${stderr}${chunkText}`.slice(0, DU_STDERR_MAX_CHARS)
@@ -226,6 +242,9 @@ async function readLocalDuDepthOne(
         return
       }
       settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
       if (onAbort) {
         signal?.removeEventListener('abort', onAbort)
       }
@@ -244,15 +263,30 @@ async function readLocalDuDepthOne(
     }
 
     try {
-      // Why: large worktrees can produce more top-level du rows than
-      // execFile's fixed buffer allows; stream rows so accuracy has no cap.
+      // Why: stream beyond execFile's fixed buffer while bounding retained rows.
       child = spawn('du', ['-k', '-d', '1', rootPath], { stdio: ['ignore', 'pipe', 'pipe'] })
     } catch (error) {
       settle(() => reject(error))
       return
     }
+    timer = setTimeout(() => {
+      settle(() => {
+        child?.kill()
+        reject(new WorkspaceSpaceDuTimeoutError())
+      })
+    }, DU_TIMEOUT_MS)
     child.stdout.on('data', (chunk) => {
-      bufferedLine = consumeDuOutputChunk(sizes, bufferedLine, stdoutDecoder.write(chunk))
+      if (settled) {
+        return
+      }
+      try {
+        bufferedLine = consumeDuOutputChunk(sizes, budget, bufferedLine, stdoutDecoder.write(chunk))
+      } catch (error) {
+        settle(() => {
+          child?.kill()
+          reject(error)
+        })
+      }
     })
     child.stderr.on('data', (chunk) => {
       appendStderr(stderrDecoder.write(chunk))
@@ -261,16 +295,27 @@ async function readLocalDuDepthOne(
       settle(() => reject(error))
     })
     child.once('close', (code) => {
-      settle(() => {
+      if (settled) {
+        return
+      }
+      try {
         const decodedTail = stdoutDecoder.end()
         if (decodedTail) {
-          bufferedLine = consumeDuOutputChunk(sizes, bufferedLine, decodedTail)
+          bufferedLine = consumeDuOutputChunk(sizes, budget, bufferedLine, decodedTail)
         }
         appendStderr(stderrDecoder.end())
         const parsed = parseDuDepthOneLine(bufferedLine)
         if (parsed) {
+          if (!sizes.has(parsed[0])) {
+            retainWorkspaceSpaceScanEntry(budget, parsed[0], sizes.size)
+          }
           sizes.set(parsed[0], parsed[1])
         }
+      } catch (error) {
+        settle(() => reject(error))
+        return
+      }
+      settle(() => {
         if (code === 0) {
           resolve(sizes)
           return
@@ -294,6 +339,9 @@ function classifyError(error: unknown): {
   // Why: a workspace over the scan budget is intact and readable, just too big
   // to size safely, so it reads as unavailable rather than a filesystem error.
   if (error instanceof WorkspaceSpaceScanCapacityError) {
+    return { status: 'unavailable', message }
+  }
+  if (error instanceof WorkspaceSpaceDuTimeoutError) {
     return { status: 'unavailable', message }
   }
   if (code === 'ENOENT' || code === 'ENOTDIR') {
@@ -509,19 +557,16 @@ async function scanLocalWorktreeWithDu(
     }
   }
 
-  const [entries, duSizes] = await Promise.all([
-    opendir(worktree.path).then(async (directory) => {
-      const admission = await collectWorkspaceSpaceDirectoryEntries(
-        directory,
-        worktree.path,
-        (entry) => entry.name,
-        createWorkspaceSpaceScanBudget(),
-        () => throwIfAborted(signal)
-      )
-      return admission.entries
-    }),
-    readLocalDuDepthOne(worktree.path, signal)
-  ])
+  const directory = await opendir(worktree.path)
+  const admission = await collectWorkspaceSpaceDirectoryEntries(
+    directory,
+    worktree.path,
+    (entry) => entry.name,
+    createWorkspaceSpaceScanBudget(),
+    () => throwIfAborted(signal)
+  )
+  const entries = admission.entries
+  const duSizes = await readLocalDuDepthOne(worktree.path, signal)
   throwIfAborted(signal)
   const childStats = await mapWithConcurrency(
     entries,
@@ -610,7 +655,10 @@ async function scanLocalWorktree(
       if (error instanceof WorkspaceSpaceScanCancelledError) {
         throw error
       }
-      if (error instanceof WorkspaceSpaceScanCapacityError) {
+      if (
+        error instanceof WorkspaceSpaceScanCapacityError ||
+        error instanceof WorkspaceSpaceDuTimeoutError
+      ) {
         const classified = classifyError(error)
         return createUnavailableWorktreeRow(
           repo,

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -1,4 +1,3 @@
-import { execFile } from 'node:child_process'
 import { platform } from 'node:process'
 import type { Store } from './persistence'
 import type {
@@ -7,6 +6,10 @@ import type {
 } from '../shared/workspace-space-types'
 import { mapWithConcurrency } from '../shared/map-with-concurrency'
 import { escapeRegex } from '../shared/string-utils'
+import {
+  readWorkspaceSpaceDuDepthOne,
+  WorkspaceSpaceDuTimeoutError
+} from '../shared/workspace-space-du-stream'
 import {
   WorkspaceSpaceScanCancelledError,
   createWorkspaceSpaceScanLimiter,
@@ -22,10 +25,8 @@ import {
 const REPO_SCAN_CONCURRENCY = 2
 const LOCAL_WORKTREE_SCAN_CONCURRENCY = 1
 const REMOTE_FALLBACK_SCAN_CONCURRENCY = 2
-const DU_TIMEOUT_MS = 120_000
-const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
-export { WorkspaceSpaceScanCancelledError }
+export { WorkspaceSpaceScanCancelledError, WorkspaceSpaceDuTimeoutError }
 
 function normalizeLocalDuPath(pathValue: string): string {
   const separator = platform === 'win32' ? '\\' : '/'
@@ -33,79 +34,15 @@ function normalizeLocalDuPath(pathValue: string): string {
   return trimmed.length > 0 ? trimmed : pathValue
 }
 
-function parseWorkspaceSpaceDuOutput(stdout: string): Map<string, number> {
-  const sizes = new Map<string, number>()
-  for (const line of stdout.split('\n')) {
-    const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
-    if (!normalizedLine) {
-      continue
-    }
-    const match = /^(\d+)\s+(.+)$/.exec(normalizedLine)
-    if (!match) {
-      continue
-    }
-    sizes.set(normalizeLocalDuPath(match[2]), Number(match[1]) * 1024)
-  }
-  return sizes
-}
-
 async function readLocalDuDepthOne(
   rootPath: string,
   signal?: AbortSignal
 ): Promise<Map<string, number>> {
-  const stdout = await new Promise<string>((resolve, reject) => {
-    let settled = false
-    let child: ReturnType<typeof execFile> | undefined
-    let onAbort: (() => void) | null = null
-    let timer: ReturnType<typeof setTimeout> | null = null
-    const settle = (callback: () => void): void => {
-      if (settled) {
-        return
-      }
-      settled = true
-      if (timer) {
-        clearTimeout(timer)
-      }
-      if (onAbort) {
-        signal?.removeEventListener('abort', onAbort)
-      }
-      callback()
-    }
-    timer = setTimeout(() => {
-      settle(() => {
-        child?.kill()
-        reject(new Error(`du timed out after ${DU_TIMEOUT_MS}ms`))
-      })
-    }, DU_TIMEOUT_MS)
-    onAbort = () => {
-      settle(() => {
-        child?.kill()
-        reject(new Error('Workspace space scan cancelled'))
-      })
-    }
-    signal?.addEventListener('abort', onAbort, { once: true })
-    if (signal?.aborted) {
-      onAbort()
-      return
-    }
-    try {
-      child = execFile(
-        'du',
-        ['-k', '-d', '1', rootPath],
-        { encoding: 'utf8', maxBuffer: DU_MAX_BUFFER_BYTES, signal, timeout: DU_TIMEOUT_MS },
-        (error, output) => {
-          if (error) {
-            settle(() => reject(error))
-            return
-          }
-          settle(() => resolve(String(output)))
-        }
-      )
-    } catch (error) {
-      settle(() => reject(error))
-    }
+  return readWorkspaceSpaceDuDepthOne(rootPath, {
+    signal,
+    normalizePath: normalizeLocalDuPath,
+    createCancelledError: () => new WorkspaceSpaceScanCancelledError()
   })
-  return parseWorkspaceSpaceDuOutput(stdout)
 }
 
 export async function analyzeWorkspaceSpace(

--- a/src/main/workspace-space-local-scan.ts
+++ b/src/main/workspace-space-local-scan.ts
@@ -10,6 +10,7 @@ import {
   scanWorkspaceSpaceEntryTree,
   type WorkspaceSpaceEntryScan
 } from '../shared/workspace-space-entry-traversal'
+import { WorkspaceSpaceDuTimeoutError } from '../shared/workspace-space-du-stream'
 import {
   collectWorkspaceSpaceDirectoryEntries,
   createWorkspaceSpaceScanBudget,
@@ -112,19 +113,16 @@ async function scanLocalWorktreeWithDu(
       ...compact
     })
   }
-  const [entries, duSizes] = await Promise.all([
-    opendir(worktree.path).then(async (directory) => {
-      const admission = await collectWorkspaceSpaceDirectoryEntries(
-        directory,
-        worktree.path,
-        (entry) => entry.name,
-        createWorkspaceSpaceScanBudget(),
-        () => throwIfWorkspaceSpaceScanAborted(signal)
-      )
-      return admission.entries
-    }),
-    readDu(worktree.path, signal)
-  ])
+  const directory = await opendir(worktree.path)
+  const admission = await collectWorkspaceSpaceDirectoryEntries(
+    directory,
+    worktree.path,
+    (entry) => entry.name,
+    createWorkspaceSpaceScanBudget(),
+    () => throwIfWorkspaceSpaceScanAborted(signal)
+  )
+  const entries = admission.entries
+  const duSizes = await readDu(worktree.path, signal)
   throwIfWorkspaceSpaceScanAborted(signal)
   const childStats = await mapWithConcurrency(entries, LOCAL_FS_CONCURRENCY, async (entry) => {
     try {
@@ -209,7 +207,10 @@ export async function scanLocalWorkspaceSpaceWorktree(
       if (error instanceof WorkspaceSpaceScanCancelledError) {
         throw error
       }
-      if (error instanceof WorkspaceSpaceScanCapacityError) {
+      if (
+        error instanceof WorkspaceSpaceScanCapacityError ||
+        error instanceof WorkspaceSpaceDuTimeoutError
+      ) {
         const classified = classifyWorkspaceSpaceError(error)
         return createUnavailableWorkspaceSpaceRow(
           repo,

--- a/src/main/workspace-space-scan-control.test.ts
+++ b/src/main/workspace-space-scan-control.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { WorkspaceSpaceDuTimeoutError } from '../shared/workspace-space-du-stream'
 import { WorkspaceSpaceScanCapacityError } from '../shared/workspace-space-scan-budget'
 import {
   WorkspaceSpaceScanCancelledError,
@@ -19,6 +20,14 @@ describe('workspace space scan boundaries', () => {
 
   it('keeps capacity exhaustion distinct from filesystem errors', () => {
     const error = new WorkspaceSpaceScanCapacityError({ maxEntries: 1, maxRetainedBytes: 1 })
+    expect(classifyWorkspaceSpaceError(error)).toEqual({
+      status: 'unavailable',
+      message: error.message
+    })
+  })
+
+  it('classifies a streamed du deadline as unavailable', () => {
+    const error = new WorkspaceSpaceDuTimeoutError()
     expect(classifyWorkspaceSpaceError(error)).toEqual({
       status: 'unavailable',
       message: error.message

--- a/src/main/workspace-space-scan-control.ts
+++ b/src/main/workspace-space-scan-control.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceSpaceScanStatus } from '../shared/workspace-space-types'
+import { WorkspaceSpaceDuTimeoutError } from '../shared/workspace-space-du-stream'
 import { WorkspaceSpaceScanCapacityError } from '../shared/workspace-space-scan-budget'
 
 export type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
@@ -37,7 +38,10 @@ export function classifyWorkspaceSpaceError(error: unknown): {
       ? String((error as { code?: unknown }).code)
       : ''
   const message = error instanceof Error ? error.message : String(error)
-  if (error instanceof WorkspaceSpaceScanCapacityError) {
+  if (
+    error instanceof WorkspaceSpaceScanCapacityError ||
+    error instanceof WorkspaceSpaceDuTimeoutError
+  ) {
     return { status: 'unavailable', message }
   }
   if (code === 'ENOENT' || code === 'ENOTDIR') {

--- a/src/relay/workspace-space-scan-du-capacity.test.ts
+++ b/src/relay/workspace-space-scan-du-capacity.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events'
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -6,12 +7,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type * as WorkspaceSpaceScanBudgetModule from '../shared/workspace-space-scan-budget'
 import type { RequestContext } from './dispatcher'
 
-const { execFileMock, budgetState } = vi.hoisted(() => ({
-  execFileMock: vi.fn(),
-  budgetState: { created: 0 }
+const { budgetState, spawnMock } = vi.hoisted(() => ({
+  budgetState: {
+    created: 0,
+    duMaxEntries: null as number | null,
+    listingMaxEntries: null as number | null
+  },
+  spawnMock: vi.fn()
 }))
 
-vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 
 vi.mock('node:process', async () => {
   const actual = await vi.importActual<typeof NodeProcess>('node:process')
@@ -29,7 +34,11 @@ vi.mock('../shared/workspace-space-scan-budget', async () => {
     createWorkspaceSpaceScanBudget: () => {
       budgetState.created += 1
       return actual.createWorkspaceSpaceScanBudget(
-        budgetState.created === 1 ? { maxEntries: 2 } : undefined
+        budgetState.created === 1 && budgetState.listingMaxEntries
+          ? { maxEntries: budgetState.listingMaxEntries }
+          : budgetState.created === 2 && budgetState.duMaxEntries
+            ? { maxEntries: budgetState.duMaxEntries }
+            : undefined
       )
     }
   }
@@ -43,11 +52,26 @@ const context: RequestContext = {
   isStale: () => false
 }
 
+function createSpawnedDu() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  return child
+}
+
 describe('relay workspace space scan du path', () => {
   let tempDir: string | null = null
 
   afterEach(async () => {
-    execFileMock.mockReset()
+    budgetState.created = 0
+    budgetState.duMaxEntries = null
+    budgetState.listingMaxEntries = null
+    spawnMock.mockReset()
     if (tempDir) {
       await rm(tempDir, { recursive: true, force: true })
       tempDir = null
@@ -59,26 +83,33 @@ describe('relay workspace space scan du path', () => {
     const rootPath = join(tempDir, 'repo')
     await mkdir(rootPath, { recursive: true })
     await Promise.all(['one', 'two', 'three'].map((name) => writeFile(join(rootPath, name), name)))
-    execFileMock.mockImplementation(
-      (
-        _file: string,
-        args: string[],
-        _options: unknown,
-        callback: (error: Error | null, output: { stdout: string; stderr: string }) => void
-      ) => {
-        callback(null, { stdout: `1\t${args.at(-1)}\n`, stderr: '' })
-        return { kill: vi.fn() }
-      }
-    )
+    budgetState.listingMaxEntries = 2
+    spawnMock.mockReturnValue(createSpawnedDu())
 
     await expect(scanWorkspaceSpaceDirectory(rootPath, context)).rejects.toBeInstanceOf(
       WorkspaceSpaceScanCapacityError
     )
-    expect(execFileMock).toHaveBeenCalledWith(
-      'du',
-      ['-k', '-d', '1', rootPath],
-      expect.any(Object),
-      expect.any(Function)
-    )
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('kills du and fails closed when streamed rows exceed the retained budget', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-relay-du-capacity-'))
+    const rootPath = join(tempDir, 'repo')
+    await mkdir(rootPath, { recursive: true })
+    await writeFile(join(rootPath, 'one'), 'one')
+    budgetState.duMaxEntries = 2
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    const scanPromise = scanWorkspaceSpaceDirectory(rootPath, context)
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    const rejection = expect(scanPromise).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
+    child.stdout.emit('data', Buffer.from(`1\t${join(rootPath, 'one')}\n`))
+    child.stdout.emit('data', Buffer.from(`1\t${join(rootPath, 'two')}\n`))
+    child.stdout.emit('data', Buffer.from(`1\t${join(rootPath, 'three')}\n`))
+    child.emit('close', 0)
+
+    await rejection
+    expect(child.kill).toHaveBeenCalled()
   })
 })

--- a/src/relay/workspace-space-scan-du-capacity.test.ts
+++ b/src/relay/workspace-space-scan-du-capacity.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events'
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -6,12 +7,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type * as WorkspaceSpaceScanBudgetModule from '../shared/workspace-space-scan-budget'
 import type { RequestContext } from './dispatcher'
 
-const { execFileMock, budgetState } = vi.hoisted(() => ({
-  execFileMock: vi.fn(),
-  budgetState: { created: 0 }
+const { budgetState, spawnMock } = vi.hoisted(() => ({
+  budgetState: {
+    created: 0,
+    duMaxEntries: null as number | null,
+    listingMaxEntries: null as number | null
+  },
+  spawnMock: vi.fn()
 }))
 
-vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 
 vi.mock('node:process', async () => {
   const actual = await vi.importActual<typeof NodeProcess>('node:process')
@@ -24,12 +29,14 @@ vi.mock('../shared/workspace-space-scan-budget', async () => {
   )
   return {
     ...actual,
-    // Why: only the du path's top-level listing is capped, so a swallowed
-    // capacity error would let the portable retry succeed and fail this test.
     createWorkspaceSpaceScanBudget: () => {
       budgetState.created += 1
       return actual.createWorkspaceSpaceScanBudget(
-        budgetState.created === 1 ? { maxEntries: 2 } : undefined
+        budgetState.created === 1 && budgetState.listingMaxEntries
+          ? { maxEntries: budgetState.listingMaxEntries }
+          : budgetState.created === 2 && budgetState.duMaxEntries
+            ? { maxEntries: budgetState.duMaxEntries }
+            : undefined
       )
     }
   }
@@ -43,11 +50,26 @@ const context: RequestContext = {
   isStale: () => false
 }
 
+function createSpawnedDu() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  return child
+}
+
 describe('relay workspace space scan du path', () => {
   let tempDir: string | null = null
 
   afterEach(async () => {
-    execFileMock.mockReset()
+    budgetState.created = 0
+    budgetState.duMaxEntries = null
+    budgetState.listingMaxEntries = null
+    spawnMock.mockReset()
     if (tempDir) {
       await rm(tempDir, { recursive: true, force: true })
       tempDir = null
@@ -59,26 +81,33 @@ describe('relay workspace space scan du path', () => {
     const rootPath = join(tempDir, 'repo')
     await mkdir(rootPath, { recursive: true })
     await Promise.all(['one', 'two', 'three'].map((name) => writeFile(join(rootPath, name), name)))
-    execFileMock.mockImplementation(
-      (
-        _file: string,
-        args: string[],
-        _options: unknown,
-        callback: (error: Error | null, output: { stdout: string; stderr: string }) => void
-      ) => {
-        callback(null, { stdout: `1\t${args.at(-1)}\n`, stderr: '' })
-        return { kill: vi.fn() }
-      }
-    )
+    budgetState.listingMaxEntries = 2
+    spawnMock.mockReturnValue(createSpawnedDu())
 
     await expect(scanWorkspaceSpaceDirectory(rootPath, context)).rejects.toBeInstanceOf(
       WorkspaceSpaceScanCapacityError
     )
-    expect(execFileMock).toHaveBeenCalledWith(
-      'du',
-      ['-k', '-d', '1', rootPath],
-      expect.any(Object),
-      expect.any(Function)
-    )
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('kills du and fails closed when streamed rows exceed the retained budget', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-relay-du-capacity-'))
+    const rootPath = join(tempDir, 'repo')
+    await mkdir(rootPath, { recursive: true })
+    await writeFile(join(rootPath, 'one'), 'one')
+    budgetState.duMaxEntries = 2
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    const scanPromise = scanWorkspaceSpaceDirectory(rootPath, context)
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    const rejection = expect(scanPromise).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
+    child.stdout.emit('data', Buffer.from(`1\t${join(rootPath, 'one')}\n`))
+    child.stdout.emit('data', Buffer.from(`1\t${join(rootPath, 'two')}\n`))
+    child.stdout.emit('data', Buffer.from(`1\t${join(rootPath, 'three')}\n`))
+    child.emit('close', 0)
+
+    await rejection
+    expect(child.kill).toHaveBeenCalled()
   })
 })

--- a/src/relay/workspace-space-scan-du.test.ts
+++ b/src/relay/workspace-space-scan-du.test.ts
@@ -1,0 +1,164 @@
+import { EventEmitter } from 'node:events'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestContext } from './dispatcher'
+
+const { execFileMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  spawn: spawnMock
+}))
+
+import { scanWorkspaceSpaceDirectory } from './workspace-space-scan'
+
+function createContext(signal?: AbortSignal): RequestContext {
+  return {
+    clientId: 1,
+    isStale: () => false,
+    signal
+  }
+}
+
+function createSpawnedDu() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  return child
+}
+
+describe('relay workspace space scan du handling', () => {
+  let tempDir: string | null = null
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-relay-space-du-'))
+    execFileMock.mockReset()
+    spawnMock.mockReset()
+    execFileMock.mockImplementation((_cmd, _args, _options, callback) => {
+      callback(new Error('execFile should not be used for workspace Space scans'))
+    })
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'streams native du output instead of using execFile buffering',
+    async () => {
+      await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
+      const child = createSpawnedDu()
+      spawnMock.mockReturnValue(child)
+
+      const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext())
+
+      await vi.waitFor(() =>
+        expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+      )
+      child.stdout.emit('data', Buffer.from(`4\t${join(tempDir!, 'app.ts')}\n`))
+      child.stdout.emit('data', Buffer.from(`12\t${tempDir!}\n`))
+      child.emit('close', 0)
+
+      await expect(scanPromise).resolves.toMatchObject({
+        sizeBytes: 12 * 1024,
+        skippedEntryCount: 0,
+        topLevelItems: [expect.objectContaining({ name: 'app.ts' })]
+      })
+      expect(execFileMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves multibyte du paths split across stdout chunks',
+    async () => {
+      const dirname = '数据'
+      await mkdir(join(tempDir!, dirname), { recursive: true })
+      await writeFile(join(tempDir!, dirname, 'pkg.js'), Buffer.alloc(128))
+      const child = createSpawnedDu()
+      spawnMock.mockReturnValue(child)
+
+      const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext())
+
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+      const dirnameBytes = Buffer.from(dirname)
+      const duLine = Buffer.from(`24\t${join(tempDir!, dirname)}\n`)
+      const splitAt = duLine.indexOf(dirnameBytes) + 1
+      child.stdout.emit('data', duLine.subarray(0, splitAt))
+      child.stdout.emit('data', duLine.subarray(splitAt))
+      child.stdout.emit('data', Buffer.from(`32\t${tempDir!}\n`))
+      child.emit('close', 0)
+
+      await expect(scanPromise).resolves.toMatchObject({
+        sizeBytes: 32 * 1024,
+        topLevelItems: [
+          expect.objectContaining({
+            name: dirname,
+            sizeBytes: 24 * 1024
+          })
+        ]
+      })
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'bounds native du with a deadline while preserving cancellation',
+    async () => {
+      await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
+      const controller = new AbortController()
+      const child = createSpawnedDu()
+      spawnMock.mockReturnValue(child)
+
+      vi.useFakeTimers()
+      const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext(controller.signal))
+
+      await vi.waitFor(() =>
+        expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+      )
+      const rejection = expect(scanPromise).rejects.toMatchObject({
+        name: 'RelayWorkspaceSpaceDuTimeoutError',
+        message: 'du timed out after 120000ms'
+      })
+      await vi.advanceTimersByTimeAsync(120_000)
+
+      controller.abort()
+      await rejection
+      expect(child.kill).toHaveBeenCalled()
+    }
+  )
+
+  it('falls back accurately when native du is unavailable', async () => {
+    await mkdir(join(tempDir!, 'node_modules'), { recursive: true })
+    await writeFile(join(tempDir!, 'node_modules', 'pkg.js'), Buffer.alloc(512))
+    await writeFile(join(tempDir!, 'app.ts'), Buffer.alloc(128))
+    spawnMock.mockImplementation(() => {
+      throw Object.assign(new Error('du not found'), { code: 'ENOENT' })
+    })
+
+    await expect(scanWorkspaceSpaceDirectory(tempDir!, createContext())).resolves.toMatchObject({
+      skippedEntryCount: 0,
+      topLevelItems: expect.arrayContaining([
+        expect.objectContaining({ name: 'node_modules', sizeBytes: expect.any(Number) }),
+        expect.objectContaining({ name: 'app.ts', sizeBytes: 128 })
+      ])
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/relay/workspace-space-scan-du.test.ts
+++ b/src/relay/workspace-space-scan-du.test.ts
@@ -117,7 +117,7 @@ describe('relay workspace space scan du handling', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
-    'keeps native du running past the old timeout and kills it on cancellation',
+    'bounds native du with a deadline while preserving cancellation',
     async () => {
       await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
       const controller = new AbortController()
@@ -125,29 +125,21 @@ describe('relay workspace space scan du handling', () => {
       spawnMock.mockReturnValue(child)
 
       vi.useFakeTimers()
-      let settled = false
       const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext(controller.signal))
-        .then((scan) => {
-          settled = true
-          return scan
-        })
-        .catch((error: unknown) => {
-          settled = true
-          throw error
-        })
 
       await vi.waitFor(() =>
         expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
           stdio: ['ignore', 'pipe', 'pipe']
         })
       )
+      const rejection = expect(scanPromise).rejects.toMatchObject({
+        name: 'RelayWorkspaceSpaceDuTimeoutError',
+        message: 'du timed out after 120000ms'
+      })
       await vi.advanceTimersByTimeAsync(120_000)
 
-      expect(settled).toBe(false)
       controller.abort()
-      await expect(scanPromise).rejects.toMatchObject({
-        name: 'RelayWorkspaceSpaceScanCancelledError'
-      })
+      await rejection
       expect(child.kill).toHaveBeenCalled()
     }
   )

--- a/src/relay/workspace-space-scan-du.test.ts
+++ b/src/relay/workspace-space-scan-du.test.ts
@@ -1,0 +1,163 @@
+import { EventEmitter } from 'node:events'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestContext } from './dispatcher'
+
+const { execFileMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  spawn: spawnMock
+}))
+
+import { scanWorkspaceSpaceDirectory } from './workspace-space-scan'
+
+function createContext(signal?: AbortSignal): RequestContext {
+  return {
+    clientId: 1,
+    isStale: () => false,
+    signal
+  }
+}
+
+function createSpawnedDu() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  return child
+}
+
+describe('relay workspace space scan du handling', () => {
+  let tempDir: string | null = null
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-relay-space-du-'))
+    execFileMock.mockReset()
+    spawnMock.mockReset()
+    execFileMock.mockImplementation((_cmd, _args, _options, callback) => {
+      callback(new Error('execFile should not be used for workspace Space scans'))
+    })
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('streams native du output instead of using execFile buffering', async () => {
+    await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext())
+
+    await vi.waitFor(() =>
+      expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    )
+    child.stdout.emit('data', Buffer.from(`4\t${join(tempDir!, 'app.ts')}\n`))
+    child.stdout.emit('data', Buffer.from(`12\t${tempDir!}\n`))
+    child.emit('close', 0)
+
+    await expect(scanPromise).resolves.toMatchObject({
+      sizeBytes: 12 * 1024,
+      skippedEntryCount: 0,
+      topLevelItems: [expect.objectContaining({ name: 'app.ts' })]
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves multibyte du paths split across stdout chunks', async () => {
+    const dirname = '数据'
+    await mkdir(join(tempDir!, dirname), { recursive: true })
+    await writeFile(join(tempDir!, dirname, 'pkg.js'), Buffer.alloc(128))
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext())
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    const dirnameBytes = Buffer.from(dirname)
+    const duLine = Buffer.from(`24\t${join(tempDir!, dirname)}\n`)
+    const splitAt = duLine.indexOf(dirnameBytes) + 1
+    child.stdout.emit('data', duLine.subarray(0, splitAt))
+    child.stdout.emit('data', duLine.subarray(splitAt))
+    child.stdout.emit('data', Buffer.from(`32\t${tempDir!}\n`))
+    child.emit('close', 0)
+
+    await expect(scanPromise).resolves.toMatchObject({
+      sizeBytes: 32 * 1024,
+      topLevelItems: [
+        expect.objectContaining({
+          name: dirname,
+          sizeBytes: 24 * 1024
+        })
+      ]
+    })
+  })
+
+  it('keeps native du running past the old timeout and kills it on cancellation', async () => {
+    await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
+    const controller = new AbortController()
+    const child = createSpawnedDu()
+    spawnMock.mockReturnValue(child)
+
+    vi.useFakeTimers()
+    let settled = false
+    const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext(controller.signal))
+      .then((scan) => {
+        settled = true
+        return scan
+      })
+      .catch((error: unknown) => {
+        settled = true
+        throw error
+      })
+
+    await vi.waitFor(() =>
+      expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    )
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(settled).toBe(false)
+    controller.abort()
+    await expect(scanPromise).rejects.toMatchObject({
+      name: 'RelayWorkspaceSpaceScanCancelledError'
+    })
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('falls back accurately when native du is unavailable', async () => {
+    await mkdir(join(tempDir!, 'node_modules'), { recursive: true })
+    await writeFile(join(tempDir!, 'node_modules', 'pkg.js'), Buffer.alloc(512))
+    await writeFile(join(tempDir!, 'app.ts'), Buffer.alloc(128))
+    spawnMock.mockImplementation(() => {
+      throw Object.assign(new Error('du not found'), { code: 'ENOENT' })
+    })
+
+    await expect(scanWorkspaceSpaceDirectory(tempDir!, createContext())).resolves.toMatchObject({
+      skippedEntryCount: 0,
+      topLevelItems: expect.arrayContaining([
+        expect.objectContaining({ name: 'node_modules', sizeBytes: expect.any(Number) }),
+        expect.objectContaining({ name: 'app.ts', sizeBytes: 128 })
+      ])
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/relay/workspace-space-scan-du.test.ts
+++ b/src/relay/workspace-space-scan-du.test.ts
@@ -57,91 +57,100 @@ describe('relay workspace space scan du handling', () => {
     }
   })
 
-  it('streams native du output instead of using execFile buffering', async () => {
-    await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
-    const child = createSpawnedDu()
-    spawnMock.mockReturnValue(child)
+  it.skipIf(process.platform === 'win32')(
+    'streams native du output instead of using execFile buffering',
+    async () => {
+      await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
+      const child = createSpawnedDu()
+      spawnMock.mockReturnValue(child)
 
-    const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext())
+      const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext())
 
-    await vi.waitFor(() =>
-      expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
-        stdio: ['ignore', 'pipe', 'pipe']
-      })
-    )
-    child.stdout.emit('data', Buffer.from(`4\t${join(tempDir!, 'app.ts')}\n`))
-    child.stdout.emit('data', Buffer.from(`12\t${tempDir!}\n`))
-    child.emit('close', 0)
-
-    await expect(scanPromise).resolves.toMatchObject({
-      sizeBytes: 12 * 1024,
-      skippedEntryCount: 0,
-      topLevelItems: [expect.objectContaining({ name: 'app.ts' })]
-    })
-    expect(execFileMock).not.toHaveBeenCalled()
-  })
-
-  it('preserves multibyte du paths split across stdout chunks', async () => {
-    const dirname = '数据'
-    await mkdir(join(tempDir!, dirname), { recursive: true })
-    await writeFile(join(tempDir!, dirname, 'pkg.js'), Buffer.alloc(128))
-    const child = createSpawnedDu()
-    spawnMock.mockReturnValue(child)
-
-    const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext())
-
-    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
-    const dirnameBytes = Buffer.from(dirname)
-    const duLine = Buffer.from(`24\t${join(tempDir!, dirname)}\n`)
-    const splitAt = duLine.indexOf(dirnameBytes) + 1
-    child.stdout.emit('data', duLine.subarray(0, splitAt))
-    child.stdout.emit('data', duLine.subarray(splitAt))
-    child.stdout.emit('data', Buffer.from(`32\t${tempDir!}\n`))
-    child.emit('close', 0)
-
-    await expect(scanPromise).resolves.toMatchObject({
-      sizeBytes: 32 * 1024,
-      topLevelItems: [
-        expect.objectContaining({
-          name: dirname,
-          sizeBytes: 24 * 1024
+      await vi.waitFor(() =>
+        expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
+          stdio: ['ignore', 'pipe', 'pipe']
         })
-      ]
-    })
-  })
+      )
+      child.stdout.emit('data', Buffer.from(`4\t${join(tempDir!, 'app.ts')}\n`))
+      child.stdout.emit('data', Buffer.from(`12\t${tempDir!}\n`))
+      child.emit('close', 0)
 
-  it('keeps native du running past the old timeout and kills it on cancellation', async () => {
-    await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
-    const controller = new AbortController()
-    const child = createSpawnedDu()
-    spawnMock.mockReturnValue(child)
-
-    vi.useFakeTimers()
-    let settled = false
-    const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext(controller.signal))
-      .then((scan) => {
-        settled = true
-        return scan
+      await expect(scanPromise).resolves.toMatchObject({
+        sizeBytes: 12 * 1024,
+        skippedEntryCount: 0,
+        topLevelItems: [expect.objectContaining({ name: 'app.ts' })]
       })
-      .catch((error: unknown) => {
-        settled = true
-        throw error
-      })
+      expect(execFileMock).not.toHaveBeenCalled()
+    }
+  )
 
-    await vi.waitFor(() =>
-      expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
-        stdio: ['ignore', 'pipe', 'pipe']
-      })
-    )
-    await vi.advanceTimersByTimeAsync(120_000)
+  it.skipIf(process.platform === 'win32')(
+    'preserves multibyte du paths split across stdout chunks',
+    async () => {
+      const dirname = '数据'
+      await mkdir(join(tempDir!, dirname), { recursive: true })
+      await writeFile(join(tempDir!, dirname, 'pkg.js'), Buffer.alloc(128))
+      const child = createSpawnedDu()
+      spawnMock.mockReturnValue(child)
 
-    expect(settled).toBe(false)
-    controller.abort()
-    await expect(scanPromise).rejects.toMatchObject({
-      name: 'RelayWorkspaceSpaceScanCancelledError'
-    })
-    expect(child.kill).toHaveBeenCalled()
-  })
+      const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext())
+
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+      const dirnameBytes = Buffer.from(dirname)
+      const duLine = Buffer.from(`24\t${join(tempDir!, dirname)}\n`)
+      const splitAt = duLine.indexOf(dirnameBytes) + 1
+      child.stdout.emit('data', duLine.subarray(0, splitAt))
+      child.stdout.emit('data', duLine.subarray(splitAt))
+      child.stdout.emit('data', Buffer.from(`32\t${tempDir!}\n`))
+      child.emit('close', 0)
+
+      await expect(scanPromise).resolves.toMatchObject({
+        sizeBytes: 32 * 1024,
+        topLevelItems: [
+          expect.objectContaining({
+            name: dirname,
+            sizeBytes: 24 * 1024
+          })
+        ]
+      })
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps native du running past the old timeout and kills it on cancellation',
+    async () => {
+      await writeFile(join(tempDir!, 'app.ts'), 'console.log("ok")\n')
+      const controller = new AbortController()
+      const child = createSpawnedDu()
+      spawnMock.mockReturnValue(child)
+
+      vi.useFakeTimers()
+      let settled = false
+      const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, createContext(controller.signal))
+        .then((scan) => {
+          settled = true
+          return scan
+        })
+        .catch((error: unknown) => {
+          settled = true
+          throw error
+        })
+
+      await vi.waitFor(() =>
+        expect(spawnMock).toHaveBeenCalledWith('du', ['-k', '-d', '1', tempDir], {
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+      )
+      await vi.advanceTimersByTimeAsync(120_000)
+
+      expect(settled).toBe(false)
+      controller.abort()
+      await expect(scanPromise).rejects.toMatchObject({
+        name: 'RelayWorkspaceSpaceScanCancelledError'
+      })
+      expect(child.kill).toHaveBeenCalled()
+    }
+  )
 
   it('falls back accurately when native du is unavailable', async () => {
     await mkdir(join(tempDir!, 'node_modules'), { recursive: true })

--- a/src/relay/workspace-space-scan-du.test.ts
+++ b/src/relay/workspace-space-scan-du.test.ts
@@ -144,6 +144,33 @@ describe('relay workspace space scan du handling', () => {
     }
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'kills streaming du when the relay request becomes stale without an abort signal',
+    async () => {
+      const child = createSpawnedDu()
+      spawnMock.mockReturnValue(child)
+      let stale = false
+      const context = { ...createContext(), isStale: () => stale }
+      const scanPromise = scanWorkspaceSpaceDirectory(tempDir!, context)
+      const rejection = expect(scanPromise).rejects.toMatchObject({
+        name: 'RelayWorkspaceSpaceScanCancelledError'
+      })
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+      child.stdout.emit('data', Buffer.from(`4\t${tempDir!}\n`))
+      stale = true
+      child.stdout.emit('data', Buffer.from(`8\t${tempDir!}\n`))
+      try {
+        expect(child.kill).toHaveBeenCalledTimes(1)
+        child.stdout.emit('data', Buffer.from(`12\t${tempDir!}\n`))
+        expect(child.kill).toHaveBeenCalledTimes(1)
+      } finally {
+        child.emit('close', 0)
+        await rejection
+      }
+      expect(execFileMock).not.toHaveBeenCalled()
+    }
+  )
+
   it('falls back accurately when native du is unavailable', async () => {
     await mkdir(join(tempDir!, 'node_modules'), { recursive: true })
     await writeFile(join(tempDir!, 'node_modules', 'pkg.js'), Buffer.alloc(512))

--- a/src/relay/workspace-space-scan-fallback-concurrency.test.ts
+++ b/src/relay/workspace-space-scan-fallback-concurrency.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestContext } from './dispatcher'
+
+const { lstatMock, opendirMock, spawnMock } = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  opendirMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  lstat: lstatMock,
+  opendir: opendirMock
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock
+}))
+
+import { scanWorkspaceSpaceDirectory } from './workspace-space-scan'
+
+function createContext(signal?: AbortSignal): RequestContext {
+  return {
+    clientId: 1,
+    isStale: () => false,
+    signal
+  }
+}
+
+function createDirStat(size = 16) {
+  return {
+    size,
+    isSymbolicLink: () => false,
+    isDirectory: () => true
+  }
+}
+
+function createFileStat(size: number) {
+  return {
+    size,
+    isSymbolicLink: () => false,
+    isDirectory: () => false
+  }
+}
+
+describe('relay workspace space scan fallback concurrency', () => {
+  beforeEach(() => {
+    lstatMock.mockReset()
+    opendirMock.mockReset()
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('scans portable fallback entries concurrently without retaining a child tree', async () => {
+    const rootPath = '/repo'
+    spawnMock.mockImplementation(() => {
+      throw Object.assign(new Error('du not found'), { code: 'ENOENT' })
+    })
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield { name: 'a.txt' }
+        yield { name: 'b.txt' }
+      }
+    })
+
+    let started = 0
+    let active = 0
+    let maxActive = 0
+    let released = false
+    const releases: (() => void)[] = []
+    const releaseAll = (): void => {
+      released = true
+      while (releases.length > 0) {
+        releases.shift()?.()
+      }
+    }
+    lstatMock.mockImplementation((targetPath: string) => {
+      if (targetPath === rootPath) {
+        return Promise.resolve(createDirStat())
+      }
+      started += 1
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      const finish = (): ReturnType<typeof createFileStat> => {
+        active -= 1
+        return createFileStat(targetPath.endsWith('a.txt') ? 128 : 256)
+      }
+      if (released) {
+        return Promise.resolve(finish())
+      }
+      return new Promise((resolve) => {
+        releases.push(() => resolve(finish()))
+      })
+    })
+
+    const scanPromise = scanWorkspaceSpaceDirectory(rootPath, createContext())
+    try {
+      await vi.waitFor(() => expect(started).toBeGreaterThanOrEqual(2), { timeout: 200 })
+    } finally {
+      releaseAll()
+    }
+
+    await expect(scanPromise).resolves.toMatchObject({
+      topLevelItems: expect.arrayContaining([
+        expect.objectContaining({ name: 'a.txt', sizeBytes: 128 }),
+        expect.objectContaining({ name: 'b.txt', sizeBytes: 256 })
+      ])
+    })
+    expect(maxActive).toBeGreaterThan(1)
+  })
+})

--- a/src/relay/workspace-space-scan.ts
+++ b/src/relay/workspace-space-scan.ts
@@ -1,11 +1,12 @@
 /* eslint-disable max-lines -- Why: local and relay Space scans share the same
    cancellation, symlink, and top-level compaction semantics in one scanner. */
-import { execFile } from 'node:child_process'
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
 import type { Dirent } from 'node:fs'
 import { lstat, opendir } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import { platform } from 'node:process'
-import { promisify } from 'node:util'
+import type { Readable } from 'node:stream'
+import { StringDecoder } from 'node:string_decoder'
 import type {
   WorkspaceSpaceDirectoryScanResult,
   WorkspaceSpaceItem
@@ -24,9 +25,7 @@ import {
 import type { RequestContext } from './dispatcher'
 
 const RELAY_FS_CONCURRENCY = 48
-const DU_TIMEOUT_MS = 120_000
-const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
-const execFileAsync = promisify(execFile)
+const DU_STDERR_MAX_CHARS = 64 * 1024
 
 type ScanStats = WorkspaceSpaceEntryScan
 
@@ -48,20 +47,32 @@ function normalizeDuPath(pathValue: string): string {
   return trimmed.length > 0 ? trimmed : pathValue
 }
 
-function parseDuDepthOneOutput(stdout: string): Map<string, number> {
-  const sizes = new Map<string, number>()
-  for (const line of stdout.split('\n')) {
-    const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
-    if (!normalizedLine) {
-      continue
-    }
-    const match = /^(\d+)\s+(.+)$/.exec(normalizedLine)
-    if (!match) {
-      continue
-    }
-    sizes.set(normalizeDuPath(match[2]), Number(match[1]) * 1024)
+function parseDuDepthOneLine(line: string): [string, number] | null {
+  const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
+  if (!normalizedLine) {
+    return null
   }
-  return sizes
+  const match = /^(\d+)\s+(.+)$/.exec(normalizedLine)
+  if (!match) {
+    return null
+  }
+  return [normalizeDuPath(match[2]), Number(match[1]) * 1024]
+}
+
+function consumeDuOutputChunk(
+  sizes: Map<string, number>,
+  bufferedLine: string,
+  chunkText: string
+): string {
+  const lines = `${bufferedLine}${chunkText}`.split('\n')
+  const nextBufferedLine = lines.pop() ?? ''
+  for (const line of lines) {
+    const parsed = parseDuDepthOneLine(line)
+    if (parsed) {
+      sizes.set(parsed[0], parsed[1])
+    }
+  }
+  return nextBufferedLine
 }
 
 async function readDuDepthOne(
@@ -69,14 +80,78 @@ async function readDuDepthOne(
   context: RequestContext
 ): Promise<Map<string, number>> {
   throwIfCancelled(context)
-  const { stdout } = await execFileAsync('du', ['-k', '-d', '1', rootPath], {
-    encoding: 'utf8',
-    maxBuffer: DU_MAX_BUFFER_BYTES,
-    signal: context.signal,
-    timeout: DU_TIMEOUT_MS
+  return new Promise<Map<string, number>>((resolve, reject) => {
+    let settled = false
+    let child: ChildProcessByStdio<null, Readable, Readable> | undefined
+    let onAbort: (() => void) | null = null
+    let bufferedLine = ''
+    let stderr = ''
+    const stdoutDecoder = new StringDecoder('utf8')
+    const stderrDecoder = new StringDecoder('utf8')
+    const sizes = new Map<string, number>()
+    const appendStderr = (chunkText: string): void => {
+      if (stderr.length < DU_STDERR_MAX_CHARS) {
+        stderr = `${stderr}${chunkText}`.slice(0, DU_STDERR_MAX_CHARS)
+      }
+    }
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (onAbort) {
+        context.signal?.removeEventListener('abort', onAbort)
+      }
+      callback()
+    }
+    onAbort = () => {
+      settle(() => {
+        child?.kill()
+        reject(new RelayWorkspaceSpaceScanCancelledError())
+      })
+    }
+    context.signal?.addEventListener('abort', onAbort, { once: true })
+    if (context.signal?.aborted || context.isStale()) {
+      onAbort()
+      return
+    }
+
+    try {
+      // Why: relay scans may run on huge remote worktrees; streaming avoids
+      // execFile buffering while keeping native du as the exact source.
+      child = spawn('du', ['-k', '-d', '1', rootPath], { stdio: ['ignore', 'pipe', 'pipe'] })
+    } catch (error) {
+      settle(() => reject(error))
+      return
+    }
+    child.stdout.on('data', (chunk) => {
+      bufferedLine = consumeDuOutputChunk(sizes, bufferedLine, stdoutDecoder.write(chunk))
+    })
+    child.stderr.on('data', (chunk) => {
+      appendStderr(stderrDecoder.write(chunk))
+    })
+    child.once('error', (error) => {
+      settle(() => reject(error))
+    })
+    child.once('close', (code) => {
+      settle(() => {
+        const decodedTail = stdoutDecoder.end()
+        if (decodedTail) {
+          bufferedLine = consumeDuOutputChunk(sizes, bufferedLine, decodedTail)
+        }
+        appendStderr(stderrDecoder.end())
+        const parsed = parseDuDepthOneLine(bufferedLine)
+        if (parsed) {
+          sizes.set(parsed[0], parsed[1])
+        }
+        if (code === 0) {
+          resolve(sizes)
+          return
+        }
+        reject(new Error(stderr.trim() || `du exited with code ${code ?? 'null'}`))
+      })
+    })
   })
-  throwIfCancelled(context)
-  return parseDuDepthOneOutput(stdout)
 }
 
 function toWorkspaceSpaceItem(stats: ScanStats): WorkspaceSpaceItem {

--- a/src/relay/workspace-space-scan.ts
+++ b/src/relay/workspace-space-scan.ts
@@ -20,11 +20,14 @@ import {
 import {
   collectWorkspaceSpaceDirectoryEntries,
   createWorkspaceSpaceScanBudget,
+  retainWorkspaceSpaceScanEntry,
+  type WorkspaceSpaceScanBudget,
   WorkspaceSpaceScanCapacityError
 } from '../shared/workspace-space-scan-budget'
 import type { RequestContext } from './dispatcher'
 
 const RELAY_FS_CONCURRENCY = 48
+const DU_TIMEOUT_MS = 120_000
 const DU_STDERR_MAX_CHARS = 64 * 1024
 
 type ScanStats = WorkspaceSpaceEntryScan
@@ -33,6 +36,13 @@ class RelayWorkspaceSpaceScanCancelledError extends Error {
   constructor() {
     super('Workspace space scan cancelled')
     this.name = 'RelayWorkspaceSpaceScanCancelledError'
+  }
+}
+
+class RelayWorkspaceSpaceDuTimeoutError extends Error {
+  constructor() {
+    super(`du timed out after ${DU_TIMEOUT_MS}ms`)
+    this.name = 'RelayWorkspaceSpaceDuTimeoutError'
   }
 }
 
@@ -61,6 +71,7 @@ function parseDuDepthOneLine(line: string): [string, number] | null {
 
 function consumeDuOutputChunk(
   sizes: Map<string, number>,
+  budget: WorkspaceSpaceScanBudget,
   bufferedLine: string,
   chunkText: string
 ): string {
@@ -69,6 +80,9 @@ function consumeDuOutputChunk(
   for (const line of lines) {
     const parsed = parseDuDepthOneLine(line)
     if (parsed) {
+      if (!sizes.has(parsed[0])) {
+        retainWorkspaceSpaceScanEntry(budget, parsed[0], sizes.size)
+      }
       sizes.set(parsed[0], parsed[1])
     }
   }
@@ -84,11 +98,13 @@ async function readDuDepthOne(
     let settled = false
     let child: ChildProcessByStdio<null, Readable, Readable> | undefined
     let onAbort: (() => void) | null = null
+    let timer: ReturnType<typeof setTimeout> | null = null
     let bufferedLine = ''
     let stderr = ''
     const stdoutDecoder = new StringDecoder('utf8')
     const stderrDecoder = new StringDecoder('utf8')
     const sizes = new Map<string, number>()
+    const budget = createWorkspaceSpaceScanBudget()
     const appendStderr = (chunkText: string): void => {
       if (stderr.length < DU_STDERR_MAX_CHARS) {
         stderr = `${stderr}${chunkText}`.slice(0, DU_STDERR_MAX_CHARS)
@@ -99,6 +115,9 @@ async function readDuDepthOne(
         return
       }
       settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
       if (onAbort) {
         context.signal?.removeEventListener('abort', onAbort)
       }
@@ -117,15 +136,30 @@ async function readDuDepthOne(
     }
 
     try {
-      // Why: relay scans may run on huge remote worktrees; streaming avoids
-      // execFile buffering while keeping native du as the exact source.
+      // Why: stream beyond execFile's fixed buffer while bounding retained rows.
       child = spawn('du', ['-k', '-d', '1', rootPath], { stdio: ['ignore', 'pipe', 'pipe'] })
     } catch (error) {
       settle(() => reject(error))
       return
     }
+    timer = setTimeout(() => {
+      settle(() => {
+        child?.kill()
+        reject(new RelayWorkspaceSpaceDuTimeoutError())
+      })
+    }, DU_TIMEOUT_MS)
     child.stdout.on('data', (chunk) => {
-      bufferedLine = consumeDuOutputChunk(sizes, bufferedLine, stdoutDecoder.write(chunk))
+      if (settled) {
+        return
+      }
+      try {
+        bufferedLine = consumeDuOutputChunk(sizes, budget, bufferedLine, stdoutDecoder.write(chunk))
+      } catch (error) {
+        settle(() => {
+          child?.kill()
+          reject(error)
+        })
+      }
     })
     child.stderr.on('data', (chunk) => {
       appendStderr(stderrDecoder.write(chunk))
@@ -134,16 +168,27 @@ async function readDuDepthOne(
       settle(() => reject(error))
     })
     child.once('close', (code) => {
-      settle(() => {
+      if (settled) {
+        return
+      }
+      try {
         const decodedTail = stdoutDecoder.end()
         if (decodedTail) {
-          bufferedLine = consumeDuOutputChunk(sizes, bufferedLine, decodedTail)
+          bufferedLine = consumeDuOutputChunk(sizes, budget, bufferedLine, decodedTail)
         }
         appendStderr(stderrDecoder.end())
         const parsed = parseDuDepthOneLine(bufferedLine)
         if (parsed) {
+          if (!sizes.has(parsed[0])) {
+            retainWorkspaceSpaceScanEntry(budget, parsed[0], sizes.size)
+          }
           sizes.set(parsed[0], parsed[1])
         }
+      } catch (error) {
+        settle(() => reject(error))
+        return
+      }
+      settle(() => {
         if (code === 0) {
           resolve(sizes)
           return
@@ -242,19 +287,16 @@ async function scanDirectoryWithDu(
     return scanDirectoryWithNode(rootPath, context)
   }
 
-  const [entries, duSizes] = await Promise.all([
-    opendir(rootPath).then(async (directory) => {
-      const admission = await collectWorkspaceSpaceDirectoryEntries(
-        directory,
-        rootPath,
-        (entry) => entry.name,
-        createWorkspaceSpaceScanBudget(),
-        () => throwIfCancelled(context)
-      )
-      return admission.entries
-    }),
-    readDuDepthOne(rootPath, context)
-  ])
+  const directory = await opendir(rootPath)
+  const admission = await collectWorkspaceSpaceDirectoryEntries(
+    directory,
+    rootPath,
+    (entry) => entry.name,
+    createWorkspaceSpaceScanBudget(),
+    () => throwIfCancelled(context)
+  )
+  const entries = admission.entries
+  const duSizes = await readDuDepthOne(rootPath, context)
   throwIfCancelled(context)
   const childStats = await mapWithConcurrency(
     entries,
@@ -312,6 +354,7 @@ export async function scanWorkspaceSpaceDirectory(
     } catch (error) {
       if (
         error instanceof RelayWorkspaceSpaceScanCancelledError ||
+        error instanceof RelayWorkspaceSpaceDuTimeoutError ||
         error instanceof WorkspaceSpaceScanCapacityError
       ) {
         throw error

--- a/src/relay/workspace-space-scan.ts
+++ b/src/relay/workspace-space-scan.ts
@@ -1,15 +1,17 @@
-import { execFile } from 'node:child_process'
 import type { Dirent } from 'node:fs'
 import { lstat, opendir } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import { platform } from 'node:process'
-import { promisify } from 'node:util'
 import type {
   WorkspaceSpaceDirectoryScanResult,
   WorkspaceSpaceItem
 } from '../shared/workspace-space-types'
 import { compactWorkspaceSpaceItems } from '../shared/workspace-space-compaction'
 import { mapWithConcurrency } from '../shared/map-with-concurrency'
+import {
+  readWorkspaceSpaceDuDepthOne,
+  WORKSPACE_SPACE_DU_TIMEOUT_MS
+} from '../shared/workspace-space-du-stream'
 import {
   scanWorkspaceSpaceEntryTree,
   type WorkspaceSpaceEntryScan
@@ -22,9 +24,6 @@ import {
 import type { RequestContext } from './dispatcher'
 
 const RELAY_FS_CONCURRENCY = 48
-const DU_TIMEOUT_MS = 120_000
-const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
-const execFileAsync = promisify(execFile)
 
 type ScanStats = WorkspaceSpaceEntryScan
 
@@ -32,6 +31,13 @@ class RelayWorkspaceSpaceScanCancelledError extends Error {
   constructor() {
     super('Workspace space scan cancelled')
     this.name = 'RelayWorkspaceSpaceScanCancelledError'
+  }
+}
+
+class RelayWorkspaceSpaceDuTimeoutError extends Error {
+  constructor() {
+    super(`du timed out after ${WORKSPACE_SPACE_DU_TIMEOUT_MS}ms`)
+    this.name = 'RelayWorkspaceSpaceDuTimeoutError'
   }
 }
 
@@ -46,35 +52,18 @@ function normalizeDuPath(pathValue: string): string {
   return trimmed.length > 0 ? trimmed : pathValue
 }
 
-function parseDuDepthOneOutput(stdout: string): Map<string, number> {
-  const sizes = new Map<string, number>()
-  for (const line of stdout.split('\n')) {
-    const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
-    if (!normalizedLine) {
-      continue
-    }
-    const match = /^(\d+)\s+(.+)$/.exec(normalizedLine)
-    if (!match) {
-      continue
-    }
-    sizes.set(normalizeDuPath(match[2]), Number(match[1]) * 1024)
-  }
-  return sizes
-}
-
 async function readDuDepthOne(
   rootPath: string,
   context: RequestContext
 ): Promise<Map<string, number>> {
   throwIfCancelled(context)
-  const { stdout } = await execFileAsync('du', ['-k', '-d', '1', rootPath], {
-    encoding: 'utf8',
-    maxBuffer: DU_MAX_BUFFER_BYTES,
+  return readWorkspaceSpaceDuDepthOne(rootPath, {
     signal: context.signal,
-    timeout: DU_TIMEOUT_MS
+    isCancelled: () => context.isStale() || Boolean(context.signal?.aborted),
+    normalizePath: normalizeDuPath,
+    createTimeoutError: () => new RelayWorkspaceSpaceDuTimeoutError(),
+    createCancelledError: () => new RelayWorkspaceSpaceScanCancelledError()
   })
-  throwIfCancelled(context)
-  return parseDuDepthOneOutput(stdout)
 }
 
 function toWorkspaceSpaceItem(stats: ScanStats): WorkspaceSpaceItem {
@@ -165,19 +154,16 @@ async function scanDirectoryWithDu(
     return scanDirectoryWithNode(rootPath, context)
   }
 
-  const [entries, duSizes] = await Promise.all([
-    opendir(rootPath).then(async (directory) => {
-      const admission = await collectWorkspaceSpaceDirectoryEntries(
-        directory,
-        rootPath,
-        (entry) => entry.name,
-        createWorkspaceSpaceScanBudget(),
-        () => throwIfCancelled(context)
-      )
-      return admission.entries
-    }),
-    readDuDepthOne(rootPath, context)
-  ])
+  const directory = await opendir(rootPath)
+  const admission = await collectWorkspaceSpaceDirectoryEntries(
+    directory,
+    rootPath,
+    (entry) => entry.name,
+    createWorkspaceSpaceScanBudget(),
+    () => throwIfCancelled(context)
+  )
+  const entries = admission.entries
+  const duSizes = await readDuDepthOne(rootPath, context)
   throwIfCancelled(context)
   const childStats = await mapWithConcurrency(
     entries,
@@ -235,6 +221,7 @@ export async function scanWorkspaceSpaceDirectory(
     } catch (error) {
       if (
         error instanceof RelayWorkspaceSpaceScanCancelledError ||
+        error instanceof RelayWorkspaceSpaceDuTimeoutError ||
         error instanceof WorkspaceSpaceScanCapacityError
       ) {
         throw error

--- a/src/shared/workspace-space-du-stream.ts
+++ b/src/shared/workspace-space-du-stream.ts
@@ -1,0 +1,192 @@
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import type { Readable } from 'node:stream'
+import { StringDecoder } from 'node:string_decoder'
+import {
+  createWorkspaceSpaceScanBudget,
+  retainWorkspaceSpaceScanEntry,
+  type WorkspaceSpaceScanBudget
+} from './workspace-space-scan-budget'
+
+export const WORKSPACE_SPACE_DU_TIMEOUT_MS = 120_000
+const DU_STDERR_MAX_CHARS = 64 * 1024
+
+export class WorkspaceSpaceDuTimeoutError extends Error {
+  constructor() {
+    super(`du timed out after ${WORKSPACE_SPACE_DU_TIMEOUT_MS}ms`)
+    this.name = 'WorkspaceSpaceDuTimeoutError'
+  }
+}
+
+export type ReadWorkspaceSpaceDuDepthOneOptions = {
+  signal?: AbortSignal
+  isCancelled?: () => boolean
+  normalizePath: (path: string) => string
+  createTimeoutError?: () => Error
+  createCancelledError: () => Error
+}
+
+function parseDuDepthOneLine(
+  line: string,
+  normalizePath: (path: string) => string
+): [string, number] | null {
+  const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
+  if (!normalizedLine) {
+    return null
+  }
+  const match = /^(\d+)\s+(.+)$/.exec(normalizedLine)
+  if (!match) {
+    return null
+  }
+  return [normalizePath(match[2]), Number(match[1]) * 1024]
+}
+
+function consumeDuOutputChunk(
+  sizes: Map<string, number>,
+  budget: WorkspaceSpaceScanBudget,
+  bufferedLine: string,
+  chunkText: string,
+  normalizePath: (path: string) => string
+): string {
+  const lines = `${bufferedLine}${chunkText}`.split('\n')
+  const nextBufferedLine = lines.pop() ?? ''
+  for (const line of lines) {
+    const parsed = parseDuDepthOneLine(line, normalizePath)
+    if (parsed) {
+      if (!sizes.has(parsed[0])) {
+        retainWorkspaceSpaceScanEntry(budget, parsed[0], sizes.size)
+      }
+      sizes.set(parsed[0], parsed[1])
+    }
+  }
+  return nextBufferedLine
+}
+
+function retainParsedDuLine(
+  sizes: Map<string, number>,
+  budget: WorkspaceSpaceScanBudget,
+  parsed: [string, number]
+): void {
+  if (!sizes.has(parsed[0])) {
+    retainWorkspaceSpaceScanEntry(budget, parsed[0], sizes.size)
+  }
+  sizes.set(parsed[0], parsed[1])
+}
+
+export function readWorkspaceSpaceDuDepthOne(
+  rootPath: string,
+  options: ReadWorkspaceSpaceDuDepthOneOptions
+): Promise<Map<string, number>> {
+  const { signal, normalizePath } = options
+  return new Promise<Map<string, number>>((resolve, reject) => {
+    let settled = false
+    let child: ChildProcessByStdio<null, Readable, Readable> | undefined
+    let onAbort: (() => void) | null = null
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let bufferedLine = ''
+    let stderr = ''
+    const stdoutDecoder = new StringDecoder('utf8')
+    const stderrDecoder = new StringDecoder('utf8')
+    const sizes = new Map<string, number>()
+    const budget = createWorkspaceSpaceScanBudget()
+    const appendStderr = (chunkText: string): void => {
+      if (stderr.length < DU_STDERR_MAX_CHARS) {
+        stderr = `${stderr}${chunkText}`.slice(0, DU_STDERR_MAX_CHARS)
+      }
+    }
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+      if (onAbort) {
+        signal?.removeEventListener('abort', onAbort)
+      }
+      callback()
+    }
+    onAbort = () => {
+      settle(() => {
+        child?.kill()
+        reject(options.createCancelledError())
+      })
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted || options.isCancelled?.()) {
+      onAbort()
+      return
+    }
+
+    try {
+      // Why: stream beyond execFile's fixed buffer while bounding retained rows.
+      child = spawn('du', ['-k', '-d', '1', rootPath], { stdio: ['ignore', 'pipe', 'pipe'] })
+    } catch (error) {
+      settle(() => reject(error))
+      return
+    }
+    timer = setTimeout(() => {
+      settle(() => {
+        child?.kill()
+        reject(options.createTimeoutError?.() ?? new WorkspaceSpaceDuTimeoutError())
+      })
+    }, WORKSPACE_SPACE_DU_TIMEOUT_MS)
+    child.stdout.on('data', (chunk) => {
+      if (settled) {
+        return
+      }
+      try {
+        bufferedLine = consumeDuOutputChunk(
+          sizes,
+          budget,
+          bufferedLine,
+          stdoutDecoder.write(chunk),
+          normalizePath
+        )
+      } catch (error) {
+        settle(() => {
+          child?.kill()
+          reject(error)
+        })
+      }
+    })
+    child.stderr.on('data', (chunk) => {
+      appendStderr(stderrDecoder.write(chunk))
+    })
+    child.once('error', (error) => {
+      settle(() => reject(error))
+    })
+    child.once('close', (code) => {
+      if (settled) {
+        return
+      }
+      try {
+        const decodedTail = stdoutDecoder.end()
+        if (decodedTail) {
+          bufferedLine = consumeDuOutputChunk(
+            sizes,
+            budget,
+            bufferedLine,
+            decodedTail,
+            normalizePath
+          )
+        }
+        appendStderr(stderrDecoder.end())
+        const parsed = parseDuDepthOneLine(bufferedLine, normalizePath)
+        if (parsed) {
+          retainParsedDuLine(sizes, budget, parsed)
+        }
+      } catch (error) {
+        settle(() => reject(error))
+        return
+      }
+      settle(() => {
+        if (code === 0) {
+          resolve(sizes)
+          return
+        }
+        reject(new Error(stderr.trim() || `du exited with code ${code ?? 'null'}`))
+      })
+    })
+  })
+}

--- a/src/shared/workspace-space-du-stream.ts
+++ b/src/shared/workspace-space-du-stream.ts
@@ -136,6 +136,10 @@ export function readWorkspaceSpaceDuDepthOne(
         return
       }
       try {
+        if (options.isCancelled?.()) {
+          onAbort?.()
+          return
+        }
         bufferedLine = consumeDuOutputChunk(
           sizes,
           budget,


### PR DESCRIPTION
## Review follow-up (e9da2f56)

Observe request staleness on every du stdout chunk and use the existing abort cleanup. The new signal-free relay regression proves one child kill and cancellation; 14 tests across 5 files, allCLI/Node/Web non-composite TypeScript and changed-file hygiene passed. No prior assertions were weakened. Silent children retain the existing abort-signal/deadline behavior. Full suite/build and live SSH/native-host smoke were not repeated. Independent Cursor review passed for this exact commit.

## Previously verified rebase

## Summary

Workspace Space scans now parse native `du` stdout as it arrives, replacing the fixed 16 MiB `execFile` buffer. Retained entries use the existing 100,000-entry / 64 MiB budget; stderr is capped separately. The scan lists top-level entries before starting `du`, cancels when its owning renderer is destroyed, and stops without a second traversal when `du` reaches its deadline or the retained-entry budget.

The 120-second `du` deadline and 130-second SSH scan request deadline remain. SSH multiplex requests can optionally disable their local timer with `timeoutMs: null` while retaining explicit abort cancellation; Space scans themselves still use 130 seconds. Missing `du` retains the portable walker fallback, and Windows continues using that walker. Main and relay share the streamed parser; folder workspaces use the same scan path.

Existing timeout tests intentionally stop expecting a second portable traversal after a wedged `du`: timeout and capacity overflow now make the worktree unavailable. Tests also cover UTF-8 chunk boundaries, cancellation, retained-row overflow, owner destruction and portable fallback concurrency. No RPC method or binary stream opcode is added.

## Testing and review

At `de5c17159fe6bae69460dd6bbab25b2a044508f5`, independent verification passed 145 tests across 14 files, with no failures or skips. CLI, Node and Web TypeScript (`--composite false`), changed-file lint/format, diff whitespace and native preflight/postflight passed. Independent Cursor review passed on this exact commit.

Full repository tests, packaging and live Electron/SSH/mixed-version or Windows/Linux smoke were not run. Automated checks ran on macOS.

## AI disclosure

Cursor ported and independently reviewed the change; Codex checked the original requirements, source and verification results.
