### PR TITLE
Fix GitLab auth diagnostic waking WSL

### DIFF
--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -352,6 +352,29 @@ describe('ghExecFileAsync WSL fallback', () => {
     )
   })
 
+  it('does not wake the default WSL distro for host-only GitLab diagnostics', async () => {
+    getDefaultWslDistroMock.mockReturnValue('Ubuntu')
+    execFileMock
+      .mockImplementationOnce((_binary, _args, _options, callback) => {
+        callback(Object.assign(new Error('spawn glab ENOENT'), { code: 'ENOENT' }))
+      })
+      .mockImplementationOnce((_binary, _args, _options, callback) => {
+        callback(null, { stdout: 'Logged in to gitlab.com', stderr: '' })
+      })
+
+    await expect(
+      glabExecFileAsync(['auth', 'status'], { allowDefaultWslFallback: false })
+    ).rejects.toThrow('spawn glab ENOENT')
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock).toHaveBeenCalledWith(
+      'glab',
+      ['auth', 'status'],
+      expect.objectContaining({ cwd: undefined }),
+      expect.any(Function)
+    )
+  })
+
   it('still retries idempotent glab transient failures', async () => {
     execFileMock
       .mockImplementationOnce((_binary, _args, _options, callback) => {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -1480,6 +1480,7 @@ type GlabExecOptions = Omit<GitExecOptions, 'cwd'> & {
   cwd?: string
   wslDistro?: string
   idempotent?: boolean
+  allowDefaultWslFallback?: boolean
 }
 
 /**
@@ -1544,6 +1545,7 @@ export async function glabExecFileAsync(
         resolved.wsl === null &&
         !options.cwd &&
         !options.wslDistro &&
+        options.allowDefaultWslFallback !== false &&
         isHostCommandMissing(err, 'glab')
       ) {
         const wslResolved = resolveDefaultWslCli('glab', args)

--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -245,6 +245,9 @@ describe('gitlab client — MR operations', () => {
         hosts: ['gitlab.com'],
         activeHost: 'gitlab.com'
       })
+      expect(glabExecFileAsyncMock).toHaveBeenCalledWith(['auth', 'status'], {
+        allowDefaultWslFallback: false
+      })
     })
   })
 

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -97,7 +97,10 @@ export async function diagnoseAuth(): Promise<GitLabAuthDiagnostic> {
       ? 'GLAB_TOKEN'
       : null
   try {
-    const { stdout, stderr } = await glabExecFileAsync(['auth', 'status'])
+    // Why: a host-global diagnostic must not wake an unrelated default WSL distro.
+    const { stdout, stderr } = await glabExecFileAsync(['auth', 'status'], {
+      allowDefaultWslFallback: false
+    })
     const output = `${stdout}\n${stderr}`
     const hosts = parseGlabAuthStatusHosts(output)
     return {


### PR DESCRIPTION
﻿## Summary

- keep the global GitLab auth diagnostic on the Windows host
- prevent a missing host glab from waking the default WSL distro
- preserve the existing default-WSL fallback for GitLab operations that use normal runner behavior

## Root cause and reproduction

On Windows, diagnoseAuth() runs cwd-less glab auth status. When host glab returns ENOENT, the shared runner automatically resolves the default WSL distro and retries through wsl.exe, even when the workspace and agent runtimes are Windows and GitLab is unused.

The regression harness simulates that exact subprocess sequence: Windows host glab missing, Ubuntu configured as the default distro, and the global auth command invoked. Before the fix it recorded a second wsl.exe call running glab auth status. It now asserts that the host-only diagnostic stops after the single host attempt. A separate existing test continues to cover default-WSL fallback for ordinary cwd-less GitLab API operations.

## Validation

- pnpm exec vitest run --config config/vitest.config.ts src/main/git/runner-wsl-gh-fallback.test.ts src/main/gitlab/client-mr.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/gitlab/client-mr.test.ts src/main/gitlab/gl-utils.test.ts
- pnpm typecheck:node
- pnpm exec oxlint src/main/git/runner.ts src/main/git/runner-wsl-gh-fallback.test.ts src/main/gitlab/client.ts src/main/gitlab/client-mr.test.ts
- pnpm check:max-lines-ratchet
- git diff --check

Closes #7536
