### PR TITLE
perf(grok): avoid repeated session discovery retries

### DIFF
--- a/src/main/agent-hooks/server-grok-discovery.test.ts
+++ b/src/main/agent-hooks/server-grok-discovery.test.ts
@@ -3,12 +3,17 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as agentHookListener from '../../shared/agent-hook-listener'
+import {
+  clearGrokSessionPathLookupCacheForTests,
+  setGrokSessionPathScannerForTests
+} from '../../shared/grok-session-paths'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import { AgentHookServer } from './server'
 
 const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
 
 afterEach(() => {
+  clearGrokSessionPathLookupCacheForTests()
   vi.restoreAllMocks()
   vi.unstubAllEnvs()
 })
@@ -38,6 +43,35 @@ async function postGrokHook(
 }
 
 describe('AgentHookServer Grok discovery retries', () => {
+  it('runs slug-group discovery once while bounded content retries continue', async () => {
+    let scanCount = 0
+    setGrokSessionPathScannerForTests(async () => {
+      scanCount += 1
+      return null
+    })
+    const server = new AgentHookServer()
+    const root = mkdtempSync(join(tmpdir(), 'orca-grok-discovery-count-'))
+    vi.stubEnv('HOME', root)
+    vi.stubEnv('USERPROFILE', root)
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const endpoint = { port: env.ORCA_AGENT_HOOK_PORT, token: env.ORCA_AGENT_HOOK_TOKEN }
+
+      await postGrokHook(endpoint, {
+        hookEventName: 'Stop',
+        sessionId: '019e37f4-5135-7b63-a4ab-6d13aa6bf534',
+        cwd: join(root, 'workspace')
+      })
+      await new Promise((resolve) => setTimeout(resolve, 400))
+
+      expect(scanCount).toBe(1)
+    } finally {
+      server.stop()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('waits for delayed discovery beyond the transcript retry window', async () => {
     let releaseDiscovery!: () => void
     const discovery = new Promise<void>((resolve) => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1172,12 +1172,9 @@ export function hasPendingAgentResultText(source: AgentHookSource, body: unknown
     const transcriptPath = record.transcriptPath ?? record.transcript_path
     return typeof transcriptPath === 'string' && transcriptPath.trim().length > 0
   }
-  const pendingGrokDiscovery = preparePendingGrokResultDiscovery(source, body)
-  if (pendingGrokDiscovery) {
-    void pendingGrokDiscovery
-    return true
-  }
-  return false
+  // Why: this predicate runs before every bounded content retry. Starting path
+  // discovery here repeated a full Grok sessions-root scan on every retry.
+  return readPendingGrokResultMetadata(source, body) !== undefined
 }
 
 function hasNonEmptyString(value: unknown): boolean {
@@ -1191,19 +1188,18 @@ function hasExplicitLastAssistantResult(record: Record<string, unknown>): boolea
   )
 }
 
-/** Start bounded discovery only for a Grok completion that still needs result text. */
-export function preparePendingGrokResultDiscovery(
+function readPendingGrokResultMetadata(
   source: AgentHookSource,
   body: unknown
-): Promise<void> | null {
+): GrokSessionMetadata | undefined {
   if (source !== 'grok') {
-    return null
+    return undefined
   }
   const envelope =
     typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : null
   const record = parseHookBodyPayloadRecord(body)
   if (!record || hasExplicitLastAssistantResult(record)) {
-    return null
+    return undefined
   }
   const eventName =
     envelope?.hook_event_name ??
@@ -1211,12 +1207,17 @@ export function preparePendingGrokResultDiscovery(
     record.hook_event_name ??
     record.hookEventName
   if (!isGrokEvent(eventName, 'stop', 'session_end')) {
-    return null
+    return undefined
   }
-  const metadata = readGrokSessionMetadata(
-    record,
-    envelope ? readGrokHomeEnvelope(envelope) : undefined
-  )
+  return readGrokSessionMetadata(record, envelope ? readGrokHomeEnvelope(envelope) : undefined)
+}
+
+/** Start bounded discovery only for a Grok completion that still needs result text. */
+export function preparePendingGrokResultDiscovery(
+  source: AgentHookSource,
+  body: unknown
+): Promise<void> | null {
+  const metadata = readPendingGrokResultMetadata(source, body)
   if (!metadata) {
     return null
   }

--- a/src/shared/grok-session-path-discovery-cost.bench.test.ts
+++ b/src/shared/grok-session-path-discovery-cost.bench.test.ts
@@ -1,0 +1,53 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  clearGrokSessionPathLookupCacheForTests,
+  findGrokChatHistoryBySessionId,
+  GROK_SESSION_GROUP_SCAN_MAX_ENTRIES
+} from './grok-session-paths'
+
+const describePerf = process.env.ORCA_GROK_PATH_PERF_BENCH === '1' ? describe : describe.skip
+const ROUNDS = 5
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]
+}
+
+describePerf('Grok session path discovery cost', () => {
+  let root = ''
+  let sessionsDir = ''
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-grok-path-cost-'))
+    sessionsDir = join(root, 'sessions')
+    await mkdir(sessionsDir)
+    await Promise.all(
+      Array.from({ length: GROK_SESSION_GROUP_SCAN_MAX_ENTRIES }, (_unused, index) =>
+        mkdir(join(sessionsDir, `group-${index}`))
+      )
+    )
+  })
+
+  afterAll(async () => {
+    clearGrokSessionPathLookupCacheForTests()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('measures one bounded missing-session scan through real filesystem IO', async () => {
+    const durations: number[] = []
+    for (let round = 0; round < ROUNDS; round++) {
+      clearGrokSessionPathLookupCacheForTests()
+      const startedAt = performance.now()
+      const result = await findGrokChatHistoryBySessionId(sessionsDir, `missing-session-${round}`)
+      durations.push(performance.now() - startedAt)
+      expect(result).toBeNull()
+    }
+    console.log(
+      `bounded Grok discovery median: ${median(durations).toFixed(2)} ms ` +
+        `(${GROK_SESSION_GROUP_SCAN_MAX_ENTRIES} groups)`
+    )
+  })
+})


### PR DESCRIPTION
## Description

Make `hasPendingAgentResultText` a side-effect-free predicate and start Grok slug-group path discovery only from `preparePendingGrokResultDiscovery`.

Previously the predicate ran before every 50 ms assistant-content retry and started a new bounded sessions-root discovery each time. The path lookup already has in-flight dedupe, but once a fast miss settled the next retry launched another scan. The server now discovers the path once, then keeps the existing five bounded content retries for delayed transcript writes.

## Performance evidence

### Production retry-loop count

A regression test posts a real Grok `Stop` hook through `AgentHookServer` and counts the path-scanner boundary across the complete retry window:

| Version | Discoveries per Stop |
| --- | ---: |
| Before | 7 |
| After | 1 |
| Improvement | 85.7% fewer scans |

The test failed red with `expected 7 to be 1` before the change and passes after it.

### Real filesystem cost of one scan

Command:

```bash
ORCA_GROK_PATH_PERF_BENCH=1 pnpm exec vitest run --config config/vitest.config.ts src/shared/grok-session-path-discovery-cost.bench.test.ts --reporter=verbose
```

The isolated benchmark creates 2,048 real session-group directories, runs five bounded missing-session discoveries, and reports the median:

- One discovery: **62.06 ms median** on the test machine.
- At the reproduced 7-scan maximum, that is up to ~434 ms of aggregate filesystem scan work; reducing it to one avoids ~372 ms.

These are isolated scan/count measurements, not end-to-end UI latency. On slower filesystems the per-scan cost can be higher; when a scan remains in flight, the existing lookup queue may already collapse overlapping retries.

## ELI5

When Grok finished, Orca checked for the answer several times because the file might be written a moment late. Each check also started searching up to 2,048 folders again—like re-searching the whole filing cabinet whenever you re-open one drawer. Now Orca searches for the right folder once, then only re-checks that file for the delayed answer.

## End-user trade-offs / regressions

- The five delayed-content retries are unchanged, so late final assistant text is still recovered.
- The only production caller of the pending predicate immediately invokes the explicit discovery function when the predicate is true; no current runtime behavior depends on the old hidden side effect.
- Local/remote Grok-home resolution, session IDs, status payloads, RPC/IPC, persisted state, SSH/WSL routing, and mobile/relay contracts are unchanged.
- A future internal caller must use `preparePendingGrokResultDiscovery` when it wants I/O; calling the predicate alone now performs no filesystem work.

## Reliability proof

- **Reliability class:** `agent-session.status-final-result`.
- **Invariant:** one Grok completion performs at most one bounded path discovery, while timed content retries still surface a delayed final assistant message and never overwrite a newer turn.
- **Failure source:** discovery I/O was hidden inside a predicate called on every retry.
- **Product change type:** performance hardening.
- **Oracle:** the live hook-server test asserts one scanner call; existing delayed-discovery and newer-turn tests assert final-message recovery and stale-result rejection.
- **Performance risk inventory:** reduces agent-status filesystem scans; does not touch typing, focus, tab/workspace switching, render, PTY output, session listing, startup, subprocesses, polling intervals, SSH transport, or mobile payloads.
- **Provider/platform coverage:** local and runtime-relative Grok homes are covered by existing tests; daemon PTY, SSH, WSL, remote-runtime transport, mobile/relay, macOS/Linux/Windows behavior are unaffected because path construction and wire/state contracts did not change. No live Windows/SSH run was needed for this host-side call-count change.
- **Diagnostics:** existing Grok discovery failure logging remains unchanged.
- **Manifest status / promotion:** no matching `config/reliability-gates.jsonc` entry; deterministic unit/integration coverage is added without promoting a gate.
- **Residual gap:** the 62.06 ms benchmark is macOS filesystem evidence, not a cross-platform latency claim.
- **Rollback rule:** revert if delayed Grok assistant text stops appearing or the integration count rises above one discovery per completion.

## Validation

Tested commit: `726060879a0aae196fbb84f8114dbe03e386f89d`

- Full suite: 2,562 test files passed; 26,714 tests passed; 4 files / 34 tests skipped.
- Focused Grok/agent-hook coverage: 90/90 passed.
- Full node/CLI/web typecheck passed.
- Targeted `oxlint`, `oxfmt --check`, reliability manifest check, and max-lines ratchet passed.
- Aggregate `pnpm lint` remains blocked on main’s unrelated `ja.json` interpolation mismatch for `components.native-chat.composer.uploadingAttachments`; this PR does not touch localization files.