### PR TITLE
fix(linear): preserve mixed-version RPC filtering compatibility

### DIFF
--- a/mobile/src/transport/rpc-response-shape.test.ts
+++ b/mobile/src/transport/rpc-response-shape.test.ts
@@ -17,4 +17,23 @@ describe('isRpcResponse', () => {
     ).toBe(true)
     expect(isRpcResponse({ id: 'rpc-1', ok: false, error: { code: 'failed' } })).toBe(false)
   })
+
+  it('accepts additive future fields without weakening known-field validation', () => {
+    expect(
+      isRpcResponse({
+        id: 'rpc-1',
+        ok: true,
+        result: { value: 1 },
+        futureEnvelopeField: true
+      })
+    ).toBe(true)
+    expect(
+      isRpcResponse({
+        id: 'rpc-1',
+        ok: false,
+        error: { code: 500, message: 'Nope', futureErrorField: true },
+        futureEnvelopeField: true
+      })
+    ).toBe(false)
+  })
 })

--- a/src/cli/runtime/envelope-schema.test.ts
+++ b/src/cli/runtime/envelope-schema.test.ts
@@ -12,6 +12,26 @@ describe('RuntimeRpcEnvelopeSchema', () => {
     expect(parsed.success).toBe(true)
   })
 
+  it('accepts and strips additive future success fields', () => {
+    const parsed = RuntimeRpcEnvelopeSchema.safeParse({
+      id: 'req-1',
+      ok: true,
+      result: { value: 1, futureResultField: true },
+      futureEnvelopeField: 'new',
+      _meta: { runtimeId: 'runtime-1', futureMetaField: 2 }
+    })
+
+    expect(parsed).toEqual({
+      success: true,
+      data: {
+        id: 'req-1',
+        ok: true,
+        result: { value: 1, futureResultField: true },
+        _meta: { runtimeId: 'runtime-1' }
+      }
+    })
+  })
+
   it('accepts a well-formed failure envelope', () => {
     const parsed = RuntimeRpcEnvelopeSchema.safeParse({
       id: 'req-1',
@@ -37,6 +57,31 @@ describe('RuntimeRpcEnvelopeSchema', () => {
     })
 
     expect(parsed.success).toBe(true)
+  })
+
+  it('accepts and strips additive future failure fields', () => {
+    const parsed = RuntimeRpcEnvelopeSchema.safeParse({
+      id: 'req-1',
+      ok: false,
+      futureEnvelopeField: 'new',
+      error: {
+        code: 'failed',
+        message: 'Nope',
+        data: { retryable: true },
+        futureErrorField: 2
+      },
+      _meta: { runtimeId: 'runtime-1', futureMetaField: 3 }
+    })
+
+    expect(parsed).toEqual({
+      success: true,
+      data: {
+        id: 'req-1',
+        ok: false,
+        error: { code: 'failed', message: 'Nope', data: { retryable: true } },
+        _meta: { runtimeId: 'runtime-1' }
+      }
+    })
   })
 
   it('accepts a failure envelope without _meta', () => {
@@ -67,6 +112,17 @@ describe('RuntimeRpcEnvelopeSchema', () => {
       result: {},
       _meta: { runtimeId: 'runtime-1' }
     })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('still rejects malformed known fields when future fields are present', () => {
+    const parsed = RuntimeRpcEnvelopeSchema.safeParse({
+      id: 'req-1',
+      ok: false,
+      error: { code: 500, message: 'Nope', futureErrorField: true },
+      futureEnvelopeField: 'new'
+    })
+
     expect(parsed.success).toBe(false)
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1364,6 +1364,7 @@ describe('OrcaRuntimeService', () => {
     expect(status.capabilities).toContain('workspace-ports.v1')
     expect(status.capabilities).toContain('mobile.tasks.v1')
     expect(status.capabilities).toContain('project-host-setup.v1')
+    expect(status.capabilities).toContain('linear.issue-attribute-filter.v1')
     expect(status.capabilities).not.toContain('browser.screencast.v1')
     expect(typeof status.protocolVersion).toBe('number')
     expect(typeof status.minCompatibleMobileVersion).toBe('number')

--- a/src/renderer/src/runtime/runtime-linear-client.test.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.test.ts
@@ -368,7 +368,10 @@ describe('runtime linear client', () => {
         assignee: null,
         labelIds: []
       })
-    ).rejects.toThrow('This remote runtime must be updated to filter Linear issues.')
+    ).rejects.toMatchObject({
+      name: 'LinearIssueAttributeFilterUnsupportedError',
+      message: 'This remote runtime must be updated to filter Linear issues.'
+    })
 
     expect(runtimeEnvironmentTransportCall).toHaveBeenCalledTimes(1)
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()

--- a/src/renderer/src/runtime/runtime-linear-client.test.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.test.ts
@@ -18,6 +18,7 @@ import {
   linearUpdateIssue
 } from './runtime-linear-client'
 import {
+  createCompatibleRuntimeStatusResponse,
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
 } from './runtime-compatibility-test-fixture'
@@ -339,6 +340,71 @@ describe('runtime linear client', () => {
       selector: 'env-1',
       method: 'linear.listIssues',
       params: { filter: 'assigned', limit: 20, workspaceId: undefined },
+      timeoutMs: 30_000
+    })
+  })
+
+  it('rejects filtered reads before an older runtime can return unfiltered issues', async () => {
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-list',
+      ok: true,
+      result: { items: [{ id: 'unfiltered-issue' }] },
+      _meta: { runtimeId: 'runtime-old' }
+    })
+    const oldServerStatus = createCompatibleRuntimeStatusResponse('runtime-old')
+    if (oldServerStatus.ok) {
+      oldServerStatus.result.capabilities = oldServerStatus.result.capabilities?.filter(
+        (capability) => capability !== 'linear.issue-attribute-filter.v1'
+      )
+    }
+    runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) =>
+      args.method === 'status.get' ? oldServerStatus : runtimeEnvironmentCall(args)
+    )
+
+    await expect(
+      linearListIssues({ activeRuntimeEnvironmentId: 'env-1' }, 'all', 20, 'workspace-1', {
+        stateIds: ['state-1'],
+        priorities: [],
+        assignee: null,
+        labelIds: []
+      })
+    ).rejects.toThrow('This remote runtime must be updated to filter Linear issues.')
+
+    expect(runtimeEnvironmentTransportCall).toHaveBeenCalledTimes(1)
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
+  it('sends attribute filters to a runtime that advertises support', async () => {
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-list',
+      ok: true,
+      result: { items: [] },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+
+    await expect(
+      linearListIssues({ activeRuntimeEnvironmentId: 'env-1' }, 'all', 20, 'workspace-1', {
+        stateIds: [],
+        priorities: [2],
+        assignee: null,
+        labelIds: []
+      })
+    ).resolves.toEqual({ items: [] })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'linear.listIssues',
+      params: {
+        filter: 'all',
+        limit: 20,
+        workspaceId: 'workspace-1',
+        attributeFilter: {
+          stateIds: [],
+          priorities: [2],
+          assignee: null,
+          labelIds: []
+        }
+      },
       timeoutMs: 30_000
     })
   })

--- a/src/renderer/src/runtime/runtime-linear-client.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.ts
@@ -19,7 +19,11 @@ import type {
   LinearWorkspaceSelection,
   LinearWorkflowState
 } from '../../../shared/types'
-import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
+import {
+  callRuntimeRpc,
+  getActiveRuntimeTarget,
+  runtimeEnvironmentSupportsCapability
+} from './runtime-rpc-client'
 import {
   getTaskSourceRuntimeSettings,
   type TaskSourceContext
@@ -30,6 +34,7 @@ import {
   canonicalizeLinearIssueAttributeFilter,
   isEmptyLinearIssueAttributeFilter
 } from '../../../shared/linear-issue-attribute-filter'
+import { LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 
 export type RuntimeLinearSettings =
   | Pick<GlobalSettings, 'activeRuntimeEnvironmentId'>
@@ -207,6 +212,19 @@ export async function linearListIssues(
     limit,
     workspaceId: workspaceId ?? undefined,
     ...(canonicalAttributeFilter ? { attributeFilter: canonicalAttributeFilter } : {})
+  }
+  if (
+    target.kind === 'environment' &&
+    canonicalAttributeFilter &&
+    !(await runtimeEnvironmentSupportsCapability(
+      target.environmentId,
+      LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY,
+      30_000
+    ))
+  ) {
+    // Why: older runtimes silently strip unknown RPC params; rejecting here
+    // prevents their unfiltered rows from being presented or cached as filtered.
+    throw new Error('This remote runtime must be updated to filter Linear issues.')
   }
   const result =
     target.kind === 'environment'

--- a/src/renderer/src/runtime/runtime-linear-client.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.ts
@@ -42,6 +42,22 @@ export type RuntimeLinearSettings =
   | null
   | undefined
 
+// Why: mixed-version remotes must not look like an empty filtered result. The
+// Linear store swallows most read failures; this typed error is rethrown so UI
+// can show an upgrade message instead of "no matching issues".
+export class LinearIssueAttributeFilterUnsupportedError extends Error {
+  constructor(message = 'This remote runtime must be updated to filter Linear issues.') {
+    super(message)
+    this.name = 'LinearIssueAttributeFilterUnsupportedError'
+  }
+}
+
+export function isLinearIssueAttributeFilterUnsupportedError(
+  error: unknown
+): error is LinearIssueAttributeFilterUnsupportedError {
+  return error instanceof LinearIssueAttributeFilterUnsupportedError
+}
+
 export type LinearIssueFilter = 'assigned' | 'created' | 'all' | 'completed'
 export type LinearConnectResult = { ok: true; viewer: LinearViewer } | { ok: false; error: string }
 export type LinearCreateIssueResult =
@@ -224,7 +240,7 @@ export async function linearListIssues(
   ) {
     // Why: older runtimes silently strip unknown RPC params; rejecting here
     // prevents their unfiltered rows from being presented or cached as filtered.
-    throw new Error('This remote runtime must be updated to filter Linear issues.')
+    throw new LinearIssueAttributeFilterUnsupportedError()
   }
   const result =
     target.kind === 'environment'

--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -5,6 +5,7 @@ import {
   clearRecentRuntimeCompatibilityFailure,
   clearRuntimeCompatibilityCacheForTests,
   getActiveRuntimeTarget,
+  runtimeEnvironmentSupportsCapability,
   RuntimeRpcCallError,
   unwrapRuntimeRpcResult
 } from './runtime-rpc-client'
@@ -454,6 +455,48 @@ describe('runtime RPC client routing', () => {
         'Project setup is unavailable.'
       )
     ).resolves.toBeUndefined()
+  })
+
+  it('re-probes capability support after a failed compatibility cache entry', async () => {
+    let statusCalls = 0
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      if (method === 'status.get') {
+        statusCalls += 1
+        if (statusCalls === 1) {
+          return Promise.resolve({
+            id: 'status',
+            ok: false,
+            error: { code: 'runtime_unavailable', message: 'offline' },
+            _meta: { runtimeId: 'remote-runtime' }
+          })
+        }
+        return Promise.resolve({
+          id: 'status',
+          ok: true,
+          result: {
+            runtimeId: 'remote-runtime',
+            graphStatus: 'ready',
+            runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+            minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+            capabilities: ['linear.issue-attribute-filter.v1']
+          },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      }
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result: { ok: true },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+    const target = { kind: 'environment', environmentId: 'env-cap-recover' } as const
+
+    await expect(callRuntimeRpc(target, 'repo.list')).rejects.toThrow('offline')
+    await expect(
+      runtimeEnvironmentSupportsCapability('env-cap-recover', 'linear.issue-attribute-filter.v1')
+    ).resolves.toBe(true)
+    expect(statusCalls).toBe(2)
   })
 
   it('rejects missing advertised runtime capabilities with the caller message', async () => {

--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -526,6 +526,40 @@ describe('runtime RPC client routing', () => {
     expect(statusCalls).toBe(2)
   })
 
+  it('coalesces concurrent cold-cache capability probes onto one status.get', async () => {
+    let statusCalls = 0
+    runtimeEnvironmentCall.mockImplementation(() => {
+      statusCalls += 1
+      return Promise.resolve({
+        id: 'status',
+        ok: true,
+        result: {
+          runtimeId: 'remote-runtime',
+          graphStatus: 'ready',
+          runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+          minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+          capabilities: ['linear.issue-attribute-filter.v1']
+        },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    const [a, b, c] = await Promise.all([
+      runtimeEnvironmentSupportsCapability(
+        'env-cap-concurrent',
+        'linear.issue-attribute-filter.v1'
+      ),
+      runtimeEnvironmentSupportsCapability(
+        'env-cap-concurrent',
+        'linear.issue-attribute-filter.v1'
+      ),
+      runtimeEnvironmentSupportsCapability('env-cap-concurrent', 'linear.issue-attribute-filter.v1')
+    ])
+
+    expect([a, b, c]).toEqual([true, true, true])
+    expect(statusCalls).toBe(1)
+  })
+
   it('expires a supported capability verdict so a runtime downgrade is detected', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(0))

--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -499,6 +499,80 @@ describe('runtime RPC client routing', () => {
     expect(statusCalls).toBe(2)
   })
 
+  it('re-probes a missing capability on retry so a runtime upgrade can recover', async () => {
+    let statusCalls = 0
+    runtimeEnvironmentCall.mockImplementation(() => {
+      statusCalls += 1
+      return Promise.resolve({
+        id: 'status',
+        ok: true,
+        result: {
+          runtimeId: 'remote-runtime',
+          graphStatus: 'ready',
+          runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+          minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+          capabilities: statusCalls === 1 ? [] : ['linear.issue-attribute-filter.v1']
+        },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    await expect(
+      runtimeEnvironmentSupportsCapability('env-cap-upgrade', 'linear.issue-attribute-filter.v1')
+    ).resolves.toBe(false)
+    await expect(
+      runtimeEnvironmentSupportsCapability('env-cap-upgrade', 'linear.issue-attribute-filter.v1')
+    ).resolves.toBe(true)
+    expect(statusCalls).toBe(2)
+  })
+
+  it('expires a supported capability verdict so a runtime downgrade is detected', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(0))
+    try {
+      let statusCalls = 0
+      runtimeEnvironmentCall.mockImplementation(() => {
+        statusCalls += 1
+        return Promise.resolve({
+          id: 'status',
+          ok: true,
+          result: {
+            runtimeId: 'remote-runtime',
+            graphStatus: 'ready',
+            runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+            minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+            capabilities: statusCalls === 1 ? ['linear.issue-attribute-filter.v1'] : []
+          },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      })
+
+      await expect(
+        runtimeEnvironmentSupportsCapability(
+          'env-cap-downgrade',
+          'linear.issue-attribute-filter.v1'
+        )
+      ).resolves.toBe(true)
+      vi.setSystemTime(new Date(59_999))
+      await expect(
+        runtimeEnvironmentSupportsCapability(
+          'env-cap-downgrade',
+          'linear.issue-attribute-filter.v1'
+        )
+      ).resolves.toBe(true)
+      vi.setSystemTime(new Date(60_000))
+      await expect(
+        runtimeEnvironmentSupportsCapability(
+          'env-cap-downgrade',
+          'linear.issue-attribute-filter.v1'
+        )
+      ).resolves.toBe(false)
+      expect(statusCalls).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('rejects missing advertised runtime capabilities with the caller message', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'status',

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -16,6 +16,7 @@ type RuntimeCompatibilityCacheEntry = {
   // True only once status.get settled and proved compatible. Stays false while
   // the probe is in flight, so a recovery clear can drop a doomed pending probe.
   provenCompatible: boolean
+  status: RuntimeStatus | null
 }
 
 const runtimeCompatibilityChecks = new Map<string, RuntimeCompatibilityCacheEntry>()
@@ -108,7 +109,8 @@ async function ensureRuntimeEnvironmentCompatible(
   const entry: RuntimeCompatibilityCacheEntry = {
     check: Promise.resolve(),
     failedAt: null,
-    provenCompatible: false
+    provenCompatible: false,
+    status: null
   }
   const check = (async () => {
     const response = await window.api.runtimeEnvironments.call({
@@ -120,6 +122,7 @@ async function ensureRuntimeEnvironmentCompatible(
       response as RuntimeRpcResponse<RuntimeStatus>
     )
     assertRuntimeStatusCompatible(status)
+    entry.status = status
   })()
   entry.check = check
   rememberRuntimeEnvironmentCompatibility(environmentId, entry)
@@ -211,7 +214,8 @@ export function markRuntimeEnvironmentCompatible(environmentId: string): void {
   rememberRuntimeEnvironmentCompatibility(trimmed, {
     check: Promise.resolve(),
     failedAt: null,
-    provenCompatible: true
+    provenCompatible: true,
+    status: null
   })
 }
 
@@ -228,8 +232,30 @@ export async function getRuntimeEnvironmentStatus(
     response as RuntimeRpcResponse<RuntimeStatus>
   )
   assertRuntimeStatusCompatible(status)
-  markRuntimeEnvironmentCompatible(environmentId)
+  rememberRuntimeEnvironmentCompatibility(environmentId.trim(), {
+    check: Promise.resolve(),
+    failedAt: null,
+    provenCompatible: true,
+    status
+  })
   return status
+}
+
+export async function runtimeEnvironmentSupportsCapability(
+  environmentId: string,
+  capability: RuntimeCapability,
+  timeoutMs?: number
+): Promise<boolean> {
+  const trimmed = environmentId.trim()
+  const cached = runtimeCompatibilityChecks.get(trimmed)
+  if (cached) {
+    await cached.check
+    if (cached.status) {
+      return cached.status.capabilities?.includes(capability) === true
+    }
+  }
+  const status = await getRuntimeEnvironmentStatus(trimmed, timeoutMs)
+  return status.capabilities?.includes(capability) === true
 }
 
 export async function assertRuntimeEnvironmentCapability(

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -248,10 +248,17 @@ export async function runtimeEnvironmentSupportsCapability(
 ): Promise<boolean> {
   const trimmed = environmentId.trim()
   const cached = runtimeCompatibilityChecks.get(trimmed)
-  if (cached) {
-    await cached.check
-    if (cached.status) {
-      return cached.status.capabilities?.includes(capability) === true
+  // Why: callRuntimeRpc re-probes after failed status checks by default. Capability
+  // lookups must not pin to a rejected cache promise or they block recovery for
+  // the full failure TTL even though the next RPC would re-probe successfully.
+  if (cached && cached.failedAt === null) {
+    try {
+      await cached.check
+      if (cached.status) {
+        return cached.status.capabilities?.includes(capability) === true
+      }
+    } catch {
+      // Fall through to a fresh status.get that refreshes the cache.
     }
   }
   const status = await getRuntimeEnvironmentStatus(trimmed, timeoutMs)

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -230,23 +230,48 @@ export async function getRuntimeEnvironmentStatus(
   environmentId: string,
   timeoutMs?: number
 ): Promise<RuntimeStatus> {
-  const response = await window.api.runtimeEnvironments.call({
-    selector: environmentId,
-    method: 'status.get',
-    timeoutMs
-  })
-  const status = unwrapRuntimeRpcResult<RuntimeStatus>(
-    response as RuntimeRpcResponse<RuntimeStatus>
-  )
-  assertRuntimeStatusCompatible(status)
-  rememberRuntimeEnvironmentCompatibility(environmentId.trim(), {
+  const trimmed = environmentId.trim()
+  const entry: RuntimeCompatibilityCacheEntry = {
     check: Promise.resolve(),
     failedAt: null,
-    provenCompatible: true,
-    status,
-    statusCheckedAt: Date.now()
-  })
-  return status
+    provenCompatible: false,
+    status: null,
+    statusCheckedAt: null
+  }
+  // Why: publish the in-flight probe before awaiting so concurrent cold-cache
+  // capability lookups coalesce onto this one status.get (via the cache-hit path
+  // in runtimeEnvironmentSupportsCapability) instead of each firing their own.
+  const check = (async () => {
+    const response = await window.api.runtimeEnvironments.call({
+      selector: trimmed,
+      method: 'status.get',
+      timeoutMs
+    })
+    const status = unwrapRuntimeRpcResult<RuntimeStatus>(
+      response as RuntimeRpcResponse<RuntimeStatus>
+    )
+    assertRuntimeStatusCompatible(status)
+    entry.status = status
+    entry.statusCheckedAt = Date.now()
+    entry.provenCompatible = true
+  })()
+  entry.check = check
+  rememberRuntimeEnvironmentCompatibility(trimmed, entry)
+  try {
+    await check
+  } catch (error) {
+    // Why: this probe always re-fetches, so a failure must not linger as a
+    // cached verdict; drop the entry so the next call re-probes cleanly.
+    if (runtimeCompatibilityChecks.get(trimmed) === entry) {
+      runtimeCompatibilityChecks.delete(trimmed)
+    }
+    throw error
+  }
+  if (!entry.status) {
+    // Unreachable: a resolved probe always assigns status; narrows the type.
+    throw new Error('Runtime status probe resolved without a status.')
+  }
+  return entry.status
 }
 
 export async function runtimeEnvironmentSupportsCapability(

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -9,6 +9,9 @@ export type RuntimeClientTarget = { kind: 'local' } | { kind: 'environment'; env
 
 const RUNTIME_COMPATIBILITY_CACHE_MAX = 32
 const RECENT_RUNTIME_COMPATIBILITY_FAILURE_TTL_MS = 60_000
+// Why: a saved environment can restart into a different Orca version without
+// changing ids; capability verdicts must eventually follow that version change.
+const RUNTIME_CAPABILITY_STATUS_TTL_MS = 60_000
 
 type RuntimeCompatibilityCacheEntry = {
   check: Promise<void>
@@ -17,6 +20,7 @@ type RuntimeCompatibilityCacheEntry = {
   // the probe is in flight, so a recovery clear can drop a doomed pending probe.
   provenCompatible: boolean
   status: RuntimeStatus | null
+  statusCheckedAt: number | null
 }
 
 const runtimeCompatibilityChecks = new Map<string, RuntimeCompatibilityCacheEntry>()
@@ -110,7 +114,8 @@ async function ensureRuntimeEnvironmentCompatible(
     check: Promise.resolve(),
     failedAt: null,
     provenCompatible: false,
-    status: null
+    status: null,
+    statusCheckedAt: null
   }
   const check = (async () => {
     const response = await window.api.runtimeEnvironments.call({
@@ -123,6 +128,7 @@ async function ensureRuntimeEnvironmentCompatible(
     )
     assertRuntimeStatusCompatible(status)
     entry.status = status
+    entry.statusCheckedAt = Date.now()
   })()
   entry.check = check
   rememberRuntimeEnvironmentCompatibility(environmentId, entry)
@@ -215,7 +221,8 @@ export function markRuntimeEnvironmentCompatible(environmentId: string): void {
     check: Promise.resolve(),
     failedAt: null,
     provenCompatible: true,
-    status: null
+    status: null,
+    statusCheckedAt: null
   })
 }
 
@@ -236,7 +243,8 @@ export async function getRuntimeEnvironmentStatus(
     check: Promise.resolve(),
     failedAt: null,
     provenCompatible: true,
-    status
+    status,
+    statusCheckedAt: Date.now()
   })
   return status
 }
@@ -254,15 +262,30 @@ export async function runtimeEnvironmentSupportsCapability(
   if (cached && cached.failedAt === null) {
     try {
       await cached.check
-      if (cached.status) {
-        return cached.status.capabilities?.includes(capability) === true
+      if (
+        runtimeCompatibilityChecks.get(trimmed) === cached &&
+        cached.status &&
+        cached.statusCheckedAt !== null &&
+        Date.now() - cached.statusCheckedAt < RUNTIME_CAPABILITY_STATUS_TTL_MS
+      ) {
+        const supported = cached.status.capabilities?.includes(capability) === true
+        if (!supported) {
+          // Why: an unsupported verdict must not survive a remote upgrade. The
+          // next explicit retry re-probes instead of pinning the old capability set.
+          runtimeCompatibilityChecks.delete(trimmed)
+        }
+        return supported
       }
     } catch {
       // Fall through to a fresh status.get that refreshes the cache.
     }
   }
   const status = await getRuntimeEnvironmentStatus(trimmed, timeoutMs)
-  return status.capabilities?.includes(capability) === true
+  const supported = status.capabilities?.includes(capability) === true
+  if (!supported && runtimeCompatibilityChecks.get(trimmed)?.status === status) {
+    runtimeCompatibilityChecks.delete(trimmed)
+  }
+  return supported
 }
 
 export async function assertRuntimeEnvironmentCapability(

--- a/src/renderer/src/store/slices/linear-invalidation.test.ts
+++ b/src/renderer/src/store/slices/linear-invalidation.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/runtime/runtime-linear-client', () => ({
   linearDisconnect: vi.fn(),
   linearDisconnectWorkspace: vi.fn(),
   linearGetIssue: (...args: unknown[]) => linearGetIssue(...args),
+  isLinearIssueAttributeFilterUnsupportedError: () => false,
   linearListIssues: (...args: unknown[]) => linearListIssues(...args),
   linearListTeams: (...args: unknown[]) => linearListTeams(...args),
   linearSearchIssues: (...args: unknown[]) => linearSearchIssues(...args),

--- a/src/renderer/src/store/slices/linear.test.ts
+++ b/src/renderer/src/store/slices/linear.test.ts
@@ -17,6 +17,7 @@ import {
   type TaskSourceContext
 } from '../../../../shared/task-source-context'
 import { credentialDecryptionMessage } from '../../../../shared/integration-credential-errors'
+import { LinearIssueAttributeFilterUnsupportedError } from '@/runtime/runtime-linear-client'
 import { createLinearSlice } from './linear'
 
 const linearStatus = vi.fn()
@@ -35,25 +36,29 @@ const linearListCustomViewIssues = vi.fn()
 const linearListCustomViewProjects = vi.fn()
 const linearTestConnection = vi.fn()
 
-vi.mock('@/runtime/runtime-linear-client', () => ({
-  linearConnect: (...args: unknown[]) => linearConnect(...args),
-  linearDisconnect: (...args: unknown[]) => linearDisconnect(...args),
-  linearDisconnectWorkspace: vi.fn(),
-  linearGetCustomView: (...args: unknown[]) => linearGetCustomView(...args),
-  linearGetProject: (...args: unknown[]) => linearGetProject(...args),
-  linearGetIssue: (...args: unknown[]) => linearGetIssue(...args),
-  linearListCustomViewIssues: (...args: unknown[]) => linearListCustomViewIssues(...args),
-  linearListCustomViewProjects: (...args: unknown[]) => linearListCustomViewProjects(...args),
-  linearListCustomViews: (...args: unknown[]) => linearListCustomViews(...args),
-  linearListIssues: (...args: unknown[]) => linearListIssues(...args),
-  linearListProjectIssues: (...args: unknown[]) => linearListProjectIssues(...args),
-  linearListProjects: (...args: unknown[]) => linearListProjects(...args),
-  linearListTeams: (...args: unknown[]) => linearListTeams(...args),
-  linearSearchIssues: (...args: unknown[]) => linearSearchIssues(...args),
-  linearSelectWorkspace: vi.fn(),
-  linearStatus: (...args: unknown[]) => linearStatus(...args),
-  linearTestConnection: (...args: unknown[]) => linearTestConnection(...args)
-}))
+vi.mock('@/runtime/runtime-linear-client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    linearConnect: (...args: unknown[]) => linearConnect(...args),
+    linearDisconnect: (...args: unknown[]) => linearDisconnect(...args),
+    linearDisconnectWorkspace: vi.fn(),
+    linearGetCustomView: (...args: unknown[]) => linearGetCustomView(...args),
+    linearGetProject: (...args: unknown[]) => linearGetProject(...args),
+    linearGetIssue: (...args: unknown[]) => linearGetIssue(...args),
+    linearListCustomViewIssues: (...args: unknown[]) => linearListCustomViewIssues(...args),
+    linearListCustomViewProjects: (...args: unknown[]) => linearListCustomViewProjects(...args),
+    linearListCustomViews: (...args: unknown[]) => linearListCustomViews(...args),
+    linearListIssues: (...args: unknown[]) => linearListIssues(...args),
+    linearListProjectIssues: (...args: unknown[]) => linearListProjectIssues(...args),
+    linearListProjects: (...args: unknown[]) => linearListProjects(...args),
+    linearListTeams: (...args: unknown[]) => linearListTeams(...args),
+    linearSearchIssues: (...args: unknown[]) => linearSearchIssues(...args),
+    linearSelectWorkspace: vi.fn(),
+    linearStatus: (...args: unknown[]) => linearStatus(...args),
+    linearTestConnection: (...args: unknown[]) => linearTestConnection(...args)
+  }
+})
 
 vi.mock('../../hooks/useIssueMetadata', () => ({
   clearLinearMetadataCache: vi.fn()
@@ -272,6 +277,50 @@ describe('createLinearSlice caching', () => {
     await expect(
       store.getState().listLinearIssues({ kind: 'list', filter: 'all', limit: 36 }, { force: true })
     ).resolves.toMatchObject({ items: [{ id: 'LIN-CACHED' }] })
+  })
+
+  it('rethrows attribute-filter unsupported errors so UI can surface an upgrade message', async () => {
+    const store = createTestStore()
+    store.setState({
+      linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' }
+    })
+    const attributeFilter = {
+      stateIds: ['state-1'],
+      priorities: [] as number[],
+      assignee: null as null,
+      labelIds: [] as string[]
+    }
+    // Seed via a successful read so the cache key matches production signing.
+    linearListIssues.mockResolvedValueOnce({ items: [issue('LIN-CACHED')] })
+    await store.getState().listLinearIssues({
+      kind: 'list',
+      filter: 'all',
+      limit: 36,
+      attributeFilter
+    })
+    linearListIssues.mockRejectedValueOnce(new LinearIssueAttributeFilterUnsupportedError())
+
+    await expect(
+      store.getState().listLinearIssues(
+        {
+          kind: 'list',
+          filter: 'all',
+          limit: 36,
+          attributeFilter
+        },
+        { force: true }
+      )
+    ).rejects.toBeInstanceOf(LinearIssueAttributeFilterUnsupportedError)
+
+    // Why: must not replace a warm filtered cache with empty on capability miss.
+    expect(
+      store.getState().getCachedLinearIssues({
+        kind: 'list',
+        filter: 'all',
+        limit: 36,
+        attributeFilter
+      })
+    ).toMatchObject({ items: [{ id: 'LIN-CACHED' }] })
   })
 
   it('returns an empty list and refreshes status on Linear decrypt errors during list reads', async () => {

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -22,6 +22,7 @@ import { clampLinearIssueListLimit } from '../../../../shared/linear-issue-read-
 import { isIntegrationCredentialDecryptionError } from '../../../../shared/integration-credential-errors'
 import { clearLinearMetadataCache } from '../../hooks/useIssueMetadata'
 import {
+  isLinearIssueAttributeFilterUnsupportedError,
   linearConnect,
   linearDisconnect,
   linearDisconnectWorkspace,
@@ -1238,6 +1239,11 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       })
       .catch((error) => {
         console.warn('[linear] listLinearIssues failed:', error)
+        // Why: capability mismatch is actionable (update remote runtime). Swallowing
+        // it as [] would look like "no issues match filters" and hide the fix.
+        if (isLinearIssueAttributeFilterUnsupportedError(error)) {
+          throw error
+        }
         if (
           (isIntegrationCredentialDecryptionError(error) || looksLikeAuthError(error)) &&
           canWriteLinearReadResult(

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -27,6 +27,8 @@ export const WORKSPACE_RUN_CONTEXT_RUNTIME_CAPABILITY = 'workspace-run-context.v
 export const REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY = 'remote-runtime.shared-control.v1' as const
 export const FOLDER_WORKSPACE_PATH_STATUS_RUNTIME_CAPABILITY =
   'folder-workspace.path-status.v1' as const
+export const LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY =
+  'linear.issue-attribute-filter.v1' as const
 // Why: signals the host exposes the Agent Session History scanner over RPC
 // (aiVault.listSessions). Registered unconditionally for every build, so it is a
 // STATIC capability advertised by getStatus() automatically — NOT a runtime
@@ -50,6 +52,7 @@ export const RUNTIME_CAPABILITIES = [
   TASK_SOURCE_CONTEXT_RUNTIME_CAPABILITY,
   WORKSPACE_RUN_CONTEXT_RUNTIME_CAPABILITY,
   FOLDER_WORKSPACE_PATH_STATUS_RUNTIME_CAPABILITY,
+  LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY,
   AI_VAULT_RUNTIME_CAPABILITY
 ] as const
 

--- a/src/shared/runtime-rpc-envelope.ts
+++ b/src/shared/runtime-rpc-envelope.ts
@@ -3,37 +3,50 @@
 // other just to validate the shared RPC frame shape.
 import { z } from 'zod'
 
-const MetaSuccess = z.object({
-  runtimeId: z.string()
-})
+// Why: clients and runtimes update independently; strip additive envelope
+// fields while continuing to validate every known discriminator and field.
+const MetaSuccess = z
+  .object({
+    runtimeId: z.string()
+  })
+  .strip()
 
 const MetaFailure = z
   .object({
     runtimeId: z.union([z.string(), z.null()])
   })
+  .strip()
   .optional()
 
-const Success = z.object({
-  id: z.string(),
-  ok: z.literal(true),
-  result: z.unknown(),
-  _meta: MetaSuccess
-})
+const Success = z
+  .object({
+    id: z.string(),
+    ok: z.literal(true),
+    result: z.unknown(),
+    _meta: MetaSuccess
+  })
+  .strip()
 
-const Failure = z.object({
-  id: z.string(),
-  ok: z.literal(false),
-  error: z.object({
-    code: z.string(),
-    message: z.string(),
-    data: z.unknown().optional()
-  }),
-  _meta: MetaFailure
-})
+const Failure = z
+  .object({
+    id: z.string(),
+    ok: z.literal(false),
+    error: z
+      .object({
+        code: z.string(),
+        message: z.string(),
+        data: z.unknown().optional()
+      })
+      .strip(),
+    _meta: MetaFailure
+  })
+  .strip()
 
-const Keepalive = z.object({
-  _keepalive: z.literal(true)
-})
+const Keepalive = z
+  .object({
+    _keepalive: z.literal(true)
+  })
+  .strip()
 
 export const RuntimeRpcEnvelopeSchema = z.union([Success, Failure, Keepalive])
 


### PR DESCRIPTION
## Summary
- prevent old servers that ignore `attributeFilter` from returning silently incorrect filtered Linear results
- accept additive future RPC response fields while retaining required-field validation
- recover capability checks after transient status failures and refresh cached verdicts across server upgrades/downgrades
- surface typed capability failures instead of showing an empty issue list

## Validation
- 687 focused desktop tests, 3 mobile tests, 22 post-commit cache tests
- full node/CLI/web typecheck, targeted desktop/mobile oxlint, formatting, max-lines ratchet, diff check
- two fresh adversarial review/fix rounds (two P1s and one P2 fixed)

## Residual risk
No remaining material mixed-version, SSH, mobile, or provider risk was identified by the final reviewer.