### PR TITLE
perf(runtime): skip full wait scans for ordinary PTY output

### DIFF
--- a/src/main/runtime/orca-runtime-tail-wait-memo.test.ts
+++ b/src/main/runtime/orca-runtime-tail-wait-memo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  advanceTerminalTailWaitState,
   appendNormalizedToTailBuffer,
   buildPreview,
   computeTerminalTailWaitState,
@@ -7,11 +8,9 @@ import {
   type TerminalTailWaitState
 } from './orca-runtime'
 
-// These tests pin the onPtyData wait-detection memoization: caching the
-// post-append wait state and reusing it as the next chunk's pre-append state
-// must produce byte-for-byte the same waitBlockedAt stamping as recomputing the
-// full-tail scan on both sides of every chunk (the pre-memoization behavior),
-// while doing roughly half the full-tail work.
+// These tests pin the onPtyData wait-detection memoization: compactly advancing
+// anchor-free output must produce byte-for-byte the same waitBlockedAt stamps
+// as recomputing the full retained tail on both sides of every chunk.
 
 type RedrawCursor = ReturnType<typeof appendNormalizedToTailBuffer>['redrawCursor']
 
@@ -38,18 +37,24 @@ type Compute = typeof computeTerminalTailWaitState
 
 // Mirrors the memoized onPtyData tail loop: reuse the cached tail-derived state
 // as the previous state; only recompute it on a preview-fallback (empty tail).
-function stepMemoized(sim: TailSim, chunk: string, at: number, compute: Compute): void {
+function stepMemoized(sim: TailSim, chunk: string, at: number): void {
   const previousWaitState =
     sim.tailWaitState?.fromTail === true
       ? sim.tailWaitState
-      : compute(sim.tailBuffer, sim.tailPartialLine, sim.preview)
+      : computeTerminalTailWaitState(sim.tailBuffer, sim.tailPartialLine, sim.preview)
   const nextTail = appendNormalizedToTailBuffer(
     sim.tailBuffer,
     sim.tailPartialLine,
     chunk,
     sim.tailRedrawCursor
   )
-  const nextWaitState = compute(nextTail.lines, nextTail.partialLine, sim.preview)
+  const nextWaitState = advanceTerminalTailWaitState(
+    previousWaitState,
+    nextTail.lines,
+    nextTail.partialLine,
+    sim.preview,
+    chunk
+  )
   if (tailGainedNewerBlockedReason(previousWaitState, nextWaitState, chunk)) {
     sim.waitBlockedAt = at
   }
@@ -87,7 +92,7 @@ function runBoth(chunks: string[]): { memoized: (number | null)[]; reference: (n
   const reference: (number | null)[] = []
   chunks.forEach((chunk, index) => {
     const at = index + 1
-    stepMemoized(memoSim, chunk, at, computeTerminalTailWaitState)
+    stepMemoized(memoSim, chunk, at)
     stepReference(refSim, chunk, at, computeTerminalTailWaitState)
     memoized.push(memoSim.waitBlockedAt)
     reference.push(refSim.waitBlockedAt)
@@ -118,6 +123,15 @@ const SCENARIOS: Record<string, string[]> = {
   ]
 }
 
+const BLOCKED_PROMPT_CASES = [
+  ['Update available! Press Enter to continue.', 'codex-update-prompt'],
+  ['Choose working directory to resume. Press Enter to continue.', 'codex-cwd-prompt'],
+  ['Codex just got an upgrade. Press Enter to continue.', 'codex-model-migration-prompt'],
+  ['Hooks need review. Press Enter to confirm.', 'codex-hooks-review-prompt'],
+  ['Do you trust this workspace directory?', 'codex-trust-workspace'],
+  ['Codex permission request. Press Enter to view.', 'codex-interactive-prompt']
+] as const
+
 describe('onPtyData tail wait memoization', () => {
   it('computeTerminalTailWaitState reports fromTail and blocked signals', () => {
     const empty = computeTerminalTailWaitState([], '', '')
@@ -127,6 +141,13 @@ describe('onPtyData tail wait memoization', () => {
     const previewOnly = computeTerminalTailWaitState([], '', 'short preview')
     expect(previewOnly.fromTail).toBe(false)
     expect(previewOnly.waitText).toBe('short preview')
+
+    const blockedPreview = computeTerminalTailWaitState(
+      [],
+      '',
+      'Update available! Press Enter to continue.'
+    )
+    expect(blockedPreview.signal?.reason).toBe('codex-update-prompt')
 
     const blocked = computeTerminalTailWaitState(
       ['Update available! Press Enter to continue.'],
@@ -141,6 +162,17 @@ describe('onPtyData tail wait memoization', () => {
     it(`memoized stamping matches recompute reference: ${name}`, () => {
       const { memoized, reference } = runBoth(chunks)
       expect(memoized).toEqual(reference)
+    })
+  }
+
+  for (const [prompt, reason] of BLOCKED_PROMPT_CASES) {
+    it(`falls back for the ${reason} anchor`, () => {
+      const sim = newSim()
+      stepMemoized(sim, 'ordinary output\n', 1)
+      stepMemoized(sim, `${prompt}\n`, 2)
+
+      expect(sim.tailWaitState?.signal?.reason).toBe(reason)
+      expect(sim.waitBlockedAt).toBe(2)
     })
   }
 
@@ -178,7 +210,7 @@ describe('onPtyData tail wait memoization', () => {
     let at = 0
     const feed = (chunk: string): void => {
       at += 1
-      stepMemoized(memoSim, chunk, at, computeTerminalTailWaitState)
+      stepMemoized(memoSim, chunk, at)
       stepReference(refSim, chunk, at, computeTerminalTailWaitState)
       memoOut.push(memoSim.waitBlockedAt)
       refOut.push(refSim.waitBlockedAt)
@@ -194,34 +226,29 @@ describe('onPtyData tail wait memoization', () => {
     expect(memoSim.waitBlockedAt).not.toBeNull()
   })
 
-  it('does roughly half the full-tail wait scans of the recompute reference', () => {
+  it('falls back to the authoritative tail when a redraw introduces a prompt', () => {
+    const sim = newSim()
+    stepMemoized(sim, 'ordinary output', 1)
+    stepMemoized(sim, '\rUpdate available! Press Enter to continue.\n', 2)
+
+    expect(sim.tailWaitState?.signal?.reason).toBe('codex-update-prompt')
+    expect(sim.waitBlockedAt).toBe(2)
+  })
+
+  it('keeps anchor-free streaming output in compact scan state', () => {
     const chunks: string[] = []
     for (let i = 0; i < 500; i += 1) {
       chunks.push(`streaming line ${i}\n`)
     }
-
-    let memoCalls = 0
-    const countingMemo: Compute = (lines, partial, preview) => {
-      memoCalls += 1
-      return computeTerminalTailWaitState(lines, partial, preview)
-    }
-    let refCalls = 0
-    const countingRef: Compute = (lines, partial, preview) => {
-      refCalls += 1
-      return computeTerminalTailWaitState(lines, partial, preview)
-    }
-
     const memoSim = newSim()
-    const refSim = newSim()
     chunks.forEach((chunk, index) => {
-      stepMemoized(memoSim, chunk, index + 1, countingMemo)
-      stepReference(refSim, chunk, index + 1, countingRef)
+      stepMemoized(memoSim, chunk, index + 1)
     })
 
-    // Reference recomputes both sides every chunk: 2 per chunk.
-    expect(refCalls).toBe(chunks.length * 2)
-    // Memoized reuses the cached previous state on every non-empty-tail chunk:
-    // 1 per chunk plus a single first-chunk cold miss.
-    expect(memoCalls).toBe(chunks.length + 1)
+    expect(memoSim.tailWaitState?.signal).toBeNull()
+    expect(memoSim.tailWaitState?.waitText).toBe('')
+    const scanTail = memoSim.tailWaitState?.anchorFreeScanTail
+    expect(scanTail).toBeDefined()
+    expect(scanTail?.length ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(1024)
   })
 })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -323,6 +323,11 @@ import {
 } from './headless-tab-group-split-layout'
 import { RuntimeEmulatorCommands, setEmulatorBridge } from './orca-runtime-emulator'
 import { serveSimStateWatcher } from '../emulator/serve-sim-state-watcher'
+import {
+  advanceAnchorFreeTerminalTailWaitState,
+  createAnchorFreeTerminalTailWaitState,
+  type TerminalTailWaitState
+} from './terminal-tail-wait-state'
 import type { EmulatorBridge } from '../emulator/emulator-bridge'
 import { RuntimeFileCommands } from './orca-runtime-files'
 import { RuntimeGitCommands } from './orca-runtime-git'
@@ -5390,10 +5395,12 @@ export class OrcaRuntimeService {
         normalized.text,
         pty.tailRedrawCursor
       )
-      const nextWaitState = computeTerminalTailWaitState(
+      const nextWaitState = advanceTerminalTailWaitState(
+        previousWaitState,
         nextTail.lines,
         nextTail.partialLine,
-        pty.preview
+        pty.preview,
+        normalized.text
       )
       if (tailGainedNewerBlockedReason(previousWaitState, nextWaitState, normalized.text)) {
         pty.waitBlockedAt = at
@@ -5492,10 +5499,12 @@ export class OrcaRuntimeService {
           normalized.text,
           leaf.tailRedrawCursor
         )
-        const nextWaitState = computeTerminalTailWaitState(
+        const nextWaitState = advanceTerminalTailWaitState(
+          previousWaitState,
           nextTail.lines,
           nextTail.partialLine,
-          leaf.preview
+          leaf.preview,
+          normalized.text
         )
         if (tailGainedNewerBlockedReason(previousWaitState, nextWaitState, normalized.text)) {
           leaf.waitBlockedAt = at
@@ -23614,27 +23623,21 @@ function buildTerminalWaitText(lines: string[], partialLine: string, preview: st
   return waitText.length > 0 ? waitText : preview
 }
 
-export type TerminalTailWaitState = {
-  waitText: string
-  signal: { reason: RuntimeTerminalWaitBlockedReason; index: number } | null
-  // Why: the retained tail is authoritative; `preview` is only a fallback for an
-  // empty tail. A preview-derived state depends on a value that is recomputed
-  // after each append, so it must not be reused as the next chunk's previous
-  // state — reuse is gated on fromTail.
-  fromTail: boolean
-}
+export type { TerminalTailWaitState } from './terminal-tail-wait-state'
 
-// Why: onPtyData runs per raw PTY chunk (hundreds/sec under load). Building the
-// wait text (a full map/trim/filter/join over the up-to-256KB retained tail)
-// and lower-casing + scanning it once per chunk is unavoidable, but the old
-// code did it twice — once for the pre-append tail and once for the post-append
-// tail — every chunk. Caching the post-append state lets the next chunk reuse it
-// as its pre-append state, halving the per-chunk full-tail work.
+// Why: prompt-bearing or redrawn tails need an authoritative rebuild of the
+// up-to-256KB wait text. Anchor-free append-only output takes the compact path
+// above this fallback, while cached post-append state remains the next chunk's
+// exact pre-append state.
 export function computeTerminalTailWaitState(
   lines: string[],
   partialLine: string,
   preview: string
 ): TerminalTailWaitState {
+  const anchorFreeState = createAnchorFreeTerminalTailWaitState(lines, partialLine, preview)
+  if (anchorFreeState) {
+    return anchorFreeState
+  }
   const tailText = buildTailLines(lines, partialLine)
     .map((line) => line.trim())
     .filter(Boolean)
@@ -23646,6 +23649,19 @@ export function computeTerminalTailWaitState(
     signal: findActionableTerminalWaitBlockedSignal(waitText.toLowerCase()),
     fromTail
   }
+}
+
+export function advanceTerminalTailWaitState(
+  previous: TerminalTailWaitState,
+  lines: string[],
+  partialLine: string,
+  preview: string,
+  appendedText: string
+): TerminalTailWaitState {
+  return (
+    advanceAnchorFreeTerminalTailWaitState(previous, appendedText) ??
+    computeTerminalTailWaitState(lines, partialLine, preview)
+  )
 }
 
 // Why: decides whether the appended chunk introduced a newer actionable blocked

--- a/src/main/runtime/terminal-tail-wait-state.ts
+++ b/src/main/runtime/terminal-tail-wait-state.ts
@@ -1,0 +1,92 @@
+import type { RuntimeTerminalWaitBlockedReason } from '../../shared/runtime-types'
+
+const TERMINAL_WAIT_SCAN_TAIL_LIMIT = 1024
+const BLOCKED_PROMPT_ANCHOR_PATTERN =
+  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to confirm|press enter to continue|press enter to view|press enter to insert|press t to trust/i
+
+export type TerminalTailWaitState = {
+  waitText: string
+  signal: { reason: RuntimeTerminalWaitBlockedReason; index: number } | null
+  /** Why: preview fallback changes after append, so only tail-derived state is reusable. */
+  fromTail: boolean
+  /** Why: a bounded suffix recognizes split anchors without rebuilding an anchor-free tail. */
+  anchorFreeScanTail?: string
+}
+
+export function createAnchorFreeTerminalTailWaitState(
+  lines: readonly string[],
+  partialLine: string,
+  preview: string
+): TerminalTailWaitState | null {
+  let fromTail = partialLine.trim().length > 0
+  if (BLOCKED_PROMPT_ANCHOR_PATTERN.test(partialLine)) {
+    return null
+  }
+  for (const line of lines) {
+    fromTail ||= line.trim().length > 0
+    if (BLOCKED_PROMPT_ANCHOR_PATTERN.test(line)) {
+      return null
+    }
+  }
+  if (!fromTail && BLOCKED_PROMPT_ANCHOR_PATTERN.test(preview)) {
+    return null
+  }
+  return {
+    // Why: tailGainedNewerBlockedReason only reads prior waitText when prior
+    // signal is non-null. Anchor-free states cannot have a signal, so retain
+    // only the small raw suffix needed to recognize a split future anchor.
+    waitText: fromTail ? '' : preview,
+    signal: null,
+    fromTail,
+    anchorFreeScanTail: buildTerminalWaitScanTail(lines, partialLine)
+  }
+}
+
+export function advanceAnchorFreeTerminalTailWaitState(
+  previous: TerminalTailWaitState,
+  appendedText: string
+): TerminalTailWaitState | null {
+  if (
+    previous.signal !== null ||
+    previous.anchorFreeScanTail === undefined ||
+    !isPlainMeaningfulTerminalAppend(appendedText)
+  ) {
+    return null
+  }
+  const scanText = `${previous.anchorFreeScanTail}${appendedText}`
+  if (BLOCKED_PROMPT_ANCHOR_PATTERN.test(scanText)) {
+    return null
+  }
+  return {
+    waitText: '',
+    signal: null,
+    fromTail: true,
+    anchorFreeScanTail: scanText.slice(-TERMINAL_WAIT_SCAN_TAIL_LIMIT)
+  }
+}
+
+function isPlainMeaningfulTerminalAppend(value: string): boolean {
+  if (value.length === 0 || value.trim().length === 0) {
+    return false
+  }
+  // CR, backspace, and retained ANSI cursor controls can rewrite prior text
+  // and therefore must rebuild state from the authoritative terminal tail.
+  return !value.includes('\r') && !value.includes('\b') && !value.includes('\x1b')
+}
+
+function buildTerminalWaitScanTail(lines: readonly string[], partialLine: string): string {
+  let tail = partialLine.slice(-TERMINAL_WAIT_SCAN_TAIL_LIMIT)
+  for (
+    let index = lines.length - 1;
+    index >= 0 && tail.length < TERMINAL_WAIT_SCAN_TAIL_LIMIT;
+    index--
+  ) {
+    const separator = tail.length > 0 ? '\n' : ''
+    const remaining = TERMINAL_WAIT_SCAN_TAIL_LIMIT - tail.length - separator.length
+    if (remaining <= 0) {
+      break
+    }
+    tail = `${lines[index]!.slice(-remaining)}${separator}${tail}`
+  }
+  return tail
+}


### PR DESCRIPTION
## Description

`OrcaRuntimeService.onPtyData` maintains a retained terminal tail (up to 2,000 lines / 256 KB) so `terminal.wait` can recognize Codex trust, migration, hook-review, and other blocked prompts. The prior memoization removed one of two scans, but every raw PTY chunk still rebuilt the full tail with map/trim/filter/join, lowercased it, and searched every prompt pattern.

This change gives anchor-free tails a compact state:

- A cold/authoritative scan proves that none of the blocked-prompt anchors are present.
- The state keeps only a 1 KB raw suffix, enough to recognize an anchor split across PTY chunks.
- Ordinary append-only output advances that null-signal state from the suffix plus the new chunk.
- Any prompt anchor, partial/split anchor, CR/backspace/ANSI redraw, preview-backed prompt, or prompt-bearing tail falls back to the existing authoritative full scan.

The fallback detection logic itself is unchanged. The focused tests enumerate all six blocked reasons and cover split prompts, ready-after-blocked ordering, redraws, transcript pruning, and eviction beyond the 2,000-line cap.

## Performance evidence

Isolated steady-state Vitest benchmark through the real exported wait-state functions on arm64 macOS 26.3.1, Node 24.18.0:

1. Build a 2,000-line retained build log (236,889 characters, near the production tail ceiling).
2. Seed its current wait state once, as a live terminal already would have done while accumulating the tail.
3. Process 1,000 ordinary `progress N%` chunks.
4. Run seven timed samples and compare medians.

Before used `computeTerminalTailWaitState` per chunk, matching the old `onPtyData` path. After used `advanceTerminalTailWaitState` per chunk, matching the new path.

| Version | Seven samples (ms) | Median | Per chunk |
| --- | --- | ---: | ---: |
| Before | 982.91, 984.32, 986.78, 987.15, 994.48, 996.16, 997.11 | 987.15 ms | 0.987 ms |
| After | 2.33, 2.38, 2.39, 2.40, 2.41, 2.42, 2.51 | 2.40 ms | 0.0024 ms |

That is a **99.76% reduction / 411.7x speedup** for ordinary chunks with a long retained tail. The cached anchor-free state also shrinks from a 236,889-character duplicate wait string in this workload to a suffix capped at 1,024 characters.

This is an isolated main-process helper benchmark, not an end-to-end typing-latency claim. Its hot-path relevance is direct: these functions run synchronously inside `onPtyData`, potentially hundreds of times per second under terminal output load.

Verification:

- Runtime + wait-state + transcript-prune tests: 611 passed.
- Full suite: 26,468 passed, 33 skipped.
- Full node/CLI/web typecheck passed.
- Targeted Oxlint and formatting passed.
- Max-lines ratchet passed with no new bypasses.

## ELI5

Orca watches terminal history for a handful of “the agent needs you” messages. It used to reread a whole book every time one new progress line arrived. Once Orca has proved the book contains none of those messages, it now checks only the last page plus the new line. If the new text starts looking like a real prompt—or rewrites old terminal text—Orca rereads the authoritative history.

## End-user trade-offs / regressions

- No intended prompt-detection change: all six blocked reasons, split anchors, ready overrides, redraws, pruning, and tail eviction retain regression coverage.
- Prompt-bearing or cursor-redrawn output still pays the existing full-scan cost for correctness; the optimization targets the common anchor-free append-only stream.
- The compact state stores a 1 KB suffix instead of a duplicate full wait string only when its signal is guaranteed null. That string is internal and never crosses an RPC boundary.
- Adding a future blocked-prompt pattern also requires adding an anchor to the fast-path pattern; the focused all-reasons tests make a mismatch visible.
- No platform, SSH/runtime-host, mobile protocol, or git-provider behavior changes.
