### PR TITLE
Keep Parcel watcher isolation in Electron dev builds

### DIFF
--- a/src/main/ipc/parcel-watcher-entry-path.test.ts
+++ b/src/main/ipc/parcel-watcher-entry-path.test.ts
@@ -1,0 +1,40 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveWatcherProcessEntryPath } from './parcel-watcher-entry-path'
+
+describe('resolveWatcherProcessEntryPath', () => {
+  it('uses an adjacent entry when electron-vite appPath is already out/main', () => {
+    const builtMainPath = path.join(process.cwd(), 'out', 'main')
+    const adjacentEntry = path.join(builtMainPath, 'parcel-watcher-process-entry.js')
+
+    expect(
+      resolveWatcherProcessEntryPath(
+        builtMainPath,
+        false,
+        (candidate) => candidate === adjacentEntry
+      )
+    ).toBe(adjacentEntry)
+  })
+
+  it('uses the nested build entry when appPath is the project root', () => {
+    expect(resolveWatcherProcessEntryPath(process.cwd(), false, () => false)).toBe(
+      path.join(process.cwd(), 'out', 'main', 'parcel-watcher-process-entry.js')
+    )
+  })
+
+  it('uses the unpacked nested entry for packaged apps', () => {
+    const appPath = path.join('C:', 'Orca', 'resources', 'app.asar')
+
+    expect(resolveWatcherProcessEntryPath(appPath, true, () => true)).toBe(
+      path.join(
+        'C:',
+        'Orca',
+        'resources',
+        'app.asar.unpacked',
+        'out',
+        'main',
+        'parcel-watcher-process-entry.js'
+      )
+    )
+  })
+})

--- a/src/main/ipc/parcel-watcher-entry-path.ts
+++ b/src/main/ipc/parcel-watcher-entry-path.ts
@@ -1,0 +1,37 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+type ElectronAppPath = { getAppPath(): string; isPackaged: boolean }
+
+function loadElectronApp(): ElectronAppPath | null {
+  try {
+    return require('electron').app ?? null
+  } catch {
+    return null
+  }
+}
+
+export function resolveWatcherProcessEntryPath(
+  appPath: string,
+  isPackaged: boolean,
+  pathExists: (candidate: string) => boolean = existsSync
+): string {
+  // Why: ELECTRON_RUN_AS_NODE bypasses Electron's asar integration, so the
+  // packaged entry must be forked from app.asar.unpacked.
+  const basePath = isPackaged ? appPath.replace('app.asar', 'app.asar.unpacked') : appPath
+  const adjacentBuildEntry = join(basePath, 'parcel-watcher-process-entry.js')
+  // Why: electron-vite's unpackaged appPath is already out/main. Appending
+  // out/main again silently disables crash isolation in dev and E2E builds.
+  if (!isPackaged && pathExists(adjacentBuildEntry)) {
+    return adjacentBuildEntry
+  }
+  return join(basePath, 'out', 'main', 'parcel-watcher-process-entry.js')
+}
+
+export function getWatcherProcessEntryPath(): string {
+  const app = loadElectronApp()
+  return resolveWatcherProcessEntryPath(
+    app?.getAppPath() ?? process.cwd(),
+    app?.isPackaged === true
+  )
+}

--- a/src/main/ipc/parcel-watcher-process.ts
+++ b/src/main/ipc/parcel-watcher-process.ts
@@ -6,8 +6,8 @@
 // they can refresh state that changed during the gap.
 import { fork, type ChildProcess } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
 import type * as ParcelWatcher from '@parcel/watcher'
+import { getWatcherProcessEntryPath } from './parcel-watcher-entry-path'
 import type {
   HostToWatcherMessage,
   WatcherProcessEvent,
@@ -41,23 +41,6 @@ let shutdownRequested = false
 let loggedInProcessFallback = false
 const records = new Map<number, SubscriptionRecord>()
 const pendingUnsubscribes = new Map<number, () => void>()
-
-function loadElectronApp(): { getAppPath(): string; isPackaged: boolean } | null {
-  try {
-    return require('electron').app ?? null
-  } catch {
-    return null
-  }
-}
-
-function getWatcherProcessEntryPath(): string {
-  const app = loadElectronApp()
-  const appPath = app?.getAppPath() ?? process.cwd()
-  // Why: ELECTRON_RUN_AS_NODE bypasses Electron's asar integration, so the
-  // packaged entry must be forked from app.asar.unpacked.
-  const basePath = app?.isPackaged ? appPath.replace('app.asar', 'app.asar.unpacked') : appPath
-  return join(basePath, 'out', 'main', 'parcel-watcher-process-entry.js')
-}
 
 function shouldRunInProcess(entryPath: string): boolean {
   // Why: vitest suites mock '@parcel/watcher' at the module level; a forked


### PR DESCRIPTION
## Description

This is a follow-up to the Windows native Parcel watcher crash isolated in #7757 while auditing the 11 crash submissions collected from July 6–10.

The packaged app already forks `@parcel/watcher` from `app.asar.unpacked`, but unpackaged electron-vite builds did not always exercise that protection. In dev/E2E, Electron reports `app.getAppPath()` as `<repo>/out/main`. The watcher client appended another `out/main`, looked for:

```text
<repo>/out/main/out/main/parcel-watcher-process-entry.js
```

Because that file does not exist, it silently fell back to loading the native watcher in the host process—the exact unsafe architecture that the crash isolation was meant to remove.

This PR resolves an adjacent built entry first for unpackaged Electron layouts, while preserving the existing project-root and packaged `app.asar.unpacked` layouts. The path logic is split into a focused module so the existing watcher client remains below the repository's max-lines limit.

### All 11 crash reports audited

| Reports | Field signature | Reproduction result / action |
| --- | --- | --- |
| `33403b63`, `9fb92a8b`, `ac931617`, `dfd9076a`, `a8aa5a64` | Renderer OOM / memory-pressure family. `dfd9076a` was the unambiguous heap case: 3,586 MB JS heap and 4,338 MB renderer working set. | The current large-source-control workload stayed at 24.80 MB JS heap across three refresh cycles with 46 mounted rows, and the retained-agent leak suite passed. Those protections are already on `main` via #7528, #7619, and #8022. The exact remaining low-heap OOM exits did not reproduce, so this PR does not claim to fix them. |
| `92d6438a`, `53cfba60`, `54445e13` | Paired GPU/renderer `STATUS_BREAKPOINT` (`0x80000003`) after `gpu_fallback_applied`. | A software-rendering crash attempt produced a renderer-only `0xC0000005`, not the field's paired breakpoint failure. This is hardware/driver-specific on the available Windows machine; no speculative GPU flag change is included. |
| report 06 (`not captured`, issue #7742) | Main-process/native watcher crash under heavy multi-worktree churn, followed by terminal pipe loss. | Reproduced directly in 921 ms with `@parcel/watcher` in-process. #7757 fixed packaged builds; this PR closes the discovered dev/E2E entry-path hole so those builds also keep the native watcher out of the host. |
| `e101441e`, `af19c3b1` | Generic renderer `crashed` / exit `-1`, low stable heap. | The bundles contain no process-gone span, renderer exception, or causal breadcrumb, and the workload did not reproduce the exit. There is no evidence-backed code change to make for these two reports. |

## CLEAR UNDENIABLE fix evidence

### Red: native crash reproduced first

```text
node tools/repro-watcher-crash-7547/run.cjs delete-root 3 15000

iteration 1: exit=3221225477 (0xC0000005) after 921ms
*** NATIVE CRASH REPRODUCED ***
```

### Red: this path bug fails the regression test

With the adjacent-entry branch removed and the test retained:

```text
Expected: <repo>\out\main\parcel-watcher-process-entry.js
Received: <repo>\out\main\out\main\parcel-watcher-process-entry.js

Test Files  1 failed
Tests       1 failed | 13 passed
```

### Green: same native failure is contained after the fix

Against a fresh `electron-vite build --mode e2e` artifact:

```text
[parcel-watcher-process] watcher process exited (code=3221226505, signal=null)
[parcel-watcher-process] watcher process crashed; resubscribing 5 root(s)
[fixed-harness] subs=453 unsubs=453 events=364 watchErrors=0
[fixed-harness] containedCrashes=1 healthy=true fallback=false
[fixed-harness] PASS: host survived; watcher functional
```

The child hit Windows `0xC0000409`, but the host survived, delivered file events, recovered a healthy watcher, and never used the in-process fallback.

## ELI5

Orca put the crash-prone file watcher in a separate safety box. Development builds accidentally looked for that box inside another copy of the same folder, could not find it, and quietly brought the watcher back into Orca itself. This change looks beside the running development app first, finds the real safety box, and keeps a watcher crash from taking Orca down with it.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/parcel-watcher-entry-path.test.ts src/main/ipc/parcel-watcher-process.test.ts` — 2 files, 16 tests passed
- `pnpm typecheck:node` — passed after rebasing onto current `origin/main`
- `pnpm check:max-lines-ratchet` — passed; no new suppression or limit bump
- changed-file `oxlint`, `oxfmt --check`, and `git diff --check` — passed
- `pnpm exec electron-vite build --mode e2e` — passed; emitted `out/main/parcel-watcher-process-entry.js`
- live Windows pre-fix and isolated watcher stress commands shown above

## Trade-offs

- Unpackaged Electron dev/E2E sessions now pay the intended cost of one watcher child process plus IPC instead of using the lower-overhead unsafe in-process fallback.
- Packaged behavior is unchanged. Project-root Node harnesses retain the nested `out/main` lookup, and packaged apps retain the `app.asar.unpacked/out/main` lookup.
- If an unpackaged adjacent entry does not exist, behavior still falls back to the previous nested lookup and warning path.
- There is no UI behavior change and no SSH/remote-provider routing change; this only selects the local watcher executable path. All paths use Node's cross-platform path utilities.

## Security audit

No new network, shell, or user-controlled execution surface is introduced. The code selects between existing build artifacts using `path.join` and `existsSync`; the fork target and `ELECTRON_RUN_AS_NODE` behavior are unchanged.
