### PR TITLE
Keep speech model dropdown open during downloads

### DIFF
--- a/src/renderer/src/components/settings/VoiceSpeechModelSection.test.tsx
+++ b/src/renderer/src/components/settings/VoiceSpeechModelSection.test.tsx
@@ -8,6 +8,7 @@ import type { SpeechModelManifest, SpeechModelState } from '../../../../shared/s
 import { getDefaultVoiceSettings } from '../../../../shared/constants'
 
 const toastErrorMock = vi.hoisted(() => vi.fn())
+const menuDismissMock = vi.hoisted(() => vi.fn())
 
 vi.mock('sonner', () => ({
   toast: {
@@ -32,7 +33,7 @@ vi.mock('../ui/dropdown-menu', () => ({
   }: {
     children: ReactNode
     disabled?: boolean
-    onSelect?: () => void
+    onSelect?: (event: Event) => void
     className?: string
   }) => (
     <div
@@ -41,7 +42,11 @@ vi.mock('../ui/dropdown-menu', () => ({
       role="option"
       onClick={() => {
         if (!disabled) {
-          onSelect?.()
+          const selectEvent = new Event('select', { cancelable: true })
+          onSelect?.(selectEvent)
+          if (!selectEvent.defaultPrevented) {
+            menuDismissMock()
+          }
         }
       }}
     >
@@ -73,6 +78,7 @@ const secondLocalModel: SpeechModelManifest = {
 
 function renderSection(args: {
   deleteModel: (modelId: string) => Promise<void>
+  downloadModel?: (modelId: string) => Promise<void>
   catalog?: SpeechModelManifest[]
   modelStates?: SpeechModelState[]
   refreshModelStates?: () => void
@@ -81,7 +87,7 @@ function renderSection(args: {
     api: {
       speech: {
         deleteModel: vi.fn(args.deleteModel),
-        downloadModel: vi.fn()
+        downloadModel: vi.fn(args.downloadModel ?? (() => Promise.resolve()))
       }
     }
   })
@@ -111,6 +117,7 @@ function renderSection(args: {
 describe('VoiceSpeechModelSection', () => {
   beforeEach(() => {
     toastErrorMock.mockReset()
+    menuDismissMock.mockReset()
   })
 
   afterEach(() => {
@@ -216,6 +223,23 @@ describe('VoiceSpeechModelSection', () => {
 
     expect(toastErrorMock).toHaveBeenCalledWith('Failed to delete model.')
     expect(refreshModelStates).not.toHaveBeenCalled()
+    root.unmount()
+  })
+
+  it('keeps the model menu open when starting a local model download', async () => {
+    const { container, root } = renderSection({
+      deleteModel: () => Promise.resolve(),
+      modelStates: [{ id: localModel.id, status: 'not-downloaded' }]
+    })
+    const modelOption = container.querySelector<HTMLElement>('[role="option"]')
+
+    await act(async () => {
+      modelOption!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(window.api.speech.downloadModel).toHaveBeenCalledWith(localModel.id)
+    expect(menuDismissMock).not.toHaveBeenCalled()
     root.unmount()
   })
 })

--- a/src/renderer/src/components/settings/VoiceSpeechModelSection.tsx
+++ b/src/renderer/src/components/settings/VoiceSpeechModelSection.tsx
@@ -82,12 +82,14 @@ export function VoiceSpeechModelSection({
               <DropdownMenuItem
                 key={manifest.id}
                 disabled={isDownloading}
-                onSelect={() => {
+                onSelect={(event) => {
                   if (isReady) {
                     onUpdateVoiceSettings({ sttModel: manifest.id })
                   } else if (isCloud) {
                     onOpenOpenAiDialog(manifest.id)
                   } else if (!isDownloading) {
+                    // Why: download progress appears in this menu, so starting one should not dismiss it.
+                    event.preventDefault()
                     void window.api.speech
                       .downloadModel(manifest.id)
                       .catch(() =>


### PR DESCRIPTION
## Summary

- Keep the Settings > Voice speech-model dropdown open when a local model download starts.
- Preserve the existing close behavior for ready-model selection and cloud-model setup.
- Add regression coverage for Radix dropdown dismissal semantics.

## Root cause

Local downloads run from a DropdownMenuItem selection handler. Radix dismisses the menu after selection unless that event is canceled, so starting a download closed the surface that shows its progress.

## Validation

- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/VoiceSpeechModelSection.test.tsx
- pnpm run typecheck:web
- pnpm run check:max-lines-ratchet
- pnpm exec oxlint src/renderer/src/components/settings/VoiceSpeechModelSection.tsx src/renderer/src/components/settings/VoiceSpeechModelSection.test.tsx
- Live Electron validation in the download-speech worktree: downloaded Parakeet TDT v3 from Settings > Voice and confirmed the dropdown stayed open through completion, with the row changing to its Delete action.
- Gemini reviewed the full-window screenshot and found no clipping, overlap, z-order, or layout issue.

Full pnpm lint currently stops on a pre-existing ja.json interpolation mismatch for components.native-chat.composer.uploadingAttachments; the changed files pass oxlint.

Evidence screenshot follows in a PR comment.