### PR TITLE
fix(codex): prevent duplicate [projects] tables from breaking config.toml load

### DIFF
--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -313,6 +313,196 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     expect(runtimeConfig.match(/\[projects\."\/repo"\]/g)?.length).toBe(1)
   })
 
+  it('collapses a literal system header against a basic runtime header for one path', () => {
+    // Why: Codex CLI writes Windows trust as a literal header while Orca writes a
+    // basic one. Same decoded key → merging both verbatim yields a duplicate TOML
+    // key and Codex refuses to load config.toml.
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      ['[projects."d:\\\\tools\\\\repo"]', 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      ['model = "system"', '', "[projects.'d:\\tools\\repo']", 'trust_level = "trusted"', ''].join(
+        '\n'
+      ),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/^\s*\[projects\./gm)).toHaveLength(1)
+    expect(runtimeConfig).toContain('[projects."d:\\\\tools\\\\repo"]')
+    expect(runtimeConfig).toContain('model = "system"')
+  })
+
+  it('lets a system literal untrusted revocation override a runtime basic trust', () => {
+    // Why: an explicit revoke in ~/.codex must win even across quote-style drift.
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      ['[projects."d:\\\\tools\\\\repo"]', 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      ["[projects.'d:\\tools\\repo']", 'trust_level = "untrusted"', ''].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/^\s*\[projects\./gm)).toHaveLength(1)
+    expect(runtimeConfig).toContain('trust_level = "untrusted"')
+    expect(runtimeConfig).not.toContain('trust_level = "trusted"')
+  })
+
+  it('collapses intra-runtime basic + literal duplicates for one path', () => {
+    // Why: when both quote styles already exist in the runtime config they would
+    // otherwise be re-emitted verbatim and re-create the crash on every merge.
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [
+        '[projects."d:\\\\tools\\\\repo"]',
+        'trust_level = "trusted"',
+        '',
+        "[projects.'d:\\tools\\repo']",
+        'trust_level = "trusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(getSystemConfigPath(), ['model = "system"', ''].join('\n'), 'utf-8')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/^\s*\[projects\./gm)).toHaveLength(1)
+  })
+
+  it('dedupes a Windows project path that differs only by drive-letter case', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      ['[projects."D:\\\\Repo"]', 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      ['[projects."d:\\\\repo"]', 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/^\s*\[projects\./gm)).toHaveLength(1)
+  })
+
+  it('keeps POSIX project paths that differ only by case as two projects', () => {
+    // Why: /mnt/e/A and /mnt/e/a are distinct on case-sensitive filesystems.
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [
+        '[projects."/mnt/e/A"]',
+        'trust_level = "trusted"',
+        '',
+        '[projects."/mnt/e/a"]',
+        'trust_level = "trusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(getSystemConfigPath(), ['model = "system"', ''].join('\n'), 'utf-8')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/^\s*\[projects\./gm)).toHaveLength(2)
+    expect(runtimeConfig).toContain('[projects."/mnt/e/A"]')
+    expect(runtimeConfig).toContain('[projects."/mnt/e/a"]')
+  })
+
+  it('collapses a system-side basic + literal duplicate during merge', () => {
+    // Why: the system config can itself carry both quote styles for one path.
+    // With no matching runtime section they would both be mirrored verbatim,
+    // seeding the managed config with a duplicate TOML key Codex cannot load.
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(getRuntimeConfigPath(), ['model = "runtime"', ''].join('\n'), 'utf-8')
+    writeFileSync(
+      getSystemConfigPath(),
+      [
+        'model = "system"',
+        '',
+        '[projects."d:\\\\tools\\\\repo"]',
+        'trust_level = "trusted"',
+        '',
+        "[projects.'d:\\tools\\repo']",
+        'trust_level = "trusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/^\s*\[projects\./gm)).toHaveLength(1)
+  })
+
+  it('collapses a system-side duplicate when seeding a fresh runtime config', () => {
+    // Why: the fresh-mirror path (no runtime config yet) must also dedupe.
+    writeFileSync(
+      getSystemConfigPath(),
+      [
+        '[projects."d:\\\\tools\\\\repo"]',
+        'trust_level = "trusted"',
+        '',
+        "[projects.'d:\\tools\\repo']",
+        'trust_level = "trusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/^\s*\[projects\./gm)).toHaveLength(1)
+  })
+
+  it('preserves distinct hooks.state slash variants for one path (no project dedup leak)', () => {
+    // Why: hook trust intentionally writes both backslash and forward-slash key
+    // variants; they are genuinely distinct TOML keys and must never be deduped.
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [
+        "[hooks.state.'d:\\repo\\.orca\\hooks.json:stop:0:0']",
+        'enabled = true',
+        'trusted_hash = "sha256:a"',
+        '',
+        "[hooks.state.'d:/repo/.orca/hooks.json:stop:0:0']",
+        'enabled = true',
+        'trusted_hash = "sha256:a"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(getSystemConfigPath(), ['model = "system"', ''].join('\n'), 'utf-8')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/^\s*\[hooks\.state\./gm)).toHaveLength(2)
+  })
+
   it('does not treat TOML table headers inside multiline strings as sections', () => {
     mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
     writeFileSync(

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -9,6 +9,7 @@ import {
   isTomlStructuralLine,
   updateTomlLineScanState
 } from './config-toml-line-scan'
+import { getProjectTrustComparisonKey } from './codex-project-trust-key'
 
 function getRuntimeCodexConfigTomlPath(): string {
   return join(getOrcaManagedCodexHomePath(), 'config.toml')
@@ -156,17 +157,52 @@ function mergeSystemCodexConfigIntoRuntime(runtimeConfig: string, systemConfig: 
   // trust and project trust are written under Orca's managed CODEX_HOME and
   // must survive the copy unless the user explicitly revoked project trust in
   // the system config.
-  return joinTomlBlocks([
-    stripRuntimeOwnedTomlSections(systemConfig, runtimeProjectHeaders),
-    ...runtimeSections
+  const preservedRuntimeSections = dedupeRuntimeProjectSections(
+    runtimeSections
       .filter((section) => isRuntimePreservedTomlSection(section.header))
       .filter(
         (section) =>
           !isRuntimeProjectTomlSection(section.header) ||
           !systemUntrustedProjectHeaders.has(getTomlSectionHeaderKey(section.header))
       )
-      .map((section) => section.block)
+  )
+  return joinTomlBlocks([
+    stripRuntimeOwnedTomlSections(systemConfig, runtimeProjectHeaders),
+    ...preservedRuntimeSections.map((section) => section.block)
   ])
+}
+
+// Why: the runtime config can hold two [projects....] tables that decode to one
+// key (a basic and a literal copy of the same path). Re-emitting both verbatim
+// produces a duplicate TOML key and Codex refuses to load the file, so collapse
+// them by decoded key. A later `untrusted` revocation wins so an explicit revoke
+// is never lost. hooks.state sections pass through untouched — their slash
+// variants are intentionally distinct TOML keys.
+function dedupeRuntimeProjectSections(sections: TomlSection[]): TomlSection[] {
+  const indexByKey = new Map<string, number>()
+  const result: TomlSection[] = []
+  for (const section of sections) {
+    if (!isRuntimeProjectTomlSection(section.header)) {
+      result.push(section)
+      continue
+    }
+    const key = getTomlSectionHeaderKey(section.header)
+    const existingIndex = indexByKey.get(key)
+    if (existingIndex === undefined) {
+      indexByKey.set(key, result.length)
+      result.push(section)
+      continue
+    }
+    const existing = result[existingIndex]
+    if (
+      existing !== undefined &&
+      getProjectTrustLevel(section.block) === 'untrusted' &&
+      getProjectTrustLevel(existing.block) !== 'untrusted'
+    ) {
+      result[existingIndex] = section
+    }
+  }
+  return result
 }
 
 type TomlSection = {
@@ -183,17 +219,20 @@ function stripRuntimeOwnedTomlSections(
   const sections = getTomlSections(config)
   const firstSectionIndex = sections[0]?.start ?? -1
   const preamble = firstSectionIndex === -1 ? config : lines.slice(0, firstSectionIndex).join('\n')
+  const kept = sections
+    .filter((section) => !isRuntimeHookTrustTomlSection(section.header))
+    .filter(
+      (section) =>
+        !isRuntimeProjectTomlSection(section.header) ||
+        !runtimeProjectHeaders.has(getTomlSectionHeaderKey(section.header)) ||
+        getProjectTrustLevel(section.block) === 'untrusted'
+    )
+  // Why: a system config can itself carry decoded-duplicate project tables (basic
+  // + literal for one path). Collapse them here so neither a fresh mirror nor a
+  // merge emits a duplicate TOML key into the managed config.
   return joinTomlBlocks([
     preamble,
-    ...sections
-      .filter((section) => !isRuntimeHookTrustTomlSection(section.header))
-      .filter(
-        (section) =>
-          !isRuntimeProjectTomlSection(section.header) ||
-          !runtimeProjectHeaders.has(getTomlSectionHeaderKey(section.header)) ||
-          getProjectTrustLevel(section.block) === 'untrusted'
-      )
-      .map((section) => section.block)
+    ...dedupeRuntimeProjectSections(kept).map((section) => section.block)
   ])
 }
 
@@ -246,7 +285,10 @@ function isRuntimeProjectTomlSection(header: string): boolean {
 }
 
 function getTomlSectionHeaderKey(header: string): string {
-  return header.trim()
+  // Why: project headers dedup by DECODED key so basic-vs-literal quote style,
+  // slash direction, and drive-letter case drift resolve to one section. Other
+  // headers (hooks.state) keep raw text — their slash variants are intentional.
+  return getProjectTrustComparisonKey(header) ?? header.trim()
 }
 
 function getProjectTrustLevel(block: string): 'trusted' | 'untrusted' | null {

--- a/src/main/codex/codex-project-trust-key.test.ts
+++ b/src/main/codex/codex-project-trust-key.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodeProjectTableHeaderPath,
+  getProjectTrustComparisonKey,
+  normalizeProjectTrustKey
+} from './codex-project-trust-key'
+
+describe('decodeProjectTableHeaderPath', () => {
+  it('decodes a basic (double-quote) header, unescaping backslashes', () => {
+    expect(decodeProjectTableHeaderPath('[projects."d:\\\\tools\\\\repo"]')).toBe('d:\\tools\\repo')
+  })
+
+  it('decodes a literal (single-quote) header verbatim', () => {
+    expect(decodeProjectTableHeaderPath("[projects.'d:\\tools\\repo']")).toBe('d:\\tools\\repo')
+  })
+
+  it('tolerates inline whitespace and a trailing comment', () => {
+    expect(decodeProjectTableHeaderPath('[ projects . "/repo" ]  # note')).toBe('/repo')
+  })
+
+  it('returns null for non-project headers', () => {
+    expect(decodeProjectTableHeaderPath('[hooks.state."k"]')).toBeNull()
+    expect(decodeProjectTableHeaderPath('model = "x"')).toBeNull()
+  })
+})
+
+describe('normalizeProjectTrustKey', () => {
+  it('folds Windows separator and drive-letter case', () => {
+    expect(normalizeProjectTrustKey('C:/Users/NW/Repo')).toBe('c:\\users\\nw\\repo')
+    expect(normalizeProjectTrustKey('C:\\Users\\NW\\Repo')).toBe('c:\\users\\nw\\repo')
+  })
+
+  it('leaves POSIX paths case-sensitive', () => {
+    expect(normalizeProjectTrustKey('/mnt/e/A')).toBe('/mnt/e/A')
+  })
+})
+
+describe('getProjectTrustComparisonKey', () => {
+  it('makes basic and literal Windows headers compare equal', () => {
+    expect(getProjectTrustComparisonKey('[projects."d:\\\\tools\\\\repo"]')).toBe(
+      getProjectTrustComparisonKey("[projects.'d:\\tools\\repo']")
+    )
+  })
+})

--- a/src/main/codex/codex-project-trust-key.ts
+++ b/src/main/codex/codex-project-trust-key.ts
@@ -1,0 +1,125 @@
+// Why: Codex CLI writes Windows project-trust headers as TOML *literal* strings
+// (single quotes, raw backslashes) while Orca writes *basic* strings (double
+// quotes, escaped backslashes). Both decode to the same logical project path, so
+// any "find or dedup an existing [projects....] section" must compare keys by
+// their DECODED + normalized value. Comparing raw header text leaves two tables
+// that decode to one TOML key, which makes Codex reject config.toml with a
+// "duplicate key" load error.
+
+function usesWindowsPathSeparators(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith('\\\\')
+}
+
+// Why: content-based (not process.platform) — a WSL/SSH runtime home mirrored on
+// a Windows host can hold POSIX project paths, which stay case-sensitive. Windows
+// paths are separator- and case-insensitive, so fold both to one stable key.
+export function normalizeProjectTrustKey(projectPath: string): string {
+  return usesWindowsPathSeparators(projectPath)
+    ? projectPath.replaceAll('/', '\\').toLowerCase()
+    : projectPath
+}
+
+// Decode the quoted path inside a single `[projects.<quoted>]` table header,
+// honoring both TOML basic (") and literal (') strings. Returns null when the
+// line is not a single quoted project table header.
+export function decodeProjectTableHeaderPath(header: string): string | null {
+  const trimmed = header.trim()
+  const prefix = /^\[[ \t]*projects[ \t]*\.[ \t]*/.exec(trimmed)
+  if (!prefix) {
+    return null
+  }
+  const parsed = parseSingleLineTomlString(trimmed, prefix[0].length)
+  if (!parsed) {
+    return null
+  }
+  let index = skipInlineWhitespace(trimmed, parsed.endIndex)
+  if (trimmed[index] !== ']') {
+    return null
+  }
+  index = skipInlineWhitespace(trimmed, index + 1)
+  return index === trimmed.length || trimmed[index] === '#' ? parsed.value : null
+}
+
+// Decode + normalize in one step; null when `header` is not a project header.
+export function getProjectTrustComparisonKey(header: string): string | null {
+  const path = decodeProjectTableHeaderPath(header)
+  return path === null ? null : normalizeProjectTrustKey(path)
+}
+
+type ParsedTomlString = {
+  value: string
+  endIndex: number
+}
+
+function parseSingleLineTomlString(line: string, startIndex: number): ParsedTomlString | null {
+  if (line[startIndex] === '"') {
+    return parseBasicString(line, startIndex + 1)
+  }
+  if (line[startIndex] === "'") {
+    return parseLiteralString(line, startIndex + 1)
+  }
+  return null
+}
+
+function parseBasicString(line: string, startIndex: number): ParsedTomlString | null {
+  let value = ''
+  let index = startIndex
+  while (index < line.length) {
+    const char = line[index]
+    if (char === '"') {
+      return { value, endIndex: index + 1 }
+    }
+    if (char === '\\' && index + 1 < line.length) {
+      value += unescapeBasicStringEscape(line[index + 1])
+      index += 2
+      continue
+    }
+    value += char
+    index += 1
+  }
+  return null
+}
+
+// Why: literal strings take everything verbatim to the next single quote — TOML
+// forbids escapes inside them, so raw backslashes stay raw.
+function parseLiteralString(line: string, startIndex: number): ParsedTomlString | null {
+  const endIndex = line.indexOf("'", startIndex)
+  return endIndex === -1
+    ? null
+    : { value: line.slice(startIndex, endIndex), endIndex: endIndex + 1 }
+}
+
+function unescapeBasicStringEscape(next: string): string {
+  if (next === 'n') {
+    return '\n'
+  }
+  if (next === 'r') {
+    return '\r'
+  }
+  if (next === 't') {
+    return '\t'
+  }
+  if (next === 'b') {
+    return '\b'
+  }
+  if (next === 'f') {
+    return '\f'
+  }
+  if (next === '"') {
+    return '"'
+  }
+  if (next === '\\') {
+    return '\\'
+  }
+  // Why: unknown escapes round-trip — keep the backslash so a hand-edited config
+  // never silently loses information.
+  return `\\${next}`
+}
+
+function skipInlineWhitespace(line: string, startIndex: number): number {
+  let index = startIndex
+  while (line[index] === ' ' || line[index] === '\t') {
+    index += 1
+  }
+  return index
+}

--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -1130,6 +1130,80 @@ describe('upsertProjectTrustLevel', () => {
     expect(readFileSync(configPath, 'utf-8')).toBe(firstWrite)
     expect(existsSync(`${configPath}.bak`)).toBe(false)
   })
+
+  it('updates a Codex-written literal Windows project header in place', () => {
+    // Why: Codex CLI writes Windows project trust as a TOML literal string
+    // (single quotes, raw backslashes). Orca must update it in place rather than
+    // append a second basic table — two tables that decode to one key crash
+    // Codex with "duplicate key".
+    const original = [
+      "[projects.'C:\\Users\\nw\\repo']",
+      'trust_level = "untrusted"',
+      ''
+    ].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, 'C:\\Users\\nw\\repo', 'trusted', {
+      alreadyCanonical: true
+    })
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(1)
+    expect(updated).toContain("[projects.'C:\\Users\\nw\\repo']")
+    expect(updated).toContain('trust_level = "trusted"')
+    expect(updated).not.toContain('trust_level = "untrusted"')
+  })
+
+  it('matches a literal header across slash and drive-letter case drift', () => {
+    // Why: Codex may write the cwd with forward slashes and/or a lowercased
+    // drive letter; that must still resolve to the one existing table.
+    const original = ["[projects.'c:/Users/nw/repo']", 'notes = "keep"', ''].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, 'C:\\Users\\nw\\repo', 'trusted', {
+      alreadyCanonical: true
+    })
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(1)
+    expect(updated).toContain("[projects.'c:/Users/nw/repo']")
+    expect(updated).toContain('notes = "keep"')
+    expect(updated).toContain('trust_level = "trusted"')
+  })
+
+  it('keeps POSIX project paths case-sensitive (no false literal match)', () => {
+    // Why: /mnt/e/A and /mnt/e/a are distinct on case-sensitive filesystems, so
+    // an existing literal header for one path must not swallow the other.
+    const original = ["[projects.'/mnt/e/A']", 'trust_level = "trusted"', ''].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, '/mnt/e/a', 'trusted', {
+      alreadyCanonical: true
+    })
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(2)
+    expect(updated).toContain("[projects.'/mnt/e/A']")
+    expect(updated).toContain('[projects."/mnt/e/a"]')
+  })
+
+  it('collapses a pre-existing basic + literal duplicate for one path', () => {
+    // Why: an earlier run may have left both quote styles for the same path. The
+    // repair must remove the duplicate, not just update one table, or Codex still
+    // rejects config.toml with "duplicate key".
+    const original = [
+      '[projects."C:\\\\Users\\\\nw\\\\repo"]',
+      'trust_level = "untrusted"',
+      '',
+      "[projects.'C:\\Users\\nw\\repo']",
+      'trust_level = "untrusted"',
+      ''
+    ].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, 'C:\\Users\\nw\\repo', 'trusted', {
+      alreadyCanonical: true
+    })
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(1)
+    expect(updated).toContain('[projects."C:\\\\Users\\\\nw\\\\repo"]')
+    expect(updated).not.toContain("[projects.'")
+    expect(updated).toContain('trust_level = "trusted"')
+    expect(updated).not.toContain('untrusted')
+  })
 })
 
 describe('removeHookTrustEntries', () => {

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -9,13 +9,13 @@ import {
 } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
-import { escapeRegex } from '../../shared/string-utils'
 import { copyFileWithWindowsRetry, renameFileWithWindowsRetry } from '../codex-accounts/fs-utils'
 import {
   createTomlLineScanState,
   isTomlStructuralLine,
   updateTomlLineScanState
 } from './config-toml-line-scan'
+import { getProjectTrustComparisonKey, normalizeProjectTrustKey } from './codex-project-trust-key'
 
 // Why: Codex 0.129+ gates each hook on a `trusted_hash` entry in
 // ~/.codex/config.toml under [hooks.state."<key>"]. Without it the hook is in
@@ -346,12 +346,17 @@ export function upsertProjectTrustLevelInContent(
   const trustedProjectPath = options?.alreadyCanonical
     ? projectPath
     : getCodexCanonicalProjectPath(projectPath)
-  const headerPattern = buildProjectHeaderPattern(trustedProjectPath)
-  const match = headerPattern.exec(existing)
+  // Why: match existing [projects....] sections by their DECODED key so a
+  // Codex-written literal header (single quotes, raw backslashes) is updated in
+  // place instead of shadowed by a second basic header. When an earlier run
+  // already left both quote styles for one path, collapse every duplicate to a
+  // single table — two tables that decode to one key make Codex reject
+  // config.toml with a "duplicate key" error.
+  const ranges = findProjectTrustSectionRanges(existing, trustedProjectPath)
   const eol = existing.includes('\r\n') ? '\r\n' : '\n'
   const trustLine = `trust_level = "${trustLevel}"`
 
-  if (!match) {
+  if (ranges.length === 0) {
     const block = [`[projects."${escapeTomlString(trustedProjectPath)}"]`, trustLine].join(eol)
     if (existing.length === 0) {
       return `${block}${eol}`
@@ -364,21 +369,62 @@ export function upsertProjectTrustLevelInContent(
     return `${existing}${separator}${block}${eol}`
   }
 
-  const headerLineEnd = match.index + match[0].length
-  const after = existing.slice(headerLineEnd)
-  const nextHeaderRel = findNextTableHeader(after)
-  const blockEnd = nextHeaderRel === -1 ? existing.length : headerLineEnd + nextHeaderRel
-  const existingBlock = existing.slice(headerLineEnd, blockEnd)
   const trustLevelLinePattern =
     /^[ \t]*trust_level[ \t]*=[ \t]*(?:"(?:trusted|untrusted)"|'(?:trusted|untrusted)')[ \t\r]*(?:#.*)?$/m
-  if (trustLevelLinePattern.test(existingBlock)) {
-    return (
-      existing.slice(0, headerLineEnd) +
-      existingBlock.replace(trustLevelLinePattern, trustLine) +
-      existing.slice(blockEnd)
-    )
+  let result = ''
+  let cursor = 0
+  // Why: keep the first matching table (updated in place) and drop the rest, so a
+  // pre-existing decoded-duplicate no longer survives the repair.
+  ranges.forEach((range, index) => {
+    result += existing.slice(cursor, range.start)
+    if (index === 0) {
+      const headerLine = existing.slice(range.start, range.headerLineEnd)
+      const body = existing.slice(range.headerLineEnd, range.end)
+      result += trustLevelLinePattern.test(body)
+        ? headerLine + body.replace(trustLevelLinePattern, trustLine)
+        : `${headerLine}${eol}${trustLine}${body}`
+    }
+    cursor = range.end
+  })
+  return result + existing.slice(cursor)
+}
+
+type ProjectTrustSectionRange = {
+  start: number
+  headerLineEnd: number
+  end: number
+}
+
+// Why: collect every [projects....] table whose decoded+normalized key matches
+// the target, so basic/literal quote style, slash direction, and drive-letter
+// case all resolve to the same logical project. Mirrors findTrustBlockRanges'
+// multiline-aware line scan.
+function findProjectTrustSectionRanges(
+  content: string,
+  projectPath: string
+): ProjectTrustSectionRange[] {
+  const targetKey = normalizeProjectTrustKey(projectPath)
+  const ranges: ProjectTrustSectionRange[] = []
+  let cursor = 0
+  let scanState = createTomlLineScanState()
+  while (cursor < content.length) {
+    const newlineIdx = content.indexOf('\n', cursor)
+    const lineEnd = newlineIdx === -1 ? content.length : newlineIdx
+    const rawLine = content.slice(cursor, lineEnd)
+    const line = rawLine.replace(/\r$/, '')
+    const nextCursor = newlineIdx === -1 ? content.length : newlineIdx + 1
+    const key = isTomlStructuralLine(scanState) ? getProjectTrustComparisonKey(line) : null
+    if (key !== null && key === targetKey) {
+      const headerLineEnd = rawLine.endsWith('\r') ? lineEnd - 1 : lineEnd
+      const after = content.slice(headerLineEnd)
+      const nextHeaderRel = findNextTableHeader(after)
+      const end = nextHeaderRel === -1 ? content.length : headerLineEnd + nextHeaderRel
+      ranges.push({ start: cursor, headerLineEnd, end })
+    }
+    scanState = updateTomlLineScanState(scanState, line)
+    cursor = nextCursor
   }
-  return `${existing.slice(0, headerLineEnd)}${eol}${trustLine}${existing.slice(headerLineEnd)}`
+  return ranges
 }
 
 // Why: build the canonical block we own. The two field names mirror what
@@ -550,20 +596,6 @@ function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
     cursor = nextCursor
   }
   return ranges
-}
-
-function buildProjectHeaderPattern(projectPath: string): RegExp {
-  const headerPathValues = [projectPath]
-  if (usesWindowsPathSeparators(projectPath)) {
-    headerPathValues.push(projectPath.replace(/\//g, '\\'), projectPath.replace(/\\/g, '/'))
-  }
-  const headerPaths = [...new Set(headerPathValues)].map((path) =>
-    escapeRegex(escapeTomlString(path))
-  )
-  return new RegExp(
-    `(^|\\r?\\n)[ \\t]*\\[projects\\."(?:${headerPaths.join('|')})"\\][ \\t]*(?:#[^\\r\\n]*)?(?=\\r?\\n|$)`,
-    process.platform === 'win32' ? 'i' : undefined
-  )
 }
 
 type ParsedTomlString = {


### PR DESCRIPTION
## Summary

On Windows, Codex launched through Orca could crash at config load with `failed to load configuration: ...\config.toml:NNN: duplicate key`. The managed `config.toml` accumulated two `[projects....]` tables that decode to the **same** TOML key — a *basic* string (double quotes, escaped backslashes) written by Orca and a *literal* string (single quotes, raw backslashes) written by the Codex CLI. TOML compares keys by decoded value, so the two collide and Codex refuses to load the file. It recurred on every launch (the config mirror re-emitted the collision), so deleting the offending line never stuck.

This PR makes project-trust reads/writes compare `[projects....]` headers by their **decoded, normalized** key across both the trust writer and the config mirror, and collapses any pre-existing decoded-duplicate to a single table.

### Root cause / fix
- `upsertProjectTrustLevelInContent` matched only double-quoted (basic) headers, so an existing literal header was not found and a duplicate basic table was appended. It now scans by decoded + normalized key and collapses all duplicate matches into one table.
- The config mirror deduped project sections by raw header text, so basic / literal / slash / drive-case variants of one path both survived the merge. It now dedupes by decoded key, including system-side duplicates in both the merge and fresh-mirror paths.
- New shared helper `codex-project-trust-key.ts`: Windows-style paths fold separators and drive-letter case; POSIX paths stay case-sensitive (SSH/WSL-safe). `hooks.state` keys are deliberately left untouched — their slash variants are genuinely distinct keys.

## Screenshots

No visual change (config-file handling only).

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Note: the `pnpm` suite was not run in my environment (dependencies not installed there). I verified the changed modules end-to-end by driving the real code (`upsertProjectTrustLevelInContent` and `syncSystemConfigIntoManagedCodexHome`) against temporary configs — all new and regression scenarios pass — and `node config/scripts/check-max-lines-ratchet.mjs` reports no new bypasses. New tests cover: literal↔basic match, slash/drive-case drift, POSIX case sensitivity, pre-existing duplicate collapse, system-side dedup (merge + fresh mirror), and a `hooks.state` no-dedup guard. Please rely on CI for the full `pnpm` gate.

## AI Review Report

Reviewed with Codex over two rounds. Round 1 flagged two P2 robustness gaps: (1) the upsert updated only the first matching table and left a pre-existing decoded-duplicate behind; (2) the mirror could still emit a system-side basic/literal duplicate when the runtime had no matching section (both the merge and fresh-mirror paths). Both were fixed — collapse-all in the upsert, and system-side dedup in `stripRuntimeOwnedTomlSections` — and re-review found no discrete correctness issues.

Cross-platform: this is Windows-focused; macOS/Linux/POSIX case sensitivity is explicitly preserved (POSIX paths are never folded), and the SSH/WSL case (POSIX paths under a Windows host, already-canonical remote paths) is handled by content-based normalization rather than `process.platform`. No keyboard shortcuts, labels, or shell behavior are touched; paths flow through decode/normalize helpers rather than raw separators.

## Security Audit

The change only reads and rewrites `~/.codex/config.toml` and Orca's managed runtime `config.toml`. No command execution, network, auth, secrets, or IPC surface is touched. Writes continue to use the existing atomic write + `.bak` rotation, and byte-preservation of unrelated config is retained (edits stay scoped to `[projects....]` sections). Input is untrusted TOML from disk; parsing is bounded single-line string decoding with no eval or regex-DoS risk.

## Notes

- The reported crash affects Orca-launched Codex (managed `CODEX_HOME`); the runtime config self-heals on the next launch once this ships.
- A pre-existing duplicate in the **global** `~/.codex/config.toml` (from before this fix) is collapsed the next time Orca marks that project trusted, but is not otherwise migrated.
- No dependency or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
