### PR TITLE
fix(mobile): drop smart-dash write-back recovery that kills iOS dictation

### DIFF
--- a/mobile/src/terminal/terminal-text-input-normalization.test.ts
+++ b/mobile/src/terminal/terminal-text-input-normalization.test.ts
@@ -11,10 +11,4 @@ describe('normalizeTerminalTextInput', () => {
   it('keeps ASCII hyphens unchanged', () => {
     expect(normalizeTerminalTextInput('git checkout -- file')).toBe('git checkout -- file')
   })
-
-  it('preserves longer trailing hyphen runs when iOS re-collapses the controlled value', () => {
-    expect(normalizeTerminalTextInput('—', '--')).toBe('---')
-    expect(normalizeTerminalTextInput('—', '---')).toBe('----')
-    expect(normalizeTerminalTextInput('git checkout —', 'git checkout --')).toBe('git checkout ---')
-  })
 })

--- a/mobile/src/terminal/terminal-text-input-normalization.ts
+++ b/mobile/src/terminal/terminal-text-input-normalization.ts
@@ -1,18 +1,9 @@
 // Why: iOS smart punctuation can rewrite two ASCII hyphens into a single
-// Unicode dash before React Native delivers terminal text input.
+// Unicode dash before React Native delivers terminal text input. Each dash maps
+// to exactly "--": recovering longer runs (#5222) needed the previous controlled
+// value written back into the field, and that write-back kills iOS dictation (#7925).
 const IOS_SMART_DASH_REPLACEMENT_PATTERN = /[\u2013\u2014]/g
-const IOS_SMART_DASH_REPLACEMENT_TEST = /[\u2013\u2014]/
 
-export function normalizeTerminalTextInput(text: string, previousText = ''): string {
-  const normalizedText = text.replace(IOS_SMART_DASH_REPLACEMENT_PATTERN, '--')
-  const previousTrailingHyphens = /-+$/.exec(previousText)?.[0] ?? ''
-  const previousPrefix = previousText.slice(0, previousText.length - previousTrailingHyphens.length)
-  const collapsedPreviousHyphenRun =
-    previousTrailingHyphens.length >= 2 &&
-    IOS_SMART_DASH_REPLACEMENT_TEST.test(text) &&
-    (text === `${previousPrefix}\u2013` || text === `${previousPrefix}\u2014`)
-  if (collapsedPreviousHyphenRun) {
-    return `${previousText}-`
-  }
-  return normalizedText
+export function normalizeTerminalTextInput(text: string): string {
+  return text.replace(IOS_SMART_DASH_REPLACEMENT_PATTERN, '--')
 }


### PR DESCRIPTION
## Summary

Typing multiple hyphens in the mobile terminal (e.g. `git checkout ---`) no longer depends on rewriting the controlled input value when iOS smart punctuation collapses them to an en/em dash. That rewrite path was the same class of write-back that killed iOS keyboard dictation in #7933 / #7925: JS putting different text into the focused field ends the dictation/IME session.

After #7933, terminal inputs already keep the raw field text and normalize only on send/PTY. The multi-hyphen recovery in `normalizeTerminalTextInput(text, previousText)` needed the previous controlled value and is no longer useful on that path—and keeping it invites reintroducing write-back. This PR maps each smart dash to exactly `--` with a single-arg normalizer and drops the recovery tests that encoded the old write-back contract.

## Test plan

- [x] Existing unit tests for en/em dash → `--` and ASCII hyphens unchanged
- [ ] On a physical iPhone: enable smart punctuation, type `--` / `---` in live terminal input and buffered command input; confirm PTY gets ASCII hyphens and dictation keeps running if used mid-edit
- [ ] Confirm `git checkout -- file` still sends ASCII hyphens when iOS rewrites to en/em dash

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Grok](https://img.shields.io/badge/Grok_4.5-000000)
