### PR TITLE
perf(terminal): scope hibernation liveness scans

### DIFF
--- a/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
@@ -380,6 +380,61 @@ describe('agent sleep coordinator', () => {
     expect(shutdown).not.toHaveBeenCalled()
   })
 
+  it('lists only locally eligible runtime worktrees before fresh liveness', async () => {
+    const tabsByWorktree: Record<string, TerminalTab[]> = { 'wt-bg': [tab()] }
+    for (let index = 0; index < 50; index += 1) {
+      const worktreeId = `wt-shell-${index}`
+      tabsByWorktree[worktreeId] = [
+        {
+          ...tab(),
+          id: `tab-shell-${index}`,
+          worktreeId,
+          title: 'Shell'
+        }
+      ]
+    }
+    installRuntimeListResponses(runtimeListResult(['pty-1']))
+    installEligibleState(vi.fn().mockResolvedValue(undefined), {
+      settings: {
+        experimentalAgentHibernation: true,
+        agentHibernationIdleMs: DEFAULT_AGENT_HIBERNATION_IDLE_MS,
+        activeRuntimeEnvironmentId: 'runtime-1'
+      } as never,
+      tabsByWorktree,
+      ptyIdsByTabId: { 'tab-1': [] }
+    })
+
+    await runAgentHibernationTick()
+
+    const listCalls = mockRuntimeEnvironmentCall.mock.calls.filter(
+      ([args]) => args.method === 'terminal.list'
+    )
+    expect(listCalls).toHaveLength(1)
+    expect(listCalls[0]?.[0]).toEqual(
+      expect.objectContaining({ params: expect.objectContaining({ worktree: 'id:wt-bg' }) })
+    )
+  })
+
+  it('skips runtime liveness entirely when local state has no candidate', async () => {
+    const workingEntry = { ...entry(), state: 'working' as const }
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined), {
+      settings: {
+        experimentalAgentHibernation: true,
+        agentHibernationIdleMs: DEFAULT_AGENT_HIBERNATION_IDLE_MS,
+        activeRuntimeEnvironmentId: 'runtime-1'
+      } as never,
+      ptyIdsByTabId: { 'tab-1': [] },
+      agentStatusByPaneKey: { [workingEntry.paneKey]: workingEntry }
+    })
+
+    await runAgentHibernationTick()
+
+    expect(
+      mockRuntimeEnvironmentCall.mock.calls.filter(([args]) => args.method === 'terminal.list')
+    ).toHaveLength(0)
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
   it('hibernates a runtime-backed candidate with fresh liveness and exact PTYs', async () => {
     vi.useFakeTimers()
     installRuntimeListResponses(

--- a/src/renderer/src/lib/agent-hibernation-coordinator.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.ts
@@ -89,6 +89,43 @@ function getRuntimeLivenessTargetWorktrees(state: AppState): Map<string, string>
   return targets
 }
 
+function getLocallyEligibleRuntimeLivenessTargets(
+  state: AppState,
+  now: number,
+  runtimeTargets: ReadonlyMap<string, string>
+): Map<string, string> {
+  if (runtimeTargets.size === 0) {
+    return new Map()
+  }
+  const assumedLivePtyIdsByWorktreeId: Record<string, string[]> = {}
+  for (const worktreeId of runtimeTargets.keys()) {
+    const ptyIds = new Set<string>()
+    for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
+      const layout = state.terminalLayoutsByTabId[tab.id]
+      for (const ptyId of Object.values(layout?.ptyIdsByLeafId ?? {})) {
+        if (ptyId) {
+          ptyIds.add(ptyId)
+        }
+      }
+    }
+    assumedLivePtyIdsByWorktreeId[worktreeId] = [...ptyIds]
+  }
+
+  // Why: fresh provider liveness is still mandatory for shutdown, but local
+  // state can cheaply prove most worktrees ineligible before any RPC fanout.
+  const locallyEligibleWorktreeIds = new Set(
+    planAgentHibernationCandidates(
+      snapshotFromState(state, now, {
+        runtimeLivePtyIdsByWorktreeId: assumedLivePtyIdsByWorktreeId,
+        runtimeLivenessRequiredWorktreeIds: [...runtimeTargets.keys()]
+      })
+    ).map((candidate) => candidate.worktreeId)
+  )
+  return new Map(
+    [...runtimeTargets].filter(([worktreeId]) => locallyEligibleWorktreeIds.has(worktreeId))
+  )
+}
+
 function getTypedRuntimePtyId(terminal: RuntimeTerminalSummary): string | null {
   if (terminal.ptyId) {
     return terminal.ptyId
@@ -99,10 +136,16 @@ function getTypedRuntimePtyId(terminal: RuntimeTerminalSummary): string | null {
   return null
 }
 
-async function collectRuntimePtyLiveness(state: AppState): Promise<RuntimePtyLivenessSample> {
-  const targets = getRuntimeLivenessTargetWorktrees(state)
+async function collectRuntimePtyLiveness(
+  state: AppState,
+  now: number
+): Promise<RuntimePtyLivenessSample> {
+  const runtimeTargets = getRuntimeLivenessTargetWorktrees(state)
+  const targets = getLocallyEligibleRuntimeLivenessTargets(state, now, runtimeTargets)
   const runtimeLivePtyIdsByWorktreeId: Record<string, string[]> = {}
-  const runtimeLivenessRequiredWorktreeIds = [...targets.keys()]
+  // Unqueried runtime worktrees remain marked as requiring a sample, so a
+  // state change during the await fails closed until the next coordinator tick.
+  const runtimeLivenessRequiredWorktreeIds = [...runtimeTargets.keys()]
   await Promise.all(
     [...targets].map(async ([worktreeId, runtimeEnvironmentId]) => {
       try {
@@ -140,7 +183,7 @@ async function collectRuntimePtyLiveness(state: AppState): Promise<RuntimePtyLiv
 }
 
 async function currentCandidates(now: number) {
-  const runtimeLiveness = await collectRuntimePtyLiveness(useAppStore.getState())
+  const runtimeLiveness = await collectRuntimePtyLiveness(useAppStore.getState(), now)
   const freshState = useAppStore.getState()
   return planAgentHibernationCandidates(snapshotFromState(freshState, now, runtimeLiveness))
     .filter((candidate) => {


### PR DESCRIPTION
## Summary

### Description

Bound the experimental agent-hibernation coordinator's fresh runtime-liveness fanout.

Before this change, every 60-second hibernation tick called `terminal.list` for every runtime-owned worktree that had any tab, before checking whether the worktree contained a completed, idle, resumable, background agent pane. Each request asked the provider for up to 10,000 terminals with `requireFreshPtyLiveness: true`.

The coordinator now runs the existing pure hibernation planner first with a deliberately permissive view of layout-bound PTYs. That prepass can only reject locally impossible candidates; it cannot authorize shutdown. Only worktrees that pass the local gates receive a fresh provider query. The authoritative planner still runs afterward with the real provider sample, and every unqueried runtime worktree remains marked as requiring fresh liveness so it fails closed.

### Evidence — this is a performance issue

A deterministic baseline test created 51 runtime-owned worktrees:

- 1 worktree with one locally eligible completed agent;
- 50 worktrees containing ordinary shell tabs and no eligible agent.

Against the pre-fix coordinator, one hibernation tick made **51 `terminal.list` RPCs**. The committed test runs the same fixture and proves exactly **1 RPC**, targeted at `id:wt-bg`.

| One 60-second hibernation tick | Before | After |
| --- | ---: | ---: |
| Runtime-owned worktrees | 51 | 51 |
| Locally eligible worktrees | 1 | 1 |
| Fresh `terminal.list` RPCs | 51 | 1 |
| RPC reduction | — | 98.0% |

A second committed test proves **0 RPCs** when the runtime worktree has no locally eligible candidate.

This matters because each avoided call crosses renderer → runtime transport and requests a fresh provider-owned terminal inventory with a 10-second timeout and a 10,000-row limit. The old cost scaled with all runtime worktrees; the new cost scales only with worktrees that could actually hibernate.

Reproduce:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/agent-hibernation-coordinator.test.ts --reporter=verbose
```

### ELI5

Once a minute, Orca used to call every remote workspace and ask for a full terminal roll call—even when the workspace only had a normal shell and nothing could be put to sleep. Now Orca checks its local list first and calls only the remote workspaces that actually have a possible sleeping candidate. It still asks the remote workspace for proof before turning anything off.

### Trade-offs / end-user regressions

- The existing 60-second tick now does one additional in-memory planner pass over tabs/panes. In the 51-worktree regression fixture the entire test completes in about 1 ms; no new timer or polling loop is added.
- If a worktree becomes locally eligible during the narrow provider-await window after the prepass, it fails closed and waits for the next tick. That can delay hibernation by up to one minute, but cannot close a terminal early. Hibernation already requires two stable ticks.
- No expected terminal/session regression. Fresh exact-PTY liveness, two-tick confirmation, final pre-shutdown revalidation, mobile locks, and truncated/rejected sample fail-closed behavior are unchanged and covered.

## Screenshots

No visual change.

## Testing

- [x] `pnpm test -- --reporter=dot` — 2,535 files passed; 26,429 tests passed; 3 files/33 tests skipped
- [x] `pnpm typecheck`
- [x] Changed-file `oxlint`
- [x] Changed-file `oxfmt --check`
- [x] `pnpm run check:reliability-gates`
- [x] `pnpm check:max-lines-ratchet`
- [x] Added deterministic provider-call count coverage (51→1 and 1→0)
- [ ] `pnpm lint` — all lint/reliability/max-lines stages passed until the unchanged base-branch localization gate failed on Japanese interpolation parity for `components.native-chat.composer.uploadingAttachments`; this PR does not touch localization
- [ ] `pnpm build` — not run; no dependency, native, packaging, or protocol changes

## Terminal Reliability Proof

- **Reliability class:** `agent-session.hibernation-liveness-sampling`
- **Manifest gate:** existing `agent-session.provider-ownership`; maturity/protection remain `experimental` / `partial`
- **Product change type:** terminal performance hardening
- **Invariant:** a runtime-backed pane may be shut down only after a fresh provider sample contains its exact PTY and the same candidate survives confirmation plus final revalidation
- **Oracle:** coordinator tests assert the exact `terminal.list` target and count, exact expected runtime PTY passed to shutdown, three fresh samples across confirmation/final recheck, and no shutdown on truncation, rejection, fresh-state activation, input, output, foreground visibility, or mobile ownership
- **Performance risk inventory:** provider listing is touched; typing, focus, switching, visibility resume, resize, render, startup, hidden output, PTY output, store subscribers, git scans, and subprocesses are not touched
- **No-regression evidence:** 51-worktree count test bounds the new fanout at one; zero-candidate test bounds it at zero; the existing exact-liveness tests remain green
- **Diagnostics:** existing shutdown failures remain logged with candidate ID; liveness failures remain fail-closed without destructive action
- **Provider/platform coverage:** remote-runtime is covered by deterministic mocked provider contracts; local and daemon PTYs are unaffected; SSH and WSL ownership paths do not use this runtime-environment listing path; mobile locks remain part of the local prepass. The logic is platform-neutral on macOS, Linux, and Windows
- **Residual gaps:** no live remote-runtime soak or long-running wall-clock CPU/network capture was added
- **Promotion status:** unchanged (`partial`); this count gate is deterministic but does not justify promotion without live-provider soak history
- **Rollback/demotion rule:** revert the prefilter if an eligible runtime-backed completed agent stops reaching hibernation, if a provider query targets the wrong worktree, or if the count gate becomes nondeterministic without a product regression

## AI Review Report

Reviewed local eligibility gates, layout/PTy identity conversion, provider freshness authority, state changes during awaits, confirmation signatures, final shutdown revalidation, mobile locks, remote-runtime ownership, timer overlap, and scale factors.

The main safety risk was accidentally treating locally bound PTYs as authoritative liveness. The implementation avoids that: layout IDs exist only for the permissive reject-only prepass. Unqueried runtime worktrees are still included in `runtimeLivenessRequiredWorktreeIds`, so the authoritative planner cannot use a missing sample to hibernate them.

Cross-platform review found no shortcut, label, path, shell, or Electron platform behavior changes. The logic is provider-neutral TypeScript and retains the existing local/daemon/SSH/WSL boundaries.

## Security Audit

- Adds no command execution, filesystem access, network endpoint, auth, secrets, telemetry, dependency, or persisted state.
- Uses existing trusted renderer store state only to reduce which authenticated runtime RPCs are sent.
- Does not accept or transform new user-controlled input.
- No security follow-up is required.

## Notes

The experimental hibernation feature remains fail-closed. This PR reduces provider work; it does not broaden which agents are eligible or change the shutdown authority.
