### PR TITLE
skills: prefer agent-first worktree launch; avoid empty shell tabs

### DIFF
--- a/config/scripts/orca-cli-skill-guidance.test.mjs
+++ b/config/scripts/orca-cli-skill-guidance.test.mjs
@@ -45,6 +45,28 @@ describe('orca CLI skill guidance', () => {
     expect(skill).toContain('send the prompt, and stop')
   })
 
+  it('prefers agent-first workers without duplicating terminal delivery', () => {
+    const skill = readSkill()
+
+    expect(skill).toContain('Prefer agent-first create for agent workers')
+    expect(skill).toContain('fallback shell plus a later `terminal create')
+    expect(skill).toContain('Repo setup or default-terminal settings may still add tabs or splits')
+    expect(skill).toContain(
+      'when no repo default-terminal configuration supplies a primary terminal'
+    )
+    expect(skill).toContain('Configured default tabs are materialized instead')
+    expect(skill).toContain(
+      'only after `terminal list` or `terminal show` confirms it is an unused shell'
+    )
+    expect(skill).not.toContain('bare `worktree create` (no `--agent`) still opens')
+    expect(skill).not.toContain('ends with **one** tab')
+    expect(skill).toContain('Use `startupTerminal.handle` as the sole agent handle')
+    expect(skill).toContain('never dual-send to old and replacement handles')
+    expect(skill).toContain(
+      "this checks the caller's inbox and does not remotely deliver input to another terminal"
+    )
+  })
+
   it('keeps browser injection guidance narrow and avoids literal secret examples', () => {
     const skill = readSkill()
 

--- a/config/scripts/orchestration-skill-guidance.test.mjs
+++ b/config/scripts/orchestration-skill-guidance.test.mjs
@@ -188,4 +188,34 @@ describe('orchestration skill guidance', () => {
     expect(skill).not.toContain('post-completion polling messages')
     expect(skill).not.toContain('every 2 minutes')
   })
+
+  it('keeps agent-first launch, handle recovery, and inbox injection distinct', () => {
+    const skill = readSkill()
+    const messaging = getSection(skill, 'Messaging')
+    const workerTerminals = getSection(skill, 'Worker Terminals')
+    const agentFirstExample = workerTerminals.match(
+      /```bash\norca worktree create --name <task-name> --agent codex --json\n[\s\S]*?```/
+    )?.[0]
+
+    expect(workerTerminals).toContain('Agent-first (required for ordinary agent workers)')
+    expect(workerTerminals).toContain('fallback shell + agent pair')
+    expect(workerTerminals).toContain(
+      'Repo setup or default-terminal settings may still add tabs or splits'
+    )
+    expect(workerTerminals).toContain('without configured default tabs')
+    expect(workerTerminals).toContain(
+      'only after `terminal list` or `terminal show` confirms it is an unused shell'
+    )
+    expect(workerTerminals).not.toContain('bare create opens a default shell')
+    expect(workerTerminals).not.toContain('ends with **one** agent tab')
+    expect(agentFirstExample).toBeDefined()
+    expect(agentFirstExample).not.toContain('orca terminal list')
+    expect(agentFirstExample).toContain('startupTerminal.handle')
+    expect(messaging).toContain(
+      'Use `startupTerminal.handle` from the create response when present'
+    )
+    expect(messaging).toContain('continue with the replacement only')
+    expect(messaging).toContain('it does not remotely wake another terminal')
+    expect(messaging).toContain('Use `orchestration dispatch --inject` to deliver a tracked task')
+  })
 })

--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -55,7 +55,9 @@ Use `--no-parent` and omit `--base-branch` for independent top-level handoffs un
 
 Custom Codex model/effort handoff:
 
-`worktree create --agent codex --prompt ...` launches the known Codex agent but does not accept Codex-specific `--model` or `-c model_reasoning_effort=...` arguments. For requests such as `gpt-5.5 xhigh`, create the independent worktree, launch the requested Codex command there, wait only for TUI readiness if needed to avoid losing input, send the prompt, and stop:
+`worktree create --agent codex --prompt ...` launches the known Codex agent but does not accept Codex-specific `--model` or `-c model_reasoning_effort=...` arguments. For requests such as `gpt-5.5 xhigh`, create the independent worktree, launch the requested Codex command there, wait only for TUI readiness if needed to avoid losing input, send the prompt, and stop.
+
+**Empty first terminal:** bare `worktree create` (no `--agent`) still opens a default shell as the worktree's first terminal. The subsequent `terminal create --command ...` adds a **second** tab for the agent. Prefer `--agent` whenever the built-in launcher is enough. When custom argv forces the two-step path, target the agent handle only, and optionally `orca terminal close` the leftover shell tab so the worktree is not left with a dead empty terminal.
 
 ```bash
 orca worktree create --name <task-name> --no-parent --json
@@ -121,13 +123,15 @@ orca worktree create --name task --setup skip --json
 orca worktree create --name task --run-hooks --json
 ```
 
-- `--agent <id>` launches that agent in the first terminal; `--prompt <text>` sends initial work to it.
+- `--agent <id>` launches that agent **in the first terminal** (Orca docs: *"`--agent` launches the selected agent in the first terminal"*); `--prompt <text>` sends initial work to it. Known ids include `claude`, `codex`, `omp`, `pi`, `grok`, and other installed TUI agents.
+- **Prefer agent-first create for agent workers.** `orca worktree create --agent <id> --prompt "..."` ends with **one** tab (the agent). Bare `orca worktree create` (no `--agent`) always opens a default **shell** first terminal; a later `orca terminal create --command <agent>` adds a **second** tab. That empty-shell + agent pair is an anti-pattern for ordinary agent worktrees — use `--agent` instead of “create worktree, then open agent.”
+- After create, resolve the live agent handle with `orca terminal list --worktree id:<newWorktreeId> --json` (or `name:<displayName>`). Do not assume `startupTerminal.handle` from the create response is the only valid handle, and do not dual-send to both a create-time handle and a list-time handle.
 - `--setup run|skip|inherit` controls repo setup hooks. Default is `inherit`, which follows the repo's setup policy.
 - `--run-hooks` is a legacy alias for `--setup run`; it also reveals/activates the new worktree.
 - `--agent`, `--activate`, and `--run-hooks` reveal the new worktree. Plain create stays in the background.
-- Let Orca choose setup terminal placement from repo settings, including tab vs split behavior. Do not manually create extra setup terminals.
-- If an older installed CLI rejects `--agent`, `--prompt`, or `--setup`, create the worktree normally, then run `orca terminal create --worktree <selector> --command "codex"` and `orca terminal send` if a prompt is needed.
-- `worktree create` creates a new checkout. For a fresh agent in the current checkout, use `orca terminal create --worktree active --command "codex" --json`.
+- Let Orca choose setup terminal placement from repo settings, including tab vs split behavior. Do not manually create extra setup terminals when `--agent` already owns the first tab.
+- If an older installed CLI rejects `--agent`, `--prompt`, or `--setup`, create the worktree normally, then run `orca terminal create --worktree <selector> --command "codex"` and `orca terminal send` if a prompt is needed — and expect the leftover empty shell tab (close it if unwanted).
+- `worktree create` creates a new checkout. For a fresh agent in the **current** checkout (no new worktree), use `orca terminal create --worktree active --command "codex" --json` — that path does not create a second worktree shell.
 
 ## Worktree Comments
 
@@ -173,10 +177,10 @@ Terminal rules:
 - `--terminal` is optional for most commands; omitted means the active terminal in the current worktree.
 - Use `terminal read` before `terminal send` unless the next input is obvious.
 - Use `terminal send` only for direct terminal input or one-off prompts where no task state, inbox, or reply tracking is needed.
-- For structured coordination, invoke the `orchestration` skill; it uses `orca orchestration ...` commands for messages, handoffs, task DAGs, dispatches, inbox/reply flows, and coordinator loops.
-- Use `terminal create --worktree active --command "<agent>"` for a fresh agent in the current worktree. Use `worktree create --agent <agent>` only for a separate checkout.
-- Use `terminal wait --for tui-idle` for agent CLIs such as Claude Code, Gemini, and Codex; always pass `--timeout-ms`.
-- Terminal handles are runtime-scoped. If Orca restarts or returns `terminal_handle_stale`, reacquire with `terminal list`.
+- For structured coordination, invoke the `orchestration` skill; it uses `orca orchestration ...` commands for messages, handoffs, task DAGs, dispatches, inbox/reply flows, and coordinator loops. Prefer `orca orchestration check --terminal <handle> --unread --inject` to deliver mail into an existing agent TUI — inject does **not** open a new shell tab.
+- Use `terminal create --worktree active --command "<agent>"` for a fresh agent in the current worktree. Use `worktree create --agent <agent>` only for a separate checkout (agent in the first terminal — do not also `terminal create` the same agent).
+- Use `terminal wait --for tui-idle` for agent CLIs such as Claude Code, Gemini, Codex, OMP, Pi, and Grok; always pass `--timeout-ms`.
+- Terminal handles are runtime-scoped. If Orca restarts or returns `terminal_handle_stale`, reacquire with `terminal list`. After `worktree create --agent`, always re-list before messaging so you use the live agent handle once.
 - For long output, use cursor reads. After a limited tail preview, page from `oldestCursor`; after a cursor read, continue with `nextCursor` while `limited` is true and `nextCursor !== latestCursor`.
 - `--direction horizontal` splits left/right. `--direction vertical` splits top/bottom.
 

--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -57,7 +57,7 @@ Custom Codex model/effort handoff:
 
 `worktree create --agent codex --prompt ...` launches the known Codex agent but does not accept Codex-specific `--model` or `-c model_reasoning_effort=...` arguments. For requests such as `gpt-5.5 xhigh`, create the independent worktree, launch the requested Codex command there, wait only for TUI readiness if needed to avoid losing input, send the prompt, and stop.
 
-**Empty first terminal:** bare `worktree create` (no `--agent`) still opens a default shell as the worktree's first terminal. The subsequent `terminal create --command ...` adds a **second** tab for the agent. Prefer `--agent` whenever the built-in launcher is enough. When custom argv forces the two-step path, target the agent handle only, and optionally `orca terminal close` the leftover shell tab so the worktree is not left with a dead empty terminal.
+**Extra first terminal:** when no repo default-terminal configuration supplies a primary terminal, bare `worktree create` (no `--agent`) opens a fallback shell before the later `terminal create --command ...` adds the agent. Configured default tabs are materialized instead and may run real commands. Prefer `--agent` whenever the built-in launcher is enough. When custom argv forces the two-step path, target the agent handle only; close a prior terminal only after `terminal list` or `terminal show` confirms it is an unused shell.
 
 ```bash
 orca worktree create --name <task-name> --no-parent --json
@@ -124,13 +124,13 @@ orca worktree create --name task --run-hooks --json
 ```
 
 - `--agent <id>` launches that agent **in the first terminal** (Orca docs: *"`--agent` launches the selected agent in the first terminal"*); `--prompt <text>` sends initial work to it. Known ids include `claude`, `codex`, `omp`, `pi`, `grok`, and other installed TUI agents.
-- **Prefer agent-first create for agent workers.** `orca worktree create --agent <id> --prompt "..."` ends with **one** tab (the agent). Bare `orca worktree create` (no `--agent`) always opens a default **shell** first terminal; a later `orca terminal create --command <agent>` adds a **second** tab. That empty-shell + agent pair is an anti-pattern for ordinary agent worktrees — use `--agent` instead of “create worktree, then open agent.”
-- After create, resolve the live agent handle with `orca terminal list --worktree id:<newWorktreeId> --json` (or `name:<displayName>`). Do not assume `startupTerminal.handle` from the create response is the only valid handle, and do not dual-send to both a create-time handle and a list-time handle.
+- **Prefer agent-first create for agent workers.** `orca worktree create --agent <id> --prompt "..."` puts the agent in the worktree's first terminal without adding a separate fallback shell for that worker. Repo setup or default-terminal settings may still add tabs or splits. Without configured default tabs, the bare-create fallback shell plus a later `terminal create --command <agent>` is an anti-pattern for ordinary agent worktrees — use `--agent` instead of “create worktree, then open agent.” Configured default tabs are intentional surfaces; never treat one as disposable without verifying that it is an unused shell.
+- After create, use exactly one agent handle: `startupTerminal.handle` from the create response when present, or the matching result from `orca terminal list --worktree id:<newWorktreeId> --json` (or `name:<displayName>`) when the response omits it. If a handle later returns `terminal_handle_stale`, re-list it; never dual-send to old and replacement handles.
 - `--setup run|skip|inherit` controls repo setup hooks. Default is `inherit`, which follows the repo's setup policy.
 - `--run-hooks` is a legacy alias for `--setup run`; it also reveals/activates the new worktree.
 - `--agent`, `--activate`, and `--run-hooks` reveal the new worktree. Plain create stays in the background.
 - Let Orca choose setup terminal placement from repo settings, including tab vs split behavior. Do not manually create extra setup terminals when `--agent` already owns the first tab.
-- If an older installed CLI rejects `--agent`, `--prompt`, or `--setup`, create the worktree normally, then run `orca terminal create --worktree <selector> --command "codex"` and `orca terminal send` if a prompt is needed — and expect the leftover empty shell tab (close it if unwanted).
+- If an older installed CLI rejects `--agent`, `--prompt`, or `--setup`, create the worktree normally, then run `orca terminal create --worktree <selector> --command "codex"` and `orca terminal send` if a prompt is needed. This can leave a fallback shell when no default tabs are configured; close it only after confirming it is unused.
 - `worktree create` creates a new checkout. For a fresh agent in the **current** checkout (no new worktree), use `orca terminal create --worktree active --command "codex" --json` — that path does not create a second worktree shell.
 
 ## Worktree Comments
@@ -177,10 +177,10 @@ Terminal rules:
 - `--terminal` is optional for most commands; omitted means the active terminal in the current worktree.
 - Use `terminal read` before `terminal send` unless the next input is obvious.
 - Use `terminal send` only for direct terminal input or one-off prompts where no task state, inbox, or reply tracking is needed.
-- For structured coordination, invoke the `orchestration` skill; it uses `orca orchestration ...` commands for messages, handoffs, task DAGs, dispatches, inbox/reply flows, and coordinator loops. Prefer `orca orchestration check --terminal <handle> --unread --inject` to deliver mail into an existing agent TUI — inject does **not** open a new shell tab.
+- For structured coordination, invoke the `orchestration` skill; it uses `orca orchestration ...` commands for messages, handoffs, task DAGs, dispatches, inbox/reply flows, and coordinator loops. A receiving agent can run `orca orchestration check --unread --inject` to render its unread mail in agent-readable form; this checks the caller's inbox and does not remotely deliver input to another terminal.
 - Use `terminal create --worktree active --command "<agent>"` for a fresh agent in the current worktree. Use `worktree create --agent <agent>` only for a separate checkout (agent in the first terminal — do not also `terminal create` the same agent).
 - Use `terminal wait --for tui-idle` for agent CLIs such as Claude Code, Gemini, Codex, OMP, Pi, and Grok; always pass `--timeout-ms`.
-- Terminal handles are runtime-scoped. If Orca restarts or returns `terminal_handle_stale`, reacquire with `terminal list`. After `worktree create --agent`, always re-list before messaging so you use the live agent handle once.
+- Terminal handles are runtime-scoped. Use `startupTerminal.handle` as the sole agent handle when `worktree create --agent` returns it; if Orca restarts, omits the handle, or returns `terminal_handle_stale`, reacquire with `terminal list` and continue with the replacement only.
 - For long output, use cursor reads. After a limited tail preview, page from `oldestCursor`; after a cursor read, continue with `nextCursor` while `limited` is true and `nextCursor !== latestCursor`.
 - `--direction horizontal` splits left/right. `--direction vertical` splits top/bottom.
 

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -88,8 +88,8 @@ orca orchestration inbox [--limit <n>] [--json]
 Rules:
 
 - Omit `--from` unless impersonating another terminal; Orca auto-resolves it from the current terminal.
-- Message **one** live agent handle per worker. Re-resolve with `orca terminal list --worktree ... --json` after spawn; do not dual-send to both a create-time `startupTerminal` handle and a later list handle.
-- To wake a worker on new mail without opening a shell, use `orca orchestration check --terminal <handle> --unread --inject --json`. Prefer inject over `terminal send` for pure orchestration pings; use `terminal send` only when the agent needs a free-form prompt.
+- Message **one** live agent handle per worker. Use `startupTerminal.handle` from the create response when present; if it is missing or later returns `terminal_handle_stale`, re-resolve with `orca terminal list --worktree ... --json` and continue with the replacement only.
+- `orca orchestration check --unread --inject --json` renders unread mail for the agent terminal that runs it; it does not remotely wake another terminal. Use `orchestration dispatch --inject` to deliver a tracked task, or `terminal send` when an existing agent needs a free-form prompt.
 - While supervising workers manually, use `check --wait --types worker_done,escalation,decision_gate --timeout-ms <n>` instead of sleep/poll loops. Reply to `decision_gate` messages with `orca orchestration reply --id <msg_id> --body <answer> --json`, then keep waiting.
 - Treat a `check --wait` timeout or `{count:0}` as a checkpoint, not a worker failure. Long coding tasks routinely run 15-60 minutes; keep using rolling waits unless you receive `worker_done`/`escalation`, the terminal exits or disappears, or the user explicitly asks you to stop.
 - Heartbeats and visible terminal activity mean the worker is alive, not done. Do not stop, close, kill, or restart a worker just because it has not produced a completion message yet.
@@ -163,7 +163,7 @@ Custom Codex model/effort handoff:
 
 `orca worktree create --agent codex --prompt ...` launches the known Codex agent but does not accept Codex-specific `--model` or `-c model_reasoning_effort=...` arguments. When the user asks for a specific Codex model or effort, create the independent worktree first, launch Codex with the requested command in that worktree, wait only for TUI readiness if prompt delivery would otherwise race startup, send the prompt, and stop.
 
-Note: bare create leaves a default shell as the first terminal; `terminal create` adds the agent as a second tab. Prefer `--agent` whenever custom argv is not required. With the two-step path, target only the agent handle and close the leftover shell if unwanted.
+Note: when no repo default-terminal configuration supplies a primary terminal, bare create opens a fallback shell before `terminal create` adds the agent. Configured default tabs are materialized instead and may run real commands. Prefer `--agent` whenever custom argv is not required. With the two-step path, target only the agent handle; close a prior terminal only after `terminal list` or `terminal show` confirms it is an unused shell.
 
 ```bash
 orca worktree create --name <task-name> --no-parent --json
@@ -191,14 +191,14 @@ Reuse an idle agent in the required worktree only if the prompt allows reuse; ot
 ```bash
 orca worktree create --name <task-name> --agent codex --json
 # or: --agent claude | omp | pi | grok | ...
-orca terminal list --worktree id:<newWorktreeId> --json
+# Read <handle> from startupTerminal.handle in the create response.
 orca terminal wait --terminal <handle> --for tui-idle --timeout-ms 60000 --json
 orca orchestration dispatch --task <task_id> --to <handle> --inject --json
 ```
 
-For new-worktree workers, read the id from `worktree create`, then use `terminal list` to get the **live** agent handle (prefer that over create-response `startupTerminal.handle` alone). Omit `--repo` only inside an Orca-managed worktree; otherwise pass `--repo <selector>`.
+For new-worktree workers, read the id and `startupTerminal.handle` from `worktree create`. Use that as the sole worker handle when present; otherwise use `terminal list` to resolve the agent handle. Omit `--repo` only inside an Orca-managed worktree; otherwise pass `--repo <selector>`.
 
-**Agent-first (required for ordinary agent workers):** `--agent` reveals the new worktree and launches the selected agent **in its first terminal**, so the worktree ends with **one** agent tab. Do **not** run bare `worktree create` and then `terminal create --command <agent>` for the same worker — bare create always opens a default shell first terminal, and the extra `terminal create` leaves an empty shell + agent (two tabs). Only use the two-step path when custom agent argv is required (for example Codex model/effort flags) or when an older CLI rejects `--agent`; if you must, message only the agent handle and close the leftover shell if unwanted. Do not run `worktree create` when the task must stay in the current worktree.
+**Agent-first (required for ordinary agent workers):** `--agent` reveals the new worktree and launches the selected agent **in its first terminal**, without adding a separate fallback shell for that worker. Repo setup or default-terminal settings may still add tabs or splits. Do **not** run bare `worktree create` and then `terminal create --command <agent>` for the same worker when agent-first create is available: without configured default tabs, that two-step path leaves a fallback shell + agent pair. Only use it when custom agent argv is required (for example Codex model/effort flags) or when an older CLI rejects `--agent`; if you must, message only the agent handle. Configured default tabs are intentional surfaces, so close a prior terminal only after `terminal list` or `terminal show` confirms it is an unused shell. Do not run `worktree create` when the task must stay in the current worktree.
 
 Use `orca worktree create --prompt ...` or `orca terminal send ...` for full handoffs or untracked/lightweight prompts. Those paths do not attach `taskId`/`dispatchId`; the worker should not send lifecycle messages unless the prompt supplies a live orchestration preamble.
 

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -88,6 +88,8 @@ orca orchestration inbox [--limit <n>] [--json]
 Rules:
 
 - Omit `--from` unless impersonating another terminal; Orca auto-resolves it from the current terminal.
+- Message **one** live agent handle per worker. Re-resolve with `orca terminal list --worktree ... --json` after spawn; do not dual-send to both a create-time `startupTerminal` handle and a later list handle.
+- To wake a worker on new mail without opening a shell, use `orca orchestration check --terminal <handle> --unread --inject --json`. Prefer inject over `terminal send` for pure orchestration pings; use `terminal send` only when the agent needs a free-form prompt.
 - While supervising workers manually, use `check --wait --types worker_done,escalation,decision_gate --timeout-ms <n>` instead of sleep/poll loops. Reply to `decision_gate` messages with `orca orchestration reply --id <msg_id> --body <answer> --json`, then keep waiting.
 - Treat a `check --wait` timeout or `{count:0}` as a checkpoint, not a worker failure. Long coding tasks routinely run 15-60 minutes; keep using rolling waits unless you receive `worker_done`/`escalation`, the terminal exits or disappears, or the user explicitly asks you to stop.
 - Heartbeats and visible terminal activity mean the worker is alive, not done. Do not stop, close, kill, or restart a worker just because it has not produced a completion message yet.
@@ -159,7 +161,9 @@ orca terminal send --terminal <handle> --text "<task brief>" --enter --json
 
 Custom Codex model/effort handoff:
 
-`orca worktree create --agent codex --prompt ...` launches the known Codex agent but does not accept Codex-specific `--model` or `-c model_reasoning_effort=...` arguments. When the user asks for a specific Codex model or effort, create the independent worktree first, launch Codex with the requested command in that worktree, wait only for TUI readiness if prompt delivery would otherwise race startup, send the prompt, and stop:
+`orca worktree create --agent codex --prompt ...` launches the known Codex agent but does not accept Codex-specific `--model` or `-c model_reasoning_effort=...` arguments. When the user asks for a specific Codex model or effort, create the independent worktree first, launch Codex with the requested command in that worktree, wait only for TUI readiness if prompt delivery would otherwise race startup, send the prompt, and stop.
+
+Note: bare create leaves a default shell as the first terminal; `terminal create` adds the agent as a second tab. Prefer `--agent` whenever custom argv is not required. With the two-step path, target only the agent handle and close the leftover shell if unwanted.
 
 ```bash
 orca worktree create --name <task-name> --no-parent --json
@@ -186,12 +190,15 @@ Reuse an idle agent in the required worktree only if the prompt allows reuse; ot
 
 ```bash
 orca worktree create --name <task-name> --agent codex --json
+# or: --agent claude | omp | pi | grok | ...
 orca terminal list --worktree id:<newWorktreeId> --json
 orca terminal wait --terminal <handle> --for tui-idle --timeout-ms 60000 --json
 orca orchestration dispatch --task <task_id> --to <handle> --inject --json
 ```
 
-For new-worktree workers, read the id from `worktree create`, then use `terminal list` to get the agent handle. Omit `--repo` only inside an Orca-managed worktree; otherwise pass `--repo <selector>`. `--agent` reveals the new worktree and launches the selected agent in its first terminal, so do not create a separate startup terminal. Do not run `worktree create` when the task must stay in the current worktree.
+For new-worktree workers, read the id from `worktree create`, then use `terminal list` to get the **live** agent handle (prefer that over create-response `startupTerminal.handle` alone). Omit `--repo` only inside an Orca-managed worktree; otherwise pass `--repo <selector>`.
+
+**Agent-first (required for ordinary agent workers):** `--agent` reveals the new worktree and launches the selected agent **in its first terminal**, so the worktree ends with **one** agent tab. Do **not** run bare `worktree create` and then `terminal create --command <agent>` for the same worker — bare create always opens a default shell first terminal, and the extra `terminal create` leaves an empty shell + agent (two tabs). Only use the two-step path when custom agent argv is required (for example Codex model/effort flags) or when an older CLI rejects `--agent`; if you must, message only the agent handle and close the leftover shell if unwanted. Do not run `worktree create` when the task must stay in the current worktree.
 
 Use `orca worktree create --prompt ...` or `orca terminal send ...` for full handoffs or untracked/lightweight prompts. Those paths do not attach `taskId`/`dispatchId`; the worker should not send lifecycle messages unless the prompt supplies a live orchestration preamble.
 


### PR DESCRIPTION
## Summary

- Document agent-first worktree creation in `skills/orca-cli` and `skills/orchestration` so ordinary agent workers do not gain a separate fallback shell.
- Prefer `worktree create --agent <id>` for known TUI agents; repo-configured setup/default-terminal tabs remain intentional and may still add tabs or splits.
- Use `startupTerminal.handle` as the sole destination when returned; re-list only when the handle is missing or stale, and never dual-send.
- Clarify that `orchestration check --unread --inject` renders the inbox for the agent that runs it; use `dispatch --inject` or `terminal send` for remote delivery.
- Add regression tests for the guidance and safe handling of configured default terminals.

This is skill guidance and static tests only; no product runtime code changes. It aligns with the CLI contract that `--agent` launches the selected agent in the first terminal.

## Why

The two-step create-then-launch path can leave a fallback shell when no configured default terminal supplies the primary surface. Agent-first creation avoids that extra worker shell while preserving setup/default terminals that may run real commands. Custom argv, such as Codex model or effort flags, still requires the two-step fallback.

## Test plan

- [x] `pnpm vitest run config/scripts/orca-cli-skill-guidance.test.mjs config/scripts/orchestration-skill-guidance.test.mjs` — 13 tests passed
- [x] Worktree provisioning oracles — 3 tests passed
- [x] Orchestration injection contracts — 2 tests passed
- [x] `pnpm typecheck`
- [x] Two-round adversarial review/fix loop; both final reviewers clean
- [x] Performance audit clean