### PR TITLE
fix(agent-status): waiting state for Claude AskUserQuestion + stop stale-title worktree spinners

### DIFF
--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -93,6 +93,39 @@ describe('getWorktreeStatus', () => {
 
     expect(status).toBe('active')
   })
+
+  // Why: an exited agent can leave a frozen braille-spinner frame in the
+  // title forever (reproduced live: '⠐ Review branch for regressions' over a
+  // plain shell prompt). The row builder rejects that title as a Claude row
+  // (no explicit "claude" token), so the sidebar shows 0 agents — the worktree
+  // dot must agree instead of spinning on the unattributable title alone.
+  it('does not spin on a bare braille-spinner tab title that yields no agent row', () => {
+    const status = getWorktreeStatus(
+      [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+      [],
+      livePtyMap('tab-1')
+    )
+
+    expect(status).toBe('active')
+  })
+
+  it('does not spin on a bare braille-spinner pane title that yields no agent row', () => {
+    const status = getWorktreeStatus([{ id: 'tab-1', title: 'bash' }], [], livePtyMap('tab-1'), {
+      'tab-1': { 0: '⠐ Review branch for regressions', 1: 'bash' }
+    })
+
+    expect(status).toBe('active')
+  })
+
+  it('still spins on an agent-attributable braille-spinner title', () => {
+    const status = getWorktreeStatus(
+      [{ id: 'tab-1', title: '⠹ codex fix flaky test' }],
+      [],
+      livePtyMap('tab-1')
+    )
+
+    expect(status).toBe('working')
+  })
 })
 
 describe('resolveWorktreeStatus', () => {
@@ -328,6 +361,36 @@ describe('resolveWorktreeStatus', () => {
     })
 
     expect(status).toBe('done')
+  })
+
+  it('keeps a hook-backed working agent spinning despite an unattributable stale title', () => {
+    // Why: hook-managed agents drive the dot via hasLiveWorking, not the title
+    // heuristic — the attribution gate must not regress them.
+    const status = resolveWorktreeStatus({
+      tabs: [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+      browserTabs: [],
+      ptyIdsByTabId: livePtyMap('tab-1'),
+      hasPermission: false,
+      hasLiveWorking: true,
+      hasLiveDone: false,
+      hasRetainedDone: false
+    })
+
+    expect(status).toBe('working')
+  })
+
+  it('resolves a stale unattributable spinner title with no hook entry to active, not working', () => {
+    const status = resolveWorktreeStatus({
+      tabs: [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+      browserTabs: [],
+      ptyIdsByTabId: livePtyMap('tab-1'),
+      hasPermission: false,
+      hasLiveWorking: false,
+      hasLiveDone: false,
+      hasRetainedDone: false
+    })
+
+    expect(status).toBe('active')
   })
 
   it('falls through to active heuristic when nothing else applies', () => {

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -1,3 +1,4 @@
+import { resolveAgentTypeFromTerminalTitle } from '@/components/sidebar/worktree-title-derived-agent-rows'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { resolveRuntimePaneTitleLeafIdFromRoot } from '@/lib/runtime-pane-title-leaf-id'
@@ -91,7 +92,7 @@ function tabHasStatus(
       ) {
         continue
       }
-      if (classifyTitleActivity(title) === status) {
+      if (classifyTitleActivity(title) === status && titleStatusIsAgentAttributable(title)) {
         return true
       }
     }
@@ -103,7 +104,17 @@ function tabHasStatus(
   if (agentStatusPaneIds && agentStatusPaneIds.size > 0) {
     return false
   }
-  return classifyTitleActivity(tab.title) === status
+  return classifyTitleActivity(tab.title) === status && titleStatusIsAgentAttributable(tab.title)
+}
+
+// Why: the title heuristic is only a fallback — hook-managed agents promote the
+// worktree via hasLiveWorking/hasPermission in resolveWorktreeStatus, not here.
+// A bare braille-spinner title (e.g. an exited agent's never-cleared "⠐ task"
+// frame) classifies as working yet produces no sidebar agent row, spinning the
+// worktree forever with "0 agents". Require the same agent attribution the row
+// builder uses, so a title only spins the dot when it would also show a row.
+function titleStatusIsAgentAttributable(title: string): boolean {
+  return resolveAgentTypeFromTerminalTitle(title) !== null
 }
 
 export function getWorktreeStatusLabel(status: WorktreeStatus): string {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -170,11 +170,72 @@ describe('shared agent-hook-listener', () => {
     )
 
     expect(event?.payload.toolName).toBe('AskUserQuestion')
+    // Why: the auto-allowed AskUserQuestion PreToolUse is a human-input boundary,
+    // so it must read as waiting (amber attention) rather than a working spinner.
+    expect(event?.payload.state).toBe('waiting')
     const expected = JSON.stringify(questions)
     expect(event?.payload.interactivePrompt).toBe(expected)
     // Why: must NOT be truncated to the 160-char toolInput preview cap.
     expect(expected.length).toBeGreaterThan(200)
     expect(event?.payload.interactivePrompt!.length).toBe(expected.length)
+  })
+
+  it('maps Claude AskUserQuestion PreToolUse to waiting, then back to working on answer', () => {
+    const question = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'AskUserQuestion',
+          tool_input: { questions: [{ question: 'Pick', options: ['a', 'b'] }] }
+        }
+      },
+      'production'
+    )
+    const answered = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PostToolUse',
+          tool_name: 'AskUserQuestion',
+          tool_response: { selected: ['a'] }
+        }
+      },
+      'production'
+    )
+
+    expect(question?.payload).toMatchObject({
+      agentType: 'claude',
+      state: 'waiting',
+      toolName: 'AskUserQuestion'
+    })
+    expect(answered?.payload).toMatchObject({
+      agentType: 'claude',
+      state: 'working',
+      toolName: 'AskUserQuestion'
+    })
+  })
+
+  it('keeps a normal Claude PreToolUse tool call as working', () => {
+    const event = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' }
+        }
+      },
+      'production'
+    )
+    expect(event?.payload.state).toBe('working')
+    expect(event?.payload.toolName).toBe('Bash')
   })
 
   it('leaves interactivePrompt undefined for a normal tool call', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2162,13 +2162,21 @@ function normalizeClaudeEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
+  // Why: Claude's AskUserQuestion tool is auto-allowed, so it emits PreToolUse
+  // (not PermissionRequest) while blocked on a human answer — Claude posts a
+  // Notification instead of PermissionRequest, and Orca does not register the
+  // Notification hook. Treat that PreToolUse as waiting so the sidebar shows the
+  // amber attention state instead of a working spinner that decays to grey while
+  // the question sits unanswered. Mirrors normalizeKimiEvent's handling.
+  const isAskUserQuestion =
+    eventName === 'PreToolUse' && isAskUserQuestionTool(readString(hookPayload, 'tool_name'))
   const stateName =
     eventName === 'UserPromptSubmit' ||
-    eventName === 'PreToolUse' ||
     eventName === 'PostToolUse' ||
-    eventName === 'PostToolUseFailure'
+    eventName === 'PostToolUseFailure' ||
+    (eventName === 'PreToolUse' && !isAskUserQuestion)
       ? 'working'
-      : eventName === 'PermissionRequest'
+      : eventName === 'PermissionRequest' || isAskUserQuestion
         ? 'waiting'
         : eventName === 'Stop' || eventName === 'StopFailure'
           ? 'done'


### PR DESCRIPTION
## Problem

Two agent-status accuracy bugs, both reproduced against a live instance:

1. **Claude `AskUserQuestion` showed grey/idle** while the agent was actually waiting for the user to answer an interactive question. Its auto-allowed tool emits a `PreToolUse` (not `PermissionRequest`) while blocked, which `normalizeClaudeEvent` mapped to `working` — so the row showed a spinner that then decayed to grey.
2. **Worktree dot spun with "0 agents"** — a frozen braille-spinner title left by an exited agent (e.g. `⠐ Review branch for regressions` sitting over a plain shell prompt) kept `classifyTitleActivity` returning `working`, so the worktree top-level dot spun forever even though no agent was running and the sidebar showed 0 agent rows.

## Fix

- `src/shared/agent-hook-listener.ts` — map the auto-allowed `AskUserQuestion` `PreToolUse` to `waiting` (mirrors the existing Kimi/OpenCode handling, reuses `isAskUserQuestionTool`). Sidebar dot and worktree dot now read amber "Waiting for input" and stay durable instead of decaying to grey.
- `src/renderer/src/lib/worktree-status.ts` — gate `tabHasStatus`'s title-derived `working`/`permission` on agent attribution (`resolveAgentTypeFromTerminalTitle(title) !== null`), the same check the sidebar row builder uses. A title only spins the worktree dot when it would also produce an agent row. Hook-driven status (`hasLiveWorking`/`hasPermission`) is untouched, so real working/blocked agents are unaffected.

## Why the second gate is safe

Managed agents (Claude/Codex/Gemini/…) drive the worktree via their hook status, not the title heuristic — the title path is only a fallback. Gating it on attribution kills the unattributable stale-spinner case while leaving hook-backed agents spinning. Added tests cover: `⠐ Review branch for regressions` → not working; an attributable `⠹ codex …` title → working; and a hook-backed agent still working despite a stale unattributable title.

## Validation

- 102 tests pass across `agent-hook-listener`, `worktree-status`, `WorktreeCard`, `worktree-agent-activity-summary`, `AgentStateDot` (new tests reproduce the exact reported titles).
- oxlint + oxfmt clean (pre-commit), typecheck clean, no new `max-lines` suppressions.
- Not driven in the live Electron app: a frozen-spinner-over-shell state can't be reproduced deterministically at runtime, so validation rests on unit tests that reproduce the exact titles in both code branches.

Made with [Orca](https://github.com/stablyai/orca) 🐋
