### PR TITLE
Bump mobile app.json to 0.0.27

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump `mobile/app.json` `expo.version` to **0.0.27**.
- iOS **0.0.26** is already submitted/released on the App Store, so a new TestFlight build requires a new marketing version.
- Android **0.0.26** is shipping separately from `mobile-android-v0.0.26` (first successful APK after the TS6 Expo bundling fix).

## Verification
- Confirmed App Store train closed for 0.0.26 via failed iOS release:
  `iOS version 0.0.26 is already submitted/released on the App Store and cannot accept new builds`