### PR TITLE
fix(editor): open files in the focused pane when it is a browser (#6891)

### DIFF
--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1147,6 +1147,35 @@ describe('createEditorSlice split-group editor routing', () => {
 
     expect(findUnifiedTabByEntity(store, '/repo/explicit.ts')?.groupId).toBe(terminalGroupId)
   })
+
+  it('opens implicit files in a focused browser split group instead of stealing an editor pane (#6891)', () => {
+    const store = createEditorTabsStore()
+    const { editorGroupId } = seedTerminalAndEditorGroups(store)
+
+    // Regression #6891: with a split like Agent | Browser, focusing the browser
+    // pane and opening a file sent it to another pane. A focused browser pane
+    // was treated like a focused agent terminal, so the open was stolen into an
+    // existing editor pane instead of the focused group.
+    const browserGroupId = store.getState().createEmptySplitGroup('wt-1', editorGroupId, 'right')
+    if (!browserGroupId) {
+      throw new Error('Expected split browser group')
+    }
+    store.getState().createUnifiedTab('wt-1', 'browser', {
+      id: 'browser-tab',
+      entityId: 'browser-tab',
+      label: 'Browser',
+      targetGroupId: browserGroupId
+    })
+    store.setState({
+      activeGroupIdByWorktree: { 'wt-1': browserGroupId },
+      activeTabType: 'browser',
+      activeTabTypeByWorktree: { 'wt-1': 'browser' }
+    } as Partial<AppState>)
+
+    openSourceFile(store, '/repo/from-browser.ts')
+
+    expect(findUnifiedTabByEntity(store, '/repo/from-browser.ts')?.groupId).toBe(browserGroupId)
+  })
 })
 
 describe('createEditorSlice untitled cleanup routing', () => {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -903,7 +903,10 @@ function resolveEditorOpenTargetGroupId(
     groups.find((group) => group.id === state.activeGroupIdByWorktree?.[worktreeId]) ??
     fallbackGroup
   const activeTab = getGroupActiveTab(activeGroup, tabsById)
-  if (!activeTab || isEditorTabContentType(activeTab.contentType)) {
+  // Why: only a focused agent *terminal* should defer to an existing editor pane
+  // (#6891). Editor, browser, and simulator panes open the file in the focused
+  // group so it lands where the user is looking instead of a stale editor pane.
+  if (!activeTab || activeTab.contentType !== 'terminal') {
     return activeGroup.id
   }
 


### PR DESCRIPTION
## Summary

Opening a file while a browser (or simulator) split pane is focused now routes the file into that focused pane instead of stealing an unrelated, stale editor pane.

## ELI5

If you were looking at a browser panel and opened a file, the file used to pop up in some other editor panel off to the side. Now it opens right where you're looking.

## Root cause & fix

`resolveEditorOpenTargetGroupId` deferred to an existing editor pane whenever the focused group's active tab was any editor-family tab *or* when there was no active tab (`if (!activeTab || isEditorTabContentType(activeTab.contentType))`). That "reuse an existing editor pane" path is only meant for a focused agent terminal, so a focused non-terminal, non-editor pane (browser/simulator) fell through and the file was routed to a stale editor pane. The fix narrows the condition to defer only when the focused pane is a terminal (`if (!activeTab || activeTab.contentType !== 'terminal')`), so browser and simulator panes now open the file in the focused group.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Clean rebase onto `origin/main` (base `7ab601487c`, head `6f74ea9ef6`).

- Test file: `src/renderer/src/store/slices/editor.test.ts` (`npx vitest run --config config/vitest.config.ts`).
- On branch (fix present): **183 passed (183)**.
- Fix reverted to `origin/main`, test kept: **1 failed | 182 passed** — the regression test `opens implicit files in a focused browser split group instead of stealing an editor pane (#6891)` fails.
- Lint clean: `npx oxlint src/renderer/src/store/slices/editor.ts` reports no warnings/errors.

```
On branch:   Test Files 1 passed (1) ; Tests 183 passed (183)
Fix reverted: Tests 1 failed | 182 passed (183)
  FAIL: opens implicit files in a focused browser split group instead of
        stealing an editor pane (#6891)
  AssertionError: expected '<editor-group-id>' to be '<browser-group-id>'
```

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression by construction: the terminal-focused case is byte-identical (still defers to an existing editor pane). The only changed path is focused non-terminal, non-editor panes (browser/simulator), which now route to the focused group — the intended behavior, proven by the passing regression test.

*Credit to original author @westkite1201 (SeoYeonKim). Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
