### PR TITLE
perf(renderer): compact ignored Cursor title effects

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -313,6 +313,80 @@ describe('createIpcPtyTransport', () => {
     }
   })
 
+  it('compacts ignored Cursor native titles into one deferred drain', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor } = await import('./pty-transport')
+      const onTitleChange = vi.fn()
+      const processor = createPtyOutputProcessor({ onTitleChange })
+      const callbacks = { onData: vi.fn() }
+      const ignoredTitles = Array.from({ length: 4_096 }, () => '\x1b]0;Cursor Agent\x07').join('')
+
+      processor.processData(ignoredTitles, callbacks)
+
+      expect(vi.getTimerCount()).toBe(1)
+      await vi.runOnlyPendingTimersAsync()
+
+      expect(vi.getTimerCount()).toBe(0)
+      expect(onTitleChange).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('lets an ignored Cursor native title clear a pending stale-title fallback', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor } = await import('./pty-transport')
+      const onAgentBecameIdle = vi.fn()
+      const processor = createPtyOutputProcessor({
+        onTitleChange: vi.fn(),
+        onAgentBecameIdle,
+        onAgentBecameWorking: vi.fn()
+      })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;⠋ Cursor Agent\x07', callbacks)
+      await vi.advanceTimersByTimeAsync(0)
+      processor.processData('plain output\r\n', callbacks)
+      await vi.advanceTimersByTimeAsync(0)
+
+      processor.processData('\x1b]0;Cursor Agent\x07', callbacks)
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(3_000)
+
+      expect(onAgentBecameIdle).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('re-arms stale-title fallback after a later title-free output scan', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor } = await import('./pty-transport')
+      const onTitleChange = vi.fn()
+      const processor = createPtyOutputProcessor({
+        onTitleChange,
+        onAgentBecameIdle: vi.fn(),
+        onAgentBecameWorking: vi.fn()
+      })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;⠋ Cursor Agent\x07', callbacks)
+      await vi.advanceTimersByTimeAsync(0)
+      onTitleChange.mockClear()
+      processor.processData('\x1b]0;Cursor Agent\x07', callbacks)
+      processor.processData('plain output\r\n', callbacks)
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(3_000)
+
+      expect(onTitleChange).toHaveBeenCalledWith('Cursor Agent', 'Cursor Agent')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('preserves stale-title detection after compacting deferred side effects', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -94,9 +94,33 @@ type ProcessPtyOutputOptions = {
 type PendingPtySideEffect = {
   payloads: ProcessedAgentStatusChunk['payloads']
   titles: string[]
-  scannedForTitles: boolean
+  titleScanEffect: 'none' | 'stale-probe' | 'ignored-cursor-native'
   containsBell: boolean
   suppressAttentionEvents: boolean
+}
+
+function isIgnoredCursorNativeTitle(title: string): boolean {
+  return title.trim().toLowerCase() === 'cursor agent'
+}
+
+function removeIgnoredCursorNativeTitles(titles: string[]): boolean {
+  let writeIndex = 0
+  let removed = false
+  for (let readIndex = 0; readIndex < titles.length; readIndex += 1) {
+    const title = titles[readIndex]
+    if (isIgnoredCursorNativeTitle(title)) {
+      removed = true
+      continue
+    }
+    if (writeIndex !== readIndex) {
+      titles[writeIndex] = title
+    }
+    writeIndex += 1
+  }
+  if (removed) {
+    titles.length = writeIndex
+  }
+  return removed
 }
 
 export function createPtyOutputProcessor({
@@ -152,21 +176,6 @@ export function createPtyOutputProcessor({
   }
 
   function applyObservedTerminalTitle(title: string, suppressAgentTracker = false): void {
-    // Why: cursor-agent's native OSC title is the literal string "Cursor Agent"
-    // and it re-emits that title many times per turn (on every internal redraw)
-    // even while it's actively working. Orca drives the cursor spinner/unread
-    // path by injecting its own synthesized "⠋ Cursor Agent" and "Cursor ready"
-    // frames from the hook server (see src/main/index.ts). If we let cursor's
-    // bare title through, it lands in `runtimePaneTitlesByTabId` — where
-    // `getWorktreeStatus` reads from — and flips the sidebar dot back to solid
-    // within a second of the spinner appearing. Dropping the bare title before
-    // it reaches the store leaves the synthesized frame as the last-applied
-    // state until the next hook event overwrites it. Match is literal (trimmed,
-    // case-insensitive) so any task/chat title cursor auto-generates still
-    // passes through unchanged.
-    if (title.trim().toLowerCase() === 'cursor agent') {
-      return
-    }
     lastEmittedTitle = normalizeTerminalTitle(title)
     onTitleChange?.(lastEmittedTitle, title)
     if (!suppressAgentTracker) {
@@ -203,7 +212,9 @@ export function createPtyOutputProcessor({
       next.payloads.length === 0 &&
       !next.containsBell
     ) {
-      prior.scannedForTitles ||= next.scannedForTitles
+      // Why: for adjacent no-op scans, only the latest event decides whether
+      // stale-title detection should remain cleared or be re-armed.
+      prior.titleScanEffect = next.titleScanEffect
       pendingWorkingTitleSideEffects += workingTitleCount
       return
     }
@@ -218,6 +229,9 @@ export function createPtyOutputProcessor({
   ): void {
     const scannedForTitles = Boolean(onTitleChange && data.includes('\x1b]'))
     const titles = scannedForTitles ? extractAllOscTitles(data) : []
+    // Why: Cursor emits this ignored title on every redraw; keep one ordered
+    // queue fact instead of one allocation and drain slot per native frame.
+    const ignoredCursorNativeTitle = removeIgnoredCursorNativeTitles(titles)
     const deliveredPayloads =
       onAgentStatus && !suppressAttentionEvents && payloads.length > 0 ? payloads : []
     const containsBell = Boolean(
@@ -231,6 +245,11 @@ export function createPtyOutputProcessor({
       (isWorkingTitle(lastEmittedTitle) || pendingWorkingTitleSideEffects > 0)
     )
     const shouldEmitEmptyTitleScan = scannedForTitles || needsStaleTitleProbe
+    const emptyTitleScanEffect: PendingPtySideEffect['titleScanEffect'] = ignoredCursorNativeTitle
+      ? 'ignored-cursor-native'
+      : shouldEmitEmptyTitleScan
+        ? 'stale-probe'
+        : 'none'
     if (!shouldEmitEmptyTitleScan && deliveredPayloads.length === 0 && !containsBell) {
       return
     }
@@ -242,7 +261,7 @@ export function createPtyOutputProcessor({
       enqueuePtySideEffect({
         payloads: [],
         titles: [],
-        scannedForTitles: shouldEmitEmptyTitleScan,
+        titleScanEffect: emptyTitleScanEffect,
         containsBell,
         suppressAttentionEvents
       })
@@ -251,7 +270,7 @@ export function createPtyOutputProcessor({
         enqueuePtySideEffect({
           payloads: [payload],
           titles: [],
-          scannedForTitles: false,
+          titleScanEffect: 'none',
           containsBell: false,
           suppressAttentionEvents
         })
@@ -260,7 +279,7 @@ export function createPtyOutputProcessor({
         enqueuePtySideEffect({
           payloads: [],
           titles: [],
-          scannedForTitles: shouldEmitEmptyTitleScan,
+          titleScanEffect: emptyTitleScanEffect,
           containsBell: false,
           suppressAttentionEvents
         })
@@ -269,7 +288,7 @@ export function createPtyOutputProcessor({
         enqueuePtySideEffect({
           payloads: [],
           titles: [title],
-          scannedForTitles,
+          titleScanEffect: 'none',
           containsBell: false,
           suppressAttentionEvents
         })
@@ -278,7 +297,7 @@ export function createPtyOutputProcessor({
         enqueuePtySideEffect({
           payloads: [],
           titles: [],
-          scannedForTitles: false,
+          titleScanEffect: 'none',
           containsBell: true,
           suppressAttentionEvents
         })
@@ -319,7 +338,7 @@ export function createPtyOutputProcessor({
         onAgentStatus(payload)
       }
     }
-    processObservedTitles(next.titles, next.scannedForTitles, next.suppressAttentionEvents)
+    processObservedTitles(next.titles, next.titleScanEffect, next.suppressAttentionEvents)
     if (onBell && next.containsBell) {
       onBell()
     }
@@ -354,7 +373,7 @@ export function createPtyOutputProcessor({
 
   function processObservedTitles(
     titles: string[],
-    scannedForTitles: boolean,
+    titleScanEffect: PendingPtySideEffect['titleScanEffect'],
     suppressAgentTracker: boolean
   ): void {
     if (!onTitleChange) {
@@ -369,8 +388,10 @@ export function createPtyOutputProcessor({
       for (const title of titles) {
         applyObservedTerminalTitle(title, suppressAgentTracker)
       }
+    } else if (titleScanEffect === 'ignored-cursor-native') {
+      clearStaleTitleTimer()
     } else if (
-      scannedForTitles &&
+      titleScanEffect === 'stale-probe' &&
       !suppressAgentTracker &&
       lastEmittedTitle &&
       detectAgentStatusFromTitle(lastEmittedTitle) === 'working'


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. This PTY hot path already ignored the bare native Cursor Agent title for correctness, but only after allocating and scheduling one deferred side effect for every redraw frame.

## 1. Description

Cursor Agent re-emits the literal native OSC title `Cursor Agent` on every internal redraw. Orca must ignore it so it cannot overwrite the synthesized spinner and ready titles that drive agent state.

The PTY output processor previously extracted every title, created one `PendingPtySideEffect` object per ignored title, and drained those objects 64 at a time on zero-delay timer turns. The eventual callback returned without changing product state, so every allocation and drain slot was wasted.

Fix:

- compact ignored native Cursor titles out of the freshly extracted local title array before the deferred queue;
- retain one ordered `titleScanEffect` fact so an ignored native title still clears the stale-title fallback at the correct point;
- let the latest adjacent no-op scan win, preserving the existing rule that later title-free output re-arms stale-title detection;
- keep meaningful OSC titles, agent-status payloads, and BEL effects in their original order.

## 2. Undeniable evidence + measurable improvement

- The committed scale fixture feeds **4,096 ignored native Cursor title frames** in one PTY chunk.
- Before, that produced **4,096 queued side-effect objects**. With the existing 64-effect drain budget, it required **64 renderer timer turns**; the red run proved another timer remained after turn 1.
- After, the same fixture produces **one compact ordered queue fact** and finishes in **one timer turn**: queued effects **4,096 -> 1**, drain turns **64 -> 1**, title callbacks remain **0**.
- Two ordering tests prove the compact fact still clears an already armed stale-title timer and that later title-free output still re-arms it.
- All **478** focused PTY transport, dispatcher, remote-runtime, and terminal connection/restore tests pass.

## ELI5
Cursor repeatedly announces a title that Orca intentionally throws away. Orca used to put every announcement in a to-do list and later cross off 64 useless items at a time. Now it records one note saying those announcements happened and handles that note once.

## 4. Trade-offs that regress the end experience

None material. Classification moves from deferred application to the extraction boundary, so every title is still checked once. The freshly allocated extraction array is compacted in place; meaningful title strings are not copied into a second array.

The compact scan state adds ordering logic because an ignored Cursor title clears a stale-title timer, while later ordinary output must re-arm it. Dedicated tests cover both directions. Raw PTY bytes, xterm writes, output scheduler bounds, title/status/BEL callback ordering, and provider protocols are unchanged.

## Reliability proof

- **Reliability class / gate:** `terminal-performance.output-backpressure-budget`.
- **Failure source:** the existing Cursor native-title behavior emits one ignored OSC title per redraw; the audit found those no-op frames accumulating in the bounded deferred side-effect queue.
- **Product change type:** renderer performance hardening.
- **Invariant:** PTY data reaches xterm immediately, meaningful title/status/BEL effects retain byte order, ignored native Cursor titles cannot overwrite synthesized state, and ignored frames do not consume queue space or repeated timer turns.
- **Performance risk inventory:** per-PTY-chunk OSC title extraction and the deferred derived-side-effect queue. No typing/input routing, focus, resize, raw output batching, hidden-output restore, startup, provider listing, polling, IPC/RPC shape, subprocess, persistence, telemetry, git, or network behavior changes.
- **Oracle:** the red/green 4,096-frame count fixture proves queue and timer bounds; stale-title ordering tests prove both timer transitions; the 478 focused tests cover local IPC and remote-runtime consumers plus connection/restore behavior.
- **Manifest status:** existing experimental gate with partial protection, unchanged. This focused renderer queue proof does not promote the broader backpressure gate.
- **Provider/platform matrix:** the shared processor serves local/daemon/SSH-shaped IPC transports and remote-runtime transports. Mocked IPC and remote-runtime suites pass. WSL, relay/mobile, macOS/Linux/Windows process, path, shell, ConPTY, and protocol branches are unchanged.
- **Diagnostics:** no new telemetry or raw-output retention. Existing title/status callbacks and deterministic timer-count tests remain the observable oracle.
- **Residual gaps:** no live Cursor session or background-throttled Electron soak was added; the deterministic queue-count test directly proves the removed work but does not measure whole-renderer CPU under a real Cursor redraw flood.
- **Rollback/demotion:** revert the compaction if meaningful title order changes, ignored native titles reach `onTitleChange`, or stale-title clear/re-arm behavior diverges. Do not promote the broader gate from this PR alone.

## Testing

- [x] Red proof: focused count test failed because one drain timer remained after the first 64 effects
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts src/renderer/src/components/terminal-pane/pty-transport-pi-coalesce.test.ts src/renderer/src/components/terminal-pane/pty-transport-pi-spinner.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.test.ts` (129 passed)
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` (349 passed)
- [x] `pnpm typecheck`
- [x] targeted `oxlint`, react-doctor pre-commit checks, and `oxfmt --check`
- [x] `pnpm lint:switch-exhaustiveness`
- [x] `pnpm check:reliability-gates`
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff --check`
- [ ] Full `pnpm lint` reaches localization verification, then fails on the current-main Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR changes only the two renderer PTY files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋