### PR TITLE
perf(renderer): gate worktree list review caches

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -122,6 +122,7 @@ import {
   getVisibleWorktreeBrowserActivityTabs,
   getVisibleWorktreeTerminalActivityTabs
 } from './visible-worktree-activity-inputs'
+import { selectWorktreeListReviewCacheInputs } from './worktree-list-review-cache-inputs'
 import {
   VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT,
   useVirtualizedScrollAnchor,
@@ -5249,20 +5250,8 @@ const WorktreeList = React.memo(function WorktreeList({
 
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
 
-  // PR cache is needed for PR-status grouping and when the status lane can
-  // show PR state on quiet/done workspace cards.
-  const prCache = useAppStore((s) =>
-    groupBy === 'pr-status' ||
-    (s.settings?.experimentalNewWorktreeCardStyle === true
-      ? cardProps.includes('status')
-      : cardProps.includes('pr'))
-      ? s.prCache
-      : null
-  )
-  const hostedReviewCache = useAppStore((s) =>
-    s.settings?.experimentalNewWorktreeCardStyle === true && cardProps.includes('status')
-      ? s.hostedReviewCache
-      : null
+  const { prCache, hostedReviewCache } = useAppStore(
+    useShallow((s) => selectWorktreeListReviewCacheInputs(s, groupBy, cardProps))
   )
   const settings = useAppStore((s) => s.settings)
   const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)

--- a/src/renderer/src/components/sidebar/worktree-list-review-cache-inputs.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-review-cache-inputs.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { shallow } from 'zustand/shallow'
+import type { FolderWorkspace } from '../../../../shared/types'
+import {
+  EMPTY_WORKTREE_LIST_REVIEW_CACHE_INPUTS,
+  selectWorktreeListReviewCacheInputs,
+  type WorktreeListReviewCacheState
+} from './worktree-list-review-cache-inputs'
+
+const EMPTY_STATE: WorktreeListReviewCacheState = {
+  folderWorkspaces: [],
+  hostedReviewCache: {},
+  prCache: {},
+  settings: null
+}
+
+const FOLDER_WORKSPACE = { id: 'folder-1' } as FolderWorkspace
+
+describe('selectWorktreeListReviewCacheInputs', () => {
+  it('ignores cache churn for ordinary cards outside PR-status grouping', () => {
+    const first = selectWorktreeListReviewCacheInputs(EMPTY_STATE, 'repo', ['pr'])
+    const afterCacheFill = selectWorktreeListReviewCacheInputs(
+      {
+        ...EMPTY_STATE,
+        prCache: { branch: {} as never },
+        hostedReviewCache: { branch: {} as never }
+      },
+      'repo',
+      ['pr']
+    )
+
+    expect(first).toBe(EMPTY_WORKTREE_LIST_REVIEW_CACHE_INPUTS)
+    expect(afterCacheFill).toBe(EMPTY_WORKTREE_LIST_REVIEW_CACHE_INPUTS)
+    expect(shallow(first, afterCacheFill)).toBe(true)
+  })
+
+  it('keeps the PR cache live for PR-status grouping', () => {
+    const prCache = { branch: {} as never }
+    const selected = selectWorktreeListReviewCacheInputs(
+      { ...EMPTY_STATE, prCache },
+      'pr-status',
+      []
+    )
+
+    expect(selected).toEqual({ prCache, hostedReviewCache: null })
+  })
+
+  it('keeps the PR cache live for legacy folder-card review displays', () => {
+    const prCache = { branch: {} as never }
+    const selected = selectWorktreeListReviewCacheInputs(
+      { ...EMPTY_STATE, folderWorkspaces: [FOLDER_WORKSPACE], prCache },
+      'repo',
+      ['pr']
+    )
+
+    expect(selected).toEqual({ prCache, hostedReviewCache: null })
+  })
+
+  it('keeps both caches live for new-style folder status displays', () => {
+    const prCache = { branch: {} as never }
+    const hostedReviewCache = { branch: {} as never }
+    const selected = selectWorktreeListReviewCacheInputs(
+      {
+        ...EMPTY_STATE,
+        folderWorkspaces: [FOLDER_WORKSPACE],
+        prCache,
+        hostedReviewCache,
+        settings: { experimentalNewWorktreeCardStyle: true } as never
+      },
+      'repo',
+      ['status']
+    )
+
+    expect(selected).toEqual({ prCache, hostedReviewCache })
+  })
+
+  it('ignores both caches when folder cards hide review presentation', () => {
+    const selected = selectWorktreeListReviewCacheInputs(
+      { ...EMPTY_STATE, folderWorkspaces: [FOLDER_WORKSPACE] },
+      'repo',
+      ['comment']
+    )
+
+    expect(selected).toBe(EMPTY_WORKTREE_LIST_REVIEW_CACHE_INPUTS)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list-review-cache-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-review-cache-inputs.ts
@@ -1,0 +1,44 @@
+import type { AppState } from '@/store/types'
+import type { WorktreeCardProperty } from '../../../../shared/types'
+import type { WorktreeGroupBy } from './worktree-list-groups'
+
+export type WorktreeListReviewCacheState = Pick<
+  AppState,
+  'folderWorkspaces' | 'hostedReviewCache' | 'prCache' | 'settings'
+>
+
+export type WorktreeListReviewCacheInputs = {
+  prCache: AppState['prCache'] | null
+  hostedReviewCache: AppState['hostedReviewCache'] | null
+}
+
+export const EMPTY_WORKTREE_LIST_REVIEW_CACHE_INPUTS: WorktreeListReviewCacheInputs = Object.freeze(
+  {
+    prCache: null,
+    hostedReviewCache: null
+  }
+)
+
+export function selectWorktreeListReviewCacheInputs(
+  state: WorktreeListReviewCacheState,
+  groupBy: WorktreeGroupBy,
+  cardProperties: readonly WorktreeCardProperty[]
+): WorktreeListReviewCacheInputs {
+  const hasFolderWorkspaces = state.folderWorkspaces.length > 0
+  const newCardStyle = state.settings?.experimentalNewWorktreeCardStyle === true
+  const folderCardsNeedReview =
+    hasFolderWorkspaces &&
+    (newCardStyle ? cardProperties.includes('status') : cardProperties.includes('pr'))
+  const needsPrCache = groupBy === 'pr-status' || folderCardsNeedReview
+  const needsHostedReviewCache = newCardStyle && folderCardsNeedReview
+
+  // Why: ordinary git worktree cards own entry-level subscriptions. The list
+  // needs whole caches only for PR grouping or synthetic folder-card displays.
+  if (!needsPrCache && !needsHostedReviewCache) {
+    return EMPTY_WORKTREE_LIST_REVIEW_CACHE_INPUTS
+  }
+  return {
+    prCache: needsPrCache ? state.prCache : null,
+    hostedReviewCache: needsHostedReviewCache ? state.hostedReviewCache : null
+  }
+}


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. This is a
separate sidebar survivor: broad review-cache subscriptions at the virtualized
list owner, above the already-granular per-card subscriptions.

## 1. Description

`WorktreeList` subscribed to the complete `prCache` whenever normal cards showed
PR metadata, and to the complete `hostedReviewCache` whenever new-style cards
showed status. Every cache entry update therefore invalidated the parent list's
`rows` memo and rebuilt grouping/lineage/placeholder models across all
worktrees.

That parent data is not read for ordinary git worktree cards:
`WorktreeCard` already selects only its own branch's PR, hosted-review, and issue
entries. The whole caches are needed only for two parent-owned cases:

- PR-status grouping, where cached PR state determines each row's section;
- synthetic folder-workspace cards, whose status summarizes attached child
  reviews.

Fix: one shallow selector returns a shared null-cache projection outside those
cases. It restores both caches immediately for new-style folder status, restores
the PR cache for legacy folder PR display, and always restores the PR cache for
PR-status grouping.

## 2. Undeniable evidence + measurable improvement

- Five deterministic selector cases prove:
  - ordinary repo grouping + PR cards stays referentially equal across both
    cache replacements;
  - PR-status grouping receives the live PR cache;
  - legacy folder PR display receives the live PR cache;
  - new-style folder status receives both live caches;
  - folder cards with review presentation disabled ignore both caches.
- Metric: outside folder-workspace/PR-status modes, `WorktreeList` row-model
  rebuilds per review-cache update drop from **1 -> 0**. Across `K` cache writes
  and `W` worktrees, this removes the parent `O(K * W)` `buildRows`/grouping
  work; the one affected `WorktreeCard` still updates through its entry selector.
- The existing PR-cache key-count remeasurement remains intentionally intact,
  so the virtualizer can remeasure when metadata first changes card height. The
  removed work is the parent row-model invalidation, not that correctness pass.
- 160 focused selector, folder-card, normal-card, merged-PR, grouping, and
  lineage tests pass.
- Exact-branch Electron validation in an isolated profile:
  - ordinary `repo` grouping, zero folder workspaces, and default card properties;
  - injecting a matching hosted/PR cache entry visibly produced
    `Linked PR #9004` on the normal card, proving its entry-level subscription
    remains live;
  - switching to `pr-status` visibly placed the same card beneath `In review`,
    proving the list-level PR-cache path remains live when grouping needs it.

## ELI5
The whole sidebar was rereading and regrouping every workspace whenever one
workspace learned new PR details. Normal cards already listen only for their own
PR, so now the list stays out of it—except in the two modes where the list itself
really does need everyone’s PR state.

## 4. Trade-offs that regress the end experience

None material. Each store update adds only constant-time checks for grouping,
folder-workspace presence, card style, and two small property arrays. Folder
workspaces conservatively keep the broad caches even if filtered offscreen,
prioritizing correctness over a more complex visible-folder projection.

## Reliability proof

- **Reliability invariant:** `terminal-performance.store-and-git-hot-paths` —
  unrelated review-cache writes must not trigger unbounded parent store
  projection, while PR grouping and folder-card review summaries remain live.
- **Product change type:** renderer performance hardening.
- **Performance risk inventory:** Zustand selection and sidebar row derivation
  only. No typing, focus, terminal/session ownership, PTY output, polling,
  timers, IPC/RPC, startup await, git/provider subprocess, persistence,
  telemetry, or cache retention change.
- **Oracle:** shallow-reference tests prove the inactive render gate; existing
  model/render tests and exact visible `Linked PR #9004` plus `In review`
  validation prove the three active ownership paths.
- **Manifest status:** existing experimental gate, `protection: none`, unchanged;
  this selector oracle does not promote the broader hot-interaction gate.
- **Provider/platform matrix:** GitHub PR grouping and provider-generic hosted
  review presentation keep their existing cache objects whenever parent-owned.
  Local, daemon, SSH, WSL, remote runtime, relay, GitLab/Bitbucket/Azure/Gitea,
  macOS/Linux/Windows, and mobile transport behavior are otherwise unaffected;
  macOS/local was rendered live.
- **Residual gaps:** the exact app had no folder workspace, so legacy/new folder
  paths are covered deterministically rather than by a live folder UI run. No
  high-worktree React profiler artifact was added; selected-reference equality
  is the committed row-memo invalidation oracle. The existing key-count
  remeasurement remains by design.
- **Rollback/demotion:** revert to the broad cache selectors if a normal card,
  PR-status section, or folder review summary stops reacting to cache updates;
  do not promote the broader reliability gate from this PR alone.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-review-cache-inputs.test.ts src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts` (160 passed)
- [x] `pnpm typecheck`
- [x] `oxlint`, switch-exhaustiveness, scrollbar, reliability-manifest, and
  max-lines checks reached by `pnpm lint`
- [x] `git diff --check`
- [x] Exact-branch Electron/CDP visible validation described above
- [ ] Full `pnpm lint` reaches localization verification, then fails on the
  current-main Japanese interpolation mismatch for
  `components.native-chat.composer.uploadingAttachments`; this PR changes only
  the three renderer files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or
permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
