### PR TITLE
perf(emulator): skip ordinary PTY output scans

### DIFF
--- a/src/main/emulator/serve-sim-state-watcher.test.ts
+++ b/src/main/emulator/serve-sim-state-watcher.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ServeSimStateWatcher, type ServeSimStateDetectedEvent } from './serve-sim-state-watcher'
 
 const TEST_UDID = '11111111-2222-3333-4444-555555555555'
@@ -39,6 +39,22 @@ describe('ServeSimStateWatcher', () => {
     await Promise.all(
       cleanupPaths.splice(0).map((path) => rm(path, { recursive: true, force: true }))
     )
+  })
+
+  it('does not rescan state files for an unchanged PTY binding', () => {
+    const watcher = createIsolatedWatcher()
+    const scanExistingStateFiles = vi.spyOn(
+      watcher as unknown as { scanExistingStateFiles: () => void },
+      'scanExistingStateFiles'
+    )
+
+    watcher.bindPty('pty-1', 'worktree-1')
+    watcher.bindPty('pty-1', 'worktree-1')
+    expect(scanExistingStateFiles).toHaveBeenCalledTimes(1)
+
+    watcher.bindPty('pty-1', 'worktree-2')
+    expect(scanExistingStateFiles).toHaveBeenCalledTimes(2)
+    watcher.stop()
   })
 
   it('attaches to the serve-sim state directory when it appears after startup', async () => {

--- a/src/main/emulator/serve-sim-state-watcher.test.ts
+++ b/src/main/emulator/serve-sim-state-watcher.test.ts
@@ -105,6 +105,31 @@ describe('ServeSimStateWatcher', () => {
     watcher.stop()
   })
 
+  it('detects a serve-sim payload split across ordinary PTY chunks', () => {
+    const watcher = createIsolatedWatcher()
+    const events: ServeSimStateDetectedEvent[] = []
+    const payload = JSON.stringify({
+      device: TEST_UDID,
+      streamUrl: 'http://127.0.0.1:3100/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3100/ws',
+      pid: 12345
+    })
+    const firstSplit = payload.indexOf('streamUrl')
+    const secondSplit = payload.indexOf('wsUrl')
+
+    watcher.bindPty('pty-1', 'worktree-1')
+    watcher.onDetected((event) => events.push(event))
+    watcher.ingestPtyOutput('pty-1', 'ordinary terminal output\n')
+    watcher.ingestPtyOutput('pty-1', payload.slice(0, firstSplit))
+    watcher.ingestPtyOutput('pty-1', payload.slice(firstSplit, secondSplit))
+    expect(events).toHaveLength(0)
+    watcher.ingestPtyOutput('pty-1', payload.slice(secondSplit))
+
+    expect(events).toHaveLength(1)
+    expect(events[0]?.info.helperPid).toBe(12345)
+    watcher.stop()
+  })
+
   it('prunes worktree-scoped dedupe keys on forget so a re-bound worktree re-emits', () => {
     const watcher = createIsolatedWatcher()
     const events: ServeSimStateDetectedEvent[] = []

--- a/src/main/emulator/serve-sim-state-watcher.ts
+++ b/src/main/emulator/serve-sim-state-watcher.ts
@@ -25,6 +25,7 @@ export type ServeSimStateDetectedEvent = {
 const DEFAULT_STATE_DIR = join(tmpdir(), 'serve-sim')
 const STATE_FILE_RE = /^server-([0-9A-F-]{36})\.json$/i
 const PTY_JSON_RE = /\{[^{}]*"streamUrl"\s*:\s*"[^"]+"[^{}]*"wsUrl"\s*:\s*"[^"]+"[^{}]*\}/g
+const PTY_JSON_BUFFER_LIMIT = 16 * 1024
 
 function parseHelperInfo(raw: unknown, fallbackUdid?: string): ServeSimHelperInfo | null {
   if (!raw || typeof raw !== 'object') {
@@ -132,11 +133,33 @@ export class ServeSimStateWatcher {
       return
     }
 
-    const prev = this.ptyBuffers.get(ptyId) ?? ''
-    const combined = (prev + data).slice(-16_384)
-    this.ptyBuffers.set(ptyId, combined)
+    const previous = this.ptyBuffers.get(ptyId)
+    const source = previous
+      ? `${previous}${data}`.slice(-PTY_JSON_BUFFER_LIMIT)
+      : data.length > PTY_JSON_BUFFER_LIMIT
+        ? data.slice(-PTY_JSON_BUFFER_LIMIT)
+        : data
+    const firstOpen = source.indexOf('{')
+    if (firstOpen === -1) {
+      this.ptyBuffers.delete(ptyId)
+      return
+    }
+    const candidateText = source.slice(firstOpen)
+    const lastOpen = candidateText.lastIndexOf('{')
+    const lastClose = candidateText.lastIndexOf('}')
+    // Why: this sees every raw PTY chunk. Only an unfinished object can match
+    // after more data arrives; retaining ordinary transcript caused a 16 KB
+    // copy and regex scan for every unrelated terminal update.
+    if (lastOpen > lastClose) {
+      this.ptyBuffers.set(ptyId, candidateText.slice(lastOpen))
+    } else {
+      this.ptyBuffers.delete(ptyId)
+    }
+    if (lastClose === -1) {
+      return
+    }
 
-    const matches = combined.match(PTY_JSON_RE)
+    const matches = candidateText.slice(0, lastClose + 1).match(PTY_JSON_RE)
     if (!matches) {
       return
     }

--- a/src/main/emulator/serve-sim-state-watcher.ts
+++ b/src/main/emulator/serve-sim-state-watcher.ts
@@ -100,7 +100,12 @@ export class ServeSimStateWatcher {
   }
 
   bindPty(ptyId: string, worktreeId: string): void {
+    if (this.ptyToWorktree.get(ptyId) === worktreeId) {
+      return
+    }
     this.ptyToWorktree.set(ptyId, worktreeId)
+    // Why: a first binding or actual re-home may reveal an existing external
+    // helper; repeated per-chunk bindings must never rescan files synchronously.
     this.scanExistingStateFiles()
   }
 


### PR DESCRIPTION
## Description

`OrcaRuntimeService.onPtyData` feeds every bound terminal chunk into the serve-sim state watcher and refreshes the PTY binding. Two pieces of watcher work were happening for unrelated shell/agent output:

1. PTY ingestion retained the last 16 KB of the entire transcript, copied that rolling window, and ran its JSON regex over it for every chunk—even text with no `{`.
2. Rebinding an already-bound PTY synchronously rescanned the serve-sim state directory, including reading/parsing helper files, on every chunk.

The watcher now returns immediately for an unchanged PTY/worktree binding. For data ingestion, it retains only the final unfinished `{...` fragment that could become a future match; completed fragments are scanned once and discarded. A real PTY re-home still rescans state files, and a regression test splits a serve-sim payload across three PTY chunks to preserve the cross-chunk contract.

## Performance evidence

Isolated Vitest microbenchmarks through the public `ServeSimStateWatcher` boundary on arm64 macOS 26.3.1, Node 24.18.0.

### Ordinary PTY ingestion

1. Bind one PTY to a worktree.
2. Feed 16,384 ordinary characters, filling the old rolling transcript.
3. Feed 20,000 subsequent `progress N%` chunks.
4. Run seven timed samples and compare medians.

| Version | Seven samples (ms) | Median |
| --- | --- | ---: |
| Before | 97.40, 98.32, 98.76, 98.76, 99.40, 102.21, 110.36 | 98.76 ms |
| After | 0.53, 0.63, 0.66, 0.72, 0.73, 0.86, 0.90 | 0.72 ms |

That is a **99.27% reduction / 137.2x speedup**. The old loop also revisited roughly 327.7 million retained character positions across this workload (20,000 × 16,384); the new path performs a map lookup and scans only the incoming short chunk for `{`.

### Unchanged PTY rebinding

With one valid helper state file in the watched directory, bind once and repeat the same PTY/worktree binding 10,000 times:

| Version | Seven samples (ms) | Median |
| --- | --- | ---: |
| Before | 294.31, 296.19, 298.77, 299.56, 301.42, 311.03, 321.43 | 299.56 ms |
| After | 0.091, 0.124, 0.126, 0.127, 0.127, 0.132, 0.236 | 0.127 ms |

That is a **99.96% reduction / 2,367x speedup**, removing about 0.030 ms of synchronous file scanning per repeated bind in this one-file state directory.

These are isolated watcher benchmarks, not end-to-end UI latency claims. Their hot-path relevance is direct: `onPtyData` synchronously invokes ingestion and refreshes the binding for every raw PTY chunk.

Verification:

- Full suite: 26,463 passed, 33 skipped.
- Serve-sim watcher tests: 6 passed, including split payload and unchanged-binding scan-count regressions.
- Node typecheck passed.
- Targeted Oxlint and formatting passed.
- Max-lines ratchet passed with no new bypasses.

## ELI5

Orca watches terminal text for one small JSON message that says a simulator started. It used to reread the last 16 KB of the conversation and reopen the simulator-state filing cabinet for every new progress update. Now it ignores text with no opening brace, saves only an unfinished JSON message, and recognizes when the terminal is already filed under the right workspace.

## End-user trade-offs / regressions

- Split serve-sim JSON remains detectable up to the same 16 KB cap; the regression test covers splits before both `streamUrl` and `wsUrl`.
- First binding and actual worktree re-homing still scan existing helper state. An unchanged binding relies on the already-running state-directory watch/poll for newly created files instead of using every PTY chunk as another synchronous fallback scan.
- Completed JSON is no longer reparsed on every unrelated later chunk. External helpers were already deduplicated, while Orca-managed helpers are unmarked only during stop/kill/shutdown; a freshly printed payload is still detected.
- Malformed or over-cap unfinished fragments are discarded once they cannot match, reducing stale per-PTY memory.
- No platform, SSH/runtime-host, mobile protocol, or git-provider behavior changes.
