### PR TITLE
fix(updater): restore Windows update signature verification

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1766,11 +1766,14 @@ describe('updater', () => {
     expect(setPendingUpdateNudgeId).toHaveBeenCalledWith(null)
   })
 
-  // Why: issue #631 — the Windows auto-updater fails because installed
-  // versions signed with the wrong certificate have a stale publisherName
-  // in app-update.yml. verifyUpdateCodeSignature must be overridden on
-  // Windows so electron-updater skips Authenticode verification.
-  it('overrides verifyUpdateCodeSignature on Windows to skip signing verification', async () => {
+  // Why: the Windows auto-updater must keep electron-updater's built-in
+  // Authenticode verification, which checks the downloaded installer against
+  // the SignPath Foundation publisherName that electron-builder embeds in
+  // app-update.yml. A no-op verifyUpdateCodeSignature override would silently
+  // accept every installer, so setup must NOT install one. (The issue #631
+  // stale-publisherName problem that once justified an override is resolved now
+  // that SignPath builds embed the correct publisherName.)
+  it('does not disable Windows Authenticode verification on win32', async () => {
     vi.stubGlobal('process', { ...process, platform: 'win32' })
 
     const { setupAutoUpdater } = await import('./updater')
@@ -1780,11 +1783,7 @@ describe('updater', () => {
 
     setupAutoUpdater(mainWindow as never)
 
-    // The override should be set on the autoUpdater mock
-    const override = (autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature
-    expect(override).toBeTypeOf('function')
-    // Calling it should resolve to null (meaning "signature valid, skip check")
-    await expect((override as () => Promise<string | null>)()).resolves.toBeNull()
+    expect((autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature).toBeUndefined()
   })
 
   it('does not override verifyUpdateCodeSignature on non-Windows platforms', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines */
 import { app, BrowserWindow, powerMonitor } from 'electron'
-import type { NsisUpdater } from 'electron-updater'
 import { is } from '@electron-toolkit/utils'
 import type { UpdateCheckOptions, UpdateStatus } from '../shared/types'
 import { killAllPty } from './ipc/pty'
@@ -1269,15 +1268,11 @@ export function setupAutoUpdater(
     debug: (m: unknown) => console.debug('[autoUpdater]', m)
   } as never
 
-  // Why: older Windows installs either have no publisherName or have the
-  // stale macOS Apple Developer ID publisherName from issue #631. Keep the
-  // migration path open while SignPath-signed builds roll out.
-  //
-  // TODO: re-enable after SignPath-signed builds with the explicit Windows
-  // publisherName have been the minimum supported updater source for a while.
-  if (process.platform === 'win32') {
-    ;(autoUpdater as NsisUpdater).verifyUpdateCodeSignature = () => Promise.resolve(null)
-  }
+  // Why: Windows update integrity is enforced by electron-updater's built-in
+  // Authenticode check against the `publisherName` (SignPath Foundation) that
+  // electron-builder embeds in app-update.yml. Do NOT re-add a
+  // `verifyUpdateCodeSignature` override — a no-op override silently accepts
+  // every downloaded installer, disabling signature verification entirely.
 
   // Use the generic provider with GitHub's /releases/latest/download/ URL as
   // the startup fallback so electron-updater can fetch the manifest


### PR DESCRIPTION
## Summary

The Windows auto-updater overrode `verifyUpdateCodeSignature` to a no-op on win32, so electron-updater accepted any downloaded installer without running an Authenticode check. This removes the override so the built-in verification runs again.

The override was a migration shim for `#631` (installs with a stale/missing `publisherName` in `app-update.yml`). That condition is resolved: SignPath-signed builds now embed `publisherName: [SignPath Foundation]` in `app-update.yml`, and the released installer's signer subject is `CN=SignPath Foundation` — so electron-updater's default verifier can validate the downloaded installer against it.

## What changed

- `src/main/updater.ts`: remove the win32 `verifyUpdateCodeSignature` no-op override (and its now-unused `NsisUpdater` import). Verification is left to electron-updater's built-in Authenticode check against the embedded `publisherName`.
- `src/main/updater.test.ts`: the existing test pinned the no-op override (asserted it was installed and resolved to `null`); update it to assert Windows verification stays enabled.

## How we know this fixes it

The advisory's defect is that verification was disabled. Removing the override restores it; the evidence that verification then succeeds on genuine releases and rejects impostors:

1. **The restored path is electron-updater's built-in verifier.** With the override gone, `NsisUpdater.verifySignature` reads `publisherName` from the running build's `app-update.yml` and runs `Get-AuthenticodeSignature` on the downloaded installer, requiring `Status = Valid`, a matching file path, and the signer **subject** to match `publisherName`.
2. **The inputs it needs are present and correct** — both checked against the current `v1.4.128` release:
   - `app-update.yml` embeds `publisherName: [SignPath Foundation]`.
   - `orca-windows-setup.exe` is Authenticode-signed, signer subject `CN=SignPath Foundation` (chain: GlobalSign GCC R45 CodeSigning CA 2020 → GlobalSign Code Signing Root R45).
   - CN match ⇒ a genuine SignPath-signed release **passes**; an installer not signed by that subject **fails** and is not installed.
3. **Standard mechanism.** This is the electron-builder / electron-updater `publisherName` verification used across the ecosystem, not a bespoke check.
4. **No migration breakage.** The restored verifier only runs once a client is already on a build containing this change; the hop *to* the fixed build uses the existing (no-op) code. No current user is stranded, and any hypothetical mismatch could only affect the version-after-next.
5. **RC installers are signed too.** SignPath signing in `release-cut.yml` is gated on `matrix.platform == 'win'`, not on release channel — so prerelease auto-update is unaffected, and rc→rc Windows updates exercise the restored verifier on real signed installers before stable.
6. **Existing Windows-update E2E suites are unaffected.** `win-update-e2e.yml` and `win-update-survival-e2e.yml` install the `.exe` directly via `silentInstall` (they do not traverse electron-updater's download/verify path), so this change neither breaks them nor depends on them for signature coverage.

**Not yet observed end-to-end:** verification here is static analysis + unit tests (electron-updater mocked) + live artifact inspection; a real Windows `Get-AuthenticodeSignature` verify-and-install has not been run. The rc→rc Windows auto-update in the normal RC cycle is the intended validation gate before a stable release.

## Validation

- `updater.test.ts` (75) + sibling `setupAutoUpdater` suites pass; oxlint + oxfmt clean.

Supersedes #6990 — that PR's custom PowerShell verifier plus a pinned leaf-certificate thumbprint is unnecessary once the override is removed, and a single-leaf thumbprint pin would break auto-update whenever the SignPath certificate rotates.
