### PR TITLE
fix(sidebar): only show the projects scrollbar when the list overflows

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -473,12 +473,12 @@
   scrollbar-color: color-mix(in srgb, var(--muted-foreground, #737373) 48%, transparent) transparent;
 }
 
-/* Keep the sidebar gutter reserved; only the thumb fades in on hover. */
+/* Why: no reserved `scrollbar-gutter` — paired with `overflow-y: auto`, a list
+   that fits shows no scrollbar (and no Windows scrollbar arrow buttons), so its
+   rows stay flush with the fixed header controls, matching macOS. The gutter is
+   only taken while actually scrolling. Thumb still fades in on hover. */
 .worktree-sidebar-scrollbar {
-  /* Why: the scrollbar gutter is paint-only in Chromium; this keeps card
-     surfaces clear of Orca's resize handle and right-edge sidebar chrome. */
   padding-right: 4px;
-  scrollbar-gutter: stable;
   scrollbar-color: transparent transparent;
 }
 

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -3988,7 +3988,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         onWheel={markDirectScrollInput}
         onDragOver={handleWorktreeDragOver}
         onDrop={handleWorktreeDrop}
-        className="worktree-sidebar-scrollbar h-full overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
+        className="worktree-sidebar-scrollbar h-full overflow-y-auto overflow-x-hidden pl-1 scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
         style={WORKTREE_SIDEBAR_SCROLL_STYLE}
       >
         <div
@@ -6722,7 +6722,7 @@ const WorktreeList = React.memo(function WorktreeList({
         data-contextual-tour-target="workspace-list"
         className="relative min-h-0 flex-1"
       >
-        <div className="worktree-sidebar-scrollbar flex h-full flex-col overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek pt-px">
+        <div className="worktree-sidebar-scrollbar flex h-full flex-col overflow-y-auto overflow-x-hidden pl-1 scrollbar-sleek pt-px">
           <div className="flex flex-col items-center gap-2 px-4 py-6 text-center text-[11px] text-muted-foreground">
             <span>
               {translate('auto.components.sidebar.WorktreeList.b7acbf038b', 'No workspaces found')}


### PR DESCRIPTION
## Problem

In the Projects sidebar on **Windows**, hovering a project row reveals its controls (`⌄  …  +`), but the row's `+` sits ~**10px left** of the Projects **header's `+`** — they're not flush. macOS lines them up fine.

Root cause: the list uses `overflow-y: scroll` **with a reserved `scrollbar-gutter: stable`**, so the scrollbar track is always present even when there's nothing to scroll. Two consequences on Windows:

- The reserved gutter insets the **rows** (which live inside the scroll container) but **not** the fixed header — so the row `+` is pushed left of the header `+`.
- With classic Windows scrollbars, the always-present track also paints the ▲/▼ **arrow buttons** in that gutter (the "up caret"), even with nothing to scroll.

macOS overlay scrollbars reserve no gutter and draw no buttons, so none of this shows there.

## Fix

Switch the projects list to `overflow-y: auto` and drop the reserved `scrollbar-gutter`. When the list fits, there's **no scrollbar, no gutter, and no arrow buttons** — the row controls stay flush with the header controls, matching macOS. The scrollbar returns only while the list actually overflows.

- `WorktreeList.tsx`: `overflow-y-scroll` → `overflow-y-auto` on the two sidebar scroll containers.
- `main.css`: remove `scrollbar-gutter: stable` from `.worktree-sidebar-scrollbar`.

## Verified (live, in a dev Orca instance on Windows via CDP)

Measured the header `+` and the hovered row `+` right-edges:

| | header `+` | row `+` | delta |
|---|---|---|---|
| Before | x=272 | x=262 | **10px** |
| After | x=272 | x=272 | **0px** |

- **Fits:** gutter 0 → no scrollbar, no caret, `+`s flush at the edge (matches macOS).
- **Overflows:** scrollbar reappears and scrolls normally; virtual rows still render.

## Notes / scope

- **macOS unchanged** — it already reserved no gutter (overlay scrollbars), so this is a no-op there.
- Trade-off: when the list *does* overflow, the scrollbar consumes width as it appears (content shifts by the scrollbar width) — standard behavior, and the same as macOS conceptually. The previous `scrollbar-gutter: stable` avoided that shift at the cost of the always-present gutter/arrows.
- When the list overflows on older Windows/Chromium (classic scrollbars), the ▲/▼ buttons still appear on the *real* scrollbar. That's the expected "there is a scrollbar" case; happy to also switch the sidebar to a custom (webkit) button-free scrollbar on Windows if you want them gone there too.
