### PR TITLE
Bump mobile app.json to 0.0.26

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump `mobile/app.json` `expo.version` to 0.0.26 so the repo's source of truth matches the shipping release.
- iOS `buildNumber` and Android `versionCode` are intentionally left untouched — those are resolved/incremented by the release workflows (fastlane `prepare_release_version` / `prepare-android-release.mjs`).

## Context
- iOS 0.0.26 (build 3) was built via the Mobile iOS Release workflow and is processed on TestFlight.
- Mobile Android Release for 0.0.26 is building now.

## Verification
- `node -e` on app.json confirms `version: 0.0.26 | ios.buildNumber: 1 | android.versionCode: 6` (only the marketing version changed).

Made with [Orca](https://github.com/stablyai/orca) 🐋
