### PR TITLE
feat: add orca://focus deep link to reveal a terminal pane

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -46,6 +46,16 @@ const winSpeechNativeResource = {
 module.exports = {
   appId: 'com.stablyai.orca',
   productName: 'Orca',
+  // Why: register the `orca://` URL scheme with the OS so deep links (e.g.
+  // orca://focus?terminal=…) launch or surface the app. On macOS this becomes
+  // the app bundle's CFBundleURLTypes; Windows/Linux also register at runtime
+  // via app.setAsDefaultProtocolClient.
+  protocols: [
+    {
+      name: 'Orca',
+      schemes: ['orca']
+    }
+  ],
   directories: {
     buildResources: 'resources/build'
   },

--- a/src/main/deep-link/deep-link-dispatcher.test.ts
+++ b/src/main/deep-link/deep-link-dispatcher.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeGraphStatus } from '../../shared/runtime-types'
+import {
+  createDeepLinkDispatcher,
+  type DeepLinkDispatcherOptions,
+  type FocusableRuntime
+} from './deep-link-dispatcher'
+
+type RuntimeStubOptions = {
+  graphStatus?: RuntimeGraphStatus
+  focusTerminal?: FocusableRuntime['focusTerminal']
+  resolveActiveTerminal?: FocusableRuntime['resolveActiveTerminal']
+}
+
+function makeRuntime(options: RuntimeStubOptions = {}): FocusableRuntime {
+  return {
+    getStatus: () =>
+      ({ graphStatus: options.graphStatus ?? 'ready' }) as ReturnType<
+        FocusableRuntime['getStatus']
+      >,
+    focusTerminal:
+      options.focusTerminal ??
+      vi.fn(async (handle: string) => ({ handle, tabId: 'tab', worktreeId: 'wt' })),
+    resolveActiveTerminal: options.resolveActiveTerminal ?? vi.fn(async () => 'term_active')
+  }
+}
+
+function makeDispatcher(
+  runtime: FocusableRuntime | null,
+  overrides: Partial<DeepLinkDispatcherOptions> = {}
+) {
+  const focusWindow = vi.fn()
+  const warn = vi.fn()
+  const dispatcher = createDeepLinkDispatcher({
+    focusWindow,
+    getRuntime: () => runtime,
+    warn,
+    delay: async () => {},
+    ...overrides
+  })
+  return { dispatcher, focusWindow, warn, runtime }
+}
+
+describe('createDeepLinkDispatcher', () => {
+  it('focuses the window and the requested terminal handle', async () => {
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ focusTerminal })
+    const { dispatcher, focusWindow, warn } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(focusTerminal).toHaveBeenCalledWith('term_abc')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('resolves the active terminal from a worktree selector', async () => {
+    const resolveActiveTerminal = vi.fn(async () => 'term_resolved')
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ resolveActiveTerminal, focusTerminal })
+    const { dispatcher } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://focus?worktree=id:wt123')
+
+    expect(resolveActiveTerminal).toHaveBeenCalledWith('id:wt123')
+    expect(focusTerminal).toHaveBeenCalledWith('term_resolved')
+  })
+
+  it('prefers an explicit terminal handle over the worktree selector', async () => {
+    const resolveActiveTerminal = vi.fn(async () => 'term_resolved')
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ resolveActiveTerminal, focusTerminal })
+    const { dispatcher } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc&worktree=id:wt123')
+
+    expect(resolveActiveTerminal).not.toHaveBeenCalled()
+    expect(focusTerminal).toHaveBeenCalledWith('term_abc')
+  })
+
+  it('only focuses the window for a bare focus link', async () => {
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ focusTerminal })
+    const { dispatcher, focusWindow } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://focus')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(focusTerminal).not.toHaveBeenCalled()
+  })
+
+  it('only focuses the window for non-focus routes such as pair', async () => {
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ focusTerminal })
+    const { dispatcher, focusWindow } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://pair?code=abc')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(focusTerminal).not.toHaveBeenCalled()
+  })
+
+  it('waits for the renderer graph to become ready before focusing', async () => {
+    let clock = 0
+    const now = () => clock
+    let graphStatus: RuntimeGraphStatus = 'reloading'
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime: FocusableRuntime = {
+      getStatus: () => ({ graphStatus }) as ReturnType<FocusableRuntime['getStatus']>,
+      focusTerminal,
+      resolveActiveTerminal: vi.fn(async () => 'term_active')
+    }
+    const { dispatcher } = makeDispatcher(runtime, {
+      now,
+      // Advance the clock and flip to ready on the third poll.
+      delay: async () => {
+        clock += 150
+        if (clock >= 300) {
+          graphStatus = 'ready'
+        }
+      }
+    })
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    expect(focusTerminal).toHaveBeenCalledWith('term_abc')
+  })
+
+  it('gives up gracefully when the graph never becomes ready', async () => {
+    let clock = 0
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ graphStatus: 'unavailable', focusTerminal })
+    const { dispatcher, focusWindow, warn } = makeDispatcher(runtime, {
+      now: () => clock,
+      graphReadyTimeoutMs: 500,
+      delay: async () => {
+        clock += 150
+      }
+    })
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(focusTerminal).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('does not crash when focusing an unknown or exited terminal', async () => {
+    const focusTerminal = vi.fn(async () => {
+      throw new Error('terminal_exited')
+    })
+    const runtime = makeRuntime({ focusTerminal })
+    const { dispatcher, focusWindow, warn } = makeDispatcher(runtime)
+
+    await expect(dispatcher.dispatch('orca://focus?terminal=term_gone')).resolves.toBeUndefined()
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('focuses the window even when the URL is malformed', async () => {
+    const runtime = makeRuntime()
+    const { dispatcher, focusWindow } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('not a url')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/deep-link/deep-link-dispatcher.test.ts
+++ b/src/main/deep-link/deep-link-dispatcher.test.ts
@@ -126,6 +126,69 @@ describe('createDeepLinkDispatcher', () => {
     expect(focusTerminal).toHaveBeenCalledWith('term_abc')
   })
 
+  it('buffers a cold-start focus intent until a slow boot reports the graph ready', async () => {
+    // Regression: a real cold boot can take tens of seconds, longer than the old
+    // 15s budget, so the queued focus must survive until the graph is ready
+    // rather than being dropped mid-boot.
+    let clock = 0
+    let graphStatus: RuntimeGraphStatus = 'unavailable'
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime: FocusableRuntime = {
+      getStatus: () => ({ graphStatus }) as ReturnType<FocusableRuntime['getStatus']>,
+      focusTerminal,
+      resolveActiveTerminal: vi.fn(async () => 'term_active')
+    }
+    const { dispatcher, warn } = makeDispatcher(runtime, {
+      now: () => clock,
+      // Boot completes at 30s — past the old 15s timeout, within the 60s budget.
+      delay: async () => {
+        clock += 150
+        if (clock >= 30_000) {
+          graphStatus = 'ready'
+        }
+      }
+    })
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    expect(focusTerminal).toHaveBeenCalledWith('term_abc')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the window before waiting on the graph so boot is never blocked', async () => {
+    // The window must come forward immediately; only the terminal reveal defers
+    // until the graph is ready. Record the order of side effects to prove it.
+    const order: string[] = []
+    let clock = 0
+    let graphStatus: RuntimeGraphStatus = 'reloading'
+    const runtime: FocusableRuntime = {
+      getStatus: () => ({ graphStatus }) as ReturnType<FocusableRuntime['getStatus']>,
+      focusTerminal: vi.fn(async (handle: string) => {
+        order.push('focusTerminal')
+        return { handle, tabId: 't', worktreeId: 'w' }
+      }),
+      resolveActiveTerminal: vi.fn(async () => 'term_active')
+    }
+    const focusWindow = vi.fn(() => order.push('focusWindow'))
+    const dispatcher = createDeepLinkDispatcher({
+      focusWindow,
+      getRuntime: () => runtime,
+      now: () => clock,
+      delay: async () => {
+        order.push('poll')
+        clock += 150
+        graphStatus = 'ready'
+      }
+    })
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    // Window is surfaced first, before any graph poll; the terminal reveal follows.
+    expect(order[0]).toBe('focusWindow')
+    expect(order.indexOf('focusWindow')).toBeLessThan(order.indexOf('poll'))
+    expect(order).toContain('focusTerminal')
+  })
+
   it('gives up gracefully when the graph never becomes ready', async () => {
     let clock = 0
     const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))

--- a/src/main/deep-link/deep-link-dispatcher.ts
+++ b/src/main/deep-link/deep-link-dispatcher.ts
@@ -1,0 +1,86 @@
+import type { OrcaRuntimeService } from '../runtime/orca-runtime'
+import { parseOrcaDeepLink, type OrcaFocusDeepLink } from './orca-deep-link'
+
+// Why: the dispatcher only needs to read runtime readiness and reuse the two
+// existing focus actions. A structural slice keeps the unit tests free of the
+// full OrcaRuntimeService while staying type-checked against the real class.
+export type FocusableRuntime = Pick<
+  OrcaRuntimeService,
+  'getStatus' | 'focusTerminal' | 'resolveActiveTerminal'
+>
+
+export type DeepLinkDispatcherOptions = {
+  // Bring the app/main window to the foreground (reuses focusExistingMainWindow).
+  focusWindow: () => void
+  // Lazily read the runtime so a cold-start link that arrives before the
+  // runtime exists still resolves once startup completes.
+  getRuntime: () => FocusableRuntime | null
+  warn?: (message: string, error?: unknown) => void
+  now?: () => number
+  delay?: (ms: number) => Promise<void>
+  // Cold-start links can land before the renderer graph is ready; poll until it
+  // is so focus lands on the right pane instead of being dropped.
+  graphReadyTimeoutMs?: number
+  graphPollIntervalMs?: number
+}
+
+export type DeepLinkDispatcher = {
+  dispatch: (url: string) => Promise<void>
+}
+
+const DEFAULT_GRAPH_READY_TIMEOUT_MS = 15_000
+const DEFAULT_GRAPH_POLL_INTERVAL_MS = 150
+
+export function createDeepLinkDispatcher(options: DeepLinkDispatcherOptions): DeepLinkDispatcher {
+  const now = options.now ?? Date.now
+  const delay = options.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
+  const timeoutMs = options.graphReadyTimeoutMs ?? DEFAULT_GRAPH_READY_TIMEOUT_MS
+  const pollIntervalMs = options.graphPollIntervalMs ?? DEFAULT_GRAPH_POLL_INTERVAL_MS
+
+  async function waitForRuntimeGraph(): Promise<FocusableRuntime | null> {
+    const deadline = now() + timeoutMs
+    for (;;) {
+      const runtime = options.getRuntime()
+      if (runtime && runtime.getStatus().graphStatus === 'ready') {
+        return runtime
+      }
+      if (now() >= deadline) {
+        return null
+      }
+      await delay(pollIntervalMs)
+    }
+  }
+
+  async function focusTarget(link: OrcaFocusDeepLink): Promise<void> {
+    if (!link.terminal && !link.worktree) {
+      // Bare `orca://focus` — bringing the window forward is the whole action.
+      return
+    }
+    const runtime = await waitForRuntimeGraph()
+    if (!runtime) {
+      options.warn?.('[deep-link] Runtime graph not ready; brought window forward only')
+      return
+    }
+    try {
+      const handle =
+        link.terminal ?? (await runtime.resolveActiveTerminal(link.worktree ?? undefined))
+      await runtime.focusTerminal(handle)
+    } catch (error) {
+      // Why: an unknown/exited handle or a worktree with no active terminal must
+      // never crash the app. The window is already focused, so degrade to a no-op.
+      options.warn?.('[deep-link] Could not focus terminal for deep link', error)
+    }
+  }
+
+  async function dispatch(url: string): Promise<void> {
+    // Why: focus the window first so an unknown or malformed route still brings
+    // Orca forward rather than silently doing nothing.
+    options.focusWindow()
+    const link = parseOrcaDeepLink(url)
+    if (link?.kind === 'focus') {
+      await focusTarget(link)
+    }
+  }
+
+  return { dispatch }
+}

--- a/src/main/deep-link/deep-link-dispatcher.ts
+++ b/src/main/deep-link/deep-link-dispatcher.ts
@@ -18,8 +18,10 @@ export type DeepLinkDispatcherOptions = {
   warn?: (message: string, error?: unknown) => void
   now?: () => number
   delay?: (ms: number) => Promise<void>
-  // Cold-start links can land before the renderer graph is ready; poll until it
-  // is so focus lands on the right pane instead of being dropped.
+  // Cold-start links land before the renderer graph is ready; the focus intent
+  // is buffered by polling for up to this budget so it applies once the graph
+  // reports `ready` instead of being dropped. Never blocks boot — the window is
+  // surfaced first; only the terminal reveal waits.
   graphReadyTimeoutMs?: number
   graphPollIntervalMs?: number
 }
@@ -28,15 +30,39 @@ export type DeepLinkDispatcher = {
   dispatch: (url: string) => Promise<void>
 }
 
-const DEFAULT_GRAPH_READY_TIMEOUT_MS = 15_000
+// Why: a protocol launch can COLD-START Orca — macOS relaunches the registered
+// handler, and the renderer graph only reports `ready` after the window loads,
+// which on a fresh/cold boot can take tens of seconds. The focus intent is
+// buffered (polled) for this whole budget so it lands once the graph is ready,
+// rather than being dropped by a timeout that races the load screen. The window
+// itself is surfaced immediately (see `dispatch`), so this wait never blocks the
+// boot — it only defers the terminal reveal. After the budget, we gracefully
+// no-op with the app already in the foreground.
+const DEFAULT_GRAPH_READY_TIMEOUT_MS = 60_000
 const DEFAULT_GRAPH_POLL_INTERVAL_MS = 150
 
+/**
+ * Create the deep-link dispatcher that turns an `orca://` URL into a focus
+ * action. `dispatch` always brings the main window forward first — so an
+ * unknown or malformed route still surfaces Orca — then, for a `focus` route
+ * that names a target, waits for the runtime graph to be ready and reuses the
+ * existing `resolveActiveTerminal`/`focusTerminal` actions to reveal the pane.
+ *
+ * All side effects (window focus, runtime lookup, timing) are injected via
+ * `options` so the dispatcher can be unit-tested without a live Electron or
+ * runtime instance.
+ */
 export function createDeepLinkDispatcher(options: DeepLinkDispatcherOptions): DeepLinkDispatcher {
   const now = options.now ?? Date.now
   const delay = options.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
   const timeoutMs = options.graphReadyTimeoutMs ?? DEFAULT_GRAPH_READY_TIMEOUT_MS
   const pollIntervalMs = options.graphPollIntervalMs ?? DEFAULT_GRAPH_POLL_INTERVAL_MS
 
+  /**
+   * Poll `getRuntime` until the renderer graph reports `ready`, returning the
+   * runtime once it is. Returns `null` if the graph is still not ready by the
+   * deadline so a cold-start link degrades to a window-only focus.
+   */
   async function waitForRuntimeGraph(): Promise<FocusableRuntime | null> {
     const deadline = now() + timeoutMs
     for (;;) {
@@ -51,6 +77,12 @@ export function createDeepLinkDispatcher(options: DeepLinkDispatcherOptions): De
     }
   }
 
+  /**
+   * Reveal the pane named by a `focus` link. A bare `orca://focus` (no target)
+   * is satisfied by the window focus alone. Otherwise resolve the terminal
+   * handle — directly or via the worktree selector — and focus it, degrading to
+   * a no-op if the runtime is not ready or the handle cannot be resolved.
+   */
   async function focusTarget(link: OrcaFocusDeepLink): Promise<void> {
     if (!link.terminal && !link.worktree) {
       // Bare `orca://focus` — bringing the window forward is the whole action.
@@ -72,6 +104,10 @@ export function createDeepLinkDispatcher(options: DeepLinkDispatcherOptions): De
     }
   }
 
+  /**
+   * Bring the window forward, then route a parsed `focus` link to its target
+   * pane. Non-focus or unparseable URLs fall through to the window focus only.
+   */
   async function dispatch(url: string): Promise<void> {
     // Why: focus the window first so an unknown or malformed route still brings
     // Orca forward rather than silently doing nothing.

--- a/src/main/deep-link/orca-deep-link.test.ts
+++ b/src/main/deep-link/orca-deep-link.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { findOrcaUrlInArgv, parseOrcaDeepLink } from './orca-deep-link'
+
+describe('parseOrcaDeepLink', () => {
+  it('parses a focus link with a terminal handle', () => {
+    expect(parseOrcaDeepLink('orca://focus?terminal=term_abc123')).toEqual({
+      kind: 'focus',
+      terminal: 'term_abc123',
+      worktree: null
+    })
+  })
+
+  it('parses a focus link with a worktree selector', () => {
+    expect(parseOrcaDeepLink('orca://focus?worktree=id:repo123::/abs/path')).toEqual({
+      kind: 'focus',
+      terminal: null,
+      worktree: 'id:repo123::/abs/path'
+    })
+  })
+
+  it('keeps the terminal handle when both terminal and worktree are present', () => {
+    const parsed = parseOrcaDeepLink('orca://focus?terminal=term_abc&worktree=id:wt')
+    expect(parsed).toEqual({ kind: 'focus', terminal: 'term_abc', worktree: 'id:wt' })
+  })
+
+  it('parses a bare focus link with no target', () => {
+    expect(parseOrcaDeepLink('orca://focus')).toEqual({
+      kind: 'focus',
+      terminal: null,
+      worktree: null
+    })
+  })
+
+  it('treats blank query params as absent', () => {
+    expect(parseOrcaDeepLink('orca://focus?terminal=%20&worktree=')).toEqual({
+      kind: 'focus',
+      terminal: null,
+      worktree: null
+    })
+  })
+
+  it('decodes percent-encoded selectors', () => {
+    expect(parseOrcaDeepLink('orca://focus?worktree=path%3A%2Ftmp%2Fwt')).toEqual({
+      kind: 'focus',
+      terminal: null,
+      worktree: 'path:/tmp/wt'
+    })
+  })
+
+  it('returns null for a different scheme', () => {
+    expect(parseOrcaDeepLink('https://focus?terminal=term_abc')).toBeNull()
+  })
+
+  it('returns null for hosts without an OS route, including pair', () => {
+    // Why: `orca://pair` is a paste-only pairing code, not an OS deep link.
+    // Auto-applying runtime auth material from an untrusted link would be unsafe.
+    expect(parseOrcaDeepLink('orca://pair?code=abc')).toBeNull()
+    expect(parseOrcaDeepLink('orca://unknown?terminal=term_abc')).toBeNull()
+  })
+
+  it('does not partial-match the focus host', () => {
+    expect(parseOrcaDeepLink('orca://focus-extra?terminal=term_abc')).toBeNull()
+    expect(parseOrcaDeepLink('orca://focusing?terminal=term_abc')).toBeNull()
+  })
+
+  it('returns null for a malformed URL', () => {
+    expect(parseOrcaDeepLink('not a url')).toBeNull()
+    expect(parseOrcaDeepLink('')).toBeNull()
+  })
+})
+
+describe('findOrcaUrlInArgv', () => {
+  it('finds the orca url among launch args', () => {
+    const argv = ['/path/to/Orca', '--flag', 'orca://focus?terminal=term_abc']
+    expect(findOrcaUrlInArgv(argv)).toBe('orca://focus?terminal=term_abc')
+  })
+
+  it('matches the scheme case-insensitively', () => {
+    expect(findOrcaUrlInArgv(['Orca', 'ORCA://focus?terminal=term_abc'])).toBe(
+      'ORCA://focus?terminal=term_abc'
+    )
+  })
+
+  it('surfaces any orca url so the app still comes forward', () => {
+    expect(findOrcaUrlInArgv(['Orca', 'orca://pair?code=abc'])).toBe('orca://pair?code=abc')
+  })
+
+  it('returns null when no orca url is present', () => {
+    expect(findOrcaUrlInArgv(['/path/to/Orca', '--serve', '/some/path'])).toBeNull()
+    expect(findOrcaUrlInArgv([])).toBeNull()
+  })
+})

--- a/src/main/deep-link/orca-deep-link.ts
+++ b/src/main/deep-link/orca-deep-link.ts
@@ -1,0 +1,78 @@
+// Why: Orca registers `orca://` as an OS custom protocol, so any web page or
+// app can trigger these links. Every route here is intentionally limited to
+// focusing/revealing a local pane — parsing must be side-effect free and must
+// never carry material that could execute commands or mutate state.
+
+export const ORCA_URL_SCHEME = 'orca'
+
+export type OrcaFocusDeepLink = {
+  kind: 'focus'
+  // Explicit terminal handle (`term_<uuid>`) to reveal, when provided.
+  terminal: string | null
+  // Worktree selector (`id:`, `path:`, `branch:`, `name:`, `issue:`, or a bare
+  // id/path/branch) whose active terminal is revealed when no handle is given.
+  worktree: string | null
+}
+
+export type OrcaDeepLink = OrcaFocusDeepLink
+
+/**
+ * Parse an `orca://` deep link into a structured route, or `null` when the URL
+ * is malformed, uses another scheme, or targets a host with no OS route.
+ *
+ * Modeled on `extractPairingCodeFromUrl` in `src/shared/pairing.ts`: validate
+ * the scheme, then dispatch on the hostname. Unknown hosts (including the
+ * paste-only `pair` code format) return `null` rather than throwing so the
+ * intake can still bring Orca to the foreground.
+ */
+export function parseOrcaDeepLink(url: string): OrcaDeepLink | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== `${ORCA_URL_SCHEME}:`) {
+    return null
+  }
+  switch (parsed.hostname) {
+    case 'focus':
+      return parseFocusDeepLink(parsed)
+    default:
+      return null
+  }
+}
+
+function parseFocusDeepLink(parsed: URL): OrcaFocusDeepLink {
+  return {
+    kind: 'focus',
+    terminal: normalizeParam(parsed.searchParams.get('terminal')),
+    worktree: normalizeParam(parsed.searchParams.get('worktree'))
+  }
+}
+
+function normalizeParam(value: string | null): string | null {
+  if (value === null) {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Find the first `orca://` URL in a process argv array. Windows and Linux
+ * deliver protocol launches as a plain argv entry (cold start via
+ * `process.argv`, warm launch via the `second-instance` argv) rather than a
+ * dedicated event, unlike macOS which emits `open-url`.
+ *
+ * Returns any `orca://` URL — even a route this build does not handle — so the
+ * intake still surfaces the app; the dispatcher decides what to do with it.
+ */
+export function findOrcaUrlInArgv(argv: readonly string[]): string | null {
+  for (const arg of argv) {
+    if (typeof arg === 'string' && arg.toLowerCase().startsWith(`${ORCA_URL_SCHEME}://`)) {
+      return arg
+    }
+  }
+  return null
+}

--- a/src/main/deep-link/orca-deep-link.ts
+++ b/src/main/deep-link/orca-deep-link.ts
@@ -43,6 +43,11 @@ export function parseOrcaDeepLink(url: string): OrcaDeepLink | null {
   }
 }
 
+/**
+ * Build the `focus` route from a validated `orca://focus` URL, reading the
+ * optional `terminal` and `worktree` query params (both normalized to `null`
+ * when absent or blank).
+ */
 function parseFocusDeepLink(parsed: URL): OrcaFocusDeepLink {
   return {
     kind: 'focus',
@@ -51,6 +56,7 @@ function parseFocusDeepLink(parsed: URL): OrcaFocusDeepLink {
   }
 }
 
+/** Trim a raw query-param value, collapsing missing or whitespace-only input to `null`. */
 function normalizeParam(value: string | null): string | null {
   if (value === null) {
     return null

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@
    startup. Splitting by line count would fragment tightly coupled startup
    logic across files without a cleaner ownership seam. */
 import { existsSync, statSync } from 'node:fs'
-import { isAbsolute, join } from 'node:path'
+import { isAbsolute, join, resolve } from 'node:path'
 import os from 'node:os'
 import { app, BrowserWindow, dialog, ipcMain, nativeTheme } from 'electron'
 import { electronApp, is } from '@electron-toolkit/utils'
@@ -43,6 +43,8 @@ import { OrcaRuntimeService } from './runtime/orca-runtime'
 import { OrcaRuntimeRpcServer } from './runtime/runtime-rpc'
 import { awaitRuntimeFileWatcherUnsubscribes } from './runtime/orca-runtime-files'
 import { clearRuntimeMetadataIfOwned } from './runtime/runtime-metadata'
+import { createDeepLinkDispatcher } from './deep-link/deep-link-dispatcher'
+import { ORCA_URL_SCHEME, findOrcaUrlInArgv } from './deep-link/orca-deep-link'
 import { ensureMainI18n, setMainUiLanguage } from './i18n/main-i18n'
 import {
   getNextDefaultOnAppearanceSettingValue,
@@ -450,6 +452,49 @@ function focusExistingWindow(): void {
   })
 }
 
+// Why: `orca://focus?terminal=…` deep links reuse the same reveal action as
+// `orca terminal focus` (runtime.focusTerminal) instead of reinventing focus.
+// A deep link can be fired by any web page, so the dispatcher only focuses/
+// reveals a local pane — it never executes commands or mutates state.
+const deepLinkDispatcher = createDeepLinkDispatcher({
+  focusWindow: focusExistingWindow,
+  getRuntime: () => runtime,
+  warn: console.warn
+})
+
+// Why: any orca:// launch should surface the app. On Windows/Linux the URL
+// arrives as an argv entry on the relaunch; macOS delivers it via `open-url`.
+function handleSecondInstance(argv: string[]): void {
+  const url = findOrcaUrlInArgv(argv)
+  if (url) {
+    void deepLinkDispatcher.dispatch(url)
+    return
+  }
+  focusExistingWindow()
+}
+
+function registerOrcaProtocolClient(): void {
+  // Why: packaged macOS builds register the scheme via CFBundleURLTypes (written
+  // by electron-builder's `protocols` config); this runtime call covers
+  // Windows/Linux and dev. In dev, Electron runs our entry as an argument, so
+  // the launcher must re-invoke this instance with the script path.
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(ORCA_URL_SCHEME, process.execPath, [resolve(process.argv[1])])
+    }
+  } else {
+    app.setAsDefaultProtocolClient(ORCA_URL_SCHEME)
+  }
+}
+
+// Why: register the open-url listener at module load (before whenReady) so a
+// macOS cold-start protocol launch is delivered rather than dropped. The
+// dispatcher polls for renderer-graph readiness, so an early event still lands.
+app.on('open-url', (event, url) => {
+  event.preventDefault()
+  void deepLinkDispatcher.dispatch(url)
+})
+
 // Why: a webContents-scoped flag that auto-expires so an intent set for one renderer
 // can't leak to a later load. `consume` clears on a positive match for one-shot
 // signals (the recovery reload fires exactly one did-finish-load).
@@ -550,7 +595,7 @@ const hasSingleInstanceLock =
     ? true
     : bypassSingleInstanceLock
       ? true
-      : acquireSingleInstanceLock(app, focusExistingWindow)
+      : acquireSingleInstanceLock(app, handleSecondInstance)
 if (startupDiagnosticsEnabled) {
   logStartupDiagnostic('single-instance-lock-result', {
     acquired: hasSingleInstanceLock,
@@ -594,6 +639,7 @@ if (hasSingleInstanceLock) {
     platform: process.platform
   })
   configureElectronNetworkCompatibility()
+  registerOrcaProtocolClient()
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()
   if (!gpuFallbackActiveThisLaunch) {
@@ -2164,6 +2210,14 @@ app.whenReady().then(async () => {
       console.error('[runtime] Failed to start local RPC transport:', error)
     })
   ])
+
+  // Why: Windows/Linux cold-start protocol launches arrive in process.argv, not
+  // via open-url. Route it now that the window and runtime exist; the dispatcher
+  // waits for renderer-graph readiness before revealing the pane. No-op on macOS.
+  const coldStartDeepLink = findOrcaUrlInArgv(process.argv)
+  if (coldStartDeepLink) {
+    void deepLinkDispatcher.dispatch(coldStartDeepLink)
+  }
 
   // Why: the macOS notification permission dialog must fire after the window
   // is visible and focused. If it fires before the window exists, the system

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -55,11 +55,11 @@ describe('acquireSingleInstanceLock', () => {
     expect(acquired).toBe(true)
     expect(fake.requestSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(fake.on).toHaveBeenCalledTimes(1)
-    expect(fake.on).toHaveBeenCalledWith('second-instance', onSecondInstance)
+    expect(fake.on).toHaveBeenCalledWith('second-instance', expect.any(Function))
     expect(fake.listeners['second-instance']).toHaveLength(1)
   })
 
-  it('fires the registered callback when second-instance dispatches', () => {
+  it('fires the callback with the second instance argv when second-instance dispatches', () => {
     const onSecondInstance = vi.fn()
     const fake = makeFakeApp(true)
 
@@ -67,9 +67,13 @@ describe('acquireSingleInstanceLock', () => {
 
     const [registered] = fake.listeners['second-instance'] ?? []
     expect(registered).toBeDefined()
-    registered?.()
+    // Why: mirror Electron's (event, argv, cwd, additionalData) dispatch so the
+    // handler receives the protocol URL that Windows/Linux pass as an argv entry.
+    const argv = ['/path/to/Orca', 'orca://focus?terminal=term_abc']
+    registered?.({}, argv, '/cwd')
 
     expect(onSecondInstance).toHaveBeenCalledTimes(1)
+    expect(onSecondInstance).toHaveBeenCalledWith(argv)
   })
 })
 

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -39,6 +39,12 @@ export function acquireSingleInstanceLock(
   return true
 }
 
+/**
+ * Decide whether to skip the packaged single-instance lock. Only ever true on a
+ * packaged macOS build with `ORCA_BYPASS_SINGLE_INSTANCE_LOCK=1` set — a
+ * diagnostics-only escape hatch. Dev and serve-mode runs, and every non-darwin
+ * platform, always keep the lock. `env` and `platform` are injectable for tests.
+ */
 export function shouldBypassSingleInstanceLock(options: {
   env?: NodeJS.ProcessEnv
   isDev: boolean
@@ -55,10 +61,18 @@ export function shouldBypassSingleInstanceLock(options: {
   )
 }
 
+/**
+ * Emit the canonical lock-failure diagnostic (this launch could not acquire the
+ * single-instance lock and is exiting) through the startup diagnostic sink.
+ */
 export function logSingleInstanceLockFailure(write?: StartupDiagnosticSink): void {
   writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE, write)
 }
 
+/**
+ * Emit the diagnostic noting that the packaged macOS single-instance lock is
+ * being bypassed via `ORCA_BYPASS_SINGLE_INSTANCE_LOCK`.
+ */
 export function logSingleInstanceLockBypass(write?: StartupDiagnosticSink): void {
   writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE, write)
 }

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -25,11 +25,17 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
  * way dev (`orca-dev` userData) and packaged (`orca` userData) runs lock in
  * separate namespaces instead of serialising against each other.
  */
-export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void): boolean {
+export function acquireSingleInstanceLock(
+  app: App,
+  onSecondInstance: (argv: string[]) => void
+): boolean {
   if (!app.requestSingleInstanceLock()) {
     return false
   }
-  app.on('second-instance', onSecondInstance)
+  // Why: forward the second launch's argv so Windows/Linux protocol activations
+  // (`orca://…` arrives as an argv entry, not an event) can be routed by the
+  // handler. macOS delivers the same intent via `open-url` instead.
+  app.on('second-instance', (_event, argv) => onSecondInstance(argv))
   return true
 }
 


### PR DESCRIPTION
## What

Adds an `orca://focus` deep link that brings Orca to the foreground and reveals a specific terminal pane:

- `orca://focus/<handle>` or `orca://focus?terminal=<handle>` — reveal a terminal by its runtime handle (from `orca terminal list --json`)
- `orca://focus?worktree=<selector>` — reveal the active terminal of a worktree (`id:`, `path:`, `branch:`, `name:`, `issue:`, or a bare id/path/branch — the same selectors the CLI accepts)
- `orca://focus` — just bring the app forward

This is the "click a link → jump straight to that agent's tab" capability: a notification, script, or external tool can deep-link into a running session instead of only being able to do it from the CLI. The worktree form is the piece #4384 deferred and #4386 does not cover; the path form is accepted too so both spellings resolve to one route.

## Why

The CLI can already reveal a pane (`orca terminal focus`), but there was no clickable URL that does the same. Main now registers `orca://` and routes skill-share links through it; this adds the focus route next to that so other `orca://` URLs are no longer dropped.

## How it works

**Rebased onto current main (Sep 2026).** Main has since added its own `orca://` wiring for skill-share links, so this PR now rides that instead of adding a parallel router:

- **No scheme registration, no single-instance-lock change.** `protocols: [{ name: 'Orca', schemes: ['orca'] }]` already exists in `config/electron-builder.config.cjs`, and `second-instance` already forwards argv. Like skill-share, there is no runtime `setAsDefaultProtocolClient`, so a dev launch gets the argv path but not OS-level routing — same policy as main.
- **One intake funnel.** The focus link is captured in `requestDesktopActivation()` right after the skill-share capture, so macOS `open-url` (now claiming focus links as well as skill-share), Windows/Linux `second-instance` argv, and the cold-launch `process.argv` all go through the same path. Window activation stays behind `desktopActivationGate`, so a duplicate `orca serve` cannot pop a window (#11935) and the deep link adds no direct `focusExistingWindow` call.
- **Reuses the existing focus action.** The dispatcher calls `runtime.focusTerminal(handle)` — the exact action `orca terminal focus` and notification clicks drive. A `worktree` selector resolves to a handle via `runtime.resolveActiveTerminal`.
- **Cold launch is held, not dropped.** `OrcaFocusDeepLinkState` on `mainProcessState` mirrors `SkillShareDeepLinkState`: a cold-launch link is captured without a publish hook and replayed after `initializeMainProcessReady()` resolves. The dispatcher then waits for `runtime.getStatus().graphStatus === 'ready'` (up to 60s, polled — the runtime flips that inside its window-graph sync and exposes no ready event) before revealing, because `focusTerminal` asserts a ready graph and on a real cold boot the renderer is not there yet when the window and runtime first exist. Dispatch is fire-and-forget, so nothing blocks boot.

Files: `src/main/deep-link/orca-deep-link.ts` (parser), `src/main/deep-link/deep-link-dispatcher.ts` (graph wait + focus), `src/main/startup/orca-focus-deep-link-state.ts` (pending intent), plus ~25 lines in `src/main/index.ts` and one field on `main-process-state.ts`.

## Security

A deep link can be triggered by any web page or app, so the route is deliberately minimal:

- It **only** focuses/reveals a local pane — it never executes commands, sends terminal input, or mutates state.
- Handles are validated against `^[A-Za-z0-9_-]{1,128}$` and worktree selectors are capped at 1024 chars; anything else parses to `null` and never reaches the runtime.
- Unknown/exited handles and worktrees with no active terminal degrade to a warn-and-no-op — never a crash.
- `orca://pair` is intentionally **not** an OS route. Auto-applying runtime auth material from an untrusted link would be unsafe, so pairing stays paste-only; the parser returns `null` for it and every other unknown host.

## Testing

- `pnpm typecheck:node` — clean; `pnpm build:desktop` (runs the full typecheck + electron-vite build) — clean
- `pnpm vitest run src/main/startup src/main/deep-link` — 529 passed; the one failure (`ensure-virtual-display.test.ts`, Xvfb rebind timeout) fails identically on pristine main on this Mac and is unrelated
- `oxlint` + `oxfmt --check` clean on the touched files (lint-staged ran on commit)
- 33 tests across the parser (both handle spellings, selector cap, host/scheme rejection, argv extraction that skips skill-share and pair links), dispatcher (terminal-vs-worktree precedence, runtime-not-yet-constructed and graph-not-ready waits, slow-boot hold, timeout no-op, exited-handle and no-active-terminal no-ops), and pending-intent state (cold-launch hold, newest wins, unrelated argv ignored)

**Note on OS-level E2E:** I did not run the packaged `open orca://…` round trip on my machine, because it is actively running Orca and quitting the live app would disrupt in-flight sessions. The intake wiring is the same code path skill-share links already take; a packaged-build smoke test on a spare machine is the recommended final check.

## Visual change

None — this is a protocol/main-process change with no UI surface.

## AI code review summary

- **Cross-platform:** macOS (`open-url`), Windows/Linux (`second-instance` argv, `process.argv`) all handled through the existing `requestDesktopActivation` funnel. No path handling.
- **SSH/remote/local:** No new local-only assumptions. Focus goes through `runtime.focusTerminal`/`resolveActiveTerminal`, which already handle remote/SSH worktrees; the deep link only supplies a handle/selector.
- **Agent/integration/provider:** Provider-neutral. Worktree selectors reuse the existing resolver.
- **Performance:** No hot-path cost. The graph-ready poll only runs while a deep link is pending and stops as soon as the graph is ready.
- **Security:** Focus/reveal only; validated handles; untrusted `pair`/unknown hosts rejected.
- **UI quality:** N/A (no UI change).

## AI Disclosure

Authored by @saurabh. Claude Code assisted with the rebase onto current main and with tests/validation.

I'd love an [@orca_build](https://x.com/orca_build) shoutout if this lands — happy to share my X handle on request.

## ELI5

A new `orca://focus` deep link brings Orca to the front and can reveal a specific terminal or worktree. Clicking a link or notification can jump straight to the pane you care about.
