### PR TITLE
perf(hook-commands): skip unrelated store flushes

### DIFF
--- a/src/renderer/src/lib/hook-command-delayed-delivery-perf.test.ts
+++ b/src/renderer/src/lib/hook-command-delayed-delivery-perf.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import {
+  queueHookCommandsForFirstWorktreeTab,
+  resetHookCommandDelayedDeliveryForTests
+} from './hook-command-delayed-delivery'
+
+const initialState = useAppStore.getState()
+
+afterEach(() => {
+  resetHookCommandDelayedDeliveryForTests()
+  useAppStore.setState(initialState, true)
+})
+
+describe('delayed hook-command subscription', () => {
+  it('does not rescan pending worktrees for unrelated store updates', () => {
+    const reads = { value: 0 }
+    useAppStore.setState({
+      tabsByWorktree: {},
+      getKnownWorktreeById: ((worktreeId: string) => {
+        reads.value += 1
+        return { id: worktreeId }
+      }) as never
+    } as never)
+
+    for (let index = 0; index < 500; index += 1) {
+      queueHookCommandsForFirstWorktreeTab({
+        worktreeId: `runtime-worktree-${index}`,
+        deliver: vi.fn()
+      })
+    }
+
+    reads.value = 0
+    for (let update = 0; update < 100; update += 1) {
+      useAppStore.setState({ activeView: update % 2 === 0 ? 'terminal' : 'settings' } as never)
+    }
+
+    expect(reads.value).toBe(0)
+  })
+})

--- a/src/renderer/src/lib/hook-command-delayed-delivery.ts
+++ b/src/renderer/src/lib/hook-command-delayed-delivery.ts
@@ -33,7 +33,31 @@ function ensurePendingHookCommandSubscription(): void {
   if (unsubscribePendingHookCommandDeliveries) {
     return
   }
-  unsubscribePendingHookCommandDeliveries = useAppStore.subscribe(() => {
+  const initial = useAppStore.getState()
+  // Capture references so unrelated PTY/status updates do not rescan every
+  // runtime worktree waiting for its first mirrored terminal tab.
+  let previousTabsByWorktree = initial.tabsByWorktree
+  let previousWorktreesByRepo = initial.worktreesByRepo
+  let previousDetectedWorktreesByRepo = initial.detectedWorktreesByRepo
+  let previousFolderWorkspaces = initial.folderWorkspaces
+  let previousWorktreeLookup = initial.getKnownWorktreeById
+  unsubscribePendingHookCommandDeliveries = useAppStore.subscribe((state) => {
+    // Why: only these slices (or the test-adapter lookup itself) can change
+    // whether a pending worktree exists or has received its first tab.
+    if (
+      state.tabsByWorktree === previousTabsByWorktree &&
+      state.worktreesByRepo === previousWorktreesByRepo &&
+      state.detectedWorktreesByRepo === previousDetectedWorktreesByRepo &&
+      state.folderWorkspaces === previousFolderWorkspaces &&
+      state.getKnownWorktreeById === previousWorktreeLookup
+    ) {
+      return
+    }
+    previousTabsByWorktree = state.tabsByWorktree
+    previousWorktreesByRepo = state.worktreesByRepo
+    previousDetectedWorktreesByRepo = state.detectedWorktreesByRepo
+    previousFolderWorkspaces = state.folderWorkspaces
+    previousWorktreeLookup = state.getKnownWorktreeById
     flushPendingHookCommandDeliveries()
   })
 }


### PR DESCRIPTION
## Description

When a runtime-created worktree has not received its first mirrored terminal tab yet, Orca holds its hook-command delivery in a pending map and subscribes to the app store. The old subscriber flushed that map on every store mutation, including unrelated PTY, status, focus, and usage updates. Each flush checked every pending worktree and performed a worktree lookup.

This PR gates the subscriber on the exact state references that can change delivery eligibility: tabs by worktree, visible worktrees, detected worktrees, folder workspaces, and the lookup function reference used by test/runtime adapters. The gate is allocation-free and keeps the existing delivery/drop semantics.

## Performance evidence

Deterministic fixture: 500 pending runtime worktrees and 100 unrelated store updates.

- Before (red run with the original subscriber): 50,000 `getKnownWorktreeById` calls (500 × 100).
- After: 0 lookup calls for the same unrelated updates.
- Reduction: 100% of unrelated-update lookup work (50,000 → 0).

The test counts the lookup calls directly. It does not rely on timing noise or a small synthetic timeout.

## Correctness evidence

The focused suite proves:

- pending delivery waits for the first mirrored tab and delivers exactly once;
- delivery happens immediately when a tab already exists;
- a worktree removed before mirroring drops the pending command;
- the new unrelated-update gate skips the expensive scan.

Validation:

- Focused hook/worktree suite: 3 files / 35 tests passed.
- Red/green benchmark: original code failed with `expected 50000 to be 0`; gated code passes with 0.
- `pnpm typecheck`: passed.
- Changed-file `oxlint` and `oxfmt --check`: passed.
- The full repository suite and ratchet/reliability gates were already green on the same current-main base during this sweep; this branch is test-only/runtime-local and adds no provider or IPC surface.

## Reliability proof

- **Reliability class / gate:** `agent-session.provider-ownership` / `experimental`, `partial`.
- **Invariant:** a queued hook command is delivered only to the first tab of the matching runtime worktree, and a removed worktree cannot receive stale commands.
- **Product change type:** performance hardening with deterministic regression coverage.
- **Performance risk inventory:** only the pending first-tab delivery subscriber is touched. No typing, focus, visibility polling, resize, provider listing, hidden output, subprocess, SSH, WSL, mobile/relay, or persistence paths change.
- **No-regression evidence:** direct 50,000 → 0 lookup-count proof plus the existing delivery/drop tests; eligibility references are compared without allocation on unrelated updates.
- **Provider/platform matrix:** local, daemon, SSH, WSL, remote-runtime, and mobile/relay are unaffected because the change is renderer-side gating over provider-neutral worktree/tab state; macOS, Linux, and Windows behavior is unchanged.
- **Diagnostics:** the deterministic lookup counter is the regression oracle; no production diagnostics are needed for this allocation-free gate.
- **Residual gap:** no live Electron run was performed because branch-specific macOS dev app identities trigger repeated Safe Storage dialogs; the correct renderer-state seam is covered deterministically.
- **Promotion status:** remains `experimental` / `partial`; this PR adds proof without promoting the manifest gate.
- **Rollback rule:** if a first-tab hook command is missed or delivered to a removed worktree, revert the gate and inspect which eligibility slice failed to preserve reference identity.

## ELI5

Orca had a waiting list of worktrees. Every time anything changed, it walked the whole list to see whether a tab had appeared. Now it first checks whether any of the few pieces that matter changed. If none changed, it leaves the list alone. In the test, 50,000 checks become zero while delivery still happens when the tab really arrives.

## End-user trade-offs / regressions

No intentional behavior change. Tab arrival, worktree removal, and test/runtime lookup replacement still trigger a flush. The only accepted gap is the lack of a live Electron run because doing so would create unrelated macOS Keychain/Safe Storage prompts.
