### PR TITLE
feat(settings): configurable default tab when opening a branch from the sidebar

### DIFF
--- a/src/renderer/src/components/settings/GeneralWorkspaceDefaultTabSetting.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceDefaultTabSetting.tsx
@@ -1,0 +1,231 @@
+import type React from 'react'
+import { useMemo } from 'react'
+import { Globe, TerminalSquare } from 'lucide-react'
+import type { GlobalSettings } from '../../../../shared/types'
+import type { BuiltInWindowsTerminalShell } from '../../../../shared/windows-terminal-shell'
+import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
+import type { DefaultWorkspaceTab } from '../../../../shared/default-workspace-tab'
+import {
+  normalizeDefaultWorkspaceTab,
+  parseDefaultWorkspaceTab,
+  serializeDefaultWorkspaceTab
+} from '../../../../shared/default-workspace-tab'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue
+} from '../ui/select'
+import { SettingsRow } from './SettingsFormControls'
+import { SearchableSetting } from './SearchableSetting'
+import {
+  buildTabCreateMenuOptions,
+  type TabCreateMenuOption
+} from '../tab-bar/tab-create-menu-options'
+import {
+  buildTabAgentLaunchOptions,
+  orderTabLaunchAgents
+} from '../tab-bar/tab-agent-launch-options'
+import { ShellIcon } from '../tab-bar/shell-icons'
+import { AgentIcon } from '@/lib/agent-catalog'
+import { useAppStore } from '../../store'
+import { useDetectedAgents } from '@/hooks/useDetectedAgents'
+import {
+  useWindowsTerminalCapabilities,
+  type WindowsTerminalCapabilities
+} from '@/lib/windows-terminal-capabilities'
+import { translate } from '@/i18n/i18n'
+
+const IS_WINDOWS_CLIENT =
+  typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows')
+
+type GeneralWorkspaceDefaultTabSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+// Why: reuse the exact "+" new-tab menu icons so the default picker and the menu
+// stay visually identical. Shells use the per-shell brand glyph like the static
+// menu; browser/terminal use the same lucide icons.
+function menuOptionIcon(option: TabCreateMenuOption): React.ReactNode {
+  if (option.kind === 'new-browser') {
+    return <Globe className="size-4 text-muted-foreground" />
+  }
+  if (option.kind === 'new-terminal-shell' && option.shell) {
+    return <ShellIcon shell={option.shell} size={16} />
+  }
+  return <TerminalSquare className="size-4 text-muted-foreground" />
+}
+
+// Maps a "+" menu option to the stored descriptor. Returns null for surfaces
+// that are not offered as a first-open default (markdown, mobile emulator) or a
+// future kind not yet wired into activation — those are simply skipped.
+function menuOptionToDefaultTab(option: TabCreateMenuOption): DefaultWorkspaceTab | null {
+  if (option.kind === 'new-terminal') {
+    return { kind: 'terminal' }
+  }
+  if (option.kind === 'new-terminal-shell') {
+    return option.shell ? { kind: 'terminal-shell', shell: option.shell } : { kind: 'terminal' }
+  }
+  if (option.kind === 'new-browser') {
+    return { kind: 'browser' }
+  }
+  return null
+}
+
+// Why: mirror the "+" menu's Windows shell list (PowerShell/CMD always, Git Bash
+// and WSL when the local probe finds them, default shell first). Reuses the same
+// translation keys as the menu so labels stay identical across locales.
+function buildWindowsShellEntries(
+  capabilities: WindowsTerminalCapabilities,
+  defaultShell: string | undefined,
+  current: DefaultWorkspaceTab
+): { label: string; shell: BuiltInWindowsTerminalShell }[] | undefined {
+  if (!IS_WINDOWS_CLIENT) {
+    return undefined
+  }
+  const labels: Record<BuiltInWindowsTerminalShell, string> = {
+    'powershell.exe': translate('auto.components.tab.bar.TabBar.2148f65e04', 'PowerShell'),
+    'cmd.exe': translate('auto.components.tab.bar.TabBar.1a8af49530', 'CMD Prompt'),
+    'wsl.exe': translate('auto.components.tab.bar.TabBar.d1afac112b', 'WSL'),
+    [WINDOWS_GIT_BASH_SHELL]: translate('auto.components.tab.bar.TabBar.efb33546ff', 'Git Bash')
+  }
+  const shells: BuiltInWindowsTerminalShell[] = ['powershell.exe', 'cmd.exe']
+  if (capabilities.gitBashAvailable) {
+    shells.push(WINDOWS_GIT_BASH_SHELL)
+  }
+  if (capabilities.wslAvailable) {
+    shells.push('wsl.exe')
+  }
+  // Keep the stored shell selectable even if the local probe no longer lists it.
+  if (current.kind === 'terminal-shell' && !shells.includes(current.shell)) {
+    shells.push(current.shell)
+  }
+  const ordered =
+    defaultShell && shells.includes(defaultShell as BuiltInWindowsTerminalShell)
+      ? [
+          defaultShell as BuiltInWindowsTerminalShell,
+          ...shells.filter((shell) => shell !== defaultShell)
+        ]
+      : shells
+  return ordered.map((shell) => ({ label: labels[shell], shell }))
+}
+
+export function GeneralWorkspaceDefaultTabSetting({
+  settings,
+  updateSettings
+}: GeneralWorkspaceDefaultTabSettingProps): React.JSX.Element {
+  const capabilities = useWindowsTerminalCapabilities(IS_WINDOWS_CLIENT, false)
+  const defaultAgent = useAppStore((state) => state.settings?.defaultTuiAgent)
+  const { detectedIds } = useDetectedAgents(null)
+
+  const current = normalizeDefaultWorkspaceTab(settings.defaultWorkspaceTab)
+
+  // Single source of truth: exactly the same options the "+" new-tab menu shows
+  // — on Windows the specific shells (no plain "New Terminal"), on other
+  // platforms "New Terminal" — minus the document/emulator surfaces that do not
+  // make sense as a reopen default.
+  const surfaceItems = useMemo(() => {
+    const windowsShellEntries = buildWindowsShellEntries(
+      capabilities,
+      settings.terminalWindowsShell,
+      current
+    )
+    const menuOptions = buildTabCreateMenuOptions({
+      terminalOnly: false,
+      windowsShellEntries,
+      hasNewBrowser: true,
+      hasNewMarkdown: false,
+      hasOpenMarkdown: false,
+      hasSimulator: false,
+      simulatorIsGoTo: false
+    })
+    const items: { value: string; label: string; icon: React.ReactNode }[] = []
+    for (const option of menuOptions) {
+      const descriptor = menuOptionToDefaultTab(option)
+      if (!descriptor) {
+        continue
+      }
+      items.push({
+        value: serializeDefaultWorkspaceTab(descriptor),
+        label: option.label,
+        icon: menuOptionIcon(option)
+      })
+    }
+    return items
+  }, [capabilities, current, settings.terminalWindowsShell])
+
+  const agentItems = useMemo(() => {
+    const ordered = orderTabLaunchAgents(defaultAgent, detectedIds ?? [])
+    const withCurrent =
+      current.kind === 'agent' && !ordered.includes(current.agent)
+        ? [current.agent, ...ordered]
+        : ordered
+    return buildTabAgentLaunchOptions(withCurrent)
+  }, [current, defaultAgent, detectedIds])
+
+  // Why: the stored default may not be a rendered option — a plain-terminal
+  // default on Windows (where the menu shows shells, not "New Terminal"), or a
+  // shell/agent no longer available on this host. Show the first option (the
+  // default shell on Windows, "New Terminal" elsewhere) so the trigger always
+  // reflects a valid, matching selection.
+  const currentValue = serializeDefaultWorkspaceTab(current)
+  const selectedValue = useMemo(() => {
+    const values = new Set<string>([
+      ...surfaceItems.map((item) => item.value),
+      ...agentItems.map((agent) => `agent:${agent.agent}`)
+    ])
+    return values.has(currentValue) ? currentValue : (surfaceItems[0]?.value ?? currentValue)
+  }, [surfaceItems, agentItems, currentValue])
+
+  const title = translate(
+    'auto.components.settings.GeneralWorkspaceDefaultTabSetting.d5ace069a0',
+    'Default Tab'
+  )
+  const description = translate(
+    'auto.components.settings.GeneralWorkspaceDefaultTabSetting.c8b1d50fbe',
+    'The tab that opens the first time you open a workspace from the sidebar.'
+  )
+
+  return (
+    <SearchableSetting title={title} description={description}>
+      <SettingsRow
+        label={title}
+        description={description}
+        control={
+          <Select
+            value={selectedValue}
+            onValueChange={(value) =>
+              updateSettings({ defaultWorkspaceTab: parseDefaultWorkspaceTab(value) })
+            }
+          >
+            <SelectTrigger size="sm" className="w-60">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {surfaceItems.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  <span className="flex items-center gap-2">
+                    {item.icon}
+                    {item.label}
+                  </span>
+                </SelectItem>
+              ))}
+              {agentItems.length > 0 && <SelectSeparator />}
+              {agentItems.map((agent) => (
+                <SelectItem key={`agent:${agent.agent}`} value={`agent:${agent.agent}`}>
+                  <span className="flex items-center gap-2">
+                    <AgentIcon agent={agent.agent} size={14} />
+                    {agent.label}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        }
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
@@ -4,6 +4,7 @@ import { OpenInMenuSetting } from './OpenInMenuSetting'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
 import { WorkspaceDirectorySetting } from './WorkspaceDirectorySetting'
+import { GeneralWorkspaceDefaultTabSetting } from './GeneralWorkspaceDefaultTabSetting'
 import { translate } from '@/i18n/i18n'
 
 type GeneralWorkspaceSettingsSectionProps = {
@@ -29,6 +30,8 @@ export function GeneralWorkspaceSettingsSection({
       />
 
       <WorkspaceDirectorySetting settings={settings} updateSettings={updateSettings} />
+
+      <GeneralWorkspaceDefaultTabSetting settings={settings} updateSettings={updateSettings} />
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8994,6 +8994,10 @@
           "a8f3e2c1b4": "Weekly credits",
           "b7e2d9f0a3": "Same weekly credit % as the grok /usage screen in the terminal.",
           "c6d1a8f4e2": "Resets {{when}}"
+        },
+        "GeneralWorkspaceDefaultTabSetting": {
+          "d5ace069a0": "Default Tab",
+          "c8b1d50fbe": "The tab that opens the first time you open a workspace from the sidebar."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8994,6 +8994,10 @@
           "a8f3e2c1b4": "Créditos semanales",
           "b7e2d9f0a3": "El mismo porcentaje de créditos semanales que la pantalla grok /usage en la terminal.",
           "c6d1a8f4e2": "Se restablece {{when}}"
+        },
+        "GeneralWorkspaceDefaultTabSetting": {
+          "d5ace069a0": "Pestaña predeterminada",
+          "c8b1d50fbe": "La pestaña que se muestra al abrir un espacio de trabajo por primera vez desde la barra lateral."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8994,6 +8994,10 @@
           "a8f3e2c1b4": "週次クレジット",
           "b7e2d9f0a3": "ターミナルの grok /usage 画面と同じ週次クレジット率です。",
           "c6d1a8f4e2": "{{when}} にリセット"
+        },
+        "GeneralWorkspaceDefaultTabSetting": {
+          "d5ace069a0": "デフォルトタブ",
+          "c8b1d50fbe": "サイドバーからワークスペースを初めて開いたときに表示されるタブです。"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8994,6 +8994,10 @@
           "a8f3e2c1b4": "주간 크레딧",
           "b7e2d9f0a3": "터미널의 grok /usage 화면과 같은 주간 크레딧 비율입니다.",
           "c6d1a8f4e2": "{{when}}에 재설정"
+        },
+        "GeneralWorkspaceDefaultTabSetting": {
+          "d5ace069a0": "기본 탭",
+          "c8b1d50fbe": "사이드바에서 워크스페이스를 처음 열 때 표시되는 탭입니다."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8994,6 +8994,10 @@
           "a8f3e2c1b4": "每周额度",
           "b7e2d9f0a3": "与终端中 grok /usage 屏幕显示的每周额度百分比相同。",
           "c6d1a8f4e2": "{{when}} 重置"
+        },
+        "GeneralWorkspaceDefaultTabSetting": {
+          "d5ace069a0": "默认选项卡",
+          "c8b1d50fbe": "首次从侧边栏打开工作区时显示的选项卡。"
         }
       },
       "right": {

--- a/src/renderer/src/lib/open-default-workspace-tab.ts
+++ b/src/renderer/src/lib/open-default-workspace-tab.ts
@@ -1,0 +1,166 @@
+import type { TuiAgent, Worktree } from '../../../shared/types'
+import type { BuiltInWindowsTerminalShell } from '../../../shared/windows-terminal-shell'
+import type { DefaultWorkspaceTab } from '../../../shared/default-workspace-tab'
+import type { WorktreeStartupPayload } from './worktree-activation'
+import type { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
+import { shouldAutoCreateInitialTerminal } from '@/components/terminal/initial-terminal'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { isWebRuntimeSessionActive } from '@/runtime/web-runtime-session'
+import { getCachedWindowsTerminalCapabilities } from '@/lib/windows-terminal-capabilities'
+import { resolveWindowsShellLaunchTarget } from '@/components/tab-bar/windows-shell-launch'
+import { getAgentLaunchPlatformForRepo } from '@/lib/agent-launch-platform'
+import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { CLIENT_PLATFORM } from './new-workspace'
+import { tuiAgentToAgentKind } from './telemetry'
+import { buildAgentStartupPlan } from './tui-agent-startup'
+import {
+  resolveTuiAgentLaunchArgs,
+  resolveTuiAgentLaunchEnv
+} from '../../../shared/tui-agent-launch-defaults'
+import { repoIsRemote } from '../../../shared/agent-launch-remote'
+
+type WorkspaceSurfaceStore = ReturnType<typeof useAppStore.getState>
+
+/**
+ * How the configurable default surface for a first workspace activation should
+ * be realized. `terminal` feeds the existing initial-terminal path (optionally
+ * with an agent startup or a specific shell); `created` means a non-terminal
+ * surface was opened directly; `fallback-terminal` means the chosen surface is
+ * not creatable on this host and the caller should open a plain terminal.
+ */
+export type DefaultWorkspaceSurfaceOutcome =
+  | { kind: 'terminal'; startup?: WorktreeStartupPayload; shellOverride?: string }
+  | { kind: 'created'; tabId: string }
+  | { kind: 'fallback-terminal' }
+
+/**
+ * Builds the agent-launch startup payload used to seed a workspace's first
+ * terminal with a coding agent. Shared by the "created with agent" reopen path
+ * and the default-workspace-tab agent option so both launch identically.
+ */
+export function buildSidebarAgentStartup(
+  store: WorkspaceSurfaceStore,
+  worktree: Worktree,
+  agent: TuiAgent,
+  requestKind: 'new' | 'resume'
+): WorktreeStartupPayload | undefined {
+  const repo = store.repos.find((entry) => entry.id === worktree.repoId)
+  const launchPlatform = repo
+    ? getAgentLaunchPlatformForRepo(
+        repo,
+        repo.connectionId ? undefined : getLocalProjectExecutionRuntimeContext(store, worktree.id)
+      )
+    : CLIENT_PLATFORM
+
+  const startupPlan = buildAgentStartupPlan({
+    agent,
+    prompt: '',
+    cmdOverrides: store.settings?.agentCmdOverrides ?? {},
+    agentArgs: resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs),
+    agentEnv: resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv),
+    platform: launchPlatform,
+    isRemote: repo ? repoIsRemote(repo) : false,
+    allowEmptyPromptLaunch: true
+  })
+  if (!startupPlan) {
+    return undefined
+  }
+
+  return {
+    command: startupPlan.launchCommand,
+    ...(startupPlan.env ? { env: startupPlan.env } : {}),
+    launchConfig: startupPlan.launchConfig,
+    launchAgent: agent,
+    ...(startupPlan.startupCommandDelivery
+      ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
+      : {}),
+    telemetry: {
+      agent_kind: tuiAgentToAgentKind(agent),
+      launch_source: 'sidebar',
+      request_kind: requestKind
+    }
+  }
+}
+
+// Why: shellOverride is a raw shell token spawned on the worktree's host. We can
+// only be sure that host is Windows for a local worktree on a Windows client;
+// remote/SSH hosts have an unknown platform, so they fall back to a plain
+// terminal rather than risk spawning an invalid shell.
+function resolveDefaultTerminalShellOverride(
+  store: WorkspaceSurfaceStore,
+  worktree: Worktree,
+  shell: BuiltInWindowsTerminalShell
+): string | undefined {
+  const repo = store.repos.find((entry) => entry.id === worktree.repoId)
+  const isLocalWorktree =
+    !getRuntimeEnvironmentIdForWorktree(store, worktree.id) && !(repo ? repoIsRemote(repo) : false)
+  if (!isLocalWorktree || !navigator.userAgent.includes('Windows')) {
+    return undefined
+  }
+  const implementation = store.settings?.terminalWindowsPowerShellImplementation ?? 'auto'
+  const pwshAvailable = getCachedWindowsTerminalCapabilities().pwshAvailable
+  return resolveWindowsShellLaunchTarget(shell, implementation, pwshAvailable)
+}
+
+// Why: only open a non-terminal default when the worktree truly has no surface
+// yet (matching the initial-terminal auto-create guard) and is not a runtime-
+// mirrored web session, whose host owns tab creation.
+function canCreateNonTerminalDefaultSurface(
+  store: WorkspaceSurfaceStore,
+  worktreeId: string
+): boolean {
+  if (isWebRuntimeSessionActive(getRuntimeEnvironmentIdForWorktree(store, worktreeId))) {
+    return false
+  }
+  const { renderableTabCount } = store.reconcileWorktreeTabModel(worktreeId)
+  return shouldAutoCreateInitialTerminal(renderableTabCount)
+}
+
+function createDefaultBrowserSurface(
+  store: WorkspaceSurfaceStore,
+  worktreeId: string
+): string | null {
+  const defaultUrl = store.browserDefaultUrl ?? 'about:blank'
+  const browserTab = store.createBrowserTab(worktreeId, defaultUrl, {
+    title: translate('auto.store.slices.browser.d175274b6d', 'New Browser Tab'),
+    focusAddressBar: true,
+    activate: true
+  })
+  return browserTab.id
+}
+
+/**
+ * Resolves the user's configured default-workspace-tab into a concrete surface
+ * for the first activation of a worktree. Reuses the same store methods as the
+ * "+" new-tab menu (agent startup, `createBrowserTab`) so the default stays
+ * consistent with manual creation; any surface that cannot be created on the
+ * current host degrades to a plain terminal.
+ */
+export function resolveDefaultWorkspaceSurface(
+  store: WorkspaceSurfaceStore,
+  worktree: Worktree,
+  descriptor: DefaultWorkspaceTab
+): DefaultWorkspaceSurfaceOutcome {
+  switch (descriptor.kind) {
+    case 'terminal':
+      return { kind: 'terminal' }
+    case 'terminal-shell':
+      return {
+        kind: 'terminal',
+        shellOverride: resolveDefaultTerminalShellOverride(store, worktree, descriptor.shell)
+      }
+    case 'agent':
+      return {
+        kind: 'terminal',
+        startup: buildSidebarAgentStartup(store, worktree, descriptor.agent, 'new')
+      }
+    case 'browser': {
+      if (!canCreateNonTerminalDefaultSurface(store, worktree.id)) {
+        return { kind: 'fallback-terminal' }
+      }
+      const tabId = createDefaultBrowserSurface(store, worktree.id)
+      return tabId ? { kind: 'created', tabId } : { kind: 'fallback-terminal' }
+    }
+  }
+}

--- a/src/renderer/src/lib/worktree-activation-default-tab.test.ts
+++ b/src/renderer/src/lib/worktree-activation-default-tab.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings, Worktree } from '../../../shared/types'
+import type { DefaultWorkspaceTab } from '../../../shared/default-workspace-tab'
+import { useAppStore } from '@/store'
+import { activateAndRevealWorktree } from './worktree-activation'
+import { makeCreatedAgentWorktree } from '@/lib/worktree-activation-created-agent-test-state'
+
+type AppStoreState = ReturnType<typeof useAppStore.getState>
+
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+// A worktree not created with an agent, so `buildCreatedAgentReopenStartup`
+// stays out of the way and the default-workspace-tab setting takes effect.
+function makePlainWorktree(): Worktree {
+  return { ...makeCreatedAgentWorktree(), createdWithAgent: undefined }
+}
+
+function seedEmptyWorktree(
+  worktree: Worktree,
+  defaultWorkspaceTab: DefaultWorkspaceTab,
+  overrides: Partial<ReturnType<typeof useAppStore.getState>> = {}
+): void {
+  useAppStore.setState({
+    repos: [
+      {
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000000',
+        addedAt: 0
+      }
+    ],
+    worktreesByRepo: { 'repo-1': [worktree] },
+    activeRepoId: 'repo-1',
+    activeView: 'terminal',
+    tabsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    activeGroupIdByWorktree: {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    activeFileIdByWorktree: {},
+    activeBrowserTabIdByWorktree: {},
+    activeTabTypeByWorktree: {},
+    activeTabIdByWorktree: {},
+    tabBarOrderByWorktree: {},
+    pendingStartupByTabId: {},
+    settings: {
+      agentCmdOverrides: {},
+      setupScriptLaunchMode: 'new-tab',
+      defaultWorkspaceTab
+    } as unknown as GlobalSettings,
+    markWorktreeVisited: vi.fn(),
+    recordWorktreeVisit: vi.fn(),
+    refreshGitHubForWorktreeIfStale: vi.fn(),
+    revealWorktreeInSidebar: vi.fn(),
+    ...overrides
+  })
+}
+
+describe('activateAndRevealWorktree default workspace tab', () => {
+  it('opens a plain terminal when the default is terminal', () => {
+    const worktree = makePlainWorktree()
+    seedEmptyWorktree(worktree, { kind: 'terminal' })
+
+    const result = activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const tab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(tab).toBeDefined()
+    expect(result).toEqual({ primaryTabId: tab?.id })
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(state.browserTabsByWorktree[worktree.id] ?? []).toHaveLength(0)
+  })
+
+  it('seeds the first terminal with the configured default agent', () => {
+    const worktree = makePlainWorktree()
+    seedEmptyWorktree(worktree, { kind: 'agent', agent: 'codex' })
+
+    const result = activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const tab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(tab).toBeDefined()
+    expect(result).toEqual({ primaryTabId: tab?.id })
+    expect(state.pendingStartupByTabId[tab!.id]).toMatchObject({
+      launchAgent: 'codex',
+      telemetry: { agent_kind: 'codex', launch_source: 'sidebar', request_kind: 'new' }
+    })
+  })
+
+  it('opens a browser surface when the default is browser', () => {
+    const worktree = makePlainWorktree()
+    const createBrowserTab = vi.fn(() => ({ id: 'browser-1' }))
+    seedEmptyWorktree(
+      worktree,
+      { kind: 'browser' },
+      {
+        createBrowserTab: createBrowserTab as unknown as AppStoreState['createBrowserTab']
+      }
+    )
+
+    const result = activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+
+    expect(createBrowserTab).toHaveBeenCalledWith(
+      worktree.id,
+      expect.any(String),
+      expect.objectContaining({ activate: true })
+    )
+    expect(result).toEqual({ primaryTabId: 'browser-1' })
+    // The browser surface replaces the terminal — no terminal tab is created.
+    expect(state.tabsByWorktree[worktree.id]).toBeUndefined()
+  })
+
+  it('does not override an existing surface with a non-terminal default', () => {
+    const worktree = makePlainWorktree()
+    const createBrowserTab = vi.fn()
+    seedEmptyWorktree(
+      worktree,
+      { kind: 'browser' },
+      {
+        createBrowserTab: createBrowserTab as unknown as AppStoreState['createBrowserTab'],
+        tabsByWorktree: {
+          [worktree.id]: [
+            {
+              id: 'tab-1',
+              ptyId: 'pty-1',
+              worktreeId: worktree.id,
+              title: 'Terminal 1',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        unifiedTabsByWorktree: {
+          [worktree.id]: [
+            {
+              id: 'tab-1',
+              entityId: 'tab-1',
+              groupId: 'group-1',
+              worktreeId: worktree.id,
+              contentType: 'terminal',
+              label: 'Terminal 1',
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        groupsByWorktree: {
+          [worktree.id]: [
+            { id: 'group-1', worktreeId: worktree.id, activeTabId: 'tab-1', tabOrder: ['tab-1'] }
+          ]
+        },
+        activeGroupIdByWorktree: { [worktree.id]: 'group-1' }
+      }
+    )
+
+    const result = activateAndRevealWorktree(worktree.id)
+
+    expect(createBrowserTab).not.toHaveBeenCalled()
+    expect(result).toEqual({ primaryTabId: null })
+  })
+
+  it('resolves a terminal-shell default to a shell override on a local Windows host', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' })
+    const worktree = makePlainWorktree()
+    const createTab = vi.fn(() => ({ id: 'shell-tab' }))
+    seedEmptyWorktree(
+      worktree,
+      { kind: 'terminal-shell', shell: 'cmd.exe' },
+      {
+        createTab: createTab as unknown as AppStoreState['createTab'],
+        setActiveTab: vi.fn()
+      }
+    )
+
+    activateAndRevealWorktree(worktree.id)
+
+    expect(createTab).toHaveBeenCalledWith(
+      worktree.id,
+      undefined,
+      'cmd.exe',
+      expect.objectContaining({ pendingActivationSpawn: true })
+    )
+  })
+
+  it('falls back to a plain terminal for a shell default on a non-Windows host', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)' })
+    const worktree = makePlainWorktree()
+    const createTab = vi.fn(() => ({ id: 'plain-tab' }))
+    seedEmptyWorktree(
+      worktree,
+      { kind: 'terminal-shell', shell: 'cmd.exe' },
+      {
+        createTab: createTab as unknown as AppStoreState['createTab'],
+        setActiveTab: vi.fn()
+      }
+    )
+
+    activateAndRevealWorktree(worktree.id)
+
+    // No shell override — a remote/non-Windows host gets a plain terminal.
+    expect(createTab).toHaveBeenCalledWith(
+      worktree.id,
+      undefined,
+      undefined,
+      expect.objectContaining({ pendingActivationSpawn: true })
+    )
+  })
+
+  it('lets an explicit startup take precedence over the default tab', () => {
+    const worktree = makePlainWorktree()
+    const createBrowserTab = vi.fn()
+    seedEmptyWorktree(
+      worktree,
+      { kind: 'browser' },
+      { createBrowserTab: createBrowserTab as unknown as AppStoreState['createBrowserTab'] }
+    )
+
+    const result = activateAndRevealWorktree(worktree.id, {
+      startup: { command: 'echo precedence' }
+    })
+    const state = useAppStore.getState()
+    const tab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(createBrowserTab).not.toHaveBeenCalled()
+    expect(tab).toBeDefined()
+    expect(result).toEqual({ primaryTabId: tab?.id })
+    expect(state.pendingStartupByTabId[tab!.id]).toMatchObject({ command: 'echo precedence' })
+  })
+
+  it('lets a created-with-agent reopen take precedence over the default tab', () => {
+    // makeCreatedAgentWorktree seeds createdWithAgent: 'codex'.
+    const worktree = makeCreatedAgentWorktree()
+    const createBrowserTab = vi.fn()
+    seedEmptyWorktree(
+      worktree,
+      { kind: 'browser' },
+      { createBrowserTab: createBrowserTab as unknown as AppStoreState['createBrowserTab'] }
+    )
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const tab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(createBrowserTab).not.toHaveBeenCalled()
+    expect(tab).toBeDefined()
+    expect(state.pendingStartupByTabId[tab!.id]).toMatchObject({
+      launchAgent: 'codex',
+      telemetry: { request_kind: 'resume' }
+    })
+  })
+})

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -19,10 +19,6 @@ import { shouldAutoCreateInitialTerminal } from '@/components/terminal/initial-t
 import { buildSetupRunnerCommand } from './setup-runner'
 import { createSequencedSetupAgentCommands } from '../../../shared/setup-agent-sequencing'
 import { getSetupRunnerCommandPlatformForPath } from '../../../shared/setup-runner-command'
-import { buildAgentStartupPlan } from './tui-agent-startup'
-import { getAgentLaunchPlatformForRepo } from '@/lib/agent-launch-platform'
-import { CLIENT_PLATFORM } from './new-workspace'
-import { tuiAgentToAgentKind } from './telemetry'
 import { agentKindToTuiAgent } from '../../../shared/agent-kind'
 import { useAppStore } from '@/store'
 import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
@@ -42,15 +38,9 @@ import {
   setWorktreeNavActivator,
   setWorktreeNavViewActivator
 } from '@/store/slices/worktree-nav-history'
-import {
-  resolveTuiAgentLaunchArgs,
-  resolveTuiAgentLaunchEnv
-} from '../../../shared/tui-agent-launch-defaults'
 import { isTuiAgent } from '../../../shared/tui-agent-config'
-import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
 import { queueHookCommandsForFirstWorktreeTab } from '@/lib/hook-command-delayed-delivery'
-import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import {
   getRuntimeEnvironmentIdForWorktree,
   type WorktreeRuntimeOwnerState
@@ -65,6 +55,11 @@ import { toast } from 'sonner'
 import { initialAgentTabViewModeProps } from './native-chat-initial-view-mode'
 import { getConnectionId } from '@/lib/connection-context'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
+import { normalizeDefaultWorkspaceTab } from '../../../shared/default-workspace-tab'
+import {
+  buildSidebarAgentStartup,
+  resolveDefaultWorkspaceSurface
+} from './open-default-workspace-tab'
 
 /** Telemetry payload threaded from the launch site to `pty:spawn`. Main
  *  fires `agent_started` only after the spawn succeeds — see
@@ -243,44 +238,56 @@ function buildCreatedAgentReopenStartup(worktree: Worktree): WorktreeStartupPayl
   if (!isTuiAgent(agent)) {
     return undefined
   }
+  return buildSidebarAgentStartup(useAppStore.getState(), worktree, agent, 'resume')
+}
 
+/**
+ * Opens the surface a worktree should show on first activation. On a plain
+ * activation (no startup/setup/issue/default-tabs/cwd work) it honors the user's
+ * `defaultWorkspaceTab` setting, reusing the "+" menu's surface creators; every
+ * other case — and any surface that cannot be created on the current host —
+ * falls back to the existing initial-terminal behavior.
+ */
+function openWorktreeInitialSurface(
+  worktreeId: string,
+  worktree: Worktree,
+  startup: WorktreeStartupPayload | undefined,
+  setup: WorktreeSetupLaunch | undefined,
+  issueCommand: IssueCommandLaunch | undefined,
+  defaultTabs: WorktreeDefaultTabsLaunch | undefined,
+  hasInitialCwd: boolean
+): string | null {
   const state = useAppStore.getState()
-  const repo = state.repos.find((entry) => entry.id === worktree.repoId)
-  const launchPlatform = repo
-    ? getAgentLaunchPlatformForRepo(
-        repo,
-        repo.connectionId ? undefined : getLocalProjectExecutionRuntimeContext(state, worktree.id)
-      )
-    : CLIENT_PLATFORM
+  const hasActivationWork = Boolean(
+    startup || setup || issueCommand || defaultTabs || hasInitialCwd
+  )
+  let effectiveStartup = startup
+  let shellOverride: string | undefined
 
-  const startupPlan = buildAgentStartupPlan({
-    agent,
-    prompt: '',
-    cmdOverrides: state.settings?.agentCmdOverrides ?? {},
-    agentArgs: resolveTuiAgentLaunchArgs(agent, state.settings?.agentDefaultArgs),
-    agentEnv: resolveTuiAgentLaunchEnv(agent, state.settings?.agentDefaultEnv),
-    platform: launchPlatform,
-    isRemote: repo ? repoIsRemote(repo) : false,
-    allowEmptyPromptLaunch: true
-  })
-  if (!startupPlan) {
-    return undefined
-  }
-
-  return {
-    command: startupPlan.launchCommand,
-    ...(startupPlan.env ? { env: startupPlan.env } : {}),
-    launchConfig: startupPlan.launchConfig,
-    launchAgent: agent,
-    ...(startupPlan.startupCommandDelivery
-      ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
-      : {}),
-    telemetry: {
-      agent_kind: tuiAgentToAgentKind(agent),
-      launch_source: 'sidebar',
-      request_kind: 'resume'
+  if (!hasActivationWork) {
+    const descriptor = normalizeDefaultWorkspaceTab(state.settings?.defaultWorkspaceTab)
+    if (descriptor.kind !== 'terminal') {
+      const outcome = resolveDefaultWorkspaceSurface(state, worktree, descriptor)
+      if (outcome.kind === 'created') {
+        return outcome.tabId
+      }
+      if (outcome.kind === 'terminal') {
+        effectiveStartup = outcome.startup ?? startup
+        shellOverride = outcome.shellOverride
+      }
+      // 'fallback-terminal' → fall through to a plain terminal below.
     }
   }
+
+  return ensureWorktreeHasInitialTerminal(
+    state,
+    worktreeId,
+    effectiveStartup,
+    setup,
+    issueCommand,
+    defaultTabs,
+    shellOverride !== undefined ? { shellOverride } : undefined
+  )
 }
 
 export function activateAndRevealWorktree(
@@ -363,13 +370,14 @@ export function activateAndRevealWorktree(
   resumeSleepingAgentSessionsForWorktree(worktreeId)
 
   // 4. Ensure a focusable surface exists for externally-created worktrees
-  const primaryTabId = ensureWorktreeHasInitialTerminal(
-    useAppStore.getState(),
+  const primaryTabId = openWorktreeInitialSurface(
     worktreeId,
+    wt,
     opts?.startup ?? buildCreatedAgentReopenStartup(wt),
     opts?.setup,
     opts?.issueCommand,
-    opts?.defaultTabs
+    opts?.defaultTabs,
+    opts?.initialCwd !== undefined
   )
   if (primaryTabId && opts?.initialCwd) {
     useAppStore.getState().queueTabInitialCwd(primaryTabId, opts.initialCwd)
@@ -461,7 +469,7 @@ export function ensureWorktreeHasInitialTerminal(
   setup?: WorktreeSetupLaunch,
   issueCommand?: IssueCommandLaunch,
   defaultTabs?: WorktreeDefaultTabsLaunch,
-  opts?: { activateCreatedTabs?: boolean }
+  opts?: { activateCreatedTabs?: boolean; shellOverride?: string }
 ): string | null {
   const { renderableTabCount } = store.reconcileWorktreeTabModel(worktreeId)
   // Why: activation can now restore editor- or browser-only worktrees from the
@@ -577,7 +585,7 @@ export function ensureWorktreeHasInitialTerminal(
     (sequencedStartup?.telemetry
       ? (agentKindToTuiAgent(sequencedStartup.telemetry.agent_kind) ?? undefined)
       : undefined)
-  const terminalTab = store.createTab(worktreeId, undefined, undefined, {
+  const terminalTab = store.createTab(worktreeId, undefined, opts?.shellOverride, {
     pendingActivationSpawn: true,
     ...(launchAgent
       ? {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -23,6 +23,7 @@ import { DEFAULT_OPEN_IN_APPLICATIONS } from './open-in-applications'
 import { DEFAULT_BROWSER_PAGE_ZOOM_LEVEL } from './browser-page-zoom'
 import { DEFAULT_DISABLED_TUI_AGENTS } from './tui-agent-selection'
 import { DEFAULT_TUI_AGENT_ARGS, DEFAULT_TUI_AGENT_ENV } from './tui-agent-launch-defaults'
+import { DEFAULT_WORKSPACE_TAB } from './default-workspace-tab'
 import { UI_LANGUAGE_SYSTEM } from './ui-language'
 import {
   DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
@@ -276,6 +277,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     localhostWorktreeLabelsEnabled: false,
     openLinksInAppPreferencePrompted: false,
     openAgentTabsInChatByDefault: false,
+    defaultWorkspaceTab: { ...DEFAULT_WORKSPACE_TAB },
     experimentalNativeChat: false,
     openInApplications: [...DEFAULT_OPEN_IN_APPLICATIONS],
     rightSidebarOpenByDefault: true,

--- a/src/shared/default-workspace-tab.test.ts
+++ b/src/shared/default-workspace-tab.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_WORKSPACE_TAB,
+  normalizeDefaultWorkspaceTab,
+  parseDefaultWorkspaceTab,
+  serializeDefaultWorkspaceTab
+} from './default-workspace-tab'
+
+describe('normalizeDefaultWorkspaceTab', () => {
+  it('coerces missing or unrecognized values to a terminal', () => {
+    expect(normalizeDefaultWorkspaceTab(undefined)).toEqual({ kind: 'terminal' })
+    expect(normalizeDefaultWorkspaceTab(null)).toEqual({ kind: 'terminal' })
+    expect(normalizeDefaultWorkspaceTab('terminal')).toEqual({ kind: 'terminal' })
+    expect(normalizeDefaultWorkspaceTab({})).toEqual({ kind: 'terminal' })
+    expect(normalizeDefaultWorkspaceTab({ kind: 'nonsense' })).toEqual({ kind: 'terminal' })
+  })
+
+  it('keeps valid terminal and browser descriptors', () => {
+    expect(normalizeDefaultWorkspaceTab({ kind: 'terminal' })).toEqual({ kind: 'terminal' })
+    expect(normalizeDefaultWorkspaceTab({ kind: 'browser' })).toEqual({ kind: 'browser' })
+  })
+
+  it('validates the shell of a terminal-shell descriptor', () => {
+    expect(
+      normalizeDefaultWorkspaceTab({ kind: 'terminal-shell', shell: 'powershell.exe' })
+    ).toEqual({ kind: 'terminal-shell', shell: 'powershell.exe' })
+    expect(normalizeDefaultWorkspaceTab({ kind: 'terminal-shell', shell: 'git-bash' })).toEqual({
+      kind: 'terminal-shell',
+      shell: 'git-bash'
+    })
+    // An unrecognized (or dropped) shell degrades to a plain terminal.
+    expect(normalizeDefaultWorkspaceTab({ kind: 'terminal-shell', shell: 'bash' })).toEqual({
+      kind: 'terminal'
+    })
+    expect(normalizeDefaultWorkspaceTab({ kind: 'terminal-shell' })).toEqual({ kind: 'terminal' })
+  })
+
+  it('validates the agent of an agent descriptor', () => {
+    expect(normalizeDefaultWorkspaceTab({ kind: 'agent', agent: 'claude' })).toEqual({
+      kind: 'agent',
+      agent: 'claude'
+    })
+    // An agent id removed in a later version degrades to a plain terminal.
+    expect(normalizeDefaultWorkspaceTab({ kind: 'agent', agent: 'not-a-real-agent' })).toEqual({
+      kind: 'terminal'
+    })
+    expect(normalizeDefaultWorkspaceTab({ kind: 'agent' })).toEqual({ kind: 'terminal' })
+  })
+})
+
+describe('serializeDefaultWorkspaceTab and parseDefaultWorkspaceTab', () => {
+  it('round-trips every descriptor kind', () => {
+    const descriptors = [
+      { kind: 'terminal' },
+      { kind: 'browser' },
+      { kind: 'terminal-shell', shell: 'cmd.exe' },
+      { kind: 'agent', agent: 'claude' }
+    ] as const
+    for (const descriptor of descriptors) {
+      expect(parseDefaultWorkspaceTab(serializeDefaultWorkspaceTab(descriptor))).toEqual(descriptor)
+    }
+  })
+
+  it('serializes to stable string ids', () => {
+    expect(serializeDefaultWorkspaceTab({ kind: 'terminal' })).toBe('terminal')
+    expect(serializeDefaultWorkspaceTab({ kind: 'browser' })).toBe('browser')
+    expect(serializeDefaultWorkspaceTab({ kind: 'terminal-shell', shell: 'wsl.exe' })).toBe(
+      'terminal-shell:wsl.exe'
+    )
+    expect(serializeDefaultWorkspaceTab({ kind: 'agent', agent: 'codex' })).toBe('agent:codex')
+  })
+
+  it('parses invalid serialized values back to a terminal', () => {
+    expect(parseDefaultWorkspaceTab('agent:not-real')).toEqual({ kind: 'terminal' })
+    expect(parseDefaultWorkspaceTab('terminal-shell:nope')).toEqual({ kind: 'terminal' })
+    expect(parseDefaultWorkspaceTab('garbage')).toEqual({ kind: 'terminal' })
+  })
+
+  it('defaults to a plain terminal', () => {
+    expect(DEFAULT_WORKSPACE_TAB).toEqual({ kind: 'terminal' })
+  })
+})

--- a/src/shared/default-workspace-tab.ts
+++ b/src/shared/default-workspace-tab.ts
@@ -1,0 +1,103 @@
+import type { TuiAgent } from './types'
+import { isTuiAgent } from './tui-agent-config'
+import type { BuiltInWindowsTerminalShell } from './windows-terminal-shell'
+import { WINDOWS_GIT_BASH_SHELL } from './windows-terminal-shell'
+
+/**
+ * The surface Orca opens when a workspace is first activated from the sidebar
+ * and has no existing tab. Mirrors the concrete choices in the "+" new-tab menu
+ * so the configurable default stays in sync with what a user can create by hand.
+ * `terminal` preserves the historical behavior and is the default; document
+ * actions (New/Open Markdown) are intentionally excluded because they are
+ * one-shot file operations, not a surface to reopen a workspace into.
+ */
+export type DefaultWorkspaceTab =
+  | { kind: 'terminal' }
+  | { kind: 'terminal-shell'; shell: BuiltInWindowsTerminalShell }
+  | { kind: 'agent'; agent: TuiAgent }
+  | { kind: 'browser' }
+
+// Why: frozen + copied at every hand-off (like the other object/array defaults
+// in getDefaultSettings) so a shared reference can never be mutated in place and
+// corrupt the default for other callers/profiles.
+export const DEFAULT_WORKSPACE_TAB: Readonly<DefaultWorkspaceTab> = { kind: 'terminal' }
+
+const BUILT_IN_WINDOWS_SHELLS: readonly BuiltInWindowsTerminalShell[] = [
+  'powershell.exe',
+  'cmd.exe',
+  'wsl.exe',
+  WINDOWS_GIT_BASH_SHELL
+]
+
+function isBuiltInWindowsTerminalShell(value: unknown): value is BuiltInWindowsTerminalShell {
+  return (
+    typeof value === 'string' &&
+    BUILT_IN_WINDOWS_SHELLS.includes(value as BuiltInWindowsTerminalShell)
+  )
+}
+
+/**
+ * Coerces a persisted (and therefore untrusted) settings value into a valid
+ * descriptor, falling back to a plain terminal for anything unrecognized — e.g.
+ * a shell or agent id dropped in a later version. Whether the surface is
+ * actually creatable on the current host (SSH/remote/platform) is a separate
+ * runtime concern resolved at activation time.
+ */
+export function normalizeDefaultWorkspaceTab(value: unknown): DefaultWorkspaceTab {
+  if (!value || typeof value !== 'object') {
+    return { ...DEFAULT_WORKSPACE_TAB }
+  }
+  const kind = (value as { kind?: unknown }).kind
+  switch (kind) {
+    case 'terminal':
+      return { kind: 'terminal' }
+    case 'browser':
+      return { kind: 'browser' }
+    case 'terminal-shell': {
+      const shell = (value as { shell?: unknown }).shell
+      return isBuiltInWindowsTerminalShell(shell)
+        ? { kind: 'terminal-shell', shell }
+        : { ...DEFAULT_WORKSPACE_TAB }
+    }
+    case 'agent': {
+      const agent = (value as { agent?: unknown }).agent
+      return isTuiAgent(agent) ? { kind: 'agent', agent } : { ...DEFAULT_WORKSPACE_TAB }
+    }
+    default:
+      return { ...DEFAULT_WORKSPACE_TAB }
+  }
+}
+
+const TERMINAL_SHELL_PREFIX = 'terminal-shell:'
+const AGENT_PREFIX = 'agent:'
+
+/**
+ * Stable string id for a descriptor, used as the value of the settings
+ * `<Select>`. Round-trips through {@link parseDefaultWorkspaceTab}.
+ */
+export function serializeDefaultWorkspaceTab(tab: DefaultWorkspaceTab): string {
+  switch (tab.kind) {
+    case 'terminal':
+      return 'terminal'
+    case 'browser':
+      return 'browser'
+    case 'terminal-shell':
+      return `${TERMINAL_SHELL_PREFIX}${tab.shell}`
+    case 'agent':
+      return `${AGENT_PREFIX}${tab.agent}`
+  }
+}
+
+/** Inverse of {@link serializeDefaultWorkspaceTab}; invalid input → terminal. */
+export function parseDefaultWorkspaceTab(value: string): DefaultWorkspaceTab {
+  if (value.startsWith(TERMINAL_SHELL_PREFIX)) {
+    return normalizeDefaultWorkspaceTab({
+      kind: 'terminal-shell',
+      shell: value.slice(TERMINAL_SHELL_PREFIX.length)
+    })
+  }
+  if (value.startsWith(AGENT_PREFIX)) {
+    return normalizeDefaultWorkspaceTab({ kind: 'agent', agent: value.slice(AGENT_PREFIX.length) })
+  }
+  return normalizeDefaultWorkspaceTab({ kind: value })
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,6 +12,7 @@ import type {
 import type { VoiceSettings } from './speech-types'
 import type { WorkspaceCleanupUIState } from './workspace-cleanup'
 import type { LargeDiffRenderLimit } from './large-diff-render-limit'
+import type { DefaultWorkspaceTab } from './default-workspace-tab'
 import type { GitLabProjectSettings } from './gitlab-types'
 import type { TaskProvider } from './task-providers'
 import type { FeatureTipId } from './feature-tips'
@@ -2647,6 +2648,11 @@ export type GlobalSettings = {
    *  view instead of the raw terminal. Off by default so existing workflows are
    *  unchanged. Optional for legacy-settings compatibility; defaults applied. */
   openAgentTabsInChatByDefault?: boolean
+  /** Which surface a workspace opens into when first activated from the sidebar
+   *  and it has no existing tab. Mirrors the "+" new-tab menu (terminal, a
+   *  specific shell, a coding agent, or a browser). Defaults to a plain terminal
+   *  so existing behavior is unchanged. Optional for legacy-settings compat. */
+  defaultWorkspaceTab?: DefaultWorkspaceTab
   /** Experimental: native chat surface for Claude/Codex terminal sessions.
    *  Off by default while the desktop UX is still being exercised. */
   experimentalNativeChat?: boolean


### PR DESCRIPTION
## Summary

Adds a **Default Tab** setting (Settings → General → Workspace) that controls which surface a workspace opens into the **first time** you activate it from the left sidebar. Today that is always a terminal, which is friction for people whose primary surface is something else.

The picker **consumes the same option builder as the new-tab (+) menu** (`buildTabCreateMenuOptions` + the agent launch options), so the list, labels, **icons**, and localized text are a single source of truth — a new shell or agent added to the (+) menu shows up here automatically, with no parallel list to maintain. This PR wires four surfaces as first-open defaults:

- **Terminal** (default — existing behavior, unchanged)
- **Terminal: <shell>** — a specific Windows shell (PowerShell / CMD / Git Bash / WSL), shown only on Windows-capable hosts
- **Agent** — a specific coding agent (Claude, Codex, …), reusing the exact startup recipe as the "reopen a worktree created with an agent" flow
- **Web Browser**

Mobile Emulator and Markdown are intentionally **not** offered as first-open defaults (the emulator needs a pre-existing tab group + attach lifecycle; New/Open Markdown are one-shot file actions).

Resolves #8235.

### How it works

- The setting is stored as a small, serializable descriptor (`DefaultWorkspaceTab`) that defaults to `{ kind: 'terminal' }`, so existing users see **no behavior change**.
- On a *plain* first activation (no startup / setup / issue-command / `.orca.yaml` default-tabs / cwd work), `activateAndRevealWorktree` resolves the descriptor and reuses the same store methods the (+) menu uses — `createBrowserTab` for browser, the shared agent-startup builder for agents, and `createTab`'s `shellOverride` for shells.
- Any surface that **cannot** be created on the current host (SSH/remote, non-Windows, runtime-mirrored web session, or a stored agent/shell that no longer exists) **degrades gracefully to a plain terminal**. Repo/task-driven activations (agent reopen, setup scripts, `.orca.yaml` `defaultTabs`) continue to take precedence over the generic default.
- The "reopen created-with-agent worktree" path was refactored to share one agent-startup builder (`buildSidebarAgentStartup`) with the new agent default — no duplicated launch logic.

## Screenshots

New control in **Settings → General → Workspace**: a "Default Tab" dropdown (shadcn `Select`) that renders each option with the **same icon + label as the (+) new-tab menu** — terminal, the available Windows shells, Web Browser, and detected agents (with their brand icons).

_No screenshot attached from this environment; the change is a single new settings dropdown built from existing shadcn primitives + the (+) menu's own option/icon source, following `docs/STYLEGUIDE.md`. Happy to attach one from a running build on request._

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (added tests + all directly-affected suites; see note)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New tests:
- `src/shared/default-workspace-tab.test.ts` — descriptor normalize / serialize / parse, including invalid-value and dropped-agent/shell degradation to terminal.
- `src/renderer/src/lib/worktree-activation-default-tab.test.ts` — activation opens the configured terminal / **terminal-shell** / agent / browser surface; a shell default resolves to a `shellOverride` on a local Windows host and **falls back to a plain terminal off Windows**; and an explicit **startup**, an existing surface, and a **created-with-agent reopen** all take **precedence** over the configured default.

Regression coverage run locally: `worktree-activation*.test.ts`, `constants.test.ts` + settings slice + `src/main/ipc/settings.test.ts`, `GeneralPane.test.ts`, plus the two new suites — all green. Full lint gate (oxlint, switch-exhaustiveness, max-lines ratchet, styled-scrollbars, reliability-gates, localization catalog + coverage) passes.

## AI Review Report

Reviewed the diff with a focus on the repo's contribution constraints:

- **Cross-platform (macOS/Linux/Windows):** No keyboard shortcuts, labels, or hardcoded path separators were added. "Terminal: <shell>" is the only platform-specific option and is gated to Windows-capable hosts both in the picker (via `useWindowsTerminalCapabilities`) and at activation (Windows client + local worktree only); everything else is platform-neutral.
- **SSH / remote / local:** Shell override only applies to a **local** worktree on a Windows client — remote/SSH hosts (unknown platform) fall back to a plain terminal rather than risk spawning an invalid shell. Browser default skips runtime-mirrored web sessions (host owns tab creation) and falls back. Agent default reuses `getAgentLaunchPlatformForRepo` / `repoIsRemote`, the same remote-aware path as the existing reopen flow.
- **Agent / integration / git-provider compatibility:** The agent option is provider-neutral — it reuses the existing `buildAgentStartupPlan` recipe and the shared agent catalog/detection; no agent-specific or provider-specific branching was introduced.
- **Performance:** The activation hot path adds one settings read + a descriptor normalize; for the default `terminal` case it short-circuits on `descriptor.kind !== 'terminal'` before any extra work, so the common path is effectively unchanged. Non-terminal defaults do one extra tab-model reconcile only when the worktree has no surface yet.
- **UI quality:** Uses existing shadcn `Select` + `SettingsRow` + `SearchableSetting`, and the (+) menu's own icons/labels; no new color/size/shadow tokens. Keeps the stored agent/shell visible in the trigger even if not currently detected.
- **Security:** See below.

## Security Audit

- **Command execution:** The agent default does not build new command strings itself — it delegates to the existing `buildAgentStartupPlan`, and the shell override goes through the existing `resolveWindowsShellLaunchTarget`. No new user-controlled string reaches a shell.
- **Untrusted input:** `defaultWorkspaceTab` is persisted settings (potentially stale/hand-edited), so it is validated via `normalizeDefaultWorkspaceTab` on read — unknown kinds, invalid shells, and unknown agent ids all coerce to a safe terminal.
- **IPC / auth / secrets:** No IPC surface, auth, or secret handling was added or changed.
- **Path handling:** No filesystem path construction was added.

## Notes

- **CodeRabbit feedback addressed:**
  - _"Add coverage for shell defaults and activation precedence"_ → added `terminal-shell` and precedence tests (explicit startup, existing surface, created-with-agent reopen) as noted above.
  - _"Use this component's locale namespace for shell labels"_ → resolved by **reusing the (+) menu's option builder** instead of copying labels: the picker now consumes `buildTabCreateMenuOptions`, so option labels/icons/translations come from the canonical shared source (single source of truth) rather than duplicated component-scoped strings. Only the setting's own title/description are new keys.
- **Localization:** the only new catalog keys are the setting's `title` and `description`, translated into `es / ja / ko / zh` (not English placeholders), matching Orca's existing term choices (workspace / tab / sidebar / default).
- **Rebased** onto the latest `main`; the only overlap was locale files + `types.ts`, resolved cleanly (locales regenerated).
- Scope was deliberately limited to Terminal / Shell / Agent / Browser; **Mobile Emulator** and **Markdown** are documented follow-ups.

## Follow-up suggestions (out of scope — not implemented here)

These are product decisions beyond this PR; noting them for maintainers to consider:

1. **Surface the setting during first-time onboarding.** Add a short mention of the Default Tab in the new-user landing/guide so people discover they can change what opens on first activation.
2. **Offer an intentional first-use choice.** On first use, let the user deliberately pick their default tab (e.g., a one-time prompt or an onboarding step) instead of only discovering it later in Settings.

## X handle

_(optional — add your X/Twitter handle for a shoutout on merge)_

## ELI5

A new Default Tab setting controls what opens the first time you activate a workspace from the sidebar (not always a terminal). The choices match the new-tab menu so labels and icons stay consistent.
