### PR TITLE
Fix Linux Parcel watcher crawl restart loop

### DIFF
--- a/src/main/ipc/filesystem-watcher-ignore.test.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.test.ts
@@ -45,10 +45,11 @@ describe('buildParcelWatcherIgnoreOptions', () => {
       for (const dir of WATCHER_IGNORE_DIRS) {
         expect(regex.test(dir)).toBe(true)
         expect(regex.test(`packages/app/${dir}`)).toBe(true)
-        expect(regex.test(`packages\\app\\${dir}\\nested\\file.ts`)).toBe(true)
+        expect(regex.test(`packages\\app\\${dir}\\nested\\file.ts`)).toBe(platform === 'win32')
       }
       expect(regex.test('packages/app/.github/workflows')).toBe(false)
       expect(regex.test('packages/app/node_modules-cache/file.ts')).toBe(false)
+      expect(regex.test('project\\node_modules/file.ts')).toBe(platform === 'win32')
     }
   })
 })

--- a/src/main/ipc/filesystem-watcher-ignore.test.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT,
   WATCHER_IGNORE_DIRS,
-  buildParcelWatcherIgnoreOption
+  buildParcelWatcherIgnoreOptions
 } from './filesystem-watcher-ignore'
 
 const realPlatform = process.platform
@@ -11,39 +11,44 @@ function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', { value: platform })
 }
 
-describe('buildParcelWatcherIgnoreOption', () => {
+describe('buildParcelWatcherIgnoreOptions', () => {
   afterEach(() => {
     setPlatform(realPlatform)
   })
 
   it('keeps at most 8 plain paths on macOS so FSEventStreamSetExclusionPaths succeeds', () => {
     setPlatform('darwin')
-    const option = buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS)
+    const options = buildParcelWatcherIgnoreOptions(WATCHER_IGNORE_DIRS)
+    const option = options.ignore ?? []
     // @parcel/watcher passes non-glob entries to FSEventStreamSetExclusionPaths,
     // which rejects the WHOLE set past 8 paths — silently disabling daemon-side
     // exclusion of node_modules/.git churn.
     const plainPaths = option.filter((entry) => !entry.includes('*'))
     expect(plainPaths.length).toBeLessThanOrEqual(MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
-    // Every ignore dir must still be covered, as a path or as a glob.
-    for (const dir of WATCHER_IGNORE_DIRS) {
-      expect(
-        option.some((entry) => entry === dir || entry === `**/${dir}` || entry === `**/${dir}/**`)
-      ).toBe(true)
+    expect(option).toEqual(WATCHER_IGNORE_DIRS.slice(0, MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT))
+    const fallbackRegex = new RegExp(options.ignoreGlobs?.[0] ?? '(?!)')
+    for (const dir of WATCHER_IGNORE_DIRS.slice(MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)) {
+      expect(fallbackRegex.test(`packages/app/${dir}/file.ts`)).toBe(true)
     }
+    expect(options.ignoreGlobs?.[0]).not.toContain('?!')
   })
 
-  it('expands to nested globs on Linux/Windows so nested node_modules/.git are excluded', () => {
+  it('uses one lookahead-free native regex for nested ignores on Linux/Windows', () => {
     for (const platform of ['linux', 'win32'] as const) {
       setPlatform(platform)
-      const option = buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS)
-      // @parcel/watcher resolves plain names to top-level-only absolute paths on
-      // these platforms, so nested dirs must be matched via depth-agnostic globs.
+      const options = buildParcelWatcherIgnoreOptions(WATCHER_IGNORE_DIRS)
+      expect(options.ignore).toBeUndefined()
+      expect(options.ignoreGlobs).toHaveLength(1)
+      const source = options.ignoreGlobs![0]
+      expect(source).not.toContain('?!')
+      const regex = new RegExp(source)
       for (const dir of WATCHER_IGNORE_DIRS) {
-        expect(option).toContain(`**/${dir}`)
-        expect(option).toContain(`**/${dir}/**`)
+        expect(regex.test(dir)).toBe(true)
+        expect(regex.test(`packages/app/${dir}`)).toBe(true)
+        expect(regex.test(`packages\\app\\${dir}\\nested\\file.ts`)).toBe(true)
       }
-      // No plain (glob-free) entries — those would only exclude the top level.
-      expect(option.every((entry) => entry.includes('*'))).toBe(true)
+      expect(regex.test('packages/app/.github/workflows')).toBe(false)
+      expect(regex.test('packages/app/node_modules-cache/file.ts')).toBe(false)
     }
   })
 })

--- a/src/main/ipc/filesystem-watcher-ignore.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.ts
@@ -23,19 +23,38 @@ export const WATCHER_IGNORE_DIRS: string[] = [
 // therefore meaningful: the first 8 get true daemon-side exclusion on macOS.
 export const MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT = 8
 
-export function buildParcelWatcherIgnoreOption(ignoreDirs: readonly string[]): string[] {
-  if (process.platform !== 'darwin') {
-    // Linux/Windows: @parcel/watcher resolves plain names to top-level-only
-    // absolute paths, so nested node_modules/.git/build/etc. (monorepos) get
-    // fully watched — on Linux that means one inotify watch per nested dir,
-    // exhausting fs.inotify.max_user_watches. Nested globs match at any depth
-    // (and **/dir still matches the top-level dir), pruning those subtrees.
-    return ignoreDirs.flatMap((dir) => [`**/${dir}`, `**/${dir}/**`])
+export type ParcelWatcherIgnoreOptions = {
+  ignore?: string[]
+  // @parcel/watcher's wrapper preserves this native option even though its
+  // public TypeScript declaration omits it. See parcel-bundler/watcher#244.
+  ignoreGlobs?: string[]
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+}
+
+function buildNestedDirectoryRegex(ignoreDirs: readonly string[]): string {
+  const alternatives = ignoreDirs.map(escapeRegex).join('|')
+  return `^(?:[^\\\\/]+[\\\\/])*(?:${alternatives})(?:[\\\\/].*)?$`
+}
+
+export function buildParcelWatcherIgnoreOptions(
+  ignoreDirs: readonly string[]
+): ParcelWatcherIgnoreOptions {
+  if (ignoreDirs.length === 0) {
+    return {}
   }
-  return [
-    ...ignoreDirs.slice(0, MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT),
-    ...ignoreDirs
-      .slice(MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
-      .flatMap((dir) => [`**/${dir}`, `**/${dir}/**`])
-  ]
+  if (process.platform !== 'darwin') {
+    // Why: Parcel 2.5.6 turns leading-** globs into nested-lookahead regexes
+    // that are pathological in native std::regex (10-17x slower upstream).
+    // One component-aware regex preserves nested pruning without that CPU cost.
+    return { ignoreGlobs: [buildNestedDirectoryRegex(ignoreDirs)] }
+  }
+  const daemonExcludedDirs = ignoreDirs.slice(0, MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
+  const remainingDirs = ignoreDirs.slice(MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
+  return {
+    ignore: [...daemonExcludedDirs],
+    ...(remainingDirs.length > 0 ? { ignoreGlobs: [buildNestedDirectoryRegex(remainingDirs)] } : {})
+  }
 }

--- a/src/main/ipc/filesystem-watcher-ignore.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.ts
@@ -36,7 +36,11 @@ function escapeRegex(value: string): string {
 
 function buildNestedDirectoryRegex(ignoreDirs: readonly string[]): string {
   const alternatives = ignoreDirs.map(escapeRegex).join('|')
-  return `^(?:[^\\\\/]+[\\\\/])*(?:${alternatives})(?:[\\\\/].*)?$`
+  if (process.platform === 'win32') {
+    return `^(?:[^\\\\/]+[\\\\/])*(?:${alternatives})(?:[\\\\/].*)?$`
+  }
+  // Why: backslash is a legal POSIX filename character, not a path separator.
+  return `^(?:[^/]+/)*(?:${alternatives})(?:/.*)?$`
 }
 
 export function buildParcelWatcherIgnoreOptions(

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -18,7 +18,7 @@ import { disposeWatcherProcess, subscribeViaWatcherProcess } from './parcel-watc
 // events never leave the OS/daemon. This list is separate from the File
 // Explorer display filter (which only hides rows). Directories like `dist`
 // and `build` remain visible in the tree but will not auto-refresh.
-import { WATCHER_IGNORE_DIRS, buildParcelWatcherIgnoreOption } from './filesystem-watcher-ignore'
+import { WATCHER_IGNORE_DIRS, buildParcelWatcherIgnoreOptions } from './filesystem-watcher-ignore'
 
 // ── Debounce helpers ─────────────────────────────────────────────────
 
@@ -293,7 +293,7 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
     let errorCleanedUp = false
 
     const watcherOptions = {
-      ignore: buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS),
+      ...buildParcelWatcherIgnoreOptions(WATCHER_IGNORE_DIRS),
       // Why: Parcel checks Watchman before the native Windows backend by
       // default, and Windows prints a shell-level "watchman not recognized"
       // error for that probe. Pinning the backend keeps local watches quiet.

--- a/src/main/ipc/parcel-watcher-process-entry.test.ts
+++ b/src/main/ipc/parcel-watcher-process-entry.test.ts
@@ -84,6 +84,123 @@ describe('parcel watcher process canary', () => {
     expect(exitSpy).not.toHaveBeenCalled()
   })
 
+  it('still restarts when unsubscribe deadlocks while another root remains live', async () => {
+    subscribeMock
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockResolvedValueOnce({ unsubscribe: vi.fn(() => new Promise(() => undefined)) })
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 1, dir: '/repo-a', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 2, dir: '/repo-b', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+
+    process.emit('message', { op: 'unsubscribe', id: 1 })
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(3)
+    expect(exitSpy).toHaveBeenCalledWith(2)
+  })
+
+  it('drains active crawls before starting teardown deadlock detection', async () => {
+    let finishSecondCrawl:
+      | ((subscription: { unsubscribe: () => Promise<void> }) => void)
+      | undefined
+    const deadlockedUnsubscribe = vi.fn(() => new Promise<void>(() => undefined))
+    subscribeMock
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockResolvedValueOnce({ unsubscribe: deadlockedUnsubscribe })
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishSecondCrawl = resolve
+        })
+      )
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 1, dir: '/repo-a', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 2, dir: '/repo-b', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'unsubscribe', id: 1 })
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(deadlockedUnsubscribe).not.toHaveBeenCalled()
+    expect(writeFileSyncMock).not.toHaveBeenCalled()
+
+    finishSecondCrawl?.({ unsubscribe: vi.fn().mockResolvedValue(undefined) })
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(deadlockedUnsubscribe).toHaveBeenCalledTimes(1)
+    expect(exitSpy).toHaveBeenCalledWith(2)
+  })
+
+  it('keeps later crawls queued behind teardown deadlock detection', async () => {
+    const deadlockedUnsubscribe = vi.fn(() => new Promise<void>(() => undefined))
+    subscribeMock
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockResolvedValueOnce({ unsubscribe: deadlockedUnsubscribe })
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 1, dir: '/repo-a', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 2, dir: '/repo-b', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'unsubscribe', id: 1 })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(deadlockedUnsubscribe).toHaveBeenCalledTimes(1)
+
+    process.emit('message', { op: 'subscribe', id: 3, dir: '/repo-c', opts: {} })
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(subscribeMock).toHaveBeenCalledTimes(3)
+    expect(exitSpy).toHaveBeenCalledWith(2)
+  })
+
+  it('reserves teardown order while its subscription is still crawling', async () => {
+    let finishCrawl: ((subscription: { unsubscribe: () => Promise<void> }) => void) | undefined
+    const deadlockedUnsubscribe = vi.fn(() => new Promise<void>(() => undefined))
+    subscribeMock
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishCrawl = resolve
+        })
+      )
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 1, dir: '/live-repo', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 2, dir: '/crawling-repo', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'unsubscribe', id: 2 })
+    process.emit('message', { op: 'subscribe', id: 3, dir: '/later-repo', opts: {} })
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(writeFileSyncMock).not.toHaveBeenCalled()
+
+    finishCrawl?.({ unsubscribe: deadlockedUnsubscribe })
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(deadlockedUnsubscribe).toHaveBeenCalledTimes(1)
+    expect(subscribeMock).toHaveBeenCalledTimes(3)
+    expect(exitSpy).toHaveBeenCalledWith(2)
+  })
+
   it('still restarts after consecutive missed events once every subscription is live', async () => {
     subscribeMock.mockResolvedValue({ unsubscribe: vi.fn() })
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)

--- a/src/main/ipc/parcel-watcher-process-entry.test.ts
+++ b/src/main/ipc/parcel-watcher-process-entry.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { subscribeMock, writeFileSyncMock } = vi.hoisted(() => ({
+  subscribeMock: vi.fn(),
+  writeFileSyncMock: vi.fn()
+}))
+
+vi.mock('node:fs', () => ({
+  mkdtempSync: vi.fn(() => '/tmp/orca-watcher-canary-test'),
+  rmSync: vi.fn(),
+  writeFileSync: writeFileSyncMock
+}))
+vi.mock('@parcel/watcher', () => ({ subscribe: subscribeMock }))
+
+describe('parcel watcher process canary', () => {
+  let originalMessageListeners: ReturnType<typeof process.listeners>
+  let originalExitListeners: ReturnType<typeof process.listeners>
+  let originalDisconnectListeners: ReturnType<typeof process.listeners>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    subscribeMock.mockReset()
+    writeFileSyncMock.mockReset()
+    originalMessageListeners = process.listeners('message')
+    originalExitListeners = process.listeners('exit')
+    originalDisconnectListeners = process.listeners('disconnect')
+  })
+
+  afterEach(() => {
+    for (const listener of process.listeners('message')) {
+      if (!originalMessageListeners.includes(listener)) {
+        process.off('message', listener)
+      }
+    }
+    for (const listener of process.listeners('exit')) {
+      if (!originalExitListeners.includes(listener)) {
+        process.off('exit', listener)
+      }
+    }
+    for (const listener of process.listeners('disconnect')) {
+      if (!originalDisconnectListeners.includes(listener)) {
+        process.off('disconnect', listener)
+      }
+    }
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('does not restart while a native subscription is still crawling', async () => {
+    subscribeMock
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockReturnValueOnce(new Promise(() => undefined))
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 1, dir: '/large-repo', opts: {} })
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(writeFileSyncMock).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('invalidates an outstanding probe when another subscription starts crawling', async () => {
+    subscribeMock
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockResolvedValueOnce({ unsubscribe: vi.fn() })
+      .mockReturnValueOnce(new Promise(() => undefined))
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 1, dir: '/repo', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1)
+
+    process.emit('message', { op: 'subscribe', id: 2, dir: '/large-repo', opts: {} })
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1)
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('still restarts after consecutive missed events once every subscription is live', async () => {
+    subscribeMock.mockResolvedValue({ unsubscribe: vi.fn() })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', { op: 'subscribe', id: 1, dir: '/repo', opts: {} })
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(3)
+    expect(exitSpy).toHaveBeenCalledWith(2)
+  })
+})

--- a/src/main/ipc/parcel-watcher-process-entry.ts
+++ b/src/main/ipc/parcel-watcher-process-entry.ts
@@ -130,17 +130,27 @@ function main(): void {
   // native handle — on Windows a leaked handle keeps the worktree dir locked.
   const subscriptions = new Map<number, Promise<ParcelWatcher.AsyncSubscription | null>>()
   const liveSubscriptionIds = new Set<number>()
-  let pendingSubscriptionOperations = 0
+  let pendingSubscriptionCrawls = 0
   let subscriptionActivityRevision = 0
+  let nativeLifecycleTail = Promise.resolve()
 
-  const beginSubscriptionOperation = (): void => {
-    pendingSubscriptionOperations++
+  const beginSubscriptionCrawl = (): void => {
+    pendingSubscriptionCrawls++
     subscriptionActivityRevision++
   }
 
-  const finishSubscriptionOperation = (): void => {
-    pendingSubscriptionOperations--
+  const finishSubscriptionCrawl = (): void => {
+    pendingSubscriptionCrawls--
     subscriptionActivityRevision++
+  }
+
+  const runNativeWatcherLifecycleExclusive = <T>(operation: () => Promise<T>): Promise<T> => {
+    const ready = nativeLifecycleTail
+    let release: () => void
+    nativeLifecycleTail = new Promise((resolve) => {
+      release = resolve
+    })
+    return ready.then(operation).finally(() => release())
   }
 
   const handleSubscribe = async (
@@ -148,26 +158,32 @@ function main(): void {
     dir: string,
     opts: WatcherProcessSubscribeOptions
   ): Promise<ParcelWatcher.AsyncSubscription | null> => {
-    beginSubscriptionOperation()
     try {
-      const watcher = await import('@parcel/watcher')
-      const subscription = await watcher.subscribe(
-        dir,
-        (err, events) => {
-          if (err) {
-            send({ op: 'watch-error', id, message: errorMessage(err) })
-            return
-          }
-          if (events.length > 0) {
-            send({
-              op: 'events',
-              id,
-              events: events.map((event) => ({ type: event.type, path: event.path }))
-            })
-          }
-        },
-        opts as ParcelWatcher.Options
-      )
+      const subscription = await runNativeWatcherLifecycleExclusive(async () => {
+        beginSubscriptionCrawl()
+        try {
+          const watcher = await import('@parcel/watcher')
+          return await watcher.subscribe(
+            dir,
+            (err, events) => {
+              if (err) {
+                send({ op: 'watch-error', id, message: errorMessage(err) })
+                return
+              }
+              if (events.length > 0) {
+                send({
+                  op: 'events',
+                  id,
+                  events: events.map((event) => ({ type: event.type, path: event.path }))
+                })
+              }
+            },
+            opts as ParcelWatcher.Options
+          )
+        } finally {
+          finishSubscriptionCrawl()
+        }
+      })
       // An unsubscribe can remove the record while subscribe() is crawling.
       // Only advertise it as live if it is still owned by this process.
       if (subscriptions.has(id)) {
@@ -180,25 +196,29 @@ function main(): void {
       liveSubscriptionIds.delete(id)
       send({ op: 'subscribe-failed', id, message: errorMessage(err) })
       return null
-    } finally {
-      finishSubscriptionOperation()
     }
   }
 
   const handleUnsubscribe = async (id: number): Promise<void> => {
-    beginSubscriptionOperation()
+    // Why: invalidate a probe already in flight, but keep future probes active.
+    // A native teardown deadlock is the failure the canary exists to recover.
+    subscriptionActivityRevision++
     const pending = subscriptions.get(id)
     subscriptions.delete(id)
     liveSubscriptionIds.delete(id)
     try {
-      const subscription = await pending
-      await subscription?.unsubscribe()
+      // Why: Parcel already serializes crawl and teardown on one backend mutex.
+      // Mirror that ordering here so neither operation can mask a canary miss.
+      await runNativeWatcherLifecycleExclusive(async () => {
+        const subscription = await pending
+        await subscription?.unsubscribe()
+      })
     } catch (err) {
       process.stderr.write(
         `[parcel-watcher-process] unsubscribe ${id} failed: ${errorMessage(err)}\n`
       )
     } finally {
-      finishSubscriptionOperation()
+      subscriptionActivityRevision++
     }
     send({ op: 'unsubscribed', id })
   }
@@ -217,7 +237,7 @@ function main(): void {
   })
 
   void startCanary(() => {
-    if (pendingSubscriptionOperations > 0 || liveSubscriptionIds.size === 0) {
+    if (pendingSubscriptionCrawls > 0 || liveSubscriptionIds.size === 0) {
       return null
     }
     return subscriptionActivityRevision

--- a/src/main/ipc/parcel-watcher-process-entry.ts
+++ b/src/main/ipc/parcel-watcher-process-entry.ts
@@ -16,6 +16,7 @@ export type WatcherProcessEvent = {
 
 export type WatcherProcessSubscribeOptions = {
   ignore?: string[]
+  ignoreGlobs?: string[]
   backend?: string
 }
 
@@ -45,7 +46,7 @@ const CANARY_INTERVAL_MS = 10_000
 const CANARY_EVENT_TIMEOUT_MS = 5_000
 const CANARY_MAX_MISSES = 2
 
-async function startCanary(hasLiveSubscriptions: () => boolean): Promise<void> {
+async function startCanary(getStableActivityRevision: () => number | null): Promise<void> {
   let canaryDir: string
   let lastEventAt = 0
   try {
@@ -79,9 +80,11 @@ async function startCanary(hasLiveSubscriptions: () => boolean): Promise<void> {
 
   let misses = 0
   setInterval(() => {
-    // An idle watcher process can't wedge anything visible; only probe while
-    // roots are subscribed so an idle child doesn't restart pointlessly.
-    if (!hasLiveSubscriptions()) {
+    // Why: Parcel holds its shared backend mutex throughout each initial tree
+    // crawl, which legitimately starves canary delivery. Only apply the 5 s
+    // event SLA after every requested subscription has finished crawling.
+    const activityRevision = getStableActivityRevision()
+    if (activityRevision === null) {
       misses = 0
       return
     }
@@ -92,6 +95,12 @@ async function startCanary(hasLiveSubscriptions: () => boolean): Promise<void> {
       return
     }
     setTimeout(() => {
+      // A root may start crawling after this probe was written. Invalidate the
+      // probe instead of misclassifying lifecycle work as a delivery deadlock.
+      if (getStableActivityRevision() !== activityRevision) {
+        misses = 0
+        return
+      }
       if (lastEventAt >= probedAt) {
         misses = 0
         return
@@ -120,12 +129,26 @@ function main(): void {
   // that races a still-crawling subscribe awaits it instead of leaking the
   // native handle — on Windows a leaked handle keeps the worktree dir locked.
   const subscriptions = new Map<number, Promise<ParcelWatcher.AsyncSubscription | null>>()
+  const liveSubscriptionIds = new Set<number>()
+  let pendingSubscriptionOperations = 0
+  let subscriptionActivityRevision = 0
+
+  const beginSubscriptionOperation = (): void => {
+    pendingSubscriptionOperations++
+    subscriptionActivityRevision++
+  }
+
+  const finishSubscriptionOperation = (): void => {
+    pendingSubscriptionOperations--
+    subscriptionActivityRevision++
+  }
 
   const handleSubscribe = async (
     id: number,
     dir: string,
     opts: WatcherProcessSubscribeOptions
   ): Promise<ParcelWatcher.AsyncSubscription | null> => {
+    beginSubscriptionOperation()
     try {
       const watcher = await import('@parcel/watcher')
       const subscription = await watcher.subscribe(
@@ -145,18 +168,28 @@ function main(): void {
         },
         opts as ParcelWatcher.Options
       )
+      // An unsubscribe can remove the record while subscribe() is crawling.
+      // Only advertise it as live if it is still owned by this process.
+      if (subscriptions.has(id)) {
+        liveSubscriptionIds.add(id)
+      }
       send({ op: 'subscribed', id })
       return subscription
     } catch (err) {
       subscriptions.delete(id)
+      liveSubscriptionIds.delete(id)
       send({ op: 'subscribe-failed', id, message: errorMessage(err) })
       return null
+    } finally {
+      finishSubscriptionOperation()
     }
   }
 
   const handleUnsubscribe = async (id: number): Promise<void> => {
+    beginSubscriptionOperation()
     const pending = subscriptions.get(id)
     subscriptions.delete(id)
+    liveSubscriptionIds.delete(id)
     try {
       const subscription = await pending
       await subscription?.unsubscribe()
@@ -164,6 +197,8 @@ function main(): void {
       process.stderr.write(
         `[parcel-watcher-process] unsubscribe ${id} failed: ${errorMessage(err)}\n`
       )
+    } finally {
+      finishSubscriptionOperation()
     }
     send({ op: 'unsubscribed', id })
   }
@@ -181,7 +216,12 @@ function main(): void {
     }
   })
 
-  void startCanary(() => subscriptions.size > 0)
+  void startCanary(() => {
+    if (pendingSubscriptionOperations > 0 || liveSubscriptionIds.size === 0) {
+      return null
+    }
+    return subscriptionActivityRevision
+  })
 
   // Why: if the host dies (or kills us during shutdown), exit immediately —
   // process death releases every native watcher handle without running the

--- a/src/main/runtime/file-watcher-host.ts
+++ b/src/main/runtime/file-watcher-host.ts
@@ -13,10 +13,10 @@ import type { FileWatcherHostMessage, FileWatcherWorkerMessage } from './file-wa
 // exclusions silently fail and fseventsd delivers full node_modules churn.
 import {
   WATCHER_IGNORE_DIRS,
-  buildParcelWatcherIgnoreOption
+  buildParcelWatcherIgnoreOptions
 } from '../ipc/filesystem-watcher-ignore'
 
-const RUNTIME_FILE_WATCH_IGNORE = buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS)
+const RUNTIME_FILE_WATCH_IGNORE_OPTIONS = buildParcelWatcherIgnoreOptions(WATCHER_IGNORE_DIRS)
 
 // Why: clean teardown is async (the worker awaits subscription.unsubscribe()
 // before closing its port and exiting). Wait this long for the worker to exit on
@@ -66,7 +66,7 @@ export function watchFileExplorerInWorker(
 ): Promise<() => Promise<void>> {
   return new Promise((resolve, reject) => {
     const worker = new Worker(getFileWatcherWorkerPath(), {
-      workerData: { rootPath, ignore: RUNTIME_FILE_WATCH_IGNORE }
+      workerData: { rootPath, ignoreOptions: RUNTIME_FILE_WATCH_IGNORE_OPTIONS }
     })
 
     let ready = false

--- a/src/main/runtime/file-watcher-worker.ts
+++ b/src/main/runtime/file-watcher-worker.ts
@@ -10,13 +10,14 @@ import { stat } from 'node:fs/promises'
 import { parentPort, workerData } from 'node:worker_threads'
 import type * as ParcelWatcher from '@parcel/watcher'
 import type { FsChangeEvent } from '../../shared/types'
+import type { ParcelWatcherIgnoreOptions } from '../ipc/filesystem-watcher-ignore'
 
 const RUNTIME_FILE_WATCH_EVENT_STAT_LIMIT = 200
 const RUNTIME_FILE_WATCH_STAT_CONCURRENCY = 8
 
 type FileWatcherWorkerData = {
   rootPath: string
-  ignore: string[]
+  ignoreOptions: ParcelWatcherIgnoreOptions
 }
 
 // Messages the worker sends back to the host.
@@ -117,7 +118,7 @@ async function main(): Promise<void> {
         // rejection that crashes the worker silently. Surface it instead.
         .catch((err: unknown) => reportWatchError(err))
     },
-    { ignore: data.ignore }
+    data.ignoreOptions as ParcelWatcher.Options
   )
 
   // The crawl finished and the subscription is live.

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -36,7 +36,7 @@ import { buildRelayCommandEnv } from './relay-command-env'
 import { assertNoClobberRenameDestinationAvailable } from '../shared/filesystem-rename-collision'
 import {
   WATCHER_IGNORE_DIRS,
-  buildParcelWatcherIgnoreOption
+  buildParcelWatcherIgnoreOptions
 } from '../main/ipc/filesystem-watcher-ignore'
 
 type WatchState = {
@@ -461,9 +461,9 @@ export class FsHandler {
           }))
           this.dispatcher.notify('fs.changed', { events: mapped })
         },
-        // Why: align remote-Linux watchers with the shared nested-glob exclusion
-        // so nested node_modules/.git don't exhaust inotify on large codebases.
-        { ignore: buildParcelWatcherIgnoreOption(WATCHER_IGNORE_DIRS) }
+        // Why: align remote watchers with the shared nested exclusion so
+        // generated trees neither exhaust inotify nor trigger slow glob regexes.
+        buildParcelWatcherIgnoreOptions(WATCHER_IGNORE_DIRS)
       )
       watchState.unwatchFn = () => {
         void subscription.unsubscribe()


### PR DESCRIPTION
## Summary

- pause the Parcel watcher canary only while a native subscription crawl is active
- serialize native subscribe/unsubscribe lifecycle work in IPC receive order, preserving teardown-deadlock recovery
- invalidate probes when watcher lifecycle activity starts after the probe was written
- replace Parcel's expensive recursive ignore globs with one lookahead-free, platform-correct component regex
- apply the optimized ignore options consistently to desktop, runtime workers, Windows, and SSH relays

Addresses #8112.

## Root cause

The native stack in `InotifyBackend::handleEvents()` was a symptom of subscription setup, not an inotify-limit failure. Parcel holds its shared backend mutex while recursively crawling a root, so canary events cannot be delivered during a large crawl.

Orca considered a subscription live as soon as its promise was inserted into the map. After two missed canary deadlines, it killed the child mid-crawl. The host then respawned it and restarted every crawl from zero, producing the persistent one-core CPU loop.

Parcel 2.5.6 also converts Orca's 18 leading-`**` ignore globs into nested-lookahead expressions that are pathological in native `std::regex`. The replacement regex preserves nested `.git`, `node_modules`, build-output, and cache exclusions without that conversion.

## Correctness and lifecycle

The canary is suppressed only during active crawls. Native subscribe/unsubscribe operations use a FIFO lifecycle queue, mirroring Parcel's existing backend mutex, so:

- legitimate crawls cannot be mistaken for delivery deadlocks
- teardown deadlocks remain detectable
- later crawls cannot hide a deadlocked teardown
- unsubscribe racing a pending crawl retains IPC receive order
- failures always release the queue and balance canary state

Regression tests cover both operation orderings, pending-subscription unsubscribe, slow crawl suppression, and post-startup missed-event recovery.

## Performance evidence

Docker/Linux arm64 benchmark over a synthetic 100,000-file monorepo:

| Ignore representation | Wall time | User CPU |
| --- | ---: | ---: |
| Existing 18 picomatch globs | 10,252 ms | 9,978 ms |
| One lookahead-free native regex | 355 ms | 233 ms |

That is about 29x faster wall time and 43x less user CPU for initial subscription.

A native Linux event test also verified that a normal source-file event is delivered while a nested `.git/HEAD` event remains excluded. Differential matching over 200,000 Linux and 200,000 Windows paths found zero old/new semantic mismatches after platform-specific separator handling.

## Review-until-clean

Four adversarial review/fix rounds completed. The loop found and fixed:

1. unsubscribe deadlock recovery being suppressed with other live roots
2. crawl/teardown overlap in both receive orderings
3. pending-subscription unsubscribe losing FIFO order
4. POSIX backslashes being treated as path separators

Final lifecycle and platform/native reviews reported no proven in-scope issues.

## Tests

- Node typecheck
- 119 focused watcher/runtime/relay tests (1 platform-skipped)
- changed-file oxlint
- max-lines ratchet
- reliability gates
- relay builds for Linux, macOS, Windows, x64, and arm64

Full repository lint reaches an unrelated existing Japanese localization interpolation mismatch at `components.native-chat.composer.uploadingAttachments`; watcher lint passes.

## Residual gap

Direct native Windows event delivery was not run locally. Windows separators, exact old/new ignore matching, typechecking, and Windows relay builds are covered.

## Scope note

Appendix B in #8112 describes a separate stale-workspace Git polling problem. Current builds already bound most of the original enrichment storm, but a complete fix needs a host-aware unavailable-worktree state for local, WSL, and SSH paths. This PR deliberately does not add a local-only path check or conflate that independent lifecycle with the watcher fix.
