### PR TITLE
fix(cli): report starting instead of stale_bootstrap while the app process is alive

### DIFF
--- a/src/cli/runtime/status-bootstrap.test.ts
+++ b/src/cli/runtime/status-bootstrap.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+import { getRuntimeMetadataPath } from '../../shared/runtime-bootstrap'
+import { getCliStatus } from './status'
+
+function writeMetadata(userDataPath: string, authToken: string | null, pid: number): void {
+  writeFileSync(
+    getRuntimeMetadataPath(userDataPath),
+    JSON.stringify({
+      runtimeId: 'runtime-1',
+      pid,
+      transports: [
+        {
+          kind: 'unix',
+          endpoint: ''
+        }
+      ],
+      authToken,
+      startedAt: 1
+    }),
+    'utf8'
+  )
+}
+
+function findUnusedPid(seed = 200_000): number {
+  // Why: the stale-bootstrap test must point metadata at a definitely-dead
+  // process. Hard-coding a small PID is host-dependent and flakes when that
+  // PID happens to be alive on the machine running the suite.
+  let pid = Math.max(seed, process.pid + 10_000)
+  while (pid < 2_000_000) {
+    try {
+      process.kill(pid, 0)
+      pid += 1
+    } catch {
+      return pid
+    }
+  }
+  return 2_000_000
+}
+
+it('reports not_running when no runtime metadata exists', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-status-'))
+
+  const status = await getCliStatus(userDataPath)
+
+  expect(status.result).toEqual({
+    app: {
+      running: false,
+      pid: null
+    },
+    runtime: {
+      state: 'not_running',
+      reachable: false,
+      runtimeId: null
+    },
+    graph: {
+      state: 'not_running'
+    }
+  })
+})
+
+it('reports starting when incomplete bootstrap metadata points to the live app', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-status-'))
+  writeMetadata(userDataPath, null, process.pid)
+
+  const status = await getCliStatus(userDataPath)
+
+  expect(status.result).toEqual({
+    app: {
+      running: true,
+      pid: process.pid
+    },
+    runtime: {
+      state: 'starting',
+      reachable: false,
+      runtimeId: null
+    },
+    graph: {
+      state: 'starting'
+    }
+  })
+})
+
+it('keeps stale_bootstrap when incomplete bootstrap metadata points to a dead app', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-status-'))
+  writeMetadata(userDataPath, null, findUnusedPid())
+
+  const status = await getCliStatus(userDataPath)
+
+  expect(status.result).toEqual({
+    app: {
+      running: false,
+      pid: null
+    },
+    runtime: {
+      state: 'stale_bootstrap',
+      reachable: false,
+      runtimeId: null
+    },
+    graph: {
+      state: 'not_running'
+    }
+  })
+})

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -10,21 +10,22 @@ export async function getCliStatus(
   const metadata = tryReadMetadata(userDataPath)
   const transport = metadata ? findTransport(metadata, 'unix', 'named-pipe') : null
   if (!transport || !metadata?.authToken) {
+    const running = metadata ? isProcessRunning(metadata.pid) : false
     return buildCliStatusResponse({
       app: {
-        running: false,
-        pid: null
+        running,
+        pid: running ? metadata!.pid : null
       },
       runtime: {
         // Why: distinguishing "never started" from "was running but died"
         // gives the user a better signal about what happened. If the metadata
         // file exists, Orca was running at some point.
-        state: metadata ? 'stale_bootstrap' : 'not_running',
+        state: metadata ? (running ? 'starting' : 'stale_bootstrap') : 'not_running',
         reachable: false,
         runtimeId: null
       },
       graph: {
-        state: 'not_running'
+        state: running ? 'starting' : 'not_running'
       }
     })
   }


### PR DESCRIPTION
## Summary

Closes #7848.

The local CLI status mapper now reports `starting` while incomplete bootstrap metadata points to a live Orca process. Dead or invalid PIDs retain `stale_bootstrap`, and missing metadata retains `not_running`. Reachable `ready` and `graph_not_ready` mappings are unchanged.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/cli/runtime/status-bootstrap.test.ts`
- [x] `pnpm run typecheck:cli`
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Test coverage

Focused validation output: Vitest reported `Test Files 1 passed (1)` and `Tests 3 passed (3)`. CLI typecheck completed with exit code 0.

## AI Review Report

- Scope is limited to the local CLI status mapper and its focused bootstrap status regression tests.
- The change reuses the existing `isProcessRunning(metadata.pid)` check to distinguish a live Orca process from stale bootstrap metadata.
- Regression coverage now exercises the live-PID, dead-PID, and missing-metadata boundaries. Reachable socket-backed mappings remain covered by the existing runtime status tests and CI.

## Security Audit

The change only probes the already-recorded PID with Node's existing `process.kill(pid, 0)` helper and changes local status classification. It adds no permissions, IPC, network, authentication, metadata, or process-launch behavior.

## Notes

- No visual change.

## ELI5

The local CLI could report `stale_bootstrap` while Orca was actually still starting and the process was alive. Live incomplete bootstrap now shows as `starting`, and only dead or invalid PIDs stay `stale_bootstrap`.
