### PR TITLE
fix(codex): share the user's global AGENTS.md into the managed Codex runtime home

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -495,6 +495,9 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
+    const wslSystemHomePath = join(wslHome, '.codex')
+    mkdirSync(wslSystemHomePath, { recursive: true })
+    writeFileSync(join(wslSystemHomePath, 'AGENTS.md'), '# WSL instructions\n', 'utf-8')
     const store = createStore(
       createSettings({
         activeCodexManagedAccountId: null,
@@ -520,9 +523,12 @@ describe('CodexRuntimeHomeService', () => {
       expect(startWslCodexSessionBridgeInBackground).toHaveBeenCalledTimes(1)
       expect(startWslCodexSessionBridgeInBackground).toHaveBeenCalledWith({
         distro: 'Ubuntu',
-        systemCodexHomePath: join(wslHome, '.codex'),
+        systemCodexHomePath: wslSystemHomePath,
         managedCodexHomePath: wslRuntimeHomePath
       })
+      const runtimeAgentsPath = join(wslRuntimeHomePath, 'AGENTS.md')
+      expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('# WSL instructions\n')
+      expectResourceLinkedOrCopied(runtimeAgentsPath, join(wslSystemHomePath, 'AGENTS.md'))
     } finally {
       vi.doUnmock('../codex/wsl-codex-session-bridge')
       vi.doUnmock('../wsl')

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -528,7 +528,7 @@ describe('CodexRuntimeHomeService', () => {
       })
       const runtimeAgentsPath = join(wslRuntimeHomePath, 'AGENTS.md')
       expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('# WSL instructions\n')
-      expectResourceLinkedOrCopied(runtimeAgentsPath, join(wslSystemHomePath, 'AGENTS.md'))
+      expect(lstatSync(runtimeAgentsPath).isSymbolicLink()).toBe(false)
     } finally {
       vi.doUnmock('../codex/wsl-codex-session-bridge')
       vi.doUnmock('../wsl')

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -38,6 +38,7 @@ import { writeFileAtomically } from './fs-utils'
 import {
   getOrcaManagedCodexHomePath,
   getSystemCodexHomePath,
+  syncCodexGlobalInstructionsIntoManagedHome,
   syncSystemCodexResourcesIntoManagedHome
 } from '../codex/codex-home-paths'
 import { startSystemCodexSessionBridgeInBackground } from '../codex/codex-session-bridge'
@@ -141,7 +142,7 @@ export class CodexRuntimeHomeService {
     if (target?.runtime === 'wsl') {
       const wslTarget = this.resolveWslDefaultTarget(target)
       const syncedRuntimeHomePath = this.syncWslRuntimeForCurrentSelection(wslTarget)
-      this.syncWslConfigSettingsForLaunch(wslTarget, syncedRuntimeHomePath)
+      this.syncWslConfigAndGlobalInstructionsForLaunch(wslTarget, syncedRuntimeHomePath)
       const runtimeHomePath = syncedRuntimeHomePath ?? this.getWslSystemCodexHomePath(wslTarget)
       this.startWslSessionBridgeForLaunch(wslTarget, runtimeHomePath)
       return runtimeHomePath
@@ -223,10 +224,7 @@ export class CodexRuntimeHomeService {
     return home ? this.joinWslPath(home, '.codex') : null
   }
 
-  // Why: WSL needs the same promote-then-mirror transaction as host. It keeps
-  // in-Orca changes while reconciling a newer external ~/.codex edit before
-  // advancing the per-distro baseline. Only runs on a materialized runtime.
-  private syncWslConfigSettingsForLaunch(
+  private syncWslConfigAndGlobalInstructionsForLaunch(
     target: CodexAccountSelectionTarget,
     runtimeHomePath: string | null
   ): void {
@@ -242,6 +240,12 @@ export class CodexRuntimeHomeService {
     if (!systemHomePath || systemHomePath === runtimeHomePath) {
       return
     }
+    // Why: WSL uses a distro-local CODEX_HOME, so host resource mirroring
+    // cannot provide the distro user's global instructions.
+    syncCodexGlobalInstructionsIntoManagedHome({
+      systemHomePath,
+      managedHomePath: runtimeHomePath
+    })
     syncSystemConfigIntoManagedCodexHome({ runtimeHomePath, systemHomePath })
   }
 

--- a/src/main/codex/codex-home-paths.test.ts
+++ b/src/main/codex/codex-home-paths.test.ts
@@ -255,7 +255,10 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
 
     const runtimeAgentsPath = join(managedHomePath, 'AGENTS.md')
     expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('# WSL instructions\n')
-    expectSymbolicLinkTargetIfLinked(runtimeAgentsPath, join(systemHomePath, 'AGENTS.md'))
+    // Why: WSL homes are \\wsl.localhost UNC paths, so a host-side symlink would
+    // store a target the distro cannot resolve; global instructions must be a
+    // real copy even when symlinks are available.
+    expect(lstatSync(runtimeAgentsPath).isSymbolicLink()).toBe(false)
     expect(existsSync(join(managedHomePath, 'skills'))).toBe(false)
   })
 

--- a/src/main/codex/codex-home-paths.test.ts
+++ b/src/main/codex/codex-home-paths.test.ts
@@ -51,7 +51,10 @@ vi.mock('node:os', async () => {
   }
 })
 
-import { syncSystemCodexResourcesIntoManagedHome } from './codex-home-paths'
+import {
+  syncCodexGlobalInstructionsIntoManagedHome,
+  syncSystemCodexResourcesIntoManagedHome
+} from './codex-home-paths'
 
 let fakeHomeDir: string
 let userDataDir: string
@@ -228,5 +231,62 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
 
     expect(lstatSync(runtimeHooksPath).isSymbolicLink()).toBe(true)
     expectSymbolicLinkTargetIfLinked(runtimeHooksPath, systemHooksPath)
+  })
+
+  it('mirrors the global AGENTS.md into the managed runtime home so user instructions survive', () => {
+    const systemAgentsPath = join(getSystemCodexHomePath(), 'AGENTS.md')
+    const runtimeAgentsPath = join(getRuntimeCodexHomePath(), 'AGENTS.md')
+    writeFileSync(systemAgentsPath, '# Global instructions\n')
+
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('# Global instructions\n')
+    expectSymbolicLinkTargetIfLinked(runtimeAgentsPath, systemAgentsPath)
+  })
+
+  it('mirrors only global instructions when explicit Codex homes are provided', () => {
+    const systemHomePath = getSystemCodexHomePath()
+    const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+    mkdirSync(join(systemHomePath, 'skills'), { recursive: true })
+    writeFileSync(join(systemHomePath, 'skills', 'system.md'), 'skill\n')
+    writeFileSync(join(systemHomePath, 'AGENTS.md'), '# WSL instructions\n')
+
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+
+    const runtimeAgentsPath = join(managedHomePath, 'AGENTS.md')
+    expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('# WSL instructions\n')
+    expectSymbolicLinkTargetIfLinked(runtimeAgentsPath, join(systemHomePath, 'AGENTS.md'))
+    expect(existsSync(join(managedHomePath, 'skills'))).toBe(false)
+  })
+
+  it('refreshes and removes owned global-instruction copies when file symlinks fail', () => {
+    fsMockState.failSymlink = true
+    const systemHomePath = getSystemCodexHomePath()
+    const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+    const systemAgentsPath = join(systemHomePath, 'AGENTS.md')
+    const runtimeAgentsPath = join(managedHomePath, 'AGENTS.md')
+    writeFileSync(systemAgentsPath, 'first\n')
+
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+    writeFileSync(systemAgentsPath, 'second\n')
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+
+    expect(lstatSync(runtimeAgentsPath).isSymbolicLink()).toBe(false)
+    expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('second\n')
+    rmSync(systemAgentsPath)
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+    expect(existsSync(runtimeAgentsPath)).toBe(false)
+  })
+
+  it('preserves runtime-owned global instructions in an explicit managed home', () => {
+    const systemHomePath = getSystemCodexHomePath()
+    const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+    mkdirSync(managedHomePath, { recursive: true })
+    writeFileSync(join(systemHomePath, 'AGENTS.md'), 'system\n')
+    writeFileSync(join(managedHomePath, 'AGENTS.md'), 'runtime\n')
+
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+
+    expect(readFileSync(join(managedHomePath, 'AGENTS.md'), 'utf-8')).toBe('runtime\n')
   })
 })

--- a/src/main/codex/codex-home-paths.test.ts
+++ b/src/main/codex/codex-home-paths.test.ts
@@ -21,13 +21,28 @@ const { getPathMock, homedirMock } = vi.hoisted(() => ({
 }))
 
 const { fsMockState } = vi.hoisted(() => ({
-  fsMockState: { failSymlink: false }
+  fsMockState: {
+    copyCount: 0,
+    failSymlink: false,
+    trackedReadCount: 0,
+    trackedReadPath: null as string | null
+  }
 }))
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof NodeFs>('node:fs')
   return {
     ...actual,
+    cpSync: (...args: Parameters<typeof actual.cpSync>) => {
+      fsMockState.copyCount += 1
+      return actual.cpSync(...args)
+    },
+    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => {
+      if (args[0] === fsMockState.trackedReadPath) {
+        fsMockState.trackedReadCount += 1
+      }
+      return actual.readFileSync(...args)
+    },
     symlinkSync: (...args: Parameters<typeof actual.symlinkSync>) => {
       if (fsMockState.failSymlink) {
         throw new Error('symlink disabled for test')
@@ -91,7 +106,10 @@ function mockElectronAppPaths(): void {
 
 beforeEach(() => {
   mockElectronAppPaths()
+  fsMockState.copyCount = 0
   fsMockState.failSymlink = false
+  fsMockState.trackedReadCount = 0
+  fsMockState.trackedReadPath = null
   fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-resource-home-'))
   userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-resource-user-data-'))
   previousUserDataPath = process.env.ORCA_USER_DATA_PATH
@@ -244,6 +262,22 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
     expectSymbolicLinkTargetIfLinked(runtimeAgentsPath, systemAgentsPath)
   })
 
+  it('skips unchanged global-instruction fallback copies when symlinks fail', () => {
+    fsMockState.failSymlink = true
+    const systemAgentsPath = join(getSystemCodexHomePath(), 'AGENTS.md')
+    writeFileSync(systemAgentsPath, 'first\n')
+
+    syncSystemCodexResourcesIntoManagedHome()
+    expect(fsMockState.copyCount).toBe(1)
+    syncSystemCodexResourcesIntoManagedHome()
+    expect(fsMockState.copyCount).toBe(1)
+    writeFileSync(systemAgentsPath, 'second\n')
+    syncSystemCodexResourcesIntoManagedHome()
+
+    expect(fsMockState.copyCount).toBe(2)
+    expect(readFileSync(join(getRuntimeCodexHomePath(), 'AGENTS.md'), 'utf-8')).toBe('second\n')
+  })
+
   it('mirrors only global instructions when explicit Codex homes are provided', () => {
     const systemHomePath = getSystemCodexHomePath()
     const managedHomePath = join(userDataDir, 'wsl-runtime-home')
@@ -262,8 +296,59 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
     expect(existsSync(join(managedHomePath, 'skills'))).toBe(false)
   })
 
-  it('refreshes and removes owned global-instruction copies when file symlinks fail', () => {
-    fsMockState.failSymlink = true
+  // Why: creating file symlinks on Windows requires developer mode; the
+  // runtime-home integration test still enforces real-copy behavior there.
+  it.skipIf(process.platform === 'win32')(
+    'materializes symlinked global instructions as a real file for WSL',
+    () => {
+      const systemHomePath = getSystemCodexHomePath()
+      const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+      const instructionSourcePath = join(userDataDir, 'global-instructions.md')
+      writeFileSync(instructionSourcePath, 'linked instructions\n')
+      symlinkSync(instructionSourcePath, join(systemHomePath, 'AGENTS.md'))
+
+      syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+
+      const runtimeAgentsPath = join(managedHomePath, 'AGENTS.md')
+      expect(lstatSync(runtimeAgentsPath).isSymbolicLink()).toBe(false)
+      expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('linked instructions\n')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'replaces an existing system-instruction link despite a malformed marker directory',
+    () => {
+      const systemHomePath = getSystemCodexHomePath()
+      const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+      const systemAgentsPath = join(systemHomePath, 'AGENTS.md')
+      const runtimeAgentsPath = join(managedHomePath, 'AGENTS.md')
+      mkdirSync(managedHomePath, { recursive: true })
+      writeFileSync(systemAgentsPath, 'system\n')
+      symlinkSync(systemAgentsPath, runtimeAgentsPath)
+      mkdirSync(join(managedHomePath, '.orca-resource-copies', 'AGENTS.md.json'), {
+        recursive: true
+      })
+
+      syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+
+      expect(lstatSync(runtimeAgentsPath).isSymbolicLink()).toBe(false)
+      expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('system\n')
+    }
+  )
+
+  it('removes an unowned copy when recording copy ownership fails', () => {
+    const systemHomePath = getSystemCodexHomePath()
+    const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+    writeFileSync(join(systemHomePath, 'AGENTS.md'), 'system\n')
+    mkdirSync(managedHomePath, { recursive: true })
+    writeFileSync(join(managedHomePath, '.orca-resource-copies'), 'blocks marker directory\n')
+
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+
+    expect(existsSync(join(managedHomePath, 'AGENTS.md'))).toBe(false)
+  })
+
+  it('skips unchanged copies, then refreshes and removes owned global instructions', () => {
     const systemHomePath = getSystemCodexHomePath()
     const managedHomePath = join(userDataDir, 'wsl-runtime-home')
     const systemAgentsPath = join(systemHomePath, 'AGENTS.md')
@@ -271,13 +356,54 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
     writeFileSync(systemAgentsPath, 'first\n')
 
     syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+    expect(fsMockState.copyCount).toBe(1)
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+    expect(fsMockState.copyCount).toBe(1)
     writeFileSync(systemAgentsPath, 'second\n')
     syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
 
+    expect(fsMockState.copyCount).toBe(2)
     expect(lstatSync(runtimeAgentsPath).isSymbolicLink()).toBe(false)
     expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('second\n')
     rmSync(systemAgentsPath)
     syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+    expect(existsSync(runtimeAgentsPath)).toBe(false)
+  })
+
+  it('replaces an owned non-file instruction entry without reading it', () => {
+    const systemHomePath = getSystemCodexHomePath()
+    const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+    const runtimeAgentsPath = join(managedHomePath, 'AGENTS.md')
+    writeFileSync(join(systemHomePath, 'AGENTS.md'), 'system\n')
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+    rmSync(runtimeAgentsPath)
+    mkdirSync(runtimeAgentsPath)
+    fsMockState.trackedReadPath = runtimeAgentsPath
+
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+
+    expect(fsMockState.trackedReadCount).toBe(0)
+    expect(lstatSync(runtimeAgentsPath).isFile()).toBe(true)
+    expect(readFileSync(runtimeAgentsPath, 'utf-8')).toBe('system\n')
+  })
+
+  it('removes owned instructions instead of mirroring a non-file source', () => {
+    const systemHomePath = getSystemCodexHomePath()
+    const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+    const systemAgentsPath = join(systemHomePath, 'AGENTS.md')
+    const runtimeAgentsPath = join(managedHomePath, 'AGENTS.md')
+    writeFileSync(systemAgentsPath, 'system\n')
+    syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+    rmSync(systemAgentsPath)
+    mkdirSync(systemAgentsPath)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+    } finally {
+      warn.mockRestore()
+    }
+
     expect(existsSync(runtimeAgentsPath)).toBe(false)
   })
 
@@ -292,4 +418,22 @@ describe('syncSystemCodexResourcesIntoManagedHome', () => {
 
     expect(readFileSync(join(managedHomePath, 'AGENTS.md'), 'utf-8')).toBe('runtime\n')
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves an unowned dangling runtime instruction symlink',
+    () => {
+      const systemHomePath = getSystemCodexHomePath()
+      const managedHomePath = join(userDataDir, 'wsl-runtime-home')
+      const runtimeAgentsPath = join(managedHomePath, 'AGENTS.md')
+      const missingTargetPath = join(userDataDir, 'missing-runtime-instructions.md')
+      mkdirSync(managedHomePath, { recursive: true })
+      writeFileSync(join(systemHomePath, 'AGENTS.md'), 'system\n')
+      symlinkSync(missingTargetPath, runtimeAgentsPath)
+
+      syncCodexGlobalInstructionsIntoManagedHome({ systemHomePath, managedHomePath })
+
+      expect(lstatSync(runtimeAgentsPath).isSymbolicLink()).toBe(true)
+      expect(readlinkSync(runtimeAgentsPath)).toBe(missingTargetPath)
+    }
+  )
 })

--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -68,13 +68,20 @@ export function syncCodexGlobalInstructionsIntoManagedHome({
   managedHomePath: string
 }): void {
   mkdirSync(managedHomePath, { recursive: true })
-  linkSystemCodexResource(systemHomePath, managedHomePath, CODEX_GLOBAL_INSTRUCTIONS_ENTRY)
+  // Why: this only runs for WSL runtime homes, whose system + managed homes are
+  // both \\wsl.localhost UNC paths. A host-side symlink there stores a Windows
+  // UNC target the distro cannot resolve, so copy the file like the config
+  // mirror does across the same boundary.
+  linkSystemCodexResource(systemHomePath, managedHomePath, CODEX_GLOBAL_INSTRUCTIONS_ENTRY, {
+    preferCopy: true
+  })
 }
 
 function linkSystemCodexResource(
   systemHomePath: string,
   managedHomePath: string,
-  entryName: string
+  entryName: string,
+  { preferCopy = false }: { preferCopy?: boolean } = {}
 ): void {
   const sourcePath = join(systemHomePath, entryName)
   const targetPath = join(managedHomePath, entryName)
@@ -100,6 +107,11 @@ function linkSystemCodexResource(
     rmSync(targetPath, { recursive: true, force: true })
   }
 
+  if (preferCopy) {
+    copySystemCodexResourceAsOwnedFallback(sourcePath, targetPath, managedHomePath, entryName)
+    return
+  }
+
   try {
     const sourceStat = lstatSync(sourcePath)
     symlinkSync(
@@ -109,16 +121,36 @@ function linkSystemCodexResource(
     )
     clearCopiedResourceMarker(managedHomePath, entryName)
   } catch (error) {
-    try {
-      rmSync(targetPath, { recursive: true, force: true })
-      // Why: Windows can reject file symlinks outside developer mode. Copy is
-      // a fallback for launch-time resources; mark ownership so later syncs can
-      // refresh the copy without touching user-created runtime resources.
-      cpSync(sourcePath, targetPath, { recursive: true, force: false, errorOnExist: true })
-      markCopiedResource(managedHomePath, entryName, sourcePath)
-    } catch {
-      console.warn('[codex-home] Failed to link system Codex resource:', entryName, error)
-    }
+    // Why: Windows can reject file symlinks outside developer mode. Copy is
+    // a fallback for launch-time resources; mark ownership so later syncs can
+    // refresh the copy without touching user-created runtime resources.
+    copySystemCodexResourceAsOwnedFallback(
+      sourcePath,
+      targetPath,
+      managedHomePath,
+      entryName,
+      error
+    )
+  }
+}
+
+function copySystemCodexResourceAsOwnedFallback(
+  sourcePath: string,
+  targetPath: string,
+  managedHomePath: string,
+  entryName: string,
+  symlinkError?: unknown
+): void {
+  try {
+    rmSync(targetPath, { recursive: true, force: true })
+    cpSync(sourcePath, targetPath, { recursive: true, force: false, errorOnExist: true })
+    markCopiedResource(managedHomePath, entryName, sourcePath)
+  } catch (copyError) {
+    console.warn(
+      '[codex-home] Failed to link system Codex resource:',
+      entryName,
+      symlinkError ?? copyError
+    )
   }
 }
 

--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -7,6 +7,7 @@ import {
   readlinkSync,
   rmdirSync,
   rmSync,
+  statSync,
   symlinkSync,
   unlinkSync,
   writeFileSync
@@ -89,10 +90,20 @@ function linkSystemCodexResource(
     removeCopiedResourceIfOwned(targetPath, managedHomePath, entryName, sourcePath)
     return
   }
+  if (
+    entryName === CODEX_GLOBAL_INSTRUCTIONS_ENTRY &&
+    !systemResourceIsRegularFile(sourcePath)
+  ) {
+    removeCopiedResourceIfOwned(targetPath, managedHomePath, entryName, sourcePath)
+    console.warn('[codex-home] Ignoring non-file system Codex resource:', entryName)
+    return
+  }
 
   if (targetAlreadyPointsToSource(targetPath, sourcePath)) {
     clearCopiedResourceMarker(managedHomePath, entryName)
-    return
+    if (!preferCopy || !removeSymlinkEntry(targetPath)) {
+      return
+    }
   }
   const shouldRefreshFallbackCopy = targetIsOwnedFallbackCopy(
     targetPath,
@@ -100,10 +111,18 @@ function linkSystemCodexResource(
     entryName,
     sourcePath
   )
-  if (existsSync(targetPath) && !shouldRefreshFallbackCopy) {
+  if (pathEntryExists(targetPath) && !shouldRefreshFallbackCopy) {
     return
   }
   if (shouldRefreshFallbackCopy) {
+    // Why: WSL launch preparation runs before every Codex start. Avoid
+    // rewriting an unchanged file across the UNC boundary on every launch.
+    if (
+      entryName === CODEX_GLOBAL_INSTRUCTIONS_ENTRY &&
+      copiedFileContentsMatch(sourcePath, targetPath)
+    ) {
+      return
+    }
     rmSync(targetPath, { recursive: true, force: true })
   }
 
@@ -143,14 +162,62 @@ function copySystemCodexResourceAsOwnedFallback(
 ): void {
   try {
     rmSync(targetPath, { recursive: true, force: true })
-    cpSync(sourcePath, targetPath, { recursive: true, force: false, errorOnExist: true })
+    cpSync(sourcePath, targetPath, {
+      recursive: true,
+      force: false,
+      errorOnExist: true,
+      // Why: dotfile managers commonly symlink AGENTS.md. WSL needs the file
+      // contents because a copied host-side link is not usable in the distro.
+      dereference: entryName === CODEX_GLOBAL_INSTRUCTIONS_ENTRY
+    })
     markCopiedResource(managedHomePath, entryName, sourcePath)
   } catch (copyError) {
+    // Why: an unmarked copy cannot be refreshed or safely removed later.
+    // Roll it back instead of stranding stale instructions in the runtime home.
+    try {
+      rmSync(targetPath, { recursive: true, force: true })
+    } catch (cleanupError) {
+      console.warn(
+        '[codex-home] Failed to remove incomplete resource copy:',
+        entryName,
+        cleanupError
+      )
+    }
     console.warn(
-      '[codex-home] Failed to link system Codex resource:',
+      '[codex-home] Failed to mirror system Codex resource:',
       entryName,
       symlinkError ?? copyError
     )
+  }
+}
+
+function systemResourceIsRegularFile(sourcePath: string): boolean {
+  try {
+    return statSync(sourcePath).isFile()
+  } catch {
+    return false
+  }
+}
+
+function pathEntryExists(entryPath: string): boolean {
+  try {
+    lstatSync(entryPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function copiedFileContentsMatch(sourcePath: string, targetPath: string): boolean {
+  try {
+    // Why: reading a FIFO or device synchronously can block Codex launch.
+    // Follow source symlinks, but only compare two regular files.
+    if (!statSync(sourcePath).isFile() || !lstatSync(targetPath).isFile()) {
+      return false
+    }
+    return readFileSync(sourcePath).equals(readFileSync(targetPath))
+  } catch {
+    return false
   }
 }
 
@@ -205,7 +272,12 @@ function readCopiedResourceSourcePath(managedHomePath: string, entryName: string
 }
 
 function clearCopiedResourceMarker(managedHomePath: string, entryName: string): void {
-  rmSync(getResourceCopyMarkerPath(managedHomePath, entryName), { force: true })
+  // Why: a malformed marker directory must not block Codex launch or prevent
+  // an owned resource from being repaired.
+  rmSync(getResourceCopyMarkerPath(managedHomePath, entryName), {
+    recursive: true,
+    force: true
+  })
 }
 
 function targetIsOwnedFallbackCopy(

--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -14,6 +14,8 @@ import {
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
+const CODEX_GLOBAL_INSTRUCTIONS_ENTRY = 'AGENTS.md'
+
 const CODEX_SYSTEM_RESOURCE_ENTRIES = [
   'skills',
   'hooks',
@@ -21,7 +23,8 @@ const CODEX_SYSTEM_RESOURCE_ENTRIES = [
   'plugin-state',
   'profile-v2',
   'themes',
-  'prompts'
+  'prompts',
+  CODEX_GLOBAL_INSTRUCTIONS_ENTRY
 ] as const
 
 export function getSystemCodexHomePath(): string {
@@ -55,6 +58,17 @@ export function syncSystemCodexResourcesIntoManagedHome(): void {
   for (const entryName of CODEX_SYSTEM_RESOURCE_ENTRIES) {
     linkSystemCodexResource(systemHomePath, managedHomePath, entryName)
   }
+}
+
+export function syncCodexGlobalInstructionsIntoManagedHome({
+  systemHomePath,
+  managedHomePath
+}: {
+  systemHomePath: string
+  managedHomePath: string
+}): void {
+  mkdirSync(managedHomePath, { recursive: true })
+  linkSystemCodexResource(systemHomePath, managedHomePath, CODEX_GLOBAL_INSTRUCTIONS_ENTRY)
 }
 
 function linkSystemCodexResource(


### PR DESCRIPTION
## Summary

Codex sessions launched inside Orca silently ignore the user's global `~/.codex/AGENTS.md` because Orca points `CODEX_HOME` at a managed runtime home. This PR:

- shares `AGENTS.md` through the existing ownership-aware link-or-copy resource path for host and remote-host runtimes;
- mirrors only the distro user's `AGENTS.md` into WSL managed homes during launch preparation, without copying skills/plugins directories;
- preserves runtime-owned files and removes or refreshes only entries Orca can prove it owns.

## Reproduction

With a global `~/.codex/AGENTS.md` present, run in an empty directory with no project `AGENTS.md`:

```
codex exec --skip-git-repo-check "Does your context include a global AGENTS.md with user instructions? If yes, quote its first sentence verbatim; if none, answer: none"
```

| Environment | Result before this PR |
|---|---|
| Orca terminal using managed `CODEX_HOME` | `none` |
| Same command with the user's system `CODEX_HOME` | quotes the global instructions |

Manually placing the global file in the managed home fixes the first case, isolating the missing resource share as the cause.

## Testing

- [x] Focused runtime-home suites: 94/94 tests passed
- [x] Full `pnpm test`: 2,711 test files passed; 28,532 tests passed; 42 skipped
- [x] `pnpm run typecheck:node`
- [x] `pnpm run typecheck:cli`
- [x] Focused `oxlint` on all four touched files
- [x] `pnpm run check:reliability-gates`
- [x] `pnpm run check:max-lines-ratchet`
- [x] Regression coverage for host sharing, WSL launch integration, Windows file-symlink fallback copies, refresh, deletion cleanup, runtime-owned file protection, and avoiding unrelated WSL resource copies

## Reliability contract

- **Invariant:** `agent-session.global-instructions-parity` — a Codex process launched with an Orca-managed host or WSL `CODEX_HOME` sees the same user-level `AGENTS.md` as the corresponding system Codex home.
- **Failure source:** PR #7927 reproduction; managed homes changed Codex instruction discovery by omitting the global file.
- **Oracle:** after launch preparation, the managed home reads the same instruction contents; externally owned managed files remain unchanged; Orca-owned fallback copies refresh and disappear with the source.
- **Gate:** no matching gate currently exists in `config/reliability-gates.jsonc`; accepted as focused deterministic unit/integration coverage for this non-PTY filesystem invariant.
- **Provider/platform coverage:** macOS/Linux host and remote-host behavior use the existing resource mirror; Windows file-symlink failure is deterministically forced through the owned-copy path; WSL path selection and launch integration are covered with a Windows-shaped runtime test. SSH/remote servers execute the same host-side code in their own filesystem. Mobile/relay does not own Codex launch-home preparation and is unaffected.
- **Performance budget:** one bounded file sync during launch preparation; no directory scan, polling, subprocess, provider fanout, retry loop, or awaited background work. The WSL-specific path deliberately does not mirror skills/plugins directories.
- **Diagnostics:** existing `[codex-home] Failed to link system Codex resource` warning identifies the failed entry and error.
- **Residual gap:** no live Windows+WSL filesystem run was available locally; Windows CI remains the platform gate.

## Cross-platform and security review

- Paths use Node path utilities; no shell strings or new subprocesses are introduced.
- Windows systems without file-symlink permission use the existing ownership-marked copy fallback.
- `auth.json`, `config.toml`, `hooks.json`, session history, and other private/runtime-owned files remain outside this new WSL-specific sync.
- A pre-existing runtime-owned `AGENTS.md` is never overwritten.
- Deleting the system file removes only a matching symlink or ownership-marked fallback copy.
- The file is user-authored instructions copied between two user-owned Codex homes; no new external trust boundary is introduced.

## Screenshots

No visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
