### PR TITLE
ci(daemon): fail builds, packaging, and CI when the terminal daemon cannot start — and stop failing silently

### DIFF
--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -10,7 +10,14 @@ on:
       - 'config/scripts/computer-use-skill-guidance.test.mjs'
       - 'config/scripts/computer-use-smoke.mjs'
       - 'config/scripts/computer-use-smoke.test.mjs'
+      - 'config/scripts/daemon-boot-smoke.mjs'
       - 'config/scripts/verify-computer-native.mjs'
+      # Why: the native-smoke job boots the built terminal daemon under plain
+      # Node, so any change to the daemon bundle graph or the main build must
+      # re-run it (the v1.4.129-rc.1 daemon outage shipped with green CI).
+      - 'electron.vite.config.ts'
+      - 'build-plugins/**'
+      - 'src/main/daemon/**'
       - 'native/computer-use-macos/**'
       - 'native/computer-use-linux/**'
       - 'native/computer-use-windows/**'
@@ -98,6 +105,12 @@ jobs:
       - run: pnpm verify:computer-native
       - run: pnpm build:cli
       - run: pnpm build:electron-vite
+      # Why: boot the BUILT daemon-entry under plain Node the way production
+      # forks it. v1.4.129-rc.1 shipped a daemon that exited at module load
+      # (leaked electron require) while every other check passed; this fails
+      # the PR when the built daemon cannot start on ubuntu-22.04 / windows.
+      - name: Daemon boot smoke
+        run: node config/scripts/daemon-boot-smoke.mjs
       - if: runner.os == 'Linux'
         env:
           ORCA_COMPUTER_E2E: '1'

--- a/build-plugins/plain-node-entry-guard.ts
+++ b/build-plugins/plain-node-entry-guard.ts
@@ -1,0 +1,130 @@
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+import type { NormalizedOutputOptions, OutputBundle, OutputChunk, Plugin } from 'rollup'
+
+// Why: v1.4.129-rc.1 shipped a dead terminal daemon because a shared main
+// chunk gained `require("electron")` (an import edge added in #7642), and the
+// daemon is forked as a plain-Node process where electron cannot be required.
+// Nothing in CI executes the built daemon-entry under plain Node, so the leak
+// stayed invisible until an adopted old daemon died. This guard fails the
+// build when any chunk reachable from a plain-Node fork entry requires
+// electron, and smoke-loads daemon-entry under plain Node to prove its module
+// graph still resolves.
+
+// Entries executed as plain Node (ELECTRON_RUN_AS_NODE / no electron runtime):
+// forked daemon, parcel-watcher and computer sidecars, and the CLI-run
+// agent-hooks entry. require("electron") throws MODULE_NOT_FOUND in all of them.
+const PLAIN_NODE_ENTRY_NAMES = [
+  'daemon-entry',
+  'parcel-watcher-process-entry',
+  'computer-sidecar',
+  'agent-hooks/managed-agent-hook-controls'
+] as const
+
+const ELECTRON_REQUIRE_RE = /require\(\s*["']electron["']\s*\)/
+
+function collectReachableChunks(
+  entry: OutputChunk,
+  byFileName: Map<string, OutputChunk>
+): OutputChunk[] {
+  const seen = new Set<string>()
+  const reachable: OutputChunk[] = []
+  const stack = [entry.fileName]
+  while (stack.length > 0) {
+    const fileName = stack.pop() as string
+    if (seen.has(fileName)) {
+      continue
+    }
+    seen.add(fileName)
+    const chunk = byFileName.get(fileName)
+    if (!chunk) {
+      continue
+    }
+    reachable.push(chunk)
+    for (const imported of [...chunk.imports, ...chunk.dynamicImports]) {
+      stack.push(imported)
+    }
+  }
+  return reachable
+}
+
+function assertNoElectronRequire(
+  entryName: string,
+  entry: OutputChunk,
+  byFileName: Map<string, OutputChunk>
+): void {
+  for (const chunk of collectReachableChunks(entry, byFileName)) {
+    if (ELECTRON_REQUIRE_RE.test(chunk.code)) {
+      throw new Error(
+        `[plain-node-entry-guard] "${entryName}" reaches chunk "${chunk.fileName}" that ` +
+          `requires electron. "${entryName}" runs as a plain-Node process, where ` +
+          `require("electron") throws MODULE_NOT_FOUND and kills it at startup (the ` +
+          `v1.4.129-rc.1 daemon outage). Keep electron imports out of its module graph.`
+      )
+    }
+  }
+}
+
+// Why: proves the whole daemon-entry graph resolves under plain Node (no
+// unresolved requires). require("electron") does not throw in a dev tree with
+// node_modules present, so the static scan above — not this smoke — is the
+// electron regression guard; this only catches gross load failures.
+function smokeLoadDaemonEntry(outputDir: string): void {
+  const entryPath = join(outputDir, 'daemon-entry.js')
+  const result = spawnSync(process.execPath, [entryPath], {
+    encoding: 'utf8',
+    timeout: 15_000
+  })
+  if (result.error) {
+    throw new Error(
+      `[plain-node-entry-guard] could not smoke-load daemon-entry.js under plain Node: ` +
+        `${result.error.message}`
+    )
+  }
+  const stderr = result.stderr ?? ''
+  if (/Cannot find module|MODULE_NOT_FOUND/.test(stderr)) {
+    throw new Error(
+      `[plain-node-entry-guard] daemon-entry.js failed to load under plain Node:\n${stderr}`
+    )
+  }
+  if (!stderr.includes('Usage: daemon-entry')) {
+    throw new Error(
+      `[plain-node-entry-guard] daemon-entry.js did not reach argv parsing under plain Node ` +
+        `(expected the "Usage: daemon-entry" error). stderr:\n${stderr}`
+    )
+  }
+}
+
+export function createPlainNodeEntryGuardPlugin(): Plugin {
+  return {
+    name: 'orca-plain-node-entry-guard',
+    writeBundle(options: NormalizedOutputOptions, bundle: OutputBundle) {
+      // Why: skip in `electron-vite dev` watch mode — the smoke would respawn on
+      // every rebuild, and the guard only needs to gate produced builds.
+      if (this.meta.watchMode) {
+        return
+      }
+      const chunks = Object.values(bundle).filter(
+        (item): item is OutputChunk => item.type === 'chunk'
+      )
+      const byFileName = new Map(chunks.map((chunk) => [chunk.fileName, chunk]))
+      const entryByName = new Map<string, OutputChunk>()
+      for (const chunk of chunks) {
+        if (chunk.isEntry && chunk.name) {
+          entryByName.set(chunk.name, chunk)
+        }
+      }
+
+      for (const entryName of PLAIN_NODE_ENTRY_NAMES) {
+        const entry = entryByName.get(entryName)
+        if (entry) {
+          assertNoElectronRequire(entryName, entry, byFileName)
+        }
+      }
+
+      if (entryByName.has('daemon-entry') && options.dir) {
+        smokeLoadDaemonEntry(options.dir)
+      }
+    }
+  }
+}

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -2,6 +2,7 @@ const { chmodSync, existsSync, readdirSync } = require('node:fs')
 const { execFileSync } = require('node:child_process')
 const { join, resolve } = require('node:path')
 const electronBuilderNativeRebuild = require('./scripts/electron-builder-native-rebuild.cjs')
+const { verifyPackagedDaemonEntryBoots } = require('./scripts/verify-packaged-daemon-entry.cjs')
 const {
   createPackagedRuntimeNodeModuleResources,
   prunePackagedRuntimeNodeModules,
@@ -130,6 +131,20 @@ module.exports = {
     }
     prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName, context.arch)
     verifyPackagedMainRuntimeDeps(resourcesDir)
+    // Why: boot the packaged daemon-entry under plain Node, but only for the
+    // slice matching the packaging host's arch — daemon-entry.js is JS, yet it
+    // require()s the native (N-API) node-pty for the TARGET arch, which the host
+    // Node cannot load cross-arch. `Arch` enum: ia32=0, x64=1, armv7l=2,
+    // arm64=3, universal=4 (universal contains the host slice, so run it).
+    const archEnumByNodeArch = { ia32: 0, x64: 1, armv7l: 2, arm64: 3 }
+    const hostArchEnum = archEnumByNodeArch[process.arch]
+    if (context.arch === hostArchEnum || context.arch === 4) {
+      verifyPackagedDaemonEntryBoots(resourcesDir)
+    } else {
+      console.log(
+        `[verify-packaged-daemon-entry] skipped cross-arch slice (target ${context.arch}, host ${process.arch})`
+      )
+    }
     chmodUnixCliLaunchers(resourcesDir, context.electronPlatformName)
     chmodMacServeSimHelpers(resourcesDir, context.electronPlatformName)
     for (const filename of readdirSync(resourcesDir)) {

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -110,6 +110,39 @@ describe('computer-use e2e workflow', () => {
     }
   })
 
+  it('boots the built daemon under plain Node in the PR native-smoke job after the main build', () => {
+    const workflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/computer-e2e.yml'), 'utf8')
+    )
+    const steps = workflow.jobs['native-smoke'].steps
+    const runs = steps.map((step) => step.run).filter((run) => typeof run === 'string')
+    const buildIndex = runs.indexOf('pnpm build:electron-vite')
+    const daemonSmokeIndex = runs.indexOf('node config/scripts/daemon-boot-smoke.mjs')
+
+    expect(daemonSmokeIndex, 'native-smoke must boot the built daemon').toBeGreaterThanOrEqual(0)
+    expect(
+      buildIndex,
+      'daemon boot smoke must run after the main bundle is built'
+    ).toBeGreaterThanOrEqual(0)
+    expect(daemonSmokeIndex).toBeGreaterThan(buildIndex)
+  })
+
+  it('re-runs the native-smoke job when the daemon bundle graph changes', () => {
+    const workflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/computer-e2e.yml'), 'utf8')
+    )
+    const triggerPaths = workflow.on.pull_request.paths
+
+    expect(triggerPaths).toEqual(
+      expect.arrayContaining([
+        'config/scripts/daemon-boot-smoke.mjs',
+        'electron.vite.config.ts',
+        'build-plugins/**',
+        'src/main/daemon/**'
+      ])
+    )
+  })
+
   it('runs Linux computer-use e2e in the PR native-smoke job under Xvfb', () => {
     const workflow = parse(
       readFileSync(join(projectDir, '.github/workflows/computer-e2e.yml'), 'utf8')

--- a/config/scripts/daemon-boot-smoke.mjs
+++ b/config/scripts/daemon-boot-smoke.mjs
@@ -1,0 +1,217 @@
+/**
+ * Boots the BUILT terminal daemon (out/main/daemon-entry.js) under plain Node —
+ * the exact way production forks it (ELECTRON_RUN_AS_NODE = a plain-Node
+ * process) — and asserts it starts, serves a real PTY, and stops.
+ *
+ * Why this exists: native-smoke CI (and packaging) went green while
+ * v1.4.129-rc.1 shipped a daemon that exited code 1 at module load because an
+ * electron `require` leaked into its bundle graph. Nothing executed the built
+ * entry under plain Node, so the outage was invisible until an adopted old
+ * daemon died in the field. This runs on every PR that touches the daemon.
+ *
+ * Hard assertions (fail the job):
+ *   - the daemon signals `{ type: 'ready' }` over IPC within the timeout, and
+ *   - it terminates when asked (no hang / zombie).
+ * Best-effort (logged skip, never fails): an end-to-end `ptySpawnHealth` RPC,
+ * because node-pty spawn can be flaky on constrained CI runners.
+ */
+import { fork } from 'node:child_process'
+import { connect } from 'node:net'
+import { randomUUID } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+const entryPath = join(projectDir, 'out', 'main', 'daemon-entry.js')
+
+const READY_TIMEOUT_MS = 30_000
+const PTY_HEALTH_TIMEOUT_MS = 10_000
+const SHUTDOWN_TIMEOUT_MS = 10_000
+
+function log(message) {
+  process.stdout.write(`[daemon-boot-smoke] ${message}\n`)
+}
+
+// Why: the daemon rejects a hello whose protocol version differs, so read the
+// current version from source rather than hardcoding a number that can drift.
+function readProtocolVersion() {
+  const source = readFileSync(join(projectDir, 'src/main/daemon/types.ts'), 'utf8')
+  const match = source.match(/PROTOCOL_VERSION\s*=\s*(\d+)/)
+  if (!match) {
+    throw new Error('could not read PROTOCOL_VERSION from src/main/daemon/types.ts')
+  }
+  return Number(match[1])
+}
+
+function makeSocketPath(userDataDir) {
+  // Why: Windows AF_UNIX-style IPC uses named pipes; POSIX uses a filesystem
+  // socket kept under the scratch userData dir so cleanup removes it.
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\orca-daemon-smoke-${process.pid}-${randomUUID()}`
+  }
+  return join(userDataDir, 'daemon.sock')
+}
+
+// Best-effort end-to-end PTY check over the daemon's own control-socket RPC.
+// Connects a single control socket, completes the hello handshake, and calls
+// `ptySpawnHealth` (the daemon spawns a throwaway PTY internally). Resolves
+// true on success, false on any failure — never throws.
+function runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion) {
+  return new Promise((resolveCheck) => {
+    let settled = false
+    let buffer = ''
+    const socket = connect(socketPath)
+    const finish = (ok, reason) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      socket.destroy()
+      if (!ok && reason) {
+        log(`PTY spawn health check skipped (best-effort): ${reason}`)
+      }
+      resolveCheck(ok)
+    }
+    const timer = setTimeout(() => finish(false, 'timed out'), PTY_HEALTH_TIMEOUT_MS)
+
+    socket.on('error', (err) => finish(false, err.message))
+    socket.on('connect', () => {
+      const token = readFileSync(tokenPath, 'utf8').trim()
+      socket.write(
+        `${JSON.stringify({
+          type: 'hello',
+          version: protocolVersion,
+          token,
+          clientId: randomUUID(),
+          role: 'control'
+        })}\n`
+      )
+    })
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString('utf8')
+      let newlineIdx = buffer.indexOf('\n')
+      while (newlineIdx !== -1) {
+        const line = buffer.slice(0, newlineIdx)
+        buffer = buffer.slice(newlineIdx + 1)
+        let msg
+        try {
+          msg = JSON.parse(line)
+        } catch {
+          finish(false, 'invalid response line')
+          return
+        }
+        if (msg.type === 'hello') {
+          if (!msg.ok) {
+            finish(false, `hello rejected: ${msg.error ?? 'unknown'}`)
+            return
+          }
+          socket.write(`${JSON.stringify({ id: 'health-1', type: 'ptySpawnHealth' })}\n`)
+        } else if (msg.id === 'health-1') {
+          finish(
+            msg.ok === true,
+            msg.ok === true ? undefined : (msg.error ?? 'ptySpawnHealth failed')
+          )
+          return
+        }
+        newlineIdx = buffer.indexOf('\n')
+      }
+    })
+  })
+}
+
+async function main() {
+  const userDataDir = mkdtempSync(join(tmpdir(), 'orca-daemon-boot-smoke-'))
+  const socketPath = makeSocketPath(userDataDir)
+  const tokenPath = join(userDataDir, 'daemon.token')
+  const protocolVersion = readProtocolVersion()
+
+  log(`forking ${entryPath} under plain Node (${process.execPath})`)
+  const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {
+    // Plain Node: no ELECTRON_RUN_AS_NODE. process.execPath is already node in
+    // CI, and this is exactly the runtime where a leaked `require("electron")`
+    // throws MODULE_NOT_FOUND — the failure this smoke exists to catch.
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    env: { ...process.env, ORCA_USER_DATA_PATH: userDataDir }
+  })
+
+  let stderr = ''
+  child.stderr?.on('data', (chunk) => {
+    stderr += chunk.toString('utf8')
+  })
+  child.stdout?.on('data', (chunk) => {
+    process.stdout.write(chunk)
+  })
+
+  const cleanup = () => {
+    if (child.exitCode === null && child.signalCode === null && child.pid) {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // already gone
+      }
+    }
+    rmSync(userDataDir, { recursive: true, force: true })
+  }
+
+  try {
+    await new Promise((resolveReady, rejectReady) => {
+      const timer = setTimeout(() => {
+        rejectReady(
+          new Error(
+            `daemon did not signal 'ready' within ${READY_TIMEOUT_MS}ms.\nstderr:\n${stderr}`
+          )
+        )
+      }, READY_TIMEOUT_MS)
+      child.on('message', (msg) => {
+        if (msg && typeof msg === 'object' && msg.type === 'ready') {
+          clearTimeout(timer)
+          resolveReady()
+        }
+      })
+      child.on('error', (err) => {
+        clearTimeout(timer)
+        rejectReady(new Error(`daemon fork errored: ${err.message}\nstderr:\n${stderr}`))
+      })
+      child.on('exit', (code, signal) => {
+        clearTimeout(timer)
+        rejectReady(
+          new Error(
+            `daemon exited before 'ready' (code=${code}, signal=${signal}).\nstderr:\n${stderr}`
+          )
+        )
+      })
+    })
+    log('daemon signaled ready')
+
+    const ptyHealthy = await runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion)
+    if (ptyHealthy) {
+      log('ptySpawnHealth OK — daemon spawned a real PTY end-to-end')
+    }
+
+    await new Promise((resolveExit, rejectExit) => {
+      const timer = setTimeout(() => {
+        rejectExit(new Error(`daemon did not exit within ${SHUTDOWN_TIMEOUT_MS}ms of SIGTERM`))
+      }, SHUTDOWN_TIMEOUT_MS)
+      child.on('exit', (code, signal) => {
+        clearTimeout(timer)
+        log(`daemon exited after signal (code=${code}, signal=${signal})`)
+        resolveExit()
+      })
+      // Why: SIGTERM is the graceful stop on POSIX (the daemon handles it);
+      // Windows has no POSIX signal delivery, so Node maps this to process
+      // termination. Either way the hard assertion is "it stops, no hang".
+      child.kill('SIGTERM')
+    })
+
+    log('PASS: daemon booted, served, and shut down under plain Node')
+  } finally {
+    cleanup()
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`[daemon-boot-smoke] FAIL: ${error.message}\n`)
+  process.exitCode = 1
+})

--- a/config/scripts/verify-packaged-daemon-entry.cjs
+++ b/config/scripts/verify-packaged-daemon-entry.cjs
@@ -1,0 +1,46 @@
+const { existsSync } = require('node:fs')
+const { spawnSync } = require('node:child_process')
+const { join } = require('node:path')
+
+// Why: v1.4.129-rc.1 shipped a terminal daemon that could not load (an electron
+// `require` leaked into its bundle) while every build check passed. This boots
+// the PACKAGED daemon-entry under plain Node against the asar-unpacked layout,
+// so a bundling / asar-unpack regression fails packaging instead of reaching
+// users. Module-load proof only: with no args the entry must reach argv parsing
+// and print its "Usage: daemon-entry" error — a MODULE_NOT_FOUND or a missing
+// usage line means the packaged graph does not load and the build must fail.
+//
+// resourcesDir is the packaged Resources dir (Contents/Resources on macOS,
+// <appOutDir>/resources elsewhere). execPath defaults to the packaging Node.
+function verifyPackagedDaemonEntryBoots(resourcesDir, options = {}) {
+  const execPath = options.execPath || process.execPath
+  const entryPath = join(resourcesDir, 'app.asar.unpacked', 'out', 'main', 'daemon-entry.js')
+  if (!existsSync(entryPath)) {
+    // Why: some targets/layouts do not unpack here; skip rather than fail so
+    // the hook stays safe across platforms it has not verified.
+    console.log(`[verify-packaged-daemon-entry] skipped — no unpacked entry at ${entryPath}`)
+    return
+  }
+
+  const result = spawnSync(execPath, [entryPath], { encoding: 'utf8', timeout: 10_000 })
+  if (result.error) {
+    throw new Error(
+      `[verify-packaged-daemon-entry] could not launch daemon-entry.js: ${result.error.message}`
+    )
+  }
+  const stderr = result.stderr || ''
+  if (/Cannot find module|MODULE_NOT_FOUND/.test(stderr)) {
+    throw new Error(
+      `[verify-packaged-daemon-entry] packaged daemon-entry.js failed to load under plain Node:\n${stderr}`
+    )
+  }
+  if (!stderr.includes('Usage: daemon-entry')) {
+    throw new Error(
+      `[verify-packaged-daemon-entry] packaged daemon-entry.js did not reach argv parsing ` +
+        `(expected the "Usage: daemon-entry" error). stderr:\n${stderr}`
+    )
+  }
+  console.log('[verify-packaged-daemon-entry] OK — packaged daemon-entry loads under plain Node')
+}
+
+module.exports = { verifyPackagedDaemonEntryBoots }

--- a/config/tsconfig.node.json
+++ b/config/tsconfig.node.json
@@ -2,6 +2,7 @@
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   "include": [
     "../electron.vite.config.*",
+    "../build-plugins/**/*",
     "../src/main/**/*",
     "../src/preload/**/*",
     "../src/shared/**/*",

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path'
 import { defineConfig } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { createPlainNodeEntryGuardPlugin } from './build-plugins/plain-node-entry-guard'
 
 // Why: the telemetry transport is gated by two compile-time constants that
 // only the official CI release workflow sets. Contributor / `pnpm dev` /
@@ -191,7 +192,7 @@ export default defineConfig({
             'src/main/agent-hooks/managed-agent-hook-controls.ts'
           )
         },
-        plugins: [createStartupDiagnosticsBootstrapPlugin()]
+        plugins: [createStartupDiagnosticsBootstrapPlugin(), createPlainNodeEntryGuardPlugin()]
       }
     },
     // Why: compile-time substitution for the telemetry gate. See the block

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -46,6 +46,13 @@ export function parseArgs(argv: string[]): ParsedDaemonArgs {
 }
 
 async function main(): Promise<void> {
+  // Why: the parent captures daemon startup stderr then destroys its end of the
+  // pipe once the daemon is ready. A later write here (e.g. the uncaughtException
+  // console.error below) would then hit a broken pipe and emit 'error' on
+  // process.stderr — with no listener that becomes an unhandled error that kills
+  // an otherwise healthy detached daemon. Swallow it: stderr is diagnostic only.
+  process.stderr.on('error', () => {})
+
   const { socketPath, tokenPath, logFilePath } = parseArgs(process.argv.slice(2))
   // Fail-open: a broken log path must never block daemon startup.
   const daemonLog = logFilePath ? createDaemonFileLog(logFilePath) : createNoopDaemonFileLog()

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -1365,6 +1365,123 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(child.unref).not.toHaveBeenCalled()
   })
 
+  it('captures daemon startup stderr into the failure error', async () => {
+    const mod = await importFresh()
+    checkDaemonHealthMock.mockResolvedValue('unreachable')
+    await mod.initDaemonPtyProvider()
+
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string
+    ) => Promise<{ shutdown(): Promise<void> }>
+    const handlers: Record<string, ((arg?: unknown) => void)[]> = {
+      message: [],
+      error: [],
+      exit: []
+    }
+    const stderrDataCbs: ((chunk: Buffer) => void)[] = []
+    const stderrDestroy = vi.fn()
+    const stderr = {
+      on(event: string, cb: (chunk: Buffer) => void) {
+        if (event === 'data') {
+          stderrDataCbs.push(cb)
+        }
+        return this
+      },
+      off(event: string, cb: (chunk: Buffer) => void) {
+        if (event === 'data') {
+          const idx = stderrDataCbs.indexOf(cb)
+          if (idx !== -1) {
+            stderrDataCbs.splice(idx, 1)
+          }
+        }
+        return this
+      },
+      destroy: stderrDestroy
+    }
+    const child = {
+      pid: 4321,
+      stderr,
+      on(event: string, cb: (arg?: unknown) => void) {
+        handlers[event]?.push(cb)
+        if (event === 'exit') {
+          // Why: deliver the stderr tail before the exit so the failure path
+          // sees the captured crash reason, mirroring a module-load crash.
+          queueMicrotask(() => {
+            for (const dataCb of stderrDataCbs.slice()) {
+              dataCb(Buffer.from("Error: Cannot find module 'electron'\n"))
+            }
+            cb(1)
+          })
+        }
+        return this
+      },
+      off: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+        handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+        return child
+      }),
+      disconnect: vi.fn(),
+      unref: vi.fn()
+    }
+    forkMock.mockReturnValueOnce(child)
+
+    const error = await launcher('/fake/socket', '/fake/token').catch((err: Error) => err)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toMatch(/Cannot find module 'electron'/)
+    expect((error as Error).message).toMatch(/Daemon stderr \(tail\)/)
+    // Why: the piped stderr must be released so the detached daemon does not
+    // keep the parent event loop alive after the failure.
+    expect(stderrDestroy).toHaveBeenCalled()
+  })
+
+  it('destroys the daemon stderr pipe once the daemon signals ready', async () => {
+    const mod = await importFresh()
+    checkDaemonHealthMock.mockResolvedValue('unreachable')
+    await mod.initDaemonPtyProvider()
+
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string
+    ) => Promise<{ shutdown(): Promise<void> }>
+    const handlers: Record<string, ((arg?: unknown) => void)[]> = {
+      message: [],
+      error: [],
+      exit: []
+    }
+    const stderrOff = vi.fn()
+    const stderrDestroy = vi.fn()
+    const stderr = {
+      on() {
+        return this
+      },
+      off: stderrOff,
+      destroy: stderrDestroy
+    }
+    const child = {
+      pid: 12345,
+      stderr,
+      on(event: string, cb: (arg?: unknown) => void) {
+        handlers[event]?.push(cb)
+        if (event === 'message') {
+          queueMicrotask(() => cb({ type: 'ready' }))
+        }
+        return this
+      },
+      off: vi.fn(() => child),
+      disconnect: vi.fn(),
+      unref: vi.fn()
+    }
+    forkMock.mockReturnValueOnce(child)
+
+    await launcher('/fake/socket', '/fake/token')
+
+    expect(stderrOff).toHaveBeenCalledWith('data', expect.any(Function))
+    expect(stderrDestroy).toHaveBeenCalledOnce()
+    expect(child.disconnect).toHaveBeenCalledOnce()
+    expect(child.unref).toHaveBeenCalledOnce()
+  })
+
   it('preserves a health-check-failing daemon when it owns live sessions', async () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -298,10 +298,13 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
         // userData keeps process.cwd() valid after a repo/worktree is deleted.
         cwd: userDataPath,
         // Why: detached + unref lets the daemon outlive the Electron process.
-        // stdio 'ignore' prevents the child from holding the parent's stdout
-        // open, which would prevent Electron from exiting cleanly.
+        // stdout stays 'ignore' so the child never holds the parent's stdout
+        // open (which would block Electron exit); stderr is 'pipe' so a
+        // module-load crash during startup is captured instead of discarded
+        // (v1.4.129-rc.1 shipped a daemon that only logged "exited with code 1"
+        // because stderr was thrown away). The pipe is destroyed on readiness.
         detached: true,
-        stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+        stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
         // Why: run the relocated Orca.exe copy instead of the install-dir one.
         // It is byte-identical, so run-as-node behavior is unchanged; only the
         // image path moves out of the updater's kill zone.
@@ -319,6 +322,30 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
         }
       }
     )
+
+    // Why: keep only the startup-window stderr tail so a crash cause is
+    // visible without unbounded memory if the daemon spews before dying.
+    const STARTUP_STDERR_MAX_BYTES = 8192
+    let startupStderr = ''
+    let collectingStderr = true
+    const onStartupStderr = (chunk: Buffer): void => {
+      if (!collectingStderr) {
+        return
+      }
+      startupStderr += chunk.toString('utf8')
+      if (startupStderr.length > STARTUP_STDERR_MAX_BYTES) {
+        startupStderr = startupStderr.slice(-STARTUP_STDERR_MAX_BYTES)
+      }
+    }
+    child.stderr?.on('data', onStartupStderr)
+    // Why: once the daemon is up (or has failed) the parent must not keep a
+    // live handle on the detached daemon's stderr — a piped stream would ref
+    // the parent event loop and prevent Electron from exiting cleanly.
+    const releaseStderr = (): void => {
+      collectingStderr = false
+      child.stderr?.off('data', onStartupStderr)
+      child.stderr?.destroy()
+    }
 
     // Wait for the daemon to signal readiness via IPC
     await new Promise<void>((resolve, reject) => {
@@ -338,6 +365,14 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
         }
         settled = true
         cleanupStartupListeners()
+        // Why: stderr was previously discarded, so a startup crash surfaced only
+        // as "exited with code 1". Attach the captured tail to the thrown error
+        // (which the fallback path reports) and log it so the real cause shows.
+        const stderrTail = startupStderr.trim()
+        if (stderrTail) {
+          console.warn(`[daemon] startup failed; captured stderr tail:\n${stderrTail}`)
+        }
+        releaseStderr()
         if (child.pid) {
           try {
             process.kill(child.pid, 'SIGTERM')
@@ -345,7 +380,9 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
             // Already dead
           }
         }
-        reject(error)
+        reject(
+          stderrTail ? new Error(`${error.message}\nDaemon stderr (tail):\n${stderrTail}`) : error
+        )
       }
       function onReadyMessage(msg: unknown): void {
         if (msg && typeof msg === 'object' && (msg as { type?: string }).type === 'ready') {
@@ -372,8 +409,10 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
               { mode: 0o600 }
             )
           }
-          // Why: disconnect IPC channel and unref so Electron can exit
-          // without waiting for the daemon. The daemon keeps running.
+          // Why: disconnect IPC channel, release the stderr pipe, and unref so
+          // Electron can exit without waiting for the daemon. The daemon keeps
+          // running detached.
+          releaseStderr()
           child.disconnect()
           child.unref()
           resolve()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,7 +27,8 @@ import { registerCoreHandlers } from './ipc/register-core-handlers'
 import { initObservability, shutdownObservability } from './observability'
 import { startSpan } from './observability/tracer'
 import { registerMobileHandlers } from './ipc/mobile'
-import { initTelemetry, shutdownTelemetry, trackAppOpenedOnce } from './telemetry/client'
+import { initTelemetry, shutdownTelemetry, trackAppOpenedOnce, track } from './telemetry/client'
+import { classifyError } from './telemetry/classify-error'
 import { runManagedHookInstallers } from './agent-hooks/install-telemetry'
 import {
   isAgentStatusHooksEnabled,
@@ -644,7 +645,16 @@ function startDesktopFirstWindowStartupServices(): Promise<void> {
       logStartupMilestone('startup-service-done', { service: 'agent-hook-server' })
     },
     onDaemonError: (error) => {
-      console.error('[daemon] Failed to start daemon PTY provider, falling back to local:', error)
+      // Why: daemon startup failure silently dropped terminals onto the local
+      // provider (killed on quit, no persistence) — the v1.4.129-rc.1 outage was
+      // invisible in the field. Log loudly (error.message carries the captured
+      // daemon stderr tail from the fork) and emit a low-cardinality telemetry
+      // signal so a fleet-wide daemon failure is observable without a bug report.
+      const reason = error instanceof Error ? error.message : String(error)
+      console.error(
+        `[daemon] STARTUP FAILED — falling back to local PTYs; terminals will not persist across quit. Reason: ${reason}`
+      )
+      track('daemon_start_failed', classifyError(error))
     },
     onAgentHookServerError: (error) => {
       // Why: Claude/Codex/Gemini/OpenCode/Cursor hook callbacks are sidebar

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -261,6 +261,7 @@ describe('registerPtyHandlers', () => {
   const savedOrcaClaudeAgentStatusSettings = process.env.ORCA_CLAUDE_AGENT_STATUS_SETTINGS
   const savedProcessPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
   const savedDisableMacosLoginShell = process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL
+  const savedOrcaUserDataPath = process.env.ORCA_USER_DATA_PATH
 
   beforeEach(() => {
     // Why: most PTY spawn tests assert POSIX shell behavior; Windows-specific
@@ -333,6 +334,10 @@ describe('registerPtyHandlers', () => {
       handlers.delete(channel)
     })
     getPathMock.mockReturnValue('/tmp/orca-user-data')
+    // Why: shell-ready wrapper roots resolve from ORCA_USER_DATA_PATH (main
+    // canonicalizes it to app.getPath('userData') at startup before any spawn);
+    // mirror that here so ZDOTDIR/wrapper assertions match the mocked userData.
+    process.env.ORCA_USER_DATA_PATH = '/tmp/orca-user-data'
     existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue({ isDirectory: () => true, mode: 0o755 })
     readFileSyncMock.mockReturnValue('')
@@ -386,6 +391,11 @@ describe('registerPtyHandlers', () => {
       process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL = savedDisableMacosLoginShell
     } else {
       delete process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL
+    }
+    if (savedOrcaUserDataPath !== undefined) {
+      process.env.ORCA_USER_DATA_PATH = savedOrcaUserDataPath
+    } else {
+      delete process.env.ORCA_USER_DATA_PATH
     }
     if (savedOpenCodeConfigDir !== undefined) {
       process.env.OPENCODE_CONFIG_DIR = savedOpenCodeConfigDir

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -14,20 +14,24 @@ import {
   writeStartupCommandWhenShellReady
 } from './local-pty-shell-ready'
 
-const { getUserDataPathMock } = vi.hoisted(() => ({
-  getUserDataPathMock: vi.fn<() => string>()
-}))
+// Why: the wrapper root is resolved from ORCA_USER_DATA_PATH (main
+// canonicalizes it at startup; the daemon fork sets it explicitly). This
+// module must not import electron because it is bundled into the plain-node
+// daemon-entry fork, so tests point the root through the env var rather than
+// mocking electron's app.
+function setTestUserDataPath(path: string): void {
+  process.env.ORCA_USER_DATA_PATH = path
+}
 
-vi.mock('electron', () => ({
-  app: {
-    getPath: (name: string) => {
-      if (name === 'userData') {
-        return getUserDataPathMock()
-      }
-      throw new Error(`unexpected app.getPath(${name})`)
-    }
+const ORIGINAL_ORCA_USER_DATA_PATH = process.env.ORCA_USER_DATA_PATH
+
+afterEach(() => {
+  if (ORIGINAL_ORCA_USER_DATA_PATH === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = ORIGINAL_ORCA_USER_DATA_PATH
   }
-}))
+})
 
 async function importFreshLocalPtyShellReady(): Promise<typeof LocalPtyShellReadyModule> {
   vi.resetModules()
@@ -279,6 +283,23 @@ describe('scanForShellReady', () => {
   })
 })
 
+describe('shell-ready wrapper root resolution', () => {
+  // Why: regression guard — the daemon-entry fork runs as plain Node and cannot
+  // import electron, so the wrapper root must resolve from ORCA_USER_DATA_PATH
+  // (set by main at startup and by the daemon fork) rather than app.getPath.
+  it('resolves the wrapper root from ORCA_USER_DATA_PATH', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-userdata-env-'))
+    try {
+      setTestUserDataPath(root)
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      const config = getShellReadyLaunchConfig('/bin/zsh')
+      expect(config.env.ZDOTDIR).toBe(`${root}/shell-ready/zsh`)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
 const describePosix = process.platform === 'win32' ? describe.skip : describe
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
 const itWithBash = hasBash ? it : it.skip
@@ -342,7 +363,7 @@ describePosix('local PTY shell-ready launch config', () => {
     previousOrcaOrigZdotdir = process.env.ORCA_ORIG_ZDOTDIR
     delete process.env.ORCA_ORIG_ZDOTDIR
     userDataPath = mkdtempSync(join(tmpdir(), 'local-pty-shell-ready-test-'))
-    getUserDataPathMock.mockReturnValue(userDataPath)
+    setTestUserDataPath(userDataPath)
   })
 
   afterEach(() => {
@@ -723,7 +744,7 @@ describePosix('live zsh subprocess tests', () => {
     beforeEach(async () => {
       testHome = mkdtempSync(join(tmpdir(), 'orca-zsh-test-home-'))
       userDataPath = mkdtempSync(join(tmpdir(), 'orca-zsh-test-userdata-'))
-      getUserDataPathMock.mockReturnValue(userDataPath)
+      setTestUserDataPath(userDataPath)
     })
 
     afterEach(() => {
@@ -957,7 +978,7 @@ export MY_VAR=foo
     beforeEach(async () => {
       testHome = mkdtempSync(join(tmpdir(), 'orca-zsh-edge-'))
       userDataPath = mkdtempSync(join(tmpdir(), 'orca-zsh-userdata-'))
-      getUserDataPathMock.mockReturnValue(userDataPath)
+      setTestUserDataPath(userDataPath)
     })
 
     afterEach(() => {
@@ -1283,7 +1304,7 @@ export MY_VAR=foo
     beforeEach(async () => {
       testHome = mkdtempSync(join(tmpdir(), 'orca-term-'))
       userDataPath = mkdtempSync(join(tmpdir(), 'orca-term-userdata-'))
-      getUserDataPathMock.mockReturnValue(userDataPath)
+      setTestUserDataPath(userDataPath)
     })
 
     afterEach(() => {
@@ -1516,7 +1537,7 @@ export MY_VAR=foo
     beforeEach(async () => {
       testHome = mkdtempSync(join(tmpdir(), 'orca-auto-'))
       userDataPath = mkdtempSync(join(tmpdir(), 'orca-auto-userdata-'))
-      getUserDataPathMock.mockReturnValue(userDataPath)
+      setTestUserDataPath(userDataPath)
     })
 
     afterEach(() => {

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -13,7 +13,6 @@
 import { tmpdir } from 'node:os'
 import { basename, win32 as pathWin32 } from 'node:path'
 import { mkdirSync, writeFileSync, chmodSync, existsSync } from 'node:fs'
-import { app } from 'electron'
 import type * as pty from 'node-pty'
 import {
   encodePowerShellCommand,
@@ -50,11 +49,11 @@ export type ShellReadySignal = {
 // ── Shell wrapper files ─────────────────────────────────────────────
 
 function getShellReadyWrapperRoot(): string {
-  // Why: this instance's userData must win over an inherited
-  // ORCA_USER_DATA_PATH (Orca launched from another Orca's terminal), so the
-  // wrapper writer root always matches the root buildPtyHostEnv hands to
-  // WSL children.
-  const userDataPath = app?.getPath?.('userData') ?? process.env.ORCA_USER_DATA_PATH ?? tmpdir()
+  // Why: bundled into daemon-entry.js (a plain-node fork with no electron
+  // require), so this must not import electron. Main canonicalizes
+  // ORCA_USER_DATA_PATH to its own userData at startup (configureOrcaUserDataPathEnv)
+  // and the daemon fork sets it explicitly, so the env value matches this root.
+  const userDataPath = process.env.ORCA_USER_DATA_PATH ?? tmpdir()
   return `${userDataPath}/shell-ready`
 }
 

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -436,6 +436,13 @@ const agentErrorSchema = z
   })
   .strict()
 
+// Why: emitted when the terminal daemon cannot start and terminals fall back to
+// the (non-persistent) local provider. Enum-only `error_class` — the raw daemon
+// stderr tail stays in local logs and never reaches the wire (paths/usernames).
+// A spike in this event is the fleet-wide signal for a daemon outage like
+// v1.4.129-rc.1, which was otherwise invisible until users filed bug reports.
+const daemonStartFailedSchema = z.object({ error_class: errorClassSchema }).strict()
+
 const settingsChangedSchema = z
   .object({
     setting_key: settingsChangedKeySchema,
@@ -1419,6 +1426,8 @@ export const eventSchemas = {
   agent_error: agentErrorSchema,
   agent_hook_install_failed: agentHookInstallFailedSchema,
   agent_hook_unattributed: agentHookUnattributedSchema,
+
+  daemon_start_failed: daemonStartFailedSchema,
 
   settings_changed: settingsChangedSchema,
 


### PR DESCRIPTION
## Why

**v1.4.129-rc.1** shipped a terminal daemon that exited at module load (an electron `require` leaked into its bundle graph — fixed in #7844) while **every CI check passed**. The app fell back to local PTYs silently, nothing executed the built daemon, and its startup stderr was discarded — so the outage was invisible until adopted old daemons died in the field.

This PR adds the defense layers around daemon startup that would have caught it:

**build guard (#7844) → per-PR CI boot → packaging smoke → field observability.**

> Stacked on #7844 — its commits appear in this PR until it merges. Merge #7844 first.

## A — native-smoke CI boots the built daemon (per PR)

`config/scripts/daemon-boot-smoke.mjs` forks the **built** `out/main/daemon-entry.js` under **plain Node** (the way production forks it under `ELECTRON_RUN_AS_NODE`) and:
- **hard-asserts** the `{ type: 'ready' }` IPC within 30s, and a clean shutdown (no hang/zombie);
- **best-effort** runs the daemon's own `ptySpawnHealth` RPC over the control socket (a real end-to-end PTY spawn), logging a skip rather than failing since node-pty spawn can be flaky on constrained runners.

Wired into the `native-smoke` job in `computer-e2e.yml` (matrix `ubuntu-22.04` + `windows-latest`, per PR) right after `build:electron-vite`. Daemon bundle-graph paths (`src/main/daemon/**`, `electron.vite.config.ts`, `build-plugins/**`, the smoke script) now re-trigger the workflow, and `computer-e2e-workflow.test.mjs` asserts the step + triggers exist.

node-pty is N-API (ABI-stable), so it loads under plain Node even when rebuilt for Electron — the `ready` assertion is safe on both runners.

## B — packaging-time daemon smoke (electron-builder afterPack)

`config/scripts/verify-packaged-daemon-entry.cjs` boots the **packaged** `app.asar.unpacked/out/main/daemon-entry.js` under plain Node in the existing `afterPack` hook, requiring the `Usage: daemon-entry` stderr and failing the build on `MODULE_NOT_FOUND` / a missing usage line. This is a module-load proof against the real packaged layout — it catches asar-unpack/bundling regressions the repo-tree build guard cannot see. Arch-gated to the host slice (daemon-entry.js is JS but requires the target-arch native node-pty, which the host Node cannot load cross-arch); cross-arch slices are skipped with a log.

## C — daemon startup stderr is no longer discarded

The daemon fork previously used `stdio: ['ignore','ignore','ignore','ipc']`, so a module-load crash surfaced only as "exited with code 1". Now:
- stderr is **piped**, a bounded (~8KB) tail is captured during the startup window, attached to the thrown failure error, and logged;
- the pipe is **released** (`off` + `destroy`) on `ready` so the detached daemon does not keep Electron's event loop alive;
- `daemon-entry` installs a `process.stderr.on('error', ...)` guard so a broken pipe (after the parent releases its end) cannot kill a healthy daemon.

Unit tests in `daemon-init.test.ts` cover both the capture-into-error path (the scope-C negative test) and the release-on-ready path.

## D — daemon-unavailable is loud, not silent

`onDaemonError` now logs a loud reason (carrying the captured stderr tail from C) and emits a low-cardinality `daemon_start_failed` telemetry event via the existing `track()` pipeline — `error_class` enum only, **no raw stderr on the wire** (paths/usernames stay local). A spike in this event is the fleet-wide signal for a daemon outage.

**No new UI:** there is no existing lightweight main->renderer toast/banner channel to reuse, and the spec said not to build new UI — surfacing this in-app is noted as a follow-up.

## Verification

Local (quick, targeted): `typecheck:node` passes; `daemon-init` + `telemetry` + `computer-e2e-workflow` suites pass; the boot smoke and the packaged-entry verifier were exercised against the built/synthetic layouts. Full build/test verification is delegated to this PR's CI (native-smoke on both OSes exercises A; unit suites exercise C/D).
