### PR TITLE
perf(native-chat): coalesce concurrent transcript reads

### DIFF
--- a/src/main/native-chat/transcript-read-cache-inflight-cost.bench.test.ts
+++ b/src/main/native-chat/transcript-read-cache-inflight-cost.bench.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  clearNativeChatTranscriptCache,
+  readNativeChatTranscriptCached
+} from './transcript-read-cache'
+
+const describePerf = process.env.ORCA_NATIVE_CHAT_PERF_BENCH === '1' ? describe : describe.skip
+const TARGET_BYTES = Number(process.env.ORCA_NATIVE_CHAT_PERF_BYTES ?? 16 * 1024 * 1024)
+const CONCURRENCY = Number(process.env.ORCA_NATIVE_CHAT_PERF_CONCURRENCY ?? 8)
+const ROUNDS = 5
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]
+}
+
+describePerf('native chat transcript cache concurrent-miss cost', () => {
+  let root = ''
+  let filePath = ''
+  let fileBytes = 0
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-native-chat-cache-inflight-'))
+    filePath = join(root, 'transcript.jsonl')
+    const line = `${JSON.stringify({ type: 'progress', data: 'x'.repeat(72) })}\n`
+    await writeFile(filePath, line.repeat(Math.ceil(TARGET_BYTES / Buffer.byteLength(line))))
+    fileBytes = (await stat(filePath)).size
+  })
+
+  afterAll(async () => {
+    clearNativeChatTranscriptCache()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('measures simultaneous reads of one uncached production transcript', async () => {
+    const durations: number[] = []
+    for (let round = 0; round < ROUNDS; round++) {
+      clearNativeChatTranscriptCache()
+      const startedAt = performance.now()
+      const results = await Promise.all(
+        Array.from({ length: CONCURRENCY }, () =>
+          readNativeChatTranscriptCached('claude', 'bench', filePath)
+        )
+      )
+      durations.push(performance.now() - startedAt)
+      expect(results.every((result) => 'messages' in result)).toBe(true)
+    }
+    console.log(
+      `concurrent cache misses median: ${median(durations).toFixed(2)} ms ` +
+        `(${CONCURRENCY} callers, ${fileBytes} bytes)`
+    )
+  })
+})

--- a/src/main/native-chat/transcript-read-cache.test.ts
+++ b/src/main/native-chat/transcript-read-cache.test.ts
@@ -85,6 +85,18 @@ describe('readNativeChatTranscriptCached', () => {
     expect(second).toBe(first)
   })
 
+  it('coalesces concurrent cache misses for the same transcript snapshot', async () => {
+    const filePath = await seedSession('sess-concurrent', 3)
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        readNativeChatTranscriptCached('claude', 'sess-concurrent', filePath)
+      )
+    )
+
+    expect(readSpy).toHaveBeenCalledTimes(1)
+    expect(results.every((result) => result === results[0])).toBe(true)
+  })
+
   it('re-reads when the file mtime changes', async () => {
     const filePath = await seedSession('sess-mtime', 2)
     await readNativeChatTranscriptCached('claude', 'sess-mtime')
@@ -158,9 +170,12 @@ describe('readNativeChatTranscriptCached', () => {
         : ''
 
     // Same sessionId, different transcript files (worktree A resumed into C).
-    const a = await readNativeChatTranscriptCached('claude', 'shared-session', fileA)
-    const c = await readNativeChatTranscriptCached('claude', 'shared-session', fileC)
+    const [a, c] = await Promise.all([
+      readNativeChatTranscriptCached('claude', 'shared-session', fileA),
+      readNativeChatTranscriptCached('claude', 'shared-session', fileC)
+    ])
 
+    expect(readSpy).toHaveBeenCalledTimes(2)
     expect(readText(a)).toContain('from-worktree-A')
     expect(readText(c)).toContain('from-worktree-C')
     expect(readText(c)).not.toContain('from-worktree-A')

--- a/src/main/native-chat/transcript-read-cache.ts
+++ b/src/main/native-chat/transcript-read-cache.ts
@@ -1,5 +1,6 @@
 import { stat } from 'node:fs/promises'
 import type { AgentType } from '../../shared/native-chat-types'
+import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { resolveSessionFilePath } from './session-file-resolver'
 import { readNativeChatTranscript, type ReadTranscriptResult } from './transcript-reader'
 
@@ -27,6 +28,8 @@ type CachedTranscript = {
 }
 
 const cache = new Map<string, CachedTranscript>()
+const transcriptReadsInFlight = new InFlightPromiseDedupe<ReadTranscriptResult>()
+let cacheGeneration = 0
 
 // Why: cap the cache so a long-lived process browsing many sessions can't grow
 // it unbounded. Map preserves insertion order, so evicting the first key drops
@@ -103,15 +106,25 @@ export async function readNativeChatTranscriptCached(
     return cached.result
   }
 
-  const result = await readNativeChatTranscript(agent, sessionId, { filePath })
-  if (Number.isFinite(mtimeMs)) {
-    setCached(key, { result, mtimeMs, bytes })
-  }
-  return result
+  const generation = cacheGeneration
+  // Why: desktop panes and paired clients can request one large transcript at
+  // once; share only the exact on-disk snapshot so newer appends read afresh.
+  return transcriptReadsInFlight.run(
+    stableInFlightKey([key, mtimeMs, bytes, generation]),
+    async () => {
+      const result = await readNativeChatTranscript(agent, sessionId, { filePath })
+      if (generation === cacheGeneration && Number.isFinite(mtimeMs)) {
+        setCached(key, { result, mtimeMs, bytes })
+      }
+      return result
+    }
+  )
 }
 
 /** Test-only: drop the transcript parse cache between runs. */
 export function clearNativeChatTranscriptCache(): void {
+  cacheGeneration += 1
+  transcriptReadsInFlight.clear()
   cache.clear()
 }
 


### PR DESCRIPTION
## Description

Coalesce concurrent cache misses for the same native-chat transcript snapshot. The cache now keys in-flight work by agent, resolved transcript path, mtime, byte size, and cache generation, so simultaneous desktop panes and paired web/mobile clients share one parse while changed files and different worktrees remain isolated.

This also adds:
- a deterministic regression test proving eight simultaneous callers issue one underlying read;
- concurrent cross-worktree coverage proving identical session IDs and mtimes do not collide;
- an opt-in production-boundary benchmark.

## Performance evidence

Command:

```bash
ORCA_NATIVE_CHAT_PERF_BENCH=1 pnpm exec vitest run --config config/vitest.config.ts src/main/native-chat/transcript-read-cache-inflight-cost.bench.test.ts --reporter=verbose
```

The isolated benchmark sends 8 simultaneous `readNativeChatTranscriptCached` calls through the real resolver/stat/cache/file-stream/Claude-decoder boundary for one uncached 16 MiB JSONL transcript (5 rounds, median):

| Version | Median |
| --- | ---: |
| Before | 359.81 ms |
| After | 47.65 ms |
| Improvement | 86.8% faster / 7.55x |

The before-state regression test independently confirmed 8 underlying parses; after the fix it confirms exactly 1. This is an isolated concurrent cache-miss benchmark, not end-to-end UI latency.

## ELI5

If eight Orca views asked for the same large chat at once, Orca used to photocopy and read the whole book eight separate times. Now the first request reads it and the other seven wait for that same copy, so the work happens once.

## End-user trade-offs / regressions

- No RPC, IPC, persisted-state, route, message-windowing, SSH, filesystem-routing, or provider contract changes.
- Different agents, files, mtimes, sizes, and post-clear cache generations do not share work.
- Concurrent callers now share the same settled error/result for that one snapshot. The in-flight entry clears on settle (or the existing 30-second safety timeout), so a later request retries normally.
- Completed-read LRU and byte-budget behavior is unchanged.

## Validation

- Full suite: 2,562 test files passed; 26,714 tests passed; 4 files / 34 tests skipped.
- Native-chat focused suite: 34/34 passed across cache, parser, watcher, desktop IPC, and runtime RPC/mobile windowing.
- Full node/CLI/web typecheck passed.
- Targeted `oxlint`, `oxfmt --check`, reliability gates, and max-lines ratchet passed.
- Aggregate `pnpm lint` reaches a pre-existing `ja.json` interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR does not touch localization files.