### PR TITLE
perf(runtime): skip unchanged PTY path retention

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -10619,6 +10619,12 @@ describe('OrcaRuntimeService', () => {
     expect(appendRecentPtyOutput(undefined, data)).toBe(data.slice(-outputLimit))
   })
 
+  it('reuses retained PTY path candidates when a chunk contains no paths', () => {
+    const retained = appendRecentPtyPathCandidates(undefined, '/tmp/result.json\n')
+
+    expect(appendRecentPtyPathCandidates(retained, 'ordinary terminal output')).toBe(retained)
+  })
+
   it('keeps mobile-visible artifact paths in bounded PTY path candidates', () => {
     const artifactPath = '/tmp/result-visible-in-mobile-scrollback.json'
     const prefix = 'x'.repeat(8 * 1024)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23316,8 +23316,14 @@ export function appendRecentPtyPathCandidates(
   previous: string[] | undefined,
   data: string
 ): string[] {
+  const extracted = extractTerminalOutputPathCandidates(data)
+  // Why: this runs for every raw PTY chunk; ordinary output must not clone and
+  // remeasure the full retained path list when there is nothing to append.
+  if (extracted.length === 0) {
+    return previous ?? []
+  }
   const next = previous ? previous.slice() : []
-  for (const candidate of extractTerminalOutputPathCandidates(data)) {
+  for (const candidate of extracted) {
     if (Buffer.byteLength(candidate, 'utf8') > RECENT_PTY_PATH_CANDIDATE_MAX_BYTES) {
       continue
     }


### PR DESCRIPTION
## Description

Raw PTY data calls `appendRecentPtyPathCandidates` for every chunk so Orca can recognize artifact paths later. Once a terminal had retained path candidates, the old implementation cloned that entire array and recalculated its byte budget even when the new chunk contained no path at all.

This change extracts candidates first and returns the existing immutable retained array when extraction is empty. Chunks that contain a path still use the existing clone, size checks, and pruning behavior. A regression test pins the allocation-free identity fast path.

## Performance evidence

Isolated Vitest microbenchmark through the real exported `appendRecentPtyPathCandidates` boundary on arm64 macOS 26.3.1, Node 24.18.0:

1. Seed the helper with 1,024 `/tmp/build/output-N.js` paths, matching its bounded retained-count ceiling and modeling a path-heavy build/test log.
2. Process 20,000 subsequent ordinary `progress N%` PTY chunks with no path.
3. Run seven timed samples and compare medians.

| Version | Seven samples (ms) | Median |
| --- | --- | ---: |
| Before | 386.6, 389.2, 389.8, 393.3, 395.2, 398.5, 428.5 | 393.3 ms |
| After | 5.7, 6.0, 6.5, 7.0, 7.2, 8.3, 9.0 | 7.0 ms |

That is a **98.2% reduction / 56.6x speedup** for this hot-path workload. It also avoids copying 20,480,000 retained array element slots across those chunks. This is an isolated helper benchmark at the retained-list ceiling, not an end-to-end UI latency claim; its relevance is that the helper runs synchronously on every raw PTY chunk and path-heavy builds can fill the retained set before later ordinary agent/terminal output.

Verification:

- Full `orca-runtime.test.ts`: 593 passed.
- Focused path/URI coverage: 13 passed.
- Full suite: 26,461 passed; one unrelated `node-pty` native-helper failure, which passed immediately in isolation (1/1).
- Node typecheck passed.
- Targeted Oxlint and formatting passed.
- Max-lines ratchet passed with no new bypasses.

## ELI5

Orca keeps a small recent list of file paths printed by a terminal. Previously, every ordinary progress message photocopied and recounted that whole list even though it added nothing. Now Orca first checks whether the message contains a path and reuses the list when it does not.

## End-user trade-offs / regressions

- No intended behavior change: path extraction, limits, and eviction are unchanged whenever a chunk adds a candidate.
- The returned array now keeps the same identity for path-free chunks. The sole production caller treats it as immutable and stores it in a private map; the regression test pins that contract.
- No platform, SSH/runtime-host, mobile, or git-provider behavior changes.
