### PR TITLE
Fix Codex WSL runtime status hooks

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -14,6 +14,7 @@
     "../src/main/codex/codex-config-path-reference-rewrite.ts",
     "../src/main/codex/codex-home-paths.ts",
     "../src/main/codex/codex-hook-identity.ts",
+    "../src/main/codex/codex-wsl-hook-install-plan.ts",
     "../src/main/codex/config-settings-promotion.ts",
     "../src/main/codex/config-toml-line-scan.ts",
     "../src/main/codex/config-toml-trust.ts",

--- a/src/main/codex/codex-wsl-hook-install-plan.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from 'node:child_process'
+import { win32 as pathWin32 } from 'node:path'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
+import { getDefaultWslDistro, toLinuxPath } from '../wsl'
+
+export type CodexWslRuntimeHookInstallPlan = {
+  configPath: string
+  tomlPath: string
+  scriptPath: string
+  commandScriptPath: string
+  trustConfigPath: string
+}
+
+export type CanonicalizeWslLinuxPath = (distro: string, linuxPath: string) => string | null
+
+function trimTrailingSlash(value: string): string {
+  return value.length > 1 ? value.replace(/\/+$/, '') : value
+}
+
+function canonicalizeWslLinuxPath(distro: string, linuxPath: string): string | null {
+  if (process.platform !== 'win32') {
+    return linuxPath
+  }
+  try {
+    const canonicalPath = execFileSync(
+      'wsl.exe',
+      ['-d', distro, '--', 'readlink', '-f', '--', linuxPath],
+      {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5000
+      }
+    ).trim()
+    return canonicalPath.startsWith('/') ? canonicalPath : null
+  } catch {
+    return null
+  }
+}
+
+export function createCodexWslRuntimeHookInstallPlan(
+  runtimeHomePath: string | null | undefined,
+  target?: CodexAccountSelectionTarget,
+  canonicalize: CanonicalizeWslLinuxPath = canonicalizeWslLinuxPath
+): CodexWslRuntimeHookInstallPlan | null {
+  if (!runtimeHomePath) {
+    return null
+  }
+
+  const wslInfo = parseWslUncPath(runtimeHomePath)
+  if (!wslInfo && target?.runtime !== 'wsl') {
+    return null
+  }
+  const distro =
+    wslInfo?.distro ||
+    target?.wslDistro?.trim() ||
+    (target?.runtime === 'wsl' ? getDefaultWslDistro() : null)
+  if (!distro) {
+    return null
+  }
+
+  const logicalLinuxRuntimeHome = wslInfo?.linuxPath ?? toLinuxPath(runtimeHomePath)
+  if (!logicalLinuxRuntimeHome.startsWith('/')) {
+    return null
+  }
+  // Why: Codex canonicalizes hook sources inside WSL; resolving there keeps
+  // trust keys valid when HOME or the runtime directory crosses a symlink.
+  const linuxRuntimeHome = trimTrailingSlash(
+    canonicalize(distro, logicalLinuxRuntimeHome) ?? logicalLinuxRuntimeHome
+  )
+
+  return {
+    configPath: pathWin32.join(runtimeHomePath, 'hooks.json'),
+    tomlPath: pathWin32.join(runtimeHomePath, 'config.toml'),
+    scriptPath: pathWin32.join(runtimeHomePath, '.orca', 'agent-hooks', 'codex-hook.sh'),
+    commandScriptPath: `${linuxRuntimeHome}/.orca/agent-hooks/codex-hook.sh`,
+    trustConfigPath: `${linuxRuntimeHome}/hooks.json`
+  }
+}

--- a/src/main/codex/codex-wsl-hook-install-plan.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.ts
@@ -1,8 +1,11 @@
 import { execFileSync } from 'node:child_process'
 import { win32 as pathWin32 } from 'node:path'
 import { parseWslUncPath } from '../../shared/wsl-paths'
-import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
-import { getDefaultWslDistro, toLinuxPath } from '../wsl'
+
+export type CodexWslRuntimeHookTarget = {
+  runtime?: 'host' | 'wsl'
+  wslDistro?: string | null
+}
 
 export type CodexWslRuntimeHookInstallPlan = {
   configPath: string
@@ -16,6 +19,14 @@ export type CanonicalizeWslLinuxPath = (distro: string, linuxPath: string) => st
 
 function trimTrailingSlash(value: string): string {
   return value.length > 1 ? value.replace(/\/+$/, '') : value
+}
+
+function toDefaultWslLinuxPath(windowsPath: string): string {
+  const driveMatch = windowsPath.match(/^([A-Za-z]):[/\\](.*)$/)
+  if (!driveMatch) {
+    return windowsPath
+  }
+  return `/mnt/${driveMatch[1].toLowerCase()}/${driveMatch[2].replace(/\\/g, '/')}`
 }
 
 function canonicalizeWslLinuxPath(distro: string, linuxPath: string): string | null {
@@ -40,7 +51,7 @@ function canonicalizeWslLinuxPath(distro: string, linuxPath: string): string | n
 
 export function createCodexWslRuntimeHookInstallPlan(
   runtimeHomePath: string | null | undefined,
-  target?: CodexAccountSelectionTarget,
+  target?: CodexWslRuntimeHookTarget,
   canonicalize: CanonicalizeWslLinuxPath = canonicalizeWslLinuxPath
 ): CodexWslRuntimeHookInstallPlan | null {
   if (!runtimeHomePath) {
@@ -51,15 +62,12 @@ export function createCodexWslRuntimeHookInstallPlan(
   if (!wslInfo && target?.runtime !== 'wsl') {
     return null
   }
-  const distro =
-    wslInfo?.distro ||
-    target?.wslDistro?.trim() ||
-    (target?.runtime === 'wsl' ? getDefaultWslDistro() : null)
+  const distro = wslInfo?.distro || (target?.runtime === 'wsl' ? target.wslDistro?.trim() : null)
   if (!distro) {
     return null
   }
 
-  const logicalLinuxRuntimeHome = wslInfo?.linuxPath ?? toLinuxPath(runtimeHomePath)
+  const logicalLinuxRuntimeHome = wslInfo?.linuxPath ?? toDefaultWslLinuxPath(runtimeHomePath)
   if (!logicalLinuxRuntimeHome.startsWith('/')) {
     return null
   }

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -1,88 +1,69 @@
-import { describe, expect, it } from 'vitest'
-import type { SFTPWrapper } from 'ssh2'
-import { win32 as pathWin32 } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { dirname, join, win32 as pathWin32 } from 'node:path'
 
-import { CodexHookService, createCodexWslRuntimeHookInstallPlan } from './hook-service'
+import { MANAGED_HOOK_TIMEOUT_SECONDS } from '../agent-hooks/installer-utils'
+import {
+  computeTrustKey,
+  computeTrustedHash,
+  readHookTrustEntries,
+  type CodexTrustEntry
+} from './config-toml-trust'
+import {
+  _internals,
+  createCodexWslRuntimeHookInstallPlan,
+  type CodexWslRuntimeHookInstallPlan
+} from './hook-service'
 
-type FakeFs = {
-  files: Map<string, string>
-  modes: Map<string, number>
+type HooksConfig = {
+  hooks: Record<string, { hooks?: { command?: string }[] }[]>
 }
 
-function createFakeSftp(): {
-  sftp: SFTPWrapper
-  fs: FakeFs
-} {
-  const fs: FakeFs = {
-    files: new Map(),
-    modes: new Map()
+const managedEvents = [
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PermissionRequest',
+  'PostToolUse',
+  'Stop'
+] as const
+
+let tempRoots: string[] = []
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    rmSync(root, { recursive: true, force: true })
   }
-  const noEntryError = (path: string): { code: number; message: string } => ({
-    code: 2,
-    message: `ENOENT ${path}`
-  })
+  tempRoots = []
+})
 
-  const sftp = {
-    readFile: (path: string, _enc: string, cb: (err: unknown, data?: string) => void): void => {
-      const value = fs.files.get(path)
-      if (value === undefined) {
-        cb(noEntryError(path))
-        return
-      }
-      cb(null, value)
-    },
-    writeFile: (
-      path: string,
-      content: string,
-      options: string | { mode?: number },
-      cb: (err: unknown) => void
-    ): void => {
-      fs.files.set(path, content)
-      if (typeof options !== 'string' && options.mode !== undefined) {
-        fs.modes.set(path, options.mode)
-      }
-      cb(null)
-    },
-    rename: (src: string, dst: string, cb: (err: unknown) => void): void => {
-      const value = fs.files.get(src)
-      if (value === undefined) {
-        cb(noEntryError(src))
-        return
-      }
-      fs.files.set(dst, value)
-      fs.files.delete(src)
-      const mode = fs.modes.get(src)
-      if (mode !== undefined) {
-        fs.modes.set(dst, mode)
-        fs.modes.delete(src)
-      }
-      cb(null)
-    },
-    unlink: (path: string, cb: (err: unknown) => void): void => {
-      fs.files.delete(path)
-      fs.modes.delete(path)
-      cb(null)
-    },
-    chmod: (path: string, mode: number, cb: (err: unknown) => void): void => {
-      fs.modes.set(path, mode)
-      cb(null)
-    },
-    stat: (path: string, cb: (err: unknown, stats?: { mode: number }) => void): void => {
-      if (!fs.files.has(path)) {
-        cb(noEntryError(path))
-        return
-      }
-      cb(null, { mode: fs.modes.get(path) ?? 0o100644 })
-    },
-    readdir: (_path: string, cb: (err: unknown, list?: { filename: string }[]) => void): void => {
-      cb(null, [])
-    },
-    mkdir: (_path: string, cb: (err: unknown) => void): void => {
-      cb(null)
-    }
-  } as unknown as SFTPWrapper
+function createTestPlan(): CodexWslRuntimeHookInstallPlan {
+  const root = mkdtempSync(join(tmpdir(), 'orca-codex-wsl-hooks-'))
+  tempRoots.push(root)
+  const linuxHome = '/home/alice/.local/share/orca/codex-runtime-home/home'
+  return {
+    configPath: join(root, 'hooks.json'),
+    tomlPath: join(root, 'config.toml'),
+    scriptPath: join(root, '.orca', 'agent-hooks', 'codex-hook.sh'),
+    commandScriptPath: `${linuxHome}/.orca/agent-hooks/codex-hook.sh`,
+    trustConfigPath: `${linuxHome}/hooks.json`
+  }
+}
 
-  return { sftp, fs }
+function getManagedTrustEntry(
+  plan: CodexWslRuntimeHookInstallPlan,
+  command: string
+): CodexTrustEntry {
+  return {
+    sourcePath: plan.trustConfigPath,
+    eventLabel: 'user_prompt_submit',
+    groupIndex: 0,
+    handlerIndex: 0,
+    command,
+    timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+  }
 }
 
 describe('Codex WSL runtime hook install', () => {
@@ -100,12 +81,10 @@ describe('Codex WSL runtime hook install', () => {
     })
   })
 
-  it('generates a POSIX hook that bridges WSL loopback failures through Windows curl', async () => {
-    const { sftp, fs } = createFakeSftp()
-
-    await new CodexHookService().installRemote(sftp, '/home/dev')
-
-    const script = fs.files.get('/home/dev/.orca/agent-hooks/codex-hook.sh')
+  it('generates a POSIX hook that bridges WSL loopback failures through Windows curl', () => {
+    const script = _internals.getManagedScript('posix')
+    expect(script).toContain('load_hook_endpoint()')
+    expect(script).toContain('"set ORCA_AGENT_HOOK_TOKEN="*)')
     expect(script).toContain('post_codex_hook()')
     expect(script).toContain('is_wsl_runtime()')
     expect(script).toContain('WSL_DISTRO_NAME')
@@ -113,5 +92,123 @@ describe('Codex WSL runtime hook install', () => {
     expect(script).toContain('--data-urlencode "payload@-"')
     expect(script).toContain('if post_codex_hook curl >/dev/null 2>&1; then')
     expect(script).toContain('post_codex_hook "$windows_curl" 3 5 >/dev/null 2>&1 || true')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'refreshes stale hook coordinates from a Windows endpoint file',
+    () => {
+      const plan = createTestPlan()
+      const root = dirname(plan.configPath)
+      const endpointPath = join(root, 'endpoint.cmd')
+      const binDir = join(root, 'bin')
+      const curlPath = join(binDir, 'curl')
+      const capturePath = join(root, 'curl-args.txt')
+      mkdirSync(binDir, { recursive: true })
+      writeFileSync(
+        endpointPath,
+        [
+          'set ORCA_AGENT_HOOK_PORT=43210',
+          'set ORCA_AGENT_HOOK_TOKEN=fresh-token',
+          'set ORCA_AGENT_HOOK_ENV=development',
+          'set ORCA_AGENT_HOOK_VERSION=1',
+          ''
+        ].join('\r\n'),
+        'utf-8'
+      )
+      writeFileSync(
+        curlPath,
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$ORCA_TEST_CAPTURE"\ncat >> "$ORCA_TEST_CAPTURE"\n',
+        'utf-8'
+      )
+      chmodSync(curlPath, 0o755)
+      mkdirSync(dirname(plan.scriptPath), { recursive: true })
+      writeFileSync(plan.scriptPath, _internals.getManagedScript('posix'), 'utf-8')
+
+      const result = spawnSync('/bin/sh', [plan.scriptPath], {
+        encoding: 'utf-8',
+        input: '{"hook_event_name":"UserPromptSubmit","prompt":"restart"}',
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ''}`,
+          ORCA_AGENT_HOOK_ENDPOINT: endpointPath,
+          ORCA_AGENT_HOOK_PORT: '1',
+          ORCA_AGENT_HOOK_TOKEN: 'stale-token',
+          ORCA_PANE_KEY: 'pane-1',
+          ORCA_TEST_CAPTURE: capturePath
+        }
+      })
+
+      expect(result.status).toBe(0)
+      const posted = readFileSync(capturePath, 'utf-8')
+      expect(posted).toContain('http://127.0.0.1:43210/hook/codex')
+      expect(posted).toContain('X-Orca-Agent-Hook-Token: fresh-token')
+      expect(posted).not.toContain('stale-token')
+    }
+  )
+
+  it('installs trusted WSL hooks and removes only Orca entries when disabled', () => {
+    const plan = createTestPlan()
+    const userCommand = '/bin/sh /home/alice/user-hook.sh'
+    writeFileSync(
+      plan.configPath,
+      `${JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [{ hooks: [{ type: 'command', command: userCommand }] }],
+          PreCompact: [
+            {
+              hooks: [
+                {
+                  type: 'command',
+                  command:
+                    "if [ -x '/old/.orca/agent-hooks/codex-hook.sh' ]; then /bin/sh '/old/.orca/agent-hooks/codex-hook.sh'; fi"
+                }
+              ]
+            }
+          ]
+        }
+      })}\n`,
+      'utf-8'
+    )
+    const unrelatedTrustKey = '/home/alice/custom/hooks.json:stop:0:0'
+    writeFileSync(
+      plan.tomlPath,
+      `[hooks.state."${unrelatedTrustKey}"]\nenabled = false\ntrusted_hash = "sha256:user"\n`,
+      'utf-8'
+    )
+
+    expect(_internals.installManagedHooksIntoWslRuntime(plan).state).toBe('installed')
+
+    const installed = JSON.parse(readFileSync(plan.configPath, 'utf-8')) as HooksConfig
+    expect(Object.keys(installed.hooks).sort()).toEqual([...managedEvents].sort())
+    const managedCommand = installed.hooks.UserPromptSubmit[0]?.hooks?.[0]?.command
+    expect(managedCommand).toBe(
+      `if [ -r '${plan.commandScriptPath}' ]; then /bin/sh '${plan.commandScriptPath}'; fi`
+    )
+    expect(installed.hooks.UserPromptSubmit[1]?.hooks?.[0]?.command).toBe(userCommand)
+    expect(readFileSync(plan.scriptPath, 'utf-8')).toContain('/mnt/c/Windows/System32/curl.exe')
+
+    const managedTrustEntry = getManagedTrustEntry(plan, managedCommand!)
+    const trustEntries = readHookTrustEntries(plan.tomlPath)
+    expect(trustEntries.get(computeTrustKey(managedTrustEntry))).toEqual({
+      enabled: true,
+      trustedHash: computeTrustedHash(managedTrustEntry)
+    })
+    expect(trustEntries.get(unrelatedTrustKey)).toEqual({
+      enabled: false,
+      trustedHash: 'sha256:user'
+    })
+
+    expect(_internals.refreshWslRuntimeUserHooks(plan).state).toBe('not_installed')
+
+    const refreshed = JSON.parse(readFileSync(plan.configPath, 'utf-8')) as HooksConfig
+    expect(refreshed.hooks).toEqual({
+      UserPromptSubmit: [{ hooks: [{ type: 'command', command: userCommand }] }]
+    })
+    const refreshedTrustEntries = readHookTrustEntries(plan.tomlPath)
+    expect(refreshedTrustEntries.has(computeTrustKey(managedTrustEntry))).toBe(false)
+    expect(refreshedTrustEntries.get(unrelatedTrustKey)).toEqual({
+      enabled: false,
+      trustedHash: 'sha256:user'
+    })
   })
 })

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import type { SFTPWrapper } from 'ssh2'
+import { win32 as pathWin32 } from 'node:path'
+
+import { CodexHookService, createCodexWslRuntimeHookInstallPlan } from './hook-service'
+
+type FakeFs = {
+  files: Map<string, string>
+  modes: Map<string, number>
+}
+
+function createFakeSftp(): {
+  sftp: SFTPWrapper
+  fs: FakeFs
+} {
+  const fs: FakeFs = {
+    files: new Map(),
+    modes: new Map()
+  }
+  const noEntryError = (path: string): { code: number; message: string } => ({
+    code: 2,
+    message: `ENOENT ${path}`
+  })
+
+  const sftp = {
+    readFile: (path: string, _enc: string, cb: (err: unknown, data?: string) => void): void => {
+      const value = fs.files.get(path)
+      if (value === undefined) {
+        cb(noEntryError(path))
+        return
+      }
+      cb(null, value)
+    },
+    writeFile: (
+      path: string,
+      content: string,
+      options: string | { mode?: number },
+      cb: (err: unknown) => void
+    ): void => {
+      fs.files.set(path, content)
+      if (typeof options !== 'string' && options.mode !== undefined) {
+        fs.modes.set(path, options.mode)
+      }
+      cb(null)
+    },
+    rename: (src: string, dst: string, cb: (err: unknown) => void): void => {
+      const value = fs.files.get(src)
+      if (value === undefined) {
+        cb(noEntryError(src))
+        return
+      }
+      fs.files.set(dst, value)
+      fs.files.delete(src)
+      const mode = fs.modes.get(src)
+      if (mode !== undefined) {
+        fs.modes.set(dst, mode)
+        fs.modes.delete(src)
+      }
+      cb(null)
+    },
+    unlink: (path: string, cb: (err: unknown) => void): void => {
+      fs.files.delete(path)
+      fs.modes.delete(path)
+      cb(null)
+    },
+    chmod: (path: string, mode: number, cb: (err: unknown) => void): void => {
+      fs.modes.set(path, mode)
+      cb(null)
+    },
+    stat: (path: string, cb: (err: unknown, stats?: { mode: number }) => void): void => {
+      if (!fs.files.has(path)) {
+        cb(noEntryError(path))
+        return
+      }
+      cb(null, { mode: fs.modes.get(path) ?? 0o100644 })
+    },
+    readdir: (_path: string, cb: (err: unknown, list?: { filename: string }[]) => void): void => {
+      cb(null, [])
+    },
+    mkdir: (_path: string, cb: (err: unknown) => void): void => {
+      cb(null)
+    }
+  } as unknown as SFTPWrapper
+
+  return { sftp, fs }
+}
+
+describe('Codex WSL runtime hook install', () => {
+  it('plans WSL hook files with Linux command and trust paths', () => {
+    const runtimeHome =
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\home'
+
+    expect(createCodexWslRuntimeHookInstallPlan(runtimeHome)).toEqual({
+      configPath: pathWin32.join(runtimeHome, 'hooks.json'),
+      tomlPath: pathWin32.join(runtimeHome, 'config.toml'),
+      scriptPath: pathWin32.join(runtimeHome, '.orca', 'agent-hooks', 'codex-hook.sh'),
+      commandScriptPath:
+        '/home/alice/.local/share/orca/codex-runtime-home/home/.orca/agent-hooks/codex-hook.sh',
+      trustConfigPath: '/home/alice/.local/share/orca/codex-runtime-home/home/hooks.json'
+    })
+  })
+
+  it('generates a POSIX hook that bridges WSL loopback failures through Windows curl', async () => {
+    const { sftp, fs } = createFakeSftp()
+
+    await new CodexHookService().installRemote(sftp, '/home/dev')
+
+    const script = fs.files.get('/home/dev/.orca/agent-hooks/codex-hook.sh')
+    expect(script).toContain('post_codex_hook()')
+    expect(script).toContain('is_wsl_runtime()')
+    expect(script).toContain('WSL_DISTRO_NAME')
+    expect(script).toContain('/mnt/c/Windows/System32/curl.exe')
+    expect(script).toContain('--data-urlencode "payload@-"')
+    expect(script).toContain('if post_codex_hook curl >/dev/null 2>&1; then')
+    expect(script).toContain('post_codex_hook "$windows_curl" 3 5 >/dev/null 2>&1 || true')
+  })
+})

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -71,7 +71,9 @@ describe('Codex WSL runtime hook install', () => {
     const runtimeHome =
       '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\home'
 
-    expect(createCodexWslRuntimeHookInstallPlan(runtimeHome)).toEqual({
+    expect(
+      createCodexWslRuntimeHookInstallPlan(runtimeHome, undefined, (_distro, path) => path)
+    ).toEqual({
       configPath: pathWin32.join(runtimeHome, 'hooks.json'),
       tomlPath: pathWin32.join(runtimeHome, 'config.toml'),
       scriptPath: pathWin32.join(runtimeHome, '.orca', 'agent-hooks', 'codex-hook.sh'),
@@ -81,6 +83,45 @@ describe('Codex WSL runtime hook install', () => {
     })
   })
 
+  it('plans WSL hooks when the distro home is mounted on a Windows drive', () => {
+    const runtimeHome = 'D:\\wsl-home\\.local\\share\\orca\\codex-runtime-home\\home'
+
+    expect(
+      createCodexWslRuntimeHookInstallPlan(
+        runtimeHome,
+        { runtime: 'wsl', wslDistro: 'Ubuntu' },
+        (_distro, path) => path
+      )
+    ).toEqual({
+      configPath: pathWin32.join(runtimeHome, 'hooks.json'),
+      tomlPath: pathWin32.join(runtimeHome, 'config.toml'),
+      scriptPath: pathWin32.join(runtimeHome, '.orca', 'agent-hooks', 'codex-hook.sh'),
+      commandScriptPath:
+        '/mnt/d/wsl-home/.local/share/orca/codex-runtime-home/home/.orca/agent-hooks/codex-hook.sh',
+      trustConfigPath: '/mnt/d/wsl-home/.local/share/orca/codex-runtime-home/home/hooks.json'
+    })
+  })
+
+  it('uses WSL-canonical paths for hook commands and trust keys', () => {
+    const runtimeHome =
+      '\\\\wsl.localhost\\Ubuntu\\home\\alias\\.local\\share\\orca\\codex-runtime-home\\home'
+    const canonicalHome = '/home/alice/.local/share/orca/codex-runtime-home/home'
+
+    const plan = createCodexWslRuntimeHookInstallPlan(
+      runtimeHome,
+      { runtime: 'wsl', wslDistro: 'Ubuntu' },
+      (distro, linuxPath) => {
+        expect(distro).toBe('Ubuntu')
+        expect(linuxPath).toBe('/home/alias/.local/share/orca/codex-runtime-home/home')
+        return canonicalHome
+      }
+    )
+
+    expect(plan?.commandScriptPath).toBe(`${canonicalHome}/.orca/agent-hooks/codex-hook.sh`)
+    expect(plan?.trustConfigPath).toBe(`${canonicalHome}/hooks.json`)
+    expect(plan?.configPath).toBe(pathWin32.join(runtimeHome, 'hooks.json'))
+  })
+
   it('generates a POSIX hook that bridges WSL loopback failures through Windows curl', () => {
     const script = _internals.getManagedScript('posix')
     expect(script).toContain('load_hook_endpoint()')
@@ -88,7 +129,7 @@ describe('Codex WSL runtime hook install', () => {
     expect(script).toContain('post_codex_hook()')
     expect(script).toContain('is_wsl_runtime()')
     expect(script).toContain('WSL_DISTRO_NAME')
-    expect(script).toContain('/mnt/c/Windows/System32/curl.exe')
+    expect(script).toContain('windows_curl=$(command -v curl.exe 2>/dev/null || true)')
     expect(script).toContain('--data-urlencode "payload@-"')
     expect(script).toContain('if post_codex_hook curl >/dev/null 2>&1; then')
     expect(script).toContain('post_codex_hook "$windows_curl" 3 5 >/dev/null 2>&1 || true')
@@ -146,6 +187,46 @@ describe('Codex WSL runtime hook install', () => {
     }
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'uses the Windows curl discovered from the WSL PATH after loopback fails',
+    () => {
+      const plan = createTestPlan()
+      const root = dirname(plan.configPath)
+      const binDir = join(root, 'bin')
+      const capturePath = join(root, 'windows-curl-args.txt')
+      mkdirSync(binDir, { recursive: true })
+      writeFileSync(join(binDir, 'curl'), '#!/bin/sh\nexit 7\n', 'utf-8')
+      writeFileSync(
+        join(binDir, 'curl.exe'),
+        '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$ORCA_TEST_CAPTURE"\ncat >> "$ORCA_TEST_CAPTURE"\n',
+        'utf-8'
+      )
+      chmodSync(join(binDir, 'curl'), 0o755)
+      chmodSync(join(binDir, 'curl.exe'), 0o755)
+      mkdirSync(dirname(plan.scriptPath), { recursive: true })
+      writeFileSync(plan.scriptPath, _internals.getManagedScript('posix'), 'utf-8')
+
+      const result = spawnSync('/bin/sh', [plan.scriptPath], {
+        encoding: 'utf-8',
+        input: '{"hook_event_name":"Stop"}',
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ''}`,
+          WSL_DISTRO_NAME: 'Ubuntu',
+          ORCA_AGENT_HOOK_PORT: '43210',
+          ORCA_AGENT_HOOK_TOKEN: 'token',
+          ORCA_PANE_KEY: 'pane-1',
+          ORCA_TEST_CAPTURE: capturePath
+        }
+      })
+
+      expect(result.status).toBe(0)
+      const posted = readFileSync(capturePath, 'utf-8')
+      expect(posted).toContain('http://127.0.0.1:43210/hook/codex')
+      expect(posted).toContain('X-Orca-Agent-Hook-Token: token')
+    }
+  )
+
   it('installs trusted WSL hooks and removes only Orca entries when disabled', () => {
     const plan = createTestPlan()
     const userCommand = '/bin/sh /home/alice/user-hook.sh'
@@ -185,7 +266,7 @@ describe('Codex WSL runtime hook install', () => {
       `if [ -r '${plan.commandScriptPath}' ]; then /bin/sh '${plan.commandScriptPath}'; fi`
     )
     expect(installed.hooks.UserPromptSubmit[1]?.hooks?.[0]?.command).toBe(userCommand)
-    expect(readFileSync(plan.scriptPath, 'utf-8')).toContain('/mnt/c/Windows/System32/curl.exe')
+    expect(readFileSync(plan.scriptPath, 'utf-8')).toContain('command -v curl.exe')
 
     const managedTrustEntry = getManagedTrustEntry(plan, managedCommand!)
     const trustEntries = readHookTrustEntries(plan.tomlPath)

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -773,8 +773,30 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: see claude/hook-service.ts for rationale. Sourcing refreshes
     // PORT/TOKEN/ENV/VERSION from the current Orca so a surviving PTY keeps
     // reporting after a restart.
+    'load_hook_endpoint() {',
+    '  endpoint_path="$1"',
+    '  case "$endpoint_path" in',
+    '    *.cmd)',
+    // Why: Windows passes endpoint.cmd into WSL through WSLENV path translation.
+    // Parse only Orca's known assignments; cmd.exe `set` lines are not shell syntax.
+    '      endpoint_cr=$(printf "\\r")',
+    '      while IFS= read -r endpoint_line || [ -n "$endpoint_line" ]; do',
+    '        endpoint_line=${endpoint_line%"$endpoint_cr"}',
+    '        case "$endpoint_line" in',
+    '          "set ORCA_AGENT_HOOK_PORT="*) ORCA_AGENT_HOOK_PORT=${endpoint_line#*=} ;;',
+    '          "set ORCA_AGENT_HOOK_TOKEN="*) ORCA_AGENT_HOOK_TOKEN=${endpoint_line#*=} ;;',
+    '          "set ORCA_AGENT_HOOK_ENV="*) ORCA_AGENT_HOOK_ENV=${endpoint_line#*=} ;;',
+    '          "set ORCA_AGENT_HOOK_VERSION="*) ORCA_AGENT_HOOK_VERSION=${endpoint_line#*=} ;;',
+    '        esac',
+    '      done < "$endpoint_path"',
+    '      ;;',
+    '    *)',
+    '      . "$endpoint_path" 2>/dev/null || :',
+    '      ;;',
+    '  esac',
+    '}',
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
-    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
+    '  load_hook_endpoint "$ORCA_AGENT_HOOK_ENDPOINT"',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
     '  exit 0',
@@ -1383,3 +1405,9 @@ export class CodexHookService {
 }
 
 export const codexHookService = new CodexHookService()
+
+export const _internals = {
+  getManagedScript,
+  installManagedHooksIntoWslRuntime,
+  refreshWslRuntimeUserHooks
+}

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1,8 +1,9 @@
 /* eslint-disable max-lines -- Why: getStatus + install + remove all share the managed-command and trust-key derivation. Splitting would hide that the three operations must agree on group index, event label, and command bytes. */
 import { existsSync, readFileSync, unlinkSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, win32 as pathWin32 } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
@@ -121,6 +122,46 @@ function getManagedCommand(scriptPath: string): string {
   return process.platform === 'win32'
     ? wrapWindowsCmdHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
+}
+
+export type CodexWslRuntimeHookInstallPlan = {
+  configPath: string
+  tomlPath: string
+  scriptPath: string
+  commandScriptPath: string
+  trustConfigPath: string
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.length > 1 ? value.replace(/\/+$/, '') : value
+}
+
+export function createCodexWslRuntimeHookInstallPlan(
+  runtimeHomePath: string | null | undefined
+): CodexWslRuntimeHookInstallPlan | null {
+  if (!runtimeHomePath) {
+    return null
+  }
+  const wslInfo = parseWslUncPath(runtimeHomePath)
+  if (!wslInfo) {
+    return null
+  }
+
+  const linuxRuntimeHome = trimTrailingSlash(wslInfo.linuxPath)
+  return {
+    configPath: pathWin32.join(runtimeHomePath, 'hooks.json'),
+    tomlPath: pathWin32.join(runtimeHomePath, 'config.toml'),
+    scriptPath: pathWin32.join(runtimeHomePath, '.orca', 'agent-hooks', 'codex-hook.sh'),
+    commandScriptPath: `${linuxRuntimeHome}/.orca/agent-hooks/codex-hook.sh`,
+    trustConfigPath: `${linuxRuntimeHome}/hooks.json`
+  }
+}
+
+function wrapReadablePosixHookCommand(scriptPath: string): string {
+  const quoted = `'${scriptPath.replaceAll("'", "'\\''")}'`
+  // Why: WSL runtime hooks are written from Windows through UNC, where the
+  // executable bit is not reliable. /bin/sh only needs the script to be readable.
+  return `if [ -r ${quoted} ]; then /bin/sh ${quoted}; fi`
 }
 
 function getSystemConfigPath(): string {
@@ -662,6 +703,52 @@ function removeRuntimeManagedHookTrustEntries(configPath: string): void {
   }
 }
 
+function removeWslRuntimeManagedHookTrustEntries(plan: CodexWslRuntimeHookInstallPlan): void {
+  try {
+    const existingEntries = readHookTrustEntries(plan.tomlPath)
+    const command = wrapReadablePosixHookCommand(plan.commandScriptPath)
+    const managedEventLabels = new Set<CodexEventLabel>(
+      CODEX_EVENTS.map((event) => CODEX_EVENT_LABEL[event])
+    )
+    const canonicalConfigPath = getCodexCanonicalTrustPath(plan.trustConfigPath)
+    const ourKeys: string[] = []
+    for (const [key, state] of existingEntries) {
+      const parts = parseTrustKey(key)
+      if (parts === null) {
+        continue
+      }
+      if (getCodexCanonicalTrustPath(parts.sourcePath) !== canonicalConfigPath) {
+        continue
+      }
+      if (!managedEventLabels.has(parts.eventLabel)) {
+        continue
+      }
+      const expectedEntry: CodexTrustEntry = {
+        sourcePath: plan.trustConfigPath,
+        eventLabel: parts.eventLabel,
+        groupIndex: parts.groupIndex,
+        handlerIndex: parts.handlerIndex,
+        command,
+        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+      }
+      const recognizedHashes = new Set([
+        computeTrustedHash(expectedEntry),
+        computeTrustedHash({ ...expectedEntry, timeoutSec: undefined })
+      ])
+      if (state.trustedHash && recognizedHashes.has(state.trustedHash)) {
+        ourKeys.push(key)
+      }
+    }
+    if (ourKeys.length > 0) {
+      removeHookTrustEntries(plan.tomlPath, ourKeys)
+    }
+  } catch (error) {
+    // Why: removing disabled WSL status hooks should be best-effort like the
+    // host cleanup path; stale trust is inert once hooks.json no longer points at us.
+    console.warn('[codex-hook-service] failed to clean WSL trust entries', error)
+  }
+}
+
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
@@ -696,6 +783,10 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     'if [ -z "$payload" ]; then',
     '  exit 0',
     'fi',
+    'post_codex_hook() {',
+    '  curl_bin="$1"',
+    '  connect_timeout="${2:-0.5}"',
+    '  max_time="${3:-1.5}"',
     // Why: worktreeId embeds a filesystem path, so hand-building JSON in POSIX
     // shell is not safe once a path contains quotes or newlines. Post the raw
     // hook payload plus metadata as form fields and let the receiver parse it.
@@ -703,23 +794,160 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
     // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
     // command line (EDR command-line false positives). Wire body is identical.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/codex" \\',
-    '  --connect-timeout 0.5 --max-time 1.5 \\',
-    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
-    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
-    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
-    '  --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
-    '  --data-urlencode "launchToken=${ORCA_AGENT_LAUNCH_TOKEN}" \\',
-    '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
-    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
-    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  printf \'%s\' "$payload" | "$curl_bin" -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/codex" \\',
+    '    --connect-timeout "$connect_timeout" --max-time "$max_time" \\',
+    '    --noproxy "127.0.0.1" \\',
+    '    -H "Content-Type: application/x-www-form-urlencoded" \\',
+    '    -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
+    '    --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
+    '    --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
+    '    --data-urlencode "launchToken=${ORCA_AGENT_LAUNCH_TOKEN}" \\',
+    '    --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
+    '    --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
+    '    --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
+    '    --data-urlencode "payload@-"',
+    '}',
+    'is_wsl_runtime() {',
+    '  [ -n "$WSL_DISTRO_NAME" ] && return 0',
+    '  grep -qiE "microsoft|wsl" /proc/sys/kernel/osrelease /proc/version 2>/dev/null',
+    '}',
+    'if post_codex_hook curl >/dev/null 2>&1; then',
+    '  exit 0',
+    'fi',
+    'if is_wsl_runtime; then',
+    '  windows_curl=/mnt/c/Windows/System32/curl.exe',
+    '  if [ -x "$windows_curl" ]; then',
+    '    post_codex_hook "$windows_curl" 3 5 >/dev/null 2>&1 || true',
+    '  fi',
+    'fi',
     'exit 0',
     ''
   ].join('\n')
 }
 
+function installManagedHooksIntoWslRuntime(
+  plan: CodexWslRuntimeHookInstallPlan
+): AgentHookInstallStatus {
+  const config = readHooksJson(plan.configPath)
+  if (!config) {
+    return {
+      agent: 'codex',
+      state: 'error',
+      configPath: plan.configPath,
+      managedHooksPresent: false,
+      detail: 'Could not parse Codex hooks.json'
+    }
+  }
+
+  const isManagedCommand = createManagedCommandMatcher('codex-hook.sh')
+  const command = wrapReadablePosixHookCommand(plan.commandScriptPath)
+  const nextHooks = { ...config.hooks }
+  const managedEvents = new Set<string>(CODEX_EVENTS)
+  for (const [eventName, definitions] of Object.entries(nextHooks)) {
+    if (managedEvents.has(eventName) || !Array.isArray(definitions)) {
+      continue
+    }
+    const cleaned = removeManagedCommands(definitions, isManagedCommand)
+    if (cleaned.length === 0) {
+      delete nextHooks[eventName]
+    } else {
+      nextHooks[eventName] = cleaned
+    }
+  }
+
+  const trustEntries: CodexTrustEntry[] = []
+  for (const eventName of CODEX_EVENTS) {
+    const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
+    const cleaned = removeManagedCommands(current, isManagedCommand)
+    const definition: HookDefinition = {
+      hooks: [buildManagedCommandHook(command)]
+    }
+    nextHooks[eventName] = [definition, ...cleaned]
+    trustEntries.push({
+      sourcePath: plan.trustConfigPath,
+      eventLabel: CODEX_EVENT_LABEL[eventName],
+      groupIndex: 0,
+      handlerIndex: 0,
+      command,
+      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+    })
+  }
+
+  config.hooks = nextHooks
+  writeManagedScript(plan.scriptPath, getManagedScript('posix'))
+  writeCodexHooksJson(plan.configPath, nextHooks)
+  try {
+    // Why: WSL runtime homes may carry user hook approvals we did not rebuild
+    // here; only upsert Orca's entries instead of sweeping the whole source.
+    upsertHookTrustEntries(plan.tomlPath, trustEntries)
+  } catch (error) {
+    return {
+      agent: 'codex',
+      state: 'error',
+      configPath: plan.configPath,
+      managedHooksPresent: true,
+      detail: `Hooks installed but trust entries could not be written: ${error instanceof Error ? error.message : String(error)}. Run /hooks in Codex to approve.`
+    }
+  }
+
+  return {
+    agent: 'codex',
+    state: 'installed',
+    configPath: plan.configPath,
+    managedHooksPresent: true,
+    detail: null
+  }
+}
+
+function refreshWslRuntimeUserHooks(plan: CodexWslRuntimeHookInstallPlan): AgentHookInstallStatus {
+  const config = readHooksJson(plan.configPath)
+  if (!config) {
+    return {
+      agent: 'codex',
+      state: 'error',
+      configPath: plan.configPath,
+      managedHooksPresent: false,
+      detail: 'Could not parse Codex hooks.json'
+    }
+  }
+
+  const isManagedCommand = createManagedCommandMatcher('codex-hook.sh')
+  const nextHooks = { ...config.hooks }
+  for (const [eventName, definitions] of Object.entries(nextHooks)) {
+    if (!Array.isArray(definitions)) {
+      continue
+    }
+    const cleaned = removeManagedCommands(definitions, isManagedCommand)
+    if (cleaned.length === 0) {
+      delete nextHooks[eventName]
+    } else {
+      nextHooks[eventName] = cleaned
+    }
+  }
+  writeCodexHooksJson(plan.configPath, nextHooks)
+  removeWslRuntimeManagedHookTrustEntries(plan)
+  return {
+    agent: 'codex',
+    state: 'not_installed',
+    configPath: plan.configPath,
+    managedHooksPresent: false,
+    detail: null
+  }
+}
+
 export class CodexHookService {
+  installForRuntimeHome(runtimeHomePath: string | null | undefined): AgentHookInstallStatus | null {
+    const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath)
+    return wslPlan ? installManagedHooksIntoWslRuntime(wslPlan) : null
+  }
+
+  refreshRuntimeUserHooksForRuntimeHome(
+    runtimeHomePath: string | null | undefined
+  ): AgentHookInstallStatus | null {
+    const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath)
+    return wslPlan ? refreshWslRuntimeUserHooks(wslPlan) : null
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const scriptPath = getManagedScriptPath()

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-lines -- Why: getStatus + install + remove all share the managed-command and trust-key derivation. Splitting would hide that the three operations must agree on group index, event label, and command bytes. */
 import { existsSync, readFileSync, unlinkSync } from 'node:fs'
-import { join, win32 as pathWin32 } from 'node:path'
+import { join } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
-import { parseWslUncPath } from '../../shared/wsl-paths'
+import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
@@ -44,6 +44,10 @@ import {
 } from './config-toml-trust'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
 import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+import {
+  createCodexWslRuntimeHookInstallPlan,
+  type CodexWslRuntimeHookInstallPlan
+} from './codex-wsl-hook-install-plan'
 import {
   CODEX_HOOK_EVENT_LABEL,
   createCodexHookTrustEntry,
@@ -124,38 +128,8 @@ function getManagedCommand(scriptPath: string): string {
     : wrapPosixHookCommand(scriptPath)
 }
 
-export type CodexWslRuntimeHookInstallPlan = {
-  configPath: string
-  tomlPath: string
-  scriptPath: string
-  commandScriptPath: string
-  trustConfigPath: string
-}
-
-function trimTrailingSlash(value: string): string {
-  return value.length > 1 ? value.replace(/\/+$/, '') : value
-}
-
-export function createCodexWslRuntimeHookInstallPlan(
-  runtimeHomePath: string | null | undefined
-): CodexWslRuntimeHookInstallPlan | null {
-  if (!runtimeHomePath) {
-    return null
-  }
-  const wslInfo = parseWslUncPath(runtimeHomePath)
-  if (!wslInfo) {
-    return null
-  }
-
-  const linuxRuntimeHome = trimTrailingSlash(wslInfo.linuxPath)
-  return {
-    configPath: pathWin32.join(runtimeHomePath, 'hooks.json'),
-    tomlPath: pathWin32.join(runtimeHomePath, 'config.toml'),
-    scriptPath: pathWin32.join(runtimeHomePath, '.orca', 'agent-hooks', 'codex-hook.sh'),
-    commandScriptPath: `${linuxRuntimeHome}/.orca/agent-hooks/codex-hook.sh`,
-    trustConfigPath: `${linuxRuntimeHome}/hooks.json`
-  }
-}
+export { createCodexWslRuntimeHookInstallPlan }
+export type { CodexWslRuntimeHookInstallPlan }
 
 function wrapReadablePosixHookCommand(scriptPath: string): string {
   const quoted = `'${scriptPath.replaceAll("'", "'\\''")}'`
@@ -837,8 +811,8 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  exit 0',
     'fi',
     'if is_wsl_runtime; then',
-    '  windows_curl=/mnt/c/Windows/System32/curl.exe',
-    '  if [ -x "$windows_curl" ]; then',
+    '  windows_curl=$(command -v curl.exe 2>/dev/null || true)',
+    '  if [ -n "$windows_curl" ] && [ -x "$windows_curl" ]; then',
     '    post_codex_hook "$windows_curl" 3 5 >/dev/null 2>&1 || true',
     '  fi',
     'fi',
@@ -958,15 +932,19 @@ function refreshWslRuntimeUserHooks(plan: CodexWslRuntimeHookInstallPlan): Agent
 }
 
 export class CodexHookService {
-  installForRuntimeHome(runtimeHomePath: string | null | undefined): AgentHookInstallStatus | null {
-    const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath)
+  installForRuntimeHome(
+    runtimeHomePath: string | null | undefined,
+    target?: CodexAccountSelectionTarget
+  ): AgentHookInstallStatus | null {
+    const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target)
     return wslPlan ? installManagedHooksIntoWslRuntime(wslPlan) : null
   }
 
   refreshRuntimeUserHooksForRuntimeHome(
-    runtimeHomePath: string | null | undefined
+    runtimeHomePath: string | null | undefined,
+    target?: CodexAccountSelectionTarget
   ): AgentHookInstallStatus | null {
-    const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath)
+    const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target)
     return wslPlan ? refreshWslRuntimeUserHooks(wslPlan) : null
   }
 

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -3,7 +3,6 @@ import { existsSync, readFileSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
-import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
@@ -46,7 +45,8 @@ import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-hom
 import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
 import {
   createCodexWslRuntimeHookInstallPlan,
-  type CodexWslRuntimeHookInstallPlan
+  type CodexWslRuntimeHookInstallPlan,
+  type CodexWslRuntimeHookTarget
 } from './codex-wsl-hook-install-plan'
 import {
   CODEX_HOOK_EVENT_LABEL,
@@ -934,7 +934,7 @@ function refreshWslRuntimeUserHooks(plan: CodexWslRuntimeHookInstallPlan): Agent
 export class CodexHookService {
   installForRuntimeHome(
     runtimeHomePath: string | null | undefined,
-    target?: CodexAccountSelectionTarget
+    target?: CodexWslRuntimeHookTarget
   ): AgentHookInstallStatus | null {
     const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target)
     return wslPlan ? installManagedHooksIntoWslRuntime(wslPlan) : null
@@ -942,7 +942,7 @@ export class CodexHookService {
 
   refreshRuntimeUserHooksForRuntimeHome(
     runtimeHomePath: string | null | undefined,
-    target?: CodexAccountSelectionTarget
+    target?: CodexWslRuntimeHookTarget
   ): AgentHookInstallStatus | null {
     const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target)
     return wslPlan ? refreshWslRuntimeUserHooks(wslPlan) : null

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -122,6 +122,7 @@ import {
 } from './codex-accounts/runtime-selection'
 import { normalizeClaudeRuntimeSelection } from './claude-accounts/runtime-selection'
 import { codexHookService } from './codex/hook-service'
+import { getDefaultWslDistro } from './wsl'
 import { ClaudeAccountService } from './claude-accounts/service'
 import { ClaudeRuntimeAuthService } from './claude-accounts/runtime-auth-service'
 import {
@@ -694,14 +695,21 @@ async function startServeAgentHookServer(): Promise<void> {
 
 function prepareCodexRuntimeHomeForLaunch(target?: CodexAccountSelectionTarget): string | null {
   const runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target)
+  const hookTarget =
+    target?.runtime === 'wsl'
+      ? {
+          runtime: 'wsl' as const,
+          wslDistro: target.wslDistro?.trim() || getDefaultWslDistro()
+        }
+      : target
   const hooksEnabled = isAgentStatusHooksEnabled(store?.getSettings())
   try {
     // Why: launch prep is reachable after startup via PTY/runtime paths; honor
     // the persisted off switch so those launches cannot reinstall removed hooks.
     const status = hooksEnabled
-      ? (codexHookService.installForRuntimeHome(runtimeHomePath, target) ??
+      ? (codexHookService.installForRuntimeHome(runtimeHomePath, hookTarget) ??
         codexHookService.install())
-      : (codexHookService.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath, target) ??
+      : (codexHookService.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath, hookTarget) ??
         codexHookService.refreshRuntimeUserHooks())
     if (status.state === 'error') {
       console.warn(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -699,8 +699,9 @@ function prepareCodexRuntimeHomeForLaunch(target?: CodexAccountSelectionTarget):
     // Why: launch prep is reachable after startup via PTY/runtime paths; honor
     // the persisted off switch so those launches cannot reinstall removed hooks.
     const status = hooksEnabled
-      ? codexHookService.install()
-      : codexHookService.refreshRuntimeUserHooks()
+      ? (codexHookService.installForRuntimeHome(runtimeHomePath) ?? codexHookService.install())
+      : (codexHookService.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath) ??
+        codexHookService.refreshRuntimeUserHooks())
     if (status.state === 'error') {
       console.warn(
         `[codex-hook-service] failed to ${

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -699,8 +699,9 @@ function prepareCodexRuntimeHomeForLaunch(target?: CodexAccountSelectionTarget):
     // Why: launch prep is reachable after startup via PTY/runtime paths; honor
     // the persisted off switch so those launches cannot reinstall removed hooks.
     const status = hooksEnabled
-      ? (codexHookService.installForRuntimeHome(runtimeHomePath) ?? codexHookService.install())
-      : (codexHookService.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath) ??
+      ? (codexHookService.installForRuntimeHome(runtimeHomePath, target) ??
+        codexHookService.install())
+      : (codexHookService.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath, target) ??
         codexHookService.refreshRuntimeUserHooks())
     if (status.state === 'error') {
       console.warn(


### PR DESCRIPTION
﻿## Summary
- install Codex managed status hooks into Orca-managed WSL `CODEX_HOME` instead of falling back to the Windows host runtime hook install
- write WSL runtime hook commands with Linux paths and a readable-script `/bin/sh` wrapper for UNC-written files
- bridge WSL loopback failures by falling back from Linux `curl` to `/mnt/c/Windows/System32/curl.exe`
- add focused coverage for WSL hook path planning and POSIX fallback script generation

Fixes #6907

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex/hook-service-wsl-runtime.test.ts src/main/codex/hook-service.test.ts src/main/codex/hook-trust-promotion.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/codex/hook-service.ts src/main/index.ts src/main/codex/hook-service-wsl-runtime.test.ts`
- `pnpm exec oxfmt --check src/main/codex/hook-service.ts src/main/index.ts src/main/codex/hook-service-wsl-runtime.test.ts`

## Electron E2E
- Launched the dev app for this worktree with CDP and verified `window.api.app.getIdentity()` matched `Jinwoo-H/wsl-6907-codex-worktree-status`.
- Added a WSL-backed repo at `\\wsl.localhost\Ubuntu\home\jinwoo\orca-6907-e2e-20260709161127` and verified the active worktree/terminal in the sidebar.
- Verified the WSL runtime home had `hooks.json`, `config.toml`, and `.orca/agent-hooks/codex-hook.sh` under `\\wsl.localhost\Ubuntu\home\jinwoo\.local\share\orca\codex-runtime-home\home`, with hook commands using Linux paths.
- Ran the generated WSL hook script with Linux `curl` hidden from `PATH`; the script used the Windows curl fallback and posted a native Codex `UserPromptSubmit` form body to the live Electron app.
- Confirmed the visible sidebar row updated to `Working node spawned wsl hook to app 1783629054303 - Codex` and `last-status.json` contained the same prompt, WSL worktree id, launch token, and `agentType: "codex"`.
