### PR TITLE
feat(terminal): make minimum contrast ratio configurable

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -60,6 +60,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalFontFamily: 'JetBrains Mono',
     terminalFontWeight: 500,
     terminalLineHeight: 1,
+    terminalMinimumContrastRatio: 4.5,
     terminalScrollSensitivity: 1.15,
     terminalFastScrollSensitivity: 5,
     terminalTuiScrollSensitivity: 1,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -65,6 +65,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     terminalFontFamily: 'JetBrains Mono',
     terminalFontWeight: 500,
     terminalLineHeight: 1,
+    terminalMinimumContrastRatio: 4.5,
     terminalScrollSensitivity: 1.15,
     terminalFastScrollSensitivity: 5,
     terminalTuiScrollSensitivity: 1,

--- a/src/renderer/src/components/settings/TerminalRenderingSection.tsx
+++ b/src/renderer/src/components/settings/TerminalRenderingSection.tsx
@@ -1,11 +1,19 @@
 import type { GlobalSettings } from '../../../../shared/types'
 import {
+  DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO,
+  TERMINAL_MINIMUM_CONTRAST_RATIO_MAX,
+  TERMINAL_MINIMUM_CONTRAST_RATIO_MIN,
+  normalizeTerminalMinimumContrastRatio
+} from '@/lib/pane-manager/pane-terminal-options'
+import {
+  NumberField,
   SettingsRow,
   SettingsSegmentedControl,
   SettingsSubsectionHeader
 } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
 import { translate } from '@/i18n/i18n'
+import { getTerminalRenderingSearchEntries } from './terminal-typography-search'
 
 type TerminalRenderingSectionProps = {
   settings: GlobalSettings
@@ -16,6 +24,10 @@ export function TerminalRenderingSection({
   settings,
   updateSettings
 }: TerminalRenderingSectionProps): React.JSX.Element {
+  const searchEntries = getTerminalRenderingSearchEntries()
+  // Why index 1: catalog order is GPU Acceleration, then Minimum Contrast Ratio.
+  const contrastEntry = searchEntries[1]
+
   return (
     <section key="rendering" className="space-y-3">
       <SettingsSubsectionHeader
@@ -88,6 +100,53 @@ export function TerminalRenderingSection({
                   }
                 ]}
               />
+            }
+          />
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.TerminalPane.minimumContrastRatio.title',
+            'Minimum Contrast Ratio'
+          )}
+          description={
+            contrastEntry?.description ??
+            translate(
+              'auto.components.settings.TerminalPane.minimumContrastRatio.description',
+              'Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is.'
+            )
+          }
+          keywords={
+            contrastEntry?.keywords ?? [
+              'terminal',
+              'contrast',
+              'color',
+              'ansi',
+              'minimum contrast',
+              'colors',
+              'xterm'
+            ]
+          }
+        >
+          <NumberField
+            label={translate(
+              'auto.components.settings.TerminalPane.minimumContrastRatio.title',
+              'Minimum Contrast Ratio'
+            )}
+            description={translate(
+              'auto.components.settings.TerminalPane.minimumContrastRatio.helper',
+              '1 leaves colors unchanged; 4.5 is the accessibility default.'
+            )}
+            value={normalizeTerminalMinimumContrastRatio(settings.terminalMinimumContrastRatio)}
+            defaultValue={DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO}
+            min={TERMINAL_MINIMUM_CONTRAST_RATIO_MIN}
+            max={TERMINAL_MINIMUM_CONTRAST_RATIO_MAX}
+            step={0.5}
+            suffix="1-21"
+            onChange={(value) =>
+              updateSettings({
+                terminalMinimumContrastRatio: normalizeTerminalMinimumContrastRatio(value)
+              })
             }
           />
         </SearchableSetting>

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
@@ -114,7 +114,8 @@ vi.mock('@/components/ui/card', () => ({
   CardTitle: 'CardTitle'
 }))
 
-vi.mock('@/lib/pane-manager/pane-terminal-options', () => ({
+vi.mock('@/lib/pane-manager/pane-terminal-options', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   buildDefaultTerminalOptions: () => ({ scrollback: 0 })
 }))
 

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -4,7 +4,10 @@ import { LigaturesAddon } from '@xterm/addon-ligatures'
 import { Moon, Sun } from 'lucide-react'
 import '@xterm/xterm/css/xterm.css'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { buildDefaultTerminalOptions } from '@/lib/pane-manager/pane-terminal-options'
+import {
+  buildDefaultTerminalOptions,
+  normalizeTerminalMinimumContrastRatio
+} from '@/lib/pane-manager/pane-terminal-options'
 import { buildFontFamily } from '@/components/terminal-pane/layout-serialization'
 import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-appearance'
 import { clampNumber, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
@@ -165,6 +168,9 @@ export function TerminalSettingsPreview({
       fontWeight: weights.fontWeight,
       fontWeightBold: weights.fontWeightBold,
       lineHeight: terminalLineHeight,
+      minimumContrastRatio: normalizeTerminalMinimumContrastRatio(
+        settings.terminalMinimumContrastRatio
+      ),
       theme: composedTheme ?? undefined,
       allowTransparency:
         settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1,
@@ -211,6 +217,9 @@ export function TerminalSettingsPreview({
     terminal.options.fontWeight = weights.fontWeight
     terminal.options.fontWeightBold = weights.fontWeightBold
     terminal.options.lineHeight = terminalLineHeight
+    terminal.options.minimumContrastRatio = normalizeTerminalMinimumContrastRatio(
+      settings.terminalMinimumContrastRatio
+    )
     terminal.options.cursorStyle = settings.terminalCursorStyle
     // Why: see constructor — mirror so the unfocused cursor reflects the
     // user's chosen shape (xterm defaults inactive to 'outline').
@@ -221,6 +230,7 @@ export function TerminalSettingsPreview({
     effectiveFontFamily,
     settings.terminalFontWeight,
     terminalLineHeight,
+    settings.terminalMinimumContrastRatio,
     settings.terminalCursorStyle,
     settings.terminalCursorBlink
   ])

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -5,6 +5,7 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalFontFamily: 'Font Family',
   terminalFontWeight: 'Font Weight',
   terminalLineHeight: 'Line Height',
+  terminalMinimumContrastRatio: 'Minimum Contrast Ratio',
   terminalScrollSensitivity: 'Normal Scroll Speed',
   terminalFastScrollSensitivity: 'Fast Scroll Speed',
   terminalTuiScrollSensitivity: 'TUI Scroll Speed',

--- a/src/renderer/src/components/settings/terminal-typography-search.ts
+++ b/src/renderer/src/components/settings/terminal-typography-search.ts
@@ -128,6 +128,43 @@ export const getTerminalRenderingSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.terminal.search.7d924d870d', 'graphics'),
       ...translateSearchKeyword('auto.components.settings.terminal.search.1abcf4d7de', 'linux')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.terminal.search.minimumContrastRatio.title',
+      'Minimum Contrast Ratio'
+    ),
+    description: translate(
+      'auto.components.settings.terminal.search.minimumContrastRatio.description',
+      'Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.terminal.search.f66a7cf715', 'terminal'),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrastRatio.contrast',
+        'contrast'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrastRatio.color',
+        'color'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrastRatio.ansi',
+        'ansi'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrastRatio.ratio',
+        'minimum contrast'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrastRatio.colors',
+        'colors'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.minimumContrastRatio.xterm',
+        'xterm'
+      )
+    ]
   }
 ])
 

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -13,6 +13,7 @@ import { guardParserHandler } from './terminal-parser-handler-guard'
 import { captureScrollState, restoreScrollState, safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import {
   normalizeTerminalFastScrollSensitivity,
+  normalizeTerminalMinimumContrastRatio,
   normalizeTerminalScrollSensitivity,
   resolveTerminalCursorInactiveStyle
 } from '@/lib/pane-manager/pane-terminal-options'
@@ -285,6 +286,9 @@ export function applyTerminalAppearance(
     )
     pane.terminal.options.fastScrollSensitivity = normalizeTerminalFastScrollSensitivity(
       settings.terminalFastScrollSensitivity
+    )
+    pane.terminal.options.minimumContrastRatio = normalizeTerminalMinimumContrastRatio(
+      settings.terminalMinimumContrastRatio
     )
     // Why: xterm's macOptionIsMeta only flips on the 'true' mode. 'left' and
     // 'right' are handled in the keydown policy (terminal-shortcut-policy),

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -11,6 +11,7 @@ import {
 import { consumePendingWebRuntimeSplitMirrorTelemetry } from '@/runtime/web-runtime-session'
 import {
   normalizeTerminalFastScrollSensitivity,
+  normalizeTerminalMinimumContrastRatio,
   normalizeTerminalScrollSensitivity,
   resolveTerminalCursorInactiveStyle
 } from '@/lib/pane-manager/pane-terminal-options'
@@ -1480,6 +1481,9 @@ export function useTerminalPaneLifecycle({
           ),
           fastScrollSensitivity: normalizeTerminalFastScrollSensitivity(
             currentSettings?.terminalFastScrollSensitivity
+          ),
+          minimumContrastRatio: normalizeTerminalMinimumContrastRatio(
+            currentSettings?.terminalMinimumContrastRatio
           ),
           macOptionIsMeta: effectiveMacOptionAsAltRef.current === 'true',
           lineHeight: normalizeTerminalLineHeight(currentSettings?.terminalLineHeight),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6810,6 +6810,11 @@
             "fastDescription": "Extra multiplier while scrolling with a modifier key.",
             "tui": "TUI",
             "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
+          },
+          "minimumContrastRatio": {
+            "title": "Minimum Contrast Ratio",
+            "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is.",
+            "helper": "1 leaves colors unchanged; 4.5 is the accessibility default."
           }
         },
         "TerminalSettingsPreview": {
@@ -8512,6 +8517,10 @@
               "title": "Theme Mode",
               "keyword_target": "target",
               "keyword_editing": "editing"
+            },
+            "minimumContrastRatio": {
+              "title": "Minimum Contrast Ratio",
+              "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is."
             }
           },
           "windows": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6773,6 +6773,11 @@
             "fastDescription": "Multiplicador adicional al desplazarse con una tecla modificadora.",
             "tui": "TUI",
             "tuiDescription": "Eventos discretos de rueda para apps de terminal de pantalla completa."
+          },
+          "minimumContrastRatio": {
+            "title": "Minimum Contrast Ratio",
+            "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is.",
+            "helper": "1 leaves colors unchanged; 4.5 is the accessibility default."
           }
         },
         "TerminalSettingsPreview": {
@@ -8475,6 +8480,10 @@
               "title": "Modo del tema",
               "keyword_target": "destino",
               "keyword_editing": "edición"
+            },
+            "minimumContrastRatio": {
+              "title": "Minimum Contrast Ratio",
+              "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is."
             }
           },
           "windows": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6795,6 +6795,11 @@
             "fastDescription": "修飾キーを押しながらスクロールするときの追加倍率。",
             "tui": "TUI",
             "tuiDescription": "全画面ターミナルアプリ向けの離散的なホイール通知。"
+          },
+          "minimumContrastRatio": {
+            "title": "Minimum Contrast Ratio",
+            "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is.",
+            "helper": "1 leaves colors unchanged; 4.5 is the accessibility default."
           }
         },
         "TerminalSettingsPreview": {
@@ -8497,6 +8502,10 @@
               "title": "テーマモード",
               "keyword_target": "対象",
               "keyword_editing": "編集"
+            },
+            "minimumContrastRatio": {
+              "title": "Minimum Contrast Ratio",
+              "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is."
             }
           },
           "windows": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6758,6 +6758,11 @@
             "fastDescription": "수정 키로 스크롤할 때 적용되는 추가 배율.",
             "tui": "TUI",
             "tuiDescription": "전체 화면 터미널 앱을 위한 개별 휠 보고."
+          },
+          "minimumContrastRatio": {
+            "title": "Minimum Contrast Ratio",
+            "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is.",
+            "helper": "1 leaves colors unchanged; 4.5 is the accessibility default."
           }
         },
         "TerminalSettingsPreview": {
@@ -8460,6 +8465,10 @@
               "title": "테마 모드",
               "keyword_target": "대상",
               "keyword_editing": "편집"
+            },
+            "minimumContrastRatio": {
+              "title": "Minimum Contrast Ratio",
+              "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is."
             }
           },
           "windows": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6758,6 +6758,11 @@
             "fastDescription": "按住修饰键滚动时的额外倍数。",
             "tui": "TUI",
             "tuiDescription": "面向全屏终端应用的离散滚轮报告。"
+          },
+          "minimumContrastRatio": {
+            "title": "Minimum Contrast Ratio",
+            "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is.",
+            "helper": "1 leaves colors unchanged; 4.5 is the accessibility default."
           }
         },
         "TerminalSettingsPreview": {
@@ -8460,6 +8465,10 @@
               "title": "主题模式",
               "keyword_target": "目标",
               "keyword_editing": "编辑"
+            },
+            "minimumContrastRatio": {
+              "title": "Minimum Contrast Ratio",
+              "description": "Raises low-contrast ANSI text toward the background until this ratio is met. Set to 1 to use theme colors as-is."
             }
           },
           "windows": {

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -11,8 +11,10 @@ import { ensureArabicShapingJoinerForText } from './terminal-arabic-shaping-join
 import {
   buildDefaultTerminalOptions,
   DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
+  DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO,
   DEFAULT_TERMINAL_SCROLL_SENSITIVITY,
   normalizeTerminalFastScrollSensitivity,
+  normalizeTerminalMinimumContrastRatio,
   normalizeTerminalScrollSensitivity,
   resolveTerminalCursorInactiveStyle
 } from './pane-terminal-options'
@@ -113,7 +115,22 @@ describe('buildDefaultTerminalOptions', () => {
   })
 
   it('enables xterm contrast correction for low-contrast CLI colors', () => {
-    expect(buildDefaultTerminalOptions().minimumContrastRatio).toBe(4.5)
+    expect(buildDefaultTerminalOptions().minimumContrastRatio).toBe(
+      DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO
+    )
+  })
+
+  it('normalizes terminal minimum contrast ratio to the xterm 1–21 range', () => {
+    expect(normalizeTerminalMinimumContrastRatio(undefined)).toBe(
+      DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO
+    )
+    expect(normalizeTerminalMinimumContrastRatio(1)).toBe(1)
+    expect(normalizeTerminalMinimumContrastRatio(0)).toBe(1)
+    expect(normalizeTerminalMinimumContrastRatio(21)).toBe(21)
+    expect(normalizeTerminalMinimumContrastRatio(30)).toBe(21)
+    expect(normalizeTerminalMinimumContrastRatio(Number.NaN)).toBe(
+      DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO
+    )
   })
 
   it('only uses inactive outline for block cursors', () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
@@ -6,6 +6,12 @@ type TerminalCursorInactiveStyle = NonNullable<ITerminalOptions['cursorInactiveS
 
 export const DEFAULT_TERMINAL_SCROLL_SENSITIVITY = 1.15
 export const DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY = 5
+// Why: xterm accepts 1–21; 1 means no correction, 4.5 keeps low-contrast ANSI
+// body text readable on light themes (default). Users can lower it when themes
+// already choose colors carefully (#7934).
+export const DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO = 4.5
+export const TERMINAL_MINIMUM_CONTRAST_RATIO_MIN = 1
+export const TERMINAL_MINIMUM_CONTRAST_RATIO_MAX = 21
 
 export function normalizeTerminalScrollSensitivity(value: number | undefined): number {
   return typeof value === 'number' && Number.isFinite(value)
@@ -17,6 +23,16 @@ export function normalizeTerminalFastScrollSensitivity(value: number | undefined
   return typeof value === 'number' && Number.isFinite(value)
     ? Math.min(20, Math.max(1, value))
     : DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY
+}
+
+export function normalizeTerminalMinimumContrastRatio(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO
+  }
+  return Math.min(
+    TERMINAL_MINIMUM_CONTRAST_RATIO_MAX,
+    Math.max(TERMINAL_MINIMUM_CONTRAST_RATIO_MIN, value)
+  )
 }
 
 export function resolveTerminalCursorInactiveStyle(
@@ -49,7 +65,8 @@ export function buildDefaultTerminalOptions(): ITerminalOptions {
     allowTransparency: false,
     // Why: agent CLIs sometimes render body text with ANSI white/bright-white
     // on light themes; xterm can keep those cells readable across renderers.
-    minimumContrastRatio: 4.5,
+    // Overridable via settings.terminalMinimumContrastRatio (#7934).
+    minimumContrastRatio: DEFAULT_TERMINAL_MINIMUM_CONTRAST_RATIO,
     // Why: on macOS, non-US layouts rely on Option to compose characters like @ and €.
     macOptionIsMeta: false,
     macOptionClickForcesSelection: true,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -220,6 +220,9 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,
     terminalLineHeight: 1,
+    // Why: match xterm default used in pane-terminal-options; users can lower
+    // to 1 when theme colors should render without contrast boosting (#7934).
+    terminalMinimumContrastRatio: 4.5,
     terminalScrollSensitivity: 1.15,
     terminalFastScrollSensitivity: 5,
     terminalTuiScrollSensitivity: 1,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2543,6 +2543,8 @@ export type GlobalSettings = {
   terminalFontFamily: string
   terminalFontWeight: number
   terminalLineHeight: number
+  /** xterm minimumContrastRatio (1–21). 1 disables correction; default 4.5. */
+  terminalMinimumContrastRatio: number
   terminalScrollSensitivity: number
   terminalFastScrollSensitivity: number
   terminalTuiScrollSensitivity: number


### PR DESCRIPTION
## Summary

Makes xterm `minimumContrastRatio` user-configurable (issue #7934).

The hardcoded `4.5` in `pane-terminal-options.ts` boosts low-contrast ANSI text for accessibility, but can rewrite carefully chosen theme colors. Users can now set **1** (no correction) through **21** under **Settings → Terminal → Rendering**.

- Default remains **4.5** so existing behavior is unchanged.
- Applied on pane create and live appearance updates.
- Settings preview follows the same value.

## Test plan

- [x] `vitest` pane-lifecycle normalize/default tests
- [x] `typecheck:tsc:node`
- [ ] Manual: Settings → Terminal → Rendering → set Minimum Contrast Ratio to `1`; confirm theme colors render without boost
- [ ] Manual: leave default `4.5`; low-contrast white-on-light still readable
- [ ] Manual: settings search finds “Minimum Contrast Ratio” / “contrast”

Fixes #7934