### PR TITLE
fix: normalize Zellij-wrapped OMP terminal titles

### DIFF
--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -118,13 +118,18 @@ describe('Pi-compatible title detection', () => {
     ['π: tmp', 'omp', 'OMP ready'],
     ['\u280b π: tmp', 'omp', '\u280b OMP'],
     ['\u280b π - tmp', 'omp', '\u280b OMP'],
-    ['\u280b OMP', 'pi', '\u280b Pi']
+    ['\u280b OMP', 'pi', '\u280b Pi'],
+    ['lucky-echidna | \u283c π - Diagnose Orca terminal title flicker - test', 'omp', '\u280b OMP'],
+    ['lucky-echidna | Pi ready', 'omp', 'OMP ready'],
+    ['Codex | Pi ready', 'omp', 'OMP ready'],
+    ['lucky-echidna | \u283c π - Diagnose | test', 'omp', '\u280b OMP']
   ] as const)('normalizes %s to the authoritative %s owner', (title, owner, expectedTitle) => {
     expect(normalizeCompatibleAgentTitleForOwner(title, owner)).toBe(expectedTitle)
   })
 
   it('preserves Pi-compatible custom titles and unrelated owners', () => {
     expect(normalizeCompatibleAgentTitleForOwner('Fix pi bugs', 'omp')).toBe('Fix pi bugs')
+    expect(normalizeCompatibleAgentTitleForOwner('xxPi ready', 'omp')).toBe('xxPi ready')
     expect(normalizeCompatibleAgentTitleForOwner('\u280b Pi', 'codex')).toBe('\u280b Pi')
   })
 

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -122,6 +122,9 @@ describe('Pi-compatible title detection', () => {
     ['lucky-echidna | \u283c π - Diagnose Orca terminal title flicker - test', 'omp', '\u280b OMP'],
     ['lucky-echidna | Pi ready', 'omp', 'OMP ready'],
     ['Codex | Pi ready', 'omp', 'OMP ready'],
+    // Why: the wrapped whole reads as a braille Claude title, but the re-ownable
+    // synthetic pane suffix must still win.
+    ['lucky-echidna | ⠋ OMP', 'omp', '⠋ OMP'],
     ['lucky-echidna | \u283c π - Diagnose | test', 'omp', '\u280b OMP']
   ] as const)('normalizes %s to the authoritative %s owner', (title, owner, expectedTitle) => {
     expect(normalizeCompatibleAgentTitleForOwner(title, owner)).toBe(expectedTitle)
@@ -129,6 +132,11 @@ describe('Pi-compatible title detection', () => {
 
   it('preserves Pi-compatible custom titles and unrelated owners', () => {
     expect(normalizeCompatibleAgentTitleForOwner('Fix pi bugs', 'omp')).toBe('Fix pi bugs')
+    // Why: a wrapped title with no re-ownable identity in any " | " segment
+    // passes through untouched instead of collapsing to the owner label.
+    expect(normalizeCompatibleAgentTitleForOwner('lucky-echidna | Fix pi bugs', 'omp')).toBe(
+      'lucky-echidna | Fix pi bugs'
+    )
     expect(normalizeCompatibleAgentTitleForOwner('xxPi ready', 'omp')).toBe('xxPi ready')
     expect(normalizeCompatibleAgentTitleForOwner('\u280b Pi', 'codex')).toBe('\u280b Pi')
   })

--- a/src/shared/agent-title-owner.ts
+++ b/src/shared/agent-title-owner.ts
@@ -36,8 +36,8 @@ function getProfileForTitleLabel(label: string | null): TitleLabelProfileMatch |
  * Resolves the synthetic title profile matching a given terminal title.
  */
 function getProfileForTitle(title: string): TitleProfileMatch | null {
-  // Zellij/session wrappers prefix dynamic titles with ` | `, so inspect each
-  // suffix to preserve the inner compatible agent identity.
+  // Multiplexers/session wrappers prefix dynamic titles with ` | `, so inspect
+  // each suffix to preserve the inner compatible agent identity.
   const candidates = [title]
   let wrapperSeparatorIndex = title.indexOf(' | ')
   while (wrapperSeparatorIndex >= 0) {

--- a/src/shared/agent-title-owner.ts
+++ b/src/shared/agent-title-owner.ts
@@ -36,6 +36,8 @@ function getProfileForTitleLabel(label: string | null): TitleLabelProfileMatch |
  * Resolves the synthetic title profile matching a given terminal title.
  */
 function getProfileForTitle(title: string): TitleProfileMatch | null {
+  // Zellij/session wrappers prefix dynamic titles with ` | `, so inspect each
+  // suffix to preserve the inner compatible agent identity.
   const candidates = [title]
   let wrapperSeparatorIndex = title.indexOf(' | ')
   while (wrapperSeparatorIndex >= 0) {

--- a/src/shared/agent-title-owner.ts
+++ b/src/shared/agent-title-owner.ts
@@ -9,14 +9,17 @@ import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
 
 type TitleProfileMatch = {
   profile: SyntheticAgentTitleProfile
+  sourceTitle: string
 }
+
+type TitleLabelProfileMatch = Pick<TitleProfileMatch, 'profile'>
 
 const COMPATIBLE_IDLE_TITLE_RE = /(?<![\w./\\-])(?:ready|idle|done)(?![\w-])/i
 
 /**
  * Resolves the synthetic title profile matching a given agent label.
  */
-function getProfileForTitleLabel(label: string | null): TitleProfileMatch | null {
+function getProfileForTitleLabel(label: string | null): TitleLabelProfileMatch | null {
   if (!label) {
     return null
   }
@@ -33,14 +36,33 @@ function getProfileForTitleLabel(label: string | null): TitleProfileMatch | null
  * Resolves the synthetic title profile matching a given terminal title.
  */
 function getProfileForTitle(title: string): TitleProfileMatch | null {
-  const labelProfile = getProfileForTitleLabel(getAgentLabel(title))
-  if (labelProfile) {
-    return labelProfile
+  const candidates = [title]
+  let wrapperSeparatorIndex = title.indexOf(' | ')
+  while (wrapperSeparatorIndex >= 0) {
+    const wrappedPaneTitle = title.slice(wrapperSeparatorIndex + 3).trim()
+    if (wrappedPaneTitle && !candidates.includes(wrappedPaneTitle)) {
+      candidates.push(wrappedPaneTitle)
+    }
+    wrapperSeparatorIndex = title.indexOf(' | ', wrapperSeparatorIndex + 3)
   }
-  if (isLegacyPiCompatibleTitle(title)) {
-    return getProfileForTitleLabel('Pi')
+
+  let fallback: TitleProfileMatch | null = null
+  for (const candidate of candidates) {
+    const labelProfile = getProfileForTitleLabel(getAgentLabel(candidate))
+    const legacyProfile = isLegacyPiCompatibleTitle(candidate)
+      ? getProfileForTitleLabel('Pi')
+      : null
+    const candidateProfile = labelProfile ?? legacyProfile
+    if (!candidateProfile) {
+      continue
+    }
+    const match = { ...candidateProfile, sourceTitle: candidate }
+    if (candidateProfile.profile.titleIdentityGroup) {
+      return match
+    }
+    fallback ??= match
   }
-  return null
+  return fallback
 }
 
 /**
@@ -132,7 +154,7 @@ export function normalizeCompatibleAgentTitleForOwner(
   ) {
     return title
   }
-  const sourceStatus = getSourceTitleStatus(title)
+  const sourceStatus = getSourceTitleStatus(source.sourceTitle)
   if (sourceStatus === 'working') {
     return `\u280b ${ownerProfile.workingLabel}`
   }
@@ -142,10 +164,10 @@ export function normalizeCompatibleAgentTitleForOwner(
   if (sourceStatus === 'idle') {
     return ownerProfile.idleLabel
   }
-  if (hasPermissionSuffix(title, source.profile)) {
+  if (hasPermissionSuffix(source.sourceTitle, source.profile)) {
     return ownerProfile.permissionLabel
   }
-  if (hasIdleSuffix(title, source.profile)) {
+  if (hasIdleSuffix(source.sourceTitle, source.profile)) {
     return ownerProfile.idleLabel
   }
   return ownerProfile.workingLabel


### PR DESCRIPTION
## Summary

- recognize Pi-compatible agent titles nested inside Zellij/session pane-title wrappers
- prefer the inner compatible identity over generic outer wrapper labels
- derive working, idle, and permission state from the matched inner title
- add regression coverage for wrapped OMP titles and false-positive boundaries

Fixes #8032

## Screenshots

No static visual change. The user-visible effect is that the existing Orca tab label no longer flickers when OMP updates its title inside Zellij.

## Testing

- [ ] `pnpm lint` — full suite not run; changed-file `oxlint` passed
- [ ] `pnpm typecheck` — full suite not run; Node and web TypeScript checks passed
- [ ] `pnpm test` — full suite not run; 40/40 tests passed in `src/shared/agent-detection.test.ts`
- [ ] `pnpm build` — full suite not run; the macOS arm64 app built and launched successfully
- [x] Added regression cases for wrapped OMP/Pi-compatible titles and a false-positive boundary case
- Manual verification in the original Zellij + OMP scenario confirmed that the tab flicker disappeared

## AI Review Report

CodeRabbit reviewed both changed files. It found one maintainability nit: the wrapper-splitting logic needed a brief comment explaining why every suffix after ` | ` is considered. That comment is now included.

The review also checked the main behavioral risks: selecting the inner compatible identity instead of a generic wrapper label, deriving status from the matched inner title, and leaving unrelated custom titles unchanged. Cross-platform compatibility was checked explicitly: the change is platform-independent string normalization and does not alter keyboard shortcuts, platform labels, paths, shell behavior, or Electron platform APIs. It also makes no local-only assumption, so terminal titles received through SSH sessions follow the same normalization path.

## Security Audit

Terminal titles are treated as untrusted strings and are only inspected with `indexOf`, `slice`, `trim`, and existing profile matching. The change does not evaluate title content or introduce command execution, path handling, authentication, secrets, dependencies, network access, or new IPC. No security follow-up is required for this scope.

## Notes

- Reproduced independently on current `main` (`1.4.132`, commit `6f895eff0a`) in #8032.
- The normalization applies equally on macOS, Linux, and Windows because it contains no platform-specific branch.
- Zellij and SSH remain supported; the fix operates on the terminal title after it reaches Orca rather than assuming a local process layout.
