### PR TITLE
perf(terminal): avoid rebuilding stalled output backlog

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1197,7 +1197,7 @@
         "macos"
       ],
       "coveredProviders": [],
-      "coverageNotes": "Local macOS evidence over the main-process pending-output caps that exist on main@1282f5c2d. Daemon stream write(false)/drain contracts, cross-session drain priority, and bounded queued tails arrive with the pending perf slice; live flood/latency artifacts remain gaps.",
+      "coverageNotes": "Local macOS evidence covers the main-process pending-output caps and the chunk-queued retained tail. Daemon stream write(false)/drain contracts, cross-session drain priority, and bounded queued tails have deterministic contract coverage; live flood/latency artifacts remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6836",
         "https://github.com/stablyai/orca/pull/6858",
@@ -1205,14 +1205,24 @@
         "https://github.com/stablyai/orca/pull/7054"
       ],
       "invariant": "High-volume terminal output must stay bounded across daemon socket writes, main-to-renderer in-flight bytes, renderer scheduler queues, and hidden-output restore without starving focused input.",
-      "oracle": "The current executable slice injects daemon socket backpressure and main-process renderer backlog pressure, then asserts write(false)/drain ordering, bounded queued daemon bytes, per-PTY and total pending-output caps, preserved sequenced-tail metadata, active-pending protection ahead of background trimming, and ACK-gated in-flight bounds. The live Electron perf oracle adds hidden-output floods, renderer scheduler queue depth, dropped-output-zero normal scenarios, and active key latency budgets before promotion.",
+      "oracle": "The current executable slice injects daemon socket backpressure and main-process renderer backlog pressure, then asserts write(false)/drain ordering, bounded queued daemon bytes, per-PTY and total pending-output caps, repeated capped appends without prior-tail rebuilding, preserved sequenced-tail metadata, active-pending protection ahead of background trimming, and ACK-gated in-flight bounds. The live Electron perf oracle adds hidden-output floods, renderer scheduler queue depth, dropped-output-zero normal scenarios, and active key latency budgets before promotion.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty-pending-output-buffer.test.ts src/main/ipc/pty.test.ts"
       ],
       "testFiles": [
+        "src/main/ipc/pty-pending-output-buffer.test.ts",
         "src/main/ipc/pty.test.ts"
       ],
       "assertionRefs": [
+        {
+          "file": "src/main/ipc/pty-pending-output-buffer.test.ts",
+          "assertions": [
+            "avoids rebuilding a capped backlog across repeated small appends",
+            "advances through one oversized chunk without changing the newest tail",
+            "retains the newest tail and emits the drop flag only once",
+            "drops sequence metadata after transformed output breaks raw offsets"
+          ]
+        },
         {
           "file": "src/main/ipc/pty.test.ts",
           "assertions": [
@@ -1224,13 +1234,13 @@
       ],
       "evidenceRuns": [
         {
-          "date": "2026-07-03",
+          "date": "2026-07-10",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty-pending-output-buffer.test.ts src/main/ipc/pty.test.ts",
           "result": "passed",
-          "durationSeconds": 1.5,
-          "summary": "1 test file(s) passed, 209 tests passed on main@1282f5c2d in a clean checkout."
+          "durationSeconds": 1.1,
+          "summary": "2 test files passed, 238 tests passed on the exact rebased tree based on main@96d1fa1d62."
         }
       ],
       "runtimeBudget": {
@@ -1243,11 +1253,11 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Tests assert daemon stream writes pause after socket write(false), later stream data queues behind the pressured socket, flush-immediate output from another session is prioritized ahead of unrelated queued background backlog on drain while preserving per-session order, queued lines resume on drain, global cleanup clears clients that only have backpressured writes, queued daemon stream bytes are bounded by keeping priority output and the newest tail under sustained pressure, main pending renderer output is capped per PTY and in total, total-pressure trimming prefers background pending output before active pending output, trimmed pending tails preserve seq/rawLength metadata, and ACK-gated in-flight output remains bounded. Existing renderer tests cover replay/backlog slices. Needs intentional-break proof and broader hidden-output/input-latency perf artifacts before promotion."
+        "evidence": "Tests assert daemon stream writes pause after socket write(false), later stream data queues behind the pressured socket, flush-immediate output from another session is prioritized ahead of unrelated queued background backlog on drain while preserving per-session order, queued lines resume on drain, global cleanup clears clients that only have backpressured writes, queued daemon stream bytes are bounded by keeping priority output and the newest tail under sustained pressure, main pending renderer output is capped per PTY and in total, 4,096 capped 1 KiB appends and an oversized single-chunk head preserve the newest 2 MiB tail without reconstructing the retained tail per append, total-pressure trimming prefers background pending output before active pending output, trimmed pending tails preserve seq/rawLength metadata, and ACK-gated in-flight output remains bounded. Existing renderer tests cover replay/backlog slices. Needs broader intentional-break proof and hidden-output/input-latency perf artifacts before promotion."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Suggested ceilings: renderer in-flight <=8MB total, <=512KB per PTY plus active reserve, renderer queued chars <=2MB, dropped backlogs 0, hidden restore <=1000ms, active key median/worst <=75ms/300ms in perf scenarios."
+        "evidence": "Suggested ceilings: renderer in-flight <=8MB total, <=512KB per PTY plus active reserve, renderer queued chars <=2MB, dropped backlogs 0, hidden restore <=1000ms, active key median/worst <=75ms/300ms in perf scenarios. A local exact-shape run at the 2 MiB cap reduced 4,096/8,192/16,384 append time from 366.13/1,114.18/2,601.32ms to 0.52/0.55/0.61ms, with one 0.25-0.46ms drain join. Starting from one oversized chunk and then appending 4,096 1 KiB chunks reduced append time from 770.10ms to 0.07ms with the same retained tail."
       },
       "promotionCriteria": [
         "Split daemon stream backpressure into a deterministic provider/IPC contract if full E2E is flaky.",

--- a/src/main/ipc/pty-pending-output-buffer.test.ts
+++ b/src/main/ipc/pty-pending-output-buffer.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+import { PtyPendingOutputBuffer } from './pty-pending-output-buffer'
+
+describe('PTY pending output buffer', () => {
+  it('avoids rebuilding a capped backlog across repeated small appends', () => {
+    const maxChars = 2 * 1024 * 1024
+    const chunk = 'x'.repeat(1024)
+    const appendCount = 4096
+    let previousLength = 0
+    let previousLogicalCopiedChars = 0
+    for (let index = 0; index < appendCount; index += 1) {
+      previousLogicalCopiedChars += previousLength
+      previousLength += chunk.length
+      if (previousLength > maxChars) {
+        previousLogicalCopiedChars += maxChars
+        previousLength = maxChars
+      }
+    }
+    expect(previousLogicalCopiedChars).toBe(10_736_369_664)
+
+    const pending = new PtyPendingOutputBuffer(maxChars)
+    for (let index = 0; index < appendCount; index += 1) {
+      pending.append({
+        data: chunk,
+        startSeq: index * chunk.length,
+        preservesSeq: true,
+        containsBackgroundOutput: false
+      })
+    }
+
+    expect(pending.length).toBe(maxChars)
+    const drained = pending.takeAll()
+    expect(drained).toMatchObject({
+      startSeq: appendCount * chunk.length - maxChars,
+      droppedBacklog: true
+    })
+    expect(drained.data).toHaveLength(maxChars)
+    expect(drained.data).toBe('x'.repeat(maxChars))
+    expect(pending.length).toBe(0)
+  })
+
+  it('advances through one oversized chunk without changing the newest tail', () => {
+    const pending = new PtyPendingOutputBuffer(8)
+    pending.append({
+      data: 'abcdefghijkl',
+      startSeq: 100,
+      preservesSeq: true,
+      containsBackgroundOutput: false
+    })
+    for (const [index, data] of ['m', 'n', 'o', 'p'].entries()) {
+      pending.append({
+        data,
+        startSeq: 112 + index,
+        preservesSeq: true,
+        containsBackgroundOutput: false
+      })
+    }
+
+    expect(pending.takeAll()).toEqual({
+      data: 'ijklmnop',
+      startSeq: 108,
+      droppedBacklog: true
+    })
+  })
+
+  it('drains across chunk boundaries while advancing sequence and metadata', () => {
+    const pending = new PtyPendingOutputBuffer(64)
+    pending.append({
+      data: 'abc',
+      startSeq: 10,
+      preservesSeq: true,
+      containsBackgroundOutput: false
+    })
+    pending.append({
+      data: 'def',
+      startSeq: 13,
+      preservesSeq: true,
+      containsBackgroundOutput: true
+    })
+
+    expect(pending.takePrefix(4)).toEqual({
+      data: 'abcd',
+      startSeq: 10,
+      containsBackgroundOutput: true
+    })
+    expect(pending.takeAll()).toEqual({
+      data: 'ef',
+      startSeq: 14,
+      containsBackgroundOutput: true
+    })
+  })
+
+  it('retains the newest tail and emits the drop flag only once', () => {
+    const pending = new PtyPendingOutputBuffer(5)
+    pending.append({
+      data: 'abc',
+      startSeq: 100,
+      preservesSeq: true,
+      containsBackgroundOutput: false
+    })
+    pending.append({
+      data: 'def',
+      startSeq: 103,
+      preservesSeq: true,
+      containsBackgroundOutput: false
+    })
+
+    expect(pending.takePrefix(2)).toEqual({
+      data: 'bc',
+      startSeq: 101,
+      droppedBacklog: true
+    })
+    expect(pending.takeAll()).toEqual({
+      data: 'def',
+      startSeq: 103
+    })
+  })
+
+  it('drops sequence metadata after transformed output breaks raw offsets', () => {
+    const pending = new PtyPendingOutputBuffer(5)
+    pending.append({
+      data: 'abc',
+      startSeq: 10,
+      preservesSeq: true,
+      containsBackgroundOutput: false
+    })
+    pending.append({
+      data: 'WXYZ',
+      startSeq: undefined,
+      preservesSeq: false,
+      containsBackgroundOutput: false
+    })
+
+    expect(pending.takeAll()).toEqual({
+      data: 'cWXYZ',
+      droppedBacklog: true
+    })
+  })
+})

--- a/src/main/ipc/pty-pending-output-buffer.ts
+++ b/src/main/ipc/pty-pending-output-buffer.ts
@@ -1,0 +1,165 @@
+export type PtyPendingOutputAppend = {
+  data: string
+  startSeq: number | undefined
+  preservesSeq: boolean
+  containsBackgroundOutput: boolean
+}
+
+export type PtyPendingOutputChunk = {
+  data: string
+  startSeq?: number
+  containsBackgroundOutput?: boolean
+  droppedBacklog?: boolean
+}
+
+const CHUNK_STORAGE_COMPACT_THRESHOLD = 1024
+
+export class PtyPendingOutputBuffer {
+  private chunks: string[] = []
+  private headIndex = 0
+  private headOffset = 0
+  private totalChars = 0
+  private startSeq: number | undefined
+  private containsBackgroundOutput = false
+  private droppedBacklog = false
+  private readonly maxChars: number
+
+  constructor(maxChars: number) {
+    this.maxChars = Math.max(1, Math.floor(maxChars))
+  }
+
+  get length(): number {
+    return this.totalChars
+  }
+
+  append({ data, startSeq, preservesSeq, containsBackgroundOutput }: PtyPendingOutputAppend): void {
+    if (!data) {
+      return
+    }
+
+    if (this.totalChars === 0) {
+      this.startSeq = preservesSeq ? startSeq : undefined
+    } else if (!preservesSeq) {
+      // Why: transformed color-query output no longer maps one-to-one to raw
+      // provider offsets, so later payloads must omit sequence metadata too.
+      this.startSeq = undefined
+    }
+    this.containsBackgroundOutput ||= containsBackgroundOutput
+    this.chunks.push(data)
+    this.totalChars += data.length
+
+    const overflowChars = this.totalChars - this.maxChars
+    if (overflowChars <= 0) {
+      return
+    }
+    this.consumePrefix(overflowChars, true)
+    this.droppedBacklog = true
+  }
+
+  toString(): string {
+    return this.readPrefix(this.totalChars)
+  }
+
+  takePrefix(maxChars: number): PtyPendingOutputChunk {
+    const takeChars = Math.min(this.totalChars, Math.max(0, Math.floor(maxChars)))
+    if (takeChars === 0) {
+      return { data: '' }
+    }
+
+    const chunk: PtyPendingOutputChunk = {
+      data: this.readPrefix(takeChars)
+    }
+    if (typeof this.startSeq === 'number') {
+      chunk.startSeq = this.startSeq
+    }
+    if (this.containsBackgroundOutput) {
+      chunk.containsBackgroundOutput = true
+    }
+    if (this.droppedBacklog) {
+      chunk.droppedBacklog = true
+      // Why: the renderer restore is idempotent; one trim should signal only
+      // the first emitted chunk, matching the former string-buffer behavior.
+      this.droppedBacklog = false
+    }
+
+    this.consumePrefix(takeChars, false)
+    return chunk
+  }
+
+  takeAll(): PtyPendingOutputChunk {
+    return this.takePrefix(this.totalChars)
+  }
+
+  private readPrefix(charCount: number): string {
+    let remaining = charCount
+    let index = this.headIndex
+    let offset = this.headOffset
+    const parts: string[] = []
+    while (remaining > 0 && index < this.chunks.length) {
+      const source = this.chunks[index]
+      const available = source.length - offset
+      const take = Math.min(remaining, available)
+      parts.push(source.slice(offset, offset + take))
+      remaining -= take
+      index += 1
+      offset = 0
+    }
+    return parts.length === 1 ? parts[0] : parts.join('')
+  }
+
+  private consumePrefix(charCount: number, releasePartialHead: boolean): void {
+    let remaining = Math.min(charCount, this.totalChars)
+    const consumedChars = remaining
+    while (remaining > 0 && this.headIndex < this.chunks.length) {
+      const source = this.chunks[this.headIndex]
+      const available = source.length - this.headOffset
+      if (remaining < available) {
+        this.headOffset += remaining
+        remaining = 0
+        break
+      }
+      remaining -= available
+      this.chunks[this.headIndex] = ''
+      this.headIndex += 1
+      this.headOffset = 0
+    }
+
+    this.totalChars -= consumedChars
+    if (typeof this.startSeq === 'number') {
+      this.startSeq += consumedChars
+    }
+    if (this.totalChars === 0) {
+      this.resetEmptyStorage()
+      return
+    }
+
+    if (releasePartialHead && this.headOffset > 0) {
+      const source = this.chunks[this.headIndex]
+      // Why: release an oversized provider chunk immediately, then wait until
+      // half is dead so repeated cap trims stay amortized instead of re-slicing.
+      if (source.length > this.maxChars || this.headOffset * 2 >= source.length) {
+        this.chunks[this.headIndex] = source.slice(this.headOffset)
+        this.headOffset = 0
+      }
+    }
+    // Why: compact only after dead slots rival live slots; tiny provider chunks
+    // must not recopy a full capped index every 1,024 appends.
+    if (
+      this.headIndex >= CHUNK_STORAGE_COMPACT_THRESHOLD &&
+      this.headIndex >= this.chunks.length - this.headIndex
+    ) {
+      this.chunks = this.chunks.slice(this.headIndex)
+      this.headIndex = 0
+    }
+  }
+
+  private resetEmptyStorage(): void {
+    this.chunks = []
+    this.headIndex = 0
+    this.headOffset = 0
+    this.totalChars = 0
+    this.startSeq = undefined
+    this.containsBackgroundOutput = false
+    this.droppedBacklog = false
+  }
+}

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -46,6 +46,7 @@ import {
 } from '../providers/ssh-pty-provider'
 import { parseAppSshPtyId, toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
 import { createPtySpawnTiming } from './pty-spawn-timing'
+import { PtyPendingOutputBuffer } from './pty-pending-output-buffer'
 import { mintPtySessionId, isSafePtySessionId } from '../daemon/pty-session-id'
 import { addNodePtyRecoveryHint } from '../daemon/node-pty-error-hints'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
@@ -1430,15 +1431,7 @@ export function registerPtyHandlers(
   // reduces IPC round-trips from hundreds/sec to ~120/sec under high
   // throughput. Keystroke echo/redraws bypass this below because agent TUIs
   // already spend tens of ms producing their redraw.
-  type PendingPtyData = {
-    data: string
-    startSeq?: number
-    containsBackgroundOutput?: boolean
-    /** Set once this pty's unsent backlog was trimmed past the cap; rides the
-     *  next payload so the renderer rebuilds the dropped span from the main
-     *  headless snapshot (see appendPendingPtyData / dataCallback). */
-    droppedBacklog?: boolean
-  }
+  type PendingPtyData = PtyPendingOutputBuffer
 
   type PtyDataPayload = {
     id: string
@@ -1514,7 +1507,7 @@ export function registerPtyHandlers(
     let pendingChars = 0
     let maxPendingCharsByPty = 0
     for (const pending of pendingData.values()) {
-      const chars = pending.data.length
+      const chars = pending.length
       pendingChars += chars
       maxPendingCharsByPty = Math.max(maxPendingCharsByPty, chars)
     }
@@ -1548,7 +1541,7 @@ export function registerPtyHandlers(
     let pendingChars = 0
     let maxPendingCharsByPty = 0
     for (const pending of pendingData.values()) {
-      const chars = pending.data.length
+      const chars = pending.length
       pendingChars += chars
       maxPendingCharsByPty = Math.max(maxPendingCharsByPty, chars)
     }
@@ -1593,32 +1586,37 @@ export function registerPtyHandlers(
   // hoisted fn, so this bridge assignment can precede its definition).
   clearRendererDispatcherReadyWatchdog = clearDispatcherReadyWatchdog
 
-  function isLikelyInteractiveRedraw(data: string): boolean {
-    if (data.length <= INTERACTIVE_OUTPUT_MAX_CHARS) {
+  function isLikelyInteractiveRedraw(dataLength: number, containsAnsiRedraw: boolean): boolean {
+    if (dataLength <= INTERACTIVE_OUTPUT_MAX_CHARS) {
       return true
     }
     // Why: Codex-style TUIs can repaint more than 1 KB per keypress. ANSI
     // control redraws are still latency-sensitive, while plain command output
     // should stay on the throughput batch path.
-    return data.length <= INTERACTIVE_REDRAW_MAX_CHARS && data.includes('\x1b[')
+    return dataLength <= INTERACTIVE_REDRAW_MAX_CHARS && containsAnsiRedraw
   }
 
-  function shouldSendInteractiveOutputNow(id: string, data: string, now: number): boolean {
+  function shouldSendInteractiveOutputNow(
+    id: string,
+    dataLength: number,
+    containsAnsiRedraw: boolean,
+    now: number
+  ): boolean {
     const lastInputAt = lastInputAtByPty.get(id)
     if (lastInputAt === undefined || now - lastInputAt > INTERACTIVE_OUTPUT_WINDOW_MS) {
       interactiveOutputCharsByPty.delete(id)
       return false
     }
-    if (!isLikelyInteractiveRedraw(data)) {
+    if (!isLikelyInteractiveRedraw(dataLength, containsAnsiRedraw)) {
       interactiveOutputCharsByPty.set(id, INTERACTIVE_OUTPUT_BUDGET_CHARS)
       return false
     }
     const usedChars = interactiveOutputCharsByPty.get(id) ?? 0
-    if (usedChars + data.length > INTERACTIVE_OUTPUT_BUDGET_CHARS) {
+    if (usedChars + dataLength > INTERACTIVE_OUTPUT_BUDGET_CHARS) {
       interactiveOutputCharsByPty.set(id, INTERACTIVE_OUTPUT_BUDGET_CHARS)
       return false
     }
-    interactiveOutputCharsByPty.set(id, usedChars + data.length)
+    interactiveOutputCharsByPty.set(id, usedChars + dataLength)
     return true
   }
 
@@ -1715,28 +1713,6 @@ export function registerPtyHandlers(
     return [...active, ...background]
   }
 
-  // Why: bound the unsent backlog to the most-recent PENDING_DATA_MAX_CHARS,
-  // advancing startSeq by the dropped-char count (same arithmetic flushPendingData
-  // uses when it slices) so the remaining tail's seq stays correct. Flags
-  // droppedBacklog so the next payload tells the renderer to rebuild the dropped
-  // span from the main headless snapshot. A no-op when under the cap (the common
-  // case: the renderer is ACKing and pendingData stays tiny).
-  function capPendingPtyData(pending: PendingPtyData): PendingPtyData {
-    if (pending.data.length <= PENDING_DATA_MAX_CHARS) {
-      return pending
-    }
-    const trimmed = pending.data.slice(pending.data.length - PENDING_DATA_MAX_CHARS)
-    const droppedChars = pending.data.length - trimmed.length
-    const next: PendingPtyData = { data: trimmed, droppedBacklog: true }
-    if (typeof pending.startSeq === 'number') {
-      next.startSeq = pending.startSeq + droppedChars
-    }
-    if (pending.containsBackgroundOutput === true) {
-      next.containsBackgroundOutput = true
-    }
-    return next
-  }
-
   function appendPendingPtyData(
     existing: PendingPtyData | undefined,
     data: string,
@@ -1744,31 +1720,11 @@ export function registerPtyHandlers(
     preservesSeq: boolean,
     containsBackgroundOutput: boolean
   ): PendingPtyData {
-    const nextContainsBackgroundOutput =
-      existing?.containsBackgroundOutput === true || containsBackgroundOutput
-    // Carry a prior drop flag forward until it actually rides an outgoing payload.
-    const inheritedDropped = existing?.droppedBacklog === true
-    const base: PendingPtyData = { data: '' }
-    if (!preservesSeq) {
-      base.data = (existing?.data ?? '') + data
-    } else if (!existing) {
-      base.data = data
-      if (typeof startSeq === 'number') {
-        base.startSeq = startSeq
-      }
-    } else {
-      base.data = existing.data + data
-      if (typeof existing.startSeq === 'number') {
-        base.startSeq = existing.startSeq
-      }
-    }
-    if (nextContainsBackgroundOutput) {
-      base.containsBackgroundOutput = true
-    }
-    if (inheritedDropped) {
-      base.droppedBacklog = true
-    }
-    return capPendingPtyData(base)
+    const pending = existing ?? new PtyPendingOutputBuffer(PENDING_DATA_MAX_CHARS)
+    // Why: a frozen renderer can leave this queue at the 2 MB cap for many
+    // chunks. Append to the chunk queue instead of rebuilding that whole tail.
+    pending.append({ data, startSeq, preservesSeq, containsBackgroundOutput })
+    return pending
   }
 
   function schedulePendingDataFlush(delayMs: number): void {
@@ -1831,30 +1787,20 @@ export function registerPtyHandlers(
         continue
       }
       pendingData.delete(id)
-      const { data } = pending
-      const chunk = data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
-      const remaining = data.slice(PTY_BATCH_FLUSH_CHUNK_CHARS)
-      if (remaining) {
-        const nextPending: PendingPtyData = { data: remaining }
-        if (typeof pending.startSeq === 'number') {
-          nextPending.startSeq = pending.startSeq + chunk.length
-        }
-        if (pending.containsBackgroundOutput === true) {
-          nextPending.containsBackgroundOutput = true
-        }
-        pendingData.set(id, nextPending)
+      const outgoing = pending.takePrefix(PTY_BATCH_FLUSH_CHUNK_CHARS)
+      if (pending.length > 0) {
+        pendingData.set(id, pending)
       }
       // Why: the drop flag rides the first emitted chunk (renderer restore is
-      // idempotent) and is intentionally not copied onto `remaining` above, so a
-      // single backlog trim signals the renderer exactly once.
+      // idempotent), so a single backlog trim signals the renderer exactly once.
       sendPtyDataToRenderer(
         id,
         makePtyDataPayload(
           id,
-          chunk,
-          pending.startSeq,
-          pending.containsBackgroundOutput,
-          pending.droppedBacklog
+          outgoing.data,
+          outgoing.startSeq,
+          outgoing.containsBackgroundOutput,
+          outgoing.droppedBacklog
         )
       )
       writes++
@@ -1913,14 +1859,15 @@ export function registerPtyHandlers(
     // tears down the terminal on pty:exit before the batch timer fires.
     const remaining = pendingData.get(payload.id)
     if (remaining) {
+      const outgoing = remaining.takeAll()
       sendPtyDataToRenderer(
         payload.id,
         makePtyDataPayload(
           payload.id,
-          remaining.data,
-          remaining.startSeq,
-          remaining.containsBackgroundOutput,
-          remaining.droppedBacklog
+          outgoing.data,
+          outgoing.startSeq,
+          outgoing.containsBackgroundOutput,
+          outgoing.droppedBacklog
         )
       )
       pendingData.delete(payload.id)
@@ -2009,11 +1956,22 @@ export function registerPtyHandlers(
         preservesSeq,
         containsBackgroundOutput
       )
-      const nextData = pending.data
+      const pendingLength = pending.length
+      const now = performance.now()
+      const lastInputAt = lastInputAtByPty.get(payload.id)
+      // Why: ANSI classification matters only for recent-input redraws inside
+      // 16 KiB; never join an ordinary or multi-megabyte stalled backlog for it.
+      const containsAnsiRedraw =
+        pendingLength > INTERACTIVE_OUTPUT_MAX_CHARS &&
+        pendingLength <= INTERACTIVE_REDRAW_MAX_CHARS &&
+        lastInputAt !== undefined &&
+        now - lastInputAt <= INTERACTIVE_OUTPUT_WINDOW_MS &&
+        pending.toString().includes('\x1b[')
       const isInteractiveOutput = shouldSendInteractiveOutputNow(
         payload.id,
-        nextData,
-        performance.now()
+        pendingLength,
+        containsAnsiRedraw,
+        now
       )
       // Why: gate the interactive fast path on the dispatcher handshake too, so
       // boot-window keystroke echo accrues in pendingData instead of being sent
@@ -2029,17 +1987,19 @@ export function registerPtyHandlers(
         }
         pendingData.delete(payload.id)
         clearFlushTimerIfIdle()
+        const outgoing = pending.takeAll()
         // Why: agent TUIs redraw small prompt regions after every keystroke.
         // Waiting for the throughput batch timer adds visible input latency.
-        sendPtyDataToRenderer(payload.id, {
-          id: payload.id,
-          data: nextData,
-          ...(typeof pending.startSeq === 'number'
-            ? { seq: pending.startSeq + nextData.length, rawLength: nextData.length }
-            : {}),
-          ...(pending.containsBackgroundOutput === true ? { background: true } : {}),
-          ...(pending.droppedBacklog === true ? { droppedBacklog: true } : {})
-        })
+        sendPtyDataToRenderer(
+          payload.id,
+          makePtyDataPayload(
+            payload.id,
+            outgoing.data,
+            outgoing.startSeq,
+            outgoing.containsBackgroundOutput,
+            outgoing.droppedBacklog
+          )
+        )
         return
       }
       pendingData.set(payload.id, pending)


### PR DESCRIPTION
## Summary

When renderer ACKs stall, main retains up to 2 MiB of unsent PTY output. That backlog was one string, so every later provider chunk concatenated and sliced the retained tail again. A frozen/background renderer could therefore make ordinary terminal output increasingly expensive even though the byte cap held.

This replaces that string with a bounded chunk queue. Appends advance through old chunks without rebuilding the retained tail; strings are materialized only for the existing 16 KiB flush slices, a recent-input ANSI classification, or the required final drain. Sequence offsets, background metadata, one-shot `droppedBacklog`, active-terminal priority, ACK bounds, and exit-before-data ordering remain unchanged.

Representative local exact-shape measurements at the 2 MiB cap:

| 1 KiB appends | Previous append path | Chunk queue append | One drain join |
| ---: | ---: | ---: | ---: |
| 4,096 | 366.13 ms | 0.52 ms | 0.46 ms |
| 8,192 | 1,114.18 ms | 0.55 ms | 0.29 ms |
| 16,384 | 2,601.32 ms | 0.61 ms | 0.25 ms |

The 4,096-chunk fixture represents 10,736,369,664 logical prior characters rebuilt by the previous shape. A second fixture starting with one 5 MiB provider chunk and then appending 4,096 1 KiB chunks measured 770.10 ms to 0.07 ms, with the same retained 2 MiB tail and sequence.

## Screenshots

No visual change. Exact-commit Electron validation visibly rendered `PTY_FINAL_VISIBLE_OK` in the real terminal; the screenshot remains local evidence and is not committed.

## Testing

- [ ] `pnpm lint` — all code, switch-exhaustiveness, reliability, and max-lines stages pass; aggregate lint stops at the unchanged `ja.json` interpolation mismatch for `components.native-chat.composer.uploadingAttachments`
- [x] `pnpm typecheck` — node, CLI, and web passed
- [x] `pnpm test` — 2,563 files / 26,718 tests passed; 3 files / 33 tests skipped
- [ ] `pnpm build` — production build not run; the exact commit completed Electron main, preload, and renderer dev builds twice
- [x] Added focused regression coverage — 2 files / 238 tests passed for the registered backpressure gate

Additional gates:

- `pnpm run check:reliability-gates`
- `pnpm run check:max-lines-ratchet`
- targeted `oxlint`, `oxfmt --check`, and `git diff --check`
- exact commit `c02fc1cddd` in Electron on isolated ports: real terminal input/output, focused input, live PTY, and zero pending/in-flight delivery after renderer ACK

## AI Review Report

The review audited the PTY append, partial-flush, interactive bypass, exit, lifecycle-reset, and metadata paths for ordering and bounded work. It found and fixed two edge cases before submission: ANSI classification could join a small queue without recent input, and repeated cap trims after one oversized provider chunk could re-slice a shrinking large head. The final queue gates ANSI materialization on the existing 100 ms interactive window and releases partial heads amortized rather than per append.

Cross-platform review found no new shortcuts, labels, paths, shell commands, subprocesses, or native APIs. The implementation uses the existing JavaScript string-length contract and main-process delivery path on macOS, Linux, and Windows. Local and daemon behavior have deterministic coverage; WSL shares the local main-delivery shape but was not live-tested on Windows. SSH and remote-runtime transports use separate provider/transport paths and are unchanged rather than claimed as covered.

## Security Audit

No auth, secrets, dependency, filesystem path, shell execution, or external IPC schema changes. Provider output was already trusted only as terminal data and remains capped at the existing 2 MiB logical-character limit. The queue does not interpret output beyond the existing bounded ANSI substring check, and emitted payload fields are unchanged.

## Reliability proof

- **Gate:** `terminal-performance.output-backpressure-budget` (experimental / partial, unchanged maturity)
- **Touched class:** main-process PTY output backpressure and renderer delivery
- **Invariant:** repeated output while renderer ACKs are stalled must remain bounded without rebuilding the retained 2 MiB tail; ordering, sequence metadata, drop signaling, ACK limits, and focused-input priority must remain unchanged
- **Failure source:** the prior capped string still performed `existing + data` and newest-tail slicing for every provider chunk
- **Product change type:** performance hardening plus deterministic gate coverage
- **Oracle:** focused buffer contracts prove newest-tail content, sequence advancement/invalidation, background metadata, partial drains, oversized heads, and one-shot drop signaling; the existing 233 PTY IPC tests prove cap, ACK, lifecycle reset, active priority, exit flushing, and interactive behavior; exact Electron proves visible real input/output and drained delivery accounting
- **Diagnostics:** the existing renderer-delivery debug snapshot continues to expose pending/in-flight current and peak chars, ACK-gated skips, lifecycle resets, and dispatcher readiness
- **Provider/platform coverage:** macOS local/installed-provider live path covered; local and daemon contract paths covered; Linux, Windows, and WSL code-compatible but not live-tested; SSH, remote-runtime, and mobile/relay paths unaffected
- **Residual gaps:** no live frozen-renderer 2 MiB soak, Linux/Windows/WSL live run, or renderer parse/input-latency artifact; those remain explicit promotion criteria in the experimental gate
- **Rollback/demotion rule:** revert or follow up if output order, sequence/raw-length metadata, one-shot restore signaling, ACK bounds, or interactive latency regress; do not promote the gate without the existing cross-platform live artifacts

## Notes

This PR does not change the 2 MiB cap or renderer restore behavior. It changes only how the already-bounded pending tail is represented and drained.

## ELI5

This branch kept a backed-up terminal queue as chunks instead of copying up to 2 MiB for every new output piece. It was closed because current main shipped a newer queue strategy, so this describes the branch’s intent rather than merged behavior.
