### PR TITLE
fix(status-bar): show usage after mid-session installs

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -73,7 +73,11 @@ import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { SkillUpdateStatusSegment } from './SkillUpdateStatusSegment'
 import { RemoteServerUpdateStatusSegment } from './RemoteServerUpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
-import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
+import {
+  getVisibleUsageProvider,
+  isProviderConfigured,
+  isUsageEmptyState
+} from './status-bar-provider-visibility'
 import { StatusBarUsageEmptyCta } from './StatusBarUsageEmptyCta'
 import { UsagePercentageDisplayChangeNotice } from './UsagePercentageDisplayChangeNotice'
 import {
@@ -2072,7 +2076,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   // Why: Antigravity visibility also requires geminiCliOAuthEnabled because its usage snapshot mirrors the Gemini fetch.
   const antigravityUsageConfigured =
     statusBarItems.includes('antigravity') &&
-    isStatusBarItemAvailable('antigravity', detectedAgentIds)
+    isStatusBarItemAvailable('antigravity', detectedAgentIds, isProviderConfigured(antigravity))
   // Why: thread non-GlobalSettings durability flags so bars stay visible across reloads and snapshot refreshes.
   const usageSettings = {
     ...settings,
@@ -2090,29 +2094,29 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const showClaude =
     visibleClaude !== null &&
     statusBarItems.includes('claude') &&
-    isStatusBarItemAvailable('claude', detectedAgentIds)
+    isStatusBarItemAvailable('claude', detectedAgentIds, isProviderConfigured(claude))
   const showCodex =
     visibleCodex !== null &&
     statusBarItems.includes('codex') &&
-    isStatusBarItemAvailable('codex', detectedAgentIds)
+    isStatusBarItemAvailable('codex', detectedAgentIds, isProviderConfigured(codex))
   const showGemini =
     visibleGemini !== null &&
     statusBarItems.includes('gemini') &&
-    isStatusBarItemAvailable('gemini', detectedAgentIds)
+    isStatusBarItemAvailable('gemini', detectedAgentIds, isProviderConfigured(gemini))
   const showKimi =
     visibleKimi !== null &&
     statusBarItems.includes('kimi') &&
-    isStatusBarItemAvailable('kimi', detectedAgentIds)
+    isStatusBarItemAvailable('kimi', detectedAgentIds, isProviderConfigured(kimi))
   const showAntigravity =
     visibleAntigravity !== null &&
     statusBarItems.includes('antigravity') &&
-    isStatusBarItemAvailable('antigravity', detectedAgentIds)
+    isStatusBarItemAvailable('antigravity', detectedAgentIds, isProviderConfigured(antigravity))
   // Why: MiniMax is cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const showMiniMax = visibleMiniMax !== null && statusBarItems.includes('minimax')
   const showGrok =
     visibleGrok !== null &&
     statusBarItems.includes('grok') &&
-    isStatusBarItemAvailable('grok', detectedAgentIds)
+    isStatusBarItemAvailable('grok', detectedAgentIds, isProviderConfigured(grok))
   // Why: OpenCode Go is web/cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, usageSettings)
   const showOpencodeGo = visibleOpencodeGo !== null && statusBarItems.includes('opencode-go')
@@ -2405,7 +2409,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="min-w-0 w-fit" sideOffset={0} align="start">
-          {isStatusBarItemAvailable('claude', detectedAgentIds) && (
+          {isStatusBarItemAvailable('claude', detectedAgentIds, isProviderConfigured(claude)) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('claude')}
               onCheckedChange={() => {
@@ -2417,7 +2421,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
               {translate('auto.components.status.bar.StatusBar.3885eb74d8', 'Claude Usage')}
             </DropdownMenuCheckboxItem>
           )}
-          {isStatusBarItemAvailable('codex', detectedAgentIds) && (
+          {isStatusBarItemAvailable('codex', detectedAgentIds, isProviderConfigured(codex)) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('codex')}
               onCheckedChange={() => {
@@ -2429,7 +2433,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
               {translate('auto.components.status.bar.StatusBar.c0909c686e', 'Codex Usage')}
             </DropdownMenuCheckboxItem>
           )}
-          {isStatusBarItemAvailable('gemini', detectedAgentIds) && (
+          {isStatusBarItemAvailable('gemini', detectedAgentIds, isProviderConfigured(gemini)) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('gemini')}
               onCheckedChange={() => {
@@ -2441,7 +2445,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
               {translate('auto.components.status.bar.StatusBar.c1df0d67ec', 'Gemini Usage')}
             </DropdownMenuCheckboxItem>
           )}
-          {isStatusBarItemAvailable('antigravity', detectedAgentIds) && (
+          {isStatusBarItemAvailable('antigravity', detectedAgentIds, isProviderConfigured(antigravity)) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('antigravity')}
               onCheckedChange={() => {
@@ -2466,7 +2470,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             <OpenCodeGoIcon size={14} />
             {translate('auto.components.status.bar.StatusBar.8c86cd77b0', 'OpenCode Go Usage')}
           </DropdownMenuCheckboxItem>
-          {isStatusBarItemAvailable('kimi', detectedAgentIds) && (
+          {isStatusBarItemAvailable('kimi', detectedAgentIds, isProviderConfigured(kimi)) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('kimi')}
               onCheckedChange={() => {
@@ -2488,7 +2492,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             <MiniMaxIcon size={14} />
             {translate('auto.components.status.bar.StatusBar.3bbf140864', 'MiniMax Usage')}
           </DropdownMenuCheckboxItem>
-          {isStatusBarItemAvailable('grok', detectedAgentIds) && (
+          {isStatusBarItemAvailable('grok', detectedAgentIds, isProviderConfigured(grok)) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('grok')}
               onCheckedChange={() => {

--- a/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
@@ -10,6 +10,7 @@ import { AgentIcon } from '@/lib/agent-catalog'
 import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { translate } from '@/i18n/i18n'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
+import { isProviderConfigured } from './status-bar-provider-visibility'
 import type { StatusBarController } from './use-status-bar-controller'
 
 export function StatusBarVisibilityMenu({
@@ -18,7 +19,13 @@ export function StatusBarVisibilityMenu({
   controller: StatusBarController
 }): React.JSX.Element {
   const {
+    antigravity,
+    claude,
+    codex,
     detectedAgentIds,
+    gemini,
+    grok,
+    kimi,
     menuOpen,
     menuPoint,
     recordFeatureInteraction,
@@ -38,7 +45,7 @@ export function StatusBarVisibilityMenu({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="min-w-0 w-fit" sideOffset={0} align="start">
-        {isStatusBarItemAvailable('claude', detectedAgentIds) && (
+        {isStatusBarItemAvailable('claude', detectedAgentIds, isProviderConfigured(claude)) && (
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('claude')}
             onCheckedChange={() => {
@@ -50,7 +57,7 @@ export function StatusBarVisibilityMenu({
             {translate('auto.components.status.bar.StatusBar.3885eb74d8', 'Claude Usage')}
           </DropdownMenuCheckboxItem>
         )}
-        {isStatusBarItemAvailable('codex', detectedAgentIds) && (
+        {isStatusBarItemAvailable('codex', detectedAgentIds, isProviderConfigured(codex)) && (
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('codex')}
             onCheckedChange={() => {
@@ -62,7 +69,7 @@ export function StatusBarVisibilityMenu({
             {translate('auto.components.status.bar.StatusBar.c0909c686e', 'Codex Usage')}
           </DropdownMenuCheckboxItem>
         )}
-        {isStatusBarItemAvailable('gemini', detectedAgentIds) && (
+        {isStatusBarItemAvailable('gemini', detectedAgentIds, isProviderConfigured(gemini)) && (
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('gemini')}
             onCheckedChange={() => {
@@ -74,7 +81,11 @@ export function StatusBarVisibilityMenu({
             {translate('auto.components.status.bar.StatusBar.c1df0d67ec', 'Gemini Usage')}
           </DropdownMenuCheckboxItem>
         )}
-        {isStatusBarItemAvailable('antigravity', detectedAgentIds) && (
+        {isStatusBarItemAvailable(
+          'antigravity',
+          detectedAgentIds,
+          isProviderConfigured(antigravity)
+        ) && (
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('antigravity')}
             onCheckedChange={() => {
@@ -99,7 +110,7 @@ export function StatusBarVisibilityMenu({
           <OpenCodeGoIcon size={14} />
           {translate('auto.components.status.bar.StatusBar.8c86cd77b0', 'OpenCode Go Usage')}
         </DropdownMenuCheckboxItem>
-        {isStatusBarItemAvailable('kimi', detectedAgentIds) && (
+        {isStatusBarItemAvailable('kimi', detectedAgentIds, isProviderConfigured(kimi)) && (
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('kimi')}
             onCheckedChange={() => {
@@ -121,7 +132,7 @@ export function StatusBarVisibilityMenu({
           <MiniMaxIcon size={14} />
           {translate('auto.components.status.bar.StatusBar.3bbf140864', 'MiniMax Usage')}
         </DropdownMenuCheckboxItem>
-        {isStatusBarItemAvailable('grok', detectedAgentIds) && (
+        {isStatusBarItemAvailable('grok', detectedAgentIds, isProviderConfigured(grok)) && (
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('grok')}
             onCheckedChange={() => {

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -37,4 +37,9 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('antigravity', ['antigravity'])).toBe(true)
     expect(isStatusBarItemAvailable('grok', ['grok'])).toBe(true)
   })
+
+  it('lets live provider evidence override a cached negative PATH result', () => {
+    expect(isStatusBarItemAvailable('codex', [], true)).toBe(true)
+    expect(isStatusBarItemAvailable('codex', [], false)).toBe(false)
+  })
 })

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
@@ -17,7 +17,8 @@ const CLI_GATED_ITEMS: ReadonlySet<StatusBarItem> = new Set([
 
 export function isStatusBarItemAvailable(
   id: StatusBarItem,
-  detectedAgentIds: TuiAgent[] | null
+  detectedAgentIds: TuiAgent[] | null,
+  hasProviderEvidence = false
 ): boolean {
   if (!CLI_GATED_ITEMS.has(id)) {
     return true
@@ -25,5 +26,7 @@ export function isStatusBarItemAvailable(
   if (detectedAgentIds === null) {
     return true
   }
-  return detectedAgentIds.includes(id as TuiAgent)
+  // Why: PATH detection is a cached negative snapshot. A later successful
+  // usage fetch proves a CLI was installed mid-session and must win over it.
+  return hasProviderEvidence || detectedAgentIds.includes(id as TuiAgent)
 }

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
@@ -18,7 +18,8 @@ const CLI_GATED_ITEMS: ReadonlySet<StatusBarItem> = new Set([
 
 export function isStatusBarItemAvailable(
   id: StatusBarItem,
-  detectedAgentIds: TuiAgent[] | null
+  detectedAgentIds: TuiAgent[] | null,
+  hasProviderEvidence = false
 ): boolean {
   if (!CLI_GATED_ITEMS.has(id)) {
     return true
@@ -26,5 +27,7 @@ export function isStatusBarItemAvailable(
   if (detectedAgentIds === null) {
     return true
   }
-  return detectedAgentIds.includes(id as TuiAgent)
+  // Why: PATH detection is a cached negative snapshot. A later successful
+  // usage fetch proves a CLI was installed mid-session and must win over it.
+  return hasProviderEvidence || detectedAgentIds.includes(id as TuiAgent)
 }

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -6,7 +6,11 @@ import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 import { normalizeUsagePercentageDisplay } from '../../../../shared/usage-percentage-display'
 import { normalizeStatusBarUsageMode } from '../../../../shared/status-bar-usage-mode'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
-import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
+import {
+  getVisibleUsageProvider,
+  isProviderConfigured,
+  isUsageEmptyState
+} from './status-bar-provider-visibility'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT, useStatusBarMenuFocusHandoff } from './ProviderDetailsMenu'
 import { observeStatusBarContainer } from './status-bar-container-observer'
@@ -106,7 +110,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   // Why: Antigravity visibility also requires geminiCliOAuthEnabled because its usage snapshot mirrors the Gemini fetch.
   const antigravityUsageConfigured =
     statusBarItems.includes('antigravity') &&
-    isStatusBarItemAvailable('antigravity', detectedAgentIds)
+    isStatusBarItemAvailable('antigravity', detectedAgentIds, isProviderConfigured(antigravity))
   // Why: thread non-GlobalSettings durability flags so bars stay visible across reloads and snapshot refreshes.
   const usageSettings = {
     ...settings,
@@ -125,29 +129,29 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const showClaude =
     visibleClaude !== null &&
     statusBarItems.includes('claude') &&
-    isStatusBarItemAvailable('claude', detectedAgentIds)
+    isStatusBarItemAvailable('claude', detectedAgentIds, isProviderConfigured(claude))
   const showCodex =
     visibleCodex !== null &&
     statusBarItems.includes('codex') &&
-    isStatusBarItemAvailable('codex', detectedAgentIds)
+    isStatusBarItemAvailable('codex', detectedAgentIds, isProviderConfigured(codex))
   const showGemini =
     visibleGemini !== null &&
     statusBarItems.includes('gemini') &&
-    isStatusBarItemAvailable('gemini', detectedAgentIds)
+    isStatusBarItemAvailable('gemini', detectedAgentIds, isProviderConfigured(gemini))
   const showKimi =
     visibleKimi !== null &&
     statusBarItems.includes('kimi') &&
-    isStatusBarItemAvailable('kimi', detectedAgentIds)
+    isStatusBarItemAvailable('kimi', detectedAgentIds, isProviderConfigured(kimi))
   const showAntigravity =
     visibleAntigravity !== null &&
     statusBarItems.includes('antigravity') &&
-    isStatusBarItemAvailable('antigravity', detectedAgentIds)
+    isStatusBarItemAvailable('antigravity', detectedAgentIds, isProviderConfigured(antigravity))
   // Why: MiniMax is cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const showMiniMax = visibleMiniMax !== null && statusBarItems.includes('minimax')
   const showGrok =
     visibleGrok !== null &&
     statusBarItems.includes('grok') &&
-    isStatusBarItemAvailable('grok', detectedAgentIds)
+    isStatusBarItemAvailable('grok', detectedAgentIds, isProviderConfigured(grok))
   // Why: OpenCode Go is web/cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, usageSettings)
   const showOpencodeGo = visibleOpencodeGo !== null && statusBarItems.includes('opencode-go')
@@ -237,6 +241,12 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     compact,
     containerRefCallback,
     detectedAgentIds,
+    claude,
+    codex,
+    gemini,
+    kimi,
+    antigravity,
+    grok,
     floatingTerminalActionLabel,
     floatingTerminalShortcut,
     handleManageAccounts,


### PR DESCRIPTION
## Summary

A CLI installed and authenticated after Orca starts can remain hidden by the cached startup PATH result. The status bar and its visibility menu now accept the existing configured-provider snapshot as evidence that overrides that negative result. Existing provider rules still hide unavailable or empty initial-fetch snapshots and keep transient configured-provider errors visible.

The same evidence is passed for all six CLI-gated providers, including Antigravity. Non-CLI items remain ungated. The separate Appearance settings switches retain their existing PATH-based behavior; this change covers the status bar and its context menu.

## Testing and review

At `c25c4e0405878b3825386864b3d81d6f0714fba0`, independent verification passed 341 tests across 50 status-bar test files. The new regression checks positive provider evidence against a cached-negative PATH result. CLI, Node and Web TypeScript checks (`--composite false`), changed-file lint/format and diff whitespace passed. Independent Cursor review passed on this exact commit.

Full repository tests, packaging and rendered Electron before/after or Windows/Linux/SSH smoke were not run. The visibility logic has automated coverage; no manual visual proof is claimed. Renderer-only change, with no RPC or stream schema changes.

## AI disclosure

Cursor ported and independently reviewed the change; Codex checked the original requirements, source and verification results.
