### PR TITLE
fix(cleanup): reconcile authoritative late removal results

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -617,6 +617,28 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
         }
         removalInFlightRef.current = false
       },
+      onLateResult: (result) => {
+        if (!mountedRef.current) {
+          return
+        }
+        setRowFailures((current) => {
+          const next = { ...current }
+          for (const id of result.removedIds) {
+            delete next[id]
+          }
+          for (const failure of result.failures) {
+            next[failure.worktreeId] = failure.message
+          }
+          return next
+        })
+        setSelectedIds((current) => {
+          const next = new Set(current)
+          for (const id of result.removedIds) {
+            next.delete(id)
+          }
+          return next
+        })
+      },
       onError: () => {
         for (const candidate of removableCandidates) {
           clearWorktreeDeleteState(candidate.worktreeId)

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal-late-settlement.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal-late-settlement.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { startWorkspaceCleanupBackgroundRemoval } from './workspace-cleanup-background-removal'
+import { makeCandidate } from './workspace-cleanup-presentation-fixtures'
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn()
+  }
+}))
+
+async function settleBackgroundRemoval(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('workspace cleanup late settlement reconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses a post-grace child success that arrives before its parent is considered', async () => {
+    const parent = makeCandidate({
+      worktreeId: 'repo-1::/repo/p',
+      displayName: 'parent',
+      branch: 'parent',
+      path: '/repo/p'
+    })
+    const child = makeCandidate({
+      worktreeId: 'repo-1::/repo/p/child-long',
+      displayName: 'child',
+      branch: 'child',
+      path: '/repo/p/child-long'
+    })
+    const unrelated = makeCandidate({
+      worktreeId: 'repo-1::/repo/other',
+      displayName: 'other',
+      branch: 'other',
+      path: '/repo/other'
+    })
+    let resolveChild: (result: { removedIds: string[]; failures: [] }) => void = () => {}
+    let resolveUnrelated: (result: { removedIds: string[]; failures: [] }) => void = () => {}
+    const removeCandidates = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ removedIds: string[]; failures: [] }>((resolve) => {
+            resolveChild = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ removedIds: string[]; failures: [] }>((resolve) => {
+            resolveUnrelated = resolve
+          })
+      )
+      .mockResolvedValueOnce({ removedIds: [parent.worktreeId], failures: [] })
+    const onResult = vi.fn()
+
+    startWorkspaceCleanupBackgroundRemoval({
+      candidates: [parent, unrelated, child],
+      removeCandidates,
+      onProgress: vi.fn(),
+      onResult,
+      removalTimeoutMs: 5,
+      removalSettlementGraceMs: 5
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(removeCandidates).toHaveBeenCalledTimes(2)
+    resolveChild({ removedIds: [child.worktreeId], failures: [] })
+    await settleBackgroundRemoval()
+    resolveUnrelated({ removedIds: [unrelated.worktreeId], failures: [] })
+    await settleBackgroundRemoval()
+
+    expect(removeCandidates).toHaveBeenNthCalledWith(3, [parent.worktreeId], {
+      approvedCandidates: [parent]
+    })
+    expect(onResult).toHaveBeenCalledWith({
+      removedIds: [child.worktreeId, unrelated.worktreeId, parent.worktreeId],
+      failures: []
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts
@@ -425,7 +425,7 @@ describe('startWorkspaceCleanupBackgroundRemoval', () => {
     })
   })
 
-  it('reports an unresolved timeout and skips its parent', async () => {
+  it('reports a timeout, skips its parent, then reports the authoritative result', async () => {
     vi.useFakeTimers()
     const parent = makeCandidate({
       worktreeId: 'repo-1::/repo/parent',
@@ -439,20 +439,23 @@ describe('startWorkspaceCleanupBackgroundRemoval', () => {
       branch: 'child',
       path: '/repo/parent/child'
     })
+    let resolveChild: (result: { removedIds: string[]; failures: [] }) => void = () => {}
     const removeCandidates = vi.fn(
       () =>
-        new Promise<Awaited<ReturnType<WorkspaceCleanupBackgroundRemovalArgs['removeCandidates']>>>(
-          () => undefined
-        )
+        new Promise<{ removedIds: string[]; failures: [] }>((resolve) => {
+          resolveChild = resolve
+        })
     )
     const onProgress = vi.fn()
     const onResult = vi.fn()
+    const onLateResult = vi.fn()
 
     startWorkspaceCleanupBackgroundRemoval({
       candidates: [parent, child],
       removeCandidates,
       onProgress,
       onResult,
+      onLateResult,
       removalTimeoutMs: 5,
       removalSettlementGraceMs: 5
     })
@@ -485,6 +488,51 @@ describe('startWorkspaceCleanupBackgroundRemoval', () => {
         }
       ]
     })
+
+    resolveChild({ removedIds: [child.worktreeId], failures: [] })
+    await settleBackgroundRemoval()
+
+    expect(removeCandidates).toHaveBeenCalledTimes(1)
+    expect(onResult).toHaveBeenCalledTimes(1)
+    expect(onLateResult).toHaveBeenCalledWith({
+      removedIds: [child.worktreeId],
+      failures: []
+    })
+    expect(toast.success).toHaveBeenLastCalledWith('Removed workspaces: 1')
+  })
+
+  it('reports an authoritative rejection after the timeout result', async () => {
+    vi.useFakeTimers()
+    const candidate = makeCandidate()
+    let rejectRemoval: (error: Error) => void = () => {}
+    const onLateResult = vi.fn()
+
+    startWorkspaceCleanupBackgroundRemoval({
+      candidates: [candidate],
+      removeCandidates: vi.fn(
+        () =>
+          new Promise<{ removedIds: string[]; failures: [] }>((_resolve, reject) => {
+            rejectRemoval = reject
+          })
+      ),
+      onProgress: vi.fn(),
+      onLateResult,
+      removalTimeoutMs: 5,
+      removalSettlementGraceMs: 5
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+    rejectRemoval(new Error('remote removal failed'))
+    await settleBackgroundRemoval()
+
+    expect(onLateResult).toHaveBeenCalledWith({
+      removedIds: [],
+      failures: [expect.objectContaining({ message: 'remote removal failed' })]
+    })
+    expect(toast.error).toHaveBeenLastCalledWith(
+      'Workspaces not removed: 1',
+      expect.objectContaining({ description: 'remote removal failed' })
+    )
   })
 
   it('keeps removal outcome toasts when the result callback throws', async () => {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.test.ts
@@ -322,42 +322,166 @@ describe('startWorkspaceCleanupBackgroundRemoval', () => {
     )
   })
 
-  it('times out a stalled row removal and continues reporting progress', async () => {
+  it('uses a success confirmed after the initial timeout and proceeds with its parent', async () => {
     vi.useFakeTimers()
-    const candidate = makeCandidate()
+    const parent = makeCandidate({
+      worktreeId: 'repo-1::/repo/parent',
+      displayName: 'parent',
+      branch: 'parent',
+      path: '/repo/parent'
+    })
+    const child = makeCandidate({
+      worktreeId: 'repo-1::/repo/parent/child',
+      displayName: 'child',
+      branch: 'child',
+      path: '/repo/parent/child'
+    })
+    let resolveChild: (result: { removedIds: string[]; failures: [] }) => void = () => {}
+    const removeCandidates = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ removedIds: string[]; failures: [] }>((resolve) => {
+            resolveChild = resolve
+          })
+      )
+      .mockResolvedValueOnce({ removedIds: [parent.worktreeId], failures: [] })
+    const onResult = vi.fn()
+
+    startWorkspaceCleanupBackgroundRemoval({
+      candidates: [parent, child],
+      removeCandidates,
+      onProgress: vi.fn(),
+      onResult,
+      removalTimeoutMs: 5,
+      removalSettlementGraceMs: 5
+    })
+
+    await vi.advanceTimersByTimeAsync(5)
+    resolveChild({ removedIds: [child.worktreeId], failures: [] })
+    await settleBackgroundRemoval()
+
+    expect(removeCandidates).toHaveBeenNthCalledWith(2, [parent.worktreeId], {
+      approvedCandidates: [parent]
+    })
+    expect(onResult).toHaveBeenCalledWith({
+      removedIds: [child.worktreeId, parent.worktreeId],
+      failures: []
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('reports a definitive late failure and skips its parent', async () => {
+    vi.useFakeTimers()
+    const parent = makeCandidate({
+      worktreeId: 'repo-1::C:\\repo\\parent',
+      displayName: 'parent',
+      branch: 'parent',
+      path: 'C:\\repo\\parent'
+    })
+    const child = makeCandidate({
+      worktreeId: 'repo-1::C:\\repo\\parent\\child',
+      displayName: 'child',
+      branch: 'child',
+      path: 'C:\\repo\\parent\\child'
+    })
+    let rejectChild: (error: Error) => void = () => {}
+    const removeCandidates = vi.fn(
+      () =>
+        new Promise<{ removedIds: string[]; failures: [] }>((_resolve, reject) => {
+          rejectChild = reject
+        })
+    )
+    const onResult = vi.fn()
+
+    startWorkspaceCleanupBackgroundRemoval({
+      candidates: [parent, child],
+      removeCandidates,
+      onProgress: vi.fn(),
+      onResult,
+      removalTimeoutMs: 5,
+      removalSettlementGraceMs: 5
+    })
+
+    await vi.advanceTimersByTimeAsync(5)
+    rejectChild(new Error('remote removal failed'))
+    await settleBackgroundRemoval()
+
+    expect(removeCandidates).toHaveBeenCalledTimes(1)
+    expect(onResult).toHaveBeenCalledWith({
+      removedIds: [],
+      failures: [
+        {
+          worktreeId: child.worktreeId,
+          displayName: child.displayName,
+          message: 'remote removal failed'
+        },
+        {
+          worktreeId: parent.worktreeId,
+          displayName: parent.displayName,
+          message: 'Skipped because a nested workspace could not be removed.'
+        }
+      ]
+    })
+  })
+
+  it('reports an unresolved timeout and skips its parent', async () => {
+    vi.useFakeTimers()
+    const parent = makeCandidate({
+      worktreeId: 'repo-1::/repo/parent',
+      displayName: 'parent',
+      branch: 'parent',
+      path: '/repo/parent'
+    })
+    const child = makeCandidate({
+      worktreeId: 'repo-1::/repo/parent/child',
+      displayName: 'child',
+      branch: 'child',
+      path: '/repo/parent/child'
+    })
+    const removeCandidates = vi.fn(
+      () =>
+        new Promise<Awaited<ReturnType<WorkspaceCleanupBackgroundRemovalArgs['removeCandidates']>>>(
+          () => undefined
+        )
+    )
     const onProgress = vi.fn()
     const onResult = vi.fn()
 
     startWorkspaceCleanupBackgroundRemoval({
-      candidates: [candidate],
-      removeCandidates: vi.fn(
-        () =>
-          new Promise<
-            Awaited<ReturnType<WorkspaceCleanupBackgroundRemovalArgs['removeCandidates']>>
-          >(() => undefined)
-      ),
+      candidates: [parent, child],
+      removeCandidates,
       onProgress,
       onResult,
-      removalTimeoutMs: 5
+      removalTimeoutMs: 5,
+      removalSettlementGraceMs: 5
     })
 
     await vi.advanceTimersByTimeAsync(5)
+    expect(onResult).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(5)
     await settleBackgroundRemoval()
 
+    expect(removeCandidates).toHaveBeenCalledTimes(1)
     expect(onProgress).toHaveBeenLastCalledWith({
-      totalCount: 1,
-      processedCount: 1,
+      totalCount: 2,
+      processedCount: 2,
       removedCount: 0,
-      failedCount: 1
+      failedCount: 2
     })
     expect(onResult).toHaveBeenCalledWith({
       removedIds: [],
       failures: [
         {
-          worktreeId: candidate.worktreeId,
-          displayName: candidate.displayName,
+          worktreeId: child.worktreeId,
+          displayName: child.displayName,
           message:
-            'Removing alpha is taking longer than expected. It will keep running in the background.'
+            'Removing child is taking longer than expected. It will keep running in the background.'
+        },
+        {
+          worktreeId: parent.worktreeId,
+          displayName: parent.displayName,
+          message: 'Skipped because a nested workspace could not be removed.'
         }
       ]
     })

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.ts
@@ -10,17 +10,14 @@ import type {
   WorkspaceCleanupRemoveResult
 } from '@/store/slices/workspace-cleanup'
 import { translate } from '@/i18n/i18n'
+import {
+  getWorkspaceCleanupTimeoutFailure,
+  trackWorkspaceCleanupLateSettlement,
+  waitForWorkspaceCleanupRemovalWithTimeout
+} from './workspace-cleanup-removal-settlement'
 
 const DEFAULT_WORKSPACE_CLEANUP_REMOVAL_TIMEOUT_MS = 120_000
 const DEFAULT_WORKSPACE_CLEANUP_SETTLEMENT_GRACE_MS = 5_000
-
-type WorkspaceCleanupRemovalSettlement =
-  | { status: 'fulfilled'; result: WorkspaceCleanupRemoveResult }
-  | { status: 'rejected'; error: unknown }
-
-type WorkspaceCleanupRemovalWaitResult =
-  | WorkspaceCleanupRemovalSettlement
-  | { status: 'unresolved' }
 
 export type WorkspaceCleanupRemovalProgress = {
   totalCount: number
@@ -37,6 +34,9 @@ export type WorkspaceCleanupBackgroundRemovalArgs = {
   ) => Promise<WorkspaceCleanupRemoveResult>
   onProgress: (progress: WorkspaceCleanupRemovalProgress) => void
   onResult?: (result: WorkspaceCleanupRemoveResult) => void
+  // Why: the timeout is provisional because renderer IPC cannot be cancelled;
+  // consumers need the eventual outcome to replace stale timeout UI.
+  onLateResult?: (result: WorkspaceCleanupRemoveResult) => void
   onError?: (error: unknown) => void
   // Why: a row can fail before its removal starts (preflight failure or a
   // skipped nested workspace); report it now so its queued overlay can clear
@@ -51,6 +51,7 @@ export function startWorkspaceCleanupBackgroundRemoval({
   removeCandidates,
   onProgress,
   onResult,
+  onLateResult,
   onError,
   onRowFailed,
   removalTimeoutMs = DEFAULT_WORKSPACE_CLEANUP_REMOVAL_TIMEOUT_MS,
@@ -69,6 +70,7 @@ export function startWorkspaceCleanupBackgroundRemoval({
   const removedIds: string[] = []
   const failures: WorkspaceCleanupFailure[] = []
   const failedCandidates: WorkspaceCleanupCandidate[] = []
+  const detachLateResultReconcilers: (() => void)[] = []
   let processedCount = 0
 
   const emitProgress = (): void => {
@@ -120,12 +122,46 @@ export function startWorkspaceCleanupBackgroundRemoval({
         continue
       }
       try {
-        const result = await withWorkspaceCleanupRemovalTimeout(
+        const outcome = await waitForWorkspaceCleanupRemovalWithTimeout(
           removeCandidates([candidate.worktreeId], { approvedCandidates: [candidate] }),
-          candidate,
           removalTimeoutMs,
           removalSettlementGraceMs
         )
+        if (outcome.status === 'rejected') {
+          throw outcome.error
+        }
+        if (outcome.status === 'unresolved') {
+          const timeoutFailure = getWorkspaceCleanupTimeoutFailure(candidate)
+          failedCandidates.push(candidate)
+          reportFailures([timeoutFailure])
+          // Why: renderer IPC cannot be cancelled at the timeout boundary. Keep
+          // its authoritative settlement without letting an unknown child
+          // outcome permit deletion of an ancestor.
+          detachLateResultReconcilers.push(
+            trackWorkspaceCleanupLateSettlement(
+              outcome.settlement,
+              candidate,
+              (lateResult) => {
+                const timeoutIndex = failures.indexOf(timeoutFailure)
+                if (timeoutIndex >= 0) {
+                  failures.splice(timeoutIndex, 1)
+                }
+                removedIds.push(...lateResult.removedIds)
+                reportFailures(lateResult.failures)
+                if (lateResult.failures.length === 0) {
+                  const failedCandidateIndex = failedCandidates.indexOf(candidate)
+                  if (failedCandidateIndex >= 0) {
+                    failedCandidates.splice(failedCandidateIndex, 1)
+                  }
+                }
+                emitProgress()
+              },
+              (lateResult) => reportLateWorkspaceCleanupResult(lateResult, onLateResult)
+            )
+          )
+          continue
+        }
+        const result = outcome.result
         removedIds.push(...result.removedIds)
         reportFailures(result.failures)
         if (result.failures.length > 0) {
@@ -146,6 +182,9 @@ export function startWorkspaceCleanupBackgroundRemoval({
       }
     }
 
+    for (const detach of detachLateResultReconcilers) {
+      detach()
+    }
     const result = { removedIds, failures }
     try {
       onResult?.(result)
@@ -153,33 +192,11 @@ export function startWorkspaceCleanupBackgroundRemoval({
       console.error('Workspace cleanup result callback failed', callbackError)
     }
 
-    if (result.removedIds.length > 0) {
-      toast.success(
-        translate(
-          'auto.components.workspace.cleanup.backgroundRemoval.removed',
-          'Removed workspaces: {{value0}}',
-          {
-            value0: result.removedIds.length
-          }
-        )
-      )
-    }
-
-    if (result.failures.length > 0) {
-      toast.error(
-        translate(
-          'auto.components.workspace.cleanup.backgroundRemoval.failed',
-          'Workspaces not removed: {{value0}}',
-          {
-            value0: result.failures.length
-          }
-        ),
-        {
-          description: result.failures.map((failure) => failure.message).join('; ')
-        }
-      )
-    }
+    showWorkspaceCleanupRemovalResultToasts(result)
   })().catch((error: unknown) => {
+    for (const detach of detachLateResultReconcilers) {
+      detach()
+    }
     onError?.(error)
     toast.error(
       translate(
@@ -193,69 +210,37 @@ export function startWorkspaceCleanupBackgroundRemoval({
   })
 }
 
-async function withWorkspaceCleanupRemovalTimeout(
-  promise: Promise<WorkspaceCleanupRemoveResult>,
-  candidate: WorkspaceCleanupCandidate,
-  timeoutMs: number,
-  settlementGraceMs: number
-): Promise<WorkspaceCleanupRemoveResult> {
-  if (timeoutMs <= 0 || !Number.isFinite(timeoutMs)) {
-    return promise
+function reportLateWorkspaceCleanupResult(
+  result: WorkspaceCleanupRemoveResult,
+  onLateResult: WorkspaceCleanupBackgroundRemovalArgs['onLateResult']
+): void {
+  try {
+    onLateResult?.(result)
+  } catch (callbackError) {
+    console.error('Workspace cleanup late result callback failed', callbackError)
   }
-
-  // Why: a timeout does not cancel renderer IPC. Preserve the eventual outcome
-  // so a confirmation racing the deadline remains authoritative.
-  const settlement = promise.then<
-    WorkspaceCleanupRemovalSettlement,
-    WorkspaceCleanupRemovalSettlement
-  >(
-    (result) => ({ status: 'fulfilled', result }),
-    (error: unknown) => ({ status: 'rejected', error })
-  )
-  const initialOutcome = await waitForWorkspaceCleanupRemoval(settlement, timeoutMs)
-  const outcome =
-    initialOutcome.status === 'unresolved' &&
-    settlementGraceMs > 0 &&
-    Number.isFinite(settlementGraceMs)
-      ? await waitForWorkspaceCleanupRemoval(settlement, settlementGraceMs)
-      : initialOutcome
-
-  if (outcome.status === 'fulfilled') {
-    return outcome.result
-  }
-  if (outcome.status === 'rejected') {
-    throw outcome.error
-  }
-
-  // Why: only an operation still unresolved after the bounded confirmation
-  // window blocks ancestor deletion; a confirmed late success proceeds safely.
-  throw new Error(
-    translate(
-      'auto.components.workspace.cleanup.backgroundRemoval.timedOut',
-      'Removing {{value0}} is taking longer than expected. It will keep running in the background.',
-      { value0: candidate.displayName }
-    )
-  )
+  showWorkspaceCleanupRemovalResultToasts(result)
 }
 
-async function waitForWorkspaceCleanupRemoval(
-  settlement: Promise<WorkspaceCleanupRemovalSettlement>,
-  timeoutMs: number
-): Promise<WorkspaceCleanupRemovalWaitResult> {
-  let timeout: ReturnType<typeof setTimeout> | null = null
-  try {
-    return await Promise.race([
-      settlement,
-      new Promise<{ status: 'unresolved' }>((resolve) => {
-        timeout = setTimeout(() => {
-          resolve({ status: 'unresolved' })
-        }, timeoutMs)
-      })
-    ])
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout)
-    }
+function showWorkspaceCleanupRemovalResultToasts(result: WorkspaceCleanupRemoveResult): void {
+  if (result.removedIds.length > 0) {
+    toast.success(
+      translate(
+        'auto.components.workspace.cleanup.backgroundRemoval.removed',
+        'Removed workspaces: {{value0}}',
+        { value0: result.removedIds.length }
+      )
+    )
+  }
+  if (result.failures.length > 0) {
+    toast.error(
+      translate(
+        'auto.components.workspace.cleanup.backgroundRemoval.failed',
+        'Workspaces not removed: {{value0}}',
+        { value0: result.failures.length }
+      ),
+      { description: result.failures.map((failure) => failure.message).join('; ') }
+    )
   }
 }
 

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-background-removal.ts
@@ -12,6 +12,15 @@ import type {
 import { translate } from '@/i18n/i18n'
 
 const DEFAULT_WORKSPACE_CLEANUP_REMOVAL_TIMEOUT_MS = 120_000
+const DEFAULT_WORKSPACE_CLEANUP_SETTLEMENT_GRACE_MS = 5_000
+
+type WorkspaceCleanupRemovalSettlement =
+  | { status: 'fulfilled'; result: WorkspaceCleanupRemoveResult }
+  | { status: 'rejected'; error: unknown }
+
+type WorkspaceCleanupRemovalWaitResult =
+  | WorkspaceCleanupRemovalSettlement
+  | { status: 'unresolved' }
 
 export type WorkspaceCleanupRemovalProgress = {
   totalCount: number
@@ -34,6 +43,7 @@ export type WorkspaceCleanupBackgroundRemovalArgs = {
   // instead of waiting for the whole batch to settle.
   onRowFailed?: (failure: WorkspaceCleanupFailure) => void
   removalTimeoutMs?: number
+  removalSettlementGraceMs?: number
 }
 
 export function startWorkspaceCleanupBackgroundRemoval({
@@ -43,7 +53,8 @@ export function startWorkspaceCleanupBackgroundRemoval({
   onResult,
   onError,
   onRowFailed,
-  removalTimeoutMs = DEFAULT_WORKSPACE_CLEANUP_REMOVAL_TIMEOUT_MS
+  removalTimeoutMs = DEFAULT_WORKSPACE_CLEANUP_REMOVAL_TIMEOUT_MS,
+  removalSettlementGraceMs = DEFAULT_WORKSPACE_CLEANUP_SETTLEMENT_GRACE_MS
 }: WorkspaceCleanupBackgroundRemovalArgs): void {
   if (candidates.length === 0) {
     try {
@@ -112,7 +123,8 @@ export function startWorkspaceCleanupBackgroundRemoval({
         const result = await withWorkspaceCleanupRemovalTimeout(
           removeCandidates([candidate.worktreeId], { approvedCandidates: [candidate] }),
           candidate,
-          removalTimeoutMs
+          removalTimeoutMs,
+          removalSettlementGraceMs
         )
         removedIds.push(...result.removedIds)
         reportFailures(result.failures)
@@ -184,30 +196,59 @@ export function startWorkspaceCleanupBackgroundRemoval({
 async function withWorkspaceCleanupRemovalTimeout(
   promise: Promise<WorkspaceCleanupRemoveResult>,
   candidate: WorkspaceCleanupCandidate,
-  timeoutMs: number
+  timeoutMs: number,
+  settlementGraceMs: number
 ): Promise<WorkspaceCleanupRemoveResult> {
   if (timeoutMs <= 0 || !Number.isFinite(timeoutMs)) {
     return promise
   }
 
+  // Why: a timeout does not cancel renderer IPC. Preserve the eventual outcome
+  // so a confirmation racing the deadline remains authoritative.
+  const settlement = promise.then<
+    WorkspaceCleanupRemovalSettlement,
+    WorkspaceCleanupRemovalSettlement
+  >(
+    (result) => ({ status: 'fulfilled', result }),
+    (error: unknown) => ({ status: 'rejected', error })
+  )
+  const initialOutcome = await waitForWorkspaceCleanupRemoval(settlement, timeoutMs)
+  const outcome =
+    initialOutcome.status === 'unresolved' &&
+    settlementGraceMs > 0 &&
+    Number.isFinite(settlementGraceMs)
+      ? await waitForWorkspaceCleanupRemoval(settlement, settlementGraceMs)
+      : initialOutcome
+
+  if (outcome.status === 'fulfilled') {
+    return outcome.result
+  }
+  if (outcome.status === 'rejected') {
+    throw outcome.error
+  }
+
+  // Why: only an operation still unresolved after the bounded confirmation
+  // window blocks ancestor deletion; a confirmed late success proceeds safely.
+  throw new Error(
+    translate(
+      'auto.components.workspace.cleanup.backgroundRemoval.timedOut',
+      'Removing {{value0}} is taking longer than expected. It will keep running in the background.',
+      { value0: candidate.displayName }
+    )
+  )
+}
+
+async function waitForWorkspaceCleanupRemoval(
+  settlement: Promise<WorkspaceCleanupRemovalSettlement>,
+  timeoutMs: number
+): Promise<WorkspaceCleanupRemovalWaitResult> {
   let timeout: ReturnType<typeof setTimeout> | null = null
   try {
     return await Promise.race([
-      promise,
-      new Promise<WorkspaceCleanupRemoveResult>((_resolve, reject) => {
+      settlement,
+      new Promise<{ status: 'unresolved' }>((resolve) => {
         timeout = setTimeout(() => {
-          // Why: the underlying removal cannot be cancelled from the renderer,
-          // so the row stays "Deleting" and this message must not claim the
-          // removal stopped.
-          reject(
-            new Error(
-              translate(
-                'auto.components.workspace.cleanup.backgroundRemoval.timedOut',
-                'Removing {{value0}} is taking longer than expected. It will keep running in the background.',
-                { value0: candidate.displayName }
-              )
-            )
-          )
+          resolve({ status: 'unresolved' })
         }, timeoutMs)
       })
     ])

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-settlement.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-settlement.ts
@@ -1,0 +1,137 @@
+import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
+import type {
+  WorkspaceCleanupFailure,
+  WorkspaceCleanupRemoveResult
+} from '@/store/slices/workspace-cleanup'
+import { translate } from '@/i18n/i18n'
+
+export type WorkspaceCleanupRemovalSettlement =
+  | { status: 'fulfilled'; result: WorkspaceCleanupRemoveResult }
+  | { status: 'rejected'; error: unknown }
+
+type WorkspaceCleanupRemovalPollResult =
+  | WorkspaceCleanupRemovalSettlement
+  | { status: 'unresolved' }
+
+export type WorkspaceCleanupRemovalWaitResult =
+  | WorkspaceCleanupRemovalSettlement
+  | { status: 'unresolved'; settlement: Promise<WorkspaceCleanupRemovalSettlement> }
+
+export async function waitForWorkspaceCleanupRemovalWithTimeout(
+  promise: Promise<WorkspaceCleanupRemoveResult>,
+  timeoutMs: number,
+  settlementGraceMs: number
+): Promise<WorkspaceCleanupRemovalWaitResult> {
+  if (timeoutMs <= 0 || !Number.isFinite(timeoutMs)) {
+    return promise.then<WorkspaceCleanupRemovalSettlement, WorkspaceCleanupRemovalSettlement>(
+      (result) => ({ status: 'fulfilled', result }),
+      (error: unknown) => ({ status: 'rejected', error })
+    )
+  }
+
+  // Why: a timeout does not cancel renderer IPC. Preserve the eventual outcome
+  // so a confirmation racing the deadline remains authoritative.
+  const settlement = promise.then<
+    WorkspaceCleanupRemovalSettlement,
+    WorkspaceCleanupRemovalSettlement
+  >(
+    (result) => ({ status: 'fulfilled', result }),
+    (error: unknown) => ({ status: 'rejected', error })
+  )
+  const initialOutcome = await pollWorkspaceCleanupRemoval(settlement, timeoutMs)
+  const outcome =
+    initialOutcome.status === 'unresolved' &&
+    settlementGraceMs > 0 &&
+    Number.isFinite(settlementGraceMs)
+      ? await pollWorkspaceCleanupRemoval(settlement, settlementGraceMs)
+      : initialOutcome
+
+  return outcome.status === 'unresolved' ? { ...outcome, settlement } : outcome
+}
+
+export function getWorkspaceCleanupTimeoutFailure(
+  candidate: WorkspaceCleanupCandidate
+): WorkspaceCleanupFailure {
+  return {
+    worktreeId: candidate.worktreeId,
+    displayName: candidate.displayName,
+    message: translate(
+      'auto.components.workspace.cleanup.backgroundRemoval.timedOut',
+      'Removing {{value0}} is taking longer than expected. It will keep running in the background.',
+      { value0: candidate.displayName }
+    )
+  }
+}
+
+export function trackWorkspaceCleanupLateSettlement(
+  settlement: Promise<WorkspaceCleanupRemovalSettlement>,
+  candidate: WorkspaceCleanupCandidate,
+  reconcileBeforeBatchResult: (result: WorkspaceCleanupRemoveResult) => void,
+  reportAfterBatchResult: (result: WorkspaceCleanupRemoveResult) => void
+): () => void {
+  const state: { reconcile: ((result: WorkspaceCleanupRemoveResult) => void) | null } = {
+    reconcile: reconcileBeforeBatchResult
+  }
+  void settlement.then(createLateSettlementReporter(state, candidate, reportAfterBatchResult))
+  // Why: a truly hung IPC promise can live for the renderer's lifetime. Drop
+  // the batch-array closure once its initial result has been reported.
+  return () => {
+    state.reconcile = null
+  }
+}
+
+function createLateSettlementReporter(
+  state: { reconcile: ((result: WorkspaceCleanupRemoveResult) => void) | null },
+  candidate: WorkspaceCleanupCandidate,
+  reportAfterBatchResult: (result: WorkspaceCleanupRemoveResult) => void
+): (settlement: WorkspaceCleanupRemovalSettlement) => void {
+  return (settlement) => {
+    const result = toWorkspaceCleanupRemoveResult(candidate, settlement)
+    if (state.reconcile) {
+      state.reconcile(result)
+      return
+    }
+    reportAfterBatchResult(result)
+  }
+}
+
+function toWorkspaceCleanupRemoveResult(
+  candidate: WorkspaceCleanupCandidate,
+  settlement: WorkspaceCleanupRemovalSettlement
+): WorkspaceCleanupRemoveResult {
+  if (settlement.status === 'fulfilled') {
+    return settlement.result
+  }
+  return {
+    removedIds: [],
+    failures: [
+      {
+        worktreeId: candidate.worktreeId,
+        displayName: candidate.displayName,
+        message:
+          settlement.error instanceof Error ? settlement.error.message : String(settlement.error)
+      }
+    ]
+  }
+}
+
+async function pollWorkspaceCleanupRemoval(
+  settlement: Promise<WorkspaceCleanupRemovalSettlement>,
+  timeoutMs: number
+): Promise<WorkspaceCleanupRemovalPollResult> {
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  try {
+    return await Promise.race([
+      settlement,
+      new Promise<{ status: 'unresolved' }>((resolve) => {
+        timeout = setTimeout(() => {
+          resolve({ status: 'unresolved' })
+        }, timeoutMs)
+      })
+    ])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- distinguish unresolved cleanup timeouts from definitive failure and late success
- preserve parent-deletion safety while reconciling authoritative results after the timeout/grace window
- update dialog/toast reporting for late success and failure
- detach batch closures from indefinitely hung, uncancellable IPC operations

## Validation
- 48 focused cleanup tests across 9 files
- web typecheck, focused oxlint/format, React Doctor, max-lines ratchet, diff check
- two fresh adversarial review/fix rounds (final round fixed a P1 late-settlement loss)

## Residual risk
A destroyed initiating renderer cannot display a later notification; authoritative store/scan reconciliation remains intact.