### PR TITLE
perf(runtime): reuse unchanged PTY path history

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1178,6 +1178,7 @@
       "surfaces": [
         "daemon stream",
         "main PTY batching",
+        "runtime path provenance",
         "renderer ACK",
         "xterm scheduler",
         "hidden output"
@@ -1197,20 +1198,22 @@
         "macos"
       ],
       "coveredProviders": [],
-      "coverageNotes": "Local macOS evidence over the main-process pending-output caps that exist on main@1282f5c2d. Daemon stream write(false)/drain contracts, cross-session drain priority, and bounded queued tails arrive with the pending perf slice; live flood/latency artifacts remain gaps.",
+      "coverageNotes": "Local macOS evidence covers the existing main-process pending-output caps plus deterministic runtime path-provenance history reuse. Daemon stream write(false)/drain contracts, cross-session drain priority, and bounded queued tails arrive with the pending perf slice; live flood/latency artifacts remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6836",
         "https://github.com/stablyai/orca/pull/6858",
         "https://github.com/stablyai/orca/pull/7002",
         "https://github.com/stablyai/orca/pull/7054"
       ],
-      "invariant": "High-volume terminal output must stay bounded across daemon socket writes, main-to-renderer in-flight bytes, renderer scheduler queues, and hidden-output restore without starving focused input.",
-      "oracle": "The current executable slice injects daemon socket backpressure and main-process renderer backlog pressure, then asserts write(false)/drain ordering, bounded queued daemon bytes, per-PTY and total pending-output caps, preserved sequenced-tail metadata, active-pending protection ahead of background trimming, and ACK-gated in-flight bounds. The live Electron perf oracle adds hidden-output floods, renderer scheduler queue depth, dropped-output-zero normal scenarios, and active key latency budgets before promotion.",
+      "invariant": "High-volume terminal output must stay bounded across daemon socket writes, main runtime metadata, main-to-renderer in-flight bytes, renderer scheduler queues, and hidden-output restore without starving focused input.",
+      "oracle": "The current executable slice injects daemon socket backpressure and main-process renderer backlog pressure, then asserts write(false)/drain ordering, bounded queued daemon bytes, unchanged path-provenance history reuse for pathless output, per-PTY and total pending-output caps, preserved sequenced-tail metadata, active-pending protection ahead of background trimming, and ACK-gated in-flight bounds. The live Electron perf oracle adds hidden-output floods, renderer scheduler queue depth, dropped-output-zero normal scenarios, and active key latency budgets before promotion.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-path-candidate-history.test.ts"
       ],
       "testFiles": [
-        "src/main/ipc/pty.test.ts"
+        "src/main/ipc/pty.test.ts",
+        "src/main/runtime/orca-runtime-path-candidate-history.test.ts"
       ],
       "assertionRefs": [
         {
@@ -1219,6 +1222,13 @@
             "total renderer in-flight output is capped across many PTYs",
             "active PTY pending output is prioritized during renderer backpressure",
             "combined pending output exceeding the interactive size limit is batched"
+          ]
+        },
+        {
+          "file": "src/main/runtime/orca-runtime-path-candidate-history.test.ts",
+          "assertions": [
+            "reuses path-candidate history across repeated pathless PTY output",
+            "copies history when new output adds a path candidate"
           ]
         }
       ],
@@ -1231,6 +1241,15 @@
           "result": "passed",
           "durationSeconds": 1.5,
           "summary": "1 test file(s) passed, 209 tests passed on main@1282f5c2d in a clean checkout."
+        },
+        {
+          "date": "2026-07-10",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-path-candidate-history.test.ts",
+          "result": "passed",
+          "durationSeconds": 3.49,
+          "summary": "1 test file passed, 2 tests passed on the exact rebased tree based on main@dc468f0ded."
         }
       ],
       "runtimeBudget": {
@@ -1243,11 +1262,11 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Tests assert daemon stream writes pause after socket write(false), later stream data queues behind the pressured socket, flush-immediate output from another session is prioritized ahead of unrelated queued background backlog on drain while preserving per-session order, queued lines resume on drain, global cleanup clears clients that only have backpressured writes, queued daemon stream bytes are bounded by keeping priority output and the newest tail under sustained pressure, main pending renderer output is capped per PTY and in total, total-pressure trimming prefers background pending output before active pending output, trimmed pending tails preserve seq/rawLength metadata, and ACK-gated in-flight output remains bounded. Existing renderer tests cover replay/backlog slices. Needs intentional-break proof and broader hidden-output/input-latency perf artifacts before promotion."
+        "evidence": "Tests assert daemon stream writes pause after socket write(false), later stream data queues behind the pressured socket, flush-immediate output from another session is prioritized ahead of unrelated queued background backlog on drain while preserving per-session order, queued lines resume on drain, global cleanup clears clients that only have backpressured writes, queued daemon stream bytes are bounded by keeping priority output and the newest tail under sustained pressure, pathless runtime output reuses unchanged path-provenance history with zero old-candidate byte scans, main pending renderer output is capped per PTY and in total, total-pressure trimming prefers background pending output before active pending output, trimmed pending tails preserve seq/rawLength metadata, and ACK-gated in-flight output remains bounded. Intentionally restoring the old path-history shape failed the focused scale test after 774ms and 4,096 replacements; the fixed shape passed in 6ms. Existing renderer tests cover replay/backlog slices. Needs broader hidden-output/input-latency perf artifacts before promotion."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Suggested ceilings: renderer in-flight <=8MB total, <=512KB per PTY plus active reserve, renderer queued chars <=2MB, dropped backlogs 0, hidden restore <=1000ms, active key median/worst <=75ms/300ms in perf scenarios."
+        "evidence": "Suggested ceilings: renderer in-flight <=8MB total, <=512KB per PTY plus active reserve, renderer queued chars <=2MB, dropped backlogs 0, hidden restore <=1000ms, active key median/worst <=75ms/300ms in perf scenarios. With 1,024 retained provenance candidates, 4,096 pathless chunks dropped from 78.84ms and 4,096 array replacements to 1.74ms and zero replacements."
       },
       "promotionCriteria": [
         "Split daemon stream backpressure into a deterministic provider/IPC contract if full E2E is flaky.",
@@ -1256,6 +1275,7 @@
       ],
       "knownGaps": [
         "Current command asserts daemon stream write(false)/drain/cleanup at the batcher contract layer and main pending renderer caps at the IPC contract layer.",
+        "Runtime provenance coverage is deterministic and does not include a live high-throughput provider artifact.",
         "Current command does not prove renderer parse pressure, scheduler queue depth, event-loop delay, or active key latency.",
         "Live hidden-output pressure, active input latency, and full Electron perf artifacts remain unproved."
       ],

--- a/src/main/runtime/orca-runtime-path-candidate-history.test.ts
+++ b/src/main/runtime/orca-runtime-path-candidate-history.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import { appendRecentPtyPathCandidates } from './orca-runtime'
+
+function fullCandidateHistory(): string[] {
+  return Array.from(
+    { length: 1024 },
+    (_, index) => `/tmp/artifact-${index.toString().padStart(4, '0')}.json`
+  )
+}
+
+describe('PTY path candidate history', () => {
+  it('reuses path-candidate history across repeated pathless PTY output', () => {
+    const previous = fullCandidateHistory()
+    const byteLengthSpy = vi.spyOn(Buffer, 'byteLength')
+    let candidates = previous
+    let replacements = 0
+    let byteLengthCalls = 0
+    try {
+      for (let index = 0; index < 4096; index += 1) {
+        const next = appendRecentPtyPathCandidates(
+          candidates,
+          'ordinary compiler progress without a path\n'
+        )
+        if (next !== candidates) {
+          replacements += 1
+        }
+        candidates = next
+      }
+    } finally {
+      byteLengthCalls = byteLengthSpy.mock.calls.length
+      byteLengthSpy.mockRestore()
+    }
+
+    expect(candidates).toBe(previous)
+    expect(replacements).toBe(0)
+    expect(byteLengthCalls).toBe(0)
+  })
+
+  it('copies history when new output adds a path candidate', () => {
+    const previous = fullCandidateHistory()
+    const changed = appendRecentPtyPathCandidates(previous, 'wrote /tmp/new-artifact.json\n')
+
+    expect(changed).not.toBe(previous)
+    expect(changed).toContain('/tmp/new-artifact.json')
+    expect(previous).not.toContain('/tmp/new-artifact.json')
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23410,8 +23410,14 @@ export function appendRecentPtyPathCandidates(
   previous: string[] | undefined,
   data: string
 ): string[] {
+  const extractedCandidates = extractTerminalOutputPathCandidates(data)
+  if (extractedCandidates.length === 0) {
+    // Why: pathless output is the common hot path. Reuse immutable history so
+    // each PTY chunk does not clone and byte-scan up to 1,024 old candidates.
+    return previous ?? []
+  }
   const next = previous ? previous.slice() : []
-  for (const candidate of extractTerminalOutputPathCandidates(data)) {
+  for (const candidate of extractedCandidates) {
     if (Buffer.byteLength(candidate, 'utf8') > RECENT_PTY_PATH_CANDIDATE_MAX_BYTES) {
       continue
     }


### PR DESCRIPTION
## Summary

Orca keeps a bounded history of terminal-emitted artifact paths so mobile/runtime file access can verify provenance. Once that history fills, every later pathless PTY chunk still cloned up to 1,024 strings and recomputed every retained candidate's UTF-8 length before discovering that nothing changed.

This extracts candidates first and reuses the immutable history when the chunk contains no path. Chunks that add a path still copy, append, and prune exactly as before.

Exact-shape local measurement over 4,096 pathless chunks:

| Retained candidates | Previous | This PR | Array replacements |
| ---: | ---: | ---: | ---: |
| 0 | 2.42 ms | 1.86 ms | 4,096 -> 0 |
| 10 | 3.06 ms | 1.78 ms | 4,096 -> 0 |
| 100 | 9.76 ms | 1.77 ms | 4,096 -> 0 |
| 1,024 | 78.84 ms | 1.74 ms | 4,096 -> 0 |

At the bound, retained-candidate UTF-8 scans fall from 4,194,304 to zero. Relevant path output still creates a new history and preserves the old array.

## Screenshots

No visual change. Exact-commit Electron validation visibly rendered a real artifact path, a pathless output burst, and `PTY_PATH_HISTORY_FINAL_OK`; the screenshot remains local evidence and is not committed.

## Testing

- [ ] `pnpm lint` — all code, switch-exhaustiveness, reliability, and max-lines stages pass; aggregate lint stops at the unchanged `ja.json` interpolation mismatch for `components.native-chat.composer.uploadingAttachments`
- [x] `pnpm typecheck` — node, CLI, and web passed
- [x] `pnpm test` — 2,567 files / 26,777 tests passed; 3 files / 33 tests skipped
- [ ] `pnpm build` — production build not run; the exact commit completed Electron main, preload, and renderer dev builds
- [x] Added focused regression coverage — 2 scale/correctness tests plus 830 existing PTY/runtime tests passed

Additional evidence:

- intentional old-shape run: focused scale test failed after 774 ms with 4,096 replacements
- restored fix: the same focused test passed in 6 ms with zero replacements and zero UTF-8 rescans
- `pnpm run check:reliability-gates`
- `pnpm run check:max-lines-ratchet`
- targeted `oxlint`, `oxfmt --check`, and `git diff --check`
- exact commit `14bdfd370b`: real PTY remained live and focused; authoritative snapshot retained both the artifact path and final marker; renderer delivery returned to zero pending/in-flight chars

## AI Review Report

The review traced every call and mutation site for `appendRecentPtyPathCandidates`. The returned history is stored and read immutably; no caller mutates it. Pathless output can therefore reuse identity safely, while detected paths still take the original copy/append/prune route. The review also checked that per-candidate and total-byte caps, WSL alias matching, file-URI parsing, path boundaries, and recent-output fallback remain unchanged.

Cross-platform review found no new shortcuts, labels, filesystem operations, shell behavior, subprocesses, or Electron platform branches. The optimization is provider-agnostic after terminal data reaches `OrcaRuntimeService` and uses the existing string/Buffer semantics on macOS, Linux, and Windows. macOS received a live PTY smoke; Windows, Linux, WSL, SSH, and remote-runtime paths have deterministic shared-code coverage but were not live-tested here.

## Security Audit

No auth, secrets, dependencies, file reads/writes, command execution, or IPC/RPC schema changes. Terminal text remains untrusted data passed through the existing bounded path parser. Relevant candidates still receive the existing per-candidate 4 KiB, count 1,024, and total 64 KiB limits; the fast path only avoids work when extraction found no candidate.

## Reliability proof

- **Gate:** `terminal-performance.output-backpressure-budget` (experimental / partial, unchanged maturity)
- **Touched class:** main-runtime per-output metadata and artifact-path provenance
- **Invariant:** a pathless PTY chunk must not clone or rescan unchanged bounded candidate history; a chunk containing a path must still copy, append, bound, and expose that candidate
- **Failure source:** unconditional `previous.slice()` plus full `pruneRecentPtyPathCandidates` traversal on every raw PTY chunk
- **Product change type:** performance hardening plus deterministic gate coverage
- **Oracle:** a 1,024-entry / 4,096-chunk test asserts identity reuse, zero replacements, and zero `Buffer.byteLength` calls; a sibling test asserts relevant output returns a new array with the new path and leaves prior history unchanged
- **Performance evidence:** 78.84 ms -> 1.74 ms at the history bound; 4,194,304 retained-entry scans -> 0
- **Diagnostics:** existing terminal delivery snapshots remain unchanged; the scale contract reports replacement and byte-scan counts directly
- **Provider/platform coverage:** provider-independent runtime path; macOS installed-provider live smoke; deterministic macOS unit coverage for shared code; Linux/Windows/WSL/SSH/remote-runtime live runs remain gaps
- **Residual gaps:** no live 1,024-candidate provider soak or cross-platform artifact; renderer parse/input-latency artifacts remain part of the broader experimental gate
- **Rollback/demotion rule:** revert if pathful output stops producing a new bounded history or artifact provenance regresses; do not promote the broader gate from this unit slice alone

## Notes

The branch was validated against `main@dc468f0ded`. A later Windows-daemon commit touches a different reliability-gate section; three-way merge is clean, and GitHub checks will validate the combined merge result.

## ELI5

Ordinary terminal output no longer recopies a full history of previously seen file paths. New paths are still recorded and bounded so mobile and remote file access can verify where artifacts came from.
