### PR TITLE
Align per-workspace environments experimental toggle

### DIFF
--- a/src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx
@@ -26,7 +26,7 @@ export function EphemeralVmsExperimentalSetting({
       className="max-w-none space-y-4 py-2"
       id="ephemeral-vms"
     >
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex max-w-3xl items-start justify-between gap-4">
         <div className="min-w-0 shrink space-y-0.5">
           <Label>
             {translate(


### PR DESCRIPTION
## Summary

Aligns the Per-Workspace Environments experimental setting toggle with the other Experimental pane switches by capping the toggle row at the standard settings row width while leaving the expanded setup controls full-width.

## Screenshots

- Not captured: this worktree does not have `node_modules`, so the app/dev server could not be launched locally without installing dependencies.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation run:

- [x] `git diff --check`
- [x] `pnpm check:max-lines-ratchet --prune`
- [ ] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ExperimentalPane.test.tsx` (blocked: `vitest` is not installed because this checkout has no `node_modules`; pnpm also reports Node v26.5.0 while the repo requests Node 24)

No test changes: this is a one-class layout alignment fix for an existing row, with no behavior change.

## AI Review Report

Reviewed the settings layout against `docs/STYLEGUIDE.md` and the existing Experimental pane row grammar. The issue was isolated to `EphemeralVmsExperimentalSetting`: its wrapper intentionally uses `max-w-none` for the expanded setup pane, but that also made the switch row justify against the wider container. The fix applies the existing `max-w-3xl` settings width only to the switch row.

Cross-platform compatibility checked for macOS, Linux, and Windows: this PR only changes renderer CSS utility classes. It does not touch shortcuts, labels, paths, shell behavior, IPC, Electron main/preload behavior, or provider-specific source-control code.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependencies, or IPC surfaces are changed. The change is limited to a Tailwind layout class on an existing settings row.

## Notes

The expanded Per-Workspace Environments setup controls still use the wider layout; only the header/toggle row is constrained to align with the rest of Experimental settings.
