### PR TITLE
Fix tui-idle detection for cursor-agent lanes with dismissed trust dialog

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -874,6 +874,32 @@ function antigravityPromptBeforeModelReadyScreen(model = 'Gemini 3.5 Flash (High
   ].join('\n')
 }
 
+// Why: verbatim shape of a real cursor-agent 2026.07 idle screen. The fresh
+// input prompt is "→ Plan, search, build anything" (not "→ Add a follow-up",
+// which only appears after the first turn), so the matcher keys on the "→"
+// glyph, not a specific placeholder.
+function cursorReadyScreen(): string {
+  return [
+    'Cursor Agent',
+    'v2026.07.09-a3815c0',
+    'Tip: Use /plan to plan execution and reach the right outcome faster.',
+    '→ Plan, search, build anything',
+    'Composer 2.5 Fast                                          Run Everything',
+    '~/Documents/projects/AutoGenie · main'
+  ].join('\n')
+}
+
+function cursorBusyScreen(): string {
+  return [
+    'Cursor Agent',
+    'v2026.07.09-a3815c0',
+    '⠰⠳ Thinking  28.61k tokens',
+    '→ Plan, search, build anything',
+    'Composer 2.5 Fast                                          Run Everything',
+    '~/Documents/projects/AutoGenie · main'
+  ].join('\n')
+}
+
 // Why: these runtime feature tests only need message-queue semantics; using
 // SQLite here makes them fail on unrelated native runtime ABI drift.
 class InMemoryOrchestrationMessages {
@@ -10523,6 +10549,67 @@ describe('OrcaRuntimeService', () => {
       status: 'running',
       blockedReason: 'codex-trust-workspace'
     })
+  })
+
+  it('resolves tui-idle for an idle Cursor lane past its dismissed trust dialog (#8210)', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'cursor-agent'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    // Cursor's dismissed trust dialog stays in the scrollback tail; the idle
+    // ready prompt after it must both clear the stale trust hit and satisfy idle.
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        '⚠ Workspace Trust Required\n',
+        'Do you trust the contents of this directory?\n',
+        '  ▶ [a] Trust this workspace\n',
+        '    [q] Quit\n',
+        cursorReadyScreen()
+      ].join(''),
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running'
+    })
+  })
+
+  it('does not block a mid-run Cursor lane on its dismissed trust dialog (#8210)', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'cursor-agent'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        '⚠ Workspace Trust Required\n',
+        'Do you trust the contents of this directory?\n',
+        '  ▶ [a] Trust this workspace\n',
+        '    [q] Quit\n',
+        cursorBusyScreen()
+      ].join(''),
+      Date.now()
+    )
+
+    // Busy Cursor is neither blocked nor idle: the wait must keep polling, then
+    // time out honestly rather than return a stale trust block.
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 200 })
+    ).rejects.toThrow('timeout')
   })
 
   it('returns a blocked wait result for Codex cwd selection prompts', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -10565,6 +10565,9 @@ describe('OrcaRuntimeService', () => {
     runtime.onPtyData(
       'pty-bg',
       [
+        // Trust dialog body can mention "Cursor Agent" before the ready banner;
+        // lastIndexOf must pick the later banner, not this earlier hit.
+        'Cursor Agent\n',
         '⚠ Workspace Trust Required\n',
         'Do you trust the contents of this directory?\n',
         '  ▶ [a] Trust this workspace\n',
@@ -10596,6 +10599,8 @@ describe('OrcaRuntimeService', () => {
     runtime.onPtyData(
       'pty-bg',
       [
+        // Same earlier "Cursor Agent" hit as the idle case — banner must win.
+        'Cursor Agent\n',
         '⚠ Workspace Trust Required\n',
         'Do you trust the contents of this directory?\n',
         '  ▶ [a] Trust this workspace\n',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -25550,18 +25550,62 @@ function findActionableTerminalWaitBlockedSignal(
   if (blockedSignal === null) {
     return null
   }
-  const readyIndex = findKnownReadyPromptIndex(normalized)
+  const dismissedModalIndex = findDismissedStartupModalIndex(normalized)
   // Why: retained terminal tails can include stale startup modals. If a known
-  // ready prompt appears after that modal, the latest signal is ready.
-  return readyIndex !== null && readyIndex > blockedSignal.index ? null : blockedSignal
+  // agent's live prompt appears after that modal, the modal was dismissed and
+  // the signal is no longer actionable — even if the agent is still mid-run
+  // (Cursor never reports idle via OSC title, so its busy prompt clears too).
+  return dismissedModalIndex !== null && dismissedModalIndex > blockedSignal.index
+    ? null
+    : blockedSignal
+}
+
+// Why: a recognized agent's live prompt (idle OR busy) proves its startup modal
+// was dismissed. Broader than the idle-only ready set so a mid-run Cursor lane
+// stops reporting a stale trust hit for the rest of the session.
+function findDismissedStartupModalIndex(normalized: string): number | null {
+  const indexes = [
+    findCodexReadyPromptIndex(normalized),
+    findAntigravityReadyPromptIndex(normalized),
+    findCursorActivePromptIndex(normalized)
+  ].filter((index): index is number => index !== null)
+  return indexes.length > 0 ? Math.max(...indexes) : null
 }
 
 function findKnownReadyPromptIndex(normalized: string): number | null {
   const indexes = [
     findCodexReadyPromptIndex(normalized),
-    findAntigravityReadyPromptIndex(normalized)
+    findAntigravityReadyPromptIndex(normalized),
+    findCursorReadyPromptIndex(normalized)
   ].filter((index): index is number => index !== null)
   return indexes.length > 0 ? Math.max(...indexes) : null
+}
+
+// Why: cursor-agent keeps a persistent TUI — a printed "Cursor Agent" banner and
+// a "→" input-prompt line appear once its trust dialog is dismissed, in both
+// busy and idle states. The banner is matched by its last occurrence so the
+// trust dialog's own "Cursor Agent" body text (which precedes the banner) does
+// not win. The "→" glyph is cursor-agent's input prompt marker ("→ Plan,
+// search, build anything" fresh, "→ Add a follow-up" after the first turn).
+function findCursorActivePromptIndex(normalized: string): number | null {
+  const headerIndex = normalized.lastIndexOf('cursor agent')
+  if (headerIndex === -1) {
+    return null
+  }
+  return normalized.includes('→', headerIndex) ? headerIndex : null
+}
+
+// Why: cursor-agent never emits an idle OSC title (its bare title is dropped),
+// so tui-idle can only resolve from the tail. Busy frames draw a braille
+// spinner in the on-screen status line; its absence past the banner is idle.
+const CURSOR_BUSY_SPINNER_RE = /[⠁-⣿]/
+
+function findCursorReadyPromptIndex(normalized: string): number | null {
+  const activeIndex = findCursorActivePromptIndex(normalized)
+  if (activeIndex === null) {
+    return null
+  }
+  return CURSOR_BUSY_SPINNER_RE.test(normalized.slice(activeIndex)) ? null : activeIndex
 }
 
 function findCodexReadyPromptIndex(normalized: string): number | null {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10086,6 +10086,11 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "aiVaultSessionLogOpen": {
+            "workspaceGone": "Couldn't open log — workspace is no longer available.",
+            "notAuthorized": "Couldn't open log — path not authorized.",
+            "alreadyEditable": "Log is already open for editing."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10086,6 +10086,11 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "aiVaultSessionLogOpen": {
+            "workspaceGone": "Couldn't open log — workspace is no longer available.",
+            "notAuthorized": "Couldn't open log — path not authorized.",
+            "alreadyEditable": "Log is already open for editing."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10086,6 +10086,11 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "aiVaultSessionLogOpen": {
+            "workspaceGone": "Couldn't open log — workspace is no longer available.",
+            "notAuthorized": "Couldn't open log — path not authorized.",
+            "alreadyEditable": "Log is already open for editing."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10086,6 +10086,11 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "aiVaultSessionLogOpen": {
+            "workspaceGone": "Couldn't open log — workspace is no longer available.",
+            "notAuthorized": "Couldn't open log — path not authorized.",
+            "alreadyEditable": "Log is already open for editing."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10086,6 +10086,11 @@
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
             "viewLog": "View Log"
+          },
+          "aiVaultSessionLogOpen": {
+            "workspaceGone": "Couldn't open log — workspace is no longer available.",
+            "notAuthorized": "Couldn't open log — path not authorized.",
+            "alreadyEditable": "Log is already open for editing."
           }
         }
       },


### PR DESCRIPTION
## Summary

Fixes #8210 — `terminal wait --for tui-idle` never resolves for `cursor-agent` lanes.

Two coupled defects made `tui-idle` unusable for Cursor lanes driven via the CLI:

1. **Stale trust modal never cleared.** `findActionableTerminalWaitBlockedSignal` only clears a blocked signal (e.g. `codex-trust-workspace`) when a *recognized* agent's ready prompt appears after it in the tail. cursor-agent had no matcher, so a dismissed "Do you trust the contents of this directory?" dialog stayed in the scrollback tail and kept returning `blockedReason: codex-trust-workspace` for the rest of the session.
2. **No Cursor ready-prompt matcher, and no idle OSC title.** cursor-agent never reports `idle` via its OSC title (the bare `Cursor Agent` title is dropped to `null`; only the braille-spinner title maps to `working`). With no tail matcher either, `tui-idle` for a Cursor lane could only time out — never resolve.

### Fix

Added two cursor-agent matchers in `src/main/runtime/orca-runtime.ts`, keyed on the agent's **real** TUI output:

- `findCursorActivePromptIndex` (busy **or** idle): printed `Cursor Agent` banner (matched by last occurrence so the trust dialog's own "Cursor Agent" body text can't win) + a `→` input-prompt line. Used to **clear** a stale startup/trust modal even while the agent is mid-run.
- `findCursorReadyPromptIndex` (idle only): the above, minus any braille spinner (`⠁-⣿`) after the banner. Used to **satisfy** `tui-idle`.

The blocked-clearing path (`findDismissedStartupModalIndex`) now includes the busy-or-idle matcher; the idle-resolution path (`findKnownReadyPromptIndex`) includes the idle-only matcher. Result: an idle Cursor lane past a dismissed trust dialog resolves `satisfied`, a mid-run Cursor lane is no longer falsely blocked (it keeps polling until idle or times out honestly), and Codex/Antigravity behavior is unchanged.

## Screenshots

No UI component changed — this is main-process terminal-wait/CLI behavior. Verified against the **real running app** with **real cursor-agent** (see Testing). The visible state at resolution: the dismissed Workspace Trust dialog sits in the terminal scrollback with the `Cursor Agent` idle prompt (`→ Plan, search, build anything`) below it, while `orca terminal wait --for tui-idle` returns `satisfied: true`. (Screenshot available on request; not committed per repo policy.)

## Testing

- [x] `pnpm lint` — passes. A separate `chore(i18n)` commit syncs the localization catalog for a **pre-existing** gap from #8205 (`aiVaultSessionLogOpen` keys, unrelated to this fix) that fails the localization check on `origin/main`; oxlint is clean on the changed files.
- [x] `pnpm typecheck` — passes (all three configs).
- [x] `pnpm test` — `src/main/runtime/orca-runtime.test.ts` passes (636 tests) including 2 new `#8210` cases using verbatim-real cursor-agent fixtures (idle resolves; mid-run not blocked). Full suite/`pnpm build` not run this session.
- [x] Added or updated high-quality tests that would catch regressions.

**End-to-end verification against real cursor-agent in the running dev app** (via `orca terminal create/send/read/wait`):

| Step | State | `wait --for tui-idle` |
|------|-------|-----------------------|
| Trust dialog **live** | dialog on screen | `blockedReason: codex-trust-workspace` (correct) |
| After sending `a` | stale trust text still in tail + banner + `→` prompt | — |
| Wait after dismissal | cursor idle | **`satisfied: true, blockedReason: null`** ✅ |

Real-app testing also caught a defect an early fix missed: the fresh idle prompt is `→ Plan, search, build anything`, not `→ Add a follow-up` (which only appears after the first turn) — the matcher now keys on the `→` glyph, and the unit fixtures were updated to the captured-real output.

## AI Review Report

Reviewed the diff for correctness and regression risk. Main risks checked: (a) the new matchers falsely resolving `tui-idle` while Cursor is still working — mitigated by gating idle on the absence of the braille spinner after the banner, and covered by a mid-run test; (b) accidentally clearing a *live* trust modal — the clear only fires when a recognized prompt appears strictly after the modal in the tail; (c) Codex/Antigravity regressions — their matchers are unchanged and the busy-or-idle Cursor addition only matches when `Cursor Agent` + `→` are present. Cross-platform: change is pure string matching over the terminal tail (no paths, shell, shortcuts, or Electron platform APIs), so macOS/Linux/Windows behavior is identical; the SSH/remote path uses the same runtime wait logic and is unaffected.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change is read-only string matching over the already-captured PTY tail buffer; the busy-spinner regex is a bounded character-class test over an existing string. No follow-up needed.

## Notes

- Scoped to issue #8210's fix #1 (a first-class cursor-agent matcher). Issue #8210's fix #2 — scoping blocked-signal detection to the live screen rather than the scrollback tail, which would help *any* unrecognized TUI — is a larger, independent refactor left as follow-up.
- Includes one unrelated `chore(i18n)` commit that syncs missing `aiVaultSessionLogOpen` localization keys (from #8205) purely to unblock `pnpm lint`; the tui-idle fix itself is isolated to `src/main/runtime/orca-runtime.ts` and its test.
- cursor-agent's per-agent tail markers and OSC-title quirks are documented in the internal `agent-tui-wait-markers` reference for future terminal-wait work.
