### PR TITLE
feat(crash-reporting): capture GPU status diagnostics

### DIFF
--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   buildProcessGoneCrashDetails,
   buildSuppressedProcessGoneBreadcrumbData,
+  collectGpuFeatureStatusDetails,
   collectProcessGoneMetricDetails
 } from './process-gone-diagnostics'
 
@@ -11,13 +12,15 @@ type MetricFixture = {
   memory: { workingSetSize: number }
 }
 
-const { appMetricsMock } = vi.hoisted(() => ({
-  appMetricsMock: vi.fn<() => MetricFixture[]>(() => [])
+const { appMetricsMock, gpuFeatureStatusMock } = vi.hoisted(() => ({
+  appMetricsMock: vi.fn<() => MetricFixture[]>(() => []),
+  gpuFeatureStatusMock: vi.fn<() => Record<string, unknown>>(() => ({}))
 }))
 
 vi.mock('electron', () => ({
   app: {
-    getAppMetrics: appMetricsMock
+    getAppMetrics: appMetricsMock,
+    getGPUFeatureStatus: gpuFeatureStatusMock
   }
 }))
 
@@ -56,11 +59,44 @@ describe('process gone diagnostics', () => {
       { pid: 22, type: 'Tab', memory: { workingSetSize: 1024 * 400 } }
     ])
 
-    expect(buildProcessGoneCrashDetails({ processType: 'renderer' })).toMatchObject({
+    expect(buildProcessGoneCrashDetails({ processType: 'renderer' }, false)).toMatchObject({
       processType: 'renderer',
       processMetricsCount: 2,
       processMetricsRendererWorkingSetMB: 400,
-      processMetricsLargestPid: 22
+      processMetricsLargestPid: 22,
+      gpuFallbackActive: false
+    })
+  })
+
+  it('captures only allowlisted GPU feature statuses and fallback state', () => {
+    expect(
+      collectGpuFeatureStatusDetails(
+        {
+          gpu_compositing: 'enabled',
+          rasterization: 'disabled_software',
+          webgl2: 'unavailable_off',
+          driver_vendor: 'not collected',
+          diagnostics: 'not collected'
+        },
+        true
+      )
+    ).toEqual({
+      gpuFallbackActive: true,
+      gpuFeatureCompositing: 'enabled',
+      gpuFeatureRasterization: 'disabled_software',
+      gpuFeatureWebgl2: 'unavailable_off'
+    })
+  })
+
+  it('keeps process-gone reporting usable when Electron GPU status collection fails', () => {
+    gpuFeatureStatusMock.mockImplementationOnce(() => {
+      throw new Error('GPU process unavailable')
+    })
+
+    expect(buildProcessGoneCrashDetails({ processType: 'child' }, true)).toMatchObject({
+      processType: 'child',
+      gpuFallbackActive: true,
+      gpuFeatureStatusError: 'Error'
     })
   })
 

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -21,6 +21,18 @@ type ProcessMetricBucket = {
 
 const PROCESS_METRIC_BUCKETS = ['browser', 'renderer', 'gpu', 'utility', 'other'] as const
 
+const GPU_FEATURE_STATUS_FIELDS = [
+  ['2d_canvas', 'gpuFeature2dCanvas'],
+  ['gpu_compositing', 'gpuFeatureCompositing'],
+  ['multiple_raster_threads', 'gpuFeatureMultipleRasterThreads'],
+  ['native_gpu_memory_buffers', 'gpuFeatureNativeMemoryBuffers'],
+  ['rasterization', 'gpuFeatureRasterization'],
+  ['video_decode', 'gpuFeatureVideoDecode'],
+  ['video_encode', 'gpuFeatureVideoEncode'],
+  ['webgl', 'gpuFeatureWebgl'],
+  ['webgl2', 'gpuFeatureWebgl2']
+] as const
+
 type ProcessMetricBucketName = (typeof PROCESS_METRIC_BUCKETS)[number]
 
 function safeString(value: unknown): string | undefined {
@@ -109,13 +121,46 @@ function getProcessGoneMetricDetails(): CrashReportDetails {
   }
 }
 
-export function buildProcessGoneCrashDetails(details: Record<string, unknown>): CrashReportDetails {
+export function collectGpuFeatureStatusDetails(
+  status: unknown,
+  gpuFallbackActive: boolean
+): CrashReportDetails {
+  const details: CrashReportDetails = { gpuFallbackActive }
+  if (typeof status !== 'object' || status === null) {
+    return details
+  }
+  const statusRecord = status as Record<string, unknown>
+  for (const [electronKey, detailKey] of GPU_FEATURE_STATUS_FIELDS) {
+    const value = safeString(statusRecord[electronKey])
+    if (value) {
+      details[detailKey] = value.slice(0, 80)
+    }
+  }
+  return details
+}
+
+function getGpuFeatureStatusDetails(gpuFallbackActive: boolean): CrashReportDetails {
+  try {
+    return collectGpuFeatureStatusDetails(app.getGPUFeatureStatus(), gpuFallbackActive)
+  } catch (error) {
+    const errorName = error instanceof Error ? error.name : typeof error
+    return { gpuFallbackActive, gpuFeatureStatusError: errorName }
+  }
+}
+
+export function buildProcessGoneCrashDetails(
+  details: Record<string, unknown>,
+  gpuFallbackActive: boolean
+): CrashReportDetails {
   const sanitizedDetails = sanitizeCrashReportDetails(details)
   // Why: low-JS-heap renderer kills can still be native/process memory pressure.
   // Capture Electron process buckets at process-gone time before recovery reloads.
   return {
     ...sanitizedDetails,
-    ...getProcessGoneMetricDetails()
+    ...getProcessGoneMetricDetails(),
+    // Why: GPU failures are hardware-specific; fixed status keys distinguish
+    // disabled/software paths without collecting the full GPU-info payload.
+    ...getGpuFeatureStatusDetails(gpuFallbackActive)
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1258,7 +1258,7 @@ function recordProcessGoneCrash(
   if (!processGoneDedupe.shouldRecord(key)) {
     return
   }
-  const crashDetails = buildProcessGoneCrashDetails(details)
+  const crashDetails = buildProcessGoneCrashDetails(details, gpuFallbackActiveThisLaunch)
   const span = startSpan('electron.process_gone', {
     attributes: {
       'crash.source': source,


### PR DESCRIPTION
## Description

Adds bounded GPU-state evidence to accepted renderer and child-process crash reports for #8221.

The supplied Windows reports show the GPU child and renderer exiting with `STATUS_BREAKPOINT` even when Orca's software-rendering fallback is active. They do not contain enough GPU-state evidence to justify another Chromium flag or claim a root-cause fix. This PR records:

- whether the build-scoped GPU fallback is active for this launch,
- nine allowlisted values from Electron's GPU feature status,
- a safe error type if Electron cannot return status after the process loss.

It deliberately does not collect full GPU info, driver/device strings, or unknown future fields.

Refs #8221.

## Evidence: reproduction before and after

**Before (current main `b677b2a20`):**

A deterministic process-gone diagnostic test requires `gpuFallbackActive: false` in the persisted crash details.

- Result: **1 failed, 2 passed**.
- Exact failure: the expected `gpuFallbackActive` field is absent.
- The existing crash report therefore cannot distinguish first-launch/native rendering from a fallback-active launch, nor show which Chromium GPU features remained enabled/software/disabled.

**After (`960246d19`):**

The same focused test file passes **5/5** and verifies:

- fallback-active and fallback-inactive state,
- fixed allowlist capture,
- omission of driver/full-info/unknown keys,
- safe persistence when `app.getGPUFeatureStatus()` throws.

Additional validation:

- `pnpm run typecheck:node` — passed.
- Touched-file `oxlint` — passed.
- Formatting check — passed.
- `pnpm run check:max-lines-ratchet` — passed.
- `git diff --check origin/main...HEAD` — passed.

## ELI5

The crash report currently says “the graphics helper broke,” but not which safety mode Orca was using or which graphics features Chromium thought were active. This adds a small dashboard snapshot to the report. It gives the next affected-machine report useful clues without changing the engine or guessing at a repair.

## User-facing trade-offs

- **Benefit:** the next hardware-specific crash report can distinguish normal and fallback-active launches.
- **Benefit:** feature status can show whether compositing, rasterization, video acceleration, or WebGL was enabled, software-only, or unavailable.
- **Cost:** one synchronous Electron status lookup occurs only when an accepted, deduplicated process-gone crash is being persisted.
- **Limit:** diagnostics do not prevent or recover the crash and are not a native stack trace.
- **Privacy:** full GPU info, driver/device identifiers, and unknown fields are intentionally omitted.

## Compatibility and security

- Uses Electron's cross-platform runtime API; no Windows-only path or hardcoded separator.
- SSH, WSL, remote execution, Git providers, and Git behavior are unchanged.
- No new IPC, network request, subprocess, dependency, or upload behavior.
- Reports still use the existing crash-detail sanitizer and user-approved submission flow.