### PR TITLE
test(e2e): stabilize Windows large-repo benchmark teardown

### DIFF
--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -32,6 +32,7 @@ import { createSeededTestRepo, isValidGitRepo } from './seeded-test-repo'
 
 type OrcaTestFixtures = {
   electronApp: ElectronApplication
+  registerPostElectronShutdownCleanup: (cleanup: () => Promise<void>) => void
   sharedPage: Page
   orcaPage: Page
   // Why: every fresh userData dir paints the first-launch onboarding overlay
@@ -145,12 +146,36 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     { scope: 'worker' }
   ],
 
+  // Why: Windows keeps watched worktrees locked until Electron and its
+  // detached test daemons exit. Tests register fixture cleanup here so it runs
+  // after electronApp teardown instead of masking the real assertion failure.
+  registerPostElectronShutdownCleanup: [
+    // oxlint-disable-next-line no-empty-pattern -- Playwright fixture callbacks require object destructuring here.
+    async ({}, provideFixture) => {
+      const cleanups: (() => Promise<void>)[] = []
+      await provideFixture((cleanup) => cleanups.push(cleanup))
+      for (const cleanup of cleanups.toReversed()) {
+        await cleanup()
+      }
+    },
+    { scope: 'test' }
+  ],
+
   // Test-scoped: one Electron app per test
   electronApp: async (
-    { dismissOnboarding, launchEnv, orcaAppExtraEnv, orcaAppExtraArgs },
+    {
+      dismissOnboarding,
+      launchEnv,
+      orcaAppExtraEnv,
+      orcaAppExtraArgs,
+      registerPostElectronShutdownCleanup
+    },
     provideFixture,
     testInfo
   ) => {
+    // Establish fixture ordering: registered path cleanup must run only after
+    // this Electron fixture has released watchers, terminals, and daemons.
+    void registerPostElectronShutdownCleanup
     const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
     const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-userdata-'))
 

--- a/tests/e2e/source-control-large-file-count.spec.ts
+++ b/tests/e2e/source-control-large-file-count.spec.ts
@@ -102,15 +102,34 @@ async function addAndActivateRepo(orcaPage: Page, repoPath: string): Promise<str
   )
 
   // Why: repo activation can finish sidebar routing after the store mutation;
-  // enter Source Control through the visible control before timing its render.
+  // assert the user-visible panel before timing its render. Clicking the
+  // already-active activity button races the first cold status scan and tests
+  // Playwright's two-frame actionability window instead of panel readiness.
   const sourceControlButton = orcaPage.getByRole('button', { name: /^Source Control/ })
   await expect(sourceControlButton).toBeVisible()
-  await sourceControlButton.click()
   await expect
     .poll(() => orcaPage.evaluate(() => window.__store?.getState().rightSidebarTab))
     .toBe('source-control')
+  await expect(orcaPage.getByRole('button', { name: 'Filter files by name' })).toBeVisible()
 
   return worktreeId
+}
+
+async function unregisterLargeFileCountRepos(
+  orcaPage: Page,
+  repoPaths: readonly string[]
+): Promise<void> {
+  // Why: remove disposable projects through the product so their terminals
+  // and watcher subscriptions begin shutting down before Electron teardown.
+  for (const repoPath of repoPaths) {
+    await orcaPage.evaluate(async (pathToRepo) => {
+      const store = window.__store
+      const repo = store?.getState().repos.find((entry) => entry.path === pathToRepo)
+      if (repo) {
+        await store?.getState().removeProject(repo.id)
+      }
+    }, repoPath)
+  }
 }
 
 /**
@@ -242,7 +261,8 @@ test.describe('Source Control large file count (#8013)', () => {
 
   test('thousands of untracked files under the status cap stay responsive', async ({
     orcaPage,
-    electronApp
+    electronApp,
+    registerPostElectronShutdownCleanup
   }) => {
     test.setTimeout(600_000)
     const untrackedFiles = Number(process.env.ORCA_LARGE_FILE_COUNT ?? '9500')
@@ -255,6 +275,7 @@ test.describe('Source Control large file count (#8013)', () => {
       untrackedFiles,
       untrackedFileBytes
     })
+    registerPostElectronShutdownCleanup(() => removeLargeFileCountRepo(fixture.repoPath))
     try {
       await waitForSessionReady(orcaPage)
       const worktreeId = await addAndActivateRepo(orcaPage, fixture.repoPath)
@@ -286,17 +307,19 @@ test.describe('Source Control large file count (#8013)', () => {
         )
       }
     } finally {
-      await removeLargeFileCountRepo(fixture.repoPath)
+      await unregisterLargeFileCountRepos(orcaPage, [fixture.repoPath])
     }
   })
 
   test('thousands of modified tracked files under the status cap stay responsive', async ({
     orcaPage,
-    electronApp
+    electronApp,
+    registerPostElectronShutdownCleanup
   }) => {
     test.setTimeout(600_000)
     const modifiedFiles = Number(process.env.ORCA_LARGE_FILE_COUNT ?? '5000')
     const fixture = createLargeFileCountRepo({ trackedFiles: modifiedFiles, modifiedFiles })
+    registerPostElectronShutdownCleanup(() => removeLargeFileCountRepo(fixture.repoPath))
     try {
       await waitForSessionReady(orcaPage)
       const worktreeId = await addAndActivateRepo(orcaPage, fixture.repoPath)
@@ -319,17 +342,19 @@ test.describe('Source Control large file count (#8013)', () => {
       expect(measurement.renderedRows).toBeLessThan(MAX_MOUNTED_ROWS)
       expect(measurement.maxLagMs).toBeLessThan(MAX_EVENT_LOOP_LAG_MS)
     } finally {
-      await removeLargeFileCountRepo(fixture.repoPath)
+      await unregisterLargeFileCountRepos(orcaPage, [fixture.repoPath])
     }
   })
 
   test('a change set over the status cap degrades to the too-many-changes state', async ({
     orcaPage,
-    electronApp
+    electronApp,
+    registerPostElectronShutdownCleanup
   }) => {
     test.setTimeout(600_000)
     const untrackedFiles = DEFAULT_GIT_STATUS_LIMIT + 1_000
     const fixture = createLargeFileCountRepo({ trackedFiles: 100, untrackedFiles })
+    registerPostElectronShutdownCleanup(() => removeLargeFileCountRepo(fixture.repoPath))
     try {
       await waitForSessionReady(orcaPage)
       const worktreeId = await addAndActivateRepo(orcaPage, fixture.repoPath)
@@ -361,11 +386,14 @@ test.describe('Source Control large file count (#8013)', () => {
       )
       expect(hugeState).not.toBeNull()
     } finally {
-      await removeLargeFileCountRepo(fixture.repoPath)
+      await unregisterLargeFileCountRepos(orcaPage, [fixture.repoPath])
     }
   })
 
-  test('untracked line-stat cache stays effective above 2,048 files', async ({ orcaPage }) => {
+  test('untracked line-stat cache stays effective above 2,048 files', async ({
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  }) => {
     test.setTimeout(600_000)
     // Why: the untracked line-stat cache historically capped at 2,048 entries
     // with FIFO eviction, so a sequential scan over more files evicted every
@@ -380,6 +408,7 @@ test.describe('Source Control large file count (#8013)', () => {
       untrackedFiles: 2_000,
       untrackedFileBytes: fileBytes
     })
+    registerPostElectronShutdownCleanup(() => removeLargeFileCountRepo(smallRepo.repoPath))
     let largeRepo: ReturnType<typeof createLargeFileCountRepo> | null = null
     try {
       largeRepo = createLargeFileCountRepo({
@@ -387,6 +416,8 @@ test.describe('Source Control large file count (#8013)', () => {
         untrackedFiles: 4_000,
         untrackedFileBytes: fileBytes
       })
+      const largeRepoPath = largeRepo.repoPath
+      registerPostElectronShutdownCleanup(() => removeLargeFileCountRepo(largeRepoPath))
       await waitForSessionReady(orcaPage)
 
       const warmRescanPerFileMs = async (repoPath: string, files: number): Promise<number> => {
@@ -407,20 +438,22 @@ test.describe('Source Control large file count (#8013)', () => {
       )
       expect(largePerFileMs).toBeLessThan(smallPerFileMs * 2)
     } finally {
-      await removeLargeFileCountRepo(smallRepo.repoPath)
-      if (largeRepo) {
-        await removeLargeFileCountRepo(largeRepo.repoPath)
-      }
+      await unregisterLargeFileCountRepos(orcaPage, [
+        smallRepo.repoPath,
+        ...(largeRepo ? [largeRepo.repoPath] : [])
+      ])
     }
   })
 
   test('a large clean repo (tracked files only) loads instantly', async ({
     orcaPage,
-    electronApp
+    electronApp,
+    registerPostElectronShutdownCleanup
   }) => {
     test.setTimeout(600_000)
     const trackedFiles = Number(process.env.ORCA_LARGE_FILE_COUNT ?? '15000')
     const fixture = createLargeFileCountRepo({ trackedFiles })
+    registerPostElectronShutdownCleanup(() => removeLargeFileCountRepo(fixture.repoPath))
     try {
       await waitForSessionReady(orcaPage)
       const worktreeId = await addAndActivateRepo(orcaPage, fixture.repoPath)
@@ -440,7 +473,7 @@ test.describe('Source Control large file count (#8013)', () => {
       expect(measurement.entryCount).toBe(0)
       expect(measurement.maxLagMs).toBeLessThan(MAX_EVENT_LOOP_LAG_MS)
     } finally {
-      await removeLargeFileCountRepo(fixture.repoPath)
+      await unregisterLargeFileCountRepos(orcaPage, [fixture.repoPath])
     }
   })
 })


### PR DESCRIPTION
## Description

Stabilizes the Windows large-Source-Control benchmark added for #8013 without claiming a new product fix:

- stops clicking the Source Control activity button after setup has already made that tab active; instead it verifies the user-visible Source Control panel before measurement
- adds an ordered post-Electron-shutdown cleanup fixture
- unregisters disposable projects through Orca first, then deletes their on-disk repositories only after Electron, watchers, terminals, and detached E2E daemons have exited

This follow-up was prompted by Windows crash case 10 from Orca 1.4.128: renderer working set reached 4,338 MB, JS heap became stuck at 3,586 MB, and roughly 10k Git spans targeted one worktree. That signature remains historical evidence for the large-Source-Control family fixed by #7619 and #8022. Profiling this PR's current-main reproduction showed the production renderer is now healthy; the remaining failures were in test sequencing and teardown.

## Evidence of fix (reproduction before + after)

Command:

```powershell
pnpm exec electron-vite build --mode e2e
$env:SKIP_BUILD='1'
$env:ORCA_LARGE_FILE_COUNT='9500'
pnpm exec playwright test tests/e2e/source-control-large-file-count.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --grep 'thousands of untracked files under the status cap stay responsive'
```

Before:

- Playwright waited 30 seconds for the already-active Source Control button to satisfy its two-frame click actionability check and timed out.
- Test cleanup then attempted to remove the still-watched repository before Electron teardown and failed with Windows `EPERM`, masking the click timeout in standard output.
- Result: `1 failed`.

After:

```text
entryCount: 9500
cold scan: 39,741.9 ms
warm rescan: 586.5 ms
render: 12.7 ms
mounted rows: 46
max event-loop lag: 450.2 ms
p95 event-loop lag: 13.2 ms
JS heap: 26.321 MB across all 3 repeated polls
renderer working set: 192.49 -> 215.10 MB
result: 1 passed (1.6m)
```

The cold Git scan is slow but asynchronous; a renderer CPU profile was predominantly idle during it. This confirms that current-main virtualization/cache behavior remains bounded and that the test now reports that product result accurately. Post-shutdown repository deletion also completed without `EPERM`.

Additional checks:

- `pnpm exec oxlint tests/e2e/helpers/orca-app.ts tests/e2e/source-control-large-file-count.spec.ts`
- `pnpm exec tsc --noEmit -p config/tsconfig.node.json --pretty false`
- `pnpm check:max-lines-ratchet`
- `git diff --check`

## ELI5

The test told Orca to open Source Control, then tried to click the button for the panel that was already open. On Windows it also tried to throw away the test folder while Orca was still holding it. Now it checks that the panel is visible and waits until Orca has fully shut down before deleting the folder.

## User-facing trade-offs

- No production UI or Git behavior changes.
- Large-repository users keep the existing bounded row rendering and stable-memory behavior.
- E2E teardown may take slightly longer because filesystem deletion is deliberately ordered after Electron and daemon shutdown.
- The benchmark still reports the real cold-scan latency; this change does not hide or reduce it.
