### PR TITLE
perf(mobile): avoid shifting saturated terminal queue

### DIFF
--- a/mobile/src/terminal/terminal-webview-pending-messages.test.ts
+++ b/mobile/src/terminal/terminal-webview-pending-messages.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalWebViewCommand } from './terminal-webview-messages'
+import { createTerminalWebViewPendingMessages } from './terminal-webview-pending-messages'
+
+function flushMessages(
+  queue: ReturnType<typeof createTerminalWebViewPendingMessages>
+): TerminalWebViewCommand[] {
+  const messages: TerminalWebViewCommand[] = []
+  queue.flush((message) => messages.push(message))
+  return messages
+}
+
+describe('TerminalWebView pending messages', () => {
+  it('evicts the oldest writes without dropping or reordering control messages', () => {
+    const queue = createTerminalWebViewPendingMessages()
+    queue.queue({ type: 'resize', cols: 80, rows: 24 })
+    for (let index = 0; index < 5200; index += 1) {
+      if (index === 100) {
+        queue.queue({ type: 'clear' })
+      }
+      if (index === 3000) {
+        queue.queue({ type: 'set-font-scale', fontScale: 1.1 })
+      }
+      queue.queue({ type: 'write', data: String(index) })
+    }
+
+    const messages = flushMessages(queue)
+    const writes = messages.filter((message) => message.type === 'write')
+    expect(writes).toHaveLength(4096)
+    expect(writes[0]).toEqual({ type: 'write', data: '1104' })
+    expect(writes.at(-1)).toEqual({ type: 'write', data: '5199' })
+    expect(messages.slice(0, 2).map((message) => message.type)).toEqual(['resize', 'clear'])
+    expect(messages.findIndex((message) => message.type === 'set-font-scale')).toBe(
+      messages.findIndex((message) => message.type === 'write' && message.data === '3000') - 1
+    )
+  })
+
+  it('applies the byte cap while keeping control messages', () => {
+    const queue = createTerminalWebViewPendingMessages()
+    queue.queue({ type: 'write', data: 'a'.repeat(400_000) })
+    queue.queue({ type: 'clear' })
+    queue.queue({ type: 'write', data: 'b'.repeat(400_000) })
+    queue.queue({ type: 'write', data: 'c'.repeat(400_000) })
+    queue.queue({ type: 'write', data: 'd'.repeat(700_000) })
+
+    const messages = flushMessages(queue)
+    expect(messages.map((message) => message.type)).toEqual(['clear', 'write'])
+    expect(messages[1]).toEqual({ type: 'write', data: 'd'.repeat(700_000) })
+  })
+
+  it('clears pending messages and accepts a fresh generation', () => {
+    const queue = createTerminalWebViewPendingMessages()
+    queue.queue({ type: 'write', data: 'stale' })
+    queue.clear()
+    queue.queue({ type: 'write', data: 'fresh' })
+
+    expect(flushMessages(queue)).toEqual([{ type: 'write', data: 'fresh' }])
+  })
+})

--- a/mobile/src/terminal/terminal-webview-pending-messages.ts
+++ b/mobile/src/terminal/terminal-webview-pending-messages.ts
@@ -2,20 +2,54 @@ import type { TerminalWebViewCommand } from './terminal-webview-messages'
 
 const MAX_PENDING_WEB_WRITE_BYTES = 1_000_000
 const MAX_PENDING_WEB_WRITE_MESSAGES = 4096
+const PENDING_WRITE_COMPACTION_DROPS = 1024
 
 export function createTerminalWebViewPendingMessages() {
-  let pending: TerminalWebViewCommand[] = []
+  let pending: Array<TerminalWebViewCommand | null> = []
   let pendingWriteBytes = 0
   let pendingWriteCount = 0
+  let pendingWriteDropCursor = 0
+  let droppedWriteSlots = 0
 
-  const resetCounters = () => {
+  const resetQueueState = () => {
     pendingWriteBytes = 0
     pendingWriteCount = 0
+    pendingWriteDropCursor = 0
+    droppedWriteSlots = 0
   }
 
   const clear = () => {
     pending = []
-    resetCounters()
+    resetQueueState()
+  }
+
+  const compactDroppedWrites = () => {
+    pending = pending.filter((msg): msg is TerminalWebViewCommand => msg !== null)
+    pendingWriteDropCursor = 0
+    droppedWriteSlots = 0
+  }
+
+  const dropOldestWrite = (): boolean => {
+    while (pendingWriteDropCursor < pending.length) {
+      const dropIndex = pendingWriteDropCursor
+      pendingWriteDropCursor += 1
+      const dropped = pending[dropIndex]
+      if (dropped?.type !== 'write') {
+        continue
+      }
+
+      // Why: splice shifts up to 4,096 slots per saturated write. Tombstones make
+      // eviction O(1); periodic stable compaction preserves order and bounds memory.
+      pending[dropIndex] = null
+      pendingWriteBytes -= dropped.data.length
+      pendingWriteCount -= 1
+      droppedWriteSlots += 1
+      if (droppedWriteSlots >= PENDING_WRITE_COMPACTION_DROPS) {
+        compactDroppedWrites()
+      }
+      return true
+    }
+    return false
   }
 
   const queue = (msg: TerminalWebViewCommand) => {
@@ -30,15 +64,9 @@ export function createTerminalWebViewPendingMessages() {
       pendingWriteBytes > MAX_PENDING_WEB_WRITE_BYTES ||
       pendingWriteCount > MAX_PENDING_WEB_WRITE_MESSAGES
     ) {
-      const dropIndex = pending.findIndex((candidate) => candidate.type === 'write')
-      if (dropIndex === -1) {
-        resetCounters()
+      if (!dropOldestWrite()) {
+        resetQueueState()
         return
-      }
-      const [dropped] = pending.splice(dropIndex, 1)
-      if (dropped?.type === 'write') {
-        pendingWriteBytes = Math.max(0, pendingWriteBytes - dropped.data.length)
-        pendingWriteCount = Math.max(0, pendingWriteCount - 1)
       }
     }
   }
@@ -47,7 +75,9 @@ export function createTerminalWebViewPendingMessages() {
     const messages = pending
     clear()
     for (const msg of messages) {
-      send(msg)
+      if (msg) {
+        send(msg)
+      }
     }
   }
 

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it } from 'vitest'
 
 // The in-WebView JS lives in terminal-webview-html.ts; the RN wrapper in
 // TerminalWebView.tsx. Concatenate both so assertions resolve regardless of file.
+const pendingMessagesSource = readFileSync(
+  new URL('./terminal-webview-pending-messages.ts', import.meta.url),
+  'utf8'
+)
 const source =
   readFileSync(new URL('./TerminalWebView.tsx', import.meta.url), 'utf8') +
-  readFileSync(new URL('./terminal-webview-pending-messages.ts', import.meta.url), 'utf8') +
+  pendingMessagesSource +
   readFileSync(new URL('./terminal-webview-url-tap.ts', import.meta.url), 'utf8') +
   readFileSync(new URL('./terminal-webview-tap-dispatch-injected.ts', import.meta.url), 'utf8') +
   readFileSync(new URL('./terminal-webview-html.ts', import.meta.url), 'utf8')
@@ -124,7 +128,8 @@ describe('TerminalWebView scroll routing', () => {
     expect(source).toContain('let pendingWriteCount = 0')
     expect(source).toContain('const queue = (msg: TerminalWebViewCommand)')
     expect(source).toContain('pendingWriteCount > MAX_PENDING_WEB_WRITE_MESSAGES')
-    expect(source).toContain("candidate.type === 'write'")
+    expect(pendingMessagesSource).not.toContain('pending.findIndex(')
+    expect(pendingMessagesSource).not.toContain('pending.splice(')
     expect(source).toContain('pendingMessages.queue(msg)')
     expect(source).toContain('pendingMessages.clear()')
   })


### PR DESCRIPTION
## Description

Make eviction from the mobile TerminalWebView pre-ready queue amortized instead of shifting the whole pending array for every saturated terminal write.

While a WebView is starting or reloading, terminal writes and control messages are queued natively. The queue deliberately retains at most 4,096 writes / 1,000,000 data units while preserving control messages. Previously, every write beyond either cap found the oldest write and removed it with Array.splice, shifting all later entries.

This change marks evicted writes with an ordered null tombstone, advances a drop cursor, and performs a stable compaction after 1,024 evictions. Flush skips tombstones. The oldest-write policy, write caps, control-message order, clear/reload behavior, and ready-WebView fast path remain unchanged.

## Evidence

Production path:

- TerminalWebView queues every terminal write while the embedded WebView has not reported ready.
- Terminal output can continue during initial load or reload.
- Once 4,096 writes are pending, the old queue executed one splice for every additional write.
- With an all-write backlog, each splice removed index 0 and shifted approximately 4,096 retained entries.

Isolated saturated-queue stress case: enqueue 100,000 one-character writes, then flush and verify that exactly 4,096 remain.

| | Before | After |
|---|---:|---:|
| Array.splice calls | 95,904 | 0 |
| Instrumented shifted array slots | 392,822,784 | 0 |
| Median queue + flush time | 31.742 ms | 1.788 ms |
| Retained writes | 4,096 | 4,096 |

That is a 94.4% reduction in this isolated queue benchmark. Timings are the median of 21 samples after 5 warmups in the same Node/TSX harness. This is not an end-to-end terminal latency claim; it isolates saturated native-side backlog maintenance and excludes transport, React Native, WebView, and xterm work.

The slot count came from instrumenting the actual Array.splice calls in the old implementation. The new path performs a stable linear compaction once per 1,024 evictions instead of a linear shift for every incoming chunk.

## ELI5

Imagine a line of 4,096 boxes. The old code threw away the first box and physically moved every other box one position left each time a new box arrived. During a big burst, it repeated that move almost 96,000 times.

The new code puts an empty marker on the old box and keeps moving forward. After 1,024 markers, it tidies the line once. The same newest 4,096 terminal chunks remain in the same order, but the JS thread does far less shuffling.

## End-user trade-offs / regressions

No behavioral regression is expected.

- The queue still drops only the oldest terminal writes and never drops control messages.
- Control and retained-write ordering is unchanged.
- The same 4,096-write and 1,000,000-data-unit bounds apply.
- Writes sent after the WebView is ready still bypass this queue.
- No RPC, persisted-state, route, SSH/runtime-host, or git-provider contract changes.

Memory trade-off: the pending array may temporarily contain up to 1,023 null slots before compaction. The dropped message objects and their data are released immediately because the slots are nulled; only the bounded empty slots remain. Compaction introduces one occasional linear pass per 1,024 evictions, replacing the previous linear shift on every saturated write.

Expected user impact is less mobile JS-thread work during heavy terminal output while a WebView starts or reloads, reducing the chance that recovery/loading competes with taps or rendering.

## Validation

- pnpm --dir mobile test — 186 files passed; 1,317 tests passed; 2 skipped
- pnpm --dir mobile exec tsc --noEmit
- pnpm --dir mobile lint
- pnpm --dir mobile exec oxfmt --check on all 3 changed files
- pnpm check:max-lines-ratchet
- Differential compatibility check: 200 seeded scenarios × 5,000 mixed write/control/flush/clear operations produced identical flush output before and after
