### PR TITLE
perf(renderer): scope active review cache subscriptions

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -87,6 +87,7 @@ import { getHostedReviewCacheKey, refreshHostedReviewCard } from '@/store/slices
 import { toast } from 'sonner'
 import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import { type ChecksPanelReview, selectChecksPanelReview } from './checks-panel-review'
+import { selectReviewCacheEntry } from './review-cache-entry-selection'
 import {
   checksPanelAsyncResultKey,
   checksPanelHostedReviewAsyncResultKey,
@@ -394,7 +395,6 @@ export default function ChecksPanel(): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const updateSettings = useAppStore((s) => s.updateSettings)
   const updateRepo = useAppStore((s) => s.updateRepo)
-  const prCache = useAppStore((s) => s.prCache)
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const fetchHostedReviewForBranch = useAppStore((s) => s.fetchHostedReviewForBranch)
   const expireGitHubPRRefreshState = useAppStore((s) => s.expireGitHubPRRefreshState)
@@ -648,7 +648,9 @@ export default function ChecksPanel(): React.JSX.Element {
     refreshContextKeyRef.current = refreshContextKey
     refreshRequestKeyRef.current = null
   }
-  const prCacheEntry = prCacheKey ? prCache[prCacheKey] : undefined
+  // Why: background PR refreshes replace the cache map; Checks only renders
+  // the entry for the active repo and branch.
+  const prCacheEntry = useAppStore((s) => selectReviewCacheEntry(s.prCache, prCacheKey || null))
   const pr: PRInfo | null = prCacheEntry?.data ?? null
   const hostedReview = useAppStore((s) =>
     hostedReviewCacheKey ? (s.hostedReviewCache[hostedReviewCacheKey]?.data ?? null) : null

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -110,6 +110,7 @@ import {
   type SourceControlSectionArea
 } from './source-control-section-order'
 import { SourceControlVirtualFileList } from './source-control-virtual-file-list'
+import { selectReviewCacheData, selectReviewCacheEntry } from './review-cache-entry-selection'
 import {
   buildActiveOpenFileSignature,
   buildActiveOpenRowKeys
@@ -819,6 +820,9 @@ function SourceControlInner(): React.JSX.Element {
   const worktreeMap = useWorktreeMap()
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
+  const gitIdentityDisplay = activeWorktree ? getWorktreeGitIdentityDisplay(activeWorktree) : null
+  const detachedHeadDisplay = gitIdentityDisplay?.kind === 'detached' ? gitIdentityDisplay : null
+  const branchName = gitIdentityDisplay?.kind === 'branch' ? gitIdentityDisplay.branchName : ''
   const entries = useAppStore((s) =>
     activeWorktreeId
       ? (s.gitStatusByWorktree[activeWorktreeId] ?? EMPTY_GIT_STATUS_ENTRIES)
@@ -850,6 +854,37 @@ function SourceControlInner(): React.JSX.Element {
   const isRemoteOperationActive = useAppStore((s) => s.isRemoteOperationActive)
   const inFlightRemoteOpKind = useAppStore((s) => s.inFlightRemoteOpKind)
   const settings = useAppStore((s) => s.settings)
+  const hostedReviewCacheKey =
+    activeRepo && branchName
+      ? getHostedReviewCacheKey(
+          activeRepo.path,
+          branchName,
+          settings,
+          activeRepo.id,
+          activeRepo.connectionId,
+          activeRepo.executionHostId,
+          true
+        )
+      : null
+  const activePrCacheKey =
+    activeRepo && branchName
+      ? getGitHubPRCacheKey(
+          activeRepo.path,
+          activeRepo.id,
+          branchName,
+          settings,
+          activeRepo.connectionId,
+          activeRepo.executionHostId,
+          true
+        )
+      : null
+  // Why: background worktree review refreshes replace both cache maps; this
+  // large panel only needs the entries for its active repo and branch.
+  const hostedReviewEntry = useAppStore((s) =>
+    selectReviewCacheEntry(s.hostedReviewCache, hostedReviewCacheKey)
+  )
+  const hostedReviewEntryData = hostedReviewEntry?.data ?? null
+  const activePrFromQueue = useAppStore((s) => selectReviewCacheData(s.prCache, activePrCacheKey))
   // Why: git/file mutations and repo metadata requests belong to the repo
   // OWNER host, not the currently focused host in the sidebar.
   const activeRepoSettings = useMemo(
@@ -859,7 +894,6 @@ function SourceControlInner(): React.JSX.Element {
   const updateSettings = useAppStore((s) => s.updateSettings)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
-  const hostedReviewCache = useAppStore((s) => s.hostedReviewCache)
   const fetchHostedReviewForBranch = useAppStore((s) => s.fetchHostedReviewForBranch)
   const getHostedReviewCreationEligibility = useAppStore(
     (s) => s.getHostedReviewCreationEligibility
@@ -867,7 +901,6 @@ function SourceControlInner(): React.JSX.Element {
   const createHostedReview = useAppStore((s) => s.createHostedReview)
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
-  const prCache = useAppStore((s) => s.prCache)
   const enqueueGitHubPRRefresh = useAppStore((s) => s.enqueueGitHubPRRefresh)
   const updateRepo = useAppStore((s) => s.updateRepo)
   const setGitStatus = useAppStore((s) => s.setGitStatus)
@@ -1211,9 +1244,6 @@ function SourceControlInner(): React.JSX.Element {
       ? undefined
       : getLocalProjectExecutionRuntimeContext(useAppStore.getState(), activeWorktreeId)
   })
-  const gitIdentityDisplay = activeWorktree ? getWorktreeGitIdentityDisplay(activeWorktree) : null
-  const detachedHeadDisplay = gitIdentityDisplay?.kind === 'detached' ? gitIdentityDisplay : null
-  const branchName = gitIdentityDisplay?.kind === 'branch' ? gitIdentityDisplay.branchName : ''
   const activePullRequestGenerationKey = getPullRequestGenerationRecordKey({
     worktreeId: activeWorktreeId,
     worktreePath,
@@ -1418,35 +1448,6 @@ function SourceControlInner(): React.JSX.Element {
     hostedReviewCreation?.provider
   )
   const hostedReviewCreateCopy = localizedHostedReviewCopy(hostedReviewCreateProvider)
-  const hostedReviewCacheKey =
-    activeRepo && branchName
-      ? getHostedReviewCacheKey(
-          activeRepo.path,
-          branchName,
-          settings,
-          activeRepo.id,
-          activeRepo.connectionId,
-          activeRepo.executionHostId,
-          true
-        )
-      : null
-  const hostedReviewEntry = hostedReviewCacheKey
-    ? hostedReviewCache[hostedReviewCacheKey]
-    : undefined
-  const activePrCacheKey =
-    activeRepo && branchName
-      ? getGitHubPRCacheKey(
-          activeRepo.path,
-          activeRepo.id,
-          branchName,
-          settings,
-          activeRepo.connectionId,
-          activeRepo.executionHostId,
-          true
-        )
-      : null
-  const activePrFromQueue = activePrCacheKey ? (prCache[activePrCacheKey]?.data ?? null) : null
-  const hostedReviewEntryData = hostedReviewEntry?.data ?? null
   const hostedReview: HostedReviewInfo | null = useMemo(() => {
     if (!hostedReviewCacheKey) {
       return null

--- a/src/renderer/src/components/right-sidebar/review-cache-entry-selection.test.ts
+++ b/src/renderer/src/components/right-sidebar/review-cache-entry-selection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { selectReviewCacheData, selectReviewCacheEntry } from './review-cache-entry-selection'
+
+type Review = { id: string }
+type ReviewEntry = { data: Review | null; fetchedAt: number }
+
+const ACTIVE_KEY = 'repo-active::feature'
+
+function replaceUnrelatedEntry(
+  cache: Record<string, ReviewEntry>,
+  index: number
+): Record<string, ReviewEntry> {
+  return {
+    ...cache,
+    [`repo-background-${index % 100}::feature`]: {
+      data: { id: `background-${index}` },
+      fetchedAt: index
+    }
+  }
+}
+
+describe('review cache entry selection', () => {
+  it('turns unrelated active-panel cache invalidations into stable selections', () => {
+    const activeHostedReview = { id: 'hosted-active' }
+    const activePullRequest = { id: 'pr-active' }
+    let hostedCache: Record<string, ReviewEntry> = {
+      [ACTIVE_KEY]: { data: activeHostedReview, fetchedAt: 1 }
+    }
+    let pullRequestCache: Record<string, ReviewEntry> = {
+      [ACTIVE_KEY]: { data: activePullRequest, fetchedAt: 1 }
+    }
+    let previousHostedMap = hostedCache
+    let previousPullRequestMap = pullRequestCache
+    let previousHostedSelection = selectReviewCacheData(hostedCache, ACTIVE_KEY)
+    let previousPullRequestSelection = selectReviewCacheEntry(pullRequestCache, ACTIVE_KEY)
+    let wholeMapInvalidations = 0
+    let scopedSelectionInvalidations = 0
+
+    for (let index = 0; index < 200; index += 1) {
+      hostedCache = replaceUnrelatedEntry(hostedCache, index)
+      pullRequestCache = replaceUnrelatedEntry(pullRequestCache, index)
+      if (hostedCache !== previousHostedMap) {
+        wholeMapInvalidations += 1
+      }
+      if (pullRequestCache !== previousPullRequestMap) {
+        wholeMapInvalidations += 1
+      }
+
+      const hostedSelection = selectReviewCacheData(hostedCache, ACTIVE_KEY)
+      const pullRequestSelection = selectReviewCacheEntry(pullRequestCache, ACTIVE_KEY)
+      if (hostedSelection !== previousHostedSelection) {
+        scopedSelectionInvalidations += 1
+      }
+      if (pullRequestSelection !== previousPullRequestSelection) {
+        scopedSelectionInvalidations += 1
+      }
+
+      previousHostedMap = hostedCache
+      previousPullRequestMap = pullRequestCache
+      previousHostedSelection = hostedSelection
+      previousPullRequestSelection = pullRequestSelection
+    }
+
+    expect(wholeMapInvalidations).toBe(400)
+    expect(scopedSelectionInvalidations).toBe(0)
+  })
+
+  it('publishes relevant entry replacements and handles absent keys', () => {
+    const first = { data: { id: 'first' }, fetchedAt: 1 }
+    const second = { data: { id: 'second' }, fetchedAt: 2 }
+
+    expect(selectReviewCacheEntry({ [ACTIVE_KEY]: first }, ACTIVE_KEY)).toBe(first)
+    expect(selectReviewCacheEntry({ [ACTIVE_KEY]: second }, ACTIVE_KEY)).toBe(second)
+    expect(selectReviewCacheData({ [ACTIVE_KEY]: second }, ACTIVE_KEY)).toBe(second.data)
+    expect(selectReviewCacheEntry({}, ACTIVE_KEY)).toBeUndefined()
+    expect(selectReviewCacheData({}, ACTIVE_KEY)).toBeNull()
+    expect(selectReviewCacheEntry({ [ACTIVE_KEY]: first }, null)).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/review-cache-entry-selection.ts
+++ b/src/renderer/src/components/right-sidebar/review-cache-entry-selection.ts
@@ -1,0 +1,17 @@
+type ReviewCacheEntry<T> = {
+  data: T | null
+}
+
+export function selectReviewCacheEntry<T, Entry extends ReviewCacheEntry<T>>(
+  cache: Readonly<Record<string, Entry>>,
+  key: string | null
+): Entry | undefined {
+  return key ? cache[key] : undefined
+}
+
+export function selectReviewCacheData<T>(
+  cache: Readonly<Record<string, ReviewCacheEntry<T>>>,
+  key: string | null
+): T | null {
+  return selectReviewCacheEntry(cache, key)?.data ?? null
+}


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545.

## 1. Description

Source Control subscribed to the entire provider-generic hosted review cache and the entire GitHub PR cache. Checks subscribed to the entire GitHub PR cache. Each panel then read only the entry for its active repo, branch, and execution host.

Background review refreshes replace these immutable cache maps for sidebar worktrees. That made unrelated cache writes invalidate the large active Source Control or Checks component even though the value it rendered was unchanged.

This PR moves those subscriptions to the already-computed host-aware cache key:

- Source Control selects only its active hosted-review entry.
- Source Control selects only its active GitHub PR data because it does not consume PR fetch metadata.
- Checks selects only its active GitHub PR entry because its refresh logic does consume fetchedAt.

Relevant active-entry replacements remain reactive. Missing-entry versus cached-null behavior in Source Control is preserved for its publish/loading gate.

## 2. Undeniable evidence + measurable improvement

The committed scale fixture performs 200 unrelated hosted-review cache replacements and 200 unrelated PR-cache replacements while preserving the active entries.

- Whole-map identity invalidations: **400**.
- Active entry/data identity invalidations after this change: **0**.
- Relevant active-entry replacements still publish immediately.
- Missing keys and null keys preserve their existing undefined/null results.

This removes panel repaint triggers, not merely lookup time: Zustand now sees the same selected identity for background worktree refreshes.

## ELI5
The panels watched two whole filing cabinets even though they only displayed one folder. They now watch that folder directly, so someone updating a different project does not repaint the open panel.

## 4. Trade-offs that regress the end experience

None material. The provider- and host-aware key builders are unchanged. GitLab, Bitbucket, Azure DevOps, Gitea, local, SSH, and runtime-host ownership still flow through the same hosted-review key. The GitHub-only PR cache remains behind its existing explicit GitHub key.

Source Control intentionally selects the full hosted-review entry so it can still distinguish a missing entry from cached null. Checks intentionally selects the full PR entry because refresh metadata matters there. Source Control selects PR data only because no PR cache metadata is rendered or used by its effects.

## Reliability proof

- **Reliability class / gate:** terminal-performance.store-and-git-hot-paths.
- **Failure source:** unrelated immutable review-cache replacements invalidated active large-panel subscriptions.
- **Product change type:** renderer performance hardening.
- **Invariant:** background worktree review refreshes must not repaint the active review panel; active repo/branch/provider/host changes and relevant cache writes must still publish.
- **Oracle:** deterministic identity-count fixture: 400 whole-map invalidations become 0 active-selection invalidations, with relevant replacement coverage.
- **Performance risk inventory:** selector identity only. No polling cadence, API request, git subprocess, cache write/eviction, IPC/RPC, persistence, telemetry, or rendering output changes.
- **Provider/platform matrix:** provider key builders and local/SSH/runtime host inputs are unchanged; the hosted review path stays provider-generic and the GitHub PR fallback stays explicitly GitHub-scoped.
- **Diagnostics:** no new logging, telemetry, timers, or retained payloads.
- **Residual gap:** no React Profiler artifact was added; selector identity is the direct render-invalidation oracle.
- **Rollback:** revert if an active cache entry stops updating or Source Control loses the missing-versus-null loading distinction.

## Testing

- [x] 2 deterministic review-cache selection tests
- [x] 15 direct SourceControl/ChecksPanel suites, 117 tests
- [x] pnpm typecheck
- [x] targeted oxlint, react-doctor, and oxfmt
- [x] pnpm lint:switch-exhaustiveness
- [x] pnpm check:reliability-gates
- [x] pnpm check:max-lines-ratchet
- [x] git diff --check
- [ ] Full pnpm lint reaches localization verification, then fails on the current-main Japanese interpolation mismatch for components.native-chat.composer.uploadingAttachments; this PR changes no localization files.

No visual design, protocol, persistence, security, dependency, path, shell, or permission change.

Made with [Orca](https://github.com/stablyai/orca) 🐋