### PR TITLE
fix(mobile): bump Android versionCode to 6 for the 0.0.25 release

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 5
+      "versionCode": 6
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
## Summary
- `Prepare mobile 0.0.25` (#7751) bumped `expo.version` to 0.0.25 but left `expo.android.versionCode` at **5** — the same value `mobile-android-v0.0.24` shipped.
- The Android release workflow (`mobile/scripts/prepare-android-release.mjs`) uses the committed `versionCode` as-is and explicitly rejects bumping it at dispatch time, so a 0.0.25 APK built now would carry versionCode 5 and **collide with v0.0.24** — Android blocks installing an update whose versionCode isn't higher, so existing users couldn't upgrade.
- Bumps `versionCode` 5 → 6 so the 0.0.25 Android release is installable over v0.0.24.

## Context
Needed before triggering `Mobile Android Release` for 0.0.25 (which carries the STA-1511 mobile source-control fix). iOS is unaffected — it uses a separate CI-owned `buildNumber`.

## Verification
- `node -e` parse of `mobile/app.json`: version 0.0.25, android.versionCode 6, ios.buildNumber untouched.
- versionCode history confirmed: v0.0.22=4, v0.0.24=5, so 6 is the correct next value.

Made with [Orca](https://github.com/stablyai/orca) 🐋
