### PR TITLE
Cancel stale mode 2031 retries across resubscribe

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts
@@ -17,6 +17,7 @@ describe('pushMode2031SeedReply', () => {
     const sendInputImmediate = vi.fn<(data: string) => boolean>(() => true)
     const scheduled: (() => void)[] = []
     const recordMode = vi.fn()
+    const currentAttempt = { current: Symbol() }
     const transport = {
       isConnected: () => connectedState.current,
       sendInput,
@@ -29,15 +30,19 @@ describe('pushMode2031SeedReply', () => {
       sendInputImmediate,
       scheduled,
       recordMode,
-      push: () =>
+      push: () => {
+        const attempt = Symbol()
+        currentAttempt.current = attempt
         pushMode2031SeedReply(1, {
           hasPane: () => true,
           isSubscribed: () => subscribed.current,
+          isCurrentAttempt: () => currentAttempt.current === attempt,
           getTransport: () => transport,
           getMode: () => 'dark',
           recordMode,
           schedule: (callback) => scheduled.push(callback)
         })
+      }
     }
   }
 
@@ -64,5 +69,22 @@ describe('pushMode2031SeedReply', () => {
     expect(harness.sendInputImmediate).not.toHaveBeenCalled()
     expect(harness.sendInput).not.toHaveBeenCalled()
     expect(harness.scheduled).toHaveLength(0)
+  })
+
+  it('does not let an old retry answer a later subscription', () => {
+    const harness = createHarness(false)
+
+    harness.push()
+    harness.subscribed.current = false
+    harness.subscribed.current = true
+    harness.push()
+    expect(harness.scheduled).toHaveLength(2)
+
+    harness.connected.current = true
+    harness.scheduled.shift()?.()
+    harness.scheduled.shift()?.()
+
+    expect(harness.sendInputImmediate).toHaveBeenCalledTimes(1)
+    expect(harness.recordMode).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.ts
@@ -10,6 +10,7 @@ type Mode2031ReplyTransport = Pick<PtyTransport, 'isConnected' | 'sendInputImmed
 type Mode2031SeedReplyDeps = {
   hasPane: (paneId: number) => boolean
   isSubscribed: (paneId: number) => boolean
+  isCurrentAttempt: (paneId: number) => boolean
   getTransport: (paneId: number) => Mode2031ReplyTransport | undefined
   getMode: () => TerminalColorSchemeMode | null
   recordMode: (paneId: number, mode: TerminalColorSchemeMode) => void
@@ -30,7 +31,7 @@ export function pushMode2031SeedReply(paneId: number, deps: Mode2031SeedReplyDep
   const send = (): void => {
     // Why: a TUI can unsubscribe while the PTY is connecting; every delayed
     // attempt must revalidate intent or its color reply can land at a shell prompt.
-    if (!deps.hasPane(paneId) || !deps.isSubscribed(paneId)) {
+    if (!deps.hasPane(paneId) || !deps.isSubscribed(paneId) || !deps.isCurrentAttempt(paneId)) {
       return
     }
     const transport = deps.getTransport(paneId)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -575,6 +575,7 @@ export function useTerminalPaneLifecycle({
   const selectionDisposablesRef = useRef(new Map<number, IDisposable>())
   const selectionCaptureTimersRef = useRef(new Map<number, number>())
   const mode2031DisposablesRef = useRef(new Map<number, IDisposable[]>())
+  const mode2031SeedAttemptTokensRef = useRef(new Map<number, symbol>())
   const osc52DisposablesRef = useRef(new Map<number, IDisposable>())
   const osc7DisposablesRef = useRef(new Map<number, IDisposable>())
   const mouseHideDisposablesRef = useRef(new Map<number, IDisposable>())
@@ -601,10 +602,15 @@ export function useTerminalPaneLifecycle({
   }
 
   const pushMode2031ForPane = (paneId: number): void => {
+    const attemptToken = Symbol()
+    mode2031SeedAttemptTokensRef.current.set(paneId, attemptToken)
     pushMode2031SeedReply(paneId, {
       hasPane: (candidateId) =>
         managerRef.current?.getPanes().some((pane) => pane.id === candidateId) === true,
       isSubscribed: (candidateId) => paneMode2031Ref.current.get(candidateId) === true,
+      // Why: an older connect retry must not answer a later resubscription.
+      isCurrentAttempt: (candidateId) =>
+        mode2031SeedAttemptTokensRef.current.get(candidateId) === attemptToken,
       getTransport: (candidateId) => paneTransportsRef.current.get(candidateId),
       getMode: () => {
         const currentSettings = settingsRef.current
@@ -1222,6 +1228,7 @@ export function useTerminalPaneLifecycle({
           mode2031DisposablesRef.current.delete(paneId)
         }
         paneMode2031Ref.current.delete(paneId)
+        mode2031SeedAttemptTokensRef.current.delete(paneId)
         paneKittyKeyboardModesRef.current.delete(paneId)
         paneLastThemeModeRef.current.delete(paneId)
         const osc52Disposable = osc52DisposablesRef.current.get(paneId)


### PR DESCRIPTION
## Description

Follow-up to #8206. A mode-2031 subscription can arrive before its PTY transport connects, so Orca retries the initial color-scheme reply up to eight times. #8206 stops a retry after a plain unsubscribe, but this sequence still duplicated the reply:

```text
subscribe → queue retry A → unsubscribe → resubscribe → queue retry B → connect
```

Both A and B saw a currently subscribed pane and answered the newer subscription. A program can consume one reply and leave the duplicate to leak into its next input owner.

This PR gives every subscription attempt an opaque ownership token. A delayed retry sends only if its token still owns that pane. Starting a later subscription invalidates all earlier retries, and pane teardown deletes the token.

## Evidence of fix

The deterministic regression test was added before production code. On merged `main`:

```text
FAIL does not let an old retry answer a later subscription
expected sendInputImmediate 1 time, received 2 times
```

After the fix:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/terminal-mode-2031-replies.test.ts \
  src/renderer/src/components/terminal-pane/terminal-appearance.test.ts \
  src/renderer/src/components/terminal-pane/remote-runtime-pty-query-reply-immediate.test.ts
```

```text
Test Files  3 passed (3)
Tests       29 passed (29)
```

The test queues retries for two subscription generations, connects the transport, executes both callbacks, and proves exactly one immediate reply and one recorded mode.

Additional checks passed:

- `pnpm typecheck:web`
- changed-file `oxlint`
- `pnpm check:max-lines-ratchet`
- `pnpm check:reliability-gates`

## ELI5

Imagine two people take numbered tickets to answer the same terminal question. The first person leaves and a second person asks again. Previously, both old and new tickets could answer once the connection opened. Orca now accepts only the newest ticket, so the old delayed answer cannot spill into the terminal as random text.

## User-facing trade-offs

- Rapid unsubscribe/resubscribe cycles during terminal connection should receive one color-scheme reply instead of duplicates.
- A superseded retry is intentionally dropped even if it fires first; the current subscription owns its own retry and still receives a reply.
- Each active pane retains one symbol token, removed during existing pane teardown.
- No retry interval/count, network call, provider API, terminal byte format, or UI setting changes.

## Terminal reliability proof

- **Reliability invariant:** `terminal-capability.query-reply-generation` — a delayed mode-2031 seed reply must belong to the current subscription generation, not merely a currently true subscription boolean.
- **Failure source:** adversarial review of #8206 reproduced two replies for subscribe/unsubscribe/resubscribe before connection.
- **Product change type:** runtime lifecycle hardening plus deterministic unit coverage.
- **Manifest status:** accepted gap; intended future gate remains `terminal-capability.mode-2031-reply-timeliness`.
- **Oracle:** two queued generations execute after connection but emit exactly one `sendInputImmediate` call.
- **Provider/platform coverage:** generation ownership is renderer state above the provider boundary and applies equally to local, daemon, SSH, WSL, and remote-runtime transports. No OS, filesystem, shell, mobile/relay, or Git-provider code changes. Live SSH/Windows/Linux/mobile runs remain accepted gaps.
- **Performance budget:** one symbol allocation and one bounded map entry per subscribing pane; the entry is replaced on resubscribe and deleted on teardown. No new timers, retries, scans, polling, IPC, or buffering.
- **Diagnostics:** the focused test reports duplicate send and mode-record counts without logging terminal contents.
- **Promotion status:** `none`; deterministic red/green proof exists but the gate is not registered or cross-platform promoted.
- **Rollback rule:** revert or follow up if a current subscription misses its seed or pane-token entries survive teardown.
