### PR TITLE
feat: add `orca notify` — agent-triggered pane notifications (desktop + mobile)

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -46,6 +46,16 @@ const winSpeechNativeResource = {
 module.exports = {
   appId: 'com.stablyai.orca',
   productName: 'Orca',
+  // Why: register the `orca://` URL scheme with the OS so deep links (e.g.
+  // orca://focus?terminal=…) launch or surface the app. On macOS this becomes
+  // the app bundle's CFBundleURLTypes; Windows/Linux also register at runtime
+  // via app.setAsDefaultProtocolClient.
+  protocols: [
+    {
+      name: 'Orca',
+      schemes: ['orca']
+    }
+  ],
   directories: {
     buildResources: 'resources/build'
   },

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -812,13 +812,15 @@ export default function SessionScreen() {
     worktreeId,
     name: routeWorktreeName,
     created,
-    warning: createdWarning
+    warning: createdWarning,
+    pane: routePaneKey
   } = useLocalSearchParams<{
     hostId: string
     worktreeId: string
     name?: string
     created?: string
     warning?: string
+    pane?: string
   }>()
   const isFolderWorkspaceRoute = worktreeId.startsWith('folder:')
   const router = useRouter()
@@ -1031,6 +1033,11 @@ export default function SessionScreen() {
   const activeSessionTabTypeRef = useRef<MobileSessionTabType | null>(null)
   const pendingActiveSessionTabIdRef = useRef<string | null>(null)
   const pendingActiveTerminalHandleRef = useRef<string | null>(null)
+  // Why: a `pane=` query param (from a dispatch/agent notification tap) names a
+  // specific split to focus on load. Resolve it to a live handle once, then
+  // activate it through the vetted switchTab path when its tab appears.
+  const routePaneResolvedHandleRef = useRef<string | null>(null)
+  const routePaneFocusAppliedRef = useRef(false)
   // Why: a browser tab opened from a terminal-tapped HTML must be focused as an
   // Orca session tab (bridge auto-activate only flags the live webContents, not
   // the app-level active tab). We remember the page id and, once its session tab
@@ -2885,6 +2892,50 @@ export default function SessionScreen() {
       worktreeId
     ]
   )
+
+  // Why: focus the pane named by a notification tap (`?pane=`). Resolve the
+  // stable pane key to a live terminal handle once, then hand off to switchTab
+  // when its session tab has loaded. Failure is a no-op — the worktree-level
+  // view (the pre-existing behavior) still shows.
+  useEffect(() => {
+    if (!routePaneKey || connState !== 'connected' || !client) {
+      return
+    }
+    if (routePaneFocusAppliedRef.current) {
+      return
+    }
+    const activeClient = client
+    let cancelled = false
+    void (async () => {
+      let handle = routePaneResolvedHandleRef.current
+      if (!handle) {
+        try {
+          const response = await activeClient.sendRequest('terminal.resolvePane', {
+            paneKey: routePaneKey
+          })
+          handle = (response as { terminal?: { handle?: string } })?.terminal?.handle ?? null
+        } catch {
+          handle = null
+        }
+        if (cancelled || !handle) {
+          return
+        }
+        routePaneResolvedHandleRef.current = handle
+      }
+      const resolvedHandle = handle
+      const hasTab = sessionTabs.some(
+        (tab) => tab.type === 'terminal' && tab.terminal === resolvedHandle
+      )
+      if (!hasTab) {
+        return
+      }
+      routePaneFocusAppliedRef.current = true
+      switchTab(resolvedHandle)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [routePaneKey, connState, client, sessionTabs, switchTab])
 
   const switchSessionTab = useCallback(
     (tab: MobileSessionTab) => {

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -2893,6 +2893,15 @@ export default function SessionScreen() {
     ]
   )
 
+  // Why: a fresh notification tap can change `?pane=` while this screen stays
+  // mounted (Expo reuses the route component). Clear the one-shot guard and the
+  // cached handle so the focus effect below re-resolves and re-focuses the new
+  // pane instead of short-circuiting on the previous tap's applied state.
+  useEffect(() => {
+    routePaneFocusAppliedRef.current = false
+    routePaneResolvedHandleRef.current = null
+  }, [routePaneKey])
+
   // Why: focus the pane named by a notification tap (`?pane=`). Resolve the
   // stable pane key to a live terminal handle once, then hand off to switchTab
   // when its session tab has loaded. Failure is a no-op — the worktree-level

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -10,6 +10,7 @@ type NotificationEvent = {
   title: string
   body: string
   worktreeId?: string
+  paneKey?: string
   notificationId?: string
 }
 

--- a/mobile/src/notifications/notification-routing.test.ts
+++ b/mobile/src/notifications/notification-routing.test.ts
@@ -20,6 +20,26 @@ describe('notification routing', () => {
     })
   })
 
+  it('carries the pane key through to locally scheduled notification data', () => {
+    expect(
+      buildLocalNotificationData(
+        {
+          source: 'dispatch',
+          worktreeId: 'repo::/Users/me/orca/workspaces/feature',
+          paneKey: 'tab-9:11111111-1111-4111-8111-111111111111',
+          notificationId: 'dispatch:one'
+        },
+        'host-1'
+      )
+    ).toEqual({
+      source: 'dispatch',
+      hostId: 'host-1',
+      worktreeId: 'repo::/Users/me/orca/workspaces/feature',
+      paneKey: 'tab-9:11111111-1111-4111-8111-111111111111',
+      notificationId: 'dispatch:one'
+    })
+  })
+
   it('routes notification taps to the worktree terminal screen', () => {
     expect(
       getNotificationNavigationPath({
@@ -27,6 +47,18 @@ describe('notification routing', () => {
         worktreeId: 'repo::/Users/me/orca/workspaces/feature'
       })
     ).toBe('/h/host-1/session/repo%3A%3A%2FUsers%2Fme%2Forca%2Fworkspaces%2Ffeature')
+  })
+
+  it('appends the pane key as a query param when the tap names a pane', () => {
+    expect(
+      getNotificationNavigationPath({
+        hostId: 'host-1',
+        worktreeId: 'repo::/Users/me/orca/workspaces/feature',
+        paneKey: 'tab-9:11111111-1111-4111-8111-111111111111'
+      })
+    ).toBe(
+      '/h/host-1/session/repo%3A%3A%2FUsers%2Fme%2Forca%2Fworkspaces%2Ffeature?pane=tab-9%3A11111111-1111-4111-8111-111111111111'
+    )
   })
 
   it('falls back to the host screen when the payload has no worktree id', () => {

--- a/mobile/src/notifications/notification-routing.ts
+++ b/mobile/src/notifications/notification-routing.ts
@@ -1,8 +1,14 @@
-export type DesktopNotificationSource = 'agent-task-complete' | 'terminal-bell' | 'test'
+export type DesktopNotificationSource =
+  | 'agent-task-complete'
+  | 'terminal-bell'
+  | 'test'
+  | 'dispatch'
 
 export type DesktopNotificationEvent = {
   source: DesktopNotificationSource
   worktreeId?: string
+  /** Stable `${tabId}:${leafId}` pane key so the tap can focus the exact pane. */
+  paneKey?: string
   notificationId?: string
 }
 
@@ -10,6 +16,7 @@ export type LocalNotificationData = {
   source: DesktopNotificationSource
   hostId: string
   worktreeId?: string
+  paneKey?: string
   notificationId?: string
 }
 
@@ -31,6 +38,9 @@ export function buildLocalNotificationData(
   }
   if (event.worktreeId) {
     data.worktreeId = event.worktreeId
+  }
+  if (event.paneKey) {
+    data.paneKey = event.paneKey
   }
   if (event.notificationId) {
     data.notificationId = event.notificationId
@@ -61,5 +71,10 @@ export function getNotificationNavigationPath(
     return hostPath
   }
 
-  return `${hostPath}/session/${encodeURIComponent(worktreeId)}`
+  const sessionPath = `${hostPath}/session/${encodeURIComponent(worktreeId)}`
+  // Why: a `dispatch`/agent notification can name the exact pane. Carry it as a
+  // query param so the session screen can focus that split on load; taps
+  // without a pane keep the plain worktree-granular route.
+  const paneKey = readNonEmptyString(record.paneKey)
+  return paneKey ? `${sessionPath}?pane=${encodeURIComponent(paneKey)}` : sessionPath
 }

--- a/mobile/src/notifications/notification-routing.ts
+++ b/mobile/src/notifications/notification-routing.ts
@@ -28,6 +28,12 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value : null
 }
 
+/**
+ * Builds serializable tap-routing data for a local mobile notification.
+ *
+ * A mobile notification is shown by the app from a desktop runtime event, so
+ * this keeps only the host/worktree/pane identifiers needed after the tap.
+ */
 export function buildLocalNotificationData(
   event: DesktopNotificationEvent,
   hostId: string
@@ -48,6 +54,12 @@ export function buildLocalNotificationData(
   return data
 }
 
+/**
+ * Resolves local notification data into the mobile route opened after a tap.
+ *
+ * Invalid or unknown-host payloads are ignored because notification data can
+ * outlive the active host list or come from an older app version.
+ */
 export function getNotificationNavigationPath(
   data: unknown,
   options: NotificationNavigationOptions = {}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -135,6 +135,7 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
       'repo',
       'worktree',
       'terminal',
+      'notify',
       'file',
       'orchestration',
       'computer',

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -7,6 +7,7 @@ import { REPO_HANDLERS } from './handlers/repo'
 import { WORKTREE_HANDLERS } from './handlers/worktree'
 import { FILE_HANDLERS } from './handlers/file'
 import { TERMINAL_HANDLERS } from './handlers/terminal'
+import { NOTIFY_HANDLERS } from './handlers/notify'
 import { BROWSER_NAV_HANDLERS } from './handlers/browser-nav'
 import { BROWSER_INTERACT_HANDLERS } from './handlers/browser-interact'
 import { BROWSER_TAB_HANDLERS } from './handlers/browser-tab'
@@ -44,6 +45,7 @@ function buildHandlers(): Map<string, CommandHandler> {
     WORKTREE_HANDLERS,
     FILE_HANDLERS,
     TERMINAL_HANDLERS,
+    NOTIFY_HANDLERS,
     BROWSER_NAV_HANDLERS,
     BROWSER_INTERACT_HANDLERS,
     BROWSER_TAB_HANDLERS,

--- a/src/cli/handlers/notify.ts
+++ b/src/cli/handlers/notify.ts
@@ -1,0 +1,45 @@
+import type { RuntimeNotificationDispatch } from '../../shared/runtime-types'
+import type { CommandHandler } from '../dispatch'
+import { printResult } from '../format'
+import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
+import { getOptionalWorktreeSelector } from '../selectors'
+
+function formatNotifyDispatch({ dispatch }: { dispatch: RuntimeNotificationDispatch }): string {
+  if (!dispatch.delivered) {
+    return `Notification not delivered${dispatch.reason ? ` (${dispatch.reason})` : ''}.`
+  }
+  const target = dispatch.paneKey
+    ? ` → pane ${dispatch.paneKey}`
+    : dispatch.worktreeId
+      ? ` → ${dispatch.worktreeId}`
+      : ''
+  return `Notification delivered${target}.`
+}
+
+export const NOTIFY_HANDLERS: Record<string, CommandHandler> = {
+  // Why: gives an agent/orchestrator a native way to fire an Orca notification
+  // on demand (an AI summary), deep-linking the tap to the pane it names —
+  // the trigger that previously forced shelling out to a third-party push.
+  notify: async ({ flags, client, cwd, json }) => {
+    // `--pane` takes a terminal handle; `--terminal` is a compatibility alias.
+    const terminal =
+      getOptionalStringFlag(flags, 'pane') ?? getOptionalStringFlag(flags, 'terminal')
+    const worktree = await getOptionalWorktreeSelector(flags, 'worktree', cwd, client)
+    const title = getOptionalStringFlag(flags, 'title')
+    const result = await client.call<{ dispatch: RuntimeNotificationDispatch }>(
+      'notifications.dispatch',
+      {
+        message: getRequiredStringFlag(flags, 'message'),
+        ...(title ? { title } : {}),
+        ...(terminal ? { terminal } : {}),
+        ...(worktree ? { worktree } : {})
+      }
+    )
+    printResult(result, json, formatNotifyDispatch)
+    if (!result.result.dispatch.delivered) {
+      // Why: parity with `terminal wait` — a non-delivered notification is a
+      // soft failure scripts can detect via exit code.
+      process.exitCode = 1
+    }
+  }
+}

--- a/src/cli/handlers/notify.ts
+++ b/src/cli/handlers/notify.ts
@@ -16,6 +16,12 @@ function formatNotifyDispatch({ dispatch }: { dispatch: RuntimeNotificationDispa
   return `Notification delivered${target}.`
 }
 
+/**
+ * CLI handlers for agent-triggered Orca notifications.
+ *
+ * This gives scripts a first-party notification trigger instead of requiring
+ * third-party push services just to surface an agent status summary.
+ */
 export const NOTIFY_HANDLERS: Record<string, CommandHandler> = {
   // Why: gives an agent/orchestrator a native way to fire an Orca notification
   // on demand (an AI summary), deep-linking the tap to the pane it names —

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -76,6 +76,9 @@ Terminals:
   terminal focus            Alias for terminal switch
   terminal close            Close a terminal pane (or tab if last pane)
 
+Notifications:
+  notify                    Fire a native notification that deep-links to a pane
+
 Orchestration:
   orchestration send        Send an inter-agent message
   orchestration check       Check messages for a terminal
@@ -216,6 +219,7 @@ Common Commands:
   orca terminal split [--terminal <handle>] [--direction horizontal|vertical] [--json]
   orca terminal switch [--terminal <handle>] [--json]
   orca terminal close [--terminal <handle>] [--json]
+  orca notify --message <text> [--title <text>] [--pane <handle>|--worktree <selector>] [--json]
   orca project list [--json]
   orca project setups [--project <id>] [--host <host-id>] [--json]
   orca project setup-existing-folder --project <id> --host <host-id> --path <path> [--kind git|folder] [--display-name <name>] [--json]

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -275,5 +275,23 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'orca terminal split --terminal term_abc123 --direction horizontal --json',
       'orca terminal split --terminal term_abc123 --command "codex"'
     ]
+  },
+  {
+    path: ['notify'],
+    summary: 'Fire a native Orca notification that deep-links to a pane',
+    usage:
+      'orca notify --message <text> [--title <text>] [--pane <handle>|--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'message', 'title', 'pane', 'terminal', 'worktree'],
+    notes: [
+      'Delivers to the desktop app and any paired mobile device; clicking the notification jumps to the target pane.',
+      'Omit --pane and --worktree to target the active terminal in the current worktree.',
+      'Pass --pane with a terminal handle (from `orca terminal list --json`) to focus that exact pane on tap.',
+      'A bare `orca notify --message "…"` still fires when no terminal can be resolved, but the tap has no pane to focus.'
+    ],
+    examples: [
+      'orca notify --message "Tests passed — ready for review"',
+      'orca notify --pane term_abc123 --title "Blocked" --message "Needs your input on the migration" --json',
+      'orca notify --worktree active --message "Deploy finished"'
+    ]
   }
 ]

--- a/src/main/deep-link/deep-link-dispatcher.test.ts
+++ b/src/main/deep-link/deep-link-dispatcher.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeGraphStatus } from '../../shared/runtime-types'
+import {
+  createDeepLinkDispatcher,
+  type DeepLinkDispatcherOptions,
+  type FocusableRuntime
+} from './deep-link-dispatcher'
+
+type RuntimeStubOptions = {
+  graphStatus?: RuntimeGraphStatus
+  focusTerminal?: FocusableRuntime['focusTerminal']
+  resolveActiveTerminal?: FocusableRuntime['resolveActiveTerminal']
+}
+
+function makeRuntime(options: RuntimeStubOptions = {}): FocusableRuntime {
+  return {
+    getStatus: () =>
+      ({ graphStatus: options.graphStatus ?? 'ready' }) as ReturnType<
+        FocusableRuntime['getStatus']
+      >,
+    focusTerminal:
+      options.focusTerminal ??
+      vi.fn(async (handle: string) => ({ handle, tabId: 'tab', worktreeId: 'wt' })),
+    resolveActiveTerminal: options.resolveActiveTerminal ?? vi.fn(async () => 'term_active')
+  }
+}
+
+function makeDispatcher(
+  runtime: FocusableRuntime | null,
+  overrides: Partial<DeepLinkDispatcherOptions> = {}
+) {
+  const focusWindow = vi.fn()
+  const warn = vi.fn()
+  const dispatcher = createDeepLinkDispatcher({
+    focusWindow,
+    getRuntime: () => runtime,
+    warn,
+    delay: async () => {},
+    ...overrides
+  })
+  return { dispatcher, focusWindow, warn, runtime }
+}
+
+describe('createDeepLinkDispatcher', () => {
+  it('focuses the window and the requested terminal handle', async () => {
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ focusTerminal })
+    const { dispatcher, focusWindow, warn } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(focusTerminal).toHaveBeenCalledWith('term_abc')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('resolves the active terminal from a worktree selector', async () => {
+    const resolveActiveTerminal = vi.fn(async () => 'term_resolved')
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ resolveActiveTerminal, focusTerminal })
+    const { dispatcher } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://focus?worktree=id:wt123')
+
+    expect(resolveActiveTerminal).toHaveBeenCalledWith('id:wt123')
+    expect(focusTerminal).toHaveBeenCalledWith('term_resolved')
+  })
+
+  it('prefers an explicit terminal handle over the worktree selector', async () => {
+    const resolveActiveTerminal = vi.fn(async () => 'term_resolved')
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ resolveActiveTerminal, focusTerminal })
+    const { dispatcher } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc&worktree=id:wt123')
+
+    expect(resolveActiveTerminal).not.toHaveBeenCalled()
+    expect(focusTerminal).toHaveBeenCalledWith('term_abc')
+  })
+
+  it('only focuses the window for a bare focus link', async () => {
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ focusTerminal })
+    const { dispatcher, focusWindow } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://focus')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(focusTerminal).not.toHaveBeenCalled()
+  })
+
+  it('only focuses the window for non-focus routes such as pair', async () => {
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ focusTerminal })
+    const { dispatcher, focusWindow } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('orca://pair?code=abc')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(focusTerminal).not.toHaveBeenCalled()
+  })
+
+  it('waits for the renderer graph to become ready before focusing', async () => {
+    let clock = 0
+    const now = () => clock
+    let graphStatus: RuntimeGraphStatus = 'reloading'
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime: FocusableRuntime = {
+      getStatus: () => ({ graphStatus }) as ReturnType<FocusableRuntime['getStatus']>,
+      focusTerminal,
+      resolveActiveTerminal: vi.fn(async () => 'term_active')
+    }
+    const { dispatcher } = makeDispatcher(runtime, {
+      now,
+      // Advance the clock and flip to ready on the third poll.
+      delay: async () => {
+        clock += 150
+        if (clock >= 300) {
+          graphStatus = 'ready'
+        }
+      }
+    })
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    expect(focusTerminal).toHaveBeenCalledWith('term_abc')
+  })
+
+  it('gives up gracefully when the graph never becomes ready', async () => {
+    let clock = 0
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime = makeRuntime({ graphStatus: 'unavailable', focusTerminal })
+    const { dispatcher, focusWindow, warn } = makeDispatcher(runtime, {
+      now: () => clock,
+      graphReadyTimeoutMs: 500,
+      delay: async () => {
+        clock += 150
+      }
+    })
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(focusTerminal).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('does not crash when focusing an unknown or exited terminal', async () => {
+    const focusTerminal = vi.fn(async () => {
+      throw new Error('terminal_exited')
+    })
+    const runtime = makeRuntime({ focusTerminal })
+    const { dispatcher, focusWindow, warn } = makeDispatcher(runtime)
+
+    await expect(dispatcher.dispatch('orca://focus?terminal=term_gone')).resolves.toBeUndefined()
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('focuses the window even when the URL is malformed', async () => {
+    const runtime = makeRuntime()
+    const { dispatcher, focusWindow } = makeDispatcher(runtime)
+
+    await dispatcher.dispatch('not a url')
+
+    expect(focusWindow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/deep-link/deep-link-dispatcher.test.ts
+++ b/src/main/deep-link/deep-link-dispatcher.test.ts
@@ -126,6 +126,69 @@ describe('createDeepLinkDispatcher', () => {
     expect(focusTerminal).toHaveBeenCalledWith('term_abc')
   })
 
+  it('buffers a cold-start focus intent until a slow boot reports the graph ready', async () => {
+    // Regression: a real cold boot can take tens of seconds, longer than the old
+    // 15s budget, so the queued focus must survive until the graph is ready
+    // rather than being dropped mid-boot.
+    let clock = 0
+    let graphStatus: RuntimeGraphStatus = 'unavailable'
+    const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))
+    const runtime: FocusableRuntime = {
+      getStatus: () => ({ graphStatus }) as ReturnType<FocusableRuntime['getStatus']>,
+      focusTerminal,
+      resolveActiveTerminal: vi.fn(async () => 'term_active')
+    }
+    const { dispatcher, warn } = makeDispatcher(runtime, {
+      now: () => clock,
+      // Boot completes at 30s — past the old 15s timeout, within the 60s budget.
+      delay: async () => {
+        clock += 150
+        if (clock >= 30_000) {
+          graphStatus = 'ready'
+        }
+      }
+    })
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    expect(focusTerminal).toHaveBeenCalledWith('term_abc')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the window before waiting on the graph so boot is never blocked', async () => {
+    // The window must come forward immediately; only the terminal reveal defers
+    // until the graph is ready. Record the order of side effects to prove it.
+    const order: string[] = []
+    let clock = 0
+    let graphStatus: RuntimeGraphStatus = 'reloading'
+    const runtime: FocusableRuntime = {
+      getStatus: () => ({ graphStatus }) as ReturnType<FocusableRuntime['getStatus']>,
+      focusTerminal: vi.fn(async (handle: string) => {
+        order.push('focusTerminal')
+        return { handle, tabId: 't', worktreeId: 'w' }
+      }),
+      resolveActiveTerminal: vi.fn(async () => 'term_active')
+    }
+    const focusWindow = vi.fn(() => order.push('focusWindow'))
+    const dispatcher = createDeepLinkDispatcher({
+      focusWindow,
+      getRuntime: () => runtime,
+      now: () => clock,
+      delay: async () => {
+        order.push('poll')
+        clock += 150
+        graphStatus = 'ready'
+      }
+    })
+
+    await dispatcher.dispatch('orca://focus?terminal=term_abc')
+
+    // Window is surfaced first, before any graph poll; the terminal reveal follows.
+    expect(order[0]).toBe('focusWindow')
+    expect(order.indexOf('focusWindow')).toBeLessThan(order.indexOf('poll'))
+    expect(order).toContain('focusTerminal')
+  })
+
   it('gives up gracefully when the graph never becomes ready', async () => {
     let clock = 0
     const focusTerminal = vi.fn(async (handle: string) => ({ handle, tabId: 't', worktreeId: 'w' }))

--- a/src/main/deep-link/deep-link-dispatcher.ts
+++ b/src/main/deep-link/deep-link-dispatcher.ts
@@ -1,0 +1,86 @@
+import type { OrcaRuntimeService } from '../runtime/orca-runtime'
+import { parseOrcaDeepLink, type OrcaFocusDeepLink } from './orca-deep-link'
+
+// Why: the dispatcher only needs to read runtime readiness and reuse the two
+// existing focus actions. A structural slice keeps the unit tests free of the
+// full OrcaRuntimeService while staying type-checked against the real class.
+export type FocusableRuntime = Pick<
+  OrcaRuntimeService,
+  'getStatus' | 'focusTerminal' | 'resolveActiveTerminal'
+>
+
+export type DeepLinkDispatcherOptions = {
+  // Bring the app/main window to the foreground (reuses focusExistingMainWindow).
+  focusWindow: () => void
+  // Lazily read the runtime so a cold-start link that arrives before the
+  // runtime exists still resolves once startup completes.
+  getRuntime: () => FocusableRuntime | null
+  warn?: (message: string, error?: unknown) => void
+  now?: () => number
+  delay?: (ms: number) => Promise<void>
+  // Cold-start links can land before the renderer graph is ready; poll until it
+  // is so focus lands on the right pane instead of being dropped.
+  graphReadyTimeoutMs?: number
+  graphPollIntervalMs?: number
+}
+
+export type DeepLinkDispatcher = {
+  dispatch: (url: string) => Promise<void>
+}
+
+const DEFAULT_GRAPH_READY_TIMEOUT_MS = 15_000
+const DEFAULT_GRAPH_POLL_INTERVAL_MS = 150
+
+export function createDeepLinkDispatcher(options: DeepLinkDispatcherOptions): DeepLinkDispatcher {
+  const now = options.now ?? Date.now
+  const delay = options.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
+  const timeoutMs = options.graphReadyTimeoutMs ?? DEFAULT_GRAPH_READY_TIMEOUT_MS
+  const pollIntervalMs = options.graphPollIntervalMs ?? DEFAULT_GRAPH_POLL_INTERVAL_MS
+
+  async function waitForRuntimeGraph(): Promise<FocusableRuntime | null> {
+    const deadline = now() + timeoutMs
+    for (;;) {
+      const runtime = options.getRuntime()
+      if (runtime && runtime.getStatus().graphStatus === 'ready') {
+        return runtime
+      }
+      if (now() >= deadline) {
+        return null
+      }
+      await delay(pollIntervalMs)
+    }
+  }
+
+  async function focusTarget(link: OrcaFocusDeepLink): Promise<void> {
+    if (!link.terminal && !link.worktree) {
+      // Bare `orca://focus` — bringing the window forward is the whole action.
+      return
+    }
+    const runtime = await waitForRuntimeGraph()
+    if (!runtime) {
+      options.warn?.('[deep-link] Runtime graph not ready; brought window forward only')
+      return
+    }
+    try {
+      const handle =
+        link.terminal ?? (await runtime.resolveActiveTerminal(link.worktree ?? undefined))
+      await runtime.focusTerminal(handle)
+    } catch (error) {
+      // Why: an unknown/exited handle or a worktree with no active terminal must
+      // never crash the app. The window is already focused, so degrade to a no-op.
+      options.warn?.('[deep-link] Could not focus terminal for deep link', error)
+    }
+  }
+
+  async function dispatch(url: string): Promise<void> {
+    // Why: focus the window first so an unknown or malformed route still brings
+    // Orca forward rather than silently doing nothing.
+    options.focusWindow()
+    const link = parseOrcaDeepLink(url)
+    if (link?.kind === 'focus') {
+      await focusTarget(link)
+    }
+  }
+
+  return { dispatch }
+}

--- a/src/main/deep-link/deep-link-dispatcher.ts
+++ b/src/main/deep-link/deep-link-dispatcher.ts
@@ -18,8 +18,10 @@ export type DeepLinkDispatcherOptions = {
   warn?: (message: string, error?: unknown) => void
   now?: () => number
   delay?: (ms: number) => Promise<void>
-  // Cold-start links can land before the renderer graph is ready; poll until it
-  // is so focus lands on the right pane instead of being dropped.
+  // Cold-start links land before the renderer graph is ready; the focus intent
+  // is buffered by polling for up to this budget so it applies once the graph
+  // reports `ready` instead of being dropped. Never blocks boot — the window is
+  // surfaced first; only the terminal reveal waits.
   graphReadyTimeoutMs?: number
   graphPollIntervalMs?: number
 }
@@ -28,15 +30,39 @@ export type DeepLinkDispatcher = {
   dispatch: (url: string) => Promise<void>
 }
 
-const DEFAULT_GRAPH_READY_TIMEOUT_MS = 15_000
+// Why: a protocol launch can COLD-START Orca — macOS relaunches the registered
+// handler, and the renderer graph only reports `ready` after the window loads,
+// which on a fresh/cold boot can take tens of seconds. The focus intent is
+// buffered (polled) for this whole budget so it lands once the graph is ready,
+// rather than being dropped by a timeout that races the load screen. The window
+// itself is surfaced immediately (see `dispatch`), so this wait never blocks the
+// boot — it only defers the terminal reveal. After the budget, we gracefully
+// no-op with the app already in the foreground.
+const DEFAULT_GRAPH_READY_TIMEOUT_MS = 60_000
 const DEFAULT_GRAPH_POLL_INTERVAL_MS = 150
 
+/**
+ * Create the deep-link dispatcher that turns an `orca://` URL into a focus
+ * action. `dispatch` always brings the main window forward first — so an
+ * unknown or malformed route still surfaces Orca — then, for a `focus` route
+ * that names a target, waits for the runtime graph to be ready and reuses the
+ * existing `resolveActiveTerminal`/`focusTerminal` actions to reveal the pane.
+ *
+ * All side effects (window focus, runtime lookup, timing) are injected via
+ * `options` so the dispatcher can be unit-tested without a live Electron or
+ * runtime instance.
+ */
 export function createDeepLinkDispatcher(options: DeepLinkDispatcherOptions): DeepLinkDispatcher {
   const now = options.now ?? Date.now
   const delay = options.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
   const timeoutMs = options.graphReadyTimeoutMs ?? DEFAULT_GRAPH_READY_TIMEOUT_MS
   const pollIntervalMs = options.graphPollIntervalMs ?? DEFAULT_GRAPH_POLL_INTERVAL_MS
 
+  /**
+   * Poll `getRuntime` until the renderer graph reports `ready`, returning the
+   * runtime once it is. Returns `null` if the graph is still not ready by the
+   * deadline so a cold-start link degrades to a window-only focus.
+   */
   async function waitForRuntimeGraph(): Promise<FocusableRuntime | null> {
     const deadline = now() + timeoutMs
     for (;;) {
@@ -51,6 +77,12 @@ export function createDeepLinkDispatcher(options: DeepLinkDispatcherOptions): De
     }
   }
 
+  /**
+   * Reveal the pane named by a `focus` link. A bare `orca://focus` (no target)
+   * is satisfied by the window focus alone. Otherwise resolve the terminal
+   * handle — directly or via the worktree selector — and focus it, degrading to
+   * a no-op if the runtime is not ready or the handle cannot be resolved.
+   */
   async function focusTarget(link: OrcaFocusDeepLink): Promise<void> {
     if (!link.terminal && !link.worktree) {
       // Bare `orca://focus` — bringing the window forward is the whole action.
@@ -72,6 +104,10 @@ export function createDeepLinkDispatcher(options: DeepLinkDispatcherOptions): De
     }
   }
 
+  /**
+   * Bring the window forward, then route a parsed `focus` link to its target
+   * pane. Non-focus or unparseable URLs fall through to the window focus only.
+   */
   async function dispatch(url: string): Promise<void> {
     // Why: focus the window first so an unknown or malformed route still brings
     // Orca forward rather than silently doing nothing.

--- a/src/main/deep-link/orca-deep-link.test.ts
+++ b/src/main/deep-link/orca-deep-link.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { findOrcaUrlInArgv, parseOrcaDeepLink } from './orca-deep-link'
+
+describe('parseOrcaDeepLink', () => {
+  it('parses a focus link with a terminal handle', () => {
+    expect(parseOrcaDeepLink('orca://focus?terminal=term_abc123')).toEqual({
+      kind: 'focus',
+      terminal: 'term_abc123',
+      worktree: null
+    })
+  })
+
+  it('parses a focus link with a worktree selector', () => {
+    expect(parseOrcaDeepLink('orca://focus?worktree=id:repo123::/abs/path')).toEqual({
+      kind: 'focus',
+      terminal: null,
+      worktree: 'id:repo123::/abs/path'
+    })
+  })
+
+  it('keeps the terminal handle when both terminal and worktree are present', () => {
+    const parsed = parseOrcaDeepLink('orca://focus?terminal=term_abc&worktree=id:wt')
+    expect(parsed).toEqual({ kind: 'focus', terminal: 'term_abc', worktree: 'id:wt' })
+  })
+
+  it('parses a bare focus link with no target', () => {
+    expect(parseOrcaDeepLink('orca://focus')).toEqual({
+      kind: 'focus',
+      terminal: null,
+      worktree: null
+    })
+  })
+
+  it('treats blank query params as absent', () => {
+    expect(parseOrcaDeepLink('orca://focus?terminal=%20&worktree=')).toEqual({
+      kind: 'focus',
+      terminal: null,
+      worktree: null
+    })
+  })
+
+  it('decodes percent-encoded selectors', () => {
+    expect(parseOrcaDeepLink('orca://focus?worktree=path%3A%2Ftmp%2Fwt')).toEqual({
+      kind: 'focus',
+      terminal: null,
+      worktree: 'path:/tmp/wt'
+    })
+  })
+
+  it('returns null for a different scheme', () => {
+    expect(parseOrcaDeepLink('https://focus?terminal=term_abc')).toBeNull()
+  })
+
+  it('returns null for hosts without an OS route, including pair', () => {
+    // Why: `orca://pair` is a paste-only pairing code, not an OS deep link.
+    // Auto-applying runtime auth material from an untrusted link would be unsafe.
+    expect(parseOrcaDeepLink('orca://pair?code=abc')).toBeNull()
+    expect(parseOrcaDeepLink('orca://unknown?terminal=term_abc')).toBeNull()
+  })
+
+  it('does not partial-match the focus host', () => {
+    expect(parseOrcaDeepLink('orca://focus-extra?terminal=term_abc')).toBeNull()
+    expect(parseOrcaDeepLink('orca://focusing?terminal=term_abc')).toBeNull()
+  })
+
+  it('returns null for a malformed URL', () => {
+    expect(parseOrcaDeepLink('not a url')).toBeNull()
+    expect(parseOrcaDeepLink('')).toBeNull()
+  })
+})
+
+describe('findOrcaUrlInArgv', () => {
+  it('finds the orca url among launch args', () => {
+    const argv = ['/path/to/Orca', '--flag', 'orca://focus?terminal=term_abc']
+    expect(findOrcaUrlInArgv(argv)).toBe('orca://focus?terminal=term_abc')
+  })
+
+  it('matches the scheme case-insensitively', () => {
+    expect(findOrcaUrlInArgv(['Orca', 'ORCA://focus?terminal=term_abc'])).toBe(
+      'ORCA://focus?terminal=term_abc'
+    )
+  })
+
+  it('surfaces any orca url so the app still comes forward', () => {
+    expect(findOrcaUrlInArgv(['Orca', 'orca://pair?code=abc'])).toBe('orca://pair?code=abc')
+  })
+
+  it('returns null when no orca url is present', () => {
+    expect(findOrcaUrlInArgv(['/path/to/Orca', '--serve', '/some/path'])).toBeNull()
+    expect(findOrcaUrlInArgv([])).toBeNull()
+  })
+})

--- a/src/main/deep-link/orca-deep-link.ts
+++ b/src/main/deep-link/orca-deep-link.ts
@@ -1,0 +1,78 @@
+// Why: Orca registers `orca://` as an OS custom protocol, so any web page or
+// app can trigger these links. Every route here is intentionally limited to
+// focusing/revealing a local pane — parsing must be side-effect free and must
+// never carry material that could execute commands or mutate state.
+
+export const ORCA_URL_SCHEME = 'orca'
+
+export type OrcaFocusDeepLink = {
+  kind: 'focus'
+  // Explicit terminal handle (`term_<uuid>`) to reveal, when provided.
+  terminal: string | null
+  // Worktree selector (`id:`, `path:`, `branch:`, `name:`, `issue:`, or a bare
+  // id/path/branch) whose active terminal is revealed when no handle is given.
+  worktree: string | null
+}
+
+export type OrcaDeepLink = OrcaFocusDeepLink
+
+/**
+ * Parse an `orca://` deep link into a structured route, or `null` when the URL
+ * is malformed, uses another scheme, or targets a host with no OS route.
+ *
+ * Modeled on `extractPairingCodeFromUrl` in `src/shared/pairing.ts`: validate
+ * the scheme, then dispatch on the hostname. Unknown hosts (including the
+ * paste-only `pair` code format) return `null` rather than throwing so the
+ * intake can still bring Orca to the foreground.
+ */
+export function parseOrcaDeepLink(url: string): OrcaDeepLink | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== `${ORCA_URL_SCHEME}:`) {
+    return null
+  }
+  switch (parsed.hostname) {
+    case 'focus':
+      return parseFocusDeepLink(parsed)
+    default:
+      return null
+  }
+}
+
+function parseFocusDeepLink(parsed: URL): OrcaFocusDeepLink {
+  return {
+    kind: 'focus',
+    terminal: normalizeParam(parsed.searchParams.get('terminal')),
+    worktree: normalizeParam(parsed.searchParams.get('worktree'))
+  }
+}
+
+function normalizeParam(value: string | null): string | null {
+  if (value === null) {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Find the first `orca://` URL in a process argv array. Windows and Linux
+ * deliver protocol launches as a plain argv entry (cold start via
+ * `process.argv`, warm launch via the `second-instance` argv) rather than a
+ * dedicated event, unlike macOS which emits `open-url`.
+ *
+ * Returns any `orca://` URL — even a route this build does not handle — so the
+ * intake still surfaces the app; the dispatcher decides what to do with it.
+ */
+export function findOrcaUrlInArgv(argv: readonly string[]): string | null {
+  for (const arg of argv) {
+    if (typeof arg === 'string' && arg.toLowerCase().startsWith(`${ORCA_URL_SCHEME}://`)) {
+      return arg
+    }
+  }
+  return null
+}

--- a/src/main/deep-link/orca-deep-link.ts
+++ b/src/main/deep-link/orca-deep-link.ts
@@ -43,6 +43,11 @@ export function parseOrcaDeepLink(url: string): OrcaDeepLink | null {
   }
 }
 
+/**
+ * Build the `focus` route from a validated `orca://focus` URL, reading the
+ * optional `terminal` and `worktree` query params (both normalized to `null`
+ * when absent or blank).
+ */
 function parseFocusDeepLink(parsed: URL): OrcaFocusDeepLink {
   return {
     kind: 'focus',
@@ -51,6 +56,7 @@ function parseFocusDeepLink(parsed: URL): OrcaFocusDeepLink {
   }
 }
 
+/** Trim a raw query-param value, collapsing missing or whitespace-only input to `null`. */
 function normalizeParam(value: string | null): string | null {
   if (value === null) {
     return null

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@
    startup. Splitting by line count would fragment tightly coupled startup
    logic across files without a cleaner ownership seam. */
 import { existsSync, statSync } from 'node:fs'
-import { isAbsolute, join } from 'node:path'
+import { isAbsolute, join, resolve } from 'node:path'
 import os from 'node:os'
 import { app, BrowserWindow, dialog, ipcMain, nativeTheme } from 'electron'
 import { electronApp, is } from '@electron-toolkit/utils'
@@ -43,6 +43,8 @@ import { OrcaRuntimeService } from './runtime/orca-runtime'
 import { OrcaRuntimeRpcServer } from './runtime/runtime-rpc'
 import { awaitRuntimeFileWatcherUnsubscribes } from './runtime/orca-runtime-files'
 import { clearRuntimeMetadataIfOwned } from './runtime/runtime-metadata'
+import { createDeepLinkDispatcher } from './deep-link/deep-link-dispatcher'
+import { ORCA_URL_SCHEME, findOrcaUrlInArgv } from './deep-link/orca-deep-link'
 import { ensureMainI18n, setMainUiLanguage } from './i18n/main-i18n'
 import {
   getNextDefaultOnAppearanceSettingValue,
@@ -450,6 +452,49 @@ function focusExistingWindow(): void {
   })
 }
 
+// Why: `orca://focus?terminal=…` deep links reuse the same reveal action as
+// `orca terminal focus` (runtime.focusTerminal) instead of reinventing focus.
+// A deep link can be fired by any web page, so the dispatcher only focuses/
+// reveals a local pane — it never executes commands or mutates state.
+const deepLinkDispatcher = createDeepLinkDispatcher({
+  focusWindow: focusExistingWindow,
+  getRuntime: () => runtime,
+  warn: console.warn
+})
+
+// Why: any orca:// launch should surface the app. On Windows/Linux the URL
+// arrives as an argv entry on the relaunch; macOS delivers it via `open-url`.
+function handleSecondInstance(argv: string[]): void {
+  const url = findOrcaUrlInArgv(argv)
+  if (url) {
+    void deepLinkDispatcher.dispatch(url)
+    return
+  }
+  focusExistingWindow()
+}
+
+function registerOrcaProtocolClient(): void {
+  // Why: packaged macOS builds register the scheme via CFBundleURLTypes (written
+  // by electron-builder's `protocols` config); this runtime call covers
+  // Windows/Linux and dev. In dev, Electron runs our entry as an argument, so
+  // the launcher must re-invoke this instance with the script path.
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(ORCA_URL_SCHEME, process.execPath, [resolve(process.argv[1])])
+    }
+  } else {
+    app.setAsDefaultProtocolClient(ORCA_URL_SCHEME)
+  }
+}
+
+// Why: register the open-url listener at module load (before whenReady) so a
+// macOS cold-start protocol launch is delivered rather than dropped. The
+// dispatcher polls for renderer-graph readiness, so an early event still lands.
+app.on('open-url', (event, url) => {
+  event.preventDefault()
+  void deepLinkDispatcher.dispatch(url)
+})
+
 // Why: a webContents-scoped flag that auto-expires so an intent set for one renderer
 // can't leak to a later load. `consume` clears on a positive match for one-shot
 // signals (the recovery reload fires exactly one did-finish-load).
@@ -550,7 +595,7 @@ const hasSingleInstanceLock =
     ? true
     : bypassSingleInstanceLock
       ? true
-      : acquireSingleInstanceLock(app, focusExistingWindow)
+      : acquireSingleInstanceLock(app, handleSecondInstance)
 if (startupDiagnosticsEnabled) {
   logStartupDiagnostic('single-instance-lock-result', {
     acquired: hasSingleInstanceLock,
@@ -594,6 +639,7 @@ if (hasSingleInstanceLock) {
     platform: process.platform
   })
   configureElectronNetworkCompatibility()
+  registerOrcaProtocolClient()
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()
   if (!gpuFallbackActiveThisLaunch) {
@@ -2164,6 +2210,14 @@ app.whenReady().then(async () => {
       console.error('[runtime] Failed to start local RPC transport:', error)
     })
   ])
+
+  // Why: Windows/Linux cold-start protocol launches arrive in process.argv, not
+  // via open-url. Route it now that the window and runtime exist; the dispatcher
+  // waits for renderer-graph readiness before revealing the pane. No-op on macOS.
+  const coldStartDeepLink = findOrcaUrlInArgv(process.argv)
+  if (coldStartDeepLink) {
+    void deepLinkDispatcher.dispatch(coldStartDeepLink)
+  }
 
   // Why: the macOS notification permission dialog must fire after the window
   // is visible and focused. If it fires before the window exists, the system

--- a/src/main/ipc/notification-options.ts
+++ b/src/main/ipc/notification-options.ts
@@ -3,6 +3,10 @@ import type { NotificationDispatchRequest } from '../../shared/types'
 const NOTIFICATION_AGENT_LABEL_MAX_LENGTH = 40
 const NOTIFICATION_TITLE_CONTEXT_MAX_LENGTH = 80
 const NOTIFICATION_BODY_PREVIEW_MAX_LENGTH = 180
+// Why: `dispatch` bodies are agent-authored (often an AI summary), so allow a
+// longer preview than the auto-generated sources while still bounding the
+// string the OS notification center has to render.
+const NOTIFICATION_DISPATCH_BODY_MAX_LENGTH = 500
 
 const AGENT_TYPE_LABELS: Readonly<Record<string, string>> = {
   claude: 'Claude',
@@ -37,6 +41,13 @@ export function buildNotificationOptions(args: NotificationDispatchRequest): {
     return {
       title: 'Orca notifications are on',
       body: 'This is a test notification from Orca.'
+    }
+  }
+
+  if (args.source === 'dispatch') {
+    return {
+      title: normalizeNotificationText(args.title, NOTIFICATION_TITLE_CONTEXT_MAX_LENGTH) || 'Orca',
+      body: normalizeNotificationText(args.message, NOTIFICATION_DISPATCH_BODY_MAX_LENGTH)
     }
   }
 

--- a/src/main/ipc/notification-options.ts
+++ b/src/main/ipc/notification-options.ts
@@ -24,6 +24,12 @@ const AGENT_TYPE_LABELS: Readonly<Record<string, string>> = {
   hermes: 'Hermes'
 }
 
+/**
+ * Converts an internal notification request into Electron display text.
+ *
+ * Dispatcher-triggered notifications carry agent-authored prose, while the
+ * existing automatic sources still use their compact generated copy.
+ */
 export function buildNotificationOptions(args: NotificationDispatchRequest): {
   title: string
   body: string

--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -849,6 +849,92 @@ describe('registerNotificationHandlers', () => {
     expect(notificationCtorMock).not.toHaveBeenCalled()
   })
 
+  it('delivers a custom "dispatch" message with pane key to mobile and native', async () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: true
+          }
+        })
+      } as never,
+      { dispatchMobileNotification, setNotificationDispatcher: vi.fn() } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(
+      await handler(
+        {},
+        {
+          source: 'dispatch',
+          title: 'Blocked',
+          message: 'Needs your input on the migration',
+          worktreeId: 'repo::wt1',
+          paneKey: 'tab-9:11111111-1111-4111-8111-111111111111'
+        }
+      )
+    ).toEqual({ delivered: true })
+
+    expect(dispatchMobileNotification).toHaveBeenCalledWith({
+      type: 'notification',
+      source: 'dispatch',
+      title: 'Blocked',
+      body: 'Needs your input on the migration',
+      worktreeId: 'repo::wt1',
+      paneKey: 'tab-9:11111111-1111-4111-8111-111111111111'
+    })
+    expect(notificationCtorMock).toHaveBeenCalledWith(
+      expectedNativeNotificationOptions({
+        title: 'Blocked',
+        body: 'Needs your input on the migration'
+      })
+    )
+  })
+
+  it('registers a runtime notification dispatcher that honors the global enable toggle', async () => {
+    let enabled = false
+    const dispatchMobileNotification = vi.fn()
+    const setNotificationDispatcher = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: true
+          }
+        })
+      } as never,
+      { dispatchMobileNotification, setNotificationDispatcher } as never
+    )
+
+    expect(setNotificationDispatcher).toHaveBeenCalledTimes(1)
+    const dispatcher = setNotificationDispatcher.mock.calls[0]![0] as (request: unknown) => unknown
+
+    // Global toggle off: the dispatcher short-circuits without touching mobile.
+    expect(await dispatcher({ source: 'dispatch', message: 'ping' })).toEqual({
+      delivered: false,
+      reason: 'disabled'
+    })
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+
+    // Global toggle on: it reuses the same native+mobile delivery path.
+    enabled = true
+    expect(
+      await dispatcher({ source: 'dispatch', message: 'ping', worktreeId: 'repo::wt1' })
+    ).toEqual({
+      delivered: true
+    })
+    expect(dispatchMobileNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'notification', source: 'dispatch', body: 'ping' })
+    )
+  })
+
   it('does not dispatch mobile notifications when notifications are disabled', async () => {
     const dispatchMobileNotification = vi.fn()
     registerNotificationHandlers(

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -312,12 +312,12 @@ function pruneRecentNotifications(recentNotifications: Map<string, number>, now:
   }
 }
 
-// Why: the native-delivery core (build options → mobile push → native
-// Notification with click-to-focus routing) is shared by the renderer-driven
-// IPC dispatch and the agent-driven runtime dispatch (`notifications.dispatch`).
-// The renderer-only gates (tray attention, focus suppression, burst dedupe)
-// stay in the IPC handler; this function is the part both paths reuse so a
-// notification behaves identically however it was triggered.
+/**
+ * Delivers a notification through the shared mobile and native channels.
+ *
+ * The renderer IPC path and agent RPC path reuse this core so click routing
+ * behaves identically; renderer-only gates stay in `registerNotificationHandlers`.
+ */
 export function performNotificationDelivery(
   store: Store,
   runtime: OrcaRuntimeService | undefined,

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -312,6 +312,175 @@ function pruneRecentNotifications(recentNotifications: Map<string, number>, now:
   }
 }
 
+// Why: the native-delivery core (build options → mobile push → native
+// Notification with click-to-focus routing) is shared by the renderer-driven
+// IPC dispatch and the agent-driven runtime dispatch (`notifications.dispatch`).
+// The renderer-only gates (tray attention, focus suppression, burst dedupe)
+// stay in the IPC handler; this function is the part both paths reuse so a
+// notification behaves identically however it was triggered.
+export function performNotificationDelivery(
+  store: Store,
+  runtime: OrcaRuntimeService | undefined,
+  args: NotificationDispatchRequest
+): NotificationDispatchResult | Promise<NotificationDispatchResult> {
+  const settings = store.getSettings().notifications
+  const notificationOptions = buildNotificationOptions(args)
+
+  // Why: paired mobile clients should follow the same user-facing
+  // notification gates as desktop delivery, while still working on hosts
+  // where Electron native notifications are unavailable.
+  if (runtime && args.source !== 'test') {
+    runtime.dispatchMobileNotification({
+      type: 'notification',
+      source: args.source,
+      title: notificationOptions.title,
+      body: notificationOptions.body,
+      worktreeId: args.worktreeId,
+      // Why: carry the pane key so a mobile tap can land on the exact split
+      // pane, not just the worktree. Desktop already routes to the pane via
+      // the native click handler below.
+      ...(args.paneKey ? { paneKey: args.paneKey } : {}),
+      ...(args.notificationId ? { notificationId: args.notificationId } : {})
+    })
+  }
+
+  if (!Notification.isSupported()) {
+    return { delivered: false, reason: 'not-supported' }
+  }
+
+  function deliverNativeNotification():
+    | NotificationDispatchResult
+    | Promise<NotificationDispatchResult> {
+    if (getEffectiveNotificationSoundId(settings) !== 'system') {
+      notificationOptions.silent = true
+    } else if (process.platform === 'darwin') {
+      // Why: macOS treats an unset notification sound as silent. When Orca is
+      // using the OS sound, ask Electron for the default notification sound.
+      notificationOptions.sound = 'default'
+    }
+    const notification = new Notification(notificationOptions)
+    if (args.notificationId) {
+      const previous = activeNotificationsById.get(args.notificationId)
+      if (previous) {
+        previous.notification.close()
+        previous.release()
+      }
+    }
+
+    // Why: prevent GC from collecting the notification (and its click
+    // handler) while it's still visible in macOS Notification Center.
+    let clickHandler: (() => void) | null = null
+    let failedHandler: ((_event: unknown, error?: string) => void) | null = null
+    const entryForId: { notification: Notification; release: () => void } | null =
+      args.notificationId ? { notification, release: () => {} } : null
+    const release = retainNotificationUntilRelease(notification, () => {
+      if (clickHandler) {
+        notification.removeListener('click', clickHandler)
+        clickHandler = null
+      }
+      if (failedHandler) {
+        notification.removeListener('failed', failedHandler)
+        failedHandler = null
+      }
+      if (args.notificationId && activeNotificationsById.get(args.notificationId) === entryForId) {
+        activeNotificationsById.delete(args.notificationId)
+      }
+    })
+    if (entryForId && args.notificationId) {
+      entryForId.release = release
+      activeNotificationsById.set(args.notificationId, entryForId)
+    }
+
+    failedHandler = (_event, error) => {
+      // Why: Electron 42's macOS UNNotification backend reports unsigned
+      // apps and native delivery errors here; release immediately instead
+      // of retaining a dead notification until the fallback timer.
+      logNativeNotificationFailure(args.source, error)
+      // A definitive rejection — feeds the permission card's evidence.
+      lastObservedDeliveryOutcome = 'failed'
+      release()
+    }
+    notification.on('failed', failedHandler)
+
+    // Why: clicking a notification should bring Orca to the foreground and
+    // switch to the worktree/pane that triggered it. Worktree activation owns
+    // repo/sidebar state; the optional focusTerminal follow-up uses the stable
+    // pane leaf id so split-pane notifications land on the exact pane.
+    // Why: worktreeId is formatted as "repoId::worktreePath".  If the
+    // separator is missing we cannot reliably extract a repoId, so skip
+    // the click-to-navigate binding — the notification still fires but
+    // clicking it will not attempt to switch to an unknown worktree.
+    if (args.worktreeId && args.worktreeId.includes('::')) {
+      const repoId = getRepoIdFromWorktreeId(args.worktreeId)
+      clickHandler = () => {
+        release()
+        const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+        if (!win) {
+          return
+        }
+        if (process.platform === 'darwin') {
+          app.focus({ steal: true })
+        }
+        if (win.isMinimized()) {
+          win.restore()
+        }
+        win.focus()
+        win.webContents.send('ui:activateWorktree', {
+          repoId,
+          worktreeId: args.worktreeId
+        })
+        const paneTarget = args.paneKey ? parsePaneKey(args.paneKey) : null
+        if (paneTarget) {
+          win.webContents.send('ui:focusTerminal', {
+            tabId: paneTarget.tabId,
+            worktreeId: args.worktreeId,
+            leafId: paneTarget.leafId,
+            ackPaneKeyOnSuccess: args.paneKey,
+            flashFocusedPane: true,
+            scrollToBottomIfOutputSinceLastView: true
+          })
+        }
+      }
+      notification.on('click', clickHandler)
+    }
+
+    const displayConfirmation = args.requireDisplayConfirmation
+      ? waitForNotificationDisplay(notification)
+      : null
+    notification.show()
+
+    if (displayConfirmation) {
+      return displayConfirmation.then((displayed) => {
+        if (!displayed) {
+          release()
+          return { delivered: false, reason: 'not-displayed' }
+        }
+        lastObservedDeliveryOutcome = 'delivered'
+        return { delivered: true }
+      })
+    }
+
+    return { delivered: true }
+  }
+
+  if (process.platform !== 'darwin') {
+    return deliverNativeNotification()
+  }
+  // Why: macOS silently swallows accepted notifications while permission
+  // is denied or the permission dialog is unanswered (verified on macOS
+  // 26). Skip the doomed native notification and tell the caller, so the
+  // renderer can surface an in-app fallback pointing at System Settings.
+  // The mobile dispatch above is unaffected — paired devices have their
+  // own notification channel.
+  return readNotificationAuthorizationStatus().then((authorization) => {
+    if (authorization === 'denied' || authorization === 'not-determined') {
+      lastObservedDeliveryOutcome = 'failed'
+      return { delivered: false, reason: 'blocked-by-system' }
+    }
+    return deliverNativeNotification()
+  })
+}
+
 export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntimeService): void {
   const recentNotifications = new Map<string, number>()
   // Why: handler registration marks a fresh session — permission evidence
@@ -471,162 +640,21 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
         pruneRecentNotifications(recentNotifications, now)
       }
 
-      const notificationOptions = buildNotificationOptions(args)
-
-      // Why: paired mobile clients should follow the same user-facing
-      // notification gates as desktop delivery, while still working on hosts
-      // where Electron native notifications are unavailable.
-      if (runtime && args.source !== 'test') {
-        runtime.dispatchMobileNotification({
-          type: 'notification',
-          source: args.source,
-          title: notificationOptions.title,
-          body: notificationOptions.body,
-          worktreeId: args.worktreeId,
-          ...(args.notificationId ? { notificationId: args.notificationId } : {})
-        })
-      }
-
-      if (!Notification.isSupported()) {
-        return { delivered: false, reason: 'not-supported' }
-      }
-
-      function deliverNativeNotification():
-        | NotificationDispatchResult
-        | Promise<NotificationDispatchResult> {
-        if (getEffectiveNotificationSoundId(settings) !== 'system') {
-          notificationOptions.silent = true
-        } else if (process.platform === 'darwin') {
-          // Why: macOS treats an unset notification sound as silent. When Orca is
-          // using the OS sound, ask Electron for the default notification sound.
-          notificationOptions.sound = 'default'
-        }
-        const notification = new Notification(notificationOptions)
-        if (args.notificationId) {
-          const previous = activeNotificationsById.get(args.notificationId)
-          if (previous) {
-            previous.notification.close()
-            previous.release()
-          }
-        }
-
-        // Why: prevent GC from collecting the notification (and its click
-        // handler) while it's still visible in macOS Notification Center.
-        let clickHandler: (() => void) | null = null
-        let failedHandler: ((_event: unknown, error?: string) => void) | null = null
-        const entryForId: { notification: Notification; release: () => void } | null =
-          args.notificationId ? { notification, release: () => {} } : null
-        const release = retainNotificationUntilRelease(notification, () => {
-          if (clickHandler) {
-            notification.removeListener('click', clickHandler)
-            clickHandler = null
-          }
-          if (failedHandler) {
-            notification.removeListener('failed', failedHandler)
-            failedHandler = null
-          }
-          if (
-            args.notificationId &&
-            activeNotificationsById.get(args.notificationId) === entryForId
-          ) {
-            activeNotificationsById.delete(args.notificationId)
-          }
-        })
-        if (entryForId && args.notificationId) {
-          entryForId.release = release
-          activeNotificationsById.set(args.notificationId, entryForId)
-        }
-
-        failedHandler = (_event, error) => {
-          // Why: Electron 42's macOS UNNotification backend reports unsigned
-          // apps and native delivery errors here; release immediately instead
-          // of retaining a dead notification until the fallback timer.
-          logNativeNotificationFailure(args.source, error)
-          // A definitive rejection — feeds the permission card's evidence.
-          lastObservedDeliveryOutcome = 'failed'
-          release()
-        }
-        notification.on('failed', failedHandler)
-
-        // Why: clicking a notification should bring Orca to the foreground and
-        // switch to the worktree/pane that triggered it. Worktree activation owns
-        // repo/sidebar state; the optional focusTerminal follow-up uses the stable
-        // pane leaf id so split-pane notifications land on the exact pane.
-        // Why: worktreeId is formatted as "repoId::worktreePath".  If the
-        // separator is missing we cannot reliably extract a repoId, so skip
-        // the click-to-navigate binding — the notification still fires but
-        // clicking it will not attempt to switch to an unknown worktree.
-        if (args.worktreeId && args.worktreeId.includes('::')) {
-          const repoId = getRepoIdFromWorktreeId(args.worktreeId)
-          clickHandler = () => {
-            release()
-            const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
-            if (!win) {
-              return
-            }
-            if (process.platform === 'darwin') {
-              app.focus({ steal: true })
-            }
-            if (win.isMinimized()) {
-              win.restore()
-            }
-            win.focus()
-            win.webContents.send('ui:activateWorktree', {
-              repoId,
-              worktreeId: args.worktreeId
-            })
-            const paneTarget = args.paneKey ? parsePaneKey(args.paneKey) : null
-            if (paneTarget) {
-              win.webContents.send('ui:focusTerminal', {
-                tabId: paneTarget.tabId,
-                worktreeId: args.worktreeId,
-                leafId: paneTarget.leafId,
-                ackPaneKeyOnSuccess: args.paneKey,
-                flashFocusedPane: true,
-                scrollToBottomIfOutputSinceLastView: true
-              })
-            }
-          }
-          notification.on('click', clickHandler)
-        }
-
-        const displayConfirmation = args.requireDisplayConfirmation
-          ? waitForNotificationDisplay(notification)
-          : null
-        notification.show()
-
-        if (displayConfirmation) {
-          return displayConfirmation.then((displayed) => {
-            if (!displayed) {
-              release()
-              return { delivered: false, reason: 'not-displayed' }
-            }
-            lastObservedDeliveryOutcome = 'delivered'
-            return { delivered: true }
-          })
-        }
-
-        return { delivered: true }
-      }
-
-      if (process.platform !== 'darwin') {
-        return deliverNativeNotification()
-      }
-      // Why: macOS silently swallows accepted notifications while permission
-      // is denied or the permission dialog is unanswered (verified on macOS
-      // 26). Skip the doomed native notification and tell the caller, so the
-      // renderer can surface an in-app fallback pointing at System Settings.
-      // The mobile dispatch above is unaffected — paired devices have their
-      // own notification channel.
-      return readNotificationAuthorizationStatus().then((authorization) => {
-        if (authorization === 'denied' || authorization === 'not-determined') {
-          lastObservedDeliveryOutcome = 'failed'
-          return { delivered: false, reason: 'blocked-by-system' }
-        }
-        return deliverNativeNotification()
-      })
+      return performNotificationDelivery(store, runtime, args)
     }
   )
+
+  // Why: agents/orchestrators fire notifications through the runtime RPC
+  // (`notifications.dispatch`), which has no access to Electron's main-process
+  // Notification API. Register the native+mobile delivery here — where `store`
+  // and `runtime` are already in scope — so a `dispatch` notification reuses
+  // the exact same path as the renderer, honoring the global enable toggle.
+  runtime?.setNotificationDispatcher?.((request) => {
+    if (!store.getSettings().notifications.enabled) {
+      return { delivered: false, reason: 'disabled' }
+    }
+    return performNotificationDelivery(store, runtime, request)
+  })
 
   // Why: the preload caches the decoded blob keyed by path. Returning just
   // the validated path lets it skip the 10MB IPC round-trip on every dispatch

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -420,7 +420,9 @@ import type {
   GitLabMRInlineCommentInput,
   GitLabProjectRef,
   GitLabWorkItem,
-  MRListState
+  MRListState,
+  NotificationDispatchRequest,
+  NotificationDispatchResult
 } from '../../shared/types'
 import { inspectSetupScriptImportCandidates } from '../../shared/setup-script-imports'
 import type {
@@ -1944,10 +1946,12 @@ type ResolvedWorktreeInFlight = {
 
 export type MobileNotificationDispatchEvent = {
   type: 'notification'
-  source: 'agent-task-complete' | 'terminal-bell' | 'test'
+  source: 'agent-task-complete' | 'terminal-bell' | 'test' | 'dispatch'
   title: string
   body: string
   worktreeId?: string
+  /** Stable `${tabId}:${leafId}` pane key so a mobile tap can focus the exact pane. */
+  paneKey?: string
   notificationId?: string
 }
 
@@ -1959,6 +1963,12 @@ export type MobileNotificationDismissEvent = {
 export type MobileNotificationEvent =
   | MobileNotificationDispatchEvent
   | MobileNotificationDismissEvent
+
+// Why: the native notification dispatcher may deliver synchronously (non-macOS)
+// or await the macOS authorization readout before delivering.
+type NotificationDispatchResultAsync =
+  | NotificationDispatchResult
+  | Promise<NotificationDispatchResult>
 
 // Why: presence-based driver state for the mobile-presence lock. Exactly one
 // driver per PTY at any moment. See docs/mobile-presence-lock.md.
@@ -2113,6 +2123,14 @@ export class OrcaRuntimeService {
   // mobile client gets its own listener, and dispatchMobileNotification
   // iterates them all. Listeners are cleaned up via subscriptionCleanups.
   private notificationListeners = new Set<(event: MobileNotificationEvent) => void>()
+  // Why: the native desktop notification path (Electron Notification + mobile
+  // push) lives in the main-process IPC layer. `notifications.dispatch` runs in
+  // the runtime and reaches it through this injected dispatcher, set by
+  // registerNotificationHandlers. Null when no window/notification layer is
+  // attached (e.g. headless serve) — dispatch reports delivered:false.
+  private notificationDispatcher:
+    | ((request: NotificationDispatchRequest) => NotificationDispatchResultAsync)
+    | null = null
   private ptysById = new Map<string, RuntimePtyWorktreeRecord>()
   private titleObservationSequence = 0
   private headlessTerminals = new Map<string, RuntimeHeadlessTerminal>()
@@ -6443,6 +6461,26 @@ export class OrcaRuntimeService {
     for (const listener of this.notificationListeners) {
       listener(event)
     }
+  }
+
+  // Why: injected by registerNotificationHandlers so the runtime can fire a
+  // native desktop + mobile notification (used by `notifications.dispatch`)
+  // without importing Electron's main-process Notification API directly.
+  setNotificationDispatcher(
+    dispatcher: ((request: NotificationDispatchRequest) => NotificationDispatchResultAsync) | null
+  ): void {
+    this.notificationDispatcher = dispatcher
+  }
+
+  async dispatchNotification(
+    request: NotificationDispatchRequest
+  ): Promise<NotificationDispatchResult> {
+    if (!this.notificationDispatcher) {
+      // Why: no notification layer attached (e.g. headless serve). Report the
+      // miss instead of throwing so callers can degrade gracefully.
+      return { delivered: false, reason: 'not-supported' }
+    }
+    return this.notificationDispatcher(request)
   }
 
   dismissMobileNotification(notificationId: string): void {

--- a/src/main/runtime/rpc/methods/notifications.test.ts
+++ b/src/main/runtime/rpc/methods/notifications.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest, RpcResponse } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { NOTIFICATION_METHODS } from './notifications'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function resultOf(response: RpcResponse): unknown {
+  if ('error' in response && response.error) {
+    throw new Error(`RPC failed: ${JSON.stringify(response.error)}`)
+  }
+  return (response as { result: unknown }).result
+}
+
+describe('notifications.dispatch RPC method', () => {
+  it('resolves a terminal handle to a worktree + pane key and fires the notification', async () => {
+    const dispatchNotification = vi.fn().mockResolvedValue({ delivered: true })
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      showTerminal: vi.fn().mockResolvedValue({
+        handle: 'term_abc',
+        worktreeId: 'repo::wt1',
+        tabId: 'tab-9',
+        leafId: LEAF_ID
+      }),
+      resolveActiveTerminal: vi.fn(),
+      dispatchNotification
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: NOTIFICATION_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('notifications.dispatch', {
+        terminal: 'term_abc',
+        title: 'Blocked',
+        message: 'Needs your input'
+      })
+    )
+
+    expect(runtime.resolveActiveTerminal).not.toHaveBeenCalled()
+    expect(dispatchNotification).toHaveBeenCalledWith({
+      source: 'dispatch',
+      message: 'Needs your input',
+      title: 'Blocked',
+      worktreeId: 'repo::wt1',
+      paneKey: `tab-9:${LEAF_ID}`
+    })
+    expect(resultOf(response)).toEqual({
+      dispatch: { delivered: true, worktreeId: 'repo::wt1', paneKey: `tab-9:${LEAF_ID}` }
+    })
+  })
+
+  it('falls back to the active terminal in the selected worktree', async () => {
+    const dispatchNotification = vi.fn().mockResolvedValue({ delivered: true })
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      resolveActiveTerminal: vi.fn().mockResolvedValue('term_active'),
+      showTerminal: vi.fn().mockResolvedValue({
+        handle: 'term_active',
+        worktreeId: 'repo::wt2',
+        tabId: 'tab-3',
+        leafId: LEAF_ID
+      }),
+      dispatchNotification
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: NOTIFICATION_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('notifications.dispatch', { worktree: 'active', message: 'Done' })
+    )
+
+    expect(runtime.resolveActiveTerminal).toHaveBeenCalledWith('active')
+    expect(dispatchNotification).toHaveBeenCalledWith({
+      source: 'dispatch',
+      message: 'Done',
+      worktreeId: 'repo::wt2',
+      paneKey: `tab-3:${LEAF_ID}`
+    })
+  })
+
+  it('still fires a plain notification when no terminal can be resolved', async () => {
+    const dispatchNotification = vi.fn().mockResolvedValue({ delivered: true })
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      resolveActiveTerminal: vi.fn().mockRejectedValue(new Error('no_active_terminal')),
+      showTerminal: vi.fn(),
+      dispatchNotification
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: NOTIFICATION_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('notifications.dispatch', { message: 'Heads up' })
+    )
+
+    expect(dispatchNotification).toHaveBeenCalledWith({ source: 'dispatch', message: 'Heads up' })
+    expect(resultOf(response)).toEqual({ dispatch: { delivered: true } })
+  })
+
+  it('surfaces the resolution error when an explicit target cannot be found', async () => {
+    const dispatchNotification = vi.fn()
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      resolveActiveTerminal: vi.fn(),
+      showTerminal: vi.fn().mockRejectedValue(new Error('terminal_not_found')),
+      dispatchNotification
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: NOTIFICATION_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('notifications.dispatch', { terminal: 'term_missing', message: 'hi' })
+    )
+
+    expect(dispatchNotification).not.toHaveBeenCalled()
+    expect('error' in response && response.error).toBeTruthy()
+  })
+
+  it('rejects a dispatch without a message', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      dispatchNotification: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: NOTIFICATION_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest('notifications.dispatch', {}))
+    expect('error' in response && response.error).toBeTruthy()
+    expect(runtime.dispatchNotification).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/rpc/methods/notifications.ts
+++ b/src/main/runtime/rpc/methods/notifications.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 import { defineStreamingMethod, defineMethod, type RpcAnyMethod } from '../core'
+import { OptionalString, requiredString } from '../schemas'
+import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id'
 
 // Why: monotonically increasing per-process counter eliminates the
 // Date.now() collision that could fire when two near-simultaneous
@@ -11,6 +13,18 @@ const NotificationUnsubscribeParams = z.object({
     .unknown()
     .transform((value) => (typeof value === 'string' && value.length > 0 ? value : ''))
     .pipe(z.string().min(1, 'Missing subscriptionId'))
+})
+
+// Why: `notifications.dispatch` is the agent-facing trigger behind `orca notify`.
+// It carries an arbitrary message and (via the resolved pane) deep-links the
+// tap to a specific terminal on desktop and mobile. `message` is required;
+// `terminal`/`worktree` select which pane the tap should focus (optional — a
+// bare notify still fires without click routing).
+const NotificationDispatchParams = z.object({
+  message: requiredString('Missing --message'),
+  title: OptionalString,
+  terminal: OptionalString,
+  worktree: OptionalString
 })
 
 // Why: notifications.subscribe streams desktop notification events to mobile
@@ -51,6 +65,47 @@ export const NOTIFICATION_METHODS: readonly RpcAnyMethod[] = [
     handler: async (params, { runtime }) => {
       runtime.cleanupSubscription(params.subscriptionId)
       return { unsubscribed: true }
+    }
+  }),
+  defineMethod({
+    name: 'notifications.dispatch',
+    params: NotificationDispatchParams,
+    handler: async (params, { runtime }) => {
+      let worktreeId: string | undefined
+      let paneKey: string | undefined
+      try {
+        // Reuse the exact resolution `terminal focus` uses: an explicit handle,
+        // else the active terminal in the selected (or current) worktree.
+        const handle = params.terminal ?? (await runtime.resolveActiveTerminal(params.worktree))
+        const terminal = await runtime.showTerminal(handle)
+        worktreeId = terminal.worktreeId
+        if (terminal.tabId && !terminal.tabId.includes(':') && isTerminalLeafId(terminal.leafId)) {
+          paneKey = makePaneKey(terminal.tabId, terminal.leafId)
+        }
+      } catch (error) {
+        // Why: a bare `orca notify --message …` with no live terminal should
+        // still fire a plain notification. Only surface the error when the
+        // caller explicitly named a target that could not be resolved.
+        if (params.terminal || params.worktree) {
+          throw error
+        }
+      }
+
+      const result = await runtime.dispatchNotification({
+        source: 'dispatch',
+        message: params.message,
+        ...(params.title ? { title: params.title } : {}),
+        ...(worktreeId ? { worktreeId } : {}),
+        ...(paneKey ? { paneKey } : {})
+      })
+
+      return {
+        dispatch: {
+          ...result,
+          ...(worktreeId ? { worktreeId } : {}),
+          ...(paneKey ? { paneKey } : {})
+        }
+      }
     }
   })
 ]

--- a/src/main/runtime/rpc/methods/notifications.ts
+++ b/src/main/runtime/rpc/methods/notifications.ts
@@ -27,10 +27,12 @@ const NotificationDispatchParams = z.object({
   worktree: OptionalString
 })
 
-// Why: notifications.subscribe streams desktop notification events to mobile
-// clients over WebSocket. The mobile client shows a local push notification
-// for each event. This avoids requiring Firebase/APNs — the existing
-// persistent WebSocket connection doubles as the push channel.
+/**
+ * Registers notification RPC methods for mobile subscriptions and agent dispatch.
+ *
+ * Mobile subscriptions reuse the persistent WebSocket as the push channel,
+ * while `notifications.dispatch` backs the CLI-triggered notification path.
+ */
 export const NOTIFICATION_METHODS: readonly RpcAnyMethod[] = [
   defineStreamingMethod({
     name: 'notifications.subscribe',

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -55,11 +55,11 @@ describe('acquireSingleInstanceLock', () => {
     expect(acquired).toBe(true)
     expect(fake.requestSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(fake.on).toHaveBeenCalledTimes(1)
-    expect(fake.on).toHaveBeenCalledWith('second-instance', onSecondInstance)
+    expect(fake.on).toHaveBeenCalledWith('second-instance', expect.any(Function))
     expect(fake.listeners['second-instance']).toHaveLength(1)
   })
 
-  it('fires the registered callback when second-instance dispatches', () => {
+  it('fires the callback with the second instance argv when second-instance dispatches', () => {
     const onSecondInstance = vi.fn()
     const fake = makeFakeApp(true)
 
@@ -67,9 +67,13 @@ describe('acquireSingleInstanceLock', () => {
 
     const [registered] = fake.listeners['second-instance'] ?? []
     expect(registered).toBeDefined()
-    registered?.()
+    // Why: mirror Electron's (event, argv, cwd, additionalData) dispatch so the
+    // handler receives the protocol URL that Windows/Linux pass as an argv entry.
+    const argv = ['/path/to/Orca', 'orca://focus?terminal=term_abc']
+    registered?.({}, argv, '/cwd')
 
     expect(onSecondInstance).toHaveBeenCalledTimes(1)
+    expect(onSecondInstance).toHaveBeenCalledWith(argv)
   })
 })
 

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -39,6 +39,12 @@ export function acquireSingleInstanceLock(
   return true
 }
 
+/**
+ * Decide whether to skip the packaged single-instance lock. Only ever true on a
+ * packaged macOS build with `ORCA_BYPASS_SINGLE_INSTANCE_LOCK=1` set — a
+ * diagnostics-only escape hatch. Dev and serve-mode runs, and every non-darwin
+ * platform, always keep the lock. `env` and `platform` are injectable for tests.
+ */
 export function shouldBypassSingleInstanceLock(options: {
   env?: NodeJS.ProcessEnv
   isDev: boolean
@@ -55,10 +61,18 @@ export function shouldBypassSingleInstanceLock(options: {
   )
 }
 
+/**
+ * Emit the canonical lock-failure diagnostic (this launch could not acquire the
+ * single-instance lock and is exiting) through the startup diagnostic sink.
+ */
 export function logSingleInstanceLockFailure(write?: StartupDiagnosticSink): void {
   writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE, write)
 }
 
+/**
+ * Emit the diagnostic noting that the packaged macOS single-instance lock is
+ * being bypassed via `ORCA_BYPASS_SINGLE_INSTANCE_LOCK`.
+ */
 export function logSingleInstanceLockBypass(write?: StartupDiagnosticSink): void {
   writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE, write)
 }

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -25,11 +25,17 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
  * way dev (`orca-dev` userData) and packaged (`orca` userData) runs lock in
  * separate namespaces instead of serialising against each other.
  */
-export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void): boolean {
+export function acquireSingleInstanceLock(
+  app: App,
+  onSecondInstance: (argv: string[]) => void
+): boolean {
   if (!app.requestSingleInstanceLock()) {
     return false
   }
-  app.on('second-instance', onSecondInstance)
+  // Why: forward the second launch's argv so Windows/Linux protocol activations
+  // (`orca://…` arrives as an argv entry, not an event) can be routed by the
+  // handler. macOS delivers the same intent via `open-url` instead.
+  app.on('second-instance', (_event, argv) => onSecondInstance(argv))
   return true
 }
 

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -13,6 +13,7 @@ import type {
   GitWorktreeInfo,
   RemoveWorktreeResult,
   Repo,
+  NotificationDispatchResult,
   TabGroupLayoutNode,
   TerminalColorOverrides,
   TerminalLayoutSnapshot,
@@ -537,6 +538,14 @@ export type RuntimeTerminalClose = {
   handle: string
   tabId: string
   ptyKilled: boolean
+}
+
+/** Result of `notifications.dispatch` (the `orca notify` runtime RPC). */
+export type RuntimeNotificationDispatch = NotificationDispatchResult & {
+  /** Resolved worktree the tap will activate, when a target was resolved. */
+  worktreeId?: string
+  /** Resolved pane key the tap will focus, when a live pane was resolved. */
+  paneKey?: string
 }
 
 export type RuntimeTerminalWaitCondition = 'exit' | 'tui-idle'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3000,7 +3000,14 @@ export type GhosttyImportPreview = {
 // schema-vs-renderer enum sync guard.
 export type DiscoveryStatusEmitted = 'found' | 'absent' | 'imported'
 
-export type NotificationEventSource = 'agent-task-complete' | 'terminal-bell' | 'test'
+export type NotificationEventSource =
+  | 'agent-task-complete'
+  | 'terminal-bell'
+  | 'test'
+  // Why: an explicit notification fired on demand by an agent/orchestrator via
+  // `orca notify` (runtime RPC `notifications.dispatch`), carrying a custom
+  // message. Bypasses the renderer's per-source enable gates and burst dedupe.
+  | 'dispatch'
 
 export type NotificationDispatchRequest = {
   source: NotificationEventSource
@@ -3010,6 +3017,10 @@ export type NotificationDispatchRequest = {
   worktreeId?: string
   /** Stable `${tabId}:${leafId}` terminal pane key for click-to-focus routing. */
   paneKey?: string
+  /** Custom heading for `source: 'dispatch'` notifications; ignored otherwise. */
+  title?: string
+  /** Custom body for `source: 'dispatch'` notifications; ignored otherwise. */
+  message?: string
   repoLabel?: string
   worktreeLabel?: string
   hasMultipleActiveRepos?: boolean


### PR DESCRIPTION
## Summary

Adds a native way for an agent/orchestrator to **fire an Orca notification on demand** — carrying an arbitrary message (e.g. an AI summary) and deep-linking the tap to a specific terminal pane on **desktop and mobile**.

Today notifications are only auto-emitted by the renderer on agent-idle / terminal-bell, and the runtime RPC surface exposes only `notifications.subscribe`/`unsubscribe` (the outbound mobile push stream). An agent running in a pane — which talks to the runtime RPC — had **no way to dispatch one**, which is the single missing trigger that otherwise forces shelling out to a third-party push service.

```
orca notify --message "Tests passed — ready for review"
orca notify --pane term_abc123 --title "Blocked" --message "Needs your input on the migration"
orca notify --worktree active --message "Deploy finished"
```

> [!IMPORTANT]
> **Stacked on #7930** (`feat/focus-deep-link`). This PR is branched off that PR's head, so the diff against `main` includes #7930's commits. **Only the commits from `feat(notifications): add notifications.dispatch …` onward belong to this PR.** Merge #7930 first, then this rebases cleanly onto `main`. (#7930 reuses `runtime.focusTerminal`; this PR reuses the same click→pane routing.)

## What's in it

**A. Runtime RPC dispatch (`notifications.dispatch`)** — `src/main/runtime/rpc/methods/notifications.ts`. Resolves the selected terminal to `worktreeId` + `paneKey` using the **exact** resolution `terminal focus` uses (`resolveActiveTerminal` → `showTerminal`), then fires the notification. Reuses the delivery core rather than duplicating it: the native+mobile delivery (`performNotificationDelivery`) is extracted from the renderer IPC handler and injected into the runtime via `setNotificationDispatcher`, so a dispatched notification takes the **identical** path as an auto-emitted one and honors the global enable toggle. The renderer-only gates (tray attention, focus suppression, burst dedupe) stay in the IPC handler.

**B. CLI verb (`orca notify`)** — `src/cli/handlers/notify.ts`, mirroring the terminal handlers. `--pane <handle>` (with `--terminal` alias) or `--worktree <selector>` picks the pane the tap focuses; omit both to target the active terminal in the current worktree. Non-delivery is a soft failure surfaced via non-zero exit code (parity with `terminal wait`).

**C. Pane-granular mobile tap** — previously `dispatchMobileNotification` dropped `paneKey` and mobile taps stopped at `/h/<host>/session/<worktreeId>`. Now `paneKey` is threaded through the mobile notification event + local notification data, appended to the session route as `?pane=<paneKey>`, and the session screen resolves it to a live handle (`terminal.resolvePane`) and focuses that split through the vetted `switchTab` path once its tab loads. Failure degrades to the pre-existing worktree-level view.

The desktop click handler already routes `worktreeId`+`paneKey` to the exact pane (unchanged), so click-to-focus works the moment those fields are populated.

## Security

The RPC validates inputs with zod and **only fires a notification** — it never executes commands or injects text into a terminal. `message`/`title` are length-bounded before rendering. No new inbound-text surface.

## Testing

- New RPC unit tests: `src/main/runtime/rpc/methods/notifications.test.ts` (pane resolution, worktree fallback, bare notify with no terminal, explicit-target error, missing-message rejection).
- Extended `src/main/ipc/notifications.test.ts`: `dispatch` source builds the custom title/body + threads `paneKey` to mobile; the injected runtime dispatcher honors the global enable toggle.
- Extended `mobile/src/notifications/notification-routing.test.ts`: `paneKey` → `?pane=` and local-data threading.
- `pnpm typecheck` (node/cli/web) ✅ · `mobile` `tsc --noEmit` ✅ · `oxlint` clean on changed files ✅ · `check:max-lines-ratchet` ✅ (no new suppressions) · full CLI + RPC suites (899 tests) ✅.
- `pnpm build:desktop` ✅; verified `orca notify --help` renders from the built CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

N/A - this is a CLI/runtime notification dispatch path with desktop/mobile tap routing; there is no new persistent visual UI state to capture.

## AI Review Report

CodeRabbit reviewed the branch and raised one Major inline finding about the mobile pane-focus guard. Commit `7d40f69` fixed it, Saurabh replied in-thread, and CodeRabbit confirmed the thread is fully addressed/resolved. This follow-up also adds JSDoc to the branch-specific exported notification helpers in response to the pre-merge docstring warning.

## Notes

This remains stacked on #7930. The mobile signing/build step is intentionally not part of this PR follow-up; existing source checks and targeted notification tests cover the code paths changed here.

## ELI5

Agents can fire an on-demand Orca notification with a custom message via `orca notify`, and tapping it focuses the right terminal pane on desktop or mobile. Notifications are no longer only automatic idle/bell events.
