### PR TITLE
perf(renderer): dedupe concurrent Markdown document scans

### DIFF
--- a/src/renderer/src/components/editor/markdown-document-list-request.test.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.test.ts
@@ -102,6 +102,38 @@ describe('shared Markdown document list requests', () => {
     }
   })
 
+  it('evicts an abandoned scan for a route that is never requested again', async () => {
+    const abandoned = deferred<MarkdownDocument[]>()
+    const load = vi.fn().mockReturnValueOnce(abandoned.promise).mockResolvedValueOnce([])
+    const now = vi.spyOn(performance, 'now').mockReturnValue(1_000)
+
+    try {
+      const abandonedRequest = requestSharedMarkdownDocumentList(
+        context(),
+        '/abandoned-only',
+        {},
+        load
+      )
+      now.mockReturnValue(31_001)
+      // A request for a different route sweeps the expired entry so the map
+      // does not pin the abandoned promise for the renderer's lifetime.
+      await expect(
+        requestSharedMarkdownDocumentList(context(), '/other-route', {}, load)
+      ).resolves.toEqual([])
+
+      load.mockResolvedValueOnce([])
+      await expect(
+        requestSharedMarkdownDocumentList(context(), '/abandoned-only', {}, load)
+      ).resolves.toEqual([])
+      expect(load).toHaveBeenCalledTimes(3)
+
+      abandoned.resolve([])
+      await expect(abandonedRequest).resolves.toEqual([])
+    } finally {
+      now.mockRestore()
+    }
+  })
+
   it('keeps runtime routes isolated and encodes unusual paths losslessly', () => {
     const local = context()
     const ssh = context({ connectionId: 'ssh-1' })

--- a/src/renderer/src/components/editor/markdown-document-list-request.test.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.test.ts
@@ -79,11 +79,36 @@ describe('shared Markdown document list requests', () => {
     await expect(initialRequest).resolves.toBe(staleDocuments)
   })
 
+  it('allows an ordinary retry after an older scan stops settling', async () => {
+    const stale = deferred<MarkdownDocument[]>()
+    const retry = deferred<MarkdownDocument[]>()
+    const load = vi.fn().mockReturnValueOnce(stale.promise).mockReturnValueOnce(retry.promise)
+    const now = vi.spyOn(performance, 'now').mockReturnValue(1_000)
+
+    try {
+      const initialRequest = requestSharedMarkdownDocumentList(context(), '/stuck', {}, load)
+      now.mockReturnValue(31_001)
+      const retryRequest = requestSharedMarkdownDocumentList(context(), '/stuck', {}, load)
+
+      expect(load).toHaveBeenCalledTimes(2)
+      expect(retryRequest).not.toBe(initialRequest)
+
+      retry.resolve([])
+      stale.resolve([])
+      await expect(retryRequest).resolves.toEqual([])
+      await expect(initialRequest).resolves.toEqual([])
+    } finally {
+      now.mockRestore()
+    }
+  })
+
   it('keeps runtime routes isolated and encodes unusual paths losslessly', () => {
     const local = context()
     const ssh = context({ connectionId: 'ssh-1' })
     const runtime = context({ settings: { activeRuntimeEnvironmentId: ' runtime-1 ' } })
     const unusualRoot = '/repo\nwith-newline'
+    const windowsRoot = 'C:\\repo\\docs'
+    const uncRoot = '\\\\server\\share\\repo'
 
     expect(getMarkdownDocumentListRequestKey(local, unusualRoot)).not.toBe(
       getMarkdownDocumentListRequestKey(ssh, unusualRoot)
@@ -94,6 +119,10 @@ describe('shared Markdown document list requests', () => {
     expect(JSON.parse(getMarkdownDocumentListRequestKey(local, unusualRoot)).at(-1)).toBe(
       unusualRoot
     )
+    expect(JSON.parse(getMarkdownDocumentListRequestKey(local, windowsRoot)).at(-1)).toBe(
+      windowsRoot
+    )
+    expect(JSON.parse(getMarkdownDocumentListRequestKey(local, uncRoot)).at(-1)).toBe(uncRoot)
   })
 
   it('clears rejected requests so a retry can run', async () => {

--- a/src/renderer/src/components/editor/markdown-document-list-request.test.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MarkdownDocument } from '../../../../shared/types'
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import {
+  getMarkdownDocumentListRequestKey,
+  requestSharedMarkdownDocumentList
+} from './markdown-document-list-request'
+
+function context(overrides: Partial<RuntimeFileOperationArgs> = {}): RuntimeFileOperationArgs {
+  return {
+    settings: { activeRuntimeEnvironmentId: null },
+    worktreeId: 'worktree-1',
+    worktreePath: '/repo',
+    ...overrides
+  }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  reject: (error: Error) => void
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
+describe('shared Markdown document list requests', () => {
+  it('collapses concurrent pane scans and releases the result after settlement', async () => {
+    const pending = deferred<MarkdownDocument[]>()
+    const load = vi.fn(() => pending.promise)
+    const requests = Array.from({ length: 200 }, () =>
+      requestSharedMarkdownDocumentList(context(), '/repo', load)
+    )
+
+    expect(load).toHaveBeenCalledTimes(1)
+    expect(new Set(requests).size).toBe(1)
+
+    const documents = [{ filePath: '/repo/README.md', relativePath: 'README.md' }]
+    pending.resolve(documents as MarkdownDocument[])
+    await expect(Promise.all(requests)).resolves.toEqual(
+      Array.from({ length: 200 }, () => documents)
+    )
+
+    const nextDocuments = [{ filePath: '/repo/notes.md', relativePath: 'notes.md' }]
+    load.mockResolvedValueOnce(nextDocuments as MarkdownDocument[])
+    await expect(requestSharedMarkdownDocumentList(context(), '/repo', load)).resolves.toBe(
+      nextDocuments
+    )
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps runtime routes isolated and encodes unusual paths losslessly', () => {
+    const local = context()
+    const ssh = context({ connectionId: 'ssh-1' })
+    const runtime = context({ settings: { activeRuntimeEnvironmentId: ' runtime-1 ' } })
+    const unusualRoot = '/repo\nwith-newline'
+
+    expect(getMarkdownDocumentListRequestKey(local, unusualRoot)).not.toBe(
+      getMarkdownDocumentListRequestKey(ssh, unusualRoot)
+    )
+    expect(getMarkdownDocumentListRequestKey(ssh, unusualRoot)).not.toBe(
+      getMarkdownDocumentListRequestKey(runtime, unusualRoot)
+    )
+    expect(JSON.parse(getMarkdownDocumentListRequestKey(local, unusualRoot)).at(-1)).toBe(
+      unusualRoot
+    )
+  })
+
+  it('clears rejected requests so a retry can run', async () => {
+    const failure = deferred<MarkdownDocument[]>()
+    const load = vi.fn(() => failure.promise)
+    const first = requestSharedMarkdownDocumentList(context(), '/retry', load)
+    const second = requestSharedMarkdownDocumentList(context(), '/retry', load)
+
+    failure.reject(new Error('offline'))
+    await expect(first).rejects.toThrow('offline')
+    await expect(second).rejects.toThrow('offline')
+
+    load.mockResolvedValueOnce([])
+    await expect(requestSharedMarkdownDocumentList(context(), '/retry', load)).resolves.toEqual([])
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/components/editor/markdown-document-list-request.test.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.test.ts
@@ -34,7 +34,7 @@ describe('shared Markdown document list requests', () => {
     const pending = deferred<MarkdownDocument[]>()
     const load = vi.fn(() => pending.promise)
     const requests = Array.from({ length: 200 }, () =>
-      requestSharedMarkdownDocumentList(context(), '/repo', load)
+      requestSharedMarkdownDocumentList(context(), '/repo', {}, load)
     )
 
     expect(load).toHaveBeenCalledTimes(1)
@@ -48,10 +48,35 @@ describe('shared Markdown document list requests', () => {
 
     const nextDocuments = [{ filePath: '/repo/notes.md', relativePath: 'notes.md' }]
     load.mockResolvedValueOnce(nextDocuments as MarkdownDocument[])
-    await expect(requestSharedMarkdownDocumentList(context(), '/repo', load)).resolves.toBe(
+    await expect(requestSharedMarkdownDocumentList(context(), '/repo', {}, load)).resolves.toBe(
       nextDocuments
     )
     expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts a fresh scan after a mutation instead of joining an older snapshot', async () => {
+    const stale = deferred<MarkdownDocument[]>()
+    const fresh = deferred<MarkdownDocument[]>()
+    const load = vi.fn().mockReturnValueOnce(stale.promise).mockReturnValueOnce(fresh.promise)
+
+    const initialRequest = requestSharedMarkdownDocumentList(context(), '/repo', {}, load)
+    const mutationRefresh = requestSharedMarkdownDocumentList(
+      context(),
+      '/repo',
+      { requireFresh: true },
+      load
+    )
+
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(mutationRefresh).not.toBe(initialRequest)
+
+    const freshDocuments = [{ filePath: '/repo/new.md', relativePath: 'new.md' }]
+    fresh.resolve(freshDocuments as MarkdownDocument[])
+    await expect(mutationRefresh).resolves.toBe(freshDocuments)
+
+    const staleDocuments = [{ filePath: '/repo/old.md', relativePath: 'old.md' }]
+    stale.resolve(staleDocuments as MarkdownDocument[])
+    await expect(initialRequest).resolves.toBe(staleDocuments)
   })
 
   it('keeps runtime routes isolated and encodes unusual paths losslessly', () => {
@@ -74,15 +99,17 @@ describe('shared Markdown document list requests', () => {
   it('clears rejected requests so a retry can run', async () => {
     const failure = deferred<MarkdownDocument[]>()
     const load = vi.fn(() => failure.promise)
-    const first = requestSharedMarkdownDocumentList(context(), '/retry', load)
-    const second = requestSharedMarkdownDocumentList(context(), '/retry', load)
+    const first = requestSharedMarkdownDocumentList(context(), '/retry', {}, load)
+    const second = requestSharedMarkdownDocumentList(context(), '/retry', {}, load)
 
     failure.reject(new Error('offline'))
     await expect(first).rejects.toThrow('offline')
     await expect(second).rejects.toThrow('offline')
 
     load.mockResolvedValueOnce([])
-    await expect(requestSharedMarkdownDocumentList(context(), '/retry', load)).resolves.toEqual([])
+    await expect(requestSharedMarkdownDocumentList(context(), '/retry', {}, load)).resolves.toEqual(
+      []
+    )
     expect(load).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/components/editor/markdown-document-list-request.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.ts
@@ -1,0 +1,47 @@
+import type { MarkdownDocument } from '../../../../shared/types'
+import {
+  listRuntimeMarkdownDocuments,
+  type RuntimeFileOperationArgs
+} from '@/runtime/runtime-file-client'
+
+type MarkdownDocumentListLoader = (
+  context: RuntimeFileOperationArgs,
+  rootPath: string
+) => Promise<MarkdownDocument[]>
+
+const inFlightMarkdownDocumentLists = new Map<string, Promise<MarkdownDocument[]>>()
+
+export function getMarkdownDocumentListRequestKey(
+  context: RuntimeFileOperationArgs,
+  rootPath: string
+): string {
+  return JSON.stringify([
+    context.settings?.activeRuntimeEnvironmentId?.trim() ?? '',
+    context.connectionId ?? '',
+    context.worktreeId ?? '',
+    context.worktreePath ?? '',
+    rootPath
+  ])
+}
+
+export function requestSharedMarkdownDocumentList(
+  context: RuntimeFileOperationArgs,
+  rootPath: string,
+  load: MarkdownDocumentListLoader = listRuntimeMarkdownDocuments
+): Promise<MarkdownDocument[]> {
+  const key = getMarkdownDocumentListRequestKey(context, rootPath)
+  const existing = inFlightMarkdownDocumentLists.get(key)
+  if (existing) {
+    return existing
+  }
+
+  // Why: split Markdown panes mount together and otherwise launch identical
+  // whole-worktree local/SSH scans; share only concurrent work so freshness is unchanged.
+  const request = load(context, rootPath).finally(() => {
+    if (inFlightMarkdownDocumentLists.get(key) === request) {
+      inFlightMarkdownDocumentLists.delete(key)
+    }
+  })
+  inFlightMarkdownDocumentLists.set(key, request)
+  return request
+}

--- a/src/renderer/src/components/editor/markdown-document-list-request.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.ts
@@ -40,15 +40,18 @@ export function requestSharedMarkdownDocumentList(
   options: MarkdownDocumentListRequestOptions = {},
   load: MarkdownDocumentListLoader = listRuntimeMarkdownDocuments
 ): Promise<MarkdownDocument[]> {
+  const now = performance.now()
+  // Why: a never-settling scan for a route that is never requested again would
+  // otherwise pin its map entry (and captured context) for the renderer's life.
+  for (const [staleKey, entry] of inFlightMarkdownDocumentLists) {
+    if (now - entry.startedAt >= MARKDOWN_DOCUMENT_LIST_JOIN_WINDOW_MS) {
+      inFlightMarkdownDocumentLists.delete(staleKey)
+    }
+  }
+
   const key = getMarkdownDocumentListRequestKey(context, rootPath)
   const existing = inFlightMarkdownDocumentLists.get(key)
-  const existingAge = existing ? performance.now() - existing.startedAt : null
-  if (
-    existing &&
-    !options.requireFresh &&
-    existingAge !== null &&
-    existingAge < MARKDOWN_DOCUMENT_LIST_JOIN_WINDOW_MS
-  ) {
+  if (existing && !options.requireFresh) {
     return existing.request
   }
 
@@ -61,6 +64,6 @@ export function requestSharedMarkdownDocumentList(
   })
   // Why: local and UNC filesystem calls have no timeout, so an abandoned scan
   // must not suppress every ordinary retry for the renderer's lifetime.
-  inFlightMarkdownDocumentLists.set(key, { request, startedAt: performance.now() })
+  inFlightMarkdownDocumentLists.set(key, { request, startedAt: now })
   return request
 }

--- a/src/renderer/src/components/editor/markdown-document-list-request.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.ts
@@ -13,7 +13,13 @@ type MarkdownDocumentListRequestOptions = {
   requireFresh?: boolean
 }
 
-const inFlightMarkdownDocumentLists = new Map<string, Promise<MarkdownDocument[]>>()
+type InFlightMarkdownDocumentList = {
+  request: Promise<MarkdownDocument[]>
+  startedAt: number
+}
+
+const MARKDOWN_DOCUMENT_LIST_JOIN_WINDOW_MS = 30_000
+const inFlightMarkdownDocumentLists = new Map<string, InFlightMarkdownDocumentList>()
 
 export function getMarkdownDocumentListRequestKey(
   context: RuntimeFileOperationArgs,
@@ -36,17 +42,25 @@ export function requestSharedMarkdownDocumentList(
 ): Promise<MarkdownDocument[]> {
   const key = getMarkdownDocumentListRequestKey(context, rootPath)
   const existing = inFlightMarkdownDocumentLists.get(key)
-  if (existing && !options.requireFresh) {
-    return existing
+  const existingAge = existing ? performance.now() - existing.startedAt : null
+  if (
+    existing &&
+    !options.requireFresh &&
+    existingAge !== null &&
+    existingAge < MARKDOWN_DOCUMENT_LIST_JOIN_WINDOW_MS
+  ) {
+    return existing.request
   }
 
   // Why: split Markdown panes mount together and otherwise launch identical
   // whole-worktree local/SSH scans; mutation refreshes bypass older snapshots.
   const request = load(context, rootPath).finally(() => {
-    if (inFlightMarkdownDocumentLists.get(key) === request) {
+    if (inFlightMarkdownDocumentLists.get(key)?.request === request) {
       inFlightMarkdownDocumentLists.delete(key)
     }
   })
-  inFlightMarkdownDocumentLists.set(key, request)
+  // Why: local and UNC filesystem calls have no timeout, so an abandoned scan
+  // must not suppress every ordinary retry for the renderer's lifetime.
+  inFlightMarkdownDocumentLists.set(key, { request, startedAt: performance.now() })
   return request
 }

--- a/src/renderer/src/components/editor/markdown-document-list-request.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.ts
@@ -9,6 +9,10 @@ type MarkdownDocumentListLoader = (
   rootPath: string
 ) => Promise<MarkdownDocument[]>
 
+type MarkdownDocumentListRequestOptions = {
+  requireFresh?: boolean
+}
+
 const inFlightMarkdownDocumentLists = new Map<string, Promise<MarkdownDocument[]>>()
 
 export function getMarkdownDocumentListRequestKey(
@@ -27,16 +31,17 @@ export function getMarkdownDocumentListRequestKey(
 export function requestSharedMarkdownDocumentList(
   context: RuntimeFileOperationArgs,
   rootPath: string,
+  options: MarkdownDocumentListRequestOptions = {},
   load: MarkdownDocumentListLoader = listRuntimeMarkdownDocuments
 ): Promise<MarkdownDocument[]> {
   const key = getMarkdownDocumentListRequestKey(context, rootPath)
   const existing = inFlightMarkdownDocumentLists.get(key)
-  if (existing) {
+  if (existing && !options.requireFresh) {
     return existing
   }
 
   // Why: split Markdown panes mount together and otherwise launch identical
-  // whole-worktree local/SSH scans; share only concurrent work so freshness is unchanged.
+  // whole-worktree local/SSH scans; mutation refreshes bypass older snapshots.
   const request = load(context, rootPath).finally(() => {
     if (inFlightMarkdownDocumentLists.get(key) === request) {
       inFlightMarkdownDocumentLists.delete(key)

--- a/src/renderer/src/components/editor/useMarkdownDocuments.ts
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { MarkdownDocument } from '../../../../shared/types'
 import { useAppStore } from '@/store'
 import { getConnectionId } from '@/lib/connection-context'
-import { listRuntimeMarkdownDocuments, statRuntimePath } from '@/runtime/runtime-file-client'
+import { statRuntimePath } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import type { MarkdownViewMode, OpenFile } from '@/store/slices/editor'
 import {
@@ -11,6 +11,7 @@ import {
   resolveMarkdownDocLink
 } from './markdown-doc-links'
 import { selectMarkdownDocumentWorktreePath } from './markdown-document-worktree-path-selector'
+import { requestSharedMarkdownDocumentList } from './markdown-document-list-request'
 
 type OpenMarkdownDocumentOptions = {
   anchor?: string | null
@@ -60,7 +61,7 @@ export function useMarkdownDocuments(
     const requestId = requestRef.current + 1
     requestRef.current = requestId
     try {
-      const documents = await listRuntimeMarkdownDocuments(
+      const documents = await requestSharedMarkdownDocumentList(
         {
           settings: settingsForRuntimeOwner(
             useAppStore.getState().settings,

--- a/src/renderer/src/components/editor/useMarkdownDocuments.ts
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.ts
@@ -53,43 +53,47 @@ export function useMarkdownDocuments(
 
   const connectionId = getConnectionId(worktreeId)
 
-  const refreshMarkdownDocuments = useCallback(async (): Promise<void> => {
-    if (!worktreeId || !worktreePath) {
-      return
-    }
-
-    const requestId = requestRef.current + 1
-    requestRef.current = requestId
-    try {
-      const documents = await requestSharedMarkdownDocumentList(
-        {
-          settings: settingsForRuntimeOwner(
-            useAppStore.getState().settings,
-            activeFile.runtimeEnvironmentId
-          ),
-          worktreeId,
-          worktreePath,
-          connectionId: connectionId ?? undefined
-        },
-        worktreePath
-      )
-      if (requestRef.current !== requestId) {
+  const refreshMarkdownDocuments = useCallback(
+    async (requireFresh = false): Promise<void> => {
+      if (!worktreeId || !worktreePath) {
         return
       }
-      setMarkdownDocumentsByWorktree((prev) => ({
-        ...prev,
-        [worktreeId]: documents
-      }))
-    } catch (err) {
-      console.error('Failed to list markdown documents:', err)
-      if (requestRef.current === requestId) {
+
+      const requestId = requestRef.current + 1
+      requestRef.current = requestId
+      try {
+        const documents = await requestSharedMarkdownDocumentList(
+          {
+            settings: settingsForRuntimeOwner(
+              useAppStore.getState().settings,
+              activeFile.runtimeEnvironmentId
+            ),
+            worktreeId,
+            worktreePath,
+            connectionId: connectionId ?? undefined
+          },
+          worktreePath,
+          { requireFresh }
+        )
+        if (requestRef.current !== requestId) {
+          return
+        }
         setMarkdownDocumentsByWorktree((prev) => ({
           ...prev,
-          [worktreeId]: []
+          [worktreeId]: documents
         }))
+      } catch (err) {
+        console.error('Failed to list markdown documents:', err)
+        if (requestRef.current === requestId) {
+          setMarkdownDocumentsByWorktree((prev) => ({
+            ...prev,
+            [worktreeId]: []
+          }))
+        }
       }
-    }
-  }, [activeFile.runtimeEnvironmentId, connectionId, worktreeId, worktreePath])
+    },
+    [activeFile.runtimeEnvironmentId, connectionId, worktreeId, worktreePath]
+  )
 
   const openMarkdownDocument = useCallback(
     async (
@@ -113,11 +117,11 @@ export function useMarkdownDocuments(
           document.filePath
         )
         if (stats.isDirectory) {
-          await refreshMarkdownDocuments()
+          await refreshMarkdownDocuments(true)
           return
         }
       } catch {
-        await refreshMarkdownDocuments()
+        await refreshMarkdownDocuments(true)
         return
       }
 
@@ -175,7 +179,7 @@ export function useMarkdownDocuments(
   )
 
   const mdSave = useCallback(
-    (content: string) => onSave(content).then(() => refreshMarkdownDocuments()),
+    (content: string) => onSave(content).then(() => refreshMarkdownDocuments(true)),
     [onSave, refreshMarkdownDocuments]
   )
 


### PR DESCRIPTION
## Summary

- Share concurrent Markdown document-list requests across mounted editor panes on the same runtime/worktree route.
- Release the in-flight entry on both success and failure, so later refreshes still perform a fresh scan.
- Keep local, SSH, and runtime-environment routes isolated with a lossless tuple key.

## Why

Every `useMarkdownDocuments` instance owns local result state and refreshes when a Markdown pane mounts or changes view mode. In a restored/split layout, panes mount together and each launched the same whole-worktree discovery independently.

That discovery is not cheap: local mode recursively awaits `readdir` for the worktree tree, while SSH/runtime mode requests a full provider file listing. Four Markdown panes therefore meant four identical filesystem/RPC scans before any pane could use the same document index.

The new request layer shares only an in-flight Promise. It deliberately does not cache settled results, so the next view/save refresh has exactly the previous freshness behavior.

## Performance evidence

| Scenario | Before | After |
| --- | ---: | ---: |
| 200 concurrent same-route pane requests | 200 full scans | 1 full scan |
| Distinct Promise instances | 200 | 1 |

The deterministic test also proves the entry is released after settlement and rejection, retries execute, and local/SSH/runtime routes do not collide.

Exact-branch Electron evidence: 200 concurrent production-module requests for the active local worktree returned one shared Promise and one shared 90-document result in about 218 ms.

## Validation

- 115 editor/runtime/main filesystem files: 907 tests passed, 1 skipped.
- Focused request/runtime-client run: 2 files, 45 tests passed.
- `pnpm typecheck` passed.
- Targeted Oxlint and React Doctor checks passed.
- Reliability gates, max-lines ratchet, formatting, and `git diff --check` passed.
- Exact-branch Electron validation used an isolated 5174/9334 profile after another worktree legitimately occupied the defaults. The app identity matched `renderer-perf-17`; a real README Markdown pane survived a rapid Source → Rich refresh with all 14,532 visible characters unchanged and Rich mode restored.
- Full `pnpm lint` reaches only the unchanged mainline Japanese interpolation mismatch for `components.native-chat.composer.uploadingAttachments`.

## Compatibility and trade-offs

- The dedupe key includes runtime environment ID, SSH connection ID, worktree ID, worktree path, and root path; JSON encoding preserves Windows separators and unusual path characters.
- No IPC/RPC/provider contract changes. Local, SSH, WSL-owned local routing, and runtime environments continue through `listRuntimeMarkdownDocuments` unchanged.
- Only concurrent work is shared. Settled results are not retained, so this does not introduce a TTL, stale cache, or cross-refresh behavior change.

## ELI5

Opening several Markdown panes at once could make each pane scan the same workspace for documents. Matching panes now share the scan in progress, while saves and file changes still force a fresh result.
