### PR TITLE
fix(windows): open WSL workspaces in VS Code remote

### DIFF
--- a/docs/issue-7649-vscode-wsl-launch.md
+++ b/docs/issue-7649-vscode-wsl-launch.md
@@ -1,0 +1,95 @@
+# VS Code WSL Workspace Launch
+
+## Problem
+
+On Windows, choosing **Open in VS Code** for a workspace stored under a WSL UNC path opens the folder in a Windows VS Code environment instead of a Remote - WSL window ([issue #7649](https://github.com/stablyai/orca/issues/7649)). The renderer passes the workspace path and configured editor command unchanged (`src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx:103-121`), and the main process delegates launch argument construction to `resolveExternalEditorLaunchSpec` (`src/main/ipc/shell.ts:101-110`). The builder currently gives every non-Cursor executable only the original path (`src/main/external-editor-launch.ts:109-116`).
+
+The deterministic reproduction for `\\wsl.localhost\Ubuntu\home\aliuq\project` produces `code <UNC path>` with no remote authority. VS Code's supported Windows CLI form is `code --remote wsl+<distro> <Linux path>`.
+
+## Root cause
+
+`resolveExternalEditorLaunchSpec` does not distinguish a VS Code launch targeting a WSL UNC workspace. Orca already has a shared parser for both modern `\\wsl.localhost\...` and legacy `\\wsl$\...` paths (`src/shared/wsl-paths.ts:1-20`), but the editor launcher never uses it. VS Code therefore receives the Windows-visible UNC folder and correctly opens it as a local Windows workspace.
+
+## Non-goals
+
+- Change the Open in menu, settings UI, IPC payload, file-manager behavior, or SSH/remote-runtime behavior.
+- Infer WSL identity for ordinary drive-letter paths from project runtime settings.
+- Rewrite user-defined compound shell commands or add remote flags to Cursor, VSCodium, or arbitrary editors.
+- Install or configure the VS Code WSL extension.
+
+## Design
+
+1. In the external-editor launch-spec builder, parse the target path with the shared WSL UNC parser when the host platform is Windows.
+2. For direct/executable VS Code launchers only, reuse the existing normalized launcher-basename check and translate a recognized WSL target into `['--remote', 'wsl+<distro>', '<linuxPath>']`. The match is case-insensitive and strips every Windows launcher suffix already supported by Orca (`.cmd`, `.exe`, and `.bat`), so direct paths such as `Code.exe` and resolved shims such as `CODE.CMD` or `code.bat` all identify as basename `code`.
+3. Keep local paths, non-Windows hosts, non-VS-Code applications, and compound commands on their existing argument paths. The existing main-process spawn and Windows shim handling remain unchanged.
+4. Replace the temporary reproduction harness with focused regression cases in `src/main/external-editor-launch.test.ts` covering modern and legacy WSL UNC forms plus unaffected local/custom-editor behavior.
+
+## Data flow
+
+- Worktree menu selects VS Code and sends `(workspacePath, 'code')` over existing IPC.
+- Main process validates the absolute existing host path.
+- Launch-spec builder resolves the VS Code executable.
+- On Windows + WSL UNC + VS Code, the builder emits the Remote - WSL authority and Linux-native folder path.
+- Existing Windows spawn wrapping launches VS Code with those arguments.
+
+## Edge cases
+
+- Modern `\\wsl.localhost\<distro>\...` and legacy `\\wsl$\<distro>\...` paths both preserve the distro spelling and convert separators to a POSIX path.
+- Distro names and Linux folder paths containing spaces remain single arguments because launch-spec construction and Windows shim wrapping preserve argument-array boundaries.
+- A WSL distro root maps to `/`.
+- Windows drive-letter and ordinary UNC paths stay local.
+- macOS/Linux behavior stays unchanged even for strings that resemble WSL UNC paths.
+- Cursor retains `--new-window`; other custom editors retain their existing single path argument.
+- Compound commands remain user-owned and are not rewritten because inserting flags safely would require parsing arbitrary shell syntax.
+- SSH and remote-runtime workspaces remain blocked from local path opening by the existing renderer guard; this change does not alter that boundary.
+- If the VS Code WSL extension is unavailable, launch behavior is left to VS Code and Orca retains its existing spawn-success contract.
+
+## Test plan
+
+- Unit: demonstrate the pre-fix launch spec lacks `--remote` for a modern WSL UNC path.
+- Unit: assert the fixed modern UNC launch is `--remote`, `wsl+Ubuntu`, `/home/...`.
+- Unit: assert legacy `\\wsl$` and distro-root paths produce the same Remote - WSL form.
+- Unit: assert direct and resolved Windows VS Code launchers are matched case-insensitively across `.exe`, `.cmd`, and `.bat` suffixes.
+- Unit: assert distro names and Linux folder paths containing spaces remain intact arguments through launch-spec construction and Windows shim forwarding.
+- Unit: assert a Windows local path remains unchanged and explicit `darwin` and `linux` hosts do not acquire WSL remote arguments.
+- Unit: assert Cursor and another custom editor are not given VS Code remote arguments.
+- Integration/Electron: create a throwaway repo in the installed Ubuntu WSL distro, add/open it in Orca, choose Open in VS Code, and verify the VS Code remote indicator and an integrated-terminal Linux probe.
+- Adjacent smoke: open a local Windows workspace in VS Code and verify it remains a local Windows window.
+- Repository gates: focused Vitest files, `pnpm typecheck`, `pnpm lint`, and `pnpm check:max-lines-ratchet`.
+
+## UI quality bar
+
+Not UI-visible in Orca. The existing menu, labels, loading behavior, and errors do not change. The user-visible acceptance criterion is external: the launched VS Code window must identify the selected WSL distro and its terminal must run Linux.
+
+## Review screenshots
+
+1. Golden path: VS Code opened from a throwaway WSL workspace, showing the Remote - WSL indicator and a terminal Linux probe.
+2. Adjacent local path: VS Code opened from a local Windows workspace, showing a local Windows terminal/environment.
+
+## Rollout
+
+1. Add launch-spec regression tests and observe the WSL case fail against the desired arguments.
+2. Add the scoped VS Code + Windows + WSL argument translation.
+3. Run focused and repository-wide static/test gates.
+4. Validate WSL and local launches end to end, retaining local screenshots outside the PR.
+
+## Lightweight Eng Review
+
+- Scope: Kept to the launch-spec seam; no renderer, IPC, persistence, runtime-routing, or settings changes are needed because WSL filesystem identity is encoded in the UNC path.
+- Architecture/data flow: Reuse `parseWslUncPath` in the main-process pure argument builder, then leave executable resolution, Windows shim wrapping, spawn lifecycle, and renderer guards unchanged.
+- Failure modes covered:
+  - Modern and legacy WSL UNC aliases route to the correct distro and Linux path.
+  - Local/ordinary UNC paths and non-Windows platforms do not acquire remote flags.
+  - Case variants and supported Windows VS Code shim suffixes are recognized without classifying custom editors or compound shell commands as VS Code.
+  - Distro and folder names containing spaces survive the Windows shim as distinct arguments.
+  - Missing VS Code WSL support still follows the existing launch contract rather than adding a new partial-failure protocol.
+- Test coverage required:
+  - Pure launch-spec regression cases in `src/main/external-editor-launch.test.ts` for WSL aliases/root, launcher case/suffix variants, and unaffected branches.
+  - `src/main/ipc/shell.test.ts` plus the existing Windows shim contract to prove remote arguments, including spaces, are forwarded as distinct values.
+  - Live Windows + Ubuntu WSL + VS Code smoke for the actual environment boundary.
+- Performance/blast radius: One regex parse per external-editor click only; no startup, polling, watcher, terminal, or renderer cost. Blast radius is limited to direct VS Code launches of WSL UNC paths on Windows.
+- UI quality bar: Not UI-visible in Orca; VS Code must visibly attach to the requested WSL distro and run a Linux terminal.
+- Required review screenshots:
+  1. WSL VS Code window with distro indicator and Linux terminal probe.
+  2. Local Windows VS Code window demonstrating unchanged local launch behavior.
+- Residual risks: VS Code without the WSL extension may reject or prompt on the valid remote launch; this is external dependency behavior and should not cause Orca to fall back silently to the wrong Windows environment.

--- a/docs/issue-7649-vscode-wsl-launch.md
+++ b/docs/issue-7649-vscode-wsl-launch.md
@@ -20,7 +20,7 @@ The deterministic reproduction for `\\wsl.localhost\Ubuntu\home\aliuq\project` p
 ## Design
 
 1. In the external-editor launch-spec builder, parse the target path with the shared WSL UNC parser when the host platform is Windows.
-2. For direct/executable VS Code launchers only, reuse the existing normalized launcher-basename check and translate a recognized WSL target into `['--remote', 'wsl+<distro>', '<linuxPath>']`. The match is case-insensitive and strips every Windows launcher suffix already supported by Orca (`.cmd`, `.exe`, and `.bat`), so direct paths such as `Code.exe` and resolved shims such as `CODE.CMD` or `code.bat` all identify as basename `code`.
+2. For direct/executable VS Code Stable or Insiders launchers only, reuse the existing normalized launcher-basename check and translate a recognized WSL target into `['--remote', 'wsl+<distro>', '<linuxPath>']`. The exact allowlist recognizes Stable's `code`, Insiders' `code-insiders`, and the direct `Code - Insiders.exe` basename without matching unrelated `code-*` editors. Matching is case-insensitive and strips every Windows launcher suffix already supported by Orca (`.cmd`, `.exe`, and `.bat`).
 3. Keep local paths, non-Windows hosts, non-VS-Code applications, and compound commands on their existing argument paths. The existing main-process spawn and Windows shim handling remain unchanged.
 4. Replace the temporary reproduction harness with focused regression cases in `src/main/external-editor-launch.test.ts` covering modern and legacy WSL UNC forms plus unaffected local/custom-editor behavior.
 
@@ -49,7 +49,7 @@ The deterministic reproduction for `\\wsl.localhost\Ubuntu\home\aliuq\project` p
 - Unit: demonstrate the pre-fix launch spec lacks `--remote` for a modern WSL UNC path.
 - Unit: assert the fixed modern UNC launch is `--remote`, `wsl+Ubuntu`, `/home/...`.
 - Unit: assert legacy `\\wsl$` and distro-root paths produce the same Remote - WSL form.
-- Unit: assert direct and resolved Windows VS Code launchers are matched case-insensitively across `.exe`, `.cmd`, and `.bat` suffixes.
+- Unit: assert direct and resolved Windows VS Code Stable and Insiders launchers are matched case-insensitively across `.exe`, `.cmd`, and `.bat` suffixes.
 - Unit: assert distro names and Linux folder paths containing spaces remain intact arguments through launch-spec construction and Windows shim forwarding.
 - Unit: assert a Windows local path remains unchanged and explicit `darwin` and `linux` hosts do not acquire WSL remote arguments.
 - Unit: assert Cursor and another custom editor are not given VS Code remote arguments.

--- a/src/main/external-editor-launch.test.ts
+++ b/src/main/external-editor-launch.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { resolveCliCommandMock } = vi.hoisted(() => ({
+  resolveCliCommandMock: vi.fn((command: string) => command)
+}))
+
+vi.mock('./codex-cli/command', () => ({
+  resolveCliCommand: resolveCliCommandMock
+}))
+
 import { getCmdExePath } from './win32-utils'
 import { resolveExternalEditorLaunchSpec } from './external-editor-launch'
 
 describe('resolveExternalEditorLaunchSpec', () => {
+  beforeEach(() => {
+    resolveCliCommandMock.mockReset()
+    resolveCliCommandMock.mockImplementation((command: string) => command)
+  })
+
   it('keeps simple CLI commands on the executable launch path', () => {
     const spec = resolveExternalEditorLaunchSpec('cursor', '/tmp/workspace', {
       platform: 'darwin'
@@ -119,6 +133,115 @@ describe('resolveExternalEditorLaunchSpec', () => {
       hideWindowsConsole: false,
       spawnCmd: getCmdExePath(),
       spawnArgs: ['/d', '/s', '/c', 'nvim --clean C:\\workspaces\\orca']
+    })
+  })
+
+  it('opens modern WSL UNC workspaces in the matching VS Code remote', () => {
+    expect(
+      resolveExternalEditorLaunchSpec('code', '\\\\wsl.localhost\\Ubuntu\\home\\aliuq\\project', {
+        platform: 'win32'
+      }).spawnArgs
+    ).toEqual(['--remote', 'wsl+Ubuntu', '/home/aliuq/project'])
+  })
+
+  it.each([
+    [
+      'legacy WSL UNC workspace',
+      '\\\\wsl$\\Debian\\home\\ada\\project',
+      'wsl+Debian',
+      '/home/ada/project'
+    ],
+    ['modern WSL distro root', '\\\\wsl.localhost\\Ubuntu', 'wsl+Ubuntu', '/'],
+    ['legacy WSL distro root', '\\\\wsl$\\Debian', 'wsl+Debian', '/']
+  ])('opens a %s in the matching VS Code remote', (_label, pathValue, authority, linuxPath) => {
+    expect(
+      resolveExternalEditorLaunchSpec('code', pathValue, { platform: 'win32' }).spawnArgs
+    ).toEqual(['--remote', authority, linuxPath])
+  })
+
+  it.each([
+    'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+    'C:\\Tools\\CODE.CMD',
+    'C:\\Tools\\code.bat'
+  ])('recognizes the direct Windows VS Code launcher %s', (editorCommand) => {
+    expect(
+      resolveExternalEditorLaunchSpec(
+        editorCommand,
+        '\\\\wsl.localhost\\Ubuntu\\home\\ada\\project',
+        { platform: 'win32' }
+      ).spawnArgs
+    ).toEqual(['--remote', 'wsl+Ubuntu', '/home/ada/project'])
+  })
+
+  it.each(['C:\\Tools\\CODE.CMD', 'C:\\Tools\\code.bat'])(
+    'recognizes the resolved Windows VS Code launcher %s',
+    (resolvedCommand) => {
+      resolveCliCommandMock.mockReturnValueOnce(resolvedCommand)
+
+      expect(
+        resolveExternalEditorLaunchSpec('code', '\\\\wsl.localhost\\Ubuntu\\home\\ada\\project', {
+          platform: 'win32'
+        })
+      ).toEqual({
+        kind: 'executable',
+        hideWindowsConsole: true,
+        spawnCmd: resolvedCommand,
+        spawnArgs: ['--remote', 'wsl+Ubuntu', '/home/ada/project']
+      })
+    }
+  )
+
+  it('preserves spaces in WSL distro and folder arguments', () => {
+    expect(
+      resolveExternalEditorLaunchSpec(
+        'code',
+        '\\\\wsl.localhost\\Ubuntu Preview\\home\\Ada Lovelace\\project',
+        { platform: 'win32' }
+      ).spawnArgs
+    ).toEqual(['--remote', 'wsl+Ubuntu Preview', '/home/Ada Lovelace/project'])
+  })
+
+  it.each(['darwin', 'linux'] as const)('keeps WSL-looking paths local on %s', (platform) => {
+    const pathValue = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\project'
+    expect(resolveExternalEditorLaunchSpec('code', pathValue, { platform }).spawnArgs).toEqual([
+      pathValue
+    ])
+  })
+
+  it.each(['C:\\workspaces\\orca', '\\\\server\\share\\project'])(
+    'keeps the non-WSL Windows path %s local',
+    (pathValue) => {
+      expect(
+        resolveExternalEditorLaunchSpec('code', pathValue, { platform: 'win32' }).spawnArgs
+      ).toEqual([pathValue])
+    }
+  )
+
+  it('does not add VS Code remote arguments to other editors', () => {
+    const pathValue = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\project'
+
+    expect(
+      resolveExternalEditorLaunchSpec('C:\\Tools\\cursor.exe', pathValue, {
+        platform: 'win32'
+      }).spawnArgs
+    ).toEqual(['--new-window', pathValue])
+    expect(
+      resolveExternalEditorLaunchSpec('C:\\Tools\\codium.exe', pathValue, {
+        platform: 'win32'
+      }).spawnArgs
+    ).toEqual([pathValue])
+  })
+
+  it('does not rewrite compound VS Code commands', () => {
+    const pathValue = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\project'
+
+    expect(
+      resolveExternalEditorLaunchSpec('code --reuse-window', pathValue, { platform: 'win32' })
+    ).toEqual({
+      kind: 'shell',
+      hideWindowsConsole: true,
+      spawnCmd: getCmdExePath(),
+      spawnArgs: ['/d', '/s', '/c', `code --reuse-window ${pathValue}`]
     })
   })
 })

--- a/src/main/external-editor-launch.test.ts
+++ b/src/main/external-editor-launch.test.ts
@@ -136,13 +136,18 @@ describe('resolveExternalEditorLaunchSpec', () => {
     })
   })
 
-  it('opens modern WSL UNC workspaces in the matching VS Code remote', () => {
-    expect(
-      resolveExternalEditorLaunchSpec('code', '\\\\wsl.localhost\\Ubuntu\\home\\aliuq\\project', {
-        platform: 'win32'
-      }).spawnArgs
-    ).toEqual(['--remote', 'wsl+Ubuntu', '/home/aliuq/project'])
-  })
+  it.each(['code', 'code-insiders'])(
+    'opens modern WSL UNC workspaces with %s in the matching VS Code remote',
+    (editorCommand) => {
+      expect(
+        resolveExternalEditorLaunchSpec(
+          editorCommand,
+          '\\\\wsl.localhost\\Ubuntu\\home\\aliuq\\project',
+          { platform: 'win32' }
+        ).spawnArgs
+      ).toEqual(['--remote', 'wsl+Ubuntu', '/home/aliuq/project'])
+    }
+  )
 
   it.each([
     [
@@ -161,8 +166,10 @@ describe('resolveExternalEditorLaunchSpec', () => {
 
   it.each([
     'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+    'C:\\Program Files\\Microsoft VS Code Insiders\\Code - Insiders.exe',
     'C:\\Tools\\CODE.CMD',
-    'C:\\Tools\\code.bat'
+    'C:\\Tools\\code.bat',
+    'C:\\Tools\\code-insiders.cmd'
   ])('recognizes the direct Windows VS Code launcher %s', (editorCommand) => {
     expect(
       resolveExternalEditorLaunchSpec(
@@ -173,23 +180,26 @@ describe('resolveExternalEditorLaunchSpec', () => {
     ).toEqual(['--remote', 'wsl+Ubuntu', '/home/ada/project'])
   })
 
-  it.each(['C:\\Tools\\CODE.CMD', 'C:\\Tools\\code.bat'])(
-    'recognizes the resolved Windows VS Code launcher %s',
-    (resolvedCommand) => {
-      resolveCliCommandMock.mockReturnValueOnce(resolvedCommand)
+  it.each([
+    ['code', 'C:\\Tools\\CODE.CMD'],
+    ['code', 'C:\\Tools\\code.bat'],
+    ['code-insiders', 'C:\\Tools\\code-insiders.cmd']
+  ])('recognizes the resolved Windows VS Code launcher %s', (editorCommand, resolvedCommand) => {
+    resolveCliCommandMock.mockReturnValueOnce(resolvedCommand)
 
-      expect(
-        resolveExternalEditorLaunchSpec('code', '\\\\wsl.localhost\\Ubuntu\\home\\ada\\project', {
-          platform: 'win32'
-        })
-      ).toEqual({
-        kind: 'executable',
-        hideWindowsConsole: true,
-        spawnCmd: resolvedCommand,
-        spawnArgs: ['--remote', 'wsl+Ubuntu', '/home/ada/project']
-      })
-    }
-  )
+    expect(
+      resolveExternalEditorLaunchSpec(
+        editorCommand,
+        '\\\\wsl.localhost\\Ubuntu\\home\\ada\\project',
+        { platform: 'win32' }
+      )
+    ).toEqual({
+      kind: 'executable',
+      hideWindowsConsole: true,
+      spawnCmd: resolvedCommand,
+      spawnArgs: ['--remote', 'wsl+Ubuntu', '/home/ada/project']
+    })
+  })
 
   it('preserves spaces in WSL distro and folder arguments', () => {
     expect(

--- a/src/main/external-editor-launch.ts
+++ b/src/main/external-editor-launch.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs'
 import { basename, posix, win32 } from 'node:path'
+import { parseWslUncPath } from '../shared/wsl-paths'
 import { resolveCliCommand } from './codex-cli/command'
 import { getCmdExePath } from './win32-utils'
 
@@ -106,11 +107,22 @@ function shouldShowWindowsConsole(
   return platform === 'win32' && WINDOWS_CONSOLE_EDITORS.has(getLauncherBaseName(command, options))
 }
 
-function buildExecutableArgs(editorCommand: string, pathValue: string): string[] {
+function buildExecutableArgs(
+  editorCommand: string,
+  pathValue: string,
+  platform: NodeJS.Platform
+): string[] {
   if (getLauncherBaseName(editorCommand) === 'cursor') {
     // Why: Cursor can route bare folder launches through the last active
     // workbench. A new window keeps "Open in Cursor" scoped to this worktree.
     return ['--new-window', pathValue]
+  }
+  if (platform === 'win32' && getLauncherBaseName(editorCommand) === 'code') {
+    const wslPath = parseWslUncPath(pathValue)
+    if (wslPath) {
+      // Why: VS Code otherwise treats a WSL UNC path as a local Windows folder.
+      return ['--remote', `wsl+${wslPath.distro}`, wslPath.linuxPath]
+    }
   }
   return [pathValue]
 }
@@ -156,7 +168,7 @@ export function resolveExternalEditorLaunchSpec(
       kind: 'executable',
       hideWindowsConsole: !shouldShowWindowsConsole(editorCommand, platform),
       spawnCmd: editorCommand,
-      spawnArgs: buildExecutableArgs(editorCommand, pathValue)
+      spawnArgs: buildExecutableArgs(editorCommand, pathValue, platform)
     }
   }
 
@@ -169,6 +181,6 @@ export function resolveExternalEditorLaunchSpec(
     kind: 'executable',
     hideWindowsConsole: !shouldShowWindowsConsole(editorCommand, platform),
     spawnCmd: editorCommand,
-    spawnArgs: buildExecutableArgs(editorCommand, pathValue)
+    spawnArgs: buildExecutableArgs(editorCommand, pathValue, platform)
   }
 }

--- a/src/main/external-editor-launch.ts
+++ b/src/main/external-editor-launch.ts
@@ -6,6 +6,7 @@ import { getCmdExePath } from './win32-utils'
 
 export const EXTERNAL_EDITOR_CLI_COMMAND = 'code'
 const WINDOWS_CONSOLE_EDITORS = new Set(['nvim', 'vim'])
+const VSCODE_REMOTE_EDITORS = new Set(['code', 'code-insiders', 'code - insiders'])
 
 export type ExternalEditorLaunchSpec =
   | {
@@ -112,12 +113,13 @@ function buildExecutableArgs(
   pathValue: string,
   platform: NodeJS.Platform
 ): string[] {
-  if (getLauncherBaseName(editorCommand) === 'cursor') {
+  const launcherBaseName = getLauncherBaseName(editorCommand)
+  if (launcherBaseName === 'cursor') {
     // Why: Cursor can route bare folder launches through the last active
     // workbench. A new window keeps "Open in Cursor" scoped to this worktree.
     return ['--new-window', pathValue]
   }
-  if (platform === 'win32' && getLauncherBaseName(editorCommand) === 'code') {
+  if (platform === 'win32' && VSCODE_REMOTE_EDITORS.has(launcherBaseName)) {
     const wslPath = parseWslUncPath(pathValue)
     if (wslPath) {
       // Why: VS Code otherwise treats a WSL UNC path as a local Windows folder.

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -321,27 +321,22 @@ describe('registerShellHandlers', () => {
       ])
     })
 
-    it('forwards WSL remote arguments with spaces through the Windows launcher shim', async () => {
-      const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
-      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
-      const workspacePath = '\\\\wsl.localhost\\Ubuntu Preview\\home\\Ada Lovelace\\project'
-      const codeShim = 'C:\\Tools\\CODE.CMD'
-      resolveCliCommandMock.mockReturnValueOnce(codeShim)
-      const handler = getHandler('shell:openInExternalEditor')
+    it.runIf(process.platform === 'win32')(
+      'forwards WSL remote arguments with spaces through the Windows launcher shim',
+      async () => {
+        const workspacePath = '\\\\wsl.localhost\\Ubuntu Preview\\home\\Ada Lovelace\\project'
+        const codeShim = 'C:\\Tools\\CODE.CMD'
+        resolveCliCommandMock.mockReturnValueOnce(codeShim)
+        const handler = getHandler('shell:openInExternalEditor')
 
-      try {
         await expect(handler({}, workspacePath, 'code')).resolves.toEqual({ ok: true })
         expect(getSpawnArgsForWindowsMock).toHaveBeenCalledWith(codeShim, [
           '--remote',
           'wsl+Ubuntu Preview',
           '/home/Ada Lovelace/project'
         ])
-      } finally {
-        if (platformDescriptor) {
-          Object.defineProperty(process, 'platform', platformDescriptor)
-        }
       }
-    })
+    )
 
     it('shows the Windows console for NeoVim executable launchers on Windows', async () => {
       const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -321,6 +321,28 @@ describe('registerShellHandlers', () => {
       ])
     })
 
+    it('forwards WSL remote arguments with spaces through the Windows launcher shim', async () => {
+      const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const workspacePath = '\\\\wsl.localhost\\Ubuntu Preview\\home\\Ada Lovelace\\project'
+      const codeShim = 'C:\\Tools\\CODE.CMD'
+      resolveCliCommandMock.mockReturnValueOnce(codeShim)
+      const handler = getHandler('shell:openInExternalEditor')
+
+      try {
+        await expect(handler({}, workspacePath, 'code')).resolves.toEqual({ ok: true })
+        expect(getSpawnArgsForWindowsMock).toHaveBeenCalledWith(codeShim, [
+          '--remote',
+          'wsl+Ubuntu Preview',
+          '/home/Ada Lovelace/project'
+        ])
+      } finally {
+        if (platformDescriptor) {
+          Object.defineProperty(process, 'platform', platformDescriptor)
+        }
+      }
+    })
+
     it('shows the Windows console for NeoVim executable launchers on Windows', async () => {
       const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/win32-utils.test.ts
+++ b/src/main/win32-utils.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+  getCmdExePath,
   getSpawnArgsForWindows,
   isPermissionError,
   isWindowsBatchScript,
@@ -63,6 +64,26 @@ describe('getSpawnArgsForWindows', () => {
         process.env.ComSpec = originalComSpec
       }
     }
+  })
+
+  it('preserves VS Code WSL remote arguments with spaces through .cmd launchers', () => {
+    withPlatform('win32', () => {
+      const { spawnCmd, spawnArgs } = getSpawnArgsForWindows('C:\\tools\\code.cmd', [
+        '--remote',
+        'wsl+Ubuntu Preview',
+        '/home/Ada Lovelace/project'
+      ])
+
+      expect(spawnCmd).toBe(getCmdExePath())
+      expect(spawnArgs).toEqual([
+        '/d',
+        '/c',
+        'C:\\tools\\code.cmd',
+        '--remote',
+        'wsl+Ubuntu Preview',
+        '/home/Ada Lovelace/project'
+      ])
+    })
   })
 
   it('passes .exe through unchanged on win32', () => {


### PR DESCRIPTION
﻿## Summary

- Detect modern and legacy WSL UNC workspace paths when Windows launches VS Code.
- Pass `--remote wsl+<distro> <linux-path>` so the selected project opens in the matching Remote - WSL environment instead of as a local Windows folder.
- Preserve existing behavior for local/ordinary UNC paths, other editors, compound commands, macOS/Linux, and SSH/remote workspaces.

## Design

- [VS Code WSL workspace launch design](./docs/issue-7649-vscode-wsl-launch.md)

## Validation

- `pnpm typecheck`
- Focused normal and type-aware lint on the changed files
- `pnpm exec oxfmt --check` on the changed files
- `pnpm check:max-lines-ratchet`
- 70 focused tests across the launcher, shell IPC, Windows command shim, and shared WSL parser
- Windows Electron validation: Orca's rendered **Open in > VS Code** action opened a real `\\wsl.localhost\Ubuntu\...` repository as `[WSL: Ubuntu]`; a repeat WSL launch remained remote, and the adjacent local Windows launch remained local

## Screenshots

Local review evidence is retained under ignored `validation-screenshots/` and is intentionally not committed.

Fixes #7649
