### PR TITLE
feat(jira): group Jira issues by status

### DIFF
--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -6,6 +6,7 @@ import {
   createIssue,
   getIssue,
   getIssueComments,
+  getProjectStatusOrder,
   listAssignableUsers,
   listCreateFields,
   listIssueTypes,
@@ -14,8 +15,7 @@ import {
   listProjects,
   listTransitions,
   searchIssues,
-  updateIssue,
-  getProjectStatuses
+  updateIssue
 } from '../jira/issues'
 import type {
   JiraConnectArgs,
@@ -262,12 +262,12 @@ export function registerJiraHandlers(): void {
   })
 
   ipcMain.handle(
-    'jira:getProjectStatuses',
+    'jira:getProjectStatusOrder',
     async (_event, args: { projectKey: string; siteId?: string }) => {
       if (typeof args?.projectKey !== 'string' || !args.projectKey.trim()) {
-        return []
+        return { statusIdsByColumn: [] }
       }
-      return getProjectStatuses(args.projectKey.trim(), normalizeSiteId(args.siteId))
+      return getProjectStatusOrder(args.projectKey.trim(), normalizeSiteId(args.siteId))
     }
   )
 }

--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -14,7 +14,8 @@ import {
   listProjects,
   listTransitions,
   searchIssues,
-  updateIssue
+  updateIssue,
+  getProjectStatuses
 } from '../jira/issues'
 import type {
   JiraConnectArgs,
@@ -259,4 +260,14 @@ export function registerJiraHandlers(): void {
     }
     return listTransitions(args.key.trim(), normalizeSiteId(args.siteId))
   })
+
+  ipcMain.handle(
+    'jira:getProjectStatuses',
+    async (_event, args: { projectKey: string; siteId?: string }) => {
+      if (typeof args?.projectKey !== 'string' || !args.projectKey.trim()) {
+        return []
+      }
+      return getProjectStatuses(args.projectKey.trim(), normalizeSiteId(args.siteId))
+    }
+  )
 }

--- a/src/main/jira/issues.test.ts
+++ b/src/main/jira/issues.test.ts
@@ -398,4 +398,126 @@ describe('Jira issue operations', () => {
       }
     ])
   })
+
+  describe('getProjectStatuses', () => {
+    it('returns empty array when no clients are available', async () => {
+      getClientsMock.mockReturnValue([])
+      const { getProjectStatuses } = await import('./issues')
+
+      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual([])
+    })
+
+    it('returns statuses from project statuses API when no board configuration exists', async () => {
+      jiraRequestMock
+        .mockResolvedValueOnce([
+          {
+            name: 'Bug',
+            statuses: [
+              { id: '1', name: 'To Do' },
+              { id: '2', name: 'In Progress' },
+              { id: '3', name: 'Done' }
+            ]
+          }
+        ])
+        .mockResolvedValueOnce({ values: [] })
+
+      const { getProjectStatuses } = await import('./issues')
+
+      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual([
+        'To Do',
+        'In Progress',
+        'Done'
+      ])
+    })
+
+    it('orders statuses by agile board column configuration when available', async () => {
+      jiraRequestMock
+        .mockResolvedValueOnce([
+          {
+            name: 'Bug',
+            statuses: [
+              { id: '1', name: 'To Do' },
+              { id: '2', name: 'In Progress' },
+              { id: '3', name: 'Done' },
+              { id: '4', name: 'Closed' }
+            ]
+          }
+        ])
+        .mockResolvedValueOnce({
+          values: [{ id: 'board-1' }]
+        })
+        .mockResolvedValueOnce({
+          columnConfig: {
+            columns: [
+              {
+                statuses: [{ id: '3' }]
+              },
+              {
+                statuses: [{ id: '2' }]
+              },
+              {
+                statuses: [{ id: '1' }]
+              }
+            ]
+          }
+        })
+
+      const { getProjectStatuses } = await import('./issues')
+
+      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual([
+        'Done',
+        'In Progress',
+        'To Do',
+        'Closed'
+      ])
+    })
+
+    it('handles missing status IDs gracefully by falling back to unordered list', async () => {
+      jiraRequestMock
+        .mockResolvedValueOnce([
+          {
+            name: 'Bug',
+            statuses: [
+              { id: '1', name: 'To Do' },
+              { id: '2', name: 'In Progress' }
+            ]
+          }
+        ])
+        .mockResolvedValueOnce({
+          values: [{ id: 'board-1' }]
+        })
+        .mockResolvedValueOnce({
+          columnConfig: {
+            columns: [
+              {
+                statuses: [{ id: '999' }]
+              }
+            ]
+          }
+        })
+
+      const { getProjectStatuses } = await import('./issues')
+
+      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual(['To Do', 'In Progress'])
+    })
+
+    it('clears token on auth errors', async () => {
+      const authError = new Error('Unauthorized')
+      isAuthErrorMock.mockReturnValue(true)
+      jiraRequestMock.mockRejectedValueOnce(authError)
+
+      const { getProjectStatuses } = await import('./issues')
+
+      await expect(getProjectStatuses('ALP', 'site-1')).rejects.toThrow('Unauthorized')
+      expect(clearTokenMock).toHaveBeenCalledWith('site-1')
+    })
+
+    it('returns empty array on operational errors', async () => {
+      jiraRequestMock.mockRejectedValueOnce(new Error('Service Unavailable'))
+
+      const { getProjectStatuses } = await import('./issues')
+
+      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual([])
+    })
+  })
 })

--- a/src/main/jira/issues.test.ts
+++ b/src/main/jira/issues.test.ts
@@ -399,125 +399,99 @@ describe('Jira issue operations', () => {
     ])
   })
 
-  describe('getProjectStatuses', () => {
-    it('returns empty array when no clients are available', async () => {
+  describe('getProjectStatusOrder', () => {
+    it('returns an empty order when no clients are available', async () => {
       getClientsMock.mockReturnValue([])
-      const { getProjectStatuses } = await import('./issues')
+      const { getProjectStatusOrder } = await import('./issues')
 
-      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual([])
+      await expect(getProjectStatusOrder('ALP', 'site-1')).resolves.toEqual({
+        statusIdsByColumn: []
+      })
     })
 
-    it('returns statuses from project statuses API when no board configuration exists', async () => {
-      jiraRequestMock
-        .mockResolvedValueOnce([
-          {
-            name: 'Bug',
-            statuses: [
-              { id: '1', name: 'To Do' },
-              { id: '2', name: 'In Progress' },
-              { id: '3', name: 'Done' }
-            ]
-          }
-        ])
-        .mockResolvedValueOnce({ values: [] })
+    it('returns an empty order when an omitted site resolves to multiple clients', async () => {
+      getClientsMock.mockReturnValue([makeEntry('site-1'), makeEntry('site-2')])
+      const { getProjectStatusOrder } = await import('./issues')
 
-      const { getProjectStatuses } = await import('./issues')
-
-      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual([
-        'To Do',
-        'In Progress',
-        'Done'
-      ])
+      await expect(getProjectStatusOrder('ALP')).resolves.toEqual({ statusIdsByColumn: [] })
+      expect(jiraRequestMock).not.toHaveBeenCalled()
     })
 
-    it('orders statuses by agile board column configuration when available', async () => {
+    it('returns an empty order when the project has no accessible board', async () => {
+      jiraRequestMock.mockResolvedValueOnce({ values: [] })
+      const { getProjectStatusOrder } = await import('./issues')
+
+      await expect(getProjectStatusOrder('ALP & OPS', 'site-1')).resolves.toEqual({
+        statusIdsByColumn: []
+      })
+      expect(String(jiraRequestMock.mock.calls[0][1])).toContain(
+        '/rest/agile/1.0/board?projectKeyOrId=ALP+%26+OPS&maxResults=2'
+      )
+    })
+
+    it('keeps alphabetical fallback when a project has multiple boards', async () => {
+      jiraRequestMock.mockResolvedValueOnce({
+        total: 2,
+        values: [{ id: 42 }, { id: 43 }]
+      })
+      const { getProjectStatusOrder } = await import('./issues')
+
+      await expect(getProjectStatusOrder('ALP', 'site-1')).resolves.toEqual({
+        statusIdsByColumn: []
+      })
+      expect(jiraRequestMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps alphabetical fallback when Jira reports another board page', async () => {
+      jiraRequestMock.mockResolvedValueOnce({
+        isLast: false,
+        values: [{ id: 42 }]
+      })
+      const { getProjectStatusOrder } = await import('./issues')
+
+      await expect(getProjectStatusOrder('ALP', 'site-1')).resolves.toEqual({
+        statusIdsByColumn: []
+      })
+      expect(jiraRequestMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns status IDs grouped by Jira board column order', async () => {
       jiraRequestMock
-        .mockResolvedValueOnce([
-          {
-            name: 'Bug',
-            statuses: [
-              { id: '1', name: 'To Do' },
-              { id: '2', name: 'In Progress' },
-              { id: '3', name: 'Done' },
-              { id: '4', name: 'Closed' }
-            ]
-          }
-        ])
-        .mockResolvedValueOnce({
-          values: [{ id: 'board-1' }]
-        })
+        .mockResolvedValueOnce({ total: 1, values: [{ id: 42 }] })
         .mockResolvedValueOnce({
           columnConfig: {
             columns: [
-              {
-                statuses: [{ id: '3' }]
-              },
-              {
-                statuses: [{ id: '2' }]
-              },
-              {
-                statuses: [{ id: '1' }]
-              }
+              { statuses: [{ id: '1' }, { id: '2' }] },
+              { statuses: [{ id: '3' }, { id: '2' }] },
+              { statuses: [] }
             ]
           }
         })
+      const { getProjectStatusOrder } = await import('./issues')
 
-      const { getProjectStatuses } = await import('./issues')
-
-      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual([
-        'Done',
-        'In Progress',
-        'To Do',
-        'Closed'
-      ])
+      await expect(getProjectStatusOrder('ALP', 'site-1')).resolves.toEqual({
+        statusIdsByColumn: [['1', '2'], ['3']]
+      })
+      expect(jiraRequestMock.mock.calls[1]?.[1]).toBe('/rest/agile/1.0/board/42/configuration')
     })
 
-    it('handles missing status IDs gracefully by falling back to unordered list', async () => {
-      jiraRequestMock
-        .mockResolvedValueOnce([
-          {
-            name: 'Bug',
-            statuses: [
-              { id: '1', name: 'To Do' },
-              { id: '2', name: 'In Progress' }
-            ]
-          }
-        ])
-        .mockResolvedValueOnce({
-          values: [{ id: 'board-1' }]
-        })
-        .mockResolvedValueOnce({
-          columnConfig: {
-            columns: [
-              {
-                statuses: [{ id: '999' }]
-              }
-            ]
-          }
-        })
-
-      const { getProjectStatuses } = await import('./issues')
-
-      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual(['To Do', 'In Progress'])
-    })
-
-    it('clears token on auth errors', async () => {
+    it('clears the token and surfaces credential failures', async () => {
       const authError = new Error('Unauthorized')
       isAuthErrorMock.mockReturnValue(true)
       jiraRequestMock.mockRejectedValueOnce(authError)
+      const { getProjectStatusOrder } = await import('./issues')
 
-      const { getProjectStatuses } = await import('./issues')
-
-      await expect(getProjectStatuses('ALP', 'site-1')).rejects.toThrow('Unauthorized')
+      await expect(getProjectStatusOrder('ALP', 'site-1')).rejects.toThrow('Unauthorized')
       expect(clearTokenMock).toHaveBeenCalledWith('site-1')
     })
 
-    it('returns empty array on operational errors', async () => {
+    it('falls back to an empty order on operational errors', async () => {
       jiraRequestMock.mockRejectedValueOnce(new Error('Service Unavailable'))
+      const { getProjectStatusOrder } = await import('./issues')
 
-      const { getProjectStatuses } = await import('./issues')
-
-      await expect(getProjectStatuses('ALP', 'site-1')).resolves.toEqual([])
+      await expect(getProjectStatusOrder('ALP', 'site-1')).resolves.toEqual({
+        statusIdsByColumn: []
+      })
     })
   })
 })

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -14,6 +14,7 @@ import type {
   JiraMutationResult,
   JiraPriority,
   JiraProject,
+  JiraProjectStatusOrder,
   JiraSite,
   JiraSiteSelection,
   JiraStatus,
@@ -108,6 +109,13 @@ function asRecord(value: unknown): JiraRecord {
 
 function asString(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value : fallback
+}
+
+function asIdentifier(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  return typeof value === 'number' && Number.isFinite(value) ? String(value) : ''
 }
 
 function asStringArray(value: unknown): string[] {
@@ -811,96 +819,75 @@ export async function listTransitions(
   }
 }
 
-export async function getProjectStatuses(
+export async function getProjectStatusOrder(
   projectKey: string,
   siteId?: string | null
-): Promise<string[]> {
-  const entry = getClients(siteId)[0]
+): Promise<JiraProjectStatusOrder> {
+  // Why: an omitted site can resolve to the persisted "all" selection; board
+  // metadata is only truthful when exactly one Jira connection owns the project.
+  const entries = getClients(siteId)
+  const entry = entries.length === 1 ? entries[0] : undefined
   if (!entry) {
-    return []
+    return { statusIdsByColumn: [] }
   }
   await acquire()
   try {
-    const statusesResponse = await jiraRequest<unknown>(
+    // Why: without an explicit board picker there is no truthful way to choose
+    // among multiple project boards, so ambiguous projects keep alphabetical order.
+    const params = new URLSearchParams({ projectKeyOrId: projectKey, maxResults: '2' })
+    const boardsResponse = await jiraRequest<JiraPagedResponse<JiraRecord>>(
       entry,
-      `/rest/api/3/project/${encodeURIComponent(projectKey)}/statuses`
+      `/rest/agile/1.0/board?${params.toString()}`
     )
-    const statusMap = new Map<string, string>()
-    if (Array.isArray(statusesResponse)) {
-      for (const issueType of statusesResponse) {
-        const typeRecord = asRecord(issueType)
-        if (Array.isArray(typeRecord.statuses)) {
-          for (const s of typeRecord.statuses) {
-            const statusRecord = asRecord(s)
-            const id = asString(statusRecord.id)
-            const name = asString(statusRecord.name)
-            if (id && name) {
-              statusMap.set(id, name)
-            }
-          }
-        }
-      }
+    const boards = boardsResponse.values ?? []
+    const boardCount = asFiniteNumber(boardsResponse.total)
+    const singleBoardIsProven =
+      boards.length === 1 &&
+      boardsResponse.isLast !== false &&
+      (boardCount === 1 || (boardCount === null && boardsResponse.isLast === true))
+    const boardId = singleBoardIsProven ? asIdentifier(asRecord(boards[0]).id) : ''
+    if (!boardId) {
+      return { statusIdsByColumn: [] }
     }
 
-    const boardsResponse = await jiraRequest<{ values?: unknown[] }>(
+    const configResponse = await jiraRequest<unknown>(
       entry,
-      `/rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKey)}`
+      `/rest/agile/1.0/board/${encodeURIComponent(boardId)}/configuration`
     )
-
-    if (
-      boardsResponse &&
-      Array.isArray(boardsResponse.values) &&
-      boardsResponse.values.length > 0
-    ) {
-      const boardId = asRecord(boardsResponse.values[0]).id
-      if (boardId) {
-        const configResponse = await jiraRequest<{ columnConfig?: { columns?: unknown[] } }>(
-          entry,
-          `/rest/agile/1.0/board/${boardId}/configuration`
-        )
-
-        if (
-          configResponse &&
-          configResponse.columnConfig &&
-          Array.isArray(configResponse.columnConfig.columns)
-        ) {
-          const orderedNames: string[] = []
-          const seen = new Set<string>()
-          for (const col of configResponse.columnConfig.columns) {
-            const colRecord = asRecord(col)
-            if (Array.isArray(colRecord.statuses)) {
-              for (const statusRef of colRecord.statuses) {
-                const refRecord = asRecord(statusRef)
-                const refId = asString(refRecord.id)
-                if (refId) {
-                  const name = statusMap.get(refId)
-                  if (name && !seen.has(name)) {
-                    seen.add(name)
-                    orderedNames.push(name)
-                  }
-                }
-              }
-            }
-          }
-          for (const name of statusMap.values()) {
-            if (!seen.has(name)) {
-              seen.add(name)
-              orderedNames.push(name)
-            }
-          }
-          return orderedNames
-        }
-      }
+    const columns = asRecord(asRecord(configResponse).columnConfig).columns
+    if (!Array.isArray(columns)) {
+      return { statusIdsByColumn: [] }
     }
 
-    return Array.from(statusMap.values())
+    // Why: issues already carry status names and IDs, so returning board IDs
+    // avoids a second metadata request and keeps duplicate names unambiguous.
+    const seenStatusIds = new Set<string>()
+    const statusIdsByColumn: string[][] = []
+    for (const column of columns) {
+      const statuses = asRecord(column).statuses
+      if (!Array.isArray(statuses)) {
+        continue
+      }
+      const columnStatusIds: string[] = []
+      for (const status of statuses) {
+        const statusId = asIdentifier(asRecord(status).id)
+        if (statusId && !seenStatusIds.has(statusId)) {
+          seenStatusIds.add(statusId)
+          columnStatusIds.push(statusId)
+        }
+      }
+      if (columnStatusIds.length > 0) {
+        statusIdsByColumn.push(columnStatusIds)
+      }
+    }
+    return { statusIdsByColumn }
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.site.id)
       throw error
     }
-    console.warn('[jira] getProjectStatuses failed:', error)
-    return []
+    console.warn('[jira] getProjectStatusOrder failed:', error)
+    return { statusIdsByColumn: [] }
   } finally {
     release()
   }

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -810,3 +810,98 @@ export async function listTransitions(
     release()
   }
 }
+
+export async function getProjectStatuses(
+  projectKey: string,
+  siteId?: string | null
+): Promise<string[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  await acquire()
+  try {
+    const statusesResponse = await jiraRequest<unknown>(
+      entry,
+      `/rest/api/3/project/${encodeURIComponent(projectKey)}/statuses`
+    )
+    const statusMap = new Map<string, string>()
+    if (Array.isArray(statusesResponse)) {
+      for (const issueType of statusesResponse) {
+        const typeRecord = asRecord(issueType)
+        if (Array.isArray(typeRecord.statuses)) {
+          for (const s of typeRecord.statuses) {
+            const statusRecord = asRecord(s)
+            const id = asString(statusRecord.id)
+            const name = asString(statusRecord.name)
+            if (id && name) {
+              statusMap.set(id, name)
+            }
+          }
+        }
+      }
+    }
+
+    const boardsResponse = await jiraRequest<{ values?: unknown[] }>(
+      entry,
+      `/rest/agile/1.0/board?projectKeyOrId=${encodeURIComponent(projectKey)}`
+    )
+
+    if (
+      boardsResponse &&
+      Array.isArray(boardsResponse.values) &&
+      boardsResponse.values.length > 0
+    ) {
+      const boardId = asRecord(boardsResponse.values[0]).id
+      if (boardId) {
+        const configResponse = await jiraRequest<{ columnConfig?: { columns?: unknown[] } }>(
+          entry,
+          `/rest/agile/1.0/board/${boardId}/configuration`
+        )
+
+        if (
+          configResponse &&
+          configResponse.columnConfig &&
+          Array.isArray(configResponse.columnConfig.columns)
+        ) {
+          const orderedNames: string[] = []
+          const seen = new Set<string>()
+          for (const col of configResponse.columnConfig.columns) {
+            const colRecord = asRecord(col)
+            if (Array.isArray(colRecord.statuses)) {
+              for (const statusRef of colRecord.statuses) {
+                const refRecord = asRecord(statusRef)
+                const refId = asString(refRecord.id)
+                if (refId) {
+                  const name = statusMap.get(refId)
+                  if (name && !seen.has(name)) {
+                    seen.add(name)
+                    orderedNames.push(name)
+                  }
+                }
+              }
+            }
+          }
+          for (const name of statusMap.values()) {
+            if (!seen.has(name)) {
+              seen.add(name)
+              orderedNames.push(name)
+            }
+          }
+          return orderedNames
+        }
+      }
+    }
+
+    return Array.from(statusMap.values())
+  } catch (error) {
+    if (isAuthError(error)) {
+      clearToken(entry.site.id)
+      throw error
+    }
+    console.warn('[jira] getProjectStatuses failed:', error)
+    return []
+  } finally {
+    release()
+  }
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -536,7 +536,8 @@ import {
   listProjects as listJiraProjects,
   listTransitions as listJiraTransitions,
   searchIssues as searchJiraIssues,
-  updateIssue as updateJiraIssue
+  updateIssue as updateJiraIssue,
+  getProjectStatuses as getJiraProjectStatuses
 } from '../jira/issues'
 import {
   clearProjectItemFieldValue,
@@ -22566,6 +22567,13 @@ export class OrcaRuntimeService {
 
   jiraListTransitions(key: string, siteId?: string): ReturnType<typeof listJiraTransitions> {
     return listJiraTransitions(key, siteId)
+  }
+
+  jiraGetProjectStatuses(
+    projectKey: string,
+    siteId?: string
+  ): ReturnType<typeof getJiraProjectStatuses> {
+    return getJiraProjectStatuses(projectKey, siteId)
   }
 
   // ── Browser automation ──

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -528,6 +528,7 @@ import {
   createIssue as createJiraIssue,
   getIssue as getJiraIssue,
   getIssueComments as getJiraIssueComments,
+  getProjectStatusOrder as getJiraProjectStatusOrder,
   listAssignableUsers as listJiraAssignableUsers,
   listCreateFields as listJiraCreateFields,
   listIssueTypes as listJiraIssueTypes,
@@ -536,8 +537,7 @@ import {
   listProjects as listJiraProjects,
   listTransitions as listJiraTransitions,
   searchIssues as searchJiraIssues,
-  updateIssue as updateJiraIssue,
-  getProjectStatuses as getJiraProjectStatuses
+  updateIssue as updateJiraIssue
 } from '../jira/issues'
 import {
   clearProjectItemFieldValue,
@@ -22569,11 +22569,11 @@ export class OrcaRuntimeService {
     return listJiraTransitions(key, siteId)
   }
 
-  jiraGetProjectStatuses(
+  jiraGetProjectStatusOrder(
     projectKey: string,
     siteId?: string
-  ): ReturnType<typeof getJiraProjectStatuses> {
-    return getJiraProjectStatuses(projectKey, siteId)
+  ): ReturnType<typeof getJiraProjectStatusOrder> {
+    return getJiraProjectStatusOrder(projectKey, siteId)
   }
 
   // ── Browser automation ──

--- a/src/main/runtime/rpc/methods/jira.test.ts
+++ b/src/main/runtime/rpc/methods/jira.test.ts
@@ -159,4 +159,18 @@ describe('jira RPC methods', () => {
     expect(runtime.jiraListAssignableUsers).toHaveBeenCalledWith('ABC-3', 'Ada', 'site-1')
     expect(runtime.jiraListTransitions).toHaveBeenCalledWith('ABC-3', 'site-1')
   })
+
+  it('routes Jira project statuses request to the runtime server', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      jiraGetProjectStatuses: vi.fn().mockResolvedValue(['To Do', 'In Progress', 'Done'])
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: JIRA_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('jira.getProjectStatuses', { projectKey: 'ALP', siteId: 'site-1' })
+    )
+
+    expect(runtime.jiraGetProjectStatuses).toHaveBeenCalledWith('ALP', 'site-1')
+  })
 })

--- a/src/main/runtime/rpc/methods/jira.test.ts
+++ b/src/main/runtime/rpc/methods/jira.test.ts
@@ -125,7 +125,10 @@ describe('jira RPC methods', () => {
       jiraListCreateFields: vi.fn().mockResolvedValue([{ key: 'customfield_10010' }]),
       jiraListPriorities: vi.fn().mockResolvedValue([{ id: 'priority-1' }]),
       jiraListAssignableUsers: vi.fn().mockResolvedValue([{ accountId: 'user-1' }]),
-      jiraListTransitions: vi.fn().mockResolvedValue([{ id: 'transition-1' }])
+      jiraListTransitions: vi.fn().mockResolvedValue([{ id: 'transition-1' }]),
+      jiraGetProjectStatusOrder: vi.fn().mockResolvedValue({
+        statusIdsByColumn: [['status-1']]
+      })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: JIRA_METHODS })
 
@@ -151,6 +154,9 @@ describe('jira RPC methods', () => {
     await dispatcher.dispatch(
       makeRequest('jira.listTransitions', { key: 'ABC-3', siteId: 'site-1' })
     )
+    await dispatcher.dispatch(
+      makeRequest('jira.getProjectStatusOrder', { projectKey: 'ALP', siteId: 'site-1' })
+    )
 
     expect(runtime.jiraListProjects).toHaveBeenCalledWith('all')
     expect(runtime.jiraListIssueTypes).toHaveBeenCalledWith('project-1', 'site-1')
@@ -158,19 +164,6 @@ describe('jira RPC methods', () => {
     expect(runtime.jiraListPriorities).toHaveBeenCalledWith('site-1')
     expect(runtime.jiraListAssignableUsers).toHaveBeenCalledWith('ABC-3', 'Ada', 'site-1')
     expect(runtime.jiraListTransitions).toHaveBeenCalledWith('ABC-3', 'site-1')
-  })
-
-  it('routes Jira project statuses request to the runtime server', async () => {
-    const runtime = {
-      getRuntimeId: () => 'test-runtime',
-      jiraGetProjectStatuses: vi.fn().mockResolvedValue(['To Do', 'In Progress', 'Done'])
-    } as unknown as OrcaRuntimeService
-    const dispatcher = new RpcDispatcher({ runtime, methods: JIRA_METHODS })
-
-    await dispatcher.dispatch(
-      makeRequest('jira.getProjectStatuses', { projectKey: 'ALP', siteId: 'site-1' })
-    )
-
-    expect(runtime.jiraGetProjectStatuses).toHaveBeenCalledWith('ALP', 'site-1')
+    expect(runtime.jiraGetProjectStatusOrder).toHaveBeenCalledWith('ALP', 'site-1')
   })
 })

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -88,7 +88,7 @@ const AssignableUsers = z.object({
   siteId: OptionalString
 })
 
-const ProjectStatuses = z.object({
+const ProjectStatusOrder = z.object({
   projectKey: requiredString('Project key is required'),
   siteId: OptionalString
 })
@@ -211,9 +211,9 @@ export const JIRA_METHODS: RpcMethod[] = [
       runtime.jiraListTransitions(params.key.trim(), params.siteId)
   }),
   defineMethod({
-    name: 'jira.getProjectStatuses',
-    params: ProjectStatuses,
+    name: 'jira.getProjectStatusOrder',
+    params: ProjectStatusOrder,
     handler: async (params, { runtime }) =>
-      runtime.jiraGetProjectStatuses(params.projectKey.trim(), params.siteId)
+      runtime.jiraGetProjectStatusOrder(params.projectKey.trim(), params.siteId)
   })
 ]

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -88,6 +88,11 @@ const AssignableUsers = z.object({
   siteId: OptionalString
 })
 
+const ProjectStatuses = z.object({
+  projectKey: requiredString('Project key is required'),
+  siteId: OptionalString
+})
+
 export const JIRA_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'jira.connect',
@@ -204,5 +209,11 @@ export const JIRA_METHODS: RpcMethod[] = [
     params: IssueKey,
     handler: async (params, { runtime }) =>
       runtime.jiraListTransitions(params.key.trim(), params.siteId)
+  }),
+  defineMethod({
+    name: 'jira.getProjectStatuses',
+    params: ProjectStatuses,
+    handler: async (params, { runtime }) =>
+      runtime.jiraGetProjectStatuses(params.projectKey.trim(), params.siteId)
   })
 ]

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1854,6 +1854,7 @@ export type PreloadApi = {
       siteId?: string
     }) => Promise<JiraUser[]>
     listTransitions: (args: { key: string; siteId?: string }) => Promise<JiraTransition[]>
+    getProjectStatuses: (args: { projectKey: string; siteId?: string }) => Promise<string[]>
   }
   starNag: {
     onShow: (

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -94,6 +94,7 @@ import type {
   JiraIssue,
   JiraIssueFilter,
   JiraIssueType,
+  JiraProjectStatusOrder,
   JiraIssueUpdate,
   JiraPriority,
   JiraProject,
@@ -1854,7 +1855,10 @@ export type PreloadApi = {
       siteId?: string
     }) => Promise<JiraUser[]>
     listTransitions: (args: { key: string; siteId?: string }) => Promise<JiraTransition[]>
-    getProjectStatuses: (args: { projectKey: string; siteId?: string }) => Promise<string[]>
+    getProjectStatusOrder: (args: {
+      projectKey: string
+      siteId?: string
+    }) => Promise<JiraProjectStatusOrder>
   }
   starNag: {
     onShow: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -25,6 +25,7 @@ import type {
   GitHubAssignableUser,
   GitHubCommentResult,
   GitHubWorkItem,
+  JiraProjectStatusOrder,
   GitPushTarget,
   GitStagingArea,
   GitForkSyncExpectedUpstream,
@@ -1638,8 +1639,10 @@ const api = {
 
     listTransitions: (args: { key: string; siteId?: string }): Promise<unknown[]> =>
       ipcRenderer.invoke('jira:listTransitions', args),
-    getProjectStatuses: (args: { projectKey: string; siteId?: string }): Promise<unknown> =>
-      ipcRenderer.invoke('jira:getProjectStatuses', args)
+    getProjectStatusOrder: (args: {
+      projectKey: string
+      siteId?: string
+    }): Promise<JiraProjectStatusOrder> => ipcRenderer.invoke('jira:getProjectStatusOrder', args)
   },
 
   starNag: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1637,7 +1637,9 @@ const api = {
     }): Promise<unknown[]> => ipcRenderer.invoke('jira:listAssignableUsers', args),
 
     listTransitions: (args: { key: string; siteId?: string }): Promise<unknown[]> =>
-      ipcRenderer.invoke('jira:listTransitions', args)
+      ipcRenderer.invoke('jira:listTransitions', args),
+    getProjectStatuses: (args: { projectKey: string; siteId?: string }): Promise<unknown> =>
+      ipcRenderer.invoke('jira:getProjectStatuses', args)
   },
 
   starNag: {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -13,6 +13,7 @@ import {
   Check,
   CheckCircle2,
   ChevronDown,
+  ChevronUp,
   ChevronLeft,
   ChevronRight,
   CircleDot,
@@ -4538,6 +4539,19 @@ export default function TaskPage(): React.JSX.Element {
   const [appliedJiraSearch, setAppliedJiraSearch] = useState('')
   const [activeJiraPreset, setActiveJiraPreset] = useState<JiraPresetId>('assigned')
   const [jiraRefreshNonce, setJiraRefreshNonce] = useState(0)
+  const [collapsedJiraGroups, setCollapsedJiraGroups] = useState<Set<string>>(new Set())
+
+  const toggleJiraGroup = useCallback((groupKey: string) => {
+    setCollapsedJiraGroups((prev) => {
+      const next = new Set(prev)
+      if (next.has(groupKey)) {
+        next.delete(groupKey)
+      } else {
+        next.add(groupKey)
+      }
+      return next
+    })
+  }, [])
 
   useEffect(() => {
     if (taskResumeAppliedRef.current || !persistedUIReady || !settings) {
@@ -5497,6 +5511,30 @@ export default function TaskPage(): React.JSX.Element {
       ),
     [jiraIssues, jiraCacheSnapshot.issueCache, jiraCacheSnapshot.searchCache, jiraTaskSourceContext]
   )
+
+  const jiraIssueSections = useMemo(() => {
+    const sections: { key: string; label: string; issues: JiraIssue[] }[] = []
+    const sectionsMap = new Map<string, JiraIssue[]>()
+
+    for (const issue of displayedJiraIssues) {
+      const statusName = issue.status.name
+      if (!sectionsMap.has(statusName)) {
+        sectionsMap.set(statusName, [])
+      }
+      sectionsMap.get(statusName)!.push(issue)
+    }
+
+    sectionsMap.forEach((issues, statusName) => {
+      sections.push({
+        key: statusName,
+        label: statusName,
+        issues
+      })
+    })
+
+    sections.sort((a, b) => a.label.localeCompare(b.label))
+    return sections
+  }, [displayedJiraIssues])
 
   // New Linear project dialog state
   const [newLinearProjectOpen, setNewLinearProjectOpen] = useState(false)
@@ -9896,182 +9934,229 @@ export default function TaskPage(): React.JSX.Element {
                   ) : null}
 
                   <div className="divide-y divide-border/50">
-                    {displayedJiraIssues.map((issue) => {
-                      const selected = issue.key === selectedJiraIssueKey
-                      const labels = issue.labels.slice(0, 3)
-                      const contextLabel =
-                        selectedJiraSiteId === 'all' && issue.siteName
-                          ? `${issue.siteName} / ${issue.project.key}`
-                          : issue.project.key
-                      return (
+                    {jiraIssueSections.flatMap((section) => {
+                      const isCollapsed = collapsedJiraGroups.has(section.key)
+                      return [
                         <div
-                          key={`${issue.siteId ?? 'site'}:${issue.key}`}
+                          key={`section:${section.key}`}
                           role="button"
                           tabIndex={0}
-                          aria-current={selected ? 'true' : undefined}
-                          data-current={selected ? 'true' : undefined}
-                          onClick={() => openJiraDetailPage(issue)}
+                          onClick={() => toggleJiraGroup(section.key)}
                           onKeyDown={(e) => {
-                            if (e.target !== e.currentTarget) {
-                              return
-                            }
                             if (e.key === 'Enter' || e.key === ' ') {
                               e.preventDefault()
-                              openJiraDetailPage(issue)
+                              toggleJiraGroup(section.key)
                             }
                           }}
-                          className={cn(
-                            'group/row grid min-h-12 cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring md:grid-cols-[90px_minmax(0,1fr)_128px_92px_80px] lg:grid-cols-[96px_minmax(0,1.25fr)_132px_120px_136px_96px_64px] xl:grid-cols-[104px_minmax(0,1.45fr)_144px_132px_160px_128px_72px]',
-                            selected && 'bg-accent'
-                          )}
+                          className="flex h-9 cursor-pointer select-none items-center gap-2 bg-muted/35 px-3 hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none transition-colors"
                         >
-                          <span className="block truncate font-mono text-[12px] text-muted-foreground max-md:!hidden">
-                            {issue.key}
+                          {isCollapsed ? (
+                            <ChevronUp className="size-3 shrink-0 text-muted-foreground" />
+                          ) : (
+                            <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+                          )}
+                          <span className="min-w-0 truncate text-[13px] font-medium text-foreground">
+                            {section.label}
                           </span>
-
-                          <div className="min-w-0">
-                            <div className="flex min-w-0 items-center gap-2">
-                              <span className="shrink-0 font-mono text-[11px] text-muted-foreground md:hidden">
-                                {issue.key}
-                              </span>
-                              <h3 className="min-w-0 truncate text-[13px] font-medium text-foreground">
-                                {issue.title}
-                              </h3>
-                            </div>
-                            <div className="mt-1 flex min-w-0 items-center gap-1.5 md:!hidden">
-                              <span
-                                className={cn(
-                                  'inline-flex min-w-0 items-center rounded-full border px-1.5 py-0.5 text-[11px] font-medium',
-                                  getJiraStatusTone(issue.status.categoryKey)
-                                )}
-                              >
-                                <span className="truncate">{issue.status.name}</span>
-                              </span>
-                              <span className="shrink-0 text-[11px] text-muted-foreground">
-                                {issue.priority?.name ??
-                                  translate('auto.components.TaskPage.713179dfdc', 'No priority')}
-                              </span>
-                              <span className="min-w-0 truncate text-[11px] text-muted-foreground">
-                                {issue.assignee?.displayName ??
-                                  translate('auto.components.TaskPage.42a9160321', 'Unassigned')}
-                              </span>
-                            </div>
-                            <div className="mt-1 flex min-w-0 items-center gap-1 max-lg:!hidden">
-                              <span className="max-w-[160px] truncate text-[10px] text-muted-foreground xl:!hidden">
-                                {contextLabel}
-                              </span>
-                              {labels.map((label) => (
-                                <span
-                                  key={label}
-                                  className="max-w-[140px] truncate rounded-full border border-border/50 bg-muted/35 px-1.5 py-0.5 text-[10px] text-muted-foreground"
-                                >
-                                  {label}
-                                </span>
-                              ))}
-                              {issue.labels.length > labels.length ? (
-                                <span className="text-[10px] text-muted-foreground">
-                                  +{issue.labels.length - labels.length}
-                                </span>
-                              ) : null}
-                            </div>
-                          </div>
-
-                          <div className="flex min-w-0 max-md:!hidden">
-                            <span
-                              className={cn(
-                                'inline-flex max-w-full items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
-                                getJiraStatusTone(issue.status.categoryKey)
-                              )}
-                            >
-                              <span className="truncate">{issue.status.name}</span>
-                            </span>
-                          </div>
-
-                          <span className="block truncate text-[12px] text-muted-foreground max-md:!hidden">
-                            {issue.priority?.name ??
-                              translate('auto.components.TaskPage.713179dfdc', 'No priority')}
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {section.issues.length}
                           </span>
-
-                          <div className="flex min-w-0 items-center gap-2 text-[12px] text-muted-foreground max-lg:!hidden">
-                            {issue.assignee?.avatarUrl ? (
-                              <img
-                                src={issue.assignee.avatarUrl}
-                                alt={issue.assignee.displayName}
-                                className="size-5 shrink-0 rounded-full"
-                              />
-                            ) : (
-                              <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-[10px]">
-                                {issue.assignee?.displayName?.slice(0, 1) ?? '-'}
-                              </span>
-                            )}
-                            <span className="truncate">
-                              {issue.assignee?.displayName ??
-                                translate('auto.components.TaskPage.42a9160321', 'Unassigned')}
-                            </span>
-                          </div>
-
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div className="block min-w-0 truncate text-[12px] text-muted-foreground max-md:!hidden">
-                                {formatRelativeTime(issue.updatedAt)}
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom" sideOffset={6}>
-                              {new Date(issue.updatedAt).toLocaleString()}
-                            </TooltipContent>
-                          </Tooltip>
-
-                          <div className="flex shrink-0 items-center justify-end gap-1 md:opacity-0 md:transition-opacity md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100">
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon-xs"
-                                  onClick={(event) => {
-                                    event.stopPropagation()
-                                    handleUseJiraItem(issue)
+                        </div>,
+                        ...(isCollapsed
+                          ? []
+                          : section.issues.map((issue) => {
+                              const selected = issue.key === selectedJiraIssueKey
+                              const labels = issue.labels.slice(0, 3)
+                              const contextLabel =
+                                selectedJiraSiteId === 'all' && issue.siteName
+                                  ? `${issue.siteName} / ${issue.project.key}`
+                                  : issue.project.key
+                              return (
+                                <div
+                                  key={`${issue.siteId ?? 'site'}:${issue.key}`}
+                                  role="button"
+                                  tabIndex={0}
+                                  aria-current={selected ? 'true' : undefined}
+                                  data-current={selected ? 'true' : undefined}
+                                  onClick={() => openJiraDetailPage(issue)}
+                                  onKeyDown={(e) => {
+                                    if (e.target !== e.currentTarget) {
+                                      return
+                                    }
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      e.preventDefault()
+                                      openJiraDetailPage(issue)
+                                    }
                                   }}
-                                  aria-label={translate(
-                                    'auto.components.TaskPage.ff90d0abc7',
-                                    'Start workspace from {{value0}}',
-                                    { value0: issue.key }
+                                  className={cn(
+                                    'group/row grid min-h-12 cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring md:grid-cols-[90px_minmax(0,1fr)_128px_92px_80px] lg:grid-cols-[96px_minmax(0,1.25fr)_132px_120px_136px_96px_64px] xl:grid-cols-[104px_minmax(0,1.45fr)_144px_132px_160px_128px_72px]',
+                                    selected && 'bg-accent'
                                   )}
                                 >
-                                  <ArrowRight className="size-3.5" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom" sideOffset={6}>
-                                {translate(
-                                  'auto.components.TaskPage.9497f2787c',
-                                  'Start workspace'
-                                )}
-                              </TooltipContent>
-                            </Tooltip>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon-xs"
-                                  onClick={(event) => {
-                                    event.stopPropagation()
-                                    window.api.shell.openUrl(issue.url)
-                                  }}
-                                  aria-label={translate(
-                                    'auto.components.TaskPage.4ac8ff2275',
-                                    'Open {{value0}} in Jira',
-                                    { value0: issue.key }
-                                  )}
-                                >
-                                  <ExternalLink className="size-3.5" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom" sideOffset={6}>
-                                {translate('auto.components.TaskPage.eee68073b2', 'Open in Jira')}
-                              </TooltipContent>
-                            </Tooltip>
-                          </div>
-                        </div>
-                      )
+                                  <span className="block truncate font-mono text-[12px] text-muted-foreground max-md:!hidden">
+                                    {issue.key}
+                                  </span>
+
+                                  <div className="min-w-0">
+                                    <div className="flex min-w-0 items-center gap-2">
+                                      <span className="shrink-0 font-mono text-[11px] text-muted-foreground md:hidden">
+                                        {issue.key}
+                                      </span>
+                                      <h3 className="min-w-0 truncate text-[13px] font-medium text-foreground">
+                                        {issue.title}
+                                      </h3>
+                                    </div>
+                                    <div className="mt-1 flex min-w-0 items-center gap-1.5 md:!hidden">
+                                      <span
+                                        className={cn(
+                                          'inline-flex min-w-0 items-center rounded-full border px-1.5 py-0.5 text-[11px] font-medium',
+                                          getJiraStatusTone(issue.status.categoryKey)
+                                        )}
+                                      >
+                                        <span className="truncate">{issue.status.name}</span>
+                                      </span>
+                                      <span className="shrink-0 text-[11px] text-muted-foreground">
+                                        {issue.priority?.name ??
+                                          translate(
+                                            'auto.components.TaskPage.713179dfdc',
+                                            'No priority'
+                                          )}
+                                      </span>
+                                      <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+                                        {issue.assignee?.displayName ??
+                                          translate(
+                                            'auto.components.TaskPage.42a9160321',
+                                            'Unassigned'
+                                          )}
+                                      </span>
+                                    </div>
+                                    <div className="mt-1 flex min-w-0 items-center gap-1 max-lg:!hidden">
+                                      <span className="max-w-[160px] truncate text-[10px] text-muted-foreground xl:!hidden">
+                                        {contextLabel}
+                                      </span>
+                                      {labels.map((label) => (
+                                        <span
+                                          key={label}
+                                          className="max-w-[140px] truncate rounded-full border border-border/50 bg-muted/35 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                                        >
+                                          {label}
+                                        </span>
+                                      ))}
+                                      {issue.labels.length > labels.length ? (
+                                        <span className="text-[10px] text-muted-foreground">
+                                          +{issue.labels.length - labels.length}
+                                        </span>
+                                      ) : null}
+                                    </div>
+                                  </div>
+
+                                  <div className="flex min-w-0 max-md:!hidden">
+                                    <span
+                                      className={cn(
+                                        'inline-flex max-w-full items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                                        getJiraStatusTone(issue.status.categoryKey)
+                                      )}
+                                    >
+                                      <span className="truncate">{issue.status.name}</span>
+                                    </span>
+                                  </div>
+
+                                  <span className="block truncate text-[12px] text-muted-foreground max-md:!hidden">
+                                    {issue.priority?.name ??
+                                      translate(
+                                        'auto.components.TaskPage.713179dfdc',
+                                        'No priority'
+                                      )}
+                                  </span>
+
+                                  <div className="flex min-w-0 items-center gap-2 text-[12px] text-muted-foreground max-lg:!hidden">
+                                    {issue.assignee?.avatarUrl ? (
+                                      <img
+                                        src={issue.assignee.avatarUrl}
+                                        alt={issue.assignee.displayName}
+                                        className="size-5 shrink-0 rounded-full"
+                                      />
+                                    ) : (
+                                      <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-[10px]">
+                                        {issue.assignee?.displayName?.slice(0, 1) ?? '-'}
+                                      </span>
+                                    )}
+                                    <span className="truncate">
+                                      {issue.assignee?.displayName ??
+                                        translate(
+                                          'auto.components.TaskPage.42a9160321',
+                                          'Unassigned'
+                                        )}
+                                    </span>
+                                  </div>
+
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <div className="block min-w-0 truncate text-[12px] text-muted-foreground max-md:!hidden">
+                                        {formatRelativeTime(issue.updatedAt)}
+                                      </div>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" sideOffset={6}>
+                                      {new Date(issue.updatedAt).toLocaleString()}
+                                    </TooltipContent>
+                                  </Tooltip>
+
+                                  <div className="flex shrink-0 items-center justify-end gap-1 md:opacity-0 md:transition-opacity md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100">
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <Button
+                                          variant="ghost"
+                                          size="icon-xs"
+                                          onClick={(event) => {
+                                            event.stopPropagation()
+                                            handleUseJiraItem(issue)
+                                          }}
+                                          aria-label={translate(
+                                            'auto.components.TaskPage.ff90d0abc7',
+                                            'Start workspace from {{value0}}',
+                                            { value0: issue.key }
+                                          )}
+                                        >
+                                          <ArrowRight className="size-3.5" />
+                                        </Button>
+                                      </TooltipTrigger>
+                                      <TooltipContent side="bottom" sideOffset={6}>
+                                        {translate(
+                                          'auto.components.TaskPage.9497f2787c',
+                                          'Start workspace'
+                                        )}
+                                      </TooltipContent>
+                                    </Tooltip>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <Button
+                                          variant="ghost"
+                                          size="icon-xs"
+                                          onClick={(event) => {
+                                            event.stopPropagation()
+                                            window.api.shell.openUrl(issue.url)
+                                          }}
+                                          aria-label={translate(
+                                            'auto.components.TaskPage.4ac8ff2275',
+                                            'Open {{value0}} in Jira',
+                                            { value0: issue.key }
+                                          )}
+                                        >
+                                          <ExternalLink className="size-3.5" />
+                                        </Button>
+                                      </TooltipTrigger>
+                                      <TooltipContent side="bottom" sideOffset={6}>
+                                        {translate(
+                                          'auto.components.TaskPage.eee68073b2',
+                                          'Open in Jira'
+                                        )}
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </div>
+                                </div>
+                              )
+                            }))
+                      ]
                     })}
                   </div>
                 </div>

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -13,7 +13,6 @@ import {
   Check,
   CheckCircle2,
   ChevronDown,
-  ChevronUp,
   ChevronLeft,
   ChevronRight,
   CircleDot,
@@ -160,6 +159,12 @@ import {
   LinearProjectTable
 } from '@/components/linear-project-view-surfaces'
 import JiraIssueWorkspace from '@/components/JiraIssueWorkspace'
+import { TaskPageJiraIssueList } from '@/components/task-page-jira-issue-list'
+import {
+  getSingleJiraProjectScope,
+  getTaskPageJiraStatusOrderScopeKey,
+  loadTaskPageJiraProjectStatusOrder
+} from '@/components/task-page-jira-status-order'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { cn } from '@/lib/utils'
 import {
@@ -260,6 +265,7 @@ import type {
   JiraIssue,
   JiraIssueType,
   JiraProject,
+  JiraProjectStatusOrder,
   LinearIssue,
   LinearProjectDetail,
   LinearProjectSummary,
@@ -299,8 +305,7 @@ import {
   jiraGetIssue,
   jiraListCreateFields,
   jiraListIssueTypes,
-  jiraListProjects,
-  jiraGetProjectStatuses
+  jiraListProjects
 } from '@/runtime/runtime-jira-client'
 import {
   normalizeVisibleTaskProviders,
@@ -3474,6 +3479,9 @@ export default function TaskPage(): React.JSX.Element {
       selectedJiraSiteId
     ]
   )
+  const jiraTaskSourceScopeKey = jiraTaskSourceContext
+    ? getTaskSourceCacheScope(jiraTaskSourceContext)
+    : providerRuntimeContextKey
   const accountBackedTaskSourceHostAvailability = useMemo<TaskSourceHostAvailability[]>(() => {
     if (taskSource !== 'linear' && taskSource !== 'jira') {
       return []
@@ -4540,20 +4548,10 @@ export default function TaskPage(): React.JSX.Element {
   const [appliedJiraSearch, setAppliedJiraSearch] = useState('')
   const [activeJiraPreset, setActiveJiraPreset] = useState<JiraPresetId>('assigned')
   const [jiraRefreshNonce, setJiraRefreshNonce] = useState(0)
-  const [collapsedJiraGroups, setCollapsedJiraGroups] = useState<Set<string>>(new Set())
-  const [jiraProjectStatuses, setJiraProjectStatuses] = useState<Record<string, string[]>>({})
-
-  const toggleJiraGroup = useCallback((groupKey: string) => {
-    setCollapsedJiraGroups((prev) => {
-      const next = new Set(prev)
-      if (next.has(groupKey)) {
-        next.delete(groupKey)
-      } else {
-        next.add(groupKey)
-      }
-      return next
-    })
-  }, [])
+  const [jiraProjectStatusOrder, setJiraProjectStatusOrder] = useState<{
+    order: JiraProjectStatusOrder
+    scopeKey: string
+  } | null>(null)
 
   useEffect(() => {
     if (taskResumeAppliedRef.current || !persistedUIReady || !settings) {
@@ -5513,88 +5511,17 @@ export default function TaskPage(): React.JSX.Element {
       ),
     [jiraIssues, jiraCacheSnapshot.issueCache, jiraCacheSnapshot.searchCache, jiraTaskSourceContext]
   )
-
-  useEffect(() => {
-    if (!jiraConnected || displayedJiraIssues.length === 0) {
-      return
-    }
-
-    const uniqueProjects = Array.from(
-      new Set(displayedJiraIssues.map((issue) => issue.project.key).filter(Boolean))
-    )
-
-    let cancelled = false
-
-    for (const projectKey of uniqueProjects) {
-      if (jiraProjectStatuses[projectKey]) {
-        continue
-      }
-      const issue = displayedJiraIssues.find((i) => i.project.key === projectKey)
-      const siteId = issue?.siteId ?? null
-
-      void jiraGetProjectStatuses(jiraTaskSourceContext ?? settings, projectKey, siteId)
-        .then((statuses) => {
-          if (!cancelled && statuses && statuses.length > 0) {
-            setJiraProjectStatuses((prev) => ({
-              ...prev,
-              [projectKey]: statuses
-            }))
-          }
-        })
-        .catch((err) => {
-          console.warn(`[jira] Failed to load statuses for project ${projectKey}:`, err)
-        })
-    }
-
-    return () => {
-      cancelled = true
-    }
-  }, [displayedJiraIssues, jiraConnected, jiraTaskSourceContext, settings, jiraProjectStatuses])
-
-  const jiraIssueSections = useMemo(() => {
-    const sections: { key: string; label: string; issues: JiraIssue[] }[] = []
-    const sectionsMap = new Map<string, JiraIssue[]>()
-
-    for (const issue of displayedJiraIssues) {
-      const statusName = issue.status.name
-      if (!sectionsMap.has(statusName)) {
-        sectionsMap.set(statusName, [])
-      }
-      sectionsMap.get(statusName)!.push(issue)
-    }
-
-    sectionsMap.forEach((issues, statusName) => {
-      sections.push({
-        key: statusName,
-        label: statusName,
-        issues
-      })
-    })
-
-    const getStatusIndex = (statusName: string): number => {
-      for (const projectKey of Object.keys(jiraProjectStatuses)) {
-        const list = jiraProjectStatuses[projectKey]
-        if (list) {
-          const idx = list.indexOf(statusName)
-          if (idx !== -1) {
-            return idx
-          }
-        }
-      }
-      return 99999
-    }
-
-    sections.sort((a, b) => {
-      const idxA = getStatusIndex(a.label)
-      const idxB = getStatusIndex(b.label)
-      if (idxA !== idxB) {
-        return idxA - idxB
-      }
-      return a.label.localeCompare(b.label)
-    })
-
-    return sections
-  }, [displayedJiraIssues, jiraProjectStatuses])
+  const displayedJiraProjectScope = useMemo(
+    () => getSingleJiraProjectScope(displayedJiraIssues),
+    [displayedJiraIssues]
+  )
+  const displayedJiraStatusOrderScopeKey = displayedJiraProjectScope
+    ? getTaskPageJiraStatusOrderScopeKey(jiraTaskSourceScopeKey, displayedJiraProjectScope)
+    : null
+  const displayedJiraStatusOrder =
+    jiraProjectStatusOrder && displayedJiraStatusOrderScopeKey === jiraProjectStatusOrder.scopeKey
+      ? jiraProjectStatusOrder.order
+      : null
 
   // New Linear project dialog state
   const [newLinearProjectOpen, setNewLinearProjectOpen] = useState(false)
@@ -7770,6 +7697,26 @@ export default function TaskPage(): React.JSX.Element {
         }
         setJiraIssues(issues)
         setJiraLoading(false)
+        const projectScope = getSingleJiraProjectScope(issues)
+        if (!projectScope) {
+          return
+        }
+        const statusOrderScopeKey = getTaskPageJiraStatusOrderScopeKey(
+          jiraTaskSourceScopeKey,
+          projectScope
+        )
+        void loadTaskPageJiraProjectStatusOrder(
+          jiraTaskSourceContext ?? settings,
+          jiraTaskSourceScopeKey,
+          projectScope
+        ).then((order) => {
+          if (!cancelled) {
+            setJiraProjectStatusOrder({
+              order,
+              scopeKey: statusOrderScopeKey
+            })
+          }
+        })
       })
       .catch((err) => {
         if (cancelled) {
@@ -7793,7 +7740,8 @@ export default function TaskPage(): React.JSX.Element {
     activeJiraPreset,
     jiraRefreshNonce,
     taskResumeApplied,
-    jiraTaskSourceContext
+    jiraTaskSourceContext,
+    jiraTaskSourceScopeKey
   ])
 
   useEffect(() => {
@@ -9993,232 +9941,16 @@ export default function TaskPage(): React.JSX.Element {
                     </div>
                   ) : null}
 
-                  <div className="divide-y divide-border/50">
-                    {jiraIssueSections.flatMap((section) => {
-                      const isCollapsed = collapsedJiraGroups.has(section.key)
-                      return [
-                        <div
-                          key={`section:${section.key}`}
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => toggleJiraGroup(section.key)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault()
-                              toggleJiraGroup(section.key)
-                            }
-                          }}
-                          className="flex h-9 cursor-pointer select-none items-center gap-2 bg-muted/35 px-3 hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none transition-colors"
-                        >
-                          {isCollapsed ? (
-                            <ChevronUp className="size-3 shrink-0 text-muted-foreground" />
-                          ) : (
-                            <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
-                          )}
-                          <span className="min-w-0 truncate text-[13px] font-medium text-foreground">
-                            {section.label}
-                          </span>
-                          <span className="shrink-0 text-[11px] text-muted-foreground">
-                            {section.issues.length}
-                          </span>
-                        </div>,
-                        ...(isCollapsed
-                          ? []
-                          : section.issues.map((issue) => {
-                              const selected = issue.key === selectedJiraIssueKey
-                              const labels = issue.labels.slice(0, 3)
-                              const contextLabel =
-                                selectedJiraSiteId === 'all' && issue.siteName
-                                  ? `${issue.siteName} / ${issue.project.key}`
-                                  : issue.project.key
-                              return (
-                                <div
-                                  key={`${issue.siteId ?? 'site'}:${issue.key}`}
-                                  role="button"
-                                  tabIndex={0}
-                                  aria-current={selected ? 'true' : undefined}
-                                  data-current={selected ? 'true' : undefined}
-                                  onClick={() => openJiraDetailPage(issue)}
-                                  onKeyDown={(e) => {
-                                    if (e.target !== e.currentTarget) {
-                                      return
-                                    }
-                                    if (e.key === 'Enter' || e.key === ' ') {
-                                      e.preventDefault()
-                                      openJiraDetailPage(issue)
-                                    }
-                                  }}
-                                  className={cn(
-                                    'group/row grid min-h-12 cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring md:grid-cols-[90px_minmax(0,1fr)_128px_92px_80px] lg:grid-cols-[96px_minmax(0,1.25fr)_132px_120px_136px_96px_64px] xl:grid-cols-[104px_minmax(0,1.45fr)_144px_132px_160px_128px_72px]',
-                                    selected && 'bg-accent'
-                                  )}
-                                >
-                                  <span className="block truncate font-mono text-[12px] text-muted-foreground max-md:!hidden">
-                                    {issue.key}
-                                  </span>
-
-                                  <div className="min-w-0">
-                                    <div className="flex min-w-0 items-center gap-2">
-                                      <span className="shrink-0 font-mono text-[11px] text-muted-foreground md:hidden">
-                                        {issue.key}
-                                      </span>
-                                      <h3 className="min-w-0 truncate text-[13px] font-medium text-foreground">
-                                        {issue.title}
-                                      </h3>
-                                    </div>
-                                    <div className="mt-1 flex min-w-0 items-center gap-1.5 md:!hidden">
-                                      <span
-                                        className={cn(
-                                          'inline-flex min-w-0 items-center rounded-full border px-1.5 py-0.5 text-[11px] font-medium',
-                                          getJiraStatusTone(issue.status.categoryKey)
-                                        )}
-                                      >
-                                        <span className="truncate">{issue.status.name}</span>
-                                      </span>
-                                      <span className="shrink-0 text-[11px] text-muted-foreground">
-                                        {issue.priority?.name ??
-                                          translate(
-                                            'auto.components.TaskPage.713179dfdc',
-                                            'No priority'
-                                          )}
-                                      </span>
-                                      <span className="min-w-0 truncate text-[11px] text-muted-foreground">
-                                        {issue.assignee?.displayName ??
-                                          translate(
-                                            'auto.components.TaskPage.42a9160321',
-                                            'Unassigned'
-                                          )}
-                                      </span>
-                                    </div>
-                                    <div className="mt-1 flex min-w-0 items-center gap-1 max-lg:!hidden">
-                                      <span className="max-w-[160px] truncate text-[10px] text-muted-foreground xl:!hidden">
-                                        {contextLabel}
-                                      </span>
-                                      {labels.map((label) => (
-                                        <span
-                                          key={label}
-                                          className="max-w-[140px] truncate rounded-full border border-border/50 bg-muted/35 px-1.5 py-0.5 text-[10px] text-muted-foreground"
-                                        >
-                                          {label}
-                                        </span>
-                                      ))}
-                                      {issue.labels.length > labels.length ? (
-                                        <span className="text-[10px] text-muted-foreground">
-                                          +{issue.labels.length - labels.length}
-                                        </span>
-                                      ) : null}
-                                    </div>
-                                  </div>
-
-                                  <div className="flex min-w-0 max-md:!hidden">
-                                    <span
-                                      className={cn(
-                                        'inline-flex max-w-full items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
-                                        getJiraStatusTone(issue.status.categoryKey)
-                                      )}
-                                    >
-                                      <span className="truncate">{issue.status.name}</span>
-                                    </span>
-                                  </div>
-
-                                  <span className="block truncate text-[12px] text-muted-foreground max-md:!hidden">
-                                    {issue.priority?.name ??
-                                      translate(
-                                        'auto.components.TaskPage.713179dfdc',
-                                        'No priority'
-                                      )}
-                                  </span>
-
-                                  <div className="flex min-w-0 items-center gap-2 text-[12px] text-muted-foreground max-lg:!hidden">
-                                    {issue.assignee?.avatarUrl ? (
-                                      <img
-                                        src={issue.assignee.avatarUrl}
-                                        alt={issue.assignee.displayName}
-                                        className="size-5 shrink-0 rounded-full"
-                                      />
-                                    ) : (
-                                      <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-[10px]">
-                                        {issue.assignee?.displayName?.slice(0, 1) ?? '-'}
-                                      </span>
-                                    )}
-                                    <span className="truncate">
-                                      {issue.assignee?.displayName ??
-                                        translate(
-                                          'auto.components.TaskPage.42a9160321',
-                                          'Unassigned'
-                                        )}
-                                    </span>
-                                  </div>
-
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <div className="block min-w-0 truncate text-[12px] text-muted-foreground max-md:!hidden">
-                                        {formatRelativeTime(issue.updatedAt)}
-                                      </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent side="bottom" sideOffset={6}>
-                                      {new Date(issue.updatedAt).toLocaleString()}
-                                    </TooltipContent>
-                                  </Tooltip>
-
-                                  <div className="flex shrink-0 items-center justify-end gap-1 md:opacity-0 md:transition-opacity md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100">
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <Button
-                                          variant="ghost"
-                                          size="icon-xs"
-                                          onClick={(event) => {
-                                            event.stopPropagation()
-                                            handleUseJiraItem(issue)
-                                          }}
-                                          aria-label={translate(
-                                            'auto.components.TaskPage.ff90d0abc7',
-                                            'Start workspace from {{value0}}',
-                                            { value0: issue.key }
-                                          )}
-                                        >
-                                          <ArrowRight className="size-3.5" />
-                                        </Button>
-                                      </TooltipTrigger>
-                                      <TooltipContent side="bottom" sideOffset={6}>
-                                        {translate(
-                                          'auto.components.TaskPage.9497f2787c',
-                                          'Start workspace'
-                                        )}
-                                      </TooltipContent>
-                                    </Tooltip>
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <Button
-                                          variant="ghost"
-                                          size="icon-xs"
-                                          onClick={(event) => {
-                                            event.stopPropagation()
-                                            window.api.shell.openUrl(issue.url)
-                                          }}
-                                          aria-label={translate(
-                                            'auto.components.TaskPage.4ac8ff2275',
-                                            'Open {{value0}} in Jira',
-                                            { value0: issue.key }
-                                          )}
-                                        >
-                                          <ExternalLink className="size-3.5" />
-                                        </Button>
-                                      </TooltipTrigger>
-                                      <TooltipContent side="bottom" sideOffset={6}>
-                                        {translate(
-                                          'auto.components.TaskPage.eee68073b2',
-                                          'Open in Jira'
-                                        )}
-                                      </TooltipContent>
-                                    </Tooltip>
-                                  </div>
-                                </div>
-                              )
-                            }))
-                      ]
-                    })}
-                  </div>
+                  <TaskPageJiraIssueList
+                    formatUpdatedAt={formatRelativeTime}
+                    getStatusTone={getJiraStatusTone}
+                    issues={displayedJiraIssues}
+                    onOpenIssue={openJiraDetailPage}
+                    onStartWorkspace={handleUseJiraItem}
+                    selectedIssue={selectedJiraIssue}
+                    showSiteContext={selectedJiraSiteId === 'all'}
+                    statusOrder={displayedJiraStatusOrder}
+                  />
                 </div>
                 <JiraIssueWorkspace
                   issue={selectedJiraIssue}

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -299,7 +299,8 @@ import {
   jiraGetIssue,
   jiraListCreateFields,
   jiraListIssueTypes,
-  jiraListProjects
+  jiraListProjects,
+  jiraGetProjectStatuses
 } from '@/runtime/runtime-jira-client'
 import {
   normalizeVisibleTaskProviders,
@@ -4540,6 +4541,7 @@ export default function TaskPage(): React.JSX.Element {
   const [activeJiraPreset, setActiveJiraPreset] = useState<JiraPresetId>('assigned')
   const [jiraRefreshNonce, setJiraRefreshNonce] = useState(0)
   const [collapsedJiraGroups, setCollapsedJiraGroups] = useState<Set<string>>(new Set())
+  const [jiraProjectStatuses, setJiraProjectStatuses] = useState<Record<string, string[]>>({})
 
   const toggleJiraGroup = useCallback((groupKey: string) => {
     setCollapsedJiraGroups((prev) => {
@@ -5512,6 +5514,43 @@ export default function TaskPage(): React.JSX.Element {
     [jiraIssues, jiraCacheSnapshot.issueCache, jiraCacheSnapshot.searchCache, jiraTaskSourceContext]
   )
 
+  useEffect(() => {
+    if (!jiraConnected || displayedJiraIssues.length === 0) {
+      return
+    }
+
+    const uniqueProjects = Array.from(
+      new Set(displayedJiraIssues.map((issue) => issue.project.key).filter(Boolean))
+    )
+
+    let cancelled = false
+
+    for (const projectKey of uniqueProjects) {
+      if (jiraProjectStatuses[projectKey]) {
+        continue
+      }
+      const issue = displayedJiraIssues.find((i) => i.project.key === projectKey)
+      const siteId = issue?.siteId ?? null
+
+      void jiraGetProjectStatuses(jiraTaskSourceContext ?? settings, projectKey, siteId)
+        .then((statuses) => {
+          if (!cancelled && statuses && statuses.length > 0) {
+            setJiraProjectStatuses((prev) => ({
+              ...prev,
+              [projectKey]: statuses
+            }))
+          }
+        })
+        .catch((err) => {
+          console.warn(`[jira] Failed to load statuses for project ${projectKey}:`, err)
+        })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [displayedJiraIssues, jiraConnected, jiraTaskSourceContext, settings, jiraProjectStatuses])
+
   const jiraIssueSections = useMemo(() => {
     const sections: { key: string; label: string; issues: JiraIssue[] }[] = []
     const sectionsMap = new Map<string, JiraIssue[]>()
@@ -5532,9 +5571,30 @@ export default function TaskPage(): React.JSX.Element {
       })
     })
 
-    sections.sort((a, b) => a.label.localeCompare(b.label))
+    const getStatusIndex = (statusName: string): number => {
+      for (const projectKey of Object.keys(jiraProjectStatuses)) {
+        const list = jiraProjectStatuses[projectKey]
+        if (list) {
+          const idx = list.indexOf(statusName)
+          if (idx !== -1) {
+            return idx
+          }
+        }
+      }
+      return 99999
+    }
+
+    sections.sort((a, b) => {
+      const idxA = getStatusIndex(a.label)
+      const idxB = getStatusIndex(b.label)
+      if (idxA !== idxB) {
+        return idxA - idxB
+      }
+      return a.label.localeCompare(b.label)
+    })
+
     return sections
-  }, [displayedJiraIssues])
+  }, [displayedJiraIssues, jiraProjectStatuses])
 
   // New Linear project dialog state
   const [newLinearProjectOpen, setNewLinearProjectOpen] = useState(false)

--- a/src/renderer/src/components/task-page-jira-grouping.test.ts
+++ b/src/renderer/src/components/task-page-jira-grouping.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import type { JiraIssue } from '../../../shared/types'
+
+describe('TaskPage Jira grouping functionality', () => {
+  function jiraIssue(key: string, title: string, statusName: string, siteId = 'site-1'): JiraIssue {
+    return {
+      id: `${siteId}:${key}`,
+      key,
+      title,
+      url: `https://example.atlassian.net/browse/${key}`,
+      siteId,
+      siteName: 'Example Jira',
+      project: { id: '10000', key: 'ALP', name: 'Alpha', siteId },
+      issueType: { id: '10001', name: 'Bug' },
+      status: { id: '1', name: statusName, categoryKey: 'new', categoryName: statusName },
+      labels: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    }
+  }
+
+  describe('jira issue sections grouping', () => {
+    it('groups issues by status name', () => {
+      const issues = [
+        jiraIssue('ALP-1', 'Issue 1', 'To Do'),
+        jiraIssue('ALP-2', 'Issue 2', 'In Progress'),
+        jiraIssue('ALP-3', 'Issue 3', 'To Do'),
+        jiraIssue('ALP-4', 'Issue 4', 'Done')
+      ]
+
+      const sectionsMap = new Map<string, JiraIssue[]>()
+      for (const issue of issues) {
+        const statusName = issue.status.name
+        if (!sectionsMap.has(statusName)) {
+          sectionsMap.set(statusName, [])
+        }
+        sectionsMap.get(statusName)!.push(issue)
+      }
+
+      expect(sectionsMap.size).toBe(3)
+      expect(sectionsMap.get('To Do')?.length).toBe(2)
+      expect(sectionsMap.get('In Progress')?.length).toBe(1)
+      expect(sectionsMap.get('Done')?.length).toBe(1)
+    })
+
+    it('sorts sections by agile board column configuration when available', () => {
+      const issues = [
+        jiraIssue('ALP-1', 'Issue 1', 'Done'),
+        jiraIssue('ALP-2', 'Issue 2', 'To Do'),
+        jiraIssue('ALP-3', 'Issue 3', 'In Progress')
+      ]
+
+      const jiraProjectStatuses: Record<string, string[]> = {
+        ALP: ['In Progress', 'To Do', 'Done']
+      }
+
+      const sectionsMap = new Map<string, JiraIssue[]>()
+      for (const issue of issues) {
+        const statusName = issue.status.name
+        if (!sectionsMap.has(statusName)) {
+          sectionsMap.set(statusName, [])
+        }
+        sectionsMap.get(statusName)!.push(issue)
+      }
+
+      const sections: { key: string; label: string; issues: JiraIssue[] }[] = []
+      sectionsMap.forEach((issues, statusName) => {
+        sections.push({
+          key: statusName,
+          label: statusName,
+          issues
+        })
+      })
+
+      const getStatusIndex = (statusName: string): number => {
+        for (const projectKey of Object.keys(jiraProjectStatuses)) {
+          const list = jiraProjectStatuses[projectKey]
+          if (list) {
+            const idx = list.indexOf(statusName)
+            if (idx !== -1) {
+              return idx
+            }
+          }
+        }
+        return 99999
+      }
+
+      sections.sort((a, b) => {
+        const idxA = getStatusIndex(a.label)
+        const idxB = getStatusIndex(b.label)
+        if (idxA !== idxB) {
+          return idxA - idxB
+        }
+        return a.label.localeCompare(b.label)
+      })
+
+      expect(sections.at(0)?.label).toBe('In Progress')
+      expect(sections.at(1)?.label).toBe('To Do')
+      expect(sections.at(2)?.label).toBe('Done')
+    })
+
+    it('falls back to alphabetical sorting when no board configuration exists', () => {
+      const issues = [
+        jiraIssue('ALP-1', 'Issue 1', 'Done'),
+        jiraIssue('ALP-2', 'Issue 2', 'To Do'),
+        jiraIssue('ALP-3', 'Issue 3', 'In Progress')
+      ]
+
+      const jiraProjectStatuses: Record<string, string[]> = {}
+
+      const sectionsMap = new Map<string, JiraIssue[]>()
+      for (const issue of issues) {
+        const statusName = issue.status.name
+        if (!sectionsMap.has(statusName)) {
+          sectionsMap.set(statusName, [])
+        }
+        sectionsMap.get(statusName)!.push(issue)
+      }
+
+      const sections: { key: string; label: string; issues: JiraIssue[] }[] = []
+      sectionsMap.forEach((issues, statusName) => {
+        sections.push({
+          key: statusName,
+          label: statusName,
+          issues
+        })
+      })
+
+      const getStatusIndex = (statusName: string): number => {
+        for (const projectKey of Object.keys(jiraProjectStatuses)) {
+          const list = jiraProjectStatuses[projectKey]
+          if (list) {
+            const idx = list.indexOf(statusName)
+            if (idx !== -1) {
+              return idx
+            }
+          }
+        }
+        return 99999
+      }
+
+      sections.sort((a, b) => {
+        const idxA = getStatusIndex(a.label)
+        const idxB = getStatusIndex(b.label)
+        if (idxA !== idxB) {
+          return idxA - idxB
+        }
+        return a.label.localeCompare(b.label)
+      })
+
+      expect(sections.at(0)?.label).toBe('Done')
+      expect(sections.at(1)?.label).toBe('In Progress')
+      expect(sections.at(2)?.label).toBe('To Do')
+    })
+  })
+
+  describe('collapsed groups state management', () => {
+    it('toggles group collapse state correctly', () => {
+      let collapsedGroups = new Set<string>(['To Do'])
+
+      const toggleGroup = (groupKey: string, current: Set<string>) => {
+        const next = new Set(current)
+        if (next.has(groupKey)) {
+          next.delete(groupKey)
+        } else {
+          next.add(groupKey)
+        }
+        return next
+      }
+
+      collapsedGroups = toggleGroup('To Do', collapsedGroups)
+      expect(collapsedGroups.has('To Do')).toBe(false)
+
+      collapsedGroups = toggleGroup('In Progress', collapsedGroups)
+      expect(collapsedGroups.has('In Progress')).toBe(true)
+      expect(collapsedGroups.has('To Do')).toBe(false)
+
+      collapsedGroups = toggleGroup('To Do', collapsedGroups)
+      expect(collapsedGroups.has('To Do')).toBe(true)
+      expect(collapsedGroups.has('In Progress')).toBe(true)
+    })
+
+    it('filters issues based on collapsed state', () => {
+      const collapsedGroups = new Set<string>(['To Do'])
+
+      const sections = [
+        { key: 'To Do', label: 'To Do', issues: [jiraIssue('ALP-1', 'Issue 1', 'To Do')] },
+        {
+          key: 'In Progress',
+          label: 'In Progress',
+          issues: [jiraIssue('ALP-2', 'Issue 2', 'In Progress')]
+        }
+      ]
+
+      const visibleIssues = sections
+        .filter((section) => !collapsedGroups.has(section.key))
+        .flatMap((section) => section.issues)
+
+      expect(visibleIssues.length).toBe(1)
+      expect(visibleIssues.at(0)?.key).toBe('ALP-2')
+    })
+  })
+})

--- a/src/renderer/src/components/task-page-jira-grouping.test.ts
+++ b/src/renderer/src/components/task-page-jira-grouping.test.ts
@@ -1,203 +1,171 @@
-import { describe, expect, it } from 'vitest'
-import type { JiraIssue } from '../../../shared/types'
+// @vitest-environment happy-dom
 
-describe('TaskPage Jira grouping functionality', () => {
-  function jiraIssue(key: string, title: string, statusName: string, siteId = 'site-1'): JiraIssue {
-    return {
-      id: `${siteId}:${key}`,
-      key,
-      title,
-      url: `https://example.atlassian.net/browse/${key}`,
-      siteId,
-      siteName: 'Example Jira',
-      project: { id: '10000', key: 'ALP', name: 'Alpha', siteId },
-      issueType: { id: '10001', name: 'Bug' },
-      status: { id: '1', name: statusName, categoryKey: 'new', categoryName: statusName },
-      labels: [],
-      createdAt: '2026-01-01T00:00:00.000Z',
-      updatedAt: '2026-01-01T00:00:00.000Z'
-    }
+import '@testing-library/jest-dom/vitest'
+
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { groupJiraIssuesByStatus, TaskPageJiraIssueList } from './task-page-jira-issue-list'
+import {
+  getSingleJiraProjectScope,
+  loadTaskPageJiraProjectStatusOrder
+} from './task-page-jira-status-order'
+import type { JiraIssue, JiraProjectStatusOrder } from '../../../shared/types'
+
+const { jiraGetProjectStatusOrderMock } = vi.hoisted(() => ({
+  jiraGetProjectStatusOrderMock: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-jira-client', () => ({
+  jiraGetProjectStatusOrder: (...args: unknown[]) => jiraGetProjectStatusOrderMock(...args)
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  jiraGetProjectStatusOrderMock.mockReset()
+})
+
+function jiraIssue(
+  key: string,
+  title: string,
+  statusId: string,
+  statusName: string,
+  options: { projectKey?: string; siteId?: string } = {}
+): JiraIssue {
+  const siteId = options.siteId ?? 'site-1'
+  const projectKey = options.projectKey ?? 'ALP'
+  return {
+    id: `${siteId}:${key}`,
+    key,
+    title,
+    url: `https://example.atlassian.net/browse/${key}`,
+    siteId,
+    siteName: 'Example Jira',
+    project: { id: projectKey, key: projectKey, name: projectKey, siteId },
+    issueType: { id: '10001', name: 'Bug' },
+    status: { id: statusId, name: statusName, categoryKey: 'new', categoryName: statusName },
+    labels: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
   }
+}
 
-  describe('jira issue sections grouping', () => {
-    it('groups issues by status name', () => {
-      const issues = [
-        jiraIssue('ALP-1', 'Issue 1', 'To Do'),
-        jiraIssue('ALP-2', 'Issue 2', 'In Progress'),
-        jiraIssue('ALP-3', 'Issue 3', 'To Do'),
-        jiraIssue('ALP-4', 'Issue 4', 'Done')
-      ]
+function statusOrder(statusIdsByColumn: string[][]): JiraProjectStatusOrder {
+  return { statusIdsByColumn }
+}
 
-      const sectionsMap = new Map<string, JiraIssue[]>()
-      for (const issue of issues) {
-        const statusName = issue.status.name
-        if (!sectionsMap.has(statusName)) {
-          sectionsMap.set(statusName, [])
-        }
-        sectionsMap.get(statusName)!.push(issue)
-      }
+describe('Jira issue status grouping', () => {
+  it('groups issues through the production implementation and preserves row order', () => {
+    const first = jiraIssue('ALP-1', 'First', '1', 'To Do')
+    const second = jiraIssue('ALP-2', 'Second', '2', 'In Progress')
+    const third = jiraIssue('ALP-3', 'Third', '1', 'To Do')
 
-      expect(sectionsMap.size).toBe(3)
-      expect(sectionsMap.get('To Do')?.length).toBe(2)
-      expect(sectionsMap.get('In Progress')?.length).toBe(1)
-      expect(sectionsMap.get('Done')?.length).toBe(1)
-    })
+    const sections = groupJiraIssuesByStatus([first, second, third], null)
 
-    it('sorts sections by agile board column configuration when available', () => {
-      const issues = [
-        jiraIssue('ALP-1', 'Issue 1', 'Done'),
-        jiraIssue('ALP-2', 'Issue 2', 'To Do'),
-        jiraIssue('ALP-3', 'Issue 3', 'In Progress')
-      ]
-
-      const jiraProjectStatuses: Record<string, string[]> = {
-        ALP: ['In Progress', 'To Do', 'Done']
-      }
-
-      const sectionsMap = new Map<string, JiraIssue[]>()
-      for (const issue of issues) {
-        const statusName = issue.status.name
-        if (!sectionsMap.has(statusName)) {
-          sectionsMap.set(statusName, [])
-        }
-        sectionsMap.get(statusName)!.push(issue)
-      }
-
-      const sections: { key: string; label: string; issues: JiraIssue[] }[] = []
-      sectionsMap.forEach((issues, statusName) => {
-        sections.push({
-          key: statusName,
-          label: statusName,
-          issues
-        })
-      })
-
-      const getStatusIndex = (statusName: string): number => {
-        for (const projectKey of Object.keys(jiraProjectStatuses)) {
-          const list = jiraProjectStatuses[projectKey]
-          if (list) {
-            const idx = list.indexOf(statusName)
-            if (idx !== -1) {
-              return idx
-            }
-          }
-        }
-        return 99999
-      }
-
-      sections.sort((a, b) => {
-        const idxA = getStatusIndex(a.label)
-        const idxB = getStatusIndex(b.label)
-        if (idxA !== idxB) {
-          return idxA - idxB
-        }
-        return a.label.localeCompare(b.label)
-      })
-
-      expect(sections.at(0)?.label).toBe('In Progress')
-      expect(sections.at(1)?.label).toBe('To Do')
-      expect(sections.at(2)?.label).toBe('Done')
-    })
-
-    it('falls back to alphabetical sorting when no board configuration exists', () => {
-      const issues = [
-        jiraIssue('ALP-1', 'Issue 1', 'Done'),
-        jiraIssue('ALP-2', 'Issue 2', 'To Do'),
-        jiraIssue('ALP-3', 'Issue 3', 'In Progress')
-      ]
-
-      const jiraProjectStatuses: Record<string, string[]> = {}
-
-      const sectionsMap = new Map<string, JiraIssue[]>()
-      for (const issue of issues) {
-        const statusName = issue.status.name
-        if (!sectionsMap.has(statusName)) {
-          sectionsMap.set(statusName, [])
-        }
-        sectionsMap.get(statusName)!.push(issue)
-      }
-
-      const sections: { key: string; label: string; issues: JiraIssue[] }[] = []
-      sectionsMap.forEach((issues, statusName) => {
-        sections.push({
-          key: statusName,
-          label: statusName,
-          issues
-        })
-      })
-
-      const getStatusIndex = (statusName: string): number => {
-        for (const projectKey of Object.keys(jiraProjectStatuses)) {
-          const list = jiraProjectStatuses[projectKey]
-          if (list) {
-            const idx = list.indexOf(statusName)
-            if (idx !== -1) {
-              return idx
-            }
-          }
-        }
-        return 99999
-      }
-
-      sections.sort((a, b) => {
-        const idxA = getStatusIndex(a.label)
-        const idxB = getStatusIndex(b.label)
-        if (idxA !== idxB) {
-          return idxA - idxB
-        }
-        return a.label.localeCompare(b.label)
-      })
-
-      expect(sections.at(0)?.label).toBe('Done')
-      expect(sections.at(1)?.label).toBe('In Progress')
-      expect(sections.at(2)?.label).toBe('To Do')
-    })
+    expect(sections.map((section) => section.label)).toEqual(['In Progress', 'To Do'])
+    expect(sections[1]?.issues).toEqual([first, third])
   })
 
-  describe('collapsed groups state management', () => {
-    it('toggles group collapse state correctly', () => {
-      let collapsedGroups = new Set<string>(['To Do'])
+  it('uses Jira column order while sorting statuses in the same column alphabetically', () => {
+    const sections = groupJiraIssuesByStatus(
+      [
+        jiraIssue('ALP-1', 'Done issue', '3', 'Done'),
+        jiraIssue('ALP-2', 'To do issue', '1', 'To Do'),
+        jiraIssue('ALP-3', 'Progress issue', '2', 'In Progress')
+      ],
+      statusOrder([['1', '2'], ['3']])
+    )
 
-      const toggleGroup = (groupKey: string, current: Set<string>) => {
-        const next = new Set(current)
-        if (next.has(groupKey)) {
-          next.delete(groupKey)
-        } else {
-          next.add(groupKey)
-        }
-        return next
-      }
+    expect(sections.map((section) => section.label)).toEqual(['In Progress', 'To Do', 'Done'])
+  })
 
-      collapsedGroups = toggleGroup('To Do', collapsedGroups)
-      expect(collapsedGroups.has('To Do')).toBe(false)
+  it('places statuses missing from board configuration last in alphabetical order', () => {
+    const sections = groupJiraIssuesByStatus(
+      [
+        jiraIssue('ALP-1', 'Done issue', '3', 'Done'),
+        jiraIssue('ALP-2', 'To do issue', '1', 'To Do'),
+        jiraIssue('ALP-3', 'Progress issue', '2', 'In Progress')
+      ],
+      statusOrder([['2']])
+    )
 
-      collapsedGroups = toggleGroup('In Progress', collapsedGroups)
-      expect(collapsedGroups.has('In Progress')).toBe(true)
-      expect(collapsedGroups.has('To Do')).toBe(false)
+    expect(sections.map((section) => section.label)).toEqual(['In Progress', 'Done', 'To Do'])
+  })
 
-      collapsedGroups = toggleGroup('To Do', collapsedGroups)
-      expect(collapsedGroups.has('To Do')).toBe(true)
-      expect(collapsedGroups.has('In Progress')).toBe(true)
+  it('only selects a board-order scope for one Jira site and project', () => {
+    const singleScope = getSingleJiraProjectScope([
+      jiraIssue('ALP-1', 'First', '1', 'To Do'),
+      jiraIssue('ALP-2', 'Second', '2', 'In Progress')
+    ])
+    const multipleSites = getSingleJiraProjectScope([
+      jiraIssue('ALP-1', 'First', '1', 'To Do', { siteId: 'site-1' }),
+      jiraIssue('ALP-2', 'Second', '2', 'In Progress', { siteId: 'site-2' })
+    ])
+    const multipleProjects = getSingleJiraProjectScope([
+      jiraIssue('ALP-1', 'First', '1', 'To Do', { projectKey: 'ALP' }),
+      jiraIssue('BRV-1', 'Second', '2', 'In Progress', { projectKey: 'BRV' })
+    ])
+    const missingSite = jiraIssue('ALP-3', 'Third', '3', 'Done')
+    delete missingSite.siteId
+    delete missingSite.project.siteId
+
+    expect(singleScope).toMatchObject({ projectKey: 'ALP', siteId: 'site-1' })
+    expect(multipleSites).toBeNull()
+    expect(multipleProjects).toBeNull()
+    expect(getSingleJiraProjectScope([missingSite])).toBeNull()
+  })
+
+  it('uses alphabetical fallback when status-order metadata is unavailable', async () => {
+    const error = new Error('Unknown RPC method')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    jiraGetProjectStatusOrderMock.mockRejectedValueOnce(error)
+    const scope = getSingleJiraProjectScope([jiraIssue('ALP-1', 'First', '1', 'To Do')])
+    if (!scope) {
+      throw new Error('Expected one Jira project scope')
+    }
+
+    await expect(loadTaskPageJiraProjectStatusOrder(null, 'runtime:old', scope)).resolves.toEqual({
+      statusIdsByColumn: []
     })
+    expect(warn).toHaveBeenCalledWith('[jira] Failed to load project status order:', error)
+  })
 
-    it('filters issues based on collapsed state', () => {
-      const collapsedGroups = new Set<string>(['To Do'])
+  it('collapses and expands a status group through its accessible trigger', async () => {
+    const user = userEvent.setup()
+    render(
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(TaskPageJiraIssueList, {
+          formatUpdatedAt: () => 'today',
+          getStatusTone: () => 'border-border',
+          issues: [
+            jiraIssue('ALP-1', 'First issue', '1', 'To Do'),
+            jiraIssue('ALP-2', 'Second issue', '1', 'To Do')
+          ],
+          onOpenIssue: vi.fn(),
+          onStartWorkspace: vi.fn(),
+          selectedIssue: null,
+          showSiteContext: false,
+          statusOrder: null
+        })
+      )
+    )
 
-      const sections = [
-        { key: 'To Do', label: 'To Do', issues: [jiraIssue('ALP-1', 'Issue 1', 'To Do')] },
-        {
-          key: 'In Progress',
-          label: 'In Progress',
-          issues: [jiraIssue('ALP-2', 'Issue 2', 'In Progress')]
-        }
-      ]
+    const trigger = screen.getByRole('button', { name: 'To Do 2' })
+    expect(trigger).toHaveAttribute('data-variant', 'ghost')
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('First issue')).toBeInTheDocument()
 
-      const visibleIssues = sections
-        .filter((section) => !collapsedGroups.has(section.key))
-        .flatMap((section) => section.issues)
+    await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('First issue')).not.toBeInTheDocument()
 
-      expect(visibleIssues.length).toBe(1)
-      expect(visibleIssues.at(0)?.key).toBe('ALP-2')
-    })
+    await user.click(trigger)
+    expect(screen.getByText('First issue')).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/task-page-jira-issue-list.tsx
+++ b/src/renderer/src/components/task-page-jira-issue-list.tsx
@@ -1,0 +1,349 @@
+import React, { useMemo, useState } from 'react'
+import { ArrowRight, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import type { JiraIssue, JiraProjectStatusOrder } from '../../../shared/types'
+
+export type TaskPageJiraIssueSection = {
+  key: string
+  label: string
+  issues: JiraIssue[]
+}
+
+type TaskPageJiraIssueListProps = {
+  formatUpdatedAt: (updatedAt: string) => string
+  getStatusTone: (categoryKey: string) => string
+  issues: JiraIssue[]
+  onOpenIssue: (issue: JiraIssue) => void
+  onStartWorkspace: (issue: JiraIssue) => void
+  selectedIssue: JiraIssue | null
+  showSiteContext: boolean
+  statusOrder: JiraProjectStatusOrder | null
+}
+
+function statusColumnRanks(order: JiraProjectStatusOrder | null): Map<string, number> {
+  const ranks = new Map<string, number>()
+  for (const [columnIndex, statusIds] of (order?.statusIdsByColumn ?? []).entries()) {
+    for (const statusId of statusIds) {
+      if (!ranks.has(statusId)) {
+        ranks.set(statusId, columnIndex)
+      }
+    }
+  }
+  return ranks
+}
+
+function sectionColumnRank(
+  section: TaskPageJiraIssueSection,
+  ranks: ReadonlyMap<string, number>
+): number {
+  let rank = Number.POSITIVE_INFINITY
+  for (const issue of section.issues) {
+    rank = Math.min(rank, ranks.get(issue.status.id) ?? Number.POSITIVE_INFINITY)
+  }
+  return rank
+}
+
+export function groupJiraIssuesByStatus(
+  issues: readonly JiraIssue[],
+  statusOrder: JiraProjectStatusOrder | null
+): TaskPageJiraIssueSection[] {
+  const sections = new Map<string, TaskPageJiraIssueSection>()
+  for (const issue of issues) {
+    const key = `status:${issue.status.name}`
+    const section = sections.get(key)
+    if (section) {
+      section.issues.push(issue)
+    } else {
+      sections.set(key, { key, label: issue.status.name, issues: [issue] })
+    }
+  }
+
+  const ranks = statusColumnRanks(statusOrder)
+  const sectionRanks = new Map(
+    [...sections.values()].map((section) => [section.key, sectionColumnRank(section, ranks)])
+  )
+  return [...sections.values()].sort((a, b) => {
+    const rankA = sectionRanks.get(a.key) ?? Number.POSITIVE_INFINITY
+    const rankB = sectionRanks.get(b.key) ?? Number.POSITIVE_INFINITY
+    return rankA === rankB ? a.label.localeCompare(b.label) : rankA - rankB
+  })
+}
+
+function isSelectedIssue(issue: JiraIssue, selectedIssue: JiraIssue | null): boolean {
+  if (!selectedIssue || issue.key !== selectedIssue.key) {
+    return false
+  }
+  return !selectedIssue.siteId || !issue.siteId || selectedIssue.siteId === issue.siteId
+}
+
+function JiraIssueRow({
+  formatUpdatedAt,
+  getStatusTone,
+  issue,
+  onOpenIssue,
+  onStartWorkspace,
+  selected,
+  showSiteContext
+}: {
+  formatUpdatedAt: (updatedAt: string) => string
+  getStatusTone: (categoryKey: string) => string
+  issue: JiraIssue
+  onOpenIssue: (issue: JiraIssue) => void
+  onStartWorkspace: (issue: JiraIssue) => void
+  selected: boolean
+  showSiteContext: boolean
+}): React.JSX.Element {
+  const labels = issue.labels.slice(0, 3)
+  const contextLabel =
+    showSiteContext && issue.siteName
+      ? `${issue.siteName} / ${issue.project.key}`
+      : issue.project.key
+
+  return (
+    // Why: the row contains action buttons, so a native button wrapper would
+    // create invalid nested buttons; role + keyboard handling preserves access.
+    <div
+      role="button"
+      tabIndex={0}
+      aria-current={selected ? 'true' : undefined}
+      data-current={selected ? 'true' : undefined}
+      onClick={() => onOpenIssue(issue)}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) {
+          return
+        }
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onOpenIssue(issue)
+        }
+      }}
+      className={cn(
+        'group/row grid min-h-12 cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring md:grid-cols-[90px_minmax(0,1fr)_128px_92px_80px] lg:grid-cols-[96px_minmax(0,1.25fr)_132px_120px_136px_96px_64px] xl:grid-cols-[104px_minmax(0,1.45fr)_144px_132px_160px_128px_72px]',
+        selected && 'bg-accent'
+      )}
+    >
+      <span className="block truncate font-mono text-[12px] text-muted-foreground max-md:!hidden">
+        {issue.key}
+      </span>
+
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="shrink-0 font-mono text-[11px] text-muted-foreground md:hidden">
+            {issue.key}
+          </span>
+          <h3 className="min-w-0 truncate text-[13px] font-medium text-foreground">
+            {issue.title}
+          </h3>
+        </div>
+        <div className="mt-1 flex min-w-0 items-center gap-1.5 md:!hidden">
+          <span
+            className={cn(
+              'inline-flex min-w-0 items-center rounded-full border px-1.5 py-0.5 text-[11px] font-medium',
+              getStatusTone(issue.status.categoryKey)
+            )}
+          >
+            <span className="truncate">{issue.status.name}</span>
+          </span>
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            {issue.priority?.name ??
+              translate('auto.components.TaskPage.713179dfdc', 'No priority')}
+          </span>
+          <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+            {issue.assignee?.displayName ??
+              translate('auto.components.TaskPage.42a9160321', 'Unassigned')}
+          </span>
+        </div>
+        <div className="mt-1 flex min-w-0 items-center gap-1 max-lg:!hidden">
+          <span className="max-w-[160px] truncate text-[10px] text-muted-foreground xl:!hidden">
+            {contextLabel}
+          </span>
+          {labels.map((label) => (
+            <span
+              key={label}
+              className="max-w-[140px] truncate rounded-full border border-border/50 bg-muted/35 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+            >
+              {label}
+            </span>
+          ))}
+          {issue.labels.length > labels.length ? (
+            <span className="text-[10px] text-muted-foreground">
+              +{issue.labels.length - labels.length}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex min-w-0 max-md:!hidden">
+        <span
+          className={cn(
+            'inline-flex max-w-full items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
+            getStatusTone(issue.status.categoryKey)
+          )}
+        >
+          <span className="truncate">{issue.status.name}</span>
+        </span>
+      </div>
+
+      <span className="block truncate text-[12px] text-muted-foreground max-md:!hidden">
+        {issue.priority?.name ?? translate('auto.components.TaskPage.713179dfdc', 'No priority')}
+      </span>
+
+      <div className="flex min-w-0 items-center gap-2 text-[12px] text-muted-foreground max-lg:!hidden">
+        {issue.assignee?.avatarUrl ? (
+          <img
+            src={issue.assignee.avatarUrl}
+            alt={issue.assignee.displayName}
+            className="size-5 shrink-0 rounded-full"
+          />
+        ) : (
+          <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-[10px]">
+            {issue.assignee?.displayName?.slice(0, 1) ?? '-'}
+          </span>
+        )}
+        <span className="truncate">
+          {issue.assignee?.displayName ??
+            translate('auto.components.TaskPage.42a9160321', 'Unassigned')}
+        </span>
+      </div>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="block min-w-0 truncate text-[12px] text-muted-foreground max-md:!hidden">
+            {formatUpdatedAt(issue.updatedAt)}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {new Date(issue.updatedAt).toLocaleString()}
+        </TooltipContent>
+      </Tooltip>
+
+      <div className="flex shrink-0 items-center justify-end gap-1 md:opacity-0 md:transition-opacity md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={(event) => {
+                event.stopPropagation()
+                onStartWorkspace(issue)
+              }}
+              aria-label={translate(
+                'auto.components.TaskPage.ff90d0abc7',
+                'Start workspace from {{value0}}',
+                { value0: issue.key }
+              )}
+            >
+              <ArrowRight className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {translate('auto.components.TaskPage.9497f2787c', 'Start workspace')}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={(event) => {
+                event.stopPropagation()
+                window.api.shell.openUrl(issue.url)
+              }}
+              aria-label={translate(
+                'auto.components.TaskPage.4ac8ff2275',
+                'Open {{value0}} in Jira',
+                { value0: issue.key }
+              )}
+            >
+              <ExternalLink className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {translate('auto.components.TaskPage.eee68073b2', 'Open in Jira')}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
+export function TaskPageJiraIssueList({
+  formatUpdatedAt,
+  getStatusTone,
+  issues,
+  onOpenIssue,
+  onStartWorkspace,
+  selectedIssue,
+  showSiteContext,
+  statusOrder
+}: TaskPageJiraIssueListProps): React.JSX.Element {
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set())
+  const sections = useMemo(
+    () => groupJiraIssuesByStatus(issues, statusOrder),
+    [issues, statusOrder]
+  )
+
+  return (
+    <div className="divide-y divide-border/50">
+      {sections.map((section) => {
+        const open = !collapsedGroups.has(section.key)
+        return (
+          <Collapsible
+            key={section.key}
+            open={open}
+            onOpenChange={(nextOpen) => {
+              setCollapsedGroups((current) => {
+                const next = new Set(current)
+                if (nextOpen) {
+                  next.delete(section.key)
+                } else {
+                  next.add(section.key)
+                }
+                return next
+              })
+            }}
+          >
+            <CollapsibleTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-9 w-full justify-start rounded-none bg-muted/35 px-3 text-left font-normal transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+              >
+                {open ? (
+                  <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="size-3 shrink-0 text-muted-foreground" />
+                )}
+                <span className="min-w-0 truncate text-[13px] font-medium text-foreground">
+                  {section.label}
+                </span>
+                <span className="shrink-0 text-[11px] text-muted-foreground">
+                  {section.issues.length}
+                </span>
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="divide-y divide-border/50 border-t border-border/50">
+              {section.issues.map((issue) => (
+                <JiraIssueRow
+                  key={`${issue.siteId ?? 'site'}:${issue.id || issue.key}`}
+                  formatUpdatedAt={formatUpdatedAt}
+                  getStatusTone={getStatusTone}
+                  issue={issue}
+                  onOpenIssue={onOpenIssue}
+                  onStartWorkspace={onStartWorkspace}
+                  selected={isSelectedIssue(issue, selectedIssue)}
+                  showSiteContext={showSiteContext}
+                />
+              ))}
+            </CollapsibleContent>
+          </Collapsible>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/task-page-jira-status-order.ts
+++ b/src/renderer/src/components/task-page-jira-status-order.ts
@@ -1,0 +1,63 @@
+import type { JiraIssue, JiraProjectStatusOrder } from '../../../shared/types'
+import { jiraGetProjectStatusOrder, type RuntimeJiraSettings } from '@/runtime/runtime-jira-client'
+import { createMetadataRequestStore, loadMetadata } from '@/hooks/metadata-request-cache'
+
+export type TaskPageJiraProjectScope = {
+  key: string
+  projectKey: string
+  siteId: string
+}
+
+const jiraProjectStatusOrderStore = createMetadataRequestStore<JiraProjectStatusOrder>()
+
+export function getTaskPageJiraStatusOrderScopeKey(
+  runtimeScopeKey: string,
+  projectScope: TaskPageJiraProjectScope
+): string {
+  return `${encodeURIComponent(runtimeScopeKey)}:${projectScope.key}`
+}
+
+function issueProjectScope(issue: JiraIssue): TaskPageJiraProjectScope | null {
+  const projectKey = issue.project.key.trim()
+  const siteId = issue.siteId?.trim() || issue.project.siteId?.trim()
+  if (!projectKey || !siteId) {
+    return null
+  }
+  return {
+    key: `${encodeURIComponent(siteId)}:${encodeURIComponent(projectKey)}`,
+    projectKey,
+    siteId
+  }
+}
+
+export function getSingleJiraProjectScope(
+  issues: readonly JiraIssue[]
+): TaskPageJiraProjectScope | null {
+  let onlyScope: TaskPageJiraProjectScope | null = null
+  for (const issue of issues) {
+    const scope = issueProjectScope(issue)
+    if (!scope || (onlyScope && onlyScope.key !== scope.key)) {
+      return null
+    }
+    onlyScope = scope
+  }
+  return onlyScope
+}
+
+export function loadTaskPageJiraProjectStatusOrder(
+  settings: RuntimeJiraSettings,
+  runtimeScopeKey: string,
+  projectScope: TaskPageJiraProjectScope
+): Promise<JiraProjectStatusOrder> {
+  // Why: a project key can exist on multiple Jira sites and runtimes; all three
+  // identities must participate in caching to preserve SSH and multi-site parity.
+  const cacheKey = getTaskPageJiraStatusOrderScopeKey(runtimeScopeKey, projectScope)
+  return loadMetadata(jiraProjectStatusOrderStore, cacheKey, () =>
+    jiraGetProjectStatusOrder(settings, projectScope.projectKey, projectScope.siteId)
+  ).catch((error: unknown) => {
+    // Why: older remote runtimes do not expose this optional metadata method;
+    // an empty order preserves the deterministic alphabetical fallback.
+    console.warn('[jira] Failed to load project status order:', error)
+    return { statusIdsByColumn: [] }
+  })
+}

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -280,3 +280,15 @@ export async function jiraListTransitions(
     ? callRuntimeRpc<JiraTransition[]>(target, 'jira.listTransitions', args, { timeoutMs: 30_000 })
     : window.api.jira.listTransitions(args)
 }
+
+export async function jiraGetProjectStatuses(
+  settings: RuntimeJiraSettings,
+  projectKey: string,
+  siteId?: string | null
+): Promise<string[]> {
+  const target = getJiraRuntimeTarget(settings)
+  const args = { projectKey, siteId: siteId ?? undefined }
+  return target.kind === 'environment'
+    ? callRuntimeRpc<string[]>(target, 'jira.getProjectStatuses', args, { timeoutMs: 30_000 })
+    : (window.api.jira.getProjectStatuses(args) as Promise<string[]>)
+}

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -12,6 +12,7 @@ import type {
   JiraMutationResult,
   JiraPriority,
   JiraProject,
+  JiraProjectStatusOrder,
   JiraSiteSelection,
   JiraTransition,
   JiraUser,
@@ -281,14 +282,16 @@ export async function jiraListTransitions(
     : window.api.jira.listTransitions(args)
 }
 
-export async function jiraGetProjectStatuses(
+export async function jiraGetProjectStatusOrder(
   settings: RuntimeJiraSettings,
   projectKey: string,
   siteId?: string | null
-): Promise<string[]> {
+): Promise<JiraProjectStatusOrder> {
   const target = getJiraRuntimeTarget(settings)
   const args = { projectKey, siteId: siteId ?? undefined }
   return target.kind === 'environment'
-    ? callRuntimeRpc<string[]>(target, 'jira.getProjectStatuses', args, { timeoutMs: 30_000 })
-    : (window.api.jira.getProjectStatuses(args) as Promise<string[]>)
+    ? callRuntimeRpc<JiraProjectStatusOrder>(target, 'jira.getProjectStatusOrder', args, {
+        timeoutMs: 30_000
+      })
+    : window.api.jira.getProjectStatusOrder(args)
 }

--- a/src/shared/jira-types.ts
+++ b/src/shared/jira-types.ts
@@ -81,6 +81,10 @@ export type JiraStatus = {
   colorName?: string
 }
 
+export type JiraProjectStatusOrder = {
+  statusIdsByColumn: string[][]
+}
+
 export type JiraTransition = {
   id: string
   name: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1844,6 +1844,7 @@ export type {
   JiraMutationResult,
   JiraPriority,
   JiraProject,
+  JiraProjectStatusOrder,
   JiraSite,
   JiraSiteSelection,
   JiraStatus,


### PR DESCRIPTION
## Description
Groups and orders Jira issue sections in the task page dynamically based on the project's Agile board columns configuration, rather than sorting status sections alphabetically. If no board status configuration is loaded or if it fails, it falls back to standard alphabetical grouping.

## User-Visible Changes
    - Status groups are arranged in the precise swimlane/column order of the project's Jira agile board.
    - Displays statuses dynamically sorted (e.g. `To Do` -> `In Progress` -> `In Review`) based on board indexing.

## Media
<img width="2560" height="1440" alt="Screenshot 2026-07-09 at 19 47 37" src="https://github.com/user-attachments/assets/edc47da3-6d84-4bc7-8b84-a9dbce721b73" />

## AI Code Review Summary
    - **Cross-Platform:** Purely web-client and standard Electron main/preload IPC. Tested for macOS, Linux, and Windows.
    - **SSH/Remote/Local:** Relies on the standard runtime API layer, fully compatible with SSH worktrees and remote servers.
    - **Agent/Integration Parity:** Keeps provider integration neutral; fallback to standard alphabetical sorting is preserved if status lists fail to load.
    - **Performance Risk:** Low. Status configuration is fetched once per project key and cached in react state, avoiding redundant network traffic in render loops.
    - **Security:** Standard sanitization of parameters (e.g. projectKey encoding) is handled before request dispatch.
    

## Technical Details
    - Added `/rest/api/3/project/{projectKey}/statuses` to retrieve project status metadata.
    - Added `/rest/agile/1.0/board/{boardId}/configuration` to fetch the Agile board's active column sequence.
    - Implemented state cache (`jiraProjectStatuses`) in `TaskPage.tsx` loaded via renderer client hooks.
    - Integrated `getStatusIndex` in the section-grouping `useMemo` block to sort status groups by board sequence index.

