### PR TITLE
fix(terminal): use shell-ready delivery for Codex session resume

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -380,6 +380,12 @@ type ColdRestoreAgentResumeStartup = PendingStartupCommand & {
   agent: ResumableTuiAgent
   launchConfig: NonNullable<ReturnType<typeof buildAgentResumeStartupPlan>>['launchConfig']
   launchToken: string
+  // Why: carries Codex's shell-ready delivery flag so the fresh replacement
+  // spawn injects `codex resume <id>` after rc-file startup instead of racing
+  // it (markerless delivery can drop the resume payload → a blank new session).
+  startupCommandDelivery?: NonNullable<
+    ReturnType<typeof buildAgentResumeStartupPlan>
+  >['startupCommandDelivery']
   useLiveEntry: boolean
   hasSleepingRecord: boolean
   sleepingRecordEntry: { paneKey: string; record: SleepingAgentSessionRecord } | null
@@ -3627,6 +3633,9 @@ export function connectPanePty(
         },
         launchConfig: startupPlan.launchConfig,
         launchToken: coldRestoreLaunchToken,
+        ...(startupPlan.startupCommandDelivery
+          ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
+          : {}),
         useLiveEntry: Boolean(useLiveEntry),
         hasSleepingRecord: Boolean(sleepingRecord),
         sleepingRecordEntry
@@ -3786,6 +3795,9 @@ export function connectPanePty(
         ...(coldRestoreOverride ? { launchConfig: coldRestoreOverride.launchConfig } : {}),
         ...(coldRestoreOverride ? { launchToken: coldRestoreOverride.launchToken } : {}),
         ...(coldRestoreOverride ? { launchAgent: coldRestoreOverride.agent } : {}),
+        ...(coldRestoreOverride?.startupCommandDelivery
+          ? { startupCommandDelivery: coldRestoreOverride.startupCommandDelivery }
+          : {}),
         callbacks: {
           onData: dataCallback,
           onReplayData: replayDataCallback,
@@ -5797,6 +5809,9 @@ export function connectPanePty(
                 ? { launchToken: coldRestoreStartup.launchToken }
                 : {}),
               ...(coldRestoreStartup?.agent ? { launchAgent: coldRestoreStartup.agent } : {}),
+              ...(coldRestoreStartup?.startupCommandDelivery
+                ? { startupCommandDelivery: coldRestoreStartup.startupCommandDelivery }
+                : {}),
               callbacks: {
                 onData: dataCallback,
                 onReplayData: replayDataCallback,
@@ -5980,6 +5995,9 @@ export function connectPanePty(
           : {}),
         ...(coldRestoreStartup?.launchToken ? { launchToken: coldRestoreStartup.launchToken } : {}),
         ...(coldRestoreStartup?.agent ? { launchAgent: coldRestoreStartup.agent } : {}),
+        ...(coldRestoreStartup?.startupCommandDelivery
+          ? { startupCommandDelivery: coldRestoreStartup.startupCommandDelivery }
+          : {}),
         callbacks: {
           onData: dataCallback,
           onReplayData: replayDataCallback,

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -545,6 +545,9 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(startup?.command).not.toContain('changed')
     expect(startup?.launchConfig).toEqual(record.launchConfig)
     expect(startup?.resumeProviderSession).toEqual(record.providerSession)
+    // Why (#5232/#5356): Codex resume must use shell-ready delivery so the
+    // `resume <id>` payload survives rc-file noise instead of racing it.
+    expect(startup?.startupCommandDelivery).toBe('shell-ready')
   })
 
   it('launches once and clears skipped duplicates for the same provider session', () => {

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -57,6 +57,13 @@ describe('agent process recognition', () => {
       agent: 'claude',
       processName: 'claude'
     })
+    // Why (#5232/#5356): the Codex resume launch must be recognized as codex so
+    // the spawn path applies Codex's shell-ready delivery — otherwise the
+    // `resume <id>` payload can be dropped and a fresh session launches instead.
+    expect(recognizeAgentProcessFromCommandLine('codex resume sess-1')).toEqual({
+      agent: 'codex',
+      processName: 'codex'
+    })
   })
 
   it('recognizes Command Code without classifying Windows cmd.exe as an agent', () => {

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -235,6 +235,35 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchCommand).toBe("codex 'resume' 's1'")
   })
 
+  it('forces shell-ready delivery for Codex resume so the payload survives rc-file noise', () => {
+    // Why (#5232/#5356): `codex resume <id>` is payload-bearing Codex startup
+    // text. Without shell-ready delivery the daemon markerless fast path can
+    // drop the resume target and silently launch a fresh session instead.
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe("codex 'resume' 's1'")
+    expect(plan?.startupCommandDelivery).toBe('shell-ready')
+  })
+
+  it('does not force shell-ready delivery for non-Codex resume (already shell-ready by default)', () => {
+    // Non-Codex commands always take the daemon's shell-ready launch config, so
+    // requesting it here would be redundant and diverge from the prompt path.
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe("claude '--resume' 's1'")
+    expect(plan?.startupCommandDelivery).toBeUndefined()
+  })
+
   it('honors command overrides when building POSIX resume plans', () => {
     const plan = buildAgentResumeStartupPlan({
       agent: 'codex',

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -219,6 +219,11 @@ export function buildAgentResumeStartupPlan(args: {
     expectedProcess: config.expectedProcess,
     followupPrompt: null,
     launchConfig,
+    // Why: the resume target (`codex resume <id>`) is payload-bearing Codex
+    // startup text, which the markerless fast path can drop to rc-file noise —
+    // silently launching a fresh session instead of resuming. Mirror the
+    // prompt/draft launch plans and force shell-ready delivery for Codex.
+    ...(args.agent === 'codex' ? { startupCommandDelivery: 'shell-ready' as const } : {}),
     ...(args.agentEnv ? { env: { ...args.agentEnv } } : {})
   }
 }


### PR DESCRIPTION
## Problem

When Orca can't reattach a persisted agent session, it spawns a fresh shell and **injects a resume command** (`claude --resume <id>`, `codex resume <id>`, …). For **Codex**, the spawn path (`pty-subprocess.ts` / `local-pty-provider.ts`) has a markerless "fast" launch path whose own comment warns:

> payload-bearing Codex startup text can be dropped by rc-file noise; plain Codex stays markerless to preserve the startup-speed path.

The prompt-launch (`buildAgentStartupPlan`) and draft-launch (`buildAgentDraftLaunchPlan`) builders both opt Codex into `startupCommandDelivery: 'shell-ready'` so their payload survives. **`buildAgentResumeStartupPlan` did not.**

Because `codex resume <id>` *is* recognized as codex (only `claude`/`ante` get headless-filtered), the resume launch takes the codex branch and — without the flag — uses markerless delivery. The `resume <id>` payload can then be dropped/corrupted by rc-file output, so **Codex silently launches a fresh session instead of resuming**. It's a race, so it fails intermittently.

This affects every Codex resume path: manual sidebar wake, mobile-driven wake, and cold-restore on first launch after upgrade (the session-loss class tracked in #5232 / #5356). Non-Codex agents are unaffected — they always take the shell-ready launch config (the `else` branch).

## Fix

- **`buildAgentResumeStartupPlan`** (`src/shared/tui-agent-startup.ts`): set `startupCommandDelivery: 'shell-ready'` for Codex, mirroring the prompt/draft builders. This alone fixes the manual/mobile wake paths, which already thread the flag through to spawn.
- **`pty-connection.ts` cold-restore path**: propagate the flag so first-launch-after-upgrade Codex resume also survives — added `startupCommandDelivery` to the `ColdRestoreAgentResumeStartup` type, populated it in `buildColdRestoreAgentResumeStartup`, and forwarded it at all **three** connect sites that inject the resume command (the fresh-spawn site plus the two deferred-reattach sites that fall back to a fresh spawn when the daemon session is gone).

The flag flows through the existing spawn pipeline that the normal Codex prompt launch already relies on, and is honored by both the daemon (`pty-subprocess.ts`) and local (`local-pty-provider.ts`) providers.

## Tests

Additive regression coverage locking the contract:
- `tui-agent-startup.test.ts` — Codex resume plan → `shell-ready`; non-Codex resume → undefined.
- `agent-process-recognition.test.ts` — `codex resume sess-1` is recognized as codex (the reason the bug triggers).
- `resume-sleeping-agent-session.test.ts` — the queued Codex wake command carries `shell-ready` (propagation through the real wake path).

All touched suites pass (425 tests); node + web typechecks clean.
