### PR TITLE
fix(crash-reporting): make Windows capture and submission reliable

### DIFF
--- a/src/main/crash-reporting/crash-feedback-diagnostic-bundle.ts
+++ b/src/main/crash-reporting/crash-feedback-diagnostic-bundle.ts
@@ -1,0 +1,119 @@
+import os from 'node:os'
+import { app } from 'electron'
+import {
+  sanitizeCrashReportString,
+  type CrashReportDiagnosticBundle
+} from '../../shared/crash-reporting'
+import { collectDiagnosticBundle, getDiagnosticsStatus } from '../observability'
+import { resolveDiagnosticOrcaChannel } from '../observability/diagnostic-upload-endpoint'
+import type { FeedbackDiagnosticBundleAttachment, FeedbackSubmitResult } from '../ipc/feedback'
+
+const CRASH_REPORT_LOG_LOOKBACK_MINUTES = 3 * 24 * 60
+
+export type CrashDiagnosticBundleAttachment = {
+  readonly diagnosticBundle: CrashReportDiagnosticBundle
+  readonly feedbackDiagnosticBundle?: FeedbackDiagnosticBundleAttachment
+}
+
+function formatUnknownError(error: unknown): string {
+  return sanitizeCrashReportString(error instanceof Error ? error.message : String(error))
+}
+
+function skippedCrashDiagnosticBundle(): CrashDiagnosticBundleAttachment {
+  return {
+    diagnosticBundle: {
+      status: 'not_uploaded',
+      reason: 'diagnostic log upload skipped by user'
+    }
+  }
+}
+
+function collectCrashDiagnosticBundleAttachment(): CrashDiagnosticBundleAttachment {
+  const status = getDiagnosticsStatus()
+  if (!status.bundleEnabled) {
+    return {
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: status.disabledReason ?? 'diagnostic bundle collection is disabled'
+      }
+    }
+  }
+
+  let bundle: ReturnType<typeof collectDiagnosticBundle>
+  try {
+    bundle = collectDiagnosticBundle({
+      appVersion: app.getVersion(),
+      platform: os.platform(),
+      arch: os.arch(),
+      osRelease: os.release(),
+      orcaChannel: resolveDiagnosticOrcaChannel(),
+      // Why: Help > Report Crash is often used after relaunch, long after the
+      // default 30 minute support bundle window would miss the failure context.
+      lookbackMinutes: CRASH_REPORT_LOG_LOOKBACK_MINUTES
+    })
+  } catch (error) {
+    return { diagnosticBundle: { status: 'not_uploaded', reason: formatUnknownError(error) } }
+  }
+
+  return {
+    diagnosticBundle: {
+      status: 'attached',
+      bundleSubmissionId: bundle.bundleSubmissionId,
+      bytes: bundle.bytes,
+      spanCount: bundle.spanCount
+    },
+    feedbackDiagnosticBundle: {
+      bundleSubmissionId: bundle.bundleSubmissionId,
+      content: bundle.payload,
+      bytes: bundle.bytes,
+      spanCount: bundle.spanCount
+    }
+  }
+}
+
+export function prepareCrashDiagnosticBundle(
+  includeDiagnosticLogs: boolean
+): CrashDiagnosticBundleAttachment {
+  return includeDiagnosticLogs
+    ? collectCrashDiagnosticBundleAttachment()
+    : skippedCrashDiagnosticBundle()
+}
+
+export function diagnosticBundleForReportOnlyRetry(
+  attachment: CrashDiagnosticBundleAttachment
+): CrashReportDiagnosticBundle | undefined {
+  const bundle = attachment.feedbackDiagnosticBundle
+  if (!bundle) {
+    return undefined
+  }
+  return {
+    status: 'not_uploaded',
+    reason: 'diagnostic log attachment could not be sent; report retried without logs',
+    bundleSubmissionId: bundle.bundleSubmissionId,
+    bytes: bundle.bytes,
+    spanCount: bundle.spanCount
+  }
+}
+
+export function resolveSubmittedDiagnosticBundle(
+  attachment: CrashDiagnosticBundleAttachment,
+  result: FeedbackSubmitResult
+): CrashReportDiagnosticBundle {
+  const bundle = attachment.feedbackDiagnosticBundle
+  if (!bundle) {
+    return attachment.diagnosticBundle
+  }
+  const failure =
+    result.diagnosticBundleFailure ??
+    (!result.ok ? { status: result.status, error: result.error } : undefined)
+  if (!failure) {
+    return attachment.diagnosticBundle
+  }
+  return {
+    status: 'not_uploaded',
+    reason: `diagnostic log attachment failed: ${formatUnknownError(failure.error)}`,
+    bundleSubmissionId: bundle.bundleSubmissionId,
+    bytes: bundle.bytes,
+    spanCount: bundle.spanCount
+  }
+}

--- a/src/main/crash-reporting/crash-report-copy-text.test.ts
+++ b/src/main/crash-reporting/crash-report-copy-text.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { formatCrashReportCopyText } from './crash-report-copy-text'
+
+describe('formatCrashReportCopyText', () => {
+  it('appends only sanitized report and diagnostic omission failure fields', () => {
+    const text = formatCrashReportCopyText('[Crash Report]', {
+      error: 'proxy failed at C:\\Users\\alice\\Orca',
+      diagnosticContext: {
+        status: 'not_uploaded',
+        reason: 'timeout token=super-secret-value\n- Forged field: hidden',
+        internalEndpointError: 'must-not-cross-copy-boundary'
+      },
+      internalTransportFailure: 'must-not-cross-copy-boundary'
+    })
+
+    expect(text).toContain('Submission failure:')
+    expect(text).toContain('Report error: proxy failed at [redacted-path]')
+    expect(text).toContain('Diagnostic logs not uploaded: timeout token=[redacted]')
+    expect(text).not.toContain('\n- Forged field')
+    expect(text).not.toContain('alice')
+    expect(text).not.toContain('must-not-cross-copy-boundary')
+  })
+
+  it('includes a sanitized uploaded ticket without accepting unrelated fields', () => {
+    const text = formatCrashReportCopyText('[Crash Report]', {
+      error: 'report link failed',
+      diagnosticContext: {
+        status: 'uploaded',
+        ticketId: 'ticket-123',
+        bundleSubmissionId: 'not-allow-listed'
+      }
+    })
+
+    expect(text).toContain('Diagnostic ticket uploaded but not linked: ticket-123')
+    expect(text).not.toContain('not-allow-listed')
+  })
+
+  it('leaves the report unchanged when failure context is invalid', () => {
+    expect(formatCrashReportCopyText('[Crash Report]', { error: '' })).toBe('[Crash Report]')
+  })
+})

--- a/src/main/crash-reporting/crash-report-copy-text.ts
+++ b/src/main/crash-reporting/crash-report-copy-text.ts
@@ -1,0 +1,53 @@
+import {
+  sanitizeCrashReportString,
+  type CrashReportCopySubmissionFailure
+} from '../../shared/crash-reporting'
+
+function sanitizedNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const sanitized = sanitizeCrashReportString(value.replace(/[\r\n]+/g, ' ')).trim()
+  return sanitized || null
+}
+
+function normalizeSubmissionFailure(value: unknown): CrashReportCopySubmissionFailure | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const record = value as Record<string, unknown>
+  const error = sanitizedNonEmptyString(record.error)
+  if (!error) {
+    return null
+  }
+
+  const rawContext = record.diagnosticContext
+  if (!rawContext || typeof rawContext !== 'object' || Array.isArray(rawContext)) {
+    return { error }
+  }
+  const context = rawContext as Record<string, unknown>
+  if (context.status === 'uploaded') {
+    const ticketId = sanitizedNonEmptyString(context.ticketId)
+    return ticketId ? { error, diagnosticContext: { status: 'uploaded', ticketId } } : { error }
+  }
+  if (context.status === 'not_uploaded') {
+    const reason = sanitizedNonEmptyString(context.reason)
+    return reason ? { error, diagnosticContext: { status: 'not_uploaded', reason } } : { error }
+  }
+  return { error }
+}
+
+export function formatCrashReportCopyText(baseText: string, submissionFailure: unknown): string {
+  const failure = normalizeSubmissionFailure(submissionFailure)
+  if (!failure) {
+    return baseText
+  }
+
+  const lines = [baseText, '', 'Submission failure:', `- Report error: ${failure.error}`]
+  if (failure.diagnosticContext?.status === 'uploaded') {
+    lines.push(`- Diagnostic ticket uploaded but not linked: ${failure.diagnosticContext.ticketId}`)
+  } else if (failure.diagnosticContext?.status === 'not_uploaded') {
+    lines.push(`- Diagnostic logs not uploaded: ${failure.diagnosticContext.reason}`)
+  }
+  return lines.join('\n')
+}

--- a/src/main/crash-reporting/crash-report-store.test.ts
+++ b/src/main/crash-reporting/crash-report-store.test.ts
@@ -168,6 +168,28 @@ describe('CrashReportStore', () => {
     await expect(store.getLatestPending()).resolves.toMatchObject({ id: report.id })
   })
 
+  it.each(['EPERM', 'EACCES', 'EBUSY'] as const)(
+    'recovers a pending report after a transient Windows %s read failure',
+    async (code) => {
+      const { store, filePath } = await createStore()
+      const report = await store.record(input())
+      const reloaded = new CrashReportStore(filePath)
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+      const readError = Object.assign(new Error('temporary read failure'), { code })
+      const readFileSpy = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(readError)
+
+      await expect(reloaded.getLatestPending()).resolves.toMatchObject({ id: report.id })
+
+      expect(readFileSpy).toHaveBeenCalledTimes(2)
+      if (code === 'EBUSY') {
+        expect(grantDirAclMock).not.toHaveBeenCalled()
+      } else {
+        expect(grantDirAclMock).toHaveBeenCalledOnce()
+        expect(grantDirAclMock).toHaveBeenCalledWith(path.dirname(filePath))
+      }
+    }
+  )
+
   it('retries a transient Windows rename lock', async () => {
     const { store } = await createStore()
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')

--- a/src/main/crash-reporting/crash-report-store.test.ts
+++ b/src/main/crash-reporting/crash-report-store.test.ts
@@ -3,11 +3,13 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { grantDirAclMock } = vi.hoisted(() => ({ grantDirAclMock: vi.fn() }))
+const { grantDirAclAsyncMock } = vi.hoisted(() => ({
+  grantDirAclAsyncMock: vi.fn().mockResolvedValue(undefined)
+}))
 
 vi.mock('../win32-utils', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
-  return { ...actual, grantDirAcl: grantDirAclMock }
+  return { ...actual, grantDirAclAsync: grantDirAclAsyncMock }
 })
 
 import { CrashReportStore } from './crash-report-store'
@@ -47,7 +49,8 @@ function input(reason = 'crashed'): CrashReportCreateInput {
 
 afterEach(async () => {
   vi.restoreAllMocks()
-  grantDirAclMock.mockReset()
+  grantDirAclAsyncMock.mockReset()
+  grantDirAclAsyncMock.mockResolvedValue(undefined)
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
 })
 
@@ -163,7 +166,7 @@ describe('CrashReportStore', () => {
 
     const report = await store.record(input())
 
-    expect(grantDirAclMock).toHaveBeenCalledWith(path.dirname(filePath))
+    expect(grantDirAclAsyncMock).toHaveBeenCalledWith(path.dirname(filePath))
     expect(writeFileSpy).toHaveBeenCalledTimes(2)
     await expect(store.getLatestPending()).resolves.toMatchObject({ id: report.id })
   })
@@ -182,10 +185,10 @@ describe('CrashReportStore', () => {
 
       expect(readFileSpy).toHaveBeenCalledTimes(2)
       if (code === 'EBUSY') {
-        expect(grantDirAclMock).not.toHaveBeenCalled()
+        expect(grantDirAclAsyncMock).not.toHaveBeenCalled()
       } else {
-        expect(grantDirAclMock).toHaveBeenCalledOnce()
-        expect(grantDirAclMock).toHaveBeenCalledWith(path.dirname(filePath))
+        expect(grantDirAclAsyncMock).toHaveBeenCalledOnce()
+        expect(grantDirAclAsyncMock).toHaveBeenCalledWith(path.dirname(filePath))
       }
     }
   )
@@ -199,7 +202,7 @@ describe('CrashReportStore', () => {
     await expect(store.record(input())).resolves.toMatchObject({ status: 'pending' })
 
     expect(renameSpy).toHaveBeenCalledTimes(2)
-    expect(grantDirAclMock).not.toHaveBeenCalled()
+    expect(grantDirAclAsyncMock).not.toHaveBeenCalled()
   })
 
   it('removes its temp file after a terminal write failure', async () => {

--- a/src/main/crash-reporting/crash-report-store.test.ts
+++ b/src/main/crash-reporting/crash-report-store.test.ts
@@ -1,7 +1,15 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { grantDirAclMock } = vi.hoisted(() => ({ grantDirAclMock: vi.fn() }))
+
+vi.mock('../win32-utils', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, grantDirAcl: grantDirAclMock }
+})
+
 import { CrashReportStore } from './crash-report-store'
 import type { CrashReportCreateInput } from '../../shared/crash-reporting'
 
@@ -38,6 +46,8 @@ function input(reason = 'crashed'): CrashReportCreateInput {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks()
+  grantDirAclMock.mockReset()
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
 })
 
@@ -133,5 +143,51 @@ describe('CrashReportStore', () => {
     await Promise.all(Array.from({ length: 5 }, (_, index) => store.record(input(`oom-${index}`))))
 
     await expect(store.listRecent()).resolves.toHaveLength(5)
+  })
+
+  it('waits for an in-flight crash write before reading the pending report', async () => {
+    const { store } = await createStore()
+
+    const recordPromise = store.record(input())
+    const pendingPromise = store.getLatestPending()
+    const report = await recordPromise
+
+    await expect(pendingPromise).resolves.toMatchObject({ id: report.id, status: 'pending' })
+  })
+
+  it('repairs the Windows userData ACL and retries a denied crash write', async () => {
+    const { store, filePath } = await createStore()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const permissionError = Object.assign(new Error('permission denied'), { code: 'EPERM' })
+    const writeFileSpy = vi.spyOn(fs, 'writeFile').mockRejectedValueOnce(permissionError)
+
+    const report = await store.record(input())
+
+    expect(grantDirAclMock).toHaveBeenCalledWith(path.dirname(filePath))
+    expect(writeFileSpy).toHaveBeenCalledTimes(2)
+    await expect(store.getLatestPending()).resolves.toMatchObject({ id: report.id })
+  })
+
+  it('retries a transient Windows rename lock', async () => {
+    const { store } = await createStore()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const busyError = Object.assign(new Error('file busy'), { code: 'EBUSY' })
+    const renameSpy = vi.spyOn(fs, 'rename').mockRejectedValueOnce(busyError)
+
+    await expect(store.record(input())).resolves.toMatchObject({ status: 'pending' })
+
+    expect(renameSpy).toHaveBeenCalledTimes(2)
+    expect(grantDirAclMock).not.toHaveBeenCalled()
+  })
+
+  it('removes its temp file after a terminal write failure', async () => {
+    const { store, filePath } = await createStore()
+    const ioError = Object.assign(new Error('disk error'), { code: 'EIO' })
+    vi.spyOn(fs, 'rename').mockRejectedValueOnce(ioError)
+
+    await expect(store.record(input())).rejects.toBe(ioError)
+
+    const entries = await fs.readdir(path.dirname(filePath))
+    expect(entries.filter((entry) => entry.endsWith('.tmp'))).toEqual([])
   })
 })

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -15,7 +15,7 @@ import {
 
 const MAX_REPORTS = 5
 const RELATED_CRASH_WINDOW_MS = 5_000
-const WINDOWS_WRITE_RETRY_DELAYS_MS = [50, 100, 150, 200, 250]
+const WINDOWS_FILE_OPERATION_RETRY_DELAYS_MS = [50, 100, 150, 200, 250]
 
 type CrashReportFile = {
   reports: CrashReportRecord[]
@@ -39,7 +39,7 @@ function isRelatedCrashEvent(anchor: CrashReportRecord, candidate: CrashReportRe
   )
 }
 
-function isRetryableWindowsWriteError(error: unknown): boolean {
+function isRetryableWindowsFileOperationError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException).code
   return code === 'EPERM' || code === 'EACCES' || code === 'EBUSY'
 }
@@ -48,34 +48,33 @@ async function wait(delayMs: number): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, delayMs))
 }
 
-async function runCrashReportWriteWithWindowsRecovery(
+async function runCrashReportFileOperationWithWindowsRecovery<T>(
   directory: string,
-  operation: () => Promise<void>
-): Promise<void> {
+  operation: () => Promise<T>
+): Promise<T> {
   let repairedAcl = false
   for (let attempt = 0; ; attempt += 1) {
     try {
-      await operation()
-      return
+      return await operation()
     } catch (error) {
       if (
         process.platform !== 'win32' ||
-        !isRetryableWindowsWriteError(error) ||
-        attempt >= WINDOWS_WRITE_RETRY_DELAYS_MS.length
+        !isRetryableWindowsFileOperationError(error) ||
+        attempt >= WINDOWS_FILE_OPERATION_RETRY_DELAYS_MS.length
       ) {
         throw error
       }
       if (!repairedAcl && isPermissionError(error)) {
         repairedAcl = true
         try {
-          // Why: Chromium can reset userData ACLs before the asynchronous
-          // startup grant finishes, exactly when an early crash must persist.
+          // Why: Chromium can reset userData ACLs before startup capture or
+          // recovery, so both the crash write and next prompt must repair it.
           grantDirAcl(directory)
         } catch {
           // The bounded retry below still handles transient file locks.
         }
       }
-      await wait(WINDOWS_WRITE_RETRY_DELAYS_MS[attempt])
+      await wait(WINDOWS_FILE_OPERATION_RETRY_DELAYS_MS[attempt])
     }
   }
 }
@@ -201,7 +200,10 @@ export class CrashReportStore {
 
   private async readReportsFromDisk(): Promise<CrashReportRecord[]> {
     try {
-      const raw = await fs.readFile(this.filePath, 'utf8')
+      const raw = await runCrashReportFileOperationWithWindowsRecovery(
+        path.dirname(this.filePath),
+        () => fs.readFile(this.filePath, 'utf8')
+      )
       const parsed = JSON.parse(raw) as Partial<CrashReportFile>
       return Array.isArray(parsed.reports) ? parsed.reports.slice(0, MAX_REPORTS) : []
     } catch (error) {
@@ -216,7 +218,7 @@ export class CrashReportStore {
     const directory = path.dirname(this.filePath)
     const tmpPath = `${this.filePath}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`
     try {
-      await runCrashReportWriteWithWindowsRecovery(directory, async () => {
+      await runCrashReportFileOperationWithWindowsRecovery(directory, async () => {
         await fs.mkdir(directory, { recursive: true })
         await fs.writeFile(tmpPath, `${JSON.stringify({ reports }, null, 2)}${os.EOL}`, 'utf8')
         await fs.rename(tmpPath, this.filePath)

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { app } from 'electron'
-import { grantDirAcl, isPermissionError } from '../win32-utils'
+import { grantDirAclAsync, isPermissionError } from '../win32-utils'
 import {
   formatCrashReportText,
   sanitizeCrashReportBreadcrumbs,
@@ -69,7 +69,7 @@ async function runCrashReportFileOperationWithWindowsRecovery<T>(
         try {
           // Why: Chromium can reset userData ACLs before startup capture or
           // recovery, so both the crash write and next prompt must repair it.
-          grantDirAcl(directory)
+          await grantDirAclAsync(directory)
         } catch {
           // The bounded retry below still handles transient file locks.
         }

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { app } from 'electron'
+import { grantDirAcl, isPermissionError } from '../win32-utils'
 import {
   formatCrashReportText,
   sanitizeCrashReportBreadcrumbs,
@@ -14,6 +15,7 @@ import {
 
 const MAX_REPORTS = 5
 const RELATED_CRASH_WINDOW_MS = 5_000
+const WINDOWS_WRITE_RETRY_DELAYS_MS = [50, 100, 150, 200, 250]
 
 type CrashReportFile = {
   reports: CrashReportRecord[]
@@ -35,6 +37,47 @@ function isRelatedCrashEvent(anchor: CrashReportRecord, candidate: CrashReportRe
     anchor.appVersion === candidate.appVersion &&
     anchor.platform === candidate.platform
   )
+}
+
+function isRetryableWindowsWriteError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code
+  return code === 'EPERM' || code === 'EACCES' || code === 'EBUSY'
+}
+
+async function wait(delayMs: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+}
+
+async function runCrashReportWriteWithWindowsRecovery(
+  directory: string,
+  operation: () => Promise<void>
+): Promise<void> {
+  let repairedAcl = false
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await operation()
+      return
+    } catch (error) {
+      if (
+        process.platform !== 'win32' ||
+        !isRetryableWindowsWriteError(error) ||
+        attempt >= WINDOWS_WRITE_RETRY_DELAYS_MS.length
+      ) {
+        throw error
+      }
+      if (!repairedAcl && isPermissionError(error)) {
+        repairedAcl = true
+        try {
+          // Why: Chromium can reset userData ACLs before the asynchronous
+          // startup grant finishes, exactly when an early crash must persist.
+          grantDirAcl(directory)
+        } catch {
+          // The bounded retry below still handles transient file locks.
+        }
+      }
+      await wait(WINDOWS_WRITE_RETRY_DELAYS_MS[attempt])
+    }
+  }
 }
 
 export class CrashReportStore {
@@ -135,7 +178,9 @@ export class CrashReportStore {
     mutate: (reports: CrashReportRecord[]) => Promise<{ reports: CrashReportRecord[]; result: T }>
   ): Promise<T> {
     const run = this.writeChain.then(async () => {
-      const reports = await this.readReports()
+      // Why: awaiting writeChain from inside its own callback would deadlock;
+      // this writer already has exclusive ownership and can read disk directly.
+      const reports = await this.readReportsFromDisk()
       const { reports: nextReports, result } = await mutate(reports)
       await this.writeReports(nextReports)
       return result
@@ -148,6 +193,13 @@ export class CrashReportStore {
   }
 
   private async readReports(): Promise<CrashReportRecord[]> {
+    // Why: renderer recovery can query the one-shot startup prompt while the
+    // crash write is still in flight. Wait so a successful capture is visible.
+    await this.writeChain
+    return this.readReportsFromDisk()
+  }
+
+  private async readReportsFromDisk(): Promise<CrashReportRecord[]> {
     try {
       const raw = await fs.readFile(this.filePath, 'utf8')
       const parsed = JSON.parse(raw) as Partial<CrashReportFile>
@@ -161,9 +213,18 @@ export class CrashReportStore {
   }
 
   private async writeReports(reports: CrashReportRecord[]): Promise<void> {
-    await fs.mkdir(path.dirname(this.filePath), { recursive: true })
+    const directory = path.dirname(this.filePath)
     const tmpPath = `${this.filePath}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`
-    await fs.writeFile(tmpPath, `${JSON.stringify({ reports }, null, 2)}${os.EOL}`, 'utf8')
-    await fs.rename(tmpPath, this.filePath)
+    try {
+      await runCrashReportWriteWithWindowsRecovery(directory, async () => {
+        await fs.mkdir(directory, { recursive: true })
+        await fs.writeFile(tmpPath, `${JSON.stringify({ reports }, null, 2)}${os.EOL}`, 'utf8')
+        await fs.rename(tmpPath, this.filePath)
+      })
+    } finally {
+      // Why: disk-full and terminal rename failures must not accumulate a new
+      // orphaned multi-report temp file after every crash.
+      await fs.rm(tmpPath, { force: true }).catch(() => {})
+    }
   }
 }

--- a/src/main/crash-reporting/durable-crash-breadcrumb.test.ts
+++ b/src/main/crash-reporting/durable-crash-breadcrumb.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearCrashBreadcrumbsForTest, getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
+import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observability/tracer'
+
+type CapturingSink = TracerSink & { records: unknown[]; flushMock: ReturnType<typeof vi.fn> }
+
+function capturingSink(): CapturingSink {
+  const records: unknown[] = []
+  const flushMock = vi.fn()
+  return {
+    records,
+    flushMock,
+    push: (record) => records.push(record),
+    flush: flushMock,
+    close: vi.fn()
+  }
+}
+
+let sink: CapturingSink
+
+beforeEach(() => {
+  sink = capturingSink()
+  setActiveSink(sink)
+  clearCrashBreadcrumbsForTest()
+})
+
+afterEach(() => {
+  _resetTracerForTests()
+  clearCrashBreadcrumbsForTest()
+})
+
+describe('recordDurableCrashBreadcrumb', () => {
+  it('records, traces, and flushes a sanitized crash breadcrumb', () => {
+    recordDurableCrashBreadcrumb('process_gone_suppressed', {
+      source: 'renderer',
+      path: 'C:\\Users\\alice\\project'
+    })
+
+    expect(getCrashBreadcrumbSnapshot()).toEqual([
+      expect.objectContaining({
+        name: 'process_gone_suppressed',
+        data: { source: 'renderer', path: '[redacted-path]' }
+      })
+    ])
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        name: 'crash.breadcrumb',
+        attributes: expect.objectContaining({
+          kind: 'crash-breadcrumb',
+          'breadcrumb.name': 'process_gone_suppressed'
+        }),
+        exit: { _tag: 'Success' }
+      })
+    ])
+    expect(sink.flushMock).toHaveBeenCalledOnce()
+  })
+
+  it('records persistence failures as failed, flushed spans', () => {
+    recordDurableCrashBreadcrumb(
+      'crash_report_persist_failed',
+      { errorCode: 'EPERM' },
+      'EPERM at C:\\Users\\alice\\AppData\\Roaming\\Orca'
+    )
+
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        exit: expect.objectContaining({ _tag: 'Failure', cause: expect.stringContaining('EPERM') })
+      })
+    ])
+    expect(JSON.stringify(sink.records)).not.toContain('alice')
+    expect(sink.flushMock).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/crash-reporting/durable-crash-breadcrumb.ts
+++ b/src/main/crash-reporting/durable-crash-breadcrumb.ts
@@ -1,0 +1,33 @@
+import {
+  sanitizeCrashReportDetails,
+  sanitizeCrashReportString,
+  type CrashReportBreadcrumbData
+} from '../../shared/crash-reporting'
+import { flushActiveSink, startSpan } from '../observability/tracer'
+import { recordCrashBreadcrumb } from './crash-breadcrumb-store'
+
+export function recordDurableCrashBreadcrumb(
+  name: string,
+  data?: CrashReportBreadcrumbData,
+  failureCause?: string
+): void {
+  const sanitizedName = sanitizeCrashReportString(name)
+  const sanitizedData = data ? sanitizeCrashReportDetails(data) : undefined
+  recordCrashBreadcrumb(sanitizedName, sanitizedData)
+
+  const span = startSpan('crash.breadcrumb', {
+    attributes: {
+      kind: 'crash-breadcrumb',
+      'breadcrumb.name': sanitizedName,
+      ...(sanitizedData ? { 'breadcrumb.data': sanitizedData } : {})
+    }
+  })
+  if (failureCause) {
+    span.fail(sanitizeCrashReportString(failureCause, 1_000))
+  } else {
+    span.end()
+  }
+  // Why: these breadcrumbs explain a missing crash record; losing one to the
+  // normal trace batching window would recreate the diagnostic blind spot.
+  flushActiveSink()
+}

--- a/src/main/crash-reporting/process-gone-dedupe.test.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.test.ts
@@ -11,6 +11,27 @@ describe('ProcessGoneDedupe', () => {
     expect(dedupe.shouldRecord(key, 3_000)).toBe(true)
   })
 
+  it('allows an immediate retry after a failed claim is released', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+    const claim = dedupe.tryClaim('renderer', 1_000)
+
+    expect(claim).not.toBeNull()
+    expect(dedupe.tryClaim('renderer', 1_001)).toBeNull()
+    dedupe.release(claim!)
+    expect(dedupe.tryClaim('renderer', 1_001)).not.toBeNull()
+  })
+
+  it('does not release a newer claim when an older persistence attempt fails late', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+    const oldClaim = dedupe.tryClaim('renderer', 1_000)
+    const currentClaim = dedupe.tryClaim('renderer', 3_000)
+
+    expect(oldClaim).not.toBeNull()
+    expect(currentClaim).not.toBeNull()
+    dedupe.release(oldClaim!)
+    expect(dedupe.tryClaim('renderer', 3_001)).toBeNull()
+  })
+
   it('prunes stale keys outside the dedupe window', () => {
     const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
 

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -6,10 +6,19 @@ type ProcessGoneDedupeOptions = {
   maxKeys?: number
 }
 
+export type ProcessGoneDedupeClaim = {
+  readonly key: string
+}
+
+type ProcessGoneDedupeEntry = {
+  readonly recordedAt: number
+  readonly claim: ProcessGoneDedupeClaim
+}
+
 export class ProcessGoneDedupe {
   private readonly windowMs: number
   private readonly maxKeys: number
-  private readonly recentKeys = new Map<string, number>()
+  private readonly recentKeys = new Map<string, ProcessGoneDedupeEntry>()
 
   constructor(options: ProcessGoneDedupeOptions = {}) {
     this.windowMs = options.windowMs ?? DEFAULT_PROCESS_GONE_DEDUPE_WINDOW_MS
@@ -17,19 +26,33 @@ export class ProcessGoneDedupe {
   }
 
   shouldRecord(key: string, now = Date.now()): boolean {
+    return this.tryClaim(key, now) !== null
+  }
+
+  tryClaim(key: string, now = Date.now()): ProcessGoneDedupeClaim | null {
     this.prune(now)
 
     const previous = this.recentKeys.get(key)
-    if (previous !== undefined && now - previous < this.windowMs) {
-      return false
+    if (previous && now - previous.recordedAt < this.windowMs) {
+      return null
     }
 
+    const claim = { key }
     // Why: process-gone tuples come from Electron and can vary by exit code;
     // keep the short dedupe window without retaining stale tuples forever.
     this.recentKeys.delete(key)
-    this.recentKeys.set(key, now)
+    this.recentKeys.set(key, { recordedAt: now, claim })
     this.prune(now)
-    return true
+    return claim
+  }
+
+  release(claim: ProcessGoneDedupeClaim): void {
+    const current = this.recentKeys.get(claim.key)
+    // Why: an old failed write must not erase a newer claim for the same
+    // renderer after the dedupe window expires or bounded entries are evicted.
+    if (current?.claim === claim) {
+      this.recentKeys.delete(claim.key)
+    }
   }
 
   get size(): number {
@@ -37,8 +60,8 @@ export class ProcessGoneDedupe {
   }
 
   private prune(now: number): void {
-    for (const [key, recordedAt] of this.recentKeys) {
-      if (now - recordedAt >= this.windowMs) {
+    for (const [key, entry] of this.recentKeys) {
+      if (now - entry.recordedAt >= this.windowMs) {
         this.recentKeys.delete(key)
       }
     }

--- a/src/main/crash-reporting/process-gone-diagnostics.test.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.test.ts
@@ -71,6 +71,7 @@ describe('process gone diagnostics', () => {
         processType: 'Utility',
         reason: 'killed',
         exitCode: 1,
+        expectedTeardown: 'app-shutdown',
         details: {
           name: 'Network Service',
           serviceName: 'network.mojom.NetworkService',
@@ -82,6 +83,7 @@ describe('process gone diagnostics', () => {
       processType: 'Utility',
       reason: 'killed',
       exitCode: 1,
+      expectedTeardown: 'app-shutdown',
       name: 'Network Service',
       serviceName: 'network.mojom.NetworkService'
     })

--- a/src/main/crash-reporting/process-gone-diagnostics.ts
+++ b/src/main/crash-reporting/process-gone-diagnostics.ts
@@ -4,6 +4,7 @@ import {
   type CrashReportBreadcrumbData,
   type CrashReportDetailValue
 } from '../../shared/crash-reporting'
+import type { ExpectedTeardownScope } from './process-gone-classification'
 
 type ProcessMetricLike = {
   pid?: unknown
@@ -124,19 +125,22 @@ export function buildSuppressedProcessGoneBreadcrumbData({
   processType,
   reason,
   exitCode,
+  expectedTeardown,
   details
 }: {
   source: 'renderer' | 'child'
   processType: string
   reason: string
   exitCode: number | null
+  expectedTeardown: ExpectedTeardownScope
   details: Record<string, unknown>
 }): CrashReportBreadcrumbData {
   const breadcrumb: CrashReportBreadcrumbData = {
     source,
     processType,
     reason,
-    exitCode
+    exitCode,
+    expectedTeardown
   }
   const name = safeString(details.name)
   if (name) {

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.2.3-test',
+    getAppMetrics: () => []
+  }
+}))
+
+import { clearCrashBreadcrumbsForTest, getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
+import { ProcessGoneDedupe } from './process-gone-dedupe'
+import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
+import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observability/tracer'
+
+type CapturingSink = TracerSink & { records: unknown[]; flushMock: ReturnType<typeof vi.fn> }
+
+function capturingSink(): CapturingSink {
+  const records: unknown[] = []
+  const flushMock = vi.fn()
+  return {
+    records,
+    flushMock,
+    push: (record) => records.push(record),
+    flush: flushMock,
+    close: vi.fn()
+  }
+}
+
+function event(overrides: Partial<ProcessGoneCrashEvent> = {}): ProcessGoneCrashEvent {
+  return {
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'crashed',
+    exitCode: 5,
+    expectedTeardown: 'none',
+    details: { processType: 'renderer' },
+    ...overrides
+  }
+}
+
+let sink: CapturingSink
+
+beforeEach(() => {
+  sink = capturingSink()
+  setActiveSink(sink)
+  clearCrashBreadcrumbsForTest()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  _resetTracerForTests()
+  clearCrashBreadcrumbsForTest()
+})
+
+describe('recordProcessGoneCrash', () => {
+  it('durably records when the crash report store is unavailable', () => {
+    recordProcessGoneCrash(null, event(), new ProcessGoneDedupe())
+
+    expect(getCrashBreadcrumbSnapshot()).toEqual([
+      expect.objectContaining({
+        name: 'crash_report_store_unavailable',
+        data: expect.objectContaining({
+          source: 'renderer',
+          expectedTeardown: 'none'
+        })
+      })
+    ])
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        name: 'crash.breadcrumb',
+        exit: expect.objectContaining({ _tag: 'Failure' })
+      })
+    ])
+    expect(sink.flushMock).toHaveBeenCalledOnce()
+  })
+
+  it('durably records why an expected renderer teardown was suppressed', () => {
+    const record = vi.fn()
+
+    recordProcessGoneCrash(
+      { record } as never,
+      event({ reason: 'killed', exitCode: 1, expectedTeardown: 'renderer-reload' }),
+      new ProcessGoneDedupe()
+    )
+
+    expect(record).not.toHaveBeenCalled()
+    expect(getCrashBreadcrumbSnapshot()).toEqual([
+      expect.objectContaining({
+        name: 'process_gone_suppressed',
+        data: expect.objectContaining({ expectedTeardown: 'renderer-reload' })
+      })
+    ])
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        name: 'crash.breadcrumb',
+        attributes: expect.objectContaining({
+          'breadcrumb.name': 'process_gone_suppressed'
+        })
+      })
+    ])
+    expect(sink.flushMock).toHaveBeenCalledOnce()
+  })
+
+  it('persists a report and flushes the process-gone trace before recovery', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+
+    recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'renderer', reason: 'crashed', exitCode: 5 })
+    )
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        name: 'electron.process_gone',
+        exit: expect.objectContaining({ _tag: 'Failure' })
+      })
+    ])
+    expect(sink.flushMock).toHaveBeenCalledOnce()
+  })
+
+  it('durably records a sanitized crash-report persistence failure', async () => {
+    const persistError = Object.assign(
+      new Error('EPERM at C:\\Users\\alice\\AppData\\Roaming\\Orca\\crash-reports.json'),
+      { code: 'EPERM' }
+    )
+    const record = vi.fn().mockRejectedValue(persistError)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+
+    await vi.waitFor(() => {
+      expect(getCrashBreadcrumbSnapshot()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'crash_report_persist_failed',
+            data: expect.objectContaining({ errorCode: 'EPERM' })
+          })
+        ])
+      )
+    })
+    expect(sink.records).toHaveLength(2)
+    expect(sink.records[1]).toEqual(
+      expect.objectContaining({
+        name: 'crash.breadcrumb',
+        exit: expect.objectContaining({ _tag: 'Failure' })
+      })
+    )
+    expect(JSON.stringify(sink.records)).not.toContain('alice')
+    expect(sink.flushMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -119,6 +119,30 @@ describe('recordProcessGoneCrash', () => {
     expect(sink.flushMock).toHaveBeenCalledOnce()
   })
 
+  it('still persists the report when the forced trace flush fails', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    sink.flushMock.mockImplementation(() => {
+      throw new Error('trace disk unavailable')
+    })
+
+    expect(() =>
+      recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+    ).not.toThrow()
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+  })
+
+  it('still persists the report when the trace sink handoff fails', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    sink.push = () => {
+      throw new Error('trace rotation failed')
+    }
+
+    expect(() =>
+      recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+    ).not.toThrow()
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+  })
+
   it('durably records a sanitized crash-report persistence failure', async () => {
     const persistError = Object.assign(
       new Error('EPERM at C:\\Users\\alice\\AppData\\Roaming\\Orca\\crash-reports.json'),
@@ -148,5 +172,24 @@ describe('recordProcessGoneCrash', () => {
     )
     expect(JSON.stringify(sink.records)).not.toContain('alice')
     expect(sink.flushMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows the same renderer crash to retry after persistence fails', async () => {
+    const record = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('disk unavailable'))
+      .mockResolvedValueOnce({ id: 'report-2' })
+    const dedupe = new ProcessGoneDedupe()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    recordProcessGoneCrash({ record } as never, event(), dedupe)
+    await vi.waitFor(() =>
+      expect(getCrashBreadcrumbSnapshot()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'crash_report_persist_failed' })])
+      )
+    )
+    recordProcessGoneCrash({ record } as never, event(), dedupe)
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(2))
   })
 })

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -174,6 +174,24 @@ describe('recordProcessGoneCrash', () => {
     expect(sink.flushMock).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps null persistence rejections inside the fail-open diagnostic path', async () => {
+    const record = vi.fn().mockRejectedValue(null)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+
+    await vi.waitFor(() =>
+      expect(getCrashBreadcrumbSnapshot()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'crash_report_persist_failed',
+            data: expect.objectContaining({ errorName: 'object', errorMessage: 'null' })
+          })
+        ])
+      )
+    )
+  })
+
   it('allows the same renderer crash to retry after persistence fails', async () => {
     const record = vi
       .fn()

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -1,0 +1,132 @@
+import os from 'node:os'
+import { app } from 'electron'
+import { isCrashReportReason, sanitizeCrashReportString } from '../../shared/crash-reporting'
+import type { CrashReportStore } from './crash-report-store'
+import { getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
+import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+import {
+  shouldRecordProcessGoneCrash,
+  type ExpectedTeardownScope,
+  type ProcessGoneSource
+} from './process-gone-classification'
+import {
+  buildProcessGoneCrashDetails,
+  buildSuppressedProcessGoneBreadcrumbData
+} from './process-gone-diagnostics'
+import {
+  getProcessGoneDedupeKey,
+  processGoneDedupe,
+  type ProcessGoneDedupe
+} from './process-gone-dedupe'
+import { flushActiveSink, startSpan } from '../observability/tracer'
+
+export type ProcessGoneCrashEvent = {
+  source: ProcessGoneSource
+  processType: string
+  reason: string
+  exitCode: number | null
+  expectedTeardown: ExpectedTeardownScope
+  details: Record<string, unknown>
+}
+
+type CrashReportRecorderStore = Pick<CrashReportStore, 'record'>
+
+function processGoneBreadcrumbData(event: ProcessGoneCrashEvent) {
+  return buildSuppressedProcessGoneBreadcrumbData(event)
+}
+
+function persistFailureData(event: ProcessGoneCrashEvent, error: unknown) {
+  const nodeError = error as NodeJS.ErrnoException
+  return {
+    ...processGoneBreadcrumbData(event),
+    errorName: error instanceof Error ? error.name : typeof error,
+    errorMessage: sanitizeCrashReportString(error instanceof Error ? error.message : String(error)),
+    ...(typeof nodeError.code === 'string' ? { errorCode: nodeError.code } : {})
+  }
+}
+
+export function recordProcessGoneCrash(
+  store: CrashReportRecorderStore | null,
+  event: ProcessGoneCrashEvent,
+  dedupe: ProcessGoneDedupe = processGoneDedupe
+): void {
+  if (!isCrashReportReason(event.reason)) {
+    return
+  }
+  if (
+    !shouldRecordProcessGoneCrash({
+      source: event.source,
+      processType: event.processType,
+      serviceName:
+        typeof event.details.serviceName === 'string' ? event.details.serviceName : undefined,
+      reason: event.reason,
+      exitCode: event.exitCode,
+      expectedTeardown: event.expectedTeardown
+    })
+  ) {
+    recordDurableCrashBreadcrumb('process_gone_suppressed', processGoneBreadcrumbData(event))
+    return
+  }
+  if (!store) {
+    recordDurableCrashBreadcrumb(
+      'crash_report_store_unavailable',
+      processGoneBreadcrumbData(event),
+      'Crash report store unavailable'
+    )
+    return
+  }
+
+  const key = getProcessGoneDedupeKey(event.source, event.processType, event.reason, event.exitCode)
+  if (!dedupe.shouldRecord(key)) {
+    return
+  }
+  const crashDetails = buildProcessGoneCrashDetails(event.details)
+  const breadcrumbs = getCrashBreadcrumbSnapshot()
+  const span = startSpan('electron.process_gone', {
+    attributes: {
+      'crash.source': event.source,
+      'crash.process_type': event.processType,
+      'crash.reason': event.reason,
+      ...(event.exitCode !== null ? { 'crash.exit_code': event.exitCode } : {}),
+      'app.version': app.getVersion(),
+      platform: process.platform,
+      osRelease: os.release(),
+      arch: process.arch,
+      electronVersion: process.versions.electron,
+      chromeVersion: process.versions.chrome,
+      details: crashDetails,
+      breadcrumbs
+    }
+  })
+  // Why: a renderer crash can be followed by another process exit before the
+  // trace batch window closes, so make the primary signal durable immediately.
+  span.fail(
+    `${event.source} process gone: ${event.processType} ${event.reason} (${event.exitCode ?? 'unknown'})`
+  )
+  flushActiveSink()
+
+  void store
+    .record({
+      source: event.source,
+      processType: event.processType,
+      reason: event.reason,
+      exitCode: event.exitCode,
+      appVersion: app.getVersion(),
+      platform: process.platform,
+      osRelease: os.release(),
+      arch: process.arch,
+      electronVersion: process.versions.electron ?? 'unknown',
+      chromeVersion: process.versions.chrome ?? 'unknown',
+      details: crashDetails,
+      breadcrumbs
+    })
+    .catch((error) => {
+      console.error('[crash-reporting] Failed to persist crash report:', error)
+      const data = persistFailureData(event, error)
+      recordDurableCrashBreadcrumb(
+        'crash_report_persist_failed',
+        data,
+        `${String(data.errorName)}: ${String(data.errorMessage)}`
+      )
+    })
+}

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -36,12 +36,15 @@ function processGoneBreadcrumbData(event: ProcessGoneCrashEvent) {
 }
 
 function persistFailureData(event: ProcessGoneCrashEvent, error: unknown) {
-  const nodeError = error as NodeJS.ErrnoException
+  const errorCode =
+    typeof error === 'object' && error !== null && 'code' in error && typeof error.code === 'string'
+      ? error.code
+      : undefined
   return {
     ...processGoneBreadcrumbData(event),
     errorName: error instanceof Error ? error.name : typeof error,
     errorMessage: sanitizeCrashReportString(error instanceof Error ? error.message : String(error)),
-    ...(typeof nodeError.code === 'string' ? { errorCode: nodeError.code } : {})
+    ...(errorCode ? { errorCode } : {})
   }
 }
 

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -77,7 +77,8 @@ export function recordProcessGoneCrash(
   }
 
   const key = getProcessGoneDedupeKey(event.source, event.processType, event.reason, event.exitCode)
-  if (!dedupe.shouldRecord(key)) {
+  const claim = dedupe.tryClaim(key)
+  if (!claim) {
     return
   }
   const crashDetails = buildProcessGoneCrashDetails(event.details)
@@ -121,6 +122,7 @@ export function recordProcessGoneCrash(
       breadcrumbs
     })
     .catch((error) => {
+      dedupe.release(claim)
       console.error('[crash-reporting] Failed to persist crash report:', error)
       const data = persistFailureData(event, error)
       recordDurableCrashBreadcrumb(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,7 +26,6 @@ import { closeAllWatchers } from './ipc/filesystem-watcher'
 import { disposeWorktreeBaseDirectoryWatchers } from './ipc/worktree-base-directory-watcher'
 import { registerCoreHandlers } from './ipc/register-core-handlers'
 import { initObservability, shutdownObservability } from './observability'
-import { startSpan } from './observability/tracer'
 import { registerMobileHandlers } from './ipc/mobile'
 import { initTelemetry, shutdownTelemetry, trackAppOpenedOnce, track } from './telemetry/client'
 import { classifyError } from './telemetry/classify-error'
@@ -159,28 +158,21 @@ import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headles
 import { AgentAwakeService } from './agent-awake-service'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import {
-  getCrashBreadcrumbSnapshot,
   recordCoalescedCrashBreadcrumb,
   recordCrashBreadcrumb
 } from './crash-reporting/crash-breadcrumb-store'
 import { CrashReportStore } from './crash-reporting/crash-report-store'
 import {
-  shouldRecordProcessGoneCrash,
   shouldRecoverRendererAfterProcessGone,
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
-import {
-  buildProcessGoneCrashDetails,
-  buildSuppressedProcessGoneBreadcrumbData
-} from './crash-reporting/process-gone-diagnostics'
-import { getProcessGoneDedupeKey, processGoneDedupe } from './crash-reporting/process-gone-dedupe'
+import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
 import {
   advanceSyntheticTitleSpinnerEntries,
   type SyntheticTitleSpinnerEntry
 } from './synthetic-title-spinner'
 import { shouldSendSyntheticTitleFrame } from './synthetic-title-visibility'
 import { shouldCopySyntheticTitleFrameToPtyData } from './synthetic-title-frame-routing'
-import { isCrashReportReason } from '../shared/crash-reporting'
 import {
   getSyntheticAgentTitleProfile,
   shouldDriveSyntheticAgentTitleFromHook,
@@ -833,14 +825,6 @@ function openMainWindow(): BrowserWindow {
         webContentsId
       )
     },
-    shouldRecordRendererCrash: (details, webContentsId) =>
-      shouldRecordProcessGoneCrash({
-        source: 'renderer',
-        processType: 'renderer',
-        reason: details.reason,
-        exitCode: details.exitCode ?? null,
-        expectedTeardown: getExpectedTeardownScope(webContentsId)
-      }),
     shouldRecoverRenderer: (details, webContentsId) =>
       shouldRecoverRendererAfterProcessGone({
         reason: details.reason,
@@ -1229,75 +1213,14 @@ function recordProcessGoneCrash(
   details: Record<string, unknown>,
   webContentsId?: number
 ): void {
-  if (!crashReports || !isCrashReportReason(reason)) {
-    return
-  }
-  if (
-    !shouldRecordProcessGoneCrash({
-      source,
-      processType,
-      serviceName: typeof details.serviceName === 'string' ? details.serviceName : undefined,
-      reason,
-      exitCode,
-      expectedTeardown: getExpectedTeardownScope(webContentsId)
-    })
-  ) {
-    recordCrashBreadcrumb(
-      'process_gone_suppressed',
-      buildSuppressedProcessGoneBreadcrumbData({
-        source,
-        processType,
-        reason,
-        exitCode,
-        details
-      })
-    )
-    return
-  }
-  const key = getProcessGoneDedupeKey(source, processType, reason, exitCode)
-  if (!processGoneDedupe.shouldRecord(key)) {
-    return
-  }
-  const crashDetails = buildProcessGoneCrashDetails(details)
-  const span = startSpan('electron.process_gone', {
-    attributes: {
-      'crash.source': source,
-      'crash.process_type': processType,
-      'crash.reason': reason,
-      ...(exitCode !== null ? { 'crash.exit_code': exitCode } : {}),
-      'app.version': app.getVersion(),
-      platform: process.platform,
-      osRelease: os.release(),
-      arch: process.arch,
-      electronVersion: process.versions.electron,
-      chromeVersion: process.versions.chrome,
-      details: crashDetails,
-      breadcrumbs: getCrashBreadcrumbSnapshot()
-    }
+  recordProcessGoneCrashEvent(crashReports, {
+    source,
+    processType,
+    reason,
+    exitCode,
+    expectedTeardown: getExpectedTeardownScope(webContentsId),
+    details
   })
-  // Why: renderer/child crashes belong in the local trace lane so the
-  // diagnostic bundle has the same process-gone signal as the startup prompt.
-  span.fail(`${source} process gone: ${processType} ${reason} (${exitCode ?? 'unknown'})`)
-  void crashReports
-    .record({
-      source,
-      processType,
-      reason,
-      exitCode,
-      appVersion: app.getVersion(),
-      platform: process.platform,
-      osRelease: os.release(),
-      arch: process.arch,
-      electronVersion: process.versions.electron,
-      chromeVersion: process.versions.chrome,
-      details: crashDetails,
-      // Why: breadcrumbs stay memory-only during normal operation. Persist a
-      // snapshot only after Electron reports a crash-like process exit.
-      breadcrumbs: getCrashBreadcrumbSnapshot()
-    })
-    .catch((error) => {
-      console.error('[crash-reporting] Failed to persist crash report:', error)
-    })
 }
 
 function shutdownWatchersOnce(): Promise<void> {

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -185,6 +185,42 @@ describe('registerCrashReportingHandlers', () => {
     expect(listRecent).not.toHaveBeenCalled()
   })
 
+  it('copies sanitized submission and diagnostic omission failures for a captured report', async () => {
+    const pending = report('pending', 'crash-copy-failure')
+    registerCrashReportingHandlers({
+      getById: vi.fn(async () => pending),
+      dismiss: vi.fn(),
+      markSent: vi.fn(),
+      markDismissedSent: vi.fn(),
+      listRecent: vi.fn(async () => [pending]),
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const result = await handlers.get('crashReports:copyLatestDiagnostics')?.(null, {
+      reportId: pending.id,
+      notes: 'current notes',
+      submissionFailure: {
+        error: 'fallback failed at C:\\Users\\alice\\Orca',
+        diagnosticContext: {
+          status: 'not_uploaded',
+          reason: 'attachment token=super-secret-value',
+          internalEndpointError: 'must-not-cross-copy-boundary'
+        },
+        diagnosticBundleFailure: 'must-not-cross-copy-boundary'
+      }
+    })
+
+    expect(result).toEqual({ ok: true })
+    const copiedText = String(clipboardWriteTextMock.mock.calls[0]?.[0])
+    expect(copiedText).toContain('Report ID: crash-copy-failure')
+    expect(copiedText).toContain('Submission failure:')
+    expect(copiedText).toContain('Report error: fallback failed at [redacted-path]')
+    expect(copiedText).toContain('Diagnostic logs not uploaded: attachment token=[redacted]')
+    expect(copiedText).not.toContain('alice')
+    expect(copiedText).not.toContain('must-not-cross-copy-boundary')
+  })
+
   it('returns dismissed unsent reports for the manual Help menu entry', async () => {
     const dismissed = report('dismissed', 'crash-help-menu')
     registerCrashReportingHandlers({
@@ -541,8 +577,9 @@ describe('registerCrashReportingHandlers', () => {
     const markSent = vi.fn()
     submitFeedbackMock.mockResolvedValue({
       ok: false,
-      status: 500,
-      error: 'status 500'
+      status: null,
+      error: 'report-only network failed',
+      diagnosticBundleFailure: { status: 500, error: 'status 500' }
     })
     registerCrashReportingHandlers({
       getById: vi.fn(async () => pending),
@@ -563,8 +600,8 @@ describe('registerCrashReportingHandlers', () => {
 
     expect(result).toEqual({
       ok: false,
-      status: 500,
-      error: 'status 500',
+      status: null,
+      error: 'report-only network failed',
       report: pending,
       diagnosticBundle: {
         status: 'not_uploaded',
@@ -574,6 +611,7 @@ describe('registerCrashReportingHandlers', () => {
         spanCount: 1
       }
     })
+    expect(result).not.toHaveProperty('diagnosticBundleFailure')
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({
         diagnosticBundle: {

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -244,7 +244,8 @@ describe('registerCrashReportingHandlers', () => {
         content: diagnosticBundle().payload,
         bytes: 25,
         spanCount: 1
-      }
+      },
+      feedbackWithoutDiagnosticBundle: expect.stringContaining('Status: not uploaded')
     })
     expect(markSent).toHaveBeenCalledWith(pending.id)
   })
@@ -294,7 +295,8 @@ describe('registerCrashReportingHandlers', () => {
         content: diagnosticBundle().payload,
         bytes: 25,
         spanCount: 1
-      }
+      },
+      feedbackWithoutDiagnosticBundle: expect.stringContaining('Status: not uploaded')
     })
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({ feedback: expect.stringContaining('Status: attached') })
@@ -343,6 +345,52 @@ describe('registerCrashReportingHandlers', () => {
           bytes: 25,
           spanCount: 1
         }
+      })
+    )
+  })
+
+  it('marks the report sent when transport retries successfully without diagnostic logs', async () => {
+    const pending = report('pending', 'crash-degraded')
+    const sent = report('sent', pending.id)
+    const markSent = vi.fn(async () => sent)
+    submitFeedbackMock.mockResolvedValueOnce({
+      ok: true,
+      diagnosticBundleFailure: { status: 413, error: 'status 413' }
+    })
+    registerCrashReportingHandlers({
+      getById: vi.fn(async () => pending),
+      dismiss: vi.fn(),
+      markSent,
+      markDismissedSent: vi.fn(),
+      listRecent: vi.fn(async () => [pending]),
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const result = await handlers.get('crashReports:submit')?.(null, {
+      reportId: pending.id,
+      notes: 'manual report',
+      submitAnonymously: true,
+      githubLogin: null,
+      githubEmail: null
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      report: sent,
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: 'diagnostic log attachment failed: status 413',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 25,
+        spanCount: 1
+      }
+    })
+    expect(markSent).toHaveBeenCalledWith(pending.id)
+    expect(submitFeedbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedback: expect.stringContaining('Status: attached'),
+        feedbackWithoutDiagnosticBundle: expect.stringContaining('Status: not uploaded')
       })
     )
   })
@@ -459,7 +507,8 @@ describe('registerCrashReportingHandlers', () => {
         content: diagnosticBundle().payload,
         bytes: 25,
         spanCount: 1
-      }
+      },
+      feedbackWithoutDiagnosticBundle: expect.stringContaining('Status: not uploaded')
     })
     expect(markDismissedSent).toHaveBeenCalledWith(dismissed.id)
   })
@@ -516,7 +565,14 @@ describe('registerCrashReportingHandlers', () => {
       ok: false,
       status: 500,
       error: 'status 500',
-      report: pending
+      report: pending,
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: 'diagnostic log attachment failed: status 500',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 25,
+        spanCount: 1
+      }
     })
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -20,10 +20,12 @@ import {
   getCrashBreadcrumbSnapshot,
   recordCrashBreadcrumb
 } from '../crash-reporting/crash-breadcrumb-store'
-import { collectDiagnosticBundle, getDiagnosticsStatus } from '../observability'
-import { resolveDiagnosticOrcaChannel } from '../observability/diagnostic-upload-endpoint'
 import { startSpan } from '../observability/tracer'
-import type { FeedbackDiagnosticBundleAttachment } from './feedback'
+import {
+  diagnosticBundleForReportOnlyRetry,
+  prepareCrashDiagnosticBundle,
+  resolveSubmittedDiagnosticBundle
+} from '../crash-reporting/crash-feedback-diagnostic-bundle'
 import {
   assertClipboardTextWriteWithinLimit,
   isClipboardTextWriteTooLargeError
@@ -37,7 +39,6 @@ const RENDERER_ERROR_DEDUPE_MS = 10 * 60 * 1000
 const MAX_RENDERER_ERROR_KEY_AGE_MS = RENDERER_ERROR_DEDUPE_MS * 2
 const MAX_RECENT_RENDERER_ERROR_REPORT_KEYS = 256
 const MAX_SUBMITTED_REPORT_IDS = 256
-const CRASH_REPORT_LOG_LOOKBACK_MINUTES = 3 * 24 * 60
 
 const REACT_ERROR_BOUNDARY_SURFACES = new Set<ReactErrorBoundaryReportArgs['surface']>([
   'app-root',
@@ -51,11 +52,6 @@ const REACT_ERROR_BOUNDARY_SURFACES = new Set<ReactErrorBoundaryReportArgs['surf
   'overlay',
   'rich-markdown-editor'
 ])
-
-type CrashDiagnosticBundleAttachment = {
-  readonly diagnosticBundle: CrashReportDiagnosticBundle
-  readonly feedbackDiagnosticBundle?: FeedbackDiagnosticBundleAttachment
-}
 
 function stringField(value: unknown, maxLength: number): string | undefined {
   if (typeof value !== 'string') {
@@ -302,10 +298,6 @@ function recordRendererBreadcrumbTrace(
   span.end()
 }
 
-function formatUnknownError(error: unknown): string {
-  return sanitizeCrashReportString(error instanceof Error ? error.message : String(error))
-}
-
 function buildUncapturedCrashReportText(
   notes: string | undefined,
   diagnosticBundle?: CrashReportDiagnosticBundle
@@ -323,58 +315,6 @@ function buildUncapturedCrashReportText(
     notes,
     diagnosticBundle
   )
-}
-
-function skippedCrashDiagnosticBundle(): CrashDiagnosticBundleAttachment {
-  return {
-    diagnosticBundle: {
-      status: 'not_uploaded',
-      reason: 'diagnostic log upload skipped by user'
-    }
-  }
-}
-
-function collectCrashDiagnosticBundleAttachment(): CrashDiagnosticBundleAttachment {
-  const status = getDiagnosticsStatus()
-  if (!status.bundleEnabled) {
-    return {
-      diagnosticBundle: {
-        status: 'not_uploaded',
-        reason: status.disabledReason ?? 'diagnostic bundle collection is disabled'
-      }
-    }
-  }
-
-  let bundle: ReturnType<typeof collectDiagnosticBundle>
-  try {
-    bundle = collectDiagnosticBundle({
-      appVersion: app.getVersion(),
-      platform: os.platform(),
-      arch: os.arch(),
-      osRelease: os.release(),
-      orcaChannel: resolveDiagnosticOrcaChannel(),
-      // Why: Help > Report Crash is often used after relaunch, long after the
-      // default 30 minute support bundle window would miss the failure context.
-      lookbackMinutes: CRASH_REPORT_LOG_LOOKBACK_MINUTES
-    })
-  } catch (error) {
-    return { diagnosticBundle: { status: 'not_uploaded', reason: formatUnknownError(error) } }
-  }
-
-  return {
-    diagnosticBundle: {
-      status: 'attached',
-      bundleSubmissionId: bundle.bundleSubmissionId,
-      bytes: bundle.bytes,
-      spanCount: bundle.spanCount
-    },
-    feedbackDiagnosticBundle: {
-      bundleSubmissionId: bundle.bundleSubmissionId,
-      content: bundle.payload,
-      bytes: bundle.bytes,
-      spanCount: bundle.spanCount
-    }
-  }
 }
 
 export function registerCrashReportingHandlers(store: CrashReportStore): void {
@@ -448,11 +388,9 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
     async (_event, args: CrashReportSubmitArgs): Promise<CrashReportSubmitResult> => {
       const report = await getRequestedCrashReport(store, args)
       if (!report) {
-        const diagnosticUpload =
-          args.includeDiagnosticLogs === false
-            ? skippedCrashDiagnosticBundle()
-            : collectCrashDiagnosticBundleAttachment()
+        const diagnosticUpload = prepareCrashDiagnosticBundle(args.includeDiagnosticLogs !== false)
         const diagnosticBundle = diagnosticUpload.diagnosticBundle
+        const reportOnlyDiagnosticBundle = diagnosticBundleForReportOnlyRetry(diagnosticUpload)
         const result = await submitFeedback({
           feedback: buildUncapturedCrashReportText(args.notes, diagnosticBundle),
           submissionType: 'crash',
@@ -460,14 +398,22 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
           githubLogin: args.githubLogin,
           githubEmail: args.githubEmail,
           ...(diagnosticUpload.feedbackDiagnosticBundle
-            ? { diagnosticBundle: diagnosticUpload.feedbackDiagnosticBundle }
+            ? {
+                diagnosticBundle: diagnosticUpload.feedbackDiagnosticBundle,
+                feedbackWithoutDiagnosticBundle: buildUncapturedCrashReportText(
+                  args.notes,
+                  reportOnlyDiagnosticBundle
+                )
+              }
             : {})
         })
+        const submittedDiagnosticBundle = resolveSubmittedDiagnosticBundle(diagnosticUpload, result)
         return result.ok
-          ? { ok: true, report: null, diagnosticBundle }
+          ? { ok: true, report: null, diagnosticBundle: submittedDiagnosticBundle }
           : {
               ...result,
-              report: null
+              report: null,
+              diagnosticBundle: submittedDiagnosticBundle
             }
       }
       const canSubmitDismissedReport = Boolean(args.reportId && report.status === 'dismissed')
@@ -491,11 +437,9 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
 
       inFlightSubmissions.add(report.id)
       try {
-        const diagnosticUpload =
-          args.includeDiagnosticLogs === false
-            ? skippedCrashDiagnosticBundle()
-            : collectCrashDiagnosticBundleAttachment()
+        const diagnosticUpload = prepareCrashDiagnosticBundle(args.includeDiagnosticLogs !== false)
         const diagnosticBundle = diagnosticUpload.diagnosticBundle
+        const reportOnlyDiagnosticBundle = diagnosticBundleForReportOnlyRetry(diagnosticUpload)
         const result = await submitFeedback({
           feedback: formatCrashReportText(report, args.notes, diagnosticBundle),
           submissionType: 'crash',
@@ -503,13 +447,22 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
           githubLogin: args.githubLogin,
           githubEmail: args.githubEmail,
           ...(diagnosticUpload.feedbackDiagnosticBundle
-            ? { diagnosticBundle: diagnosticUpload.feedbackDiagnosticBundle }
+            ? {
+                diagnosticBundle: diagnosticUpload.feedbackDiagnosticBundle,
+                feedbackWithoutDiagnosticBundle: formatCrashReportText(
+                  report,
+                  args.notes,
+                  reportOnlyDiagnosticBundle
+                )
+              }
             : {})
         })
+        const submittedDiagnosticBundle = resolveSubmittedDiagnosticBundle(diagnosticUpload, result)
         if (!result.ok) {
           return {
             ...result,
-            report
+            report,
+            diagnosticBundle: submittedDiagnosticBundle
           }
         }
         rememberSubmittedReportId(report.id)
@@ -518,21 +471,37 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
             // Why: startup prompts are dismissed before the user can send from
             // the still-open dialog, so successful uploads must update storage.
             const sent = await store.markDismissedSent(report.id)
-            return { ok: true, report: sent ?? { ...report, status: 'sent' }, diagnosticBundle }
+            return {
+              ok: true,
+              report: sent ?? { ...report, status: 'sent' },
+              diagnosticBundle: submittedDiagnosticBundle
+            }
           } catch (error) {
             console.error('[crash-reporting] Failed to mark dismissed crash report sent:', error)
-            return { ok: true, report: { ...report, status: 'sent' }, diagnosticBundle }
+            return {
+              ok: true,
+              report: { ...report, status: 'sent' },
+              diagnosticBundle: submittedDiagnosticBundle
+            }
           }
         }
         try {
           const sent = await store.markSent(report.id)
-          return { ok: true, report: sent ?? { ...report, status: 'sent' }, diagnosticBundle }
+          return {
+            ok: true,
+            report: sent ?? { ...report, status: 'sent' },
+            diagnosticBundle: submittedDiagnosticBundle
+          }
         } catch (error) {
           // Why: the upstream submission already succeeded. A local persistence
           // failure must not present as upload failure or invite duplicate sends
           // during this app session.
           console.error('[crash-reporting] Failed to mark crash report sent:', error)
-          return { ok: true, report: { ...report, status: 'sent' }, diagnosticBundle }
+          return {
+            ok: true,
+            report: { ...report, status: 'sent' },
+            diagnosticBundle: submittedDiagnosticBundle
+          }
         }
       } finally {
         inFlightSubmissions.delete(report.id)

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import { app, clipboard, ipcMain } from 'electron'
 import {
   type CrashReportBreadcrumbData,
+  type CrashReportCopyDiagnosticsArgs,
   type CrashReportDiagnosticBundle,
   type ReactErrorBoundaryReportArgs,
   type ReactErrorBoundaryReportResult,
@@ -30,6 +31,7 @@ import {
   assertClipboardTextWriteWithinLimit,
   isClipboardTextWriteTooLargeError
 } from '../../shared/clipboard-text'
+import { formatCrashReportCopyText } from '../crash-reporting/crash-report-copy-text'
 
 const inFlightSubmissions = new Set<string>()
 const submittedReportIds = new Set<string>()
@@ -352,15 +354,16 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
   ipcMain.removeHandler('crashReports:copyLatestDiagnostics')
   ipcMain.handle(
     'crashReports:copyLatestDiagnostics',
-    async (_event, args?: { reportId?: string; notes?: string }) => {
+    async (_event, args?: CrashReportCopyDiagnosticsArgs) => {
       const report = await getRequestedCrashReport(store, args)
-      if (!report) {
-        clipboard.writeText(buildUncapturedCrashReportText(args?.notes))
-        return { ok: true as const }
-      }
+      const baseText = report
+        ? formatCrashReportText(report, args?.notes)
+        : buildUncapturedCrashReportText(args?.notes)
       try {
         clipboard.writeText(
-          assertClipboardTextWriteWithinLimit(formatCrashReportText(report, args?.notes))
+          assertClipboardTextWriteWithinLimit(
+            formatCrashReportCopyText(baseText, args?.submissionFailure)
+          )
         )
       } catch (error) {
         if (isClipboardTextWriteTooLargeError(error)) {
@@ -411,7 +414,11 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
         return result.ok
           ? { ok: true, report: null, diagnosticBundle: submittedDiagnosticBundle }
           : {
-              ...result,
+              // Why: the transport-only attachment failure may contain raw
+              // endpoint detail; only its sanitized bundle reason crosses IPC.
+              ok: false,
+              status: result.status,
+              error: result.error,
               report: null,
               diagnosticBundle: submittedDiagnosticBundle
             }
@@ -460,7 +467,11 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
         const submittedDiagnosticBundle = resolveSubmittedDiagnosticBundle(diagnosticUpload, result)
         if (!result.ok) {
           return {
-            ...result,
+            // Why: keep the renderer contract allow-listed instead of leaking
+            // the transport's internal diagnosticBundleFailure object.
+            ok: false,
+            status: result.status,
+            error: result.error,
             report,
             diagnosticBundle: submittedDiagnosticBundle
           }

--- a/src/main/ipc/feedback.test.ts
+++ b/src/main/ipc/feedback.test.ts
@@ -22,9 +22,34 @@ function okResponse(): Response {
   return { ok: true, status: 200 } as unknown as Response
 }
 
-function postedBody(): Record<string, unknown> {
-  const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
-  return JSON.parse(String(init?.body)) as Record<string, unknown>
+function errorResponse(status: number): Response {
+  return { ok: false, status } as unknown as Response
+}
+
+function requestInit(callIndex = 0): RequestInit {
+  return fetchMock.mock.calls[callIndex]?.[1] as RequestInit
+}
+
+function postedBody(callIndex = 0): Record<string, unknown> {
+  return JSON.parse(String(requestInit(callIndex).body)) as Record<string, unknown>
+}
+
+function diagnosticSubmitArgs(): Parameters<typeof submitFeedback>[0] {
+  return {
+    feedback: '[Crash Report]\n\nDiagnostic log:\n- Status: attached',
+    feedbackWithoutDiagnosticBundle:
+      '[Crash Report]\n\nDiagnostic log:\n- Status: not uploaded\n- Reason: attachment failed',
+    submissionType: 'crash',
+    submitAnonymously: true,
+    githubLogin: null,
+    githubEmail: null,
+    diagnosticBundle: {
+      bundleSubmissionId: 'bundleabcdefghijklmnop',
+      content: '{"type":"bundle-header"}\n',
+      bytes: 25,
+      spanCount: 1
+    }
+  }
 }
 
 describe('submitFeedback', () => {
@@ -139,6 +164,118 @@ describe('submitFeedback', () => {
     expect(JSON.parse(String(feedbackInit?.body))).not.toHaveProperty('diagnosticBundle')
   })
 
+  it('retries a rejected diagnostic attachment as report-only JSON on the website API', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(413)).mockResolvedValueOnce(okResponse())
+
+    await expect(submitFeedback(diagnosticSubmitArgs())).resolves.toEqual({
+      ok: true,
+      diagnosticBundleFailure: { status: 413, error: 'status 413' }
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://www.onorca.dev/v1/feedback')
+    expect(requestInit(0).body).toBeInstanceOf(FormData)
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://www.onorca.dev/v1/feedback')
+    expect(requestInit(1).headers).toEqual({
+      'Content-Type': 'application/json'
+    })
+    expect(postedBody(1)).toMatchObject({
+      feedback:
+        '[Crash Report]\n\nDiagnostic log:\n- Status: not uploaded\n- Reason: attachment failed',
+      submissionType: 'crash'
+    })
+    expect(postedBody(1)).not.toHaveProperty('diagnosticBundle')
+  })
+
+  it('retries a diagnostic attachment server error as report-only JSON on the fallback API', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(500)).mockResolvedValueOnce(okResponse())
+
+    await expect(submitFeedback(diagnosticSubmitArgs())).resolves.toEqual({
+      ok: true,
+      diagnosticBundleFailure: { status: 500, error: 'status 500' }
+    })
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://api.onorca.dev/v1/feedback')
+    expect(requestInit(1).headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(postedBody(1)).not.toHaveProperty('diagnosticBundle')
+  })
+
+  it('retries a diagnostic attachment network error as report-only JSON on the fallback API', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('attachment network failed'))
+    fetchMock.mockResolvedValueOnce(okResponse())
+
+    await expect(submitFeedback(diagnosticSubmitArgs())).resolves.toEqual({
+      ok: true,
+      diagnosticBundleFailure: { status: null, error: 'attachment network failed' }
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://api.onorca.dev/v1/feedback')
+    expect(requestInit(1).body).not.toBeInstanceOf(FormData)
+    expect(postedBody(1)).not.toHaveProperty('diagnosticBundle')
+  })
+
+  it('allows 60 seconds for a diagnostic attachment before retrying report-only JSON', async () => {
+    vi.useFakeTimers()
+    fetchMock.mockImplementationOnce((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('runtime abort text')))
+      })
+    })
+    fetchMock.mockResolvedValueOnce(okResponse())
+    const result = submitFeedback(diagnosticSubmitArgs())
+
+    await vi.advanceTimersByTimeAsync(59_999)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(result).resolves.toEqual({
+      ok: true,
+      diagnosticBundleFailure: { status: null, error: 'request timed out after 60 seconds' }
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://api.onorca.dev/v1/feedback')
+    expect(postedBody(1)).not.toHaveProperty('diagnosticBundle')
+  })
+
+  it('retries a proxy-rejected diagnostic attachment as website JSON', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(403)).mockResolvedValueOnce(okResponse())
+
+    await expect(submitFeedback(diagnosticSubmitArgs())).resolves.toEqual({
+      ok: true,
+      diagnosticBundleFailure: { status: 403, error: 'status 403' }
+    })
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://www.onorca.dev/v1/feedback')
+    expect(requestInit(1).body).not.toBeInstanceOf(FormData)
+  })
+
+  it.each([401, 409, 429])(
+    'does not retry a diagnostic attachment rejected with status %s',
+    async (status) => {
+      fetchMock.mockResolvedValueOnce(errorResponse(status))
+
+      await expect(submitFeedback(diagnosticSubmitArgs())).resolves.toEqual({
+        ok: false,
+        status,
+        error: `status ${status}`
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('preserves attachment and report-only failures when the degraded retry fails', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('attachment network failed'))
+    fetchMock.mockRejectedValueOnce(new Error('report-only network failed'))
+
+    await expect(submitFeedback(diagnosticSubmitArgs())).resolves.toEqual({
+      ok: false,
+      status: null,
+      error: 'report-only network failed',
+      diagnosticBundleFailure: { status: null, error: 'attachment network failed' }
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('falls back when the primary feedback request stalls', async () => {
     vi.useFakeTimers()
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {
@@ -184,7 +321,7 @@ describe('submitFeedback', () => {
     await expect(Promise.race([result, Promise.resolve('pending')])).resolves.toEqual({
       ok: false,
       status: null,
-      error: 'fallback aborted'
+      error: 'request timed out after 10 seconds'
     })
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })

--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -9,7 +9,11 @@ import { app, ipcMain, net } from 'electron'
 const FEEDBACK_API_URL = 'https://www.onorca.dev/v1/feedback'
 const FEEDBACK_API_FALLBACK_URL = 'https://api.onorca.dev/v1/feedback'
 const FEEDBACK_REQUEST_TIMEOUT_MS = 10_000
+const FEEDBACK_ATTACHMENT_REQUEST_TIMEOUT_MS = 60_000
 const DIAGNOSTIC_BUNDLE_CONTENT_TYPE = 'application/x-ndjson'
+// Why: corporate filters can reject multipart with 403 while allowing the
+// small JSON report, so content-shaped failures should shed the attachment.
+const DIAGNOSTIC_BUNDLE_JSON_RETRY_STATUSES = new Set([400, 403, 408, 413, 415, 422])
 
 export type FeedbackSubmissionType = 'feedback' | 'crash'
 
@@ -39,13 +43,21 @@ type FeedbackSubmitBody = {
   diagnosticBundle?: FeedbackDiagnosticBundleAttachment
 }
 
+export type FeedbackRequestFailure = {
+  status: number | null
+  error: string
+}
+
 export type FeedbackSubmitResult =
-  | { ok: true }
-  | { ok: false; status: number | null; error: string }
+  | { ok: true; diagnosticBundleFailure?: FeedbackRequestFailure }
+  | ({ ok: false } & FeedbackRequestFailure & {
+        diagnosticBundleFailure?: FeedbackRequestFailure
+      })
 
 type InternalFeedbackSubmitArgs = FeedbackSubmitArgs & {
   submissionType?: FeedbackSubmissionType
   diagnosticBundle?: FeedbackDiagnosticBundleAttachment
+  feedbackWithoutDiagnosticBundle?: string
 }
 
 // Why: the Slack notification and any follow-up investigation need to know
@@ -74,11 +86,15 @@ function buildSubmitBody(args: InternalFeedbackSubmitArgs): FeedbackSubmitBody {
   }
 }
 
-async function postFeedback(url: string, body: FeedbackSubmitBody): Promise<Response> {
+async function postFeedback(
+  url: string,
+  body: FeedbackSubmitBody,
+  timeoutMs = FEEDBACK_REQUEST_TIMEOUT_MS
+): Promise<Response> {
   const controller = new AbortController()
   // Why: a silent feedback endpoint should not leave IPC or crash-report
   // submission flows pending forever.
-  const timeout = setTimeout(() => controller.abort(), FEEDBACK_REQUEST_TIMEOUT_MS)
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
   try {
     const init: RequestInit = {
       method: 'POST',
@@ -86,6 +102,13 @@ async function postFeedback(url: string, body: FeedbackSubmitBody): Promise<Resp
       signal: controller.signal
     }
     return await net.fetch(url, init)
+  } catch (error) {
+    // Why: Electron and Node use different AbortError messages. Normalize our
+    // client deadline so support logs explain which request budget expired.
+    if (controller.signal.aborted) {
+      throw new Error(`request timed out after ${timeoutMs / 1000} seconds`)
+    }
+    throw error
   } finally {
     clearTimeout(timeout)
   }
@@ -140,6 +163,14 @@ function messageFromError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function responseFailure(response: Response): FeedbackRequestFailure {
+  return { status: response.status, error: `status ${response.status}` }
+}
+
+function errorFailure(error: unknown): FeedbackRequestFailure {
+  return { status: null, error: messageFromError(error) }
+}
+
 async function submitFallbackFeedback(
   body: FeedbackSubmitBody,
   primaryError?: unknown
@@ -163,10 +194,82 @@ async function submitFallbackFeedback(
   }
 }
 
+function diagnosticRetryUrl(status: number): string | null {
+  if (DIAGNOSTIC_BUNDLE_JSON_RETRY_STATUSES.has(status)) {
+    return FEEDBACK_API_URL
+  }
+  if (status === 404 || status >= 500) {
+    return FEEDBACK_API_FALLBACK_URL
+  }
+  return null
+}
+
+async function submitFeedbackWithoutDiagnosticBundle(
+  url: string,
+  body: FeedbackSubmitBody,
+  diagnosticBundleFailure: FeedbackRequestFailure
+): Promise<FeedbackSubmitResult> {
+  try {
+    const response = await postFeedback(url, body)
+    if (response.ok) {
+      return { ok: true, diagnosticBundleFailure }
+    }
+    return { ok: false, ...responseFailure(response), diagnosticBundleFailure }
+  } catch (error) {
+    return { ok: false, ...errorFailure(error), diagnosticBundleFailure }
+  }
+}
+
+async function submitFeedbackWithDiagnosticBundle(
+  body: FeedbackSubmitBody,
+  bodyWithoutDiagnosticBundle: FeedbackSubmitBody | null
+): Promise<FeedbackSubmitResult> {
+  try {
+    // Why: diagnostic bundles can approach 4 MiB and need more upload time than
+    // the small JSON report-only path, especially on constrained connections.
+    const response = await postFeedback(
+      FEEDBACK_API_URL,
+      body,
+      FEEDBACK_ATTACHMENT_REQUEST_TIMEOUT_MS
+    )
+    if (response.ok) {
+      return { ok: true }
+    }
+    const failure = responseFailure(response)
+    if (bodyWithoutDiagnosticBundle) {
+      const retryUrl = diagnosticRetryUrl(response.status)
+      if (retryUrl) {
+        return submitFeedbackWithoutDiagnosticBundle(retryUrl, bodyWithoutDiagnosticBundle, failure)
+      }
+    }
+    return { ok: false, ...failure }
+  } catch (error) {
+    const failure = errorFailure(error)
+    return bodyWithoutDiagnosticBundle
+      ? submitFeedbackWithoutDiagnosticBundle(
+          FEEDBACK_API_FALLBACK_URL,
+          bodyWithoutDiagnosticBundle,
+          failure
+        )
+      : { ok: false, ...failure }
+  }
+}
+
 export async function submitFeedback(
   args: InternalFeedbackSubmitArgs
 ): Promise<FeedbackSubmitResult> {
   const body = buildSubmitBody(args)
+  if (body.diagnosticBundle) {
+    const bodyWithoutDiagnosticBundle =
+      args.feedbackWithoutDiagnosticBundle !== undefined
+        ? buildSubmitBody({
+            ...args,
+            feedback: args.feedbackWithoutDiagnosticBundle,
+            diagnosticBundle: undefined
+          })
+        : null
+    return submitFeedbackWithDiagnosticBundle(body, bodyWithoutDiagnosticBundle)
+  }
   try {
     const res = await postFeedback(FEEDBACK_API_URL, body)
     if (res.ok) {

--- a/src/main/observability/tracer.test.ts
+++ b/src/main/observability/tracer.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   _resetTracerForTests,
+  flushActiveSink,
   getActiveSpanContext,
   setActiveSink,
   startSpan,
@@ -67,6 +68,23 @@ describe('tracer — basic span lifecycle', () => {
     const r = sink.records[0] as { exit: { _tag: string; cause: string } }
     expect(r.exit._tag).toBe('Interrupted')
     expect(r.exit.cause).toBe('user-cancelled')
+  })
+
+  it('keeps forced sink flush failures from escaping crash boundaries', () => {
+    sink.flush = () => {
+      throw new Error('disk unavailable')
+    }
+
+    expect(() => flushActiveSink()).not.toThrow()
+  })
+
+  it('keeps sink handoff failures from escaping instrumented operations', async () => {
+    sink.push = () => {
+      throw new Error('trace rotation failed')
+    }
+
+    expect(() => startSpan('test').fail('boom')).not.toThrow()
+    await expect(withSpan('async-test', async () => 'result')).resolves.toBe('result')
   })
 
   it('end() is idempotent — second call is a no-op', () => {

--- a/src/main/observability/tracer.ts
+++ b/src/main/observability/tracer.ts
@@ -112,6 +112,12 @@ export function setActiveSink(sink: TracerSink | null): void {
   activeSink = sink
 }
 
+/** Force records already handed to the tracer onto disk. Reserve this for
+ * crash boundaries where the process may not survive the normal batch window. */
+export function flushActiveSink(): void {
+  activeSink?.flush()
+}
+
 /** Get the current parent context, or `undefined` if we are at the top of
  *  the trace tree. Renderer-IPC entry points capture this, embed it in
  *  span-event attributes (so cross-process spans can be visually linked

--- a/src/main/observability/tracer.ts
+++ b/src/main/observability/tracer.ts
@@ -115,7 +115,12 @@ export function setActiveSink(sink: TracerSink | null): void {
 /** Force records already handed to the tracer onto disk. Reserve this for
  * crash boundaries where the process may not survive the normal batch window. */
 export function flushActiveSink(): void {
-  activeSink?.flush()
+  try {
+    activeSink?.flush()
+  } catch {
+    // Why: a disk/rotation failure in optional local diagnostics must never
+    // turn a recoverable renderer crash into a main-process crash.
+  }
 }
 
 /** Get the current parent context, or `undefined` if we are at the top of
@@ -227,7 +232,12 @@ export function startSpan(
     // Wrap in a `type: 'effect-span'` envelope so the NDJSON file is
     // compatible with Effect-style span output. Effect-oriented consumers
     // (the LGTM stack, jq cookbooks) can read the file unchanged.
-    activeSink?.push({ type: 'effect-span', ...redacted })
+    try {
+      activeSink?.push({ type: 'effect-span', ...redacted })
+    } catch {
+      // Why: tracing is optional; a local file rotation failure must not turn
+      // the instrumented operation into an application failure.
+    }
   }
 
   return {

--- a/src/main/win32-utils-async-acl.test.ts
+++ b/src/main/win32-utils-async-acl.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, execFileSyncMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock
+}))
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
+
+const originalUsername = process.env.USERNAME
+
+beforeEach(() => {
+  vi.resetModules()
+  execFileMock.mockReset()
+  execFileSyncMock.mockReset()
+})
+
+afterEach(() => {
+  if (originalUsername === undefined) {
+    delete process.env.USERNAME
+  } else {
+    process.env.USERNAME = originalUsername
+  }
+})
+
+describe('grantDirAclAsync', () => {
+  it('keeps icacls off the synchronous main-process path', async () => {
+    process.env.USERNAME = 'alice'
+    let complete: ExecCallback | undefined
+    execFileMock.mockImplementation(
+      (_command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+        complete = callback
+        return {} as never
+      }
+    )
+    const { getIcaclsExePath, grantDirAclAsync } = await import('./win32-utils')
+
+    const pending = grantDirAclAsync('C:\\Users\\alice\\Orca')
+    await Promise.resolve()
+
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+    expect(execFileMock).toHaveBeenCalledWith(
+      getIcaclsExePath(),
+      ['C:\\Users\\alice\\Orca', '/grant:r', 'alice:(OI)(CI)(F)'],
+      { encoding: 'utf-8', windowsHide: true, timeout: 10_000 },
+      expect.any(Function)
+    )
+    complete?.(null, '', '')
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('resolves a missing username through asynchronous whoami before icacls', async () => {
+    delete process.env.USERNAME
+    execFileMock
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(null, '"DOMAIN\\alice","S-1-5-21-123"\r\n', '')
+          return {} as never
+        }
+      )
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(null, '', '')
+          return {} as never
+        }
+      )
+    const { getWhoamiExePath, grantDirAclAsync } = await import('./win32-utils')
+
+    await grantDirAclAsync('C:\\Orca')
+
+    expect(execFileMock.mock.calls[0]?.slice(0, 3)).toEqual([
+      getWhoamiExePath(),
+      ['/user', '/fo', 'csv', '/nh'],
+      { encoding: 'utf-8', windowsHide: true, timeout: 5000 }
+    ])
+    expect(execFileMock.mock.calls[1]?.[1]).toEqual([
+      'C:\\Orca',
+      '/grant:r',
+      '*S-1-5-21-123:(OI)(CI)(F)'
+    ])
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('does not overwrite a concurrent cached identity with a late async result', async () => {
+    delete process.env.USERNAME
+    let completeWhoami: ExecCallback | undefined
+    execFileMock
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          completeWhoami = callback
+          return {} as never
+        }
+      )
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(null, '', '')
+          return {} as never
+        }
+      )
+    execFileSyncMock.mockReturnValue('"DOMAIN\\sync","S-1-5-21-456"\r\n')
+    const { grantDirAclAsync, resolveCurrentWindowsIdentity } = await import('./win32-utils')
+
+    const pending = grantDirAclAsync('C:\\Orca')
+    await Promise.resolve()
+    expect(resolveCurrentWindowsIdentity()).toBe('*S-1-5-21-456')
+    completeWhoami?.(null, '"DOMAIN\\async","S-1-5-21-789"\r\n', '')
+    await pending
+
+    expect(execFileMock.mock.calls[1]?.[1]).toEqual([
+      'C:\\Orca',
+      '/grant:r',
+      '*S-1-5-21-456:(OI)(CI)(F)'
+    ])
+  })
+})

--- a/src/main/win32-utils-async-acl.test.ts
+++ b/src/main/win32-utils-async-acl.test.ts
@@ -117,4 +117,41 @@ describe('grantDirAclAsync', () => {
       '*S-1-5-21-456:(OI)(CI)(F)'
     ])
   })
+
+  it('retries identity resolution after a transient whoami failure', async () => {
+    delete process.env.USERNAME
+    execFileMock
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(new Error('whoami timed out'), '', '')
+          return {} as never
+        }
+      )
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(null, '"DOMAIN\\alice","S-1-5-21-123"\r\n', '')
+          return {} as never
+        }
+      )
+      .mockImplementationOnce(
+        (_command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(null, '', '')
+          return {} as never
+        }
+      )
+    const { getWhoamiExePath, grantDirAclAsync } = await import('./win32-utils')
+
+    await grantDirAclAsync('C:\\Orca')
+    await grantDirAclAsync('C:\\Orca')
+
+    expect(
+      execFileMock.mock.calls.filter(([command]) => command === getWhoamiExePath())
+    ).toHaveLength(2)
+    expect(execFileMock.mock.calls[2]?.[1]).toEqual([
+      'C:\\Orca',
+      '/grant:r',
+      '*S-1-5-21-123:(OI)(CI)(F)'
+    ])
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/win32-utils.ts
+++ b/src/main/win32-utils.ts
@@ -1,6 +1,22 @@
-import { execFileSync } from 'node:child_process'
+import { execFile, execFileSync, type ExecFileOptionsWithStringEncoding } from 'node:child_process'
 import { delimiter, join } from 'node:path'
 import { existsSync } from 'node:fs'
+
+function execFileWithoutBlocking(
+  command: string,
+  args: string[],
+  options: ExecFileOptionsWithStringEncoding
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, options, (error, stdout) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(stdout)
+    })
+  })
+}
 
 /**
  * Full path to icacls.exe. Electron's main process may have a stripped PATH
@@ -8,6 +24,11 @@ import { existsSync } from 'node:fs'
  */
 export function getIcaclsExePath(): string {
   return `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\icacls.exe`
+}
+
+/** Absolute path because service-launched Electron can omit System32 from PATH. */
+export function getWhoamiExePath(): string {
+  return `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\whoami.exe`
 }
 
 /**
@@ -79,12 +100,9 @@ export function isPermissionError(error: unknown): boolean {
 // `whoami /user` (same strategy as runtime-metadata.ts), which is authoritative
 // and always available on Windows. Cached because it never changes in-process.
 let cachedIdentity: string | null | undefined
+let pendingIdentityResolution: Promise<string | null> | null = null
 
-export function resolveCurrentWindowsIdentity(): string | null {
-  return resolveCurrentIdentity()
-}
-
-function resolveCurrentIdentity(): string | null {
+function cachedOrEnvironmentIdentity(): string | null | undefined {
   if (cachedIdentity !== undefined) {
     return cachedIdentity
   }
@@ -92,20 +110,72 @@ function resolveCurrentIdentity(): string | null {
     cachedIdentity = process.env.USERNAME
     return cachedIdentity
   }
+  return undefined
+}
+
+function identityFromWhoamiOutput(output: string): string | null {
+  // CSV columns: "DOMAIN\\user","S-1-5-21-..."
+  const sidMatch = /"(S-[\d-]+)"\s*$/.exec(output.trim())
+  return sidMatch ? `*${sidMatch[1]}` : null
+}
+
+export function resolveCurrentWindowsIdentity(): string | null {
+  return resolveCurrentIdentity()
+}
+
+function resolveCurrentIdentity(): string | null {
+  const knownIdentity = cachedOrEnvironmentIdentity()
+  if (knownIdentity !== undefined) {
+    return knownIdentity
+  }
   try {
-    const output = execFileSync('whoami', ['/user', '/fo', 'csv', '/nh'], {
+    const output = execFileSync(getWhoamiExePath(), ['/user', '/fo', 'csv', '/nh'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       windowsHide: true,
       timeout: 5000
-    }).trim()
-    // CSV columns: "DOMAIN\\user","S-1-5-21-..."
-    const sidMatch = /"(S-[\d-]+)"\s*$/.exec(output)
-    cachedIdentity = sidMatch ? `*${sidMatch[1]}` : null
+    })
+    cachedIdentity = identityFromWhoamiOutput(output)
   } catch {
     cachedIdentity = null
   }
-  return cachedIdentity
+  return cachedIdentity ?? null
+}
+
+async function resolveCurrentIdentityAsync(): Promise<string | null> {
+  const knownIdentity = cachedOrEnvironmentIdentity()
+  if (knownIdentity !== undefined) {
+    return knownIdentity
+  }
+  if (!pendingIdentityResolution) {
+    pendingIdentityResolution = (async () => {
+      try {
+        const stdout = await execFileWithoutBlocking(
+          getWhoamiExePath(),
+          ['/user', '/fo', 'csv', '/nh'],
+          {
+            encoding: 'utf-8',
+            windowsHide: true,
+            timeout: 5000
+          }
+        )
+        // Why: a synchronous caller may resolve identity while async whoami
+        // is in flight; its authoritative cached result must win the race.
+        if (cachedIdentity === undefined) {
+          cachedIdentity = identityFromWhoamiOutput(stdout)
+        }
+        return cachedIdentity ?? null
+      } catch {
+        if (cachedIdentity === undefined) {
+          cachedIdentity = null
+        }
+        return cachedIdentity ?? null
+      }
+    })().finally(() => {
+      pendingIdentityResolution = null
+    })
+  }
+  return pendingIdentityResolution
 }
 
 /**
@@ -136,6 +206,24 @@ export function grantDirAcl(dirPath: string, options?: { recursive?: boolean }):
     windowsHide: true,
     timeout
   })
+}
+
+export async function grantDirAclAsync(dirPath: string): Promise<void> {
+  const identity = await resolveCurrentIdentityAsync()
+  if (!identity) {
+    return
+  }
+  // Why: crash recovery runs on Electron's main thread; an asynchronous
+  // icacls child keeps its worst-case timeout from freezing every window.
+  await execFileWithoutBlocking(
+    getIcaclsExePath(),
+    [dirPath, '/grant:r', `${identity}:(OI)(CI)(F)`],
+    {
+      encoding: 'utf-8',
+      windowsHide: true,
+      timeout: 10_000
+    }
+  )
 }
 
 /**

--- a/src/main/win32-utils.ts
+++ b/src/main/win32-utils.ts
@@ -99,10 +99,10 @@ export function isPermissionError(error: unknown): boolean {
 // and hardened envs where USERNAME is unset. Fall back to the SID via
 // `whoami /user` (same strategy as runtime-metadata.ts), which is authoritative
 // and always available on Windows. Cached because it never changes in-process.
-let cachedIdentity: string | null | undefined
+let cachedIdentity: string | undefined
 let pendingIdentityResolution: Promise<string | null> | null = null
 
-function cachedOrEnvironmentIdentity(): string | null | undefined {
+function cachedOrEnvironmentIdentity(): string | undefined {
   if (cachedIdentity !== undefined) {
     return cachedIdentity
   }
@@ -135,11 +135,14 @@ function resolveCurrentIdentity(): string | null {
       windowsHide: true,
       timeout: 5000
     })
-    cachedIdentity = identityFromWhoamiOutput(output)
+    const resolvedIdentity = identityFromWhoamiOutput(output)
+    if (resolvedIdentity) {
+      cachedIdentity = resolvedIdentity
+    }
+    return resolvedIdentity
   } catch {
-    cachedIdentity = null
+    return null
   }
-  return cachedIdentity ?? null
 }
 
 async function resolveCurrentIdentityAsync(): Promise<string | null> {
@@ -161,14 +164,14 @@ async function resolveCurrentIdentityAsync(): Promise<string | null> {
         )
         // Why: a synchronous caller may resolve identity while async whoami
         // is in flight; its authoritative cached result must win the race.
-        if (cachedIdentity === undefined) {
-          cachedIdentity = identityFromWhoamiOutput(stdout)
+        const resolvedIdentity = identityFromWhoamiOutput(stdout)
+        if (cachedIdentity === undefined && resolvedIdentity) {
+          cachedIdentity = resolvedIdentity
         }
-        return cachedIdentity ?? null
+        return cachedIdentity ?? resolvedIdentity
       } catch {
-        if (cachedIdentity === undefined) {
-          cachedIdentity = null
-        }
+        // Why: transient service/PATH failures must not permanently disable
+        // ACL repair for every later crash attempt in this process.
         return cachedIdentity ?? null
       }
     })().finally(() => {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2389,7 +2389,7 @@ describe('createMainWindow', () => {
     expect(onRendererProcessGone).toHaveBeenCalledWith(details, 142)
   })
 
-  it('passes the renderer webContents id through crash classification callbacks', () => {
+  it('passes the renderer webContents id through crash recording and recovery callbacks', () => {
     vi.useFakeTimers()
 
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
@@ -2422,13 +2422,11 @@ describe('createMainWindow', () => {
       return browserWindowInstance
     })
     const onRendererProcessGone = vi.fn()
-    const shouldRecordRendererCrash = vi.fn(() => true)
     const shouldRecoverRenderer = vi.fn(() => true)
 
     try {
       createMainWindow(null, {
         onRendererProcessGone,
-        shouldRecordRendererCrash,
         shouldRecoverRenderer
       })
 
@@ -2436,7 +2434,6 @@ describe('createMainWindow', () => {
       windowHandlers['render-process-gone']?.({} as never, details)
       vi.advanceTimersByTime(250)
 
-      expect(shouldRecordRendererCrash).toHaveBeenCalledWith(details, 424)
       expect(onRendererProcessGone).toHaveBeenCalledWith(details, 424)
       expect(shouldRecoverRenderer).toHaveBeenCalledWith(details, 424)
     } finally {
@@ -2444,9 +2441,10 @@ describe('createMainWindow', () => {
     }
   })
 
-  it('does not notify the crash recorder for an expected renderer teardown', () => {
+  it('forwards expected renderer teardowns so the recorder can diagnose suppression', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
+      id: 142,
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),
@@ -2475,10 +2473,7 @@ describe('createMainWindow', () => {
     })
     const onRendererProcessGone = vi.fn()
 
-    createMainWindow(null, {
-      onRendererProcessGone,
-      shouldRecordRendererCrash: () => false
-    })
+    createMainWindow(null, { onRendererProcessGone })
 
     windowHandlers['render-process-gone']?.(
       {} as never,
@@ -2488,7 +2483,10 @@ describe('createMainWindow', () => {
       } as Electron.RenderProcessGoneDetails
     )
 
-    expect(onRendererProcessGone).not.toHaveBeenCalled()
+    expect(onRendererProcessGone).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'killed', exitCode: 15 }),
+      expect.any(Number)
+    )
 
     consoleError.mockRestore()
   })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -111,13 +111,6 @@ type CreateMainWindowOptions = {
     details: Electron.RenderProcessGoneDetails,
     webContentsId: number
   ) => void
-  /** Returns true when a renderer loss should be reported as a crash. Why:
-   *  intentional reload/update/quit paths can emit crash-like `killed`
-   *  renderer exits, but surfacing those as crash reports is noise. */
-  shouldRecordRendererCrash?: (
-    details: Electron.RenderProcessGoneDetails,
-    webContentsId: number
-  ) => boolean
   /** Returns true when Orca should reload after an unexpected renderer loss.
    *  Why: update relaunch and app quit intentionally tear down child
    *  processes; recovering those paths can fight Electron's shutdown. */
@@ -713,10 +706,9 @@ export function createMainWindow(
     resetShortcutRecorderFocus()
     // Why: macOS can report BrowserWindow teardown as renderer `killed`/SIGKILL
     // after a confirmed close; that is window lifecycle noise, not a crash.
-    if (
-      !windowClosing &&
-      opts?.shouldRecordRendererCrash?.(details, rendererWebContentsId) !== false
-    ) {
+    if (!windowClosing) {
+      // Why: the recorder owns crash classification and durable suppression
+      // diagnostics; filtering here made expected-teardown evidence unreachable.
       opts?.onRendererProcessGone?.(details, rendererWebContentsId)
     }
     if (!windowClosing) {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -316,6 +316,7 @@ import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
 import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
 import type {
   CrashReportBreadcrumbData,
+  CrashReportCopyDiagnosticsArgs,
   CrashReportRecord,
   CrashReportSubmitArgs,
   CrashReportSubmitResult,
@@ -1397,10 +1398,9 @@ export type PreloadApi = {
     ) => Promise<ReactErrorBoundaryReportResult>
     recordBreadcrumb: (args: { name: string; data?: CrashReportBreadcrumbData }) => void
     submit: (args: CrashReportSubmitArgs) => Promise<CrashReportSubmitResult>
-    copyLatestDiagnostics: (args?: {
-      reportId?: string
-      notes?: string
-    }) => Promise<{ ok: true } | { ok: false; error: string }>
+    copyLatestDiagnostics: (
+      args?: CrashReportCopyDiagnosticsArgs
+    ) => Promise<{ ok: true } | { ok: false; error: string }>
   }
   export: ExportApi
   gh: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -212,6 +212,7 @@ import type {
 } from '../shared/localhost-worktree-labels'
 import type {
   CrashReportBreadcrumbData,
+  CrashReportCopyDiagnosticsArgs,
   CrashReportSubmitArgs,
   CrashReportSubmitResult,
   ReactErrorBoundaryReportArgs,
@@ -1148,7 +1149,7 @@ const api = {
       ipcRenderer.send('crashReports:recordBreadcrumb', args),
     submit: (args: CrashReportSubmitArgs): Promise<CrashReportSubmitResult> =>
       ipcRenderer.invoke('crashReports:submit', args),
-    copyLatestDiagnostics: (args?: { reportId?: string; notes?: string }) =>
+    copyLatestDiagnostics: (args?: CrashReportCopyDiagnosticsArgs) =>
       ipcRenderer.invoke('crashReports:copyLatestDiagnostics', args)
   },
 

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -16,10 +16,16 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   formatCrashReportText,
   isReactErrorBoundaryReport,
+  type CrashReportDiagnosticBundle,
   type CrashReportRecord
 } from '../../../../shared/crash-reporting'
 import type { GitHubViewer } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
+import {
+  CRASH_REPORT_SUBMIT_FAILURE_TOAST_ID,
+  getCrashReportSubmitFailureNotice,
+  getCrashReportSubmitWarningNotice
+} from './crash-report-submit-notice'
 
 function formatSummary(report: CrashReportRecord): string {
   if (isReactErrorBoundaryReport(report)) {
@@ -134,6 +140,28 @@ export function CrashReportDialogSurface({
     )
   }
 
+  const showSubmitFailure = (
+    error: unknown,
+    diagnosticBundle?: CrashReportDiagnosticBundle
+  ): void => {
+    const notice = getCrashReportSubmitFailureNotice(
+      { error, ...(diagnosticBundle ? { diagnosticBundle } : {}) },
+      includeDiagnosticLogs
+    )
+    toast.error(notice.title, {
+      id: CRASH_REPORT_SUBMIT_FAILURE_TOAST_ID,
+      description: notice.description,
+      duration: Infinity,
+      dismissible: true,
+      action: {
+        label: notice.actionLabel,
+        onClick: () => {
+          void handleCopy()
+        }
+      }
+    })
+  }
+
   const dismissReportIfNeeded = async (): Promise<void> => {
     if (report?.status === 'pending') {
       await window.api.crashReports.dismiss({ reportId: report.id })
@@ -164,22 +192,7 @@ export function CrashReportDialogSurface({
         githubEmail: null
       })
       if (!result.ok) {
-        if (result.diagnosticBundle?.status === 'uploaded') {
-          toast.error(
-            translate(
-              'auto.components.crash.report.CrashReportDialog.b2e36f53a1',
-              'Failed to send crash report. Diagnostic ticket {{value0}} was uploaded but not linked.',
-              { value0: result.diagnosticBundle.ticketId }
-            )
-          )
-        } else {
-          toast.error(
-            translate(
-              'auto.components.crash.report.CrashReportDialog.56a3dfa283',
-              'Failed to send crash report.'
-            )
-          )
-        }
+        showSubmitFailure(result.error, result.diagnosticBundle)
         console.error('Failed to submit crash report:', result.error)
         return
       }
@@ -188,17 +201,21 @@ export function CrashReportDialogSurface({
       }
       onReportChange(result.report)
       setNotes('')
-      toast.success(
-        translate('auto.components.crash.report.CrashReportDialog.8e24fe4f75', 'Crash report sent.')
-      )
+      toast.dismiss(CRASH_REPORT_SUBMIT_FAILURE_TOAST_ID)
+      const warningNotice = getCrashReportSubmitWarningNotice(result, includeDiagnosticLogs)
+      if (warningNotice) {
+        toast.warning(warningNotice.title, { description: warningNotice.description })
+      } else {
+        toast.success(
+          translate(
+            'auto.components.crash.report.CrashReportDialog.8e24fe4f75',
+            'Crash report sent.'
+          )
+        )
+      }
       onOpenChange(false)
     } catch (error) {
-      toast.error(
-        translate(
-          'auto.components.crash.report.CrashReportDialog.56a3dfa283',
-          'Failed to send crash report.'
-        )
-      )
+      showSubmitFailure(error)
       console.error('Failed to submit crash report:', error)
     } finally {
       if (mountedRef.current) {

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -23,9 +23,11 @@ import type { GitHubViewer } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 import {
   CRASH_REPORT_SUBMIT_FAILURE_TOAST_ID,
+  getCrashReportCopySubmissionFailure,
   getCrashReportSubmitFailureNotice,
   getCrashReportSubmitWarningNotice
 } from './crash-report-submit-notice'
+import { useCrashReportCopy } from './use-crash-report-copy'
 
 function formatSummary(report: CrashReportRecord): string {
   if (isReactErrorBoundaryReport(report)) {
@@ -94,6 +96,7 @@ export function CrashReportDialogSurface({
     () => (report ? formatCrashReportText(report, deferredNotes) : ''),
     [deferredNotes, report]
   )
+  const copyCrashReportDetails = useCrashReportCopy(report, notes)
 
   const clearViewer = useCallback((): void => {
     viewerRequestIdRef.current += 1
@@ -127,27 +130,13 @@ export function CrashReportDialogSurface({
     loadViewerForOpenDialog()
   }, [clearViewer, loadViewerForOpenDialog, open])
 
-  const handleCopy = async (): Promise<void> => {
-    const result = await window.api.crashReports.copyLatestDiagnostics(
-      report ? { reportId: report.id, notes } : { notes }
-    )
-    if (!result.ok) {
-      toast.error(result.error)
-      return
-    }
-    toast.success(
-      translate('auto.components.crash.report.CrashReportDialog.8b8473c544', 'Crash report copied.')
-    )
-  }
-
   const showSubmitFailure = (
     error: unknown,
     diagnosticBundle?: CrashReportDiagnosticBundle
   ): void => {
-    const notice = getCrashReportSubmitFailureNotice(
-      { error, ...(diagnosticBundle ? { diagnosticBundle } : {}) },
-      includeDiagnosticLogs
-    )
+    const failure = { error, ...(diagnosticBundle ? { diagnosticBundle } : {}) }
+    const notice = getCrashReportSubmitFailureNotice(failure, includeDiagnosticLogs)
+    const copyFailure = getCrashReportCopySubmissionFailure(failure)
     toast.error(notice.title, {
       id: CRASH_REPORT_SUBMIT_FAILURE_TOAST_ID,
       description: notice.description,
@@ -156,7 +145,7 @@ export function CrashReportDialogSurface({
       action: {
         label: notice.actionLabel,
         onClick: () => {
-          void handleCopy()
+          void copyCrashReportDetails(copyFailure)
         }
       }
     })
@@ -321,7 +310,13 @@ export function CrashReportDialogSurface({
         </div>
 
         <DialogFooter className="gap-2">
-          <Button type="button" variant="outline" size="sm" onClick={handleCopy} disabled={loading}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void copyCrashReportDetails()}
+            disabled={loading}
+          >
             <Clipboard className="size-3.5" />
             {translate('auto.components.crash.report.CrashReportDialog.50b00dc327', 'Copy Details')}
           </Button>

--- a/src/renderer/src/components/crash-report/crash-report-submit-notice.test.ts
+++ b/src/renderer/src/components/crash-report/crash-report-submit-notice.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getCrashReportCopySubmissionFailure,
   getCrashReportSubmitFailureNotice,
   getCrashReportSubmitWarningNotice
 } from './crash-report-submit-notice'
 
 describe('crash report submit notices', () => {
+  it('builds an allow-listed copy context with the exact sanitized failure reasons', () => {
+    expect(
+      getCrashReportCopySubmissionFailure({
+        error: 'request failed at C:\\Users\\alice\\Orca',
+        diagnosticBundle: {
+          status: 'not_uploaded',
+          reason: 'attachment timeout token=super-secret-value'
+        }
+      })
+    ).toEqual({
+      error: 'request failed at [redacted-path]',
+      diagnosticContext: {
+        status: 'not_uploaded',
+        reason: 'attachment timeout token=[redacted]'
+      }
+    })
+  })
+
   it('keeps the returned error and points attached-log failures to the no-log retry', () => {
     const notice = getCrashReportSubmitFailureNotice({ error: 'status 413' }, true)
 

--- a/src/renderer/src/components/crash-report/crash-report-submit-notice.test.ts
+++ b/src/renderer/src/components/crash-report/crash-report-submit-notice.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCrashReportSubmitFailureNotice,
+  getCrashReportSubmitWarningNotice
+} from './crash-report-submit-notice'
+
+describe('crash report submit notices', () => {
+  it('keeps the returned error and points attached-log failures to the no-log retry', () => {
+    const notice = getCrashReportSubmitFailureNotice({ error: 'status 413' }, true)
+
+    expect(notice).toEqual({
+      title: "Crash report wasn't sent",
+      description:
+        'status 413. Uncheck "Attach recent diagnostic logs" and try again, or copy the details.',
+      actionLabel: 'Copy Details'
+    })
+  })
+
+  it('uses connection guidance when diagnostic logs were already excluded', () => {
+    const notice = getCrashReportSubmitFailureNotice({ error: 'network unreachable' }, false)
+
+    expect(notice.description).toBe(
+      'network unreachable. Check your connection and try again, or copy the details.'
+    )
+    expect(notice.description).not.toContain('Uncheck')
+  })
+
+  it('preserves an uploaded diagnostic ticket alongside the core failure', () => {
+    const notice = getCrashReportSubmitFailureNotice(
+      {
+        error: 'status 502',
+        diagnosticBundle: {
+          status: 'uploaded',
+          ticketId: 'ticket-123',
+          bundleSubmissionId: 'bundle-123',
+          bytes: 42,
+          spanCount: 2
+        }
+      },
+      true
+    )
+
+    expect(notice.description).toContain('status 502.')
+    expect(notice.description).toContain(
+      'Diagnostic ticket ticket-123 was uploaded but not linked.'
+    )
+  })
+
+  it('shows both failures when the attachment was already omitted', () => {
+    const notice = getCrashReportSubmitFailureNotice(
+      {
+        error: 'fallback host unreachable',
+        diagnosticBundle: {
+          status: 'not_uploaded',
+          reason: 'diagnostic log attachment failed: request timed out after 60 seconds'
+        }
+      },
+      true
+    )
+
+    expect(notice.description).toContain('fallback host unreachable.')
+    expect(notice.description).toContain(
+      'Diagnostic logs were not attached: diagnostic log attachment failed: request timed out after 60 seconds.'
+    )
+    expect(notice.description).toContain('Check your connection')
+    expect(notice.description).not.toContain('Uncheck')
+  })
+
+  it('safely surfaces Error messages and ignores unhelpful rejected values', () => {
+    expect(
+      getCrashReportSubmitFailureNotice({ error: new Error('IPC channel closed') }, false)
+        .description
+    ).toContain('IPC channel closed.')
+    expect(
+      getCrashReportSubmitFailureNotice({ error: { unexpected: true } }, false).description
+    ).toContain('The crash report request failed before it returned a reason.')
+  })
+
+  it('redacts paths and tokens before displaying transport errors', () => {
+    const token = `ghp_${'a'.repeat(30)}`
+    const notice = getCrashReportSubmitFailureNotice(
+      {
+        error: `request failed at C:\\Users\\alice\\Orca\\crash-reports.json token=${token}`
+      },
+      false
+    )
+
+    expect(notice.description).not.toContain('alice')
+    expect(notice.description).not.toContain(token)
+    expect(notice.description).toContain('[redacted')
+  })
+
+  it('warns only when an opted-in diagnostic bundle was not attached', () => {
+    const result = {
+      ok: true as const,
+      report: null,
+      diagnosticBundle: {
+        status: 'not_uploaded' as const,
+        reason: 'bundle collection failed'
+      }
+    }
+
+    expect(getCrashReportSubmitWarningNotice(result, true)).toEqual({
+      title: 'Crash report sent without diagnostic logs',
+      description: 'Diagnostic logs were not attached: bundle collection failed'
+    })
+    expect(getCrashReportSubmitWarningNotice(result, false)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/crash-report/crash-report-submit-notice.ts
+++ b/src/renderer/src/components/crash-report/crash-report-submit-notice.ts
@@ -1,6 +1,7 @@
 import { translate } from '@/i18n/i18n'
 import {
   sanitizeCrashReportString,
+  type CrashReportCopySubmissionFailure,
   type CrashReportDiagnosticBundle,
   type CrashReportSubmitResult
 } from '../../../../shared/crash-reporting'
@@ -37,6 +38,27 @@ function normalizedFailureMessage(error: unknown): string {
 
 function asSentence(message: string): string {
   return /[.!?]$/.test(message) ? message : `${message}.`
+}
+
+export function getCrashReportCopySubmissionFailure(
+  failure: CrashReportSubmitFailureLike
+): CrashReportCopySubmissionFailure {
+  const diagnosticContext =
+    failure.diagnosticBundle?.status === 'uploaded'
+      ? {
+          status: 'uploaded' as const,
+          ticketId: sanitizeCrashReportString(failure.diagnosticBundle.ticketId)
+        }
+      : failure.diagnosticBundle?.status === 'not_uploaded'
+        ? {
+            status: 'not_uploaded' as const,
+            reason: normalizedFailureMessage(failure.diagnosticBundle.reason)
+          }
+        : undefined
+  return {
+    error: normalizedFailureMessage(failure.error),
+    ...(diagnosticContext ? { diagnosticContext } : {})
+  }
 }
 
 export function getCrashReportSubmitFailureNotice(

--- a/src/renderer/src/components/crash-report/crash-report-submit-notice.ts
+++ b/src/renderer/src/components/crash-report/crash-report-submit-notice.ts
@@ -1,0 +1,112 @@
+import { translate } from '@/i18n/i18n'
+import {
+  sanitizeCrashReportString,
+  type CrashReportDiagnosticBundle,
+  type CrashReportSubmitResult
+} from '../../../../shared/crash-reporting'
+
+export const CRASH_REPORT_SUBMIT_FAILURE_TOAST_ID = 'crash-report-submit-failure'
+
+export type CrashReportSubmitFailureNotice = {
+  title: string
+  description: string
+  actionLabel: string
+}
+
+export type CrashReportSubmitWarningNotice = {
+  title: string
+  description: string
+}
+
+type CrashReportSubmitFailureLike = {
+  error: unknown
+  diagnosticBundle?: CrashReportDiagnosticBundle
+}
+
+function normalizedFailureMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
+  const sanitized = sanitizeCrashReportString(message).trim()
+  return (
+    sanitized ||
+    translate(
+      'auto.components.crash.report.submit.notice.unknownError',
+      'The crash report request failed before it returned a reason.'
+    )
+  )
+}
+
+function asSentence(message: string): string {
+  return /[.!?]$/.test(message) ? message : `${message}.`
+}
+
+export function getCrashReportSubmitFailureNotice(
+  failure: CrashReportSubmitFailureLike,
+  includeDiagnosticLogs: boolean
+): CrashReportSubmitFailureNotice {
+  const ticketDetail =
+    failure.diagnosticBundle?.status === 'uploaded'
+      ? translate(
+          'auto.components.crash.report.submit.notice.ticketUploaded',
+          'Diagnostic ticket {{value0}} was uploaded but not linked.',
+          { value0: sanitizeCrashReportString(failure.diagnosticBundle.ticketId) }
+        )
+      : null
+  const omittedDetail =
+    failure.diagnosticBundle?.status === 'not_uploaded'
+      ? asSentence(
+          translate(
+            'auto.components.crash.report.submit.notice.diagnosticsReason',
+            'Diagnostic logs were not attached: {{value0}}',
+            { value0: normalizedFailureMessage(failure.diagnosticBundle.reason) }
+          )
+        )
+      : null
+  const attachmentAlreadyOmitted = failure.diagnosticBundle?.status === 'not_uploaded'
+  const recovery =
+    includeDiagnosticLogs && !attachmentAlreadyOmitted
+      ? translate(
+          'auto.components.crash.report.submit.notice.uncheckDiagnostics',
+          'Uncheck "Attach recent diagnostic logs" and try again, or copy the details.'
+        )
+      : translate(
+          'auto.components.crash.report.submit.notice.checkConnection',
+          'Check your connection and try again, or copy the details.'
+        )
+
+  return {
+    title: translate(
+      'auto.components.crash.report.submit.notice.notSent',
+      "Crash report wasn't sent"
+    ),
+    description: [
+      asSentence(normalizedFailureMessage(failure.error)),
+      ticketDetail,
+      omittedDetail,
+      recovery
+    ]
+      .filter((part): part is string => Boolean(part))
+      .join(' '),
+    actionLabel: translate('auto.components.crash.report.submit.notice.copyDetails', 'Copy Details')
+  }
+}
+
+export function getCrashReportSubmitWarningNotice(
+  result: Extract<CrashReportSubmitResult, { ok: true }>,
+  includeDiagnosticLogs: boolean
+): CrashReportSubmitWarningNotice | null {
+  if (!includeDiagnosticLogs || result.diagnosticBundle?.status !== 'not_uploaded') {
+    return null
+  }
+
+  return {
+    title: translate(
+      'auto.components.crash.report.submit.notice.sentWithoutDiagnostics',
+      'Crash report sent without diagnostic logs'
+    ),
+    description: translate(
+      'auto.components.crash.report.submit.notice.diagnosticsReason',
+      'Diagnostic logs were not attached: {{value0}}',
+      { value0: normalizedFailureMessage(result.diagnosticBundle.reason) }
+    )
+  }
+}

--- a/src/renderer/src/components/crash-report/use-crash-report-copy.test.tsx
+++ b/src/renderer/src/components/crash-report/use-crash-report-copy.test.tsx
@@ -95,6 +95,24 @@ describe('useCrashReportCopy', () => {
     expect(JSON.stringify(copyLatestDiagnostics.mock.calls)).not.toContain('private notes for B')
   })
 
+  it('keeps a returned copy failure visible with its safe reason', async () => {
+    copyLatestDiagnostics.mockResolvedValueOnce({
+      ok: false,
+      error: 'Crash diagnostics are too large to copy safely.'
+    })
+    const { result } = renderHook(() => useCrashReportCopy(report(), 'current notes'))
+
+    await act(async () => result.current())
+
+    expect(toast.error).toHaveBeenCalledWith('Crash report details could not be copied.', {
+      id: CRASH_REPORT_COPY_FAILURE_TOAST_ID,
+      description: 'Crash diagnostics are too large to copy safely.',
+      duration: Infinity,
+      dismissible: true
+    })
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
   it('shows a safe sticky error toast when copy IPC rejects', async () => {
     copyLatestDiagnostics.mockRejectedValueOnce(
       new Error('renderer destroyed with token=must-not-be-shown')

--- a/src/renderer/src/components/crash-report/use-crash-report-copy.test.tsx
+++ b/src/renderer/src/components/crash-report/use-crash-report-copy.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import type {
+  CrashReportCopySubmissionFailure,
+  CrashReportRecord
+} from '../../../../shared/crash-reporting'
+import { CRASH_REPORT_COPY_FAILURE_TOAST_ID, useCrashReportCopy } from './use-crash-report-copy'
+
+const copyLatestDiagnostics = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn()
+  }
+}))
+
+function report(id = 'crash-1'): CrashReportRecord {
+  return {
+    id,
+    createdAt: '2026-05-16T01:00:00.000Z',
+    status: 'pending',
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'crashed',
+    exitCode: 5,
+    appVersion: '1.0.0',
+    platform: 'win32',
+    osRelease: 'test',
+    arch: 'x64',
+    electronVersion: '41',
+    chromeVersion: '141',
+    details: {}
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  copyLatestDiagnostics.mockResolvedValue({ ok: true })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { crashReports: { copyLatestDiagnostics } }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('useCrashReportCopy', () => {
+  it('uses the latest edited notes from an older failure-toast action', async () => {
+    const failure: CrashReportCopySubmissionFailure = {
+      error: 'report request timed out',
+      diagnosticContext: { status: 'not_uploaded', reason: 'logs timed out' }
+    }
+    const { result, rerender } = renderHook(({ notes }) => useCrashReportCopy(report(), notes), {
+      initialProps: { notes: 'notes at submit' }
+    })
+    const failureToastCopyAction = result.current
+
+    rerender({ notes: 'notes edited while waiting' })
+    await act(async () => failureToastCopyAction(failure))
+
+    expect(copyLatestDiagnostics).toHaveBeenCalledWith({
+      reportId: 'crash-1',
+      notes: 'notes edited while waiting',
+      submissionFailure: failure
+    })
+  })
+
+  it("does not combine an older report action with a newer report's notes", async () => {
+    const { result, rerender } = renderHook(
+      ({ currentReport, notes }) => useCrashReportCopy(currentReport, notes),
+      {
+        initialProps: {
+          currentReport: report('crash-a'),
+          notes: 'latest notes for A'
+        }
+      }
+    )
+    const reportACopyAction = result.current
+
+    rerender({ currentReport: report('crash-b'), notes: 'private notes for B' })
+    await act(async () => reportACopyAction())
+
+    expect(copyLatestDiagnostics).toHaveBeenCalledWith({
+      reportId: 'crash-a',
+      notes: 'latest notes for A'
+    })
+    expect(JSON.stringify(copyLatestDiagnostics.mock.calls)).not.toContain('private notes for B')
+  })
+
+  it('shows a safe sticky error toast when copy IPC rejects', async () => {
+    copyLatestDiagnostics.mockRejectedValueOnce(
+      new Error('renderer destroyed with token=must-not-be-shown')
+    )
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { result } = renderHook(() => useCrashReportCopy(report(), 'current notes'))
+
+    await act(async () => result.current())
+
+    expect(toast.error).toHaveBeenCalledWith('Crash report details could not be copied.', {
+      id: CRASH_REPORT_COPY_FAILURE_TOAST_ID,
+      duration: Infinity,
+      dismissible: true
+    })
+    expect(JSON.stringify(vi.mocked(toast.error).mock.calls)).not.toContain('must-not-be-shown')
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/crash-report/use-crash-report-copy.ts
+++ b/src/renderer/src/components/crash-report/use-crash-report-copy.ts
@@ -1,0 +1,69 @@
+import { useCallback, useRef } from 'react'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import type {
+  CrashReportCopySubmissionFailure,
+  CrashReportRecord
+} from '../../../../shared/crash-reporting'
+
+export const CRASH_REPORT_COPY_FAILURE_TOAST_ID = 'crash-report-copy-failure'
+
+function showCopyFailure(description?: string): void {
+  toast.error(
+    translate(
+      'auto.components.crash.report.copy.copyFailed',
+      'Crash report details could not be copied.'
+    ),
+    {
+      id: CRASH_REPORT_COPY_FAILURE_TOAST_ID,
+      ...(description ? { description } : {}),
+      duration: Infinity,
+      dismissible: true
+    }
+  )
+}
+
+export function useCrashReportCopy(
+  report: CrashReportRecord | null,
+  notes: string
+): (submissionFailure?: CrashReportCopySubmissionFailure) => Promise<void> {
+  const reportId = report?.id ?? null
+  const notesRef = useRef({ reportId, value: notes })
+  // Why: a submission toast can outlive the render that created it while the
+  // user edits or changes reports; keep live notes scoped to that report.
+  if (notesRef.current.reportId === reportId) {
+    notesRef.current.value = notes
+  } else {
+    notesRef.current = { reportId, value: notes }
+  }
+  const reportNotes = notesRef.current
+
+  return useCallback(
+    async (submissionFailure?: CrashReportCopySubmissionFailure): Promise<void> => {
+      try {
+        const result = await window.api.crashReports.copyLatestDiagnostics({
+          ...(report ? { reportId: report.id } : {}),
+          notes: reportNotes.value,
+          ...(submissionFailure ? { submissionFailure } : {})
+        })
+        if (!result.ok) {
+          showCopyFailure(result.error)
+          return
+        }
+        toast.dismiss(CRASH_REPORT_COPY_FAILURE_TOAST_ID)
+        toast.success(
+          translate(
+            'auto.components.crash.report.CrashReportDialog.8b8473c544',
+            'Crash report copied.'
+          )
+        )
+      } catch (error) {
+        console.error('Failed to copy crash report details:', error)
+        // Why: Sonner closes an action toast when clicked, so a sticky generic
+        // replacement keeps the failure actionable without exposing raw IPC detail.
+        showCopyFailure()
+      }
+    },
+    [report, reportNotes]
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11905,6 +11905,18 @@
             "ead6fc0510": "No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.",
             "b082f27490": "Attach recent diagnostic logs",
             "e59f0b9427": "Sends a capped redacted log bundle with the report."
+          },
+          "submit": {
+            "notice": {
+              "unknownError": "The crash report request failed before it returned a reason.",
+              "ticketUploaded": "Diagnostic ticket {{value0}} was uploaded but not linked.",
+              "uncheckDiagnostics": "Uncheck \"Attach recent diagnostic logs\" and try again, or copy the details.",
+              "checkConnection": "Check your connection and try again, or copy the details.",
+              "notSent": "Crash report wasn't sent",
+              "copyDetails": "Copy Details",
+              "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
+              "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11917,6 +11917,9 @@
               "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
               "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
             }
+          },
+          "copy": {
+            "copyFailed": "Crash report details could not be copied."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11905,6 +11905,18 @@
             "ead6fc0510": "No se capturó ningún informe de fallo automático. Aun así puedes enviar detalles e incluir logs de diagnóstico recientes cuando estén disponibles.",
             "b082f27490": "Adjuntar logs de diagnóstico recientes",
             "e59f0b9427": "Envía un paquete limitado de logs redactados junto con el informe."
+          },
+          "submit": {
+            "notice": {
+              "unknownError": "The crash report request failed before it returned a reason.",
+              "ticketUploaded": "Diagnostic ticket {{value0}} was uploaded but not linked.",
+              "uncheckDiagnostics": "Uncheck \"Attach recent diagnostic logs\" and try again, or copy the details.",
+              "checkConnection": "Check your connection and try again, or copy the details.",
+              "notSent": "Crash report wasn't sent",
+              "copyDetails": "Copy Details",
+              "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
+              "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11917,6 +11917,9 @@
               "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
               "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
             }
+          },
+          "copy": {
+            "copyFailed": "No se pudieron copiar los detalles del informe de fallo."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11917,6 +11917,9 @@
               "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
               "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
             }
+          },
+          "copy": {
+            "copyFailed": "クラッシュレポートの詳細をコピーできませんでした。"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11905,6 +11905,18 @@
             "ead6fc0510": "No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.",
             "b082f27490": "Attach recent diagnostic logs",
             "e59f0b9427": "Sends a capped redacted log bundle with the report."
+          },
+          "submit": {
+            "notice": {
+              "unknownError": "The crash report request failed before it returned a reason.",
+              "ticketUploaded": "Diagnostic ticket {{value0}} was uploaded but not linked.",
+              "uncheckDiagnostics": "Uncheck \"Attach recent diagnostic logs\" and try again, or copy the details.",
+              "checkConnection": "Check your connection and try again, or copy the details.",
+              "notSent": "Crash report wasn't sent",
+              "copyDetails": "Copy Details",
+              "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
+              "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11905,6 +11905,18 @@
             "ead6fc0510": "자동 크래시 보고서가 캡처되지 않았습니다. 그래도 세부 정보를 보내고, 가능한 경우 최근 진단 로그를 포함할 수 있습니다.",
             "b082f27490": "최근 진단 로그 첨부",
             "e59f0b9427": "보고서와 함께 크기가 제한되고 민감 정보가 제거된 로그 묶음을 보냅니다."
+          },
+          "submit": {
+            "notice": {
+              "unknownError": "The crash report request failed before it returned a reason.",
+              "ticketUploaded": "Diagnostic ticket {{value0}} was uploaded but not linked.",
+              "uncheckDiagnostics": "Uncheck \"Attach recent diagnostic logs\" and try again, or copy the details.",
+              "checkConnection": "Check your connection and try again, or copy the details.",
+              "notSent": "Crash report wasn't sent",
+              "copyDetails": "Copy Details",
+              "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
+              "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
+            }
           }
         }
       },
@@ -12734,7 +12746,7 @@
               "confirm": {
                 "move": {
                   "title": "프로젝트를 이동하시겠습니까?",
-                  "description": "{{repoName}}을(를) {{targetName}}(으)로 이동합니다. Orca가 {{repoName}}을(를) {{activeProfileName}}에서 제거한 뒤 파일은 유지하고 {{targetName}}(으)로 다시 시작합니다.",
+                  "description": "{{repoName}}을(를) {{targetName}}(으)로 이동합니다. Orca가 해당 프로젝트를 {{activeProfileName}}에서 제거한 뒤 파일은 유지하고 {{targetName}}(으)로 다시 시작합니다.",
                   "action": "프로젝트 이동"
                 },
                 "copy": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11917,6 +11917,9 @@
               "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
               "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
             }
+          },
+          "copy": {
+            "copyFailed": "충돌 보고서 세부 정보를 복사하지 못했습니다."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11905,6 +11905,18 @@
             "ead6fc0510": "没有捕获到自动崩溃报告。你仍然可以发送详情，并在可用时包含最近的诊断日志。",
             "b082f27490": "附加最近的诊断日志",
             "e59f0b9427": "随报告发送经过删减且有大小限制的日志包。"
+          },
+          "submit": {
+            "notice": {
+              "unknownError": "The crash report request failed before it returned a reason.",
+              "ticketUploaded": "Diagnostic ticket {{value0}} was uploaded but not linked.",
+              "uncheckDiagnostics": "Uncheck \"Attach recent diagnostic logs\" and try again, or copy the details.",
+              "checkConnection": "Check your connection and try again, or copy the details.",
+              "notSent": "Crash report wasn't sent",
+              "copyDetails": "Copy Details",
+              "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
+              "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11917,6 +11917,9 @@
               "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
               "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
             }
+          },
+          "copy": {
+            "copyFailed": "无法复制崩溃报告详细信息。"
           }
         }
       },

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -108,6 +108,19 @@ export type CrashReportSubmitResult =
       diagnosticBundle?: CrashReportDiagnosticBundle
     }
 
+export type CrashReportCopySubmissionFailure = {
+  error: string
+  diagnosticContext?:
+    | { status: 'uploaded'; ticketId: string }
+    | { status: 'not_uploaded'; reason: string }
+}
+
+export type CrashReportCopyDiagnosticsArgs = {
+  reportId?: string
+  notes?: string
+  submissionFailure?: CrashReportCopySubmissionFailure
+}
+
 const MAX_STRING_DETAIL_LENGTH = 240
 const MAX_STACK_DETAIL_LENGTH = 4_000
 const MAX_BREADCRUMB_NAME_LENGTH = 80


### PR DESCRIPTION
## Summary

Fixes #7776.

Crash reporting now fails open around optional diagnostics while making automatic capture consistent and diagnosable:

- pending-report reads wait for already-started writes, closing the 250 ms renderer-recovery / one-shot startup-prompt race;
- Windows crash-report reads and writes asynchronously repair a denied `userData` ACL, retry transient `EPERM` / `EACCES` / `EBUSY` locks, and clean failed temp files;
- renderer exits reach one classifier; failed persistence releases its dedupe claim for recovery, while optional trace sink failures remain fail-open and suppression/store/persist outcomes stay durable;
- a diagnostic bundle gets a 60-second upload budget, then eligible multipart failures retry once as small report-only JSON (never multipart on the legacy host);
- final errors are shown in a sticky, dismissible toast; Copy Details includes the sanitized submission/attachment failure without stale cross-report notes, while degraded success says the report arrived without logs.

This combines and extends the narrower approaches in #7874 and #7875. In particular, it avoids re-entering the two-host feedback policy from crash IPC and also fixes the capture read race and Windows persistence gap that diagnostic-only handling does not cover.

## ELI5

Think of a crash report as a note with an optional box of logs attached. Orca now makes sure the note is actually saved, even when Windows briefly locks the file. If the box of logs is too slow or rejected, Orca sends the smaller note once without the box instead of giving up. If anything still fails, it keeps a safe receipt explaining what happened and lets the user copy the exact redacted details.

## Screenshots

No layout change. The changed UI is transient toast copy/behavior; its success, failure, redaction, recovery-guidance, and Copy Details configuration are covered by focused tests.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — the full 28,103-test suite passed in PR `verify` on rerun; the first final-head attempt had one unrelated terminal foreground-sampling flake
- [ ] `pnpm build` — not run
- [x] Added or updated high-quality tests that would catch regressions

Focused verification:

- 201 tests passed across Windows crash-store read/write/ACL recovery, process-gone classification/dedupe/recording, feedback transport, crash IPC, tracer durability, diagnostic bundles, and renderer copy/notices.
- `pnpm run lint` passed, including switch exhaustiveness, reliability gates, max-lines ratchet, and localization verification.
- `pnpm run typecheck` passed for node, CLI, and web.
- PR `verify` also passed the unpacked-app build and packaged-CLI smoke test.
- `git diff --check origin/main...HEAD` passed.

## AI Review Report

The solution was designed and tested before inspecting existing PRs. Parallel review traced automatic capture, feedback transport, and renderer UX independently, then compared #7874/#7875 only after the implementation was frozen.

Main risks checked:

- startup prompt observing stale disk state while `record()` is still in flight;
- deadlock when adding read-after-write consistency to the serialized store;
- Chromium's asynchronous Windows `userData` ACL repair window and antivirus rename locks;
- duplicate classification hiding suppression diagnostics;
- trace batching losing the only explanation for a missing record;
- multipart retries multiplying across primary/fallback hosts;
- slow/corporate uplinks, multipart 4xx/proxy rejection, and bounded timeout behavior;
- accidentally marking a report sent when both transport attempts fail;
- raw paths or tokens reaching renderer error copy;
- max-lines growth in the existing crash IPC module.

The review led to a raw-disk read split to avoid self-deadlock, a focused diagnostic-bundle module that shrinks the grandfathered IPC file, a website-only multipart attempt with one JSON degradation request, synchronous trace flushes at crash boundaries, and redaction tests.

Cross-platform review covered macOS, Linux, and Windows. The transport and renderer behavior are platform-neutral; ACL repair/retry is gated by `process.platform === 'win32'`. No shortcuts, labels, shell commands, Git behavior, provider behavior, or path separators were introduced. SSH-hosted worktrees remain unaffected because crash capture/submission belongs to the local Electron main process.

## Security Audit

- No new dependency, endpoint, auth flow, IPC channel, or automatic upload was added.
- Diagnostic bundles remain capped, redacted, and user-controlled.
- Error text is sanitized before renderer display; tests cover Windows paths and token-shaped secrets.
- Feedback retries are bounded and do not duplicate a successful request.
- Windows ACL recovery uses the existing System32-resolved `icacls` lane asynchronously and only targets the known crash-store parent after a permission error.
- Crash diagnostic attributes accept only sanitized primitive values and local traces are flushed through the existing consent/rotation lane.

No security follow-up is required for this change.

## Notes

- The post-rebase localization gate exposed one pre-existing Korean interpolation-count mismatch from current `main`; this branch preserves the Korean translation while correcting its placeholder multiplicity.
- This improves capture/delivery reliability but does not add Crashpad minidump upload or symbolication; that remains a separate follow-up noted on #7776.






