### PR TITLE
perf(renderer): scope editor draft subscriptions by panel

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { getConnectionId } from '@/lib/connection-context'
 import { detectLanguage } from '@/lib/language-detect'
@@ -22,6 +22,7 @@ import {
   selectEditorPanelGitBranchEntries,
   selectEditorPanelGitStatusEntries
 } from './editor-panel-git-entry-selector'
+import { createEditorPanelDraftSelector } from './editor-panel-draft-selector'
 
 function EditorPanelInner({
   activeFileId: activeFileIdProp,
@@ -60,7 +61,11 @@ function EditorPanelInner({
   const setMarkdownTableOfContentsVisible = useAppStore((s) => s.setMarkdownTableOfContentsVisible)
   const closeFile = useAppStore((s) => s.closeFile)
   const clearUntitled = useAppStore((s) => s.clearUntitled)
-  const editorDrafts = useAppStore((s) => s.editorDrafts)
+  const editorDraftSelector = useMemo(
+    () => createEditorPanelDraftSelector(activeFile),
+    [activeFile]
+  )
+  const editorDrafts = useAppStore(editorDraftSelector)
   const setEditorDraft = useAppStore((s) => s.setEditorDraft)
   const settings = useAppStore((s) => s.settings)
   const panelRef = useRef<HTMLDivElement>(null)

--- a/src/renderer/src/components/editor/editor-panel-draft-selector.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-draft-selector.test.ts
@@ -75,4 +75,35 @@ describe('createEditorPanelDraftSelector', () => {
     })
     expect(selectNoDrafts({ editorDrafts })).toEqual({})
   })
+
+  it('includes overview conflict drafts and ignores unrelated draft replacements', () => {
+    const conflictReview = makeFile('review', {
+      filePath: 'C:\\repo',
+      mode: 'conflict-review',
+      conflictReview: {
+        source: 'live-summary',
+        snapshotTimestamp: 1,
+        entries: [
+          { path: 'src/a.ts', conflictKind: 'both_modified' },
+          { path: 'src\\b.ts', conflictKind: 'both_modified' }
+        ]
+      }
+    })
+    const selectDrafts = createEditorPanelDraftSelector(conflictReview)
+    const editorDrafts = {
+      'C:\\repo\\src\\a.ts': 'draft a',
+      'C:\\repo\\src\\b.ts': '',
+      unrelated: 'other draft'
+    }
+
+    const selection = selectDrafts({ editorDrafts })
+    expect(selection).toEqual({
+      'C:\\repo\\src\\a.ts': 'draft a',
+      'C:\\repo\\src\\b.ts': ''
+    })
+
+    expect(
+      selectDrafts({ editorDrafts: { ...editorDrafts, unrelated: 'changed elsewhere' } })
+    ).toBe(selection)
+  })
 })

--- a/src/renderer/src/components/editor/editor-panel-draft-selector.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-draft-selector.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import { createEditorPanelDraftSelector } from './editor-panel-draft-selector'
+
+function makeFile(id: string, overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id,
+    filePath: `/repo/${id}.ts`,
+    relativePath: `${id}.ts`,
+    worktreeId: 'worktree-1',
+    language: 'typescript',
+    mode: 'edit',
+    isDirty: false,
+    ...overrides
+  }
+}
+
+describe('createEditorPanelDraftSelector', () => {
+  it('limits draft invalidations to the panel that owns each keystroke', () => {
+    const files = Array.from({ length: 200 }, (_, index) => makeFile(`file-${index}`))
+    let editorDrafts: Record<string, string> = {}
+    let wholeMapInvalidations = 0
+    let scopedInvalidations = 0
+    let unrelatedPanelInvalidations = 0
+    const selectors = files.map(createEditorPanelDraftSelector)
+    const previousSelections = selectors.map((selector) => selector({ editorDrafts }))
+
+    for (let edit = 0; edit < 200; edit += 1) {
+      const previousDrafts = editorDrafts
+      editorDrafts = { ...editorDrafts, 'file-0': `edit-${edit}` }
+      for (let panelIndex = 0; panelIndex < files.length; panelIndex += 1) {
+        if (previousDrafts !== editorDrafts) {
+          wholeMapInvalidations += 1
+        }
+        const nextSelection = selectors[panelIndex]({ editorDrafts })
+        if (previousSelections[panelIndex] !== nextSelection) {
+          scopedInvalidations += 1
+          if (panelIndex !== 0) {
+            unrelatedPanelInvalidations += 1
+          }
+          previousSelections[panelIndex] = nextSelection
+        }
+      }
+    }
+
+    expect(wholeMapInvalidations).toBe(40_000)
+    expect(scopedInvalidations).toBe(200)
+    expect(unrelatedPanelInvalidations).toBe(0)
+  })
+
+  it('includes preview and selected conflict-review drafts but excludes unrelated files', () => {
+    const preview = makeFile('preview', { markdownPreviewSourceFileId: 'source' })
+    const conflictReview = makeFile('review', {
+      mode: 'conflict-review',
+      conflictReview: { selectedFileId: 'selected' } as NonNullable<OpenFile['conflictReview']>
+    })
+    const editorDrafts = {
+      preview: 'preview draft',
+      source: '',
+      review: 'review draft',
+      selected: 'selected draft',
+      unrelated: 'other draft'
+    }
+    const selectPreviewDrafts = createEditorPanelDraftSelector(preview)
+    const selectConflictDrafts = createEditorPanelDraftSelector(conflictReview)
+    const selectNoDrafts = createEditorPanelDraftSelector(null)
+
+    expect(selectPreviewDrafts({ editorDrafts })).toEqual({
+      preview: 'preview draft',
+      source: ''
+    })
+    expect(selectConflictDrafts({ editorDrafts })).toEqual({
+      review: 'review draft',
+      selected: 'selected draft'
+    })
+    expect(selectNoDrafts({ editorDrafts })).toEqual({})
+  })
+})

--- a/src/renderer/src/components/editor/editor-panel-draft-selector.ts
+++ b/src/renderer/src/components/editor/editor-panel-draft-selector.ts
@@ -1,4 +1,5 @@
 import type { AppState } from '@/store'
+import { joinPath } from '@/lib/path'
 import type { OpenFile } from '@/store/slices/editor'
 
 type EditorDraftState = Pick<AppState, 'editorDrafts'>
@@ -17,7 +18,12 @@ export function createEditorPanelDraftSelector(
           [
             activeFile.id,
             activeFile.markdownPreviewSourceFileId,
-            activeFile.conflictReview?.selectedFileId
+            activeFile.conflictReview?.selectedFileId,
+            ...(activeFile.mode === 'conflict-review' && !activeFile.conflictReview?.selectedFileId
+              ? (activeFile.conflictReview?.entries ?? []).map((entry) =>
+                  joinPath(activeFile.filePath, entry.path)
+                )
+              : [])
           ].filter((fileId): fileId is string => Boolean(fileId))
         )
       )

--- a/src/renderer/src/components/editor/editor-panel-draft-selector.ts
+++ b/src/renderer/src/components/editor/editor-panel-draft-selector.ts
@@ -1,0 +1,57 @@
+import type { AppState } from '@/store'
+import type { OpenFile } from '@/store/slices/editor'
+
+type EditorDraftState = Pick<AppState, 'editorDrafts'>
+type EditorPanelDraftSelector = (state: EditorDraftState) => Record<string, string>
+
+const EMPTY_EDITOR_PANEL_DRAFTS = Object.freeze({}) as Record<string, string>
+
+export function createEditorPanelDraftSelector(
+  activeFile: OpenFile | null
+): EditorPanelDraftSelector {
+  // Why: previews and conflict review can render a related file, but drafts
+  // from every other panel must not wake this editor on each keystroke.
+  const fileIds = activeFile
+    ? Array.from(
+        new Set(
+          [
+            activeFile.id,
+            activeFile.markdownPreviewSourceFileId,
+            activeFile.conflictReview?.selectedFileId
+          ].filter((fileId): fileId is string => Boolean(fileId))
+        )
+      )
+    : []
+  let previousDrafts: AppState['editorDrafts'] | null = null
+  let previousSelection = EMPTY_EDITOR_PANEL_DRAFTS
+
+  return (state) => {
+    // Why: every Zustand write reruns the selector. The slice identity guard
+    // keeps unrelated terminal/status traffic allocation-free.
+    if (previousDrafts === state.editorDrafts) {
+      return previousSelection
+    }
+    previousDrafts = state.editorDrafts
+
+    const changed = fileIds.some((fileId) => {
+      const draft = state.editorDrafts[fileId]
+      return (
+        draft !== previousSelection[fileId] ||
+        (draft === undefined && Object.prototype.hasOwnProperty.call(previousSelection, fileId))
+      )
+    })
+    if (!changed) {
+      return previousSelection
+    }
+
+    const nextSelection: Record<string, string> = {}
+    for (const fileId of fileIds) {
+      const draft = state.editorDrafts[fileId]
+      if (draft !== undefined) {
+        nextSelection[fileId] = draft
+      }
+    }
+    previousSelection = nextSelection
+    return previousSelection
+  }
+}


### PR DESCRIPTION
Part of the repository-wide performance audit requested after #7545.

## Summary

`setEditorDraft` replaces the immutable `editorDrafts` map as editor content changes. Every mounted `EditorPanel` subscribed to that whole map, so typing in one split pane caused every other Monaco, rich Markdown, diff, preview, and conflict-review panel to pass the Zustand identity check and render again.

This PR gives each panel a memoized selector for only the draft IDs it can render:

- its active file
- the source file behind a Markdown preview
- the selected file inside conflict review

Unrelated draft changes return the exact previous selection reference. Unrelated store writes exit on the unchanged `editorDrafts` slice identity without allocating.

## Performance evidence

The committed deterministic fixture models 200 mounted panels and 200 edits owned by one panel:

| | Before | After |
| --- | ---: | ---: |
| Whole/scoped selector invalidations | 40,000 | 200 |
| Invalidations in unrelated panels | 39,800 | 0 |

For an ordinary split with N editor panels, each serialized edit now wakes 1 panel instead of N.

## Correctness

- empty-string drafts remain present
- Markdown preview source drafts remain live
- selected conflict-review drafts remain live
- changing or removing a relevant draft publishes a new projection
- terminal/status/store traffic with the same draft slice is allocation-free
- no editor persistence, autosave, file I/O, runtime ownership, SSH, or protocol behavior changes

## Visible Electron validation

Validated on the exact `renderer-perf-14` dev build:

1. created a real two-pane rich-editor layout
2. opened `.orca-link-z-index-repro.md` on the left and `README.md` on the right
3. typed a marker into the left editor
4. visibly confirmed the left pane updated while the right pane remained unchanged
5. confirmed store state contained only the left draft and only the left file was dirty
6. undid the edit, verified both panes returned to their original content, then removed the temporary draft/tab/split state

## Validation

- 112 editor and owning-container test files / 797 tests pass
- `pnpm typecheck`
- targeted oxlint and react-doctor checks
- formatting and max-lines ratchet
- `git diff --check`
- full `pnpm lint` passes oxlint, switch exhaustiveness, reliability gates, and max-lines, then stops at the unchanged current-main Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`

No visual design, platform-specific shortcut, path, provider, network, subprocess, telemetry, or dependency change.

## ELI5
A keystroke in one editor used to wake every open editor because they all watched the full draft list. Each panel now watches only its own and directly related drafts, so split editors stay smoother.
