### PR TITLE
perf(renderer): keep pre-handler PTY buffering linear

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  bufferPreHandlerPtyData,
+  clearPreHandlerPtyState,
+  drainPreHandlerPtyData
+} from './pty-pre-handler-buffer'
+
+const RESCAN_PTY_ID = 'pty-pre-handler-rescan'
+const TRIM_PTY_ID = 'pty-pre-handler-trim'
+
+describe('pre-handler PTY buffer', () => {
+  afterEach(() => {
+    clearPreHandlerPtyState(RESCAN_PTY_ID)
+    clearPreHandlerPtyState(TRIM_PTY_ID)
+  })
+
+  it('does not rescan historical chunks while buffering small startup output', () => {
+    const originalReduce = Array.prototype.reduce
+
+    try {
+      Object.defineProperty(Array.prototype, 'reduce', {
+        configurable: true,
+        writable: true,
+        value() {
+          throw new Error('Array.reduce should not be used by the pre-handler PTY buffer')
+        }
+      })
+      for (let index = 0; index < 4_096; index += 1) {
+        bufferPreHandlerPtyData(RESCAN_PTY_ID, 'x')
+      }
+    } finally {
+      Object.defineProperty(Array.prototype, 'reduce', {
+        configurable: true,
+        writable: true,
+        value: originalReduce
+      })
+    }
+
+    const drained: string[] = []
+    drainPreHandlerPtyData(RESCAN_PTY_ID, (data) => drained.push(data))
+    expect(drained).toHaveLength(4_096)
+  })
+
+  it('does not shift the live array while trimming a capped backlog', () => {
+    const originalShift = Array.prototype.shift
+    const originalWarn = console.warn
+
+    try {
+      console.warn = () => {}
+      Object.defineProperty(Array.prototype, 'shift', {
+        configurable: true,
+        writable: true,
+        value() {
+          throw new Error('Array.shift should not be used by the pre-handler PTY buffer')
+        }
+      })
+      for (let index = 0; index < 2_048; index += 1) {
+        bufferPreHandlerPtyData(TRIM_PTY_ID, 'x'.repeat(1_024))
+      }
+    } finally {
+      console.warn = originalWarn
+      Object.defineProperty(Array.prototype, 'shift', {
+        configurable: true,
+        writable: true,
+        value: originalShift
+      })
+    }
+
+    const drained: string[] = []
+    drainPreHandlerPtyData(TRIM_PTY_ID, (data) => drained.push(data))
+    expect(drained).toHaveLength(512)
+    expect(drained.join('')).toHaveLength(512 * 1_024)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -7,7 +7,13 @@ type BufferedPreHandlerPtyData = {
   meta?: PtyDataMeta
 }
 
-const preHandlerPtyData = new Map<string, BufferedPreHandlerPtyData[]>()
+type BufferedPreHandlerPtyState = {
+  chunks: BufferedPreHandlerPtyData[]
+  head: number
+  bytes: number
+}
+
+const preHandlerPtyData = new Map<string, BufferedPreHandlerPtyState>()
 const preHandlerPtyExit = new Map<string, number>()
 
 // Why: Windows startup commands can emit output before pty:spawn resolves and
@@ -36,21 +42,32 @@ export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyD
     meta && chunk.data.length !== data.length && typeof meta.rawLength === 'number'
       ? { ...meta, rawLength: chunk.bytes }
       : meta
-  const chunks = preHandlerPtyData.get(ptyId) ?? []
-  chunks.push({
+  let state = preHandlerPtyData.get(ptyId)
+  if (!state) {
+    state = { chunks: [], head: 0, bytes: 0 }
+    preHandlerPtyData.set(ptyId, state)
+  }
+  state.chunks.push({
     data: chunk.data,
     bytes: chunk.bytes,
     ...(bufferedMeta ? { meta: bufferedMeta } : {})
   })
-  let totalBytes = chunks.reduce((total, entry) => total + entry.bytes, 0)
-  while (totalBytes > PRE_HANDLER_PTY_DATA_MAX_BYTES && chunks.length > 1) {
-    totalBytes -= chunks.shift()?.bytes ?? 0
+  state.bytes += chunk.bytes
+  // Why: a missing handler can accumulate many small chunks; a stored total
+  // and head index keep that failure path linear instead of rescanning/shifting.
+  while (state.bytes > PRE_HANDLER_PTY_DATA_MAX_BYTES && state.head < state.chunks.length - 1) {
+    state.bytes -= state.chunks[state.head].bytes
+    state.chunks[state.head] = { data: '', bytes: 0 }
+    state.head += 1
   }
-  preHandlerPtyData.set(ptyId, chunks)
-  if (totalBytes > PRE_HANDLER_PTY_DATA_WARN_BYTES && !warnedLostHandlerPtyIds.has(ptyId)) {
+  if (state.head > 0 && state.head * 2 >= state.chunks.length) {
+    state.chunks.splice(0, state.head)
+    state.head = 0
+  }
+  if (state.bytes > PRE_HANDLER_PTY_DATA_WARN_BYTES && !warnedLostHandlerPtyIds.has(ptyId)) {
     warnedLostHandlerPtyIds.add(ptyId)
     console.warn(
-      `[pty] ${ptyId}: ${totalBytes} bytes buffered with no registered data handler; ` +
+      `[pty] ${ptyId}: ${state.bytes} bytes buffered with no registered data handler; ` +
         'the owning pane may have lost its handler to a detach/attach race'
     )
   }
@@ -60,13 +77,14 @@ export function drainPreHandlerPtyData(
   ptyId: string,
   handler: (data: string, meta?: PtyDataMeta) => void
 ): void {
-  const chunks = preHandlerPtyData.get(ptyId)
+  const state = preHandlerPtyData.get(ptyId)
   warnedLostHandlerPtyIds.delete(ptyId)
-  if (!chunks) {
+  if (!state) {
     return
   }
   preHandlerPtyData.delete(ptyId)
-  for (const chunk of chunks) {
+  for (let index = state.head; index < state.chunks.length; index += 1) {
+    const chunk = state.chunks[index]
     handler(chunk.data, chunk.meta)
   }
 }


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. This catches a quadratic fallback in the renderer PTY dispatcher: the eager reconnect buffer already uses stored byte accounting and a head index, but the earlier pre-handler race buffer still rescanned and shifted its entire chunk array.

## 1. Description

PTY output can arrive before a pane registers its per-PTY handler, especially for fast Windows startup commands and during detach/attach races. The singleton dispatcher ACKs that output and temporarily retains up to 512 KiB per PTY so the eventual transport can replay it instead of losing setup output.

The pre-handler buffer previously did this on every chunk:

1. append the chunk;
2. `reduce` the full retained array to recompute total bytes;
3. call `Array.shift()` for every leading chunk trimmed at the cap.

That makes the missing-handler fallback quadratic in chunk count and reindexes the live array repeatedly under sustained output. This is especially harmful in the frozen-pane failure mode that the buffer warning is meant to diagnose.

Fix: store `{ chunks, head, bytes }` per PTY. Appends update the byte total in O(1), cap trimming advances a head index, and dead slots compact only after they reach half the array. Drain still delivers every retained chunk in FIFO order.

## 2. Undeniable evidence + measurable improvement

- The first committed red gate buffers **4,096 one-byte startup chunks** while making any `Array.reduce` call fail.
- Before, the append path performs **8,390,656 historical-entry visits**: `1 + 2 + ... + 4,096`. After, historical rescans are **8,390,656 -> 0**.
- The second red gate buffers **2,048 x 1 KiB chunks** behind the existing **512 KiB** cap while making any `Array.shift` call fail.
- Before, every chunk after the first 512 shifts the array: **1,536 live-array shifts**. After, shifts are **1,536 -> 0**; head advancement plus periodic compaction is amortized O(C).
- The capped fixture still drains exactly the newest **512 chunks / 512 KiB**, and the uncapped fixture drains all 4,096 chunks.
- All **72** focused pre-handler, singleton dispatcher, eager-buffer, transport, title/status/BEL, and early-exit tests pass.

## ELI5
When output arrived just before a terminal was ready, Orca kept recounting every saved piece after each new piece and moved the whole list whenever it dropped the oldest one. Now it keeps a running total and moves a bookmark instead.

## 4. Trade-offs that regress the end experience

None material. Each temporarily buffered PTY now stores two numbers, `head` and `bytes`. Existing limits remain unchanged: 512 KiB per PTY and 64 PTYs globally.

Dropped entries are blanked immediately so their strings and metadata can be collected, then the array is compacted when dead slots reach half its length. That periodic splice is O(C), but it happens only after O(C) head advances, making the total amortized linear. FIFO ordering, UTF-8 tail clamping, sequence metadata, raw-length correction, warning threshold, exit ordering, ACK timing, and eviction order are unchanged.

## Reliability proof

- **Reliability class / gate:** `terminal-performance.output-backpressure-budget`.
- **Failure source:** the startup/missing-handler race and the documented frozen-pane detach/attach failure path can accumulate many small chunks before a handler drains them.
- **Product change type:** renderer performance hardening.
- **Invariant:** renderer-accepted PTY bytes remain bounded, newest output is retained at the cap, metadata and FIFO order survive pre-handler replay, and a missing handler cannot turn chunk arrival into quadratic renderer work.
- **Performance risk inventory:** only temporary pre-handler output accounting and trimming. No typing/input path, xterm parse/write scheduler, title/status/BEL processing, focus, resize, restore snapshots, startup awaits, polling, provider listing, IPC/RPC payload shape, subprocess, persistence, telemetry, git, or network behavior changes.
- **Oracle:** red tests forbid the two costly array operations at realistic scale; green tests assert all 4,096 uncapped chunks drain and exactly 512 KiB survives cap pressure; existing dispatcher/transport tests prove early data precedes exit and retains metadata.
- **Manifest status:** existing experimental output-backpressure gate with partial protection, unchanged. This renderer-only slice does not promote the broader gate.
- **Provider/platform matrix:** local, daemon, SSH, WSL, macOS, Linux, and Windows IPC PTYs share this renderer dispatcher. The trigger is especially relevant to fast Windows startup output, but the data structure is platform-neutral. Remote-runtime/mobile/relay streams bypass this pre-handler map and are unaffected.
- **Diagnostics:** the existing bounded lost-handler warning remains byte-accurate and content-free. No raw output is added to logs or telemetry.
- **Residual gaps:** no live Windows fast-start or deliberately frozen Electron pane soak was added; deterministic dispatcher-level ordering and operation-count tests cover the changed contract.
- **Rollback/demotion:** revert if early output, metadata, or exit ordering changes, if retained output exceeds 512 KiB, or if cap trimming stops preserving the newest tail. Do not promote the broader gate from this PR alone.

## Testing

- [x] Red proof: 4,096-chunk fixture failed on the historical `reduce`
- [x] Red proof: capped 2,048-chunk fixture failed on `Array.shift`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts` (72 passed)
- [x] `pnpm typecheck`
- [x] targeted `oxlint`, react-doctor pre-commit checks, and `oxfmt --check`
- [x] `pnpm lint:switch-exhaustiveness`
- [x] `pnpm check:reliability-gates`
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff --check`
- [ ] Full `pnpm lint` reaches localization verification, then fails on the current-main Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR changes only the two renderer PTY files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋