### PR TITLE
fix(win): bound renderer launch-failed recovery

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -366,19 +366,22 @@ describe('shouldRecoverRendererAfterProcessGone', () => {
     ).toBe(false)
   })
 
-  it('does not recover renderer startup and security launch failures', () => {
+  it('recovers transient renderer launch failures', () => {
     expect(
       shouldRecoverRendererAfterProcessGone({
         reason: 'launch-failed',
         expectedTeardown: 'none'
       })
-    ).toBe(false)
+    ).toBe(true)
     expect(
       shouldRecoverRendererAfterProcessGone({
         reason: 'launch-failed',
         expectedTeardown: 'renderer-reload'
       })
-    ).toBe(false)
+    ).toBe(true)
+  })
+
+  it('does not recover renderer integrity failures', () => {
     expect(
       shouldRecoverRendererAfterProcessGone({
         reason: 'integrity-failure',

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -11,7 +11,7 @@ const RECOVERABLE_UTILITY_SERVICE_NAMES = new Set([
   'video_capture.mojom.VideoCaptureService'
 ])
 const RECOVERABLE_CHILD_PROCESS_REASONS = new Set(['abnormal-exit', 'crashed', 'killed'])
-const NON_RECOVERABLE_RENDERER_REASONS = new Set(['integrity-failure', 'launch-failed'])
+const NON_RECOVERABLE_RENDERER_REASONS = new Set(['integrity-failure'])
 
 function isWindowsControlTerminationExitCode(exitCode: number | null): boolean {
   if (exitCode === null) {
@@ -95,8 +95,9 @@ export function shouldRecoverRendererAfterProcessGone({
   if (expectedTeardown === 'app-shutdown') {
     return false
   }
-  // Why: these mean Chromium could not start or trust the renderer process;
-  // retrying the same BrowserWindow load can loop indefinitely on Windows.
+  // Why: an integrity failure means Chromium cannot trust the renderer, so a
+  // reload cannot safely recover it. Launch failures can be transient and are
+  // bounded by the caller's renderer-recovery circuit breaker.
   if (NON_RECOVERABLE_RENDERER_REASONS.has(reason)) {
     return false
   }

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -62,6 +62,7 @@ vi.mock('../browser/browser-manager', () => ({
 
 import { createMainWindow, loadMainWindow } from './createMainWindow'
 import { ipcMain } from 'electron'
+import { shouldRecoverRendererAfterProcessGone } from '../crash-reporting/process-gone-classification'
 
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const original = process.platform
@@ -2701,6 +2702,48 @@ describe('createMainWindow', () => {
     )
 
     consoleError.mockRestore()
+  })
+
+  it('bounds renderer launch-failed recovery with the crash-loop breaker', () => {
+    vi.useFakeTimers()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onRendererRecoveryExhausted = vi.fn()
+    const { browserWindowInstance, windowHandlers } = createRendererRecoveryWindowHarness()
+
+    try {
+      createMainWindow(null, {
+        onRendererRecoveryExhausted,
+        shouldRecoverRenderer: (details) =>
+          shouldRecoverRendererAfterProcessGone({
+            reason: details.reason,
+            expectedTeardown: 'none'
+          })
+      })
+
+      const details = {
+        reason: 'launch-failed',
+        exitCode: 18
+      } as Electron.RenderProcessGoneDetails
+      const driveLaunchFailure = (): void => {
+        windowHandlers['render-process-gone']?.({} as never, details)
+        vi.advanceTimersByTime(250)
+      }
+
+      driveLaunchFailure()
+      driveLaunchFailure()
+      driveLaunchFailure()
+      expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(4)
+
+      driveLaunchFailure()
+      expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(4)
+      expect(onRendererRecoveryExhausted).toHaveBeenCalledOnce()
+      expect(onRendererRecoveryExhausted).toHaveBeenCalledWith(
+        expect.objectContaining({ details, recentRecoveryCount: 3 })
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
   function createStartupRevealWindowFixture() {


### PR DESCRIPTION
Fixes #8223

## Description

Renderer `launch-failed` events were recorded as crashes but categorically blocked from renderer recovery. That policy predates the bounded recovery circuit breaker, so a transient Windows child-process launch failure left a dead/blank window even though the reports show a later launch of the same build succeeding.

This change allows `launch-failed` through the existing renderer recovery path:

- the first three failures inside 60 seconds reload the app shell while preserving the existing PTY recovery lifecycle
- a fourth failure opens the existing main-process **Reload / Quit** recovery prompt and performs no further automatic load
- `integrity-failure` remains non-recoverable because Chromium cannot safely trust that renderer
- app shutdown, expected teardown, quitting, destroyed-window, and explicit recovery-disable guards are unchanged

No Git command, provider, SSH, WSL, remote-runtime, or renderer UI contract changes.

## Evidence of fix (reproduction before + after)

The regression drives the production classification and BrowserWindow recovery seam with the crash-batch signature: renderer `launch-failed`, exit code `18`.

Command:

```powershell
pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/window/createMainWindow.test.ts
```

Before, with the old classification restored:

```text
Test Files  2 failed (2)
Tests       2 failed | 85 passed (87)

expected launch-failed recovery true, received false
expected loadFile to be called 4 times, received 1
```

The renderer never retried, so the circuit breaker could not protect the retry loop or offer recovery.

After:

```text
Test Files  2 passed (2)
Tests       87 passed (87)
```

The exact integration test proves one initial load plus three bounded recovery loads, then a fourth exit-code-18 failure invokes `onRendererRecoveryExhausted` with `recentRecoveryCount: 3` and does not call `loadFile` again.

Additional validation:

- `pnpm run typecheck:node`
- touched-file `oxlint`
- `pnpm check:max-lines-ratchet`
- `git diff --check`

## ELI5

Orca used to treat “Windows could not start the window engine this time” as permanently broken, so it recorded the failure but never tried again. The same engine often started normally on a later manual attempt. Orca now tries three times automatically; if all three fail, it stops and asks whether to retry or quit instead of looping forever.

## User-facing trade-offs

- A transient launch failure can recover without restarting the whole app.
- A persistent launch failure now incurs up to three bounded reload attempts before the recovery prompt appears.
- The prompt remains native and English because the renderer is unavailable; this is the existing crash-loop recovery surface.
- Integrity failures still do not retry.
- Live terminal recovery follows the existing in-place renderer reload contract; no new terminal teardown behavior is introduced.