### PR TITLE
fix(terminal): derive zsh wrapper ZDOTDIR from %x so non-ASCII WSL logins load .zshrc (#8003)

### DIFF
--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -734,7 +734,19 @@ describePosix('local PTY shell-ready launch config', () => {
 
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
 
-    expect(zshenv).toContain('_orca_wrapper_zdotdir_self="${ZDOTDIR:-}"')
+    // Why: derive the wrapper dir from %x (zsh's internal script name), not the
+    // env-imported $ZDOTDIR — zsh corrupts environment values whose UTF-8 bytes
+    // fall in its 0x84-0x9D token range (non-ASCII Windows usernames), which
+    // would fail the self-check and fall back to the unusable baked literal.
+    expect(zshenv).toContain('_orca_wrapper_zdotdir_self="${${(%):-%x}:h}"')
+    // Keep $ZDOTDIR only as a fallback when %x expansion yields nothing. The
+    // final restore below re-validates with -f before trusting the value, so no
+    // stat is needed here.
+    expect(zshenv).toContain(
+      'if [[ -z "${_orca_wrapper_zdotdir_self:-}" ]]; then\n' +
+        '  _orca_wrapper_zdotdir_self="${ZDOTDIR:-}"\n' +
+        'fi'
+    )
     // The runtime path is only trusted when it still holds a wrapper .zshenv;
     // otherwise the generation-time literal remains as the fallback.
     expect(zshenv).toContain(
@@ -745,7 +757,7 @@ describePosix('local PTY shell-ready launch config', () => {
         'fi'
     )
     // Capture must happen before the wrapper unsets ZDOTDIR to source user files.
-    expect(zshenv.indexOf('_orca_wrapper_zdotdir_self="${ZDOTDIR:-}"')).toBeLessThan(
+    expect(zshenv.indexOf('_orca_wrapper_zdotdir_self="${${(%):-%x}:h}"')).toBeLessThan(
       zshenv.indexOf('unset ZDOTDIR')
     )
   })
@@ -889,6 +901,52 @@ path=(/custom/bin $path)
         }
       } finally {
         rmSync(movedUserData, { recursive: true, force: true })
+      }
+    })
+
+    it('loads user .zshrc when the wrapper dir contains a non-ASCII (token-range) path', async () => {
+      // Why: issue #8003 second trigger — a non-ASCII Windows username (e.g. a
+      // Korean login) puts UTF-8 bytes in zsh's 0x84-0x9D token range into the
+      // wrapper path. zsh corrupts the env-imported $ZDOTDIR while processing
+      // startup files, so deriving the wrapper dir from $ZDOTDIR fails the
+      // self-check and falls back to the unusable baked literal, leaving the
+      // user's .zshrc unloaded. Deriving from %x sidesteps the corruption.
+      writeFileSync(join(testHome, '.zshrc'), 'export USER_ZSHRC_LOADED=yes\n')
+
+      const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+      getShellReadyLaunchConfig('/bin/zsh')
+
+      // Move the generated wrappers under a non-ASCII runtime root so the baked
+      // literal is unusable and the runtime $ZDOTDIR gets corrupted on import.
+      const nonAsciiUserData = join(dirname(userDataPath), '홍길동-wsl-view')
+      renameSync(userDataPath, nonAsciiUserData)
+      try {
+        const cleanEnv: Record<string, string | undefined> = {
+          ...process.env,
+          HOME: testHome,
+          PATH: '/usr/bin:/bin'
+        }
+        delete cleanEnv.ZDOTDIR
+        delete cleanEnv.ORCA_ORIG_ZDOTDIR
+        delete cleanEnv.ORCA_ATTRIBUTION_SHIM_DIR
+        delete cleanEnv.USER_ZSHRC_LOADED
+        cleanEnv.ZDOTDIR = join(nonAsciiUserData, 'shell-ready', 'zsh')
+
+        for (const args of [['-i'], ['-l', '-i']] as const) {
+          const result = spawnSync(
+            'zsh',
+            [...args, '-c', 'echo "USER_ZSHRC_LOADED=${USER_ZSHRC_LOADED:-no}"'],
+            {
+              env: cleanEnv as NodeJS.ProcessEnv,
+              encoding: 'utf8'
+            }
+          )
+
+          expect(result.status, `zsh ${args.join(' ')} failed: ${result.stderr}`).toBe(0)
+          expect(result.stdout).toContain('USER_ZSHRC_LOADED=yes')
+        }
+      } finally {
+        rmSync(nonAsciiUserData, { recursive: true, force: true })
       }
     })
 

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -13,7 +13,17 @@ export function getZshEnvTemplate(zshDir: string, headerPrefix = ''): string {
 # Why: capture the runtime wrapper dir before it is unset below. On WSL this
 # file is generated with a Windows path but sourced via /mnt/c, so the baked
 # literal is unusable there and ZDOTDIR must be restored from this value.
-_orca_wrapper_zdotdir_self="\${ZDOTDIR:-}"
+# Derive it from the file being sourced (%x, zsh's internal script name) rather
+# than the env-imported $ZDOTDIR: zsh corrupts environment values whose UTF-8
+# bytes fall in its 0x84-0x9D token range (e.g. a non-ASCII Windows username
+# such as a Korean login), which would make the self-check below fail and fall
+# back to the unusable baked literal, so the user's .zshrc never loads (#8003).
+# %x is not subject to that corruption; keep $ZDOTDIR as a fallback for the
+# rare shell where %x prompt expansion yields nothing.
+_orca_wrapper_zdotdir_self="\${\${(%):-%x}:h}"
+if [[ -z "\${_orca_wrapper_zdotdir_self:-}" ]]; then
+  _orca_wrapper_zdotdir_self="\${ZDOTDIR:-}"
+fi
 while [[ "\${_orca_wrapper_zdotdir_self:-}" == */ ]]; do
   _orca_wrapper_zdotdir_self="\${_orca_wrapper_zdotdir_self%/}"
 done


### PR DESCRIPTION
Closes #8003

> **Takeover note:** This PR started as @rodboev's `ORCA_ORIG_ZDOTDIR` Windows-path normalization. It has been reworked (with credit — see the `Co-authored-by` trailer) to a smaller wrapper self-location fix that resolves the deeper root cause, including the non-ASCII trigger the normalization approach did not cover. Rationale for the approach change is in **Trade-offs** below.

## Description

The zsh shell-ready wrapper (`getZshEnvTemplate`) restored `ZDOTDIR` from the **env-imported** `${ZDOTDIR}`. That value is unreliable in exactly the scenario #8003 hits:

- On **Windows + WSL**, the wrappers are generated under the Windows user-data path (a Windows literal is baked into `.zshenv`) but sourced inside WSL via `/mnt/c`. The baked literal doesn't exist in WSL, so the wrapper must recover the runtime dir from `${ZDOTDIR}`.
- For a **non-ASCII Windows username** (e.g. a Korean login `홍길동`), the WSL-visible `ZDOTDIR` path contains UTF-8 bytes in zsh's internal **0x84–0x9D token range**. zsh corrupts environment-imported values containing those bytes while processing startup files. The corrupted `${ZDOTDIR}` failed the self-check, the wrapper fell back to the **unusable baked Windows literal**, and the user's `~/.zshrc` never loaded — the reported bare `HOSTNAME%` prompt with no theme, aliases, or PATH.

**Fix:** derive the wrapper dir from `${${(%):-%x}:h}` — `%x` is zsh's internal script name for the file currently being sourced (`:h` = its dirname). It's regenerated from zsh's correctly-metafied internal state, so it is **not** subject to the env-import corruption. `${ZDOTDIR}` is kept only as a fallback when `%x` expansion yields nothing, and the pre-existing final restore still validates with `-f` before trusting the value.

One template (`getZshEnvTemplate`) feeds local PTYs, the daemon, **and** the Windows→WSL launch path (`buildWslShellArgs` → `ensureShellReadyWrappersAt`), so the single change covers every zsh transport.

## Evidence

zsh 5.9 on Ubuntu (WSL2). Core mechanism, isolated:

```
ENV_METHOD=[/root/.../홍길동(corrupted: �`=길�{`)/shell-ready/zsh]   ENV_HAS_ZSHENV=no
SELF_METHOD=[/root/.../홍길동/shell-ready/zsh]                        SELF_HAS_ZSHENV=yes
```
`${ZDOTDIR}` (env method) is corrupted → self-check fails. `${${(%):-%x}:h}` (self method) stays correct.

End-to-end, using the **real** production-generated wrappers, with the baked literal pointing at a missing path (mirrors the Windows→WSL split):

| Scenario | Before (unfixed) | After (this PR) |
|---|---|---|
| ASCII username, path-view move | `.zshrc` loads ✅ | `.zshrc` loads ✅ |
| **Non-ASCII (홍길동) username** | **`.zshrc` NOT loaded ❌** | **`.zshrc` loads ✅** |

Regression pass against the fixed wrappers (real zsh): ASCII path-move, non-ASCII path-move (both `zsh -i` and `zsh -l -i`), XDG `ZDOTDIR` discovery + `typeset -U path` scoping, and vanilla-no-ZDOTDIR fallback all still behave correctly. Windows unit tests, `oxlint`, and `tsc` pass. A new live-zsh regression test (`loads user .zshrc when the wrapper dir contains a non-ASCII (token-range) path`) runs in Linux CI.

## ELI5

Orca leaves zsh a note ("your real config lives over here") using an address written on an envelope. On Windows→WSL that address is garbled by zsh's mailroom when the username has non-English letters (like Korean) — so zsh gives up and your shell opens with no theme, aliases, or PATH. Instead of reading the garbled envelope, we now ask zsh "which file are you reading right now?" and use the folder it's already sitting in. That answer is never garbled, so your real `~/.zshrc` loads every time.

## Trade-offs / user regressions

**Targeted regression risk: zero.**
- **macOS / Linux / SSH (common case):** the value derived from `%x` is identical to the old `${ZDOTDIR}` value (dirname of the `.zshenv` being sourced = the wrapper dir), so behavior is byte-for-byte unchanged. Verified by live-zsh tests.
- **`%x` availability:** `%x`, the `(%)` prompt flag, and the `:h` modifier are all present since zsh 5.0 — below the supported baseline. If `%x` ever expanded to nothing, we fall back to the old `${ZDOTDIR}` path.
- **Perf:** startup-only, in-process string expansion — no subshell/fork, no added filesystem stat (the simplified fallback drops a redundant `-f`; the existing final restore already validates). Confirmed by an adversarial perf review.
- **SSH/relay** uses a separate template that bakes an always-valid literal (deployed to the same path it's sourced from) and is immune by construction — out of scope, unchanged.

**Why the approach changed from path-normalization:** the original `ORCA_ORIG_ZDOTDIR` normalization operated on a *different* variable (the user's config dir, not the wrapper's `ZDOTDIR` self-restore that #8003 breaks), did **not** fix the non-ASCII corruption (a normalized `/mnt/c/Users/홍길동/…` still corrupts on import), and hardcoded the `/mnt/` automount root (breaking custom-automount users). The `%x` self-location fix is smaller, root-cause, and regression-free.

**Known residual (not a regression):** in the non-ASCII case the *final* interactive `$ZDOTDIR` can still read back corrupted, because zsh re-reads the poisoned env value across startup-file boundaries after our restore runs. This is cosmetic — the user's `~/.zshrc` (prompt, theme, aliases, PATH) loads correctly because those are sourced via the HOME-derived `ORCA_ORIG_ZDOTDIR`, which zsh does **not** corrupt. Before this PR that path was *also* wrong **and** nothing loaded, so this is a strict improvement.

## Adversarial review

Ran adversarial perf and correctness/reliability reviews over the diff and all consumers. No blocker/major findings. The one perf nit (a redundant `stat`) was addressed by simplifying the fallback guard.
