### PR TITLE
perf(file-explorer): batch and debounce ignored checks

### DIFF
--- a/src/main/git/check-ignored-paths.test.ts
+++ b/src/main/git/check-ignored-paths.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { checkIgnoredPaths } from './check-ignored-paths'
 import { gitExecFileAsync } from './runner'
+import { GIT_CHECK_IGNORE_TIMEOUT_MS } from '../../shared/git-check-ignore-stdio'
 
 vi.mock('./runner', () => ({
   gitExecFileAsync: vi.fn()
@@ -14,29 +15,43 @@ describe('checkIgnoredPaths', () => {
   })
 
   it('returns ignored paths from git check-ignore output', async () => {
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'dist/bundle.js\n.env\n', stderr: '' })
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'dist/bundle.js\0.env\0', stderr: '' })
 
     await expect(
       checkIgnoredPaths('/repo', ['dist/bundle.js', 'src/index.ts', '.env'])
     ).resolves.toEqual(['dist/bundle.js', '.env'])
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        '-c',
-        'core.quotePath=false',
-        'check-ignore',
-        '--',
-        'dist/bundle.js',
-        'src/index.ts',
-        '.env'
-      ],
-      { cwd: '/repo' }
+      ['-c', 'core.quotePath=false', 'check-ignore', '-z', '--stdin'],
+      {
+        cwd: '/repo',
+        stdin: 'dist/bundle.js\0src/index.ts\0.env\0',
+        timeout: GIT_CHECK_IGNORE_TIMEOUT_MS
+      }
     )
+  })
+
+  it('checks ten thousand paths with one bounded subprocess', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+    const paths = Array.from({ length: 10_000 }, (_, index) => `generated/file-${index}.js`)
+
+    await expect(checkIgnoredPaths('/repo', paths)).resolves.toEqual([])
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock.mock.calls[0]?.[1]).toMatchObject({
+      timeout: GIT_CHECK_IGNORE_TIMEOUT_MS
+    })
+    expect(gitExecFileAsyncMock.mock.calls[0]?.[1].stdin?.split('\0')).toHaveLength(10_001)
   })
 
   it('treats exit code 1 as no ignored paths', async () => {
     gitExecFileAsyncMock.mockRejectedValue(Object.assign(new Error('no matches'), { code: 1 }))
 
     await expect(checkIgnoredPaths('/repo', ['src/index.ts'])).resolves.toEqual([])
+  })
+
+  it('skips the subprocess for an empty path list', async () => {
+    await expect(checkIgnoredPaths('/repo', [])).resolves.toEqual([])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/git/check-ignored-paths.ts
+++ b/src/main/git/check-ignored-paths.ts
@@ -1,30 +1,32 @@
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 import { gitExecFileAsync } from './runner'
-
-const CHECK_IGNORE_CHUNK_SIZE = 100
+import {
+  encodeGitCheckIgnorePaths,
+  GIT_CHECK_IGNORE_STDIN_ARGS,
+  GIT_CHECK_IGNORE_TIMEOUT_MS,
+  parseGitCheckIgnorePaths,
+  splitGitCheckIgnorePathsByStdinBytes
+} from '../../shared/git-check-ignore-stdio'
 
 type GitExecError = Error & { stdout?: string; code?: number | string }
 
-function parseCheckIgnoreOutput(stdout: string): string[] {
-  return stdout.split(/\r?\n/).filter(Boolean)
-}
-
-async function runCheckIgnoreChunk(
+async function runCheckIgnoredPaths(
   worktreePath: string,
   relativePaths: string[],
-  options: GitRuntimeOptions = {}
+  options: GitRuntimeOptions
 ): Promise<string[]> {
   try {
-    const { stdout } = await gitExecFileAsync(
-      ['-c', 'core.quotePath=false', 'check-ignore', '--', ...relativePaths],
-      gitOptionsForWorktree(worktreePath, options)
-    )
-    return parseCheckIgnoreOutput(stdout)
+    const { stdout } = await gitExecFileAsync([...GIT_CHECK_IGNORE_STDIN_ARGS], {
+      ...gitOptionsForWorktree(worktreePath, options),
+      stdin: encodeGitCheckIgnorePaths(relativePaths),
+      timeout: GIT_CHECK_IGNORE_TIMEOUT_MS
+    })
+    return parseGitCheckIgnorePaths(stdout)
   } catch (error) {
     const gitError = error as GitExecError
     if (gitError.code === 1) {
-      return parseCheckIgnoreOutput(gitError.stdout ?? '')
+      return parseGitCheckIgnorePaths(gitError.stdout ?? '')
     }
     throw error
   }
@@ -35,10 +37,12 @@ export async function checkIgnoredPaths(
   relativePaths: string[],
   options: GitRuntimeOptions = {}
 ): Promise<string[]> {
+  if (relativePaths.length === 0) {
+    return []
+  }
   const ignored = new Set<string>()
-  for (let i = 0; i < relativePaths.length; i += CHECK_IGNORE_CHUNK_SIZE) {
-    const chunk = relativePaths.slice(i, i + CHECK_IGNORE_CHUNK_SIZE)
-    for (const ignoredPath of await runCheckIgnoreChunk(worktreePath, chunk, options)) {
+  for (const chunk of splitGitCheckIgnorePathsByStdinBytes(relativePaths)) {
+    for (const ignoredPath of await runCheckIgnoredPaths(worktreePath, chunk, options)) {
       ignored.add(ignoredPath)
     }
   }

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -36,6 +36,7 @@ import {
   quotePosixShell
 } from '../../shared/wsl-login-shell-command'
 import { UNTRANSLATED_GIT_OUTPUT_ENV } from '../../shared/git-output-locale'
+import { endSubprocessStdin } from '../../shared/subprocess-stdin-write'
 
 // ─── Core resolution ────────────────────────────────────────────────
 
@@ -430,7 +431,7 @@ function execFileCapture(
     child.once('error', (error) => finish(error))
 
     if (options.stdin !== undefined) {
-      child.stdin?.end(options.stdin)
+      endSubprocessStdin(child.stdin, options.stdin)
     }
 
     // Why: Node's native execFile timeout waits for the child to exit after

--- a/src/relay/git-handler-check-ignore.test.ts
+++ b/src/relay/git-handler-check-ignore.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitExec } from './git-handler-ops'
+import { checkIgnoredPathsOp } from './git-handler-check-ignore'
+import { GIT_CHECK_IGNORE_TIMEOUT_MS } from '../shared/git-check-ignore-stdio'
+
+describe('checkIgnoredPathsOp', () => {
+  it('passes exact paths over one bounded NUL-delimited stdin invocation', async () => {
+    const git = vi.fn<GitExec>().mockResolvedValue({
+      stdout: 'dist/bundle.js\0line\nbreak.txt\0',
+      stderr: ''
+    })
+
+    await expect(
+      checkIgnoredPathsOp(git, {
+        worktreePath: '/repo',
+        paths: ['dist/bundle.js', 'line\nbreak.txt', 'src/index.ts']
+      })
+    ).resolves.toEqual(['dist/bundle.js', 'line\nbreak.txt'])
+
+    expect(git).toHaveBeenCalledWith(
+      ['-c', 'core.quotePath=false', 'check-ignore', '-z', '--stdin'],
+      '/repo',
+      {
+        stdin: 'dist/bundle.js\0line\nbreak.txt\0src/index.ts\0',
+        timeout: GIT_CHECK_IGNORE_TIMEOUT_MS
+      }
+    )
+  })
+
+  it('treats git exit code 1 as no ignored paths', async () => {
+    const noMatches = Object.assign(new Error('no ignored paths'), {
+      code: 1,
+      stdout: ''
+    })
+    const git = vi.fn<GitExec>().mockRejectedValue(noMatches)
+
+    await expect(
+      checkIgnoredPathsOp(git, {
+        worktreePath: '/repo',
+        paths: ['src/index.ts']
+      })
+    ).resolves.toEqual([])
+  })
+})

--- a/src/relay/git-handler-check-ignore.ts
+++ b/src/relay/git-handler-check-ignore.ts
@@ -1,0 +1,35 @@
+import type { GitExec } from './git-handler-ops'
+import {
+  encodeGitCheckIgnorePaths,
+  GIT_CHECK_IGNORE_STDIN_ARGS,
+  GIT_CHECK_IGNORE_TIMEOUT_MS,
+  parseGitCheckIgnorePaths,
+  splitGitCheckIgnorePathsByStdinBytes
+} from '../shared/git-check-ignore-stdio'
+
+export async function checkIgnoredPathsOp(
+  git: GitExec,
+  params: Record<string, unknown>
+): Promise<string[]> {
+  const worktreePath = params.worktreePath as string
+  const paths = Array.isArray(params.paths)
+    ? params.paths.filter((path): path is string => typeof path === 'string' && path.length > 0)
+    : []
+  const ignored: string[] = []
+  for (const chunk of splitGitCheckIgnorePathsByStdinBytes(paths)) {
+    try {
+      const { stdout } = await git([...GIT_CHECK_IGNORE_STDIN_ARGS], worktreePath, {
+        stdin: encodeGitCheckIgnorePaths(chunk),
+        timeout: GIT_CHECK_IGNORE_TIMEOUT_MS
+      })
+      ignored.push(...parseGitCheckIgnorePaths(stdout))
+    } catch (error) {
+      const gitError = error as Error & { code?: number | string; stdout?: string }
+      if (gitError.code !== 1) {
+        throw error
+      }
+      ignored.push(...parseGitCheckIgnorePaths(gitError.stdout ?? ''))
+    }
+  }
+  return ignored
+}

--- a/src/relay/git-handler-ops.ts
+++ b/src/relay/git-handler-ops.ts
@@ -16,7 +16,7 @@ import { readWorkingDiffFile } from './git-working-file-read'
 export type GitExec = (
   args: string[],
   cwd: string,
-  opts?: { maxBuffer?: number; disableOptionalLocks?: boolean; stdin?: string }
+  opts?: { maxBuffer?: number; disableOptionalLocks?: boolean; stdin?: string; timeout?: number }
 ) => Promise<{ stdout: string; stderr: string }>
 
 export type GitBufferExec = (args: string[], cwd: string) => Promise<Buffer>

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -249,34 +249,3 @@ function shouldProbeEffectiveUpstreamStatus(
   const parsed = splitRemoteBranchName(upstreamName)
   return parsed?.remoteName === 'origin' && parsed.branchName !== branchName
 }
-
-function parseCheckIgnoreOutput(stdout: string): string[] {
-  return stdout.split(/\r?\n/).filter(Boolean)
-}
-
-export async function checkIgnoredPathsOp(
-  git: GitExec,
-  params: Record<string, unknown>
-): Promise<string[]> {
-  const worktreePath = params.worktreePath as string
-  const paths = Array.isArray(params.paths)
-    ? params.paths.filter((path): path is string => typeof path === 'string' && path.length > 0)
-    : []
-  if (paths.length === 0) {
-    return []
-  }
-
-  try {
-    const { stdout } = await git(
-      ['-c', 'core.quotePath=false', 'check-ignore', '--', ...paths],
-      worktreePath
-    )
-    return parseCheckIgnoreOutput(stdout)
-  } catch (error) {
-    const gitError = error as Error & { code?: number | string; stdout?: string }
-    if (gitError.code === 1) {
-      return parseCheckIgnoreOutput(gitError.stdout ?? '')
-    }
-    throw error
-  }
-}

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -39,7 +39,8 @@ import {
 } from './git-handler-worktree-ops'
 import { forceDeletePreservedRelayBranch } from './git-handler-branch-cleanup'
 import { refreshLocalBaseRefForWorktreeCreateOp } from './git-handler-local-base-ref-refresh'
-import { checkIgnoredPathsOp, detectConflictOperation, getStatusOp } from './git-handler-status-ops'
+import { detectConflictOperation, getStatusOp } from './git-handler-status-ops'
+import { checkIgnoredPathsOp } from './git-handler-check-ignore'
 import { resolveRelayPushTarget } from './git-handler-push-target'
 import { isNoUpstreamError, normalizeGitErrorMessage } from '../shared/git-remote-error'
 import { upstreamOnlyCommitsArePatchEquivalent } from '../shared/git-upstream-status'
@@ -304,6 +305,7 @@ export class GitHandler {
       signal?: AbortSignal
       nonInteractive?: boolean
       stdin?: string
+      timeout?: number
     }
   ): Promise<{ stdout: string; stderr: string }> {
     const env = buildRelayGitEnv()
@@ -321,6 +323,7 @@ export class GitHandler {
       env,
       encoding: 'utf-8',
       maxBuffer: opts?.maxBuffer ?? MAX_GIT_BUFFER,
+      timeout: opts?.timeout,
       signal: opts?.signal
     } satisfies ExecFileOptions
     if (opts?.stdin !== undefined) {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -64,6 +64,7 @@ import { InFlightPromiseDedupe, stableInFlightKey } from '../shared/in-flight-pr
 import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../shared/git-fetch-auto-maintenance'
 import { GitResponseStreamRegistry } from './git-response-stream'
 import { GIT_RESPONSE_STREAM_THRESHOLD } from './protocol'
+import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
@@ -167,7 +168,7 @@ function execFileWithStdin(
       finish(null, stdout, stderr)
     })
     child.once('error', (error) => finish(error))
-    child.stdin?.end(stdin)
+    endSubprocessStdin(child.stdin, stdin)
   })
 }
 

--- a/src/renderer/src/components/right-sidebar/file-explorer-runtime-owner-boundary.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-runtime-owner-boundary.test.ts
@@ -15,7 +15,7 @@ describe('right sidebar file/git runtime ownership boundaries', () => {
     'src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts',
     'src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts',
     'src/renderer/src/components/right-sidebar/useFileDuplicate.ts',
-    'src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts',
+    'src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts',
     'src/renderer/src/components/right-sidebar/useGitStatusPolling.ts',
     'src/renderer/src/components/right-sidebar/useFileSearchRunner.ts',
     'src/renderer/src/components/quick-open-file-list.ts'

--- a/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts
+++ b/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react'
+import { getConnectionId } from '@/lib/connection-context'
+import { getRuntimeGitIgnoredPaths } from '@/runtime/runtime-git-client'
+import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-owner'
+
+const EMPTY_IGNORED_PATHS: readonly string[] = []
+export const FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS = 300
+
+export type IgnoredPathResult = {
+  activeWorktreeId: string
+  paths: string[]
+  worktreePath: string
+}
+
+export function getEffectiveFileExplorerIgnoredPaths({
+  activeWorktreeId,
+  canLoadIgnoredPaths,
+  ignoredPathResult,
+  worktreePath
+}: {
+  activeWorktreeId: string | null
+  canLoadIgnoredPaths: boolean
+  ignoredPathResult: IgnoredPathResult | null
+  worktreePath: string | null
+}): readonly string[] {
+  const ignoredPathResultMatchesCurrentWorktree =
+    ignoredPathResult !== null &&
+    ignoredPathResult.activeWorktreeId === activeWorktreeId &&
+    ignoredPathResult.worktreePath === worktreePath
+
+  if (!canLoadIgnoredPaths || !ignoredPathResultMatchesCurrentWorktree) {
+    return EMPTY_IGNORED_PATHS
+  }
+
+  // Why: expanding folders changes the query before the async ignored refresh returns.
+  // Keep same-worktree answers so known ignored rows do not flash as normal text.
+  return ignoredPathResult.paths
+}
+
+export function useFileExplorerIgnoredPaths({
+  activeWorktreeId,
+  canLoadIgnoredPaths,
+  relativePaths,
+  shouldDebounceIgnoredQuery,
+  worktreePath
+}: {
+  activeWorktreeId: string | null
+  canLoadIgnoredPaths: boolean
+  relativePaths: readonly string[]
+  shouldDebounceIgnoredQuery: boolean
+  worktreePath: string | null
+}): readonly string[] {
+  const [ignoredPathResult, setIgnoredPathResult] = useState<IgnoredPathResult | null>(null)
+
+  useEffect(() => {
+    if (!canLoadIgnoredPaths || !activeWorktreeId || !worktreePath) {
+      return
+    }
+
+    let canceled = false
+    const refresh = (): void => {
+      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      void getRuntimeGitIgnoredPaths(
+        {
+          settings: getRightSidebarWorktreeRuntimeSettings(activeWorktreeId),
+          worktreeId: activeWorktreeId,
+          worktreePath,
+          connectionId
+        },
+        [...relativePaths]
+      )
+        .then((paths) => {
+          if (!canceled) {
+            setIgnoredPathResult({ activeWorktreeId, paths, worktreePath })
+          }
+        })
+        .catch(() => {
+          if (!canceled) {
+            setIgnoredPathResult({ activeWorktreeId, paths: [], worktreePath })
+          }
+        })
+    }
+
+    // Why: every filter keystroke changes relativePaths. Waiting for a short
+    // quiet window prevents obsolete queries from launching uncancellable Git
+    // subprocess chains while the visible name projection stays immediate.
+    const timer = shouldDebounceIgnoredQuery
+      ? window.setTimeout(refresh, FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS)
+      : null
+    if (timer === null) {
+      refresh()
+    }
+
+    return () => {
+      canceled = true
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [
+    activeWorktreeId,
+    canLoadIgnoredPaths,
+    relativePaths,
+    shouldDebounceIgnoredQuery,
+    worktreePath
+  ])
+
+  return getEffectiveFileExplorerIgnoredPaths({
+    activeWorktreeId,
+    canLoadIgnoredPaths,
+    ignoredPathResult,
+    worktreePath
+  })
+}

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.debounce.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.debounce.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import { useFileExplorerVisibleRowProjection } from './useFileExplorerVisibleRowProjection'
+import { FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS } from './use-file-explorer-ignored-paths'
+
+const getRuntimeGitIgnoredPathsMock = vi.hoisted(() => vi.fn())
+vi.mock('@/runtime/runtime-git-client', () => ({
+  getRuntimeGitIgnoredPaths: getRuntimeGitIgnoredPathsMock
+}))
+
+const initialAppState = useAppStore.getInitialState()
+const relativePaths = Array.from({ length: 5_000 }, (_, index) => `src/generated-${index}.ts`)
+
+function useProjection(query: string) {
+  return useFileExplorerVisibleRowProjection('worktree-1', '/repo', {}, new Set(), true, true, {
+    query,
+    relativePaths
+  })
+}
+
+function useTreeProjection() {
+  return useFileExplorerVisibleRowProjection(
+    'worktree-1',
+    '/repo',
+    {
+      '/repo': {
+        children: [
+          {
+            name: 'src',
+            path: '/repo/src',
+            relativePath: 'src',
+            isDirectory: true,
+            depth: 0
+          }
+        ],
+        loading: false
+      }
+    },
+    new Set(),
+    true,
+    true,
+    null
+  )
+}
+
+describe('file explorer ignored-path query debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    getRuntimeGitIgnoredPathsMock.mockReset().mockResolvedValue([])
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState(initialAppState, true)
+    vi.useRealTimers()
+  })
+
+  it('coalesces a broad typing burst into one final ignored-path request', async () => {
+    const hook = renderHook(({ query }) => useProjection(query), {
+      initialProps: { query: 's' }
+    })
+
+    await act(async () => vi.advanceTimersByTimeAsync(100))
+    hook.rerender({ query: 'sr' })
+    await act(async () => vi.advanceTimersByTimeAsync(100))
+    hook.rerender({ query: 'src' })
+
+    await act(async () => vi.advanceTimersByTimeAsync(FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS - 1))
+    expect(getRuntimeGitIgnoredPathsMock).not.toHaveBeenCalled()
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(1)
+    expect(getRuntimeGitIgnoredPathsMock.mock.calls[0]?.[1]).toHaveLength(relativePaths.length)
+  })
+
+  it('cancels the pending ignored-path request when the explorer unmounts', async () => {
+    const hook = renderHook(() => useProjection('src'))
+    hook.unmount()
+
+    await act(async () => vi.advanceTimersByTimeAsync(FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS))
+    expect(getRuntimeGitIgnoredPathsMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps ordinary expanded-tree ignored checks immediate', () => {
+    renderHook(() => useTreeProjection())
+
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(1)
+    expect(getRuntimeGitIgnoredPathsMock.mock.calls[0]?.[1]).toEqual(['src'])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
@@ -2,9 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { DirCache, TreeNode } from './file-explorer-types'
 import {
   createVisibleFileExplorerRowProjection,
-  getEffectiveFileExplorerIgnoredPaths,
   getFileExplorerIgnoredQueryRelativePaths
 } from './useFileExplorerVisibleRowProjection'
+import { getEffectiveFileExplorerIgnoredPaths } from './use-file-explorer-ignored-paths'
 import {
   FILE_EXPLORER_NAME_FILTER_QUERY_MAX_BYTES,
   getFileExplorerNameFilterExpandedPaths,
@@ -336,8 +336,6 @@ describe('file explorer visible row projection', () => {
   })
 
   it('keeps same-worktree ignored paths while an expanded-folder query is loading', () => {
-    const previousRelativePaths = ['out', 'src']
-
     expect(
       getEffectiveFileExplorerIgnoredPaths({
         activeWorktreeId: 'worktree-1',
@@ -345,7 +343,6 @@ describe('file explorer visible row projection', () => {
         ignoredPathResult: {
           activeWorktreeId: 'worktree-1',
           paths: ['out'],
-          relativePaths: previousRelativePaths,
           worktreePath: '/repo'
         },
         worktreePath: '/repo'
@@ -372,7 +369,6 @@ describe('file explorer visible row projection', () => {
         ignoredPathResult: {
           activeWorktreeId: 'worktree-1',
           paths: ['out'],
-          relativePaths: ['out'],
           worktreePath: '/repo'
         },
         worktreePath: '/repo'
@@ -386,7 +382,6 @@ describe('file explorer visible row projection', () => {
         ignoredPathResult: {
           activeWorktreeId: 'worktree-1',
           paths: ['out'],
-          relativePaths: ['out'],
           worktreePath: '/repo'
         },
         worktreePath: '/other-repo'

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
@@ -1,8 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useAppStore } from '@/store'
-import { getConnectionId } from '@/lib/connection-context'
-import { getRuntimeGitIgnoredPaths } from '@/runtime/runtime-git-client'
-import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-owner'
 import { isDotfileRelativePath } from './file-explorer-entries'
 import type { DirCache, TreeNode } from './file-explorer-types'
 import {
@@ -16,16 +13,9 @@ import {
   getFileExplorerNameFilterIgnoredQueryRelativePaths,
   type FileExplorerNameFilterProjectionSource
 } from './file-explorer-name-filter-projection'
+import { useFileExplorerIgnoredPaths } from './use-file-explorer-ignored-paths'
 
-const EMPTY_IGNORED_PATHS: readonly string[] = []
 const EMPTY_RELATIVE_PATHS: string[] = []
-
-export type IgnoredPathResult = {
-  activeWorktreeId: string
-  paths: string[]
-  relativePaths: readonly string[]
-  worktreePath: string
-}
 
 type VisibleFileExplorerRowProjectionOptions = {
   ignoredSet: Set<string>
@@ -119,31 +109,6 @@ export function createVisibleFileExplorerRowProjection(
   return createFileExplorerRowProjectionFromParts(visibleFlatRows, rowsByPath)
 }
 
-export function getEffectiveFileExplorerIgnoredPaths({
-  activeWorktreeId,
-  canLoadIgnoredPaths,
-  ignoredPathResult,
-  worktreePath
-}: {
-  activeWorktreeId: string | null
-  canLoadIgnoredPaths: boolean
-  ignoredPathResult: IgnoredPathResult | null
-  worktreePath: string | null
-}): readonly string[] {
-  const ignoredPathResultMatchesCurrentWorktree =
-    ignoredPathResult !== null &&
-    ignoredPathResult.activeWorktreeId === activeWorktreeId &&
-    ignoredPathResult.worktreePath === worktreePath
-
-  if (!canLoadIgnoredPaths || !ignoredPathResultMatchesCurrentWorktree) {
-    return EMPTY_IGNORED_PATHS
-  }
-
-  // Why: expanding folders changes the query before the async ignored refresh returns.
-  // Keep same-worktree answers so known ignored rows do not flash as normal text.
-  return ignoredPathResult.paths
-}
-
 export function useFileExplorerVisibleRowProjection(
   activeWorktreeId: string | null,
   worktreePath: string | null,
@@ -163,7 +128,6 @@ export function useFileExplorerVisibleRowProjection(
   const settings = useAppStore((s) => s.settings)
   const updateSettings = useAppStore((s) => s.updateSettings)
   const showGitIgnoredFiles = settings?.showGitIgnoredFiles ?? true
-  const [ignoredPathResult, setIgnoredPathResult] = useState<IgnoredPathResult | null>(null)
   const relativePaths = useMemo(
     () =>
       activeRepoSupportsGit
@@ -181,53 +145,12 @@ export function useFileExplorerVisibleRowProjection(
     Boolean(activeWorktreeId) &&
     Boolean(worktreePath) &&
     relativePaths.length > 0
-
-  useEffect(() => {
-    if (!canLoadIgnoredPaths || !activeWorktreeId || !worktreePath) {
-      return
-    }
-
-    let canceled = false
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-    void getRuntimeGitIgnoredPaths(
-      {
-        settings: getRightSidebarWorktreeRuntimeSettings(activeWorktreeId),
-        worktreeId: activeWorktreeId,
-        worktreePath,
-        connectionId
-      },
-      [...relativePaths]
-    )
-      .then((nextIgnoredPaths) => {
-        if (!canceled) {
-          setIgnoredPathResult({
-            activeWorktreeId,
-            paths: nextIgnoredPaths,
-            relativePaths,
-            worktreePath
-          })
-        }
-      })
-      .catch(() => {
-        if (!canceled) {
-          setIgnoredPathResult({
-            activeWorktreeId,
-            paths: [],
-            relativePaths,
-            worktreePath
-          })
-        }
-      })
-
-    return () => {
-      canceled = true
-    }
-  }, [activeWorktreeId, canLoadIgnoredPaths, relativePaths, worktreePath])
-
-  const effectiveIgnoredPaths = getEffectiveFileExplorerIgnoredPaths({
+  const shouldDebounceIgnoredQuery = nameFilter !== null
+  const effectiveIgnoredPaths = useFileExplorerIgnoredPaths({
     activeWorktreeId,
     canLoadIgnoredPaths,
-    ignoredPathResult,
+    relativePaths,
+    shouldDebounceIgnoredQuery,
     worktreePath
   })
   const ignoredSet = useMemo(() => buildIgnoredSet(effectiveIgnoredPaths), [effectiveIgnoredPaths])

--- a/src/shared/git-check-ignore-stdio.test.ts
+++ b/src/shared/git-check-ignore-stdio.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  encodeGitCheckIgnorePaths,
+  GIT_CHECK_IGNORE_STDIN_ARGS,
+  parseGitCheckIgnorePaths,
+  splitGitCheckIgnorePathsByStdinBytes
+} from './git-check-ignore-stdio'
+
+describe('git check-ignore stdio', () => {
+  it('uses the NUL-delimited stdin command shape', () => {
+    expect(GIT_CHECK_IGNORE_STDIN_ARGS).toEqual([
+      '-c',
+      'core.quotePath=false',
+      'check-ignore',
+      '-z',
+      '--stdin'
+    ])
+    expect(encodeGitCheckIgnorePaths(['dist/bundle.js', 'line\nbreak.txt', '-leading.txt'])).toBe(
+      'dist/bundle.js\0line\nbreak.txt\0-leading.txt\0'
+    )
+  })
+
+  it('parses exact paths without treating embedded newlines as records', () => {
+    expect(parseGitCheckIgnorePaths('dist/bundle.js\0line\nbreak.txt\0-leading.txt\0')).toEqual([
+      'dist/bundle.js',
+      'line\nbreak.txt',
+      '-leading.txt'
+    ])
+  })
+
+  it('bounds stdin chunks by encoded bytes without splitting a path', () => {
+    expect(splitGitCheckIgnorePathsByStdinBytes(['abcd', 'efgh', 'ijk'], 10)).toEqual([
+      ['abcd', 'efgh'],
+      ['ijk']
+    ])
+    expect(splitGitCheckIgnorePathsByStdinBytes(['éé', 'a'], 5)).toEqual([['éé'], ['a']])
+  })
+})

--- a/src/shared/git-check-ignore-stdio.ts
+++ b/src/shared/git-check-ignore-stdio.ts
@@ -1,0 +1,42 @@
+export const GIT_CHECK_IGNORE_TIMEOUT_MS = 15_000
+export const GIT_CHECK_IGNORE_STDIN_CHUNK_BYTES = 1024 * 1024
+
+export const GIT_CHECK_IGNORE_STDIN_ARGS = [
+  '-c',
+  'core.quotePath=false',
+  'check-ignore',
+  '-z',
+  '--stdin'
+] as const
+
+export function encodeGitCheckIgnorePaths(paths: readonly string[]): string {
+  return `${paths.join('\0')}\0`
+}
+
+export function splitGitCheckIgnorePathsByStdinBytes(
+  paths: readonly string[],
+  maxBytes: number = GIT_CHECK_IGNORE_STDIN_CHUNK_BYTES
+): string[][] {
+  const encoder = new TextEncoder()
+  const chunks: string[][] = []
+  let chunk: string[] = []
+  let chunkBytes = 0
+  for (const path of paths) {
+    const pathBytes = encoder.encode(path).byteLength + 1
+    if (chunk.length > 0 && chunkBytes + pathBytes > maxBytes) {
+      chunks.push(chunk)
+      chunk = []
+      chunkBytes = 0
+    }
+    chunk.push(path)
+    chunkBytes += pathBytes
+  }
+  if (chunk.length > 0) {
+    chunks.push(chunk)
+  }
+  return chunks
+}
+
+export function parseGitCheckIgnorePaths(stdout: string): string[] {
+  return stdout.split('\0').filter((path) => path.length > 0)
+}

--- a/src/shared/subprocess-stdin-write.test.ts
+++ b/src/shared/subprocess-stdin-write.test.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from 'node:events'
+import type { Writable } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import { endSubprocessStdin } from './subprocess-stdin-write'
+
+describe('endSubprocessStdin', () => {
+  it('handles an early-exit pipe error emitted while ending a large write', () => {
+    const pipeError = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+    const stdin = new EventEmitter() as Writable
+    stdin.end = vi.fn(() => {
+      stdin.emit('error', pipeError)
+      return stdin
+    }) as Writable['end']
+    expect(() => endSubprocessStdin(stdin, 'x'.repeat(1_000_000))).not.toThrow()
+
+    expect(stdin.listenerCount('error')).toBe(0)
+  })
+
+  it('keeps the error handler attached for a pipe failure after the caller times out', () => {
+    const stdin = new EventEmitter() as Writable
+    stdin.end = vi.fn(() => stdin) as Writable['end']
+    endSubprocessStdin(stdin, 'payload')
+    expect(stdin.listenerCount('error')).toBe(1)
+
+    const pipeError = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+    expect(() => stdin.emit('error', pipeError)).not.toThrow()
+
+    expect(stdin.listenerCount('error')).toBe(0)
+  })
+})

--- a/src/shared/subprocess-stdin-write.ts
+++ b/src/shared/subprocess-stdin-write.ts
@@ -1,0 +1,10 @@
+import type { Writable } from 'node:stream'
+
+export function endSubprocessStdin(stdin: Writable | null | undefined, input: string): void {
+  if (!stdin) {
+    return
+  }
+  // Why: early exit or timeout can close a large write; the child callback owns the command result.
+  stdin.once('error', () => {})
+  stdin.end(input)
+}


### PR DESCRIPTION
## Description

File Explorer ignored-path work is reduced at both ends:

- name-filter queries wait for a 300 ms quiet window, so obsolete keystrokes do not launch Git work
- each query sends paths through NUL-delimited `git check-ignore -z --stdin` instead of sequential 100-path argv batches
- stdin payloads are capped at 1 MiB per subprocess and each subprocess has a 15 second timeout
- the same encoding, parsing, chunking, and timeout contract covers local, WSL, runtime, relay, and SSH paths

Visible filename matches still update immediately. Ordinary expanded-tree ignored checks remain immediate.

## Performance evidence

### Proven waste before this change

Every filename-filter keystroke immediately launched an ignored-path request. Local and WSL checks split paths into groups of 100 and awaited one Git process per group. React ignored stale responses, but it could not cancel the already-running process chains.

For 5,000 matching paths:

- one query: 50 sequential Git processes
- typing `s` → `sr` → `src`: 150 Git processes
- after this change: the debounce emits one final request, and the bounded stdin helper emits one Git process

Deterministic tests assert both halves of the 150 → 1 reduction: the three-keystroke burst makes one runtime request, and 10,000 representative paths stay within one bounded Git subprocess.

### Before/after benchmark

Benchmark from the production helper path in this repository with 10,000 ignored paths:

| | Before | After |
| --- | ---: | ---: |
| Sequential Git processes | 100 | 1 |
| Median wall time | 1317.93 ms | 731.21 ms |

That is 44.5% faster, or about 1.8x, for one broad query. The debounce additionally removes whole obsolete query chains during typing.

### Correctness evidence

NUL-delimited input/output preserves filenames that line-based parsing cannot represent safely:

- embedded-newline filename: exact round-trip
- leading-dash filename: treated as path data, not argv
- empty path list: zero subprocesses
- Git exit code 1: preserved as the normal no-match result

Tests also cover UTF-8 byte-aware 1 MiB chunking, stale-response suppression, timer cleanup on unmount, runtime-owner/SSH routing, and immediate ordinary-tree checks.

## ELI5
Previously, typing three letters could hire 150 workers, even though 149 answers were already obsolete. Now Orca waits until typing pauses, puts the paths into one safely sized list, and usually asks one worker once.

## End-user trade-offs / regressions

- During active filename filtering, ignored-file styling or hiding can trail the typed query by up to 300 ms. Filename matches themselves still render immediately.
- A small 100-path check has roughly 3 ms of extra fixed stdin setup in the local comparison. Larger checks win by removing process launches.
- Inputs above 1 MiB intentionally use more than one sequential Git process. This gives up a theoretical single-process result for unusually large requests in exchange for a hard per-process input/memory bound.
- A Git chunk that exceeds 15 seconds now fails to an empty ignored-path result instead of hanging indefinitely. On a severely stalled filesystem, ignored styling may temporarily be absent.

Ordinary tree expansion is not debounced.

## Screenshots

No visual change.

## Testing

- [x] changed-file lint, React Doctor lint, formatting, reliability, and max-lines ratchet passed after rebasing onto current main, which contains the unrelated max-lines fix
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2,570 files and 26,805 tests passed; 3 files / 33 tests skipped
- [ ] `pnpm build` — not run; no build configuration or dependency changes
- [x] Added regression tests for process/request counts, NUL protocol, UTF-8 chunk bounds, newline/leading-dash filenames, empty input, debounce cleanup, ordinary-tree immediacy, and runtime-owner routing

Additional validation:

- focused combined behavior: 6 files / 38 tests passed
- relay, SSH, runtime RPC/client, and Git runner: 24 files / 441 tests passed
- targeted `oxlint`, React Doctor lint, and `oxfmt --check` passed
- `pnpm run check:max-lines-ratchet` passed
- `pnpm run check:reliability-gates` passed
- branch rebased onto current `origin/main@e84a8ddec9`

## AI Review Report

Reviewed the hot path for subprocess fanout, event-loop work, input/output memory bounds, timer cleanup, stale async state, and local/WSL/SSH provider parity.

Cross-platform review covered macOS, Linux, Windows, WSL, and SSH. The implementation uses direct Git argv plus stdin, adds no shell invocation or path-separator assumptions, and preserves existing runtime-owner routing. React review confirmed that the effect is appropriate external Git synchronization, clears pending timers, ignores responses after dependency changes or unmount, and does not delay ordinary tree navigation.

The review found and addressed:

- the extracted request hook needed the runtime-owner boundary test to follow the new file
- ordinary expanded-tree checks needed an explicit immediate-execution assertion
- unbounded single-process stdin was rejected in favor of the existing 1 MiB byte-aware chunk design
- the small-request timing cost and 15-second timeout behavior are disclosed above

## Security Audit

No new dependency, authentication, secret, or network surface.

Relative paths still pass through existing IPC/runtime validation. Git is executed directly without `shell: true`; moving path data from argv to NUL-delimited stdin reduces argument-length, quoting, and leading-dash risk. NUL-delimited output prevents embedded newlines from becoming record boundaries. The 1 MiB stdin cap and 15-second timeout bound subprocess resource use. The same contract applies in the SSH relay.

## Notes

Electron was not launched for this validation because disposable branch identities currently trigger repeated macOS safe-storage dialogs. Hook, runtime, relay, and full-suite tests provide behavioral evidence without another prompt.