### PR TITLE
fix(terminal): guard PTY handler unregistration against detach/attach remount races (frozen pane)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -246,8 +246,12 @@ export function registerEagerPtyBuffer(
   const exitHandler = (code: number): void => {
     // Shell died before TerminalPane attached — clean up and notify the store
     // so the tab's ptyId is cleared and connectPanePty falls through to connect().
-    ptyDataHandlers.delete(ptyId)
-    ptyReplayHandlers.delete(ptyId)
+    // Identity-guarded like dispose(): never delete a handler a transport has
+    // since registered for this id.
+    if (ptyDataHandlers.get(ptyId) === dataHandler) {
+      ptyDataHandlers.delete(ptyId)
+      ptyReplayHandlers.delete(ptyId)
+    }
     ptyExitHandlers.delete(ptyId)
     eagerPtyHandles.delete(ptyId)
     onExit(ptyId, code)

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -15,6 +15,11 @@ const preHandlerPtyExit = new Map<string, number>()
 // and dropping the first setup-script bytes.
 const PRE_HANDLER_PTY_DATA_MAX_BYTES = 512 * 1024
 const PRE_HANDLER_PTY_DATA_MAX_PTYS = 64
+// Why: legit pre-attach windows drain within milliseconds and hold little
+// data. Sustained accumulation means a pane lost its data handler (the
+// frozen-pane detach/attach race) — leave a breadcrumb for trace capture.
+const PRE_HANDLER_PTY_DATA_WARN_BYTES = 64 * 1024
+const warnedLostHandlerPtyIds = new Set<string>()
 
 export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyDataMeta): void {
   const chunk = clampUtf8Tail(data, PRE_HANDLER_PTY_DATA_MAX_BYTES)
@@ -42,6 +47,13 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
     totalBytes -= chunks.shift()?.bytes ?? 0
   }
   preHandlerPtyData.set(ptyId, chunks)
+  if (totalBytes > PRE_HANDLER_PTY_DATA_WARN_BYTES && !warnedLostHandlerPtyIds.has(ptyId)) {
+    warnedLostHandlerPtyIds.add(ptyId)
+    console.warn(
+      `[pty] ${ptyId}: ${totalBytes} bytes buffered with no registered data handler; ` +
+        'the owning pane may have lost its handler to a detach/attach race'
+    )
+  }
 }
 
 export function drainPreHandlerPtyData(
@@ -49,6 +61,7 @@ export function drainPreHandlerPtyData(
   handler: (data: string, meta?: PtyDataMeta) => void
 ): void {
   const chunks = preHandlerPtyData.get(ptyId)
+  warnedLostHandlerPtyIds.delete(ptyId)
   if (!chunks) {
     return
   }
@@ -73,9 +86,11 @@ export function drainPreHandlerPtyExit(ptyId: string, handler: (code: number) =>
 
 export function clearPreHandlerPtyData(ptyId: string): void {
   preHandlerPtyData.delete(ptyId)
+  warnedLostHandlerPtyIds.delete(ptyId)
 }
 
 export function clearPreHandlerPtyState(ptyId: string): void {
   preHandlerPtyData.delete(ptyId)
   preHandlerPtyExit.delete(ptyId)
+  warnedLostHandlerPtyIds.delete(ptyId)
 }

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -137,6 +137,65 @@ describe('createIpcPtyTransport', () => {
     expect(onReplayData).toHaveBeenCalledWith('new replay')
   })
 
+  it('keeps the live handler when detach() runs after a newer transport attached to the same PTY', async () => {
+    // Why: pane->tab detach and split-group moves rehome the React subtree, so
+    // the NEW TerminalPane can attach to the same ptyId BEFORE the old pane's
+    // unmount detach() runs. An unconditional unregister deletes the live
+    // handler and the pane freezes with the PTY still alive (frozen-pane bug).
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const receivedByNewPane = vi.fn()
+    const replayedToNewPane = vi.fn()
+    const exitSeenByNewPane = vi.fn()
+    const receivedByOldPane = vi.fn()
+
+    const oldPane = createIpcPtyTransport({})
+    await oldPane.connect({ url: '', callbacks: { onData: receivedByOldPane } })
+
+    const newPane = createIpcPtyTransport({})
+    newPane.attach?.({
+      existingPtyId: 'pty-1',
+      callbacks: {
+        onData: receivedByNewPane,
+        onReplayData: replayedToNewPane,
+        onExit: exitSeenByNewPane
+      }
+    })
+    oldPane.detach?.()
+
+    onData?.({ id: 'pty-1', data: 'live output' })
+    onReplay?.({ id: 'pty-1', data: 'replay output' })
+
+    expect(receivedByNewPane).toHaveBeenCalledWith('live output')
+    expect(replayedToNewPane).toHaveBeenCalledWith('replay output')
+    expect(receivedByOldPane).not.toHaveBeenCalled()
+
+    onExit?.({ id: 'pty-1', code: 0 })
+    expect(exitSeenByNewPane).toHaveBeenCalledWith(0)
+  })
+
+  it('buffers data across a normal detach-then-attach gap and drains it to the next pane', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const receivedByNewPane = vi.fn()
+
+    const oldPane = createIpcPtyTransport({})
+    await oldPane.connect({ url: '', callbacks: { onData: vi.fn() } })
+    oldPane.detach?.()
+
+    onData?.({ id: 'pty-1', data: 'buffered while detached' })
+    expect(receivedByNewPane).not.toHaveBeenCalled()
+
+    const newPane = createIpcPtyTransport({})
+    newPane.attach?.({
+      existingPtyId: 'pty-1',
+      callbacks: { onData: receivedByNewPane }
+    })
+
+    expect(receivedByNewPane).toHaveBeenCalledWith('buffered while detached')
+
+    onData?.({ id: 'pty-1', data: 'live after reattach' })
+    expect(receivedByNewPane).toHaveBeenCalledWith('live after reattach')
+  })
+
   it('exposes the connection identity captured at transport creation', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
 

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -502,16 +502,41 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   })
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
 
+  // Why: pane->tab detach / split-group moves rehome the React subtree, so a
+  // NEW TerminalPane can attach to the same ptyId before the OLD instance's
+  // detach() runs. Track the handlers THIS instance registered so unregister
+  // paths only delete map entries they still own — an unconditional delete
+  // destroys the live handler and the pane freezes (data diverts into the
+  // pre-handler buffer forever).
+  const ownedDataAndReplayHandlers = new Map<
+    string,
+    { data: (data: string, meta?: PtyDataMeta) => void; replay: (data: string) => void }
+  >()
+  const ownedExitHandlers = new Map<string, (code: number) => void>()
+
   function unregisterPtyHandlers(id: string): void {
-    ptyDataHandlers.delete(id)
-    ptyReplayHandlers.delete(id)
-    ptyExitHandlers.delete(id)
-    ptyTeardownHandlers.delete(id)
+    unregisterPtyDataAndStatusHandlers(id)
+    const ownedExit = ownedExitHandlers.get(id)
+    if (ownedExit && ptyExitHandlers.get(id) === ownedExit) {
+      ptyExitHandlers.delete(id)
+    }
+    ownedExitHandlers.delete(id)
+    if (ptyTeardownHandlers.get(id) === clearAccumulatedState) {
+      ptyTeardownHandlers.delete(id)
+    }
   }
 
   function unregisterPtyDataAndStatusHandlers(id: string): void {
-    ptyDataHandlers.delete(id)
-    ptyReplayHandlers.delete(id)
+    const owned = ownedDataAndReplayHandlers.get(id)
+    if (owned) {
+      if (ptyDataHandlers.get(id) === owned.data) {
+        ptyDataHandlers.delete(id)
+      }
+      if (ptyReplayHandlers.get(id) === owned.replay) {
+        ptyReplayHandlers.delete(id)
+      }
+    }
+    ownedDataAndReplayHandlers.delete(id)
   }
 
   // Why: shared by connect() and attach() to avoid duplicating title/bell/exit
@@ -520,7 +545,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     // Why: relay pty.attach sends replay data via a dedicated pty:replay IPC
     // channel. Route it through onReplayData so the renderer engages the
     // replay guard and xterm auto-replies do not leak into the shell.
-    ptyReplayHandlers.set(id, (data) => {
+    const replayHandler = (data: string): void => {
       if (ptyId !== id) {
         return
       }
@@ -529,7 +554,8 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       } else {
         storedCallbacks.onData?.(data)
       }
-    })
+    }
+    ptyReplayHandlers.set(id, replayHandler)
     const dataHandler = (data: string, meta?: PtyDataMeta): void => {
       if (ptyId !== id) {
         return
@@ -544,6 +570,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       )
     }
     ptyDataHandlers.set(id, dataHandler)
+    ownedDataAndReplayHandlers.set(id, { data: dataHandler, replay: replayHandler })
     drainPreHandlerPtyData(id, dataHandler)
   }
 
@@ -599,6 +626,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       onPtyExit?.(id)
     }
     ptyExitHandlers.set(id, exitHandler)
+    ownedExitHandlers.set(id, exitHandler)
     // Why: shutdownWorktreeTerminals bypasses the transport layer — it
     // kills PTYs directly via IPC without calling disconnect()/destroy().
     // This teardown callback lets unregisterPtyDataHandlers cancel


### PR DESCRIPTION
## Symptom

A terminal pane permanently stops updating while its PTY/process stays alive (the "frozen pane" bug). The pane still repaints on theme changes (rendering is healthy) but never receives another byte; the main process side (agent status, PTY drain, ACKs) stays fully live. Live-debugged in production 1.4.129-rc.2 on 2026-07-08.

## Root cause

Renderer PTY data delivery routes through a module-global `ptyDataHandlers` map keyed by ptyId. Pane→tab detach and split-group moves rehome the React subtree: the old `TerminalPane` unmounts (→ `transport.detach()`) while a **new** `TerminalPane` attaches to the **same** ptyId, and ordering across the two React trees is not guaranteed. `detach()` called `unregisterPtyDataAndStatusHandlers(ptyId)`, which deleted the `ptyDataHandlers`/`ptyReplayHandlers` entries **unconditionally** — no check that the registered handler belonged to that transport instance. When the new pane's `attach()` registered its handler before the old pane's `detach()` ran, the delete destroyed the live handler. From then on the dispatcher found no handler and diverted all data into the pre-handler buffer (512 KB tail cap) forever — nothing drains it because draining only happens at handler registration, which the live pane had already done.

This flow was armed by #7215 (`isDetachedToTab` → `transport.detach()` in the common pane→tab path); user freeze reports started right after it shipped in v1.4.122.

## Fix

- `pty-transport.ts`: each transport instance now tracks the data/replay/exit handlers it registered (per ptyId). `unregisterPtyHandlers` / `unregisterPtyDataAndStatusHandlers` delete a map entry only if it still points to a handler this instance owns — the same identity-guard pattern already used by `registerTerminalBacklogRecovery` and the eager-buffer `dispose()`. The teardown-handler delete is identity-guarded the same way. The exit handler's existing `ptyId !== id` stale-path now also cleans up only owned entries.
- `pty-dispatcher.ts`: the eager-buffer exit handler's cleanup gets the same identity guard (it previously deleted `ptyDataHandlers`/`ptyReplayHandlers` unconditionally).
- `pty-pre-handler-buffer.ts`: one-shot `console.warn` breadcrumb when >64 KB accumulates for a ptyId with no registered handler — sustained accumulation is exactly this bug class and legit pre-attach windows drain within milliseconds.
- `remote-runtime-pty-transport.ts` (SSH/remote runtime) was audited and is **not** affected: its `detach()` closes only its own instance-held multiplexed stream, and the multiplexer keys subscriptions by a per-subscription stream id, so a stale detach cannot destroy a newer pane's subscription. No change needed there; SSH paths are untouched by this diff.

## Regression tests

- Failure ordering (fails without the fix): transport A connected to ptyId X; transport B attaches to X; A's `detach()` runs afterward → data, replay, and exit for X still reach B, and A's callbacks stay silent.
- Normal ordering: A detaches, data arrives in the gap (buffered), B attaches → buffered data drains to B and live data flows.

## Verification

- `pty-transport.test.ts`: 60/60 pass (new race test fails on unfixed code, verified by stash-run).
- Full terminal-pane suite: 1687 pass. pane-manager suite: 391 pass.
- `typecheck:web` and oxlint clean.

Fixes the frozen-pane regression introduced alongside #7215.

Made with [Orca](https://github.com/stablyai/orca) 🐋
