### PR TITLE
fix(sidebar): show browser tab counts per workspace

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeBrowserTabIndicator.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeBrowserTabIndicator.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Globe } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+
+function getBrowserTabCountLabel(tabCount: number): string {
+  if (tabCount === 1) {
+    return translate(
+      'auto.components.sidebar.WorktreeBrowserTabIndicator.single',
+      '1 open browser tab'
+    )
+  }
+  return translate(
+    'auto.components.sidebar.WorktreeBrowserTabIndicator.multiple',
+    '{{value0}} open browser tabs',
+    { value0: tabCount }
+  )
+}
+
+export const WorktreeBrowserTabIndicator = React.memo(function WorktreeBrowserTabIndicator({
+  worktreeId
+}: {
+  worktreeId: string
+}): React.JSX.Element | null {
+  // Why: selecting only the count avoids rerendering every sidebar card when a
+  // browser title, URL, or loading state changes inside its owning workspace.
+  const tabCount = useAppStore((state) => state.browserTabsByWorktree?.[worktreeId]?.length ?? 0)
+  if (tabCount === 0) {
+    return null
+  }
+
+  const label = getBrowserTabCountLabel(tabCount)
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          role="img"
+          aria-label={label}
+          data-worktree-browser-tab-count={tabCount}
+          className="inline-flex h-4 shrink-0 items-center gap-0.5 rounded px-0.5 text-[11px] tabular-nums leading-none text-muted-foreground"
+        >
+          <Globe className="size-3" aria-hidden="true" />
+          <span aria-hidden="true">{tabCount}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+})

--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -482,6 +482,36 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).not.toContain('aria-label="Delete workspace"')
   })
 
+  it('identifies the workspace that owns live browser tabs', () => {
+    const owner = makeWorktree()
+    const other = makeWorktree({ id: 'repo-1::/repo/worktrees/no-browser' })
+    browserTabsByWorktree = { [owner.id]: [{ id: 'browser-1' }, { id: 'browser-2' }] }
+
+    const ownerMarkup = renderToStaticMarkup(
+      <WorktreeCard worktree={owner} repo={makeRepo()} isActive={false} />
+    )
+    const otherMarkup = renderToStaticMarkup(
+      <WorktreeCard worktree={other} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(ownerMarkup).toContain('data-worktree-browser-tab-count="2"')
+    expect(ownerMarkup).toContain('aria-label="2 open browser tabs"')
+    expect(ownerMarkup).toContain('lucide-globe')
+    expect(otherMarkup).not.toContain('data-worktree-browser-tab-count')
+
+    browserTabsByWorktree = { [owner.id]: [{ id: 'browser-1' }] }
+    const singleMarkup = renderToStaticMarkup(
+      <WorktreeCard worktree={owner} repo={makeRepo()} isActive={false} />
+    )
+    expect(singleMarkup).toContain('aria-label="1 open browser tab"')
+
+    browserTabsByWorktree = {}
+    const closedMarkup = renderToStaticMarkup(
+      <WorktreeCard worktree={owner} repo={makeRepo()} isActive={false} />
+    )
+    expect(closedMarkup).not.toContain('data-worktree-browser-tab-count')
+  })
+
   it('does not show sleep as the top-right quick action for an active workspace', () => {
     const worktree = makeWorktree()
     tabsByWorktree = { [worktree.id]: [{ id: 'tab-1' }] }

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -26,6 +26,7 @@ import { AutoRenameFailedDialog } from './AutoRenameFailedDialog'
 import { LinearAgentSkillSetupPrompt } from './LinearAgentSkillSetupPrompt'
 import WorktreeCardAgents from './WorktreeCardAgents'
 import { useWorktreeAgentRows } from './useWorktreeAgentRows'
+import { WorktreeBrowserTabIndicator } from './WorktreeBrowserTabIndicator'
 import { WorktreeCardStatusSlot } from './WorktreeCardStatusSlot'
 import { cn } from '@/lib/utils'
 import { activateWorktreeFromSidebar } from '@/lib/sidebar-worktree-activation'
@@ -1577,6 +1578,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 </TooltipContent>
               </Tooltip>
             )}
+
+            <WorktreeBrowserTabIndicator worktreeId={worktree.id} />
 
             {showTitleRowIndicators && titleRowIndicators}
           </div>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4645,6 +4645,10 @@
           "cancel": "Cancel",
           "forget": "Remove from Orca",
           "reconnectAndDelete": "Reconnect & Delete"
+        },
+        "WorktreeBrowserTabIndicator": {
+          "single": "1 open browser tab",
+          "multiple": "{{value0}} open browser tabs"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4645,6 +4645,10 @@
           "cancel": "Cancel",
           "forget": "Eliminar de Orca",
           "reconnectAndDelete": "Reconectar y eliminar"
+        },
+        "WorktreeBrowserTabIndicator": {
+          "single": "1 open browser tab",
+          "multiple": "{{value0}} open browser tabs"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4645,6 +4645,10 @@
           "cancel": "Cancel",
           "forget": "Orcaから削除",
           "reconnectAndDelete": "再接続して削除"
+        },
+        "WorktreeBrowserTabIndicator": {
+          "single": "1 open browser tab",
+          "multiple": "{{value0}} open browser tabs"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4645,6 +4645,10 @@
           "cancel": "Cancel",
           "forget": "Orca에서 제거",
           "reconnectAndDelete": "재연결 후 삭제"
+        },
+        "WorktreeBrowserTabIndicator": {
+          "single": "1 open browser tab",
+          "multiple": "{{value0}} open browser tabs"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4645,6 +4645,10 @@
           "cancel": "Cancel",
           "forget": "从 Orca 中移除",
           "reconnectAndDelete": "重新连接并删除"
+        },
+        "WorktreeBrowserTabIndicator": {
+          "single": "1 open browser tab",
+          "multiple": "{{value0}} open browser tabs"
         }
       },
       "shared": {


### PR DESCRIPTION
Fixes #5095

## Description

Adds a quiet Globe + count to each sidebar workspace that owns open browser tabs. The indicator reads the owning workspace's `browserTabsByWorktree` entry directly, so local, SSH, and Orca-server workspaces share the same provider-neutral behavior.

The count has singular/plural accessible labels and a tooltip. Its isolated, memoized selector subscribes only to the count, so browser URL, title, loading, and favicon updates do not rerender the indicator.

## Evidence of fix (before + after)

### Before

The reproduction on current `main` is captured in [issue #5095](https://github.com/stablyai/orca/issues/5095#issuecomment-4934213874): two worktrees had distinct `browserTabsByWorktree` entries, but both sidebar rows exposed only generic **Active** status with no browser icon, count, or label.

The new component regression reproduced that gap before the implementation: the owner row did not contain the expected browser count or accessible label.

### After

- The same component seam now renders `2 open browser tabs` only on the owning row; its sibling remains unmarked.
- The regression also proves singular copy (`1 open browser tab`) and that closing the last browser tab removes the indicator.
- In the exact Electron branch build, the live sidebar visibly showed local `2`, SSH `1`, and Orca-server `3` browser counts alongside a browser-free local sibling. Matching unified browser-tab entries remained associated with the same workspace IDs.
- At Orca's 220 px minimum sidebar width, titles truncated normally while every Globe/count remained visible without clipping or overlap.
- Clearing both browser-workspace and unified-tab state removed all three live indicators; restoring the state restored the correct counts.
- Hover verification found and fixed an initial collision with the whole-card hover surface by moving the count tooltip to the style-guide default top placement.

Validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard` — 18 files, 174 tests passed
- `pnpm typecheck:web`
- targeted `oxlint`
- `pnpm lint:react-doctor:changed`
- `pnpm check:max-lines-ratchet`
- `pnpm verify:localization-coverage`
- exact Electron dev build and visible full-window inspection

Known base gap: `pnpm verify:localization-catalog` still reports the pre-existing `origin/main` placeholder mismatch for `components.native-chat.composer.uploadingAttachments` in ja/ko/zh. This PR syncs its two new keys across all catalogs and does not modify that unrelated string.

## ELI5

Orca already knew which workspace owned each browser, but the sidebar only said “Active.” It was like knowing a machine was running somewhere in a building without labeling the room. Each owning row now gets a small globe and the number of open browser tabs, so the room is easy to find.

## User-facing trade-offs

- The indicator uses a small amount of title-row width, so very long workspace names can truncate a few characters earlier at narrow widths.
- It identifies and counts browser tabs but does not add a separate close action; users still open the workspace and close tabs from the tab bar.
- Browser ownership becomes always visible rather than hiding behind the generic activity status, adding one quiet metadata item only to affected rows.
- There is no new polling, remote call, or provider-specific behavior; the count reflects existing in-memory state.
