### PR TITLE
Make source-control AI timeout configurable

### DIFF
--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -17,6 +17,7 @@ import {
   generateCommitMessageFromContext,
   generatePullRequestFieldsFromContext,
   resolveCommitMessageSettings,
+  resolveSourceControlGenerationTimeoutMs,
   trimGeneratedCommitMessage
 } from './commit-message-text-generation'
 
@@ -36,6 +37,7 @@ vi.mock('child_process', async (importOriginal) => {
 
 const execMock = vi.mocked(exec)
 const spawnMock = vi.mocked(spawn)
+const timeoutEnvKey = 'ORCA_SOURCE_CONTROL_AI_TIMEOUT_MS'
 
 type MockDiscoveryChild = EventEmitter & {
   pid: number
@@ -78,9 +80,56 @@ function expectChildTerminated(child: { pid: number; kill: ReturnType<typeof vi.
   expect(child.kill).toHaveBeenCalledWith('SIGKILL')
 }
 
+async function withTimeoutEnv<T>(value: string | undefined, fn: () => T | Promise<T>): Promise<T> {
+  const previous = process.env[timeoutEnvKey]
+  if (value === undefined) {
+    delete process.env[timeoutEnvKey]
+  } else {
+    process.env[timeoutEnvKey] = value
+  }
+  try {
+    return await fn()
+  } finally {
+    if (previous === undefined) {
+      delete process.env[timeoutEnvKey]
+    } else {
+      process.env[timeoutEnvKey] = previous
+    }
+  }
+}
+
 beforeEach(() => {
   execMock.mockClear()
   spawnMock.mockClear()
+})
+
+describe('resolveSourceControlGenerationTimeoutMs', () => {
+  it('uses 60 seconds by default', async () => {
+    await withTimeoutEnv(undefined, () => {
+      expect(resolveSourceControlGenerationTimeoutMs()).toBe(60_000)
+    })
+  })
+
+  it('accepts configured timeouts from 30 to 300 seconds', async () => {
+    await withTimeoutEnv('120000', () => {
+      expect(resolveSourceControlGenerationTimeoutMs()).toBe(120_000)
+    })
+  })
+
+  it('clamps configured timeouts to the supported range', async () => {
+    await withTimeoutEnv('5000', () => {
+      expect(resolveSourceControlGenerationTimeoutMs()).toBe(30_000)
+    })
+    await withTimeoutEnv('999999', () => {
+      expect(resolveSourceControlGenerationTimeoutMs()).toBe(300_000)
+    })
+  })
+
+  it('ignores invalid configured timeouts', async () => {
+    await withTimeoutEnv('not-a-number', () => {
+      expect(resolveSourceControlGenerationTimeoutMs()).toBe(60_000)
+    })
+  })
 })
 
 describe('resolveCommitMessageSettings', () => {
@@ -615,7 +664,45 @@ describe('generateCommitMessageFromContext', () => {
     })
   })
 
-  it('exposes raw CLI failure output only after path sanitization', async () => {
+  it('uses the configured timeout for remote commit-message generation', async () => {
+    await withTimeoutEnv('120000', async () => {
+      let requestedTimeout = 0
+      const result = await generateCommitMessageFromContext(
+        {
+          branch: 'main',
+          stagedSummary: 'M\tREADME.md',
+          stagedPatch: '+hello'
+        },
+        {
+          agentId: 'custom',
+          model: '',
+          customAgentCommand: 'agent'
+        },
+        {
+          kind: 'remote',
+          cwd: '/repo',
+          missingBinaryLocation: 'remote PATH',
+          execute: async (_plan, _cwd, timeoutMs) => {
+            requestedTimeout = timeoutMs
+            return {
+              stdout: '',
+              stderr: '',
+              exitCode: null,
+              timedOut: true
+            }
+          }
+        }
+      )
+
+      expect(requestedTimeout).toBe(120_000)
+      expect(result).toEqual({
+        success: false,
+        error: 'Generation timed out after 120s.'
+      })
+    })
+  })
+
+  it('does not expose unstructured raw CLI failure output', async () => {
     const result = await generateCommitMessageFromContext(
       {
         branch: 'main',

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -55,7 +55,10 @@ import {
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { wslAwareSpawn } from '../git/runner'
 
-const GENERATION_TIMEOUT_MS = 60_000
+const DEFAULT_SOURCE_CONTROL_GENERATION_TIMEOUT_MS = 60_000
+const MIN_SOURCE_CONTROL_GENERATION_TIMEOUT_MS = 30_000
+const MAX_SOURCE_CONTROL_GENERATION_TIMEOUT_MS = 300_000
+const SOURCE_CONTROL_GENERATION_TIMEOUT_ENV = 'ORCA_SOURCE_CONTROL_AI_TIMEOUT_MS'
 const MAX_AGENT_OUTPUT_BYTES = 4 * 1024 * 1024
 
 export type GenerateCommitMessageParams = ResolvedSourceControlAiGenerationParams
@@ -129,6 +132,27 @@ export type CommitMessageModelDiscoveryLocalOptions = {
 
 export function trimGeneratedCommitMessage(message: string): string {
   return message.replace(/\s+$/, '')
+}
+
+export function resolveSourceControlGenerationTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = env[SOURCE_CONTROL_GENERATION_TIMEOUT_ENV]?.trim()
+  if (!raw) {
+    return DEFAULT_SOURCE_CONTROL_GENERATION_TIMEOUT_MS
+  }
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_SOURCE_CONTROL_GENERATION_TIMEOUT_MS
+  }
+  return Math.min(
+    MAX_SOURCE_CONTROL_GENERATION_TIMEOUT_MS,
+    Math.max(MIN_SOURCE_CONTROL_GENERATION_TIMEOUT_MS, Math.round(parsed))
+  )
+}
+
+function formatTimeoutSeconds(timeoutMs: number): number {
+  return Math.round(timeoutMs / 1000)
 }
 
 export function resolveCommitMessageSettings(
@@ -314,6 +338,7 @@ export async function discoverCommitMessageModelsLocal(
 
   return new Promise((resolve) => {
     let child: ChildProcess
+    const timeoutMs = resolveSourceControlGenerationTimeoutMs()
     const spawnEnv = env ?? process.env
     try {
       const planned = planModelDiscovery(spec, agentCommandOverride)
@@ -375,9 +400,9 @@ export async function discoverCommitMessageModelsLocal(
       killProcessTree(child)
       finish({
         success: false,
-        error: `${spec.label} model discovery timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
+        error: `${spec.label} model discovery timed out after ${formatTimeoutSeconds(timeoutMs)}s.`
       })
-    }, GENERATION_TIMEOUT_MS)
+    }, timeoutMs)
 
     const onData = (chunk: Buffer, append: (text: string) => void): void => {
       if (stdout.length + stderr.length + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
@@ -450,9 +475,10 @@ export async function discoverCommitMessageModelsRemote(
   if (!planned.ok) {
     return { success: false, error: planned.error }
   }
+  const timeoutMs = resolveSourceControlGenerationTimeoutMs()
   let result: RemoteCommitMessageExecResult
   try {
-    result = await execute(planned.plan, cwd, GENERATION_TIMEOUT_MS)
+    result = await execute(planned.plan, cwd, timeoutMs)
   } catch (error) {
     console.error('[commit-message] Remote model discovery request failed:', error)
     return {
@@ -482,7 +508,7 @@ export async function discoverCommitMessageModelsRemote(
   if (result.timedOut) {
     return {
       success: false,
-      error: `${spec.label} model discovery timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
+      error: `${spec.label} model discovery timed out after ${formatTimeoutSeconds(timeoutMs)}s.`
     }
   }
   return finalizeModelDiscoveryOutput(spec, result.stdout, result.stderr, result.exitCode)
@@ -609,6 +635,7 @@ async function runLocalPlan(
     let outputLimitExceeded = false
     let settled = false
     let canceledByUser = false
+    const timeoutMs = resolveSourceControlGenerationTimeoutMs()
     const laneKey = localLaneKey(operation, cwd)
     let cancelToken: (() => void) | null = null
     let timer: ReturnType<typeof setTimeout> | null = null
@@ -642,9 +669,9 @@ async function runLocalPlan(
       killProcessTree(child)
       finalize({
         success: false,
-        error: `Generation timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
+        error: `Generation timed out after ${formatTimeoutSeconds(timeoutMs)}s.`
       })
-    }, GENERATION_TIMEOUT_MS)
+    }, timeoutMs)
 
     const onStdoutData = (chunk: Buffer): void => {
       stdoutBytes += chunk.byteLength
@@ -790,9 +817,10 @@ async function runRemotePlan(
   operation: TextGenerationOperation = 'commit-message'
 ): Promise<InternalTextGenerationResult> {
   const { binary, label } = plan
+  const timeoutMs = resolveSourceControlGenerationTimeoutMs()
   let result: RemoteCommitMessageExecResult
   try {
-    result = await target.execute(plan, target.cwd, GENERATION_TIMEOUT_MS, operation)
+    result = await target.execute(plan, target.cwd, timeoutMs, operation)
   } catch (error) {
     console.error('[commit-message] Remote generator request failed:', error)
     return {
@@ -825,7 +853,7 @@ async function runRemotePlan(
   if (result.timedOut) {
     return {
       success: false,
-      error: `Generation timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
+      error: `Generation timed out after ${formatTimeoutSeconds(timeoutMs)}s.`
     }
   }
 


### PR DESCRIPTION
## Summary

- Make source-control AI timeout configurable with `ORCA_SOURCE_CONTROL_AI_TIMEOUT_MS`
- Keep the default at 60 seconds and clamp configured values to 30-300 seconds
- Apply the resolved timeout to local/remote model discovery and generation paths

Closes #7865

## Test plan

- `pnpm exec vitest run --config config/vitest.config.ts src/main/text-generation/commit-message-text-generation.test.ts`
- `pnpm exec oxfmt --check src/main/text-generation/commit-message-text-generation.ts src/main/text-generation/commit-message-text-generation.test.ts`
- `pnpm exec oxlint src/main/text-generation/commit-message-text-generation.ts src/main/text-generation/commit-message-text-generation.test.ts`
- `pnpm run typecheck`
- `pnpm run build:desktop`
- `git diff --check`

## Notes

- No visual change.
- `pnpm run lint` still fails on an unrelated pre-existing switch exhaustiveness issue in `src/main/ipc/notification-authorization-status.ts:76`.
- Full `pnpm test` was interrupted after unrelated runtime/socket/daemon failures.

## Review checklist

- Local, remote, and SSH-backed source-control generation use the same timeout resolver.
- Unsupported or missing timeout values fall back to the default.
- Timeout values outside the supported range are clamped before use.
- No release metadata or version files changed.
- X handle: not provided.

## ELI5

Source-control AI (like commit message generation) timeout is configurable via `ORCA_SOURCE_CONTROL_AI_TIMEOUT_MS`, default 60s, clamped between 30 and 300 seconds. Slow models can finish without always hitting the old hard limit.
