### PR TITLE
fix(editor): focus Explorer-opened Markdown for find

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -24,6 +24,7 @@ import {
   runRichMarkdownContextCommand
 } from './rich-markdown-context-command-routing'
 import { useRichMarkdownSpellcheckAttribute } from './rich-markdown-spellcheck'
+import { autoFocusRichEditor } from './rich-markdown-auto-focus'
 import { useRichMarkdownSuperscriptLinkSetup } from './useRichMarkdownSuperscriptLinkSetup'
 import {
   formatSelectedHtmlSuperscriptLinkStatus,
@@ -79,6 +80,11 @@ export default function RichMarkdownEditor({
   const richMarkdownSpellcheckEnabled = settings?.richMarkdownSpellcheckEnabled ?? true
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const activateMarkdownLink = useAppStore((s) => s.activateMarkdownLink)
+  const pendingEditorFocusRequest = useAppStore((s) => {
+    const request = s.pendingEditorFocusRequest
+    return request?.fileId === fileId && request.worktreeId === worktreeId ? request : null
+  })
+  const consumeEditorFocusRequest = useAppStore((s) => s.consumeEditorFocusRequest)
   const addDiffComment = useAppStore((s) => s.addDiffComment)
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
   const updateDiffComment = useAppStore((s) => s.updateDiffComment)
@@ -258,6 +264,16 @@ export default function RichMarkdownEditor({
     setSlashMenu: menu.setSlashMenu,
     setDocLinkMenu: menu.setDocLinkMenu
   })
+
+  useEffect(() => {
+    if (!editor || !pendingEditorFocusRequest) {
+      return
+    }
+    cancelAutoFocusRef.current?.()
+    cancelAutoFocusRef.current = autoFocusRichEditor(editor, rootRef.current, true)
+    consumeEditorFocusRequest(pendingEditorFocusRequest.token)
+  }, [consumeEditorFocusRequest, editor, pendingEditorFocusRequest])
+
   // Why: useEditor defaults shouldRerenderOnTransaction to false, so selection-only
   // citation NodeSelections would leave aria status stale without useEditorState.
   const selectedCitationStatus = useEditorState({

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
@@ -9,7 +9,10 @@ function createEditor(focus = vi.fn()): Editor {
   } as unknown as Editor
 }
 
-function setupScheduledFocus(activeElement: { closest: (selector: string) => unknown } | null): {
+function setupScheduledFocus(
+  activeElement: object | null,
+  force = false
+): {
   focus: ReturnType<typeof vi.fn>
   runFrame: () => void
 } {
@@ -23,7 +26,7 @@ function setupScheduledFocus(activeElement: { closest: (selector: string) => unk
   })
   vi.stubGlobal('cancelAnimationFrame', vi.fn())
   vi.stubGlobal('document', { activeElement, body: {} })
-  autoFocusRichEditor(createEditor(focus), null)
+  autoFocusRichEditor(createEditor(focus), null, force)
 
   return {
     focus,
@@ -59,22 +62,15 @@ describe('autoFocusRichEditor', () => {
     expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
   })
 
-  it('takes focus from the Explorer file row that opened the document', () => {
-    const activeElement = {
-      closest: vi.fn().mockReturnValue({})
-    }
-    const { focus, runFrame } = setupScheduledFocus(activeElement)
+  it('honors an explicit focus handoff', () => {
+    const { focus, runFrame } = setupScheduledFocus({}, true)
     runFrame()
 
-    expect(activeElement.closest).toHaveBeenCalledWith('[data-file-explorer-row]')
     expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
   })
 
   it('does not steal focus from other controls outside the editor', () => {
-    const activeElement = {
-      closest: vi.fn().mockReturnValue(null)
-    }
-    const { focus, runFrame } = setupScheduledFocus(activeElement)
+    const { focus, runFrame } = setupScheduledFocus({})
     runFrame()
 
     expect(focus).not.toHaveBeenCalled()

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
@@ -47,4 +47,47 @@ describe('autoFocusRichEditor', () => {
 
     expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
   })
+
+  it('takes focus from the Explorer file row that opened the document', () => {
+    let pendingFrame: FrameRequestCallback = () => {
+      throw new Error('expected focus frame to be scheduled')
+    }
+    const focus = vi.fn()
+    const activeElement = {
+      closest: vi.fn().mockReturnValue({})
+    }
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      pendingFrame = callback
+      return 7
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('document', { activeElement, body: {} })
+
+    autoFocusRichEditor(createEditor(focus), null)
+    pendingFrame(0)
+
+    expect(activeElement.closest).toHaveBeenCalledWith('[data-file-explorer-row]')
+    expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
+  })
+
+  it('does not steal focus from other controls outside the editor', () => {
+    let pendingFrame: FrameRequestCallback = () => {
+      throw new Error('expected focus frame to be scheduled')
+    }
+    const focus = vi.fn()
+    const activeElement = {
+      closest: vi.fn().mockReturnValue(null)
+    }
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      pendingFrame = callback
+      return 7
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('document', { activeElement, body: {} })
+
+    autoFocusRichEditor(createEditor(focus), null)
+    pendingFrame(0)
+
+    expect(focus).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
@@ -9,6 +9,28 @@ function createEditor(focus = vi.fn()): Editor {
   } as unknown as Editor
 }
 
+function setupScheduledFocus(activeElement: { closest: (selector: string) => unknown } | null): {
+  focus: ReturnType<typeof vi.fn>
+  runFrame: () => void
+} {
+  let pendingFrame: FrameRequestCallback = () => {
+    throw new Error('expected focus frame to be scheduled')
+  }
+  const focus = vi.fn()
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    pendingFrame = callback
+    return 7
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  vi.stubGlobal('document', { activeElement, body: {} })
+  autoFocusRichEditor(createEditor(focus), null)
+
+  return {
+    focus,
+    runFrame: () => pendingFrame(0)
+  }
+}
+
 describe('autoFocusRichEditor', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -31,62 +53,29 @@ describe('autoFocusRichEditor', () => {
   })
 
   it('focuses the editor when the frame fires with neutral focus', () => {
-    let pendingFrame: FrameRequestCallback = () => {
-      throw new Error('expected focus frame to be scheduled')
-    }
-    const focus = vi.fn()
-    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-      pendingFrame = callback
-      return 7
-    })
-    vi.stubGlobal('cancelAnimationFrame', vi.fn())
-    vi.stubGlobal('document', { activeElement: null, body: {} })
-
-    autoFocusRichEditor(createEditor(focus), null)
-    pendingFrame(0)
+    const { focus, runFrame } = setupScheduledFocus(null)
+    runFrame()
 
     expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
   })
 
   it('takes focus from the Explorer file row that opened the document', () => {
-    let pendingFrame: FrameRequestCallback = () => {
-      throw new Error('expected focus frame to be scheduled')
-    }
-    const focus = vi.fn()
     const activeElement = {
       closest: vi.fn().mockReturnValue({})
     }
-    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-      pendingFrame = callback
-      return 7
-    })
-    vi.stubGlobal('cancelAnimationFrame', vi.fn())
-    vi.stubGlobal('document', { activeElement, body: {} })
-
-    autoFocusRichEditor(createEditor(focus), null)
-    pendingFrame(0)
+    const { focus, runFrame } = setupScheduledFocus(activeElement)
+    runFrame()
 
     expect(activeElement.closest).toHaveBeenCalledWith('[data-file-explorer-row]')
     expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
   })
 
   it('does not steal focus from other controls outside the editor', () => {
-    let pendingFrame: FrameRequestCallback = () => {
-      throw new Error('expected focus frame to be scheduled')
-    }
-    const focus = vi.fn()
     const activeElement = {
       closest: vi.fn().mockReturnValue(null)
     }
-    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-      pendingFrame = callback
-      return 7
-    })
-    vi.stubGlobal('cancelAnimationFrame', vi.fn())
-    vi.stubGlobal('document', { activeElement, body: {} })
-
-    autoFocusRichEditor(createEditor(focus), null)
-    pendingFrame(0)
+    const { focus, runFrame } = setupScheduledFocus(activeElement)
+    runFrame()
 
     expect(focus).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
@@ -12,13 +12,15 @@ export function autoFocusRichEditor(nextEditor: Editor, rootEl: HTMLElement | nu
     if (nextEditor.isDestroyed) {
       return
     }
-    // Why: don't steal focus if something outside the editor root is already
-    // focused (modal, rename dialog, sidebar search input, etc.). Only
-    // auto-focus when focus is nowhere or already inside the editor.
+    // Why: Explorer file-row activation hands focus to the opened editor, matching Monaco.
+    // Other controls retain focus so lazy mounts cannot disrupt fields or dialogs.
     const active = document.activeElement
-    const isNeutralFocus =
-      active === null || active === document.body || (rootEl?.contains(active) ?? false)
-    if (!isNeutralFocus) {
+    const canTakeFocus =
+      active === null ||
+      active === document.body ||
+      (rootEl?.contains(active) ?? false) ||
+      Boolean(active?.closest('[data-file-explorer-row]'))
+    if (!canTakeFocus) {
       return
     }
     // Why: pass 'start' (not null) to resolve to a proper TextSelection at

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
@@ -6,20 +6,21 @@ import type { Editor } from '@tiptap/react'
  * from modals/dialogs and skips scrollIntoView to avoid racing with
  * useEditorScrollRestore.
  */
-export function autoFocusRichEditor(nextEditor: Editor, rootEl: HTMLElement | null): () => void {
+export function autoFocusRichEditor(
+  nextEditor: Editor,
+  rootEl: HTMLElement | null,
+  force = false
+): () => void {
   let frameId: number | null = requestAnimationFrame(() => {
     frameId = null
     if (nextEditor.isDestroyed) {
       return
     }
-    // Why: Explorer file-row activation hands focus to the opened editor, matching Monaco.
-    // Other controls retain focus so lazy mounts cannot disrupt fields or dialogs.
     const active = document.activeElement
+    // Why: explicit file-open requests may hand focus to the editor; ordinary
+    // lazy mounts must still leave unrelated fields and dialogs alone.
     const canTakeFocus =
-      active === null ||
-      active === document.body ||
-      (rootEl?.contains(active) ?? false) ||
-      Boolean(active?.closest('[data-file-explorer-row]'))
+      force || active === null || active === document.body || (rootEl?.contains(active) ?? false)
     if (!canTakeFocus) {
       return
     }

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
@@ -108,7 +108,7 @@ describe('activateFileExplorerNode', () => {
         language: expect.any(String),
         mode: 'edit'
       },
-      { preview: true, suppressActiveRuntimeFallback: false }
+      { preview: true, focusEditor: true, suppressActiveRuntimeFallback: false }
     )
   })
 
@@ -145,7 +145,7 @@ describe('activateFileExplorerNode', () => {
         filePath: '/repo/README.md',
         runtimeEnvironmentId: undefined
       }),
-      { preview: true, suppressActiveRuntimeFallback: true }
+      { preview: true, focusEditor: true, suppressActiveRuntimeFallback: true }
     )
   })
 })

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -23,7 +23,11 @@ type UseFileExplorerHandlersParams = {
       mode: 'edit'
       runtimeEnvironmentId?: string | null
     },
-    options?: { preview?: boolean; suppressActiveRuntimeFallback?: boolean }
+    options?: {
+      preview?: boolean
+      suppressActiveRuntimeFallback?: boolean
+      focusEditor?: boolean
+    }
   ) => void
   makePreviewFilePermanent: (filePath: string) => void
   toggleDir: (worktreeId: string, dirPath: string) => void
@@ -137,6 +141,9 @@ export async function activateFileExplorerNode(args: {
     },
     {
       preview: true,
+      // Why: activating an Explorer file is a focus handoff even if the rich
+      // editor finishes mounting after the row receives browser focus.
+      focusEditor: true,
       // Why: explicit local opens must not inherit the active runtime, so we
       // encode "no runtime owner" via the fallback-suppression option.
       suppressActiveRuntimeFallback: fileRuntimeEnvironmentId === null

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -106,6 +106,30 @@ function mirroredEditorUnifiedTab(id: string, entityId: string, worktreeId: stri
 }
 
 describe('createEditorSlice right sidebar state', () => {
+  it('queues and safely consumes explicit editor focus requests', () => {
+    const store = createEditorStore()
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/README.md',
+        relativePath: 'README.md',
+        worktreeId: 'wt-1',
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { focusEditor: true }
+    )
+
+    const request = store.getState().pendingEditorFocusRequest
+    expect(request).toMatchObject({ fileId: '/repo/README.md', worktreeId: 'wt-1' })
+
+    store.getState().consumeEditorFocusRequest((request?.token ?? 0) + 1)
+    expect(store.getState().pendingEditorFocusRequest).toBe(request)
+
+    store.getState().consumeEditorFocusRequest(request?.token ?? 0)
+    expect(store.getState().pendingEditorFocusRequest).toBeNull()
+  })
+
   it('does not record markdown-file-created when opening an existing markdown file', () => {
     const store = createEditorStore()
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -310,6 +310,14 @@ export type PendingEditorReveal = {
   matchLength: number
 }
 
+export type PendingEditorFocusRequest = {
+  fileId: string
+  worktreeId: string
+  token: number
+}
+
+let nextEditorFocusRequestToken = 0
+
 const pendingEditorLineRevealFrameIds = new Set<number>()
 
 function cancelPendingEditorLineRevealFrames(): void {
@@ -440,6 +448,7 @@ export type EditorSlice = {
       recordReplacedPreview?: boolean
       suppressActiveRuntimeFallback?: boolean
       forceContentReload?: boolean
+      focusEditor?: boolean
     }
   ) => void
   openNewMarkdownInActiveWorkspace: (groupId: string) => Promise<void>
@@ -687,6 +696,8 @@ export type EditorSlice = {
   // Editor navigation (for search result → go-to-line)
   pendingEditorReveal: PendingEditorReveal | null
   setPendingEditorReveal: (reveal: PendingEditorReveal | null) => void
+  pendingEditorFocusRequest: PendingEditorFocusRequest | null
+  consumeEditorFocusRequest: (token: number) => void
 
   // Session hydration — restore editor files from persisted workspace session
   hydrateEditorSession: (
@@ -1638,6 +1649,17 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         resolveEditorOpenTargetGroupId(s, worktreeId, options?.targetGroupId) ?? undefined
       editorItemTargetGroupId = targetGroupId
       const activeResult = buildEditorActiveResult(s, worktreeId, id)
+      // Why: the renderer may mount asynchronously after the opening control
+      // receives DOM focus, so carry the user's explicit focus handoff by file.
+      const focusRequestUpdate = options?.focusEditor
+        ? {
+            pendingEditorFocusRequest: {
+              fileId: id,
+              worktreeId,
+              token: ++nextEditorFocusRequestToken
+            }
+          }
+        : {}
 
       if (existing) {
         // If opening as non-preview, also pin the existing tab
@@ -1665,7 +1687,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           existing.runtimeEnvironmentId !== runtimeEnvironmentId ||
           existing.fileContentReloadNonce !== fileContentReloadNonce
         if (!needsExistingUpdate) {
-          return activeResult
+          return { ...activeResult, ...focusRequestUpdate }
         }
         // Why: `readOnly` is intentionally NOT in this override map — it's sticky, so `...f` preserves the tab's own read-only state.
         return {
@@ -1693,7 +1715,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
                 }
               : f
           ),
-          ...activeResult
+          ...activeResult,
+          ...focusRequestUpdate
         }
       }
 
@@ -1771,7 +1794,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             recentlyClosedEditorTabsByWorktree: nextRecentlyClosed,
             recentlyClosedTabKindsByWorktree: nextRecentlyClosedKinds,
             ...previewTabBarUpdate,
-            ...activeResult
+            ...activeResult,
+            ...focusRequestUpdate
           }
         }
       }
@@ -1811,7 +1835,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           }
         ],
         ...tabBarUpdate,
-        ...activeResult
+        ...activeResult,
+        ...focusRequestUpdate
       }
     })
     void openWorkspaceEditorItem(
@@ -2154,6 +2179,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         markdownTableOfContentsVisible: newMarkdownTableOfContentsVisible,
         tabBarOrderByWorktree: nextTabBarOrderByWorktree,
         pendingEditorReveal: null,
+        pendingEditorFocusRequest:
+          s.pendingEditorFocusRequest?.fileId === fileId ? null : s.pendingEditorFocusRequest,
         recentlyClosedEditorTabsByWorktree: nextRecentlyClosed,
         recentlyClosedTabKindsByWorktree: nextRecentlyClosedKinds
       }
@@ -2239,7 +2266,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           editorViewMode: {},
           markdownFrontmatterVisible: {},
           markdownTableOfContentsVisible: {},
-          pendingEditorReveal: null
+          pendingEditorReveal: null,
+          pendingEditorFocusRequest: null
         }
       }
       // Only close files for the current worktree
@@ -2334,6 +2362,10 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         tabBarOrderByWorktree: nextTabBarOrderByWorktree,
         // Why: clear the one-shot search reveal; keeping it after closing all editors would make a later reopen jump to an old match.
         pendingEditorReveal: null,
+        pendingEditorFocusRequest:
+          s.pendingEditorFocusRequest?.worktreeId === activeWorktreeId
+            ? null
+            : s.pendingEditorFocusRequest,
         recentlyClosedEditorTabsByWorktree: {
           ...s.recentlyClosedEditorTabsByWorktree,
           [activeWorktreeId]: nextRecentClosed
@@ -4237,6 +4269,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   // Editor navigation
   pendingEditorReveal: null,
   setPendingEditorReveal: (reveal) => set({ pendingEditorReveal: reveal }),
+  pendingEditorFocusRequest: null,
+  consumeEditorFocusRequest: (token) =>
+    set((s) =>
+      s.pendingEditorFocusRequest?.token === token ? { pendingEditorFocusRequest: null } : s
+    ),
 
   activateMarkdownLink: async (rawHref, ctx) => {
     const initialState = get()

--- a/tests/e2e/markdown-explorer-find-focus.spec.ts
+++ b/tests/e2e/markdown-explorer-find-focus.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from './helpers/orca-app'
+import { openFileExplorer } from './helpers/file-explorer'
+import { pressShortcut } from './helpers/shortcuts'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+test('Explorer-opened Markdown accepts the find shortcut without a document click', async ({
+  orcaPage
+}) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await openFileExplorer(orcaPage)
+
+  const readmeRow = orcaPage.locator('[data-file-explorer-row]').filter({ hasText: 'README.md' })
+  await expect(readmeRow).toBeVisible({ timeout: 10_000 })
+  await readmeRow.focus()
+  await readmeRow.click()
+
+  await expect(orcaPage.locator('.rich-markdown-editor')).toBeVisible({ timeout: 25_000 })
+  await pressShortcut(orcaPage, 'f')
+
+  await expect(
+    orcaPage.getByRole('textbox', { name: 'Find in rich markdown editor' })
+  ).toBeVisible()
+})


### PR DESCRIPTION
## Summary

Opening a Markdown file from Explorer now hands keyboard focus to the rich Markdown editor, so the first Command/Ctrl+F opens rich Markdown search instead of doing nothing.

## ELI5

Before, clicking a Markdown file in the sidebar left your cursor "stuck" on the file name, so pressing Find did nothing. Now the file you open is ready to type in and search right away.

## Root cause & fix

When a Markdown file was opened from Explorer, focus stayed on the file row while the rich editor mounted. The editor's protective auto-focus guard treated that lingering Explorer focus like any unrelated control and refused to grab focus, so the first find shortcut fired outside the editor. The fix threads an explicit `focusEditor` intent from Explorer file activation through a token-based `pendingEditorFocusRequest` in the editor store, and gives `autoFocusRichEditor` a `force` param (default `false`) so only genuine Explorer opens claim focus — dialogs and other inputs stay protected.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Rebase was clean onto `origin/main`.

- Scoped run on branch across `rich-markdown-auto-focus.test.ts`, `useFileExplorerHandlers.test.ts`, and `editor.test.ts`: **3 test files, 191 tests passed**.
- Reverting only the 4 fix files (tests kept) fails, proving the tests exercise the fix:

```
Test Files  3 failed (3)
Tests  4 failed | 187 passed (191)
 - useFileExplorerHandlers.test.ts:143 — openFile expected with focusEditor:true
 - editor.test.ts:124 — pendingEditorFocusRequest expected { fileId:'/repo/README.md', worktreeId:'wt-1' }, received undefined
```

- Lint: `oxlint` on the 4 changed source files is clean (no warnings/errors).
- A `requires-app` Electron E2E (`tests/e2e/markdown-explorer-find-focus.spec.ts`) covers the real open-then-find path; not run under vitest.

## Trade-offs

None — pure fix.

## Regression risk

Low-to-zero. `autoFocusRichEditor` gains a `force` param defaulting to `false`, so ordinary lazy mounts keep the prior neutral-focus guard byte-identical. New behavior is gated on `options.focusEditor`, set only by explicit Explorer file activation, and the `pendingEditorFocusRequest` is consumed by matching token and cleared on file close / close-all / target-file close, avoiding stale focus steals. A negative test locks in the non-Explorer focus guard.

_Original fix by @gatsby74 (fixes #8078). Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
