### PR TITLE
fix(remote): deliver initial prompt to interpreter-wrapped agents (aider/vibe) + surface drops

### DIFF
--- a/src/renderer/src/lib/agent-followup-delivery.test.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendFollowupPromptWhenAgentReady } from './agent-followup-delivery'
+import {
+  inspectRuntimeTerminalProcess,
+  sendRuntimePtyInputVerified
+} from '@/runtime/runtime-terminal-inspection'
+import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  inspectRuntimeTerminalProcess: vi.fn(),
+  sendRuntimePtyInputVerified: vi.fn()
+}))
+
+// The interpreter-wrapped agents that deliver their prompt over stdin after the
+// process starts. These are pip console-scripts, so the PTY foreground comm is
+// python/python3 — never the agent's own name.
+const INTERPRETER_WRAPPED_AGENTS = [
+  { agent: 'aider', expectedProcess: TUI_AGENT_CONFIG.aider.expectedProcess },
+  { agent: 'mistral-vibe', expectedProcess: TUI_AGENT_CONFIG['mistral-vibe'].expectedProcess }
+] as const
+
+describe('sendFollowupPromptWhenAgentReady — interpreter-wrapped agents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('globalThis', globalThis)
+    // Deliver the prompt write eagerly so the test does not depend on retries.
+    vi.mocked(sendRuntimePtyInputVerified).mockResolvedValue(true)
+  })
+
+  it('sanity: config keeps aider/vibe as stdin-after-start with python-style expected process', () => {
+    expect(TUI_AGENT_CONFIG.aider.promptInjectionMode).toBe('stdin-after-start')
+    expect(TUI_AGENT_CONFIG['mistral-vibe'].promptInjectionMode).toBe('stdin-after-start')
+  })
+
+  for (const { agent, expectedProcess } of INTERPRETER_WRAPPED_AGENTS) {
+    it(`types the prompt once ${agent} is up behind a python3 wrapper with a live child`, async () => {
+      // The console-script agent is running: foreground comm is python3 and the
+      // PTY has a non-shell child. The exact agent name never appears.
+      vi.mocked(inspectRuntimeTerminalProcess).mockResolvedValue({
+        foregroundProcess: 'python3',
+        hasChildProcesses: true
+      })
+
+      const delivered = await sendFollowupPromptWhenAgentReady({
+        ptyId: 'pty-1',
+        expectedProcess,
+        prompt: 'ship it',
+        settings: null
+      })
+
+      expect(delivered).toBe(true)
+      expect(sendRuntimePtyInputVerified).toHaveBeenCalledWith(null, 'pty-1', 'ship it\r')
+    })
+
+    it(`still refuses to type into a bare ${agent} shell foreground`, async () => {
+      // No agent yet: foreground is a plain shell with no non-shell child. The
+      // guard must NOT write user text into an arbitrary shell.
+      vi.mocked(inspectRuntimeTerminalProcess).mockResolvedValue({
+        foregroundProcess: 'zsh',
+        hasChildProcesses: false
+      })
+
+      const delivered = await sendFollowupPromptWhenAgentReady({
+        ptyId: 'pty-1',
+        expectedProcess,
+        prompt: 'ship it',
+        settings: null
+      })
+
+      expect(delivered).toBe(false)
+      expect(sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+    })
+  }
+
+  it('types immediately when the resolver already returns the agent name (local ps path)', async () => {
+    // On local desktop the ps-table resolver usually resolves python3 → aider
+    // before we poll; the exact-match path must keep working.
+    vi.mocked(inspectRuntimeTerminalProcess).mockResolvedValue({
+      foregroundProcess: 'aider',
+      hasChildProcesses: true
+    })
+
+    const delivered = await sendFollowupPromptWhenAgentReady({
+      ptyId: 'pty-1',
+      expectedProcess: 'aider',
+      prompt: 'ship it',
+      settings: null
+    })
+
+    expect(delivered).toBe(true)
+    expect(sendRuntimePtyInputVerified).toHaveBeenCalledWith(null, 'pty-1', 'ship it\r')
+  })
+})

--- a/src/renderer/src/lib/agent-followup-delivery.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.ts
@@ -2,7 +2,11 @@ import {
   inspectRuntimeTerminalProcess,
   sendRuntimePtyInputVerified
 } from '@/runtime/runtime-terminal-inspection'
-import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
+import {
+  isAgentForegroundWrapperProcess,
+  isExpectedAgentProcess
+} from '../../../shared/agent-process-recognition'
+import { isShellProcess } from '../../../shared/shell-process-detection'
 import type { GlobalSettings } from '../../../shared/types'
 
 type RuntimeOwnerSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
@@ -25,7 +29,7 @@ export async function sendFollowupPromptWhenAgentReady(args: {
 }
 
 // Why: delayed follow-ups must not type into an arbitrary shell. Require a
-// positive expected-process match before writing user/task text to the PTY.
+// positive readiness signal before writing user/task text to the PTY.
 async function waitForAgentForeground(
   ptyId: string,
   expectedProcess: string,
@@ -39,6 +43,20 @@ async function waitForAgentForeground(
       const process = await inspectRuntimeTerminalProcess(settings, ptyId)
       const foreground = process.foregroundProcess?.toLowerCase() ?? ''
       if (isExpectedAgentProcess(foreground, expectedProcess)) {
+        return true
+      }
+      // Why: interpreter-wrapped agents (aider, mistral-vibe are pip console
+      // scripts) surface a python/node foreground comm, so the exact-name check
+      // never matches — locally when the ps-table resolver can't pin the child,
+      // and over SSH when the relay falls back to the bare interpreter name. If
+      // the foreground is a known agent wrapper (not a shell) with a live
+      // non-shell child, the agent has taken over the PTY and can accept input.
+      if (
+        attempt >= 4 &&
+        isAgentForegroundWrapperProcess(foreground) &&
+        !isShellProcess(foreground) &&
+        process.hasChildProcesses
+      ) {
         return true
       }
     } catch {

--- a/src/renderer/src/lib/new-workspace.test.ts
+++ b/src/renderer/src/lib/new-workspace.test.ts
@@ -4,6 +4,7 @@ const {
   mockInspectRuntimeTerminalProcess,
   mockSendRuntimePtyInputVerified,
   mockPasteDraftToAgentPtyWhenReady,
+  mockShowAutomationPromptNotSentToast,
   mockTrack,
   store,
   storeListeners,
@@ -12,6 +13,7 @@ const {
   mockInspectRuntimeTerminalProcess: vi.fn(),
   mockSendRuntimePtyInputVerified: vi.fn(),
   mockPasteDraftToAgentPtyWhenReady: vi.fn(),
+  mockShowAutomationPromptNotSentToast: vi.fn(),
   mockTrack: vi.fn(),
   storeListeners: new Set<(state: unknown, previousState: unknown) => void>(),
   startupLeafId: '11111111-1111-4111-8111-111111111111',
@@ -86,6 +88,10 @@ vi.mock('@/lib/browser-uuid', () => ({
 
 vi.mock('@/lib/telemetry', () => ({
   track: mockTrack
+}))
+
+vi.mock('@/lib/agent-background-session-timeout-toast', () => ({
+  showAutomationPromptNotSentToast: mockShowAutomationPromptNotSentToast
 }))
 
 import {
@@ -298,6 +304,65 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
   })
 
+  it('surfaces the not-sent toast when a follow-up prompt is dropped', async () => {
+    // Foreground never becomes a recognized agent and there is no live child,
+    // so the readiness wait times out and the prompt is not delivered.
+    mockInspectRuntimeTerminalProcess.mockResolvedValue({
+      foregroundProcess: 'zsh',
+      hasChildProcesses: false
+    })
+
+    await ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      startup: {
+        agent: 'aider',
+        launchCommand: 'aider',
+        expectedProcess: 'aider',
+        followupPrompt: 'fix the spinner',
+        launchConfig: { agentArgs: '', agentEnv: {} }
+      }
+    })
+
+    expect(mockSendRuntimePtyInputVerified).not.toHaveBeenCalled()
+    expect(mockShowAutomationPromptNotSentToast).toHaveBeenCalledWith('aider')
+  })
+
+  it('does not toast when a follow-up prompt is delivered', async () => {
+    await ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      startup: {
+        agent: 'aider',
+        launchCommand: 'aider',
+        expectedProcess: 'aider',
+        followupPrompt: 'fix the spinner',
+        launchConfig: { agentArgs: '', agentEnv: {} }
+      }
+    })
+
+    expect(mockShowAutomationPromptNotSentToast).not.toHaveBeenCalled()
+  })
+
+  it('passes an onTimeout that surfaces the not-sent toast to the draft paste path', async () => {
+    await ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      startup: {
+        agent: 'claude',
+        launchCommand: 'claude',
+        expectedProcess: 'claude',
+        followupPrompt: null,
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        draftPrompt: 'review this before sending'
+      }
+    })
+
+    const call = mockPasteDraftToAgentPtyWhenReady.mock.calls.at(-1)?.[0] as
+      | { onTimeout?: () => void }
+      | undefined
+    expect(call?.onTimeout).toBeTypeOf('function')
+    call?.onTimeout?.()
+    expect(mockShowAutomationPromptNotSentToast).toHaveBeenCalledWith('claude')
+  })
+
   it('does not track when follow-up prompt delivery rejects', async () => {
     mockSendRuntimePtyInputVerified.mockRejectedValue(new Error('runtime timeout'))
 
@@ -335,7 +400,8 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       ptyId: 'pty-1',
       content: 'review this before sending',
       agent: 'claude',
-      forcePaste: true
+      forcePaste: true,
+      onTimeout: expect.any(Function)
     })
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
   })
@@ -378,7 +444,8 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       ptyId: 'agent-pty',
       content: 'Linear context draft',
       agent: 'codex',
-      forcePaste: true
+      forcePaste: true,
+      onTimeout: expect.any(Function)
     })
   })
 
@@ -434,7 +501,8 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       ptyId: 'pty-delayed',
       content: 'https://github.com/stablyai/orca/pull/2051',
       agent: 'codex',
-      forcePaste: true
+      forcePaste: true,
+      onTimeout: expect.any(Function)
     })
   })
 
@@ -515,7 +583,8 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       ptyId: 'startup-pty',
       content: 'linked draft',
       agent: 'codex',
-      forcePaste: true
+      forcePaste: true,
+      onTimeout: expect.any(Function)
     })
   })
 

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -4,6 +4,7 @@ import {
   pasteDraftToAgentPtyWhenReady
 } from '@/lib/agent-paste-draft'
 import { sendFollowupPromptWhenAgentReady } from '@/lib/agent-followup-delivery'
+import { showAutomationPromptNotSentToast } from '@/lib/agent-background-session-timeout-toast'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import type { LinkedWorkItemContext } from '@/lib/linked-work-item-context'
 import {
@@ -302,12 +303,17 @@ async function deliverAgentStartupToTerminal(
   // (aider, goose, etc.) that need their initial prompt typed into the live
   // session and submitted. Wait until the agent owns the PTY before writing.
   if (startup.followupPrompt) {
-    await sendFollowupPromptWhenAgentReady({
+    const delivered = await sendFollowupPromptWhenAgentReady({
       ptyId,
       expectedProcess: startup.expectedProcess,
       prompt: startup.followupPrompt,
       settings: runtimeSettings
     })
+    // Why: a dropped follow-up is otherwise silent — surface the same toast the
+    // draft path uses so the user knows to open the workspace and paste it.
+    if (!delivered) {
+      showAutomationPromptNotSentToast(startup.agent)
+    }
   }
 
   // Why: draftPrompt uses bracketed-paste so the URL lands atomically in the
@@ -321,7 +327,9 @@ async function deliverAgentStartupToTerminal(
       agent: startup.agent,
       // Why: startup.draftPrompt is only attached after native draft launch
       // planning is unavailable, so this paste is the first delivery attempt.
-      forcePaste: true
+      forcePaste: true,
+      // Why: surface a dropped draft instead of silently losing it.
+      onTimeout: () => showAutomationPromptNotSentToast(startup.agent)
     })
   }
 }


### PR DESCRIPTION
## Summary

Interpreter-wrapped agents (aider, mistral-vibe — both pip console-scripts) silently dropped their initial prompt when launched via the stdin-after-start delivery path, and a dropped delivery had no user-visible surface. Two commits:

1. **HIGH — prompt delivery** (`fix(remote): deliver stdin-after-start prompt to interpreter-wrapped agents…`). `sendFollowupPromptWhenAgentReady` → `waitForAgentForeground` gated **solely** on `isExpectedAgentProcess(foreground, expectedProcess)` (exact/prefix name match). aider/mistral-vibe run as `python3 …/bin/aider`, so the PTY foreground comm is `python3` (or `python`) — never `aider`/`vibe`. The wait polled 30×150ms (~4.5s), returned false, and the prompt was dropped with no error. This bit both **locally** (when the `ps`-table resolver can't pin the wrapped child to a single candidate) and **over SSH** (when the relay's `getForegroundProcessName` falls back to the bare interpreter name). Fix: after a few polls, also accept the foreground when it's a known **agent wrapper process** (`node`/`python*`, via the existing `isAgentForegroundWrapperProcess`), is **not a shell**, and the PTY has a **non-shell child** — the same readiness signal `waitForAgentReady` (the Use-button flow) already uses. Client-side only; uses just `foregroundProcess` + `hasChildProcesses`, both already in `RuntimeTerminalProcessInspection`, so **no relay/RPC protocol change** and it works identically on local and SSH.

2. **MEDIUM — failure surface** (`fix(remote): surface a toast when agent startup prompt/draft delivery is dropped`). `deliverAgentStartupToTerminal` ignored `sendFollowupPromptWhenAgentReady`'s boolean and passed no `onTimeout` to `pasteDraftToAgentPtyWhenReady`, so a genuine drop was silent. Wired both to the existing `showAutomationPromptNotSentToast(agent)` (already a standalone, generically-named module — reused directly, not moved).

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck` (green)
- [x] `pnpm oxlint` on all touched files (clean)
- [x] `agent-followup-delivery.test.ts` — NEW. Pins the real config entries (`aider`, `mistral-vibe`) rather than synthetic agents. The `python3`-wrapper-with-live-child cases **fail on pre-fix code** (prompt dropped after full ~4.5s poll, no write) and pass post-fix; the bare-shell cases still correctly refuse to type; the already-resolved (`foreground === 'aider'`) case keeps working.
- [x] `new-workspace.test.ts` — added toast-on-drop tests for both the follow-up and draft branches (drop → toast; success → no toast; draft `onTimeout` invokes the toast), and updated the existing exact-match `pasteDraft` assertions for the new `onTimeout` arg.
- [x] Ran `agent-ready-wait`, `agent-process-recognition`, `pty-shell-utils` suites alongside — 65 passed / 5 files.

## AI Review Report

Reviewed for: correctness of the readiness relaxation (the new branch is gated behind `attempt >= 4`, requires a non-shell wrapper foreground AND a live non-shell child — identical to the existing accepted `waitForAgentReady` heuristic, so it doesn't newly type into an arbitrary shell); SSH parity (traced the relay path: `getForegroundProcessName` resolves the wrapped descendant when it can, and falls back to `python3` otherwise; `hasChildProcesses` over SSH is `pgrep` on the shell pid, which is true when the agent child is live — so the new signal fires on both transports); no protocol change; file-boundary compliance (did NOT touch `agent-paste-draft.ts`, `draft-paste-ready-scanner.ts`, or `tui-agent-config.ts` — PR #7862's territory). Cross-platform: `isAgentForegroundWrapperProcess` already covers `node`/`python`/`python3`; Windows foreground resolution has its own path and is unaffected; no shell/path/shortcut assumptions added.

## Security Audit

The follow-up path still refuses to write into a bare shell — the relaxation only accepts a recognized non-shell agent-wrapper foreground with a live child, so user/task text is not typed into an arbitrary prompt. No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The toast wiring only surfaces an existing best-effort UI message.

## Notes

- SSH story: no relay protocol addition needed — the fix relies only on fields the inspection RPC already returns (`foregroundProcess`, `hasChildProcesses`), so it works over SSH where the relay reports remote `python3`.
- Two separate commits (delivery fix, then failure-surface wiring). Do not merge — flagging for review.

Made with [Orca](https://github.com/stablyai/orca) 🐋
