### PR TITLE
fix(crash-reporting): persist no-capture crash diagnostics

### DIFF
--- a/src/main/crash-reporting/process-gone-crash.test.ts
+++ b/src/main/crash-reporting/process-gone-crash.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { CrashReportCreateInput } from '../../shared/crash-reporting'
+import type { ActiveSpan } from '../observability/tracer'
+import { recordProcessGoneCrash, type RecordProcessGoneCrashRuntime } from './process-gone-crash'
+
+type MockFn = ReturnType<typeof vi.fn>
+type TestRuntime = RecordProcessGoneCrashRuntime & {
+  crashReports: { record: MockFn } | null
+  dedupe: { shouldRecord: MockFn }
+  getCrashBreadcrumbSnapshot: MockFn
+  recordCrashBreadcrumb: MockFn
+  startSpan: MockFn
+  recordNoCaptureDiagnostic: MockFn
+}
+
+function runtime(overrides: Partial<RecordProcessGoneCrashRuntime> = {}): TestRuntime {
+  const span: ActiveSpan = {
+    traceId: 'trace',
+    spanId: 'span',
+    setAttribute: vi.fn(),
+    addEvent: vi.fn(),
+    fail: vi.fn(),
+    interrupt: vi.fn(),
+    end: vi.fn()
+  }
+  const testRuntime: RecordProcessGoneCrashRuntime = {
+    crashReports: { record: vi.fn(() => Promise.resolve({ id: 'report' } as never)) },
+    expectedTeardown: 'none',
+    getCrashBreadcrumbSnapshot: vi.fn(() => [
+      { createdAt: '2026-05-16T01:00:00.000Z', name: 'before_crash' }
+    ]),
+    recordCrashBreadcrumb: vi.fn(),
+    dedupe: { shouldRecord: vi.fn(() => true) },
+    getAppVersion: () => '1.0.0',
+    osRelease: 'test-os',
+    platform: 'win32',
+    arch: 'x64',
+    electronVersion: '42',
+    chromeVersion: '141',
+    startSpan: vi.fn(() => span),
+    recordNoCaptureDiagnostic: vi.fn(),
+    ...overrides
+  }
+  return testRuntime as TestRuntime
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('recordProcessGoneCrash', () => {
+  it('does not emit a no-capture span for non-report reasons', () => {
+    const testRuntime = runtime({ crashReports: null })
+
+    recordProcessGoneCrash('renderer', 'renderer', 'clean-exit', 0, {}, testRuntime)
+
+    expect(testRuntime.recordNoCaptureDiagnostic).not.toHaveBeenCalled()
+    expect(testRuntime.recordCrashBreadcrumb).not.toHaveBeenCalled()
+  })
+
+  it('records a store-unavailable no-capture span for reportable events without a store', () => {
+    const testRuntime = runtime({ crashReports: null })
+
+    recordProcessGoneCrash('child', 'renderer', 'crashed', null, { name: 'Renderer' }, testRuntime)
+
+    expect(testRuntime.recordNoCaptureDiagnostic).toHaveBeenCalledWith(
+      'process_gone_store_unavailable',
+      {
+        source: 'child',
+        processType: 'renderer',
+        reason: 'crashed',
+        exitCode: null,
+        details: { name: 'Renderer' }
+      }
+    )
+    expect(testRuntime.recordCrashBreadcrumb).not.toHaveBeenCalled()
+  })
+
+  it('records suppressed breadcrumb and durable no-capture span for expected teardown', () => {
+    const testRuntime = runtime({ expectedTeardown: 'renderer-reload' })
+
+    recordProcessGoneCrash('renderer', 'renderer', 'killed', 15, { name: 'Renderer' }, testRuntime)
+
+    expect(testRuntime.recordCrashBreadcrumb).toHaveBeenCalledWith('process_gone_suppressed', {
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'killed',
+      exitCode: 15,
+      name: 'Renderer'
+    })
+    expect(testRuntime.recordNoCaptureDiagnostic).toHaveBeenCalledWith('process_gone_suppressed', {
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'killed',
+      exitCode: 15,
+      details: { name: 'Renderer' }
+    })
+    expect(testRuntime.crashReports?.record).not.toHaveBeenCalled()
+  })
+
+  it('keeps deduped reportable events silent', () => {
+    const testRuntime = runtime({ dedupe: { shouldRecord: vi.fn(() => false) } })
+
+    recordProcessGoneCrash('renderer', 'renderer', 'crashed', 5, {}, testRuntime)
+
+    expect(testRuntime.dedupe.shouldRecord).toHaveBeenCalledWith('renderer:renderer')
+    expect(testRuntime.startSpan).not.toHaveBeenCalled()
+    expect(testRuntime.crashReports?.record).not.toHaveBeenCalled()
+    expect(testRuntime.recordNoCaptureDiagnostic).not.toHaveBeenCalled()
+  })
+
+  it('persists accepted reportable events with crash context and breadcrumbs', () => {
+    const testRuntime = runtime()
+
+    recordProcessGoneCrash(
+      'renderer',
+      'renderer',
+      'crashed',
+      5,
+      { serviceName: 'renderer' },
+      testRuntime
+    )
+
+    expect(testRuntime.startSpan).toHaveBeenCalledWith('electron.process_gone', {
+      attributes: expect.objectContaining({
+        'crash.source': 'renderer',
+        'crash.process_type': 'renderer',
+        'crash.reason': 'crashed',
+        'crash.exit_code': 5,
+        'app.version': '1.0.0',
+        details: expect.objectContaining({ serviceName: 'renderer' }),
+        breadcrumbs: [{ createdAt: '2026-05-16T01:00:00.000Z', name: 'before_crash' }]
+      })
+    })
+    expect(testRuntime.crashReports?.record).toHaveBeenCalledWith({
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 5,
+      appVersion: '1.0.0',
+      platform: 'win32',
+      osRelease: 'test-os',
+      arch: 'x64',
+      electronVersion: '42',
+      chromeVersion: '141',
+      details: expect.objectContaining({ serviceName: 'renderer' }),
+      breadcrumbs: [{ createdAt: '2026-05-16T01:00:00.000Z', name: 'before_crash' }]
+    } satisfies CrashReportCreateInput)
+  })
+
+  it('records a persist-failed no-capture span when accepted persistence rejects', async () => {
+    const error = new Error('write failed')
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const record = vi.fn(() => Promise.reject(error))
+    const testRuntime = runtime({ crashReports: { record } })
+
+    recordProcessGoneCrash('renderer', 'renderer', 'crashed', 5, { name: 'Renderer' }, testRuntime)
+    await Promise.resolve()
+
+    expect(warn).toHaveBeenCalledWith('[crash-reporting] Failed to persist crash report:', error)
+    expect(testRuntime.recordNoCaptureDiagnostic).toHaveBeenCalledWith(
+      'process_gone_persist_failed',
+      {
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'crashed',
+        exitCode: 5,
+        details: { name: 'Renderer' },
+        error
+      }
+    )
+  })
+})

--- a/src/main/crash-reporting/process-gone-crash.ts
+++ b/src/main/crash-reporting/process-gone-crash.ts
@@ -1,0 +1,151 @@
+import os from 'node:os'
+import { app } from 'electron'
+import {
+  isCrashReportReason,
+  type CrashReportBreadcrumb,
+  type CrashReportBreadcrumbData,
+  type CrashReportCreateInput
+} from '../../shared/crash-reporting'
+import { startSpan, type ActiveSpan } from '../observability/tracer'
+import type { CrashReportStore } from './crash-report-store'
+import {
+  type ExpectedTeardownScope,
+  shouldRecordProcessGoneCrash
+} from './process-gone-classification'
+import { getProcessGoneDedupeKey, processGoneDedupe } from './process-gone-dedupe'
+import {
+  buildProcessGoneCrashDetails,
+  buildSuppressedProcessGoneBreadcrumbData,
+  recordProcessGoneNoCaptureDiagnostic
+} from './process-gone-diagnostics'
+
+type CrashReportRecorder = Pick<CrashReportStore, 'record'>
+
+type ProcessGoneDedupeLike = {
+  shouldRecord(key: string): boolean
+}
+
+export type RecordProcessGoneCrashRuntime = {
+  crashReports: CrashReportRecorder | null
+  expectedTeardown: ExpectedTeardownScope
+  getCrashBreadcrumbSnapshot: () => CrashReportBreadcrumb[]
+  recordCrashBreadcrumb: (name: string, data?: CrashReportBreadcrumbData) => void
+  dedupe?: ProcessGoneDedupeLike
+  getAppVersion?: () => string
+  osRelease?: string
+  platform?: NodeJS.Platform
+  arch?: string
+  electronVersion?: string
+  chromeVersion?: string
+  startSpan?: typeof startSpan
+  recordNoCaptureDiagnostic?: typeof recordProcessGoneNoCaptureDiagnostic
+}
+
+export function recordProcessGoneCrash(
+  source: 'renderer' | 'child',
+  processType: string,
+  reason: string,
+  exitCode: number | null,
+  details: Record<string, unknown>,
+  runtime: RecordProcessGoneCrashRuntime
+): void {
+  if (!isCrashReportReason(reason)) {
+    return
+  }
+  const recordNoCaptureDiagnostic =
+    runtime.recordNoCaptureDiagnostic ?? recordProcessGoneNoCaptureDiagnostic
+  if (!runtime.crashReports) {
+    recordNoCaptureDiagnostic('process_gone_store_unavailable', {
+      source,
+      processType,
+      reason,
+      exitCode,
+      details
+    })
+    return
+  }
+  if (
+    !shouldRecordProcessGoneCrash({
+      source,
+      processType,
+      serviceName: typeof details.serviceName === 'string' ? details.serviceName : undefined,
+      reason,
+      exitCode,
+      expectedTeardown: runtime.expectedTeardown
+    })
+  ) {
+    runtime.recordCrashBreadcrumb(
+      'process_gone_suppressed',
+      buildSuppressedProcessGoneBreadcrumbData({
+        source,
+        processType,
+        reason,
+        exitCode,
+        details
+      })
+    )
+    recordNoCaptureDiagnostic('process_gone_suppressed', {
+      source,
+      processType,
+      reason,
+      exitCode,
+      details
+    })
+    return
+  }
+  const key = getProcessGoneDedupeKey(source, processType, reason, exitCode)
+  if (!(runtime.dedupe ?? processGoneDedupe).shouldRecord(key)) {
+    return
+  }
+  const crashDetails = buildProcessGoneCrashDetails(details)
+  const breadcrumbs = runtime.getCrashBreadcrumbSnapshot()
+  const appVersion = runtime.getAppVersion?.() ?? app.getVersion()
+  const crashContext: Omit<CrashReportCreateInput, 'details' | 'breadcrumbs'> = {
+    source,
+    processType,
+    reason,
+    exitCode,
+    appVersion,
+    platform: runtime.platform ?? process.platform,
+    osRelease: runtime.osRelease ?? os.release(),
+    arch: runtime.arch ?? process.arch,
+    electronVersion: runtime.electronVersion ?? process.versions.electron,
+    chromeVersion: runtime.chromeVersion ?? process.versions.chrome
+  }
+  const span: ActiveSpan = (runtime.startSpan ?? startSpan)('electron.process_gone', {
+    attributes: {
+      'crash.source': source,
+      'crash.process_type': processType,
+      'crash.reason': reason,
+      ...(exitCode !== null ? { 'crash.exit_code': exitCode } : {}),
+      'app.version': appVersion,
+      platform: crashContext.platform,
+      osRelease: crashContext.osRelease,
+      arch: crashContext.arch,
+      electronVersion: crashContext.electronVersion,
+      chromeVersion: crashContext.chromeVersion,
+      details: crashDetails,
+      breadcrumbs
+    }
+  })
+  // Why: process crashes belong in the local trace lane so diagnostic bundles
+  // retain the same process-gone signal as the persisted startup report.
+  span.fail(`${source} process gone: ${processType} ${reason} (${exitCode ?? 'unknown'})`)
+  void runtime.crashReports
+    .record({
+      ...crashContext,
+      details: crashDetails,
+      breadcrumbs
+    })
+    .catch((error) => {
+      console.error('[crash-reporting] Failed to persist crash report:', error)
+      recordNoCaptureDiagnostic('process_gone_persist_failed', {
+        source,
+        processType,
+        reason,
+        exitCode,
+        details,
+        error
+      })
+    })
+}

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildProcessGoneCrashDetails,
+  buildProcessGoneNoCaptureDiagnosticAttributes,
   buildSuppressedProcessGoneBreadcrumbData,
-  collectProcessGoneMetricDetails
+  collectProcessGoneMetricDetails,
+  recordProcessGoneNoCaptureDiagnostic
 } from './process-gone-diagnostics'
 
 type MetricFixture = {
@@ -11,8 +13,9 @@ type MetricFixture = {
   memory: { workingSetSize: number }
 }
 
-const { appMetricsMock } = vi.hoisted(() => ({
-  appMetricsMock: vi.fn<() => MetricFixture[]>(() => [])
+const { appMetricsMock, startSpanMock } = vi.hoisted(() => ({
+  appMetricsMock: vi.fn<() => MetricFixture[]>(() => []),
+  startSpanMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -20,6 +23,16 @@ vi.mock('electron', () => ({
     getAppMetrics: appMetricsMock
   }
 }))
+
+vi.mock('../observability/tracer', () => ({
+  startSpan: startSpanMock
+}))
+
+afterEach(() => {
+  appMetricsMock.mockClear()
+  startSpanMock.mockReset()
+  vi.restoreAllMocks()
+})
 
 describe('process gone diagnostics', () => {
   it('summarizes Electron process memory by crash-report-friendly buckets', () => {
@@ -85,5 +98,169 @@ describe('process gone diagnostics', () => {
       name: 'Network Service',
       serviceName: 'network.mojom.NetworkService'
     })
+  })
+
+  it('records durable suppressed-process diagnostics with sanitized identity fields', () => {
+    const end = vi.fn()
+    startSpanMock.mockReturnValue({ end })
+
+    const attributes = buildProcessGoneNoCaptureDiagnosticAttributes({
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'killed',
+      exitCode: 0,
+      details: {
+        name: 'C:\\Users\\alice\\Renderer',
+        serviceName: 'renderer.service token=abc123',
+        type: 'tab',
+        nested: { ignored: true }
+      }
+    })
+
+    expect(attributes).toEqual({
+      kind: 'crash-no-capture',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'killed',
+      exitCode: 0,
+      name: '[redacted-path]',
+      serviceName: 'renderer.service token=[redacted]',
+      type: 'tab'
+    })
+
+    recordProcessGoneNoCaptureDiagnostic('process_gone_suppressed', {
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'killed',
+      exitCode: 0,
+      details: {
+        name: 'C:\\Users\\alice\\Renderer',
+        serviceName: 'renderer.service token=abc123',
+        type: 'tab'
+      }
+    })
+
+    expect(startSpanMock).toHaveBeenCalledWith('process_gone_suppressed', {
+      attributes
+    })
+    expect(end).toHaveBeenCalledTimes(1)
+  })
+
+  it('records a store-unavailable no-capture span with process-gone identity fields', () => {
+    const end = vi.fn()
+    startSpanMock.mockReturnValue({ end })
+
+    recordProcessGoneNoCaptureDiagnostic('process_gone_store_unavailable', {
+      source: 'child',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: null,
+      details: {
+        name: 'Renderer',
+        serviceName: 'renderer.service'
+      }
+    })
+
+    expect(startSpanMock).toHaveBeenCalledWith('process_gone_store_unavailable', {
+      attributes: {
+        kind: 'crash-no-capture',
+        source: 'child',
+        processType: 'renderer',
+        reason: 'crashed',
+        name: 'Renderer',
+        serviceName: 'renderer.service'
+      }
+    })
+    expect(end).toHaveBeenCalledTimes(1)
+  })
+
+  it('sanitizes persist-failed error payloads before recording the span', () => {
+    const end = vi.fn()
+    startSpanMock.mockReturnValue({ end })
+
+    const attributes = buildProcessGoneNoCaptureDiagnosticAttributes({
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 5,
+      details: {
+        name: 'Renderer',
+        serviceName: 'renderer.service'
+      },
+      error: new Error(
+        'failed at C:\\Users\\alice\\workspace with token=abc123 and sk-12345678901234567890'
+      )
+    })
+
+    expect(attributes).toMatchObject({
+      kind: 'crash-no-capture',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 5,
+      name: 'Renderer',
+      serviceName: 'renderer.service',
+      'error.name': 'Error'
+    })
+    expect(attributes['error.message']).toContain('[redacted-path]')
+    expect(attributes['error.message']).toContain('token=[redacted]')
+    expect(attributes['error.message']).toContain('[redacted-secret]')
+
+    recordProcessGoneNoCaptureDiagnostic('process_gone_persist_failed', {
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 5,
+      details: {
+        name: 'Renderer',
+        serviceName: 'renderer.service'
+      },
+      error: new Error(
+        'failed at C:\\Users\\alice\\workspace with token=abc123 and sk-12345678901234567890'
+      )
+    })
+
+    expect(startSpanMock).toHaveBeenCalledWith('process_gone_persist_failed', {
+      attributes
+    })
+    expect(end).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves falsey persistence rejection details', () => {
+    expect(
+      buildProcessGoneNoCaptureDiagnosticAttributes({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'crashed',
+        exitCode: 5,
+        details: {},
+        error: 0
+      })
+    ).toMatchObject({
+      'error.name': 'number',
+      'error.message': '0'
+    })
+  })
+
+  it('swallows tracer failures when recording no-capture diagnostics', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    startSpanMock.mockImplementation(() => {
+      throw new Error('boom')
+    })
+
+    expect(() =>
+      recordProcessGoneNoCaptureDiagnostic('process_gone_store_unavailable', {
+        source: 'child',
+        processType: 'renderer',
+        reason: 'crashed',
+        exitCode: null,
+        details: {}
+      })
+    ).not.toThrow()
+
+    expect(warn).toHaveBeenCalledWith(
+      '[crash-reporting] Failed to record no-capture crash diagnostic:',
+      expect.any(Error)
+    )
   })
 })

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -1,6 +1,8 @@
 import { app } from 'electron'
+import { startSpan } from '../observability/tracer'
 import {
   sanitizeCrashReportDetails,
+  sanitizeCrashReportString,
   type CrashReportBreadcrumbData,
   type CrashReportDetailValue
 } from '../../shared/crash-reporting'
@@ -106,6 +108,77 @@ function getProcessGoneMetricDetails(): CrashReportDetails {
   } catch (error) {
     const errorName = error instanceof Error ? error.name : typeof error
     return { processMetricsError: errorName }
+  }
+}
+
+export type ProcessGoneNoCaptureDiagnosticName =
+  | 'process_gone_suppressed'
+  | 'process_gone_store_unavailable'
+  | 'process_gone_persist_failed'
+
+type ProcessGoneNoCaptureDiagnosticInput = {
+  source: 'renderer' | 'child'
+  processType: string
+  reason: string
+  exitCode: number | null
+  details: Record<string, unknown>
+  error?: unknown
+}
+
+function buildProcessGoneNoCaptureErrorDetails(error: unknown): CrashReportBreadcrumbData {
+  if (error === undefined || error === null) {
+    return {}
+  }
+  const errorName = error instanceof Error ? error.name : typeof error
+  const errorMessage = error instanceof Error ? error.message : String(error)
+  return {
+    'error.name': sanitizeCrashReportString(errorName),
+    'error.message': sanitizeCrashReportString(errorMessage)
+  }
+}
+
+export function buildProcessGoneNoCaptureDiagnosticAttributes({
+  source,
+  processType,
+  reason,
+  exitCode,
+  details,
+  error
+}: ProcessGoneNoCaptureDiagnosticInput): CrashReportBreadcrumbData {
+  const breadcrumbData = buildSuppressedProcessGoneBreadcrumbData({
+    source,
+    processType,
+    reason,
+    exitCode,
+    details
+  })
+  const identity = sanitizeCrashReportDetails({
+    source,
+    processType,
+    reason,
+    ...(exitCode !== null ? { exitCode } : {}),
+    ...(breadcrumbData.name ? { name: breadcrumbData.name } : {}),
+    ...(breadcrumbData.serviceName ? { serviceName: breadcrumbData.serviceName } : {}),
+    ...(breadcrumbData.type ? { type: breadcrumbData.type } : {})
+  })
+  return {
+    kind: 'crash-no-capture',
+    ...identity,
+    ...buildProcessGoneNoCaptureErrorDetails(error)
+  }
+}
+
+export function recordProcessGoneNoCaptureDiagnostic(
+  name: ProcessGoneNoCaptureDiagnosticName,
+  input: ProcessGoneNoCaptureDiagnosticInput
+): void {
+  try {
+    const span = startSpan(name, {
+      attributes: buildProcessGoneNoCaptureDiagnosticAttributes(input)
+    })
+    span.end()
+  } catch (error) {
+    console.warn('[crash-reporting] Failed to record no-capture crash diagnostic:', error)
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,7 +26,6 @@ import { closeAllWatchers } from './ipc/filesystem-watcher'
 import { disposeWorktreeBaseDirectoryWatchers } from './ipc/worktree-base-directory-watcher'
 import { registerCoreHandlers } from './ipc/register-core-handlers'
 import { initObservability, shutdownObservability } from './observability'
-import { startSpan } from './observability/tracer'
 import { registerMobileHandlers } from './ipc/mobile'
 import { initTelemetry, shutdownTelemetry, trackAppOpenedOnce, track } from './telemetry/client'
 import { classifyError } from './telemetry/classify-error'
@@ -165,22 +164,16 @@ import {
 } from './crash-reporting/crash-breadcrumb-store'
 import { CrashReportStore } from './crash-reporting/crash-report-store'
 import {
-  shouldRecordProcessGoneCrash,
   shouldRecoverRendererAfterProcessGone,
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
-import {
-  buildProcessGoneCrashDetails,
-  buildSuppressedProcessGoneBreadcrumbData
-} from './crash-reporting/process-gone-diagnostics'
-import { getProcessGoneDedupeKey, processGoneDedupe } from './crash-reporting/process-gone-dedupe'
+import { recordProcessGoneCrash } from './crash-reporting/process-gone-crash'
 import {
   advanceSyntheticTitleSpinnerEntries,
   type SyntheticTitleSpinnerEntry
 } from './synthetic-title-spinner'
 import { shouldSendSyntheticTitleFrame } from './synthetic-title-visibility'
 import { shouldCopySyntheticTitleFrameToPtyData } from './synthetic-title-frame-routing'
-import { isCrashReportReason } from '../shared/crash-reporting'
 import {
   getSyntheticAgentTitleProfile,
   shouldDriveSyntheticAgentTitleFromHook,
@@ -821,8 +814,10 @@ function openMainWindow(): BrowserWindow {
       isQuitting = false
       clearExpectedRendererReload()
     },
+    // Why: classification stays in the recorder so suppressed reportable exits
+    // can leave a durable diagnostic instead of disappearing at the window boundary.
     onRendererProcessGone: (details, webContentsId) => {
-      recordProcessGoneCrash(
+      recordProcessGoneCrashFromMain(
         'renderer',
         'renderer',
         details.reason,
@@ -833,14 +828,6 @@ function openMainWindow(): BrowserWindow {
         webContentsId
       )
     },
-    shouldRecordRendererCrash: (details, webContentsId) =>
-      shouldRecordProcessGoneCrash({
-        source: 'renderer',
-        processType: 'renderer',
-        reason: details.reason,
-        exitCode: details.exitCode ?? null,
-        expectedTeardown: getExpectedTeardownScope(webContentsId)
-      }),
     shouldRecoverRenderer: (details, webContentsId) =>
       shouldRecoverRendererAfterProcessGone({
         reason: details.reason,
@@ -1221,7 +1208,7 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   app.exit(0)
 }
 
-function recordProcessGoneCrash(
+function recordProcessGoneCrashFromMain(
   source: 'renderer' | 'child',
   processType: string,
   reason: string,
@@ -1229,75 +1216,12 @@ function recordProcessGoneCrash(
   details: Record<string, unknown>,
   webContentsId?: number
 ): void {
-  if (!crashReports || !isCrashReportReason(reason)) {
-    return
-  }
-  if (
-    !shouldRecordProcessGoneCrash({
-      source,
-      processType,
-      serviceName: typeof details.serviceName === 'string' ? details.serviceName : undefined,
-      reason,
-      exitCode,
-      expectedTeardown: getExpectedTeardownScope(webContentsId)
-    })
-  ) {
-    recordCrashBreadcrumb(
-      'process_gone_suppressed',
-      buildSuppressedProcessGoneBreadcrumbData({
-        source,
-        processType,
-        reason,
-        exitCode,
-        details
-      })
-    )
-    return
-  }
-  const key = getProcessGoneDedupeKey(source, processType, reason, exitCode)
-  if (!processGoneDedupe.shouldRecord(key)) {
-    return
-  }
-  const crashDetails = buildProcessGoneCrashDetails(details)
-  const span = startSpan('electron.process_gone', {
-    attributes: {
-      'crash.source': source,
-      'crash.process_type': processType,
-      'crash.reason': reason,
-      ...(exitCode !== null ? { 'crash.exit_code': exitCode } : {}),
-      'app.version': app.getVersion(),
-      platform: process.platform,
-      osRelease: os.release(),
-      arch: process.arch,
-      electronVersion: process.versions.electron,
-      chromeVersion: process.versions.chrome,
-      details: crashDetails,
-      breadcrumbs: getCrashBreadcrumbSnapshot()
-    }
+  recordProcessGoneCrash(source, processType, reason, exitCode, details, {
+    crashReports,
+    expectedTeardown: getExpectedTeardownScope(webContentsId),
+    getCrashBreadcrumbSnapshot,
+    recordCrashBreadcrumb
   })
-  // Why: renderer/child crashes belong in the local trace lane so the
-  // diagnostic bundle has the same process-gone signal as the startup prompt.
-  span.fail(`${source} process gone: ${processType} ${reason} (${exitCode ?? 'unknown'})`)
-  void crashReports
-    .record({
-      source,
-      processType,
-      reason,
-      exitCode,
-      appVersion: app.getVersion(),
-      platform: process.platform,
-      osRelease: os.release(),
-      arch: process.arch,
-      electronVersion: process.versions.electron,
-      chromeVersion: process.versions.chrome,
-      details: crashDetails,
-      // Why: breadcrumbs stay memory-only during normal operation. Persist a
-      // snapshot only after Electron reports a crash-like process exit.
-      breadcrumbs: getCrashBreadcrumbSnapshot()
-    })
-    .catch((error) => {
-      console.error('[crash-reporting] Failed to persist crash report:', error)
-    })
 }
 
 function shutdownWatchersOnce(): Promise<void> {
@@ -1977,11 +1901,17 @@ app.whenReady().then(async () => {
   }
 
   app.on('child-process-gone', (_event, details) => {
-    recordProcessGoneCrash('child', details.type, details.reason, details.exitCode ?? null, {
-      name: details.name,
-      serviceName: details.serviceName,
-      type: details.type
-    })
+    recordProcessGoneCrashFromMain(
+      'child',
+      details.type,
+      details.reason,
+      details.exitCode ?? null,
+      {
+        name: details.name,
+        serviceName: details.serviceName,
+        type: details.type
+      }
+    )
     if (
       isGpuFallbackCrashCandidate({
         platform: process.platform,


### PR DESCRIPTION
## Description

Adds durable, privacy-safe local diagnostics for the automatic-capture half of #7776.

A reportable Electron process exit can leave no pending crash report when:

1. the crash-report store is unavailable,
2. the event is intentionally suppressed as expected teardown, or
3. persistence rejects.

Those paths now write bounded local trace spans that can be included in a user-approved diagnostic bundle. The production renderer path classifies inside the recorder, so suppressed events reach the diagnostic branch instead of being filtered out at the window boundary. Normal accepted crashes still create the same pending report, use the same dedupe key, and preserve the same recovery behavior.

This is complementary to #7874, which handles failed report submission and retry-without-logs.

Refs #7776.

## Evidence: reproduction before and after

**Before (current main):**

Using deterministic process-gone inputs:

- Set the crash-report store to unavailable, then emit a reportable renderer/child crash: the recorder returns without a durable reason.
- Mark a reportable renderer exit as expected teardown: startup wiring filters it before the recorder; only in-memory behavior remains and no durable no-capture span is written.
- Make `CrashReportStore.record()` reject: Orca logs to the console, but the diagnostic bundle has no durable `process_gone_persist_failed` signal.

That reproduces the issue's “No automatic crash report was captured” state without enough evidence to distinguish why.

**After:**

Focused routing tests verify:

- store unavailable → `process_gone_store_unavailable`,
- expected-teardown suppression → `process_gone_suppressed`,
- persistence rejection → `process_gone_persist_failed`,
- accepted crashes still persist with crash context and breadcrumbs,
- deduped and non-reportable exits remain quiet,
- paths, token-like values, secret-like values, and unusual falsey rejection details are safely bounded/sanitized.

Validation on refreshed SHA `f1e4a6014`:

- `pnpm test -- src/main/crash-reporting/process-gone-crash.test.ts src/main/crash-reporting/process-gone-diagnostics.test.ts src/main/window/createMainWindow.test.ts` — 80 passed.
- Expanded crash-reporting run including classification and dedupe — 104 tests run; the only initial failure exposed a test-fixture mismatch during sanitizer hardening, corrected before the final 80-test rerun.
- `pnpm run typecheck:node` — passed.
- Touched-file `oxlint` — passed.
- `pnpm run check:max-lines-ratchet` — passed.
- `git diff --check` — passed.

## ELI5

Previously, if Orca failed to save the crash note, it could also lose the explanation for why the note was missing. This change keeps a tiny, redacted “receipt” saying whether saving was skipped, unavailable, or failed. That receipt can later travel with logs only when the user chooses to attach them.

## User-facing trade-offs

- **Benefit:** “no crash captured” reports can reveal which capture stage failed.
- **Benefit:** accepted crash prompts and automatic recovery behavior do not change.
- **Benefit:** diagnostic identity/error strings use existing crash-report sanitization.
- **Cost:** suppressed reportable exits add a small local trace record.
- **Cost:** the diagnostic identifies the failure category, not a native crash stack or minidump.
- **Privacy:** no automatic upload is added; these local spans leave the machine only through the existing user-approved diagnostic-bundle flow.

## Compatibility and security

- Cross-platform main-process code; no OS-specific paths or flags.
- SSH, WSL, remote, Git-provider, and Git-version behavior are unchanged.
- No new IPC, subprocess, endpoint, auth flow, dependency, or renderer surface.
- Existing observability consent/no-op gating, rotation, and redaction remain in force.