### PR TITLE
Extract web-host agent launch path to fix max-lines lint break on main

### DIFF
--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -14,11 +14,8 @@ import { initialAgentTabViewModeProps } from '@/lib/native-chat-initial-view-mod
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
-import {
-  createWebRuntimeSessionTerminal,
-  isWebRuntimeSessionActive,
-  isWebTerminalSurfaceTabId
-} from '@/runtime/web-runtime-session'
+import { isWebRuntimeSessionActive } from '@/runtime/web-runtime-session'
+import { launchAgentInWebHostTab } from '@/lib/launch-agent-web-host-tab'
 import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
@@ -56,15 +53,6 @@ export type LaunchAgentInNewTabArgs = {
   launchPlatform?: NodeJS.Platform
   /** Called after the prompt is actually delivered to the agent input path. */
   onPromptDelivered?: () => void
-}
-
-function removeStaleLocalAgentTabsForWebHostLaunch(worktreeId: string): void {
-  const state = useAppStore.getState()
-  for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
-    if (tab.launchAgent && !isWebTerminalSurfaceTabId(tab.id)) {
-      state.closeTab(tab.id)
-    }
-  }
 }
 
 export type LaunchAgentInNewTabResult = {
@@ -215,44 +203,14 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
 
   const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(store, worktreeId)
   if (isWebRuntimeSessionActive(runtimeEnvironmentId) && pasteDraftAfterLaunch === null) {
-    // Why: paired web tabs are host-owned and return tabId: null on success.
-    // Local-only agent tabs cannot be closed because close routes through
-    // session.tabs.close on the host, so prune them before the host snapshot.
-    removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
-    void createWebRuntimeSessionTerminal({
+    launchAgentInWebHostTab({
+      agent,
       worktreeId,
       environmentId: runtimeEnvironmentId,
-      targetGroupId: groupId,
-      activate: true,
-      ...(hasPrompt
-        ? {
-            command: startupPlan.launchCommand,
-            ...(startupPlan.env ? { env: startupPlan.env } : {}),
-            launchConfig: startupPlan.launchConfig,
-            launchAgent: agent,
-            ...(startupPlan.startupCommandDelivery
-              ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
-              : {})
-          }
-        : { agent })
-    }).then((created) => {
-      // Why: created means the host accepted the launch, not that a local tab
-      // exists; keep pruning stale local rows until the snapshot mirrors.
-      removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
-      if (!created) {
-        toast.error(
-          translate(
-            'auto.lib.launch.agent.in.new.tab.11cce5cc77',
-            'Could not launch {{value0}} in a new terminal.',
-            { value0: agent }
-          )
-        )
-        return
-      }
-      store.setActiveTabType('terminal')
-      if (hasPrompt) {
-        onPromptDelivered?.()
-      }
+      groupId,
+      hasPrompt,
+      startupPlan,
+      onPromptDelivered
     })
     return { tabId: null, startupPlan, pasteDraftAfterLaunch: false }
   }

--- a/src/renderer/src/lib/launch-agent-web-host-tab.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.ts
@@ -1,0 +1,75 @@
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+import {
+  createWebRuntimeSessionTerminal,
+  isWebTerminalSurfaceTabId
+} from '@/runtime/web-runtime-session'
+import type { TuiAgent } from '../../../shared/types'
+import { translate } from '@/i18n/i18n'
+
+function removeStaleLocalAgentTabsForWebHostLaunch(worktreeId: string): void {
+  const state = useAppStore.getState()
+  for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
+    if (tab.launchAgent && !isWebTerminalSurfaceTabId(tab.id)) {
+      state.closeTab(tab.id)
+    }
+  }
+}
+
+/**
+ * Launch an agent terminal on the web runtime host instead of a local tab.
+ *
+ * Why: paired web tabs are host-owned, so this path never creates a local tab
+ * (callers return tabId: null). Local-only agent tabs cannot be closed because
+ * close routes through session.tabs.close on the host, so prune them before
+ * the host snapshot.
+ */
+export function launchAgentInWebHostTab(args: {
+  agent: TuiAgent
+  worktreeId: string
+  environmentId: string | null
+  groupId?: string
+  hasPrompt: boolean
+  startupPlan: AgentStartupPlan
+  onPromptDelivered?: () => void
+}): void {
+  const { agent, worktreeId, environmentId, groupId, hasPrompt, startupPlan, onPromptDelivered } =
+    args
+  removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
+  void createWebRuntimeSessionTerminal({
+    worktreeId,
+    environmentId,
+    targetGroupId: groupId,
+    activate: true,
+    ...(hasPrompt
+      ? {
+          command: startupPlan.launchCommand,
+          ...(startupPlan.env ? { env: startupPlan.env } : {}),
+          launchConfig: startupPlan.launchConfig,
+          launchAgent: agent,
+          ...(startupPlan.startupCommandDelivery
+            ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
+            : {})
+        }
+      : { agent })
+  }).then((created) => {
+    // Why: created means the host accepted the launch, not that a local tab
+    // exists; keep pruning stale local rows until the snapshot mirrors.
+    removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
+    if (!created) {
+      toast.error(
+        translate(
+          'auto.lib.launch.agent.in.new.tab.11cce5cc77',
+          'Could not launch {{value0}} in a new terminal.',
+          { value0: agent }
+        )
+      )
+      return
+    }
+    useAppStore.getState().setActiveTabType('terminal')
+    if (hasPrompt) {
+      onPromptDelivered?.()
+    }
+  })
+}


### PR DESCRIPTION
## Summary
`verify` is currently failing on **every open PR** — including ones that don't touch this file — because `src/renderer/src/lib/launch-agent-in-new-tab.ts` is over the oxlint `max-lines` limit (303/300 counted lines) on `main`:

- #5510 and #7944 both grew the file; each PR individually passed `verify`, but their combination on `main` crossed the limit (merge race — `verify` doesn't run on `main` pushes, so this landed silently).
- The file is not in `config/max-lines-baseline.txt`, and per AGENTS.md the fix is to split, not suppress.

This extracts the web-runtime host launch branch (stale-local-tab pruning + `createWebRuntimeSessionTerminal` call with its created/failed handling) into `launch-agent-web-host-tab.ts`. `launchAgentInNewTab`'s public API and behavior are unchanged; the moved toast keeps its existing i18n key so all five locale catalogs are untouched.

## Testing
- `pnpm exec oxlint` — repo-wide `max-lines` errors: 0 (was 1)
- `npx vitest run --config config/vitest.config.ts` on `launch-agent-in-new-tab.test.ts`, `QuickLaunchButton.test.ts`, `terminal-agent-session-fork.test.ts`, `source-control-ai-commit-failure-launch.test.ts`, `launch-ai-vault-session.test.ts` — 61/61 pass
- `pnpm typecheck:web` — clean

Unblocks #8172 (and any other PR whose `verify` re-runs after this merges).