### PR TITLE
fix(sidebar): surface Git tabs after in-place git init (#8125)

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5190,6 +5190,45 @@ describe('OrcaRuntimeService', () => {
     expect(added).toEqual([expect.objectContaining({ badgeColor: DEFAULT_REPO_BADGE_COLOR })])
   })
 
+  it('promotes an existing folder repo when its path becomes a git repo', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-git-promotion-'))
+    const repos: Record<string, unknown>[] = []
+    const runtimeStore = {
+      ...store,
+      getRepos: () => repos as never,
+      addRepo: (repo: Record<string, unknown>) => {
+        repos.push(repo)
+      },
+      getRepo: (id: string) => repos.find((repo) => repo.id === id) as never,
+      updateRepo: (id: string, updates: Record<string, unknown>) => {
+        const index = repos.findIndex((repo) => repo.id === id)
+        if (index === -1) {
+          return null
+        }
+        repos[index] = { ...repos[index], ...updates }
+        return repos[index] as never
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    try {
+      const folderRepo = await runtime.addRepo(tempRoot, 'folder')
+      execFileSync('git', ['init'], { cwd: tempRoot, stdio: 'ignore' })
+
+      const promotedRepo = await runtime.addRepo(tempRoot, 'git')
+
+      expect(promotedRepo).toMatchObject({ id: folderRepo.id, path: tempRoot, kind: 'git' })
+      expect(repos).toHaveLength(1)
+      expect(prepareLocalWorktreeRootForRepoMock).toHaveBeenLastCalledWith(
+        runtimeStore,
+        promotedRepo
+      )
+      expect(invalidateAuthorizedRootsCacheMock).toHaveBeenCalled()
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
   it('prepares the runtime worktree root when adding a repo', async () => {
     const added: Record<string, unknown>[] = []
     const runtimeStore = {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10504,6 +10504,16 @@ export class OrcaRuntimeService {
         this.notifyReposChanged()
         return adopted
       }
+      if (kind === 'git' && isFolderRepo(existing)) {
+        const updated = this.store.updateRepo(existing.id, { kind: 'git' })
+        if (updated) {
+          await prepareLocalWorktreeRootForRepo(this.store, updated)
+          invalidateAuthorizedRootsCache()
+          this.invalidateResolvedWorktreeCache()
+          this.notifyReposChanged()
+          return updated
+        }
+      }
       return existing
     }
 

--- a/src/renderer/src/store/slices/repos-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups.test.ts
@@ -1,5 +1,6 @@
+/* eslint-disable max-lines -- This routing test file already owns the folder workspace activation matrix. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createTestStore } from './store-test-helpers'
+import { createTestStore, makeWorktree } from './store-test-helpers'
 import type {
   NestedRepoScanResult,
   Repo,
@@ -13,6 +14,14 @@ import {
 import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { SshConnectionState } from '../../../../shared/ssh-types'
+
+const worktreeActivation = vi.hoisted(() => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('../../lib/worktree-activation', () => ({
+  activateAndRevealWorktree: worktreeActivation.activateAndRevealWorktree
+}))
 
 const remoteRepo: Repo = {
   id: 'remote-repo',
@@ -36,6 +45,7 @@ const projectGroup: ProjectGroup = {
 }
 
 const reposList = vi.fn()
+const reposAdd = vi.fn()
 const reposRemove = vi.fn()
 const ptyKill = vi.fn()
 const projectGroupsList = vi.fn()
@@ -51,6 +61,7 @@ const folderWorkspacesGetPathStatus = vi.fn()
 const folderWorkspacesCreate = vi.fn()
 const folderWorkspacesUpdate = vi.fn()
 const folderWorkspacesDelete = vi.fn()
+const worktreesListDetected = vi.fn()
 const runtimeEnvironmentCall = vi.fn()
 const runtimeEnvironmentTransportCall = vi.fn()
 
@@ -66,6 +77,7 @@ function makeSshConnectionState(status: SshConnectionState['status']): SshConnec
 beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
   reposList.mockReset()
+  reposAdd.mockReset()
   reposRemove.mockReset()
   reposRemove.mockResolvedValue(undefined)
   ptyKill.mockReset()
@@ -84,18 +96,24 @@ beforeEach(() => {
   folderWorkspacesCreate.mockReset()
   folderWorkspacesUpdate.mockReset()
   folderWorkspacesDelete.mockReset()
+  worktreesListDetected.mockReset()
   runtimeEnvironmentCall.mockReset()
   runtimeEnvironmentTransportCall.mockReset()
+  worktreeActivation.activateAndRevealWorktree.mockReset()
   runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
     return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
   })
   vi.stubGlobal('window', {
     api: {
       repos: {
+        add: reposAdd,
         list: reposList,
         remove: reposRemove
       },
       pty: { kill: ptyKill },
+      worktrees: {
+        listDetected: worktreesListDetected
+      },
       projectGroups: {
         list: projectGroupsList,
         create: projectGroupsCreate,
@@ -368,6 +386,95 @@ describe('project group store routing', () => {
       reason: 'missing'
     })
     expect(folderWorkspacesGetPathStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('promotes an active folder workspace to the canonical git worktree when the same path becomes a repo', async () => {
+    const folderWorkspace: FolderWorkspace = {
+      id: 'folder-workspace-1',
+      projectGroupId: projectGroup.id,
+      name: 'Platform',
+      folderPath: '/workspace/platform',
+      linkedTask: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 1,
+      lastActivityAt: 0,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    reposAdd.mockResolvedValue({
+      repo: {
+        id: 'repo-1',
+        path: folderWorkspace.folderPath,
+        displayName: 'Platform',
+        badgeColor: '#111',
+        addedAt: 2,
+        kind: 'git'
+      }
+    })
+    worktreesListDetected.mockResolvedValue({
+      repoId: 'repo-1',
+      authoritative: true,
+      source: 'git',
+      worktrees: [
+        {
+          ...makeWorktree({
+            id: 'repo-1::root',
+            repoId: 'repo-1',
+            path: folderWorkspace.folderPath,
+            isMainWorktree: true,
+            displayName: 'platform'
+          }),
+          ownership: 'orca-managed',
+          selectedCheckout: true,
+          visible: true
+        }
+      ]
+    })
+    const store = createTestStore()
+    store.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: folderWorkspace.folderPath,
+          displayName: 'Platform',
+          badgeColor: '#111',
+          addedAt: 1,
+          kind: 'folder',
+          executionHostId: 'local'
+        }
+      ],
+      folderWorkspaces: [folderWorkspace],
+      activeWorktreeId: folderWorkspaceKey(folderWorkspace.id)
+    })
+
+    await expect(
+      store.getState().fetchFolderWorkspacePathStatus({
+        scope: 'folder-workspace',
+        folderWorkspaceId: folderWorkspace.id
+      })
+    ).resolves.toEqual({ path: folderWorkspace.folderPath, exists: true })
+
+    expect(reposAdd).toHaveBeenCalledWith({ path: folderWorkspace.folderPath, kind: 'git' })
+    expect(worktreesListDetected).toHaveBeenCalledWith({ repoId: 'repo-1' })
+    expect(store.getState().repos).toEqual([
+      expect.objectContaining({
+        id: 'repo-1',
+        path: folderWorkspace.folderPath,
+        kind: 'git',
+        executionHostId: 'local'
+      })
+    ])
+    expect(store.getState().worktreesByRepo['repo-1']).toEqual([
+      expect.objectContaining({
+        id: 'repo-1::root',
+        path: folderWorkspace.folderPath,
+        repoId: 'repo-1'
+      })
+    ])
+    expect(worktreeActivation.activateAndRevealWorktree).toHaveBeenCalledWith('repo-1::root')
   })
 
   it('ignores stale folder path status responses after a group path changes', async () => {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -44,7 +44,10 @@ import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { sanitizeRepoIcon } from '../../../../shared/repo-icon'
 import { normalizeRepoBadgeColor } from '../../../../shared/repo-badge-color'
 import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
-import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
+import {
+  isPathInsideOrEqual,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
 import { reconcileFetchedRepos } from './repo-identity-reconcile'
@@ -1130,7 +1133,10 @@ function getRuntimeTargetCachePrefix(
 }
 
 type FolderWorkspacePathStatusRouteOptions = { runtimeEnvironmentId?: string | null }
-type AddRepoPathRouteOptions = { runtimeEnvironmentId?: string | null }
+type AddRepoPathRouteOptions = {
+  runtimeEnvironmentId?: string | null
+  suppressFolderFallback?: boolean
+}
 
 function getFolderWorkspacePathStatusRouteSettings(
   options: FolderWorkspacePathStatusRouteOptions | undefined,
@@ -1793,6 +1799,31 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               }
             : state.folderWorkspacePathStatuses
       }))
+      if (request.scope === 'folder-workspace' && status.exists) {
+        const state = get()
+        const workspace = state.folderWorkspaces.find(
+          (entry) => entry.id === request.folderWorkspaceId
+        )
+        if (workspace && state.activeWorktreeId === folderWorkspaceKey(workspace.id)) {
+          const repo = await state.addRepoPath(workspace.folderPath, 'git', {
+            runtimeEnvironmentId: getFolderWorkspacePathStatusRouteSettings(options, state.settings)
+              ?.activeRuntimeEnvironmentId,
+            suppressFolderFallback: true
+          })
+          if (repo && isGitRepoKind(repo)) {
+            await get().fetchWorktrees(repo.id, { requireAuthoritative: true })
+            const canonicalWorktree = get().worktreesByRepo[repo.id]?.find(
+              (worktree) =>
+                normalizeRuntimePathForComparison(worktree.path) ===
+                normalizeRuntimePathForComparison(workspace.folderPath)
+            )
+            if (canonicalWorktree) {
+              const { activateAndRevealWorktree } = await import('../../lib/worktree-activation')
+              activateAndRevealWorktree(canonicalWorktree.id)
+            }
+          }
+        }
+      }
       return status
     } catch (err) {
       console.error('Failed to fetch folder workspace path status:', err)
@@ -2216,6 +2247,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         if (kind !== 'git' || !message.includes('Not a valid git repository')) {
           throw err
         }
+        if (options?.suppressFolderFallback) {
+          return null
+        }
         if (target.kind !== 'local') {
           const status = await fetchRuntimeAddProjectPathStatus({ target, path })
           if (status?.exists !== true) {
@@ -2250,13 +2284,29 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
       repo = repoWithFetchedOwner(repo, target)
       const repoIdentity = getRepoHostIdentity(repo)
-      const alreadyAdded = get().repos.some((r) => getRepoHostIdentity(r) === repoIdentity)
+      const existingRepo = get().repos.find((r) => getRepoHostIdentity(r) === repoIdentity)
+      const alreadyAdded = Boolean(existingRepo)
+      const repoChanged = Boolean(existingRepo && existingRepo.kind !== repo.kind)
       if (alreadyAdded) {
         get().clearOrcaHookTrustForRepo(repo.id)
       }
       set((s) => {
-        if (s.repos.some((r) => getRepoHostIdentity(r) === repoIdentity)) {
-          return s
+        const existingIndex = s.repos.findIndex((r) => getRepoHostIdentity(r) === repoIdentity)
+        if (existingIndex !== -1) {
+          if (!repoChanged) {
+            return s
+          }
+          const nextRepos = [...s.repos]
+          nextRepos[existingIndex] = repo
+          return {
+            repos: nextRepos,
+            ...mergeProjectCompatibilityForHostRepoChange({
+              previous: { projects: s.projects, projectHostSetups: s.projectHostSetups },
+              nextRepos,
+              hostId: getRepoExecutionHostId(repo)
+            }),
+            folderWorkspacePathStatuses: {}
+          }
         }
         const nextRepos = [...s.repos, repo]
         const hostId = getRepoExecutionHostId(repo)
@@ -2270,11 +2320,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           folderWorkspacePathStatuses: {}
         }
       })
-      if (alreadyAdded) {
+      if (alreadyAdded && !repoChanged) {
         toast.info(translate('auto.store.slices.repos.a8e4b3af5b', 'Project already added'), {
           description: repo.displayName
         })
-      } else {
+      } else if (!alreadyAdded) {
         toast.success(
           isGitRepoKind(repo)
             ? translate('auto.store.slices.repos.8bb3ad7935', 'Project added')


### PR DESCRIPTION
## Summary

- Reuses the existing folder-to-git promotion path in the runtime when `addRepo(path, 'git')` hits an already-added folder repo at the same path.
- Re-probes active folder workspaces during path-status refresh, retries the same path as a git repo without falling back to folder mode, then fetches authoritative worktrees and swaps to the canonical git root.
- Keeps plain folder handling and the existing clone-collision promotion behavior unchanged.

Closes #8125.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/repos-project-groups.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.test.ts`
- `pnpm run typecheck`

## AI Review Report

The risky edge here is stale folder state after the repo kind flips. The runtime promotion now stays on the same same-path upgrade path already used for clone collisions, and the renderer only attempts the handoff when the active folder workspace path re-probes as present, the git add succeeds, and an authoritative worktree refresh resolves the same canonical path. Plain folders still stop in folder mode because the reprobe suppresses the fallback instead of auto-converting them.

## Security Audit

No auth, network, or shell expansion behavior changed. The slice reuses existing repo detection, repo update, and worktree activation paths.

## Notes

The slice stays scoped to same-path folder-to-git promotion after `git init`. Manual refresh affordances, nested-repo folder review changes, and broader sidebar logic stay out of scope.

## ELI5

If you ran `git init` in a folder already open as a non-git workspace, Git-related sidebar tabs did not appear until awkward workarounds. Orca re-probes and promotes that path to a git repo in place so Git UI shows up after init.
