### PR TITLE
perf(mobile): avoid serializing terminal snapshots

### DIFF
--- a/mobile/src/session/mobile-terminal-record-equality.test.ts
+++ b/mobile/src/session/mobile-terminal-record-equality.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../src/shared/agent-status-types'
+import type { MobileTerminalTheme } from '../terminal/terminal-webview-contract'
+import { agentStatusEntriesEqual, terminalThemesEqual } from './mobile-terminal-record-equality'
+
+function createAgentStatus(): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: 'ship it',
+    updatedAt: 20,
+    stateStartedAt: 10,
+    agentType: 'claude',
+    paneKey: 'term-1:leaf-1',
+    terminalHandle: 'pty-1',
+    worktreeId: 'worktree-1',
+    tabId: 'term-1',
+    terminalTitle: 'Claude',
+    stateHistory: [
+      {
+        state: 'waiting',
+        prompt: 'previous prompt',
+        startedAt: 1,
+        interrupted: false
+      }
+    ],
+    toolName: 'Read',
+    toolInput: 'src/index.ts',
+    interactivePrompt: '{"questions":[]}',
+    lastAssistantMessage: 'Working on it',
+    interrupted: false,
+    orchestration: {
+      taskId: 'task-1',
+      dispatchId: 'dispatch-1',
+      taskTitle: 'Scan performance',
+      displayName: 'Worker',
+      parentTerminalHandle: 'pty-parent',
+      parentPaneKey: 'term-parent:leaf-parent',
+      coordinatorHandle: 'pty-coordinator',
+      orchestrationRunId: 'run-1'
+    },
+    providerSession: {
+      key: 'session_id',
+      id: 'session-1',
+      transcriptPath: '/tmp/session-1.jsonl'
+    }
+  }
+}
+
+function createTerminalTheme(): MobileTerminalTheme {
+  return {
+    mode: 'dark',
+    theme: {
+      foreground: '#eeeeee',
+      background: '#111111',
+      cursor: '#ffffff',
+      brightMagenta: '#ff00ff',
+      bold: '#ffffff'
+    }
+  }
+}
+
+describe('mobile terminal record equality', () => {
+  it('matches structurally equal fresh status and theme snapshots', () => {
+    expect(agentStatusEntriesEqual(createAgentStatus(), createAgentStatus())).toBe(true)
+    expect(terminalThemesEqual(createTerminalTheme(), createTerminalTheme())).toBe(true)
+  })
+
+  it('detects nested state-history changes', () => {
+    const changed = createAgentStatus()
+    changed.stateHistory[0]!.interrupted = true
+
+    expect(agentStatusEntriesEqual(createAgentStatus(), changed)).toBe(false)
+  })
+
+  it('detects orchestration metadata changes', () => {
+    const changed = createAgentStatus()
+    changed.orchestration!.coordinatorHandle = 'pty-other-coordinator'
+
+    expect(agentStatusEntriesEqual(createAgentStatus(), changed)).toBe(false)
+  })
+
+  it('detects provider-session metadata changes', () => {
+    const changed = createAgentStatus()
+    changed.providerSession!.transcriptPath = '/tmp/other-session.jsonl'
+
+    expect(agentStatusEntriesEqual(createAgentStatus(), changed)).toBe(false)
+  })
+
+  it('detects terminal theme color changes', () => {
+    const changed = createTerminalTheme()
+    changed.theme.brightMagenta = '#cc00cc'
+
+    expect(terminalThemesEqual(createTerminalTheme(), changed)).toBe(false)
+  })
+
+  it('preserves null and undefined snapshot compatibility', () => {
+    expect(agentStatusEntriesEqual(null, undefined)).toBe(true)
+    expect(terminalThemesEqual(null, undefined)).toBe(true)
+    expect(agentStatusEntriesEqual(createAgentStatus(), null)).toBe(false)
+    expect(terminalThemesEqual(createTerminalTheme(), undefined)).toBe(false)
+  })
+})

--- a/mobile/src/session/mobile-terminal-record-equality.ts
+++ b/mobile/src/session/mobile-terminal-record-equality.ts
@@ -1,0 +1,171 @@
+import type { AgentStatusEntry } from '../../../src/shared/agent-status-types'
+import type { MobileTerminalTheme } from '../terminal/terminal-webview-contract'
+
+type AgentStateHistoryEntry = AgentStatusEntry['stateHistory'][number]
+type AgentOrchestration = NonNullable<AgentStatusEntry['orchestration']>
+type AgentProviderSession = NonNullable<AgentStatusEntry['providerSession']>
+type TerminalThemeColors = MobileTerminalTheme['theme']
+
+// Why: mobile snapshots contain fresh object identities, so field coverage must
+// stay exhaustive without falling back to allocating serialized copies every 2s.
+const AGENT_STATUS_FIELD_COVERAGE = {
+  state: true,
+  prompt: true,
+  updatedAt: true,
+  stateStartedAt: true,
+  agentType: true,
+  paneKey: true,
+  terminalHandle: true,
+  worktreeId: true,
+  tabId: true,
+  terminalTitle: true,
+  stateHistory: true,
+  toolName: true,
+  toolInput: true,
+  interactivePrompt: true,
+  lastAssistantMessage: true,
+  interrupted: true,
+  orchestration: true,
+  providerSession: true
+} satisfies { [K in keyof AgentStatusEntry]-?: true }
+
+const AGENT_STATE_HISTORY_FIELD_COVERAGE = {
+  state: true,
+  prompt: true,
+  startedAt: true,
+  interrupted: true
+} satisfies { [K in keyof AgentStateHistoryEntry]-?: true }
+
+const AGENT_ORCHESTRATION_FIELD_COVERAGE = {
+  taskId: true,
+  dispatchId: true,
+  taskTitle: true,
+  displayName: true,
+  parentTerminalHandle: true,
+  parentPaneKey: true,
+  coordinatorHandle: true,
+  orchestrationRunId: true
+} satisfies { [K in keyof AgentOrchestration]-?: true }
+
+const AGENT_PROVIDER_SESSION_FIELD_COVERAGE = {
+  key: true,
+  id: true,
+  transcriptPath: true
+} satisfies { [K in keyof AgentProviderSession]-?: true }
+
+const TERMINAL_THEME_COLOR_FIELD_COVERAGE = {
+  foreground: true,
+  background: true,
+  cursor: true,
+  cursorAccent: true,
+  selectionBackground: true,
+  selectionForeground: true,
+  black: true,
+  red: true,
+  green: true,
+  yellow: true,
+  blue: true,
+  magenta: true,
+  cyan: true,
+  white: true,
+  brightBlack: true,
+  brightRed: true,
+  brightGreen: true,
+  brightYellow: true,
+  brightBlue: true,
+  brightMagenta: true,
+  brightCyan: true,
+  brightWhite: true,
+  bold: true
+} satisfies { [K in keyof TerminalThemeColors]-?: true }
+
+const AGENT_STATUS_FIELDS = Object.keys(AGENT_STATUS_FIELD_COVERAGE) as (keyof AgentStatusEntry)[]
+const AGENT_STATE_HISTORY_FIELDS = Object.keys(
+  AGENT_STATE_HISTORY_FIELD_COVERAGE
+) as (keyof AgentStateHistoryEntry)[]
+const AGENT_ORCHESTRATION_FIELDS = Object.keys(
+  AGENT_ORCHESTRATION_FIELD_COVERAGE
+) as (keyof AgentOrchestration)[]
+const AGENT_PROVIDER_SESSION_FIELDS = Object.keys(
+  AGENT_PROVIDER_SESSION_FIELD_COVERAGE
+) as (keyof AgentProviderSession)[]
+const TERMINAL_THEME_COLOR_FIELDS = Object.keys(
+  TERMINAL_THEME_COLOR_FIELD_COVERAGE
+) as (keyof TerminalThemeColors)[]
+
+function recordsMatchOnFields<T extends object>(
+  a: T | null | undefined,
+  b: T | null | undefined,
+  fields: readonly (keyof T)[]
+): boolean {
+  if (a === b) {
+    return true
+  }
+  if (a == null || b == null) {
+    return false
+  }
+  for (const field of fields) {
+    if (a[field] !== b[field]) {
+      return false
+    }
+  }
+  return true
+}
+
+function agentStateHistoriesEqual(
+  a: AgentStatusEntry['stateHistory'] | null | undefined,
+  b: AgentStatusEntry['stateHistory'] | null | undefined
+): boolean {
+  if (a === b) {
+    return true
+  }
+  if (a == null || b == null || a.length !== b.length) {
+    return false
+  }
+  for (let index = 0; index < a.length; index += 1) {
+    if (!recordsMatchOnFields(a[index], b[index], AGENT_STATE_HISTORY_FIELDS)) {
+      return false
+    }
+  }
+  return true
+}
+
+export function agentStatusEntriesEqual(
+  a: AgentStatusEntry | null | undefined,
+  b: AgentStatusEntry | null | undefined
+): boolean {
+  if (a === b || (a == null && b == null)) {
+    return true
+  }
+  if (a == null || b == null) {
+    return false
+  }
+  for (const field of AGENT_STATUS_FIELDS) {
+    if (field === 'stateHistory' || field === 'orchestration' || field === 'providerSession') {
+      continue
+    }
+    if (a[field] !== b[field]) {
+      return false
+    }
+  }
+  return (
+    agentStateHistoriesEqual(a.stateHistory, b.stateHistory) &&
+    recordsMatchOnFields(a.orchestration, b.orchestration, AGENT_ORCHESTRATION_FIELDS) &&
+    recordsMatchOnFields(a.providerSession, b.providerSession, AGENT_PROVIDER_SESSION_FIELDS)
+  )
+}
+
+export function terminalThemesEqual(
+  a: MobileTerminalTheme | null | undefined,
+  b: MobileTerminalTheme | null | undefined
+): boolean {
+  if (a === b || (a == null && b == null)) {
+    return true
+  }
+  return (
+    a != null &&
+    b != null &&
+    a.mode === b.mode &&
+    recordsMatchOnFields(a.theme, b.theme, TERMINAL_THEME_COLOR_FIELDS)
+  )
+}

--- a/mobile/src/session/mobile-terminal-records.test.ts
+++ b/mobile/src/session/mobile-terminal-records.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   getTerminalRecordsFromSessionTabs,
   mergeTerminalListWithKnownRecords,
@@ -112,5 +112,53 @@ describe('mobile terminal records', () => {
         ]
       )
     ).toBe(false)
+  })
+
+  it('compares large unchanged snapshots without serializing status or theme data', () => {
+    const history = Array.from({ length: 20 }, (_, index) => ({
+      state: index % 2 === 0 ? ('working' as const) : ('waiting' as const),
+      prompt: `prompt-${index}`,
+      startedAt: index
+    }))
+    const tabs: MobileTerminalSessionTab[] = Array.from({ length: 40 }, (_, index) => ({
+      type: 'terminal',
+      id: `term-${index}::leaf-${index}`,
+      parentTabId: `term-${index}`,
+      leafId: `leaf-${index}`,
+      title: 'Claude',
+      status: 'ready',
+      terminal: `pty-${index}`,
+      terminalTheme: index % 2 === 0 ? lightTheme : darkTheme,
+      isActive: index === 0,
+      agentStatus: {
+        state: 'working',
+        prompt: 'ship it',
+        updatedAt: 1,
+        stateStartedAt: 1,
+        agentType: 'claude',
+        paneKey: `term-${index}:leaf-${index}`,
+        terminalHandle: `pty-${index}`,
+        stateHistory: history,
+        interactivePrompt: 'q'.repeat(16_000),
+        lastAssistantMessage: 'a'.repeat(8_000)
+      }
+    }))
+    const copy = JSON.parse(JSON.stringify(tabs)) as MobileTerminalSessionTab[]
+    const originalStringify = JSON.stringify
+    let serializedCalls = 0
+    let serializedChars = 0
+    const stringifySpy = vi.spyOn(JSON, 'stringify').mockImplementation((...args) => {
+      serializedCalls += 1
+      const result = originalStringify(...args)
+      serializedChars += result?.length ?? 0
+      return result
+    })
+
+    const equal = mobileSessionTabsEqual(tabs, copy)
+    stringifySpy.mockRestore()
+
+    expect(equal).toBe(true)
+    expect(serializedCalls).toBe(0)
+    expect(serializedChars).toBe(0)
   })
 })

--- a/mobile/src/session/mobile-terminal-records.ts
+++ b/mobile/src/session/mobile-terminal-records.ts
@@ -1,5 +1,6 @@
 import type { MobileTerminalTheme } from '../terminal/TerminalWebView'
 import type { AgentStatusEntry } from '../../../src/shared/agent-status-types'
+import { agentStatusEntriesEqual, terminalThemesEqual } from './mobile-terminal-record-equality'
 
 export type TerminalRecord = {
   handle: string
@@ -84,8 +85,8 @@ function mobileSessionTabEqual(
         a.leafId === b.leafId &&
         a.status === b.status &&
         a.terminal === b.terminal &&
-        JSON.stringify(a.agentStatus ?? null) === JSON.stringify(b.agentStatus ?? null) &&
-        JSON.stringify(a.terminalTheme ?? null) === JSON.stringify(b.terminalTheme ?? null)
+        agentStatusEntriesEqual(a.agentStatus, b.agentStatus) &&
+        terminalThemesEqual(a.terminalTheme, b.terminalTheme)
       )
     case 'markdown':
       return (
@@ -183,8 +184,7 @@ export function terminalRecordsEqual(
       (terminal, index) =>
         terminal.handle === b[index]?.handle &&
         terminal.title === b[index]?.title &&
-        JSON.stringify(terminal.terminalTheme ?? null) ===
-          JSON.stringify(b[index]?.terminalTheme ?? null) &&
+        terminalThemesEqual(terminal.terminalTheme, b[index]?.terminalTheme) &&
         terminal.isActive === b[index]?.isActive
     )
   )


### PR DESCRIPTION
## Summary

Mobile reprocesses session-tab snapshots from both the live `session.tabs.subscribe` stream and a focused-route 2-second fallback poll. Even when a snapshot was unchanged, its equality check serialized every terminal's full agent status and theme on both sides.

This PR replaces those `JSON.stringify` comparisons with field-by-field comparators for agent status, state history, orchestration metadata, provider-session metadata, and terminal theme colors. The field maps are exhaustive at compile time, so adding a typed field without covering it becomes a TypeScript error. The same theme comparator also removes serialization from terminal-record equality.

## Performance evidence

The regression fixture uses 40 unchanged terminal tabs with valid bounded payloads: 20 state-history rows, a 16,000-character interactive prompt, and an 8,000-character assistant message per status.

| Equality pass | `JSON.stringify` calls | Serialized characters |
| --- | ---: | ---: |
| Before | 160 | 2,030,620 |
| After | 0 | 0 |

The before count was captured by instrumenting `JSON.stringify` against this fixture before changing the implementation. The committed regression test runs the same fixture and asserts zero calls and zero serialized characters.

While the mobile session route is focused, the fallback runs every 2 seconds (30 passes/minute). With this fixture, the old session-tab comparator therefore generated **60,918,600 transient serialized characters per minute** from fallback polling alone, in addition to live push updates. These figures conservatively exclude the additional theme serialization removed from `terminalRecordsEqual`.

## ELI5

Every two seconds, the phone compared two filing cabinets by photocopying every document in both cabinets and comparing the photocopies. Now it checks the labeled fields directly. The answer stays the same, but it no longer creates millions of temporary characters just to learn that nothing changed.

## End-user trade-offs / regressions

- No expected user-visible regression: equal snapshots remain equal, and changes to nested history, orchestration, provider-session data, or theme colors still trigger updates.
- `null` and `undefined` retain the previous top-level compatibility behavior from `value ?? null`.
- The comparator adds explicit schema-maintenance code. Exhaustive mapped-key declarations make future typed fields fail TypeScript until equality coverage is updated.
- Direct comparison does a small bounded number of primitive checks, trading that work for removal of much larger serialization and temporary-string allocation.
- Older mobile builds ignore fields introduced only by a newer runtime, as they already cannot consume those unknown fields; all fields known to the compiled client are covered.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — root lint is currently blocked on `main` by the unrelated `ja.json` locale interpolation mismatch for `components.native-chat.composer.uploadingAttachments`
- [ ] `pnpm typecheck` — root command not run; mobile TypeScript passed
- [ ] `pnpm test` — root command not run; full mobile suite passed
- [ ] `pnpm build` — not run; no build configuration changed
- [x] Added or updated high-quality tests that would catch regressions

Executed on the final rebased commit:

- `pnpm --dir mobile test` — 186 files passed; 1,321 tests passed; 2 skipped
- `pnpm --dir mobile test src/session/mobile-terminal-records.test.ts src/session/mobile-terminal-record-equality.test.ts --reporter=verbose` — 2 files / 11 tests passed
- `pnpm --dir mobile exec tsc --noEmit -p tsconfig.json`
- `pnpm --dir mobile lint`
- `pnpm --dir mobile format:check`
- `pnpm check:max-lines-ratchet`
- `git diff origin/main...HEAD --check`

## AI Review Report

Reviewed the change for semantic parity with the former JSON comparison, including every current `AgentStatusEntry`, state-history, orchestration, provider-session, and terminal-theme field; deep fresh-object equality; nested differences; null/undefined behavior; short-circuit behavior; and future-field exhaustiveness. The initial implementation exceeded the 300-line file limit, so the comparator was extracted into the focused `mobile-terminal-record-equality.ts` module rather than adding a suppression.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This is platform-neutral TypeScript data comparison: it changes no shortcuts, labels, filesystem paths, shell commands, native modules, Electron behavior, or OS branches. Remote/SSH-backed session snapshots use the same typed comparison path and require no provider-specific behavior.

## Security Audit

This change performs pure comparisons on already-received typed snapshot data. It adds no input parsing, command execution, filesystem/path handling, auth, secrets, dependencies, network calls, IPC methods, or persistence. Payload strings are read but never executed or logged. No security follow-up is needed.

## Notes

The measured stress fixture intentionally uses the existing payload bounds to make transient allocation visible. Smaller sessions save proportionally less work, while every unchanged snapshot avoids serialization entirely.
