### PR TITLE
feat(mobile): edit host address, report device model, fix iOS 27 launch

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -80,6 +80,7 @@
     "plugins": [
       "expo-router",
       "./plugins/android-respect-rotation-lock.js",
+      "./plugins/ios-uikit-scene-lifecycle.js",
       [
         "expo-splash-screen",
         {

--- a/mobile/app/h/[hostId]/edit.tsx
+++ b/mobile/app/h/[hostId]/edit.tsx
@@ -22,6 +22,7 @@ import {
 import {
   displayHostEndpoint,
   endpointPort,
+  endpointScheme,
   normalizeHostEndpoint
 } from '../../../src/transport/host-endpoint'
 import { useForceReconnect, usePrimeHosts } from '../../../src/transport/client-context'
@@ -69,11 +70,12 @@ export default function EditHostScreen() {
   }, [load])
 
   const fallbackPort = host ? endpointPort(host.endpoint) : undefined
+  const fallbackScheme = host ? endpointScheme(host.endpoint) : 'ws'
 
   const normalizedPreview = useMemo(() => {
-    const result = normalizeHostEndpoint(address, { fallbackPort })
+    const result = normalizeHostEndpoint(address, { fallbackPort, fallbackScheme })
     return result.ok ? result.endpoint : null
-  }, [address, fallbackPort])
+  }, [address, fallbackPort, fallbackScheme])
 
   const nameTrimmed = name.trim()
   const nameChanged = host != null && nameTrimmed.length > 0 && nameTrimmed !== host.name
@@ -96,7 +98,8 @@ export default function EditHostScreen() {
       return
     }
     const normalized = normalizeHostEndpoint(address, {
-      fallbackPort: endpointPort(host.endpoint)
+      fallbackPort: endpointPort(host.endpoint),
+      fallbackScheme: endpointScheme(host.endpoint)
     })
     if (!normalized.ok) {
       setSaveError(normalized.error)

--- a/mobile/app/h/[hostId]/edit.tsx
+++ b/mobile/app/h/[hostId]/edit.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  Pressable,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { ChevronLeft } from 'lucide-react-native'
+import { colors, radii, spacing, typography } from '../../../src/theme/mobile-theme'
+import {
+  loadHosts,
+  renameHost,
+  updateHostEndpoint
+} from '../../../src/transport/host-store'
+import {
+  displayHostEndpoint,
+  endpointPort,
+  normalizeHostEndpoint
+} from '../../../src/transport/host-endpoint'
+import { useForceReconnect, usePrimeHosts } from '../../../src/transport/client-context'
+import type { HostProfile } from '../../../src/transport/types'
+
+export default function EditHostScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const { hostId } = useLocalSearchParams<{ hostId: string }>()
+  const primeHosts = usePrimeHosts()
+  const forceReconnectHost = useForceReconnect()
+
+  const [host, setHost] = useState<HostProfile | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [address, setAddress] = useState('')
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const load = useCallback(async () => {
+    if (!hostId) {
+      setLoadError('Missing host.')
+      return
+    }
+    try {
+      const hosts = await loadHosts()
+      const found = hosts.find((h) => h.id === hostId) ?? null
+      if (!found) {
+        setLoadError('This host is no longer saved on this phone.')
+        setHost(null)
+        return
+      }
+      setHost(found)
+      setName(found.name)
+      setAddress(displayHostEndpoint(found.endpoint))
+      setLoadError(null)
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to load host.')
+      setHost(null)
+    }
+  }, [hostId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const fallbackPort = host ? endpointPort(host.endpoint) : undefined
+
+  const normalizedPreview = useMemo(() => {
+    const result = normalizeHostEndpoint(address, { fallbackPort })
+    return result.ok ? result.endpoint : null
+  }, [address, fallbackPort])
+
+  const nameTrimmed = name.trim()
+  const nameChanged = host != null && nameTrimmed.length > 0 && nameTrimmed !== host.name
+  const endpointChanged =
+    host != null && normalizedPreview != null && normalizedPreview !== host.endpoint
+  const canSave =
+    host != null &&
+    nameTrimmed.length > 0 &&
+    normalizedPreview != null &&
+    (nameChanged || endpointChanged) &&
+    !saving
+
+  async function handleSave() {
+    if (!host || !hostId) {
+      return
+    }
+    const nextName = name.trim()
+    if (!nextName) {
+      setSaveError('Enter a name.')
+      return
+    }
+    const normalized = normalizeHostEndpoint(address, {
+      fallbackPort: endpointPort(host.endpoint)
+    })
+    if (!normalized.ok) {
+      setSaveError(normalized.error)
+      return
+    }
+
+    const willRename = nextName !== host.name
+    const willUpdateEndpoint = normalized.endpoint !== host.endpoint
+    if (!willRename && !willUpdateEndpoint) {
+      router.back()
+      return
+    }
+
+    setSaving(true)
+    setSaveError(null)
+    try {
+      if (willRename) {
+        await renameHost(host.id, nextName)
+      }
+      if (willUpdateEndpoint) {
+        await updateHostEndpoint(host.id, normalized.endpoint)
+      }
+
+      const hosts = await loadHosts()
+      primeHosts(hosts)
+
+      if (willUpdateEndpoint) {
+        await forceReconnectHost(host.id)
+      }
+
+      router.back()
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save host.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
+      <View style={styles.topRow}>
+        <Pressable
+          style={styles.backButton}
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+        >
+          <ChevronLeft size={22} color={colors.textSecondary} />
+        </Pressable>
+        <Text style={styles.heading}>Edit host</Text>
+        <Pressable
+          style={({ pressed }) => [
+            styles.saveButton,
+            (!canSave || pressed) && styles.saveButtonDisabled
+          ]}
+          onPress={() => void handleSave()}
+          disabled={!canSave}
+          accessibilityRole="button"
+          accessibilityLabel="Save host"
+        >
+          {saving ? (
+            <ActivityIndicator size="small" color={colors.bgBase} />
+          ) : (
+            <Text style={styles.saveButtonText}>Save</Text>
+          )}
+        </Pressable>
+      </View>
+
+      {loadError ? (
+        <View style={styles.errorState}>
+          <Text style={styles.errorText}>{loadError}</Text>
+          <Pressable style={styles.secondaryButton} onPress={() => router.back()}>
+            <Text style={styles.secondaryButtonText}>Go back</Text>
+          </Pressable>
+        </View>
+      ) : !host ? (
+        <View style={styles.loadingState}>
+          <ActivityIndicator color={colors.textSecondary} />
+        </View>
+      ) : (
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        >
+          <ScrollView
+            contentContainerStyle={[
+              styles.form,
+              { paddingBottom: insets.bottom + spacing.xl }
+            ]}
+            keyboardShouldPersistTaps="handled"
+          >
+            <Text style={styles.help}>
+              Change the display name or connection address. Address edits only switch where this
+              phone connects — they do not re-pair. Use this when the same desktop is reachable at a
+              different IP (for example home LAN vs Tailscale).
+            </Text>
+
+            <Text style={styles.label}>Name</Text>
+            <TextInput
+              style={styles.input}
+              value={name}
+              onChangeText={(value) => {
+                setName(value)
+                setSaveError(null)
+              }}
+              placeholder="Host name"
+              placeholderTextColor={colors.textMuted}
+              autoCapitalize="words"
+              autoCorrect={false}
+              returnKeyType="next"
+            />
+
+            <Text style={styles.label}>Address</Text>
+            <TextInput
+              style={styles.input}
+              value={address}
+              onChangeText={(value) => {
+                setAddress(value)
+                setSaveError(null)
+              }}
+              placeholder="192.168.1.10:6768"
+              placeholderTextColor={colors.textMuted}
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="off"
+              keyboardType="url"
+              returnKeyType="done"
+              onSubmitEditing={() => {
+                if (canSave) {
+                  void handleSave()
+                }
+              }}
+            />
+            <Text style={styles.hint}>
+              Accepts IP, host:port, or ws:// / wss://. Missing port defaults to the current port
+              (or 6768).
+            </Text>
+
+            {normalizedPreview ? (
+              <Text style={styles.preview} numberOfLines={2}>
+                Connects to {normalizedPreview}
+              </Text>
+            ) : address.trim().length > 0 ? (
+              <Text style={styles.previewError}>
+                {(() => {
+                  const result = normalizeHostEndpoint(address, { fallbackPort })
+                  return result.ok ? null : result.error
+                })()}
+              </Text>
+            ) : null}
+
+            {saveError ? <Text style={styles.errorText}>{saveError}</Text> : null}
+          </ScrollView>
+        </KeyboardAvoidingView>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgBase
+  },
+  flex: {
+    flex: 1
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+    gap: spacing.sm
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  heading: {
+    flex: 1,
+    color: colors.textPrimary,
+    fontSize: 20,
+    fontWeight: '700'
+  },
+  saveButton: {
+    minWidth: 64,
+    height: 34,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.button,
+    backgroundColor: colors.surfaceBright,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  saveButtonDisabled: {
+    opacity: 0.4
+  },
+  saveButtonText: {
+    color: colors.bgBase,
+    fontSize: typography.bodySize,
+    fontWeight: '600'
+  },
+  form: {
+    paddingHorizontal: spacing.lg,
+    gap: spacing.sm
+  },
+  help: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    lineHeight: 20,
+    marginBottom: spacing.sm
+  },
+  label: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontWeight: '500',
+    marginTop: spacing.sm,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4
+  },
+  input: {
+    backgroundColor: colors.bgPanel,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radii.row,
+    color: colors.textPrimary,
+    fontSize: typography.bodySize,
+    paddingHorizontal: spacing.md,
+    paddingVertical: Platform.OS === 'ios' ? 12 : 10
+  },
+  hint: {
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    lineHeight: 16
+  },
+  preview: {
+    marginTop: spacing.sm,
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : typography.monoFamily
+  },
+  previewError: {
+    marginTop: spacing.sm,
+    color: colors.statusRed,
+    fontSize: typography.bodySize
+  },
+  errorText: {
+    color: colors.statusRed,
+    fontSize: typography.bodySize,
+    marginTop: spacing.md
+  },
+  errorState: {
+    flex: 1,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.xl,
+    gap: spacing.md
+  },
+  loadingState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  secondaryButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised
+  },
+  secondaryButtonText: {
+    color: colors.textPrimary,
+    fontSize: typography.bodySize,
+    fontWeight: '500'
+  }
+})

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -39,6 +39,7 @@ function HostStack({ animation }: { animation: 'none' | 'default' }) {
       }}
     >
       <Stack.Screen name="[hostId]/index" options={{ title: 'Host' }} />
+      <Stack.Screen name="[hostId]/edit" options={{ title: 'Edit host' }} />
       <Stack.Screen name="[hostId]/accounts" options={{ title: 'Accounts' }} />
       <Stack.Screen name="[hostId]/tasks" options={{ title: 'Tasks' }} />
       <Stack.Screen name="[hostId]/session/[worktreeId]" options={{ title: 'Terminal' }} />

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -25,7 +25,7 @@ import {
   UsageBar
 } from '../src/components/AccountUsage'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { loadHosts, removeHost, renameHost } from '../src/transport/host-store'
+import { loadHosts, removeHost } from '../src/transport/host-store'
 import { pickResumeWorktree } from '../src/worktree/resume-worktree'
 import type { RpcClient } from '../src/transport/rpc-client'
 import {
@@ -41,7 +41,6 @@ import { triggerMediumImpact } from '../src/platform/haptics'
 import { OrcaLogo } from '../src/components/OrcaLogo'
 import { StatusDot } from '../src/components/StatusDot'
 import { TaskProviderLogo } from '../src/components/TaskProviderLogo'
-import { TextInputModal } from '../src/components/TextInputModal'
 import { ActionSheetModal, type ActionSheetAction } from '../src/components/ActionSheetModal'
 import { ConfirmModal } from '../src/components/ConfirmModal'
 import { setCachedWorktrees, getCachedWorktrees } from '../src/cache/worktree-cache'
@@ -305,7 +304,6 @@ export default function HomeScreen() {
   const { isWideLayout, contentMaxWidth } = useResponsiveLayout()
   const [hosts, setHosts] = useState<HostProfile[]>([])
   const [actionTarget, setActionTarget] = useState<HostProfile | null>(null)
-  const [renameTarget, setRenameTarget] = useState<HostProfile | null>(null)
   const [confirmRemove, setConfirmRemove] = useState<HostProfile | null>(null)
   const [hostStates, setHostStates] = useState<Record<string, ConnectionState>>({})
   const [hostAttempts, setHostAttempts] = useState<Record<string, number>>({})
@@ -693,19 +691,6 @@ export default function HomeScreen() {
     </Pressable>
   )
 
-  async function handleRename(newName: string) {
-    if (!renameTarget) {
-      return
-    }
-    try {
-      await renameHost(renameTarget.id, newName)
-      setRenameTarget(null)
-      setHosts(await loadHosts())
-    } catch {
-      setRenameTarget(null)
-    }
-  }
-
   async function handleRemove() {
     if (!confirmRemove) {
       return
@@ -1077,11 +1062,11 @@ export default function HomeScreen() {
             })
           }
           items.push({
-            label: 'Rename',
+            label: 'Edit host',
             icon: Edit3,
             onPress: () => {
               setActionTarget(null)
-              setRenameTarget(host)
+              router.push(`/h/${host.id}/edit`)
             }
           })
           items.push({
@@ -1095,16 +1080,6 @@ export default function HomeScreen() {
           return items
         })()}
         onClose={() => setActionTarget(null)}
-      />
-
-      <TextInputModal
-        visible={renameTarget != null}
-        title="Rename Host"
-        message="Enter a new name for this host."
-        defaultValue={renameTarget?.name ?? ''}
-        placeholder="Host name"
-        onSubmit={(name) => void handleRename(name)}
-        onCancel={() => setRenameTarget(null)}
       />
 
       <ConfirmModal

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -29,6 +29,7 @@
     "expo-clipboard": "^55.0.13",
     "expo-constants": "^55.0.16",
     "expo-crypto": "^55.0.14",
+    "expo-device": "^55.0.14",
     "expo-dev-client": "~55.0.35",
     "expo-document-picker": "^55.0.13",
     "expo-file-system": "55.0.19",

--- a/mobile/plugins/ios-uikit-scene-lifecycle.js
+++ b/mobile/plugins/ios-uikit-scene-lifecycle.js
@@ -72,7 +72,55 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 }
 `
 
+const BOOTSTRAP_MIGRATED_MARKER = 'self.launchOptions = launchOptions'
+
+function hasMigratedBootstrap(contents) {
+  // Why: after the first successful bootstrap rewrite the old UIWindow pattern
+  // is gone. Reruns must short-circuit on this marker — not only on the scene
+  // hook — or a partial first pass (bootstrap ok, scene insert missed) throws
+  // on the second prebuild.
+  return (
+    contents.includes(BOOTSTRAP_MIGRATED_MARKER) ||
+    contents.includes('SceneDelegate owns the window under the UIScene lifecycle')
+  )
+}
+
+function insertSceneConfigurationHook(contents) {
+  if (contents.includes('configurationForConnecting')) {
+    return contents
+  }
+  const insertAfter = `return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }`
+  const sceneHook = `return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // Why: explicit scene configuration so UIKit uses SceneDelegate even if
+  // Info.plist naming differs across build modules.
+  public func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    let configuration = UISceneConfiguration(
+      name: "Default Configuration",
+      sessionRole: connectingSceneSession.role
+    )
+    configuration.delegateClass = SceneDelegate.self
+    return configuration
+  }`
+  if (!contents.includes(insertAfter)) {
+    throw new Error(
+      'ios-uikit-scene-lifecycle: could not insert configurationForConnecting; refuse partial rewrite'
+    )
+  }
+  return contents.replace(insertAfter, sceneHook)
+}
+
 function rewriteAppDelegate(contents) {
+  if (hasMigratedBootstrap(contents)) {
+    // Bootstrap already deferred to SceneDelegate — only ensure the scene hook.
+    return insertSceneConfigurationHook(contents)
+  }
   if (contents.includes('class SceneDelegate') || contents.includes('configurationForConnecting')) {
     return contents
   }
@@ -105,7 +153,7 @@ function rewriteAppDelegate(contents) {
       launchOptions: launchOptions)
 #endif`
 
-  const newBootstrap = `self.launchOptions = launchOptions
+  const newBootstrap = `${BOOTSTRAP_MIGRATED_MARKER}
 
     // Why: do not create UIWindow here — SceneDelegate owns the window under
     // the UIScene lifecycle required by iOS 27.`
@@ -115,7 +163,7 @@ function rewriteAppDelegate(contents) {
     // Fallback for slightly reformatted templates.
     next = next.replace(
       /window = UIWindow\(frame: UIScreen\.main\.bounds\)\s*\n\s*factory\.startReactNative\(\s*\n\s*withModuleName: "main",\s*\n\s*in: window,\s*\n\s*launchOptions: launchOptions\)/,
-      'self.launchOptions = launchOptions\n    // SceneDelegate owns the window under the UIScene lifecycle required by iOS 27.'
+      `${BOOTSTRAP_MIGRATED_MARKER}\n    // SceneDelegate owns the window under the UIScene lifecycle required by iOS 27.`
     )
   } else {
     next = next.replace(oldBootstrap, newBootstrap)
@@ -126,30 +174,9 @@ function rewriteAppDelegate(contents) {
     )
   }
 
-  if (!next.includes('configurationForConnecting')) {
-    const insertAfter = `return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }`
-    const sceneHook = `return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
-
-  // Why: explicit scene configuration so UIKit uses SceneDelegate even if
-  // Info.plist naming differs across build modules.
-  public func application(
-    _ application: UIApplication,
-    configurationForConnecting connectingSceneSession: UISceneSession,
-    options: UIScene.ConnectionOptions
-  ) -> UISceneConfiguration {
-    let configuration = UISceneConfiguration(
-      name: "Default Configuration",
-      sessionRole: connectingSceneSession.role
-    )
-    configuration.delegateClass = SceneDelegate.self
-    return configuration
-  }`
-    if (next.includes(insertAfter)) {
-      next = next.replace(insertAfter, sceneHook)
-    }
-  }
+  // Why: refuse partial migration — bootstrap without scene configuration leaves
+  // the app without a SceneDelegate on the next launch.
+  next = insertSceneConfigurationHook(next)
 
   return next
 }

--- a/mobile/plugins/ios-uikit-scene-lifecycle.js
+++ b/mobile/plugins/ios-uikit-scene-lifecycle.js
@@ -56,14 +56,24 @@ function rewriteAppDelegate(contents) {
     return contents
   }
 
-  // Ensure launchOptions storage + factory fields stay public for SceneDelegate.
-  let next = contents.replace(
-    /var reactNativeFactory: RCTReactNativeFactory\?/,
-    `var reactNativeFactory: RCTReactNativeFactory?
+  let next = contents
+  // Why: prebuild re-runs; never inject a second launchOptions property or the
+  // Swift build fails with a redeclaration error.
+  if (!/\bvar\s+launchOptions\s*:/.test(next)) {
+    const withLaunchOptions = next.replace(
+      /var reactNativeFactory: RCTReactNativeFactory\?/,
+      `var reactNativeFactory: RCTReactNativeFactory?
   // Why: SceneDelegate starts RN after the UIWindowScene connects; keep the
   // original launchOptions so deep links / cold-start params still work.
   var launchOptions: [UIApplication.LaunchOptionsKey: Any]?`
-  )
+    )
+    if (withLaunchOptions === next) {
+      throw new Error(
+        'ios-uikit-scene-lifecycle: could not find reactNativeFactory field to attach launchOptions'
+      )
+    }
+    next = withLaunchOptions
+  }
 
   // Replace window-owned RN bootstrap with deferred SceneDelegate bootstrap.
   const oldBootstrap = `#if os(iOS) || os(tvOS)
@@ -79,6 +89,7 @@ function rewriteAppDelegate(contents) {
     // Why: do not create UIWindow here — SceneDelegate owns the window under
     // the UIScene lifecycle required by iOS 27.`
 
+  const beforeBootstrap = next
   if (!next.includes(oldBootstrap)) {
     // Fallback for slightly reformatted templates.
     next = next.replace(
@@ -87,6 +98,11 @@ function rewriteAppDelegate(contents) {
     )
   } else {
     next = next.replace(oldBootstrap, newBootstrap)
+  }
+  if (next === beforeBootstrap) {
+    throw new Error(
+      'ios-uikit-scene-lifecycle: AppDelegate bootstrap pattern not found; refuse silent no-op rewrite'
+    )
   }
 
   if (!next.includes('configurationForConnecting')) {

--- a/mobile/plugins/ios-uikit-scene-lifecycle.js
+++ b/mobile/plugins/ios-uikit-scene-lifecycle.js
@@ -14,6 +14,7 @@ const path = require('node:path')
 // on iOS 27. See Apple TN3187 and expo/expo#46664.
 
 const SCENE_DELEGATE_SOURCE = `import UIKit
+import React
 
 // Why: iOS 27 / Xcode 27 UIKit requires the scene-based lifecycle. Apps that
 // only create UIWindow in AppDelegate hit EXC_BREAKPOINT in
@@ -42,11 +43,31 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     self.window = window
     appDelegate.window = window
 
+    // Why: under UIScene, cold-start orca://pair URLs land in
+    // connectionOptions.urlContexts, not UIApplication launchOptions. Merge
+    // them so Linking.getInitialURL() can still see the pair deep link.
+    var launchOptions = appDelegate.launchOptions ?? [:]
+    if let url = connectionOptions.urlContexts.first?.url {
+      launchOptions[UIApplication.LaunchOptionsKey.url] = url
+    }
+
     factory.startReactNative(
       withModuleName: "main",
       in: window,
-      launchOptions: appDelegate.launchOptions
+      launchOptions: launchOptions
     )
+  }
+
+  // Why: warm opens (app already running) deliver orca:// via this scene
+  // callback, not AppDelegate.application(_:open:). Forward to RN Linking.
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    for context in URLContexts {
+      RCTLinkingManager.application(
+        UIApplication.shared,
+        open: context.url,
+        options: [:]
+      )
+    }
   }
 }
 `

--- a/mobile/plugins/ios-uikit-scene-lifecycle.js
+++ b/mobile/plugins/ios-uikit-scene-lifecycle.js
@@ -1,0 +1,200 @@
+const {
+  withDangerousMod,
+  withInfoPlist,
+  withXcodeProject,
+  IOSConfig
+} = require('expo/config-plugins')
+const fs = require('node:fs')
+const path = require('node:path')
+
+// Why: iOS 27 / Xcode 27 UIKit aborts apps that still own UIWindow only from
+// AppDelegate (UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption).
+// Expo prebuild still emits that template; this plugin rewrites it to a
+// SceneDelegate-based lifecycle so TestFlight and local device builds launch
+// on iOS 27. See Apple TN3187 and expo/expo#46664.
+
+const SCENE_DELEGATE_SOURCE = `import UIKit
+
+// Why: iOS 27 / Xcode 27 UIKit requires the scene-based lifecycle. Apps that
+// only create UIWindow in AppDelegate hit EXC_BREAKPOINT in
+// UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption. Move the RN
+// root window onto UIWindowScene here (Apple TN3187).
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else {
+      return
+    }
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+      return
+    }
+    guard let factory = appDelegate.reactNativeFactory else {
+      return
+    }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+    appDelegate.window = window
+
+    factory.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: appDelegate.launchOptions
+    )
+  }
+}
+`
+
+function rewriteAppDelegate(contents) {
+  if (contents.includes('class SceneDelegate') || contents.includes('configurationForConnecting')) {
+    return contents
+  }
+
+  // Ensure launchOptions storage + factory fields stay public for SceneDelegate.
+  let next = contents.replace(
+    /var reactNativeFactory: RCTReactNativeFactory\?/,
+    `var reactNativeFactory: RCTReactNativeFactory?
+  // Why: SceneDelegate starts RN after the UIWindowScene connects; keep the
+  // original launchOptions so deep links / cold-start params still work.
+  var launchOptions: [UIApplication.LaunchOptionsKey: Any]?`
+  )
+
+  // Replace window-owned RN bootstrap with deferred SceneDelegate bootstrap.
+  const oldBootstrap = `#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    factory.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif`
+
+  const newBootstrap = `self.launchOptions = launchOptions
+
+    // Why: do not create UIWindow here — SceneDelegate owns the window under
+    // the UIScene lifecycle required by iOS 27.`
+
+  if (!next.includes(oldBootstrap)) {
+    // Fallback for slightly reformatted templates.
+    next = next.replace(
+      /window = UIWindow\(frame: UIScreen\.main\.bounds\)\s*\n\s*factory\.startReactNative\(\s*\n\s*withModuleName: "main",\s*\n\s*in: window,\s*\n\s*launchOptions: launchOptions\)/,
+      'self.launchOptions = launchOptions\n    // SceneDelegate owns the window under the UIScene lifecycle required by iOS 27.'
+    )
+  } else {
+    next = next.replace(oldBootstrap, newBootstrap)
+  }
+
+  if (!next.includes('configurationForConnecting')) {
+    const insertAfter = `return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }`
+    const sceneHook = `return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // Why: explicit scene configuration so UIKit uses SceneDelegate even if
+  // Info.plist naming differs across build modules.
+  public func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    let configuration = UISceneConfiguration(
+      name: "Default Configuration",
+      sessionRole: connectingSceneSession.role
+    )
+    configuration.delegateClass = SceneDelegate.self
+    return configuration
+  }`
+    if (next.includes(insertAfter)) {
+      next = next.replace(insertAfter, sceneHook)
+    }
+  }
+
+  return next
+}
+
+function withSceneInfoPlist(config) {
+  return withInfoPlist(config, (cfg) => {
+    cfg.modResults.UIApplicationSceneManifest = {
+      UIApplicationSupportsMultipleScenes: false,
+      UISceneConfigurations: {
+        UIWindowSceneSessionRoleApplication: [
+          {
+            UISceneConfigurationName: 'Default Configuration',
+            UISceneDelegateClassName: '$(PRODUCT_MODULE_NAME).SceneDelegate'
+          }
+        ]
+      }
+    }
+    return cfg
+  })
+}
+
+function withSceneDelegateFile(config) {
+  return withDangerousMod(config, [
+    'ios',
+    async (cfg) => {
+      const projectRoot = cfg.modRequest.platformProjectRoot
+      const projectName = IOSConfig.XcodeUtils.getProjectName(cfg.modRequest.projectRoot)
+      const appDir = path.join(projectRoot, projectName)
+
+      fs.writeFileSync(path.join(appDir, 'SceneDelegate.swift'), SCENE_DELEGATE_SOURCE)
+
+      const appDelegatePath = path.join(appDir, 'AppDelegate.swift')
+      if (fs.existsSync(appDelegatePath)) {
+        const original = fs.readFileSync(appDelegatePath, 'utf8')
+        const rewritten = rewriteAppDelegate(original)
+        if (rewritten !== original) {
+          fs.writeFileSync(appDelegatePath, rewritten)
+        }
+      }
+
+      return cfg
+    }
+  ])
+}
+
+function withSceneDelegateXcodeProject(config) {
+  return withXcodeProject(config, (cfg) => {
+    const project = cfg.modResults
+    const projectName = IOSConfig.XcodeUtils.getProjectName(cfg.modRequest.projectRoot)
+    const filePath = `${projectName}/SceneDelegate.swift`
+
+    // Why: prebuild may re-run; skip if the file is already linked.
+    try {
+      const section =
+        typeof project.pbxFileReferenceSection === 'function'
+          ? project.pbxFileReferenceSection()
+          : project.pbxFileReferenceSection
+      const alreadyLinked = Object.values(section ?? {}).some(
+        (entry) =>
+          entry &&
+          typeof entry === 'object' &&
+          typeof entry.path === 'string' &&
+          entry.path.includes('SceneDelegate.swift')
+      )
+      if (!alreadyLinked) {
+        IOSConfig.XcodeUtils.addBuildSourceFileToGroup({
+          filepath: filePath,
+          groupName: projectName,
+          project
+        })
+      }
+    } catch {
+      // Best-effort: file is still written to disk for manual Xcode include.
+    }
+
+    return cfg
+  })
+}
+
+module.exports = function withIosUIKitSceneLifecycle(config) {
+  config = withSceneInfoPlist(config)
+  config = withSceneDelegateFile(config)
+  config = withSceneDelegateXcodeProject(config)
+  return config
+}

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       expo-dev-client:
         specifier: ~55.0.35
         version: 55.0.35(expo@55.0.23)
+      expo-device:
+        specifier: ^55.0.14
+        version: 55.0.18(expo@55.0.23)
       expo-document-picker:
         specifier: ^55.0.13
         version: 55.0.13(expo@55.0.23)
@@ -1895,48 +1898,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.52.0':
     resolution: {integrity: sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
     resolution: {integrity: sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
     resolution: {integrity: sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.52.0':
     resolution: {integrity: sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.52.0':
     resolution: {integrity: sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.52.0':
     resolution: {integrity: sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.52.0':
     resolution: {integrity: sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.52.0':
     resolution: {integrity: sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==}
@@ -2009,48 +2020,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.71.0':
     resolution: {integrity: sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.71.0':
     resolution: {integrity: sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.71.0':
     resolution: {integrity: sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.71.0':
     resolution: {integrity: sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.71.0':
     resolution: {integrity: sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.71.0':
     resolution: {integrity: sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.71.0':
     resolution: {integrity: sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.71.0':
     resolution: {integrity: sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==}
@@ -2512,36 +2531,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.3':
     resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.3':
     resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.3':
     resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.3':
     resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.3':
     resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.3':
     resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
@@ -2839,11 +2864,6 @@ packages:
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.17.0:
-    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3822,6 +3842,11 @@ packages:
 
   expo-dev-menu@55.0.30:
     resolution: {integrity: sha512-uwDI4cEPzpRemf06Ts5O41azJcz8BBcE6QOkNaTX8JlzdJ05eq9jWxmbA1WhoSoE5C+NFo8njHSvmHqUqTpOng==}
+    peerDependencies:
+      expo: '*'
+
+  expo-device@55.0.18:
+    resolution: {integrity: sha512-MEdnb+Si3VICmJzzSVsQyo90LQg8cG5h9to2tcaHFXPX31yOolYJXbHGN5bmR9MjKOgw6d6h7Ow/kMTnSwZrPQ==}
     peerDependencies:
       expo: '*'
 
@@ -4821,24 +4846,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6198,6 +6227,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ua-parser-js@0.7.41:
+    resolution: {integrity: sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==}
+    hasBin: true
+
   ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
@@ -6945,22 +6978,22 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.7)':
     dependencies:
@@ -6970,7 +7003,7 @@ snapshots:
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-export-default-from@7.28.6(@babel/core@7.29.7)':
     dependencies:
@@ -7005,12 +7038,12 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
@@ -7025,42 +7058,42 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
@@ -8422,7 +8455,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -8589,7 +8622,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -9347,24 +9380,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/chai@5.2.3':
     dependencies:
@@ -9379,7 +9412,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/hammerjs@2.0.46': {}
 
@@ -9626,17 +9659,15 @@ snapshots:
       acorn: 8.15.0
       acorn-walk: 8.3.5
 
-  acorn-jsx@5.3.2(acorn@8.17.0):
+  acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.15.0
 
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
-
-  acorn@8.17.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -9792,7 +9823,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-instrument: 5.2.1
@@ -10465,7 +10496,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
@@ -10761,8 +10792,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
@@ -10886,6 +10917,11 @@ snapshots:
     dependencies:
       expo: 55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       expo-dev-menu-interface: 55.0.2(expo@55.0.23)
+
+  expo-device@55.0.18(expo@55.0.23):
+    dependencies:
+      expo: 55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      ua-parser-js: 0.7.41
 
   expo-document-picker@55.0.13(expo@55.0.23):
     dependencies:
@@ -11295,7 +11331,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -11867,7 +11903,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12022,7 +12058,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12067,7 +12103,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -13740,7 +13776,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.17.0
+      acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -13880,6 +13916,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.3: {}
+
+  ua-parser-js@0.7.41: {}
 
   ua-parser-js@1.0.41: {}
 

--- a/mobile/src/transport/device-identity.test.ts
+++ b/mobile/src/transport/device-identity.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const constantsMock = vi.hoisted(() => ({
+  platform: {
+    ios: { model: null as string | null }
+  }
+}))
+
+const platformMock = vi.hoisted(() => ({
+  OS: 'ios' as string,
+  constants: {} as Record<string, string>
+}))
+
+vi.mock('expo-constants', () => ({
+  default: constantsMock
+}))
+
+vi.mock('react-native', () => ({
+  Platform: platformMock
+}))
+
+import { resolveMobileDeviceDisplayName, sanitizeDeviceDisplayName } from './device-identity'
+
+describe('sanitizeDeviceDisplayName', () => {
+  it('trims and caps length', () => {
+    expect(sanitizeDeviceDisplayName('  iPhone 15 Pro Max  ')).toBe('iPhone 15 Pro Max')
+    expect(sanitizeDeviceDisplayName('x'.repeat(80))).toHaveLength(64)
+  })
+
+  it('rejects empty / control-only strings', () => {
+    expect(sanitizeDeviceDisplayName('   ')).toBeNull()
+    expect(sanitizeDeviceDisplayName('\u0000\u0001')).toBeNull()
+  })
+})
+
+describe('resolveMobileDeviceDisplayName', () => {
+  afterEach(() => {
+    platformMock.OS = 'ios'
+    platformMock.constants = {}
+    constantsMock.platform.ios.model = null
+  })
+
+  it('prefers iOS marketing model from expo-constants', () => {
+    platformMock.OS = 'ios'
+    constantsMock.platform.ios.model = 'iPhone 15 Pro Max'
+    expect(resolveMobileDeviceDisplayName()).toBe('iPhone 15 Pro Max')
+  })
+
+  it('falls back to iPhone when model is unavailable', () => {
+    platformMock.OS = 'ios'
+    constantsMock.platform.ios.model = null
+    expect(resolveMobileDeviceDisplayName()).toBe('iPhone')
+  })
+
+  it('uses Android brand + model when present', () => {
+    platformMock.OS = 'android'
+    platformMock.constants = { Brand: 'Google', Model: 'Pixel 8' }
+    expect(resolveMobileDeviceDisplayName()).toBe('Google Pixel 8')
+  })
+
+  it('avoids duplicating brand when model already includes it', () => {
+    platformMock.OS = 'android'
+    platformMock.constants = { Brand: 'Samsung', Model: 'Samsung Galaxy S24' }
+    expect(resolveMobileDeviceDisplayName()).toBe('Samsung Galaxy S24')
+  })
+})

--- a/mobile/src/transport/device-identity.test.ts
+++ b/mobile/src/transport/device-identity.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const constantsMock = vi.hoisted(() => ({
-  platform: {
-    ios: { model: null as string | null }
-  }
+const deviceMock = vi.hoisted(() => ({
+  modelName: null as string | null
 }))
 
 const platformMock = vi.hoisted(() => ({
@@ -11,9 +9,7 @@ const platformMock = vi.hoisted(() => ({
   constants: {} as Record<string, string>
 }))
 
-vi.mock('expo-constants', () => ({
-  default: constantsMock
-}))
+vi.mock('expo-device', () => deviceMock)
 
 vi.mock('react-native', () => ({
   Platform: platformMock
@@ -37,18 +33,18 @@ describe('resolveMobileDeviceDisplayName', () => {
   afterEach(() => {
     platformMock.OS = 'ios'
     platformMock.constants = {}
-    constantsMock.platform.ios.model = null
+    deviceMock.modelName = null
   })
 
-  it('prefers iOS marketing model from expo-constants', () => {
+  it('prefers iOS marketing model from expo-device', () => {
     platformMock.OS = 'ios'
-    constantsMock.platform.ios.model = 'iPhone 15 Pro Max'
+    deviceMock.modelName = 'iPhone 15 Pro Max'
     expect(resolveMobileDeviceDisplayName()).toBe('iPhone 15 Pro Max')
   })
 
   it('falls back to iPhone when model is unavailable', () => {
     platformMock.OS = 'ios'
-    constantsMock.platform.ios.model = null
+    deviceMock.modelName = null
     expect(resolveMobileDeviceDisplayName()).toBe('iPhone')
   })
 

--- a/mobile/src/transport/device-identity.ts
+++ b/mobile/src/transport/device-identity.ts
@@ -43,8 +43,15 @@ export function resolveMobileDeviceDisplayName(): string {
 }
 
 export function sanitizeDeviceDisplayName(raw: string): string | null {
+  // Why: device metadata is untrusted display text; remove terminal/control
+  // bytes without a control-character regex that cross-platform lint rejects.
   const cleaned = raw
-    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .split('')
+    .filter((character) => {
+      const code = character.charCodeAt(0)
+      return code > 0x1f && code !== 0x7f
+    })
+    .join('')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, MAX_DEVICE_NAME_LENGTH)

--- a/mobile/src/transport/device-identity.ts
+++ b/mobile/src/transport/device-identity.ts
@@ -1,4 +1,4 @@
-import Constants from 'expo-constants'
+import * as Device from 'expo-device'
 import { Platform } from 'react-native'
 
 // Why: desktop Settings → Paired Devices currently shows the placeholder name
@@ -8,9 +8,14 @@ import { Platform } from 'react-native'
 const MAX_DEVICE_NAME_LENGTH = 64
 
 export function resolveMobileDeviceDisplayName(): string {
-  const iosModel = Constants.platform?.ios?.model
-  if (typeof iosModel === 'string' && iosModel.trim()) {
-    return sanitizeDeviceDisplayName(iosModel) ?? fallbackPlatformLabel()
+  // Why: expo-constants dropped Constants.platform.ios.model in SDK 52+; use
+  // expo-device's marketing name so iOS reports "iPhone 15 Pro" instead of
+  // the bare "iPhone" fallback.
+  if (Platform.OS === 'ios') {
+    const modelName = typeof Device.modelName === 'string' ? Device.modelName.trim() : ''
+    if (modelName) {
+      return sanitizeDeviceDisplayName(modelName) ?? fallbackPlatformLabel()
+    }
   }
 
   // Why: AndroidManifest in expo-constants has no marketing model field, but

--- a/mobile/src/transport/device-identity.ts
+++ b/mobile/src/transport/device-identity.ts
@@ -1,0 +1,57 @@
+import Constants from 'expo-constants'
+import { Platform } from 'react-native'
+
+// Why: desktop Settings → Paired Devices currently shows the placeholder name
+// minted at QR time ("Mobile 7/3/2026"). The phone can report a human model
+// on e2ee_auth so the desktop renames the registry entry after first connect.
+
+const MAX_DEVICE_NAME_LENGTH = 64
+
+export function resolveMobileDeviceDisplayName(): string {
+  const iosModel = Constants.platform?.ios?.model
+  if (typeof iosModel === 'string' && iosModel.trim()) {
+    return sanitizeDeviceDisplayName(iosModel) ?? fallbackPlatformLabel()
+  }
+
+  // Why: AndroidManifest in expo-constants has no marketing model field, but
+  // RN Platform.constants exposes Brand/Model on Android native builds.
+  if (Platform.OS === 'android') {
+    const constants = Platform.constants as {
+      Brand?: string
+      Model?: string
+      Manufacturer?: string
+    }
+    const brand = typeof constants.Brand === 'string' ? constants.Brand.trim() : ''
+    const model = typeof constants.Model === 'string' ? constants.Model.trim() : ''
+    if (brand && model && !model.toLowerCase().startsWith(brand.toLowerCase())) {
+      return sanitizeDeviceDisplayName(`${brand} ${model}`) ?? fallbackPlatformLabel()
+    }
+    if (model) {
+      return sanitizeDeviceDisplayName(model) ?? fallbackPlatformLabel()
+    }
+    if (brand) {
+      return sanitizeDeviceDisplayName(brand) ?? fallbackPlatformLabel()
+    }
+  }
+
+  return fallbackPlatformLabel()
+}
+
+export function sanitizeDeviceDisplayName(raw: string): string | null {
+  const cleaned = raw
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_DEVICE_NAME_LENGTH)
+  return cleaned.length > 0 ? cleaned : null
+}
+
+function fallbackPlatformLabel(): string {
+  if (Platform.OS === 'ios') {
+    return 'iPhone'
+  }
+  if (Platform.OS === 'android') {
+    return 'Android'
+  }
+  return 'Mobile'
+}

--- a/mobile/src/transport/host-endpoint.test.ts
+++ b/mobile/src/transport/host-endpoint.test.ts
@@ -98,6 +98,32 @@ describe('normalizeHostEndpoint', () => {
     })
   })
 
+  it('rejects bare hosts with path, query, or spaces', () => {
+    expect(normalizeHostEndpoint('desk/path')).toEqual({
+      ok: false,
+      error: 'Not a valid hostname.'
+    })
+    expect(normalizeHostEndpoint('desk?route')).toEqual({
+      ok: false,
+      error: 'Not a valid hostname.'
+    })
+    expect(normalizeHostEndpoint('desk name')).toEqual({
+      ok: false,
+      error: 'Not a valid hostname.'
+    })
+  })
+
+  it('rejects scheme URLs with path or query', () => {
+    expect(normalizeHostEndpoint('ws://desk.example/path')).toEqual({
+      ok: false,
+      error: 'Host must not include a path or query.'
+    })
+    expect(normalizeHostEndpoint('ws://desk.example?route=1')).toEqual({
+      ok: false,
+      error: 'Host must not include a path or query.'
+    })
+  })
+
   it('accepts bracketed IPv6 with port', () => {
     expect(normalizeHostEndpoint('[fd7a:115c:a1e0::1]:6768')).toEqual({
       ok: true,

--- a/mobile/src/transport/host-endpoint.test.ts
+++ b/mobile/src/transport/host-endpoint.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { displayHostEndpoint, endpointPort, normalizeHostEndpoint } from './host-endpoint'
+
+describe('displayHostEndpoint', () => {
+  it('shows host:port for websocket URLs', () => {
+    expect(displayHostEndpoint('ws://192.168.1.10:6768')).toBe('192.168.1.10:6768')
+    // Why: URL omits default scheme ports (443 for wss); use a non-default port.
+    expect(displayHostEndpoint('wss://desk.example:8443')).toBe('desk.example:8443')
+  })
+
+  it('returns the raw string when not a URL', () => {
+    expect(displayHostEndpoint('not-a-url')).toBe('not-a-url')
+  })
+})
+
+describe('endpointPort', () => {
+  it('reads the port when present', () => {
+    expect(endpointPort('ws://192.168.1.10:6768')).toBe('6768')
+  })
+
+  it('returns undefined when the port is omitted', () => {
+    expect(endpointPort('ws://192.168.1.10')).toBeUndefined()
+  })
+})
+
+describe('normalizeHostEndpoint', () => {
+  it('accepts a full ws URL', () => {
+    expect(normalizeHostEndpoint('ws://100.64.0.5:6768')).toEqual({
+      ok: true,
+      endpoint: 'ws://100.64.0.5:6768'
+    })
+  })
+
+  it('accepts wss and preserves scheme', () => {
+    expect(normalizeHostEndpoint('wss://desk.example:8443')).toEqual({
+      ok: true,
+      endpoint: 'wss://desk.example:8443'
+    })
+  })
+
+  it('accepts bare host:port', () => {
+    expect(normalizeHostEndpoint('192.168.1.10:6768')).toEqual({
+      ok: true,
+      endpoint: 'ws://192.168.1.10:6768'
+    })
+  })
+
+  it('defaults missing port to 6768', () => {
+    expect(normalizeHostEndpoint('192.168.1.10')).toEqual({
+      ok: true,
+      endpoint: 'ws://192.168.1.10:6768'
+    })
+  })
+
+  it('uses fallbackPort when the user omits the port', () => {
+    expect(normalizeHostEndpoint('mac-mini.local', { fallbackPort: '7777' })).toEqual({
+      ok: true,
+      endpoint: 'ws://mac-mini.local:7777'
+    })
+  })
+
+  it('fills missing port on scheme URLs from fallbackPort', () => {
+    expect(normalizeHostEndpoint('ws://192.168.1.10', { fallbackPort: '9000' })).toEqual({
+      ok: true,
+      endpoint: 'ws://192.168.1.10:9000'
+    })
+  })
+
+  it('trims whitespace', () => {
+    expect(normalizeHostEndpoint('  10.0.0.2:6768  ')).toEqual({
+      ok: true,
+      endpoint: 'ws://10.0.0.2:6768'
+    })
+  })
+
+  it('rejects empty input', () => {
+    expect(normalizeHostEndpoint('   ')).toEqual({
+      ok: false,
+      error: 'Enter a host address.'
+    })
+  })
+
+  it('rejects non-websocket schemes', () => {
+    expect(normalizeHostEndpoint('http://192.168.1.10:6768')).toEqual({
+      ok: false,
+      error: 'Use ws:// or wss:// (or host:port).'
+    })
+  })
+
+  it('rejects invalid ports', () => {
+    expect(normalizeHostEndpoint('192.168.1.10:99999')).toEqual({
+      ok: false,
+      error: 'Port must be 1–65535.'
+    })
+  })
+
+  it('accepts bracketed IPv6 with port', () => {
+    expect(normalizeHostEndpoint('[fd7a:115c:a1e0::1]:6768')).toEqual({
+      ok: true,
+      endpoint: 'ws://[fd7a:115c:a1e0::1]:6768'
+    })
+  })
+})

--- a/mobile/src/transport/host-endpoint.test.ts
+++ b/mobile/src/transport/host-endpoint.test.ts
@@ -11,6 +11,10 @@ describe('displayHostEndpoint', () => {
   it('returns the raw string when not a URL', () => {
     expect(displayHostEndpoint('not-a-url')).toBe('not-a-url')
   })
+
+  it('brackets IPv6 hostnames for round-trip safety', () => {
+    expect(displayHostEndpoint('ws://[fd7a:115c:a1e0::1]:6768')).toBe('[fd7a:115c:a1e0::1]:6768')
+  })
 })
 
 describe('endpointPort', () => {
@@ -98,6 +102,25 @@ describe('normalizeHostEndpoint', () => {
     expect(normalizeHostEndpoint('[fd7a:115c:a1e0::1]:6768')).toEqual({
       ok: true,
       endpoint: 'ws://[fd7a:115c:a1e0::1]:6768'
+    })
+  })
+
+  it('preserves wss when re-normalizing bare host:port via fallbackScheme', () => {
+    expect(
+      normalizeHostEndpoint('desk.example:8443', { fallbackScheme: 'wss', fallbackPort: '8443' })
+    ).toEqual({
+      ok: true,
+      endpoint: 'wss://desk.example:8443'
+    })
+  })
+
+  it('round-trips displayed IPv6 endpoints without port corruption', () => {
+    const original = 'ws://[fd7a:115c:a1e0::1]:6768'
+    const displayed = displayHostEndpoint(original)
+    expect(displayed).toBe('[fd7a:115c:a1e0::1]:6768')
+    expect(normalizeHostEndpoint(displayed, { fallbackPort: '6768' })).toEqual({
+      ok: true,
+      endpoint: original
     })
   })
 })

--- a/mobile/src/transport/host-endpoint.test.ts
+++ b/mobile/src/transport/host-endpoint.test.ts
@@ -25,6 +25,11 @@ describe('endpointPort', () => {
   it('returns undefined when the port is omitted', () => {
     expect(endpointPort('ws://192.168.1.10')).toBeUndefined()
   })
+
+  it('preserves scheme-default ports that URL.port hides', () => {
+    expect(endpointPort('ws://192.168.1.10:80')).toBe('80')
+    expect(endpointPort('wss://desk.example:443')).toBe('443')
+  })
 })
 
 describe('normalizeHostEndpoint', () => {
@@ -68,6 +73,19 @@ describe('normalizeHostEndpoint', () => {
       ok: true,
       endpoint: 'ws://192.168.1.10:9000'
     })
+  })
+
+  it('preserves explicit ws :80 and wss :443 instead of rewriting to fallback', () => {
+    expect(normalizeHostEndpoint('ws://192.168.1.10:80', { fallbackPort: '6768' })).toEqual({
+      ok: true,
+      endpoint: 'ws://192.168.1.10:80'
+    })
+    expect(normalizeHostEndpoint('wss://desk.example:443', { fallbackPort: '6768' })).toEqual({
+      ok: true,
+      endpoint: 'wss://desk.example:443'
+    })
+    expect(displayHostEndpoint('ws://192.168.1.10:80')).toBe('192.168.1.10:80')
+    expect(displayHostEndpoint('wss://desk.example:443')).toBe('desk.example:443')
   })
 
   it('trims whitespace', () => {

--- a/mobile/src/transport/host-endpoint.ts
+++ b/mobile/src/transport/host-endpoint.ts
@@ -15,7 +15,8 @@ export function displayHostEndpoint(endpoint: string): string {
     // Why: some URL parsers leave IPv6 brackets on hostname, others strip them.
     // Normalize once so round-trip through normalizeHostEndpoint stays stable.
     const host = formatHostForUrl(unwrapHostname(url.hostname))
-    return `${host}${url.port ? `:${url.port}` : ''}`
+    const port = resolveWebsocketUrlPort(endpoint, url)
+    return port ? `${host}:${port}` : host
   } catch {
     return endpoint
   }
@@ -25,10 +26,46 @@ function unwrapHostname(hostname: string): string {
   return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
 }
 
+/**
+ * Recover an explicitly written port from a ws(s) URL authority.
+ * Why: `new URL('ws://host:80').port` and `wss://host:443` are empty — the
+ * URL parser hides scheme-default ports, so callers that need the user's
+ * literal :80/:443 must re-parse the original string.
+ */
+function extractExplicitPortFromWebsocketUrl(input: string): string | null {
+  const withoutScheme = input.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, '')
+  if (withoutScheme.startsWith('[')) {
+    const close = withoutScheme.indexOf(']')
+    if (close <= 1) {
+      return null
+    }
+    const rest = withoutScheme.slice(close + 1)
+    const match = /^:(\d+)(?=[/?#]|$)/.exec(rest)
+    return match?.[1] ?? null
+  }
+  const end = withoutScheme.search(/[/?#]/)
+  const authority = end === -1 ? withoutScheme : withoutScheme.slice(0, end)
+  const at = authority.lastIndexOf('@')
+  const hostPort = at === -1 ? authority : authority.slice(at + 1)
+  const match = /:(\d+)$/.exec(hostPort)
+  return match?.[1] ?? null
+}
+
+function resolveWebsocketUrlPort(input: string, url: URL): string | null {
+  if (url.port) {
+    return url.port
+  }
+  const explicit = extractExplicitPortFromWebsocketUrl(input)
+  if (explicit && isValidPort(explicit)) {
+    return explicit
+  }
+  return null
+}
+
 export function endpointPort(endpoint: string): string | undefined {
   try {
     const url = new URL(endpoint)
-    return url.port || undefined
+    return resolveWebsocketUrlPort(endpoint, url) ?? undefined
   } catch {
     return undefined
   }
@@ -104,7 +141,9 @@ function normalizeSchemeUrl(input: string, fallbackPort: string): NormalizeHostE
     return { ok: false, error: hostError }
   }
 
-  const port = url.port || fallbackPort
+  // Why: keep explicit :80/:443 (URL.port is empty for scheme defaults) instead
+  // of rewriting them to fallbackPort (usually 6768).
+  const port = resolveWebsocketUrlPort(input, url) ?? fallbackPort
   if (!isValidPort(port)) {
     return { ok: false, error: 'Port must be 1–65535.' }
   }

--- a/mobile/src/transport/host-endpoint.ts
+++ b/mobile/src/transport/host-endpoint.ts
@@ -12,13 +12,17 @@ const DEFAULT_PORT = '6768'
 export function displayHostEndpoint(endpoint: string): string {
   try {
     const url = new URL(endpoint)
-    // Why: URL.hostname strips IPv6 brackets; re-wrap so round-trip through
-    // normalizeHostEndpoint does not treat "addr:port" as a single host.
-    const host = url.hostname.includes(':') ? `[${url.hostname}]` : url.hostname
+    // Why: some URL parsers leave IPv6 brackets on hostname, others strip them.
+    // Normalize once so round-trip through normalizeHostEndpoint stays stable.
+    const host = formatHostForUrl(unwrapHostname(url.hostname))
     return `${host}${url.port ? `:${url.port}` : ''}`
   } catch {
     return endpoint
   }
+}
+
+function unwrapHostname(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
 }
 
 export function endpointPort(endpoint: string): string | undefined {
@@ -84,14 +88,29 @@ function normalizeSchemeUrl(input: string, fallbackPort: string): NormalizeHostE
     return { ok: false, error: 'Missing hostname.' }
   }
 
+  // Why: edit-host persists a bare host:port WebSocket endpoint. Path/query/
+  // userinfo are not part of the pairing contract — reject rather than strip
+  // so typos like desk/path or desk?route cannot be saved silently.
+  if (url.username || url.password) {
+    return { ok: false, error: 'Not a valid address.' }
+  }
+  if ((url.pathname && url.pathname !== '/') || url.search || url.hash) {
+    return { ok: false, error: 'Host must not include a path or query.' }
+  }
+
+  const hostname = unwrapHostname(url.hostname)
+  const hostError = validateHostname(hostname)
+  if (hostError) {
+    return { ok: false, error: hostError }
+  }
+
   const port = url.port || fallbackPort
   if (!isValidPort(port)) {
     return { ok: false, error: 'Port must be 1–65535.' }
   }
 
-  // Why: rebuild so path/query noise and accidental whitespace never reach the
-  // WebSocket constructor; pairing offers are host:port only.
-  return { ok: true, endpoint: `${url.protocol}//${formatHostForUrl(url.hostname)}:${port}` }
+  // Why: rebuild so accidental whitespace never reaches the WebSocket constructor.
+  return { ok: true, endpoint: `${url.protocol}//${formatHostForUrl(hostname)}:${port}` }
 }
 
 function normalizeHostPort(
@@ -131,6 +150,13 @@ function normalizeHostPort(
     return { ok: false, error: 'Missing hostname.' }
   }
 
+  // Why: bare input is not a URL, so characters that only make sense in a URL
+  // (path, query, fragment, whitespace) must not be treated as hostname bytes.
+  const hostError = validateHostname(host)
+  if (hostError) {
+    return { ok: false, error: hostError }
+  }
+
   if (port !== undefined) {
     port = port.trim()
     if (!isValidPort(port)) {
@@ -144,6 +170,36 @@ function normalizeHostPort(
 
 function formatHostForUrl(host: string): string {
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
+}
+
+/**
+ * Reject hostnames that would be illegal or ambiguous in a websocket URL.
+ * Allows DNS labels, `.local` mDNS, IPv4, and IPv6 hex forms.
+ */
+function validateHostname(host: string): string | null {
+  if (!host) {
+    return 'Missing hostname.'
+  }
+  // Spaces, path/query/fragment separators, userinfo separators, brackets.
+  if (/[\s/?#@[\]]/.test(host)) {
+    return 'Not a valid hostname.'
+  }
+  if (host.includes(':')) {
+    // Why: bare IPv6 is hex + colons only (brackets already stripped).
+    if (!/^[0-9a-fA-F:]+$/.test(host) || host.split(':').length < 3) {
+      return 'Not a valid hostname.'
+    }
+    return null
+  }
+  // DNS / IPv4 / mDNS: labels of alnum and hyphen, dots between, no empty labels.
+  if (
+    !/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(
+      host
+    )
+  ) {
+    return 'Not a valid hostname.'
+  }
+  return null
 }
 
 function isValidPort(port: string): boolean {

--- a/mobile/src/transport/host-endpoint.ts
+++ b/mobile/src/transport/host-endpoint.ts
@@ -12,7 +12,10 @@ const DEFAULT_PORT = '6768'
 export function displayHostEndpoint(endpoint: string): string {
   try {
     const url = new URL(endpoint)
-    return `${url.hostname}${url.port ? `:${url.port}` : ''}`
+    // Why: URL.hostname strips IPv6 brackets; re-wrap so round-trip through
+    // normalizeHostEndpoint does not treat "addr:port" as a single host.
+    const host = url.hostname.includes(':') ? `[${url.hostname}]` : url.hostname
+    return `${host}${url.port ? `:${url.port}` : ''}`
   } catch {
     return endpoint
   }
@@ -27,9 +30,18 @@ export function endpointPort(endpoint: string): string | undefined {
   }
 }
 
+export function endpointScheme(endpoint: string): 'ws' | 'wss' {
+  try {
+    const protocol = new URL(endpoint).protocol.replace(':', '')
+    return protocol === 'wss' ? 'wss' : 'ws'
+  } catch {
+    return 'ws'
+  }
+}
+
 export function normalizeHostEndpoint(
   input: string,
-  options?: { fallbackPort?: string | number }
+  options?: { fallbackPort?: string | number; fallbackScheme?: 'ws' | 'wss' }
 ): NormalizeHostEndpointResult {
   const trimmed = input.trim()
   if (!trimmed) {
@@ -37,12 +49,13 @@ export function normalizeHostEndpoint(
   }
 
   const fallbackPort = resolveFallbackPort(options?.fallbackPort)
+  const fallbackScheme = options?.fallbackScheme === 'wss' ? 'wss' : 'ws'
 
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
     return normalizeSchemeUrl(trimmed, fallbackPort)
   }
 
-  return normalizeHostPort(trimmed, fallbackPort)
+  return normalizeHostPort(trimmed, fallbackPort, fallbackScheme)
 }
 
 function resolveFallbackPort(value: string | number | undefined): string {
@@ -81,7 +94,11 @@ function normalizeSchemeUrl(input: string, fallbackPort: string): NormalizeHostE
   return { ok: true, endpoint: `${url.protocol}//${formatHostForUrl(url.hostname)}:${port}` }
 }
 
-function normalizeHostPort(input: string, fallbackPort: string): NormalizeHostEndpointResult {
+function normalizeHostPort(
+  input: string,
+  fallbackPort: string,
+  fallbackScheme: 'ws' | 'wss'
+): NormalizeHostEndpointResult {
   let host: string
   let port: string | undefined
 
@@ -122,7 +139,7 @@ function normalizeHostPort(input: string, fallbackPort: string): NormalizeHostEn
   }
 
   const finalPort = port ?? fallbackPort
-  return { ok: true, endpoint: `ws://${formatHostForUrl(host)}:${finalPort}` }
+  return { ok: true, endpoint: `${fallbackScheme}://${formatHostForUrl(host)}:${finalPort}` }
 }
 
 function formatHostForUrl(host: string): string {

--- a/mobile/src/transport/host-endpoint.ts
+++ b/mobile/src/transport/host-endpoint.ts
@@ -1,0 +1,138 @@
+// Why: mobile host profiles store a single websocket endpoint fixed at pair
+// time. Edit-host lets the user rewrite host/port without re-pairing; this
+// helper accepts phone-friendly input (bare IP, host:port, or full ws URL)
+// and normalizes to the ws(s):// form RpcClient expects.
+
+export type NormalizeHostEndpointResult =
+  | { ok: true; endpoint: string }
+  | { ok: false; error: string }
+
+const DEFAULT_PORT = '6768'
+
+export function displayHostEndpoint(endpoint: string): string {
+  try {
+    const url = new URL(endpoint)
+    return `${url.hostname}${url.port ? `:${url.port}` : ''}`
+  } catch {
+    return endpoint
+  }
+}
+
+export function endpointPort(endpoint: string): string | undefined {
+  try {
+    const url = new URL(endpoint)
+    return url.port || undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function normalizeHostEndpoint(
+  input: string,
+  options?: { fallbackPort?: string | number }
+): NormalizeHostEndpointResult {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return { ok: false, error: 'Enter a host address.' }
+  }
+
+  const fallbackPort = resolveFallbackPort(options?.fallbackPort)
+
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
+    return normalizeSchemeUrl(trimmed, fallbackPort)
+  }
+
+  return normalizeHostPort(trimmed, fallbackPort)
+}
+
+function resolveFallbackPort(value: string | number | undefined): string {
+  if (value == null) {
+    return DEFAULT_PORT
+  }
+  const asString = String(value).trim()
+  if (!asString || !isValidPort(asString)) {
+    return DEFAULT_PORT
+  }
+  return asString
+}
+
+function normalizeSchemeUrl(input: string, fallbackPort: string): NormalizeHostEndpointResult {
+  let url: URL
+  try {
+    url = new URL(input)
+  } catch {
+    return { ok: false, error: 'Not a valid address.' }
+  }
+
+  if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+    return { ok: false, error: 'Use ws:// or wss:// (or host:port).' }
+  }
+  if (!url.hostname) {
+    return { ok: false, error: 'Missing hostname.' }
+  }
+
+  const port = url.port || fallbackPort
+  if (!isValidPort(port)) {
+    return { ok: false, error: 'Port must be 1–65535.' }
+  }
+
+  // Why: rebuild so path/query noise and accidental whitespace never reach the
+  // WebSocket constructor; pairing offers are host:port only.
+  return { ok: true, endpoint: `${url.protocol}//${formatHostForUrl(url.hostname)}:${port}` }
+}
+
+function normalizeHostPort(input: string, fallbackPort: string): NormalizeHostEndpointResult {
+  let host: string
+  let port: string | undefined
+
+  if (input.startsWith('[')) {
+    const close = input.indexOf(']')
+    if (close <= 1) {
+      return { ok: false, error: 'Not a valid address.' }
+    }
+    host = input.slice(1, close)
+    const rest = input.slice(close + 1)
+    if (rest.startsWith(':')) {
+      port = rest.slice(1)
+    } else if (rest.length > 0) {
+      return { ok: false, error: 'Not a valid address.' }
+    }
+  } else {
+    const firstColon = input.indexOf(':')
+    const lastColon = input.lastIndexOf(':')
+    if (firstColon !== -1 && firstColon === lastColon) {
+      host = input.slice(0, firstColon)
+      port = input.slice(firstColon + 1)
+    } else {
+      // No port, or bare IPv6 (multiple colons, no brackets).
+      host = input
+    }
+  }
+
+  host = host.trim()
+  if (!host) {
+    return { ok: false, error: 'Missing hostname.' }
+  }
+
+  if (port !== undefined) {
+    port = port.trim()
+    if (!isValidPort(port)) {
+      return { ok: false, error: 'Port must be 1–65535.' }
+    }
+  }
+
+  const finalPort = port ?? fallbackPort
+  return { ok: true, endpoint: `ws://${formatHostForUrl(host)}:${finalPort}` }
+}
+
+function formatHostForUrl(host: string): string {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
+}
+
+function isValidPort(port: string): boolean {
+  if (!/^\d+$/.test(port)) {
+    return false
+  }
+  const n = Number(port)
+  return n >= 1 && n <= 65535
+}

--- a/mobile/src/transport/host-store-endpoint.test.ts
+++ b/mobile/src/transport/host-store-endpoint.test.ts
@@ -1,0 +1,66 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { updateHostEndpoint } from './host-store'
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn()
+  }
+}))
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY'
+}))
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' }
+}))
+
+describe('updateHostEndpoint', () => {
+  beforeEach(() => {
+    vi.mocked(AsyncStorage.getItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockReset()
+  })
+
+  it('rewrites only the endpoint for the matching host', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(
+      JSON.stringify([
+        {
+          id: 'host-1',
+          name: 'Desk',
+          endpoint: 'ws://100.64.0.5:6768',
+          publicKeyB64: 'pk',
+          lastConnected: 1
+        }
+      ])
+    )
+
+    await updateHostEndpoint('host-1', 'ws://192.168.1.10:6768')
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'orca:hosts',
+      JSON.stringify([
+        {
+          id: 'host-1',
+          name: 'Desk',
+          endpoint: 'ws://192.168.1.10:6768',
+          publicKeyB64: 'pk',
+          lastConnected: 1
+        }
+      ])
+    )
+  })
+
+  it('throws when the host is missing', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue('[]')
+    await expect(updateHostEndpoint('missing', 'ws://1.2.3.4:6768')).rejects.toThrow(
+      'Host not found'
+    )
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -205,6 +205,19 @@ export async function renameHost(hostId: string, newName: string): Promise<void>
   }
 }
 
+// Why: Edit host rewrites only the connection address when the same paired
+// desktop is reachable at a different IP (LAN vs Tailscale). deviceToken and
+// publicKey stay in place so workspaces do not need re-pairing.
+export async function updateHostEndpoint(hostId: string, endpoint: string): Promise<void> {
+  const hosts = await loadStoredHosts()
+  const host = hosts.find((h) => h.id === hostId)
+  if (!host) {
+    throw new Error('Host not found')
+  }
+  host.endpoint = endpoint
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(hosts))
+}
+
 export async function getNextHostName(): Promise<string> {
   const hosts = await loadStoredHosts()
   return getNextHostNameFromHosts(hosts)

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -29,6 +29,7 @@ import {
 import { describeSocketEvent } from './socket-event-debug'
 import { isRpcResponse } from './rpc-response-shape'
 import { websocketPayloadToUint8 } from './websocket-payload-bytes'
+import { resolveMobileDeviceDisplayName } from './device-identity'
 
 type PendingRequest = {
   resolve: (response: RpcResponse) => void
@@ -446,7 +447,14 @@ export function connect(
           const msg = JSON.parse(raw)
           if (msg.type === 'e2ee_ready') {
             emitLog('success', 'Received e2ee_ready', 'Sending device token')
-            sendEncrypted({ type: 'e2ee_auth', deviceToken })
+            // Why: report the marketing model (e.g. "iPhone 15 Pro Max") so the
+            // desktop Paired Devices list can replace the QR-time placeholder
+            // name "Mobile <date>". Optional on the wire for older desktops.
+            sendEncrypted({
+              type: 'e2ee_auth',
+              deviceToken,
+              deviceName: resolveMobileDeviceDisplayName()
+            })
             return
           }
         } catch {

--- a/src/main/runtime/device-registry-name.test.ts
+++ b/src/main/runtime/device-registry-name.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { DeviceRegistry } from './device-registry'
+
+describe('DeviceRegistry.updateName', () => {
+  const dirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  function createRegistry(): DeviceRegistry {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-device-registry-'))
+    dirs.push(dir)
+    return new DeviceRegistry(dir)
+  }
+
+  it('renames a device and persists across reload', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-device-registry-'))
+    dirs.push(dir)
+    const registry = new DeviceRegistry(dir)
+    const device = registry.addDevice('Mobile 7/3/2026', 'mobile')
+
+    expect(registry.updateName(device.deviceId, 'iPhone 15 Pro Max')).toBe(true)
+    expect(registry.getDevice(device.deviceId)?.name).toBe('iPhone 15 Pro Max')
+
+    const reloaded = new DeviceRegistry(dir)
+    expect(reloaded.getDevice(device.deviceId)?.name).toBe('iPhone 15 Pro Max')
+  })
+
+  it('no-ops when the name is unchanged', () => {
+    const registry = createRegistry()
+    const device = registry.addDevice('iPhone 15 Pro Max', 'mobile')
+    expect(registry.updateName(device.deviceId, 'iPhone 15 Pro Max')).toBe(false)
+  })
+
+  it('rejects empty names', () => {
+    const registry = createRegistry()
+    const device = registry.addDevice('Mobile 1/1/2026', 'mobile')
+    expect(registry.updateName(device.deviceId, '   ')).toBe(false)
+    expect(registry.getDevice(device.deviceId)?.name).toBe('Mobile 1/1/2026')
+  })
+})

--- a/src/main/runtime/device-registry.ts
+++ b/src/main/runtime/device-registry.ts
@@ -98,6 +98,24 @@ export class DeviceRegistry {
     }
   }
 
+  // Why: mobile clients report a marketing model (e.g. "iPhone 15 Pro Max")
+  // during e2ee_auth. Replace the QR-time placeholder ("Mobile <date>") so
+  // Settings → Paired Devices is recognizable. No-op when the name is empty
+  // or unchanged so reconnects do not thrash the registry file.
+  updateName(deviceId: string, name: string): boolean {
+    const device = this.devices.find((d) => d.deviceId === deviceId)
+    if (!device) {
+      return false
+    }
+    const next = name.trim()
+    if (!next || next === device.name) {
+      return false
+    }
+    device.name = next
+    this.save()
+    return true
+  }
+
   private load(): void {
     if (!existsSync(this.registryPath)) {
       this.devices = []

--- a/src/main/runtime/rpc/e2ee-channel.test.ts
+++ b/src/main/runtime/rpc/e2ee-channel.test.ts
@@ -66,6 +66,7 @@ describe('E2EEChannel', () => {
       expect(ctx.onReady).toHaveBeenCalledWith(ctx.channel)
       expect(ctx.onError).not.toHaveBeenCalled()
       expect(ctx.channel.deviceToken).toBe('valid-token')
+      expect(ctx.channel.reportedDeviceName).toBeNull()
 
       const readyMsg = JSON.parse(ctx.ws.sent[0]!)
       expect(readyMsg).toEqual({ type: 'e2ee_ready' })
@@ -74,6 +75,30 @@ describe('E2EEChannel', () => {
         deriveSharedKey(ctx.clientKeys.secretKey, ctx.serverKeys.publicKey)
       )
       expect(JSON.parse(authMsg!)).toEqual({ type: 'e2ee_authenticated' })
+    })
+
+    it('captures optional deviceName from e2ee_auth', () => {
+      const ctx = setup()
+      ctx.channel.handleRawMessage(
+        JSON.stringify({
+          type: 'e2ee_hello',
+          publicKeyB64: publicKeyToBase64(ctx.clientKeys.publicKey)
+        })
+      )
+      const shared = deriveSharedKey(ctx.clientKeys.secretKey, ctx.serverKeys.publicKey)
+      ctx.channel.handleRawMessage(
+        encrypt(
+          JSON.stringify({
+            type: 'e2ee_auth',
+            deviceToken: 'valid-token',
+            deviceName: '  iPhone 15 Pro Max  '
+          }),
+          shared
+        )
+      )
+
+      expect(ctx.onReady).toHaveBeenCalled()
+      expect(ctx.channel.reportedDeviceName).toBe('iPhone 15 Pro Max')
     })
 
     it('does not authenticate from plaintext hello alone', () => {

--- a/src/main/runtime/rpc/e2ee-channel.ts
+++ b/src/main/runtime/rpc/e2ee-channel.ts
@@ -18,6 +18,24 @@ type E2EEHello = {
 type E2EEAuth = {
   type: 'e2ee_auth'
   deviceToken: string
+  // Why: optional so older mobile builds keep working. When present, the
+  // desktop renames the paired-device entry from "Mobile <date>" to a model
+  // string like "iPhone 15 Pro Max".
+  deviceName?: string
+}
+
+const MAX_REPORTED_DEVICE_NAME_LENGTH = 64
+
+export function sanitizeReportedDeviceName(raw: unknown): string | null {
+  if (typeof raw !== 'string') {
+    return null
+  }
+  const cleaned = raw
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_REPORTED_DEVICE_NAME_LENGTH)
+  return cleaned.length > 0 ? cleaned : null
 }
 
 export type E2EEChannelOptions = {
@@ -50,6 +68,7 @@ export class E2EEChannel {
   private binaryMessageHandler: ((plaintext: Uint8Array<ArrayBufferLike>) => void) | null = null
 
   deviceToken: string | null = null
+  reportedDeviceName: string | null = null
 
   constructor(ws: WebSocket, options: E2EEChannelOptions) {
     this.ws = ws
@@ -204,6 +223,7 @@ export class E2EEChannel {
     }
 
     this.deviceToken = auth.deviceToken
+    this.reportedDeviceName = sanitizeReportedDeviceName(auth.deviceName)
     this.state = 'ready'
 
     if (this.handshakeTimer) {

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -736,6 +736,12 @@ export class OrcaRuntimeRpcServer {
                   const device = this.deviceRegistry?.validateToken(ch.deviceToken)
                   if (device) {
                     this.deviceRegistry?.updateLastSeen(device.deviceId)
+                    // Why: phone reports marketing model on auth (e.g.
+                    // "iPhone 15 Pro Max") so Settings stops showing the
+                    // QR-time placeholder "Mobile <date>".
+                    if (ch.reportedDeviceName) {
+                      this.deviceRegistry?.updateName(device.deviceId, ch.reportedDeviceName)
+                    }
                   }
                 }
               },


### PR DESCRIPTION
## Summary

- **Edit host on mobile**: long-press a desktop → **Edit host** (replaces Rename). Change display name and connection address without re-pairing, so LAN vs Tailscale IP switches work when the computer is not nearby.
- **Desktop paired-device label**: mobile reports its marketing model (e.g. `iPhone 15 Pro Max`) during `e2ee_auth`; the device registry renames the QR-time placeholder (`Mobile <date>`).
- **iOS 27 launch fix**: Expo config plugin adopts the UIKit scene lifecycle (`UIApplicationSceneManifest` + `SceneDelegate`) so builds with Xcode 27 / iOS 27 no longer `SIGTRAP` at launch (`UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption`).

Verified on physical **iPhone 17 Pro Max (iOS 27 beta)** after local Release install: app stays up and JS bundle loads.

## Test plan

- [ ] Mobile: long-press a paired host → **Edit host** → rename only → list updates, no reconnect required
- [ ] Mobile: edit address to a reachable LAN IP → Save → host reconnects with new endpoint; pairing token unchanged
- [ ] Mobile: reject invalid address input without writing storage
- [ ] Desktop Settings → Mobile → Paired Devices: after reconnect, name shows phone model instead of `Mobile <date>`
- [ ] `cd mobile && pnpm exec vitest run src/transport/host-endpoint.test.ts src/transport/host-store-endpoint.test.ts src/transport/device-identity.test.ts`
- [ ] Desktop: `pnpm exec vitest run src/main/runtime/rpc/e2ee-channel.test.ts src/main/runtime/device-registry-name.test.ts` (when root deps available)
- [ ] iOS: `npx expo prebuild --platform ios` then build/run on iOS 27 simulator or device — app launches without SIGTRAP

## Notes

- `mobile/ios` remains gitignored; the scene lifecycle change is applied via `mobile/plugins/ios-uikit-scene-lifecycle.js` on prebuild.
- Local Debug builds still need Metro; Release embeds `main.jsbundle`.