### PR TITLE
perf(renderer): share terminal agent type index

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -101,7 +101,6 @@ import {
 import { shouldChatTakeOverMobileSurface } from '../native-chat/native-chat-send-eligibility'
 import { canToggleNativeChat } from '../native-chat/native-chat-availability'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
-import type { AgentType } from '../../../../shared/agent-status-types'
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { captureTerminalShutdownLayout } from './terminal-shutdown-layout-capture'
@@ -148,6 +147,7 @@ import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-atlas-rec
 import { restoreTerminalFitToDesktop, restoreTerminalFitsToDesktop } from './terminal-fit-restore'
 import { useVisibleTerminalTabClaim } from './use-visible-terminal-tab-claim'
 import { TerminalSshReconnectOverlay } from './TerminalSshReconnectOverlay'
+import { selectTerminalTabAgentTypesByLeaf } from './terminal-tab-agent-type-index'
 
 const NATIVE_CHAT_ROOT_SELECTOR = '[data-native-chat-root="true"]'
 
@@ -680,19 +680,10 @@ export default function TerminalPane({
   // when Orca launched a *supported* agent here or one was detected live for the
   // leaf, keyed `${tabId}:${leafId}`. Carry the agent identity, not just "an
   // agent exists", so the gate can reject Grok et al.
-  // Scoped to this tab's panes (leafId → agentType) and shallow-compared so an
-  // unrelated tab's agent status tick doesn't re-render this pane.
-  const tabAgentTypeByLeaf = useAppStore(
-    useShallow((store) => {
-      const prefix = `${tabId}:`
-      const byLeaf: Record<string, AgentType> = {}
-      for (const [paneKey, entry] of Object.entries(store.agentStatusByPaneKey)) {
-        if (paneKey.startsWith(prefix) && entry.agentType) {
-          byLeaf[paneKey.slice(prefix.length)] = entry.agentType
-        }
-      }
-      return byLeaf
-    })
+  // Scope to this tab's panes and reuse the shared map index so hidden tabs do
+  // not each rescan every agent entry on unrelated store writes.
+  const tabAgentTypeByLeaf = useAppStore((store) =>
+    selectTerminalTabAgentTypesByLeaf(store.agentStatusByPaneKey, tabId)
   )
   const toggleTabViewMode = useAppStore((store) => store.toggleTabViewMode)
   const savedLayout = useAppStore((store) => store.terminalLayoutsByTabId[tabId] ?? EMPTY_LAYOUT)

--- a/src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { createTerminalTabAgentTypeSelector } from './terminal-tab-agent-type-index'
+
+function entry(agentType: AgentStatusEntry['agentType'], state = 'working'): AgentStatusEntry {
+  return { agentType, state, updatedAt: 0 } as AgentStatusEntry
+}
+
+describe('createTerminalTabAgentTypeSelector', () => {
+  it('scans one global map only once across all mounted tab selectors', () => {
+    const onEntryVisited = vi.fn()
+    const select = createTerminalTabAgentTypeSelector({ onEntryVisited })
+    const state = {
+      'tab-1:leaf-a': entry('claude'),
+      'tab-1:leaf-b': entry('codex'),
+      'tab-2:leaf-c': entry('grok')
+    }
+
+    expect(select(state, 'tab-1')).toEqual({ 'leaf-a': 'claude', 'leaf-b': 'codex' })
+    expect(select(state, 'tab-2')).toEqual({ 'leaf-c': 'grok' })
+    for (let index = 0; index < 100; index += 1) {
+      select(state, `hidden-tab-${index}`)
+    }
+
+    expect(onEntryVisited).toHaveBeenCalledTimes(3)
+  })
+
+  it('reuses per-tab results across state-only agent transitions', () => {
+    const select = createTerminalTabAgentTypeSelector()
+    const working = {
+      'tab-1:leaf-a': entry('claude', 'working'),
+      'tab-2:leaf-b': entry('codex', 'working')
+    }
+    const firstTab = select(working, 'tab-1')
+    const secondTab = select(working, 'tab-2')
+    const done = {
+      'tab-1:leaf-a': entry('claude', 'done'),
+      'tab-2:leaf-b': entry('codex', 'done')
+    }
+
+    expect(select(done, 'tab-1')).toBe(firstTab)
+    expect(select(done, 'tab-2')).toBe(secondTab)
+  })
+
+  it('changes only the tab whose agent identity changes', () => {
+    const select = createTerminalTabAgentTypeSelector()
+    const before = {
+      'tab-1:leaf-a': entry('claude'),
+      'tab-2:leaf-b': entry('codex')
+    }
+    const firstTab = select(before, 'tab-1')
+    const secondTab = select(before, 'tab-2')
+    const after = {
+      ...before,
+      'tab-2:leaf-b': entry('grok')
+    }
+
+    expect(select(after, 'tab-1')).toBe(firstTab)
+    expect(select(after, 'tab-2')).not.toBe(secondTab)
+    expect(select(after, 'tab-2')).toEqual({ 'leaf-b': 'grok' })
+  })
+
+  it('ignores missing agent types and keys without a tab prefix', () => {
+    const select = createTerminalTabAgentTypeSelector()
+    const state = {
+      malformed: entry('claude'),
+      ':leaf-a': entry('codex'),
+      'tab-1:leaf-a': entry(undefined)
+    }
+
+    expect(select(state, 'tab-1')).toEqual({})
+    expect(select(state, 'malformed')).toEqual({})
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.ts
@@ -1,0 +1,73 @@
+import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
+
+export type TerminalTabAgentTypeState = Record<string, AgentStatusEntry>
+export type TerminalTabAgentTypesByLeaf = Readonly<Record<string, AgentType>>
+
+type SelectorDependencies = {
+  onEntryVisited?: (paneKey: string) => void
+}
+
+const EMPTY_AGENT_TYPES_BY_LEAF: TerminalTabAgentTypesByLeaf = Object.freeze({})
+
+function reuseRecordIfEqual(
+  previous: TerminalTabAgentTypesByLeaf | undefined,
+  next: Record<string, AgentType>
+): TerminalTabAgentTypesByLeaf {
+  if (!previous) {
+    return next
+  }
+  const nextKeys = Object.keys(next)
+  if (Object.keys(previous).length !== nextKeys.length) {
+    return next
+  }
+  return nextKeys.every((key) => previous[key] === next[key]) ? previous : next
+}
+
+export function createTerminalTabAgentTypeSelector(
+  dependencies: SelectorDependencies = {}
+): (state: TerminalTabAgentTypeState, tabId: string) => TerminalTabAgentTypesByLeaf {
+  let cachedState: TerminalTabAgentTypeState | null = null
+  let cachedByTabId = new Map<string, TerminalTabAgentTypesByLeaf>()
+
+  return (state, tabId) => {
+    // Why: production writes replace this map. Its identity lets unrelated
+    // Zustand notifications skip the global scan entirely.
+    if (state !== cachedState) {
+      const previousByTabId = cachedByTabId
+      const nextByTabId = new Map<string, Record<string, AgentType>>()
+      for (const [paneKey, entry] of Object.entries(state)) {
+        dependencies.onEntryVisited?.(paneKey)
+        if (!entry.agentType) {
+          continue
+        }
+        const separator = paneKey.indexOf(':')
+        if (separator <= 0) {
+          continue
+        }
+        const entryTabId = paneKey.slice(0, separator)
+        const leafId = paneKey.slice(separator + 1)
+        const byLeaf = nextByTabId.get(entryTabId)
+        if (byLeaf) {
+          byLeaf[leafId] = entry.agentType
+        } else {
+          nextByTabId.set(entryTabId, { [leafId]: entry.agentType })
+        }
+      }
+
+      const stabilizedByTabId = new Map<string, TerminalTabAgentTypesByLeaf>()
+      for (const [entryTabId, byLeaf] of nextByTabId) {
+        stabilizedByTabId.set(
+          entryTabId,
+          reuseRecordIfEqual(previousByTabId.get(entryTabId), byLeaf)
+        )
+      }
+      cachedByTabId = stabilizedByTabId
+      cachedState = state
+    }
+    return cachedByTabId.get(tabId) ?? EMPTY_AGENT_TYPES_BY_LEAF
+  }
+}
+
+// Why: TerminalPane is mounted once per retained tab. Share one index so a
+// store write scans the global agent map once, not once for every hidden tab.
+export const selectTerminalTabAgentTypesByLeaf = createTerminalTabAgentTypeSelector()


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. This is a terminal-renderer survivor: every retained terminal tab repeated the same global agent-map scan on every Zustand notification.

## 1. Description

Orca retains one mounted `TerminalPane` per terminal tab, including tabs hidden with `display: none`. Each pane subscribed with a selector that ran:

```ts
for (const [paneKey, entry] of Object.entries(store.agentStatusByPaneKey))
```

The tab prefix filtered the output, and `useShallow` prevented React renders when that output stayed equal. It did not prevent selector execution: every store notification still made every mounted tab scan every global agent entry and allocate a fresh record.

With `P` mounted terminal tabs and `A` agent entries, one notification therefore performed `P × A` entry visits. Hidden tabs paid the same scan cost as the visible tab.

Fix: a module-level selector builds one `tabId -> leafId -> agentType` index when the immutable `agentStatusByPaneKey` reference changes, then gives each pane an O(1) tab lookup. It reuses per-tab result references when only working/done state changes, and an unrelated store write that preserves the agent-map reference performs no entry scan.

## 2. Undeniable evidence + measurable improvement

- The committed deterministic selector proof uses three global entries, two real tabs, and 100 hidden-tab lookups. The old selectors would perform **102 × 3 = 306 entry visits** for that notification; the shared index performs **3 total visits**.
- Reusing the same agent-map reference after warmup performs **0 entry visits**, rather than another `P × A` scan on an unrelated store notification.
- A state-only `working -> done` replacement keeps both per-tab output references identical.
- Changing one tab from Codex to Grok changes only that tab output; the unrelated tab keeps its previous reference.
- 80 focused selector, native-chat availability/eligibility, tab-bar projection, attention-subscription, and terminal lifecycle/global-effect tests pass.
- Exact-branch Electron validation on macOS/local:
  - four mounted terminal roots were present, one visible and three hidden;
  - a real Claude Code turn produced a pane-scoped `claude / working` store entry and one visible `Show chat view` affordance;
  - clicking it visibly opened the real native-chat surface while the agent worked, then returned to the terminal;
  - normal `done` preserved the affordance in the done frame and terminal output showed `PERF_INDEX_OK` / `PERF_CHAT_OK` before the existing post-exit status cleanup;
  - the temporary experimental setting was restored and the tab remained in terminal mode.

## ELI5
Every terminal tab, even hidden ones, reread the entire app-wide agent list whenever anything in the store changed. Now one shared index reads that list once when the list itself changes, and each tab grabs its own small answer directly.

## 4. Trade-offs that regress the end experience

None material. A changed agent-map reference now creates one retained O(A) index, including projections for agent-bearing tabs that may not currently be visible. That replaces up to P full scans plus P temporary records per notification and is discarded on the next map change. The cache relies on the existing store invariant that every production `agentStatusByPaneKey` mutation replaces the top-level object; all production write sites were checked, and the identity contract is documented next to the cache.

The projection deliberately preserves the old prefix semantics instead of introducing stricter stable-pane parsing, so native-chat eligibility does not change for legacy or partially populated keys.

## Reliability proof

- **Reliability invariant:** `terminal-performance.store-and-git-hot-paths` — hidden and mounted terminal tabs must not each rescan global agent state on unrelated store writes, while per-leaf native-chat eligibility still reacts to agent identity changes.
- **Product change type:** renderer performance hardening.
- **Performance risk inventory:** Zustand selector work and a bounded O(A) renderer index only. No PTY output, batching, resize, xterm lifecycle, focus, tab/session ownership, restore, polling, timers, listeners, IPC/RPC, subprocess, persistence, telemetry, git, or network behavior changes.
- **Oracle:** deterministic entry-visit counts and reference-identity assertions prove the scaling change; existing lifecycle/native-chat suites and exact visible real-Claude validation prove the active behavior.
- **Manifest status:** existing experimental terminal performance gate, `protection: none`, unchanged; this focused selector proof does not promote the broader gate.
- **Provider/platform matrix:** the selector consumes provider-neutral `AgentType` state. Local, daemon, SSH, WSL, remote runtime, relay, GitHub/GitLab/other git providers, macOS/Linux/Windows, and mobile protocols are unchanged; macOS/local was rendered live.
- **Residual gaps:** no high-tab-count React profiler trace was added because deterministic entry visits are the direct waste oracle. SSH/WSL/remote and non-macOS were not run live because this PR changes no transport, path, shell, process, protocol, or platform branch.
- **Rollback/demotion:** revert to the per-pane shallow selector if a pane stops reacting to a live agent identity change; do not promote the broader reliability gate from this PR alone.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.test.ts src/renderer/src/components/terminal-pane/native-chat-leaf-title-agent.test.ts src/renderer/src/components/native-chat/native-chat-availability.test.ts src/renderer/src/components/native-chat/native-chat-send-eligibility.test.ts src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts src/renderer/src/components/tab-bar/tab-agent-types-by-tab-id.test.ts` (80 passed)
- [x] `pnpm typecheck`
- [x] targeted `oxlint`
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff origin/main...HEAD --check`
- [x] exact-branch Electron/CDP real-agent and visible native-chat validation described above
- [ ] Full `pnpm lint` reaches localization verification, then fails on the current-main Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR changes only the three renderer files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
