### PR TITLE
fix(preflight): reject Windows paths from WSL agent lookup

### DIFF
--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -78,11 +78,11 @@ describe('detectWslCommandsOnPath', () => {
 
   it('ignores commands whose resolved path is not absolute', async () => {
     execFileAsyncMock.mockResolvedValue({
-      stdout: '__ORCA_AGENT_PATH__claude\tclaude\n',
+      stdout: '__ORCA_AGENT_PATH__claude\tclaude\n' + '__ORCA_AGENT_PATH__codex\tC:\\spoof\n',
       stderr: ''
     })
 
-    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
 
     expect(found).toEqual(new Set())
   })

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -114,6 +114,8 @@ function parseWslDetectedCommands(stdout: string): Set<string> {
     }
     const command = payload.slice(0, separatorIndex)
     const resolvedPath = payload.slice(separatorIndex + 1)
+    // Why: WSL commands run in a POSIX guest; accepting C:\ paths lets host
+    // startup chatter masquerade as an installed guest executable.
     if (path.posix.isAbsolute(resolvedPath)) {
       found.add(command)
     }

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -114,8 +114,8 @@ function parseWslDetectedCommands(stdout: string): Set<string> {
     }
     const command = payload.slice(0, separatorIndex)
     const resolvedPath = payload.slice(separatorIndex + 1)
-    // Why: WSL commands run in a POSIX guest; accepting C:\ paths lets host
-    // startup chatter masquerade as an installed guest executable.
+    // Why: a real guest executable always resolves to a POSIX-absolute path, so
+    // a Windows-style C:\ path here is spoofed/non-guest output, not an install.
     if (path.posix.isAbsolute(resolvedPath)) {
       found.add(command)
     }

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -114,7 +114,7 @@ function parseWslDetectedCommands(stdout: string): Set<string> {
     }
     const command = payload.slice(0, separatorIndex)
     const resolvedPath = payload.slice(separatorIndex + 1)
-    if (path.posix.isAbsolute(resolvedPath) || path.win32.isAbsolute(resolvedPath)) {
+    if (path.posix.isAbsolute(resolvedPath)) {
       found.add(command)
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to **#7867**. WSL agent PATH discovery previously treated `path.win32.isAbsolute` results as valid guest paths, so a Windows absolute path like `C:\spoof` could be counted as a found agent inside WSL.

Only POSIX absolute paths are valid inside the WSL guest.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - `vitest run src/main/ipc/preflight-wsl-agent-detection.test.ts` (covers `C:\spoof` rejection)

## AI Review Report

Scoped one-line semantic fix + regression test. Checked:
- **Windows / WSL only**: path classification for WSL guest; host Windows paths must not count as in-guest agent installs.
- **macOS / Linux**: no behavior change (WSL detection path is Windows-specific).
- **SSH / remote**: not in scope; this is local WSL preflight only.
- **Security**: avoids treating a host-side absolute path as proof an agent exists in the guest.

## Security Audit

- No new IPC, command execution, or secrets.
- Tightens validation: rejects Windows-style absolute paths when parsing WSL `which`-style agent discovery output, reducing false-positive agent detection.

## Notes

- Rebased onto latest `origin/main` (`65449cb9e`).
- Platform: Windows + WSL. Other platforms unchanged.