### PR TITLE
Fix hidden terminal WebGL bleed across tabs on Windows

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -12,6 +12,7 @@ import {
 import TerminalPane from './TerminalPane'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { useNativeChatToggleShortcut } from '../native-chat/use-native-chat-toggle-shortcut'
+import { getTerminalOverlayPaintStyle } from './terminal-overlay-paint-style'
 import { shouldDeferParkedPtyExitTabClose } from './terminal-parked-tab-watchers'
 import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
 
@@ -187,9 +188,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
             left: `anchor(${anchorName} left)`,
             width: `anchor-size(${anchorName} width)`,
             height: `anchor-size(${anchorName} height)`,
-            display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
-            opacity: isVisible ? 1 : 0,
-            pointerEvents: isVisible ? 'auto' : 'none'
+            ...getTerminalOverlayPaintStyle(isVisible, shouldMeasureHiddenStartup)
           }
         : anchorName
           ? {
@@ -201,9 +200,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
               left: measuredFallbackRect?.left ?? 0,
               width: measuredFallbackRect?.width ?? '100%',
               height: measuredFallbackRect?.height ?? 'calc(100% - 32px)',
-              display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
-              opacity: isVisible ? 1 : 0,
-              pointerEvents: isVisible ? 'auto' : 'none'
+              ...getTerminalOverlayPaintStyle(isVisible, shouldMeasureHiddenStartup)
             }
           : {
               position: 'absolute',

--- a/src/renderer/src/components/terminal-pane/terminal-overlay-paint-style.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-overlay-paint-style.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { getTerminalOverlayPaintStyle } from './terminal-overlay-paint-style'
+
+describe('getTerminalOverlayPaintStyle', () => {
+  it('keeps a hidden startup terminal measurable without letting it paint', () => {
+    expect(getTerminalOverlayPaintStyle(false, true)).toEqual({
+      display: 'flex',
+      opacity: 0,
+      visibility: 'hidden',
+      pointerEvents: 'none'
+    })
+  })
+
+  it('shows only the active terminal overlay', () => {
+    expect(getTerminalOverlayPaintStyle(true, false)).toEqual({
+      display: 'flex',
+      opacity: 1,
+      visibility: 'visible',
+      pointerEvents: 'auto'
+    })
+    expect(getTerminalOverlayPaintStyle(false, false)).toEqual({
+      display: 'none',
+      opacity: 0,
+      visibility: 'hidden',
+      pointerEvents: 'none'
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-overlay-paint-style.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-overlay-paint-style.ts
@@ -1,0 +1,21 @@
+import type { CSSProperties } from 'react'
+
+type TerminalOverlayPaintStyle = Pick<
+  CSSProperties,
+  'display' | 'opacity' | 'pointerEvents' | 'visibility'
+>
+
+export function getTerminalOverlayPaintStyle(
+  isVisible: boolean,
+  shouldMeasureHiddenStartup: boolean
+): TerminalOverlayPaintStyle {
+  const shouldLayout = isVisible || shouldMeasureHiddenStartup
+
+  return {
+    display: shouldLayout ? 'flex' : 'none',
+    opacity: isVisible ? 1 : 0,
+    // Why: opacity alone can leak stale WebGL pixels from a measurable hidden xterm on Windows.
+    visibility: isVisible ? 'visible' : 'hidden',
+    pointerEvents: isVisible ? 'auto' : 'none'
+  }
+}


### PR DESCRIPTION
## Summary

- prevent hidden, measurable terminal overlays from painting stale xterm WebGL content
- preserve startup geometry measurement while the background tab remains inactive
- add a focused regression test for the overlay paint contract

## Root cause

On Windows, a newly created background terminal tab remains mounted at full size so xterm can measure its startup viewport. The overlay used `display: flex` with `opacity: 0`. With WebGL enabled, Chromium could retain and composite that hidden xterm surface over the still-active original tab.

Serialized xterm buffers and PTY diagnostics stayed isolated: every terminal used a fresh PTY, no replay or reattach occurred, and only pixels—not output data—crossed the visual boundary.

The fix adds `visibility: hidden` while the overlay is inactive. This prevents painting without removing it from layout, so startup measurement remains intact.

## Reproduction

- Windows, isolated Electron dev profile
- baseline: `orca-performance`
- original TUI tab remained active
- create an agy terminal tab in the background and wait at its workspace-trust screen
- reproduced 1/1 with GPU/WebGL enabled
- GPU disabled: clean
- patched build with WebGL enabled: clean (0/1)

## Validation

- `pnpm exec vitest run src/renderer/src/components/terminal-pane/terminal-overlay-paint-style.test.ts`
- `pnpm typecheck`
- `pnpm check:max-lines-ratchet`
- pre-commit oxlint and formatting hooks
- visible validation in an isolated Electron dev instance on Windows

## Risk

Low and renderer-local. The change does not alter PTY delivery, terminal buffers, resizing, SSH, or platform transport behavior. Hidden startup terminals remain measurable but can no longer paint or receive pointer events.