### PR TITLE
fix(terminal): warn on headless interactive terminal fallback (#7442)

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8509,6 +8509,30 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('warns when an interactive renderer-backed terminal falls back to a background surface without a renderer window', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    const created = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'claude',
+      rendererBacked: true
+    })
+
+    expect(created).toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      surface: 'background'
+    })
+    expect(created.warning).toContain('background surface')
+    expect(created.warning).toContain('open Orca window')
+    expect(created.warning).toContain(`orca terminal focus --terminal ${created.handle}`)
+  })
+
   it('accepts renderer-backed terminal create replies only from the target renderer', async () => {
     const webContents = { send: vi.fn() }
     const send = vi.fn((_channel: string, payload: { requestId: string }) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1199,6 +1199,13 @@ function createTerminalRevealWarning(handle: string, error?: unknown): string {
   ].join(' ')
 }
 
+function createTerminalRendererFallbackWarning(handle: string): string {
+  return [
+    `Terminal ${handle} is running in a background surface because Orca had no renderer window for this interactive session.`,
+    `Interactive terminal UIs may need an open Orca window to complete their display handshake. Run \`orca terminal focus --terminal ${handle}\` to reveal and focus it.`
+  ].join(' ')
+}
+
 function resolveTerminalPresentation(opts: {
   presentation?: RuntimeTerminalPresentation
   focus?: boolean
@@ -16010,6 +16017,9 @@ export class OrcaRuntimeService {
     // the renderer IPC path to preserve that behavior.
     const rendererWindow =
       opts.rendererBacked === true ? this.getAvailableAuthoritativeWindow() : null
+    // Why: focused requests need the existing reveal fallback path when no renderer is available.
+    const rendererBackedWithoutWindow =
+      opts.rendererBacked === true && rendererWindow === null && !requiresRendererFocus
     const shouldCreateInBackground =
       worktreeSelector !== undefined &&
       ((!requiresRendererFocus && opts.rendererBacked !== true) ||
@@ -16168,7 +16178,9 @@ export class OrcaRuntimeService {
       }
       let surface: RuntimeTerminalCreate['surface'] = 'background'
       let warning: string | undefined
-      if (presentation !== 'background' && this.notifier?.revealTerminalSession) {
+      if (rendererBackedWithoutWindow) {
+        warning = createTerminalRendererFallbackWarning(handle)
+      } else if (presentation !== 'background' && this.notifier?.revealTerminalSession) {
         try {
           // Why: after the PTY is spawned, renderer tab adoption is best-effort;
           // failing here must not strand a live process without returning a handle.


### PR DESCRIPTION
## Summary

- Adds an explicit warning when an interactive renderer-backed terminal request falls back to a background PTY because no Orca renderer window is available.
- Keeps the terminal handle creation behavior unchanged, including ordinary background terminals and one-shot `claude -p` style commands.

Refs #7442.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/cli/codex-command-classification.test.ts src/cli/index.test.ts` - passed, 3 files passed, 724 tests total, 3 skipped.
- `pnpm run typecheck:node` - passed.

## AI Review Report

The change is scoped to terminal creation response guidance. The warning only fires when a renderer-backed interactive request falls back to a background PTY because no renderer window is available. Ordinary background terminals, renderer-adopted sessions, and classification logic stay unchanged.

Cross-platform behavior was checked for macOS, Linux, and Windows concerns: the patch only changes a runtime response warning and preserves terminal handle creation, existing focus recovery, and renderer adoption paths across platforms.

## Security Audit

No command execution, auth, browser, SSH, or filesystem permissions changed. The warning only reports the terminal handle and the existing `orca terminal focus --terminal <handle>` command.

## Notes

This is a scoped mitigation for the deterministic no-renderer fallback. It does not claim to fix Claude Code's probabilistic renderer handshake race for fresh sessions.

## ELI5

When an interactive terminal can’t open a real Orca window, it still runs in the background. Orca now shows a clear warning so you know the pane fell back instead of failing silently.
