### PR TITLE
perf(memory): skip unrelated boot worktree scans

### DIFF
--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -32,9 +32,9 @@ vi.mock('../daemon/daemon-init', () => ({
   getDaemonProvider: () => getDaemonProviderMock()
 }))
 
-// Why: the hydrator builds its worktreeId → connectionId map by calling
-// listRepoWorktrees(repo) for every repo in the store. The git I/O is
-// out of scope for this unit; mock returns whatever the test wants.
+// Why: the hydrator builds its worktreeId → connectionId map through
+// listRepoWorktrees(repo). The git I/O is out of scope for this unit; the mock
+// also lets count tests prove repos without live sessions launch no Git work.
 const listRepoWorktreesMock = vi.fn()
 vi.mock('../repo-worktrees', () => ({
   listRepoWorktrees: (repo: unknown) => listRepoWorktreesMock(repo)
@@ -127,6 +127,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     await hydrate(makeStore([{ id: 'repo-a' }]))
 
     expect(provider.listSessions).toHaveBeenCalledTimes(1)
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
   })
 
   it('catches provider.listSessions rejection and does not throw', async () => {
@@ -145,6 +146,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     warnSpy.mockRestore()
 
     expect(listRegisteredPtys()).toHaveLength(0)
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
   })
 
   it('does not clobber a pre-existing registry pid with a null pid from listSessions', async () => {
@@ -180,6 +182,7 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry).toBeDefined()
     expect(entry!.pid).toBe(12345)
     expect(entry!.paneKey).toBe('tab-1:1')
+    expect(listRepoWorktreesMock).not.toHaveBeenCalled()
   })
 
   it('skips SSH repos before enumerating worktrees', async () => {
@@ -221,6 +224,60 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry).toBeDefined()
     expect(entry!.pid).toBe(4242)
     expect(entry!.worktreeId).toBe('repo-a::/local/Triton')
+  })
+
+  it('does not register a daemon session whose worktree was removed', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const provider = makeProvider([
+      {
+        sessionId: 'repo-a::/local/removed@@deadbeef',
+        pid: 4242,
+        cwd: '/local/removed'
+      } as unknown as SessionInfo
+    ])
+    getDaemonProviderMock.mockReturnValue(provider)
+    listRepoWorktreesMock.mockResolvedValue([
+      { path: '/local/current', head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+
+    await hydrate(makeStore([{ id: 'repo-a', connectionId: null }]))
+
+    expect(listRepoWorktreesMock).toHaveBeenCalledTimes(1)
+    expect(listRegisteredPtys()).toHaveLength(0)
+  })
+
+  it('enumerates worktrees only for repos referenced by live daemon sessions', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+    const repos = Array.from({ length: 100 }, (_, index) => ({ id: `repo-${index}` }))
+    const activeRepoIds = ['repo-17', 'repo-83']
+    const provider = makeProvider(
+      activeRepoIds.map(
+        (repoId, index) =>
+          ({
+            sessionId: `${repoId}::/local/${repoId}@@0000000${index}`,
+            pid: 4000 + index,
+            cwd: `/local/${repoId}`
+          }) as unknown as SessionInfo
+      )
+    )
+    getDaemonProviderMock.mockReturnValue(provider)
+    listRepoWorktreesMock.mockImplementation(async (repo: Repo) => [
+      {
+        path: `/local/${repo.id}`,
+        head: '',
+        branch: '',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    await hydrate(makeStore(repos))
+
+    expect(listRepoWorktreesMock).toHaveBeenCalledTimes(activeRepoIds.length)
+    expect(listRepoWorktreesMock.mock.calls.map(([repo]) => (repo as Repo).id)).toEqual(
+      activeRepoIds
+    )
+    expect(listRegisteredPtys()).toHaveLength(activeRepoIds.length)
   })
 
   it('hydrates large daemon session lists', async () => {

--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -79,6 +79,17 @@ function makeLocalSessions(repoId: string, worktreePath: string, count: number):
   return sessions
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver
+  })
+  return { promise, resolve }
+}
+
 // Why: the module under test memoizes `hasHydrated` at module scope so it
 // only runs the git/RPC pass once per process. The pty-registry module
 // also stashes state in a module-level Map, so we have to load BOTH
@@ -183,6 +194,68 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry!.pid).toBe(12345)
     expect(entry!.paneKey).toBe('tab-1:1')
     expect(listRepoWorktreesMock).not.toHaveBeenCalled()
+  })
+
+  it('does not clobber a pty:spawn registration that arrives during worktree enumeration', async () => {
+    const { hydrate, listRegisteredPtys, registerPty } = await loadFresh()
+    const ptyId = 'repo-a::/local/Triton@@deadbeef'
+    const provider = makeProvider([
+      { sessionId: ptyId, pid: null, cwd: '/local/Triton' } as unknown as SessionInfo
+    ])
+    getDaemonProviderMock.mockReturnValue(provider)
+    const worktrees =
+      createDeferred<
+        { path: string; head: string; branch: string; isBare: boolean; isMainWorktree: boolean }[]
+      >()
+    listRepoWorktreesMock.mockReturnValue(worktrees.promise)
+
+    const hydration = hydrate(makeStore([{ id: 'repo-a', connectionId: null }]))
+    await vi.waitFor(() => expect(listRepoWorktreesMock).toHaveBeenCalledTimes(1))
+    registerPty({
+      ptyId,
+      worktreeId: 'repo-a::/local/Triton',
+      sessionId: ptyId,
+      paneKey: 'tab-1:1',
+      pid: 12345
+    })
+    worktrees.resolve([
+      { path: '/local/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+    await hydration
+
+    expect(listRegisteredPtys()).toEqual([
+      expect.objectContaining({ ptyId, pid: 12345, paneKey: 'tab-1:1' })
+    ])
+  })
+
+  it('does not resurrect a daemon session that exits during worktree enumeration', async () => {
+    const { hydrate, listRegisteredPtys, unregisterPty } = await loadFresh()
+    const ptyId = 'repo-a::/local/Triton@@deadbeef'
+    const provider = {
+      listSessions: vi
+        .fn()
+        .mockResolvedValueOnce([
+          { sessionId: ptyId, pid: 4242, cwd: '/local/Triton' } as unknown as SessionInfo
+        ])
+        .mockResolvedValueOnce([])
+    }
+    getDaemonProviderMock.mockReturnValue(provider)
+    const worktrees =
+      createDeferred<
+        { path: string; head: string; branch: string; isBare: boolean; isMainWorktree: boolean }[]
+      >()
+    listRepoWorktreesMock.mockReturnValue(worktrees.promise)
+
+    const hydration = hydrate(makeStore([{ id: 'repo-a', connectionId: null }]))
+    await vi.waitFor(() => expect(listRepoWorktreesMock).toHaveBeenCalledTimes(1))
+    unregisterPty(ptyId)
+    worktrees.resolve([
+      { path: '/local/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+    await hydration
+
+    expect(provider.listSessions).toHaveBeenCalledTimes(2)
+    expect(listRegisteredPtys()).toHaveLength(0)
   })
 
   it('skips SSH repos before enumerating worktrees', async () => {

--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -353,6 +353,45 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(listRegisteredPtys()).toHaveLength(activeRepoIds.length)
   })
 
+  it('scans a repo that only becomes visible on the post-enumeration re-read', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+
+    const sessionA = {
+      sessionId: 'repo-a::/local/repo-a@@00000001',
+      pid: 4001,
+      cwd: '/local/repo-a'
+    } as unknown as SessionInfo
+    const sessionB = {
+      sessionId: 'repo-b::/local/repo-b@@00000002',
+      pid: 4002,
+      cwd: '/local/repo-b'
+    } as unknown as SessionInfo
+    // Why: a briefly unreachable adapter can omit a session from the first
+    // listing; once it reappears on the re-read its repo must still be
+    // scanned and the session registered instead of silently dropped.
+    const listSessions = vi
+      .fn()
+      .mockResolvedValueOnce([sessionA])
+      .mockResolvedValue([sessionA, sessionB])
+    getDaemonProviderMock.mockReturnValue({ listSessions })
+    listRepoWorktreesMock.mockImplementation(async (repo: Repo) => [
+      { path: `/local/${repo.id}`, head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+
+    await hydrate(makeStore([{ id: 'repo-a' }, { id: 'repo-b' }]))
+
+    expect(listRepoWorktreesMock.mock.calls.map(([repo]) => (repo as Repo).id)).toEqual([
+      'repo-a',
+      'repo-b'
+    ])
+    expect(listSessions).toHaveBeenCalledTimes(3)
+    const registered = listRegisteredPtys()
+    expect(registered.map((p) => p.ptyId).sort()).toEqual([
+      'repo-a::/local/repo-a@@00000001',
+      'repo-b::/local/repo-b@@00000002'
+    ])
+  })
+
   it('hydrates large daemon session lists', async () => {
     const { hydrate, listRegisteredPtys } = await loadFresh()
 

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -25,6 +25,7 @@ import type { SessionInfo } from '../daemon/types'
 import { listRegisteredPtys, registerPty } from './pty-registry'
 import { listRepoWorktrees } from '../repo-worktrees'
 import { parsePtySessionId } from '../../shared/pty-session-id-format'
+import { splitWorktreeId } from '../../shared/worktree-id'
 import type { Store } from '../persistence'
 
 // Why: `attachMainWindowServices` runs on every macOS dock re-activation
@@ -70,13 +71,33 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
     // renderer-side union still covers that case.
     hasHydrated = true
 
+    // Why: ask the daemon which repos matter before launching Git worktree
+    // enumeration. Most configured repos have no preserved session at boot,
+    // so scanning all of them creates pure background subprocess churn.
+    const sessionInfos = await collectSessionInfos(provider)
+    const alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
+    const referencedRepoIds = new Set<string>()
+    for (const info of sessionInfos) {
+      if (alreadyRegistered.has(info.sessionId)) {
+        continue
+      }
+      const { worktreeId } = parsePtySessionId(info.sessionId)
+      const parsedWorktreeId = worktreeId ? splitWorktreeId(worktreeId) : null
+      if (parsedWorktreeId) {
+        referencedRepoIds.add(parsedWorktreeId.repoId)
+      }
+    }
+
     // Why: build a worktree-id → connectionId map so we can SSH-gate each
-    // session before registering. Live git enumeration matches the path
-    // shape used by `mintPtySessionId` (`${repoId}::${path}`).
+    // session before registering. Live git enumeration still verifies that a
+    // referenced worktree exists instead of resurrecting removed worktrees.
     const repos = store.getRepos()
     const repoConnectionIdByWorktreeId = new Map<string, string | null>()
 
     for (const repo of repos) {
+      if (!referencedRepoIds.has(repo.id)) {
+        continue
+      }
       const connectionId = repo.connectionId ?? null
       if (connectionId) {
         // Why: SSH PTYs are never registered for local process sampling, so
@@ -89,14 +110,6 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
         repoConnectionIdByWorktreeId.set(worktreeId, connectionId)
       }
     }
-
-    // Why: SessionInfo is read through the adapter's listSessions() so we
-    // get the pid alongside each id. Routing through every adapter
-    // (current + legacy) keeps protocol coverage symmetric with the
-    // orphan-cleanup path.
-    const sessionInfos = await collectSessionInfos(provider)
-
-    const alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
 
     for (const info of sessionInfos) {
       // Why: pid-write ordering — `pty:spawn` is the authoritative

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -74,11 +74,11 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
     // Why: ask the daemon which repos matter before launching Git worktree
     // enumeration. Most configured repos have no preserved session at boot,
     // so scanning all of them creates pure background subprocess churn.
-    const sessionInfos = await collectSessionInfos(provider)
-    const alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
+    const initialSessionInfos = await collectSessionInfos(provider)
+    const initiallyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
     const referencedRepoIds = new Set<string>()
-    for (const info of sessionInfos) {
-      if (alreadyRegistered.has(info.sessionId)) {
+    for (const info of initialSessionInfos) {
+      if (initiallyRegistered.has(info.sessionId)) {
         continue
       }
       const { worktreeId } = parsePtySessionId(info.sessionId)
@@ -87,12 +87,14 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
         referencedRepoIds.add(parsedWorktreeId.repoId)
       }
     }
+    if (referencedRepoIds.size === 0) {
+      return
+    }
 
-    // Why: build a worktree-id → connectionId map so we can SSH-gate each
-    // session before registering. Live git enumeration still verifies that a
-    // referenced worktree exists instead of resurrecting removed worktrees.
+    // Why: live git enumeration verifies that a referenced local worktree
+    // still exists instead of resurrecting removed worktrees.
     const repos = store.getRepos()
-    const repoConnectionIdByWorktreeId = new Map<string, string | null>()
+    const liveLocalWorktreeIds = new Set<string>()
 
     for (const repo of repos) {
       if (!referencedRepoIds.has(repo.id)) {
@@ -106,11 +108,15 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       }
       const worktrees = await listRepoWorktrees(repo)
       for (const wt of worktrees) {
-        const worktreeId = `${repo.id}::${wt.path}`
-        repoConnectionIdByWorktreeId.set(worktreeId, connectionId)
+        liveLocalWorktreeIds.add(`${repo.id}::${wt.path}`)
       }
     }
 
+    // Why: Git enumeration can take seconds. Re-read daemon and registry state
+    // so sessions that exited or were authoritatively registered meanwhile do
+    // not get resurrected or overwritten from the stale selection snapshot.
+    const sessionInfos = await collectSessionInfos(provider)
+    const alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
     for (const info of sessionInfos) {
       // Why: pid-write ordering — `pty:spawn` is the authoritative
       // writer for in-session sessions; if that fired before this loop
@@ -128,10 +134,7 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       // `src/main/ipc/pty.ts`. If the repo isn't in the store, skip the
       // session: we can't prove it's local, and the renderer-side union
       // still surfaces the session at the cost of a missing pid sample.
-      if (!repoConnectionIdByWorktreeId.has(worktreeId)) {
-        continue
-      }
-      if (repoConnectionIdByWorktreeId.get(worktreeId)) {
+      if (!liveLocalWorktreeIds.has(worktreeId)) {
         continue
       }
       registerPty({

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -74,49 +74,59 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
     // Why: ask the daemon which repos matter before launching Git worktree
     // enumeration. Most configured repos have no preserved session at boot,
     // so scanning all of them creates pure background subprocess churn.
-    const initialSessionInfos = await collectSessionInfos(provider)
-    const initiallyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
-    const referencedRepoIds = new Set<string>()
-    for (const info of initialSessionInfos) {
-      if (initiallyRegistered.has(info.sessionId)) {
-        continue
-      }
-      const { worktreeId } = parsePtySessionId(info.sessionId)
-      const parsedWorktreeId = worktreeId ? splitWorktreeId(worktreeId) : null
-      if (parsedWorktreeId) {
-        referencedRepoIds.add(parsedWorktreeId.repoId)
-      }
-    }
-    if (referencedRepoIds.size === 0) {
-      return
-    }
-
+    const reposById = new Map(store.getRepos().map((repo) => [repo.id, repo]))
     // Why: live git enumeration verifies that a referenced local worktree
     // still exists instead of resurrecting removed worktrees.
-    const repos = store.getRepos()
     const liveLocalWorktreeIds = new Set<string>()
+    const resolvedRepoIds = new Set<string>()
 
-    for (const repo of repos) {
-      if (!referencedRepoIds.has(repo.id)) {
-        continue
+    let sessionInfos = await collectSessionInfos(provider)
+    let alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
+
+    // Why: repo selection and registration must come from the same daemon
+    // snapshot. Git enumeration can take seconds, so after each scan pass we
+    // re-read daemon and registry state; sessions that exited or were
+    // authoritatively registered meanwhile are not resurrected or overwritten,
+    // and a session that only became visible during a slow scan (e.g. a
+    // briefly unreachable legacy adapter) gets its repo scanned on the next
+    // pass instead of being silently dropped. Terminates because every pass
+    // permanently resolves at least one new repo id.
+    for (;;) {
+      const newlyReferencedRepos = new Map<string, ReturnType<(typeof store)['getRepos']>[number]>()
+      for (const info of sessionInfos) {
+        if (alreadyRegistered.has(info.sessionId)) {
+          continue
+        }
+        const { worktreeId } = parsePtySessionId(info.sessionId)
+        const parsedWorktreeId = worktreeId ? splitWorktreeId(worktreeId) : null
+        if (!parsedWorktreeId || resolvedRepoIds.has(parsedWorktreeId.repoId)) {
+          continue
+        }
+        const repo = reposById.get(parsedWorktreeId.repoId)
+        if (!repo || (repo.connectionId ?? null)) {
+          // Why: unknown repos can't be proven local, and SSH PTYs are never
+          // registered for local process sampling — resolve without git
+          // enumeration so neither can extend the loop.
+          resolvedRepoIds.add(parsedWorktreeId.repoId)
+          continue
+        }
+        newlyReferencedRepos.set(repo.id, repo)
       }
-      const connectionId = repo.connectionId ?? null
-      if (connectionId) {
-        // Why: SSH PTYs are never registered for local process sampling, so
-        // avoid startup SSH/git enumeration for repos we will skip anyway.
-        continue
+      if (newlyReferencedRepos.size === 0) {
+        break
       }
-      const worktrees = await listRepoWorktrees(repo)
-      for (const wt of worktrees) {
-        liveLocalWorktreeIds.add(`${repo.id}::${wt.path}`)
+
+      for (const repo of newlyReferencedRepos.values()) {
+        resolvedRepoIds.add(repo.id)
+        const worktrees = await listRepoWorktrees(repo)
+        for (const wt of worktrees) {
+          liveLocalWorktreeIds.add(`${repo.id}::${wt.path}`)
+        }
       }
+
+      sessionInfos = await collectSessionInfos(provider)
+      alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
     }
-
-    // Why: Git enumeration can take seconds. Re-read daemon and registry state
-    // so sessions that exited or were authoritatively registered meanwhile do
-    // not get resurrected or overwritten from the stale selection snapshot.
-    const sessionInfos = await collectSessionInfos(provider)
-    const alreadyRegistered = new Set(listRegisteredPtys().map((p) => p.ptyId))
     for (const info of sessionInfos) {
       // Why: pid-write ordering — `pty:spawn` is the authoritative
       // writer for in-session sessions; if that fired before this loop


### PR DESCRIPTION
## Description

Boot-time local PTY registry hydration now asks the daemon which repos actually have unregistered live sessions before launching any worktree enumeration.

Previously, the hydrator ran `listRepoWorktrees` for every configured local repo, then fetched daemon sessions. Now it:

1. lists current and legacy daemon sessions to identify referenced repos
2. extracts the referenced repo IDs from strict minted PTY session IDs
3. excludes sessions already registered by the authoritative `pty:spawn` path
4. runs worktree enumeration only for referenced local repos
5. re-lists current and legacy daemon sessions after Git enumeration
6. refreshes the registry snapshot and registers only sessions that are still live and still unregistered

SSH repos, unknown repos, removed worktrees, and already-registered sessions remain excluded.

## Performance evidence

### Deterministic red/green proof

Fixture: 100 configured local repos, with preserved daemon sessions in 2 repos.

Before the fix, the new count test failed with:

```
expected listRepoWorktrees to be called 2 times, but got 100 times
```

After the fix:

| Boot hydration work | Before | After |
| --- | ---: | ---: |
| Repo worktree enumerations | 100 | 2 |
| Repos without preserved sessions scanned | 98 | 0 |

Successful empty session lists, failed daemon session lists, SSH-only sessions, and sessions already registered by `pty:spawn` now launch zero repo worktree scans.

### Production wall-time benchmark

Benchmark used the production `listRepoWorktrees` helper in this repository, with five alternating sequential runs of the proven before/after call counts.

| Scenario | Median |
| --- | ---: |
| Before: 100 enumerations | 10,599.32 ms |
| After: 2 enumerations | 200.42 ms |

That removes 98.1% of the measured background worktree-enumeration time. The hydrator is fire-and-forget after main-window service attachment, so this does not change first-paint ordering; it removes roughly ten seconds of background Git/process/disk churn after launch in the 100-repo fixture.

Each repo enumeration can itself run multiple bounded worktree/sparse-check operations, so the deterministic call reduction is the conservative process-fanout evidence.

## ELI5

Orca used to knock on every repository door after launch to ask whether a surviving terminal lived there. The daemon already knows which repositories have surviving terminals. Orca now asks the daemon first and knocks only on those doors.

## End-user trade-offs / regressions

- Empty or already-registered session sets use one current+legacy daemon listing. Referenced-session paths perform a second listing after Git enumeration so a session that exited during a slow scan is not resurrected, and refresh the registry Set so an authoritative `pty:spawn` registration is not overwritten.
- The second listing adds one O(number of daemon sessions) RPC/fanout and a transient response allocation on non-empty hydration. The existing 150,000-session stress test remains green. This accepted cost closes the spawn/exit races while replacing Git subprocess I/O that scales with every configured repo.
- Session-list failure still degrades gracefully. A failure in the post-enumeration refresh skips registration rather than using stale daemon state.
- Referenced repos still use the existing unbounded worktree-list timeout behavior. This PR reduces their count but does not introduce a new timeout policy; that remains an explicit reliability gap.
- There is no intended UI change. Local sessions still require a currently live worktree, remote/unknown sessions remain excluded, and an existing `pty:spawn` PID remains authoritative.

## Screenshots

No visual change.

## Testing

- [x] changed-file lint and formatting passed; the branch is rebased onto current main, which contains the unrelated max-lines fix
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2,567 files and 26,797 tests passed; 3 files / 33 tests skipped
- [ ] `pnpm build` — not run; no build configuration or dependency changes
- [x] Added a regression test that fails at 100 scans before the fix and passes at 2 after it

Additional validation:

- hydration, memory collector, main-window attach, and daemon router: 4 files / 63 tests passed
- deferred concurrency tests prove `pty:spawn` during enumeration is not clobbered and a daemon exit during enumeration is not resurrected
- PTY session ID and Windows/POSIX worktree ID coverage: 3 files / 52 tests passed
- targeted `oxlint` and `oxfmt --check` passed
- `pnpm run check:max-lines-ratchet` passed
- `pnpm run check:reliability-gates` passed
- production five-run alternating benchmark completed

## Terminal reliability proof

- **Reliability class:** `terminal-session.snapshot-freshness`
- **Invariant:** boot hydration may register only an unregistered daemon session owned by a configured local repo whose worktree is still live; `pty:spawn` PID state remains authoritative
- **Failure source:** background boot hydration multiplied Git work by every configured repo, including repos with no preserved session
- **Product change type:** performance hardening
- **Oracle:** count test proves 100 configured / 2 referenced repos yields exactly 2 enumerations and 2 registered sessions; removed-worktree, SSH, daemon-failure, empty-list, and pre-registered PID tests prove the exclusion rules
- **Manifest status:** no matching dedicated reliability gate; focused unit/provider coverage remains partial and this is recorded as an accepted gap
- **Performance budget:** no polling, startup await, renderer work, or new subprocess was added; repo scans become O(referenced repos) instead of O(configured repos). Non-empty hydration adds one O(session count) current+legacy daemon-list RPC/fanout plus transient response allocation to close spawn/exit races.
- **Diagnostics:** existing per-adapter and hydration warning logs remain unchanged
- **Rollback rule:** revert if local preserved sessions lose CPU/memory attribution, SSH sessions enter local sampling, or removed worktrees are re-registered

## Provider and platform coverage

- Local/daemon PTY: covered by hydration and registry tests
- Current + legacy daemon adapters: covered by router and failure-isolation tests
- SSH: covered; SSH repos still skip worktree enumeration and local registration
- WSL: unaffected; referenced local WSL repos continue through the existing worktree provider/path handling
- Runtime-host/mobile/relay: unaffected by this local sampling registry
- macOS/Linux/Windows: repo-ID filtering is path-separator independent; shared worktree-ID tests cover POSIX and Windows paths
- Electron/manual startup: not run because disposable branch identities trigger repeated macOS safe-storage dialogs

## AI Review Report

Reviewed startup/background work, subprocess fanout, session ownership, stale PID protection, removed-worktree behavior, current/legacy daemon adapters, SSH exclusion, Windows/WSL path parsing, large session lists, and failure degradation.

The review rejected two weaker alternatives:

- parallelizing all repo scans would keep the unnecessary process fanout
- deriving locality from repo ID alone without live worktree enumeration could resurrect removed worktrees

The final change deletes unrelated repo scans while preserving the existing live-worktree safety boundary.

## Security Audit

No new dependency, IPC, authentication, secret, shell, or external-input surface.

Session IDs continue through the strict shared `parsePtySessionId` parser and worktree IDs through the shared parser before their repo IDs influence scan selection. Existing configured-repo membership, SSH exclusion, and live-worktree verification remain required before registration.

## Review follow-up (supersedes #8170)

This PR replaces #8170, whose head branch became detached (deleted/recreated branch gotcha). It contains the identical reviewed diff plus one review fix:

- **fix(memory): rescan repos referenced only by the re-read snapshot** — repo selection previously came solely from the first daemon listing, so a session that only became visible on the post-enumeration re-read (e.g. a briefly unreachable adapter) could never be registered for the life of the process. Enumeration now loops until the latest daemon snapshot references no unresolved repos, so selection and registration always share a snapshot. Termination is bounded by the configured repo count; the steady case still does exactly 2 listings and only-referenced-repo scans. Covered by a new red/green regression test.

Made with [Orca](https://github.com/stablyai/orca) 🐋
