### PR TITLE
Fix delayed terminal color-scheme replies leaking into fish

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -6,10 +6,10 @@ import {
   applyTerminalAppearance,
   hexToRgba,
   installMode2031Handlers,
-  maybePushMode2031Flip,
-  mode2031SequenceFor,
   publishTerminalViewAttributesAtAppStart
 } from './terminal-appearance'
+import { maybePushMode2031Flip } from './terminal-mode-2031-replies'
+import { mode2031SequenceFor } from '../../../../shared/terminal-color-scheme-protocol'
 import { replayIntoTerminal, type ReplayingPanesRef } from './replay-guard'
 import { _resetTerminalViewAttributesPublisherForTest } from './terminal-view-attributes-publisher'
 import type { TerminalViewAttributes } from '../../../../shared/terminal-view-attributes'
@@ -17,12 +17,14 @@ import type { TerminalViewAttributes } from '../../../../shared/terminal-view-at
 function fakeTransport(overrides?: { connected?: boolean; sendOk?: boolean }): {
   isConnected: () => boolean
   sendInput: ReturnType<typeof vi.fn<(data: string) => boolean>>
+  sendInputImmediate: ReturnType<typeof vi.fn<(data: string) => boolean>>
 } {
   const connected = overrides?.connected ?? true
   const sendOk = overrides?.sendOk ?? true
   return {
     isConnected: () => connected,
-    sendInput: vi.fn<(data: string) => boolean>(() => sendOk)
+    sendInput: vi.fn<(data: string) => boolean>(() => sendOk),
+    sendInputImmediate: vi.fn<(data: string) => boolean>(() => sendOk)
   }
 }
 
@@ -42,7 +44,7 @@ describe('maybePushMode2031Flip', () => {
     const pushed = maybePushMode2031Flip(1, 'dark', transport, subs, last)
 
     expect(pushed).toBe(false)
-    expect(transport.sendInput).not.toHaveBeenCalled()
+    expect(transport.sendInputImmediate).not.toHaveBeenCalled()
     expect(last.has(1)).toBe(false)
   })
 
@@ -54,8 +56,9 @@ describe('maybePushMode2031Flip', () => {
     const pushed = maybePushMode2031Flip(1, 'dark', transport, subs, last)
 
     expect(pushed).toBe(true)
-    expect(transport.sendInput).toHaveBeenCalledTimes(1)
-    expect(transport.sendInput).toHaveBeenCalledWith('\x1b[?997;1n')
+    expect(transport.sendInputImmediate).toHaveBeenCalledTimes(1)
+    expect(transport.sendInputImmediate).toHaveBeenCalledWith('\x1b[?997;1n')
+    expect(transport.sendInput).not.toHaveBeenCalled()
     expect(last.get(1)).toBe('dark')
   })
 
@@ -70,7 +73,7 @@ describe('maybePushMode2031Flip', () => {
     maybePushMode2031Flip(1, 'dark', transport, subs, last)
     maybePushMode2031Flip(1, 'dark', transport, subs, last)
 
-    expect(transport.sendInput).toHaveBeenCalledTimes(1)
+    expect(transport.sendInputImmediate).toHaveBeenCalledTimes(1)
     expect(last.get(1)).toBe('dark')
   })
 
@@ -83,7 +86,7 @@ describe('maybePushMode2031Flip', () => {
     maybePushMode2031Flip(1, 'light', transport, subs, last)
     maybePushMode2031Flip(1, 'dark', transport, subs, last)
 
-    expect(transport.sendInput.mock.calls.map((c) => c[0])).toEqual([
+    expect(transport.sendInputImmediate.mock.calls.map((c) => c[0])).toEqual([
       '\x1b[?997;1n',
       '\x1b[?997;2n',
       '\x1b[?997;1n'
@@ -99,11 +102,11 @@ describe('maybePushMode2031Flip', () => {
     const pushed = maybePushMode2031Flip(1, 'dark', transport, subs, last)
 
     expect(pushed).toBe(false)
-    expect(transport.sendInput).not.toHaveBeenCalled()
+    expect(transport.sendInputImmediate).not.toHaveBeenCalled()
     expect(last.has(1)).toBe(false)
   })
 
-  it('leaves last-mode untouched when sendInput reports failure', () => {
+  it('leaves last-mode untouched when immediate input reports failure', () => {
     // So a reconnect / retry will re-emit on the next appearance pass.
     const transport = fakeTransport({ sendOk: false })
     const subs = new Map([[1, true]])
@@ -112,7 +115,7 @@ describe('maybePushMode2031Flip', () => {
     const pushed = maybePushMode2031Flip(1, 'dark', transport, subs, last)
 
     expect(pushed).toBe(false)
-    expect(transport.sendInput).toHaveBeenCalledTimes(1)
+    expect(transport.sendInputImmediate).toHaveBeenCalledTimes(1)
     expect(last.has(1)).toBe(false)
   })
 
@@ -130,8 +133,8 @@ describe('maybePushMode2031Flip', () => {
     maybePushMode2031Flip(1, 'dark', transportA, subs, last) // suppressed
     maybePushMode2031Flip(2, 'dark', transportB, subs, last) // flip
 
-    expect(transportA.sendInput).toHaveBeenCalledTimes(1)
-    expect(transportB.sendInput).toHaveBeenCalledTimes(2)
+    expect(transportA.sendInputImmediate).toHaveBeenCalledTimes(1)
+    expect(transportB.sendInputImmediate).toHaveBeenCalledTimes(2)
     expect(last.get(1)).toBe('dark')
     expect(last.get(2)).toBe('dark')
   })

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -1,7 +1,6 @@
 import type { IDisposable, IParser, ITheme } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { GlobalSettings } from '../../../../shared/types'
-import { mode2031SequenceFor } from '../../../../shared/terminal-color-scheme-protocol'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
 import {
@@ -24,8 +23,7 @@ import { HEX_COLOR_RE } from '../../../../shared/color-validation'
 import type { TerminalViewAttributes } from '../../../../shared/terminal-view-attributes'
 import { publishTerminalViewAttributes } from './terminal-view-attributes-publisher'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
-
-export { mode2031SequenceFor }
+import { maybePushMode2031Flip } from './terminal-mode-2031-replies'
 
 // Why Pick<IParser, ...> over a hand-rolled structural type: keeps the helper
 // tied to xterm's canonical signature so any upstream tightening (added
@@ -110,33 +108,6 @@ export function installMode2031Handlers(deps: Mode2031HandlerDeps): IDisposable[
       })
     )
   ]
-}
-
-// Gate on actual mode flip so font/size/opacity tweaks — which also re-run
-// applyTerminalAppearance — don't spam subscribed TUIs with CSI 997. The
-// subscribe/last-mode maps are mutated in place so callers share state with
-// the lifecycle hook's seed path.
-export function maybePushMode2031Flip(
-  paneId: number,
-  mode: 'dark' | 'light',
-  transport: Pick<PtyTransport, 'isConnected' | 'sendInput'>,
-  paneMode2031: Map<number, boolean>,
-  paneLastThemeMode: Map<number, 'dark' | 'light'>
-): boolean {
-  if (!transport.isConnected()) {
-    return false
-  }
-  if (!paneMode2031.get(paneId)) {
-    return false
-  }
-  if (paneLastThemeMode.get(paneId) === mode) {
-    return false
-  }
-  if (!transport.sendInput(mode2031SequenceFor(mode))) {
-    return false
-  }
-  paneLastThemeMode.set(paneId, mode)
-  return true
 }
 
 export function hexToRgba(hex: string, alpha: number): string {

--- a/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts
@@ -41,7 +41,7 @@ describe('pushMode2031SeedReply', () => {
     }
   }
 
-  it('routes the DSR response through latency-critical input', () => {
+  it('routes the color-scheme response through latency-critical input', () => {
     const harness = createHarness(true)
 
     harness.push()

--- a/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { pushMode2031SeedReply } from './terminal-mode-2031-replies'
+
+describe('pushMode2031SeedReply', () => {
+  function createHarness(connected: boolean): {
+    connected: { current: boolean }
+    subscribed: { current: boolean }
+    sendInput: ReturnType<typeof vi.fn<(data: string) => boolean>>
+    sendInputImmediate: ReturnType<typeof vi.fn<(data: string) => boolean>>
+    scheduled: (() => void)[]
+    recordMode: ReturnType<typeof vi.fn>
+    push: () => void
+  } {
+    const connectedState = { current: connected }
+    const subscribed = { current: true }
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const sendInputImmediate = vi.fn<(data: string) => boolean>(() => true)
+    const scheduled: (() => void)[] = []
+    const recordMode = vi.fn()
+    const transport = {
+      isConnected: () => connectedState.current,
+      sendInput,
+      sendInputImmediate
+    }
+    return {
+      connected: connectedState,
+      subscribed,
+      sendInput,
+      sendInputImmediate,
+      scheduled,
+      recordMode,
+      push: () =>
+        pushMode2031SeedReply(1, {
+          hasPane: () => true,
+          isSubscribed: () => subscribed.current,
+          getTransport: () => transport,
+          getMode: () => 'dark',
+          recordMode,
+          schedule: (callback) => scheduled.push(callback)
+        })
+    }
+  }
+
+  it('routes the DSR response through latency-critical input', () => {
+    const harness = createHarness(true)
+
+    harness.push()
+
+    expect(harness.sendInputImmediate).toHaveBeenCalledWith('\x1b[?997;1n')
+    expect(harness.sendInput).not.toHaveBeenCalled()
+    expect(harness.recordMode).toHaveBeenCalledWith(1, 'dark')
+  })
+
+  it('cancels a pre-connect retry after the program unsubscribes', () => {
+    const harness = createHarness(false)
+
+    harness.push()
+    expect(harness.scheduled).toHaveLength(1)
+
+    harness.subscribed.current = false
+    harness.connected.current = true
+    harness.scheduled.shift()?.()
+
+    expect(harness.sendInputImmediate).not.toHaveBeenCalled()
+    expect(harness.sendInput).not.toHaveBeenCalled()
+    expect(harness.scheduled).toHaveLength(0)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.ts
@@ -29,7 +29,7 @@ export function pushMode2031SeedReply(paneId: number, deps: Mode2031SeedReplyDep
   let attempts = 0
   const send = (): void => {
     // Why: a TUI can unsubscribe while the PTY is connecting; every delayed
-    // attempt must revalidate intent or its DSR reply can land at a shell prompt.
+    // attempt must revalidate intent or its color reply can land at a shell prompt.
     if (!deps.hasPane(paneId) || !deps.isSubscribed(paneId)) {
       return
     }

--- a/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.ts
@@ -1,0 +1,75 @@
+import { mode2031SequenceFor } from '../../../../shared/terminal-color-scheme-protocol'
+import type { TerminalColorSchemeMode } from '../../../../shared/terminal-color-scheme-protocol'
+import type { PtyTransport } from './pty-transport'
+
+const MODE_2031_CONNECT_RETRY_MS = 25
+const MODE_2031_CONNECT_ATTEMPTS = 8
+
+type Mode2031ReplyTransport = Pick<PtyTransport, 'isConnected' | 'sendInputImmediate'>
+
+type Mode2031SeedReplyDeps = {
+  hasPane: (paneId: number) => boolean
+  isSubscribed: (paneId: number) => boolean
+  getTransport: (paneId: number) => Mode2031ReplyTransport | undefined
+  getMode: () => TerminalColorSchemeMode | null
+  recordMode: (paneId: number, mode: TerminalColorSchemeMode) => void
+  schedule: (callback: () => void, delayMs: number) => void
+}
+
+function sendMode2031Reply(
+  transport: Mode2031ReplyTransport,
+  mode: TerminalColorSchemeMode
+): boolean {
+  // Why: fish stops reading mode-2031 replies quickly; remote input batching
+  // can otherwise deliver this terminal response after the shell regains input.
+  return transport.sendInputImmediate(mode2031SequenceFor(mode))
+}
+
+export function pushMode2031SeedReply(paneId: number, deps: Mode2031SeedReplyDeps): void {
+  let attempts = 0
+  const send = (): void => {
+    // Why: a TUI can unsubscribe while the PTY is connecting; every delayed
+    // attempt must revalidate intent or its DSR reply can land at a shell prompt.
+    if (!deps.hasPane(paneId) || !deps.isSubscribed(paneId)) {
+      return
+    }
+    const transport = deps.getTransport(paneId)
+    if (!transport?.isConnected()) {
+      attempts += 1
+      if (attempts < MODE_2031_CONNECT_ATTEMPTS) {
+        deps.schedule(send, MODE_2031_CONNECT_RETRY_MS)
+      }
+      return
+    }
+    const mode = deps.getMode()
+    if (mode && sendMode2031Reply(transport, mode)) {
+      deps.recordMode(paneId, mode)
+    }
+  }
+  send()
+}
+
+// Appearance updates include font and opacity changes, so only report actual
+// color-mode flips to programs that still have mode 2031 enabled.
+export function maybePushMode2031Flip(
+  paneId: number,
+  mode: TerminalColorSchemeMode,
+  transport: Mode2031ReplyTransport,
+  paneMode2031: Map<number, boolean>,
+  paneLastThemeMode: Map<number, TerminalColorSchemeMode>
+): boolean {
+  if (!transport.isConnected()) {
+    return false
+  }
+  if (!paneMode2031.get(paneId)) {
+    return false
+  }
+  if (paneLastThemeMode.get(paneId) === mode) {
+    return false
+  }
+  if (!sendMode2031Reply(transport, mode)) {
+    return false
+  }
+  paneLastThemeMode.set(paneId, mode)
+  return true
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -58,11 +58,8 @@ import {
 import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
-import {
-  applyTerminalAppearance,
-  installMode2031Handlers,
-  mode2031SequenceFor
-} from './terminal-appearance'
+import { applyTerminalAppearance, installMode2031Handlers } from './terminal-appearance'
+import { pushMode2031SeedReply } from './terminal-mode-2031-replies'
 import { handleOsc52ClipboardRequest } from './osc52-clipboard'
 import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
@@ -604,34 +601,22 @@ export function useTerminalPaneLifecycle({
   }
 
   const pushMode2031ForPane = (paneId: number): void => {
-    let attempts = 0
-    const send = (): void => {
-      if (!managerRef.current?.getPanes().some((pane) => pane.id === paneId)) {
-        return
+    pushMode2031SeedReply(paneId, {
+      hasPane: (candidateId) =>
+        managerRef.current?.getPanes().some((pane) => pane.id === candidateId) === true,
+      isSubscribed: (candidateId) => paneMode2031Ref.current.get(candidateId) === true,
+      getTransport: (candidateId) => paneTransportsRef.current.get(candidateId),
+      getMode: () => {
+        const currentSettings = settingsRef.current
+        return currentSettings
+          ? resolveEffectiveTerminalAppearance(currentSettings, systemPrefersDarkRef.current).mode
+          : null
+      },
+      recordMode: (candidateId, mode) => paneLastThemeModeRef.current.set(candidateId, mode),
+      schedule: (callback, delayMs) => {
+        window.setTimeout(callback, delayMs)
       }
-      const transport = paneTransportsRef.current.get(paneId)
-      if (!transport?.isConnected()) {
-        // Why: TUIs can subscribe before pty:spawn resolves. Retry briefly so
-        // the recorded subscription still receives the initial dark/light seed.
-        attempts += 1
-        if (attempts < 8) {
-          window.setTimeout(send, 25)
-        }
-        return
-      }
-      const currentSettings = settingsRef.current
-      if (!currentSettings) {
-        return
-      }
-      const { mode } = resolveEffectiveTerminalAppearance(
-        currentSettings,
-        systemPrefersDarkRef.current
-      )
-      if (transport.sendInput(mode2031SequenceFor(mode))) {
-        paneLastThemeModeRef.current.set(paneId, mode)
-      }
-    }
-    send()
+    })
   }
 
   // Initialize PaneManager instance once


### PR DESCRIPTION
## Description

Fixes #8128.

fish 4.7.1 subscribes to terminal color-scheme updates with `CSI ?2031h` and expects the terminal's `CSI ?997;1n`/`;2n` response while it still owns a short raw-input read window. The visible-pane responder used ordinary remote input batching, so an 8 ms-delayed response could arrive after fish ran `CSI ?2031l` and handed input to a foreground command. The escaped response then appeared as `^[[?997;1n`.

This PR:

- routes visible mode-2031 seed and theme-flip replies through `sendInputImmediate`, matching other latency-sensitive terminal-query responders;
- rechecks the live mode-2031 subscription before every bounded pre-connect retry, so `?2031l` cancels a stale seed;
- extracts the timing policy into `terminal-mode-2031-replies.ts` with deterministic regression tests.

## Evidence of fix

### Before: reproduced

Reproduction and protocol analysis: https://github.com/stablyai/orca/issues/8128#issuecomment-4942056433

A real fish 4.7.1 + node-pty + Orca xterm.js harness ran `sleep 0.15` immediately after fish subscribed:

```text
8 ms ordinary-input delay: leak=true  matches=["sleep 0.15", "^[[?997;1n..."] rawEcho=true
0 ms immediate control:   leak=false matches=["sleep 0.15"]                 rawEcho=false
```

This was rerun after implementation with the same result, proving the timing oracle independently of mocks. No external downloads or untrusted artifacts were used.

### After: fixed source path

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts \
  src/renderer/src/components/terminal-pane/terminal-appearance.test.ts \
  src/renderer/src/components/terminal-pane/remote-runtime-pty-query-reply-immediate.test.ts
```

```text
Test Files  3 passed (3)
Tests       28 passed (28)
```

The regression oracle proves that the visible mode-2031 response calls `sendInputImmediate` with `CSI ?997;1n`, never calls ordinary `sendInput`, and sends nothing when a queued pre-connect attempt runs after unsubscribe. Existing remote-transport coverage also proves immediate replies flush earlier typed bytes in order before bypassing the 8 ms batch.

Additional checks:

- `pnpm typecheck:web` — passed.
- focused `oxlint` on all five changed files — passed.
- `pnpm check:max-lines-ratchet` — passed; no new suppression.
- `pnpm check:reliability-gates` — passed.
- Pre-rebase full `pnpm test` — 26,490 passed, 33 skipped, one unrelated 100-tab wall-clock threshold failure (`57.17 ms > 50 ms`); the isolated test rerun passed (1/1, 51 ms total test duration).
- Full `pnpm lint` reached an unrelated existing Japanese localization interpolation mismatch at `components.native-chat.composer.uploadingAttachments`; changed-file lint and all relevant gates passed.

## ELI5

fish briefly asks Orca, “am I using dark or light colors?” Orca knew the answer, but remote terminals sometimes held that tiny answer for 8 ms to batch it with typing. By then fish had stopped listening, so the answer was treated like text typed into the next command and printed as random characters. Orca now sends this terminal-only answer immediately, and throws it away if fish has already said it no longer wants updates.

## User-facing trade-offs

- Users should no longer see `^[[?997;1n`/`^[[?997;2n` leak into fish prompts or foreground commands on delayed remote paths.
- A rare mode-2031 subscribe/theme-change reply bypasses the normal 8 ms input batch. The immediate transport flushes pending user input first, preserving byte order, but may end one typing batch slightly early.
- If a program unsubscribes while its PTY is still connecting, Orca intentionally drops the stale initial color reply. A later fresh subscribe still triggers a new reply.
- No setting, UI, shell-specific filesystem assumption, or provider-specific protocol was added.

## Terminal reliability proof

- **Reliability invariant:** `terminal-capability.query-reply-timeliness` — a mode-2031 `CSI 997` response must reach the subscribing program before its raw-read window closes, in byte order, and must never be sent for a subscription that has since been cleared. Motivated by #8128.
- **Failure source:** deterministic fish 4.7.1/node-pty/xterm reproduction of an 8 ms delayed remote-style reply escaping into the next input owner.
- **Material impact:** makes delayed/stale color-scheme responses harder to reintroduce on visible panes; both immediate routing and unsubscribe-during-connect are pinned independently.
- **Product change type:** mixed product runtime hardening and renderer contract coverage.
- **Manifest status:** accepted gap. The adjacent experimental `terminal-capability.startup-color-query` gate is OSC 10/11-specific and remains unchanged. Intended future gate id is `terminal-capability.mode-2031-reply-timeliness`; this PR does not claim promotion from a mismatched gate.
- **Oracle:** delayed real-fish reply renders `^[[?997;1n`; immediate reply does not. Source-coupled tests require the immediate method and zero post-unsubscribe sends.
- **Performance risk inventory:** touches rare mode-2031 subscribe/theme responses and the existing pane-connect retry only. It does not touch per-keystroke typing work, PTY output, rendering, focus, resize, startup awaits, provider listing, subprocesses, or retained buffers.
- **No-regression evidence:** no new polling, timers, scans, provider calls, hidden-pane wakeups, or output buffering. The existing retry remains capped at eight total attempts/25 ms spacing; the stale-retry test proves unsubscribe stops rescheduling. Immediate remote input uses the existing ordered flush contract.
- **Diagnostics:** the deterministic fish harness captures `leak`, matching rendered lines, and raw PTY echo; focused tests identify whether immediate routing or stale cancellation regressed. No raw-terminal telemetry/logging was added.
- **Provider/platform coverage:** local PTY behavior covered by real fish on macOS and local immediate transport semantics; remote-runtime ordering covered by the existing immediate-reply transport test; daemon/local IPC uses the same immediate alias and is unaffected apart from routing; SSH uses the provider-neutral transport interface with no local filesystem/process assumption. Linux behavior is represented by fish protocol semantics but not live-tested in this run. WSL/Windows and mobile/relay are accepted live-test gaps; gate-managed hidden mode-2031 handling was already immediate and is unchanged; snapshot-skip, discarded-query salvage, and resubscribe-generation paths remain explicit follow-up gaps from the similar-class audit.
- **Residual gaps:** no packaged Electron end-to-end run, live SSH host run, Linux host run, or Windows/WSL shell run. The real harness controls the response timing directly; the renderer contract test is the source-coupled after proof.
- **Promotion status:** `none` — deterministic red/green coverage exists, but there is no registered manifest command or cross-platform stability history yet.
- **Rollback/demotion rule:** revert or follow up if immediate mode replies reorder pending typed bytes, create duplicate theme responses, or a live provider shows a regression. Do not promote the future gate until remote/SSH and platform evidence is stable.
