### PR TITLE
Show dispatch task preview and refresh worker tab titles

### DIFF
--- a/src/renderer/src/lib/agent-row-primary-text.test.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.test.ts
@@ -9,11 +9,7 @@ describe('getAgentRowPrimaryText', () => {
   it('prefers orchestration display name over the raw hook prompt', () => {
     expect(
       getAgentRowPrimaryText({
-        prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
-Your task ID is: task-1
-
-=== TASK ===
-Checkout race body`,
+        prompt: 'You are working inside Orca, a multi-agent IDE.',
         orchestration: {
           taskId: 'task-1',
           dispatchId: 'ctx-1',
@@ -27,11 +23,7 @@ Checkout race body`,
   it('falls back to task title when display name is absent', () => {
     expect(
       getAgentRowPrimaryText({
-        prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
-Your task ID is: task-1
-
-=== TASK ===
-Checkout race body`,
+        prompt: 'You are working inside Orca, a multi-agent IDE.',
         orchestration: {
           taskId: 'task-1',
           dispatchId: 'ctx-1',

--- a/src/renderer/src/lib/agent-row-primary-text.test.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.test.ts
@@ -29,6 +29,24 @@ describe('getAgentRowPrimaryText', () => {
     ).toBe('Checkout race')
   })
 
+  it('uses the task block when orchestration metadata has not arrived yet', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your coordinator's terminal handle is: term_parent
+Your task ID is: task_1
+
+=== CLI COMMANDS ===
+orca orchestration send --to term_parent
+
+=== TASK ===
+Review dispatch prompts and make worker labels distinct
+
+Keep the raw preamble out of the sidebar.`
+      })
+    ).toBe('Review dispatch prompts and make worker labels distinct')
+  })
+
   it('falls back to the raw prompt outside orchestration workers', () => {
     expect(getAgentRowPrimaryText({ prompt: 'Fix checkout race' })).toBe('Fix checkout race')
   })

--- a/src/renderer/src/lib/agent-row-primary-text.test.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import { getAgentRowPrimaryText } from './agent-row-primary-text'
+import {
+  getAgentRowGeneratedTitleText,
+  getAgentRowPrimaryText,
+  isOrcaDispatchPrompt
+} from './agent-row-primary-text'
 
 describe('getAgentRowPrimaryText', () => {
   it('prefers orchestration display name over the raw hook prompt', () => {
     expect(
       getAgentRowPrimaryText({
-        prompt: 'You are working inside Orca, a multi-agent IDE.',
+        prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task-1
+
+=== TASK ===
+Checkout race body`,
         orchestration: {
           taskId: 'task-1',
           dispatchId: 'ctx-1',
@@ -19,7 +27,11 @@ describe('getAgentRowPrimaryText', () => {
   it('falls back to task title when display name is absent', () => {
     expect(
       getAgentRowPrimaryText({
-        prompt: 'You are working inside Orca, a multi-agent IDE.',
+        prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task-1
+
+=== TASK ===
+Checkout race body`,
         orchestration: {
           taskId: 'task-1',
           dispatchId: 'ctx-1',
@@ -27,6 +39,24 @@ describe('getAgentRowPrimaryText', () => {
         }
       })
     ).toBe('Checkout race')
+  })
+
+  it('ignores sticky orchestration labels that belong to a different task id', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task_2
+
+=== TASK ===
+Review dispatch prompts and make worker labels distinct`,
+        orchestration: {
+          taskId: 'task_1',
+          dispatchId: 'ctx-1',
+          taskTitle: 'Stale task',
+          displayName: 'Stale worker label'
+        }
+      })
+    ).toBe('Review dispatch prompts and make worker labels distinct')
   })
 
   it('uses the task block when orchestration metadata has not arrived yet', () => {
@@ -49,5 +79,45 @@ Keep the raw preamble out of the sidebar.`
 
   it('falls back to the raw prompt outside orchestration workers', () => {
     expect(getAgentRowPrimaryText({ prompt: 'Fix checkout race' })).toBe('Fix checkout race')
+  })
+})
+
+describe('isOrcaDispatchPrompt / getAgentRowGeneratedTitleText', () => {
+  it('treats leading whitespace as still a dispatch preamble', () => {
+    expect(
+      isOrcaDispatchPrompt('  You are working inside Orca, a multi-agent IDE. Worker task')
+    ).toBe(true)
+  })
+
+  it('uses orchestration labels for generated titles only on matching dispatch prompts', () => {
+    expect(
+      getAgentRowGeneratedTitleText({
+        prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task-1
+
+=== TASK ===
+Checkout race body`,
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          taskTitle: 'Checkout race',
+          displayName: 'Fix checkout race'
+        }
+      })
+    ).toBe('Fix checkout race')
+  })
+
+  it('ignores sticky orchestration for non-dispatch generated titles', () => {
+    expect(
+      getAgentRowGeneratedTitleText({
+        prompt: 'Refactor the auth middleware',
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          taskTitle: 'Stale task',
+          displayName: 'Stale worker label'
+        }
+      })
+    ).toBe('Refactor the auth middleware')
   })
 })

--- a/src/renderer/src/lib/agent-row-primary-text.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.ts
@@ -1,42 +1,105 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 
-const ORCA_DISPATCH_PREAMBLE_PREFIX = 'You are working inside Orca, a multi-agent IDE.'
+export const ORCA_DISPATCH_PREAMBLE_PREFIX = 'You are working inside Orca, a multi-agent IDE.'
 const ORCA_DISPATCH_TASK_MARKER = '=== TASK ==='
+const ORCA_DISPATCH_TASK_ID_MARKER = 'Your task ID is:'
+// Why: match deriveGeneratedTabTitle's scan budget — previews only need the
+// first non-empty task line, not the rest of a paste-sized worker prompt.
+const ORCA_DISPATCH_TASK_PREVIEW_SCAN_LIMIT = 512
+// Why: task id lives near the top of the preamble; keep that scan tight.
+const ORCA_DISPATCH_TASK_ID_SCAN_LIMIT = 1024
+// Why: === TASK === sits after CLI instructions (a few KB). Cap the search so a
+// malformed multi-MB prompt without a marker never full-scans the task body.
+const ORCA_DISPATCH_TASK_MARKER_SCAN_LIMIT = 32_768
+
+/** True when the live prompt is still an Orca dispatch turn (not sticky metadata alone). */
+export function isOrcaDispatchPrompt(prompt: string): boolean {
+  return prompt.trimStart().startsWith(ORCA_DISPATCH_PREAMBLE_PREFIX)
+}
+
+/**
+ * True when orchestration labels belong to the live dispatch preamble (same taskId).
+ * Sticky completed-dispatch metadata must not rename a later dispatch turn.
+ */
+export function orchestrationLabelsMatchLiveDispatch(
+  entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
+): boolean {
+  if (!isOrcaDispatchPrompt(entry.prompt)) {
+    return false
+  }
+  const orchestrationTaskId = entry.orchestration?.taskId?.trim()
+  if (!orchestrationTaskId) {
+    return false
+  }
+  const liveTaskId = getOrcaDispatchTaskId(entry.prompt)
+  return liveTaskId !== null && liveTaskId === orchestrationTaskId
+}
 
 export function getAgentRowPrimaryText(
   entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
 ): string {
+  if (orchestrationLabelsMatchLiveDispatch(entry)) {
+    return (
+      entry.orchestration?.displayName?.trim() ||
+      entry.orchestration?.taskTitle?.trim() ||
+      getOrcaDispatchTaskPreview(entry.prompt) ||
+      // Why: non-dispatch and unmatched paths keep a full trim for display; this
+      // branch only runs for matched dispatch turns, where a bounded preview
+      // almost always succeeds first.
+      entry.prompt.trimStart().slice(0, ORCA_DISPATCH_TASK_PREVIEW_SCAN_LIMIT).trim()
+    )
+  }
   return (
-    entry.orchestration?.displayName?.trim() ||
-    entry.orchestration?.taskTitle?.trim() ||
     getOrcaDispatchTaskPreview(entry.prompt) ||
-    entry.prompt.trim()
+    // Why: ordinary prompts stay small; dispatch prompts without a TASK marker
+    // still must not full-trim a multi-MB body for a sidebar label.
+    (isOrcaDispatchPrompt(entry.prompt)
+      ? entry.prompt.trimStart().slice(0, ORCA_DISPATCH_TASK_PREVIEW_SCAN_LIMIT).trim()
+      : entry.prompt.trim())
   )
 }
 
 export function getAgentRowGeneratedTitleText(
   entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
 ): string {
-  if (
-    entry.orchestration?.displayName?.trim() ||
-    entry.orchestration?.taskTitle?.trim() ||
-    entry.prompt.startsWith(ORCA_DISPATCH_PREAMBLE_PREFIX)
-  ) {
+  // Why: only prefer orchestration/task labels while the live prompt is still
+  // the same dispatch turn — sticky orchestration must not rename new work.
+  if (isOrcaDispatchPrompt(entry.prompt)) {
     return getAgentRowPrimaryText(entry)
   }
   return entry.prompt
 }
 
+export function getOrcaDispatchTaskId(prompt: string): string | null {
+  if (!isOrcaDispatchPrompt(prompt)) {
+    return null
+  }
+  const scan = prompt.trimStart().slice(0, ORCA_DISPATCH_TASK_ID_SCAN_LIMIT)
+  const markerIndex = scan.indexOf(ORCA_DISPATCH_TASK_ID_MARKER)
+  if (markerIndex === -1) {
+    return null
+  }
+  const afterMarker = scan.slice(markerIndex + ORCA_DISPATCH_TASK_ID_MARKER.length)
+  const lineEnd = afterMarker.search(/\r|\n/)
+  const idLine = (lineEnd === -1 ? afterMarker : afterMarker.slice(0, lineEnd)).trim()
+  return idLine || null
+}
+
 function getOrcaDispatchTaskPreview(prompt: string): string {
-  const trimmed = prompt.trim()
-  if (!trimmed.startsWith(ORCA_DISPATCH_PREAMBLE_PREFIX)) {
+  // Why: sidebar rows call this during render; never full-trim/split paste-sized
+  // dispatch prompts — only scan bounded windows for the marker and first line.
+  if (!isOrcaDispatchPrompt(prompt)) {
     return ''
   }
-  const taskMarkerIndex = trimmed.indexOf(ORCA_DISPATCH_TASK_MARKER)
+  const scan = prompt
+    .trimStart()
+    .slice(0, ORCA_DISPATCH_TASK_MARKER_SCAN_LIMIT + ORCA_DISPATCH_TASK_PREVIEW_SCAN_LIMIT)
+  const taskMarkerIndex = scan.indexOf(ORCA_DISPATCH_TASK_MARKER)
   if (taskMarkerIndex === -1) {
     return ''
   }
-  const taskBody = trimmed.slice(taskMarkerIndex + ORCA_DISPATCH_TASK_MARKER.length)
+  const taskBodyStart = taskMarkerIndex + ORCA_DISPATCH_TASK_MARKER.length
+  const taskBody = scan.slice(taskBodyStart, taskBodyStart + ORCA_DISPATCH_TASK_PREVIEW_SCAN_LIMIT)
   for (const line of taskBody.split(/\r?\n/)) {
     const preview = line.trim().replace(/\s+/g, ' ')
     if (preview) {

--- a/src/renderer/src/lib/agent-row-primary-text.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.ts
@@ -18,8 +18,10 @@ export function isOrcaDispatchPrompt(prompt: string): boolean {
 }
 
 /**
- * True when orchestration labels belong to the live dispatch preamble (same taskId).
- * Sticky completed-dispatch metadata must not rename a later dispatch turn.
+ * True when orchestration labels may label the live dispatch turn.
+ * Reject only when both sides expose a taskId and they differ — sticky completed
+ * metadata must not rename a later dispatch. When the live prompt is truncated
+ * (agent-status fields are short) and has no parseable taskId, trust labels.
  */
 export function orchestrationLabelsMatchLiveDispatch(
   entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
@@ -32,7 +34,10 @@ export function orchestrationLabelsMatchLiveDispatch(
     return false
   }
   const liveTaskId = getOrcaDispatchTaskId(entry.prompt)
-  return liveTaskId !== null && liveTaskId === orchestrationTaskId
+  if (!liveTaskId) {
+    return true
+  }
+  return liveTaskId === orchestrationTaskId
 }
 
 export function getAgentRowPrimaryText(

--- a/src/renderer/src/lib/agent-row-primary-text.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.ts
@@ -1,11 +1,47 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 
+const ORCA_DISPATCH_PREAMBLE_PREFIX = 'You are working inside Orca, a multi-agent IDE.'
+const ORCA_DISPATCH_TASK_MARKER = '=== TASK ==='
+
 export function getAgentRowPrimaryText(
   entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
 ): string {
   return (
     entry.orchestration?.displayName?.trim() ||
     entry.orchestration?.taskTitle?.trim() ||
+    getOrcaDispatchTaskPreview(entry.prompt) ||
     entry.prompt.trim()
   )
+}
+
+export function getAgentRowGeneratedTitleText(
+  entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
+): string {
+  if (
+    entry.orchestration?.displayName?.trim() ||
+    entry.orchestration?.taskTitle?.trim() ||
+    entry.prompt.startsWith(ORCA_DISPATCH_PREAMBLE_PREFIX)
+  ) {
+    return getAgentRowPrimaryText(entry)
+  }
+  return entry.prompt
+}
+
+function getOrcaDispatchTaskPreview(prompt: string): string {
+  const trimmed = prompt.trim()
+  if (!trimmed.startsWith(ORCA_DISPATCH_PREAMBLE_PREFIX)) {
+    return ''
+  }
+  const taskMarkerIndex = trimmed.indexOf(ORCA_DISPATCH_TASK_MARKER)
+  if (taskMarkerIndex === -1) {
+    return ''
+  }
+  const taskBody = trimmed.slice(taskMarkerIndex + ORCA_DISPATCH_TASK_MARKER.length)
+  for (const line of taskBody.split(/\r?\n/)) {
+    const preview = line.trim().replace(/\s+/g, ' ')
+    if (preview) {
+      return preview
+    }
+  }
+  return ''
 }

--- a/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
+++ b/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
@@ -74,6 +74,7 @@ describe('generated agent tab titles', () => {
     store.getState().setAgentStatus(paneKey, {
       state: 'working',
       prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task-1
 
 === CLI COMMANDS ===
 orca orchestration send --to term_parent
@@ -101,6 +102,175 @@ Implement the detailed worker instructions that should not be the short label`,
     )
     expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID][0].generatedLabel).toBe(
       'Better worker label'
+    )
+  })
+
+  it('does not replace with sticky orchestration when a new non-dispatch prompt arrives', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    const paneKey = makePaneKey(tabId, LEAF_ID)
+    const dispatchPrompt = `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task-1
+
+=== CLI COMMANDS ===
+orca orchestration send --to term_parent
+
+=== TASK ===
+Implement the detailed worker instructions that should not be the short label`
+
+    store.getState().setAgentStatus(paneKey, {
+      state: 'working',
+      prompt: dispatchPrompt,
+      agentType: 'codex'
+    })
+    store.getState().setRuntimeAgentOrchestrationByPaneKey({
+      [paneKey]: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        taskTitle: 'Implement worker instructions',
+        displayName: 'Better worker label'
+      }
+    })
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Better worker label'
+    )
+
+    // Why: orchestration metadata is sticky (~30m). A later non-dispatch turn on
+    // the same pane must first-write-wins — not re-assert the old dispatch name.
+    store.getState().setAgentStatus(paneKey, {
+      state: 'working',
+      prompt: 'Refactor the auth middleware to use JWT tokens for session recovery',
+      agentType: 'codex'
+    })
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Better worker label'
+    )
+  })
+
+  it('generates from a new non-dispatch prompt when sticky orchestration remains but no title exists', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    const paneKey = makePaneKey(tabId, LEAF_ID)
+
+    // Seed sticky orchestration without a prior generated title (e.g. feature was off).
+    store.getState().setAgentStatus(paneKey, {
+      state: 'done',
+      prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task-1
+
+=== TASK ===
+Old dispatch task that already finished`,
+      agentType: 'codex'
+    })
+    store.getState().setRuntimeAgentOrchestrationByPaneKey({
+      [paneKey]: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        taskTitle: 'Old dispatch task',
+        displayName: 'Stale worker label'
+      }
+    })
+    // Clear any title set during the dispatch turn so the next non-dispatch
+    // prompt is a pure first-write with sticky orchestration still present.
+    const tabs = store.getState().tabsByWorktree[WORKTREE_ID]
+    store.setState({
+      tabsByWorktree: {
+        ...store.getState().tabsByWorktree,
+        [WORKTREE_ID]: tabs.map((tab) =>
+          tab.id === tabId ? { ...tab, generatedTitle: undefined } : tab
+        )
+      },
+      unifiedTabsByWorktree: {
+        ...store.getState().unifiedTabsByWorktree,
+        [WORKTREE_ID]: (store.getState().unifiedTabsByWorktree[WORKTREE_ID] ?? []).map((tab) =>
+          tab.id === tabId ? { ...tab, generatedLabel: undefined } : tab
+        )
+      }
+    })
+
+    store.getState().setAgentStatus(paneKey, {
+      state: 'working',
+      prompt: 'Can you please refactor the auth middleware to use JWT tokens?',
+      agentType: 'codex'
+    })
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Refactor the auth middleware to use JWT'
+    )
+    expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID][0].generatedLabel).toBe(
+      'Refactor the auth middleware to use JWT'
+    )
+  })
+
+  it('does not re-pin sticky task A labels onto a later dispatch task B preamble', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    const paneKey = makePaneKey(tabId, LEAF_ID)
+
+    store.getState().setAgentStatus(paneKey, {
+      state: 'working',
+      prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task-a
+
+=== TASK ===
+Implement task A worker instructions that should not stick`,
+      agentType: 'codex'
+    })
+    store.getState().setRuntimeAgentOrchestrationByPaneKey({
+      [paneKey]: {
+        taskId: 'task-a',
+        dispatchId: 'ctx-a',
+        taskTitle: 'Task A',
+        displayName: 'Worker A label'
+      }
+    })
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe('Worker A label')
+
+    store.getState().setAgentStatus(paneKey, {
+      state: 'working',
+      prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task-b
+
+=== TASK ===
+Implement task B worker instructions for the next dispatch`,
+      agentType: 'codex'
+    })
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Implement task B worker instructions'
+    )
+  })
+
+  it('does not force-replace titles when sticky orchestration updates after a non-dispatch prompt', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    const paneKey = makePaneKey(tabId, LEAF_ID)
+
+    store.getState().setAgentStatus(paneKey, {
+      state: 'working',
+      prompt: 'Can you please refactor the auth middleware to use JWT tokens?',
+      agentType: 'codex'
+    })
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Refactor the auth middleware to use JWT'
+    )
+
+    store.getState().setRuntimeAgentOrchestrationByPaneKey({
+      [paneKey]: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        taskTitle: 'Stale orchestration task',
+        displayName: 'Stale orchestration label'
+      }
+    })
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Refactor the auth middleware to use JWT'
     )
   })
 

--- a/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
+++ b/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
@@ -65,6 +65,45 @@ describe('generated agent tab titles', () => {
     )
   })
 
+  it('replaces a raw dispatch preamble title when orchestration display metadata arrives', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    const paneKey = makePaneKey(tabId, LEAF_ID)
+
+    store.getState().setAgentStatus(paneKey, {
+      state: 'working',
+      prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+
+=== CLI COMMANDS ===
+orca orchestration send --to term_parent
+
+=== TASK ===
+Implement the detailed worker instructions that should not be the short label`,
+      agentType: 'codex'
+    })
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Implement the detailed worker'
+    )
+
+    store.getState().setRuntimeAgentOrchestrationByPaneKey({
+      [paneKey]: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        taskTitle: 'Implement worker instructions',
+        displayName: 'Better worker label'
+      }
+    })
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Better worker label'
+    )
+    expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID][0].generatedLabel).toBe(
+      'Better worker label'
+    )
+  })
+
   it('does not trim the full paste-sized prompt before generating an optional title', () => {
     vi.useFakeTimers()
     const trimSpy = vi.spyOn(String.prototype, 'trim')

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../../shared/agent-status-identity'
 import type { TerminalTab } from '../../../../shared/types'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import { getAgentRowGeneratedTitleText } from '@/lib/agent-row-primary-text'
 import { createFreshnessScheduler } from './agent-status-freshness-scheduler'
 
 /** Snapshot of a finished (or vanished) agent status entry, kept around so
@@ -914,6 +915,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
     recentlyClosedAgentStatusTabIds: {},
 
     setRuntimeAgentOrchestrationByPaneKey: (entries) => {
+      const generatedTitleUpdates: AgentStatusEntry[] = []
       set((s) => {
         const runtimeMapChanged = !orchestrationMapsEqual(
           s.runtimeAgentOrchestrationByPaneKey,
@@ -936,7 +938,11 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
                 nextLive = { ...nextLive }
                 liveChanged = true
               }
-              nextLive[paneKey] = { ...liveEntry, orchestration: merged }
+              const nextEntry = { ...liveEntry, orchestration: merged }
+              nextLive[paneKey] = nextEntry
+              if (merged.displayName || merged.taskTitle) {
+                generatedTitleUpdates.push(nextEntry)
+              }
             }
           }
 
@@ -970,6 +976,15 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           ...(liveChanged ? { agentStatusEpoch: s.agentStatusEpoch + 1 } : {})
         }
       })
+      for (const entry of generatedTitleUpdates) {
+        get().setGeneratedTabTitleFromAgentPrompt(
+          entry.paneKey,
+          getAgentRowGeneratedTitleText(entry),
+          {
+            replaceExistingGeneratedTitle: true
+          }
+        )
+      }
     },
 
     registerAgentLaunchConfig: (paneKey, launchConfig, metadata) => {
@@ -1071,6 +1086,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       }
       let completionRefreshWorktreeId: string | null = null
       let suppressedInheritedTerminalStatus = false
+      const generatedTitleEntry: { current: AgentStatusEntry | null } = { current: null }
       set((s) => {
         const existing = s.agentStatusByPaneKey[paneKey]
         // Why: snapshots and live pushes share receivedAt from the same main-side
@@ -1245,6 +1261,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           // it when a new turn starts (working → Stop reprices it).
           interrupted: payload.interrupted
         }
+        generatedTitleEntry.current = entry
         if (
           isAgentCompletionState(entry.state) &&
           existing !== undefined &&
@@ -1385,7 +1402,22 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       if (suppressedInheritedTerminalStatus) {
         return
       }
-      get().setGeneratedTabTitleFromAgentPrompt(paneKey, payload.prompt)
+      const entryForGeneratedTitle = generatedTitleEntry.current
+      if (!entryForGeneratedTitle) {
+        return
+      }
+      const generatedTitlePrompt = getAgentRowGeneratedTitleText(entryForGeneratedTitle)
+      const shouldReplaceGeneratedTitle = Boolean(
+        entryForGeneratedTitle.orchestration?.displayName ||
+        entryForGeneratedTitle.orchestration?.taskTitle
+      )
+      if (shouldReplaceGeneratedTitle) {
+        get().setGeneratedTabTitleFromAgentPrompt(paneKey, generatedTitlePrompt, {
+          replaceExistingGeneratedTitle: true
+        })
+      } else {
+        get().setGeneratedTabTitleFromAgentPrompt(paneKey, generatedTitlePrompt)
+      }
       // Why: schedule after set completes so the timer reads the updated map.
       // queueMicrotask avoids re-entry into the zustand store during set.
       queueMicrotask(() => freshness.schedule())

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -24,7 +24,12 @@ import {
 } from '../../../../shared/agent-status-identity'
 import type { TerminalTab } from '../../../../shared/types'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
-import { getAgentRowGeneratedTitleText } from '@/lib/agent-row-primary-text'
+import {
+  getAgentRowGeneratedTitleText,
+  getOrcaDispatchTaskId,
+  isOrcaDispatchPrompt,
+  orchestrationLabelsMatchLiveDispatch
+} from '@/lib/agent-row-primary-text'
 import { createFreshnessScheduler } from './agent-status-freshness-scheduler'
 
 /** Snapshot of a finished (or vanished) agent status entry, kept around so
@@ -262,6 +267,34 @@ function getTabIdFromPaneKey(paneKey: string): string | null {
     return null
   }
   return paneKey.slice(0, separator)
+}
+
+/** True when auto-title generation would no-op without replace (custom/quick/generated). */
+function agentStatusTabAlreadyHasProtectedOrGeneratedTitle(
+  state: AppState,
+  tabId: string | null,
+  worktreeId?: string | null
+): boolean {
+  if (!tabId) {
+    return false
+  }
+  const ownerTabs = worktreeId ? state.tabsByWorktree[worktreeId] : undefined
+  if (ownerTabs) {
+    const tab = ownerTabs.find((candidate) => candidate.id === tabId)
+    return Boolean(
+      tab?.customTitle?.trim() || tab?.quickCommandLabel?.trim() || tab?.generatedTitle?.trim()
+    )
+  }
+  for (const tabs of Object.values(state.tabsByWorktree)) {
+    const tab = tabs.find((candidate) => candidate.id === tabId)
+    if (!tab) {
+      continue
+    }
+    return Boolean(
+      tab.customTitle?.trim() || tab.quickCommandLabel?.trim() || tab.generatedTitle?.trim()
+    )
+  }
+  return false
 }
 
 function getLeafIdFromPaneKey(paneKey: string): string | null {
@@ -940,7 +973,15 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
               }
               const nextEntry = { ...liveEntry, orchestration: merged }
               nextLive[paneKey] = nextEntry
-              if (merged.displayName || merged.taskTitle) {
+              // Why: only replace titles when labels match the live dispatch
+              // taskId; sticky completed context must not rename a later turn.
+              if (
+                (merged.displayName?.trim() || merged.taskTitle?.trim()) &&
+                orchestrationLabelsMatchLiveDispatch({
+                  prompt: nextEntry.prompt,
+                  orchestration: merged
+                })
+              ) {
                 generatedTitleUpdates.push(nextEntry)
               }
             }
@@ -1403,20 +1444,50 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         return
       }
       const entryForGeneratedTitle = generatedTitleEntry.current
-      if (!entryForGeneratedTitle) {
-        return
-      }
-      const generatedTitlePrompt = getAgentRowGeneratedTitleText(entryForGeneratedTitle)
-      const shouldReplaceGeneratedTitle = Boolean(
-        entryForGeneratedTitle.orchestration?.displayName ||
-        entryForGeneratedTitle.orchestration?.taskTitle
-      )
-      if (shouldReplaceGeneratedTitle) {
-        get().setGeneratedTabTitleFromAgentPrompt(paneKey, generatedTitlePrompt, {
-          replaceExistingGeneratedTitle: true
-        })
-      } else {
-        get().setGeneratedTabTitleFromAgentPrompt(paneKey, generatedTitlePrompt)
+      if (entryForGeneratedTitle) {
+        // Why: sticky orchestration (~30m) can outlive the dispatch turn.
+        // - Matching labels: replace so displayName upgrades the task preview.
+        // - Mismatched sticky taskId on a new dispatch preamble: replace so the
+        //   prior task's title does not stick across re-dispatch on the same pane.
+        const hasMatchingOrchestrationLabels = Boolean(
+          (entryForGeneratedTitle.orchestration?.displayName?.trim() ||
+            entryForGeneratedTitle.orchestration?.taskTitle?.trim()) &&
+          orchestrationLabelsMatchLiveDispatch(entryForGeneratedTitle)
+        )
+        const liveIsDispatchPrompt = isOrcaDispatchPrompt(entryForGeneratedTitle.prompt)
+        const liveDispatchTaskId = liveIsDispatchPrompt
+          ? getOrcaDispatchTaskId(entryForGeneratedTitle.prompt)
+          : null
+        const stickyOrchestrationTaskId =
+          entryForGeneratedTitle.orchestration?.taskId?.trim() || null
+        const isNewDispatchAgainstStickyOrchestration = Boolean(
+          liveDispatchTaskId &&
+          stickyOrchestrationTaskId &&
+          liveDispatchTaskId !== stickyOrchestrationTaskId
+        )
+        const shouldReplaceGeneratedTitle =
+          hasMatchingOrchestrationLabels || isNewDispatchAgainstStickyOrchestration
+        // Why: setAgentStatus is high-frequency. Only parse dispatch preambles when
+        // a title write is still possible (feature on + replace or first-write).
+        const mayWriteGeneratedTitle =
+          get().settings?.tabAutoGenerateTitle === true &&
+          (shouldReplaceGeneratedTitle ||
+            !agentStatusTabAlreadyHasProtectedOrGeneratedTitle(
+              get(),
+              entryForGeneratedTitle.tabId ?? getTabIdFromPaneKey(paneKey),
+              entryForGeneratedTitle.worktreeId
+            ))
+        const generatedTitlePrompt =
+          liveIsDispatchPrompt && mayWriteGeneratedTitle
+            ? getAgentRowGeneratedTitleText(entryForGeneratedTitle)
+            : entryForGeneratedTitle.prompt
+        if (shouldReplaceGeneratedTitle) {
+          get().setGeneratedTabTitleFromAgentPrompt(paneKey, generatedTitlePrompt, {
+            replaceExistingGeneratedTitle: true
+          })
+        } else {
+          get().setGeneratedTabTitleFromAgentPrompt(paneKey, generatedTitlePrompt)
+        }
       }
       // Why: schedule after set completes so the timer reads the updated map.
       // queueMicrotask avoids re-entry into the zustand store during set.

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -582,7 +582,11 @@ export type TerminalSlice = {
   setActiveTab: (tabId: string) => void
   setActiveTabForWorktree: (worktreeId: string, tabId: string) => void
   updateTabTitle: (tabId: string, title: string) => void
-  setGeneratedTabTitleFromAgentPrompt: (paneKey: string, prompt: string) => void
+  setGeneratedTabTitleFromAgentPrompt: (
+    paneKey: string,
+    prompt: string,
+    options?: { replaceExistingGeneratedTitle?: boolean }
+  ) => void
   clearTabLaunchAgent: (tabId: string) => void
   setRuntimePaneTitle: (tabId: string, paneId: number, title: string) => void
   clearRuntimePaneTitle: (tabId: string, paneId: number) => void
@@ -1547,9 +1551,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     })
   },
 
-  setGeneratedTabTitleFromAgentPrompt: (paneKey, prompt) => {
+  setGeneratedTabTitleFromAgentPrompt: (paneKey, prompt, options) => {
     const tabId = getTabIdFromPaneKey(paneKey)
     if (!tabId || prompt.length === 0) {
+      return
+    }
+    const generatedTitle = deriveGeneratedTabTitle(prompt)
+    if (!generatedTitle) {
       return
     }
     set((s) => {
@@ -1563,16 +1571,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const tabs = s.tabsByWorktree[ownerWorktreeId] ?? []
       const tabIndex = tabs.findIndex((tab) => tab.id === tabId)
       const currentTab = tabs[tabIndex]
-      if (
-        !currentTab ||
-        currentTab.customTitle?.trim() ||
-        currentTab.quickCommandLabel?.trim() ||
-        currentTab.generatedTitle?.trim()
-      ) {
+      if (!currentTab || currentTab.customTitle?.trim() || currentTab.quickCommandLabel?.trim()) {
         return s
       }
-      const generatedTitle = deriveGeneratedTabTitle(prompt)
-      if (!generatedTitle) {
+      const existingGeneratedTitle = currentTab.generatedTitle?.trim()
+      if (
+        existingGeneratedTitle &&
+        (existingGeneratedTitle === generatedTitle ||
+          options?.replaceExistingGeneratedTitle !== true)
+      ) {
         return s
       }
       const ownerTabs = tabs.map((tab) => (tab.id === tabId ? { ...tab, generatedTitle } : tab))

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1552,37 +1552,58 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   setGeneratedTabTitleFromAgentPrompt: (paneKey, prompt, options) => {
+    // Why: setAgentStatus is high-frequency; skip derive/set unless the feature
+    // is on and this tab still needs a (re)generated title.
+    if (get().settings?.tabAutoGenerateTitle !== true) {
+      return
+    }
     const tabId = getTabIdFromPaneKey(paneKey)
     if (!tabId || prompt.length === 0) {
       return
     }
+    const ownerWorktreeId = getTerminalTabOwnerWorktreeId(get().tabsByWorktree, tabId)
+    if (!ownerWorktreeId) {
+      return
+    }
+    const tabs = get().tabsByWorktree[ownerWorktreeId] ?? []
+    const currentTab = tabs.find((tab) => tab.id === tabId)
+    if (!currentTab || currentTab.customTitle?.trim() || currentTab.quickCommandLabel?.trim()) {
+      return
+    }
+    const existingGeneratedTitle = currentTab.generatedTitle?.trim()
+    if (existingGeneratedTitle && options?.replaceExistingGeneratedTitle !== true) {
+      return
+    }
     const generatedTitle = deriveGeneratedTabTitle(prompt)
-    if (!generatedTitle) {
+    if (!generatedTitle || existingGeneratedTitle === generatedTitle) {
       return
     }
     set((s) => {
-      if (s.settings?.tabAutoGenerateTitle !== true) {
+      const ownerTabsForWrite = s.tabsByWorktree[ownerWorktreeId]
+      if (!ownerTabsForWrite) {
         return s
       }
-      const ownerWorktreeId = getTerminalTabOwnerWorktreeId(s.tabsByWorktree, tabId)
-      if (!ownerWorktreeId) {
-        return s
-      }
-      const tabs = s.tabsByWorktree[ownerWorktreeId] ?? []
-      const tabIndex = tabs.findIndex((tab) => tab.id === tabId)
-      const currentTab = tabs[tabIndex]
-      if (!currentTab || currentTab.customTitle?.trim() || currentTab.quickCommandLabel?.trim()) {
-        return s
-      }
-      const existingGeneratedTitle = currentTab.generatedTitle?.trim()
+      const tabIndex = ownerTabsForWrite.findIndex((tab) => tab.id === tabId)
+      const tabForWrite = ownerTabsForWrite[tabIndex]
+      // Why: re-check inside set so concurrent renames / setting flips win.
       if (
-        existingGeneratedTitle &&
-        (existingGeneratedTitle === generatedTitle ||
-          options?.replaceExistingGeneratedTitle !== true)
+        !tabForWrite ||
+        s.settings?.tabAutoGenerateTitle !== true ||
+        tabForWrite.customTitle?.trim() ||
+        tabForWrite.quickCommandLabel?.trim()
       ) {
         return s
       }
-      const ownerTabs = tabs.map((tab) => (tab.id === tabId ? { ...tab, generatedTitle } : tab))
+      const latestGeneratedTitle = tabForWrite.generatedTitle?.trim()
+      if (
+        latestGeneratedTitle &&
+        (latestGeneratedTitle === generatedTitle || options?.replaceExistingGeneratedTitle !== true)
+      ) {
+        return s
+      }
+      const ownerTabs = ownerTabsForWrite.map((tab) =>
+        tab.id === tabId ? { ...tab, generatedTitle } : tab
+      )
       const currentUnifiedTabs = s.unifiedTabsByWorktree[ownerWorktreeId] ?? []
       const unifiedTabsWithGeneratedLabel = updateUnifiedTerminalGeneratedLabel(
         currentUnifiedTabs,


### PR DESCRIPTION
## Summary
- Extract the first `=== TASK ===` line from Orca dispatch preambles so sidebar/dashboard worker rows show a useful label before orchestration metadata arrives.
- Refresh auto-generated tab titles when matching orchestration `displayName`/`taskTitle` arrives, while keeping first-write-wins for ordinary prompts.
- Bound preamble scans and only replace titles when labels match the live dispatch task id (or a new dispatch supersedes sticky metadata), so paste-sized prompts and re-dispatch do not regress title behavior.

## Test plan
- [x] Unit: `agent-row-primary-text.test.ts` (task preview, sticky/mismatch orchestration)
- [x] Unit: `agent-generated-tab-title.test.ts` (replace on metadata, non-dispatch sticky, re-dispatch task B)
- [x] Unit: `agent-status.test.ts`
- [x] `pnpm typecheck`
- [ ] Manual: dispatch a worker, confirm sidebar shows task line before runtime metadata; confirm tab title upgrades to displayName when it arrives