### PR TITLE
fix(mobile): surface disconnected source-control states + keep the mobile WS fallback port stable (STA-1511)

### DIFF
--- a/mobile/app/h/[hostId]/history/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/history/[worktreeId].tsx
@@ -3,14 +3,15 @@ import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from '
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react-native'
-import { useHostClient } from '../../../../src/transport/client-context'
+import { useForceReconnect, useHostClient } from '../../../../src/transport/client-context'
 import type { RpcSuccess } from '../../../../src/transport/types'
-import { colors, spacing, typography } from '../../../../src/theme/mobile-theme'
+import { colors, radii, spacing, typography } from '../../../../src/theme/mobile-theme'
 import {
   fetchMobileGitHistory,
   mapMobileCommitRows,
   type MobileCommitRow
 } from '../../../../src/source-control/mobile-git-history'
+import { resolveMobileHistoryScreenView } from '../../../../src/source-control/mobile-history-screen-state'
 import type { GitBranchChangeEntry } from '../../../../../src/shared/types'
 
 function firstParam(value: string | string[] | undefined): string {
@@ -27,9 +28,11 @@ export default function HistoryScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const { client, state: connState } = useHostClient(hostId)
+  const forceReconnect = useForceReconnect()
 
   const [rows, setRows] = useState<MobileCommitRow[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [reloadNonce, setReloadNonce] = useState(0)
   const [expanded, setExpanded] = useState<string | null>(null)
   const [filesById, setFilesById] = useState<Record<string, GitBranchChangeEntry[] | 'loading'>>({})
 
@@ -57,7 +60,20 @@ export default function HistoryScreen() {
     return () => {
       active = false
     }
-  }, [client, connState, worktreeId])
+  }, [client, connState, reloadNonce, worktreeId])
+
+  const retry = useCallback(() => {
+    setError(null)
+    // Why: retrying the fetch is useless while the transport's reconnect loop
+    // is parked at its backoff cap — revive the connection instead (mirrors
+    // MobileSourceControlPanel / issue #5049). The load effect re-runs via
+    // connState once the fresh client connects.
+    if (connState !== 'connected' && hostId) {
+      void forceReconnect(hostId)
+      return
+    }
+    setReloadNonce((n) => n + 1)
+  }, [connState, forceReconnect, hostId])
 
   const toggleCommit = useCallback(
     (row: MobileCommitRow) => {
@@ -130,6 +146,12 @@ export default function HistoryScreen() {
     [expanded, filesById, toggleCommit]
   )
 
+  const view = resolveMobileHistoryScreenView({
+    connected: client !== null && connState === 'connected',
+    rows,
+    error
+  })
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.header}>
@@ -138,21 +160,26 @@ export default function HistoryScreen() {
         </Pressable>
         <Text style={styles.title}>Commit History</Text>
       </View>
-      {error ? (
+      {view.kind === 'error' || view.kind === 'waiting' ? (
         <View style={styles.state}>
-          <Text style={styles.stateText}>{error}</Text>
+          <Text style={styles.stateText}>
+            {view.kind === 'waiting' ? 'Waiting for desktop...' : view.message}
+          </Text>
+          <Pressable style={styles.retryButton} onPress={retry} accessibilityLabel="Retry">
+            <Text style={styles.retryText}>Retry</Text>
+          </Pressable>
         </View>
-      ) : rows === null ? (
+      ) : view.kind === 'loading' ? (
         <View style={styles.state}>
           <ActivityIndicator color={colors.textSecondary} />
         </View>
-      ) : rows.length === 0 ? (
+      ) : view.kind === 'empty' ? (
         <View style={styles.state}>
           <Text style={styles.stateText}>No commits.</Text>
         </View>
       ) : (
         <FlatList
-          data={rows}
+          data={view.rows}
           renderItem={renderCommit}
           keyExtractor={(row) => row.id}
           contentContainerStyle={{ paddingBottom: spacing.lg + insets.bottom }}
@@ -175,6 +202,14 @@ const styles = StyleSheet.create({
   title: { color: colors.textPrimary, fontSize: typography.bodySize, fontWeight: '600' },
   state: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.lg },
   stateText: { color: colors.textMuted, fontSize: typography.bodySize },
+  retryButton: {
+    marginTop: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised
+  },
+  retryText: { color: colors.textPrimary, fontSize: typography.bodySize, fontWeight: '600' },
   commit: { borderBottomWidth: 1, borderBottomColor: colors.borderSubtle },
   commitHeader: {
     flexDirection: 'row',

--- a/mobile/src/source-control/MobileSourceControlContent.tsx
+++ b/mobile/src/source-control/MobileSourceControlContent.tsx
@@ -16,6 +16,7 @@ type Props = {
 export function MobileSourceControlContent({ state }: Props) {
   const {
     insets,
+    connState,
     busyAction,
     commitMessage,
     setCommitMessage,
@@ -56,6 +57,15 @@ export function MobileSourceControlContent({ state }: Props) {
 
   return (
     <>
+      {connState !== 'connected' ? (
+        // Why: once data has loaded the screen looks alive even when the
+        // desktop link is down, so taps appear to do nothing (STA-1511).
+        // Surface the reconnect state where the user is looking.
+        <View style={styles.reconnectBanner}>
+          <ActivityIndicator size="small" color={colors.statusAmber} />
+          <Text style={styles.reconnectBannerText}>Reconnecting to desktop...</Text>
+        </View>
+      ) : null}
       <View style={styles.summaryCard}>
         <View style={styles.summaryHeader}>
           <View style={styles.branchLine}>

--- a/mobile/src/source-control/mobile-history-screen-state.test.ts
+++ b/mobile/src/source-control/mobile-history-screen-state.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMobileHistoryScreenView } from './mobile-history-screen-state'
+import type { MobileCommitRow } from './mobile-git-history'
+
+const row: MobileCommitRow = {
+  id: 'abc123',
+  shortId: 'abc123',
+  subject: 'commit',
+  author: 'author',
+  parentId: null,
+  relativeTime: '1m'
+}
+
+describe('resolveMobileHistoryScreenView', () => {
+  it('shows waiting (not an endless spinner) when disconnected with nothing loaded', () => {
+    // Regression (STA-1511): the load effect no-ops while disconnected, so
+    // rows stay null forever — the screen must offer a retry, not a spinner.
+    expect(resolveMobileHistoryScreenView({ connected: false, rows: null, error: null })).toEqual({
+      kind: 'waiting'
+    })
+  })
+
+  it('spins only while connected and loading', () => {
+    expect(resolveMobileHistoryScreenView({ connected: true, rows: null, error: null })).toEqual({
+      kind: 'loading'
+    })
+  })
+
+  it('keeps already-loaded rows visible across a connection drop', () => {
+    expect(resolveMobileHistoryScreenView({ connected: false, rows: [row], error: null })).toEqual({
+      kind: 'rows',
+      rows: [row]
+    })
+  })
+
+  it('prefers the error state over waiting so failures stay actionable', () => {
+    expect(resolveMobileHistoryScreenView({ connected: false, rows: null, error: 'boom' })).toEqual(
+      { kind: 'error', message: 'boom' }
+    )
+  })
+
+  it('distinguishes an empty history from a pending load', () => {
+    expect(resolveMobileHistoryScreenView({ connected: true, rows: [], error: null })).toEqual({
+      kind: 'empty'
+    })
+  })
+})

--- a/mobile/src/source-control/mobile-history-screen-state.ts
+++ b/mobile/src/source-control/mobile-history-screen-state.ts
@@ -1,0 +1,30 @@
+import type { MobileCommitRow } from './mobile-git-history'
+
+export type MobileHistoryScreenView =
+  | { kind: 'error'; message: string }
+  | { kind: 'waiting' }
+  | { kind: 'loading' }
+  | { kind: 'empty' }
+  | { kind: 'rows'; rows: MobileCommitRow[] }
+
+// Why: the history load effect no-ops while the client isn't connected, so
+// without an explicit 'waiting' view the screen showed an infinite spinner
+// with no retry when opened during a reconnect window (STA-1511). Rows loaded
+// before a drop stay visible — stale history beats a blank screen.
+export function resolveMobileHistoryScreenView(input: {
+  connected: boolean
+  rows: MobileCommitRow[] | null
+  error: string | null
+}): MobileHistoryScreenView {
+  const { connected, rows, error } = input
+  if (error) {
+    return { kind: 'error', message: error }
+  }
+  if (rows !== null) {
+    return rows.length === 0 ? { kind: 'empty' } : { kind: 'rows', rows }
+  }
+  if (!connected) {
+    return { kind: 'waiting' }
+  }
+  return { kind: 'loading' }
+}

--- a/mobile/src/source-control/mobile-source-control-styles.ts
+++ b/mobile/src/source-control/mobile-source-control-styles.ts
@@ -125,6 +125,24 @@ const baseStyles = StyleSheet.create({
     fontWeight: '600',
     textTransform: 'capitalize'
   },
+  reconnectBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.lg,
+    marginBottom: -spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.statusAmber
+  },
+  reconnectBannerText: {
+    color: colors.textPrimary,
+    fontSize: typography.metaSize
+  },
   actionError: {
     marginTop: spacing.sm,
     paddingHorizontal: spacing.md,

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -1,0 +1,159 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ConnectionState } from './types'
+import type { RpcClient } from './rpc-client'
+
+const connectMock = vi.fn()
+const loadHostsMock = vi.fn()
+
+vi.mock('./rpc-client', () => ({
+  connect: (...args: unknown[]) => connectMock(...args)
+}))
+vi.mock('./host-store', () => ({
+  loadHosts: () => loadHostsMock()
+}))
+vi.mock('./connection-revival-triggers', () => ({
+  subscribeConnectionRevivalTriggers: () => () => {}
+}))
+
+import { RpcClientProvider, useCloseHost, useHostClient } from './client-context'
+
+type FakeClient = RpcClient & {
+  emitState: (state: ConnectionState) => void
+  closeMock: ReturnType<typeof vi.fn>
+}
+
+function makeFakeClient(initialState: ConnectionState): FakeClient {
+  let state = initialState
+  const listeners = new Set<(state: ConnectionState) => void>()
+  const closeMock = vi.fn()
+  return {
+    sendRequest: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+    updateTerminalSubscriptionViewport: vi.fn(),
+    getState: () => state,
+    getReconnectAttempt: () => 0,
+    getLastConnectedAt: () => null,
+    onStateChange: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    notifyForeground: vi.fn(),
+    close: closeMock,
+    closeMock,
+    emitState: (next) => {
+      state = next
+      for (const listener of listeners) {
+        listener(next)
+      }
+    }
+  } as FakeClient
+}
+
+const HOST = {
+  id: 'host-1',
+  name: 'Host 1',
+  endpoint: 'ws://127.0.0.1:1',
+  deviceToken: 'token',
+  publicKeyB64: 'key',
+  lastConnected: 0
+}
+
+type Harness = {
+  readonly hook: ReturnType<typeof useHostClient>
+  readonly closeHost: (hostId: string) => void
+  readonly unmount: () => void
+}
+
+function suppressReactTestRendererDeprecationWarning(): () => void {
+  const originalConsoleError = console.error
+  const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    const firstArg = args[0]
+    if (typeof firstArg === 'string' && firstArg.includes('react-test-renderer is deprecated')) {
+      return
+    }
+    originalConsoleError(...args)
+  })
+  return () => spy.mockRestore()
+}
+
+async function renderHarness(hostId: string): Promise<Harness> {
+  let hook: ReturnType<typeof useHostClient> | null = null
+  let closeHost: ((hostId: string) => void) | null = null
+  let renderer: ReactTestRenderer | null = null
+
+  function Probe(): null {
+    hook = useHostClient(hostId)
+    closeHost = useCloseHost()
+    return null
+  }
+
+  const restore = suppressReactTestRendererDeprecationWarning()
+  try {
+    await act(async () => {
+      renderer = create(createElement(RpcClientProvider, null, createElement(Probe)))
+    })
+  } finally {
+    restore()
+  }
+  if (!hook || !closeHost || !renderer) {
+    throw new Error('harness did not render')
+  }
+  const mounted = renderer as ReactTestRenderer
+  return {
+    get hook() {
+      if (!hook) {
+        throw new Error('hook not rendered')
+      }
+      return hook
+    },
+    closeHost: (id) => {
+      if (!closeHost) {
+        throw new Error('closeHost not rendered')
+      }
+      closeHost(id)
+    },
+    unmount: () => mounted.unmount()
+  }
+}
+
+beforeEach(() => {
+  connectMock.mockReset()
+  loadHostsMock.mockReset()
+})
+
+describe('useHostClient', () => {
+  it('drops the closed client when the host entry is removed', async () => {
+    const fake = makeFakeClient('connected')
+    connectMock.mockReturnValue(fake)
+    loadHostsMock.mockResolvedValue([HOST])
+
+    const harness = await renderHarness(HOST.id)
+    expect(harness.hook.client).toBe(fake)
+    expect(harness.hook.state).toBe('connected')
+
+    // Regression (STA-1511): closeHost deletes the entry; before the fix the
+    // hook kept handing out the closed client, so mounted screens kept
+    // driving requests that could never resolve.
+    await act(async () => {
+      harness.closeHost(HOST.id)
+    })
+    expect(fake.closeMock).toHaveBeenCalled()
+    expect(harness.hook.client).toBeNull()
+    expect(harness.hook.state).toBe('disconnected')
+
+    harness.unmount()
+  })
+
+  it('reports disconnected instead of hanging when the host id is unknown', async () => {
+    loadHostsMock.mockResolvedValue([])
+
+    const harness = await renderHarness('missing-host')
+    expect(connectMock).not.toHaveBeenCalled()
+    expect(harness.hook.client).toBeNull()
+    expect(harness.hook.state).toBe('disconnected')
+
+    harness.unmount()
+  })
+})

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -133,6 +133,11 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
           return null
         }
         if (!host) {
+          // Why: returning silently leaves mounted screens on a permanent
+          // spinner (STA-1511) — surface 'disconnected' so they can render
+          // their waiting/retry affordance instead.
+          notifyHostState(hostId, 'disconnected')
+          notifyAllHosts()
           return null
         }
       }
@@ -405,6 +410,12 @@ export function useHostClient(hostId: string | undefined): {
       const found = ctx.getAllClients().find((entry) => entry.hostId === hostId)
       if (found && found.client !== clientRef.current) {
         clientRef.current = found.client
+        force((n) => n + 1)
+      } else if (!found && clientRef.current) {
+        // Why: closeHost deletes the entry without a replacement; holding the
+        // closed client would let screens keep issuing requests that can never
+        // resolve (STA-1511). Null it so they render disconnected states.
+        clientRef.current = null
         force((n) => n + 1)
       }
     })

--- a/src/main/runtime/rpc/ws-fallback-port-store.test.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.test.ts
@@ -1,0 +1,35 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { readWsFallbackPort, writeWsFallbackPort } from './ws-fallback-port-store'
+
+function makeUserDataPath(): string {
+  return mkdtempSync(join(tmpdir(), 'ws-fallback-port-test-'))
+}
+
+describe('ws-fallback-port-store', () => {
+  it('round-trips a persisted fallback port', () => {
+    const userDataPath = makeUserDataPath()
+    expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+    writeWsFallbackPort(userDataPath, 54321)
+    expect(readWsFallbackPort(userDataPath)).toBe(54321)
+  })
+
+  it('ignores corrupt or invalid contents', () => {
+    const userDataPath = makeUserDataPath()
+    writeFileSync(join(userDataPath, 'mobile-ws-fallback-port.json'), 'not json', 'utf8')
+    expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+    writeFileSync(join(userDataPath, 'mobile-ws-fallback-port.json'), '{"port":-4}', 'utf8')
+    expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+    writeFileSync(join(userDataPath, 'mobile-ws-fallback-port.json'), '{"port":"80"}', 'utf8')
+    expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+  })
+
+  it('refuses to persist an invalid port', () => {
+    const userDataPath = makeUserDataPath()
+    writeWsFallbackPort(userDataPath, 0)
+    writeWsFallbackPort(userDataPath, 70000)
+    expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+  })
+})

--- a/src/main/runtime/rpc/ws-fallback-port-store.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.ts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Why: when the preferred WS port is taken (second Orca instance), the OS
+// assigns a random port. Paired mobile devices store ws://ip:port endpoints,
+// so a port that changes on every restart permanently orphans those pairings
+// (STA-1511). Persist the assigned fallback so the same instance re-binds the
+// same port next launch.
+
+const FALLBACK_PORT_FILE = 'mobile-ws-fallback-port.json'
+
+function isValidPort(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 65535
+}
+
+export function readWsFallbackPort(userDataPath: string): number | undefined {
+  try {
+    const raw = readFileSync(join(userDataPath, FALLBACK_PORT_FILE), 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      isValidPort((parsed as { port?: unknown }).port)
+    ) {
+      return (parsed as { port: number }).port
+    }
+  } catch {
+    // Missing or corrupt file — treated as "no previous fallback".
+  }
+  return undefined
+}
+
+export function writeWsFallbackPort(userDataPath: string, port: number): void {
+  if (!isValidPort(port)) {
+    return
+  }
+  try {
+    writeFileSync(join(userDataPath, FALLBACK_PORT_FILE), JSON.stringify({ port }), 'utf8')
+  } catch {
+    // Why: persistence is best-effort — failing to record the port must not
+    // break transport startup; the cost is a re-pair after the next restart.
+  }
+}

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -441,4 +441,55 @@ describe('WebSocketTransport', () => {
     expect(serverClosed).toBe(true)
     expect(wss.clients.size).toBe(0)
   }, 5_000)
+
+  // Why: paired mobile devices store ws://ip:port endpoints, so the fallback
+  // port must stay stable across restarts or pairings go permanently dead
+  // when the preferred port is held by another instance (STA-1511).
+  describe('fallback port stability', () => {
+    async function reserveFreePort(): Promise<number> {
+      const scratch = new WebSocketTransport({ host: '127.0.0.1', port: 0 })
+      await scratch.start()
+      const port = scratch.resolvedPort
+      await scratch.stop()
+      return port
+    }
+
+    it('retries the persisted fallback port before an OS-assigned one', async () => {
+      const holder = new WebSocketTransport({ host: '127.0.0.1', port: 0 })
+      transports.push(holder)
+      await holder.start()
+      const takenPort = holder.resolvedPort
+      const fallbackPort = await reserveFreePort()
+
+      const transport = new WebSocketTransport({
+        host: '127.0.0.1',
+        port: takenPort,
+        fallbackPort
+      })
+      transports.push(transport)
+      await transport.start()
+      expect(transport.resolvedPort).toBe(fallbackPort)
+    })
+
+    it('falls back to an OS-assigned port when the persisted port is also taken', async () => {
+      const holder = new WebSocketTransport({ host: '127.0.0.1', port: 0 })
+      const fallbackHolder = new WebSocketTransport({ host: '127.0.0.1', port: 0 })
+      transports.push(holder, fallbackHolder)
+      await holder.start()
+      await fallbackHolder.start()
+      const takenPort = holder.resolvedPort
+      const takenFallbackPort = fallbackHolder.resolvedPort
+
+      const transport = new WebSocketTransport({
+        host: '127.0.0.1',
+        port: takenPort,
+        fallbackPort: takenFallbackPort
+      })
+      transports.push(transport)
+      await transport.start()
+      expect(transport.resolvedPort).not.toBe(takenPort)
+      expect(transport.resolvedPort).not.toBe(takenFallbackPort)
+      expect(transport.resolvedPort).toBeGreaterThan(0)
+    })
+  })
 })

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -48,6 +48,11 @@ export type WebSocketTransportOptions = {
   // Why: the pairing server can also serve the browser client, so users do
   // not need a second dev/static server once the web bundle is built.
   staticRoot?: string
+  // Why: when the preferred port is taken, an unstable OS-assigned port would
+  // change on every restart and permanently orphan existing mobile pairings
+  // (their stored ws://ip:port endpoint goes dead — STA-1511). Callers pass
+  // the previously assigned fallback port so it is retried first.
+  fallbackPort?: number
 }
 
 export class WebSocketTransport implements RpcTransport {
@@ -58,6 +63,7 @@ export class WebSocketTransport implements RpcTransport {
   private readonly heartbeatIntervalMs: number
   private readonly preAuthTimeoutMs: number
   private readonly staticRoot: string | undefined
+  private readonly fallbackPort: number | undefined
   private httpServer: HttpsServer | HttpServer | null = null
   private wss: WebSocketServer | null = null
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
@@ -81,7 +87,8 @@ export class WebSocketTransport implements RpcTransport {
     tlsKey,
     heartbeatIntervalMs,
     preAuthTimeoutMs,
-    staticRoot
+    staticRoot,
+    fallbackPort
   }: WebSocketTransportOptions) {
     this.host = host
     this.port = port
@@ -90,6 +97,7 @@ export class WebSocketTransport implements RpcTransport {
     this.heartbeatIntervalMs = heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS
     this.preAuthTimeoutMs = preAuthTimeoutMs ?? PRE_AUTH_TIMEOUT_MS
     this.staticRoot = staticRoot
+    this.fallbackPort = fallbackPort
   }
 
   onMessage(handler: WebSocketMessageHandler): void {
@@ -144,19 +152,37 @@ export class WebSocketTransport implements RpcTransport {
     // Why: when the preferred port is occupied (e.g. another Orca instance is
     // already running), fall back to an OS-assigned port so mobile pairing
     // still works. The QR code reads resolvedPort after start, so it will
-    // advertise the correct port regardless.
+    // advertise the correct port regardless. A persisted fallback port is
+    // retried before port 0 so paired devices keep a stable endpoint across
+    // restarts (STA-1511).
     let port = this.port
     try {
       await this.tryListen(port)
+      return
     } catch (error: unknown) {
-      if (isEAddressInUse(error) && port !== 0) {
-        console.warn(`[ws-transport] Port ${port} is in use, falling back to OS-assigned port`)
-        port = 0
-        await this.tryListen(port)
-      } else {
+      if (!isEAddressInUse(error) || port === 0) {
         throw error
       }
     }
+    if (
+      this.fallbackPort !== undefined &&
+      this.fallbackPort !== 0 &&
+      this.fallbackPort !== this.port
+    ) {
+      try {
+        console.warn(
+          `[ws-transport] Port ${port} is in use, retrying previous fallback port ${this.fallbackPort}`
+        )
+        await this.tryListen(this.fallbackPort)
+        return
+      } catch (error: unknown) {
+        if (!isEAddressInUse(error)) {
+          throw error
+        }
+      }
+    }
+    console.warn(`[ws-transport] Port ${port} is in use, falling back to OS-assigned port`)
+    await this.tryListen(0)
   }
 
   private createHttpServer(): HttpServer | HttpsServer {

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -16,6 +16,7 @@ import { errorResponse } from './rpc/errors'
 import type { RpcMessageContext, RpcTransport } from './rpc/transport'
 import { UnixSocketTransport } from './rpc/unix-socket-transport'
 import { WebSocketTransport } from './rpc/ws-transport'
+import { readWsFallbackPort, writeWsFallbackPort } from './rpc/ws-fallback-port-store'
 import type { WebSocket } from 'ws'
 import { DeviceRegistry, type DeviceScope } from './device-registry'
 import { loadOrCreateE2EEKeypair, type E2EEKeypair } from './e2ee-keypair'
@@ -702,7 +703,11 @@ export class OrcaRuntimeRpcServer {
         const wsTransport = new WebSocketTransport({
           host: '0.0.0.0',
           port: this.wsPort,
-          staticRoot: this.webClientRoot
+          staticRoot: this.webClientRoot,
+          // Why: keep the fallback port stable across restarts so paired
+          // devices' stored endpoints stay valid (STA-1511). wsPort 0 means
+          // the caller explicitly wants a random port (E2E) — don't pin it.
+          ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {})
         })
         this.wsTransport = wsTransport
 
@@ -785,6 +790,9 @@ export class OrcaRuntimeRpcServer {
         })
 
         await wsTransport.start()
+        if (this.wsPort !== 0 && wsTransport.resolvedPort !== this.wsPort) {
+          writeWsFallbackPort(this.userDataPath, wsTransport.resolvedPort)
+        }
         activeTransports.push(wsTransport)
         transportsMeta.push({
           kind: 'websocket',


### PR DESCRIPTION
Fixes STA-1511 ([WeChat User][Mobile] Unable to load the files under Changes & Unchanged).

## What the user hit

Orca Mobile 0.0.24, paired with a desktop. Their Source Control screen loaded (1241 files / 486 commits vs `origin/internal/main`), then tapping files under Changes/Untracked did nothing, and Commit History spun forever. Reproduced on an Android emulator: the git features work — every symptom is a **silently dead desktop connection behind a loaded-looking UI**. Full investigation notes are on the Linear ticket thread (agent session).

## Root causes fixed

**Mobile**

1. **Commit History screen had no failure states** (`mobile/app/h/[hostId]/history/[worktreeId].tsx`). Its load effect silently no-ops unless `client && connState === 'connected'`, so mounting during a reconnect window left an infinite spinner with no error, no timeout, no retry — the ticket's screenshot. Now: a "Waiting for desktop..." state with a Retry button (Retry revives the connection via `forceReconnect`, mirroring the source-control panel's issue `#5049` pattern), an error state with Retry, and rows loaded before a drop stay visible. View precedence lives in a pure resolver (`mobile-history-screen-state.ts`) with unit tests.
2. **`useHostClient` kept handing out a closed client** after `closeHost` removed the entry — mounted screens kept driving requests that could never resolve. Now the hook nulls its client and reports `disconnected` when the entry disappears (fail-on-revert test included).
3. **`openEntry` returned `null` silently for an unknown host id** — screens waiting on that host spun forever with zero feedback. Now it notifies `disconnected` (parity with the existing keychain-failure branch).
4. **Source Control gave no visible signal when the link dropped behind loaded content** — taps on file rows were rejected with only a subtle `actionError` line, which reads as "clicking has no effect". Now a "Reconnecting to desktop..." banner renders over loaded content whenever `connState !== 'connected'`.

**Desktop**

5. **The WS fallback port changed on every restart**, permanently orphaning pairings. When the preferred port (6768/6769) is held by another Orca instance, the transport fell back to a fresh OS-assigned port each launch — but paired devices store `ws://ip:port` endpoints, so every desktop restart bricked existing pairings until a manual re-pair. Now the assigned fallback port is persisted (`userData/mobile-ws-fallback-port.json`) and retried before falling back to a new OS-assigned port. E2E/`wsPort: 0` callers are exempt.

## Validation

- Unit: 7 new mobile tests (view resolver + client-context, the dead-client test proven fail-on-revert) and 5 new desktop tests (port-store round-trip/corruption, transport fallback chain with genuinely occupied ports). Full mobile suite 175 files / 1258 tests green; `typecheck:node`, mobile `tsc`, oxlint, oxfmt green. The only lint failure (`source-control-manual-review-url.ts` switch-exhaustiveness) pre-exists on `origin/main` and is untouched by this diff.
- Live on Android emulator + dev desktop:
  - Killed the desktop while Source Control was open → clear "Unable to Load / Waiting for desktop... / Retry" instead of a dead-looking loaded screen; Retry revived the connection and reloaded.
  - Fallback port persisted as `{"port":53165}` on first launch; on restart the log shows `retrying previous fallback port 53165` and the transport re-bound it — the paired emulator auto-reconnected to the restarted desktop **without re-pairing** (previously impossible once the preferred port was taken).
- The history screen's new waiting/retry UI and the reconnect banner are covered by the unit tests above; their live repro window (mount mid-reconnect) is timing-dependent and was exercised via the resolver tests rather than screenshots.

## Follow-ups (not in this PR)

- Uncaught `sendRequest` rejections ("Connection interrupted" / "Client closed", request id 0) surface as dev LogBox toasts during client swaps — harmless but noisy; worth a `.catch` sweep at fire-and-forget call sites.
- Reconnect backoff reaches 30–60s between attempts; a foreground tap could reset the schedule.
- Stale host records dial dead endpoints forever (see also STA-1288 re-pair dupes); a "host unreachable — remove?" affordance would help.

Made with [Orca](https://github.com/stablyai/orca) 🐋
