### PR TITLE
perf(renderer): index web session tab reconciliation

### DIFF
--- a/src/renderer/src/runtime/web-session-existing-tab-index.test.ts
+++ b/src/renderer/src/runtime/web-session-existing-tab-index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { Tab } from '../../../shared/tab-types'
+import { buildWebSessionExistingTabIndex } from './web-session-existing-tab-index'
+
+const WT = 'repo::/worktree'
+
+function makeTab(id: string, entityId: string, contentType: 'editor' | 'browser'): Tab {
+  return {
+    id,
+    entityId,
+    groupId: 'group-1',
+    worktreeId: WT,
+    contentType,
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+describe('buildWebSessionExistingTabIndex', () => {
+  it('preserves first-match editor lookup behavior across both accepted keys', () => {
+    const firstFileId = '/repo/file.ts'
+    const firstByFileId = makeTab('older-host-id', firstFileId, 'editor')
+    const laterByHostId = makeTab('current-host-id', '/repo/other.ts', 'editor')
+    const index = buildWebSessionExistingTabIndex({
+      unifiedTabs: [firstByFileId, laterByHostId]
+    })
+
+    expect(index.getEditorUnifiedTab(firstFileId, laterByHostId.id)).toBe(firstByFileId)
+    expect(index.getEditorUnifiedTab(laterByHostId.entityId, firstByFileId.id)).toBe(firstByFileId)
+  })
+
+  it('ignores browser tabs and returns null when neither key matches', () => {
+    const index = buildWebSessionExistingTabIndex({
+      unifiedTabs: [makeTab('browser-tab', 'workspace-1', 'browser')]
+    })
+
+    expect(index.getEditorUnifiedTab('/repo/missing.ts', 'absent-host-id')).toBeNull()
+  })
+
+  it('resolves by host tab id and by file id independently', () => {
+    const byHostId = makeTab('host-1', '/repo/a.ts', 'editor')
+    const index = buildWebSessionExistingTabIndex({ unifiedTabs: [byHostId] })
+
+    expect(index.getEditorUnifiedTab('/repo/unrelated.ts', 'host-1')).toBe(byHostId)
+    expect(index.getEditorUnifiedTab('/repo/a.ts', 'unrelated-host')).toBe(byHostId)
+  })
+})

--- a/src/renderer/src/runtime/web-session-existing-tab-index.test.ts
+++ b/src/renderer/src/runtime/web-session-existing-tab-index.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import type { BrowserPage, BrowserWorkspace, Tab } from '../../../shared/types'
+import type { OpenFile } from '../store/slices/editor'
+import { buildWebSessionExistingTabIndex } from './web-session-existing-tab-index'
+
+const WT = 'repo::/worktree'
+const ENV = 'remote-env'
+
+function makeFile(id: string, worktreeId = WT): OpenFile {
+  return {
+    id,
+    filePath: id,
+    relativePath: id,
+    worktreeId,
+    language: 'typescript',
+    isDirty: false,
+    mode: 'edit'
+  }
+}
+
+function makeTab(id: string, entityId: string, contentType: 'editor' | 'browser'): Tab {
+  return {
+    id,
+    entityId,
+    groupId: 'group-1',
+    worktreeId: WT,
+    contentType,
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function makeWorkspace(id: string): BrowserWorkspace {
+  return {
+    id,
+    worktreeId: WT,
+    url: 'https://example.com',
+    title: id,
+    loading: false,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    loadError: null,
+    createdAt: 1
+  }
+}
+
+function makePage(id: string, workspaceId: string): BrowserPage {
+  return {
+    id,
+    workspaceId,
+    worktreeId: WT,
+    url: 'https://example.com',
+    title: id,
+    loading: false,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    loadError: null,
+    createdAt: 1
+  }
+}
+
+describe('buildWebSessionExistingTabIndex', () => {
+  it('preserves first-match editor lookup behavior across both accepted keys', () => {
+    const firstFile = makeFile('/repo/file.ts')
+    const firstByFileId = makeTab('older-host-id', firstFile.id, 'editor')
+    const laterByHostId = makeTab('current-host-id', '/repo/other.ts', 'editor')
+    const index = buildWebSessionExistingTabIndex({
+      worktreeId: WT,
+      environmentId: ENV,
+      openFiles: [makeFile(firstFile.id, 'other-worktree'), firstFile, makeFile(firstFile.id)],
+      unifiedTabs: [firstByFileId, laterByHostId],
+      browserWorkspaces: [],
+      browserPagesByWorkspace: {},
+      remoteBrowserPageHandlesByPageId: {}
+    })
+
+    expect(index.getEditorFile(firstFile.id)).toBe(firstFile)
+    expect(index.getEditorUnifiedTab(firstFile.id, laterByHostId.id)).toBe(firstByFileId)
+    expect(index.getEditorUnifiedTab(laterByHostId.entityId, firstByFileId.id)).toBe(firstByFileId)
+  })
+
+  it('preserves the first matching browser workspace, page, and unified tab', () => {
+    const firstWorkspace = makeWorkspace('workspace-1')
+    const laterWorkspace = makeWorkspace('workspace-2')
+    const firstPage = makePage('page-1', firstWorkspace.id)
+    const laterPage = makePage('page-2', laterWorkspace.id)
+    const firstUnifiedTab = makeTab('browser-tab-1', firstWorkspace.id, 'browser')
+    const duplicateUnifiedTab = makeTab('browser-tab-duplicate', firstWorkspace.id, 'browser')
+    const index = buildWebSessionExistingTabIndex({
+      worktreeId: WT,
+      environmentId: ENV,
+      openFiles: [],
+      unifiedTabs: [firstUnifiedTab, duplicateUnifiedTab],
+      browserWorkspaces: [firstWorkspace, laterWorkspace],
+      browserPagesByWorkspace: {
+        [firstWorkspace.id]: [firstPage],
+        [laterWorkspace.id]: [laterPage]
+      },
+      remoteBrowserPageHandlesByPageId: {
+        [firstPage.id]: { environmentId: ENV, remotePageId: 'remote-page' },
+        [laterPage.id]: { environmentId: ENV, remotePageId: 'remote-page' }
+      }
+    })
+
+    expect(index.getBrowserTab('remote-page')).toEqual({
+      workspace: firstWorkspace,
+      page: firstPage,
+      unifiedTab: firstUnifiedTab
+    })
+  })
+})

--- a/src/renderer/src/runtime/web-session-existing-tab-index.ts
+++ b/src/renderer/src/runtime/web-session-existing-tab-index.ts
@@ -1,0 +1,60 @@
+import type { Tab } from '../../../shared/tab-types'
+
+type PositionedTab = {
+  position: number
+  tab: Tab
+}
+
+export type WebSessionExistingTabIndex = {
+  getEditorUnifiedTab: (fileId: string, hostTabId: string) => Tab | null
+}
+
+type BuildWebSessionExistingTabIndexArgs = {
+  unifiedTabs: readonly Tab[]
+}
+
+function setFirst<K, V>(map: Map<K, V>, key: K, value: V): void {
+  if (!map.has(key)) {
+    map.set(key, value)
+  }
+}
+
+export function buildWebSessionExistingTabIndex({
+  unifiedTabs
+}: BuildWebSessionExistingTabIndexArgs): WebSessionExistingTabIndex {
+  let indexes: {
+    editorTabById: Map<string, PositionedTab>
+    editorTabByFileId: Map<string, PositionedTab>
+  } | null = null
+  // Why: terminal-only snapshots are the common case, so a snapshot carrying no
+  // mirrored editor tab never pays to walk the worktree's unified tab list.
+  const getIndexes = (): NonNullable<typeof indexes> => {
+    if (!indexes) {
+      const editorTabById = new Map<string, PositionedTab>()
+      const editorTabByFileId = new Map<string, PositionedTab>()
+      unifiedTabs.forEach((tab, position) => {
+        if (tab.contentType === 'editor') {
+          const positioned = { position, tab }
+          setFirst(editorTabById, tab.id, positioned)
+          setFirst(editorTabByFileId, tab.entityId, positioned)
+        }
+      })
+      indexes = { editorTabById, editorTabByFileId }
+    }
+    return indexes
+  }
+
+  return {
+    getEditorUnifiedTab: (fileId, hostTabId) => {
+      const { editorTabById, editorTabByFileId } = getIndexes()
+      const byHostId = editorTabById.get(hostTabId)
+      const byFileId = editorTabByFileId.get(fileId)
+      // Why: the former Array.find accepted either key, so duplicate legacy
+      // entries must still resolve to whichever candidate appeared first.
+      if (byHostId && byFileId) {
+        return byHostId.position <= byFileId.position ? byHostId.tab : byFileId.tab
+      }
+      return byHostId?.tab ?? byFileId?.tab ?? null
+    }
+  }
+}

--- a/src/renderer/src/runtime/web-session-existing-tab-index.ts
+++ b/src/renderer/src/runtime/web-session-existing-tab-index.ts
@@ -1,0 +1,124 @@
+import type { BrowserPage, BrowserWorkspace, Tab } from '../../../shared/types'
+import type { OpenFile } from '../store/slices/editor'
+
+type PositionedTab = {
+  position: number
+  tab: Tab
+}
+
+export type ExistingBrowserTab = {
+  workspace: BrowserWorkspace
+  page: BrowserPage
+  unifiedTab: Tab | null
+}
+
+export type WebSessionExistingTabIndex = {
+  getEditorFile: (fileId: string) => OpenFile | undefined
+  getEditorUnifiedTab: (fileId: string, hostTabId: string) => Tab | null
+  getBrowserTab: (remotePageId: string) => ExistingBrowserTab | null
+}
+
+type BuildWebSessionExistingTabIndexArgs = {
+  worktreeId: string
+  environmentId: string
+  openFiles: readonly OpenFile[]
+  unifiedTabs: readonly Tab[]
+  browserWorkspaces: readonly BrowserWorkspace[]
+  browserPagesByWorkspace: Readonly<Record<string, readonly BrowserPage[]>>
+  remoteBrowserPageHandlesByPageId: Readonly<
+    Record<string, { environmentId: string; remotePageId: string }>
+  >
+}
+
+function setFirst<K, V>(map: Map<K, V>, key: K, value: V): void {
+  if (!map.has(key)) {
+    map.set(key, value)
+  }
+}
+
+export function buildWebSessionExistingTabIndex({
+  worktreeId,
+  environmentId,
+  openFiles,
+  unifiedTabs,
+  browserWorkspaces,
+  browserPagesByWorkspace,
+  remoteBrowserPageHandlesByPageId
+}: BuildWebSessionExistingTabIndexArgs): WebSessionExistingTabIndex {
+  let editorFileById: Map<string, OpenFile> | null = null
+  const getEditorFileById = (): Map<string, OpenFile> => {
+    if (!editorFileById) {
+      editorFileById = new Map<string, OpenFile>()
+      for (const file of openFiles) {
+        if (file.worktreeId === worktreeId) {
+          setFirst(editorFileById, file.id, file)
+        }
+      }
+    }
+    return editorFileById
+  }
+
+  let unifiedTabIndexes: {
+    editorTabById: Map<string, PositionedTab>
+    editorTabByFileId: Map<string, PositionedTab>
+    browserTabByWorkspaceId: Map<string, Tab>
+  } | null = null
+  const getUnifiedTabIndexes = (): NonNullable<typeof unifiedTabIndexes> => {
+    if (!unifiedTabIndexes) {
+      const editorTabById = new Map<string, PositionedTab>()
+      const editorTabByFileId = new Map<string, PositionedTab>()
+      const browserTabByWorkspaceId = new Map<string, Tab>()
+      unifiedTabs.forEach((tab, position) => {
+        if (tab.contentType === 'editor') {
+          const positioned = { position, tab }
+          setFirst(editorTabById, tab.id, positioned)
+          setFirst(editorTabByFileId, tab.entityId, positioned)
+        } else if (tab.contentType === 'browser') {
+          setFirst(browserTabByWorkspaceId, tab.entityId, tab)
+        }
+      })
+      unifiedTabIndexes = { editorTabById, editorTabByFileId, browserTabByWorkspaceId }
+    }
+    return unifiedTabIndexes
+  }
+
+  let browserTabByRemotePageId: Map<string, ExistingBrowserTab> | null = null
+  const getBrowserTabByRemotePageId = (): Map<string, ExistingBrowserTab> => {
+    if (!browserTabByRemotePageId) {
+      browserTabByRemotePageId = new Map<string, ExistingBrowserTab>()
+      const { browserTabByWorkspaceId } = getUnifiedTabIndexes()
+      for (const workspace of browserWorkspaces) {
+        for (const page of browserPagesByWorkspace[workspace.id] ?? []) {
+          const handle = remoteBrowserPageHandlesByPageId[page.id]
+          if (handle?.environmentId !== environmentId) {
+            continue
+          }
+          setFirst(browserTabByRemotePageId, handle.remotePageId, {
+            workspace,
+            page,
+            unifiedTab: browserTabByWorkspaceId.get(workspace.id) ?? null
+          })
+        }
+      }
+    }
+    return browserTabByRemotePageId
+  }
+
+  return {
+    // Why: terminal-only snapshots are common, so each linear setup pass stays
+    // lazy until a mirrored editor or browser surface actually needs it.
+    getEditorFile: (fileId) => getEditorFileById().get(fileId),
+    getEditorUnifiedTab: (fileId, hostTabId) => {
+      const { editorTabById, editorTabByFileId } = getUnifiedTabIndexes()
+      const byHostId = editorTabById.get(hostTabId)
+      const byFileId = editorTabByFileId.get(fileId)
+      // Why: the former Array.find accepted either key, so duplicate legacy
+      // entries must still resolve to whichever candidate appeared first.
+      if (byHostId && byFileId) {
+        return byHostId.position <= byFileId.position ? byHostId.tab : byFileId.tab
+      }
+      return byHostId?.tab ?? byFileId?.tab ?? null
+    },
+    getBrowserTab: (remotePageId) => getBrowserTabByRemotePageId().get(remotePageId) ?? null
+  }
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -96,6 +96,10 @@ import {
   resetWebSessionBrowserPlacementsForTests
 } from './web-session-browser-placement'
 import { suppressE2eWebRuntimeBrowserSnapshot } from './web-runtime-browser-creation-e2e-fault'
+import {
+  buildWebSessionExistingTabIndex,
+  type WebSessionExistingTabIndex
+} from './web-session-existing-tab-index'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
 export const WEB_SESSION_TABS_VISIBILITY_RESUME_STAGGER_MS = 100
@@ -1394,24 +1398,11 @@ function buildEditorUnifiedTab(
   }
 }
 
-function findExistingEditorUnifiedTab(
-  state: WebSessionTabsSyncState,
-  worktreeId: string,
-  fileId: string,
-  hostTabId: string
-): Tab | null {
-  return (
-    (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
-      (tab) => tab.contentType === 'editor' && (tab.id === hostTabId || tab.entityId === fileId)
-    ) ?? null
-  )
-}
-
 function buildMirroredEditorTabs(
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
-  state: WebSessionTabsSyncState,
   worktreeOpenFileById: ReadonlyMap<string, OpenFile>,
+  existingTabIndex: WebSessionExistingTabIndex,
   hostGroupIdByTabId: ReadonlyMap<string, string>,
   fallbackGroupId: string,
   sortOffset: number,
@@ -1420,12 +1411,7 @@ function buildMirroredEditorTabs(
   return snapshot.tabs.filter(isReadyEditorTab).map((tab, index) => {
     const fileId = localEditorFileId(tab)
     const existingFile = worktreeOpenFileById.get(fileId)
-    const existingUnifiedTab = findExistingEditorUnifiedTab(
-      state,
-      snapshot.worktree,
-      fileId,
-      tab.id
-    )
+    const existingUnifiedTab = existingTabIndex.getEditorUnifiedTab(fileId, tab.id)
     const sourceFileId = editorSourceFileId(tab)
     const groupId = hostGroupIdByTabId.get(tab.id) ?? fallbackGroupId
     const file: OpenFile = {
@@ -1850,8 +1836,9 @@ function buildMirroredHostGroups({
           validUnifiedTabIds.has(tabId) &&
           !clientGroupIdByLocalTabId.has(tabId)
       )
+    const localHostOrderIds = new Set(localHostOrder)
     const hostTabOrder = [
-      ...(existing?.tabOrder.filter((tabId) => !localHostOrder.includes(tabId)) ?? []),
+      ...(existing?.tabOrder.filter((tabId) => !localHostOrderIds.has(tabId)) ?? []),
       ...localHostOrder
     ]
     // Why: a pending client reorder wins over a stale pre-move host order until the host echoes the move (or membership changes).
@@ -2459,6 +2446,9 @@ function applyWebSessionTabsSnapshotWithContext(
 
   const targetGroupId = chooseTargetGroupId(state, snapshot)
   const hostGroupIdByTabId = buildHostGroupIdByTabId(snapshot.tabGroups)
+  const existingTabIndex = buildWebSessionExistingTabIndex({
+    unifiedTabs: state.unifiedTabsByWorktree[worktreeId] ?? []
+  })
   const readyBrowserTabs = snapshot.tabs.filter(isReadyBrowserTab)
   const nextRemoteBrowserPageIds = new Set(readyBrowserTabs.map((tab) => tab.browserPageId))
   const mirroredBrowserTabs = buildMirroredBrowserTabs(
@@ -2505,8 +2495,8 @@ function applyWebSessionTabsSnapshotWithContext(
   const mirroredEditorTabs = buildMirroredEditorTabs(
     snapshot,
     environmentId,
-    state,
     firstOpenFileByIdForWorktree(worktreeOpenFiles),
+    existingTabIndex,
     hostGroupIdByTabId,
     targetGroupId,
     mirroredTerminalTabEntries.length + mirroredBrowserTabs.length,
@@ -2830,8 +2820,10 @@ function applyWebSessionTabsSnapshotWithContext(
           .filter((tabId): tabId is string => tabId !== undefined && validTabBarIds.has(tabId))
       ) ?? []
     const next: string[] = []
+    const seen = new Set<string>()
     const push = (tabId: string): void => {
-      if (validTabBarIds.has(tabId) && !next.includes(tabId)) {
+      if (validTabBarIds.has(tabId) && !seen.has(tabId)) {
+        seen.add(tabId)
         next.push(tabId)
       }
     }

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -68,6 +68,10 @@ import {
   shouldSkipWebRuntimeWakeTerminalRespawn
 } from './web-runtime-wake-terminal-respawn'
 import { isRuntimeSubscriptionReplayResponse } from '../../../shared/runtime-subscription-replay'
+import {
+  buildWebSessionExistingTabIndex,
+  type WebSessionExistingTabIndex
+} from './web-session-existing-tab-index'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
 
@@ -810,23 +814,10 @@ function buildEditorUnifiedTab(
   }
 }
 
-function findExistingEditorUnifiedTab(
-  state: WebSessionTabsSyncState,
-  worktreeId: string,
-  fileId: string,
-  hostTabId: string
-): Tab | null {
-  return (
-    (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
-      (tab) => tab.contentType === 'editor' && (tab.id === hostTabId || tab.entityId === fileId)
-    ) ?? null
-  )
-}
-
 function buildMirroredEditorTabs(
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
-  state: WebSessionTabsSyncState,
+  existingTabIndex: WebSessionExistingTabIndex,
   hostGroupIdByTabId: ReadonlyMap<string, string>,
   fallbackGroupId: string,
   sortOffset: number,
@@ -834,15 +825,8 @@ function buildMirroredEditorTabs(
 ): MirroredEditorTab[] {
   return snapshot.tabs.filter(isReadyEditorTab).map((tab, index) => {
     const fileId = localEditorFileId(tab)
-    const existingFile = state.openFiles.find(
-      (file) => file.worktreeId === snapshot.worktree && file.id === fileId
-    )
-    const existingUnifiedTab = findExistingEditorUnifiedTab(
-      state,
-      snapshot.worktree,
-      fileId,
-      tab.id
-    )
+    const existingFile = existingTabIndex.getEditorFile(fileId)
+    const existingUnifiedTab = existingTabIndex.getEditorUnifiedTab(fileId, tab.id)
     const sourceFileId = editorSourceFileId(tab)
     const groupId = hostGroupIdByTabId.get(tab.id) ?? fallbackGroupId
     const file: OpenFile = {
@@ -877,32 +861,6 @@ function buildMirroredEditorTabs(
   })
 }
 
-function findBrowserWorkspaceForRemotePage(
-  state: WebSessionTabsSyncState,
-  worktreeId: string,
-  environmentId: string,
-  remotePageId: string
-): { workspace: BrowserWorkspace; page: BrowserPage; unifiedTab: Tab | null } | null {
-  const workspaces = state.browserTabsByWorktree[worktreeId] ?? []
-  for (const workspace of workspaces) {
-    const pages = state.browserPagesByWorkspace[workspace.id] ?? []
-    for (const page of pages) {
-      const handle = state.remoteBrowserPageHandlesByPageId[page.id]
-      if (handle?.environmentId === environmentId && handle.remotePageId === remotePageId) {
-        return {
-          workspace,
-          page,
-          unifiedTab:
-            (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
-              (tab) => tab.contentType === 'browser' && tab.entityId === workspace.id
-            ) ?? null
-        }
-      }
-    }
-  }
-  return null
-}
-
 function browserWorkspaceHasRemoteEnvironmentPage(
   state: WebSessionTabsSyncState,
   workspace: BrowserWorkspace,
@@ -916,19 +874,14 @@ function browserWorkspaceHasRemoteEnvironmentPage(
 function buildMirroredBrowserTabs(
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
-  state: WebSessionTabsSyncState,
+  existingTabIndex: WebSessionExistingTabIndex,
   hostGroupIdByTabId: ReadonlyMap<string, string>,
   fallbackGroupId: string,
   sortOffset: number,
   now: number
 ): MirroredBrowserTab[] {
   return snapshot.tabs.filter(isReadyBrowserTab).map((tab, index) => {
-    const existing = findBrowserWorkspaceForRemotePage(
-      state,
-      snapshot.worktree,
-      environmentId,
-      tab.browserPageId
-    )
+    const existing = existingTabIndex.getBrowserTab(tab.browserPageId)
     const workspaceId = existing?.workspace.id ?? tab.browserWorkspaceId
     const pageId = existing?.page.id ?? tab.browserPageId
     const createdAt = existing?.page.createdAt ?? now + sortOffset + index
@@ -1213,8 +1166,9 @@ function buildMirroredHostGroups({
     const localHostOrder = hostGroup.tabOrder
       .map((tabId) => hostToLocalTabId.get(tabId))
       .filter((tabId): tabId is string => tabId !== undefined && validUnifiedTabIds.has(tabId))
+    const localHostOrderIds = new Set(localHostOrder)
     const hostTabOrder = [
-      ...(existing?.tabOrder.filter((tabId) => !localHostOrder.includes(tabId)) ?? []),
+      ...(existing?.tabOrder.filter((tabId) => !localHostOrderIds.has(tabId)) ?? []),
       ...localHostOrder
     ]
     // Why: a pending client reorder for this group wins over a stale pre-move
@@ -1715,12 +1669,21 @@ export function applyWebSessionTabsSnapshot(
 
   const targetGroupId = chooseTargetGroupId(state, snapshot)
   const hostGroupIdByTabId = buildHostGroupIdByTabId(snapshot.tabGroups)
+  const existingTabIndex = buildWebSessionExistingTabIndex({
+    worktreeId,
+    environmentId,
+    openFiles: state.openFiles,
+    unifiedTabs: state.unifiedTabsByWorktree[worktreeId] ?? [],
+    browserWorkspaces: state.browserTabsByWorktree[worktreeId] ?? [],
+    browserPagesByWorkspace: state.browserPagesByWorkspace,
+    remoteBrowserPageHandlesByPageId: state.remoteBrowserPageHandlesByPageId
+  })
   const readyBrowserTabs = snapshot.tabs.filter(isReadyBrowserTab)
   const nextRemoteBrowserPageIds = new Set(readyBrowserTabs.map((tab) => tab.browserPageId))
   const mirroredBrowserTabs = buildMirroredBrowserTabs(
     snapshot,
     environmentId,
-    state,
+    existingTabIndex,
     hostGroupIdByTabId,
     targetGroupId,
     mirroredTerminalTabEntries.length,
@@ -1760,7 +1723,7 @@ export function applyWebSessionTabsSnapshot(
   const mirroredEditorTabs = buildMirroredEditorTabs(
     snapshot,
     environmentId,
-    state,
+    existingTabIndex,
     hostGroupIdByTabId,
     targetGroupId,
     mirroredTerminalTabEntries.length + mirroredBrowserTabs.length,
@@ -2043,8 +2006,10 @@ export function applyWebSessionTabsSnapshot(
           .filter((tabId): tabId is string => tabId !== undefined && validTabBarIds.has(tabId))
       ) ?? []
     const next: string[] = []
+    const seen = new Set<string>()
     const push = (tabId: string): void => {
-      if (validTabBarIds.has(tabId) && !next.includes(tabId)) {
+      if (validTabBarIds.has(tabId) && !seen.has(tabId)) {
+        seen.add(tabId)
         next.push(tabId)
       }
     }


### PR DESCRIPTION
## Description

Replace the per-editor-tab linear scan in web-session snapshot reconciliation with a lazily-built map, and swap two `includes`-in-a-loop scans for Set membership.

- `findExistingEditorUnifiedTab` ran `Array.find` over the worktree's whole unified-tab list for **every** incoming mirrored editor tab. It is now one map keyed by both accepted keys (host tab id and file id), built once per snapshot.
- Host group order (`buildMirroredHostGroups`) and tab-bar order rebuild used `Array.includes` against arrays that grow as the loop runs. Both now use a `Set`.
- The map is built lazily on first lookup, so terminal-only snapshots — the common case — pay only an object allocation.
- The index lives in its own module rather than growing the already-grandfathered reconciliation file.

## Scope reduction (rebase)

This PR originally indexed three things. Two were removed because they are no longer wins:

- **Open-file lookup** — already shipped on `main` as `firstOpenFileByIdForWorktree` (#13748). This PR now uses main's index rather than building a duplicate.
- **Remote browser-page lookup** — the index eagerly walked every browser workspace's page list for the worktree on first use, so a worktree with many local browser workspaces but only one mirrored page did **more** work than `main`. Reverted to `findBrowserWorkspaceForRemotePage`.

Net effect: +265/-23 becomes **+125/-23**, and `web-session-tabs-sync.ts` is **-33 lines**.

## Rebase correctness fix

Two things had rotted and would have broken `main`:

- `buildMirroredBrowserTabs` merged **without a conflict marker** into non-compiling code: this branch removed `state` from its signature, while `main` added `state.layoutByWorktree` / `state.groupsByWorktree` reads to its body. Only `tsc` caught it. **Do not merge this PR with the merge button without a rebase.**
- Both new files imported `../../../shared/types`, the barrel deleted by #14447. Corrected to `shared/tab-types` and (no longer needed) `shared/browser-workspace-types`.

## Performance evidence

**The benchmark table from the original revision has been removed rather than restated.** It measured all three indexes at 2,000 tabs; two of those indexes are gone, so those figures materially overstate what this PR now does. The remaining change has **not** been re-benchmarked.

What can be stated without measurement: the editor-tab lookup goes from O(editor tabs in snapshot × unified tabs in worktree) to O(unified tabs) setup plus O(1) per lookup, and the two order-merge scans go from O(n²) to O(n). The practical size of that win is bounded by tabs-per-worktree, not by the 2,000-tab figure the original benchmark used.

## ELI5

Restoring remote tabs used to re-read the whole tab list from the top for every single tab, like rereading a phone book for each name. It now builds one small lookup table and checks each tab directly — and only builds that table if the snapshot actually contains editor tabs.

## End-user trade-offs / regressions

- None found. This is renderer-local reconciliation of already-received snapshot state.
- No RPC params, stream opcodes, or persisted state — nothing a paired client and host exchange, so remote wire compatibility is not engaged.
- No git commands or filesystem paths, so folder (non-git) workspaces, SSH hosts, Windows/Linux, and the Git 2.25 floor are unaffected.
- Duplicate legacy IDs still resolve to the former first-match result; covered by a focused test.
- The map is scoped to one synchronous snapshot application and is collectible afterward, so there is no cache-invalidation surface.

## Validation

- `pnpm typecheck` — all three tsconfigs (node, cli, web)
- Targeted Vitest: `src/renderer/src/runtime` — 78 files, 781 tests passed
- `pnpm check:max-lines-ratchet`, `pnpm check:reliability-gates`
- Targeted `oxlint` (incl. react-doctor config) + `oxfmt`
