### PR TITLE
Fix Windows focus stealing from agent foreground-process scan (hide conhost window)

### DIFF
--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -1,0 +1,87 @@
+// Regression guard: the Windows agent foreground-process scan re-forks
+// powershell.exe (or the wmic fallback) on a ~1s/pane cadence. Electron's main
+// process has no console, so a spawn without windowsHide pops a fresh conhost
+// window per scan that flashes and steals keyboard focus from the foreground app
+// (including Orca's own terminal). Both probes MUST pass windowsHide: true.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+
+vi.mock('child_process', () => ({ execFile: execFileMock }))
+
+import {
+  queryWindowsProcessDescendants,
+  resetWindowsProcessRowsSnapshotForTests
+} from './windows-foreground-process-rows'
+
+type ExecFileCallback = (err: unknown, result: { stdout: string; stderr: string }) => void
+type ExecFileCall = [string, string[], Record<string, unknown>, ExecFileCallback]
+
+const POWERSHELL_ROWS_JSON = JSON.stringify([
+  {
+    ProcessId: 200,
+    ParentProcessId: 100,
+    Name: 'node.exe',
+    CommandLine: 'node C:/Users/dev/AppData/codex/bin/codex.js',
+    ExecutablePath: 'C:/Program Files/nodejs/node.exe'
+  }
+])
+
+const WMIC_ROWS_VALUE =
+  'CommandLine=node C:/Users/dev/AppData/codex/bin/codex.js\n' +
+  'ExecutablePath=C:/Program Files/nodejs/node.exe\n' +
+  'Name=node.exe\n' +
+  'ParentProcessId=100\n' +
+  'ProcessId=200\n'
+
+/** Returns the options object passed to the mocked execFile for a given command. */
+function optionsForCommand(command: string): Record<string, unknown> | undefined {
+  const call = execFileMock.mock.calls.find(
+    (args) => (args as ExecFileCall)[0] === command
+  ) as ExecFileCall | undefined
+  return call?.[2]
+}
+
+describe('windows foreground process rows spawn options', () => {
+  let platform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetWindowsProcessRowsSnapshotForTests()
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  })
+
+  afterEach(() => {
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+  })
+
+  it('hides the console window for the powershell process-table scan', async () => {
+    execFileMock.mockImplementation((_cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
+    })
+
+    const candidates = await queryWindowsProcessDescendants(100)
+
+    expect(candidates?.[0]?.pid).toBe(200)
+    expect(optionsForCommand('powershell.exe')).toMatchObject({ windowsHide: true })
+  })
+
+  it('hides the console window for the wmic fallback scan', async () => {
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      // Force the powershell probe to miss so the wmic fallback runs.
+      if (cmd === 'powershell.exe') {
+        cb(new Error('powershell unavailable'), { stdout: '', stderr: '' })
+        return
+      }
+      cb(null, { stdout: WMIC_ROWS_VALUE, stderr: '' })
+    })
+
+    const candidates = await queryWindowsProcessDescendants(100)
+
+    expect(candidates?.[0]?.pid).toBe(200)
+    expect(optionsForCommand('wmic')).toMatchObject({ windowsHide: true })
+  })
+})

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -19,6 +19,13 @@ type ExecFileCall = [string, string[], Record<string, unknown>, ExecFileCallback
 
 const POWERSHELL_ROWS_JSON = JSON.stringify([
   {
+    ProcessId: 100,
+    ParentProcessId: 50,
+    Name: 'powershell.exe',
+    CommandLine: 'powershell.exe',
+    ExecutablePath: 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
+  },
+  {
     ProcessId: 200,
     ParentProcessId: 100,
     Name: 'node.exe',
@@ -28,6 +35,11 @@ const POWERSHELL_ROWS_JSON = JSON.stringify([
 ])
 
 const WMIC_ROWS_VALUE =
+  'CommandLine=powershell.exe\n' +
+  'ExecutablePath=C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe\n' +
+  'Name=powershell.exe\n' +
+  'ParentProcessId=50\n' +
+  'ProcessId=100\n\n' +
   'CommandLine=node C:/Users/dev/AppData/codex/bin/codex.js\n' +
   'ExecutablePath=C:/Program Files/nodejs/node.exe\n' +
   'Name=node.exe\n' +
@@ -36,9 +48,9 @@ const WMIC_ROWS_VALUE =
 
 /** Returns the options object passed to the mocked execFile for a given command. */
 function optionsForCommand(command: string): Record<string, unknown> | undefined {
-  const call = execFileMock.mock.calls.find(
-    (args) => (args as ExecFileCall)[0] === command
-  ) as ExecFileCall | undefined
+  const call = execFileMock.mock.calls.find((args) => (args as ExecFileCall)[0] === command) as
+    | ExecFileCall
+    | undefined
   return call?.[2]
 }
 

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -200,6 +200,7 @@ function collectDescendants<Row extends { pid: number; ppid: number }>(
   return descendants
 }
 
+/** Runs the PowerShell/CIM whole-process-table scan; returns null when unavailable. */
 async function queryWindowsProcessesWithPowerShell(): Promise<WindowsProcessRow[] | null> {
   try {
     const { stdout } = await execFileAsync(
@@ -208,7 +209,12 @@ async function queryWindowsProcessesWithPowerShell(): Promise<WindowsProcessRow[
       {
         encoding: 'utf8',
         timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
-        maxBuffer: 8 * 1024 * 1024
+        maxBuffer: 8 * 1024 * 1024,
+        // Why: this scan re-forks on a ~1s/pane cadence. Electron's main has no
+        // console, so without windowsHide each fork pops a fresh conhost window
+        // that flashes and steals keyboard focus from the foreground app
+        // (including Orca's own terminal).
+        windowsHide: true
       }
     )
     const rows = parseWindowsProcessJsonRows(stdout)
@@ -218,6 +224,7 @@ async function queryWindowsProcessesWithPowerShell(): Promise<WindowsProcessRow[
   }
 }
 
+/** Fallback whole-process-table scan via wmic when PowerShell is unavailable. */
 async function queryWindowsProcessesWithWmic(): Promise<WindowsProcessRow[] | null> {
   try {
     const { stdout } = await execFileAsync(
@@ -231,7 +238,10 @@ async function queryWindowsProcessesWithWmic(): Promise<WindowsProcessRow[] | nu
       {
         encoding: 'utf8',
         timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
-        maxBuffer: 8 * 1024 * 1024
+        maxBuffer: 8 * 1024 * 1024,
+        // Why: same focus-stealing hazard as the powershell probe — hide the
+        // wmic fallback's console window too.
+        windowsHide: true
       }
     )
     return parseWindowsProcessValueRows(stdout)


### PR DESCRIPTION
## Summary

On Windows, Orca **steals keyboard focus from whatever window the user is typing in** while an agent session is open — the caret silently drops out of the focused input (the mouse pointer does not move), so keystrokes are lost until the user clicks back in. It happens to *any* foreground app (editors, browsers, chat, other terminals) and even to Orca's own terminal panes.

**Severity — high impact.** In practice the focus is stolen **roughly once every few tens of seconds** for the whole time an agent is running (the underlying scan can fire more often under heavy agent output). Even at that rate it is a serious, recurring interruption: it repeatedly yanks you out of whatever you are typing, all day, for anyone who keeps Orca open while running agents. Multiple users are affected, and the disruption disappears the moment Orca is closed — so we'd really appreciate an expedited review/merge.

### Root cause

Agent foreground-process inspection (`windows-foreground-process-rows.ts`) re-forks `powershell.exe` — or the `wmic` fallback — to detect which agent is running in each terminal. Both spawns **omitted `windowsHide`**. Electron's main process has no attached console, so Windows creates a *fresh visible conhost window* for each console child; it flashes for a few tens of milliseconds and vanishes, but that is long enough to grab the foreground and steal keyboard focus from the active window.

The scan runs on a per-pane poll cadence (750ms active / 2000ms), but is gated down by relaxed retry tiers (~5s after recent PTY output, ~15s when idle) and a 500ms shared-snapshot dedup, so a *fresh* fork/flash does not happen every second — in normal use it lands roughly once every few tens of seconds, matching the observed symptom, and more often only while an agent is streaming continuous output.

Every other Windows spawn in the codebase already sets `windowsHide: true` (git runner, rate-limit fetchers, account services, port scanner, …) — these two probes were the only ones missing it. Same class of bug reported against other agent tools: anthropics/claude-code#40334 and aaif-goose/goose#6701.

Note: a related Windows 11 24H2 (build 26100) TSF/MSCTFIME focus regression can cause similar symptoms independently of Orca, but the recurring theft during agent use is squarely this scan.

### Fix

Add `windowsHide: true` to both the PowerShell and wmic process-table probes. Purely a window-visibility flag — args, stdout capture, and parsing are unchanged; it only suppresses the console window that should never have appeared.

## Screenshots

No visual change (the fix *removes* an unwanted flashing console window; there is no in-app UI change to screenshot).

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Added `windows-foreground-process-rows.test.ts`, which drives `queryWindowsProcessDescendants` under a mocked `child_process` and asserts both the PowerShell path and the wmic fallback pass `windowsHide: true` (guards against a future regression re-introducing the flash).

> Note: the command checkboxes above are left unchecked because the contributor's local checkout did not have full dev dependencies installed, so `lint`/`typecheck`/`test`/`build` were not run locally — please rely on CI to validate them. Targeted run for reviewers:
> ```
> pnpm test -- src/main/providers/windows-foreground-process-rows.test.ts \
>              src/main/providers/windows-agent-foreground-process-scan-volume.test.ts
> ```

## AI Review Report

Reviewed with an AI coding agent; passed with no changes required. Focus areas checked:
- **Correctness**: `windowsHide: true` is a valid `ExecFileOptions` field; it changes only console-window visibility, not process args, stdout capture, or the JSON/value parsing that follows. Behavior of `queryWindowsProcessesWithPowerShell` -> `queryWindowsProcessesWithWmic` fallback is unchanged.
- **Cross-platform (macOS/Linux/Windows)**: the touched code path is entirely `win32`-gated (`resolveAgentForegroundProcess` routes non-Windows to the POSIX `ps` snapshot, which is unaffected). No shortcuts, labels, or path handling are involved. `windowsHide` is a no-op on non-Windows platforms. No Electron main-window/focus APIs are touched.
- **Convention alignment**: matches the `windowsHide: true` pattern used by every other Windows spawn in the repo.
- **Test quality**: the new test reuses the established `vi.mock('child_process')` pattern from `windows-agent-foreground-process-scan-volume.test.ts` and asserts the exact regression surface.

## Security Audit

Low risk. No new input handling, no new command execution surface, no auth/secrets/IPC/dependency changes. The `powershell.exe`/`wmic` argument vectors are untouched (still fixed, non-interpolated argv). If anything this *reduces* a UI-integrity risk by eliminating an unexpected foreground window that hijacks user focus. No follow-up required.

## Notes

Windows-only behavior change. No config or migration needed. Users on the shipped release will pick this up in the next build; meanwhile the only workaround is closing Orca or reducing agent activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)