### PR TITLE
fix(terminal): open WSL file links on Windows

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
@@ -1,7 +1,11 @@
 import type { IBufferLine, IBufferRange } from '@xterm/xterm'
 import { extractTerminalFileLinkCandidates, resolveTerminalFileLink } from '@/lib/terminal-links'
 import { isRemoteRuntimeFileOperation } from '@/runtime/runtime-file-client'
-import { getTerminalFileContext, openDetectedFilePath } from './terminal-file-open-routing'
+import {
+  getTerminalFileContext,
+  mapTerminalFilePath,
+  openDetectedFilePath
+} from './terminal-file-open-routing'
 import { getTerminalPathExistsCacheKey } from './terminal-path-exists-cache'
 import { resolveKnownWorktreeRootPathLink } from './terminal-worktree-path-link'
 import {
@@ -57,18 +61,19 @@ export function openFilePathLinkAtBufferPosition(
         deps.worktreePath,
         deps.runtimeEnvironmentId
       )
+      const mappedPath = mapTerminalFilePath(resolved.absolutePath, deps.worktreePath)
       const cacheKey = getTerminalPathExistsCacheKey({
-        absolutePath: resolved.absolutePath,
+        absolutePath: mappedPath,
         connectionId: fileContext.connectionId,
-        isRemoteRuntimePath: isRemoteRuntimeFileOperation(fileContext, resolved.absolutePath),
+        isRemoteRuntimePath: isRemoteRuntimeFileOperation(fileContext, mappedPath),
         runtimeEnvironmentId: deps.runtimeEnvironmentId
       })
-      const isKnownWorktreeRoot = Boolean(resolveKnownWorktreeRootPathLink(resolved.absolutePath))
+      const isKnownWorktreeRoot = Boolean(resolveKnownWorktreeRootPathLink(mappedPath))
       if (/[\\/]$/.test(parsed.pathText) && !isKnownWorktreeRoot) {
         continue
       }
       matches.push({
-        absolutePath: resolved.absolutePath,
+        absolutePath: mappedPath,
         line: resolved.line,
         column: resolved.column,
         pathText: parsed.pathText,

--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -11,6 +11,7 @@ import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { resolveKnownWorktreeRootPathLink } from './terminal-worktree-path-link'
+import { parseWslUncPath } from '../../../../shared/wsl-paths'
 
 type TerminalFileOpenDeps = {
   worktreeId: string
@@ -47,6 +48,14 @@ export function getTerminalFileContext(
     worktreePath,
     connectionId: getConnectionId(worktreeId || null) ?? undefined
   }
+}
+
+export function mapTerminalFilePath(filePath: string, worktreePath: string): string {
+  const wslPath = parseWslUncPath(worktreePath)
+  if (!wslPath || !filePath.startsWith('/') || filePath.startsWith('//')) {
+    return filePath
+  }
+  return `//wsl.localhost/${wslPath.distro}${filePath}`
 }
 
 export function shouldOpenTerminalFileWithSystemDefault(
@@ -92,16 +101,20 @@ export function openDetectedFilePath(
   deps: TerminalFileOpenDeps
 ): void {
   const { openWithSystemDefault = false, runtimeEnvironmentId, worktreeId, worktreePath } = deps
+  const mappedFilePath = mapTerminalFilePath(filePath, worktreePath)
   const requestId = ++latestOpenDetectedFilePathRequestId
   cancelPendingEditorRevealFrames()
 
   void (async () => {
     let statResult
     const fileContext = getTerminalFileContext(worktreeId, worktreePath, runtimeEnvironmentId)
-    const canOpenWithSystemDefault = shouldOpenTerminalFileWithSystemDefault(fileContext, filePath)
+    const canOpenWithSystemDefault = shouldOpenTerminalFileWithSystemDefault(
+      fileContext,
+      mappedFilePath
+    )
 
     if (!openWithSystemDefault) {
-      const worktreeRootLink = resolveKnownWorktreeRootPathLink(filePath)
+      const worktreeRootLink = resolveKnownWorktreeRootPathLink(mappedFilePath)
       if (worktreeRootLink) {
         // Why: root workspace switching must work for SSH/runtime paths without
         // local auth/stat, while still coalescing provider + fallback clicks.
@@ -117,9 +130,9 @@ export function openDetectedFilePath(
     try {
       // Why: remote paths don't need local auth — the relay/runtime is the security boundary.
       if (canOpenWithSystemDefault) {
-        await window.api.fs.authorizeExternalPath({ targetPath: filePath })
+        await window.api.fs.authorizeExternalPath({ targetPath: mappedFilePath })
       }
-      statResult = await statRuntimePath(fileContext, filePath)
+      statResult = await statRuntimePath(fileContext, mappedFilePath)
     } catch {
       return
     }
@@ -131,7 +144,7 @@ export function openDetectedFilePath(
     if (openWithSystemDefault && canOpenWithSystemDefault) {
       // Why: Shift+Cmd/Ctrl mirrors URL links by escaping Orca and honoring the
       // user's OS file associations without adding editor-specific settings.
-      const openedWithSystemDefault = await window.api.shell.openFilePath(filePath)
+      const openedWithSystemDefault = await window.api.shell.openFilePath(mappedFilePath)
       if (openedWithSystemDefault || statResult.isDirectory) {
         return
       }
@@ -139,7 +152,7 @@ export function openDetectedFilePath(
 
     if (statResult.isDirectory) {
       if (canOpenWithSystemDefault) {
-        await window.api.shell.openFilePath(filePath)
+        await window.api.shell.openFilePath(mappedFilePath)
       }
       return
     }
@@ -147,16 +160,16 @@ export function openDetectedFilePath(
     // Why: local HTML files render in Orca's browser for ordinary Cmd/Ctrl-click,
     // and remain the fallback if Shift+Cmd/Ctrl cannot launch the OS default.
     if (
-      isHtmlFilePath(filePath) &&
-      shouldOpenTerminalFileWithSystemDefault(fileContext, filePath)
+      isHtmlFilePath(mappedFilePath) &&
+      shouldOpenTerminalFileWithSystemDefault(fileContext, mappedFilePath)
     ) {
-      openHtmlFileInBrowser(filePath, worktreeId)
+      openHtmlFileInBrowser(mappedFilePath, worktreeId)
       return
     }
 
-    let relativePath = filePath
-    if (worktreePath && isPathInsideWorktree(filePath, worktreePath)) {
-      const maybeRelative = toWorktreeRelativePath(filePath, worktreePath)
+    let relativePath = mappedFilePath
+    if (worktreePath && isPathInsideWorktree(mappedFilePath, worktreePath)) {
+      const maybeRelative = toWorktreeRelativePath(mappedFilePath, worktreePath)
       if (maybeRelative !== null && maybeRelative.length > 0) {
         relativePath = maybeRelative
       }
@@ -172,10 +185,10 @@ export function openDetectedFilePath(
 
     store.openFile(
       {
-        filePath,
+        filePath: mappedFilePath,
         relativePath,
         worktreeId: worktreeId || '',
-        language: detectLanguage(filePath),
+        language: detectLanguage(mappedFilePath),
         mode: 'edit',
         runtimeEnvironmentId
       },
@@ -190,7 +203,7 @@ export function openDetectedFilePath(
           return
         }
         store.setPendingEditorReveal({
-          filePath,
+          filePath: mappedFilePath,
           line,
           column: targetColumn,
           matchLength: 0

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -9,6 +9,7 @@ import {
   getTerminalHtmlFileOpenHint,
   getTerminalUrlOpenHint,
   installFilePathLinkClickFallback,
+  mapTerminalFilePath,
   isTerminalLinkActivation,
   openFilePathLinkAtBufferPosition,
   openDetectedFilePath
@@ -694,6 +695,69 @@ describe('handleOscLink', () => {
     expect(openFilePathMock).not.toHaveBeenCalled()
   })
 
+  it('maps POSIX OSC file links for a WSL worktree before opening them', async () => {
+    setPlatform('Windows')
+
+    handleOscLink(
+      '/root/workspace/myrepo/README.md:5:3',
+      { metaKey: false, ctrlKey: true },
+      {
+        ...deps,
+        startupCwd: '/root/workspace/myrepo',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo'
+      }
+    )
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith({
+      targetPath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      }),
+      { forceContentReload: true }
+    )
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
+      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      line: 5,
+      column: 3,
+      matchLength: 0
+    })
+  })
+
+  it('maps file URL OSC links for a WSL worktree before opening them', async () => {
+    setPlatform('Windows')
+
+    handleOscLink(
+      'file:///root/workspace/myrepo/README.md#L5C3',
+      { metaKey: false, ctrlKey: true },
+      {
+        ...deps,
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo'
+      }
+    )
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith({
+      targetPath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      }),
+      { forceContentReload: true }
+    )
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
+      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      line: 5,
+      column: 3,
+      matchLength: 0
+    })
+  })
+
   it('opens tilde OSC file links against explicit terminal home when cwd is outside home', async () => {
     setPlatform('Macintosh')
 
@@ -1065,7 +1129,7 @@ describe('createFilePathLinkProvider range bounds', () => {
       1,
       {
         worktreeId: 'wt-1',
-        worktreePath: '/repo',
+        worktreePath: depsOverrides.worktreePath ?? '/repo',
         startupCwd: '/repo',
         managerRef,
         linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
@@ -1460,6 +1524,44 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(openFilePathMock).not.toHaveBeenCalled()
   })
 
+  it('maps POSIX file paths for a WSL direct-click fallback before opening them', async () => {
+    setPlatform('Windows')
+
+    const opened = openFilePathLinkAtBufferPosition(
+      makeBuffer([makeBufferLine('/root/workspace/myrepo/README.md:5:3')]),
+      { x: 10, y: 1 },
+      80,
+      {
+        startupCwd: '/root/workspace/myrepo',
+        worktreeId: 'wt-1',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
+        runtimeEnvironmentId: null,
+        pathExistsCache: new Map([
+          ['active\0//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md', true]
+        ])
+      }
+    )
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(opened).toBe(true)
+    expect(statMock).toHaveBeenCalledWith({
+      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+      }),
+      { forceContentReload: true }
+    )
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
+      filePath: '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md',
+      line: 5,
+      column: 3,
+      matchLength: 0
+    })
+  })
+
   it('switches to a known worktree root from direct fallback even when cache says missing', async () => {
     setPlatform('Macintosh')
     storeState.worktreesByRepo = {
@@ -1635,6 +1737,82 @@ describe('createFilePathLinkProvider range bounds', () => {
 
     expect(links.map((link) => link.text)).toEqual(['package.json'])
     expect(window.api.shell.pathExists).toHaveBeenCalledWith('/repo/package.json')
+  })
+
+  it.each([
+    ['modern', '\\\\wsl.localhost\\Ubuntu\\home\\repo'],
+    ['legacy', '\\\\wsl$\\Ubuntu\\home\\repo']
+  ])('maps POSIX terminal links for a %s WSL worktree', async (_label, worktreePath) => {
+    const mappedPath = '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    vi.mocked(window.api.shell.pathExists).mockImplementation(
+      async (pathValue) => pathValue === mappedPath
+    )
+    const { provider, linkTooltip } = createProviderSetup(
+      [makeBufferLine('/root/workspace/myrepo/README.md:5:3')],
+      new Map(),
+      { worktreePath, startupCwd: '/root/workspace/myrepo' }
+    )
+
+    const links = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(links).toHaveLength(1)
+    expect(window.api.shell.pathExists).toHaveBeenCalledWith(mappedPath)
+    links[0]!.hover?.({} as MouseEvent, links[0]!.text)
+    expect(linkTooltip.textContent).toContain(mappedPath)
+    links[0]!.activate?.(
+      { ctrlKey: true, metaKey: false, shiftKey: false } as MouseEvent,
+      links[0]!.text
+    )
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(statMock).toHaveBeenCalledWith({ filePath: mappedPath })
+    expect(openFileMock).toHaveBeenCalledWith(expect.objectContaining({ filePath: mappedPath }), {
+      forceContentReload: true
+    })
+    expect(setPendingEditorRevealMock).toHaveBeenLastCalledWith({
+      filePath: mappedPath,
+      line: 5,
+      column: 3,
+      matchLength: 0
+    })
+  })
+
+  it('resolves relative POSIX terminal links against the pane cwd before mapping', async () => {
+    const mappedPath = '//wsl.localhost/Ubuntu/root/workspace/myrepo/README.md'
+    vi.mocked(window.api.shell.pathExists).mockImplementation(
+      async (pathValue) => pathValue === mappedPath
+    )
+    const { provider } = createProviderSetup([makeBufferLine('README.md:5')], new Map(), {
+      worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
+      startupCwd: '/stale',
+      getPaneLinkCwd: () => '/root/workspace/myrepo'
+    })
+
+    const links = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(links).toHaveLength(1)
+    expect(window.api.shell.pathExists).toHaveBeenCalledWith(mappedPath)
+  })
+
+  it('preserves existing UNC and native paths', () => {
+    expect(
+      mapTerminalFilePath('//wsl.localhost/Ubuntu/root/file.md', '\\\\wsl.localhost\\Ubuntu\\repo')
+    ).toBe('//wsl.localhost/Ubuntu/root/file.md')
+    expect(
+      mapTerminalFilePath('\\\\server\\share\\file.md', '\\\\wsl.localhost\\Ubuntu\\repo')
+    ).toBe('\\\\server\\share\\file.md')
+    expect(mapTerminalFilePath('C:/repo/file.md', '\\\\wsl.localhost\\Ubuntu\\repo')).toBe(
+      'C:/repo/file.md'
+    )
+  })
+
+  it('does not map POSIX paths for a native Windows worktree', () => {
+    expect(mapTerminalFilePath('/repo/file.md', 'C:\\repo')).toBe('/repo/file.md')
   })
 
   it('opens an existing extensionless spaced prefix from direct fallback cache', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -14,6 +14,7 @@ import {
 import {
   getTerminalFileContext,
   isHtmlFilePath,
+  mapTerminalFilePath,
   openDetectedFilePath,
   shouldOpenTerminalFileWithSystemDefault
 } from './terminal-file-open-routing'
@@ -39,6 +40,7 @@ import { resolveKnownWorktreeRootPathLink } from './terminal-worktree-path-link'
 import { isTerminalLinkActivation } from './terminal-link-activation'
 
 export { openDetectedFilePath } from './terminal-file-open-routing'
+export { mapTerminalFilePath } from './terminal-file-open-routing'
 export { openFilePathLinkAtBufferPosition } from './terminal-file-link-hit-testing'
 export { getTerminalFileOpenHint, getTerminalHtmlFileOpenHint, getTerminalUrlOpenHint }
 export { isTerminalLinkActivation } from './terminal-link-activation'
@@ -132,6 +134,7 @@ export function createFilePathLinkProvider(
               if (!resolved) {
                 return null
               }
+              const mappedPath = mapTerminalFilePath(resolved.absolutePath, worktreePath)
               const range = rangeForParsedFileLink(logicalLine, parsed.startIndex, parsed.endIndex)
               if (!range) {
                 return null
@@ -144,17 +147,14 @@ export function createFilePathLinkProvider(
                 worktreePath,
                 runtimeEnvironmentId
               )
-              const isRemoteRuntimePath = isRemoteRuntimeFileOperation(
-                fileContext,
-                resolved.absolutePath
-              )
+              const isRemoteRuntimePath = isRemoteRuntimeFileOperation(fileContext, mappedPath)
               const cacheKey = getTerminalPathExistsCacheKey({
-                absolutePath: resolved.absolutePath,
+                absolutePath: mappedPath,
                 connectionId: fileContext.connectionId,
                 isRemoteRuntimePath,
                 runtimeEnvironmentId
               })
-              const worktreeRootLink = resolveKnownWorktreeRootPathLink(resolved.absolutePath)
+              const worktreeRootLink = resolveKnownWorktreeRootPathLink(mappedPath)
               if (/[\\/]$/.test(parsed.pathText) && !worktreeRootLink) {
                 return null
               }
@@ -165,8 +165,8 @@ export function createFilePathLinkProvider(
                 const exists =
                   cachedExists ??
                   (fileContext.connectionId || isRemoteRuntimePath
-                    ? await runtimePathExists(fileContext, resolved.absolutePath)
-                    : await window.api.shell.pathExists(resolved.absolutePath))
+                    ? await runtimePathExists(fileContext, mappedPath)
+                    : await window.api.shell.pathExists(mappedPath))
                 writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
                 if (!exists) {
                   return null
@@ -182,7 +182,7 @@ export function createFilePathLinkProvider(
                     if (!isTerminalLinkActivation(event)) {
                       return
                     }
-                    openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, {
+                    openDetectedFilePath(mappedPath, resolved.line, resolved.column, {
                       worktreeId,
                       worktreePath,
                       runtimeEnvironmentId,
@@ -194,16 +194,16 @@ export function createFilePathLinkProvider(
                     // default escape hatch; remote paths may not exist locally.
                     const canOpenWithSystemDefault = shouldOpenTerminalFileWithSystemDefault(
                       fileContext,
-                      resolved.absolutePath
+                      mappedPath
                     )
                     const hint = worktreeRootLink
                       ? getTerminalWorktreePathOpenHint(canOpenWithSystemDefault)
                       : canOpenWithSystemDefault
-                        ? isHtmlFilePath(resolved.absolutePath)
+                        ? isHtmlFilePath(mappedPath)
                           ? getTerminalHtmlFileOpenHint()
                           : openLinkHint
                         : getTerminalOrcaFileOpenHint()
-                    linkTooltip.textContent = `${resolved.absolutePath} (${hint})`
+                    linkTooltip.textContent = `${mappedPath} (${hint})`
                     linkTooltip.style.display = ''
                   },
                   leave: () => {


### PR DESCRIPTION
## Summary

Makes POSIX file paths printed by terminals running inside a WSL distro clickable and openable from a Windows-hosted WSL worktree.

## ELI5

When you run a terminal inside WSL on Windows, file links show up as Linux-style paths like `/root/workspace/README.md`. Windows can't open those directly, so clicking did nothing. This teaches Orca to translate them into a Windows-visible location so the file opens.

## Root cause & fix

Terminals running in a WSL distro emit POSIX absolute paths, but the Windows host cannot resolve them. The fix adds a pure `mapTerminalFilePath(filePath, worktreePath)` in `terminal-file-open-routing.ts` that rewrites a POSIX absolute path to `//wsl.localhost/<distro><path>` when the worktree parses as a WSL UNC path (both modern `\\wsl.localhost` and legacy `\\wsl$` forms). Every file-open call site — hit-testing, path-exists caching, `stat`, `authorizeExternalPath`, `openFile`, tooltip, and `pendingEditorReveal` — now routes through the mapped path. The guard returns the original path unchanged for non-WSL worktrees and for native Windows (`C:\`), existing UNC (`//`), or relative inputs, so no other platform behavior changes.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Rebase: clean onto `origin/main` (base `7ab601487c`, head `9227939c8b`).
- Test file: `terminal-link-handlers.test.ts` — passes on branch, fails when the fix is reverted (proven regression guard).
- Lint: `oxlint` clean on all 3 changed source files (no warnings/errors).

```
On branch:                Test Files 1 passed | Tests 89 passed (89)
Fix reverted (test kept): Test Files 1 failed | Tests 8 failed | 81 passed
  - "maps POSIX OSC file links for a WSL worktree before opening them"
    expected authorizeExternalPath({targetPath: //wsl.localhost/Ubuntu/root/...})
  - "preserves existing UNC and native paths": mapTerminalFilePath is not a function
  - "does not map POSIX paths for a native Windows worktree": mapTerminalFilePath is not a function
```

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression by construction: `mapTerminalFilePath` is a pure, tightly-guarded transform. Non-WSL worktrees hit the identity path (`parseWslUncPath` returns `null`), and native Windows / UNC / relative inputs are returned byte-identical — both covered by passing tests. Only the WSL branch changes behavior.

---

_Credit to original author @rodboev. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
