### PR TITLE
Add an always-on main-thread stall detector

### DIFF
--- a/src/main/diagnostics/main-thread-stall-detector.test.ts
+++ b/src/main/diagnostics/main-thread-stall-detector.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { endMock, startSpanMock } = vi.hoisted(() => {
+  const end = vi.fn()
+  return { endMock: end, startSpanMock: vi.fn(() => ({ end })) }
+})
+
+vi.mock('../observability/tracer', () => ({
+  startSpan: startSpanMock
+}))
+
+import {
+  startMainThreadStallDetector,
+  stopMainThreadStallDetector
+} from './main-thread-stall-detector'
+
+// The detector reads `performance.now()` once per tick; driving that clock
+// independently of the fake timer is what lets us simulate a late tick.
+let nowSpy: ReturnType<typeof vi.spyOn>
+
+function tickAt(ms: number): void {
+  nowSpy.mockReturnValue(ms)
+  vi.advanceTimersByTime(1_000)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0)
+  startSpanMock.mockClear()
+  endMock.mockClear()
+})
+
+afterEach(() => {
+  stopMainThreadStallDetector()
+  vi.useRealTimers()
+  nowSpy.mockRestore()
+})
+
+describe('startMainThreadStallDetector', () => {
+  it('stays silent when ticks land on time', () => {
+    startMainThreadStallDetector()
+    tickAt(1_000)
+    tickAt(2_000)
+    tickAt(3_000)
+    expect(startSpanMock).not.toHaveBeenCalled()
+  })
+
+  it('stays silent for sub-threshold jank', () => {
+    startMainThreadStallDetector()
+    // 999ms late — jank, not a freeze.
+    tickAt(1_999)
+    expect(startSpanMock).not.toHaveBeenCalled()
+  })
+
+  it('emits one main-thread.stall span with the block time when a tick fires late', () => {
+    startMainThreadStallDetector()
+    // Tick due at 1000ms actually ran at 4500ms ⇒ the thread was blocked 3500ms.
+    tickAt(4_500)
+    expect(startSpanMock).toHaveBeenCalledTimes(1)
+    expect(startSpanMock).toHaveBeenCalledWith('main-thread.stall', {
+      attributes: { gapMs: 3_500, tickMs: 1_000 }
+    })
+    expect(endMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('measures each stall from the previous tick, not from start', () => {
+    startMainThreadStallDetector()
+    tickAt(4_500)
+    // Next tick due at 5500ms, ran at 8000ms ⇒ 2500ms of block, not 7000ms.
+    tickAt(8_000)
+    expect(startSpanMock).toHaveBeenLastCalledWith('main-thread.stall', {
+      attributes: { gapMs: 2_500, tickMs: 1_000 }
+    })
+  })
+
+  it('is idempotent — a second start does not double-arm the timer', () => {
+    startMainThreadStallDetector()
+    startMainThreadStallDetector()
+    tickAt(4_500)
+    expect(startSpanMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops emitting once stopped', () => {
+    startMainThreadStallDetector()
+    stopMainThreadStallDetector()
+    tickAt(4_500)
+    expect(startSpanMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/diagnostics/main-thread-stall-detector.ts
+++ b/src/main/diagnostics/main-thread-stall-detector.ts
@@ -1,0 +1,48 @@
+import { startSpan } from '../observability/tracer'
+
+// Why: a timer that fires N ms late proves the main thread was blocked for N ms.
+// Always-on counterpart to main-thread-churn-probe, which is env-gated and stderr-only.
+const TICK_MS = 1_000
+
+// Why: coarse on purpose — it trades most sub-second jank for negligible idle
+// wakeups (#7983 was an idle-churn regression). Multi-second beachballs still land.
+const STALL_THRESHOLD_MS = 1_000
+
+let timer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * Emit a `main-thread.stall` span whenever the main thread blocks for >=1s.
+ *
+ * No-op while the observability sink is unset — `startSpan` returns `noopSpan`
+ * once the consent gates in `observability/index.ts` decline, so this needs no
+ * gate of its own.
+ *
+ * Attribution is deliberately left out of the span: the `git.exec` spans that
+ * overlap the stall window are already in the same trace file, timestamped.
+ */
+export function startMainThreadStallDetector(): void {
+  if (timer) {
+    return
+  }
+  let last = performance.now()
+  timer = setInterval(() => {
+    const now = performance.now()
+    const gapMs = now - last - TICK_MS
+    last = now
+    if (gapMs < STALL_THRESHOLD_MS) {
+      return
+    }
+    startSpan('main-thread.stall', {
+      attributes: { gapMs: Math.round(gapMs), tickMs: TICK_MS }
+    }).end()
+  }, TICK_MS)
+  timer.unref?.()
+}
+
+export function stopMainThreadStallDetector(): void {
+  if (!timer) {
+    return
+  }
+  clearInterval(timer)
+  timer = null
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -96,6 +96,7 @@ import {
 } from './startup/single-instance-lock'
 import { startEventLoopStallProbe } from './startup/event-loop-stall-probe'
 import { startMainThreadChurnProbe } from './diagnostics/main-thread-churn-probe'
+import { startMainThreadStallDetector } from './diagnostics/main-thread-stall-detector'
 import {
   isStartupDiagnosticsEnabled,
   logStartupDiagnostic,
@@ -1717,6 +1718,10 @@ app.whenReady().then(async () => {
   // Honors DO_NOT_TRACK / ORCA_TELEMETRY_DISABLED / ORCA_DIAGNOSTICS_DISABLED
   // / CI internally; those gates do not need to be re-checked here.
   initObservability()
+  // Why: beachballs leave no trace today — the churn probe is env-gated and
+  // stderr-only. This emits a `main-thread.stall` span for any >=1s block, so
+  // a freeze lands in the diagnostic bundle without a terminal relaunch.
+  startMainThreadStallDetector()
   // Why: cohort-classifier reads the repo count synchronously at every emit
   // for cohort-extended events. The Store has been sync-loaded above, and
   // this init runs before any IPC handler is registered and before any


### PR DESCRIPTION
## Summary

Split out of #8119, which bundled this diagnostic with an unrelated `automationRuns` retention fix. Issue #8118 files it under **"Secondary defects (separate fixes)"**.

A beachball leaves no trace today. There is no `crashReporter`, no `unresponsive` handler, and the main-thread churn probe is env-gated behind `ORCA_MAIN_THREAD_DIAGNOSTICS` and writes only to stderr — so a packaged user staring at a frozen window cannot capture one without relaunching from a terminal.

`src/main/diagnostics/main-thread-stall-detector.ts` (new) — a 1 s `unref`'d timer's own lateness *is* the block time. Any stall ≥1 s emits a `main-thread.stall` span into the existing trace NDJSON, so a freeze lands in a diagnostic bundle with no relaunch.

**Design notes:**

- **No new consent gate.** `startSpan` no-ops while the observability sink is unset, and the sink is installed only after the gates in `observability/index.ts`. `diagnostics → observability` is the allowed import direction (`observability/architecture.test.ts` forbids only `telemetry ↔ observability`); `git/runner.ts` sets the precedent.
- **1 s tick, not 25 ms.** `bench:idle-cpu` guards idle cost and #7983 was an idle-churn regression. It therefore misses most sub-second jank, which the env-gated churn probe already covers on demand — **a clean stall trace must not be read as "no main-thread problem"**.
- **No spawn attribution.** `recordSubprocessSpawn` no-ops unless `ORCA_MAIN_THREAD_DIAGNOSTICS=1`, so an always-on detector would get an empty map. The `git.exec` spans are already in the same NDJSON, timestamped — overlap them with the stall window instead.
- **It would not have caught #8118.** That freeze is twelve *separate* ~200 ms blocks, each under the 1 s threshold — not one 2.4 s block. This earns its place on the next freeze (a single long block). Lowering the threshold to catch that class would reintroduce #7983's idle cost, for a bug #8119 removes at the source. That is precisely why these are now two PRs.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — `oxlint` and every lint gate `pr.yml` actually runs (`check:styled-scrollbars`, `check:reliability-gates`, `check:max-lines-ratchet`, `check:feature-wall-assets`, `verify:macos-entitlements`, the `.d.ts` guard) pass. The `pnpm lint` alias additionally runs `verify:localization-catalog`, which fails identically on a clean `main` checkout (`components.native-chat.composer.uploadingAttachments` interpolation mismatch) — pre-existing, untouched here, and not a `pr.yml` step.
- [x] `pnpm typecheck`
- [x] `pnpm test` — full suite, 2542 files / 26,477 tests passed, 0 failed. Includes `observability/architecture.test.ts`, which enforces the import direction this module relies on.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

**End-to-end, no mocks**: real detector → real tracer → real NDJSON sink, with a genuinely blocked main thread. Idle 2.5 s → zero spans. A real 3 s block → exactly one span, `{"name":"main-thread.stall","attributes":{"gapMs":2499,"tickMs":1000}}`. The unit tests additionally drive fake timers with controlled `performance.now()` values to pin the threshold boundary and the idempotent start/stop.

**Idle CPU**: `bench:idle-cpu` vs clean-`main`. Main 0.775% → 0.854% — noise, not the timer: the *untouched* renderer (+0.098) and GPU (+0.102) moved further in the same comparison.

CI (`pr.yml`) has not run: this is a fork PR and the workflow is gated on `action_required`. Every `pr.yml` step above was run locally instead.

## AI Review Report

Reviewed for repo-standards conformance and for over-engineering.

- **Comment length.** `AGENTS.md` requires "one or two lines" and forbids narrating the mechanism; the two constant comments ran to four lines each, one of them explaining the sampling maths. **Trimmed.**
- **Over-engineering pass: nothing to cut.** `stopMainThreadStallDetector` has no production caller, but the module-level `timer` makes it load-bearing for test isolation, so it stays — a test seam is the minimum, not bloat. The `if (timer) return` guard keeps `start` idempotent. No speculative parameters, no dead flexibility.
- **Threshold honesty.** The reviewer flagged that shipping a stall detector alongside the bug it cannot detect is misleading. Rather than lower the threshold (which would reintroduce #7983's idle-churn cost), the limitation is stated explicitly here and in the module's own comment.

**Cross-platform (macOS / Linux / Windows):** explicitly checked. No path handling, no shell invocation, no keyboard shortcut or accelerator, no UI label, no Electron platform branch. `performance.now()` and `setInterval` are identical on all three. `timer.unref?.()` is optional-chained because the `setInterval` return type is platform-typed; `unref` exists on Node's `Timeout` on every platform, and the guard costs nothing if it ever resolves to a DOM `number`. The `unref` matters cross-platform for the same reason everywhere: the timer must never hold the process open at quit.

**SSH:** unaffected. The detector measures the local Electron main thread. A stall caused by work on behalf of a remote host is still a local main-thread stall and is still captured.

## Security Audit

- **Input handling:** none. The detector reads only its own `performance.now()` deltas. No user input, no parsing, no network.
- **Data emitted:** two integers per span, `gapMs` and `tickMs`. No paths, no hostnames, no repo names, no user content — nothing to leak into a diagnostic bundle that was not already there.
- **Consent / privacy:** no new gate needed *and none bypassed*. `startSpan` returns `noopSpan` while the observability sink is unset, and the sink is installed only after the existing consent gates in `observability/index.ts`. If the user has not consented, this module writes nothing.
- **Command execution, path handling, auth, secrets, dependencies, IPC:** none added. No new dependency.
- **Resource risk:** one `setInterval` at 1 Hz, `unref`'d so it cannot keep the process alive at quit; `startMainThreadStallDetector` is idempotent, so a double-init cannot leak a second timer. Idle-CPU impact measured as noise (above).
- **Follow-up:** none blocking.

## Notes

- **A clean stall trace does not mean "no main-thread problem."** The 1 s threshold is a deliberate trade against idle wakeups (#7983). Sub-second jank stays the env-gated churn probe's job, on demand.
- Independent of #8119 — both branch off `main` and can merge in either order.

## ELI5

When the main process freezes (a beachball), there was almost no log trail in packaged builds. An always-on stall detector records main-thread hangs so freezes can be diagnosed without special env flags or a terminal relaunch.
