### PR TITLE
fix(relay): detach primary client on write failure to trigger reconnect

### DIFF
--- a/src/relay/dispatcher.test.ts
+++ b/src/relay/dispatcher.test.ts
@@ -396,6 +396,44 @@ describe('RelayDispatcher', () => {
     expect(listener).toHaveBeenCalledWith(1)
   })
 
+  it('detaches the primary client when its write throws (frame lost, trigger reconnect)', () => {
+    // Regression: a primary-client write throw dropped the frame (possibly
+    // pty.data/pty.exit) with no resend AND without notifying detach, so the
+    // owning Orca's reconnect + PTY-reattach path never engaged until the ~20s
+    // keepalive timeout — output/pane-death were silently lost in the meantime.
+    let throwOnWrite = false
+    const detachDispatcher = new RelayDispatcher((data) => {
+      if (throwOnWrite) {
+        throw new Error('socket closed')
+      }
+      written.push(Buffer.from(data))
+    })
+    try {
+      const detachListener = vi.fn()
+      detachDispatcher.onClientDetached(detachListener)
+
+      // A frame the owning Orca must not silently miss (e.g. a pane exit).
+      throwOnWrite = true
+      detachDispatcher.notify('pty.exit', { id: 'pty-1', code: 0 })
+
+      // Fix: the write failure detaches the primary so the reconnect/reattach
+      // machinery runs promptly instead of waiting for keepalive timeout.
+      expect(detachListener).toHaveBeenCalledWith(1)
+
+      // Recovery: a reconnecting socket swaps the write via setWrite; the client
+      // is usable again and later frames flow to the new sink.
+      throwOnWrite = false
+      const recovered: Buffer[] = []
+      detachDispatcher.setWrite((data) => {
+        recovered.push(Buffer.from(data))
+      })
+      detachDispatcher.notify('pty.data', { id: 'pty-1', data: 'x' })
+      expect(recovered.length).toBeGreaterThan(0)
+    } finally {
+      detachDispatcher.dispose()
+    }
+  })
+
   describe('notifyBulk (bulk lane backpressure)', () => {
     it('resolves immediately when the sink accepts the frame', async () => {
       const frames: Buffer[] = []

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -537,10 +537,19 @@ export class RelayDispatcher {
       client.closed = true
       client.generation++
       this.flushDrainWaiters(client)
+      // Why: a write throw means this frame (possibly pty.data or pty.exit) was
+      // lost with no resend — the framing carries seq/ack but no retransmit
+      // buffer. Detach so the owning Orca's reconnect + PTY-reattach path runs
+      // promptly (regenerating dropped pty.data from the replay buffer and pane
+      // death via reattach-not-found), instead of silently dropping frames until
+      // the ~20s keepalive timeout notices. The primary client stays in the map
+      // (its object is reused across setWrite reconnects) but detach listeners
+      // must still fire, exactly as invalidateClient() does for stdin/stdout
+      // death — this makes the socket-write-throw path consistent with those.
       if (client !== this.primaryClient) {
         this.clients.delete(client.id)
-        this.notifyClientDetached(client.id)
       }
+      this.notifyClientDetached(client.id)
       process.stderr.write(
         `[relay] Client write failed: ${err instanceof Error ? err.message : String(err)}\n`
       )


### PR DESCRIPTION
## Summary

The relay dispatcher silently drops frames on a **primary-client** write failure and never triggers reconnect, so the owning Orca can miss `pty.data` output or a `pty.exit` pane-death.

`writeFrame` (`src/relay/dispatcher.ts`) catches a write throw. For **non-primary** clients it deletes and detaches them; for the **primary** client it only logged to stderr and set `closed = true` **without notifying detach**. The framing carries seq/ack but there is no retransmit buffer, so the frame is gone. Because detach never fired, none of the primary-death consumers ran and the owning Orca kept treating the primary as alive until the ~20s keepalive timeout — during that window every frame written to the throwing sink was silently lost.

Every other primary-death path (`process.stdin` end/error, `process.stdout` error in `relay.ts`) already calls `dispatcher.invalidateClient()`, which fires `notifyClientDetached`. The socket-write-throw path in `writeFrame` was the one inconsistency.

## Fix & design rationale

**Fail-fast (reuse existing reconnect + reattach), not a new resend buffer.** On a primary write throw, `writeFrame` now fires `notifyClientDetached` (the primary client object stays in the map because it is reused across `setWrite` reconnects, but listeners must still fire — exactly as `invalidateClient()` does for stdin/stdout death). This makes the socket-write-throw path consistent with every other primary-death path and engages the reconnect machinery **promptly** instead of after the keepalive timeout.

Why fail-fast over a seq-keyed resend buffer:
- The existing reconnect path already regenerates the two things that matter. `reattachKnownPtys` (`ssh-relay-session.ts`) replays each PTY's buffered output (the relay keeps the last ~100 KB in `managed.buffered`), and a PTY that **exited** during the failure window is torn out of the relay's map, so reattach throws not-found and the session emits `pty:exit` to the renderer. **Pane death is therefore never lost.**
- A general seq-keyed retransmit buffer would touch the hot outbound path for every frame and duplicate reconnection logic the client already owns — much larger surface, higher risk, for a transient-write-blip edge.

Known tradeoff (documented, acceptable): the reattach-not-found path surfaces a pane exit as `code: -1` rather than the process's real exit code. The renderer treats any exit as pane death; the exact code is informational. The guarantee the task required — `pty.exit` is never *lost* — holds. Preserving the exact code would require the resend buffer, which is out of proportion to the benefit; noted as possible follow-up.

## Repro / evidence

`src/relay/dispatcher.test.ts` → `detaches the primary client when its write throws`:
- Primary sink throws on write; dispatcher `notify('pty.exit', …)`.
- **Before:** `onClientDetached` listener is never called (verified: the test fails on pre-fix `dispatcher.ts` — `expected "vi.fn()" to be called with arguments: [ 1 ]`).
- **After:** the listener fires with the primary client id, and a `setWrite` reconnect makes the client usable again (subsequent `pty.data` reaches the new sink).

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck`
- [x] `oxlint` on changed files clean
- [x] `src/relay/dispatcher.test.ts` (23), `pty-handler.test.ts` (63), `integration.test.ts` (27) pass in isolation. New regression test fails on pre-fix, passes on post-fix.

## AI Review Report

Reviewed the re-entrancy of firing `notifyClientDetached` mid-`notify()` loop: the primary is not deleted from the client map, so iteration stays valid; non-primary deletion behavior is unchanged. Confirmed the fs-handler detach listener (`releaseClientWatches` + `wakeAllAckWaiters`) already runs on primary death via `invalidateClient()`, so this path introduces no new listener behavior — only makes the write-throw case consistent. Cross-platform: pure JS control-flow, no path/shell/OS assumptions; the relay runs on Linux/macOS/Windows remote hosts. Git operations are unaffected.

## Security Audit

No input handling, command execution, path, auth, secrets, or IPC surface added or changed. The change only alters when an existing detach notification fires on a failed write; it cannot be driven by remote input beyond causing the write to fail, which already triggers the same recovery for non-primary clients.

## Notes

Fail-fast reuses the reconnect + PTY-reattach machinery in `ssh-relay-session.ts`. If exact exit-code fidelity across a primary write blip is ever required, that would need a bounded seq-keyed retransmit buffer (deliberately out of scope here).

Made with [Orca](https://github.com/stablyai/orca) 🐋
