### PR TITLE
feat(linear): add server-side issue filters for status and other properties

### DIFF
--- a/src/main/ipc/linear.test.ts
+++ b/src/main/ipc/linear.test.ts
@@ -97,7 +97,43 @@ describe('registerLinearHandlers', () => {
       workspaceId: 'workspace-1'
     })
 
-    expect(listIssuesMock).toHaveBeenCalledWith('all', 216, 'workspace-1')
+    expect(listIssuesMock).toHaveBeenCalledWith('all', 216, 'workspace-1', {
+      attributeFilter: undefined
+    })
+  })
+
+  it('parses attribute filters and rejects malformed payloads before listIssues', async () => {
+    listIssuesMock.mockResolvedValue({ items: [], hasMore: false })
+    registerLinearHandlers()
+
+    await handlers['linear:listIssues'](null, {
+      filter: 'all',
+      limit: 20,
+      workspaceId: 'workspace-1',
+      attributeFilter: {
+        stateIds: ['state-1'],
+        priorities: [1],
+        assignee: { kind: 'unassigned' },
+        labelIds: []
+      }
+    })
+    expect(listIssuesMock).toHaveBeenCalledWith('all', 20, 'workspace-1', {
+      attributeFilter: {
+        stateIds: ['state-1'],
+        priorities: [1],
+        assignee: { kind: 'unassigned' },
+        labelIds: []
+      }
+    })
+
+    listIssuesMock.mockClear()
+    await expect(
+      handlers['linear:listIssues'](null, {
+        filter: 'all',
+        attributeFilter: { stateIds: [] }
+      })
+    ).rejects.toThrow(/required/)
+    expect(listIssuesMock).not.toHaveBeenCalled()
   })
 
   it('forwards expanded Linear project issue limits through local IPC', async () => {

--- a/src/main/ipc/linear.ts
+++ b/src/main/ipc/linear.ts
@@ -25,6 +25,7 @@ import {
 import { listTeams, getTeamStates, getTeamLabels, getTeamMembers } from '../linear/teams'
 import type { LinearListFilter } from '../linear/issues'
 import { clampLinearIssueListLimit } from '../../shared/linear-issue-read-limits'
+import { optionalParsedLinearIssueAttributeFilter } from '../../shared/linear-issue-attribute-filter'
 import type {
   LinearCustomViewModel,
   LinearIssueUpdate,
@@ -131,13 +132,26 @@ export function registerLinearHandlers(): void {
     'linear:listIssues',
     async (
       _event,
-      args?: { filter?: LinearListFilter; limit?: number; workspaceId?: LinearWorkspaceSelection }
+      args?: {
+        filter?: LinearListFilter
+        limit?: number
+        workspaceId?: LinearWorkspaceSelection
+        attributeFilter?: unknown
+      }
     ) => {
       const filter = VALID_FILTERS.has(args?.filter as LinearListFilter)
         ? (args!.filter as LinearListFilter)
         : undefined
       const limit = clampLinearIssueListLimit(args?.limit)
-      return listIssues(filter, limit, normalizeWorkspaceSelection(args?.workspaceId))
+      // Why: reject malformed filters at the trust boundary instead of
+      // normalizing them to empty (which would silently broaden results).
+      const attributeFilter =
+        args && 'attributeFilter' in args && args.attributeFilter !== undefined
+          ? optionalParsedLinearIssueAttributeFilter(args.attributeFilter)
+          : undefined
+      return listIssues(filter, limit, normalizeWorkspaceSelection(args?.workspaceId), {
+        attributeFilter
+      })
     }
   )
 

--- a/src/main/linear/issue-list-filter.test.ts
+++ b/src/main/linear/issue-list-filter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { buildLinearListIssueFilter } from './issue-list-filter'
+
+describe('buildLinearListIssueFilter', () => {
+  it('returns undefined for all preset without attributes or team', () => {
+    expect(buildLinearListIssueFilter({ filter: 'all' })).toBeUndefined()
+  })
+
+  it('merges status ids, priority, assignee, and labels for the all preset', () => {
+    expect(
+      buildLinearListIssueFilter({
+        filter: 'all',
+        attributeFilter: {
+          stateIds: ['state-1', 'state-2'],
+          priorities: [0, 1],
+          assignee: { kind: 'user', id: 'user-1' },
+          labelIds: ['label-1', 'label-2']
+        }
+      })
+    ).toEqual({
+      state: { id: { in: ['state-1', 'state-2'] } },
+      priority: { in: [0, 1] },
+      assignee: { id: { eq: 'user-1' } },
+      labels: { some: { id: { in: ['label-1', 'label-2'] } } }
+    })
+  })
+
+  it('keeps preset state.type and attribute state.id together', () => {
+    expect(
+      buildLinearListIssueFilter({
+        filter: 'assigned',
+        attributeFilter: {
+          stateIds: ['state-open'],
+          priorities: [],
+          assignee: null,
+          labelIds: []
+        }
+      })
+    ).toEqual({
+      state: {
+        type: { nin: ['completed', 'canceled'] },
+        id: { in: ['state-open'] }
+      }
+    })
+  })
+
+  it('shapes unassigned and optional team filters', () => {
+    expect(
+      buildLinearListIssueFilter({
+        filter: 'all',
+        teamId: 'team-1',
+        attributeFilter: {
+          stateIds: [],
+          priorities: [],
+          assignee: { kind: 'unassigned' },
+          labelIds: []
+        }
+      })
+    ).toEqual({
+      team: { id: { eq: 'team-1' } },
+      assignee: { null: true }
+    })
+  })
+
+  it('omits empty attribute filters so variables match the unfiltered path', () => {
+    expect(
+      buildLinearListIssueFilter({
+        filter: 'completed',
+        attributeFilter: {
+          stateIds: [],
+          priorities: [],
+          assignee: null,
+          labelIds: []
+        }
+      })
+    ).toEqual({
+      state: { type: { in: ['completed', 'canceled'] } }
+    })
+  })
+})

--- a/src/main/linear/issue-list-filter.ts
+++ b/src/main/linear/issue-list-filter.ts
@@ -1,0 +1,117 @@
+import {
+  isEmptyLinearIssueAttributeFilter,
+  type LinearIssueAttributeFilter
+} from '../../shared/linear-issue-attribute-filter'
+import type { LinearListFilter } from './issues'
+
+// Why: attribute facets must merge into Linear's IssueFilter before the first-N
+// cursor walk so hasMore reflects the filtered set, not the unfiltered window.
+// @linear/sdk does not export IssueFilter as a public type, so we keep a
+// structural subset that matches the operators this list path actually sends.
+
+export type LinearGraphQLIssueFilter = {
+  state?: {
+    type?: { nin?: string[]; in?: string[] }
+    id?: { in?: string[] }
+  }
+  team?: { id?: { eq?: string } }
+  priority?: { in?: number[] }
+  assignee?: { null?: boolean; id?: { eq?: string } }
+  labels?: { some?: { id?: { in?: string[] } } }
+}
+
+const ACTIVE_STATE_FILTER: LinearGraphQLIssueFilter = {
+  state: { type: { nin: ['completed', 'canceled'] } }
+}
+const COMPLETED_STATE_FILTER: LinearGraphQLIssueFilter = {
+  state: { type: { in: ['completed', 'canceled'] } }
+}
+
+function listFilterForState(filter: LinearListFilter): LinearGraphQLIssueFilter | undefined {
+  if (filter === 'assigned' || filter === 'created' || filter === 'open') {
+    return ACTIVE_STATE_FILTER
+  }
+  if (filter === 'completed') {
+    return COMPLETED_STATE_FILTER
+  }
+  return undefined
+}
+
+function attributeFacetFilter(
+  attributeFilter: LinearIssueAttributeFilter | null | undefined
+): LinearGraphQLIssueFilter | undefined {
+  if (!attributeFilter || isEmptyLinearIssueAttributeFilter(attributeFilter)) {
+    return undefined
+  }
+
+  const next: LinearGraphQLIssueFilter = {}
+
+  if (attributeFilter.stateIds.length > 0) {
+    next.state = { id: { in: attributeFilter.stateIds } }
+  }
+
+  if (attributeFilter.priorities.length > 0) {
+    next.priority = { in: attributeFilter.priorities }
+  }
+
+  if (attributeFilter.assignee?.kind === 'unassigned') {
+    next.assignee = { null: true }
+  } else if (attributeFilter.assignee?.kind === 'user') {
+    next.assignee = { id: { eq: attributeFilter.assignee.id } }
+  }
+
+  if (attributeFilter.labelIds.length > 0) {
+    // Why: collection `some` is any-of; a direct labels.id comparator would
+    // not express multi-label membership the same way.
+    next.labels = { some: { id: { in: attributeFilter.labelIds } } }
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined
+}
+
+function mergeIssueFilters(
+  ...parts: (LinearGraphQLIssueFilter | undefined)[]
+): LinearGraphQLIssueFilter | undefined {
+  const defined = parts.filter((part): part is LinearGraphQLIssueFilter => part !== undefined)
+  if (defined.length === 0) {
+    return undefined
+  }
+  if (defined.length === 1) {
+    return defined[0]
+  }
+
+  const merged: LinearGraphQLIssueFilter = {}
+  for (const part of defined) {
+    if (part.state) {
+      // Why: preset state.type and attribute state.id must coexist; a top-level
+      // spread would overwrite one nested constraint.
+      merged.state = { ...merged.state, ...part.state }
+    }
+    if (part.team) {
+      merged.team = part.team
+    }
+    if (part.priority) {
+      merged.priority = part.priority
+    }
+    if (part.assignee) {
+      merged.assignee = part.assignee
+    }
+    if (part.labels) {
+      merged.labels = part.labels
+    }
+  }
+  return merged
+}
+
+export function buildLinearListIssueFilter(options: {
+  filter: LinearListFilter
+  teamId?: string
+  attributeFilter?: LinearIssueAttributeFilter | null
+}): LinearGraphQLIssueFilter | undefined {
+  const stateFilter = listFilterForState(options.filter)
+  const teamFilter: LinearGraphQLIssueFilter | undefined = options.teamId
+    ? { team: { id: { eq: options.teamId } } }
+    : undefined
+  const attributes = attributeFacetFilter(options.attributeFilter)
+  return mergeIssueFilters(stateFilter, teamFilter, attributes)
+}

--- a/src/main/linear/issues.test.ts
+++ b/src/main/linear/issues.test.ts
@@ -188,7 +188,9 @@ describe('Linear issue queries', () => {
     })
     const { listIssues } = await import('./issues')
 
-    await expect(listIssues('open', 10, 'workspace-1', 'team-1')).resolves.toMatchObject({
+    await expect(
+      listIssues('open', 10, 'workspace-1', { teamId: 'team-1' })
+    ).resolves.toMatchObject({
       items: [{ id: 'LIN-1' }],
       hasMore: false
     })
@@ -200,6 +202,48 @@ describe('Linear issue queries', () => {
         team: { id: { eq: 'team-1' } }
       }
     })
+  })
+
+  it('passes attribute facets into Linear GraphQL variables before pagination', async () => {
+    rawRequest.mockResolvedValueOnce({
+      data: { issues: { nodes: [rawIssue('LIN-1')], pageInfo: { hasNextPage: false } } }
+    })
+    const { listIssues } = await import('./issues')
+
+    await expect(
+      listIssues('all', 10, 'workspace-1', {
+        attributeFilter: {
+          stateIds: ['state-1'],
+          priorities: [0, 1],
+          assignee: { kind: 'unassigned' },
+          labelIds: ['label-1']
+        }
+      })
+    ).resolves.toMatchObject({ items: [{ id: 'LIN-1' }] })
+
+    expect(rawRequest.mock.calls[0][1]).toMatchObject({
+      filter: {
+        state: { id: { in: ['state-1'] } },
+        priority: { in: [0, 1] },
+        assignee: { null: true },
+        labels: { some: { id: { in: ['label-1'] } } }
+      }
+    })
+  })
+
+  it('rejects non-empty attribute filters when workspace scope is all', async () => {
+    const { listIssues } = await import('./issues')
+    await expect(
+      listIssues('all', 10, 'all', {
+        attributeFilter: {
+          stateIds: ['state-1'],
+          priorities: [],
+          assignee: null,
+          labelIds: []
+        }
+      })
+    ).rejects.toThrow(/concrete workspace/i)
+    expect(getClients).not.toHaveBeenCalled()
   })
 
   it('keeps single-workspace search results in Linear relevance order', async () => {

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -15,6 +15,10 @@ import {
   clampLinearIssueListLimit
 } from '../../shared/linear-issue-read-limits'
 import {
+  isEmptyLinearIssueAttributeFilter,
+  type LinearIssueAttributeFilter
+} from '../../shared/linear-issue-attribute-filter'
+import {
   acquire,
   release,
   getClients,
@@ -22,7 +26,13 @@ import {
   clearToken,
   type LinearClientForWorkspace
 } from './client'
+import { buildLinearListIssueFilter } from './issue-list-filter'
 import { mapLinearIssue } from './mappers'
+
+export type LinearIssueListOptions = {
+  teamId?: string
+  attributeFilter?: LinearIssueAttributeFilter | null
+}
 
 type LinearIssueNode = {
   id: string
@@ -457,11 +467,17 @@ function getOldestIssueTime(issues: LinearIssue[]): number {
 function getListIssueConnectionLoader(
   entry: LinearClientForWorkspace,
   filter: LinearListFilter,
-  teamId?: string
+  options?: LinearIssueListOptions
 ): LinearIssueConnectionLoader {
   const orderBy = 'updatedAt'
   const variables = { orderBy }
-  const filterInput = listIssueFilter(filter, teamId)
+  // Why: apply attribute + team filters in GraphQL variables before the first-N
+  // cursor walk so pagination hasMore matches the filtered set.
+  const filterInput = buildLinearListIssueFilter({
+    filter,
+    teamId: options?.teamId,
+    attributeFilter: options?.attributeFilter
+  })
 
   if (filter === 'assigned') {
     return async (page) => {
@@ -833,31 +849,6 @@ export async function searchIssues(
 
 export type LinearListFilter = 'assigned' | 'created' | 'all' | 'completed' | 'open'
 
-const ACTIVE_STATE_FILTER = { state: { type: { nin: ['completed', 'canceled'] } } }
-const COMPLETED_STATE_FILTER = { state: { type: { in: ['completed', 'canceled'] } } }
-
-function listFilterForState(filter: LinearListFilter): Record<string, unknown> | undefined {
-  if (filter === 'assigned' || filter === 'created' || filter === 'open') {
-    return ACTIVE_STATE_FILTER
-  }
-  if (filter === 'completed') {
-    return COMPLETED_STATE_FILTER
-  }
-  return undefined
-}
-
-function listIssueFilter(
-  filter: LinearListFilter,
-  teamId?: string
-): Record<string, unknown> | undefined {
-  const stateFilter = listFilterForState(filter)
-  const teamFilter = teamId ? { team: { id: { eq: teamId } } } : undefined
-  if (stateFilter && teamFilter) {
-    return { ...stateFilter, ...teamFilter }
-  }
-  return stateFilter ?? teamFilter
-}
-
 type LinearIssuePageResult = {
   items: LinearIssue[]
   hasMore: boolean
@@ -904,14 +895,14 @@ async function readListIssuesForWorkspace(
   filter: LinearListFilter,
   limit: number,
   workspaceId: LinearWorkspaceSelection | null | undefined,
-  teamId?: string
+  options?: LinearIssueListOptions
 ): Promise<LinearCollectionResult<LinearIssue>> {
   await acquire()
   try {
     return await readIssueConnectionPages(
       entry,
       limit,
-      getListIssueConnectionLoader(entry, filter, teamId)
+      getListIssueConnectionLoader(entry, filter, options)
     )
   } catch (error) {
     if (isAuthError(error)) {
@@ -1016,11 +1007,11 @@ async function readListIssuesAcrossWorkspaces(
   filter: LinearListFilter,
   limit: number,
   workspaceId: LinearWorkspaceSelection | null | undefined,
-  teamId?: string
+  options?: LinearIssueListOptions
 ): Promise<LinearCollectionResult<LinearIssue>> {
   const states: LinearIssueWorkspacePageState[] = entries.map((entry) => ({
     entry,
-    loadConnection: getListIssueConnectionLoader(entry, filter, teamId),
+    loadConnection: getListIssueConnectionLoader(entry, filter, options),
     items: [],
     hasMore: false,
     canPage: false
@@ -1063,19 +1054,32 @@ export async function listIssues(
   filter: LinearListFilter = 'assigned',
   limit = 20,
   workspaceId?: LinearWorkspaceSelection | null,
-  teamId?: string
+  options?: LinearIssueListOptions
 ): Promise<LinearCollectionResult<LinearIssue>> {
   const effectiveLimit = clampLinearIssueListLimit(limit)
+  const attributeFilter = options?.attributeFilter
+  // Why: workspace-specific state/member/label ids cannot fan out safely across
+  // "all" workspaces; reject before creating clients so non-UI callers cannot
+  // get a misleading partial subset.
+  if (
+    attributeFilter &&
+    !isEmptyLinearIssueAttributeFilter(attributeFilter) &&
+    workspaceId === 'all'
+  ) {
+    throw new Error(
+      'Linear attribute filters require a concrete workspace; "all" workspaces is not supported.'
+    )
+  }
   const entries = getClients(workspaceId)
   if (entries.length === 0) {
     return { items: [] }
   }
 
   if (entries.length === 1) {
-    return readListIssuesForWorkspace(entries[0], filter, effectiveLimit, workspaceId, teamId)
+    return readListIssuesForWorkspace(entries[0], filter, effectiveLimit, workspaceId, options)
   }
 
-  return readListIssuesAcrossWorkspaces(entries, filter, effectiveLimit, workspaceId, teamId)
+  return readListIssuesAcrossWorkspaces(entries, filter, effectiveLimit, workspaceId, options)
 }
 
 export async function createIssue(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -480,7 +480,8 @@ import {
   updateIssueForAgent as updateLinearIssueForAgent,
   updateIssue as updateLinearIssue,
   LinearWriteFailure,
-  type LinearListFilter
+  type LinearListFilter,
+  type LinearIssueListOptions
 } from '../linear/issues'
 import {
   LinearAgentAccessError,
@@ -20799,7 +20800,9 @@ export class OrcaRuntimeService {
       : null
     const workspaceId = team?.workspaceId ?? params.workspaceId
     try {
-      const result = await listLinearIssues(filter, limit, workspaceId, team?.id)
+      const result = await listLinearIssues(filter, limit, workspaceId, {
+        teamId: team?.id
+      })
       return {
         issues: result.items.map((issue) => ({
           id: issue.id,
@@ -20927,9 +20930,9 @@ export class OrcaRuntimeService {
     filter?: LinearListFilter,
     limit = 20,
     workspaceId?: LinearWorkspaceSelection,
-    teamId?: string
+    options?: LinearIssueListOptions
   ): ReturnType<typeof listLinearIssues> {
-    return listLinearIssues(filter, clampLinearIssueListLimit(limit), workspaceId, teamId)
+    return listLinearIssues(filter, clampLinearIssueListLimit(limit), workspaceId, options)
   }
 
   linearCreateIssue(

--- a/src/main/runtime/rpc/methods/linear-issue-attribute-filter-schema.ts
+++ b/src/main/runtime/rpc/methods/linear-issue-attribute-filter-schema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+import {
+  LINEAR_ISSUE_ATTRIBUTE_FILTER_ID_MAX_LENGTH,
+  LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS,
+  LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_PRIORITIES,
+  LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
+} from '../../../../shared/linear-issue-attribute-filter'
+
+// Why: keep ListIssues param validation co-located with shared limits without
+// pushing linear.ts past the max-lines ratchet.
+const LinearAttributeFilterId = z
+  .string()
+  .trim()
+  .min(1)
+  .max(LINEAR_ISSUE_ATTRIBUTE_FILTER_ID_MAX_LENGTH)
+
+export const LinearIssueAttributeFilterSchema = z
+  .object({
+    stateIds: z.array(LinearAttributeFilterId).max(LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS),
+    priorities: z
+      .array(z.number().int().min(0).max(4))
+      .max(LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_PRIORITIES),
+    assignee: z.union([
+      z.object({ kind: z.literal('unassigned') }).strict(),
+      z
+        .object({
+          kind: z.literal('user'),
+          id: LinearAttributeFilterId
+        })
+        .strict(),
+      z.null()
+    ]),
+    labelIds: z.array(LinearAttributeFilterId).max(LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS)
+  })
+  .strict()

--- a/src/main/runtime/rpc/methods/linear.test.ts
+++ b/src/main/runtime/rpc/methods/linear.test.ts
@@ -102,7 +102,9 @@ describe('linear RPC methods', () => {
     )
 
     expect(runtime.linearSearchIssues).toHaveBeenCalledWith('bug', 30, 'all')
-    expect(runtime.linearListIssues).toHaveBeenCalledWith('assigned', 20, 'workspace-1')
+    expect(runtime.linearListIssues).toHaveBeenCalledWith('assigned', 20, 'workspace-1', {
+      attributeFilter: undefined
+    })
     expect(runtime.linearGetIssue).toHaveBeenCalledWith('issue-3', 'workspace-1')
     expect(runtime.linearCreateIssue).toHaveBeenCalledWith(
       'team-1',

--- a/src/main/runtime/rpc/methods/linear.ts
+++ b/src/main/runtime/rpc/methods/linear.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
 import { LINEAR_PROJECT_CREATE_METHOD } from './linear-project-create'
+import { LinearIssueAttributeFilterSchema } from './linear-issue-attribute-filter-schema'
 
 const VALID_FILTERS = ['assigned', 'created', 'all', 'completed'] as const
 const VALID_CUSTOM_VIEW_MODELS = ['issue', 'project'] as const
@@ -37,8 +38,10 @@ const ListIssues = z
   .object({
     filter: z.enum(VALID_FILTERS).optional(),
     limit: OptionalFiniteNumber,
-    workspaceId: OptionalString
+    workspaceId: OptionalString,
+    attributeFilter: LinearIssueAttributeFilterSchema.optional()
   })
+  .strict()
   .optional()
 
 const CreateIssue = z.object({
@@ -164,7 +167,9 @@ export const LINEAR_METHODS: RpcMethod[] = [
     name: 'linear.listIssues',
     params: ListIssues,
     handler: async (params, { runtime }) =>
-      runtime.linearListIssues(params?.filter, params?.limit, params?.workspaceId)
+      runtime.linearListIssues(params?.filter, params?.limit, params?.workspaceId, {
+        attributeFilter: params?.attributeFilter
+      })
   }),
   defineMethod({
     name: 'linear.createIssue',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -39,6 +39,7 @@ import type {
 } from '../shared/orca-profiles'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { TaskSourceContext } from '../shared/task-source-context'
+import type { LinearIssueAttributeFilter } from '../shared/linear-issue-attribute-filter'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 import type { StartupCommandDelivery } from '../shared/codex-startup-delivery'
 import type { SleepingAgentLaunchConfig } from '../shared/agent-session-resume'
@@ -1776,6 +1777,7 @@ export type PreloadApi = {
       filter?: 'assigned' | 'created' | 'all' | 'completed'
       limit?: number
       workspaceId?: LinearWorkspaceSelection
+      attributeFilter?: LinearIssueAttributeFilter
     }) => Promise<LinearCollectionResult<LinearIssue>>
     createIssue: (args: {
       teamId: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1462,6 +1462,7 @@ const api = {
       filter?: 'assigned' | 'created' | 'all' | 'completed'
       limit?: number
       workspaceId?: string
+      attributeFilter?: unknown
     }): Promise<unknown> => ipcRenderer.invoke('linear:listIssues', args),
 
     createIssue: (args: {

--- a/src/renderer/src/components/LinearItemDrawer.tsx
+++ b/src/renderer/src/components/LinearItemDrawer.tsx
@@ -203,6 +203,7 @@ export function LinearIssueEditSection({
           patchLinearIssue(issue.id, { state: prevState }, { sourceContext })
         },
         onSuccess: () => {
+          useAppStore.getState().invalidateLinearIssueLists({ sourceContext })
           useAppStore.getState().recordFeatureInteraction('linear-tasks')
         },
         onError: (err) => toast.error(err)
@@ -237,6 +238,7 @@ export function LinearIssueEditSection({
           patchLinearIssue(issue.id, { priority: prevPriority }, { sourceContext })
         },
         onSuccess: () => {
+          useAppStore.getState().invalidateLinearIssueLists({ sourceContext })
           useAppStore.getState().recordFeatureInteraction('linear-tasks')
         },
         onError: (err) => toast.error(err)
@@ -328,6 +330,7 @@ export function LinearIssueEditSection({
           patchLinearIssue(issue.id, { assignee: prevAssignee }, { sourceContext })
         },
         onSuccess: () => {
+          useAppStore.getState().invalidateLinearIssueLists({ sourceContext })
           useAppStore.getState().recordFeatureInteraction('linear-tasks')
         },
         onError: (err) => toast.error(err)
@@ -383,6 +386,7 @@ export function LinearIssueEditSection({
           )
         },
         onSuccess: () => {
+          useAppStore.getState().invalidateLinearIssueLists({ sourceContext })
           useAppStore.getState().recordFeatureInteraction('linear-tasks')
         },
         onError: (err) => toast.error(err)

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -199,6 +199,24 @@ import {
   type TaskPageRepoSourceState
 } from '@/components/task-page-cache-selectors'
 import { shouldHideTaskPageListChrome } from '@/components/task-page-list-chrome-visibility'
+import LinearIssueAttributeFilterDropdowns from '@/components/linear-issue-attribute-filter-dropdowns'
+import { resolveLinearIssueAttributeFilterPrimaryTeam } from '@/components/linear-issue-attribute-filter-primary-team'
+import {
+  buildLinearIssueListReadArgs,
+  buildLinearIssueListRequestSignature,
+  isLinearIssueSearchActive,
+  shouldForceLinearIssueListRead,
+  teamDerivedFacetsForPrimaryTeamChange
+} from '@/components/task-page-linear-issue-request'
+import {
+  resolveLinearIssueEmptyKind,
+  shouldOfferLinearIssueFetchMore
+} from '@/components/task-page-linear-issue-empty-state'
+import {
+  emptyLinearIssueAttributeFilter,
+  linearIssueAttributeFilterSignature,
+  type LinearIssueAttributeFilter
+} from '../../../shared/linear-issue-attribute-filter'
 import {
   isNewIssueDraftContentful,
   resolveNewIssueOpenSeed,
@@ -652,27 +670,28 @@ function LinearStateCell({
       }
 
       setPending(true)
-      patchLinearIssue(issue.id, { state: nextState })
+      patchLinearIssue(issue.id, { state: nextState }, { sourceContext })
       void linearUpdateIssue(providerSettings, issue.id, { stateId }, issue.workspaceId)
         .then((result) => {
           if (reqId !== reqRef.current) {
             return
           }
           if (result.ok === false) {
-            patchLinearIssue(issue.id, { state: previousState })
+            patchLinearIssue(issue.id, { state: previousState }, { sourceContext })
             toast.error(
               result.error ??
                 translate('auto.components.TaskPage.6775c05483', 'Failed to update Linear state')
             )
             return
           }
+          useAppStore.getState().invalidateLinearIssueLists({ sourceContext })
           useAppStore.getState().recordFeatureInteraction('linear-tasks')
         })
         .catch(() => {
           if (reqId !== reqRef.current) {
             return
           }
-          patchLinearIssue(issue.id, { state: previousState })
+          patchLinearIssue(issue.id, { state: previousState }, { sourceContext })
           toast.error(
             translate('auto.components.TaskPage.6775c05483', 'Failed to update Linear state')
           )
@@ -691,6 +710,7 @@ function LinearStateCell({
       patchLinearIssue,
       pending,
       providerSettings,
+      sourceContext,
       states.data
     ]
   )
@@ -3054,6 +3074,8 @@ export default function TaskPage(): React.JSX.Element {
   const selectLinearWorkspace = useAppStore((s) => s.selectLinearWorkspace)
   const searchLinearIssues = useAppStore((s) => s.searchLinearIssues)
   const listLinearIssues = useAppStore((s) => s.listLinearIssues)
+  const linearListInvalidationToken = useAppStore((s) => s.linearListInvalidationToken)
+  const invalidateLinearIssueLists = useAppStore((s) => s.invalidateLinearIssueLists)
   const getCachedLinearIssues = useAppStore((s) => s.getCachedLinearIssues)
   const getCachedLinearTeams = useAppStore((s) => s.getCachedLinearTeams)
   const listLinearTeams = useAppStore((s) => s.listLinearTeams)
@@ -3452,6 +3474,13 @@ export default function TaskPage(): React.JSX.Element {
       selectedLinearWorkspaceId
     ]
   )
+  // Why: only react to invalidation tokens for this TaskPage source scope.
+  const linearListInvalidationVersionForSource = useMemo(() => {
+    const scope = linearTaskSourceContext
+      ? getTaskSourceCacheScope(linearTaskSourceContext)
+      : 'local'
+    return linearListInvalidationToken.scope === scope ? linearListInvalidationToken.version : 0
+  }, [linearListInvalidationToken, linearTaskSourceContext])
   const jiraTaskSourceContext = useMemo(
     () =>
       normalizeTaskSourceContext({
@@ -4355,6 +4384,14 @@ export default function TaskPage(): React.JSX.Element {
   const [linearError, setLinearError] = useState<string | null>(null)
   const [linearSearchInput, setLinearSearchInput] = useState('')
   const [appliedLinearSearch, setAppliedLinearSearch] = useState('')
+  const [linearAttributeFilter, setLinearAttributeFilter] = useState<LinearIssueAttributeFilter>(
+    () => emptyLinearIssueAttributeFilter()
+  )
+  const linearAttributeFilterSignatureRef = useRef(
+    linearIssueAttributeFilterSignature(emptyLinearIssueAttributeFilter())
+  )
+  const linearPrimaryTeamIdRef = useRef<string | null>(null)
+  const previousLinearWorkspaceIdForFiltersRef = useRef<string | null | undefined>(undefined)
   const [linearViewMode, setLinearViewMode] = useState<LinearViewMode>('list')
   const [linearGroupBy, setLinearGroupBy] = useState<LinearGroupBy>('none')
   const [linearOrderBy, setLinearOrderBy] = useState<LinearOrderBy>('priority')
@@ -5100,6 +5137,57 @@ export default function TaskPage(): React.JSX.Element {
     )
   }, [linearTeamOptions, defaultLinearTeamSelection])
 
+  const linearAttributePrimaryTeam = useMemo(
+    () =>
+      resolveLinearIssueAttributeFilterPrimaryTeam({
+        selectedTeamIds: [...linearTeamSelection],
+        availableTeams: linearTeamOptions
+      }),
+    [linearTeamOptions, linearTeamSelection]
+  )
+
+  const applyLinearAttributeFilter = useCallback((next: LinearIssueAttributeFilter) => {
+    // Why: batch filter + limit/page reset in one transition so the fetch
+    // effect never issues an old expanded-limit request for the new filter.
+    setLinearAttributeFilter(next)
+    setLinearIssueLimit(LINEAR_ITEM_LIMIT)
+    setLinearIssuePage(0)
+    setLinearIssueLoadingTargetPage(null)
+  }, [])
+
+  useEffect(() => {
+    const workspaceId = selectedLinearWorkspaceId ?? null
+    const previous = previousLinearWorkspaceIdForFiltersRef.current
+    previousLinearWorkspaceIdForFiltersRef.current = workspaceId
+    if (previous === undefined || previous === workspaceId) {
+      return
+    }
+    applyLinearAttributeFilter(emptyLinearIssueAttributeFilter())
+  }, [applyLinearAttributeFilter, selectedLinearWorkspaceId])
+
+  useEffect(() => {
+    const nextId = linearAttributePrimaryTeam?.id ?? null
+    const previousId = linearPrimaryTeamIdRef.current
+    linearPrimaryTeamIdRef.current = nextId
+    if (previousId === null || previousId === nextId) {
+      return
+    }
+    // Why: status/assignee/labels are team-scoped; clearing them is a filter change
+    // and must reset limit/page via applyLinearAttributeFilter (R6), not a bare set.
+    const next = teamDerivedFacetsForPrimaryTeamChange(linearAttributeFilter)
+    if (
+      linearIssueAttributeFilterSignature(linearAttributeFilter) ===
+      linearIssueAttributeFilterSignature(next)
+    ) {
+      return
+    }
+    applyLinearAttributeFilter(next)
+  }, [applyLinearAttributeFilter, linearAttributeFilter, linearAttributePrimaryTeam?.id])
+
+  const linearSearchActive = isLinearIssueSearchActive(linearSearchInput, appliedLinearSearch)
+  const showLinearAttributeFilters =
+    linearMode === 'issues' && !activeLinearIssueContextLabel && !linearSearchActive
+
   const filteredLinearIssues = useMemo(() => {
     if (activeLinearIssueContextLabel) {
       return displayedLinearIssues
@@ -5418,7 +5506,7 @@ export default function TaskPage(): React.JSX.Element {
           color: workflowState.color
         }
 
-        patchLinearIssue(issue.id, { state: nextState })
+        patchLinearIssue(issue.id, { state: nextState }, { sourceContext: linearTaskSourceContext })
         patchScopedLinearIssue(issue.id, { state: nextState })
         applyFallbackState(nextState)
 
@@ -5429,7 +5517,11 @@ export default function TaskPage(): React.JSX.Element {
           issue.workspaceId
         )
         if (result.ok === false) {
-          patchLinearIssue(issue.id, { state: previousState })
+          patchLinearIssue(
+            issue.id,
+            { state: previousState },
+            { sourceContext: linearTaskSourceContext }
+          )
           patchScopedLinearIssue(issue.id, { state: previousState })
           applyFallbackState(previousState)
           toast.error(
@@ -5438,9 +5530,14 @@ export default function TaskPage(): React.JSX.Element {
           )
           return
         }
+        invalidateLinearIssueLists({ sourceContext: linearTaskSourceContext })
         useAppStore.getState().recordFeatureInteraction('linear-tasks')
       } catch {
-        patchLinearIssue(issue.id, { state: previousState })
+        patchLinearIssue(
+          issue.id,
+          { state: previousState },
+          { sourceContext: linearTaskSourceContext }
+        )
         patchScopedLinearIssue(issue.id, { state: previousState })
         applyFallbackState(previousState)
         toast.error(
@@ -5456,6 +5553,7 @@ export default function TaskPage(): React.JSX.Element {
     },
     [
       filteredLinearIssues,
+      invalidateLinearIssueLists,
       linearBoardDraggingIssueId,
       linearBoardUpdatingIssueIds,
       linearStatusBoardEnabled,
@@ -7177,9 +7275,8 @@ export default function TaskPage(): React.JSX.Element {
     taskSource
   ])
 
-  // Why: fetch Linear issues when the tab is active and the account is
-  // connected. An empty search falls back to `listLinearIssues` (assigned
-  // issues) so the default view shows the user's own work.
+  // Why: fetch Linear issues when the tab is active and connected. Empty search
+  // uses the plain `all` list with optional server-side attribute filters.
   useEffect(() => {
     if (!taskResumeApplied) {
       return
@@ -7199,10 +7296,17 @@ export default function TaskPage(): React.JSX.Element {
 
     const trimmed = appliedLinearSearch.trim()
     const effectiveLinearIssueLimit = clampLinearIssueListLimit(linearIssueLimit)
-    const readArgs =
-      trimmed.length > 0
-        ? ({ kind: 'search', query: trimmed, limit: LINEAR_ITEM_LIMIT } as const)
-        : ({ kind: 'list', filter: 'all', limit: effectiveLinearIssueLimit } as const)
+    const searchActive = trimmed.length > 0
+    const listReadArgs = buildLinearIssueListReadArgs({
+      filter: 'all',
+      limit: effectiveLinearIssueLimit,
+      attributeFilter: linearAttributeFilter,
+      searchActive,
+      allowAttributeFilter: selectedLinearWorkspaceId !== 'all'
+    })
+    const readArgs = searchActive
+      ? ({ kind: 'search', query: trimmed, limit: LINEAR_ITEM_LIMIT } as const)
+      : listReadArgs
     const cachedResult = getCachedLinearIssues(readArgs, { sourceContext: linearTaskSourceContext })
     if (readArgs.kind === 'search') {
       setLinearIssuesHasMore(false)
@@ -7217,15 +7321,29 @@ export default function TaskPage(): React.JSX.Element {
       )
     }
 
-    const requestSignature =
-      trimmed.length > 0
-        ? `${selectedLinearWorkspaceId ?? 'default'}::search::${trimmed}::${LINEAR_ITEM_LIMIT}`
-        : `${selectedLinearWorkspaceId ?? 'default'}::list::all::${effectiveLinearIssueLimit}`
+    const nextFilterSignature = linearIssueAttributeFilterSignature(linearAttributeFilter)
+    const previousFilterSignature = linearAttributeFilterSignatureRef.current
+    linearAttributeFilterSignatureRef.current = nextFilterSignature
+    const filterForce = shouldForceLinearIssueListRead({
+      previousFilterSignature,
+      nextFilterSignature,
+      refreshForced: false
+    })
+
+    const requestSignature = buildLinearIssueListRequestSignature({
+      sourceContext: linearTaskSourceContext,
+      workspaceId: selectedLinearWorkspaceId,
+      filter: 'all',
+      limit: effectiveLinearIssueLimit,
+      attributeFilter: linearAttributeFilter,
+      searchQuery: searchActive ? trimmed : undefined
+    })
     const previousRequest = lastLinearRequestRef.current
     const forceRefresh =
-      linearRefreshNonce > 0 &&
-      previousRequest?.nonce !== linearRefreshNonce &&
-      previousRequest?.signature === requestSignature
+      filterForce ||
+      (linearRefreshNonce > 0 &&
+        previousRequest?.nonce !== linearRefreshNonce &&
+        previousRequest?.signature === requestSignature)
     lastLinearRequestRef.current = { nonce: linearRefreshNonce, signature: requestSignature }
     const shouldProbeOnLanding =
       !forceRefresh &&
@@ -7248,7 +7366,7 @@ export default function TaskPage(): React.JSX.Element {
             force: forceRefresh || shouldProbeOnLanding,
             sourceContext: linearTaskSourceContext
           })
-        : listLinearIssues(readArgs.filter, effectiveLinearIssueLimit, {
+        : listLinearIssues(listReadArgs, {
             force: forceRefresh || shouldProbeOnLanding,
             sourceContext: linearTaskSourceContext
           })
@@ -7311,6 +7429,8 @@ export default function TaskPage(): React.JSX.Element {
     appliedLinearSearch,
     linearIssueLimit,
     linearRefreshNonce,
+    linearAttributeFilter,
+    linearListInvalidationVersionForSource,
     taskResumeApplied,
     getCachedLinearIssues,
     linearTaskSourceContext
@@ -8593,7 +8713,18 @@ export default function TaskPage(): React.JSX.Element {
                     </div>
 
                     {linearMode === 'issues' ? (
-                      <div className="mt-3 flex min-w-0 items-center gap-3">
+                      <div className="mt-3 flex min-w-0 items-center gap-2">
+                        {showLinearAttributeFilters ? (
+                          <LinearIssueAttributeFilterDropdowns
+                            value={linearAttributeFilter}
+                            onChange={applyLinearAttributeFilter}
+                            workspaceId={selectedLinearWorkspaceId ?? null}
+                            isAllWorkspaces={selectedLinearWorkspaceId === 'all'}
+                            primaryTeam={linearAttributePrimaryTeam}
+                            selectedTeamCount={linearTeamSelection.size}
+                            settings={linearTaskSourceContext ?? settings}
+                          />
+                        ) : null}
                         <div className="relative min-w-0 flex-1 basis-64">
                           <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
                           <Input
@@ -10537,20 +10668,37 @@ export default function TaskPage(): React.JSX.Element {
                       {translate('auto.components.TaskPage.903c7af49f', 'No Linear issues found')}
                     </p>
                     <p className="mt-2 text-sm text-muted-foreground">
-                      {activeLinearIssueContextLabel
-                        ? translate(
+                      {(() => {
+                        const emptyKind = resolveLinearIssueEmptyKind({
+                          hasContextLabel: Boolean(activeLinearIssueContextLabel),
+                          searchActive: linearSearchActive,
+                          attributeFilter: linearAttributeFilter,
+                          serverIssueCount: activeLinearIssues.length,
+                          filteredIssueCount: filteredLinearIssues.length
+                        })
+                        if (emptyKind === 'context') {
+                          return translate(
                             'auto.components.TaskPage.25ff84769a',
                             'No issues match this Linear context.'
                           )
-                        : linearSearchInput
-                          ? translate(
-                              'auto.components.TaskPage.2bdefbcac3',
-                              'Try a different search query.'
-                            )
-                          : translate(
-                              'auto.components.TaskPage.d079be2dc8',
-                              'No assigned issues. Try searching for something.'
-                            )}
+                        }
+                        if (emptyKind === 'search') {
+                          return translate(
+                            'auto.components.TaskPage.2bdefbcac3',
+                            'Try a different search query.'
+                          )
+                        }
+                        if (emptyKind === 'server-attribute-filter') {
+                          return translate(
+                            'auto.components.TaskPage.linearEmptyAttributeFilter',
+                            'No issues match the selected filters. Clear a filter or try different criteria.'
+                          )
+                        }
+                        return translate(
+                          'auto.components.TaskPage.linearEmptyUnfilteredScope',
+                          'No issues in this workspace scope. Try searching or adjusting teams.'
+                        )
+                      })()}
                     </p>
                   </div>
                 ) : null}
@@ -10571,6 +10719,27 @@ export default function TaskPage(): React.JSX.Element {
                         'Try selecting more teams or refreshing; team filters apply to the current fetched issue set.'
                       )}
                     </p>
+                    {shouldOfferLinearIssueFetchMore({
+                      emptyKind: 'client-team',
+                      serverHasMore: linearIssuesHasMore
+                    }) ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="mt-3 h-7 text-xs"
+                        onClick={() => {
+                          setLinearIssueLimit((limit) =>
+                            Math.min(
+                              clampLinearIssueListLimit(limit + LINEAR_ITEM_LIMIT),
+                              LINEAR_ISSUE_LIST_MAX
+                            )
+                          )
+                        }}
+                      >
+                        {translate('auto.components.TaskPage.linearFetchMore', 'Fetch more')}
+                      </Button>
+                    ) : null}
                   </div>
                 ) : null}
 

--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clearLinearIssueAttributeFacet,
+  countLinearIssueAttributeFilters,
+  linearIssueAttributeFilterPillLabels
+} from './linear-issue-attribute-filter-sections'
+import type { LinearIssueAttributeFilter } from '../../../shared/linear-issue-attribute-filter'
+
+const sample: LinearIssueAttributeFilter = {
+  stateIds: ['s1', 's2'],
+  priorities: [0, 1],
+  assignee: { kind: 'unassigned' },
+  labelIds: ['l1']
+}
+
+describe('linear-issue-attribute-filter helpers', () => {
+  it('counts active facets and clears individual facets', () => {
+    expect(countLinearIssueAttributeFilters(sample)).toBe(4)
+    expect(clearLinearIssueAttributeFacet(sample, 'status').stateIds).toEqual([])
+    expect(clearLinearIssueAttributeFacet(sample, 'priority').priorities).toEqual([])
+    expect(clearLinearIssueAttributeFacet(sample, 'assignee').assignee).toBeNull()
+    expect(clearLinearIssueAttributeFacet(sample, 'labels').labelIds).toEqual([])
+  })
+
+  it('builds pill labels from metadata maps', () => {
+    const pills = linearIssueAttributeFilterPillLabels({
+      value: sample,
+      stateNamesById: new Map([
+        ['s1', 'Todo'],
+        ['s2', 'In Progress']
+      ]),
+      memberNamesById: new Map(),
+      labelNamesById: new Map([['l1', 'Bug']])
+    })
+    expect(pills.map((p) => p.key)).toEqual(['status', 'priority', 'assignee', 'labels'])
+    expect(pills[0]?.value).toContain('Todo')
+    expect(pills[2]?.value).toMatch(/Unassigned/i)
+    expect(pills[3]?.value).toBe('Bug')
+  })
+})

--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
@@ -1,0 +1,298 @@
+// Why: Linear Filters chrome mirrors GitHub PR filters — one outline button,
+// sectioned popover, removable pills — without encoding facets into free-text search.
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { ListFilter, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useTeamLabels, useTeamMembers, useTeamStates } from '@/hooks/useIssueMetadata'
+import type { RuntimeLinearSettings } from '@/runtime/runtime-linear-client'
+import { translate } from '@/i18n/i18n'
+import {
+  canonicalizeLinearIssueAttributeFilter,
+  emptyLinearIssueAttributeFilter,
+  type LinearIssueAttributeFilter
+} from '../../../shared/linear-issue-attribute-filter'
+import type { LinearTeam } from '../../../shared/types'
+import {
+  LinearIssueFilterSectionDetail,
+  LinearIssueFilterSectionMenu,
+  clearLinearIssueAttributeFacet,
+  countLinearIssueAttributeFilters,
+  linearIssueAttributeFilterPillLabels,
+  type LinearIssueFilterSectionKey
+} from './linear-issue-attribute-filter-sections'
+
+type Props = {
+  value: LinearIssueAttributeFilter
+  onChange: (next: LinearIssueAttributeFilter) => void
+  workspaceId: string | null
+  isAllWorkspaces: boolean
+  primaryTeam: LinearTeam | null
+  selectedTeamCount: number
+  settings?: RuntimeLinearSettings
+}
+
+function ActivePill({
+  label,
+  value,
+  onClear
+}: {
+  label: string
+  value: string
+  onClear: () => void
+}): React.JSX.Element {
+  return (
+    <span className="inline-flex h-6 items-center gap-1 rounded-full border border-border/60 bg-muted/50 pl-2 pr-1 text-[11px] text-foreground">
+      <span className="text-muted-foreground">{label}:</span>
+      <span className="max-w-[160px] truncate font-medium">{value}</span>
+      <button
+        type="button"
+        aria-label={translate(
+          'auto.components.linear-issue-attribute-filter-dropdowns.removeFilter',
+          'Remove {{value0}} filter',
+          { value0: label }
+        )}
+        onClick={onClear}
+        className="rounded-full p-0.5 text-muted-foreground transition hover:bg-muted hover:text-foreground"
+      >
+        <X className="size-3" />
+      </button>
+    </span>
+  )
+}
+
+export default function LinearIssueAttributeFilterDropdowns({
+  value,
+  onChange,
+  workspaceId,
+  isAllWorkspaces,
+  primaryTeam,
+  selectedTeamCount,
+  settings
+}: Props): React.JSX.Element {
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const [openSection, setOpenSection] = useState<LinearIssueFilterSectionKey | null>(null)
+
+  const activeTeamId = popoverOpen && !isAllWorkspaces ? (primaryTeam?.id ?? null) : null
+  const concreteWorkspaceId =
+    popoverOpen && !isAllWorkspaces && workspaceId && workspaceId !== 'all' ? workspaceId : null
+
+  const states = useTeamStates(activeTeamId, settings, concreteWorkspaceId)
+  const labels = useTeamLabels(activeTeamId, settings, concreteWorkspaceId)
+  const members = useTeamMembers(activeTeamId, settings, concreteWorkspaceId)
+
+  // Why: prune only after a successful non-empty metadata load for the same team;
+  // loading/error/empty-before-load must never clear active selections (R12).
+  const pruneTeamKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!activeTeamId || !concreteWorkspaceId) {
+      return
+    }
+    if (states.loading || labels.loading || members.loading) {
+      return
+    }
+    if (states.error || labels.error || members.error) {
+      return
+    }
+    if (states.data.length === 0 && labels.data.length === 0 && members.data.length === 0) {
+      return
+    }
+    const pruneKey = `${concreteWorkspaceId}::${activeTeamId}`
+    if (pruneTeamKeyRef.current === pruneKey) {
+      return
+    }
+    pruneTeamKeyRef.current = pruneKey
+    const stateIds = new Set(states.data.map((s) => s.id))
+    const labelIds = new Set(labels.data.map((l) => l.id))
+    const memberIds = new Set(members.data.map((m) => m.id))
+    const next: LinearIssueAttributeFilter = {
+      ...value,
+      stateIds: value.stateIds.filter((id) => stateIds.has(id)),
+      labelIds: value.labelIds.filter((id) => labelIds.has(id)),
+      assignee:
+        value.assignee?.kind === 'user' && !memberIds.has(value.assignee.id) ? null : value.assignee
+    }
+    const canonicalNext = canonicalizeLinearIssueAttributeFilter(next)
+    const canonicalValue = canonicalizeLinearIssueAttributeFilter(value)
+    if (JSON.stringify(canonicalNext) !== JSON.stringify(canonicalValue)) {
+      onChange(canonicalNext)
+    }
+  }, [
+    activeTeamId,
+    concreteWorkspaceId,
+    states.loading,
+    states.error,
+    states.data,
+    labels.loading,
+    labels.error,
+    labels.data,
+    members.loading,
+    members.error,
+    members.data,
+    value,
+    onChange
+  ])
+
+  const statusOptions = useMemo(
+    () => states.data.map((state) => ({ key: state.id, primary: state.name })),
+    [states.data]
+  )
+  const labelOptions = useMemo(
+    () => labels.data.map((label) => ({ key: label.id, primary: label.name })),
+    [labels.data]
+  )
+  const assigneeOptions = useMemo(
+    () =>
+      members.data.map((member) => ({
+        key: member.id,
+        primary: member.displayName || member.id
+      })),
+    [members.data]
+  )
+
+  const stateNamesById = useMemo(
+    () => new Map(states.data.map((state) => [state.id, state.name] as const)),
+    [states.data]
+  )
+  const labelNamesById = useMemo(
+    () => new Map(labels.data.map((label) => [label.id, label.name] as const)),
+    [labels.data]
+  )
+  const memberNamesById = useMemo(
+    () =>
+      new Map(members.data.map((member) => [member.id, member.displayName || member.id] as const)),
+    [members.data]
+  )
+
+  const activeCount = countLinearIssueAttributeFilters(value)
+  const pills = linearIssueAttributeFilterPillLabels({
+    value,
+    stateNamesById,
+    memberNamesById,
+    labelNamesById
+  })
+
+  const teamRequiredMessage = !primaryTeam
+    ? translate(
+        'auto.components.linear-issue-attribute-filter-dropdowns.teamRequired',
+        'Select a team to load status, assignees, and labels for this workspace.'
+      )
+    : null
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+      <Popover
+        open={popoverOpen}
+        onOpenChange={(open) => {
+          setPopoverOpen(open)
+          if (!open) {
+            setOpenSection(null)
+          }
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 px-2 text-xs"
+            aria-label={translate(
+              'auto.components.linear-issue-attribute-filter-dropdowns.filters',
+              'Filters'
+            )}
+          >
+            <ListFilter className="size-3.5" />
+            {translate(
+              'auto.components.linear-issue-attribute-filter-dropdowns.filters',
+              'Filters'
+            )}
+            {activeCount > 0 ? (
+              <span className="rounded-full bg-muted px-1.5 text-[10px] font-medium text-muted-foreground">
+                {activeCount}
+              </span>
+            ) : null}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-72 p-0">
+          {isAllWorkspaces ? (
+            <div className="space-y-2 p-3 text-xs">
+              <p className="font-medium text-foreground">
+                {translate(
+                  'auto.components.linear-issue-attribute-filter-dropdowns.allWorkspacesTitle',
+                  'Select one workspace'
+                )}
+              </p>
+              <p className="text-muted-foreground">
+                {translate(
+                  'auto.components.linear-issue-attribute-filter-dropdowns.allWorkspacesBody',
+                  'Status, assignee, and label filters use ids from a single Linear workspace. Choose one workspace to filter by those attributes.'
+                )}
+              </p>
+            </div>
+          ) : (
+            <>
+              {selectedTeamCount > 1 && primaryTeam ? (
+                <p className="border-b border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
+                  {translate(
+                    'auto.components.linear-issue-attribute-filter-dropdowns.optionsFromTeam',
+                    'Options from {{team}}',
+                    { team: primaryTeam.name }
+                  )}
+                </p>
+              ) : null}
+              {openSection ? (
+                <LinearIssueFilterSectionDetail
+                  section={openSection}
+                  value={value}
+                  onChange={(next) => onChange(canonicalizeLinearIssueAttributeFilter(next))}
+                  statusOptions={statusOptions}
+                  assigneeOptions={assigneeOptions}
+                  labelOptions={labelOptions}
+                  statusLoading={states.loading}
+                  statusError={states.error}
+                  assigneeLoading={members.loading}
+                  assigneeError={members.error}
+                  labelLoading={labels.loading}
+                  labelError={labels.error}
+                  teamRequiredMessage={teamRequiredMessage}
+                  onBack={() => setOpenSection(null)}
+                />
+              ) : (
+                <LinearIssueFilterSectionMenu value={value} onOpenSection={setOpenSection} />
+              )}
+              {activeCount > 0 ? (
+                <div className="border-t border-border/50 p-2">
+                  <button
+                    type="button"
+                    className="w-full rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition hover:bg-muted/50 hover:text-foreground"
+                    onClick={() => onChange(emptyLinearIssueAttributeFilter())}
+                  >
+                    {translate(
+                      'auto.components.linear-issue-attribute-filter-dropdowns.clearAll',
+                      'Clear all filters'
+                    )}
+                  </button>
+                </div>
+              ) : null}
+            </>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {pills.map((pill) => (
+        <ActivePill
+          key={pill.key}
+          label={pill.label}
+          value={pill.value}
+          onClear={() =>
+            onChange(
+              canonicalizeLinearIssueAttributeFilter(
+                clearLinearIssueAttributeFacet(value, pill.key)
+              )
+            )
+          }
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/linear-issue-attribute-filter-primary-team.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-primary-team.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { resolveLinearIssueAttributeFilterPrimaryTeam } from './linear-issue-attribute-filter-primary-team'
+import type { LinearTeam } from '../../../shared/types'
+
+const teams: LinearTeam[] = [
+  { id: 't-b', name: 'Backend', key: 'BE' },
+  { id: 't-a', name: 'App', key: 'APP' },
+  { id: 't-c', name: 'Core', key: 'CORE' }
+]
+
+describe('resolveLinearIssueAttributeFilterPrimaryTeam', () => {
+  it('picks the first available team by stable name/id when none selected', () => {
+    expect(
+      resolveLinearIssueAttributeFilterPrimaryTeam({
+        selectedTeamIds: [],
+        availableTeams: teams
+      })?.id
+    ).toBe('t-a')
+  })
+
+  it('picks the first selected team by stable name/id order', () => {
+    expect(
+      resolveLinearIssueAttributeFilterPrimaryTeam({
+        selectedTeamIds: ['t-c', 't-b'],
+        availableTeams: teams
+      })?.id
+    ).toBe('t-b')
+  })
+
+  it('falls back to first available when selected ids are unavailable', () => {
+    expect(
+      resolveLinearIssueAttributeFilterPrimaryTeam({
+        selectedTeamIds: ['missing'],
+        availableTeams: teams
+      })?.id
+    ).toBe('t-a')
+  })
+})

--- a/src/renderer/src/components/linear-issue-attribute-filter-primary-team.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-primary-team.ts
@@ -1,0 +1,30 @@
+import type { LinearTeam } from '../../../shared/types'
+
+function compareTeamNameId(a: LinearTeam, b: LinearTeam): number {
+  const nameCmp = a.name.localeCompare(b.name)
+  if (nameCmp !== 0) {
+    return nameCmp
+  }
+  return a.id.localeCompare(b.id)
+}
+
+/** Deterministic primary team: first selected by name/id, else first available. */
+export function resolveLinearIssueAttributeFilterPrimaryTeam(options: {
+  selectedTeamIds: string[]
+  availableTeams: LinearTeam[]
+}): LinearTeam | null {
+  const { selectedTeamIds, availableTeams } = options
+  if (availableTeams.length === 0) {
+    return null
+  }
+  if (selectedTeamIds.length === 0) {
+    return [...availableTeams].sort(compareTeamNameId)[0] ?? null
+  }
+  const selected = availableTeams
+    .filter((team) => selectedTeamIds.includes(team.id))
+    .sort(compareTeamNameId)
+  if (selected.length > 0) {
+    return selected[0] ?? null
+  }
+  return [...availableTeams].sort(compareTeamNameId)[0] ?? null
+}

--- a/src/renderer/src/components/linear-issue-attribute-filter-sections.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-sections.tsx
@@ -1,0 +1,377 @@
+import React from 'react'
+import { ChevronRight } from 'lucide-react'
+import {
+  MultiSelectList,
+  SingleSelectList,
+  type PickerOption
+} from '@/components/github/PRFilterPickers'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import {
+  canonicalizeLinearIssueAttributeFilter,
+  type LinearIssueAttributeFilter
+} from '../../../shared/linear-issue-attribute-filter'
+import { getLinearPriorityLabel } from './task-page-localized-options'
+
+export type LinearIssueFilterSectionKey = 'status' | 'priority' | 'assignee' | 'labels'
+
+export function countLinearIssueAttributeFilters(value: LinearIssueAttributeFilter): number {
+  const canonical = canonicalizeLinearIssueAttributeFilter(value)
+  return (
+    (canonical.stateIds.length > 0 ? 1 : 0) +
+    (canonical.priorities.length > 0 ? 1 : 0) +
+    (canonical.assignee ? 1 : 0) +
+    (canonical.labelIds.length > 0 ? 1 : 0)
+  )
+}
+
+export function clearLinearIssueAttributeFacet(
+  value: LinearIssueAttributeFilter,
+  facet: LinearIssueFilterSectionKey
+): LinearIssueAttributeFilter {
+  switch (facet) {
+    case 'status':
+      return { ...value, stateIds: [] }
+    case 'priority':
+      return { ...value, priorities: [] }
+    case 'assignee':
+      return { ...value, assignee: null }
+    case 'labels':
+      return { ...value, labelIds: [] }
+  }
+}
+
+export function linearIssueAttributeFilterPillLabels(options: {
+  value: LinearIssueAttributeFilter
+  stateNamesById: Map<string, string>
+  memberNamesById: Map<string, string>
+  labelNamesById: Map<string, string>
+}): { key: LinearIssueFilterSectionKey; label: string; value: string }[] {
+  const canonical = canonicalizeLinearIssueAttributeFilter(options.value)
+  const pills: { key: LinearIssueFilterSectionKey; label: string; value: string }[] = []
+  if (canonical.stateIds.length > 0) {
+    pills.push({
+      key: 'status',
+      label: translate('auto.components.linear-issue-attribute-filter-sections.status', 'Status'),
+      value: canonical.stateIds.map((id) => options.stateNamesById.get(id) ?? id).join(', ')
+    })
+  }
+  if (canonical.priorities.length > 0) {
+    pills.push({
+      key: 'priority',
+      label: translate(
+        'auto.components.linear-issue-attribute-filter-sections.priority',
+        'Priority'
+      ),
+      value: canonical.priorities.map((p) => getLinearPriorityLabel(p)).join(', ')
+    })
+  }
+  if (canonical.assignee?.kind === 'unassigned') {
+    pills.push({
+      key: 'assignee',
+      label: translate(
+        'auto.components.linear-issue-attribute-filter-sections.assignee',
+        'Assignee'
+      ),
+      value: translate(
+        'auto.components.linear-issue-attribute-filter-sections.unassigned',
+        'Unassigned'
+      )
+    })
+  } else if (canonical.assignee?.kind === 'user') {
+    pills.push({
+      key: 'assignee',
+      label: translate(
+        'auto.components.linear-issue-attribute-filter-sections.assignee',
+        'Assignee'
+      ),
+      value: options.memberNamesById.get(canonical.assignee.id) ?? canonical.assignee.id
+    })
+  }
+  if (canonical.labelIds.length > 0) {
+    pills.push({
+      key: 'labels',
+      label: translate('auto.components.linear-issue-attribute-filter-sections.labels', 'Labels'),
+      value: canonical.labelIds.map((id) => options.labelNamesById.get(id) ?? id).join(', ')
+    })
+  }
+  return pills
+}
+
+function priorityOptions(): PickerOption[] {
+  return [0, 1, 2, 3, 4].map((priority) => ({
+    key: String(priority),
+    primary: getLinearPriorityLabel(priority)
+  }))
+}
+
+export function LinearIssueFilterSectionMenu({
+  value,
+  onOpenSection
+}: {
+  value: LinearIssueAttributeFilter
+  onOpenSection: (section: LinearIssueFilterSectionKey) => void
+}): React.JSX.Element {
+  const sections: { key: LinearIssueFilterSectionKey; label: string; summary: string }[] = [
+    {
+      key: 'status',
+      label: translate('auto.components.linear-issue-attribute-filter-sections.status', 'Status'),
+      summary:
+        value.stateIds.length > 0
+          ? translate(
+              'auto.components.linear-issue-attribute-filter-sections.countSelected',
+              '{{count}} selected',
+              { count: value.stateIds.length }
+            )
+          : ''
+    },
+    {
+      key: 'priority',
+      label: translate(
+        'auto.components.linear-issue-attribute-filter-sections.priority',
+        'Priority'
+      ),
+      summary:
+        value.priorities.length > 0
+          ? translate(
+              'auto.components.linear-issue-attribute-filter-sections.countSelected',
+              '{{count}} selected',
+              { count: value.priorities.length }
+            )
+          : ''
+    },
+    {
+      key: 'assignee',
+      label: translate(
+        'auto.components.linear-issue-attribute-filter-sections.assignee',
+        'Assignee'
+      ),
+      summary: value.assignee
+        ? value.assignee.kind === 'unassigned'
+          ? translate(
+              'auto.components.linear-issue-attribute-filter-sections.unassigned',
+              'Unassigned'
+            )
+          : translate('auto.components.linear-issue-attribute-filter-sections.selected', 'selected')
+        : ''
+    },
+    {
+      key: 'labels',
+      label: translate('auto.components.linear-issue-attribute-filter-sections.labels', 'Labels'),
+      summary:
+        value.labelIds.length > 0
+          ? translate(
+              'auto.components.linear-issue-attribute-filter-sections.countSelected',
+              '{{count}} selected',
+              { count: value.labelIds.length }
+            )
+          : ''
+    }
+  ]
+
+  return (
+    <div className="py-1 text-xs">
+      {sections.map((section) => (
+        <button
+          key={section.key}
+          type="button"
+          onClick={() => onOpenSection(section.key)}
+          className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50"
+        >
+          <span className="font-medium">{section.label}</span>
+          <span className="inline-flex items-center gap-1 text-muted-foreground">
+            {section.summary ? (
+              <span className="max-w-[120px] truncate">{section.summary}</span>
+            ) : null}
+            <ChevronRight className="size-3.5" />
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function LinearIssueFilterSectionDetail({
+  section,
+  value,
+  onChange,
+  statusOptions,
+  assigneeOptions,
+  labelOptions,
+  statusLoading,
+  statusError,
+  assigneeLoading,
+  assigneeError,
+  labelLoading,
+  labelError,
+  teamRequiredMessage,
+  onBack
+}: {
+  section: LinearIssueFilterSectionKey
+  value: LinearIssueAttributeFilter
+  onChange: (next: LinearIssueAttributeFilter) => void
+  statusOptions: PickerOption[]
+  assigneeOptions: PickerOption[]
+  labelOptions: PickerOption[]
+  statusLoading: boolean
+  statusError: string | null
+  assigneeLoading: boolean
+  assigneeError: string | null
+  labelLoading: boolean
+  labelError: string | null
+  teamRequiredMessage: string | null
+  onBack: () => void
+}): React.JSX.Element {
+  if (section === 'priority') {
+    return (
+      <div>
+        <SectionBack onBack={onBack} />
+        <MultiSelectList
+          options={priorityOptions()}
+          selected={value.priorities.map(String)}
+          loading={false}
+          error={null}
+          searchPlaceholder={translate(
+            'auto.components.linear-issue-attribute-filter-sections.searchPriority',
+            'Filter priority…'
+          )}
+          onChange={(keys) =>
+            onChange({
+              ...value,
+              priorities: keys
+                .map((key) => Number.parseInt(key, 10))
+                .filter((n) => Number.isInteger(n) && n >= 0 && n <= 4)
+            })
+          }
+        />
+      </div>
+    )
+  }
+
+  if (
+    teamRequiredMessage &&
+    (section === 'status' || section === 'labels' || section === 'assignee')
+  ) {
+    return (
+      <div>
+        <SectionBack onBack={onBack} />
+        {section === 'assignee' ? (
+          <div className="px-3 py-1.5">
+            <button
+              type="button"
+              className={cn(
+                'w-full rounded-md px-2 py-1.5 text-left text-xs transition hover:bg-muted/50',
+                value.assignee?.kind === 'unassigned' && 'bg-muted/40 font-medium'
+              )}
+              onClick={() =>
+                onChange({
+                  ...value,
+                  assignee: value.assignee?.kind === 'unassigned' ? null : { kind: 'unassigned' }
+                })
+              }
+            >
+              {translate(
+                'auto.components.linear-issue-attribute-filter-sections.unassigned',
+                'Unassigned'
+              )}
+            </button>
+          </div>
+        ) : null}
+        <p className="px-3 py-2 text-xs text-muted-foreground">{teamRequiredMessage}</p>
+      </div>
+    )
+  }
+
+  if (section === 'status') {
+    return (
+      <div>
+        <SectionBack onBack={onBack} />
+        <MultiSelectList
+          options={statusOptions}
+          selected={value.stateIds}
+          loading={statusLoading}
+          error={statusError}
+          searchPlaceholder={translate(
+            'auto.components.linear-issue-attribute-filter-sections.searchStatus',
+            'Filter status…'
+          )}
+          onChange={(stateIds) => onChange({ ...value, stateIds })}
+        />
+      </div>
+    )
+  }
+
+  if (section === 'labels') {
+    return (
+      <div>
+        <SectionBack onBack={onBack} />
+        <MultiSelectList
+          options={labelOptions}
+          selected={value.labelIds}
+          loading={labelLoading}
+          error={labelError}
+          searchPlaceholder={translate(
+            'auto.components.linear-issue-attribute-filter-sections.searchLabels',
+            'Filter labels…'
+          )}
+          onChange={(labelIds) => onChange({ ...value, labelIds })}
+        />
+      </div>
+    )
+  }
+
+  const activeAssignee =
+    value.assignee?.kind === 'unassigned'
+      ? '__unassigned__'
+      : value.assignee?.kind === 'user'
+        ? value.assignee.id
+        : null
+
+  return (
+    <div>
+      <SectionBack onBack={onBack} />
+      <SingleSelectList
+        options={[
+          {
+            key: '__unassigned__',
+            primary: translate(
+              'auto.components.linear-issue-attribute-filter-sections.unassigned',
+              'Unassigned'
+            )
+          },
+          ...assigneeOptions
+        ]}
+        activeValue={activeAssignee}
+        loading={assigneeLoading}
+        error={assigneeError}
+        searchPlaceholder={translate(
+          'auto.components.linear-issue-attribute-filter-sections.searchAssignee',
+          'Filter assignee…'
+        )}
+        onSelect={(key) => {
+          if (!key) {
+            onChange({ ...value, assignee: null })
+            return
+          }
+          if (key === '__unassigned__') {
+            onChange({ ...value, assignee: { kind: 'unassigned' } })
+            return
+          }
+          onChange({ ...value, assignee: { kind: 'user', id: key } })
+        }}
+      />
+    </div>
+  )
+}
+
+function SectionBack({ onBack }: { onBack: () => void }): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onBack}
+      className="flex w-full items-center gap-1 border-b border-border/50 px-3 py-1.5 text-left text-xs text-muted-foreground transition hover:bg-muted/40 hover:text-foreground"
+    >
+      {translate('auto.components.linear-issue-attribute-filter-sections.back', 'Back')}
+    </button>
+  )
+}

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -853,9 +853,10 @@ export default function SmartWorkspaceNameField({
     const trimmed = debouncedQuery.trim()
     const request = trimmed
       ? searchLinearIssues(trimmed, RESULT_LIMIT, { sourceContext: linearSourceContext })
-      : listLinearIssues('assigned', RESULT_LIMIT, { sourceContext: linearSourceContext }).then(
-          (result) => result.items
-        )
+      : listLinearIssues(
+          { kind: 'list', filter: 'assigned', limit: RESULT_LIMIT },
+          { sourceContext: linearSourceContext }
+        ).then((result) => result.items)
     void request
       .then((issues) => {
         if (!stale) {

--- a/src/renderer/src/components/task-page-linear-issue-empty-state.test.ts
+++ b/src/renderer/src/components/task-page-linear-issue-empty-state.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveLinearIssueEmptyKind,
+  shouldOfferLinearIssueFetchMore
+} from './task-page-linear-issue-empty-state'
+import { emptyLinearIssueAttributeFilter } from '../../../shared/linear-issue-attribute-filter'
+
+describe('task-page-linear-issue-empty-state', () => {
+  it('prefers context, then search, then server filter, then client team, then unfiltered', () => {
+    expect(
+      resolveLinearIssueEmptyKind({
+        hasContextLabel: true,
+        searchActive: true,
+        attributeFilter: emptyLinearIssueAttributeFilter(),
+        serverIssueCount: 0,
+        filteredIssueCount: 0
+      })
+    ).toBe('context')
+
+    expect(
+      resolveLinearIssueEmptyKind({
+        hasContextLabel: false,
+        searchActive: true,
+        attributeFilter: {
+          stateIds: ['s'],
+          priorities: [],
+          assignee: null,
+          labelIds: []
+        },
+        serverIssueCount: 0,
+        filteredIssueCount: 0
+      })
+    ).toBe('search')
+
+    expect(
+      resolveLinearIssueEmptyKind({
+        hasContextLabel: false,
+        searchActive: false,
+        attributeFilter: {
+          stateIds: ['s'],
+          priorities: [],
+          assignee: null,
+          labelIds: []
+        },
+        serverIssueCount: 0,
+        filteredIssueCount: 0
+      })
+    ).toBe('server-attribute-filter')
+
+    expect(
+      resolveLinearIssueEmptyKind({
+        hasContextLabel: false,
+        searchActive: false,
+        attributeFilter: emptyLinearIssueAttributeFilter(),
+        serverIssueCount: 3,
+        filteredIssueCount: 0
+      })
+    ).toBe('client-team')
+
+    expect(
+      resolveLinearIssueEmptyKind({
+        hasContextLabel: false,
+        searchActive: false,
+        attributeFilter: emptyLinearIssueAttributeFilter(),
+        serverIssueCount: 0,
+        filteredIssueCount: 0
+      })
+    ).toBe('unfiltered-scope')
+  })
+
+  it('offers fetch more only for client-team thinning with server hasMore', () => {
+    expect(shouldOfferLinearIssueFetchMore({ emptyKind: 'client-team', serverHasMore: true })).toBe(
+      true
+    )
+    expect(
+      shouldOfferLinearIssueFetchMore({
+        emptyKind: 'server-attribute-filter',
+        serverHasMore: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/task-page-linear-issue-empty-state.ts
+++ b/src/renderer/src/components/task-page-linear-issue-empty-state.ts
@@ -1,0 +1,46 @@
+import {
+  isEmptyLinearIssueAttributeFilter,
+  type LinearIssueAttributeFilter
+} from '../../../shared/linear-issue-attribute-filter'
+
+export type LinearIssueEmptyKind =
+  | 'context'
+  | 'search'
+  | 'server-attribute-filter'
+  | 'client-team'
+  | 'unfiltered-scope'
+  | null
+
+export function resolveLinearIssueEmptyKind(options: {
+  hasContextLabel: boolean
+  searchActive: boolean
+  attributeFilter: LinearIssueAttributeFilter
+  serverIssueCount: number
+  filteredIssueCount: number
+}): LinearIssueEmptyKind {
+  if (options.serverIssueCount > 0 && options.filteredIssueCount === 0) {
+    return 'client-team'
+  }
+  if (options.serverIssueCount > 0) {
+    return null
+  }
+  if (options.hasContextLabel) {
+    return 'context'
+  }
+  if (options.searchActive) {
+    return 'search'
+  }
+  if (!isEmptyLinearIssueAttributeFilter(options.attributeFilter)) {
+    return 'server-attribute-filter'
+  }
+  return 'unfiltered-scope'
+}
+
+export function shouldOfferLinearIssueFetchMore(options: {
+  emptyKind: LinearIssueEmptyKind
+  serverHasMore: boolean
+}): boolean {
+  // Why: Fetch more is only honest for client-team thinning of a larger server
+  // window. Server-filtered empties must not invite more pages of the same empty set.
+  return options.emptyKind === 'client-team' && options.serverHasMore
+}

--- a/src/renderer/src/components/task-page-linear-issue-request.test.ts
+++ b/src/renderer/src/components/task-page-linear-issue-request.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLinearIssueListReadArgs,
+  buildLinearIssueListRequestSignature,
+  isLinearIssueSearchActive,
+  shouldForceLinearIssueListRead,
+  teamDerivedFacetsForPrimaryTeamChange
+} from './task-page-linear-issue-request'
+import type { LinearIssueAttributeFilter } from '../../../shared/linear-issue-attribute-filter'
+
+const filter: LinearIssueAttributeFilter = {
+  stateIds: ['s1'],
+  priorities: [1],
+  assignee: { kind: 'unassigned' },
+  labelIds: ['l1']
+}
+
+describe('task-page-linear-issue-request', () => {
+  it('treats immediate or applied search as active', () => {
+    expect(isLinearIssueSearchActive('q', '')).toBe(true)
+    expect(isLinearIssueSearchActive('', 'q')).toBe(true)
+    expect(isLinearIssueSearchActive('  ', '  ')).toBe(false)
+  })
+
+  it('omits attribute filters from list read args while search is active', () => {
+    expect(
+      buildLinearIssueListReadArgs({
+        limit: 36,
+        attributeFilter: filter,
+        searchActive: true
+      }).attributeFilter
+    ).toBeUndefined()
+    expect(
+      buildLinearIssueListReadArgs({
+        limit: 36,
+        attributeFilter: filter,
+        searchActive: false
+      }).attributeFilter
+    ).toEqual(filter)
+  })
+
+  it('includes source scope and canonical signature in the request identity', () => {
+    const signature = buildLinearIssueListRequestSignature({
+      workspaceId: 'ws-1',
+      limit: 36,
+      attributeFilter: filter
+    })
+    expect(signature).toContain('local::ws-1::list::all::36::')
+    expect(signature).toContain('"stateIds":["s1"]')
+  })
+
+  it('forces a read when the filter signature changes', () => {
+    expect(
+      shouldForceLinearIssueListRead({
+        previousFilterSignature: 'a',
+        nextFilterSignature: 'b',
+        refreshForced: false
+      })
+    ).toBe(true)
+    expect(
+      shouldForceLinearIssueListRead({
+        previousFilterSignature: 'a',
+        nextFilterSignature: 'a',
+        refreshForced: false
+      })
+    ).toBe(false)
+  })
+
+  it('clears team-derived facets while preserving priority', () => {
+    expect(teamDerivedFacetsForPrimaryTeamChange(filter)).toEqual({
+      stateIds: [],
+      priorities: [1],
+      assignee: null,
+      labelIds: []
+    })
+  })
+})

--- a/src/renderer/src/components/task-page-linear-issue-request.ts
+++ b/src/renderer/src/components/task-page-linear-issue-request.ts
@@ -1,0 +1,80 @@
+import {
+  isEmptyLinearIssueAttributeFilter,
+  linearIssueAttributeFilterSignature,
+  type LinearIssueAttributeFilter
+} from '../../../shared/linear-issue-attribute-filter'
+import {
+  getTaskSourceCacheScope,
+  type TaskSourceContext
+} from '../../../shared/task-source-context'
+import type { LinearIssueListReadArgs } from '../store/slices/linear'
+
+export function isLinearIssueSearchActive(immediateQuery: string, appliedQuery: string): boolean {
+  return immediateQuery.trim().length > 0 || appliedQuery.trim().length > 0
+}
+
+export function buildLinearIssueListReadArgs(options: {
+  filter?: 'assigned' | 'created' | 'all' | 'completed'
+  limit: number
+  attributeFilter: LinearIssueAttributeFilter
+  searchActive: boolean
+  /** Concrete workspace only; `all` must never send workspace-scoped facet ids. */
+  allowAttributeFilter?: boolean
+}): LinearIssueListReadArgs {
+  const attributeFilter =
+    options.searchActive ||
+    options.allowAttributeFilter === false ||
+    isEmptyLinearIssueAttributeFilter(options.attributeFilter)
+      ? undefined
+      : options.attributeFilter
+  return {
+    kind: 'list',
+    filter: options.filter ?? 'all',
+    limit: options.limit,
+    attributeFilter
+  }
+}
+
+export function buildLinearIssueListRequestSignature(options: {
+  sourceContext?: TaskSourceContext | null
+  workspaceId: string | null | undefined
+  filter?: 'assigned' | 'created' | 'all' | 'completed'
+  limit: number
+  attributeFilter: LinearIssueAttributeFilter
+  searchQuery?: string
+}): string {
+  const sourceScope = options.sourceContext
+    ? getTaskSourceCacheScope(options.sourceContext)
+    : 'local'
+  const workspace = options.workspaceId ?? 'default'
+  if (options.searchQuery && options.searchQuery.trim().length > 0) {
+    return `${sourceScope}::${workspace}::search::${options.searchQuery.trim()}`
+  }
+  const signature = linearIssueAttributeFilterSignature(options.attributeFilter)
+  return `${sourceScope}::${workspace}::list::${options.filter ?? 'all'}::${options.limit}::${signature}`
+}
+
+export function shouldForceLinearIssueListRead(options: {
+  previousFilterSignature: string
+  nextFilterSignature: string
+  refreshForced: boolean
+}): boolean {
+  if (options.refreshForced) {
+    return true
+  }
+  // Why: filter signature changes always need a current server read, even when
+  // returning to a previously cached signature that is still warm.
+  return options.previousFilterSignature !== options.nextFilterSignature
+}
+
+export function teamDerivedFacetsForPrimaryTeamChange(
+  current: LinearIssueAttributeFilter
+): LinearIssueAttributeFilter {
+  // Why: status/assignee/labels are team-scoped ids; priority is global 0..4.
+  return {
+    stateIds: [],
+    priorities: current.priorities,
+    assignee: null,
+    labelIds: []
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1731,7 +1731,10 @@
         "searchIssues": "Search issues",
         "useIssueNumber": "Use issue #{{value0}}",
         "noMatchingIssuesLoaded": "No matching issues loaded.",
-        "editReviewersWithCurrent": "Edit reviewers: {{value0}}"
+        "editReviewersWithCurrent": "Edit reviewers: {{value0}}",
+        "linearEmptyAttributeFilter": "No issues match the selected filters. Clear a filter or try different criteria.",
+        "linearEmptyUnfilteredScope": "No issues in this workspace scope. Try searching or adjusting teams.",
+        "linearFetchMore": "Fetch more"
       },
       "Terminal": {
         "73768427cf": "Close",
@@ -12754,6 +12757,29 @@
             }
           }
         }
+      },
+      "linear-issue-attribute-filter-dropdowns": {
+        "removeFilter": "Remove {{value0}} filter",
+        "teamRequired": "Select a team to load status, assignees, and labels for this workspace.",
+        "filters": "Filters",
+        "allWorkspacesTitle": "Select one workspace",
+        "allWorkspacesBody": "Status, assignee, and label filters use ids from a single Linear workspace. Choose one workspace to filter by those attributes.",
+        "optionsFromTeam": "Options from {{team}}",
+        "clearAll": "Clear all filters"
+      },
+      "linear-issue-attribute-filter-sections": {
+        "status": "Status",
+        "priority": "Priority",
+        "assignee": "Assignee",
+        "unassigned": "Unassigned",
+        "labels": "Labels",
+        "countSelected": "{{count}} selected",
+        "selected": "selected",
+        "searchPriority": "Filter priority…",
+        "searchStatus": "Filter status…",
+        "searchLabels": "Filter labels…",
+        "searchAssignee": "Filter assignee…",
+        "back": "Back"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1731,7 +1731,10 @@
         "searchIssues": "Buscar issues",
         "useIssueNumber": "Usar issue #{{value0}}",
         "noMatchingIssuesLoaded": "No se cargaron issues coincidentes.",
-        "editReviewersWithCurrent": "Editar revisores: {{value0}}"
+        "editReviewersWithCurrent": "Editar revisores: {{value0}}",
+        "linearEmptyAttributeFilter": "No issues match the selected filters. Clear a filter or try different criteria.",
+        "linearEmptyUnfilteredScope": "No issues in this workspace scope. Try searching or adjusting teams.",
+        "linearFetchMore": "Fetch more"
       },
       "Terminal": {
         "73768427cf": "Cerrar",
@@ -12754,6 +12757,29 @@
             }
           }
         }
+      },
+      "linear-issue-attribute-filter-dropdowns": {
+        "removeFilter": "Remove {{value0}} filter",
+        "teamRequired": "Select a team to load status, assignees, and labels for this workspace.",
+        "filters": "Filters",
+        "allWorkspacesTitle": "Select one workspace",
+        "allWorkspacesBody": "Status, assignee, and label filters use ids from a single Linear workspace. Choose one workspace to filter by those attributes.",
+        "optionsFromTeam": "Options from {{team}}",
+        "clearAll": "Clear all filters"
+      },
+      "linear-issue-attribute-filter-sections": {
+        "status": "Status",
+        "priority": "Priority",
+        "assignee": "Assignee",
+        "unassigned": "Unassigned",
+        "labels": "Labels",
+        "countSelected": "{{count}} selected",
+        "selected": "selected",
+        "searchPriority": "Filter priority…",
+        "searchStatus": "Filter status…",
+        "searchLabels": "Filter labels…",
+        "searchAssignee": "Filter assignee…",
+        "back": "Back"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1731,7 +1731,10 @@
         "searchIssues": "Issue を検索",
         "useIssueNumber": "Issue #{{value0}} を使用",
         "noMatchingIssuesLoaded": "一致する issue は読み込まれていません。",
-        "editReviewersWithCurrent": "レビュアーを編集: {{value0}}"
+        "editReviewersWithCurrent": "レビュアーを編集: {{value0}}",
+        "linearEmptyAttributeFilter": "No issues match the selected filters. Clear a filter or try different criteria.",
+        "linearEmptyUnfilteredScope": "No issues in this workspace scope. Try searching or adjusting teams.",
+        "linearFetchMore": "Fetch more"
       },
       "Terminal": {
         "73768427cf": "閉じる",
@@ -12754,6 +12757,29 @@
             }
           }
         }
+      },
+      "linear-issue-attribute-filter-dropdowns": {
+        "removeFilter": "Remove {{value0}} filter",
+        "teamRequired": "Select a team to load status, assignees, and labels for this workspace.",
+        "filters": "Filters",
+        "allWorkspacesTitle": "Select one workspace",
+        "allWorkspacesBody": "Status, assignee, and label filters use ids from a single Linear workspace. Choose one workspace to filter by those attributes.",
+        "optionsFromTeam": "Options from {{team}}",
+        "clearAll": "Clear all filters"
+      },
+      "linear-issue-attribute-filter-sections": {
+        "status": "Status",
+        "priority": "Priority",
+        "assignee": "Assignee",
+        "unassigned": "Unassigned",
+        "labels": "Labels",
+        "countSelected": "{{count}} selected",
+        "selected": "selected",
+        "searchPriority": "Filter priority…",
+        "searchStatus": "Filter status…",
+        "searchLabels": "Filter labels…",
+        "searchAssignee": "Filter assignee…",
+        "back": "Back"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1731,7 +1731,10 @@
         "searchIssues": "이슈 검색",
         "useIssueNumber": "이슈 #{{value0}} 사용",
         "noMatchingIssuesLoaded": "일치하는 이슈를 불러오지 않았습니다.",
-        "editReviewersWithCurrent": "리뷰어 편집: {{value0}}"
+        "editReviewersWithCurrent": "리뷰어 편집: {{value0}}",
+        "linearEmptyAttributeFilter": "No issues match the selected filters. Clear a filter or try different criteria.",
+        "linearEmptyUnfilteredScope": "No issues in this workspace scope. Try searching or adjusting teams.",
+        "linearFetchMore": "Fetch more"
       },
       "Terminal": {
         "73768427cf": "닫기",
@@ -12754,6 +12757,29 @@
             }
           }
         }
+      },
+      "linear-issue-attribute-filter-dropdowns": {
+        "removeFilter": "Remove {{value0}} filter",
+        "teamRequired": "Select a team to load status, assignees, and labels for this workspace.",
+        "filters": "Filters",
+        "allWorkspacesTitle": "Select one workspace",
+        "allWorkspacesBody": "Status, assignee, and label filters use ids from a single Linear workspace. Choose one workspace to filter by those attributes.",
+        "optionsFromTeam": "Options from {{team}}",
+        "clearAll": "Clear all filters"
+      },
+      "linear-issue-attribute-filter-sections": {
+        "status": "Status",
+        "priority": "Priority",
+        "assignee": "Assignee",
+        "unassigned": "Unassigned",
+        "labels": "Labels",
+        "countSelected": "{{count}} selected",
+        "selected": "selected",
+        "searchPriority": "Filter priority…",
+        "searchStatus": "Filter status…",
+        "searchLabels": "Filter labels…",
+        "searchAssignee": "Filter assignee…",
+        "back": "Back"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1731,7 +1731,10 @@
         "searchIssues": "搜索议题",
         "useIssueNumber": "使用议题 #{{value0}}",
         "noMatchingIssuesLoaded": "没有加载到匹配的议题。",
-        "editReviewersWithCurrent": "编辑评审人：{{value0}}"
+        "editReviewersWithCurrent": "编辑评审人：{{value0}}",
+        "linearEmptyAttributeFilter": "No issues match the selected filters. Clear a filter or try different criteria.",
+        "linearEmptyUnfilteredScope": "No issues in this workspace scope. Try searching or adjusting teams.",
+        "linearFetchMore": "Fetch more"
       },
       "Terminal": {
         "73768427cf": "关闭",
@@ -12754,6 +12757,29 @@
             }
           }
         }
+      },
+      "linear-issue-attribute-filter-dropdowns": {
+        "removeFilter": "Remove {{value0}} filter",
+        "teamRequired": "Select a team to load status, assignees, and labels for this workspace.",
+        "filters": "Filters",
+        "allWorkspacesTitle": "Select one workspace",
+        "allWorkspacesBody": "Status, assignee, and label filters use ids from a single Linear workspace. Choose one workspace to filter by those attributes.",
+        "optionsFromTeam": "Options from {{team}}",
+        "clearAll": "Clear all filters"
+      },
+      "linear-issue-attribute-filter-sections": {
+        "status": "Status",
+        "priority": "Priority",
+        "assignee": "Assignee",
+        "unassigned": "Unassigned",
+        "labels": "Labels",
+        "countSelected": "{{count}} selected",
+        "selected": "selected",
+        "searchPriority": "Filter priority…",
+        "searchStatus": "Filter status…",
+        "searchLabels": "Filter labels…",
+        "searchAssignee": "Filter assignee…",
+        "back": "Back"
       }
     },
     "i18n": {

--- a/src/renderer/src/runtime/runtime-linear-client.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.ts
@@ -25,6 +25,11 @@ import {
   type TaskSourceContext
 } from '../../../shared/task-source-context'
 import { isRuntimeProviderSearchQueryWithinLimit } from './runtime-provider-search-bounds'
+import type { LinearIssueAttributeFilter } from '../../../shared/linear-issue-attribute-filter'
+import {
+  canonicalizeLinearIssueAttributeFilter,
+  isEmptyLinearIssueAttributeFilter
+} from '../../../shared/linear-issue-attribute-filter'
 
 export type RuntimeLinearSettings =
   | Pick<GlobalSettings, 'activeRuntimeEnvironmentId'>
@@ -189,22 +194,26 @@ export async function linearListIssues(
   settings: RuntimeLinearSettings,
   filter?: LinearIssueFilter,
   limit?: number,
-  workspaceId?: LinearWorkspaceSelection | null
+  workspaceId?: LinearWorkspaceSelection | null,
+  attributeFilter?: LinearIssueAttributeFilter | null
 ): Promise<LinearCollectionResult<LinearIssue>> {
   const target = getLinearRuntimeTarget(settings)
+  const canonicalAttributeFilter =
+    attributeFilter && !isEmptyLinearIssueAttributeFilter(attributeFilter)
+      ? canonicalizeLinearIssueAttributeFilter(attributeFilter)
+      : undefined
+  const payload = {
+    filter,
+    limit,
+    workspaceId: workspaceId ?? undefined,
+    ...(canonicalAttributeFilter ? { attributeFilter: canonicalAttributeFilter } : {})
+  }
   const result =
     target.kind === 'environment'
-      ? await callRuntimeRpc<unknown>(
-          target,
-          'linear.listIssues',
-          { filter, limit, workspaceId: workspaceId ?? undefined },
-          { timeoutMs: 30_000 }
-        )
-      : await window.api.linear.listIssues({
-          filter,
-          limit,
-          workspaceId: workspaceId ?? undefined
+      ? await callRuntimeRpc<unknown>(target, 'linear.listIssues', payload, {
+          timeoutMs: 30_000
         })
+      : await window.api.linear.listIssues(payload)
   return normalizeLinearIssueCollectionResult(result)
 }
 

--- a/src/renderer/src/store/slices/linear-invalidation.test.ts
+++ b/src/renderer/src/store/slices/linear-invalidation.test.ts
@@ -104,7 +104,7 @@ describe('createLinearSlice invalidation', () => {
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
       linearListCache: {
-        'workspace-1::list::all::36': { data: { items: [issue('LIST')] }, fetchedAt: Date.now() }
+        'workspace-1::list::all::36::': { data: { items: [issue('LIST')] }, fetchedAt: Date.now() }
       }
     })
     linearSearchIssues.mockResolvedValueOnce([issue('SEARCH')])
@@ -161,7 +161,7 @@ describe('createLinearSlice invalidation', () => {
         'workspace-1::search::issue::20': { data: [issue('issue-id')], fetchedAt: Date.now() }
       },
       linearListCache: {
-        'workspace-1::list::all::36': {
+        'workspace-1::list::all::36::': {
           data: { items: [issue('issue-id')], hasMore: false },
           fetchedAt: Date.now()
         }
@@ -197,7 +197,7 @@ describe('createLinearSlice invalidation', () => {
         'workspace-1::issue-1': { data: issue('issue-1'), fetchedAt: Date.now() }
       },
       linearListCache: {
-        'workspace-1::list::all::36': {
+        'workspace-1::list::all::36::': {
           data: { items: [issue('LIN-CACHED')] },
           fetchedAt: Date.now()
         }
@@ -259,7 +259,7 @@ describe('createLinearSlice invalidation', () => {
     store.setState({
       linearStatus: status('workspace-1', 'Old Org'),
       linearListCache: {
-        'workspace-1::list::all::36': {
+        'workspace-1::list::all::36::': {
           data: { items: [issue('LIN-CACHED')] },
           fetchedAt: Date.now()
         }
@@ -306,7 +306,9 @@ describe('createLinearSlice invalidation', () => {
     linearListIssues.mockRejectedValueOnce(new Error('401 unauthorized'))
     linearStatus.mockResolvedValueOnce(status('workspace-2', 'Beta'))
 
-    await expect(store.getState().listLinearIssues('all', 36, { force: true })).resolves.toEqual({
+    await expect(
+      store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 }, { force: true })
+    ).resolves.toEqual({
       items: []
     })
     expect(store.getState().linearStatus.connected).toBe(true)

--- a/src/renderer/src/store/slices/linear.test.ts
+++ b/src/renderer/src/store/slices/linear.test.ts
@@ -130,17 +130,71 @@ describe('createLinearSlice caching', () => {
       .mockResolvedValueOnce({ items: [issue('LIN-1')] })
       .mockResolvedValueOnce({ items: [issue('LIN-2')] })
 
-    await expect(store.getState().listLinearIssues('all', 36)).resolves.toMatchObject({
-      items: [{ id: 'LIN-1' }]
-    })
-    await expect(store.getState().listLinearIssues('all', 36)).resolves.toMatchObject({
+    await expect(
+      store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
+    ).resolves.toMatchObject({
       items: [{ id: 'LIN-1' }]
     })
     await expect(
-      store.getState().listLinearIssues('all', 36, { force: true })
+      store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
+    ).resolves.toMatchObject({
+      items: [{ id: 'LIN-1' }]
+    })
+    await expect(
+      store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 }, { force: true })
     ).resolves.toMatchObject({ items: [{ id: 'LIN-2' }] })
 
     expect(linearListIssues).toHaveBeenCalledTimes(2)
+  })
+
+  it('isolates list cache entries by attribute filter signature', async () => {
+    const store = createTestStore()
+    store.setState({
+      linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' }
+    })
+    const filtered = {
+      stateIds: ['state-1'],
+      priorities: [1],
+      assignee: null as null,
+      labelIds: [] as string[]
+    }
+    linearListIssues
+      .mockResolvedValueOnce({ items: [issue('LIN-ALL')] })
+      .mockResolvedValueOnce({ items: [issue('LIN-FILTERED')] })
+
+    await store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
+    await store.getState().listLinearIssues({
+      kind: 'list',
+      filter: 'all',
+      limit: 36,
+      attributeFilter: filtered
+    })
+
+    expect(linearListIssues).toHaveBeenCalledTimes(2)
+    expect(
+      store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
+    ).toMatchObject({ items: [{ id: 'LIN-ALL' }] })
+    expect(
+      store.getState().getCachedLinearIssues({
+        kind: 'list',
+        filter: 'all',
+        limit: 36,
+        attributeFilter: filtered
+      })
+    ).toMatchObject({ items: [{ id: 'LIN-FILTERED' }] })
+
+    store.getState().invalidateLinearIssueLists()
+    expect(
+      store.getState().getCachedLinearIssues({
+        kind: 'list',
+        filter: 'all',
+        limit: 36,
+        attributeFilter: filtered
+      })
+    ).toBeNull()
+    expect(
+      store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
+    ).toMatchObject({ items: [{ id: 'LIN-ALL' }] })
   })
 
   it('lets forced list refresh bypass older in-flight reads without stale cache overwrite', async () => {
@@ -154,8 +208,12 @@ describe('createLinearSlice caching', () => {
       .mockReturnValueOnce(staleRequest.promise)
       .mockReturnValueOnce(forcedRequest.promise)
 
-    const stalePromise = store.getState().listLinearIssues('all', 36)
-    const forcedPromise = store.getState().listLinearIssues('all', 36, { force: true })
+    const stalePromise = store
+      .getState()
+      .listLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
+    const forcedPromise = store
+      .getState()
+      .listLinearIssues({ kind: 'list', filter: 'all', limit: 36 }, { force: true })
 
     expect(linearListIssues).toHaveBeenCalledTimes(2)
 
@@ -206,13 +264,13 @@ describe('createLinearSlice caching', () => {
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
       linearListCache: {
-        'workspace-1::list::all::36': { data: { items: [issue('LIN-CACHED')] }, fetchedAt: 1 }
+        'workspace-1::list::all::36::': { data: { items: [issue('LIN-CACHED')] }, fetchedAt: 1 }
       }
     })
     linearListIssues.mockRejectedValueOnce(new Error('network down'))
 
     await expect(
-      store.getState().listLinearIssues('all', 36, { force: true })
+      store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 }, { force: true })
     ).resolves.toMatchObject({ items: [{ id: 'LIN-CACHED' }] })
   })
 
@@ -222,7 +280,7 @@ describe('createLinearSlice caching', () => {
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
       linearListCache: {
-        'workspace-1::list::all::36': { data: { items: [issue('LIN-CACHED')] }, fetchedAt: 1 }
+        'workspace-1::list::all::36::': { data: { items: [issue('LIN-CACHED')] }, fetchedAt: 1 }
       }
     })
     linearStatus.mockResolvedValue({
@@ -233,7 +291,7 @@ describe('createLinearSlice caching', () => {
     linearListIssues.mockRejectedValueOnce(error)
 
     await expect(
-      store.getState().listLinearIssues('all', 36, { force: true })
+      store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 }, { force: true })
     ).resolves.toMatchObject({ items: [] })
     expect(linearStatus).toHaveBeenCalled()
   })
@@ -274,7 +332,7 @@ describe('createLinearSlice caching', () => {
     })
 
     await expect(
-      store.getState().listLinearIssues('all', 36, { force: true })
+      store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 }, { force: true })
     ).resolves.toMatchObject({ items: [{ id: 'LIN-OK' }] })
     await vi.waitFor(() => {
       expect(store.getState().linearStatus.credentialError).toBeUndefined()
@@ -725,7 +783,7 @@ describe('createLinearSlice caching', () => {
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
       linearListCache: {
-        'workspace-1::list::all::36': { data: { items: [issue('LIN-1')] }, fetchedAt: 1 }
+        'workspace-1::list::all::36::': { data: { items: [issue('LIN-1')] }, fetchedAt: 1 }
       }
     })
 
@@ -739,7 +797,7 @@ describe('createLinearSlice caching', () => {
     store.setState({
       linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
       linearListCache: {
-        'workspace-1::list::all::36': { data: { items: [issue('LIST')] }, fetchedAt: Date.now() }
+        'workspace-1::list::all::36::': { data: { items: [issue('LIST')] }, fetchedAt: Date.now() }
       }
     })
     linearSearchIssues.mockResolvedValueOnce([issue('SEARCH')])
@@ -781,12 +839,20 @@ describe('createLinearSlice caching', () => {
     const sourceResult = deferred<LinearCollectionResult<LinearIssue>>()
     linearListIssues.mockReturnValueOnce(sourceResult.promise)
 
-    const request = store.getState().listLinearIssues('all', 36, { sourceContext })
+    const request = store
+      .getState()
+      .listLinearIssues({ kind: 'list', filter: 'all', limit: 36 }, { sourceContext })
     store.setState({ settings: { activeRuntimeEnvironmentId: 'focused-runtime' } as never })
 
     sourceResult.resolve({ items: [issue('LIN-SOURCE')] })
     await expect(request).resolves.toMatchObject({ items: [{ id: 'LIN-SOURCE' }] })
-    expect(linearListIssues).toHaveBeenCalledWith(sourceContext, 'all', 36, 'workspace-1')
+    expect(linearListIssues).toHaveBeenCalledWith(
+      sourceContext,
+      'all',
+      36,
+      'workspace-1',
+      undefined
+    )
     expect(
       store
         .getState()
@@ -860,7 +926,7 @@ describe('createLinearSlice caching', () => {
         'workspace-1::issue-id': { data: issue('issue-id'), fetchedAt: Date.now() }
       },
       linearListCache: {
-        'workspace-1::list::all::36': {
+        'workspace-1::list::all::36::': {
           data: { items: [issue('issue-id')] },
           fetchedAt: Date.now()
         }
@@ -884,7 +950,7 @@ describe('createLinearSlice caching', () => {
     expect(store.getState().linearIssueCache['workspace-1::issue-id'].data?.title).toBe('Updated')
     expect(store.getState().linearIssueCache['workspace-1::issue-id'].fetchedAt).toBe(0)
     expect(
-      store.getState().linearListCache['workspace-1::list::all::36'].data?.items[0]?.title
+      store.getState().linearListCache['workspace-1::list::all::36::'].data?.items[0]?.title
     ).toBe('Updated')
     expect(
       store.getState().linearProjectIssueCache['workspace-1::project-issues::project-1::20'].data
@@ -1065,9 +1131,13 @@ describe('createLinearSlice', () => {
     const store = createTestStore()
     store.setState({ linearStatus: { connected: true, viewer: null } })
 
-    const localRequest = store.getState().listLinearIssues('assigned', 20)
+    const localRequest = store
+      .getState()
+      .listLinearIssues({ kind: 'list', filter: 'assigned', limit: 20 })
     store.setState({ settings: { activeRuntimeEnvironmentId: 'runtime-1' } as never })
-    const remoteRequest = store.getState().listLinearIssues('assigned', 20)
+    const remoteRequest = store
+      .getState()
+      .listLinearIssues({ kind: 'list', filter: 'assigned', limit: 20 })
 
     remoteList.resolve({ items: [issue('LIN-REMOTE')] })
     await remoteRequest

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -47,6 +47,12 @@ import {
   getTaskSourceRuntimeSettings,
   type TaskSourceContext
 } from '../../../../shared/task-source-context'
+import {
+  canonicalizeLinearIssueAttributeFilter,
+  isEmptyLinearIssueAttributeFilter,
+  linearIssueAttributeFilterSignature,
+  type LinearIssueAttributeFilter
+} from '../../../../shared/linear-issue-attribute-filter'
 
 const CACHE_TTL = 60_000 // 60s — same as GitHub work-items revalidation TTL
 const TEAM_CACHE_TTL = 10 * 60_000 // Teams change rarely and block visible Linear rows.
@@ -194,9 +200,19 @@ function linearSearchCacheKey(
 function linearListCacheKey(
   workspaceId: LinearWorkspaceSelection | null | undefined,
   filter: 'assigned' | 'created' | 'all' | 'completed',
-  limit: number
+  limit: number,
+  attributeFilter?: LinearIssueAttributeFilter | null
 ): string {
-  return `${workspaceId ?? 'default'}::list::${filter}::${limit}`
+  const attributeSignature = linearIssueAttributeFilterSignature(attributeFilter)
+  return `${workspaceId ?? 'default'}::list::${filter}::${limit}::${attributeSignature}`
+}
+
+// Why: facet mutations need one source-scoped token TaskPage can observe without
+// scattering membership guesses through board/detail components.
+const LINEAR_LIST_INVALIDATION_VERSION_CAP = 10_000
+let linearListInvalidationToken: { scope: string; version: number } = {
+  scope: '',
+  version: 0
 }
 
 function linearTeamsCacheKey(workspaceId: LinearWorkspaceSelection | null | undefined): string {
@@ -355,12 +371,28 @@ function patchLinearIssueCollectionCache(
   return { cache: nextCache, changed }
 }
 
-type LinearIssueReadArgs =
+export type LinearIssueListReadArgs = {
+  kind: 'list'
+  filter?: 'assigned' | 'created' | 'all' | 'completed'
+  limit?: number
+  attributeFilter?: LinearIssueAttributeFilter | null
+}
+
+export type LinearIssueReadArgs =
   | { kind: 'search'; query: string; limit?: number }
-  | { kind: 'list'; filter?: 'assigned' | 'created' | 'all' | 'completed'; limit?: number }
+  | LinearIssueListReadArgs
 
 type LinearFetchOptions = { force?: boolean; sourceContext?: TaskSourceContext | null }
 type LinearPatchOptions = { sourceContext?: TaskSourceContext | null }
+
+function normalizeListAttributeFilter(
+  attributeFilter?: LinearIssueAttributeFilter | null
+): LinearIssueAttributeFilter | undefined {
+  if (!attributeFilter || isEmptyLinearIssueAttributeFilter(attributeFilter)) {
+    return undefined
+  }
+  return canonicalizeLinearIssueAttributeFilter(attributeFilter)
+}
 
 type LinearReadScope = {
   settings: AppState['settings'] | TaskSourceContext | null
@@ -475,10 +507,11 @@ export type LinearSlice = {
     options?: LinearFetchOptions
   ) => Promise<LinearIssue[]>
   listLinearIssues: (
-    filter?: 'assigned' | 'created' | 'all' | 'completed',
-    limit?: number,
+    args: LinearIssueListReadArgs,
     options?: LinearFetchOptions
   ) => Promise<LinearCollectionResult<LinearIssue>>
+  linearListInvalidationToken: { scope: string; version: number }
+  invalidateLinearIssueLists: (options?: Pick<LinearFetchOptions, 'sourceContext'>) => void
   getCachedLinearTeams: (
     workspaceId?: LinearWorkspaceSelection | null,
     options?: Pick<LinearFetchOptions, 'sourceContext'>
@@ -562,6 +595,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
   linearCustomViewDetailCache: {},
   linearCustomViewIssueCache: {},
   linearCustomViewProjectCache: {},
+  linearListInvalidationToken: linearListInvalidationToken,
 
   checkLinearConnection: async (force = false) => {
     const contextKey = getProviderRuntimeContextKey(get().settings)
@@ -994,9 +1028,10 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       return get().linearSearchCache[cacheKey]?.data ?? null
     }
     const limit = clampLinearIssueListLimit(args.limit)
+    const attributeFilter = normalizeListAttributeFilter(args.attributeFilter)
     const cacheKey = scopedLinearCacheKey(
       scope,
-      linearListCacheKey(workspaceId, args.filter ?? 'assigned', limit)
+      linearListCacheKey(workspaceId, args.filter ?? 'assigned', limit, attributeFilter)
     )
     return get().linearListCache[cacheKey]?.data ?? null
   },
@@ -1026,9 +1061,16 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       return
     }
     const limit = clampLinearIssueListLimit(args.limit)
+    const attributeFilter = normalizeListAttributeFilter(args.attributeFilter)
+    const listArgs: LinearIssueListReadArgs = {
+      kind: 'list',
+      filter: args.filter,
+      limit,
+      attributeFilter
+    }
     const cacheKey = scopedLinearCacheKey(
       scope,
-      linearListCacheKey(workspaceId, args.filter ?? 'assigned', limit)
+      linearListCacheKey(workspaceId, args.filter ?? 'assigned', limit, attributeFilter)
     )
     const inflight = inflightListRequests.get(cacheKey)
     if (
@@ -1040,7 +1082,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       return
     }
     void get()
-      .listLinearIssues(args.filter, limit, options)
+      .listLinearIssues(listArgs, options)
       .catch(() => {})
   },
 
@@ -1137,14 +1179,16 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     return promise
   },
 
-  listLinearIssues: async (filter = 'assigned', limit = 20, options) => {
+  listLinearIssues: async (args, options) => {
     const scope = getLinearReadScope(get().settings, options?.sourceContext)
     const { contextKey } = scope
     const workspaceId = getSelectedWorkspaceId(get().linearStatus)
-    const effectiveLimit = clampLinearIssueListLimit(limit)
+    const filter = args.filter ?? 'assigned'
+    const effectiveLimit = clampLinearIssueListLimit(args.limit)
+    const attributeFilter = normalizeListAttributeFilter(args.attributeFilter)
     const cacheKey = scopedLinearCacheKey(
       scope,
-      linearListCacheKey(workspaceId, filter, effectiveLimit)
+      linearListCacheKey(workspaceId, filter, effectiveLimit, attributeFilter)
     )
     const cached = get().linearListCache[cacheKey]
     if (!options?.force && isFresh(cached)) {
@@ -1168,7 +1212,8 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       scope.settings,
       filter,
       effectiveLimit,
-      workspaceId
+      workspaceId,
+      attributeFilter
     )
       .then((result) => {
         const data = result as LinearCollectionResult<LinearIssue>
@@ -2058,6 +2103,50 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     }
     inflightCustomViewProjectRequests.set(cacheKey, entry)
     return promise
+  },
+
+  invalidateLinearIssueLists: (options) => {
+    const scope = getLinearReadScope(get().settings, options?.sourceContext)
+    const tokenScope = scope.cachePrefix ?? 'local'
+    const nextVersion =
+      linearListInvalidationToken.scope === tokenScope
+        ? (linearListInvalidationToken.version + 1) % LINEAR_LIST_INVALIDATION_VERSION_CAP || 1
+        : 1
+    linearListInvalidationToken = { scope: tokenScope, version: nextVersion }
+
+    // Why: drop only attribute-filtered plain list entries in this source scope
+    // so the next TaskPage read is forced current without wiping search/unrelated
+    // collections.
+    set((s) => {
+      const nextListCache = { ...s.linearListCache }
+      let changed = false
+      for (const key of Object.keys(nextListCache)) {
+        const parts = key.split('::')
+        // Cache keys end with the attribute signature; unfiltered entries end empty.
+        const attributeSignature = parts.at(-1) ?? ''
+        if (!attributeSignature) {
+          continue
+        }
+        if (scope.cachePrefix) {
+          if (!key.startsWith(`${scope.cachePrefix}::`)) {
+            continue
+          }
+        } else if (parts[1] !== 'list') {
+          // Why: unscoped invalidation must not touch other runtimes' scoped list keys.
+          continue
+        }
+        delete nextListCache[key]
+        inflightListRequests.delete(key)
+        changed = true
+      }
+      if (!changed) {
+        return { linearListInvalidationToken: linearListInvalidationToken }
+      }
+      return {
+        linearListCache: nextListCache,
+        linearListInvalidationToken: linearListInvalidationToken
+      }
+    })
   },
 
   patchLinearIssue: (issueId, patch, options) => {

--- a/src/shared/linear-issue-attribute-filter.test.ts
+++ b/src/shared/linear-issue-attribute-filter.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EMPTY_LINEAR_ISSUE_ATTRIBUTE_FILTER,
+  canonicalizeLinearIssueAttributeFilter,
+  emptyLinearIssueAttributeFilter,
+  isEmptyLinearIssueAttributeFilter,
+  linearIssueAttributeFilterSignature,
+  parseLinearIssueAttributeFilter,
+  type LinearIssueAttributeFilter
+} from './linear-issue-attribute-filter'
+
+const sample: LinearIssueAttributeFilter = {
+  stateIds: ['b', 'a', 'a', '  c  '],
+  priorities: [3, 1, 1, 0],
+  assignee: { kind: 'user', id: '  user-1  ' },
+  labelIds: ['z', 'y', 'z']
+}
+
+describe('linear-issue-attribute-filter', () => {
+  it('treats the canonical empty value as empty and signature-less', () => {
+    expect(isEmptyLinearIssueAttributeFilter(EMPTY_LINEAR_ISSUE_ATTRIBUTE_FILTER)).toBe(true)
+    expect(isEmptyLinearIssueAttributeFilter(emptyLinearIssueAttributeFilter())).toBe(true)
+    expect(linearIssueAttributeFilterSignature(EMPTY_LINEAR_ISSUE_ATTRIBUTE_FILTER)).toBe('')
+    expect(linearIssueAttributeFilterSignature(undefined)).toBe('')
+  })
+
+  it('canonicalizes without mutating the input and produces a stable signature', () => {
+    const input = structuredClone(sample)
+    const canonical = canonicalizeLinearIssueAttributeFilter(input)
+    expect(input).toEqual(sample)
+    expect(canonical).toEqual({
+      stateIds: ['a', 'b', 'c'],
+      priorities: [0, 1, 3],
+      assignee: { kind: 'user', id: 'user-1' },
+      labelIds: ['y', 'z']
+    })
+    expect(linearIssueAttributeFilterSignature(sample)).toBe(
+      linearIssueAttributeFilterSignature(canonical)
+    )
+    expect(linearIssueAttributeFilterSignature(sample)).toContain('"priorities":[0,1,3]')
+  })
+
+  it('changes the signature when any facet changes', () => {
+    const base = canonicalizeLinearIssueAttributeFilter(sample)
+    expect(linearIssueAttributeFilterSignature({ ...base, stateIds: ['x'] })).not.toBe(
+      linearIssueAttributeFilterSignature(base)
+    )
+    expect(linearIssueAttributeFilterSignature({ ...base, priorities: [4] })).not.toBe(
+      linearIssueAttributeFilterSignature(base)
+    )
+    expect(
+      linearIssueAttributeFilterSignature({ ...base, assignee: { kind: 'unassigned' } })
+    ).not.toBe(linearIssueAttributeFilterSignature(base))
+    expect(linearIssueAttributeFilterSignature({ ...base, labelIds: ['other'] })).not.toBe(
+      linearIssueAttributeFilterSignature(base)
+    )
+  })
+
+  it('preserves priority 0 and unassigned assignee', () => {
+    const canonical = canonicalizeLinearIssueAttributeFilter({
+      stateIds: [],
+      priorities: [0],
+      assignee: { kind: 'unassigned' },
+      labelIds: []
+    })
+    expect(canonical.priorities).toEqual([0])
+    expect(canonical.assignee).toEqual({ kind: 'unassigned' })
+    expect(isEmptyLinearIssueAttributeFilter(canonical)).toBe(false)
+  })
+
+  it('parses valid wire input and rejects partial/unknown/malformed payloads', () => {
+    expect(
+      parseLinearIssueAttributeFilter({
+        stateIds: ['s1'],
+        priorities: [0, 2],
+        assignee: { kind: 'unassigned' },
+        labelIds: ['l1']
+      })
+    ).toEqual({
+      stateIds: ['s1'],
+      priorities: [0, 2],
+      assignee: { kind: 'unassigned' },
+      labelIds: ['l1']
+    })
+
+    expect(() => parseLinearIssueAttributeFilter({ stateIds: [] })).toThrow(/required/)
+    expect(() =>
+      parseLinearIssueAttributeFilter({
+        stateIds: [],
+        priorities: [],
+        assignee: null,
+        labelIds: [],
+        extra: true
+      })
+    ).toThrow(/unknown key/)
+    expect(() =>
+      parseLinearIssueAttributeFilter({
+        stateIds: [''],
+        priorities: [],
+        assignee: null,
+        labelIds: []
+      })
+    ).toThrow(/non-empty/)
+    expect(() =>
+      parseLinearIssueAttributeFilter({
+        stateIds: [],
+        priorities: [1.5],
+        assignee: null,
+        labelIds: []
+      })
+    ).toThrow(/integer/)
+    expect(() =>
+      parseLinearIssueAttributeFilter({
+        stateIds: [],
+        priorities: [5],
+        assignee: null,
+        labelIds: []
+      })
+    ).toThrow(/0 to 4/)
+    expect(() =>
+      parseLinearIssueAttributeFilter({
+        stateIds: [],
+        priorities: [],
+        assignee: { kind: 'user' },
+        labelIds: []
+      })
+    ).toThrow(/assignee\.id/)
+    expect(() =>
+      parseLinearIssueAttributeFilter({
+        stateIds: Array.from({ length: 101 }, (_, i) => `s${i}`),
+        priorities: [],
+        assignee: null,
+        labelIds: []
+      })
+    ).toThrow(/exceeds 100/)
+  })
+})

--- a/src/shared/linear-issue-attribute-filter.ts
+++ b/src/shared/linear-issue-attribute-filter.ts
@@ -1,0 +1,244 @@
+// Why: shared wire + cache identity for Linear plain-list attribute facets.
+// IPC/RPC parse unknown input; renderer canonicalizes typed state. An empty
+// filter is omitted from transport so unfiltered list requests stay equivalent.
+
+export const LINEAR_ISSUE_ATTRIBUTE_FILTER_ID_MAX_LENGTH = 256
+export const LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS = 100
+export const LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS = 100
+export const LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_PRIORITIES = 5
+
+export type LinearIssueAttributeAssignee = { kind: 'user'; id: string } | { kind: 'unassigned' }
+
+export type LinearIssueAttributeFilter = {
+  stateIds: string[]
+  priorities: number[]
+  assignee: LinearIssueAttributeAssignee | null
+  labelIds: string[]
+}
+
+export const EMPTY_LINEAR_ISSUE_ATTRIBUTE_FILTER: LinearIssueAttributeFilter = Object.freeze({
+  stateIds: Object.freeze([]) as unknown as string[],
+  priorities: Object.freeze([]) as unknown as number[],
+  assignee: null,
+  labelIds: Object.freeze([]) as unknown as string[]
+}) as LinearIssueAttributeFilter
+
+const ATTRIBUTE_FILTER_KEYS = new Set(['stateIds', 'priorities', 'assignee', 'labelIds'])
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+function canonicalizeIds(ids: string[]): string[] {
+  const seen = new Set<string>()
+  const next: string[] = []
+  for (const raw of ids) {
+    const id = raw.trim()
+    if (!id || seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    next.push(id)
+  }
+  next.sort(compareStrings)
+  return next
+}
+
+function canonicalizePriorities(priorities: number[]): number[] {
+  const seen = new Set<number>()
+  const next: number[] = []
+  for (const priority of priorities) {
+    if (!Number.isInteger(priority) || priority < 0 || priority > 4 || seen.has(priority)) {
+      continue
+    }
+    seen.add(priority)
+    next.push(priority)
+  }
+  next.sort((a, b) => a - b)
+  return next
+}
+
+function canonicalizeAssignee(
+  assignee: LinearIssueAttributeAssignee | null
+): LinearIssueAttributeAssignee | null {
+  if (assignee === null) {
+    return null
+  }
+  if (assignee.kind === 'unassigned') {
+    return { kind: 'unassigned' }
+  }
+  const id = assignee.id.trim()
+  if (!id) {
+    return null
+  }
+  return { kind: 'user', id }
+}
+
+export function emptyLinearIssueAttributeFilter(): LinearIssueAttributeFilter {
+  return {
+    stateIds: [],
+    priorities: [],
+    assignee: null,
+    labelIds: []
+  }
+}
+
+export function canonicalizeLinearIssueAttributeFilter(
+  filter: LinearIssueAttributeFilter
+): LinearIssueAttributeFilter {
+  return {
+    stateIds: canonicalizeIds(filter.stateIds),
+    priorities: canonicalizePriorities(filter.priorities),
+    assignee: canonicalizeAssignee(filter.assignee),
+    labelIds: canonicalizeIds(filter.labelIds)
+  }
+}
+
+export function isEmptyLinearIssueAttributeFilter(
+  filter: LinearIssueAttributeFilter | null | undefined
+): boolean {
+  if (!filter) {
+    return true
+  }
+  const canonical = canonicalizeLinearIssueAttributeFilter(filter)
+  return (
+    canonical.stateIds.length === 0 &&
+    canonical.priorities.length === 0 &&
+    canonical.assignee === null &&
+    canonical.labelIds.length === 0
+  )
+}
+
+export function linearIssueAttributeFilterSignature(
+  filter: LinearIssueAttributeFilter | null | undefined
+): string {
+  if (!filter || isEmptyLinearIssueAttributeFilter(filter)) {
+    return ''
+  }
+  const canonical = canonicalizeLinearIssueAttributeFilter(filter)
+  return JSON.stringify({
+    stateIds: canonical.stateIds,
+    priorities: canonical.priorities,
+    assignee: canonical.assignee,
+    labelIds: canonical.labelIds
+  })
+}
+
+function assertId(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid Linear attribute filter: ${field} must be a string id`)
+  }
+  const id = value.trim()
+  if (!id) {
+    throw new Error(`Invalid Linear attribute filter: ${field} must be non-empty`)
+  }
+  if (id.length > LINEAR_ISSUE_ATTRIBUTE_FILTER_ID_MAX_LENGTH) {
+    throw new Error(
+      `Invalid Linear attribute filter: ${field} exceeds ${LINEAR_ISSUE_ATTRIBUTE_FILTER_ID_MAX_LENGTH} characters`
+    )
+  }
+  return id
+}
+
+function assertIdArray(value: unknown, field: string, max: number): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid Linear attribute filter: ${field} must be an array`)
+  }
+  if (value.length > max) {
+    throw new Error(`Invalid Linear attribute filter: ${field} exceeds ${max} entries`)
+  }
+  return value.map((entry, index) => assertId(entry, `${field}[${index}]`))
+}
+
+function assertPriorities(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Invalid Linear attribute filter: priorities must be an array')
+  }
+  if (value.length > LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_PRIORITIES) {
+    throw new Error(
+      `Invalid Linear attribute filter: priorities exceeds ${LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_PRIORITIES} entries`
+    )
+  }
+  return value.map((entry, index) => {
+    if (typeof entry !== 'number' || !Number.isInteger(entry) || entry < 0 || entry > 4) {
+      throw new Error(
+        `Invalid Linear attribute filter: priorities[${index}] must be an integer from 0 to 4`
+      )
+    }
+    return entry
+  })
+}
+
+function assertAssignee(value: unknown): LinearIssueAttributeAssignee | null {
+  if (value === null) {
+    return null
+  }
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid Linear attribute filter: assignee must be an object or null')
+  }
+  const keys = Object.keys(value)
+  if (value.kind === 'unassigned') {
+    if (keys.some((key) => key !== 'kind')) {
+      throw new Error('Invalid Linear attribute filter: unassigned assignee has unknown keys')
+    }
+    return { kind: 'unassigned' }
+  }
+  if (value.kind === 'user') {
+    if (keys.some((key) => key !== 'kind' && key !== 'id')) {
+      throw new Error('Invalid Linear attribute filter: user assignee has unknown keys')
+    }
+    return { kind: 'user', id: assertId(value.id, 'assignee.id') }
+  }
+  throw new Error('Invalid Linear attribute filter: assignee.kind must be "user" or "unassigned"')
+}
+
+/** Throwing parser for IPC/RPC wire input. Present partial objects are invalid. */
+export function parseLinearIssueAttributeFilter(value: unknown): LinearIssueAttributeFilter {
+  if (value === undefined || value === null) {
+    throw new Error('Invalid Linear attribute filter: value is required when present')
+  }
+  if (!isPlainObject(value)) {
+    throw new Error('Invalid Linear attribute filter: expected an object')
+  }
+  for (const key of Object.keys(value)) {
+    if (!ATTRIBUTE_FILTER_KEYS.has(key)) {
+      throw new Error(`Invalid Linear attribute filter: unknown key "${key}"`)
+    }
+  }
+  if (
+    !('stateIds' in value) ||
+    !('priorities' in value) ||
+    !('assignee' in value) ||
+    !('labelIds' in value)
+  ) {
+    throw new Error(
+      'Invalid Linear attribute filter: stateIds, priorities, assignee, and labelIds are required'
+    )
+  }
+
+  const parsed: LinearIssueAttributeFilter = {
+    stateIds: assertIdArray(
+      value.stateIds,
+      'stateIds',
+      LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_STATE_IDS
+    ),
+    priorities: assertPriorities(value.priorities),
+    assignee: assertAssignee(value.assignee),
+    labelIds: assertIdArray(value.labelIds, 'labelIds', LINEAR_ISSUE_ATTRIBUTE_FILTER_MAX_LABEL_IDS)
+  }
+  return canonicalizeLinearIssueAttributeFilter(parsed)
+}
+
+export function optionalParsedLinearIssueAttributeFilter(
+  value: unknown
+): LinearIssueAttributeFilter | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  const parsed = parseLinearIssueAttributeFilter(value)
+  return isEmptyLinearIssueAttributeFilter(parsed) ? undefined : parsed
+}


### PR DESCRIPTION
## Summary
- Add Linear issue attribute filters (status, priority, assignee, labels) on the Tasks Linear issues list, applied in GraphQL before pagination so `hasMore` matches the filtered set.
- Thread `attributeFilter` through local IPC, Remote Orca RPC, preload, runtime client, and the Linear store cache (signature-keyed entries + source-scoped invalidation after issue mutations).
- TaskPage filter chrome mirrors GitHub PR filters (outline button, sectioned popover, removable pills); workspace `all` and free-text search correctly disable/clear facets.

## Test plan
- [ ] Connect Linear, open Tasks → Issues, select a concrete workspace and team
- [ ] Filter by status / priority / assignee / labels; confirm list and empty states update
- [ ] Load more under a filter, then change primary team; confirm limit/page reset
- [ ] Switch workspace to All workspaces; filters clear and facet UI is disabled
- [ ] Search while filters active; search takes over and facets are not sent
- [ ] Mutate issue status under an active filter; filtered list invalidates without full refresh of unrelated caches
- [ ] Remote Orca / SSH path: listIssues with attributeFilter still works end-to-end