### PR TITLE
Collapse Grok rotating working titles to stable label

### DIFF
--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -390,6 +390,35 @@ describe('normalizeTerminalTitle', () => {
     expect(normalizeTerminalTitle('bash')).toBe('bash')
   })
 
+  it('collapses Grok rotating working titles to one stable label', () => {
+    // Grok interpolates a rotating status/tool phrase between the spinner and its
+    // name, so each frame is a distinct title; they must all fold to one label.
+    expect(normalizeTerminalTitle('⠋ - Waiting for response… - grok')).toBe('⠋ Grok')
+    expect(normalizeTerminalTitle('⠴ - Thinking - grok')).toBe('⠋ Grok')
+    expect(normalizeTerminalTitle('⠙ - Responding - grok')).toBe('⠋ Grok')
+    expect(normalizeTerminalTitle('⠦ - Sleep 2s then echo hello-from-grok… - grok')).toBe('⠋ Grok')
+    expect(
+      normalizeTerminalTitle('⠹ - Waiting for response… - Execute Shell Command sleep 2 - grok')
+    ).toBe('⠋ Grok')
+    // Idempotent: re-normalizing our own collapsed label stays stable.
+    expect(normalizeTerminalTitle('⠋ Grok')).toBe('⠋ Grok')
+  })
+
+  it('leaves Grok idle and session titles unchanged', () => {
+    // No spinner → not a working frame; the meaningful final title still shows.
+    expect(normalizeTerminalTitle('grok')).toBe('grok')
+    expect(normalizeTerminalTitle('Fix the auth bug - grok')).toBe('Fix the auth bug - grok')
+    // Names "grok" mid-title but ends with another agent → not a Grok frame.
+    expect(normalizeTerminalTitle('⠋ debugging grok - claude')).toBe('⠋ debugging grok - claude')
+    // Claude/Codex task text ending in "grok" must not collapse — only the
+    // Grok Build identity suffix " - grok" is the rotating-frame signal.
+    expect(normalizeTerminalTitle('⠋ wire up grok')).toBe('⠋ wire up grok')
+    expect(normalizeTerminalTitle('⠋ Codex is thinking about grok')).toBe(
+      '⠋ Codex is thinking about grok'
+    )
+    expect(normalizeTerminalTitle('⠋ support for Grok')).toBe('⠋ support for Grok')
+  })
+
   it('collapses Pi spinner and idle titles to stable labels', () => {
     expect(normalizeTerminalTitle('⠋ π - my-project')).toBe('⠋ Pi')
     expect(normalizeTerminalTitle('π - my-project')).toBe('Pi')

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -1,5 +1,32 @@
 import { describe, expect, it } from 'vitest'
-import { resolveExplicitTerminalTitleAgentType } from './terminal-title-agent-type'
+import {
+  isGrokRotatingWorkingTitle,
+  resolveExplicitTerminalTitleAgentType
+} from './terminal-title-agent-type'
+
+describe('isGrokRotatingWorkingTitle', () => {
+  it('matches Grok working frames regardless of the rotating middle text', () => {
+    expect(isGrokRotatingWorkingTitle('⠋ - Waiting for response… - grok')).toBe(true)
+    expect(isGrokRotatingWorkingTitle('⠴ - Thinking - grok')).toBe(true)
+    expect(isGrokRotatingWorkingTitle('⠦ - Sleep 2s then echo hello… - grok')).toBe(true)
+    // Collapsed/stable form must stay matched so re-normalization is idempotent.
+    expect(isGrokRotatingWorkingTitle('⠋ grok')).toBe(true)
+    expect(isGrokRotatingWorkingTitle('⠋ Grok')).toBe(true)
+  })
+
+  it('ignores non-working, non-Grok, and lookalike titles', () => {
+    expect(isGrokRotatingWorkingTitle('grok')).toBe(false) // idle bare name, no spinner
+    expect(isGrokRotatingWorkingTitle('Fix the auth bug - grok')).toBe(false) // session title, no spinner
+    expect(isGrokRotatingWorkingTitle('⠋ debugging grok - claude')).toBe(false) // trailing name is another agent
+    expect(isGrokRotatingWorkingTitle('⠋ ~/grok-scratch/ready')).toBe(false) // path fragment, not a trailing token
+    expect(isGrokRotatingWorkingTitle('⠋ grokking the plan')).toBe(false) // "grok" not a whole trailing token
+    expect(isGrokRotatingWorkingTitle('⠋ Codex')).toBe(false)
+    // Task text ending in "grok" is not the Grok Build identity suffix " - grok".
+    expect(isGrokRotatingWorkingTitle('⠋ wire up grok')).toBe(false)
+    expect(isGrokRotatingWorkingTitle('⠋ Codex is thinking about grok')).toBe(false)
+    expect(isGrokRotatingWorkingTitle('⠋ support for Grok')).toBe(false)
+  })
+})
 
 describe('resolveExplicitTerminalTitleAgentType', () => {
   it('maps explicit product-name titles to their TuiAgent id', () => {

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -51,6 +51,24 @@ export function isPiTerminalTitle(title: string): boolean {
   return isLegacyPiCompatibleTitle(title) && !containsBrailleSpinner(title)
 }
 
+// Why: Grok Build's working OSC titles interpolate a rotating status/tool phrase
+// between the spinner and its name — "⠋ - Waiting for response… - grok",
+// "⠴ - Thinking - grok", "⠦ - Sleep 2s… - grok" — so every frame is a distinct
+// title that flips the tab and sidebar labels. Require the identity suffix
+// " - grok" (not arbitrary task text ending in "grok") so Claude/Codex titles
+// like "⠋ wire up grok" stay intact. Spinner marks working; no-spinner session
+// titles ("Fix the auth bug - grok") pass through. The bare "spinner + grok"
+// branch keeps our own collapsed label idempotent under re-normalization.
+const GROK_FRAME_IDENTITY_SUFFIX_RE = / - grok\s*$/i
+const GROK_COLLAPSED_WORKING_TITLE_RE = /^[\u2800-\u28FF]+\s+grok\s*$/i
+
+export function isGrokRotatingWorkingTitle(title: string): boolean {
+  if (!containsBrailleSpinner(title)) {
+    return false
+  }
+  return GROK_FRAME_IDENTITY_SUFFIX_RE.test(title) || GROK_COLLAPSED_WORKING_TITLE_RE.test(title)
+}
+
 export function isPiAgentTitle(title: string): boolean {
   return isLegacyPiCompatibleTitle(title)
 }

--- a/src/shared/terminal-title-display.ts
+++ b/src/shared/terminal-title-display.ts
@@ -10,6 +10,7 @@ import {
   GEMINI_SILENT_WORKING,
   GEMINI_WORKING,
   isGeminiTerminalTitle,
+  isGrokRotatingWorkingTitle,
   isPiAgentTitle
 } from './terminal-title-agent-type'
 import {
@@ -93,6 +94,14 @@ export function normalizeTerminalTitle(title: string): string {
     if (status === 'idle') {
       return 'Pi'
     }
+  }
+
+  // Why: Grok Build interpolates a rotating status/tool phrase between the
+  // spinner and its name, so its working frames change the title many times per
+  // turn. Collapse them to one stable label; idle/session titles carry no
+  // spinner and pass through, so the meaningful final title still shows.
+  if (isGrokRotatingWorkingTitle(title)) {
+    return '\u280b Grok'
   }
 
   return title


### PR DESCRIPTION
## Summary

Collapses Grok Build's rotating working terminal titles (e.g., `⠋ - Waiting for response… - grok`, `⠴ - Thinking - grok`) to a single stable label (`⠋ Grok`). This prevents tab and sidebar labels from constantly jumping/flickering during agent execution. Idle/session titles and task text containing "grok" are preserved.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

*Note: Unit tests added in `agent-status.test.ts` and `terminal-title-agent-type.test.ts` verify both matching and non-matching lookalike/idle titles.*

## AI Review Report

Reviewed regex pattern matches for Grok's working titles to ensure that general task texts ending in or referencing "grok" are not inadvertently collapsed. Confirmed cross-platform compatibility: Unicode spinner character logic and string processing are fully platform-agnostic across macOS, Linux, and Windows.

## Security Audit

Reviewed terminal title input parsing. The bounded regular expressions used to match the suffix ` - grok` pose no security or ReDoS risk. No IPC, auth, or command execution channels are touched.

## Notes

The collapsed representation is fully idempotent and remains stable upon subsequent normalizations.