### PR TITLE
fix(i18n): unbreak main lint — locale parity for uploadingAttachments

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
+++ b/src/renderer/src/components/native-chat/native-chat-attachment-upload.ts
@@ -84,8 +84,8 @@ export async function uploadNativeChatAttachmentPaths(
   const pending = toast.loading(
     translate(
       'components.native-chat.composer.uploadingAttachments',
-      'Uploading {{value0}} file{{value1}} to remote…',
-      { value0: paths.length, value1: paths.length === 1 ? '' : 's' }
+      'Uploading {{value0}} file(s) to remote…',
+      { value0: paths.length }
     )
   )
   try {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12877,7 +12877,7 @@
         "pastedImageLabel": "Pasted image",
         "imagePasteFailed": "Image paste failed.",
         "worktreeNotReady": "Worktree not ready — try again in a moment.",
-        "uploadingAttachments": "Uploading {{value0}} file{{value1}} to remote…"
+        "uploadingAttachments": "Uploading {{value0}} file(s) to remote…"
       },
       "tool": {
         "running": "Running…",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12877,7 +12877,7 @@
         "pastedImageLabel": "Imagen pegada",
         "imagePasteFailed": "Error al pegar imagen.",
         "worktreeNotReady": "Worktree no está listo — intenta de nuevo en un momento.",
-        "uploadingAttachments": "Subiendo {{value0}} archivo{{value1}} al remoto…"
+        "uploadingAttachments": "Subiendo {{value0}} archivo(s) al remoto…"
       },
       "tool": {
         "running": "Ejecutando…",


### PR DESCRIPTION
## Problem

`main` fails `pnpm lint` (so every open PR's `verify` fails on the merge ref):

```
Locale catalog parity failed for ja.json.
interpolation mismatch: components.native-chat.composer.uploadingAttachments
```

`ko.json` and `zh.json` have the same mismatch — the checker just fails fast at `ja`.

## Cause

The English string uses a plural-suffix hack — `Uploading {{value0}} file{{value1}} to remote…` with `value1 = '' | 's'` — that has no equivalent in ja/ko/zh, whose translations correctly omit `{{value1}}`. `verify:localization-catalog` requires exact placeholder parity, so the correct CJK translations fail the gate. (Landed via the `ja.json` sync in the AI Vault subagents merge.)

## Fix

Use the catalog's established `(s)` convention (`item(s)`, `message(s)`, `transcript(s)` already use it): `Uploading {{value0}} file(s) to remote…`, matching `archivo(s)` in Spanish, and drop `value1` from the caller. The ja/ko/zh translations are untouched.

Deliberately **not** `pnpm run sync:localization-catalog`: its repair overwrites mismatched locale entries with the English source text, which would clobber three good CJK translations.

Scoped to the one failing key; the two similar `file{{value1}}` strings in `terminal-native-file-drop.ts` pass parity today and are left alone.

## Validation

`verify:localization-catalog` green for all locales (10493 keys each), full `pnpm lint` green, `pnpm typecheck` green.

Made with [Orca](https://github.com/stablyai/orca) 🐋