### PR TITLE
perf: target hosted-review IPC to the app renderer

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -5,12 +5,14 @@ import type { GitHubPRRefreshCandidate, PRInfo } from '../../shared/types'
 
 const {
   sendMock,
+  sendToTrustedUIRendererMock,
   getAllWebContentsMock,
   getPRForBranchOutcomeMock,
   getRateLimitMock,
   rateLimitGuardMock
 } = vi.hoisted(() => ({
   sendMock: vi.fn(),
+  sendToTrustedUIRendererMock: vi.fn(),
   getAllWebContentsMock: vi.fn(),
   getPRForBranchOutcomeMock: vi.fn(),
   getRateLimitMock: vi.fn(),
@@ -31,6 +33,10 @@ vi.mock('./rate-limit', () => ({
   getRateLimit: getRateLimitMock,
   noteRateLimitSpend: vi.fn(),
   rateLimitGuard: rateLimitGuardMock
+}))
+
+vi.mock('../ipc/ui', () => ({
+  sendToTrustedUIRenderer: sendToTrustedUIRendererMock
 }))
 
 function makeCandidate(
@@ -82,6 +88,10 @@ describe('pr-refresh-coordinator', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
     sendMock.mockReset()
+    sendToTrustedUIRendererMock.mockReset()
+    sendToTrustedUIRendererMock.mockImplementation((channel, payload) => {
+      sendMock(channel, payload)
+    })
     getAllWebContentsMock.mockReset()
     getPRForBranchOutcomeMock.mockReset()
     getRateLimitMock.mockReset()
@@ -99,6 +109,29 @@ describe('pr-refresh-coordinator', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('sends each refresh event once without broadcasting to 100 browser guests', async () => {
+    const guestSends = Array.from({ length: 100 }, () => vi.fn())
+    getAllWebContentsMock.mockReturnValue(
+      guestSends.map((send, index) => ({
+        id: index + 100,
+        isDestroyed: () => false,
+        send
+      }))
+    )
+    const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
+
+    enqueuePRRefresh(makeCandidate({ isBare: true }), 'manual')
+
+    expect(sendToTrustedUIRendererMock).toHaveBeenCalledOnce()
+    expect(sendToTrustedUIRendererMock).toHaveBeenCalledWith(
+      'gh:prRefreshEvent',
+      expect.objectContaining({ status: 'skipped', skippedReason: 'bare' })
+    )
+    expect(sendMock).toHaveBeenCalledOnce()
+    expect(getAllWebContentsMock).not.toHaveBeenCalled()
+    expect(guestSends.reduce((total, send) => total + send.mock.calls.length, 0)).toBe(0)
   })
 
   it('forwards the candidate worktree head into the branch lookup options', async () => {

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -13,6 +13,7 @@ import type {
 import { getPRForBranchOutcome, type GitHubPRBranchLookupOptions } from './client'
 import { getRateLimit, noteRateLimitSpend, rateLimitGuard } from './rate-limit'
 import { recordCoalescedCrashBreadcrumb } from '../crash-reporting/crash-breadcrumb-store'
+import { sendToTrustedUIRenderer } from '../ipc/ui'
 
 type QueueEntry = {
   key: string
@@ -211,11 +212,7 @@ function nextQueueOrder(): number {
 
 function broadcast(event: Omit<GitHubPRRefreshEvent, 'sequence'>, sequenceOverride?: number): void {
   const payload = { ...event, sequence: sequenceOverride ?? nextSequence() } as GitHubPRRefreshEvent
-  for (const wc of webContents.getAllWebContents()) {
-    if (!wc.isDestroyed()) {
-      wc.send('gh:prRefreshEvent', payload)
-    }
-  }
+  sendToTrustedUIRenderer('gh:prRefreshEvent', payload)
 }
 
 function refreshKey(candidate: GitHubPRRefreshCandidate): string {

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -47,6 +47,7 @@ const {
   trackMock,
   getCohortAtEmitMock,
   getAllWebContentsMock,
+  sendToTrustedUIRendererMock,
   clearVisiblePRRefreshWindowMock,
   enqueuePRRefreshMock,
   refreshPRNowMock,
@@ -88,6 +89,7 @@ const {
   trackMock: vi.fn(),
   getCohortAtEmitMock: vi.fn(),
   getAllWebContentsMock: vi.fn(),
+  sendToTrustedUIRendererMock: vi.fn(),
   clearVisiblePRRefreshWindowMock: vi.fn(),
   enqueuePRRefreshMock: vi.fn(),
   refreshPRNowMock: vi.fn(),
@@ -155,6 +157,10 @@ vi.mock('../telemetry/client', () => ({
 
 vi.mock('../telemetry/cohort-classifier', () => ({
   getCohortAtEmit: getCohortAtEmitMock
+}))
+
+vi.mock('./ui', () => ({
+  sendToTrustedUIRenderer: sendToTrustedUIRendererMock
 }))
 
 import { registerGitHubHandlers } from './github'
@@ -233,6 +239,7 @@ describe('registerGitHubHandlers', () => {
     getCohortAtEmitMock.mockReturnValue({ nth_repo_added: undefined })
     getAllWebContentsMock.mockReset()
     getAllWebContentsMock.mockReturnValue([])
+    sendToTrustedUIRendererMock.mockReset()
     clearVisiblePRRefreshWindowMock.mockReset()
     enqueuePRRefreshMock.mockReset()
     refreshPRNowMock.mockReset()
@@ -282,12 +289,15 @@ describe('registerGitHubHandlers', () => {
     )
   })
 
-  it('broadcasts mutation notifications by repo id even when the payload path is remote', async () => {
-    const sendMock = vi.fn()
-    getAllWebContentsMock.mockReturnValue([
-      { id: 1, isDestroyed: () => false, send: vi.fn() },
-      { id: 2, isDestroyed: () => false, send: sendMock }
-    ])
+  it('targets mutation notifications without broadcasting to 100 browser guests', async () => {
+    const guestSends = Array.from({ length: 100 }, () => vi.fn())
+    getAllWebContentsMock.mockReturnValue(
+      guestSends.map((send, index) => ({
+        id: index + 100,
+        isDestroyed: () => false,
+        send
+      }))
+    )
     registerGitHubHandlers(store as never, stats as never)
 
     const result = await handlers['gh:notifyWorkItemMutated'](
@@ -301,20 +311,22 @@ describe('registerGitHubHandlers', () => {
     )
 
     expect(result).toBe(true)
-    expect(sendMock).toHaveBeenCalledWith('gh:workItemMutated', {
-      repoPath: '/workspace/repo',
-      repoId: 'repo-1',
-      type: 'pr',
-      number: 42
-    })
+    expect(sendToTrustedUIRendererMock).toHaveBeenCalledOnce()
+    expect(sendToTrustedUIRendererMock).toHaveBeenCalledWith(
+      'gh:workItemMutated',
+      {
+        repoPath: '/workspace/repo',
+        repoId: 'repo-1',
+        type: 'pr',
+        number: 42
+      },
+      1
+    )
+    expect(getAllWebContentsMock).not.toHaveBeenCalled()
+    expect(guestSends.reduce((total, send) => total + send.mock.calls.length, 0)).toBe(0)
   })
 
-  it('broadcasts mutation notifications with resolved repo id when called by repo path', async () => {
-    const sendMock = vi.fn()
-    getAllWebContentsMock.mockReturnValue([
-      { id: 1, isDestroyed: () => false, send: vi.fn() },
-      { id: 2, isDestroyed: () => false, send: sendMock }
-    ])
+  it('targets mutation notifications with resolved repo id when called by repo path', async () => {
     registerGitHubHandlers(store as never, stats as never)
 
     const result = await handlers['gh:notifyWorkItemMutated'](
@@ -327,20 +339,19 @@ describe('registerGitHubHandlers', () => {
     )
 
     expect(result).toBe(true)
-    expect(sendMock).toHaveBeenCalledWith('gh:workItemMutated', {
-      repoPath: '/workspace/repo',
-      repoId: 'repo-1',
-      type: 'issue',
-      number: 7
-    })
+    expect(sendToTrustedUIRendererMock).toHaveBeenCalledWith(
+      'gh:workItemMutated',
+      {
+        repoPath: '/workspace/repo',
+        repoId: 'repo-1',
+        type: 'issue',
+        number: 7
+      },
+      1
+    )
   })
 
-  it('broadcasts PR file viewed mutations with repo id for sibling cache invalidation', async () => {
-    const sendMock = vi.fn()
-    getAllWebContentsMock.mockReturnValue([
-      { id: 1, isDestroyed: () => false, send: vi.fn() },
-      { id: 2, isDestroyed: () => false, send: sendMock }
-    ])
+  it('targets PR file viewed mutations with repo id for cache invalidation', async () => {
     setPRFileViewedMock.mockResolvedValue(true)
     registerGitHubHandlers(store as never, stats as never)
 
@@ -356,12 +367,16 @@ describe('registerGitHubHandlers', () => {
     )
 
     expect(result).toBe(true)
-    expect(sendMock).toHaveBeenCalledWith('gh:workItemMutated', {
-      repoPath: '/workspace/repo',
-      repoId: 'repo-1',
-      type: 'pr',
-      number: 42
-    })
+    expect(sendToTrustedUIRendererMock).toHaveBeenCalledWith(
+      'gh:workItemMutated',
+      {
+        repoPath: '/workspace/repo',
+        repoId: 'repo-1',
+        type: 'pr',
+        number: 42
+      },
+      1
+    )
   })
 
   it('rejects unknown repository paths', async () => {

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -2,7 +2,7 @@
 the repo-path validation, preference-threading, and stats wiring patterns are
 reviewable as one surface. Splitting by feature area would risk drifting
 validation/gate conventions across handler files. */
-import { ipcMain, webContents } from 'electron'
+import { ipcMain } from 'electron'
 import { resolve } from 'node:path'
 import type {
   Repo,
@@ -108,15 +108,12 @@ import type {
 import { appStarSourceSchema } from '../../shared/gh-star-source'
 import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
+import { sendToTrustedUIRenderer } from './ui'
 
 const prRefreshVisibilityCleanupRegistered = new Set<number>()
 
-// Why: notify every renderer (each window has its own SWR cache instance)
-// that a work item was mutated locally so they can drop their cached entry
-// and refetch on the next open. Only emitted after a successful mutation.
-// We skip the originating webContents because that renderer already updated
-// its cache optimistically — re-broadcasting would race the optimistic write
-// and erase it.
+// Why: the app renderer owns the SWR cache; browser guests cannot consume this
+// event. Skip the origin because it already updated its cache optimistically.
 function broadcastWorkItemMutated(
   payload: {
     repoPath: string
@@ -126,15 +123,7 @@ function broadcastWorkItemMutated(
   },
   senderId?: number
 ): void {
-  for (const wc of webContents.getAllWebContents()) {
-    if (wc.isDestroyed()) {
-      continue
-    }
-    if (senderId !== undefined && wc.id === senderId) {
-      continue
-    }
-    wc.send('gh:workItemMutated', payload)
-  }
+  sendToTrustedUIRenderer('gh:workItemMutated', payload, senderId)
 }
 
 // Why: returns the full Repo object instead of just the path string so that

--- a/src/main/ipc/ui.test.ts
+++ b/src/main/ipc/ui.test.ts
@@ -1,13 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { fromWebContentsMock, getAllWindowsMock, handleMock, onMock, removeAllListenersMock } =
-  vi.hoisted(() => ({
-    fromWebContentsMock: vi.fn(),
-    getAllWindowsMock: vi.fn(() => []),
-    handleMock: vi.fn(),
-    onMock: vi.fn(),
-    removeAllListenersMock: vi.fn()
-  }))
+const {
+  fromIdMock,
+  fromWebContentsMock,
+  getAllWebContentsMock,
+  getAllWindowsMock,
+  handleMock,
+  onMock,
+  removeAllListenersMock
+} = vi.hoisted(() => ({
+  fromIdMock: vi.fn(),
+  fromWebContentsMock: vi.fn(),
+  getAllWebContentsMock: vi.fn(),
+  getAllWindowsMock: vi.fn(() => []),
+  handleMock: vi.fn(),
+  onMock: vi.fn(),
+  removeAllListenersMock: vi.fn()
+}))
 
 vi.mock('electron', () => ({
   BrowserWindow: {
@@ -18,12 +27,17 @@ vi.mock('electron', () => ({
     handle: handleMock,
     on: onMock,
     removeAllListeners: removeAllListenersMock
+  },
+  webContents: {
+    fromId: fromIdMock,
+    getAllWebContents: getAllWebContentsMock
   }
 }))
 
 import {
   clearTrustedUIRendererWebContentsId,
   registerUIHandlers,
+  sendToTrustedUIRenderer,
   setTrustedUIRendererWebContentsId
 } from './ui'
 
@@ -56,10 +70,13 @@ function getNativePasteHandler():
   return onMock.mock.calls.find(([channel]) => channel === 'ui:performNativePaste')?.[1]
 }
 
-describe('registerUIHandlers', () => {
+describe('UI IPC', () => {
   beforeEach(() => {
     vi.stubEnv('ELECTRON_RENDERER_URL', '')
+    fromIdMock.mockReset()
     fromWebContentsMock.mockReset()
+    getAllWebContentsMock.mockReset()
+    getAllWebContentsMock.mockReturnValue([])
     getAllWindowsMock.mockReset()
     getAllWindowsMock.mockReturnValue([])
     handleMock.mockReset()
@@ -70,6 +87,69 @@ describe('registerUIHandlers', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs()
+  })
+
+  it('sends app events once to the trusted renderer without waking 100 browser guests', () => {
+    const rendererSend = vi.fn()
+    const guestSends = Array.from({ length: 100 }, () => vi.fn())
+    getAllWebContentsMock.mockReturnValue(
+      guestSends.map((send, index) => ({
+        id: index + 100,
+        isDestroyed: () => false,
+        send
+      }))
+    )
+    fromIdMock.mockReturnValue({ id: 17, isDestroyed: () => false, send: rendererSend })
+    setTrustedUIRendererWebContentsId(17)
+
+    sendToTrustedUIRenderer('gh:prRefreshEvent', { sequence: 1 })
+
+    expect(fromIdMock).toHaveBeenCalledOnce()
+    expect(fromIdMock).toHaveBeenCalledWith(17)
+    expect(rendererSend).toHaveBeenCalledOnce()
+    expect(rendererSend).toHaveBeenCalledWith('gh:prRefreshEvent', { sequence: 1 })
+    expect(getAllWebContentsMock).not.toHaveBeenCalled()
+    expect(guestSends.reduce((total, send) => total + send.mock.calls.length, 0)).toBe(0)
+  })
+
+  it('skips missing, destroyed, and originating renderers', () => {
+    const rendererSend = vi.fn()
+    setTrustedUIRendererWebContentsId(17)
+
+    fromIdMock.mockReturnValueOnce(undefined)
+    sendToTrustedUIRenderer('gh:workItemMutated', { number: 7 })
+
+    fromIdMock.mockReturnValueOnce({ id: 17, isDestroyed: () => true, send: rendererSend })
+    sendToTrustedUIRenderer('gh:workItemMutated', { number: 7 })
+
+    sendToTrustedUIRenderer('gh:workItemMutated', { number: 7 }, 17)
+
+    expect(fromIdMock).toHaveBeenCalledTimes(2)
+    expect(rendererSend).not.toHaveBeenCalled()
+  })
+
+  it('routes to a reopened window without retaining the closed renderer', () => {
+    const oldRendererSend = vi.fn()
+    const newRendererSend = vi.fn()
+    fromIdMock.mockImplementation((id) =>
+      id === 17
+        ? { id, isDestroyed: () => false, send: oldRendererSend }
+        : { id, isDestroyed: () => false, send: newRendererSend }
+    )
+
+    setTrustedUIRendererWebContentsId(17)
+    sendToTrustedUIRenderer('gh:prRefreshEvent', { sequence: 1 })
+
+    setTrustedUIRendererWebContentsId(42)
+    clearTrustedUIRendererWebContentsId(17)
+    sendToTrustedUIRenderer('gh:prRefreshEvent', { sequence: 2 })
+
+    clearTrustedUIRendererWebContentsId(42)
+    sendToTrustedUIRenderer('gh:prRefreshEvent', { sequence: 3 })
+
+    expect(oldRendererSend).toHaveBeenCalledTimes(1)
+    expect(newRendererSend).toHaveBeenCalledTimes(1)
+    expect(newRendererSend).toHaveBeenCalledWith('gh:prRefreshEvent', { sequence: 2 })
   })
 
   it('routes native paste fallback to the requesting webContents only', () => {

--- a/src/main/ipc/ui.ts
+++ b/src/main/ipc/ui.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, type WebContents } from 'electron'
+import { BrowserWindow, ipcMain, webContents, type WebContents } from 'electron'
 import type { Store } from '../persistence'
 import type { PersistedUIState } from '../../shared/types'
 import { isFeatureInteractionId } from '../../shared/feature-interactions'
@@ -13,6 +13,24 @@ export function clearTrustedUIRendererWebContentsId(webContentsId: number): void
   if (trustedUIRendererWebContentsId === webContentsId) {
     trustedUIRendererWebContentsId = null
   }
+}
+
+export function sendToTrustedUIRenderer(
+  channel: string,
+  payload: unknown,
+  excludedWebContentsId?: number
+): void {
+  const rendererId = trustedUIRendererWebContentsId
+  if (rendererId == null || rendererId === excludedWebContentsId) {
+    return
+  }
+  const renderer = webContents.fromId(rendererId)
+  if (!renderer || renderer.isDestroyed()) {
+    return
+  }
+  // Why: app events belong to the registered UI renderer; enumerating every
+  // WebContents wakes retained browser guests that cannot consume the channel.
+  renderer.send(channel, payload)
 }
 
 export function registerUIHandlers(store: Store): void {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1443,10 +1443,9 @@ const api = {
       sourceContext?: TaskSourceContext | null
     }): Promise<GitHubAssignableUser[]> => ipcRenderer.invoke('gh:listAssignableUsers', args),
 
-    // Why: every renderer subscribes to local mutation broadcasts so each
-    // window's work-item-details cache invalidates the affected entry. The
-    // event fires after a successful mutation in any window — see
-    // src/main/ipc/github.ts broadcastWorkItemMutated.
+    // Why: the app renderer owns the work-item-details cache. Main targets this
+    // bridge for non-origin mutations; origin callers already updated their
+    // cache optimistically — see src/main/ipc/github.ts.
     onWorkItemMutated: (
       callback: (payload: {
         repoPath: string

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -1579,9 +1579,9 @@ function patchCachedWorkItemBody(cacheKey: string, body: string): void {
 }
 
 // Why: install once at module load — every dialog instance shares the cache,
-// so a single subscription is enough. The preload bridge re-emits the
-// main-process broadcast for every window, so each renderer invalidates its
-// own cache when any window's mutation lands. We track the unsubscribe so
+// so a single subscription is enough. Main targets the registered app renderer
+// for non-origin mutations, and this listener invalidates the matching entry.
+// We track the unsubscribe so
 // Vite HMR doesn't accumulate listeners across module reloads in dev.
 let workItemMutatedUnsub: (() => void) | undefined
 let workItemDetailsCacheEventUnsub: (() => void) | undefined

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -1621,9 +1621,9 @@ function patchCachedWorkItemBody(cacheKey: string, body: string): void {
 }
 
 // Why: install once at module load — every dialog instance shares the cache,
-// so a single subscription is enough. The preload bridge re-emits the
-// main-process broadcast for every window, so each renderer invalidates its
-// own cache when any window's mutation lands. We track the unsubscribe so
+// so a single subscription is enough. Main targets the registered app renderer
+// for non-origin mutations, and this listener invalidates the matching entry.
+// We track the unsubscribe so
 // Vite HMR doesn't accumulate listeners across module reloads in dev.
 let workItemMutatedUnsub: (() => void) | undefined
 let workItemDetailsCacheEventUnsub: (() => void) | undefined


### PR DESCRIPTION
## Summary

Two main-process hosted-review paths sent each event through `webContents.getAllWebContents()`:

- `gh:prRefreshEvent`
- `gh:workItemMutated`

That collection includes every retained browser guest, offscreen browser window, and popup even though only Orca's app renderer installs these preload listeners. A workspace with 100 retained browser tabs therefore turned one review event into 101 IPC sends.

This change routes both channels through the existing trusted UI-renderer ownership boundary:

- resolve the current renderer with `webContents.fromId(trustedUIRendererWebContentsId)`
- skip missing or destroyed renderers
- preserve work-item mutation origin exclusion so the optimistic write is not invalidated
- keep close/reopen ownership safe without retaining a stale `WebContents` object
- update preload/renderer comments to describe the targeted contract

Electron 42 benchmark with a 1,592-byte payload, 100 events, and seven rounds per fixture:

| Retained webviews | Before sends | After sends | Before median | After median |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 100 | 100 | 0.400 ms | 0.363 ms |
| 20 | 2,100 | 100 | 12.477 ms | 0.341 ms |
| 100 | 10,100 | 100 | 60.983 ms | 0.337 ms |

At 100 retained browser tabs, this removes 10,000 irrelevant IPC sends per 100 events and makes the measured path about 181x faster. Targeted delivery stays flat at roughly 0.34 ms from 0 to 100 guests.

## Screenshots

No visual change.

Exact-branch Electron validation used an isolated fresh profile on renderer/CDP ports `5175/9335`. The visible Orca shell rendered, app identity matched `renderer-perf-2 @ nwparker/renderer-perf-27`, and the console reported zero errors. A real preload-to-main `gh:enqueuePRRefresh` call then delivered exactly one `skipped/bare` `gh:prRefreshEvent` back to the app renderer. No evidence files were committed.

## Testing

- [x] `pnpm typecheck`
- [x] Focused suites: 3 files / 68 tests passed
- [x] `pnpm test`: 2,567 files / 26,799 tests passed; 3 files / 33 tests intentionally skipped
- [x] Deterministic 100-guest count coverage for both hosted-review call sites
- [x] Missing, destroyed, originating, close, and reopen renderer coverage
- [x] Targeted oxlint and oxfmt checks
- [x] Switch-exhaustiveness, styled-scrollbar, reliability, max-lines-ratchet, and localization-coverage gates
- [x] `git diff --check`
- [x] Electron 42 before/after benchmark with 0, 20, and 100 real webviews
- [x] Exact final branch Electron dev build and real hosted-review IPC round-trip
- [ ] `pnpm lint`: branch-local code and all later gates pass, but aggregate lint stops on two untouched `origin/main` failures: `src/renderer/src/lib/launch-agent-in-new-tab.ts` has 303 counted lines against 300, and `ja.json` has the existing `components.native-chat.composer.uploadingAttachments` interpolation mismatch
- [ ] `pnpm build`: not run separately; exact-branch Electron validation compiled main, preload, and renderer successfully

## Performance and correctness proof

- **User-visible waste:** review refreshes and mutations wake every retained browser guest, adding main-process serialization/IPC work as browser-tab count grows.
- **Scale factor:** event count × live `WebContents`; 100 events with 100 guests produced 10,100 sends before this change.
- **Smallest fix:** reuse the main renderer ID already established by `createMainWindow` and updated by core-handler registration; no new registry or lifecycle listener is added.
- **Correctness oracle:** the app renderer receives one event; 100 guest send functions receive zero. Relevant payloads and sequence allocation are unchanged.
- **Lifecycle oracle:** missing/destroyed targets are skipped, a stale window close cannot clear newer ownership, and reopen delivery resolves the new renderer by ID.
- **Origin oracle:** `broadcastWorkItemMutated` still passes the invoking renderer ID, so the helper skips the optimistic origin exactly as before.
- **Performance risk inventory:** adds one ID lookup and destroyed check per event. It adds no polling, timers, cache, subprocess, provider fan-out, startup await, renderer render work, or retained object.
- **Platform/provider coverage:** `webContents.fromId` and the trusted window lifecycle are Electron APIs shared across macOS, Linux, and Windows. No filesystem, path, shell, SSH/WSL, git-provider, or hosted-provider payload contract changes.

## Security audit

The target ID is main-owned and already gates privileged native-paste IPC; renderer input cannot select it. Targeting that trusted renderer also stops hosted-review payloads from being copied into unrelated browser guest processes. No auth, repository validation, payload contents, or preload exposure changes.

## ELI5

GitHub refresh events now go only to Orca’s app window instead of waking every open browser tab. Review updates therefore stay bounded as browser-tab count grows.
