### PR TITLE
fix(agents): confirm launch prompts via the agent's own submit receipt (#7466)

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -89,6 +89,37 @@ afterEach(() => {
 })
 
 describe('AgentHookServer listener replay', () => {
+  it('forwards the hook boundary fields to the listener and snapshot', () => {
+    // Why: prompt-delivery receipts key on hookEventName/hasExplicitPrompt —
+    // codex SessionStart also maps to 'working', so the coarse state cannot
+    // prove a prompt was accepted (#7466).
+    const server = new AgentHookServer()
+    const listener = vi.fn()
+    server.setListener(listener)
+    try {
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hookEventName: 'UserPromptSubmit',
+          hasExplicitPrompt: true,
+          payload: { state: 'working', prompt: 'fix the bug', agentType: 'codex' }
+        },
+        'conn-1'
+      )
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ hookEventName: 'UserPromptSubmit', hasExplicitPrompt: true })
+      )
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ hookEventName: 'UserPromptSubmit', hasExplicitPrompt: true })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
   it('applies inferred interrupts through the cached status lifecycle', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -248,6 +248,8 @@ function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentSta
     receivedAt: entry.receivedAt,
     stateStartedAt: entry.stateStartedAt,
     ...(entry.providerSession ? { providerSession: entry.providerSession } : {}),
+    ...(entry.hookEventName ? { hookEventName: entry.hookEventName } : {}),
+    ...(entry.hasExplicitPrompt === true ? { hasExplicitPrompt: true } : {}),
     ...entry.payload
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1017,6 +1017,8 @@ function openMainWindow(): BrowserWindow {
       stateStartedAt,
       launchToken,
       providerSession,
+      hookEventName,
+      hasExplicitPrompt,
       isReplay
     }) => {
       if (mainWindow?.isDestroyed()) {
@@ -1036,7 +1038,12 @@ function openMainWindow(): BrowserWindow {
         receivedAt,
         stateStartedAt,
         ...(providerSession ? { providerSession } : {}),
-        ...(orchestration ? { orchestration } : {})
+        ...(orchestration ? { orchestration } : {}),
+        // Why: prompt-delivery receipts need the exact hook boundary; the
+        // coarse state cannot prove a prompt was accepted (codex SessionStart
+        // is also 'working').
+        ...(hookEventName ? { hookEventName } : {}),
+        ...(hasExplicitPrompt === true ? { hasExplicitPrompt: true } : {})
       })
       recordAgentStateCrashBreadcrumb(payload.agentType ?? 'unknown', payload.state)
       // Why: some native OSC titles miss terminal idle/permission frames.

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.test.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.test.ts
@@ -3,11 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   pasteDraftWhenAgentReady: vi.fn(),
   seedNativeChatLaunchPrompt: vi.fn(),
-  markNativeChatLaunchPromptFailed: vi.fn()
+  markNativeChatLaunchPromptFailed: vi.fn(),
+  isPromptReceiptEligible: vi.fn(),
+  watchForPromptSubmitReceipt: vi.fn(),
+  receiptCancel: vi.fn()
 }))
 
 vi.mock('@/lib/agent-paste-draft', () => ({
   pasteDraftWhenAgentReady: mocks.pasteDraftWhenAgentReady
+}))
+
+vi.mock('@/lib/agent-prompt-submit-receipt', () => ({
+  isPromptReceiptEligible: mocks.isPromptReceiptEligible,
+  watchForPromptSubmitReceipt: mocks.watchForPromptSubmitReceipt
 }))
 
 vi.mock('@/store', () => ({
@@ -25,6 +33,11 @@ describe('deliverLaunchPromptToAgentTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.pasteDraftWhenAgentReady.mockResolvedValue(true)
+    mocks.isPromptReceiptEligible.mockResolvedValue(false)
+    mocks.watchForPromptSubmitReceipt.mockReturnValue({
+      result: Promise.resolve(true),
+      cancel: mocks.receiptCancel
+    })
   })
 
   it('seeds a native-chat launch prompt for supported submitted content', async () => {
@@ -130,7 +143,7 @@ describe('deliverLaunchPromptToAgentTab', () => {
     expect(mocks.markNativeChatLaunchPromptFailed).not.toHaveBeenCalled()
   })
 
-  it('passes timeout options through to the paste transport', async () => {
+  it('passes timeout options through and stamps readiness-timeout as the reason', async () => {
     const onTimeout = vi.fn()
 
     await deliverLaunchPromptToAgentTab({
@@ -144,7 +157,103 @@ describe('deliverLaunchPromptToAgentTab', () => {
     })
 
     expect(mocks.pasteDraftWhenAgentReady).toHaveBeenCalledWith(
-      expect.objectContaining({ timeoutMs: 123, onTimeout })
+      expect.objectContaining({ timeoutMs: 123, onTimeout: expect.any(Function) })
     )
+    const forwarded = mocks.pasteDraftWhenAgentReady.mock.calls[0][0].onTimeout
+    forwarded()
+    expect(onTimeout).toHaveBeenCalledWith('readiness-timeout')
+  })
+
+  describe('prompt-submit receipt gating', () => {
+    it('confirms delivery only after the hook receipt arrives', async () => {
+      mocks.isPromptReceiptEligible.mockResolvedValue(true)
+
+      await expect(
+        deliverLaunchPromptToAgentTab({
+          tabId: 'tab-1',
+          agent: 'codex',
+          content: 'Fix failing checks',
+          submit: true,
+          forcePaste: true
+        })
+      ).resolves.toBe(true)
+
+      expect(mocks.watchForPromptSubmitReceipt).toHaveBeenCalledWith({
+        tabId: 'tab-1',
+        agent: 'codex',
+        since: expect.any(Number)
+      })
+      expect(mocks.markNativeChatLaunchPromptFailed).not.toHaveBeenCalled()
+    })
+
+    it('fails with receipt-timeout when the paste goes in but no receipt arrives', async () => {
+      mocks.isPromptReceiptEligible.mockResolvedValue(true)
+      mocks.watchForPromptSubmitReceipt.mockReturnValue({
+        result: Promise.resolve(false),
+        cancel: mocks.receiptCancel
+      })
+      const onTimeout = vi.fn()
+
+      await expect(
+        deliverLaunchPromptToAgentTab({
+          tabId: 'tab-1',
+          agent: 'codex',
+          content: 'Fix failing checks',
+          submit: true,
+          forcePaste: true,
+          onTimeout
+        })
+      ).resolves.toBe(false)
+
+      expect(onTimeout).toHaveBeenCalledWith('receipt-timeout')
+      expect(mocks.markNativeChatLaunchPromptFailed).toHaveBeenCalledWith('tab-1')
+    })
+
+    it('cancels the receipt watch when the paste itself fails', async () => {
+      mocks.isPromptReceiptEligible.mockResolvedValue(true)
+      mocks.pasteDraftWhenAgentReady.mockResolvedValue(false)
+
+      await expect(
+        deliverLaunchPromptToAgentTab({
+          tabId: 'tab-1',
+          agent: 'codex',
+          content: 'Fix failing checks',
+          submit: true,
+          forcePaste: true
+        })
+      ).resolves.toBe(false)
+
+      expect(mocks.receiptCancel).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the optimistic verdict for agents without installed managed hooks', async () => {
+      mocks.isPromptReceiptEligible.mockResolvedValue(false)
+
+      await expect(
+        deliverLaunchPromptToAgentTab({
+          tabId: 'tab-1',
+          agent: 'grok',
+          content: 'Fix failing checks',
+          submit: true,
+          forcePaste: true
+        })
+      ).resolves.toBe(true)
+
+      expect(mocks.watchForPromptSubmitReceipt).not.toHaveBeenCalled()
+    })
+
+    it('does not require receipts for unsubmitted drafts', async () => {
+      mocks.isPromptReceiptEligible.mockResolvedValue(true)
+
+      await deliverLaunchPromptToAgentTab({
+        tabId: 'tab-1',
+        agent: 'codex',
+        content: 'Draft notes',
+        submit: false,
+        forcePaste: true
+      })
+
+      expect(mocks.watchForPromptSubmitReceipt).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.test.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.test.ts
@@ -284,5 +284,26 @@ describe('deliverLaunchPromptToAgentTab', () => {
 
       expect(mocks.watchForPromptSubmitReceipt).not.toHaveBeenCalled()
     })
+
+    it('keeps the optimistic verdict for remote launches', async () => {
+      // Why: eligibility reads LOCAL hook evidence, which says nothing about a
+      // remote host whose hooks may silently not fire — strict-gating there
+      // would false-fail delivered prompts. Remote graduates in a follow-up
+      // with host-scoped observed evidence.
+      mocks.isPromptReceiptEligible.mockResolvedValue(true)
+
+      await expect(
+        deliverLaunchPromptToAgentTab({
+          tabId: 'tab-1',
+          agent: 'codex',
+          content: 'Fix failing checks',
+          submit: true,
+          forcePaste: true,
+          remoteLaunch: true
+        })
+      ).resolves.toBe(true)
+
+      expect(mocks.watchForPromptSubmitReceipt).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.test.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.test.ts
@@ -6,7 +6,8 @@ const mocks = vi.hoisted(() => ({
   markNativeChatLaunchPromptFailed: vi.fn(),
   isPromptReceiptEligible: vi.fn(),
   watchForPromptSubmitReceipt: vi.fn(),
-  receiptCancel: vi.fn()
+  receiptCancel: vi.fn(),
+  receiptStartTimer: vi.fn()
 }))
 
 vi.mock('@/lib/agent-paste-draft', () => ({
@@ -36,7 +37,8 @@ describe('deliverLaunchPromptToAgentTab', () => {
     mocks.isPromptReceiptEligible.mockResolvedValue(false)
     mocks.watchForPromptSubmitReceipt.mockReturnValue({
       result: Promise.resolve(true),
-      cancel: mocks.receiptCancel
+      cancel: mocks.receiptCancel,
+      startTimer: mocks.receiptStartTimer
     })
   })
 
@@ -183,6 +185,9 @@ describe('deliverLaunchPromptToAgentTab', () => {
         agent: 'codex',
         since: expect.any(Number)
       })
+      // Why: the receipt window is armed only after the paste lands, so a slow
+      // readiness wait can't consume it before the prompt is submitted (#7466).
+      expect(mocks.receiptStartTimer).toHaveBeenCalledTimes(1)
       expect(mocks.markNativeChatLaunchPromptFailed).not.toHaveBeenCalled()
     })
 
@@ -190,7 +195,8 @@ describe('deliverLaunchPromptToAgentTab', () => {
       mocks.isPromptReceiptEligible.mockResolvedValue(true)
       mocks.watchForPromptSubmitReceipt.mockReturnValue({
         result: Promise.resolve(false),
-        cancel: mocks.receiptCancel
+        cancel: mocks.receiptCancel,
+        startTimer: mocks.receiptStartTimer
       })
       const onTimeout = vi.fn()
 
@@ -224,6 +230,9 @@ describe('deliverLaunchPromptToAgentTab', () => {
       ).resolves.toBe(false)
 
       expect(mocks.receiptCancel).toHaveBeenCalledTimes(1)
+      // Why: a failed paste never submits a prompt, so the receipt window is
+      // released rather than armed.
+      expect(mocks.receiptStartTimer).not.toHaveBeenCalled()
     })
 
     it('keeps the optimistic verdict for agents without installed managed hooks', async () => {

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.test.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.test.ts
@@ -251,6 +251,26 @@ describe('deliverLaunchPromptToAgentTab', () => {
       expect(mocks.watchForPromptSubmitReceipt).not.toHaveBeenCalled()
     })
 
+    it('does not require a receipt for native-prefill delivery (no submitted paste)', async () => {
+      // Why: claude --prefill delivers the prompt at launch without a submit,
+      // so no UserPromptSubmit ever fires — arming a receipt would hang the
+      // full window and false-fail even though delivery succeeded.
+      mocks.isPromptReceiptEligible.mockResolvedValue(true)
+
+      await expect(
+        deliverLaunchPromptToAgentTab({
+          tabId: 'tab-1',
+          agent: 'claude',
+          content: 'Fix failing checks',
+          submit: true,
+          forcePaste: false
+        })
+      ).resolves.toBe(true)
+
+      expect(mocks.watchForPromptSubmitReceipt).not.toHaveBeenCalled()
+      expect(mocks.markNativeChatLaunchPromptFailed).not.toHaveBeenCalled()
+    })
+
     it('does not require receipts for unsubmitted drafts', async () => {
       mocks.isPromptReceiptEligible.mockResolvedValue(true)
 

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.ts
@@ -1,17 +1,27 @@
 import { agentDeliversDraftViaNativePrefill } from '@/lib/agent-native-draft-prefill'
 import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
+import {
+  isPromptReceiptEligible,
+  watchForPromptSubmitReceipt
+} from '@/lib/agent-prompt-submit-receipt'
 import { isNativeChatSupportedAgent } from '@/lib/native-chat-supported-agent'
 import { useAppStore } from '@/store'
 import type { TuiAgent } from '../../../shared/types'
 
-export function deliverLaunchPromptToAgentTab(args: {
+/** Why a reason: launch failures diverge — 'readiness-timeout' means the TUI
+ * never looked ready (nothing was sent), 'receipt-timeout' means the paste
+ * and Enter went in but the agent never acknowledged a submitted prompt
+ * (trust/update/login screen swallowed it — issue #7466). */
+export type LaunchPromptDeliveryFailureReason = 'readiness-timeout' | 'receipt-timeout'
+
+export async function deliverLaunchPromptToAgentTab(args: {
   tabId: string
   agent: TuiAgent
   content: string
   submit: boolean
   forcePaste: boolean
   timeoutMs?: number
-  onTimeout?: () => void
+  onTimeout?: (reason?: LaunchPromptDeliveryFailureReason) => void
 }): Promise<boolean> {
   const { tabId, agent, content, submit, forcePaste, timeoutMs, onTimeout } = args
   const shouldSeed =
@@ -31,18 +41,46 @@ export function deliverLaunchPromptToAgentTab(args: {
   // native delivery, not a failure — don't flag the seeded bubble in that case.
   const deliversViaNativePrefill = agentDeliversDraftViaNativePrefill(agent, forcePaste)
 
-  return pasteDraftWhenAgentReady({
+  // Why: readiness heuristics can pass on screens that swallow the paste
+  // (codex trust/update, claude login), so submitted launch prompts are only
+  // "delivered" once the agent's own managed hook acknowledges a submitted
+  // prompt (UserPromptSubmit). Agents without installed managed hooks keep
+  // the optimistic legacy verdict instead of false-failing.
+  const requireReceipt = submit === true && (await isPromptReceiptEligible(agent))
+  const receiptWatch = requireReceipt
+    ? watchForPromptSubmitReceipt({ tabId, agent, since: Date.now() })
+    : null
+
+  const markSeedFailed = (): void => {
+    if (shouldSeed) {
+      useAppStore.getState().markNativeChatLaunchPromptFailed(tabId)
+    }
+  }
+
+  const pasted = await pasteDraftWhenAgentReady({
     tabId,
     content,
     agent,
     submit,
     forcePaste,
     timeoutMs,
-    onTimeout
-  }).then((delivered) => {
-    if (shouldSeed && !delivered && !deliversViaNativePrefill) {
-      useAppStore.getState().markNativeChatLaunchPromptFailed(tabId)
-    }
-    return delivered || deliversViaNativePrefill
+    onTimeout: onTimeout ? () => onTimeout('readiness-timeout') : undefined
   })
+
+  if (!pasted && !deliversViaNativePrefill) {
+    receiptWatch?.cancel()
+    markSeedFailed()
+    return false
+  }
+
+  if (receiptWatch) {
+    const receipted = await receiptWatch.result
+    if (!receipted) {
+      onTimeout?.('receipt-timeout')
+      markSeedFailed()
+      return false
+    }
+  }
+
+  return true
 }

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.ts
@@ -57,15 +57,23 @@ export async function deliverLaunchPromptToAgentTab(args: {
     }
   }
 
-  const pasted = await pasteDraftWhenAgentReady({
-    tabId,
-    content,
-    agent,
-    submit,
-    forcePaste,
-    timeoutMs,
-    onTimeout: onTimeout ? () => onTimeout('readiness-timeout') : undefined
-  })
+  let pasted: boolean
+  try {
+    pasted = await pasteDraftWhenAgentReady({
+      tabId,
+      content,
+      agent,
+      submit,
+      forcePaste,
+      timeoutMs,
+      onTimeout: onTimeout ? () => onTimeout('readiness-timeout') : undefined
+    })
+  } catch (error) {
+    // Why: the receipt timeout is only armed after a successful paste, so an
+    // unexpected paste throw must still release the watch's IPC subscription.
+    receiptWatch?.cancel()
+    throw error
+  }
 
   if (!pasted && !deliversViaNativePrefill) {
     receiptWatch?.cancel()
@@ -74,6 +82,10 @@ export async function deliverLaunchPromptToAgentTab(args: {
   }
 
   if (receiptWatch) {
+    // Why: arm the receipt window only now that the paste+Enter is in, so the
+    // full timeout covers the post-submit hook round-trip rather than the
+    // preceding readiness wait (which can run many seconds on a cold SSH boot).
+    receiptWatch.startTimer()
     const receipted = await receiptWatch.result
     if (!receipted) {
       onTimeout?.('receipt-timeout')

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.ts
@@ -20,10 +20,16 @@ export async function deliverLaunchPromptToAgentTab(args: {
   content: string
   submit: boolean
   forcePaste: boolean
+  /** Why: receipt eligibility reads LOCAL evidence (local hook install state,
+   * locally-observed statuses), which says nothing about a remote host whose
+   * hooks may silently not fire — strict-gating there would false-fail
+   * delivered prompts. Remote launches keep the optimistic verdict until
+   * host-scoped evidence exists (follow-up). */
+  remoteLaunch?: boolean
   timeoutMs?: number
   onTimeout?: (reason?: LaunchPromptDeliveryFailureReason) => void
 }): Promise<boolean> {
-  const { tabId, agent, content, submit, forcePaste, timeoutMs, onTimeout } = args
+  const { tabId, agent, content, submit, forcePaste, remoteLaunch, timeoutMs, onTimeout } = args
   const shouldSeed =
     submit === true && content.trim().length > 0 && isNativeChatSupportedAgent(agent)
 
@@ -49,7 +55,10 @@ export async function deliverLaunchPromptToAgentTab(args: {
   // delivery has no submitted paste, so it never waits on a receipt (which
   // would never arrive).
   const requireReceipt =
-    submit === true && !deliversViaNativePrefill && (await isPromptReceiptEligible(agent))
+    submit === true &&
+    remoteLaunch !== true &&
+    !deliversViaNativePrefill &&
+    (await isPromptReceiptEligible(agent))
   const receiptWatch = requireReceipt
     ? watchForPromptSubmitReceipt({ tabId, agent, since: Date.now() })
     : null

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.ts
@@ -45,8 +45,11 @@ export async function deliverLaunchPromptToAgentTab(args: {
   // (codex trust/update, claude login), so submitted launch prompts are only
   // "delivered" once the agent's own managed hook acknowledges a submitted
   // prompt (UserPromptSubmit). Agents without installed managed hooks keep
-  // the optimistic legacy verdict instead of false-failing.
-  const requireReceipt = submit === true && (await isPromptReceiptEligible(agent))
+  // the optimistic legacy verdict instead of false-failing. Native-prefill
+  // delivery has no submitted paste, so it never waits on a receipt (which
+  // would never arrive).
+  const requireReceipt =
+    submit === true && !deliversViaNativePrefill && (await isPromptReceiptEligible(agent))
   const receiptWatch = requireReceipt
     ? watchForPromptSubmitReceipt({ tabId, agent, since: Date.now() })
     : null

--- a/src/renderer/src/lib/agent-prompt-submit-receipt.test.ts
+++ b/src/renderer/src/lib/agent-prompt-submit-receipt.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusIpcPayload } from '../../../shared/agent-status-types'
+import { isPromptReceiptEligible, watchForPromptSubmitReceipt } from './agent-prompt-submit-receipt'
+
+const listeners: ((data: AgentStatusIpcPayload) => void)[] = []
+const unsubscribe = vi.fn()
+const onSet = vi.fn((callback: (data: AgentStatusIpcPayload) => void) => {
+  listeners.push(callback)
+  return unsubscribe
+})
+const claudeStatus = vi.fn()
+const codexStatus = vi.fn()
+
+function emit(partial: Partial<AgentStatusIpcPayload>): void {
+  const payload = {
+    paneKey: 'tab-1:leaf-1',
+    tabId: 'tab-1',
+    connectionId: null,
+    receivedAt: Date.now(),
+    stateStartedAt: Date.now(),
+    state: 'working',
+    prompt: 'Fix failing checks',
+    agentType: 'codex',
+    hookEventName: 'UserPromptSubmit',
+    hasExplicitPrompt: true,
+    ...partial
+  } as AgentStatusIpcPayload
+  for (const listener of listeners.slice()) {
+    listener(payload)
+  }
+}
+
+describe('agent-prompt-submit-receipt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    listeners.length = 0
+    unsubscribe.mockClear()
+    onSet.mockClear()
+    claudeStatus.mockReset()
+    codexStatus.mockReset()
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+      api: {
+        agentStatus: { onSet },
+        agentHooks: { claudeStatus, codexStatus }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  describe('watchForPromptSubmitReceipt', () => {
+    it('resolves true on a matching UserPromptSubmit receipt', async () => {
+      const watch = watchForPromptSubmitReceipt({ tabId: 'tab-1', agent: 'codex', since: 1000 })
+      emit({ receivedAt: 2000 })
+      await expect(watch.result).resolves.toBe(true)
+      expect(unsubscribe).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores receipts for other tabs', async () => {
+      const watch = watchForPromptSubmitReceipt({
+        tabId: 'tab-1',
+        agent: 'codex',
+        since: 1000,
+        timeoutMs: 50
+      })
+      emit({ tabId: 'tab-2', receivedAt: 2000 })
+      await vi.advanceTimersByTimeAsync(50)
+      await expect(watch.result).resolves.toBe(false)
+    })
+
+    it('ignores non-submit hook events — codex SessionStart also maps to working', async () => {
+      const watch = watchForPromptSubmitReceipt({
+        tabId: 'tab-1',
+        agent: 'codex',
+        since: 1000,
+        timeoutMs: 50
+      })
+      emit({ hookEventName: 'SessionStart', hasExplicitPrompt: undefined, receivedAt: 2000 })
+      emit({ hookEventName: 'PreToolUse', hasExplicitPrompt: undefined, receivedAt: 2000 })
+      await vi.advanceTimersByTimeAsync(50)
+      await expect(watch.result).resolves.toBe(false)
+    })
+
+    it('ignores submits without an explicit prompt (harness-injected turns)', async () => {
+      const watch = watchForPromptSubmitReceipt({
+        tabId: 'tab-1',
+        agent: 'codex',
+        since: 1000,
+        timeoutMs: 50
+      })
+      emit({ hasExplicitPrompt: undefined, receivedAt: 2000 })
+      await vi.advanceTimersByTimeAsync(50)
+      await expect(watch.result).resolves.toBe(false)
+    })
+
+    it('ignores receipts from before the watch (minus clock slack)', async () => {
+      const watch = watchForPromptSubmitReceipt({
+        tabId: 'tab-1',
+        agent: 'codex',
+        since: 10_000,
+        timeoutMs: 50
+      })
+      emit({ receivedAt: 1000 })
+      await vi.advanceTimersByTimeAsync(50)
+      await expect(watch.result).resolves.toBe(false)
+    })
+
+    it('ignores receipts from a different agent on the same tab', async () => {
+      const watch = watchForPromptSubmitReceipt({
+        tabId: 'tab-1',
+        agent: 'claude',
+        since: 1000,
+        timeoutMs: 50
+      })
+      emit({ agentType: 'codex', receivedAt: 2000 })
+      await vi.advanceTimersByTimeAsync(50)
+      await expect(watch.result).resolves.toBe(false)
+    })
+
+    it('resolves false on timeout and unsubscribes', async () => {
+      const watch = watchForPromptSubmitReceipt({
+        tabId: 'tab-1',
+        agent: 'codex',
+        since: 1000,
+        timeoutMs: 100
+      })
+      await vi.advanceTimersByTimeAsync(100)
+      await expect(watch.result).resolves.toBe(false)
+      expect(unsubscribe).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancel resolves false immediately', async () => {
+      const watch = watchForPromptSubmitReceipt({ tabId: 'tab-1', agent: 'codex', since: 1000 })
+      watch.cancel()
+      await expect(watch.result).resolves.toBe(false)
+      expect(unsubscribe).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('isPromptReceiptEligible', () => {
+    it('requires the managed hook service to be installed', async () => {
+      claudeStatus.mockResolvedValue({ state: 'installed' })
+      await expect(isPromptReceiptEligible('claude')).resolves.toBe(true)
+
+      codexStatus.mockResolvedValue({ state: 'not_installed' })
+      await expect(isPromptReceiptEligible('codex')).resolves.toBe(false)
+
+      codexStatus.mockResolvedValue({ state: 'error' })
+      await expect(isPromptReceiptEligible('codex')).resolves.toBe(false)
+    })
+
+    it('is false for agents outside the verified set and on status failures', async () => {
+      await expect(isPromptReceiptEligible('grok')).resolves.toBe(false)
+      await expect(isPromptReceiptEligible(undefined)).resolves.toBe(false)
+      claudeStatus.mockRejectedValue(new Error('ipc down'))
+      await expect(isPromptReceiptEligible('claude')).resolves.toBe(false)
+    })
+  })
+})

--- a/src/renderer/src/lib/agent-prompt-submit-receipt.test.ts
+++ b/src/renderer/src/lib/agent-prompt-submit-receipt.test.ts
@@ -11,6 +11,14 @@ const onSet = vi.fn((callback: (data: AgentStatusIpcPayload) => void) => {
 const claudeStatus = vi.fn()
 const codexStatus = vi.fn()
 
+const storeState = vi.hoisted(() => ({
+  agentStatusByPaneKey: {} as Record<string, { agentType?: string }>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => storeState }
+}))
+
 function emit(partial: Partial<AgentStatusIpcPayload>): void {
   const payload = {
     paneKey: 'tab-1:leaf-1',
@@ -143,6 +151,13 @@ describe('agent-prompt-submit-receipt', () => {
   })
 
   describe('isPromptReceiptEligible', () => {
+    beforeEach(() => {
+      storeState.agentStatusByPaneKey = {
+        'tab-9:leaf-1': { agentType: 'claude' },
+        'tab-8:leaf-1': { agentType: 'codex' }
+      }
+    })
+
     it('requires the managed hook service to be installed', async () => {
       claudeStatus.mockResolvedValue({ state: 'installed' })
       await expect(isPromptReceiptEligible('claude')).resolves.toBe(true)
@@ -151,6 +166,18 @@ describe('agent-prompt-submit-receipt', () => {
       await expect(isPromptReceiptEligible('codex')).resolves.toBe(false)
 
       codexStatus.mockResolvedValue({ state: 'error' })
+      await expect(isPromptReceiptEligible('codex')).resolves.toBe(false)
+    })
+
+    it('requires an observed hook status from the agent this session', async () => {
+      // Why: codex silently drops untrusted hooks.json configs while the
+      // install check still passes — without observed evidence the strict
+      // verdict would false-fail every launch for affected users.
+      claudeStatus.mockResolvedValue({ state: 'installed' })
+      codexStatus.mockResolvedValue({ state: 'installed' })
+      storeState.agentStatusByPaneKey = { 'tab-9:leaf-1': { agentType: 'claude' } }
+
+      await expect(isPromptReceiptEligible('claude')).resolves.toBe(true)
       await expect(isPromptReceiptEligible('codex')).resolves.toBe(false)
     })
 

--- a/src/renderer/src/lib/agent-prompt-submit-receipt.test.ts
+++ b/src/renderer/src/lib/agent-prompt-submit-receipt.test.ts
@@ -76,20 +76,25 @@ describe('agent-prompt-submit-receipt', () => {
         since: 1000,
         timeoutMs: 50
       })
+      watch.startTimer()
       emit({ tabId: 'tab-2', receivedAt: 2000 })
       await vi.advanceTimersByTimeAsync(50)
       await expect(watch.result).resolves.toBe(false)
     })
 
-    it('ignores non-submit hook events — codex SessionStart also maps to working', async () => {
+    it('ignores non-submit hook events even when they carry an explicit prompt', async () => {
       const watch = watchForPromptSubmitReceipt({
         tabId: 'tab-1',
         agent: 'codex',
         since: 1000,
         timeoutMs: 50
       })
-      emit({ hookEventName: 'SessionStart', hasExplicitPrompt: undefined, receivedAt: 2000 })
-      emit({ hookEventName: 'PreToolUse', hasExplicitPrompt: undefined, receivedAt: 2000 })
+      watch.startTimer()
+      // Why: the codex normalizer can stamp hasExplicitPrompt on a SessionStart
+      // that carries a prompt (it maps to working too), so the hookEventName
+      // guard — not hasExplicitPrompt alone — is what rejects the boot event.
+      emit({ hookEventName: 'SessionStart', hasExplicitPrompt: true, receivedAt: 2000 })
+      emit({ hookEventName: 'PreToolUse', hasExplicitPrompt: true, receivedAt: 2000 })
       await vi.advanceTimersByTimeAsync(50)
       await expect(watch.result).resolves.toBe(false)
     })
@@ -101,6 +106,7 @@ describe('agent-prompt-submit-receipt', () => {
         since: 1000,
         timeoutMs: 50
       })
+      watch.startTimer()
       emit({ hasExplicitPrompt: undefined, receivedAt: 2000 })
       await vi.advanceTimersByTimeAsync(50)
       await expect(watch.result).resolves.toBe(false)
@@ -113,6 +119,7 @@ describe('agent-prompt-submit-receipt', () => {
         since: 10_000,
         timeoutMs: 50
       })
+      watch.startTimer()
       emit({ receivedAt: 1000 })
       await vi.advanceTimersByTimeAsync(50)
       await expect(watch.result).resolves.toBe(false)
@@ -125,6 +132,7 @@ describe('agent-prompt-submit-receipt', () => {
         since: 1000,
         timeoutMs: 50
       })
+      watch.startTimer()
       emit({ agentType: 'codex', receivedAt: 2000 })
       await vi.advanceTimersByTimeAsync(50)
       await expect(watch.result).resolves.toBe(false)
@@ -137,9 +145,29 @@ describe('agent-prompt-submit-receipt', () => {
         since: 1000,
         timeoutMs: 100
       })
+      watch.startTimer()
       await vi.advanceTimersByTimeAsync(100)
       await expect(watch.result).resolves.toBe(false)
       expect(unsubscribe).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not arm the timeout until startTimer is called', async () => {
+      // Why: the window must cover the post-submit hook round-trip, not the
+      // readiness wait that precedes the paste — arming at creation would
+      // expire the window during a slow cold boot (#7466).
+      const watch = watchForPromptSubmitReceipt({
+        tabId: 'tab-1',
+        agent: 'codex',
+        since: 1000,
+        timeoutMs: 50
+      })
+      await vi.advanceTimersByTimeAsync(1000)
+      const pending = Symbol('pending')
+      await expect(Promise.race([watch.result, Promise.resolve(pending)])).resolves.toBe(pending)
+
+      watch.startTimer()
+      await vi.advanceTimersByTimeAsync(50)
+      await expect(watch.result).resolves.toBe(false)
     })
 
     it('cancel resolves false immediately', async () => {

--- a/src/renderer/src/lib/agent-prompt-submit-receipt.ts
+++ b/src/renderer/src/lib/agent-prompt-submit-receipt.ts
@@ -1,0 +1,95 @@
+import type { AgentStatusIpcPayload } from '../../../shared/agent-status-types'
+import type { TuiAgent } from '../../../shared/types'
+
+// Why: hook receipts prove the agent accepted the prompt as a real turn —
+// codex trust/update screens and claude login screens swallow pastes without
+// ever firing UserPromptSubmit, and both agents' Orca-managed hooks emit it
+// on genuine submission (issue #7466). Strict verification applies only to
+// agents whose managed hook service is installed; anything else keeps the
+// optimistic legacy behavior rather than false-failing on absent plumbing.
+const RECEIPT_ELIGIBLE_AGENTS = new Set<TuiAgent>(['claude', 'codex'])
+
+// Why: the receipt normally lands ~1-2s after submit, but a paste buffered
+// during agent cold boot is only submitted once the TUI drains stdin — the
+// window must absorb that boot, and a slow verdict is safe because failure
+// only re-opens the recovery dialog.
+export const PROMPT_RECEIPT_TIMEOUT_MS = 15_000
+
+// Why: receivedAt is stamped by the main process while `since` is renderer
+// time; a small slack absorbs cross-process clock skew without admitting
+// receipts from a previous turn.
+const RECEIPT_CLOCK_SLACK_MS = 2_000
+
+export async function isPromptReceiptEligible(agent: TuiAgent | undefined): Promise<boolean> {
+  if (!agent || !RECEIPT_ELIGIBLE_AGENTS.has(agent)) {
+    return false
+  }
+  try {
+    const status =
+      agent === 'claude'
+        ? await window.api.agentHooks.claudeStatus()
+        : await window.api.agentHooks.codexStatus()
+    return status.state === 'installed'
+  } catch {
+    return false
+  }
+}
+
+export type PromptSubmitReceiptWatch = {
+  /** Resolves true when a UserPromptSubmit receipt for the tab arrives; false on timeout/cancel. */
+  result: Promise<boolean>
+  cancel: () => void
+}
+
+/**
+ * Watch the agent-status IPC stream for a UserPromptSubmit receipt bound to
+ * `tabId`. Start the watch BEFORE submitting so a fast receipt cannot slip
+ * past the subscription. Remote (SSH) launches arrive through the same
+ * channel via the agent-hook relay, so no transport split is needed.
+ */
+export function watchForPromptSubmitReceipt(args: {
+  tabId: string
+  agent: TuiAgent
+  since: number
+  timeoutMs?: number
+}): PromptSubmitReceiptWatch {
+  const { tabId, agent, since, timeoutMs } = args
+  let cancel: () => void = () => {}
+  const result = new Promise<boolean>((resolve) => {
+    let settled = false
+    let unsubscribe: (() => void) | null = null
+    let timer: number | null = null
+
+    const finish = (value: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+      unsubscribe?.()
+      resolve(value)
+    }
+    cancel = () => finish(false)
+
+    unsubscribe = window.api.agentStatus.onSet((data: AgentStatusIpcPayload) => {
+      if (data.tabId !== tabId) {
+        return
+      }
+      if (data.hookEventName !== 'UserPromptSubmit' || data.hasExplicitPrompt !== true) {
+        return
+      }
+      if (data.agentType !== undefined && data.agentType !== agent) {
+        return
+      }
+      if (data.receivedAt < since - RECEIPT_CLOCK_SLACK_MS) {
+        return
+      }
+      finish(true)
+    })
+
+    timer = window.setTimeout(() => finish(false), timeoutMs ?? PROMPT_RECEIPT_TIMEOUT_MS)
+  })
+  return { result, cancel }
+}

--- a/src/renderer/src/lib/agent-prompt-submit-receipt.ts
+++ b/src/renderer/src/lib/agent-prompt-submit-receipt.ts
@@ -1,3 +1,4 @@
+import { useAppStore } from '@/store'
 import type { AgentStatusIpcPayload } from '../../../shared/agent-status-types'
 import type { TuiAgent } from '../../../shared/types'
 
@@ -20,8 +21,27 @@ export const PROMPT_RECEIPT_TIMEOUT_MS = 15_000
 // receipts from a previous turn.
 const RECEIPT_CLOCK_SLACK_MS = 2_000
 
+// Why: "installed" is not proof the channel speaks — codex silently drops
+// hooks.json configs it does not trust while the install check still passes
+// (live-reproduced: fresh managed home → zero hook events → every launch
+// would false-fail). Require at least one observed hook status from the
+// agent this session before trusting its receipts; until then the launch
+// keeps the optimistic legacy verdict, which is today's behavior.
+function hasObservedHookStatusForAgent(agent: TuiAgent): boolean {
+  const statuses = useAppStore.getState().agentStatusByPaneKey ?? {}
+  for (const status of Object.values(statuses)) {
+    if (status?.agentType === agent) {
+      return true
+    }
+  }
+  return false
+}
+
 export async function isPromptReceiptEligible(agent: TuiAgent | undefined): Promise<boolean> {
   if (!agent || !RECEIPT_ELIGIBLE_AGENTS.has(agent)) {
+    return false
+  }
+  if (!hasObservedHookStatusForAgent(agent)) {
     return false
   }
   try {

--- a/src/renderer/src/lib/agent-prompt-submit-receipt.ts
+++ b/src/renderer/src/lib/agent-prompt-submit-receipt.ts
@@ -58,14 +58,23 @@ export async function isPromptReceiptEligible(agent: TuiAgent | undefined): Prom
 export type PromptSubmitReceiptWatch = {
   /** Resolves true when a UserPromptSubmit receipt for the tab arrives; false on timeout/cancel. */
   result: Promise<boolean>
+  /**
+   * Arm the timeout countdown. Call AFTER the paste+Enter is issued so the full
+   * window covers the post-submit hook round-trip, not the readiness wait that
+   * precedes the paste (which can run many seconds on a cold SSH boot) —
+   * otherwise the window expires before the prompt is even submitted (issue
+   * #7466). Idempotent and a no-op once the watch has settled.
+   */
+  startTimer: () => void
   cancel: () => void
 }
 
 /**
  * Watch the agent-status IPC stream for a UserPromptSubmit receipt bound to
- * `tabId`. Start the watch BEFORE submitting so a fast receipt cannot slip
- * past the subscription. Remote (SSH) launches arrive through the same
- * channel via the agent-hook relay, so no transport split is needed.
+ * `tabId`. Subscribe BEFORE submitting so a fast receipt cannot slip past the
+ * subscription, then call `startTimer()` once the paste is in to arm the
+ * timeout. Remote (SSH) launches arrive through the same channel via the
+ * agent-hook relay, so no transport split is needed.
  */
 export function watchForPromptSubmitReceipt(args: {
   tabId: string
@@ -75,6 +84,7 @@ export function watchForPromptSubmitReceipt(args: {
 }): PromptSubmitReceiptWatch {
   const { tabId, agent, since, timeoutMs } = args
   let cancel: () => void = () => {}
+  let startTimer: () => void = () => {}
   const result = new Promise<boolean>((resolve) => {
     let settled = false
     let unsubscribe: (() => void) | null = null
@@ -92,6 +102,12 @@ export function watchForPromptSubmitReceipt(args: {
       resolve(value)
     }
     cancel = () => finish(false)
+    startTimer = () => {
+      if (settled || timer !== null) {
+        return
+      }
+      timer = window.setTimeout(() => finish(false), timeoutMs ?? PROMPT_RECEIPT_TIMEOUT_MS)
+    }
 
     unsubscribe = window.api.agentStatus.onSet((data: AgentStatusIpcPayload) => {
       if (data.tabId !== tabId) {
@@ -108,8 +124,6 @@ export function watchForPromptSubmitReceipt(args: {
       }
       finish(true)
     })
-
-    timer = window.setTimeout(() => finish(false), timeoutMs ?? PROMPT_RECEIPT_TIMEOUT_MS)
   })
-  return { result, cancel }
+  return { result, startTimer, cancel }
 }

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -94,6 +94,14 @@ vi.mock('@/components/tab-bar/reconcile-order', () => ({
   )
 }))
 
+const mockIsPromptReceiptEligible = vi.fn()
+const mockWatchForPromptSubmitReceipt = vi.fn()
+
+vi.mock('@/lib/agent-prompt-submit-receipt', () => ({
+  isPromptReceiptEligible: mockIsPromptReceiptEligible,
+  watchForPromptSubmitReceipt: mockWatchForPromptSubmitReceipt
+}))
+
 vi.mock('@/lib/agent-paste-draft', () => ({
   pasteDraftWhenAgentReady: mockPasteDraftWhenAgentReady
 }))
@@ -150,6 +158,11 @@ describe('launchAgentInNewTab', () => {
     store.terminalLayoutsByTabId = {}
     mockCreateTab.mockReturnValue({ id: 'tab-1' })
     mockPasteDraftWhenAgentReady.mockResolvedValue(true)
+    mockIsPromptReceiptEligible.mockResolvedValue(false)
+    mockWatchForPromptSubmitReceipt.mockReturnValue({
+      result: Promise.resolve(true),
+      cancel: vi.fn()
+    })
   })
 
   it('stamps the launched agent on the new tab for immediate provider icon bootstrap', async () => {
@@ -678,6 +691,36 @@ describe('launchAgentInNewTab', () => {
     })
     expect(mockToastMessage).toHaveBeenCalledWith(
       "Your prompt wasn't sent — paste it once the agent is ready."
+    )
+    expect(mockTrack).toHaveBeenCalledWith(
+      'agent_error',
+      expect.objectContaining({ error_class: 'paste_readiness_timeout' })
+    )
+  })
+
+  it('classifies a missing prompt-submit receipt separately in telemetry', async () => {
+    mockIsPromptReceiptEligible.mockResolvedValue(true)
+    mockWatchForPromptSubmitReceipt.mockReturnValue({
+      result: Promise.resolve(false),
+      cancel: vi.fn()
+    })
+    store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-1' } as never] }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'codex',
+      worktreeId: 'wt-1',
+      prompt: 'large generated prompt',
+      promptDelivery: 'submit-after-ready'
+    })
+
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: false,
+      failureNotified: true
+    })
+    expect(mockTrack).toHaveBeenCalledWith(
+      'agent_error',
+      expect.objectContaining({ error_class: 'prompt_receipt_timeout' })
     )
   })
 

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -161,7 +161,8 @@ describe('launchAgentInNewTab', () => {
     mockIsPromptReceiptEligible.mockResolvedValue(false)
     mockWatchForPromptSubmitReceipt.mockReturnValue({
       result: Promise.resolve(true),
-      cancel: vi.fn()
+      cancel: vi.fn(),
+      startTimer: vi.fn()
     })
   })
 
@@ -702,7 +703,8 @@ describe('launchAgentInNewTab', () => {
     mockIsPromptReceiptEligible.mockResolvedValue(true)
     mockWatchForPromptSubmitReceipt.mockReturnValue({
       result: Promise.resolve(false),
-      cancel: vi.fn()
+      cancel: vi.fn(),
+      startTimer: vi.fn()
     })
     store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-1' } as never] }
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -309,7 +309,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       agent,
       submit: submitPastedPrompt,
       forcePaste: forcePasteAfterLaunch,
-      onTimeout: () => {
+      onTimeout: (reason) => {
         const state = useAppStore.getState()
         const tabsForWorktree = state.tabsByWorktree[worktreeId] ?? []
         const currentTab = tabsForWorktree.find((t) => t.id === tab.id)
@@ -335,7 +335,8 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
         )
         failureNotified = true
         track('agent_error', {
-          error_class: 'paste_readiness_timeout',
+          error_class:
+            reason === 'receipt-timeout' ? 'prompt_receipt_timeout' : 'paste_readiness_timeout',
           agent_kind: tuiAgentToAgentKind(agent)
         })
       }

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -309,6 +309,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       agent,
       submit: submitPastedPrompt,
       forcePaste: forcePasteAfterLaunch,
+      remoteLaunch: isRemote || runtimeEnvironmentId != null,
       onTimeout: (reason) => {
         const state = useAppStore.getState()
         const tabsForWorktree = state.tabsByWorktree[worktreeId] ?? []

--- a/src/renderer/src/lib/launch-work-item-direct-agent.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.test.ts
@@ -1,14 +1,23 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ deliverLaunchPromptToAgentTab: vi.fn() }))
 
 vi.mock('sonner', () => ({ toast: { message: vi.fn() } }))
 vi.mock('@/lib/agent-paste-draft', () => ({ pasteDraftWhenAgentReady: vi.fn() }))
+vi.mock('@/lib/agent-launch-prompt-delivery', () => ({
+  deliverLaunchPromptToAgentTab: mocks.deliverLaunchPromptToAgentTab
+}))
 vi.mock('@/lib/telemetry', () => ({
   track: vi.fn(),
   tuiAgentToAgentKind: (agent: string) => agent
 }))
 vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, value: string) => value }))
 
-import { buildDirectWorkItemStartupOpts } from './launch-work-item-direct-agent'
+import { track } from '@/lib/telemetry'
+import {
+  buildDirectWorkItemStartupOpts,
+  pasteDirectWorkItemDraftWhenAgentReady
+} from './launch-work-item-direct-agent'
 import type { AgentStartupPlan } from './tui-agent-startup'
 
 describe('buildDirectWorkItemStartupOpts', () => {
@@ -34,6 +43,55 @@ describe('buildDirectWorkItemStartupOpts', () => {
           request_kind: 'new'
         }
       }
+    })
+  })
+})
+
+describe('pasteDirectWorkItemDraftWhenAgentReady onTimeout telemetry', () => {
+  const plan: AgentStartupPlan = {
+    agent: 'codex',
+    launchCommand: "codex 'review linked issue'",
+    expectedProcess: 'codex',
+    followupPrompt: null,
+    launchConfig: { agentArgs: '', agentEnv: {} },
+    startupCommandDelivery: 'shell-ready'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  async function runWithTimeoutReason(
+    reason: 'readiness-timeout' | 'receipt-timeout'
+  ): Promise<void> {
+    mocks.deliverLaunchPromptToAgentTab.mockImplementation(
+      async (args: { onTimeout?: (reason?: 'readiness-timeout' | 'receipt-timeout') => void }) => {
+        args.onTimeout?.(reason)
+        return false
+      }
+    )
+    await pasteDirectWorkItemDraftWhenAgentReady({
+      primaryTabId: 'tab-1',
+      startupPlan: plan,
+      content: 'do the thing',
+      submit: true,
+      forcePaste: true
+    })
+  }
+
+  it('classifies a swallowed submit as prompt_receipt_timeout', async () => {
+    await runWithTimeoutReason('receipt-timeout')
+    expect(track).toHaveBeenCalledWith('agent_error', {
+      error_class: 'prompt_receipt_timeout',
+      agent_kind: 'codex'
+    })
+  })
+
+  it('folds other startup timeouts to unknown', async () => {
+    await runWithTimeoutReason('readiness-timeout')
+    expect(track).toHaveBeenCalledWith('agent_error', {
+      error_class: 'unknown',
+      agent_kind: 'codex'
     })
   })
 })

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -142,14 +142,23 @@ export async function pasteDirectWorkItemDraftWhenAgentReady(args: {
   content: string
   submit?: boolean
   forcePaste?: boolean
+  remoteLaunch?: boolean
 }): Promise<void> {
-  const { primaryTabId, startupPlan, content, submit = false, forcePaste = false } = args
+  const {
+    primaryTabId,
+    startupPlan,
+    content,
+    submit = false,
+    forcePaste = false,
+    remoteLaunch
+  } = args
   await deliverLaunchPromptToAgentTab({
     tabId: primaryTabId,
     content,
     agent: startupPlan.agent,
     submit,
     forcePaste,
+    remoteLaunch,
     onTimeout: (reason) => {
       const label = submit ? 'prompt' : 'work item context'
       toast.message(

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -150,7 +150,7 @@ export async function pasteDirectWorkItemDraftWhenAgentReady(args: {
     agent: startupPlan.agent,
     submit,
     forcePaste,
-    onTimeout: () => {
+    onTimeout: (reason) => {
       const label = submit ? 'prompt' : 'work item context'
       toast.message(
         translate(
@@ -159,10 +159,11 @@ export async function pasteDirectWorkItemDraftWhenAgentReady(args: {
           { value0: label }
         )
       )
-      // Why: process-startup timeout has no v1 enum slot; the `unknown` slice
-      // on the dashboard is the trigger to add one.
+      // Why: a swallowed submit is its own class (#7466); other startup
+      // timeouts still fold to `unknown`, whose dashboard slice is the trigger
+      // to add a dedicated enum value.
       track('agent_error', {
-        error_class: 'unknown',
+        error_class: reason === 'receipt-timeout' ? 'prompt_receipt_timeout' : 'unknown',
         agent_kind: tuiAgentToAgentKind(startupPlan.agent)
       })
     }

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AppState } from '@/store'
 import type * as TuiAgentSelectionModule from '../../../shared/tui-agent-selection'
 import type * as TuiAgentStartupModule from '@/lib/tui-agent-startup'
+import type * as LaunchWorkItemDirectAgentModule from '@/lib/launch-work-item-direct-agent'
 
 const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
@@ -56,6 +57,19 @@ vi.mock('@/lib/ensure-hooks-confirmed', () => ({
 vi.mock('@/lib/connection-context', () => ({
   getConnectionId: mocks.getConnectionId
 }))
+
+// Why: wrap the real paste helper in a spy so existing paste assertions keep
+// exercising the real delivery path while we can still inspect the threaded
+// `remoteLaunch` value the direct flow computes.
+vi.mock('@/lib/launch-work-item-direct-agent', async () => {
+  const actual = await vi.importActual<typeof LaunchWorkItemDirectAgentModule>(
+    '@/lib/launch-work-item-direct-agent'
+  )
+  return {
+    ...actual,
+    pasteDirectWorkItemDraftWhenAgentReady: vi.fn(actual.pasteDirectWorkItemDraftWhenAgentReady)
+  }
+})
 
 vi.mock('@/runtime/runtime-hooks-client', () => ({
   checkRuntimeHooks: vi
@@ -115,6 +129,7 @@ vi.mock('../../../shared/tui-agent-selection', async () => {
 })
 
 import { launchWorkItemDirect } from './launch-work-item-direct'
+import { pasteDirectWorkItemDraftWhenAgentReady } from '@/lib/launch-work-item-direct-agent'
 import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
 import { pickTuiAgent } from '../../../shared/tui-agent-selection'
@@ -709,6 +724,84 @@ describe('launchWorkItemDirect', () => {
         agent: 'codex',
         platform: 'linux'
       })
+    )
+  })
+
+  it('threads remoteLaunch=true for a runtime-hosted launch on a local-backed repo', async () => {
+    // Why: a focused runtime environment runs the agent off the local host, so
+    // its prompt-submit hook may never surface a local receipt. The direct flow
+    // must keep those optimistic (like launch-agent-in-new-tab) even though
+    // getConnectionId is null for the local-backed repo (finding F1).
+    mocks.getConnectionId.mockReturnValue(null)
+    mocks.store.settings = {
+      defaultTuiAgent: 'codex',
+      disabledTuiAgents: [],
+      agentCmdOverrides: {},
+      activeRuntimeEnvironmentId: 'runtime-web-1'
+    }
+    vi.mocked(buildAgentStartupPlan).mockReturnValueOnce({
+      agent: 'codex',
+      launchCommand: 'codex',
+      expectedProcess: 'codex',
+      followupPrompt: null,
+      launchConfig: { agentArgs: '', agentEnv: {} }
+    })
+    const { launchWorkItemDirect } = await import('./launch-work-item-direct')
+
+    await expect(
+      launchWorkItemDirect({
+        item: {
+          title: 'Fix failing checks',
+          url: 'https://github.com/acme/repo/pull/1',
+          type: 'issue',
+          number: 1,
+          pasteContent: 'Fix the failing checks.'
+        },
+        repoId: 'repo-1',
+        openModalFallback: mocks.openModalFallback,
+        launchSource: 'task_page',
+        agentOverride: 'codex',
+        promptDelivery: 'submit-after-ready'
+      })
+    ).resolves.toBe(true)
+
+    expect(vi.mocked(pasteDirectWorkItemDraftWhenAgentReady)).toHaveBeenCalledWith(
+      expect.objectContaining({ submit: true, remoteLaunch: true })
+    )
+  })
+
+  it('threads remoteLaunch=false for a purely local launch (receipt gate applies)', async () => {
+    // Why: no SSH connection and no focused runtime — the agent runs locally, so
+    // the receipt gate must stay active and remoteLaunch must be false.
+    mocks.getConnectionId.mockReturnValue(null)
+    vi.mocked(buildAgentStartupPlan).mockReturnValueOnce({
+      agent: 'codex',
+      launchCommand: 'codex',
+      expectedProcess: 'codex',
+      followupPrompt: null,
+      launchConfig: { agentArgs: '', agentEnv: {} }
+    })
+    const { launchWorkItemDirect } = await import('./launch-work-item-direct')
+
+    await expect(
+      launchWorkItemDirect({
+        item: {
+          title: 'Fix failing checks',
+          url: 'https://github.com/acme/repo/pull/1',
+          type: 'issue',
+          number: 1,
+          pasteContent: 'Fix the failing checks.'
+        },
+        repoId: 'repo-1',
+        openModalFallback: mocks.openModalFallback,
+        launchSource: 'task_page',
+        agentOverride: 'codex',
+        promptDelivery: 'submit-after-ready'
+      })
+    ).resolves.toBe(true)
+
+    expect(vi.mocked(pasteDirectWorkItemDraftWhenAgentReady)).toHaveBeenCalledWith(
+      expect.objectContaining({ submit: true, remoteLaunch: false })
     )
   })
 })

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -326,7 +326,8 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     startupPlan,
     content: draftContent,
     submit: promptDelivery === 'submit-after-ready',
-    forcePaste: promptDelivery === 'submit-after-ready'
+    forcePaste: promptDelivery === 'submit-after-ready',
+    remoteLaunch: typeof getConnectionId(worktreeId) === 'string'
   })
   return true
 }

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/launch-work-item-direct-messages'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getConnectionId } from '@/lib/connection-context'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import type { GitPushTarget, SetupDecision, TuiAgent } from '../../../shared/types'
 import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 import { resolveGitHubWorkItemIdentity } from '@/lib/github-work-item-identity'
@@ -327,7 +328,12 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     content: draftContent,
     submit: promptDelivery === 'submit-after-ready',
     forcePaste: promptDelivery === 'submit-after-ready',
-    remoteLaunch: typeof getConnectionId(worktreeId) === 'string'
+    // Why: SSH or a focused runtime environment runs the agent off the local
+    // host, where its prompt-submit hook may not surface a local receipt; keep
+    // those on the optimistic verdict like launch-agent-in-new-tab (F1).
+    remoteLaunch:
+      typeof getConnectionId(worktreeId) === 'string' ||
+      getRuntimeEnvironmentIdForWorktree(useAppStore.getState(), worktreeId) != null
   })
   return true
 }

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -193,6 +193,13 @@ export type AgentStatusIpcPayload = ParsedAgentStatusPayload & {
   stateStartedAt: number
   orchestration?: AgentStatusOrchestrationContext
   providerSession?: AgentProviderSessionMetadata
+  /** Why: prompt-delivery receipts need the precise hook boundary — codex maps
+   *  SessionStart to 'working' too, so the coarse state cannot prove a prompt
+   *  was accepted. Absent for non-hook (title-derived/synthetic) statuses. */
+  hookEventName?: string
+  /** True when the event carries a genuine new user prompt (harness-injected
+   *  turns and cached-prompt tool pings are folded to false/absent). */
+  hasExplicitPrompt?: boolean
 }
 
 /** Maximum character length for the prompt field. Truncated on parse. */

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -117,6 +117,10 @@ export type AgentKind = z.infer<typeof agentKindSchema>
 //   - `paste_readiness_timeout` — bracketed-paste readiness wait timed out.
 //     The agent process spawned but its TUI input box didn't reach a ready
 //     state before the watchdog deadline, so the queued draft was dropped.
+//   - `prompt_receipt_timeout` — the paste and Enter went in after readiness,
+//     but the agent's managed hook never acknowledged a submitted prompt
+//     (UserPromptSubmit), so a trust/update/login screen likely swallowed it
+//     and the launch reported failure instead of a false success.
 //   - `unknown` — every other thrown error (env-build failures,
 //     unclassifiable shell-spawn errors).
 // Provider-side errors (`auth_expired`, `rate_limited`, `network_timeout`,
@@ -124,7 +128,12 @@ export type AgentKind = z.infer<typeof agentKindSchema>
 // to Orca — see telemetry-plan.md §Decision: Defer per-incident error fields.
 // Adding a new value is additive-safe; do it when the call site lands, not in
 // anticipation.
-export const errorClassSchema = z.enum(['binary_not_found', 'paste_readiness_timeout', 'unknown'])
+export const errorClassSchema = z.enum([
+  'binary_not_found',
+  'paste_readiness_timeout',
+  'prompt_receipt_timeout',
+  'unknown'
+])
 export type ErrorClass = z.infer<typeof errorClassSchema>
 
 export const repoMethodSchema = z.enum(['folder_picker', 'clone_url', 'drag_drop'])


### PR DESCRIPTION
## Summary

Finishes #7466 by making the prompt-delivery verdict *true*, using the agents' own submission receipts instead of terminal heuristics.

Stage 1 (#7638, merged) gated launch side effects — resolving PR comments, clearing the queue, closing the dialog — on a delivered verdict. But that verdict still meant "paste bytes were written after a readiness heuristic fired", and codex's trust/update screens (and claude's login screen) pass those heuristics while silently swallowing the paste: the launch reported success, the comments resolved, the prompt was lost, and the blind Enter could even answer the swallowing screen (all live-reproduced, including our Enter confirming codex's self-updater).

**The verdict now comes from the agent itself.** Both claude and codex fire `UserPromptSubmit` through their Orca-managed hooks — pane-bound via the env-stamped keys, SSH-relayed through the existing agent-hook channel. A submitted launch prompt is `delivered` only when that receipt arrives for the tab (15s window, armed after the paste so cold boots don't eat it). No receipt → the stage-1 recovery: dialog retained with the prompt, comments untouched, `prompt_receipt_timeout` telemetry.

The only wire change is forwarding two already-computed fields (`hookEventName`, `hasExplicitPrompt`) onto the `agentStatus:set` IPC — they were being dropped at the send site. The precise event name is load-bearing: codex `SessionStart` also normalizes to `working`, so coarse state-watching would false-positive on boot.

A previous approach that screen-scraped the terminal for the pasted text echoing back (#7851) was rejected as too coupled to per-TUI rendering and replaced by this design.

Closes #7466.

## Eligibility: strict only where the channel is proven

The strict verdict applies only when **all** of these hold; everything else keeps today's optimistic behavior (never false-fails on absent plumbing):

- Agent is claude or codex (the agents with managed `UserPromptSubmit` hooks, and the ones in the bug report).
- The managed hook service reports installed **and at least one hook status from that agent has been observed this session** — because codex silently drops `hooks.json` configs it doesn't trust while the install probe still passes (live-reproduced: fresh managed home, zero events; strict gating there would false-fail every launch).
- The launch targets the **local host**. Eligibility evidence is local, so SSH and runtime-hosted launches stay optimistic until a follow-up adds host-scoped observed evidence.
- Delivery is a submitted paste (native-prefill launches and unsubmitted drafts are never receipt-gated).

## Live validation (Electron dev build, real agents)

- **Real codex trust screen (the swallow case):** launch into an untrusted dir → readiness passes on the trust screen, paste swallowed → no receipt → failure at ~16s with the dialog retained, prompt intact, no success toast, conflict untouched.
- **Real claude:** receipt-verified success ~7s end-to-end — proving the full new pipeline including the IPC field forwarding (without it the watch would have timed out).
- Re-validated after the eligibility amendment. Not live-validated (unit-tested only): the codex optimistic-fallback cell, which is behavior identical to production today.

## Review hardening (adversarial loop, all fixes revert-proofed)

- Receipt window armed **after** the paste via a lazy timer — arming at watch creation could expire during a slow SSH cold boot and false-fail a delivered prompt.
- Native-prefill launches never arm a receipt (no submit ever fires one).
- Runtime-hosted direct launches treated as remote in both callers (a focused runtime environment can host a launch on a local repo).
- Second caller's telemetry maps `receipt-timeout` correctly instead of folding to `unknown`.
- Guard tests strengthened: codex's normalizer can stamp `hasExplicitPrompt` on a `SessionStart`, so the `hookEventName` check is what rejects boot events — now pinned by a test that fails if the guard is removed.

## Follow-ups (deliberately out of scope)

- **Host-scoped eligibility:** thread the launch host into the observed-evidence gate so SSH/runtime launches can graduate to strict verification.
- **Codex hook-trust preflight:** seed codex's hook trust the way worktree trust is preflighted, so codex graduates immediately instead of after first observed evidence.
- **Automations path:** the background-session launch path keeps its existing behavior until the receipt verdict has soak time (agreed earlier).

## Testing

- [x] `pnpm typecheck` (all three projects)
- [x] `pnpm exec oxlint`, oxfmt, `pnpm check:max-lines-ratchet`
- [x] 330 tests across the 8 affected suites, including the receipt watcher truth table, delivery gating (receipt success / receipt timeout / paste failure cancels the watch / native-prefill and draft and remote exemptions), hook-boundary field forwarding through the server snapshot and IPC, telemetry classification, and the timer-arming regression.

## Security Audit

No new subprocesses, filesystem writes, credentials, or IPC channels. Forwards two existing enum-ish fields on an existing IPC event; adds one bounded (≤15s, per-launch) renderer subscription to that same event. Withholding success on missing receipts strictly reduces destructive side effects.

Made with [Orca](https://github.com/stablyai/orca) 🐋
