### PR TITLE
STA-1598: Handle CRLF project headers during Codex config repair

### DIFF
--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -334,6 +334,72 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     expect(runtimeConfig).toContain("[projects.'c:\\gemini_etl']")
   })
 
+  it('deduplicates a CRLF system project header against an LF runtime header', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    const projectHeader = '[projects."C:/Users/jinwo/orca/workspaces/orca/repo"]'
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [projectHeader, 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      [projectHeader, 'trust_level = "trusted"', ''].join('\r\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/\[projects\./g)).toHaveLength(1)
+    expect(runtimeConfig).toContain(`${projectHeader}\ntrust_level = "trusted"`)
+  })
+
+  it('self-heals duplicate project tables in a CRLF runtime config', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    const projectHeader = '[projects."C:/Users/jinwo/orca/workspaces/orca/repo"]'
+    writeFileSync(
+      getRuntimeConfigPath(),
+      [
+        projectHeader,
+        'trust_level = "trusted"',
+        '',
+        projectHeader,
+        'trust_level = "trusted"',
+        ''
+      ].join('\r\n'),
+      'utf-8'
+    )
+    writeFileSync(getSystemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/\[projects\./g)).toHaveLength(1)
+    expect(runtimeConfig).toContain('trust_level = "trusted"')
+  })
+
+  it('applies a CRLF system revocation to an LF runtime project', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    writeFileSync(
+      getRuntimeConfigPath(),
+      ["[projects.'c:\\repo']", 'trust_level = "trusted"', ''].join('\n'),
+      'utf-8'
+    )
+    writeFileSync(
+      getSystemConfigPath(),
+      ['[projects."C:/repo"]', 'trust_level = "untrusted"', ''].join('\r\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readFileSync(getRuntimeConfigPath(), 'utf-8')
+    expect(runtimeConfig.match(/\[projects\./g)).toHaveLength(1)
+    expect(runtimeConfig).toContain('trust_level = "untrusted"')
+    expect(runtimeConfig).not.toContain('trust_level = "trusted"')
+  })
+
   it('lets a semantically matching system revocation replace runtime trust', () => {
     mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
     writeFileSync(

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -591,7 +591,9 @@ function parseHookStateHeaderKey(line: string): string | null {
 }
 
 export function parseCodexProjectHeaderPath(line: string): string | null {
-  const trimmed = line.trimStart()
+  // Why: mirror section headers come from split CRLF files and retain the
+  // terminal carriage return, while direct upserts scan CR-stripped lines.
+  const trimmed = line.replace(/\r$/, '').trimStart()
   const prefixMatch = /^\[[ \t]*projects[ \t]*\.[ \t]*/.exec(trimmed)
   if (!prefixMatch) {
     return null


### PR DESCRIPTION
## Why this follow-up exists

This fixes a regression introduced by #8138 while addressing STA-1598.

The semantic project-header parser is used from two paths with different line shapes:

- direct trust upserts scan lines after removing the CR from CRLF input
- the mirror uses `config.split('\n')`, so a CRLF section header still ends in `\r`

`parseCodexProjectHeaderPath` accepted only spaces/tabs after the closing `]`. As a result, it rejected every CRLF project header supplied by the mirror. A Windows system config project section was copied as ordinary config, then the LF runtime-owned copy was appended, creating an exact duplicate table before Codex auto-started.

This was reproduced on `1.4.135-rc.1.perf`: the real runtime config contained 142 duplicated project-header groups. The two copies of the reported workspace differed only by the first header's terminal `0x0D` carriage return.

## Fix

Strip one terminal CR before parsing a project header. This aligns mirror parsing with the existing direct-upsert scanner without changing path values, quote handling, Windows/UNC normalization, SSH behavior, or hooks-state formatting.

## Regression coverage

New end-to-end mirror tests cover:

- CRLF system project + LF runtime project collapsing to one table
- self-healing duplicates already inside a CRLF runtime config
- CRLF system `untrusted` revocation overriding LF runtime `trusted`

All three tests failed before the fix and pass afterward.

## Evidence so far

- focused project trust + mirror tests: 118 passed
- Codex, Codex accounts, local trust, and remote/SSH trust suites: 419 passed, 7 skipped
- `pnpm typecheck`: passed
- `pnpm check:max-lines-ratchet`: passed
- targeted oxlint/lint-staged: passed
- copied production-shaped config replay: 142 duplicate header groups before, 0 after; real `codex features list` parsed the healed copy
- Electron/CDP Windows E2E: seeded a duplicate CRLF/LF runtime config and confirmed real Codex rejected it; created a disposable repo workspace with backend Codex auto-start (`startupTerminal.spawned = true`); the rendered terminal showed the interactive Codex v0.144 prompt in the new workspace; afterward the seed project and new workspace each had one table, no duplicate groups remained, and `codex features list` exited 0 against the healed runtime

## References

- Linear: [STA-1598](https://linear.app/stably/issue/STA-1598/prevent-codex-startup-failure-by-deduplicating-toml-project)
- Original fix: #8138
- Source report: [Slack](https://stablygroup.slack.com/archives/C0ASMDT6LQZ/p1783700935620169)