### PR TITLE
fix(remote): shared-control replay-window subscription leak, benign snapshot banner, viewport clear

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS } from '../../../../shared/clipboard-text'
-import { createRemoteRuntimePtyTextBatcher } from './remote-runtime-pty-batching'
+import {
+  createRemoteRuntimePtyTextBatcher,
+  createRemoteRuntimeViewportBatcher
+} from './remote-runtime-pty-batching'
 
 describe('createRemoteRuntimePtyTextBatcher', () => {
   it('coalesces small input until the debounce flush', async () => {
@@ -134,6 +137,45 @@ describe('createRemoteRuntimePtyTextBatcher', () => {
       batcher.flush()
 
       expect(flushes).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('createRemoteRuntimeViewportBatcher', () => {
+  it('drops the queued viewport on clear so a later flush emits nothing', () => {
+    vi.useFakeTimers()
+    try {
+      const resizes: { cols: number; rows: number }[] = []
+      const batcher = createRemoteRuntimeViewportBatcher(33, (cols, rows) => {
+        resizes.push({ cols, rows })
+      })
+
+      batcher.queue(120, 40)
+      batcher.clear()
+      // A stale pending viewport left behind by clear() would leak out here.
+      batcher.flush()
+
+      expect(resizes).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not emit a cleared viewport when the debounce timer would have fired', () => {
+    vi.useFakeTimers()
+    try {
+      const resizes: { cols: number; rows: number }[] = []
+      const batcher = createRemoteRuntimeViewportBatcher(33, (cols, rows) => {
+        resizes.push({ cols, rows })
+      })
+
+      batcher.queue(90, 30)
+      batcher.clear()
+      vi.advanceTimersByTime(100)
+
+      expect(resizes).toEqual([])
     } finally {
       vi.useRealTimers()
     }

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.ts
@@ -173,6 +173,9 @@ export function createRemoteRuntimeViewportBatcher(
       clearTimeout(timer)
       timer = null
     }
+    // Why: also drop the queued viewport so a later flush()/reuse can't emit a
+    // stale resize after the batcher was cleared on teardown/resubscribe.
+    pending = null
   }
 
   const flush = (): void => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -1990,9 +1990,9 @@ describe('createRemoteRuntimePtyTransport', () => {
     emitOutput(streamId, 'live-after-overflow')
 
     expect(onReplayData).not.toHaveBeenCalled()
-    expect(onError).toHaveBeenCalledWith(
-      'Remote terminal snapshot exceeded the 2 MiB replay limit; live output will continue.'
-    )
+    // Why: an oversized snapshot is skipped but live output continues, so the
+    // transport classifies it as benign and never surfaces a fatal red banner.
+    expect(onError).not.toHaveBeenCalled()
     expect(onConnect).toHaveBeenCalled()
     expect(onData).toHaveBeenCalledWith('live-after-overflow', expect.objectContaining({ seq: 1 }))
   })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -21,6 +21,7 @@ import {
 } from '../../runtime/runtime-terminal-stream'
 import {
   getRemoteRuntimeTerminalMultiplexer,
+  REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE,
   type RemoteRuntimeMultiplexedTerminal
 } from '../../runtime/remote-runtime-terminal-multiplexer'
 import {
@@ -373,6 +374,11 @@ export function createRemoteRuntimePtyTransport(
 
   function handleRemoteTerminalError(error: unknown): void {
     const message = runtimeTerminalErrorMessage(error)
+    if (message === REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE) {
+      // Why: an oversized initial snapshot is skipped but live output keeps
+      // flowing — informational, not fatal, so never surface a red xterm banner.
+      return
+    }
     if (isRemoteTerminalGoneMessage(message)) {
       // Why: paired web clients consume host-published PTY handles. If the host
       // retires one between snapshots, clear this mirror and wait for the next

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -111,7 +111,9 @@ type RemoteRuntimeSnapshotRequest = {
 const CONTROL_STREAM_ID = 0
 const MAX_REMOTE_TERMINAL_SNAPSHOT_BYTES = 2 * 1024 * 1024
 const REMOTE_TERMINAL_SNAPSHOT_REQUEST_TIMEOUT_MS = 10_000
-const REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE =
+// Why: exported so the transport can classify it as benign — the snapshot was
+// skipped but live output continues, so it must not surface a fatal red banner.
+export const REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE =
   'Remote terminal snapshot exceeded the 2 MiB replay limit; live output will continue.'
 
 class RemoteRuntimeTerminalMultiplexer {

--- a/src/shared/remote-runtime-shared-control-state.ts
+++ b/src/shared/remote-runtime-shared-control-state.ts
@@ -149,6 +149,9 @@ export function handleSharedControlSubscriptionResponse(
     if (subscriptionId) {
       subscription.remoteSubscriptionId = subscriptionId
     }
+    // Why: the resubscribe landed — the id-less replay window is over, so a
+    // later close cleans up by id through the normal path.
+    subscription.awaitingResubscribe = false
   }
   let delivered = response
   if (subscription.pendingReplayTag) {

--- a/src/shared/remote-runtime-shared-control-subscriptions.test.ts
+++ b/src/shared/remote-runtime-shared-control-subscriptions.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
+import {
+  closeSharedControlLogicalSubscription,
+  createSharedControlSubscription,
+  handleSharedControlLogicalResponse,
+  replaySharedControlSubscriptions
+} from './remote-runtime-shared-control-subscriptions'
+import type { SharedControlLogicalSubscription } from './remote-runtime-shared-control-types'
+
+function makeSubscriptions(): {
+  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
+  subscription: SharedControlLogicalSubscription<unknown>
+} {
+  const subscriptions = new Map<string, SharedControlLogicalSubscription<unknown>>()
+  const subscription = createSharedControlSubscription({
+    requestId: 'req-1',
+    method: 'runtime.clientEvents.subscribe',
+    params: null,
+    callbacks: { onResponse: vi.fn(), onError: vi.fn() }
+  })
+  subscriptions.set(subscription.requestId, subscription)
+  return { subscriptions, subscription }
+}
+
+function okResponse(subscriptionId: string): RuntimeRpcResponse<unknown> {
+  return {
+    ok: true,
+    id: 'req-1',
+    result: { subscriptionId }
+  } as unknown as RuntimeRpcResponse<unknown>
+}
+
+describe('closeSharedControlLogicalSubscription — replay-window leak', () => {
+  it('sends the unsubscribe when closed after an established subscribe replay completes', () => {
+    const { subscriptions, subscription } = makeSubscriptions()
+    // First establishment: server assigned a concrete subscription id.
+    subscription.sent = true
+    subscription.remoteSubscriptionId = 'server-sub-1'
+
+    const request = vi.fn()
+    closeSharedControlLogicalSubscription({ subscriptions, subscription, request })
+
+    // Established subscription cleans up immediately by its known id.
+    expect(request).toHaveBeenCalledWith('runtime.clientEvents.unsubscribe', {
+      subscriptionId: 'server-sub-1'
+    })
+    expect(subscriptions.size).toBe(0)
+  })
+
+  it('does NOT leak a server subscription when close races the replay resubscribe window', () => {
+    const { subscriptions, subscription } = makeSubscriptions()
+    // Subscription was previously established on the server.
+    subscription.sent = true
+    subscription.remoteSubscriptionId = 'server-sub-1'
+
+    // Reconnect replay: sent flips false and the old id is cleared right before
+    // the resubscribe frame goes out. The server WILL assign a fresh id.
+    const sent: SharedControlLogicalSubscription<unknown>[] = []
+    replaySharedControlSubscriptions({
+      subscriptions,
+      send: (s) => {
+        sent.push(s)
+      },
+      tagReplayedResponses: true
+    })
+    expect(subscription.sent).toBe(false)
+    expect(subscription.remoteSubscriptionId).toBeNull()
+
+    // close() arrives during the window: no remoteSubscriptionId yet, so a
+    // naive close finishes locally and never unsubscribes — leaking the server
+    // subscription that the in-flight resubscribe is about to create.
+    const request = vi.fn()
+    closeSharedControlLogicalSubscription({ subscriptions, subscription, request })
+
+    // The close must be deferred, not finished with no cleanup.
+    expect(subscriptions.size).toBe(1)
+    expect(request).not.toHaveBeenCalled()
+
+    // When the resubscribe's ready response arrives with the new server id, the
+    // deferred close fires the unsubscribe and only then finishes.
+    handleSharedControlLogicalResponse({
+      subscriptions,
+      subscription,
+      response: okResponse('server-sub-2'),
+      request
+    })
+
+    expect(request).toHaveBeenCalledWith('runtime.clientEvents.unsubscribe', {
+      subscriptionId: 'server-sub-2'
+    })
+    expect(subscriptions.size).toBe(0)
+  })
+
+  it('finishes locally without an unsubscribe for a never-sent subscription', () => {
+    const { subscriptions, subscription } = makeSubscriptions()
+    // Brand new: never sent, no server subscription exists.
+    const request = vi.fn()
+    closeSharedControlLogicalSubscription({ subscriptions, subscription, request })
+
+    expect(request).not.toHaveBeenCalled()
+    expect(subscriptions.size).toBe(0)
+  })
+})

--- a/src/shared/remote-runtime-shared-control-subscriptions.ts
+++ b/src/shared/remote-runtime-shared-control-subscriptions.ts
@@ -62,9 +62,14 @@ export function closeSharedControlLogicalSubscription(args: {
     args.request(cleanup.method, cleanup.params)
     return
   }
-  if (args.subscription.sent && cleanupNeedsRemoteSubscriptionId(args.subscription.method)) {
+  if (
+    (args.subscription.sent || args.subscription.awaitingResubscribe) &&
+    cleanupNeedsRemoteSubscriptionId(args.subscription.method)
+  ) {
     // Why: id-scoped server subscriptions can only be cleaned up after the
-    // server returns its concrete subscription id in the ready response.
+    // server returns its concrete subscription id in the ready response. This
+    // also covers the reconnect replay window (sent===false, id cleared) where
+    // a resubscribe is in flight — finishing locally there would leak it.
     args.subscription.closeAfterReady = true
     return
   }
@@ -100,6 +105,10 @@ export function replaySharedControlSubscriptions(args: {
     }
     subscription.sent = false
     subscription.remoteSubscriptionId = null
+    // Why: mark the id-less window so a close() racing this resubscribe defers
+    // to closeAfterReady instead of finishing locally and leaking the server
+    // subscription the resubscribe is about to create.
+    subscription.awaitingResubscribe = true
     if (args.tagReplayedResponses) {
       subscription.pendingReplayTag = true
     }

--- a/src/shared/remote-runtime-shared-control-types.ts
+++ b/src/shared/remote-runtime-shared-control-types.ts
@@ -34,6 +34,11 @@ export type SharedControlLogicalSubscription<TResult = unknown> = {
   // response is the authoritative re-emitted snapshot and gets tagged so
   // monotonic freshness gates don't drop it (#7718).
   pendingReplayTag?: boolean
+  // Why: true from the moment a reconnect replay clears remoteSubscriptionId
+  // until the resubscribe response arrives. A close() during this window has no
+  // id to unsubscribe by yet, so it must defer instead of finishing locally —
+  // otherwise the resubscribe the server is about to accept leaks.
+  awaitingResubscribe?: boolean
 }
 
 export type SharedControlReadyWaiter = {


### PR DESCRIPTION
## Summary

Three small, independently-committed remote-terminal / shared-control client fixes:

1. **Shared-control subscription leak on close-during-replay** (`fix(remote): defer close during shared-control replay window…`). On reconnect, `replaySharedControlSubscriptions` clears `remoteSubscriptionId` and flips `sent=false` immediately before re-sending each id-scoped subscription (`accounts.subscribe`, `notifications.subscribe`, `runtime.clientEvents.subscribe`, `files.watch`). If `close()` raced that window, `closeSharedControlLogicalSubscription` found no cleanup id and no `sent` flag, so it finished the record locally **without** sending an `*.unsubscribe` — leaking the server subscription the in-flight resubscribe was about to create. Fix: a new per-subscription `awaitingResubscribe` flag arms `closeAfterReady` during that window, so the deferred close fires the unsubscribe once the fresh server id arrives, then finishes.

2. **Benign snapshot overflow rendered a fatal red banner** (`fix(remote): treat oversized snapshot skip as benign…`). An initial replay snapshot over the 2 MiB limit is skipped while live output keeps flowing — informational, not fatal — but the multiplexer's `onError(REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE)` propagated through the transport to a red xterm banner. Fix: classify that exact message as benign in `handleRemoteTerminalError` (same seam as the existing `terminal_gone` retire path) and swallow it. The constant is now exported so the transport can match on it.

3. **Viewport batcher `clear()` left `pending` set** (`fix(remote): clear pending viewport in batcher clear()…`). The text batcher's `clear()` nulls its pending buffer; the viewport batcher's `clear()` only cancelled the timer, leaving the queued viewport in place — a later `flush()` or batcher reuse could emit a stale resize. Fix: null `pending` in `clear()`, matching the text batcher.

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck` (green)
- [x] `pnpm oxlint` on all touched files (clean)
- [x] Targeted suites (with `--config config/vitest.config.ts` so `@/` aliases resolve):
  - `remote-runtime-shared-control-subscriptions.test.ts` — NEW: 3 cases (established close cleans up by id; close-during-replay defers then unsubscribes with the fresh id; never-sent close finishes locally with no unsubscribe). The replay-window case **fails on pre-fix code** (finishes locally, size 0, no unsubscribe).
  - `remote-runtime-pty-transport.test.ts` — updated the oversized-snapshot case to assert `onError` is **not** called and live output continues (44 passed).
  - `remote-runtime-pty-batching.test.ts` — NEW viewport `clear()` cases; the flush-after-clear case **fails on pre-fix code** (9 passed after fix).
  - `remote-runtime-shared-control-connection.test.ts` — passes (this real-websocket suite is pre-existing flaky under heavy parallel load with `runtime_timeout` in the request path, unrelated to these changes; passes when run in isolation).

## AI Review Report

Reviewed for: correctness of the replay-window race (verified the leak window is `remoteSubscriptionId=null` + resubscribe in flight, and that `awaitingResubscribe` is cleared on the successful resubscribe response so normal id-scoped close still works); no double-unsubscribe (established close path unchanged); benign-classification is an exact-string match so it can't mask unrelated errors; viewport `clear()` change matches the text batcher's existing semantics. Cross-platform: pure TypeScript client logic, no shell/path/shortcut/Electron-platform surface touched — behavior identical on macOS/Linux/Windows. SSH/remote: these are the remote-runtime client paths; the subscription-leak fix directly reduces stranded server subscriptions on flaky-reconnect (SSH/relay) links.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The subscription fix sends one additional `*.unsubscribe` (already an existing, authenticated cleanup message) in a previously-leaking path; the benign-classification fix only suppresses a UI banner and never widens what is treated as success. No follow-up needed.

## Notes

Each fix is a separate commit; all three are small and self-contained, so they ship as one PR per the task scope. Do not merge — flagging for review.

Made with [Orca](https://github.com/stablyai/orca) 🐋
