### PR TITLE
fix(lint): unbreak main max-lines — split prompt-plan resolution out of launch-agent-in-new-tab

### DIFF
--- a/src/renderer/src/lib/agent-launch-prompt-plan.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-plan.ts
@@ -1,0 +1,115 @@
+import {
+  buildAgentDraftLaunchPlan,
+  buildAgentStartupPlan,
+  type AgentStartupPlan
+} from '@/lib/tui-agent-startup'
+import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+
+/** Shared launch inputs for a single agent tab launch, minus the prompt fields
+ *  this module resolves. */
+export type AgentLaunchStartupPlanBase = Omit<
+  Parameters<typeof buildAgentStartupPlan>[0],
+  'prompt' | 'allowEmptyPromptLaunch'
+>
+
+export type AgentLaunchPromptPlan = {
+  startupPlan: AgentStartupPlan | null
+  /** Prompt text to bracket-paste into the TUI after launch, or null when the
+   *  prompt (if any) rides the launch command itself. */
+  pasteDraftAfterLaunch: string | null
+  submitPastedPrompt: boolean
+  forcePasteAfterLaunch: boolean
+  trimmedPrompt: string
+  hasPrompt: boolean
+  isFollowupPath: boolean
+}
+
+/**
+ * Resolve how a launch prompt reaches the agent: folded into the launch
+ * command, left as an editable post-launch draft paste, or pasted+submitted
+ * once the TUI is ready.
+ *
+ * Why: argv/flag agents fold the prompt into the launch command and
+ * auto-submit — keeping behavior consistent with the composer/tab-bar `+`
+ * mental model, where the prompt is "the first turn the user sent".
+ * Followup-path and generated-context launches can deliver a prompt via
+ * post-launch bracketed paste; callers decide whether that paste remains a
+ * draft or submits after readiness.
+ */
+export function resolveAgentLaunchPromptPlan(args: {
+  startupPlanBase: AgentLaunchStartupPlanBase
+  prompt: string | undefined
+  promptDelivery: 'auto-submit' | 'draft' | 'submit-after-ready'
+}): AgentLaunchPromptPlan {
+  const { startupPlanBase, prompt, promptDelivery } = args
+  const trimmedPrompt = prompt?.trim() ?? ''
+  const hasPrompt = trimmedPrompt.length > 0
+  const isFollowupPath =
+    TUI_AGENT_CONFIG[startupPlanBase.agent].promptInjectionMode === 'stdin-after-start'
+
+  let startupPlan: AgentStartupPlan | null = null
+  let pasteDraftAfterLaunch: string | null = null
+  let submitPastedPrompt = false
+  let forcePasteAfterLaunch = false
+
+  if (hasPrompt && promptDelivery === 'submit-after-ready') {
+    // Why: generated multi-line prompts are too large to echo through a shell
+    // argv/prefill command. Launch cleanly, then paste+submit inside the TUI.
+    startupPlan = buildAgentStartupPlan({
+      ...startupPlanBase,
+      prompt: '',
+      allowEmptyPromptLaunch: true
+    })
+    pasteDraftAfterLaunch = trimmedPrompt
+    submitPastedPrompt = true
+    forcePasteAfterLaunch = true
+  } else if (hasPrompt && promptDelivery === 'draft') {
+    const draftLaunchPlan = buildAgentDraftLaunchPlan({
+      ...startupPlanBase,
+      draft: trimmedPrompt
+    })
+    if (draftLaunchPlan) {
+      startupPlan = {
+        agent: draftLaunchPlan.agent,
+        launchCommand: draftLaunchPlan.launchCommand,
+        expectedProcess: draftLaunchPlan.expectedProcess,
+        followupPrompt: null,
+        launchConfig: draftLaunchPlan.launchConfig,
+        ...(draftLaunchPlan.startupCommandDelivery
+          ? { startupCommandDelivery: draftLaunchPlan.startupCommandDelivery }
+          : {}),
+        ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
+      }
+    } else {
+      startupPlan = buildAgentStartupPlan({
+        ...startupPlanBase,
+        prompt: '',
+        allowEmptyPromptLaunch: true
+      })
+      pasteDraftAfterLaunch = trimmedPrompt
+    }
+  } else if (hasPrompt && isFollowupPath) {
+    startupPlan = buildAgentStartupPlan({
+      ...startupPlanBase,
+      prompt: '',
+      allowEmptyPromptLaunch: true
+    })
+    pasteDraftAfterLaunch = trimmedPrompt
+  } else {
+    startupPlan = buildAgentStartupPlan({
+      ...startupPlanBase,
+      prompt: hasPrompt ? trimmedPrompt : '',
+      allowEmptyPromptLaunch: !hasPrompt
+    })
+  }
+
+  return {
+    startupPlan,
+    pasteDraftAfterLaunch,
+    submitPastedPrompt,
+    forcePasteAfterLaunch,
+    trimmedPrompt,
+    hasPrompt,
+    isFollowupPath
+  }
+}

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -1,10 +1,7 @@
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
-import {
-  buildAgentDraftLaunchPlan,
-  buildAgentStartupPlan,
-  type AgentStartupPlan
-} from '@/lib/tui-agent-startup'
+import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+import { resolveAgentLaunchPromptPlan } from '@/lib/agent-launch-prompt-plan'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { getAgentLaunchPlatformForRepo } from '@/lib/agent-launch-platform'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
@@ -24,7 +21,6 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
-import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-status-seed'
 import type { TuiAgent } from '../../../shared/types'
@@ -143,71 +139,16 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     agentArgs: effectiveAgentArgs,
     agentEnv
   }
-  const trimmedPrompt = prompt?.trim() ?? ''
-  const hasPrompt = trimmedPrompt.length > 0
-  const isFollowupPath = TUI_AGENT_CONFIG[agent].promptInjectionMode === 'stdin-after-start'
-  // Why: argv/flag agents fold the prompt into the launch command and
-  // auto-submit — keeping behavior consistent with the composer/tab-bar `+`
-  // mental model, where the prompt is "the first turn the user sent".
-  // Followup-path and generated-context launches can deliver a prompt via
-  // post-launch bracketed paste; callers decide whether that paste remains a
-  // draft or submits after readiness.
-  let startupPlan: AgentStartupPlan | null = null
-  let pasteDraftAfterLaunch: string | null = null
-  let submitPastedPrompt = false
-  let forcePasteAfterLaunch = false
+  const {
+    startupPlan,
+    pasteDraftAfterLaunch,
+    submitPastedPrompt,
+    forcePasteAfterLaunch,
+    trimmedPrompt,
+    hasPrompt,
+    isFollowupPath
+  } = resolveAgentLaunchPromptPlan({ startupPlanBase, prompt, promptDelivery })
   let promptDeliveryResult: Promise<{ delivered: boolean; failureNotified: boolean }> | undefined
-
-  if (hasPrompt && promptDelivery === 'submit-after-ready') {
-    // Why: generated multi-line prompts are too large to echo through a shell
-    // argv/prefill command. Launch cleanly, then paste+submit inside the TUI.
-    startupPlan = buildAgentStartupPlan({
-      ...startupPlanBase,
-      prompt: '',
-      allowEmptyPromptLaunch: true
-    })
-    pasteDraftAfterLaunch = trimmedPrompt
-    submitPastedPrompt = true
-    forcePasteAfterLaunch = true
-  } else if (hasPrompt && promptDelivery === 'draft') {
-    const draftLaunchPlan = buildAgentDraftLaunchPlan({
-      ...startupPlanBase,
-      draft: trimmedPrompt
-    })
-    if (draftLaunchPlan) {
-      startupPlan = {
-        agent: draftLaunchPlan.agent,
-        launchCommand: draftLaunchPlan.launchCommand,
-        expectedProcess: draftLaunchPlan.expectedProcess,
-        followupPrompt: null,
-        launchConfig: draftLaunchPlan.launchConfig,
-        ...(draftLaunchPlan.startupCommandDelivery
-          ? { startupCommandDelivery: draftLaunchPlan.startupCommandDelivery }
-          : {}),
-        ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
-      }
-    } else {
-      startupPlan = buildAgentStartupPlan({
-        ...startupPlanBase,
-        prompt: '',
-        allowEmptyPromptLaunch: true
-      })
-      pasteDraftAfterLaunch = trimmedPrompt
-    }
-  } else if (hasPrompt && isFollowupPath) {
-    startupPlan = buildAgentStartupPlan({
-      ...startupPlanBase,
-      prompt: '',
-      allowEmptyPromptLaunch: true
-    })
-    pasteDraftAfterLaunch = trimmedPrompt
-  } else {
-    startupPlan = buildAgentStartupPlan({
-      ...startupPlanBase,
-      prompt: hasPrompt ? trimmedPrompt : '',
-      allowEmptyPromptLaunch: !hasPrompt
-    })
-  }
 
   if (!startupPlan) {
     return null


### PR DESCRIPTION
## Problem

`main` fails `pnpm lint` again, so every open PR's `verify` fails on the merge ref:

```
src/renderer/src/lib/launch-agent-in-new-tab.ts:397:2: error eslint(max-lines): File has too many lines (303). help: Maximum allowed is 300.
```

The file sat at exactly 300 counted lines; the oxfmt line-width wrapping that came in with the live-port indicator merge (`7d216de48`) reformatted two long lines into multi-line form (+3 counted lines) and crossed the threshold. Reproduced on pristine `origin/main`.

## Fix

Per AGENTS.md (never bump or suppress max-lines — split instead): extract the prompt-delivery plan branching (how a launch prompt reaches the agent — folded into the launch command, post-launch draft paste, or paste+submit after readiness) into a new pure module `agent-launch-prompt-plan.ts`, and have `launchAgentInNewTab` destructure its result. Mechanical move — none of the extracted values were reassigned downstream, so behavior is unchanged. The main file drops to ~250 counted lines with headroom.

## Validation

- `pnpm lint` green (was failing on max-lines)
- `pnpm typecheck` green
- `launch-agent-in-new-tab.test.ts` + `QuickLaunchButton.test.ts`: 32/32 pass

Made with [Orca](https://github.com/stablyai/orca) 🐋