### PR TITLE
Auto-resume rate-limited agents

### DIFF
--- a/notes/auto-resume-rate-limited-agents.md
+++ b/notes/auto-resume-rate-limited-agents.md
@@ -1,0 +1,153 @@
+# Auto-Resume Rate-Limited Agents
+
+## Problem
+
+Agent CLIs (Claude Code, Codex) stall when they hit provider usage limits. Claude Code shows either
+an idle banner — `You've hit your session limit · resets 3:50pm (Europe/London)` — or a blocking menu:
+
+```
+What do you want to do?
+❯ 1. Stop and wait for limit to reset
+  2. Ask your admin for more usage
+  Enter to confirm · Esc to cancel
+```
+
+Today an external cron script scrapes terminal-history files and sends keystrokes. It fails in
+practice: append-only history keeps stale banner text matching for hours, a content-hash cooldown
+then blinds it to *new* limit events on the same terminal, and 30-minute polling adds worst-case
+multi-hour blackouts. Detection must be event-driven on live PTY output, inside Orca.
+
+## Decided product behavior (owner sign-off, do not re-litigate)
+
+1. **Opt-in**: global setting, **off by default**.
+2. **Scope v1**: **Claude Code and Codex** stuck-state patterns. Architecture must be
+   provider-pluggable for gemini/opencode later.
+3. **Menu grace**: when the wait-for-reset menu is detected, do NOT act immediately. Wait the
+   agent idle-timer duration already configured in Orca (the hibernation idle timeout the user can
+   configure; e.g. 5 min) so a human can intervene, then select option 1 ("Stop and wait for limit
+   to reset") if the menu is still live. The agent CLI then handles its own countdown/resume.
+4. **Banner-only case** (agent idle at prompt with a limit banner): arm a timer for the parsed
+   `resetsAt` + ~90s grace, re-verify the banner is still on the live screen, then send
+   `continue` + Enter.
+5. **Dead PTY case**: if the limited agent's process has exited and a sleeping-session record
+   exists, resume via the existing sleeping-agent relaunch path instead of keystrokes.
+6. **Never act on stale data**: all detection and pre-send verification happens against the live
+   PTY tail buffer, never terminal-history files on disk. Before any send, confirm the
+   triggering banner/menu is still present and the agent title/status is not "working".
+
+## Existing primitives to build on (verified file:line on origin/main)
+
+Detection:
+- `src/main/runtime/orca-runtime.ts:24460` — `findTerminalWaitBlockedSignal` scans each PTY's
+  tail-buffer preview per output chunk for banner substrings; classifies into
+  `RuntimeTerminalWaitBlockedReason` (`src/shared/runtime-types.ts:543`). Per-chunk hook with
+  `tailWaitState` / `waitBlockedAt` tracking at `orca-runtime.ts:5390-5423`.
+  Entry points: `detectTerminalWaitBlockedReason` (24377), `isKnownReadyPromptPreview` (24364).
+- `src/shared/terminal-title-status.ts:138` — `detectAgentStatusFromTitle` (working/permission/idle
+  from OSC titles); per-PTY `lastAgentStatus` updated at `orca-runtime.ts:5397-5423`.
+
+Reset-time parsing:
+- `src/main/rate-limits/claude-pty-reset-parser.ts:68` — `extractClaudePtyResetMetadata` already
+  parses "resets 3:50pm", "resets Jan 5 at 4pm", relative "3h 20m" → timestamp. Reuse, don't rewrite.
+
+Structured quota data (cross-check / fallback):
+- `src/main/rate-limits/service.ts:106` — `RateLimitService`, `onStateChange` (161), poller +
+  focus-refresh (211-236). `RateLimitWindow.resetsAt` in `src/shared/rate-limit-types.ts:1`.
+- Codex: `src/main/rate-limits/codex-fetcher.ts` (JSON-RPC usage probe, resetsAt at 384).
+
+Service template:
+- `src/main/agent-awake-service.ts:42` — `AgentAwakeService`: settings-toggled (`setEnabled`, 84),
+  fed by status changes (`setStatuses`, 92; wired via `agentHookServer.subscribeStatusChanges` in
+  `src/main/index.ts:1691`), per-agent future-expiry `setTimeout` (`scheduleStaleTimer`, 134).
+  Registered in composition root `src/main/index.ts:1685-1917`. Model the new service on this.
+
+Wake actions:
+- Live PTY keystrokes: `terminal.send` RPC `src/main/runtime/rpc/methods/terminal.ts:903` →
+  `runtime.sendTerminal` (`orca-runtime.ts:8891`) → `ptyController.write`.
+- Dead PTY resume: `src/renderer/src/lib/resume-sleeping-agent-session.ts:62`
+  (`launchSleepingAgentSession` — new tab + resume argv from
+  `src/shared/agent-session-resume.ts:195`). Sleeping records:
+  `SleepingAgentSessionRecord` (`agent-session-resume.ts:38`).
+- Idle-timer setting to reuse for menu grace: see `src/renderer/src/lib/agent-hibernation-planner.ts`
+  (default 30-min idle, line 12) and its configurable setting — the menu grace must read the same
+  user-configured value, not a new hardcoded constant.
+
+Settings:
+- `GlobalSettings` in `src/shared/types.ts:2469` (analog toggle `keepComputerAwakeWhileAgentsRun`
+  at 2817); defaults `src/shared/constants.ts:333`; persistence `src/main/persistence.ts:5084/5131`;
+  IPC `src/main/ipc/settings.ts:109`. UI: clone
+  `src/renderer/src/components/settings/AgentAwakeSetting.tsx` (+ `agent-awake-copy.ts`), mount in
+  `src/renderer/src/components/settings/AgentsPane.tsx:836`.
+
+Status surfaces:
+- Worktree card status: `src/renderer/src/lib/worktree-status.ts:11`
+  (`WorktreeStatus = 'active'|'working'|'permission'|'done'|'inactive'`, heuristic `getWorktreeStatus`
+  at 27, labels at 120); rendered via
+  `src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx` / `StatusIndicator.tsx`.
+- Agent status vocabulary: `src/shared/agent-status-types.ts` (`working|blocked|waiting|done`),
+  visual mapping `src/renderer/src/lib/agent-status.ts:221`.
+- Status bar usage UI: `src/renderer/src/components/status-bar/StatusBar.tsx`,
+  `inline-usage-bars.tsx`; renderer slice `src/renderer/src/store/slices/rate-limits.ts`.
+- Native notifications: `src/main/ipc/notifications.ts` (settings-gated via `NotificationSettings`,
+  `src/shared/types.ts:2233`).
+
+## Implementation plan
+
+### 1. Detection (main process, runtime)
+
+- Add `'usage-limit-banner'` and `'usage-limit-menu'` to `RuntimeTerminalWaitBlockedReason`.
+- Extend `findTerminalWaitBlockedSignal` with Claude Code patterns (session/usage/rate limit banner;
+  wait-for-reset menu) and Codex equivalents (research Codex's actual limit-stall TUI text first —
+  check codex-fetcher / codexbar notes; if Codex has no interactive stall state, document that and
+  ship Codex as quota-timer-only).
+- On detection, parse reset time from the matched text via `extractClaudePtyResetMetadata`; record
+  `{ptyId, reason, resetsAt, detectedAt}` on the PTY record and emit an event.
+
+### 2. `AgentAutoResumeService` (new, main process)
+
+- Modeled on `AgentAwakeService`; registered in the composition root; enabled only by the new setting.
+- Subscribes to limit-detected events. State machine per PTY:
+  - `usage-limit-menu` → arm timer = user idle-timeout setting → on fire, verify menu still in live
+    tail + agent not working → `sendTerminal(handle, Enter)` (selects option 1).
+  - `usage-limit-banner` → arm timer = max(resetsAt from banner, resetsAt from RateLimitService for
+    that provider) + 90s → verify banner still live → `sendTerminal(handle, "continue", enter)`.
+  - PTY exit while limited → if a sleeping-session record exists for the pane, trigger the resume
+    path; else notify only.
+- Dedup: one in-flight action per ptyId; re-arm only on a *new* detection event (never re-match old
+  content). Clear state on PTY output that changes agent status to working.
+- Cap retries (e.g. 2 per detection) and always notify on give-up.
+
+### 3. Setting
+
+- `autoResumeRateLimitedAgents: boolean` in `GlobalSettings`, default **false** in constants.
+- Toggle component cloned from `AgentAwakeSetting.tsx`, mounted in AgentsPane near the awake toggle.
+  Copy: "Auto-resume rate-limited agents — when an agent hits a provider usage limit, Orca waits for
+  the limit to reset and resumes it automatically."
+
+### 4. UX surfaces
+
+- New worktree status `'rate-limited'` (amber) in `worktree-status.ts` + card chip in
+  `WorktreeCardStatusSlot`: `⏳ Rate-limited · resumes 3:50pm` (time from detection record; fall back
+  to "waiting for reset" when unparsed). Priority: above 'inactive'/'done', below 'permission'.
+- Status bar: small segment when ≥1 agent is limited: "1 agent paused · resumes 3:50pm"; click
+  focuses that terminal. Reuse rate-limits slice plumbing (`rateLimits:update`-style push or a new
+  channel from the service).
+- Native notifications (gated by existing NotificationSettings + only when feature enabled):
+  on detection ("Agent rate-limited — auto-resumes at 3:50pm") and on failed resume. Successful
+  resume may notify quietly (respect existing notification granularity patterns).
+
+### 5. Tests & gates
+
+- Vitest units: banner/menu pattern matching (real captured Claude Code output incl. ANSI-stripped
+  text; the menu text sometimes renders with collapsed spaces — "Askyouradminformoreusage" — so
+  match case/space-insensitively), reset-parser integration, service state machine with fake timers
+  (grace waits, re-verification, dedup, retry cap, PTY-exit path).
+- Run repo gates: `pnpm tc`, `pnpm lint` (mind the max-lines ratchet — new files, don't bloat
+  orca-runtime.ts; keep the service in its own module), `pnpm test`.
+
+## Non-goals (v1)
+
+- No per-repo/per-worktree overrides.
+- No gemini/opencode/other agent patterns (keep detection provider-pluggable).
+- No scraping of terminal-history files, ever.
+- No changes to the automations subsystem (this is a service, not an automation).

--- a/notes/auto-resume-rate-limited-agents.md
+++ b/notes/auto-resume-rate-limited-agents.md
@@ -5,7 +5,7 @@
 Agent CLIs (Claude Code, Codex) stall when they hit provider usage limits. Claude Code shows either
 an idle banner — `You've hit your session limit · resets 3:50pm (Europe/London)` — or a blocking menu:
 
-```
+```text
 What do you want to do?
 ❯ 1. Stop and wait for limit to reset
   2. Ask your admin for more usage

--- a/notes/codex-usage-limit-patterns.md
+++ b/notes/codex-usage-limit-patterns.md
@@ -1,0 +1,118 @@
+# Codex Usage-Limit Detection Patterns
+
+## Exact strings captured from Codex sessions
+
+```text
+You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at Apr 23rd, 2026 10:42 AM.
+```
+
+```text
+You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at May 14th, 2026 2:32 PM.
+```
+
+The May string appeared twice. These were the only Codex usage-limit error variants in the 19
+retained sessions searched from April 17 through July 9, 2026.
+
+## Stable detection strings
+
+Use both when structured event data is available:
+
+```text
+payload.codex_error_info == "usage_limit_exceeded"
+payload.type == "error"
+```
+
+For live terminal output, detect the stable prefix:
+
+```text
+You've hit your usage limit.
+```
+
+and require this reset marker later in the same live-screen match:
+
+```text
+or try again at
+```
+
+Do not depend on the upgrade sentence or URL. They are product copy and may change independently
+of the limit and reset fields.
+
+## Regex for live terminal output
+
+Strip ANSI escape sequences before matching. Match case-insensitively because rendering should
+not affect detection.
+
+```regex
+/you['’]ve\s+hit\s+your\s+usage\s+limit\.[\s\S]*?or\s+try\s+again\s+at\s+(?<reset>[A-Z][a-z]{2,8}\s+\d{1,2}(?:st|nd|rd|th)?,?\s+\d{4}\s+\d{1,2}:\d{2}\s*(?:AM|PM))\.?/i
+```
+
+Captured `reset` examples:
+
+```text
+Apr 23rd, 2026 10:42 AM
+May 14th, 2026 2:32 PM
+```
+
+If the live-tail implementation normalizes terminal text into one line, use the same regex. If it
+preserves wrapped lines, `[\s\S]*?` permits the copy between the prefix and reset marker to wrap.
+
+## Narrow reset-time regex
+
+After the usage-limit prefix has already been confirmed, extract only the timestamp with:
+
+```regex
+/or\s+try\s+again\s+at\s+(?<reset>[A-Z][a-z]{2,8}\s+\d{1,2}(?:st|nd|rd|th)?,?\s+\d{4}\s+\d{1,2}:\d{2}\s*(?:AM|PM))\.?/i
+```
+
+Normalize the captured value before parsing:
+
+```text
+Apr 23rd, 2026 10:42 AM -> Apr 23, 2026 10:42 AM
+May 14th, 2026 2:32 PM -> May 14, 2026 2:32 PM
+```
+
+Remove `st`, `nd`, `rd`, or `th` only when it immediately follows the day number. Preserve the
+year and AM/PM marker.
+
+## Structured reset fields
+
+Codex session events also expose Unix-second timestamps that need no text parsing:
+
+```text
+payload.rate_limits.primary.resets_at
+payload.rate_limits.secondary.resets_at
+```
+
+The corresponding exhaustion values are:
+
+```text
+payload.rate_limits.primary.used_percent
+payload.rate_limits.secondary.used_percent
+```
+
+When an exhausted structured window is present, use its `resets_at`. If multiple windows are at
+100%, use the latest reset. Use the captured `or try again at` time when structured data is absent.
+
+## Required safety checks
+
+- Match against the live PTY tail, not terminal-history files or arbitrary scrollback.
+- Reconfirm the complete usage-limit match immediately before resuming.
+- Deduplicate repeated matches with the same PTY and parsed reset timestamp.
+- The text timestamp has no timezone. For SSH sessions, do not silently interpret it in the Orca
+  client's timezone; prefer Unix `resets_at`, or retain the runtime host's timezone context.
+- Add the auto-resume grace period only after parsing the provider's reset time.
+
+## Fixtures
+
+```ts
+export const CODEX_USAGE_LIMIT_FIXTURES = [
+  {
+    text: "You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at Apr 23rd, 2026 10:42 AM.",
+    resetText: 'Apr 23rd, 2026 10:42 AM',
+  },
+  {
+    text: "You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at May 14th, 2026 2:32 PM.",
+    resetText: 'May 14th, 2026 2:32 PM',
+  },
+] as const
+```

--- a/src/main/agent-auto-resume-notifications.ts
+++ b/src/main/agent-auto-resume-notifications.ts
@@ -1,0 +1,80 @@
+import { Notification } from 'electron'
+import type { NotificationSettings } from '../shared/types'
+import type { AgentAutoResumeNotification } from './agent-auto-resume-service'
+
+// Why: main-originated (not renderer-dispatched) notifications, so they build
+// their own Notification the way triggerStartupNotificationRegistration does,
+// while still honoring the user's global notifications-enabled switch.
+export type AgentAutoResumeNotifierDeps = {
+  getNotificationSettings: () => NotificationSettings
+  /** Bring Orca forward and focus the affected worktree/pane on click. */
+  focus?: (worktreeId: string, paneKey: string | null) => void
+  formatTime?: (epochMs: number) => string
+  logger?: Pick<Console, 'warn'>
+}
+
+function defaultFormatTime(epochMs: number): string {
+  try {
+    return new Date(epochMs).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  } catch {
+    return 'the reset time'
+  }
+}
+
+function buildContent(
+  notification: AgentAutoResumeNotification,
+  formatTime: (epochMs: number) => string
+): { title: string; body: string } {
+  const when =
+    typeof notification.resumesAt === 'number' && Number.isFinite(notification.resumesAt)
+      ? formatTime(notification.resumesAt)
+      : null
+  if (notification.kind === 'detected') {
+    return {
+      title: 'Agent rate-limited',
+      body: when
+        ? `Orca will auto-resume it at ${when}.`
+        : 'Orca will auto-resume it when the limit resets.'
+    }
+  }
+  if (notification.kind === 'dead-pty') {
+    return {
+      title: 'Rate-limited agent exited',
+      body: 'The agent process exited while rate-limited. Reopen its worktree to resume the session.'
+    }
+  }
+  return {
+    title: 'Auto-resume failed',
+    body: "Orca couldn't resume the rate-limited agent. Resume it manually."
+  }
+}
+
+/**
+ * Deliver a native notification for an auto-resume lifecycle event, gated by
+ * the global notifications switch. Detection and give-up always notify; a
+ * quiet successful resume is intentionally not surfaced here (the CLI shows its
+ * own countdown), matching the existing notification-granularity patterns.
+ */
+export function deliverAgentAutoResumeNotification(
+  notification: AgentAutoResumeNotification,
+  deps: AgentAutoResumeNotifierDeps
+): void {
+  if (deps.getNotificationSettings().enabled !== true) {
+    return
+  }
+  if (!Notification.isSupported()) {
+    return
+  }
+  const { title, body } = buildContent(notification, deps.formatTime ?? defaultFormatTime)
+  try {
+    const native = new Notification({ title, body })
+    if (notification.worktreeId && deps.focus) {
+      const worktreeId = notification.worktreeId
+      const paneKey = notification.paneKey
+      native.on('click', () => deps.focus?.(worktreeId, paneKey))
+    }
+    native.show()
+  } catch (error) {
+    deps.logger?.warn('[auto-resume] notification failed', error)
+  }
+}

--- a/src/main/agent-auto-resume-service.test.ts
+++ b/src/main/agent-auto-resume-service.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AgentAutoResumeService,
+  BANNER_RESET_GRACE_MS,
+  MAX_RESUME_ATTEMPTS,
+  POST_SEND_VERIFY_MS,
+  type AgentAutoResumeNotification
+} from './agent-auto-resume-service'
+import type { UsageLimitStallEvent, UsageLimitStallSnapshot } from './runtime/orca-runtime'
+import type { UsageLimitStallReason } from '../shared/agent-auto-resume-types'
+
+const MENU_GRACE_MS = 5 * 60 * 1000
+const PTY = 'pty-1'
+const HANDLE = 'handle-1'
+
+function detectedEvent(
+  overrides: Partial<Extract<UsageLimitStallEvent, { kind: 'detected' }>> = {}
+): UsageLimitStallEvent {
+  return {
+    kind: 'detected',
+    ptyId: PTY,
+    handle: HANDLE,
+    worktreeId: 'repo::wt',
+    paneKey: 'tab:leaf',
+    provider: 'claude',
+    reason: 'usage-limit-banner',
+    resetsAt: null,
+    detectedAt: Date.now(),
+    ...overrides
+  }
+}
+
+type StallState = { present: boolean; agentWorking: boolean; reason: UsageLimitStallReason }
+
+function makeHarness(providerResetAt: number | null = null) {
+  const sendKeys = vi.fn<
+    (handle: string, action: { text?: string; enter?: boolean }) => Promise<void>
+  >(() => Promise.resolve())
+  const notify = vi.fn<(n: AgentAutoResumeNotification) => void>()
+  const snapshots: number[] = []
+  const stall: StallState = { present: true, agentWorking: false, reason: 'usage-limit-banner' }
+  const verifyStall = vi.fn<(ptyId: string) => UsageLimitStallSnapshot | null>((ptyId) => ({
+    ptyId,
+    handle: HANDLE,
+    worktreeId: 'repo::wt',
+    paneKey: 'tab:leaf',
+    provider: 'claude',
+    reason: stall.reason,
+    resetsAt: null,
+    detectedAt: 0,
+    present: stall.present,
+    agentWorking: stall.agentWorking
+  }))
+  const service = new AgentAutoResumeService({
+    verifyStall,
+    sendKeys,
+    getMenuGraceMs: () => MENU_GRACE_MS,
+    getProviderResetAt: () => providerResetAt,
+    notify,
+    onSnapshot: (snapshot) => snapshots.push(snapshot.entries.length)
+  })
+  service.setEnabled(true)
+  return { service, sendKeys, notify, verifyStall, stall, snapshots }
+}
+
+describe('AgentAutoResumeService', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('notifies on detection and tracks the stall', () => {
+    const { service, notify, snapshots } = makeHarness()
+    service.handleEvent(detectedEvent())
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'detected' }))
+    expect(snapshots.at(-1)).toBe(1)
+    expect(service.getSnapshot().entries[0]).toMatchObject({
+      ptyId: PTY,
+      reason: 'usage-limit-banner'
+    })
+  })
+
+  it('presses Enter on the wait-for-reset menu only after the idle grace', async () => {
+    const { service, sendKeys, stall } = makeHarness()
+    stall.reason = 'usage-limit-menu'
+    service.handleEvent(detectedEvent({ reason: 'usage-limit-menu' }))
+
+    await vi.advanceTimersByTimeAsync(MENU_GRACE_MS - 1000)
+    expect(sendKeys).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(sendKeys).toHaveBeenCalledExactlyOnceWith(HANDLE, { enter: true })
+    expect(service.getSnapshot().entries).toHaveLength(0)
+  })
+
+  it('does not poke the menu if a human already resumed the agent (working)', async () => {
+    const { service, sendKeys, stall } = makeHarness()
+    stall.reason = 'usage-limit-menu'
+    service.handleEvent(detectedEvent({ reason: 'usage-limit-menu' }))
+    stall.agentWorking = true
+
+    await vi.advanceTimersByTimeAsync(MENU_GRACE_MS)
+    expect(sendKeys).not.toHaveBeenCalled()
+    expect(service.getSnapshot().entries).toHaveLength(0)
+  })
+
+  it('resends "continue" for a banner after resetsAt + grace', async () => {
+    const { service, sendKeys, stall } = makeHarness()
+    stall.reason = 'usage-limit-banner'
+    const resetsAt = Date.now() + 60_000
+    service.handleEvent(detectedEvent({ resetsAt }))
+
+    await vi.advanceTimersByTimeAsync(60_000 + BANNER_RESET_GRACE_MS - 1000)
+    expect(sendKeys).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(sendKeys).toHaveBeenCalledWith(HANDLE, { text: 'continue', enter: true })
+  })
+
+  it('uses the provider resetsAt when the banner carries none', async () => {
+    const providerResetAt = Date.now() + 120_000
+    const { service, sendKeys } = makeHarness(providerResetAt)
+    service.handleEvent(detectedEvent({ resetsAt: null }))
+
+    await vi.advanceTimersByTimeAsync(120_000 + BANNER_RESET_GRACE_MS - 500)
+    expect(sendKeys).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(500)
+    expect(sendKeys).toHaveBeenCalledOnce()
+  })
+
+  it('does nothing when the banner cleared before the timer fired', async () => {
+    const { service, sendKeys, notify, stall } = makeHarness()
+    service.handleEvent(detectedEvent({ resetsAt: Date.now() + 1000 }))
+    stall.present = false
+
+    await vi.advanceTimersByTimeAsync(1000 + BANNER_RESET_GRACE_MS)
+    expect(sendKeys).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalledWith(expect.objectContaining({ kind: 'failed' }))
+    expect(service.getSnapshot().entries).toHaveLength(0)
+  })
+
+  it('dedups repeated detections of the same stall (arms one timer)', async () => {
+    const { service, sendKeys } = makeHarness()
+    const resetsAt = Date.now() + 1000
+    service.handleEvent(detectedEvent({ resetsAt }))
+    service.handleEvent(detectedEvent({ resetsAt }))
+    service.handleEvent(detectedEvent({ resetsAt }))
+    expect(service.getSnapshot().entries).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(1000 + BANNER_RESET_GRACE_MS)
+    expect(sendKeys).toHaveBeenCalledOnce()
+  })
+
+  it('re-arms when the reason changes (banner → menu)', async () => {
+    const { service, sendKeys, stall } = makeHarness()
+    service.handleEvent(
+      detectedEvent({ reason: 'usage-limit-banner', resetsAt: Date.now() + 1_000_000 })
+    )
+    stall.reason = 'usage-limit-menu'
+    service.handleEvent(detectedEvent({ reason: 'usage-limit-menu' }))
+    expect(service.getSnapshot().entries[0]).toMatchObject({ reason: 'usage-limit-menu' })
+
+    await vi.advanceTimersByTimeAsync(MENU_GRACE_MS)
+    expect(sendKeys).toHaveBeenCalledExactlyOnceWith(HANDLE, { enter: true })
+  })
+
+  it('retries up to the cap then gives up and notifies', async () => {
+    const { service, sendKeys, notify } = makeHarness()
+    service.handleEvent(detectedEvent({ resetsAt: Date.now() + 1000 }))
+
+    // First attempt.
+    await vi.advanceTimersByTimeAsync(1000 + BANNER_RESET_GRACE_MS)
+    // Post-send verify still stalled → second attempt.
+    await vi.advanceTimersByTimeAsync(POST_SEND_VERIFY_MS)
+    // Post-send verify still stalled → give up.
+    await vi.advanceTimersByTimeAsync(POST_SEND_VERIFY_MS)
+
+    expect(sendKeys).toHaveBeenCalledTimes(MAX_RESUME_ATTEMPTS)
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'failed' }))
+    expect(service.getSnapshot().entries).toHaveLength(0)
+  })
+
+  it('stops tracking and clears the timer when the agent resumes (cleared)', async () => {
+    const { service, sendKeys } = makeHarness()
+    service.handleEvent(detectedEvent({ resetsAt: Date.now() + 1000 }))
+    service.handleEvent({ kind: 'cleared', ptyId: PTY })
+    expect(service.getSnapshot().entries).toHaveLength(0)
+
+    await vi.advanceTimersByTimeAsync(1000 + BANNER_RESET_GRACE_MS)
+    expect(sendKeys).not.toHaveBeenCalled()
+  })
+
+  it('notifies and stops tracking when the PTY exits while limited', () => {
+    const { service, notify, sendKeys } = makeHarness()
+    service.handleEvent(detectedEvent())
+    service.handleEvent({
+      kind: 'exited',
+      ptyId: PTY,
+      worktreeId: 'repo::wt',
+      paneKey: 'tab:leaf',
+      exitCode: 1
+    })
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'dead-pty' }))
+    expect(service.getSnapshot().entries).toHaveLength(0)
+    expect(sendKeys).not.toHaveBeenCalled()
+  })
+
+  it('ignores events while disabled and drops pending timers on opt-out', async () => {
+    const { service, sendKeys } = makeHarness()
+    service.handleEvent(detectedEvent({ resetsAt: Date.now() + 1000 }))
+    service.setEnabled(false)
+    expect(service.getSnapshot().entries).toHaveLength(0)
+
+    await vi.advanceTimersByTimeAsync(1000 + BANNER_RESET_GRACE_MS)
+    expect(sendKeys).not.toHaveBeenCalled()
+
+    // A detection while disabled is a no-op.
+    service.handleEvent(detectedEvent())
+    expect(service.getSnapshot().entries).toHaveLength(0)
+  })
+})

--- a/src/main/agent-auto-resume-service.ts
+++ b/src/main/agent-auto-resume-service.ts
@@ -1,0 +1,342 @@
+import type {
+  AgentAutoResumeEntry,
+  AgentAutoResumePhase,
+  AgentAutoResumeSnapshot,
+  UsageLimitProvider,
+  UsageLimitStallReason
+} from '../shared/agent-auto-resume-types'
+import type { UsageLimitStallEvent, UsageLimitStallSnapshot } from './runtime/orca-runtime'
+
+// Why: after a banner's reset time, give the provider a short cushion before
+// resending so the agent CLI has actually cleared the limit server-side.
+export const BANNER_RESET_GRACE_MS = 90 * 1000
+// Why: some banners print no parseable reset (and the provider quota probe may
+// be unavailable). Retry conservatively rather than hammering the CLI.
+export const BANNER_UNKNOWN_RESET_DELAY_MS = 5 * 60 * 1000
+// Why: after resending, wait before checking whether the agent recovered; a
+// real resume flips the title to "working" within this window.
+export const POST_SEND_VERIFY_MS = 45 * 1000
+// Product rule: cap attempts and always notify on give-up.
+export const MAX_RESUME_ATTEMPTS = 2
+
+export type AgentAutoResumeNotificationKind = 'detected' | 'failed' | 'dead-pty'
+
+export type AgentAutoResumeNotification = {
+  kind: AgentAutoResumeNotificationKind
+  worktreeId: string | null
+  paneKey: string | null
+  provider: UsageLimitProvider | null
+  reason: UsageLimitStallReason
+  resumesAt: number | null
+}
+
+type SendKeysAction = { text?: string; enter?: boolean }
+
+export type AgentAutoResumeServiceOptions = {
+  /** Re-verify a stall against the live PTY tail immediately before acting. */
+  verifyStall: (ptyId: string) => UsageLimitStallSnapshot | null
+  /** Write keystrokes to the agent terminal identified by its runtime handle. */
+  sendKeys: (handle: string, action: SendKeysAction) => Promise<void>
+  /** The user-configured agent idle timeout, reused as the menu grace period. */
+  getMenuGraceMs: () => number
+  /** resetsAt from RateLimitService for the provider, if known. */
+  getProviderResetAt?: (provider: UsageLimitProvider | null) => number | null
+  /** Fire a native/mobile notification (already gated by NotificationSettings). */
+  notify?: (notification: AgentAutoResumeNotification) => void
+  /** Push the current tracked-entry snapshot to the renderer. */
+  onSnapshot?: (snapshot: AgentAutoResumeSnapshot) => void
+  now?: () => number
+  logger?: Pick<Console, 'debug' | 'warn'>
+}
+
+type TrackedStall = {
+  ptyId: string
+  handle: string | null
+  worktreeId: string | null
+  paneKey: string | null
+  provider: UsageLimitProvider | null
+  reason: UsageLimitStallReason
+  resetsAt: number | null
+  detectedAt: number
+  phase: AgentAutoResumePhase
+  attempts: number
+  resumesAt: number | null
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+/**
+ * Watches for usage-limit stall events (from the runtime's live PTY scan) and,
+ * when the opt-in setting is on, auto-resumes the agent:
+ *
+ *  - `usage-limit-menu`: wait the user's configured idle timeout so a human can
+ *    intervene, then — if the menu is still live — press Enter to select "Stop
+ *    and wait for limit to reset". The CLI then owns its own countdown/resume.
+ *  - `usage-limit-banner`: arm a timer for max(banner resetsAt, provider
+ *    resetsAt) + grace, re-verify the banner is still on screen, then resend
+ *    "continue". Retry once more on failure, then give up and notify.
+ *  - PTY exit while limited: notify (the dead-PTY path is handed to the
+ *    renderer's sleeping-agent resume flow on worktree activation).
+ *
+ * Every action is gated on a fresh re-verification against the live tail — the
+ * service never acts on stale content and never pokes a working agent.
+ */
+export class AgentAutoResumeService {
+  private enabled = false
+  private readonly tracked = new Map<string, TrackedStall>()
+  private readonly opts: AgentAutoResumeServiceOptions
+  private readonly now: () => number
+  private readonly logger: Pick<Console, 'debug' | 'warn'>
+
+  constructor(options: AgentAutoResumeServiceOptions) {
+    this.opts = options
+    this.now = options.now ?? Date.now
+    this.logger = options.logger ?? console
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (this.enabled === enabled) {
+      return
+    }
+    this.enabled = enabled
+    if (!enabled) {
+      // Why: disabling must immediately drop every pending timer so a
+      // mid-flight grace/reset wait can't fire keystrokes after opt-out.
+      for (const stall of this.tracked.values()) {
+        this.clearTimer(stall)
+      }
+      this.tracked.clear()
+    }
+    this.emitSnapshot()
+  }
+
+  handleEvent(event: UsageLimitStallEvent): void {
+    if (event.kind === 'detected') {
+      this.onDetected(event)
+      return
+    }
+    if (event.kind === 'cleared') {
+      this.onCleared(event.ptyId)
+      return
+    }
+    this.onExited(event)
+  }
+
+  dispose(): void {
+    for (const stall of this.tracked.values()) {
+      this.clearTimer(stall)
+    }
+    this.tracked.clear()
+  }
+
+  private onDetected(event: Extract<UsageLimitStallEvent, { kind: 'detected' }>): void {
+    if (!this.enabled) {
+      return
+    }
+    const existing = this.tracked.get(event.ptyId)
+    // Dedup: an active wait for the same stall must not re-arm on redraw churn.
+    // Only a changed reason (or a stall we already resolved) re-arms.
+    if (
+      existing &&
+      (existing.phase === 'waiting' || existing.phase === 'acting') &&
+      existing.reason === event.reason
+    ) {
+      existing.handle = event.handle ?? existing.handle
+      return
+    }
+    if (existing) {
+      this.clearTimer(existing)
+    }
+    const stall: TrackedStall = {
+      ptyId: event.ptyId,
+      handle: event.handle,
+      worktreeId: event.worktreeId,
+      paneKey: event.paneKey,
+      provider: event.provider,
+      reason: event.reason,
+      resetsAt: event.resetsAt,
+      detectedAt: event.detectedAt,
+      phase: 'waiting',
+      attempts: 0,
+      resumesAt: null,
+      timer: null
+    }
+    this.tracked.set(event.ptyId, stall)
+    this.armActionTimer(stall)
+    this.opts.notify?.({
+      kind: 'detected',
+      worktreeId: stall.worktreeId,
+      paneKey: stall.paneKey,
+      provider: stall.provider,
+      reason: stall.reason,
+      resumesAt: stall.resumesAt
+    })
+    this.emitSnapshot()
+  }
+
+  private onCleared(ptyId: string): void {
+    const stall = this.tracked.get(ptyId)
+    if (!stall) {
+      return
+    }
+    this.clearTimer(stall)
+    this.tracked.delete(ptyId)
+    this.emitSnapshot()
+  }
+
+  private onExited(event: Extract<UsageLimitStallEvent, { kind: 'exited' }>): void {
+    const stall = this.tracked.get(event.ptyId)
+    if (!stall) {
+      return
+    }
+    this.clearTimer(stall)
+    this.tracked.delete(event.ptyId)
+    this.opts.notify?.({
+      kind: 'dead-pty',
+      worktreeId: event.worktreeId,
+      paneKey: event.paneKey,
+      provider: stall.provider,
+      reason: stall.reason,
+      resumesAt: null
+    })
+    this.emitSnapshot()
+  }
+
+  private armActionTimer(stall: TrackedStall): void {
+    const now = this.now()
+    const resumesAt =
+      stall.reason === 'usage-limit-menu'
+        ? now + Math.max(0, this.opts.getMenuGraceMs())
+        : this.computeBannerResumeAt(stall, now)
+    stall.resumesAt = resumesAt
+    stall.phase = 'waiting'
+    const delay = Math.max(0, resumesAt - now)
+    stall.timer = this.schedule(() => {
+      void this.onActionDue(stall.ptyId)
+    }, delay)
+  }
+
+  private computeBannerResumeAt(stall: TrackedStall, now: number): number {
+    const providerResetAt = this.opts.getProviderResetAt?.(stall.provider) ?? null
+    const target = Math.max(stall.resetsAt ?? 0, providerResetAt ?? 0)
+    if (target <= 0) {
+      return now + BANNER_UNKNOWN_RESET_DELAY_MS
+    }
+    // A reset already in the past means the limit should have cleared — act
+    // after the grace cushion measured from now, not from the stale timestamp.
+    return Math.max(target, now) + BANNER_RESET_GRACE_MS
+  }
+
+  private async onActionDue(ptyId: string): Promise<void> {
+    const stall = this.tracked.get(ptyId)
+    if (!stall) {
+      return
+    }
+    stall.timer = null
+    stall.phase = 'acting'
+    const snapshot = this.opts.verifyStall(ptyId)
+    // Product rule #6: never act on stale data. If the banner/menu is gone or
+    // the agent is already working, it recovered on its own — stop quietly.
+    if (!snapshot || !snapshot.present || snapshot.agentWorking) {
+      this.tracked.delete(ptyId)
+      this.emitSnapshot()
+      return
+    }
+    const handle = snapshot.handle ?? stall.handle
+    if (!handle) {
+      this.giveUp(stall, 'no-handle')
+      return
+    }
+    stall.attempts += 1
+    try {
+      if (stall.reason === 'usage-limit-menu') {
+        // Enter selects the highlighted default option 1 ("Stop and wait for
+        // limit to reset"); the CLI then runs its own countdown + resume.
+        await this.opts.sendKeys(handle, { enter: true })
+        this.tracked.delete(ptyId)
+        this.emitSnapshot()
+        return
+      }
+      await this.opts.sendKeys(handle, { text: 'continue', enter: true })
+    } catch (error) {
+      this.logger.warn('[auto-resume] sendKeys failed', { ptyId, error })
+      this.giveUp(stall, 'send-failed')
+      return
+    }
+    // Banner: confirm the resend actually resumed the agent.
+    stall.resumesAt = this.now() + POST_SEND_VERIFY_MS
+    stall.phase = 'acting'
+    stall.timer = this.schedule(() => {
+      void this.onPostSendVerify(ptyId)
+    }, POST_SEND_VERIFY_MS)
+    this.emitSnapshot()
+  }
+
+  private async onPostSendVerify(ptyId: string): Promise<void> {
+    const stall = this.tracked.get(ptyId)
+    if (!stall) {
+      return
+    }
+    stall.timer = null
+    const snapshot = this.opts.verifyStall(ptyId)
+    if (!snapshot || !snapshot.present || snapshot.agentWorking) {
+      // Recovered — the resend worked (or the agent moved on).
+      this.tracked.delete(ptyId)
+      this.emitSnapshot()
+      return
+    }
+    if (stall.attempts >= MAX_RESUME_ATTEMPTS) {
+      this.giveUp(stall, 'max-attempts')
+      return
+    }
+    // Still stalled and attempts remain — resend once more immediately.
+    void this.onActionDue(ptyId)
+  }
+
+  private giveUp(stall: TrackedStall, reason: string): void {
+    this.logger.debug('[auto-resume] giving up', { ptyId: stall.ptyId, reason })
+    this.clearTimer(stall)
+    this.tracked.delete(stall.ptyId)
+    this.opts.notify?.({
+      kind: 'failed',
+      worktreeId: stall.worktreeId,
+      paneKey: stall.paneKey,
+      provider: stall.provider,
+      reason: stall.reason,
+      resumesAt: null
+    })
+    this.emitSnapshot()
+  }
+
+  private schedule(fn: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+    const timer = setTimeout(fn, delayMs)
+    if (typeof timer.unref === 'function') {
+      timer.unref()
+    }
+    return timer
+  }
+
+  private clearTimer(stall: TrackedStall): void {
+    if (stall.timer) {
+      clearTimeout(stall.timer)
+      stall.timer = null
+    }
+  }
+
+  private emitSnapshot(): void {
+    this.opts.onSnapshot?.(this.getSnapshot())
+  }
+
+  getSnapshot(): AgentAutoResumeSnapshot {
+    const entries: AgentAutoResumeEntry[] = [...this.tracked.values()].map((stall) => ({
+      ptyId: stall.ptyId,
+      worktreeId: stall.worktreeId,
+      paneKey: stall.paneKey,
+      provider: stall.provider,
+      reason: stall.reason,
+      resumesAt: stall.resumesAt,
+      detectedAt: stall.detectedAt,
+      phase: stall.phase
+    }))
+    return { enabled: this.enabled, entries }
+  }
+}

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -132,6 +132,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
     keepComputerAwakeWhileAgentsRun: false,
+    autoResumeRateLimitedAgents: false,
     confirmClosePinnedTab: true,
     terminalMacOptionAsAlt: 'false',
     terminalMacOptionAsAltMigrated: true,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -137,6 +137,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
     keepComputerAwakeWhileAgentsRun: false,
+    autoResumeRateLimitedAgents: false,
     confirmClosePinnedTab: true,
     terminalMacOptionAsAlt: 'false',
     terminalMacOptionAsAltMigrated: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -157,6 +157,12 @@ import { AutomationService } from './automations/service'
 import { createHeadlessAutomationOutputSnapshotBuffer } from './automations/headless-dispatch'
 import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headless-workspace-create'
 import { AgentAwakeService } from './agent-awake-service'
+import { AgentAutoResumeService } from './agent-auto-resume-service'
+import { deliverAgentAutoResumeNotification } from './agent-auto-resume-notifications'
+import {
+  AGENT_AUTO_RESUME_UPDATE_CHANNEL,
+  type UsageLimitProvider
+} from '../shared/agent-auto-resume-types'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import {
   getCrashBreadcrumbSnapshot,
@@ -217,6 +223,8 @@ let headlessBrowserDisplayAvailable = false
 
 let starNag: StarNagService | null = null
 let agentAwakeService: AgentAwakeService | null = null
+let agentAutoResumeService: AgentAutoResumeService | null = null
+let unsubscribeUsageLimitStall: (() => void) | null = null
 let crashReports: CrashReportStore | null = null
 let unsubscribeAgentAwakeStatusChanges: (() => void) | null = null
 let unsubscribeSystemResumeBroadcast: (() => void) | null = null
@@ -751,6 +759,84 @@ function showMainWindowFromTray(): void {
   }
 }
 
+// Why: the wait-for-reset menu grace reuses the user's configured agent idle
+// timeout so a human has the same window to intervene they already expect.
+// Clamped inline (the renderer's planner constants can't be imported into main).
+const DEFAULT_MENU_GRACE_MS = 30 * 60 * 1000
+const MIN_MENU_GRACE_MS = 60 * 1000
+const MAX_MENU_GRACE_MS = 24 * 60 * 60 * 1000
+
+function resolveMenuGraceMs(value: unknown): number {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= MIN_MENU_GRACE_MS &&
+    value <= MAX_MENU_GRACE_MS
+    ? value
+    : DEFAULT_MENU_GRACE_MS
+}
+
+function createAgentAutoResumeService(
+  runtimeService: OrcaRuntimeService,
+  activeStore: Store,
+  rateLimitService: RateLimitService | null
+): AgentAutoResumeService {
+  const service = new AgentAutoResumeService({
+    verifyStall: (ptyId) => runtimeService.getUsageLimitStallSnapshot(ptyId),
+    sendKeys: async (handle, action) => {
+      await runtimeService.sendTerminal(handle, action)
+    },
+    getMenuGraceMs: () => resolveMenuGraceMs(activeStore.getSettings().agentHibernationIdleMs),
+    getProviderResetAt: (provider) => getProviderResetAt(rateLimitService, provider),
+    notify: (notification) =>
+      deliverAgentAutoResumeNotification(notification, {
+        getNotificationSettings: () => activeStore.getSettings().notifications,
+        focus: (worktreeId) => focusWorktreeFromMain(worktreeId)
+      }),
+    onSnapshot: (snapshot) =>
+      mainWindow?.webContents.send(AGENT_AUTO_RESUME_UPDATE_CHANNEL, snapshot)
+  })
+  service.setEnabled(activeStore.getSettings().autoResumeRateLimitedAgents)
+  unsubscribeUsageLimitStall = runtimeService.subscribeUsageLimitStall((event) =>
+    service.handleEvent(event)
+  )
+  return service
+}
+
+function getProviderResetAt(
+  rateLimitService: RateLimitService | null,
+  provider: UsageLimitProvider | null
+): number | null {
+  if (!rateLimitService || !provider) {
+    return null
+  }
+  const state = rateLimitService.getState()
+  const windows = provider === 'claude' ? state.claude : state.codex
+  // The 5-hour session window is the one that stalls active agents; fall back
+  // to the weekly window when the session window carries no reset.
+  return windows?.session?.resetsAt ?? windows?.weekly?.resetsAt ?? null
+}
+
+function focusWorktreeFromMain(worktreeId: string): void {
+  if (!worktreeId.includes('::')) {
+    return
+  }
+  const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+  if (!win) {
+    return
+  }
+  if (process.platform === 'darwin') {
+    app.focus({ steal: true })
+  }
+  if (win.isMinimized()) {
+    win.restore()
+  }
+  win.focus()
+  win.webContents.send('ui:activateWorktree', {
+    repoId: getRepoIdFromWorktreeId(worktreeId),
+    worktreeId
+  })
+}
+
 function openMainWindow(): BrowserWindow {
   logStartupMilestone('open-main-window-start')
   if (!store) {
@@ -956,7 +1042,8 @@ function openMainWindow(): BrowserWindow {
         isQuitting = true
         await preserveAgentAuthBeforeRestart({ codexRuntimeHome, claudeRuntimeAuth, store })
       }
-    }
+    },
+    agentAutoResumeService ?? undefined
   )
   automations.setWebContents(window.webContents)
   automations.start()
@@ -1812,6 +1899,7 @@ app.whenReady().then(async () => {
       isAgentStatusHooksEnabled(store?.getSettings()) ? agentHookServer.buildPtyEnv() : {}
   })
   runtime = runtimeService
+  agentAutoResumeService = createAgentAutoResumeService(runtimeService, store, rateLimits)
   automations = new AutomationService(store, {
     claudeUsage,
     codexUsage,
@@ -2224,6 +2312,10 @@ app.on('before-quit', () => {
   unsubscribeAgentAwakeStatusChanges = null
   agentAwakeService?.dispose()
   agentAwakeService = null
+  unsubscribeUsageLimitStall?.()
+  unsubscribeUsageLimitStall = null
+  agentAutoResumeService?.dispose()
+  agentAutoResumeService = null
   // Why: PTY cleanup is deferred to will-quit so the renderer has a chance to
   // capture terminal scrollback buffers before PTY exit events race in and
   // unmount TerminalPane components (removing their capture callbacks).

--- a/src/main/ipc/agent-auto-resume.ts
+++ b/src/main/ipc/agent-auto-resume.ts
@@ -1,0 +1,17 @@
+import { ipcMain } from 'electron'
+import type { AgentAutoResumeService } from '../agent-auto-resume-service'
+import type { AgentAutoResumeSnapshot } from '../../shared/agent-auto-resume-types'
+
+const EMPTY_SNAPSHOT: AgentAutoResumeSnapshot = { enabled: false, entries: [] }
+
+// Why: the service only pushes snapshots on state changes, so a renderer that
+// mounts after a stall was already detected would show stale UI until the next
+// transition. This one-shot getter lets the renderer hydrate current state on
+// startup, mirroring rateLimits.get().
+export function registerAgentAutoResumeHandlers(service?: AgentAutoResumeService): void {
+  ipcMain.removeHandler('agentAutoResume:get')
+  ipcMain.handle(
+    'agentAutoResume:get',
+    (): AgentAutoResumeSnapshot => service?.getSnapshot() ?? EMPTY_SNAPSHOT
+  )
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -484,7 +484,7 @@ describe('registerCoreHandlers', () => {
     expect(registerNotificationHandlersMock).toHaveBeenCalledWith(store, runtime)
     expect(registerDeveloperPermissionHandlersMock).toHaveBeenCalled()
     expect(registerComputerUsePermissionHandlersMock).toHaveBeenCalled()
-    expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store, agentAwakeService)
+    expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store, agentAwakeService, undefined)
     expect(registerSkillsHandlersMock).toHaveBeenCalledWith(store)
     expect(registerWorkspaceSpaceHandlersMock).toHaveBeenCalledWith(store)
     expect(registerWorkspacePortHandlersMock).toHaveBeenCalledWith(store)

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -18,6 +18,7 @@ const {
   registerDeveloperPermissionHandlersMock,
   registerComputerUsePermissionHandlersMock,
   registerSettingsHandlersMock,
+  registerAgentAutoResumeHandlersMock,
   registerKeybindingHandlersMock,
   registerTelemetryHandlersMock,
   registerDiagnosticsHandlersMock,
@@ -79,6 +80,7 @@ const {
   registerDeveloperPermissionHandlersMock: vi.fn(),
   registerComputerUsePermissionHandlersMock: vi.fn(),
   registerSettingsHandlersMock: vi.fn(),
+  registerAgentAutoResumeHandlersMock: vi.fn(),
   registerKeybindingHandlersMock: vi.fn(),
   registerTelemetryHandlersMock: vi.fn(),
   registerDiagnosticsHandlersMock: vi.fn(),
@@ -204,6 +206,10 @@ vi.mock('./computer-use-permissions', () => ({
 
 vi.mock('./settings', () => ({
   registerSettingsHandlers: registerSettingsHandlersMock
+}))
+
+vi.mock('./agent-auto-resume', () => ({
+  registerAgentAutoResumeHandlers: registerAgentAutoResumeHandlersMock
 }))
 
 vi.mock('./skills', () => ({

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -35,6 +35,7 @@ import { registerComputerUsePermissionHandlers } from './computer-use-permission
 import { setTrustedBrowserRendererWebContentsId, setAgentBrowserBridgeRef } from './browser'
 import { registerSessionHandlers } from './session'
 import { registerSettingsHandlers } from './settings'
+import { registerAgentAutoResumeHandlers } from './agent-auto-resume'
 import { registerDiagnosticsHandlers } from './diagnostics'
 import { registerSkillsHandlers } from './skills'
 import { registerWorkspaceSpaceHandlers } from './workspace-space'
@@ -153,6 +154,7 @@ export function registerCoreHandlers(
   registerDiagnosticsHandlers()
   registerComputerUsePermissionHandlers()
   registerSettingsHandlers(store, agentAwakeService, agentAutoResumeService)
+  registerAgentAutoResumeHandlers(agentAutoResumeService)
   registerSkillsHandlers(store)
   if (automations) {
     registerAutomationHandlers(store, automations)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -70,6 +70,7 @@ import type { CodexAccountService } from '../codex-accounts/service'
 import type { ClaudeAccountService } from '../claude-accounts/service'
 import type { AutomationService } from '../automations/service'
 import type { AgentAwakeService } from '../agent-awake-service'
+import type { AgentAutoResumeService } from '../agent-auto-resume-service'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
 import type { KeybindingService } from '../keybindings/keybinding-service'
 import {
@@ -100,7 +101,8 @@ export function registerCoreHandlers(
   agentAwakeService?: AgentAwakeService,
   crashReports?: CrashReportStore,
   keybindings?: KeybindingService,
-  lifecycleOptions: CoreHandlerLifecycleOptions = {}
+  lifecycleOptions: CoreHandlerLifecycleOptions = {},
+  agentAutoResumeService?: AgentAutoResumeService
 ): void {
   // Why: on macOS the app can stay alive after all windows close, then
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
@@ -150,7 +152,7 @@ export function registerCoreHandlers(
   // not load-bearing; both register independent ipcMain channels.
   registerDiagnosticsHandlers()
   registerComputerUsePermissionHandlers()
-  registerSettingsHandlers(store, agentAwakeService)
+  registerSettingsHandlers(store, agentAwakeService, agentAutoResumeService)
   registerSkillsHandlers(store)
   if (automations) {
     registerAutomationHandlers(store, automations)

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -9,6 +9,7 @@ import { rebuildAppMenu } from '../menu/register-app-menu'
 import { track } from '../telemetry/client'
 import { SETTINGS_CHANGED_WHITELIST, type SettingsChangedKey } from '../../shared/telemetry-events'
 import type { AgentAwakeService } from '../agent-awake-service'
+import type { AgentAutoResumeService } from '../agent-auto-resume-service'
 import { sanitizeFloatingWorkspaceDirectorySetting } from './floating-workspace-directory'
 import { applyAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
 import { applyElectronProxySettings } from '../network/proxy-settings'
@@ -51,7 +52,8 @@ const APPEARANCE_MENU_KEYS: readonly (keyof GlobalSettings)[] = [
 
 export function registerSettingsHandlers(
   store: Store,
-  agentAwakeService?: AgentAwakeService
+  agentAwakeService?: AgentAwakeService,
+  agentAutoResumeService?: AgentAutoResumeService
 ): void {
   store.onSettingsChanged((updates, _settings, originWebContentsId) => {
     for (const window of BrowserWindow.getAllWindows()) {
@@ -116,6 +118,9 @@ export function registerSettingsHandlers(
     })
     if ('keepComputerAwakeWhileAgentsRun' in sanitizedArgs) {
       agentAwakeService?.setEnabled(result.keepComputerAwakeWhileAgentsRun)
+    }
+    if ('autoResumeRateLimitedAgents' in sanitizedArgs) {
+      agentAutoResumeService?.setEnabled(result.autoResumeRateLimitedAgents)
     }
     if (
       'agentStatusHooksEnabled' in sanitizedArgs &&

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -326,6 +326,15 @@ import { serveSimStateWatcher } from '../emulator/serve-sim-state-watcher'
 import type { EmulatorBridge } from '../emulator/emulator-bridge'
 import { RuntimeFileCommands } from './orca-runtime-files'
 import { RuntimeGitCommands } from './orca-runtime-git'
+import {
+  detectUsageLimitStall,
+  extractUsageLimitResetAt,
+  type UsageLimitStallSignal
+} from './usage-limit-stall-detection'
+import type {
+  UsageLimitProvider,
+  UsageLimitStallReason
+} from '../../shared/agent-auto-resume-types'
 import { ClaudeAgentTeamsService } from './claude-agent-teams-service'
 import type {
   AgentTeamsTmuxCompatRequest,
@@ -973,6 +982,56 @@ type RuntimePtyWorktreeRecord = {
   waitBlockedAt: number | null
   // Why: memoized wait scan of the current retained tail (see RuntimeLeafRecord).
   tailWaitState?: TerminalTailWaitState
+  // Why: the live usage-limit stall this PTY is currently in, stamped when a
+  // *newer* banner/menu appears in the tail. Feeds AgentAutoResumeService via
+  // the usage-limit-stall event; cleared when the agent goes back to working.
+  usageLimitStall: PtyUsageLimitStall | null
+}
+
+type PtyUsageLimitStall = {
+  reason: UsageLimitStallReason
+  resetsAt: number | null
+  detectedAt: number
+}
+
+/** Emitted whenever a PTY's usage-limit state changes. Consumed by
+ *  AgentAutoResumeService in the composition root. */
+export type UsageLimitStallEvent =
+  | {
+      kind: 'detected'
+      ptyId: string
+      handle: string | null
+      worktreeId: string | null
+      paneKey: string | null
+      provider: UsageLimitProvider | null
+      reason: UsageLimitStallReason
+      resetsAt: number | null
+      detectedAt: number
+    }
+  | { kind: 'cleared'; ptyId: string }
+  | {
+      kind: 'exited'
+      ptyId: string
+      worktreeId: string | null
+      paneKey: string | null
+      exitCode: number
+    }
+
+/** Live re-verification of a PTY's usage-limit stall, read against the current
+ *  tail just before the service acts (never against stale history). */
+export type UsageLimitStallSnapshot = {
+  ptyId: string
+  handle: string | null
+  worktreeId: string | null
+  paneKey: string | null
+  provider: UsageLimitProvider | null
+  reason: UsageLimitStallReason
+  resetsAt: number | null
+  detectedAt: number
+  /** Whether the triggering banner/menu is still present in the live tail. */
+  present: boolean
+  /** Whether the agent is currently working (a resumed agent must not be poked). */
+  agentWorking: boolean
 }
 
 type TerminalCreateOptions = {
@@ -2104,6 +2163,9 @@ export class OrcaRuntimeService {
     Set<(event: { mode: 'mobile-fit' | 'desktop-fit'; cols: number; rows: number }) => void>
   >()
   private driverListeners = new Map<string, Set<(driver: DriverState) => void>>()
+  // Why: process-wide (not per-PTY) fan-out of usage-limit stall events to the
+  // single AgentAutoResumeService registered in the composition root.
+  private usageLimitStallListeners = new Set<(event: UsageLimitStallEvent) => void>()
   private subscriptionCleanups = new Map<string, () => void>()
   // Why: index of subscriptionIds by per-WebSocket connectionId so the
   // server can sweep all subscriptions for a closing socket without
@@ -5398,6 +5460,9 @@ export class OrcaRuntimeService {
       if (tailGainedNewerBlockedReason(previousWaitState, nextWaitState, normalized.text)) {
         pty.waitBlockedAt = at
       }
+      if (tailGainedNewerUsageLimitStall(previousWaitState, nextWaitState, normalized.text)) {
+        this.recordPtyUsageLimitStall(pty, ptyId, nextWaitState, at)
+      }
       pty.tailWaitState = nextWaitState
       ptyTailAfter = nextTail
       pty.tailBuffer = nextTail.lines
@@ -5416,6 +5481,12 @@ export class OrcaRuntimeService {
         this.setPtyManagementTitleFromObservedTitle(pty, oscTitle, observedAt)
         shouldTouchPtyBackedSessionTabs =
           prevTitle !== oscTitle || prevStatus !== pty.lastAgentStatus
+        // Why: a resumed agent must stop being tracked so the service never
+        // pokes a working agent (product rule #6). Working is the only status
+        // that clears — an idle-at-banner agent is still limited.
+        if (agentStatus === 'working' && pty.usageLimitStall) {
+          this.clearPtyUsageLimitStall(pty, ptyId)
+        }
         if (agentStatus === 'idle' && prevStatus !== 'idle') {
           this.resolvePtyTuiIdleWaiters(pty, ptyId)
         }
@@ -5778,6 +5849,94 @@ export class OrcaRuntimeService {
 
   subscribeToDriverChanges(ptyId: string, listener: (driver: DriverState) => void): () => void {
     return addListenerToMap(this.driverListeners, ptyId, listener)
+  }
+
+  /** Subscribe to usage-limit stall lifecycle events (detected / cleared /
+   *  exited). One subscriber — the composition root's AgentAutoResumeService. */
+  subscribeUsageLimitStall(listener: (event: UsageLimitStallEvent) => void): () => void {
+    this.usageLimitStallListeners.add(listener)
+    return () => {
+      this.usageLimitStallListeners.delete(listener)
+    }
+  }
+
+  private emitUsageLimitStall(event: UsageLimitStallEvent): void {
+    for (const listener of this.usageLimitStallListeners) {
+      try {
+        listener(event)
+      } catch (error) {
+        console.warn('[usage-limit] stall listener threw', error)
+      }
+    }
+  }
+
+  private ptyUsageLimitProvider(pty: RuntimePtyWorktreeRecord): UsageLimitProvider | null {
+    const agent = pty.foregroundAgent ?? pty.launchAgent
+    if (agent === 'claude' || agent === 'claude-agent-teams' || agent === 'openclaude') {
+      return 'claude'
+    }
+    return agent === 'codex' ? 'codex' : null
+  }
+
+  private recordPtyUsageLimitStall(
+    pty: RuntimePtyWorktreeRecord,
+    ptyId: string,
+    waitState: TerminalTailWaitState,
+    at: number
+  ): void {
+    const signal = waitState.usageLimitSignal
+    if (!signal) {
+      return
+    }
+    // Why: parse the reset from the live tail lines the same scan matched, never
+    // from history on disk. The menu carries no time, so this is null for menus.
+    const resetsAt =
+      signal.reason === 'usage-limit-banner'
+        ? extractUsageLimitResetAt(waitState.waitText.split('\n'))
+        : null
+    pty.usageLimitStall = { reason: signal.reason, resetsAt, detectedAt: at }
+    this.emitUsageLimitStall({
+      kind: 'detected',
+      ptyId,
+      handle: this.handleByPtyId.get(ptyId) ?? null,
+      worktreeId: pty.worktreeId ?? null,
+      paneKey: pty.paneKey,
+      provider: this.ptyUsageLimitProvider(pty),
+      reason: signal.reason,
+      resetsAt,
+      detectedAt: at
+    })
+  }
+
+  private clearPtyUsageLimitStall(pty: RuntimePtyWorktreeRecord, ptyId: string): void {
+    if (!pty.usageLimitStall) {
+      return
+    }
+    pty.usageLimitStall = null
+    this.emitUsageLimitStall({ kind: 'cleared', ptyId })
+  }
+
+  /** Re-scan the live tail for the service's pre-send verification. Returns null
+   *  when the PTY is gone or was never recorded as limited. */
+  getUsageLimitStallSnapshot(ptyId: string): UsageLimitStallSnapshot | null {
+    const pty = this.ptysById.get(ptyId)
+    if (!pty || !pty.usageLimitStall) {
+      return null
+    }
+    const waitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
+    const liveSignal = detectUsageLimitStall(waitText.toLowerCase())
+    return {
+      ptyId,
+      handle: this.handleByPtyId.get(ptyId) ?? null,
+      worktreeId: pty.worktreeId ?? null,
+      paneKey: pty.paneKey,
+      provider: this.ptyUsageLimitProvider(pty),
+      reason: pty.usageLimitStall.reason,
+      resetsAt: pty.usageLimitStall.resetsAt,
+      detectedAt: pty.usageLimitStall.detectedAt,
+      present: liveSignal?.reason === pty.usageLimitStall.reason,
+      agentWorking: pty.lastAgentStatus === 'working'
+    }
   }
 
   private notifyFitOverrideListeners(
@@ -7238,6 +7397,19 @@ export class OrcaRuntimeService {
       pty.connected = false
       pty.disconnectedAt = Date.now()
       pty.lastExitCode = exitCode
+      // Why: a PTY dying mid-stall can't be resumed by keystrokes; hand the
+      // dead-PTY case to the service (which notifies / defers to the sleeping-
+      // agent resume path) before the record is pruned.
+      if (pty.usageLimitStall) {
+        this.emitUsageLimitStall({
+          kind: 'exited',
+          ptyId,
+          worktreeId: pty.worktreeId ?? null,
+          paneKey: pty.paneKey,
+          exitCode
+        })
+        pty.usageLimitStall = null
+      }
       this.resolvePtyExitWaiters(pty, ptyId)
       this.pruneDisconnectedPtyTranscript(pty)
       this.touchMobileSessionSnapshotsForPty(ptyId)
@@ -18611,7 +18783,8 @@ export class OrcaRuntimeService {
         tailTruncated: false,
         tailLinesTotal: 0,
         preview: state.preview ?? '',
-        waitBlockedAt: null
+        waitBlockedAt: null,
+        usageLimitStall: null
       }
       if (state.title) {
         this.setPtyManagementTitleFromObservedTitle(pty, state.title, titleObservedAt ?? 0)
@@ -23617,6 +23790,10 @@ function buildTerminalWaitText(lines: string[], partialLine: string, preview: st
 export type TerminalTailWaitState = {
   waitText: string
   signal: { reason: RuntimeTerminalWaitBlockedReason; index: number } | null
+  // Why: usage-limit stalls ride the same per-chunk lowercased tail scan but
+  // travel a separate reason so they are never conflated with a blocked
+  // permission prompt (see agent-auto-resume-types.ts).
+  usageLimitSignal: UsageLimitStallSignal | null
   // Why: the retained tail is authoritative; `preview` is only a fallback for an
   // empty tail. A preview-derived state depends on a value that is recomputed
   // after each append, so it must not be reused as the next chunk's previous
@@ -23641,11 +23818,33 @@ export function computeTerminalTailWaitState(
     .join('\n')
   const fromTail = tailText.length > 0
   const waitText = fromTail ? tailText : preview
+  const normalized = waitText.toLowerCase()
   return {
     waitText,
-    signal: findActionableTerminalWaitBlockedSignal(waitText.toLowerCase()),
+    signal: findActionableTerminalWaitBlockedSignal(normalized),
+    usageLimitSignal: detectUsageLimitStall(normalized),
     fromTail
   }
+}
+
+// Why: mirrors tailGainedNewerBlockedReason for usage-limit stalls — returns
+// true only when the appended chunk introduced a stall newer than any the
+// previous tail already held, so the auto-resume timer arms once per fresh
+// limit event and never re-fires on stale banner/menu text lingering in the
+// tail (the exact failure mode of the old history-scraping cron).
+export function tailGainedNewerUsageLimitStall(
+  previous: TerminalTailWaitState,
+  next: TerminalTailWaitState,
+  appendedText: string
+): boolean {
+  if (next.usageLimitSignal === null) {
+    return false
+  }
+  if (previous.usageLimitSignal === null) {
+    return true
+  }
+  const appendCandidate = detectUsageLimitStall(`${previous.waitText}${appendedText}`.toLowerCase())
+  return appendCandidate !== null && appendCandidate.index > previous.usageLimitSignal.index
 }
 
 // Why: decides whether the appended chunk introduced a newer actionable blocked

--- a/src/main/runtime/pty-transcript-prune-wait-cache.test.ts
+++ b/src/main/runtime/pty-transcript-prune-wait-cache.test.ts
@@ -31,6 +31,7 @@ describe('pruneDisconnectedPtyTranscript clears the wait-scan cache', () => {
     pty.tailWaitState = {
       waitText: 'update available! press enter to continue.',
       signal: { reason: 'codex-update-prompt', index: 0 },
+      usageLimitSignal: null,
       fromTail: true
     }
 

--- a/src/main/runtime/usage-limit-stall-detection.test.ts
+++ b/src/main/runtime/usage-limit-stall-detection.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { detectUsageLimitStall, extractUsageLimitResetAt } from './usage-limit-stall-detection'
+
+// The runtime passes an ANSI-stripped, lowercased tail to detectUsageLimitStall.
+const lc = (text: string): string => text.toLowerCase()
+
+describe('detectUsageLimitStall', () => {
+  it('detects the Claude Code idle session-limit banner', () => {
+    const signal = detectUsageLimitStall(
+      lc("You've hit your session limit · resets 3:50pm (Europe/London)")
+    )
+    expect(signal?.reason).toBe('usage-limit-banner')
+  })
+
+  it('detects a usage-limit banner phrased "hit your usage limit"', () => {
+    expect(detectUsageLimitStall(lc("You've hit your usage limit. Try again later."))?.reason).toBe(
+      'usage-limit-banner'
+    )
+  })
+
+  it('detects a "usage limit reached" banner', () => {
+    expect(detectUsageLimitStall(lc('Weekly limit reached — resets Thu'))?.reason).toBe(
+      'usage-limit-banner'
+    )
+  })
+
+  it('detects the wait-for-reset menu', () => {
+    const menu = [
+      'What do you want to do?',
+      '❯ 1. Stop and wait for limit to reset',
+      '  2. Ask your admin for more usage',
+      '  Enter to confirm · Esc to cancel'
+    ].join('\n')
+    expect(detectUsageLimitStall(lc(menu))?.reason).toBe('usage-limit-menu')
+  })
+
+  it('detects the menu even when the PTY collapses the spaces', () => {
+    // The menu text sometimes renders with collapsed whitespace.
+    expect(detectUsageLimitStall('stopandwaitforlimittoreset')?.reason).toBe('usage-limit-menu')
+    expect(detectUsageLimitStall('askyouradminformoreusage')?.reason).toBe('usage-limit-menu')
+  })
+
+  it('classifies the menu over a banner when both are in the tail', () => {
+    const tail = [
+      "You've hit your session limit · resets 3pm",
+      '❯ 1. Stop and wait for limit to reset'
+    ].join('\n')
+    expect(detectUsageLimitStall(lc(tail))?.reason).toBe('usage-limit-menu')
+  })
+
+  it('ignores the "Show plan usage limits" command palette entry', () => {
+    expect(detectUsageLimitStall(lc('> Show plan usage limits'))).toBeNull()
+  })
+
+  it('ignores a /usage table that merely lists reset times', () => {
+    const usage = [
+      'Current session   45% used   resets 3:00pm',
+      'Weekly            12% used   resets Thu'
+    ].join('\n')
+    expect(detectUsageLimitStall(lc(usage))).toBeNull()
+  })
+
+  it('ignores an ordinary idle prompt', () => {
+    expect(detectUsageLimitStall(lc('> \n╭─ claude ─╮'))).toBeNull()
+  })
+})
+
+describe('extractUsageLimitResetAt', () => {
+  it('parses the reset time from a banner into a future timestamp', () => {
+    const resetsAt = extractUsageLimitResetAt([
+      "You've hit your session limit · resets 3:50pm (Europe/London)"
+    ])
+    expect(typeof resetsAt).toBe('number')
+    expect(resetsAt).toBeGreaterThan(Date.now())
+  })
+
+  it('parses a relative reset duration', () => {
+    const resetsAt = extractUsageLimitResetAt(['Usage limit reached. Resets in 3h 20m'])
+    expect(resetsAt).toBeGreaterThan(Date.now())
+  })
+
+  it('returns null when the tail carries no reset (e.g. the menu)', () => {
+    expect(extractUsageLimitResetAt(['❯ 1. Stop and wait for limit to reset'])).toBeNull()
+  })
+})

--- a/src/main/runtime/usage-limit-stall-detection.test.ts
+++ b/src/main/runtime/usage-limit-stall-detection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { detectUsageLimitStall, extractUsageLimitResetAt } from './usage-limit-stall-detection'
 
 // The runtime passes an ANSI-stripped, lowercased tail to detectUsageLimitStall.
@@ -55,6 +55,21 @@ describe('detectUsageLimitStall', () => {
     expect(detectUsageLimitStall(lc(tail))?.reason).toBe('usage-limit-menu')
   })
 
+  it('anchors the index to the latest banner when two coexist in the tail', () => {
+    // Regression: two limit banners can sit in the retained tail (limit →
+    // resume → limit again). The index must point at the NEWER one so the
+    // runtime re-arms on the second event instead of the stale first.
+    const tail = lc(
+      "You've hit your session limit · resets 1pm\n" +
+        'resumed and worked for a while\n' +
+        "You've hit your session limit · resets 8pm"
+    )
+    const signal = detectUsageLimitStall(tail)
+    expect(signal?.reason).toBe('usage-limit-banner')
+    expect(signal?.index).toBe(tail.lastIndexOf('hit your'))
+    expect(signal?.index).toBeGreaterThan(tail.indexOf('hit your'))
+  })
+
   it('ignores the "Show plan usage limits" command palette entry', () => {
     expect(detectUsageLimitStall(lc('> Show plan usage limits'))).toBeNull()
   })
@@ -73,7 +88,15 @@ describe('detectUsageLimitStall', () => {
 })
 
 describe('extractUsageLimitResetAt', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('parses the reset time from a banner into a future timestamp', () => {
+    // Pin the clock so the "resets 3:50pm" wall-clock assertion is deterministic
+    // regardless of when the suite runs.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T09:00:00'))
     const resetsAt = extractUsageLimitResetAt([
       "You've hit your session limit · resets 3:50pm (Europe/London)"
     ])
@@ -82,6 +105,8 @@ describe('extractUsageLimitResetAt', () => {
   })
 
   it('parses a relative reset duration', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T09:00:00'))
     const resetsAt = extractUsageLimitResetAt(['Usage limit reached. Resets in 3h 20m'])
     expect(resetsAt).toBeGreaterThan(Date.now())
   })
@@ -101,5 +126,25 @@ describe('extractUsageLimitResetAt', () => {
   it('parses a Codex reset with a PM time', () => {
     const resetsAt = extractUsageLimitResetAt(['or try again at May 14th, 2026 2:32 PM.'])
     expect(resetsAt).toBe(new Date('May 14, 2026 2:32 PM').getTime())
+  })
+
+  it('parses the NEWEST Codex reset when two banners coexist', () => {
+    const resetsAt = extractUsageLimitResetAt([
+      "You've hit your usage limit … or try again at Apr 23rd, 2026 10:42 AM.",
+      'worked, then hit the limit again',
+      "You've hit your usage limit … or try again at May 14th, 2026 2:32 PM."
+    ])
+    expect(resetsAt).toBe(new Date('May 14, 2026 2:32 PM').getTime())
+  })
+
+  it('parses the NEWEST Claude reset when two banners coexist', () => {
+    const resetsAt = extractUsageLimitResetAt([
+      "You've hit your session limit · resets Jan 5 at 4pm",
+      'worked for a while',
+      "You've hit your session limit · resets Jun 9 at 9am"
+    ])
+    expect(resetsAt).not.toBeNull()
+    // June (month index 5) proves it anchored to the newer banner, not January.
+    expect(new Date(resetsAt as number).getMonth()).toBe(5)
   })
 })

--- a/src/main/runtime/usage-limit-stall-detection.test.ts
+++ b/src/main/runtime/usage-limit-stall-detection.test.ts
@@ -24,6 +24,13 @@ describe('detectUsageLimitStall', () => {
     )
   })
 
+  it('detects the Codex usage-limit error banner', () => {
+    const codex =
+      "You've hit your usage limit. Upgrade to Plus to continue using Codex " +
+      '(https://chatgpt.com/explore/plus), or try again at Apr 23rd, 2026 10:42 AM.'
+    expect(detectUsageLimitStall(lc(codex))?.reason).toBe('usage-limit-banner')
+  })
+
   it('detects the wait-for-reset menu', () => {
     const menu = [
       'What do you want to do?',
@@ -81,5 +88,18 @@ describe('extractUsageLimitResetAt', () => {
 
   it('returns null when the tail carries no reset (e.g. the menu)', () => {
     expect(extractUsageLimitResetAt(['❯ 1. Stop and wait for limit to reset'])).toBeNull()
+  })
+
+  it('parses Codex "or try again at <date>" including the ordinal suffix', () => {
+    const resetsAt = extractUsageLimitResetAt([
+      "You've hit your usage limit. Upgrade to Plus to continue using Codex " +
+        '(https://chatgpt.com/explore/plus), or try again at Apr 23rd, 2026 10:42 AM.'
+    ])
+    expect(resetsAt).toBe(new Date('Apr 23, 2026 10:42 AM').getTime())
+  })
+
+  it('parses a Codex reset with a PM time', () => {
+    const resetsAt = extractUsageLimitResetAt(['or try again at May 14th, 2026 2:32 PM.'])
+    expect(resetsAt).toBe(new Date('May 14, 2026 2:32 PM').getTime())
   })
 })

--- a/src/main/runtime/usage-limit-stall-detection.ts
+++ b/src/main/runtime/usage-limit-stall-detection.ts
@@ -1,0 +1,80 @@
+import type { UsageLimitStallReason } from '../../shared/agent-auto-resume-types'
+import { extractClaudePtyResetMetadata } from '../rate-limits/claude-pty-reset-parser'
+
+export type UsageLimitStallSignal = {
+  reason: UsageLimitStallReason
+  /** Offset of the match in the scanned (lowercased) tail. Used to decide when
+   *  an appended chunk introduced a *newer* stall than the previous tail held. */
+  index: number
+}
+
+// Why: match the wait-for-reset menu option. `\s*` between tokens tolerates the
+// space-collapsed render the PTY sometimes emits ("Stopandwaitforlimittoreset")
+// as well as normal spacing. The reset option is the strongest menu signal.
+const MENU_RESET_OPTION_RE = /stop\s*and\s*wait\s*for\s*(?:the\s*)?limit\s*to\s*reset/
+// Why: the admin option co-occurs with the reset option; matching it too keeps
+// detection alive if the reset line scrolls just out of the retained tail.
+const MENU_ADMIN_OPTION_RE = /ask\s*your\s*admin\s*for\s*more\s*usage/
+
+// Why: the idle banner states the agent is blocked BY a limit. Requiring
+// "hit/reached your … limit" (or "… limit reached") keeps this specific enough
+// to skip the /usage table and the "Show plan usage limits" command palette,
+// which also contain the word "limit" and even "resets" lines. Whitespace is
+// tolerant for the same collapsed-render reason as the menu patterns.
+const BANNER_HIT_LIMIT_RE =
+  /(?:hit|hitting|reached|reaching)\s*your\s*(?:(?:5-?\s*hour|5h|weekly|session|usage|rate)\s*)*limit/
+const BANNER_LIMIT_REACHED_RE = /(?:session|usage|weekly|rate)\s*limit\s*(?:has\s*been\s*)?reached/
+
+function firstMatchIndex(text: string, patterns: RegExp[]): number | null {
+  let best: number | null = null
+  for (const pattern of patterns) {
+    const match = pattern.exec(text)
+    if (match && (best === null || match.index < best)) {
+      best = match.index
+    }
+  }
+  return best
+}
+
+/**
+ * Detect whether an agent CLI is stalled on a provider usage limit.
+ *
+ * @param normalizedTail the retained PTY tail, ANSI-stripped and lowercased
+ *   (the same text `findActionableTerminalWaitBlockedSignal` scans).
+ *
+ * Menu wins over banner: the interactive chooser is the actionable state and
+ * its "limit to reset" text never matches the banner patterns, so the two
+ * classifications stay disjoint. The returned index is the latest match so the
+ * caller's "did this chunk add a newer stall?" comparison stays monotonic.
+ */
+export function detectUsageLimitStall(normalizedTail: string): UsageLimitStallSignal | null {
+  const menuIndex = firstMatchIndex(normalizedTail, [MENU_RESET_OPTION_RE, MENU_ADMIN_OPTION_RE])
+  if (menuIndex !== null) {
+    return { reason: 'usage-limit-menu', index: menuIndex }
+  }
+  const bannerIndex = firstMatchIndex(normalizedTail, [
+    BANNER_HIT_LIMIT_RE,
+    BANNER_LIMIT_REACHED_RE
+  ])
+  if (bannerIndex !== null) {
+    return { reason: 'usage-limit-banner', index: bannerIndex }
+  }
+  return null
+}
+
+const BANNER_LABEL_RE =
+  /(?:session|usage|weekly|rate|5-?\s*hour|5h)\s*limit|hit\s*your|limit\s*reset/i
+
+/**
+ * Parse the reset timestamp out of a usage-limit banner's tail. Reuses the
+ * Claude PTY reset parser (handles "resets 3:50pm", "resets Jan 5 at 4pm",
+ * relative "3h 20m", time zones). Returns null when the banner carries no
+ * parseable reset (e.g. the menu, which never prints a time).
+ */
+export function extractUsageLimitResetAt(tailLines: string[]): number | null {
+  return extractClaudePtyResetMetadata(
+    tailLines,
+    (line) => BANNER_LABEL_RE.test(line),
+    () => false
+  ).resetsAt
+}

--- a/src/main/runtime/usage-limit-stall-detection.ts
+++ b/src/main/runtime/usage-limit-stall-detection.ts
@@ -11,26 +11,37 @@ export type UsageLimitStallSignal = {
 // Why: match the wait-for-reset menu option. `\s*` between tokens tolerates the
 // space-collapsed render the PTY sometimes emits ("Stopandwaitforlimittoreset")
 // as well as normal spacing. The reset option is the strongest menu signal.
-const MENU_RESET_OPTION_RE = /stop\s*and\s*wait\s*for\s*(?:the\s*)?limit\s*to\s*reset/
-// Why: the admin option co-occurs with the reset option; matching it too keeps
-// detection alive if the reset line scrolls just out of the retained tail.
-const MENU_ADMIN_OPTION_RE = /ask\s*your\s*admin\s*for\s*more\s*usage/
+// The `g` flag lets latestMatchIndex scan for every occurrence via matchAll.
+const MENU_PATTERNS = [
+  /stop\s*and\s*wait\s*for\s*(?:the\s*)?limit\s*to\s*reset/g,
+  // The admin option co-occurs with the reset option; matching it too keeps
+  // detection alive if the reset line scrolls just out of the retained tail.
+  /ask\s*your\s*admin\s*for\s*more\s*usage/g
+]
 
 // Why: the idle banner states the agent is blocked BY a limit. Requiring
 // "hit/reached your … limit" (or "… limit reached") keeps this specific enough
 // to skip the /usage table and the "Show plan usage limits" command palette,
 // which also contain the word "limit" and even "resets" lines. Whitespace is
 // tolerant for the same collapsed-render reason as the menu patterns.
-const BANNER_HIT_LIMIT_RE =
-  /(?:hit|hitting|reached|reaching)\s*your\s*(?:(?:5-?\s*hour|5h|weekly|session|usage|rate)\s*)*limit/
-const BANNER_LIMIT_REACHED_RE = /(?:session|usage|weekly|rate)\s*limit\s*(?:has\s*been\s*)?reached/
+const BANNER_PATTERNS = [
+  /(?:hit|hitting|reached|reaching)\s*your\s*(?:(?:5-?\s*hour|5h|weekly|session|usage|rate)\s*)*limit/g,
+  /(?:session|usage|weekly|rate)\s*limit\s*(?:has\s*been\s*)?reached/g
+]
 
-function firstMatchIndex(text: string, patterns: RegExp[]): number | null {
+// Why: return the LATEST (greatest-offset) match, mirroring the blocked-reason
+// signal's lastIndexOf. Retained PTY tails keep earlier output, so a first-match
+// index would stay pinned to a stale banner/menu and the caller's "did this
+// chunk add a *newer* stall?" comparison could never re-arm on a second event.
+// matchAll clones the (global) regex, so the shared module-level patterns are
+// safe to reuse across calls.
+function latestMatchIndex(text: string, patterns: RegExp[]): number | null {
   let best: number | null = null
   for (const pattern of patterns) {
-    const match = pattern.exec(text)
-    if (match && (best === null || match.index < best)) {
-      best = match.index
+    for (const match of text.matchAll(pattern)) {
+      if (match.index !== undefined && (best === null || match.index > best)) {
+        best = match.index
+      }
     }
   }
   return best
@@ -48,14 +59,11 @@ function firstMatchIndex(text: string, patterns: RegExp[]): number | null {
  * caller's "did this chunk add a newer stall?" comparison stays monotonic.
  */
 export function detectUsageLimitStall(normalizedTail: string): UsageLimitStallSignal | null {
-  const menuIndex = firstMatchIndex(normalizedTail, [MENU_RESET_OPTION_RE, MENU_ADMIN_OPTION_RE])
+  const menuIndex = latestMatchIndex(normalizedTail, MENU_PATTERNS)
   if (menuIndex !== null) {
     return { reason: 'usage-limit-menu', index: menuIndex }
   }
-  const bannerIndex = firstMatchIndex(normalizedTail, [
-    BANNER_HIT_LIMIT_RE,
-    BANNER_LIMIT_REACHED_RE
-  ])
+  const bannerIndex = latestMatchIndex(normalizedTail, BANNER_PATTERNS)
   if (bannerIndex !== null) {
     return { reason: 'usage-limit-banner', index: bannerIndex }
   }
@@ -67,20 +75,26 @@ const BANNER_LABEL_RE =
 
 // Why: Codex phrases its reset as "…or try again at Apr 23rd, 2026 10:42 AM.",
 // which the Claude "resets …" parser doesn't recognize. Match the date after
-// the retry marker; [\s\S]*? lets the copy between the prefix and marker wrap.
+// the retry marker; global so we can select the LAST occurrence (see below).
 const CODEX_RETRY_AT_RE =
-  /or\s+try\s+again\s+at\s+([A-Z][a-z]{2,8}\s+\d{1,2}(?:st|nd|rd|th)?,?\s+\d{4}\s+\d{1,2}:\d{2}\s*(?:AM|PM))\.?/i
+  /or\s+try\s+again\s+at\s+([A-Z][a-z]{2,8}\s+\d{1,2}(?:st|nd|rd|th)?,?\s+\d{4}\s+\d{1,2}:\d{2}\s*(?:AM|PM))\.?/gi
 const DAY_ORDINAL_RE = /(\d{1,2})(?:st|nd|rd|th)/i
 
-function parseCodexRetryAt(text: string): number | null {
-  const match = CODEX_RETRY_AT_RE.exec(text)
-  if (!match) {
+function parseLatestCodexRetryAt(text: string): number | null {
+  // Anchor to the NEWEST banner: two limit banners can coexist in the retained
+  // tail (limit → resume → limit again), and inheriting the older reset would
+  // schedule a resume at a past time and fire early.
+  let latest: RegExpMatchArray | null = null
+  for (const match of text.matchAll(CODEX_RETRY_AT_RE)) {
+    latest = match
+  }
+  if (!latest) {
     return null
   }
   // "Apr 23rd, 2026 10:42 AM" -> "Apr 23, 2026 10:42 AM" so Date can parse it.
   // The text carries no timezone, so this resolves in the runtime host's local
   // zone; the service prefers the provider's structured resets_at when present.
-  const normalized = match[1].replace(DAY_ORDINAL_RE, '$1')
+  const normalized = latest[1].replace(DAY_ORDINAL_RE, '$1')
   const timestamp = new Date(normalized).getTime()
   return Number.isFinite(timestamp) ? timestamp : null
 }
@@ -90,14 +104,27 @@ function parseCodexRetryAt(text: string): number | null {
  * "or try again at <date>" and Claude's "resets 3:50pm" / "resets Jan 5 at 4pm"
  * / relative "3h 20m" (with time zones). Returns null when the banner carries
  * no parseable reset (e.g. the menu, which never prints a time).
+ *
+ * Anchored to the newest banner in the tail so a stale earlier banner can't
+ * supply an old reset time.
  */
 export function extractUsageLimitResetAt(tailLines: string[]): number | null {
-  return (
-    parseCodexRetryAt(tailLines.join('\n')) ??
-    extractClaudePtyResetMetadata(
-      tailLines,
-      (line) => BANNER_LABEL_RE.test(line),
-      () => false
-    ).resetsAt
-  )
+  const codexResetAt = parseLatestCodexRetryAt(tailLines.join('\n'))
+  if (codexResetAt !== null) {
+    return codexResetAt
+  }
+  // Claude: scan only from the last banner-label line so the parser reads the
+  // newest banner's reset rather than the first one it finds top-down.
+  let lastLabelIndex = -1
+  for (let i = 0; i < tailLines.length; i++) {
+    if (BANNER_LABEL_RE.test(tailLines[i])) {
+      lastLabelIndex = i
+    }
+  }
+  const scopedLines = lastLabelIndex >= 0 ? tailLines.slice(lastLabelIndex) : tailLines
+  return extractClaudePtyResetMetadata(
+    scopedLines,
+    (line) => BANNER_LABEL_RE.test(line),
+    () => false
+  ).resetsAt
 }

--- a/src/main/runtime/usage-limit-stall-detection.ts
+++ b/src/main/runtime/usage-limit-stall-detection.ts
@@ -65,16 +65,39 @@ export function detectUsageLimitStall(normalizedTail: string): UsageLimitStallSi
 const BANNER_LABEL_RE =
   /(?:session|usage|weekly|rate|5-?\s*hour|5h)\s*limit|hit\s*your|limit\s*reset/i
 
+// Why: Codex phrases its reset as "…or try again at Apr 23rd, 2026 10:42 AM.",
+// which the Claude "resets …" parser doesn't recognize. Match the date after
+// the retry marker; [\s\S]*? lets the copy between the prefix and marker wrap.
+const CODEX_RETRY_AT_RE =
+  /or\s+try\s+again\s+at\s+([A-Z][a-z]{2,8}\s+\d{1,2}(?:st|nd|rd|th)?,?\s+\d{4}\s+\d{1,2}:\d{2}\s*(?:AM|PM))\.?/i
+const DAY_ORDINAL_RE = /(\d{1,2})(?:st|nd|rd|th)/i
+
+function parseCodexRetryAt(text: string): number | null {
+  const match = CODEX_RETRY_AT_RE.exec(text)
+  if (!match) {
+    return null
+  }
+  // "Apr 23rd, 2026 10:42 AM" -> "Apr 23, 2026 10:42 AM" so Date can parse it.
+  // The text carries no timezone, so this resolves in the runtime host's local
+  // zone; the service prefers the provider's structured resets_at when present.
+  const normalized = match[1].replace(DAY_ORDINAL_RE, '$1')
+  const timestamp = new Date(normalized).getTime()
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
 /**
- * Parse the reset timestamp out of a usage-limit banner's tail. Reuses the
- * Claude PTY reset parser (handles "resets 3:50pm", "resets Jan 5 at 4pm",
- * relative "3h 20m", time zones). Returns null when the banner carries no
- * parseable reset (e.g. the menu, which never prints a time).
+ * Parse the reset timestamp out of a usage-limit banner's tail. Handles Codex's
+ * "or try again at <date>" and Claude's "resets 3:50pm" / "resets Jan 5 at 4pm"
+ * / relative "3h 20m" (with time zones). Returns null when the banner carries
+ * no parseable reset (e.g. the menu, which never prints a time).
  */
 export function extractUsageLimitResetAt(tailLines: string[]): number | null {
-  return extractClaudePtyResetMetadata(
-    tailLines,
-    (line) => BANNER_LABEL_RE.test(line),
-    () => false
-  ).resetsAt
+  return (
+    parseCodexRetryAt(tailLines.join('\n')) ??
+    extractClaudePtyResetMetadata(
+      tailLines,
+      (line) => BANNER_LABEL_RE.test(line),
+      () => false
+    ).resetsAt
+  )
 }

--- a/src/main/runtime/usage-limit-tail-state.test.ts
+++ b/src/main/runtime/usage-limit-tail-state.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { computeTerminalTailWaitState, tailGainedNewerUsageLimitStall } from './orca-runtime'
+
+function stateFor(text: string) {
+  return computeTerminalTailWaitState([text], '', text)
+}
+
+describe('usage-limit tail-state edge trigger', () => {
+  it('exposes a usage-limit signal on the memoized wait state', () => {
+    const state = stateFor("You've hit your session limit · resets 3:50pm")
+    expect(state.usageLimitSignal?.reason).toBe('usage-limit-banner')
+  })
+
+  it('fires once when a fresh stall appears in the appended chunk', () => {
+    const before = stateFor('working on it…')
+    const appended = "\nYou've hit your session limit · resets 3:50pm"
+    const after = computeTerminalTailWaitState(
+      ['working on it…', "You've hit your session limit · resets 3:50pm"],
+      '',
+      ''
+    )
+    expect(tailGainedNewerUsageLimitStall(before, after, appended)).toBe(true)
+  })
+
+  it('does not re-fire on stale banner text already in the previous tail', () => {
+    const banner = "You've hit your session limit · resets 3:50pm"
+    const before = stateFor(banner)
+    // A later spinner redraw chunk with no new limit line must not re-arm.
+    const after = computeTerminalTailWaitState([banner, '⠋ thinking'], '', '')
+    expect(tailGainedNewerUsageLimitStall(before, after, '\n⠋ thinking')).toBe(false)
+  })
+})

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -356,6 +356,7 @@ import type {
   RateLimitRuntimeTarget,
   RateLimitState
 } from '../shared/rate-limit-types'
+import type { AgentAutoResumeSnapshot } from '../shared/agent-auto-resume-types'
 import type {
   SpeechErrorEvent,
   SpeechLifecycleEvent,
@@ -2886,6 +2887,9 @@ export type PreloadApi = {
     refreshMiniMax: () => Promise<RateLimitState>
     refreshGrok: () => Promise<RateLimitState>
     onUpdate: (callback: (state: RateLimitState) => void) => () => void
+  }
+  agentAutoResume: {
+    onUpdate: (callback: (snapshot: AgentAutoResumeSnapshot) => void) => () => void
   }
   minimaxCredentials: {
     getStatus: () => Promise<{ configured: boolean }>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2889,6 +2889,7 @@ export type PreloadApi = {
     onUpdate: (callback: (state: RateLimitState) => void) => () => void
   }
   agentAutoResume: {
+    get: () => Promise<AgentAutoResumeSnapshot>
     onUpdate: (callback: (snapshot: AgentAutoResumeSnapshot) => void) => () => void
   }
   minimaxCredentials: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3867,6 +3867,7 @@ const api = {
   },
 
   agentAutoResume: {
+    get: (): Promise<AgentAutoResumeSnapshot> => ipcRenderer.invoke('agentAutoResume:get'),
     onUpdate: (callback: (snapshot: AgentAutoResumeSnapshot) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, snapshot: AgentAutoResumeSnapshot) =>
         callback(snapshot)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -83,6 +83,10 @@ import type {
   RateLimitRuntimeTarget,
   RateLimitState
 } from '../shared/rate-limit-types'
+import {
+  AGENT_AUTO_RESUME_UPDATE_CHANNEL,
+  type AgentAutoResumeSnapshot
+} from '../shared/agent-auto-resume-types'
 import type { WorkspaceSpaceScanProgress } from '../shared/workspace-space-types'
 import type { WorkspaceCleanupScanProgress } from '../shared/workspace-cleanup'
 import type { WorkspacePortAdvertisedUrlChangedEvent } from '../shared/workspace-ports'
@@ -3859,6 +3863,15 @@ const api = {
       const listener = (_event: Electron.IpcRendererEvent, state: RateLimitState) => callback(state)
       ipcRenderer.on('rateLimits:update', listener)
       return () => ipcRenderer.removeListener('rateLimits:update', listener)
+    }
+  },
+
+  agentAutoResume: {
+    onUpdate: (callback: (snapshot: AgentAutoResumeSnapshot) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, snapshot: AgentAutoResumeSnapshot) =>
+        callback(snapshot)
+      ipcRenderer.on(AGENT_AUTO_RESUME_UPDATE_CHANNEL, listener)
+      return () => ipcRenderer.removeListener(AGENT_AUTO_RESUME_UPDATE_CHANNEL, listener)
     }
   },
 

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -11,6 +11,7 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { cn } from '@/lib/utils'
 import { AgentAwakeSetting } from './AgentAwakeSetting'
+import { AutoResumeRateLimitedSetting } from './AutoResumeRateLimitedSetting'
 import { AgentCacheTimerSection } from './AgentCacheTimerSection'
 import { AgentRuntimeSetting } from './AgentRuntimeSetting'
 import {
@@ -834,6 +835,8 @@ export function AgentsPane({
       <AgentGeneratedTabTitlesSetting settings={settings} updateSettings={updateSettings} />
 
       <AgentAwakeSetting settings={settings} updateSettings={updateSettings} />
+
+      <AutoResumeRateLimitedSetting settings={settings} updateSettings={updateSettings} />
 
       <AgentCacheTimerSection settings={settings} updateSettings={updateSettings} />
 

--- a/src/renderer/src/components/settings/AutoResumeRateLimitedSetting.tsx
+++ b/src/renderer/src/components/settings/AutoResumeRateLimitedSetting.tsx
@@ -1,0 +1,61 @@
+import type { GlobalSettings } from '../../../../shared/types'
+import { Label } from '../ui/label'
+import {
+  getAutoResumeDescription,
+  getAutoResumeSearchKeywords,
+  getAutoResumeTitle
+} from './auto-resume-copy'
+import { SearchableSetting } from './SearchableSetting'
+
+type AutoResumeRateLimitedSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function AutoResumeRateLimitedSetting({
+  settings,
+  updateSettings
+}: AutoResumeRateLimitedSettingProps): React.JSX.Element {
+  const title = getAutoResumeTitle()
+  const description = getAutoResumeDescription()
+
+  return (
+    <section className="space-y-3">
+      <SearchableSetting
+        title={title}
+        description={description}
+        keywords={getAutoResumeSearchKeywords()}
+      >
+        <div className="flex items-start justify-between gap-4 py-2">
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <Label>{title}</Label>
+            <p className="text-xs text-muted-foreground">{description}</p>
+          </div>
+          {/* Why: this button is read directly from the React element tree by tests
+              that walk props (without rendering), so the role/aria attributes
+              must remain on a literal <button>, not behind a component wrapper. */}
+          <button
+            type="button"
+            role="switch"
+            aria-label={title}
+            aria-checked={settings.autoResumeRateLimitedAgents}
+            onClick={() =>
+              updateSettings({
+                autoResumeRateLimitedAgents: !settings.autoResumeRateLimitedAgents
+              })
+            }
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+              settings.autoResumeRateLimitedAgents ? 'bg-foreground' : 'bg-muted-foreground/30'
+            } outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50`}
+          >
+            <span
+              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+                settings.autoResumeRateLimitedAgents ? 'translate-x-4' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </div>
+      </SearchableSetting>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/auto-resume-copy.ts
+++ b/src/renderer/src/components/settings/auto-resume-copy.ts
@@ -1,0 +1,27 @@
+import { translate } from '@/i18n/i18n'
+import { searchKeywords } from './settings-search-keywords'
+
+const AUTO_RESUME_TITLE_KEY = 'auto.components.settings.auto-resume-copy.title'
+const AUTO_RESUME_DESCRIPTION_KEY = 'auto.components.settings.auto-resume-copy.description'
+
+export function getAutoResumeTitle(): string {
+  return translate(AUTO_RESUME_TITLE_KEY, 'Auto-resume rate-limited agents')
+}
+
+export function getAutoResumeDescription(): string {
+  return translate(
+    AUTO_RESUME_DESCRIPTION_KEY,
+    'When an agent hits a provider usage limit, Orca waits for the limit to reset and resumes it automatically.'
+  )
+}
+
+export function getAutoResumeSearchKeywords(): string[] {
+  return searchKeywords([
+    { key: 'auto.components.settings.agents.search.autoresume.0', fallback: 'auto-resume' },
+    { key: 'auto.components.settings.agents.search.autoresume.1', fallback: 'rate limit' },
+    { key: 'auto.components.settings.agents.search.autoresume.2', fallback: 'usage limit' },
+    { key: 'auto.components.settings.agents.search.autoresume.3', fallback: 'resume' },
+    { key: 'auto.components.settings.agents.search.autoresume.4', fallback: 'paused' },
+    { key: 'auto.components.settings.agents.search.autoresume.5', fallback: 'agent' }
+  ])
+}

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Hourglass } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
 
@@ -36,6 +37,21 @@ const StatusIndicator = React.memo(function StatusIndicator({
         {/* Why: a stepped spin preserves the worker-is-running affordance while
             avoiding a full-refresh-rate compositor loop for long agent runs. */}
         <span className="block size-2 rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite]" />
+      </span>
+    )
+  }
+
+  if (status === 'rate-limited') {
+    // Why: a paused/waiting-for-reset agent gets its own amber hourglass so it
+    // reads as "Orca is waiting to resume this", distinct from the permission
+    // dot (also amber) which demands user action.
+    return (
+      <span
+        className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
+        title={resolvedTitle}
+        {...rest}
+      >
+        <Hourglass className="size-2.5 text-amber-500" aria-hidden="true" />
       </span>
     )
   }

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import { Bell, GitBranch } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
+import { useAppStore } from '@/store'
+import { formatRateLimitedLabel, selectWorktreeRateLimitStatus } from '@/store/slices/auto-resume'
 import { FilledBellIcon } from './WorktreeCardHelpers'
 import StatusIndicator from './StatusIndicator'
 import { useWorktreeActivityStatus } from './use-worktree-activity-status'
@@ -101,7 +104,11 @@ export function WorktreeCardStatusSlot({
   className
 }: WorktreeCardStatusSlotProps): React.JSX.Element | null {
   const status = useWorktreeActivityStatus(worktreeId)
-  const statusLabel = getWorktreeStatusLabel(status) || status
+  const rateLimit = useAppStore(useShallow((s) => selectWorktreeRateLimitStatus(s, worktreeId)))
+  const statusLabel =
+    status === 'rate-limited'
+      ? formatRateLimitedLabel(rateLimit.resumesAt)
+      : getWorktreeStatusLabel(status) || status
   const canShowReviewStatus =
     newCardStyle &&
     showStatus &&

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -9,6 +9,7 @@ import {
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
 import { selectWorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
+import { selectHasRateLimitedForWorktree } from '@/store/slices/auto-resume'
 
 export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const tabs = useAppStore((s) => s.tabsByWorktree[worktreeId] ?? EMPTY_TABS)
@@ -24,6 +25,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   )
   const { hasPermission, hasLiveWorking, hasLiveDone, hasRetainedDone, agentStatusPaneIdsByTabId } =
     useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
+  const hasRateLimited = useAppStore((s) => selectHasRateLimitedForWorktree(s, worktreeId))
 
   // Why: compact and detailed cards need the same status-dot semantics:
   // runtime liveness gates title-derived states, then explicit agent rows can
@@ -40,7 +42,8 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         hasPermission,
         hasLiveWorking,
         hasLiveDone,
-        hasRetainedDone
+        hasRetainedDone,
+        hasRateLimited
       }),
     [
       tabs,
@@ -52,7 +55,8 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       hasPermission,
       hasLiveWorking,
       hasLiveDone,
-      hasRetainedDone
+      hasRetainedDone,
+      hasRateLimited
     ]
   )
 }

--- a/src/renderer/src/components/sidebar/worktree-section-activity.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.ts
@@ -18,6 +18,7 @@ import {
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
 import { selectWorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
+import { selectHasRateLimitedForWorktree } from '@/store/slices/auto-resume'
 import type { BrowserActivityTab } from './visible-worktree-activity-inputs'
 
 export type WorktreeSectionActivityState = Pick<
@@ -28,6 +29,7 @@ export type WorktreeSectionActivityState = Pick<
   | 'agentStatusByPaneKey'
   | 'migrationUnsupportedByPtyId'
   | 'retainedAgentsByPaneKey'
+  | 'autoResumeEntries'
 > & {
   tabsByWorktree: Record<string, readonly Pick<TerminalTab, 'id' | 'title'>[]>
   browserTabsByWorktree: Record<string, readonly BrowserActivityTab[]>
@@ -111,6 +113,7 @@ function getSectionWorktreeStatus(
     hasPermission: agentSummary.hasPermission,
     hasLiveWorking: agentSummary.hasLiveWorking,
     hasLiveDone: agentSummary.hasLiveDone,
-    hasRetainedDone: agentSummary.hasRetainedDone
+    hasRetainedDone: agentSummary.hasRetainedDone,
+    hasRateLimited: selectHasRateLimitedForWorktree(state, worktreeId)
   })
 }

--- a/src/renderer/src/components/status-bar/AutoResumeStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AutoResumeStatusSegment.tsx
@@ -2,16 +2,27 @@ import React from 'react'
 import { Hourglass } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
 import { useAppStore } from '../../store'
+
+// i18n keys held as constants (not inline literals) to match the settings-copy
+// pattern and the catalog verifier, which only statically checks literal keys.
+const WAITING_KEY = 'auto.components.status-bar.auto-resume.waiting'
+const RESUMES_KEY = 'auto.components.status-bar.auto-resume.resumes'
+const AGENT_KEY = 'auto.components.status-bar.auto-resume.agent'
+const AGENTS_KEY = 'auto.components.status-bar.auto-resume.agents'
+const LABEL_KEY = 'auto.components.status-bar.auto-resume.label'
+const TOOLTIP_KEY = 'auto.components.status-bar.auto-resume.tooltip'
 
 function formatResumeClock(resumesAt: number | null): string {
   if (typeof resumesAt !== 'number' || !Number.isFinite(resumesAt)) {
-    return 'waiting for reset'
+    return translate(WAITING_KEY, 'waiting for reset')
   }
   try {
-    return `resumes ${new Date(resumesAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
+    const time = new Date(resumesAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    return translate(RESUMES_KEY, 'resumes {{time}}', { time })
   } catch {
-    return 'waiting for reset'
+    return translate(WAITING_KEY, 'waiting for reset')
   }
 }
 
@@ -53,9 +64,13 @@ export function AutoResumeStatusSegment({
     return null
   }
 
-  const plural = summary.count === 1 ? 'agent' : 'agents'
-  const label = `${summary.count} paused`
-  const tooltip = `${summary.count} ${plural} paused · ${formatResumeClock(summary.soonestAt)}`
+  const noun = summary.count === 1 ? translate(AGENT_KEY, 'agent') : translate(AGENTS_KEY, 'agents')
+  const label = translate(LABEL_KEY, '{{n}} paused', { n: summary.count })
+  const tooltip = translate(TOOLTIP_KEY, '{{n}} {{noun}} paused · {{detail}}', {
+    n: summary.count,
+    noun,
+    detail: formatResumeClock(summary.soonestAt)
+  })
 
   return (
     <Tooltip>

--- a/src/renderer/src/components/status-bar/AutoResumeStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/AutoResumeStatusSegment.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { Hourglass } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useAppStore } from '../../store'
+
+function formatResumeClock(resumesAt: number | null): string {
+  if (typeof resumesAt !== 'number' || !Number.isFinite(resumesAt)) {
+    return 'waiting for reset'
+  }
+  try {
+    return `resumes ${new Date(resumesAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
+  } catch {
+    return 'waiting for reset'
+  }
+}
+
+/**
+ * Compact status-bar segment shown while ≥1 agent is paused on a usage limit.
+ * Reads the auto-resume store snapshot pushed from the main-process service.
+ * Clicking focuses the soonest-resuming worktree.
+ */
+export function AutoResumeStatusSegment({
+  iconOnly
+}: {
+  compact: boolean
+  iconOnly: boolean
+}): React.JSX.Element | null {
+  const summary = useAppStore(
+    useShallow((s) => {
+      let count = 0
+      let soonestAt: number | null = null
+      let targetWorktreeId: string | null = null
+      for (const entry of s.autoResumeEntries) {
+        count += 1
+        if (
+          typeof entry.resumesAt === 'number' &&
+          (soonestAt === null || entry.resumesAt < soonestAt)
+        ) {
+          soonestAt = entry.resumesAt
+          targetWorktreeId = entry.worktreeId
+        }
+        if (targetWorktreeId === null) {
+          targetWorktreeId = entry.worktreeId
+        }
+      }
+      return { count, soonestAt, targetWorktreeId }
+    })
+  )
+  const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
+
+  if (summary.count === 0) {
+    return null
+  }
+
+  const plural = summary.count === 1 ? 'agent' : 'agents'
+  const label = `${summary.count} paused`
+  const tooltip = `${summary.count} ${plural} paused · ${formatResumeClock(summary.soonestAt)}`
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => {
+            if (summary.targetWorktreeId) {
+              setActiveWorktree(summary.targetWorktreeId)
+            }
+          }}
+          className="inline-flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 hover:bg-accent/70"
+          aria-label={tooltip}
+        >
+          <Hourglass className="size-3 text-amber-500" />
+          {!iconOnly && <span className="text-[11px] tabular-nums">{label}</span>}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -94,6 +94,11 @@ const ResourceUsageStatusSegment = lazyWithRetry(() =>
 const PortsStatusSegment = lazyWithRetry(() =>
   import('./PortsStatusSegment').then((module) => ({ default: module.PortsStatusSegment }))
 )
+const AutoResumeStatusSegment = lazyWithRetry(() =>
+  import('./AutoResumeStatusSegment').then((module) => ({
+    default: module.AutoResumeStatusSegment
+  }))
+)
 const SshStatusSegment = lazyWithRetry(() =>
   import('./SshStatusSegment').then((module) => ({ default: module.SshStatusSegment }))
 )
@@ -2121,6 +2126,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
       <div className="flex items-center gap-3">
         <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
         <React.Suspense fallback={null}>
+          <AutoResumeStatusSegment compact={compact} iconOnly={iconOnly} />
           {petEnabled ? <PetStatusSegment /> : null}
           {showResourceUsage ? (
             <ResourceUsageStatusSegment compact={compact} iconOnly={iconOnly} />

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2558,6 +2558,13 @@ export function useIpcEvents(): void {
     if (unsubscribeAutoResume) {
       unsubs.push(unsubscribeAutoResume)
     }
+    // Why: the service only pushes on state changes, so hydrate current state
+    // once on mount in case a stall was detected before this subscription.
+    void window.api.agentAutoResume?.get?.().then((snapshot) => {
+      if (snapshot) {
+        useAppStore.getState().setAutoResumeSnapshot(snapshot)
+      }
+    })
     // Why: the startup get is a fallback; a live push may already include
     // system-default account snapshots that an older get result lacks.
     window.api.rateLimits.get().then((state) => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2552,6 +2552,12 @@ export function useIpcEvents(): void {
         useAppStore.getState().setRateLimitsFromPush(state as RateLimitState)
       })
     )
+    const unsubscribeAutoResume = window.api.agentAutoResume?.onUpdate?.((snapshot) => {
+      useAppStore.getState().setAutoResumeSnapshot(snapshot)
+    })
+    if (unsubscribeAutoResume) {
+      unsubs.push(unsubscribeAutoResume)
+    }
     // Why: the startup get is a fallback; a live push may already include
     // system-default account snapshots that an older get result lacks.
     window.api.rateLimits.get().then((state) => {

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -8,7 +8,13 @@ import type {
   TerminalTab
 } from '../../../shared/types'
 
-export type WorktreeStatus = 'active' | 'working' | 'permission' | 'done' | 'inactive'
+export type WorktreeStatus =
+  | 'active'
+  | 'working'
+  | 'permission'
+  | 'rate-limited'
+  | 'done'
+  | 'inactive'
 
 type WorktreeStatusHeuristicOptions = {
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
@@ -20,6 +26,7 @@ const STATUS_LABELS: Record<WorktreeStatus, string> = {
   active: 'Active',
   working: 'Working',
   permission: 'Needs permission',
+  'rate-limited': 'Rate-limited',
   done: 'Done',
   inactive: 'Inactive'
 }
@@ -157,6 +164,7 @@ export function resolveWorktreeStatus(args: {
   hasLiveWorking: boolean
   hasLiveDone: boolean
   hasRetainedDone: boolean
+  hasRateLimited?: boolean
 }): WorktreeStatus {
   const heuristic = getWorktreeStatus(
     args.tabs,
@@ -185,6 +193,12 @@ export function resolveWorktreeStatus(args: {
   // Trust the fresh explicit working row so those cards stay yellow on restart.
   if (args.hasLiveWorking || heuristic === 'working') {
     return 'working'
+  }
+  // Why: a rate-limited (paused) agent outranks the passive done/active/inactive
+  // states so the card advertises that Orca is waiting to auto-resume it, but
+  // stays below permission/working which are more user-actionable / live.
+  if (args.hasRateLimited) {
+    return 'rate-limited'
   }
   if (args.hasLiveDone || args.hasRetainedDone) {
     return 'done'

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -22,6 +22,7 @@ import { createCodexUsageSlice } from './slices/codex-usage'
 import { createOpenCodeUsageSlice } from './slices/opencode-usage'
 import { createBrowserSlice } from './slices/browser'
 import { createRateLimitSlice } from './slices/rate-limits'
+import { createAutoResumeSlice } from './slices/auto-resume'
 import { createSshSlice } from './slices/ssh'
 import { createRuntimeEnvironmentSshSlice } from './slices/runtime-environment-ssh'
 import { createAgentStatusSlice } from './slices/agent-status'
@@ -63,6 +64,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createOpenCodeUsageSlice(...a),
   ...createBrowserSlice(...a),
   ...createRateLimitSlice(...a),
+  ...createAutoResumeSlice(...a),
   ...createSshSlice(...a),
   ...createRuntimeEnvironmentSshSlice(...a),
   ...createAgentStatusSlice(...a),

--- a/src/renderer/src/store/slices/auto-resume.ts
+++ b/src/renderer/src/store/slices/auto-resume.ts
@@ -3,7 +3,14 @@ import type {
   AgentAutoResumeEntry,
   AgentAutoResumeSnapshot
 } from '../../../../shared/agent-auto-resume-types'
+import { translate } from '@/i18n/i18n'
 import type { AppState } from '../types'
+
+// Keys as constants (not inline literals) so the localization catalog verifier
+// — which only statically checks literal keys — treats the English fallbacks as
+// authoritative, matching the settings-copy pattern.
+const RATE_LIMITED_WAITING_KEY = 'auto.lib.auto-resume.rate-limited-waiting'
+const RATE_LIMITED_RESUMES_KEY = 'auto.lib.auto-resume.rate-limited-resumes'
 
 // Why: the main-process AgentAutoResumeService pushes its full tracked-entry
 // list on every state change; the renderer just mirrors it and derives the
@@ -63,12 +70,12 @@ export function selectHasRateLimitedForWorktree(
  *  time is unknown (e.g. an unparsed banner or the wait-for-reset menu). */
 export function formatRateLimitedLabel(resumesAt: number | null): string {
   if (typeof resumesAt !== 'number' || !Number.isFinite(resumesAt)) {
-    return 'Rate-limited · waiting for reset'
+    return translate(RATE_LIMITED_WAITING_KEY, 'Rate-limited · waiting for reset')
   }
   try {
     const time = new Date(resumesAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-    return `Rate-limited · resumes ${time}`
+    return translate(RATE_LIMITED_RESUMES_KEY, 'Rate-limited · resumes {{time}}', { time })
   } catch {
-    return 'Rate-limited · waiting for reset'
+    return translate(RATE_LIMITED_WAITING_KEY, 'Rate-limited · waiting for reset')
   }
 }

--- a/src/renderer/src/store/slices/auto-resume.ts
+++ b/src/renderer/src/store/slices/auto-resume.ts
@@ -37,7 +37,7 @@ export function selectWorktreeRateLimitStatus(
 ): WorktreeRateLimitStatus {
   let hasRateLimited = false
   let resumesAt: number | null = null
-  for (const entry of state.autoResumeEntries) {
+  for (const entry of state.autoResumeEntries ?? []) {
     if (entry.worktreeId !== worktreeId) {
       continue
     }
@@ -56,7 +56,7 @@ export function selectHasRateLimitedForWorktree(
   state: Pick<AutoResumeSlice, 'autoResumeEntries'>,
   worktreeId: string
 ): boolean {
-  return state.autoResumeEntries.some((entry) => entry.worktreeId === worktreeId)
+  return (state.autoResumeEntries ?? []).some((entry) => entry.worktreeId === worktreeId)
 }
 
 /** "Rate-limited · resumes 3:50 PM", or "· waiting for reset" when the reset

--- a/src/renderer/src/store/slices/auto-resume.ts
+++ b/src/renderer/src/store/slices/auto-resume.ts
@@ -1,0 +1,74 @@
+import type { StateCreator } from 'zustand'
+import type {
+  AgentAutoResumeEntry,
+  AgentAutoResumeSnapshot
+} from '../../../../shared/agent-auto-resume-types'
+import type { AppState } from '../types'
+
+// Why: the main-process AgentAutoResumeService pushes its full tracked-entry
+// list on every state change; the renderer just mirrors it and derives the
+// card/status-bar surfaces from it.
+export type AutoResumeSlice = {
+  autoResumeEnabled: boolean
+  autoResumeEntries: AgentAutoResumeEntry[]
+  setAutoResumeSnapshot: (snapshot: AgentAutoResumeSnapshot) => void
+}
+
+export const createAutoResumeSlice: StateCreator<AppState, [], [], AutoResumeSlice> = (set) => ({
+  autoResumeEnabled: false,
+  autoResumeEntries: [],
+  setAutoResumeSnapshot: (snapshot) =>
+    set({ autoResumeEnabled: snapshot.enabled, autoResumeEntries: snapshot.entries })
+})
+
+export type WorktreeRateLimitStatus = {
+  hasRateLimited: boolean
+  /** Soonest planned resume for the worktree (ms epoch), or null if unknown. */
+  resumesAt: number | null
+}
+
+const NO_RATE_LIMIT: WorktreeRateLimitStatus = { hasRateLimited: false, resumesAt: null }
+
+/** Rate-limit summary for one worktree: whether any tracked agent in it is
+ *  paused, and the soonest planned resume time to display. */
+export function selectWorktreeRateLimitStatus(
+  state: Pick<AutoResumeSlice, 'autoResumeEntries'>,
+  worktreeId: string
+): WorktreeRateLimitStatus {
+  let hasRateLimited = false
+  let resumesAt: number | null = null
+  for (const entry of state.autoResumeEntries) {
+    if (entry.worktreeId !== worktreeId) {
+      continue
+    }
+    hasRateLimited = true
+    if (
+      typeof entry.resumesAt === 'number' &&
+      (resumesAt === null || entry.resumesAt < resumesAt)
+    ) {
+      resumesAt = entry.resumesAt
+    }
+  }
+  return hasRateLimited ? { hasRateLimited, resumesAt } : NO_RATE_LIMIT
+}
+
+export function selectHasRateLimitedForWorktree(
+  state: Pick<AutoResumeSlice, 'autoResumeEntries'>,
+  worktreeId: string
+): boolean {
+  return state.autoResumeEntries.some((entry) => entry.worktreeId === worktreeId)
+}
+
+/** "Rate-limited · resumes 3:50 PM", or "· waiting for reset" when the reset
+ *  time is unknown (e.g. an unparsed banner or the wait-for-reset menu). */
+export function formatRateLimitedLabel(resumesAt: number | null): string {
+  if (typeof resumesAt !== 'number' || !Number.isFinite(resumesAt)) {
+    return 'Rate-limited · waiting for reset'
+  }
+  try {
+    const time = new Date(resumesAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    return `Rate-limited · resumes ${time}`
+  } catch {
+    return 'Rate-limited · waiting for reset'
+  }
+}

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -20,6 +20,7 @@ import type { CodexUsageSlice } from './slices/codex-usage'
 import type { OpenCodeUsageSlice } from './slices/opencode-usage'
 import type { BrowserSlice } from './slices/browser'
 import type { RateLimitSlice } from './slices/rate-limits'
+import type { AutoResumeSlice } from './slices/auto-resume'
 import type { SshSlice } from './slices/ssh'
 import type { RuntimeEnvironmentSshSlice } from './slices/runtime-environment-ssh'
 import type { AgentStatusSlice } from './slices/agent-status'
@@ -58,6 +59,7 @@ export type AppState = RepoSlice &
   OpenCodeUsageSlice &
   BrowserSlice &
   RateLimitSlice &
+  AutoResumeSlice &
   SshSlice &
   RuntimeEnvironmentSshSlice &
   AgentStatusSlice &

--- a/src/shared/agent-auto-resume-types.ts
+++ b/src/shared/agent-auto-resume-types.ts
@@ -1,0 +1,41 @@
+// Why: shared vocabulary for the auto-resume feature so main (detection +
+// service) and renderer (status surfaces) agree on one contract. Kept separate
+// from RuntimeTerminalWaitBlockedReason on purpose: a usage-limit stall must
+// NOT be classified as a generic blocked/permission prompt (that would show a
+// rate-limited agent as "Needs permission" everywhere terminal.wait is
+// consumed), so it travels its own path with its own reason type.
+
+/** Providers whose usage-limit stalls v1 can auto-resume. Architecture stays
+ *  open for gemini/opencode later — add a provider + detection patterns. */
+export type UsageLimitProvider = 'claude' | 'codex'
+
+/** How the agent CLI is stuck on a provider usage limit.
+ *  - `usage-limit-menu`: an interactive blocking menu is up (Claude Code's
+ *    "Stop and wait for limit to reset" chooser). Needs a keypress.
+ *  - `usage-limit-banner`: the agent is idle at its prompt showing a limit
+ *    banner ("You've hit your session limit · resets 3:50pm"). Needs a resend. */
+export type UsageLimitStallReason = 'usage-limit-banner' | 'usage-limit-menu'
+
+/** Lifecycle of a tracked stall inside AgentAutoResumeService. */
+export type AgentAutoResumePhase = 'waiting' | 'acting' | 'resolved' | 'gave-up'
+
+/** One agent the service is tracking, as surfaced to the renderer. */
+export type AgentAutoResumeEntry = {
+  ptyId: string
+  worktreeId: string | null
+  paneKey: string | null
+  provider: UsageLimitProvider | null
+  reason: UsageLimitStallReason
+  /** When the service plans to act (ms epoch), or null while unknown. */
+  resumesAt: number | null
+  detectedAt: number
+  phase: AgentAutoResumePhase
+}
+
+/** Pushed to the renderer on every service state change (status bar + cards). */
+export type AgentAutoResumeSnapshot = {
+  enabled: boolean
+  entries: AgentAutoResumeEntry[]
+}
+
+export const AGENT_AUTO_RESUME_UPDATE_CHANNEL = 'agentAutoResume:update'

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -331,6 +331,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     tabAutoGenerateTitle: false,
     confirmClosePinnedTab: true,
     keepComputerAwakeWhileAgentsRun: false,
+    autoResumeRateLimitedAgents: false,
     // Why: 'auto' runs a layout-aware probe at boot (see
     // src/renderer/src/lib/keyboard-layout/*) that picks 'true' for US and
     // US-International and 'false' for every other layout. This mirrors

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2815,6 +2815,10 @@ export type GlobalSettings = {
   confirmClosePinnedTab: boolean
   /** When true, Orca requests local awake assertions while hook-reported agents are working. */
   keepComputerAwakeWhileAgentsRun: boolean
+  /** When true, Orca auto-resumes agents stalled on a provider usage limit:
+   *  waits for the limit to reset (or the configured idle grace for the
+   *  wait-for-reset menu) then resumes them. Opt-in, off by default. */
+  autoResumeRateLimitedAgents: boolean
   /** Why: macOS terminals must choose between letting Option compose layout
    *  characters (@ on German, € on French) or treating Option as Meta/Esc for
    *  readline shortcuts. Mirrors Ghostty's macos-option-as-alt setting — and


### PR DESCRIPTION
## Summary

Opt-in (off by default) auto-resume for agents stalled on a provider usage limit. When Claude Code or Codex hits its limit — an idle banner or a blocking wait-for-reset menu — Orca detects it on the **live PTY output** (never terminal-history files) and resumes the agent once the limit resets, replacing the flaky external cron (stale banner matches, content-hash blind spots, 30-min polling blackouts).

- **Detection** (`usage-limit-stall-detection.ts` + runtime per-chunk tail scan): matches Claude's banner/menu (whitespace/case-tolerant for collapsed PTY renders) and Codex's `You've hit your usage limit … or try again at <date>`. Returns the latest match and anchors reset parsing to the newest banner so a second limit event re-arms correctly. A dedicated `UsageLimitStallReason` keeps rate-limited agents from being misclassified as needing permission.
- **`AgentAutoResumeService`**: menu → wait the configured agent idle grace, re-verify, press Enter ("Stop and wait for limit to reset"); banner → wait `max(banner, provider resetsAt) + 90s`, re-verify the banner is still live, resend `continue`, retry once then give up + notify; PTY-exit → notify. Dedups per PTY, caps attempts, clears on resume, never acts on stale data or pokes a working agent.
- **Setting**: `autoResumeRateLimitedAgents` (default **false**) in Settings → Agents.
- **UX**: amber "Rate-limited" worktree indicator, card label `Rate-limited · resumes 3:50pm`, status-bar segment `N paused · resumes …` (click focuses the worktree), native notifications; renderer state hydrated on startup via `agentAutoResume:get` and kept live via a push channel.

## Screenshots
This surfaces an amber hourglass worktree indicator when the session is stalled.
<img width="345" height="188" alt="image" src="https://github.com/user-attachments/assets/421e5223-220c-4ae6-9856-a48c18d4b89c" />

## Testing

- [x] `pnpm lint` (oxlint / reliability gates / max-lines ratchet pass; the only failure is a **pre-existing** `ja.json` localization-parity drift that also reproduces on `main` and is untouched by this PR)
- [x] `pnpm typecheck`
- [x] `pnpm test` (26,522 passed)
- [x] `pnpm build`
- [x] Added/updated tests: detection patterns (incl. Codex fixtures, collapsed-space menu, two-banner anchoring), reset parsing, per-chunk edge trigger, and the full service state machine with fake timers (grace, resetsAt fallback, re-verify, dedup, reason re-arm, retry cap + give-up, cleared/exit, opt-out teardown)

## AI Review Report

Reviewed with an AI coding agent (build + adversarial pass) plus CodeRabbit. Main risks checked: detection false positives/negatives on the live tail, timer/state-machine correctness, and re-arming across repeated limit events. It flagged — and this PR fixes — two real correctness bugs: (1) detection returned the *first* tail match, so a second limit event couldn't re-arm while the old banner was still retained; now returns the latest match, mirroring the blocked-reason signal. (2) Reset parsing read the oldest banner when two coexisted, risking an early resume; now anchored to the newest banner, with two-banner regression tests. Cross-platform: no hardcoded `metaKey`, no OS-specific paths; timers use `setTimeout`/`unref`; keystroke injection reuses the existing `terminal.send` path; the reset text carries no timezone so it resolves in the runtime host's zone and the service prefers the provider's structured `resets_at`.

## Security Audit

- **IPC**: one new read-only channel (`agentAutoResume:get`) returning a snapshot; one renderer push. No renderer-supplied input executed.
- **Command/keystroke execution**: resumes only ever inject a fixed `continue`/Enter into the already-authenticated agent terminal via the existing `sendTerminal` path — no shell command construction, no user/remote-controlled payload.
- **Input handling**: detection is pure regex over the PTY tail; reset parsing normalizes a matched date and `Date`-parses it (no eval). Feature is gated behind an opt-in setting (default off).
- No secrets, auth, or dependency changes.

## Notes

- Detection stays provider-pluggable (gemini/opencode can be added later); v1 covers Claude Code + Codex only.
- Non-goals: no per-repo/per-worktree overrides; dead-PTY case is notify-only (relaunch stays with the existing sleeping-agent resume path); no automations-subsystem changes.
- Manual test tooling (usage-limit simulator scripts) lives outside this repo.

## ELI5

Optional auto-resume watches live terminal output for Claude/Codex usage-limit stalls and restarts the agent when the limit resets. You do not need a flaky external cron; it stays off by default until you enable it.
