### PR TITLE
feat(mobile): add host projects from the mobile app

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -44,6 +44,7 @@ import type { RpcSuccess } from '../../../src/transport/types'
 import { StatusDot } from '../../../src/components/StatusDot'
 import { NewWorktreeModalController } from '../../../src/components/NewWorktreeModalController'
 import { NewWorkspaceFab, FAB_SIZE } from '../../../src/components/NewWorkspaceFab'
+import { AddProjectIconButton, AddProjectModal } from '../../../src/components/AddProjectModal'
 import { MobileRepoIcon } from '../../../src/components/MobileRepoIcon'
 import { WorktreeListRow } from '../../../src/components/WorktreeListRow'
 import { useNow } from '../../../src/hooks/use-now'
@@ -181,6 +182,7 @@ export function HostScreen({
   const [showSortPicker, setShowSortPicker] = useState(false)
   const [showGroupPicker, setShowGroupPicker] = useState(false)
   const [showFilterModal, setShowFilterModal] = useState(false)
+  const [showAddProject, setShowAddProject] = useState(false)
   const [actionTarget, setActionTarget] = useState<Worktree | null>(null)
   const [hostCapabilities, setHostCapabilities] = useState<string[]>([])
   const [confirmDelete, setConfirmDelete] = useState<Worktree | null>(null)
@@ -1016,6 +1018,12 @@ export function HostScreen({
                 />
               </Pressable>
 
+              <AddProjectIconButton
+                style={styles.embeddedToolbarIconButton}
+                connected={connState === 'connected'}
+                onPress={() => setShowAddProject(true)}
+              />
+
               <Pressable
                 style={[
                   styles.embeddedToolbarIconButton,
@@ -1109,6 +1117,12 @@ export function HostScreen({
                 color={connState === 'connected' ? colors.textSecondary : colors.textMuted}
               />
             </Pressable>
+
+            <AddProjectIconButton
+              style={styles.searchToggle}
+              connected={connState === 'connected'}
+              onPress={() => setShowAddProject(true)}
+            />
 
             <Pressable style={styles.searchToggle} onPress={() => setShowSearch((s) => !s)}>
               {showSearch ? (
@@ -1419,6 +1433,13 @@ export function HostScreen({
         destructive
         onConfirm={() => void handleRemoveHost()}
         onCancel={() => setConfirmRemoveHost(false)}
+      />
+
+      <AddProjectModal
+        visible={showAddProject}
+        client={client}
+        onClose={() => setShowAddProject(false)}
+        onAdded={() => void fetchRepoMetadata({ force: true })}
       />
 
       <NewWorktreeModalController

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -1439,7 +1439,9 @@ export function HostScreen({
         visible={showAddProject}
         client={client}
         onClose={() => setShowAddProject(false)}
-        onAdded={() => void fetchRepoMetadata({ force: true })}
+        // Why: workspace sections come from worktree.ps, not repo.list; refresh
+        // both so the added project appears without waiting for the next poll.
+        onAdded={() => void Promise.all([fetchWorktrees(), fetchRepoMetadata({ force: true })])}
       />
 
       <NewWorktreeModalController

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -47,6 +47,7 @@ import { NewWorkspaceFab, FAB_SIZE } from '../../../src/components/NewWorkspaceF
 import { AddProjectIconButton, AddProjectModal } from '../../../src/components/AddProjectModal'
 import { MobileRepoIcon } from '../../../src/components/MobileRepoIcon'
 import { WorktreeListRow } from '../../../src/components/WorktreeListRow'
+import { WorkspaceListSeparator } from '../../../src/components/WorkspaceListSeparator'
 import { useNow } from '../../../src/hooks/use-now'
 import { useActiveWorktreeScroll } from '../../../src/hooks/use-active-worktree-scroll'
 import type { RepoIcon } from '../../../../src/shared/repo-icon'
@@ -1241,7 +1242,7 @@ export function HostScreen({
               </Pressable>
             )
           }}
-          ItemSeparatorComponent={ListSeparator}
+          ItemSeparatorComponent={WorkspaceListSeparator}
           renderItem={({ item }) => (
             <WorktreeListRow
               item={item}
@@ -1478,10 +1479,6 @@ export default function HostWorktreeRoute() {
   return <HostScreen />
 }
 
-function ListSeparator() {
-  return <View style={styles.separator} />
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -1693,12 +1690,6 @@ const styles = StyleSheet.create({
     fontSize: 11,
     color: colors.textMuted,
     marginLeft: spacing.xs
-  },
-  separator: {
-    height: 1,
-    backgroundColor: colors.borderSubtle,
-    marginLeft: spacing.lg + 24,
-    marginRight: spacing.lg
   },
   filterModalHeader: {
     flexDirection: 'row',

--- a/mobile/src/components/AddProjectModal.test.ts
+++ b/mobile/src/components/AddProjectModal.test.ts
@@ -10,16 +10,41 @@ type MockClient = {
   sendRequest: ReturnType<typeof vi.fn>
 }
 
-vi.mock('react-native', () => ({
-  ActivityIndicator: 'ActivityIndicator',
-  Pressable: 'Pressable',
-  StyleSheet: {
-    create: (styles: unknown) => styles,
-    hairlineWidth: 1
-  },
-  Text: 'Text',
-  View: 'View'
-}))
+vi.mock('react-native', async () => {
+  const React = await import('react')
+  return {
+    ActivityIndicator: 'ActivityIndicator',
+    FlatList: (props: {
+      data: unknown[]
+      keyExtractor: (item: unknown, index: number) => string
+      renderItem: (info: {
+        item: unknown
+        index: number
+        separators: Record<string, never>
+      }) => unknown
+      ListFooterComponent?: unknown
+    }) =>
+      React.createElement(
+        'FlatList',
+        props,
+        props.data.map((item, index) =>
+          React.createElement(
+            'FlatListItem',
+            { key: props.keyExtractor(item, index) },
+            props.renderItem({ item, index, separators: {} })
+          )
+        ),
+        props.ListFooterComponent ?? null
+      ),
+    Pressable: 'Pressable',
+    StyleSheet: {
+      create: (styles: unknown) => styles,
+      hairlineWidth: 1
+    },
+    Text: 'Text',
+    View: 'View'
+  }
+})
 
 vi.mock('lucide-react-native', () => ({
   ArrowUp: 'ArrowUp',
@@ -144,31 +169,27 @@ function renderedText(renderer: ReactTestRenderer): string {
     .join(' | ')
 }
 
-async function pressRowByText(renderer: ReactTestRenderer, text: string): Promise<void> {
+async function pressPressableWithText(
+  renderer: ReactTestRenderer,
+  matches: (text: string) => boolean,
+  label: string
+): Promise<void> {
   const pressable = renderer.root
     .findAllByType('Pressable')
-    .find((node) => node.findAllByType('Text').some((t) => textOf(t.props.children) === text))
+    .find((node) => node.findAllByType('Text').some((t) => matches(textOf(t.props.children))))
   if (!pressable) {
-    throw new Error(`Unable to find pressable row with text: ${text}`)
+    throw new Error(`Unable to find pressable: ${label}`)
   }
   await act(async () => {
     pressable.props.onPress()
   })
 }
 
-async function pressAddButton(renderer: ReactTestRenderer): Promise<void> {
-  const pressable = renderer.root
-    .findAllByType('Pressable')
-    .find((node) =>
-      node.findAllByType('Text').some((t) => textOf(t.props.children).startsWith('Add '))
-    )
-  if (!pressable) {
-    throw new Error('Unable to find the Add button')
-  }
-  await act(async () => {
-    pressable.props.onPress()
-  })
-}
+const pressRowByText = (renderer: ReactTestRenderer, text: string) =>
+  pressPressableWithText(renderer, (t) => t === text, `row "${text}"`)
+
+const pressAddButton = (renderer: ReactTestRenderer) =>
+  pressPressableWithText(renderer, (t) => t.startsWith('Add '), 'Add button')
 
 function defaultProps(client: MockClient | null): ModalProps {
   return { visible: true, client, onAdded: vi.fn(), onClose: vi.fn() }

--- a/mobile/src/components/AddProjectModal.test.ts
+++ b/mobile/src/components/AddProjectModal.test.ts
@@ -1,0 +1,350 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AddProjectModal } from './AddProjectModal'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcResponse } from '../transport/types'
+import type { DirEntry } from '../../../src/shared/types'
+
+type MockClient = {
+  sendRequest: ReturnType<typeof vi.fn>
+}
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  Pressable: 'Pressable',
+  StyleSheet: {
+    create: (styles: unknown) => styles,
+    hairlineWidth: 1
+  },
+  Text: 'Text',
+  View: 'View'
+}))
+
+vi.mock('lucide-react-native', () => ({
+  ArrowUp: 'ArrowUp',
+  ChevronRight: 'ChevronRight',
+  Folder: 'Folder',
+  FolderGit2: 'FolderGit2',
+  FolderPlus: 'FolderPlus'
+}))
+
+vi.mock('./BottomDrawer', async () => {
+  const React = await import('react')
+  return {
+    BottomDrawer: ({ visible, children }: { visible: boolean; children: unknown }) =>
+      visible ? React.createElement('BottomDrawer', null, children) : null
+  }
+})
+
+function suppressReactTestRendererDeprecationWarning(): () => void {
+  const originalConsoleError = console.error
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    const firstArg = args[0]
+    if (typeof firstArg === 'string' && firstArg.includes('react-test-renderer is deprecated')) {
+      return
+    }
+    originalConsoleError(...args)
+  })
+  return () => consoleErrorSpy.mockRestore()
+}
+
+function entry(name: string, isDirectory = true): DirEntry {
+  return { name, isDirectory, isSymlink: false }
+}
+
+function rpcOk(result: unknown): RpcResponse {
+  return { id: 'response-id', ok: true, result, _meta: { runtimeId: 'runtime-id' } }
+}
+
+function rpcError(message: string): RpcResponse {
+  return {
+    id: 'response-id',
+    ok: false,
+    error: { code: 'internal', message },
+    _meta: { runtimeId: 'runtime-id' }
+  }
+}
+
+type Listing = { resolvedPath: string; entries: DirEntry[] }
+
+function createMockClient(
+  listings: Record<string, Listing>,
+  onRepoAdd?: (params: Record<string, unknown>) => RpcResponse | Promise<RpcResponse>
+): MockClient {
+  return {
+    sendRequest: vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === 'files.browseServerDir') {
+        const listing = listings[params.path as string]
+        if (!listing) {
+          throw new Error(`No mock listing for path: ${String(params.path)}`)
+        }
+        return rpcOk(listing)
+      }
+      if (method === 'repo.add') {
+        return onRepoAdd ? onRepoAdd(params) : rpcOk({})
+      }
+      throw new Error(`Unexpected RPC method: ${method}`)
+    })
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+type ModalProps = {
+  visible: boolean
+  client: MockClient | null
+  onAdded: () => void
+  onClose: () => void
+}
+
+function modalElement(props: ModalProps) {
+  return createElement(AddProjectModal, {
+    ...props,
+    client: props.client as unknown as RpcClient | null
+  })
+}
+
+async function renderModal(props: ModalProps): Promise<ReactTestRenderer> {
+  let renderer: ReactTestRenderer | null = null
+  const restoreConsoleError = suppressReactTestRendererDeprecationWarning()
+  try {
+    await act(async () => {
+      renderer = create(modalElement(props))
+    })
+  } finally {
+    restoreConsoleError()
+  }
+  if (!renderer) {
+    throw new Error('AddProjectModal did not render')
+  }
+  return renderer
+}
+
+async function updateModal(renderer: ReactTestRenderer, props: ModalProps): Promise<void> {
+  await act(async () => {
+    renderer.update(modalElement(props))
+  })
+}
+
+function textOf(children: unknown): string {
+  return Array.isArray(children) ? children.join('') : String(children)
+}
+
+function renderedText(renderer: ReactTestRenderer): string {
+  return renderer.root
+    .findAllByType('Text')
+    .map((node) => textOf(node.props.children))
+    .join(' | ')
+}
+
+async function pressRowByText(renderer: ReactTestRenderer, text: string): Promise<void> {
+  const pressable = renderer.root
+    .findAllByType('Pressable')
+    .find((node) => node.findAllByType('Text').some((t) => textOf(t.props.children) === text))
+  if (!pressable) {
+    throw new Error(`Unable to find pressable row with text: ${text}`)
+  }
+  await act(async () => {
+    pressable.props.onPress()
+  })
+}
+
+async function pressAddButton(renderer: ReactTestRenderer): Promise<void> {
+  const pressable = renderer.root
+    .findAllByType('Pressable')
+    .find((node) =>
+      node.findAllByType('Text').some((t) => textOf(t.props.children).startsWith('Add '))
+    )
+  if (!pressable) {
+    throw new Error('Unable to find the Add button')
+  }
+  await act(async () => {
+    pressable.props.onPress()
+  })
+}
+
+function defaultProps(client: MockClient | null): ModalProps {
+  return { visible: true, client, onAdded: vi.fn(), onClose: vi.fn() }
+}
+
+describe('AddProjectModal', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('browses the host home on open and lists only visible folders', async () => {
+    const client = createMockClient({
+      '~': {
+        resolvedPath: '/Users/tester',
+        entries: [entry('projects'), entry('.hidden'), entry('notes.txt', false)]
+      }
+    })
+
+    const renderer = await renderModal(defaultProps(client))
+
+    expect(client.sendRequest).toHaveBeenCalledWith(
+      'files.browseServerDir',
+      { path: '~' },
+      { timeoutMs: 15_000 }
+    )
+    const text = renderedText(renderer)
+    expect(text).toContain('/Users/tester')
+    expect(text).toContain('projects')
+    expect(text).not.toContain('.hidden')
+    expect(text).not.toContain('notes.txt')
+    expect(text).toContain('Not a git repository — added as a folder project')
+    expect(text).toContain('Add "tester"')
+  })
+
+  it('navigates into folders and back up through the server-resolved .. path', async () => {
+    const client = createMockClient({
+      '~': { resolvedPath: '/Users/tester', entries: [entry('projects')] },
+      '/Users/tester/projects': {
+        resolvedPath: '/Users/tester/projects',
+        entries: [entry('orca')]
+      },
+      '/Users/tester/projects/..': { resolvedPath: '/Users/tester', entries: [entry('projects')] }
+    })
+
+    const renderer = await renderModal(defaultProps(client))
+
+    await pressRowByText(renderer, 'projects')
+    expect(renderedText(renderer)).toContain('orca')
+    expect(renderedText(renderer)).toContain('Add "projects"')
+
+    await pressRowByText(renderer, '..')
+    expect(client.sendRequest).toHaveBeenLastCalledWith(
+      'files.browseServerDir',
+      { path: '/Users/tester/projects/..' },
+      { timeoutMs: 15_000 }
+    )
+    expect(renderedText(renderer)).toContain('Add "tester"')
+  })
+
+  it('hides the up row at Unix and Windows filesystem roots', async () => {
+    const unixRoot = await renderModal(
+      defaultProps(createMockClient({ '~': { resolvedPath: '/', entries: [entry('home')] } }))
+    )
+    expect(renderedText(unixRoot)).not.toContain('..')
+
+    const windowsRoot = await renderModal(
+      defaultProps(createMockClient({ '~': { resolvedPath: 'C:\\', entries: [entry('Users')] } }))
+    )
+    expect(renderedText(windowsRoot)).not.toContain('..')
+
+    const windowsFolder = await renderModal(
+      defaultProps(
+        createMockClient({
+          '~': { resolvedPath: 'C:\\Users\\dev\\proj', entries: [] }
+        })
+      )
+    )
+    expect(renderedText(windowsFolder)).toContain('..')
+    expect(renderedText(windowsFolder)).toContain('Add "proj"')
+  })
+
+  it('detects a git repo from a .git entry (even a file) and adds with kind git', async () => {
+    const client = createMockClient({
+      '~': {
+        resolvedPath: '/Users/tester/repo',
+        // .git as a file covers worktrees/submodules; hidden entries are
+        // filtered from the rows but must still feed the git probe.
+        entries: [entry('.git', false), entry('src')]
+      }
+    })
+    const props = defaultProps(client)
+
+    const renderer = await renderModal(props)
+    expect(renderedText(renderer)).toContain('Git repository')
+
+    await pressAddButton(renderer)
+
+    expect(client.sendRequest).toHaveBeenLastCalledWith(
+      'repo.add',
+      { path: '/Users/tester/repo', kind: 'git' },
+      { timeoutMs: 30_000 }
+    )
+    expect(props.onClose).toHaveBeenCalledTimes(1)
+    expect(props.onAdded).toHaveBeenCalledTimes(1)
+  })
+
+  it('adds non-git folders with kind folder', async () => {
+    const client = createMockClient({
+      '~': { resolvedPath: '/Users/tester/notes', entries: [entry('drafts')] }
+    })
+    const props = defaultProps(client)
+
+    const renderer = await renderModal(props)
+    await pressAddButton(renderer)
+
+    expect(client.sendRequest).toHaveBeenLastCalledWith(
+      'repo.add',
+      { path: '/Users/tester/notes', kind: 'folder' },
+      { timeoutMs: 30_000 }
+    )
+    expect(props.onAdded).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the server error inline when add fails and keeps the modal open', async () => {
+    const client = createMockClient({ '~': { resolvedPath: '/Users/tester', entries: [] } }, () =>
+      rpcError('Path is not a git repository')
+    )
+    const props = defaultProps(client)
+
+    const renderer = await renderModal(props)
+    await pressAddButton(renderer)
+
+    expect(renderedText(renderer)).toContain('Path is not a git repository')
+    expect(props.onClose).not.toHaveBeenCalled()
+    expect(props.onAdded).not.toHaveBeenCalled()
+  })
+
+  it('ignores a stale repo.add completion after the drawer is closed and reopened', async () => {
+    const pendingAdd = deferred<RpcResponse>()
+    const client = createMockClient(
+      { '~': { resolvedPath: '/Users/tester', entries: [] } },
+      () => pendingAdd.promise
+    )
+    const props = defaultProps(client)
+
+    const renderer = await renderModal(props)
+    await pressAddButton(renderer)
+
+    // User closes the drawer while repo.add is still in flight, then reopens.
+    await updateModal(renderer, { ...props, visible: false })
+    await updateModal(renderer, { ...props, visible: true })
+
+    await act(async () => {
+      pendingAdd.resolve(rpcOk({}))
+      await pendingAdd.promise
+    })
+
+    // The stale completion must not close/refresh the reopened session.
+    expect(props.onClose).not.toHaveBeenCalled()
+    expect(props.onAdded).not.toHaveBeenCalled()
+    expect(renderedText(renderer)).toContain('Add "tester"')
+  })
+
+  it('caps the rendered folder list and reports the truncation', async () => {
+    const entries = Array.from({ length: 301 }, (_, i) =>
+      entry(`dir-${String(i).padStart(3, '0')}`)
+    )
+    const client = createMockClient({
+      '~': { resolvedPath: '/Users/tester', entries }
+    })
+
+    const renderer = await renderModal(defaultProps(client))
+
+    const text = renderedText(renderer)
+    expect(text).toContain('Showing 300 of 301 folders')
+    expect(text).toContain('dir-000')
+    expect(text).not.toContain('dir-300')
+  })
+})

--- a/mobile/src/components/AddProjectModal.tsx
+++ b/mobile/src/components/AddProjectModal.tsx
@@ -5,46 +5,77 @@ import {
   Pressable,
   StyleSheet,
   ActivityIndicator,
+  FlatList,
   type StyleProp,
   type ViewStyle
 } from 'react-native'
 import { ArrowUp, ChevronRight, Folder, FolderGit2, FolderPlus } from 'lucide-react-native'
 import type { RpcClient } from '../transport/rpc-client'
-import type { RpcSuccess } from '../transport/types'
+import type { RpcResponse, RpcSuccess } from '../transport/types'
 import type { DirEntry } from '../../../src/shared/types'
 import { colors, radii, spacing, typography } from '../theme/mobile-theme'
 import { BottomDrawer } from './BottomDrawer'
+import { pathBasename } from './path-basename'
 
 type BrowseListing = {
   resolvedPath: string
   entries: DirEntry[]
 }
 
-// Why: folders like node_modules can hold thousands of entries; cap what a
-// single drawer renders so a stray tap doesn't hang the JS thread.
+// Why: folders like node_modules can hold thousands of entries; even with a
+// virtualized list, cap the rows so absurd folders stay responsive.
 const MAX_VISIBLE_DIRECTORIES = 300
+
+// Sentinel row for "go up one level"; a real entry can never be named "..".
+const UP_ENTRY: DirEntry = { name: '..', isDirectory: true, isSymlink: false }
 
 function isFilesystemRoot(path: string): boolean {
   return path === '/' || /^[A-Za-z]:[\\/]?$/.test(path)
 }
 
-function folderBasename(path: string): string {
-  return /([^\\/]+)[\\/]*$/.exec(path)?.[1] ?? path
+// Why: browse and add must both discard completions that land after their
+// epoch was invalidated (a newer request, or the drawer being reopened) —
+// one guard, parameterized by which epoch invalidates it.
+async function runEpochGuardedRequest<T>(args: {
+  epochRef: { current: number }
+  epoch: number
+  setBusy: (busy: boolean) => void
+  setError: (message: string) => void
+  fallbackError: string
+  request: () => Promise<RpcResponse>
+  onSuccess: (result: T) => void
+}): Promise<void> {
+  const { epochRef, epoch } = args
+  args.setBusy(true)
+  args.setError('')
+  try {
+    const response = await args.request()
+    if (epochRef.current !== epoch) {
+      return
+    }
+    if (!response.ok) {
+      args.setError(response.error.message)
+      return
+    }
+    args.onSuccess((response as RpcSuccess).result as T)
+  } catch (e) {
+    if (epochRef.current === epoch) {
+      args.setError(e instanceof Error ? e.message : args.fallbackError)
+    }
+  } finally {
+    if (epochRef.current === epoch) {
+      args.setBusy(false)
+    }
+  }
 }
 
 type IconButtonProps = {
   connected: boolean
   onPress: () => void
   style: StyleProp<ViewStyle>
-  iconSize?: number
 }
 
-export function AddProjectIconButton({
-  connected,
-  onPress,
-  style,
-  iconSize = 16
-}: IconButtonProps) {
+export function AddProjectIconButton({ connected, onPress, style }: IconButtonProps) {
   return (
     <Pressable
       style={[style, !connected && styles.iconButtonDisabled]}
@@ -53,7 +84,7 @@ export function AddProjectIconButton({
       accessibilityRole="button"
       accessibilityLabel="Add project"
     >
-      <FolderPlus size={iconSize} color={connected ? colors.textSecondary : colors.textMuted} />
+      <FolderPlus size={16} color={connected ? colors.textSecondary : colors.textMuted} />
     </Pressable>
   )
 }
@@ -83,32 +114,16 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
       if (!client) {
         return
       }
-      const epoch = ++requestEpochRef.current
-      setLoading(true)
-      setError('')
-      try {
-        const response = await client.sendRequest(
-          'files.browseServerDir',
-          { path: target },
-          { timeoutMs: 15_000 }
-        )
-        if (requestEpochRef.current !== epoch) {
-          return
-        }
-        if (!response.ok) {
-          setError(response.error.message)
-          return
-        }
-        setListing((response as RpcSuccess).result as BrowseListing)
-      } catch (e) {
-        if (requestEpochRef.current === epoch) {
-          setError(e instanceof Error ? e.message : 'Failed to browse host folders')
-        }
-      } finally {
-        if (requestEpochRef.current === epoch) {
-          setLoading(false)
-        }
-      }
+      await runEpochGuardedRequest<BrowseListing>({
+        epochRef: requestEpochRef,
+        epoch: ++requestEpochRef.current,
+        setBusy: setLoading,
+        setError,
+        fallbackError: 'Failed to browse host folders',
+        request: () =>
+          client.sendRequest('files.browseServerDir', { path: target }, { timeoutMs: 15_000 }),
+        onSuccess: setListing
+      })
     },
     [client]
   )
@@ -133,43 +148,48 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
   )
   const visibleDirectories = directories.slice(0, MAX_VISIBLE_DIRECTORIES)
   const hasUpRow = path != null && !isFilesystemRoot(path)
+  const rows = hasUpRow ? [UP_ENTRY, ...visibleDirectories] : visibleDirectories
   const canAdd = path != null && !adding && !loading
 
   async function handleAdd() {
     if (!client || !path) {
       return
     }
-    const session = sessionEpochRef.current
-    setAdding(true)
-    setError('')
-    try {
-      const response = await client.sendRequest(
-        'repo.add',
-        { path, kind: isGitRepo ? 'git' : 'folder' },
-        { timeoutMs: 30_000 }
-      )
-      if (sessionEpochRef.current !== session) {
-        return
+    await runEpochGuardedRequest({
+      epochRef: sessionEpochRef,
+      epoch: sessionEpochRef.current,
+      setBusy: setAdding,
+      setError,
+      fallbackError: 'Failed to add project',
+      request: () =>
+        client.sendRequest(
+          'repo.add',
+          { path, kind: isGitRepo ? 'git' : 'folder' },
+          { timeoutMs: 30_000 }
+        ),
+      onSuccess: () => {
+        onClose()
+        onAdded()
       }
-      if (!response.ok) {
-        setError(response.error.message)
-        return
-      }
-      onClose()
-      onAdded()
-    } catch (e) {
-      if (sessionEpochRef.current === session) {
-        setError(e instanceof Error ? e.message : 'Failed to add project')
-      }
-    } finally {
-      if (sessionEpochRef.current === session) {
-        setAdding(false)
-      }
-    }
+    })
   }
 
+  const listFooter =
+    directories.length === 0 ? (
+      <Text style={styles.emptyDirText}>No subfolders</Text>
+    ) : directories.length > visibleDirectories.length ? (
+      <Text style={styles.truncatedText}>
+        Showing {visibleDirectories.length} of {directories.length} folders
+      </Text>
+    ) : null
+
   return (
-    <BottomDrawer visible={visible} onClose={onClose}>
+    <BottomDrawer
+      visible={visible}
+      onClose={onClose}
+      dragContentToDismiss={false}
+      contentScrollable={false}
+    >
       <View style={styles.header}>
         <Text style={styles.title}>Add Project</Text>
         <Text style={styles.subtitle}>Pick a folder on the host to add as a project.</Text>
@@ -184,57 +204,44 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
         ) : null}
       </View>
 
-      <View style={styles.listGroup}>
-        {listing == null ? (
-          <View style={styles.loadingContainer}>
-            {loading ? (
-              <ActivityIndicator size="small" color={colors.textSecondary} />
-            ) : (
-              <Text style={styles.emptyText}>Unable to browse host folders</Text>
-            )}
-          </View>
-        ) : (
-          <>
-            {hasUpRow ? (
-              <Pressable
-                style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-                // Why: the server resolves paths with platform-native
-                // path.resolve, and Windows accepts mixed separators, so
-                // joining with '/' is safe for both hosts.
-                onPress={() => void browse(`${path}/..`)}
-              >
+      {listing == null ? (
+        <View style={[styles.listGroup, styles.loadingContainer]}>
+          {loading ? (
+            <ActivityIndicator size="small" color={colors.textSecondary} />
+          ) : (
+            <Text style={styles.emptyText}>Unable to browse host folders</Text>
+          )}
+        </View>
+      ) : (
+        <FlatList
+          data={rows}
+          keyExtractor={(entry) => entry.name}
+          style={styles.listGroup}
+          keyboardShouldPersistTaps="handled"
+          nestedScrollEnabled
+          ItemSeparatorComponent={RowSeparator}
+          ListFooterComponent={listFooter}
+          renderItem={({ item }) => (
+            <Pressable
+              style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+              // Why: the server resolves paths with platform-native
+              // path.resolve, and Windows accepts mixed separators, so
+              // joining with '/' is safe for both hosts.
+              onPress={() => void browse(`${path}/${item.name}`)}
+            >
+              {item === UP_ENTRY ? (
                 <ArrowUp size={14} color={colors.textSecondary} />
-                <Text style={styles.rowText} numberOfLines={1}>
-                  ..
-                </Text>
-              </Pressable>
-            ) : null}
-            {visibleDirectories.map((entry, i) => (
-              <View key={entry.name}>
-                {(hasUpRow || i > 0) && <View style={styles.rowSeparator} />}
-                <Pressable
-                  style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-                  onPress={() => void browse(`${path}/${entry.name}`)}
-                >
-                  <Folder size={14} color={colors.textSecondary} />
-                  <Text style={styles.rowText} numberOfLines={1}>
-                    {entry.name}
-                  </Text>
-                  <ChevronRight size={14} color={colors.textMuted} />
-                </Pressable>
-              </View>
-            ))}
-            {directories.length > visibleDirectories.length ? (
-              <Text style={styles.truncatedText}>
-                Showing {visibleDirectories.length} of {directories.length} folders
+              ) : (
+                <Folder size={14} color={colors.textSecondary} />
+              )}
+              <Text style={styles.rowText} numberOfLines={1}>
+                {item.name}
               </Text>
-            ) : null}
-            {directories.length === 0 ? (
-              <Text style={styles.emptyDirText}>No subfolders</Text>
-            ) : null}
-          </>
-        )}
-      </View>
+              {item === UP_ENTRY ? null : <ChevronRight size={14} color={colors.textMuted} />}
+            </Pressable>
+          )}
+        />
+      )}
 
       {listing != null ? (
         <View style={styles.kindHint}>
@@ -261,13 +268,17 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
             <ActivityIndicator size="small" color={colors.bgBase} />
           ) : (
             <Text style={styles.addText} numberOfLines={1}>
-              {path ? `Add "${folderBasename(path)}"` : 'Add'}
+              {path ? `Add "${pathBasename(path) || path}"` : 'Add'}
             </Text>
           )}
         </Pressable>
       </View>
     </BottomDrawer>
   )
+}
+
+function RowSeparator() {
+  return <View style={styles.rowSeparator} />
 }
 
 const styles = StyleSheet.create({
@@ -305,6 +316,10 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgPanel,
     borderRadius: radii.input,
     overflow: 'hidden',
+    // Why: the drawer content is static (contentScrollable={false}); bound the
+    // list so it scrolls internally and the Add button stays reachable.
+    maxHeight: 420,
+    flexGrow: 0,
     marginBottom: spacing.md
   },
   loadingContainer: {

--- a/mobile/src/components/AddProjectModal.tsx
+++ b/mobile/src/components/AddProjectModal.tsx
@@ -1,0 +1,377 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ActivityIndicator,
+  type StyleProp,
+  type ViewStyle
+} from 'react-native'
+import { ArrowUp, ChevronRight, Folder, FolderGit2, FolderPlus } from 'lucide-react-native'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcSuccess } from '../transport/types'
+import type { DirEntry } from '../../../src/shared/types'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+import { BottomDrawer } from './BottomDrawer'
+
+type BrowseListing = {
+  resolvedPath: string
+  entries: DirEntry[]
+}
+
+// Why: folders like node_modules can hold thousands of entries; cap what a
+// single drawer renders so a stray tap doesn't hang the JS thread.
+const MAX_VISIBLE_DIRECTORIES = 300
+
+function isFilesystemRoot(path: string): boolean {
+  return path === '/' || /^[A-Za-z]:[\\/]?$/.test(path)
+}
+
+function folderBasename(path: string): string {
+  return /([^\\/]+)[\\/]*$/.exec(path)?.[1] ?? path
+}
+
+type IconButtonProps = {
+  connected: boolean
+  onPress: () => void
+  style: StyleProp<ViewStyle>
+  iconSize?: number
+}
+
+export function AddProjectIconButton({
+  connected,
+  onPress,
+  style,
+  iconSize = 16
+}: IconButtonProps) {
+  return (
+    <Pressable
+      style={[style, !connected && styles.iconButtonDisabled]}
+      onPress={onPress}
+      disabled={!connected}
+      accessibilityRole="button"
+      accessibilityLabel="Add project"
+    >
+      <FolderPlus size={iconSize} color={connected ? colors.textSecondary : colors.textMuted} />
+    </Pressable>
+  )
+}
+
+type Props = {
+  visible: boolean
+  client: RpcClient | null
+  onAdded: () => void
+  onClose: () => void
+}
+
+// Why: mobile has no native picker for the host's filesystem, so this drawer
+// browses it remotely via files.browseServerDir (the same RPC desktop uses
+// for SSH/runtime hosts) and registers the picked folder with repo.add.
+export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
+  const [listing, setListing] = useState<BrowseListing | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [adding, setAdding] = useState(false)
+  const [error, setError] = useState('')
+  const requestEpochRef = useRef(0)
+
+  const browse = useCallback(
+    async (target: string) => {
+      if (!client) {
+        return
+      }
+      const epoch = ++requestEpochRef.current
+      setLoading(true)
+      setError('')
+      try {
+        const response = await client.sendRequest(
+          'files.browseServerDir',
+          { path: target },
+          { timeoutMs: 15_000 }
+        )
+        if (requestEpochRef.current !== epoch) {
+          return
+        }
+        if (!response.ok) {
+          setError(response.error.message)
+          return
+        }
+        setListing((response as RpcSuccess).result as BrowseListing)
+      } catch (e) {
+        if (requestEpochRef.current === epoch) {
+          setError(e instanceof Error ? e.message : 'Failed to browse host folders')
+        }
+      } finally {
+        if (requestEpochRef.current === epoch) {
+          setLoading(false)
+        }
+      }
+    },
+    [client]
+  )
+
+  useEffect(() => {
+    if (!visible) {
+      return
+    }
+    // Each open is a fresh session starting from the host user's home.
+    setListing(null)
+    setAdding(false)
+    void browse('~')
+  }, [visible, browse])
+
+  const path = listing?.resolvedPath ?? null
+  // Why: .git can be a directory or a file (worktrees/submodules); either
+  // marks the folder as a git repo, which picks repo.add's kind.
+  const isGitRepo = listing?.entries.some((entry) => entry.name === '.git') ?? false
+  const directories = (listing?.entries ?? []).filter(
+    (entry) => entry.isDirectory && !entry.name.startsWith('.')
+  )
+  const visibleDirectories = directories.slice(0, MAX_VISIBLE_DIRECTORIES)
+  const hasUpRow = path != null && !isFilesystemRoot(path)
+  const canAdd = path != null && !adding && !loading
+
+  async function handleAdd() {
+    if (!client || !path) {
+      return
+    }
+    setAdding(true)
+    setError('')
+    try {
+      const response = await client.sendRequest(
+        'repo.add',
+        { path, kind: isGitRepo ? 'git' : 'folder' },
+        { timeoutMs: 30_000 }
+      )
+      if (!response.ok) {
+        setError(response.error.message)
+        return
+      }
+      onClose()
+      onAdded()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to add project')
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  return (
+    <BottomDrawer visible={visible} onClose={onClose}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Add Project</Text>
+        <Text style={styles.subtitle}>Pick a folder on the host to add as a project.</Text>
+      </View>
+
+      <View style={styles.pathRow}>
+        <Text style={styles.pathText} numberOfLines={1} ellipsizeMode="middle">
+          {path ?? ' '}
+        </Text>
+        {loading && listing ? (
+          <ActivityIndicator size="small" color={colors.textSecondary} />
+        ) : null}
+      </View>
+
+      <View style={styles.listGroup}>
+        {listing == null ? (
+          <View style={styles.loadingContainer}>
+            {loading ? (
+              <ActivityIndicator size="small" color={colors.textSecondary} />
+            ) : (
+              <Text style={styles.emptyText}>Unable to browse host folders</Text>
+            )}
+          </View>
+        ) : (
+          <>
+            {hasUpRow ? (
+              <Pressable
+                style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+                // Why: the server resolves paths with platform-native
+                // path.resolve, and Windows accepts mixed separators, so
+                // joining with '/' is safe for both hosts.
+                onPress={() => void browse(`${path}/..`)}
+              >
+                <ArrowUp size={14} color={colors.textSecondary} />
+                <Text style={styles.rowText} numberOfLines={1}>
+                  ..
+                </Text>
+              </Pressable>
+            ) : null}
+            {visibleDirectories.map((entry, i) => (
+              <View key={entry.name}>
+                {(hasUpRow || i > 0) && <View style={styles.rowSeparator} />}
+                <Pressable
+                  style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+                  onPress={() => void browse(`${path}/${entry.name}`)}
+                >
+                  <Folder size={14} color={colors.textSecondary} />
+                  <Text style={styles.rowText} numberOfLines={1}>
+                    {entry.name}
+                  </Text>
+                  <ChevronRight size={14} color={colors.textMuted} />
+                </Pressable>
+              </View>
+            ))}
+            {directories.length > visibleDirectories.length ? (
+              <Text style={styles.truncatedText}>
+                Showing {visibleDirectories.length} of {directories.length} folders
+              </Text>
+            ) : null}
+            {directories.length === 0 ? (
+              <Text style={styles.emptyDirText}>No subfolders</Text>
+            ) : null}
+          </>
+        )}
+      </View>
+
+      {listing != null ? (
+        <View style={styles.kindHint}>
+          {isGitRepo ? (
+            <FolderGit2 size={14} color={colors.statusGreen} />
+          ) : (
+            <Folder size={14} color={colors.textMuted} />
+          )}
+          <Text style={styles.kindHintText}>
+            {isGitRepo ? 'Git repository' : 'Not a git repository — added as a folder project'}
+          </Text>
+        </View>
+      ) : null}
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <View style={styles.actions}>
+        <Pressable
+          style={[styles.addButton, !canAdd && styles.addButtonDisabled]}
+          disabled={!canAdd}
+          onPress={() => void handleAdd()}
+        >
+          {adding ? (
+            <ActivityIndicator size="small" color={colors.bgBase} />
+          ) : (
+            <Text style={styles.addText} numberOfLines={1}>
+              {path ? `Add "${folderBasename(path)}"` : 'Add'}
+            </Text>
+          )}
+        </Pressable>
+      </View>
+    </BottomDrawer>
+  )
+}
+
+const styles = StyleSheet.create({
+  iconButtonDisabled: {
+    opacity: 0.6
+  },
+  header: {
+    paddingHorizontal: spacing.xs,
+    marginBottom: spacing.md
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.textPrimary
+  },
+  subtitle: {
+    fontSize: 13,
+    color: colors.textMuted,
+    marginTop: 2
+  },
+  pathRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.xs,
+    marginBottom: spacing.sm
+  },
+  pathText: {
+    flex: 1,
+    fontSize: 12,
+    fontFamily: typography.monoFamily,
+    color: colors.textSecondary
+  },
+  listGroup: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: radii.input,
+    overflow: 'hidden',
+    marginBottom: spacing.md
+  },
+  loadingContainer: {
+    paddingVertical: spacing.xl,
+    alignItems: 'center'
+  },
+  emptyText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize
+  },
+  emptyDirText: {
+    color: colors.textMuted,
+    fontSize: typography.bodySize,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  truncatedText: {
+    color: colors.textMuted,
+    fontSize: 12,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md + 2
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  rowPressed: {
+    backgroundColor: colors.bgRaised
+  },
+  rowText: {
+    flex: 1,
+    fontSize: typography.bodySize,
+    color: colors.textPrimary
+  },
+  rowSeparator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.borderSubtle,
+    marginHorizontal: spacing.md
+  },
+  kindHint: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.xs,
+    marginBottom: spacing.sm
+  },
+  kindHintText: {
+    flex: 1,
+    fontSize: 12,
+    color: colors.textSecondary
+  },
+  error: {
+    color: colors.statusRed,
+    fontSize: 13,
+    marginBottom: spacing.md
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: spacing.sm
+  },
+  addButton: {
+    backgroundColor: colors.textPrimary,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.button,
+    minWidth: 160,
+    maxWidth: '100%',
+    alignItems: 'center'
+  },
+  addButtonDisabled: {
+    opacity: 0.4
+  },
+  addText: {
+    color: colors.bgBase,
+    fontSize: typography.bodySize,
+    fontWeight: '600'
+  }
+})

--- a/mobile/src/components/AddProjectModal.tsx
+++ b/mobile/src/components/AddProjectModal.tsx
@@ -74,6 +74,9 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
   const [adding, setAdding] = useState(false)
   const [error, setError] = useState('')
   const requestEpochRef = useRef(0)
+  // Why: each drawer opening is a distinct session. An in-flight repo.add from
+  // a previous opening must not close/refresh the freshly reopened modal.
+  const sessionEpochRef = useRef(0)
 
   const browse = useCallback(
     async (target: string) => {
@@ -115,6 +118,7 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
       return
     }
     // Each open is a fresh session starting from the host user's home.
+    sessionEpochRef.current += 1
     setListing(null)
     setAdding(false)
     void browse('~')
@@ -135,6 +139,7 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
     if (!client || !path) {
       return
     }
+    const session = sessionEpochRef.current
     setAdding(true)
     setError('')
     try {
@@ -143,6 +148,9 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
         { path, kind: isGitRepo ? 'git' : 'folder' },
         { timeoutMs: 30_000 }
       )
+      if (sessionEpochRef.current !== session) {
+        return
+      }
       if (!response.ok) {
         setError(response.error.message)
         return
@@ -150,9 +158,13 @@ export function AddProjectModal({ visible, client, onAdded, onClose }: Props) {
       onClose()
       onAdded()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to add project')
+      if (sessionEpochRef.current === session) {
+        setError(e instanceof Error ? e.message : 'Failed to add project')
+      }
     } finally {
-      setAdding(false)
+      if (sessionEpochRef.current === session) {
+        setAdding(false)
+      }
     }
   }
 

--- a/mobile/src/components/WorkspaceListSeparator.tsx
+++ b/mobile/src/components/WorkspaceListSeparator.tsx
@@ -1,0 +1,16 @@
+import { View, StyleSheet } from 'react-native'
+import { colors, spacing } from '../theme/mobile-theme'
+
+// Row separator for the host workspace list; inset to align with row text.
+export function WorkspaceListSeparator() {
+  return <View style={styles.separator} />
+}
+
+const styles = StyleSheet.create({
+  separator: {
+    height: 1,
+    backgroundColor: colors.borderSubtle,
+    marginLeft: spacing.lg + 24,
+    marginRight: spacing.lg
+  }
+})

--- a/mobile/src/components/path-basename.ts
+++ b/mobile/src/components/path-basename.ts
@@ -1,0 +1,12 @@
+// Why: cross-platform path basename — handles both POSIX ("/") and Windows
+// ("\\") separators, mirroring src/renderer/src/lib/path.ts so mobile path
+// display and collision checks agree with the desktop.
+function stripTrailingSeparators(p: string): string {
+  return p.replace(/[\\/]+$/, '')
+}
+
+export function pathBasename(p: string): string {
+  const normalized = stripTrailingSeparators(p)
+  const idx = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+  return idx === -1 ? normalized : normalized.slice(idx + 1)
+}

--- a/mobile/src/components/worktree-name-suggestion.ts
+++ b/mobile/src/components/worktree-name-suggestion.ts
@@ -1,23 +1,11 @@
 import { MARINE_CREATURES } from '../constants/marine-creatures'
+import { pathBasename } from './path-basename'
 
 // Why: matches the desktop fallback in
 // src/renderer/src/components/sidebar/worktree-name-suggestions.ts. The
 // "already exists locally" collision is on the on-disk worktree directory
 // name (the path basename), not the user-facing displayName — so we derive
 // the used set from path basenames just like the desktop does.
-
-function stripTrailingSeparators(p: string): string {
-  return p.replace(/[\\/]+$/, '')
-}
-
-// Why: cross-platform path basename — handles both POSIX ("/") and Windows
-// ("\\") separators, mirroring src/renderer/src/lib/path.ts so the mobile
-// suggestion logic agrees with the desktop's collision check.
-function pathBasename(p: string): string {
-  const normalized = stripTrailingSeparators(p)
-  const idx = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
-  return idx === -1 ? normalized : normalized.slice(idx + 1)
-}
 
 function normalize(name: string): string {
   return name.trim().toLowerCase()

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -285,6 +285,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'preflight.detectAgents',
   'preflight.detectRemoteAgents',
   'projectGroup.list',
+  'repo.add',
   'repo.baseRefDefault',
   'repo.gitAvailable',
   'repo.hooks',


### PR DESCRIPTION
## Summary

The mobile app can only operate on projects that were already registered from the desktop. This PR adds an **"Add project"** button to the mobile workspace-list toolbar (both the phone toolbar and the embedded/tablet sidebar variant) that lets you register a new project on the paired host directly from the phone:

- A bottom drawer browses the **host's** filesystem remotely via the existing `files.browseServerDir` RPC (the same one the desktop uses for its SSH/runtime folder picker), starting at the host user's home. Navigation is tap-to-enter plus a `..` row; hidden dot-folders are filtered out and rendering is capped at 300 entries per folder.
- The current folder's kind is detected client-side (a `.git` entry — dir or file, so worktrees/submodules count) and shown inline: a green "Git repository" badge, or "Not a git repository — added as a folder project".
- Confirming calls `repo.add` with the resolved absolute path and the detected kind, then refreshes both `worktree.ps` and `repo.list`, so the project appears immediately in the workspace list (and on the desktop, since both read the same store).

One server-side line is required: `repo.add` joins `MOBILE_RPC_METHOD_ALLOWLIST` in `src/main/runtime/runtime-rpc.ts`. Mobile-scoped device tokens were not authorized to call it (the guard test `mobile-rpc-allowlist.test.ts` now enforces this pairing). Everything else — transport, auth, `repo.add`, `files.browseServerDir` — already existed; the change is mobile UI plus that authorization.

## Screenshots

Posted in the first comment below (validated end-to-end on the iOS simulator against a runtime built from this branch: browse home → open a test git repo → git badge shown → Add → repo appears in the workspace list and in the host's `repo list`).

## Testing

- [x] `pnpm lint` — mobile `pnpm lint` (oxlint) and `pnpm format:check` pass. Root `pnpm lint` fails only on the pre-existing `src/main/ipc/notification-authorization-status.ts:71` switch-exhaustiveness error, which is untouched by this PR and reproduces on a clean `main` checkout.
- [x] `pnpm typecheck` — root passes; mobile `tsc --noEmit` passes.
- [x] `pnpm test` — full mobile suite: 178 files, 1275 passed / 2 skipped. Desktop side: `mobile-rpc-allowlist.test.ts` (3 tests, includes the new `repo.add` entry) and the `runtime-rpc` suite (39 tests) pass. Full root suite not run.
- [x] `pnpm build` — `build:cli` + `build:electron-vite` built successfully (used to run the E2E validation runtime); full `build:desktop` not run.
- [x] `pnpm check:max-lines-ratchet` passes — `app/h/*/index.tsx` is capped at 1603 counted lines, so the modal and its toolbar button live in a new `AddProjectModal.tsx` and the screen integration was kept to +21 lines.
- [x] New unit tests: `mobile/src/components/AddProjectModal.test.ts` (8 tests, react-test-renderer) covers home browse + dot-folder filtering, folder/`..` navigation, Unix/Windows root detection, `.git` kind detection (including `.git`-as-file), `repo.add` success/error paths, the 300-entry render cap, and a regression test for the stale `repo.add` completion guard (verified to fail against the pre-guard version). The allowlist regression is covered by the existing `mobile-rpc-allowlist.test.ts` guard. Behavior was also verified end-to-end on the iOS simulator (screenshots below), including the non-git folder fallback and the server-error path.

## AI Review Report

Reviewed with Claude Code. Checks performed:

- **Cross-platform (macOS/Linux/Windows hosts)**: the client joins browse paths with `/`, which is safe because `files.browseServerDir` resolves with the host's platform-native `path.resolve` and Windows accepts mixed separators; `..` navigation reuses the same server resolution instead of client-side path math. `isFilesystemRoot` recognizes both `/` and `X:\` drive roots so the up-row hides correctly on Windows hosts. No shortcuts, labels, or local path handling involved.
- **SSH/remote/local**: browsing and `repo.add` both execute on the paired host over the existing E2EE WebSocket RPC — no assumption of local execution. Registering *SSH-remote* repos (`repos:addRemote`) remains a desktop-only flow and is intentionally out of scope.
- **Git-provider neutrality**: nothing provider-specific; kind detection is a filesystem `.git` check and the server re-validates git-ness in `runtime.addRepo`.
- **Back-compat**: against an older desktop whose allowlist lacks `repo.add`, the button and browsing still work and the Add action surfaces the server's "not available to mobile clients" error inline in the drawer — graceful, no crash.
- **Performance**: folder rendering is capped at `MAX_VISIBLE_DIRECTORIES = 300` with an explicit "Showing N of M" line (no silent truncation); a request-epoch ref discards stale browse responses; the post-add `repo.list` refresh reuses the screen's existing throttled fetch with `force`.
- **UI quality**: reuses `BottomDrawer`, existing theme tokens, and the row/button styles of `NewWorktreeModal`/`PickerListDrawer`; disabled state follows the toolbar's existing color+opacity convention.
- Flagged and fixed during review: separator rendering at the top of the list when the up-row is hidden, and `AXPress`/accessibility labels on the toolbar button.

## Security Audit

- **Authorization surface**: the only server change is authorizing `repo.add` for mobile-scoped device tokens. Mobile pairing is already trusted with comparable or stronger mutations (`worktree.create`/`rm`, `git.push`, `files.writeTerminalArtifact`), and `files.browseServerDir` was already mobile-allowlisted, so this does not extend the existing trust model — it lets an already-paired device register a folder the host user can already see.
- **Input handling**: the client only ever sends paths derived from server-returned `resolvedPath` values plus entry names. Server-side validation is unchanged: `repo.add` rejects non-absolute paths and non-git paths for `kind: 'git'`; `browseServerDir` rejects null bytes and anchors relative input to the host home. Duplicate adds are idempotent (server returns the existing repo).
- No command execution, no new dependencies, no secrets displayed or logged; errors shown in the UI are the server's own RPC error messages rendered as plain `Text`.

## Notes

- Requires a desktop build that includes this PR's allowlist line; older desktops degrade to an inline error on Add (browse still works since `files.browseServerDir` was already allowlisted).
- Hidden (dot-prefixed) folders are not listed in the browser; the `.git` probe uses the unfiltered listing.
- Follow-up candidates (not in this PR): clone-by-URL (`repo.clone` is registered server-side but not mobile-allowlisted), create-new-folder (`repo.create`), and SSH-remote project registration.
- X handle: @kaynansc

https://claude.ai/code/session_01BUVtVd7FxdvLodgUBdgyTi

## ELI5

From the mobile app you can add a project on the paired host instead of only using projects already registered on desktop. A drawer browses the host filesystem remotely and registers the folder for use on the phone.
