### PR TITLE
fix(project-view): route 'Use PR' launches through submit-after-ready waiter

### DIFF
--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -666,6 +666,7 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
         repoId: resolution.repo.id,
         launchSource: 'task_page',
         telemetrySource: 'sidebar',
+        promptDelivery: 'submit-after-ready',
         openModalFallback: () => {
           // Why: Project mode does not own the new-workspace composer modal.
           // When `launchWorkItemDirect` wants user input (setupRunPolicy:'ask'
@@ -950,6 +951,7 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
               repoId: current.workItem.repoId,
               launchSource: 'task_page',
               telemetrySource: 'sidebar',
+              promptDelivery: 'submit-after-ready',
               openModalFallback: () => {
                 if (item.url) {
                   void window.api.shell.openUrl(item.url)

--- a/src/renderer/src/components/github-project/project-view-wrapper-source-context-boundary.test.ts
+++ b/src/renderer/src/components/github-project/project-view-wrapper-source-context-boundary.test.ts
@@ -31,4 +31,22 @@ describe('ProjectViewWrapper GitHub source context boundary', () => {
     expect(contextSection).toContain('repo: resolvedDialogRepo')
     expect(dialogSection).toContain('sourceContext={resolvedDialogSourceContext}')
   })
+
+  it('routes both project-view "Use" launches through the fixed submit-after-ready waiter', () => {
+    const source = componentSource('ProjectViewWrapper.tsx')
+    // Both direct launchWorkItemDirect call sites must request submit-after-ready
+    // so the prompt is pasted AND submitted (the draft default pastes but never
+    // submits, which leaves Hermes idle). Regression guard for the #7862 gap.
+    const launchSites = source.split('launchWorkItemDirect({').slice(1)
+    expect(launchSites.length).toBeGreaterThanOrEqual(2)
+    let submitReadyCount = 0
+    for (const site of launchSites) {
+      // Each site's args block ends before the closing `})`
+      const block = site.slice(0, site.indexOf('})'))
+      if (block.includes("promptDelivery: 'submit-after-ready'")) {
+        submitReadyCount += 1
+      }
+    }
+    expect(submitReadyCount).toBe(launchSites.length)
+  })
 })

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -167,6 +167,10 @@ describe('pasteDraftWhenAgentReady', () => {
       'pty-1',
       PASTED_ISSUE_URL
     )
+    // Guard against a duplicate paste: the quiet window should fire exactly once.
+    // Boundary stays aligned with BRACKETED_PASTE_QUIET_MS (1500) via the
+    // 1499ms + 1ms split above.
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the render-quiet wait for agents without the Codex ready signal', async () => {

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -143,6 +143,32 @@ describe('pasteDraftWhenAgentReady', () => {
     )
   })
 
+  it('pastes into Hermes on the quiet window without a bracketed-paste handshake', async () => {
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'hermes'
+    })
+    await flushMicrotasks()
+
+    // Hermes's prompt_toolkit TUI never emits DECSET 2004; it just renders.
+    testState.ptyObserver?.('Hermes Agent - AI assistant\x1b[2J\x1b[H> ')
+    await flushMicrotasks()
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1499)
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      PASTED_ISSUE_URL
+    )
+  })
+
   it('keeps the render-quiet wait for agents without the Codex ready signal', async () => {
     const promise = pasteDraftWhenAgentReady({
       tabId: 'tab-1',

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -107,6 +107,17 @@ export async function pasteDraftWhenAgentReady(args: {
   const settings = getSettingsForAgentTabRuntimeOwner(tabId)
   const ready = await waitForAgentDraftInputReady(ptyId, budget, readySignal, settings)
   if (!ready) {
+    // Why: `process-ready` agents (e.g. Hermes's prompt_toolkit TUI) never
+    // emit DECSET 2004, so readiness is the PTY-quiet window alone (handled by
+    // `waitForAgentDraftInputReady` above). The legacy fallback below inspects
+    // the foreground process name, but wrapped interpreter launches surface as
+    // `python3 .../hermes` — `isExpectedAgentProcess('python3','hermes')` fails,
+    // so the fallback can never confirm readiness and would only drop the paste.
+    // Trust the quiet-window signal for this signal; do not fall back.
+    if (readySignal === 'process-ready') {
+      onTimeout?.()
+      return false
+    }
     // Why: fast-starting TUIs can emit the paste-ready escape sequence before
     // this sidecar subscription attaches. If process/title inspection says the
     // launched agent owns the PTY, fall back to a best-effort paste instead of

--- a/src/shared/draft-paste-ready-scanner.ts
+++ b/src/shared/draft-paste-ready-scanner.ts
@@ -39,6 +39,12 @@ export type DraftPasteReadyScanResult = {
  *     the caller's hard timeout is the backstop if it never appears.
  *   - `render-quiet-after-bracketed-paste` (default): no signal marker; arms the
  *     quiet window once DECSET 2004 is seen.
+ *   - `process-ready`: no DECSET 2004 handshake and no marker. Used by agents
+ *     (e.g. Hermes's prompt_toolkit TUI) that never emit bracketed-paste
+ *     enable. Arms the quiet window on the first PTY output chunk; once the
+ *     agent's render burst settles (BRACKETED_PASTE_QUIET_MS of silence) the
+ *     caller pastes. The caller's existing process-ownership fallback is the
+ *     backstop if output never arrives.
  *
  * A 512-byte ring (`recent` / `postHandshakeRecent`) covers escape sequences
  * split across chunk boundaries without retaining terminal scrollback.
@@ -56,11 +62,18 @@ export function createDraftPasteReadyScanner(readySignal: DraftPasteReadySignal)
       : readySignal === 'render-cursor-after-bracketed-paste'
         ? DECTCEM_SHOW_CURSOR
         : null
+  const isProcessReady = readySignal === 'process-ready'
 
   return {
     observe(data: string): DraftPasteReadyScanResult {
       const combined = recent + data
       recent = combined.slice(-512)
+      // Why: agents using `process-ready` never emit DECSET 2004. Arm the quiet
+      // window on the first render output so the caller pastes once the TUI
+      // settles. No marker check, no 2004 gate.
+      if (isProcessReady) {
+        return { ready: false, armQuietTimer: true }
+      }
       if (!saw2004) {
         const markerIndex = combined.indexOf(DECSET_BRACKETED_PASTE)
         if (markerIndex === -1) {

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -12,6 +12,7 @@ export type DraftPasteReadySignal =
   | 'render-quiet-after-bracketed-paste'
   | 'codex-composer-prompt'
   | 'render-cursor-after-bracketed-paste'
+  | 'process-ready'
 
 export type TuiAgentConfig = {
   detectCmd: string
@@ -306,7 +307,12 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // `--tui` starts the full-screen agent UI Orca is designed to host.
     launchCmd: 'hermes --tui',
     expectedProcess: 'hermes',
-    promptInjectionMode: 'stdin-after-start'
+    promptInjectionMode: 'stdin-after-start',
+    // Why: Hermes's TUI (prompt_toolkit) does not emit the DECSET 2004
+    // bracketed-paste handshake that `render-quiet-after-bracketed-paste`
+    // waits for, so the draft paste never fires and the agent sits idle.
+    // Fall back to process-presence + PTY-quiet readiness detection.
+    draftPasteReadySignal: 'process-ready'
   },
   openclaw: {
     detectCmd: 'openclaw',


### PR DESCRIPTION
## Problem
Project-view "Use PR" / "open task" actions called `launchWorkItemDirect` without `promptDelivery`, defaulting to `'draft'`. The draft path pastes the work item URL into the agent but never submits it (the startup `draftPrompt` delivery intentionally omits Enter — `src/renderer/src/lib/new-workspace.ts:316`). For TUI agents like Hermes that require Enter to start, the prompt then sits idle in the input box — the exact "opens terminal, URL inside, does nothing" symptom.

## Fix
Set `promptDelivery: 'submit-after-ready'` on both `launchWorkItemDirect` call sites in `ProjectViewWrapper.tsx` (lines ~664 and ~948). This routes the launch through the fixed `pasteDraftWhenAgentReady` waiter (PR #7862, `draftPasteReadySignal: 'process-ready'`) which pastes AND submits. `PullRequestPage.tsx` already did this correctly; the project view did not.

This depends on #7862 (the waiter fix). Verified live: the project-view path now delivers `^[[200~<url>^[[201~\r` (bracketed paste + Enter) into Hermes.

## Verification
- `pnpm run typecheck` clean
- `launch-work-item-direct.test.ts` (11) + new regression test (2) pass
- Live: PR #123 "Use" via the dev build pasted + submitted into Hermes TUI (PTY replica shows `...pull/123^[[201~\r`)

## Test plan
- `pnpm run test src/renderer/src/components/github-project/project-view-wrapper-source-context-boundary.test.ts`
- Manual: open a PR from the GitHub project view, confirm Hermes receives and runs the prompt

## ELI5

"Use PR" from project view pasted the work item into the agent but never submitted it, so agents like Hermes sat idle with the URL in the box. Launch now uses submit-after-ready delivery so the prompt is actually sent when the agent is ready.
