### PR TITLE
perf(renderer): scope Markdown worktree path subscriptions

### DIFF
--- a/src/renderer/src/components/editor/markdown-document-worktree-path-selector.test.ts
+++ b/src/renderer/src/components/editor/markdown-document-worktree-path-selector.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { selectMarkdownDocumentWorktreePath } from './markdown-document-worktree-path-selector'
+
+const PANEL_COUNT = 200
+const UPDATE_COUNT = 200
+const WORKTREE_COUNT = 100
+const ACTIVE_ID = `worktree-${WORKTREE_COUNT - 1}`
+
+type CountedFixture = {
+  readCount: () => number
+  replaceBackgroundWorktree: (worktrees: Worktree[], update: number) => Worktree[]
+  resetReadCount: () => void
+  worktrees: Worktree[]
+}
+
+function createCountedFixture(): CountedFixture {
+  let reads = 0
+  const makeWorktree = (index: number): Worktree => {
+    const worktree = {
+      path: `/worktrees/${index}`
+    } as Worktree
+    Object.defineProperty(worktree, 'id', {
+      enumerable: true,
+      get: () => {
+        reads += 1
+        return `worktree-${index}`
+      }
+    })
+    return worktree
+  }
+  return {
+    readCount: () => reads,
+    replaceBackgroundWorktree: (worktrees, update) => {
+      const next = [...worktrees]
+      const index = update % (WORKTREE_COUNT - 1)
+      next[index] = makeWorktree(index)
+      return next
+    },
+    resetReadCount: () => {
+      reads = 0
+    },
+    worktrees: Array.from({ length: WORKTREE_COUNT }, (_, index) => makeWorktree(index))
+  }
+}
+
+describe('Markdown document worktree path selector', () => {
+  it('keeps mounted editors stable across worktree metadata replacements', () => {
+    const wholeMapFixture = createCountedFixture()
+    let wholeMap = { repo: wholeMapFixture.worktrees }
+    let wholeMapInvalidations = 0
+    wholeMapFixture.resetReadCount()
+
+    for (let update = 0; update < UPDATE_COUNT; update += 1) {
+      const previousMap = wholeMap
+      wholeMap = {
+        repo: wholeMapFixture.replaceBackgroundWorktree(wholeMap.repo, update)
+      }
+      for (let panel = 0; panel < PANEL_COUNT; panel += 1) {
+        wholeMapInvalidations += Number(previousMap !== wholeMap)
+        expect(findWorktreeById(wholeMap, ACTIVE_ID)?.path).toBe(`/worktrees/${WORKTREE_COUNT - 1}`)
+      }
+    }
+
+    const scopedFixture = createCountedFixture()
+    let scopedMap = { repo: scopedFixture.worktrees }
+    const selectedPaths = Array.from({ length: PANEL_COUNT }, () =>
+      selectMarkdownDocumentWorktreePath({ worktreesByRepo: scopedMap }, ACTIVE_ID)
+    )
+    let scopedInvalidations = 0
+    scopedFixture.resetReadCount()
+
+    for (let update = 0; update < UPDATE_COUNT; update += 1) {
+      scopedMap = {
+        repo: scopedFixture.replaceBackgroundWorktree(scopedMap.repo, update)
+      }
+      for (let panel = 0; panel < PANEL_COUNT; panel += 1) {
+        const nextPath = selectMarkdownDocumentWorktreePath(
+          { worktreesByRepo: scopedMap },
+          ACTIVE_ID
+        )
+        scopedInvalidations += Number(selectedPaths[panel] !== nextPath)
+        selectedPaths[panel] = nextPath
+      }
+    }
+
+    expect(wholeMapInvalidations).toBe(40_000)
+    expect(scopedInvalidations).toBe(0)
+    expect(wholeMapFixture.readCount()).toBe(4_000_000)
+    expect(scopedFixture.readCount()).toBe(20_000)
+  })
+
+  it('publishes path replacements and handles an absent worktree', () => {
+    const first = { id: 'active', path: '/worktrees/first' } as Worktree
+    const next = { id: 'active', path: '/worktrees/next' } as Worktree
+
+    expect(
+      selectMarkdownDocumentWorktreePath({ worktreesByRepo: { repo: [first] } }, 'active')
+    ).toBe('/worktrees/first')
+    expect(
+      selectMarkdownDocumentWorktreePath({ worktreesByRepo: { repo: [next] } }, 'active')
+    ).toBe('/worktrees/next')
+    expect(selectMarkdownDocumentWorktreePath({ worktreesByRepo: {} }, null)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/markdown-document-worktree-path-selector.ts
+++ b/src/renderer/src/components/editor/markdown-document-worktree-path-selector.ts
@@ -1,0 +1,12 @@
+import { getWorktreeMapFromState } from '@/store/selectors'
+import type { AppState } from '@/store/types'
+
+export function selectMarkdownDocumentWorktreePath(
+  state: Pick<AppState, 'worktreesByRepo'>,
+  worktreeId: string | null | undefined
+): string | null {
+  if (!worktreeId) {
+    return null
+  }
+  return getWorktreeMapFromState(state).get(worktreeId)?.path ?? null
+}

--- a/src/renderer/src/components/editor/useMarkdownDocuments.ts
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { MarkdownDocument } from '../../../../shared/types'
 import { useAppStore } from '@/store'
-import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { getConnectionId } from '@/lib/connection-context'
 import { listRuntimeMarkdownDocuments, statRuntimePath } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
@@ -11,6 +10,7 @@ import {
   getMarkdownDocLinkAnchor,
   resolveMarkdownDocLink
 } from './markdown-doc-links'
+import { selectMarkdownDocumentWorktreePath } from './markdown-document-worktree-path-selector'
 
 type OpenMarkdownDocumentOptions = {
   anchor?: string | null
@@ -40,20 +40,15 @@ export function useMarkdownDocuments(
   onSave: (content: string) => Promise<void>
 ): UseMarkdownDocumentsResult {
   const worktreeId = activeFile.worktreeId
-  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  // Why: PTY activity replaces worktree metadata; only a routing-path change
+  // should wake every mounted editor's document-link controller.
+  const worktreePath = useAppStore((s) => selectMarkdownDocumentWorktreePath(s, worktreeId))
   const openFile = useAppStore((s) => s.openFile)
   const openMarkdownPreview = useAppStore((s) => s.openMarkdownPreview)
   const [markdownDocumentsByWorktree, setMarkdownDocumentsByWorktree] = useState<
     Record<string, MarkdownDocument[]>
   >({})
   const requestRef = useRef(0)
-
-  const worktreePath = useMemo(() => {
-    if (!worktreeId) {
-      return null
-    }
-    return findWorktreeById(worktreesByRepo, worktreeId)?.path ?? null
-  }, [worktreeId, worktreesByRepo])
 
   const connectionId = getConnectionId(worktreeId)
 


### PR DESCRIPTION
## Summary

- Subscribe each mounted editor document-link controller to its worktree path instead of the complete `worktreesByRepo` map.
- Reuse the store’s snapshot-cached worktree index, keeping metadata-only replacements referentially invisible to editors.
- Add deterministic scale coverage for render invalidations and worktree-ID reads, plus path replacement correctness.

## Why

`useMarkdownDocuments` runs inside every `EditorContent`, including non-Markdown panes. It selected the whole worktree map, then linearly called `findWorktreeById` in a memo just to obtain one path.

Worktree metadata is replaced by normal PTY lifecycle activity (`bumpWorktreeActivity` on attach/exit), review-link updates, and workspace metadata changes. Each replacement therefore woke every mounted editor controller and made every pane search the worktree collection even though its routing path had not changed.

The path is the only reactive value this hook needs. Selecting that scalar through the existing snapshot-cached index preserves path changes while making unrelated and same-worktree metadata changes invisible.

## Performance evidence

Deterministic fixture: 200 mounted editor controllers, 200 background worktree metadata replacements, and 100 worktrees with the selected worktree last.

| Metric | Before | After |
| --- | ---: | ---: |
| Editor subscription invalidations | 40,000 | 0 |
| Worktree ID reads | 4,000,000 | 20,000 |

The lookup work drops 200× because one cached index build is shared across all panel selectors for each immutable map snapshot. A selected worktree path replacement still publishes immediately.

## Validation

- 112 editor/container/store-selector files: 752 tests passed.
- Focused selector and Markdown-link run: 2 files, 19 tests passed.
- `pnpm typecheck` passed.
- Targeted Oxlint and React Doctor checks passed.
- Reliability gates, max-lines ratchet, formatting, and `git diff --check` passed.
- Exact-branch Electron validation passed on a real rich Markdown editor: 200 background plus 200 owning-worktree metadata replacements kept the routing path stable, preserved the complete document text, produced zero editor DOM mutations, retained the visible link, and restored the original store map. The settled full-window screenshot was visually normal.
- Full `pnpm lint` reaches only the unchanged mainline Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`.

## Compatibility and trade-offs

- Local, WSL, SSH, and other runtime routing remain unchanged; the same path, runtime environment ID, settings owner, and connection ID feed the existing filesystem calls.
- Each new worktree-map snapshot still pays one shared O(W) index build so a genuine path replacement remains reactive. The removed cost is the prior per-panel O(W) scan and render fanout.

## ELI5

Markdown editors used to react whenever metadata changed for any worktree, even when their own folder stayed put. They now watch only their worktree’s path.
