### PR TITLE
perf(renderer): index worktree runtime owners

### DIFF
--- a/src/renderer/src/lib/worktree-runtime-owner-index.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findRuntimeOwnerRepoById,
+  findRuntimeOwnerWorktreeById,
+  type RuntimeOwnerRepoRecord,
+  type RuntimeOwnerWorktreesByRepo
+} from './worktree-runtime-owner-index'
+
+describe('runtime owner indexes', () => {
+  it('reuses indexes while slice references are unchanged', () => {
+    let worktreeIdReads = 0
+    let repoIdReads = 0
+    const repos: RuntimeOwnerRepoRecord[] = Array.from({ length: 3 }, (_, index) => {
+      const id = `repo-${index}`
+      const repo: RuntimeOwnerRepoRecord = {
+        id,
+        connectionId: null,
+        executionHostId: `runtime:env-${index}`
+      }
+      Object.defineProperty(repo, 'id', {
+        enumerable: true,
+        get: () => ((repoIdReads += 1), id)
+      })
+      return repo
+    })
+    const worktreesByRepo: RuntimeOwnerWorktreesByRepo = Object.fromEntries(
+      repos.map((repo, index) => {
+        const id = `${repo.id}::wt-${index}`
+        const worktree = { id, repoId: repo.id }
+        Object.defineProperty(worktree, 'id', {
+          enumerable: true,
+          get: () => ((worktreeIdReads += 1), id)
+        })
+        return [repo.id, [worktree]]
+      })
+    )
+    repoIdReads = 0
+
+    expect(findRuntimeOwnerWorktreeById(worktreesByRepo, 'repo-2::wt-2')?.repoId).toBe('repo-2')
+    expect(findRuntimeOwnerRepoById(repos, 'repo-2')?.executionHostId).toBe('runtime:env-2')
+    expect(findRuntimeOwnerWorktreeById(worktreesByRepo, 'repo-1::wt-1')?.repoId).toBe('repo-1')
+    expect(findRuntimeOwnerRepoById(repos, 'repo-1')?.executionHostId).toBe('runtime:env-1')
+    expect(worktreeIdReads).toBe(3)
+    expect(repoIdReads).toBe(3)
+  })
+
+  it('preserves first-match behavior for duplicate ids', () => {
+    const firstRepo: RuntimeOwnerRepoRecord = { id: 'duplicate' }
+    const secondRepo: RuntimeOwnerRepoRecord = { id: 'duplicate', connectionId: 'second' }
+    const worktreesByRepo: RuntimeOwnerWorktreesByRepo = {
+      first: [{ id: 'duplicate', repoId: 'first' }],
+      second: [{ id: 'duplicate', repoId: 'second' }]
+    }
+
+    expect(findRuntimeOwnerWorktreeById(worktreesByRepo, 'duplicate')?.repoId).toBe('first')
+    expect(findRuntimeOwnerRepoById([firstRepo, secondRepo], 'duplicate')).toBe(firstRepo)
+  })
+
+  it('rebuilds indexes when immutable slice references change', () => {
+    const firstRepos: RuntimeOwnerRepoRecord[] = [{ id: 'repo', executionHostId: 'runtime:first' }]
+    const secondRepos: RuntimeOwnerRepoRecord[] = [
+      { id: 'repo', executionHostId: 'runtime:second' }
+    ]
+    const firstWorktrees: RuntimeOwnerWorktreesByRepo = {
+      repo: [{ id: 'worktree', repoId: 'first' }]
+    }
+    const secondWorktrees: RuntimeOwnerWorktreesByRepo = {
+      repo: [{ id: 'worktree', repoId: 'second' }]
+    }
+
+    expect(findRuntimeOwnerRepoById(firstRepos, 'repo')?.executionHostId).toBe('runtime:first')
+    expect(findRuntimeOwnerRepoById(secondRepos, 'repo')?.executionHostId).toBe('runtime:second')
+    expect(findRuntimeOwnerWorktreeById(firstWorktrees, 'worktree')?.repoId).toBe('first')
+    expect(findRuntimeOwnerWorktreeById(secondWorktrees, 'worktree')?.repoId).toBe('second')
+  })
+})

--- a/src/renderer/src/lib/worktree-runtime-owner-index.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.ts
@@ -1,0 +1,56 @@
+import type { Repo, Worktree } from '../../../shared/types'
+
+export type RuntimeOwnerWorktreeRecord = Pick<Worktree, 'id' | 'repoId' | 'hostId'>
+export type RuntimeOwnerRepoRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+export type RuntimeOwnerWorktreesByRepo = Record<string, readonly RuntimeOwnerWorktreeRecord[]>
+
+// Why: Zustand reruns owner selectors on every store write. Cache only the current
+// immutable slice references so repeated lookups are O(1) without retaining history.
+let indexedWorktreesByRepo: RuntimeOwnerWorktreesByRepo | null = null
+let worktreeById = new Map<string, RuntimeOwnerWorktreeRecord>()
+let indexedRepos: readonly RuntimeOwnerRepoRecord[] | null = null
+let repoById = new Map<string, RuntimeOwnerRepoRecord>()
+
+export function findRuntimeOwnerWorktreeById(
+  worktreesByRepo: RuntimeOwnerWorktreesByRepo | undefined,
+  worktreeId: string
+): RuntimeOwnerWorktreeRecord | null {
+  if (!worktreesByRepo) {
+    return null
+  }
+  if (indexedWorktreesByRepo !== worktreesByRepo) {
+    const next = new Map<string, RuntimeOwnerWorktreeRecord>()
+    for (const worktrees of Object.values(worktreesByRepo)) {
+      for (const worktree of worktrees) {
+        const id = worktree.id
+        if (!next.has(id)) {
+          next.set(id, worktree)
+        }
+      }
+    }
+    indexedWorktreesByRepo = worktreesByRepo
+    worktreeById = next
+  }
+  return worktreeById.get(worktreeId) ?? null
+}
+
+export function findRuntimeOwnerRepoById(
+  repos: readonly RuntimeOwnerRepoRecord[] | undefined,
+  repoId: string
+): RuntimeOwnerRepoRecord | null {
+  if (!repos) {
+    return null
+  }
+  if (indexedRepos !== repos) {
+    const next = new Map<string, RuntimeOwnerRepoRecord>()
+    for (const repo of repos) {
+      const id = repo.id
+      if (!next.has(id)) {
+        next.set(id, repo)
+      }
+    }
+    indexedRepos = repos
+    repoById = next
+  }
+  return repoById.get(repoId) ?? null
+}

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -14,6 +14,10 @@ import type {
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
+import {
+  findRuntimeOwnerRepoById,
+  findRuntimeOwnerWorktreeById
+} from './worktree-runtime-owner-index'
 
 type RuntimeExecutionHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
 
@@ -24,19 +28,6 @@ export type WorktreeRuntimeOwnerState = {
   folderWorkspaces?: readonly Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'>[]
   projectGroups?: readonly Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>[]
   restoredRuntimeHostIdByWorkspaceSessionKey?: Record<string, ExecutionHostId>
-}
-
-function findWorktreeRecord(
-  worktreesByRepo: WorktreeRuntimeOwnerState['worktreesByRepo'],
-  worktreeId: string
-): Pick<Worktree, 'id' | 'repoId' | 'hostId'> | null {
-  for (const worktrees of Object.values(worktreesByRepo ?? {})) {
-    const match = worktrees.find((worktree) => worktree.id === worktreeId)
-    if (match) {
-      return match
-    }
-  }
-  return null
 }
 
 function findFolderProjectGroup(
@@ -169,7 +160,7 @@ export function getRuntimeEnvironmentIdForWorktree(
   if (workspaceScope?.type === 'folder') {
     return getRuntimeEnvironmentIdForFolderWorkspace(state, workspaceScope.folderWorkspaceId)
   }
-  const worktree = findWorktreeRecord(state.worktreesByRepo, worktreeId)
+  const worktree = findRuntimeOwnerWorktreeById(state.worktreesByRepo, worktreeId)
   const worktreeRuntimeEnvironmentId = getRuntimeEnvironmentIdFromWorktreeHost(worktree?.hostId)
   if (worktreeRuntimeEnvironmentId !== undefined) {
     // Why: the same repo can exist on local and remote hosts; a concrete
@@ -177,7 +168,7 @@ export function getRuntimeEnvironmentIdForWorktree(
     return worktreeRuntimeEnvironmentId
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repo = findRuntimeOwnerRepoById(state.repos, repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
@@ -200,12 +191,12 @@ export function getExplicitRuntimeEnvironmentIdForWorktree(
       workspaceScope.folderWorkspaceId
     )
   }
-  const worktree = findWorktreeRecord(state.worktreesByRepo, worktreeId)
+  const worktree = findRuntimeOwnerWorktreeById(state.worktreesByRepo, worktreeId)
   if (worktree?.hostId) {
     return getExplicitRuntimeEnvironmentIdFromHost(worktree.hostId)
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repo = findRuntimeOwnerRepoById(state.repos, repoId)
   if (!repo) {
     return null
   }
@@ -263,7 +254,7 @@ export function getExecutionHostIdForWorktree(
   if (workspaceScope?.type === 'folder') {
     return getExecutionHostIdForFolderWorkspace(state, workspaceScope.folderWorkspaceId)
   }
-  const worktree = findWorktreeRecord(state.worktreesByRepo, worktreeId)
+  const worktree = findRuntimeOwnerWorktreeById(state.worktreesByRepo, worktreeId)
   const worktreeHostId = getExecutionHostIdFromWorktreeHost(worktree?.hostId)
   if (worktreeHostId) {
     // Why: per-worktree host ownership is more specific than the repo host
@@ -271,7 +262,7 @@ export function getExecutionHostIdForWorktree(
     return worktreeHostId
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repo = findRuntimeOwnerRepoById(state.repos, repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     return getRepoExecutionHostId(repo)


### PR DESCRIPTION
## Description

Index the current renderer worktree and repo slices for runtime-owner resolution instead of rescanning every repo bucket for every lookup.

The three generic owner resolvers now share one-entry indexes:

- getRuntimeEnvironmentIdForWorktree
- getExplicitRuntimeEnvironmentIdForWorktree
- getExecutionHostIdForWorktree

The indexes rebuild only when the immutable worktreesByRepo or repos slice reference changes. Only the current slice references are retained, so replacing a slice releases the previous index and source. Duplicate IDs deliberately keep the former first-match behavior.

This is routing lookup bookkeeping only. Local, SSH, runtime, folder-workspace, restored-session, and floating-terminal ownership rules are unchanged.

## Evidence

There are 72 production calls to these owner resolvers in the renderer. Several are Zustand selectors in always-mounted surfaces such as TabBar, BrowserPane, ChecksPanel, FileExplorer, and PortsPanel. Zustand invokes each selector on every store write even when the selected owner does not change.

Before this change, each non-folder lookup:

1. allocated Object.values(worktreesByRepo),
2. scanned worktree arrays until the ID matched,
3. scanned repos until the owner repo matched.

Isolated steady-state benchmark: 200 repos, one worktree per repo, target in the last repo, 10,000 repeated getRuntimeEnvironmentIdForWorktree calls against unchanged slice references.

| | Before | After |
|---|---:|---:|
| Median time | 21.697 ms | 2.634 ms |
| Reduction | — | 87.9% |

Deterministic getter instrumentation over 1,000 lookups in the same 200-repo state:

| | Before | After |
|---|---:|---:|
| Worktree ID reads | 200,000 | 200 |
| Repo ID reads | 200,000 | 200 |
| Total ID-read reduction | — | 99.9% |

The after counts include the initial index build. Subsequent lookups use Map.get without rereading IDs.

The timing is an isolated repeated-lookup benchmark, not an end-to-end UI latency claim. It uses 21 samples after 5 warmups and intentionally models the stable-snapshot case that dominates unrelated Zustand store writes.

## ELI5

The renderer repeatedly answered “which computer owns this workspace?” by rereading the entire workspace list and project list—even when neither list had changed.

Now it makes a small address book the first time it sees each current list. Repeated questions use that address book instantly. When the list changes, it throws away the old address book and builds a new one.

## End-user trade-offs / regressions

No routing regression is expected.

- Local, SSH, runtime-hosted, folder, restored, and floating workspace decisions still run through the same owner rules.
- Duplicate IDs preserve the old first-match result.
- New slice references invalidate and rebuild both indexes; tests cover this explicitly.
- No RPC, persistence, filesystem, or git-provider contract changes.

Trade-offs:

- The renderer retains one Map entry per distinct worktree and repo for the current snapshots. Historical snapshots are not retained.
- The first lookup after a slice replacement indexes the whole slice, so a one-off lookup for an early item can do more work than the former early-exit scan. The cost is then shared across the 72 production call sites and repeated selector evaluations.
- The cache relies on the renderer store's existing immutable slice-reference contract, the same contract already used by cached store selectors.

Expected user impact is lower renderer bookkeeping during frequent unrelated state writes, especially with many imported repos/worktrees and multiple mounted owner-aware surfaces.

## Validation

- pnpm test — 2,537 files passed; 26,440 tests passed; 3 files / 33 tests skipped
- pnpm typecheck
- Focused oxlint on all 3 changed files
- Focused oxfmt check on all 3 changed files
- pnpm check:max-lines-ratchet
- Post-rebase owner/index suites — 2 files / 17 tests passed
