### PR TITLE
Add always-visible git branch + sync control to the status bar

### DIFF
--- a/src/renderer/src/components/status-bar/GitBranchStatusSegment.test.ts
+++ b/src/renderer/src/components/status-bar/GitBranchStatusSegment.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { isRemoteActionEnabled, syncDotColor } from './GitBranchStatusSegment'
+import type { GitUpstreamStatus } from '../../../../shared/git-status-types'
+
+function upstream(overrides: Partial<GitUpstreamStatus>): GitUpstreamStatus {
+  return { hasUpstream: true, ahead: 0, behind: 0, ...overrides }
+}
+
+describe('syncDotColor', () => {
+  it('is muted when there is no upstream', () => {
+    expect(syncDotColor(undefined)).toBe('bg-muted-foreground/40')
+    expect(syncDotColor(upstream({ hasUpstream: false }))).toBe('bg-muted-foreground/40')
+  })
+
+  it('is emerald when up to date with the remote', () => {
+    expect(syncDotColor(upstream({ ahead: 0, behind: 0 }))).toBe('bg-emerald-500')
+  })
+
+  it('is amber when ahead or behind the remote', () => {
+    expect(syncDotColor(upstream({ ahead: 2, behind: 0 }))).toBe('bg-amber-500')
+    expect(syncDotColor(upstream({ ahead: 0, behind: 3 }))).toBe('bg-amber-500')
+    expect(syncDotColor(upstream({ ahead: 1, behind: 1 }))).toBe('bg-amber-500')
+  })
+})
+
+describe('isRemoteActionEnabled', () => {
+  it('disables remote actions without a resolved upstream', () => {
+    expect(isRemoteActionEnabled(undefined)).toBe(false)
+    expect(isRemoteActionEnabled(upstream({ hasUpstream: false }))).toBe(false)
+  })
+
+  it('enables remote actions once an upstream exists', () => {
+    expect(isRemoteActionEnabled(upstream({ hasUpstream: true }))).toBe(true)
+  })
+})

--- a/src/renderer/src/components/status-bar/GitBranchStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/GitBranchStatusSegment.tsx
@@ -1,0 +1,303 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { ArrowDown, ArrowUp, GitBranch, Loader2, RefreshCw } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '../../store'
+import { useActiveWorktree, useActiveWorktreeId, useRepoById } from '../../store/selectors'
+import { getConnectionId } from '../../lib/connection-context'
+import { getWorktreeGitIdentityDisplay } from '../../lib/worktree-git-identity-display'
+import {
+  fetchRuntimeGit,
+  getRuntimeGitUpstreamStatus,
+  pullRuntimeGit,
+  pushRuntimeGit,
+  type RuntimeGitContext
+} from '../../runtime/runtime-git-client'
+import type { GitPushTarget } from '../../../../shared/types'
+import type { GitUpstreamStatus } from '../../../../shared/git-status-types'
+
+type GitAction = 'fetch' | 'pull' | 'push' | 'sync'
+
+// Why: amber signals "needs attention" per Orca's status convention; emerald means
+// in-sync, and muted means there is no upstream to compare against.
+export function syncDotColor(upstream: GitUpstreamStatus | undefined): string {
+  if (!upstream?.hasUpstream) {
+    return 'bg-muted-foreground/40'
+  }
+  if (upstream.ahead > 0 || upstream.behind > 0) {
+    return 'bg-amber-500'
+  }
+  return 'bg-emerald-500'
+}
+
+// Why: fetch/pull/push all need a resolved upstream; without one there is no
+// remote ref to reconcile against, so the actions must stay disabled.
+export function isRemoteActionEnabled(upstream: GitUpstreamStatus | undefined): boolean {
+  return upstream?.hasUpstream ?? false
+}
+
+export function GitBranchStatusSegment({
+  compact,
+  iconOnly
+}: {
+  compact: boolean
+  iconOnly: boolean
+}): React.JSX.Element | null {
+  const activeWorktreeId = useActiveWorktreeId()
+  const activeWorktree = useActiveWorktree()
+  const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
+  const settings = useAppStore((s) => s.settings)
+  const upstream = useAppStore((s) =>
+    activeWorktreeId ? s.remoteStatusesByWorktree[activeWorktreeId] : undefined
+  )
+  const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
+  const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
+  const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
+
+  const [busyAction, setBusyAction] = useState<GitAction | null>(null)
+
+  const identity = useMemo(
+    () =>
+      activeWorktree
+        ? getWorktreeGitIdentityDisplay({
+            branch: activeWorktree.branch,
+            head: activeWorktree.head
+          })
+        : null,
+    [activeWorktree]
+  )
+
+  const pushTarget: GitPushTarget | undefined = activeWorktree?.pushTarget
+
+  const buildContext = useCallback((): RuntimeGitContext | null => {
+    if (!activeWorktree?.path) {
+      return null
+    }
+    const connectionId = getConnectionId(activeWorktreeId) ?? activeRepo?.connectionId ?? undefined
+    return {
+      settings,
+      worktreeId: activeWorktreeId,
+      worktreePath: activeWorktree.path,
+      connectionId: connectionId ?? undefined
+    }
+  }, [activeRepo?.connectionId, activeWorktree?.path, activeWorktreeId, settings])
+
+  const refreshUpstream = useCallback(
+    async (context: RuntimeGitContext): Promise<void> => {
+      if (!activeWorktreeId) {
+        return
+      }
+      try {
+        const next = await getRuntimeGitUpstreamStatus(context, pushTarget)
+        setUpstreamStatus(activeWorktreeId, next)
+      } catch {
+        // Why: the indicator refresh is best-effort; the periodic poll will
+        // reconcile it, so a transient failure here must not surface an error.
+      }
+    },
+    [activeWorktreeId, pushTarget, setUpstreamStatus]
+  )
+
+  const runAction = useCallback(
+    async (action: GitAction): Promise<void> => {
+      const context = buildContext()
+      if (!context || busyAction) {
+        return
+      }
+      setBusyAction(action)
+      try {
+        if (action === 'fetch') {
+          await fetchRuntimeGit(context, pushTarget)
+        } else if (action === 'pull') {
+          await pullRuntimeGit(context, pushTarget)
+        } else if (action === 'push') {
+          await pushRuntimeGit(context, pushTarget ? { pushTarget } : {})
+        } else {
+          // Sync: reconcile remote first, then publish local commits.
+          await pullRuntimeGit(context, pushTarget)
+          await pushRuntimeGit(context, pushTarget ? { pushTarget } : {})
+        }
+        await refreshUpstream(context)
+      } catch (err) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : translate(
+                'auto.components.status.bar.GitBranchStatusSegment.action_failed',
+                'Git action failed'
+              )
+        )
+      } finally {
+        setBusyAction(null)
+      }
+    },
+    [buildContext, busyAction, pushTarget, refreshUpstream]
+  )
+
+  if (!activeWorktree || !identity) {
+    return null
+  }
+
+  const branchLabel = identity.kind === 'branch' ? identity.branchName : identity.shortHead
+  const hasUpstream = isRemoteActionEnabled(upstream)
+  const ahead = upstream?.ahead ?? 0
+  const behind = upstream?.behind ?? 0
+  const busy = busyAction !== null
+  const isDetached = identity.kind === 'detached'
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 hover:bg-accent/70"
+          aria-label={translate(
+            'auto.components.status.bar.GitBranchStatusSegment.aria_label',
+            'Current branch and remote sync status'
+          )}
+        >
+          {busy ? (
+            <Loader2 className="size-3 animate-spin text-muted-foreground" />
+          ) : (
+            <GitBranch className="size-3 text-muted-foreground" />
+          )}
+          {!iconOnly && (
+            <span className="max-w-[12rem] truncate text-[11px] text-muted-foreground">
+              {branchLabel}
+            </span>
+          )}
+          {hasUpstream && !compact && (ahead > 0 || behind > 0) && (
+            <span className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground">
+              {ahead > 0 && (
+                <span className="inline-flex items-center">
+                  <ArrowUp className="size-3" />
+                  {ahead}
+                </span>
+              )}
+              {behind > 0 && (
+                <span className="inline-flex items-center">
+                  <ArrowDown className="size-3" />
+                  {behind}
+                </span>
+              )}
+            </span>
+          )}
+          <span className={`inline-block size-1.5 rounded-full ${syncDotColor(upstream)}`} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="w-[min(18rem,calc(100vw-1rem))]"
+      >
+        <DropdownMenuLabel className="flex items-center gap-1.5 truncate">
+          <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate">{branchLabel}</span>
+        </DropdownMenuLabel>
+        <div className="px-2 pb-1 text-[11px] text-muted-foreground">
+          {isDetached
+            ? translate(
+                'auto.components.status.bar.GitBranchStatusSegment.detached_head',
+                'Detached HEAD — no branch to sync'
+              )
+            : !hasUpstream
+              ? translate(
+                  'auto.components.status.bar.GitBranchStatusSegment.no_upstream',
+                  'No upstream branch set'
+                )
+              : ahead === 0 && behind === 0
+                ? translate(
+                    'auto.components.status.bar.GitBranchStatusSegment.in_sync',
+                    'Up to date with remote'
+                  )
+                : translate(
+                    'auto.components.status.bar.GitBranchStatusSegment.ahead_behind',
+                    '{{value0}} ahead, {{value1}} behind',
+                    { value0: String(ahead), value1: String(behind) }
+                  )}
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          disabled={busy || !hasUpstream}
+          onSelect={(event) => {
+            event.preventDefault()
+            void runAction('sync')
+          }}
+        >
+          {busyAction === 'sync' ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="size-3.5" />
+          )}
+          {translate(
+            'auto.components.status.bar.GitBranchStatusSegment.sync',
+            'Sync (Pull then Push)'
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={busy || !hasUpstream}
+          onSelect={(event) => {
+            event.preventDefault()
+            void runAction('fetch')
+          }}
+        >
+          {busyAction === 'fetch' ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <ArrowDown className="size-3.5" />
+          )}
+          {translate('auto.components.status.bar.GitBranchStatusSegment.fetch', 'Fetch')}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={busy || !hasUpstream}
+          onSelect={(event) => {
+            event.preventDefault()
+            void runAction('pull')
+          }}
+        >
+          {busyAction === 'pull' ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <ArrowDown className="size-3.5" />
+          )}
+          {translate('auto.components.status.bar.GitBranchStatusSegment.pull', 'Pull')}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={busy || !hasUpstream}
+          onSelect={(event) => {
+            event.preventDefault()
+            void runAction('push')
+          }}
+        >
+          {busyAction === 'push' ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <ArrowUp className="size-3.5" />
+          )}
+          {translate('auto.components.status.bar.GitBranchStatusSegment.push', 'Push')}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={() => {
+            setRightSidebarOpen(true)
+            setRightSidebarTab('source-control')
+          }}
+        >
+          {translate(
+            'auto.components.status.bar.GitBranchStatusSegment.open_source_control',
+            'Open Source Control…'
+          )}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -97,6 +97,11 @@ const PortsStatusSegment = lazyWithRetry(() =>
 const SshStatusSegment = lazyWithRetry(() =>
   import('./SshStatusSegment').then((module) => ({ default: module.SshStatusSegment }))
 )
+const GitBranchStatusSegment = lazyWithRetry(() =>
+  import('./GitBranchStatusSegment').then((module) => ({
+    default: module.GitBranchStatusSegment
+  }))
+)
 
 export type CodexStatusRuntimeTarget = {
   runtime: 'host' | 'wsl'
@@ -2127,6 +2132,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
           ) : null}
           {showPorts ? <PortsStatusSegment compact={compact} iconOnly={iconOnly} /> : null}
           {showSsh ? <SshStatusSegment compact={compact} iconOnly={iconOnly} /> : null}
+          <GitBranchStatusSegment compact={compact} iconOnly={iconOnly} />
         </React.Suspense>
         {showFloatingTerminalToggle && (
           <FloatingTerminalIconContextMenu currentLocation="status-bar" className="relative">

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3198,6 +3198,19 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"
+          },
+          "GitBranchStatusSegment": {
+            "action_failed": "Git action failed",
+            "aria_label": "Current branch and remote sync status",
+            "detached_head": "Detached HEAD — no branch to sync",
+            "no_upstream": "No upstream branch set",
+            "in_sync": "Up to date with remote",
+            "ahead_behind": "{{value0}} ahead, {{value1}} behind",
+            "sync": "Sync (Pull then Push)",
+            "fetch": "Fetch",
+            "pull": "Pull",
+            "push": "Push",
+            "open_source_control": "Open Source Control…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3198,6 +3198,19 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "Host SSH"
+          },
+          "GitBranchStatusSegment": {
+            "action_failed": "Git action failed",
+            "aria_label": "Current branch and remote sync status",
+            "detached_head": "Detached HEAD — no branch to sync",
+            "no_upstream": "No upstream branch set",
+            "in_sync": "Up to date with remote",
+            "ahead_behind": "{{value0}} ahead, {{value1}} behind",
+            "sync": "Sync (Pull then Push)",
+            "fetch": "Fetch",
+            "pull": "Pull",
+            "push": "Push",
+            "open_source_control": "Open Source Control…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3198,6 +3198,19 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH ホスト"
+          },
+          "GitBranchStatusSegment": {
+            "action_failed": "Git action failed",
+            "aria_label": "Current branch and remote sync status",
+            "detached_head": "Detached HEAD — no branch to sync",
+            "no_upstream": "No upstream branch set",
+            "in_sync": "Up to date with remote",
+            "ahead_behind": "{{value0}} ahead, {{value1}} behind",
+            "sync": "Sync (Pull then Push)",
+            "fetch": "Fetch",
+            "pull": "Pull",
+            "push": "Push",
+            "open_source_control": "Open Source Control…"
           }
         }
       },
@@ -12877,7 +12890,7 @@
         "pastedImageLabel": "貼り付けた画像",
         "imagePasteFailed": "画像の貼り付けに失敗しました。",
         "worktreeNotReady": "Worktreeが準備できていません — しばらくしてから再試行してください。",
-        "uploadingAttachments": "{{value0}}個のファイルをリモートにアップロード中…"
+        "uploadingAttachments": "Uploading {{value0}} file{{value1}} to remote…"
       },
       "tool": {
         "running": "実行中…",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3198,6 +3198,19 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 호스트"
+          },
+          "GitBranchStatusSegment": {
+            "action_failed": "Git action failed",
+            "aria_label": "Current branch and remote sync status",
+            "detached_head": "Detached HEAD — no branch to sync",
+            "no_upstream": "No upstream branch set",
+            "in_sync": "Up to date with remote",
+            "ahead_behind": "{{value0}} ahead, {{value1}} behind",
+            "sync": "Sync (Pull then Push)",
+            "fetch": "Fetch",
+            "pull": "Pull",
+            "push": "Push",
+            "open_source_control": "Open Source Control…"
           }
         }
       },
@@ -12877,7 +12890,7 @@
         "pastedImageLabel": "붙여넣은 이미지",
         "imagePasteFailed": "이미지 붙여넣기 실패.",
         "worktreeNotReady": "워크트리가 준비되지 않았습니다 — 잠시 후 다시 시도하세요.",
-        "uploadingAttachments": "{{value0}}개 파일을 원격으로 업로드 중…"
+        "uploadingAttachments": "Uploading {{value0}} file{{value1}} to remote…"
       },
       "tool": {
         "running": "실행 중…",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3198,6 +3198,19 @@
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 主机"
+          },
+          "GitBranchStatusSegment": {
+            "action_failed": "Git action failed",
+            "aria_label": "Current branch and remote sync status",
+            "detached_head": "Detached HEAD — no branch to sync",
+            "no_upstream": "No upstream branch set",
+            "in_sync": "Up to date with remote",
+            "ahead_behind": "{{value0}} ahead, {{value1}} behind",
+            "sync": "Sync (Pull then Push)",
+            "fetch": "Fetch",
+            "pull": "Pull",
+            "push": "Push",
+            "open_source_control": "Open Source Control…"
           }
         }
       },
@@ -12877,7 +12890,7 @@
         "pastedImageLabel": "粘贴的图片",
         "imagePasteFailed": "图片粘贴失败。",
         "worktreeNotReady": "Worktree 未就绪 — 请稍后重试。",
-        "uploadingAttachments": "正在上传 {{value0}} 个文件到远程…"
+        "uploadingAttachments": "Uploading {{value0}} file{{value1}} to remote…"
       },
       "tool": {
         "running": "正在运行…",


### PR DESCRIPTION
## Summary

Adds an always-visible git segment to the bottom status bar. It shows the active
worktree's **branch name** and remote **ahead/behind**, with a small state dot
(muted = no upstream, emerald = up to date, amber = ahead/behind). Clicking it opens
a dropdown with **Sync (Pull then Push)**, **Fetch**, **Pull**, **Push**, and
**Open Source Control…**.

Previously the branch and its remote-sync state lived only in the right-sidebar
Source Control panel, which is often collapsed. This makes "what branch am I on, and
is it in sync?" answerable at a glance and actionable without opening the sidebar.

Implementation reuses existing plumbing end-to-end — **no new IPC and no new git
primitives**:
- `runtime/runtime-git-client.ts` (`fetchRuntimeGit` / `pullRuntimeGit` / `pushRuntimeGit`,
  already local/remote/SSH aware) for the actions.
- `remoteStatusesByWorktree` store state (kept fresh by the existing `useGitStatusPolling`)
  for ahead/behind, refreshed via `setUpstreamStatus` after each action.
- `getWorktreeGitIdentityDisplay` for branch/detached-HEAD identity.

Remote actions are gated on a resolved upstream; first-publish of an upstream-less
branch is intentionally deferred to the Source Control panel (linked from the menu).
The segment self-hides when there is no active git worktree.

X (Twitter): @taesung_le91599

## Screenshots

_Status bar segment and its dropdown (attached to the PR conversation)._
<img width="2880" height="1740" alt="orca-git-segment-full" src="https://github.com/user-attachments/assets/e3b1672e-9160-455a-89a0-b964e0a67a5f" />
<img width="2880" height="1740" alt="orca-git-segment-menu" src="https://github.com/user-attachments/assets/6c872617-7106-456c-8bd2-750be1633a50" />

- Bottom-right status bar showing **⎇ main**.
- Dropdown with Sync / Fetch / Pull / Push / Open Source Control (actions disabled and
  "No upstream branch set" shown for a branch without an upstream).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (26,494 passed)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added a colocated unit test (`GitBranchStatusSegment.test.ts`) covering the sync-dot state
mapping and the disabled-without-upstream gating. Also verified end-to-end in a real Electron
launch via the E2E fixture: the branch renders, the dropdown renders, and the actions are
correctly disabled without an upstream.

## AI Review Report

Reviewed with Claude Code across the dimensions below; nothing outstanding.

- **Cross-platform (macOS / Linux / Windows):** The component contains no platform-specific
  code — no `metaKey`/keyboard handling, no path separators, no shell invocation. It uses lucide
  icons, shadcn `DropdownMenu`, and design tokens only, so rendering is identical on all three.
  Git actions delegate to the existing runtime client, which already encapsulates platform
  differences. No Electron main-process changes.
- **SSH / remote / local:** All actions go through `runtime-git-client`, which routes to the
  local `window.api.git.*` bridge or a runtime RPC based on the active target — the same path the
  Source Control panel uses. No local-only assumptions.
- **Git provider compatibility:** The feature is plain git fetch/pull/push and is provider-neutral;
  no GitHub-only naming or API usage. "Open Source Control" reuses the existing provider-agnostic panel.
- **Performance:** Subscribes to narrow store slices, memoizes branch identity, and is lazy-loaded
  like the other segments. It adds **no new polling** — it reads the ahead/behind state the existing
  `useGitStatusPolling` already maintains. Per-action in-flight state is local.
- **UI quality:** Follows the existing status-bar segment conventions (`SshStatusSegment`), token-based
  colors, `compact`/`iconOnly` modes, and label truncation.

## Security Audit

- **Command execution / input handling:** No new command construction. Actions call existing
  execFile-based git primitives with fixed argument shapes; branch/upstream values are only rendered
  as text, never interpolated into a shell. No new IPC channels or preload surface.
- **Path handling:** No filesystem path manipulation in the renderer; the worktree path comes from
  store state and is passed through the existing typed client.
- **Secrets / auth:** None handled. Auth for push/pull is delegated to the existing git client flow.
- **Error handling:** Action failures surface via `toast.error`; the best-effort upstream refresh
  swallows transient errors by design (the periodic poll reconciles). No sensitive data logged.
- Follow-up: none required.

## Notes

- **No upstream → actions disabled.** A branch without a resolved upstream shows "No upstream branch set"
  and disables Fetch/Pull/Push/Sync; first-publish is handled in the Source Control panel (linked). This
  keeps fork/push-target resolution in one place rather than duplicating it in the status bar.
- **Sync semantics:** Sync = pull then push. Conflicts surface as a toast and are resolved via the Source
  Control panel.
- **i18n:** New strings registered in the localization catalog via `pnpm sync:localization-catalog`
  (en + es/ja/ko/zh parity).

## ELI5

The bottom status bar always shows the active branch and ahead/behind with a small color dot. Click it for Sync, Fetch, Pull, Push, or open Source Control without opening the right sidebar.
