### PR TITLE
Normalize invalid terminal line height before xterm

### DIFF
--- a/src/main/ipc/settings.test.ts
+++ b/src/main/ipc/settings.test.ts
@@ -306,6 +306,24 @@ describe('registerSettingsHandlers', () => {
     )
   })
 
+  it('normalizes terminal line height updates before persistence', async () => {
+    store.getSettings.mockReturnValue({ terminalLineHeight: 1 })
+    store.updateSettings.mockReturnValue({ terminalLineHeight: 1 })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find((call) => call[0] === 'settings:set')?.[1] as (
+      _event: unknown,
+      args: unknown
+    ) => Promise<unknown>
+
+    await handler(settingsInvokeEvent, { terminalLineHeight: 0.85 })
+
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      { terminalLineHeight: 1 },
+      { notifyListeners: true, originWebContentsId: 1 }
+    )
+  })
+
   it('normalizes custom terminal themes from renderer settings IPC', async () => {
     store.getSettings.mockReturnValue({ terminalCustomThemes: [] })
     store.updateSettings.mockReturnValue({ terminalCustomThemes: [] })

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -18,6 +18,7 @@ import { normalizeUiLanguage } from '../../shared/ui-language'
 import { applyAppIcon } from '../app-icon'
 import { normalizeTerminalCustomThemes } from '../../shared/terminal-custom-themes'
 import { normalizeDesktopTerminalScrollbackRows } from '../../shared/terminal-scrollback-policy'
+import { normalizeTerminalLineHeight } from '../../shared/terminal-line-height-settings'
 import { prepareLocalWorktreeRootsForRepos } from '../worktree-root-preparation'
 import { scheduleCurrentWorktreeBaseDirectoryWatcherSync } from './worktree-base-directory-watcher'
 
@@ -94,6 +95,9 @@ export function registerSettingsHandlers(
       sanitizedArgs.terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(
         args.terminalScrollbackRows
       )
+    }
+    if ('terminalLineHeight' in args) {
+      sanitizedArgs.terminalLineHeight = normalizeTerminalLineHeight(args.terminalLineHeight)
     }
     if ('uiLanguage' in args) {
       sanitizedArgs.uiLanguage = normalizeUiLanguage(args.uiLanguage)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -535,6 +535,20 @@ describe('Store', () => {
     expect(settings.notifications.suppressWhenFocused).toBe(true)
   })
 
+  it('repairs a persisted terminal line height outside xterm bounds', async () => {
+    const persisted = getDefaultPersistedState(testState.dir)
+    writeDataFile({
+      ...persisted,
+      settings: { ...persisted.settings, terminalLineHeight: 0.85 }
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().terminalLineHeight).toBe(1)
+    store.flush()
+    expect((readDataFile() as PersistedState).settings.terminalLineHeight).toBe(1)
+  })
+
   it('returns default UI state when no data file exists', async () => {
     const store = await createStore()
     const ui = store.getUI()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -203,6 +203,7 @@ import {
   normalizeTuiAgentEnvRecord
 } from '../shared/tui-agent-launch-defaults'
 import { normalizeTerminalCursorStyleDefault } from '../shared/terminal-cursor-style-settings'
+import { normalizeTerminalLineHeight } from '../shared/terminal-line-height-settings'
 import { normalizeUiLanguage } from '../shared/ui-language'
 import { normalizeBrowserPageZoomLevel } from '../shared/browser-page-zoom'
 import { persistedUIValuesEqual } from '../shared/persisted-ui-equality'
@@ -2987,6 +2988,15 @@ export class Store {
           parsed.settings
         )
         const migratedTerminalCursorStyle = normalizeTerminalCursorStyleDefault(parsed.settings)
+        const migratedTerminalLineHeight = normalizeTerminalLineHeight(
+          parsed.settings?.terminalLineHeight
+        )
+        if (
+          parsed.settings?.terminalLineHeight !== undefined &&
+          parsed.settings.terminalLineHeight !== migratedTerminalLineHeight
+        ) {
+          this.loadNeedsSave = true
+        }
         const rawTaskProviderSettings = normalizeTaskProviderSettings({
           visibleTaskProviders: parsed.settings?.visibleTaskProviders,
           defaultTaskSource: parsed.settings?.defaultTaskSource
@@ -3119,6 +3129,7 @@ export class Store {
               primarySelectionDefaultedForTerminalDefaults || stampPrimarySelectionTerminalDefaults,
             ...migratedAutoRenameBranchFromWork,
             ...migratedTerminalCursorStyle,
+            terminalLineHeight: migratedTerminalLineHeight,
             ...migratedTerminalTuiScrollSensitivity.settings,
             experimentalActivity: migratedExperimentalActivity,
             experimentalActivityDefaultedOffForAllUsers: true,

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
@@ -225,6 +225,12 @@ describe('TerminalSettingsPreview terminal lifecycle', () => {
     expect(terminal.dispose).toHaveBeenCalledOnce()
   })
 
+  it('does not pass a persisted sub-minimum line height to xterm', () => {
+    renderPreview(makeSettings({ terminalLineHeight: 0.85 }))
+
+    expect(mockXterm.instances[0]?.options.lineHeight).toBe(1)
+  })
+
   it('disposes the ligatures addon before disposing the terminal', () => {
     mockLigaturesAddon.enabled = true
 

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -10,6 +10,7 @@ import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-
 import { clampNumber, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
+import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { PREVIEW_BUFFER } from './terminal-preview-content'
 import { SettingsSwitch } from './SettingsFormControls'
 import type { GlobalSettings } from '../../../../shared/types'
@@ -79,6 +80,7 @@ export function TerminalSettingsPreview({
   const skipInitialThemeRewriteRef = useRef(false)
 
   const effectiveFontFamily = previewFontFamily || settings.terminalFontFamily
+  const terminalLineHeight = normalizeTerminalLineHeight(settings.terminalLineHeight)
 
   // Why: lazy-init from the active app theme so the toggle starts in the
   // user's current mode. After init the toggle is independent — flipping
@@ -162,7 +164,7 @@ export function TerminalSettingsPreview({
       fontFamily: buildFontFamily(effectiveFontFamily),
       fontWeight: weights.fontWeight,
       fontWeightBold: weights.fontWeightBold,
-      lineHeight: settings.terminalLineHeight,
+      lineHeight: terminalLineHeight,
       theme: composedTheme ?? undefined,
       allowTransparency:
         settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1,
@@ -208,7 +210,7 @@ export function TerminalSettingsPreview({
     terminal.options.fontFamily = buildFontFamily(effectiveFontFamily)
     terminal.options.fontWeight = weights.fontWeight
     terminal.options.fontWeightBold = weights.fontWeightBold
-    terminal.options.lineHeight = settings.terminalLineHeight
+    terminal.options.lineHeight = terminalLineHeight
     terminal.options.cursorStyle = settings.terminalCursorStyle
     // Why: see constructor — mirror so the unfocused cursor reflects the
     // user's chosen shape (xterm defaults inactive to 'outline').
@@ -218,7 +220,7 @@ export function TerminalSettingsPreview({
     settings.terminalFontSize,
     effectiveFontFamily,
     settings.terminalFontWeight,
-    settings.terminalLineHeight,
+    terminalLineHeight,
     settings.terminalCursorStyle,
     settings.terminalCursorBlink
   ])

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -20,6 +20,7 @@ import { getFitOverrideForPty } from '@/lib/pane-manager/mobile-fit-overrides'
 import type { PtyTransport } from './pty-transport'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { HEX_COLOR_RE } from '../../../../shared/color-validation'
+import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 
 export { mode2031SequenceFor }
 
@@ -252,7 +253,7 @@ export function applyTerminalAppearance(
     // detection behavior; the detection layer simply decides *what* value
     // `effectiveMacOptionAsAlt` carries.
     pane.terminal.options.macOptionIsMeta = effectiveMacOptionAsAlt === 'true'
-    pane.terminal.options.lineHeight = settings.terminalLineHeight
+    pane.terminal.options.lineHeight = normalizeTerminalLineHeight(settings.terminalLineHeight)
     // Why call unconditionally: the per-pane helper is a no-op when the
     // current addon state already matches, so passing the resolved value on
     // every appearance apply keeps newly-created panes in sync without a

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -14,6 +14,7 @@ import {
   resolveTerminalCursorInactiveStyle
 } from '@/lib/pane-manager/pane-terminal-options'
 import { normalizeDesktopTerminalScrollbackRows } from '../../../../shared/terminal-scrollback-policy'
+import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { normalizeTerminalTuiMouseWheelMultiplier } from '@/lib/pane-manager/pane-terminal-mouse-wheel'
 import { buildWindowsPtyCompatibilityOptions } from '@/lib/pane-manager/windows-pty-compatibility'
 import { buildTerminalKeyboardProtocolOptions } from '@/lib/pane-manager/terminal-keyboard-protocol'
@@ -1407,7 +1408,7 @@ export function useTerminalPaneLifecycle({
             currentSettings?.terminalFastScrollSensitivity
           ),
           macOptionIsMeta: effectiveMacOptionAsAltRef.current === 'true',
-          lineHeight: currentSettings?.terminalLineHeight ?? 1,
+          lineHeight: normalizeTerminalLineHeight(currentSettings?.terminalLineHeight),
           wordSeparator: currentSettings?.terminalWordSeparator
         }
       },

--- a/src/shared/terminal-line-height-settings.test.ts
+++ b/src/shared/terminal-line-height-settings.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_TERMINAL_LINE_HEIGHT,
+  MIN_TERMINAL_LINE_HEIGHT,
+  normalizeTerminalLineHeight
+} from './terminal-line-height-settings'
+
+describe('normalizeTerminalLineHeight', () => {
+  it.each([
+    [undefined, MIN_TERMINAL_LINE_HEIGHT],
+    [Number.NaN, MIN_TERMINAL_LINE_HEIGHT],
+    [0.85, MIN_TERMINAL_LINE_HEIGHT],
+    [1, 1],
+    [1.35, 1.35],
+    [3, 3],
+    [4, MAX_TERMINAL_LINE_HEIGHT]
+  ])('normalizes %s to %s', (input, expected) => {
+    expect(normalizeTerminalLineHeight(input)).toBe(expected)
+  })
+})

--- a/src/shared/terminal-line-height-settings.ts
+++ b/src/shared/terminal-line-height-settings.ts
@@ -1,0 +1,11 @@
+export const MIN_TERMINAL_LINE_HEIGHT = 1
+export const MAX_TERMINAL_LINE_HEIGHT = 3
+
+export function normalizeTerminalLineHeight(value: unknown): number {
+  // Why: older or user-edited profiles can bypass the UI clamp, and xterm
+  // throws during construction when lineHeight is below one.
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return MIN_TERMINAL_LINE_HEIGHT
+  }
+  return Math.min(MAX_TERMINAL_LINE_HEIGHT, Math.max(MIN_TERMINAL_LINE_HEIGHT, value))
+}


### PR DESCRIPTION
## Description

Fixes crash reports `ebfaa501-de3f-4dea-a118-53939a4b531a` and `e5f85f81-1bc4-4003-85e7-f9016ce1459b`.

Both reports contain the same xterm exception: `lineHeight cannot be less than 1, value: 0.85`. The Settings control already clamps new input to `[1, 3]`, but legacy/user-edited persisted state and renderer IPC updates bypassed that clamp. A stored `0.85` therefore reached both the terminal workbench and Settings preview and escaped through their React error boundaries.

This PR adds one shared line-height normalizer, repairs invalid persisted values on load, normalizes renderer IPC updates before persistence, and defensively normalizes both xterm construction/mutation paths.

## Clear, undeniable fix evidence

### Before (exact live reproduction)

Using an isolated Orca dev profile on current `main`:

1. Persist `terminalLineHeight=0.85`.
2. Open Settings → Appearance.
3. Observe two console errors from `TerminalSettingsPreview`:
   `Error: lineHeight cannot be less than 1, value: 0.85`.

The regression test was then added before the fix and failed:

```
expected 0.85 to be 1
- Expected: 1
+ Received: 0.85
TerminalSettingsPreview.lifecycle.test.tsx:231
```

### After (same corrupted value)

With the renderer store deliberately left at `terminalLineHeight=0.85`:

- Settings → Appearance: `xtermSurfaces=1`, Appearance heading visible, **0 console errors**.
- Terminal workbench: `xtermSurfaces=1`, terminal surface visible, **0 console errors**.
- Persistence reload rewrites `0.85` to `1`.
- `settings:set({ terminalLineHeight: 0.85 })` persists `1`.

Automated evidence:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-line-height-settings.test.ts src/main/ipc/settings.test.ts src/main/persistence.test.ts src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx` — **391 passed**
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-appearance.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts` — **39 passed**
- Existing `xterm-addon.boundary-containment` reliability command — **41 passed**
- `pnpm typecheck` — passed
- changed-file `oxlint`, `git diff --check`, and `pnpm check:max-lines-ratchet` — passed

## ELI5

Orca's settings screen only lets users choose safe terminal line spacing, but an older settings file could still contain an unsafe number. Orca handed that number directly to the terminal library, and the library threw an error that removed the terminal/settings surface. Orca now checks the number whenever it loads, saves, or applies it, so old bad values become the nearest safe value before the terminal sees them.

## Trade-offs

- Values below `1` now become `1`; values above `3` become `3`; non-finite values become `1`.
- This intentionally changes behavior for manually edited/legacy unsupported values: Orca no longer preserves spacing outside the Settings UI's documented `1–3` range.
- No supported value changes, and no polling, scans, PTY calls, provider calls, or render loops are added.

## Reliability proof

- **Reliability class / gate:** `xterm-addon.boundary-containment` (existing experimental, partial gate; unchanged).
- **Invariant:** persisted, renderer-supplied, local, or remote settings cannot pass an out-of-contract line height into xterm construction or live option mutation.
- **Product change type:** runtime hardening plus regression coverage.
- **Performance risk:** constant-time numeric normalization in settings load/update and terminal option application. Typing, focus, switching, resize, output, startup awaits, provider listing, hidden output, and git/worktree scans are unchanged.
- **Provider/platform coverage:** shared option path covers local, daemon, SSH, WSL, remote-runtime, and mobile/relay consumers. Automated tests are platform-neutral; live Electron evidence is macOS only.
- **Residual gaps:** no live Linux/Windows Electron run in this PR; Windows crash payloads are being handled separately on a Windows machine.
- **Promotion status:** gate remains experimental/partial because this fix does not add cross-platform runtime history.
- **Rollback/demotion rule:** revert or follow up if any supported value in `[1,3]` changes, if xterm surfaces diverge from the persisted normalized value, or if cross-platform Electron validation exposes a provider-specific settings path.
