### PR TITLE
feat(runtime): show and edit Remote Orca Server connection details

### DIFF
--- a/src/main/ipc/runtime-environment-connectivity-handlers.ts
+++ b/src/main/ipc/runtime-environment-connectivity-handlers.ts
@@ -3,6 +3,8 @@ import {
   addEnvironmentFromPairingCode,
   listEnvironments,
   removeEnvironment,
+  renameEnvironment,
+  updateEnvironmentFromPairingCode,
   resolveEnvironment
 } from '../../shared/runtime-environment-store'
 import {
@@ -77,6 +79,23 @@ export function registerRuntimeEnvironmentConnectivityHandlers({
   )
   ipcMain.handle('runtimeEnvironments:resolve', (_event, args: { selector: string }) =>
     redactRuntimeEnvironment(resolveEnvironment(getUserDataPath(), args.selector))
+  )
+  ipcMain.handle(
+    'runtimeEnvironments:rename',
+    (_event, args: { selector: string; name: string }) =>
+      redactRuntimeEnvironment(renameEnvironment(getUserDataPath(), args.selector, { name: args.name }))
+  )
+  ipcMain.handle(
+    'runtimeEnvironments:updateFromPairingCode',
+    (_event, args: { selector: string; pairingCode: string }) => {
+      // Why: re-pair replaces the endpoint/token; drop live sockets so the next
+      // connect uses the new peer rather than a stale transport generation.
+      const environment = updateEnvironmentFromPairingCode(getUserDataPath(), args.selector, {
+        pairingCode: args.pairingCode
+      })
+      invalidateTransport(environment.id)
+      return redactRuntimeEnvironment(environment)
+    }
   )
   ipcMain.handle(
     'runtimeEnvironments:remove',

--- a/src/main/ipc/runtime-environment-handler-channels.ts
+++ b/src/main/ipc/runtime-environment-handler-channels.ts
@@ -3,6 +3,8 @@ export const RUNTIME_ENVIRONMENT_HANDLER_CHANNELS = [
   'runtimeEnvironments:addFromPairingCode',
   'runtimeEnvironments:verifyAndAddFromPairingCode',
   'runtimeEnvironments:resolve',
+  'runtimeEnvironments:rename',
+  'runtimeEnvironments:updateFromPairingCode',
   'runtimeEnvironments:remove',
   'runtimeEnvironments:disconnect',
   'runtimeEnvironments:connect',

--- a/src/main/ipc/runtime-environments.test.ts
+++ b/src/main/ipc/runtime-environments.test.ts
@@ -150,6 +150,8 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       'runtimeEnvironments:addFromPairingCode',
       'runtimeEnvironments:verifyAndAddFromPairingCode',
       'runtimeEnvironments:resolve',
+      'runtimeEnvironments:rename',
+      'runtimeEnvironments:updateFromPairingCode',
       'runtimeEnvironments:remove',
       'runtimeEnvironments:disconnect',
       'runtimeEnvironments:connect',
@@ -172,6 +174,8 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       'runtimeEnvironments:addFromPairingCode',
       'runtimeEnvironments:verifyAndAddFromPairingCode',
       'runtimeEnvironments:resolve',
+      'runtimeEnvironments:rename',
+      'runtimeEnvironments:updateFromPairingCode',
       'runtimeEnvironments:remove',
       'runtimeEnvironments:disconnect',
       'runtimeEnvironments:connect',
@@ -227,6 +231,48 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     expect(closeRemoteRuntimeRequestConnectionMock).toHaveBeenCalledWith(added.environment.id)
     expect(JSON.stringify(removed)).not.toContain('device-token')
     expect(await list(null, undefined)).toEqual([])
+  })
+
+
+  it('renames a saved environment without changing its id', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+    const added = await add(null, { name: 'desk', pairingCode: pairingCode() })
+    const rename = handler<{ selector: string; name: string }, { id: string; name: string }>(
+      'runtimeEnvironments:rename'
+    )
+    expect(rename(null, { selector: added.environment.id, name: 'lab' })).toMatchObject({
+      id: added.environment.id,
+      name: 'lab'
+    })
+    const list = handler<undefined, { id: string; name: string }[]>('runtimeEnvironments:list')
+    expect(await list(null, undefined)).toMatchObject([{ id: added.environment.id, name: 'lab' }])
+  })
+
+  it('re-pairs a saved environment and invalidates its transport', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string; endpoint?: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+    const added = await add(null, {
+      name: 'desk',
+      pairingCode: pairingCode('ws://192.168.1.10:6768')
+    })
+    const update = handler<
+      { selector: string; pairingCode: string },
+      { id: string; name: string }
+    >('runtimeEnvironments:updateFromPairingCode')
+    expect(
+      update(null, {
+        selector: added.environment.id,
+        pairingCode: pairingCode('ws://100.64.0.5:6768')
+      })
+    ).toMatchObject({ id: added.environment.id, name: 'desk' })
+    expect(closeRemoteRuntimeRequestConnectionMock).toHaveBeenCalledWith(added.environment.id)
   })
 
   it('blocks loopback before verification unless an SSH tunnel is declared', async () => {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3323,6 +3323,11 @@ export type PreloadApi = {
       allowLoopback?: boolean
     }) => Promise<VerifyAndAddRuntimeEnvironmentResult>
     resolve: (args: { selector: string }) => Promise<PublicKnownRuntimeEnvironment>
+    rename: (args: { selector: string; name: string }) => Promise<PublicKnownRuntimeEnvironment>
+    updateFromPairingCode: (args: {
+      selector: string
+      pairingCode: string
+    }) => Promise<PublicKnownRuntimeEnvironment>
     remove: (args: { selector: string }) => Promise<{ removed: PublicKnownRuntimeEnvironment }>
     disconnect: (args: {
       selector: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4285,6 +4285,16 @@ const api = {
       ipcRenderer.invoke('runtimeEnvironments:verifyAndAddFromPairingCode', args),
     resolve: (args: { selector: string }): Promise<PublicKnownRuntimeEnvironment> =>
       ipcRenderer.invoke('runtimeEnvironments:resolve', args),
+    rename: (args: {
+      selector: string
+      name: string
+    }): Promise<PublicKnownRuntimeEnvironment> =>
+      ipcRenderer.invoke('runtimeEnvironments:rename', args),
+    updateFromPairingCode: (args: {
+      selector: string
+      pairingCode: string
+    }): Promise<PublicKnownRuntimeEnvironment> =>
+      ipcRenderer.invoke('runtimeEnvironments:updateFromPairingCode', args),
     remove: (args: { selector: string }): Promise<{ removed: PublicKnownRuntimeEnvironment }> =>
       ipcRenderer.invoke('runtimeEnvironments:remove', args),
     disconnect: (args: {

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   ChevronDown,
   Loader2,
+  Pencil,
   Plus,
   RefreshCw,
   Server,
@@ -46,6 +47,15 @@ import {
   DialogTitle
 } from '../ui/dialog'
 import { RuntimePairingUrlGenerator } from './RuntimePairingUrlGenerator'
+import {
+  getPreferredPublicRuntimeEndpoint,
+  getRuntimeEndpointTransportKind
+} from '../../../../shared/runtime-environment-endpoint-display'
+import {
+  getRuntimeEndpointTransportLabel,
+  getRuntimeServerEndpointDisplay
+} from './runtime-server-endpoint-labels'
+import { RuntimeServerEditDialog, type RuntimeServerEditSaveArgs } from './RuntimeServerEditDialog'
 import { EphemeralVmRuntimesSection } from './EphemeralVmRuntimesSection'
 import { CloudVmSetupGuide } from './CloudVmSetupGuide'
 import {
@@ -277,6 +287,9 @@ export function RuntimeEnvironmentsPane({
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null)
   const [pendingSwitchValue, setPendingSwitchValue] = useState<string | null>(null)
   const [pendingRemove, setPendingRemove] = useState<PublicKnownRuntimeEnvironment | null>(null)
+  const [pendingEdit, setPendingEdit] = useState<PublicKnownRuntimeEnvironment | null>(null)
+  const [editError, setEditError] = useState<string | null>(null)
+  const [isEditing, setIsEditing] = useState(false)
   const [addServerFormOpen, setAddServerFormOpen] = useState(false)
   const [shareServerFormOpen, setShareServerFormOpen] = useState(true)
   const [advancedOpen, setAdvancedOpen] = useState(false)
@@ -301,6 +314,7 @@ export function RuntimeEnvironmentsPane({
     (allowLocalRuntime ? LOCAL_RUNTIME_VALUE : NO_RUNTIME_VALUE)
   const isBusy =
     isSaving ||
+    isEditing ||
     connectingId !== null ||
     switchingValue !== null ||
     removingId !== null ||
@@ -579,6 +593,97 @@ export function RuntimeEnvironmentsPane({
     } finally {
       if (mountedRef.current) {
         setRemovingId(null)
+      }
+    }
+  }
+
+  const saveEditedEnvironment = async (args: RuntimeServerEditSaveArgs): Promise<void> => {
+    const environment = pendingEdit
+    if (!environment) {
+      return
+    }
+    const nextName = args.name.trim()
+    if (!nextName) {
+      setEditError(
+        translate(
+          'auto.components.settings.RuntimeEnvironmentsPane.editNameRequired',
+          'Server name is required.'
+        )
+      )
+      return
+    }
+    const renameNeeded = nextName !== environment.name
+    const rePairNeeded = args.pairingCode != null && args.pairingCode.length > 0
+    if (!renameNeeded && !rePairNeeded) {
+      setPendingEdit(null)
+      setEditError(null)
+      return
+    }
+    const duplicate = environments.find(
+      (entry) =>
+        entry.id !== environment.id && entry.name.trim().toLowerCase() === nextName.toLowerCase()
+    )
+    if (duplicate) {
+      setEditError(
+        translate(
+          'auto.components.settings.RuntimeEnvironmentsPane.5ef712f407',
+          'A server named "{{value0}}" already exists.',
+          { value0: duplicate.name }
+        )
+      )
+      return
+    }
+
+    setIsEditing(true)
+    setEditError(null)
+    try {
+      let latest = environment
+      if (renameNeeded) {
+        latest = await window.api.runtimeEnvironments.rename({
+          selector: environment.id,
+          name: nextName
+        })
+      }
+      if (rePairNeeded && args.pairingCode) {
+        latest = await window.api.runtimeEnvironments.updateFromPairingCode({
+          selector: latest.id,
+          pairingCode: args.pairingCode
+        })
+      }
+      await loadEnvironments()
+      if (mountedRef.current) {
+        toast.success(
+          rePairNeeded
+            ? translate(
+                'auto.components.settings.RuntimeEnvironmentsPane.editServerUpdatedConnection',
+                'Updated {{value0}}. Reconnect if you changed the address.',
+                { value0: latest.name }
+              )
+            : translate(
+                'auto.components.settings.RuntimeEnvironmentsPane.editServerRenamed',
+                'Renamed server to {{value0}}.',
+                { value0: latest.name }
+              )
+        )
+        setPendingEdit(null)
+      }
+    } catch (error) {
+      // Why: rename may have succeeded before re-pair failed; reload so the UI
+      // reflects partial backend changes instead of a stale server name.
+      await loadEnvironments()
+      if (mountedRef.current) {
+        setEditError(
+          error instanceof Error
+            ? error.message
+            : translate(
+                'auto.components.settings.RuntimeEnvironmentsPane.editServerFailed',
+                'Failed to update server.'
+              )
+        )
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsEditing(false)
       }
     }
   }
@@ -963,6 +1068,18 @@ export function RuntimeEnvironmentsPane({
                         <div className="min-w-0 flex-1">
                           <div className="flex min-w-0 items-center gap-2">
                             <div className="truncate text-sm font-medium">{environment.name}</div>
+                            {(() => {
+                              const endpoint = getPreferredPublicRuntimeEndpoint(environment)
+                              const transport = getRuntimeEndpointTransportKind(endpoint)
+                              if (!endpoint) {
+                                return null
+                              }
+                              return (
+                                <span className="shrink-0 rounded border border-border/60 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                                  {getRuntimeEndpointTransportLabel(transport)}
+                                </span>
+                              )
+                            })()}
                             <span
                               className={cn(
                                 'size-2 shrink-0 rounded-full',
@@ -978,6 +1095,15 @@ export function RuntimeEnvironmentsPane({
                               <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
                             ) : null}
                           </div>
+                          {(() => {
+                            const endpoint = getPreferredPublicRuntimeEndpoint(environment)
+                            const display = getRuntimeServerEndpointDisplay(endpoint)
+                            return display ? (
+                              <p className="truncate font-mono text-[11px] text-muted-foreground">
+                                {display}
+                              </p>
+                            ) : null
+                          })()}
                           <p className="truncate text-xs text-muted-foreground">
                             {environment.connectionDependency === 'ssh-tunnel'
                               ? translate(
@@ -1084,6 +1210,24 @@ export function RuntimeEnvironmentsPane({
                               )}
                             </Button>
                           )}
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => {
+                              setEditError(null)
+                              setPendingEdit(environment)
+                            }}
+                            className="size-7"
+                            disabled={isBusy}
+                            aria-label={translate(
+                              'auto.components.settings.RuntimeEnvironmentsPane.editServerAria',
+                              'Edit {{value0}}',
+                              { value0: environment.name }
+                            )}
+                          >
+                            <Pencil className="size-3" />
+                          </Button>
                           <Button
                             type="button"
                             variant="ghost"
@@ -1552,6 +1696,22 @@ export function RuntimeEnvironmentsPane({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </SearchableSetting>
+    
+      <RuntimeServerEditDialog
+        // Why: a fresh editor instance prevents draft values from leaking between servers.
+        key={pendingEdit?.id ?? 'closed'}
+        environment={pendingEdit}
+        open={pendingEdit !== null}
+        saving={isEditing}
+        error={editError}
+        onOpenChange={(open) => {
+          if (!open && !isEditing) {
+            setEditError(null)
+            setPendingEdit(null)
+          }
+        }}
+        onSave={saveEditedEnvironment}
+      />
+</SearchableSetting>
   )
 }

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -53,7 +53,7 @@ import {
 } from '../../../../shared/runtime-environment-endpoint-display'
 import {
   getRuntimeEndpointTransportLabel,
-  getRuntimeServerEndpointDisplay
+  getRuntimeServerListEndpointDisplay
 } from './runtime-server-endpoint-labels'
 import { RuntimeServerEditDialog, type RuntimeServerEditSaveArgs } from './RuntimeServerEditDialog'
 import { EphemeralVmRuntimesSection } from './EphemeralVmRuntimesSection'
@@ -1097,7 +1097,7 @@ export function RuntimeEnvironmentsPane({
                           </div>
                           {(() => {
                             const endpoint = getPreferredPublicRuntimeEndpoint(environment)
-                            const display = getRuntimeServerEndpointDisplay(endpoint)
+                            const display = getRuntimeServerListEndpointDisplay(endpoint)
                             return display ? (
                               <p className="truncate font-mono text-[11px] text-muted-foreground">
                                 {display}
@@ -1696,7 +1696,7 @@ export function RuntimeEnvironmentsPane({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    
+
       <RuntimeServerEditDialog
         // Why: a fresh editor instance prevents draft values from leaking between servers.
         key={pendingEdit?.id ?? 'closed'}
@@ -1712,6 +1712,6 @@ export function RuntimeEnvironmentsPane({
         }}
         onSave={saveEditedEnvironment}
       />
-</SearchableSetting>
+    </SearchableSetting>
   )
 }

--- a/src/renderer/src/components/settings/RuntimeServerEditDialog.tsx
+++ b/src/renderer/src/components/settings/RuntimeServerEditDialog.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import {
+  getPreferredPublicRuntimeEndpoint,
+  getRuntimeEndpointTransportKind
+} from '../../../../shared/runtime-environment-endpoint-display'
+import {
+  getRuntimeEndpointTransportLabel,
+  getRuntimeServerEndpointDisplay
+} from './runtime-server-endpoint-labels'
+import { translate } from '@/i18n/i18n'
+
+export type RuntimeServerEditSaveArgs = {
+  name: string
+  pairingCode: string | null
+}
+
+type RuntimeServerEditDialogProps = {
+  environment: PublicKnownRuntimeEnvironment | null
+  open: boolean
+  saving: boolean
+  error: string | null
+  onOpenChange: (open: boolean) => void
+  onSave: (args: RuntimeServerEditSaveArgs) => void | Promise<void>
+}
+
+export function RuntimeServerEditDialog({
+  environment,
+  open,
+  saving,
+  error,
+  onOpenChange,
+  onSave
+}: RuntimeServerEditDialogProps): React.JSX.Element {
+  const [name, setName] = useState(environment?.name ?? '')
+  const [pairingCode, setPairingCode] = useState('')
+  const endpoint = environment ? getPreferredPublicRuntimeEndpoint(environment) : null
+  const transportLabel = getRuntimeEndpointTransportLabel(getRuntimeEndpointTransportKind(endpoint))
+
+  const trimmedName = name.trim()
+  const trimmedPairingCode = pairingCode.trim()
+  const nameUnchanged = environment != null && trimmedName === environment.name
+  const canSave =
+    trimmedName.length > 0 && (!nameUnchanged || trimmedPairingCode.length > 0) && !saving
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && saving) {
+          return
+        }
+        onOpenChange(nextOpen)
+      }}
+    >
+      <DialogContent className="max-w-md sm:max-w-md" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle className="text-sm">
+            {translate(
+              'auto.components.settings.RuntimeEnvironmentsPane.editServerTitle',
+              'Edit Server'
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            {translate(
+              'auto.components.settings.RuntimeEnvironmentsPane.editServerDescription',
+              'Rename this server, or paste a new pairing code to change its connection address without removing workspaces.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="runtime-server-edit-name">
+              {translate(
+                'auto.components.settings.RuntimeEnvironmentsPane.54ebacc600',
+                'Server name'
+              )}
+            </Label>
+            <Input
+              id="runtime-server-edit-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="h-8 text-xs"
+              autoFocus
+              disabled={saving}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label>
+              {translate(
+                'auto.components.settings.RuntimeEnvironmentsPane.currentEndpoint',
+                'Current connection'
+              )}
+            </Label>
+            <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
+              <div className="flex min-w-0 items-center gap-2">
+                {environment ? (
+                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+                    {transportLabel}
+                  </span>
+                ) : null}
+                <span className="min-w-0 truncate font-mono text-muted-foreground">
+                  {getRuntimeServerEndpointDisplay(endpoint)}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="runtime-server-edit-pairing-code">
+              {translate(
+                'auto.components.settings.RuntimeEnvironmentsPane.newPairingCode',
+                'New pairing code (optional)'
+              )}
+            </Label>
+            <Input
+              id="runtime-server-edit-pairing-code"
+              aria-describedby="runtime-server-edit-pairing-code-help"
+              value={pairingCode}
+              onChange={(event) => setPairingCode(event.target.value)}
+              placeholder={translate(
+                'auto.components.settings.RuntimeEnvironmentsPane.c3d772c514',
+                'orca://pair?code=...'
+              )}
+              className="h-8 min-w-0 font-mono text-xs"
+              disabled={saving}
+            />
+            <p id="runtime-server-edit-pairing-code-help" className="text-xs text-muted-foreground">
+              {translate(
+                'auto.components.settings.RuntimeEnvironmentsPane.editPairingCodeHelp',
+                'Leave blank to keep the current address. To switch LAN ↔ Tailscale, generate a new pairing URL on the server with the desired --pairing-address.'
+              )}
+            </p>
+          </div>
+
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            {translate('auto.components.settings.RuntimeEnvironmentsPane.af53761f31', 'Cancel')}
+          </Button>
+          <Button
+            type="button"
+            disabled={!canSave}
+            onClick={() => {
+              void onSave({
+                name: trimmedName,
+                pairingCode: trimmedPairingCode.length > 0 ? trimmedPairingCode : null
+              })
+            }}
+          >
+            {saving ? <Loader2 className="animate-spin" /> : null}
+            {translate(
+              'auto.components.settings.RuntimeEnvironmentsPane.editServerSave',
+              'Save Changes'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/settings/runtime-server-endpoint-labels.test.ts
+++ b/src/renderer/src/components/settings/runtime-server-endpoint-labels.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { getRuntimeServerListEndpointDisplay } from './runtime-server-endpoint-labels'
+
+describe('getRuntimeServerListEndpointDisplay', () => {
+  it('omits the server-list endpoint row when no endpoint exists', () => {
+    expect(getRuntimeServerListEndpointDisplay(null)).toBeNull()
+  })
+
+  it('returns the endpoint when the server-list row has one', () => {
+    expect(getRuntimeServerListEndpointDisplay('ws://100.64.0.5:6768')).toBe('ws://100.64.0.5:6768')
+  })
+})

--- a/src/renderer/src/components/settings/runtime-server-endpoint-labels.ts
+++ b/src/renderer/src/components/settings/runtime-server-endpoint-labels.ts
@@ -1,0 +1,21 @@
+import type { RuntimeEndpointTransportKind } from '../../../../shared/runtime-environment-endpoint-display'
+import { translate } from '@/i18n/i18n'
+
+export function getRuntimeEndpointTransportLabel(kind: RuntimeEndpointTransportKind): string {
+  return kind === 'tailscale'
+    ? translate(
+        'auto.components.settings.RuntimeEnvironmentsPane.endpointTransportTailscale',
+        'Tailscale'
+      )
+    : translate(
+        'auto.components.settings.RuntimeEnvironmentsPane.endpointTransportDirect',
+        'Direct'
+      )
+}
+
+export function getRuntimeServerEndpointDisplay(endpoint: string | null): string {
+  return (
+    endpoint ??
+    translate('auto.components.settings.RuntimeEnvironmentsPane.6ef71985da', 'No endpoint')
+  )
+}

--- a/src/renderer/src/components/settings/runtime-server-endpoint-labels.ts
+++ b/src/renderer/src/components/settings/runtime-server-endpoint-labels.ts
@@ -19,3 +19,7 @@ export function getRuntimeServerEndpointDisplay(endpoint: string | null): string
     translate('auto.components.settings.RuntimeEnvironmentsPane.6ef71985da', 'No endpoint')
   )
 }
+
+export function getRuntimeServerListEndpointDisplay(endpoint: string | null): string | null {
+  return endpoint ? getRuntimeServerEndpointDisplay(endpoint) : null
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1465,6 +1465,57 @@ function createRuntimeEnvironmentsApi(): NonNullable<Partial<PreloadApi>['runtim
         runtimeStatus
       }
     },
+    rename: async ({ selector, name }) => {
+      const environment = resolveEnvironment(selector)
+      const trimmed = name.trim()
+      if (!trimmed) {
+        throw new Error('Server name is required.')
+      }
+      const next = {
+        ...environment,
+        name: trimmed,
+        updatedAt: Date.now()
+      }
+      if (activeEnvironment?.id === environment.id) {
+        activeEnvironment = next
+        saveStoredWebRuntimeEnvironment(next)
+      }
+      return redactStoredWebRuntimeEnvironment(next)
+    },
+    updateFromPairingCode: async ({ selector, pairingCode }) => {
+      const environment = resolveEnvironment(selector)
+      const offer = parseWebPairingInput(pairingCode)
+      if (!offer) {
+        throw new Error('Invalid Orca pairing code.')
+      }
+      // Why: web clients only keep one active env; re-pair must drop the live
+      // socket so the next call uses the newly stored endpoint/token.
+      if (activeEnvironment?.id === environment.id) {
+        closeActiveRuntimeClients()
+      }
+      const now = Date.now()
+      const endpointId = environment.preferredEndpointId || `ws-${environment.id}`
+      const next = {
+        ...environment,
+        updatedAt: now,
+        preferredEndpointId: endpointId,
+        endpoints: [
+          {
+            id: endpointId,
+            kind: 'websocket' as const,
+            label: environment.endpoints[0]?.label ?? 'WebSocket',
+            endpoint: offer.endpoint,
+            deviceToken: offer.deviceToken,
+            publicKeyB64: offer.publicKeyB64
+          }
+        ]
+      }
+      if (activeEnvironment?.id === environment.id) {
+        activeEnvironment = next
+        saveStoredWebRuntimeEnvironment(next)
+      }
+      return redactStoredWebRuntimeEnvironment(next)
+    },
     resolve: async ({ selector }) =>
       redactStoredWebRuntimeEnvironment(resolveEnvironment(selector)),
     remove: async ({ selector }) => {

--- a/src/shared/runtime-environment-endpoint-display.test.ts
+++ b/src/shared/runtime-environment-endpoint-display.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getPreferredPublicRuntimeEndpoint,
+  getRuntimeEndpointTransportKind
+} from './runtime-environment-endpoint-display'
+import type { PublicKnownRuntimeEnvironment } from './runtime-environments'
+
+function makeEnvironment(
+  overrides?: Partial<PublicKnownRuntimeEnvironment>
+): PublicKnownRuntimeEnvironment {
+  return {
+    id: 'env-1',
+    name: 'desk',
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: null,
+    preferredEndpointId: 'ws-1',
+    endpoints: [
+      {
+        id: 'ws-1',
+        kind: 'websocket',
+        label: 'WebSocket',
+        endpoint: 'ws://192.168.1.10:6768'
+      }
+    ],
+    ...overrides
+  }
+}
+
+describe('getPreferredPublicRuntimeEndpoint', () => {
+  it('prefers preferredEndpointId over the first list entry', () => {
+    const environment = makeEnvironment({
+      preferredEndpointId: 'ws-2',
+      endpoints: [
+        {
+          id: 'ws-1',
+          kind: 'websocket',
+          label: 'LAN',
+          endpoint: 'ws://192.168.1.10:6768'
+        },
+        {
+          id: 'ws-2',
+          kind: 'websocket',
+          label: 'Tailscale',
+          endpoint: 'ws://100.64.0.5:6768'
+        }
+      ]
+    })
+    expect(getPreferredPublicRuntimeEndpoint(environment)).toBe('ws://100.64.0.5:6768')
+  })
+
+  it('falls back to the first endpoint when preferred is missing', () => {
+    const environment = makeEnvironment({ preferredEndpointId: 'missing' })
+    expect(getPreferredPublicRuntimeEndpoint(environment)).toBe('ws://192.168.1.10:6768')
+  })
+})
+
+describe('getRuntimeEndpointTransportKind', () => {
+  it('classifies Tailscale endpoints', () => {
+    expect(getRuntimeEndpointTransportKind('ws://100.64.0.5:6768')).toBe('tailscale')
+    expect(getRuntimeEndpointTransportKind('wss://box.tailnet.ts.net')).toBe('tailscale')
+  })
+
+  it('classifies non-Tailscale endpoints as direct', () => {
+    expect(getRuntimeEndpointTransportKind('ws://192.168.1.10:6768')).toBe('direct')
+    expect(getRuntimeEndpointTransportKind('wss://orca.example.com')).toBe('direct')
+    expect(getRuntimeEndpointTransportKind(null)).toBe('direct')
+  })
+})

--- a/src/shared/runtime-environment-endpoint-display.ts
+++ b/src/shared/runtime-environment-endpoint-display.ts
@@ -1,0 +1,19 @@
+import { isTailscaleEndpoint } from './remote-runtime-tailscale-hint'
+import type { PublicKnownRuntimeEnvironment } from './runtime-environments'
+
+export type RuntimeEndpointTransportKind = 'tailscale' | 'direct'
+
+export function getPreferredPublicRuntimeEndpoint(
+  environment: Pick<PublicKnownRuntimeEnvironment, 'endpoints' | 'preferredEndpointId'>
+): string | null {
+  const preferred =
+    environment.endpoints.find((entry) => entry.id === environment.preferredEndpointId) ??
+    environment.endpoints[0]
+  return preferred?.endpoint?.trim() || null
+}
+
+export function getRuntimeEndpointTransportKind(
+  endpoint: string | null | undefined
+): RuntimeEndpointTransportKind {
+  return isTailscaleEndpoint(endpoint) ? 'tailscale' : 'direct'
+}

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -10,6 +10,7 @@ import {
   listEnvironments,
   MAX_RUNTIME_ENVIRONMENT_STORE_FILE_BYTES,
   markEnvironmentUsed,
+  renameEnvironment,
   updateEnvironmentFromPairingCode
 } from './runtime-environment-store'
 
@@ -177,4 +178,42 @@ describe('runtime environment store', () => {
     ).toThrow(RuntimeEnvironmentStoreError)
     expect(listEnvironments(userDataPath)).toEqual([first])
   })
+
+  it('renames a saved server while keeping its id and endpoint', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    const env = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'dev box',
+      pairingCode: pairingCode('ws://127.0.0.1:6768')
+    })
+
+    const renamed = renameEnvironment(userDataPath, env.id, { name: 'lab box', now: 9_000 })
+    expect(renamed).toMatchObject({
+      id: env.id,
+      name: 'lab box',
+      preferredEndpointId: env.preferredEndpointId
+    })
+    expect(renamed.endpoints).toEqual(env.endpoints)
+    expect(listEnvironments(userDataPath).map((entry) => entry.name)).toEqual(['lab box'])
+  })
+
+  it('rejects rename to an existing server name', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    addEnvironmentFromPairingCode(userDataPath, {
+      name: 'alpha',
+      pairingCode: pairingCode('ws://127.0.0.1:6768')
+    })
+    const beta = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'beta',
+      pairingCode: pairingCode('ws://127.0.0.1:6769')
+    })
+
+    expect(() => renameEnvironment(userDataPath, beta.id, { name: 'Alpha' })).toThrow(
+      /already exists/i
+    )
+  })
+
 })
+
+

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -154,6 +154,45 @@ function getPairingConnectionDependency(
   }
 }
 
+export function renameEnvironment(
+  userDataPath: string,
+  selector: string,
+  args: { name: string; now?: number }
+): KnownRuntimeEnvironment {
+  const name = args.name.trim()
+  if (!name) {
+    throw new RuntimeEnvironmentStoreError('invalid_argument', 'Server name is required.')
+  }
+  const store = readEnvironmentStore(userDataPath)
+  const existing = resolveEnvironmentFromStore(store, selector)
+  if (existing.name === name) {
+    return existing
+  }
+  // Why: names are the human selector in CLI/UI; duplicates make resolve-by-name ambiguous.
+  const duplicate = store.environments.find(
+    (entry) => entry.id !== existing.id && entry.name.toLowerCase() === name.toLowerCase()
+  )
+  if (duplicate) {
+    throw new RuntimeEnvironmentStoreError(
+      'invalid_argument',
+      `A server named "${duplicate.name}" already exists.`
+    )
+  }
+  const now = args.now ?? Date.now()
+  const next: KnownRuntimeEnvironment = {
+    ...existing,
+    name,
+    updatedAt: now
+  }
+  writeEnvironmentStore(userDataPath, {
+    version: 1,
+    environments: store.environments
+      .map((entry) => (entry.id === existing.id ? next : entry))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  })
+  return next
+}
+
 export function resolveEnvironment(
   userDataPath: string,
   selector: string


### PR DESCRIPTION
## Summary
- Show each Remote Orca Server’s preferred connection endpoint in Settings, with a **Tailscale** / **Direct** transport badge so LAN vs tailnet pairing is obvious.
- Add in-place **Edit Server** (rename + optional re-pair via new pairing code), preserving environment id so workspaces stay attached.
- Wire store/IPC/preload/web APIs: `rename` and `updateFromPairingCode`; re-pair drops live sockets so the next connect uses the new endpoint.

## Test plan
- [ ] Open **Settings → Remote Orca Servers** and confirm each row shows transport badge + endpoint URL.
- [ ] Edit a server name only; confirm list label updates and id is unchanged.
- [ ] Edit with a new pairing code (e.g. Tailscale address); confirm endpoint updates without remove/re-add.
- [ ] After re-pair, Connect works against the new endpoint; old socket is not reused.
- [ ] Reject rename to a duplicate server name.
- [ ] `pnpm exec vitest run src/shared/runtime-environment-store.test.ts src/shared/runtime-environment-endpoint-display.test.ts src/main/ipc/runtime-environments.test.ts`

## ELI5

Settings show each Remote Orca Server's connection endpoint and whether it is Tailscale or Direct. You can rename a server or re-pair with a new code without losing the environment id that keeps workspaces attached.
