### PR TITLE
Fix task workspace handoff after switching workspaces

### DIFF
--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -504,6 +504,65 @@ describe('staged background worktree creation', () => {
     })
   })
 
+  it('reveals the completed workspace after the user switches to another workspace', async () => {
+    let resolveCreate!: (result: { worktree: { id: string; repoId: string } }) => void
+    store.createWorktree.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveCreate = resolve
+      })
+    )
+
+    const started = continueBackgroundWorktreeCreation('creation-1', makeRequest(), {
+      revealCreationSurface: false
+    })
+
+    expect(started).toBe(true)
+    await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalledTimes(1))
+    // Why: selecting a real workspace clears only the pending surface pointer;
+    // completion should still finish the task-launch handoff once it is ready.
+    store.activePendingCreationId = null
+    resolveCreate({ worktree: { id: 'wt-1', repoId: 'repo-1' } })
+    await flushAsyncWorktreeCreation()
+
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', {
+      sidebarRevealBehavior: 'auto'
+    })
+    expect(ensureWorktreeHasInitialTerminal).not.toHaveBeenCalled()
+    expect(store.removePendingWorktreeCreation).toHaveBeenCalledWith('creation-1', {
+      cleanupVm: false
+    })
+  })
+
+  it('does not reveal a workspace cancelled during post-create trust preflight', async () => {
+    let resolveTrust!: () => void
+    const markTrusted = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTrust = resolve
+        })
+    )
+    globalThis.window = { api: { agentTrust: { markTrusted } } } as never
+    store.repos = [{ id: 'repo-1', connectionId: null }]
+    store.createWorktree.mockResolvedValueOnce({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/repo/wt-1' }
+    })
+
+    const started = continueBackgroundWorktreeCreation(
+      'creation-1',
+      makeRequest({ agent: 'codex' }),
+      { revealCreationSurface: false }
+    )
+
+    expect(started).toBe(true)
+    await vi.waitFor(() => expect(markTrusted).toHaveBeenCalledTimes(1))
+    delete store.pendingWorktreeCreations['creation-1']
+    store.activePendingCreationId = null
+    resolveTrust()
+    await vi.waitFor(() => expect(ensureWorktreeHasInitialTerminal).toHaveBeenCalledTimes(1))
+
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+  })
+
   // Why: one-click "Start workspace from issue" commonly backgrounds, so the
   // user-moved-on path is the common delivery for the repo's issue command; it
   // must thread through as the 5th positional arg, not be dropped to undefined.

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -214,13 +214,20 @@ async function executeWorktreeCreation(
     await preflightAgentTrust(preparedRequest, worktree.path, repoConnectionId)
   }
 
-  // `createWorktree` already inserted the real worktree row. Whether we steal
-  // the view depends on whether the user is still watching this creation.
-  const stillActive = isPendingCreationSurfaceVisible(creationId)
+  // `createWorktree` already inserted the real worktree row. Leaving for an app
+  // view keeps the create in the background, while selecting another workspace
+  // means the user still expects this task-launch handoff when it becomes ready;
+  // the entry guard prevents a late trust preflight from reviving a cancelled create.
+  const completionState = useAppStore.getState()
+  const shouldActivateOnCompletion =
+    completionState.pendingWorktreeCreations[creationId] !== undefined &&
+    (isPendingCreationSurfaceVisible(creationId) ||
+      (completionState.activeView === 'terminal' &&
+        completionState.activePendingCreationId === null))
 
   let activation: ActivateAndRevealResult | false = false
   let primaryTabId: string | null
-  if (stillActive) {
+  if (shouldActivateOnCompletion) {
     activation = activateAndRevealWorktree(worktree.id, {
       sidebarRevealBehavior: 'auto',
       ...(result.setup ? { setup: result.setup } : {}),
@@ -254,7 +261,7 @@ async function executeWorktreeCreation(
       startup: preparedRequest.startupPlan
     })
   }
-  if (stillActive && !preparedRequest.suppressTerminalFocusOnCompletion) {
+  if (shouldActivateOnCompletion && !preparedRequest.suppressTerminalFocusOnCompletion) {
     queueNewWorkspaceTerminalFocus(worktree.id, activation)
   }
 


### PR DESCRIPTION
## Summary

When a workspace created from Tasks finishes after the user switches to another workspace, complete the handoff and open the new workspace instead of dropping its pending row and leaving it inactive.

Leaving the creation flow for Tasks, Settings, or another app view still keeps creation in the background without stealing focus. Cancelled creations also remain cancelled when post-create trust preflight finishes late.

## Screenshots

No visual change. This changes the completion/navigation behavior of the existing pending workspace row.

## Testing

- [ ] `pnpm lint` (full repository lint not run)
- [x] `pnpm run typecheck:web`
- [ ] `pnpm test` (full repository suite not run)
- [ ] `pnpm build` (not run)
- [x] Added regression coverage for switching workspaces during creation and cancelling during post-create trust preflight
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/store/slices/worktrees.test.ts` — 211 passed
- [x] Focused oxlint and oxfmt checks passed
- [x] `pnpm check:max-lines-ratchet` and `git diff --check` passed
- [x] Electron validation: started a GitHub issue workspace, switched to an existing workspace while creation was pending, and confirmed the completed workspace became active with its terminal mounted

## AI Review Report

Ran two adversarial review/fix rounds with `review-until-clean` against the branch diff.

Round 1 found a cancellation race: if the pending row was cancelled while agent-trust preflight was still awaiting, the new completion predicate could misclassify the cleared pending pointer as a workspace switch. Added an entry-existence guard and a regression test. Round 2 found no remaining in-scope issues.

The review checked success, failure, cancellation, retry/concurrency state, terminal startup handoff, Tasks/settings focus preservation, local/SSH/runtime ownership, and test depth. It explicitly checked macOS, Linux, and Windows compatibility; this renderer-only state change touches no shortcuts, labels, paths, shell commands, Git commands, or platform-specific Electron APIs.

Performance risk is negligible: completion adds one Zustand state read/map lookup and predicate evaluation once per workspace creation, with no polling, listeners, timers, IPC/RPC, storage, or render fanout.

## Security Audit

No new external inputs, command execution, path handling, authentication, secrets, dependencies, or IPC surfaces are introduced. Existing agent-trust and workspace-create boundaries are unchanged. The cancellation guard prevents a late async trust result from reviving a user-cancelled workspace.

## Notes

The fix is renderer-state based and applies equally to local, SSH, and runtime-backed workspace creation. Temporary workspaces created for manual reproduction and validation were removed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
