### PR TITLE
feat(tab-bar): add Run Script button for package.json scripts

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarRunScriptButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarRunScriptButton.tsx
@@ -1,0 +1,118 @@
+import { useMemo, useState } from 'react'
+import { ChevronDown, SquareTerminal } from 'lucide-react'
+import { useAppStore } from '@/store'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { runQuickCommandInNewTab } from '@/lib/run-quick-command-in-new-tab'
+import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import type { TerminalQuickCommand } from '../../../../shared/types'
+import type { PackageJsonScript } from '../../../../shared/package-json-scripts'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { useWorktreePackageScripts } from './useWorktreePackageScripts'
+
+type TabBarRunScriptButtonProps = {
+  worktreeId: string
+  groupId: string
+}
+
+export function TabBarRunScriptButton({
+  worktreeId,
+  groupId
+}: TabBarRunScriptButtonProps): React.JSX.Element | null {
+  const packageScripts = useWorktreePackageScripts(worktreeId)
+  const repos = useAppStore((s) => s.repos)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  // Why: package.json scripts run in the worktree regardless of repo scope, but
+  // a real repoId lets the synthetic command carry repo scope for parity with
+  // quick commands. Floating terminals have no owning repo.
+  const repoId = useMemo(() => {
+    if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+      return null
+    }
+    const candidate = getRepoIdFromWorktreeId(worktreeId)
+    return repos.some((r) => r.id === candidate) ? candidate : null
+  }, [worktreeId, repos])
+
+  if (!packageScripts || packageScripts.scripts.length === 0) {
+    return null
+  }
+
+  const handleRun = (script: PackageJsonScript): void => {
+    const command: TerminalQuickCommand = {
+      id: `package-script-${script.name}`,
+      label: script.name,
+      action: 'terminal-command',
+      command: packageScripts.runCommandFor(script.name),
+      appendEnter: true,
+      scope: repoId ? { type: 'repo', repoId } : { type: 'global' }
+    }
+    setMenuOpen(false)
+    runQuickCommandInNewTab({ command, worktreeId, groupId })
+  }
+
+  const label = translate('auto.components.tab.bar.TabBarRunScriptButton.runScript', 'Run Script')
+
+  return (
+    <DropdownMenu
+      modal={false}
+      open={menuOpen}
+      onOpenChange={(next) => {
+        setMenuOpen(next)
+        if (next) {
+          // Why: re-read package.json on open so freshly added/removed scripts
+          // show up without waiting for a worktree re-focus.
+          packageScripts.refresh()
+        }
+      }}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="my-auto flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              aria-label={label}
+            >
+              <SquareTerminal className="size-3.5" />
+              <span className="text-[12px] font-medium">{label}</span>
+              <ChevronDown className="size-3" strokeWidth={2.5} />
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {translate(
+            'auto.components.tab.bar.TabBarRunScriptButton.runScriptTooltip',
+            'Run a package.json script'
+          )}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        align="end"
+        side="bottom"
+        sideOffset={6}
+        className="scrollbar-sleek max-h-72 w-64 overflow-y-auto"
+      >
+        {packageScripts.scripts.map((script) => (
+          <DropdownMenuItem
+            key={script.name}
+            onSelect={() => handleRun(script)}
+            className="flex flex-col items-start gap-0.5"
+          >
+            <span className="max-w-full truncate font-medium">{script.name}</span>
+            <span className={cn('max-w-full truncate text-[11px] text-muted-foreground')}>
+              {script.command}
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/tab-bar/useWorktreePackageScripts.ts
+++ b/src/renderer/src/components/tab-bar/useWorktreePackageScripts.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useAppStore } from '@/store'
+import { joinPath } from '@/lib/path'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import {
+  buildPackageManagerRunCommand,
+  getPackageJsonField,
+  parsePackageJsonScripts,
+  resolvePackageManager,
+  type PackageJsonScript,
+  type PackageManagerName
+} from '../../../../shared/package-json-scripts'
+
+export type WorktreePackageScripts = {
+  scripts: PackageJsonScript[]
+  packageManager: PackageManagerName
+  /** Terminal command that runs the named script with the resolved manager. */
+  runCommandFor: (scriptName: string) => string
+  /** Re-read package.json (e.g. when the picker opens) to catch on-disk edits. */
+  refresh: () => void
+}
+
+const EMPTY_SCRIPTS: PackageJsonScript[] = []
+
+function isMissingFileError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /ENOENT|no such file|not found/i.test(message)
+}
+
+async function readWorktreePackageScripts(
+  worktreePath: string,
+  connectionId: string | undefined
+): Promise<{ scripts: PackageJsonScript[]; packageManager: PackageManagerName } | null> {
+  let packageJsonContent: string
+  try {
+    const result = await window.api.fs.readFile({
+      filePath: joinPath(worktreePath, 'package.json'),
+      connectionId
+    })
+    if (result.isBinary) {
+      return null
+    }
+    packageJsonContent = result.content
+  } catch (error) {
+    // Why: no package.json (or an unreadable one) simply means "not a node
+    // project" for this feature — surface an empty result, not an error.
+    if (isMissingFileError(error)) {
+      return null
+    }
+    return null
+  }
+
+  const scripts = parsePackageJsonScripts(packageJsonContent)
+  if (scripts.length === 0) {
+    return null
+  }
+
+  let lockfileNames: string[] = []
+  try {
+    const entries = await window.api.fs.readDir({ dirPath: worktreePath, connectionId })
+    lockfileNames = entries.map((entry) => entry.name)
+  } catch {
+    // Why: lockfile detection is best-effort; fall back to the packageManager
+    // field or npm when the directory listing fails.
+    lockfileNames = []
+  }
+
+  const packageManager = resolvePackageManager(
+    getPackageJsonField(packageJsonContent, 'packageManager'),
+    lockfileNames
+  )
+  return { scripts, packageManager }
+}
+
+/**
+ * Read the focused worktree's package.json `scripts` block for the tab-bar
+ * "Run Script" picker. Returns null while loading or when the worktree has no
+ * runnable scripts, so callers can hide the button entirely.
+ */
+export function useWorktreePackageScripts(worktreeId: string): WorktreePackageScripts | null {
+  const worktreePath = useAppStore(
+    (s) => findWorktreeById(s.worktreesByRepo ?? {}, worktreeId)?.path
+  )
+  const repoId = useMemo(() => {
+    const state = useAppStore.getState()
+    const worktree = findWorktreeById(state.worktreesByRepo ?? {}, worktreeId)
+    return worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
+  }, [worktreeId])
+  const connectionId = useAppStore((s) => s.repos.find((r) => r.id === repoId)?.connectionId)
+
+  const [state, setState] = useState<{
+    scripts: PackageJsonScript[]
+    packageManager: PackageManagerName
+  } | null>(null)
+  const [reloadToken, setReloadToken] = useState(0)
+  const requestIdRef = useRef(0)
+
+  useEffect(() => {
+    if (!worktreePath) {
+      setState(null)
+      return
+    }
+    const requestId = ++requestIdRef.current
+    let cancelled = false
+    void readWorktreePackageScripts(worktreePath, connectionId ?? undefined).then((result) => {
+      if (cancelled || requestId !== requestIdRef.current) {
+        return
+      }
+      setState(result)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [worktreePath, connectionId, reloadToken])
+
+  const refresh = useCallback(() => setReloadToken((token) => token + 1), [])
+
+  return useMemo(() => {
+    if (!state) {
+      return null
+    }
+    return {
+      scripts: state.scripts ?? EMPTY_SCRIPTS,
+      packageManager: state.packageManager,
+      runCommandFor: (scriptName: string) =>
+        buildPackageManagerRunCommand(state.packageManager, scriptName),
+      refresh
+    }
+  }, [state, refresh])
+}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -13,6 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import TabBar from '../tab-bar/TabBar'
 
 import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
+import { TabBarRunScriptButton } from '../tab-bar/TabBarRunScriptButton'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
@@ -269,6 +270,9 @@ export default function TabGroupPanel({
             <div className={focusedActionChromeClassName}>
               {isFocused ? (
                 <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
+              ) : null}
+              {isFocused ? (
+                <TabBarRunScriptButton worktreeId={worktreeId} groupId={groupId} />
               ) : null}
               {isFocused && hasSplitGroups ? (
                 <Tooltip>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2791,6 +2791,10 @@
             "b27864279e": "Launch agent",
             "39676a184c": "Open any file, URL, agent, ..."
           },
+          "TabBarRunScriptButton": {
+            "runScript": "Run Script",
+            "runScriptTooltip": "Run a package.json script"
+          },
           "TabBarQuickCommandsButton": {
             "a2c7a33831": "Command",
             "20bbd75896": "No commands",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2791,6 +2791,10 @@
             "b27864279e": "Iniciar agente",
             "39676a184c": "Abrir cualquier archivo, URL, agente, ..."
           },
+          "TabBarRunScriptButton": {
+            "runScript": "Run Script",
+            "runScriptTooltip": "Run a package.json script"
+          },
           "TabBarQuickCommandsButton": {
             "a2c7a33831": "Comando",
             "20bbd75896": "Sin comandos",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2791,6 +2791,10 @@
             "b27864279e": "agent を起動",
             "39676a184c": "任意のファイル、URL、agent などを開きます..."
           },
+          "TabBarRunScriptButton": {
+            "runScript": "Run Script",
+            "runScriptTooltip": "Run a package.json script"
+          },
           "TabBarQuickCommandsButton": {
             "a2c7a33831": "コマンド",
             "20bbd75896": "コマンドはありません",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2791,6 +2791,10 @@
             "b27864279e": "agent 실행",
             "39676a184c": "모든 파일, URL, agent를 엽니다..."
           },
+          "TabBarRunScriptButton": {
+            "runScript": "Run Script",
+            "runScriptTooltip": "Run a package.json script"
+          },
           "TabBarQuickCommandsButton": {
             "a2c7a33831": "명령",
             "20bbd75896": "명령 없음",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2791,6 +2791,10 @@
             "b27864279e": "启动智能体",
             "39676a184c": "打开任何文件、URL、智能体..."
           },
+          "TabBarRunScriptButton": {
+            "runScript": "Run Script",
+            "runScriptTooltip": "Run a package.json script"
+          },
           "TabBarQuickCommandsButton": {
             "a2c7a33831": "命令",
             "20bbd75896": "无命令",

--- a/src/shared/package-json-scripts.test.ts
+++ b/src/shared/package-json-scripts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPackageManagerRunCommand,
+  detectPackageManagerFromField,
+  detectPackageManagerFromLockfiles,
+  getPackageJsonField,
+  parsePackageJsonScripts,
+  resolvePackageManager
+} from './package-json-scripts'
+
+describe('parsePackageJsonScripts', () => {
+  it('extracts string-valued scripts in declared order', () => {
+    const content = JSON.stringify({
+      scripts: { dev: 'vite', build: 'vite build', test: 'vitest' }
+    })
+    expect(parsePackageJsonScripts(content)).toEqual([
+      { name: 'dev', command: 'vite' },
+      { name: 'build', command: 'vite build' },
+      { name: 'test', command: 'vitest' }
+    ])
+  })
+
+  it('ignores non-string script values and blank names', () => {
+    const content = JSON.stringify({
+      scripts: { dev: 'vite', bad: 42, nested: { a: 1 }, '': 'noop' }
+    })
+    expect(parsePackageJsonScripts(content)).toEqual([{ name: 'dev', command: 'vite' }])
+  })
+
+  it('returns an empty array for missing, empty, or invalid input', () => {
+    expect(parsePackageJsonScripts(null)).toEqual([])
+    expect(parsePackageJsonScripts('')).toEqual([])
+    expect(parsePackageJsonScripts('not json')).toEqual([])
+    expect(parsePackageJsonScripts(JSON.stringify({}))).toEqual([])
+    expect(parsePackageJsonScripts(JSON.stringify({ scripts: [] }))).toEqual([])
+  })
+})
+
+describe('package manager detection', () => {
+  it('reads the packageManager field', () => {
+    expect(detectPackageManagerFromField('pnpm@9.1.0')).toBe('pnpm')
+    expect(detectPackageManagerFromField('yarn@4.0.0')).toBe('yarn')
+    expect(detectPackageManagerFromField('bun@1.1.0')).toBe('bun')
+    expect(detectPackageManagerFromField('npm@10.0.0')).toBe('npm')
+    expect(detectPackageManagerFromField('deno@1.0.0')).toBeNull()
+    expect(detectPackageManagerFromField(undefined)).toBeNull()
+  })
+
+  it('reads a single lockfile', () => {
+    expect(detectPackageManagerFromLockfiles(['pnpm-lock.yaml', 'README.md'])).toBe('pnpm')
+    expect(detectPackageManagerFromLockfiles(['yarn.lock'])).toBe('yarn')
+    expect(detectPackageManagerFromLockfiles(['bun.lockb'])).toBe('bun')
+  })
+
+  it('returns null on conflicting or absent lockfiles', () => {
+    expect(detectPackageManagerFromLockfiles(['pnpm-lock.yaml', 'yarn.lock'])).toBeNull()
+    expect(detectPackageManagerFromLockfiles(['README.md'])).toBeNull()
+  })
+
+  it('prefers the field, then lockfiles, then npm', () => {
+    expect(resolvePackageManager('pnpm@9', ['yarn.lock'])).toBe('pnpm')
+    expect(resolvePackageManager(undefined, ['yarn.lock'])).toBe('yarn')
+    expect(resolvePackageManager(undefined, [])).toBe('npm')
+  })
+})
+
+describe('buildPackageManagerRunCommand', () => {
+  it('builds a uniform run command per manager', () => {
+    expect(buildPackageManagerRunCommand('npm', 'dev')).toBe('npm run dev')
+    expect(buildPackageManagerRunCommand('pnpm', 'build')).toBe('pnpm run build')
+    expect(buildPackageManagerRunCommand('yarn', 'test')).toBe('yarn run test')
+    expect(buildPackageManagerRunCommand('bun', 'lint')).toBe('bun run lint')
+  })
+})
+
+describe('getPackageJsonField', () => {
+  it('returns a top-level field or undefined', () => {
+    const content = JSON.stringify({ name: 'orca', packageManager: 'pnpm@9' })
+    expect(getPackageJsonField(content, 'packageManager')).toBe('pnpm@9')
+    expect(getPackageJsonField(content, 'missing')).toBeUndefined()
+    expect(getPackageJsonField(null, 'name')).toBeUndefined()
+  })
+})

--- a/src/shared/package-json-scripts.ts
+++ b/src/shared/package-json-scripts.ts
@@ -1,0 +1,117 @@
+export type PackageManagerName = 'pnpm' | 'bun' | 'yarn' | 'npm'
+
+export type PackageJsonScript = {
+  /** Script key as declared under `scripts` in package.json. */
+  name: string
+  /** The shell command the script runs. Shown only as a tooltip/subtitle. */
+  command: string
+}
+
+// Why: mirrors the lockfile→manager table used by setup-script package-manager
+// suggestion so run-command detection stays consistent with install detection.
+const LOCKFILE_TO_MANAGER: Record<string, PackageManagerName> = {
+  'pnpm-lock.yaml': 'pnpm',
+  'bun.lock': 'bun',
+  'bun.lockb': 'bun',
+  'yarn.lock': 'yarn',
+  'package-lock.json': 'npm',
+  'npm-shrinkwrap.json': 'npm'
+}
+
+const PACKAGE_MANAGER_PREFIXES: PackageManagerName[] = ['pnpm', 'bun', 'yarn', 'npm']
+
+function parsePackageJson(content: string | null): Record<string, unknown> | null {
+  if (!content) {
+    return null
+  }
+  try {
+    const parsed: unknown = JSON.parse(content)
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract the `scripts` block from raw package.json content, preserving the
+ * declared order. Returns an empty array when the file is missing, unparseable,
+ * or has no (string-valued) scripts.
+ */
+export function parsePackageJsonScripts(content: string | null): PackageJsonScript[] {
+  const packageJson = parsePackageJson(content)
+  const scripts = packageJson?.scripts
+  if (scripts === null || typeof scripts !== 'object' || Array.isArray(scripts)) {
+    return []
+  }
+  const result: PackageJsonScript[] = []
+  for (const [name, command] of Object.entries(scripts as Record<string, unknown>)) {
+    if (typeof command === 'string' && name.trim().length > 0) {
+      result.push({ name, command })
+    }
+  }
+  return result
+}
+
+/**
+ * Resolve the package manager from a package.json `packageManager` field value
+ * (e.g. `"pnpm@9.1.0"`). Returns null when absent or unrecognized.
+ */
+export function detectPackageManagerFromField(value: unknown): PackageManagerName | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const normalized = value.trim().toLowerCase()
+  return PACKAGE_MANAGER_PREFIXES.find((manager) => normalized.startsWith(`${manager}@`)) ?? null
+}
+
+/**
+ * Resolve the package manager from lockfiles present in a worktree root. Returns
+ * null when no lockfile is found or multiple conflicting managers are detected.
+ */
+export function detectPackageManagerFromLockfiles(
+  fileNames: readonly string[]
+): PackageManagerName | null {
+  const managers = new Set<PackageManagerName>()
+  for (const fileName of fileNames) {
+    const manager = LOCKFILE_TO_MANAGER[fileName]
+    if (manager) {
+      managers.add(manager)
+    }
+  }
+  return managers.size === 1 ? [...managers][0] : null
+}
+
+/**
+ * Resolve the effective package manager for running scripts: the explicit
+ * `packageManager` field wins, then lockfile detection, then npm as the
+ * universal fallback.
+ */
+export function resolvePackageManager(
+  packageManagerField: unknown,
+  lockfileNames: readonly string[]
+): PackageManagerName {
+  return (
+    detectPackageManagerFromField(packageManagerField) ??
+    detectPackageManagerFromLockfiles(lockfileNames) ??
+    'npm'
+  )
+}
+
+/**
+ * Build the terminal command that runs a package.json script with the given
+ * manager. `<pm> run <name>` is valid for all four managers (npm requires it,
+ * pnpm/yarn/bun accept it), so a uniform form avoids conflicts with built-in
+ * subcommands (e.g. `bun test`, `yarn install`).
+ */
+export function buildPackageManagerRunCommand(
+  manager: PackageManagerName,
+  scriptName: string
+): string {
+  return `${manager} run ${scriptName}`
+}
+
+export function getPackageJsonField(content: string | null, field: string): unknown {
+  return parsePackageJson(content)?.[field]
+}


### PR DESCRIPTION
## Summary

Adds a **Run Script** dropdown to the focused worktree's tab bar. It reads the worktree's `package.json` `scripts`, auto-detects the package manager, and runs the selected script in a new terminal tab.

- **Package manager detection** resolves in this order: the `packageManager` field (e.g. `"pnpm@9.1.0"`) → lockfile in the worktree root (`pnpm-lock.yaml`, `bun.lock(b)`, `yarn.lock`, `package-lock.json`, `npm-shrinkwrap.json`) → `npm` as the universal fallback. This mirrors the lockfile→manager table already used for setup-script package-manager suggestions, so run detection stays consistent with install detection.
- **Uniform run form** `<pm> run <name>` is used for all four managers. `run` is valid everywhere (npm requires it; pnpm/yarn/bun accept it) and avoids clashing with built-in subcommands like `bun test` or `yarn <script-that-shadows-a-builtin>`.
- **Self-hiding**: the button renders nothing when the worktree has no runnable scripts (no `package.json`, unparseable, or empty `scripts`), so non-Node worktrees are unaffected.
- **Fresh on open**: `package.json` is re-read when the menu opens, so newly added/removed scripts show up without re-focusing the worktree.
- Runs the script through the existing quick-command path (`runQuickCommandInNewTab`), carrying repo scope when the worktree has an owning repo and falling back to global scope for floating terminals.

## Screenshots

Run Script dropdown in the tab bar, showing the focused worktree's `package.json` scripts (a turbo-based repo):

<img width="278" alt="Run Script dropdown showing package.json scripts" src="https://github.com/user-attachments/assets/545e4d95-16ea-493a-9533-35f15fe228fc" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — the new `src/shared/package-json-scripts.test.ts` passes. Two unrelated tests fail identically on `main` in this local environment (`posix-command-path-lookup` zsh alias/function masking and a `useIpcEvents` focus timing test); they are pre-existing and untouched by this change.
- [x] `pnpm build`
- [x] Added `src/shared/package-json-scripts.test.ts` covering script parsing (order preservation, missing/empty/unparseable input, non-string values), `packageManager`-field detection, lockfile detection (including conflicting-lockfile → null), the field→lockfile→npm resolution priority, and run-command construction.

## AI Review Report

Reviewed with an AI coding agent for correctness, cross-platform behavior, remote/SSH compatibility, performance, and UI quality.

- **Cross-platform (macOS/Linux/Windows)**: No hardcoded modifier keys or path separators. Paths are built with the project's `joinPath`; lockfile detection is filename-based. The `<pm> run <name>` command form is platform-neutral and runs in the worktree's own shell. No new keyboard shortcuts or accelerators. UI uses the shadcn `DropdownMenu`/`Tooltip` primitives, `lucide-react` icons, design tokens, and the required `scrollbar-sleek` class on the scrollable menu; the label is localized (en/es/ja/ko/zh added).
- **Remote/SSH/local**: `package.json` and the directory listing are read via `window.api.fs` with the repo's `connectionId`, so detection works for local, remote, and SSH worktrees rather than assuming local disk.
- **Performance**: Reads are gated on the focused worktree, debounced by a request-id guard that discards stale async results, and only re-run on worktree/connection change or menu open. Lockfile listing is best-effort and degrades to field/npm on failure.
- **Flagged & addressed**: initial lint failure — the scrollable menu needed an Orca scrollbar style; fixed by adding `scrollbar-sleek`.

## Security Audit

- **Command execution**: The command is `<pm> run <name>` where `<name>` is a key from the worktree's own `package.json`. This is the same trust boundary the repo already carries — opening a worktree already implies trusting its `package.json` (its scripts run on normal install/use). No user free-text is interpolated, and the manager is restricted to a fixed `pnpm|bun|yarn|npm` set. The command is dispatched through the existing quick-command terminal path, not a new exec surface.
- **Input handling / parsing**: `package.json` is parsed defensively (`JSON.parse` wrapped in try/catch, non-object/array rejected, only string-valued script entries kept). Malformed files yield an empty result rather than throwing.
- **Path handling**: Uses `joinPath`; no path is built from untrusted concatenation.
- **IPC / secrets / dependencies**: No new IPC channels, no secret handling, no new dependencies.

## Notes

- No new keyboard shortcuts. UI-only surface addition on the tab bar; existing tab-bar buttons are unchanged.
- Follow-up idea (out of scope): remember the last-run script per worktree for one-click re-run.

## ELI5

The tab bar gets a Run Script menu that reads `package.json` scripts, detects pnpm/yarn/npm/bun, and runs the script in a new terminal. You can kick off common project scripts without typing the package manager command yourself.
