### PR TITLE
fix(terminal-links): clean up the link-routing preference modal

### DIFF
--- a/src/renderer/src/components/link-routing-preference-dialog.tsx
+++ b/src/renderer/src/components/link-routing-preference-dialog.tsx
@@ -59,6 +59,8 @@ export function LinkRoutingPreferenceDialogProvider({
   const setContextualToursBlockingSurfaceVisible = useAppStore(
     (s) => s.setContextualToursBlockingSurfaceVisible
   )
+  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const lastDisplayedRequestRef = useRef<LinkRoutingPreferenceDialogRequest | null>(activeRequest)
   activeRequestRef.current = activeRequest
   if (activeRequest) {
@@ -119,6 +121,14 @@ export function LinkRoutingPreferenceDialogProvider({
     })
   }, [])
 
+  // Dismiss like the overlay (keeps the current default) and jump to the Browser
+  // settings so the user can change link routing from the same place the note names.
+  const openBrowserSettings = useCallback(() => {
+    settleActiveRequest(false)
+    openSettingsPage()
+    openSettingsTarget({ pane: 'browser', repoId: null })
+  }, [settleActiveRequest, openSettingsPage, openSettingsTarget])
+
   return (
     <LinkRoutingPreferenceDialogContext.Provider value={requestPreference}>
       {children}
@@ -133,19 +143,13 @@ export function LinkRoutingPreferenceDialogProvider({
         >
           <div className="rounded-t-lg border-b border-border bg-muted/30 px-6 pt-5 pb-4">
             <DialogHeader className="gap-3">
-              <div className="flex items-center justify-between gap-3">
-                <Badge variant="outline" className="bg-background/70 text-muted-foreground">
-                  {translate(
-                    'auto.components.link.routing.preference.dialog.badge',
-                    'Terminal link'
-                  )}
-                </Badge>
-                {displayedRequest?.options.preview ? (
+              {displayedRequest?.options.preview ? (
+                <div className="flex items-center justify-end">
                   <Badge variant="secondary">
                     {translate('auto.components.link.routing.preference.dialog.preview', 'Preview')}
                   </Badge>
-                ) : null}
-              </div>
+                </div>
+              ) : null}
               <div className="space-y-2">
                 <DialogTitle className="text-xl leading-tight">
                   {openLinksInAppDefault
@@ -177,7 +181,7 @@ export function LinkRoutingPreferenceDialogProvider({
             {displayHost ? (
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <span>
-                  {translate('auto.components.link.routing.preference.dialog.link.label', 'Link')}
+                  {translate('auto.components.link.routing.preference.dialog.link.label', 'Link:')}
                 </span>
                 <span className="rounded-md border border-border bg-muted/30 px-2 py-1 font-mono">
                   {displayHost}
@@ -196,15 +200,26 @@ export function LinkRoutingPreferenceDialogProvider({
                 </p>
                 <p>
                   {translate(
-                    'auto.components.link.routing.preference.dialog.settings.note',
-                    'Change this later in Settings → Browser.'
-                  )}
+                    'auto.components.link.routing.preference.dialog.settings.note.prefix',
+                    'Change this later in'
+                  )}{' '}
+                  <button
+                    type="button"
+                    onClick={openBrowserSettings}
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    {translate(
+                      'auto.components.link.routing.preference.dialog.settings.note.link',
+                      'Settings → Browser'
+                    )}
+                  </button>
+                  .
                 </p>
                 <p className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
                   <span>
                     {translate(
                       'auto.components.link.routing.preference.dialog.shortcut.note.prefix',
-                      'When links open in Orca,'
+                      'Hold'
                     )}
                   </span>
                   <ShortcutKeyCombo
@@ -215,7 +230,7 @@ export function LinkRoutingPreferenceDialogProvider({
                   <span>
                     {translate(
                       'auto.components.link.routing.preference.dialog.shortcut.note.suffix',
-                      'click opens system browser once.'
+                      'and click a link to open it in your system browser instead.'
                     )}
                   </span>
                 </p>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12302,7 +12302,6 @@
         "routing": {
           "preference": {
             "dialog": {
-              "badge": "Terminal link",
               "preview": "Preview",
               "keep": {
                 "title": "Keep terminal links in Orca's browser?",
@@ -12314,19 +12313,22 @@
               "title": "Open terminal links in Orca's browser?",
               "description": "Use Orca's browser for terminal links, or keep your system browser.",
               "link": {
-                "label": "Link"
+                "label": "Link:"
               },
               "orca": {
                 "note": "Orca can use imported cookies for logged-in sites.",
                 "button": "Open in Orca"
               },
               "settings": {
-                "note": "Change this later in Settings → Browser."
+                "note": {
+                  "prefix": "Change this later in",
+                  "link": "Settings → Browser"
+                }
               },
               "shortcut": {
                 "note": {
-                  "prefix": "When links open in Orca,",
-                  "suffix": "click opens system browser once."
+                  "prefix": "Hold",
+                  "suffix": "and click a link to open it in your system browser instead."
                 }
               },
               "system": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12302,7 +12302,6 @@
         "routing": {
           "preference": {
             "dialog": {
-              "badge": "Enlace del terminal",
               "preview": "Vista previa",
               "title": "¿Abrir enlaces del terminal en el navegador de Orca?",
               "description": "Usa el navegador de Orca para los enlaces del terminal o conserva tu navegador del sistema.",
@@ -12311,18 +12310,21 @@
                 "note": "Orca puede usar cookies importadas para sitios con sesión iniciada."
               },
               "settings": {
-                "note": "Cámbialo después en Configuración → Navegador."
+                "note": {
+                  "prefix": "Cámbialo después en",
+                  "link": "Configuración → Navegador"
+                }
               },
               "system": {
                 "button": "Usar navegador del sistema"
               },
               "link": {
-                "label": "Enlace"
+                "label": "Enlace:"
               },
               "shortcut": {
                 "note": {
-                  "prefix": "Cuando los enlaces se abren en Orca,",
-                  "suffix": "clic abre el navegador del sistema una vez."
+                  "prefix": "Mantén pulsado",
+                  "suffix": "y haz clic en un enlace para abrirlo en tu navegador del sistema."
                 }
               },
               "keep": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -12302,7 +12302,6 @@
         "routing": {
           "preference": {
             "dialog": {
-              "badge": "Terminal リンク",
               "preview": "プレビュー",
               "title": "terminal のリンクを Orca のブラウザで開きますか？",
               "description": "terminal のリンクを Orca のブラウザで開くか、システムブラウザを使い続けます。",
@@ -12311,18 +12310,21 @@
                 "note": "Orca はインポート済み Cookie を使ってログイン済みサイトを開けます。"
               },
               "settings": {
-                "note": "後で 設定 → ブラウザ から変更できます。"
+                "note": {
+                  "prefix": "後で",
+                  "link": "設定 → ブラウザ"
+                }
               },
               "system": {
                 "button": "システムブラウザを使用"
               },
               "link": {
-                "label": "リンク"
+                "label": "リンク:"
               },
               "shortcut": {
                 "note": {
-                  "prefix": "リンクを Orca で開く場合、",
-                  "suffix": "クリックで今回だけシステムブラウザで開きます。"
+                  "prefix": "",
+                  "suffix": "を押しながらリンクをクリックすると、システムブラウザで開きます。"
                 }
               },
               "keep": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -12302,7 +12302,6 @@
         "routing": {
           "preference": {
             "dialog": {
-              "badge": "Terminal 링크",
               "preview": "미리보기",
               "title": "terminal 링크를 Orca 브라우저에서 열까요?",
               "description": "terminal 링크를 Orca 브라우저에서 열거나 시스템 브라우저를 계속 사용합니다.",
@@ -12311,18 +12310,21 @@
                 "note": "Orca는 가져온 쿠키를 사용해 로그인된 사이트를 열 수 있습니다."
               },
               "settings": {
-                "note": "나중에 설정 → 브라우저에서 변경할 수 있습니다."
+                "note": {
+                  "prefix": "나중에",
+                  "link": "설정 → 브라우저"
+                }
               },
               "system": {
                 "button": "시스템 브라우저 사용"
               },
               "link": {
-                "label": "링크"
+                "label": "링크:"
               },
               "shortcut": {
                 "note": {
-                  "prefix": "링크가 Orca에서 열릴 때,",
-                  "suffix": "클릭하면 한 번만 시스템 브라우저에서 열립니다."
+                  "prefix": "",
+                  "suffix": "을 누른 채 링크를 클릭하면 시스템 브라우저에서 열립니다."
                 }
               },
               "keep": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -12302,7 +12302,6 @@
         "routing": {
           "preference": {
             "dialog": {
-              "badge": "终端链接",
               "preview": "预览",
               "title": "在 Orca 浏览器中打开终端链接？",
               "description": "用 Orca 浏览器打开终端链接，或继续使用系统浏览器。",
@@ -12311,18 +12310,21 @@
                 "note": "Orca 可以使用已导入的 Cookie 打开已登录的网站。"
               },
               "settings": {
-                "note": "之后可在设置 → 浏览器中更改。"
+                "note": {
+                  "prefix": "之后可在",
+                  "link": "设置 → 浏览器"
+                }
               },
               "system": {
                 "button": "使用系统浏览器"
               },
               "link": {
-                "label": "链接"
+                "label": "链接："
               },
               "shortcut": {
                 "note": {
-                  "prefix": "当链接在 Orca 中打开时，",
-                  "suffix": "点击可临时改用系统浏览器。"
+                  "prefix": "按住",
+                  "suffix": "并点击链接，即可改用系统浏览器打开。"
                 }
               },
               "keep": {


### PR DESCRIPTION
## What

Tidies the **"Open terminal links in Orca's browser?"** prompt that appears the first time a terminal link is clicked.

- **Removed the "Terminal link" badge** — the title already conveys the context, so the badge was redundant chrome.
- **`Link: <host>`** — added the colon before the host.
- **"Settings → Browser" is now a real link** — it dismisses the prompt and opens Settings on the Browser pane (where Link Routing lives), instead of being inert text.
- **Reworded the modifier-click hint** to `Hold ⇧⌘ and click a link to open it in your system browser instead.` — the old "When links open in Orca, … opens system browser once." phrasing read as confusing.

Locale catalogs (`en/es/zh/ja/ko`) updated in parity; no key drift introduced.

## Cross-platform

The shortcut hint already resolves per-platform (`⇧⌘` on macOS, `Shift`/`Ctrl` elsewhere) via the existing `navigator.userAgent` check — unchanged.

## Verification

Ran the dev app and exercised the modal end-to-end:
- Badge gone; `Link: github.com`; new hint copy rendered.
- Clicking **Settings → Browser** closed the prompt and opened Settings → Browser (Link Routing toggle visible), with `settingsNavigationTarget → { pane: 'browser' }`.

## Note

`verify:localization-catalog` is currently red on this branch, but only from **pre-existing** unsynced SSH-dialog keys (`ForgetSshWorkspaceDialog`, `HostRemoveDialog`, `RemoveFolderDialog`, `TerminalSshReconnectOverlay`) — not from this change. Left untouched to keep this PR scoped to the modal.

Made with [Orca](https://github.com/stablyai/orca) 🐋
