### PR TITLE
fix(preflight): resolve WSL/SSH agent paths past shell aliases

### DIFF
--- a/src/main/ipc/preflight-command-exec.test.ts
+++ b/src/main/ipc/preflight-command-exec.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
+
+const { runPreflightCommandInWslMock } = vi.hoisted(() => ({
+  runPreflightCommandInWslMock: vi.fn()
+}))
+
+vi.mock('./preflight-wsl-command', () => ({
+  runPreflightCommandInWsl: runPreflightCommandInWslMock
+}))
+
+import { isCommandOnPath } from './preflight-command-exec'
+
+describe('isCommandOnPath', () => {
+  const sentinel = '__ORCA_PREFLIGHT_COMMAND_PATH__'
+
+  beforeEach(() => {
+    runPreflightCommandInWslMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses the shared literal lookup and accepts a sentinel-prefixed POSIX path', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    runPreflightCommandInWslMock.mockResolvedValue({
+      stdout: `shell startup chatter\n${sentinel}/home/user/.local/bin/codex\n`,
+      stderr: ''
+    })
+
+    const found = await isCommandOnPath('codex', { distro: 'Ubuntu' })
+
+    expect(found).toBe(true)
+    expect(runPreflightCommandInWslMock).toHaveBeenCalledOnce()
+    const [, command] = runPreflightCommandInWslMock.mock.calls[0] as [{ distro: string }, string]
+    expect(command).toContain(
+      buildPosixCommandPathLookupScript({ kind: 'literal', value: 'codex' })
+    )
+    expect(command).toContain(
+      ['if [ -n "$resolved" ]; then', `printf '${sentinel}%s\\n' "$resolved"`, 'fi'].join('\n')
+    )
+  })
+
+  it.each([
+    ['/absolute/startup/chatter', false],
+    [`${sentinel}relative/path`, false],
+    ['codex', false],
+    ["alias codex='codex --wrapped'", false]
+  ])('parses WSL lookup output %s as available: %s', async (stdout, expected) => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    runPreflightCommandInWslMock.mockResolvedValue({ stdout: `${stdout}\n`, stderr: '' })
+
+    await expect(isCommandOnPath('codex', { distro: 'Ubuntu' })).resolves.toBe(expected)
+  })
+})

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -81,12 +81,23 @@ export async function isCommandOnPath(
   const finder = process.platform === 'win32' ? 'where' : 'which'
   try {
     const { stdout } = wslTarget
-      ? await execCommandInWsl(wslTarget, `command -v ${shellQuote(command)}`)
+      ? // Why: match WSL agent discovery (#7816) — bash type -P, zsh type -p,
+        // then command -v so shell aliases do not mask PATH executables.
+        await execCommandInWsl(
+          wslTarget,
+          [
+            `if resolved=$(type -P ${shellQuote(command)} 2>/dev/null) || resolved=$(type -p ${shellQuote(command)} 2>/dev/null) || resolved=$(command -v ${shellQuote(command)} 2>/dev/null); then`,
+            'printf \'%s\\n\' "$resolved"',
+            'fi'
+          ].join('\n')
+        )
       : await execLocalPreflightCommand(finder, [command])
+    // Why: WSL returns POSIX paths; path.isAbsolute on win32 rejects /usr/bin/...
+    const isAbsolute = wslTarget ? path.posix.isAbsolute.bind(path.posix) : path.isAbsolute
     return stdout
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .some((line) => path.isAbsolute(line))
+      .some((line) => isAbsolute(line))
   } catch {
     return false
   }

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -86,7 +86,10 @@ export async function isCommandOnPath(
         await execCommandInWsl(
           wslTarget,
           [
-            `if resolved=$(type -P ${shellQuote(command)} 2>/dev/null) || resolved=$(type -p ${shellQuote(command)} 2>/dev/null) || resolved=$(command -v ${shellQuote(command)} 2>/dev/null); then`,
+            `resolved=$(type -P ${shellQuote(command)} 2>/dev/null)`,
+            `[ -n "$resolved" ] || resolved=$(type -p ${shellQuote(command)} 2>/dev/null)`,
+            `[ -n "$resolved" ] || resolved=$(command -v ${shellQuote(command)} 2>/dev/null)`,
+            'if [ -n "$resolved" ]; then',
             'printf \'%s\\n\' "$resolved"',
             'fi'
           ].join('\n')

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -1,12 +1,14 @@
 import { execFile } from 'node:child_process'
 import path from 'node:path'
 import { promisify } from 'node:util'
+import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 import { buildLocalPreflightEnv } from './preflight-local-env'
 import { runPreflightCommandInWsl } from './preflight-wsl-command'
 import type { WslPreflightTarget } from './preflight-wsl-agent-detection'
 
 const execFileAsync = promisify(execFile)
 export const PREFLIGHT_COMMAND_TIMEOUT_MS = 5000
+const WSL_COMMAND_PATH_SENTINEL = '__ORCA_PREFLIGHT_COMMAND_PATH__'
 
 export type PreflightCommandResult = { stdout: string; stderr: string }
 
@@ -81,26 +83,31 @@ export async function isCommandOnPath(
   const finder = process.platform === 'win32' ? 'where' : 'which'
   try {
     const { stdout } = wslTarget
-      ? // Why: match WSL agent discovery (#7816) — bash type -P, zsh type -p,
-        // then command -v so shell aliases do not mask PATH executables.
+      ? // Why: preflight must validate the executable on PATH, not a shell alias or function.
         await execCommandInWsl(
           wslTarget,
           [
-            `resolved=$(type -P ${shellQuote(command)} 2>/dev/null)`,
-            `[ -n "$resolved" ] || resolved=$(type -p ${shellQuote(command)} 2>/dev/null)`,
-            `[ -n "$resolved" ] || resolved=$(command -v ${shellQuote(command)} 2>/dev/null)`,
+            buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
             'if [ -n "$resolved" ]; then',
-            'printf \'%s\\n\' "$resolved"',
+            `printf '${WSL_COMMAND_PATH_SENTINEL}%s\\n' "$resolved"`,
             'fi'
           ].join('\n')
         )
       : await execLocalPreflightCommand(finder, [command])
-    // Why: WSL returns POSIX paths; path.isAbsolute on win32 rejects /usr/bin/...
-    const isAbsolute = wslTarget ? path.posix.isAbsolute.bind(path.posix) : path.isAbsolute
+    if (wslTarget) {
+      // Why: WSL startup chatter can contain unrelated absolute paths.
+      return stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith(WSL_COMMAND_PATH_SENTINEL))
+        .map((line) => line.slice(WSL_COMMAND_PATH_SENTINEL.length))
+        .some((line) => path.posix.isAbsolute(line))
+    }
+
     return stdout
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .some((line) => isAbsolute(line))
+      .some((line) => path.isAbsolute(line))
   } catch {
     return false
   }

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -47,6 +47,21 @@ describe('detectWslCommandsOnPath', () => {
     expect(payload).toContain('fi\ndone')
   })
 
+  it('prefers type -P/-p over command -v so shell aliases do not mask PATH binaries', async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+
+    await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
+
+    const payload = lastShCommandPayload()
+    // Why: LeanCTX and similar tools alias claude/codex; command -v alone
+    // returns alias text and fails absolute-path detection (#7816).
+    // bash: type -P; zsh: type -p; dash/sh: command -v.
+    // `$` is escaped for Windows argv preprocessing before the WSL shell runs.
+    expect(payload).toContain(
+      'if resolved=\\$(type -P "\\$cmd" 2>/dev/null) || resolved=\\$(type -p "\\$cmd" 2>/dev/null) || resolved=\\$(command -v "\\$cmd" 2>/dev/null); then'
+    )
+  })
+
   it('parses detected commands from prefixed stdout', async () => {
     execFileAsyncMock.mockResolvedValue({
       stdout:
@@ -63,6 +78,18 @@ describe('detectWslCommandsOnPath', () => {
   it('ignores commands whose resolved path is not absolute', async () => {
     execFileAsyncMock.mockResolvedValue({
       stdout: '__ORCA_AGENT_PATH__claude\tclaude\n',
+      stderr: ''
+    })
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    expect(found).toEqual(new Set())
+  })
+
+  it('ignores alias-style resolution output that is not an absolute path', async () => {
+    execFileAsyncMock.mockResolvedValue({
+      stdout:
+        '__ORCA_AGENT_PATH__claude\talias claude=\'LEAN_CTX_AGENT=1 BASH_ENV="$HOME/.bashenv" claude\'\n',
       stderr: ''
     })
 

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -16,6 +16,8 @@ vi.mock('child_process', () => {
 })
 
 import { detectWslCommandsOnPath } from './preflight-wsl-agent-detection'
+import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
+import { escapeWslShCommandForWindows } from '../../shared/wsl-login-shell-command'
 
 function lastShCommandPayload(): string {
   const call = execFileAsyncMock.mock.calls.at(-1)
@@ -47,23 +49,18 @@ describe('detectWslCommandsOnPath', () => {
     expect(payload).toContain('fi\ndone')
   })
 
-  it('prefers type -P/-p over command -v so shell aliases do not mask PATH binaries', async () => {
+  it('uses the shared alias- and function-neutral PATH lookup', async () => {
     execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
 
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
 
     const payload = lastShCommandPayload()
-    // Why: LeanCTX and similar tools alias claude/codex; command -v alone
-    // returns alias text and fails absolute-path detection (#7816).
-    // bash: type -P; zsh: type -p; dash/sh: command -v.
-    // Non-empty checks between steps avoid empty-success short-circuit.
-    // `$` is escaped for Windows argv preprocessing before the WSL shell runs.
-    expect(payload).toContain('resolved=\\$(type -P "\\$cmd" 2>/dev/null)')
-    expect(payload).toContain('[ -n "\\$resolved" ] || resolved=\\$(type -p "\\$cmd" 2>/dev/null)')
-    expect(payload).toContain(
-      '[ -n "\\$resolved" ] || resolved=\\$(command -v "\\$cmd" 2>/dev/null)'
-    )
-    expect(payload).toContain('if [ -n "\\$resolved" ]; then')
+    const lookupScript = buildPosixCommandPathLookupScript({
+      kind: 'shell-variable',
+      name: 'cmd'
+    })
+    expect(payload).toContain(escapeWslShCommandForWindows(lookupScript))
+    expect(payload).not.toContain('type -P')
   })
 
   it('parses detected commands from prefixed stdout', async () => {
@@ -82,18 +79,6 @@ describe('detectWslCommandsOnPath', () => {
   it('ignores commands whose resolved path is not absolute', async () => {
     execFileAsyncMock.mockResolvedValue({
       stdout: '__ORCA_AGENT_PATH__claude\tclaude\n',
-      stderr: ''
-    })
-
-    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
-
-    expect(found).toEqual(new Set())
-  })
-
-  it('ignores alias-style resolution output that is not an absolute path', async () => {
-    execFileAsyncMock.mockResolvedValue({
-      stdout:
-        '__ORCA_AGENT_PATH__claude\talias claude=\'LEAN_CTX_AGENT=1 BASH_ENV="$HOME/.bashenv" claude\'\n',
       stderr: ''
     })
 

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -56,10 +56,14 @@ describe('detectWslCommandsOnPath', () => {
     // Why: LeanCTX and similar tools alias claude/codex; command -v alone
     // returns alias text and fails absolute-path detection (#7816).
     // bash: type -P; zsh: type -p; dash/sh: command -v.
+    // Non-empty checks between steps avoid empty-success short-circuit.
     // `$` is escaped for Windows argv preprocessing before the WSL shell runs.
+    expect(payload).toContain('resolved=\\$(type -P "\\$cmd" 2>/dev/null)')
+    expect(payload).toContain('[ -n "\\$resolved" ] || resolved=\\$(type -p "\\$cmd" 2>/dev/null)')
     expect(payload).toContain(
-      'if resolved=\\$(type -P "\\$cmd" 2>/dev/null) || resolved=\\$(type -p "\\$cmd" 2>/dev/null) || resolved=\\$(command -v "\\$cmd" 2>/dev/null); then'
+      '[ -n "\\$resolved" ] || resolved=\\$(command -v "\\$cmd" 2>/dev/null)'
     )
+    expect(payload).toContain('if [ -n "\\$resolved" ]; then')
   })
 
   it('parses detected commands from prefixed stdout', async () => {

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -28,9 +28,15 @@ export async function detectWslCommandsOnPath(
   // (it needs a separator before `done`); the login shell may be zsh, so a
   // space-joined script silently fails for every agent. Newlines are valid
   // statement separators in every POSIX shell and zsh.
+  //
+  // Why: interactive login shells load aliases (e.g. LeanCTX wraps claude/codex).
+  // `command -v` then prints alias text, which fails our absolute-path check and
+  // hides installed agents (#7816). Bash needs `type -P` to force a PATH lookup
+  // past aliases/functions; zsh's equivalent is lowercase `type -p` (uppercase
+  // -P is not valid there). Dash/sh support neither, so fall back to `command -v`.
   const script = [
     `for cmd in ${commandList}; do`,
-    'if resolved=$(command -v "$cmd" 2>/dev/null); then',
+    'if resolved=$(type -P "$cmd" 2>/dev/null) || resolved=$(type -p "$cmd" 2>/dev/null) || resolved=$(command -v "$cmd" 2>/dev/null); then',
     `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
     'fi',
     'done'

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -34,9 +34,14 @@ export async function detectWslCommandsOnPath(
   // hides installed agents (#7816). Bash needs `type -P` to force a PATH lookup
   // past aliases/functions; zsh's equivalent is lowercase `type -p` (uppercase
   // -P is not valid there). Dash/sh support neither, so fall back to `command -v`.
+  // Why non-empty checks between steps: bash `type -p` can exit 0 with empty
+  // stdout for alias-only names; a bare `||` chain would then skip `command -v`.
   const script = [
     `for cmd in ${commandList}; do`,
-    'if resolved=$(type -P "$cmd" 2>/dev/null) || resolved=$(type -p "$cmd" 2>/dev/null) || resolved=$(command -v "$cmd" 2>/dev/null); then',
+    'resolved=$(type -P "$cmd" 2>/dev/null)',
+    '[ -n "$resolved" ] || resolved=$(type -p "$cmd" 2>/dev/null)',
+    '[ -n "$resolved" ] || resolved=$(command -v "$cmd" 2>/dev/null)',
+    'if [ -n "$resolved" ]; then',
     `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
     'fi',
     'done'

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
+import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 import {
   buildWslLoginShellCommand,
   escapeWslShCommandForWindows
@@ -24,23 +25,14 @@ export async function detectWslCommandsOnPath(
   }
 
   const commandList = uniqueCommands.map(shellQuote).join(' ')
-  // Why: join with newlines, not spaces. zsh treats `fi done` as a parse error
-  // (it needs a separator before `done`); the login shell may be zsh, so a
-  // space-joined script silently fails for every agent. Newlines are valid
-  // statement separators in every POSIX shell and zsh.
-  //
-  // Why: interactive login shells load aliases (e.g. LeanCTX wraps claude/codex).
-  // `command -v` then prints alias text, which fails our absolute-path check and
-  // hides installed agents (#7816). Bash needs `type -P` to force a PATH lookup
-  // past aliases/functions; zsh's equivalent is lowercase `type -p` (uppercase
-  // -P is not valid there). Dash/sh support neither, so fall back to `command -v`.
-  // Why non-empty checks between steps: bash `type -p` can exit 0 with empty
-  // stdout for alias-only names; a bare `||` chain would then skip `command -v`.
+  const lookupScript = buildPosixCommandPathLookupScript({
+    kind: 'shell-variable',
+    name: 'cmd'
+  })
+  // Newlines keep the loop valid in zsh and every POSIX shell used here.
   const script = [
     `for cmd in ${commandList}; do`,
-    'resolved=$(type -P "$cmd" 2>/dev/null)',
-    '[ -n "$resolved" ] || resolved=$(type -p "$cmd" 2>/dev/null)',
-    '[ -n "$resolved" ] || resolved=$(command -v "$cmd" 2>/dev/null)',
+    lookupScript,
     'if [ -n "$resolved" ]; then',
     `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
     'fi',

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -38,7 +38,7 @@ function lookupArgs(command: string, mode: '-lc' | '-ilc' = '-lc'): string[] {
   return [
     mode,
     [
-      `if resolved=$(command -v ${command} 2>/dev/null); then`,
+      `if resolved=$(type -P ${command} 2>/dev/null) || resolved=$(type -p ${command} 2>/dev/null) || resolved=$(command -v ${command} 2>/dev/null); then`,
       'printf \'__ORCA_AGENT_PATH__%s\\n\' "$resolved"',
       'fi'
     ].join('\n')

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -38,7 +38,10 @@ function lookupArgs(command: string, mode: '-lc' | '-ilc' = '-lc'): string[] {
   return [
     mode,
     [
-      `if resolved=$(type -P ${command} 2>/dev/null) || resolved=$(type -p ${command} 2>/dev/null) || resolved=$(command -v ${command} 2>/dev/null); then`,
+      `resolved=$(type -P ${command} 2>/dev/null)`,
+      `[ -n "$resolved" ] || resolved=$(type -p ${command} 2>/dev/null)`,
+      `[ -n "$resolved" ] || resolved=$(command -v ${command} 2>/dev/null)`,
+      'if [ -n "$resolved" ]; then',
       'printf \'__ORCA_AGENT_PATH__%s\\n\' "$resolved"',
       'fi'
     ].join('\n')

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildPosixCommandPathLookupScript } from '../shared/posix-command-path-lookup'
 
 const { execFileAsyncMock } = vi.hoisted(() => ({
   execFileAsyncMock: vi.fn()
@@ -38,9 +39,7 @@ function lookupArgs(command: string, mode: '-lc' | '-ilc' = '-lc'): string[] {
   return [
     mode,
     [
-      `resolved=$(type -P ${command} 2>/dev/null)`,
-      `[ -n "$resolved" ] || resolved=$(type -p ${command} 2>/dev/null)`,
-      `[ -n "$resolved" ] || resolved=$(command -v ${command} 2>/dev/null)`,
+      buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
       'if [ -n "$resolved" ]; then',
       'printf \'__ORCA_AGENT_PATH__%s\\n\' "$resolved"',
       'fi'
@@ -80,14 +79,14 @@ describe('buildCommandLookupSpec', () => {
   it('falls back to sh for POSIX probes without a configured shell', () => {
     expect(buildCommandLookupSpec('codex', 'linux', {}, null)).toEqual({
       file: '/bin/sh',
-      args: lookupArgs("'codex'")
+      args: lookupArgs('codex')
     })
   })
 
   it('uses the configured remote shell for POSIX probes', () => {
     expect(buildCommandLookupSpec('codex', 'linux', { SHELL: '/bin/zsh' }, '/bin/zsh')).toEqual({
       file: '/bin/zsh',
-      args: lookupArgs("'codex'", '-ilc')
+      args: lookupArgs('codex', '-ilc')
     })
   })
 
@@ -96,7 +95,7 @@ describe('buildCommandLookupSpec', () => {
       buildCommandLookupSpec("agent'cli", 'linux', { SHELL: '/bin/bash' }, '/bin/bash')
     ).toEqual({
       file: '/bin/bash',
-      args: lookupArgs("'agent'\\''cli'", '-ilc')
+      args: lookupArgs("agent'cli", '-ilc')
     })
   })
 })
@@ -104,8 +103,8 @@ describe('buildCommandLookupSpec', () => {
 describe('buildCommandLookupSpecs', () => {
   it('falls back to inherited PATH after a trusted configured POSIX shell', () => {
     expect(buildCommandLookupSpecs('codex', 'linux', { SHELL: '/bin/zsh' }, '/bin/zsh')).toEqual([
-      { file: '/bin/zsh', args: lookupArgs("'codex'", '-ilc') },
-      { file: '/bin/sh', args: lookupArgs("'codex'") }
+      { file: '/bin/zsh', args: lookupArgs('codex', '-ilc') },
+      { file: '/bin/sh', args: lookupArgs('codex') }
     ])
   })
 
@@ -118,15 +117,15 @@ describe('buildCommandLookupSpecs', () => {
         '/opt/homebrew/bin/zsh'
       )
     ).toEqual([
-      { file: '/opt/homebrew/bin/zsh', args: lookupArgs("'codex'", '-ilc') },
-      { file: '/bin/sh', args: lookupArgs("'codex'") }
+      { file: '/opt/homebrew/bin/zsh', args: lookupArgs('codex', '-ilc') },
+      { file: '/bin/sh', args: lookupArgs('codex') }
     ])
   })
 
   it('allows conservative system shell paths when account lookup is unavailable', () => {
     expect(buildCommandLookupSpecs('codex', 'linux', { SHELL: '/usr/bin/bash' }, null)[0]).toEqual({
       file: '/usr/bin/bash',
-      args: lookupArgs("'codex'", '-ilc')
+      args: lookupArgs('codex', '-ilc')
     })
   })
 
@@ -139,14 +138,14 @@ describe('buildCommandLookupSpecs', () => {
 
   it('ignores untrusted temp shell paths even when the basename is supported', () => {
     expect(buildCommandLookupSpecs('codex', 'linux', { SHELL: '/tmp/zsh' }, '/bin/bash')).toEqual([
-      { file: '/bin/sh', args: lookupArgs("'codex'") }
+      { file: '/bin/sh', args: lookupArgs('codex') }
     ])
   })
 
   it('ignores untrusted home-bin shell paths even when the basename is supported', () => {
     expect(
       buildCommandLookupSpecs('codex', 'linux', { SHELL: '/home/test/bin/bash' }, '/bin/bash')
-    ).toEqual([{ file: '/bin/sh', args: lookupArgs("'codex'") }])
+    ).toEqual([{ file: '/bin/sh', args: lookupArgs('codex') }])
   })
 })
 
@@ -163,17 +162,12 @@ describe('isCommandOnPathForRelay', () => {
         accountLoginShell: '/bin/zsh'
       })
     ).resolves.toBe(true)
-    expect(execFileAsyncMock).toHaveBeenNthCalledWith(
-      1,
-      '/bin/zsh',
-      lookupArgs("'codex'", '-ilc'),
-      {
-        encoding: 'utf-8',
-        env: expect.objectContaining({ SHELL: '/bin/zsh' }),
-        timeout: 5000
-      }
-    )
-    expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, '/bin/sh', lookupArgs("'codex'"), {
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(1, '/bin/zsh', lookupArgs('codex', '-ilc'), {
+      encoding: 'utf-8',
+      env: expect.objectContaining({ SHELL: '/bin/zsh' }),
+      timeout: 5000
+    })
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, '/bin/sh', lookupArgs('codex'), {
       encoding: 'utf-8',
       env: expect.objectContaining({ SHELL: '/bin/zsh' }),
       timeout: 5000
@@ -206,7 +200,7 @@ describe('isCommandOnPathForRelay', () => {
       })
     ).resolves.toBe(true)
     expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
-    expect(execFileAsyncMock).toHaveBeenCalledWith('/bin/sh', lookupArgs("'codex'"), {
+    expect(execFileAsyncMock).toHaveBeenCalledWith('/bin/sh', lookupArgs('codex'), {
       encoding: 'utf-8',
       env: expect.objectContaining({ SHELL: '/tmp/zsh' }),
       timeout: 5000

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -220,8 +220,12 @@ function buildPosixCommandLookupSpec(command: string, shell: string): CommandLoo
 
 function buildShCommandLookupScript(command: string): string {
   const quotedCommand = shellQuote(command)
+  // Why: interactive login shells load aliases (e.g. LeanCTX wraps agent CLIs).
+  // `command -v` then prints alias text, which fails absolute-path detection.
+  // Bash needs `type -P` past aliases; zsh uses lowercase `type -p`; dash/sh
+  // support neither, so fall back to `command -v`.
   return [
-    `if resolved=$(command -v ${quotedCommand} 2>/dev/null); then`,
+    `if resolved=$(type -P ${quotedCommand} 2>/dev/null) || resolved=$(type -p ${quotedCommand} 2>/dev/null) || resolved=$(command -v ${quotedCommand} 2>/dev/null); then`,
     `printf '${AGENT_PATH_PREFIX}%s\\n' "$resolved"`,
     'fi'
   ].join('\n')

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -7,6 +7,7 @@ import { buildRelayCommandEnv } from './relay-command-env'
 import { isPwshAvailable } from '../main/pwsh'
 import { isWslAvailable, listWslDistros } from '../main/wsl'
 import { isGitBashAvailable } from '../main/git-bash'
+import { buildPosixCommandPathLookupScript } from '../shared/posix-command-path-lookup'
 
 const execFileAsync = promisify(execFile)
 
@@ -219,16 +220,9 @@ function buildPosixCommandLookupSpec(command: string, shell: string): CommandLoo
 }
 
 function buildShCommandLookupScript(command: string): string {
-  const quotedCommand = shellQuote(command)
-  // Why: interactive login shells load aliases (e.g. LeanCTX wraps agent CLIs).
-  // `command -v` then prints alias text, which fails absolute-path detection.
-  // Bash needs `type -P` past aliases; zsh uses lowercase `type -p`; dash/sh
-  // support neither, so fall back to `command -v`. Non-empty checks between
-  // steps avoid bash `type -p` empty success short-circuiting the chain.
+  // Why: login shells may define aliases or functions that mask the PATH executable.
   return [
-    `resolved=$(type -P ${quotedCommand} 2>/dev/null)`,
-    `[ -n "$resolved" ] || resolved=$(type -p ${quotedCommand} 2>/dev/null)`,
-    `[ -n "$resolved" ] || resolved=$(command -v ${quotedCommand} 2>/dev/null)`,
+    buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
     'if [ -n "$resolved" ]; then',
     `printf '${AGENT_PATH_PREFIX}%s\\n' "$resolved"`,
     'fi'

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -223,9 +223,13 @@ function buildShCommandLookupScript(command: string): string {
   // Why: interactive login shells load aliases (e.g. LeanCTX wraps agent CLIs).
   // `command -v` then prints alias text, which fails absolute-path detection.
   // Bash needs `type -P` past aliases; zsh uses lowercase `type -p`; dash/sh
-  // support neither, so fall back to `command -v`.
+  // support neither, so fall back to `command -v`. Non-empty checks between
+  // steps avoid bash `type -p` empty success short-circuiting the chain.
   return [
-    `if resolved=$(type -P ${quotedCommand} 2>/dev/null) || resolved=$(type -p ${quotedCommand} 2>/dev/null) || resolved=$(command -v ${quotedCommand} 2>/dev/null); then`,
+    `resolved=$(type -P ${quotedCommand} 2>/dev/null)`,
+    `[ -n "$resolved" ] || resolved=$(type -p ${quotedCommand} 2>/dev/null)`,
+    `[ -n "$resolved" ] || resolved=$(command -v ${quotedCommand} 2>/dev/null)`,
+    'if [ -n "$resolved" ]; then',
     `printf '${AGENT_PATH_PREFIX}%s\\n' "$resolved"`,
     'fi'
   ].join('\n')

--- a/src/shared/posix-command-path-lookup.test.ts
+++ b/src/shared/posix-command-path-lookup.test.ts
@@ -1,0 +1,312 @@
+import { execFileSync } from 'node:child_process'
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, delimiter, dirname, isAbsolute, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildPosixCommandPathLookupScript } from './posix-command-path-lookup'
+import { buildWslLoginShellCommand, escapeWslShCommandForWindows } from './wsl-login-shell-command'
+
+type ShellCase = {
+  name: string
+  path: string | null
+}
+
+const isWindows = process.platform === 'win32'
+const WSL_TEST_COMMAND_TIMEOUT_MS = 10_000
+let wslShAvailable: boolean | null = null
+const shellCases: ShellCase[] = [
+  { name: 'sh', path: executablePath(['/bin/sh']) },
+  { name: 'bash', path: executablePath(['/bin/bash', '/usr/bin/bash']) },
+  { name: 'zsh', path: executablePath(['/bin/zsh', '/usr/bin/zsh']) },
+  { name: 'dash', path: executablePath(['/bin/dash', '/usr/bin/dash']) }
+]
+
+describe('buildPosixCommandPathLookupScript', () => {
+  for (const shell of shellCases) {
+    it.skipIf(isWindows || shell.path === null)(
+      `resolves without mutating alias and function masks in ${shell.name}`,
+      () => {
+        const commandName = basename(process.execPath)
+        const script = [
+          `${commandName}() { printf '%s\\n' masked-function; }`,
+          `alias ${commandName}='printf "%s\\n" masked-alias'`,
+          buildPosixCommandPathLookupScript({ kind: 'literal', value: commandName }),
+          `printf '%s\\n' "$resolved"`,
+          `alias ${commandName} >/dev/null`,
+          `unalias ${commandName}`,
+          `${commandName}`
+        ].join('\n')
+
+        const resolved = execFileSync(shell.path!, ['-c', script], {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${dirname(process.execPath)}${delimiter}${process.env.PATH ?? ''}`
+          }
+        })
+          .trim()
+          .split('\n')
+
+        expect(isAbsolute(resolved[0])).toBe(true)
+        expect(realpathSync(resolved[0])).toBe(realpathSync(process.execPath))
+        expect(resolved[1]).toBe('masked-function')
+      }
+    )
+  }
+
+  it.skipIf(isWindows || executablePath(['/bin/sh']) === null)(
+    'resolves a command held in a validated shell variable',
+    () => {
+      const commandName = basename(process.execPath)
+      const script = [
+        `cmd='${commandName}'`,
+        `${commandName}() { printf '%s\\n' masked-function; }`,
+        `alias ${commandName}='printf "%s\\n" masked-alias'`,
+        buildPosixCommandPathLookupScript({ kind: 'shell-variable', name: 'cmd' }),
+        `printf '%s\\n' "$resolved"`
+      ].join('\n')
+
+      const resolved = execFileSync('/bin/sh', ['-c', script], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${dirname(process.execPath)}${delimiter}${process.env.PATH ?? ''}`
+        }
+      }).trim()
+
+      expect(isAbsolute(resolved)).toBe(true)
+      expect(realpathSync(resolved)).toBe(realpathSync(process.execPath))
+    }
+  )
+
+  it.skipIf(isWindows || executablePath(['/bin/bash', '/usr/bin/bash']) === null)(
+    'resolves past a readonly bash function mask',
+    () => {
+      const commandName = basename(process.execPath)
+      const script = [
+        `${commandName}() { printf '%s\\n' masked-function; }`,
+        `readonly -f ${commandName}`,
+        buildPosixCommandPathLookupScript({ kind: 'literal', value: commandName }),
+        `printf '%s\\n' "$resolved"`
+      ].join('\n')
+
+      const resolved = execFileSync(
+        executablePath(['/bin/bash', '/usr/bin/bash'])!,
+        ['-c', script],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${dirname(process.execPath)}${delimiter}${process.env.PATH ?? ''}`
+          }
+        }
+      ).trim()
+
+      expect(realpathSync(resolved)).toBe(realpathSync(process.execPath))
+    }
+  )
+
+  it.skipIf(isWindows || executablePath(['/bin/sh']) === null)(
+    'prefers the first external executable even when its name is a shell builtin',
+    () => {
+      withExecutableFixture('printf', (directory, executable, root) => {
+        const secondDirectory = join(root, 'second-bin')
+        const secondExecutable = join(secondDirectory, 'printf')
+        mkdirSync(secondDirectory)
+        writeFileSync(secondExecutable, '#!/bin/sh\nexit 0\n')
+        chmodSync(secondExecutable, 0o755)
+        const script = [
+          buildPosixCommandPathLookupScript({ kind: 'literal', value: 'printf' }),
+          `printf '%s\\n' "$resolved"`
+        ].join('\n')
+        const resolved = execFileSync('/bin/sh', ['-c', script], {
+          encoding: 'utf8',
+          env: { ...process.env, PATH: `${directory}:${secondDirectory}` }
+        }).trim()
+
+        expectResolvedExecutable(resolved, executable)
+      })
+    }
+  )
+
+  it.skipIf(isWindows || executablePath(['/bin/sh']) === null)(
+    'makes relative and trailing-empty PATH matches absolute',
+    () => {
+      withExecutableFixture('relative-agent', (directory, executable, root) => {
+        const relativeDirectory = basename(directory)
+        const script = [
+          buildPosixCommandPathLookupScript({ kind: 'literal', value: 'relative-agent' }),
+          `printf '%s\\n' "$resolved"`
+        ].join('\n')
+        const relativeResolved = execFileSync('/bin/sh', ['-c', script], {
+          cwd: root,
+          encoding: 'utf8',
+          env: { ...process.env, PATH: `${relativeDirectory}:` }
+        }).trim()
+        const trailingResolved = execFileSync('/bin/sh', ['-c', script], {
+          cwd: directory,
+          encoding: 'utf8',
+          env: { ...process.env, PATH: '/missing:' }
+        }).trim()
+        const emptyResolved = execFileSync('/bin/sh', ['-c', script], {
+          cwd: directory,
+          encoding: 'utf8',
+          env: { ...process.env, PATH: ':/missing' }
+        }).trim()
+
+        expectResolvedExecutable(relativeResolved, executable)
+        expectResolvedExecutable(trailingResolved, executable)
+        expectResolvedExecutable(emptyResolved, executable)
+      })
+    }
+  )
+
+  it.skipIf(isWindows || executablePath(['/bin/sh']) === null)(
+    'handles leading-dash names and explicit relative paths',
+    () => {
+      withExecutableFixture('-agent', (directory, executable) => {
+        const script = [
+          buildPosixCommandPathLookupScript({ kind: 'shell-variable', name: 'cmd' }),
+          `printf '%s\\n' "$resolved"`,
+          buildPosixCommandPathLookupScript({ kind: 'literal', value: './-agent' }),
+          `printf '%s\\n' "$resolved"`
+        ].join('\n')
+        const output = execFileSync('/bin/sh', ['-c', script], {
+          cwd: directory,
+          encoding: 'utf8',
+          env: { ...process.env, PATH: directory, cmd: '-agent' }
+        })
+          .trim()
+          .split('\n')
+
+        expectResolvedExecutable(output[0], executable)
+        expectResolvedExecutable(output[1], executable)
+      })
+    }
+  )
+
+  it.skipIf(isWindows || executablePath(['/bin/sh']) === null)(
+    'keeps set -e callers running when the command is absent',
+    () => {
+      const script = [
+        'set -e',
+        buildPosixCommandPathLookupScript({
+          kind: 'literal',
+          value: '__orca_missing_command_path_lookup__'
+        }),
+        `printf '%s\\n' survived`
+      ].join('\n')
+
+      expect(execFileSync('/bin/sh', ['-c', script], { encoding: 'utf8' }).trim()).toBe('survived')
+    }
+  )
+
+  it.each(['', '$cmd', 'cmd-name', 'cmd; echo injected'])(
+    'rejects an unsafe shell variable name: %s',
+    (name) => {
+      expect(() => buildPosixCommandPathLookupScript({ kind: 'shell-variable', name })).toThrow(
+        'Invalid shell variable name'
+      )
+    }
+  )
+
+  it('quotes literal targets before assigning them in the generated shell fragment', () => {
+    const script = buildPosixCommandPathLookupScript({
+      kind: 'literal',
+      value: "agent'; echo injected; '"
+    })
+
+    expect(script).toContain(`_orca_lookup_command='agent'\\''; echo injected; '\\'''`)
+  })
+
+  it.skipIf(!canRunWslSh())(
+    'resolves through the Windows-to-WSL login-shell boundary with inline masks',
+    () => {
+      const lookup = buildPosixCommandPathLookupScript({ kind: 'literal', value: 'sh' })
+      const command = buildWslLoginShellCommand(
+        [
+          `sh() { printf '%s\\n' masked-function; }`,
+          `alias sh='printf masked-alias'`,
+          lookup,
+          `printf '%s' "$resolved"`
+        ].join('\n')
+      )
+      const resolved = execFileSync(
+        'wsl.exe',
+        ['--', 'sh', '-lc', escapeWslShCommandForWindows(command)],
+        { encoding: 'utf8', timeout: WSL_TEST_COMMAND_TIMEOUT_MS }
+      ).trim()
+
+      expect(resolved).toMatch(/^\/.+\/sh$/)
+    },
+    30_000
+  )
+})
+
+function expectResolvedExecutable(resolved: string, executable: string): void {
+  expect(isAbsolute(resolved)).toBe(true)
+  expect(realpathSync(resolved)).toBe(realpathSync(executable))
+}
+
+function canRunWslSh(): boolean {
+  if (!isWindows) {
+    return false
+  }
+  if (wslShAvailable !== null) {
+    return wslShAvailable
+  }
+  try {
+    execFileSync('wsl.exe', ['--', 'sh', '-lc', 'true'], {
+      timeout: WSL_TEST_COMMAND_TIMEOUT_MS
+    })
+    wslShAvailable = true
+  } catch {
+    wslShAvailable = false
+  }
+  return wslShAvailable
+}
+
+function withExecutableFixture(
+  name: string,
+  run: (directory: string, executable: string, root: string) => void
+): void {
+  const root = mkdtempSync(join(tmpdir(), 'orca-path-lookup-'))
+  const directory = join(root, 'bin')
+  const executable = join(directory, name)
+  try {
+    mkdirSync(directory)
+    writeFileSync(executable, '#!/bin/sh\nexit 0\n')
+    chmodSync(executable, 0o755)
+    run(directory, executable, root)
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+}
+
+function executablePath(candidates: readonly string[]): string | null {
+  if (isWindows) {
+    return null
+  }
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) {
+      continue
+    }
+    try {
+      accessSync(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      // Keep checking alternate standard locations when this entry is not executable.
+    }
+  }
+  return null
+}

--- a/src/shared/posix-command-path-lookup.ts
+++ b/src/shared/posix-command-path-lookup.ts
@@ -1,0 +1,65 @@
+export type PosixCommandPathLookupTarget =
+  | { kind: 'literal'; value: string }
+  | { kind: 'shell-variable'; name: string }
+
+const SHELL_VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+export function buildPosixCommandPathLookupScript(target: PosixCommandPathLookupTarget): string {
+  const commandAssignment = buildCommandAssignment(target)
+  // Shell command resolution can be masked by aliases, functions, and builtins, so inspect PATH.
+  return [
+    `_orca_lookup_command=${commandAssignment}`,
+    'resolved=',
+    'case "$_orca_lookup_command" in',
+    '  */*)',
+    '    case "$_orca_lookup_command" in',
+    '      /*) _orca_lookup_candidate=$_orca_lookup_command ;;',
+    '      *) _orca_lookup_candidate=${PWD%/}/$_orca_lookup_command ;;',
+    '    esac',
+    '    if [ -x "$_orca_lookup_candidate" ] && [ ! -d "$_orca_lookup_candidate" ]; then',
+    '      resolved=$_orca_lookup_candidate',
+    '    fi',
+    '    ;;',
+    '  *)',
+    '    _orca_lookup_remaining=${PATH-}',
+    '    while :; do',
+    '      case "$_orca_lookup_remaining" in',
+    '        *:*)',
+    '          _orca_lookup_component=${_orca_lookup_remaining%%:*}',
+    '          _orca_lookup_remaining=${_orca_lookup_remaining#*:}',
+    '          _orca_lookup_has_more=1',
+    '          ;;',
+    '        *)',
+    '          _orca_lookup_component=$_orca_lookup_remaining',
+    '          _orca_lookup_has_more=',
+    '          ;;',
+    '      esac',
+    '      [ -n "$_orca_lookup_component" ] || _orca_lookup_component=.',
+    '      case "$_orca_lookup_component" in',
+    '        /*) _orca_lookup_candidate=$_orca_lookup_component/$_orca_lookup_command ;;',
+    '        *) _orca_lookup_candidate=${PWD%/}/$_orca_lookup_component/$_orca_lookup_command ;;',
+    '      esac',
+    '      if [ -x "$_orca_lookup_candidate" ] && [ ! -d "$_orca_lookup_candidate" ]; then',
+    '        resolved=$_orca_lookup_candidate',
+    '        break',
+    '      fi',
+    '      [ -n "$_orca_lookup_has_more" ] || break',
+    '    done',
+    '    ;;',
+    'esac'
+  ].join('\n')
+}
+
+function buildCommandAssignment(target: PosixCommandPathLookupTarget): string {
+  if (target.kind === 'literal') {
+    return shellQuote(target.value)
+  }
+  if (!SHELL_VARIABLE_NAME_PATTERN.test(target.name)) {
+    throw new Error(`Invalid shell variable name: ${target.name}`)
+  }
+  return `\${${target.name}-}`
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}


### PR DESCRIPTION
## Summary

- Fixes [#7816](https://github.com/stablyai/orca/issues/7816): WSL agent discovery failed when `claude`/`codex` were shell aliases (e.g. LeanCTX), because `command -v` returned alias text and absolute-path detection dropped them.
- Prefer a portable PATH lookup chain in agent probes: bash `type -P`, then zsh `type -p`, then `command -v` for dash/sh.
- Apply the same chain to WSL `isCommandOnPath` and remote relay POSIX lookup; use `path.posix.isAbsolute` for WSL paths on Windows hosts.
- May also help related WSL detection noise in #7796 / #7563 when aliases were involved.

## Review notes

- Reviewer caught that `type -P` alone is **bash-only**; zsh needs lowercase `type -p`. Final chain is `type -P || type -p || command -v`.
- Absolute-path gate still rejects residual alias text if every lookup falls through to `command -v`.
- Fish remains on `command -v` (separate syntax path; WSL probes do not run under fish).

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/preflight-wsl-agent-detection.test.ts src/relay/preflight-handler.test.ts src/main/ipc/preflight.test.ts` (65 passed)
- [ ] On Windows + WSL with LeanCTX (or manual) aliases for `claude`/`codex`, refresh agent detection and confirm both appear
- [ ] Same check with bash and zsh as the WSL login shell
- [ ] Confirm agents still detect when no aliases are present

## AI code review summary

- Cross-platform: WSL-focused; native Windows uses `where`; local POSIX uses `which`; relay POSIX probes updated; fish unchanged.
- SSH/remote: relay `buildShCommandLookupScript` uses the same portable chain under trusted login shells.
- Agent/integration: detection-only change; launch path unchanged once a real PATH binary is found.
- Performance: one extra failing builtin attempt on dash/zsh before success; negligible vs WSL probe cost.
- Security: command names still single-quote escaped; absolute-path filter retained.