### PR TITLE
Move macOS notification helper to Contents/MacOS to prevent crash

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -159,7 +159,7 @@ module.exports = {
     if (context.electronPlatformName === 'darwin') {
       await signMacComputerUseHelper(join(resourcesDir, 'Orca Computer Use.app'), context.packager)
       await signMacNotificationStatusHelper(
-        join(resourcesDir, 'orca-notification-status'),
+        join(resourcesDir, '..', 'MacOS', 'orca-notification-status'),
         context.packager
       )
     }
@@ -251,11 +251,16 @@ module.exports = {
         from: 'native/computer-use-macos/.build/release/Orca Computer Use.app',
         to: 'Orca Computer Use.app'
       },
+      featureWallResources
+    ],
+    // Why: the notification-status helper must execute from Contents/MacOS —
+    // on macOS 26 UNUserNotificationCenter aborts (bundleProxyForCurrentProcess
+    // is nil) for executables launched out of Contents/Resources (#7929).
+    extraFiles: [
       {
         from: 'native/notification-status-macos/.build/release/orca-notification-status',
-        to: 'orca-notification-status'
-      },
-      featureWallResources
+        to: 'MacOS/orca-notification-status'
+      }
     ],
     target: [
       {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -63,6 +63,22 @@ describe('electron-builder config', () => {
     )
   })
 
+  // Why: on macOS 26 UNUserNotificationCenter aborts for executables launched
+  // from Contents/Resources, so the helper must ship in Contents/MacOS (#7929).
+  it('ships the mac notification-status helper in Contents/MacOS, not Resources', () => {
+    expect(electronBuilderConfig.mac.extraFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'native/notification-status-macos/.build/release/orca-notification-status',
+          to: 'MacOS/orca-notification-status'
+        })
+      ])
+    )
+    expect(electronBuilderConfig.mac.extraResources).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ to: 'orca-notification-status' })])
+    )
+  })
+
   it('unpacks the compiled CommonJS boundary with CLI runtime files', () => {
     expect(electronBuilderConfig.asarUnpack).toEqual(
       expect.arrayContaining(['out/package.json', 'out/cli/**', 'out/shared/**'])

--- a/src/main/ipc/notification-authorization-status.ts
+++ b/src/main/ipc/notification-authorization-status.ts
@@ -12,10 +12,11 @@ let cachedHelperPath: string | null | undefined
 /**
  * Resolves the bundled notification-status helper binary.
  *
- * Why: the helper must live inside the app bundle — NSBundle resolves the
- * process's bundle by walking up from the executable path, and macOS keys
- * notification records to that identity. Both dev copies and packaged builds
- * place it next to the Electron executable in Contents/MacOS.
+ * Why: the helper must live in Contents/MacOS next to the Electron executable
+ * — NSBundle resolves the process's bundle by walking up from the executable
+ * path, macOS keys notification records to that identity, and macOS 26 aborts
+ * UNUserNotificationCenter for executables run from Contents/Resources
+ * (#7929). Dev copies and packaged builds (extraFiles) both place it there.
  */
 function resolveHelperPath(): string | null {
   if (cachedHelperPath !== undefined) {
@@ -25,14 +26,8 @@ function resolveHelperPath(): string | null {
     cachedHelperPath = null
     return cachedHelperPath
   }
-  // Dev copies place the helper next to the Electron executable; packaged
-  // builds ship it via extraResources. Both are inside the .app, which is
-  // what NSBundle resolution requires.
-  const candidates = [
-    join(dirname(process.execPath), HELPER_EXECUTABLE),
-    ...(process.resourcesPath ? [join(process.resourcesPath, HELPER_EXECUTABLE)] : [])
-  ]
-  cachedHelperPath = candidates.find((candidate) => existsSync(candidate)) ?? null
+  const candidate = join(dirname(process.execPath), HELPER_EXECUTABLE)
+  cachedHelperPath = existsSync(candidate) ? candidate : null
   return cachedHelperPath
 }
 


### PR DESCRIPTION
## Summary

Moves the notification status helper (`orca-notification-status`) from `Contents/Resources` to `Contents/MacOS` in the macOS app bundle. On macOS 26, `UNUserNotificationCenter` aborts (since `bundleProxyForCurrentProcess` is nil) if the executable is launched from `Contents/Resources` (#7929).

This also simplifies the path resolution in `resolveHelperPath` as both development and production builds now place the helper next to the Electron executable in `Contents/MacOS`.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Updated `config/scripts/electron-builder-config.test.mjs` with a new test `ships the mac notification-status helper in Contents/MacOS, not Resources` to verify the configuration correctness.

## AI Review Report

Reviewed the file path adjustments and macOS bundle requirements. Verified that placing `orca-notification-status` helper next to the main Electron executable in `Contents/MacOS` satisfies macOS security and bundle requirements. Verified macOS cross-platform compatibility aspect: this helper code is exclusive to macOS and has no side effects on other platforms.

## Security Audit

Verified that helper code signing path is correctly adjusted to the new `Contents/MacOS` location. The helper path resolution is restricted to the directory of the running executable using `process.execPath`. No new input handling, command execution vulnerabilities, or secrets are introduced.

## Notes

This addresses a critical macOS 26 regression (#7929) where the helper crashed immediately upon launch due to a strict security verification behavior of `UNUserNotificationCenter` in Apple's frameworks.