### PR TITLE
feat(terminal): support custom local default shell

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -168,6 +168,20 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
       expect(lastSubprocess.write).toHaveBeenCalledWith("codex 'linked issue context'\n")
     })
+
+    itOnPosix('does not inherit zsh shell-ready support when the shell override is fish', async () => {
+      await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        command: "codex 'linked issue context'",
+        startupCommandDelivery: 'shell-ready',
+        env: { SHELL: '/bin/zsh' },
+        shellOverride: '/usr/bin/fish'
+      })
+
+      await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
+      expect(lastSubprocess.write).toHaveBeenCalledWith("codex 'linked issue context'\n")
+    })
   })
 
   describe('write', () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -213,7 +213,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
     let effectiveCols = restoreInfo?.cols ?? opts.cols
     let effectiveRows = restoreInfo?.rows ?? opts.rows
 
-    const shellReadySupported = opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
+    const shellReadySupported = opts.command
+      ? supportsPtyStartupBarrier(opts.env ?? {}, opts.shellOverride)
+      : false
     const isCodexStartupCommand =
       recognizeAgentProcessFromCommandLine(opts.command)?.agent === 'codex'
     const shouldWaitForShellReady =

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable max-lines -- Why: exercises full PTY subprocess surface (spawn setup, signal routing, data events, platform-specific shell configs, and Windows PowerShell implementations) with co-located test scenarios to prevent fixture drift. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import type * as LocalPtyUtils from '../providers/local-pty-utils'
@@ -1358,6 +1358,93 @@ describe('createPtySubprocess', () => {
       expect.any(String),
       expect.any(Array),
       expect.objectContaining({ cwd: '/' })
+    )
+  })
+
+  it('sets SHELL to the POSIX shell override before daemon spawn', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    const shellPath = join(userDataPath, 'fish')
+    writeFileSync(shellPath, '#!/bin/sh\n')
+    chmodSync(shellPath, 0o755)
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: '/',
+        env: { SHELL: '/bin/zsh' },
+        shellOverride: shellPath
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      shellPath,
+      expect.any(Array),
+      expect.objectContaining({ env: expect.objectContaining({ SHELL: shellPath }) })
+    )
+  })
+
+  it('ignores stale non-POSIX shell overrides before daemon POSIX spawn', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: '/',
+        env: { SHELL: '/bin/bash' },
+        shellOverride: 'powershell.exe'
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/bash',
+      expect.any(Array),
+      expect.objectContaining({ env: expect.objectContaining({ SHELL: '/bin/bash' }) })
+    )
+  })
+
+  it('falls back to SHELL for stale absolute shell overrides before daemon POSIX spawn', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: '/',
+        env: { SHELL: '/bin/bash' },
+        shellOverride: join(userDataPath, 'fish')
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/bin/bash',
+      expect.any(Array),
+      expect.objectContaining({ env: expect.objectContaining({ SHELL: '/bin/bash' }) })
     )
   })
 

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -42,6 +42,7 @@ import {
 } from '../pty/powerlevel10k-wizard-env'
 import { isWindowsGitBashShellPath, resolveWindowsGitBashShellPath } from '../git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../../shared/windows-terminal-shell'
+import { getLaunchablePosixShellOverrideForSpawn } from '../terminal-default-shell-validation'
 import { resolveAgentForegroundProcessWithAvailability } from '../providers/agent-foreground-process'
 import { readWindowsConptyProcessIds } from '../providers/windows-conpty-process-membership'
 import {
@@ -589,10 +590,23 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       ? getWslContextFromPreferredDistro(opts.terminalWindowsWslDistro)
       : undefined
   // Why: WSL worktree cwd is the repo's execution environment. Older persisted
-  // tabs can carry a PowerShell/cmd shellOverride; ignore it so reconnects and
-  // daemon-backed terminals enter the WSL distro just like LocalPtyProvider.
+  // tabs can carry a PowerShell/cmd shellOverride, and POSIX overrides can go
+  // stale after validation; ignore them so the spawn path can fall back.
+  const posixShellOverride =
+    process.platform === 'win32'
+      ? undefined
+      : getLaunchablePosixShellOverrideForSpawn(opts.shellOverride)
   let shellPath =
-    cwdWslInfo || sessionWslContext ? 'wsl.exe' : opts.shellOverride || resolvePtyShellPath(env)
+    cwdWslInfo || sessionWslContext
+      ? 'wsl.exe'
+      : process.platform === 'win32'
+        ? opts.shellOverride || resolvePtyShellPath(env)
+        : posixShellOverride || resolvePtyShellPath(env)
+  if (process.platform !== 'win32') {
+    // Why: shell-ready wrappers and user startup files read SHELL before
+    // spawn; keep it aligned with the actual configured POSIX shell.
+    env.SHELL = shellPath
+  }
   let shellArgs: string[]
   let startupCommandDeliveredInShellArgs = false
   let windowsFallbackAttempts: WindowsShellSpawnAttempt[] = []

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -184,6 +184,15 @@ describePosix('daemon shell-ready launch config', () => {
     vi.restoreAllMocks()
   })
 
+  it('uses the POSIX shell override when deciding startup barrier support', async () => {
+    const { supportsPtyStartupBarrier } = await importFreshShellReady()
+
+    expect(supportsPtyStartupBarrier({ SHELL: '/bin/zsh' }, '/usr/bin/fish')).toBe(false)
+    expect(supportsPtyStartupBarrier({ SHELL: '/usr/bin/fish' }, '/bin/bash')).toBe(true)
+    expect(supportsPtyStartupBarrier({ SHELL: '/bin/zsh' }, 'powershell.exe')).toBe(true)
+    expect(supportsPtyStartupBarrier({ SHELL: '/usr/bin/fish' }, 'bash')).toBe(false)
+  })
+
   it('stores wrapper rcfiles under durable userData instead of tmp', async () => {
     const { getShellReadyLaunchConfig } = await importFreshShellReady()
 

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -17,6 +17,7 @@ import {
   getZshShellReadyMarkerRegistrationBlock,
   getZshStartupFileSourceBlock
 } from '../shell-templates'
+import { normalizeTerminalDefaultShellPath } from '../../shared/terminal-default-shell'
 
 const ORCA_USER_DATA_PATH_ENV = 'ORCA_USER_DATA_PATH'
 const SHELL_READY_MARKER = '\\033]777;orca-shell-ready\\007'
@@ -353,11 +354,19 @@ export function shellPathSupportsPtyStartupBarrier(shellPath: string): boolean {
   return shellName === 'zsh' || shellName === 'bash'
 }
 
-export function supportsPtyStartupBarrier(env: Record<string, string>): boolean {
+export function supportsPtyStartupBarrier(
+  env: Record<string, string>,
+  shellOverride?: string
+): boolean {
   if (process.platform === 'win32') {
     return false
   }
-  return shellPathSupportsPtyStartupBarrier(resolvePtyShellPath(env))
+  // Why: a user-configured POSIX shell path is authoritative for this spawn.
+  // Falling back to inherited SHELL here can mark fish/other shells as
+  // shell-ready capable and make startup commands wait for markers they never emit.
+  const resolvedShell =
+    normalizeTerminalDefaultShellPath(shellOverride) || resolvePtyShellPath(env)
+  return shellPathSupportsPtyStartupBarrier(resolvedShell)
 }
 
 type ShellLaunchConfig = {

--- a/src/main/ipc/settings.test.ts
+++ b/src/main/ipc/settings.test.ts
@@ -135,6 +135,18 @@ describe('registerSettingsHandlers', () => {
     expect(channels).toContain('settings:previewWarpThemeImport')
   })
 
+  it('registers default shell validation handler', async () => {
+    registerSettingsHandlers(store as never)
+    const handler = handleMock.mock.calls.find(
+      (call) => call[0] === 'settings:validateTerminalDefaultShellPath'
+    )?.[1] as (_event: unknown, value: unknown) => unknown
+
+    expect(handler(null, 'fish')).toMatchObject({
+      ok: false,
+      code: 'not-posix-absolute'
+    })
+  })
+
   it('settings:previewGhosttyImport returns preview result', async () => {
     const expected = { found: false, diff: {}, unsupportedKeys: [] }
     previewGhosttyImportMock.mockResolvedValue(expected)
@@ -362,6 +374,22 @@ describe('registerSettingsHandlers', () => {
       { terminalLineHeight: 1 },
       { notifyListeners: true, originWebContentsId: 1 }
     )
+  })
+
+  it('rejects invalid default shell paths from renderer settings IPC', async () => {
+    store.getSettings.mockReturnValue({ terminalDefaultShellPath: null })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find((call) => call[0] === 'settings:set')?.[1] as (
+      _event: unknown,
+      args: unknown
+    ) => Promise<unknown>
+
+    await expect(
+      handler(settingsInvokeEvent, { terminalDefaultShellPath: 'fish' })
+    ).rejects.toThrow('POSIX absolute shell path')
+
+    expect(store.updateSettings).not.toHaveBeenCalled()
   })
 
   it('normalizes custom terminal themes from renderer settings IPC', async () => {

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -19,6 +19,10 @@ import { applyAppIcon } from '../app-icon'
 import { normalizeTerminalCustomThemes } from '../../shared/terminal-custom-themes'
 import { normalizeDesktopTerminalScrollbackRows } from '../../shared/terminal-scrollback-policy'
 import { normalizeTerminalLineHeight } from '../../shared/terminal-line-height-settings'
+import {
+  requireValidTerminalDefaultShellPath,
+  validateTerminalDefaultShellPath
+} from '../terminal-default-shell-validation'
 import { prepareLocalWorktreeRootsForRepos } from '../worktree-root-preparation'
 import { scheduleCurrentWorktreeBaseDirectoryWatcherSync } from './worktree-base-directory-watcher'
 import { applyPRBotAuthorOverride } from '../../shared/pr-bot-author-overrides'
@@ -90,6 +94,10 @@ export function registerSettingsHandlers(
     event.returnValue = store.getSettings()
   })
 
+  ipcMain.handle('settings:validateTerminalDefaultShellPath', (_event, value: unknown) => {
+    return validateTerminalDefaultShellPath(value)
+  })
+
   ipcMain.handle('settings:set', async (event, args: Partial<GlobalSettings>) => {
     const sanitizedArgs = sanitizeRendererSettingsUpdate(args)
     // Why: Floating Workspace grants are trusted only when written by the
@@ -121,6 +129,11 @@ export function registerSettingsHandlers(
     }
     if ('terminalLineHeight' in args) {
       sanitizedArgs.terminalLineHeight = normalizeTerminalLineHeight(args.terminalLineHeight)
+    }
+    if ('terminalDefaultShellPath' in args) {
+      sanitizedArgs.terminalDefaultShellPath = requireValidTerminalDefaultShellPath(
+        args.terminalDefaultShellPath
+      )
     }
     if ('uiLanguage' in args) {
       sanitizedArgs.uiLanguage = normalizeUiLanguage(args.uiLanguage)

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -151,6 +151,7 @@ import {
   normalizeRuntimePathForComparison
 } from '../shared/cross-platform-path'
 import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-commands'
+import { validateTerminalDefaultShellPath } from './terminal-default-shell-validation'
 import { normalizeTaskProviderSettings } from '../shared/task-providers'
 import { normalizeAutoRenameBranchFromWorkDefaultOn } from '../shared/auto-rename-branch-from-work-settings'
 import { normalizeOpenInApplications } from '../shared/open-in-applications'
@@ -3172,6 +3173,12 @@ export class Store {
             floatingTerminalTrustedCwds: migratedFloatingTerminalTrustedCwds,
             floatingTerminalCwdMigratedToAppWorkspace: true,
             terminalScrollbackRows: migratedTerminalScrollback.rows,
+            terminalDefaultShellPath: (() => {
+              const validation = validateTerminalDefaultShellPath(
+                parsed.settings?.terminalDefaultShellPath
+              )
+              return validation.ok ? validation.shellPath : null
+            })(),
             terminalQuickCommands: normalizeTerminalQuickCommands(
               parsed.settings?.terminalQuickCommands
             ),

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -7,6 +7,8 @@ const {
   statSyncMock,
   accessSyncMock,
   mkdirSyncMock,
+  readFileSyncMock,
+  realpathSyncMock,
   writeFileSyncMock,
   spawnMock,
   resolveAgentForegroundProcessMock
@@ -15,6 +17,8 @@ const {
   statSyncMock: vi.fn(),
   accessSyncMock: vi.fn(),
   mkdirSyncMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+  realpathSyncMock: vi.fn(),
   writeFileSyncMock: vi.fn(),
   spawnMock: vi.fn(),
   resolveAgentForegroundProcessMock: vi.fn()
@@ -25,6 +29,8 @@ vi.mock('fs', () => ({
   statSync: statSyncMock,
   accessSync: accessSyncMock,
   mkdirSync: mkdirSyncMock,
+  readFileSync: readFileSyncMock,
+  realpathSync: realpathSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
   constants: { X_OK: 1 }
@@ -119,8 +125,10 @@ describe('LocalPtyProvider', () => {
     delete process.env.HISTFILE
 
     existsSyncMock.mockReturnValue(true)
-    statSyncMock.mockReturnValue({ isDirectory: () => true, mode: 0o755 })
+    statSyncMock.mockReturnValue({ isDirectory: () => true, isFile: () => true, mode: 0o755 })
     accessSyncMock.mockReturnValue(undefined)
+    readFileSyncMock.mockReturnValue('')
+    realpathSyncMock.mockImplementation((value: string) => value)
     mkdirSyncMock.mockReset()
     writeFileSyncMock.mockReset()
     resolveAgentForegroundProcessMock.mockReset()
@@ -216,6 +224,50 @@ describe('LocalPtyProvider', () => {
           rows: 40,
           cwd: '/tmp'
         })
+      )
+    })
+
+    it('uses an explicit POSIX shell override for new local terminals', async () => {
+      await provider.spawn({ cols: 80, rows: 24, cwd: '/tmp', shellOverride: '/usr/bin/fish' })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[0]).toBe('/usr/bin/fish')
+      expect(spawnCall[1]).toEqual(['-l'])
+      expect(spawnCall[2]).toEqual(
+        expect.objectContaining({ env: expect.objectContaining({ SHELL: '/usr/bin/fish' }) })
+      )
+    })
+
+    it('ignores stale non-POSIX shell overrides for local POSIX terminals', async () => {
+      await provider.spawn({ cols: 80, rows: 24, cwd: '/tmp', shellOverride: 'powershell.exe' })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[0]).toBe('/bin/zsh')
+      expect(spawnCall[2]).toEqual(
+        expect.objectContaining({ env: expect.objectContaining({ SHELL: '/bin/zsh' }) })
+      )
+    })
+
+    it('falls back to SHELL for stale absolute POSIX shell overrides', async () => {
+      statSyncMock.mockImplementation((p: string) => {
+        if (p === '/usr/local/bin/fish') {
+          throw new Error('missing shell')
+        }
+        return { isDirectory: () => true, isFile: () => true, mode: 0o755 }
+      })
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp',
+        env: { SHELL: '/bin/bash' },
+        shellOverride: '/usr/local/bin/fish'
+      })
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[0]).toBe('/bin/bash')
+      expect(spawnCall[2]).toEqual(
+        expect.objectContaining({ env: expect.objectContaining({ SHELL: '/bin/bash' }) })
       )
     })
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -51,6 +51,7 @@ import {
   resolveWindowsGitBashShellPath
 } from '../git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../../shared/windows-terminal-shell'
+import { getLaunchablePosixShellOverrideForSpawn } from '../terminal-default-shell-validation'
 import { resolveAgentForegroundProcessWithAvailability } from './agent-foreground-process'
 import { getAgentForegroundContextPaths } from './agent-foreground-context-paths'
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
@@ -455,7 +456,10 @@ export class LocalPtyProvider implements IPtyProvider {
         startupCommandDeliveredInShellArgs = resolved.startupCommandDeliveredInShellArgs === true
       }
     } else {
-      shellPath = args.env?.SHELL || process.env.SHELL || '/bin/zsh'
+      // Why: persisted tabs can carry Windows values or stale POSIX paths;
+      // ignore them so new local terminals still fall back to the host shell.
+      const configuredShell = getLaunchablePosixShellOverrideForSpawn(args.shellOverride)
+      shellPath = configuredShell || args.env?.SHELL || process.env.SHELL || '/bin/zsh'
       shellArgs = ['-l']
       effectiveCwd = cwd
       validationCwd = cwd
@@ -531,6 +535,11 @@ export class LocalPtyProvider implements IPtyProvider {
     }
     if (args.env?.TERM) {
       finalEnv.TERM = args.env.TERM
+    }
+    if (process.platform !== 'win32') {
+      // Why: custom POSIX shells should see themselves as the login shell in
+      // startup files and inherited child processes, not Orca's old parent shell.
+      finalEnv.SHELL = shellPath
     }
     if (process.platform === 'win32') {
       const codexHomeWslInfo = finalEnv.CODEX_HOME ? parseWslPath(finalEnv.CODEX_HOME) : null
@@ -677,10 +686,6 @@ export class LocalPtyProvider implements IPtyProvider {
     }
     if (args.command && getFallbackShellReadyConfig) {
       shellReadyLaunch = getFallbackShellReadyConfig(shellPath)
-    }
-
-    if (process.platform !== 'win32') {
-      finalEnv.SHELL = shellPath
     }
 
     const proc = spawnResult.process

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -83,9 +83,8 @@ export type PtySpawnOptions = {
    *  replace the daemon out from under a still-live PTY. */
   isNewSession?: boolean
   /** Why: allows the renderer to request a specific shell for a single new
-   *  terminal tab (e.g. "open this tab in WSL" from the "+" submenu) without
-   *  changing the user's persistent default shell setting. Only consulted on
-   *  Windows; ignored on macOS/Linux where shell selection is not exposed. */
+   *  terminal tab (e.g. "open this tab in WSL" from the "+" submenu, or a
+   *  configured POSIX default shell) without changing process-global env. */
   shellOverride?: string
   /** Preferred WSL distro for generic `wsl.exe` launches. Worktree/session
    *  distro still wins when the cwd already identifies a WSL distro. */

--- a/src/main/terminal-default-shell-validation.test.ts
+++ b/src/main/terminal-default-shell-validation.test.ts
@@ -1,0 +1,74 @@
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  getLaunchablePosixShellOverrideForSpawn,
+  requireValidPosixShellOverrideForSpawn,
+  validateTerminalDefaultShellPath
+} from './terminal-default-shell-validation'
+
+const itOnPosix = process.platform === 'win32' ? it.skip : it
+
+describe('validateTerminalDefaultShellPath', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-shell-validation-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  itOnPosix('accepts executable recognized shell binaries', () => {
+    const shellPath = join(dir, 'fish')
+    writeFileSync(shellPath, '#!/bin/sh\n')
+    chmodSync(shellPath, 0o755)
+
+    expect(validateTerminalDefaultShellPath(shellPath)).toEqual({
+      ok: true,
+      shellPath
+    })
+  })
+
+  itOnPosix('rejects missing, non-executable, and non-shell paths', () => {
+    const notExecutable = join(dir, 'bash')
+    const notShell = join(dir, 'node')
+    const directory = join(dir, 'zsh')
+    writeFileSync(notExecutable, '#!/bin/sh\n')
+    chmodSync(notExecutable, 0o644)
+    writeFileSync(notShell, '#!/bin/sh\n')
+    chmodSync(notShell, 0o755)
+    mkdirSync(directory)
+
+    expect(validateTerminalDefaultShellPath(join(dir, 'missing')).ok).toBe(false)
+    expect(validateTerminalDefaultShellPath(notExecutable)).toMatchObject({
+      ok: false,
+      code: 'not-executable'
+    })
+    expect(validateTerminalDefaultShellPath(notShell)).toMatchObject({
+      ok: false,
+      code: 'not-recognized-shell'
+    })
+    expect(validateTerminalDefaultShellPath(directory)).toMatchObject({
+      ok: false,
+      code: 'not-file'
+    })
+  })
+
+  itOnPosix('ignores stale non-POSIX spawn overrides but validates absolute ones', () => {
+    const shellPath = join(dir, 'fish')
+    writeFileSync(shellPath, '#!/bin/sh\n')
+    chmodSync(shellPath, 0o755)
+
+    expect(requireValidPosixShellOverrideForSpawn('powershell.exe')).toBeUndefined()
+    expect(requireValidPosixShellOverrideForSpawn(shellPath)).toBe(shellPath)
+    expect(() => requireValidPosixShellOverrideForSpawn(join(dir, 'missing'))).toThrow(
+      'does not exist'
+    )
+    expect(getLaunchablePosixShellOverrideForSpawn('powershell.exe')).toBeUndefined()
+    expect(getLaunchablePosixShellOverrideForSpawn(shellPath)).toBe(shellPath)
+    expect(getLaunchablePosixShellOverrideForSpawn(join(dir, 'missing'))).toBeUndefined()
+  })
+})

--- a/src/main/terminal-default-shell-validation.ts
+++ b/src/main/terminal-default-shell-validation.ts
@@ -1,0 +1,164 @@
+import { accessSync, constants, readFileSync, realpathSync, statSync } from 'node:fs'
+import { basename } from 'node:path'
+import {
+  normalizeTerminalDefaultShellPath,
+  type TerminalDefaultShellValidationCode,
+  type TerminalDefaultShellValidationResult
+} from '../shared/terminal-default-shell'
+
+const RECOGNIZED_POSIX_SHELL_NAMES = new Set([
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  'dash',
+  'ash',
+  'ksh',
+  'mksh',
+  'pdksh',
+  'oksh',
+  'yash',
+  'csh',
+  'tcsh',
+  'elvish',
+  'nu',
+  'nushell',
+  'xonsh',
+  'pwsh'
+])
+
+let systemShellPathsCache: Set<string> | null = null
+let systemShellRealpathsCache: Set<string> | null = null
+
+function failure(
+  code: TerminalDefaultShellValidationCode,
+  message: string
+): TerminalDefaultShellValidationResult {
+  return { ok: false, code, message }
+}
+
+function getSystemShellPaths(): Set<string> {
+  if (systemShellPathsCache) {
+    return systemShellPathsCache
+  }
+  const paths = new Set<string>()
+  try {
+    for (const line of readFileSync('/etc/shells', 'utf8').split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (trimmed && !trimmed.startsWith('#')) {
+        paths.add(trimmed)
+      }
+    }
+  } catch {
+    // /etc/shells is not guaranteed in minimal containers; basename fallback
+    // below still blocks arbitrary binaries like editors or language runtimes.
+  }
+  systemShellPathsCache = paths
+  return paths
+}
+
+function getSystemShellRealpaths(): Set<string> {
+  if (systemShellRealpathsCache) {
+    return systemShellRealpathsCache
+  }
+  const realpaths = new Set<string>()
+  for (const shellPath of getSystemShellPaths()) {
+    try {
+      realpaths.add(realpathSync(shellPath))
+    } catch {
+      // Ignore stale /etc/shells entries.
+    }
+  }
+  systemShellRealpathsCache = realpaths
+  return realpaths
+}
+
+function isRecognizedShell(shellPath: string): boolean {
+  if (getSystemShellPaths().has(shellPath)) {
+    return true
+  }
+  try {
+    if (getSystemShellRealpaths().has(realpathSync(shellPath))) {
+      return true
+    }
+  } catch {
+    return false
+  }
+  return RECOGNIZED_POSIX_SHELL_NAMES.has(basename(shellPath).toLowerCase())
+}
+
+export function validateTerminalDefaultShellPath(
+  value: unknown
+): TerminalDefaultShellValidationResult {
+  if (value === null || value === undefined) {
+    return { ok: true, shellPath: null }
+  }
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return { ok: true, shellPath: null }
+  }
+
+  const shellPath = normalizeTerminalDefaultShellPath(value)
+  if (!shellPath) {
+    return failure(
+      'not-posix-absolute',
+      'Use a POSIX absolute shell path, such as /bin/zsh or /usr/bin/fish.'
+    )
+  }
+  if (process.platform === 'win32') {
+    return failure(
+      'unsupported-platform',
+      'Custom POSIX default shells are only supported on macOS and Linux.'
+    )
+  }
+
+  try {
+    const stats = statSync(shellPath)
+    if (!stats.isFile()) {
+      return failure('not-file', `Shell "${shellPath}" is not a file.`)
+    }
+  } catch {
+    return failure('not-found', `Shell "${shellPath}" does not exist.`)
+  }
+
+  try {
+    accessSync(shellPath, constants.X_OK)
+  } catch {
+    return failure('not-executable', `Shell "${shellPath}" is not executable.`)
+  }
+
+  if (!isRecognizedShell(shellPath)) {
+    return failure(
+      'not-recognized-shell',
+      `Shell "${shellPath}" is not a recognized shell. Choose bash, zsh, fish, sh, ksh, dash, tcsh, csh, or a path listed in /etc/shells.`
+    )
+  }
+
+  return { ok: true, shellPath }
+}
+
+export function requireValidTerminalDefaultShellPath(value: unknown): string | null {
+  const validation = validateTerminalDefaultShellPath(value)
+  if (!validation.ok) {
+    throw new Error(validation.message)
+  }
+  return validation.shellPath
+}
+
+export function requireValidPosixShellOverrideForSpawn(value: unknown): string | undefined {
+  const shellPath = normalizeTerminalDefaultShellPath(value)
+  if (!shellPath) {
+    return undefined
+  }
+  return requireValidTerminalDefaultShellPath(shellPath) ?? undefined
+}
+
+export function getLaunchablePosixShellOverrideForSpawn(value: unknown): string | undefined {
+  const shellPath = normalizeTerminalDefaultShellPath(value)
+  if (!shellPath) {
+    return undefined
+  }
+  const validation = validateTerminalDefaultShellPath(shellPath)
+  // Why: a persisted shell path can disappear after settings validation; spawn
+  // should fall back to the host shell instead of failing to open a terminal.
+  return validation.ok ? (validation.shellPath ?? undefined) : undefined
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -44,6 +44,7 @@ import type {
   OrcaProfileOrgMembersListResult
 } from '../shared/orca-profiles'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
+import type { TerminalDefaultShellValidationResult } from '../shared/terminal-default-shell'
 import type { TaskSourceContext } from '../shared/task-source-context'
 import type { LinearIssueAttributeFilter } from '../shared/linear-issue-attribute-filter'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
@@ -2079,6 +2080,9 @@ export type PreloadApi = {
     getSync: () => GlobalSettings | null
     set: (args: Partial<GlobalSettings>) => Promise<GlobalSettings>
     updatePRBotAuthorOverride: (args: { author: string; isBot: boolean }) => Promise<GlobalSettings>
+    validateTerminalDefaultShellPath: (
+      value: unknown
+    ) => Promise<TerminalDefaultShellValidationResult>
     listFonts: () => Promise<string[]>
     previewGhosttyImport: () => Promise<GhosttyImportPreview>
     previewWarpThemeImport: (source: WarpThemeImportSource) => Promise<WarpThemeImportPreview>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1880,6 +1880,9 @@ const api = {
     updatePRBotAuthorOverride: (args: { author: string; isBot: boolean }): Promise<unknown> =>
       ipcRenderer.invoke('settings:update-pr-bot-author-override', args),
 
+    validateTerminalDefaultShellPath: (value: unknown): Promise<unknown> =>
+      ipcRenderer.invoke('settings:validateTerminalDefaultShellPath', value),
+
     listFonts: (): Promise<string[]> => ipcRenderer.invoke('settings:listFonts'),
 
     previewGhosttyImport: (): Promise<GhosttyImportPreview> =>

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -798,6 +798,7 @@ function Settings(): React.JSX.Element {
   // Only the latter should render disabled WSL controls.
   const wslSupportedPlatform = isWindows || windowsTerminalCapabilities.hostPlatform === 'win32'
   const isWindowsTerminalHost = isWindows || windowsTerminalCapabilities.hostPlatform === 'win32'
+  const supportsTerminalDefaultShell = !isWebClient && !isWindowsTerminalHost
 
   if ([...neededSectionIds].some((id) => !mountedSectionIds.has(id))) {
     // Why: lazy Settings sections are remembered for the session; record newly
@@ -1342,6 +1343,7 @@ function Settings(): React.JSX.Element {
                       pwshAvailable={windowsTerminalCapabilities.pwshAvailable}
                       gitBashAvailable={windowsTerminalCapabilities.gitBashAvailable}
                       isWindowsTerminalHost={isWindowsTerminalHost}
+                      supportsTerminalDefaultShell={supportsTerminalDefaultShell}
                     />
                   ) : null}
                 </SettingsSection>

--- a/src/renderer/src/components/settings/TerminalDefaultShellSection.tsx
+++ b/src/renderer/src/components/settings/TerminalDefaultShellSection.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useRef, useState } from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import {
+  isAbsoluteTerminalShellPath,
+  normalizeTerminalDefaultShellPath,
+  type TerminalDefaultShellValidationCode
+} from '../../../../shared/terminal-default-shell'
+import { Input } from '../ui/input'
+import {
+  SettingsRow,
+  SettingsSegmentedControl,
+  SettingsSubsectionHeader
+} from './SettingsFormControls'
+import { SearchableSetting } from './SearchableSetting'
+import { translate } from '@/i18n/i18n'
+
+type TerminalDefaultShellSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+}
+
+type TerminalDefaultShellMode = 'system' | 'custom'
+
+const SHELL_PATH_INPUT_ID = 'terminal-default-shell-path'
+const SHELL_PATH_MESSAGE_ID = 'terminal-default-shell-path-message'
+
+function getValidationMessage(code: TerminalDefaultShellValidationCode, shellPath: string): string {
+  switch (code) {
+    case 'not-posix-absolute':
+      return translate(
+        'auto.components.settings.TerminalDefaultShellSection.d2ad34c1f6',
+        'Use a POSIX absolute path, such as /bin/zsh or /usr/bin/fish.'
+      )
+    case 'not-found':
+      return translate(
+        'auto.components.settings.TerminalDefaultShellSection.95cca730e4',
+        'Shell "{{value0}}" does not exist.',
+        { value0: shellPath }
+      )
+    case 'not-file':
+      return translate(
+        'auto.components.settings.TerminalDefaultShellSection.d96c7331bb',
+        'Shell "{{value0}}" is not a file.',
+        { value0: shellPath }
+      )
+    case 'not-executable':
+      return translate(
+        'auto.components.settings.TerminalDefaultShellSection.6334403ed7',
+        'Shell "{{value0}}" is not executable.',
+        { value0: shellPath }
+      )
+    case 'not-recognized-shell':
+      return translate(
+        'auto.components.settings.TerminalDefaultShellSection.ffcf81d40f',
+        'Shell "{{value0}}" is not recognized. Choose bash, zsh, fish, sh, ksh, dash, tcsh, csh, or a path listed in /etc/shells.',
+        { value0: shellPath }
+      )
+    case 'unsupported-platform':
+      return translate(
+        'auto.components.settings.TerminalDefaultShellSection.26d742c733',
+        'Custom POSIX default shells are only supported on macOS and Linux.'
+      )
+    default:
+      return translate(
+        'auto.components.settings.TerminalDefaultShellSection.28b50d850b',
+        'Shell "{{value0}}" is not valid.',
+        { value0: shellPath }
+      )
+  }
+}
+
+export function TerminalDefaultShellSection({
+  settings,
+  updateSettings
+}: TerminalDefaultShellSectionProps): React.JSX.Element {
+  const persistedShell = settings.terminalDefaultShellPath ?? ''
+  const [mode, setMode] = useState<TerminalDefaultShellMode>(persistedShell ? 'custom' : 'system')
+  const [draftShell, setDraftShell] = useState(persistedShell)
+  const [validationMessage, setValidationMessage] = useState<string | null>(null)
+  const validationRequestIdRef = useRef(0)
+  const trimmedDraftShell = draftShell.trim()
+  const shellPathInvalid =
+    mode === 'custom' &&
+    trimmedDraftShell.length > 0 &&
+    !isAbsoluteTerminalShellPath(trimmedDraftShell)
+  const shellPathMessage =
+    shellPathInvalid || !validationMessage
+      ? translate(
+          'auto.components.settings.TerminalDefaultShellSection.d2ad34c1f6',
+          'Use a POSIX absolute path, such as /bin/zsh or /usr/bin/fish.'
+        )
+      : validationMessage
+  const shellPathHasError = shellPathInvalid || validationMessage !== null
+
+  useEffect(() => {
+    validationRequestIdRef.current += 1
+    setDraftShell(persistedShell)
+    setMode(persistedShell ? 'custom' : 'system')
+    setValidationMessage(null)
+  }, [persistedShell])
+
+  const commitDraftShell = async (): Promise<void> => {
+    if (shellPathInvalid) {
+      return
+    }
+    const requestId = ++validationRequestIdRef.current
+    const normalizedShell = normalizeTerminalDefaultShellPath(draftShell)
+    if (normalizedShell) {
+      const validation = await window.api.settings.validateTerminalDefaultShellPath(normalizedShell)
+      if (validationRequestIdRef.current !== requestId) {
+        return
+      }
+      if (!validation.ok) {
+        setValidationMessage(getValidationMessage(validation.code, normalizedShell))
+        return
+      }
+    }
+    if (validationRequestIdRef.current !== requestId) {
+      return
+    }
+    setValidationMessage(null)
+    updateSettings({
+      terminalDefaultShellPath: normalizedShell
+    })
+  }
+
+  return (
+    <section className="space-y-3">
+      <SettingsSubsectionHeader
+        title={translate(
+          'auto.components.settings.TerminalDefaultShellSection.ee7cb911e8',
+          'Local Shell'
+        )}
+        description={translate(
+          'auto.components.settings.TerminalDefaultShellSection.67a5341565',
+          'Default shell for new local macOS and Linux terminal panes.'
+        )}
+      />
+
+      <div className="divide-y divide-border/40">
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.TerminalDefaultShellSection.e52e156b21',
+            'Default Shell'
+          )}
+          description={translate(
+            'auto.components.settings.TerminalDefaultShellSection.771784d945',
+            'Choose the shell Orca opens for new local macOS and Linux terminal panes.'
+          )}
+          keywords={[
+            'terminal',
+            'shell',
+            'default',
+            'zsh',
+            'bash',
+            'fish',
+            'macos',
+            'linux',
+            'local'
+          ]}
+        >
+          <SettingsRow
+            alignTop
+            label={translate(
+              'auto.components.settings.TerminalDefaultShellSection.e52e156b21',
+              'Default Shell'
+            )}
+            description={translate(
+              'auto.components.settings.TerminalDefaultShellSection.80099ab61e',
+              'Takes effect for new local terminals. Existing panes keep the shell they already launched.'
+            )}
+            control={
+              <div className="flex w-64 flex-col items-stretch gap-2">
+                <SettingsSegmentedControl<TerminalDefaultShellMode>
+                  ariaLabel={translate(
+                    'auto.components.settings.TerminalDefaultShellSection.e52e156b21',
+                    'Default Shell'
+                  )}
+                  value={mode}
+                  onChange={(nextMode) => {
+                    validationRequestIdRef.current += 1
+                    setMode(nextMode)
+                    setValidationMessage(null)
+                    if (nextMode === 'system') {
+                      setDraftShell('')
+                      updateSettings({ terminalDefaultShellPath: null })
+                    }
+                  }}
+                  equalWidth
+                  options={[
+                    {
+                      value: 'system',
+                      label: translate(
+                        'auto.components.settings.TerminalDefaultShellSection.d884efa6ee',
+                        'System'
+                      )
+                    },
+                    {
+                      value: 'custom',
+                      label: translate(
+                        'auto.components.settings.TerminalDefaultShellSection.981c472a7d',
+                        'Custom'
+                      )
+                    }
+                  ]}
+                />
+                {mode === 'custom' ? (
+                  <div className="space-y-1">
+                    <Input
+                      id={SHELL_PATH_INPUT_ID}
+                      value={draftShell}
+                      onChange={(event) => {
+                        validationRequestIdRef.current += 1
+                        setDraftShell(event.target.value)
+                        setValidationMessage(null)
+                      }}
+                      onBlur={() => void commitDraftShell()}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          void commitDraftShell()
+                          event.currentTarget.blur()
+                        }
+                      }}
+                      aria-invalid={shellPathHasError}
+                      aria-describedby={SHELL_PATH_MESSAGE_ID}
+                      placeholder="/bin/zsh"
+                      className="font-mono text-xs"
+                    />
+                    <p
+                      id={SHELL_PATH_MESSAGE_ID}
+                      className={
+                        shellPathHasError
+                          ? 'text-[11px] text-destructive'
+                          : 'text-[11px] text-muted-foreground'
+                      }
+                    >
+                      {shellPathMessage}
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+            }
+          />
+        </SearchableSetting>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
@@ -343,6 +343,51 @@ describe('TerminalPane PowerShell version setting', () => {
     expect(text).not.toContain('WSL')
   })
 
+  it('hides local default shell controls in the web client', () => {
+    const globals = globalThis as typeof globalThis & {
+      window?: Window & { __ORCA_WEB_CLIENT__?: boolean }
+    }
+    const hadWindow = globals.window !== undefined
+    const webWindow =
+      globals.window ??
+      ({
+        location: { pathname: '/' }
+      } as Window & { __ORCA_WEB_CLIENT__?: boolean })
+    const previousWebFlag = webWindow.__ORCA_WEB_CLIENT__
+    globals.window = webWindow
+    webWindow.__ORCA_WEB_CLIENT__ = true
+    try {
+      const element = TerminalPane({
+        settings: {
+          terminalScrollbackRows: 5_000,
+          terminalWindowsShell: 'powershell.exe',
+          terminalWindowsPowerShellImplementation: 'auto',
+          terminalWordSeparator: ''
+        } as never,
+        updateSettings: () => {},
+        scrollbackMode: 'preset',
+        setScrollbackMode: () => {},
+        wslAvailable: false,
+        pwshAvailable: false,
+        gitBashAvailable: false,
+        isWindowsTerminalHost: false
+      })
+
+      const text = collectText(element)
+      expect(text).not.toContain('Local Shell')
+      expect(text).not.toContain('Default shell for new local macOS and Linux terminal panes')
+    } finally {
+      if (previousWebFlag === undefined) {
+        delete webWindow.__ORCA_WEB_CLIENT__
+      } else {
+        webWindow.__ORCA_WEB_CLIENT__ = previousWebFlag
+      }
+      if (!hadWindow) {
+        Reflect.deleteProperty(globals, 'window')
+      }
+    }
+  })
+
   it('hides WSL as a Windows default shell option when unavailable', () => {
     const element = TerminalPane({
       settings: {

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -3,9 +3,11 @@ import { Separator } from '../ui/separator'
 import { matchesSettingsSearch } from './settings-search'
 import { useAppStore } from '../../store'
 import { isMacUserAgent, isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
+import { isWebClientLocation } from '@/lib/web-client-location'
 import {
   getManageSessionsSearchEntries,
   getTerminalAdvancedSearchEntries,
+  getTerminalDefaultShellSearchEntry,
   getTerminalMacOptionSearchEntries,
   getTerminalMacYenSearchEntries,
   getTerminalPaneInteractionSearchEntries,
@@ -22,6 +24,7 @@ import { TerminalAdvancedSection } from './TerminalAdvancedSection'
 import { TerminalInteractionSection } from './TerminalInteractionSection'
 import { TerminalRenderingSection } from './TerminalRenderingSection'
 import { TerminalSetupScriptSection } from './TerminalSetupScriptSection'
+import { TerminalDefaultShellSection } from './TerminalDefaultShellSection'
 import { TerminalWindowsShellSection } from './TerminalWindowsShellSection'
 
 type TerminalPaneProps = {
@@ -41,6 +44,8 @@ type TerminalPaneProps = {
   gitBashAvailable?: boolean
   /** Whether the active terminal host is Windows, even if the client is not. */
   isWindowsTerminalHost?: boolean
+  /** Whether this renderer can validate and launch a desktop-local POSIX shell. */
+  supportsTerminalDefaultShell?: boolean
 }
 
 export function TerminalPane({
@@ -50,11 +55,15 @@ export function TerminalPane({
   setScrollbackMode,
   pwshAvailable,
   gitBashAvailable = false,
-  isWindowsTerminalHost
+  isWindowsTerminalHost,
+  supportsTerminalDefaultShell: supportsTerminalDefaultShellProp
 }: TerminalPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
   const isWindows = isWindowsUserAgent()
   const showWindowsHostSettings = isWindowsTerminalHost ?? isWindows
+  const isWebClient = isWebClientLocation()
+  const supportsTerminalDefaultShell = supportsTerminalDefaultShellProp ?? !isWebClient
+  const showTerminalDefaultShell = supportsTerminalDefaultShell && !showWindowsHostSettings
   const isMac = isMacUserAgent()
   const rawWindowsShell = settings.terminalWindowsShell ?? 'powershell.exe'
   const windowsShell = rawWindowsShell === 'wsl.exe' ? 'powershell.exe' : rawWindowsShell
@@ -69,6 +78,14 @@ export function TerminalPane({
         updateSettings={updateSettings}
         windowsShell={windowsShell}
         gitBashAvailable={gitBashAvailable}
+      />
+    ) : null,
+    showTerminalDefaultShell &&
+    matchesSettingsSearch(searchQuery, getTerminalDefaultShellSearchEntry()) ? (
+      <TerminalDefaultShellSection
+        key="default-shell"
+        settings={settings}
+        updateSettings={updateSettings}
       />
     ) : null,
     matchesSettingsSearch(searchQuery, getTerminalRenderingSearchEntries()) ? (

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -45,6 +45,17 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(entries.some((entry) => entry.title === 'PowerShell Version')).toBe(false)
   })
 
+  it('omits the local default shell setting when unsupported', () => {
+    const entries = getTerminalPaneSearchEntries({
+      isWindows: false,
+      isMac: false,
+      supportsTerminalDefaultShell: false
+    })
+
+    expect(entries.some((entry) => entry.title === 'Default Shell')).toBe(false)
+    expect(entries.some((entry) => (entry.keywords ?? []).includes('fish'))).toBe(false)
+  })
+
   it('includes the Option as Alt setting on macOS', () => {
     const entries = getTerminalPaneSearchEntries({ isWindows: false, isMac: true })
     expect(entries.some((entry) => entry.title === 'Option as Alt')).toBe(true)

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -32,6 +32,7 @@ import {
   getTerminalWindowSearchEntries
 } from './terminal-window-setup-search'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+import { translate } from '@/i18n/i18n'
 
 export {
   getTerminalAdvancedTypographySearchEntries,
@@ -65,6 +66,22 @@ export {
 type TerminalAppearanceSearchOptions = {
   showWarpImport?: boolean
 }
+
+export const getTerminalDefaultShellSearchEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry[] => [
+    {
+      title: translate(
+        'auto.components.settings.terminal.search.defaultShell.title',
+        'Default Shell'
+      ),
+      description: translate(
+        'auto.components.settings.terminal.search.defaultShell.description',
+        'Choose the shell Orca opens for new local macOS and Linux terminal panes.'
+      ),
+      keywords: ['terminal', 'shell', 'default', 'zsh', 'bash', 'fish', 'macos', 'linux', 'local']
+    }
+  ]
+)
 
 const getTerminalAppearanceSearchEntriesWithoutWarp = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
@@ -101,14 +118,18 @@ export function getTerminalPaneSearchEntries(platform: {
   isWindows: boolean
   isWindowsTerminalHost?: boolean
   isMac: boolean
+  supportsTerminalDefaultShell?: boolean
 }): SettingsSearchEntry[] {
   const isWindowsTerminalHost = platform.isWindowsTerminalHost ?? platform.isWindows
+  const supportsTerminalDefaultShell = platform.supportsTerminalDefaultShell ?? true
+  const showTerminalDefaultShell = supportsTerminalDefaultShell && !isWindowsTerminalHost
   // Why: the settings search index must mirror the visible controls. Keeping
   // platform-only controls out of other platforms' search results prevents
   // users from landing on an option the UI intentionally hides.
   return [
     ...getTerminalRenderingSearchEntries(),
     ...getTerminalPaneInteractionSearchEntries(),
+    ...(showTerminalDefaultShell ? getTerminalDefaultShellSearchEntry() : []),
     ...(isWindowsTerminalHost
       ? [
           ...getTerminalWindowsShellSearchEntry(),

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -162,6 +162,20 @@ describe('settings navigation metadata', () => {
     )
   })
 
+  it('keeps desktop local shell settings out of web metadata', () => {
+    const sections = buildSettingsNavigationMetadata({
+      isMac: false,
+      isWindows: false,
+      isWebClient: true,
+      repos: [repo]
+    })
+    const terminal = sections.find((section) => section.id === 'terminal')
+
+    expect(terminal?.searchEntries.some((entry) => (entry.keywords ?? []).includes('fish'))).toBe(
+      false
+    )
+  })
+
   it('places Advanced near the bottom on desktop without putting it under Experimental', () => {
     const desktopIds = ids()
 

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -125,7 +125,8 @@ export function buildSettingsNavigationMetadata({
   const terminalPaneSearchEntries = getTerminalPaneSearchEntries({
     isWindows,
     isWindowsTerminalHost,
-    isMac
+    isMac,
+    supportsTerminalDefaultShell: showDesktopOnlySettings && !isWindowsTerminalHost
   })
   const runtimeEnvironmentsSearchEntry = isWebClient
     ? getWebRuntimeEnvironmentsSearchEntry()

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6811,6 +6811,22 @@
             "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
           }
         },
+        "TerminalDefaultShellSection": {
+          "ee7cb911e8": "Local Shell",
+          "67a5341565": "Default shell for new local macOS and Linux terminal panes.",
+          "e52e156b21": "Default Shell",
+          "771784d945": "Choose the shell Orca opens for new local macOS and Linux terminal panes.",
+          "80099ab61e": "Takes effect for new local terminals. Existing panes keep the shell they already launched.",
+          "d884efa6ee": "System",
+          "981c472a7d": "Custom",
+          "d2ad34c1f6": "Use a POSIX absolute path, such as /bin/zsh or /usr/bin/fish.",
+          "95cca730e4": "Shell \"{{value0}}\" does not exist.",
+          "d96c7331bb": "Shell \"{{value0}}\" is not a file.",
+          "6334403ed7": "Shell \"{{value0}}\" is not executable.",
+          "ffcf81d40f": "Shell \"{{value0}}\" is not recognized. Choose bash, zsh, fish, sh, ksh, dash, tcsh, csh, or a path listed in /etc/shells.",
+          "26d742c733": "Custom POSIX default shells are only supported on macOS and Linux.",
+          "28b50d850b": "Shell \"{{value0}}\" is not valid."
+        },
         "TerminalSettingsPreview": {
           "a63953a48a": "Preview {{value0}} theme",
           "2c248fcc27": "Preview theme",
@@ -8320,6 +8336,10 @@
             }
           },
           "search": {
+            "defaultShell": {
+              "title": "Default Shell",
+              "description": "Choose the shell Orca opens for new local macOS and Linux terminal panes."
+            },
             "c047f398cc": "launch",
             "b872de3926": "location",
             "fd6c24313d": "new",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6774,6 +6774,22 @@
             "tuiDescription": "Eventos discretos de rueda para apps de terminal de pantalla completa."
           }
         },
+        "TerminalDefaultShellSection": {
+          "ee7cb911e8": "Shell local",
+          "67a5341565": "Shell predeterminada para nuevos paneles de terminal locales en macOS y Linux.",
+          "e52e156b21": "Shell predeterminada",
+          "771784d945": "Elige la shell que Orca abre para nuevos paneles de terminal locales en macOS y Linux.",
+          "80099ab61e": "Se aplica a nuevos terminales locales. Los paneles existentes conservan la shell con la que ya se iniciaron.",
+          "d884efa6ee": "Sistema",
+          "981c472a7d": "Personalizada",
+          "d2ad34c1f6": "Usa una ruta absoluta POSIX, como /bin/zsh o /usr/bin/fish.",
+          "95cca730e4": "La shell \"{{value0}}\" no existe.",
+          "d96c7331bb": "La shell \"{{value0}}\" no es un archivo.",
+          "6334403ed7": "La shell \"{{value0}}\" no es ejecutable.",
+          "ffcf81d40f": "La shell \"{{value0}}\" no se reconoce. Elige bash, zsh, fish, sh, ksh, dash, tcsh, csh o una ruta listada en /etc/shells.",
+          "26d742c733": "Las shells POSIX personalizadas predeterminadas solo son compatibles con macOS y Linux.",
+          "28b50d850b": "La shell \"{{value0}}\" no es válida."
+        },
         "TerminalSettingsPreview": {
           "a63953a48a": "Vista previa del tema {{value0}}",
           "2c248fcc27": "Vista previa del tema",
@@ -8283,6 +8299,10 @@
             }
           },
           "search": {
+            "defaultShell": {
+              "title": "Shell predeterminada",
+              "description": "Elige la shell que Orca abre para nuevos paneles de terminal locales en macOS y Linux."
+            },
             "c047f398cc": "iniciar",
             "b872de3926": "ubicación",
             "fd6c24313d": "nuevo",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6796,6 +6796,22 @@
             "tuiDescription": "全画面ターミナルアプリ向けの離散的なホイール通知。"
           }
         },
+        "TerminalDefaultShellSection": {
+          "ee7cb911e8": "ローカル Shell",
+          "67a5341565": "新しいローカル macOS / Linux ターミナルペインの既定 shell。",
+          "e52e156b21": "既定の Shell",
+          "771784d945": "Orca が新しいローカル macOS / Linux ターミナルペインで開く shell を選びます。",
+          "80099ab61e": "新しいローカルターミナルに適用されます。既存ペインは起動済みの shell を保持します。",
+          "d884efa6ee": "システム",
+          "981c472a7d": "カスタム",
+          "d2ad34c1f6": "/bin/zsh や /usr/bin/fish などの POSIX 絶対パスを使ってください。",
+          "95cca730e4": "Shell “{{value0}}” が存在しません。",
+          "d96c7331bb": "Shell “{{value0}}” はファイルではありません。",
+          "6334403ed7": "Shell “{{value0}}” は実行できません。",
+          "ffcf81d40f": "Shell “{{value0}}” は認識できる shell ではありません。bash、zsh、fish、sh、ksh、dash、tcsh、csh、または /etc/shells に listed されたパスを選んでください。",
+          "26d742c733": "カスタム POSIX 既定 shell は macOS と Linux でのみサポートされています。",
+          "28b50d850b": "Shell “{{value0}}” は無効です。"
+        },
         "TerminalSettingsPreview": {
           "a63953a48a": "{{value0}} テーマのプレビュー",
           "2c248fcc27": "プレビューテーマ",
@@ -8305,6 +8321,10 @@
             }
           },
           "search": {
+            "defaultShell": {
+              "title": "既定の Shell",
+              "description": "Orca が新しいローカル macOS / Linux ターミナルペインで開く shell を選びます。"
+            },
             "c047f398cc": "起動",
             "b872de3926": "場所",
             "fd6c24313d": "新規",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6759,6 +6759,22 @@
             "tuiDescription": "전체 화면 터미널 앱을 위한 개별 휠 보고."
           }
         },
+        "TerminalDefaultShellSection": {
+          "ee7cb911e8": "로컬 Shell",
+          "67a5341565": "새 로컬 macOS 및 Linux 터미널 창의 기본 shell입니다.",
+          "e52e156b21": "기본 Shell",
+          "771784d945": "Orca가 새 로컬 macOS 및 Linux 터미널 창에서 열 shell을 선택하세요.",
+          "80099ab61e": "새 로컬 터미널에 적용됩니다. 기존 창은 이미 시작한 shell을 유지합니다.",
+          "d884efa6ee": "시스템",
+          "981c472a7d": "사용자 지정",
+          "d2ad34c1f6": "/bin/zsh 또는 /usr/bin/fish 같은 POSIX 절대 경로를 사용하세요.",
+          "95cca730e4": "Shell \"{{value0}}\"이(가) 존재하지 않습니다.",
+          "d96c7331bb": "Shell \"{{value0}}\"은(는) 파일이 아닙니다.",
+          "6334403ed7": "Shell \"{{value0}}\"은(는) 실행할 수 없습니다.",
+          "ffcf81d40f": "Shell \"{{value0}}\"은(는) 인식된 shell이 아닙니다. bash, zsh, fish, sh, ksh, dash, tcsh, csh 또는 /etc/shells에 나열된 경로를 선택하세요.",
+          "26d742c733": "사용자 지정 POSIX 기본 shell은 macOS와 Linux에서만 지원됩니다.",
+          "28b50d850b": "Shell \"{{value0}}\"은(는) 유효하지 않습니다."
+        },
         "TerminalSettingsPreview": {
           "a63953a48a": "{{value0}} 테마 미리보기",
           "2c248fcc27": "테마 미리보기",
@@ -8268,6 +8284,10 @@
             }
           },
           "search": {
+            "defaultShell": {
+              "title": "기본 Shell",
+              "description": "Orca가 새 로컬 macOS 및 Linux 터미널 창에서 열 shell을 선택하세요."
+            },
             "c047f398cc": "실행",
             "b872de3926": "위치",
             "fd6c24313d": "새로운",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6759,6 +6759,22 @@
             "tuiDescription": "面向全屏终端应用的离散滚轮报告。"
           }
         },
+        "TerminalDefaultShellSection": {
+          "ee7cb911e8": "本地 Shell",
+          "67a5341565": "新的本地 macOS 和 Linux 终端面板的默认 shell。",
+          "e52e156b21": "默认 Shell",
+          "771784d945": "选择 Orca 为新的本地 macOS 和 Linux 终端面板打开的 shell。",
+          "80099ab61e": "仅对新建的本地终端生效。现有面板会保留已经启动的 shell。",
+          "d884efa6ee": "系统",
+          "981c472a7d": "自定义",
+          "d2ad34c1f6": "使用 POSIX 绝对路径，例如 /bin/zsh 或 /usr/bin/fish。",
+          "95cca730e4": "Shell “{{value0}}” 不存在。",
+          "d96c7331bb": "Shell “{{value0}}” 不是文件。",
+          "6334403ed7": "Shell “{{value0}}” 不可执行。",
+          "ffcf81d40f": "Shell “{{value0}}” 不是可识别的 shell。请选择 bash、zsh、fish、sh、ksh、dash、tcsh、csh，或 /etc/shells 中列出的路径。",
+          "26d742c733": "自定义 POSIX 默认 shell 仅支持 macOS 和 Linux。",
+          "28b50d850b": "Shell “{{value0}}” 无效。"
+        },
         "TerminalSettingsPreview": {
           "a63953a48a": "预览 {{value0}} 主题",
           "2c248fcc27": "预览主题",
@@ -8268,6 +8284,10 @@
             }
           },
           "search": {
+            "defaultShell": {
+              "title": "默认 Shell",
+              "description": "选择 Orca 为新的本地 macOS 和 Linux 终端面板打开的 shell。"
+            },
             "c047f398cc": "启动",
             "b872de3926": "位置",
             "fd6c24313d": "新的",

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -22,6 +22,7 @@ import {
 import { bumpProviderRuntimeSessionGeneration } from '@/lib/provider-runtime-context'
 import { normalizeUiLanguage } from '../../../../shared/ui-language'
 import { normalizeDesktopTerminalScrollbackRows } from '../../../../shared/terminal-scrollback-policy'
+import { normalizeTerminalDefaultShellPath } from '../../../../shared/terminal-default-shell'
 import { translate } from '@/i18n/i18n'
 
 export type SettingsSlice = SettingsSearchState & {
@@ -133,6 +134,11 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
       if ('terminalScrollbackRows' in updates) {
         sanitizedUpdates.terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(
           updates.terminalScrollbackRows
+        )
+      }
+      if ('terminalDefaultShellPath' in updates) {
+        sanitizedUpdates.terminalDefaultShellPath = normalizeTerminalDefaultShellPath(
+          updates.terminalDefaultShellPath
         )
       }
       const nextSettings = await window.api.settings.set(sanitizedUpdates)

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -1381,6 +1381,65 @@ describe('setActiveWorktree', () => {
     }
   })
 
+  it('stamps the POSIX default shell onto new local terminal tabs', () => {
+    const originalNavigator = globalThis.navigator
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { userAgent: 'Mozilla/5.0 (X11; Linux x86_64)' },
+      configurable: true
+    })
+    try {
+      const store = createTestStore()
+      const wt = 'repo1::/path/wt1'
+
+      seedStore(store, {
+        settings: { ...getDefaultSettings('/tmp'), terminalDefaultShellPath: '/usr/bin/fish' },
+        worktreesByRepo: {
+          repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+        }
+      })
+
+      const terminal = store.getState().createTab(wt)
+      expect(terminal.shellOverride).toBe('/usr/bin/fish')
+
+      store.setState({
+        settings: { ...store.getState().settings!, terminalDefaultShellPath: '/bin/bash' }
+      })
+      expect(store.getState().tabsByWorktree[wt][0].shellOverride).toBe('/usr/bin/fish')
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: originalNavigator,
+        configurable: true
+      })
+    }
+  })
+
+  it('does not stamp invalid POSIX default shell paths onto new local terminal tabs', () => {
+    const originalNavigator = globalThis.navigator
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { userAgent: 'Mozilla/5.0 (X11; Linux x86_64)' },
+      configurable: true
+    })
+    try {
+      const store = createTestStore()
+      const wt = 'repo1::/path/wt1'
+
+      seedStore(store, {
+        settings: { ...getDefaultSettings('/tmp'), terminalDefaultShellPath: 'fish' },
+        worktreesByRepo: {
+          repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+        }
+      })
+
+      const terminal = store.getState().createTab(wt)
+      expect(terminal.shellOverride).toBeUndefined()
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: originalNavigator,
+        configurable: true
+      })
+    }
+  })
+
   it('stamps host shell metadata when project runtime overrides stale WSL defaults', () => {
     const originalNavigator = globalThis.navigator
     Object.defineProperty(globalThis, 'navigator', {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -40,6 +40,7 @@ import type { ProjectExecutionRuntimeResolution } from '../../../../shared/proje
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
 import { resolveLocalWindowsTerminalShellOverrideForTab } from '../../../../shared/local-windows-terminal-runtime'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
+import { getTerminalDefaultShellOverride } from '../../../../shared/terminal-default-shell'
 import type { AgentStartedTelemetry } from '../../lib/worktree-activation'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { forgetAgentHibernationTabOutput } from '@/lib/agent-hibernation-output-activity'
@@ -294,6 +295,7 @@ function isAllowedRemoteWindowsTerminalShell(shell: string | undefined): boolean
 function resolveCreatedTabShellOverride(
   explicitShellOverride: string | undefined,
   defaultWindowsShell: string | undefined,
+  defaultTerminalShellPath: string | null | undefined,
   isRemoteWorktree: boolean,
   remotePlatform: NodeJS.Platform | null,
   isWslWorktree: boolean,
@@ -316,7 +318,7 @@ function resolveCreatedTabShellOverride(
   if (explicitShellOverride !== undefined) {
     return explicitShellOverride
   }
-  return undefined
+  return getTerminalDefaultShellOverride(defaultTerminalShellPath)
 }
 
 function worktreeUsesWslPath(
@@ -965,10 +967,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const startupCwd = options?.startupCwd
       const remoteConnectionId = getRemoteConnectionIdForWorktree(s, worktreeId)
       const isRemoteWorktree = Boolean(remoteConnectionId)
+      const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(s, worktreeId)
       const isWslWorktree = worktreeUsesWslPath(s, worktreeId)
       const createdShellOverride = resolveCreatedTabShellOverride(
         shellOverride,
         s.settings?.terminalWindowsShell,
+        // Why: a POSIX shell path is a local filesystem preference. Runtime
+        // hosts keep their own login-shell defaults until host-scoped shell
+        // overrides exist.
+        runtimeEnvironmentId ? undefined : s.settings?.terminalDefaultShellPath,
         // Why: SSH PTYs ignore local Windows shell selection; persisting a
         // local shell icon would mislabel a remote terminal.
         isRemoteWorktree,

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -305,6 +305,24 @@ describe('web settings preload API', () => {
     expect(settings.terminalCursorStyleDefaultedToBlock).toBe(true)
   })
 
+  it('clears stored custom local shell settings on web', async () => {
+    const globals = installBrowserGlobals('Linux')
+    globals.storage.setItem(
+      'orca.web.settings.v1',
+      JSON.stringify({ terminalDefaultShellPath: '/bin/zsh' })
+    )
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const settings = await globals.window.api.settings.get()
+    const stored = JSON.parse(globals.storage.getItem('orca.web.settings.v1') ?? '{}') as {
+      terminalDefaultShellPath?: string | null
+    }
+
+    expect(settings.terminalDefaultShellPath).toBeNull()
+    expect(stored.terminalDefaultShellPath).toBeNull()
+  })
+
   it('preserves first-work branch auto-rename web opt-outs after migration', async () => {
     const globals = installBrowserGlobals('Linux')
     globals.storage.setItem(
@@ -342,6 +360,29 @@ describe('web settings preload API', () => {
     expect(settings.autoRenameBranchFromWorkDefaultedOn).toBe(true)
     expect(stored.autoRenameBranchFromWork).toBe(false)
     expect(stored.autoRenameBranchFromWorkDefaultedOn).toBe(true)
+  })
+
+  it('reports custom local shell validation as unsupported on web', async () => {
+    const { api } = await installApi('Linux')
+
+    await expect(api.settings.validateTerminalDefaultShellPath('/bin/zsh')).resolves.toMatchObject(
+      {
+        ok: false,
+        code: 'unsupported-platform'
+      }
+    )
+  })
+
+  it('drops custom local shell updates on web', async () => {
+    const { api, storage } = await installApi('Linux')
+
+    const settings = await api.settings.set({ terminalDefaultShellPath: '/bin/zsh' })
+    const stored = JSON.parse(storage.getItem('orca.web.settings.v1') ?? '{}') as {
+      terminalDefaultShellPath?: string | null
+    }
+
+    expect(settings.terminalDefaultShellPath).toBeNull()
+    expect(stored.terminalDefaultShellPath).toBeNull()
   })
 
   it('hydrates compact worktree cards from paired runtime settings', async () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -585,6 +585,10 @@ function createWebPreloadApi(): Partial<PreloadApi> {
           disconnectActiveRuntimeEnvironment()
         }
         const sanitizedUpdates = { ...updates }
+        if ('terminalDefaultShellPath' in sanitizedUpdates) {
+          // Why: browser clients cannot validate or launch desktop-local shells.
+          sanitizedUpdates.terminalDefaultShellPath = null
+        }
         if ('autoRenameBranchFromWorkDefaultedOn' in sanitizedUpdates) {
           sanitizedUpdates.autoRenameBranchFromWorkDefaultedOn = true
         }
@@ -595,6 +599,12 @@ function createWebPreloadApi(): Partial<PreloadApi> {
         return syncRuntimeBackedSettings(sanitizedUpdates, next)
       },
       updatePRBotAuthorOverride: (args) => updateRuntimePRBotAuthorOverride(args),
+      validateTerminalDefaultShellPath: () =>
+        Promise.resolve({
+          ok: false,
+          code: 'unsupported-platform',
+          message: 'Custom POSIX default shells are only supported on macOS and Linux.'
+        }),
       listFonts: () => Promise.resolve([]),
       onChanged: () => noopUnsubscribe
     } satisfies Partial<WebSettingsApi> as unknown as WebSettingsApi,
@@ -3053,6 +3063,8 @@ function getStoredSettings(): GlobalSettings {
     ...stored,
     ...normalizeAutoRenameBranchFromWorkDefaultOn(stored),
     ...normalizeTerminalCursorStyleDefault(stored),
+    // Why: this desktop-local shell preference is not portable to browser clients.
+    terminalDefaultShellPath: null,
     terminalCustomThemes: normalizeTerminalCustomThemes(stored.terminalCustomThemes),
     uiLanguage: normalizeUiLanguage(stored.uiLanguage)
   }
@@ -3064,6 +3076,7 @@ function getStoredSettings(): GlobalSettings {
       stored.terminalCursorStyle !== migratedStored.terminalCursorStyle ||
       stored.terminalCursorStyleDefaultedToBlock !==
         migratedStored.terminalCursorStyleDefaultedToBlock ||
+      stored.terminalDefaultShellPath != null ||
       stored.terminalCustomThemes !== migratedStored.terminalCustomThemes ||
       stored.uiLanguage !== migratedStored.uiLanguage)
   ) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -249,6 +249,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // and Linux keep right-click available for the context menu by default.
     terminalRightClickToPaste: getDefaultTerminalRightClickToPaste(),
     terminalRightClickToPasteDefaultedForPlatform: true,
+    terminalDefaultShellPath: null,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsWslDistro: null,
     localAccountRuntime: 'host',

--- a/src/shared/terminal-default-shell.test.ts
+++ b/src/shared/terminal-default-shell.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertAbsoluteTerminalShellPath,
+  getTerminalDefaultShellOverride,
+  isAbsoluteTerminalShellPath,
+  normalizeTerminalDefaultShellPath
+} from './terminal-default-shell'
+
+describe('terminal default shell settings', () => {
+  it('normalizes empty values to null and trims configured paths', () => {
+    expect(normalizeTerminalDefaultShellPath(undefined)).toBeNull()
+    expect(normalizeTerminalDefaultShellPath('  ')).toBeNull()
+    expect(normalizeTerminalDefaultShellPath('  /usr/bin/fish  ')).toBe('/usr/bin/fish')
+    expect(normalizeTerminalDefaultShellPath('fish')).toBeNull()
+    expect(normalizeTerminalDefaultShellPath('C:\\fish.exe')).toBeNull()
+    expect(getTerminalDefaultShellOverride(' /bin/zsh ')).toBe('/bin/zsh')
+    expect(getTerminalDefaultShellOverride('fish')).toBeUndefined()
+  })
+
+  it('recognizes POSIX absolute shell paths', () => {
+    expect(isAbsoluteTerminalShellPath('/bin/bash')).toBe(true)
+    expect(isAbsoluteTerminalShellPath('C:\\Program Files\\PowerShell\\7\\pwsh.exe')).toBe(false)
+    expect(isAbsoluteTerminalShellPath('\\\\server\\share\\shell.exe')).toBe(false)
+    expect(isAbsoluteTerminalShellPath('fish')).toBe(false)
+  })
+
+  it('throws for relative shell paths at spawn boundaries', () => {
+    expect(() => assertAbsoluteTerminalShellPath('fish')).toThrow(
+      'Default terminal shell must be a POSIX absolute path'
+    )
+    expect(() => getTerminalDefaultShellOverride('fish', { onInvalid: 'throw' })).toThrow(
+      'Default terminal shell must be a POSIX absolute path'
+    )
+  })
+})

--- a/src/shared/terminal-default-shell.ts
+++ b/src/shared/terminal-default-shell.ts
@@ -1,0 +1,52 @@
+export type TerminalDefaultShellValidationCode =
+  | 'not-posix-absolute'
+  | 'not-found'
+  | 'not-file'
+  | 'not-executable'
+  | 'not-recognized-shell'
+  | 'unsupported-platform'
+
+export type TerminalDefaultShellValidationResult =
+  | { ok: true; shellPath: string | null }
+  | { ok: false; code: TerminalDefaultShellValidationCode; message: string }
+
+export function normalizeTerminalDefaultShellPath(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return null
+  }
+  return isAbsoluteTerminalShellPath(trimmed) ? trimmed : null
+}
+
+export function isAbsoluteTerminalShellPath(shellPath: string): boolean {
+  // Why: persisted shell overrides must name the executable explicitly; PATH
+  // lookup would make terminal launches depend on mutable process environment.
+  return shellPath.startsWith('/')
+}
+
+type TerminalDefaultShellOverrideOptions = {
+  onInvalid?: 'ignore' | 'throw'
+}
+
+export function getTerminalDefaultShellOverride(
+  value: unknown,
+  options: TerminalDefaultShellOverrideOptions = {}
+): string | undefined {
+  const normalized = normalizeTerminalDefaultShellPath(value)
+  if (normalized) {
+    return normalized
+  }
+  if (options.onInvalid === 'throw' && typeof value === 'string' && value.trim().length > 0) {
+    assertAbsoluteTerminalShellPath(value.trim())
+  }
+  return undefined
+}
+
+export function assertAbsoluteTerminalShellPath(shellPath: string): void {
+  if (!isAbsoluteTerminalShellPath(shellPath)) {
+    throw new Error('Default terminal shell must be a POSIX absolute path')
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2595,6 +2595,10 @@ export type GlobalSettings = {
   /** One-shot guard that distinguishes the old global true default from a
    *  choice made after the setting became available on every platform. */
   terminalRightClickToPasteDefaultedForPlatform?: boolean
+  /** Why: macOS/Linux users may prefer a shell different from the process
+   *  login shell Orca inherited. Null/undefined preserves the system default.
+   *  Windows keeps its own shell-family setting below. */
+  terminalDefaultShellPath?: string | null
   /** Why: COMSPEC always points to cmd.exe on stock Windows, so without an
    *  explicit setting the terminal would always open CMD instead of the
    *  user's preferred shell. Defaults to 'powershell.exe' which is the


### PR DESCRIPTION
## Summary
- add a macOS/Linux local default shell setting with main-process validation
- apply valid POSIX shell overrides to new local terminals while keeping existing panes stable
- keep Web, Windows, SSH, and remote runtime paths isolated from the desktop-local preference

## Testing
- git diff --cached --check
- Not run: typecheck/unit tests require node/pnpm, which are unavailable in this environment

Closes #7779

## ELI5

On Mac and Linux you can pick a custom default shell for new local terminals. Existing panes stay put; only new local terminals use your choice (not Web, Windows, or SSH).
