### PR TITLE
perf(renderer): index terminal unified tab reads

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -178,7 +178,10 @@ import {
   subscribeTerminalPaneAttention
 } from './terminal-pane-attention-subscriptions'
 import { getCachedTerminalTabForWorktree } from './terminal-tab-lookup'
-import { getCachedTerminalGroupIdForWorktree } from './terminal-unified-tab-lookup'
+import {
+  getCachedTerminalGroupIdForWorktree,
+  getCachedUnifiedTerminalTabForWorktree
+} from './terminal-unified-tab-lookup'
 import { resolveNativeChatLeafTitleAgent } from './native-chat-leaf-title-agent'
 import { useRepoById } from '@/store/selectors'
 import {
@@ -646,23 +649,18 @@ export default function TerminalPane({
   // communicates the presence-lock inside the chat surface instead (U9/R8).
   const unifiedTabId = useAppStore(
     (store) =>
-      (store.unifiedTabsByWorktree[worktreeId] ?? []).find(
-        (t) => t.contentType === 'terminal' && t.entityId === tabId
-      )?.id
+      getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)?.id
   )
   const isChatViewMode = useAppStore(
     (store) =>
-      (store.unifiedTabsByWorktree[worktreeId] ?? []).find(
-        (t) => t.contentType === 'terminal' && t.entityId === tabId
-      )?.viewMode === 'chat'
+      getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)
+        ?.viewMode === 'chat'
   )
   const nativeChatEnabled = useAppStore((store) => store.settings?.experimentalNativeChat === true)
   const effectiveChatViewMode = nativeChatEnabled && isChatViewMode
   const unifiedTabLabel = useAppStore(
     (store) =>
-      (store.unifiedTabsByWorktree[worktreeId] ?? []).find(
-        (t) => t.contentType === 'terminal' && t.entityId === tabId
-      )?.label
+      getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)?.label
   )
   const runtimePaneTitlesByPaneId = useAppStore(
     useShallow((store) => store.runtimePaneTitlesByTabId[tabId] ?? {})

--- a/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Tab } from '../../../../shared/types'
-import { getCachedTerminalGroupIdForWorktree } from './terminal-unified-tab-lookup'
+import {
+  getCachedTerminalGroupIdForWorktree,
+  getCachedUnifiedTerminalTabForWorktree
+} from './terminal-unified-tab-lookup'
 
 function makeTerminalTab(entityId: string, groupId: string): Tab {
   return {
@@ -45,8 +48,8 @@ function iterableTabs(tabs: Tab[]): {
   }
 }
 
-describe('getCachedTerminalGroupIdForWorktree', () => {
-  it('reuses the terminal group lookup while the unified tab array is unchanged', () => {
+describe('terminal unified tab lookup', () => {
+  it('shares one terminal lookup across all pane field and group reads', () => {
     const tabs = [
       makeEditorTab('editor-1'),
       ...Array.from({ length: 200 }, (_, index) =>
@@ -56,14 +59,23 @@ describe('getCachedTerminalGroupIdForWorktree', () => {
     const { value, iterator } = iterableTabs(tabs)
     const unifiedTabsByWorktree = { 'wt-1': value }
 
-    expect(getCachedTerminalGroupIdForWorktree(unifiedTabsByWorktree, 'wt-1', 'terminal-199')).toBe(
-      'group-3'
-    )
+    for (let index = 0; index < 200; index += 1) {
+      const terminalTabId = `terminal-${index}`
+      expect(
+        getCachedUnifiedTerminalTabForWorktree(unifiedTabsByWorktree, 'wt-1', terminalTabId)
+      ).toBe(tabs[index + 1])
+      expect(
+        getCachedUnifiedTerminalTabForWorktree(unifiedTabsByWorktree, 'wt-1', terminalTabId)?.id
+      ).toBe(terminalTabId)
+      expect(
+        getCachedUnifiedTerminalTabForWorktree(unifiedTabsByWorktree, 'wt-1', terminalTabId)?.label
+      ).toBe(terminalTabId)
+    }
     expect(getCachedTerminalGroupIdForWorktree(unifiedTabsByWorktree, 'wt-1', 'terminal-0')).toBe(
       'group-0'
     )
     expect(
-      getCachedTerminalGroupIdForWorktree(unifiedTabsByWorktree, 'wt-1', 'editor-1')
+      getCachedUnifiedTerminalTabForWorktree(unifiedTabsByWorktree, 'wt-1', 'editor-1')
     ).toBeNull()
 
     expect(iterator).toHaveBeenCalledTimes(1)
@@ -73,9 +85,9 @@ describe('getCachedTerminalGroupIdForWorktree', () => {
     const first = iterableTabs([makeTerminalTab('terminal-1', 'group-a')])
     const second = iterableTabs([makeTerminalTab('terminal-1', 'group-b')])
 
-    expect(getCachedTerminalGroupIdForWorktree({ 'wt-1': first.value }, 'wt-1', 'terminal-1')).toBe(
-      'group-a'
-    )
+    expect(
+      getCachedUnifiedTerminalTabForWorktree({ 'wt-1': first.value }, 'wt-1', 'terminal-1')?.groupId
+    ).toBe('group-a')
     expect(
       getCachedTerminalGroupIdForWorktree({ 'wt-1': second.value }, 'wt-1', 'terminal-1')
     ).toBe('group-b')

--- a/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.ts
@@ -1,29 +1,40 @@
 import type { Tab } from '../../../../shared/types'
 
-const terminalGroupLookupByUnifiedTabs = new WeakMap<readonly Tab[], Map<string, string>>()
+const terminalTabLookupByUnifiedTabs = new WeakMap<readonly Tab[], Map<string, Tab>>()
+
+export function getCachedUnifiedTerminalTabForWorktree(
+  unifiedTabsByWorktree: Record<string, Tab[]>,
+  worktreeId: string,
+  terminalTabId: string
+): Tab | null {
+  const unifiedTabs = unifiedTabsByWorktree[worktreeId]
+  if (!unifiedTabs) {
+    return null
+  }
+
+  let lookup = terminalTabLookupByUnifiedTabs.get(unifiedTabs)
+  if (!lookup) {
+    // Why: every retained TerminalPane reads this tab on every store update.
+    // Share one immutable-array index instead of repeating linear scans.
+    lookup = new Map()
+    for (const tab of unifiedTabs) {
+      if (tab.contentType === 'terminal') {
+        lookup.set(tab.entityId, tab)
+      }
+    }
+    terminalTabLookupByUnifiedTabs.set(unifiedTabs, lookup)
+  }
+
+  return lookup.get(terminalTabId) ?? null
+}
 
 export function getCachedTerminalGroupIdForWorktree(
   unifiedTabsByWorktree: Record<string, Tab[]>,
   worktreeId: string,
   terminalTabId: string
 ): string | null {
-  const unifiedTabs = unifiedTabsByWorktree[worktreeId]
-  if (!unifiedTabs) {
-    return null
-  }
-
-  let lookup = terminalGroupLookupByUnifiedTabs.get(unifiedTabs)
-  if (!lookup) {
-    // Why: every mounted TerminalPane asks for its owning group on store updates.
-    // Cache by immutable tab-array ref so 200 panes do not repeat the same scan.
-    lookup = new Map()
-    for (const tab of unifiedTabs) {
-      if (tab.contentType === 'terminal') {
-        lookup.set(tab.entityId, tab.groupId)
-      }
-    }
-    terminalGroupLookupByUnifiedTabs.set(unifiedTabs, lookup)
-  }
-
-  return lookup.get(terminalTabId) ?? null
+  return (
+    getCachedUnifiedTerminalTabForWorktree(unifiedTabsByWorktree, worktreeId, terminalTabId)
+      ?.groupId ?? null
+  )
 }


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. This terminal-pane survivor sits beside an existing cache: group ownership was indexed, but three other reads still linearly searched the same unified-tab array in every retained pane.

## 1. Description

Every mounted `TerminalPane`, including hidden retained tabs, opened three separate Zustand selectors for its unified terminal record:

```text
unified tab id
native-chat view mode
unified tab label
```

Each selector called `.find(...)` over `unifiedTabsByWorktree[worktreeId]` on every store notification. Scalar equality prevented unnecessary React renders, but it did not prevent the three repeated array scans.

The same component already calls `getCachedTerminalGroupIdForWorktree`, which builds a WeakMap-backed terminal index once per immutable unified-tab array. That cache stored only `groupId`, so the other three selectors could not use it.

Fix: let the existing index retain the terminal `Tab` object instead. Group ownership reads `tab.groupId`, while the three existing scalar selectors read `id`, `viewMode`, and `label` through O(1) lookups. They remain separate scalar subscriptions, so render granularity is unchanged.

## 2. Undeniable evidence + measurable improvement

- The committed scale proof uses **200 terminal tabs plus one editor tab** and mirrors all three field selectors for all 200 panes: **600 terminal lookups**, followed by the group lookup, trigger exactly **one** array iteration.
- Before, those three `.find` calls perform **60,900 predicate visits** for the same 200 panes. After, the already-required group index performs **201 entry visits** once plus O(1) map reads: entry visits drop **60,900 -> 201** when the unified array changes.
- On subsequent store notifications with the same unified-array reference, entry visits drop **60,900 -> 0**.
- A replacement unified array rebuilds once and immediately exposes the changed group/tab object; editor tabs remain excluded, preserving the original terminal-only predicate.
- All **78** focused unified/terminal lookup, native-chat availability/eligibility/shortcut, and terminal lifecycle/global-effect tests pass.
- Exact-branch Electron validation on macOS/local with four retained terminal panes, three hidden:
  - a real OSC title changed the active unified label to `Claude Code`;
  - the cached lookup returned the exact terminal object held by the store, with the expected id/entityId, label, and terminal view mode;
  - the pane visibly exposed `Show chat view`, proving the cached label still feeds native-chat eligibility;
  - toggling through the real control visibly opened native chat and moved cached `viewMode` from `terminal -> chat`, then returned to a visible terminal and `terminal` mode;
  - the original title and experimental setting were restored.

## ELI5
Each hidden terminal was searching the same tab list three times whenever anything in the app changed, even though Orca had already built a lookup table for a fourth field. Now all four questions use that one lookup table.

## 4. Trade-offs that regress the end experience

None material. The existing WeakMap index now stores one `Tab` reference per terminal instead of one group-id string. Cardinality and lifetime remain O(U), tied to the immutable unified-tab array so replaced snapshots can be collected. Building the full index on a new array is not new work: the group lookup already paid that same full scan.

Separate scalar Zustand selectors are deliberately retained. Combining them into one object subscription could make an unrelated unified-tab field change rerender the pane; this PR removes scan work without broadening render invalidation.

## Reliability proof

- **Reliability invariant:** `terminal-performance.store-and-git-hot-paths` — retained panes must not repeat linear unified-tab scans on unrelated store writes, while tab identity, native-chat eligibility, mode toggles, and group ownership stay live.
- **Product change type:** renderer performance hardening.
- **Performance risk inventory:** one existing WeakMap index and three scalar Zustand lookups only. No PTY output, batching, resize, xterm lifecycle, focus/session ownership, restore, polling, timers, listeners, IPC/RPC, subprocess, persistence, telemetry, git, or network behavior changes.
- **Oracle:** one-iterator scale test proves the traversal bound; focused lifecycle/native-chat tests and exact visible OSC-title plus terminal/chat toggle validation prove the changed consumers.
- **Manifest status:** existing experimental terminal performance gate, `protection: none`, unchanged; this focused lookup proof does not promote the broader gate.
- **Provider/platform matrix:** unified terminal tabs are provider-neutral renderer state. Local/daemon/SSH/WSL/remote/relay transports, git providers, macOS/Linux/Windows path and shell branches, and mobile protocols are unchanged; macOS/local was rendered live.
- **Residual gaps:** no high-tab-count React Profiler artifact was added because deterministic entry iteration is the direct selector-work oracle. Non-macOS and remote transports were not run live because no transport, protocol, path, process, or platform branch changes.
- **Rollback/demotion:** restore the three direct `.find` selectors if cached id, label, mode, or group ownership stops following unified-tab replacement; do not promote the broader reliability gate from this PR alone.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.test.ts src/renderer/src/components/terminal-pane/terminal-tab-lookup.test.ts src/renderer/src/components/terminal-pane/native-chat-leaf-title-agent.test.ts src/renderer/src/components/native-chat/native-chat-availability.test.ts src/renderer/src/components/native-chat/native-chat-send-eligibility.test.ts src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts` (78 passed)
- [x] `pnpm typecheck`
- [x] targeted `oxlint` and react-doctor pre-commit checks
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff --check`
- [x] exact-branch Electron/CDP visible OSC-title and terminal/chat-mode validation described above
- [ ] Full `pnpm lint` reaches localization verification, then fails on the current-main Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR changes only the three renderer files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
