### PR TITLE
feat(wiki): add repository wiki panel with background generation

### DIFF
--- a/resources/wiki-templates/overview.md
+++ b/resources/wiki-templates/overview.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - topic/meta
+---
+
+# 📦 Template: repository (agent-memory)
+
+Repository notes live in `Projects/<Project>/<repo>/`. Reference: `Projects/MySky/custom-pricelist-api/`.
+
+```
+<repo>/
+  <repo>.md                 # overview: purpose, note map, Where in code, commands; tags type/overview + type/moc
+  <repo> — Architecture.md   # layers, DI, pipelines, deploy (+Mermaid)
+  <repo> — Data.md        # domain model, tables, migrations, invariants (+ER Mermaid)
+  <repo> — Interfaces.md     # HTTP, buses, outgoing clients, consumers
+  Business logic/<Feature>.md   # 1 feature = 1 note (type/logic + code:)
+  Services/                  # monorepo only: microservice cards/folders
+```
+
+Overview frontmatter:
+
+```yaml
+---
+tags: [type/overview, type/moc, project/<slug>, repo/<repo>, lang/<lang>, domain/<domain>]
+path: ~/JOB/.../<repo>
+branch: origin/<master|main|trunk>
+entrypoints: [...]
+infra: <prod host, if known>
+---
+```
+
+Rules: facts from the code on the default branch; English prose; tables over narrative; the
+overview must include a "Note map" (a table with links and each note's area of responsibility).

--- a/resources/wiki-templates/prompt.md
+++ b/resources/wiki-templates/prompt.md
@@ -1,0 +1,26 @@
+# Wiki generation contract
+
+You are generating a repository wiki into the `.wiki/` folder at the root of the current
+repository. Work only inside `.wiki/`; treat the rest of the repo as read-only reference.
+
+Rules:
+- Facts come from the code on the current default branch. Mark anything reconstructed
+  indirectly with ⚠️.
+- Write all prose in English; identifiers (paths, tables, services, fields) exactly as in code.
+- Prefer tables over narrative. One note = one responsibility.
+- Create the root overview note as `.wiki/Home.md` — it MUST contain a "Note map" table
+  linking every other note and a "Where in code" table.
+- Repository wiki layout (adapt to the repo; skip sections that do not apply):
+  - `.wiki/Home.md` — overview, note map, where-in-code, commands.
+  - `.wiki/<repo> — Architecture.md`, `— Data.md`, `— Interfaces.md`.
+  - `.wiki/Business logic/<Feature>.md` — one note per feature (frontmatter `code:` list).
+  - `.wiki/Services/<service>.md` — only for monorepos.
+- Cross-link notes with **relative Markdown links** so the in-app wiki viewer can follow them,
+  e.g. `[Sub note](./Business logic/Feature.md)` or `[Overview](./Home.md)`. Paths are relative
+  to the linking note and must point at real `.md` files inside `.wiki/`. Do NOT use
+  `[[Basename]]` wikilinks — the viewer renders those as plain text, not clickable links.
+- Do not put page tags in a way that's meant to be read as body text — frontmatter tags are
+  fine (the viewer hides frontmatter), but keep them in YAML frontmatter, not inline.
+
+Templates to follow are provided below. Do not copy them verbatim — use them as the structure
+and frontmatter contract.

--- a/resources/wiki-templates/service.md
+++ b/resources/wiki-templates/service.md
@@ -56,7 +56,7 @@ libs: []
 
 ## Folder (core service)
 
-```
+```text
 Services/<service>/
   <service>.md              # overview + note map (table) + Where in code + business areas + Gotchas; tag + type/moc
   <service> — Data.md     # tables, models, DSN

--- a/resources/wiki-templates/service.md
+++ b/resources/wiki-templates/service.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - topic/meta
+---
+
+# 🧩 Template: service (agent-memory)
+
+Two formats. **Card** — the service fits in one note (`Services/<service>.md`). **Folder** — a
+core/large service (`Services/<service>/` with an overview, — Data, — Interfaces, Business
+logic/). References: card — any note under `findocs_back/Services/*.md`; folder —
+`Services/sky_ledger/`.
+
+## Card
+
+```markdown
+---
+tags:
+  - type/service
+  - project/<slug>
+  - repo/<repo>
+  - lang/<python|go>
+  - domain/<domain>          # closest business domain; pure infra → topic/infra
+  - status/<core|legacy|nascent>   # optional
+path: src/services/<service>
+entrypoints: [<service>/app.py]
+tables: []          # only what's verified in code
+queues: []          # RabbitMQ
+topics_kafka: []
+clients_out: []
+consumed_by: []
+libs: []
+---
+
+# <service>
+
+> <1-2 lines: business purpose — what it does and why it exists.>
+
+## Where in code
+<entrypoint, key modules with paths, shared libs.>
+
+## Data
+<tables/models + where defined. Skip if stateless.>
+
+## Interfaces
+<HTTP (main groups, internal routes), queues/topics in+out, outgoing clients (env), who consumes.>
+
+## Business logic
+<key algorithms: name — path in code — gist in 2-4 lines.>
+
+## Gotchas
+<non-obvious invariants. Skip if none.>
+
+## Links
+[[<related>]] · [[<domain>]]
+```
+
+## Folder (core service)
+
+```
+Services/<service>/
+  <service>.md              # overview + note map (table) + Where in code + business areas + Gotchas; tag + type/moc
+  <service> — Data.md     # tables, models, DSN
+  <service> — Interfaces.md # HTTP/robot, queues, clients, consumers
+  Business logic/<Feature>.md   # 1 feature = 1 note; tag type/logic + code: [files]
+```
+
+Rules: content from the code on the default branch (`git show origin/<branch>:<path>`); English
+prose, identifiers as in code; ⚠️ = reconstructed indirectly; tables over narrative.

--- a/resources/wiki-templates/task.md
+++ b/resources/wiki-templates/task.md
@@ -1,0 +1,71 @@
+---
+tags:
+  - topic/meta
+---
+
+# ✅ Template: task (agent-memory)
+
+One note = one task (MT-XXXXX). Lives in `Projects/<Project>/Tasks/` — the project's single task
+list. File basename: `MT-XXXXX <short name>.md` (the number is unique across the vault, so the
+wikilink `[[MT-XXXXX ...]]` doesn't break). Frontmatter is for filters/Dataview; the body is a
+description + an "Execution log" with append-only dated entries.
+
+Reference for the log format: any file under `Tasks/`.
+
+```markdown
+---
+tags:
+  - type/task
+  - project/<slug>
+  - repo/<repo>              # findocs_back | custom-pricelist-api; multiple if cross-repo
+  - domain/<domain>          # optional, closest business domain
+  - status/<todo|in-progress|done|blocked>
+task: MT-XXXXX               # task number
+title: "<short name>"
+services: [<service>, ...]   # which service(s)/microservice(s) this touches; can be several
+branch: <git-branch>          # e.g. MT-XXXXX-short-slug; empty if there is no branch
+link: <url>                  # link to the ticket (Notion/Jira); empty if none
+---
+
+# MT-XXXXX — <short name>
+
+> <short 1-2 line description: what the task is and why.>
+
+- **Link**: <url / —> ·
+- **Branch**: `<branch / —>` ·
+- **Services**: <svc1, svc2> ·
+- **Status**: ✅/🔨/⚠️/❌
+
+## Description
+<what needs to be done; rules, constraints, context from the ticket.>
+
+## Acceptance Criteria
+- [ ] ...
+
+---
+
+## Execution log
+
+### [YYYY-MM-DD HH:MM]
+
+#### Task analysis
+<how the task was understood and the plan of action.>
+
+#### Reasoning
+<what options were considered, why this approach was chosen.>
+
+#### Changes
+- `path/to/file` — what changed and why
+
+#### Outcome
+Status: ✅ Done / ⚠️ Partial / ❌ Blocked
+
+<short report: what was done, what remains.>
+```
+
+## Log rules
+- **Append only** to the end — do not touch or rewrite old entries.
+- Each entry starts with `### [YYYY-MM-DD HH:MM]`.
+- Be concrete: real file paths, functions, reasons for decisions; write plainly.
+- Be honest: if blocked or only partially done, say so explicitly (`⚠️`/`❌`).
+- On a status change — update `status/*` in the tags and `**Status**` in the header.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,6 +29,7 @@ import type { WikiHandlerDeps } from './ipc/wiki'
 import { WikiGenerationService } from './wiki/wiki-generation-service'
 import { spawnWikiAgent } from './wiki/wiki-generation-process'
 import { TUI_AGENT_CONFIG, getTuiAgentLaunchCommand } from '../shared/tui-agent-config'
+import type { WikiGenerationChangedPayload } from '../shared/types'
 import { initObservability, shutdownObservability } from './observability'
 import { startSpan } from './observability/tracer'
 import { registerMobileHandlers } from './ipc/mobile'
@@ -942,7 +943,7 @@ function openMainWindow(): BrowserWindow {
         getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[agent], process.platform, { isRemote: false })
       )
     },
-    emitChanged: (payload) => {
+    emitChanged: (payload: WikiGenerationChangedPayload) => {
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.webContents.send('wiki:generationChanged', payload)
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@
    startup. Splitting by line count would fragment tightly coupled startup
    logic across files without a cleaner ownership seam. */
 import { existsSync, statSync } from 'node:fs'
-import { isAbsolute, join } from 'node:path'
+import { basename, isAbsolute, join } from 'node:path'
 import os from 'node:os'
 import { app, BrowserWindow, dialog, ipcMain, nativeTheme } from 'electron'
 import { electronApp, is } from '@electron-toolkit/utils'
@@ -25,6 +25,10 @@ import { initDaemonPtyProvider, disconnectDaemon, shutdownDaemon } from './daemo
 import { closeAllWatchers } from './ipc/filesystem-watcher'
 import { disposeWorktreeBaseDirectoryWatchers } from './ipc/worktree-base-directory-watcher'
 import { registerCoreHandlers } from './ipc/register-core-handlers'
+import type { WikiHandlerDeps } from './ipc/wiki'
+import { WikiGenerationService } from './wiki/wiki-generation-service'
+import { spawnWikiAgent } from './wiki/wiki-generation-process'
+import { TUI_AGENT_CONFIG, getTuiAgentLaunchCommand } from '../shared/tui-agent-config'
 import { initObservability, shutdownObservability } from './observability'
 import { startSpan } from './observability/tracer'
 import { registerMobileHandlers } from './ipc/mobile'
@@ -136,7 +140,7 @@ import { wslHookRelayManager } from './agent-hooks/wsl-hook-relay-manager'
 import { maybeAutoRenameBranchOnFirstWork } from './agent-hooks/first-work-branch-rename'
 import { renameWorktreeFolderOnFirstWork } from './agent-hooks/first-work-folder-rename'
 import { moveWorktree } from './git/worktree'
-import { getRepoIdFromWorktreeId } from '../shared/worktree-id'
+import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../shared/worktree-id'
 import { parseWorkspaceKey } from '../shared/workspace-scope'
 import { setMigrationUnsupportedPtyListener } from './agent-hooks/migration-unsupported-pty-state'
 import {
@@ -930,6 +934,49 @@ function openMainWindow(): BrowserWindow {
   }
   window.webContents.on('did-finish-load', onFirstWindowLoad)
 
+  const wikiGenerationService = new WikiGenerationService({
+    resolveBinary: (agent) => {
+      const overrides = store!.getSettings().agentCmdOverrides
+      return (
+        overrides?.[agent] ||
+        getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[agent], process.platform, { isRemote: false })
+      )
+    },
+    emitChanged: (payload) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('wiki:generationChanged', payload)
+      }
+    },
+    spawnAgent: spawnWikiAgent,
+    now: () => Date.now()
+  })
+
+  const wikiDeps: WikiHandlerDeps = {
+    getWorktree: (worktreeId) => {
+      // Why: worktree ids are `${repoId}::${path}` (see shared/worktree-id.ts),
+      // so the path resolves synchronously without a runtime git rescan.
+      const parsed = splitWorktreeIdForFilesystem(worktreeId)
+      if (!parsed) {
+        return null
+      }
+      const repo = store!.getRepo(parsed.repoId)
+      if (!repo) {
+        return null
+      }
+      return {
+        path: parsed.worktreePath,
+        repoName: repo.displayName || basename(repo.path),
+        connectionId: repo.connectionId ?? undefined
+      }
+    },
+    getSettings: () => store!.getSettings(),
+    generation: {
+      start: (input) => wikiGenerationService.start(input),
+      getStatus: (worktreeId) => wikiGenerationService.getStatus(worktreeId),
+      cancel: (worktreeId) => wikiGenerationService.cancel(worktreeId)
+    }
+  }
+
   registerCoreHandlers(
     store,
     runtime,
@@ -956,7 +1003,8 @@ function openMainWindow(): BrowserWindow {
         isQuitting = true
         await preserveAgentAuthBeforeRestart({ codexRuntimeHome, claudeRuntimeAuth, store })
       }
-    }
+    },
+    wikiDeps
   )
   automations.setWebContents(window.webContents)
   automations.start()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -57,6 +57,7 @@ import { registerAgentTrustHandlers } from './agent-trust'
 import { registerClaudeAccountHandlers } from './claude-accounts'
 import { registerMiniMaxCredentialsHandlers } from './minimax-credentials'
 import { registerGrokAccountHandlers } from './grok-accounts'
+import { registerWikiHandlers, type WikiHandlerDeps } from './wiki'
 import { registerUpdaterHandlers } from '../window/attach-main-window-services'
 import {
   registerClipboardHandlers,
@@ -100,7 +101,8 @@ export function registerCoreHandlers(
   agentAwakeService?: AgentAwakeService,
   crashReports?: CrashReportStore,
   keybindings?: KeybindingService,
-  lifecycleOptions: CoreHandlerLifecycleOptions = {}
+  lifecycleOptions: CoreHandlerLifecycleOptions = {},
+  wikiDeps?: WikiHandlerDeps
 ): void {
   // Why: on macOS the app can stay alive after all windows close, then
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
@@ -189,6 +191,9 @@ export function registerCoreHandlers(
       scanRuntimeAiVaultSessions(app.getPath('userData'), environmentId, args, options)
   })
   registerNativeChatHandlers()
+  if (wikiDeps) {
+    registerWikiHandlers(wikiDeps)
+  }
   registerClipboardHandlers(store)
   registerUpdaterHandlers(store)
   registerSpeechHandlers(store)

--- a/src/main/ipc/wiki.test.ts
+++ b/src/main/ipc/wiki.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<string, (event: unknown, args: unknown) => unknown>()
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (e: unknown, a: unknown) => unknown) => handlers.set(channel, fn)
+  }
+}))
+// Why: the prompt builder imports electron `app`; stub the template reader import path instead.
+const buildWikiGenerationPrompt = vi.fn(async (_input: unknown) => 'PROMPT')
+vi.mock('../wiki/wiki-generation-prompt', () => ({
+  buildWikiGenerationPrompt: (input: unknown) => buildWikiGenerationPrompt(input),
+  readWikiTemplateFile: async () => ''
+}))
+
+const getSshFilesystemProvider = vi.fn()
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: (connectionId: string) => getSshFilesystemProvider(connectionId)
+}))
+
+import { registerWikiHandlers } from './wiki'
+import type { WikiGenerationStatus } from '../wiki/wiki-generation-service'
+
+let root: string
+beforeEach(async () => {
+  handlers.clear()
+  buildWikiGenerationPrompt.mockClear()
+  root = await mkdtemp(join(tmpdir(), 'wiki-ipc-'))
+})
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+function register(overrides: Partial<Parameters<typeof registerWikiHandlers>[0]> = {}) {
+  const generation = {
+    start: vi.fn(() => ({ ok: true as const })),
+    getStatus: vi.fn((): WikiGenerationStatus | null => null),
+    cancel: vi.fn()
+  }
+  registerWikiHandlers({
+    getWorktree: () => ({ path: root, repoName: 'my-repo' }),
+    getSettings: () => ({
+      defaultTuiAgent: 'claude',
+      disabledTuiAgents: [],
+      sourceControlAi: undefined
+    }),
+    generation,
+    ...overrides
+  })
+  return { generation }
+}
+
+describe('wiki:read', () => {
+  it('returns hasWiki:false when empty', async () => {
+    register()
+    const result = await handlers.get('wiki:read')!({}, { worktreeId: 'w1' })
+    expect(result).toEqual({ hasWiki: false })
+  })
+  it('returns the root note content', async () => {
+    await mkdir(join(root, '.wiki'), { recursive: true })
+    await writeFile(join(root, '.wiki', 'Home.md'), '# Home', 'utf8')
+    register()
+    const result = await handlers.get('wiki:read')!({}, { worktreeId: 'w1' })
+    expect(result).toMatchObject({
+      hasWiki: true,
+      rootRelativePath: 'Home.md',
+      note: { relativePath: 'Home.md', content: '# Home' }
+    })
+  })
+
+  it('reads over SSH when the worktree has a connectionId', async () => {
+    getSshFilesystemProvider.mockReturnValue({
+      listFiles: async () => ['Home.md'],
+      realpath: async (p: string) => p,
+      stat: async () => ({ size: 10, type: 'file', mtime: 0 }),
+      readFile: async () => ({ content: '# Remote Home', isBinary: false })
+    })
+    register({
+      getWorktree: () => ({ path: '/remote/repo', repoName: 'my-repo', connectionId: 'ssh-1' })
+    })
+    const result = await handlers.get('wiki:read')!({}, { worktreeId: 'w1' })
+    expect(getSshFilesystemProvider).toHaveBeenCalledWith('ssh-1')
+    expect(result).toMatchObject({
+      hasWiki: true,
+      rootRelativePath: 'Home.md',
+      note: { relativePath: 'Home.md', content: '# Remote Home' }
+    })
+  })
+
+  it('returns hasWiki:false when the SSH provider is unavailable', async () => {
+    getSshFilesystemProvider.mockReturnValue(undefined)
+    register({
+      getWorktree: () => ({ path: '/remote/repo', repoName: 'my-repo', connectionId: 'ssh-1' })
+    })
+    const result = await handlers.get('wiki:read')!({}, { worktreeId: 'w1' })
+    expect(result).toEqual({ hasWiki: false })
+  })
+})
+
+describe('wiki:generate', () => {
+  it('starts generation for the resolved agent with the built prompt', async () => {
+    const { generation } = register()
+    const result = await handlers.get('wiki:generate')!({}, { worktreeId: 'w1' })
+    expect(result).toEqual({ ok: true })
+    expect(generation.start).toHaveBeenCalledWith({
+      worktreeId: 'w1',
+      cwd: root,
+      agent: 'claude',
+      prompt: 'PROMPT'
+    })
+  })
+  it('errors when no agent configured', async () => {
+    register({
+      getSettings: () => ({
+        defaultTuiAgent: null,
+        disabledTuiAgents: [],
+        sourceControlAi: undefined
+      })
+    })
+    const result = await handlers.get('wiki:generate')!({}, { worktreeId: 'w1' })
+    expect(result).toMatchObject({ ok: false })
+  })
+  it('forwards the addClaudeMdInstruction flag to the prompt builder', async () => {
+    register()
+    await handlers.get('wiki:generate')!({}, { worktreeId: 'w1', addClaudeMdInstruction: true })
+    expect(buildWikiGenerationPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ addClaudeMdInstruction: true })
+    )
+  })
+  it('defaults addClaudeMdInstruction to false when omitted', async () => {
+    register()
+    await handlers.get('wiki:generate')!({}, { worktreeId: 'w1' })
+    expect(buildWikiGenerationPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ addClaudeMdInstruction: false })
+    )
+  })
+  it('rejects SSH worktrees without calling generation.start', async () => {
+    const { generation } = register({
+      getWorktree: () => ({ path: '/remote/repo', repoName: 'my-repo', connectionId: 'ssh-1' })
+    })
+    const result = await handlers.get('wiki:generate')!({}, { worktreeId: 'w1' })
+    expect(result).toEqual({
+      ok: false,
+      error: 'Background wiki generation is not available for SSH worktrees yet.'
+    })
+    expect(generation.start).not.toHaveBeenCalled()
+  })
+})
+
+describe('wiki:generationStatus', () => {
+  it('returns what generation.getStatus returns', async () => {
+    const status = { running: true, output: 'log' }
+    const { generation } = register()
+    generation.getStatus.mockReturnValue(status)
+    const result = await handlers.get('wiki:generationStatus')!({}, { worktreeId: 'w1' })
+    expect(generation.getStatus).toHaveBeenCalledWith('w1')
+    expect(result).toBe(status)
+  })
+})
+
+describe('wiki:cancelGeneration', () => {
+  it('cancels the generation and returns ok:true', async () => {
+    const { generation } = register()
+    const result = await handlers.get('wiki:cancelGeneration')!({}, { worktreeId: 'w1' })
+    expect(generation.cancel).toHaveBeenCalledWith('w1')
+    expect(result).toEqual({ ok: true })
+  })
+})

--- a/src/main/ipc/wiki.ts
+++ b/src/main/ipc/wiki.ts
@@ -14,6 +14,7 @@ import type { WikiGenerationStatus } from '../wiki/wiki-generation-service'
 
 const SSH_NOT_SUPPORTED_ERROR = 'Background wiki generation is not available for SSH worktrees yet.'
 
+/** Dependencies `registerWikiHandlers` needs from the main process: worktree/settings lookup and the background generation service. */
 export type WikiHandlerDeps = {
   getWorktree: (
     worktreeId: string
@@ -37,6 +38,7 @@ export type WikiHandlerDeps = {
 type WikiOverview = { hasWiki: boolean; rootRelativePath: string | null; notes: string[] }
 type WikiNote = { relativePath: string; content: string } | null
 
+/** Registers the `wiki:read`, `wiki:generate`, `wiki:generationStatus`, and `wiki:cancelGeneration` IPC handlers. */
 export function registerWikiHandlers(deps: WikiHandlerDeps): void {
   ipcMain.handle(
     'wiki:read',

--- a/src/main/ipc/wiki.ts
+++ b/src/main/ipc/wiki.ts
@@ -1,0 +1,121 @@
+import { ipcMain } from 'electron'
+import type {
+  GlobalSettings,
+  TuiAgent,
+  WikiGenerateResult,
+  WikiReadResult
+} from '../../shared/types'
+import { readWikiNote, readWikiOverview, resolveWikiTarget } from '../wiki/wiki-repository'
+import { readWikiNoteSsh, readWikiOverviewSsh } from '../wiki/wiki-repository-ssh'
+import { buildWikiGenerationPrompt, readWikiTemplateFile } from '../wiki/wiki-generation-prompt'
+import { resolveWikiGenerationAgent } from '../wiki/wiki-agent-selection'
+import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
+import type { WikiGenerationStatus } from '../wiki/wiki-generation-service'
+
+const SSH_NOT_SUPPORTED_ERROR = 'Background wiki generation is not available for SSH worktrees yet.'
+
+export type WikiHandlerDeps = {
+  getWorktree: (
+    worktreeId: string
+  ) => { path: string; repoName: string; connectionId?: string } | null
+  getSettings: () => Pick<
+    GlobalSettings,
+    'defaultTuiAgent' | 'disabledTuiAgents' | 'sourceControlAi'
+  >
+  generation: {
+    start: (input: {
+      worktreeId: string
+      cwd: string
+      agent: TuiAgent
+      prompt: string
+    }) => { ok: true } | { ok: false; error: string }
+    getStatus: (worktreeId: string) => WikiGenerationStatus | null
+    cancel: (worktreeId: string) => void
+  }
+}
+
+type WikiOverview = { hasWiki: boolean; rootRelativePath: string | null; notes: string[] }
+type WikiNote = { relativePath: string; content: string } | null
+
+export function registerWikiHandlers(deps: WikiHandlerDeps): void {
+  ipcMain.handle(
+    'wiki:read',
+    async (
+      _event,
+      args: { worktreeId: string; target?: string; fromRelativePath?: string }
+    ): Promise<WikiReadResult> => {
+      const worktree = deps.getWorktree(args.worktreeId)
+      if (!worktree) {
+        return { hasWiki: false }
+      }
+
+      let readOverview: () => Promise<WikiOverview>
+      let readNote: (relativePath: string) => Promise<WikiNote>
+      if (worktree.connectionId) {
+        const provider = getSshFilesystemProvider(worktree.connectionId)
+        if (!provider) {
+          return { hasWiki: false }
+        }
+        readOverview = () => readWikiOverviewSsh(provider, worktree.path, worktree.repoName)
+        readNote = (relativePath) => readWikiNoteSsh(provider, worktree.path, relativePath)
+      } else {
+        readOverview = () => readWikiOverview(worktree.path, worktree.repoName)
+        readNote = (relativePath) => readWikiNote(worktree.path, relativePath)
+      }
+
+      const overview = await readOverview()
+      if (!overview.hasWiki || !overview.rootRelativePath) {
+        return { hasWiki: false }
+      }
+      const requested =
+        args.target && args.fromRelativePath
+          ? resolveWikiTarget(overview.notes, args.fromRelativePath, args.target)
+          : (args.target ?? overview.rootRelativePath)
+      const relativePath = requested ?? overview.rootRelativePath
+      const note = await readNote(relativePath)
+      return { hasWiki: true, rootRelativePath: overview.rootRelativePath, note }
+    }
+  )
+
+  ipcMain.handle(
+    'wiki:generate',
+    async (
+      _event,
+      args: { worktreeId: string; addClaudeMdInstruction?: boolean }
+    ): Promise<WikiGenerateResult> => {
+      const worktree = deps.getWorktree(args.worktreeId)
+      if (!worktree) {
+        return { ok: false, error: 'No active worktree.' }
+      }
+      if (worktree.connectionId) {
+        return { ok: false, error: SSH_NOT_SUPPORTED_ERROR }
+      }
+      const resolved = resolveWikiGenerationAgent(deps.getSettings())
+      if (!resolved.ok) {
+        return resolved
+      }
+      const prompt = await buildWikiGenerationPrompt({
+        repoName: worktree.repoName,
+        readTemplateFile: readWikiTemplateFile,
+        addClaudeMdInstruction: args.addClaudeMdInstruction ?? false
+      })
+      return deps.generation.start({
+        worktreeId: args.worktreeId,
+        cwd: worktree.path,
+        agent: resolved.agent,
+        prompt
+      })
+    }
+  )
+
+  ipcMain.handle(
+    'wiki:generationStatus',
+    (_event, args: { worktreeId: string }): WikiGenerationStatus | null =>
+      deps.generation.getStatus(args.worktreeId)
+  )
+
+  ipcMain.handle('wiki:cancelGeneration', (_event, args: { worktreeId: string }): { ok: true } => {
+    deps.generation.cancel(args.worktreeId)
+    return { ok: true }
+  })
+}

--- a/src/main/wiki/wiki-agent-selection.test.ts
+++ b/src/main/wiki/wiki-agent-selection.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWikiGenerationAgent } from './wiki-agent-selection'
+import type { TuiAgent } from '../../shared/types'
+
+// Why: disabledTuiAgents is a mutable TuiAgent[] on GlobalSettings, so `as const`
+// (which the brief used) would freeze it to a readonly [] and fail to compile.
+const base = {
+  defaultTuiAgent: null,
+  disabledTuiAgents: [] as TuiAgent[],
+  sourceControlAi: undefined
+}
+
+describe('resolveWikiGenerationAgent', () => {
+  it('prefers the sourceControlAi agent when set', () => {
+    expect(
+      resolveWikiGenerationAgent({
+        ...base,
+        sourceControlAi: { agentId: 'codex' } as never
+      })
+    ).toEqual({ ok: true, agent: 'codex' })
+  })
+  it('falls back to defaultTuiAgent', () => {
+    expect(resolveWikiGenerationAgent({ ...base, defaultTuiAgent: 'claude' })).toEqual({
+      ok: true,
+      agent: 'claude'
+    })
+  })
+  it('errors when no agent is configured', () => {
+    expect(resolveWikiGenerationAgent(base)).toEqual({
+      ok: false,
+      error: expect.stringContaining('agent')
+    })
+  })
+  it('errors when the resolved agent is disabled', () => {
+    expect(
+      resolveWikiGenerationAgent({
+        ...base,
+        defaultTuiAgent: 'claude',
+        disabledTuiAgents: ['claude']
+      })
+    ).toMatchObject({ ok: false })
+  })
+})

--- a/src/main/wiki/wiki-agent-selection.ts
+++ b/src/main/wiki/wiki-agent-selection.ts
@@ -7,6 +7,7 @@ type WikiAgentSettings = Pick<
   'defaultTuiAgent' | 'disabledTuiAgents' | 'sourceControlAi'
 >
 
+/** Picks the TUI agent to run wiki generation with, preferring the source-control AI agent, falling back to the default agent, and rejecting disabled agents. */
 export function resolveWikiGenerationAgent(
   settings: WikiAgentSettings
 ): { ok: true; agent: TuiAgent } | { ok: false; error: string } {

--- a/src/main/wiki/wiki-agent-selection.ts
+++ b/src/main/wiki/wiki-agent-selection.ts
@@ -1,0 +1,29 @@
+import { isTuiAgent } from '../../shared/tui-agent-config'
+import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
+import type { GlobalSettings, TuiAgent } from '../../shared/types'
+
+type WikiAgentSettings = Pick<
+  GlobalSettings,
+  'defaultTuiAgent' | 'disabledTuiAgents' | 'sourceControlAi'
+>
+
+export function resolveWikiGenerationAgent(
+  settings: WikiAgentSettings
+): { ok: true; agent: TuiAgent } | { ok: false; error: string } {
+  const preferred = settings.sourceControlAi?.agentId
+  const candidate =
+    preferred && preferred !== 'custom' && isTuiAgent(preferred)
+      ? preferred
+      : settings.defaultTuiAgent &&
+          settings.defaultTuiAgent !== 'blank' &&
+          isTuiAgent(settings.defaultTuiAgent)
+        ? settings.defaultTuiAgent
+        : null
+  if (!candidate) {
+    return { ok: false, error: 'No coding agent is configured. Set a default agent in Settings.' }
+  }
+  if (!isTuiAgentEnabled(candidate, settings.disabledTuiAgents ?? [])) {
+    return { ok: false, error: `The configured agent "${candidate}" is disabled.` }
+  }
+  return { ok: true, agent: candidate }
+}

--- a/src/main/wiki/wiki-generation-command.test.ts
+++ b/src/main/wiki/wiki-generation-command.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { buildWikiHeadlessArgs } from './wiki-generation-command'
+
+describe('buildWikiHeadlessArgs', () => {
+  it('builds the claude headless args', () => {
+    expect(buildWikiHeadlessArgs('claude')).toEqual({
+      args: ['-p', '--dangerously-skip-permissions'],
+      promptViaStdin: true
+    })
+  })
+
+  it('builds args for codex containing exec', () => {
+    const result = buildWikiHeadlessArgs('codex')
+    expect(result?.args).toContain('exec')
+    expect(result?.promptViaStdin).toBe(true)
+  })
+
+  it('returns null for an unsupported agent', () => {
+    expect(buildWikiHeadlessArgs('aider')).toBeNull()
+  })
+})

--- a/src/main/wiki/wiki-generation-command.ts
+++ b/src/main/wiki/wiki-generation-command.ts
@@ -1,0 +1,21 @@
+import type { TuiAgent } from '../../shared/types'
+
+export type WikiHeadlessCommand = { args: string[]; promptViaStdin: boolean }
+
+// Why: agentic file-writing in headless mode needs the agent's print/exec mode plus its
+// permission-bypass flag. Only agents with a known headless-write invocation are supported.
+export function buildWikiHeadlessArgs(agent: TuiAgent): WikiHeadlessCommand | null {
+  switch (agent) {
+    case 'claude':
+    case 'openclaude':
+    case 'claude-agent-teams':
+      return { args: ['-p', '--dangerously-skip-permissions'], promptViaStdin: true }
+    case 'codex':
+      return {
+        args: ['exec', '--dangerously-bypass-approvals-and-sandbox', '-'],
+        promptViaStdin: true
+      }
+    default:
+      return null
+  }
+}

--- a/src/main/wiki/wiki-generation-command.ts
+++ b/src/main/wiki/wiki-generation-command.ts
@@ -1,7 +1,9 @@
 import type { TuiAgent } from '../../shared/types'
 
+/** CLI args and stdin-prompt flag for launching a TUI agent in headless wiki-generation mode. */
 export type WikiHeadlessCommand = { args: string[]; promptViaStdin: boolean }
 
+/** Builds the headless invocation for the given agent, or null if that agent has no known headless-write mode. */
 // Why: agentic file-writing in headless mode needs the agent's print/exec mode plus its
 // permission-bypass flag. Only agents with a known headless-write invocation are supported.
 export function buildWikiHeadlessArgs(agent: TuiAgent): WikiHeadlessCommand | null {

--- a/src/main/wiki/wiki-generation-process.ts
+++ b/src/main/wiki/wiki-generation-process.ts
@@ -1,0 +1,61 @@
+import { exec, spawn, type ChildProcess } from 'node:child_process'
+import { resolveCliCommand } from '../codex-cli/command'
+import { getSpawnArgsForWindows } from '../win32-utils'
+
+export type SpawnWikiAgentInput = {
+  binary: string
+  args: string[]
+  cwd: string
+  prompt: string
+  promptViaStdin: boolean
+}
+
+// Why: mirrors commit-message-text-generation.ts's local spawn shape so the
+// headless wiki agent resolves the same Windows .cmd shims and cwd/env rules.
+export function spawnWikiAgent(input: SpawnWikiAgentInput): ChildProcess {
+  const spawnEnv = process.env
+  const resolvedBinary =
+    process.platform === 'win32'
+      ? resolveCliCommand(input.binary, { pathEnv: spawnEnv.PATH ?? spawnEnv.Path ?? null })
+      : input.binary
+  const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(resolvedBinary, input.args)
+  const child = spawn(spawnCmd, spawnArgs, {
+    cwd: input.cwd,
+    env: spawnEnv,
+    // Why: detached so killProcessTree can signal the whole process group on
+    // POSIX; Windows has no process groups so taskkill walks the tree instead.
+    detached: process.platform !== 'win32',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true
+  })
+  if (input.promptViaStdin) {
+    child.stdin?.end(input.prompt)
+  }
+  return child
+}
+
+// Why: on Windows, npm-installed CLIs are usually .cmd shims, so child.kill()
+// only terminates the wrapper. taskkill /T /F walks the process tree from the
+// wrapper PID. On POSIX, the negative pid targets the whole detached group.
+export function killProcessTree(child: ChildProcess): void {
+  const pid = child.pid
+  if (!pid) {
+    return
+  }
+  if (process.platform === 'win32') {
+    exec(`taskkill /pid ${pid} /T /F`, () => {
+      // Best-effort; the spawn's `close` listener fires once the tree exits.
+    })
+    return
+  }
+  try {
+    process.kill(-pid, 'SIGKILL')
+  } catch {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // The child may have already exited between the in-flight check and the
+      // kill - that race is benign and can be ignored.
+    }
+  }
+}

--- a/src/main/wiki/wiki-generation-process.ts
+++ b/src/main/wiki/wiki-generation-process.ts
@@ -1,7 +1,8 @@
-import { exec, spawn, type ChildProcess } from 'node:child_process'
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
 import { resolveCliCommand } from '../codex-cli/command'
 import { getSpawnArgsForWindows } from '../win32-utils'
 
+/** Input for spawning a headless wiki-generation agent process. */
 export type SpawnWikiAgentInput = {
   binary: string
   args: string[]
@@ -10,6 +11,7 @@ export type SpawnWikiAgentInput = {
   promptViaStdin: boolean
 }
 
+/** Spawns the wiki-generation agent's CLI binary, resolving Windows shims and piping the prompt via stdin when required. */
 // Why: mirrors commit-message-text-generation.ts's local spawn shape so the
 // headless wiki agent resolves the same Windows .cmd shims and cwd/env rules.
 export function spawnWikiAgent(input: SpawnWikiAgentInput): ChildProcess {
@@ -34,6 +36,7 @@ export function spawnWikiAgent(input: SpawnWikiAgentInput): ChildProcess {
   return child
 }
 
+/** Kills the given child process and its whole process tree, cross-platform. */
 // Why: on Windows, npm-installed CLIs are usually .cmd shims, so child.kill()
 // only terminates the wrapper. taskkill /T /F walks the process tree from the
 // wrapper PID. On POSIX, the negative pid targets the whole detached group.
@@ -43,7 +46,8 @@ export function killProcessTree(child: ChildProcess): void {
     return
   }
   if (process.platform === 'win32') {
-    exec(`taskkill /pid ${pid} /T /F`, () => {
+    // Why: execFile avoids spawning a shell (exec) for a fixed argv.
+    execFile('taskkill', ['/pid', String(pid), '/T', '/F'], () => {
       // Best-effort; the spawn's `close` listener fires once the tree exits.
     })
     return

--- a/src/main/wiki/wiki-generation-prompt.test.ts
+++ b/src/main/wiki/wiki-generation-prompt.test.ts
@@ -1,0 +1,89 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildWikiGenerationPrompt, wikiTemplatesDirCandidates } from './wiki-generation-prompt'
+
+describe('wikiTemplatesDirCandidates', () => {
+  it('probes the asar.unpacked resources dir for packaged builds', () => {
+    const candidates = wikiTemplatesDirCandidates({
+      isPackaged: true,
+      resourcesPath: '/Applications/Orca.app/Contents/Resources',
+      appPath: '/Applications/Orca.app/Contents/Resources/app.asar'
+    })
+    expect(candidates).toContain(
+      join(
+        '/Applications/Orca.app/Contents/Resources',
+        'app.asar.unpacked',
+        'resources',
+        'wiki-templates'
+      )
+    )
+    expect(candidates).toContain(
+      join('/Applications/Orca.app/Contents/Resources', 'wiki-templates')
+    )
+  })
+
+  it('falls back to the app path when resourcesPath is undefined', () => {
+    const candidates = wikiTemplatesDirCandidates({
+      isPackaged: true,
+      resourcesPath: undefined,
+      appPath: '/Applications/Orca.app/Contents/Resources/app.asar'
+    })
+    expect(candidates).toEqual([
+      join('/Applications/Orca.app/Contents/Resources/app.asar', 'resources', 'wiki-templates')
+    ])
+  })
+
+  it('reads from the repo root in dev', () => {
+    const candidates = wikiTemplatesDirCandidates({
+      isPackaged: false,
+      resourcesPath: '/some/dev/resourcesPath',
+      appPath: '/repo/root'
+    })
+    expect(candidates).toEqual([join('/repo/root', 'resources', 'wiki-templates')])
+  })
+})
+
+describe('buildWikiGenerationPrompt', () => {
+  it('inlines the contract, templates, and repo name', async () => {
+    const files: Record<string, string> = {
+      'prompt.md': '# Contract\nGenerate into .wiki/.',
+      'overview.md': 'OVERVIEW-TEMPLATE',
+      'service.md': 'SERVICE-TEMPLATE',
+      'task.md': 'TASK-TEMPLATE'
+    }
+    const prompt = await buildWikiGenerationPrompt({
+      repoName: 'custom-pricelist-api',
+      readTemplateFile: async (name) => files[name]
+    })
+    expect(prompt).toContain('# Contract')
+    expect(prompt).toContain('custom-pricelist-api')
+    expect(prompt).toContain('OVERVIEW-TEMPLATE')
+    expect(prompt).toContain('SERVICE-TEMPLATE')
+    expect(prompt).toContain('TASK-TEMPLATE')
+  })
+
+  const templateFiles: Record<string, string> = {
+    'prompt.md': 'C',
+    'overview.md': 'O',
+    'service.md': 'S',
+    'task.md': 'T'
+  }
+
+  it('omits the CLAUDE.md instruction by default', async () => {
+    const prompt = await buildWikiGenerationPrompt({
+      repoName: 'demo',
+      readTemplateFile: async (name) => templateFiles[name]
+    })
+    expect(prompt).not.toContain('CLAUDE.md')
+  })
+
+  it('appends a CLAUDE.md instruction when addClaudeMdInstruction is true', async () => {
+    const prompt = await buildWikiGenerationPrompt({
+      repoName: 'demo',
+      readTemplateFile: async (name) => templateFiles[name],
+      addClaudeMdInstruction: true
+    })
+    expect(prompt).toContain('CLAUDE.md')
+    expect(prompt).toMatch(/create it/i)
+  })
+})

--- a/src/main/wiki/wiki-generation-prompt.ts
+++ b/src/main/wiki/wiki-generation-prompt.ts
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { app } from 'electron'
+
+export function wikiTemplatesDirCandidates(env: {
+  isPackaged: boolean
+  resourcesPath: string | undefined
+  appPath: string
+}): string[] {
+  const candidates: string[] = []
+  // Why: electron-builder ships resources/ via asarUnpack, which lands under
+  // app.asar.unpacked/resources rather than directly under Resources — probe
+  // both plus the unpacked-app-path fallback (mirrors getLocalRelayCandidates).
+  if (env.isPackaged && env.resourcesPath) {
+    candidates.push(join(env.resourcesPath, 'wiki-templates'))
+    candidates.push(join(env.resourcesPath, 'app.asar.unpacked', 'resources', 'wiki-templates'))
+  }
+  candidates.push(join(env.appPath, 'resources', 'wiki-templates'))
+  return [...new Set(candidates)]
+}
+
+export function resolveWikiTemplatesDir(): string {
+  return wikiTemplatesDirCandidates({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    appPath: app.getAppPath()
+  })[0]
+}
+
+const CLAUDE_MD_INSTRUCTION = [
+  '',
+  '## Also update CLAUDE.md',
+  'In addition to the wiki, ensure a `CLAUDE.md` file exists at the repository root and contains a',
+  'short instruction about the wiki. If `CLAUDE.md` does not exist, create it. If it exists but has',
+  'no wiki section, append one; do not duplicate an existing wiki section. The instruction must tell',
+  'future agents: this repository has a `.wiki/` folder (root `.wiki/Home.md`) documenting the',
+  'project — keep it up to date when changing architecture, data, interfaces, or business logic.'
+].join('\n')
+
+export async function buildWikiGenerationPrompt(input: {
+  repoName: string
+  readTemplateFile: (name: string) => Promise<string>
+  addClaudeMdInstruction?: boolean
+}): Promise<string> {
+  const [contract, overview, service, task] = await Promise.all([
+    input.readTemplateFile('prompt.md'),
+    input.readTemplateFile('overview.md'),
+    input.readTemplateFile('service.md'),
+    input.readTemplateFile('task.md')
+  ])
+  const sections = [
+    contract.trim(),
+    `\nRepository: **${input.repoName}**. Generate the wiki in the \`.wiki/\` folder of this repository.`
+  ]
+  if (input.addClaudeMdInstruction) {
+    sections.push(CLAUDE_MD_INSTRUCTION)
+  }
+  sections.push(
+    '\n---\n## Template: repository (overview)\n',
+    overview.trim(),
+    '\n---\n## Template: service\n',
+    service.trim(),
+    '\n---\n## Template: task\n',
+    task.trim()
+  )
+  return sections.join('\n')
+}
+
+export async function readWikiTemplateFile(name: string): Promise<string> {
+  const candidates = wikiTemplatesDirCandidates({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    appPath: app.getAppPath()
+  })
+  const triedPaths: string[] = []
+  for (const dir of candidates) {
+    const filePath = join(dir, name)
+    triedPaths.push(filePath)
+    try {
+      return await readFile(filePath, 'utf8')
+    } catch {
+      // Why: try the next candidate; only surface a failure once all are exhausted.
+    }
+  }
+  throw new Error(`Wiki template "${name}" not found. Tried: ${triedPaths.join(', ')}`)
+}

--- a/src/main/wiki/wiki-generation-prompt.ts
+++ b/src/main/wiki/wiki-generation-prompt.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { app } from 'electron'
 
+/** Lists candidate directories that may hold the wiki-generation prompt templates, in lookup order. */
 export function wikiTemplatesDirCandidates(env: {
   isPackaged: boolean
   resourcesPath: string | undefined
@@ -19,6 +20,7 @@ export function wikiTemplatesDirCandidates(env: {
   return [...new Set(candidates)]
 }
 
+/** Resolves the first candidate wiki-templates directory for the running Electron app. */
 export function resolveWikiTemplatesDir(): string {
   return wikiTemplatesDirCandidates({
     isPackaged: app.isPackaged,
@@ -37,6 +39,7 @@ const CLAUDE_MD_INSTRUCTION = [
   'project — keep it up to date when changing architecture, data, interfaces, or business logic.'
 ].join('\n')
 
+/** Assembles the full wiki-generation prompt from the contract and template files, optionally appending the CLAUDE.md instruction. */
 export async function buildWikiGenerationPrompt(input: {
   repoName: string
   readTemplateFile: (name: string) => Promise<string>
@@ -66,6 +69,7 @@ export async function buildWikiGenerationPrompt(input: {
   return sections.join('\n')
 }
 
+/** Reads the named wiki template file, trying each candidate templates directory until one succeeds. */
 export async function readWikiTemplateFile(name: string): Promise<string> {
   const candidates = wikiTemplatesDirCandidates({
     isPackaged: app.isPackaged,

--- a/src/main/wiki/wiki-generation-service.test.ts
+++ b/src/main/wiki/wiki-generation-service.test.ts
@@ -147,8 +147,9 @@ describe('WikiGenerationService', () => {
     })
   })
 
-  it('cancels a running generation, kills the process, and treats the following close as canceled', () => {
+  it('cancels a running generation, kills the process, and preserves accumulated output', () => {
     service.start({ worktreeId: 'w1', cwd: '/repo', agent: 'claude', prompt: 'PROMPT' })
+    child.stdout.emit('data', Buffer.from('partial output'))
     service.cancel('w1')
     expect(killProcessTree).toHaveBeenCalledWith(child)
     expect(child.kill).toHaveBeenCalledWith('SIGKILL')
@@ -156,7 +157,7 @@ describe('WikiGenerationService', () => {
     expect(emitChanged).toHaveBeenLastCalledWith({
       worktreeId: 'w1',
       running: false,
-      output: '',
+      output: 'partial output',
       done: true
     })
     expect(service.getStatus('w1')).toBeNull()

--- a/src/main/wiki/wiki-generation-service.test.ts
+++ b/src/main/wiki/wiki-generation-service.test.ts
@@ -1,0 +1,190 @@
+import type { ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TuiAgent } from '../../shared/types'
+
+const killProcessTree = vi.fn((child: { kill: (signal: string) => void }) => child.kill('SIGKILL'))
+vi.mock('./wiki-generation-process', () => ({
+  killProcessTree: (child: { kill: (signal: string) => void }) => killProcessTree(child)
+}))
+
+import { WikiGenerationService, type WikiGenerationServiceDeps } from './wiki-generation-service'
+
+type MockChild = EventEmitter & {
+  pid: number
+  kill: ReturnType<typeof vi.fn>
+  stdout: EventEmitter
+  stderr: EventEmitter
+}
+
+function createMockChild(): MockChild {
+  const child = new EventEmitter() as MockChild
+  child.pid = 4321
+  child.kill = vi.fn()
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child
+}
+
+describe('WikiGenerationService', () => {
+  let emitChanged: ReturnType<typeof vi.fn<WikiGenerationServiceDeps['emitChanged']>>
+  let spawnAgent: ReturnType<typeof vi.fn<WikiGenerationServiceDeps['spawnAgent']>>
+  let resolveBinary: ReturnType<typeof vi.fn<(agent: TuiAgent) => string>>
+  let service: WikiGenerationService
+  let child: MockChild
+
+  beforeEach(() => {
+    killProcessTree.mockClear()
+    child = createMockChild()
+    emitChanged = vi.fn()
+    resolveBinary = vi.fn(() => 'claude')
+    spawnAgent = vi.fn(() => child as unknown as ChildProcess)
+    service = new WikiGenerationService({
+      resolveBinary,
+      emitChanged,
+      spawnAgent,
+      now: () => 1000
+    })
+  })
+
+  it('starts a generation and reports running status', () => {
+    const result = service.start({
+      worktreeId: 'w1',
+      cwd: '/repo',
+      agent: 'claude',
+      prompt: 'PROMPT'
+    })
+    expect(result).toEqual({ ok: true })
+    expect(spawnAgent).toHaveBeenCalledWith({
+      binary: 'claude',
+      args: ['-p', '--dangerously-skip-permissions'],
+      cwd: '/repo',
+      prompt: 'PROMPT',
+      promptViaStdin: true
+    })
+    expect(service.getStatus('w1')).toEqual({ running: true, output: '' })
+  })
+
+  it('appends stdout to output and emits changed with running:true', () => {
+    service.start({ worktreeId: 'w1', cwd: '/repo', agent: 'claude', prompt: 'PROMPT' })
+    child.stdout.emit('data', Buffer.from('generating...'))
+    expect(service.getStatus('w1')).toEqual({ running: true, output: 'generating...' })
+    expect(emitChanged).toHaveBeenLastCalledWith({
+      worktreeId: 'w1',
+      running: true,
+      output: 'generating...'
+    })
+  })
+
+  it('throttles rapid stdout emits by the injected clock, but always emits the terminal event', () => {
+    // Why: now() is a counter here (not the fixed 1000 from beforeEach) so we can
+    // observe both a throttled chunk (same timestamp) and an un-throttled one
+    // (>= WIKI_GENERATION_EMIT_INTERVAL_MS later) deterministically.
+    let currentNow = 1000
+    const throttledNow = vi.fn(() => currentNow)
+    const throttledEmit = vi.fn<WikiGenerationServiceDeps['emitChanged']>()
+    const throttledChild = createMockChild()
+    const throttledSpawn = vi.fn(() => throttledChild as unknown as ChildProcess)
+    const throttledService = new WikiGenerationService({
+      resolveBinary,
+      emitChanged: throttledEmit,
+      spawnAgent: throttledSpawn,
+      now: throttledNow
+    })
+    throttledService.start({ worktreeId: 'w1', cwd: '/repo', agent: 'claude', prompt: 'PROMPT' })
+    throttledChild.stdout.emit('data', Buffer.from('a'))
+    throttledChild.stdout.emit('data', Buffer.from('b')) // same timestamp -> coalesced
+    expect(throttledEmit).toHaveBeenCalledTimes(1)
+    expect(throttledEmit).toHaveBeenLastCalledWith({ worktreeId: 'w1', running: true, output: 'a' })
+
+    currentNow += 200
+    throttledChild.stdout.emit('data', Buffer.from('c'))
+    expect(throttledEmit).toHaveBeenCalledTimes(2)
+    expect(throttledEmit).toHaveBeenLastCalledWith({
+      worktreeId: 'w1',
+      running: true,
+      output: 'abc'
+    })
+
+    // Terminal event must never be throttled, even without the clock advancing.
+    throttledChild.emit('close', 0)
+    expect(throttledEmit).toHaveBeenCalledTimes(3)
+    expect(throttledEmit).toHaveBeenLastCalledWith({
+      worktreeId: 'w1',
+      running: false,
+      output: 'abc',
+      done: true
+    })
+  })
+
+  it('emits done:true and clears status when the process closes with code 0', () => {
+    service.start({ worktreeId: 'w1', cwd: '/repo', agent: 'claude', prompt: 'PROMPT' })
+    child.stdout.emit('data', Buffer.from('done'))
+    child.emit('close', 0)
+    expect(emitChanged).toHaveBeenLastCalledWith({
+      worktreeId: 'w1',
+      running: false,
+      output: 'done',
+      done: true
+    })
+    expect(service.getStatus('w1')).toBeNull()
+  })
+
+  it('records an error status when the process closes with a nonzero code', () => {
+    service.start({ worktreeId: 'w1', cwd: '/repo', agent: 'claude', prompt: 'PROMPT' })
+    child.stderr.emit('data', Buffer.from('boom'))
+    child.emit('close', 1)
+    expect(emitChanged).toHaveBeenLastCalledWith({
+      worktreeId: 'w1',
+      running: false,
+      output: 'boom',
+      error: 'Generation exited with code 1.'
+    })
+    expect(service.getStatus('w1')).toEqual({
+      running: false,
+      output: 'boom',
+      error: 'Generation exited with code 1.'
+    })
+  })
+
+  it('cancels a running generation, kills the process, and treats the following close as canceled', () => {
+    service.start({ worktreeId: 'w1', cwd: '/repo', agent: 'claude', prompt: 'PROMPT' })
+    service.cancel('w1')
+    expect(killProcessTree).toHaveBeenCalledWith(child)
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    child.emit('close', 137)
+    expect(emitChanged).toHaveBeenLastCalledWith({
+      worktreeId: 'w1',
+      running: false,
+      output: '',
+      done: true
+    })
+    expect(service.getStatus('w1')).toBeNull()
+  })
+
+  it('returns ok:false for an unsupported agent without spawning', () => {
+    const result = service.start({
+      worktreeId: 'w1',
+      cwd: '/repo',
+      agent: 'aider',
+      prompt: 'PROMPT'
+    })
+    expect(result).toEqual({
+      ok: false,
+      error: 'Agent "aider" does not support background wiki generation.'
+    })
+    expect(spawnAgent).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent when starting twice while already running', () => {
+    service.start({ worktreeId: 'w1', cwd: '/repo', agent: 'claude', prompt: 'PROMPT' })
+    const second = service.start({
+      worktreeId: 'w1',
+      cwd: '/repo',
+      agent: 'claude',
+      prompt: 'PROMPT'
+    })
+    expect(second).toEqual({ ok: true })
+    expect(spawnAgent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/wiki/wiki-generation-service.ts
+++ b/src/main/wiki/wiki-generation-service.ts
@@ -1,0 +1,147 @@
+import type { ChildProcess } from 'node:child_process'
+import type { TuiAgent } from '../../shared/types'
+import { buildWikiHeadlessArgs } from './wiki-generation-command'
+import { killProcessTree } from './wiki-generation-process'
+
+export type WikiGenerationStatus = { running: boolean; output: string; error?: string }
+
+export type WikiGenerationServiceDeps = {
+  // Resolve the agent launch binary (cmd override or TUI_AGENT_CONFIG launchCmd). See wiring notes.
+  resolveBinary: (agent: TuiAgent) => string
+  // Emit a status snapshot to the renderer (webContents.send('wiki:generationChanged', payload)).
+  emitChanged: (payload: { worktreeId: string } & WikiGenerationStatus & { done?: boolean }) => void
+  // Injected for tests; defaults to the real spawn wrapper in production.
+  spawnAgent: (input: {
+    binary: string
+    args: string[]
+    cwd: string
+    prompt: string
+    promptViaStdin: boolean
+  }) => ChildProcess
+  now: () => number
+}
+
+const MAX_OUTPUT_TAIL = 64 * 1024
+// Why: coalesce emitChanged so a chatty child process doesn't flood the
+// renderer with an IPC message per stdout chunk.
+const WIKI_GENERATION_EMIT_INTERVAL_MS = 200
+
+type GenerationRecord = {
+  status: 'running' | 'error'
+  output: string
+  error?: string
+  startedAt: number
+  canceled?: boolean
+  lastEmitAt?: number
+}
+
+// Why: owns the wiki-generation child process + per-worktree state in the main
+// process so it survives renderer unmount/remount (sidebar tab switches).
+export class WikiGenerationService {
+  private readonly records = new Map<string, GenerationRecord>()
+  private readonly children = new Map<string, ChildProcess>()
+
+  constructor(private readonly deps: WikiGenerationServiceDeps) {}
+
+  start(input: {
+    worktreeId: string
+    cwd: string
+    agent: TuiAgent
+    prompt: string
+  }): { ok: true } | { ok: false; error: string } {
+    if (this.records.get(input.worktreeId)?.status === 'running') {
+      return { ok: true } // idempotent: already generating
+    }
+    const headless = buildWikiHeadlessArgs(input.agent)
+    if (!headless) {
+      return {
+        ok: false,
+        error: `Agent "${input.agent}" does not support background wiki generation.`
+      }
+    }
+    const binary = this.deps.resolveBinary(input.agent)
+    this.records.set(input.worktreeId, {
+      status: 'running',
+      output: '',
+      startedAt: this.deps.now()
+    })
+    const child = this.deps.spawnAgent({
+      binary,
+      args: headless.args,
+      cwd: input.cwd,
+      prompt: input.prompt,
+      promptViaStdin: headless.promptViaStdin
+    })
+    this.children.set(input.worktreeId, child)
+    const append = (chunk: Buffer | string): void => {
+      const record = this.records.get(input.worktreeId)
+      if (!record) {
+        return
+      }
+      record.output = (record.output + chunk.toString()).slice(-MAX_OUTPUT_TAIL)
+      const now = this.deps.now()
+      if (now - (record.lastEmitAt ?? 0) >= WIKI_GENERATION_EMIT_INTERVAL_MS) {
+        record.lastEmitAt = now
+        this.deps.emitChanged({
+          worktreeId: input.worktreeId,
+          running: true,
+          output: record.output
+        })
+      }
+    }
+    child.stdout?.on('data', append)
+    child.stderr?.on('data', append)
+    child.on('error', (err) => this.finish(input.worktreeId, { failed: true, error: err.message }))
+    child.on('close', (code) =>
+      this.finish(input.worktreeId, {
+        failed: code !== 0,
+        error: code !== 0 ? `Generation exited with code ${code}.` : undefined
+      })
+    )
+    return { ok: true }
+  }
+
+  private finish(worktreeId: string, result: { failed: boolean; error?: string }): void {
+    this.children.delete(worktreeId)
+    if (this.records.get(worktreeId)?.canceled) {
+      this.records.delete(worktreeId)
+      this.deps.emitChanged({ worktreeId, running: false, output: '', done: true })
+      return
+    }
+    const record = this.records.get(worktreeId)
+    const output = record?.output ?? ''
+    if (result.failed) {
+      this.records.set(worktreeId, {
+        status: 'error',
+        output,
+        error: result.error,
+        startedAt: record?.startedAt ?? this.deps.now()
+      })
+      this.deps.emitChanged({ worktreeId, running: false, output, error: result.error })
+    } else {
+      this.records.delete(worktreeId)
+      this.deps.emitChanged({ worktreeId, running: false, output, done: true })
+    }
+  }
+
+  getStatus(worktreeId: string): WikiGenerationStatus | null {
+    const record = this.records.get(worktreeId)
+    if (!record) {
+      return null
+    }
+    return { running: record.status === 'running', output: record.output, error: record.error }
+  }
+
+  cancel(worktreeId: string): void {
+    const child = this.children.get(worktreeId)
+    if (!child) {
+      this.records.delete(worktreeId)
+      return
+    }
+    const record = this.records.get(worktreeId)
+    if (record) {
+      record.canceled = true
+    }
+    killProcessTree(child)
+  }
+}

--- a/src/main/wiki/wiki-generation-service.ts
+++ b/src/main/wiki/wiki-generation-service.ts
@@ -1,15 +1,17 @@
 import type { ChildProcess } from 'node:child_process'
-import type { TuiAgent } from '../../shared/types'
+import type { TuiAgent, WikiGenerationChangedPayload } from '../../shared/types'
 import { buildWikiHeadlessArgs } from './wiki-generation-command'
 import { killProcessTree } from './wiki-generation-process'
 
+/** Snapshot of a worktree's background wiki-generation run: whether it's running, its accumulated output, and any error. */
 export type WikiGenerationStatus = { running: boolean; output: string; error?: string }
 
+/** Dependencies injected into `WikiGenerationService` so it can resolve binaries, notify the renderer, spawn processes, and get the current time. */
 export type WikiGenerationServiceDeps = {
   // Resolve the agent launch binary (cmd override or TUI_AGENT_CONFIG launchCmd). See wiring notes.
   resolveBinary: (agent: TuiAgent) => string
   // Emit a status snapshot to the renderer (webContents.send('wiki:generationChanged', payload)).
-  emitChanged: (payload: { worktreeId: string } & WikiGenerationStatus & { done?: boolean }) => void
+  emitChanged: (payload: WikiGenerationChangedPayload) => void
   // Injected for tests; defaults to the real spawn wrapper in production.
   spawnAgent: (input: {
     binary: string
@@ -35,14 +37,17 @@ type GenerationRecord = {
   lastEmitAt?: number
 }
 
+/** Runs and tracks a background wiki-generation agent process per worktree. */
 // Why: owns the wiki-generation child process + per-worktree state in the main
 // process so it survives renderer unmount/remount (sidebar tab switches).
 export class WikiGenerationService {
   private readonly records = new Map<string, GenerationRecord>()
   private readonly children = new Map<string, ChildProcess>()
 
+  /** Creates the service with its injected binary-resolution, IPC, spawn, and clock dependencies. */
   constructor(private readonly deps: WikiGenerationServiceDeps) {}
 
+  /** Starts a wiki-generation run for the worktree, or returns an error if the agent has no headless mode. Idempotent while already running. */
   start(input: {
     worktreeId: string
     cwd: string
@@ -103,12 +108,13 @@ export class WikiGenerationService {
 
   private finish(worktreeId: string, result: { failed: boolean; error?: string }): void {
     this.children.delete(worktreeId)
-    if (this.records.get(worktreeId)?.canceled) {
+    const record = this.records.get(worktreeId)
+    if (record?.canceled) {
       this.records.delete(worktreeId)
-      this.deps.emitChanged({ worktreeId, running: false, output: '', done: true })
+      // Why: preserve output accumulated before Stop so the panel can still show it.
+      this.deps.emitChanged({ worktreeId, running: false, output: record.output, done: true })
       return
     }
-    const record = this.records.get(worktreeId)
     const output = record?.output ?? ''
     if (result.failed) {
       this.records.set(worktreeId, {
@@ -124,6 +130,7 @@ export class WikiGenerationService {
     }
   }
 
+  /** Returns the worktree's current generation status, or null if no run is tracked. */
   getStatus(worktreeId: string): WikiGenerationStatus | null {
     const record = this.records.get(worktreeId)
     if (!record) {
@@ -132,6 +139,7 @@ export class WikiGenerationService {
     return { running: record.status === 'running', output: record.output, error: record.error }
   }
 
+  /** Cancels the worktree's running generation, killing its process tree and preserving output already emitted. */
   cancel(worktreeId: string): void {
     const child = this.children.get(worktreeId)
     if (!child) {

--- a/src/main/wiki/wiki-repository-ssh.test.ts
+++ b/src/main/wiki/wiki-repository-ssh.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { IFilesystemProvider } from '../providers/types'
 import { readWikiNoteSsh, readWikiOverviewSsh } from './wiki-repository-ssh'
 
-const WORKTREE = '/repo'
-const WIKI_DIR = '/repo/.wiki'
+const WORKTREE = '/remote/repo'
+const WIKI_DIR = '/remote/repo/.wiki'
 
 function fakeProvider(overrides: Partial<IFilesystemProvider>): IFilesystemProvider {
   const notImplemented = () => {
@@ -67,13 +67,18 @@ describe('readWikiOverviewSsh', () => {
 
 describe('readWikiNoteSsh', () => {
   it('reads a note', async () => {
+    const statSpy = vi.fn(async () => ({ size: 10, type: 'file' as const, mtime: 0 }))
+    const readFileSpy = vi.fn(async () => ({ content: '# Home', isBinary: false }))
     const provider = fakeProvider({
       realpath: async (p: string) => p,
-      stat: async () => ({ size: 10, type: 'file', mtime: 0 }),
-      readFile: async () => ({ content: '# Home', isBinary: false })
+      stat: statSpy,
+      readFile: readFileSpy
     })
     const result = await readWikiNoteSsh(provider, WORKTREE, 'Home.md')
     expect(result).toEqual({ relativePath: 'Home.md', content: '# Home' })
+    // Why: regression guard for the leading-slash strip bug — provider must see absolute paths.
+    expect(statSpy).toHaveBeenCalledWith('/remote/repo/.wiki/Home.md')
+    expect(readFileSpy).toHaveBeenCalledWith('/remote/repo/.wiki/Home.md')
   })
 
   it('rejects when stat.type is not file', async () => {

--- a/src/main/wiki/wiki-repository-ssh.test.ts
+++ b/src/main/wiki/wiki-repository-ssh.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import type { IFilesystemProvider } from '../providers/types'
+import { readWikiNoteSsh, readWikiOverviewSsh } from './wiki-repository-ssh'
+
+const WORKTREE = '/repo'
+const WIKI_DIR = '/repo/.wiki'
+
+function fakeProvider(overrides: Partial<IFilesystemProvider>): IFilesystemProvider {
+  const notImplemented = () => {
+    throw new Error('not implemented')
+  }
+  return {
+    readDir: notImplemented,
+    readFile: notImplemented,
+    writeFile: notImplemented,
+    writeFileBase64: notImplemented,
+    writeFileBase64Chunk: notImplemented,
+    stat: notImplemented,
+    deletePath: notImplemented,
+    createFile: notImplemented,
+    createDir: notImplemented,
+    createDirNoClobber: notImplemented,
+    rename: notImplemented,
+    renameNoClobber: notImplemented,
+    copy: notImplemented,
+    realpath: notImplemented,
+    search: notImplemented,
+    listFiles: notImplemented,
+    watch: notImplemented,
+    ...overrides
+  } as IFilesystemProvider
+}
+
+describe('readWikiOverviewSsh', () => {
+  it('reports no wiki when listFiles returns empty', async () => {
+    const provider = fakeProvider({ listFiles: async () => [] })
+    expect(await readWikiOverviewSsh(provider, WORKTREE, 'my-repo')).toEqual({
+      hasWiki: false,
+      rootRelativePath: null,
+      notes: []
+    })
+  })
+
+  it('reports no wiki when listFiles throws', async () => {
+    const provider = fakeProvider({
+      listFiles: async () => {
+        throw new Error('no such dir')
+      }
+    })
+    expect(await readWikiOverviewSsh(provider, WORKTREE, 'my-repo')).toEqual({
+      hasWiki: false,
+      rootRelativePath: null,
+      notes: []
+    })
+  })
+
+  it('lists notes filtered to markdown and sorted, with Home.md as root', async () => {
+    const provider = fakeProvider({
+      listFiles: async () => ['notes/Feature.md', 'Home.md', 'image.png']
+    })
+    const result = await readWikiOverviewSsh(provider, WORKTREE, 'my-repo')
+    expect(result.hasWiki).toBe(true)
+    expect(result.rootRelativePath).toBe('Home.md')
+    expect(result.notes).toEqual(['Home.md', 'notes/Feature.md'])
+  })
+})
+
+describe('readWikiNoteSsh', () => {
+  it('reads a note', async () => {
+    const provider = fakeProvider({
+      realpath: async (p: string) => p,
+      stat: async () => ({ size: 10, type: 'file', mtime: 0 }),
+      readFile: async () => ({ content: '# Home', isBinary: false })
+    })
+    const result = await readWikiNoteSsh(provider, WORKTREE, 'Home.md')
+    expect(result).toEqual({ relativePath: 'Home.md', content: '# Home' })
+  })
+
+  it('rejects when stat.type is not file', async () => {
+    const provider = fakeProvider({
+      realpath: async (p: string) => p,
+      stat: async () => ({ size: 0, type: 'directory', mtime: 0 })
+    })
+    expect(await readWikiNoteSsh(provider, WORKTREE, 'Home.md')).toBeNull()
+  })
+
+  it('rejects binary content', async () => {
+    const provider = fakeProvider({
+      realpath: async (p: string) => p,
+      stat: async () => ({ size: 10, type: 'file', mtime: 0 }),
+      readFile: async () => ({ content: '', isBinary: true })
+    })
+    expect(await readWikiNoteSsh(provider, WORKTREE, 'Home.md')).toBeNull()
+  })
+
+  it('rejects traversal outside .wiki', async () => {
+    const provider = fakeProvider({})
+    expect(await readWikiNoteSsh(provider, WORKTREE, '../secret.md')).toBeNull()
+  })
+
+  it('rejects a symlink escape outside the wiki dir', async () => {
+    const provider = fakeProvider({
+      realpath: async (p: string) => (p === `${WIKI_DIR}/leak.md` ? '/repo/secret.md' : WIKI_DIR)
+    })
+    expect(await readWikiNoteSsh(provider, WORKTREE, 'leak.md')).toBeNull()
+  })
+})

--- a/src/main/wiki/wiki-repository-ssh.ts
+++ b/src/main/wiki/wiki-repository-ssh.ts
@@ -1,0 +1,65 @@
+import { posix } from 'node:path'
+import type { IFilesystemProvider } from '../providers/types'
+import { isMarkdownDocumentName } from '../ipc/markdown-documents'
+import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
+import { isContainedRelativePath, resolveWikiDir, shapeWikiOverview } from './wiki-repository'
+
+function toPosix(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\/+/, '')
+}
+
+export async function readWikiOverviewSsh(
+  provider: IFilesystemProvider,
+  worktreePath: string,
+  repoName: string
+): Promise<{ hasWiki: boolean; rootRelativePath: string | null; notes: string[] }> {
+  const wikiDir = resolveWikiDir(worktreePath)
+  let relPaths: string[]
+  try {
+    relPaths = await provider.listFiles(wikiDir)
+  } catch {
+    return { hasWiki: false, rootRelativePath: null, notes: [] }
+  }
+  const notes = relPaths
+    .map(toPosix)
+    .filter((p) => isMarkdownDocumentName(p) && isContainedRelativePath(p))
+    .sort((a, b) => a.localeCompare(b))
+  return shapeWikiOverview(notes, repoName)
+}
+
+export async function readWikiNoteSsh(
+  provider: IFilesystemProvider,
+  worktreePath: string,
+  relativePath: string
+): Promise<{ relativePath: string; content: string } | null> {
+  if (!isContainedRelativePath(relativePath)) {
+    return null
+  }
+  const normalized = toPosix(relativePath)
+  if (!isMarkdownDocumentName(normalized)) {
+    return null
+  }
+  const wikiDir = resolveWikiDir(worktreePath)
+  const abs = posix.join(toPosix(wikiDir), normalized)
+  try {
+    // Why: reject symlink escapes — the resolved real path must stay inside .wiki/.
+    const [realWikiDir, realAbs] = await Promise.all([
+      provider.realpath(wikiDir),
+      provider.realpath(abs)
+    ])
+    if (!isPathInsideOrEqual(toPosix(realWikiDir), toPosix(realAbs))) {
+      return null
+    }
+    const fileStat = await provider.stat(abs)
+    if (fileStat.type !== 'file') {
+      return null
+    }
+    const result = await provider.readFile(abs)
+    if (result.isBinary) {
+      return null
+    }
+    return { relativePath: normalized, content: result.content }
+  } catch {
+    return null
+  }
+}

--- a/src/main/wiki/wiki-repository-ssh.ts
+++ b/src/main/wiki/wiki-repository-ssh.ts
@@ -8,6 +8,13 @@ function toPosix(p: string): string {
   return p.replace(/\\/g, '/').replace(/^\/+/, '')
 }
 
+// Why: wikiDir/realpath values are absolute remote paths — toPosix's leading-slash
+// strip would turn them relative and break provider.stat/readFile/realpath.
+function toRemotePosix(p: string): string {
+  return p.replace(/\\/g, '/')
+}
+
+/** Lists a remote worktree's `.wiki/` notes over SSH and resolves the root note, mirroring the local `readWikiOverview`. */
 export async function readWikiOverviewSsh(
   provider: IFilesystemProvider,
   worktreePath: string,
@@ -27,6 +34,7 @@ export async function readWikiOverviewSsh(
   return shapeWikiOverview(notes, repoName)
 }
 
+/** Reads one `.wiki/` note over SSH, rejecting paths that escape `.wiki/` (including via symlinks) or aren't markdown. */
 export async function readWikiNoteSsh(
   provider: IFilesystemProvider,
   worktreePath: string,
@@ -40,14 +48,14 @@ export async function readWikiNoteSsh(
     return null
   }
   const wikiDir = resolveWikiDir(worktreePath)
-  const abs = posix.join(toPosix(wikiDir), normalized)
+  const abs = posix.join(toRemotePosix(wikiDir), normalized)
   try {
     // Why: reject symlink escapes — the resolved real path must stay inside .wiki/.
     const [realWikiDir, realAbs] = await Promise.all([
       provider.realpath(wikiDir),
       provider.realpath(abs)
     ])
-    if (!isPathInsideOrEqual(toPosix(realWikiDir), toPosix(realAbs))) {
+    if (!isPathInsideOrEqual(toRemotePosix(realWikiDir), toRemotePosix(realAbs))) {
       return null
     }
     const fileStat = await provider.stat(abs)

--- a/src/main/wiki/wiki-repository.test.ts
+++ b/src/main/wiki/wiki-repository.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  readWikiNote,
+  readWikiOverview,
+  resolveWikiRootRelativePath,
+  resolveWikiTarget
+} from './wiki-repository'
+
+let root: string
+
+async function seedWiki(files: Record<string, string>): Promise<void> {
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, '.wiki', rel)
+    await mkdir(join(abs, '..'), { recursive: true })
+    await writeFile(abs, body, 'utf8')
+  }
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'wiki-repo-'))
+})
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('readWikiOverview', () => {
+  it('reports no wiki when .wiki is missing', async () => {
+    const result = await readWikiOverview(root, 'my-repo')
+    expect(result).toEqual({ hasWiki: false, rootRelativePath: null, notes: [] })
+  })
+
+  it('lists notes and resolves Home.md as root', async () => {
+    await seedWiki({ 'Home.md': '# Home', 'Бизнес-логика/Feature.md': '# F' })
+    const result = await readWikiOverview(root, 'my-repo')
+    expect(result.hasWiki).toBe(true)
+    expect(result.rootRelativePath).toBe('Home.md')
+    expect(result.notes).toEqual(['Home.md', 'Бизнес-логика/Feature.md'])
+  })
+})
+
+describe('resolveWikiRootRelativePath', () => {
+  it('prefers Home over repo-named over index over README over first', () => {
+    expect(resolveWikiRootRelativePath(['README.md', 'my-repo.md', 'Home.md'], 'my-repo')).toBe(
+      'Home.md'
+    )
+    expect(resolveWikiRootRelativePath(['README.md', 'my-repo.md'], 'my-repo')).toBe('my-repo.md')
+    expect(resolveWikiRootRelativePath(['b.md', 'a.md'], 'my-repo')).toBe('a.md')
+    expect(resolveWikiRootRelativePath([], 'my-repo')).toBeNull()
+  })
+})
+
+describe('readWikiNote', () => {
+  it('reads a note by relative path', async () => {
+    await seedWiki({ 'Home.md': '# Home' })
+    const note = await readWikiNote(root, 'Home.md')
+    expect(note).toEqual({ relativePath: 'Home.md', content: '# Home' })
+  })
+
+  it('rejects traversal outside .wiki', async () => {
+    await seedWiki({ 'Home.md': '# Home' })
+    expect(await readWikiNote(root, '../secret.md')).toBeNull()
+    expect(await readWikiNote(root, '../../etc/passwd')).toBeNull()
+  })
+
+  it('rejects non-markdown', async () => {
+    expect(await readWikiNote(root, 'Home.txt')).toBeNull()
+  })
+
+  it('rejects a symlink inside .wiki that points outside it', async () => {
+    const outside = join(root, 'secret.md')
+    await writeFile(outside, '# Secret', 'utf8')
+    await mkdir(join(root, '.wiki'), { recursive: true })
+    try {
+      await symlink(outside, join(root, '.wiki', 'leak.md'))
+    } catch {
+      // Why: symlink creation can be unsupported (e.g. Windows without privilege) — skip gracefully.
+      return
+    }
+    expect(await readWikiNote(root, 'leak.md')).toBeNull()
+  })
+
+  it('rejects Windows-style drive/backslash paths', async () => {
+    await seedWiki({ 'Home.md': '# Home' })
+    expect(await readWikiNote(root, 'D:\\secret.md')).toBeNull()
+    expect(await readWikiNote(root, 'sub\\..\\..\\secret.md')).toBeNull()
+  })
+})
+
+describe('resolveWikiTarget', () => {
+  const notes = ['Home.md', 'Бизнес-логика/Feature.md', 'Сервисы/svc.md']
+  it('resolves a wikilink by basename', () => {
+    expect(resolveWikiTarget(notes, 'Home.md', '[[Feature]]')).toBe('Бизнес-логика/Feature.md')
+    expect(resolveWikiTarget(notes, 'Home.md', 'Feature')).toBe('Бизнес-логика/Feature.md')
+  })
+  it('resolves a relative markdown link against the source note dir', () => {
+    expect(resolveWikiTarget(notes, 'Бизнес-логика/Feature.md', '../Сервисы/svc.md')).toBe(
+      'Сервисы/svc.md'
+    )
+  })
+  it('returns null for external or unknown targets', () => {
+    expect(resolveWikiTarget(notes, 'Home.md', 'https://example.com')).toBeNull()
+    expect(resolveWikiTarget(notes, 'Home.md', 'Nope')).toBeNull()
+  })
+  it('resolves percent-encoded links to notes with literal spaces', () => {
+    const spaced = ['Home.md', 'docsai — Architecture.md', 'Business logic/Contract check.md']
+    expect(resolveWikiTarget(spaced, 'Home.md', './docsai%20—%20Architecture.md')).toBe(
+      'docsai — Architecture.md'
+    )
+    expect(resolveWikiTarget(spaced, 'Home.md', './Business%20logic/Contract%20check.md')).toBe(
+      'Business logic/Contract check.md'
+    )
+  })
+})

--- a/src/main/wiki/wiki-repository.ts
+++ b/src/main/wiki/wiki-repository.ts
@@ -1,0 +1,177 @@
+import { readFile, readdir, realpath, stat } from 'node:fs/promises'
+import { join, posix, relative, resolve } from 'node:path'
+import { isMarkdownDocumentName } from '../ipc/markdown-documents'
+import { isDescendantOrEqual } from '../ipc/filesystem-auth'
+
+const WIKI_DIR = '.wiki'
+const ROOT_CANDIDATES = ['Home.md', 'index.md', 'README.md']
+
+export function resolveWikiDir(worktreePath: string): string {
+  return join(worktreePath, WIKI_DIR)
+}
+
+function toPosix(relativePath: string): string {
+  return relativePath.replace(/\\/g, '/')
+}
+
+export function isContainedRelativePath(relativePath: string): boolean {
+  // Why: reject traversal, and Windows drive-letter/backslash paths (Orca supports Windows).
+  if (!relativePath || relativePath.includes('\\') || /^[a-zA-Z]:/.test(relativePath)) {
+    return false
+  }
+  return !relativePath.split('/').includes('..')
+}
+
+async function listWikiNotes(wikiDir: string): Promise<string[]> {
+  const notes: string[] = []
+  async function visit(dir: string): Promise<void> {
+    let entries
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) {
+        continue
+      }
+      const abs = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === '.git' || entry.name === 'node_modules') {
+          continue
+        }
+        await visit(abs)
+        continue
+      }
+      if (entry.isFile() && isMarkdownDocumentName(entry.name)) {
+        notes.push(toPosix(relative(wikiDir, abs)))
+      }
+    }
+  }
+  await visit(wikiDir)
+  return notes.sort((a, b) => a.localeCompare(b))
+}
+
+export function resolveWikiRootRelativePath(notes: string[], repoName: string): string | null {
+  const ordered = [ROOT_CANDIDATES[0], `${repoName}.md`, ROOT_CANDIDATES[1], ROOT_CANDIDATES[2]]
+  for (const candidate of ordered) {
+    const match = notes.find((note) => note.toLowerCase() === candidate.toLowerCase())
+    if (match) {
+      return match
+    }
+  }
+  if (notes.length === 0) {
+    return null
+  }
+  // Why: "first .md" means alphabetically first, not first in input order.
+  return [...notes].sort((a, b) => a.localeCompare(b))[0]
+}
+
+export function shapeWikiOverview(
+  notes: string[],
+  repoName: string
+): { hasWiki: boolean; rootRelativePath: string | null; notes: string[] } {
+  if (notes.length === 0) {
+    return { hasWiki: false, rootRelativePath: null, notes: [] }
+  }
+  return { hasWiki: true, rootRelativePath: resolveWikiRootRelativePath(notes, repoName), notes }
+}
+
+export async function readWikiOverview(
+  worktreePath: string,
+  repoName: string
+): Promise<{ hasWiki: boolean; rootRelativePath: string | null; notes: string[] }> {
+  const wikiDir = resolveWikiDir(worktreePath)
+  const notes = await listWikiNotes(wikiDir)
+  return shapeWikiOverview(notes, repoName)
+}
+
+export async function readWikiNote(
+  worktreePath: string,
+  relativePath: string
+): Promise<{ relativePath: string; content: string } | null> {
+  // Why: check the raw input for backslashes/drive letters before toPosix would silently convert them away.
+  if (!isContainedRelativePath(relativePath)) {
+    return null
+  }
+  const normalized = toPosix(relativePath).replace(/^\/+/, '')
+  if (!isMarkdownDocumentName(normalized)) {
+    return null
+  }
+  const wikiDir = resolveWikiDir(worktreePath)
+  const abs = join(wikiDir, normalized)
+  // Why: defence in depth — confirm the resolved absolute path stays inside .wiki/.
+  const rel = relative(resolve(wikiDir), resolve(abs))
+  if (rel.startsWith('..')) {
+    return null
+  }
+  try {
+    // Why: resolve() is string-only, so a symlink in .wiki/ could still point outside it — check the real path too.
+    const [realWikiDir, realAbs] = await Promise.all([realpath(wikiDir), realpath(abs)])
+    if (!isDescendantOrEqual(realAbs, realWikiDir)) {
+      return null
+    }
+    const fileStat = await stat(abs)
+    if (!fileStat.isFile()) {
+      return null
+    }
+    const content = await readFile(abs, 'utf8')
+    return { relativePath: normalized, content }
+  } catch {
+    return null
+  }
+}
+
+// Why: agents write links with percent-encoded paths (spaces -> %20), but note
+// paths on disk keep literal spaces — decode before matching so links resolve.
+function safeDecodeHref(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+export function resolveWikiTarget(
+  notes: string[],
+  fromRelativePath: string,
+  rawHref: string
+): string | null {
+  const href = rawHref.trim()
+  if (!href || /^[a-z][a-z0-9+.-]*:/i.test(href)) {
+    return null
+  } // external scheme
+  const wikilink = href.match(/^\[\[([^\]|#]+)(?:[|#][^\]]*)?\]\]$/)
+  if (wikilink) {
+    const wanted = wikilink[1].trim().toLowerCase()
+    return (
+      notes.find((note) => {
+        const base = note.slice(note.lastIndexOf('/') + 1)
+        const name = base.replace(/\.(md|mdx|markdown)$/i, '')
+        return name.toLowerCase() === wanted || base.toLowerCase() === `${wanted}.md`
+      }) ?? null
+    )
+  }
+  const cleanHref = safeDecodeHref(href.replace(/^\.?\//, '').split(/[?#]/)[0])
+  if (!cleanHref) {
+    return null
+  }
+  const fromDir = fromRelativePath.includes('/')
+    ? fromRelativePath.slice(0, fromRelativePath.lastIndexOf('/'))
+    : ''
+  const joined = posix.normalize(fromDir ? `${fromDir}/${cleanHref}` : cleanHref)
+  if (joined.startsWith('..')) {
+    return null
+  }
+  const target = notes.find((note) => note === joined)
+  if (target) {
+    return target
+  }
+  // wikilink-style bare basename fallback
+  return (
+    notes.find(
+      (note) =>
+        note.slice(note.lastIndexOf('/') + 1).toLowerCase() === `${cleanHref.toLowerCase()}.md`
+    ) ?? null
+  )
+}

--- a/src/main/wiki/wiki-repository.ts
+++ b/src/main/wiki/wiki-repository.ts
@@ -6,6 +6,7 @@ import { isDescendantOrEqual } from '../ipc/filesystem-auth'
 const WIKI_DIR = '.wiki'
 const ROOT_CANDIDATES = ['Home.md', 'index.md', 'README.md']
 
+/** Returns the absolute path to a worktree's `.wiki/` directory. */
 export function resolveWikiDir(worktreePath: string): string {
   return join(worktreePath, WIKI_DIR)
 }
@@ -14,6 +15,7 @@ function toPosix(relativePath: string): string {
   return relativePath.replace(/\\/g, '/')
 }
 
+/** True if a relative path stays inside `.wiki/`: no `..` traversal, no backslashes, no Windows drive letters. */
 export function isContainedRelativePath(relativePath: string): boolean {
   // Why: reject traversal, and Windows drive-letter/backslash paths (Orca supports Windows).
   if (!relativePath || relativePath.includes('\\') || /^[a-zA-Z]:/.test(relativePath)) {
@@ -52,6 +54,7 @@ async function listWikiNotes(wikiDir: string): Promise<string[]> {
   return notes.sort((a, b) => a.localeCompare(b))
 }
 
+/** Picks the wiki's root/home note from `notes`: Home.md, `<repoName>.md`, index.md, README.md, else the alphabetically first note. */
 export function resolveWikiRootRelativePath(notes: string[], repoName: string): string | null {
   const ordered = [ROOT_CANDIDATES[0], `${repoName}.md`, ROOT_CANDIDATES[1], ROOT_CANDIDATES[2]]
   for (const candidate of ordered) {
@@ -67,6 +70,7 @@ export function resolveWikiRootRelativePath(notes: string[], repoName: string): 
   return [...notes].sort((a, b) => a.localeCompare(b))[0]
 }
 
+/** Builds the wiki overview result (hasWiki/rootRelativePath/notes) from a list of note paths. */
 export function shapeWikiOverview(
   notes: string[],
   repoName: string
@@ -77,6 +81,7 @@ export function shapeWikiOverview(
   return { hasWiki: true, rootRelativePath: resolveWikiRootRelativePath(notes, repoName), notes }
 }
 
+/** Lists a local worktree's `.wiki/` notes recursively and resolves its root note. */
 export async function readWikiOverview(
   worktreePath: string,
   repoName: string
@@ -86,6 +91,7 @@ export async function readWikiOverview(
   return shapeWikiOverview(notes, repoName)
 }
 
+/** Reads one local `.wiki/` note, rejecting paths that escape `.wiki/` (including via symlinks) or aren't markdown. */
 export async function readWikiNote(
   worktreePath: string,
   relativePath: string
@@ -132,6 +138,7 @@ function safeDecodeHref(value: string): string {
   }
 }
 
+/** Resolves a clicked link's href (wikilink, relative path, or bare basename) to a note path in `notes`, or null if it doesn't match one. */
 export function resolveWikiTarget(
   notes: string[],
   fromRelativePath: string,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -205,6 +205,7 @@ import type {
   WorkspaceSessionPatch,
   WorkspaceSessionState,
   WikiGenerateResult,
+  WikiGenerationChangedPayload,
   WikiReadResult
 } from '../shared/types'
 
@@ -878,11 +879,6 @@ export type AppApi = {
 }
 
 export type WikiGenerationStatus = { running: boolean; output: string; error?: string }
-
-export type WikiGenerationChangedPayload = WikiGenerationStatus & {
-  worktreeId: string
-  done?: boolean
-}
 
 export type WikiApi = {
   read: (args: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -203,7 +203,9 @@ import type {
   WorktreeSetupLaunch,
   WorktreeStartupLaunch,
   WorkspaceSessionPatch,
-  WorkspaceSessionState
+  WorkspaceSessionState,
+  WikiGenerateResult,
+  WikiReadResult
 } from '../shared/types'
 
 type GitLabRepoSelectorArgs = {
@@ -875,6 +877,28 @@ export type AppApi = {
   pickFloatingWorkspaceDirectory: () => Promise<string | null>
 }
 
+export type WikiGenerationStatus = { running: boolean; output: string; error?: string }
+
+export type WikiGenerationChangedPayload = WikiGenerationStatus & {
+  worktreeId: string
+  done?: boolean
+}
+
+export type WikiApi = {
+  read: (args: {
+    worktreeId: string
+    target?: string
+    fromRelativePath?: string
+  }) => Promise<WikiReadResult>
+  generate: (args: {
+    worktreeId: string
+    addClaudeMdInstruction?: boolean
+  }) => Promise<WikiGenerateResult>
+  generationStatus: (args: { worktreeId: string }) => Promise<WikiGenerationStatus | null>
+  cancelGeneration: (args: { worktreeId: string }) => Promise<{ ok: boolean }>
+  onGenerationChanged: (callback: (payload: WikiGenerationChangedPayload) => void) => () => void
+}
+
 export type PreloadApi = {
   app: AppApi
   orcaProfiles: {
@@ -911,6 +935,7 @@ export type PreloadApi = {
       args: OrcaProfileOrgMemberRemoveArgs
     ) => Promise<OrcaProfileOrgMemberMutationResult>
   }
+  wiki: WikiApi
   platform: {
     get: () => {
       platform: NodeJS.Platform

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -501,6 +501,26 @@ const api = {
     orgMemberChangeRole: (args) => ipcRenderer.invoke('orcaProfiles:orgMemberChangeRole', args),
     orgMemberRemove: (args) => ipcRenderer.invoke('orcaProfiles:orgMemberRemove', args)
   } satisfies PreloadApi['orcaProfiles'],
+  wiki: {
+    read: (args) => ipcRenderer.invoke('wiki:read', args),
+    generate: (args) => ipcRenderer.invoke('wiki:generate', args),
+    generationStatus: (args) => ipcRenderer.invoke('wiki:generationStatus', args),
+    cancelGeneration: (args) => ipcRenderer.invoke('wiki:cancelGeneration', args),
+    onGenerationChanged: (callback) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        payload: {
+          worktreeId: string
+          running: boolean
+          output: string
+          error?: string
+          done?: boolean
+        }
+      ) => callback(payload)
+      ipcRenderer.on('wiki:generationChanged', listener)
+      return () => ipcRenderer.removeListener('wiki:generationChanged', listener)
+    }
+  } satisfies PreloadApi['wiki'],
 
   platform: {
     get: () => ({

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -49,6 +49,7 @@ import type {
   SearchResult,
   TuiAgent,
   UpdateStatus,
+  WikiGenerationChangedPayload,
   WorktreeBaseStatusEvent,
   WorktreeDefaultTabsLaunch,
   WorktreeRemoteBranchConflictEvent
@@ -507,16 +508,8 @@ const api = {
     generationStatus: (args) => ipcRenderer.invoke('wiki:generationStatus', args),
     cancelGeneration: (args) => ipcRenderer.invoke('wiki:cancelGeneration', args),
     onGenerationChanged: (callback) => {
-      const listener = (
-        _event: Electron.IpcRendererEvent,
-        payload: {
-          worktreeId: string
-          running: boolean
-          output: string
-          error?: string
-          done?: boolean
-        }
-      ) => callback(payload)
+      const listener = (_event: Electron.IpcRendererEvent, payload: WikiGenerationChangedPayload) =>
+        callback(payload)
       ipcRenderer.on('wiki:generationChanged', listener)
       return () => ipcRenderer.removeListener('wiki:generationChanged', listener)
     }

--- a/src/renderer/src/components/right-sidebar/WikiPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/WikiPanel.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// Why: real useRepoById returns a Repo with `displayName`, not `name` — mock matches the real shape.
+const useActiveWorktree = vi.fn(() => ({ id: 'w1', path: '/repo', repoId: 'r1' }))
+vi.mock('@/store/selectors', () => ({
+  useActiveWorktree: () => useActiveWorktree(),
+  useRepoById: () => ({ id: 'r1', displayName: 'my-repo' })
+}))
+// Why: exposes onLinkClick so tests can drive real link-click navigation
+// through the component instead of asserting on props in isolation. The link
+// target is parsed out of the (already-converted) content so a test can
+// verify a wikilink was actually turned into a resolvable markdown link,
+// falling back to 'Other.md' for fixtures with no link in their content.
+vi.mock('@/components/sidebar/CommentMarkdown', () => ({
+  __esModule: true,
+  default: ({
+    content,
+    onLinkClick
+  }: {
+    content: string
+    onLinkClick?: (event: { preventDefault: () => void }, href: string) => void
+  }) => {
+    const linkMatch = content.match(/\[([^\]]+)\]\(([^)]+)\)/)
+    const href = linkMatch?.[2] ?? 'Other.md'
+    return (
+      <div data-testid="md">
+        {content}
+        <a data-testid="wiki-link" href={href} onClick={(event) => onLinkClick?.(event, href)}>
+          link
+        </a>
+      </div>
+    )
+  }
+}))
+
+import WikiPanel from './WikiPanel'
+
+const read = vi.fn()
+const generate = vi.fn()
+const generationStatus = vi.fn()
+const cancelGeneration = vi.fn()
+const onGenerationChanged = vi.fn()
+let generationChangedCallback:
+  | ((payload: {
+      worktreeId: string
+      running: boolean
+      output: string
+      error?: string
+      done?: boolean
+    }) => void)
+  | null = null
+
+beforeEach(() => {
+  read.mockReset()
+  generate.mockReset()
+  generationStatus.mockReset()
+  cancelGeneration.mockReset()
+  onGenerationChanged.mockReset()
+  generationChangedCallback = null
+  generationStatus.mockResolvedValue(null)
+  cancelGeneration.mockResolvedValue({ ok: true })
+  onGenerationChanged.mockImplementation((callback) => {
+    generationChangedCallback = callback
+    return () => {}
+  })
+  useActiveWorktree.mockReturnValue({ id: 'w1', path: '/repo', repoId: 'r1' })
+  globalThis.window.api = {
+    wiki: { read, generate, generationStatus, cancelGeneration, onGenerationChanged }
+  } as unknown as Window['api']
+})
+afterEach(() => cleanup())
+
+describe('WikiPanel', () => {
+  it('shows the generate button when no wiki exists', async () => {
+    read.mockResolvedValue({ hasWiki: false })
+    render(<WikiPanel />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /generate wiki/i })).toBeInTheDocument()
+    )
+  })
+  it('renders the root note when a wiki exists', async () => {
+    read.mockResolvedValue({
+      hasWiki: true,
+      rootRelativePath: 'Home.md',
+      note: { relativePath: 'Home.md', content: '# Home' }
+    })
+    render(<WikiPanel />)
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('# Home'))
+  })
+  it('calls generate with the CLAUDE.md checkbox enabled by default', async () => {
+    read.mockResolvedValue({ hasWiki: false })
+    generate.mockResolvedValue({ ok: true })
+    const { getByRole } = render(<WikiPanel />)
+    await waitFor(() => getByRole('button', { name: /generate wiki/i }))
+    expect(screen.getByText(/add wiki instruction to claude\.md/i)).toBeInTheDocument()
+    expect(getByRole('checkbox')).toBeInTheDocument()
+    getByRole('button', { name: /generate wiki/i }).click()
+    await waitFor(() =>
+      expect(generate).toHaveBeenCalledWith({ worktreeId: 'w1', addClaudeMdInstruction: true })
+    )
+  })
+
+  it('passes addClaudeMdInstruction:false when the checkbox is unchecked', async () => {
+    read.mockResolvedValue({ hasWiki: false })
+    generate.mockResolvedValue({ ok: true })
+    const { getByRole } = render(<WikiPanel />)
+    await waitFor(() => getByRole('button', { name: /generate wiki/i }))
+    fireEvent.click(getByRole('checkbox'))
+    getByRole('button', { name: /generate wiki/i }).click()
+    await waitFor(() =>
+      expect(generate).toHaveBeenCalledWith({ worktreeId: 'w1', addClaudeMdInstruction: false })
+    )
+  })
+
+  it('hides frontmatter and renders a wikilink as a clickable link that resolves via wiki:read', async () => {
+    read.mockResolvedValueOnce({
+      hasWiki: true,
+      rootRelativePath: 'Home.md',
+      note: {
+        relativePath: 'Home.md',
+        content: '---\ntags:\n  - topic/meta\n---\nSee [[Feature]] for details.'
+      }
+    })
+    render(<WikiPanel />)
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('See'))
+
+    const rendered = screen.getByTestId('md')
+    expect(rendered).not.toHaveTextContent('topic/meta')
+    expect(rendered).not.toHaveTextContent('---')
+    expect(rendered).toHaveTextContent('[Feature](Feature)')
+
+    read.mockResolvedValueOnce({
+      hasWiki: true,
+      rootRelativePath: 'Home.md',
+      note: { relativePath: 'Feature.md', content: '# Feature' }
+    })
+    screen.getByTestId('wiki-link').click()
+
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('# Feature'))
+    expect(read).toHaveBeenLastCalledWith({
+      worktreeId: 'w1',
+      target: 'Feature',
+      fromRelativePath: 'Home.md'
+    })
+  })
+
+  it('follows an internal link by reading the target note in-panel', async () => {
+    read.mockResolvedValueOnce({
+      hasWiki: true,
+      rootRelativePath: 'Home.md',
+      note: { relativePath: 'Home.md', content: '# Home' }
+    })
+    render(<WikiPanel />)
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('# Home'))
+
+    read.mockResolvedValueOnce({
+      hasWiki: true,
+      rootRelativePath: 'Home.md',
+      note: { relativePath: 'Other.md', content: '# Other' }
+    })
+    screen.getByTestId('wiki-link').click()
+
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('# Other'))
+    expect(read).toHaveBeenLastCalledWith({
+      worktreeId: 'w1',
+      target: 'Other.md',
+      fromRelativePath: 'Home.md'
+    })
+  })
+
+  it('resumes the generating state on mount when the main process reports a running generation', async () => {
+    // Why: this proves persistence-on-return — no generate click, phase comes
+    // straight from wiki:generationStatus, so switching tabs away and back
+    // does not lose progress.
+    generationStatus.mockResolvedValue({ running: true, output: 'working on it…' })
+    render(<WikiPanel />)
+    await waitFor(() => expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument())
+    expect(screen.getByText('working on it…')).toBeInTheDocument()
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('shows the error state on mount when the main process reports a finished, failed generation', async () => {
+    generationStatus.mockResolvedValue({
+      running: false,
+      output: '',
+      error: 'Agent exited with code 1.'
+    })
+    render(<WikiPanel />)
+    await waitFor(() => expect(screen.getByText('Agent exited with code 1.')).toBeInTheDocument())
+  })
+
+  it('clicking Stop calls cancelGeneration for the active worktree', async () => {
+    generationStatus.mockResolvedValue({ running: true, output: '' })
+    render(<WikiPanel />)
+    const stopButton = await screen.findByRole('button', { name: /stop/i })
+    stopButton.click()
+    await waitFor(() => expect(cancelGeneration).toHaveBeenCalledWith({ worktreeId: 'w1' }))
+  })
+
+  it('re-reads and shows content when onGenerationChanged fires done:true', async () => {
+    generationStatus.mockResolvedValue({ running: true, output: 'still going' })
+    read.mockResolvedValue({
+      hasWiki: true,
+      rootRelativePath: 'Home.md',
+      note: { relativePath: 'Home.md', content: '# Home' }
+    })
+    render(<WikiPanel />)
+    await waitFor(() => expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument())
+
+    generationChangedCallback?.({ worktreeId: 'w1', running: false, output: 'done', done: true })
+
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('# Home'))
+  })
+
+  it('discards a slow prior read after the worktree changes', async () => {
+    let resolveFirst!: (value: unknown) => void
+    read.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve
+        })
+    )
+    const { rerender } = render(<WikiPanel />)
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(1))
+
+    // Why: switching worktree bumps the request token before the slow first
+    // read settles, so its late resolution must not clobber worktree w2.
+    useActiveWorktree.mockReturnValue({ id: 'w2', path: '/repo2', repoId: 'r2' })
+    read.mockResolvedValueOnce({
+      hasWiki: true,
+      rootRelativePath: 'Home2.md',
+      note: { relativePath: 'Home2.md', content: '# Home Two' }
+    })
+    rerender(<WikiPanel />)
+    await waitFor(() => expect(screen.getByTestId('md')).toHaveTextContent('# Home Two'))
+
+    resolveFirst({
+      hasWiki: true,
+      rootRelativePath: 'Home1.md',
+      note: { relativePath: 'Home1.md', content: '# Home One' }
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(screen.getByTestId('md')).toHaveTextContent('# Home Two')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/WikiPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WikiPanel.tsx
@@ -10,14 +10,14 @@ import { createWikiHistory, type WikiHistory } from './wiki-panel-navigation'
 import { prepareWikiNoteForDisplay } from './wiki-note-content'
 import { WikiPanelTopBar } from './WikiPanelTopBar'
 import { WikiPanelSetupState } from './WikiPanelSetupState'
+import { translate } from '@/i18n/i18n'
 
 type WikiNote = { relativePath: string; content: string }
 type WikiPanelPhase = 'loading' | 'empty' | 'generating' | 'error' | 'content'
 
 const EXTERNAL_LINK_PATTERN = /^https?:\/\//i
-const DEFAULT_LOAD_ERROR = 'Failed to load the wiki.'
-const DEFAULT_GENERATE_ERROR = 'Failed to start generation.'
 
+/** Right-sidebar panel that loads, displays, and navigates a worktree's `.wiki/` notes, or offers to generate one. */
 export default function WikiPanel(): React.JSX.Element | null {
   const activeWorktree = useActiveWorktree()
   const repo = useRepoById(activeWorktree?.repoId ?? null)
@@ -53,7 +53,12 @@ export default function WikiPanel(): React.JSX.Element | null {
           return
         }
         if (!result.note) {
-          setErrorMessage('Failed to load the wiki root page.')
+          setErrorMessage(
+            translate(
+              'auto.components.right.sidebar.WikiPanel.9fe482ef65',
+              'Failed to load the wiki root page.'
+            )
+          )
           setPhase('error')
           return
         }
@@ -64,7 +69,14 @@ export default function WikiPanel(): React.JSX.Element | null {
         if (!mountedRef.current || requestId !== requestIdRef.current) {
           return
         }
-        setErrorMessage(error instanceof Error ? error.message : DEFAULT_LOAD_ERROR)
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : translate(
+                'auto.components.right.sidebar.WikiPanel.9e1f136ed0',
+                'Failed to load the wiki.'
+              )
+        )
         setPhase('error')
       }
     },
@@ -151,7 +163,13 @@ export default function WikiPanel(): React.JSX.Element | null {
       if (!mountedRef.current || requestId !== requestIdRef.current) {
         return
       }
-      const message = error instanceof Error ? error.message : DEFAULT_GENERATE_ERROR
+      const message =
+        error instanceof Error
+          ? error.message
+          : translate(
+              'auto.components.right.sidebar.WikiPanel.a5aa987a97',
+              'Failed to start generation.'
+            )
       toast.error(message)
       setErrorMessage(message)
       setPhase('error')
@@ -162,9 +180,20 @@ export default function WikiPanel(): React.JSX.Element | null {
     if (!worktreeId) {
       return
     }
-    // Why: the following main-process status change (running:false) drives the
-    // phase transition out of "generating" — no local phase flip here.
-    await window.api.wiki.cancelGeneration({ worktreeId })
+    try {
+      // Why: the following main-process status change (running:false) drives the
+      // phase transition out of "generating" — no local phase flip here.
+      await window.api.wiki.cancelGeneration({ worktreeId })
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : translate(
+              'auto.components.right.sidebar.WikiPanel.eccbe5d645',
+              'Failed to stop generation.'
+            )
+      )
+    }
   }, [worktreeId])
 
   const loadNoteAt = useCallback(
@@ -173,14 +202,17 @@ export default function WikiPanel(): React.JSX.Element | null {
         return
       }
       const requestId = ++requestIdRef.current
-      void window.api.wiki.read({ worktreeId, target: relativePath }).then((result) => {
-        if (!mountedRef.current || requestId !== requestIdRef.current) {
-          return
-        }
-        if (result.hasWiki && result.note) {
-          setNote(result.note)
-        }
-      })
+      window.api.wiki
+        .read({ worktreeId, target: relativePath })
+        .then((result) => {
+          if (!mountedRef.current || requestId !== requestIdRef.current) {
+            return
+          }
+          if (result.hasWiki && result.note) {
+            setNote(result.note)
+          }
+        })
+        .catch(() => {})
     },
     [worktreeId, mountedRef]
   )
@@ -219,16 +251,19 @@ export default function WikiPanel(): React.JSX.Element | null {
       }
       const fromRelativePath = historyRef.current.current()
       const requestId = ++requestIdRef.current
-      void window.api.wiki.read({ worktreeId, target: href, fromRelativePath }).then((result) => {
-        if (!mountedRef.current || requestId !== requestIdRef.current) {
-          return
-        }
-        if (result.hasWiki && result.note) {
-          historyRef.current?.push(result.note.relativePath)
-          setNote(result.note)
-          bumpHistoryTick((tick) => tick + 1)
-        }
-      })
+      window.api.wiki
+        .read({ worktreeId, target: href, fromRelativePath })
+        .then((result) => {
+          if (!mountedRef.current || requestId !== requestIdRef.current) {
+            return
+          }
+          if (result.hasWiki && result.note) {
+            historyRef.current?.push(result.note.relativePath)
+            setNote(result.note)
+            bumpHistoryTick((tick) => tick + 1)
+          }
+        })
+        .catch(() => {})
     },
     [worktreeId, mountedRef]
   )
@@ -243,7 +278,13 @@ export default function WikiPanel(): React.JSX.Element | null {
     <div
       className="flex h-full min-h-0 flex-col"
       role="region"
-      aria-label={repo ? `Wiki: ${repo.displayName}` : 'Wiki'}
+      aria-label={
+        repo
+          ? translate('auto.components.right.sidebar.WikiPanel.2a8893f928', 'Wiki: {{value0}}', {
+              value0: repo.displayName
+            })
+          : translate('auto.components.right.sidebar.WikiPanel.8521212a7a', 'Wiki')
+      }
     >
       {phase === 'content' && note ? (
         <>

--- a/src/renderer/src/components/right-sidebar/WikiPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/WikiPanel.tsx
@@ -1,0 +1,277 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import CommentMarkdown, {
+  type CommentMarkdownLinkClickHandler
+} from '@/components/sidebar/CommentMarkdown'
+import { useActiveWorktree, useRepoById } from '@/store/selectors'
+import { openHttpLink } from '@/lib/http-link-routing'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { createWikiHistory, type WikiHistory } from './wiki-panel-navigation'
+import { prepareWikiNoteForDisplay } from './wiki-note-content'
+import { WikiPanelTopBar } from './WikiPanelTopBar'
+import { WikiPanelSetupState } from './WikiPanelSetupState'
+
+type WikiNote = { relativePath: string; content: string }
+type WikiPanelPhase = 'loading' | 'empty' | 'generating' | 'error' | 'content'
+
+const EXTERNAL_LINK_PATTERN = /^https?:\/\//i
+const DEFAULT_LOAD_ERROR = 'Failed to load the wiki.'
+const DEFAULT_GENERATE_ERROR = 'Failed to start generation.'
+
+export default function WikiPanel(): React.JSX.Element | null {
+  const activeWorktree = useActiveWorktree()
+  const repo = useRepoById(activeWorktree?.repoId ?? null)
+  const worktreeId = activeWorktree?.id ?? null
+
+  const [phase, setPhase] = useState<WikiPanelPhase>('loading')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [note, setNote] = useState<WikiNote | null>(null)
+  const [addClaudeMd, setAddClaudeMd] = useState(true)
+  const [generatingOutput, setGeneratingOutput] = useState('')
+  const [, bumpHistoryTick] = useState(0)
+  const historyRef = useRef<WikiHistory | null>(null)
+  const mountedRef = useMountedRef()
+  // Why: every wiki read/generate shares this counter so a worktree switch or a
+  // newer click invalidates any still-in-flight response before it can apply.
+  const requestIdRef = useRef(0)
+  const displayContent = React.useMemo(
+    () => (note ? prepareWikiNoteForDisplay(note.content) : ''),
+    [note]
+  )
+
+  const load = useCallback(
+    async (id: string): Promise<void> => {
+      const requestId = ++requestIdRef.current
+      setPhase('loading')
+      try {
+        const result = await window.api.wiki.read({ worktreeId: id })
+        if (!mountedRef.current || requestId !== requestIdRef.current) {
+          return
+        }
+        if (!result.hasWiki) {
+          setPhase('empty')
+          return
+        }
+        if (!result.note) {
+          setErrorMessage('Failed to load the wiki root page.')
+          setPhase('error')
+          return
+        }
+        historyRef.current = createWikiHistory(result.rootRelativePath)
+        setNote(result.note)
+        setPhase('content')
+      } catch (error) {
+        if (!mountedRef.current || requestId !== requestIdRef.current) {
+          return
+        }
+        setErrorMessage(error instanceof Error ? error.message : DEFAULT_LOAD_ERROR)
+        setPhase('error')
+      }
+    },
+    [mountedRef]
+  )
+
+  // Why: generation state lives in the main process (WikiGenerationService), so
+  // a fresh mount must check it first — a sidebar tab switch away and back must
+  // not lose an in-progress generation to a stale "empty"/"content" read.
+  useEffect(() => {
+    if (!worktreeId) {
+      return
+    }
+    let canceled = false
+    void (async () => {
+      const status = await window.api.wiki.generationStatus({ worktreeId })
+      if (canceled) {
+        return
+      }
+      if (status?.running) {
+        setGeneratingOutput(status.output)
+        setPhase('generating')
+        return
+      }
+      if (status && !status.running && status.error) {
+        setErrorMessage(status.error)
+        setPhase('error')
+        return
+      }
+      void load(worktreeId)
+    })()
+    return () => {
+      canceled = true
+    }
+  }, [worktreeId, load, mountedRef])
+
+  useEffect(() => {
+    if (!worktreeId) {
+      return
+    }
+    const unsubscribe = window.api.wiki.onGenerationChanged((payload) => {
+      if (payload.worktreeId !== worktreeId) {
+        return
+      }
+      if (payload.running) {
+        setGeneratingOutput(payload.output)
+        setPhase('generating')
+        return
+      }
+      if (payload.done) {
+        void load(worktreeId)
+        return
+      }
+      if (payload.error) {
+        setErrorMessage(payload.error)
+        setPhase('error')
+      }
+    })
+    return unsubscribe
+  }, [worktreeId, load, mountedRef])
+
+  const handleGenerate = useCallback(async (): Promise<void> => {
+    if (!worktreeId) {
+      return
+    }
+    const requestId = ++requestIdRef.current
+    try {
+      const result = await window.api.wiki.generate({
+        worktreeId,
+        addClaudeMdInstruction: addClaudeMd
+      })
+      if (!mountedRef.current || requestId !== requestIdRef.current) {
+        return
+      }
+      if (result.ok) {
+        setGeneratingOutput('')
+        setPhase('generating')
+        return
+      }
+      toast.error(result.error)
+      setErrorMessage(result.error)
+      setPhase('error')
+    } catch (error) {
+      if (!mountedRef.current || requestId !== requestIdRef.current) {
+        return
+      }
+      const message = error instanceof Error ? error.message : DEFAULT_GENERATE_ERROR
+      toast.error(message)
+      setErrorMessage(message)
+      setPhase('error')
+    }
+  }, [worktreeId, mountedRef, addClaudeMd])
+
+  const handleStop = useCallback(async (): Promise<void> => {
+    if (!worktreeId) {
+      return
+    }
+    // Why: the following main-process status change (running:false) drives the
+    // phase transition out of "generating" — no local phase flip here.
+    await window.api.wiki.cancelGeneration({ worktreeId })
+  }, [worktreeId])
+
+  const loadNoteAt = useCallback(
+    (relativePath: string): void => {
+      if (!worktreeId) {
+        return
+      }
+      const requestId = ++requestIdRef.current
+      void window.api.wiki.read({ worktreeId, target: relativePath }).then((result) => {
+        if (!mountedRef.current || requestId !== requestIdRef.current) {
+          return
+        }
+        if (result.hasWiki && result.note) {
+          setNote(result.note)
+        }
+      })
+    },
+    [worktreeId, mountedRef]
+  )
+
+  const handleBack = useCallback((): void => {
+    if (!historyRef.current?.canGoBack()) {
+      return
+    }
+    historyRef.current.back()
+    loadNoteAt(historyRef.current.current())
+    bumpHistoryTick((tick) => tick + 1)
+  }, [loadNoteAt])
+
+  const handleHome = useCallback((): void => {
+    if (!historyRef.current?.canGoBack()) {
+      return
+    }
+    historyRef.current.home()
+    loadNoteAt(historyRef.current.current())
+    bumpHistoryTick((tick) => tick + 1)
+  }, [loadNoteAt])
+
+  const handleLinkClick = useCallback<CommentMarkdownLinkClickHandler>(
+    (event, href) => {
+      if (!href) {
+        return
+      }
+      event.preventDefault()
+      if (EXTERNAL_LINK_PATTERN.test(href)) {
+        openHttpLink(href, { worktreeId })
+        return
+      }
+      // Why: wiki link navigation stays inside this panel — never hand off to the editor.
+      if (!worktreeId || !historyRef.current) {
+        return
+      }
+      const fromRelativePath = historyRef.current.current()
+      const requestId = ++requestIdRef.current
+      void window.api.wiki.read({ worktreeId, target: href, fromRelativePath }).then((result) => {
+        if (!mountedRef.current || requestId !== requestIdRef.current) {
+          return
+        }
+        if (result.hasWiki && result.note) {
+          historyRef.current?.push(result.note.relativePath)
+          setNote(result.note)
+          bumpHistoryTick((tick) => tick + 1)
+        }
+      })
+    },
+    [worktreeId, mountedRef]
+  )
+
+  if (!activeWorktree) {
+    return null
+  }
+
+  const setupPhase = phase === 'content' ? 'loading' : phase
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col"
+      role="region"
+      aria-label={repo ? `Wiki: ${repo.displayName}` : 'Wiki'}
+    >
+      {phase === 'content' && note ? (
+        <>
+          <WikiPanelTopBar
+            relativePath={note.relativePath}
+            canGoBack={historyRef.current?.canGoBack() ?? false}
+            onBack={handleBack}
+            onHome={handleHome}
+          />
+          <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto px-4 py-3">
+            <CommentMarkdown
+              content={displayContent}
+              variant="document"
+              onLinkClick={handleLinkClick}
+            />
+          </div>
+        </>
+      ) : (
+        <WikiPanelSetupState
+          phase={setupPhase}
+          errorMessage={errorMessage}
+          addClaudeMd={addClaudeMd}
+          onAddClaudeMdChange={setAddClaudeMd}
+          generatingOutput={generatingOutput}
+          onGenerate={() => void handleGenerate()}
+          onStop={() => void handleStop()}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/WikiPanelSetupState.tsx
+++ b/src/renderer/src/components/right-sidebar/WikiPanelSetupState.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { BookText, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import { translate } from '@/i18n/i18n'
 
+/** Non-content phases the wiki panel can be in before a note is shown. */
 export type WikiPanelSetupPhase = 'loading' | 'empty' | 'generating' | 'error'
 
 type WikiPanelSetupStateProps = {
@@ -15,6 +17,7 @@ type WikiPanelSetupStateProps = {
   onStop: () => void
 }
 
+/** Renders the wiki panel's non-content states: loading spinner, generation progress, error, or the empty "generate wiki" prompt. */
 export function WikiPanelSetupState({
   phase,
   errorMessage,
@@ -36,14 +39,19 @@ export function WikiPanelSetupState({
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
         <Loader2 className="size-7 animate-spin text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">Generating the wiki…</p>
+        <p className="text-sm text-muted-foreground">
+          {translate(
+            'auto.components.right.sidebar.WikiPanelSetupState.ce26905ff1',
+            'Generating the wiki…'
+          )}
+        </p>
         {generatingOutput ? (
           <pre className="scrollbar-sleek max-h-40 w-full overflow-auto rounded bg-muted p-2 text-left text-xs text-muted-foreground whitespace-pre-wrap">
             {generatingOutput}
           </pre>
         ) : null}
         <Button variant="outline" size="sm" onClick={onStop}>
-          Stop
+          {translate('auto.components.right.sidebar.WikiPanelSetupState.7ee5702de8', 'Stop')}
         </Button>
       </div>
     )
@@ -53,10 +61,17 @@ export function WikiPanelSetupState({
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
         <p className="text-sm text-muted-foreground">
-          {errorMessage ?? 'Failed to load the wiki.'}
+          {errorMessage ??
+            translate(
+              'auto.components.right.sidebar.WikiPanelSetupState.36acee09c0',
+              'Failed to load the wiki.'
+            )}
         </p>
         <Button variant="outline" size="sm" onClick={onGenerate}>
-          Generate wiki
+          {translate(
+            'auto.components.right.sidebar.WikiPanelSetupState.ea1ec65541',
+            'Generate wiki'
+          )}
         </Button>
       </div>
     )
@@ -65,16 +80,24 @@ export function WikiPanelSetupState({
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
       <BookText className="size-7 text-muted-foreground" />
-      <p className="text-sm text-muted-foreground">No wiki yet for this repository.</p>
+      <p className="text-sm text-muted-foreground">
+        {translate(
+          'auto.components.right.sidebar.WikiPanelSetupState.15a2d17d3c',
+          'No wiki yet for this repository.'
+        )}
+      </p>
       <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
         <Checkbox
           checked={addClaudeMd}
           onCheckedChange={(value) => onAddClaudeMdChange(value === true)}
         />
-        Add wiki instruction to CLAUDE.md
+        {translate(
+          'auto.components.right.sidebar.WikiPanelSetupState.eded43f086',
+          'Add wiki instruction to CLAUDE.md'
+        )}
       </label>
       <Button size="sm" onClick={onGenerate}>
-        Generate wiki
+        {translate('auto.components.right.sidebar.WikiPanelSetupState.ea1ec65541', 'Generate wiki')}
       </Button>
     </div>
   )

--- a/src/renderer/src/components/right-sidebar/WikiPanelSetupState.tsx
+++ b/src/renderer/src/components/right-sidebar/WikiPanelSetupState.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { BookText, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+
+export type WikiPanelSetupPhase = 'loading' | 'empty' | 'generating' | 'error'
+
+type WikiPanelSetupStateProps = {
+  phase: WikiPanelSetupPhase
+  errorMessage: string | null
+  addClaudeMd: boolean
+  onAddClaudeMdChange: (value: boolean) => void
+  generatingOutput: string
+  onGenerate: () => void
+  onStop: () => void
+}
+
+export function WikiPanelSetupState({
+  phase,
+  errorMessage,
+  addClaudeMd,
+  onAddClaudeMdChange,
+  generatingOutput,
+  onGenerate,
+  onStop
+}: WikiPanelSetupStateProps): React.JSX.Element {
+  if (phase === 'loading') {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+      </div>
+    )
+  }
+
+  if (phase === 'generating') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <Loader2 className="size-7 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Generating the wiki…</p>
+        {generatingOutput ? (
+          <pre className="scrollbar-sleek max-h-40 w-full overflow-auto rounded bg-muted p-2 text-left text-xs text-muted-foreground whitespace-pre-wrap">
+            {generatingOutput}
+          </pre>
+        ) : null}
+        <Button variant="outline" size="sm" onClick={onStop}>
+          Stop
+        </Button>
+      </div>
+    )
+  }
+
+  if (phase === 'error') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          {errorMessage ?? 'Failed to load the wiki.'}
+        </p>
+        <Button variant="outline" size="sm" onClick={onGenerate}>
+          Generate wiki
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+      <BookText className="size-7 text-muted-foreground" />
+      <p className="text-sm text-muted-foreground">No wiki yet for this repository.</p>
+      <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+        <Checkbox
+          checked={addClaudeMd}
+          onCheckedChange={(value) => onAddClaudeMdChange(value === true)}
+        />
+        Add wiki instruction to CLAUDE.md
+      </label>
+      <Button size="sm" onClick={onGenerate}>
+        Generate wiki
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/WikiPanelTopBar.tsx
+++ b/src/renderer/src/components/right-sidebar/WikiPanelTopBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ArrowLeft, Home } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
 
 type WikiPanelTopBarProps = {
   relativePath: string
@@ -14,6 +15,7 @@ function formatWikiBreadcrumb(relativePath: string): string {
   return relativePath.replace(/\.(md|mdx|markdown)$/i, '')
 }
 
+/** Top bar for the wiki panel: back/home navigation buttons and the current note's breadcrumb. */
 export function WikiPanelTopBar({
   relativePath,
   canGoBack,
@@ -27,8 +29,8 @@ export function WikiPanelTopBar({
         size="icon-sm"
         disabled={!canGoBack}
         onClick={onBack}
-        aria-label="Back"
-        title="Back"
+        aria-label={translate('auto.components.right.sidebar.WikiPanelTopBar.b2030cab15', 'Back')}
+        title={translate('auto.components.right.sidebar.WikiPanelTopBar.b2030cab15', 'Back')}
       >
         <ArrowLeft />
       </Button>
@@ -37,8 +39,8 @@ export function WikiPanelTopBar({
         size="icon-sm"
         disabled={!canGoBack}
         onClick={onHome}
-        aria-label="Home"
-        title="Home"
+        aria-label={translate('auto.components.right.sidebar.WikiPanelTopBar.350a0c1651', 'Home')}
+        title={translate('auto.components.right.sidebar.WikiPanelTopBar.350a0c1651', 'Home')}
       >
         <Home />
       </Button>

--- a/src/renderer/src/components/right-sidebar/WikiPanelTopBar.tsx
+++ b/src/renderer/src/components/right-sidebar/WikiPanelTopBar.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { ArrowLeft, Home } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+type WikiPanelTopBarProps = {
+  relativePath: string
+  canGoBack: boolean
+  onBack: () => void
+  onHome: () => void
+}
+
+// Why: breadcrumb drops the file extension so a note path reads like a title.
+function formatWikiBreadcrumb(relativePath: string): string {
+  return relativePath.replace(/\.(md|mdx|markdown)$/i, '')
+}
+
+export function WikiPanelTopBar({
+  relativePath,
+  canGoBack,
+  onBack,
+  onHome
+}: WikiPanelTopBarProps): React.JSX.Element {
+  return (
+    <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border px-2">
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        disabled={!canGoBack}
+        onClick={onBack}
+        aria-label="Back"
+        title="Back"
+      >
+        <ArrowLeft />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        disabled={!canGoBack}
+        onClick={onHome}
+        aria-label="Home"
+        title="Home"
+      >
+        <Home />
+      </Button>
+      <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground" title={relativePath}>
+        {formatWikiBreadcrumb(relativePath)}
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: the right sidebar owns activity-bar visibility, routing, and resize behavior as one interaction surface; splitting the tab table away would make hidden-tab fallbacks harder to audit. */
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Plug, Files, GitBranch, ListChecks, PanelRight, Workflow } from 'lucide-react'
+import { Plug, Files, GitBranch, ListChecks, PanelRight, Workflow, BookText } from 'lucide-react'
 import { useAppStore } from '@/store'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 import { useRepoById } from '@/store/selectors'
@@ -129,6 +129,14 @@ function RightSidebarInner(): React.JSX.Element {
         title: translate('auto.components.right.sidebar.index.83a10e3c44', 'Checks'),
         shortcut: checksShortcut === 'Unassigned' ? '' : checksShortcut,
         gitOnly: true
+      },
+      {
+        // Why: a .wiki/ folder is not git-specific — show Wiki for folder projects too
+        // (the panel reads the worktree path, which folder repos provide).
+        id: 'wiki',
+        icon: BookText,
+        title: translate('auto.components.right.sidebar.index.375ca239c1', 'Wiki'),
+        shortcut: ''
       },
       {
         id: 'ports',

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -5,6 +5,7 @@ import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 const FileExplorer = lazy(() => import('./FileExplorer'))
 const SourceControl = lazy(() => import('./SourceControl'))
 const ChecksPanel = lazy(() => import('./ChecksPanel'))
+const WikiPanel = lazy(() => import('./WikiPanel'))
 const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
@@ -25,6 +26,7 @@ export function RightSidebarPanelContent({
         {effectiveTab === 'explorer' && <FileExplorer />}
         {effectiveTab === 'source-control' && <SourceControl />}
         {effectiveTab === 'checks' && <ChecksPanel />}
+        {effectiveTab === 'wiki' && <WikiPanel />}
         {/* Why: SSH port forwarding still depends on the raw ports.detect data,
             which the workspace-scoped status bar popover intentionally does not
             expose. Keep this panel reachable only for SSH worktrees. */}

--- a/src/renderer/src/components/right-sidebar/wiki-note-content.test.ts
+++ b/src/renderer/src/components/right-sidebar/wiki-note-content.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  prepareWikiNoteForDisplay,
+  stripFrontmatter,
+  wikilinksToMarkdownLinks
+} from './wiki-note-content'
+
+describe('stripFrontmatter', () => {
+  it('removes a leading frontmatter block', () => {
+    expect(stripFrontmatter('---\ntags:\n  - a\n---\n# Home')).toBe('# Home')
+  })
+
+  it('leaves content without frontmatter unchanged', () => {
+    expect(stripFrontmatter('# Home\n\nSome text')).toBe('# Home\n\nSome text')
+  })
+
+  it('does not strip a thematic break in the middle of the body', () => {
+    const content = '# Home\n\nIntro\n\n---\n\nMore text'
+    expect(stripFrontmatter(content)).toBe(content)
+  })
+})
+
+describe('wikilinksToMarkdownLinks', () => {
+  it('converts a bare wikilink', () => {
+    expect(wikilinksToMarkdownLinks('[[Feature]]')).toBe('[Feature](Feature)')
+  })
+
+  it('converts a wikilink with a custom label', () => {
+    expect(wikilinksToMarkdownLinks('[[Feature|Nice label]]')).toBe('[Nice label](Feature)')
+  })
+
+  it('converts a wikilink with an anchor', () => {
+    expect(wikilinksToMarkdownLinks('[[Feature#section]]')).toBe('[Feature](Feature)')
+  })
+
+  it('leaves existing markdown links untouched', () => {
+    expect(wikilinksToMarkdownLinks('[x](y.md)')).toBe('[x](y.md)')
+  })
+})
+
+describe('prepareWikiNoteForDisplay', () => {
+  it('strips frontmatter and converts wikilinks', () => {
+    const content = '---\ntags:\n  - a\n---\nSee [[Feature]] for details.'
+    expect(prepareWikiNoteForDisplay(content)).toBe('See [Feature](Feature) for details.')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/wiki-note-content.test.ts
+++ b/src/renderer/src/components/right-sidebar/wiki-note-content.test.ts
@@ -36,6 +36,14 @@ describe('wikilinksToMarkdownLinks', () => {
   it('leaves existing markdown links untouched', () => {
     expect(wikilinksToMarkdownLinks('[x](y.md)')).toBe('[x](y.md)')
   })
+
+  it('wraps a target with spaces in angle brackets', () => {
+    expect(wikilinksToMarkdownLinks('[[Target Note]]')).toBe('[Target Note](<Target Note>)')
+  })
+
+  it('leaves a target without spaces unwrapped', () => {
+    expect(wikilinksToMarkdownLinks('[[NoSpace]]')).toBe('[NoSpace](NoSpace)')
+  })
 })
 
 describe('prepareWikiNoteForDisplay', () => {

--- a/src/renderer/src/components/right-sidebar/wiki-note-content.ts
+++ b/src/renderer/src/components/right-sidebar/wiki-note-content.ts
@@ -1,11 +1,13 @@
 // Prepare a raw .wiki/ note for in-panel display: hide frontmatter tags and make wikilinks clickable.
 
+/** Strips a leading YAML frontmatter block from note content, if present. */
 export function stripFrontmatter(content: string): string {
   // Remove a leading YAML frontmatter block so page tags don't render as body text.
   const match = content.match(/^﻿?---[^\n]*\n[\s\S]*?\n---[ \t]*(?:\r?\n|$)/)
   return match ? content.slice(match[0].length) : content
 }
 
+/** Converts `[[target]]` / `[[target|label]]` / `[[target#anchor]]` wikilinks into standard markdown links. */
 export function wikilinksToMarkdownLinks(content: string): string {
   // [[target]] / [[target|label]] / [[target#anchor]] -> [label](target) so the renderer makes them clickable.
   return content.replace(
@@ -13,11 +15,14 @@ export function wikilinksToMarkdownLinks(content: string): string {
     (_full, target, label) => {
       const cleanTarget = String(target).trim()
       const text = (label ?? cleanTarget).toString().trim()
-      return `[${text}](${cleanTarget})`
+      // Why: a bare space in the link destination breaks CommonMark parsing.
+      const dest = /\s/.test(cleanTarget) ? `<${cleanTarget}>` : cleanTarget
+      return `[${text}](${dest})`
     }
   )
 }
 
+/** Prepares raw `.wiki/` note content for in-panel display: strips frontmatter and rewrites wikilinks as markdown links. */
 export function prepareWikiNoteForDisplay(content: string): string {
   return wikilinksToMarkdownLinks(stripFrontmatter(content))
 }

--- a/src/renderer/src/components/right-sidebar/wiki-note-content.ts
+++ b/src/renderer/src/components/right-sidebar/wiki-note-content.ts
@@ -1,0 +1,23 @@
+// Prepare a raw .wiki/ note for in-panel display: hide frontmatter tags and make wikilinks clickable.
+
+export function stripFrontmatter(content: string): string {
+  // Remove a leading YAML frontmatter block so page tags don't render as body text.
+  const match = content.match(/^﻿?---[^\n]*\n[\s\S]*?\n---[ \t]*(?:\r?\n|$)/)
+  return match ? content.slice(match[0].length) : content
+}
+
+export function wikilinksToMarkdownLinks(content: string): string {
+  // [[target]] / [[target|label]] / [[target#anchor]] -> [label](target) so the renderer makes them clickable.
+  return content.replace(
+    /\[\[([^\]|#\n]+)(?:#[^\]|\n]*)?(?:\|([^\]\n]+))?\]\]/g,
+    (_full, target, label) => {
+      const cleanTarget = String(target).trim()
+      const text = (label ?? cleanTarget).toString().trim()
+      return `[${text}](${cleanTarget})`
+    }
+  )
+}
+
+export function prepareWikiNoteForDisplay(content: string): string {
+  return wikilinksToMarkdownLinks(stripFrontmatter(content))
+}

--- a/src/renderer/src/components/right-sidebar/wiki-note-render.test.tsx
+++ b/src/renderer/src/components/right-sidebar/wiki-note-render.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+// Regression: the REAL CommentMarkdown must hide frontmatter and render a converted
+// [[wikilink]] as a clickable anchor that fires onLinkClick with the resolved href.
+import '@testing-library/jest-dom/vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { prepareWikiNoteForDisplay } from './wiki-note-content'
+
+afterEach(() => cleanup())
+
+const RAW =
+  '---\ntags:\n  - type/moc\nemoji: 📦\n---\n\n# Home Overview\n\nGo to [[TargetNote]] for details.\n'
+
+describe('wiki note rendered by the real CommentMarkdown', () => {
+  it('hides frontmatter tags', () => {
+    render(
+      <CommentMarkdown
+        variant="document"
+        content={prepareWikiNoteForDisplay(RAW)}
+        onLinkClick={() => {}}
+      />
+    )
+    expect(screen.queryByText(/type\/moc/)).toBeNull()
+    expect(screen.getByText(/Home Overview/)).toBeInTheDocument()
+  })
+
+  it('renders a wikilink as a clickable anchor that fires onLinkClick with the target href', async () => {
+    // Prevent happy-dom from following the anchor navigation on click.
+    const onLinkClick = vi.fn((event: { preventDefault?: () => void }, _href?: string) =>
+      event?.preventDefault?.()
+    )
+    render(
+      <CommentMarkdown
+        variant="document"
+        content={prepareWikiNoteForDisplay(RAW)}
+        onLinkClick={onLinkClick}
+      />
+    )
+    const link = screen.getByRole('link', { name: /TargetNote/i })
+    expect(link).toBeInTheDocument()
+    link.click()
+    expect(onLinkClick).toHaveBeenCalled()
+    const href = onLinkClick.mock.calls[0][1]
+    expect(href).toMatch(/TargetNote/)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/wiki-panel-navigation.test.ts
+++ b/src/renderer/src/components/right-sidebar/wiki-panel-navigation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { createWikiHistory } from './wiki-panel-navigation'
+
+describe('createWikiHistory', () => {
+  it('pushes, goes back, and resets to root', () => {
+    const h = createWikiHistory('Home.md')
+    expect(h.current()).toBe('Home.md')
+    h.push('Бизнес-логика/F.md')
+    expect(h.current()).toBe('Бизнес-логика/F.md')
+    expect(h.canGoBack()).toBe(true)
+    h.back()
+    expect(h.current()).toBe('Home.md')
+    expect(h.canGoBack()).toBe(false)
+    h.push('a.md')
+    h.home()
+    expect(h.current()).toBe('Home.md')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/wiki-panel-navigation.ts
+++ b/src/renderer/src/components/right-sidebar/wiki-panel-navigation.ts
@@ -1,3 +1,4 @@
+/** Back-stack navigation over visited wiki notes, always holding at least the root note. */
 export type WikiHistory = {
   current: () => string
   canGoBack: () => boolean
@@ -6,6 +7,7 @@ export type WikiHistory = {
   home: () => void
 }
 
+/** Creates a `WikiHistory` stack seeded with the given root note. */
 export function createWikiHistory(root: string): WikiHistory {
   const stack: string[] = [root]
   return {

--- a/src/renderer/src/components/right-sidebar/wiki-panel-navigation.ts
+++ b/src/renderer/src/components/right-sidebar/wiki-panel-navigation.ts
@@ -1,0 +1,29 @@
+export type WikiHistory = {
+  current: () => string
+  canGoBack: () => boolean
+  push: (relativePath: string) => void
+  back: () => void
+  home: () => void
+}
+
+export function createWikiHistory(root: string): WikiHistory {
+  const stack: string[] = [root]
+  return {
+    // Why: stack always holds at least root; fall back to root to keep a definite string.
+    current: () => stack.at(-1) ?? root,
+    canGoBack: () => stack.length > 1,
+    push: (relativePath) => {
+      if (stack.at(-1) !== relativePath) {
+        stack.push(relativePath)
+      }
+    },
+    back: () => {
+      if (stack.length > 1) {
+        stack.pop()
+      }
+    },
+    home: () => {
+      stack.length = 1
+    }
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9681,7 +9681,8 @@
             "fc3095d2ed": "explorer",
             "aiVaultSessionHistory": "Agents",
             "folderWorkspaces": "Attached worktrees",
-            "parentPrChecks": "PR Checks"
+            "parentPrChecks": "PR Checks",
+            "375ca239c1": "Wiki"
           },
           "right": {
             "panel": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10074,6 +10074,26 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "WikiPanel": {
+            "9fe482ef65": "Failed to load the wiki root page.",
+            "9e1f136ed0": "Failed to load the wiki.",
+            "a5aa987a97": "Failed to start generation.",
+            "eccbe5d645": "Failed to stop generation.",
+            "2a8893f928": "Wiki: {{value0}}",
+            "8521212a7a": "Wiki"
+          },
+          "WikiPanelSetupState": {
+            "ce26905ff1": "Generating the wiki…",
+            "7ee5702de8": "Stop",
+            "36acee09c0": "Failed to load the wiki.",
+            "ea1ec65541": "Generate wiki",
+            "15a2d17d3c": "No wiki yet for this repository.",
+            "eded43f086": "Add wiki instruction to CLAUDE.md"
+          },
+          "WikiPanelTopBar": {
+            "b2030cab15": "Back",
+            "350a0c1651": "Home"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9681,7 +9681,8 @@
             "fc3095d2ed": "explorador",
             "aiVaultSessionHistory": "Agentes",
             "folderWorkspaces": "Worktrees adjuntos",
-            "parentPrChecks": "Checks de PR"
+            "parentPrChecks": "Checks de PR",
+            "375ca239c1": "Wiki"
           },
           "right": {
             "panel": {
@@ -10073,6 +10074,26 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "WikiPanel": {
+            "9fe482ef65": "Failed to load the wiki root page.",
+            "9e1f136ed0": "Failed to load the wiki.",
+            "a5aa987a97": "Failed to start generation.",
+            "eccbe5d645": "Failed to stop generation.",
+            "2a8893f928": "Wiki: {{value0}}",
+            "8521212a7a": "Wiki"
+          },
+          "WikiPanelSetupState": {
+            "ce26905ff1": "Generating the wiki…",
+            "7ee5702de8": "Stop",
+            "36acee09c0": "Failed to load the wiki.",
+            "ea1ec65541": "Generate wiki",
+            "15a2d17d3c": "No wiki yet for this repository.",
+            "eded43f086": "Add wiki instruction to CLAUDE.md"
+          },
+          "WikiPanelTopBar": {
+            "b2030cab15": "Back",
+            "350a0c1651": "Home"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9681,7 +9681,8 @@
             "fc3095d2ed": "エクスプローラ",
             "aiVaultSessionHistory": "エージェント",
             "folderWorkspaces": "添付ワークツリー",
-            "parentPrChecks": "PR チェック"
+            "parentPrChecks": "PR チェック",
+            "375ca239c1": "Wiki"
           },
           "right": {
             "panel": {
@@ -10073,6 +10074,26 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "WikiPanel": {
+            "9fe482ef65": "Failed to load the wiki root page.",
+            "9e1f136ed0": "Failed to load the wiki.",
+            "a5aa987a97": "Failed to start generation.",
+            "eccbe5d645": "Failed to stop generation.",
+            "2a8893f928": "Wiki: {{value0}}",
+            "8521212a7a": "Wiki"
+          },
+          "WikiPanelSetupState": {
+            "ce26905ff1": "Generating the wiki…",
+            "7ee5702de8": "Stop",
+            "36acee09c0": "Failed to load the wiki.",
+            "ea1ec65541": "Generate wiki",
+            "15a2d17d3c": "No wiki yet for this repository.",
+            "eded43f086": "Add wiki instruction to CLAUDE.md"
+          },
+          "WikiPanelTopBar": {
+            "b2030cab15": "Back",
+            "350a0c1651": "Home"
           }
         }
       },
@@ -12877,7 +12898,7 @@
         "pastedImageLabel": "貼り付けた画像",
         "imagePasteFailed": "画像の貼り付けに失敗しました。",
         "worktreeNotReady": "Worktreeが準備できていません — しばらくしてから再試行してください。",
-        "uploadingAttachments": "{{value0}}個のファイルをリモートにアップロード中…"
+        "uploadingAttachments": "Uploading {{value0}} file{{value1}} to remote…"
       },
       "tool": {
         "running": "実行中…",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9681,7 +9681,8 @@
             "fc3095d2ed": "탐색기",
             "aiVaultSessionHistory": "에이전트",
             "folderWorkspaces": "연결된 워크트리",
-            "parentPrChecks": "PR 검사"
+            "parentPrChecks": "PR 검사",
+            "375ca239c1": "Wiki"
           },
           "right": {
             "panel": {
@@ -10073,6 +10074,26 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "WikiPanel": {
+            "9fe482ef65": "Failed to load the wiki root page.",
+            "9e1f136ed0": "Failed to load the wiki.",
+            "a5aa987a97": "Failed to start generation.",
+            "eccbe5d645": "Failed to stop generation.",
+            "2a8893f928": "Wiki: {{value0}}",
+            "8521212a7a": "Wiki"
+          },
+          "WikiPanelSetupState": {
+            "ce26905ff1": "Generating the wiki…",
+            "7ee5702de8": "Stop",
+            "36acee09c0": "Failed to load the wiki.",
+            "ea1ec65541": "Generate wiki",
+            "15a2d17d3c": "No wiki yet for this repository.",
+            "eded43f086": "Add wiki instruction to CLAUDE.md"
+          },
+          "WikiPanelTopBar": {
+            "b2030cab15": "Back",
+            "350a0c1651": "Home"
           }
         }
       },
@@ -12877,7 +12898,7 @@
         "pastedImageLabel": "붙여넣은 이미지",
         "imagePasteFailed": "이미지 붙여넣기 실패.",
         "worktreeNotReady": "워크트리가 준비되지 않았습니다 — 잠시 후 다시 시도하세요.",
-        "uploadingAttachments": "{{value0}}개 파일을 원격으로 업로드 중…"
+        "uploadingAttachments": "Uploading {{value0}} file{{value1}} to remote…"
       },
       "tool": {
         "running": "실행 중…",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9681,7 +9681,8 @@
             "fc3095d2ed": "资源管理器",
             "aiVaultSessionHistory": "智能体",
             "folderWorkspaces": "已附加的工作树",
-            "parentPrChecks": "PR 检查"
+            "parentPrChecks": "PR 检查",
+            "375ca239c1": "Wiki"
           },
           "right": {
             "panel": {
@@ -10073,6 +10074,26 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "WikiPanel": {
+            "9fe482ef65": "Failed to load the wiki root page.",
+            "9e1f136ed0": "Failed to load the wiki.",
+            "a5aa987a97": "Failed to start generation.",
+            "eccbe5d645": "Failed to stop generation.",
+            "2a8893f928": "Wiki: {{value0}}",
+            "8521212a7a": "Wiki"
+          },
+          "WikiPanelSetupState": {
+            "ce26905ff1": "Generating the wiki…",
+            "7ee5702de8": "Stop",
+            "36acee09c0": "Failed to load the wiki.",
+            "ea1ec65541": "Generate wiki",
+            "15a2d17d3c": "No wiki yet for this repository.",
+            "eded43f086": "Add wiki instruction to CLAUDE.md"
+          },
+          "WikiPanelTopBar": {
+            "b2030cab15": "Back",
+            "350a0c1651": "Home"
           }
         }
       },
@@ -12877,7 +12898,7 @@
         "pastedImageLabel": "粘贴的图片",
         "imagePasteFailed": "图片粘贴失败。",
         "worktreeNotReady": "Worktree 未就绪 — 请稍后重试。",
-        "uploadingAttachments": "正在上传 {{value0}} 个文件到远程…"
+        "uploadingAttachments": "Uploading {{value0}} file{{value1}} to remote…"
       },
       "tool": {
         "running": "正在运行…",

--- a/src/renderer/src/store/right-sidebar-route.test.ts
+++ b/src/renderer/src/store/right-sidebar-route.test.ts
@@ -16,3 +16,12 @@ describe('normalizeRightSidebarRoute', () => {
     })
   })
 })
+
+describe('normalizeRightSidebarRoute wiki', () => {
+  it('keeps the wiki tab instead of falling back to explorer', () => {
+    expect(normalizeRightSidebarRoute('wiki', 'files')).toEqual({
+      rightSidebarTab: 'wiki',
+      rightSidebarExplorerView: 'files'
+    })
+  })
+})

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -24,7 +24,8 @@ export function normalizeRightSidebarRoute(
     tab === 'pr-checks' ||
     tab === 'source-control' ||
     tab === 'checks' ||
-    tab === 'ports'
+    tab === 'ports' ||
+    tab === 'wiki'
   ) {
     return {
       rightSidebarTab: tab,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3574,6 +3574,16 @@ export type WikiReadResult =
     }
 export type WikiGenerateResult = { ok: true } | { ok: false; error: string }
 
+// Shared between preload (renderer-facing type) and main (emitChanged/webContents.send
+// payload) so the wire shape can't drift between the two sides.
+export type WikiGenerationChangedPayload = {
+  worktreeId: string
+  running: boolean
+  output: string
+  error?: string
+  done?: boolean
+}
+
 // ─── Filesystem watcher ─────────────────────────────────────
 export type FsChangeEvent = {
   kind: 'create' | 'update' | 'delete' | 'rename' | 'overflow'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3187,6 +3187,7 @@ export type RightSidebarTab =
   | 'source-control'
   | 'checks'
   | 'ports'
+  | 'wiki'
 export type ActiveRightSidebarTab = Exclude<RightSidebarTab, 'search'>
 export type RightSidebarExplorerView = 'files' | 'search'
 
@@ -3563,6 +3564,15 @@ export type MarkdownDocument = {
   basename: string
   name: string
 }
+
+export type WikiReadResult =
+  | { hasWiki: false }
+  | {
+      hasWiki: true
+      rootRelativePath: string
+      note: { relativePath: string; content: string } | null
+    }
+export type WikiGenerateResult = { ok: true } | { ok: false; error: string }
 
 // ─── Filesystem watcher ─────────────────────────────────────
 export type FsChangeEvent = {


### PR DESCRIPTION
## Description

Gives every repository a **living, agent-maintained knowledge base**. AI coding agents currently start each task cold and re-derive the same context from the code every time. This PR lets an agent generate that context **once** into an in-repo `.wiki/`, and — optionally — wires the repo's `CLAUDE.md` so future agents know the wiki exists and are told to **keep it up to date**. The wiki becomes durable, self-updating memory for agents, versioned alongside the code.

Two moving parts:
- **Auto-generated wiki** — an agent reads the code and writes a structured wiki (`Home.md` overview, architecture / data / interfaces, per-feature business logic) into `.wiki/`. Generated from the actual code, not hand-authored.
- **Agent memory via `CLAUDE.md`** — generation can add an instruction to `CLAUDE.md` telling agents to update `.wiki/` whenever they change architecture, data, interfaces, or business logic — so the memory refreshes itself instead of rotting.

A new **Wiki** tab in the right sidebar (after Checks) surfaces all of this.

## Media

<img width="1952" height="1132" alt="SCR-20260710-dmac" src="https://github.com/user-attachments/assets/a5258a81-91d3-4ffe-b6d3-7a638228a17a" />


## User-Visible Changes

- New **Wiki** sidebar tab, available for both git repositories and folder projects.
- **When a wiki exists** — an in-panel markdown browser: renders `.wiki/` from its root note, and link navigation between notes stays **inside the panel** (never opens an editor tab). Back / home history + breadcrumb.
- **When no wiki exists** — a **Generate wiki** button with an **"Add wiki instruction to CLAUDE.md"** checkbox (the agent-memory wiring).
- **Generation runs in the background** — no terminal or editor tab is opened. The panel shows a live log and a **Stop** button.
- Generation state is **per-worktree and lives in the main process**, so switching the sidebar tab away and back keeps showing the in-progress run instead of resetting.
- Page frontmatter (tags) is hidden on display; `[[wikilinks]]` are made clickable; percent-encoded links (`%20`) resolve to notes with literal spaces.

## How it works

- **Background generation** — `wiki:generate` resolves the user's configured agent + model (never hardcoded) and spawns it **headless** (`claude -p --dangerously-skip-permissions`) as a background child process owned by the main process, with `cwd` set to the worktree. A `WikiGenerationService` tracks one run per worktree, streams stdout/stderr into a bounded tail, emits a `wiki:generationChanged` event, and kills the process tree on **Stop**.
- **Self-contained prompt** — bundled English templates + a generation prompt are inlined into the agent prompt (so it works without staging files, incl. over SSH). The `CLAUDE.md` instruction is appended only when the checkbox is on; the agent creates or appends a wiki section without duplicating an existing one.
- **Reading** — a traversal-safe `.wiki/` reader lists notes, resolves the root note (`Home.md` → `<repo>.md` → `index.md` → `README.md` → first alphabetically), and resolves in-panel link targets. Local reads use `node:fs`; SSH worktrees read through the existing `IFilesystemProvider`.
- **Renderer** — the panel reuses the existing `CommentMarkdown` renderer; frontmatter stripping and `[[wikilink]]` → markdown-link conversion happen at display time; link clicks route back through `wiki:read` for target resolution.

## Testing

- `pnpm typecheck` — clean.
- `pnpm test` (wiki suites) — green: reader + traversal guard, IPC handlers, generation service (start / stop / error / per-worktree persistence), panel states, link navigation. 77 tests.
- `pnpm lint` — `oxlint` + react-doctor + localization verifiers + `max-lines` ratchet pass; no new suppressions.
- Live: booted the app, rendered a real generated wiki, exercised in-panel link navigation, and confirmed headless `claude -p` generation runs and streams into the panel.

## Review summary

- **Cross-platform** — paths via `path.join`; no hardcoded `metaKey`; process-tree kill uses `taskkill /T /F` on Windows and a detached-group `SIGKILL` on POSIX.
- **SSH** — wiki **read** works for SSH worktrees via `IFilesystemProvider`; **generation** is local-only for now and returns a clear "not available yet" message for SSH worktrees.
- **Agent compatibility** — agent + model come from settings; headless-write args are defined for the claude family + codex, with a clear error for unsupported agents.
- **Performance** — `wiki:generationChanged` is throttled (terminal event always emitted) to avoid an IPC/render flood on chatty runs; the display transform is memoized.
- **UI** — follows `docs/STYLEGUIDE.md` tokens + shadcn primitives; English copy.
- **Git provider** — the wiki is a plain in-repo folder, independent of GitHub/GitLab specifics.

## Security Audit

- **Path traversal** — `wiki:read` rejects `..` segments, absolute/Windows drive-letter paths, and backslash paths before any filesystem access.
- **Symlink escape** — after resolving, the note's **real path** (`realpath`) must be contained in the `.wiki/` real path (via the repo's shared containment helpers); a `.wiki/` symlink pointing outside the folder is refused (covered by a test). Symlinks are also skipped during listing.
- **Write scope** — headless generation runs only in the worktree the user explicitly chose to generate in; the prompt constrains writes to `.wiki/` (and `CLAUDE.md` when opted in). `--dangerously-skip-permissions` is scoped to that background run, not the interactive session.
- **No arbitrary reads** — the panel can only request notes that resolve inside `.wiki/`; targets are validated in the main process, not trusted from the renderer.

## AI Review Report

Built and reviewed with AI assistance (Claude Code), plus an automated CodeRabbit pass. Findings and resolutions:

- **SSH read path (major):** the SSH reader normalizer stripped the leading `/`, so `provider.stat/readFile/realpath` received a relative path — fixed with a leading-slash-preserving normalizer for absolute paths; the SSH test now asserts the provider is called with absolute paths.
- **Wikilinks with spaces:** `[[Target Note]]` produced an invalid markdown link — the destination is now wrapped in `<…>` when it contains whitespace.
- **IPC resilience:** added error handling to the fire-and-forget `wiki:*` calls in the panel.
- **Cleanup:** shared `WikiGenerationChangedPayload` type across main/preload; `execFile` instead of `exec` for the process-tree kill; canceled runs now preserve the accumulated log; panel strings routed through `translate()` (English defaults); templates markdownlint-clean.

## Notes

- SSH-worktree **generation** is a follow-up (read already works over SSH).
- Wiki UI strings are hardcoded English today; moving them into the i18n catalog is a follow-up if desired.

## ELI5

Each repo can get a living `.wiki/` knowledge base that agents generate and optionally keep updated. Agents stop re-deriving the same project context from scratch, and the wiki lives versioned next to the code.
