### PR TITLE
fix(relay): refuse recursive fs.watch on home/filesystem roots

### DIFF
--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -6,7 +6,7 @@ import type { RelayDispatcher } from './dispatcher'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 
 const { mockSubscribe } = vi.hoisted(() => ({
   mockSubscribe: vi.fn()
@@ -155,6 +155,24 @@ describe('FsHandler', () => {
 
   it('tempDir returns the relay host temp directory', async () => {
     await expect(dispatcher.callRequest('fs.tempDir')).resolves.toBe(tmpdir())
+  })
+
+  it('fs.watch refuses broad roots (home, /, ancestors of home) without subscribing', async () => {
+    // Why: a home-rooted recursive watch makes @parcel/watcher crawl the whole
+    // account tree (container storage, model dirs) and starves the relay.
+    await expect(
+      dispatcher.callRequest('fs.watch', { rootPath: homedir() })
+    ).resolves.toBeUndefined()
+    await expect(dispatcher.callRequest('fs.watch', { rootPath: '~' })).resolves.toBeUndefined()
+    await expect(dispatcher.callRequest('fs.watch', { rootPath: '/' })).resolves.toBeUndefined()
+    // No watch state registered — unwatch for those roots is a no-op, not a crash.
+    dispatcher._notificationHandlers.get('fs.unwatch')?.(
+      { rootPath: homedir() },
+      {
+        clientId: 0,
+        isStale: () => false
+      }
+    )
   })
 
   it('readDir returns sorted entries with directories first', async () => {

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -2,7 +2,7 @@
    path expansion, file IO, search, streaming reads, Space scans, and watch lifecycle state. */
 import { readdir, writeFile, stat, lstat, mkdir, rename, cp, rm, realpath } from 'node:fs/promises'
 import { execFile } from 'node:child_process'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import type { RelayContext } from './context'
@@ -39,6 +39,23 @@ type WatchState = {
   unwatchFn: (() => void) | null
   setupPromise: Promise<void> | null
   clients: Map<number, () => boolean>
+}
+
+// Why: a recursive watch rooted at the account home (or a filesystem root)
+// makes @parcel/watcher brute-force crawl the entire tree — container storage,
+// ML model dirs, package caches: millions of entries. That pins a libuv worker
+// and gigabytes of RSS for an hour+ and starves every other fs request on the
+// relay, freezing ALL workspaces that share the connection. Refuse those roots;
+// callers already tolerate a missing watcher (same as the no-parcel path) and
+// simply run without fs.changed events.
+function isBroadWatchRoot(rootPath: string): boolean {
+  const norm = rootPath.replace(/\/+$/, '')
+  const home = homedir().replace(/\/+$/, '')
+  if (norm === '' || norm === '/' || norm === home) {
+    return true
+  }
+  // An ancestor of home (e.g. /home) is at least as broad as home itself.
+  return home.startsWith(`${norm}/`)
 }
 
 async function isDirectoryEntry(
@@ -388,6 +405,14 @@ export class FsHandler {
 
   private async watch(params: Record<string, unknown>, context?: RequestContext) {
     const rootPath = expandTilde(params.rootPath as string)
+
+    if (isBroadWatchRoot(rootPath)) {
+      // Why: log loudly — a broad-root watch request is a client-side bug worth
+      // tracing (which surface asked to watch the whole home directory?).
+      console.log(`[relay] watch REFUSED (broad root): ${rootPath}`)
+      return
+    }
+    console.log(`[relay] watch start: ${rootPath}`)
 
     this.releaseStaleWatches()
 


### PR DESCRIPTION
## Summary

On a remote SSH host, adding/opening projects could freeze **every** workspace on the connection: the file explorer and Source Control hang, remote terminals stall, and it never recovers on its own. Root cause: the relay ends up recursively watching the **account home directory**, and `@parcel/watcher` brute-force crawls the entire tree.

This guards the relay against recursive watches on `$HOME`, filesystem roots, and ancestors of `$HOME`.

## Root cause (traced live on a real host)

The worktree base-directory watcher (`buildWorktreeBaseDirectoryWatchTargets` → `maybeAddBaseTarget`) watches each repo's **`workspaceRoot`** so it can notice worktrees created/removed outside Orca. When a user's remote repos all live directly under their home (e.g. `~/ERP`, `~/Local-ai`, `~/HyDE`, …), `workspaceRoot` resolves to **`$HOME` itself**.

The relay then calls `@parcel/watcher.subscribe($HOME, …)`. parcel is recursive and its ignore list (`WATCHER_IGNORE_DIRS`: `node_modules`, `.git`, `dist`, `build`, `.next`, `.cache`, `target`, `.venv`, `__pycache__`) does **not** include `~/.local`. On a real dev box `$HOME` contains rootless container storage (`~/.local/share/docker/containerd/**`, `~/.local/share/containers/**`) and ML model dirs — millions of files. parcel's initial crawl:

- pins one libuv worker at ~100% CPU for 60–90+ minutes,
- grows RSS into the multi-GB range,
- starves every other fs RPC on the single-threaded relay,

so `fs.readDir` / `fs.stat` for *all* workspaces on that connection exceed the 30s request timeout and the UI freezes. It only surfaced once native deps installed successfully — before that the relay logged `File watcher not available` and never loaded parcel.

Captured directly from `relay.log` with this change deployed:

```
[relay] watch REFUSED (broad root): /home/next      <-- guard catches the base-dir watch
[relay] watch start: /home/next/ERP/.git            <-- normal per-worktree watches proceed
[relay] watch start: /home/next/Local-ai/.git
...
```

With the guard in place the relay settled at ~227 MB and idle CPU; without it, the same action pinned a core and grew to 1.4 GB.

## Change

`src/relay/fs-handler.ts`:
- `isBroadWatchRoot(rootPath)` — true for `/`, `$HOME`, and any ancestor of `$HOME`.
- `watch()` refuses those roots **before** importing/subscribing parcel and returns (callers already tolerate a missing watcher — same behavior as the no-parcel path). A recursive watch on the whole home directory has no legitimate use; only the base dir's immediate entries matter, which the existing base-directory poller covers.
- Every accepted watch root is logged (`watch start: <root>`) so a broad-root requester stays traceable.

`src/relay/fs-handler.test.ts`: `fs.watch` on `homedir()`, `~`, and `/` resolves without subscribing, and a follow-up `fs.unwatch` is a no-op (not a crash).

## Notes / follow-up

This is a relay-side backstop that catches *any* caller. The cleaner root fix is main-side: `worktree-base-directory` should not request a recursive watch when `workspaceRoot` is the home dir / a filesystem root — it should rely on `worktree-base-directory-poller` (a shallow one-level readdir) instead. Happy to follow up with that if preferred. One caveat of the relay-side guard alone: the main process sees the watch as "succeeded", so it won't itself switch to polling for that root — acceptable (Orca still picks up worktree changes on the next refresh), but the main-side fix would preserve live base-dir detection.

Tested: `pnpm run typecheck` clean; relay tests pass (43); verified live on a Linux SSH host as above.

## ELI5

Opening a project over SSH could freeze every workspace because the relay recursively watched the whole home directory. Recursive watches on home, filesystem roots, and their ancestors are refused so the connection stays responsive.
