### PR TITLE
fix(remote): stop keepalives from refreshing stuck short-RPC deadlines

### DIFF
--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -346,18 +346,18 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
-  it('refreshes pending request timeouts when keepalive frames show server progress', async () => {
+  it('times out a stuck short RPC on its absolute deadline despite keepalive frames', async () => {
+    // Why: a keepalive on the shared socket is armed by an unrelated long-poll,
+    // not by this request. It must NOT extend a stuck short RPC's deadline —
+    // otherwise a hung server call hangs the caller forever (#7948).
     const server = await createServer({
+      silentMethods: ['worktree.hang'],
       sendKeepaliveBeforeResponse: true,
-      keepaliveDelayMs: 25,
-      responseDelayMs: 60
+      keepaliveDelayMs: 20
     })
     const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
 
-    await expect(connection.request('worktree.ps', undefined, 50)).resolves.toMatchObject({
-      ok: true,
-      result: { method: 'worktree.ps' }
-    })
+    await expect(connection.request('worktree.hang', undefined, 60)).rejects.toThrow('Timed out')
 
     connection.close()
   })
@@ -618,6 +618,15 @@ function handleRequest(
   delayedResponses: (() => void)[]
 ): void {
   requests.push(request)
+  // Why: keepalives are armed by an unrelated long-poll and keep flowing even
+  // while a method is deliberately silent — emit them before the silent return.
+  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs !== undefined) {
+    const timer = setInterval(
+      () => sendEncrypted(ws, sharedKey, { _keepalive: true }),
+      options.keepaliveDelayMs
+    )
+    ws.once('close', () => clearInterval(timer))
+  }
   if (options.silentMethods?.includes(request.method)) {
     return
   }
@@ -647,13 +656,10 @@ function handleRequest(
     })
   }
   const closeAfterResponse = streaming && options.closeAfterStreamingResponse?.() === true
-  if (options.sendKeepaliveBeforeResponse) {
-    const sendKeepalive = (): void => sendEncrypted(ws, sharedKey, { _keepalive: true })
-    if (options.keepaliveDelayMs !== undefined) {
-      setTimeout(sendKeepalive, options.keepaliveDelayMs)
-    } else {
-      sendKeepalive()
-    }
+  // Delayed/periodic keepalives are handled by the interval above; here we only
+  // cover the immediate single-keepalive-before-response case.
+  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs === undefined) {
+    sendEncrypted(ws, sharedKey, { _keepalive: true })
   }
   if (options.delaySubscriptionReady && streaming) {
     delayedResponses.push(sendResponse)

--- a/src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts
+++ b/src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { requestSharedControl } from './remote-runtime-shared-control-requests'
+import {
+  refreshSharedControlPendingRequestTimeouts,
+  resolveSharedControlPendingResponse
+} from './remote-runtime-shared-control-state'
+import type { SharedControlPendingRequest } from './remote-runtime-shared-control-types'
+
+// Why: a keepalive frame on the shared-control socket is armed by an unrelated
+// long-poll, not by any given pending short RPC. These fake-timer tests pin the
+// deadline semantics: keepalives must NOT keep a stuck short RPC alive forever,
+// but MAY extend a long-poll that opted into the short-RPC path.
+describe('shared control keepalive timeout refresh semantics', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function startRequest(options: { refreshTimeoutOnKeepalive?: boolean } = {}): {
+    pendingRequests: Map<string, SharedControlPendingRequest<unknown>>
+    promise: Promise<unknown>
+    onTimeout: ReturnType<typeof vi.fn>
+  } {
+    const pendingRequests = new Map<string, SharedControlPendingRequest<unknown>>()
+    const onTimeout = vi.fn()
+    const promise = requestSharedControl({
+      pendingRequests,
+      method: 'git.status',
+      params: undefined,
+      timeoutMs: 1000,
+      // ensureReady resolves immediately; the request is "in flight" but the
+      // server never answers, modelling a genuinely stuck server-side call.
+      ensureReady: () => Promise.resolve(),
+      send: () => undefined,
+      onTimeout,
+      refreshTimeoutOnKeepalive: options.refreshTimeoutOnKeepalive
+    })
+    // Swallow the eventual rejection so unhandled-rejection noise doesn't leak.
+    promise.catch(() => undefined)
+    return { pendingRequests, promise, onTimeout }
+  }
+
+  it('times out a stuck short RPC even while keepalive frames keep arriving', async () => {
+    const { pendingRequests, promise, onTimeout } = startRequest()
+
+    // Periodic keepalives arrive faster than the 1000ms deadline — as they
+    // would while a long-poll subscription streams over the same socket.
+    for (let elapsed = 0; elapsed < 1000; elapsed += 200) {
+      await vi.advanceTimersByTimeAsync(200)
+      refreshSharedControlPendingRequestTimeouts(pendingRequests)
+    }
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(promise).rejects.toThrow()
+    // The stuck-request path tears the connection down so reconnect+replay runs.
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(pendingRequests.size).toBe(0)
+  })
+
+  it('keeps refreshing a long-poll request that opted into keepalive refresh', async () => {
+    const { pendingRequests, promise, onTimeout } = startRequest({
+      refreshTimeoutOnKeepalive: true
+    })
+
+    // Same keepalive cadence, but this request opted in, so each keepalive
+    // pushes the deadline out and it never fires.
+    for (let elapsed = 0; elapsed < 3000; elapsed += 200) {
+      await vi.advanceTimersByTimeAsync(200)
+      refreshSharedControlPendingRequestTimeouts(pendingRequests)
+    }
+
+    expect(onTimeout).not.toHaveBeenCalled()
+    expect(pendingRequests.size).toBe(1)
+
+    // It still resolves normally once the server finally answers.
+    const [requestId] = pendingRequests.keys()
+    resolveSharedControlPendingResponse(pendingRequests, requestId!, {
+      id: requestId!,
+      ok: true,
+      result: { done: true },
+      _meta: { runtimeId: 'runtime-test' }
+    })
+    await expect(promise).resolves.toMatchObject({ ok: true })
+  })
+
+  it('fires the deadline for a short RPC when no keepalives arrive', async () => {
+    const { pendingRequests, promise, onTimeout } = startRequest()
+
+    await vi.advanceTimersByTimeAsync(1001)
+
+    await expect(promise).rejects.toThrow()
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(pendingRequests.size).toBe(0)
+  })
+})

--- a/src/shared/remote-runtime-shared-control-requests.ts
+++ b/src/shared/remote-runtime-shared-control-requests.ts
@@ -17,6 +17,9 @@ export function requestSharedControl<TResult>(args: {
   ensureReady: () => Promise<void>
   send: (requestId: string, method: string, params: unknown) => void
   onTimeout?: (error: RemoteRuntimeClientError) => void
+  // Why: default off — ordinary short RPCs keep an absolute deadline. Only
+  // long-polls routed through this path opt in so keepalives extend them.
+  refreshTimeoutOnKeepalive?: boolean
 }): Promise<RuntimeRpcResponse<TResult>> {
   const requestId = randomUUID()
   return new Promise<RuntimeRpcResponse<TResult>>((resolve, reject) => {
@@ -41,7 +44,8 @@ export function requestSharedControl<TResult>(args: {
       method: args.method,
       resolve: resolve as (response: RuntimeRpcResponse<unknown>) => void,
       reject,
-      timeout
+      timeout,
+      refreshTimeoutOnKeepalive: args.refreshTimeoutOnKeepalive ?? false
     })
     void args.ensureReady().then(
       () => args.send(requestId, args.method, args.params),

--- a/src/shared/remote-runtime-shared-control-state.ts
+++ b/src/shared/remote-runtime-shared-control-state.ts
@@ -64,6 +64,11 @@ export function refreshSharedControlPendingRequestTimeouts(
   pendingRequests: Map<string, SharedControlPendingRequest<unknown>>
 ): void {
   for (const pending of pendingRequests.values()) {
+    // Why: only long-poll requests opted into keepalive refresh; refreshing an
+    // ordinary short RPC would keep a genuinely-stuck server call alive forever.
+    if (!pending.refreshTimeoutOnKeepalive) {
+      continue
+    }
     const timeout = pending.timeout as ReturnType<typeof setTimeout> & { refresh?: () => void }
     timeout.refresh?.()
   }

--- a/src/shared/remote-runtime-shared-control-types.ts
+++ b/src/shared/remote-runtime-shared-control-types.ts
@@ -12,6 +12,12 @@ export type SharedControlPendingRequest<TResult> = {
   resolve: (response: RuntimeRpcResponse<TResult>) => void
   reject: (error: Error) => void
   timeout: ReturnType<typeof setTimeout>
+  // Why: keepalives on the shared socket are armed for an unrelated long-poll,
+  // not this request. Only requests that opt in (long-polls issued via the
+  // short-RPC path) may have their deadline refreshed by a keepalive; ordinary
+  // short RPCs keep an absolute deadline so a stuck server call still times
+  // out, tears the socket down, and reconnects/replays as designed.
+  refreshTimeoutOnKeepalive: boolean
 }
 
 export type SharedControlSubscriptionCallbacks<TResult> = {


### PR DESCRIPTION
## Summary

A remote-runtime server keepalive frame refreshed the timeout of **every** pending request on the shared-control socket. Those pending requests are ordinary short RPCs (git / repo / session-tabs — nearly all control-plane calls except `status.get`), while the keepalive is armed server-side *only* while a long-poll subscription is in flight on the same socket (`runtime-rpc.ts` arms it for `terminal.wait` / `orchestration.check --wait`).

Consequence: while any long-poll kept keepalives flowing, a genuinely-stuck short RPC **never** reached its deadline. The caller hung forever with no error, the timeout-driven teardown → reconnect → subscription-replay never fired, and 8 such hangs exhausted the per-environment call queue (concurrency 8, `runtime-rpc-call-queue.ts`), wedging **all** further control-plane calls for that environment.

### Fix

Distinguish request kinds. Each pending request is now tagged with `refreshTimeoutOnKeepalive` (default **false**):

- **Ordinary short RPCs** keep an **absolute** deadline — a stuck server call now times out, marks the socket suspect, tears it down, and reconnects/replays subscriptions exactly as `onTimeout` was designed to do (#7718).
- **Long-polls routed through the short-RPC path** can opt in (`refreshTimeoutOnKeepalive: true`) to keep the old keepalive-extends-deadline behavior.

No current caller sets the opt-in: today's long-polls (`terminal.wait`, `orchestration.check --wait`) run on the **subscription** map (`.subscribe()`), which has no per-request timeout and whose longevity is driven by replay/response — not by `pendingRequests`. So the refresh over `pendingRequests` never had a legitimate use; the flag is a preserved escape hatch, and subscription behavior is unchanged.

Only the **refresh semantics** change — every timeout *value* is left exactly as it was.

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm test` — full `remote-runtime-shared-control` suite (28) + `runtime-rpc`, `runtime-rpc-call-queue`, `runtime-environment-request-connections`, `runtime-environment-transport-routing` (66) all pass
- [x] oxlint (changed files) + `pnpm check:max-lines-ratchet`
- [x] Added a deterministic fake-timer repro (`remote-runtime-shared-control-keepalive-refresh.test.ts`):
  - **stuck short RPC + periodic keepalives → still times out** (this test hangs to the 30s vitest cap on unpatched `main`; passes with the fix)
  - **long-poll opted into refresh + same keepalives → never times out, resolves normally**
  - **short RPC, no keepalives → deadline fires**
  - Updated the real-socket connection test that previously asserted the buggy "keepalive extends a short RPC" contract to assert the corrected absolute-deadline behavior.

## AI Review Report

Reviewed the timeout registration/refresh/teardown path across `remote-runtime-shared-control-{requests,state,frame-dispatch,connection,send,subscription-start}.ts`. Confirmed subscriptions never enter `pendingRequests`, so tightening `pendingRequests` deadlines cannot shorten subscription longevity; the `onTimeout` → teardown/reconnect/replay wiring is preserved and still covered by the existing "tears down the socket when a request times out" test. Change is pure TypeScript control-plane logic with no platform-specific code (no shortcuts, labels, paths, shell, or Electron surfaces) — identical on macOS, Linux, and Windows.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change only makes a client-side request deadline stricter (absolute vs refreshable), which strictly *reduces* the window a wedged/half-open connection can hold resources. No follow-up needed.

## Notes

Core SSH / remote-server territory: this shared-control connection backs **both** the SSH remote-runtime and remote Orca Server topologies (both route control-plane RPCs through `RemoteRuntimeSharedControlConnection`), so both benefit from the queue-wedge fix. Risk for legitimately long-running short RPCs: they already had a bounded caller-supplied timeout before this change (keepalive refresh only ever masked hangs, it did not grant well-behaved long RPCs a larger budget), so none regress; if a genuinely long short-RPC surfaces later, bump its `timeoutMs` at the call site or opt it into refresh.

Made with [Orca](https://github.com/stablyai/orca) 🐋
