### PR TITLE
fix(remote): harden runtime liveness and shared-control recovery

### DIFF
--- a/docs/reference/2026-07-11-remote-runtime-terminal-recovery-design.md
+++ b/docs/reference/2026-07-11-remote-runtime-terminal-recovery-design.md
@@ -1,0 +1,335 @@
+# Design: Resilient Remote Orca terminal recovery
+
+**Date:** 2026-07-11
+
+**Issue:** [#8180](https://github.com/stablyai/orca/issues/8180)
+
+**Scope:** Desktop client, Remote Orca control/stream transports, and runtime WebSocket heartbeat
+
+**Status:** Approved; implementation is being delivered as a three-PR stack
+
+## Problem
+
+A recoverable client sleep or network-path interruption can leave a Remote Orca terminal permanently offline even though the remote runtime, PTY, and agent remain alive.
+
+The failure is a race between two independent WebSocket lanes:
+
+1. The dedicated `terminal.multiplex` socket detects silence and reports an error followed by close.
+2. The terminal pane reacts to close by making one `session.tabs.list` request on shared control so it can re-resolve the host-owned terminal handle.
+3. Shared control can still be half-open or reconnecting from the same interruption. If that single list request times out, it resets shared control.
+4. The failed request is not replayed and the pane has no retry trigger, so the remote task continues without a usable client terminal.
+
+The current liveness monitor can also misclassify the first timer tick after a long event-loop or system-sleep gap. It checks accumulated silence before giving a new post-resume probe a response window.
+
+This design fixes the ownership and recovery model. It does not merely increase timeout constants.
+
+## Goals
+
+- Treat sleep, event-loop pauses, half-open sockets, and network-path changes as recoverable transport events.
+- Preserve the logical terminal while physical sockets reconnect.
+- Re-resolve host-owned terminal handles from a fresh authoritative session snapshot.
+- Coalesce recovery work across panes that share an environment and worktree.
+- Retry transient recovery indefinitely, with bounded resource use, while at least one logical pane still exists.
+- Prevent old callbacks or ambiguous queued input from reaching a newly rebound handle.
+- Keep terminal and shared-control sockets separate.
+- Preserve compatibility with older Remote Orca runtimes.
+
+## Non-goals
+
+- Merging dedicated binary streams into shared control.
+- Recreating or killing the remote PTY during transport recovery.
+- Adding input sequence numbers, delivery acknowledgements, or exactly-once input semantics.
+- Automatically replaying arbitrary short RPC requests after a reconnect.
+- Adding a new terminal UI component. Existing remote-host status can show reconnecting; the pane keeps its last rendered buffer and must not show a fatal transport banner.
+- Changing pairing, encryption, or the runtime RPC wire protocol.
+
+## Current failure chain
+
+| Stage | Current behavior | Failure |
+| --- | --- | --- |
+| Socket liveness | `remote-runtime-socket-liveness.ts` compares wall-clock silence before sending the next ping. | A delayed first tick after sleep can declare the socket dead using only pre-pause evidence. |
+| Dedicated stream | `remote-runtime-client.ts` sends established failures through `onError` and then `onClose`. | A recoverable physical failure is presented as both fatal error and close. |
+| Multiplexer | `remote-runtime-terminal-multiplexer.ts` forwards the error to every stream before its close recovery callback. | Each pane can show a fatal error before recovery begins. |
+| Handle refresh | `remote-runtime-pty-transport.ts` performs one `session.tabs.list` and one resubscribe. | A shared-control race stops recovery permanently after the first failure. |
+| Shared control | A short request timeout tears down the entire control socket; subscription reconnect has a finite retry budget. | Unrelated inbound traffic cannot prove the socket alive, and a long outage exhausts logical subscriptions. |
+| Input | Debounced input is read against the current handle when it finally flushes. | Bytes queued before recovery can cross into a replacement handle unless recovery clears and fences them. |
+
+## Decision summary
+
+| Area | Decision | Why | Tradeoff |
+| --- | --- | --- | --- |
+| Liveness | Use pause-aware, probe-based liveness on client and server. Only an unanswered probe may kill a socket. | Raw elapsed silence after sleep is not proof of a dead connection. | Genuine death is detected after one full post-pause probe window instead of immediately on resume. |
+| Transport topology | Keep shared control and `terminal.multiplex` as separate sockets. | Binary terminal traffic must not head-of-line block control RPCs or subscriptions. | Recovery needs explicit coordination between the two lanes. |
+| Recovery ownership | Add one recovery coordinator per runtime environment, with worktree-scoped authoritative snapshot requests. | Panes currently retry independently and can stampede control RPCs. | Adds a small lifecycle state machine and registry. |
+| Snapshot source | During host-mirror recovery, wait on one temporary, coalesced `session.tabs.subscribe` snapshot instead of a one-shot `session.tabs.list`. | Shared-control subscriptions survive reconnect and replay an authoritative snapshot; a short RPC does not. | A temporary subscription exists during recovery, then closes after the generation settles. |
+| Retry policy | Exponential base delays from 250 ms to a 30 s cap, with actual jitter kept inside that cap while logical owners remain. System resume requests an immediate attempt. | A remote task may run for hours; a finite retry budget creates permanent client-side failure. | Persistent outages keep a low-frequency retry timer until panes close or the error is fatal. |
+| Error policy | Transport/liveness/timeout failures are recoverable. Authentication, invalid protocol, removed environment, and confirmed terminal-gone results are terminal. | Users should not see duplicate fatal banners for a reconnectable socket loss. | Error classification must preserve structured codes across the subscription boundary. |
+| Binding safety | Fence callbacks and asynchronous sends by recovery generation; commit a replacement binding atomically. | Handle equality alone is insufficient when the same handle string can reappear after reconnect. | Adds generation checks to existing handle checks. |
+| Input safety | Clear pending batches when recovery starts and reject new input until the new binding is ready. Never replay delivery-ambiguous bytes. | Sending old bytes to a new handle is worse than rejecting keystrokes during a short reconnect. | Keystrokes entered during recovery are not buffered; callers receive `false` and can retry. |
+| Short RPC timeout | Reject the timed-out request, but tear down shared control only if no valid inbound frame arrived after that request was sent. | A stuck method is not proof that the whole multiplexed control socket is dead. | Requires an inbound-activity generation counter. |
+
+## Architecture
+
+### 1. Pause-aware probe liveness
+
+`startRemoteRuntimeSocketLiveness` will track:
+
+- `lastInboundActivityAt`
+- `lastTickAt`
+- `probeSentAt: number | null`
+
+The behavior follows the existing `WebRuntimeClient` heartbeat invariant:
+
+1. If a tick arrives much later than its configured cadence, treat the gap as suspended execution, clear any old probe debt, and re-baseline time.
+2. If there is no outstanding probe and the socket has been idle long enough, send a ping and record `probeSentAt`.
+3. Close only when that sent probe remains unanswered for the full probe grace window while ticks continue normally.
+4. Any valid inbound frame, ping, or pong clears the outstanding probe and records activity.
+
+The first tick after a one-hour jump therefore cannot kill the socket. It re-baselines; a later normal tick sends a fresh probe; only that probe's full unanswered window can call `onDead`.
+
+The runtime server heartbeat in `src/main/runtime/rpc/ws-transport.ts` gets the same pause rule. If the runtime's own heartbeat loop was suspended, the first resumed tick marks existing sockets as unproven and sends a fresh ping instead of terminating all of them. A runtime that stayed awake may still reap a sleeping client's dead socket; the client recovery path must reconnect cleanly.
+
+No protocol changes are required because Node `ws` already answers RFC 6455 pings automatically.
+
+### 2. Structured dedicated-stream close
+
+The established dedicated subscription boundary already preserves `{ code, message }`. The multiplexer will distinguish:
+
+- startup failure before the subscription becomes ready: reject `subscribeTerminal()`;
+- remote terminal stream `error` event: deliver the terminal-specific error;
+- established physical socket loss with a recoverable code: deliver one `onTransportClose` event carrying the reason, without first calling pane `onError`;
+- fatal authentication/protocol failure: deliver one fatal error and close.
+
+This removes the current recoverable `onError` then `onClose` double delivery. It does not hide actual server-side terminal errors.
+
+### 3. Environment recovery coordinator
+
+Add `remote-runtime-terminal-recovery-coordinator.ts` in the renderer runtime layer. The module owns a registry keyed by runtime environment id. Each entry owns:
+
+- a monotonic recovery generation;
+- the current state: `idle`, `waiting-control`, `rebinding`, `backoff`, or `disposed`;
+- a cancellable retry timer;
+- registered pane recovery operations;
+- coalesced authoritative snapshot work keyed by worktree selector;
+- attempt count and local diagnostics.
+
+The coordinator does not own PTYs and never issues `terminal.create` or `terminal.close`.
+
+Each pane recovery registration provides:
+
+- its worktree and host surface identity, if it is a host mirror;
+- its last known handle;
+- a generation-fenced callback that resolves the next handle from a snapshot;
+- a callback that subscribes the dedicated stream;
+- a terminal-gone callback;
+- an abort signal tied to detach/destroy or a newer recovery generation.
+
+Multiple panes in the same environment/worktree await the same session snapshot. Snapshot entries are reference-counted: aborting one pane removes only that waiter, while aborting the final waiter closes the temporary subscription, cancels its timer, and removes the entry. Different worktrees in the same environment use different snapshot entries. Multiple dedicated resubscriptions still share the existing environment multiplexer and its single physical socket.
+
+The coordinator takes injected clock, scheduler, and snapshot-subscription seams. Production supplies real timers and `window.api.runtimeEnvironments`; tests drive each transition directly instead of relying on fake timers to auto-run every missed interval after a clock jump.
+
+### 4. Authoritative handle recovery
+
+For a host-mirrored terminal:
+
+1. Start or join the worktree's temporary `session.tabs.subscribe` recovery subscription.
+2. If the initial subscription cannot start because shared control is unavailable, retry its creation with capped backoff.
+3. Once established, let shared control retain and replay it across reconnects.
+4. Accept the first valid `snapshot` or `updated` result for the active recovery generation as authoritative.
+5. Resolve each pane's host tab/leaf to a ready terminal handle.
+6. Close the temporary recovery subscription after all current waiters have consumed the snapshot.
+
+If the snapshot confirms that the surface is gone, retire the local mirror without recreating or closing any remote PTY. If the surface exists but is not ready yet, remain in recovery and wait for a later subscription update.
+
+For a direct remote terminal whose handle is not host-published, skip the session snapshot and retry the known handle on a fresh dedicated stream. A server `terminal_handle_stale`, `terminal_exited`, `terminal_gone`, or `no_connected_pty` result retires it.
+
+### 5. Shared-control durability
+
+Shared-control logical subscriptions will no longer fail only because a fixed reconnect delay list was exhausted.
+
+- Recoverable transport errors use base delays of `250, 500, 1000, 2000, 4000, 8000, 15000, 30000` ms. Existing 20% jitter is preserved, and the saturated window shifts below the hard 30-second cap.
+- Closing the last logical subscription cancels the timer and allows the connection to become idle.
+- `unauthorized`, `invalid_argument`, and `invalid_runtime_response` stop retrying and notify subscribers once.
+- Successful readiness keeps the existing stable-window attempt reset, so short flaps do not create a tight loop.
+
+The recovery error matrix is explicit:
+
+| Error | Recovery action |
+| --- | --- |
+| `remote_runtime_unavailable`, `runtime_timeout`, abnormal network close | Retry with capped backoff. |
+| `unauthorized`, `invalid_argument`, `invalid_runtime_response` | Stop, cancel the generation, and surface one fatal error. |
+| Known terminal-gone result (`terminal_handle_stale`, `terminal_exited`, `terminal_gone`, `no_connected_pty`) | Retire that logical terminal without closing or recreating a PTY. |
+| Other `runtime_error` result | Do not classify it as transport loss; stop that operation and surface it once so invalid parameters cannot loop forever. |
+| Explicit environment removal, disconnect, pane detach, or pane destroy | Cancel timers/subscriptions and dispose without allowing late callbacks to reopen the connection. |
+
+Short RPCs remain at-most-once from the client's perspective. Each pending request records the shared-control inbound-activity generation at actual send time. On timeout:
+
+- always reject that request;
+- if no newer valid inbound frame has arrived, close the suspect socket so reconnect/replay can run;
+- if newer inbound traffic exists, keep the socket because the failure is method-specific, not connection-wide.
+
+Recovery does not depend on replaying a failed `session.tabs.list`; it uses the temporary logical subscription described above.
+
+### 6. Atomic terminal rebind and input fence
+
+Each remote PTY transport keeps an integer `bindingGeneration` in addition to its handle checks.
+
+When recovery begins:
+
+1. Increment the generation.
+2. Mark the binding `recovering` while preserving the rendered terminal buffer.
+3. Clear pending text and viewport sends associated with the old stream.
+4. Reject `sendInput`, `sendInputImmediate`, and acknowledged input that has not yet begun a current-generation send.
+5. Abort older snapshot/subscription work.
+
+The replacement handle and stream are staged separately. They become the active binding only after the dedicated multiplexer confirms subscription for the same generation. The initial terminal snapshot remains the authoritative display resync. Only then does input resume.
+
+Every data, snapshot, end, error, fit, driver, input continuation, and close callback captures both the binding generation and handle. A stale callback is ignored even if its handle string matches a later binding.
+
+Acknowledged multi-chunk input rechecks generation and handle between chunks. Bytes already handed to the old physical socket are never replayed because their delivery is ambiguous.
+
+Resize remains locally meaningful while input is paused. A resize during recovery updates only `desiredViewport`; it cannot use `terminal.updateViewport` against the old handle. The latest desired size is included in the generation's new dedicated subscribe request.
+
+### 7. Resume acceleration
+
+The renderer already receives `window.api.ui.onSystemResumed`. The terminal wake-recovery hook will also notify the Remote Orca recovery coordinator.
+
+Resume does not create a new recovery when all streams are healthy. It only cancels a pending backoff delay and requests an immediate attempt for entries already in `waiting-control` or `backoff`. Normal capped backoff resumes after a failed immediate attempt.
+
+## Recovery sequence
+
+```text
+dedicated stream closes
+  -> multiplexer emits one recoverable transport-close event
+  -> pane starts binding generation N and pauses input
+  -> environment coordinator coalesces panes
+       -> direct handle: reuse known handle
+       -> host mirror: await coalesced session-tabs subscription snapshot
+  -> coordinator asks shared multiplexer to subscribe all generation-N handles
+  -> dedicated stream confirms subscribe and sends authoritative terminal snapshot
+  -> pane atomically activates generation N and resumes input
+```
+
+At any asynchronous boundary, detach, destroy, a newer close, or a fatal error aborts generation N. Its later callbacks cannot mutate current pane state.
+
+## Expected file changes
+
+| Path | Change |
+| --- | --- |
+| `src/shared/remote-runtime-socket-liveness.ts` | Replace raw-silence death with pause-aware sent-probe tracking. |
+| `src/shared/remote-runtime-socket-liveness.test.ts` | New deterministic timer-jump, probe, activity, and dead-link tests. |
+| `src/main/runtime/rpc/ws-transport.ts` | Make server heartbeat pause-aware. |
+| `src/main/runtime/rpc/ws-transport.test.ts` | Prove first resumed server tick re-probes instead of terminating healthy sockets. |
+| `src/shared/remote-runtime-client.ts` | Preserve structured established-stream failure semantics. |
+| `src/shared/remote-runtime-client.test.ts` | Cover one close signal for established recoverable failure. |
+| `src/shared/remote-runtime-shared-control-{connection,reconnect,requests,state,types}.ts` | Add saturated retry, fatal classification, and inbound-activity generation. |
+| `src/shared/remote-runtime-shared-control-connection.test.ts` | Cover long outage recovery, fatal stop, request-only timeout, and silent-socket teardown. |
+| `src/renderer/src/runtime/remote-runtime-terminal-recovery-coordinator.ts` | New environment/worktree recovery state machine and snapshot coalescing. |
+| `src/renderer/src/runtime/remote-runtime-terminal-recovery-coordinator.test.ts` | New state, retry, coalescing, cancellation, and resume tests. |
+| `src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts` | Deliver recoverable physical close without a preceding fatal pane error; preserve codes/generations. |
+| `src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts` | Register recovery, stage atomic bindings, and fence input/callbacks. |
+| `src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts` | Extend two-lane recovery, multi-pane, stale callback, and input safety tests. |
+| `src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.ts` | Trigger immediate retry for already-recovering Remote Orca entries on OS resume. |
+
+The implementation may split an already-long module into concrete domain-named files. It must not add a max-lines suppression or a generic `helpers`/`utils` module.
+
+## Test plan
+
+### Deterministic unit and integration tests
+
+1. **Client liveness pause**
+   - Advance the injected clock by one hour before the next tick.
+   - Assert no `onDead` on that tick.
+   - Assert a fresh ping receives a full grace window.
+
+2. **Client liveness real death**
+   - Run normal-cadence ticks, send a probe, provide no activity, and advance beyond grace.
+   - Assert exactly one `onDead`.
+
+3. **Runtime heartbeat pause**
+   - Delay the server heartbeat by more than two cadences.
+   - Assert it re-arms/pings existing sockets and terminates only after the next unanswered normal-cadence window.
+
+4. **Shared-control request timeout**
+   - With no inbound activity after send, assert the request rejects and the socket reconnects.
+   - With an unrelated valid inbound frame after send, assert only the request rejects and the socket remains ready.
+
+5. **Shared-control long outage**
+   - Exhaust every backoff tier and verify retries remain capped at 30 seconds while a logical subscription exists.
+   - Restore connectivity and verify one replayed authoritative response.
+   - Verify fatal authentication/protocol errors stop once.
+
+6. **Two-lane terminal recovery regression**
+   - Establish a host-mirrored terminal.
+   - Blackhole both dedicated and shared-control sockets beyond their deadlines while leaving the fake remote PTY alive.
+   - Make the first recovery subscription start fail or time out.
+   - Restore control, emit one replayed session snapshot, then restore the dedicated stream.
+   - Assert the same remote PTY is rebound without manual refresh, create, or close.
+
+7. **Multi-pane coalescing**
+   - Recover two or more panes in one environment/worktree.
+   - Assert one temporary session-tabs subscription and one physical dedicated connection attempt.
+   - Recover another pane in a different worktree of the same environment and assert it uses a separate snapshot entry without opening a second physical dedicated connection.
+
+8. **Generation and input safety**
+   - Queue debounced input, start recovery, and rebind to a different handle.
+   - Assert the queued bytes never reach either the replacement stream or RPC fallback.
+   - Resolve old snapshot/subscribe/end/error callbacks after the new binding is active and assert they have no effect.
+   - Assert input returns `false` during recovery and works after the new subscription is confirmed.
+   - Resize during recovery and assert no old-handle RPC is sent; the next subscribe carries only the latest viewport.
+
+9. **Lifecycle cleanup**
+   - Destroy all waiting panes during backoff.
+   - Assert timers, temporary subscriptions, multiplexer streams, and registry entries are released.
+   - Explicitly disconnect or remove the environment, then resolve old promises and assert they cannot reopen or rebind anything.
+
+10. **Cross-lane event ordering**
+    - Parameterize `stream error -> control timeout -> resume`, `control timeout -> stream close -> resume`, and `resume -> late old response -> new response`.
+    - Assert each outage creates one active generation, no concurrent retry after resume, and no stale completion wins.
+
+### Real macOS to Windows verifier
+
+Before PR submission, verify against a physical Windows Remote Orca host with a macOS desktop client. Run one round with the same fix commit on both machines, then one backward-compatibility round with the patched Mac client against the current stable Windows runtime:
+
+1. Open three panes: two in one worktree and one in a second worktree. Start long-running PowerShell counters with distinct nonces and record runtime/terminal PIDs without publishing private host data.
+2. Suspend the Mac for 60–90 seconds so both liveness deadlines expire; optionally force a private-tunnel path change.
+3. Resume the Mac while the Windows runtime and tasks remain running.
+4. Confirm the client shows reconnecting rather than a fatal terminal error and all panes recover without manual refresh within 30 seconds of network reachability.
+5. Confirm the counters continue across the gap, runtime/terminal PIDs do not change, and unique input markers return only in their target panes.
+6. Confirm one snapshot recovery per environment/worktree generation, with no delayed or duplicate input after recovery.
+7. Repeat three times with the Mac awake while the network is unavailable beyond the liveness window, then restore it.
+8. Repeat with the Windows host unavailable longer than the old finite reconnect budget and verify recovery after it returns.
+
+Evidence attached to the PR must be sanitized. Do not include hostnames, addresses, usernames, filesystem paths, pairing data, task content, or raw screenshots containing private workspace state.
+
+## Verification gates
+
+The stack is ready only when all of the following pass:
+
+- Focused Vitest suites for liveness, shared control, multiplexer, recovery coordinator, and remote PTY transport.
+- Typecheck for the desktop/shared/preload surfaces touched by the change.
+- Oxc/lint and max-lines ratchet for changed files.
+- `git diff --check`.
+- The deterministic two-lane blackhole/recovery test.
+- The real macOS to physical Windows recovery verifier above.
+
+Any failure caused by the change is fixed before PR creation. An environment-only failure is reported with the exact skipped verifier and reason.
+
+## Rollout and rollback
+
+Deliver this as three linear stacked PRs:
+
+1. pause-aware client/server liveness and shared-control durability;
+2. cloneable subscription startup errors and structured dedicated-stream close semantics;
+3. the recovery coordinator, terminal rebind/input fencing, and deterministic integration coverage.
+
+The first two PRs reference #8180; only the final PR uses `Fixes #8180`. Each layer keeps the prior one-shot terminal recovery path usable until the final coordinator layer lands. The wire protocol is unchanged, so mixed desktop/runtime versions remain supported. Rollback proceeds in reverse stack order. Reverting the final layer restores the one-shot recovery behavior without persisted-state or server migration work; lower layers can then be reverted independently. The remote PTY is never mutated by the new coordinator, which limits rollback risk.
+
+## Resolved design choices
+
+- **Separate sockets or one socket?** Separate sockets.
+- **Retry for a fixed duration or while owned?** While at least one logical pane/subscription owns recovery, with jitter bounded by a 30-second hard cap.
+- **Replay user input after reconnect?** No; reject input during recovery and never replay ambiguous bytes.
+- **Recreate missing PTYs?** No; only retire a confirmed-gone mirror. Creation remains an explicit user/session action.
+- **Use one-shot list or subscription snapshot for recovery?** Coalesced temporary subscription snapshot.
+- **Surface transport loss as a terminal error?** No for recoverable failures; yes once for fatal authentication/protocol/confirmed-gone failures.

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -63,6 +63,25 @@ describe('WebSocketTransport', () => {
     })
   }
 
+  function createHeartbeatSweepFixture() {
+    const socket = { ping: vi.fn(), terminate: vi.fn() }
+    const transport = new WebSocketTransport({
+      host: '127.0.0.1',
+      port: 0,
+      heartbeatIntervalMs: 50
+    })
+    const internals = transport as unknown as {
+      wss: { clients: Set<typeof socket> }
+      wsAlive: WeakSet<typeof socket>
+      lastHeartbeatTickAt: number | null
+      runHeartbeatSweep: (now: number) => void
+    }
+    internals.wss = { clients: new Set([socket]) }
+    internals.wsAlive = new WeakSet()
+    internals.lastHeartbeatTickAt = 1_000
+    return { internals, socket }
+  }
+
   it('starts and stops cleanly', async () => {
     const { transport } = await createTransport()
 
@@ -425,6 +444,24 @@ describe('WebSocketTransport', () => {
 
     const ws = await connectWs(second.resolvedPort)
     ws.close()
+  })
+
+  it('re-probes instead of terminating on the first sweep after a runtime pause', () => {
+    const { internals, socket } = createHeartbeatSweepFixture()
+
+    internals.runHeartbeatSweep(2_000)
+
+    expect(socket.terminate).not.toHaveBeenCalled()
+    expect(socket.ping).toHaveBeenCalledTimes(1)
+  })
+
+  it('terminates an unresponsive client on the next normal-cadence sweep', () => {
+    const { internals, socket } = createHeartbeatSweepFixture()
+
+    internals.runHeartbeatSweep(2_000)
+    internals.runHeartbeatSweep(2_050)
+
+    expect(socket.terminate).toHaveBeenCalledTimes(1)
   })
 
   it('reaps a half-open client that stops responding to pings', async () => {

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -1,14 +1,24 @@
-// WebSocket transport letting mobile clients reach the Orca runtime over LAN (wss:// with TLS, else ws://); auth is per-device tokens, independent of transport encryption.
+// Why: the WebSocket transport enables mobile clients to connect to the Orca
+// runtime over the local network. When TLS cert/key are provided it uses wss://
+// to prevent passive sniffing; otherwise it falls back to plain ws://. Per-device
+// tokens (validated by the message handler in OrcaRuntimeRpcServer) provide auth
+// regardless of transport encryption.
 import { createServer as createHttpsServer, type Server as HttpsServer } from 'node:https'
 import { createServer as createHttpServer, type Server as HttpServer } from 'node:http'
 import { WebSocketServer, type WebSocket } from 'ws'
+import { isRemoteRuntimeLivenessTickDelayed } from '../../../shared/remote-runtime-socket-liveness'
 import type { RpcTransport } from './transport'
 import { createStaticWebClientHandler } from './static-web-client-handler'
 
 const MAX_WS_MESSAGE_BYTES = 1024 * 1024
-// Why: one desktop remote-host client can hold many concurrent streams, so keep the cap high enough that stale streams don't starve control RPCs.
+// Why: desktop remote-host clients can legitimately hold many concurrent
+// streams (session tabs, terminals, file watches, browser streams). Keep the
+// cap high enough that leaked/stale streams do not starve short control RPCs.
 const MAX_WS_CONNECTIONS = 128
-// Why: bound pre-upgrade descriptor use above the WS cap so raw sockets can't grow without bound.
+// Why: hard-bound this listener's descriptor use above the WS-upgrade cap.
+// Node accepts then drops sockets beyond maxConnections, so raw/pre-upgrade
+// clients cannot grow without bound while the existing WS budget remains
+// available to legitimate long-lived streams.
 const MAX_TCP_CONNECTIONS = MAX_WS_CONNECTIONS * 2
 const PRE_AUTH_TIMEOUT_MS = 10_000
 type WebSocketMessagePayload = string | Uint8Array<ArrayBufferLike>
@@ -20,7 +30,16 @@ type WebSocketMessageHandler = {
   ): void
 }['bivarianceHack']
 
-// Why: mobile clients background-suspend sockets with no TCP FIN, leaving half-opens that otherwise only the OS keepalive (~2h) reaps; a 15s ping/pong sweep bounds that to ~30s (clients auto-pong per RFC 6455).
+// Why: mobile clients (iOS/Android) regularly background-suspend their
+// sockets without the OS sending a TCP FIN/RST, leaving the server with
+// half-open WebSockets that count toward MAX_WS_CONNECTIONS. Without this
+// heartbeat the only thing that ever reaps them is the OS's TCP keepalive
+// (default macOS: ~2 hours idle + 11 min of probes), which is the
+// "connection randomly turns green again after a long delay" symptom.
+// Pinging every 15s and terminating any client that hasn't pong'd by the
+// next tick collapses that worst case to ~30s. RN/browser WebSocket
+// runtimes auto-respond to server pings with pongs at the protocol layer,
+// so this works for any client that speaks RFC 6455.
 const HEARTBEAT_INTERVAL_MS = 15_000
 
 export type WebSocketTransportOptions = {
@@ -32,11 +51,19 @@ export type WebSocketTransportOptions = {
   heartbeatIntervalMs?: number
   // Why: test-only override. Production uses PRE_AUTH_TIMEOUT_MS.
   preAuthTimeoutMs?: number
-  // Why: the pairing server can also serve the browser client, avoiding a second static server.
+  // Why: the pairing server can also serve the browser client, so users do
+  // not need a second dev/static server once the web bundle is built.
   staticRoot?: string
-  // Why: devices paired while the fallback port was active point at it, so it must bind first on later launches or those pairings strand (STA-1511).
+  // Why: paired mobile devices store the full ws://ip:port endpoint. Once a
+  // fallback port has been assigned and persisted, devices paired while it was
+  // active point at it, so it must be bound FIRST on later launches — binding
+  // the (now free) preferred port instead would strand those pairings
+  // (STA-1511). Callers pass the previously assigned fallback port here.
   fallbackPort?: number
-  // Why: serve --port clients dial the pinned port; prefer it first so a stale fallback can't steal the pin (issue #8535). Default keeps fallback-first (STA-1511).
+  // Why: `orca serve --port <P>` clients dial the pinned port. Prefer that port
+  // first (fallback second) so a stale mobile-ws-fallback-port.json cannot
+  // silently steal the pin (issue #8535). Default auto/desktop keeps
+  // fallback-first for STA-1511 pairing stability.
   preferPinnedPort?: boolean
 }
 
@@ -53,13 +80,17 @@ export class WebSocketTransport implements RpcTransport {
   private httpServer: HttpsServer | HttpServer | null = null
   private wss: WebSocketServer | null = null
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
-  // Why: a socket absent from this set at the next heartbeat sweep is presumed dead and terminated.
+  private lastHeartbeatTickAt: number | null = null
+  // Why: tracks whether each socket has pong'd since the last heartbeat
+  // sweep. A socket missing from the next normal-cadence sweep is assumed
+  // dead; a delayed sweep re-probes it instead.
   private wsAlive = new WeakSet<WebSocket>()
   private messageHandler: WebSocketMessageHandler | null = null
   private connectionCloseHandler:
     | ((clientId: string | null, ws: WebSocket, hasOtherConnections: boolean) => void)
     | null = null
-  // Why: maps each socket to its authenticated clientId so close can report which device disconnected.
+  // Why: maps each WebSocket to the clientId (deviceToken) that authenticated it,
+  // so ws.on('close') can notify the runtime which mobile client disconnected.
   private wsClientIds = new Map<WebSocket, string>()
   private preAuthTimers = new WeakMap<WebSocket, ReturnType<typeof setTimeout>>()
 
@@ -89,7 +120,12 @@ export class WebSocketTransport implements RpcTransport {
     this.messageHandler = handler
   }
 
-  // Why: pass the closing `ws` and whether other sockets share its deviceToken, so client-scoped teardown fires only on the last disconnect.
+  // Why: handlers receive the closing `ws` so per-connection state can be
+  // targeted exactly (one paired device may hold multiple concurrent sockets,
+  // e.g. host screen + accounts screen). `hasOtherConnections` tells the
+  // runtime whether other sockets for the same deviceToken are still alive,
+  // so client-scoped teardown (mobile-fit overrides, etc.) only fires on the
+  // last disconnect.
   onConnectionClose(
     handler: (clientId: string | null, ws: WebSocket, hasOtherConnections: boolean) => void
   ): void {
@@ -106,13 +142,16 @@ export class WebSocketTransport implements RpcTransport {
       .filter(([, candidateClientId]) => candidateClientId === clientId)
       .map(([ws]) => ws)
     for (const ws of sockets) {
-      // Why: revocation is a security boundary; terminate() skips the handshake so a revoked stream stops immediately.
+      // Why: revocation is a security boundary; terminate skips the close
+      // handshake so a revoked mobile stream stops immediately.
       ws.terminate()
     }
     return sockets.length
   }
 
-  // Why: with port 0 the OS assigns a random port; callers read the real bound port here for metadata and the mobile QR.
+  // Why: when port 0 is passed the OS assigns a random available port. The
+  // runtime metadata and mobile QR code need the real port, so callers read
+  // it here after start() resolves.
   get resolvedPort(): number {
     const addr = this.httpServer?.address()
     if (addr && typeof addr === 'object') {
@@ -126,7 +165,16 @@ export class WebSocketTransport implements RpcTransport {
       return
     }
 
-    // Why: bind a persisted fallback first so devices paired to it aren't stranded (STA-1511); serve --port flips to pinned-first (issue #8535); on failure each candidate falls through to OS-assigned port 0.
+    // Why: default order binds a persisted fallback FIRST — devices paired
+    // while it was active store ws://ip:<fallback> and would be stranded if a
+    // later launch grabbed the (now free) preferred port instead (STA-1511).
+    // Explicit serve --port flips the order so the pinned port wins when free
+    // (issue #8535); fallback remains a secondary candidate for EADDRINUSE.
+    // Without a persisted fallback only the preferred port is tried. On
+    // EADDRINUSE each candidate falls through to the next, ending at port 0
+    // (OS-assigned) so mobile pairing still works when everything is taken.
+    // The QR code reads resolvedPort after start, so it always advertises the
+    // port that actually bound.
     const persistedFallbackPort =
       this.fallbackPort !== undefined && this.fallbackPort !== 0 && this.fallbackPort !== this.port
         ? this.fallbackPort
@@ -142,7 +190,12 @@ export class WebSocketTransport implements RpcTransport {
         await this.tryListen(port)
         return
       } catch (error: unknown) {
-        // Why: any fallback-port failure must degrade to the next candidate (Windows can reserve the port → EACCES, not just EADDRINUSE); only non-EADDRINUSE preferred-port failures are fatal.
+        // Why: a persisted fallback can become unbindable for reasons beyond
+        // EADDRINUSE (e.g. Windows reserves dynamic-range ports for Hyper-V
+        // after a reboot → EACCES). Any fallback failure must degrade to the
+        // next candidate — aborting would disable the transport every launch
+        // while the store still names that port. Only preferred-port failures
+        // other than EADDRINUSE are fatal.
         if (port !== persistedFallbackPort && (!isEAddressInUse(error) || port === 0)) {
           throw error
         }
@@ -164,7 +217,9 @@ export class WebSocketTransport implements RpcTransport {
       : createHttpServer(requestListener)
   }
 
-  // Why: attach the WSS only after listen succeeds; earlier it re-emits httpServer's EADDRINUSE as an uncatchable exception and breaks the fallback.
+  // Why: the WebSocketServer is attached only after listen succeeds. If we
+  // attached it before, the WSS would re-emit the EADDRINUSE error from the
+  // httpServer as an uncatchable exception, preventing the fallback from working.
   private async tryListen(port: number): Promise<void> {
     const httpServer = this.createHttpServer()
 
@@ -176,7 +231,8 @@ export class WebSocketTransport implements RpcTransport {
       })
     })
 
-    // Why: the WS cap applies only post-upgrade; a separate TCP cap bounds raw/pre-upgrade descriptor use.
+    // Why: the WS cap applies only after upgrade. A separate TCP cap prevents
+    // raw and pre-upgrade sockets from consuming an unbounded descriptor budget.
     httpServer.maxConnections = MAX_TCP_CONNECTIONS
 
     const wss = new WebSocketServer({
@@ -197,49 +253,80 @@ export class WebSocketTransport implements RpcTransport {
     this.startHeartbeat()
   }
 
-  // Why: force-terminate soon after the 1013 close since a half-open phone may never ack and would hold the descriptor past the WS cap; the 'error' listener absorbs a reset while closing.
+  // Why: over the WS-upgrade cap, request a graceful 1013 close but force the
+  // socket down shortly after. A backgrounded/half-open phone may never ack the
+  // close frame, so a bare ws.close() can retain the descriptor until the next
+  // heartbeat. Under a reconnect flood, shortening that window bounds the
+  // number of rejected sockets that can accumulate behind the WS cap. The
+  // 'error' listener prevents a reset while closing from becoming unhandled.
   private rejectOverCapacity(ws: WebSocket): void {
     ws.on('error', () => {})
     ws.close(1013, 'Maximum connections reached')
+    // Why: give the 1013 close a brief window, then hard-terminate so the
+    // descriptor is freed even if the client never acks the close frame.
     const terminateTimer = setTimeout(() => ws.terminate(), 1_000)
     terminateTimer.unref?.()
     ws.once('close', () => clearTimeout(terminateTimer))
   }
 
-  // Why: the only reliable reaper of half-open mobile sockets stranded by background suspension without a TCP FIN.
+  // Why: normal-cadence sweeps terminate sockets that missed the prior pong,
+  // while delayed sweeps first re-probe because pre-pause state is stale.
+  // This still reliably reaps half-open mobile sockets stranded without a
+  // TCP FIN. See HEARTBEAT_INTERVAL_MS comment.
   private startHeartbeat(): void {
     if (this.heartbeatTimer) {
       return
     }
-    this.heartbeatTimer = setInterval(() => {
-      const wss = this.wss
-      if (!wss) {
-        return
-      }
-      let reaped = 0
-      for (const ws of wss.clients) {
-        if (!this.wsAlive.has(ws)) {
-          // Why: terminate() frees the slot immediately; close() on a dead socket can hang for the OS-level TCP timeout.
-          ws.terminate()
-          reaped++
-          continue
-        }
-        this.wsAlive.delete(ws)
-        try {
-          ws.ping()
-        } catch {
-          // Why: ping() can throw on a mid-teardown socket; the close handler runs regardless, so swallow it.
-        }
-      }
-      // Why: steady reaping or riding the cap are early overload signals; stay quiet on healthy ticks.
-      if (reaped > 0 || wss.clients.size >= MAX_WS_CONNECTIONS) {
-        console.warn(
-          `[ws-transport] heartbeat reaped ${reaped}; ${wss.clients.size} tracked sockets`
-        )
-      }
-    }, this.heartbeatIntervalMs)
+    this.lastHeartbeatTickAt = Date.now()
+    this.heartbeatTimer = setInterval(
+      () => this.runHeartbeatSweep(Date.now()),
+      this.heartbeatIntervalMs
+    )
     if (typeof this.heartbeatTimer.unref === 'function') {
       this.heartbeatTimer.unref()
+    }
+  }
+
+  private runHeartbeatSweep(now: number): void {
+    const delayed =
+      this.lastHeartbeatTickAt !== null &&
+      isRemoteRuntimeLivenessTickDelayed({
+        now,
+        lastTickAt: this.lastHeartbeatTickAt,
+        intervalMs: this.heartbeatIntervalMs
+      })
+    this.lastHeartbeatTickAt = now
+
+    const wss = this.wss
+    if (!wss) {
+      return
+    }
+    let reaped = 0
+    for (const ws of wss.clients) {
+      if (!delayed && !this.wsAlive.has(ws)) {
+        // Why: terminate() (vs close()) skips the close handshake and
+        // immediately fires the 'close' event, freeing the slot. close()
+        // on an already-dead socket can hang for the OS-level TCP timeout.
+        ws.terminate()
+        reaped++
+        continue
+      }
+      // Why: a delayed sweep cannot trust pre-pause liveness state, so every
+      // socket gets a fresh probe before normal-cadence reaping resumes.
+      this.wsAlive.delete(ws)
+      try {
+        ws.ping()
+      } catch {
+        // Why: ping() can throw on a socket that's mid-tear-down; the
+        // close handler will run regardless, so swallow the throw.
+      }
+    }
+    // Why: steady reaping or a client count riding the cap are early overload
+    // signals; surface them without logging on healthy heartbeat ticks.
+    if (reaped > 0 || wss.clients.size >= MAX_WS_CONNECTIONS) {
+      console.warn(
+        `[ws-transport] heartbeat reaped ${reaped}; ${wss.clients.size} tracked sockets`
+      )
     }
   }
 
@@ -248,6 +335,7 @@ export class WebSocketTransport implements RpcTransport {
       clearInterval(this.heartbeatTimer)
       this.heartbeatTimer = null
     }
+    this.lastHeartbeatTickAt = null
   }
 
   async stop(): Promise<void> {
@@ -259,7 +347,8 @@ export class WebSocketTransport implements RpcTransport {
 
     if (wss) {
       for (const client of wss.clients) {
-        // Why: a half-open mobile socket may never answer a close frame, which keeps httpServer.close pending.
+        // Why: stop() is a teardown path. A half-open mobile socket may never
+        // answer a graceful close frame, which keeps httpServer.close pending.
         client.terminate()
       }
       wss.close()
@@ -278,14 +367,20 @@ export class WebSocketTransport implements RpcTransport {
     }
   }
 
-  // Why: WS connections are long-lived and multiplex many RPCs by `id`; auth and dispatch are delegated to the message handler.
+  // Why: WebSocket connections are long-lived (unlike Unix socket which is
+  // one-per-request). Multiple requests can be multiplexed on the same
+  // connection via the RPC `id` field. The transport delegates all auth
+  // and dispatch logic to the message handler set by OrcaRuntimeRpcServer.
   private handleConnection(ws: WebSocket): void {
     let finalized = false
     const onPong = (): void => {
       this.wsAlive.add(ws)
     }
     const onMessage = (data: WebSocket.RawData, isBinary: boolean): void => {
-      // Why: any inbound frame counts as proof of life, so an actively-talking client isn't reaped mid-request.
+      // Why: any inbound traffic counts as proof of life, not just pongs.
+      // RN's WebSocket runtime auto-pongs server pings transparently, but
+      // app-level frames also count toward liveness so an actively-talking
+      // client doesn't get terminated mid-request.
       this.wsAlive.add(ws)
       const msg =
         typeof data === 'string'
@@ -296,7 +391,8 @@ export class WebSocketTransport implements RpcTransport {
       this.messageHandler?.(
         msg,
         (response) => {
-          // Why: mobile clients disconnect often; guard the write so we don't throw on a dead socket.
+          // Why: mobile clients disconnect frequently (backgrounding, network
+          // switch, phone locked). Guard writes to avoid errors on dead sockets.
           if (ws.readyState === ws.OPEN) {
             ws.send(response)
           }
@@ -305,7 +401,8 @@ export class WebSocketTransport implements RpcTransport {
       )
     }
     const onError = (): void => {
-      // Why: close isn't guaranteed after every error path; finalize here too so pre-auth E2EE state and connection ids can't leak.
+      // Why: close is not guaranteed after every ws error path; finalize here
+      // too so pre-auth E2EE channels and connection ids cannot leak.
       finalizeConnection()
       ws.close()
     }
@@ -328,7 +425,9 @@ export class WebSocketTransport implements RpcTransport {
 
     const preAuthTimer = setTimeout(() => {
       if (!this.wsClientIds.has(ws)) {
-        // Why: a silent auto-ponging client would otherwise hold a finite mobile slot forever without starting the E2EE handshake.
+        // Why: a silent client that only auto-pongs can otherwise occupy one
+        // of the finite mobile WebSocket slots forever without ever starting
+        // the E2EE handshake.
         ws.terminate()
       }
     }, this.preAuthTimeoutMs)
@@ -337,13 +436,17 @@ export class WebSocketTransport implements RpcTransport {
     }
     this.preAuthTimers.set(ws, preAuthTimer)
 
-    // Why: seed alive so the first heartbeat tick doesn't reap a fresh socket before its first pong.
+    // Why: seed alive=true so the first heartbeat tick after connect doesn't
+    // treat a fresh socket as dead. Subsequent pongs (or any inbound traffic)
+    // re-arm it.
     this.wsAlive.add(ws)
 
     ws.on('pong', onPong)
     ws.on('message', onMessage)
 
-    // Why: clean up connection-scoped state (e.g. mobile-fit overrides) so a dropped phone doesn't leave orphaned phone-fit on desktop.
+    // Why: mobile clients disconnect when the phone locks, loses wifi, or
+    // backgrounds the app. The runtime must clean up connection-scoped state
+    // (e.g., mobile-fit overrides) to prevent orphaned phone-fit on desktop.
     ws.on('close', finalizeConnection)
     ws.on('error', onError)
   }

--- a/src/shared/remote-runtime-client-error-classification.test.ts
+++ b/src/shared/remote-runtime-client-error-classification.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isRecoverableRemoteRuntimeConnectionError } from './remote-runtime-client-error-classification'
+
+describe('isRecoverableRemoteRuntimeConnectionError', () => {
+  it('classifies only connection availability and timeout errors as recoverable', () => {
+    expect(
+      isRecoverableRemoteRuntimeConnectionError({
+        code: 'remote_runtime_unavailable',
+        message: 'offline'
+      })
+    ).toBe(true)
+    expect(
+      isRecoverableRemoteRuntimeConnectionError({
+        code: 'runtime_timeout',
+        message: 'timeout'
+      })
+    ).toBe(true)
+
+    for (const code of [
+      'unauthorized',
+      'invalid_argument',
+      'invalid_runtime_response',
+      'runtime_error'
+    ]) {
+      expect(isRecoverableRemoteRuntimeConnectionError({ code, message: code })).toBe(false)
+    }
+  })
+})

--- a/src/shared/remote-runtime-client-error-classification.ts
+++ b/src/shared/remote-runtime-client-error-classification.ts
@@ -1,0 +1,7 @@
+export type RemoteRuntimeClientErrorLike = { code: string; message: string }
+
+export function isRecoverableRemoteRuntimeConnectionError(
+  error: RemoteRuntimeClientErrorLike
+): boolean {
+  return error.code === 'remote_runtime_unavailable' || error.code === 'runtime_timeout'
+}

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -258,31 +258,41 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
-  it.each([
-    ['the final subscription', false],
-    ['the connection explicitly', true]
-  ])('cancels backoff and ignores stale callbacks after closing %s', (_label, closeConnection) => {
+  it('cancels backoff and ignores stale callbacks after closing explicitly', () => {
     vi.useFakeTimers()
     const timeout = vi.spyOn(globalThis, 'setTimeout')
     const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
     const unsafe = asTestableConnection(connection)
-    const open = vi.fn()
-    unsafe.open = open
+    unsafe.open = vi.fn()
     addTestSubscription(unsafe, 'sub-1')
 
     unsafe.scheduleReconnect()
     const reconnect = timeout.mock.calls.at(-1)![0] as () => void
-    if (closeConnection) {
-      connection.close()
-    } else {
-      unsafe.closeSubscription('sub-1')
-    }
+    connection.close()
 
     expect(vi.getTimerCount()).toBe(0)
-    expect(connection.getDiagnostics()).toMatchObject({ subscriptionCount: 0 })
     reconnect()
-    expect(open).not.toHaveBeenCalled()
-    connection.close()
+    expect(unsafe.open).not.toHaveBeenCalled()
+  })
+
+  it('fences a stale reconnect callback from a newer timer', () => {
+    vi.useFakeTimers()
+    const timeout = vi.spyOn(globalThis, 'setTimeout')
+    const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
+    const unsafe = asTestableConnection(connection)
+    unsafe.open = vi.fn()
+    addTestSubscription(unsafe, 'sub-a')
+    unsafe.scheduleReconnect()
+    const reconnectA = timeout.mock.calls.at(-1)![0] as () => void
+    unsafe.closeSubscription('sub-a')
+    addTestSubscription(unsafe, 'sub-b')
+    unsafe.scheduleReconnect()
+    const reconnectB = timeout.mock.calls.at(-1)![0] as () => void
+    reconnectA()
+    expect(unsafe.open).not.toHaveBeenCalled()
+    expect(connection.getDiagnostics()).toMatchObject({ state: 'reconnecting' })
+    reconnectB()
+    expect(unsafe.open).toHaveBeenCalledTimes(1)
   })
 
   it('cancels backoff when initial subscription readiness fails', async () => {

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -11,8 +11,13 @@ import {
   publicKeyToBase64
 } from './e2ee-crypto'
 import { encodePairingOffer, parsePairingCode, type PairingOffer } from './pairing'
+import { RemoteRuntimeClientError } from './remote-runtime-client-error'
 import { RemoteRuntimeSharedControlConnection } from './remote-runtime-shared-control-connection'
 import * as sharedControlProtocol from './remote-runtime-shared-control-protocol'
+import type {
+  SharedControlLogicalSubscription,
+  SharedControlSubscriptionCallbacks
+} from './remote-runtime-shared-control-types'
 import { isRuntimeSubscriptionReplayResponse } from './runtime-subscription-replay'
 
 const TEST_PROJECT_PATH = path.join('tmp', 'project')
@@ -26,7 +31,26 @@ type TestServer = {
 
 const servers: WebSocketServer[] = []
 
+type TestableSharedControlConnection = {
+  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
+  reconnectAttempt: number
+  scheduleReconnect: () => void
+  closeSubscription: (requestId: string) => void
+  handleSocketClosed: (error: RemoteRuntimeClientError) => void
+  ensureReadyWithTimeout: (timeoutMs: number) => Promise<void>
+  open: () => void
+}
+
+const DISCONNECTED_TEST_PAIRING: PairingOffer = {
+  v: 2,
+  endpoint: 'ws://127.0.0.1:1',
+  deviceToken: 'test-device-token',
+  publicKeyB64: 'unused-test-key'
+}
+
 afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
   await Promise.all(
     servers.splice(0).map(
       (server) =>
@@ -191,38 +215,161 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
-  it('emits one final close when reconnect attempts are exhausted', async () => {
-    const server = await createServer()
-    const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
+  it('keeps logical subscriptions and saturates reconnect delays at 30 seconds', () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const timeout = vi.spyOn(globalThis, 'setTimeout')
+    const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
     const onClose = vi.fn()
+    const unsafe = asTestableConnection(connection)
+    const open = vi.fn()
+    unsafe.open = open
+    addTestSubscription(unsafe, 'sub-1', { onClose })
 
-    const unsafe = connection as unknown as {
-      reconnectAttempt: number
-      subscriptions: Map<string, unknown>
-      scheduleReconnect: () => void
+    const expectedDelays = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000, 30_000, 30_000]
+    for (const expectedDelay of expectedDelays) {
+      unsafe.scheduleReconnect()
+      expect(timeout).toHaveBeenLastCalledWith(expect.any(Function), expectedDelay)
+      vi.advanceTimersByTime(expectedDelay)
     }
-    unsafe.reconnectAttempt = 7
-    unsafe.subscriptions.set('sub-1', {
-      requestId: 'sub-1',
-      method: 'runtime.clientEvents.subscribe',
-      params: null,
-      callbacks: { onResponse: vi.fn(), onError: vi.fn(), onClose },
-      sent: false,
-      closed: false,
-      closeAfterReady: false,
-      remoteSubscriptionId: null
+
+    expect(open).toHaveBeenCalledTimes(expectedDelays.length)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(connection.getDiagnostics()).toMatchObject({
+      reconnectAttempt: expectedDelays.length,
+      subscriptionCount: 1
     })
+    connection.close()
+  })
+
+  it('clamps the actual jittered reconnect delay to 30 seconds', () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0.999_999)
+    const timeout = vi.spyOn(globalThis, 'setTimeout')
+    const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
+    const unsafe = asTestableConnection(connection)
+    unsafe.reconnectAttempt = 7
+    unsafe.open = vi.fn()
+    addTestSubscription(unsafe, 'sub-1')
 
     unsafe.scheduleReconnect()
 
+    expect(timeout).toHaveBeenLastCalledWith(expect.any(Function), 30_000)
+    connection.close()
+  })
+
+  it.each([
+    ['the final subscription', false],
+    ['the connection explicitly', true]
+  ])('cancels backoff and ignores stale callbacks after closing %s', (_label, closeConnection) => {
+    vi.useFakeTimers()
+    const timeout = vi.spyOn(globalThis, 'setTimeout')
+    const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
+    const unsafe = asTestableConnection(connection)
+    const open = vi.fn()
+    unsafe.open = open
+    addTestSubscription(unsafe, 'sub-1')
+
+    unsafe.scheduleReconnect()
+    const reconnect = timeout.mock.calls.at(-1)![0] as () => void
+    if (closeConnection) {
+      connection.close()
+    } else {
+      unsafe.closeSubscription('sub-1')
+    }
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(connection.getDiagnostics()).toMatchObject({ subscriptionCount: 0 })
+    reconnect()
+    expect(open).not.toHaveBeenCalled()
+    connection.close()
+  })
+
+  it('cancels backoff when initial subscription readiness fails', async () => {
+    vi.useFakeTimers()
+    const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
+    const unsafe = asTestableConnection(connection)
+    const unavailable = new RemoteRuntimeClientError('remote_runtime_unavailable', 'offline')
+    unsafe.ensureReadyWithTimeout = async () => {
+      unsafe.scheduleReconnect()
+      throw unavailable
+    }
+
+    await expect(
+      connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+        onResponse: vi.fn(),
+        onError: vi.fn()
+      })
+    ).rejects.toBe(unavailable)
+
+    expect(connection.getDiagnostics()).toMatchObject({ subscriptionCount: 0 })
+    expect(vi.getTimerCount()).toBe(0)
+    connection.close()
+  })
+
+  it('stops fatal reconnects and notifies the subscription once', () => {
+    vi.useFakeTimers()
+    const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
+    const onError = vi.fn()
+    const onClose = vi.fn()
+    const unsafe = asTestableConnection(connection)
+    addTestSubscription(unsafe, 'sub-1', { onError, onClose })
+
+    unsafe.handleSocketClosed(new RemoteRuntimeClientError('unauthorized', 'denied'))
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'unauthorized' }))
     expect(onClose).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
     expect(connection.getDiagnostics()).toMatchObject({
       state: 'closed',
-      reconnectAttempt: 7,
       subscriptionCount: 0
     })
-
     connection.close()
+  })
+
+  it('finishes every fatal subscription despite throwing and reentrant callbacks', () => {
+    const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
+    const unsafe = asTestableConnection(connection)
+    const callbackCounts = new Map<string, number>()
+    const count = (name: string): void => {
+      callbackCounts.set(name, (callbackCounts.get(name) ?? 0) + 1)
+    }
+
+    addTestSubscription(unsafe, 'throws', {
+      onError: () => {
+        count('throws:error')
+        throw new Error('subscriber callback failed')
+      },
+      onClose: () => {
+        count('throws:close')
+        throw new Error('subscriber close callback failed')
+      }
+    })
+    addTestSubscription(unsafe, 'reentrant', {
+      onError: () => {
+        count('reentrant:error')
+        connection.close()
+      },
+      onClose: () => count('reentrant:close')
+    })
+    addTestSubscription(unsafe, 'remaining', {
+      onError: () => count('remaining:error'),
+      onClose: () => count('remaining:close')
+    })
+
+    expect(() =>
+      unsafe.handleSocketClosed(new RemoteRuntimeClientError('runtime_error', 'fatal'))
+    ).not.toThrow()
+    expect(Object.fromEntries(callbackCounts)).toEqual({
+      'throws:error': 1,
+      'throws:close': 1,
+      'reentrant:error': 1,
+      'reentrant:close': 1,
+      'remaining:error': 1,
+      'remaining:close': 1
+    })
+    expect(connection.getDiagnostics()).toMatchObject({ subscriptionCount: 0 })
   })
 
   it('resets reconnect attempts after a stable authenticated ready period', async () => {
@@ -489,6 +636,54 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
+  it('treats a close-only E2EE failure as fatal without reconnecting', async () => {
+    const server = await createServer({ closeBeforeResponse: true })
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
+    const onError = vi.fn()
+    const onClose = vi.fn()
+
+    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+      onResponse: vi.fn(),
+      onError,
+      onClose
+    })
+
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'invalid_runtime_response' })
+    )
+    expect(server.connectionCount()).toBe(1)
+    expect(connection.getDiagnostics()).toMatchObject({
+      state: 'closed',
+      subscriptionCount: 0
+    })
+
+    connection.close()
+  })
+
+  it('retains a subscription and reconnects after an abnormal network close', async () => {
+    const server = await createServer({ terminateBeforeResponse: true })
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
+    const onError = vi.fn()
+    const onClose = vi.fn()
+
+    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+      onResponse: vi.fn(),
+      onError,
+      onClose
+    })
+
+    await vi.waitFor(() => expect(server.connectionCount()).toBeGreaterThanOrEqual(2), {
+      timeout: 5000
+    })
+    expect(onError).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+    expect(connection.getDiagnostics()).toMatchObject({ subscriptionCount: 1 })
+
+    connection.close()
+  })
+
   it('rejects pending requests and records close diagnostics when the socket closes', async () => {
     const server = await createServer({ closeBeforeResponse: true })
     const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
@@ -506,6 +701,33 @@ describe('RemoteRuntimeSharedControlConnection', () => {
   })
 })
 
+function asTestableConnection(
+  connection: RemoteRuntimeSharedControlConnection
+): TestableSharedControlConnection {
+  return connection as unknown as TestableSharedControlConnection
+}
+
+function addTestSubscription(
+  connection: TestableSharedControlConnection,
+  requestId: string,
+  callbacks: Partial<SharedControlSubscriptionCallbacks<unknown>> = {}
+): void {
+  connection.subscriptions.set(requestId, {
+    requestId,
+    method: 'runtime.clientEvents.subscribe',
+    params: null,
+    callbacks: {
+      onResponse: callbacks.onResponse ?? vi.fn(),
+      onError: callbacks.onError ?? vi.fn(),
+      onClose: callbacks.onClose
+    },
+    sent: false,
+    closed: false,
+    closeAfterReady: false,
+    remoteSubscriptionId: null
+  })
+}
+
 async function createServer(
   options: {
     delaySubscriptionReady?: boolean
@@ -516,6 +738,7 @@ async function createServer(
     sendUnknownResponseBeforeResponse?: boolean
     closeAfterFirstStreamingResponse?: boolean
     closeBeforeResponse?: boolean
+    terminateBeforeResponse?: boolean
     suppressReadyFrame?: boolean
     // Why: half-open simulation — the socket stays open but never answers
     // protocol pings, like a wedged tunnel that swallows frames silently.
@@ -620,6 +843,7 @@ function handleRequest(
     closeAfterStreamingResponse?: () => boolean
     closeBeforeResponse?: boolean
     delayedMethods?: string[]
+    terminateBeforeResponse?: boolean
     silentMethods?: string[]
   },
   delayedResponses: (() => void)[]
@@ -639,6 +863,10 @@ function handleRequest(
   }
   if (options.closeBeforeResponse) {
     ws.close(4001, 'test close')
+    return
+  }
+  if (options.terminateBeforeResponse) {
+    ws.terminate()
     return
   }
   const streaming = isStreamingMethod(request.method)

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -215,7 +215,7 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
-  it('keeps logical subscriptions and saturates reconnect delays at 30 seconds', () => {
+  it('keeps logical subscriptions and jitters saturated retries below 30 seconds', () => {
     vi.useFakeTimers()
     vi.spyOn(Math, 'random').mockReturnValue(0)
     const timeout = vi.spyOn(globalThis, 'setTimeout')
@@ -226,7 +226,7 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     unsafe.open = open
     addTestSubscription(unsafe, 'sub-1', { onClose })
 
-    const expectedDelays = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000, 30_000, 30_000]
+    const expectedDelays = [250, 500, 1000, 2000, 4000, 8000, 15_000, 24_000, 24_000, 24_000]
     for (const expectedDelay of expectedDelays) {
       unsafe.scheduleReconnect()
       expect(timeout).toHaveBeenLastCalledWith(expect.any(Function), expectedDelay)
@@ -239,22 +239,6 @@ describe('RemoteRuntimeSharedControlConnection', () => {
       reconnectAttempt: expectedDelays.length,
       subscriptionCount: 1
     })
-    connection.close()
-  })
-
-  it('clamps the actual jittered reconnect delay to 30 seconds', () => {
-    vi.useFakeTimers()
-    vi.spyOn(Math, 'random').mockReturnValue(0.999_999)
-    const timeout = vi.spyOn(globalThis, 'setTimeout')
-    const connection = new RemoteRuntimeSharedControlConnection(DISCONNECTED_TEST_PAIRING)
-    const unsafe = asTestableConnection(connection)
-    unsafe.reconnectAttempt = 7
-    unsafe.open = vi.fn()
-    addTestSubscription(unsafe, 'sub-1')
-
-    unsafe.scheduleReconnect()
-
-    expect(timeout).toHaveBeenLastCalledWith(expect.any(Function), 30_000)
     connection.close()
   })
 

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -10,7 +10,7 @@ import {
   isSharedControlReady,
   waitForSharedControlReadyWithTimeout
 } from './remote-runtime-shared-control-ready'
-import { scheduleSharedControlReconnectOrFinish } from './remote-runtime-shared-control-reconnect'
+import * as sharedControlReconnect from './remote-runtime-shared-control-reconnect'
 import { requestSharedControl } from './remote-runtime-shared-control-requests'
 import { SharedControlReadyStableResetTimer } from './remote-runtime-shared-control-stability'
 import * as sharedControlState from './remote-runtime-shared-control-state'
@@ -21,7 +21,7 @@ import {
 import { closeSharedControlSocket } from './remote-runtime-shared-control-socket-close'
 import type { RemoteRuntimeSocketLivenessOptions } from './remote-runtime-socket-liveness'
 import * as sharedControlSubscriptions from './remote-runtime-shared-control-subscriptions'
-import { startSharedControlSubscription } from './remote-runtime-shared-control-subscription-start'
+import * as sharedControlSubscriptionLifecycle from './remote-runtime-shared-control-subscription-start'
 import type {
   RemoteRuntimeSharedConnectionDiagnostics,
   RemoteRuntimeSharedSubscription,
@@ -84,14 +84,15 @@ export class RemoteRuntimeSharedControlConnection {
     timeoutMs: number,
     callbacks: SharedControlSubscriptionCallbacks<TResult>
   ): Promise<RemoteRuntimeSharedSubscription> {
-    return startSharedControlSubscription({
+    return sharedControlSubscriptionLifecycle.startSharedControlSubscription({
       subscriptions: this.subscriptions,
       method,
       params,
       callbacks,
       ensureReady: () => this.ensureReadyWithTimeout(timeoutMs),
       sendSubscription: (subscription) => this.sendSubscription(subscription),
-      closeSubscription: (requestId) => this.closeSubscription(requestId)
+      closeSubscription: (requestId) => this.closeSubscription(requestId),
+      onSubscriptionsEmpty: () => this.clearReconnectTimer()
     })
   }
 
@@ -227,14 +228,12 @@ export class RemoteRuntimeSharedControlConnection {
   }
 
   private closeSubscription(requestId: string): void {
-    const subscription = this.subscriptions.get(requestId)
-    if (!subscription) {
-      return
-    }
-    sharedControlSubscriptions.closeSharedControlLogicalSubscription({
+    sharedControlSubscriptionLifecycle.closeSharedControlSubscriptionByRequestId({
       subscriptions: this.subscriptions,
-      subscription,
-      request: (method, params) => this.sendSubscriptionCleanupRequest(method, params)
+      requestId,
+      deviceToken: this.pairing.deviceToken,
+      send: (payload) => this.sendEncrypted(payload),
+      onSubscriptionsEmpty: () => this.clearReconnectTimer()
     })
   }
 
@@ -247,19 +246,17 @@ export class RemoteRuntimeSharedControlConnection {
     })
   }
 
-  private sendSubscriptionCleanupRequest(method: string, params: unknown): void {
-    sharedControlSubscriptions.sendSharedControlCleanupRequest({
-      deviceToken: this.pairing.deviceToken,
-      method,
-      params,
-      send: (payload) => this.sendEncrypted(payload)
-    })
-  }
-
   private handleSocketClosed(error: RemoteRuntimeClientError): void {
     this.lastError = error.message
     this.closeSocket(error)
-    if (this.subscriptions.size > 0 && !this.intentionallyClosed) {
+    if (
+      sharedControlReconnect.handleSharedControlDisconnect(
+        error,
+        this.subscriptions,
+        this.intentionallyClosed,
+        () => this.clearReconnectTimer()
+      )
+    ) {
       this.scheduleReconnect()
     }
   }
@@ -286,14 +283,15 @@ export class RemoteRuntimeSharedControlConnection {
   }
 
   private scheduleReconnect(): void {
-    const scheduled = scheduleSharedControlReconnectOrFinish({
+    const scheduled = sharedControlReconnect.scheduleSharedControlReconnectWhileSubscribed({
       current: this.reconnectTimer,
-      intentionallyClosed: this.intentionallyClosed,
+      isIntentionallyClosed: () => this.intentionallyClosed,
       reconnectAttempt: this.reconnectAttempt,
-      delaysMs: [250, 500, 1000, 2000, 4000, 8000, 15_000],
       subscriptions: this.subscriptions,
-      open: () => {
+      onTimerFired: () => {
         this.reconnectTimer = null
+      },
+      open: () => {
         this.open()
       }
     })

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -288,6 +288,7 @@ export class RemoteRuntimeSharedControlConnection {
       isIntentionallyClosed: () => this.intentionallyClosed,
       reconnectAttempt: this.reconnectAttempt,
       subscriptions: this.subscriptions,
+      getCurrentTimer: () => this.reconnectTimer,
       onTimerFired: () => {
         this.reconnectTimer = null
       },

--- a/src/shared/remote-runtime-shared-control-open.ts
+++ b/src/shared/remote-runtime-shared-control-open.ts
@@ -1,6 +1,6 @@
 import type WebSocket from 'ws'
 import type { PairingOffer } from './pairing'
-import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import { RemoteRuntimeClientError } from './remote-runtime-client-error'
 import { remoteRuntimeUnavailableError } from './remote-runtime-request-frames'
 import {
   openRemoteRuntimeWebSocket,
@@ -32,9 +32,14 @@ export function openSharedControlSocket(
   const opened = openRemoteRuntimeWebSocket(pairing, {
     onClose: (ws, code, reason) => {
       if (callbacks.getCurrentSocket() === ws) {
+        const message = formatSharedControlCloseMessage(code, reason)
+        // Why: the E2EE server uses 4001 for fatal authentication/protocol
+        // failures, including when no encrypted error frame reaches the client.
         callbacks.onClose(
           { code, reason: reason.toString() },
-          remoteRuntimeUnavailableError(formatSharedControlCloseMessage(code, reason))
+          code === 4001
+            ? new RemoteRuntimeClientError('invalid_runtime_response', message)
+            : remoteRuntimeUnavailableError(message)
         )
       }
     },

--- a/src/shared/remote-runtime-shared-control-reconnect-delay.test.ts
+++ b/src/shared/remote-runtime-shared-control-reconnect-delay.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { scheduleSharedControlReconnect } from './remote-runtime-shared-control-state'
+
+const RECONNECT_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000] as const
+
+describe('shared-control reconnect delay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it.each([
+    { attempt: 0, random: 0, expected: 250 },
+    { attempt: 0, random: 0.999_999, expected: 299 },
+    { attempt: 7, random: 0, expected: 24_000 },
+    { attempt: 7, random: 0.5, expected: 27_000 },
+    { attempt: 7, random: 0.999_999, expected: 29_999 }
+  ])(
+    'uses cap-contained jitter for attempt $attempt at random=$random',
+    ({ attempt, random, expected }) => {
+      vi.useFakeTimers()
+      vi.spyOn(Math, 'random').mockReturnValue(random)
+      const timeout = vi.spyOn(globalThis, 'setTimeout')
+      const open = vi.fn()
+
+      const result = scheduleSharedControlReconnect({
+        current: null,
+        intentionallyClosed: false,
+        reconnectAttempt: attempt,
+        delaysMs: RECONNECT_DELAYS_MS,
+        open
+      })
+
+      expect(timeout).toHaveBeenLastCalledWith(open, expected)
+      expect(result.reconnectAttempt).toBe(attempt + 1)
+    }
+  )
+})

--- a/src/shared/remote-runtime-shared-control-reconnect.ts
+++ b/src/shared/remote-runtime-shared-control-reconnect.ts
@@ -15,18 +15,24 @@ export function scheduleSharedControlReconnectWhileSubscribed(args: {
   isIntentionallyClosed: () => boolean
   reconnectAttempt: number
   subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
+  getCurrentTimer: () => ReturnType<typeof setTimeout> | null
   onTimerFired: () => void
   open: () => void
 }): { timer: ReturnType<typeof setTimeout> | null; reconnectAttempt: number } {
   if (args.subscriptions.size === 0) {
     return { timer: null, reconnectAttempt: args.reconnectAttempt }
   }
-  return scheduleSharedControlReconnect({
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const scheduled = scheduleSharedControlReconnect({
     current: args.current,
     intentionallyClosed: args.isIntentionallyClosed(),
     reconnectAttempt: args.reconnectAttempt,
     delaysMs: REMOTE_RUNTIME_SHARED_CONTROL_RECONNECT_DELAYS_MS,
     open: () => {
+      // Why: a cancelled timer may still fire after a replacement is queued.
+      if (timer === null || args.getCurrentTimer() !== timer) {
+        return
+      }
       args.onTimerFired()
       if (args.subscriptions.size === 0 || args.isIntentionallyClosed()) {
         return
@@ -34,6 +40,8 @@ export function scheduleSharedControlReconnectWhileSubscribed(args: {
       args.open()
     }
   })
+  timer = scheduled.timer
+  return scheduled
 }
 
 export function handleSharedControlDisconnect(

--- a/src/shared/remote-runtime-shared-control-reconnect.ts
+++ b/src/shared/remote-runtime-shared-control-reconnect.ts
@@ -1,26 +1,54 @@
-import { remoteRuntimeUnavailableError } from './remote-runtime-request-frames'
+import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import { isRecoverableRemoteRuntimeConnectionError } from './remote-runtime-client-error-classification'
 import {
-  finishSharedControlSubscription,
+  finishSharedControlSubscriptions,
   scheduleSharedControlReconnect
 } from './remote-runtime-shared-control-state'
 import type { SharedControlLogicalSubscription } from './remote-runtime-shared-control-types'
 
-export function scheduleSharedControlReconnectOrFinish(args: {
+const REMOTE_RUNTIME_SHARED_CONTROL_RECONNECT_DELAYS_MS = [
+  250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000
+] as const
+
+export function scheduleSharedControlReconnectWhileSubscribed(args: {
   current: ReturnType<typeof setTimeout> | null
-  intentionallyClosed: boolean
+  isIntentionallyClosed: () => boolean
   reconnectAttempt: number
-  delaysMs: readonly number[]
   subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
+  onTimerFired: () => void
   open: () => void
 }): { timer: ReturnType<typeof setTimeout> | null; reconnectAttempt: number } {
-  if (args.reconnectAttempt >= args.delaysMs.length) {
-    const error = remoteRuntimeUnavailableError(
-      'Remote Orca runtime connection could not be restored.'
-    )
-    for (const subscription of Array.from(args.subscriptions.values())) {
-      finishSharedControlSubscription(args.subscriptions, subscription, true, error)
-    }
+  if (args.subscriptions.size === 0) {
     return { timer: null, reconnectAttempt: args.reconnectAttempt }
   }
-  return scheduleSharedControlReconnect(args)
+  return scheduleSharedControlReconnect({
+    current: args.current,
+    intentionallyClosed: args.isIntentionallyClosed(),
+    reconnectAttempt: args.reconnectAttempt,
+    delaysMs: REMOTE_RUNTIME_SHARED_CONTROL_RECONNECT_DELAYS_MS,
+    open: () => {
+      args.onTimerFired()
+      if (args.subscriptions.size === 0 || args.isIntentionallyClosed()) {
+        return
+      }
+      args.open()
+    }
+  })
+}
+
+export function handleSharedControlDisconnect(
+  error: RemoteRuntimeClientError,
+  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>,
+  intentionallyClosed: boolean,
+  clearReconnectTimer: () => void
+): boolean {
+  if (subscriptions.size === 0 || intentionallyClosed) {
+    return false
+  }
+  if (isRecoverableRemoteRuntimeConnectionError(error)) {
+    return true
+  }
+  clearReconnectTimer()
+  finishSharedControlSubscriptions(subscriptions, true, error)
+  return false
 }

--- a/src/shared/remote-runtime-shared-control-state.ts
+++ b/src/shared/remote-runtime-shared-control-state.ts
@@ -129,6 +129,32 @@ export function finishSharedControlSubscription(
   }
 }
 
+export function finishSharedControlSubscriptions(
+  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>,
+  notifyClose: boolean,
+  error?: RemoteRuntimeClientError
+): void {
+  const finished: SharedControlLogicalSubscription<unknown>[] = []
+  for (const subscription of Array.from(subscriptions.values())) {
+    if (subscription.closed) {
+      continue
+    }
+    subscription.closed = true
+    subscriptions.delete(subscription.requestId)
+    finished.push(subscription)
+  }
+  // Why: fatal callbacks may throw or synchronously close the connection. All
+  // owners are detached first and each notification is isolated from the rest.
+  for (const subscription of finished) {
+    if (error) {
+      invokeSharedControlSubscriptionCallback(() => subscription.callbacks.onError(error))
+    }
+    if (notifyClose && subscription.callbacks.onClose) {
+      invokeSharedControlSubscriptionCallback(subscription.callbacks.onClose)
+    }
+  }
+}
+
 export function resolveSharedControlReadyWaiters(waiters: SharedControlReadyWaiter[]): void {
   for (const waiter of waiters.splice(0)) {
     waiter.resolve()
@@ -204,8 +230,10 @@ export function scheduleSharedControlReconnect(args: {
   if (args.current || args.intentionallyClosed) {
     return { timer: args.current, reconnectAttempt: args.reconnectAttempt }
   }
-  const delay = withReconnectJitter(
-    args.delaysMs[Math.min(args.reconnectAttempt, args.delaysMs.length - 1)]
+  const maximumDelayMs = args.delaysMs.at(-1)!
+  const delay = Math.min(
+    withReconnectJitter(args.delaysMs[Math.min(args.reconnectAttempt, args.delaysMs.length - 1)]),
+    maximumDelayMs
   )
   const timer = setTimeout(args.open, delay)
   if (typeof timer.unref === 'function') {
@@ -219,4 +247,12 @@ function withReconnectJitter(delayMs: number): number {
   // together. A small one-sided jitter avoids synchronized retry spikes.
   const jitterMs = Math.floor(delayMs * 0.2 * Math.random())
   return delayMs + jitterMs
+}
+
+function invokeSharedControlSubscriptionCallback(callback: () => void): void {
+  try {
+    callback()
+  } catch {
+    // Subscriber cleanup is best-effort; one consumer cannot starve the rest.
+  }
 }

--- a/src/shared/remote-runtime-shared-control-state.ts
+++ b/src/shared/remote-runtime-shared-control-state.ts
@@ -231,10 +231,8 @@ export function scheduleSharedControlReconnect(args: {
     return { timer: args.current, reconnectAttempt: args.reconnectAttempt }
   }
   const maximumDelayMs = args.delaysMs.at(-1)!
-  const delay = Math.min(
-    withReconnectJitter(args.delaysMs[Math.min(args.reconnectAttempt, args.delaysMs.length - 1)]),
-    maximumDelayMs
-  )
+  const baseDelayMs = args.delaysMs[Math.min(args.reconnectAttempt, args.delaysMs.length - 1)]
+  const delay = Math.min(withReconnectJitter(baseDelayMs, maximumDelayMs), maximumDelayMs)
   const timer = setTimeout(args.open, delay)
   if (typeof timer.unref === 'function') {
     timer.unref()
@@ -242,11 +240,12 @@ export function scheduleSharedControlReconnect(args: {
   return { timer, reconnectAttempt: args.reconnectAttempt + 1 }
 }
 
-function withReconnectJitter(delayMs: number): number {
+function withReconnectJitter(delayMs: number, maximumDelayMs: number): number {
   // Why: when a remote host restarts, all passive subscriptions reconnect
-  // together. A small one-sided jitter avoids synchronized retry spikes.
-  const jitterMs = Math.floor(delayMs * 0.2 * Math.random())
-  return delayMs + jitterMs
+  // together. At saturation the same 20% window shifts below the hard cap.
+  const jitterSpanMs = Math.floor(delayMs * 0.2)
+  const windowStartMs = Math.min(delayMs, Math.max(0, maximumDelayMs - jitterSpanMs))
+  return windowStartMs + Math.floor(jitterSpanMs * Math.random())
 }
 
 function invokeSharedControlSubscriptionCallback(callback: () => void): void {

--- a/src/shared/remote-runtime-shared-control-subscription-start.ts
+++ b/src/shared/remote-runtime-shared-control-subscription-start.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import { remoteRuntimeUnavailableError } from './remote-runtime-request-frames'
-import { createSharedControlSubscription } from './remote-runtime-shared-control-subscriptions'
+import {
+  closeSharedControlLogicalSubscription,
+  createSharedControlSubscription,
+  sendSharedControlCleanupRequest
+} from './remote-runtime-shared-control-subscriptions'
 import { finishSharedControlSubscription } from './remote-runtime-shared-control-state'
 import type {
   RemoteRuntimeSharedSubscription,
@@ -16,6 +20,7 @@ export async function startSharedControlSubscription<TResult>(args: {
   ensureReady: () => Promise<void>
   sendSubscription: (subscription: SharedControlLogicalSubscription<unknown>) => void
   closeSubscription: (requestId: string) => void
+  onSubscriptionsEmpty: () => void
 }): Promise<RemoteRuntimeSharedSubscription> {
   const requestId = randomUUID()
   const subscription = createSharedControlSubscription({
@@ -33,6 +38,9 @@ export async function startSharedControlSubscription<TResult>(args: {
       subscription as SharedControlLogicalSubscription<unknown>,
       false
     )
+    if (args.subscriptions.size === 0) {
+      args.onSubscriptionsEmpty()
+    }
     throw error
   }
   if (args.subscriptions.get(requestId) !== subscription) {
@@ -43,5 +51,32 @@ export async function startSharedControlSubscription<TResult>(args: {
     requestId,
     close: () => args.closeSubscription(requestId),
     sendBinary: () => false
+  }
+}
+
+export function closeSharedControlSubscriptionByRequestId(args: {
+  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
+  requestId: string
+  deviceToken: string
+  send: (payload: unknown) => boolean
+  onSubscriptionsEmpty: () => void
+}): void {
+  const subscription = args.subscriptions.get(args.requestId)
+  if (!subscription) {
+    return
+  }
+  closeSharedControlLogicalSubscription({
+    subscriptions: args.subscriptions,
+    subscription,
+    request: (method, params) =>
+      sendSharedControlCleanupRequest({
+        deviceToken: args.deviceToken,
+        method,
+        params,
+        send: args.send
+      })
+  })
+  if (args.subscriptions.size === 0) {
+    args.onSubscriptionsEmpty()
   }
 }

--- a/src/shared/remote-runtime-socket-liveness.test.ts
+++ b/src/shared/remote-runtime-socket-liveness.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isRemoteRuntimeLivenessTickDelayed,
+  startRemoteRuntimeSocketLiveness
+} from './remote-runtime-socket-liveness'
+
+describe('remote runtime socket liveness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('re-baselines after a suspended tick before judging socket death', async () => {
+    let now = 1_000
+    const ping = vi.fn()
+    const onDead = vi.fn()
+    const monitor = startRemoteRuntimeSocketLiveness({
+      ping,
+      onDead,
+      options: { pingIntervalMs: 100, livenessTimeoutMs: 250 },
+      now: () => now
+    })
+
+    now += 3_600_000
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(onDead).not.toHaveBeenCalled()
+    expect(ping).not.toHaveBeenCalled()
+    monitor.stop()
+  })
+
+  it('kills only after a fresh sent probe gets its full unanswered window', async () => {
+    let now = 1_000
+    const ping = vi.fn()
+    const onDead = vi.fn()
+    startRemoteRuntimeSocketLiveness({
+      ping,
+      onDead,
+      options: { pingIntervalMs: 100, livenessTimeoutMs: 250 },
+      now: () => now
+    })
+
+    for (const delta of [100, 100, 100]) {
+      now += delta
+      await vi.advanceTimersByTimeAsync(100)
+    }
+    expect(ping).toHaveBeenCalledTimes(1)
+    expect(onDead).not.toHaveBeenCalled()
+
+    for (const delta of [100, 100, 100]) {
+      now += delta
+      await vi.advanceTimersByTimeAsync(100)
+    }
+    expect(onDead).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears an outstanding probe after inbound activity', async () => {
+    let now = 1_000
+    const ping = vi.fn()
+    const onDead = vi.fn()
+    const monitor = startRemoteRuntimeSocketLiveness({
+      ping,
+      onDead,
+      options: { pingIntervalMs: 100, livenessTimeoutMs: 250 },
+      now: () => now
+    })
+
+    for (const delta of [100, 100, 100]) {
+      now += delta
+      await vi.advanceTimersByTimeAsync(100)
+    }
+    expect(ping).toHaveBeenCalledTimes(1)
+
+    monitor.noteActivity()
+    for (const delta of [100, 100, 100]) {
+      now += delta
+      await vi.advanceTimersByTimeAsync(100)
+    }
+
+    expect(ping).toHaveBeenCalledTimes(2)
+    expect(onDead).not.toHaveBeenCalled()
+    monitor.stop()
+  })
+
+  it('re-baselines after a backward clock jump rather than killing', async () => {
+    let now = 1_000
+    const ping = vi.fn()
+    const onDead = vi.fn()
+    const monitor = startRemoteRuntimeSocketLiveness({
+      ping,
+      onDead,
+      options: { pingIntervalMs: 100, livenessTimeoutMs: 250 },
+      now: () => now
+    })
+
+    for (const delta of [100, 100, 100]) {
+      now += delta
+      await vi.advanceTimersByTimeAsync(100)
+    }
+    expect(ping).toHaveBeenCalledTimes(1)
+
+    now = 500
+    await vi.advanceTimersByTimeAsync(100)
+    expect(onDead).not.toHaveBeenCalled()
+
+    for (const delta of [100, 100, 100]) {
+      now += delta
+      await vi.advanceTimersByTimeAsync(100)
+    }
+    expect(ping).toHaveBeenCalledTimes(2)
+    expect(onDead).not.toHaveBeenCalled()
+    monitor.stop()
+  })
+
+  it('stops idempotently', () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const monitor = startRemoteRuntimeSocketLiveness({
+      ping: vi.fn(),
+      onDead: vi.fn(),
+      options: { pingIntervalMs: 100, livenessTimeoutMs: 250 }
+    })
+
+    monitor.stop()
+    monitor.stop()
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onDead exactly once', async () => {
+    let now = 1_000
+    const onDead = vi.fn()
+    startRemoteRuntimeSocketLiveness({
+      ping: vi.fn(),
+      onDead,
+      options: { pingIntervalMs: 100, livenessTimeoutMs: 250 },
+      now: () => now
+    })
+
+    for (let tick = 0; tick < 10; tick += 1) {
+      now += 100
+      await vi.advanceTimersByTimeAsync(100)
+    }
+
+    expect(onDead).toHaveBeenCalledTimes(1)
+  })
+
+  it('detects delayed and backward liveness ticks', () => {
+    expect(
+      isRemoteRuntimeLivenessTickDelayed({ now: 1_199, lastTickAt: 1_000, intervalMs: 100 })
+    ).toBe(false)
+    expect(
+      isRemoteRuntimeLivenessTickDelayed({ now: 1_200, lastTickAt: 1_000, intervalMs: 100 })
+    ).toBe(true)
+    expect(
+      isRemoteRuntimeLivenessTickDelayed({ now: 999, lastTickAt: 1_000, intervalMs: 100 })
+    ).toBe(true)
+  })
+})

--- a/src/shared/remote-runtime-socket-liveness.ts
+++ b/src/shared/remote-runtime-socket-liveness.ts
@@ -1,9 +1,9 @@
 // Why: a half-open tunnel (devtunnel/NAT drop) never delivers a ws `close`,
 // so edge-triggered reconnect logic on the client side never fires while the
 // server has long since reaped its end (#7718/#7489). This monitor gives
-// client sockets a level-based liveness check: ping on a cadence and declare
-// the socket dead when no inbound traffic (frames, pings, or pongs) arrives
-// within the window, so the existing close/reconnect path can run.
+// client sockets a level-based liveness check: send a probe after inbound
+// silence, then declare the socket dead only if that probe gets a full
+// unanswered window, so the existing close/reconnect path can run.
 
 // Why: pings ride the RFC 6455 control-frame layer, which every supported
 // server (and the `ws` package it embeds) answers automatically — this stays
@@ -23,6 +23,15 @@ export type RemoteRuntimeSocketLivenessMonitor = {
   stop: () => void
 }
 
+export function isRemoteRuntimeLivenessTickDelayed(args: {
+  now: number
+  lastTickAt: number
+  intervalMs: number
+}): boolean {
+  const elapsed = args.now - args.lastTickAt
+  return elapsed < 0 || elapsed >= args.intervalMs * 2
+}
+
 export function startRemoteRuntimeSocketLiveness(args: {
   ping: () => void
   onDead: () => void
@@ -34,24 +43,45 @@ export function startRemoteRuntimeSocketLiveness(args: {
   const livenessTimeoutMs =
     args.options?.livenessTimeoutMs ?? REMOTE_RUNTIME_SOCKET_LIVENESS_TIMEOUT_MS
   let lastActivityAt = now()
+  let lastTickAt = lastActivityAt
+  let probeSentAt: number | null = null
   let stopped = false
 
-  const timer = setInterval(() => {
+  const runTick = (): void => {
     if (stopped) {
       return
     }
-    if (now() - lastActivityAt > livenessTimeoutMs) {
+    const current = now()
+    if (
+      isRemoteRuntimeLivenessTickDelayed({
+        now: current,
+        lastTickAt,
+        intervalMs: pingIntervalMs
+      })
+    ) {
+      lastTickAt = current
+      lastActivityAt = current
+      probeSentAt = null
+      return
+    }
+    lastTickAt = current
+    if (probeSentAt !== null && current - probeSentAt >= livenessTimeoutMs) {
       stop()
       args.onDead()
       return
     }
-    try {
-      args.ping()
-    } catch {
-      // Why: ping() can throw while a socket is mid-teardown; the liveness
-      // window (or the close handler) settles the socket's fate either way.
+    if (probeSentAt === null && current - lastActivityAt >= livenessTimeoutMs) {
+      try {
+        args.ping()
+        probeSentAt = current
+      } catch {
+        // Why: ping() can throw while a socket is mid-teardown; the close path
+        // or the unanswered probe window decides the socket's fate.
+      }
     }
-  }, pingIntervalMs)
+  }
+
+  const timer = setInterval(runTick, pingIntervalMs)
   // Why: mobile typechecks shared code with DOM timer types where unref is absent.
   const unrefable = timer as unknown as { unref?: () => void }
   if (typeof unrefable.unref === 'function') {
@@ -69,6 +99,7 @@ export function startRemoteRuntimeSocketLiveness(args: {
   return {
     noteActivity: () => {
       lastActivityAt = now()
+      probeSentAt = null
     },
     stop
   }


### PR DESCRIPTION
## Summary

- make desktop and runtime WebSocket liveness pause-aware so the first timer tick after sleep starts a real probe instead of treating accumulated wall-clock silence as a failed probe
- keep shared-control logical subscriptions alive through recoverable outages with capped exponential backoff while disposing retries when the final subscriber leaves
- reset a shared-control socket after an RPC timeout only when no newer valid inbound frame proves that the connection is still active
- classify authentication and protocol failures once, with callback-safe cleanup

This is PR 1 of a three-PR stack for #8180. It establishes transport recovery foundations without changing terminal stream framing.

Refs #8180

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] focused remote-runtime Vitest suite: 28 files / 820 tests
- [x] `pnpm check:max-lines-ratchet`
- [x] `pnpm build:desktop`
- [x] `git diff --check origin/main...HEAD`
- [x] Added or updated regression tests for pause-aware probing, long-outage retry, stale reconnect timers, timeout activity generations, and fatal close classification
- [ ] full repository Vitest suite
- [ ] Electron E2E or physical macOS-to-Windows sleep/network interruption test

The commands above are a historical validation record from the `origin/main@ff8192a331` rebase; the branch has since been rebased again. The verification host used Node 26.5.0 while the repository declares Node 24; pnpm emitted the engine warning, and all commands above still passed.

## AI Review Report

Independent reviews checked the approved #8180 design, retry/cancellation races, callback reentrancy, mixed-version behavior, and compatibility with the renderer/terminal changes in v1.4.136-rc.0. Findings led to fixes for orphan reconnect timers, jitter exceeding the 30-second cap, close-only authentication failures, and throwing/reentrant fatal callbacks. Final verdict: spec PASS and code APPROVED.

Cross-platform review covered macOS sleep/resume, Linux and Windows timer/network behavior, SSH remote runtimes, and Electron boundaries. This layer adds no shortcuts, filesystem assumptions, dependencies, or wire fields.

## Security Audit

Reviewed authentication close handling, E2EE close-code normalization, subscription cleanup, request-timeout behavior, callback isolation, and logging. Fatal authentication/protocol errors stop retrying; recoverable network errors do not expose pairing data or credentials.

## Notes

Stack order:

1. this PR: transport foundations
2. #8254: structured terminal stream close semantics
3. #8255: negotiated replay and atomic terminal recovery

Merge in this order and roll back in reverse order.
