### PR TITLE
fix(terminal): arbitrate multi-desktop PTY size ownership

### DIFF
--- a/src/main/ipc/runtime.ts
+++ b/src/main/ipc/runtime.ts
@@ -48,7 +48,12 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   ipcMain.removeHandler('runtime:getTerminalFitOverrides')
   ipcMain.handle(
     'runtime:getTerminalFitOverrides',
-    (): { ptyId: string; mode: 'mobile-fit'; cols: number; rows: number }[] => {
+    (): {
+      ptyId: string
+      mode: 'mobile-fit' | 'remote-desktop-fit'
+      cols: number
+      rows: number
+    }[] => {
       const overrides = runtime.getAllTerminalFitOverrides()
       return Array.from(overrides.entries()).map(([ptyId, override]) => ({
         ptyId,

--- a/src/main/runtime/desktop-size-arbitration.test.ts
+++ b/src/main/runtime/desktop-size-arbitration.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Multi-desktop PTY size arbitration: host ↔ remote desktop must not
+ * last-writer-win via passive reassertion. Control resize claims ownership;
+ * observe (subscribe) does not; reclaim restores local ownership.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type * as GitUsernameModule from '../git/git-username'
+import { OrcaRuntimeService } from './orca-runtime'
+import { LOCAL_DESKTOP_CLIENT_ID } from './desktop-size-ownership'
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: vi.fn().mockResolvedValue([]),
+  listWorktreesStrict: vi.fn().mockResolvedValue([])
+}))
+vi.mock('../hooks', () => ({
+  createSetupRunnerScript: vi.fn(),
+  getEffectiveHooks: vi.fn().mockReturnValue(null),
+  runHook: vi.fn().mockResolvedValue({ success: true, output: '' })
+}))
+vi.mock('../ipc/worktree-logic', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, computeWorktreePath: vi.fn(), ensurePathWithinWorkspace: vi.fn() }
+})
+vi.mock('../ipc/filesystem-auth', () => ({ invalidateAuthorizedRootsCache: vi.fn() }))
+vi.mock('../git/repo', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    getDefaultBaseRef: vi.fn().mockReturnValue('origin/main'),
+    getBranchConflictKind: vi.fn().mockResolvedValue(null)
+  }
+})
+vi.mock('../git/git-username', async () => {
+  const actual = await vi.importActual<typeof GitUsernameModule>('../git/git-username')
+  return { ...actual, resolveLocalGitUsername: vi.fn(async () => '') }
+})
+
+const store = {
+  getRepo: () => ({
+    id: 'repo-1',
+    path: '/tmp/repo',
+    displayName: 'repo',
+    badgeColor: 'blue',
+    addedAt: 1
+  }),
+  getRepos: () => [store.getRepo()],
+  addRepo: () => {},
+  updateRepo: () => undefined as never,
+  getAllWorktreeMeta: () => ({}),
+  getWorktreeMeta: () => undefined,
+  getGitHubCache: () => ({ pr: {}, issue: {} }),
+  setWorktreeMeta: () => undefined as never,
+  removeWorktreeMeta: () => {},
+  getSettings: () => ({
+    workspaceDir: '/tmp/workspaces',
+    nestWorkspaces: false,
+    refreshLocalBaseRefOnWorktreeCreate: false,
+    branchPrefix: 'none',
+    branchPrefixCustom: '',
+    mobileAutoRestoreFitMs: 5_000
+  })
+}
+
+function createRuntime() {
+  const runtime = new OrcaRuntimeService(store)
+  const ptySizes = new Map<string, { cols: number; rows: number }>([
+    ['pty-1', { cols: 150, rows: 40 }]
+  ])
+  const resizes: { ptyId: string; cols: number; rows: number }[] = []
+  const fitOverrideEvents: { ptyId: string; mode: string; cols: number; rows: number }[] = []
+
+  runtime.setPtyController({
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    resize: (ptyId, cols, rows) => {
+      ptySizes.set(ptyId, { cols, rows })
+      resizes.push({ ptyId, cols, rows })
+      return true
+    },
+    getSize: (ptyId) => ptySizes.get(ptyId) ?? null
+  })
+  runtime.setNotifier({
+    worktreesChanged: vi.fn(),
+    reposChanged: vi.fn(),
+    activateWorktree: vi.fn(),
+    createTerminal: vi.fn(),
+    splitTerminal: vi.fn(),
+    renameTerminal: vi.fn(),
+    focusTerminal: vi.fn(),
+    closeTerminal: vi.fn(),
+    sleepWorktree: vi.fn(),
+    terminalFitOverrideChanged: (ptyId, mode, cols, rows) => {
+      fitOverrideEvents.push({ ptyId, mode, cols, rows })
+    },
+    terminalDriverChanged: vi.fn()
+  })
+
+  return { runtime, ptySizes, resizes, fitOverrideEvents }
+}
+
+describe('desktop size arbitration (multi-client)', () => {
+  it('observe intent does not resize, claim ownership, or pollute host restore baseline', async () => {
+    const { runtime, ptySizes, resizes } = createRuntime()
+    // Host claims first and records restore baseline.
+    runtime.onExternalPtyResize('pty-1', 150, 40)
+    expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 150, rows: 40 })
+
+    expect(
+      await runtime.updateDesktopViewport(
+        'pty-1',
+        { cols: 80, rows: 24 },
+        { clientId: 'desktop:b', intent: 'observe' }
+      )
+    ).toBe(true)
+
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    expect(resizes).toEqual([])
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe(LOCAL_DESKTOP_CLIENT_ID)
+    // Why (Codex #1): observe must not write lastRendererSizes.
+    expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 150, rows: 40 })
+  })
+
+  it('host restore after remote observe+control returns original host size', async () => {
+    const { runtime, ptySizes } = createRuntime()
+    runtime.onExternalPtyResize('pty-1', 150, 40)
+
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 80, rows: 24 },
+      { clientId: 'desktop:b', intent: 'observe' }
+    )
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 100, rows: 30 },
+      { clientId: 'desktop:b', intent: 'control' }
+    )
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 100, rows: 30 })
+
+    expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
+
+    // Not 80×24 (observe pollution) and not 100×30 (remote control).
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe(LOCAL_DESKTOP_CLIENT_ID)
+  })
+
+  it('remote control resize claims ownership and parks the host', async () => {
+    const { runtime, ptySizes, fitOverrideEvents } = createRuntime()
+    runtime.onExternalPtyResize('pty-1', 150, 40)
+    fitOverrideEvents.length = 0
+
+    expect(
+      await runtime.updateDesktopViewport(
+        'pty-1',
+        { cols: 100, rows: 30 },
+        { clientId: 'desktop:b', intent: 'control' }
+      )
+    ).toBe(true)
+
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 100, rows: 30 })
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe('desktop:b')
+    expect(fitOverrideEvents.at(-1)).toEqual({
+      ptyId: 'pty-1',
+      mode: 'remote-desktop-fit',
+      cols: 100,
+      rows: 30
+    })
+    expect(runtime.getFitHoldForViewer('pty-1', LOCAL_DESKTOP_CLIENT_ID).mode).toBe(
+      'remote-desktop-fit'
+    )
+    expect(runtime.getFitHoldForViewer('pty-1', 'desktop:b').mode).toBe('desktop-fit')
+  })
+
+  it('host reassertion echo of remote size does not reclaim ownership', async () => {
+    const { runtime, ptySizes } = createRuntime()
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 100, rows: 30 },
+      { clientId: 'desktop:b', intent: 'control' }
+    )
+
+    // Host parked at remote size; reassertion would echo 100×30.
+    runtime.onExternalPtyResize('pty-1', 100, 30)
+
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe('desktop:b')
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 100, rows: 30 })
+  })
+
+  it('host reclaim restores local size and clears remote hold', async () => {
+    const { runtime, ptySizes, fitOverrideEvents } = createRuntime()
+    runtime.onExternalPtyResize('pty-1', 150, 40)
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 100, rows: 30 },
+      { clientId: 'desktop:b', intent: 'control' }
+    )
+    fitOverrideEvents.length = 0
+
+    expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
+
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe(LOCAL_DESKTOP_CLIENT_ID)
+    expect(fitOverrideEvents.at(-1)?.mode).toBe('desktop-fit')
+    expect(runtime.getFitHoldForViewer('pty-1', 'desktop:b').mode).toBe('remote-desktop-fit')
+  })
+
+  it('host intentional resize reclaims from remote owner', async () => {
+    const { runtime, ptySizes, resizes } = createRuntime()
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 100, rows: 30 },
+      { clientId: 'desktop:b', intent: 'control' }
+    )
+    resizes.length = 0
+
+    // Simulate host pty:resize IPC: provider resize then onExternalPtyResize.
+    ptySizes.set('pty-1', { cols: 160, rows: 45 })
+    runtime.onExternalPtyResize('pty-1', 160, 45)
+
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe(LOCAL_DESKTOP_CLIENT_ID)
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 160, rows: 45 })
+  })
+
+  it('getAllTerminalFitOverrides includes remote-desktop holds for host hydrate', async () => {
+    const { runtime } = createRuntime()
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 90, rows: 28 },
+      { clientId: 'desktop:b', intent: 'control' }
+    )
+
+    const all = runtime.getAllTerminalFitOverrides()
+    expect(all.get('pty-1')).toEqual({
+      mode: 'remote-desktop-fit',
+      cols: 90,
+      rows: 28
+    })
+  })
+
+  it('does not regress mobile-fit priority over remote desktop ownership', async () => {
+    const { runtime, ptySizes } = createRuntime()
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+
+    expect(
+      await runtime.updateDesktopViewport(
+        'pty-1',
+        { cols: 120, rows: 40 },
+        { clientId: 'desktop:b', intent: 'control' }
+      )
+    ).toBe(true)
+
+    // Measurement only while phone holds.
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    expect(runtime.getTerminalFitOverride('pty-1')?.mode).toBe('mobile-fit')
+  })
+})

--- a/src/main/runtime/desktop-size-arbitration.test.ts
+++ b/src/main/runtime/desktop-size-arbitration.test.ts
@@ -237,11 +237,8 @@ describe('desktop size arbitration (multi-client)', () => {
     })
   })
 
-  it('does not regress mobile-fit priority over remote desktop ownership', async () => {
-    const { runtime, ptySizes } = createRuntime()
-    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
-    expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
-
+  it('releases remote ownership without disturbing mobile-fit priority', async () => {
+    const { runtime, ptySizes, resizes } = createRuntime()
     expect(
       await runtime.updateDesktopViewport(
         'pty-1',
@@ -249,10 +246,38 @@ describe('desktop size arbitration (multi-client)', () => {
         { clientId: 'desktop:b', intent: 'control' }
       )
     ).toBe(true)
-
-    // Measurement only while phone holds.
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
     expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    resizes.length = 0
+
+    expect(runtime.releaseRemoteDesktopSizeOwner('pty-1', 'desktop:b')).toBe(true)
+
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+    expect(resizes).toEqual([])
+    expect(runtime.getDesktopSizeOwner('pty-1')).toBeNull()
     expect(runtime.getTerminalFitOverride('pty-1')?.mode).toBe('mobile-fit')
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-A' })
+  })
+
+  it('releases only the expected remote owner and restores host size', async () => {
+    const { runtime, ptySizes, fitOverrideEvents } = createRuntime()
+    runtime.onExternalPtyResize('pty-1', 150, 40)
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 100, rows: 30 },
+      { clientId: 'desktop:tab-b:leaf-b', intent: 'control' }
+    )
+    fitOverrideEvents.length = 0
+
+    expect(runtime.releaseRemoteDesktopSizeOwner('pty-1', 'desktop:tab-a:leaf-a')).toBe(false)
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 100, rows: 30 })
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe('desktop:tab-b:leaf-b')
+    expect(fitOverrideEvents).toEqual([])
+
+    expect(runtime.releaseRemoteDesktopSizeOwner('pty-1', 'desktop:tab-b:leaf-b')).toBe(true)
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe(LOCAL_DESKTOP_CLIENT_ID)
+    expect(fitOverrideEvents.at(-1)?.mode).toBe('desktop-fit')
   })
 
   it('remote owner disconnect restores host size and clears the hold overlay', async () => {

--- a/src/main/runtime/desktop-size-arbitration.test.ts
+++ b/src/main/runtime/desktop-size-arbitration.test.ts
@@ -254,4 +254,41 @@ describe('desktop size arbitration (multi-client)', () => {
     expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
     expect(runtime.getTerminalFitOverride('pty-1')?.mode).toBe('mobile-fit')
   })
+
+  it('remote owner disconnect restores host size and clears the hold overlay', async () => {
+    const { runtime, ptySizes, fitOverrideEvents } = createRuntime()
+    runtime.onExternalPtyResize('pty-1', 150, 40)
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 100, rows: 30 },
+      { clientId: 'desktop:b', intent: 'control' }
+    )
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe('desktop:b')
+    fitOverrideEvents.length = 0
+
+    runtime.onClientDisconnected('desktop:b')
+
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe(LOCAL_DESKTOP_CLIENT_ID)
+    expect(fitOverrideEvents.at(-1)?.mode).toBe('desktop-fit')
+    expect(runtime.getFitHoldForViewer('pty-1', LOCAL_DESKTOP_CLIENT_ID).mode).toBe('desktop-fit')
+  })
+
+  it('observe under phone-fit does not poison host restore baseline', async () => {
+    const { runtime, ptySizes } = createRuntime()
+    runtime.onExternalPtyResize('pty-1', 150, 40)
+    expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 150, rows: 40 })
+
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+
+    // Remote subscribe observe while phone holds — must not rewrite baseline.
+    await runtime.updateDesktopViewport(
+      'pty-1',
+      { cols: 80, rows: 24 },
+      { clientId: 'desktop:b', intent: 'observe' }
+    )
+    expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 150, rows: 40 })
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
+  })
 })

--- a/src/main/runtime/desktop-size-ownership.test.ts
+++ b/src/main/runtime/desktop-size-ownership.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fitHoldModeForLocalHost,
+  fitHoldModeForViewer,
+  isLocalDesktopOwner,
+  LOCAL_DESKTOP_CLIENT_ID
+} from './desktop-size-ownership'
+
+describe('desktop-size-ownership', () => {
+  it('parks non-owners and clears the owner', () => {
+    expect(fitHoldModeForViewer('desktop:a', 'desktop:a')).toBe('desktop-fit')
+    expect(fitHoldModeForViewer('desktop:a', 'desktop:b')).toBe('remote-desktop-fit')
+    expect(fitHoldModeForViewer(LOCAL_DESKTOP_CLIENT_ID, 'desktop:b')).toBe('remote-desktop-fit')
+    expect(fitHoldModeForLocalHost('desktop:remote-1')).toBe('remote-desktop-fit')
+    expect(fitHoldModeForLocalHost(LOCAL_DESKTOP_CLIENT_ID)).toBe('desktop-fit')
+  })
+
+  it('treats missing owner as local', () => {
+    expect(isLocalDesktopOwner(null)).toBe(true)
+    expect(isLocalDesktopOwner(undefined)).toBe(true)
+    expect(isLocalDesktopOwner(LOCAL_DESKTOP_CLIENT_ID)).toBe(true)
+    expect(isLocalDesktopOwner('desktop:other')).toBe(false)
+  })
+})

--- a/src/main/runtime/desktop-size-ownership.ts
+++ b/src/main/runtime/desktop-size-ownership.ts
@@ -1,0 +1,35 @@
+// Why: shared PTYs can be rendered by multiple desktop clients (host + remote
+// Orca windows). Without arbitration, each client's safeFit/reassertion path
+// races to write cols/rows and the last writer wins — a permanent tug-of-war.
+// Size ownership is sticky: the controlling client owns the PTY grid; non-owners
+// park their xterm at the owner's size and must not reassert. See multi-client
+// desktop PTY size brief (2026-07-09).
+
+export const LOCAL_DESKTOP_CLIENT_ID = 'local'
+
+export type DesktopSizeOwner = {
+  clientId: string
+  cols: number
+  rows: number
+  updatedAt: number
+}
+
+/** Wire + renderer modes for the fit-hold overlay / park signal. */
+export type TerminalFitHoldMode = 'mobile-fit' | 'remote-desktop-fit' | 'desktop-fit'
+
+/**
+ * What fit-hold a viewer should apply for the current owner.
+ * Owners get `desktop-fit` (no park); non-owners park at the owner's grid.
+ */
+export function fitHoldModeForViewer(ownerClientId: string, viewerClientId: string): TerminalFitHoldMode {
+  return ownerClientId === viewerClientId ? 'desktop-fit' : 'remote-desktop-fit'
+}
+
+/** Host Electron renderer is the local owner; everyone else is a remote viewer. */
+export function fitHoldModeForLocalHost(ownerClientId: string): TerminalFitHoldMode {
+  return fitHoldModeForViewer(ownerClientId, LOCAL_DESKTOP_CLIENT_ID)
+}
+
+export function isLocalDesktopOwner(ownerClientId: string | null | undefined): boolean {
+  return ownerClientId == null || ownerClientId === LOCAL_DESKTOP_CLIENT_ID
+}

--- a/src/main/runtime/mobile-presence-lock.test.ts
+++ b/src/main/runtime/mobile-presence-lock.test.ts
@@ -363,14 +363,17 @@ describe('mobile presence lock — multi-mobile semantics', () => {
     expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
   })
 
-  it('updateDesktopViewport resizes the source PTY and records desktop geometry', async () => {
+  it('updateDesktopViewport resizes the source PTY without clobbering host restore baseline', async () => {
     const { runtime, ptySizes, resizes } = createRuntime()
 
     expect(await runtime.updateDesktopViewport('pty-1', { cols: 132, rows: 44 })).toBe(true)
 
     expect(ptySizes.get('pty-1')).toEqual({ cols: 132, rows: 44 })
     expect(resizes.at(-1)).toEqual({ ptyId: 'pty-1', cols: 132, rows: 44 })
-    expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 132, rows: 44 })
+    // Why: lastRendererSizes is the host reclaim baseline. Remote control
+    // stashes the pre-remote grid once and must not overwrite it with the
+    // remote pane dims (multi-desktop size arbitration).
+    expect(runtime.getLastRendererSize('pty-1')).toEqual({ cols: 150, rows: 40 })
   })
 
   it('updateMobileViewport records viewport without applying layout in desktop mode', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5872,6 +5872,61 @@ export class OrcaRuntimeService {
     this.desktopSizeOwners.delete(ptyId)
   }
 
+  /**
+   * Release a remote desktop size owner and restore host geometry when safe.
+   * Used by explicit host reclaim and by client disconnect so a closed window
+   * cannot leave host/viewers parked on a dead client's grid.
+   */
+  private releaseRemoteDesktopSizeOwner(
+    ptyId: string,
+    expectedClientId?: string
+  ): boolean {
+    const owner = this.desktopSizeOwners.get(ptyId)
+    if (!owner || isLocalDesktopOwner(owner.clientId)) {
+      return false
+    }
+    if (expectedClientId != null && owner.clientId !== expectedClientId) {
+      return false
+    }
+    // Why: phone still owns layout. Drop the desktop-owner map entry only —
+    // do not SIGWINCH away from phone dims mid-session.
+    if (this.terminalFitOverrides.has(ptyId) || this.getDriver(ptyId).kind === 'mobile') {
+      this.clearDesktopSizeOwner(ptyId)
+      return true
+    }
+    const fallback = this.resolveDesktopRestoreTarget(ptyId)
+    const renderer = this.lastRendererSizes.get(ptyId)
+    const cols = renderer?.cols ?? fallback.cols
+    const rows = renderer?.rows ?? fallback.rows
+    let resized = false
+    try {
+      resized = this.ptyController?.resize?.(ptyId, cols, rows) ?? false
+    } catch {
+      resized = false
+    }
+    if (!resized) {
+      // Why: still drop ownership so the "another desktop" overlay cannot
+      // name a client that is already gone; dims may lag until next fit.
+      this.clearDesktopSizeOwner(ptyId)
+      const size = this.getTerminalSize(ptyId)
+      this.notifier?.terminalFitOverrideChanged(
+        ptyId,
+        'desktop-fit',
+        size?.cols ?? 0,
+        size?.rows ?? 0
+      )
+      this.notifyFitOverrideListeners(ptyId, 'desktop-fit', size?.cols ?? 0, size?.rows ?? 0)
+      return false
+    }
+    this.resizeHeadlessTerminal(ptyId, cols, rows)
+    // Why: same as the pre-extraction reclaim path — refresh mobile subscriber
+    // previousCols/Rows baselines now rather than waiting for the next host
+    // onExternalPtyResize. No-op when lastRendererSizes already matches.
+    this.refreshRendererGeometry(ptyId, cols, rows)
+    this.claimDesktopSizeOwner(ptyId, LOCAL_DESKTOP_CLIENT_ID, cols, rows)
+    return true
+  }
+
   serializeTerminalBuffer(
     ptyId: string,
     opts: { scrollbackRows?: number } = {}
@@ -7268,6 +7323,20 @@ export class OrcaRuntimeService {
       const rows = override.previousRows ?? fallback.rows
       void this.enqueueLayout(ptyId, { kind: 'desktop', cols, rows })
     }
+
+    // (6) Multi-desktop size ownership. A remote that claimed the PTY grid
+    // then closed must not leave host/viewers parked on a dead client's size
+    // with a permanent "another desktop" overlay. Restore host geometry when
+    // phone is not driving; otherwise only drop the owner map entry.
+    const ownedDesktopPtys: string[] = []
+    for (const [ptyId, owner] of this.desktopSizeOwners) {
+      if (owner.clientId === clientId && !isLocalDesktopOwner(owner.clientId)) {
+        ownedDesktopPtys.push(ptyId)
+      }
+    }
+    for (const ptyId of ownedDesktopPtys) {
+      this.releaseRemoteDesktopSizeOwner(ptyId, clientId)
+    }
   }
 
   onPtyExit(ptyId: string, exitCode: number): void {
@@ -7501,17 +7570,17 @@ export class OrcaRuntimeService {
     const { cols, rows } = clampTerminalViewport(viewport.cols, viewport.rows)
     const clientId = options?.clientId ?? 'remote-unknown'
     const intent = options?.intent ?? 'control'
-    if (this.terminalFitOverrides.has(ptyId)) {
-      // Why: remote desktop panes do not have the local pty:reportGeometry
-      // IPC. While phone-fit holds the PTY, treat their viewport RPC as a
-      // measurement-only restore target, not a resize intent.
-      this.recordRendererGeometry(ptyId, cols, rows)
+    // Why: observe is pure for *all* cases, including phone-fit. Checking
+    // terminalFitOverrides first used to let subscribe viewports (e.g. 80×24)
+    // overwrite lastRendererSizes during a phone session and poison host
+    // restore after take-back.
+    if (intent === 'observe') {
       return true
     }
-    if (intent === 'observe') {
-      // Why: pure observation — must not touch lastRendererSizes. That map is
-      // the host reclaim baseline; a remote subscribe viewport (e.g. 80×24)
-      // must not pollute restore after a later remote control (100×30).
+    if (this.terminalFitOverrides.has(ptyId)) {
+      // Why: control while phone-fit holds is still measurement-only for the
+      // host restore baseline (no local pty:reportGeometry on remote panes).
+      this.recordRendererGeometry(ptyId, cols, rows)
       return true
     }
     if (this.isResizeSuppressed() || this.getDriver(ptyId).kind === 'mobile') {
@@ -7592,23 +7661,7 @@ export class OrcaRuntimeService {
     // is free again and remotes re-park at the host size.
     const remoteOwner = this.desktopSizeOwners.get(ptyId)
     if (remoteOwner && !isLocalDesktopOwner(remoteOwner.clientId)) {
-      const fallback = this.resolveDesktopRestoreTarget(ptyId)
-      const renderer = this.lastRendererSizes.get(ptyId)
-      const cols = renderer?.cols ?? fallback.cols
-      const rows = renderer?.rows ?? fallback.rows
-      let resized = false
-      try {
-        resized = this.ptyController?.resize?.(ptyId, cols, rows) ?? false
-      } catch {
-        resized = false
-      }
-      if (!resized) {
-        return false
-      }
-      this.resizeHeadlessTerminal(ptyId, cols, rows)
-      this.refreshRendererGeometry(ptyId, cols, rows)
-      this.claimDesktopSizeOwner(ptyId, LOCAL_DESKTOP_CLIENT_ID, cols, rows)
-      return true
+      return this.releaseRemoteDesktopSizeOwner(ptyId, remoteOwner.clientId)
     }
     const heldOverride = this.terminalFitOverrides.get(ptyId)
     if (heldOverride) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5874,18 +5874,14 @@ export class OrcaRuntimeService {
 
   /**
    * Release a remote desktop size owner and restore host geometry when safe.
-   * Used by explicit host reclaim and by client disconnect so a closed window
-   * cannot leave host/viewers parked on a dead client's grid.
+   * The expected owner keeps delayed pane detach from releasing a newer claim.
    */
-  private releaseRemoteDesktopSizeOwner(
-    ptyId: string,
-    expectedClientId?: string
-  ): boolean {
+  releaseRemoteDesktopSizeOwner(ptyId: string, expectedClientId: string): boolean {
     const owner = this.desktopSizeOwners.get(ptyId)
     if (!owner || isLocalDesktopOwner(owner.clientId)) {
       return false
     }
-    if (expectedClientId != null && owner.clientId !== expectedClientId) {
+    if (owner.clientId !== expectedClientId) {
       return false
     }
     // Why: phone still owns layout. Drop the desktop-owner map entry only —

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -716,6 +716,14 @@ import {
   resolveNestedRepoSelection
 } from '../project-groups/nested-repo-import'
 import { createNestedRepoImportTargetResolver } from '../project-groups/nested-repo-import-target'
+import {
+  fitHoldModeForLocalHost,
+  fitHoldModeForViewer,
+  isLocalDesktopOwner,
+  LOCAL_DESKTOP_CLIENT_ID,
+  type DesktopSizeOwner,
+  type TerminalFitHoldMode
+} from './desktop-size-ownership'
 
 function sanitizeNestedRepoRuntimeImportError(context: string, error: unknown): string {
   console.warn(`[project-groups] ${context}`, error)
@@ -1306,7 +1314,7 @@ type RuntimeNotifier = {
   resumeSleepingAgents?(worktreeId: string): void
   terminalFitOverrideChanged(
     ptyId: string,
-    mode: 'mobile-fit' | 'desktop-fit',
+    mode: TerminalFitHoldMode,
     cols: number,
     rows: number
   ): void
@@ -2101,8 +2109,12 @@ export class OrcaRuntimeService {
   // invoked from resizeForClient and onClientDisconnected/onPtyExit.
   private fitOverrideListeners = new Map<
     string,
-    Set<(event: { mode: 'mobile-fit' | 'desktop-fit'; cols: number; rows: number }) => void>
+    Set<(event: { mode: TerminalFitHoldMode; cols: number; rows: number }) => void>
   >()
+  // Why: multi-desktop size arbitration. Keyed by ptyId → last client that
+  // successfully control-resized the PTY (`local` = host Electron renderer).
+  // Non-owners park via remote-desktop-fit and must not reassert.
+  private desktopSizeOwners = new Map<string, DesktopSizeOwner>()
   private driverListeners = new Map<string, Set<(driver: DriverState) => void>>()
   private subscriptionCleanups = new Map<string, () => void>()
   // Why: index of subscriptionIds by per-WebSocket connectionId so the
@@ -5771,7 +5783,7 @@ export class OrcaRuntimeService {
 
   subscribeToFitOverrideChanges(
     ptyId: string,
-    listener: (event: { mode: 'mobile-fit' | 'desktop-fit'; cols: number; rows: number }) => void
+    listener: (event: { mode: TerminalFitHoldMode; cols: number; rows: number }) => void
   ): () => void {
     return addListenerToMap(this.fitOverrideListeners, ptyId, listener)
   }
@@ -5782,7 +5794,7 @@ export class OrcaRuntimeService {
 
   private notifyFitOverrideListeners(
     ptyId: string,
-    mode: 'mobile-fit' | 'desktop-fit',
+    mode: TerminalFitHoldMode,
     cols: number,
     rows: number
   ): void {
@@ -5793,6 +5805,71 @@ export class OrcaRuntimeService {
     for (const listener of listeners) {
       listener({ mode, cols, rows })
     }
+  }
+
+  // Why: per-viewer fit hold for multi-desktop arbitration. Mobile-fit still
+  // wins when present; otherwise non-owners park at the desktop size owner's
+  // grid and the owner stays free to refit.
+  getFitHoldForViewer(
+    ptyId: string,
+    viewerClientId: string
+  ): { mode: TerminalFitHoldMode; cols: number; rows: number } {
+    const mobile = this.terminalFitOverrides.get(ptyId)
+    if (mobile) {
+      return { mode: 'mobile-fit', cols: mobile.cols, rows: mobile.rows }
+    }
+    const owner = this.desktopSizeOwners.get(ptyId)
+    const size = this.getTerminalSize(ptyId)
+    const cols = owner?.cols ?? size?.cols ?? 0
+    const rows = owner?.rows ?? size?.rows ?? 0
+    if (!owner) {
+      return { mode: 'desktop-fit', cols, rows }
+    }
+    return {
+      mode: fitHoldModeForViewer(owner.clientId, viewerClientId),
+      cols,
+      rows
+    }
+  }
+
+  getDesktopSizeOwner(ptyId: string): DesktopSizeOwner | null {
+    return this.desktopSizeOwners.get(ptyId) ?? null
+  }
+
+  private claimDesktopSizeOwner(ptyId: string, clientId: string, cols: number, rows: number): void {
+    const prev = this.desktopSizeOwners.get(ptyId)
+    if (prev && prev.clientId === clientId && prev.cols === cols && prev.rows === rows) {
+      return
+    }
+    this.desktopSizeOwners.set(ptyId, {
+      clientId,
+      cols,
+      rows,
+      updatedAt: Date.now()
+    })
+    // Why: mobile-fit is a higher-priority hold; do not clobber its park signal
+    // with a desktop multi-client hold while a phone still owns the floor.
+    if (this.terminalFitOverrides.has(ptyId)) {
+      return
+    }
+    const prevHostMode = prev ? fitHoldModeForLocalHost(prev.clientId) : 'desktop-fit'
+    const hostMode = fitHoldModeForLocalHost(clientId)
+    // Why: routine host refits while local still owns must not fan out
+    // desktop-fit events (they trigger renderer cascade suppress). Only
+    // owner flips and remote-held dim changes need a park/release signal.
+    const shouldNotifyHost =
+      prevHostMode !== hostMode ||
+      (hostMode === 'remote-desktop-fit' && (prev?.cols !== cols || prev?.rows !== rows))
+    if (shouldNotifyHost) {
+      this.notifier?.terminalFitOverrideChanged(ptyId, hostMode, cols, rows)
+    }
+    // Why: multiplex viewers each compute their own hold via getFitHoldForViewer;
+    // always notify so remote owner/non-owner streams can re-park or release.
+    this.notifyFitOverrideListeners(ptyId, hostMode, cols, rows)
+  }
+
+  private clearDesktopSizeOwner(ptyId: string): void {
+    this.desktopSizeOwners.delete(ptyId)
   }
 
   serializeTerminalBuffer(
@@ -6983,10 +7060,28 @@ export class OrcaRuntimeService {
     return this.terminalFitOverrides.get(ptyId) ?? null
   }
 
-  getAllTerminalFitOverrides(): Map<string, { mode: 'mobile-fit'; cols: number; rows: number }> {
-    const result = new Map<string, { mode: 'mobile-fit'; cols: number; rows: number }>()
+  getAllTerminalFitOverrides(): Map<
+    string,
+    { mode: 'mobile-fit' | 'remote-desktop-fit'; cols: number; rows: number }
+  > {
+    const result = new Map<
+      string,
+      { mode: 'mobile-fit' | 'remote-desktop-fit'; cols: number; rows: number }
+    >()
     for (const [ptyId, override] of this.terminalFitOverrides) {
       result.set(ptyId, { mode: override.mode, cols: override.cols, rows: override.rows })
+    }
+    // Why: host renderer hydrates remote-desktop holds the same way as phone
+    // holds so a reload mid-tug-of-war re-parks instead of reasserting.
+    for (const [ptyId, owner] of this.desktopSizeOwners) {
+      if (result.has(ptyId) || isLocalDesktopOwner(owner.clientId)) {
+        continue
+      }
+      result.set(ptyId, {
+        mode: 'remote-desktop-fit',
+        cols: owner.cols,
+        rows: owner.rows
+      })
     }
     return result
   }
@@ -7223,6 +7318,14 @@ export class OrcaRuntimeService {
       this.notifier?.terminalFitOverrideChanged(ptyId, 'desktop-fit', 0, 0)
       this.notifyFitOverrideListeners(ptyId, 'desktop-fit', 0, 0)
     }
+    const desktopOwner = this.desktopSizeOwners.get(ptyId)
+    if (desktopOwner && !isLocalDesktopOwner(desktopOwner.clientId)) {
+      this.clearDesktopSizeOwner(ptyId)
+      this.notifier?.terminalFitOverrideChanged(ptyId, 'desktop-fit', 0, 0)
+      this.notifyFitOverrideListeners(ptyId, 'desktop-fit', 0, 0)
+    } else {
+      this.clearDesktopSizeOwner(ptyId)
+    }
     // Why: clear driver state and notify the renderer so any lock banner on
     // this dead pane unmounts. Without this, the pane shows a stuck banner
     // until tab teardown, and `getDriver(deadPtyId)` would keep returning a
@@ -7387,13 +7490,17 @@ export class OrcaRuntimeService {
   }
 
   // Why: remote desktop clients do not have the local `pty:resize` IPC path.
-  // Their measured xterm size still has to resize the source PTY so TUIs
-  // reflow to the visible client dimensions.
+  // Control-intent viewports claim size ownership so TUIs reflow to the
+  // controlling client's grid; observe-intent (subscribe) only records geometry
+  // so opening a second desktop does not steal size from the host.
   async updateDesktopViewport(
     ptyId: string,
-    viewport: { cols: number; rows: number }
+    viewport: { cols: number; rows: number },
+    options?: { clientId?: string; intent?: 'observe' | 'control' }
   ): Promise<boolean> {
     const { cols, rows } = clampTerminalViewport(viewport.cols, viewport.rows)
+    const clientId = options?.clientId ?? 'remote-unknown'
+    const intent = options?.intent ?? 'control'
     if (this.terminalFitOverrides.has(ptyId)) {
       // Why: remote desktop panes do not have the local pty:reportGeometry
       // IPC. While phone-fit holds the PTY, treat their viewport RPC as a
@@ -7401,8 +7508,28 @@ export class OrcaRuntimeService {
       this.recordRendererGeometry(ptyId, cols, rows)
       return true
     }
+    if (intent === 'observe') {
+      // Why: pure observation — must not touch lastRendererSizes. That map is
+      // the host reclaim baseline; a remote subscribe viewport (e.g. 80×24)
+      // must not pollute restore after a later remote control (100×30).
+      return true
+    }
     if (this.isResizeSuppressed() || this.getDriver(ptyId).kind === 'mobile') {
       return false
+    }
+    // Why: control intent is only sent after the client unparks (intentional
+    // layout change). Passive safeFit while remote-desktop-fit is held is
+    // suppressed client-side, so accepting control here is last-writer among
+    // intentional actors — not the reassertion tug-of-war.
+    // Why: lastRendererSizes is the host restore baseline. Stash the pre-remote
+    // grid once so reclaim does not fall back to the remote dims we are about
+    // to apply.
+    const priorSize = this.getTerminalSize(ptyId)
+    if (priorSize && !this.lastRendererSizes.has(ptyId)) {
+      this.lastRendererSizes.set(ptyId, {
+        cols: priorSize.cols,
+        rows: priorSize.rows
+      })
     }
     let resized = false
     try {
@@ -7413,7 +7540,10 @@ export class OrcaRuntimeService {
     if (!resized) {
       return false
     }
-    this.onExternalPtyResize(ptyId, cols, rows)
+    // Why: do not route through onExternalPtyResize — that claims *local*
+    // ownership and would overwrite lastRendererSizes with remote dims.
+    this.resizeHeadlessTerminal(ptyId, cols, rows)
+    this.claimDesktopSizeOwner(ptyId, clientId, cols, rows)
     return true
   }
 
@@ -7455,6 +7585,29 @@ export class OrcaRuntimeService {
       // switches back to the terminal tab on the phone) must default to
       // phone-fit again, not stay in passive desktop-watch mode.
       this.setMobileDisplayMode(ptyId, 'auto')
+      return true
+    }
+    // Why: multi-desktop size hold (remote client owns the grid). Restore to
+    // host geometry and reclaim local ownership so the host reassertion path
+    // is free again and remotes re-park at the host size.
+    const remoteOwner = this.desktopSizeOwners.get(ptyId)
+    if (remoteOwner && !isLocalDesktopOwner(remoteOwner.clientId)) {
+      const fallback = this.resolveDesktopRestoreTarget(ptyId)
+      const renderer = this.lastRendererSizes.get(ptyId)
+      const cols = renderer?.cols ?? fallback.cols
+      const rows = renderer?.rows ?? fallback.rows
+      let resized = false
+      try {
+        resized = this.ptyController?.resize?.(ptyId, cols, rows) ?? false
+      } catch {
+        resized = false
+      }
+      if (!resized) {
+        return false
+      }
+      this.resizeHeadlessTerminal(ptyId, cols, rows)
+      this.refreshRendererGeometry(ptyId, cols, rows)
+      this.claimDesktopSizeOwner(ptyId, LOCAL_DESKTOP_CLIENT_ID, cols, rows)
       return true
     }
     const heldOverride = this.terminalFitOverrides.get(ptyId)
@@ -8308,6 +8461,8 @@ export class OrcaRuntimeService {
   // Why: called after a desktop renderer path has successfully resized the
   // PTY (local IPC or remote desktop viewport). The runtime mirror must take
   // the same accepted geometry so hidden-output restore parses at PTY width.
+  // Local host resizes also claim desktop size ownership so a later remote
+  // reassert cannot silently keep a stale remote-desktop-fit hold.
   onExternalPtyResize(ptyId: string, cols: number, rows: number): void {
     // The pty:resize IPC handler is supposed to gate via `isResizeSuppressed`
     // before calling here, but defend against callers that don't.
@@ -8327,8 +8482,21 @@ export class OrcaRuntimeService {
     if (activeOverride && activeOverride.cols === cols && activeOverride.rows === rows) {
       return
     }
+    // Why: while a remote desktop owns size, the host renderer parks xterm at
+    // the remote grid and must not reclaim via passive reassertion. Intentional
+    // host layout changes clear the park client-side before calling pty:resize.
+    const desktopOwner = this.desktopSizeOwners.get(ptyId)
+    if (
+      desktopOwner &&
+      !isLocalDesktopOwner(desktopOwner.clientId) &&
+      desktopOwner.cols === cols &&
+      desktopOwner.rows === rows
+    ) {
+      return
+    }
     this.resizeHeadlessTerminal(ptyId, cols, rows)
     this.refreshRendererGeometry(ptyId, cols, rows)
+    this.claimDesktopSizeOwner(ptyId, LOCAL_DESKTOP_CLIENT_ID, cols, rows)
   }
 
   // Why: pty:reportGeometry IPC sibling. The renderer calls this when a

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1277,6 +1277,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         stream.exitWaiterAbort.abort()
         if (stream.isMobile && stream.client?.id) {
           runtime.handleMobileUnsubscribe(stream.ptyId, stream.client.id)
+        } else if (stream.client?.id) {
+          runtime.releaseRemoteDesktopSizeOwner(stream.ptyId, stream.client.id)
         }
         if (emitEnd) {
           emit({ type: 'end', streamId })

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -561,13 +561,17 @@ async function updateViewportForClient(
   ptyId: string,
   client: TerminalViewportClient,
   viewport: { cols: number; rows: number },
-  defaultType: 'mobile' | 'desktop'
+  defaultType: 'mobile' | 'desktop',
+  intent: 'observe' | 'control' = 'control'
 ): Promise<{ updated: boolean; applied: boolean }> {
   const type = client.type ?? defaultType
   if (type === 'mobile') {
     return runtime.updateMobileViewport(ptyId, client.id, viewport)
   }
-  const updated = await runtime.updateDesktopViewport(ptyId, viewport)
+  const updated = await runtime.updateDesktopViewport(ptyId, viewport, {
+    clientId: client.id,
+    intent
+  })
   return { updated, applied: updated }
 }
 
@@ -1522,12 +1526,15 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           if (isMobile && request.client?.id) {
             await runtime.handleMobileSubscribe(ptyId, request.client.id, request.viewport)
           } else if (request.viewport && request.client) {
+            // Why: subscribe only measures. Applying as control would steal
+            // host size the moment a second desktop opens (tug-of-war start).
             await updateViewportForClient(
               runtime,
               ptyId,
               request.client,
               request.viewport,
-              'desktop'
+              'desktop',
+              'observe'
             )
           }
           if (closed || streams.get(request.streamId) !== stream) {
@@ -1535,14 +1542,21 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           }
 
           if (!isMobile) {
-            stream.unsubscribeFit = runtime.subscribeToFitOverrideChanges(ptyId, (event) => {
+            const emitFitHoldForViewer = (): void => {
+              const hold = runtime.getFitHoldForViewer(
+                ptyId,
+                request.client?.id ?? 'remote-unknown'
+              )
               emit({
                 type: 'fit-override-changed',
                 streamId: request.streamId,
-                mode: event.mode,
-                cols: event.cols,
-                rows: event.rows
+                mode: hold.mode,
+                cols: hold.cols,
+                rows: hold.rows
               })
+            }
+            stream.unsubscribeFit = runtime.subscribeToFitOverrideChanges(ptyId, () => {
+              emitFitHoldForViewer()
             })
             stream.unsubscribeDriver = runtime.subscribeToDriverChanges(ptyId, (driver) => {
               emit({
@@ -1581,13 +1595,16 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           const snapshotFrameSeq = serialized?.seq ?? layoutSeq
           const snapshotOutputSeq = serialized?.seq
           if (!isMobile) {
-            const fitOverride = runtime.getTerminalFitOverride(ptyId)
+            const hold = runtime.getFitHoldForViewer(
+              ptyId,
+              request.client?.id ?? 'remote-unknown'
+            )
             emit({
               type: 'fit-override-changed',
               streamId: request.streamId,
-              mode: fitOverride?.mode ?? 'desktop-fit',
-              cols: fitOverride?.cols ?? size?.cols ?? 0,
-              rows: fitOverride?.rows ?? size?.rows ?? 0
+              mode: hold.mode,
+              cols: hold.cols || size?.cols || 0,
+              rows: hold.rows || size?.rows || 0
             })
             emit({
               type: 'driver-changed',
@@ -1808,13 +1825,14 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           const unsubscribeData = runtime.subscribeToTerminalData(ptyId, (data) => {
             outputBatcher.push(data)
           })
-          const unsubscribeFit = runtime.subscribeToFitOverrideChanges(ptyId, (event) => {
+          const unsubscribeFit = runtime.subscribeToFitOverrideChanges(ptyId, () => {
             outputBatcher.flush()
+            const hold = runtime.getFitHoldForViewer(ptyId, clientId ?? 'remote-unknown')
             emit({
               type: 'fit-override-changed',
-              mode: event.mode,
-              cols: event.cols,
-              rows: event.rows
+              mode: hold.mode,
+              cols: hold.cols,
+              rows: hold.rows
             })
           })
           runtime.registerSubscriptionCleanup(
@@ -2126,12 +2144,13 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
 
         // Legacy fit-override-changed for non-mobile (desktop) subscribers
         unsubscribeFit = !isMobile
-          ? runtime.subscribeToFitOverrideChanges(ptyId, (event) => {
+          ? runtime.subscribeToFitOverrideChanges(ptyId, () => {
+              const hold = runtime.getFitHoldForViewer(ptyId, clientId ?? 'remote-unknown')
               emit({
                 type: 'fit-override-changed',
-                mode: event.mode,
-                cols: event.cols,
-                rows: event.rows
+                mode: hold.mode,
+                cols: hold.cols,
+                rows: hold.rows
               })
             })
           : () => {}

--- a/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
@@ -21,6 +21,7 @@ import {
 function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
   return {
     getRuntimeId: () => 'test-runtime',
+    releaseRemoteDesktopSizeOwner: () => false,
     ...overrides
   } as OrcaRuntimeService
 }

--- a/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
@@ -58,6 +58,7 @@ describe('terminal.multiplex pending-escape-tail threading (#7329)', () => {
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
         subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
         getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -64,6 +64,7 @@ describe('terminal multiplex RPC', () => {
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
         subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
         getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)
@@ -130,10 +131,11 @@ describe('terminal multiplex RPC', () => {
           })
         ])
       )
-      expect(runtime.updateDesktopViewport).toHaveBeenCalledWith('pty-1', {
-        cols: 300,
-        rows: 150
-      })
+      expect(runtime.updateDesktopViewport).toHaveBeenCalledWith(
+        'pty-1',
+        { cols: 300, rows: 150 },
+        { clientId: 'desktop-1', intent: 'observe' }
+      )
       expect(handlers.has(5)).toBe(true)
 
       dataListenerRef.current?.('a')
@@ -176,10 +178,11 @@ describe('terminal multiplex RPC', () => {
         )!
       )
       await vi.waitFor(() =>
-        expect(runtime.updateDesktopViewport).toHaveBeenLastCalledWith('pty-1', {
-          cols: 100,
-          rows: 30
-        })
+        expect(runtime.updateDesktopViewport).toHaveBeenLastCalledWith(
+          'pty-1',
+          { cols: 100, rows: 30 },
+          { clientId: 'desktop-1', intent: 'control' }
+        )
       )
 
       const snapshotStartFrame = binaryFrames
@@ -283,6 +286,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
       subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
       getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -394,6 +398,7 @@ describe('terminal multiplex RPC', () => {
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
         subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
         getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)
@@ -490,6 +495,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
       subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
       getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -588,6 +594,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
       subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
       getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -696,6 +703,7 @@ describe('terminal multiplex RPC', () => {
         cols: 49,
         rows: 20
       }),
+      getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'mobile-fit', cols: 49, rows: 20 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'mobile', clientId: 'phone-1' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -792,6 +800,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
       subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
       getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -879,6 +888,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
       subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -968,6 +978,7 @@ describe('terminal multiplex RPC', () => {
         }),
         subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)
@@ -1054,6 +1065,7 @@ describe('terminal multiplex RPC', () => {
         }),
         subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)
@@ -1138,6 +1150,7 @@ describe('terminal multiplex RPC', () => {
         }),
         subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)
@@ -1235,6 +1248,7 @@ describe('terminal multiplex RPC', () => {
         }),
         subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)
@@ -1476,6 +1490,7 @@ describe('terminal multiplex RPC', () => {
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
         subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
         getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)
@@ -1585,6 +1600,7 @@ describe('terminal multiplex RPC', () => {
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
         subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
         getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)
@@ -1702,6 +1718,7 @@ describe('terminal multiplex RPC', () => {
         subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
         subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
         getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
         getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
         registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
           cleanups.set(id, cleanup)

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -2,9 +2,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from './dispatcher'
 import type { RpcRequest } from './core'
-import type { OrcaRuntimeService } from '../orca-runtime'
+import { OrcaRuntimeService } from '../orca-runtime'
 import { TERMINAL_METHODS } from './methods/terminal'
 import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
+import { LOCAL_DESKTOP_CLIENT_ID } from '../desktop-size-ownership'
 import {
   TerminalStreamOpcode,
   decodeTerminalStreamFrame,
@@ -18,6 +19,7 @@ import {
 function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
   return {
     getRuntimeId: () => 'test-runtime',
+    releaseRemoteDesktopSizeOwner: () => false,
     ...overrides
   } as OrcaRuntimeService
 }
@@ -76,7 +78,8 @@ describe('terminal multiplex RPC', () => {
         }),
         waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
         sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
-        updateDesktopViewport: vi.fn().mockResolvedValue(true)
+        updateDesktopViewport: vi.fn().mockResolvedValue(true),
+        releaseRemoteDesktopSizeOwner: vi.fn().mockReturnValue(true)
       })
       const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
 
@@ -107,7 +110,7 @@ describe('terminal multiplex RPC', () => {
             payload: encodeTerminalStreamJson({
               streamId: 5,
               terminal: 'terminal-1',
-              client: { id: 'desktop-1', type: 'desktop' },
+              client: { id: 'desktop:tab-1:leaf-1', type: 'desktop' },
               viewport: { cols: 300, rows: 150 }
             })
           })
@@ -134,7 +137,7 @@ describe('terminal multiplex RPC', () => {
       expect(runtime.updateDesktopViewport).toHaveBeenCalledWith(
         'pty-1',
         { cols: 300, rows: 150 },
-        { clientId: 'desktop-1', intent: 'observe' }
+        { clientId: 'desktop:tab-1:leaf-1', intent: 'observe' }
       )
       expect(handlers.has(5)).toBe(true)
 
@@ -181,7 +184,7 @@ describe('terminal multiplex RPC', () => {
         expect(runtime.updateDesktopViewport).toHaveBeenLastCalledWith(
           'pty-1',
           { cols: 100, rows: 30 },
-          { clientId: 'desktop-1', intent: 'control' }
+          { clientId: 'desktop:tab-1:leaf-1', intent: 'control' }
         )
       )
 
@@ -235,11 +238,269 @@ describe('terminal multiplex RPC', () => {
           .join('')
       ).toBe('snapshot')
 
+      handlers.get(5)?.(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.Unsubscribe,
+            streamId: 5,
+            seq: 5,
+            payload: new Uint8Array()
+          })
+        )!
+      )
+
+      expect(runtime.releaseRemoteDesktopSizeOwner).toHaveBeenCalledOnce()
+      expect(runtime.releaseRemoteDesktopSizeOwner).toHaveBeenCalledWith(
+        'pty-1',
+        'desktop:tab-1:leaf-1'
+      )
+      expect(handlers.has(5)).toBe(false)
+      expect(handlers.has(0)).toBe(true)
+
       runtime.cleanupSubscription('terminal-multiplex:conn-1')
       await dispatchPromise
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('routes pane-scoped detach cleanup by desktop and mobile ownership', async () => {
+    const messages: string[] = []
+    const handlers = new Map<
+      number,
+      (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+    >()
+    const cleanups = new Map<string, () => void>()
+    const ptyIds = new Map([
+      ['terminal-1', 'pty-1'],
+      ['terminal-2', 'pty-2'],
+      ['terminal-phone', 'pty-phone']
+    ])
+    const runtime = stubRuntime({
+      resolveLiveLeafForHandle: vi.fn((terminal: string) => ({
+        ptyId: ptyIds.get(terminal) ?? null
+      })),
+      readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue({ data: '', cols: 80, rows: 24 }),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      handleMobileSubscribe: vi.fn().mockResolvedValue(undefined),
+      handleMobileUnsubscribe: vi.fn(),
+      releaseRemoteDesktopSizeOwner: vi.fn().mockReturnValue(true),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
+      getFitHoldForViewer: vi.fn().mockReturnValue({
+        mode: 'desktop-fit',
+        cols: 80,
+        rows: 24
+      }),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {}))
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.multiplex', {}),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-multi-pane',
+        sendBinary: vi.fn(),
+        registerBinaryStreamHandler: (streamId, handler) => {
+          handlers.set(streamId, handler)
+          return () => handlers.delete(streamId)
+        }
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+    )
+    const subscribe = (
+      streamId: number,
+      terminal: string,
+      client: { id: string; type: 'desktop' | 'mobile' }
+    ): void => {
+      handlers.get(0)?.(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.Subscribe,
+            streamId: 0,
+            seq: streamId,
+            payload: encodeTerminalStreamJson({ streamId, terminal, client })
+          })
+        )!
+      )
+    }
+    subscribe(1, 'terminal-1', { id: 'desktop:tab-1:leaf-1', type: 'desktop' })
+    subscribe(2, 'terminal-2', { id: 'desktop:tab-1:leaf-2', type: 'desktop' })
+    subscribe(3, 'terminal-phone', { id: 'phone-1', type: 'mobile' })
+
+    await vi.waitFor(() =>
+      expect(messages.filter((msg) => JSON.parse(msg).result?.type === 'subscribed')).toHaveLength(
+        3
+      )
+    )
+    const unsubscribe = (streamId: number): void => {
+      handlers.get(streamId)?.(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.Unsubscribe,
+            streamId,
+            seq: streamId + 10,
+            payload: new Uint8Array()
+          })
+        )!
+      )
+    }
+
+    unsubscribe(1)
+
+    expect(runtime.releaseRemoteDesktopSizeOwner).toHaveBeenCalledTimes(1)
+    expect(runtime.releaseRemoteDesktopSizeOwner).toHaveBeenLastCalledWith(
+      'pty-1',
+      'desktop:tab-1:leaf-1'
+    )
+    expect(handlers.has(1)).toBe(false)
+    expect(handlers.has(2)).toBe(true)
+    expect(handlers.has(3)).toBe(true)
+    expect(handlers.has(0)).toBe(true)
+
+    unsubscribe(3)
+
+    expect(runtime.handleMobileUnsubscribe).toHaveBeenCalledOnce()
+    expect(runtime.handleMobileUnsubscribe).toHaveBeenCalledWith('pty-phone', 'phone-1')
+    expect(runtime.releaseRemoteDesktopSizeOwner).toHaveBeenCalledTimes(1)
+    expect(handlers.has(2)).toBe(true)
+    expect(handlers.has(0)).toBe(true)
+
+    cleanups.get('terminal-multiplex:conn-multi-pane')?.()
+    await dispatchPromise
+
+    expect(runtime.releaseRemoteDesktopSizeOwner).toHaveBeenCalledTimes(2)
+    expect(runtime.releaseRemoteDesktopSizeOwner).toHaveBeenLastCalledWith(
+      'pty-2',
+      'desktop:tab-1:leaf-2'
+    )
+  })
+
+  it('restores host geometry when a real runtime owner detaches without closing multiplex', async () => {
+    const ptySizes = new Map([['pty-1', { cols: 150, rows: 40 }]])
+    const runtime = new OrcaRuntimeService()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      resize: (ptyId, cols, rows) => {
+        ptySizes.set(ptyId, { cols, rows })
+        return true
+      },
+      getSize: (ptyId) => ptySizes.get(ptyId) ?? null
+    })
+    const terminal = runtime.preAllocateHandleForPty('pty-1')
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          title: 'Terminal',
+          activeLeafId: 'leaf-1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          leafId: 'leaf-1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+    runtime.onExternalPtyResize('pty-1', 150, 40)
+
+    const messages: string[] = []
+    const handlers = new Map<
+      number,
+      (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+    >()
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.multiplex', {}),
+      (message) => messages.push(message),
+      {
+        connectionId: 'conn-real-runtime',
+        sendBinary: vi.fn(),
+        registerBinaryStreamHandler: (streamId, handler) => {
+          handlers.set(streamId, handler)
+          return () => handlers.delete(streamId)
+        }
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((message) => JSON.parse(message).result?.type === 'ready')).toBe(true)
+    )
+    handlers.get(0)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Subscribe,
+          streamId: 0,
+          seq: 1,
+          payload: encodeTerminalStreamJson({
+            streamId: 1,
+            terminal,
+            client: { id: 'desktop:tab-1:leaf-1', type: 'desktop' }
+          })
+        })
+      )!
+    )
+    await vi.waitFor(() =>
+      expect(messages.some((message) => JSON.parse(message).result?.type === 'subscribed')).toBe(
+        true
+      )
+    )
+
+    handlers.get(1)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Resize,
+          streamId: 1,
+          seq: 2,
+          payload: encodeTerminalStreamJson({ cols: 100, rows: 30 })
+        })
+      )!
+    )
+    await vi.waitFor(() =>
+      expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe('desktop:tab-1:leaf-1')
+    )
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 100, rows: 30 })
+
+    handlers.get(1)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Unsubscribe,
+          streamId: 1,
+          seq: 3,
+          payload: new Uint8Array()
+        })
+      )!
+    )
+
+    expect(runtime.getDesktopSizeOwner('pty-1')?.clientId).toBe(LOCAL_DESKTOP_CLIENT_ID)
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    expect(handlers.has(1)).toBe(false)
+    expect(handlers.has(0)).toBe(true)
+
+    runtime.cleanupSubscription('terminal-multiplex:conn-real-runtime')
+    await dispatchPromise
   })
 
   it('drops stale mobile resize re-stream completions for multiplex streams', async () => {
@@ -286,7 +547,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
       subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
       getTerminalFitOverride: vi.fn().mockReturnValue(null),
-        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
+      getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -495,7 +756,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
       subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
       getTerminalFitOverride: vi.fn().mockReturnValue(null),
-        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
+      getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -594,7 +855,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
       subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
       getTerminalFitOverride: vi.fn().mockReturnValue(null),
-        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
+      getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)
@@ -800,7 +1061,7 @@ describe('terminal multiplex RPC', () => {
       subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
       subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
       getTerminalFitOverride: vi.fn().mockReturnValue(null),
-        getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
+      getFitHoldForViewer: vi.fn().mockReturnValue({ mode: 'desktop-fit', cols: 80, rows: 24 }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
       registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
         cleanups.set(id, cleanup)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2807,7 +2807,7 @@ export type PreloadApi = {
     getStatus: () => Promise<RuntimeStatus>
     call: (args: { method: string; params?: unknown }) => Promise<RuntimeRpcResponse<unknown>>
     getTerminalFitOverrides: () => Promise<
-      { ptyId: string; mode: 'mobile-fit'; cols: number; rows: number }[]
+      { ptyId: string; mode: 'mobile-fit' | 'remote-desktop-fit'; cols: number; rows: number }[]
     >
     getTerminalDrivers: () => Promise<
       {
@@ -2826,7 +2826,7 @@ export type PreloadApi = {
     onTerminalFitOverrideChanged: (
       callback: (event: {
         ptyId: string
-        mode: 'mobile-fit' | 'desktop-fit'
+        mode: 'mobile-fit' | 'remote-desktop-fit' | 'desktop-fit'
         cols: number
         rows: number
       }) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3732,7 +3732,7 @@ const api = {
     call: (args: { method: string; params?: unknown }): Promise<RuntimeRpcResponse<unknown>> =>
       ipcRenderer.invoke('runtime:call', args),
     getTerminalFitOverrides: (): Promise<
-      { ptyId: string; mode: 'mobile-fit'; cols: number; rows: number }[]
+      { ptyId: string; mode: 'mobile-fit' | 'remote-desktop-fit'; cols: number; rows: number }[]
     > => ipcRenderer.invoke('runtime:getTerminalFitOverrides'),
     getTerminalDrivers: (): Promise<
       {
@@ -3753,14 +3753,19 @@ const api = {
     onTerminalFitOverrideChanged: (
       callback: (event: {
         ptyId: string
-        mode: 'mobile-fit' | 'desktop-fit'
+        mode: 'mobile-fit' | 'remote-desktop-fit' | 'desktop-fit'
         cols: number
         rows: number
       }) => void
     ): (() => void) => {
       const listener = (
         _event: Electron.IpcRendererEvent,
-        data: { ptyId: string; mode: 'mobile-fit' | 'desktop-fit'; cols: number; rows: number }
+        data: {
+          ptyId: string
+          mode: 'mobile-fit' | 'remote-desktop-fit' | 'desktop-fit'
+          cols: number
+          rows: number
+        }
       ) => callback(data)
       ipcRenderer.on('runtime:terminalFitOverrideChanged', listener)
       return () => ipcRenderer.removeListener('runtime:terminalFitOverrideChanged', listener)

--- a/src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts
@@ -153,6 +153,11 @@ export function buildSourceControlManualReviewUrl(input: ManualReviewUrlInput): 
   }
 
   const provider = normalizeProvider(input.provider) ?? baseRepo.provider ?? headRepo.provider
+  // Why: provider can still be null when remotes are unparseable / non-forge.
+  // Narrow before the switch so switch-exhaustiveness covers every ManualReviewProvider.
+  if (provider == null) {
+    return null
+  }
   // Prefer the pushed branch name (pushTarget, else the tracking upstream on the
   // base remote) so the link matches what exists remotely, not the local name.
   const headBranch =

--- a/src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts
@@ -153,11 +153,6 @@ export function buildSourceControlManualReviewUrl(input: ManualReviewUrlInput): 
   }
 
   const provider = normalizeProvider(input.provider) ?? baseRepo.provider ?? headRepo.provider
-  // Why: provider can still be null when remotes are unparseable / non-forge.
-  // Narrow before the switch so switch-exhaustiveness covers every ManualReviewProvider.
-  if (provider == null) {
-    return null
-  }
   // Prefer the pushed branch name (pushTarget, else the tracking upstream on the
   // base remote) so the link matches what exists remotely, not the local name.
   const headBranch =

--- a/src/renderer/src/components/terminal-pane/MobileDriverOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/MobileDriverOverlay.tsx
@@ -3,6 +3,7 @@ import { Smartphone } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { DriverState } from '@/lib/pane-manager/mobile-driver-state'
+import type { FitHoldMode } from '@/lib/pane-manager/mobile-fit-overrides'
 import { shouldFocusMobileDriverAction } from './mobile-driver-overlay-focus'
 import {
   createMobileDriverOverlayCollapseState,
@@ -13,6 +14,8 @@ import { translate } from '@/i18n/i18n'
 type Props = {
   driver: DriverState
   hasFitOverride: boolean
+  /** Distinguishes phone hold vs another desktop client's size ownership. */
+  fitHoldMode?: Exclude<FitHoldMode, 'desktop-fit'> | null
   onAction: () => void | Promise<void>
   onAllAction?: () => void | Promise<void>
   /** Identifier class on the rendered root, used by e2e selectors. */
@@ -25,12 +28,14 @@ type Props = {
 export function MobileDriverOverlay({
   driver,
   hasFitOverride,
+  fitHoldMode = null,
   onAction,
   onAllAction,
   rootClassName
 }: Props): ReactElement | null {
   const isMobileDriving = driver.kind === 'mobile'
   const isHeldAtPhoneFit = !isMobileDriving && hasFitOverride
+  const isRemoteDesktopHold = isHeldAtPhoneFit && fitHoldMode === 'remote-desktop-fit'
   const driverClientId = driver.kind === 'mobile' ? driver.clientId : null
 
   const [collapseState, setCollapseState] = useState(() =>
@@ -90,6 +95,39 @@ export function MobileDriverOverlay({
   }
 
   if (isHeldAtPhoneFit) {
+    if (isRemoteDesktopHold) {
+      return (
+        <LoudOverlay
+          eyebrow={translate(
+            'auto.components.terminal.pane.MobileDriverOverlay.remoteDesktopEyebrow',
+            'Another desktop'
+          )}
+          title={translate(
+            'auto.components.terminal.pane.MobileDriverOverlay.remoteDesktopTitle',
+            'Sized for another desktop'
+          )}
+          body={translate(
+            'auto.components.terminal.pane.MobileDriverOverlay.remoteDesktopBody',
+            'Another Orca window is driving this terminal size. Restore to use your pane size, or drag a splitter to take size control.'
+          )}
+          actionLabel={translate(
+            'auto.components.terminal.pane.MobileDriverOverlay.b3d8e1f42a',
+            'Restore this terminal'
+          )}
+          actionPending={actionPending}
+          allActionLabel={translate(
+            'auto.components.terminal.pane.MobileDriverOverlay.e8c4f2a91b',
+            'Restore all terminals'
+          )}
+          allActionPending={allActionPending}
+          onAction={handleAction}
+          onAllAction={onAllAction ? handleAllAction : undefined}
+          tone="held"
+          rootRef={setOverlayRootRef}
+          rootClassName={rootClassName}
+        />
+      )
+    }
     return (
       <LoudOverlay
         eyebrow={translate(

--- a/src/renderer/src/components/terminal-pane/MobileDriverOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/MobileDriverOverlay.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useRef, useState, type ReactElement } from 'react'
-import { Smartphone } from 'lucide-react'
+import { Monitor, Smartphone, type LucideIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { DriverState } from '@/lib/pane-manager/mobile-driver-state'
@@ -122,6 +122,8 @@ export function MobileDriverOverlay({
           allActionPending={allActionPending}
           onAction={handleAction}
           onAllAction={onAllAction ? handleAllAction : undefined}
+          // Why: phone glyph mislabels desktop-to-desktop size ownership (#7854 review).
+          Icon={Monitor}
           tone="held"
           rootRef={setOverlayRootRef}
           rootClassName={rootClassName}
@@ -218,6 +220,8 @@ type LoudOverlayProps = {
   onAction: () => void | Promise<void>
   onAllAction?: () => void | Promise<void>
   onCollapse?: () => void
+  /** Defaults to Smartphone; remote-desktop hold uses Monitor. */
+  Icon?: LucideIcon
   tone: 'driving' | 'held'
   rootRef?: (node: HTMLDivElement | null) => void
   rootClassName?: string
@@ -234,6 +238,7 @@ function LoudOverlay({
   onAction,
   onAllAction,
   onCollapse,
+  Icon = Smartphone,
   tone,
   rootRef: outerRootRef,
   rootClassName
@@ -282,7 +287,7 @@ function LoudOverlay({
               tone === 'driving' ? 'bg-muted' : 'bg-muted/60'
             )}
           >
-            <Smartphone className="size-5 text-foreground" aria-hidden="true" />
+            <Icon className="size-5 text-foreground" aria-hidden="true" />
           </div>
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <div

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -429,15 +429,12 @@ export default function TerminalPane({
           (paneId) => paneTransportsRef.current.get(paneId)?.getPtyId(),
           event.ptyId
         )
-      if (event.mode === 'mobile-fit') {
-        // Why: when mobile starts driving, the agent re-renders its output at
-        // phone width and that phone-wrapped byte stream flows live into this
-        // passive watcher's xterm. xterm must shrink to the phone dims now or
-        // the wide desktop grid renders the narrow stream as overlapping,
-        // garbled lines. safeFit honors the active override and parks xterm at
-        // override.cols/rows, matching the incoming stream. rAF lets the DOM
-        // settle before the resize; no loud fallback is needed because the
-        // override branch of safeFit is itself the authoritative resize.
+      if (event.mode === 'mobile-fit' || event.mode === 'remote-desktop-fit') {
+        // Why: when another client owns the grid (phone or remote desktop), the
+        // agent re-renders at that width and the stream flows into this passive
+        // watcher. xterm must shrink to the held dims or the local grid renders
+        // the foreign stream as overlapping/garbled lines. safeFit parks at
+        // override.cols/rows. rAF lets the DOM settle before the resize.
         // Why: override events fan out to every terminal tab; skip the rAF
         // unless this tab has a pane still parked at the wrong grid.
         const panesNeedingFit = getPanesNeedingOverrideFit(
@@ -3180,7 +3177,8 @@ export default function TerminalPane({
         // same local/remote desktop-restore route.
         const driver = getDriverForPty(ptyId)
         const isMobileDriving = driver.kind === 'mobile'
-        const hasFitOverride = getFitOverrideForPty(ptyId) !== null
+        const fitOverride = getFitOverrideForPty(ptyId)
+        const hasFitOverride = fitOverride !== null
         if (!isMobileDriving && !hasFitOverride) {
           return null
         }
@@ -3196,6 +3194,7 @@ export default function TerminalPane({
             key={`mobile-driver-${pane.id}-${ptyId}`}
             driver={driver}
             hasFitOverride={hasFitOverride}
+            fitHoldMode={fitOverride?.mode ?? null}
             rootClassName="mobile-driver-banner"
             onAction={() => restorePaneTerminalFit(pane, ptyId)}
             onAllAction={() => restoreAllTerminalFits(pane)}

--- a/src/renderer/src/components/terminal-pane/fit-hold-passive-geometry.test.ts
+++ b/src/renderer/src/components/terminal-pane/fit-hold-passive-geometry.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { shouldForwardRemotePassiveGeometryWhileHeld } from './fit-hold-passive-geometry'
+
+describe('shouldForwardRemotePassiveGeometryWhileHeld', () => {
+  it('allows measurement-only forward under mobile-fit', () => {
+    expect(shouldForwardRemotePassiveGeometryWhileHeld('mobile-fit')).toBe(true)
+  })
+
+  it('blocks passive forward under remote-desktop-fit (would claim ownership)', () => {
+    expect(shouldForwardRemotePassiveGeometryWhileHeld('remote-desktop-fit')).toBe(false)
+  })
+
+  it('blocks when no hold is active (caller uses reassert path instead)', () => {
+    expect(shouldForwardRemotePassiveGeometryWhileHeld(null)).toBe(false)
+    expect(shouldForwardRemotePassiveGeometryWhileHeld(undefined)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/fit-hold-passive-geometry.ts
+++ b/src/renderer/src/components/terminal-pane/fit-hold-passive-geometry.ts
@@ -1,0 +1,17 @@
+// Why: while a fit hold is active, ResizeObserver still measures the local
+// pane. For mobile-fit the server treats remote desktop viewport RPCs as
+// measurement-only (terminalFitOverrides gate). remote-desktop-fit is NOT in
+// that map — forwarding passive geometry as transport.resize would arrive as
+// control intent and re-claim size ownership (desktop tug-of-war).
+
+export type FitHoldPassiveMode = 'mobile-fit' | 'remote-desktop-fit'
+
+/**
+ * Whether a remote-runtime pane may emit transport.resize for a passive
+ * geometry observation while a fit hold is active.
+ */
+export function shouldForwardRemotePassiveGeometryWhileHeld(
+  fitMode: FitHoldPassiveMode | null | undefined
+): boolean {
+  return fitMode === 'mobile-fit'
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -15600,6 +15600,47 @@ describe('connectPanePty', () => {
       }
     })
 
+    it('does not control-resize a remote PTY on passive geometry while remote-desktop-fit is active', async () => {
+      // Why (Codex #2): under mobile-fit, remote transport.resize is measurement-only
+      // server-side. remote-desktop-fit is NOT in terminalFitOverrides, so the same
+      // passive ResizeObserver path would claim ownership — must stay silent.
+      const { setFitOverride } = await import('@/lib/pane-manager/mobile-fit-overrides')
+      const pane = createPane(2)
+      const observer = installObservedPane(pane)
+      const remotePtyId = 'remote:env-1@@pty-held'
+      try {
+        const { connectPanePty } = await import('./pty-connection')
+        const transport = createMockTransport(remotePtyId)
+        transportFactoryQueue.push(transport)
+        const manager = createManager(2)
+        const deps = createDeps({
+          restoredLeafId: LEAF_2,
+          paneTransportsRef: { current: new Map([[1, createMockTransport('pty-pane-1')]]) }
+        })
+        pane.fitAddon = {
+          ...pane.fitAddon,
+          proposeDimensions: vi.fn(() => ({ cols: 101, rows: 33 }))
+        } as never
+
+        connectPanePty(pane as never, manager as never, deps as never)
+        await flushAsyncTicks()
+        setFitOverride(remotePtyId, 'remote-desktop-fit', 150, 40)
+        transport.resize.mockClear()
+        vi.mocked(window.api.pty.getSize).mockClear()
+        vi.mocked(window.api.pty.reportGeometry).mockClear()
+
+        observer.trigger()
+        await flushAsyncTicks()
+
+        expect(window.api.pty.getSize).not.toHaveBeenCalled()
+        expect(window.api.pty.reportGeometry).not.toHaveBeenCalled()
+        expect(transport.resize).not.toHaveBeenCalled()
+      } finally {
+        setFitOverride(remotePtyId, 'desktop-fit', 0, 0)
+        observer.restore()
+      }
+    })
+
     it('skips observed desktop reassertion while mobile owns the PTY without a fit override', async () => {
       const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
       const pane = createPane(2)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -33,6 +33,7 @@ import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { requestStablePaneFit } from '@/lib/pane-manager/pane-fit-resize-observer'
 import { getFitOverrideForPty, bindPanePtyId } from '@/lib/pane-manager/mobile-fit-overrides'
 import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
+import { shouldForwardRemotePassiveGeometryWhileHeld } from './fit-hold-passive-geometry'
 import { reconcilePtySizeAcrossFrames, type PtySizeReconcileHandle } from './pty-size-reconcile'
 import { createPtySizeReassertion } from './pty-size-reassertion'
 import { isPaneReplaying, replayIntoTerminal, replayIntoTerminalAsync } from './replay-guard'
@@ -3212,10 +3213,16 @@ export function connectPanePty(
       return
     }
     if (isRemoteRuntimePtyId(currentPtyId)) {
-      transport.resize(proposed.cols, proposed.rows)
-    } else {
-      window.api.pty.reportGeometry(currentPtyId, proposed.cols, proposed.rows)
+      // Why: under mobile-fit the server treats desktop viewport as
+      // measurement-only (terminalFitOverrides gate). remote-desktop-fit is
+      // NOT in that map — the same passive ResizeObserver → transport.resize
+      // would arrive as control and re-claim ownership (tug-of-war).
+      if (shouldForwardRemotePassiveGeometryWhileHeld(fitOverride.mode)) {
+        transport.resize(proposed.cols, proposed.rows)
+      }
+      return
     }
+    window.api.pty.reportGeometry(currentPtyId, proposed.cols, proposed.rows)
   }
   const geometryReportObserver =
     typeof ResizeObserver === 'undefined'

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3208,7 +3208,7 @@ export function useIpcEvents(): void {
           kind: 'fit'
           event: {
             ptyId: string
-            mode: 'mobile-fit' | 'desktop-fit'
+            mode: 'mobile-fit' | 'remote-desktop-fit' | 'desktop-fit'
             cols: number
             rows: number
           }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2513,7 +2513,10 @@
             "f2a8b9c1d3": "From your phone",
             "c7e4a2b8f1": "Your phone is in control",
             "d9f3c6e2a4": "Desktop keyboard is paused. Take back this terminal to type here, take back all terminals your phone controls, or collapse to keep watching.",
-            "a6b1d8f3e2": "Your phone session ended. Restore to desktop size for this terminal, or for all terminals your phone left at phone size."
+            "a6b1d8f3e2": "Your phone session ended. Restore to desktop size for this terminal, or for all terminals your phone left at phone size.",
+            "remoteDesktopEyebrow": "Another desktop",
+            "remoteDesktopTitle": "Sized for another desktop",
+            "remoteDesktopBody": "Another Orca window is driving this terminal size. Restore to use your pane size, or drag a splitter to take size control."
           },
           "TerminalAgentSessionForkDialog": {
             "17fc841e59": "Copy context",

--- a/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
+++ b/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
@@ -1,10 +1,12 @@
-// Why: mobile-fit overrides are runtime-owned state that the renderer must
-// respect. When a mobile client resizes a PTY to phone dimensions, the desktop
-// renderer must not auto-fit that PTY back to desktop size. This module stores
-// the override state and provides lookup for safeFit() and transport.resize().
+// Why: fit holds are runtime-owned state that the renderer must respect.
+// mobile-fit: phone owns the grid. remote-desktop-fit: another desktop client
+// owns the grid (multi-client size arbitration). In both cases this client
+// parks xterm at the held dims and must not auto-fit/reassert the PTY.
+
+export type FitHoldMode = 'mobile-fit' | 'remote-desktop-fit' | 'desktop-fit'
 
 type FitOverride = {
-  mode: 'mobile-fit'
+  mode: 'mobile-fit' | 'remote-desktop-fit'
   cols: number
   rows: number
 }
@@ -13,6 +15,12 @@ const overridesByPtyId = new Map<string, FitOverride>()
 // Why: this is an in-memory renderer fit binding, not an agent paneKey.
 // Numeric pane ids are valid here because fit overrides never cross replay.
 const ptyIdByFitBindingKey = new Map<string, string>()
+// Why: remote-desktop-fit parks non-owners. Detect intentional local layout
+// change (splitter drag) by comparing successive FitAddon proposals — only
+// then unpark and reclaim size control. Keyed per pane binding (leafId), not
+// ptyId: one PTY can be shown in multiple panes with different grids; a
+// per-pty baseline would treat sibling panes as "user dragged".
+const lastProposedByBindingKey = new Map<string, { cols: number; rows: number }>()
 
 function fitBindingKey(tabId: string, paneId: number): string {
   return `${tabId}:${paneId}`
@@ -24,14 +32,14 @@ function fitBindingKey(tabId: string, paneId: number): string {
 // and trigger safeFit on affected panes.
 type OverrideChangeEvent = {
   ptyId: string
-  mode: 'mobile-fit' | 'desktop-fit'
+  mode: FitHoldMode
   cols: number
   rows: number
   // Why: the dimensions the PTY was at *before* this event fired. For a
-  // desktop-fit transition this is the prior mobile-fit cols/rows so
-  // listeners can check whether xterm is still stuck at phone dims and
-  // needs the safety-net resize, vs. already moved on (e.g. user resized
-  // the desktop pane while mobile was active).
+  // desktop-fit transition this is the prior hold cols/rows so listeners can
+  // check whether xterm is still stuck at foreign dims and needs the
+  // safety-net resize, vs. already moved on (e.g. user resized the desktop
+  // pane while another client was active).
   priorCols: number | null
   priorRows: number | null
 }
@@ -51,15 +59,23 @@ function notifyChange(event: OverrideChangeEvent): void {
 
 export function setFitOverride(
   ptyId: string,
-  mode: 'mobile-fit' | 'desktop-fit',
+  mode: FitHoldMode,
   cols: number,
   rows: number
 ): void {
   const prior = overridesByPtyId.get(ptyId) ?? null
-  if (mode === 'mobile-fit') {
+  if (mode === 'mobile-fit' || mode === 'remote-desktop-fit') {
+    const holdChanged =
+      !prior || prior.mode !== mode || prior.cols !== cols || prior.rows !== rows
     overridesByPtyId.set(ptyId, { mode, cols, rows })
+    // Why: a newly applied (or dim-changed) hold must re-baseline every pane;
+    // stale last-proposed from a prior hold would look like a drag on first fit.
+    if (holdChanged) {
+      lastProposedByBindingKey.clear()
+    }
   } else {
     overridesByPtyId.delete(ptyId)
+    lastProposedByBindingKey.clear()
   }
   notifyChange({
     ptyId,
@@ -69,6 +85,35 @@ export function setFitOverride(
     priorCols: prior?.cols ?? null,
     priorRows: prior?.rows ?? null
   })
+}
+
+/**
+ * True when a remote-desktop-fit park should release because this pane's
+ * geometry changed since its last measurement (user dragged a splitter /
+ * resized the window). First observation for a binding only records baseline.
+ *
+ * @param bindingKey Stable per-pane key (prefer leafId). Must not be ptyId —
+ *   multiple panes can bind the same PTY at different grids.
+ */
+export function shouldTakeDesktopSizeControl(
+  bindingKey: string,
+  ptyId: string,
+  proposed: { cols: number; rows: number } | null
+): boolean {
+  if (!bindingKey || !proposed || proposed.cols <= 0 || proposed.rows <= 0) {
+    return false
+  }
+  const override = overridesByPtyId.get(ptyId)
+  if (!override || override.mode !== 'remote-desktop-fit') {
+    lastProposedByBindingKey.set(bindingKey, proposed)
+    return false
+  }
+  const last = lastProposedByBindingKey.get(bindingKey)
+  lastProposedByBindingKey.set(bindingKey, proposed)
+  if (!last) {
+    return false
+  }
+  return last.cols !== proposed.cols || last.rows !== proposed.rows
 }
 
 export function getPaneIdsForPty(ptyId: string): number[] {
@@ -117,10 +162,16 @@ export function unbindPane(paneId: number, tabId?: string): void {
 }
 
 export function hydrateOverrides(
-  overrides: { ptyId: string; mode: 'mobile-fit'; cols: number; rows: number }[]
+  overrides: {
+    ptyId: string
+    mode: 'mobile-fit' | 'remote-desktop-fit'
+    cols: number
+    rows: number
+  }[]
 ): void {
   const previous = new Map(overridesByPtyId)
   overridesByPtyId.clear()
+  lastProposedByBindingKey.clear()
   for (const o of overrides) {
     overridesByPtyId.set(o.ptyId, { mode: o.mode, cols: o.cols, rows: o.rows })
   }
@@ -131,7 +182,7 @@ export function hydrateOverrides(
     const prior = previous.get(ptyId) ?? null
     notifyChange({
       ptyId,
-      mode: 'mobile-fit',
+      mode: override.mode,
       cols: override.cols,
       rows: override.rows,
       priorCols: prior?.cols ?? null,

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -6,7 +6,11 @@ import type {
   PaneStyleOptions
 } from './pane-manager-types'
 import { createDivider, disposeDivider } from './pane-divider'
-import { getFitOverrideForPty } from './mobile-fit-overrides'
+import {
+  getFitOverrideForPty,
+  setFitOverride,
+  shouldTakeDesktopSizeControl
+} from './mobile-fit-overrides'
 import { disposeWebgl, attachWebgl } from './pane-webgl-renderer'
 import {
   captureTerminalWriteScrollIntent,
@@ -75,22 +79,35 @@ export function safeFit(pane: ManagedPane): void {
   let scrollIntent = null as ReturnType<typeof captureTerminalWriteScrollIntent>
   let shouldRestoreScroll = false
   try {
-    // Why: when a mobile client has resized this PTY to phone dimensions,
-    // the desktop must keep xterm at those dimensions instead of fitting to
-    // the desktop pane geometry. This prevents desktop auto-fit from undoing
-    // the mobile resize. Uses data-pty-id (set by bindPanePtyId) to look up
-    // the override by ptyId directly, avoiding pane ID collisions across tabs.
+    // Why: when another client owns the PTY grid (phone or remote desktop),
+    // park xterm at the held dims instead of fitting to local pane geometry.
+    // remote-desktop-fit releases on intentional local layout change so the
+    // user can reclaim size by dragging a splitter (not via passive reassert).
+    // Uses data-pty-id (set by bindPanePtyId) to look up the override by ptyId
+    // directly, avoiding pane ID collisions across tabs.
     const ptyId = pane.container.dataset.ptyId
     const override = ptyId ? getFitOverrideForPty(ptyId) : null
     if (override) {
-      if (pane.terminal.cols !== override.cols || pane.terminal.rows !== override.rows) {
-        if (canPreserveScrollIntentForFit(pane)) {
-          scrollIntent = captureTerminalWriteScrollIntent(pane.terminal)
-          shouldRestoreScroll = true
+      const proposed = getProposedDimensions(pane)
+      if (
+        ptyId &&
+        override.mode === 'remote-desktop-fit' &&
+        shouldTakeDesktopSizeControl(pane.leafId, ptyId, proposed)
+      ) {
+        // Why: clear the local park before fit so onResize is not suppressed
+        // by shouldSuppressDesktopPtyResize / isParked. Server claims this
+        // client as size owner when the control resize arrives.
+        setFitOverride(ptyId, 'desktop-fit', 0, 0)
+      } else {
+        if (pane.terminal.cols !== override.cols || pane.terminal.rows !== override.rows) {
+          if (canPreserveScrollIntentForFit(pane)) {
+            scrollIntent = captureTerminalWriteScrollIntent(pane.terminal)
+            shouldRestoreScroll = true
+          }
+          pane.terminal.resize(override.cols, override.rows)
         }
-        pane.terminal.resize(override.cols, override.rows)
+        return
       }
-      return
     }
 
     const dims = getProposedDimensions(pane)

--- a/src/renderer/src/lib/pane-manager/should-take-desktop-size-control.test.ts
+++ b/src/renderer/src/lib/pane-manager/should-take-desktop-size-control.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hydrateOverrides,
+  setFitOverride,
+  shouldTakeDesktopSizeControl
+} from './mobile-fit-overrides'
+
+describe('shouldTakeDesktopSizeControl', () => {
+  it('does not take control on first proposed observation (baseline)', () => {
+    hydrateOverrides([])
+    setFitOverride('pty-1', 'remote-desktop-fit', 150, 40)
+
+    expect(shouldTakeDesktopSizeControl('leaf-a', 'pty-1', { cols: 100, rows: 30 })).toBe(false)
+    // Second identical proposal still no take — only changes count.
+    expect(shouldTakeDesktopSizeControl('leaf-a', 'pty-1', { cols: 100, rows: 30 })).toBe(false)
+  })
+
+  it('takes control when proposed grid changes while remote-desktop-fit is held', () => {
+    hydrateOverrides([])
+    setFitOverride('pty-1', 'remote-desktop-fit', 150, 40)
+
+    expect(shouldTakeDesktopSizeControl('leaf-a', 'pty-1', { cols: 100, rows: 30 })).toBe(false)
+    expect(shouldTakeDesktopSizeControl('leaf-a', 'pty-1', { cols: 110, rows: 30 })).toBe(true)
+  })
+
+  it('never takes control for mobile-fit holds', () => {
+    hydrateOverrides([])
+    setFitOverride('pty-1', 'mobile-fit', 49, 20)
+
+    expect(shouldTakeDesktopSizeControl('leaf-a', 'pty-1', { cols: 100, rows: 30 })).toBe(false)
+    expect(shouldTakeDesktopSizeControl('leaf-a', 'pty-1', { cols: 110, rows: 30 })).toBe(false)
+  })
+
+  it('does not treat sibling panes on the same PTY as a drag takeover', () => {
+    hydrateOverrides([])
+    setFitOverride('pty-1', 'remote-desktop-fit', 150, 40)
+
+    // Pane A baseline at 100×30, pane B first sees 80×24 — different grid, same PTY.
+    expect(shouldTakeDesktopSizeControl('leaf-a', 'pty-1', { cols: 100, rows: 30 })).toBe(false)
+    expect(shouldTakeDesktopSizeControl('leaf-b', 'pty-1', { cols: 80, rows: 24 })).toBe(false)
+    // Only a later change on the *same* binding takes control.
+    expect(shouldTakeDesktopSizeControl('leaf-b', 'pty-1', { cols: 90, rows: 24 })).toBe(true)
+    expect(shouldTakeDesktopSizeControl('leaf-a', 'pty-1', { cols: 100, rows: 30 })).toBe(false)
+  })
+})

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -24,7 +24,7 @@ type TerminalMultiplexEvent =
   | {
       type: 'fit-override-changed'
       streamId: number
-      mode: 'mobile-fit' | 'desktop-fit'
+      mode: 'mobile-fit' | 'remote-desktop-fit' | 'desktop-fit'
       cols: number
       rows: number
     }
@@ -42,7 +42,7 @@ export type RemoteRuntimeMultiplexedTerminalCallbacks = {
   onEnd?: () => void
   onError?: (message: string) => void
   onFitOverrideChanged?: (event: {
-    mode: 'mobile-fit' | 'desktop-fit'
+    mode: 'mobile-fit' | 'remote-desktop-fit' | 'desktop-fit'
     cols: number
     rows: number
   }) => void
@@ -304,7 +304,9 @@ class RemoteRuntimeTerminalMultiplexer {
       )
     } else if (event.type === 'fit-override-changed') {
       if (
-        (event.mode !== 'mobile-fit' && event.mode !== 'desktop-fit') ||
+        (event.mode !== 'mobile-fit' &&
+          event.mode !== 'remote-desktop-fit' &&
+          event.mode !== 'desktop-fit') ||
         typeof event.cols !== 'number' ||
         typeof event.rows !== 'number'
       ) {


### PR DESCRIPTION
## Summary

When two Orca desktop clients render the same live terminal, both used to resize the shared PTY freely (host `pty:resize` / reassertion vs remote `updateDesktopViewport`). Last writer won, so a manual refit on the smaller machine was undone as soon as new agent output arrived — a permanent size tug-of-war with no arbitration.

This introduces **sticky desktop size ownership** (parallel to mobile-fit):

- **Subscribe = observe**: opening a second desktop no longer steals PTY size.
- **Control resize** (intentional layout change / splitter drag) claims ownership and resizes the PTY.
- **Non-owners** park xterm at the owner’s grid via `remote-desktop-fit` and suppress passive reassert.
- **Host Restore** / intentional host layout reclaim local ownership.
- **Remote owner disconnect** restores host geometry and clears the hold (no stuck “another desktop” overlay on a dead client).
- **Host restore baseline** (`lastRendererSizes`) is not polluted by remote observe (including under phone-fit).
- Mobile-fit still wins when a phone is driving.

Also: i18n catalog keys for the new overlay copy; switch-exhaustiveness fix for null git provider in manual review URL builder.

Scrollback wrapped at the old width is not retroactively reflowed — only new output needs to be correct.

## Screenshots

- New desktop hold overlay when another Orca window owns size: “Sized for another desktop” with Restore actions (reuses the existing mobile-hold modal chrome; copy differs).
- No other visual change when a single desktop owns the PTY.

## Testing

- [x] Targeted unit tests for arbitration, ownership helpers, passive geometry gate, takeover baseline, multiplex mocks, presence-lock, SC manual review URL
- [x] `pty-connection.test.ts` hold cases (with `--config config/vitest.config.ts`)
- [x] `pnpm typecheck`
- [x] `pnpm run lint:switch-exhaustiveness`
- [x] `pnpm run check:max-lines-ratchet`
- [x] `pnpm exec oxlint` (existing warnings only)
- [ ] Full `pnpm lint` / `pnpm test` / `pnpm build` (not run end-to-end in this session; catalog still reports pre-existing main missing keys for ForgetSshWorkspaceDialog etc., unrelated to this PR)
- [x] Added regression tests that would catch: observe→control→restore baseline, passive remote-desktop-fit not claiming ownership, multi-pane takeover false positive, owner disconnect restore

## AI Review Report

Reviewed iteratively with Codex (and prior self-review):

1. **Observe must not write host restore baseline** — fixed; pure `observe` even under phone-fit.
2. **Passive ResizeObserver under `remote-desktop-fit` must not control-resize** — fixed; only mobile-fit forwards remote passive geometry.
3. **Takeover baseline per pane binding (leafId), not per-pty** — fixed; multi-pane same PTY covered by tests.
4. **Owner disconnect must release ownership** — fixed; shared `releaseRemoteDesktopSizeOwner` path also used by Restore.
5. **i18n catalog** — added `remoteDesktopEyebrow/Title/Body` to `en.json`.
6. **Cross-platform** — no OS-specific keyboard/path/shell changes; resize arbitration is main/renderer/runtime and applies on macOS, Linux, and Windows the same way. No Electron accelerator or path-separator changes.

## Security Audit

- No new auth, secrets, or shell command paths.
- Resize/ownership is session-local runtime state keyed by existing client ids; disconnect clears remote ownership so a gone client cannot keep size control.
- IPC/RPC surfaces reuse existing `terminal.updateViewport` / fit-override channels; observe vs control is intentional intent, not a privilege escalation path.
- No dependency changes.

## Notes

- Related: #7209 (SSH host size locked — related family, different topology); mobile fit-hold / #7588 / #7749 / #6596 paths reused and must not regress.
- Pre-existing `verify:localization-catalog` missing keys on main (ForgetSshWorkspaceDialog, HostRemoveDialog, …) are out of scope; this PR only adds its own three overlay strings.
- Backward-compat: clients without `client.id` share `remote-unknown` and may still tug among themselves — intentional fallback.