### PR TITLE
fix(agent-status): prevent pending status replay after teardown

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -5934,17 +5934,149 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
   })
 
-  it('keeps a completed worktree-attributed row when main reports pane teardown', async () => {
+  it('cancels only the torn-down pane pending status before it can be replayed', async () => {
+    const otherLeafId = '22222222-2222-4222-8222-222222222222'
+    const otherPaneKey = makePaneKey('tab-other', otherLeafId)
+    const setAgentStatus = vi.fn()
     const removeAgentStatus = vi.fn()
-    const onClearListenerRef: {
-      current: ((data: AgentStatusClearIpcPayload) => void) | null
-    } = {
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
       current: null
     }
+    const onClearListenerRef: { current: ((data: { paneKey: string }) => void) | null } = {
+      current: null
+    }
+    const subscribeListenerRef: { current: StoreSubscribeListener | null } = { current: null }
 
     const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
       removeAgentStatus,
       workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      tabsByWorktree: { 'wt-1': [] },
+      terminalLayoutsByTabId: {}
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn((listener: StoreSubscribeListener) => {
+          subscribeListenerRef.current = listener
+          return () => {
+            subscribeListenerRef.current = null
+          }
+        }),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        },
+        onClear: (cb) => {
+          onClearListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+    if (typeof onClearListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onClear listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'working',
+      prompt: 'torn-down worker',
+      agentType: 'grok',
+      receivedAt: 1_700_000_000_100,
+      stateStartedAt: 1_699_999_999_100
+    })
+    onSetListenerRef.current({
+      paneKey: otherPaneKey,
+      state: 'working',
+      prompt: 'surviving worker',
+      agentType: 'claude',
+      receivedAt: 1_700_000_000_200,
+      stateStartedAt: 1_699_999_999_200
+    })
+
+    expect(setAgentStatus).not.toHaveBeenCalled()
+    onClearListenerRef.current({ paneKey: FUTURE_PANE_KEY })
+
+    storeState.tabsByWorktree = {
+      'wt-1': [
+        { id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' },
+        { id: 'tab-other', ptyId: 'pty-2', worktreeId: 'wt-1', title: 'Other Tab' }
+      ]
+    }
+    storeState.terminalLayoutsByTabId = {
+      'tab-future': {
+        root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+        activeLeafId: FUTURE_LEAF_ID,
+        expandedLeafId: null
+      },
+      'tab-other': {
+        root: { type: 'leaf', leafId: otherLeafId },
+        activeLeafId: otherLeafId,
+        expandedLeafId: null
+      }
+    }
+    if (typeof subscribeListenerRef.current !== 'function') {
+      throw new Error('Expected useAppStore.subscribe listener to be registered')
+    }
+    subscribeListenerRef.current(storeState)
+
+    expect(removeAgentStatus).toHaveBeenCalledTimes(1)
+    expect(removeAgentStatus).toHaveBeenCalledWith(FUTURE_PANE_KEY)
+    expect(setAgentStatus).toHaveBeenCalledTimes(1)
+    expect(setAgentStatus).toHaveBeenCalledWith(
+      otherPaneKey,
+      expect.objectContaining({ state: 'working', prompt: 'surviving worker' }),
+      'Other Tab',
+      { updatedAt: 1_700_000_000_200, stateStartedAt: 1_699_999_999_200 },
+      expectWorktreeRouting('wt-1'),
+      undefined
+    )
+  })
+
+it('keeps a completed worktree-attributed row when main reports pane teardown', async () => {
+    const setAgentStatus = vi.fn()
+    const removeAgentStatus = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    const onClearListenerRef: { current: ((data: { paneKey: string }) => void) | null } = {
+      current: null
+    }
+    const subscribeListenerRef: { current: StoreSubscribeListener | null } = { current: null }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      removeAgentStatus,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: STALE_LEAF_ID },
+          activeLeafId: STALE_LEAF_ID,
+          expandedLeafId: null
+        }
+      },
       agentStatusByPaneKey: {
         [FUTURE_PANE_KEY]: {
           state: 'done',
@@ -5962,7 +6094,12 @@ describe('useIpcEvents agent status snapshot integration', () => {
     stubReactSyncEffect()
     vi.doMock('../store', () => ({
       useAppStore: {
-        subscribe: vi.fn(() => () => {}),
+        subscribe: vi.fn((listener: StoreSubscribeListener) => {
+          subscribeListenerRef.current = listener
+          return () => {
+            subscribeListenerRef.current = null
+          }
+        }),
         getState: () => storeState
       }
     }))
@@ -5970,7 +6107,10 @@ describe('useIpcEvents agent status snapshot integration', () => {
     vi.stubGlobal(
       'window',
       buildWindowApi({
-        onSet: () => () => {},
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        },
         onClear: (cb) => {
           onClearListenerRef.current = cb
           return () => {}
@@ -5983,13 +6123,39 @@ describe('useIpcEvents agent status snapshot integration', () => {
     useIpcEvents()
     await Promise.resolve()
 
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
     if (typeof onClearListenerRef.current !== 'function') {
       throw new Error('Expected agentStatus.onClear listener to be registered')
     }
 
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'working',
+      prompt: 'late stale worker',
+      agentType: 'grok',
+      receivedAt: 1_700_000_000_300,
+      stateStartedAt: 1_700_000_000_300
+    })
+    expect(setAgentStatus).not.toHaveBeenCalled()
+
     onClearListenerRef.current({ paneKey: FUTURE_PANE_KEY })
 
+    storeState.terminalLayoutsByTabId = {
+      'tab-future': {
+        root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+        activeLeafId: FUTURE_LEAF_ID,
+        expandedLeafId: null
+      }
+    }
+    if (typeof subscribeListenerRef.current !== 'function') {
+      throw new Error('Expected useAppStore.subscribe listener to be registered')
+    }
+    subscribeListenerRef.current(storeState)
+
     expect(removeAgentStatus).not.toHaveBeenCalled()
+    expect(setAgentStatus).not.toHaveBeenCalled()
   })
 
   it('does not retain a Cursor spinner terminal title when the hook reports done', async () => {
@@ -6402,14 +6568,20 @@ describe('useIpcEvents agent status snapshot integration', () => {
   })
 
   it('buffers ready push events until a mounted tab contains the pane leaf', async () => {
-    const setAgentStatus = vi.fn()
+    const otherLeafId = '22222222-2222-4222-8222-222222222222'
+    const otherPaneKey = makePaneKey('tab-other', otherLeafId)
     const track = vi.fn()
     const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
       current: null
     }
     const subscribeListenerRef: { current: StoreSubscribeListener | null } = { current: null }
+    let storeState: StoreLike
+    const setAgentStatus = vi.fn(() => {
+      // Zustand notifies subscribers synchronously after a successful state write.
+      subscribeListenerRef.current?.(storeState)
+    })
 
-    const storeState: StoreLike = buildStoreState({
+    storeState = buildStoreState({
       setAgentStatus,
       workspaceSessionReady: true,
       settings: { terminalFontSize: 13, notifications: { enabled: false } },
@@ -6475,13 +6647,20 @@ describe('useIpcEvents agent status snapshot integration', () => {
       receivedAt: 1_700_000_000_200,
       stateStartedAt: 1_699_999_999_100
     })
+    onSetListenerRef.current({
+      paneKey: otherPaneKey,
+      state: 'working',
+      prompt: 'still unresolved',
+      agentType: 'claude',
+      receivedAt: 1_700_000_000_300,
+      stateStartedAt: 1_699_999_999_300
+    })
 
     expect(setAgentStatus).not.toHaveBeenCalled()
     expect(track).toHaveBeenCalledWith('agent_hook_unattributed', {
       reason: 'unknown_tab_id'
     })
 
-    const previousStoreState = { ...storeState }
     storeState.terminalLayoutsByTabId = {
       'tab-future': {
         root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
@@ -6492,7 +6671,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     if (typeof subscribeListenerRef.current !== 'function') {
       throw new Error('Expected useAppStore.subscribe listener to be registered')
     }
-    subscribeListenerRef.current(storeState, previousStoreState)
+    subscribeListenerRef.current(storeState)
 
     expect(setAgentStatus).toHaveBeenCalledTimes(2)
     expect(setAgentStatus).toHaveBeenNthCalledWith(
@@ -6515,6 +6694,41 @@ describe('useIpcEvents agent status snapshot integration', () => {
       }),
       'Future Tab',
       { updatedAt: 1_700_000_000_200, stateStartedAt: 1_699_999_999_100 },
+      expectWorktreeRouting('wt-1'),
+      undefined
+    )
+
+    storeState.tabsByWorktree = {
+      'wt-1': [
+        { id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' },
+        { id: 'tab-other', ptyId: 'pty-2', worktreeId: 'wt-1', title: 'Other Tab' }
+      ]
+    }
+    storeState.terminalLayoutsByTabId = {
+      'tab-future': {
+        root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+        activeLeafId: FUTURE_LEAF_ID,
+        expandedLeafId: null
+      },
+      'tab-other': {
+        root: { type: 'leaf', leafId: otherLeafId },
+        activeLeafId: otherLeafId,
+        expandedLeafId: null
+      }
+    }
+    subscribeListenerRef.current(storeState)
+
+    expect(setAgentStatus).toHaveBeenCalledTimes(3)
+    expect(setAgentStatus).toHaveBeenNthCalledWith(
+      3,
+      otherPaneKey,
+      expect.objectContaining({
+        state: 'working',
+        prompt: 'still unresolved',
+        agentType: 'claude'
+      }),
+      'Other Tab',
+      { updatedAt: 1_700_000_000_300, stateStartedAt: 1_699_999_999_300 },
       expectWorktreeRouting('wt-1'),
       undefined
     )

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2844,6 +2844,18 @@ export function useIpcEvents(): void {
       schedulePendingAgentStatusFlush()
     }
 
+    function cancelPendingAgentStatusesForPane(paneKey: string): void {
+      for (let index = pendingAgentStatusEvents.length - 1; index >= 0; index -= 1) {
+        if (pendingAgentStatusEvents[index]?.data.paneKey === paneKey) {
+          pendingAgentStatusEvents.splice(index, 1)
+        }
+      }
+      if (pendingAgentStatusEvents.length === 0 && pendingAgentStatusRetryTimer !== null) {
+        globalThis.clearTimeout(pendingAgentStatusRetryTimer)
+        pendingAgentStatusRetryTimer = null
+      }
+    }
+
     function flushPendingAgentStatuses(): void {
       // Why: guard re-entrancy — a subscriber firing mid-loop must not reprocess queued events the outer flush already owns.
       if (isFlushingAgentStatuses) {
@@ -2856,7 +2868,10 @@ export function useIpcEvents(): void {
       try {
         const now = Date.now()
         const remaining: PendingAgentStatusEvent[] = []
-        for (const event of pendingAgentStatusEvents) {
+        // Why: applying a status synchronously notifies the store subscriber below,
+        // which re-enters this flush. Drain first so it cannot replay the same batch.
+        const eventsToFlush = pendingAgentStatusEvents.splice(0)
+        for (const event of eventsToFlush) {
           if (now - event.firstSeenAt > PENDING_AGENT_STATUS_TTL_MS) {
             continue
           }
@@ -2865,8 +2880,10 @@ export function useIpcEvents(): void {
             remaining.push(event)
           }
         }
-        pendingAgentStatusEvents.length = 0
-        pendingAgentStatusEvents.push(...remaining)
+        pendingAgentStatusEvents.unshift(...remaining)
+        while (pendingAgentStatusEvents.length > MAX_PENDING_AGENT_STATUS_EVENTS) {
+          pendingAgentStatusEvents.shift()
+        }
         if (pendingAgentStatusEvents.length === 0 && pendingAgentStatusRetryTimer !== null) {
           globalThis.clearTimeout(pendingAgentStatusRetryTimer)
           pendingAgentStatusRetryTimer = null
@@ -3169,6 +3186,9 @@ export function useIpcEvents(): void {
         if (!('paneKey' in data) || typeof data.paneKey !== 'string') {
           return
         }
+        // Why: PTY teardown is authoritative for this pane. A layout-delayed hook
+        // event must not replay afterward and resurrect an idle/working agent row.
+        cancelPendingAgentStatusesForPane(data.paneKey)
         const store = useAppStore.getState()
         if (store.agentStatusByPaneKey[data.paneKey]?.state === 'done') {
           return


### PR DESCRIPTION
## Summary

Fixes a renderer crash and stale agent row after an Orca-managed background agent terminal is explicitly stopped.

The renderer now:

- drains buffered agent-status events before applying them, so synchronous Zustand subscribers cannot re-enter and replay the same live batch
- removes only the torn-down pane pending events before applying the existing completed-row retention rule
- preserves unrelated panes, unresolved events, queue ordering, TTL behavior, and the 100-event cap

No runtime protocol, PTY tombstone, SSH/remote transport, or `TerminalKilledError` behavior changes.

## Incident and root cause

The observed session ended with:

`Session "...@@708eb837" was explicitly killed`

The agent had already completed successfully. The coordinating process then intentionally stopped its terminal, but Orca retained an Idle/Done sidebar row and logged:

`RangeError: Maximum call stack size exceeded`

with the stack:

`resolvePaneKey → applyAgentStatus → flushPendingAgentStatuses → subscriber → flushPendingAgentStatuses`

Before this change, `flushPendingAgentStatuses` iterated the shared pending array and cleared it only after calling `setAgentStatus`. Zustand notifies subscribers synchronously; Orca's global subscriber calls the flush again. Once a buffered event became resolvable, the nested flush saw the same uncleared event and reapplied it recursively until the renderer exhausted the stack.

A separate teardown race left same-pane buffered events in the retry queue. Even after main emitted `agentStatus:clear`, one of those events could later replay and resurrect an Idle/Working row.

## Behavioral invariants

- Drain the current batch before applying any status.
- Requeue only unresolved, unexpired events in their original order.
- Keep newly queued/unrelated pane events and enforce the existing queue cap.
- Treat pane teardown as authoritative for pending events belonging to that pane.
- Preserve an already-rendered `done` row exactly as before.
- Do not change local, SSH, WSL, remote-runtime, mobile, or PTY lifecycle contracts.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — reaches the localization verifier, then stops on the pre-existing `ja.json` interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR changes no locale files
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full repository suite not run
- [ ] `pnpm build` — no build or packaging behavior changed
- [x] Added or updated high-quality tests that would catch regressions

Focused evidence:

- RED on the previous implementation: three focused regressions failed; the synchronous subscriber test reproduced `Maximum call stack size exceeded`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts` — 133 passed
- all eight `agent-status*.test.ts` store suites — 87 passed
- changed-file `oxlint` and `oxfmt --check`
- `pnpm check:max-lines-ratchet`
- `git diff --check`
- temporary integration with current `origin/main@03a673708`: automatic merge succeeded, the same 133 tests passed, and all three typecheck projects passed; the merge was then aborted without changing PR history

The regression tests specifically cover:

1. synchronous subscriber re-entry without duplicate apply or stack overflow
2. target-only teardown cancellation while another pane continues
3. retention of an existing completed row while stale same-pane pending work is discarded
4. preservation and later application of an unrelated unresolved event

## AI Review Report

An independent Claude review inspected the actual uncommitted diff and relevant surrounding lifecycle code. It explicitly checked:

- synchronous Zustand notification and re-entry behavior
- queue ordering, TTL, cap, retry timer cleanup, and unresolved-event preservation
- `agentStatus:clear` ordering relative to completed-row retention
- local, SSH, WSL, remote-runtime, mobile, macOS, Linux, and Windows impact
- Electron IPC and PTY teardown boundaries
- whether the test mocks reproduced the production call sequence

Verdict: **APPROVED**, with no P0–P3 findings and no requested code changes.

CodeRabbit also completed its code review with no actionable comments. Its description-template warning is addressed by this updated PR body.

## Security Audit

This change introduces no new external input, command execution, filesystem/path handling, authentication, secret handling, dependency, or network behavior.

The reviewed security/reliability boundary is the existing Electron agent-status IPC payload:

- the existing pane-key string validation and status normalization are unchanged
- cancellation performs an exact in-memory `paneKey` comparison only
- no IPC method, permission boundary, provider routing, shell invocation, or persisted data format changes
- the pending queue remains bounded by the existing 100-event limit

No security follow-up is required for this patch.

## Notes

- PR remains intentionally unmerged for maintainer approval.
- The branch is behind current `main` by unrelated commits, including native-chat transcript readability changes elsewhere in `useIpcEvents.ts`. GitHub reports the PR mergeable; a three-way merge and temporary latest-main verification completed without conflict.
- Existing local untracked files `HANDOFF.md` and `mobile/build/` are not part of this PR.

## ELI5

Stopping a managed background agent could crash the renderer or leave a stale agent row because buffered status events replayed after teardown. Pending events for that pane are drained and dropped safely so only live panes keep updating.
