### PR TITLE
Support SSH hosts via Teleport

### DIFF
--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -1003,6 +1003,22 @@ describe('SshConnection', () => {
     )
   })
 
+  it('does not apply OpenSSH ControlMaster retries to direct Teleport commands', async () => {
+    getOrcaControlSocketPathMock.mockReturnValue('/tmp/orca-ssh-501/stale-socket')
+    spawnSystemSshCommandMock.mockImplementationOnce(() =>
+      createFailingSystemCommandChannel(255, 'Teleport access denied')
+    )
+    const conn = new SshConnection(
+      createTarget({ proxyCommand: 'tsh ssh root@%h' }),
+      createCallbacks()
+    )
+
+    await expect(conn.connect()).rejects.toThrow('Teleport access denied')
+
+    expect(spawnSystemSshCommandMock).toHaveBeenCalledTimes(1)
+    expect(removeControlSocketPathMock).not.toHaveBeenCalled()
+  })
+
   it('falls back to system SSH when ssh2 hits a local network policy reachability error', async () => {
     connectBehavior = 'error'
     connectErrorMessage = 'connect EHOSTUNREACH 192.168.0.210:22 - Local (192.168.0.2:52112)'

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -36,6 +36,7 @@ import {
 } from './ssh-connection-utils'
 import type { RemoteHostPlatform } from './ssh-remote-platform'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
+import { buildTeleportSshCommand } from './teleport-ssh-command'
 export type { SshConnectionCallbacks } from './ssh-connection-utils'
 
 type SshRemoteFileOptions = {
@@ -102,6 +103,9 @@ export class SshConnection {
   canRunConcurrentExecCommands(): boolean {
     if (!this.useSystemSshTransport) {
       return true
+    }
+    if (buildTeleportSshCommand(this.target, this.systemSshResolvedConfig)) {
+      return false
     }
     return (
       getOrcaControlSocketPath(this.target, {
@@ -690,9 +694,11 @@ export class SshConnection {
   ): Promise<void> {
     this.systemSshResolvedConfig = cloneResolvedConfig(resolved)
     this.systemSshControlMasterDisabledForSession = false
-    const controlPath = getOrcaControlSocketPath(this.target, {
-      resolvedConfig: this.systemSshResolvedConfig
-    })
+    const controlPath = buildTeleportSshCommand(this.target, this.systemSshResolvedConfig)
+      ? null
+      : getOrcaControlSocketPath(this.target, {
+          resolvedConfig: this.systemSshResolvedConfig
+        })
     try {
       await this.doSystemSshProbe(connectGeneration)
     } catch (err) {
@@ -1063,9 +1069,11 @@ export class SshConnection {
         throw this.createCancelledConnectAttemptError()
       }
       this.systemSshResolvedConfig = cloneResolvedConfig(resolved)
-      const controlPath = getOrcaControlSocketPath(this.target, {
-        resolvedConfig: this.systemSshResolvedConfig
-      })
+      const controlPath = buildTeleportSshCommand(this.target, this.systemSshResolvedConfig)
+        ? null
+        : getOrcaControlSocketPath(this.target, {
+            resolvedConfig: this.systemSshResolvedConfig
+          })
       const proc = await this.spawnSystemSshWithControlMasterRetry(controlPath, connectGeneration)
       if (!this.isCurrentConnectAttempt(connectGeneration)) {
         if (this.systemSsh === proc) {

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -393,6 +393,16 @@ describe('spawnSystemSsh', () => {
     )
   })
 
+  it('spawns tsh directly for Teleport SSH proxy commands', () => {
+    spawnSystemSshCommand(createTarget({ proxyCommand: 'tsh ssh root@%h' }), 'echo hello')
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'tsh',
+      ['ssh', 'root@example.com', "exec /bin/sh -c 'echo hello'"],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    )
+  })
+
   it('spawns port forwards before the ssh destination terminator', () => {
     spawnSystemSshPortForward(createTarget({ configHost: 'fdpass-host' }), 5173, '127.0.0.1', 3000)
 
@@ -420,6 +430,21 @@ describe('spawnSystemSsh', () => {
       SYSTEM_SSH_PATH,
       expect.any(Array),
       expect.objectContaining({ stdio: ['ignore', 'ignore', 'pipe'] })
+    )
+  })
+
+  it('spawns Teleport local forwarding directly through tsh', () => {
+    spawnSystemSshPortForward(
+      createTarget({ proxyCommand: 'tsh ssh root@%h' }),
+      5173,
+      '127.0.0.1',
+      3000
+    )
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'tsh',
+      ['ssh', '-L', '127.0.0.1:5173:127.0.0.1:3000', 'root@example.com'],
+      expect.objectContaining({ stdio: ['pipe', 'ignore', 'pipe'] })
     )
   })
 
@@ -488,6 +513,29 @@ describe('spawnSystemSsh', () => {
     const standaloneControlIdx = args.indexOf('-S')
     expect(standaloneControlIdx).toBeGreaterThan(-1)
     expect(args[standaloneControlIdx + 1]).toBe('none')
+  })
+
+  it('streams POSIX directory uploads through direct Teleport commands', async () => {
+    const tarCreate = createMockChildProcess()
+    const tshExtract = createMockChildProcess()
+    spawnMock.mockReturnValueOnce(tarCreate).mockReturnValueOnce(tshExtract)
+
+    const upload = uploadDirectoryViaSystemSsh(
+      createTarget({ proxyCommand: 'tsh ssh root@%h' }),
+      '/tmp/local-relay',
+      '/tmp/remote-relay'
+    )
+    tarCreate.stdout.end('archive')
+    tarCreate.emit('close', 0)
+    tshExtract.emit('close', 0)
+
+    await expect(upload).resolves.toBeUndefined()
+    expect(spawnMock.mock.calls[1]?.[0]).toBe('tsh')
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual([
+      'ssh',
+      'root@example.com',
+      expect.stringContaining('tar -xzf -')
+    ])
   })
 
   it('writes files to Windows system SSH targets with PowerShell stdin bytes', async () => {
@@ -612,6 +660,18 @@ describe('spawnSystemSsh', () => {
     expect(result.pid).toBe(12345)
     expect(typeof result.kill).toBe('function')
     expect(typeof result.onExit).toBe('function')
+  })
+
+  it('settles direct Teleport process startup when tsh is missing', () => {
+    const proc = createEventedProcess()
+    spawnMock.mockReturnValue(proc)
+    const result = spawnSystemSsh(createTarget({ proxyCommand: 'tsh ssh root@%h' }))
+    const onExit = vi.fn()
+
+    result.onExit(onExit)
+    proc.emit('error', new Error('spawn tsh ENOENT'))
+
+    expect(onExit).toHaveBeenCalledWith(null)
   })
 })
 

--- a/src/main/ssh/system-ssh-args.ts
+++ b/src/main/ssh/system-ssh-args.ts
@@ -148,7 +148,7 @@ function shouldUseOpenSshConfigHost(target: SshTarget): boolean {
   return isOpenSshConfigBackedTarget(target)
 }
 
-function isOpenSshConfigBackedTarget(target: SshTarget): boolean {
+export function isOpenSshConfigBackedTarget(target: SshTarget): boolean {
   if (target.source === 'ssh-config') {
     return true
   }

--- a/src/main/ssh/system-ssh-command.ts
+++ b/src/main/ssh/system-ssh-command.ts
@@ -5,6 +5,7 @@ import type { SshTarget } from '../../shared/ssh-types'
 import { wrapRemoteCommandForPosixShell, type SshExecOptions } from './ssh-connection-utils'
 import { buildSshArgs, type SystemSshBuildArgsOptions } from './system-ssh-args'
 import { findSystemSsh } from './system-ssh-binary'
+import { buildTeleportSshCommand } from './teleport-ssh-command'
 
 export type SystemSshProcess = {
   stdin: NodeJS.WritableStream
@@ -32,6 +33,11 @@ export function spawnSystemSsh(
   target: SshTarget,
   options?: SystemSshBuildArgsOptions
 ): SystemSshProcess {
+  const teleportCommand = buildTeleportSshCommand(target, options?.resolvedConfig)
+  if (teleportCommand) {
+    return wrapChildProcess(spawnSshProcess(teleportCommand.executable, teleportCommand.args))
+  }
+
   const sshPath = findSystemSsh()
   if (!sshPath) {
     throw new Error(
@@ -40,10 +46,7 @@ export function spawnSystemSsh(
   }
 
   const args = buildSshArgs(target, options)
-  const proc = spawn(sshPath, args, {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    windowsHide: true
-  })
+  const proc = spawnSshProcess(sshPath, args)
 
   return wrapChildProcess(proc)
 }
@@ -53,6 +56,13 @@ export function spawnSystemSshCommand(
   command: string,
   options?: SystemSshCommandOptions
 ): SystemSshCommandChannel {
+  const remoteCommand =
+    options?.wrapCommand === false ? command : wrapRemoteCommandForPosixShell(command)
+  const teleportCommand = buildTeleportSshCommand(target, options?.resolvedConfig, remoteCommand)
+  if (teleportCommand) {
+    return wrapCommandProcess(spawnSshProcess(teleportCommand.executable, teleportCommand.args))
+  }
+
   const sshPath = findSystemSsh()
   if (!sshPath) {
     throw new Error(
@@ -60,13 +70,15 @@ export function spawnSystemSshCommand(
     )
   }
 
-  const remoteCommand =
-    options?.wrapCommand === false ? command : wrapRemoteCommandForPosixShell(command)
-  const proc = spawn(sshPath, [...buildSshArgs(target, options), remoteCommand], {
+  const proc = spawnSshProcess(sshPath, [...buildSshArgs(target, options), remoteCommand])
+  return wrapCommandProcess(proc)
+}
+
+function spawnSshProcess(executable: string, args: string[]): ChildProcess {
+  return spawn(executable, args, {
     stdio: ['pipe', 'pipe', 'pipe'],
     windowsHide: true
   })
-  return wrapCommandProcess(proc)
 }
 
 function wrapChildProcess(proc: ChildProcess): SystemSshProcess {
@@ -83,7 +95,18 @@ function wrapChildProcess(proc: ChildProcess): SystemSshProcess {
       }
     },
     onExit: (cb) => {
-      proc.on('exit', (code) => cb(code))
+      const onError = (): void => {
+        proc.off('exit', onExit)
+        cb(null)
+      }
+      const onExit = (code: number | null): void => {
+        proc.off('error', onError)
+        cb(code)
+      }
+      // Why: direct tsh paths are resolved by spawn rather than findSystemSsh;
+      // a missing executable must settle startup instead of emitting unhandled.
+      proc.once('error', onError)
+      proc.once('exit', onExit)
     }
   }
 }

--- a/src/main/ssh/system-ssh-file-transfer.ts
+++ b/src/main/ssh/system-ssh-file-transfer.ts
@@ -14,6 +14,7 @@ import {
 import { spawnSystemSshCommand } from './system-ssh-command'
 import { isWindowsRemoteHost, joinRemotePath, type RemoteHostPlatform } from './ssh-remote-platform'
 import { powerShellCommand, powerShellLiteral } from './ssh-remote-powershell'
+import { buildTeleportSshCommand } from './teleport-ssh-command'
 import {
   awaitWithSystemSshAbort,
   killProcess,
@@ -40,19 +41,27 @@ export async function uploadDirectoryViaSystemSsh(
     return
   }
 
-  const sshPath = findSystemSsh()
-  if (!sshPath) {
-    throw new Error('No system ssh binary found. Install OpenSSH to use system SSH transport.')
-  }
-
   const tarCreate = spawn('tar', ['-czf', '-', '-C', localDir, '.'], {
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true
   })
   const remoteCommand = `mkdir -p ${shellEscape(remoteDir)} && tar -xzf - -C ${shellEscape(remoteDir)}`
+  const teleportCommand = buildTeleportSshCommand(
+    target,
+    options?.resolvedConfig,
+    wrapRemoteCommandForPosixShell(remoteCommand)
+  )
+  const sshPath = teleportCommand ? teleportCommand.executable : findSystemSsh()
+  if (!sshPath) {
+    killProcess(tarCreate)
+    throw new Error('No system ssh binary found. Install OpenSSH to use system SSH transport.')
+  }
   const sshExtract = spawn(
     sshPath,
-    [...buildSshArgs(target, options), wrapRemoteCommandForPosixShell(remoteCommand)],
+    teleportCommand?.args ?? [
+      ...buildSshArgs(target, options),
+      wrapRemoteCommandForPosixShell(remoteCommand)
+    ],
     {
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true

--- a/src/main/ssh/system-ssh-forward-process.ts
+++ b/src/main/ssh/system-ssh-forward-process.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { connect, createServer } from 'node:net'
 import { buildSshArgs, findSystemSsh, type SystemSshBuildArgsOptions } from './ssh-system-fallback'
 import type { SshTarget } from '../../shared/ssh-types'
+import { buildTeleportSshPortForwardCommand } from './teleport-ssh-command'
 
 export const SYSTEM_SSH_FORWARD_STARTUP_GRACE_MS = 750
 export const SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS = 50
@@ -21,6 +22,22 @@ export function spawnSystemSshPortForward(
   remotePort: number,
   options?: SystemSshBuildArgsOptions
 ): ChildProcess {
+  const teleportCommand = buildTeleportSshPortForwardCommand(
+    target,
+    localPort,
+    remoteHost,
+    remotePort,
+    options?.resolvedConfig
+  )
+  if (teleportCommand) {
+    // Why: tsh has no no-session mode equivalent to `ssh -N`; an open stdin
+    // keeps its non-TTY session and local forward alive until Orca closes it.
+    return spawn(teleportCommand.executable, teleportCommand.args, {
+      stdio: ['pipe', 'ignore', 'pipe'],
+      windowsHide: true
+    })
+  }
+
   const sshPath = findSystemSsh()
   if (!sshPath) {
     throw new Error(

--- a/src/main/ssh/teleport-ssh-command.test.ts
+++ b/src/main/ssh/teleport-ssh-command.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import type { SshTarget } from '../../shared/ssh-types'
+import type { SystemSshResolvedConfig } from './ssh-control-socket'
+import { buildTeleportSshCommand, buildTeleportSshPortForwardCommand } from './teleport-ssh-command'
+
+function createTarget(overrides?: Partial<SshTarget>): SshTarget {
+  return {
+    id: 'teleport-target',
+    label: 'Teleport node',
+    host: 'node.internal',
+    port: 22,
+    username: 'deploy',
+    ...overrides
+  }
+}
+
+function createResolvedConfig(
+  overrides?: Partial<SystemSshResolvedConfig>
+): SystemSshResolvedConfig {
+  return {
+    hostname: 'resolved.internal',
+    port: 22,
+    user: 'resolved-user',
+    identityFile: [],
+    identitiesOnly: false,
+    forwardAgent: false,
+    proxyUseFdpass: false,
+    controlMaster: 'no',
+    controlPersist: 'no',
+    ...overrides
+  }
+}
+
+describe('buildTeleportSshCommand', () => {
+  it('turns the reported tsh ssh ProxyCommand into a direct Teleport command', () => {
+    const command = buildTeleportSshCommand(createTarget({ proxyCommand: 'tsh ssh root@%h' }))
+
+    expect(command).toEqual({
+      executable: 'tsh',
+      args: ['ssh', 'root@node.internal'],
+      targetIndex: 1
+    })
+  })
+
+  it('expands OpenSSH host, port, user, and literal-percent tokens', () => {
+    const command = buildTeleportSshCommand(
+      createTarget({
+        port: 3022,
+        proxyCommand: 'tsh ssh --reason=%%-%h-%p-%r --port=%p %r@%h'
+      })
+    )
+
+    expect(command?.args).toEqual([
+      'ssh',
+      '--reason=%-node.internal-3022-deploy',
+      '--port=3022',
+      'deploy@node.internal'
+    ])
+  })
+
+  it('adds a non-default target port before the Teleport host', () => {
+    const command = buildTeleportSshCommand(
+      createTarget({
+        port: 3022,
+        proxyCommand: 'tsh --proxy=teleport.example.com ssh --cluster=leaf %r@%h'
+      })
+    )
+
+    expect(command?.args).toEqual([
+      '--proxy=teleport.example.com',
+      'ssh',
+      '--cluster=leaf',
+      '-p',
+      '3022',
+      'deploy@node.internal'
+    ])
+    expect(command?.targetIndex).toBe(5)
+  })
+
+  it('keeps an explicit Teleport port instead of adding another', () => {
+    const command = buildTeleportSshCommand(
+      createTarget({ port: 3022, proxyCommand: 'tsh ssh --port=2022 %r@%h' })
+    )
+
+    expect(command?.args).toEqual(['ssh', '--port=2022', 'deploy@node.internal'])
+  })
+
+  it('uses a quoted tsh executable path and appends the remote command', () => {
+    const command = buildTeleportSshCommand(
+      createTarget({
+        proxyCommand: '"/Applications/Teleport Connect.app/Contents/MacOS/tsh" ssh root@%h'
+      }),
+      undefined,
+      "exec /bin/sh -c 'echo ready'"
+    )
+
+    expect(command).toEqual({
+      executable: '/Applications/Teleport Connect.app/Contents/MacOS/tsh',
+      args: ['ssh', 'root@node.internal', "exec /bin/sh -c 'echo ready'"],
+      targetIndex: 1
+    })
+  })
+
+  it('recognizes a quoted Windows tsh executable path', () => {
+    const command = buildTeleportSshCommand(
+      createTarget({
+        proxyCommand: '"C:\\Program Files\\Teleport\\tsh.exe" ssh root@%h'
+      })
+    )
+
+    expect(command?.executable).toBe('C:\\Program Files\\Teleport\\tsh.exe')
+    expect(command?.args).toEqual(['ssh', 'root@node.internal'])
+  })
+
+  it('uses fresh resolved config for an imported SSH alias', () => {
+    const command = buildTeleportSshCommand(
+      createTarget({
+        source: 'ssh-config',
+        configHost: 'teleport-node',
+        host: 'stale.internal',
+        username: '',
+        proxyCommand: 'tsh ssh stale@%h'
+      }),
+      createResolvedConfig({ proxyCommand: 'tsh ssh %r@%h', port: 3022 })
+    )
+
+    expect(command?.args).toEqual(['ssh', '-p', '3022', 'resolved-user@resolved.internal'])
+  })
+
+  it('leaves raw tsh proxy ssh commands on the OpenSSH transport', () => {
+    expect(
+      buildTeleportSshCommand(
+        createTarget({ proxyCommand: 'tsh proxy ssh --cluster=leaf %r@%h:%p' })
+      )
+    ).toBeNull()
+  })
+
+  it.each([
+    'cloudflared access ssh --hostname %h',
+    'tsh ssh root@%h 2>/dev/null',
+    'tsh ssh root@%h uptime',
+    'tsh ssh "root@%h',
+    'env TELEPORT_HOME=/tmp/tsh tsh ssh root@%h',
+    '~/bin/tsh ssh root@%h',
+    '%LOCALAPPDATA%\\Teleport\\tsh.exe ssh root@%h',
+    '"$HOME/bin/tsh" ssh root@%h',
+    'tsh ssh --reason="$REASON" root@%h',
+    'tsh ssh --cluster=leaf* root@%h'
+  ])('leaves unsupported proxy syntax unchanged: %s', (proxyCommand) => {
+    expect(buildTeleportSshCommand(createTarget({ proxyCommand }))).toBeNull()
+  })
+})
+
+describe('buildTeleportSshPortForwardCommand', () => {
+  it('places tsh local forwarding flags before the host argument', () => {
+    const command = buildTeleportSshPortForwardCommand(
+      createTarget({ proxyCommand: 'tsh ssh root@%h' }),
+      5173,
+      '127.0.0.1',
+      3000
+    )
+
+    expect(command).toEqual({
+      executable: 'tsh',
+      args: ['ssh', '-L', '127.0.0.1:5173:127.0.0.1:3000', 'root@node.internal'],
+      targetIndex: 3
+    })
+  })
+})

--- a/src/main/ssh/teleport-ssh-command.ts
+++ b/src/main/ssh/teleport-ssh-command.ts
@@ -1,0 +1,208 @@
+import type { SshTarget } from '../../shared/ssh-types'
+import type { SystemSshResolvedConfig } from './ssh-control-socket'
+import { isOpenSshConfigBackedTarget } from './system-ssh-args'
+
+export type TeleportSshCommand = {
+  executable: string
+  args: string[]
+  targetIndex: number
+}
+
+const UNSAFE_UNQUOTED_SHELL_CHARACTERS = new Set('|&;<>(){}*?[]#\r\n')
+
+// Why: `tsh ssh` is a complete SSH client, not a raw ProxyCommand byte stream;
+// nesting it under OpenSSH makes the two SSH protocol engines corrupt each other.
+export function buildTeleportSshCommand(
+  target: SshTarget,
+  resolvedConfig?: SystemSshResolvedConfig | null,
+  remoteCommand?: string
+): TeleportSshCommand | null {
+  const proxyCommand = resolveEffectiveProxyCommand(target, resolvedConfig)
+  const parsed = proxyCommand ? parseTeleportSshProxyCommand(proxyCommand) : null
+  if (!parsed) {
+    return null
+  }
+
+  const endpoint = resolveEffectiveEndpoint(target, resolvedConfig)
+  const args = parsed.args.map((arg) => expandOpenSshTokens(arg, endpoint))
+  let targetIndex = parsed.targetIndex
+  if (endpoint.port !== 22 && !hasExplicitPort(args, parsed.sshIndex, targetIndex)) {
+    args.splice(targetIndex, 0, '-p', String(endpoint.port))
+    targetIndex += 2
+  }
+  if (remoteCommand !== undefined) {
+    args.push(remoteCommand)
+  }
+
+  return { executable: parsed.executable, args, targetIndex }
+}
+
+export function buildTeleportSshPortForwardCommand(
+  target: SshTarget,
+  localPort: number,
+  remoteHost: string,
+  remotePort: number,
+  resolvedConfig?: SystemSshResolvedConfig | null
+): TeleportSshCommand | null {
+  const command = buildTeleportSshCommand(target, resolvedConfig)
+  if (!command) {
+    return null
+  }
+
+  const args = [...command.args]
+  args.splice(command.targetIndex, 0, '-L', `127.0.0.1:${localPort}:${remoteHost}:${remotePort}`)
+  return { ...command, args, targetIndex: command.targetIndex + 2 }
+}
+
+type ParsedTeleportProxyCommand = {
+  executable: string
+  args: string[]
+  sshIndex: number
+  targetIndex: number
+}
+
+function parseTeleportSshProxyCommand(command: string): ParsedTeleportProxyCommand | null {
+  const words = splitLiteralCommandWords(command)
+  if (!words || words.length < 3 || !isTshExecutable(words[0])) {
+    return null
+  }
+
+  const sshWordIndex = words.indexOf('ssh', 1)
+  if (sshWordIndex === -1 || words.slice(1, sshWordIndex).includes('proxy')) {
+    return null
+  }
+  const targetWordIndex = words.length - 1
+  // Why: a ProxyCommand containing a remote command or shell expression has
+  // ambiguous tsh semantics; leave it on OpenSSH's existing shell-backed path.
+  if (targetWordIndex <= sshWordIndex || !words[targetWordIndex].includes('%h')) {
+    return null
+  }
+
+  return {
+    executable: words[0],
+    args: words.slice(1),
+    sshIndex: sshWordIndex - 1,
+    targetIndex: targetWordIndex - 1
+  }
+}
+
+function isTshExecutable(executable: string): boolean {
+  if (executable.startsWith('~') || /[$`%]/.test(executable)) {
+    return false
+  }
+  const normalized = executable.replaceAll('\\', '/')
+  const basename = normalized.slice(normalized.lastIndexOf('/') + 1).toLowerCase()
+  return basename === 'tsh' || basename === 'tsh.exe'
+}
+
+function resolveEffectiveProxyCommand(
+  target: SshTarget,
+  resolvedConfig: SystemSshResolvedConfig | null | undefined
+): string | undefined {
+  if (isOpenSshConfigBackedTarget(target)) {
+    return resolvedConfig?.proxyCommand ?? target.proxyCommand
+  }
+  return target.proxyCommand ?? resolvedConfig?.proxyCommand
+}
+
+type TeleportEndpoint = { host: string; port: number; user: string }
+
+function resolveEffectiveEndpoint(
+  target: SshTarget,
+  resolvedConfig: SystemSshResolvedConfig | null | undefined
+): TeleportEndpoint {
+  const configBacked = isOpenSshConfigBackedTarget(target)
+  return {
+    host: configBacked
+      ? resolvedConfig?.hostname || target.host || target.configHost || target.label
+      : target.host || resolvedConfig?.hostname || target.configHost || target.label,
+    port: configBacked
+      ? resolvedConfig?.port || target.port || 22
+      : target.port || resolvedConfig?.port || 22,
+    user: target.username || resolvedConfig?.user || ''
+  }
+}
+
+function expandOpenSshTokens(value: string, endpoint: TeleportEndpoint): string {
+  return value.replace(/%%|%[hpr]/g, (token) => {
+    switch (token) {
+      case '%%':
+        return '%'
+      case '%h':
+        return endpoint.host
+      case '%p':
+        return String(endpoint.port)
+      case '%r':
+        return endpoint.user
+      default:
+        return token
+    }
+  })
+}
+
+function hasExplicitPort(args: string[], sshIndex: number, targetIndex: number): boolean {
+  return args
+    .slice(sshIndex + 1, targetIndex)
+    .some((arg) => arg === '-p' || arg === '--port' || arg.startsWith('--port='))
+}
+
+function splitLiteralCommandWords(command: string): string[] | null {
+  const words: string[] = []
+  let current = ''
+  let inWord = false
+  let quote: '"' | "'" | null = null
+  let escaped = false
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+    if (char === '\\' && quote !== "'") {
+      const next = command[index + 1]
+      if (next && (/\s/.test(next) || next === '"' || next === "'" || next === '\\')) {
+        escaped = true
+        inWord = true
+        continue
+      }
+    }
+    if ((char === '"' || char === "'") && quote === null) {
+      quote = char
+      inWord = true
+      continue
+    }
+    if (quote === char) {
+      quote = null
+      continue
+    }
+    if (quote !== "'" && /[$`]/.test(char)) {
+      return null
+    }
+    if (quote === null && UNSAFE_UNQUOTED_SHELL_CHARACTERS.has(char)) {
+      return null
+    }
+    if (quote === null && /\s/.test(char)) {
+      if (inWord) {
+        words.push(current)
+        current = ''
+        inWord = false
+      }
+      continue
+    }
+    current += char
+    inWord = true
+  }
+
+  if (escaped || quote !== null) {
+    return null
+  }
+  if (inWord) {
+    words.push(current)
+  }
+  if (words.some((word) => word.startsWith('~'))) {
+    return null
+  }
+  return words
+}


### PR DESCRIPTION
## Summary

- Detect Proxy Commands shaped like `tsh ssh ... %h` and run Teleport's SSH client directly instead of nesting a complete SSH session beneath OpenSSH.
- Route probes, remote commands, relay uploads, and local port forwards through the direct `tsh` transport while keeping normal ProxyCommand, ProxyJump, and raw `tsh proxy ssh` behavior unchanged.
- Avoid OpenSSH ControlMaster retries for direct Teleport sessions and handle missing `tsh` processes without unhandled child-process errors.

The root cause of #8123 is that `tsh ssh` is a complete SSH client, while OpenSSH ProxyCommand expects a raw byte stream. Nesting the former inside the latter makes two SSH protocol engines interpret the same stream and produces packet/MAC errors.

Fixes #8123.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — code lint, switch exhaustiveness, reliability, max-lines, and the English catalog pass; the command stops on an unrelated existing `ja.json` interpolation mismatch for `components.native-chat.composer.uploadingAttachments`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused SSH suite passes: 4 files, 130 tests.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions, including command parsing, macOS and Windows executable paths, process lifecycle, uploads, port forwarding, and ControlMaster isolation.

Focused command:

```sh
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/ssh/teleport-ssh-command.test.ts \
  src/main/ssh/ssh-system-fallback.test.ts \
  src/main/ssh/ssh-connection.test.ts \
  src/main/ssh/system-ssh-forward-process.test.ts
```

Additional passing checks:

- `pnpm check:max-lines-ratchet`
- `pnpm check:reliability-gates`
- Targeted `oxlint`
- Targeted `oxfmt --check`
- `git diff --check`

## AI Review Report

The review covered transport selection, OpenSSH fallback preservation, command token expansion, child-process lifecycle, relay uploads, local forwarding, and ControlMaster behavior. It flagged that shell variables or command substitution inside double-quoted ProxyCommand arguments could change meaning when moved to direct process arguments; the parser was tightened so variables, command substitution, redirection/control operators, unquoted globs, unmatched quotes, environment-derived executable paths, and tilde-derived executable paths stay on the existing OpenSSH path.

Cross-platform compatibility was explicitly reviewed for macOS, Linux, and Windows. The adapter recognizes `tsh` and `tsh.exe`, preserves quoted paths with spaces and Windows separators, uses argument-array spawning with `windowsHide`, keeps POSIX remote shell wrapping and existing Windows PowerShell commands intact, and introduces no shortcuts, labels, UI paths, or Electron renderer behavior.

The remaining review risk is live provider behavior: this environment has no Teleport cluster, so authentication/MFA, relay deployment, and a real `tsh ssh -L` forward still need validation against an actual cluster.

## Security Audit

ProxyCommand is already an explicit user-controlled command-execution surface. The direct adapter narrows activation to a literal `tsh`/`tsh.exe` executable, the `ssh` subcommand, and a final host argument containing `%h`. It deliberately excludes raw `tsh proxy ssh` and ambiguous shell syntax.

Host, user, port, and remote-command values are passed as separate `spawn` arguments without a local shell, preventing shell interpolation of expanded target values. The change adds no dependency, IPC surface, secret persistence, credential logging, or authentication bypass. Missing executables and process shutdown remain bounded by the existing SSH lifecycle.

Follow-up: validate the restricted parser and direct forwarding path with a real cluster before marking this PR ready.

## Notes

This is a draft because the contributor environment does not have access to a Teleport cluster. A maintainer or the issue reporter can validate it with:

1. Confirm `tsh ssh root@HOST 'echo TELEPORT_OK'` works.
2. Add the same host in Orca with Proxy Command `tsh ssh %r@%h`.
3. Confirm Orca connects without the previous `Bad packet length` / MAC error.
4. Open a remote terminal and validate a forwarded port from the Ports panel.

@stevenklar, testing this against the environment from #8123 would be especially helpful.

## ELI5

SSH hosts that use Teleport (`tsh ssh ...`) are detected and talked to with Teleport's client directly instead of nesting a full SSH session under OpenSSH. Probes, commands, uploads, and port forwards work through `tsh` while normal ProxyJump/ProxyCommand stay unchanged.
