### PR TITLE
Route provider account surfaces through the active Remote Orca Server

### DIFF
--- a/src/main/ipc/notification-authorization-status.ts
+++ b/src/main/ipc/notification-authorization-status.ts
@@ -80,6 +80,7 @@ function runStatusHelper(helperPath: string): Promise<NotificationAuthorizationS
           case 'not-determined':
             resolve('not-determined')
             return
+          case undefined:
           default:
             resolve('unknown')
         }

--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -70,4 +70,39 @@ describe('AccountsPane', () => {
     )
     expect(markup).not.toContain('This device')
   })
+
+  it('scopes account copy to the active remote server and disables local sign-in actions', () => {
+    // Note: static SSR markup reads the store's initial state (zustand v5), so
+    // this exercises the fallback server label; the named-server path is
+    // covered by live validation against a paired server.
+    const markup = renderPane(
+      {
+        ...getDefaultSettings('/tmp'),
+        activeRuntimeEnvironmentId: 'env-1'
+      },
+      { wslSupportedPlatform: true }
+    )
+
+    expect(markup).toContain(
+      'Showing accounts managed by the remote server. Add or re-authenticate accounts on that server.'
+    )
+    // The WSL account-location toggle is a local concern; a remote owner hides it.
+    expect(markup).not.toContain('aria-label="Account location"')
+    const addAccountIndex = markup.indexOf('Add Account')
+    expect(addAccountIndex).toBeGreaterThan(0)
+    expect(markup.slice(markup.lastIndexOf('<button', addAccountIndex), addAccountIndex)).toContain(
+      'disabled=""'
+    )
+  })
+
+  it('keeps local copy and enabled sign-in actions when no remote server is active', () => {
+    const markup = renderPane(getDefaultSettings('/tmp'))
+
+    expect(markup).toContain('Showing accounts for this device. New accounts are added there.')
+    const addAccountIndex = markup.indexOf('Add Account')
+    expect(addAccountIndex).toBeGreaterThan(0)
+    expect(
+      markup.slice(markup.lastIndexOf('<button', addAccountIndex), addAccountIndex)
+    ).not.toContain('disabled=""')
+  })
 })

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -62,6 +62,14 @@ import {
 import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
+import {
+  hasRemoteProviderAccountOwner,
+  removeClaudeProviderAccount,
+  removeCodexProviderAccount,
+  selectClaudeProviderAccount,
+  selectCodexProviderAccount,
+  watchProviderAccounts
+} from '@/runtime/runtime-provider-accounts-client'
 
 export { getAccountsPaneSearchEntries }
 
@@ -205,21 +213,23 @@ function getClaudeAccountLabel(
 }
 
 function getCodexAccountRuntimeLabel(
-  account: CodexRateLimitAccountsState['accounts'][number]
+  account: CodexRateLimitAccountsState['accounts'][number],
+  hostLabel = getHostRuntimeLabel()
 ): string {
   if (account.managedHomeRuntime === 'wsl') {
     return account.wslDistro ? `WSL ${account.wslDistro}` : 'WSL'
   }
-  return getHostRuntimeLabel()
+  return hostLabel
 }
 
 function getClaudeAccountRuntimeLabel(
-  account: ClaudeRateLimitAccountsState['accounts'][number]
+  account: ClaudeRateLimitAccountsState['accounts'][number],
+  hostLabel = getHostRuntimeLabel()
 ): string {
   if (account.managedAuthRuntime === 'wsl') {
     return account.wslDistro ? `WSL ${account.wslDistro}` : 'WSL'
   }
-  return getHostRuntimeLabel()
+  return hostLabel
 }
 
 function getCodexAccountErrorDescription(error: unknown): string {
@@ -340,22 +350,41 @@ export function AccountsPane({
   const miniMaxRateLimits = useAppStore((s) => s.rateLimits.minimax)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const fetchSettings = useAppStore((s) => s.fetchSettings)
+  const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const recordedOpenCodeSettingEditsRef = useRef<Set<'cookie' | 'workspaceId'>>(new Set())
   const [miniMaxCookieDraft, setMiniMaxCookieDraft] = useState('')
   const [miniMaxConfigured, setMiniMaxConfigured] = useState(false)
   const [miniMaxCredentialBusy, setMiniMaxCredentialBusy] = useState(false)
-  const accountRuntime = getSelectedAccountRuntime(
+  const localAccountRuntime = getSelectedAccountRuntime(
     settings,
     wslSupportedPlatform,
     wslAvailable,
     wslDistros,
     wslCapabilitiesLoading
   )
+  // Why: with a Remote Orca Server active the server owns provider accounts
+  // (see #7973); every list/select/remove below must scope to it, not host/WSL.
+  const isRemoteAccountScope = hasRemoteProviderAccountOwner(settings)
+  const activeRuntimeEnvironmentId = settings.activeRuntimeEnvironmentId?.trim() || null
+  const remoteServerLabel = isRemoteAccountScope
+    ? (runtimeEnvironments.find((environment) => environment.id === activeRuntimeEnvironmentId)
+        ?.name ??
+      translate('auto.components.settings.AccountsPane.remoteServerFallback', 'the remote server'))
+    : null
+  const accountRuntime: LocalAccountRuntime = isRemoteAccountScope
+    ? { runtime: 'host', label: remoteServerLabel ?? '' }
+    : localAccountRuntime
   // Why: host runtime labels are standalone UI labels; interpolated prose needs sentence casing.
   const accountRuntimeSentenceLabel =
-    accountRuntime.runtime === 'host' && !navigator.userAgent.includes('Windows')
+    !isRemoteAccountScope &&
+    accountRuntime.runtime === 'host' &&
+    !navigator.userAgent.includes('Windows')
       ? `${accountRuntime.label.charAt(0).toLocaleLowerCase()}${accountRuntime.label.slice(1)}`
       : accountRuntime.label
+  const localAccountRuntimeSentenceLabel =
+    localAccountRuntime.runtime === 'host' && !navigator.userAgent.includes('Windows')
+      ? `${localAccountRuntime.label.charAt(0).toLocaleLowerCase()}${localAccountRuntime.label.slice(1)}`
+      : localAccountRuntime.label
 
   const [codexAccounts, setCodexAccounts] = useState<CodexRateLimitAccountsState>({
     accounts: [],
@@ -384,15 +413,18 @@ export function AccountsPane({
   )
   const activeCodexAccountId = getActiveCodexAccountIdForRuntime(codexAccounts, accountRuntime)
   const activeClaudeAccountId = getActiveClaudeAccountIdForRuntime(claudeAccounts, accountRuntime)
-  const activeCodexAuthWarning = codexAccountsLoaded
-    ? getCodexAccountAuthWarning({
-        limits: codexRateLimits,
-        target: codexRateLimitTarget,
-        runtime: accountRuntime,
-        activeAccountId: activeCodexAccountId,
-        accountId: activeCodexAccountId
-      })
-    : null
+  // Why: the auth warning is derived from the desktop's own rate-limit poll;
+  // with a remote owner it would misattribute local auth state to the server.
+  const activeCodexAuthWarning =
+    codexAccountsLoaded && !isRemoteAccountScope
+      ? getCodexAccountAuthWarning({
+          limits: codexRateLimits,
+          target: codexRateLimitTarget,
+          runtime: accountRuntime,
+          activeAccountId: activeCodexAccountId,
+          accountId: activeCodexAccountId
+        })
+      : null
   const systemCodexNeedsReauthentication =
     activeCodexAccountId === null && Boolean(activeCodexAuthWarning)
   const accountRuntimeUnavailable =
@@ -477,21 +509,22 @@ export function AccountsPane({
   }, [])
 
   useEffect(() => {
-    let stale = false
-
-    const loadCodexAccounts = async (): Promise<void> => {
-      try {
-        const nextCodex = await window.api.codexAccounts.list()
-        if (!stale) {
-          setCodexAccounts(nextCodex)
+    // Why: remote snapshots stream usage refreshes after the synchronous ready
+    // message, so the watcher stays open for the pane's lifetime; the local
+    // path resolves once and the close() is a no-op.
+    const watcher = watchProviderAccounts(
+      { activeRuntimeEnvironmentId },
+      {
+        onSnapshot: (snapshot) => {
+          setCodexAccounts(snapshot.codex)
+          setClaudeAccounts(snapshot.claude)
           setCodexAccountsLoaded(true)
-        }
-      } catch (error) {
-        if (!stale) {
+        },
+        onError: (error) => {
           toast.error(
             translate(
-              'auto.components.settings.AccountsPane.b8c2905c2b',
-              'Could not load Codex accounts.'
+              'auto.components.settings.AccountsPane.loadAccountsFailed',
+              'Could not load provider accounts.'
             ),
             {
               description: String((error as Error)?.message ?? error)
@@ -499,46 +532,27 @@ export function AccountsPane({
           )
         }
       }
-    }
-
-    const loadClaudeAccounts = async (): Promise<void> => {
-      try {
-        const nextClaude = await window.api.claudeAccounts.list()
-        if (!stale) {
-          setClaudeAccounts(nextClaude)
-        }
-      } catch (error) {
-        if (!stale) {
-          toast.error(
-            translate(
-              'auto.components.settings.AccountsPane.9107406589',
-              'Could not load Claude accounts.'
-            ),
-            {
-              description: String((error as Error)?.message ?? error)
-            }
-          )
-        }
-      }
-    }
-
-    void loadCodexAccounts()
-    void loadClaudeAccounts()
+    )
 
     return () => {
-      stale = true
+      watcher.close()
     }
-  }, [])
+  }, [activeRuntimeEnvironmentId])
 
   const syncCodexAccounts = async (next: CodexRateLimitAccountsState): Promise<void> => {
     setCodexAccounts(next)
     setCodexAccountsLoaded(true)
-    await fetchSettings()
+    // Why: remote mutations never change local GlobalSettings account fields.
+    if (!isRemoteAccountScope) {
+      await fetchSettings()
+    }
   }
 
   const syncClaudeAccounts = async (next: ClaudeRateLimitAccountsState): Promise<void> => {
     setClaudeAccounts(next)
-    await fetchSettings()
+    if (!isRemoteAccountScope) {
+      await fetchSettings()
+    }
   }
 
   const formatAccountTimestamp = (timestamp: number): string => {
@@ -735,6 +749,7 @@ export function AccountsPane({
 
   const visibleSections = [
     wslSupportedPlatform &&
+    !isRemoteAccountScope &&
     matchesSettingsSearch(searchQuery, getAccountsLocationSearchEntries()) ? (
       <section key="account-runtime" id="accounts-runtime" className="space-y-3 scroll-mt-6">
         {accountRuntimeControls}
@@ -770,11 +785,17 @@ export function AccountsPane({
                 {translate('auto.components.settings.AccountsPane.94d351af4a', 'Accounts')}
               </Label>
               <p className="text-xs text-muted-foreground">
-                {translate(
-                  'auto.components.settings.AccountsPane.c0a52abfc5',
-                  'Showing accounts for {{value0}}. New accounts are added there.',
-                  { value0: accountRuntimeSentenceLabel }
-                )}
+                {isRemoteAccountScope
+                  ? translate(
+                      'auto.components.settings.AccountsPane.remoteScopeAccounts',
+                      'Showing accounts managed by {{value0}}. Add or re-authenticate accounts on that server.',
+                      { value0: accountRuntimeSentenceLabel }
+                    )
+                  : translate(
+                      'auto.components.settings.AccountsPane.c0a52abfc5',
+                      'Showing accounts for {{value0}}. New accounts are added there.',
+                      { value0: accountRuntimeSentenceLabel }
+                    )}
               </p>
             </div>
             <div className="flex shrink-0 items-center gap-1.5">
@@ -790,7 +811,12 @@ export function AccountsPane({
                   )
                 }
                 disabled={
-                  claudeAction !== 'idle' || wslCapabilitiesLoading || accountRuntimeUnavailable
+                  // Why: interactive `claude login` needs a desktop browser and
+                  // would authenticate against this device, not the server.
+                  isRemoteAccountScope ||
+                  claudeAction !== 'idle' ||
+                  wslCapabilitiesLoading ||
+                  accountRuntimeUnavailable
                 }
                 className="gap-1.5"
               >
@@ -820,7 +846,7 @@ export function AccountsPane({
               type="button"
               onClick={() =>
                 void runClaudeAccountAction('select:system', () =>
-                  window.api.claudeAccounts.select({
+                  selectClaudeProviderAccount(settings, {
                     accountId: null,
                     runtime: accountRuntime.runtime,
                     wslDistro: accountRuntime.wslDistro
@@ -888,7 +914,7 @@ export function AccountsPane({
                         type="button"
                         onClick={() =>
                           void runClaudeAccountAction(`select:${account.id}`, () =>
-                            window.api.claudeAccounts.select({
+                            selectClaudeProviderAccount(settings, {
                               accountId: account.id,
                               runtime: account.managedAuthRuntime ?? 'host',
                               wslDistro: account.wslDistro ?? null
@@ -904,7 +930,7 @@ export function AccountsPane({
                             variant="outline"
                             className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/70"
                           >
-                            {getClaudeAccountRuntimeLabel(account)}
+                            {getClaudeAccountRuntimeLabel(account, accountRuntime.label)}
                           </Badge>
                           {isActive ? (
                             <Badge
@@ -934,7 +960,7 @@ export function AccountsPane({
                               window.api.claudeAccounts.reauthenticate({ accountId: account.id })
                             )
                           }}
-                          disabled={isBusy}
+                          disabled={isRemoteAccountScope || isBusy}
                           className="h-6 px-2 text-muted-foreground hover:text-foreground"
                         >
                           {isReauthing ? (
@@ -984,10 +1010,16 @@ export function AccountsPane({
             )}
           </p>
           <p className="text-xs text-muted-foreground">
-            {translate(
-              'auto.components.settings.AccountsPane.340d6f7a85',
-              'Each account keeps its own local sign-in context in Orca. Account auth stays on this device.'
-            )}
+            {isRemoteAccountScope
+              ? translate(
+                  'auto.components.settings.AccountsPane.remoteScopeAuthContext',
+                  'Each account keeps its own sign-in context on {{value0}}.',
+                  { value0: accountRuntimeSentenceLabel }
+                )
+              : translate(
+                  'auto.components.settings.AccountsPane.340d6f7a85',
+                  'Each account keeps its own local sign-in context in Orca. Account auth stays on this device.'
+                )}
           </p>
         </div>
 
@@ -1036,11 +1068,17 @@ export function AccountsPane({
                 {translate('auto.components.settings.AccountsPane.94d351af4a', 'Accounts')}
               </Label>
               <p className="text-xs text-muted-foreground">
-                {translate(
-                  'auto.components.settings.AccountsPane.c0a52abfc5',
-                  'Showing accounts for {{value0}}. New accounts are added there.',
-                  { value0: accountRuntimeSentenceLabel }
-                )}
+                {isRemoteAccountScope
+                  ? translate(
+                      'auto.components.settings.AccountsPane.remoteScopeAccounts',
+                      'Showing accounts managed by {{value0}}. Add or re-authenticate accounts on that server.',
+                      { value0: accountRuntimeSentenceLabel }
+                    )
+                  : translate(
+                      'auto.components.settings.AccountsPane.c0a52abfc5',
+                      'Showing accounts for {{value0}}. New accounts are added there.',
+                      { value0: accountRuntimeSentenceLabel }
+                    )}
               </p>
             </div>
             <Button
@@ -1055,7 +1093,12 @@ export function AccountsPane({
                 )
               }
               disabled={
-                codexAction !== 'idle' || wslCapabilitiesLoading || accountRuntimeUnavailable
+                // Why: interactive `codex login` needs a desktop browser and
+                // would authenticate against this device, not the server.
+                isRemoteAccountScope ||
+                codexAction !== 'idle' ||
+                wslCapabilitiesLoading ||
+                accountRuntimeUnavailable
               }
               className="gap-1.5"
             >
@@ -1073,7 +1116,7 @@ export function AccountsPane({
               type="button"
               onClick={() =>
                 void runCodexAccountAction('select:system', () =>
-                  window.api.codexAccounts.select({
+                  selectCodexProviderAccount(settings, {
                     accountId: null,
                     runtime: accountRuntime.runtime,
                     wslDistro: accountRuntime.wslDistro
@@ -1175,7 +1218,7 @@ export function AccountsPane({
                         type="button"
                         onClick={() =>
                           void runCodexAccountAction(`select:${account.id}`, () =>
-                            window.api.codexAccounts.select({
+                            selectCodexProviderAccount(settings, {
                               accountId: account.id,
                               runtime: account.managedHomeRuntime ?? 'host',
                               wslDistro: account.wslDistro ?? null
@@ -1191,7 +1234,7 @@ export function AccountsPane({
                             variant="outline"
                             className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/70"
                           >
-                            {getCodexAccountRuntimeLabel(account)}
+                            {getCodexAccountRuntimeLabel(account, accountRuntime.label)}
                           </Badge>
                           {isActive ? (
                             <Badge
@@ -1253,7 +1296,7 @@ export function AccountsPane({
                               window.api.codexAccounts.reauthenticate({ accountId: account.id })
                             )
                           }}
-                          disabled={isBusy}
+                          disabled={isRemoteAccountScope || isBusy}
                           className="h-6 px-2 text-muted-foreground hover:text-foreground"
                         >
                           {isReauthing ? (
@@ -1339,7 +1382,7 @@ export function AccountsPane({
               {translate(
                 'auto.components.settings.AccountsPane.c2aee76420',
                 'Extracts OAuth credentials from your local Gemini CLI installation to authenticate with Google for {{value0}}. This uses credentials issued to the Gemini CLI app, not Orca. May break if Google updates the CLI. Use at your own risk.',
-                { value0: accountRuntimeSentenceLabel }
+                { value0: localAccountRuntimeSentenceLabel }
               )}
             </p>
           </div>
@@ -1774,7 +1817,7 @@ export function AccountsPane({
                 }
                 setRemoveAccountId(null)
                 void runCodexAccountAction(`remove:${accountId}`, () =>
-                  window.api.codexAccounts.remove({ accountId })
+                  removeCodexProviderAccount(settings, accountId)
                 )
               }}
             >
@@ -1815,7 +1858,7 @@ export function AccountsPane({
                 }
                 setRemoveClaudeAccountId(null)
                 void runClaudeAccountAction(`remove:${accountId}`, () =>
-                  window.api.claudeAccounts.remove({ accountId })
+                  removeClaudeProviderAccount(settings, accountId)
                 )
               }}
             >

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -888,11 +888,17 @@ export function AccountsPane({
             </button>
             {visibleClaudeAccounts.length === 0 ? (
               <div className="rounded-md border border-dashed border-border/70 px-3 py-4 text-xs text-muted-foreground">
-                {translate(
-                  'auto.components.settings.AccountsPane.3fe7862418',
-                  "No managed Claude accounts for {{value0}}. Orca will use that environment's system default Claude login until you add one here.",
-                  { value0: accountRuntimeSentenceLabel }
-                )}
+                {isRemoteAccountScope
+                  ? translate(
+                      'auto.components.settings.AccountsPane.remoteEmptyClaudeAccounts',
+                      'No managed Claude accounts on {{value0}}. It uses its system default Claude login; add accounts on that server.',
+                      { value0: accountRuntimeSentenceLabel }
+                    )
+                  : translate(
+                      'auto.components.settings.AccountsPane.3fe7862418',
+                      "No managed Claude accounts for {{value0}}. Orca will use that environment's system default Claude login until you add one here.",
+                      { value0: accountRuntimeSentenceLabel }
+                    )}
               </div>
             ) : (
               visibleClaudeAccounts.map((account) => {
@@ -1181,22 +1187,32 @@ export function AccountsPane({
             </button>
             {visibleCodexAccounts.length === 0 ? (
               <div className="rounded-md border border-dashed border-border/70 px-3 py-4 text-xs text-muted-foreground">
-                {translate(
-                  'auto.components.settings.AccountsPane.b4c9450319',
-                  "No managed Codex accounts for {{value0}}. Orca will use that environment's system default Codex login until you add one here.",
-                  { value0: accountRuntimeSentenceLabel }
-                )}
+                {isRemoteAccountScope
+                  ? translate(
+                      'auto.components.settings.AccountsPane.remoteEmptyCodexAccounts',
+                      'No managed Codex accounts on {{value0}}. It uses its system default Codex login; add accounts on that server.',
+                      { value0: accountRuntimeSentenceLabel }
+                    )
+                  : translate(
+                      'auto.components.settings.AccountsPane.b4c9450319',
+                      "No managed Codex accounts for {{value0}}. Orca will use that environment's system default Codex login until you add one here.",
+                      { value0: accountRuntimeSentenceLabel }
+                    )}
               </div>
             ) : (
               visibleCodexAccounts.map((account) => {
                 const isActive = activeCodexAccountId === account.id
-                const accountAuthWarning = getCodexAccountAuthWarning({
-                  limits: codexRateLimits,
-                  target: codexRateLimitTarget,
-                  runtime: accountRuntime,
-                  activeAccountId: activeCodexAccountId,
-                  accountId: account.id
-                })
+                // Why: same remote gate as the section-level warning — the
+                // desktop's rate-limit poll says nothing about server accounts.
+                const accountAuthWarning = isRemoteAccountScope
+                  ? null
+                  : getCodexAccountAuthWarning({
+                      limits: codexRateLimits,
+                      target: codexRateLimitTarget,
+                      runtime: accountRuntime,
+                      activeAccountId: activeCodexAccountId,
+                      accountId: account.id
+                    })
                 const needsReauthentication = Boolean(accountAuthWarning)
                 const isReauthing = codexAction === `reauth:${account.id}`
                 const isRemoving = codexAction === `remove:${account.id}`

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -711,12 +711,15 @@ function ClaudeSwitcherMenu({
     }
   }, [])
 
+  const activeRuntimeEnvironmentId = settings?.activeRuntimeEnvironmentId?.trim() || null
+  // Why: keyed on the owner id, not the settings object identity, so routine
+  // settings mutations don't re-run the remote snapshot round trip.
   const loadAccounts = useCallback(async () => {
-    const snapshot = await fetchProviderAccountsSnapshot(settings)
+    const snapshot = await fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId })
     if (mountedRef.current) {
       setAccounts(snapshot.claude)
     }
-  }, [settings])
+  }, [activeRuntimeEnvironmentId])
 
   useEffect(() => {
     void loadAccounts().catch((error) => {
@@ -1270,12 +1273,15 @@ function CodexSwitcherMenu({
   })
   const accountState = resolveCodexStatusAccountState(settings, accounts)
 
+  const activeRuntimeEnvironmentId = settings?.activeRuntimeEnvironmentId?.trim() || null
+  // Why: keyed on the owner id, not the settings object identity, so routine
+  // settings mutations don't re-run the remote snapshot round trip.
   const loadAccounts = useCallback(async () => {
-    const snapshot = await fetchProviderAccountsSnapshot(settings)
+    const snapshot = await fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId })
     if (mountedRef.current) {
       setAccounts(snapshot.codex)
     }
-  }, [settings])
+  }, [activeRuntimeEnvironmentId])
 
   useEffect(() => {
     mountedRef.current = true

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -72,6 +72,11 @@ import {
   useWindowsTerminalCapabilities
 } from '@/lib/windows-terminal-capabilities'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import {
+  fetchProviderAccountsSnapshot,
+  selectClaudeProviderAccount,
+  selectCodexProviderAccount
+} from '@/runtime/runtime-provider-accounts-client'
 import { translate } from '@/i18n/i18n'
 
 type StatusBarProps = {
@@ -132,6 +137,7 @@ export type ClaudeStatusSwitchGroup = {
 type StatusSwitchGroupOptions = {
   fallbackWslDistro?: string | null
   includeFallbackWsl?: boolean
+  hostLabel?: string
 }
 
 function getHostRuntimeLabel(): string {
@@ -157,9 +163,12 @@ function getCodexStatusWslKey(wslDistro: string | null | undefined): string {
   return trimmed ? trimmed : '__default__'
 }
 
-function getCodexStatusRuntimeLabel(target: CodexStatusRuntimeTarget): string {
+function getCodexStatusRuntimeLabel(
+  target: CodexStatusRuntimeTarget,
+  hostLabel = getHostRuntimeLabel()
+): string {
   if (target.runtime === 'host') {
-    return getHostRuntimeLabel()
+    return hostLabel
   }
   return target.wslDistro ? `WSL ${target.wslDistro}` : 'WSL default'
 }
@@ -261,7 +270,7 @@ export function buildCodexStatusSwitchGroups(
     const accountsForTarget = getCodexStatusAccountsForTarget(state, target)
     return {
       key: getCodexStatusRuntimeKey(target),
-      label: getCodexStatusRuntimeLabel(target),
+      label: getCodexStatusRuntimeLabel(target, options.hostLabel),
       runtimeTarget: target,
       targets: [
         {
@@ -420,7 +429,7 @@ export function buildClaudeStatusSwitchGroups(
     const accountsForTarget = getClaudeStatusAccountsForTarget(state, target)
     return {
       key: getCodexStatusRuntimeKey(target),
-      label: getCodexStatusRuntimeLabel(target),
+      label: getCodexStatusRuntimeLabel(target, options.hostLabel),
       runtimeTarget: target,
       targets: [
         {
@@ -508,6 +517,29 @@ function getClaudeStatusAccountsFromSettings(
       wsl: { ...settings.activeClaudeManagedAccountIdsByRuntime?.wsl }
     }
   }
+}
+
+// Why: with a Remote Orca Server active, accounts persisted in local
+// GlobalSettings describe this desktop, not the account owner; the snapshot
+// fetched from the server must win (#7973).
+export function resolveCodexStatusAccountState(
+  settings: GlobalSettings | null | undefined,
+  runtimeState: CodexRateLimitAccountsState
+): CodexRateLimitAccountsState {
+  if (settings?.activeRuntimeEnvironmentId?.trim()) {
+    return runtimeState
+  }
+  return getCodexStatusAccountsFromSettings(settings) ?? runtimeState
+}
+
+export function resolveClaudeStatusAccountState(
+  settings: GlobalSettings | null | undefined,
+  runtimeState: ClaudeRateLimitAccountsState
+): ClaudeRateLimitAccountsState {
+  if (settings?.activeRuntimeEnvironmentId?.trim()) {
+    return runtimeState
+  }
+  return getClaudeStatusAccountsFromSettings(settings) ?? runtimeState
 }
 
 function CodexRestartStatusPrompt(): React.JSX.Element | null {
@@ -648,8 +680,15 @@ function ClaudeSwitcherMenu({
   const inactiveClaudeAccounts = useAppStore((s) => s.rateLimits.inactiveClaudeAccounts)
   const claudeTarget = useAppStore((s) => s.rateLimits.claudeTarget)
   const settings = useAppStore((s) => s.settings)
+  const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const hasActiveRuntimeEnvironment = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
   const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
+  const providerAccountHostLabel = hasActiveRuntimeEnvironment
+    ? (runtimeEnvironments.find(
+        (environment) => environment.id === settings?.activeRuntimeEnvironmentId?.trim()
+      )?.name ??
+      translate('auto.components.status.bar.StatusBar.remoteServerLabel', 'Remote server'))
+    : undefined
   const windowsTerminalCapabilities = useWindowsTerminalCapabilities(
     navigator.userAgent.includes('Windows') || hasActiveRuntimeEnvironment,
     false,
@@ -661,9 +700,9 @@ function ClaudeSwitcherMenu({
     if (!settings) {
       return 'no-settings'
     }
-    return `${settings.activeClaudeManagedAccountId ?? 'system'}:${JSON.stringify(settings.activeClaudeManagedAccountIdsByRuntime ?? null)}:${settings.claudeManagedAccounts.map((account) => `${account.id}:${account.updatedAt}`).join('|')}`
+    return `${settings.activeRuntimeEnvironmentId?.trim() || 'local'}:${settings.activeClaudeManagedAccountId ?? 'system'}:${JSON.stringify(settings.activeClaudeManagedAccountIdsByRuntime ?? null)}:${settings.claudeManagedAccounts.map((account) => `${account.id}:${account.updatedAt}`).join('|')}`
   })
-  const accountState = getClaudeStatusAccountsFromSettings(settings) ?? accounts
+  const accountState = resolveClaudeStatusAccountState(settings, accounts)
 
   useEffect(() => {
     mountedRef.current = true
@@ -673,11 +712,11 @@ function ClaudeSwitcherMenu({
   }, [])
 
   const loadAccounts = useCallback(async () => {
-    const next = await window.api.claudeAccounts.list()
+    const snapshot = await fetchProviderAccountsSnapshot(settings)
     if (mountedRef.current) {
-      setAccounts(next)
+      setAccounts(snapshot.claude)
     }
-  }, [])
+  }, [settings])
 
   useEffect(() => {
     void loadAccounts().catch((error) => {
@@ -694,13 +733,14 @@ function ClaudeSwitcherMenu({
 
   // Why: inactive-account usage is needed only for the explicit switcher
   // expansion, so fetch it on that event instead of one render later.
+  // Remote-owned accounts have no local inactive-usage cache to fill.
   const handleAccountsExpandedToggle = useCallback((): void => {
     const nextExpanded = !accountsExpanded
     setAccountsExpanded(nextExpanded)
-    if (nextExpanded) {
+    if (nextExpanded && !hasActiveRuntimeEnvironment) {
       void fetchInactiveClaudeAccountUsage()
     }
-  }, [accountsExpanded, fetchInactiveClaudeAccountUsage])
+  }, [accountsExpanded, fetchInactiveClaudeAccountUsage, hasActiveRuntimeEnvironment])
 
   const handleSelectAccount = async (
     accountId: string | null,
@@ -711,7 +751,7 @@ function ClaudeSwitcherMenu({
     }
     setIsSwitching(true)
     try {
-      const next = await window.api.claudeAccounts.select({
+      const next = await selectClaudeProviderAccount(settings, {
         accountId,
         runtime: target.runtime,
         wslDistro: target.wslDistro
@@ -720,7 +760,11 @@ function ClaudeSwitcherMenu({
       if (mountedRef.current) {
         setAccounts(next)
       }
-      await fetchSettings()
+      // Why: remote selections live on the server; local GlobalSettings
+      // account fields are untouched, so refetching them is pure churn.
+      if (!hasActiveRuntimeEnvironment) {
+        await fetchSettings()
+      }
       if (mountedRef.current) {
         setAccountsExpanded(false)
       }
@@ -760,7 +804,8 @@ function ClaudeSwitcherMenu({
     toCodexStatusRuntimeTarget(claudeTarget),
     {
       fallbackWslDistro,
-      includeFallbackWsl: shouldIncludeSettingsWslRuntime(settings)
+      includeFallbackWsl: !hasActiveRuntimeEnvironment && shouldIncludeSettingsWslRuntime(settings),
+      hostLabel: providerAccountHostLabel
     }
   )
   const selectedGroup =
@@ -1201,8 +1246,15 @@ function CodexSwitcherMenu({
   const inactiveCodexAccounts = useAppStore((s) => s.rateLimits.inactiveCodexAccounts)
   const codexTarget = useAppStore((s) => s.rateLimits.codexTarget)
   const settings = useAppStore((s) => s.settings)
+  const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const hasActiveRuntimeEnvironment = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
   const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
+  const providerAccountHostLabel = hasActiveRuntimeEnvironment
+    ? (runtimeEnvironments.find(
+        (environment) => environment.id === settings?.activeRuntimeEnvironmentId?.trim()
+      )?.name ??
+      translate('auto.components.status.bar.StatusBar.remoteServerLabel', 'Remote server'))
+    : undefined
   const windowsTerminalCapabilities = useWindowsTerminalCapabilities(
     navigator.userAgent.includes('Windows') || hasActiveRuntimeEnvironment,
     false,
@@ -1214,16 +1266,16 @@ function CodexSwitcherMenu({
     if (!settings) {
       return 'no-settings'
     }
-    return `${settings.activeCodexManagedAccountId ?? 'system'}:${JSON.stringify(settings.activeCodexManagedAccountIdsByRuntime ?? null)}:${settings.codexManagedAccounts.map((account) => `${account.id}:${account.updatedAt}`).join('|')}`
+    return `${settings.activeRuntimeEnvironmentId?.trim() || 'local'}:${settings.activeCodexManagedAccountId ?? 'system'}:${JSON.stringify(settings.activeCodexManagedAccountIdsByRuntime ?? null)}:${settings.codexManagedAccounts.map((account) => `${account.id}:${account.updatedAt}`).join('|')}`
   })
-  const accountState = getCodexStatusAccountsFromSettings(settings) ?? accounts
+  const accountState = resolveCodexStatusAccountState(settings, accounts)
 
   const loadAccounts = useCallback(async () => {
-    const next = await window.api.codexAccounts.list()
+    const snapshot = await fetchProviderAccountsSnapshot(settings)
     if (mountedRef.current) {
-      setAccounts(next)
+      setAccounts(snapshot.codex)
     }
-  }, [])
+  }, [settings])
 
   useEffect(() => {
     mountedRef.current = true
@@ -1256,7 +1308,7 @@ function CodexSwitcherMenu({
     const previousActiveAccountId = getCodexStatusActiveId(accountState, target)
     setIsSwitching(true)
     try {
-      const next = await window.api.codexAccounts.select({
+      const next = await selectCodexProviderAccount(settings, {
         accountId,
         runtime: target.runtime,
         wslDistro: target.wslDistro
@@ -1265,7 +1317,11 @@ function CodexSwitcherMenu({
       if (mountedRef.current) {
         setAccounts(next)
       }
-      await fetchSettings()
+      // Why: remote selections live on the server; local GlobalSettings
+      // account fields are untouched, so refetching them is pure churn.
+      if (!hasActiveRuntimeEnvironment) {
+        await fetchSettings()
+      }
       const nextActiveAccountId = getCodexStatusActiveId(next, target)
       if (previousActiveAccountId !== nextActiveAccountId) {
         await markLiveCodexSessionsForRestart({
@@ -1381,12 +1437,13 @@ function CodexSwitcherMenu({
   const handleAccountsExpandedToggle = useCallback((): void => {
     const nextExpanded = !accountsExpanded
     setAccountsExpanded(nextExpanded)
-    if (nextExpanded) {
+    if (nextExpanded && !hasActiveRuntimeEnvironment) {
       // Why: inactive-account usage is needed only for the explicit switcher
       // expansion, so fetch it on that event instead of one render later.
+      // Remote-owned accounts have no local inactive-usage cache to fill.
       void fetchInactiveCodexAccountUsage()
     }
-  }, [accountsExpanded, fetchInactiveCodexAccountUsage])
+  }, [accountsExpanded, fetchInactiveCodexAccountUsage, hasActiveRuntimeEnvironment])
 
   const selectedRuntimeKey = getCodexStatusRuntimeKey(
     normalizeCodexStatusRuntimeTarget(accountState, toCodexStatusRuntimeTarget(codexTarget))
@@ -1400,7 +1457,8 @@ function CodexSwitcherMenu({
     toCodexStatusRuntimeTarget(codexTarget),
     {
       fallbackWslDistro,
-      includeFallbackWsl: shouldIncludeSettingsWslRuntime(settings)
+      includeFallbackWsl: !hasActiveRuntimeEnvironment && shouldIncludeSettingsWslRuntime(settings),
+      hostLabel: providerAccountHostLabel
     }
   )
   const selectedGroup =
@@ -1411,7 +1469,10 @@ function CodexSwitcherMenu({
     resetCreditCount !== null
       ? formatResetCreditExpiry(codex.rateLimitResetCredits?.nextExpiresAt, resetCreditCount)
       : null
-  const canRedeemReset = resetCreditCount !== null && resetCreditCount > 0
+  // Why: reset credits redeem against the desktop's own Codex login; with a
+  // remote account owner the credit does not apply to the server's account.
+  const canRedeemReset =
+    !hasActiveRuntimeEnvironment && resetCreditCount !== null && resetCreditCount > 0
 
   return (
     <ProviderDetailsMenu
@@ -1550,7 +1611,10 @@ function CodexSwitcherMenu({
                   const inactiveUsage = target.id
                     ? inactiveCodexAccounts.find((a) => a.accountId === target.id)
                     : null
+                  // Why: sign-in spawns a local `codex login`; a remote-owned
+                  // account cannot be re-authenticated from this desktop.
                   const showSignInAction =
+                    !hasActiveRuntimeEnvironment &&
                     !target.active &&
                     target.id !== null &&
                     isUnavailableInactiveUsage(inactiveUsage?.rateLimits)

--- a/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
@@ -7,7 +7,9 @@ import type {
 import {
   buildClaudeStatusSwitchGroups,
   buildCodexStatusSwitchGroups,
-  getStatusBarPreferredWslDistro
+  getStatusBarPreferredWslDistro,
+  resolveClaudeStatusAccountState,
+  resolveCodexStatusAccountState
 } from './StatusBar'
 
 const hostLabel = navigator.userAgent.includes('Windows') ? 'Windows' : 'This device'
@@ -132,5 +134,98 @@ describe('status bar runtime switch groups', () => {
         ['Ubuntu']
       )
     ).toBe('Fedora')
+  })
+
+  it('labels the host account group with the active remote server name', () => {
+    const state: CodexRateLimitAccountsState = {
+      accounts: [],
+      activeAccountId: null,
+      activeAccountIdsByRuntime: { host: null, wsl: {} }
+    }
+
+    expect(
+      buildCodexStatusSwitchGroups(
+        state,
+        { runtime: 'host', wslDistro: null },
+        { hostLabel: 'Repro Server' }
+      )[0]?.label
+    ).toBe('Repro Server')
+  })
+
+  it('prefers the runtime snapshot over local settings accounts when a remote server is active', () => {
+    const remoteState: CodexRateLimitAccountsState = {
+      accounts: [
+        {
+          id: 'server-codex-1',
+          email: 'server@example.com',
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeAccountId: 'server-codex-1',
+      activeAccountIdsByRuntime: { host: 'server-codex-1', wsl: {} }
+    }
+    const settings = {
+      activeRuntimeEnvironmentId: 'env-1',
+      activeCodexManagedAccountId: 'desktop-codex-1',
+      activeCodexManagedAccountIdsByRuntime: { host: 'desktop-codex-1', wsl: {} },
+      codexManagedAccounts: [
+        {
+          id: 'desktop-codex-1',
+          email: 'desktop@example.com',
+          managedHomePath: '/tmp/desktop-codex-1',
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ]
+    } as GlobalSettings
+
+    expect(resolveCodexStatusAccountState(settings, remoteState)).toBe(remoteState)
+    // Without a remote owner, settings-derived accounts win as before.
+    expect(
+      resolveCodexStatusAccountState(
+        { ...settings, activeRuntimeEnvironmentId: null },
+        remoteState
+      ).accounts.map((account) => account.id)
+    ).toEqual(['desktop-codex-1'])
+  })
+
+  it('prefers the runtime snapshot for Claude accounts when a remote server is active', () => {
+    const remoteState: ClaudeRateLimitAccountsState = {
+      accounts: [],
+      activeAccountId: null,
+      activeAccountIdsByRuntime: { host: null, wsl: {} }
+    }
+    const settings = {
+      activeRuntimeEnvironmentId: 'env-1',
+      activeClaudeManagedAccountId: 'desktop-claude-1',
+      activeClaudeManagedAccountIdsByRuntime: { host: 'desktop-claude-1', wsl: {} },
+      claudeManagedAccounts: [
+        {
+          id: 'desktop-claude-1',
+          email: 'desktop@example.com',
+          managedAuthPath: '/tmp/desktop-claude-1',
+          authMethod: 'subscription-oauth',
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ]
+    } as GlobalSettings
+
+    expect(resolveClaudeStatusAccountState(settings, remoteState)).toBe(remoteState)
+    expect(
+      resolveClaudeStatusAccountState(
+        { ...settings, activeRuntimeEnvironmentId: '   ' },
+        remoteState
+      ).accounts.map((account) => account.id)
+    ).toEqual(['desktop-claude-1'])
   })
 })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4794,7 +4794,9 @@
           "remoteServerFallback": "the remote server",
           "loadAccountsFailed": "Could not load provider accounts.",
           "remoteScopeAccounts": "Showing accounts managed by {{value0}}. Add or re-authenticate accounts on that server.",
-          "remoteScopeAuthContext": "Each account keeps its own sign-in context on {{value0}}."
+          "remoteScopeAuthContext": "Each account keeps its own sign-in context on {{value0}}.",
+          "remoteEmptyClaudeAccounts": "No managed Claude accounts on {{value0}}. It uses its system default Claude login; add accounts on that server.",
+          "remoteEmptyCodexAccounts": "No managed Codex accounts on {{value0}}. It uses its system default Codex login; add accounts on that server."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3028,7 +3028,8 @@
             "f077f586db": "Don't ask again",
             "c0e972d726": "Cancel",
             "06741a2f3d": "Open MiniMax usage details",
-            "3bbf140864": "MiniMax Usage"
+            "3bbf140864": "MiniMax Usage",
+            "remoteServerLabel": "Remote server"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -4789,7 +4790,11 @@
           "435df0ee51": "Under Request Headers, copy the Cookie value.",
           "7492fb3bba": "Paste it here and click Save.",
           "9fec52de4b": "How to copy the cookie",
-          "4e32e030b2": "Stored locally. Orca sends it only to platform.minimax.io for usage refreshes."
+          "4e32e030b2": "Stored locally. Orca sends it only to platform.minimax.io for usage refreshes.",
+          "remoteServerFallback": "the remote server",
+          "loadAccountsFailed": "Could not load provider accounts.",
+          "remoteScopeAccounts": "Showing accounts managed by {{value0}}. Add or re-authenticate accounts on that server.",
+          "remoteScopeAuthContext": "Each account keeps its own sign-in context on {{value0}}."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3028,7 +3028,8 @@
             "f077f586db": "No volver a preguntar",
             "c0e972d726": "Cancelar",
             "06741a2f3d": "Abrir detalles de uso de MiniMax",
-            "3bbf140864": "Uso de MiniMax"
+            "3bbf140864": "Uso de MiniMax",
+            "remoteServerLabel": "Servidor remoto"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",
@@ -4789,7 +4790,11 @@
           "435df0ee51": "En Encabezados de solicitud, copia el valor del encabezado Cookie.",
           "7492fb3bba": "Pégalo aquí y haz clic en Guardar.",
           "9fec52de4b": "Cómo copiar la cookie",
-          "4e32e030b2": "Se almacena localmente. Orca solo la envía a platform.minimax.io para actualizar el uso."
+          "4e32e030b2": "Se almacena localmente. Orca solo la envía a platform.minimax.io para actualizar el uso.",
+          "remoteServerFallback": "el servidor remoto",
+          "loadAccountsFailed": "No se pudieron cargar las cuentas de proveedor.",
+          "remoteScopeAccounts": "Mostrando las cuentas administradas por {{value0}}. Agrega o vuelve a autenticar cuentas en ese servidor.",
+          "remoteScopeAuthContext": "Cada cuenta mantiene su propio contexto de inicio de sesión en {{value0}}."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reiniciar",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4794,7 +4794,9 @@
           "remoteServerFallback": "el servidor remoto",
           "loadAccountsFailed": "No se pudieron cargar las cuentas de proveedor.",
           "remoteScopeAccounts": "Mostrando las cuentas administradas por {{value0}}. Agrega o vuelve a autenticar cuentas en ese servidor.",
-          "remoteScopeAuthContext": "Cada cuenta mantiene su propio contexto de inicio de sesión en {{value0}}."
+          "remoteScopeAuthContext": "Cada cuenta mantiene su propio contexto de inicio de sesión en {{value0}}.",
+          "remoteEmptyClaudeAccounts": "No hay cuentas de Claude administradas en {{value0}}. Usa su inicio de sesión de Claude predeterminado del sistema; agrega cuentas en ese servidor.",
+          "remoteEmptyCodexAccounts": "No hay cuentas de Codex administradas en {{value0}}. Usa su inicio de sesión de Codex predeterminado del sistema; agrega cuentas en ese servidor."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reiniciar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3028,7 +3028,8 @@
             "f077f586db": "今後表示しない",
             "c0e972d726": "キャンセル",
             "06741a2f3d": "MiniMax の使用量詳細を開く",
-            "3bbf140864": "MiniMax 使用量"
+            "3bbf140864": "MiniMax 使用量",
+            "remoteServerLabel": "リモートサーバー"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",
@@ -4774,7 +4775,11 @@
           "435df0ee51": "リクエストヘッダーの Cookie の値をコピーします。",
           "7492fb3bba": "ここに貼り付けて保存をクリックします。",
           "9fec52de4b": "Cookie のコピー方法",
-          "4e32e030b2": "ローカルに保存されます。Orca は使用量の更新のために platform.minimax.io のみに送信します。"
+          "4e32e030b2": "ローカルに保存されます。Orca は使用量の更新のために platform.minimax.io のみに送信します。",
+          "remoteServerFallback": "リモートサーバー",
+          "loadAccountsFailed": "プロバイダーアカウントを読み込めませんでした。",
+          "remoteScopeAccounts": "{{value0}} が管理するアカウントを表示しています。アカウントの追加や再認証はそのサーバー上で行ってください。",
+          "remoteScopeAuthContext": "各アカウントは {{value0}} 上に独自のサインインコンテキストを保持します。"
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4779,7 +4779,9 @@
           "remoteServerFallback": "リモートサーバー",
           "loadAccountsFailed": "プロバイダーアカウントを読み込めませんでした。",
           "remoteScopeAccounts": "{{value0}} が管理するアカウントを表示しています。アカウントの追加や再認証はそのサーバー上で行ってください。",
-          "remoteScopeAuthContext": "各アカウントは {{value0}} 上に独自のサインインコンテキストを保持します。"
+          "remoteScopeAuthContext": "各アカウントは {{value0}} 上に独自のサインインコンテキストを保持します。",
+          "remoteEmptyClaudeAccounts": "{{value0}} に管理対象の Claude アカウントはありません。システム既定の Claude ログインを使用します。アカウントの追加はそのサーバー上で行ってください。",
+          "remoteEmptyCodexAccounts": "{{value0}} に管理対象の Codex アカウントはありません。システム既定の Codex ログインを使用します。アカウントの追加はそのサーバー上で行ってください。"
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3028,7 +3028,8 @@
             "f077f586db": "다시 묻지 않기",
             "c0e972d726": "취소",
             "06741a2f3d": "MiniMax 사용량 세부 정보 열기",
-            "3bbf140864": "MiniMax 사용량"
+            "3bbf140864": "MiniMax 사용량",
+            "remoteServerLabel": "원격 서버"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",
@@ -4774,7 +4775,11 @@
           "435df0ee51": "Request Headers에서 Cookie 값을 복사합니다.",
           "7492fb3bba": "여기에 붙여넣고 저장을 클릭합니다.",
           "9fec52de4b": "Cookie 복사 방법",
-          "4e32e030b2": "로컬에 저장됩니다. Orca는 사용량 새로 고침을 위해 platform.minimax.io로만 전송합니다."
+          "4e32e030b2": "로컬에 저장됩니다. Orca는 사용량 새로 고침을 위해 platform.minimax.io로만 전송합니다.",
+          "remoteServerFallback": "원격 서버",
+          "loadAccountsFailed": "프로바이더 계정을 불러오지 못했습니다.",
+          "remoteScopeAccounts": "{{value0}}에서 관리하는 계정을 표시하고 있습니다. 계정 추가나 재인증은 해당 서버에서 진행하세요.",
+          "remoteScopeAuthContext": "각 계정은 {{value0}}에 자체 로그인 컨텍스트를 유지합니다."
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4779,7 +4779,9 @@
           "remoteServerFallback": "원격 서버",
           "loadAccountsFailed": "프로바이더 계정을 불러오지 못했습니다.",
           "remoteScopeAccounts": "{{value0}}에서 관리하는 계정을 표시하고 있습니다. 계정 추가나 재인증은 해당 서버에서 진행하세요.",
-          "remoteScopeAuthContext": "각 계정은 {{value0}}에 자체 로그인 컨텍스트를 유지합니다."
+          "remoteScopeAuthContext": "각 계정은 {{value0}}에 자체 로그인 컨텍스트를 유지합니다.",
+          "remoteEmptyClaudeAccounts": "{{value0}}에 관리되는 Claude 계정이 없습니다. 해당 서버의 시스템 기본 Claude 로그인을 사용하며, 계정 추가는 그 서버에서 진행하세요.",
+          "remoteEmptyCodexAccounts": "{{value0}}에 관리되는 Codex 계정이 없습니다. 해당 서버의 시스템 기본 Codex 로그인을 사용하며, 계정 추가는 그 서버에서 진행하세요."
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4779,7 +4779,9 @@
           "remoteServerFallback": "远程服务器",
           "loadAccountsFailed": "无法加载提供商账户。",
           "remoteScopeAccounts": "正在显示由 {{value0}} 管理的账户。请在该服务器上添加或重新验证账户。",
-          "remoteScopeAuthContext": "每个账户在 {{value0}} 上保留自己的登录上下文。"
+          "remoteScopeAuthContext": "每个账户在 {{value0}} 上保留自己的登录上下文。",
+          "remoteEmptyClaudeAccounts": "{{value0}} 上没有受管理的 Claude 账户。它使用其系统默认的 Claude 登录；请在该服务器上添加账户。",
+          "remoteEmptyCodexAccounts": "{{value0}} 上没有受管理的 Codex 账户。它使用其系统默认的 Codex 登录；请在该服务器上添加账户。"
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3028,7 +3028,8 @@
             "f077f586db": "不再询问",
             "c0e972d726": "取消",
             "06741a2f3d": "打开 MiniMax 使用量详情",
-            "3bbf140864": "MiniMax 使用量"
+            "3bbf140864": "MiniMax 使用量",
+            "remoteServerLabel": "远程服务器"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",
@@ -4774,7 +4775,11 @@
           "435df0ee51": "在请求头中，复制 Cookie 的值。",
           "7492fb3bba": "在此粘贴并点击保存。",
           "9fec52de4b": "如何复制 Cookie",
-          "4e32e030b2": "存储在本地。Orca 仅将其发送到 platform.minimax.io 以刷新使用量。"
+          "4e32e030b2": "存储在本地。Orca 仅将其发送到 platform.minimax.io 以刷新使用量。",
+          "remoteServerFallback": "远程服务器",
+          "loadAccountsFailed": "无法加载提供商账户。",
+          "remoteScopeAccounts": "正在显示由 {{value0}} 管理的账户。请在该服务器上添加或重新验证账户。",
+          "remoteScopeAuthContext": "每个账户在 {{value0}} 上保留自己的登录上下文。"
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ClaudeRateLimitAccountsState,
+  CodexRateLimitAccountsState
+} from '../../../shared/types'
+import {
+  fetchProviderAccountsSnapshot,
+  removeClaudeProviderAccount,
+  removeCodexProviderAccount,
+  selectClaudeProviderAccount,
+  selectCodexProviderAccount,
+  watchProviderAccounts,
+  type ProviderAccountsSnapshot
+} from './runtime-provider-accounts-client'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from './runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from './runtime-rpc-client'
+
+const LOCAL = { activeRuntimeEnvironmentId: null }
+const REMOTE = { activeRuntimeEnvironmentId: 'env-1' }
+
+function emptyClaudeState(): ClaudeRateLimitAccountsState {
+  return { accounts: [], activeAccountId: null, activeAccountIdsByRuntime: { host: null, wsl: {} } }
+}
+
+function emptyCodexState(): CodexRateLimitAccountsState {
+  return { accounts: [], activeAccountId: null, activeAccountIdsByRuntime: { host: null, wsl: {} } }
+}
+
+function snapshotFixture(marker: string): ProviderAccountsSnapshot {
+  return {
+    claude: {
+      ...emptyClaudeState(),
+      activeAccountId: `claude-${marker}`
+    },
+    codex: {
+      ...emptyCodexState(),
+      activeAccountId: `codex-${marker}`
+    },
+    rateLimits: null
+  }
+}
+
+type SubscriptionCallbacks = {
+  onResponse: (response: unknown) => void
+  onError?: (error: { code: string; message: string }) => void
+  onClose?: () => void
+}
+
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+const runtimeEnvironmentSubscribe = vi.fn()
+const claudeListLocal = vi.fn()
+const codexListLocal = vi.fn()
+const claudeSelectLocal = vi.fn()
+const codexSelectLocal = vi.fn()
+const claudeRemoveLocal = vi.fn()
+const codexRemoveLocal = vi.fn()
+const unsubscribe = vi.fn()
+
+let subscriptionCallbacks: SubscriptionCallbacks | null = null
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  vi.restoreAllMocks()
+  for (const mock of [
+    runtimeEnvironmentCall,
+    runtimeEnvironmentTransportCall,
+    runtimeEnvironmentSubscribe,
+    claudeListLocal,
+    codexListLocal,
+    claudeSelectLocal,
+    codexSelectLocal,
+    claudeRemoveLocal,
+    codexRemoveLocal,
+    unsubscribe
+  ]) {
+    mock.mockReset()
+  }
+  subscriptionCallbacks = null
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  runtimeEnvironmentSubscribe.mockImplementation(
+    async (_args: unknown, callbacks: SubscriptionCallbacks) => {
+      subscriptionCallbacks = callbacks
+      return { unsubscribe, sendBinary: () => false }
+    }
+  )
+  vi.stubGlobal('window', {
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    api: {
+      runtimeEnvironments: {
+        call: runtimeEnvironmentTransportCall,
+        subscribe: runtimeEnvironmentSubscribe
+      },
+      claudeAccounts: {
+        list: claudeListLocal,
+        select: claudeSelectLocal,
+        remove: claudeRemoveLocal
+      },
+      codexAccounts: {
+        list: codexListLocal,
+        select: codexSelectLocal,
+        remove: codexRemoveLocal
+      }
+    }
+  })
+})
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('watchProviderAccounts', () => {
+  it('reads local services once when no runtime environment is active', async () => {
+    claudeListLocal.mockResolvedValue(emptyClaudeState())
+    codexListLocal.mockResolvedValue(emptyCodexState())
+    const snapshots: ProviderAccountsSnapshot[] = []
+
+    watchProviderAccounts(LOCAL, {
+      onSnapshot: (snapshot) => snapshots.push(snapshot),
+      onError: () => {
+        throw new Error('unexpected error')
+      }
+    })
+    await flushMicrotasks()
+
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]?.rateLimits).toBeNull()
+    expect(claudeListLocal).toHaveBeenCalledTimes(1)
+    expect(codexListLocal).toHaveBeenCalledTimes(1)
+    expect(runtimeEnvironmentSubscribe).not.toHaveBeenCalled()
+  })
+
+  it('does not deliver a late local snapshot after close', async () => {
+    let resolveClaude: (state: ClaudeRateLimitAccountsState) => void = () => {}
+    claudeListLocal.mockImplementation(
+      () => new Promise<ClaudeRateLimitAccountsState>((resolve) => (resolveClaude = resolve))
+    )
+    codexListLocal.mockResolvedValue(emptyCodexState())
+    const snapshots: ProviderAccountsSnapshot[] = []
+
+    const watcher = watchProviderAccounts(LOCAL, {
+      onSnapshot: (snapshot) => snapshots.push(snapshot),
+      onError: () => {}
+    })
+    watcher.close()
+    resolveClaude(emptyClaudeState())
+    await flushMicrotasks()
+
+    expect(snapshots).toHaveLength(0)
+  })
+
+  it('streams remote snapshots from accounts.subscribe and unsubscribes on close', async () => {
+    const snapshots: ProviderAccountsSnapshot[] = []
+    const watcher = watchProviderAccounts(REMOTE, {
+      onSnapshot: (snapshot) => snapshots.push(snapshot),
+      onError: () => {
+        throw new Error('unexpected error')
+      }
+    })
+    await flushMicrotasks()
+
+    expect(runtimeEnvironmentSubscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ selector: 'env-1', method: 'accounts.subscribe' }),
+      expect.any(Object)
+    )
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'ready', snapshot: snapshotFixture('ready') }
+    })
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'snapshot', snapshot: snapshotFixture('refresh') }
+    })
+
+    expect(snapshots.map((s) => s.codex.activeAccountId)).toEqual(['codex-ready', 'codex-refresh'])
+    expect(claudeListLocal).not.toHaveBeenCalled()
+
+    watcher.close()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'snapshot', snapshot: snapshotFixture('late') }
+    })
+    expect(snapshots).toHaveLength(2)
+  })
+
+  it('surfaces remote subscription failures as errors', async () => {
+    const errors: unknown[] = []
+    watchProviderAccounts(REMOTE, {
+      onSnapshot: () => {
+        throw new Error('unexpected snapshot')
+      },
+      onError: (error) => errors.push(error)
+    })
+    await flushMicrotasks()
+
+    subscriptionCallbacks?.onResponse({
+      ok: false,
+      error: { code: 'forbidden', message: 'denied' }
+    })
+
+    expect(errors).toHaveLength(1)
+    expect(String((errors[0] as Error).message)).toContain('denied')
+  })
+})
+
+describe('fetchProviderAccountsSnapshot', () => {
+  it('resolves with the first remote snapshot and closes the subscription', async () => {
+    const pending = fetchProviderAccountsSnapshot(REMOTE)
+    await flushMicrotasks()
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'ready', snapshot: snapshotFixture('ready') }
+    })
+
+    await expect(pending).resolves.toMatchObject({
+      codex: { activeAccountId: 'codex-ready' }
+    })
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+
+  it('rejects when the remote subscription closes before any snapshot', async () => {
+    const pending = fetchProviderAccountsSnapshot(REMOTE)
+    await flushMicrotasks()
+    subscriptionCallbacks?.onClose?.()
+
+    await expect(pending).rejects.toThrow('subscription closed')
+  })
+})
+
+describe('provider account mutations', () => {
+  it('routes select through local IPC with the full runtime target when local', async () => {
+    codexSelectLocal.mockResolvedValue(emptyCodexState())
+    claudeSelectLocal.mockResolvedValue(emptyClaudeState())
+
+    await selectCodexProviderAccount(LOCAL, {
+      accountId: 'acc-1',
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu'
+    })
+    await selectClaudeProviderAccount(LOCAL, { accountId: null, runtime: 'host', wslDistro: null })
+
+    expect(codexSelectLocal).toHaveBeenCalledWith({
+      accountId: 'acc-1',
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu'
+    })
+    expect(claudeSelectLocal).toHaveBeenCalledWith({
+      accountId: null,
+      runtime: 'host',
+      wslDistro: null
+    })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
+  it('routes select and remove through the active runtime accounts RPC when remote', async () => {
+    runtimeEnvironmentCall.mockImplementation((args: { method: string }) => ({
+      id: 'call',
+      ok: true,
+      result: args.method.startsWith('accounts.select') ? emptyCodexState() : emptyClaudeState()
+    }))
+
+    await selectCodexProviderAccount(REMOTE, {
+      accountId: 'server-codex-2',
+      runtime: 'host',
+      wslDistro: null
+    })
+    await selectClaudeProviderAccount(REMOTE, {
+      accountId: null,
+      runtime: 'host',
+      wslDistro: null
+    })
+    await removeCodexProviderAccount(REMOTE, 'server-codex-1')
+    await removeClaudeProviderAccount(REMOTE, 'server-claude-1')
+
+    const methods = runtimeEnvironmentCall.mock.calls.map(
+      (call) => (call[0] as { method: string; params: unknown }).method
+    )
+    expect(methods).toEqual([
+      'accounts.selectCodex',
+      'accounts.selectClaude',
+      'accounts.removeCodex',
+      'accounts.removeClaude'
+    ])
+    expect(runtimeEnvironmentCall.mock.calls[0]?.[0]).toMatchObject({
+      selector: 'env-1',
+      // Why this matters: the server API takes only accountId; host/WSL
+      // targeting is a desktop-local concept and must not leak into params.
+      params: { accountId: 'server-codex-2' }
+    })
+    expect(codexSelectLocal).not.toHaveBeenCalled()
+    expect(claudeSelectLocal).not.toHaveBeenCalled()
+    expect(codexRemoveLocal).not.toHaveBeenCalled()
+    expect(claudeRemoveLocal).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.ts
@@ -1,0 +1,227 @@
+import type {
+  ClaudeRateLimitAccountsState,
+  CodexRateLimitAccountsState,
+  GlobalSettings
+} from '../../../shared/types'
+import type { RateLimitState } from '../../../shared/rate-limit-types'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import { callRuntimeRpc, getActiveRuntimeTarget, RuntimeRpcCallError } from './runtime-rpc-client'
+
+// Mirrors OrcaRuntime.getAccountsSnapshot() / the accounts.subscribe payload.
+export type ProviderAccountsSnapshot = {
+  claude: ClaudeRateLimitAccountsState
+  codex: CodexRateLimitAccountsState
+  rateLimits: RateLimitState | null
+}
+
+type ProviderAccountSelection = {
+  accountId: string | null
+  runtime: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
+type ProviderAccountsSubscriptionMessage = {
+  type: 'ready' | 'snapshot' | 'end'
+  snapshot?: ProviderAccountsSnapshot
+}
+
+const REMOTE_ACCOUNTS_FIRST_SNAPSHOT_TIMEOUT_MS = 15_000
+// Why: the server applies a selection before it awaits provider usage
+// refreshes, and those refreshes can crawl behind broken auth. Give the call
+// room to finish instead of reporting failure for an applied switch.
+const REMOTE_ACCOUNT_MUTATION_TIMEOUT_MS = 30_000
+
+export function hasRemoteProviderAccountOwner(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+): boolean {
+  return getActiveRuntimeTarget(settings).kind === 'environment'
+}
+
+export type ProviderAccountsWatcher = {
+  close: () => void
+}
+
+// Watches the provider-account snapshot for whichever runtime owns accounts.
+// Local: one-shot reads of the desktop services (they have no push channel
+// here; the pane refetches after each mutation). Remote: a live
+// accounts.subscribe stream — the ready message carries the current snapshot
+// synchronously and later broadcasts deliver refreshed usage. accounts.list is
+// deliberately avoided: it blocks behind provider usage refreshes on the
+// server and can hang for minutes behind broken auth.
+export function watchProviderAccounts(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  handlers: {
+    onSnapshot: (snapshot: ProviderAccountsSnapshot) => void
+    onError: (error: unknown) => void
+  }
+): ProviderAccountsWatcher {
+  const target = getActiveRuntimeTarget(settings)
+  if (target.kind === 'local') {
+    let closed = false
+    void Promise.all([window.api.claudeAccounts.list(), window.api.codexAccounts.list()])
+      .then(([claude, codex]) => {
+        if (!closed) {
+          handlers.onSnapshot({ claude, codex, rateLimits: null })
+        }
+      })
+      .catch((error: unknown) => {
+        if (!closed) {
+          handlers.onError(error)
+        }
+      })
+    return {
+      close: () => {
+        closed = true
+      }
+    }
+  }
+
+  let closed = false
+  let unsubscribe: (() => void) | null = null
+  let receivedSnapshot = false
+  // Why: a subscription that never produces a first snapshot looks identical
+  // to a loading state; surface it as an error so the pane can say so.
+  const firstSnapshotTimer = window.setTimeout(() => {
+    if (!closed && !receivedSnapshot) {
+      handlers.onError(new Error('Timed out waiting for remote provider accounts.'))
+    }
+  }, REMOTE_ACCOUNTS_FIRST_SNAPSHOT_TIMEOUT_MS)
+
+  void window.api.runtimeEnvironments
+    .subscribe(
+      {
+        selector: target.environmentId,
+        method: 'accounts.subscribe',
+        timeoutMs: REMOTE_ACCOUNTS_FIRST_SNAPSHOT_TIMEOUT_MS
+      },
+      {
+        onResponse: (response) => {
+          if (closed) {
+            return
+          }
+          const typed = response as RuntimeRpcResponse<ProviderAccountsSubscriptionMessage>
+          if (typed.ok === false) {
+            handlers.onError(new RuntimeRpcCallError(typed))
+            return
+          }
+          const message = typed.result
+          if ((message.type === 'ready' || message.type === 'snapshot') && message.snapshot) {
+            receivedSnapshot = true
+            handlers.onSnapshot(message.snapshot)
+          }
+        },
+        onError: (error) => {
+          if (!closed) {
+            handlers.onError(new Error(error.message))
+          }
+        },
+        onClose: () => {
+          if (!closed && !receivedSnapshot) {
+            handlers.onError(new Error('Remote provider account subscription closed.'))
+          }
+        }
+      }
+    )
+    .then((handle) => {
+      unsubscribe = handle.unsubscribe
+      if (closed) {
+        unsubscribe()
+      }
+    })
+    .catch((error: unknown) => {
+      if (!closed) {
+        handlers.onError(error)
+      }
+    })
+
+  return {
+    close: () => {
+      closed = true
+      window.clearTimeout(firstSnapshotTimer)
+      unsubscribe?.()
+    }
+  }
+}
+
+// One-shot convenience over watchProviderAccounts for surfaces that only need
+// the current snapshot (status-bar switcher menus).
+export async function fetchProviderAccountsSnapshot(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+): Promise<ProviderAccountsSnapshot> {
+  return await new Promise((resolve, reject) => {
+    const watcher = watchProviderAccounts(settings, {
+      onSnapshot: (snapshot) => {
+        watcher.close()
+        resolve(snapshot)
+      },
+      onError: (error) => {
+        watcher.close()
+        reject(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
+  })
+}
+
+export async function selectClaudeProviderAccount(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  selection: ProviderAccountSelection
+): Promise<ClaudeRateLimitAccountsState> {
+  const target = getActiveRuntimeTarget(settings)
+  if (target.kind === 'environment') {
+    return callRuntimeRpc<ClaudeRateLimitAccountsState>(
+      target,
+      'accounts.selectClaude',
+      { accountId: selection.accountId },
+      { timeoutMs: REMOTE_ACCOUNT_MUTATION_TIMEOUT_MS }
+    )
+  }
+  return window.api.claudeAccounts.select(selection)
+}
+
+export async function selectCodexProviderAccount(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  selection: ProviderAccountSelection
+): Promise<CodexRateLimitAccountsState> {
+  const target = getActiveRuntimeTarget(settings)
+  if (target.kind === 'environment') {
+    return callRuntimeRpc<CodexRateLimitAccountsState>(
+      target,
+      'accounts.selectCodex',
+      { accountId: selection.accountId },
+      { timeoutMs: REMOTE_ACCOUNT_MUTATION_TIMEOUT_MS }
+    )
+  }
+  return window.api.codexAccounts.select(selection)
+}
+
+export async function removeClaudeProviderAccount(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  accountId: string
+): Promise<ClaudeRateLimitAccountsState> {
+  const target = getActiveRuntimeTarget(settings)
+  if (target.kind === 'environment') {
+    return callRuntimeRpc<ClaudeRateLimitAccountsState>(
+      target,
+      'accounts.removeClaude',
+      { accountId },
+      { timeoutMs: REMOTE_ACCOUNT_MUTATION_TIMEOUT_MS }
+    )
+  }
+  return window.api.claudeAccounts.remove({ accountId })
+}
+
+export async function removeCodexProviderAccount(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  accountId: string
+): Promise<CodexRateLimitAccountsState> {
+  const target = getActiveRuntimeTarget(settings)
+  if (target.kind === 'environment') {
+    return callRuntimeRpc<CodexRateLimitAccountsState>(
+      target,
+      'accounts.removeCodex',
+      { accountId },
+      { timeoutMs: REMOTE_ACCOUNT_MUTATION_TIMEOUT_MS }
+    )
+  }
+  return window.api.codexAccounts.remove({ accountId })
+}


### PR DESCRIPTION
## Summary

With a Remote Orca Server selected as the active runtime, Settings > Accounts and the Claude/Codex status-bar switchers still read and mutated the **desktop-local** account services: the pane listed this device's accounts under a remote-runtime session, selecting an account reported success while remote terminals kept the server-owned account, and Add/Re-authenticate silently authenticated on the desktop.

This routes provider account **list / select / remove** through the active runtime:

- New `runtime-provider-accounts-client.ts` follows the existing `runtime-*-client` seam (`getActiveRuntimeTarget` + `callRuntimeRpc`) and mobile's `accounts.*` contract (`{ accountId }` params, accounts-snapshot results).
- **Listing uses a live `accounts.subscribe` watch, not `accounts.list`**: the server's `accounts.list` blocks on `refreshAccountsForMobile()`, which we observed hanging >15s behind broken provider auth during live validation. The subscribe `ready` message carries the snapshot synchronously and later broadcasts stream usage refreshes into the open pane. The mobile-facing `accounts.list` semantics are intentionally untouched.
- The pane + switchers label the scope with the paired server's name, disable interactive add/re-auth (they spawn local `claude login` / `codex login` PTYs that would authenticate this device), hide the host/WSL account-location toggle, and skip local-only refreshes (`fetchSettings`, inactive-usage caches, Codex reset credits, sign-in affordances) in remote scope.
- The remote snapshot wins over accounts reconstructed from local `GlobalSettings` in the status bar (`resolveCodex/ClaudeStatusAccountState`).
- Local and WSL behavior is unchanged when no remote runtime is active.

The first commit is a pre-existing one-line `switch-exhaustiveness` lint failure on main (`notification-authorization-status.ts`) that blocks `pnpm lint` for every branch; drop it if a dedicated fix lands first.

## Relationship to #7976

Community PR #7976 (@SiteupAgencia) identified the same root cause and the right RPC seam — credit to them for the direction, including the blocked-`accounts.list` observation. This PR reimplements the account slice narrowly because #7976 bundles several unrelated changes (agent-activity reordering in `orca-runtime.ts`, worktree-card compact-summary UX reversal, native-chat suppression, `hermes.png`) and its account slice has defects detailed in the review comment on that PR (one-shot subscribe that never live-updates, a mobile-facing `accounts.list` semantics change, remote rate-limits injected into the local push-fed store slot causing flicker, account reloads keyed on `settings` object identity).

## Reproduction & live validation (adapted /brennan-test-ssh harness)

Two disposable dev instances of this worktree: a headless `--serve` server and a desktop client, each seeded with divergent fake managed accounts (`server-codex-1/2`, `server-claude-1` vs `desktop-codex-1/2`, `desktop-claude-1`), paired via `runtimeEnvironments.addFromPairingCode` with the `orca://pair` URL from `--serve-json`, server set as Active Server.

**Before (main):** pane said "Showing accounts for this device", listed only `desktop-*` accounts, Add Account enabled; clicking `desktop-codex-2` flipped the *local* service to `desktop-codex-2` and showed "Active" while the server stayed on `server-codex-1`; the status-bar switcher showed the local account.

**After (this branch, same harness):**
- Pane: "Showing accounts managed by Repro Server", lists `server-claude-1`, `server-codex-1/2` with "Repro Server" badges, Add Account/Re-authenticate disabled, no Account-location section.
- Clicking `server-codex-2` in the pane → server snapshot now reports `activeAccountId: server-codex-2`; local service state and settings untouched.
- Status-bar Codex switcher lists only server accounts under a "Repro Server" group; switching to `server-codex-1` changed the server's selection; local untouched.
- Clearing the Active Server restores the exact local view (desktop accounts, enabled Add).

## Validation

- `pnpm typecheck`, `pnpm lint` (incl. localization catalog/parity, max-lines ratchet) green
- 149 renderer test files / 1021 tests green (`status-bar/`, `settings/`, `runtime/`)
- New unit coverage: local vs remote routing for watch/select/remove (incl. "params are only `{ accountId }`" contract), remote snapshot streaming + unsubscribe-on-close, subscription failure surfacing, remote-wins status-bar account state, pane copy/disable states both scopes

## Known follow-ups (unchanged behavior, called out for transparency)

- Status-bar **usage numbers** (rate-limit bars) still come from the desktop's own poll even in remote scope; fixing that needs a runtime-scoped rate-limit store slot (the #7976 approach of injecting remote snapshots into the local push-fed slot flickers, so it was deliberately left out).
- Server-side `accounts.selectCodex/selectClaude` awaits a provider usage refresh before returning; with wedged auth the RPC can be slow (30s timeout applied client-side).

Fixes #7973 (STA-1558)

Made with [Orca](https://github.com/stablyai/orca) 🐋
