### PR TITLE
Fix WSL source control path separators

### DIFF
--- a/src/main/git/status-wsl-pathspecs.test.ts
+++ b/src/main/git/status-wsl-pathspecs.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitExecFileAsyncBuffer: vi.fn(),
+  gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => env,
+  gitStreamStdout: vi.fn()
+}))
+
+import {
+  bulkDiscardChanges,
+  bulkStageFiles,
+  bulkUnstageFiles,
+  discardChanges,
+  stageFile,
+  unstageFile
+} from './status'
+
+const worktreePath = path.resolve('repo')
+const windowsRelativePath = 'tests\\breakgit'
+const wslOptions = { wslDistro: 'Ubuntu' }
+
+describe('WSL git pathspecs', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'tests/breakgit\0', stderr: '' })
+  })
+
+  it('uses POSIX separators for tracked file mutations executed inside WSL', async () => {
+    await stageFile(worktreePath, windowsRelativePath, wslOptions)
+    await unstageFile(worktreePath, windowsRelativePath, wslOptions)
+    await bulkStageFiles(worktreePath, [windowsRelativePath], wslOptions)
+    await bulkUnstageFiles(worktreePath, [windowsRelativePath], wslOptions)
+    await discardChanges(worktreePath, windowsRelativePath, wslOptions)
+    await bulkDiscardChanges(worktreePath, [windowsRelativePath], wslOptions)
+
+    const pathspecs = gitExecFileAsyncMock.mock.calls.flatMap(([args]) =>
+      (args as string[]).filter((arg) => arg.startsWith(':(literal)'))
+    )
+    expect(pathspecs).toEqual(Array(8).fill(':(literal)tests/breakgit'))
+  })
+
+  it('uses POSIX separators when discarding untracked files inside WSL', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'orca-wsl-pathspec-'))
+    const targetPath = path.resolve(repo, windowsRelativePath)
+    await mkdir(path.dirname(targetPath), { recursive: true })
+    await writeFile(targetPath, 'untracked')
+
+    try {
+      gitExecFileAsyncMock
+        .mockRejectedValueOnce(new Error('not tracked'))
+        .mockResolvedValue({ stdout: '', stderr: '' })
+      await discardChanges(repo, windowsRelativePath, wslOptions)
+
+      expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toEqual([
+        ['ls-files', '--error-unmatch', '--', ':(literal)tests/breakgit'],
+        ['clean', '-ffdx', '--', ':(literal)tests/breakgit']
+      ])
+
+      gitExecFileAsyncMock.mockReset()
+      gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+      await bulkDiscardChanges(repo, [windowsRelativePath], wslOptions)
+
+      expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toEqual([
+        ['ls-files', '-z', '--', ':(literal)tests/breakgit'],
+        ['clean', '-ffdx', '--', ':(literal)tests/breakgit']
+      ])
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves backslashes for host Git where they can be literal filename characters', async () => {
+    await stageFile(worktreePath, windowsRelativePath)
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['add', '--', ':(literal)tests\\breakgit'], {
+      cwd: worktreePath
+    })
+  })
+})

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -1837,7 +1837,7 @@ export async function stageFile(
   clearGitReadInvalidationState()
   try {
     await gitExecFileAsync(
-      ['add', '--', literalPathspec(filePath)],
+      ['add', '--', literalPathspec(filePath, options)],
       gitOptionsForWorktree(worktreePath, options)
     )
   } finally {
@@ -1855,7 +1855,7 @@ export async function unstageFile(
 ): Promise<void> {
   clearGitReadInvalidationState()
   try {
-    await gitExecFileAsync(['restore', '--staged', '--', literalPathspec(filePath)], {
+    await gitExecFileAsync(['restore', '--staged', '--', literalPathspec(filePath, options)], {
       ...gitOptionsForWorktree(worktreePath, options)
     })
   } finally {
@@ -1961,9 +1961,12 @@ export async function discardChanges(
 
     let tracked = false
     try {
-      await gitExecFileAsync(['ls-files', '--error-unmatch', '--', literalPathspec(filePath)], {
-        ...gitOptionsForWorktree(worktreePath, options)
-      })
+      await gitExecFileAsync(
+        ['ls-files', '--error-unmatch', '--', literalPathspec(filePath, options)],
+        {
+          ...gitOptionsForWorktree(worktreePath, options)
+        }
+      )
       tracked = true
     } catch {
       // File is not tracked by git
@@ -1971,7 +1974,7 @@ export async function discardChanges(
 
     if (tracked) {
       await gitExecFileAsync(
-        ['restore', '--worktree', '--source=HEAD', '--', literalPathspec(filePath)],
+        ['restore', '--worktree', '--source=HEAD', '--', literalPathspec(filePath, options)],
         {
           ...gitOptionsForWorktree(worktreePath, options)
         }
@@ -1991,9 +1994,11 @@ function normalizeGitPathForCompare(filePath: string): string {
   return filePath.replace(/\\/g, '/').replace(/\/+$/, '')
 }
 
-function literalPathspec(filePath: string): string {
-  // Why: source-control selections are concrete paths, not user-authored Git globs.
-  return `:(literal)${filePath}`
+function literalPathspec(filePath: string, options: GitRuntimeOptions): string {
+  // Why: Windows validation produces backslashes, but Git running inside WSL
+  // needs POSIX paths. Host paths stay untouched so POSIX filenames remain literal.
+  const runtimePath = options.wslDistro ? filePath.replace(/\\/g, '/') : filePath
+  return `:(literal)${runtimePath}`
 }
 
 function isTrackedPathSpec(filePath: string, trackedPaths: readonly string[]): boolean {
@@ -2013,7 +2018,7 @@ async function listTrackedPathSpecs(
   for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
     const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
     const { stdout } = await gitExecFileAsync(
-      ['ls-files', '-z', '--', ...chunk.map(literalPathspec)],
+      ['ls-files', '-z', '--', ...chunk.map((filePath) => literalPathspec(filePath, options))],
       {
         ...gitOptionsForWorktree(worktreePath, options)
       }
@@ -2038,9 +2043,12 @@ async function cleanUntrackedPaths(
     const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
     if (chunk.length > 0) {
       // Why: Git pathspec cleanup avoids raw recursive deletion through symlinked parents.
-      await gitExecFileAsync(['clean', '-ffdx', '--', ...chunk.map(literalPathspec)], {
-        ...gitOptionsForWorktree(worktreePath, options)
-      })
+      await gitExecFileAsync(
+        ['clean', '-ffdx', '--', ...chunk.map((filePath) => literalPathspec(filePath, options))],
+        {
+          ...gitOptionsForWorktree(worktreePath, options)
+        }
+      )
     }
   }
 }
@@ -2082,7 +2090,13 @@ export async function bulkDiscardChanges(
         for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
           const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
           await gitExecFileAsync(
-            ['restore', '--worktree', '--source=HEAD', '--', ...chunk.map(literalPathspec)],
+            [
+              'restore',
+              '--worktree',
+              '--source=HEAD',
+              '--',
+              ...chunk.map((filePath) => literalPathspec(filePath, options))
+            ],
             {
               ...gitOptionsForWorktree(worktreePath, options)
             }
@@ -2125,7 +2139,7 @@ export async function bulkStageFiles(
     for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
       const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
       await gitExecFileAsync(
-        ['add', '--', ...chunk.map(literalPathspec)],
+        ['add', '--', ...chunk.map((filePath) => literalPathspec(filePath, options))],
         gitOptionsForWorktree(worktreePath, options)
       )
     }
@@ -2149,9 +2163,17 @@ export async function bulkUnstageFiles(
   try {
     for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
       const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
-      await gitExecFileAsync(['restore', '--staged', '--', ...chunk.map(literalPathspec)], {
-        ...gitOptionsForWorktree(worktreePath, options)
-      })
+      await gitExecFileAsync(
+        [
+          'restore',
+          '--staged',
+          '--',
+          ...chunk.map((filePath) => literalPathspec(filePath, options))
+        ],
+        {
+          ...gitOptionsForWorktree(worktreePath, options)
+        }
+      )
     }
   } finally {
     clearGitReadInvalidationState()


### PR DESCRIPTION
## Summary

- convert repository-relative pathspecs to POSIX separators when Git executes inside WSL
- apply the boundary consistently to single and bulk stage, unstage, tracked discard, and untracked cleanup
- preserve host-Git backslashes so valid POSIX filenames are not changed outside WSL

Fixes #7021

## Root cause

Windows IPC path validation correctly resolved file paths for safety, then returned the repository-relative result from `path.relative()`. For local projects configured to run Git in WSL, that Windows-form relative path was passed unchanged into a literal Git pathspec, so nested paths such as `tests\breakgit` did not match Linux paths.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/status-wsl-pathspecs.test.ts src/main/git/status.test.ts src/main/git/status-pathspec-literals.test.ts src/main/git/status-discard-symlink.test.ts src/main/ipc/filesystem.test.ts` — 175 passed
- `pnpm run typecheck:node` — passed
- changed-file `oxlint` — passed
- `pnpm run check:max-lines-ratchet` — passed
- Win/Linux compatibility audit — no P0/P1 findings
- `pnpm run lint:switch-exhaustiveness` — blocked by an existing current-main error in `src/main/ipc/notification-authorization-status.ts:71` (`undefined` case missing)
- full `pnpm test` — timed out after 10 minutes without reporting a failing test; affected suites above pass deterministically