### PR TITLE
perf(renderer): index runtime owner lookups

### DIFF
--- a/src/renderer/src/lib/worktree-runtime-owner-index.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.ts
@@ -1,0 +1,94 @@
+import type { FolderWorkspace, ProjectGroup, Repo, Worktree } from '../../../shared/types'
+
+type WorktreeOwnerRecord = Pick<Worktree, 'id' | 'repoId' | 'hostId'>
+type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+type FolderWorkspaceOwnerRecord = Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'>
+type ProjectGroupOwnerRecord = Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>
+
+// Why: owner resolution runs inside retained selectors and interaction paths;
+// immutable-slice indexes prevent unrelated store writes from rescanning.
+const worktreeOwnerIndexCache = new WeakMap<
+  Record<string, readonly WorktreeOwnerRecord[]>,
+  ReadonlyMap<string, WorktreeOwnerRecord>
+>()
+const repoOwnerIndexCache = new WeakMap<
+  readonly RepoOwnerRecord[],
+  ReadonlyMap<string, RepoOwnerRecord>
+>()
+const folderWorkspaceOwnerIndexCache = new WeakMap<
+  readonly FolderWorkspaceOwnerRecord[],
+  ReadonlyMap<string, FolderWorkspaceOwnerRecord>
+>()
+const projectGroupOwnerIndexCache = new WeakMap<
+  readonly ProjectGroupOwnerRecord[],
+  ReadonlyMap<string, ProjectGroupOwnerRecord>
+>()
+
+function findIndexedOwnerRecord<T extends { id: string }>(
+  records: readonly T[] | undefined,
+  id: string,
+  cache: WeakMap<readonly T[], ReadonlyMap<string, T>>
+): T | null {
+  if (!records) {
+    return null
+  }
+  let index = cache.get(records)
+  if (!index) {
+    const next = new Map<string, T>()
+    for (const record of records) {
+      const recordId = record.id
+      if (!next.has(recordId)) {
+        // Preserve the prior Array.find behavior for invalid duplicate IDs.
+        next.set(recordId, record)
+      }
+    }
+    index = next
+    cache.set(records, index)
+  }
+  return index.get(id) ?? null
+}
+
+export function findIndexedWorktreeOwner(
+  worktreesByRepo: Record<string, readonly WorktreeOwnerRecord[]> | undefined,
+  worktreeId: string
+): WorktreeOwnerRecord | null {
+  if (!worktreesByRepo) {
+    return null
+  }
+  let index = worktreeOwnerIndexCache.get(worktreesByRepo)
+  if (!index) {
+    const next = new Map<string, WorktreeOwnerRecord>()
+    for (const worktrees of Object.values(worktreesByRepo)) {
+      for (const worktree of worktrees) {
+        const id = worktree.id
+        if (!next.has(id)) {
+          next.set(id, worktree)
+        }
+      }
+    }
+    index = next
+    worktreeOwnerIndexCache.set(worktreesByRepo, index)
+  }
+  return index.get(worktreeId) ?? null
+}
+
+export function findIndexedRepoOwner(
+  repos: readonly RepoOwnerRecord[] | undefined,
+  repoId: string
+): RepoOwnerRecord | null {
+  return findIndexedOwnerRecord(repos, repoId, repoOwnerIndexCache)
+}
+
+export function findIndexedFolderWorkspaceOwner(
+  folderWorkspaces: readonly FolderWorkspaceOwnerRecord[] | undefined,
+  folderWorkspaceId: string
+): FolderWorkspaceOwnerRecord | null {
+  return findIndexedOwnerRecord(folderWorkspaces, folderWorkspaceId, folderWorkspaceOwnerIndexCache)
+}
+
+export function findIndexedProjectGroupOwner(
+  projectGroups: readonly ProjectGroupOwnerRecord[] | undefined,
+  projectGroupId: string
+): ProjectGroupOwnerRecord | null {
+  return findIndexedOwnerRecord(projectGroups, projectGroupId, projectGroupOwnerIndexCache)
+}

--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -198,6 +198,126 @@ describe('getExplicitRuntimeEnvironmentIdForWorktree', () => {
   })
 })
 
+describe('runtime owner identity indexes', () => {
+  it('indexes immutable owner records once across repeated worktree and folder lookups', () => {
+    let worktreeIdReads = 0
+    let repoIdReads = 0
+    let folderWorkspaceIdReads = 0
+    let projectGroupIdReads = 0
+    const targetWorktreeId = 'worktree-99-99'
+    const targetRepoId = 'repo-99'
+    const targetFolderWorkspaceId = 'folder-workspace-999'
+    const targetProjectGroupId = 'project-group-999'
+    const repos: NonNullable<WorktreeRuntimeOwnerState['repos']>[number][] = []
+    const worktreesByRepo: NonNullable<WorktreeRuntimeOwnerState['worktreesByRepo']> = {}
+    const folderWorkspaces: NonNullable<WorktreeRuntimeOwnerState['folderWorkspaces']>[number][] =
+      []
+    const projectGroups: NonNullable<WorktreeRuntimeOwnerState['projectGroups']>[number][] = []
+
+    for (let repoIndex = 0; repoIndex < 100; repoIndex += 1) {
+      const repoId = `repo-${repoIndex}`
+      const repo: NonNullable<WorktreeRuntimeOwnerState['repos']>[number] = {
+        id: repoId,
+        connectionId: null,
+        executionHostId: repoId === targetRepoId ? 'runtime:repo-owner' : 'local'
+      }
+      Object.defineProperty(repo, 'id', {
+        enumerable: true,
+        get: () => {
+          repoIdReads += 1
+          return repoId
+        }
+      })
+      repos.push(repo)
+      worktreesByRepo[repoId] = Array.from({ length: 100 }, (_, worktreeIndex) => {
+        const worktreeId = `worktree-${repoIndex}-${worktreeIndex}`
+        const worktree = { id: worktreeId, repoId }
+        Object.defineProperty(worktree, 'id', {
+          enumerable: true,
+          get: () => {
+            worktreeIdReads += 1
+            return worktreeId
+          }
+        })
+        return worktree
+      })
+    }
+    for (let index = 0; index < 1_000; index += 1) {
+      const folderWorkspaceId = `folder-workspace-${index}`
+      const projectGroupId = `project-group-${index}`
+      const folderWorkspace = { id: folderWorkspaceId, projectGroupId }
+      const projectGroup: NonNullable<WorktreeRuntimeOwnerState['projectGroups']>[number] = {
+        id: projectGroupId,
+        connectionId: null,
+        executionHostId: projectGroupId === targetProjectGroupId ? 'runtime:folder-owner' : 'local'
+      }
+      Object.defineProperty(folderWorkspace, 'id', {
+        enumerable: true,
+        get: () => {
+          folderWorkspaceIdReads += 1
+          return folderWorkspaceId
+        }
+      })
+      Object.defineProperty(projectGroup, 'id', {
+        enumerable: true,
+        get: () => {
+          projectGroupIdReads += 1
+          return projectGroupId
+        }
+      })
+      folderWorkspaces.push(folderWorkspace)
+      projectGroups.push(projectGroup)
+    }
+    const indexedState: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: null },
+      repos,
+      worktreesByRepo,
+      folderWorkspaces,
+      projectGroups
+    }
+
+    for (let lookup = 0; lookup < 200; lookup += 1) {
+      getRuntimeEnvironmentIdForWorktree(indexedState, targetWorktreeId)
+      getExplicitRuntimeEnvironmentIdForWorktree(indexedState, targetWorktreeId)
+      getExecutionHostIdForWorktree(indexedState, targetWorktreeId)
+      getRuntimeEnvironmentIdForWorktree(indexedState, `folder:${targetFolderWorkspaceId}`)
+      getExplicitRuntimeEnvironmentIdForWorktree(indexedState, `folder:${targetFolderWorkspaceId}`)
+      getExecutionHostIdForWorktree(indexedState, `folder:${targetFolderWorkspaceId}`)
+    }
+
+    expect(worktreeIdReads).toBe(10_000)
+    expect(repoIdReads).toBe(100)
+    expect(folderWorkspaceIdReads).toBe(1_000)
+    expect(projectGroupIdReads).toBe(1_000)
+    expect(getRuntimeEnvironmentIdForWorktree(indexedState, targetWorktreeId)).toBe('repo-owner')
+    expect(getExecutionHostIdForWorktree(indexedState, `folder:${targetFolderWorkspaceId}`)).toBe(
+      'runtime:folder-owner'
+    )
+  })
+
+  it('rebuilds owner indexes when immutable collection references change', () => {
+    const first: WorktreeRuntimeOwnerState = {
+      repos: [{ id: 'repo', connectionId: null, executionHostId: 'runtime:repo-one' }],
+      worktreesByRepo: { repo: [{ id: 'worktree', repoId: 'repo' }] },
+      folderWorkspaces: [{ id: 'folder', projectGroupId: 'group' }],
+      projectGroups: [{ id: 'group', connectionId: null, executionHostId: 'runtime:folder-one' }]
+    }
+    expect(getRuntimeEnvironmentIdForWorktree(first, 'worktree')).toBe('repo-one')
+    expect(getRuntimeEnvironmentIdForWorktree(first, 'folder:folder')).toBe('folder-one')
+
+    const second: WorktreeRuntimeOwnerState = {
+      repos: [{ id: 'repo', connectionId: null, executionHostId: 'runtime:repo-two' }],
+      worktreesByRepo: {
+        repo: [{ id: 'worktree', repoId: 'repo', hostId: 'runtime:worktree-two' }]
+      },
+      folderWorkspaces: [{ id: 'folder', projectGroupId: 'group' }],
+      projectGroups: [{ id: 'group', connectionId: null, executionHostId: 'runtime:folder-two' }]
+    }
+    expect(getRuntimeEnvironmentIdForWorktree(second, 'worktree')).toBe('worktree-two')
+    expect(getRuntimeEnvironmentIdForWorktree(second, 'folder:folder')).toBe('folder-two')
+  })
+})
+
 describe('getRuntimeSessionMirrorEnvironmentIds', () => {
   it('includes focused runtime plus explicit repo, worktree, and folder owners', () => {
     const multiRuntimeState: WorktreeRuntimeOwnerState = {

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -14,6 +14,12 @@ import type {
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
+import {
+  findIndexedFolderWorkspaceOwner,
+  findIndexedProjectGroupOwner,
+  findIndexedRepoOwner as findRepoRecord,
+  findIndexedWorktreeOwner as findWorktreeRecord
+} from './worktree-runtime-owner-index'
 
 type RuntimeExecutionHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
 
@@ -26,19 +32,6 @@ export type WorktreeRuntimeOwnerState = {
   restoredRuntimeHostIdByWorkspaceSessionKey?: Record<string, ExecutionHostId>
 }
 
-function findWorktreeRecord(
-  worktreesByRepo: WorktreeRuntimeOwnerState['worktreesByRepo'],
-  worktreeId: string
-): Pick<Worktree, 'id' | 'repoId' | 'hostId'> | null {
-  for (const worktrees of Object.values(worktreesByRepo ?? {})) {
-    const match = worktrees.find((worktree) => worktree.id === worktreeId)
-    if (match) {
-      return match
-    }
-  }
-  return null
-}
-
 function findFolderProjectGroup(
   state: WorktreeRuntimeOwnerState,
   folderWorkspaceId: string
@@ -47,14 +40,14 @@ function findFolderProjectGroup(
   if (!folderWorkspace) {
     return null
   }
-  return state.projectGroups?.find((group) => group.id === folderWorkspace.projectGroupId) ?? null
+  return findIndexedProjectGroupOwner(state.projectGroups, folderWorkspace.projectGroupId)
 }
 
 function findFolderWorkspace(
   state: WorktreeRuntimeOwnerState,
   folderWorkspaceId: string
 ): Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'> | null {
-  return state.folderWorkspaces?.find((workspace) => workspace.id === folderWorkspaceId) ?? null
+  return findIndexedFolderWorkspaceOwner(state.folderWorkspaces, folderWorkspaceId)
 }
 
 function getRuntimeEnvironmentIdForFolderWorkspace(
@@ -177,7 +170,7 @@ export function getRuntimeEnvironmentIdForWorktree(
     return worktreeRuntimeEnvironmentId
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repo = findRepoRecord(state.repos, repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
@@ -205,7 +198,7 @@ export function getExplicitRuntimeEnvironmentIdForWorktree(
     return getExplicitRuntimeEnvironmentIdFromHost(worktree.hostId)
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repo = findRepoRecord(state.repos, repoId)
   if (!repo) {
     return null
   }
@@ -271,7 +264,7 @@ export function getExecutionHostIdForWorktree(
     return worktreeHostId
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repo = findRepoRecord(state.repos, repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     return getRepoExecutionHostId(repo)


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545. Runtime ownership is queried from terminal, tab-bar, browser, file-watch, native-chat, port, activation, and store paths, but each query linearly searched the same immutable identity collections.

## 1. Description

The shared runtime-owner module exposes three common lookups:

```text
getRuntimeEnvironmentIdForWorktree
getExplicitRuntimeEnvironmentIdForWorktree
getExecutionHostIdForWorktree
```

For ordinary worktrees, every call scanned worktree buckets and then repos. For folder workspaces, each call searched the folder list, then searched the folder list again while resolving its project group, then searched project groups.

These functions run inside retained Zustand selectors and interaction paths. Unrelated store writes therefore multiplied O(W + R) or O(F + G) identity scans by mounted consumers.

Fix:

- index worktrees by the immutable `worktreesByRepo` object;
- index repos, folder workspaces, and project groups by their immutable array references;
- keep indexes in WeakMaps so replaced snapshots can be collected;
- preserve prior first-match semantics for invalid duplicate IDs;
- rebuild naturally when any collection reference changes.

The cache lives in the focused `worktree-runtime-owner-index.ts` module so the existing resolver remains below the 300-line limit. The intentional full inventory scan in `getRuntimeSessionMirrorEnvironmentIds` is unchanged because it needs every owner, not one identity.

## 2. Undeniable evidence + measurable improvement

The committed fixture calls all three worktree APIs and all three folder APIs **200 times** against one immutable state containing **10,000 worktrees**, **100 repos**, **1,000 folder workspaces**, and **1,000 project groups**.

- Worktree ID reads: **6,000,000 -> 10,000**
- Repo ID reads: **60,000 -> 100**
- Folder-workspace ID reads: **1,200,000 -> 1,000**
- Project-group ID reads: **600,000 -> 1,000**
- Every same-snapshot call after the first adds **zero identity-entry reads**.
- A replacement-reference test changes worktree-host, repo-owner, and folder-group ownership and proves the new values are returned immediately.
- All **39** focused runtime-owner, Windows ConPTY, native-chat, worktree-sort, and port-row tests pass.

## ELI5
Many parts of Orca repeatedly searched four address books from the first page to answer who owns one workspace. Now each address book gets an index the first time, and later questions go straight to the matching entry.

## 4. Trade-offs that regress the end experience

None material. The first lookup for a new immutable collection still performs one O(N) build, after which identity lookups are O(1). WeakMap keys do not pin replaced Zustand snapshots.

The index deliberately keeps the first record for duplicate IDs, matching the former `Array.find` behavior. Correctness therefore does not depend on which duplicate a Map insertion would otherwise overwrite. In-place mutation of an indexed collection would be stale, but these are Zustand immutable slices; replacement-reference coverage guards the supported contract.

## Reliability proof

- **Reliability class / gate:** `terminal-performance.store-and-git-hot-paths`.
- **Failure source:** runtime-owner resolution is shared by retained terminal/tab/browser/file selectors and interaction paths, multiplying global identity scans on unrelated writes and actions.
- **Product change type:** renderer performance hardening.
- **Invariant:** terminal and adjacent interaction paths must resolve local, SSH, runtime, worktree-host, and folder-group ownership without repeated global scans, while explicit ownership precedence and replacement invalidation stay exact.
- **Performance risk inventory:** pure renderer identity projection only. No PTY output/input, xterm lifecycle, focus routing, resize, restore, startup awaits, polling, provider listing, IPC/RPC, subprocess, persistence, telemetry, git, filesystem, or network behavior changes.
- **Oracle:** getter-backed scale fixtures count exact entry reads across all six resolver paths; replacement tests prove invalidation; focused provider/platform consumers prove ownership results.
- **Manifest status:** existing experimental store-and-git hot-path gate with no protection, unchanged. This focused projection proof does not promote the broader gate.
- **Provider/platform matrix:** local, SSH, and remote-runtime ownership plus per-worktree host overrides and folder workspace owners are covered. Windows ConPTY policy and provider-generic native-chat/port consumers pass. Daemon, WSL, mobile/relay, macOS/Linux/Windows process, path, shell, and transport branches are unchanged.
- **Diagnostics:** no new logging, telemetry, polling, or retained payloads.
- **Residual gaps:** no live high-pane-count Electron profiler or remote-provider run was added; deterministic identity reads are the direct projection-work oracle.
- **Rollback/demotion:** revert if replaced collections return stale ownership, duplicate-ID first-match behavior changes, or local/SSH/runtime/folder precedence diverges. Do not promote the broader gate from this PR alone.

## Testing

- [x] Red proof: the repeated fixture reported 6,000,000 worktree ID reads instead of 10,000
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-runtime-owner.test.ts src/renderer/src/components/terminal-pane/terminal-ctrl-arrow-conpty.test.ts src/renderer/src/components/native-chat/native-chat-runtime-owner.test.ts src/renderer/src/components/native-chat/native-chat-attachment-upload.test.ts src/renderer/src/lib/worktree-sort-order-host-split.test.ts src/renderer/src/components/status-bar/ports-status-popover-rows.test.tsx` (39 passed)
- [x] `pnpm typecheck`
- [x] targeted `oxlint`, react-doctor pre-commit checks, and `oxfmt --check`
- [x] `pnpm lint:switch-exhaustiveness`
- [x] `pnpm check:reliability-gates`
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff --check`
- [ ] Full `pnpm lint` reaches localization verification, then fails on the current-main Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR changes only the three renderer runtime-owner files listed below.

No visual design, protocol, persistence, security, dependency, path, shell, or permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋