### PR TITLE
Fix iOS native keyboard dictation in mobile terminal inputs

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -5061,9 +5061,10 @@ export default function SessionScreen() {
                       }
                       style={styles.textInput}
                       value={input}
-                      onChangeText={(text) =>
-                        setInput((previousText) => normalizeTerminalTextInput(text, previousText))
-                      }
+                      // Why: iOS kills an active dictation/IME session when JS
+                      // writes a value that differs from the native field text;
+                      // store the raw field text and normalize at send time.
+                      onChangeText={setInput}
                       placeholder="Type a command…"
                       placeholderTextColor={colors.textMuted}
                       autoCapitalize="none"

--- a/mobile/src/terminal/terminal-ios-dictation-write-back.test.ts
+++ b/mobile/src/terminal/terminal-ios-dictation-write-back.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const sessionRouteSource = readFileSync(
+  new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
+  'utf8'
+)
+
+// Why: iOS terminates an active keyboard-dictation (and IME) session whenever
+// JS writes a value into the focused field that differs from the native text
+// (RN applies it via setTextAndSelection / _setAttributedString). Terminal
+// inputs therefore must echo the raw field text in their controlled value and
+// apply dash normalization only on the send/mirror path. See stablyai/orca#7925.
+describe('terminal iOS dictation write-back', () => {
+  it('does not write normalized text back into the buffered command input value', () => {
+    expect(sessionRouteSource).toContain('onChangeText={setInput}')
+    expect(sessionRouteSource).not.toContain(
+      'setInput((previousText) => normalizeTerminalTextInput'
+    )
+  })
+
+  it('still normalizes the buffered command text at send time', () => {
+    expect(sessionRouteSource).toContain('normalizeTerminalTextInput(input)')
+  })
+})

--- a/mobile/src/terminal/use-terminal-live-input-commit.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.test.ts
@@ -202,6 +202,32 @@ describe('terminal live input commit hook', () => {
     await vi.waitFor(() => expect(sent).toEqual(['a', 'b']))
   })
 
+  it('Given iOS smart-dash text When the change arrives Then the capture echoes the raw field text and the PTY gets normalized bytes', async () => {
+    // Given
+    const { captures, handlers, sent } = createTerminalLiveInputCommitHarness()
+
+    // When: iOS smart punctuation rewrote "--" into an en dash inside the field
+    handlers.handleLiveInputChange('a–')
+
+    // Then: writing "a--" back into the controlled value would kill an active
+    // iOS dictation/IME session, so the capture must keep what iOS produced
+    expect(captures).toEqual(['a–'])
+    await vi.waitFor(() => expect(sent).toEqual(['a--']))
+  })
+
+  it('Given dictation-style hypothesis revisions When changes arrive Then the field is never rewritten and the PTY converges', async () => {
+    // Given
+    const { captures, handlers, sent } = createTerminalLiveInputCommitHarness()
+
+    // When: iOS dictation replaces its hypothesis as recognition refines
+    handlers.handleLiveInputChange('high')
+    handlers.handleLiveInputChange('hi there')
+
+    // Then: captures only echo the field; the mirror repairs the PTY with DELs
+    expect(captures).toEqual(['high', 'hi there'])
+    await vi.waitFor(() => expect(sent).toEqual(['high', '\x7f\x7f there']))
+  })
+
   it('Given a trailing space after Hangul When the change arrives Then the space commits the held syllable', async () => {
     // Given
     const { handlers, sent } = createTerminalLiveInputCommitHarness()

--- a/mobile/src/terminal/use-terminal-live-input-commit.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.ts
@@ -109,9 +109,11 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
         clearPendingLiveInputCommit()
         return
       }
-      const normalizedText = normalizeTerminalTextInput(text)
-      setLiveInputCapture(normalizedText)
-      applyLiveInputMirror(activeHandle, normalizedText)
+      // Why: iOS kills an active dictation/IME session when JS writes a value
+      // that differs from the native field text, so the controlled capture must
+      // echo the field verbatim; only the PTY mirror sees normalized text.
+      setLiveInputCapture(text)
+      applyLiveInputMirror(activeHandle, normalizeTerminalTextInput(text))
     },
     [
       activeHandle,


### PR DESCRIPTION
## Problem

Reported in a comment on stablyai/orca#7925 (separate from the sherpa-onnx SIGTRAP crash that issue tracks): the microphone button on the standard Apple keyboard is unusable in the Orca iOS app. Tapping it dismisses dictation immediately, so Apple's built-in speech-to-text can never be used and the bundled sherpa-onnx recognizer is the only voice path.

## Root cause

iOS terminates an active keyboard-dictation session whenever the app programmatically writes text into the focused field that differs from the current native text. React Native's own Fabric implementation documents this (`RCTTextInputComponentView.mm`): *"When the dictation is running we can't update the attributed text on the backed up text view because setting the attributed string will kill the dictation."* During dictation RN falls back to bare string comparison, so equal-string echoes are safe — but any divergent JS value lands via `setTextAndSelection` / `_setAttributedString` and kills the session. The same mechanism disrupts IME composition (facebook/react-native#18890, #37991, #56463).

Both terminal inputs violated this:

- **Live (direct) input** — the default mode: `handleLiveInputChange` ran `normalizeTerminalTextInput` (en/em dash → `--`) and stored the *normalized* text into the controlled `value`. Any smart-punctuation dash in the field, or any dictation output containing a dash, made the JS value diverge from the native text → RN wrote back → dictation died. Dictation hypothesis revisions widen the window: each revision replaces already-inserted text, so a single stale divergent write (e.g. a rejected write-back from a stale `mostRecentEventCount` during fast typing) kills the session on the first spoken word.
- **Buffered command input**: `onChangeText` stored `normalizeTerminalTextInput(text, previousText)` into the controlled `value` — same divergent write-back on every smart-dash rewrite.

## Fix

Echo the raw native field text in the controlled `value` and apply dash normalization only where the text leaves the field:

- Live input: capture state keeps the verbatim field text; the PTY mirror (`applyLiveInputMirror`) receives the normalized text. The mirror's erase/append diffing is unaffected because `normalizeTerminalTextInput` is a deterministic per-character mapping, so consecutive normalized field snapshots stay consistent.
- Buffered input: `onChangeText={setInput}` stores raw text; `handleSend` already normalized at send time (`normalizeTerminalTextInput(input)`), so the wire bytes are unchanged.

The app never rewrites the field mid-session anymore; intentional programmatic writes (clear-after-send, tab-switch clears, accessory local edits, sherpa dictation append) are user-initiated moments where ending a dictation session is correct.

Visible trade-off: iOS smart punctuation now stays visible in the field (e.g. `–` instead of the rewritten `--`), while the PTY/send still receives `--`. The previous `previousText`-based collapse repair in the buffered input is no longer reachable — it existed to repair collapses of the literal `--` that the write-back itself put into the field.

## Hangul IME mirror

Untouched. The mirror consumes `onChangeText` text only (never the controlled value), `normalizeTerminalTextInput` is the identity on Hangul, and raw echo means strictly *fewer* native write-backs during composition. All existing mirror/flush/ordering tests pass.

## Tests

- `use-terminal-live-input-commit.test.ts`: raw capture + normalized PTY bytes for smart-dash input; dictation-style hypothesis revision converges via mirror DELs without field rewrites.
- `terminal-ios-dictation-write-back.test.ts` (new, follows the `terminal-ios-ime-keyboard.test.ts` source-guard precedent): the buffered input must not write normalized text back into its `value`; send-time normalization must remain.
- Full mobile suite: 177 files / 1267 tests pass; oxlint, tsc, and the max-lines ratchet are clean.

## Remaining work — physical-device verification

iOS dictation does not run in the Simulator and no physical iPhone was available to this run. This fix removes every app-initiated write-back path (the mechanism RN itself documents as dictation-killing), but the *instant* dismissal at mic tap could not be reproduced first-hand. If device QA still sees an immediate dismissal in live mode with an **empty** field, two follow-up hypotheses are documented, in order:

1. The live capture field is a 1×1 `opacity: 0` `position: absolute` TextInput — iOS may treat an effectively invisible field as dictation-ineligible. Plan B: give the capture field the input bar's real frame with `opacity: 0` and `pointerEvents="none"` (keeping the Pressable focus target on top).
2. `autoCorrect={false}` on the live input — iOS has historically coupled dictation availability to autocorrection on some versions. Plan B: platform/version-gate `autoCorrect` on iOS.

Buffered-mode dictation (visible, plain field) should be verified first since it isolates the write-back mechanism this PR fixes.

## App-wide TextInput audit

All ~47 non-terminal TextInput sites were audited for the same kill pattern. A controlled input that echoes text back unchanged is dictation-safe (RN only writes to the native field when the JS value diverges), and ~42 sites are exactly that or are properly focus/lock/dirty-guarded — including the PR compose form, whose fields are locked (`editable={false}`) while AI generation writes into them. Two secondary candidates were found and are left as follow-ups rather than bundled here:

- `mobile/src/browser/MobileBrowserPane.tsx:486` — a navigation stream event writes `setAddressValue(displayBrowserUrl(...))` without the `addressFocused` guard the rest of the component uses; a redirect landing while the user edits/dictates the URL overwrites the field.
- `mobile/src/source-control/use-mobile-commit-message-generation.ts:45` — AI commit-message generation writes into the commit field, which stays editable during generation (unlike the PR compose form); a generation resolving while the user dictates into the field kills the session.

Made with [Orca](https://github.com/stablyai/orca) 🐋
