### PR TITLE
Fix Orca Codex sessions missing from external history

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-07-09",
+  "updatedAt": "2026-07-10",
   "policy": {
     "maturityLevels": [
       "experimental",
@@ -484,6 +484,111 @@
         "Current command does not run a real workspace activation loop repeatedly through Electron."
       ],
       "demotionRule": "Demote or quarantine if failures are non-actionable or if a duplicate resume escape occurs outside the modeled matrix."
+    },
+    {
+      "id": "agent-session.codex-external-history-bridge",
+      "title": "Orca-created Codex sessions remain visible in external Codex history",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "agent-session",
+      "layer": "main-filesystem-contract",
+      "surfaces": [
+        "Codex launch",
+        "Codex session creation",
+        "session history persistence",
+        "upgrade recovery"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "wsl"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local"],
+      "coverageNotes": "Synthetic host filesystem evidence runs on macOS. WSL has command-construction coverage for bidirectional in-distro hardlinks, but no live Windows/WSL run; Linux and Windows host behavior awaits CI evidence.",
+      "motivatingLinks": ["https://github.com/stablyai/orca/issues/4444"],
+      "invariant": "A valid Codex session created under Orca's managed CODEX_HOME must become discoverable from the configured external Codex history root without overwriting either history, following symlink escapes, or creating divergent copies.",
+      "oracle": "Synthetic managed and system homes prove an Orca-created JSONL becomes one shared hardlinked log in both roots, concurrent appends remain coherent, repeated and raced exports are idempotent, independent relative-path collisions preserve both originals, EXDEV/EPERM failures preserve the managed original without an external copy, and a live SessionStart schedules exact-file export with UserPromptSubmit as an event-driven retry when creation was not yet observable.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-session-bridge.test.ts src/main/codex/codex-session-managed-export.test.ts src/main/codex/codex-session-managed-export-failure.test.ts src/main/codex/codex-session-history-hook.test.ts src/main/codex/wsl-codex-session-bridge.test.ts"
+      ],
+      "testFiles": [
+        "src/main/codex/codex-session-bridge.test.ts",
+        "src/main/codex/codex-session-managed-export.test.ts",
+        "src/main/codex/codex-session-managed-export-failure.test.ts",
+        "src/main/codex/codex-session-history-hook.test.ts",
+        "src/main/codex/wsl-codex-session-bridge.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/codex/codex-session-bridge.test.ts",
+          "assertions": [
+            "exports Orca-created sessions into the external Codex history root",
+            "does not overwrite runtime-owned session files"
+          ]
+        },
+        {
+          "file": "src/main/codex/codex-session-managed-export.test.ts",
+          "assertions": [
+            "creates one shared log and remains idempotent while either side appends",
+            "preserves independent histories when the relative path collides",
+            "does not follow a managed transcript symlink"
+          ]
+        },
+        {
+          "file": "src/main/codex/codex-session-managed-export-failure.test.ts",
+          "assertions": [
+            "preserves the managed log when link fails with EXDEV",
+            "preserves the managed log when link fails with EPERM",
+            "accepts a concurrent winner that creates the same hardlink"
+          ]
+        },
+        {
+          "file": "src/main/codex/codex-session-history-hook.test.ts",
+          "assertions": [
+            "exports a local managed transcript after a live Codex SessionStart",
+            "retries on the next prompt when SessionStart ran before the rollout existed"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-10",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-session-bridge.test.ts src/main/codex/codex-session-managed-export.test.ts src/main/codex/codex-session-managed-export-failure.test.ts src/main/codex/codex-session-history-hook.test.ts src/main/codex/wsl-codex-session-bridge.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.2,
+          "summary": "5 test files passed, 33 tests passed in the synthetic history bridge and WSL command-contract slice."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 5,
+        "scope": "focused main-process filesystem contract"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "Focused deterministic slice passed locally once; needs CI and cross-platform history before blocking promotion."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Before the fix, the exact production-boundary regression failed twice with ENOENT at the external system session path (1 failed, 9 skipped each run). After the fix, the combined 33-test slice passed. Live packaged Codex Mac/CLI evidence remains outstanding."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "SessionStart schedules one O(1) exact-file hardlink and a bounded 1024-entry success cache suppresses later prompt work. Upgrade recovery adds one incremental managed-history walk per Codex launch, coalesced with existing bridge tasks; it adds no polling, hot typing work, subprocess, or startup await."
+      },
+      "promotionCriteria": [
+        "Pass this command in macOS, Linux, and Windows CI.",
+        "Capture packaged Codex CLI or Mac evidence that an Orca-created session appears externally during the same live session.",
+        "Run a live WSL bridge fixture and decide whether same-session hook-triggered WSL export is required before provider coverage.",
+        "Collect stable CI history before raising protection."
+      ],
+      "knownGaps": [
+        "Cross-volume and permission-blocked hardlinks fail safely but cannot make the session externally visible; copies and symlinks are deliberately not used because copies diverge and Codex resume ignores symlinked JSONL files.",
+        "Codex project pickers still apply Codex's cwd filter. Orca keeps the truthful worktree cwd so external users may need the worktree path or codex resume --all instead of resuming into the wrong checkout.",
+        "The gate does not synchronize managed session_index.jsonl rename metadata.",
+        "WSL bidirectional migration is covered at shell-command construction only and runs on the next bridge launch, not from a live WSL SessionStart.",
+        "SSH and remote-runtime Codex are unaffected because Orca does not redirect their history into the host managed CODEX_HOME; no live remote evidence is included."
+      ],
+      "demotionRule": "Demote or quarantine if the deterministic filesystem oracle flakes, a collision overwrites either original, or a bridge path creates divergent mutable copies."
     },
     {
       "id": "terminal-geometry.visible-convergence",

--- a/src/main/codex/codex-session-bridge.test.ts
+++ b/src/main/codex/codex-session-bridge.test.ts
@@ -180,6 +180,32 @@ afterEach(() => {
 })
 
 describe('syncSystemCodexSessionsIntoManagedHome', () => {
+  it('exports Orca-created sessions into the external Codex history root', () => {
+    const relativeSessionPath = join('sessions', '2026', '07', '10', 'rollout-orca.jsonl')
+    const runtimeSessionPath = join(getRuntimeCodexHomePath(), relativeSessionPath)
+    const systemSessionPath = join(getSystemCodexHomePath(), relativeSessionPath)
+    mkdirSync(dirname(runtimeSessionPath), { recursive: true })
+    writeFileSync(
+      runtimeSessionPath,
+      `${JSON.stringify({
+        timestamp: '2026-07-10T00:00:00.000Z',
+        type: 'session_meta',
+        payload: {
+          id: '00000000-0000-4000-8000-000000004444',
+          cwd: join(fakeHomeDir, 'orca', 'workspaces', 'project', 'fix-4444')
+        }
+      })}\n`,
+      'utf-8'
+    )
+
+    syncSystemCodexSessionsIntoManagedHome()
+
+    expect(readFileSync(systemSessionPath, 'utf-8')).toContain(
+      '00000000-0000-4000-8000-000000004444'
+    )
+    expectResourceLinked(systemSessionPath, runtimeSessionPath)
+  })
+
   it('bridges system Codex session jsonl files into the managed runtime home', () => {
     const systemSessionPath = join(
       getSystemCodexHomePath(),
@@ -241,6 +267,16 @@ describe('syncSystemCodexSessionsIntoManagedHome', () => {
     )
     mkdirSync(dirname(defaultSessionPath), { recursive: true })
     writeFileSync(defaultSessionPath, '{"id":"default"}\n', 'utf-8')
+    const managedExportPath = join(
+      getRuntimeCodexHomePath(),
+      'sessions',
+      '2026',
+      '05',
+      '26',
+      'rollout-managed-custom.jsonl'
+    )
+    mkdirSync(dirname(managedExportPath), { recursive: true })
+    writeFileSync(managedExportPath, '{"id":"managed-custom"}\n', 'utf-8')
 
     syncSystemCodexSessionsIntoManagedHome(customSourceHome)
 
@@ -256,6 +292,24 @@ describe('syncSystemCodexSessionsIntoManagedHome', () => {
     expect(
       existsSync(
         join(getRuntimeCodexHomePath(), 'sessions', '2026', '05', '26', 'rollout-default.jsonl')
+      )
+    ).toBe(false)
+    expect(
+      readFileSync(
+        join(customSourceHome, 'sessions', '2026', '05', '26', 'rollout-managed-custom.jsonl'),
+        'utf-8'
+      )
+    ).toBe('{"id":"managed-custom"}\n')
+    expect(
+      existsSync(
+        join(
+          getSystemCodexHomePath(),
+          'sessions',
+          '2026',
+          '05',
+          '26',
+          'rollout-managed-custom.jsonl'
+        )
       )
     ).toBe(false)
   })

--- a/src/main/codex/codex-session-bridge.ts
+++ b/src/main/codex/codex-session-bridge.ts
@@ -3,35 +3,29 @@ import {
   linkSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readlinkSync,
   renameSync,
   rmSync,
   symlinkSync
 } from 'node:fs'
-import { dirname, isAbsolute, join, relative, sep } from 'node:path'
+import { dirname, isAbsolute, join, relative } from 'node:path'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
 import {
   listCodexSessionJsonlFiles,
   listCodexSessionJsonlFilesIncrementally
 } from './codex-session-file-listing'
 import type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
+import { exportManagedCodexSessionToSystemHistory } from './codex-session-managed-export'
+import {
+  clearLegacyCopiedSessionMarker,
+  migrateLegacyCopiedSessionBridge
+} from './codex-session-legacy-copy'
+
+export { exportManagedCodexSessionToSystemHistory } from './codex-session-managed-export'
+export { getLegacyCopiedCodexSessionBridgeScanPreference } from './codex-session-legacy-copy'
+export type { LegacyCopiedCodexSessionBridgeScanPreference } from './codex-session-legacy-copy'
 
 export type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
-
-type LegacyCopiedSessionMarker = {
-  sourcePath: string
-  sourceSize: number
-  sourceMtimeMs: number
-  targetSize: number
-  targetMtimeMs: number
-}
-
-export type LegacyCopiedCodexSessionBridgeScanPreference = {
-  sourcePath: string
-  preferManagedCopy: boolean
-  sourceSkipBytes: number | null
-}
 
 export type CodexSessionBridgeSummary = {
   scannedFiles: number
@@ -41,25 +35,31 @@ export type CodexSessionBridgeSummary = {
 let backgroundSessionBridgeTask: Promise<void> | null = null
 
 /**
- * Synchronously mirrors system session files into the managed runtime home.
+ * Synchronously reconciles system and managed Codex session histories.
  *
  * `sourceCodexHomePath` overrides the default ~/.codex history source for users
  * who run Codex with a custom CODEX_HOME; it only affects history discovery.
  */
 export function syncSystemCodexSessionsIntoManagedHome(sourceCodexHomePath?: string): void {
-  const systemSessionsRoot = join(sourceCodexHomePath || getSystemCodexHomePath(), 'sessions')
+  const systemCodexHomePath = sourceCodexHomePath || getSystemCodexHomePath()
+  const managedSessionsRoot = join(getOrcaManagedCodexHomePath(), 'sessions')
+  if (existsSync(managedSessionsRoot)) {
+    for (const managedSessionFilePath of listCodexSessionJsonlFiles(managedSessionsRoot)) {
+      exportManagedCodexSessionToSystemHistory(managedSessionFilePath, systemCodexHomePath)
+    }
+  }
+
+  const systemSessionsRoot = join(systemCodexHomePath, 'sessions')
   if (!existsSync(systemSessionsRoot)) {
     return
   }
-
-  const managedSessionsRoot = join(getOrcaManagedCodexHomePath(), 'sessions')
   for (const systemSessionFilePath of listCodexSessionJsonlFiles(systemSessionsRoot)) {
     bridgeSystemCodexSessionFile(systemSessionsRoot, managedSessionsRoot, systemSessionFilePath)
   }
 }
 
 /**
- * Starts a single background bridge task for historical system sessions.
+ * Starts one background task to reconcile historical sessions between homes.
  *
  * Concurrent callers share the same in-flight task so launch code can request
  * background bridging without starting duplicate directory walks.
@@ -86,7 +86,7 @@ export function startSystemCodexSessionBridgeInBackground(
 }
 
 /**
- * Incrementally mirrors system session files into the managed runtime home.
+ * Incrementally reconciles system and managed Codex session histories.
  *
  * Returns scan/link counts for tests and diagnostics while keeping each file
  * bridge operation equivalent to the synchronous path.
@@ -95,13 +95,27 @@ export async function syncSystemCodexSessionsIntoManagedHomeIncrementally(
   options: CodexSessionBridgeIncrementalOptions = {},
   sourceCodexHomePath?: string
 ): Promise<CodexSessionBridgeSummary> {
-  const systemSessionsRoot = join(sourceCodexHomePath || getSystemCodexHomePath(), 'sessions')
-  if (!existsSync(systemSessionsRoot)) {
-    return { scannedFiles: 0, linkedFiles: 0 }
-  }
-
+  const systemCodexHomePath = sourceCodexHomePath || getSystemCodexHomePath()
+  const systemSessionsRoot = join(systemCodexHomePath, 'sessions')
   const managedSessionsRoot = join(getOrcaManagedCodexHomePath(), 'sessions')
   const summary: CodexSessionBridgeSummary = { scannedFiles: 0, linkedFiles: 0 }
+  if (existsSync(managedSessionsRoot)) {
+    for await (const managedSessionFilePath of listCodexSessionJsonlFilesIncrementally(
+      managedSessionsRoot,
+      options
+    )) {
+      summary.scannedFiles += 1
+      if (
+        exportManagedCodexSessionToSystemHistory(managedSessionFilePath, systemCodexHomePath) ===
+        'linked'
+      ) {
+        summary.linkedFiles += 1
+      }
+    }
+  }
+  if (!existsSync(systemSessionsRoot)) {
+    return summary
+  }
   for await (const systemSessionFilePath of listCodexSessionJsonlFilesIncrementally(
     systemSessionsRoot,
     options
@@ -139,7 +153,12 @@ function bridgeSystemCodexSessionFile(
     ) {
       return true
     }
-    migrateLegacyCopiedSessionBridge(systemSessionFilePath, managedSessionFilePath, relativePath)
+    migrateLegacyCopiedSessionBridge(
+      systemSessionFilePath,
+      managedSessionFilePath,
+      relativePath,
+      tryLinkSystemCodexSessionFile
+    )
     return false
   }
   mkdirSync(dirname(managedSessionFilePath), { recursive: true })
@@ -235,142 +254,4 @@ function replaceSymlinkSessionBridgeWithHardlink(
     }
   }
   return false
-}
-
-/**
- * Migrates a legacy copied bridge to a linked bridge when the copied file still
- * matches its marker.
- */
-function migrateLegacyCopiedSessionBridge(
-  sourcePath: string,
-  targetPath: string,
-  relativePath: string
-): void {
-  const marker = readLegacyCopiedSessionMarker(relativePath)
-  if (!marker || marker.sourcePath !== sourcePath) {
-    return
-  }
-  let replacementPath: string | null = null
-  try {
-    const targetStat = lstatSync(targetPath)
-    if (targetStat.isSymbolicLink()) {
-      clearLegacyCopiedSessionMarker(relativePath)
-      return
-    }
-    if (!fileStatsMatchMarker(targetStat, marker, 'target')) {
-      return
-    }
-    replacementPath = `${targetPath}.orca-link-${process.pid}-${Date.now()}`
-    if (!tryLinkSystemCodexSessionFile(sourcePath, replacementPath)) {
-      return
-    }
-    rmSync(targetPath, { force: true })
-    renameSync(replacementPath, targetPath)
-    clearLegacyCopiedSessionMarker(relativePath)
-  } catch (error) {
-    console.warn(
-      '[codex-session-bridge] Failed to migrate copied system Codex session:',
-      sourcePath,
-      error
-    )
-    if (replacementPath) {
-      rmSync(replacementPath, { force: true })
-    }
-  }
-}
-
-/**
- * Resolves how scanners should treat a legacy copied session bridge.
- *
- * The result keeps resume scans coherent until the copied bridge is migrated to
- * a hardlink or symlink.
- */
-export function getLegacyCopiedCodexSessionBridgeScanPreference(
-  sessionFilePath: string
-): LegacyCopiedCodexSessionBridgeScanPreference | null {
-  const managedSessionsRoot = join(getOrcaManagedCodexHomePath(), 'sessions')
-  const relativePath = relative(managedSessionsRoot, sessionFilePath)
-  if (
-    relativePath === '' ||
-    relativePath === '..' ||
-    relativePath.startsWith(`..${sep}`) ||
-    isAbsolute(relativePath)
-  ) {
-    return null
-  }
-  const marker = readLegacyCopiedSessionMarker(relativePath)
-  if (!marker) {
-    return null
-  }
-
-  let targetMatchesMarker = false
-  let sourceMatchesMarker = false
-  try {
-    targetMatchesMarker = fileStatsMatchMarker(lstatSync(sessionFilePath), marker, 'target')
-  } catch {}
-  try {
-    sourceMatchesMarker = fileStatsMatchMarker(lstatSync(marker.sourcePath), marker, 'source')
-  } catch {}
-
-  return {
-    sourcePath: marker.sourcePath,
-    // Why: legacy copied bridges share a prefix with the source. Scanner must
-    // choose one full log until the bridge can be replaced with a real link.
-    preferManagedCopy: !targetMatchesMarker || sourceMatchesMarker,
-    sourceSkipBytes: !targetMatchesMarker && !sourceMatchesMarker ? marker.sourceSize : null
-  }
-}
-
-/**
- * Returns the marker path for a legacy copied session bridge.
- */
-function getLegacySessionCopyMarkerPath(relativePath: string): string {
-  return join(getOrcaManagedCodexHomePath(), '.orca-session-copies', `${relativePath}.json`)
-}
-
-/**
- * Reads and validates the marker for a legacy copied session bridge.
- */
-function readLegacyCopiedSessionMarker(relativePath: string): LegacyCopiedSessionMarker | null {
-  try {
-    const parsed: unknown = JSON.parse(
-      readFileSync(getLegacySessionCopyMarkerPath(relativePath), 'utf-8')
-    )
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return null
-    }
-    const marker = parsed as Record<string, unknown>
-    if (
-      typeof marker.sourcePath !== 'string' ||
-      typeof marker.sourceSize !== 'number' ||
-      typeof marker.sourceMtimeMs !== 'number' ||
-      typeof marker.targetSize !== 'number' ||
-      typeof marker.targetMtimeMs !== 'number'
-    ) {
-      return null
-    }
-    return marker as LegacyCopiedSessionMarker
-  } catch {
-    return null
-  }
-}
-
-/**
- * Checks whether source or target file stats still match a legacy bridge marker.
- */
-function fileStatsMatchMarker(
-  stat: { size: number; mtimeMs: number },
-  marker: LegacyCopiedSessionMarker,
-  kind: 'source' | 'target'
-): boolean {
-  const expectedSize = kind === 'source' ? marker.sourceSize : marker.targetSize
-  const expectedMtimeMs = kind === 'source' ? marker.sourceMtimeMs : marker.targetMtimeMs
-  return stat.size === expectedSize && stat.mtimeMs === expectedMtimeMs
-}
-
-/**
- * Removes the marker after a copied session bridge has been migrated or retired.
- */
-function clearLegacyCopiedSessionMarker(relativePath: string): void {
-  rmSync(getLegacySessionCopyMarkerPath(relativePath), { force: true })
 }

--- a/src/main/codex/codex-session-history-hook.test.ts
+++ b/src/main/codex/codex-session-history-hook.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { exportSessionMock } = vi.hoisted(() => ({
+  exportSessionMock: vi.fn()
+}))
+
+vi.mock('./codex-session-managed-export', () => ({
+  exportManagedCodexSessionToSystemHistory: exportSessionMock
+}))
+
+import {
+  scheduleManagedCodexSessionExportFromHook,
+  type CodexSessionHistoryHookEvent
+} from './codex-session-history-hook'
+
+const managedTranscriptPath = '/managed/.codex/sessions/2026/07/10/rollout-orca.jsonl'
+
+function createCodexSessionStart(
+  overrides: Partial<CodexSessionHistoryHookEvent> = {}
+): CodexSessionHistoryHookEvent {
+  return {
+    connectionId: null,
+    hookEventName: 'SessionStart',
+    payload: { state: 'done', prompt: '', agentType: 'codex' },
+    providerSession: {
+      key: 'session_id',
+      id: '00000000-0000-4000-8000-000000004444',
+      transcriptPath: managedTranscriptPath
+    },
+    ...overrides
+  }
+}
+
+describe('scheduleManagedCodexSessionExportFromHook', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    exportSessionMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('exports a local managed transcript after a live Codex SessionStart', () => {
+    expect(
+      scheduleManagedCodexSessionExportFromHook(
+        createCodexSessionStart(),
+        '/custom/system-codex-home'
+      )
+    ).toBe(true)
+    expect(exportSessionMock).not.toHaveBeenCalled()
+
+    vi.runAllTimers()
+
+    expect(exportSessionMock).toHaveBeenCalledWith(
+      managedTranscriptPath,
+      '/custom/system-codex-home'
+    )
+  })
+
+  it.each([
+    ['remote Codex event', { connectionId: 'ssh-connection' }],
+    ['replayed Codex event', { isReplay: true }],
+    ['non-lifecycle Codex event', { hookEventName: 'PreToolUse' }],
+    [
+      'non-Codex event',
+      { payload: { state: 'done' as const, prompt: '', agentType: 'claude' as const } }
+    ],
+    ['event without a transcript path', { providerSession: undefined }]
+  ])('ignores a %s', (_label, overrides) => {
+    expect(scheduleManagedCodexSessionExportFromHook(createCodexSessionStart(overrides))).toBe(
+      false
+    )
+    vi.runAllTimers()
+    expect(exportSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('retries on the next prompt when SessionStart ran before the rollout existed', () => {
+    exportSessionMock.mockReturnValueOnce('ignored').mockReturnValueOnce('linked')
+    expect(scheduleManagedCodexSessionExportFromHook(createCodexSessionStart())).toBe(true)
+    vi.runAllTimers()
+
+    expect(
+      scheduleManagedCodexSessionExportFromHook(
+        createCodexSessionStart({ hookEventName: 'UserPromptSubmit' })
+      )
+    ).toBe(true)
+    vi.runAllTimers()
+
+    expect(exportSessionMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/codex/codex-session-history-hook.ts
+++ b/src/main/codex/codex-session-history-hook.ts
@@ -1,0 +1,55 @@
+import type { AgentProviderSessionMetadata } from '../../shared/agent-session-resume'
+import type { ParsedAgentStatusPayload } from '../../shared/agent-status-types'
+import { exportManagedCodexSessionToSystemHistory } from './codex-session-managed-export'
+
+const EXPORTED_MANAGED_SESSION_PATHS_MAX = 1024
+const exportedManagedSessionPaths = new Set<string>()
+
+export type CodexSessionHistoryHookEvent = {
+  connectionId: string | null
+  hookEventName?: string
+  isReplay?: boolean
+  payload: ParsedAgentStatusPayload
+  providerSession?: AgentProviderSessionMetadata
+}
+
+/** Schedules a single-file export when Codex proves its rollout path exists. */
+export function scheduleManagedCodexSessionExportFromHook(
+  event: CodexSessionHistoryHookEvent,
+  systemCodexHomePath?: string
+): boolean {
+  const transcriptPath = event.providerSession?.transcriptPath
+  const exportKey = `${systemCodexHomePath ?? ''}\0${transcriptPath ?? ''}`
+  if (
+    event.connectionId !== null ||
+    event.isReplay === true ||
+    event.payload.agentType !== 'codex' ||
+    (event.hookEventName !== 'SessionStart' && event.hookEventName !== 'UserPromptSubmit') ||
+    !transcriptPath ||
+    exportedManagedSessionPaths.has(exportKey)
+  ) {
+    return false
+  }
+
+  // Why: hook delivery is the authoritative creation event, but linking must
+  // not delay Codex's hook response or agent startup.
+  const task = setImmediate(() => {
+    const result = exportManagedCodexSessionToSystemHistory(transcriptPath, systemCodexHomePath)
+    if (result === 'linked' || result === 'already-linked') {
+      rememberExportedManagedSessionPath(exportKey)
+    }
+  })
+  task.unref()
+  return true
+}
+
+function rememberExportedManagedSessionPath(exportKey: string): void {
+  exportedManagedSessionPaths.add(exportKey)
+  while (exportedManagedSessionPaths.size > EXPORTED_MANAGED_SESSION_PATHS_MAX) {
+    const oldestPath = exportedManagedSessionPaths.values().next().value
+    if (!oldestPath) {
+      return
+    }
+    exportedManagedSessionPaths.delete(oldestPath)
+  }
+}

--- a/src/main/codex/codex-session-legacy-copy.ts
+++ b/src/main/codex/codex-session-legacy-copy.ts
@@ -1,0 +1,136 @@
+import { lstatSync, readFileSync, renameSync, rmSync } from 'node:fs'
+import { isAbsolute, join, relative, sep } from 'node:path'
+import { getOrcaManagedCodexHomePath } from './codex-home-paths'
+
+type LegacyCopiedSessionMarker = {
+  sourcePath: string
+  sourceSize: number
+  sourceMtimeMs: number
+  targetSize: number
+  targetMtimeMs: number
+}
+
+export type LegacyCopiedCodexSessionBridgeScanPreference = {
+  sourcePath: string
+  preferManagedCopy: boolean
+  sourceSkipBytes: number | null
+}
+
+/** Migrates a legacy copied bridge when the copied file still matches its marker. */
+export function migrateLegacyCopiedSessionBridge(
+  sourcePath: string,
+  targetPath: string,
+  relativePath: string,
+  tryLink: (sourcePath: string, targetPath: string) => boolean
+): void {
+  const marker = readLegacyCopiedSessionMarker(relativePath)
+  if (!marker || marker.sourcePath !== sourcePath) {
+    return
+  }
+  let replacementPath: string | null = null
+  try {
+    const targetStat = lstatSync(targetPath)
+    if (targetStat.isSymbolicLink()) {
+      clearLegacyCopiedSessionMarker(relativePath)
+      return
+    }
+    if (!fileStatsMatchMarker(targetStat, marker, 'target')) {
+      return
+    }
+    replacementPath = `${targetPath}.orca-link-${process.pid}-${Date.now()}`
+    if (!tryLink(sourcePath, replacementPath)) {
+      return
+    }
+    rmSync(targetPath, { force: true })
+    renameSync(replacementPath, targetPath)
+    clearLegacyCopiedSessionMarker(relativePath)
+  } catch (error) {
+    console.warn(
+      '[codex-session-bridge] Failed to migrate copied system Codex session:',
+      sourcePath,
+      error
+    )
+    if (replacementPath) {
+      rmSync(replacementPath, { force: true })
+    }
+  }
+}
+
+/** Resolves how scanners should treat a legacy copied session bridge. */
+export function getLegacyCopiedCodexSessionBridgeScanPreference(
+  sessionFilePath: string
+): LegacyCopiedCodexSessionBridgeScanPreference | null {
+  const managedSessionsRoot = join(getOrcaManagedCodexHomePath(), 'sessions')
+  const relativePath = relative(managedSessionsRoot, sessionFilePath)
+  if (
+    relativePath === '' ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    return null
+  }
+  const marker = readLegacyCopiedSessionMarker(relativePath)
+  if (!marker) {
+    return null
+  }
+
+  let targetMatchesMarker = false
+  let sourceMatchesMarker = false
+  try {
+    targetMatchesMarker = fileStatsMatchMarker(lstatSync(sessionFilePath), marker, 'target')
+  } catch {}
+  try {
+    sourceMatchesMarker = fileStatsMatchMarker(lstatSync(marker.sourcePath), marker, 'source')
+  } catch {}
+
+  return {
+    sourcePath: marker.sourcePath,
+    // Why: legacy copied bridges share a prefix with the source. Scanner must
+    // choose one full log until the bridge can be replaced with a real link.
+    preferManagedCopy: !targetMatchesMarker || sourceMatchesMarker,
+    sourceSkipBytes: !targetMatchesMarker && !sourceMatchesMarker ? marker.sourceSize : null
+  }
+}
+
+export function clearLegacyCopiedSessionMarker(relativePath: string): void {
+  rmSync(getLegacySessionCopyMarkerPath(relativePath), { force: true })
+}
+
+function getLegacySessionCopyMarkerPath(relativePath: string): string {
+  return join(getOrcaManagedCodexHomePath(), '.orca-session-copies', `${relativePath}.json`)
+}
+
+function readLegacyCopiedSessionMarker(relativePath: string): LegacyCopiedSessionMarker | null {
+  try {
+    const parsed: unknown = JSON.parse(
+      readFileSync(getLegacySessionCopyMarkerPath(relativePath), 'utf-8')
+    )
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null
+    }
+    const marker = parsed as Record<string, unknown>
+    if (
+      typeof marker.sourcePath !== 'string' ||
+      typeof marker.sourceSize !== 'number' ||
+      typeof marker.sourceMtimeMs !== 'number' ||
+      typeof marker.targetSize !== 'number' ||
+      typeof marker.targetMtimeMs !== 'number'
+    ) {
+      return null
+    }
+    return marker as LegacyCopiedSessionMarker
+  } catch {
+    return null
+  }
+}
+
+function fileStatsMatchMarker(
+  stat: { size: number; mtimeMs: number },
+  marker: LegacyCopiedSessionMarker,
+  kind: 'source' | 'target'
+): boolean {
+  const expectedSize = kind === 'source' ? marker.sourceSize : marker.targetSize
+  const expectedMtimeMs = kind === 'source' ? marker.sourceMtimeMs : marker.targetMtimeMs
+  return stat.size === expectedSize && stat.mtimeMs === expectedMtimeMs
+}

--- a/src/main/codex/codex-session-managed-export-failure.test.ts
+++ b/src/main/codex/codex-session-managed-export-failure.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+const { linkFailureState } = vi.hoisted(() => ({
+  linkFailureState: {
+    code: 'EXDEV',
+    linkThenThrow: false
+  }
+}))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return {
+    ...actual,
+    linkSync: (sourcePath: NodeFs.PathLike, targetPath: NodeFs.PathLike) => {
+      if (linkFailureState.linkThenThrow) {
+        actual.linkSync(sourcePath, targetPath)
+      }
+      const error = new Error(`synthetic ${linkFailureState.code}`) as NodeJS.ErrnoException
+      error.code = linkFailureState.code
+      throw error
+    }
+  }
+})
+
+import { exportManagedCodexSessionToSystemHistory } from './codex-session-managed-export'
+
+let fixtureRoot: string
+let managedSessionPath: string
+let systemCodexHome: string
+let systemSessionPath: string
+let previousUserDataPath: string | undefined
+
+beforeEach(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-managed-session-link-failure-'))
+  const userDataPath = join(fixtureRoot, 'user-data')
+  managedSessionPath = join(
+    userDataPath,
+    'codex-runtime-home',
+    'home',
+    'sessions',
+    '2026',
+    '07',
+    '10',
+    'rollout-orca.jsonl'
+  )
+  systemCodexHome = join(fixtureRoot, 'system-codex-home')
+  systemSessionPath = join(systemCodexHome, 'sessions', '2026', '07', '10', 'rollout-orca.jsonl')
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataPath
+  linkFailureState.code = 'EXDEV'
+  linkFailureState.linkThenThrow = false
+  mkdirSync(dirname(managedSessionPath), { recursive: true })
+  writeFileSync(managedSessionPath, '{"id":"managed"}\n', 'utf-8')
+  vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.restoreAllMocks()
+})
+
+describe('managed Codex session hardlink failures', () => {
+  it.each(['EXDEV', 'EPERM'])('preserves the managed log when link fails with %s', (code) => {
+    linkFailureState.code = code
+
+    expect(exportManagedCodexSessionToSystemHistory(managedSessionPath, systemCodexHome)).toBe(
+      'failed'
+    )
+    expect(readFileSync(managedSessionPath, 'utf-8')).toBe('{"id":"managed"}\n')
+    expect(existsSync(systemSessionPath)).toBe(false)
+  })
+
+  it('accepts a concurrent winner that creates the same hardlink', () => {
+    linkFailureState.code = 'EEXIST'
+    linkFailureState.linkThenThrow = true
+
+    expect(exportManagedCodexSessionToSystemHistory(managedSessionPath, systemCodexHome)).toBe(
+      'already-linked'
+    )
+    expect(readFileSync(systemSessionPath, 'utf-8')).toBe('{"id":"managed"}\n')
+  })
+})

--- a/src/main/codex/codex-session-managed-export.test.ts
+++ b/src/main/codex/codex-session-managed-export.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  appendFileSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { exportManagedCodexSessionToSystemHistory } from './codex-session-managed-export'
+
+let fixtureRoot: string
+let managedCodexHome: string
+let systemCodexHome: string
+let previousUserDataPath: string | undefined
+
+function managedSessionPath(fileName: string): string {
+  return join(managedCodexHome, 'sessions', '2026', '07', '10', fileName)
+}
+
+function systemSessionPath(fileName: string): string {
+  return join(systemCodexHome, 'sessions', '2026', '07', '10', fileName)
+}
+
+beforeEach(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-managed-session-export-'))
+  const userDataPath = join(fixtureRoot, 'user-data')
+  managedCodexHome = join(userDataPath, 'codex-runtime-home', 'home')
+  systemCodexHome = join(fixtureRoot, 'system-codex-home')
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataPath
+})
+
+afterEach(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.restoreAllMocks()
+})
+
+describe('exportManagedCodexSessionToSystemHistory', () => {
+  it('creates one shared log and remains idempotent while either side appends', () => {
+    const managedPath = managedSessionPath('rollout-shared.jsonl')
+    const systemPath = systemSessionPath('rollout-shared.jsonl')
+    mkdirSync(dirname(managedPath), { recursive: true })
+    writeFileSync(managedPath, '{"id":"shared"}\n', 'utf-8')
+
+    expect(exportManagedCodexSessionToSystemHistory(managedPath, systemCodexHome)).toBe('linked')
+    expect(exportManagedCodexSessionToSystemHistory(managedPath, systemCodexHome)).toBe(
+      'already-linked'
+    )
+
+    appendFileSync(managedPath, '{"from":"orca"}\n', 'utf-8')
+    expect(readFileSync(systemPath, 'utf-8')).toContain('"from":"orca"')
+    appendFileSync(systemPath, '{"from":"external"}\n', 'utf-8')
+    expect(readFileSync(managedPath, 'utf-8')).toContain('"from":"external"')
+  })
+
+  it('preserves independent histories when the relative path collides', () => {
+    const managedPath = managedSessionPath('rollout-collision.jsonl')
+    const systemPath = systemSessionPath('rollout-collision.jsonl')
+    mkdirSync(dirname(managedPath), { recursive: true })
+    mkdirSync(dirname(systemPath), { recursive: true })
+    writeFileSync(managedPath, '{"id":"managed"}\n', 'utf-8')
+    writeFileSync(systemPath, '{"id":"system"}\n', 'utf-8')
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    expect(exportManagedCodexSessionToSystemHistory(managedPath, systemCodexHome)).toBe('collision')
+    expect(readFileSync(managedPath, 'utf-8')).toBe('{"id":"managed"}\n')
+    expect(readFileSync(systemPath, 'utf-8')).toBe('{"id":"system"}\n')
+  })
+
+  it('ignores a hook path outside the managed sessions root', () => {
+    const outsidePath = join(fixtureRoot, 'outside.jsonl')
+    writeFileSync(outsidePath, '{"id":"outside"}\n', 'utf-8')
+
+    expect(exportManagedCodexSessionToSystemHistory(outsidePath, systemCodexHome)).toBe('ignored')
+  })
+
+  it.skipIf(process.platform === 'win32')('does not follow a managed transcript symlink', () => {
+    const outsidePath = join(fixtureRoot, 'outside.jsonl')
+    const managedPath = managedSessionPath('rollout-symlink.jsonl')
+    writeFileSync(outsidePath, '{"id":"outside"}\n', 'utf-8')
+    mkdirSync(dirname(managedPath), { recursive: true })
+    symlinkSync(outsidePath, managedPath)
+
+    expect(exportManagedCodexSessionToSystemHistory(managedPath, systemCodexHome)).toBe('ignored')
+  })
+
+  it.skipIf(process.platform === 'win32')('refuses a symlinked system date directory', () => {
+    const managedPath = managedSessionPath('rollout-target-symlink.jsonl')
+    const outsideDirectory = join(fixtureRoot, 'outside-system-directory')
+    mkdirSync(dirname(managedPath), { recursive: true })
+    mkdirSync(join(systemCodexHome, 'sessions'), { recursive: true })
+    mkdirSync(outsideDirectory)
+    symlinkSync(outsideDirectory, join(systemCodexHome, 'sessions', '2026'))
+    writeFileSync(managedPath, '{"id":"managed"}\n', 'utf-8')
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    expect(exportManagedCodexSessionToSystemHistory(managedPath, systemCodexHome)).toBe('failed')
+    expect(readFileSync(managedPath, 'utf-8')).toBe('{"id":"managed"}\n')
+  })
+})

--- a/src/main/codex/codex-session-managed-export.ts
+++ b/src/main/codex/codex-session-managed-export.ts
@@ -1,0 +1,158 @@
+import { linkSync, lstatSync, mkdirSync, realpathSync, type Stats } from 'node:fs'
+import { dirname, isAbsolute, join, relative, sep } from 'node:path'
+import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
+
+export type ManagedCodexSessionExportResult =
+  | 'linked'
+  | 'already-linked'
+  | 'collision'
+  | 'failed'
+  | 'ignored'
+
+/**
+ * Publishes one managed Codex transcript into the user's external history.
+ *
+ * Hardlinks keep concurrent appends coherent. Cross-volume copies and symlinks
+ * are intentionally rejected because they either diverge or are ignored by
+ * Codex resume.
+ */
+export function exportManagedCodexSessionToSystemHistory(
+  managedSessionFilePath: string,
+  systemCodexHomePath = getSystemCodexHomePath()
+): ManagedCodexSessionExportResult {
+  const managedSessionsRoot = join(getOrcaManagedCodexHomePath(), 'sessions')
+  const relativeSessionPath = resolveManagedSessionRelativePath(
+    managedSessionsRoot,
+    managedSessionFilePath
+  )
+  if (!relativeSessionPath) {
+    return 'ignored'
+  }
+
+  const systemSessionsRoot = join(systemCodexHomePath, 'sessions')
+  const systemSessionFilePath = join(systemSessionsRoot, relativeSessionPath)
+  const existingTarget = tryLstat(systemSessionFilePath)
+  if (existingTarget) {
+    if (sameFileIdentity(tryLstat(managedSessionFilePath), existingTarget)) {
+      return 'already-linked'
+    }
+    // Why: a relative-path collision can represent two independent sessions;
+    // overwriting either history would turn a visibility fix into data loss.
+    console.warn('[codex-session-bridge] Managed session export collision:', {
+      managedSessionFilePath,
+      systemSessionFilePath
+    })
+    return 'collision'
+  }
+
+  if (!prepareSafeSystemTargetDirectory(systemSessionsRoot, dirname(systemSessionFilePath))) {
+    return 'failed'
+  }
+  try {
+    linkSync(managedSessionFilePath, systemSessionFilePath)
+    return 'linked'
+  } catch (error) {
+    // Why: another bridge can win the create race after the preflight check.
+    // Treat the resulting shared inode as success without replacing anything.
+    if (sameFileIdentity(tryLstat(managedSessionFilePath), tryLstat(systemSessionFilePath))) {
+      return 'already-linked'
+    }
+    console.warn('[codex-session-bridge] Failed to export managed Codex session:', {
+      managedSessionFilePath,
+      systemSessionFilePath,
+      error
+    })
+    return 'failed'
+  }
+}
+
+function resolveManagedSessionRelativePath(
+  managedSessionsRoot: string,
+  managedSessionFilePath: string
+): string | null {
+  const sourceStat = tryLstat(managedSessionFilePath)
+  if (!sourceStat?.isFile() || !managedSessionFilePath.endsWith('.jsonl')) {
+    return null
+  }
+  const canonicalRoot = tryRealpath(managedSessionsRoot)
+  const canonicalSource = tryRealpath(managedSessionFilePath)
+  if (!canonicalRoot || !canonicalSource) {
+    return null
+  }
+  const relativePath = relative(canonicalRoot, canonicalSource)
+  return isSafeRelativePath(relativePath) ? relativePath : null
+}
+
+function prepareSafeSystemTargetDirectory(
+  systemSessionsRoot: string,
+  targetDirectory: string
+): boolean {
+  try {
+    mkdirSync(systemSessionsRoot, { recursive: true })
+    const relativeTargetDirectory = relative(systemSessionsRoot, targetDirectory)
+    if (relativeTargetDirectory && !isSafeRelativePath(relativeTargetDirectory)) {
+      return false
+    }
+    let currentDirectory = systemSessionsRoot
+    for (const segment of relativeTargetDirectory.split(sep).filter(Boolean)) {
+      currentDirectory = join(currentDirectory, segment)
+      const existingDirectory = tryLstat(currentDirectory)
+      if (existingDirectory) {
+        if (!existingDirectory.isDirectory() || existingDirectory.isSymbolicLink()) {
+          console.warn('[codex-session-bridge] Refusing symlinked system history directory:', {
+            currentDirectory
+          })
+          return false
+        }
+        continue
+      }
+      mkdirSync(currentDirectory)
+    }
+    const canonicalRoot = realpathSync.native(systemSessionsRoot)
+    const canonicalTargetDirectory = realpathSync.native(targetDirectory)
+    const canonicalRelativeTarget = relative(canonicalRoot, canonicalTargetDirectory)
+    if (canonicalRelativeTarget === '' || isSafeRelativePath(canonicalRelativeTarget)) {
+      return true
+    }
+    console.warn('[codex-session-bridge] Refusing session export outside system history root:', {
+      systemSessionsRoot,
+      targetDirectory
+    })
+  } catch (error) {
+    console.warn('[codex-session-bridge] Failed to prepare system Codex history:', {
+      systemSessionsRoot,
+      targetDirectory,
+      error
+    })
+  }
+  return false
+}
+
+function isSafeRelativePath(relativePath: string): boolean {
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${sep}`) &&
+    !isAbsolute(relativePath)
+  )
+}
+
+function sameFileIdentity(left: Stats | null, right: Stats | null): boolean {
+  return !!left && !!right && left.ino !== 0 && left.dev === right.dev && left.ino === right.ino
+}
+
+function tryLstat(path: string): Stats | null {
+  try {
+    return lstatSync(path)
+  } catch {
+    return null
+  }
+}
+
+function tryRealpath(path: string): string | null {
+  try {
+    return realpathSync.native(path)
+  } catch {
+    return null
+  }
+}

--- a/src/main/codex/wsl-codex-session-bridge.test.ts
+++ b/src/main/codex/wsl-codex-session-bridge.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 })
 
 describe('syncWslCodexSessionsIntoManagedHome', () => {
-  it('runs a WSL hardlink bridge from the WSL system sessions into the managed home', async () => {
+  it('runs a bidirectional WSL hardlink bridge between system and managed histories', async () => {
     mockExecFileSuccess()
 
     const summary = await syncWslCodexSessionsIntoManagedHome({
@@ -61,13 +61,19 @@ describe('syncWslCodexSessionsIntoManagedHome', () => {
     expect(options.windowsHide).toBe(true)
 
     const shellCommand = args[5]
-    expect(shellCommand).toContain("source_sessions_root='/home/alice/.codex/sessions'")
+    expect(shellCommand).toContain("system_sessions_root='/home/alice/.codex/sessions'")
     expect(shellCommand).toContain(
       "managed_sessions_root='/home/alice/.local/share/orca/codex-runtime-home/home/sessions'"
     )
-    expect(shellCommand).toContain(`find "\\$source_sessions_root" -type f -name '*.jsonl' -print0`)
+    expect(shellCommand).toContain(`find "\\$source_root" -type f -name '*.jsonl' -print0`)
     expect(shellCommand).toContain('ln -- "\\$source_file" "\\$target_file"')
     expect(shellCommand).toContain('if [ -e "\\$target_file" ] || [ -L "\\$target_file" ]; then')
+    expect(shellCommand).toContain(
+      'bridge_session_tree "\\$managed_sessions_root" "\\$system_sessions_root"'
+    )
+    expect(shellCommand).toContain(
+      'bridge_session_tree "\\$system_sessions_root" "\\$managed_sessions_root"'
+    )
     expect(shellCommand).not.toContain('ln -s')
     expect(shellCommand).not.toContain('cp ')
     expect(shellCommand).not.toContain('sqlite')
@@ -149,7 +155,7 @@ describe('buildWslCodexSessionBridgeShellCommand', () => {
     })
 
     expect(shellCommand).toContain(
-      `source_sessions_root='/home/alice/.codex/sessions with '\\''quote'\\'''`
+      `system_sessions_root='/home/alice/.codex/sessions with '\\''quote'\\'''`
     )
     expect(shellCommand).toContain(`-name '*.jsonl'`)
     expect(shellCommand).not.toContain('.sqlite')
@@ -161,7 +167,8 @@ describe('buildWslCodexSessionBridgeShellCommand', () => {
       managedSessionsRoot: '/home/alice/.local/share/orca/codex-runtime-home/home/sessions'
     })
 
-    expect(shellCommand).toContain('\\$source_sessions_root')
+    expect(shellCommand).toContain('\\$system_sessions_root')
+    expect(shellCommand).toContain('\\$source_root')
     expect(shellCommand).toContain('\\$source_file')
     expect(shellCommand).toContain('\\$((scanned_files + 1))')
   })

--- a/src/main/codex/wsl-codex-session-bridge.ts
+++ b/src/main/codex/wsl-codex-session-bridge.ts
@@ -85,29 +85,34 @@ export function buildWslCodexSessionBridgeShellCommand(
 ): string {
   const shellCommand = [
     'set -u',
-    `source_sessions_root=${quoteBashString(paths.systemSessionsRoot)}`,
+    `system_sessions_root=${quoteBashString(paths.systemSessionsRoot)}`,
     `managed_sessions_root=${quoteBashString(paths.managedSessionsRoot)}`,
     'scanned_files=0',
     'linked_files=0',
-    'if [ ! -d "$source_sessions_root" ]; then',
-    `  printf '{"scannedFiles":0,"linkedFiles":0}\\n'`,
-    '  exit 0',
-    'fi',
-    "while IFS= read -r -d '' source_file; do",
-    '  scanned_files=$((scanned_files + 1))',
-    '  relative_path=${source_file#"$source_sessions_root"/}',
-    '  target_file="$managed_sessions_root/$relative_path"',
-    '  if [ -e "$target_file" ] || [ -L "$target_file" ]; then',
-    '    continue',
-    '  fi',
-    '  target_dir=${target_file%/*}',
-    '  mkdir -p -- "$target_dir" || continue',
+    'bridge_session_tree() {',
+    '  local source_root=$1',
+    '  local target_root=$2',
+    '  [ -d "$source_root" ] || return 0',
+    "  while IFS= read -r -d '' source_file; do",
+    '    scanned_files=$((scanned_files + 1))',
+    '    relative_path=${source_file#"$source_root"/}',
+    '    target_file="$target_root/$relative_path"',
+    '    if [ -e "$target_file" ] || [ -L "$target_file" ]; then',
+    '      continue',
+    '    fi',
+    '    target_dir=${target_file%/*}',
+    '    mkdir -p -- "$target_dir" || continue',
     // Why: Codex resume ignores symlinked JSONL, so WSL links must be
     // Linux hardlinks created inside the distro filesystem.
-    '  if ln -- "$source_file" "$target_file"; then',
-    '    linked_files=$((linked_files + 1))',
-    '  fi',
-    `done < <(find "$source_sessions_root" -type f -name '*.jsonl' -print0 2>/dev/null)`,
+    '    if ln -- "$source_file" "$target_file"; then',
+    '      linked_files=$((linked_files + 1))',
+    '    fi',
+    `  done < <(find "$source_root" -type f -name '*.jsonl' -print0 2>/dev/null)`,
+    '}',
+    // Why: export first so Orca-created WSL sessions survive collisions; the
+    // import pass then makes external sessions available in Orca as before.
+    'bridge_session_tree "$managed_sessions_root" "$system_sessions_root"',
+    'bridge_session_tree "$system_sessions_root" "$managed_sessions_root"',
     `printf '{"scannedFiles":%s,"linkedFiles":%s}\\n' "$scanned_files" "$linked_files"`
   ].join('\n')
   return escapeWslShCommandForWindows(shellCommand)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -123,6 +123,8 @@ import {
 } from './codex-accounts/runtime-selection'
 import { normalizeClaudeRuntimeSelection } from './claude-accounts/runtime-selection'
 import { codexHookService } from './codex/hook-service'
+import { scheduleManagedCodexSessionExportFromHook } from './codex/codex-session-history-hook'
+import { resolveHostCodexSessionSourceHome } from './codex/codex-session-source-home'
 import { getDefaultWslDistro } from './wsl'
 import { ClaudeAccountService } from './claude-accounts/service'
 import { ClaudeRuntimeAuthService } from './claude-accounts/runtime-auth-service'
@@ -756,6 +758,7 @@ function openMainWindow(): BrowserWindow {
   if (!store) {
     throw new Error('Store must be initialized before opening the main window')
   }
+  const mainWindowStore = store
   if (!runtime) {
     throw new Error('Runtime must be initialized before opening the main window')
   }
@@ -1030,9 +1033,14 @@ function openMainWindow(): BrowserWindow {
       receivedAt,
       stateStartedAt,
       launchToken,
+      hookEventName,
       providerSession,
       isReplay
     }) => {
+      scheduleManagedCodexSessionExportFromHook(
+        { connectionId, hookEventName, payload, providerSession, isReplay },
+        resolveHostCodexSessionSourceHome(mainWindowStore.getSettings())
+      )
       if (mainWindow?.isDestroyed()) {
         return
       }


### PR DESCRIPTION
## Description

Closes #4444.

Orca redirects Codex to a managed `CODEX_HOME`, but its session bridge only linked external system history into that managed home. Sessions created by Orca therefore stayed private to the managed history tree. The bridge also ran before a new rollout file was created, so merely reversing the startup scan would not make the current chat visible.

This PR:

- reconciles managed history into the configured external Codex history before retaining the existing external-to-managed import;
- uses same-file hardlinks so Orca and external Codex append to one JSONL instead of divergent copies;
- exports the exact rollout path from live local Codex `SessionStart`, with `UserPromptSubmit` as an event-driven retry if creation was not yet observable;
- preserves both originals on relative-path collisions and rejects transcript paths or target directories that escape through traversal or symlinks;
- keeps `EXDEV`/`EPERM` failures fail-safe: the managed original remains untouched and no misleading partial copy is created;
- makes the existing WSL launch-time hardlink bridge bidirectional inside the distro; and
- registers the experimental `agent-session.codex-external-history-bridge` reliability gate.

### Reliability proof

- **Reliability invariant:** a valid session created under Orca managed `CODEX_HOME` becomes discoverable from the configured external history root without overwriting either corpus or creating divergent mutable copies. Motivated by #4444.
- **Material impact:** closes the one-way persistence boundary and makes the current local session externally visible from the first authoritative Codex lifecycle event.
- **Product change type:** runtime hardening plus an experimental deterministic gate.
- **Performance risk inventory:** touches Codex launch/session-start persistence only. It does not touch typing, focus, rendering, resize, PTY output, tab/workspace switching, git scans, or store subscribers.
- **No-regression evidence:** live hooks schedule one O(1) exact-file operation off the hook response path; a bounded 1024-entry success cache suppresses later prompt work. Upgrade recovery adds one incremental managed-history walk to the existing coalesced background bridge. No polling, startup await, hidden-pane wake, subprocess, or renderer work was added.
- **Correctness evidence:** the registered five-file Vitest command proves shared-inode appends, repeat/race idempotence, collision preservation, path/symlink rejection, custom source homes, `EXDEV`/`EPERM` safety, hook timing, and WSL command construction.
- **Provider/platform coverage:** local macOS is covered with synthetic filesystem evidence. Linux/Windows host behavior awaits CI. WSL has command-contract coverage but not a live Windows/WSL run. SSH and remote-runtime are unaffected because their Codex history is not redirected into the host managed home. Daemon PTYs use the same main-process host bridge. Mobile/relay is unaffected.
- **Diagnostics:** collision, unsafe target, and link failures emit `[codex-session-bridge]` warnings containing paths and errors, never session contents.
- **Promotion status:** partial/experimental; no promotion until cross-platform CI, packaged external-Codex evidence, and soak history exist.
- **Rollback or demotion rule:** demote or revert if the deterministic filesystem oracle flakes, either original is overwritten, or a path creates a divergent mutable copy.

## Evidence of fix (before + after)

All fixtures are synthetic. No real auth, user history, reporter attachment, or user-provided code was read or copied.

**Before**

The exact production-boundary regression was run twice before implementation:

```text
pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-session-bridge.test.ts -t "exports Orca-created sessions into the external Codex history root"

1 failed, 9 skipped
ENOENT: no such file or directory, open '<synthetic-home>/.codex/sessions/2026/07/10/rollout-orca.jsonl'
```

**After**

```text
Exact original reproduction: 1 passed, 9 skipped
Focused reliability gate: 5 files passed, 33 tests passed
Bridge plus runtime-home integration: 6 files passed, 117 tests passed
pnpm run typecheck: 3 projects passed
Touched-file oxlint: passed
pnpm run check:reliability-gates: passed (32 gates)
pnpm run check:max-lines-ratchet: passed (no new bypasses)
git diff --check: passed
```

Full `pnpm run lint` passed oxlint, switch exhaustiveness, styled scrollbar, reliability, max-lines, and localization catalog reference checks, then stopped on an unrelated existing Japanese catalog interpolation mismatch for `components.native-chat.composer.uploadingAttachments`. No localization files are changed here.

## ELI5

Orca and normal Codex were keeping chat notebooks in two different filing cabinets. Orca knew how to put normal Codex notebooks into its cabinet, but not how to put Orca-created notebooks back into the normal cabinet. This makes both cabinets point at the same notebook page, so new writing stays visible from either side without copying or overwriting anyone else’s notebook.

## User-facing trade-offs

- Export requires a hardlink-capable shared filesystem. Cross-device or permission-blocked links preserve the Orca chat but cannot expose it externally; the PR deliberately avoids stale copies and symlinks that Codex ignores.
- Codex still filters project history by the recorded `cwd`. Orca keeps the truthful worktree path so resuming cannot silently edit the wrong checkout; users opening external Codex at the original repo path may need the worktree path or `codex resume --all`.
- Managed `session_index.jsonl` rename metadata is not synchronized. The transcript becomes externally discoverable, but an Orca-only renamed title may not appear externally.
- The WSL bridge is bidirectional on the next launch-time reconciliation; same-live-session WSL hook export is not yet covered.
- Packaged Codex Mac/CLI validation was intentionally not run against real user history. The deterministic production-boundary oracle is covered; live packaged evidence remains a follow-up gate.
- Independent agent review was attempted but unavailable because the review service returned a service-wide 503; local adversarial review and the listed automated gates were completed.
