### PR TITLE
fix(codex): harden WSL hook path trust lifecycle

### DIFF
--- a/src/main/codex/codex-wsl-hook-install-plan.test.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.test.ts
@@ -38,10 +38,19 @@ describe('canonicalizeWslLinuxPath', () => {
     expect(execFileMock).toHaveBeenCalledTimes(1)
     const [file, args] = execFileMock.mock.calls[0]
     expect(file).toBe('wsl.exe')
-    expect(args).toEqual(['-d', 'Ubuntu', '--', 'readlink', '-f', '--', '/home/alias'])
+    expect(args).toEqual([
+      '-d',
+      'Ubuntu',
+      '--',
+      'sh',
+      '-c',
+      '[ -d "$1" ] && readlink -f -- "$1"',
+      'sh',
+      '/home/alias'
+    ])
   })
 
-  it('caches the resolved canonical path and stops spawning wsl.exe', () => {
+  it('returns the cached path while revalidating it asynchronously', () => {
     setPlatform('win32')
     expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBeNull()
 
@@ -49,7 +58,39 @@ describe('canonicalizeWslLinuxPath', () => {
     callback(null, '/home/alice\n')
 
     expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBe('/home/alice')
-    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves a custom automount root and notifies the first launch', () => {
+    setPlatform('win32')
+    const settled = vi.fn()
+    const windowsPath = 'D:\\orca\\codex-runtime-home\\home'
+
+    expect(
+      _internals.canonicalizeWslLinuxPath(
+        'Ubuntu',
+        '/mnt/d/orca/codex-runtime-home/home',
+        windowsPath,
+        settled
+      )
+    ).toBeNull()
+
+    const [file, args, options, callback] = execFileMock.mock.calls[0]
+    expect(file).toBe('wsl.exe')
+    expect(args).toEqual([
+      '-d',
+      'Ubuntu',
+      '--',
+      'sh',
+      '-c',
+      'resolved=$(wslpath -a -u "$1") && [ -d "$resolved" ] && readlink -f -- "$resolved"',
+      'sh',
+      windowsPath
+    ])
+    expect(options).toMatchObject({ timeout: 5000, windowsHide: true })
+
+    callback(null, '/windows/d/orca/codex-runtime-home/home\n')
+    expect(settled).toHaveBeenCalledWith('/windows/d/orca/codex-runtime-home/home')
   })
 
   it('does not spawn a second subprocess while one is in flight', () => {
@@ -68,6 +109,52 @@ describe('canonicalizeWslLinuxPath', () => {
 
     expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBeNull()
     expect(execFileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidates a cached path when revalidation later fails', () => {
+    setPlatform('win32')
+    _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')
+    const firstCallback = execFileMock.mock.calls[0][3] as (
+      error: Error | null,
+      stdout: string
+    ) => void
+    firstCallback(null, '/home/alice\n')
+
+    const settled = vi.fn()
+    expect(
+      _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias', '/home/alias', settled)
+    ).toBe('/home/alice')
+    const secondCallback = execFileMock.mock.calls[1][3] as (
+      error: Error | null,
+      stdout: string
+    ) => void
+    secondCallback(new Error('path disappeared'), '')
+
+    expect(settled).toHaveBeenCalledWith(null)
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBeNull()
+  })
+
+  it('replaces a cached path when its canonical identity changes', () => {
+    setPlatform('win32')
+    _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')
+    const firstCallback = execFileMock.mock.calls[0][3] as (
+      error: Error | null,
+      stdout: string
+    ) => void
+    firstCallback(null, '/home/alice-old\n')
+
+    const settled = vi.fn()
+    expect(
+      _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias', '/home/alias', settled)
+    ).toBe('/home/alice-old')
+    const secondCallback = execFileMock.mock.calls[1][3] as (
+      error: Error | null,
+      stdout: string
+    ) => void
+    secondCallback(null, '/home/alice-new\n')
+
+    expect(settled).toHaveBeenCalledWith('/home/alice-new')
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBe('/home/alice-new')
   })
 
   it('ignores non-absolute readlink output', () => {

--- a/src/main/codex/codex-wsl-hook-install-plan.test.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.test.ts
@@ -111,7 +111,7 @@ describe('canonicalizeWslLinuxPath', () => {
     expect(execFileMock).toHaveBeenCalledTimes(2)
   })
 
-  it('invalidates a cached path when revalidation later fails', () => {
+  it('keeps the last known-good cache when revalidation later fails', () => {
     setPlatform('win32')
     _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')
     const firstCallback = execFileMock.mock.calls[0][3] as (
@@ -130,8 +130,11 @@ describe('canonicalizeWslLinuxPath', () => {
     ) => void
     secondCallback(new Error('path disappeared'), '')
 
+    // Why: a cold or wedged distro times out without proving the path changed.
+    // Dropping the cache would force the next launch onto /mnt/... and rewrite
+    // trust under a path Codex will not use when automount is customized.
     expect(settled).toHaveBeenCalledWith(null)
-    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBeNull()
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBe('/home/alice')
   })
 
   it('replaces a cached path when its canonical identity changes', () => {

--- a/src/main/codex/codex-wsl-hook-install-plan.test.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.test.ts
@@ -44,7 +44,7 @@ describe('canonicalizeWslLinuxPath', () => {
       '--',
       'sh',
       '-c',
-      '[ -d "$1" ] && readlink -f -- "$1"',
+      `if [ ! -d "$1" ]; then printf '%s\\n' '__ORCA_WSL_PATH_MISSING__'; exit 0; fi; readlink -f -- "$1"`,
       'sh',
       '/home/alias'
     ])
@@ -83,14 +83,17 @@ describe('canonicalizeWslLinuxPath', () => {
       '--',
       'sh',
       '-c',
-      'resolved=$(wslpath -a -u "$1") && [ -d "$resolved" ] && readlink -f -- "$resolved"',
+      `resolved=$(wslpath -a -u "$1") || exit; if [ ! -d "$resolved" ]; then printf '%s\\n' '__ORCA_WSL_PATH_MISSING__'; exit 0; fi; readlink -f -- "$resolved"`,
       'sh',
       windowsPath
     ])
     expect(options).toMatchObject({ timeout: 5000, windowsHide: true })
 
     callback(null, '/windows/d/orca/codex-runtime-home/home\n')
-    expect(settled).toHaveBeenCalledWith('/windows/d/orca/codex-runtime-home/home')
+    expect(settled).toHaveBeenCalledWith({
+      status: 'resolved',
+      canonicalPath: '/windows/d/orca/codex-runtime-home/home'
+    })
   })
 
   it('does not spawn a second subprocess while one is in flight', () => {
@@ -133,8 +136,31 @@ describe('canonicalizeWslLinuxPath', () => {
     // Why: a cold or wedged distro times out without proving the path changed.
     // Dropping the cache would force the next launch onto /mnt/... and rewrite
     // trust under a path Codex will not use when automount is customized.
-    expect(settled).toHaveBeenCalledWith(null)
+    expect(settled).toHaveBeenCalledWith({ status: 'unavailable' })
     expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBe('/home/alice')
+  })
+
+  it('drops the cached identity when WSL confirms the path is missing', () => {
+    setPlatform('win32')
+    _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')
+    const firstCallback = execFileMock.mock.calls[0][3] as (
+      error: Error | null,
+      stdout: string
+    ) => void
+    firstCallback(null, '/home/alice\n')
+
+    const settled = vi.fn()
+    expect(
+      _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias', '/home/alias', settled)
+    ).toBe('/home/alice')
+    const secondCallback = execFileMock.mock.calls[1][3] as (
+      error: Error | null,
+      stdout: string
+    ) => void
+    secondCallback(null, '__ORCA_WSL_PATH_MISSING__\n')
+
+    expect(settled).toHaveBeenCalledWith({ status: 'missing' })
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBeNull()
   })
 
   it('replaces a cached path when its canonical identity changes', () => {
@@ -156,7 +182,10 @@ describe('canonicalizeWslLinuxPath', () => {
     ) => void
     secondCallback(null, '/home/alice-new\n')
 
-    expect(settled).toHaveBeenCalledWith('/home/alice-new')
+    expect(settled).toHaveBeenCalledWith({
+      status: 'resolved',
+      canonicalPath: '/home/alice-new'
+    })
     expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBe('/home/alice-new')
   })
 

--- a/src/main/codex/codex-wsl-hook-install-plan.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.ts
@@ -15,7 +15,14 @@ export type CodexWslRuntimeHookInstallPlan = {
   trustConfigPath: string
 }
 
-export type CanonicalizeWslLinuxPath = (distro: string, linuxPath: string) => string | null
+export type WslCanonicalPathSettled = (canonicalPath: string | null) => void
+
+export type CanonicalizeWslLinuxPath = (
+  distro: string,
+  linuxPath: string,
+  windowsPath?: string,
+  onSettled?: WslCanonicalPathSettled
+) => string | null
 
 function trimTrailingSlash(value: string): string {
   return value.length > 1 ? value.replace(/\/+$/, '') : value
@@ -33,58 +40,96 @@ const WSL_CANONICALIZE_TIMEOUT_MS = 5000
 
 // Why: `readlink -f` over wsl.exe stalls up to the timeout on a cold or wedged
 // distro. Running it synchronously on the Electron main process froze the UI on
-// every Codex WSL launch, so resolve it off-thread and cache the stable result.
+// every Codex WSL launch, so resolve it off-thread and cache the latest result.
 const canonicalWslPathCache = new Map<string, string>()
-const inFlightWslCanonicalizations = new Set<string>()
+const inFlightWslCanonicalizations = new Map<string, Set<WslCanonicalPathSettled>>()
 
 function wslCanonicalizeCacheKey(distro: string, linuxPath: string): string {
   return `${distro}\x00${linuxPath}`
 }
 
-function scheduleWslLinuxPathCanonicalization(distro: string, linuxPath: string): void {
+function scheduleWslLinuxPathCanonicalization(
+  distro: string,
+  linuxPath: string,
+  windowsPath: string,
+  onSettled?: WslCanonicalPathSettled
+): void {
   const key = wslCanonicalizeCacheKey(distro, linuxPath)
-  // Why: cap the wedged-WSL blast radius to a single background subprocess per
-  // (distro, path); the cache holds the answer once one resolution succeeds.
-  if (canonicalWslPathCache.has(key) || inFlightWslCanonicalizations.has(key)) {
+  const listeners = inFlightWslCanonicalizations.get(key)
+  if (listeners) {
+    if (onSettled) {
+      listeners.add(onSettled)
+    }
     return
   }
-  inFlightWslCanonicalizations.add(key)
+  const nextListeners = new Set<WslCanonicalPathSettled>()
+  if (onSettled) {
+    nextListeners.add(onSettled)
+  }
+  inFlightWslCanonicalizations.set(key, nextListeners)
+  const drivePath = /^[A-Za-z]:[/\\]/.test(windowsPath)
+  // Why: wslpath reads each distro's automount root, so a custom root such as
+  // /windows is discovered without synchronously starting WSL on Electron main.
+  const args = drivePath
+    ? [
+        '-d',
+        distro,
+        '--',
+        'sh',
+        '-c',
+        'resolved=$(wslpath -a -u "$1") && [ -d "$resolved" ] && readlink -f -- "$resolved"',
+        'sh',
+        windowsPath
+      ]
+    : ['-d', distro, '--', 'sh', '-c', '[ -d "$1" ] && readlink -f -- "$1"', 'sh', linuxPath]
   execFile(
     'wsl.exe',
-    ['-d', distro, '--', 'readlink', '-f', '--', linuxPath],
+    args,
     { encoding: 'utf-8', timeout: WSL_CANONICALIZE_TIMEOUT_MS, windowsHide: true },
     (error, stdout) => {
-      inFlightWslCanonicalizations.delete(key)
-      if (error) {
-        return
-      }
       const canonicalPath = stdout.trim()
-      if (canonicalPath.startsWith('/')) {
+      const resolvedPath = !error && canonicalPath.startsWith('/') ? canonicalPath : null
+      if (resolvedPath) {
         canonicalWslPathCache.set(key, canonicalPath)
+      } else {
+        // Why: availability and mount configuration can change after launch;
+        // a failed recheck must revoke the last trusted canonical identity.
+        canonicalWslPathCache.delete(key)
+      }
+      const settledListeners = inFlightWslCanonicalizations.get(key) ?? new Set()
+      inFlightWslCanonicalizations.delete(key)
+      for (const listener of settledListeners) {
+        try {
+          listener(resolvedPath)
+        } catch (listenerError) {
+          console.warn('[codex-wsl-hook-path] failed to reconcile canonical path', listenerError)
+        }
       }
     }
   )
 }
 
-function canonicalizeWslLinuxPath(distro: string, linuxPath: string): string | null {
+function canonicalizeWslLinuxPath(
+  distro: string,
+  linuxPath: string,
+  windowsPath = linuxPath,
+  onSettled?: WslCanonicalPathSettled
+): string | null {
   if (process.platform !== 'win32') {
     return linuxPath
   }
   const cached = canonicalWslPathCache.get(wslCanonicalizeCacheKey(distro, linuxPath))
-  if (cached) {
-    return cached
-  }
-  // Why: no canonical path resolved yet — start the off-thread resolution and
-  // let the caller use the logical path for now (identical unless HOME crosses a
-  // symlink). The next launch reads the cached canonical path.
-  scheduleWslLinuxPathCanonicalization(distro, linuxPath)
-  return null
+  // Why: every launch revalidates asynchronously. Returning the cache keeps
+  // launch prep synchronous while settlement repairs or revokes trust in-place.
+  scheduleWslLinuxPathCanonicalization(distro, linuxPath, windowsPath, onSettled)
+  return cached ?? null
 }
 
 export function createCodexWslRuntimeHookInstallPlan(
   runtimeHomePath: string | null | undefined,
   target?: CodexWslRuntimeHookTarget,
-  canonicalize: CanonicalizeWslLinuxPath = canonicalizeWslLinuxPath
+  canonicalize: CanonicalizeWslLinuxPath = canonicalizeWslLinuxPath,
+  onCanonicalPathSettled?: WslCanonicalPathSettled
 ): CodexWslRuntimeHookInstallPlan | null {
   if (!runtimeHomePath) {
     return null
@@ -106,7 +151,8 @@ export function createCodexWslRuntimeHookInstallPlan(
   // Why: Codex canonicalizes hook sources inside WSL; resolving there keeps
   // trust keys valid when HOME or the runtime directory crosses a symlink.
   const linuxRuntimeHome = trimTrailingSlash(
-    canonicalize(distro, logicalLinuxRuntimeHome) ?? logicalLinuxRuntimeHome
+    canonicalize(distro, logicalLinuxRuntimeHome, runtimeHomePath, onCanonicalPathSettled) ??
+      logicalLinuxRuntimeHome
   )
 
   return {

--- a/src/main/codex/codex-wsl-hook-install-plan.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.ts
@@ -91,11 +91,10 @@ function scheduleWslLinuxPathCanonicalization(
       const resolvedPath = !error && canonicalPath.startsWith('/') ? canonicalPath : null
       if (resolvedPath) {
         canonicalWslPathCache.set(key, canonicalPath)
-      } else {
-        // Why: availability and mount configuration can change after launch;
-        // a failed recheck must revoke the last trusted canonical identity.
-        canonicalWslPathCache.delete(key)
       }
+      // Why: keep the last known-good cache on timeout/transient WSL failures.
+      // Dropping it forces the next launch onto the logical `/mnt/...` guess,
+      // which is wrong under custom automount roots and rewrites trust keys.
       const settledListeners = inFlightWslCanonicalizations.get(key) ?? new Set()
       inFlightWslCanonicalizations.delete(key)
       for (const listener of settledListeners) {

--- a/src/main/codex/codex-wsl-hook-install-plan.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.ts
@@ -15,7 +15,12 @@ export type CodexWslRuntimeHookInstallPlan = {
   trustConfigPath: string
 }
 
-export type WslCanonicalPathSettled = (canonicalPath: string | null) => void
+export type WslCanonicalPathSettlement =
+  | { status: 'resolved'; canonicalPath: string }
+  | { status: 'missing' }
+  | { status: 'unavailable' }
+
+export type WslCanonicalPathSettled = (settlement: WslCanonicalPathSettlement) => void
 
 export type CanonicalizeWslLinuxPath = (
   distro: string,
@@ -37,6 +42,7 @@ function toDefaultWslLinuxPath(windowsPath: string): string {
 }
 
 const WSL_CANONICALIZE_TIMEOUT_MS = 5000
+const WSL_PATH_MISSING_OUTPUT = '__ORCA_WSL_PATH_MISSING__'
 
 // Why: `readlink -f` over wsl.exe stalls up to the timeout on a cold or wedged
 // distro. Running it synchronously on the Electron main process froze the UI on
@@ -77,11 +83,20 @@ function scheduleWslLinuxPathCanonicalization(
         '--',
         'sh',
         '-c',
-        'resolved=$(wslpath -a -u "$1") && [ -d "$resolved" ] && readlink -f -- "$resolved"',
+        `resolved=$(wslpath -a -u "$1") || exit; if [ ! -d "$resolved" ]; then printf '%s\\n' '${WSL_PATH_MISSING_OUTPUT}'; exit 0; fi; readlink -f -- "$resolved"`,
         'sh',
         windowsPath
       ]
-    : ['-d', distro, '--', 'sh', '-c', '[ -d "$1" ] && readlink -f -- "$1"', 'sh', linuxPath]
+    : [
+        '-d',
+        distro,
+        '--',
+        'sh',
+        '-c',
+        `if [ ! -d "$1" ]; then printf '%s\\n' '${WSL_PATH_MISSING_OUTPUT}'; exit 0; fi; readlink -f -- "$1"`,
+        'sh',
+        linuxPath
+      ]
   execFile(
     'wsl.exe',
     args,
@@ -89,8 +104,18 @@ function scheduleWslLinuxPathCanonicalization(
     (error, stdout) => {
       const canonicalPath = stdout.trim()
       const resolvedPath = !error && canonicalPath.startsWith('/') ? canonicalPath : null
-      if (resolvedPath) {
+      const pathMissing = !error && canonicalPath === WSL_PATH_MISSING_OUTPUT
+      const settlement: WslCanonicalPathSettlement = resolvedPath
+        ? { status: 'resolved', canonicalPath: resolvedPath }
+        : pathMissing
+          ? { status: 'missing' }
+          : { status: 'unavailable' }
+      if (settlement.status === 'resolved') {
         canonicalWslPathCache.set(key, canonicalPath)
+      } else if (settlement.status === 'missing') {
+        // Why: a successful directory probe is stronger than a transport error;
+        // clear the identity so stale trust can be revoked and later rediscovered.
+        canonicalWslPathCache.delete(key)
       }
       // Why: keep the last known-good cache on timeout/transient WSL failures.
       // Dropping it forces the next launch onto the logical `/mnt/...` guess,
@@ -99,7 +124,7 @@ function scheduleWslLinuxPathCanonicalization(
       inFlightWslCanonicalizations.delete(key)
       for (const listener of settledListeners) {
         try {
-          listener(resolvedPath)
+          listener(settlement)
         } catch (listenerError) {
           console.warn('[codex-wsl-hook-path] failed to reconcile canonical path', listenerError)
         }

--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -1515,6 +1515,34 @@ describe('readHookTrustEntries', () => {
     }
   )
 
+  it.skipIf(process.platform !== 'win32')(
+    'keeps WSL hook trust paths case-sensitive on a Windows host',
+    () => {
+      const upperKey = '/windows/d/Repo/hooks.json:session_start:0:0'
+      const lowerKey = '/windows/d/repo/hooks.json:session_start:0:0'
+      writeFileSync(
+        configPath,
+        [
+          `[hooks.state."${upperKey}"]`,
+          'enabled = true',
+          'trusted_hash = "sha256:UPPER"',
+          '',
+          `[hooks.state."${lowerKey}"]`,
+          'enabled = true',
+          'trusted_hash = "sha256:LOWER"',
+          ''
+        ].join('\n'),
+        'utf-8'
+      )
+
+      const result = readHookTrustEntries(configPath)
+
+      expect(result.get(upperKey)?.trustedHash).toBe('sha256:UPPER')
+      expect(result.get(lowerKey)?.trustedHash).toBe('sha256:LOWER')
+      expect(result.size).toBe(2)
+    }
+  )
+
   it('reads entries from a CRLF-terminated config', () => {
     const key = '/x/hooks.json:pre_tool_use:0:0'
     const original = [

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -529,7 +529,11 @@ export function normalizeHookTrustKeyForLookup(key: string): string {
   const separated = parsed
     ? `${normalizeWindowsPathSeparators(parsed.sourcePath)}:${parsed.eventLabel}:${parsed.groupIndex}:${parsed.handlerIndex}`
     : normalizeWindowsPathSeparators(key)
-  return process.platform === 'win32' ? separated.toLowerCase() : separated
+  // Why: Windows-native paths are case-insensitive, but WSL and SSH trust
+  // sources remain case-sensitive even when Orca's host process is Windows.
+  const caseInsensitiveWindowsPath =
+    process.platform === 'win32' && usesWindowsPathSeparators(parsed?.sourcePath ?? key)
+  return caseInsensitiveWindowsPath ? separated.toLowerCase() : separated
 }
 
 function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -122,6 +122,45 @@ describe('Codex WSL runtime hook install', () => {
     expect(plan?.configPath).toBe(pathWin32.join(runtimeHome, 'hooks.json'))
   })
 
+  it('removes managed trust when the WSL canonical path changes', () => {
+    const plan = createTestPlan()
+    writeFileSync(plan.configPath, '{"hooks":{}}\n', 'utf-8')
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+
+    const oldPlan = {
+      ...plan,
+      commandScriptPath: '/old/home/.orca/agent-hooks/codex-hook.sh',
+      trustConfigPath: '/old/home/hooks.json'
+    }
+    expect(_internals.installManagedHooksIntoWslRuntime(oldPlan).state).toBe('installed')
+    const oldCommand = `if [ -r '${oldPlan.commandScriptPath}' ]; then /bin/sh '${oldPlan.commandScriptPath}'; fi`
+    const oldKey = computeTrustKey(getManagedTrustEntry(oldPlan, oldCommand))
+
+    const newPlan = {
+      ...plan,
+      commandScriptPath: '/new/home/.orca/agent-hooks/codex-hook.sh',
+      trustConfigPath: '/new/home/hooks.json'
+    }
+    expect(_internals.installManagedHooksIntoWslRuntime(newPlan).state).toBe('installed')
+    const newCommand = `if [ -r '${newPlan.commandScriptPath}' ]; then /bin/sh '${newPlan.commandScriptPath}'; fi`
+    const newKey = computeTrustKey(getManagedTrustEntry(newPlan, newCommand))
+    const trustEntries = readHookTrustEntries(plan.tomlPath)
+
+    expect(trustEntries.has(oldKey)).toBe(false)
+    expect(trustEntries.has(newKey)).toBe(true)
+  })
+
+  it('revokes managed trust when WSL canonicalization later fails', () => {
+    const plan = createTestPlan()
+    writeFileSync(plan.configPath, '{"hooks":{}}\n', 'utf-8')
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    expect(_internals.installManagedHooksIntoWslRuntime(plan).state).toBe('installed')
+
+    _internals.removeStaleWslRuntimeManagedHookTrustEntries(plan.tomlPath, [])
+
+    expect(readHookTrustEntries(plan.tomlPath).size).toBe(0)
+  })
+
   it('generates a POSIX hook that bridges WSL loopback failures through Windows curl', () => {
     const script = _internals.getManagedScript('posix')
     expect(script).toContain('load_hook_endpoint()')

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -150,7 +150,9 @@ describe('Codex WSL runtime hook install', () => {
     expect(trustEntries.has(newKey)).toBe(true)
   })
 
-  it('revokes managed trust when WSL canonicalization later fails', () => {
+  it('sweeps all managed WSL trust when the desired set is empty (disable path)', () => {
+    // Why: refresh/disable intentionally passes []. Transient canonicalize
+    // failures must NOT use this path — they leave last known-good trust alone.
     const plan = createTestPlan()
     writeFileSync(plan.configPath, '{"hooks":{}}\n', 'utf-8')
     writeFileSync(plan.tomlPath, '', 'utf-8')
@@ -159,6 +161,44 @@ describe('Codex WSL runtime hook install', () => {
     _internals.removeStaleWslRuntimeManagedHookTrustEntries(plan.tomlPath, [])
 
     expect(readHookTrustEntries(plan.tomlPath).size).toBe(0)
+  })
+
+  it('does not reinstall after a failed or unchanged WSL path settle', () => {
+    expect(
+      _internals.shouldReinstallWslHooksAfterCanonicalSettle({
+        canonicalPath: null,
+        isCurrentGeneration: true,
+        installedTrustConfigPath: '/mnt/d/home/hooks.json',
+        resolvedTrustConfigPath: null
+      })
+    ).toBe(false)
+
+    expect(
+      _internals.shouldReinstallWslHooksAfterCanonicalSettle({
+        canonicalPath: '/windows/d/home',
+        isCurrentGeneration: false,
+        installedTrustConfigPath: '/mnt/d/home/hooks.json',
+        resolvedTrustConfigPath: '/windows/d/home/hooks.json'
+      })
+    ).toBe(false)
+
+    expect(
+      _internals.shouldReinstallWslHooksAfterCanonicalSettle({
+        canonicalPath: '/windows/d/home',
+        isCurrentGeneration: true,
+        installedTrustConfigPath: '/windows/d/home/hooks.json',
+        resolvedTrustConfigPath: '/windows/d/home/hooks.json'
+      })
+    ).toBe(false)
+
+    expect(
+      _internals.shouldReinstallWslHooksAfterCanonicalSettle({
+        canonicalPath: '/windows/d/home',
+        isCurrentGeneration: true,
+        installedTrustConfigPath: '/mnt/d/home/hooks.json',
+        resolvedTrustConfigPath: '/windows/d/home/hooks.json'
+      })
+    ).toBe(true)
   })
 
   it('generates a POSIX hook that bridges WSL loopback failures through Windows curl', () => {

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -150,9 +150,9 @@ describe('Codex WSL runtime hook install', () => {
     expect(trustEntries.has(newKey)).toBe(true)
   })
 
-  it('sweeps all managed WSL trust when the desired set is empty (disable path)', () => {
-    // Why: refresh/disable intentionally passes []. Transient canonicalize
-    // failures must NOT use this path — they leave last known-good trust alone.
+  it('sweeps all managed WSL trust for disable or confirmed absence', () => {
+    // Why: disable and confirmed absence intentionally pass []. Transient
+    // unavailability must NOT use this path — last known-good trust remains.
     const plan = createTestPlan()
     writeFileSync(plan.configPath, '{"hooks":{}}\n', 'utf-8')
     writeFileSync(plan.tomlPath, '', 'utf-8')
@@ -163,42 +163,51 @@ describe('Codex WSL runtime hook install', () => {
     expect(readHookTrustEntries(plan.tomlPath).size).toBe(0)
   })
 
-  it('does not reinstall after a failed or unchanged WSL path settle', () => {
+  it('reconciles only current, conclusive WSL path settlements', () => {
     expect(
-      _internals.shouldReinstallWslHooksAfterCanonicalSettle({
-        canonicalPath: null,
+      _internals.getWslHookReconciliationAction({
+        settlement: { status: 'unavailable' },
         isCurrentGeneration: true,
         installedTrustConfigPath: '/mnt/d/home/hooks.json',
         resolvedTrustConfigPath: null
       })
-    ).toBe(false)
+    ).toBe('none')
 
     expect(
-      _internals.shouldReinstallWslHooksAfterCanonicalSettle({
-        canonicalPath: '/windows/d/home',
+      _internals.getWslHookReconciliationAction({
+        settlement: { status: 'missing' },
         isCurrentGeneration: false,
         installedTrustConfigPath: '/mnt/d/home/hooks.json',
-        resolvedTrustConfigPath: '/windows/d/home/hooks.json'
+        resolvedTrustConfigPath: null
       })
-    ).toBe(false)
+    ).toBe('none')
 
     expect(
-      _internals.shouldReinstallWslHooksAfterCanonicalSettle({
-        canonicalPath: '/windows/d/home',
+      _internals.getWslHookReconciliationAction({
+        settlement: { status: 'missing' },
+        isCurrentGeneration: true,
+        installedTrustConfigPath: '/mnt/d/home/hooks.json',
+        resolvedTrustConfigPath: null
+      })
+    ).toBe('remove')
+
+    expect(
+      _internals.getWslHookReconciliationAction({
+        settlement: { status: 'resolved', canonicalPath: '/windows/d/home' },
         isCurrentGeneration: true,
         installedTrustConfigPath: '/windows/d/home/hooks.json',
         resolvedTrustConfigPath: '/windows/d/home/hooks.json'
       })
-    ).toBe(false)
+    ).toBe('none')
 
     expect(
-      _internals.shouldReinstallWslHooksAfterCanonicalSettle({
-        canonicalPath: '/windows/d/home',
+      _internals.getWslHookReconciliationAction({
+        settlement: { status: 'resolved', canonicalPath: '/windows/d/home' },
         isCurrentGeneration: true,
         installedTrustConfigPath: '/mnt/d/home/hooks.json',
         resolvedTrustConfigPath: '/windows/d/home/hooks.json'
       })
-    ).toBe(true)
+    ).toBe('reinstall')
   })
 
   it('generates a POSIX hook that bridges WSL loopback failures through Windows curl', () => {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: getStatus + install + remove all share the managed-command and trust-key derivation. Splitting would hide that the three operations must agree on group index, event label, and command bytes. */
 import { existsSync, readFileSync, unlinkSync } from 'node:fs'
-import { join, win32 as pathWin32 } from 'node:path'
+import { join } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import {
@@ -985,6 +985,20 @@ function refreshWslRuntimeUserHooks(plan: CodexWslRuntimeHookInstallPlan): Agent
   }
 }
 
+// Why: settle callbacks must not treat a failed recheck as proof the previous
+// identity is wrong. Only a successful, different path may rewrite trust.
+function shouldReinstallWslHooksAfterCanonicalSettle(args: {
+  canonicalPath: string | null
+  isCurrentGeneration: boolean
+  installedTrustConfigPath: string | null
+  resolvedTrustConfigPath: string | null
+}): boolean {
+  if (!args.canonicalPath || !args.isCurrentGeneration || !args.resolvedTrustConfigPath) {
+    return false
+  }
+  return args.resolvedTrustConfigPath !== args.installedTrustConfigPath
+}
+
 export class CodexHookService {
   private readonly wslReconciliationGeneration = new Map<string, number>()
 
@@ -1003,38 +1017,32 @@ export class CodexHookService {
     target?: CodexWslRuntimeHookTarget
   ): AgentHookInstallStatus | null {
     const generation = this.supersedeWslReconciliation(runtimeHomePath)
+    let installedTrustConfigPath: string | null = null
     const onCanonicalPathSettled = (canonicalPath: string | null): void => {
       if (!runtimeHomePath) {
         return
       }
       const key = process.platform === 'win32' ? runtimeHomePath.toLowerCase() : runtimeHomePath
-      // Why: hook settings or account selection can change while wsl.exe is
-      // running; only the newest request may install or revoke runtime trust.
-      if (this.wslReconciliationGeneration.get(key) !== generation) {
+      const resolvedPlan = canonicalPath
+        ? createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target, () => canonicalPath)
+        : null
+      if (
+        !shouldReinstallWslHooksAfterCanonicalSettle({
+          canonicalPath,
+          isCurrentGeneration: this.wslReconciliationGeneration.get(key) === generation,
+          installedTrustConfigPath,
+          resolvedTrustConfigPath: resolvedPlan?.trustConfigPath ?? null
+        }) ||
+        !resolvedPlan
+      ) {
         return
       }
-      if (!canonicalPath) {
-        try {
-          removeStaleWslRuntimeManagedHookTrustEntries(
-            pathWin32.join(runtimeHomePath, 'config.toml'),
-            []
-          )
-        } catch (error) {
-          console.warn('[codex-hook-service] failed to revoke stale WSL hook trust', error)
-        }
+      const status = installManagedHooksIntoWslRuntime(resolvedPlan)
+      if (status.state === 'error') {
+        console.warn('[codex-hook-service] failed to reconcile WSL hook path', status.detail)
         return
       }
-      const resolvedPlan = createCodexWslRuntimeHookInstallPlan(
-        runtimeHomePath,
-        target,
-        () => canonicalPath
-      )
-      if (resolvedPlan) {
-        const status = installManagedHooksIntoWslRuntime(resolvedPlan)
-        if (status.state === 'error') {
-          console.warn('[codex-hook-service] failed to reconcile WSL hook path', status.detail)
-        }
-      }
+      installedTrustConfigPath = resolvedPlan.trustConfigPath
     }
     const wslPlan = createCodexWslRuntimeHookInstallPlan(
       runtimeHomePath,
@@ -1042,6 +1050,7 @@ export class CodexHookService {
       undefined,
       onCanonicalPathSettled
     )
+    installedTrustConfigPath = wslPlan?.trustConfigPath ?? null
     return wslPlan ? installManagedHooksIntoWslRuntime(wslPlan) : null
   }
 
@@ -1520,5 +1529,6 @@ export const _internals = {
   getManagedScript,
   installManagedHooksIntoWslRuntime,
   refreshWslRuntimeUserHooks,
-  removeStaleWslRuntimeManagedHookTrustEntries
+  removeStaleWslRuntimeManagedHookTrustEntries,
+  shouldReinstallWslHooksAfterCanonicalSettle
 }

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: getStatus + install + remove all share the managed-command and trust-key derivation. Splitting would hide that the three operations must agree on group index, event label, and command bytes. */
 import { existsSync, readFileSync, unlinkSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, win32 as pathWin32 } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import {
@@ -723,6 +723,52 @@ function removeWslRuntimeManagedHookTrustEntries(plan: CodexWslRuntimeHookInstal
   }
 }
 
+function removeStaleWslRuntimeManagedHookTrustEntries(
+  tomlPath: string,
+  desiredEntries: readonly CodexTrustEntry[]
+): void {
+  const desiredKeys = new Set(
+    desiredEntries.map((entry) => normalizeHookTrustKeyForLookup(computeTrustKey(entry)))
+  )
+  const existingEntries = readHookTrustEntries(tomlPath)
+  const ourKeys: string[] = []
+  for (const [key, state] of existingEntries) {
+    if (desiredKeys.has(normalizeHookTrustKeyForLookup(key))) {
+      continue
+    }
+    const parts = parseTrustKey(key)
+    if (!parts || !CODEX_MANAGED_EVENT_LABELS.has(parts.eventLabel)) {
+      continue
+    }
+    const sourcePath = parts.sourcePath
+    // Why: this cleanup owns only guest-side WSL trust. A runtime config can
+    // still contain user Windows/remote hooks, which must remain untouched.
+    if (!sourcePath.startsWith('/') || !sourcePath.endsWith('/hooks.json')) {
+      continue
+    }
+    const runtimeHome = sourcePath.slice(0, -'/hooks.json'.length)
+    const command = wrapReadablePosixHookCommand(`${runtimeHome}/.orca/agent-hooks/codex-hook.sh`)
+    const expectedEntry: CodexTrustEntry = {
+      sourcePath: parts.sourcePath,
+      eventLabel: parts.eventLabel,
+      groupIndex: parts.groupIndex,
+      handlerIndex: parts.handlerIndex,
+      command,
+      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+    }
+    const recognizedHashes = new Set([
+      computeTrustedHash(expectedEntry),
+      computeTrustedHash({ ...expectedEntry, timeoutSec: undefined })
+    ])
+    if (state.trustedHash && recognizedHashes.has(state.trustedHash)) {
+      ourKeys.push(key)
+    }
+  }
+  if (ourKeys.length > 0) {
+    removeHookTrustEntries(tomlPath, ourKeys)
+  }
+}
+
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
@@ -876,6 +922,7 @@ function installManagedHooksIntoWslRuntime(
     // Why: WSL runtime homes may carry user hook approvals we did not rebuild
     // here; only upsert Orca's entries instead of sweeping the whole source.
     upsertHookTrustEntries(plan.tomlPath, trustEntries)
+    removeStaleWslRuntimeManagedHookTrustEntries(plan.tomlPath, trustEntries)
   } catch (error) {
     return {
       agent: 'codex',
@@ -922,6 +969,13 @@ function refreshWslRuntimeUserHooks(plan: CodexWslRuntimeHookInstallPlan): Agent
   }
   writeCodexHooksJson(plan.configPath, nextHooks)
   removeWslRuntimeManagedHookTrustEntries(plan)
+  try {
+    // Why: the disabled path may be reached after the WSL mount root changed,
+    // so cleanup cannot be scoped only to the plan's current source path.
+    removeStaleWslRuntimeManagedHookTrustEntries(plan.tomlPath, [])
+  } catch (error) {
+    console.warn('[codex-hook-service] failed to clean stale WSL trust entries', error)
+  }
   return {
     agent: 'codex',
     state: 'not_installed',
@@ -932,11 +986,62 @@ function refreshWslRuntimeUserHooks(plan: CodexWslRuntimeHookInstallPlan): Agent
 }
 
 export class CodexHookService {
+  private readonly wslReconciliationGeneration = new Map<string, number>()
+
+  private supersedeWslReconciliation(runtimeHomePath: string | null | undefined): number {
+    if (!runtimeHomePath) {
+      return 0
+    }
+    const key = process.platform === 'win32' ? runtimeHomePath.toLowerCase() : runtimeHomePath
+    const generation = (this.wslReconciliationGeneration.get(key) ?? 0) + 1
+    this.wslReconciliationGeneration.set(key, generation)
+    return generation
+  }
+
   installForRuntimeHome(
     runtimeHomePath: string | null | undefined,
     target?: CodexWslRuntimeHookTarget
   ): AgentHookInstallStatus | null {
-    const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target)
+    const generation = this.supersedeWslReconciliation(runtimeHomePath)
+    const onCanonicalPathSettled = (canonicalPath: string | null): void => {
+      if (!runtimeHomePath) {
+        return
+      }
+      const key = process.platform === 'win32' ? runtimeHomePath.toLowerCase() : runtimeHomePath
+      // Why: hook settings or account selection can change while wsl.exe is
+      // running; only the newest request may install or revoke runtime trust.
+      if (this.wslReconciliationGeneration.get(key) !== generation) {
+        return
+      }
+      if (!canonicalPath) {
+        try {
+          removeStaleWslRuntimeManagedHookTrustEntries(
+            pathWin32.join(runtimeHomePath, 'config.toml'),
+            []
+          )
+        } catch (error) {
+          console.warn('[codex-hook-service] failed to revoke stale WSL hook trust', error)
+        }
+        return
+      }
+      const resolvedPlan = createCodexWslRuntimeHookInstallPlan(
+        runtimeHomePath,
+        target,
+        () => canonicalPath
+      )
+      if (resolvedPlan) {
+        const status = installManagedHooksIntoWslRuntime(resolvedPlan)
+        if (status.state === 'error') {
+          console.warn('[codex-hook-service] failed to reconcile WSL hook path', status.detail)
+        }
+      }
+    }
+    const wslPlan = createCodexWslRuntimeHookInstallPlan(
+      runtimeHomePath,
+      target,
+      undefined,
+      onCanonicalPathSettled
+    )
     return wslPlan ? installManagedHooksIntoWslRuntime(wslPlan) : null
   }
 
@@ -944,6 +1049,7 @@ export class CodexHookService {
     runtimeHomePath: string | null | undefined,
     target?: CodexWslRuntimeHookTarget
   ): AgentHookInstallStatus | null {
+    this.supersedeWslReconciliation(runtimeHomePath)
     const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target)
     return wslPlan ? refreshWslRuntimeUserHooks(wslPlan) : null
   }
@@ -1413,5 +1519,6 @@ export const codexHookService = new CodexHookService()
 export const _internals = {
   getManagedScript,
   installManagedHooksIntoWslRuntime,
-  refreshWslRuntimeUserHooks
+  refreshWslRuntimeUserHooks,
+  removeStaleWslRuntimeManagedHookTrustEntries
 }

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: getStatus + install + remove all share the managed-command and trust-key derivation. Splitting would hide that the three operations must agree on group index, event label, and command bytes. */
 import { existsSync, readFileSync, unlinkSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, win32 as pathWin32 } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import {
@@ -46,7 +46,8 @@ import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
 import {
   createCodexWslRuntimeHookInstallPlan,
   type CodexWslRuntimeHookInstallPlan,
-  type CodexWslRuntimeHookTarget
+  type CodexWslRuntimeHookTarget,
+  type WslCanonicalPathSettlement
 } from './codex-wsl-hook-install-plan'
 import {
   CODEX_HOOK_EVENT_LABEL,
@@ -985,18 +986,28 @@ function refreshWslRuntimeUserHooks(plan: CodexWslRuntimeHookInstallPlan): Agent
   }
 }
 
-// Why: settle callbacks must not treat a failed recheck as proof the previous
-// identity is wrong. Only a successful, different path may rewrite trust.
-function shouldReinstallWslHooksAfterCanonicalSettle(args: {
-  canonicalPath: string | null
+// Why: transport failures preserve the last known-good identity, while a
+// successful absence probe is strong enough to revoke trust immediately.
+function getWslHookReconciliationAction(args: {
+  settlement: WslCanonicalPathSettlement
   isCurrentGeneration: boolean
   installedTrustConfigPath: string | null
   resolvedTrustConfigPath: string | null
-}): boolean {
-  if (!args.canonicalPath || !args.isCurrentGeneration || !args.resolvedTrustConfigPath) {
-    return false
+}): 'none' | 'remove' | 'reinstall' {
+  if (!args.isCurrentGeneration) {
+    return 'none'
   }
-  return args.resolvedTrustConfigPath !== args.installedTrustConfigPath
+  if (args.settlement.status === 'missing') {
+    return 'remove'
+  }
+  if (
+    args.settlement.status !== 'resolved' ||
+    !args.resolvedTrustConfigPath ||
+    args.resolvedTrustConfigPath === args.installedTrustConfigPath
+  ) {
+    return 'none'
+  }
+  return 'reinstall'
 }
 
 export class CodexHookService {
@@ -1018,23 +1029,40 @@ export class CodexHookService {
   ): AgentHookInstallStatus | null {
     const generation = this.supersedeWslReconciliation(runtimeHomePath)
     let installedTrustConfigPath: string | null = null
-    const onCanonicalPathSettled = (canonicalPath: string | null): void => {
+    const onCanonicalPathSettled = (settlement: WslCanonicalPathSettlement): void => {
       if (!runtimeHomePath) {
         return
       }
       const key = process.platform === 'win32' ? runtimeHomePath.toLowerCase() : runtimeHomePath
-      const resolvedPlan = canonicalPath
-        ? createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target, () => canonicalPath)
-        : null
-      if (
-        !shouldReinstallWslHooksAfterCanonicalSettle({
-          canonicalPath,
-          isCurrentGeneration: this.wslReconciliationGeneration.get(key) === generation,
-          installedTrustConfigPath,
-          resolvedTrustConfigPath: resolvedPlan?.trustConfigPath ?? null
-        }) ||
-        !resolvedPlan
-      ) {
+      const resolvedPlan =
+        settlement.status === 'resolved'
+          ? createCodexWslRuntimeHookInstallPlan(
+              runtimeHomePath,
+              target,
+              () => settlement.canonicalPath
+            )
+          : null
+      const action = getWslHookReconciliationAction({
+        settlement,
+        isCurrentGeneration: this.wslReconciliationGeneration.get(key) === generation,
+        installedTrustConfigPath,
+        resolvedTrustConfigPath: resolvedPlan?.trustConfigPath ?? null
+      })
+      if (action === 'none') {
+        return
+      }
+      if (action === 'remove') {
+        try {
+          removeStaleWslRuntimeManagedHookTrustEntries(
+            pathWin32.join(runtimeHomePath, 'config.toml'),
+            []
+          )
+        } catch (error) {
+          console.warn('[codex-hook-service] failed to revoke stale WSL hook trust', error)
+        }
+        return
+      }
+      if (!resolvedPlan) {
         return
       }
       const status = installManagedHooksIntoWslRuntime(resolvedPlan)
@@ -1530,5 +1558,5 @@ export const _internals = {
   installManagedHooksIntoWslRuntime,
   refreshWslRuntimeUserHooks,
   removeStaleWslRuntimeManagedHookTrustEntries,
-  shouldReinstallWslHooksAfterCanonicalSettle
+  getWslHookReconciliationAction
 }


### PR DESCRIPTION
## Summary
- resolve custom WSL automount hook paths asynchronously without blocking Electron main
- preserve last-known-good trust across transient WSL transport/timeouts
- revoke managed trust when WSL confirms the hook path is missing, and update it when canonical identity changes
- keep WSL/SSH case-sensitive trust identities distinct from native Windows paths

## Validation
- 22 Codex test files: 403 passed, 8 skipped
- focused suite: 108 passed, 3 skipped
- node typecheck, full lint, formatting, max-lines ratchet, diff check
- two fresh adversarial review/fix rounds (P1 and P2 lifecycle fixes)

## Residual risk
Requires Windows CI or live custom-automount WSL confirmation; the review host was macOS.