### PR TITLE
perf(mobile): send live terminal keystrokes as fire-and-forget binary frames

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -100,9 +100,10 @@ import {
 import { createTerminalLiveAccessoryInput } from '../../../../src/terminal/terminal-live-accessory-input'
 import { getTerminalLiveAccessoryRawSendTarget } from '../../../../src/terminal/terminal-live-accessory-raw-send-target'
 import {
+  TERMINAL_LIVE_INPUT_MAX_BYTES,
   clearTerminalLiveInputFocusTimer,
+  encodeTerminalLiveInputWithinByteLimit,
   focusTerminalLiveInputTarget,
-  isTerminalLiveInputWithinByteLimit,
   scheduleTerminalLiveInputFocus
 } from '../../../../src/terminal/terminal-live-input'
 import { dismissTerminalKeyboard } from '../../../../src/terminal/terminal-keyboard-dismiss'
@@ -3115,9 +3116,10 @@ export default function SessionScreen() {
       if (text.length === 0) {
         return false
       }
-      if (!isTerminalLiveInputWithinByteLimit(text)) {
+      const encodedText = encodeTerminalLiveInputWithinByteLimit(text)
+      if (!encodedText) {
         triggerError()
-        showToast('Input too large (max 256 KiB)', 1500)
+        showToast(`Input too large (max ${TERMINAL_LIVE_INPUT_MAX_BYTES / 1024} KiB)`, 1500)
         return false
       }
       const rpc = clientRef.current
@@ -3129,6 +3131,11 @@ export default function SessionScreen() {
         activeSessionTabTypeRef.current !== 'terminal'
       ) {
         return false
+      }
+      // Why: fire-and-forget binary frame — no RPC round-trip per keystroke.
+      // Falls back to terminal.send when the stream isn't routable (e.g. older hosts).
+      if (rpc.sendTerminalBinaryInput(handle, encodedText)) {
+        return true
       }
       return rpc
         .sendRequest('terminal.send', {

--- a/mobile/src/terminal/terminal-live-input.test.ts
+++ b/mobile/src/terminal/terminal-live-input.test.ts
@@ -6,8 +6,8 @@ import {
   defaultTerminalLiveInputHandles,
   filterTerminalLiveInputDefaultCandidates,
   focusTerminalLiveInputTarget,
+  encodeTerminalLiveInputWithinByteLimit,
   getTerminalLiveSpecialKeyBytes,
-  isTerminalLiveInputWithinByteLimit,
   pruneTerminalLiveInputHandles,
   scheduleTerminalLiveInputFocus,
   type TerminalLiveInputFocusTarget,
@@ -74,14 +74,21 @@ describe('terminal live input', () => {
   })
 
   it('enforces the paste-sized byte budget', () => {
-    expect(isTerminalLiveInputWithinByteLimit('hello')).toBe(true)
-    expect(isTerminalLiveInputWithinByteLimit('x'.repeat(TERMINAL_LIVE_INPUT_MAX_BYTES))).toBe(true)
-    expect(isTerminalLiveInputWithinByteLimit('x'.repeat(TERMINAL_LIVE_INPUT_MAX_BYTES + 1))).toBe(
-      false
+    expect(encodeTerminalLiveInputWithinByteLimit('hello')).toEqual(
+      new TextEncoder().encode('hello')
     )
     expect(
-      isTerminalLiveInputWithinByteLimit('é'.repeat(TERMINAL_LIVE_INPUT_MAX_BYTES / 2 + 1))
-    ).toBe(false)
+      encodeTerminalLiveInputWithinByteLimit('x'.repeat(TERMINAL_LIVE_INPUT_MAX_BYTES))
+    ).not.toBeNull()
+    expect(
+      encodeTerminalLiveInputWithinByteLimit('x'.repeat(TERMINAL_LIVE_INPUT_MAX_BYTES + 1))
+    ).toBeNull()
+    expect(
+      encodeTerminalLiveInputWithinByteLimit('é'.repeat(TERMINAL_LIVE_INPUT_MAX_BYTES / 2))
+    ).not.toBeNull()
+    expect(
+      encodeTerminalLiveInputWithinByteLimit('é'.repeat(TERMINAL_LIVE_INPUT_MAX_BYTES / 2 + 1))
+    ).toBeNull()
   })
 
   it('defaults first-seen terminal handles to live input once', () => {

--- a/mobile/src/terminal/terminal-live-input.ts
+++ b/mobile/src/terminal/terminal-live-input.ts
@@ -93,11 +93,14 @@ export function getTerminalLiveSpecialKeyBytes(key: string): string | null {
   return buildTerminalShortcutKey({ key: shortcutKey, modifiers: [] })?.bytes ?? null
 }
 
-export function isTerminalLiveInputWithinByteLimit(
+// Why: returns the encoded payload so the per-keystroke send path doesn't
+// UTF-8-encode the same text twice (once to check, once to transmit).
+export function encodeTerminalLiveInputWithinByteLimit(
   text: string,
   maxBytes = TERMINAL_LIVE_INPUT_MAX_BYTES
-): boolean {
-  return encoder.encode(text).byteLength <= maxBytes
+): Uint8Array | null {
+  const encoded = encoder.encode(text)
+  return encoded.byteLength <= maxBytes ? encoded : null
 }
 
 export function defaultTerminalLiveInputHandles(

--- a/mobile/src/transport/e2ee.ts
+++ b/mobile/src/transport/e2ee.ts
@@ -73,7 +73,7 @@ export function decrypt(encrypted: string, sharedKey: Uint8Array): string | null
   return plaintext ? new TextDecoder().decode(plaintext) : null
 }
 
-function encryptBytes(plaintext: Uint8Array, sharedKey: Uint8Array): Uint8Array {
+export function encryptBytes(plaintext: Uint8Array, sharedKey: Uint8Array): Uint8Array {
   const nonce = u8(nacl.randomBytes(nacl.box.nonceLength))
   const ciphertext = nacl.box.after(u8(plaintext), nonce, u8(sharedKey))
 

--- a/mobile/src/transport/rpc-client-terminal-binary-input.test.ts
+++ b/mobile/src/transport/rpc-client-terminal-binary-input.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { connect } from './rpc-client'
+import { TerminalStreamOpcode } from './terminal-stream-protocol'
+import {
+  MockWebSocket,
+  authenticateMockSocket,
+  mockSockets,
+  receiveTerminalSubscribed,
+  sentRequest,
+  subscribeTerminalStream
+} from './rpc-client-test-mock-websocket'
+
+vi.mock('./e2ee', () => ({
+  generateKeyPair: () => ({
+    publicKey: new Uint8Array(32),
+    secretKey: new Uint8Array(32)
+  }),
+  deriveSharedKey: () => new Uint8Array(32),
+  publicKeyFromBase64: () => new Uint8Array(32),
+  publicKeyToBase64: () => 'client-public-key',
+  encrypt: (plaintext: string) => `encrypted:${plaintext}`,
+  decrypt: (raw: string) => raw.replace(/^encrypted:/, ''),
+  decryptBytes: (bytes: Uint8Array) => bytes,
+  encryptBytes: (bytes: Uint8Array) => bytes
+}))
+
+const originalWebSocket = globalThis.WebSocket
+
+function lastBinaryFrameStreamId(socket: MockWebSocket): number {
+  const lastSent = socket.sent[socket.sent.length - 1]!
+  expect(typeof lastSent).not.toBe('string')
+  const frame = new Uint8Array(lastSent as ArrayBuffer)
+  return new DataView(frame.buffer, frame.byteOffset, frame.byteLength).getUint32(4, true)
+}
+
+describe('mobile rpc-client terminal binary input', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockSockets.length = 0
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.WebSocket = originalWebSocket
+  })
+
+  it('sends terminal binary input as an encrypted Input frame on the subscribed stream', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = mockSockets[0]!
+    authenticateMockSocket(socket)
+    subscribeTerminalStream(client, socket, 'term-1', 42)
+
+    expect(client.sendTerminalBinaryInput('term-1', new TextEncoder().encode('ab'))).toBe(true)
+
+    const lastSent = socket.sent[socket.sent.length - 1]!
+    expect(typeof lastSent).not.toBe('string')
+    const frame = new Uint8Array(lastSent as ArrayBuffer)
+    const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength)
+    expect(view.getUint8(0)).toBe(0x74)
+    expect(view.getUint8(2)).toBe(TerminalStreamOpcode.Input)
+    expect(view.getUint32(4, true)).toBe(42)
+    expect(new TextDecoder().decode(frame.slice(16))).toBe('ab')
+
+    client.close()
+  })
+
+  it('refuses terminal binary input for a terminal that was never subscribed', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = mockSockets[0]!
+    authenticateMockSocket(socket)
+
+    const sentBefore = socket.sent.length
+    expect(client.sendTerminalBinaryInput('term-1', new TextEncoder().encode('ab'))).toBe(false)
+    expect(socket.sent.length).toBe(sentBefore)
+
+    client.close()
+  })
+
+  it('refuses terminal binary input when the host subscribes without a streamId (older host)', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = mockSockets[0]!
+    authenticateMockSocket(socket)
+    // Why: hosts predating the binary stream protocol emit subscribed with no
+    // streamId, so nothing registers and input must stay on the RPC path.
+    subscribeTerminalStream(client, socket, 'term-1')
+
+    const sentBefore = socket.sent.length
+    expect(client.sendTerminalBinaryInput('term-1', new TextEncoder().encode('ab'))).toBe(false)
+    expect(socket.sent.length).toBe(sentBefore)
+
+    client.close()
+  })
+
+  it('refuses terminal binary input after reconnect until the stream is resubscribed', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const firstSocket = mockSockets[0]!
+    authenticateMockSocket(firstSocket)
+    subscribeTerminalStream(client, firstSocket, 'term-1', 42)
+    expect(client.sendTerminalBinaryInput('term-1', new TextEncoder().encode('a'))).toBe(true)
+    expect(lastBinaryFrameStreamId(firstSocket)).toBe(42)
+
+    firstSocket.close()
+    vi.advanceTimersByTime(500)
+    const secondSocket = mockSockets[1]!
+    authenticateMockSocket(secondSocket)
+
+    // Why: reconnect clears the routing maps; sends must fail (→ RPC fallback)
+    // until the replayed subscribe delivers a fresh streamId.
+    expect(client.sendTerminalBinaryInput('term-1', new TextEncoder().encode('b'))).toBe(false)
+
+    const replay = sentRequest(secondSocket, 'terminal.subscribe')
+    receiveTerminalSubscribed(secondSocket, replay.id, 43)
+    expect(client.sendTerminalBinaryInput('term-1', new TextEncoder().encode('c'))).toBe(true)
+    expect(lastBinaryFrameStreamId(secondSocket)).toBe(43)
+
+    client.close()
+  })
+})

--- a/mobile/src/transport/rpc-client-terminal-subscription.ts
+++ b/mobile/src/transport/rpc-client-terminal-subscription.ts
@@ -31,6 +31,40 @@ export function updateTerminalSubscriptionViewport(
   }
 }
 
+// Why: resolves a terminal handle to its live binary streamId from the rpc
+// client's per-connection routing maps, so callers never track raw streamIds.
+export function findRoutableTerminalStreamId(
+  streams: ReadonlyMap<string, MutableStreamRequest>,
+  terminalStreamIdsByRequest: ReadonlyMap<string, ReadonlySet<number>>,
+  routableStreamIds: ReadonlyMap<number, unknown>,
+  terminal: string
+): number | null {
+  for (const [requestId, streamIds] of terminalStreamIdsByRequest) {
+    const stream = streams.get(requestId)
+    if (
+      !stream ||
+      stream.method !== 'terminal.subscribe' ||
+      !stream.params ||
+      typeof stream.params !== 'object' ||
+      (stream.params as TerminalStreamParams).terminal !== terminal
+    ) {
+      continue
+    }
+    // Why: a request can accumulate ids across host-side resubscribes; the
+    // latest still-routable one is the live stream.
+    let latest: number | null = null
+    for (const streamId of streamIds) {
+      if (routableStreamIds.has(streamId)) {
+        latest = streamId
+      }
+    }
+    if (latest !== null) {
+      return latest
+    }
+  }
+  return null
+}
+
 export function buildTerminalUnsubscribeParams(
   params: unknown
 ): { subscriptionId: string; client?: { id: string } } | null {

--- a/mobile/src/transport/rpc-client-test-mock-websocket.ts
+++ b/mobile/src/transport/rpc-client-test-mock-websocket.ts
@@ -1,0 +1,142 @@
+// Why: shared WebSocket test double for the rpc-client test files. Kept out of
+// the spec files so each suite stays under the max-lines lint budget.
+import { vi } from 'vitest'
+import type { RpcClient } from './rpc-client'
+import { encodeTerminalStreamFrame, TerminalStreamOpcode } from './terminal-stream-protocol'
+
+export class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readonly CONNECTING = MockWebSocket.CONNECTING
+  readonly OPEN = MockWebSocket.OPEN
+  readonly CLOSING = MockWebSocket.CLOSING
+  readonly CLOSED = MockWebSocket.CLOSED
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: (() => void) | null = null
+  emitCloseOnClose = true
+  sent: (string | ArrayBuffer)[] = []
+  close = vi.fn(() => {
+    if (this.readyState === MockWebSocket.CLOSED) {
+      return
+    }
+    this.readyState = MockWebSocket.CLOSED
+    if (this.emitCloseOnClose) {
+      this.onclose?.()
+    }
+  })
+
+  constructor(readonly endpoint: string) {
+    mockSockets.push(this)
+  }
+
+  send(payload: string | ArrayBuffer): void {
+    this.sent.push(payload)
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  receive(payload: unknown): void {
+    this.onmessage?.({ data: payload })
+  }
+}
+
+export const mockSockets: MockWebSocket[] = []
+
+export function authenticateMockSocket(socket: MockWebSocket): void {
+  socket.open()
+  socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+  socket.receive('encrypted:{"type":"e2ee_authenticated"}')
+}
+
+export function receiveTerminalSubscribed(
+  socket: MockWebSocket,
+  requestId: string,
+  streamId?: number
+): void {
+  socket.receive(
+    `encrypted:${JSON.stringify({
+      id: requestId,
+      ok: true,
+      streaming: true,
+      result: streamId === undefined ? { type: 'subscribed' } : { type: 'subscribed', streamId }
+    })}`
+  )
+}
+
+export function subscribeTerminalStream(
+  client: RpcClient,
+  socket: MockWebSocket,
+  terminal: string,
+  streamId?: number
+): void {
+  client.subscribe('terminal.subscribe', { terminal }, () => {})
+  receiveTerminalSubscribed(socket, sentRequest(socket, 'terminal.subscribe').id, streamId)
+}
+
+export function sentRequest(
+  socket: MockWebSocket,
+  method: string
+): { id: string; params?: unknown } {
+  const [first] = sentRequests(socket, method)
+  if (!first) {
+    throw new Error(`Request not sent: ${method}`)
+  }
+  return first
+}
+
+export function sentRequests(
+  socket: MockWebSocket,
+  method: string
+): Array<{ id: string; params?: unknown }> {
+  const requests: Array<{ id: string; params?: unknown }> = []
+  for (const payload of socket.sent) {
+    if (typeof payload !== 'string') {
+      continue
+    }
+    const decoded = JSON.parse(payload.replace(/^encrypted:/, '')) as {
+      id: string
+      method: string
+      params?: unknown
+    }
+    if (decoded.method === method) {
+      requests.push({ id: decoded.id, params: decoded.params })
+    }
+  }
+  return requests
+}
+
+export function encodeBrowserFrame(): Uint8Array {
+  const metadata = new TextEncoder().encode(JSON.stringify({ deviceWidth: 800, deviceHeight: 600 }))
+  const image = new Uint8Array([1, 2, 3, 4])
+  const out = new Uint8Array(16 + metadata.byteLength + image.byteLength)
+  const view = new DataView(out.buffer)
+  view.setUint8(0, 0x62)
+  view.setUint8(1, 1)
+  view.setUint8(2, 1)
+  view.setUint8(3, 1)
+  view.setUint32(4, 7, true)
+  view.setUint32(8, metadata.byteLength, true)
+  view.setUint32(12, 0, true)
+  out.set(metadata, 16)
+  out.set(image, 16 + metadata.byteLength)
+  return out
+}
+
+export function encodeTerminalOutput(streamId: number, chunk: string): Uint8Array {
+  return encodeTerminalStreamFrame({
+    opcode: TerminalStreamOpcode.Output,
+    streamId,
+    seq: 1,
+    payload: new TextEncoder().encode(chunk)
+  })
+}

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { connect } from './rpc-client'
-import { encodeTerminalStreamFrame, TerminalStreamOpcode } from './terminal-stream-protocol'
+import {
+  encodeBrowserFrame,
+  encodeTerminalOutput,
+  MockWebSocket,
+  mockSockets,
+  sentRequest,
+  sentRequests
+} from './rpc-client-test-mock-websocket'
 
 vi.mock('./e2ee', () => ({
   generateKeyPair: () => ({
@@ -12,115 +19,11 @@ vi.mock('./e2ee', () => ({
   publicKeyToBase64: () => 'client-public-key',
   encrypt: (plaintext: string) => `encrypted:${plaintext}`,
   decrypt: (raw: string) => (raw === 'undecryptable' ? null : raw.replace(/^encrypted:/, '')),
-  decryptBytes: (bytes: Uint8Array) => bytes
+  decryptBytes: (bytes: Uint8Array) => bytes,
+  encryptBytes: (bytes: Uint8Array) => bytes
 }))
 
-class MockWebSocket {
-  static CONNECTING = 0
-  static OPEN = 1
-  static CLOSING = 2
-  static CLOSED = 3
-
-  readonly CONNECTING = MockWebSocket.CONNECTING
-  readonly OPEN = MockWebSocket.OPEN
-  readonly CLOSING = MockWebSocket.CLOSING
-  readonly CLOSED = MockWebSocket.CLOSED
-
-  readyState = MockWebSocket.CONNECTING
-  onopen: (() => void) | null = null
-  onclose: (() => void) | null = null
-  onmessage: ((event: { data: unknown }) => void) | null = null
-  onerror: (() => void) | null = null
-  emitCloseOnClose = true
-  sent: string[] = []
-  close = vi.fn(() => {
-    if (this.readyState === MockWebSocket.CLOSED) {
-      return
-    }
-    this.readyState = MockWebSocket.CLOSED
-    if (this.emitCloseOnClose) {
-      this.onclose?.()
-    }
-  })
-
-  constructor(readonly endpoint: string) {
-    mockSockets.push(this)
-  }
-
-  send(payload: string): void {
-    this.sent.push(payload)
-  }
-
-  open(): void {
-    this.readyState = MockWebSocket.OPEN
-    this.onopen?.()
-  }
-
-  receive(payload: unknown): void {
-    this.onmessage?.({ data: payload })
-  }
-}
-
-const mockSockets: MockWebSocket[] = []
 const originalWebSocket = globalThis.WebSocket
-
-function sentRequest(socket: MockWebSocket, method: string): { id: string; params?: unknown } {
-  for (const payload of socket.sent) {
-    const decoded = JSON.parse(payload.replace(/^encrypted:/, '')) as {
-      id: string
-      method: string
-      params?: unknown
-    }
-    if (decoded.method === method) {
-      return { id: decoded.id, params: decoded.params }
-    }
-  }
-  throw new Error(`Request not sent: ${method}`)
-}
-
-function sentRequests(
-  socket: MockWebSocket,
-  method: string
-): Array<{ id: string; params?: unknown }> {
-  const requests: Array<{ id: string; params?: unknown }> = []
-  for (const payload of socket.sent) {
-    const decoded = JSON.parse(payload.replace(/^encrypted:/, '')) as {
-      id: string
-      method: string
-      params?: unknown
-    }
-    if (decoded.method === method) {
-      requests.push({ id: decoded.id, params: decoded.params })
-    }
-  }
-  return requests
-}
-
-function encodeBrowserFrame(): Uint8Array {
-  const metadata = new TextEncoder().encode(JSON.stringify({ deviceWidth: 800, deviceHeight: 600 }))
-  const image = new Uint8Array([1, 2, 3, 4])
-  const out = new Uint8Array(16 + metadata.byteLength + image.byteLength)
-  const view = new DataView(out.buffer)
-  view.setUint8(0, 0x62)
-  view.setUint8(1, 1)
-  view.setUint8(2, 1)
-  view.setUint8(3, 1)
-  view.setUint32(4, 7, true)
-  view.setUint32(8, metadata.byteLength, true)
-  view.setUint32(12, 0, true)
-  out.set(metadata, 16)
-  out.set(image, 16 + metadata.byteLength)
-  return out
-}
-
-function encodeTerminalOutput(streamId: number, chunk: string): Uint8Array {
-  return encodeTerminalStreamFrame({
-    opcode: TerminalStreamOpcode.Output,
-    streamId,
-    seq: 1,
-    payload: new TextEncoder().encode(chunk)
-  })
-}
 
 describe('mobile rpc-client connection timeout', () => {
   beforeEach(() => {

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -12,18 +12,21 @@ import {
   publicKeyToBase64,
   encrypt,
   decrypt,
-  decryptBytes
+  decryptBytes,
+  encryptBytes
 } from './e2ee'
 import {
   handleTerminalBinaryFrame,
   type TerminalSnapshotState
 } from './rpc-client-terminal-binary-frame'
+import { encodeTerminalStreamFrame, TerminalStreamOpcode } from './terminal-stream-protocol'
 import {
   decodeBrowserScreencastFrame,
   type BrowserScreencastFrame
 } from './browser-screencast-protocol'
 import {
   buildTerminalUnsubscribeParams,
+  findRoutableTerminalStreamId,
   updateTerminalSubscriptionViewport as updateCachedTerminalSubscriptionViewport
 } from './rpc-client-terminal-subscription'
 import { describeSocketEvent } from './socket-event-debug'
@@ -77,6 +80,9 @@ export type RpcClient = {
     terminal: string,
     viewport: { cols: number; rows: number }
   ) => void
+  // Why: fire-and-forget keystroke path — no RPC round-trip per key. Returns
+  // false when no routable binary stream exists; callers fall back to the RPC.
+  sendTerminalBinaryInput: (terminal: string, payload: Uint8Array) => boolean
   getState: () => ConnectionState
   // Why: UI escalates "Reconnecting…" to "Can't connect" once attempts cross
   // a threshold. 0 means never failed; counter is reset on successful open.
@@ -208,6 +214,7 @@ export function connect(
   const terminalStreamListeners = new Map<number, StreamingListener>()
   const terminalStreamIdsByRequest = new Map<string, Set<number>>()
   const terminalSnapshots = new Map<number, TerminalSnapshotState>()
+  let terminalBinaryInputSeq = 0
   let activeBrowserScreencastRequestId: string | null = null
   let pendingBrowserScreencastRequestId: string | null = null
   const stateListeners = new Set<(state: ConnectionState) => void>()
@@ -1158,6 +1165,31 @@ export function connect(
       viewport: { cols: number; rows: number }
     ): void {
       updateCachedTerminalSubscriptionViewport(streamListeners.values(), terminal, viewport)
+    },
+
+    sendTerminalBinaryInput(terminal: string, payload: Uint8Array): boolean {
+      // Why: the routing maps are per-connection state (cleared on reconnect
+      // and stream end), so a hit proves the host can route this frame.
+      const streamId = findRoutableTerminalStreamId(
+        streamListeners,
+        terminalStreamIdsByRequest,
+        terminalStreamListeners,
+        terminal
+      )
+      if (streamId === null) {
+        return false
+      }
+      if (!ws || ws.readyState !== WebSocket.OPEN || !sharedKey) {
+        return false
+      }
+      const frame = encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.Input,
+        streamId,
+        seq: terminalBinaryInputSeq++,
+        payload
+      })
+      ws.send(encryptBytes(frame, sharedKey).buffer as ArrayBuffer)
+      return true
     },
 
     getState(): ConnectionState {

--- a/mobile/src/transport/terminal-stream-protocol.ts
+++ b/mobile/src/transport/terminal-stream-protocol.ts
@@ -9,6 +9,9 @@ export enum TerminalStreamOpcode {
   SnapshotEnd = 4,
   Resized = 5,
   Error = 6,
+  // Why: outbound-only fire-and-forget keystrokes; never arrives inbound, so
+  // the decoder's opcode validation below intentionally omits it.
+  Input = 7,
   Metadata = 12
 }
 


### PR DESCRIPTION
## Summary

Typing in a workspace terminal from the mobile app (e.g. a tab running `claude` or `codex`) felt laggy. Every keystroke was sent as a `terminal.send` JSON RPC, and the client chained each send on the previous response — keystroke N+1 was not even transmitted until keystroke N's round trip completed, so perceived latency compounded with the network RTT while typing. The capture field is invisible (no local echo), so 100% of that latency was user-visible.

This PR switches live terminal input to the binary `Input` frame (opcode 7) of the existing terminal stream protocol — fire-and-forget over the same E2EE WebSocket, ordered by the socket itself. The host already handles this opcode on `terminal.subscribe` binary streams (including the input-lock check and `mobileTookFloor`), so **no host changes are needed**. When the binary stream is not routable (pre-subscribe, mid-reconnect, hosts older than the binary stream protocol), the client transparently falls back to the `terminal.send` RPC.

### Measurements

Keystroke → PTY echo rendered, measured with a temporary probe (removed before commit) on the iOS Simulator paired with a source-built host runtime over loopback — the worst case for showing the win, since network RTT ≈ 0:

| | RPC path (before) | Binary Input frame (after) |
|---|---|---|
| Average | 46–54 ms | **27–29 ms** |
| p50 | 50–58 ms | **26 ms** |
| Worst key in a fast burst | 79–90 ms (queue buildup) | **30 ms (flat)** |

The before-numbers show the stop-and-wait signature: within a fast burst, early keys waited 79–90 ms and latency decayed down the queue (90→59→58→27…). The binary path stays flat for every key. On a real device over Wi-Fi the improvement is larger, since the old path paid a full round trip per keystroke before the next one could be transmitted; Enter also drops from two serialized round trips (flush wait + control send) to two ordered frames.

Validated end-to-end in the simulator against live `zsh` and Claude Code sessions: the PTY buffer received the typed sequence exactly and in order, Enter executed commands, and the RPC fallback path still works (exercised as the baseline).

## Screenshots

No visual change (transport/latency only; the terminal UI is unchanged).

## Testing

- [x] `pnpm lint` — passes for this change; the only failure is a pre-existing `ja.json` locale-parity mismatch on `components.native-chat.composer.uploadingAttachments` (desktop native-chat key, unrelated — no locale files touched here)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 26,491 passed; mobile suite (`mobile && pnpm test`) 1,317 passed; `mobile && npx tsc --noEmit` clean
- [x] `pnpm build` — `build:cli` + `build:electron-vite` (used to produce the host runtime the change was validated against end-to-end)
- [x] Added tests in `rpc-client-terminal-binary-input.test.ts`: correct encrypted `Input` frame encoding on the subscribed stream, refusal for a terminal that was never subscribed, refusal when an older host subscribes without a `streamId` (pre-binary-stream hosts stay on the RPC path), and refusal after reconnect until resubscribe — including that post-resubscribe frames carry the new `streamId`. The shared `MockWebSocket` harness was extracted to `rpc-client-test-mock-websocket.ts` so both spec files stay under the max-lines budget (no suppressions added).

## AI Review Report

Main risks checked during review:

- **Keystroke ordering.** Binary frames ride the same WebSocket, which guarantees ordered delivery. Host-side, the existing `Input` handler feeds `runtime.sendTerminal` exactly as the desktop `terminal.multiplex` path already does per frame; keystroke-sized payloads traverse identical await chains, so PTY writes stay FIFO. At the binary→RPC fallback boundary, the client's existing send chain still serializes send initiation, and the RPC only resolves after the host write — no reorder window.
- **Reconnect staleness (silent input loss).** A stale stream after reconnect would route to nothing on the host. `sendTerminalBinaryInput` takes the terminal handle and resolves the live `streamId` from the client's per-connection routing maps (cleared on reconnect and stream end) — no raw `streamId` crosses the API boundary, so callers can't hold a stale one. When nothing routable resolves it refuses, which flips callers to the RPC fallback. Covered by a dedicated test.
- **Old-host compatibility.** The client only goes binary after receiving a numeric `streamId` in the `subscribed` event, which hosts emit only for binary streams. The `terminalBinaryStream` capability and the `Input` opcode handler landed in the same host commit, so any host that emits a binary `streamId` also consumes `Input` frames; older hosts keep the RPC path.
- **Input lock / floor semantics.** The host binary path already enforces `isTerminalInputLockedForClient` and fires `mobileTookFloor`, matching `terminal.send`. Behavior difference: a locked terminal silently drops binary input instead of returning `accepted: false`; live typing already surfaces lock state through other channels, and control-key gating no longer blocks on it.
- **Cross-platform (macOS/Linux/Windows, SSH).** Mobile-only change; the React Native code path is identical on iOS and Android. No shortcuts, labels, file paths, or shell behavior touched. The host is untouched, so macOS/Linux/Windows and SSH/remote-host scenarios flow through the same already-shipped handler. Frame encoding uses explicit little-endian `DataView` writes (no platform-dependent byte order).

## Security Audit

- **Input handling.** Payloads are UTF-8 text produced by the existing normalization pipeline and remain subject to the client-side 256 KiB live-input cap; the host-side `Input` handler decodes text and routes through `runtime.sendTerminal`, which enforces the existing 16 MiB limit and PTY chunking. No new parsing surface on the host — the opcode and handler already shipped.
- **Encryption/auth.** Binary frames use the same per-connection E2EE channel (Curve25519 ECDH + XSalsa20-Poly1305) as all other traffic — `encryptBytes` was already used for inbound binary; this PR only exports it for outbound use. The host drops binary messages from unauthenticated channels (`state !== 'ready'`), and frames only route to handlers registered by the device's own authenticated subscription.
- **No command execution, path handling, dependency, or IPC changes.** No new RPC methods (nothing added to `MOBILE_RPC_METHOD_ALLOWLIST`); no secrets touched.
- **Follow-up:** none identified.

## Notes

- Loopback is the worst case for demonstrating the gain; on real Wi-Fi the RTT-per-keystroke elimination dominates. If useful, a network-link-conditioner A/B on a physical device can quantify it further.
- The trade-off of fire-and-forget: no per-key ack, so a send onto a locked terminal is silently ignored rather than reported (`accepted: false`). Connection loss still flips to the RPC fallback via the routing check, so input is not silently dropped in the common failure mode.
- Larger follow-up ideas discussed but out of scope: predictive local echo (mosh-style) and a native terminal renderer.

https://claude.ai/code/session_01G5UBu5U2AYWsnnjXdzu4td

## ELI5

Typing in a remote terminal from the mobile app felt laggy because every key waited for the previous RPC round trip. Live keystrokes now go as fire-and-forget binary frames so typing stays snappy over the network.
