### PR TITLE
perf: avoid rescanning idle serve-sim PTY output

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1222,6 +1222,7 @@
         "daemon stream",
         "main PTY batching",
         "runtime path provenance",
+        "runtime serve-sim detection",
         "renderer ACK",
         "xterm scheduler",
         "hidden output"
@@ -1241,22 +1242,24 @@
         "macos"
       ],
       "coveredProviders": [],
-      "coverageNotes": "Local macOS evidence covers the existing main-process pending-output caps plus deterministic runtime path-provenance history reuse. Daemon stream write(false)/drain contracts, cross-session drain priority, and bounded queued tails arrive with the pending perf slice; live flood/latency artifacts remain gaps.",
+      "coverageNotes": "Local macOS evidence covers the existing main-process pending-output caps plus deterministic runtime path-provenance history reuse and idle-path serve-sim detection. Daemon stream write(false)/drain contracts, cross-session drain priority, and bounded queued tails arrive with the pending perf slice; live flood/latency artifacts remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6836",
         "https://github.com/stablyai/orca/pull/6858",
         "https://github.com/stablyai/orca/pull/7002",
         "https://github.com/stablyai/orca/pull/7054"
       ],
-      "invariant": "High-volume terminal output must stay bounded across daemon socket writes, main runtime metadata, main-to-renderer in-flight bytes, renderer scheduler queues, and hidden-output restore without starving focused input.",
-      "oracle": "The current executable slice injects daemon socket backpressure and main-process renderer backlog pressure, then asserts write(false)/drain ordering, bounded queued daemon bytes, unchanged path-provenance history reuse for pathless output, per-PTY and total pending-output caps, preserved sequenced-tail metadata, active-pending protection ahead of background trimming, and ACK-gated in-flight bounds. The live Electron perf oracle adds hidden-output floods, renderer scheduler queue depth, dropped-output-zero normal scenarios, and active key latency budgets before promotion.",
+      "invariant": "High-volume terminal output must stay bounded across daemon socket writes, main runtime metadata and detectors, main-to-renderer in-flight bytes, renderer scheduler queues, and hidden-output restore without starving focused input.",
+      "oracle": "The current executable slice injects daemon socket backpressure and main-process renderer backlog pressure, then asserts write(false)/drain ordering, bounded queued daemon bytes, unchanged path-provenance history reuse for pathless output, idle serve-sim detection with split-JSON continuity, per-PTY and total pending-output caps, preserved sequenced-tail metadata, active-pending protection ahead of background trimming, and ACK-gated in-flight bounds. The live Electron perf oracle adds hidden-output floods, renderer scheduler queue depth, dropped-output-zero normal scenarios, and active key latency budgets before promotion.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts",
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-path-candidate-history.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-path-candidate-history.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/emulator/serve-sim-state-watcher.test.ts"
       ],
       "testFiles": [
         "src/main/ipc/pty.test.ts",
-        "src/main/runtime/orca-runtime-path-candidate-history.test.ts"
+        "src/main/runtime/orca-runtime-path-candidate-history.test.ts",
+        "src/main/emulator/serve-sim-state-watcher.test.ts"
       ],
       "assertionRefs": [
         {
@@ -1272,6 +1275,13 @@
           "assertions": [
             "reuses path-candidate history across repeated pathless PTY output",
             "copies history when new output adds a path candidate"
+          ]
+        },
+        {
+          "file": "src/main/emulator/serve-sim-state-watcher.test.ts",
+          "assertions": [
+            "does not buffer repeated brace-free PTY output while waiting for metadata",
+            "detects serve-sim metadata split across PTY chunks and releases the partial object"
           ]
         }
       ],
@@ -1293,6 +1303,15 @@
           "result": "passed",
           "durationSeconds": 3.49,
           "summary": "1 test file passed, 2 tests passed on the exact rebased tree based on main@dc468f0ded."
+        },
+        {
+          "date": "2026-07-10",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/emulator/serve-sim-state-watcher.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.37,
+          "summary": "1 test file passed, 6 tests passed on pushed commit f0e3a185593b."
         }
       ],
       "runtimeBudget": {
@@ -1305,11 +1324,11 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Tests assert daemon stream writes pause after socket write(false), later stream data queues behind the pressured socket, flush-immediate output from another session is prioritized ahead of unrelated queued background backlog on drain while preserving per-session order, queued lines resume on drain, global cleanup clears clients that only have backpressured writes, queued daemon stream bytes are bounded by keeping priority output and the newest tail under sustained pressure, pathless runtime output reuses unchanged path-provenance history with zero old-candidate byte scans, main pending renderer output is capped per PTY and in total, total-pressure trimming prefers background pending output before active pending output, trimmed pending tails preserve seq/rawLength metadata, and ACK-gated in-flight output remains bounded. Intentionally restoring the old path-history shape failed the focused scale test after 774ms and 4,096 replacements; the fixed shape passed in 6ms. Existing renderer tests cover replay/backlog slices. Needs broader hidden-output/input-latency perf artifacts before promotion."
+        "evidence": "Tests assert daemon stream writes pause after socket write(false), later stream data queues behind the pressured socket, flush-immediate output from another session is prioritized ahead of unrelated queued background backlog on drain while preserving per-session order, queued lines resume on drain, global cleanup clears clients that only have backpressured writes, queued daemon stream bytes are bounded by keeping priority output and the newest tail under sustained pressure, pathless runtime output reuses unchanged path-provenance history with zero old-candidate byte scans, ordinary output leaves the niche serve-sim detector idle while split JSON still emits and releases its partial buffer, main pending renderer output is capped per PTY and in total, total-pressure trimming prefers background pending output before active pending output, trimmed pending tails preserve seq/rawLength metadata, and ACK-gated in-flight output remains bounded. Intentionally restoring the old path-history shape failed the focused scale test after 774ms and 4,096 replacements; restoring the old serve-sim buffer failed its scale test after 180ms with 4,096 buffer writes. The fixed shapes passed their focused suites. Existing renderer tests cover replay/backlog slices. Needs broader hidden-output/input-latency perf artifacts before promotion."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Suggested ceilings: renderer in-flight <=8MB total, <=512KB per PTY plus active reserve, renderer queued chars <=2MB, dropped backlogs 0, hidden restore <=1000ms, active key median/worst <=75ms/300ms in perf scenarios. With 1,024 retained provenance candidates, 4,096 pathless chunks dropped from 78.84ms and 4,096 array replacements to 1.74ms and zero replacements."
+        "evidence": "Suggested ceilings: renderer in-flight <=8MB total, <=512KB per PTY plus active reserve, renderer queued chars <=2MB, dropped backlogs 0, hidden restore <=1000ms, active key median/worst <=75ms/300ms in perf scenarios. With 1,024 retained provenance candidates, 4,096 pathless chunks dropped from 78.84ms and 4,096 array replacements to 1.74ms and zero replacements. Brace-free 1 KiB output dropped from 20.32/79.12/318.23ms to 0.31/0.64/2.35ms across 4,096/16,384/65,536 chunks."
       },
       "promotionCriteria": [
         "Split daemon stream backpressure into a deterministic provider/IPC contract if full E2E is flaky.",
@@ -1319,6 +1338,7 @@
       "knownGaps": [
         "Current command asserts daemon stream write(false)/drain/cleanup at the batcher contract layer and main pending renderer caps at the IPC contract layer.",
         "Runtime provenance coverage is deterministic and does not include a live high-throughput provider artifact.",
+        "Serve-sim detector coverage is deterministic and does not include a live external simulator helper.",
         "Current command does not prove renderer parse pressure, scheduler queue depth, event-loop delay, or active key latency.",
         "Live hidden-output pressure, active input latency, and full Electron perf artifacts remain unproved."
       ],

--- a/src/main/emulator/serve-sim-state-watcher.test.ts
+++ b/src/main/emulator/serve-sim-state-watcher.test.ts
@@ -78,6 +78,54 @@ describe('ServeSimStateWatcher', () => {
     watcher.stop()
   })
 
+  it('does not buffer repeated brace-free PTY output while waiting for metadata', () => {
+    const watcher = createIsolatedWatcher()
+    const buffers = (watcher as unknown as { ptyBuffers: Map<string, string> }).ptyBuffers
+    const originalSet = buffers.set
+    let setCalls = 0
+    buffers.set = function (key, value): Map<string, string> {
+      setCalls += 1
+      return originalSet.call(this, key, value)
+    }
+    watcher.bindPty('pty-1', 'worktree-1')
+
+    try {
+      for (let index = 0; index < 4096; index += 1) {
+        watcher.ingestPtyOutput('pty-1', 'ordinary compiler progress without JSON metadata\n')
+      }
+    } finally {
+      buffers.set = originalSet
+    }
+
+    expect(setCalls).toBe(0)
+    expect(buffers.has('pty-1')).toBe(false)
+    watcher.stop()
+  })
+
+  it('detects serve-sim metadata split across PTY chunks and releases the partial object', () => {
+    const watcher = createIsolatedWatcher()
+    const events: ServeSimStateDetectedEvent[] = []
+    const buffers = (watcher as unknown as { ptyBuffers: Map<string, string> }).ptyBuffers
+    const payload = JSON.stringify({
+      device: TEST_UDID,
+      streamUrl: 'http://127.0.0.1:3100/stream.mjpeg',
+      wsUrl: 'ws://127.0.0.1:3100/ws'
+    })
+    const splitIndex = payload.indexOf('streamUrl') + 4
+    watcher.bindPty('pty-1', 'worktree-1')
+    watcher.onDetected((event) => events.push(event))
+
+    watcher.ingestPtyOutput('pty-1', payload.slice(0, splitIndex))
+    expect(events).toHaveLength(0)
+    expect(buffers.has('pty-1')).toBe(true)
+
+    watcher.ingestPtyOutput('pty-1', payload.slice(splitIndex))
+    expect(events).toHaveLength(1)
+    expect(events[0]?.info.deviceUdid).toBe(TEST_UDID)
+    expect(buffers.has('pty-1')).toBe(false)
+    watcher.stop()
+  })
+
   it('suppresses Orca-managed sessions only while they are marked managed', async () => {
     const watcher = createIsolatedWatcher()
     const events: ServeSimStateDetectedEvent[] = []

--- a/src/main/emulator/serve-sim-state-watcher.ts
+++ b/src/main/emulator/serve-sim-state-watcher.ts
@@ -66,6 +66,11 @@ function helperInstanceKey(info: ServeSimHelperInfo): string {
   return `${info.deviceUdid}::${info.helperPid ?? 'pidless'}::${info.wsUrl}::${info.streamUrl}`
 }
 
+function trailingIncompletePtyJsonObject(data: string): string {
+  const lastObjectStart = data.lastIndexOf('{')
+  return lastObjectStart > data.lastIndexOf('}') ? data.slice(lastObjectStart) : ''
+}
+
 export class ServeSimStateWatcher {
   private readonly stateDir: string
   private readonly ptyToWorktree = new Map<string, string>()
@@ -132,9 +137,19 @@ export class ServeSimStateWatcher {
       return
     }
 
-    const prev = this.ptyBuffers.get(ptyId) ?? ''
-    const combined = (prev + data).slice(-16_384)
-    this.ptyBuffers.set(ptyId, combined)
+    const previous = this.ptyBuffers.get(ptyId)
+    if (!previous && !data.includes('{')) {
+      // Why: serve-sim metadata is a JSON object, while ordinary PTY output is
+      // the hot path. Stay idle instead of rebuilding and regex-scanning 16 KiB.
+      return
+    }
+    const combined = `${previous ?? ''}${data}`.slice(-16_384)
+    const trailingObject = trailingIncompletePtyJsonObject(combined)
+    if (trailingObject) {
+      this.ptyBuffers.set(ptyId, trailingObject)
+    } else {
+      this.ptyBuffers.delete(ptyId)
+    }
 
     const matches = combined.match(PTY_JSON_RE)
     if (!matches) {

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -83,7 +83,6 @@ import { canToggleNativeChat } from '../native-chat/native-chat-availability'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { selectTabAgentTypesByTabId } from './tab-agent-types-by-tab-id'
 import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
-import { getConnectionIdFromState } from '@/lib/connection-context'
 
 const isWindows = navigator.userAgent.includes('Windows')
 const isMacOs = navigator.userAgent.includes('Mac')


### PR DESCRIPTION
## Summary

The main runtime sends every bound PTY chunk through the niche serve-sim metadata detector. Previously, even ordinary brace-free output rebuilt and regex-scanned the latest 16 KiB on every chunk.

This change:
- returns immediately for brace-free output when no partial object is pending
- retains only an incomplete trailing `{...` candidate across chunks
- preserves complete and split serve-sim JSON detection
- releases the partial buffer after the object completes

Exact-shape 1,025-character ordinary chunks:

| Chunks | Before | After |
| ---: | ---: | ---: |
| 4,096 | 20.32 ms | 0.31 ms |
| 16,384 | 79.12 ms | 0.64 ms |
| 65,536 | 318.23 ms | 2.35 ms |

The deterministic regression fixture reduces PTY buffer writes from 4,096 to 0.

## Screenshots

No visual change.

Visible exact-branch Electron validation on isolated ports `5174/9334` rendered a 4.2 MiB brace-free PTY flood through the real terminal, showed `ORCA_SERVE_SIM_PERF_DONE`, accepted a subsequent keyboard command, showed `ORCA_INPUT_RESPONSIVE`, and returned to a live prompt. Evidence images were kept local and were not committed.

## Testing

- [x] `pnpm run typecheck`
- [x] `pnpm test` — 2,566 files passed, 26,781 tests passed
- [x] Added deterministic regression coverage
- [x] `pnpm run check:reliability-gates`
- [x] `pnpm run check:max-lines-ratchet`
- [x] Targeted oxlint and oxfmt checks
- [x] `git diff --check`
- [x] Exact pushed runtime commit `f0e3a185593b`: focused suite passed, 1 file / 6 tests / 0.37 s
- [x] Exact final branch: isolated Electron dev build and real local PTY flood/input validation
- [ ] `pnpm lint` — all code/reliability/max-lines gates passed; aggregate lint stops at the unchanged `ja.json` interpolation mismatch for `components.native-chat.composer.uploadingAttachments`, also present on `origin/main`
- [ ] `pnpm build` — not run separately; the exact branch's Electron dev build compiled main/preload/renderer successfully for the live validation

Intentional red proof: restoring the old buffer shape made the scale test report 4,096 buffer writes and fail after 180 ms. Restoring the fix passed.

## Terminal reliability proof

- **Reliability invariant:** `terminal-performance.output-backpressure-budget` — high-volume output must not impose accumulating main-runtime detector work, while split serve-sim metadata must still be detected.
- **Material impact:** every bound local, daemon, SSH, WSL, or remote-runtime PTY reaches this detector; ordinary output now performs one brace check instead of rebuilding and regex-scanning a 16 KiB tail.
- **Product change type:** performance hardening plus deterministic gate coverage.
- **Oracle:** 4,096 brace-free chunks cause zero buffer writes; split JSON emits one detection and leaves no partial buffer.
- **Performance risk inventory:** touches main-process PTY output ingestion only. It adds no polling, provider listing/fanout, startup await, subprocess, renderer work, hidden-pane loop, resize, focus, typing, git/worktree scan, IPC, or telemetry.
- **No-regression evidence:** count test, split-chunk correctness test, before/after timing, full repository suite, full typecheck, and real 4.2 MiB PTY output/input validation.
- **Provider/platform coverage:** live local macOS covered. The detector is provider-neutral and adds no filesystem, shell, path, or platform branch; Linux, Windows, daemon, SSH, WSL, remote-runtime, and mobile/relay semantics are unchanged but were not live-run.
- **Residual gaps:** no live external serve-sim helper run; no non-macOS/provider live artifact; broader renderer queue/input-latency perf artifacts remain outside this slice.
- **Promotion status:** the existing gate remains experimental/partial; this PR neither promotes nor broadens its blocking scope.
- **Rollback/demotion rule:** revert or demote this evidence if split JSON stops emitting, partial buffers survive completion, or ordinary brace-free chunks regain per-chunk buffer writes.

## AI Review Report

Reviewed the final three-file diff against the terminal-session reliability and performance contracts. The review checked:

- opening/closing brace and chunk-boundary behavior
- complete-object, split-object, dedupe, unbind, forget, and stop cleanup paths
- bounded 16 KiB fallback behavior for unmatched braces
- hot-path scale and allocation/scan work
- local/daemon/SSH/WSL/remote-runtime neutrality
- macOS/Linux/Windows path, shell, shortcut, and Electron differences

No additional code findings remained. The main residual gap is a live external simulator helper, recorded in the manifest and above.

## Security Audit

No new command execution, filesystem access, IPC surface, authentication, dependency, secret handling, or external data sink is introduced. PTY data is already untrusted input; this change narrows retention to the existing 16 KiB cap and continues to require the same strict flat-JSON regex plus `JSON.parse` and field validation before emitting an event.

## Notes

The reliability manifest is intentionally kept in its existing legacy formatting shape; the dedicated manifest validator passed.

## ELI5

Most terminal text is not simulator metadata, so Orca now skips that JSON detector unless it sees an opening brace or is finishing a split object. Real split serve-sim messages are still detected.
