### PR TITLE
STA-1598: Prevent duplicate TOML project keys from breaking Codex startup

### DIFF
--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -314,6 +314,170 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     expect(runtimeConfig.match(/\[projects\."\/repo"\]/g)?.length).toBe(1)
   })
 
+  it('deduplicates basic and literal project headers by decoded Windows path', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      ["[projects.'c:\\gemini_etl']", 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      ['[projects."c:\\\\gemini_etl"]', 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/\[projects\./g)).toHaveLength(1)
+    expect(runtimeConfig).toContain("[projects.'c:\\gemini_etl']")
+  })
+
+  it('lets a semantically matching system revocation replace runtime trust', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      ["[projects.'c:\\gemini_etl']", 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      ['[projects."C:/gemini_etl"]', 'trust_level = "untrusted"', ''].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/\[projects\./g)).toHaveLength(1)
+    expect(runtimeConfig).toContain('[projects."C:/gemini_etl"]')
+    expect(runtimeConfig).toContain('trust_level = "untrusted"')
+    expect(runtimeConfig).not.toContain('trust_level = "trusted"')
+  })
+
+  it.each([
+    {
+      name: 'drive-letter casing and separators',
+      runtimePath: 'c:\\work\\repo',
+      systemPath: 'C:/work/repo'
+    },
+    {
+      name: 'WSL UNC path',
+      runtimePath: '\\\\wsl$\\Ubuntu\\home\\u\\proj',
+      systemPath: '//WSL$/ubuntu/home/u/proj'
+    },
+    {
+      name: 'server UNC path',
+      runtimePath: '\\\\server\\share\\proj',
+      systemPath: '//SERVER/share/proj'
+    }
+  ])('deduplicates $name across mirror inputs', ({ runtimePath, systemPath }) => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [`[projects.'${runtimePath}']`, 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      [`[projects."${systemPath}"]`, 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readFileSync(getRuntimeConfigPath(), 'utf-8').match(/\[projects\./g)).toHaveLength(1)
+  })
+
+  it('self-heals duplicate project tables already present in the runtime config', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [
+        '[projects."c:\\\\gemini_etl"]',
+        'trust_level = "trusted"',
+        '',
+        "[projects.'c:\\gemini_etl']",
+        'trust_level = "trusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(getSystemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/\[projects\./g)).toHaveLength(1)
+    expect(runtimeConfig).toContain('[projects."c:\\\\gemini_etl"]')
+  })
+
+  it('keeps untrusted when self-healing duplicate project tables', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [
+        '[projects."c:\\\\gemini_etl"]',
+        'trust_level = "trusted"',
+        '',
+        "[projects.'C:\\gemini_etl']",
+        'trust_level = "untrusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(getSystemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/\[projects\./g)).toHaveLength(1)
+    expect(runtimeConfig).toContain('trust_level = "untrusted"')
+    expect(runtimeConfig).not.toContain('trust_level = "trusted"')
+  })
+
+  it('keeps untrusted when self-healing duplicate system project tables', () => {
+    writeFileSync(
+      getSystemConfigPath(),
+      [
+        '[projects."c:\\\\gemini_etl"]',
+        'trust_level = "trusted"',
+        '',
+        "[projects.'C:\\gemini_etl']",
+        'trust_level = "untrusted"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/\[projects\./g)).toHaveLength(1)
+    expect(runtimeConfig).toContain('trust_level = "untrusted"')
+    expect(runtimeConfig).not.toContain('trust_level = "trusted"')
+  })
+
+  it('deduplicates a POSIX project path containing a quote and backslash', () => {
+    const projectPath = '/tmp/with"quote\\and-backslash'
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [`[projects.'${projectPath}']`, 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      [`[projects."/tmp/with\\"quote\\\\and-backslash"]`, 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readFileSync(getRuntimeConfigPath(), 'utf-8').match(/\[projects\./g)).toHaveLength(1)
+  })
+
   it('does not treat TOML table headers inside multiline strings as sections', () => {
     mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
     writeFileSync(

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -15,6 +15,10 @@ import {
   isTomlStructuralLine,
   updateTomlLineScanState
 } from './config-toml-line-scan'
+import {
+  normalizeCodexProjectPathForLookup,
+  parseCodexProjectHeaderPath
+} from './config-toml-trust'
 
 export function syncSystemConfigIntoManagedCodexHome(
   homes: CodexSettingsPromotionHomes = {
@@ -160,14 +164,14 @@ function normalizeFeatureSectionLines(lines: string[], start: number, end: numbe
 }
 
 function mergeSystemCodexConfigIntoRuntime(runtimeConfig: string, systemConfig: string): string {
-  const runtimeSections = getTomlSections(runtimeConfig)
+  const runtimeSections = deduplicateProjectTomlSections(getTomlSections(runtimeConfig))
   const runtimeProjectHeaders = new Set(
     runtimeSections
       .filter((section) => isRuntimeProjectTomlSection(section.header))
       .map((section) => getTomlSectionHeaderKey(section.header))
   )
   const systemUntrustedProjectHeaders = new Set(
-    getTomlSections(systemConfig)
+    deduplicateProjectTomlSections(getTomlSections(systemConfig))
       .filter((section) => isRuntimeProjectTomlSection(section.header))
       .filter((section) => getProjectTrustLevel(section.block) === 'untrusted')
       .map((section) => getTomlSectionHeaderKey(section.header))
@@ -200,8 +204,9 @@ function stripRuntimeOwnedTomlSections(
   runtimeProjectHeaders = new Set<string>()
 ): string {
   const lines = config.split('\n')
-  const sections = getTomlSections(config)
-  const firstSectionIndex = sections[0]?.start ?? -1
+  const sourceSections = getTomlSections(config)
+  const sections = deduplicateProjectTomlSections(sourceSections)
+  const firstSectionIndex = sourceSections[0]?.start ?? -1
   const preamble = firstSectionIndex === -1 ? config : lines.slice(0, firstSectionIndex).join('\n')
   return joinTomlBlocks([
     preamble,
@@ -262,11 +267,44 @@ function isRuntimeHookTrustTomlSection(header: string): boolean {
 }
 
 function isRuntimeProjectTomlSection(header: string): boolean {
-  return header.trimStart().startsWith('[projects.')
+  return parseCodexProjectHeaderPath(header) !== null
 }
 
 function getTomlSectionHeaderKey(header: string): string {
-  return header.trim()
+  const projectPath = parseCodexProjectHeaderPath(header)
+  return projectPath === null
+    ? header.trim()
+    : `project:${normalizeCodexProjectPathForLookup(projectPath)}`
+}
+
+// Why: hook upsert already removes both quote representations, while its paired
+// Windows slash variants are required for Codex 0.140 and must remain distinct.
+function deduplicateProjectTomlSections(sections: TomlSection[]): TomlSection[] {
+  const deduplicated: TomlSection[] = []
+  const projectIndexes = new Map<string, number>()
+  for (const section of sections) {
+    if (!isRuntimeProjectTomlSection(section.header)) {
+      deduplicated.push(section)
+      continue
+    }
+    const key = getTomlSectionHeaderKey(section.header)
+    const existingIndex = projectIndexes.get(key)
+    if (existingIndex === undefined) {
+      projectIndexes.set(key, deduplicated.length)
+      deduplicated.push(section)
+      continue
+    }
+    const existing = deduplicated[existingIndex]
+    if (
+      existing &&
+      getProjectTrustLevel(existing.block) !== 'untrusted' &&
+      getProjectTrustLevel(section.block) === 'untrusted'
+    ) {
+      // Why: revocation must survive self-healing regardless of duplicate order.
+      deduplicated[existingIndex] = section
+    }
+  }
+  return deduplicated
 }
 
 function getProjectTrustLevel(block: string): 'trusted' | 'untrusted' | null {

--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -1108,6 +1108,60 @@ describe('upsertProjectTrustLevel', () => {
     expect(updated).not.toContain('trust_level = "untrusted"')
   })
 
+  it('updates a Codex literal-string Windows project block without duplicating it', () => {
+    const original = ["[projects.'c:\\gemini_etl']", 'trust_level = "untrusted"', ''].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, 'c:\\gemini_etl', 'trusted', {
+      alreadyCanonical: true
+    })
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(1)
+    expect(updated).toContain("[projects.'c:\\gemini_etl']")
+    expect(updated).toContain('trust_level = "trusted"')
+    expect(updated).not.toContain('[projects."c:\\\\gemini_etl"]')
+  })
+
+  it.each([
+    {
+      name: 'drive-letter casing and separators',
+      existingPath: 'c:\\work\\repo',
+      incomingPath: 'C:/work/repo'
+    },
+    {
+      name: 'WSL UNC path casing and separators',
+      existingPath: '\\\\wsl$\\Ubuntu\\home\\u\\proj',
+      incomingPath: '//WSL$/ubuntu/home/u/proj'
+    },
+    {
+      name: 'server UNC path casing and separators',
+      existingPath: '\\\\server\\share\\proj',
+      incomingPath: '//SERVER/share/proj'
+    }
+  ])('matches $name by decoded Windows path value', ({ existingPath, incomingPath }) => {
+    const original = [`[projects.'${existingPath}']`, 'trust_level = "untrusted"', ''].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, incomingPath, 'trusted', {
+      alreadyCanonical: true
+    })
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(1)
+    expect(updated).toContain(`[projects.'${existingPath}']`)
+    expect(updated).toContain('trust_level = "trusted"')
+  })
+
+  it('matches a literal-string POSIX project path containing a quote and backslash', () => {
+    const projectPath = '/tmp/with"quote\\and-backslash'
+    const original = [`[projects.'${projectPath}']`, 'trust_level = "untrusted"', ''].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, projectPath, 'trusted', {
+      alreadyCanonical: true
+    })
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(1)
+    expect(updated).toContain(`[projects.'${projectPath}']`)
+    expect(updated).toContain('trust_level = "trusted"')
+  })
+
   it('preserves an already-canonical remote Windows project path', () => {
     // Why: SSH project paths are resolved on the remote; local realpath would
     // canonicalize the wrong machine if the same path happens to exist locally.

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -9,7 +9,6 @@ import {
 } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
-import { escapeRegex } from '../../shared/string-utils'
 import { copyFileWithWindowsRetry, renameFileWithWindowsRetry } from '../codex-accounts/fs-utils'
 import {
   createTomlLineScanState,
@@ -202,7 +201,19 @@ function normalizeWindowsPathSeparators(sourcePath: string): string {
 }
 
 function usesWindowsPathSeparators(sourcePath: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(sourcePath) || sourcePath.startsWith('\\\\')
+  return (
+    /^[A-Za-z]:[\\/]/.test(sourcePath) ||
+    sourcePath.startsWith('\\\\') ||
+    sourcePath.startsWith('//')
+  )
+}
+
+// Why: Codex and Orca can disagree on quote style, separators, and casing for
+// the same Windows project, including when the caller targets a remote host.
+export function normalizeCodexProjectPathForLookup(projectPath: string): string {
+  return usesWindowsPathSeparators(projectPath)
+    ? normalizeWindowsPathSeparators(projectPath).toLowerCase()
+    : projectPath
 }
 
 export function parseTrustKey(key: string): {
@@ -346,12 +357,11 @@ export function upsertProjectTrustLevelInContent(
   const trustedProjectPath = options?.alreadyCanonical
     ? projectPath
     : getCodexCanonicalProjectPath(projectPath)
-  const headerPattern = buildProjectHeaderPattern(trustedProjectPath)
-  const match = headerPattern.exec(existing)
+  const headerLineEnd = findProjectHeaderLineEnd(existing, trustedProjectPath)
   const eol = existing.includes('\r\n') ? '\r\n' : '\n'
   const trustLine = `trust_level = "${trustLevel}"`
 
-  if (!match) {
+  if (headerLineEnd === null) {
     const block = [`[projects."${escapeTomlString(trustedProjectPath)}"]`, trustLine].join(eol)
     if (existing.length === 0) {
       return `${block}${eol}`
@@ -364,7 +374,6 @@ export function upsertProjectTrustLevelInContent(
     return `${existing}${separator}${block}${eol}`
   }
 
-  const headerLineEnd = match.index + match[0].length
   const after = existing.slice(headerLineEnd)
   const nextHeaderRel = findNextTableHeader(after)
   const blockEnd = nextHeaderRel === -1 ? existing.length : headerLineEnd + nextHeaderRel
@@ -552,20 +561,6 @@ function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
   return ranges
 }
 
-function buildProjectHeaderPattern(projectPath: string): RegExp {
-  const headerPathValues = [projectPath]
-  if (usesWindowsPathSeparators(projectPath)) {
-    headerPathValues.push(projectPath.replace(/\//g, '\\'), projectPath.replace(/\\/g, '/'))
-  }
-  const headerPaths = [...new Set(headerPathValues)].map((path) =>
-    escapeRegex(escapeTomlString(path))
-  )
-  return new RegExp(
-    `(^|\\r?\\n)[ \\t]*\\[projects\\."(?:${headerPaths.join('|')})"\\][ \\t]*(?:#[^\\r\\n]*)?(?=\\r?\\n|$)`,
-    process.platform === 'win32' ? 'i' : undefined
-  )
-}
-
 type ParsedTomlString = {
   value: string
   endIndex: number
@@ -589,6 +584,46 @@ function parseHookStateHeaderKey(line: string): string | null {
   }
   index = skipTomlInlineWhitespace(trimmed, index + 1)
   return index === trimmed.length || trimmed[index] === '#' ? parsedKey.value : null
+}
+
+export function parseCodexProjectHeaderPath(line: string): string | null {
+  const trimmed = line.trimStart()
+  const prefixMatch = /^\[[ \t]*projects[ \t]*\.[ \t]*/.exec(trimmed)
+  if (!prefixMatch) {
+    return null
+  }
+  const parsedPath = parseTomlSingleLineString(trimmed, prefixMatch[0].length)
+  if (!parsedPath) {
+    return null
+  }
+  let index = skipTomlInlineWhitespace(trimmed, parsedPath.endIndex)
+  if (trimmed[index] !== ']') {
+    return null
+  }
+  index = skipTomlInlineWhitespace(trimmed, index + 1)
+  return index === trimmed.length || trimmed[index] === '#' ? parsedPath.value : null
+}
+
+function findProjectHeaderLineEnd(content: string, projectPath: string): number | null {
+  const lookupPath = normalizeCodexProjectPathForLookup(projectPath)
+  let cursor = 0
+  let scanState = createTomlLineScanState()
+  while (cursor < content.length) {
+    const newlineIndex = content.indexOf('\n', cursor)
+    const lineEnd = newlineIndex === -1 ? content.length : newlineIndex
+    const rawLine = content.slice(cursor, lineEnd)
+    const line = rawLine.replace(/\r$/, '')
+    const existingPath = isTomlStructuralLine(scanState) ? parseCodexProjectHeaderPath(line) : null
+    if (existingPath !== null && normalizeCodexProjectPathForLookup(existingPath) === lookupPath) {
+      return rawLine.endsWith('\r') ? lineEnd - 1 : lineEnd
+    }
+    scanState = updateTomlLineScanState(scanState, line)
+    if (newlineIndex === -1) {
+      return null
+    }
+    cursor = newlineIndex + 1
+  }
+  return null
 }
 
 function parseTomlSingleLineString(line: string, startIndex: number): ParsedTomlString | null {


### PR DESCRIPTION
## Summary

- match `[projects.*]` headers by decoded TOML key value instead of their raw quote representation
- normalize Windows project identities across drive-letter/UNC casing and `/` vs `\` separators, including already-canonical SSH paths
- deduplicate semantic project tables during mirror preparation and merge so existing corrupted runtime configs self-heal; `untrusted` wins every conflict

## Root cause

Orca wrote project trust as a TOML basic-string key while Codex/toml_edit can write the same Windows path as a literal-string key. `buildProjectHeaderPattern` only recognized double-quoted headers, and the mirror compared raw trimmed header text. The representation mismatch let both tables survive even though TOML decodes them to the same project key, causing Codex startup to fail with a duplicate-table parse error.

This predates and is unrelated to #7896 and #7960; those changes touch neighboring hook-trust/settings write-back paths but did not create the duplicate project key.

## Self-heal and hooks

Every managed-config mirror pass now collapses semantically equivalent project sections from either input. Runtime project trust remains authoritative unless the system config marks the same normalized project `untrusted`; among already-duplicated sections, any `untrusted` entry survives.

`[hooks.state.*]` is intentionally not path-normalized by this deduper. The current hook upsert path already parses basic and literal keys and removes all quote-equivalent blocks before writing, while its paired Windows slash variants are required for Codex 0.140 raw native-path matching. This preserves the #6318 compatibility behavior and cannot recreate the reporter's quote-only hook duplication.

## Test evidence

- `pnpm vitest run src/main/codex/config-toml-trust.test.ts src/main/codex/codex-config-mirror.test.ts` — 114 passed
- `pnpm vitest run src/main/codex src/main/codex-accounts` — 396 passed, 7 skipped
- `pnpm typecheck` — passed
- `pnpm check:max-lines-ratchet` — passed
- targeted `oxlint` on all changed files — passed
- Windows live check in disposable `USERPROFILE` / `ORCA_USER_DATA_PATH`: real Codex rejected the seeded duplicate config, the real mirror healed it to one project table, and `codex features list` then parsed successfully with sandboxed `CODEX_HOME`

## References

- Linear: [STA-1598](https://linear.app/stably/issue/STA-1598/prevent-codex-startup-failure-by-deduplicating-toml-project)
- Source report: [Slack](https://stablygroup.slack.com/archives/C0ASMDT6LQZ/p1783700935620169)