### PR TITLE
perf(renderer): scope sidebar agent freshness by worktree

### DIFF
--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -16,6 +16,10 @@ import {
   selectRetainedAgentEntriesForWorktree,
   selectTerminalLayoutsForWorktree
 } from './worktree-agent-row-selectors'
+import {
+  createWorktreeAgentFreshnessSelector,
+  EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
+} from './worktree-agent-freshness-selector'
 
 export { buildWorktreeAgentRows } from './worktree-agent-rows'
 export {
@@ -36,6 +40,10 @@ export {
  * selector work on high-frequency agent status pings.
  */
 export function useWorktreeAgentRows(worktreeId: string, active = true): DashboardAgentRow[] {
+  const selectAgentFreshness = useMemo(
+    () => createWorktreeAgentFreshnessSelector(worktreeId),
+    [worktreeId]
+  )
   const tabs = useAppStore((s) => (active ? s.tabsByWorktree[worktreeId] : undefined))
   // Why: narrow the subscriptions to only THIS worktree's entries via
   // useShallow. Subscribing to the whole agentStatusByPaneKey map would make
@@ -66,19 +74,16 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
     useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
   )
-  // Why: agentStatusEpoch is included in the dependency array (but not in the
-  // computation itself) so the memo recomputes when freshness boundaries
-  // expire, even if no new PTY data arrives — same rationale as
-  // useDashboardData.
-  const agentStatusEpoch = useAppStore((s) => (active ? s.agentStatusEpoch : 0))
+  const agentFreshnessSignature = useAppStore((s) =>
+    active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
+  )
 
   return useMemo<DashboardAgentRow[]>(() => {
     if (!active) {
       return []
     }
-    // Why: Date.now() is read inside the memo (not as a dep) so stale-decay
-    // recalculates whenever agentStatusEpoch ticks — same pattern as
-    // useDashboardData.
+    // Why: Date.now() is read inside the memo so stale-decay recalculates when
+    // this worktree's freshness signature changes, even without new PTY data.
     const now = Date.now()
     const entries =
       migrationUnsupported.length > 0
@@ -113,6 +118,6 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
-    agentStatusEpoch
+    agentFreshnessSignature
   ])
 }

--- a/src/renderer/src/components/sidebar/worktree-agent-freshness-selector.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-freshness-selector.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
+import { createWorktreeAgentFreshnessSelector } from './worktree-agent-freshness-selector'
+
+const WT_1_PANE = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+const WT_2_PANE = makePaneKey('tab-2', '22222222-2222-4222-8222-222222222222')
+
+function makeTab(id: string, worktreeId: string): TerminalTab {
+  return {
+    id,
+    worktreeId,
+    ptyId: null,
+    title: 'Claude',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function makeEntry(paneKey: string, worktreeId: string, updatedAt: number): AgentStatusEntry {
+  return {
+    paneKey,
+    worktreeId,
+    state: 'working',
+    stateStartedAt: updatedAt,
+    updatedAt,
+    stateHistory: [],
+    prompt: 'working',
+    agentType: 'claude'
+  }
+}
+
+function makeState(agentStatusEpoch: number, wt1UpdatedAt: number, wt2UpdatedAt: number) {
+  return {
+    agentStatusEpoch,
+    tabsByWorktree: {
+      'wt-1': [makeTab('tab-1', 'wt-1')],
+      'wt-2': [makeTab('tab-2', 'wt-2')]
+    },
+    agentStatusByPaneKey: {
+      [WT_1_PANE]: makeEntry(WT_1_PANE, 'wt-1', wt1UpdatedAt),
+      [WT_2_PANE]: makeEntry(WT_2_PANE, 'wt-2', wt2UpdatedAt)
+    },
+    migrationUnsupportedByPtyId: {},
+    retainedAgentsByPaneKey: {}
+  }
+}
+
+describe('createWorktreeAgentFreshnessSelector', () => {
+  it('changes only the worktree whose row crosses the stale boundary', () => {
+    let now = AGENT_STATUS_STALE_AFTER_MS - 1
+    const state = makeState(1, now - 1, 0)
+    const selectWt1 = createWorktreeAgentFreshnessSelector('wt-1', () => now)
+    const selectWt2 = createWorktreeAgentFreshnessSelector('wt-2', () => now)
+    const firstWt1 = selectWt1(state)
+    const firstWt2 = selectWt2(state)
+
+    now = AGENT_STATUS_STALE_AFTER_MS + 1
+    const nextState = { ...state, agentStatusEpoch: 2 }
+
+    // The global scheduler bumps one epoch for all cards. Zustand compares the
+    // selected string by value, so the unrelated card now skips its render.
+    expect(selectWt1(nextState)).toBe(firstWt1)
+    expect(selectWt2(nextState)).not.toBe(firstWt2)
+  })
+
+  it('does constant work for same-epoch status-map churn', () => {
+    const readNow = vi.fn(() => 1_000)
+    const selector = createWorktreeAgentFreshnessSelector('wt-1', readNow)
+    const state = makeState(3, 900, 900)
+    const first = selector(state)
+
+    const sameStatePing = {
+      ...state,
+      agentStatusByPaneKey: {
+        ...state.agentStatusByPaneKey,
+        [WT_2_PANE]: { ...state.agentStatusByPaneKey[WT_2_PANE], updatedAt: 950 }
+      }
+    }
+
+    expect(selector(sameStatePing)).toBe(first)
+    expect(readNow).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['working', 'blocked', 'waiting'] as const)(
+    'wakes a %s row when it becomes stale',
+    (state) => {
+      let now = AGENT_STATUS_STALE_AFTER_MS - 1
+      const initial = makeState(10, 0, now)
+      initial.agentStatusByPaneKey[WT_1_PANE].state = state
+      const selector = createWorktreeAgentFreshnessSelector('wt-1', () => now)
+      const fresh = selector(initial)
+
+      now = AGENT_STATUS_STALE_AFTER_MS + 1
+
+      expect(selector({ ...initial, agentStatusEpoch: 11 })).not.toBe(fresh)
+    }
+  )
+})

--- a/src/renderer/src/components/sidebar/worktree-agent-freshness-selector.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-freshness-selector.ts
@@ -1,0 +1,53 @@
+import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import type { AppState } from '@/store/types'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
+import { selectLiveAgentStatusEntriesForWorktree } from './worktree-agent-row-selectors'
+
+export const EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE = ''
+
+type WorktreeAgentFreshnessState = Pick<
+  AppState,
+  | 'agentStatusByPaneKey'
+  | 'agentStatusEpoch'
+  | 'migrationUnsupportedByPtyId'
+  | 'retainedAgentsByPaneKey'
+  | 'tabsByWorktree'
+>
+
+function buildWorktreeAgentFreshnessSignature(
+  state: WorktreeAgentFreshnessState,
+  worktreeId: string,
+  now: number
+): string {
+  let signature = ''
+  for (const entry of selectLiveAgentStatusEntriesForWorktree(state, worktreeId)) {
+    if (entry.state !== 'working' && entry.state !== 'blocked' && entry.state !== 'waiting') {
+      continue
+    }
+    signature += `${entry.paneKey}\0${
+      isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS) ? '1' : '0'
+    }\0`
+  }
+  return signature
+}
+
+export function createWorktreeAgentFreshnessSelector(
+  worktreeId: string,
+  readNow: () => number = Date.now
+): (state: WorktreeAgentFreshnessState) => string {
+  let cachedGlobalEpoch: number | null = null
+  let cachedSignature = EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
+
+  return (state) => {
+    // Why: the status slice bumps the epoch for state/freshness changes;
+    // same-epoch map writes are fresh same-state metadata and cannot alter decay.
+    if (cachedGlobalEpoch === state.agentStatusEpoch) {
+      return cachedSignature
+    }
+    cachedGlobalEpoch = state.agentStatusEpoch
+    // Why: the global epoch wakes every card, but only cards whose effective
+    // fresh/stale row state changed should render and rebuild their row trees.
+    cachedSignature = buildWorktreeAgentFreshnessSignature(state, worktreeId, readNow())
+    return cachedSignature
+  }
+}


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. This is a
second survivor in the same sidebar subscription family: one narrowly scoped,
behavior-preserving selector change with deterministic render-gating proof.

## 1. Description

`useWorktreeAgentRows` already indexes live agent entries by worktree, but every
mounted sidebar card still subscribed directly to the single global
`agentStatusEpoch`. That epoch advances when **any** agent changes state and when
the freshness scheduler reaches **any** agent's stale boundary.

The result was residual cross-worktree fanout: one agent transition made every
visible inline-agent card re-render and rebuild its full row model (row
derivation, title fallback, retained-row dedupe, lineage tree, and sorting), even
when the indexed entries for those cards were referentially unchanged.

Fix: replace the raw global epoch subscription with one memoized selector per
worktree. It derives a short signature only from that worktree's
`working`/`blocked`/`waiting` freshness bits. The selector:

- does constant work while the global epoch is unchanged (including same-state
  prompt/tool pings);
- returns the same value when an epoch bump affects another worktree;
- changes when one of its own rows crosses fresh -> stale, preserving the exact
  time-driven `idle` decay with no new timer or polling loop.

## 2. Undeniable evidence + measurable improvement

- Deterministic regression proof:
  `worktree-agent-freshness-selector.test.ts` asserts that one global stale
  boundary changes only the owning worktree's selected value, while the sibling
  worktree remains equal and would be skipped by Zustand. It separately proves
  same-epoch status-map churn reads the clock only once and pins stale wakeups
  for all three decaying states: `working`, `blocked`, and `waiting`.
- Existing behavioral coverage: 105 focused agent-row, send-target, retention,
  and agent-status tests pass unchanged alongside the new test.
- Metric: row-tree rebuilds per unrelated global epoch change drop from
  **C -> 0** for unaffected cards; at a single-worktree stale boundary the
  aggregate drops from **C -> 1** (`C` = mounted worktree agent lists).
- Real visible check in the exact dev build: a real Claude turn produced a
  backing `working` hook entry and a visible `Working` sidebar row. In the same
  isolated app, backing transitions rendered `blocked` as `Needs permission`,
  `waiting` as `Waiting for input`, normal `done` as `Done`, and interrupted
  `done` as `Interrupted`. Moving the blocked entry beyond the 30-minute TTL and
  bumping the epoch changed the visible row to `Idle`.

## ELI5
Every workspace card was listening to one building-wide alarm clock. When one
agent aged out or changed state, all cards rebuilt their agent lists just to
discover that nothing changed for them. Each card now checks a tiny freshness
fingerprint for its own agents, so only the affected card redraws.

## 4. Trade-offs that regress the end experience

None material. Each mounted hook owns one small selector closure and, on a
global epoch change, scans only its already-indexed per-worktree entries to build
a short string. That bounded selector work replaces a React render plus the much
larger row-model rebuild. Same-state status payload changes still update the
owning card through its existing indexed-entry subscription.

## Reliability proof

- **Class / gate:** `terminal-performance.store-and-git-hot-paths`; the existing
  experimental gate remains unchanged (`protection: none`) because this PR adds
  a narrow deterministic selector oracle, not a full interaction counter gate.
- **Invariant:** a status/freshness change in one worktree must not rebuild
  unrelated sidebar agent rows, while the owning `working`/`blocked`/`waiting`
  row must still decay to `idle` at the stale boundary.
- **Product change type:** renderer performance hardening.
- **Performance risk inventory:** store subscription + sidebar render only. No
  typing, focus routing, resize, startup await, provider listing, git scan,
  hidden output, PTY output, buffering, IPC/RPC, subprocess, or polling change.
- **Provider/platform matrix:** local/daemon/SSH/WSL/remote-runtime/mobile and
  macOS/Linux/Windows all consume the same renderer state projection and are
  otherwise unaffected; the live visible run was macOS/local only.
- **Residual gaps:** no live Windows/Linux or real SSH agent run; real Claude
  proved `working` and natural exit, while blocked/waiting/done/interrupted and
  forced stale decay used the real app/store/render path rather than live agent
  prompts. Transport and ownership are outside the diff.
- **Rollback/demotion:** revert to the raw epoch subscription if field evidence
  shows a sidebar row failing to decay; do not promote the reliability gate from
  this PR alone.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-agent-freshness-selector.test.ts src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.send-target.test.tsx src/renderer/src/store/slices/agent-status.test.ts` (105 passed)
- [x] `pnpm typecheck`
- [x] Targeted `oxlint`, `pnpm check:max-lines-ratchet`, and `git diff --check`
- [x] Exact-branch Electron/CDP visible validation described above
- [ ] `pnpm lint` reaches all code lint, switch exhaustiveness, reliability,
  max-lines, and localization coverage checks, then fails on an unrelated
  current-main Japanese catalog interpolation mismatch for
  `components.native-chat.composer.uploadingAttachments`; this PR changes only
  the three renderer files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or
permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
