### PR TITLE
perf(renderer): scope agent send-target control updates

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -6,7 +6,10 @@ import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
 import DashboardAgentRow from '@/components/dashboard/DashboardAgentRow'
 import { useNow } from '@/components/dashboard/useNow'
 import { deriveRunningAgentSendTargets } from '@/lib/running-agent-targets'
-import { selectSendTargetInputs } from './worktree-card-send-target-inputs'
+import {
+  selectSendTargetControlInputs,
+  selectSendTargetInputs
+} from './worktree-card-send-target-inputs'
 import { useWorktreeAgentRows } from './useWorktreeAgentRows'
 import { cn } from '@/lib/utils'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
@@ -87,8 +90,9 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     useAppStore((s) => s.agentActivityDisplayMode) ?? DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE
   const dropAgentStatus = useAppStore((s) => s.dropAgentStatus)
   const dismissRetainedAgent = useAppStore((s) => s.dismissRetainedAgent)
-  const agentSendPopoverTargetMode = useAppStore((s) => s.agentSendPopoverTargetMode)
-  const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
+  const { targetMode: agentSendPopoverTargetMode, agentStatusEpoch } = useAppStore(
+    useShallow((s) => selectSendTargetControlInputs(s, worktreeId))
+  )
   // Why: these five maps are read only to derive send-target eligibility, which
   // matters only while the send-target popover targets THIS card. Two of them
   // (runtimePaneTitlesByTabId, agentStatusByPaneKey) churn on every pane-title
@@ -125,7 +129,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     [dropAgentStatus, dismissRetainedAgent]
   )
 
-  const isAgentSendTargetModeActive = agentSendPopoverTargetMode?.worktreeId === worktreeId
+  const isAgentSendTargetModeActive = agentSendPopoverTargetMode !== null
   const sendTargetsByPaneKey = useMemo(() => {
     void agentStatusEpoch
     if (!isAgentSendTargetModeActive) {

--- a/src/renderer/src/components/sidebar/worktree-card-send-target-inputs.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-send-target-inputs.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { shallow } from 'zustand/shallow'
 import type { AgentSendPopoverTargetMode } from '@/store/slices/ui'
 import {
+  EMPTY_SEND_TARGET_CONTROL_INPUTS,
   EMPTY_SEND_TARGET_INPUTS,
+  selectSendTargetControlInputs,
   selectSendTargetInputs,
+  type SendTargetControlInputsState,
   type SendTargetInputsState
 } from './worktree-card-send-target-inputs'
 
@@ -83,5 +86,46 @@ describe('selectSendTargetInputs', () => {
     // open popover re-derives eligibility, exactly as before this change.
     const s2: SendTargetInputsState = { ...s1, runtimePaneTitlesByTabId: { 'tab-1': 'codex' } }
     expect(shallow(r1, selectSendTargetInputs(s2, 'wt-A'))).toBe(false)
+  })
+})
+
+describe('selectSendTargetControlInputs', () => {
+  it('stays stable across global epoch changes while the picker is closed', () => {
+    const first = selectSendTargetControlInputs(
+      { agentSendPopoverTargetMode: null, agentStatusEpoch: 1 },
+      'wt-A'
+    )
+    const afterEpoch = selectSendTargetControlInputs(
+      { agentSendPopoverTargetMode: null, agentStatusEpoch: 2 },
+      'wt-A'
+    )
+
+    expect(first).toBe(EMPTY_SEND_TARGET_CONTROL_INPUTS)
+    expect(afterEpoch).toBe(EMPTY_SEND_TARGET_CONTROL_INPUTS)
+    expect(shallow(first, afterEpoch)).toBe(true)
+  })
+
+  it('stays stable when the picker targets another worktree', () => {
+    const state: SendTargetControlInputsState = {
+      agentSendPopoverTargetMode: makeMode('wt-B'),
+      agentStatusEpoch: 3
+    }
+
+    expect(selectSendTargetControlInputs(state, 'wt-A')).toBe(EMPTY_SEND_TARGET_CONTROL_INPUTS)
+  })
+
+  it('tracks the mode and freshness epoch only for the targeted worktree', () => {
+    const mode = makeMode('wt-A')
+    const first = selectSendTargetControlInputs(
+      { agentSendPopoverTargetMode: mode, agentStatusEpoch: 4 },
+      'wt-A'
+    )
+    const afterEpoch = selectSendTargetControlInputs(
+      { agentSendPopoverTargetMode: mode, agentStatusEpoch: 5 },
+      'wt-A'
+    )
+
+    expect(first).toEqual({ targetMode: mode, agentStatusEpoch: 4 })
+    expect(shallow(first, afterEpoch)).toBe(false)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-card-send-target-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-send-target-inputs.ts
@@ -11,6 +11,16 @@ export type SendTargetInputsState = Pick<
   | 'runtimePaneTitlesByTabId'
 >
 
+export type SendTargetControlInputsState = Pick<
+  AppState,
+  'agentSendPopoverTargetMode' | 'agentStatusEpoch'
+>
+
+export type SendTargetControlInputs = {
+  targetMode: AppState['agentSendPopoverTargetMode']
+  agentStatusEpoch: number
+}
+
 // Why: shared stable reference returned whenever the send-target popover isn't
 // targeting this card. useShallow keeps the same result across unrelated
 // pane-title / agent-status churn, so idle agent bodies stop re-rendering.
@@ -21,6 +31,13 @@ export const EMPTY_SEND_TARGET_INPUTS: RunningAgentTargetState = Object.freeze({
   terminalLayoutsByTabId: {},
   ptyIdsByTabId: {},
   runtimePaneTitlesByTabId: {}
+})
+
+// Why: the picker mode and freshness epoch are irrelevant to every card except
+// its current target. Keep inactive bodies stable across both global writes.
+export const EMPTY_SEND_TARGET_CONTROL_INPUTS: SendTargetControlInputs = Object.freeze({
+  targetMode: null,
+  agentStatusEpoch: 0
 })
 
 /**
@@ -44,4 +61,15 @@ export function selectSendTargetInputs(
     ptyIdsByTabId: s.ptyIdsByTabId,
     runtimePaneTitlesByTabId: s.runtimePaneTitlesByTabId
   }
+}
+
+export function selectSendTargetControlInputs(
+  s: SendTargetControlInputsState,
+  worktreeId: string
+): SendTargetControlInputs {
+  const targetMode = s.agentSendPopoverTargetMode
+  if (targetMode?.worktreeId !== worktreeId) {
+    return EMPTY_SEND_TARGET_CONTROL_INPUTS
+  }
+  return { targetMode, agentStatusEpoch: s.agentStatusEpoch }
 }


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. This is a
small residual in the exact component #7545 optimized: the five hot map
subscriptions were gated there, but the picker mode and global freshness epoch
still woke every mounted inline-agent body.

## 1. Description

`WorktreeCardAgentsBody` still held two app-wide subscriptions used only by the
send-target picker:

- `agentSendPopoverTargetMode`, whose object changes when the picker opens,
  closes, or enters `sending`;
- `agentStatusEpoch`, which advances for meaningful agent transitions and stale
  boundaries even when no picker is open.

Because the body is mounted once for every visible worktree with inline agent
rows, either write re-rendered every body. In the normal picker-closed state the
memo immediately returned an empty target map, so those renders could not change
the UI.

Fix: select the mode plus epoch through one `useShallow` projection. It returns a
shared frozen constant unless the picker targets this exact worktree. The target
card receives the live mode and epoch immediately; every other card stays
referentially equal.

## 2. Undeniable evidence + measurable improvement

- Deterministic selector proof extends
  `worktree-card-send-target-inputs.test.ts`:
  - picker closed: epoch `1 -> 2` returns the same shared object;
  - picker on another worktree: still the same shared object;
  - picker on this worktree: mode and epoch pass through and an epoch change is
    shallow-unequal.
- Metric:
  - unrelated/global epoch write with no picker: body renders **C -> 0**;
  - picker open/update/close for one worktree: body renders **C -> 1**;
  - epoch write while that picker is open remains **1**, preserving live target
    eligibility (`C` = mounted inline-agent bodies).
- All 40 focused selector and `WorktreeCardAgents` render tests pass.
- Exact-branch visible validation in a fresh Orca dev instance:
  - a real Claude turn produced a backing `working` hook entry and visible
    `Working` inline row, then a captured backend `done` transition and visible
    `Done` row;
  - opening the send-target mode on a live Claude row produced
    `data-agent-send-target="eligible"`;
  - updating the targeted mode plus epoch produced `sending`;
  - closing the mode removed the target affordance while the agent row stayed
    mounted.

## ELI5
Every agent row was still listening to the building-wide picker switch and
agent clock. Even with the picker closed, all rows redrew when any agent changed.
Now only the workspace whose picker is actually open listens; everyone else
keeps sleeping.

## 4. Trade-offs that regress the end experience

None material. Each body replaces two primitive/object subscriptions with one
small shallow selector. While inactive it returns a singleton with constant
work. While active it exposes the same mode object and epoch as before, and the
existing five-map selector continues to provide all eligibility inputs.

## Reliability proof

- **Reliability invariant:** `terminal-performance.store-and-git-hot-paths` —
  agent status changes must not fan out renderer work to unrelated worktree
  cards, while the targeted send picker must still update eligibility and
  sending state.
- **Motivation:** residual subscriber fanout left after #7545 deliberately kept
  the scalar epoch subscribed.
- **Product change type:** renderer performance hardening.
- **Performance risk inventory:** store subscription and inline-agent render
  only. No typing, focus routing, terminal activation, PTY output, buffering,
  polling, timers, IPC/RPC, startup, git/provider scan, subprocess, persistence,
  or telemetry change.
- **Oracle:** shallow-reference tests prove the render gate; focused render
  tests and the exact-branch visible `eligible -> sending -> closed` run prove
  the active behavior.
- **Manifest status:** existing experimental gate, `protection: none`, unchanged;
  this narrow selector oracle is not enough to promote the broader gate.
- **Provider/platform matrix:** local, daemon, SSH, WSL, remote runtime, relay,
  and mobile all consume the same renderer projection and are otherwise
  unaffected; macOS/local was exercised live. Linux, Windows, and live remote
  transports were not rerun because transport/session ownership is outside the
  diff.
- **Residual gaps:** the live turn covered `working` and normal `done`;
  blocked/waiting/interrupted mappings were not re-exercised because this PR
  does not alter row derivation or status mapping. No live multi-worktree render
  counter exists yet; the committed selector equality is the deterministic
  render-gating oracle.
- **Rollback/demotion:** revert to the two direct subscriptions if a targeted
  picker stops reflecting an epoch or mode change; do not promote the broader
  reliability gate from this PR alone.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-card-send-target-inputs.test.ts src/renderer/src/components/sidebar/WorktreeCardAgents.send-target.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx` (40 passed)
- [x] `pnpm typecheck`
- [x] `oxlint`, switch-exhaustiveness, scrollbar, reliability-manifest, and
  max-lines checks reached by `pnpm lint`
- [x] `git diff --check`
- [x] Exact-branch Electron/CDP visible validation described above
- [ ] Full `pnpm lint` reaches localization verification, then fails on the
  current-main Japanese interpolation mismatch for
  `components.native-chat.composer.uploadingAttachments`; this PR changes only
  the three renderer files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or
permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
