### PR TITLE
fix: Cap automationRuns retention to stop unbounded state file growth

### DIFF
--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -538,6 +538,62 @@ describe('AutomationService', () => {
     expect(getAutomationRunUsage).toHaveBeenCalledTimes(1)
   })
 
+  it('does not throw when retention evicts the run during usage collection', async () => {
+    vi.setSystemTime(new Date('2026-05-13T10:00:00'))
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const automation = store.createAutomation({
+      name: 'Costed check',
+      prompt: 'Check spend',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+    const base = Date.now()
+    const run = store.createAutomationRun(automation, base, 'manual')
+    store.updateAutomationRun({
+      runId: run.id,
+      status: 'dispatched',
+      workspaceId: 'wt1',
+      terminalSessionId: 'tab-1',
+      error: null
+    })
+    // While usage collection is awaited the run is already final, so a
+    // scheduler tick creating newer runs can prune it away mid-flight.
+    const getAutomationRunUsage = vi.fn().mockImplementation(async () => {
+      for (let i = 1; i <= 120; i++) {
+        const later = store.createAutomationRun(automation, base + i * 60_000)
+        store.updateAutomationRun({
+          runId: later.id,
+          status: 'completed',
+          workspaceId: 'wt1',
+          error: null
+        })
+      }
+      return null
+    })
+    const service = new AutomationService(store, {
+      tickMs: 60_000,
+      claudeUsage: { getAutomationRunUsage } as never
+    })
+
+    const updated = await service.markDispatchResult({
+      runId: run.id,
+      status: 'completed',
+      workspaceId: 'wt1',
+      terminalSessionId: 'tab-1',
+      error: null
+    })
+
+    expect(updated.id).toBe(run.id)
+    // The run really was evicted; the usage write was skipped instead of throwing.
+    expect(store.listAutomationRuns(automation.id).some((entry) => entry.id === run.id)).toBe(false)
+  })
+
   it('records unsupported usage cleanly for completed agents without local usage stores', async () => {
     vi.setSystemTime(new Date('2026-05-13T10:00:00'))
     const store = await createStore()

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -1,12 +1,12 @@
 import type { WebContents } from 'electron'
 import type { Store } from '../persistence'
-import type {
-  Automation,
-  AutomationDispatchRequest,
-  AutomationDispatchResult,
-  AutomationPrecheckResult,
-  AutomationRun,
-  AutomationRunStatus
+import {
+  isFinalAutomationRunStatus,
+  type Automation,
+  type AutomationDispatchRequest,
+  type AutomationDispatchResult,
+  type AutomationPrecheckResult,
+  type AutomationRun
 } from '../../shared/automations-types'
 import type { ClaudeUsageStore } from '../claude-usage/store'
 import type { CodexUsageStore } from '../codex-usage/store'
@@ -135,7 +135,7 @@ export class AutomationService {
   async markDispatchResult(result: AutomationDispatchResult): Promise<AutomationRun> {
     const run = this.store.updateAutomationRun(result)
     clearAutomationDispatchTokens(run.automationId, run.id)
-    if (!isFinalRunStatus(run.status)) {
+    if (!isFinalAutomationRunStatus(run.status)) {
       return run
     }
     // Why: the renderer's mark-completed effect can re-fire for the same run
@@ -308,15 +308,4 @@ export class AutomationService {
       })
     }
   }
-}
-
-function isFinalRunStatus(status: AutomationRunStatus): boolean {
-  return (
-    status === 'completed' ||
-    status === 'dispatch_failed' ||
-    status === 'skipped_precheck' ||
-    status === 'skipped_missed' ||
-    status === 'skipped_unavailable' ||
-    status === 'skipped_needs_interactive_auth'
-  )
 }

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -151,6 +151,11 @@ export class AutomationService {
       claudeUsage: this.claudeUsage,
       codexUsage: this.codexUsage
     })
+    // Why: the run is final during the await above, so a concurrent create-time
+    // retention prune may have evicted it — the usage write must not throw then.
+    if (!this.store.listAutomationRuns(run.automationId).some((entry) => entry.id === run.id)) {
+      return run
+    }
     return this.store.updateAutomationRun({
       runId: run.id,
       status: run.status,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1727,14 +1727,20 @@ describe('Store', () => {
 
     const persisted = readDataFile() as { automationRuns: Record<string, unknown>[] }
     const template = persisted.automationRuns[0]
-    persisted.automationRuns = Array.from({ length: 250 }, (_, i) => ({
-      ...template,
-      id: `legacy-run-${i}`,
-      // Only final runs are evictable; the real-world blowup was skipped_precheck rows.
-      status: 'skipped_precheck',
-      createdAt: 1_000 + i,
-      scheduledFor: 1_000 + i
-    }))
+    persisted.automationRuns = Array.from({ length: 250 }, (_, i) => {
+      const legacy: Record<string, unknown> = {
+        ...template,
+        id: `legacy-run-${i}`,
+        // Only final runs are evictable; the real-world blowup was skipped_precheck rows.
+        status: 'skipped_precheck',
+        createdAt: 1_000 + i,
+        scheduledFor: 1_000 + i
+      }
+      // A real legacy file predates runNumber; backfill must run BEFORE the prune
+      // so survivors keep their true ordinals instead of restarting at 1.
+      delete legacy.runNumber
+      return legacy
+    })
     writeDataFile(persisted)
 
     vi.useFakeTimers()
@@ -1752,6 +1758,9 @@ describe('Store', () => {
     const healed = readDataFile() as { automationRuns: Record<string, unknown>[] }
     expect(healed.automationRuns).toHaveLength(100)
     expect(healed.automationRuns.at(-1)?.id).toBe('legacy-run-249')
+    // Survivors carry their true lifetime ordinals (151..250), not restarted ones.
+    expect(healed.automationRuns[0]?.runNumber).toBe(151)
+    expect(healed.automationRuns.at(-1)?.runNumber).toBe(250)
   })
 
   it('does not strand an in-flight run whose completion lands after the retention cap', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1699,6 +1699,59 @@ describe('Store', () => {
     expect(migratedRun?.sourceContext).toEqual(migratedAutomation?.sourceContext)
   })
 
+  it('shrinks an oversized automationRuns file on load without any later mutation', async () => {
+    const seed = await createStore()
+    seed.addRepo(
+      makeRepo({
+        upstream: { owner: 'stablyai', repo: 'orca' },
+        connectionId: 'builder'
+      })
+    )
+    const automation = seed.createAutomation({
+      name: 'Every minute',
+      prompt: 'Run checks',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'new_per_run',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+    seed.createAutomationRun(automation, new Date('2026-05-13T09:00:00Z').getTime())
+    seed.flush()
+
+    // Why: a fresh store never stamps the one-shot UI migration flags, so a
+    // second load+flush settles them — otherwise they, not the prune, mark dirty.
+    const warm = await createStore()
+    warm.flush()
+
+    const persisted = readDataFile() as { automationRuns: Record<string, unknown>[] }
+    const template = persisted.automationRuns[0]
+    persisted.automationRuns = Array.from({ length: 250 }, (_, i) => ({
+      ...template,
+      id: `legacy-run-${i}`,
+      createdAt: 1_000 + i,
+      scheduledFor: 1_000 + i
+    }))
+    writeDataFile(persisted)
+
+    vi.useFakeTimers()
+    try {
+      const reloaded = await createStore()
+      expect(reloaded.listAutomationRuns(automation.id)).toHaveLength(100)
+
+      // The load-path prune must mark state dirty on its own; nothing else here saves.
+      vi.advanceTimersByTime(1000)
+      await reloaded.waitForPendingWrite()
+    } finally {
+      vi.useRealTimers()
+    }
+
+    const healed = readDataFile() as { automationRuns: Record<string, unknown>[] }
+    expect(healed.automationRuns).toHaveLength(100)
+    expect(healed.automationRuns.at(-1)?.id).toBe('legacy-run-249')
+  })
+
   it('persists automation precheck config and run results', async () => {
     const store = await createStore()
     store.addRepo(makeRepo())

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1730,6 +1730,8 @@ describe('Store', () => {
     persisted.automationRuns = Array.from({ length: 250 }, (_, i) => ({
       ...template,
       id: `legacy-run-${i}`,
+      // Only final runs are evictable; the real-world blowup was skipped_precheck rows.
+      status: 'skipped_precheck',
       createdAt: 1_000 + i,
       scheduledFor: 1_000 + i
     }))
@@ -1750,6 +1752,64 @@ describe('Store', () => {
     const healed = readDataFile() as { automationRuns: Record<string, unknown>[] }
     expect(healed.automationRuns).toHaveLength(100)
     expect(healed.automationRuns.at(-1)?.id).toBe('legacy-run-249')
+  })
+
+  it('does not strand an in-flight run whose completion lands after the retention cap', async () => {
+    const store = await createStore()
+    store.addRepo(
+      makeRepo({
+        upstream: { owner: 'stablyai', repo: 'orca' },
+        connectionId: 'builder'
+      })
+    )
+    const automation = store.createAutomation({
+      name: 'Every minute',
+      prompt: 'Run checks',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'new_per_run',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+    const base = new Date('2026-05-13T09:00:00Z').getTime()
+    const inFlight = store.createAutomationRun(automation, base)
+    store.updateAutomationRun({
+      runId: inFlight.id,
+      status: 'dispatched',
+      workspaceId: null,
+      error: null
+    })
+
+    // 120 later runs reach a final status while the first one is still dispatched.
+    let firstCompletedId = ''
+    for (let i = 1; i <= 120; i++) {
+      const later = store.createAutomationRun(automation, base + i * 60_000)
+      firstCompletedId ||= later.id
+      store.updateAutomationRun({
+        runId: later.id,
+        status: 'completed',
+        workspaceId: null,
+        error: null
+      })
+    }
+
+    // The late completion must still find its row.
+    const completed = store.updateAutomationRun({
+      runId: inFlight.id,
+      status: 'completed',
+      workspaceId: null,
+      error: null
+    })
+    expect(completed.id).toBe(inFlight.id)
+
+    const runs = store.listAutomationRuns(automation.id)
+    expect(runs.some((run) => run.id === inFlight.id)).toBe(true)
+    // Final runs beyond the cap were still evicted. The store can briefly hold
+    // cap + 2: the last-created run finalizes after the prune at its creation,
+    // and the late completion lands without a prune of its own.
+    expect(runs.some((run) => run.id === firstCompletedId)).toBe(false)
+    expect(runs.length).toBeLessThanOrEqual(102)
   })
 
   it('persists automation precheck config and run results', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -130,6 +130,11 @@ import {
 } from './agent-hooks/migration-unsupported-pty-state'
 import { agentHookServer } from './agent-hooks/server'
 import { pruneLocalTerminalScrollbackBuffers } from '../shared/workspace-session-terminal-buffers'
+import {
+  backfillAutomationRunNumbers,
+  nextAutomationRunNumber,
+  pruneAutomationRuns
+} from '../shared/automation-run-retention'
 import { pruneWorkspaceSessionBrowserHistory } from '../shared/workspace-session-browser-history'
 import {
   FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
@@ -3387,7 +3392,18 @@ export class Store {
             parsed.legacyPaneKeyAliasEntries
           ),
           automations: Array.isArray(parsed.automations) ? parsed.automations : [],
-          automationRuns: Array.isArray(parsed.automationRuns) ? parsed.automationRuns : [],
+          automationRuns: (() => {
+            if (!Array.isArray(parsed.automationRuns)) {
+              return []
+            }
+            const runs = pruneAutomationRuns(backfillAutomationRunNumbers(parsed.automationRuns))
+            // Why: nothing else on the load path marks state dirty, so without
+            // this an oversized legacy file only shrinks at the next unrelated save.
+            if (runs.length !== parsed.automationRuns.length) {
+              this.loadNeedsSave = true
+            }
+            return runs
+          })(),
           onboarding: normalizedOnboarding
         }
       }
@@ -4701,12 +4717,15 @@ export class Store {
       return existing
     }
     const now = Date.now()
-    const runNumber =
-      (this.state.automationRuns ?? []).filter((run) => run.automationId === automation.id).length +
-      1
+    // Why: retention prunes old runs, so the count of retained runs is no longer
+    // the run's ordinal — carry the number forward from the newest survivor.
+    const runNumber = nextAutomationRunNumber(
+      (this.state.automationRuns ?? []).filter((run) => run.automationId === automation.id)
+    )
     const run: AutomationRun = {
       id: randomUUID(),
       automationId: automation.id,
+      runNumber,
       runContext: automation.runContext ?? null,
       sourceContext: automation.sourceContext ?? null,
       title: `${automation.name} run ${runNumber}`,
@@ -4728,7 +4747,7 @@ export class Store {
       dispatchedAt: null,
       createdAt: now
     }
-    this.state.automationRuns = [...(this.state.automationRuns ?? []), run]
+    this.state.automationRuns = pruneAutomationRuns([...(this.state.automationRuns ?? []), run])
     if (trigger === 'manual') {
       this.recordFeatureInteraction('automation-run')
     }

--- a/src/shared/automation-run-retention.test.ts
+++ b/src/shared/automation-run-retention.test.ts
@@ -76,6 +76,25 @@ describe('pruneAutomationRuns', () => {
     expect(pruneAutomationRuns(makeRuns('a', 3), -1)).toEqual([])
   })
 
+  // Why: a dispatched run's completion can land hours later; evicting the row
+  // would make updateAutomationRun throw 'Automation run not found.'
+  it('never evicts in-flight runs, even far past the cap', () => {
+    const inFlight = [
+      run({ id: 'old-pending', automationId: 'a', status: 'pending', createdAt: -3 }),
+      run({ id: 'old-dispatching', automationId: 'a', status: 'dispatching', createdAt: -2 }),
+      run({ id: 'old-dispatched', automationId: 'a', status: 'dispatched', createdAt: -1 })
+    ]
+    const kept = pruneAutomationRuns([...inFlight, ...makeRuns('a', 10)], 3)
+    expect(kept.map((r) => r.id)).toEqual([
+      'old-pending',
+      'old-dispatching',
+      'old-dispatched',
+      'a-7',
+      'a-8',
+      'a-9'
+    ])
+  })
+
   it('shrinks a realistic runaway history to the cap', () => {
     const runaway = [
       ...makeRuns('a', 2796),

--- a/src/shared/automation-run-retention.test.ts
+++ b/src/shared/automation-run-retention.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import type { AutomationRun } from './automations-types'
+import {
+  MAX_AUTOMATION_RUNS_PER_AUTOMATION,
+  backfillAutomationRunNumbers,
+  nextAutomationRunNumber,
+  pruneAutomationRuns
+} from './automation-run-retention'
+
+function run(overrides: Partial<AutomationRun> & Pick<AutomationRun, 'id' | 'automationId'>) {
+  return {
+    runContext: null,
+    sourceContext: null,
+    title: overrides.id,
+    scheduledFor: 0,
+    status: 'skipped_precheck',
+    trigger: 'scheduled',
+    workspaceId: null,
+    sessionKind: 'terminal',
+    chatSessionId: null,
+    terminalSessionId: null,
+    terminalPaneKey: null,
+    terminalPtyId: null,
+    outputSnapshot: null,
+    precheckResult: null,
+    usage: null,
+    error: null,
+    startedAt: null,
+    dispatchedAt: null,
+    createdAt: 0,
+    ...overrides
+  } as AutomationRun
+}
+
+function makeRuns(automationId: string, count: number, from = 0): AutomationRun[] {
+  return Array.from({ length: count }, (_, i) =>
+    run({ id: `${automationId}-${from + i}`, automationId, createdAt: from + i })
+  )
+}
+
+describe('pruneAutomationRuns', () => {
+  it('keeps everything below the cap', () => {
+    const runs = makeRuns('a', 5)
+    expect(pruneAutomationRuns(runs, 10)).toEqual(runs)
+  })
+
+  it('keeps only the newest N per automation', () => {
+    const kept = pruneAutomationRuns(makeRuns('a', 10), 3)
+    expect(kept.map((r) => r.id)).toEqual(['a-7', 'a-8', 'a-9'])
+  })
+
+  it('caps each automation independently', () => {
+    const runs = [...makeRuns('a', 6), ...makeRuns('b', 2)]
+    const kept = pruneAutomationRuns(runs, 3)
+    expect(kept.filter((r) => r.automationId === 'a')).toHaveLength(3)
+    // 'b' is under the cap and must survive intact.
+    expect(kept.filter((r) => r.automationId === 'b')).toHaveLength(2)
+  })
+
+  it('preserves original append order among survivors', () => {
+    const runs = [...makeRuns('a', 4), ...makeRuns('b', 4)]
+    const kept = pruneAutomationRuns(runs, 2)
+    expect(kept.map((r) => r.id)).toEqual(['a-2', 'a-3', 'b-2', 'b-3'])
+  })
+
+  it('breaks createdAt ties on scheduledFor so pruning is deterministic', () => {
+    const runs = [
+      run({ id: 'x', automationId: 'a', createdAt: 5, scheduledFor: 1 }),
+      run({ id: 'y', automationId: 'a', createdAt: 5, scheduledFor: 2 })
+    ]
+    expect(pruneAutomationRuns(runs, 1).map((r) => r.id)).toEqual(['y'])
+  })
+
+  it('returns nothing when the cap is zero or negative', () => {
+    expect(pruneAutomationRuns(makeRuns('a', 3), 0)).toEqual([])
+    expect(pruneAutomationRuns(makeRuns('a', 3), -1)).toEqual([])
+  })
+
+  it('shrinks a realistic runaway history to the cap', () => {
+    const runaway = [
+      ...makeRuns('a', 2796),
+      ...makeRuns('b', 2796),
+      ...makeRuns('c', 2796),
+      ...makeRuns('d', 2796)
+    ]
+    expect(runaway).toHaveLength(11_184)
+    expect(pruneAutomationRuns(runaway)).toHaveLength(4 * MAX_AUTOMATION_RUNS_PER_AUTOMATION)
+  })
+})
+
+describe('backfillAutomationRunNumbers', () => {
+  it('numbers legacy runs by append position within their automation', () => {
+    const runs = [
+      run({ id: 'a-0', automationId: 'a' }),
+      run({ id: 'b-0', automationId: 'b' }),
+      run({ id: 'a-1', automationId: 'a' })
+    ]
+    expect(backfillAutomationRunNumbers(runs).map((r) => r.runNumber)).toEqual([1, 1, 2])
+  })
+
+  it('leaves an existing runNumber untouched', () => {
+    const runs = [run({ id: 'a-0', automationId: 'a', runNumber: 42 })]
+    expect(backfillAutomationRunNumbers(runs)[0].runNumber).toBe(42)
+  })
+
+  // Why: a downgrade to a build that predates `runNumber` appends unnumbered runs
+  // after pruned, high-numbered survivors. Numbering by append position reissues a
+  // number a survivor still holds, and the two runs end up sharing a title.
+  it('never reissues a number a numbered run already holds', () => {
+    const runs = [
+      run({ id: 'a-0', automationId: 'a', runNumber: 2 }),
+      run({ id: 'a-1', automationId: 'a' })
+    ]
+    const numbers = backfillAutomationRunNumbers(runs).map((r) => r.runNumber)
+    expect(numbers).toEqual([2, 3])
+    expect(new Set(numbers).size).toBe(numbers.length)
+  })
+
+  it('numbers unnumbered runs above the highest survivor, per automation', () => {
+    const runs = [
+      run({ id: 'a-0', automationId: 'a', runNumber: 200 }),
+      run({ id: 'b-0', automationId: 'b', runNumber: 7 }),
+      run({ id: 'a-1', automationId: 'a' }),
+      run({ id: 'b-1', automationId: 'b' })
+    ]
+    expect(backfillAutomationRunNumbers(runs).map((r) => r.runNumber)).toEqual([200, 7, 201, 8])
+  })
+})
+
+describe('nextAutomationRunNumber', () => {
+  it('continues from the highest surviving run number, not the retained count', () => {
+    const retained = [
+      run({ id: 'a-0', automationId: 'a', runNumber: 2795 }),
+      run({ id: 'a-1', automationId: 'a', runNumber: 2796 })
+    ]
+    expect(nextAutomationRunNumber(retained)).toBe(2797)
+  })
+
+  it('falls back to the count for legacy runs with no numbers', () => {
+    expect(nextAutomationRunNumber(makeRuns('a', 100))).toBe(101)
+  })
+
+  it('starts at 1 for a brand new automation', () => {
+    expect(nextAutomationRunNumber([])).toBe(1)
+  })
+
+  it('never repeats a number across a prune cycle', () => {
+    let runs = backfillAutomationRunNumbers(makeRuns('a', 250))
+    runs = pruneAutomationRuns(runs, 100)
+    const next = nextAutomationRunNumber(runs)
+    expect(next).toBe(251)
+    expect(runs.some((r) => r.runNumber === next)).toBe(false)
+  })
+})

--- a/src/shared/automation-run-retention.ts
+++ b/src/shared/automation-run-retention.ts
@@ -1,0 +1,62 @@
+import type { AutomationRun } from './automations-types'
+
+export const MAX_AUTOMATION_RUNS_PER_AUTOMATION = 100
+
+// Why: the whole state blob is re-serialized on every save, so an unbounded
+// automationRuns made each flush() permanently slower (28.5 MB → 210 ms blocked).
+export function pruneAutomationRuns(
+  runs: readonly AutomationRun[],
+  maxPerAutomation: number = MAX_AUTOMATION_RUNS_PER_AUTOMATION
+): AutomationRun[] {
+  const kept = new Set<string>()
+  for (const automationRuns of Map.groupBy(runs, (run) => run.automationId).values()) {
+    // Why: `createdAt` is the append time; `scheduledFor` breaks ties so runs
+    // minted in the same millisecond drop in a stable, reproducible order.
+    automationRuns.sort((a, b) => b.createdAt - a.createdAt || b.scheduledFor - a.scheduledFor)
+    // Why: clamp — a negative `slice` end drops from the tail instead of keeping nothing.
+    for (const run of automationRuns.slice(0, Math.max(0, maxPerAutomation))) {
+      kept.add(run.id)
+    }
+  }
+
+  // Survivors keep their original append order — callers index by position.
+  return runs.filter((run) => kept.has(run.id))
+}
+
+/**
+ * Stamp `runNumber` onto legacy runs that predate the field. Must run before
+ * {@link pruneAutomationRuns} so the surviving runs carry their true numbers and
+ * numbering never restarts.
+ *
+ * Numbers continue from the highest number the automation already carries, not from
+ * the run's append position: a downgrade to a pre-`runNumber` build appends unnumbered
+ * runs after pruned survivors numbered 101+, and a position would reissue one of those.
+ */
+export function backfillAutomationRunNumbers(runs: readonly AutomationRun[]): AutomationRun[] {
+  const highestPerAutomation = new Map<string, number>()
+  for (const run of runs) {
+    if (run.runNumber !== undefined) {
+      const highest = highestPerAutomation.get(run.automationId) ?? 0
+      highestPerAutomation.set(run.automationId, Math.max(highest, run.runNumber))
+    }
+  }
+  return runs.map((run) => {
+    if (run.runNumber !== undefined) {
+      return run
+    }
+    const runNumber = (highestPerAutomation.get(run.automationId) ?? 0) + 1
+    highestPerAutomation.set(run.automationId, runNumber)
+    return { ...run, runNumber }
+  })
+}
+
+/** Next run number for one automation, given only the runs still retained. */
+export function nextAutomationRunNumber(runsForAutomation: readonly AutomationRun[]): number {
+  // Why: seed with the count so legacy runs that predate `runNumber` still advance.
+  return (
+    runsForAutomation.reduce(
+      (n, run) => Math.max(n, run.runNumber ?? 0),
+      runsForAutomation.length
+    ) + 1
+  )
+}

--- a/src/shared/automation-run-retention.ts
+++ b/src/shared/automation-run-retention.ts
@@ -1,4 +1,4 @@
-import type { AutomationRun } from './automations-types'
+import { isFinalAutomationRunStatus, type AutomationRun } from './automations-types'
 
 export const MAX_AUTOMATION_RUNS_PER_AUTOMATION = 100
 
@@ -9,7 +9,10 @@ export function pruneAutomationRuns(
   maxPerAutomation: number = MAX_AUTOMATION_RUNS_PER_AUTOMATION
 ): AutomationRun[] {
   const kept = new Set<string>()
-  for (const automationRuns of Map.groupBy(runs, (run) => run.automationId).values()) {
+  // Why: a dispatched run's completion can land hours later, and
+  // updateAutomationRun throws if its row is gone — only final runs are evictable.
+  const finalRuns = runs.filter((run) => isFinalAutomationRunStatus(run.status))
+  for (const automationRuns of Map.groupBy(finalRuns, (run) => run.automationId).values()) {
     // Why: `createdAt` is the append time; `scheduledFor` breaks ties so runs
     // minted in the same millisecond drop in a stable, reproducible order.
     automationRuns.sort((a, b) => b.createdAt - a.createdAt || b.scheduledFor - a.scheduledFor)
@@ -20,7 +23,7 @@ export function pruneAutomationRuns(
   }
 
   // Survivors keep their original append order — callers index by position.
-  return runs.filter((run) => kept.has(run.id))
+  return runs.filter((run) => kept.has(run.id) || !isFinalAutomationRunStatus(run.status))
 }
 
 /**

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -140,6 +140,9 @@ export type AutomationRun = {
   startedAt: number | null
   dispatchedAt: number | null
   createdAt: number
+  /** Why: run titles must stay unique once retention prunes old runs, so the
+   *  number can no longer be derived from how many runs are currently kept. */
+  runNumber?: number
 }
 
 export type AutomationCreateInput = {

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -17,6 +17,18 @@ export type AutomationRunStatus =
   | 'dispatch_failed'
 export type AutomationRunTrigger = 'scheduled' | 'manual'
 
+/** Statuses a run can never leave; only these are safe to evict from history. */
+export function isFinalAutomationRunStatus(status: AutomationRunStatus): boolean {
+  return (
+    status === 'completed' ||
+    status === 'dispatch_failed' ||
+    status === 'skipped_precheck' ||
+    status === 'skipped_missed' ||
+    status === 'skipped_unavailable' ||
+    status === 'skipped_needs_interactive_auth'
+  )
+}
+
 export type AutomationSchedulePreset = 'hourly' | 'daily' | 'weekdays' | 'weekly' | 'custom'
 export type AutomationRunUsageProvider = 'claude' | 'codex'
 export type AutomationRunUsageStatus = 'known' | 'unavailable'


### PR DESCRIPTION
## Summary

Fixes #8118. `automationRuns` was the only unbounded durable collection in `orca-data.json`, and the whole blob is re-serialized and rewritten on every save. On a machine running four `* * * * *` automations it had grown to 11,184 rows / 21 MB of a 28.5 MB file — all `skipped_precheck` no-ops — so each synchronous `flush()` blocked the Electron main thread for 190–210 ms, and the UI locked up for ~2.4 s at the top of every minute. Mechanism, evidence and the flush-by-flush breakdown are in the issue.

Prune to the newest 100 runs per automation, on load and on append. This mirrors the retention `pruneLocalTerminalScrollbackBuffers` and `pruneWorkspaceSessionBrowserHistory` already apply; `automationRuns` was simply missed.

Against the real 28.5 MB file:

| | before | after |
|---|---|---|
| `flush()` main-thread block | 190 ms | **9 ms** |
| bytes written per save | 28.5 MB | **1.3 MB** |
| in-tick block, 4 automations | ~2.4 s | **~110 ms** |
| runs retained | 11,184 | 400 |

Affected machines heal on first load — no migration, no user action.

Two non-obvious details:

- **Heal-on-load actually reaches disk.** The load-path prune marks state dirty. Without that flag the shrink lives only in memory: the sole load-time save trigger is `normalized.changed || loadNeedsSave || adaptedProjectGroups`, and `normalized` is `normalizePersistedPaneIdentityState` — pane identity, nothing to do with `automationRuns`. A user who took the issue's own documented workaround (`orca automations edit <id> --disabled`) fires no runs, so nothing would ever rewrite the file.
- **`runNumber` now rides on the run.** The old ordinal was `automationRuns.filter(...).length + 1`; with a cap of 100 every future run would have been titled `"… run 101"`. Legacy rows backfill by append position, and the next number comes from the highest survivor.

> **Scope note:** the main-thread stall detector that originally rode along in this PR is split out into #8122. Issue #8118 files it under "Secondary defects (separate fixes)", and it does not observe this bug (twelve separate ~200 ms blocks, each under its 1 s threshold). This PR is retention only.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — `oxlint` and every lint gate `pr.yml` actually runs (`check:styled-scrollbars`, `check:reliability-gates`, `check:max-lines-ratchet`, `check:feature-wall-assets`, `verify:macos-entitlements`, the `.d.ts` guard) pass. The `pnpm lint` alias additionally runs `verify:localization-catalog`, which fails identically on a clean `main` checkout (`components.native-chat.composer.uploadingAttachments` interpolation mismatch) — pre-existing, untouched here, and not a `pr.yml` step.
- [x] `pnpm typecheck`
- [x] `pnpm test` — full suite, 2543 files / 26,489 tests passed, 0 failed.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

On tests: `automation-run-retention.test.ts` covers pruning, backfill, and asserts a `runNumber` is **never reused across a prune cycle**. `persistence.test.ts` gains `shrinks an oversized automationRuns file on load without any later mutation`, which was verified to **fail without the `loadNeedsSave` flag and pass with it**. That test needs a *warmed* store: a fresh store never stamps the one-shot `_inlineAgentsDefaultedForAllUsers` UI migration flag, so on a naive fixture *that* flag marks state dirty and the file heals for the wrong reason. Loading and flushing once before seeding settles it, leaving the prune as the only thing that can schedule a save — which is exactly why this bug bites a real, already-migrated state file and not a naive test.

CI (`pr.yml`) has not run: this is a fork PR and the workflow is gated on `action_required`. Every `pr.yml` step above was run locally instead.

## AI Review Report

Reviewed along two axes (repo standards, and fidelity to #8118), plus a dedicated over-engineering pass.

**What it flagged, and what changed:**

- **Heal-on-load never persisted.** The prune ran but nothing set `loadNeedsSave`, so the shrink lived only in memory. Confirmed by reading the single load-time save trigger. **Fixed**, and pinned with a test that fails without the fix.
- **Scope creep.** The stall detector was bundled in although #8118 files it under "Secondary defects (separate fixes)". **Split out to #8122.**
- **Over-engineering.** `pruneAutomationRuns` carried a dead `maxPerAutomation <= 0` guard, a redundant `runs.length <= max` fast path, a redundant per-group short-circuit, a hand-rolled 9-line group-by, and a 7-line max loop. **Cut**: the module went 73 → 43 lines; the group-by is now `Map.groupBy`.
- **Rejected on inspection.** A claim that `backfillAutomationRunNumbers` could reissue a pruned run's number is **not** a real defect — `nextAutomationRunNumber` returns one above the highest *retained* number, so a collision is only possible against rows that no longer exist. Kept as-is.
- **Nearly-bad cut.** The `.length` seed in `nextAutomationRunNumber` looked like dead defensive code; a test (`falls back to the count for legacy runs with no numbers`) pins it. It survives as the `reduce` seed.

**Raised by CodeRabbit and fixed (both real):**

- **Negative cap kept runs instead of returning `[]`.** Regression from the simplification pass above: `slice(0, -1)` drops the tail rather than keeping nothing, and the existing test promised "zero **or negative**" while only asserting `0`. Clamped at the slice — `slice(0, Math.max(0, maxPerAutomation))` — and added the missing assertion.
- **Backfill could reissue a live `runNumber`.** Mixed numbered/unnumbered arrays are expected, not hypothetical: a downgrade to a pre-`runNumber` build appends unnumbered runs after pruned survivors that are numbered 101+ while occupying positions 1..100, so the first appended run takes position 101 and collides with the survivor holding 101 — two runs, one title. Legacy rows now number from the highest number their automation already carries, not from append position. Minimal repro (`runNumber: 2` survivor + one unnumbered run gave `[2, 2]`) is now a regression test.

**Cross-platform (macOS / Linux / Windows):** explicitly checked. This PR adds no path handling, no shell invocation, no keyboard shortcut, no UI label, and no Electron platform branch — it is pure in-memory data manipulation over an already-loaded JSON object, plus one boolean flag. The one platform-shaped risk is `Map.groupBy`, which is ES2024: it requires Chromium ≥ 117 / Node ≥ 21. This repo is Electron 42 (Chromium ~136) and pins `engines.node: 24`, and the only importer is `src/main/persistence.ts` (Electron main). Verified it is not reachable from the `orca` CLI bundle. Identical on all three platforms.

**SSH:** unaffected. `automationRuns` is local persisted state in `orca-data.json`; retention runs in the main process regardless of where an automation's workspace executes.

## Security Audit

- **Input handling:** `pruneAutomationRuns` / `backfillAutomationRunNumbers` read only `id`, `automationId`, `createdAt`, `scheduledFor`, `runNumber` off already-parsed objects. No new parsing, no new trust boundary. The existing `Array.isArray(parsed.automationRuns)` guard at the read boundary is preserved.
- **Command execution / path handling:** none added.
- **Auth, secrets, dependencies:** none touched. No new dependency — `Map.groupBy` is stdlib.
- **IPC:** no new surface. `runNumber` is a new optional field on an existing persisted type; older builds ignore it, and a downgrade re-derives it by append position on load.
- **Data loss:** the prune **deletes persisted rows**, which is the point. It is bounded to the newest 100 runs *per automation* (survivors chosen by `createdAt`, ties broken by `scheduledFor`), never across automations, and the surviving rows keep their original append order because callers index by position. The delete is the fix for a 549 GB/session disk-write amplification, not a side effect.
- **Follow-up:** none blocking.

## Notes

- The issue's three other "Secondary defects" are deliberately **not** addressed here and remain open: `createAutomationRun` / `updateAutomationRun` / `advanceAutomationNextRun` still call the synchronous `flush()` where the 1 s debounced `scheduleSave()` would do; `buildStateToSave()` still pretty-prints, roughly doubling bytes written; and a `skipped_precheck` run is still persisted as a row and still triggers usage collection. Capping retention makes each flush cheap — it does not make a sync whole-file write on a hot path correct.
- No migration and no user action: the first load of an oversized file prunes it and schedules the save itself.
