### PR TITLE
perf(ai-vault): index visible session pane lookups

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
@@ -9,7 +9,7 @@ import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import { translate } from '@/i18n/i18n'
 import { findOriginalAiVaultSessionPane } from './ai-vault-original-pane'
 import {
-  buildAiVaultOriginalPaneIndex,
+  createLazyAiVaultOriginalPaneIndex,
   findAiVaultSessionLiveStateInIndex,
   findOriginalAiVaultSessionPaneInIndex
 } from './ai-vault-original-pane-index'
@@ -31,22 +31,23 @@ export function useAiVaultOriginalPaneActions(): {
       terminalLayoutsByTabId: s.terminalLayoutsByTabId
     }))
   )
-  // Why: the virtual list asks both questions for every visible row. Build the
-  // collection indexes once per immutable store snapshot instead of rescanning
-  // every live, retained, and sleeping agent for each row.
-  const originalPaneIndex = useMemo(
-    () => buildAiVaultOriginalPaneIndex(originalPaneLookupState),
+  // Why: loading, filtered, or collapsed views may render no session rows.
+  // Build once on the first actual lookup, then share it across visible rows.
+  const getOriginalPaneIndex = useMemo(
+    () => createLazyAiVaultOriginalPaneIndex(originalPaneLookupState),
     [originalPaneLookupState]
   )
 
   const getOriginalPaneTarget = useCallback(
-    (session: AiVaultSession) => findOriginalAiVaultSessionPaneInIndex(originalPaneIndex, session),
-    [originalPaneIndex]
+    (session: AiVaultSession) =>
+      findOriginalAiVaultSessionPaneInIndex(getOriginalPaneIndex(), session),
+    [getOriginalPaneIndex]
   )
 
   const getSessionLiveState = useCallback(
-    (session: AiVaultSession) => findAiVaultSessionLiveStateInIndex(originalPaneIndex, session),
-    [originalPaneIndex]
+    (session: AiVaultSession) =>
+      findAiVaultSessionLiveStateInIndex(getOriginalPaneIndex(), session),
+    [getOriginalPaneIndex]
   )
 
   const jumpToOriginalPane = useCallback((session: AiVaultSession): void => {

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { toast } from 'sonner'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
@@ -7,10 +7,12 @@ import { useAppStore } from '@/store'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import { translate } from '@/i18n/i18n'
+import { findOriginalAiVaultSessionPane } from './ai-vault-original-pane'
 import {
-  findAiVaultSessionLiveState,
-  findOriginalAiVaultSessionPane
-} from './ai-vault-original-pane'
+  buildAiVaultOriginalPaneIndex,
+  findAiVaultSessionLiveStateInIndex,
+  findOriginalAiVaultSessionPaneInIndex
+} from './ai-vault-original-pane-index'
 
 export function useAiVaultOriginalPaneActions(): {
   getOriginalPaneTarget: (
@@ -29,15 +31,22 @@ export function useAiVaultOriginalPaneActions(): {
       terminalLayoutsByTabId: s.terminalLayoutsByTabId
     }))
   )
-
-  const getOriginalPaneTarget = useCallback(
-    (session: AiVaultSession) => findOriginalAiVaultSessionPane(originalPaneLookupState, session),
+  // Why: the virtual list asks both questions for every visible row. Build the
+  // collection indexes once per immutable store snapshot instead of rescanning
+  // every live, retained, and sleeping agent for each row.
+  const originalPaneIndex = useMemo(
+    () => buildAiVaultOriginalPaneIndex(originalPaneLookupState),
     [originalPaneLookupState]
   )
 
+  const getOriginalPaneTarget = useCallback(
+    (session: AiVaultSession) => findOriginalAiVaultSessionPaneInIndex(originalPaneIndex, session),
+    [originalPaneIndex]
+  )
+
   const getSessionLiveState = useCallback(
-    (session: AiVaultSession) => findAiVaultSessionLiveState(originalPaneLookupState, session),
-    [originalPaneLookupState]
+    (session: AiVaultSession) => findAiVaultSessionLiveStateInIndex(originalPaneIndex, session),
+    [originalPaneIndex]
   )
 
   const jumpToOriginalPane = useCallback((session: AiVaultSession): void => {

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { AiVaultSession } from '../../../../shared/ai-vault-types'
+import {
+  buildAiVaultOriginalPaneIndex,
+  findAiVaultSessionLiveStateInIndex,
+  findOriginalAiVaultSessionPaneInIndex
+} from './ai-vault-original-pane-index'
+import {
+  findAiVaultSessionLiveState,
+  findOriginalAiVaultSessionPane
+} from './ai-vault-original-pane'
+
+const SESSION: AiVaultSession = {
+  id: 'codex:target-session',
+  executionHostId: 'local',
+  agent: 'codex',
+  sessionId: 'target-session',
+  title: 'Target session',
+  cwd: '/repo',
+  branch: null,
+  model: null,
+  filePath: '/tmp/target-session.jsonl',
+  codexHome: null,
+  createdAt: null,
+  updatedAt: '2026-07-10T00:00:00.000Z',
+  modifiedAt: '2026-07-10T00:00:00.000Z',
+  messageCount: 1,
+  totalTokens: 1,
+  previewMessages: [],
+  queuedMessageCount: 0,
+  subagentTranscriptCount: 0,
+  resumeCommand: "codex resume 'target-session'",
+  subagent: null
+}
+
+function countedRecord<T>(count: number, makeValue: (index: number) => T) {
+  const reads = { value: 0 }
+  const record: Record<string, T> = {}
+  for (let index = 0; index < count; index += 1) {
+    Object.defineProperty(record, `entry-${index}`, {
+      enumerable: true,
+      get: () => {
+        reads.value += 1
+        return makeValue(index)
+      }
+    })
+  }
+  return { reads, record }
+}
+
+function unrelatedEntry(index: number): AgentStatusEntry {
+  return {
+    state: 'done',
+    prompt: `Other task ${index}`,
+    updatedAt: index,
+    stateStartedAt: index,
+    agentType: 'claude',
+    paneKey: `other-tab-${index}:11111111-1111-4111-8111-111111111111`,
+    tabId: `other-tab-${index}`,
+    worktreeId: 'other-worktree',
+    stateHistory: [],
+    providerSession: { key: 'session_id', id: `other-session-${index}` }
+  }
+}
+
+describe('AI Vault original-pane index', () => {
+  it('builds once instead of rescanning every agent collection for every visible row', () => {
+    const live = countedRecord(500, unrelatedEntry)
+    const retained = countedRecord(500, (index) => ({
+      entry: unrelatedEntry(index),
+      worktreeId: 'other-worktree',
+      tab: { id: `other-tab-${index}` },
+      agentType: 'claude',
+      startedAt: index
+    }))
+    const sleeping = countedRecord(500, (index) => ({
+      paneKey: `other-tab-${index}:11111111-1111-4111-8111-111111111111`,
+      tabId: `other-tab-${index}`,
+      worktreeId: 'other-worktree',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: `other-session-${index}` },
+      prompt: `Other task ${index}`,
+      state: 'done',
+      capturedAt: index,
+      updatedAt: index,
+      origin: 'live'
+    }))
+    const state = {
+      agentStatusByPaneKey: live.record,
+      retainedAgentsByPaneKey: retained.record,
+      sleepingAgentSessionsByPaneKey: sleeping.record,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    } as never
+
+    const index = buildAiVaultOriginalPaneIndex(state)
+    expect(live.reads.value + retained.reads.value + sleeping.reads.value).toBe(1_500)
+
+    live.reads.value = 0
+    retained.reads.value = 0
+    sleeping.reads.value = 0
+    for (let row = 0; row < 20; row += 1) {
+      expect(findOriginalAiVaultSessionPaneInIndex(index, SESSION)).toBeNull()
+      expect(findAiVaultSessionLiveStateInIndex(index, SESSION)).toBeNull()
+    }
+    expect(live.reads.value + retained.reads.value + sleeping.reads.value).toBe(0)
+  })
+
+  it('preserves provider, prompt-fallback, retained, sleeping, and missing matches', () => {
+    const leafIds = [
+      '11111111-1111-4111-8111-111111111111',
+      '22222222-2222-4222-8222-222222222222',
+      '33333333-3333-4333-8333-333333333333',
+      '44444444-4444-4444-8444-444444444444'
+    ]
+    const tabs = leafIds.map((_, index) => ({
+      id: `tab-${index + 1}`,
+      ptyId: null,
+      worktreeId: 'wt-1',
+      title: 'Agent',
+      customTitle: null,
+      color: null,
+      sortOrder: index,
+      createdAt: index
+    }))
+    const layouts = Object.fromEntries(
+      leafIds.map((leafId, index) => [
+        `tab-${index + 1}`,
+        {
+          root: { type: 'leaf', leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: `pty-${index + 1}` }
+        }
+      ])
+    )
+    const liveDirect = {
+      ...unrelatedEntry(1),
+      agentType: 'codex',
+      paneKey: `tab-1:${leafIds[0]}`,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      state: 'blocked',
+      providerSession: { key: 'session_id', id: 'live-direct' }
+    } as AgentStatusEntry
+    const livePrompt = {
+      ...unrelatedEntry(2),
+      agentType: 'codex',
+      paneKey: `tab-2:${leafIds[1]}`,
+      tabId: 'tab-2',
+      worktreeId: 'wt-1',
+      prompt: 'Unique prompt match that is long enough',
+      providerSession: undefined
+    } as AgentStatusEntry
+    const retainedEntry = {
+      ...unrelatedEntry(3),
+      agentType: 'codex',
+      paneKey: `tab-3:${leafIds[2]}`,
+      tabId: 'tab-3',
+      worktreeId: 'wt-1',
+      providerSession: { key: 'session_id', id: 'retained-direct' }
+    } as AgentStatusEntry
+    const state = {
+      agentStatusByPaneKey: {
+        [liveDirect.paneKey]: liveDirect,
+        [livePrompt.paneKey]: livePrompt
+      },
+      retainedAgentsByPaneKey: {
+        [retainedEntry.paneKey]: {
+          entry: retainedEntry,
+          worktreeId: 'wt-1',
+          tab: tabs[2],
+          agentType: 'codex',
+          startedAt: 1
+        }
+      },
+      sleepingAgentSessionsByPaneKey: {
+        'tab-4:1': {
+          paneKey: 'tab-4:1',
+          tabId: 'tab-4',
+          worktreeId: 'wt-1',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'sleeping-direct' },
+          prompt: 'Sleeping',
+          state: 'done',
+          capturedAt: 1,
+          updatedAt: 1,
+          origin: 'live'
+        }
+      },
+      tabsByWorktree: { 'wt-1': tabs },
+      terminalLayoutsByTabId: layouts
+    } as never
+    const index = buildAiVaultOriginalPaneIndex(state)
+    const sessions = [
+      { ...SESSION, sessionId: 'live-direct' },
+      {
+        ...SESSION,
+        sessionId: 'prompt-only',
+        title: 'Unique prompt match that is long enough'
+      },
+      { ...SESSION, sessionId: 'retained-direct' },
+      { ...SESSION, sessionId: 'sleeping-direct' },
+      { ...SESSION, sessionId: 'missing' }
+    ]
+
+    for (const session of sessions) {
+      expect(findOriginalAiVaultSessionPaneInIndex(index, session)).toEqual(
+        findOriginalAiVaultSessionPane(state, session)
+      )
+      expect(findAiVaultSessionLiveStateInIndex(index, session)).toBe(
+        findAiVaultSessionLiveState(state, session)
+      )
+    }
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.test.ts
@@ -3,6 +3,7 @@ import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import {
   buildAiVaultOriginalPaneIndex,
+  createLazyAiVaultOriginalPaneIndex,
   findAiVaultSessionLiveStateInIndex,
   findOriginalAiVaultSessionPaneInIndex
 } from './ai-vault-original-pane-index'
@@ -65,6 +66,42 @@ function unrelatedEntry(index: number): AgentStatusEntry {
 }
 
 describe('AI Vault original-pane index', () => {
+  it('builds lazily on the first lookup and shares one index across callbacks', () => {
+    const live = countedRecord(500, unrelatedEntry)
+    const retained = countedRecord(500, (index) => ({
+      entry: unrelatedEntry(index),
+      worktreeId: 'other-worktree',
+      tab: { id: `other-tab-${index}` },
+      agentType: 'claude',
+      startedAt: index
+    }))
+    const sleeping = countedRecord(500, (index) => ({
+      paneKey: `other-tab-${index}:11111111-1111-4111-8111-111111111111`,
+      tabId: `other-tab-${index}`,
+      worktreeId: 'other-worktree',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: `other-session-${index}` },
+      prompt: `Other task ${index}`,
+      state: 'done',
+      capturedAt: index,
+      updatedAt: index,
+      origin: 'live'
+    }))
+    const getIndex = createLazyAiVaultOriginalPaneIndex({
+      agentStatusByPaneKey: live.record,
+      retainedAgentsByPaneKey: retained.record,
+      sleepingAgentSessionsByPaneKey: sleeping.record,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    } as never)
+
+    expect(live.reads.value + retained.reads.value + sleeping.reads.value).toBe(0)
+    expect(findAiVaultSessionLiveStateInIndex(getIndex(), SESSION)).toBeNull()
+    expect(live.reads.value + retained.reads.value + sleeping.reads.value).toBe(1_500)
+    expect(findOriginalAiVaultSessionPaneInIndex(getIndex(), SESSION)).toBeNull()
+    expect(live.reads.value + retained.reads.value + sleeping.reads.value).toBe(1_500)
+  })
+
   it('builds once instead of rescanning every agent collection for every visible row', () => {
     const live = countedRecord(500, unrelatedEntry)
     const retained = countedRecord(500, (index) => ({

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.ts
@@ -1,0 +1,177 @@
+import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import type { AiVaultSession } from '../../../../shared/ai-vault-types'
+import {
+  promptsMatchSession,
+  resolveOriginalPaneTarget,
+  type OriginalPaneState,
+  type AiVaultOriginalPaneTarget
+} from './ai-vault-original-pane'
+
+type LiveEntry = NonNullable<OriginalPaneState['agentStatusByPaneKey'][string]>
+type RetainedEntry = NonNullable<OriginalPaneState['retainedAgentsByPaneKey'][string]>
+type SleepingEntry = NonNullable<OriginalPaneState['sleepingAgentSessionsByPaneKey'][string]>
+
+type ProviderIndex<T> = Map<string, T[]>
+type AgentIndex<T> = Map<string, T[]>
+
+export type AiVaultOriginalPaneIndex = {
+  state: OriginalPaneState
+  liveByProvider: ProviderIndex<LiveEntry>
+  liveWithoutProviderByAgent: AgentIndex<LiveEntry>
+  retainedByProvider: ProviderIndex<RetainedEntry>
+  retainedWithoutProviderByAgent: AgentIndex<RetainedEntry>
+  sleepingByProvider: ProviderIndex<SleepingEntry>
+}
+
+function providerKey(agent: string, sessionId: string): string {
+  return `${agent}\u0000${sessionId}`
+}
+
+function appendToIndex<T>(index: Map<string, T[]>, key: string, value: T): void {
+  const entries = index.get(key)
+  if (entries) {
+    entries.push(value)
+  } else {
+    index.set(key, [value])
+  }
+}
+
+export function buildAiVaultOriginalPaneIndex(state: OriginalPaneState): AiVaultOriginalPaneIndex {
+  const liveByProvider: ProviderIndex<LiveEntry> = new Map()
+  const liveWithoutProviderByAgent: AgentIndex<LiveEntry> = new Map()
+  const retainedByProvider: ProviderIndex<RetainedEntry> = new Map()
+  const retainedWithoutProviderByAgent: AgentIndex<RetainedEntry> = new Map()
+  const sleepingByProvider: ProviderIndex<SleepingEntry> = new Map()
+
+  for (const entry of Object.values(state.agentStatusByPaneKey)) {
+    if (!entry?.agentType) {
+      continue
+    }
+    if (entry.providerSession) {
+      appendToIndex(liveByProvider, providerKey(entry.agentType, entry.providerSession.id), entry)
+    } else if (entry.providerSession === undefined) {
+      appendToIndex(liveWithoutProviderByAgent, entry.agentType, entry)
+    }
+  }
+  for (const retained of Object.values(state.retainedAgentsByPaneKey)) {
+    if (!retained?.agentType) {
+      continue
+    }
+    if (retained.entry.providerSession) {
+      appendToIndex(
+        retainedByProvider,
+        providerKey(retained.agentType, retained.entry.providerSession.id),
+        retained
+      )
+    } else if (retained.entry.providerSession === undefined) {
+      appendToIndex(retainedWithoutProviderByAgent, retained.agentType, retained)
+    }
+  }
+  for (const record of Object.values(state.sleepingAgentSessionsByPaneKey)) {
+    if (record) {
+      appendToIndex(
+        sleepingByProvider,
+        providerKey(record.agent, record.providerSession.id),
+        record
+      )
+    }
+  }
+
+  return {
+    state,
+    liveByProvider,
+    liveWithoutProviderByAgent,
+    retainedByProvider,
+    retainedWithoutProviderByAgent,
+    sleepingByProvider
+  }
+}
+
+export function findOriginalAiVaultSessionPaneInIndex(
+  index: AiVaultOriginalPaneIndex,
+  session: AiVaultSession
+): AiVaultOriginalPaneTarget | null {
+  const key = providerKey(session.agent, session.sessionId)
+  const promptMatchedTargets: AiVaultOriginalPaneTarget[] = []
+
+  for (const entry of index.liveByProvider.get(key) ?? []) {
+    const target = resolveOriginalPaneTarget({
+      state: index.state,
+      paneKey: entry.paneKey,
+      worktreeIdHint: entry.worktreeId,
+      tabIdHint: entry.tabId
+    })
+    if (target) {
+      return target
+    }
+  }
+  for (const entry of index.liveWithoutProviderByAgent.get(session.agent) ?? []) {
+    if (!promptsMatchSession(session, entry)) {
+      continue
+    }
+    const target = resolveOriginalPaneTarget({
+      state: index.state,
+      paneKey: entry.paneKey,
+      worktreeIdHint: entry.worktreeId,
+      tabIdHint: entry.tabId
+    })
+    if (target) {
+      promptMatchedTargets.push(target)
+    }
+  }
+  for (const retained of index.retainedByProvider.get(key) ?? []) {
+    const target = resolveOriginalPaneTarget({
+      state: index.state,
+      paneKey: retained.entry.paneKey,
+      worktreeIdHint: retained.worktreeId,
+      tabIdHint: retained.entry.tabId ?? retained.tab.id
+    })
+    if (target) {
+      return target
+    }
+  }
+  for (const retained of index.retainedWithoutProviderByAgent.get(session.agent) ?? []) {
+    if (!promptsMatchSession(session, retained.entry)) {
+      continue
+    }
+    const target = resolveOriginalPaneTarget({
+      state: index.state,
+      paneKey: retained.entry.paneKey,
+      worktreeIdHint: retained.worktreeId,
+      tabIdHint: retained.entry.tabId ?? retained.tab.id
+    })
+    if (target) {
+      promptMatchedTargets.push(target)
+    }
+  }
+  for (const record of index.sleepingByProvider.get(key) ?? []) {
+    const target = resolveOriginalPaneTarget({
+      state: index.state,
+      paneKey: record.paneKey,
+      worktreeIdHint: record.worktreeId,
+      tabIdHint: record.tabId
+    })
+    if (target) {
+      return target
+    }
+  }
+
+  return promptMatchedTargets.length === 1 ? promptMatchedTargets[0] : null
+}
+
+export function findAiVaultSessionLiveStateInIndex(
+  index: AiVaultOriginalPaneIndex,
+  session: AiVaultSession
+): AgentStatusState | null {
+  const direct = index.liveByProvider.get(providerKey(session.agent, session.sessionId))
+  if (direct?.[0]) {
+    return direct[0].state
+  }
+  const promptMatchedStates: AgentStatusState[] = []
+  for (const entry of index.liveWithoutProviderByAgent.get(session.agent) ?? []) {
+    if (promptsMatchSession(session, entry)) {
+      promptMatchedStates.push(entry.state)
+    }
+  }
+  return promptMatchedStates.length === 1 ? promptMatchedStates[0] : null
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.ts
@@ -24,6 +24,8 @@ export type AiVaultOriginalPaneIndex = {
 }
 
 function providerKey(agent: string, sessionId: string): string {
+  // Why: unlike punctuation delimiters, NUL cannot collide with agent or
+  // provider-session text, so distinct identity pairs stay distinct keys.
   return `${agent}\u0000${sessionId}`
 }
 
@@ -84,6 +86,16 @@ export function buildAiVaultOriginalPaneIndex(state: OriginalPaneState): AiVault
     retainedByProvider,
     retainedWithoutProviderByAgent,
     sleepingByProvider
+  }
+}
+
+export function createLazyAiVaultOriginalPaneIndex(
+  state: OriginalPaneState
+): () => AiVaultOriginalPaneIndex {
+  let index: AiVaultOriginalPaneIndex | null = null
+  return () => {
+    index ??= buildAiVaultOriginalPaneIndex(state)
+    return index
   }
 }
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane.ts
@@ -12,7 +12,7 @@ export type AiVaultOriginalPaneTarget = {
   leafId: string
 }
 
-type OriginalPaneState = Pick<
+export type OriginalPaneState = Pick<
   AppState,
   | 'agentStatusByPaneKey'
   | 'retainedAgentsByPaneKey'
@@ -87,10 +87,10 @@ function entryPromptCandidates(entry: {
   return [...candidates]
 }
 
-function promptsMatchSession(
+export function promptsMatchSession(
   session: AiVaultSession,
   entry: Parameters<typeof entryPromptCandidates>[0]
-) {
+): boolean {
   const sessionCandidates = sessionPromptCandidates(session)
   if (sessionCandidates.length === 0) {
     return false
@@ -134,7 +134,7 @@ function getTabOwnerWorktreeId(
   return null
 }
 
-function resolveOriginalPaneTarget(args: {
+export function resolveOriginalPaneTarget(args: {
   state: OriginalPaneState
   paneKey: string
   worktreeIdHint?: string


### PR DESCRIPTION
## Description

AI Vault asks two questions for every visible virtualized session row: whether the session is live, and whether its original terminal pane is still available. Before this change, each answer independently walked the complete live-agent collection, and original-pane resolution also walked every retained and sleeping-agent record. Any relevant Zustand snapshot change recreated the row callbacks and repeated those full scans for every visible row.

This change creates a lazy provider-session/providerless-agent index accessor per immutable AI Vault lookup snapshot. Loading, empty, fully filtered, and fully collapsed views build nothing; the first visible-row lookup builds the indexes once, and both row callbacks then share direct Map buckets. Prompt-only fallback remains scoped to providerless records for the matching agent. The one-off Jump to original pane action still reads fresh store state at click time.

## Evidence — proven performance issue

The committed deterministic fixture contains 500 live, 500 retained, and 500 sleeping records with 20 visible session rows.

| One relevant AI Vault render | Before | After |
| --- | ---: | ---: |
| Agent records | 1,500 | 1,500 |
| Visible rows | 20 | 20 |
| Collection reads with zero rendered rows | 0 | 0 |
| Collection reads during first visible-row index build | 0 | 1,500 |
| Collection reads during later row lookups | 40,000 | 0 |
| Total collection reads | 40,000 | 1,500 |
| Reduction | — | 96.25% |

Why 40,000 before: each row scanned 500 live records for live-state resolution, then 500 live + 500 retained + 500 sleeping records for original-pane resolution. That is 2,000 record reads per row times 20 rows.

A seven-run local microbenchmark used the production functions, warmed them first, and measured 100 update/render cycles. Each cycle used 1,500 records and 20 visible rows, and the indexed case pessimistically rebuilt the index every cycle.

| 100 update/render cycles | Before | After |
| --- | ---: | ---: |
| Median | 263.25 ms | 26.04 ms |
| Reduction | — | 90.1% |

Individual before runs: 263.25, 262.22, 261.76, 261.74, 267.72, 264.58, 267.41 ms.

Individual after runs: 26.04, 25.56, 25.94, 26.40, 26.42, 25.39, 26.10 ms.

The regression tests prove that zero-row snapshots read none of the three source collections, the first actual lookup builds once, and both callbacks plus 20 indexed row lookups reread none of the source collections after that shared build. A differential behavior test compares the indexed and previous lookup implementations for direct provider matches, prompt fallback, retained sessions, sleeping legacy pane keys, and missing sessions.

## ELI5

AI Vault used to search every shelf in the archive twice for every row visible on screen. Now it makes a catalog once, then each row looks up the exact shelf it needs.

## End-user trade-offs / regressions

- No expected behavior change. Provider-session precedence, unique prompt fallback, first-match ordering, stale-pane rejection, retained agents, sleeping agents, and legacy numeric pane keys are preserved.
- While AI Vault is mounted, it holds bounded Map indexes containing references to the same live, retained, and sleeping records already held by the store. This trades O(number of records) temporary index memory for removing O(visible rows × records) render work. The indexes are component-scoped and released on unmount.
- A relevant agent or terminal-topology snapshot change invalidates the lazy accessor; the next actual row lookup rebuilds once. Unrelated store changes were already filtered by the shallow selector and remain filtered.
- With the 500/500/500 benchmark shape, one visible live-matching row reads 1,500 records after versus 1,000 before because the shared index prepares retained/sleeping tiers too. At two rows the indexed path already wins (1,500 versus 2,000), and zero-row states remain at zero. This bounded one-row CPU trade-off buys constant-time direct buckets for the normal multi-row virtual list.
- Providerless prompt fallback still scans providerless records for the matching agent because prompt matching can be ambiguous; direct provider-session matches use constant-time buckets.
- No visual, persisted-state, IPC, network, terminal, SSH, WSL, provider, or platform behavior changes.

## Verification

- Full suite: 2,569 test files / 26,800 tests passed; 3 files / 33 tests skipped
- Complete AI Vault suite: 13 files / 150 tests passed
- Focused original-pane/index suite: 2 files / 13 tests passed
- Lazy-build count proof: 0 reads before the first row lookup, 1,500 on first use, and still 1,500 after the second callback
- Typecheck passed
- Changed-file oxlint passed
- Changed-file formatting passed
- Reliability manifest passed
- Max-lines ratchet passed
- Changed-file lint and formatting passed; the branch is rebased onto current main, which contains the unrelated max-lines fix

## Screenshots

No visual change. Electron was not launched because branch-specific macOS dev identities trigger repeated Safe Storage prompts.