### PR TITLE
perf(emulator): stop rescanning completed PTY output

### DIFF
--- a/src/main/emulator/serve-sim-state-watcher.test.ts
+++ b/src/main/emulator/serve-sim-state-watcher.test.ts
@@ -105,6 +105,71 @@ describe('ServeSimStateWatcher', () => {
     watcher.stop()
   })
 
+  it('detects a serve-sim payload split across small PTY chunks', () => {
+    const watcher = createIsolatedWatcher()
+    const events: ServeSimStateDetectedEvent[] = []
+    const payload = JSON.stringify({
+      device: TEST_UDID,
+      streamUrl: 'http://127.0.0.1:3100/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3100/ws',
+      pid: 12345
+    })
+
+    watcher.bindPty('pty-1', 'worktree-1')
+    watcher.onDetected((event) => events.push(event))
+    for (let offset = 0; offset < payload.length; offset += 7) {
+      watcher.ingestPtyOutput('pty-1', payload.slice(offset, offset + 7))
+    }
+
+    expect(events).toHaveLength(1)
+    expect(events[0]?.info).toMatchObject({
+      deviceUdid: TEST_UDID,
+      helperPid: 12345
+    })
+    watcher.stop()
+  })
+
+  it('detects multiple payloads after ordinary output and completed objects', () => {
+    const watcher = createIsolatedWatcher()
+    const events: ServeSimStateDetectedEvent[] = []
+    const makePayload = (port: number, pid: number): string =>
+      JSON.stringify({
+        device: TEST_UDID,
+        streamUrl: `http://127.0.0.1:${port}/stream.mjpeg`,
+        wsUrl: `ws://127.0.0.1:${port}/ws`,
+        pid
+      })
+
+    watcher.bindPty('pty-1', 'worktree-1')
+    watcher.onDetected((event) => events.push(event))
+    watcher.ingestPtyOutput('pty-1', 'shell output {"unrelated":true}\nmore output\n')
+    watcher.ingestPtyOutput('pty-1', makePayload(3100, 12345))
+    watcher.ingestPtyOutput('pty-1', `ordinary output\n${makePayload(3101, 23456)}`)
+
+    expect(events.map((event) => event.info.helperPid)).toEqual([12345, 23456])
+    watcher.stop()
+  })
+
+  it('does not replay a completed payload after the PTY is rebound', () => {
+    const watcher = createIsolatedWatcher()
+    const events: ServeSimStateDetectedEvent[] = []
+    const payload = JSON.stringify({
+      device: TEST_UDID,
+      streamUrl: 'http://127.0.0.1:3100/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3100/ws',
+      pid: 12345
+    })
+
+    watcher.onDetected((event) => events.push(event))
+    watcher.bindPty('pty-1', 'worktree-1')
+    watcher.ingestPtyOutput('pty-1', payload)
+    watcher.bindPty('pty-1', 'worktree-2')
+    watcher.ingestPtyOutput('pty-1', 'ordinary shell output\n')
+
+    expect(events.map((event) => event.worktreeId)).toEqual(['worktree-1'])
+    watcher.stop()
+  })
+
   it('prunes worktree-scoped dedupe keys on forget so a re-bound worktree re-emits', () => {
     const watcher = createIsolatedWatcher()
     const events: ServeSimStateDetectedEvent[] = []

--- a/src/main/emulator/serve-sim-state-watcher.ts
+++ b/src/main/emulator/serve-sim-state-watcher.ts
@@ -25,6 +25,7 @@ export type ServeSimStateDetectedEvent = {
 const DEFAULT_STATE_DIR = join(tmpdir(), 'serve-sim')
 const STATE_FILE_RE = /^server-([0-9A-F-]{36})\.json$/i
 const PTY_JSON_RE = /\{[^{}]*"streamUrl"\s*:\s*"[^"]+"[^{}]*"wsUrl"\s*:\s*"[^"]+"[^{}]*\}/g
+const PTY_JSON_BUFFER_LIMIT = 16_384
 
 function parseHelperInfo(raw: unknown, fallbackUdid?: string): ServeSimHelperInfo | null {
   if (!raw || typeof raw !== 'object') {
@@ -132,9 +133,27 @@ export class ServeSimStateWatcher {
       return
     }
 
-    const prev = this.ptyBuffers.get(ptyId) ?? ''
-    const combined = (prev + data).slice(-16_384)
-    this.ptyBuffers.set(ptyId, combined)
+    const previous = this.ptyBuffers.get(ptyId) ?? ''
+    const firstObjectStart = previous.length === 0 ? data.indexOf('{') : 0
+    if (firstObjectStart === -1) {
+      return
+    }
+    const combined = `${previous}${data.slice(firstObjectStart)}`.slice(-PTY_JSON_BUFFER_LIMIT)
+
+    // Why: only an unmatched object can become a split serve-sim payload in a
+    // later PTY chunk. Retaining completed shell output made every future chunk
+    // copy and regex-scan a saturated 16 KiB rolling buffer.
+    const lastObjectStart = combined.lastIndexOf('{')
+    const lastObjectEnd = combined.lastIndexOf('}')
+    if (lastObjectStart > lastObjectEnd) {
+      this.ptyBuffers.set(ptyId, combined.slice(lastObjectStart))
+    } else {
+      this.ptyBuffers.delete(ptyId)
+    }
+
+    if (!combined.includes('"streamUrl"') || !combined.includes('"wsUrl"')) {
+      return
+    }
 
     const matches = combined.match(PTY_JSON_RE)
     if (!matches) {


### PR DESCRIPTION
## Description

`ServeSimStateWatcher.ingestPtyOutput()` runs from the runtime's `onPtyData()` path for every bound local, daemon, SSH/WSL, and remote PTY. It previously retained the latest 16 KiB of **all** output. Once that buffer filled, every ordinary PTY chunk concatenated/copy-sliced the buffer, regex-scanned it for serve-sim JSON, and could repeatedly parse a completed payload until 16 KiB of newer output displaced it.

This change:

- returns immediately when ordinary output has no JSON object start;
- retains only the trailing unmatched `{...` fragment that could become a payload in a later chunk;
- uses cheap `includes()` marker checks before the full regex;
- clears completed payload text so it cannot be reparsed or replayed after a PTY is rebound;
- adds coverage for 7-character fragmented payloads, multiple payloads after ordinary/completed objects, and the cross-worktree replay regression.

## Performance evidence

### Why this is a performance issue

The old work scales with **PTY chunk count × 16 KiB**, not merely output bytes. In the small-chunk fixture below, 47.9 MiB of actual output made the watcher revisit roughly 3.05 GiB of saturated-buffer character positions. This is an optional simulator detector consuming main-process CPU on unrelated shell/TUI output.

### Before/after measurement

An isolated Node benchmark directly instantiated the real `ServeSimStateWatcher`, bound one PTY, and repeatedly called `ingestPtyOutput()` with ordinary output containing no JSON. Values are medians across 7–9 runs on the same machine and checkout; this measures the watcher hot path, **not end-to-end terminal throughput**.

| Fixture | Actual output | Before | After | Reduction | Speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| 200,000 × 251-byte chunks | 47.9 MiB | 1,611.33 ms | 3.20 ms | 99.80% | 503.5× |
| 100,000 × 4,251-byte chunks | 405.4 MiB | 502.95 ms | 9.77 ms | 98.06% | 51.5× |

Small-chunk isolated throughput improved from 29.7 MiB/s to 14,948.9 MiB/s. The large difference between fixtures is expected: the old implementation rescanned the same 16 KiB buffer per chunk, so smaller chunks paid the amplification more often.

### Red/green correctness evidence

The new PTY-rebind regression test was run against the old implementation first:

```text
expected [ 'worktree-1', 'worktree-2' ] to deeply equal [ 'worktree-1' ]
1 failed
```

The stale completed payload was being replayed under `worktree-2` after the same PTY was rebound and emitted ordinary output. With the fix restored, all 7 watcher tests pass and only `worktree-1` is emitted.

### Validation

- `pnpm test` — 2,566 files passed, 3 skipped; 26,782 tests passed, 33 skipped
- `pnpm typecheck` — passed for Node, CLI, and web projects
- targeted `oxlint` and `oxfmt --check` — passed for both changed files
- `pnpm run check:max-lines-ratchet` — passed; no new bypasses
- `pnpm run check:reliability-gates` — all 32 gates passed
- full `pnpm lint` reaches an unrelated current-main Japanese catalog mismatch at `components.native-chat.composer.uploadingAttachments`; all lint stages before that point and both changed files pass

## ELI5

Orca has a lookout that checks terminal text for a special “simulator started” message. It was rereading the last 16,000 characters for every tiny new piece of terminal output—even when the text was ordinary shell output. Now it ignores text that cannot start the special message and keeps only an unfinished message between chunks.

## End-user trade-offs / regressions

No end-user regression is intended.

- The existing 16 KiB safety cap and payload regex are unchanged.
- Payloads split across arbitrary PTY chunk boundaries remain supported; the test splits one into 7-character chunks.
- Multiple completed payloads are still detected and deduplicated.
- PTY bytes, ordering, delivery, buffering, input, renderer work, and simulator state-file detection are untouched.
- No polling, subprocess, listener, or platform-specific behavior was added.

The only state no longer retained is output through the last completed `}`. That text cannot become a future match for the existing no-nested-braces regex; retaining it only caused rescans and the proven stale worktree replay.

## Terminal reliability proof

- **Class / invariant:** `terminal-performance.output-sidecar-scan` — optional serve-sim detection must not mutate, delay through new async work, reorder, or lose PTY bytes, while fragmented helper payloads remain detectable.
- **Product change type:** PTY-output performance hardening with correctness regression coverage.
- **Risk inventory:** touches only synchronous main-process sidecar observation after PTY data reaches the runtime. No typing/focus/resize/startup/provider-listing/renderer/hidden-output delivery path changes.
- **Oracle:** fragmented payload detection, multiple-payload detection, and red/green stale-rebind test; isolated real-class CPU benchmark proves ordinary output avoids the rolling scan.
- **Provider/platform coverage:** local, daemon, SSH, WSL, remote-runtime, and mobile/relay all share or observe the same runtime output boundary but are otherwise unaffected. The code uses only JavaScript string operations and is platform-neutral across macOS, Linux, and Windows.
- **Manifest status:** no exact reliability gate exists; the manifest remains unchanged and this focused unit oracle is an accepted partial gap rather than a promoted gate.
- **Residual gap:** no live Electron throughput run was used; the benchmark isolates this detector's CPU cost. Electron was deliberately not launched to avoid repeated macOS safe-storage prompts from transient dev identities.
- **Rollback rule:** revert if real serve-sim output that matches the existing regex is missed across PTY chunk boundaries; the fragmented-payload unit test is the first demotion signal.
