### PR TITLE
perf(file-explorer): collapse ignored-path Git fanout

### DIFF
--- a/src/main/git/check-ignored-paths.test.ts
+++ b/src/main/git/check-ignored-paths.test.ts
@@ -14,24 +14,45 @@ describe('checkIgnoredPaths', () => {
   })
 
   it('returns ignored paths from git check-ignore output', async () => {
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'dist/bundle.js\n.env\n', stderr: '' })
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'dist/bundle.js\0.env\0dist/bundle.js\0',
+      stderr: ''
+    })
 
     await expect(
       checkIgnoredPaths('/repo', ['dist/bundle.js', 'src/index.ts', '.env'])
     ).resolves.toEqual(['dist/bundle.js', '.env'])
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        '-c',
-        'core.quotePath=false',
-        'check-ignore',
-        '--',
-        'dist/bundle.js',
-        'src/index.ts',
-        '.env'
-      ],
-      { cwd: '/repo' }
+      ['-c', 'core.quotePath=false', 'check-ignore', '--stdin', '-z'],
+      {
+        cwd: '/repo',
+        stdin: 'dist/bundle.js\0src/index.ts\0.env\0',
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 15_000
+      }
     )
+  })
+
+  it('checks thousands of paths in one process and preserves newline filenames', async () => {
+    const paths = Array.from({ length: 5_000 }, (_, index) => `src/generated-${index}.ts`)
+    paths[123] = 'src/file\nwith-newline.ts'
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: `${paths[123]}\0${paths.at(-1)}\0`,
+      stderr: ''
+    })
+
+    await expect(checkIgnoredPaths('/repo', paths)).resolves.toEqual([paths[123], paths.at(-1)])
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    const options = gitExecFileAsyncMock.mock.calls[0]?.[1]
+    expect(options?.stdin?.split('\0').filter(Boolean)).toEqual(paths)
+    expect(options?.timeout).toBe(15_000)
+  })
+
+  it('does not launch git for an empty path list', async () => {
+    await expect(checkIgnoredPaths('/repo', [])).resolves.toEqual([])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
   it('treats exit code 1 as no ignored paths', async () => {

--- a/src/main/git/check-ignored-paths.ts
+++ b/src/main/git/check-ignored-paths.ts
@@ -1,46 +1,41 @@
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 import { gitExecFileAsync } from './runner'
-
-const CHECK_IGNORE_CHUNK_SIZE = 100
+import {
+  encodeGitCheckIgnorePaths,
+  GIT_CHECK_IGNORE_STDIN_ARGS,
+  GIT_CHECK_IGNORE_TIMEOUT_MS,
+  getGitCheckIgnoreMaxBufferBytes,
+  parseGitCheckIgnoreOutput
+} from '../../shared/git-check-ignore-stdin'
 
 type GitExecError = Error & { stdout?: string; code?: number | string }
-
-function parseCheckIgnoreOutput(stdout: string): string[] {
-  return stdout.split(/\r?\n/).filter(Boolean)
-}
-
-async function runCheckIgnoreChunk(
-  worktreePath: string,
-  relativePaths: string[],
-  options: GitRuntimeOptions = {}
-): Promise<string[]> {
-  try {
-    const { stdout } = await gitExecFileAsync(
-      ['-c', 'core.quotePath=false', 'check-ignore', '--', ...relativePaths],
-      gitOptionsForWorktree(worktreePath, options)
-    )
-    return parseCheckIgnoreOutput(stdout)
-  } catch (error) {
-    const gitError = error as GitExecError
-    if (gitError.code === 1) {
-      return parseCheckIgnoreOutput(gitError.stdout ?? '')
-    }
-    throw error
-  }
-}
 
 export async function checkIgnoredPaths(
   worktreePath: string,
   relativePaths: string[],
   options: GitRuntimeOptions = {}
 ): Promise<string[]> {
-  const ignored = new Set<string>()
-  for (let i = 0; i < relativePaths.length; i += CHECK_IGNORE_CHUNK_SIZE) {
-    const chunk = relativePaths.slice(i, i + CHECK_IGNORE_CHUNK_SIZE)
-    for (const ignoredPath of await runCheckIgnoreChunk(worktreePath, chunk, options)) {
-      ignored.add(ignoredPath)
-    }
+  if (relativePaths.length === 0) {
+    return []
   }
-  return Array.from(ignored)
+  const stdin = encodeGitCheckIgnorePaths(relativePaths)
+  try {
+    const { stdout } = await gitExecFileAsync([...GIT_CHECK_IGNORE_STDIN_ARGS], {
+      ...gitOptionsForWorktree(worktreePath, options),
+      // Why: File Explorer can check thousands of paths after one filter
+      // pause. NUL-delimited stdin keeps this to one process without argv
+      // limits and preserves valid filenames containing newlines.
+      stdin,
+      maxBuffer: getGitCheckIgnoreMaxBufferBytes(stdin),
+      timeout: GIT_CHECK_IGNORE_TIMEOUT_MS
+    })
+    return parseGitCheckIgnoreOutput(stdout)
+  } catch (error) {
+    const gitError = error as GitExecError
+    if (gitError.code === 1) {
+      return parseGitCheckIgnoreOutput(gitError.stdout ?? '')
+    }
+    throw error
+  }
 }

--- a/src/relay/git-handler-ops.ts
+++ b/src/relay/git-handler-ops.ts
@@ -16,7 +16,7 @@ import { readWorkingDiffFile } from './git-working-file-read'
 export type GitExec = (
   args: string[],
   cwd: string,
-  opts?: { maxBuffer?: number; disableOptionalLocks?: boolean; stdin?: string }
+  opts?: { maxBuffer?: number; disableOptionalLocks?: boolean; stdin?: string; timeout?: number }
 ) => Promise<{ stdout: string; stderr: string }>
 
 export type GitBufferExec = (args: string[], cwd: string) => Promise<Buffer>

--- a/src/relay/git-handler-status-ops.test.ts
+++ b/src/relay/git-handler-status-ops.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GitExec } from './git-handler-ops'
-import { getStatusOp } from './git-handler-status-ops'
+import { checkIgnoredPathsOp, getStatusOp } from './git-handler-status-ops'
 import { clearNoEffectiveUpstreamStatusCache } from './git-status-upstream-negative-cache'
 
 const LARGE_STATUS_ENTRY_COUNT = 150_000
@@ -243,5 +243,32 @@ describe('getStatusOp', () => {
     expect(
       git.mock.calls.filter(([args]) => args[0] === 'rev-parse' && args.includes('HEAD@{u}'))
     ).toHaveLength(2)
+  })
+
+  it('checks thousands of ignored paths through one NUL-delimited stdin call', async () => {
+    const paths = Array.from({ length: 5_000 }, (_, index) => `src/generated-${index}.ts`)
+    paths[321] = 'src/file\nwith-newline.ts'
+    const git = vi.fn<GitExec>().mockResolvedValue({
+      stdout: `${paths[321]}\0${paths.at(-1)}\0`,
+      stderr: ''
+    })
+
+    await expect(checkIgnoredPathsOp(git, { worktreePath: tmpDir, paths })).resolves.toEqual([
+      paths[321],
+      paths.at(-1)
+    ])
+
+    expect(git).toHaveBeenCalledTimes(1)
+    expect(git).toHaveBeenCalledWith(
+      ['-c', 'core.quotePath=false', 'check-ignore', '--stdin', '-z'],
+      tmpDir,
+      { stdin: `${paths.join('\0')}\0`, maxBuffer: 10 * 1024 * 1024, timeout: 15_000 }
+    )
+  })
+
+  it('does not launch relay git for an empty ignored-path request', async () => {
+    const git = vi.fn<GitExec>()
+    await expect(checkIgnoredPathsOp(git, { worktreePath: tmpDir, paths: [] })).resolves.toEqual([])
+    expect(git).not.toHaveBeenCalled()
   })
 })

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -20,6 +20,13 @@ import {
   type GitLineStats
 } from '../shared/git-uncommitted-line-stats'
 import { DEFAULT_GIT_STATUS_LIMIT } from '../shared/git-status-limit'
+import {
+  encodeGitCheckIgnorePaths,
+  GIT_CHECK_IGNORE_STDIN_ARGS,
+  GIT_CHECK_IGNORE_TIMEOUT_MS,
+  getGitCheckIgnoreMaxBufferBytes,
+  parseGitCheckIgnoreOutput
+} from '../shared/git-check-ignore-stdin'
 
 export async function resolveGitDir(worktreePath: string): Promise<string> {
   const dotGitPath = path.join(worktreePath, '.git')
@@ -250,10 +257,6 @@ function shouldProbeEffectiveUpstreamStatus(
   return parsed?.remoteName === 'origin' && parsed.branchName !== branchName
 }
 
-function parseCheckIgnoreOutput(stdout: string): string[] {
-  return stdout.split(/\r?\n/).filter(Boolean)
-}
-
 export async function checkIgnoredPathsOp(
   git: GitExec,
   params: Record<string, unknown>
@@ -265,17 +268,19 @@ export async function checkIgnoredPathsOp(
   if (paths.length === 0) {
     return []
   }
+  const stdin = encodeGitCheckIgnorePaths(paths)
 
   try {
-    const { stdout } = await git(
-      ['-c', 'core.quotePath=false', 'check-ignore', '--', ...paths],
-      worktreePath
-    )
-    return parseCheckIgnoreOutput(stdout)
+    const { stdout } = await git([...GIT_CHECK_IGNORE_STDIN_ARGS], worktreePath, {
+      stdin,
+      maxBuffer: getGitCheckIgnoreMaxBufferBytes(stdin),
+      timeout: GIT_CHECK_IGNORE_TIMEOUT_MS
+    })
+    return parseGitCheckIgnoreOutput(stdout)
   } catch (error) {
     const gitError = error as Error & { code?: number | string; stdout?: string }
     if (gitError.code === 1) {
-      return parseCheckIgnoreOutput(gitError.stdout ?? '')
+      return parseGitCheckIgnoreOutput(gitError.stdout ?? '')
     }
     throw error
   }

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -304,6 +304,7 @@ export class GitHandler {
       signal?: AbortSignal
       nonInteractive?: boolean
       stdin?: string
+      timeout?: number
     }
   ): Promise<{ stdout: string; stderr: string }> {
     const env = buildRelayGitEnv()
@@ -321,6 +322,7 @@ export class GitHandler {
       env,
       encoding: 'utf-8',
       maxBuffer: opts?.maxBuffer ?? MAX_GIT_BUFFER,
+      timeout: opts?.timeout,
       signal: opts?.signal
     } satisfies ExecFileOptions
     if (opts?.stdin !== undefined) {

--- a/src/renderer/src/components/right-sidebar/file-explorer-runtime-owner-boundary.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-runtime-owner-boundary.test.ts
@@ -15,7 +15,7 @@ describe('right sidebar file/git runtime ownership boundaries', () => {
     'src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts',
     'src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts',
     'src/renderer/src/components/right-sidebar/useFileDuplicate.ts',
-    'src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts',
+    'src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts',
     'src/renderer/src/components/right-sidebar/useGitStatusPolling.ts',
     'src/renderer/src/components/right-sidebar/useFileSearchRunner.ts',
     'src/renderer/src/components/quick-open-file-list.ts'

--- a/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts
+++ b/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react'
+import { getConnectionId } from '@/lib/connection-context'
+import { getRuntimeGitIgnoredPaths } from '@/runtime/runtime-git-client'
+import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-owner'
+
+const EMPTY_IGNORED_PATHS: readonly string[] = []
+export const FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS = 300
+
+export type IgnoredPathResult = {
+  activeWorktreeId: string
+  paths: string[]
+  worktreePath: string
+}
+
+export function getEffectiveFileExplorerIgnoredPaths({
+  activeWorktreeId,
+  canLoadIgnoredPaths,
+  ignoredPathResult,
+  worktreePath
+}: {
+  activeWorktreeId: string | null
+  canLoadIgnoredPaths: boolean
+  ignoredPathResult: IgnoredPathResult | null
+  worktreePath: string | null
+}): readonly string[] {
+  const ignoredPathResultMatchesCurrentWorktree =
+    ignoredPathResult !== null &&
+    ignoredPathResult.activeWorktreeId === activeWorktreeId &&
+    ignoredPathResult.worktreePath === worktreePath
+
+  if (!canLoadIgnoredPaths || !ignoredPathResultMatchesCurrentWorktree) {
+    return EMPTY_IGNORED_PATHS
+  }
+
+  // Why: expanding folders changes the query before the async ignored refresh returns.
+  // Keep same-worktree answers so known ignored rows do not flash as normal text.
+  return ignoredPathResult.paths
+}
+
+export function useFileExplorerIgnoredPaths({
+  activeWorktreeId,
+  canLoadIgnoredPaths,
+  relativePaths,
+  shouldDebounceIgnoredQuery,
+  worktreePath
+}: {
+  activeWorktreeId: string | null
+  canLoadIgnoredPaths: boolean
+  relativePaths: readonly string[]
+  shouldDebounceIgnoredQuery: boolean
+  worktreePath: string | null
+}): readonly string[] {
+  const [ignoredPathResult, setIgnoredPathResult] = useState<IgnoredPathResult | null>(null)
+
+  useEffect(() => {
+    if (!canLoadIgnoredPaths || !activeWorktreeId || !worktreePath) {
+      return
+    }
+
+    let canceled = false
+    const refresh = (): void => {
+      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      void getRuntimeGitIgnoredPaths(
+        {
+          settings: getRightSidebarWorktreeRuntimeSettings(activeWorktreeId),
+          worktreeId: activeWorktreeId,
+          worktreePath,
+          connectionId
+        },
+        [...relativePaths]
+      )
+        .then((paths) => {
+          if (!canceled) {
+            setIgnoredPathResult({ activeWorktreeId, paths, worktreePath })
+          }
+        })
+        .catch(() => {
+          if (!canceled) {
+            setIgnoredPathResult({ activeWorktreeId, paths: [], worktreePath })
+          }
+        })
+    }
+
+    // Why: every filter keystroke changes relativePaths. Waiting for a short
+    // quiet window prevents obsolete queries from launching uncancellable Git
+    // subprocess chains while the visible name projection stays immediate.
+    const timer = shouldDebounceIgnoredQuery
+      ? window.setTimeout(refresh, FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS)
+      : null
+    if (timer === null) {
+      refresh()
+    }
+
+    return () => {
+      canceled = true
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [
+    activeWorktreeId,
+    canLoadIgnoredPaths,
+    relativePaths,
+    shouldDebounceIgnoredQuery,
+    worktreePath
+  ])
+
+  return getEffectiveFileExplorerIgnoredPaths({
+    activeWorktreeId,
+    canLoadIgnoredPaths,
+    ignoredPathResult,
+    worktreePath
+  })
+}

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.debounce.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.debounce.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import { useFileExplorerVisibleRowProjection } from './useFileExplorerVisibleRowProjection'
+import { FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS } from './use-file-explorer-ignored-paths'
+
+const getRuntimeGitIgnoredPathsMock = vi.hoisted(() => vi.fn())
+vi.mock('@/runtime/runtime-git-client', () => ({
+  getRuntimeGitIgnoredPaths: getRuntimeGitIgnoredPathsMock
+}))
+
+const initialAppState = useAppStore.getInitialState()
+const relativePaths = Array.from({ length: 5_000 }, (_, index) => `src/generated-${index}.ts`)
+
+function useProjection(query: string) {
+  return useFileExplorerVisibleRowProjection('worktree-1', '/repo', {}, new Set(), true, true, {
+    query,
+    relativePaths
+  })
+}
+
+function useTreeProjection() {
+  return useFileExplorerVisibleRowProjection(
+    'worktree-1',
+    '/repo',
+    {
+      '/repo': {
+        children: [
+          {
+            name: 'src',
+            path: '/repo/src',
+            relativePath: 'src',
+            isDirectory: true,
+            depth: 0
+          }
+        ],
+        loading: false
+      }
+    },
+    new Set(),
+    true,
+    true,
+    null
+  )
+}
+
+describe('file explorer ignored-path query debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    getRuntimeGitIgnoredPathsMock.mockReset().mockResolvedValue([])
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState(initialAppState, true)
+    vi.useRealTimers()
+  })
+
+  it('coalesces a broad typing burst into one final ignored-path request', async () => {
+    const hook = renderHook(({ query }) => useProjection(query), {
+      initialProps: { query: 's' }
+    })
+
+    await act(async () => vi.advanceTimersByTimeAsync(100))
+    hook.rerender({ query: 'sr' })
+    await act(async () => vi.advanceTimersByTimeAsync(100))
+    hook.rerender({ query: 'src' })
+
+    await act(async () => vi.advanceTimersByTimeAsync(FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS - 1))
+    expect(getRuntimeGitIgnoredPathsMock).not.toHaveBeenCalled()
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(1)
+    expect(getRuntimeGitIgnoredPathsMock.mock.calls[0]?.[1]).toHaveLength(relativePaths.length)
+  })
+
+  it('cancels the pending ignored-path request when the explorer unmounts', async () => {
+    const hook = renderHook(() => useProjection('src'))
+    hook.unmount()
+
+    await act(async () => vi.advanceTimersByTimeAsync(FILE_EXPLORER_IGNORED_QUERY_DEBOUNCE_MS))
+    expect(getRuntimeGitIgnoredPathsMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps ordinary expanded-tree ignored checks immediate', () => {
+    renderHook(() => useTreeProjection())
+
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(1)
+    expect(getRuntimeGitIgnoredPathsMock.mock.calls[0]?.[1]).toEqual(['src'])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
@@ -2,9 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { DirCache, TreeNode } from './file-explorer-types'
 import {
   createVisibleFileExplorerRowProjection,
-  getEffectiveFileExplorerIgnoredPaths,
   getFileExplorerIgnoredQueryRelativePaths
 } from './useFileExplorerVisibleRowProjection'
+import { getEffectiveFileExplorerIgnoredPaths } from './use-file-explorer-ignored-paths'
 import {
   FILE_EXPLORER_NAME_FILTER_QUERY_MAX_BYTES,
   getFileExplorerNameFilterExpandedPaths,
@@ -336,8 +336,6 @@ describe('file explorer visible row projection', () => {
   })
 
   it('keeps same-worktree ignored paths while an expanded-folder query is loading', () => {
-    const previousRelativePaths = ['out', 'src']
-
     expect(
       getEffectiveFileExplorerIgnoredPaths({
         activeWorktreeId: 'worktree-1',
@@ -345,7 +343,6 @@ describe('file explorer visible row projection', () => {
         ignoredPathResult: {
           activeWorktreeId: 'worktree-1',
           paths: ['out'],
-          relativePaths: previousRelativePaths,
           worktreePath: '/repo'
         },
         worktreePath: '/repo'
@@ -372,7 +369,6 @@ describe('file explorer visible row projection', () => {
         ignoredPathResult: {
           activeWorktreeId: 'worktree-1',
           paths: ['out'],
-          relativePaths: ['out'],
           worktreePath: '/repo'
         },
         worktreePath: '/repo'
@@ -386,7 +382,6 @@ describe('file explorer visible row projection', () => {
         ignoredPathResult: {
           activeWorktreeId: 'worktree-1',
           paths: ['out'],
-          relativePaths: ['out'],
           worktreePath: '/repo'
         },
         worktreePath: '/other-repo'

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
@@ -1,8 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useAppStore } from '@/store'
-import { getConnectionId } from '@/lib/connection-context'
-import { getRuntimeGitIgnoredPaths } from '@/runtime/runtime-git-client'
-import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-owner'
 import { isDotfileRelativePath } from './file-explorer-entries'
 import type { DirCache, TreeNode } from './file-explorer-types'
 import {
@@ -16,16 +13,9 @@ import {
   getFileExplorerNameFilterIgnoredQueryRelativePaths,
   type FileExplorerNameFilterProjectionSource
 } from './file-explorer-name-filter-projection'
+import { useFileExplorerIgnoredPaths } from './use-file-explorer-ignored-paths'
 
-const EMPTY_IGNORED_PATHS: readonly string[] = []
 const EMPTY_RELATIVE_PATHS: string[] = []
-
-export type IgnoredPathResult = {
-  activeWorktreeId: string
-  paths: string[]
-  relativePaths: readonly string[]
-  worktreePath: string
-}
 
 type VisibleFileExplorerRowProjectionOptions = {
   ignoredSet: Set<string>
@@ -119,31 +109,6 @@ export function createVisibleFileExplorerRowProjection(
   return createFileExplorerRowProjectionFromParts(visibleFlatRows, rowsByPath)
 }
 
-export function getEffectiveFileExplorerIgnoredPaths({
-  activeWorktreeId,
-  canLoadIgnoredPaths,
-  ignoredPathResult,
-  worktreePath
-}: {
-  activeWorktreeId: string | null
-  canLoadIgnoredPaths: boolean
-  ignoredPathResult: IgnoredPathResult | null
-  worktreePath: string | null
-}): readonly string[] {
-  const ignoredPathResultMatchesCurrentWorktree =
-    ignoredPathResult !== null &&
-    ignoredPathResult.activeWorktreeId === activeWorktreeId &&
-    ignoredPathResult.worktreePath === worktreePath
-
-  if (!canLoadIgnoredPaths || !ignoredPathResultMatchesCurrentWorktree) {
-    return EMPTY_IGNORED_PATHS
-  }
-
-  // Why: expanding folders changes the query before the async ignored refresh returns.
-  // Keep same-worktree answers so known ignored rows do not flash as normal text.
-  return ignoredPathResult.paths
-}
-
 export function useFileExplorerVisibleRowProjection(
   activeWorktreeId: string | null,
   worktreePath: string | null,
@@ -163,7 +128,6 @@ export function useFileExplorerVisibleRowProjection(
   const settings = useAppStore((s) => s.settings)
   const updateSettings = useAppStore((s) => s.updateSettings)
   const showGitIgnoredFiles = settings?.showGitIgnoredFiles ?? true
-  const [ignoredPathResult, setIgnoredPathResult] = useState<IgnoredPathResult | null>(null)
   const relativePaths = useMemo(
     () =>
       activeRepoSupportsGit
@@ -181,53 +145,12 @@ export function useFileExplorerVisibleRowProjection(
     Boolean(activeWorktreeId) &&
     Boolean(worktreePath) &&
     relativePaths.length > 0
-
-  useEffect(() => {
-    if (!canLoadIgnoredPaths || !activeWorktreeId || !worktreePath) {
-      return
-    }
-
-    let canceled = false
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-    void getRuntimeGitIgnoredPaths(
-      {
-        settings: getRightSidebarWorktreeRuntimeSettings(activeWorktreeId),
-        worktreeId: activeWorktreeId,
-        worktreePath,
-        connectionId
-      },
-      [...relativePaths]
-    )
-      .then((nextIgnoredPaths) => {
-        if (!canceled) {
-          setIgnoredPathResult({
-            activeWorktreeId,
-            paths: nextIgnoredPaths,
-            relativePaths,
-            worktreePath
-          })
-        }
-      })
-      .catch(() => {
-        if (!canceled) {
-          setIgnoredPathResult({
-            activeWorktreeId,
-            paths: [],
-            relativePaths,
-            worktreePath
-          })
-        }
-      })
-
-    return () => {
-      canceled = true
-    }
-  }, [activeWorktreeId, canLoadIgnoredPaths, relativePaths, worktreePath])
-
-  const effectiveIgnoredPaths = getEffectiveFileExplorerIgnoredPaths({
+  const shouldDebounceIgnoredQuery = nameFilter !== null
+  const effectiveIgnoredPaths = useFileExplorerIgnoredPaths({
     activeWorktreeId,
     canLoadIgnoredPaths,
-    ignoredPathResult,
+    relativePaths,
+    shouldDebounceIgnoredQuery,
     worktreePath
   })
   const ignoredSet = useMemo(() => buildIgnoredSet(effectiveIgnoredPaths), [effectiveIgnoredPaths])

--- a/src/shared/git-check-ignore-stdin.ts
+++ b/src/shared/git-check-ignore-stdin.ts
@@ -1,0 +1,24 @@
+export const GIT_CHECK_IGNORE_STDIN_ARGS = [
+  '-c',
+  'core.quotePath=false',
+  'check-ignore',
+  '--stdin',
+  '-z'
+] as const
+export const GIT_CHECK_IGNORE_TIMEOUT_MS = 15_000
+const GIT_CHECK_IGNORE_MIN_MAX_BUFFER_BYTES = 10 * 1024 * 1024
+
+export function encodeGitCheckIgnorePaths(paths: readonly string[]): string {
+  return paths.length > 0 ? `${paths.join('\0')}\0` : ''
+}
+
+export function getGitCheckIgnoreMaxBufferBytes(stdin: string): number {
+  // UTF-8 needs at most four bytes per UTF-16 code unit. Scale the output cap
+  // with the already-bounded request so one-process checks do not regress huge
+  // repos that previously emitted through many independent 10 MiB chunks.
+  return Math.max(GIT_CHECK_IGNORE_MIN_MAX_BUFFER_BYTES, stdin.length * 4)
+}
+
+export function parseGitCheckIgnoreOutput(stdout: string): string[] {
+  return [...new Set(stdout.split('\0').filter(Boolean))]
+}


### PR DESCRIPTION
## Description

File Explorer name filtering now waits for a 300 ms quiet window before checking Git-ignored matches, while the visible filename projection still updates immediately.

The ignored-path check itself now uses one `git check-ignore --stdin -z` process with NUL-delimited input/output instead of sequential chunks of 100 argv entries. The same bounded implementation covers local, WSL, runtime, relay, and SSH paths.

The Git call has:

- a 15 second timeout
- a minimum 10 MiB output cap that scales to 4x the input string size
- exact handling for valid filenames containing newlines
- no subprocess for an empty path list

## Performance evidence

### Proven waste before this change

Each filename-filter keystroke immediately launched an ignored-path request. Local and WSL checks split matches into chunks of 100 and awaited one Git process per chunk. Stale requests were prevented from updating React state, but their Git process chains kept running.

For 5,000 matching paths:

- one query: 50 Git processes
- typing `s` → `sr` → `src`: 150 Git processes
- after this change: the debounce emits one request, and the bulk helper emits one Git process

The deterministic tests assert both halves of that 150 → 1 reduction: a three-keystroke burst makes one runtime request, and a 5,000-path request makes one local or relay Git call.

### Before/after benchmark

Benchmark: exact old 100-path sequential loop versus the production bulk helper in this commit, run in the same repository for 15 alternating iterations; table reports medians.

| Paths | Before processes | Before median | After processes | After median | Change |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 100 | 1 | 15.60 ms | 1 | 18.86 ms | 20.9% slower |
| 1,000 | 10 | 164.62 ms | 1 | 101.70 ms | 38.2% faster |
| 5,000 | 50 | 824.38 ms | 1 | 488.85 ms | 40.7% faster |

The measured target is the broad filename-filter case: 5,000 paths plus a three-keystroke burst falls from 150 sequential Git launches to one launch.

### Correctness evidence

A real ignored pathname containing a newline was checked through Git:

- old parser: returned the C-quoted string `"out/file\\nwith-newline.js"`, not the filename
- new parser: returned the exact `out/file\nwith-newline.js` value
- exact match changed from `false` to `true`

Tests also cover duplicate-output deduplication, empty requests, timer cleanup on unmount, stale-response suppression, and immediate checks for ordinary expanded-tree navigation.

## ELI5

Previously, typing three letters could ask 150 separate workers to answer questions that were obsolete before they finished. Now Orca waits until typing pauses, puts every path into one safe list, and asks one worker once.

## End-user trade-offs / regressions

- During active filename filtering, ignored-file styling or hiding can trail the typed query by up to 300 ms. Filename matches themselves still render immediately.
- A 100-path check is about 3.3 ms slower in the local benchmark because NUL-safe stdin has fixed setup cost. Larger checks remove enough process launches to win substantially.
- A Git check that exceeds 15 seconds now fails closed to an empty ignored-path result instead of hanging indefinitely. In a severely stalled repository, ignored styling may temporarily be absent.
- Very large requests use one output buffer sized proportionally to the input. This can have a higher single-process peak than one old 100-path chunk, but it remains bounded and removes dozens of process/runtime allocations.

Ordinary tree expansion is not debounced.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — all code, switch-exhaustiveness, reliability, and max-lines stages passed; the command stops at the unrelated existing `ja.json` interpolation mismatch for `components.native-chat.composer.uploadingAttachments`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2,567 files and 26,786 tests passed; 3 files / 33 tests skipped
- [ ] `pnpm build` — not run; no build configuration or dependency changes
- [x] Added regression tests for request/process counts, NUL protocol, newline filenames, empty input, debounce cleanup, ordinary-tree immediacy, and runtime-owner routing

Additional validation:

- focused behavior: 5 files / 41 tests passed
- relay, SSH, runtime RPC/client, and Git runner: 23 files / 441 tests passed
- targeted `oxlint`, React Doctor lint, and `oxfmt --check` passed
- `pnpm run check:max-lines-ratchet` passed
- `pnpm run check:reliability-gates` passed
- real Git newline-path red/green check passed

## AI Review Report

Reviewed the hot path for subprocess fanout, event-loop work, memory growth, timer/listener cleanup, stale async state, and local/WSL/SSH provider parity.

Cross-platform review covered macOS, Linux, Windows, WSL, and SSH. The change uses direct Git argv plus stdin, adds no shell invocation or path separator assumptions, and preserves existing runtime-owner routing. React review confirmed that the effect synchronizes with external Git IPC, clears pending timers, and ignores responses after dependency changes or unmount.

The review flagged two items that were addressed:

- the extracted request hook required the runtime-owner boundary test to follow the new file
- ordinary expanded-tree checks needed an explicit assertion that they remain immediate

The small-request timing regression and 15-second timeout behavior are intentionally disclosed above.

## Security Audit

No new dependency, authentication, secret, or network surface.

Relative paths still pass through the existing IPC/runtime validation boundaries. Git is executed directly without `shell: true`; moving path data from argv to NUL-delimited stdin reduces argument-length and quoting risk. NUL-delimited output avoids treating embedded newlines as record boundaries. Timeout and output-buffer bounds limit hung or oversized subprocess resource use. The same constraints apply in the SSH relay.

## Notes

Electron was not launched for this validation because disposable branch app identities currently trigger repeated macOS safe-storage dialogs. Hook, runtime, relay, and full-suite tests provide the behavioral evidence without another prompt.