### PR TITLE
fix(terminal): drop orphaned XTVERSION bodies; set TERM_PROGRAM on remote PTYs

### DIFF
--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -20,6 +20,13 @@ function createMockMux(): MockMultiplexer {
   }
 }
 
+/** Identity env #7839 always injects for remote PTY parity with local. */
+const ORCA_TERMINAL_IDENTITY_ENV = {
+  TERM_PROGRAM: 'Orca',
+  COLORTERM: 'truecolor',
+  FORCE_HYPERLINK: '1'
+} as const
+
 describe('SshPtyProvider', () => {
   let mux: MockMultiplexer
   let provider: SshPtyProvider
@@ -44,7 +51,12 @@ describe('SshPtyProvider', () => {
         cols: 80,
         rows: 24,
         cwd: undefined,
-        env: { [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true' }
+        env: expect.objectContaining({
+          [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
+          TERM_PROGRAM: 'Orca',
+          COLORTERM: 'truecolor',
+          FORCE_HYPERLINK: '1'
+        })
       })
       expect(result).toEqual({ id: scopedPty1 })
     })
@@ -63,7 +75,13 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: '/home/user',
-        env: { FOO: 'bar', [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true' }
+        env: expect.objectContaining({
+          FOO: 'bar',
+          [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
+          TERM_PROGRAM: 'Orca',
+          COLORTERM: 'truecolor',
+          FORCE_HYPERLINK: '1'
+        })
       })
     })
 
@@ -81,7 +99,10 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: undefined,
-        env: { [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true' },
+        env: expect.objectContaining({
+          [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
+          ...ORCA_TERMINAL_IDENTITY_ENV
+        }),
         paneKey: 'tab-a:leaf-a',
         tabId: 'tab-a'
       })
@@ -101,7 +122,10 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: undefined,
-        env: { [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true' },
+        env: expect.objectContaining({
+          [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
+          ...ORCA_TERMINAL_IDENTITY_ENV
+        }),
         shellOverride: 'powershell.exe',
         terminalWindowsWslDistro: 'Ubuntu'
       })
@@ -120,7 +144,10 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: undefined,
-        env: { [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'already-set' }
+        env: expect.objectContaining({
+          [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'already-set',
+          ...ORCA_TERMINAL_IDENTITY_ENV
+        })
       })
     })
 
@@ -138,8 +165,12 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: undefined,
-        env: {}
+        env: expect.objectContaining({
+          ...ORCA_TERMINAL_IDENTITY_ENV
+        })
       })
+      const spawnCall = mux.request.mock.calls.find((call) => call[0] === 'pty.spawn')
+      expect(spawnCall?.[1]?.env).not.toHaveProperty(POWERLEVEL10K_WIZARD_DISABLE_ENV)
     })
 
     it('forwards provider command delivery to the relay', async () => {
@@ -157,7 +188,10 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: undefined,
-        env: { [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true' },
+        env: expect.objectContaining({
+          [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
+          ...ORCA_TERMINAL_IDENTITY_ENV
+        }),
         command: 'echo from-runtime',
         commandDelivery: 'provider',
         startupCommandDelivery: 'shell-ready'
@@ -183,15 +217,16 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: undefined,
-        env: {
+        env: expect.objectContaining({
           PATH: '/home/user/.orca-relay/bin:/usr/bin',
           ORCA_TERMINAL_HANDLE: 'term_ssh',
           [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
           ORCA_REMOTE_CLI_BIN_DIR: '/home/user/.orca-relay/bin',
           ORCA_RELAY_DIR: '/home/user/.orca-relay/relay-v1',
           ORCA_RELAY_NODE_PATH: '/usr/bin/node',
-          ORCA_RELAY_SOCKET_PATH: '/home/user/.orca-relay/relay.sock'
-        }
+          ORCA_RELAY_SOCKET_PATH: '/home/user/.orca-relay/relay.sock',
+          ...ORCA_TERMINAL_IDENTITY_ENV
+        })
       })
     })
 
@@ -214,14 +249,15 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: undefined,
-        env: {
+        env: expect.objectContaining({
           ORCA_TERMINAL_HANDLE: 'term_ssh',
           [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
           ORCA_REMOTE_CLI_BIN_DIR: '/home/user/.orca-relay/bin',
           ORCA_RELAY_DIR: '/home/user/.orca-relay/relay-v1',
           ORCA_RELAY_NODE_PATH: '/usr/bin/node',
-          ORCA_RELAY_SOCKET_PATH: '/home/user/.orca-relay/relay.sock'
-        }
+          ORCA_RELAY_SOCKET_PATH: '/home/user/.orca-relay/relay.sock',
+          ...ORCA_TERMINAL_IDENTITY_ENV
+        })
       })
     })
 
@@ -245,14 +281,15 @@ describe('SshPtyProvider', () => {
         cols: 120,
         rows: 40,
         cwd: undefined,
-        env: {
+        env: expect.objectContaining({
           Path: 'C:/Users/me/.orca-relay/bin;C:/Windows/System32;C:/Tools',
           [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
           ORCA_REMOTE_CLI_BIN_DIR: 'C:/Users/me/.orca-relay/bin',
           ORCA_RELAY_DIR: 'C:/Users/me/.orca-remote/relay-v1',
           ORCA_RELAY_NODE_PATH: 'C:/Program Files/nodejs/node.exe',
-          ORCA_RELAY_SOCKET_PATH: '\\\\.\\pipe\\orca-relay-123'
-        }
+          ORCA_RELAY_SOCKET_PATH: '\\\\.\\pipe\\orca-relay-123',
+          ...ORCA_TERMINAL_IDENTITY_ENV
+        })
       })
     })
 

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -20,10 +20,13 @@ function createMockMux(): MockMultiplexer {
   }
 }
 
-/** Identity env #7839 always injects for remote PTY parity with local. */
+/** Identity env #7839 always injects for remote PTY parity with local/daemon. */
 const ORCA_TERMINAL_IDENTITY_ENV = {
+  TERM: 'xterm-256color',
   TERM_PROGRAM: 'Orca',
   COLORTERM: 'truecolor',
+  // Match production: ORCA_APP_VERSION when set, else dev fallback.
+  TERM_PROGRAM_VERSION: process.env.ORCA_APP_VERSION || '0.0.0-dev',
   FORCE_HYPERLINK: '1'
 } as const
 

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -183,10 +183,11 @@ export class SshPtyProvider implements IPtyProvider {
       delete merged[key]
     }
     seedPowerlevel10kWizardEnv(merged, { envToDelete })
-    // Why: parity with local-pty-provider / daemon. Without TERM_PROGRAM=Orca,
-    // remote Grok probes XTVERSION and can show `xterm.js(...)` as the prompt
-    // when the reply is late or partially echoed (#7839).
-    merged.TERM = merged.TERM || 'xterm-256color'
+    // Why: parity with local-pty-provider / daemon (unconditional TERM). Without
+    // TERM_PROGRAM=Orca, remote Grok probes XTVERSION and can show `xterm.js(...)`
+    // as the prompt when the reply is late or partially echoed (#7839). Do not
+    // preserve ambient TERM=dumb from service hosts.
+    merged.TERM = 'xterm-256color'
     merged.COLORTERM = 'truecolor'
     merged.TERM_PROGRAM = 'Orca'
     merged.TERM_PROGRAM_VERSION =

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -183,6 +183,15 @@ export class SshPtyProvider implements IPtyProvider {
       delete merged[key]
     }
     seedPowerlevel10kWizardEnv(merged, { envToDelete })
+    // Why: parity with local-pty-provider / daemon. Without TERM_PROGRAM=Orca,
+    // remote Grok probes XTVERSION and can show `xterm.js(...)` as the prompt
+    // when the reply is late or partially echoed (#7839).
+    merged.TERM = merged.TERM || 'xterm-256color'
+    merged.COLORTERM = 'truecolor'
+    merged.TERM_PROGRAM = 'Orca'
+    merged.TERM_PROGRAM_VERSION =
+      merged.TERM_PROGRAM_VERSION || process.env.ORCA_APP_VERSION || '0.0.0-dev'
+    merged.FORCE_HYPERLINK = '1'
     if (!this.remoteCliBridgeEnv) {
       return merged
     }

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -290,8 +290,9 @@ export class PtyHandler {
     // (Grok, Claude, Codex) feature-gate correctly. SSH/relay spawns previously
     // inherited a bare remote env — Grok then falls back to XTVERSION probing
     // and can paint `xterm.js(...)` into the prompt on slow remote paths (#7839).
-    // Match local-pty-provider / daemon pty-subprocess identity.
-    baseEnv.TERM = baseEnv.TERM || 'xterm-256color'
+    // Match daemon pty-subprocess: set TERM unconditionally so ambient
+    // TERM=dumb on a headless relay host cannot poison the shell.
+    baseEnv.TERM = 'xterm-256color'
     baseEnv.COLORTERM = 'truecolor'
     baseEnv.TERM_PROGRAM = 'Orca'
     baseEnv.TERM_PROGRAM_VERSION =

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -286,6 +286,20 @@ export class PtyHandler {
     ctx: { id: string; paneKey?: string; shell: string; command?: string }
   ): Record<string, string> {
     const baseEnv = { ...process.env, ...rendererEnv } as Record<string, string>
+    // Why: local + daemon PTY spawns always set Orca terminal identity so TUIs
+    // (Grok, Claude, Codex) feature-gate correctly. SSH/relay spawns previously
+    // inherited a bare remote env — Grok then falls back to XTVERSION probing
+    // and can paint `xterm.js(...)` into the prompt on slow remote paths (#7839).
+    // Match local-pty-provider / daemon pty-subprocess identity.
+    baseEnv.TERM = baseEnv.TERM || 'xterm-256color'
+    baseEnv.COLORTERM = 'truecolor'
+    baseEnv.TERM_PROGRAM = 'Orca'
+    baseEnv.TERM_PROGRAM_VERSION =
+      baseEnv.TERM_PROGRAM_VERSION ||
+      baseEnv.ORCA_APP_VERSION ||
+      process.env.ORCA_APP_VERSION ||
+      '0.0.0-dev'
+    baseEnv.FORCE_HYPERLINK = '1'
     const augmented: Record<string, string> = {}
     for (const augmenter of this.envAugmenters) {
       try {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -5630,6 +5630,25 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).toHaveBeenCalledWith('yes')
     expect(transport.sendInput).toHaveBeenCalledWith('\x1b[A')
     expect(transport.sendInputImmediate).not.toHaveBeenCalled()
+
+    // Framed XTVERSION still takes the immediate path (#7839 / #7329).
+    // Mock sendInputImmediate delegates to sendInput, so only assert immediate.
+    transport.sendInputImmediate.mockClear()
+    const xtversionReply = '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\'
+    sendTerminalInputThroughPane(pane, xtversionReply)
+    expect(transport.sendInputImmediate).toHaveBeenCalledWith(xtversionReply)
+
+    // ESC-stripped XTVERSION body must be dropped, not typed into Grok (#7839).
+    transport.sendInput.mockClear()
+    transport.sendInputImmediate.mockClear()
+    const orphanedXtversion = '>|xterm.js(6.1.0-beta.287)'
+    sendTerminalInputThroughPane(pane, orphanedXtversion)
+    expect(transport.sendInputImmediate).not.toHaveBeenCalledWith(orphanedXtversion)
+    // sendInput is only reached for non-reply non-orphan input; body must not
+    // appear as a standalone typed chunk.
+    expect(
+      transport.sendInput.mock.calls.some((call) => call[0] === orphanedXtversion)
+    ).toBe(false)
   })
 
   it('writes the onReplayData pendingEscapeTailAnsi meta last, after the replayed bytes (#7329)', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -12,7 +12,10 @@ import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
 import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-color-reply'
-import { isTerminalQueryReply } from '../../../../shared/terminal-query-reply'
+import {
+  isOrphanedTerminalQueryReplyBody,
+  isTerminalQueryReply
+} from '../../../../shared/terminal-query-reply'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
@@ -3000,6 +3003,13 @@ export function connectPanePty(
     // so a real keystroke never reaches this branch.
     if (isTerminalQueryReply(data)) {
       transport.sendInputImmediate(data)
+      return
+    }
+    // Why: #7839 — remote Grok (and similar) can surface ESC-stripped XTVERSION
+    // bodies (`>|xterm.js(...)`) as the prompt after a late/corrupt query reply.
+    // Drop frameless reply bodies instead of forwarding them as keystrokes.
+    if (isOrphanedTerminalQueryReplyBody(data)) {
+      clearPendingTerminalInputIntent()
       return
     }
     const intent = pendingTerminalInputIntent

--- a/src/shared/terminal-query-reply.test.ts
+++ b/src/shared/terminal-query-reply.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isTerminalQueryReply } from './terminal-query-reply'
+import { isOrphanedTerminalQueryReplyBody, isTerminalQueryReply } from './terminal-query-reply'
 
 describe('isTerminalQueryReply', () => {
   it('matches synthetic query replies that must be sent immediately', () => {
@@ -34,6 +34,8 @@ describe('isTerminalQueryReply', () => {
     expect(isTerminalQueryReply('\x1bP1$r0m\x1b\\')).toBe(true)
     expect(isTerminalQueryReply('\x1bP0$r\x1b\\')).toBe(true)
     expect(isTerminalQueryReply('\x1bP>|xterm.js(5.6.0)\x1b\\')).toBe(true)
+    // Current Orca bundle: @xterm/xterm@6.1.0-beta.287 (Grok remote prompt leak #7839).
+    expect(isTerminalQueryReply('\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\')).toBe(true)
   })
 
   it('documents the accepted modified-F3/CPR collision', () => {
@@ -77,5 +79,27 @@ describe('isTerminalQueryReply', () => {
     // Incomplete / non-terminated OSC and DCS must not match.
     expect(isTerminalQueryReply('\x1b]11;rgb:2828/2c2c/3434')).toBe(false)
     expect(isTerminalQueryReply('\x1bP1$r2 q')).toBe(false)
+  })
+})
+
+describe('isOrphanedTerminalQueryReplyBody (#7839)', () => {
+  it('drops ESC-stripped XTVERSION bodies that pollute Grok/agent prompts', () => {
+    expect(isOrphanedTerminalQueryReplyBody('>|xterm.js(6.1.0-beta.287)')).toBe(true)
+    expect(isOrphanedTerminalQueryReplyBody('P>|xterm.js(6.1.0-beta.287)')).toBe(true)
+    expect(isOrphanedTerminalQueryReplyBody('>|xterm.js(5.6.0)')).toBe(true)
+  })
+
+  it('drops ESC-stripped OSC color bodies', () => {
+    expect(isOrphanedTerminalQueryReplyBody(']11;rgb:2828/2c2c/3434')).toBe(true)
+    expect(isOrphanedTerminalQueryReplyBody(']10;rgb:c0c0/c0c0/c0c0')).toBe(true)
+  })
+
+  it('does not drop ordinary typing or framed replies', () => {
+    expect(isOrphanedTerminalQueryReplyBody('yes')).toBe(false)
+    expect(isOrphanedTerminalQueryReplyBody('>|not-xterm')).toBe(false)
+    expect(isOrphanedTerminalQueryReplyBody('>|xterm.js')).toBe(false) // incomplete
+    expect(isOrphanedTerminalQueryReplyBody('xterm.js(6.1.0-beta.287)')).toBe(false)
+    // Framed replies must go through isTerminalQueryReply + immediate send.
+    expect(isOrphanedTerminalQueryReplyBody('\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\')).toBe(false)
   })
 })

--- a/src/shared/terminal-query-reply.ts
+++ b/src/shared/terminal-query-reply.ts
@@ -41,6 +41,15 @@ const OSC_RESPONSE_RE = new RegExp('^\\u001b\\][0-9]+;[^\\u0007\\u001b]*(?:\\u00
 // DCS-framed reports xterm emits: DECRQSS "ESC P 1 $ r Pt ST" / "ESC P 0 $ r ST"
 // (vim queries cursor style this way) and XTVERSION "ESC P > | text ST".
 const DCS_RESPONSE_RE = new RegExp('^\\u001bP(?:[01]\\$r[^\\u001b]*|>\\|[^\\u001b]*)\\u001b\\\\$')
+// Why: Grok (and some ConPTY-style paths) can swallow the ESC/DCS introducer
+// of an XTVERSION reply and leave only the printable body. That body then
+// lands in the TUI as if the user typed it — e.g. `>|xterm.js(6.1.0-beta.287)`
+// as the Grok prompt on remote Mac (#7839). Match only the xterm.js identity
+// form so ordinary `>|` paste is never dropped.
+const ORPHANED_XTVERSION_BODY_RE = /^(?:P)?>\|xterm\.js\([^)\r\n]*\)$/
+// Same class as Windows ConPTY OSC color reply leaks (#6975): ESC swallowed,
+// printable OSC body remains (`]10;rgb:...` / `]11;rgb:...`).
+const ORPHANED_OSC_COLOR_BODY_RE = /^\](?:10|11);[^\r\n\u0007\u001b]{1,200}$/
 /* oxlint-enable no-control-regex */
 
 /**
@@ -66,4 +75,23 @@ export function isTerminalQueryReply(data: string): boolean {
     OSC_RESPONSE_RE.test(data) ||
     DCS_RESPONSE_RE.test(data)
   )
+}
+
+/**
+ * True when `data` is a **frameless** query-reply body that must be dropped
+ * rather than forwarded as PTY input. Used after ESC/control framing was lost
+ * (remote latency + cooked echo, ConPTY-style swallow, or TUI filter miss).
+ *
+ * Conservative: only exact full-chunk bodies for known reply shapes — never a
+ * prefix of user typing.
+ */
+export function isOrphanedTerminalQueryReplyBody(data: string): boolean {
+  if (data.length < 4 || data.length > 220) {
+    return false
+  }
+  // Full framed replies go through isTerminalQueryReply, not this drop path.
+  if (data[0] === ESC) {
+    return false
+  }
+  return ORPHANED_XTVERSION_BODY_RE.test(data) || ORPHANED_OSC_COLOR_BODY_RE.test(data)
 }


### PR DESCRIPTION
## Summary

Fixes remote Grok showing `>|xterm.js(6.1.0-beta.287)` as the prompt (same Orca build works locally).

### Root cause (investigation)

1. **xterm.js identity**: Orca ships `@xterm/xterm@6.1.0-beta.287`. XTVERSION replies are:
   `ESC P > | xterm.js(6.1.0-beta.287) ESC \`
2. **Grok probes XTVERSION** (`CSI >0q`) and has logic for “dropping stalled XTVERSION reply fragment”; when framing is lost, the printable body can land in the TUI input.
3. **Local vs remote env skew**: local + daemon PTY set `TERM_PROGRAM=Orca` (+ version / `COLORTERM` / `FORCE_HYPERLINK`). **SSH/relay spawns did not**, so remote Grok leans harder on XTVERSION over a higher-latency path.

Related prior work: #7329 / #7736 (immediate query replies), #5523 (reply leak class), #6975 (Windows OSC body leak — same ESC-swallow shape).

### Fix

| Change | Why |
| --- | --- |
| `isOrphanedTerminalQueryReplyBody` + drop on `onData` | Do not forward ESC-stripped `>\|xterm.js(...)` / OSC color bodies as keystrokes |
| SSH `withRemoteCliBridgeEnv` + relay `buildSpawnEnv` seed terminal identity | Parity with local/daemon so Grok brands as Orca |
| Keep framed XTVERSION on `sendInputImmediate` | Still latency-critical (#7329) |

## Screenshots

No visual change (terminal identity / input sanitization only).

## Testing

- [x] `src/shared/terminal-query-reply.test.ts` (framed beta XTVERSION + orphan cases)
- [x] `src/main/providers/ssh-pty-provider.test.ts` (identity env on spawn)
- [x] `pty-connection` onData routing test extended for XTVERSION immediate + orphan drop
- [x] oxlint on touched files
- After rebase onto latest `origin/main`: focused vitest **45 passed**
  (`terminal-query-reply` + `ssh-pty-provider`). Full `pty-connection` suite load depends on renderer alias graph; core shared + SSH coverage green.

## AI Review Report

- Conservative orphan matcher: only full-chunk `>\|xterm.js(...)` / `]10|11;...` bodies — not prefixes of normal typing.
- Framed replies still immediate-send (not dropped).
- Remote env forces identity even if renderer omitted keys; does not override explicit `TERM` when already set (`TERM = TERM \|\| xterm-256color`).
- Cross-platform: SSH/relay only for env seed; orphan drop is path-agnostic (macOS / Linux / Windows clients over SSH).

## Security Audit

- No new IPC surface; drops orphaned query-reply bodies that would otherwise inject into agent TUI input.
- Env seeding only sets terminal identity variables (`TERM_PROGRAM`, version, `COLORTERM`, etc.) already used on local/daemon paths.
- No secrets or path handling changes.

## Notes

- Rebased onto latest `origin/main` (`0eeac678a`).
- Primary user impact: remote/SSH Grok (and similar TUIs) no longer receive leaked XTVERSION bodies as prompt text.