### PR TITLE
Restore original agent working-spinner size in AgentStateDot

### DIFF
--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -76,11 +76,8 @@ export const AgentStateDot = React.memo(function AgentStateDot({
           className={cn(
             // Why: match the sidebar worktree spinner's stepped cadence so
             // long-running visible agents do not keep a full-frame-rate loop.
-            // Sized like the check icon (not the filled dots): both are
-            // outline glyphs, so a smaller ring reads visibly undersized
-            // next to a 'done' check in the same list.
             'block rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite]',
-            icon
+            inner
           )}
         />
       </span>


### PR DESCRIPTION
## Summary
PR #7423 (AI Vault subagent display) resized the `AgentStateDot` working-spinner ring from the dot size (`inner`) to the icon size (`icon`) — sm: 6px → 10px, md: 8px → 12px. That size bump was unintentional for the sidebar agent status rows, where the spinner now reads noticeably oversized next to the worktree-level `StatusIndicator` spinner.

This restores the original `inner` sizing for the working state and drops the comment that justified the icon sizing.

## Testing
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/AgentStateDot.test.ts src/renderer/src/components/sidebar/StatusIndicator.test.ts` — 10/10 pass