### PR TITLE
Show empty sessions by default in AI Vault Panel

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -70,7 +70,7 @@ export default function AiVaultPanel(): React.JSX.Element {
   const [scope, setScope] = useState<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
   const [sort, setSort] = useState<AiVaultSort>('updated')
   const [group, setGroup] = useState<AiVaultGroup>('project')
-  const [hideEmptySessions, setHideEmptySessions] = useState(true)
+  const [hideEmptySessions, setHideEmptySessions] = useState(false)
   const [agents, setAgents] = useState<AiVaultAgent[]>([...AI_VAULT_AGENTS])
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set())
   const userChangedScopeRef = useRef(false)
@@ -160,7 +160,7 @@ export default function AiVaultPanel(): React.JSX.Element {
     (hasAllAgentsSelected ? 0 : 1) +
     (sort === 'updated' ? 0 : 1) +
     (group === 'project' ? 0 : 1) +
-    (hideEmptySessions ? 0 : 1)
+    (hideEmptySessions ? 1 : 0)
 
   // Workspace is the preferred default, but unavailable context still falls back to All.
   useEffect(() => {

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -20,6 +20,12 @@ import {
   getRestorableAiVaultScope,
   normalizeAiVaultScopeForContext
 } from './ai-vault-scope-state'
+import {
+  countAiVaultViewAdjustments,
+  DEFAULT_AI_VAULT_GROUP,
+  DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS,
+  DEFAULT_AI_VAULT_SORT
+} from './ai-vault-view-defaults'
 import { buildAiVaultProjectContext } from './ai-vault-session-projects'
 import {
   resolveAiVaultSessionResumeActions,
@@ -68,9 +74,9 @@ export default function AiVaultPanel(): React.JSX.Element {
     useAiVaultOriginalPaneActions()
   const [query, setQuery] = useState('')
   const [scope, setScope] = useState<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
-  const [sort, setSort] = useState<AiVaultSort>('updated')
-  const [group, setGroup] = useState<AiVaultGroup>('project')
-  const [hideEmptySessions, setHideEmptySessions] = useState(false)
+  const [sort, setSort] = useState<AiVaultSort>(DEFAULT_AI_VAULT_SORT)
+  const [group, setGroup] = useState<AiVaultGroup>(DEFAULT_AI_VAULT_GROUP)
+  const [hideEmptySessions, setHideEmptySessions] = useState(DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS)
   const [agents, setAgents] = useState<AiVaultAgent[]>([...AI_VAULT_AGENTS])
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set())
   const userChangedScopeRef = useRef(false)
@@ -155,12 +161,12 @@ export default function AiVaultPanel(): React.JSX.Element {
     targetState: resumeTargetState,
     agentCmdOverrides
   })
-  const hasAllAgentsSelected = agents.length === AI_VAULT_AGENTS.length
-  const viewAdjustmentCount =
-    (hasAllAgentsSelected ? 0 : 1) +
-    (sort === 'updated' ? 0 : 1) +
-    (group === 'project' ? 0 : 1) +
-    (hideEmptySessions ? 1 : 0)
+  const viewAdjustmentCount = countAiVaultViewAdjustments({
+    agents,
+    sort,
+    group,
+    hideEmptySessions
+  })
 
   // Workspace is the preferred default, but unavailable context still falls back to All.
   useEffect(() => {
@@ -286,9 +292,9 @@ export default function AiVaultPanel(): React.JSX.Element {
 
   const resetViewOptions = useCallback(() => {
     setAgents([...AI_VAULT_AGENTS])
-    setSort('updated')
-    setGroup('project')
-    setHideEmptySessions(true)
+    setSort(DEFAULT_AI_VAULT_SORT)
+    setGroup(DEFAULT_AI_VAULT_GROUP)
+    setHideEmptySessions(DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS)
   }, [])
 
   const handleScopeChange = useCallback((nextScope: AiVaultScope) => {

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { AI_VAULT_AGENTS } from '../../../../shared/ai-vault-types'
+import {
+  countAiVaultViewAdjustments,
+  DEFAULT_AI_VAULT_GROUP,
+  DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS,
+  DEFAULT_AI_VAULT_SORT
+} from './ai-vault-view-defaults'
+
+describe('ai-vault-view-defaults', () => {
+  it('shows empty sessions by default', () => {
+    expect(DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS).toBe(false)
+  })
+
+  it('counts zero adjustments for the default view', () => {
+    expect(
+      countAiVaultViewAdjustments({
+        agents: [...AI_VAULT_AGENTS],
+        sort: DEFAULT_AI_VAULT_SORT,
+        group: DEFAULT_AI_VAULT_GROUP,
+        hideEmptySessions: DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS
+      })
+    ).toBe(0)
+  })
+
+  it('treats hiding empty sessions as an adjustment from the new default', () => {
+    expect(
+      countAiVaultViewAdjustments({
+        agents: [...AI_VAULT_AGENTS],
+        sort: DEFAULT_AI_VAULT_SORT,
+        group: DEFAULT_AI_VAULT_GROUP,
+        hideEmptySessions: true
+      })
+    ).toBe(1)
+  })
+
+  it('does not count showing empty sessions as an adjustment', () => {
+    expect(
+      countAiVaultViewAdjustments({
+        agents: [...AI_VAULT_AGENTS],
+        sort: DEFAULT_AI_VAULT_SORT,
+        group: DEFAULT_AI_VAULT_GROUP,
+        hideEmptySessions: false
+      })
+    ).toBe(0)
+  })
+
+  it('counts other non-default view options independently', () => {
+    expect(
+      countAiVaultViewAdjustments({
+        agents: ['claude'],
+        sort: 'created',
+        group: 'agent',
+        hideEmptySessions: true
+      })
+    ).toBe(4)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.test.ts
@@ -45,6 +45,20 @@ describe('ai-vault-view-defaults', () => {
     ).toBe(0)
   })
 
+  it('counts an equal-length agent swap as an adjustment', () => {
+    // A swap keeps the array length but drops a default agent (here the first) for a duplicate.
+    const swapped = [...AI_VAULT_AGENTS.slice(1), AI_VAULT_AGENTS[1]]
+    expect(swapped).toHaveLength(AI_VAULT_AGENTS.length)
+    expect(
+      countAiVaultViewAdjustments({
+        agents: swapped,
+        sort: DEFAULT_AI_VAULT_SORT,
+        group: DEFAULT_AI_VAULT_GROUP,
+        hideEmptySessions: DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS
+      })
+    ).toBe(1)
+  })
+
   it('counts other non-default view options independently', () => {
     expect(
       countAiVaultViewAdjustments({

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.ts
@@ -1,0 +1,26 @@
+import {
+  AI_VAULT_AGENTS,
+  type AiVaultAgent,
+  type AiVaultGroup,
+  type AiVaultSort
+} from '../../../../shared/ai-vault-types'
+
+// Why: hide-empty used to default true; keep initial state, badge count, and Reset view
+// on one constant so a default flip cannot leave Reset pointing at the old value.
+export const DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS = false
+export const DEFAULT_AI_VAULT_SORT: AiVaultSort = 'updated'
+export const DEFAULT_AI_VAULT_GROUP: AiVaultGroup = 'project'
+
+export function countAiVaultViewAdjustments(options: {
+  agents: readonly AiVaultAgent[]
+  sort: AiVaultSort
+  group: AiVaultGroup
+  hideEmptySessions: boolean
+}): number {
+  return (
+    (options.agents.length === AI_VAULT_AGENTS.length ? 0 : 1) +
+    (options.sort === DEFAULT_AI_VAULT_SORT ? 0 : 1) +
+    (options.group === DEFAULT_AI_VAULT_GROUP ? 0 : 1) +
+    (options.hideEmptySessions === DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS ? 0 : 1)
+  )
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.ts
@@ -17,8 +17,11 @@ export function countAiVaultViewAdjustments(options: {
   group: AiVaultGroup
   hideEmptySessions: boolean
 }): number {
+  // Why: count by membership, not length — an agent swap keeps the array length but
+  // still deviates from the default of every agent enabled.
+  const allAgentsEnabled = AI_VAULT_AGENTS.every((agent) => options.agents.includes(agent))
   return (
-    (options.agents.length === AI_VAULT_AGENTS.length ? 0 : 1) +
+    (allAgentsEnabled ? 0 : 1) +
     (options.sort === DEFAULT_AI_VAULT_SORT ? 0 : 1) +
     (options.group === DEFAULT_AI_VAULT_GROUP ? 0 : 1) +
     (options.hideEmptySessions === DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS ? 0 : 1)


### PR DESCRIPTION
## Summary

Show empty sessions by default in the AI Vault Panel by setting `hideEmptySessions` to `false` by default.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

TODO

## Security Audit

TODO

## Notes

None