### PR TITLE
Send hidden terminal query replies without batching

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -12,6 +12,7 @@ import {
   RESET_TERMINAL_CURSOR_STYLE
 } from './layout-serialization'
 import { buildFreshShellViewportBlankingSequence } from './terminal-restored-viewport'
+import { DEFAULT_DA1_RESPONSE } from './terminal-capability-replies'
 import { TERMINAL_PASTE_DIRECT_MAX_BYTES } from './terminal-paste-coordinator'
 import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shift-enter'
 import type * as UseNotificationDispatchModule from './use-notification-dispatch'
@@ -8344,23 +8345,24 @@ describe('connectPanePty', () => {
         }
       })
 
-      it('salvages stateful queries out of an overflowing restore queue', async () => {
+      it('sends salvaged queries immediately from an overflowing restore queue', async () => {
         const { pane, transport, dataCallback } = await startInFlightRestore()
 
-        // Queue 400KB, then a chunk that overflows the cap and carries a DSR
-        // probe. The content is discarded (snapshot owns it) but the probe's
-        // reply is SYNTHESIZED directly — replaying it into xterm would race
-        // the restore's discard and the replay guard's auto-reply swallow.
+        // Queue 400KB, then overflow with color, CPR, and DA probes. The
+        // discarded probes need direct replies before their read windows close.
         dataCallback('a'.repeat(400 * 1024), { seq: 400 * 1024, rawLength: 400 * 1024 })
-        dataCallback(`${'b'.repeat(200 * 1024)}\x1b[6n`, {
-          seq: 600 * 1024 + 4,
-          rawLength: 200 * 1024 + 4
+        const queries = '\x1b]11;?\x1b\\\x1b[6n\x1b[c'
+        dataCallback(`${'b'.repeat(200 * 1024)}${queries}`, {
+          seq: 600 * 1024 + queries.length,
+          rawLength: 200 * 1024 + queries.length
         })
         await flushAsyncTicks(8)
 
-        const replies = transport.sendInput.mock.calls.map((call) => String(call[0]))
+        const replies = transport.sendInputImmediate.mock.calls.map((call) => String(call[0]))
+        expect(replies.some((reply) => reply.startsWith('\x1b]11;rgb:'))).toBe(true)
         // oxlint-disable-next-line no-control-regex -- the ESC byte IS the payload: this matches the CPR reply
         expect(replies.some((reply) => /^\u001b\[\d+;\d+R$/.test(reply))).toBe(true)
+        expect(replies).toContain(DEFAULT_DA1_RESPONSE)
         const written = writtenFloodData(pane)
         expect(written).not.toContain('aaaa')
         expect(written).not.toContain('bbbb')
@@ -9232,7 +9234,7 @@ describe('connectPanePty', () => {
     isVisibleRef.current = true
     capturedDataCallback.current?.('31h')
 
-    expect(transport.sendInput).toHaveBeenCalledWith('\x1b[?997;2n')
+    expect(transport.sendInputImmediate).toHaveBeenCalledWith('\x1b[?997;2n')
     expect(paneMode2031Ref.current.get(1)).toBe(true)
     expect(paneLastThemeModeRef.current.get(1)).toBe('light')
     expect(pane.terminal.write).not.toHaveBeenCalledWith('31h', expect.any(Function))

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5029,10 +5029,9 @@ export function connectPanePty(
       const settings = useAppStore.getState().settings
       const mode = resolveTerminalColorSchemeMode(settings, getSystemPrefersDark())
       // Why: hidden snapshot-backed panes skip xterm.write for PTY bytes. Answer
-      // mode 2031 out-of-band so TUIs still render the snapshot with the same
-      // theme-dependent styling they would have used in a visible pane.
+      // immediately so the reply cannot outlive the program's read window.
       deps.paneMode2031Ref.current.set(pane.id, true)
-      transport.sendInput(mode2031SequenceFor(mode))
+      transport.sendInputImmediate(mode2031SequenceFor(mode))
       deps.paneLastThemeModeRef.current.set(pane.id, mode)
       recordHiddenMode2031Reply()
     }
@@ -5311,7 +5310,7 @@ export function connectPanePty(
     // Why: discarding queued flood bytes must never swallow terminal queries —
     // a lost DSR/CPR (or color/DA) reply hangs the querying program (the bench
     // DSR timeout). The discarded CONTENT is owned by the snapshot repaint.
-    // Replies are SYNTHESIZED directly (transport.sendInput) instead of
+    // Replies are synthesized through the immediate input path instead of
     // replaying the queries into xterm: a drop always triggers a snapshot
     // restore, whose replay guard swallows xterm auto-replies and whose
     // discardTerminalOutput races away queued query writes — both killed the
@@ -5324,7 +5323,7 @@ export function connectPanePty(
       const extracted = extractHiddenStartupRendererQueryData(data, '')
       if (extracted.oscColorQueryData) {
         sendTerminalOscColorQueryReplies(extracted.oscColorQueryData, pane.terminal, (reply) =>
-          transport.sendInput(reply)
+          transport.sendInputImmediate(reply)
         )
       }
       let unansweredQueryData = ''
@@ -5338,9 +5337,9 @@ export function connectPanePty(
           const buffer = pane.terminal.buffer.active
           const row = Math.min(buffer.cursorY + 1, pane.terminal.rows)
           const col = Math.min(buffer.cursorX + 1, pane.terminal.cols)
-          transport.sendInput(`\x1b[${row};${col}R`)
+          transport.sendInputImmediate(`\x1b[${row};${col}R`)
         } else if (sequence === '\x1b[c' || sequence === '\x1b[0c') {
-          transport.sendInput(DEFAULT_DA1_RESPONSE)
+          transport.sendInputImmediate(DEFAULT_DA1_RESPONSE)
         } else {
           unansweredQueryData += sequence
         }


### PR DESCRIPTION
## Description

Follow-up to #8206. Hidden snapshot/restore paths were still routing four latency-sensitive terminal replies through ordinary remote input batching:

- mode-2031 color-scheme replies from skipped hidden output;
- OSC color replies salvaged from discarded restore data;
- CPR cursor-position replies salvaged from discarded restore data;
- DA1 replies salvaged from discarded restore data.

Remote input batches ordinary input for 8 ms. Programs read these control replies in short raw-input windows, so batching can deliver them after the program has stopped listening and leak the bytes into the next input owner. This PR routes all four through the existing ordered `sendInputImmediate` path.

## Evidence of fix

The source-coupled tests were changed before production code. On merged `main`, both red assertions failed:

```text
FAIL sends salvaged queries immediately from an overflowing restore queue
FAIL answers hidden Codex mode 2031 subscribes split across becoming visible
```

After the fix:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/pty-connection.test.ts \
  src/renderer/src/components/terminal-pane/remote-runtime-pty-query-reply-immediate.test.ts \
  src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts \
  src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
```

```text
Test Files  4 passed (4)
Tests       449 passed (449)
```

The overflow test forces the 512 KB restore queue to discard bytes containing OSC 11, CPR, and DA1 queries, then asserts every synthesized response uses `sendInputImmediate`. The hidden mode-2031 test asserts its `CSI ?997;2n` response uses the same immediate route.

Additional checks passed:

- `pnpm typecheck:web`
- changed-file `oxlint`
- `pnpm check:max-lines-ratchet`
- `pnpm check:reliability-gates`

## ELI5

A hidden terminal can throw away old screen-painting data because a fresh snapshot will repaint it. Before throwing data away, Orca saves any tiny “please answer me” terminal questions. We were saving the answers but putting them in the normal typing batch, so they could arrive too late. These answers now use the express lane while keeping earlier typed bytes in order.

## User-facing trade-offs

- Hidden or restoring remote terminals should no longer leak late color/cursor/device replies or leave querying programs waiting.
- These rare control replies can end an ordinary 8 ms typing batch early; the existing immediate transport flushes earlier input first, preserving byte order.
- No new polling, timers, parsing passes, buffers, settings, or provider-specific branches were added.
- The fix does not change how discarded screen content is restored; only the reply channel changes.

## Terminal reliability proof

- **Reliability invariant:** `terminal-capability.query-reply-timeliness` — replies salvaged or synthesized outside xterm must reach the current query owner immediately and in byte order.
- **Failure source:** same-class audit after #8206; direct code trace proved remote-runtime hidden snapshots reach ordinary 8 ms batching at the four changed calls.
- **Product change type:** runtime hardening plus deterministic renderer contract coverage.
- **Manifest status:** accepted gap; proposed future gate remains `terminal-capability.mode-2031-reply-timeliness`, broadened later if salvage coverage matures.
- **Oracle:** tests fail when the four calls use `sendInput` and pass only when mode-2031, OSC, CPR, and DA1 replies use `sendInputImmediate`.
- **Provider/platform coverage:** remote-runtime ordering is covered by the existing transport test. Local/daemon use the immediate queue alias; SSH uses the provider-neutral transport contract. No filesystem, shell, path, OS, WSL, mobile, or Git-provider behavior changed. Live SSH/Windows/Linux/mobile runs are accepted gaps.
- **Performance budget:** zero added work; four existing writes change priority. No scans, retries, wakeups, awaits, serialization, or buffering were added.
- **Diagnostics:** the overflow fixture identifies the missing reply family and transport method without recording raw user terminal output.
- **Promotion status:** `none`; focused red/green proof exists but no registered cross-platform blocking gate.
- **Rollback rule:** revert or follow up if immediate replies reorder pending typed bytes or a provider reports duplicate responses.
