### PR TITLE
perf(mobile): avoid duplicate host-list comparisons

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -148,6 +148,8 @@ export function HostScreen({
   const newWorktreeModalVisibleRef = useRef(false)
   const closeHostClient = useCloseHost()
   const forceReconnectHost = useForceReconnect()
+  // Why: retain this snapshot through disconnects; a separate last-known copy
+  // would duplicate every polling comparison while always holding the same data.
   const [worktrees, setWorktrees] = useState<Worktree[]>(initialCache ?? [])
   const [worktreesLoaded, setWorktreesLoaded] = useState(initialCache != null)
   // Why: opening a worktree activates it on the host, but the active-row
@@ -161,7 +163,6 @@ export function HostScreen({
   const [hostName, setHostName] = useState('')
   const [error, setError] = useState('')
   const [compatVerdict, setCompatVerdict] = useState<CompatVerdict>({ kind: 'ok' })
-  const [lastKnownWorktrees, setLastKnownWorktrees] = useState<Worktree[]>(initialCache ?? [])
   const [search, setSearch] = useState('')
   const [showSearch, setShowSearch] = useState(false)
   const [sortMode, setSortMode] = useState<MobileSortMode>('recent')
@@ -341,12 +342,10 @@ export function HostScreen({
     const freshCache = hostId ? (getCachedWorktrees(hostId) as Worktree[] | null) : null
     if (freshCache) {
       setWorktrees(freshCache)
-      setLastKnownWorktrees(freshCache)
       setWorktreesLoaded(true)
     } else {
       setWorktreesLoaded(false)
       setWorktrees([])
-      setLastKnownWorktrees([])
     }
     if (!hostId) {
       return
@@ -450,9 +449,6 @@ export function HostScreen({
           // poll. Preserving the existing array keeps SectionList/sort rebuilds
           // off the JS tap path unless something actually changed.
           setWorktrees((current) =>
-            areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
-          )
-          setLastKnownWorktrees((current) =>
             areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
           )
           setWorktreesLoaded(true)
@@ -631,9 +627,6 @@ export function HostScreen({
       setWorktrees((prev) =>
         prev.map((w) => (w.worktreeId === worktreeId ? { ...w, isPinned: newPinned } : w))
       )
-      setLastKnownWorktrees((prev) =>
-        prev.map((w) => (w.worktreeId === worktreeId ? { ...w, isPinned: newPinned } : w))
-      )
 
       updateLocalPins(worktreeId, newPinned)
 
@@ -658,7 +651,6 @@ export function HostScreen({
       const removeFromList = (list: Worktree[]) =>
         list.filter((w) => w.worktreeId !== item.worktreeId)
       setWorktrees(removeFromList)
-      setLastKnownWorktrees(removeFromList)
 
       try {
         const response = await client.sendRequest('worktree.rm', {
@@ -667,12 +659,10 @@ export function HostScreen({
         })
         if (!response.ok) {
           setWorktrees((prev) => [...prev, item])
-          setLastKnownWorktrees((prev) => [...prev, item])
         }
         void fetchWorktrees()
       } catch {
         setWorktrees((prev) => [...prev, item])
-        setLastKnownWorktrees((prev) => [...prev, item])
       }
     },
     [client, fetchWorktrees]
@@ -784,10 +774,7 @@ export function HostScreen({
   )
 
   const displayWorktrees = useMemo(() => {
-    const base =
-      connState === 'disconnected' || connState === 'reconnecting' || connState === 'auth-failed'
-        ? lastKnownWorktrees
-        : worktrees
+    const base = worktrees
     if (sleptIds.size === 0 && optimisticActiveWorktreeId === null) {
       return base
     }
@@ -803,7 +790,7 @@ export function HostScreen({
           : null
       return slept || active ? { ...w, ...slept, ...active } : w
     })
-  }, [connState, worktrees, lastKnownWorktrees, sleptIds, optimisticActiveWorktreeId])
+  }, [worktrees, sleptIds, optimisticActiveWorktreeId])
 
   const toggleCollapsed = useCallback(
     (key: string) => {


### PR DESCRIPTION
## Description

Keep one mobile host-list snapshot instead of maintaining worktrees and lastKnownWorktrees in lockstep.

The worktrees state already survives disconnected, reconnecting, and auth-failed transitions. Every production write initialized or transformed both arrays identically, so the second state never supplied different fallback data. Removing it also removes the second full areWorktreeListsEqual walk on every successful three-second worktree.ps poll, plus duplicate optimistic pin/remove array updates.

This is mobile renderer-only. It does not change the worktree.ps request, response shape, polling cadence, persisted data, route behavior, or host selection.

## Evidence

Production path:

- The focused host route and persistent tablet sidebar poll worktree.ps every 3 seconds.
- The request accepts as many as 10,000 worktrees.
- Before this change, every successful response invoked areWorktreeListsEqual once from setWorktrees and again from setLastKnownWorktrees.
- All other writes to those states were paired with the same cache value or the same logical pin/remove transformation. Neither state was cleared merely because the connection became unavailable.

Deterministic work count for an unchanged 5,000-worktree snapshot over five polls:

| | Before | After |
|---|---:|---:|
| Full list comparisons | 10 | 5 |
| Worktree object comparisons | 50,000 | 25,000 |
| Instrumented worktreeId reads | 100,000 | 50,000 |

Isolated comparator stress benchmark, 41 alternating samples after 20 warmups:

| | Median |
|---|---:|
| Two-state path | 2.865 ms |
| Single-state path | 1.447 ms |
| Reduction | 49.5% |

The timing measures only unchanged-snapshot equality work. It is not an end-to-end mobile latency claim and excludes RPC/network/React costs. The exact 2x to 1x invocation reduction follows directly from the production setters.

## ELI5

The screen kept two identical copies of the same workspace list. Every three seconds it checked the new list against copy A, then repeated the same check against copy B. Since both copies were always updated together, copy B could never tell us anything new. This keeps copy A through disconnects and stops doing the duplicate check.

## End-user trade-offs / regressions

No end-user regression is expected.

- Disconnected, reconnecting, and authentication-failed screens still show the retained worktree snapshot because React state is not cleared on those transitions.
- Optimistic pin and remove behavior still updates and rolls back the same visible snapshot.
- Local, SSH, and runtime-hosted worktree lists use the same unchanged RPC result.
- There is no GitHub-specific behavior and no effect on GitLab or other provider data.
- Older desktop builds remain compatible because no RPC or persisted-state contract changed.

Maintenance trade-off: if connected and last-known lists ever need to diverge in the future, that behavior would need an explicit second snapshot. The current implementation had no divergence path.

## Validation

- pnpm --dir mobile test — 185 files passed; 1,314 tests passed; 2 skipped
- pnpm --dir mobile exec tsc --noEmit
- pnpm --dir mobile lint
- pnpm --dir mobile exec oxfmt --check app/h/[hostId]/index.tsx
- pnpm check:max-lines-ratchet
