### PR TITLE
fix(settings): isolate provider account discovery failures

### DIFF
--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -73,6 +73,8 @@ import {
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import {
+  emptyClaudeAccountsState,
+  emptyCodexAccountsState,
   hasRemoteProviderAccountOwner,
   removeClaudeProviderAccount,
   removeCodexProviderAccount,
@@ -338,25 +340,27 @@ export function AccountsPane({
       ? `${localAccountRuntime.label.charAt(0).toLocaleLowerCase()}${localAccountRuntime.label.slice(1)}`
       : localAccountRuntime.label
 
-  const [codexAccounts, setCodexAccounts] = useState<CodexRateLimitAccountsState>({
-    accounts: [],
-    activeAccountId: null,
-    activeAccountIdsByRuntime: { host: null, wsl: {} }
-  })
+  const [codexAccounts, setCodexAccounts] =
+    useState<CodexRateLimitAccountsState>(emptyCodexAccountsState)
   const [codexAccountsLoaded, setCodexAccountsLoaded] = useState(false)
   const [codexAction, setCodexAction] = useState<
     'idle' | 'adding' | `reauth:${string}` | `remove:${string}` | `select:${string | 'system'}`
   >('idle')
-  const [claudeAccounts, setClaudeAccounts] = useState<ClaudeRateLimitAccountsState>({
-    accounts: [],
-    activeAccountId: null,
-    activeAccountIdsByRuntime: { host: null, wsl: {} }
-  })
+  const [claudeAccounts, setClaudeAccounts] =
+    useState<ClaudeRateLimitAccountsState>(emptyClaudeAccountsState)
   const [claudeAction, setClaudeAction] = useState<
     'idle' | 'adding' | `reauth:${string}` | `remove:${string}` | `select:${string | 'system'}`
   >('idle')
-  const [removeAccountId, setRemoveAccountId] = useState<string | null>(null)
-  const [removeClaudeAccountId, setRemoveClaudeAccountId] = useState<string | null>(null)
+  // Why: capture the account's runtime slot when the dialog opens; the roster
+  // can change underneath an open dialog and lose the slot to diff for restarts.
+  const [removeCodexTarget, setRemoveCodexTarget] = useState<{
+    id: string
+    runtime: ProviderAccountRuntimeView
+  } | null>(null)
+  const [removeClaudeTarget, setRemoveClaudeTarget] = useState<{
+    id: string
+    runtime: ProviderAccountRuntimeView
+  } | null>(null)
   const accountVisibilityOptions = {
     remoteOwner: isRemoteAccountScope,
     ownerPlatform: accountOwnerPlatform
@@ -368,15 +372,18 @@ export function AccountsPane({
     providerAccountMatchesView(account, accountRuntime, accountVisibilityOptions)
   )
   const activeCodexAccountId = getProviderAccountActiveIdForView(codexAccounts, accountRuntime)
-  const accountActiveOptions = { remoteOwner: isRemoteAccountScope }
-  // Why: under remote WSL flattening a WSL account can be active while the host
-  // default id is still null, so the forced-host activeAccountId would light up
-  // the System default row alongside it; defer that row to any active account row.
-  const systemCodexActive = !visibleCodexAccounts.some((account) =>
-    providerAccountIsActiveInView(account, codexAccounts, accountRuntime, accountActiveOptions)
+  // Why: System default lights only when no account row is active; while a remote
+  // owner's platform is unknown WSL rows hide fail-closed, so check the full roster.
+  const ownerPlatformUnknown = isRemoteAccountScope && accountOwnerPlatform === null
+  const systemCodexActive = !(
+    ownerPlatformUnknown ? codexAccounts.accounts : visibleCodexAccounts
+  ).some((account) =>
+    providerAccountIsActiveInView(account, codexAccounts, accountRuntime, accountVisibilityOptions)
   )
-  const systemClaudeActive = !visibleClaudeAccounts.some((account) =>
-    providerAccountIsActiveInView(account, claudeAccounts, accountRuntime, accountActiveOptions)
+  const systemClaudeActive = !(
+    ownerPlatformUnknown ? claudeAccounts.accounts : visibleClaudeAccounts
+  ).some((account) =>
+    providerAccountIsActiveInView(account, claudeAccounts, accountRuntime, accountVisibilityOptions)
   )
   // Why: the auth warning is derived from the desktop's own rate-limit poll;
   // with a remote owner it would misattribute local auth state to the server.
@@ -481,9 +488,15 @@ export function AccountsPane({
       { activeRuntimeEnvironmentId },
       {
         onSnapshot: (snapshot) => {
-          setCodexAccounts(snapshot.codex)
-          setClaudeAccounts(snapshot.claude)
-          setCodexAccountsLoaded(true)
+          // Why: a failed provider's half is a substituted empty roster, not
+          // authoritative data; keep prior state and leave the loaded gate shut.
+          if (!snapshot.failedProviders?.includes('codex')) {
+            setCodexAccounts(snapshot.codex)
+            setCodexAccountsLoaded(true)
+          }
+          if (!snapshot.failedProviders?.includes('claude')) {
+            setClaudeAccounts(snapshot.claude)
+          }
         },
         onError: (error) => {
           toast.error(
@@ -872,7 +885,7 @@ export function AccountsPane({
                   account,
                   claudeAccounts,
                   accountRuntime,
-                  accountActiveOptions
+                  accountVisibilityOptions
                 )
                 const isReauthing = claudeAction === `reauth:${account.id}`
                 const isBusy = claudeAction !== 'idle' || accountRuntimeUnavailable
@@ -889,18 +902,18 @@ export function AccountsPane({
                     <div className="flex w-full items-center justify-between gap-3 max-md:flex-col max-md:items-start">
                       <button
                         type="button"
-                        onClick={() =>
+                        onClick={() => {
+                          const accountRuntimeView = getProviderAccountRuntime(account)
                           void runClaudeAccountAction(
                             `select:${account.id}`,
                             () =>
                               selectClaudeProviderAccount(settings, {
                                 accountId: account.id,
-                                runtime: account.managedAuthRuntime ?? 'host',
-                                wslDistro: account.wslDistro ?? null
+                                ...accountRuntimeView
                               }),
-                            getProviderAccountRuntime(account)
+                            accountRuntimeView
                           )
-                        }
+                        }}
                         disabled={isBusy}
                         className="flex min-w-0 flex-1 flex-col gap-0.5 text-left disabled:cursor-default"
                       >
@@ -936,8 +949,13 @@ export function AccountsPane({
                           size="xs"
                           onClick={(event) => {
                             event.stopPropagation()
-                            void runClaudeAccountAction(`reauth:${account.id}`, () =>
-                              window.api.claudeAccounts.reauthenticate({ accountId: account.id })
+                            void runClaudeAccountAction(
+                              `reauth:${account.id}`,
+                              () =>
+                                window.api.claudeAccounts.reauthenticate({
+                                  accountId: account.id
+                                }),
+                              getProviderAccountRuntime(account)
                             )
                           }}
                           disabled={isRemoteAccountScope || isBusy}
@@ -958,7 +976,10 @@ export function AccountsPane({
                           size="xs"
                           onClick={(event) => {
                             event.stopPropagation()
-                            setRemoveClaudeAccountId(account.id)
+                            setRemoveClaudeTarget({
+                              id: account.id,
+                              runtime: getProviderAccountRuntime(account)
+                            })
                           }}
                           disabled={isBusy}
                           className="h-6 px-2 text-muted-foreground hover:text-destructive"
@@ -1179,7 +1200,7 @@ export function AccountsPane({
                   account,
                   codexAccounts,
                   accountRuntime,
-                  accountActiveOptions
+                  accountVisibilityOptions
                 )
                 // Why: same remote gate as the section-level warning — the
                 // desktop's rate-limit poll says nothing about server accounts.
@@ -1211,18 +1232,18 @@ export function AccountsPane({
                     <div className="flex w-full items-center justify-between gap-3 max-md:flex-col max-md:items-start">
                       <button
                         type="button"
-                        onClick={() =>
+                        onClick={() => {
+                          const accountRuntimeView = getProviderAccountRuntime(account)
                           void runCodexAccountAction(
                             `select:${account.id}`,
                             () =>
                               selectCodexProviderAccount(settings, {
                                 accountId: account.id,
-                                runtime: account.managedHomeRuntime ?? 'host',
-                                wslDistro: account.wslDistro ?? null
+                                ...accountRuntimeView
                               }),
-                            getProviderAccountRuntime(account)
+                            accountRuntimeView
                           )
-                        }
+                        }}
                         disabled={isBusy}
                         className="flex min-w-0 flex-1 flex-col gap-0.5 text-left disabled:cursor-default"
                       >
@@ -1290,8 +1311,13 @@ export function AccountsPane({
                           size="xs"
                           onClick={(event) => {
                             event.stopPropagation()
-                            void runCodexAccountAction(`reauth:${account.id}`, () =>
-                              window.api.codexAccounts.reauthenticate({ accountId: account.id })
+                            void runCodexAccountAction(
+                              `reauth:${account.id}`,
+                              () =>
+                                window.api.codexAccounts.reauthenticate({
+                                  accountId: account.id
+                                }),
+                              getProviderAccountRuntime(account)
                             )
                           }}
                           disabled={isRemoteAccountScope || isBusy}
@@ -1312,7 +1338,10 @@ export function AccountsPane({
                           size="xs"
                           onClick={(event) => {
                             event.stopPropagation()
-                            setRemoveAccountId(account.id)
+                            setRemoveCodexTarget({
+                              id: account.id,
+                              runtime: getProviderAccountRuntime(account)
+                            })
                           }}
                           disabled={isBusy}
                           className="h-6 px-2 text-muted-foreground hover:text-destructive"
@@ -1787,8 +1816,8 @@ export function AccountsPane({
   return (
     <div className="space-y-8">
       <Dialog
-        open={removeAccountId !== null}
-        onOpenChange={(open) => !open && setRemoveAccountId(null)}
+        open={removeCodexTarget !== null}
+        onOpenChange={(open) => !open && setRemoveCodexTarget(null)}
       >
         <DialogContent showCloseButton={false}>
           <DialogHeader>
@@ -1806,22 +1835,21 @@ export function AccountsPane({
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setRemoveAccountId(null)}>
+            <Button variant="outline" onClick={() => setRemoveCodexTarget(null)}>
               {translate('auto.components.settings.AccountsPane.dbb9626ed1', 'Cancel')}
             </Button>
             <Button
               variant="destructive"
               onClick={() => {
-                const accountId = removeAccountId
-                if (!accountId) {
+                const target = removeCodexTarget
+                if (!target) {
                   return
                 }
-                const account = codexAccounts.accounts.find((entry) => entry.id === accountId)
-                setRemoveAccountId(null)
+                setRemoveCodexTarget(null)
                 void runCodexAccountAction(
-                  `remove:${accountId}`,
-                  () => removeCodexProviderAccount(settings, accountId),
-                  account ? getProviderAccountRuntime(account) : accountRuntime
+                  `remove:${target.id}`,
+                  () => removeCodexProviderAccount(settings, target.id),
+                  target.runtime
                 )
               }}
             >
@@ -1831,8 +1859,8 @@ export function AccountsPane({
         </DialogContent>
       </Dialog>
       <Dialog
-        open={removeClaudeAccountId !== null}
-        onOpenChange={(open) => !open && setRemoveClaudeAccountId(null)}
+        open={removeClaudeTarget !== null}
+        onOpenChange={(open) => !open && setRemoveClaudeTarget(null)}
       >
         <DialogContent showCloseButton={false}>
           <DialogHeader>
@@ -1850,22 +1878,21 @@ export function AccountsPane({
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setRemoveClaudeAccountId(null)}>
+            <Button variant="outline" onClick={() => setRemoveClaudeTarget(null)}>
               {translate('auto.components.settings.AccountsPane.dbb9626ed1', 'Cancel')}
             </Button>
             <Button
               variant="destructive"
               onClick={() => {
-                const accountId = removeClaudeAccountId
-                if (!accountId) {
+                const target = removeClaudeTarget
+                if (!target) {
                   return
                 }
-                const account = claudeAccounts.accounts.find((entry) => entry.id === accountId)
-                setRemoveClaudeAccountId(null)
+                setRemoveClaudeTarget(null)
                 void runClaudeAccountAction(
-                  `remove:${accountId}`,
-                  () => removeClaudeProviderAccount(settings, accountId),
-                  account ? getProviderAccountRuntime(account) : accountRuntime
+                  `remove:${target.id}`,
+                  () => removeClaudeProviderAccount(settings, target.id),
+                  target.runtime
                 )
               }}
             >

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -62,6 +62,7 @@ import {
   DialogTitle
 } from '../ui/dialog'
 import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
+import { providerAccountMatchesView } from './provider-account-visibility'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import {
@@ -146,6 +147,7 @@ type AccountsPaneProps = {
   wslAvailable?: boolean
   wslDistros?: string[]
   wslCapabilitiesLoading?: boolean
+  accountOwnerPlatform?: NodeJS.Platform | null
 }
 
 function getHostRuntimeLabel(): string {
@@ -288,26 +290,6 @@ type LocalAccountRuntime = {
   label: string
 }
 
-function accountMatchesRuntime(
-  account:
-    | CodexRateLimitAccountsState['accounts'][number]
-    | ClaudeRateLimitAccountsState['accounts'][number],
-  runtime: LocalAccountRuntime
-): boolean {
-  const accountRuntime =
-    'authMethod' in account
-      ? (account.managedAuthRuntime ?? 'host')
-      : (account.managedHomeRuntime ?? 'host')
-  const accountDistro = account.wslDistro ?? null
-  if (runtime.runtime === 'host') {
-    return accountRuntime !== 'wsl'
-  }
-  if (accountRuntime !== 'wsl') {
-    return false
-  }
-  return runtime.wslDistro ? accountDistro === runtime.wslDistro : true
-}
-
 function getSelectedAccountRuntime(
   settings: GlobalSettings,
   wslSupportedPlatform: boolean,
@@ -344,7 +326,8 @@ export function AccountsPane({
   wslSupportedPlatform = false,
   wslAvailable = false,
   wslDistros = EMPTY_WSL_DISTROS,
-  wslCapabilitiesLoading = false
+  wslCapabilitiesLoading = false,
+  accountOwnerPlatform = null
 }: AccountsPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const codexRateLimits = useAppStore((s) => s.rateLimits.codex)
@@ -407,11 +390,15 @@ export function AccountsPane({
   >('idle')
   const [removeAccountId, setRemoveAccountId] = useState<string | null>(null)
   const [removeClaudeAccountId, setRemoveClaudeAccountId] = useState<string | null>(null)
+  const accountVisibilityOptions = {
+    remoteOwner: isRemoteAccountScope,
+    ownerPlatform: accountOwnerPlatform
+  }
   const visibleClaudeAccounts = claudeAccounts.accounts.filter((account) =>
-    accountMatchesRuntime(account, accountRuntime)
+    providerAccountMatchesView(account, accountRuntime, accountVisibilityOptions)
   )
   const visibleCodexAccounts = codexAccounts.accounts.filter((account) =>
-    accountMatchesRuntime(account, accountRuntime)
+    providerAccountMatchesView(account, accountRuntime, accountVisibilityOptions)
   )
   const activeCodexAccountId = getActiveCodexAccountIdForRuntime(codexAccounts, accountRuntime)
   const activeClaudeAccountId = getActiveClaudeAccountIdForRuntime(claudeAccounts, accountRuntime)

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -67,6 +67,7 @@ import {
   getProviderAccountRuntime,
   providerAccountIsActiveInView,
   providerAccountMatchesView,
+  WSL_DEFAULT_DISTRO_KEY,
   type ProviderAccountRuntimeView
 } from './provider-account-visibility'
 import { translate } from '@/i18n/i18n'
@@ -367,8 +368,16 @@ export function AccountsPane({
     providerAccountMatchesView(account, accountRuntime, accountVisibilityOptions)
   )
   const activeCodexAccountId = getProviderAccountActiveIdForView(codexAccounts, accountRuntime)
-  const activeClaudeAccountId = getProviderAccountActiveIdForView(claudeAccounts, accountRuntime)
   const accountActiveOptions = { remoteOwner: isRemoteAccountScope }
+  // Why: under remote WSL flattening a WSL account can be active while the host
+  // default id is still null, so the forced-host activeAccountId would light up
+  // the System default row alongside it; defer that row to any active account row.
+  const systemCodexActive = !visibleCodexAccounts.some((account) =>
+    providerAccountIsActiveInView(account, codexAccounts, accountRuntime, accountActiveOptions)
+  )
+  const systemClaudeActive = !visibleClaudeAccounts.some((account) =>
+    providerAccountIsActiveInView(account, claudeAccounts, accountRuntime, accountActiveOptions)
+  )
   // Why: the auth warning is derived from the desktop's own rate-limit poll;
   // with a remote owner it would misattribute local auth state to the server.
   const activeCodexAuthWarning =
@@ -569,11 +578,11 @@ export function AccountsPane({
             />
             {wslSupportedPlatform && accountRuntime.runtime === 'wsl' ? (
               <Select
-                value={accountRuntime.wslDistro ?? '__default__'}
+                value={accountRuntime.wslDistro ?? WSL_DEFAULT_DISTRO_KEY}
                 onValueChange={(value) =>
                   updateSettings({
                     localAccountRuntime: 'wsl',
-                    localAccountWslDistro: value === '__default__' ? null : value
+                    localAccountWslDistro: value === WSL_DEFAULT_DISTRO_KEY ? null : value
                   })
                 }
                 disabled={wslCapabilitiesLoading || !wslAvailable}
@@ -594,7 +603,7 @@ export function AccountsPane({
                   />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="__default__">
+                  <SelectItem value={WSL_DEFAULT_DISTRO_KEY}>
                     {translate('auto.components.settings.AccountsPane.2358ac71d2', 'WSL default')}
                   </SelectItem>
                   {wslDistros.map((distro) => (
@@ -812,7 +821,7 @@ export function AccountsPane({
               }
               disabled={claudeAction !== 'idle' || accountRuntimeUnavailable}
               className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
-                activeClaudeAccountId === null
+                systemClaudeActive
                   ? 'border-foreground/20 bg-accent/15'
                   : 'border-border/70 hover:border-border hover:bg-accent/8'
               } disabled:cursor-default disabled:opacity-100`}
@@ -825,7 +834,7 @@ export function AccountsPane({
                       'System default'
                     )}
                   </span>
-                  {activeClaudeAccountId === null ? (
+                  {systemClaudeActive ? (
                     <Badge
                       variant="outline"
                       className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/80"
@@ -1098,7 +1107,7 @@ export function AccountsPane({
               className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
                 systemCodexNeedsReauthentication
                   ? 'border-destructive/50 bg-destructive/5'
-                  : activeCodexAccountId === null
+                  : systemCodexActive
                     ? 'border-foreground/20 bg-accent/15'
                     : 'border-border/70 hover:border-border hover:bg-accent/8'
               } disabled:cursor-default disabled:opacity-100`}
@@ -1111,7 +1120,7 @@ export function AccountsPane({
                       'System default'
                     )}
                   </span>
-                  {activeCodexAccountId === null ? (
+                  {systemCodexActive ? (
                     <Badge
                       variant="outline"
                       className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/80"

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -62,7 +62,10 @@ import {
   DialogTitle
 } from '../ui/dialog'
 import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
-import { providerAccountMatchesView } from './provider-account-visibility'
+import {
+  providerAccountIsActiveInView,
+  providerAccountMatchesView
+} from './provider-account-visibility'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import {
@@ -402,6 +405,7 @@ export function AccountsPane({
   )
   const activeCodexAccountId = getActiveCodexAccountIdForRuntime(codexAccounts, accountRuntime)
   const activeClaudeAccountId = getActiveClaudeAccountIdForRuntime(claudeAccounts, accountRuntime)
+  const accountActiveOptions = { remoteOwner: isRemoteAccountScope }
   // Why: the auth warning is derived from the desktop's own rate-limit poll;
   // with a remote owner it would misattribute local auth state to the server.
   const activeCodexAuthWarning =
@@ -891,7 +895,12 @@ export function AccountsPane({
               </div>
             ) : (
               visibleClaudeAccounts.map((account) => {
-                const isActive = activeClaudeAccountId === account.id
+                const isActive = providerAccountIsActiveInView(
+                  account,
+                  claudeAccounts,
+                  accountRuntime,
+                  accountActiveOptions
+                )
                 const isReauthing = claudeAction === `reauth:${account.id}`
                 const isBusy = claudeAction !== 'idle' || accountRuntimeUnavailable
 
@@ -1190,7 +1199,12 @@ export function AccountsPane({
               </div>
             ) : (
               visibleCodexAccounts.map((account) => {
-                const isActive = activeCodexAccountId === account.id
+                const isActive = providerAccountIsActiveInView(
+                  account,
+                  codexAccounts,
+                  accountRuntime,
+                  accountActiveOptions
+                )
                 // Why: same remote gate as the section-level warning — the
                 // desktop's rate-limit poll says nothing about server accounts.
                 const accountAuthWarning = isRemoteAccountScope

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -63,8 +63,11 @@ import {
 } from '../ui/dialog'
 import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
 import {
+  getProviderAccountActiveIdForView,
+  getProviderAccountRuntime,
   providerAccountIsActiveInView,
-  providerAccountMatchesView
+  providerAccountMatchesView,
+  type ProviderAccountRuntimeView
 } from './provider-account-visibility'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
@@ -167,46 +170,6 @@ function getCodexAccountLabel(
     return 'System default'
   }
   return state.accounts.find((account) => account.id === accountId)?.email ?? 'Codex account'
-}
-
-function getActiveCodexAccountIdForRuntime(
-  state: CodexRateLimitAccountsState,
-  runtime: LocalAccountRuntime
-): string | null {
-  if (runtime.runtime === 'host') {
-    return state.activeAccountIdsByRuntime?.host ?? state.activeAccountId
-  }
-  if (runtime.wslDistro) {
-    return state.activeAccountIdsByRuntime?.wsl?.[runtime.wslDistro] ?? null
-  }
-  const defaultSelection = state.activeAccountIdsByRuntime?.wsl?.__default__
-  if (defaultSelection) {
-    return defaultSelection
-  }
-  const selectedIds = Array.from(
-    new Set(Object.values(state.activeAccountIdsByRuntime?.wsl ?? {}).filter(Boolean))
-  )
-  return selectedIds.length === 1 ? selectedIds[0] : null
-}
-
-function getActiveClaudeAccountIdForRuntime(
-  state: ClaudeRateLimitAccountsState,
-  runtime: LocalAccountRuntime
-): string | null {
-  if (runtime.runtime === 'host') {
-    return state.activeAccountIdsByRuntime?.host ?? state.activeAccountId
-  }
-  if (runtime.wslDistro) {
-    return state.activeAccountIdsByRuntime?.wsl?.[runtime.wslDistro] ?? null
-  }
-  const defaultSelection = state.activeAccountIdsByRuntime?.wsl?.__default__
-  if (defaultSelection) {
-    return defaultSelection
-  }
-  const selectedIds = Array.from(
-    new Set(Object.values(state.activeAccountIdsByRuntime?.wsl ?? {}).filter(Boolean))
-  )
-  return selectedIds.length === 1 ? selectedIds[0] : null
 }
 
 function getClaudeAccountLabel(
@@ -403,8 +366,8 @@ export function AccountsPane({
   const visibleCodexAccounts = codexAccounts.accounts.filter((account) =>
     providerAccountMatchesView(account, accountRuntime, accountVisibilityOptions)
   )
-  const activeCodexAccountId = getActiveCodexAccountIdForRuntime(codexAccounts, accountRuntime)
-  const activeClaudeAccountId = getActiveClaudeAccountIdForRuntime(claudeAccounts, accountRuntime)
+  const activeCodexAccountId = getProviderAccountActiveIdForView(codexAccounts, accountRuntime)
+  const activeClaudeAccountId = getProviderAccountActiveIdForView(claudeAccounts, accountRuntime)
   const accountActiveOptions = { remoteOwner: isRemoteAccountScope }
   // Why: the auth warning is derived from the desktop's own rate-limit poll;
   // with a remote owner it would misattribute local auth state to the server.
@@ -648,17 +611,20 @@ export function AccountsPane({
     </SearchableSetting>
   ) : null
 
+  // Why: remote Windows flattens host and WSL rows, so mutation follow-up must
+  // compare the selected row's runtime slot instead of the forced host view.
   const runCodexAccountAction = async (
     action: typeof codexAction,
-    operation: () => Promise<CodexRateLimitAccountsState>
+    operation: () => Promise<CodexRateLimitAccountsState>,
+    actionRuntime: ProviderAccountRuntimeView = accountRuntime
   ): Promise<void> => {
-    const previousActiveAccountId = getActiveCodexAccountIdForRuntime(codexAccounts, accountRuntime)
+    const previousActiveAccountId = getProviderAccountActiveIdForView(codexAccounts, actionRuntime)
     setCodexAction(action)
     try {
       const next = await operation()
       await syncCodexAccounts(next)
       recordFeatureInteraction('codex-account-switching')
-      const nextActiveAccountId = getActiveCodexAccountIdForRuntime(next, accountRuntime)
+      const nextActiveAccountId = getProviderAccountActiveIdForView(next, actionRuntime)
       const shouldPromptRestart =
         action === 'adding' ||
         (action.startsWith('select:') && previousActiveAccountId !== nextActiveAccountId) ||
@@ -689,18 +655,16 @@ export function AccountsPane({
 
   const runClaudeAccountAction = async (
     action: typeof claudeAction,
-    operation: () => Promise<ClaudeRateLimitAccountsState>
+    operation: () => Promise<ClaudeRateLimitAccountsState>,
+    actionRuntime: ProviderAccountRuntimeView = accountRuntime
   ): Promise<void> => {
-    const previousActiveAccountId = getActiveClaudeAccountIdForRuntime(
-      claudeAccounts,
-      accountRuntime
-    )
+    const previousActiveAccountId = getProviderAccountActiveIdForView(claudeAccounts, actionRuntime)
     setClaudeAction(action)
     try {
       const next = await operation()
       await syncClaudeAccounts(next)
       recordFeatureInteraction('claude-account-switching')
-      const nextActiveAccountId = getActiveClaudeAccountIdForRuntime(next, accountRuntime)
+      const nextActiveAccountId = getProviderAccountActiveIdForView(next, actionRuntime)
       const shouldPromptRestart =
         action === 'adding' ||
         previousActiveAccountId !== nextActiveAccountId ||
@@ -917,12 +881,15 @@ export function AccountsPane({
                       <button
                         type="button"
                         onClick={() =>
-                          void runClaudeAccountAction(`select:${account.id}`, () =>
-                            selectClaudeProviderAccount(settings, {
-                              accountId: account.id,
-                              runtime: account.managedAuthRuntime ?? 'host',
-                              wslDistro: account.wslDistro ?? null
-                            })
+                          void runClaudeAccountAction(
+                            `select:${account.id}`,
+                            () =>
+                              selectClaudeProviderAccount(settings, {
+                                accountId: account.id,
+                                runtime: account.managedAuthRuntime ?? 'host',
+                                wslDistro: account.wslDistro ?? null
+                              }),
+                            getProviderAccountRuntime(account)
                           )
                         }
                         disabled={isBusy}
@@ -1236,12 +1203,15 @@ export function AccountsPane({
                       <button
                         type="button"
                         onClick={() =>
-                          void runCodexAccountAction(`select:${account.id}`, () =>
-                            selectCodexProviderAccount(settings, {
-                              accountId: account.id,
-                              runtime: account.managedHomeRuntime ?? 'host',
-                              wslDistro: account.wslDistro ?? null
-                            })
+                          void runCodexAccountAction(
+                            `select:${account.id}`,
+                            () =>
+                              selectCodexProviderAccount(settings, {
+                                accountId: account.id,
+                                runtime: account.managedHomeRuntime ?? 'host',
+                                wslDistro: account.wslDistro ?? null
+                              }),
+                            getProviderAccountRuntime(account)
                           )
                         }
                         disabled={isBusy}
@@ -1837,9 +1807,12 @@ export function AccountsPane({
                 if (!accountId) {
                   return
                 }
+                const account = codexAccounts.accounts.find((entry) => entry.id === accountId)
                 setRemoveAccountId(null)
-                void runCodexAccountAction(`remove:${accountId}`, () =>
-                  removeCodexProviderAccount(settings, accountId)
+                void runCodexAccountAction(
+                  `remove:${accountId}`,
+                  () => removeCodexProviderAccount(settings, accountId),
+                  account ? getProviderAccountRuntime(account) : accountRuntime
                 )
               }}
             >
@@ -1878,9 +1851,12 @@ export function AccountsPane({
                 if (!accountId) {
                   return
                 }
+                const account = claudeAccounts.accounts.find((entry) => entry.id === accountId)
                 setRemoveClaudeAccountId(null)
-                void runClaudeAccountAction(`remove:${accountId}`, () =>
-                  removeClaudeProviderAccount(settings, accountId)
+                void runClaudeAccountAction(
+                  `remove:${accountId}`,
+                  () => removeClaudeProviderAccount(settings, accountId),
+                  account ? getProviderAccountRuntime(account) : accountRuntime
                 )
               }}
             >

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -1136,6 +1136,7 @@ function Settings(): React.JSX.Element {
                       wslAvailable={windowsTerminalCapabilities.wslAvailable}
                       wslDistros={windowsTerminalCapabilities.wslDistros}
                       wslCapabilitiesLoading={windowsTerminalCapabilities.isLoading}
+                      accountOwnerPlatform={windowsTerminalCapabilities.hostPlatform}
                     />
                   ) : null}
                 </SettingsSection>

--- a/src/renderer/src/components/settings/provider-account-visibility.test.ts
+++ b/src/renderer/src/components/settings/provider-account-visibility.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ClaudeRateLimitAccountsState,
+  CodexRateLimitAccountsState
+} from '../../../../shared/types'
+import { providerAccountMatchesView } from './provider-account-visibility'
+
+const codexWslAccount = {
+  id: 'codex-wsl',
+  email: 'wsl@example.com',
+  managedHomeRuntime: 'wsl',
+  wslDistro: 'Ubuntu',
+  providerAccountId: null,
+  workspaceLabel: null,
+  workspaceAccountId: null,
+  createdAt: 1,
+  updatedAt: 1,
+  lastAuthenticatedAt: 1
+} satisfies CodexRateLimitAccountsState['accounts'][number]
+
+const claudeHostAccount = {
+  id: 'claude-host',
+  email: 'host@example.com',
+  managedAuthRuntime: 'host',
+  wslDistro: null,
+  authMethod: 'subscription-oauth',
+  organizationUuid: null,
+  organizationName: null,
+  createdAt: 1,
+  updatedAt: 1,
+  lastAuthenticatedAt: 1
+} satisfies ClaudeRateLimitAccountsState['accounts'][number]
+
+describe('providerAccountMatchesView', () => {
+  it('shows WSL accounts owned by a Windows server regardless of the client platform', () => {
+    expect(
+      providerAccountMatchesView(
+        codexWslAccount,
+        { runtime: 'host' },
+        {
+          remoteOwner: true,
+          ownerPlatform: 'win32'
+        }
+      )
+    ).toBe(true)
+  })
+
+  it('does not expose stale WSL accounts from a non-Windows remote runtime', () => {
+    expect(
+      providerAccountMatchesView(
+        codexWslAccount,
+        { runtime: 'host' },
+        {
+          remoteOwner: true,
+          ownerPlatform: 'linux'
+        }
+      )
+    ).toBe(false)
+    expect(
+      providerAccountMatchesView(
+        claudeHostAccount,
+        { runtime: 'wsl' },
+        {
+          remoteOwner: true,
+          ownerPlatform: 'linux'
+        }
+      )
+    ).toBe(true)
+  })
+
+  it('keeps local host and WSL views isolated by runtime and distro', () => {
+    const localOptions = { remoteOwner: false, ownerPlatform: 'win32' as const }
+
+    expect(providerAccountMatchesView(codexWslAccount, { runtime: 'host' }, localOptions)).toBe(
+      false
+    )
+    expect(
+      providerAccountMatchesView(
+        codexWslAccount,
+        { runtime: 'wsl', wslDistro: 'Ubuntu' },
+        localOptions
+      )
+    ).toBe(true)
+    expect(
+      providerAccountMatchesView(
+        codexWslAccount,
+        { runtime: 'wsl', wslDistro: 'Debian' },
+        localOptions
+      )
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/provider-account-visibility.test.ts
+++ b/src/renderer/src/components/settings/provider-account-visibility.test.ts
@@ -3,13 +3,29 @@ import type {
   ClaudeRateLimitAccountsState,
   CodexRateLimitAccountsState
 } from '../../../../shared/types'
-import { providerAccountMatchesView } from './provider-account-visibility'
+import {
+  providerAccountIsActiveInView,
+  providerAccountMatchesView
+} from './provider-account-visibility'
 
 const codexWslAccount = {
   id: 'codex-wsl',
   email: 'wsl@example.com',
   managedHomeRuntime: 'wsl',
   wslDistro: 'Ubuntu',
+  providerAccountId: null,
+  workspaceLabel: null,
+  workspaceAccountId: null,
+  createdAt: 1,
+  updatedAt: 1,
+  lastAuthenticatedAt: 1
+} satisfies CodexRateLimitAccountsState['accounts'][number]
+
+const codexHostAccount = {
+  id: 'codex-host',
+  email: 'host@example.com',
+  managedHomeRuntime: 'host',
+  wslDistro: null,
   providerAccountId: null,
   workspaceLabel: null,
   workspaceAccountId: null,
@@ -88,5 +104,96 @@ describe('providerAccountMatchesView', () => {
         localOptions
       )
     ).toBe(false)
+  })
+
+  it('hides WSL accounts while remote owner platform is still unknown', () => {
+    // Why: unknown platform is fail-closed so stale WSL rows do not flash on a
+    // non-Windows remote while capabilities load.
+    expect(
+      providerAccountMatchesView(
+        codexWslAccount,
+        { runtime: 'host' },
+        {
+          remoteOwner: true,
+          ownerPlatform: null
+        }
+      )
+    ).toBe(false)
+    expect(
+      providerAccountMatchesView(
+        codexHostAccount,
+        { runtime: 'host' },
+        {
+          remoteOwner: true,
+          ownerPlatform: null
+        }
+      )
+    ).toBe(true)
+  })
+})
+
+describe('providerAccountIsActiveInView', () => {
+  it('marks remote WSL accounts active from their own runtime selection', () => {
+    const selection = {
+      activeAccountId: 'codex-host',
+      activeAccountIdsByRuntime: {
+        host: 'codex-host',
+        wsl: { Ubuntu: 'codex-wsl' }
+      }
+    }
+
+    // Why: remote Windows forces the host view filter, but Active must still
+    // light for the WSL slot that actually selected this account.
+    expect(
+      providerAccountIsActiveInView(
+        codexWslAccount,
+        selection,
+        { runtime: 'host' },
+        { remoteOwner: true }
+      )
+    ).toBe(true)
+    expect(
+      providerAccountIsActiveInView(
+        codexHostAccount,
+        selection,
+        { runtime: 'host' },
+        { remoteOwner: true }
+      )
+    ).toBe(true)
+  })
+
+  it('keeps local Active scoped to the selected host/WSL view', () => {
+    const selection = {
+      activeAccountId: 'codex-host',
+      activeAccountIdsByRuntime: {
+        host: 'codex-host',
+        wsl: { Ubuntu: 'codex-wsl' }
+      }
+    }
+
+    expect(
+      providerAccountIsActiveInView(
+        codexHostAccount,
+        selection,
+        { runtime: 'host' },
+        { remoteOwner: false }
+      )
+    ).toBe(true)
+    expect(
+      providerAccountIsActiveInView(
+        codexWslAccount,
+        selection,
+        { runtime: 'host' },
+        { remoteOwner: false }
+      )
+    ).toBe(false)
+    expect(
+      providerAccountIsActiveInView(
+        codexWslAccount,
+        selection,
+        { runtime: 'wsl', wslDistro: 'Ubuntu' },
+        { remoteOwner: false }
+      )
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/settings/provider-account-visibility.test.ts
+++ b/src/renderer/src/components/settings/provider-account-visibility.test.ts
@@ -4,6 +4,8 @@ import type {
   CodexRateLimitAccountsState
 } from '../../../../shared/types'
 import {
+  getProviderAccountActiveIdForView,
+  getProviderAccountRuntime,
   providerAccountIsActiveInView,
   providerAccountMatchesView
 } from './provider-account-visibility'
@@ -133,6 +135,32 @@ describe('providerAccountMatchesView', () => {
 })
 
 describe('providerAccountIsActiveInView', () => {
+  it('detects a remote WSL selection change even when the host selection is unchanged', () => {
+    const before = {
+      activeAccountId: 'codex-host',
+      activeAccountIdsByRuntime: {
+        host: 'codex-host',
+        wsl: { Ubuntu: 'codex-wsl-old' }
+      }
+    }
+    const after = {
+      ...before,
+      activeAccountIdsByRuntime: {
+        ...before.activeAccountIdsByRuntime,
+        wsl: { Ubuntu: 'codex-wsl' }
+      }
+    }
+    const actionRuntime = getProviderAccountRuntime(codexWslAccount)
+
+    // Why: AccountsPane's remote view is forced to host, but restart prompts
+    // must compare the WSL slot changed by selecting or removing this row.
+    expect(getProviderAccountActiveIdForView(before, actionRuntime)).toBe('codex-wsl-old')
+    expect(getProviderAccountActiveIdForView(after, actionRuntime)).toBe('codex-wsl')
+    expect(getProviderAccountActiveIdForView(before, { runtime: 'host' })).toBe(
+      getProviderAccountActiveIdForView(after, { runtime: 'host' })
+    )
+  })
+
   it('marks remote WSL accounts active from their own runtime selection', () => {
     const selection = {
       activeAccountId: 'codex-host',

--- a/src/renderer/src/components/settings/provider-account-visibility.ts
+++ b/src/renderer/src/components/settings/provider-account-visibility.ts
@@ -1,5 +1,7 @@
 import type {
+  ClaudeManagedAccountRuntimeSelection,
   ClaudeRateLimitAccountsState,
+  CodexManagedAccountRuntimeSelection,
   CodexRateLimitAccountsState
 } from '../../../../shared/types'
 
@@ -9,10 +11,9 @@ type ProviderAccount =
 
 type ProviderAccountSelection = {
   activeAccountId: string | null
-  activeAccountIdsByRuntime?: {
-    host: string | null
-    wsl: Record<string, string | null>
-  }
+  activeAccountIdsByRuntime?:
+    | ClaudeManagedAccountRuntimeSelection
+    | CodexManagedAccountRuntimeSelection
 }
 
 export type ProviderAccountRuntimeView = {

--- a/src/renderer/src/components/settings/provider-account-visibility.ts
+++ b/src/renderer/src/components/settings/provider-account-visibility.ts
@@ -20,6 +20,10 @@ export type ProviderAccountRuntimeView = {
   wslDistro?: string | null
 }
 
+// Why: sentinel for the "WSL default" distro slot; shared so the AccountsPane
+// distro Select and this active-account resolution can't drift out of sync.
+export const WSL_DEFAULT_DISTRO_KEY = '__default__'
+
 export function getProviderAccountRuntime(account: ProviderAccount): {
   runtime: 'host' | 'wsl'
   wslDistro: string | null
@@ -45,8 +49,8 @@ export function getProviderAccountActiveIdForView(
     return selection.activeAccountIdsByRuntime?.wsl?.[runtime.wslDistro] ?? null
   }
   const wsl = selection.activeAccountIdsByRuntime?.wsl ?? {}
-  if (wsl.__default__) {
-    return wsl.__default__
+  if (wsl[WSL_DEFAULT_DISTRO_KEY]) {
+    return wsl[WSL_DEFAULT_DISTRO_KEY]
   }
   const selectedIds = Array.from(new Set(Object.values(wsl).filter(Boolean)))
   return selectedIds.length === 1 ? selectedIds[0] : null

--- a/src/renderer/src/components/settings/provider-account-visibility.ts
+++ b/src/renderer/src/components/settings/provider-account-visibility.ts
@@ -1,0 +1,41 @@
+import type {
+  ClaudeRateLimitAccountsState,
+  CodexRateLimitAccountsState
+} from '../../../../shared/types'
+
+type ProviderAccount =
+  | ClaudeRateLimitAccountsState['accounts'][number]
+  | CodexRateLimitAccountsState['accounts'][number]
+
+export type ProviderAccountRuntimeView = {
+  runtime: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
+export function providerAccountMatchesView(
+  account: ProviderAccount,
+  runtime: ProviderAccountRuntimeView,
+  options: {
+    remoteOwner: boolean
+    ownerPlatform: NodeJS.Platform | null
+  }
+): boolean {
+  const accountRuntime =
+    'authMethod' in account
+      ? (account.managedAuthRuntime ?? 'host')
+      : (account.managedHomeRuntime ?? 'host')
+  const accountDistro = account.wslDistro ?? null
+
+  if (options.remoteOwner) {
+    // Why: provider accounts belong to the Orca runtime, not its client or a
+    // downstream SSH host; a Windows runtime owns both host and WSL accounts.
+    return options.ownerPlatform === 'win32' || accountRuntime !== 'wsl'
+  }
+  if (runtime.runtime === 'host') {
+    return accountRuntime !== 'wsl'
+  }
+  if (accountRuntime !== 'wsl') {
+    return false
+  }
+  return runtime.wslDistro ? accountDistro === runtime.wslDistro : true
+}

--- a/src/renderer/src/components/settings/provider-account-visibility.ts
+++ b/src/renderer/src/components/settings/provider-account-visibility.ts
@@ -7,9 +7,49 @@ type ProviderAccount =
   | ClaudeRateLimitAccountsState['accounts'][number]
   | CodexRateLimitAccountsState['accounts'][number]
 
+type ProviderAccountSelection = {
+  activeAccountId: string | null
+  activeAccountIdsByRuntime?: {
+    host: string | null
+    wsl: Record<string, string | null>
+  }
+}
+
 export type ProviderAccountRuntimeView = {
   runtime: 'host' | 'wsl'
   wslDistro?: string | null
+}
+
+function getAccountRuntime(account: ProviderAccount): {
+  runtime: 'host' | 'wsl'
+  wslDistro: string | null
+} {
+  const runtime =
+    'authMethod' in account
+      ? (account.managedAuthRuntime ?? 'host')
+      : (account.managedHomeRuntime ?? 'host')
+  return {
+    runtime,
+    wslDistro: account.wslDistro ?? null
+  }
+}
+
+function getSelectedAccountIdForRuntime(
+  selection: ProviderAccountSelection,
+  runtime: ProviderAccountRuntimeView
+): string | null {
+  if (runtime.runtime === 'host') {
+    return selection.activeAccountIdsByRuntime?.host ?? selection.activeAccountId ?? null
+  }
+  if (runtime.wslDistro) {
+    return selection.activeAccountIdsByRuntime?.wsl?.[runtime.wslDistro] ?? null
+  }
+  const wsl = selection.activeAccountIdsByRuntime?.wsl ?? {}
+  if (wsl.__default__) {
+    return wsl.__default__
+  }
+  const selectedIds = Array.from(new Set(Object.values(wsl).filter(Boolean)))
+  return selectedIds.length === 1 ? selectedIds[0] : null
 }
 
 export function providerAccountMatchesView(
@@ -20,22 +60,34 @@ export function providerAccountMatchesView(
     ownerPlatform: NodeJS.Platform | null
   }
 ): boolean {
-  const accountRuntime =
-    'authMethod' in account
-      ? (account.managedAuthRuntime ?? 'host')
-      : (account.managedHomeRuntime ?? 'host')
-  const accountDistro = account.wslDistro ?? null
+  const accountView = getAccountRuntime(account)
 
   if (options.remoteOwner) {
     // Why: provider accounts belong to the Orca runtime, not its client or a
     // downstream SSH host; a Windows runtime owns both host and WSL accounts.
-    return options.ownerPlatform === 'win32' || accountRuntime !== 'wsl'
+    return options.ownerPlatform === 'win32' || accountView.runtime !== 'wsl'
   }
   if (runtime.runtime === 'host') {
-    return accountRuntime !== 'wsl'
+    return accountView.runtime !== 'wsl'
   }
-  if (accountRuntime !== 'wsl') {
+  if (accountView.runtime !== 'wsl') {
     return false
   }
-  return runtime.wslDistro ? accountDistro === runtime.wslDistro : true
+  return runtime.wslDistro ? accountView.wslDistro === runtime.wslDistro : true
+}
+
+export function providerAccountIsActiveInView(
+  account: ProviderAccount,
+  selection: ProviderAccountSelection,
+  runtime: ProviderAccountRuntimeView,
+  options: {
+    remoteOwner: boolean
+  }
+): boolean {
+  if (options.remoteOwner) {
+    // Why: remote Windows lists host and WSL accounts in one roster; Active must
+    // follow each account's own runtime slot, not the forced host view filter.
+    return getSelectedAccountIdForRuntime(selection, getAccountRuntime(account)) === account.id
+  }
+  return getSelectedAccountIdForRuntime(selection, runtime) === account.id
 }

--- a/src/renderer/src/components/settings/provider-account-visibility.ts
+++ b/src/renderer/src/components/settings/provider-account-visibility.ts
@@ -20,7 +20,7 @@ export type ProviderAccountRuntimeView = {
   wslDistro?: string | null
 }
 
-function getAccountRuntime(account: ProviderAccount): {
+export function getProviderAccountRuntime(account: ProviderAccount): {
   runtime: 'host' | 'wsl'
   wslDistro: string | null
 } {
@@ -34,7 +34,7 @@ function getAccountRuntime(account: ProviderAccount): {
   }
 }
 
-function getSelectedAccountIdForRuntime(
+export function getProviderAccountActiveIdForView(
   selection: ProviderAccountSelection,
   runtime: ProviderAccountRuntimeView
 ): string | null {
@@ -60,7 +60,7 @@ export function providerAccountMatchesView(
     ownerPlatform: NodeJS.Platform | null
   }
 ): boolean {
-  const accountView = getAccountRuntime(account)
+  const accountView = getProviderAccountRuntime(account)
 
   if (options.remoteOwner) {
     // Why: provider accounts belong to the Orca runtime, not its client or a
@@ -87,7 +87,10 @@ export function providerAccountIsActiveInView(
   if (options.remoteOwner) {
     // Why: remote Windows lists host and WSL accounts in one roster; Active must
     // follow each account's own runtime slot, not the forced host view filter.
-    return getSelectedAccountIdForRuntime(selection, getAccountRuntime(account)) === account.id
+    return (
+      getProviderAccountActiveIdForView(selection, getProviderAccountRuntime(account)) ===
+      account.id
+    )
   }
-  return getSelectedAccountIdForRuntime(selection, runtime) === account.id
+  return getProviderAccountActiveIdForView(selection, runtime) === account.id
 }

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -717,6 +717,11 @@ function ClaudeSwitcherMenu({
   // settings mutations don't re-run the remote snapshot round trip.
   const loadAccounts = useCallback(async () => {
     const snapshot = await fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId })
+    // Why: a failed Claude half is a substituted empty roster; keep prior state.
+    if (snapshot.failedProviders?.includes('claude')) {
+      console.error('Claude account list failed; keeping previous status bar state.')
+      return
+    }
     if (mountedRef.current) {
       setAccounts(snapshot.claude)
     }
@@ -1285,6 +1290,11 @@ function CodexSwitcherMenu({
   // settings mutations don't re-run the remote snapshot round trip.
   const loadAccounts = useCallback(async () => {
     const snapshot = await fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId })
+    // Why: a failed Codex half is a substituted empty roster; keep prior state.
+    if (snapshot.failedProviders?.includes('codex')) {
+      console.error('Codex account list failed; keeping previous status bar state.')
+      return
+    }
     if (mountedRef.current) {
       setAccounts(snapshot.codex)
     }

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
@@ -155,6 +155,32 @@ describe('watchProviderAccounts', () => {
     expect(snapshots).toHaveLength(0)
   })
 
+  it('keeps a healthy local provider snapshot when the other provider fails', async () => {
+    const codexState = { ...emptyCodexState(), activeAccountId: 'codex-local' }
+    claudeListLocal.mockRejectedValue(new Error('Claude keychain unavailable'))
+    codexListLocal.mockResolvedValue(codexState)
+    const snapshots: ProviderAccountsSnapshot[] = []
+    const errors: unknown[] = []
+
+    watchProviderAccounts(LOCAL, {
+      onSnapshot: (snapshot) => snapshots.push(snapshot),
+      onError: (error) => errors.push(error)
+    })
+    await flushMicrotasks()
+
+    expect(snapshots).toEqual([
+      {
+        claude: emptyClaudeState(),
+        codex: codexState,
+        rateLimits: null
+      }
+    ])
+    expect(errors).toHaveLength(1)
+    expect((errors[0] as Error).message).toBe(
+      'Could not load Claude accounts: Claude keychain unavailable'
+    )
+  })
+
   it('streams remote snapshots from accounts.subscribe and unsubscribes on close', async () => {
     const snapshots: ProviderAccountsSnapshot[] = []
     const watcher = watchProviderAccounts(REMOTE, {

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
@@ -172,7 +172,8 @@ describe('watchProviderAccounts', () => {
       {
         claude: emptyClaudeState(),
         codex: codexState,
-        rateLimits: null
+        rateLimits: null,
+        failedProviders: ['claude']
       }
     ])
     expect(errors).toHaveLength(1)
@@ -198,7 +199,8 @@ describe('watchProviderAccounts', () => {
       {
         claude: claudeState,
         codex: emptyCodexState(),
-        rateLimits: null
+        rateLimits: null,
+        failedProviders: ['codex']
       }
     ])
     expect(errors).toHaveLength(1)
@@ -309,12 +311,12 @@ describe('fetchProviderAccountsSnapshot', () => {
     codexListLocal.mockResolvedValue(codexState)
 
     // Why: one-shot consumers (status bar menus) must keep the healthy provider
-    // even when the sibling list rejects; the trailing onError must not reject
-    // the already-resolved promise.
+    // even when the sibling list rejects instead of seeing a rejected promise.
     await expect(fetchProviderAccountsSnapshot(LOCAL)).resolves.toEqual({
       claude: emptyClaudeState(),
       codex: codexState,
-      rateLimits: null
+      rateLimits: null,
+      failedProviders: ['claude']
     })
   })
 })

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
@@ -181,6 +181,50 @@ describe('watchProviderAccounts', () => {
     )
   })
 
+  it('keeps a healthy Claude snapshot when only Codex fails', async () => {
+    const claudeState = { ...emptyClaudeState(), activeAccountId: 'claude-local' }
+    claudeListLocal.mockResolvedValue(claudeState)
+    codexListLocal.mockRejectedValue(new Error('Codex home missing'))
+    const snapshots: ProviderAccountsSnapshot[] = []
+    const errors: unknown[] = []
+
+    watchProviderAccounts(LOCAL, {
+      onSnapshot: (snapshot) => snapshots.push(snapshot),
+      onError: (error) => errors.push(error)
+    })
+    await flushMicrotasks()
+
+    expect(snapshots).toEqual([
+      {
+        claude: claudeState,
+        codex: emptyCodexState(),
+        rateLimits: null
+      }
+    ])
+    expect(errors).toHaveLength(1)
+    expect((errors[0] as Error).message).toBe('Could not load Codex accounts: Codex home missing')
+  })
+
+  it('aggregates errors without a snapshot when both local providers fail', async () => {
+    claudeListLocal.mockRejectedValue(new Error('Claude keychain unavailable'))
+    codexListLocal.mockRejectedValue(new Error('Codex home missing'))
+    const snapshots: ProviderAccountsSnapshot[] = []
+    const errors: unknown[] = []
+
+    watchProviderAccounts(LOCAL, {
+      onSnapshot: (snapshot) => snapshots.push(snapshot),
+      onError: (error) => errors.push(error)
+    })
+    await flushMicrotasks()
+
+    expect(snapshots).toHaveLength(0)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBeInstanceOf(AggregateError)
+    expect((errors[0] as AggregateError).message).toContain('Could not load Claude accounts')
+    expect((errors[0] as AggregateError).message).toContain('Could not load Codex accounts')
+    expect((errors[0] as AggregateError).errors).toHaveLength(2)
+  })
+
   it('streams remote snapshots from accounts.subscribe and unsubscribes on close', async () => {
     const snapshots: ProviderAccountsSnapshot[] = []
     const watcher = watchProviderAccounts(REMOTE, {
@@ -257,6 +301,21 @@ describe('fetchProviderAccountsSnapshot', () => {
     subscriptionCallbacks?.onClose?.()
 
     await expect(pending).rejects.toThrow('subscription closed')
+  })
+
+  it('resolves partial local snapshots so one healthy provider is still usable', async () => {
+    const codexState = { ...emptyCodexState(), activeAccountId: 'codex-local' }
+    claudeListLocal.mockRejectedValue(new Error('Claude keychain unavailable'))
+    codexListLocal.mockResolvedValue(codexState)
+
+    // Why: one-shot consumers (status bar menus) must keep the healthy provider
+    // even when the sibling list rejects; the trailing onError must not reject
+    // the already-resolved promise.
+    await expect(fetchProviderAccountsSnapshot(LOCAL)).resolves.toEqual({
+      claude: emptyClaudeState(),
+      codex: codexState,
+      rateLimits: null
+    })
   })
 })
 

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.ts
@@ -41,6 +41,19 @@ export type ProviderAccountsWatcher = {
   close: () => void
 }
 
+function emptyClaudeAccountsState(): ClaudeRateLimitAccountsState {
+  return { accounts: [], activeAccountId: null, activeAccountIdsByRuntime: { host: null, wsl: {} } }
+}
+
+function emptyCodexAccountsState(): CodexRateLimitAccountsState {
+  return { accounts: [], activeAccountId: null, activeAccountIdsByRuntime: { host: null, wsl: {} } }
+}
+
+function providerAccountsLoadError(provider: 'Claude' | 'Codex', cause: unknown): Error {
+  const message = String((cause as Error)?.message ?? cause)
+  return new Error(`Could not load ${provider} accounts: ${message}`)
+}
+
 // Watches the provider-account snapshot for whichever runtime owns accounts.
 // Local: one-shot reads of the desktop services (they have no push channel
 // here; the pane refetches after each mutation). Remote: a live
@@ -58,17 +71,39 @@ export function watchProviderAccounts(
   const target = getActiveRuntimeTarget(settings)
   if (target.kind === 'local') {
     let closed = false
-    void Promise.all([window.api.claudeAccounts.list(), window.api.codexAccounts.list()])
-      .then(([claude, codex]) => {
-        if (!closed) {
-          handlers.onSnapshot({ claude, codex, rateLimits: null })
-        }
+    void Promise.allSettled([
+      window.api.claudeAccounts.list(),
+      window.api.codexAccounts.list()
+    ]).then(([claudeResult, codexResult]) => {
+      if (closed) {
+        return
+      }
+
+      const errors = [
+        ...(claudeResult.status === 'rejected'
+          ? [providerAccountsLoadError('Claude', claudeResult.reason)]
+          : []),
+        ...(codexResult.status === 'rejected'
+          ? [providerAccountsLoadError('Codex', codexResult.reason)]
+          : [])
+      ]
+      if (errors.length === 2) {
+        handlers.onError(new AggregateError(errors, errors.map((error) => error.message).join(' ')))
+        return
+      }
+
+      handlers.onSnapshot({
+        claude:
+          claudeResult.status === 'fulfilled' ? claudeResult.value : emptyClaudeAccountsState(),
+        codex: codexResult.status === 'fulfilled' ? codexResult.value : emptyCodexAccountsState(),
+        rateLimits: null
       })
-      .catch((error: unknown) => {
-        if (!closed) {
-          handlers.onError(error)
-        }
-      })
+      // Why: publish the healthy provider first so one-shot consumers keep it,
+      // while the long-lived Accounts pane still receives a source-specific error.
+      for (const error of errors) {
+        handlers.onError(error)
+      }
+    })
     return {
       close: () => {
         closed = true

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.ts
@@ -12,6 +12,9 @@ export type ProviderAccountsSnapshot = {
   claude: ClaudeRateLimitAccountsState
   codex: CodexRateLimitAccountsState
   rateLimits: RateLimitState | null
+  // Why: a partial local load substitutes an empty state for the failed
+  // provider; consumers must not treat that half as an authoritative roster.
+  failedProviders?: ('claude' | 'codex')[]
 }
 
 type ProviderAccountSelection = {
@@ -41,11 +44,11 @@ export type ProviderAccountsWatcher = {
   close: () => void
 }
 
-function emptyClaudeAccountsState(): ClaudeRateLimitAccountsState {
+export function emptyClaudeAccountsState(): ClaudeRateLimitAccountsState {
   return { accounts: [], activeAccountId: null, activeAccountIdsByRuntime: { host: null, wsl: {} } }
 }
 
-function emptyCodexAccountsState(): CodexRateLimitAccountsState {
+export function emptyCodexAccountsState(): CodexRateLimitAccountsState {
   return { accounts: [], activeAccountId: null, activeAccountIdsByRuntime: { host: null, wsl: {} } }
 }
 
@@ -79,29 +82,40 @@ export function watchProviderAccounts(
         return
       }
 
-      const errors = [
-        ...(claudeResult.status === 'rejected'
-          ? [providerAccountsLoadError('Claude', claudeResult.reason)]
-          : []),
-        ...(codexResult.status === 'rejected'
-          ? [providerAccountsLoadError('Codex', codexResult.reason)]
-          : [])
-      ]
-      if (errors.length === 2) {
+      const claudeError =
+        claudeResult.status === 'rejected'
+          ? providerAccountsLoadError('Claude', claudeResult.reason)
+          : null
+      const codexError =
+        codexResult.status === 'rejected'
+          ? providerAccountsLoadError('Codex', codexResult.reason)
+          : null
+      if (claudeError && codexError) {
+        const errors = [claudeError, codexError]
         handlers.onError(new AggregateError(errors, errors.map((error) => error.message).join(' ')))
         return
       }
 
+      const failedProviders: ('claude' | 'codex')[] = []
+      if (claudeError) {
+        failedProviders.push('claude')
+      }
+      if (codexError) {
+        failedProviders.push('codex')
+      }
       handlers.onSnapshot({
         claude:
           claudeResult.status === 'fulfilled' ? claudeResult.value : emptyClaudeAccountsState(),
         codex: codexResult.status === 'fulfilled' ? codexResult.value : emptyCodexAccountsState(),
-        rateLimits: null
+        rateLimits: null,
+        ...(failedProviders.length > 0 ? { failedProviders } : {})
       })
       // Why: publish the healthy provider first so one-shot consumers keep it,
-      // while the long-lived Accounts pane still receives a source-specific error.
-      for (const error of errors) {
-        handlers.onError(error)
+      // but re-check closed since an onSnapshot handler may close the watcher.
+      for (const error of [claudeError, codexError]) {
+        if (error && !closed) {
+          handlers.onError(error)
+        }
       }
     })
     return {


### PR DESCRIPTION
## Summary
- isolate host and WSL provider-account loading so one source failure does not hide healthy accounts
- use runtime/server platform semantics for remote Windows WSL visibility
- correctly scope Active state and restart follow-up for flattened remote WSL accounts

## Validation
- 33 focused provider-account tests
- `typecheck:web`, targeted oxlint/oxfmt, max-lines ratchet, diff check
- two fresh adversarial review/fix rounds (one P2 fixed in each round)

## Residual risk
Live remote Windows + SSH/WSL end-to-end validation was not available on the macOS review host.