### PR TITLE
fix(git): do not wake WSL for host-missing glab auth probes

### DIFF
--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -352,6 +352,26 @@ describe('ghExecFileAsync WSL fallback', () => {
     )
   })
 
+  it('does not wake default WSL for glab auth probes when host glab is missing', async () => {
+    // Why: #7536 — diagnoseAuth / getGlabKnownHosts run `glab auth status`
+    // without a repo cwd. WSL fallback would start Ubuntu for GitHub-only users.
+    getDefaultWslDistroMock.mockReturnValue('Ubuntu')
+    execFileMock.mockImplementation((_binary, _args, _options, callback) => {
+      callback(Object.assign(new Error('spawn glab ENOENT'), { code: 'ENOENT' }))
+    })
+
+    await expect(glabExecFileAsync(['auth', 'status'])).rejects.toMatchObject({ code: 'ENOENT' })
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock).toHaveBeenCalledWith(
+      'glab',
+      ['auth', 'status'],
+      expect.anything(),
+      expect.any(Function)
+    )
+    expect(execFileMock.mock.calls.some(([binary]) => binary === 'wsl.exe')).toBe(false)
+  })
+
   it('still retries idempotent glab transient failures', async () => {
     execFileMock
       .mockImplementationOnce((_binary, _args, _options, callback) => {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -149,6 +149,11 @@ function resolveDefaultWslCli(command: 'gh' | 'glab', args: string[]): ResolvedC
   return distro ? resolveCommand(command, args, undefined, distro) : null
 }
 
+/** `glab auth …` probes — never wake the default WSL distro for these. */
+function isGlabAuthProbeArgs(args: readonly string[]): boolean {
+  return args[0] === 'auth'
+}
+
 function isHostCommandMissing(err: unknown, command: 'gh' | 'glab'): boolean {
   if (!err || typeof err !== 'object') {
     return false
@@ -1544,11 +1549,17 @@ export async function glabExecFileAsync(
         resolved.wsl === null &&
         !options.cwd &&
         !options.wslDistro &&
-        isHostCommandMissing(err, 'glab')
+        isHostCommandMissing(err, 'glab') &&
+        // Why: #7536 — `glab auth status` runs on startup / known-host probes.
+        // Falling back to the default WSL distro wakes Ubuntu for GitHub-only
+        // Windows users who never use GitLab. Auth is host-config scoped; if
+        // glab only exists inside a WSL project, callers pass wslDistro/cwd.
+        !isGlabAuthProbeArgs(args)
       ) {
         const wslResolved = resolveDefaultWslCli('glab', args)
         if (wslResolved) {
-          // Why: mirror gh's WSL-only fallback for global GitLab project/auth calls.
+          // Why: mirror gh's WSL-only fallback for global GitLab API calls
+          // (not auth probes — see isGlabAuthProbeArgs).
           resolved = wslResolved
           attemptedDefaultWslFallback = true
           attempt = -1


### PR DESCRIPTION
﻿## Summary

- Fixes #7536: on Windows, cwd-less `glab auth status` (diagnoseAuth / known-host probes) fell back to the default WSL distro when host glab was missing, which started Ubuntu even for GitHub-only users with Project/Agent runtime set to Windows.
- Skip default-WSL fallback for the `glab auth` subcommand only.
- Keep default-WSL fallback for other cwd-less glab API calls (e.g. `api projects`).
- Explicit `cwd` / `wslDistro` routing is unchanged (WSL workspaces and repo-scoped auth checks via `glabRepoExecOptions` still work).

## Review notes

- Smoking gun from the issue: wsl.exe started with `glab auth status` and no repo cwd.
- `getGlabKnownHosts` / `diagnoseAuth` call auth status with no cwd; on ENOENT they now fail on the host and fall through to existing defaults (`DEFAULT_GITLAB_HOSTS` / glabAvailable false).
- Repo-scoped checks like `auth status --hostname` already pass `glabRepoExecOptions(...)` so they resolve WSL from the project path, not the default-distro fallback.
- Residual: WSL-only self-hosted hosts that only appear in WSL glab config will not be discovered by the global known-hosts probe unless a later call supplies distro/cwd; that is preferred over waking WSL on every GitHub-only launch.

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/git/runner-wsl-gh-fallback.test.ts src/main/gitlab/client-mr.test.ts src/main/gitlab/gl-utils.test.ts` (95 passed)
- [ ] Windows + WSL Ubuntu installed, no host glab, GitHub-only workspace, Project/Agent runtime Windows: start Orca and confirm `wsl -l -v` does not flip Ubuntu to Running solely from auth probes
- [ ] With host glab installed: Integrations / GitLab diagnose still works
- [ ] WSL-backed GitLab project with glab only in the distro: repo-scoped operations still route via distro/cwd

## AI code review summary

- Cross-platform: change is gated to win32 default-WSL fallback path only.
- SSH/remote: unchanged; connection-scoped options still apply where provided.
- Agent/integration: GitHub-only Windows users no longer pay WSL cold-start for unused GitLab auth probes.
- Performance: avoids unintended WSL boot.
- Security: no new privilege surface; fails closed to host ENOENT for auth probes.
