### PR TITLE
fix(terminal): make xterm scrollbar gutter transparent

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -529,27 +529,32 @@
 
 /* ── Editor-style scrollbar (matches Monaco) ────────── */
 
-.scrollbar-editor {
+.scrollbar-editor,
+.xterm .xterm-viewport {
   scrollbar-width: thin;
   scrollbar-color: rgba(121, 121, 121, 0.4) transparent;
 }
 
-.scrollbar-editor::-webkit-scrollbar {
+.scrollbar-editor::-webkit-scrollbar,
+.xterm .xterm-viewport::-webkit-scrollbar {
   width: 14px;
 }
 
-.scrollbar-editor::-webkit-scrollbar-track {
+.scrollbar-editor::-webkit-scrollbar-track,
+.xterm .xterm-viewport::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.scrollbar-editor::-webkit-scrollbar-thumb {
+.scrollbar-editor::-webkit-scrollbar-thumb,
+.xterm .xterm-viewport::-webkit-scrollbar-thumb {
   background: rgba(121, 121, 121, 0.4);
   border: 3px solid transparent;
   border-radius: 7px;
   background-clip: padding-box;
 }
 
-.scrollbar-editor::-webkit-scrollbar-thumb:hover {
+.scrollbar-editor::-webkit-scrollbar-thumb:hover,
+.xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
   background: rgba(121, 121, 121, 0.7);
   border: 3px solid transparent;
   background-clip: padding-box;

--- a/src/renderer/src/assets/terminal-scrollbar-style.test.ts
+++ b/src/renderer/src/assets/terminal-scrollbar-style.test.ts
@@ -2,14 +2,16 @@ import fs from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const terminalCss = fs.readFileSync(new URL('./terminal.css', import.meta.url), 'utf8')
+const mainCss = fs.readFileSync(new URL('./main.css', import.meta.url), 'utf8')
 
 describe('terminal scrollbar styling', () => {
-  it('keeps the reserved xterm viewport scrollbar gutter transparent', () => {
-    expect(terminalCss).toMatch(
-      /\.xterm \.xterm-viewport\s*{[^}]*scrollbar-color:\s*var\(--xterm-scrollbar-thumb\) transparent/s
+  it('reuses the canonical editor scrollbar with a transparent gutter', () => {
+    expect(mainCss).toMatch(
+      /\.scrollbar-editor,\s*\.xterm \.xterm-viewport\s*{[^}]*scrollbar-color:\s*rgba\(121, 121, 121, 0\.4\) transparent/s
     )
-    expect(terminalCss).toMatch(
-      /\.xterm \.xterm-viewport::-webkit-scrollbar-track\s*{[^}]*background:\s*transparent/s
+    expect(mainCss).toMatch(
+      /\.scrollbar-editor::-webkit-scrollbar-track,\s*\.xterm \.xterm-viewport::-webkit-scrollbar-track\s*{[^}]*background:\s*transparent/s
     )
+    expect(terminalCss).not.toContain('--xterm-scrollbar-thumb')
   })
 })

--- a/src/renderer/src/assets/terminal-scrollbar-style.test.ts
+++ b/src/renderer/src/assets/terminal-scrollbar-style.test.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const terminalCss = fs.readFileSync(new URL('./terminal.css', import.meta.url), 'utf8')
+
+describe('terminal scrollbar styling', () => {
+  it('keeps the reserved xterm viewport scrollbar gutter transparent', () => {
+    expect(terminalCss).toMatch(
+      /\.xterm \.xterm-viewport\s*{[^}]*scrollbar-color:\s*var\(--xterm-scrollbar-thumb\) transparent/s
+    )
+    expect(terminalCss).toMatch(
+      /\.xterm \.xterm-viewport::-webkit-scrollbar-track\s*{[^}]*background:\s*transparent/s
+    )
+  })
+})

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -31,6 +31,38 @@
   overflow-y: scroll;
 }
 
+.xterm .xterm-viewport {
+  --xterm-scrollbar-thumb: rgba(121, 121, 121, 0.4);
+  --xterm-scrollbar-thumb-hover: rgba(121, 121, 121, 0.7);
+
+  /* Why: when macOS shows non-overlay scrollbars, Blink otherwise paints the
+     reserved terminal gutter with a light native track in dark terminal themes. */
+  scrollbar-width: thin;
+  scrollbar-color: var(--xterm-scrollbar-thumb) transparent;
+}
+
+.xterm .xterm-viewport::-webkit-scrollbar {
+  width: 14px;
+  background: transparent;
+}
+
+.xterm .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.xterm .xterm-viewport::-webkit-scrollbar-thumb {
+  background: var(--xterm-scrollbar-thumb);
+  border: 3px solid transparent;
+  border-radius: 7px;
+  background-clip: padding-box;
+}
+
+.xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: var(--xterm-scrollbar-thumb-hover);
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+
 /* xterm.css hard-codes the viewport background to #000 (for opaque macOS
    scrollbars). On light-themed terminals at fractional-pixel positions (e.g.
    the install terminals inside centered setup modals), that black layer

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -31,45 +31,13 @@
   overflow-y: scroll;
 }
 
-.xterm .xterm-viewport {
-  --xterm-scrollbar-thumb: rgba(121, 121, 121, 0.4);
-  --xterm-scrollbar-thumb-hover: rgba(121, 121, 121, 0.7);
-
-  /* Why: when macOS shows non-overlay scrollbars, Blink otherwise paints the
-     reserved terminal gutter with a light native track in dark terminal themes. */
-  scrollbar-width: thin;
-  scrollbar-color: var(--xterm-scrollbar-thumb) transparent;
-}
-
-.xterm .xterm-viewport::-webkit-scrollbar {
-  width: 14px;
-  background: transparent;
-}
-
-.xterm .xterm-viewport::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.xterm .xterm-viewport::-webkit-scrollbar-thumb {
-  background: var(--xterm-scrollbar-thumb);
-  border: 3px solid transparent;
-  border-radius: 7px;
-  background-clip: padding-box;
-}
-
-.xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
-  background: var(--xterm-scrollbar-thumb-hover);
-  border: 3px solid transparent;
-  background-clip: padding-box;
-}
-
 /* xterm.css hard-codes the viewport background to #000 (for opaque macOS
    scrollbars). On light-themed terminals at fractional-pixel positions (e.g.
    the install terminals inside centered setup modals), that black layer
    anti-aliases into a faint 1px line above/below the themed .xterm. Match
    xterm's own selector so this also covers terminals mounted outside the pane
-   manager, and let the themed .xterm background show through; our scrollbar is
-   already custom-styled below. */
+   manager, and let the themed .xterm background show through; the viewport
+   reuses the canonical editor scrollbar rules in main.css. */
 .xterm:not(.allow-transparency) .xterm-viewport {
   background-color: transparent;
 }


### PR DESCRIPTION
## Summary

- Style the xterm viewport scrollbar track as transparent so a reserved gutter does not render as a white strip in dark terminal themes.
- Match Orca's editor-style neutral scrollbar thumb for xterm's native viewport scrollbar.
- Add a CSS regression test that locks the xterm viewport track/thumb styling.

Closes #7366

## Test Plan

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/assets/terminal-scrollbar-style.test.ts`
- `pnpm run lint`
