### PR TITLE
fix: keep dispatch task preview after status normalization

### DIFF
--- a/src/renderer/src/lib/agent-row-primary-text.test.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.test.ts
@@ -104,6 +104,93 @@ Fix the checkout race condition in payments`
       })
     ).toBe('Fix checkout race')
   })
+
+  // Why: full preambles bury === TASK === after multi-KB CLI instructions. The
+  // status normalizer must compact the field so a missing/delayed label still
+  // yields a meaningful task preview from the single-line 200-char prompt.
+  it('derives a task preview from a normalized 200-char dispatch prompt without labels', () => {
+    const longCliNoise = Array.from(
+      { length: 40 },
+      (_, i) => `orca orchestration send --to term_parent --type heartbeat --phase step-${i}`
+    ).join('\n')
+    const taskBody =
+      'Release-fix task: orchestration fallback task preview for single-line normalization'
+    const normalized = normalizeAgentStatusPayload({
+      state: 'working',
+      prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your coordinator's terminal handle is: term_c376f37c-5d28-404b-869f-d0544edf12ff
+Your task ID is: task_bcfc6b64abe3
+
+You talk to the coordinator only through the CLI commands below.
+
+=== CLI COMMANDS ===
+${longCliNoise}
+
+=== TASK ===
+${taskBody}`
+    })
+    expect(normalized).not.toBeNull()
+    expect(normalized!.prompt.length).toBeLessThanOrEqual(200)
+    expect(normalized!.prompt.includes('\n')).toBe(false)
+    expect(normalized!.prompt).not.toContain('CLI COMMANDS')
+    expect(normalized!.prompt).toContain('=== TASK ===')
+
+    const preview = getAgentRowPrimaryText({ prompt: normalized!.prompt })
+    expect(preview).toContain('orchestration fallback task preview')
+    expect(preview).not.toContain('You are working inside Orca')
+    expect(preview).not.toContain('CLI COMMANDS')
+  })
+
+  it('uses a short single-line task body as the fallback preview', () => {
+    const normalized = normalizeAgentStatusPayload({
+      state: 'working',
+      prompt: `You are working inside Orca, a multi-agent IDE.
+Your task ID is: task_short
+
+=== TASK ===
+Fix login form`
+    })
+    expect(getAgentRowPrimaryText({ prompt: normalized!.prompt })).toBe('Fix login form')
+  })
+
+  it('prefers later orchestration labels over the extracted task preview', () => {
+    const normalized = normalizeAgentStatusPayload({
+      state: 'working',
+      prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task_label_later
+
+=== CLI COMMANDS ===
+${'orca orchestration check\n'.repeat(30)}
+=== TASK ===
+Implement the detailed worker instructions that should not stay as the final label`
+    })
+    expect(normalized).not.toBeNull()
+
+    expect(getAgentRowPrimaryText({ prompt: normalized!.prompt })).toContain(
+      'Implement the detailed worker instructions'
+    )
+
+    expect(
+      getAgentRowPrimaryText({
+        prompt: normalized!.prompt,
+        orchestration: {
+          taskId: 'task_label_later',
+          dispatchId: 'ctx-later',
+          taskTitle: 'Worker instructions',
+          displayName: 'Better worker label'
+        }
+      })
+    ).toBe('Better worker label')
+  })
+
+  it('does not surface preamble boilerplate when the TASK marker is absent', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt:
+          'You are working inside Orca, a multi-agent IDE. You are a dispatched worker. Your task ID is: task_no_body CLI noise only'
+      })
+    ).toBe('')
+  })
 })
 
 describe('getOrcaDispatchTaskId', () => {

--- a/src/renderer/src/lib/agent-row-primary-text.test.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.test.ts
@@ -191,6 +191,36 @@ Implement the detailed worker instructions that should not stay as the final lab
       })
     ).toBe('')
   })
+
+  // Why: UI helpers still accept raw multi-line preambles (tests, defensive
+  // paths). Without the standalone-line marker rule, a base-drift subject that
+  // mentions `=== TASK ===` wins over Orca's real separator.
+  it('ignores adversarial === TASK === text in raw multi-line base-drift subjects', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt: [
+          'You are working inside Orca, a multi-agent IDE. You are a dispatched worker.',
+          'Your task ID is: task_raw_drift',
+          '',
+          '--- BASE DRIFT ---',
+          '  - docs: explain === TASK === marker parsing',
+          '---',
+          '',
+          '=== TASK ===',
+          'Fix the actual dispatch fallback preview'
+        ].join('\n')
+      })
+    ).toBe('Fix the actual dispatch fallback preview')
+  })
+
+  it('still reads the task body from a normalized single-line compact prompt', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt:
+          'You are working inside Orca, a multi-agent IDE. Your task ID is: task_inline === TASK === Compact body preview'
+      })
+    ).toBe('Compact body preview')
+  })
 })
 
 describe('getOrcaDispatchTaskId', () => {

--- a/src/renderer/src/lib/agent-row-primary-text.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.ts
@@ -1,6 +1,7 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX } from '../../../shared/orca-dispatch-status-prompt'
 
-export const ORCA_DISPATCH_PREAMBLE_PREFIX = 'You are working inside Orca, a multi-agent IDE.'
+export const ORCA_DISPATCH_PREAMBLE_PREFIX = ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX
 const ORCA_DISPATCH_TASK_MARKER = '=== TASK ==='
 const ORCA_DISPATCH_TASK_ID_MARKER = 'Your task ID is:'
 // Why: match deriveGeneratedTabTitle's scan budget — previews only need the
@@ -43,25 +44,21 @@ export function orchestrationLabelsMatchLiveDispatch(
 export function getAgentRowPrimaryText(
   entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
 ): string {
+  // Why: prefer richer orchestration labels when they match the live dispatch,
+  // then fall back to the TASK-body preview. Never surface the lifecycle
+  // preamble itself — status prompts are single-line ~200-char folds, and the
+  // first characters are boilerplate ("You are working inside Orca…").
   if (orchestrationLabelsMatchLiveDispatch(entry)) {
     return (
       entry.orchestration?.displayName?.trim() ||
       entry.orchestration?.taskTitle?.trim() ||
-      getOrcaDispatchTaskPreview(entry.prompt) ||
-      // Why: non-dispatch and unmatched paths keep a full trim for display; this
-      // branch only runs for matched dispatch turns, where a bounded preview
-      // almost always succeeds first.
-      entry.prompt.trimStart().slice(0, ORCA_DISPATCH_TASK_PREVIEW_SCAN_LIMIT).trim()
+      getOrcaDispatchTaskPreview(entry.prompt)
     )
   }
-  return (
-    getOrcaDispatchTaskPreview(entry.prompt) ||
-    // Why: ordinary prompts stay small; dispatch prompts without a TASK marker
-    // still must not full-trim a multi-MB body for a sidebar label.
-    (isOrcaDispatchPrompt(entry.prompt)
-      ? entry.prompt.trimStart().slice(0, ORCA_DISPATCH_TASK_PREVIEW_SCAN_LIMIT).trim()
-      : entry.prompt.trim())
-  )
+  if (isOrcaDispatchPrompt(entry.prompt)) {
+    return getOrcaDispatchTaskPreview(entry.prompt)
+  }
+  return entry.prompt.trim()
 }
 
 export function getAgentRowGeneratedTitleText(
@@ -97,6 +94,10 @@ export function getOrcaDispatchTaskId(prompt: string): string | null {
 function getOrcaDispatchTaskPreview(prompt: string): string {
   // Why: sidebar rows call this during render; never full-trim/split paste-sized
   // dispatch prompts — only scan bounded windows for the marker and first line.
+  // Production status prompts are already folded to a single line (newlines →
+  // spaces) and capped ~200 chars by normalizePromptField, which preserves
+  // `=== TASK ===` + body. Prefer the first non-empty line so multi-line raw
+  // preambles still work; a single-line fold is one "line" after the marker.
   if (!isOrcaDispatchPrompt(prompt)) {
     return ''
   }

--- a/src/renderer/src/lib/agent-row-primary-text.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.ts
@@ -1,8 +1,12 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
-import { ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX } from '../../../shared/orca-dispatch-status-prompt'
+import {
+  findOrcaDispatchTaskMarkerIndex,
+  ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX,
+  ORCA_DISPATCH_STATUS_TASK_MARKER
+} from '../../../shared/orca-dispatch-status-prompt'
 
 export const ORCA_DISPATCH_PREAMBLE_PREFIX = ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX
-const ORCA_DISPATCH_TASK_MARKER = '=== TASK ==='
+const ORCA_DISPATCH_TASK_MARKER = ORCA_DISPATCH_STATUS_TASK_MARKER
 const ORCA_DISPATCH_TASK_ID_MARKER = 'Your task ID is:'
 // Why: match deriveGeneratedTabTitle's scan budget — previews only need the
 // first non-empty task line, not the rest of a paste-sized worker prompt.
@@ -104,7 +108,10 @@ function getOrcaDispatchTaskPreview(prompt: string): string {
   const scan = prompt
     .trimStart()
     .slice(0, ORCA_DISPATCH_TASK_MARKER_SCAN_LIMIT + ORCA_DISPATCH_TASK_PREVIEW_SCAN_LIMIT)
-  const taskMarkerIndex = scan.indexOf(ORCA_DISPATCH_TASK_MARKER)
+  // Why: share the normalizer's standalone-line marker rule. A naive indexOf
+  // would treat base-drift commit subjects that mention `=== TASK ===` as the
+  // real separator when helpers are called with raw multi-line preambles.
+  const taskMarkerIndex = findOrcaDispatchTaskMarkerIndex(scan)
   if (taskMarkerIndex === -1) {
     return ''
   }

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -118,6 +118,38 @@ Fix dispatch fallback preview for normalized status prompts`
     expect(result!.prompt).not.toContain('heartbeat')
   })
 
+  it('ignores task-marker text inside base-drift commit subjects', () => {
+    const result = normalizeAgentStatusPayload({
+      state: 'working',
+      // Why: use CRLF to cover Windows hook payloads while proving repository
+      // commit text cannot impersonate Orca's standalone task separator.
+      prompt: [
+        'You are working inside Orca, a multi-agent IDE. You are a dispatched worker.',
+        'Your task ID is: task_drift_marker',
+        '',
+        '--- BASE DRIFT ---',
+        '  - docs: explain === TASK === marker parsing',
+        '---',
+        '',
+        '=== TASK ===',
+        'Fix the actual dispatch fallback preview'
+      ].join('\r\n')
+    })
+
+    expect(result!.prompt).toContain('=== TASK === Fix the actual dispatch fallback preview')
+    expect(result!.prompt).not.toContain('marker parsing')
+  })
+
+  it('keeps dispatch detection bounded for oversized whitespace prompts', () => {
+    const trimStartSpy = vi.spyOn(String.prototype, 'trimStart')
+    const prompt = ' '.repeat(1_000_000)
+
+    expect(normalizeAgentStatusPayload({ state: 'working', prompt })!.prompt).toBe('')
+    expect(
+      trimStartSpy.mock.contexts.some((context) => String(context).length === prompt.length)
+    ).toBe(false)
+  })
+
   it('defaults missing prompt to empty string', () => {
     const result = parseAgentStatusPayload('{"state":"done"}')
     expect(result!.prompt).toBe('')

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -85,6 +85,39 @@ describe('parseAgentStatusPayload', () => {
     expect(result!.prompt).toHaveLength(AGENT_STATUS_MAX_FIELD_LENGTH)
   })
 
+  // Why: real dispatch preambles bury the task body after multi-KB CLI text. A
+  // naive head-truncation would keep only lifecycle boilerplate in the 200-char
+  // prompt field and drop the fallback label the UI needs before orchestration
+  // metadata arrives.
+  it('compacts Orca dispatch preambles so the task body survives 200-char truncation', () => {
+    const longCliNoise = Array.from(
+      { length: 50 },
+      (_, i) => `orca orchestration send --to term_parent --type heartbeat --phase step-${i}`
+    ).join('\n')
+    const result = parseAgentStatusPayload(
+      JSON.stringify({
+        state: 'working',
+        prompt: `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+Your task ID is: task_compact_1
+
+=== CLI COMMANDS ===
+${longCliNoise}
+
+=== TASK ===
+Fix dispatch fallback preview for normalized status prompts`
+      })
+    )
+    expect(result).not.toBeNull()
+    expect(result!.prompt.length).toBeLessThanOrEqual(AGENT_STATUS_MAX_FIELD_LENGTH)
+    expect(result!.prompt.includes('\n')).toBe(false)
+    expect(result!.prompt.startsWith('You are working inside Orca, a multi-agent IDE.')).toBe(true)
+    expect(result!.prompt).toContain('Your task ID is: task_compact_1')
+    expect(result!.prompt).toContain('=== TASK ===')
+    expect(result!.prompt).toContain('Fix dispatch fallback preview')
+    expect(result!.prompt).not.toContain('CLI COMMANDS')
+    expect(result!.prompt).not.toContain('heartbeat')
+  })
+
   it('defaults missing prompt to empty string', () => {
     const result = parseAgentStatusPayload('{"state":"done"}')
     expect(result!.prompt).toBe('')

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -6,6 +6,10 @@
 // terminal titles anywhere in the data flow.
 
 import type { AgentProviderSessionMetadata } from './agent-session-resume'
+import {
+  compactDispatchPromptForStatus,
+  isOrcaDispatchStatusPrompt
+} from './orca-dispatch-status-prompt'
 
 export const AGENT_STATUS_STATES = ['working', 'blocked', 'waiting', 'done'] as const
 export type AgentStatusState = (typeof AGENT_STATUS_STATES)[number]
@@ -258,6 +262,21 @@ function normalizeField(value: unknown, maxLength: number = AGENT_STATUS_MAX_FIE
   return normalizeSingleLinePreview(value, maxLength)
 }
 
+/** Normalize the agent prompt field, compacting Orca dispatch preambles. */
+function normalizePromptField(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+  if (isOrcaDispatchStatusPrompt(value)) {
+    return compactDispatchPromptForStatus(
+      value,
+      AGENT_STATUS_MAX_FIELD_LENGTH,
+      normalizeSingleLinePreview
+    )
+  }
+  return normalizeSingleLinePreview(value, AGENT_STATUS_MAX_FIELD_LENGTH)
+}
+
 function normalizeSingleLinePreview(value: string, maxLength: number): string {
   // Why: hook prompt/tool fields are previews. Bound the source scan before
   // folding line breaks so paste-sized status text cannot run a full regex
@@ -432,7 +451,7 @@ function normalizeAgentStatusObject(parsed: unknown): ParsedAgentStatusPayload |
   }
   return {
     state: state as AgentStatusState,
-    prompt: normalizeField(obj.prompt),
+    prompt: normalizePromptField(obj.prompt),
     // Why: route through normalizeOptionalField so agentType gets the same
     // trim / collapse-newlines / truncate / empty→undefined treatment as the
     // other single-line string fields (toolName, toolInput, prompt). Inline

--- a/src/shared/orca-dispatch-status-prompt.ts
+++ b/src/shared/orca-dispatch-status-prompt.ts
@@ -1,0 +1,91 @@
+// Why: full Orca dispatch preambles are multi-KB (CLI instructions before
+// `=== TASK ===`). A naive first-N-char fold of the agent-status prompt keeps
+// only lifecycle boilerplate and drops the task body the UI needs as a
+// fallback label before orchestration metadata arrives. Compact the status
+// prompt so preamble detection, the live task id, and the task body all fit
+// inside AGENT_STATUS_MAX_FIELD_LENGTH.
+
+export const ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX =
+  'You are working inside Orca, a multi-agent IDE.'
+const ORCA_DISPATCH_STATUS_TASK_MARKER = '=== TASK ==='
+const ORCA_DISPATCH_STATUS_TASK_ID_MARKER = 'Your task ID is:'
+// Why: real preambles put === TASK === near the end (~4KB+). Scan past the
+// normal single-line budget so the task body is still reachable for compacting.
+const ORCA_DISPATCH_STATUS_SOURCE_SCAN_LIMIT = 24_576
+
+export function isOrcaDispatchStatusPrompt(value: string): boolean {
+  return value.trimStart().startsWith(ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX)
+}
+
+/**
+ * Collapse a multi-KB dispatch preamble into a single-line status preview that
+ * still carries enough structure for UI helpers:
+ *   `<preamble prefix> Your task ID is: <id> === TASK === <task body>`
+ */
+export function compactDispatchPromptForStatus(
+  value: string,
+  maxLength: number,
+  normalizeSingleLine: (value: string, maxLength: number) => string
+): string {
+  const scanEnd = Math.min(value.length, ORCA_DISPATCH_STATUS_SOURCE_SCAN_LIMIT)
+  // Bound leading trim to the scan window so a multi-MB paste of pure
+  // whitespace cannot walk the entire string before we give up.
+  let start = 0
+  while (start < scanEnd && isEcmaTrimWhitespace(value.charCodeAt(start))) {
+    start++
+  }
+  const scan = value.slice(start, scanEnd)
+
+  let taskId = ''
+  const idMarkerIndex = scan.indexOf(ORCA_DISPATCH_STATUS_TASK_ID_MARKER)
+  if (idMarkerIndex !== -1) {
+    const afterId = scan.slice(idMarkerIndex + ORCA_DISPATCH_STATUS_TASK_ID_MARKER.length)
+    let idStart = 0
+    while (idStart < afterId.length && isEcmaTrimWhitespace(afterId.charCodeAt(idStart))) {
+      idStart++
+    }
+    const idRest = afterId.slice(idStart)
+    const idEnd = idRest.search(/\s/)
+    taskId = (idEnd === -1 ? idRest : idRest.slice(0, idEnd)).trim()
+  }
+
+  let taskBody = ''
+  const taskMarkerIndex = scan.indexOf(ORCA_DISPATCH_STATUS_TASK_MARKER)
+  if (taskMarkerIndex !== -1) {
+    const body = scan.slice(taskMarkerIndex + ORCA_DISPATCH_STATUS_TASK_MARKER.length)
+    for (const line of body.split(/\r?\n/)) {
+      const preview = line.trim().replace(/\s+/g, ' ')
+      if (preview) {
+        taskBody = preview
+        break
+      }
+    }
+  }
+
+  // Why: keep the dispatch prefix (isOrcaDispatchPrompt) + task id (label match)
+  // + task body (fallback preview) so UI helpers still work on the 200-char field.
+  let compact = ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX
+  if (taskId) {
+    compact += ` ${ORCA_DISPATCH_STATUS_TASK_ID_MARKER} ${taskId}`
+  }
+  if (taskBody) {
+    compact += ` ${ORCA_DISPATCH_STATUS_TASK_MARKER} ${taskBody}`
+  }
+  return normalizeSingleLine(compact, maxLength)
+}
+
+function isEcmaTrimWhitespace(code: number): boolean {
+  return (
+    code === 0x20 ||
+    (code >= 0x09 && code <= 0x0d) ||
+    code === 0xa0 ||
+    code === 0x1680 ||
+    (code >= 0x2000 && code <= 0x200a) ||
+    code === 0x2028 ||
+    code === 0x2029 ||
+    code === 0x202f ||
+    code === 0x205f ||
+    code === 0x3000 ||
+    code === 0xfeff
+  )
+}

--- a/src/shared/orca-dispatch-status-prompt.ts
+++ b/src/shared/orca-dispatch-status-prompt.ts
@@ -14,7 +14,17 @@ const ORCA_DISPATCH_STATUS_TASK_ID_MARKER = 'Your task ID is:'
 const ORCA_DISPATCH_STATUS_SOURCE_SCAN_LIMIT = 24_576
 
 export function isOrcaDispatchStatusPrompt(value: string): boolean {
-  return value.trimStart().startsWith(ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX)
+  // Why: status payloads cross a trust boundary. Keep dispatch detection
+  // bounded too, or leading whitespace can bypass the normalizer's scan cap.
+  const scanEnd = Math.min(value.length, ORCA_DISPATCH_STATUS_SOURCE_SCAN_LIMIT)
+  let start = 0
+  while (start < scanEnd && isEcmaTrimWhitespace(value.charCodeAt(start))) {
+    start++
+  }
+  return (
+    start + ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX.length <= scanEnd &&
+    value.startsWith(ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX, start)
+  )
 }
 
 /**
@@ -50,7 +60,7 @@ export function compactDispatchPromptForStatus(
   }
 
   let taskBody = ''
-  const taskMarkerIndex = scan.indexOf(ORCA_DISPATCH_STATUS_TASK_MARKER)
+  const taskMarkerIndex = findTaskMarkerIndex(scan)
   if (taskMarkerIndex !== -1) {
     const body = scan.slice(taskMarkerIndex + ORCA_DISPATCH_STATUS_TASK_MARKER.length)
     for (const line of body.split(/\r?\n/)) {
@@ -72,6 +82,35 @@ export function compactDispatchPromptForStatus(
     compact += ` ${ORCA_DISPATCH_STATUS_TASK_MARKER} ${taskBody}`
   }
   return normalizeSingleLine(compact, maxLength)
+}
+
+function findTaskMarkerIndex(value: string): number {
+  // Why: base-drift commit subjects are repository-controlled and may mention
+  // the marker. Raw preambles must use the standalone line emitted by Orca.
+  let searchFrom = 0
+  while (searchFrom < value.length) {
+    const markerIndex = value.indexOf(ORCA_DISPATCH_STATUS_TASK_MARKER, searchFrom)
+    if (markerIndex === -1) {
+      break
+    }
+    const markerEnd = markerIndex + ORCA_DISPATCH_STATUS_TASK_MARKER.length
+    const startsLine = markerIndex === 0 || isLineBreak(value.charCodeAt(markerIndex - 1))
+    const endsLine = markerEnd === value.length || isLineBreak(value.charCodeAt(markerEnd))
+    if (startsLine && endsLine) {
+      return markerIndex
+    }
+    searchFrom = markerEnd
+  }
+
+  // Already-normalized dispatch previews are single-line and intentionally
+  // carry the marker inline; normalization must stay idempotent across hops.
+  return value.includes('\n') || value.includes('\r')
+    ? -1
+    : value.indexOf(ORCA_DISPATCH_STATUS_TASK_MARKER)
+}
+
+function isLineBreak(code: number): boolean {
+  return code === 10 || code === 13
 }
 
 function isEcmaTrimWhitespace(code: number): boolean {

--- a/src/shared/orca-dispatch-status-prompt.ts
+++ b/src/shared/orca-dispatch-status-prompt.ts
@@ -7,7 +7,7 @@
 
 export const ORCA_DISPATCH_STATUS_PREAMBLE_PREFIX =
   'You are working inside Orca, a multi-agent IDE.'
-const ORCA_DISPATCH_STATUS_TASK_MARKER = '=== TASK ==='
+export const ORCA_DISPATCH_STATUS_TASK_MARKER = '=== TASK ==='
 const ORCA_DISPATCH_STATUS_TASK_ID_MARKER = 'Your task ID is:'
 // Why: real preambles put === TASK === near the end (~4KB+). Scan past the
 // normal single-line budget so the task body is still reachable for compacting.
@@ -60,7 +60,7 @@ export function compactDispatchPromptForStatus(
   }
 
   let taskBody = ''
-  const taskMarkerIndex = findTaskMarkerIndex(scan)
+  const taskMarkerIndex = findOrcaDispatchTaskMarkerIndex(scan)
   if (taskMarkerIndex !== -1) {
     const body = scan.slice(taskMarkerIndex + ORCA_DISPATCH_STATUS_TASK_MARKER.length)
     for (const line of body.split(/\r?\n/)) {
@@ -84,9 +84,14 @@ export function compactDispatchPromptForStatus(
   return normalizeSingleLine(compact, maxLength)
 }
 
-function findTaskMarkerIndex(value: string): number {
-  // Why: base-drift commit subjects are repository-controlled and may mention
-  // the marker. Raw preambles must use the standalone line emitted by Orca.
+/**
+ * Locate the Orca task separator in a dispatch prompt scan window.
+ * Why: base-drift commit subjects are repository-controlled and may mention
+ * `=== TASK ===`. Raw multi-line preambles must use the standalone line Orca
+ * emits; already-normalized single-line status previews intentionally keep the
+ * marker inline so re-normalization and UI helpers stay consistent.
+ */
+export function findOrcaDispatchTaskMarkerIndex(value: string): number {
   let searchFrom = 0
   while (searchFrom < value.length) {
     const markerIndex = value.indexOf(ORCA_DISPATCH_STATUS_TASK_MARKER, searchFrom)


### PR DESCRIPTION
## Problem

Dispatched worker rows often showed lifecycle boilerplate instead of the actual task:

- Agent-status `prompt` fields are folded to a **single line** and capped at **~200 characters**.
- Real Orca dispatch preambles are multi-KB (CLI instructions, heartbeats, ask rules) with `=== TASK ===` near the end.
- Naive head-truncation kept only the opening text (`You are working inside Orca…`) and **dropped the task body**.
- Until orchestration `displayName` / `taskTitle` arrived (sometimes delayed), the sidebar/dashboard fallback was preamble noise — or empty after guards against that noise.
- Multi-line preview helpers also assumed newline-separated paragraphs, so the production single-line shape could miss a useful fallback even when the task marker was still present.

Result: workers looked unlabeled or labeled with inject machinery during the window when a human most needs a readable task preview.

## Solution

- **Compact** dispatch preambles during status normalization so the 200-char field keeps preamble detection + task id + `=== TASK ===` body (not CLI boilerplate).
- **UI primary text** uses that task-body preview when labels are missing/delayed; prefers richer orchestration labels once they match the live dispatch; never surfaces preamble noise.
- **Shared standalone-line** `=== TASK ===` parsing so base-drift commit subjects mentioning the marker cannot hijack the fallback (raw multi-line and compacted single-line paths).

## Validation

- Focused unit tests: single-line 200-char normalization, missing/delayed labels, short specs, later label replacement, marker impersonation
- node/web typecheck, focused oxlint/format, max-lines ratchet
- Adversarial review/fix rounds (parser/robustness hardening landed on this branch)

## Residual risk

Orca-generated task IDs are short; an adversarially long untrusted token could still consume the preview budget. Task bodies past the bounded source scan still fall back to empty primary text (state label).