### PR TITLE
perf(worktrees): avoid auto-maintenance in create fetches

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -478,6 +478,7 @@ async function refreshRemoteTrackingBaseForWorktreeCreate(
     getSshWorktreeCreateBaseFetchKey(repo, base),
     getSshWorktreeCreateRemoteQueueKey(repo, base.remote),
     () =>
+      // Why: the exact-base refresh gates create; unrelated repo housekeeping must not extend it.
       provider.fetchRemoteTrackingRef(repo.path, base.remote, base.branch, base.ref, {
         skipAutoMaintenance: true
       })

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -477,7 +477,10 @@ async function refreshRemoteTrackingBaseForWorktreeCreate(
   return getOrStartSshWorktreeCreateFetch(
     getSshWorktreeCreateBaseFetchKey(repo, base),
     getSshWorktreeCreateRemoteQueueKey(repo, base.remote),
-    () => provider.fetchRemoteTrackingRef(repo.path, base.remote, base.branch, base.ref)
+    () =>
+      provider.fetchRemoteTrackingRef(repo.path, base.remote, base.branch, base.ref, {
+        skipAutoMaintenance: true
+      })
   )
 }
 

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3733,7 +3733,8 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo',
       'origin',
       'master',
-      'refs/remotes/origin/master'
+      'refs/remotes/origin/master',
+      { skipAutoMaintenance: true }
     )
   })
 
@@ -3800,7 +3801,8 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo',
       'origin',
       'main',
-      'refs/remotes/origin/main'
+      'refs/remotes/origin/main',
+      { skipAutoMaintenance: true }
     )
     expect(provider.addWorktree).toHaveBeenCalledWith(
       '/remote/repo',
@@ -4032,7 +4034,8 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo',
       'origin',
       'main',
-      'refs/remotes/origin/main'
+      'refs/remotes/origin/main',
+      { skipAutoMaintenance: true }
     )
     expect(provider.addWorktree).toHaveBeenCalledTimes(2)
   })

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -850,14 +850,16 @@ describe('SshGitProvider', () => {
       '/home/user/repo',
       'origin',
       'main',
-      'refs/remotes/origin/main'
+      'refs/remotes/origin/main',
+      { skipAutoMaintenance: true }
     )
 
     expect(mux.request).toHaveBeenCalledWith('git.fetchRemoteTrackingRef', {
       worktreePath: '/home/user/repo',
       remote: 'origin',
       branch: 'main',
-      ref: 'refs/remotes/origin/main'
+      ref: 'refs/remotes/origin/main',
+      skipAutoMaintenance: true
     })
   })
 

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -553,14 +553,16 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     remote: string,
     branch: string,
-    ref: string
+    ref: string,
+    options?: { skipAutoMaintenance?: boolean }
   ): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
       await this.mux.request('git.fetchRemoteTrackingRef', {
         worktreePath,
         remote,
         branch,
-        ref
+        ref,
+        ...(options?.skipAutoMaintenance ? { skipAutoMaintenance: true } : {})
       })
     })
   }

--- a/src/main/runtime/fetch-remote-cache.test.ts
+++ b/src/main/runtime/fetch-remote-cache.test.ts
@@ -50,6 +50,8 @@ function exactBaseRefreshArgs(branch = 'main'): string[] {
     '-c',
     'maintenance.auto=false',
     '-c',
+    'maintenance.commit-graph.auto=0',
+    '-c',
     'gc.auto=0',
     'fetch',
     '--no-tags',

--- a/src/main/runtime/fetch-remote-cache.test.ts
+++ b/src/main/runtime/fetch-remote-cache.test.ts
@@ -22,10 +22,19 @@ vi.mock('../git/runner', async (importOriginal) => {
 // normally — none of them trigger IO until a runtime method is called.
 import { OrcaRuntimeService } from './orca-runtime'
 
+function isFetchArgs(argv: unknown): argv is string[] {
+  if (!Array.isArray(argv)) {
+    return false
+  }
+  let commandIndex = 0
+  while (argv[commandIndex] === '-c' && typeof argv[commandIndex + 1] === 'string') {
+    commandIndex += 2
+  }
+  return argv[commandIndex] === 'fetch'
+}
+
 function fetchCallCount(): number {
-  return gitExecFileAsyncMock.mock.calls.filter(
-    ([argv]) => Array.isArray(argv) && argv[0] === 'fetch'
-  ).length
+  return gitExecFileAsyncMock.mock.calls.filter(([argv]) => isFetchArgs(argv)).length
 }
 
 function exactBaseRefreshOptions(cwd: string): {
@@ -34,6 +43,19 @@ function exactBaseRefreshOptions(cwd: string): {
   useConfiguredSshCommandForNetwork: boolean
 } {
   return { cwd, timeout: 60_000, useConfiguredSshCommandForNetwork: true }
+}
+
+function exactBaseRefreshArgs(branch = 'main'): string[] {
+  return [
+    '-c',
+    'maintenance.auto=false',
+    '-c',
+    'gc.auto=0',
+    'fetch',
+    '--no-tags',
+    'origin',
+    `+refs/heads/${branch}:refs/remotes/origin/${branch}`
+  ]
 }
 
 // Why (STA-1292): the broad create-path fetch must carry a timeout so a Windows
@@ -188,8 +210,20 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     })
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+      exactBaseRefreshArgs(),
       exactBaseRefreshOptions('/repo/f')
+    )
+  })
+
+  it('keeps automatic maintenance enabled for ordinary full remote fetches', async () => {
+    mockFetchResults([{ stdout: '', stderr: '' }])
+    const runtime = new OrcaRuntimeService(null)
+
+    await runtime.getOrStartRemoteFetch('/repo/full-maintenance', 'origin')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['fetch', 'origin'],
+      fullRemoteFetchOptions('/repo/full-maintenance')
     )
   })
 
@@ -297,14 +331,9 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
       { ok: true },
       { ok: true }
     ])
-    const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(
-      ([argv]) => Array.isArray(argv) && argv[0] === 'fetch'
-    )
+    const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(([argv]) => isFetchArgs(argv))
     expect(fetchCalls).toEqual([
-      [
-        ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
-        exactBaseRefreshOptions('/repo/h')
-      ],
+      [exactBaseRefreshArgs(), exactBaseRefreshOptions('/repo/h')],
       [['fetch', 'origin'], fullRemoteFetchOptions('/repo/h')]
     ])
   })
@@ -343,15 +372,10 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
       { ok: true },
       { ok: true }
     ])
-    const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(
-      ([argv]) => Array.isArray(argv) && argv[0] === 'fetch'
-    )
+    const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(([argv]) => isFetchArgs(argv))
     expect(fetchCalls).toEqual([
       [['fetch', 'origin'], fullRemoteFetchOptions('/repo/i')],
-      [
-        ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
-        exactBaseRefreshOptions('/repo/i')
-      ]
+      [exactBaseRefreshArgs(), exactBaseRefreshOptions('/repo/i')]
     ])
   })
 
@@ -389,15 +413,10 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
       { ok: false, errorKind: 'git_error' },
       { ok: true }
     ])
-    const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(
-      ([argv]) => Array.isArray(argv) && argv[0] === 'fetch'
-    )
+    const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(([argv]) => isFetchArgs(argv))
     expect(fetchCalls).toEqual([
       [['fetch', 'origin'], fullRemoteFetchOptions('/repo/i-fail')],
-      [
-        ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
-        exactBaseRefreshOptions('/repo/i-fail')
-      ]
+      [exactBaseRefreshArgs(), exactBaseRefreshOptions('/repo/i-fail')]
     ])
   })
 })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2329,6 +2329,8 @@ describe('OrcaRuntimeService', () => {
             '-c',
             'maintenance.auto=false',
             '-c',
+            'maintenance.commit-graph.auto=0',
+            '-c',
             'gc.auto=0',
             'fetch',
             '--no-tags',
@@ -2592,6 +2594,8 @@ describe('OrcaRuntimeService', () => {
         [
           '-c',
           'maintenance.auto=false',
+          '-c',
+          'maintenance.commit-graph.auto=0',
           '-c',
           'gc.auto=0',
           'fetch',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2312,7 +2312,7 @@ describe('OrcaRuntimeService', () => {
       if (args[0] === 'rev-parse' && args[1] === '--verify') {
         return { stdout: 'base-sha\n', stderr: '' }
       }
-      if (args[0] === 'fetch') {
+      if (args.includes('fetch')) {
         return refresh.promise
       }
       return { stdout: '', stderr: '' }
@@ -2325,7 +2325,16 @@ describe('OrcaRuntimeService', () => {
 
       await vi.waitFor(() => {
         expect(gitSpy).toHaveBeenCalledWith(
-          ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+          [
+            '-c',
+            'maintenance.auto=false',
+            '-c',
+            'gc.auto=0',
+            'fetch',
+            '--no-tags',
+            'origin',
+            '+refs/heads/main:refs/remotes/origin/main'
+          ],
           {
             cwd: TEST_REPO_PATH,
             useConfiguredSshCommandForNetwork: true,
@@ -2443,7 +2452,7 @@ describe('OrcaRuntimeService', () => {
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
         return { stdout: 'base-sha\n', stderr: '' }
       }
-      if (args[0] === 'fetch') {
+      if (args.includes('fetch')) {
         throw new Error('network unavailable')
       }
       return { stdout: '', stderr: '' }
@@ -2505,7 +2514,7 @@ describe('OrcaRuntimeService', () => {
       if (args[0] === 'rev-parse' && args.includes('refs/heads/develop^{commit}')) {
         return { stdout: 'develop-sha\n', stderr: '' }
       }
-      if (args[0] === 'fetch') {
+      if (args.includes('fetch')) {
         throw new Error('network unavailable')
       }
       return { stdout: '', stderr: '' }
@@ -2559,7 +2568,7 @@ describe('OrcaRuntimeService', () => {
       if (args[0] === 'rev-parse' && args.includes('refs/heads/team/feature^{commit}')) {
         return { stdout: 'team-feature-sha\n', stderr: '' }
       }
-      if (args[0] === 'fetch') {
+      if (args.includes('fetch')) {
         throw new Error('network unavailable')
       }
       return { stdout: '', stderr: '' }
@@ -2580,7 +2589,16 @@ describe('OrcaRuntimeService', () => {
         false
       )
       expect(gitSpy).not.toHaveBeenCalledWith(
-        ['fetch', '--no-tags', 'team', '+refs/heads/feature:refs/remotes/team/feature'],
+        [
+          '-c',
+          'maintenance.auto=false',
+          '-c',
+          'gc.auto=0',
+          'fetch',
+          '--no-tags',
+          'team',
+          '+refs/heads/feature:refs/remotes/team/feature'
+        ],
         expect.any(Object)
       )
     } finally {
@@ -2604,7 +2622,7 @@ describe('OrcaRuntimeService', () => {
       if (args[0] === 'rev-parse' && args[1] === '--verify') {
         throw new Error('missing ref')
       }
-      if (args[0] === 'fetch') {
+      if (args.includes('fetch')) {
         throw new Error('network unavailable')
       }
       return { stdout: '', stderr: '' }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -14621,6 +14621,7 @@ export class OrcaRuntimeService {
       if (this.getFreshFetchCompletedAt(key) !== null) {
         return { ok: true }
       }
+      // Why: this exact refresh gates worktree create; ordinary fetches still own maintenance.
       return gitExecFileAsync(
         [
           ...GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -49,6 +49,7 @@ import {
   getClonePathComparisonKey
 } from '../git/repo-clone-path'
 import { getGitCloneFailureMessage } from '../../shared/git-clone-failure-message'
+import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../../shared/git-fetch-auto-maintenance'
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
@@ -14621,7 +14622,13 @@ export class OrcaRuntimeService {
         return { ok: true }
       }
       return gitExecFileAsync(
-        ['fetch', '--no-tags', base.remote, `+refs/heads/${base.branch}:${base.ref}`],
+        [
+          ...GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS,
+          'fetch',
+          '--no-tags',
+          base.remote,
+          `+refs/heads/${base.branch}:${base.ref}`
+        ],
         {
           cwd: repoPath,
           ...gitOptions,

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -1243,6 +1243,8 @@ describe('GitHandler', () => {
           '-c',
           'maintenance.auto=false',
           '-c',
+          'maintenance.commit-graph.auto=0',
+          '-c',
           'gc.auto=0',
           'fetch',
           '--no-tags',

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -1222,7 +1222,8 @@ describe('GitHandler', () => {
         worktreePath: tmpDir,
         remote: 'origin',
         branch: 'main',
-        ref: 'refs/remotes/origin/main'
+        ref: 'refs/remotes/origin/main',
+        skipAutoMaintenance: true
       })
 
       const second = dispatcher.callRequest('git.diff', {
@@ -1238,7 +1239,16 @@ describe('GitHandler', () => {
 
       expect(gitBufferSpy).toHaveBeenCalledTimes(2)
       expect(gitSpy).toHaveBeenCalledWith(
-        ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+        [
+          '-c',
+          'maintenance.auto=false',
+          '-c',
+          'gc.auto=0',
+          'fetch',
+          '--no-tags',
+          'origin',
+          '+refs/heads/main:refs/remotes/origin/main'
+        ],
         tmpDir
       )
     })

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -60,6 +60,7 @@ import {
 import { getGitCloneFailureMessage } from '../shared/git-clone-failure-message'
 import { syncForkDefaultBranch, validateGitForkSyncExpectedUpstream } from '../shared/git-fork-sync'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../shared/in-flight-promise-dedupe'
+import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../shared/git-fetch-auto-maintenance'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
@@ -844,9 +845,13 @@ export class GitHandler {
     const remote = params.remote
     const branch = params.branch
     const ref = params.ref
+    const skipAutoMaintenance = params.skipAutoMaintenance
     try {
       if (typeof remote !== 'string' || typeof branch !== 'string' || typeof ref !== 'string') {
         throw new Error('Invalid remote-tracking fetch request.')
+      }
+      if (skipAutoMaintenance !== undefined && typeof skipAutoMaintenance !== 'boolean') {
+        throw new Error('Invalid remote-tracking fetch maintenance option.')
       }
       if (remote.startsWith('-') || branch.startsWith('-')) {
         throw new Error('Remote-tracking fetch inputs must not start with "-".')
@@ -866,7 +871,16 @@ export class GitHandler {
         }
         await this.git(['check-ref-format', `refs/heads/${branch}`], worktreePath)
         await this.git(['check-ref-format', ref], worktreePath)
-        await this.git(['fetch', '--no-tags', remote, `+refs/heads/${branch}:${ref}`], worktreePath)
+        await this.git(
+          [
+            ...(skipAutoMaintenance ? GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS : []),
+            'fetch',
+            '--no-tags',
+            remote,
+            `+refs/heads/${branch}:${ref}`
+          ],
+          worktreePath
+        )
       } catch (error) {
         // Why: create-worktree needs a write-capable fetch, but generic git.exec
         // intentionally rejects fetch. This narrow RPC keeps the relay allowlist

--- a/src/shared/git-fetch-auto-maintenance.ts
+++ b/src/shared/git-fetch-auto-maintenance.ts
@@ -1,8 +1,10 @@
-// Why: repo housekeeping is unrelated to ref freshness; per-command config also works on old Git.
-// Cover both modern maintenance and its legacy auto-gc predecessor without changing user config.
+// Why: Git 2.29 can auto-run commit-graph work before maintenance.auto became a gate.
+// The other keys cover modern maintenance and legacy auto-gc without changing user config.
 export const GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS = [
   '-c',
   'maintenance.auto=false',
+  '-c',
+  'maintenance.commit-graph.auto=0',
   '-c',
   'gc.auto=0'
 ] as const

--- a/src/shared/git-fetch-auto-maintenance.ts
+++ b/src/shared/git-fetch-auto-maintenance.ts
@@ -1,0 +1,8 @@
+// Why: repo housekeeping is unrelated to ref freshness; per-command config also works on old Git.
+// Cover both modern maintenance and its legacy auto-gc predecessor without changing user config.
+export const GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS = [
+  '-c',
+  'maintenance.auto=false',
+  '-c',
+  'gc.auto=0'
+] as const


### PR DESCRIPTION
## Summary

- keep exact-base worktree refreshes from waiting on unrelated opportunistic Git maintenance
- preserve the existing exact refspec, 30-second freshness window, timeout, failure fallback, and normal full-fetch maintenance behavior
- carry the latency-sensitive hint through the SSH provider/relay as an optional, validated field so old/new relay pairings remain compatible

The intermittent delay was not the network transfer: a traced real fetch negotiated and refreshed the requested ref in about 0.37s, then remained blocked in `git maintenance run --auto` / `reflog expire --all`. The same exact fetch with per-command maintenance disabled completed in 0.42s instead of 26.65s, with the remote-tracking SHA unchanged.

## ELI5
Before Orca creates a worktree from a base such as `origin/main`, it asks Git to update Orca's local pointer to that remote branch. This required step makes sure the new worktree starts from the current remote commit.

Sometimes that one `git fetch` command did two separate jobs:

1. **Required:** contact the remote and update the exact base-branch pointer.
2. **Optional:** if Git decided the repository had crossed a housekeeping threshold, clean up old Git logs and repository metadata.

Orca must wait for the whole command to exit, so the UI continued to say “Fetching base branch…” during the optional cleanup—even though the base branch itself was already updated. That explains why the delay was intermittent: Git only starts automatic housekeeping when its thresholds are reached. In the traced slow case, the required remote work finished in about 0.37s and the later housekeeping caused nearly all of the remaining 26.65s.

This PR tells Git, for this one latency-sensitive create-time fetch: **update the exact branch pointer, but do not start optional automatic housekeeping inside this command.** It does not skip the required fetch, accept a stale branch, change which branch is fetched, or change what happens when the fetch fails. Normal fetch/pull operations and explicit or scheduled Git maintenance can still perform housekeeping.

## Git version and platform compatibility

Orca's worktree feature requires Git 2.5 or newer. The final command covers every worktree-capable Git generation:

- **Git 2.5–2.28:** `-c` and `gc.auto=0` are supported. These versions safely ignore the newer, syntactically valid maintenance keys.
- **Git 2.29.x:** this transitional release starts `git maintenance run --auto` before `maintenance.auto=false` became a top-level gate. `gc.auto=0` disables its GC task and `maintenance.commit-graph.auto=0` disables its only other automatic task. Git still starts one fast no-op maintenance process, but performs no housekeeping task.
- **Git 2.30 and newer:** `maintenance.auto=false` prevents the automatic maintenance process from starting. The other two keys remain valid and harmless.

This was verified with locally built official Git 2.5.0 and Git 2.29.3 sources, Homebrew Git 2.44, and Apple Git 2.50.1. On Git 2.5.0, the three-key command fetched the exact remote SHA and successfully created a linked worktree from it. On Git 2.29.3, a trace first reproduced the commit-graph task with the two-key command, then showed the final three-key command running no maintenance task.

The arguments are passed as an argv array, not shell text, so no platform-specific quoting was added. Relay bundles build for Linux, macOS, Windows, and WSL on the supported x64/arm64 targets. Local, WSL, SSH, and mixed old/new relay behavior is covered by tests and static routing review.

## Trade-offs

There is no known end-user correctness or freshness trade-off. There are deliberate scheduling and compatibility details:

- **Maintenance is deferred, not eliminated.** A later normal fetch/pull, explicit maintenance command, or scheduled Git maintenance may perform the same cleanup. This moves optional work out of the interactive worktree-create path; it does not guarantee that the repository will never pay that maintenance cost elsewhere.
- **Cleanup can happen later than it otherwise would.** If a repository only ever receives these exact create-time fetches and never runs another maintenance-eligible Git operation, old reflog/metadata cleanup may be postponed and the repository metadata may remain larger for longer. Orca's ordinary fetches still allow automatic maintenance, and this PR does not disable explicit or scheduled maintenance.
- **The speedup only applies when auto-maintenance was the delay.** If Git was not going to run housekeeping, this change has little or no effect. The 26.65s → 0.42s measurement is a reproduced slow case, not a guarantee that every create will take 0.42s.
- **Git 2.29 keeps one fast no-op process.** Its version-specific behavior cannot avoid starting `git maintenance`, but the final command prevents both available tasks from running.
- **An old SSH relay preserves correctness but not the speedup.** Older relays ignore the optional new field and perform the original fetch behavior until the relay is upgraded. An old client talking to a new relay also keeps the original behavior.
- **Explicit user fetch configuration remains honored.** For example, `fetch.writeCommitGraph=true` is an explicit request inside fetch itself, not opportunistic auto-maintenance. Overriding it would create a user-configuration trade-off, so this PR intentionally does not.

What is specifically **not** traded away: the exact remote ref update, the existing 30-second freshness rule, network/authentication behavior, configured SSH/WSL routing, timeouts, failure handling, or the commit SHA used to create the worktree.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — branch checks pass; a latest-`main` local rebase separately exposed an unrelated Japanese localization mismatch in files untouched by this PR
- [x] `pnpm typecheck`
- [x] `pnpm test` — the full required GitHub `verify` check passed on the final PR head
- [ ] `pnpm build` — `pnpm build:relay` passed for linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, win32-arm64, and WSL
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused final regression suite (952 passed):

`pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/fetch-remote-cache.test.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/worktrees.test.ts src/main/providers/ssh-git-provider.test.ts src/relay/git-handler.test.ts`

Windows/WSL Git runner suite: 26 passed.

Performance/correctness trace:

- before: `git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main` — 26.65s total; remote negotiation/ref consumption finished in about 0.37s and the remainder was auto-maintenance
- after: `git -c maintenance.auto=false -c maintenance.commit-graph.auto=0 -c gc.auto=0 fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main` — 0.42s in the reproduced slow repository
- `refs/remotes/origin/main` resolved to the same SHA before and after the optimized command
- none of the maintenance settings were persisted in repository config
- isolated Electron validation visibly created and opened the exact-base worktree in 277ms; Git Trace2 recorded the final argv, no modern maintenance child, and matching remote/tracking/worktree SHAs

## AI Review Report

Two adversarial review/fix rounds covered the create hot path, fetch cache, WSL routing, SSH provider/relay protocol, Git version boundaries, and relevant tests. The review checked:

- exact remote-base freshness is still required before `git worktree add`; there is no stale-ref shortcut or longer cache window
- ordinary full remote fetches retain automatic maintenance, with a dedicated regression assertion
- no polling, additional application subprocess, fanout, unbounded cache, listener, or lifecycle work was added
- macOS/Linux/Windows use fixed argv rather than shell syntax; WSL keeps the existing distro and configured-SSH routing
- SSH's new field is optional for old/new relay compatibility and only a boolean is accepted by the relay

The first implementation used `--no-auto-gc`, which is unavailable on older Git versions Orca tolerates. It was replaced with invocation-scoped config. A later adversarial pass then reproduced Git 2.29's transitional behavior and added `maintenance.commit-graph.auto=0`. Fresh Claude and Codex reviewers both returned no issues on the final three-key implementation.

## Security Audit

- the new Git config argv is a fixed constant; no user-controlled value reaches `-c` and no shell is involved
- existing remote, branch, ref, credential, timeout, and SSH-command validation remains unchanged
- the relay validates the optional maintenance hint as a boolean and retains exact remote/ref matching checks
- no paths, auth data, secrets, dependencies, permissions, or persistent Git config were added or changed

## Notes

- Root cause: Git's threshold-triggered repository housekeeping occasionally ran after the exact base ref was already current, explaining why the delay appeared only sometimes.
- Automatic maintenance is suppressed only for latency-sensitive create-base refreshes. Normal fetch/pull paths and explicit/scheduled Git maintenance remain unchanged.
- A live throwaway Linux SSH smoke could not run because Docker Desktop's backend is non-responsive; it was not force-restarted to avoid disrupting user containers. Real relay Git integration tests, provider serialization tests, SSH create tests, and all relay target builds pass.
- No live Windows run was available. Cross-platform argv, old-Git compatibility, WSL option propagation, Windows/WSL runner tests, and win32 relay builds were verified.
