### PR TITLE
perf(renderer): scope floating workspace collections

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -61,12 +61,7 @@ import {
   ModifierDoubleTapDetector,
   toModifierDoubleTapEvent
 } from '../../../../shared/modifier-double-tap-detector'
-import type {
-  BrowserTab as BrowserTabState,
-  Tab,
-  TabGroup,
-  TerminalTab
-} from '../../../../shared/types'
+import type { BrowserTab as BrowserTabState, Tab, TerminalTab } from '../../../../shared/types'
 import { resolveUnifiedTabLabel } from '../../../../shared/tab-title-resolution'
 import { FloatingBrowserSlot } from './FloatingBrowserSlot'
 import { FloatingTerminalOrchestrationDialog } from './FloatingTerminalOrchestrationDialog'
@@ -90,10 +85,7 @@ import {
 } from './floating-terminal-panel-bounds'
 import { translate } from '@/i18n/i18n'
 import { consumeFloatingTerminalOpenMaximizedIntent } from '@/lib/floating-terminal'
-const EMPTY_TERMINAL_TABS: TerminalTab[] = []
-const EMPTY_BROWSER_TABS: BrowserTabState[] = []
-const EMPTY_GROUPS: TabGroup[] = []
-const EMPTY_UNIFIED_TABS: Tab[] = []
+import { selectFloatingTerminalPanelInputs } from './floating-terminal-panel-inputs'
 const LOCAL_RUNTIME_SETTINGS = { activeRuntimeEnvironmentId: null } as const
 
 const EditorPanel = lazy(() => import('@/components/editor/EditorPanel'))
@@ -170,12 +162,8 @@ export function FloatingTerminalPanel({
   onOpenChange,
   tourInteractionSnapshot
 }: FloatingTerminalPanelProps): React.JSX.Element | null {
-  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  const browserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
-  const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
-  const unifiedTabsByWorktree = useAppStore((s) => s.unifiedTabsByWorktree)
-  const openFiles = useAppStore((s) => s.openFiles)
-  const expandedPaneByTabId = useAppStore((s) => s.expandedPaneByTabId)
+  const { tabs, browserTabs, groups, unifiedTabs, floatingFiles, expandedPaneByTabId } =
+    useAppStore(selectFloatingTerminalPanelInputs)
   const createTab = useAppStore((s) => s.createTab)
   const createBrowserTab = useAppStore((s) => s.createBrowserTab)
   const closeTab = useAppStore((s) => s.closeTab)
@@ -243,14 +231,6 @@ export function FloatingTerminalPanel({
     moved: boolean
   } | null>(null)
 
-  const tabs = tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_TERMINAL_TABS
-  const browserTabs = browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_BROWSER_TABS
-  const groups = groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_GROUPS
-  const unifiedTabs = unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_UNIFIED_TABS
-  const floatingFiles = useMemo(
-    () => openFiles.filter((file) => file.worktreeId === FLOATING_TERMINAL_WORKTREE_ID),
-    [openFiles]
-  )
   const activeGroup = useMemo(
     () =>
       groups.find((group) => group.activeTabId != null) ??
@@ -413,6 +393,8 @@ export function FloatingTerminalPanel({
     wasFeaturePreviouslyInteracted: tourInteractionSnapshot?.wasPreviouslyInteracted
   })
 
+  // Why: this panel only queues its own editor tabs, so unrelated workspace
+  // file updates must not invalidate the hidden panel's close callbacks.
   const {
     saveDialogFileId,
     saveDialogFile,
@@ -420,7 +402,7 @@ export function FloatingTerminalPanel({
     handleSaveDialogSave,
     handleSaveDialogDiscard,
     handleSaveDialogCancel
-  } = useTerminalSaveDialog({ openFiles, closeFile, markFileDirty })
+  } = useTerminalSaveDialog({ openFiles: floatingFiles, closeFile, markFileDirty })
 
   const getNextQueuedEditorClose = useCallback((): string | null => {
     while (pendingEditorCloseQueueRef.current.length > 0) {

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-inputs.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-inputs.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { createFloatingTerminalPanelInputsSelector } from './floating-terminal-panel-inputs'
+
+const OTHER_WORKTREE_ID = 'worktree-other'
+
+type State = Parameters<ReturnType<typeof createFloatingTerminalPanelInputsSelector>>[0]
+type TerminalTab = NonNullable<AppState['tabsByWorktree'][string]>[number]
+type BrowserTab = NonNullable<AppState['browserTabsByWorktree'][string]>[number]
+type TabGroup = NonNullable<AppState['groupsByWorktree'][string]>[number]
+type UnifiedTab = NonNullable<AppState['unifiedTabsByWorktree'][string]>[number]
+type OpenFile = AppState['openFiles'][number]
+
+function terminalTab(id: string, worktreeId: string = FLOATING_TERMINAL_WORKTREE_ID): TerminalTab {
+  return { id, worktreeId } as TerminalTab
+}
+
+function browserTab(id: string, worktreeId: string = FLOATING_TERMINAL_WORKTREE_ID): BrowserTab {
+  return { id, worktreeId } as BrowserTab
+}
+
+function group(id: string, worktreeId: string = FLOATING_TERMINAL_WORKTREE_ID): TabGroup {
+  return { id, worktreeId } as TabGroup
+}
+
+function unifiedTab(id: string, worktreeId: string = FLOATING_TERMINAL_WORKTREE_ID): UnifiedTab {
+  return { id, worktreeId } as UnifiedTab
+}
+
+function openFile(id: string, worktreeId: string): OpenFile {
+  return { id, worktreeId } as OpenFile
+}
+
+function state(overrides: Partial<State> = {}): State {
+  return {
+    browserTabsByWorktree: {},
+    expandedPaneByTabId: {},
+    groupsByWorktree: {},
+    openFiles: [],
+    tabsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    ...overrides
+  }
+}
+
+describe('createFloatingTerminalPanelInputsSelector', () => {
+  it('ignores unrelated workspace collection churn while the panel is retained', () => {
+    const onExpandedTabVisited = vi.fn()
+    const onOpenFileVisited = vi.fn()
+    const select = createFloatingTerminalPanelInputsSelector({
+      onExpandedTabVisited,
+      onOpenFileVisited
+    })
+    const floatingTab = terminalTab('floating-terminal')
+    const floatingBrowser = browserTab('floating-browser')
+    const floatingGroup = group('floating-group')
+    const floatingUnifiedTab = unifiedTab('floating-unified')
+    const floatingFile = openFile('floating-file', FLOATING_TERMINAL_WORKTREE_ID)
+    const initial = state({
+      browserTabsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [floatingBrowser],
+        [OTHER_WORKTREE_ID]: [browserTab('other-browser', OTHER_WORKTREE_ID)]
+      },
+      expandedPaneByTabId: { 'floating-terminal': true, 'other-terminal': true },
+      groupsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [floatingGroup],
+        [OTHER_WORKTREE_ID]: [group('other-group', OTHER_WORKTREE_ID)]
+      },
+      openFiles: [floatingFile, openFile('other-file', OTHER_WORKTREE_ID)],
+      tabsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [floatingTab],
+        [OTHER_WORKTREE_ID]: [terminalTab('other-terminal', OTHER_WORKTREE_ID)]
+      },
+      unifiedTabsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [floatingUnifiedTab],
+        [OTHER_WORKTREE_ID]: [unifiedTab('other-unified', OTHER_WORKTREE_ID)]
+      }
+    })
+    const first = select(initial)
+    const afterUnrelatedWrites = state({
+      browserTabsByWorktree: {
+        ...initial.browserTabsByWorktree,
+        [OTHER_WORKTREE_ID]: [browserTab('other-browser-next', OTHER_WORKTREE_ID)]
+      },
+      expandedPaneByTabId: { ...initial.expandedPaneByTabId, 'other-terminal': false },
+      groupsByWorktree: {
+        ...initial.groupsByWorktree,
+        [OTHER_WORKTREE_ID]: [group('other-group-next', OTHER_WORKTREE_ID)]
+      },
+      openFiles: [floatingFile, openFile('other-file-next', OTHER_WORKTREE_ID)],
+      tabsByWorktree: {
+        ...initial.tabsByWorktree,
+        [OTHER_WORKTREE_ID]: [terminalTab('other-terminal-next', OTHER_WORKTREE_ID)]
+      },
+      unifiedTabsByWorktree: {
+        ...initial.unifiedTabsByWorktree,
+        [OTHER_WORKTREE_ID]: [unifiedTab('other-unified-next', OTHER_WORKTREE_ID)]
+      }
+    })
+
+    expect(select(afterUnrelatedWrites)).toBe(first)
+    expect(select({ ...afterUnrelatedWrites })).toBe(first)
+    expect(onOpenFileVisited).toHaveBeenCalledTimes(4)
+    expect(onExpandedTabVisited).toHaveBeenCalledTimes(2)
+  })
+
+  it('updates each collection when the floating workspace itself changes', () => {
+    const select = createFloatingTerminalPanelInputsSelector()
+    let currentState = state()
+    let previous = select(currentState)
+
+    currentState = {
+      ...currentState,
+      tabsByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: [terminalTab('terminal')] }
+    }
+    let selected = select(currentState)
+    expect(selected).not.toBe(previous)
+    expect(selected.tabs.map((tab) => tab.id)).toEqual(['terminal'])
+    previous = selected
+
+    currentState = {
+      ...currentState,
+      browserTabsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [browserTab('browser')]
+      }
+    }
+    selected = select(currentState)
+    expect(selected).not.toBe(previous)
+    expect(selected.browserTabs.map((tab) => tab.id)).toEqual(['browser'])
+    previous = selected
+
+    currentState = {
+      ...currentState,
+      groupsByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: [group('group')] }
+    }
+    selected = select(currentState)
+    expect(selected).not.toBe(previous)
+    expect(selected.groups.map((entry) => entry.id)).toEqual(['group'])
+    previous = selected
+
+    currentState = {
+      ...currentState,
+      unifiedTabsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [unifiedTab('unified')]
+      }
+    }
+    selected = select(currentState)
+    expect(selected).not.toBe(previous)
+    expect(selected.unifiedTabs.map((tab) => tab.id)).toEqual(['unified'])
+    previous = selected
+
+    currentState = {
+      ...currentState,
+      openFiles: [openFile('file', FLOATING_TERMINAL_WORKTREE_ID)]
+    }
+    selected = select(currentState)
+    expect(selected).not.toBe(previous)
+    expect(selected.floatingFiles.map((file) => file.id)).toEqual(['file'])
+    previous = selected
+
+    currentState = { ...currentState, expandedPaneByTabId: { terminal: true } }
+    selected = select(currentState)
+    expect(selected).not.toBe(previous)
+    expect(selected.expandedPaneByTabId).toEqual({ terminal: true })
+    previous = selected
+
+    currentState = { ...currentState, expandedPaneByTabId: { terminal: false } }
+    selected = select(currentState)
+    expect(selected).not.toBe(previous)
+    expect(selected.expandedPaneByTabId).toEqual({})
+  })
+
+  it('excludes non-floating files and pane expansion state', () => {
+    const select = createFloatingTerminalPanelInputsSelector()
+    const selected = select(
+      state({
+        expandedPaneByTabId: { floating: false, other: true },
+        openFiles: [
+          openFile('floating-file', FLOATING_TERMINAL_WORKTREE_ID),
+          openFile('other-file', OTHER_WORKTREE_ID)
+        ],
+        tabsByWorktree: {
+          [FLOATING_TERMINAL_WORKTREE_ID]: [terminalTab('floating')],
+          [OTHER_WORKTREE_ID]: [terminalTab('other', OTHER_WORKTREE_ID)]
+        }
+      })
+    )
+
+    expect(selected.floatingFiles.map((file) => file.id)).toEqual(['floating-file'])
+    expect(selected.expandedPaneByTabId).toEqual({})
+  })
+})

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-inputs.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-inputs.ts
@@ -1,0 +1,120 @@
+import type { AppState } from '@/store/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+
+type FloatingTerminalPanelState = Pick<
+  AppState,
+  | 'browserTabsByWorktree'
+  | 'expandedPaneByTabId'
+  | 'groupsByWorktree'
+  | 'openFiles'
+  | 'tabsByWorktree'
+  | 'unifiedTabsByWorktree'
+>
+
+export type FloatingTerminalPanelInputs = {
+  browserTabs: NonNullable<AppState['browserTabsByWorktree'][string]>
+  expandedPaneByTabId: Record<string, boolean>
+  floatingFiles: AppState['openFiles']
+  groups: NonNullable<AppState['groupsByWorktree'][string]>
+  tabs: NonNullable<AppState['tabsByWorktree'][string]>
+  unifiedTabs: NonNullable<AppState['unifiedTabsByWorktree'][string]>
+}
+
+type SelectorDependencies = {
+  onExpandedTabVisited?: (tabId: string) => void
+  onOpenFileVisited?: (fileId: string) => void
+}
+
+const EMPTY_BROWSER_TABS: FloatingTerminalPanelInputs['browserTabs'] = []
+const EMPTY_EXPANDED_PANES: FloatingTerminalPanelInputs['expandedPaneByTabId'] = {}
+const EMPTY_FILES: FloatingTerminalPanelInputs['floatingFiles'] = []
+const EMPTY_GROUPS: FloatingTerminalPanelInputs['groups'] = []
+const EMPTY_TABS: FloatingTerminalPanelInputs['tabs'] = []
+const EMPTY_UNIFIED_TABS: FloatingTerminalPanelInputs['unifiedTabs'] = []
+
+function reuseArrayIfEqual<T>(previous: T[], next: T[]): T[] {
+  return previous.length === next.length && next.every((value, index) => previous[index] === value)
+    ? previous
+    : next
+}
+
+function reuseExpandedPanesIfEqual(
+  previous: Record<string, boolean>,
+  next: Record<string, boolean>
+): Record<string, boolean> {
+  const nextKeys = Object.keys(next)
+  if (Object.keys(previous).length !== nextKeys.length) {
+    return next
+  }
+  return nextKeys.every((key) => previous[key] === next[key]) ? previous : next
+}
+
+export function createFloatingTerminalPanelInputsSelector(
+  dependencies: SelectorDependencies = {}
+): (state: FloatingTerminalPanelState) => FloatingTerminalPanelInputs {
+  let openFilesSource: AppState['openFiles'] | null = null
+  let floatingFiles = EMPTY_FILES
+  let expandedTabsSource: FloatingTerminalPanelInputs['tabs'] | null = null
+  let expandedPanesSource: AppState['expandedPaneByTabId'] | null = null
+  let expandedPaneByTabId = EMPTY_EXPANDED_PANES
+  let previous: FloatingTerminalPanelInputs | null = null
+
+  return (state) => {
+    const tabs = state.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_TABS
+    const browserTabs =
+      state.browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_BROWSER_TABS
+    const groups = state.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_GROUPS
+    const unifiedTabs =
+      state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_UNIFIED_TABS
+
+    if (state.openFiles !== openFilesSource) {
+      const nextFloatingFiles = [] as AppState['openFiles']
+      for (const file of state.openFiles) {
+        dependencies.onOpenFileVisited?.(file.id)
+        if (file.worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+          nextFloatingFiles.push(file)
+        }
+      }
+      floatingFiles = reuseArrayIfEqual(floatingFiles, nextFloatingFiles)
+      openFilesSource = state.openFiles
+    }
+
+    if (tabs !== expandedTabsSource || state.expandedPaneByTabId !== expandedPanesSource) {
+      const nextExpandedPaneByTabId: Record<string, boolean> = {}
+      for (const tab of tabs) {
+        dependencies.onExpandedTabVisited?.(tab.id)
+        if (state.expandedPaneByTabId[tab.id] === true) {
+          nextExpandedPaneByTabId[tab.id] = true
+        }
+      }
+      expandedPaneByTabId = reuseExpandedPanesIfEqual(expandedPaneByTabId, nextExpandedPaneByTabId)
+      expandedTabsSource = tabs
+      expandedPanesSource = state.expandedPaneByTabId
+    }
+
+    if (
+      previous?.tabs === tabs &&
+      previous.browserTabs === browserTabs &&
+      previous.groups === groups &&
+      previous.unifiedTabs === unifiedTabs &&
+      previous.floatingFiles === floatingFiles &&
+      previous.expandedPaneByTabId === expandedPaneByTabId
+    ) {
+      return previous
+    }
+
+    previous = {
+      browserTabs,
+      expandedPaneByTabId,
+      floatingFiles,
+      groups,
+      tabs,
+      unifiedTabs
+    }
+    return previous
+  }
+}
+
+// Why: the closed floating workspace retains its pane tree. Scope its one
+// subscription so ordinary workspace writes do not rerender that hidden tree.
+export const selectFloatingTerminalPanelInputs = createFloatingTerminalPanelInputsSelector()


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. This terminal-renderer survivor is the retained floating workspace: it stays mounted while closed so its terminal/browser/editor state survives, but it listened to whole app-wide collections.

## 1. Description

When the floating workspace owns at least one visible tab, `App` intentionally keeps `FloatingTerminalPanel` mounted after minimization. Its terminal pane then uses the normal hidden-terminal suspend path (`display: none`) so session and local pane state survive.

The retained panel opened six broad Zustand subscriptions:

```text
tabsByWorktree, browserTabsByWorktree, groupsByWorktree,
unifiedTabsByWorktree, openFiles, expandedPaneByTabId
```

Only the `global-floating-terminal` entries are rendered. Nevertheless, an ordinary workspace title, activation, browser, editor, or pane-expansion update replaces one of those global collection references and rerenders the entire hidden floating panel, including its tab bar and retained pane tree.

Fix: replace the six subscriptions with one identity-cached projection containing only floating-workspace terminal tabs, browser tabs, groups, unified tabs, editor files, and terminal expansion flags. Top-level map churn for another workspace is now O(1) and returns the exact previous object. Editor files are rescanned only when `openFiles` itself changes; floating expansion is rescanned only when its terminal list or the expansion map changes, and both derived outputs reuse their references when only another workspace changed.

The dirty-file close dialog now receives the already-scoped floating file list. That preserves its ownership contract: every close request this panel queues belongs to the floating workspace.

## 2. Undeniable evidence + measurable improvement

- The committed selector proof simultaneously replaces all six global collections for another workspace while retaining the floating entries. The complete selector result and every nested field keep the same reference, so the default Zustand `Object.is` subscription skips the render.
- Metric: hidden `FloatingTerminalPanel` renders per unrelated collection write drop from **1 -> 0**. The retained terminal/tab subtree therefore also drops from one React traversal per write to zero.
- Same-slice notifications perform **0 file/tab visits** after cache warmup. When only another editor file or pane-expansion entry changes, the selector scans the relevant source once, proves its floating projection unchanged, and still emits zero renders.
- Deterministic active-path cases prove terminal, browser, group, unified, editor-file, expanded, and collapsed floating updates each produce a new result. Non-floating files and expansion keys are excluded.
- All **101** floating-workspace selector, panel, browser-slot, bounds, trigger, toggle, and window-control tests pass, including existing dirty-file close queue coverage.
- Exact-branch Electron validation on macOS/local:
  - created a real floating terminal through the visible empty-state action;
  - minimized it and verified the panel remained mounted with `aria-hidden=true`, `visibility:hidden`, and its terminal root at `display:none`;
  - a real ordinary-terminal title action replaced both `tabsByWorktree` and `unifiedTabsByWorktree` while the floating selector and all six scoped fields retained the exact same reference; the ordinary title was restored;
  - reopened the panel, sent a real OSC title through the floating PTY, observed the scoped terminal reference change, and visibly saw `PERF_FLOATING_LIVE` in the floating tab;
  - interrupted and closed the temporary PTY, then verified floating terminal/browser/unified/file counts returned to zero and the panel unmounted.

## ELI5
The minimized floating workspace was like a hidden second desk that reorganized itself whenever anything changed on the main desk. Now it listens only to its own tabs and files, while still waking up immediately when one of those actually changes.

## 4. Trade-offs that regress the end experience

None material. The selector retains one bounded snapshot of the current floating collections. An `openFiles` replacement still costs O(F) to filter all open files, and an expansion-map replacement costs O(T) over floating terminal tabs, but unchanged floating results no longer trigger the much larger hidden React tree. Store writes that preserve those source references remain O(1).

The cache relies on the existing immutable slice contract: collection and entry changes replace their owning arrays/objects. Terminal title writes already document and enforce preserving unrelated worktree arrays specifically for selector stability.

## Reliability proof

- **Reliability invariant:** `terminal-performance.store-and-git-hot-paths` — a retained hidden floating workspace must not rerender for ordinary-workspace collection churn, while every floating tab/file/group/expansion change remains live.
- **Product change type:** renderer performance hardening.
- **Performance risk inventory:** Zustand selection and two bounded renderer projections only. No PTY output, batching, resize, xterm lifecycle, focus ownership, terminal restore, polling, timers, listeners, IPC/RPC, subprocess, persistence, telemetry, git, or network behavior changes.
- **Oracle:** exact selector identity proves the render gate; active-path reference tests, the existing 101-test surface suite, and visible real-PTY title validation prove retained behavior.
- **Manifest status:** existing experimental terminal performance gate, `protection: none`, unchanged; this focused selector proof does not promote the broader gate.
- **Provider/platform matrix:** the floating workspace uses provider-neutral renderer collections and its existing local runtime. Local/daemon/SSH/WSL/remote/relay protocols, git providers, macOS/Linux/Windows path and shell branches, and mobile behavior are unchanged; macOS/local was rendered live.
- **Residual gaps:** no React Profiler trace was added because the committed exact-object identity is the direct Zustand render oracle. Browser/editor/group active paths are deterministic rather than each recreated in the live app; the live run covered retained-hidden and terminal-title paths.
- **Rollback/demotion:** revert to the broad collection subscriptions if a floating terminal, browser, group, editor file, or expansion state stops updating; do not promote the broader reliability gate from this PR alone.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal` (101 passed)
- [x] `pnpm typecheck`
- [x] targeted `oxlint` and react-doctor pre-commit checks
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff --check`
- [x] exact-branch Electron/CDP hidden-retention plus real-PTY visible validation described above
- [ ] Full `pnpm lint` reaches localization verification, then fails on the current-main Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR changes only the three renderer files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
