### PR TITLE
fix(test): unbreak main typecheck in local-pty-shell-ready.test.ts

### DIFF
--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -866,7 +866,7 @@ path=(/custom/bin $path)
         // non-login flow used by local panes so both restore paths stay pinned.
         // Login must still load user .zshrc (via wrapper .zshrc after .zprofile)
         // and leave final ZDOTDIR at the user home after .zlogin restore.
-        for (const args of [['-i'], ['-l', '-i']] as const) {
+        for (const args of [['-i'], ['-l', '-i']]) {
           const result = spawnSync(
             'zsh',
             [


### PR DESCRIPTION
## Problem

`main` fails `pnpm typecheck` since #8025 landed:

```
src/main/providers/local-pty-shell-ready.test.ts(886,57): error TS2345: Argument of type '"-l"' is not assignable to parameter of type '"-i"'.
```

Every open PR's `verify` check now fails on the merge ref regardless of the PR's own contents (first seen on #8016's CI; reproduced on pristine `origin/main`).

## Cause

The `as const` on the zsh arg-variant loop narrows `args` to `readonly ['-i'] | readonly ['-l', '-i']`, so `args.includes('-l')` is a type error on the `['-i']` member — `Array.prototype.includes` only accepts the tuple's element type.

## Fix

Drop the `as const` so the literal infers `string[][]`. Nothing in the loop relies on tuple types (`join`, spread, `includes` only). No runtime behavior change; all 66 tests in the file still pass, full `pnpm typecheck` green.

Made with [Orca](https://github.com/stablyai/orca) 🐋