### PR TITLE
perf(terminal): tune cold-park keep-warm so common rotation never remounts

### DIFF
--- a/docs/reference/terminal-cold-park-reveal-cost.md
+++ b/docs/reference/terminal-cold-park-reveal-cost.md
@@ -1,0 +1,132 @@
+# Cold-park reveal cost — measured
+
+Companion to [`terminal-hidden-view-parking.md`](./terminal-hidden-view-parking.md).
+Quantifies the reveal latency a user pays when returning to a terminal whose
+hidden view was cold-parked, so the keep-warm policy is tuned from data rather
+than guessed. Motivated by field reports that "terminal mounting is jumpy —
+switching to a worktree after a while takes ~1s".
+
+## How to reproduce
+
+```bash
+pnpm bench:cold-park-reveal -- --cycles=12                      # empty shell
+pnpm bench:cold-park-reveal -- --cycles=10 --scrollback-lines=5000
+pnpm bench:cold-park-reveal -- --cycles=10 --scrollback-lines=20000
+```
+
+The bench (`tools/benchmarks/terminal-cold-park-reveal-bench.mjs`) drives the
+real dev app over CDP. Each cycle times a **cold** reveal (tab confirmed parked
+via `window.__terminalParkingDebug.parkedTabIds()` before revealing) and a
+**warm** reveal (revealed inside the hot-retain window, confirmed not parked),
+so the cold−warm delta is the isolated cost of parking. It shrinks the 30s
+hysteresis with `ORCA_E2E_TERMINAL_PARKING_DELAY_MS` and roots userData under a
+short `~/.ocpb` path — the default `/var/folders` tmp path overruns the macOS
+104-char Unix-socket limit, the daemon fails to bind, and terminals fall back to
+non-snapshot PTYs that never park.
+
+Phases per reveal (ms from the switch-back click): `activationMs` (store active
+worktree flips), `ptyBindMs` (revealed pane has a bound pty — xterm remounted
+and attached), `paintSettleMs` (two RAFs after ptyBind).
+
+## Results (macOS, dev app, medians / p95)
+
+| Scrollback | warm paintSettle | cold paintSettle | **cold-park penalty** |
+| ---------- | ---------------- | ---------------- | --------------------- |
+| empty shell   | 104 ms | 264 / 298 ms | **+160 ms** |
+| 5 000 lines   | 131 ms | 318 / 423 ms | **+187 ms** |
+| 20 000 lines  | 102 ms | 266 / 286 ms | **+164 ms** |
+
+All cold samples confirmed parked (`parkedConfirmed = N/N`); all warm samples
+confirmed not parked.
+
+## Finding
+
+**The cold-park reveal penalty is ~160–190 ms and effectively flat across buffer
+size.** Growing scrollback 0 → 20 000 lines did not grow the penalty (the 20k
+run is within noise of empty). So the cost is **fixed remount overhead** — React
+subtree teardown/rebuild, fresh xterm construction, WebGL attach, fit, and the
+reattach reset — **not** daemon snapshot replay, which scales fine.
+
+Implications for tuning:
+
+- The lever is **how often a remount happens**, not how much is replayed.
+  Widening the keep-warm working set (worktree hot-retain limit is 4, tabs 12)
+  and never parking the last-active tab per worktree remove remounts entirely
+  for the common switch-away-and-back, which is worth more than shaving the
+  ~170 ms remount itself.
+- Pre-warming a predicted reveal (sidebar hover, jump-palette selection) hides
+  the fixed cost behind the navigation instead of eliminating it.
+- This synthetic terminal is a plain shell. A live agent TUI in the alternate
+  screen pays additional reattach-reset + mode-rehydrate work on reveal (see the
+  Grok-scrollback reattach path), so real-world cold reveals of a busy agent
+  pane can exceed these numbers — the ~170 ms here is a floor for the mount
+  overhead, not a ceiling for the full experience.
+
+## Is parking worth having? (benefit side)
+
+`tools/benchmarks/terminal-cold-park-resource-bench.mjs`
+(`pnpm bench:cold-park-resource`) A/Bs the `terminalHiddenViewParking` setting
+in one session: mount N worktree terminals, background all but one, then read
+resources with parking off vs on. Measured at 8 backgrounded worktrees
+(5 000-line scrollback each):
+
+| metric | parking off | parking on | released |
+| ------ | ----------- | ---------- | -------- |
+| mounted pane managers | 9 | 1 | **8** |
+| DOM nodes | 2 941 | 1 389 | **1 552** |
+| attached WebGL contexts | 1 | 1 | **0** |
+
+So parking's unique win is **releasing every hidden terminal's mounted view** —
+8 xterm instances + their DOM subtrees (~1 550 nodes) here. At xterm's default
+5 000-row scrollback, each terminal buffer alone is ≥ ~4–5 MB of typed-array
+cell data (12 bytes/cell × 80 cols × 5 000 rows), so the renderer-memory floor
+is on the order of **several MB per hidden terminal** — tens of MB across a
+many-worktree session, before DOM and addon overhead.
+
+Two honest caveats on the numbers:
+
+- The **WebGL-context budget is NOT parking's win.** Even with parking off, only
+  one context was attached across 9 mounted terminals — the separate
+  WebGL-suspend-on-hide path (`suspendRendering`) already releases hidden panes'
+  contexts. So the #6874 context-exhaustion protection stands with or without
+  parking; parking's benefit is renderer memory + DOM, not contexts.
+- The measured JS-heap delta was small (~1.7 MB) because detached xterm
+  typed-array buffers GC lazily and the first measurement ran before they were
+  reclaimed. The bench was upgraded to force multi-pass GC and read whole-app
+  process memory (`window.api.memory.getSnapshot`), but a machine under disk +
+  memory pressure could not complete the upgraded run (esbuild dev-service
+  crashes). Re-run the upgraded bench on a healthy machine to get the settled
+  whole-app memory figure; the pane-manager / DOM release above is the robust,
+  reproducible part.
+
+### Verdict
+
+Parking earns its keep for the **many-worktree power user** (the reporter's
+profile): it is the only mechanism that frees hidden terminals' view memory and
+DOM, which is the dominant renderer cost at scale. It does **not** provide the
+GPU-context protection (that is suspend-on-hide's job). The reveal price is a
+flat ~170 ms remount. Net: keep it, and tune the keep-warm caps so the common
+few-worktree rotation never pays the remount.
+
+### Tuning applied
+
+Because the reveal cost is a fixed remount, the levers are all about
+**frequency**, not replay size. Three changes to
+`terminal-hidden-view-parking.ts`:
+
+- **Worktree hot-retain limit 4 → 8.** Eight covers the ordinary working set;
+  at the ~4–5 MB renderer floor per hidden worktree that is ~16–20 MB worst
+  case to eliminate remounts for the common rotation. Beyond 8, parking still
+  reclaims for the heavy tail it was built for.
+- **Hot-retain TTL 5 min → 15 min** (worktree and tab). The cap, not the clock,
+  is the primary evictor now; 5 min was aggressive enough that a meeting-length
+  absence parked the whole warm set. The tab count cap stays 12 (already
+  generous).
+- **Last-active exemption.** The single most-recently-hidden worktree/tab is
+  never parked, regardless of TTL or cap, so returning to the view you just
+  left is always instant. Implemented in `selectIdsBeyondHotRetain`; it holds
+  one warm slot and counts against the cap.
+
+Not done (deliberately): pre-warm on predicted reveal — it hides the cost
+behind navigation rather than removing it and adds hover/prediction complexity;
+and the 30 s cold-park delay is unchanged (it is the quick-flip guard).

--- a/docs/reference/terminal-hidden-view-parking.md
+++ b/docs/reference/terminal-hidden-view-parking.md
@@ -29,7 +29,11 @@ A pure policy module decides which hidden terminal tabs may park:
 
 - Cold-park hysteresis: a tab must be hidden for 30s before parking.
 - Hot-retain working set: recently visible worktrees/tabs are retained
-  (5 minutes, bounded count) so quick tab switches never pay a re-hydrate.
+  (15 minutes; up to 8 worktrees / 12 tabs) so quick tab switches never pay a
+  re-hydrate. The single most-recently-hidden (last-active) worktree/tab is
+  exempt from both the retain TTL and the count cap, so switching back to the
+  view you just left is always instant regardless of how long you were away.
+  See `terminal-cold-park-reveal-cost.md` for the data behind these caps.
 - Eligibility excludes: visible panes, hidden-measuring startup probes,
   activity-portal panes, tabs with pending startup commands or pending
   activation spawns, floating-panel tabs, and any tab whose PTY is not

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "bench:daemon-coldstart": "pnpm run ensure:electron-runtime && node tools/benchmarks/daemon-coldstart-bench.mjs",
     "bench:main-thread-jank": "pnpm run ensure:electron-runtime && node tools/benchmarks/main-thread-jank-bench.mjs",
     "bench:multi-workspace-typing": "pnpm run ensure:electron-runtime && node config/scripts/run-multi-workspace-typing-bench.mjs",
+    "bench:cold-park-reveal": "pnpm run ensure:electron-runtime && node tools/benchmarks/terminal-cold-park-reveal-bench.mjs",
+    "bench:cold-park-resource": "pnpm run ensure:electron-runtime && node tools/benchmarks/terminal-cold-park-resource-bench.mjs",
     "bench:compare": "node config/scripts/compare-benchmark-artifacts.mjs"
   },
   "dependencies": {

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
@@ -214,7 +214,12 @@ describe('selectColdParkedTerminalWorktrees', () => {
 
   it('cold-parks aged local worktrees even when under the retain limit', () => {
     const selected = selectColdParkedTerminalWorktrees({
-      worktrees: [localCandidate('wt-1', nowMs - TERMINAL_WORKTREE_HOT_RETAIN_MS)],
+      worktrees: [
+        // Why: wt-recent is the last-active exempt one; wt-1 proves the TTL
+        // sweep still parks an aged worktree that is under the cap.
+        localCandidate('wt-recent', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS),
+        localCandidate('wt-1', nowMs - TERMINAL_WORKTREE_HOT_RETAIN_MS)
+      ],
       pendingStartupByTabId: {},
       parkingEnabled: true,
       nowMs,
@@ -222,6 +227,36 @@ describe('selectColdParkedTerminalWorktrees', () => {
     })
 
     expect(selected).toEqual(new Set(['wt-1']))
+  })
+
+  it('never cold-parks the single most-recently-hidden (last-active) worktree', () => {
+    const selected = selectColdParkedTerminalWorktrees({
+      worktrees: [localCandidate('wt-1', nowMs - TERMINAL_WORKTREE_HOT_RETAIN_MS)],
+      pendingStartupByTabId: {},
+      parkingEnabled: true,
+      nowMs,
+      hotRetainLimit: 0
+    })
+
+    expect(selected).toEqual(new Set())
+  })
+
+  it('exempts only the last-active worktree from the cap, counting it against the limit', () => {
+    const selected = selectColdParkedTerminalWorktrees({
+      worktrees: [
+        localCandidate('wt-1', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS),
+        localCandidate('wt-2', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS - 1),
+        localCandidate('wt-3', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS - 2)
+      ],
+      pendingStartupByTabId: {},
+      parkingEnabled: true,
+      nowMs,
+      // Why: wt-1 (last-active) takes one of the two warm slots, so only wt-2
+      // fits the remaining slot and wt-3 parks.
+      hotRetainLimit: 2
+    })
+
+    expect(selected).toEqual(new Set(['wt-3']))
   })
 
   it('selects nothing when the settings kill switch disables parking', () => {
@@ -242,6 +277,10 @@ describe('selectColdParkedTerminalWorktrees', () => {
   it('does not cold-park terminals without local snapshot recovery', () => {
     const selected = selectColdParkedTerminalWorktrees({
       worktrees: [
+        // Why: wt-recent is last-active (exempt); wt-local proves the aged
+        // local worktree still parks while ssh/remote never enter the candidate
+        // set at all.
+        localCandidate('wt-recent', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS),
         localCandidate('wt-local', nowMs - TERMINAL_WORKTREE_HOT_RETAIN_MS),
         {
           ...localCandidate('wt-ssh', nowMs - TERMINAL_WORKTREE_HOT_RETAIN_MS),
@@ -349,7 +388,12 @@ describe('selectColdParkedTerminalTabs', () => {
   it('cold-parks aged inactive local tabs even when under the retain limit', () => {
     const selected = selectColdParkedTerminalTabs({
       worktreeId: 'wt-1',
-      terminalTabs: [localTab('tab-1', nowMs - TERMINAL_TAB_HOT_RETAIN_MS)],
+      terminalTabs: [
+        // Why: tab-recent is last-active exempt; tab-1 proves the TTL sweep
+        // still parks an aged tab under the cap.
+        localTab('tab-recent', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS),
+        localTab('tab-1', nowMs - TERMINAL_TAB_HOT_RETAIN_MS)
+      ],
       pendingStartupByTabId: {},
       parkingEnabled: true,
       nowMs,
@@ -357,6 +401,19 @@ describe('selectColdParkedTerminalTabs', () => {
     })
 
     expect(selected).toEqual(new Set(['tab-1']))
+  })
+
+  it('never cold-parks the single most-recently-hidden (last-active) tab', () => {
+    const selected = selectColdParkedTerminalTabs({
+      worktreeId: 'wt-1',
+      terminalTabs: [localTab('tab-1', nowMs - TERMINAL_TAB_HOT_RETAIN_MS)],
+      pendingStartupByTabId: {},
+      parkingEnabled: true,
+      nowMs,
+      hotRetainLimit: 0
+    })
+
+    expect(selected).toEqual(new Set())
   })
 
   it('selects nothing when the settings kill switch disables parking', () => {
@@ -379,6 +436,9 @@ describe('selectColdParkedTerminalTabs', () => {
     const selected = selectColdParkedTerminalTabs({
       worktreeId: 'wt-1',
       terminalTabs: [
+        // Why: tab-recent is last-active exempt; tab-local proves the aged
+        // local tab still parks while ssh/remote never enter the candidate set.
+        localTab('tab-recent', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS),
         localTab('tab-local', nowMs - TERMINAL_TAB_HOT_RETAIN_MS),
         {
           ...localTab('tab-ssh', nowMs - TERMINAL_TAB_HOT_RETAIN_MS),

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
@@ -5,13 +5,17 @@ import type { TerminalTab } from '../../../../shared/types'
 
 // Why: cold-park hysteresis keeps a hidden pane mounted for 30s so quick tab
 // flips never pay a re-hydrate; hot-retain keeps a bounded recently-visible
-// working set warm for 5 minutes beyond that.
+// working set warm for 15 minutes beyond that. The cap (not the clock) is the
+// primary evictor — 8 worktrees covers the ordinary working set at ~4-5MB
+// renderer floor each, so parking only engages for the many-worktree tail it
+// was built for. Reveal cost is a flat ~170ms remount regardless of buffer
+// size, so cutting remount *frequency* beats shaving replay.
 export const TERMINAL_WORKTREE_COLD_PARK_DELAY_MS = 30_000
-export const TERMINAL_WORKTREE_HOT_RETAIN_MS = 5 * 60_000
-export const TERMINAL_WORKTREE_HOT_RETAIN_LIMIT = 4
+export const TERMINAL_WORKTREE_HOT_RETAIN_MS = 15 * 60_000
+export const TERMINAL_WORKTREE_HOT_RETAIN_LIMIT = 8
 export const TERMINAL_WORKTREE_PARK_DELAY_MS = TERMINAL_WORKTREE_COLD_PARK_DELAY_MS
 export const TERMINAL_TAB_COLD_PARK_DELAY_MS = 30_000
-export const TERMINAL_TAB_HOT_RETAIN_MS = 5 * 60_000
+export const TERMINAL_TAB_HOT_RETAIN_MS = 15 * 60_000
 export const TERMINAL_TAB_HOT_RETAIN_LIMIT = 12
 
 // Why: tests override these per call (instead of process.env reads inside the
@@ -134,16 +138,40 @@ export function canParkTerminalTabRenderer(args: {
 
 type ColdParkRetainCandidate = { id: string; hiddenSinceMs: number }
 
+// Why: the single most-recently-hidden candidate is the view the user just
+// switched away from; keeping it warm regardless of the TTL or cap means
+// switching back after any absence (a meeting, coffee) is always instant, the
+// remount cost users actually notice. Ties break by id for determinism.
+function selectLastActiveRetainedId(candidates: ColdParkRetainCandidate[]): string | null {
+  let lastActive: ColdParkRetainCandidate | null = null
+  for (const candidate of candidates) {
+    if (
+      lastActive === null ||
+      candidate.hiddenSinceMs > lastActive.hiddenSinceMs ||
+      (candidate.hiddenSinceMs === lastActive.hiddenSinceMs &&
+        candidate.id.localeCompare(lastActive.id) < 0)
+    ) {
+      lastActive = candidate
+    }
+  }
+  return lastActive?.id ?? null
+}
+
 // Why: hot-retain keeps the most recently hidden ids warm up to the limit;
-// ids hidden past hotRetainMs or beyond the limit cold-park. Ties sort by id
-// so the selection is deterministic.
+// ids hidden past hotRetainMs or beyond the limit cold-park. The last-active
+// id is exempt from both so returning to it never pays a remount. Ties sort by
+// id so the selection is deterministic.
 function selectIdsBeyondHotRetain(
   candidates: ColdParkRetainCandidate[],
   args: { nowMs: number; hotRetainMs: number; hotRetainLimit: number }
 ): Set<string> {
+  const lastActiveId = selectLastActiveRetainedId(candidates)
   const coldParkedIds = new Set<string>()
   const retainedCandidates: ColdParkRetainCandidate[] = []
   for (const candidate of candidates) {
+    if (candidate.id === lastActiveId) {
+      continue
+    }
     if (args.nowMs - candidate.hiddenSinceMs >= args.hotRetainMs) {
       coldParkedIds.add(candidate.id)
     } else {
@@ -154,7 +182,10 @@ function selectIdsBeyondHotRetain(
     const recencyDelta = b.hiddenSinceMs - a.hiddenSinceMs
     return recencyDelta === 0 ? a.id.localeCompare(b.id) : recencyDelta
   })
-  for (const candidate of retainedCandidates.slice(Math.max(0, args.hotRetainLimit))) {
+  // Why: the last-active id already holds one slot in the warm working set, so
+  // the cap counts it out — the remaining candidates fill hotRetainLimit-1.
+  const remainingLimit = lastActiveId === null ? args.hotRetainLimit : args.hotRetainLimit - 1
+  for (const candidate of retainedCandidates.slice(Math.max(0, remainingLimit))) {
     coldParkedIds.add(candidate.id)
   }
   return coldParkedIds

--- a/tests/e2e/terminal-parked-memory.spec.ts
+++ b/tests/e2e/terminal-parked-memory.spec.ts
@@ -33,8 +33,9 @@ test.use({
 // never retains anything here — the ORCA_E2E_TERMINAL_PARKING_DELAY_MS
 // collapse (terminal-parking-e2e-overrides.ts) shrinks hotRetainMs to the
 // same delay as coldParkDelayMs, and the policy cold-parks any tab hidden
-// past hotRetainMs before the retain-count limit is even consulted. So all 8
-// park without needing 14 tabs or extra policy knobs.
+// past hotRetainMs before the retain-count limit is even consulted. The one
+// exception is the last-active (most-recently-hidden) tab, which is exempt
+// from parking so returning to it is instant — so 7 of the 8 park.
 const SCROLLBACK_TAB_COUNT = 8
 const SCROLLBACK_LINE_COUNT = 3000
 const PARK_SETTLE_MS = 2_000
@@ -105,13 +106,17 @@ async function countMountedPaneManagers(page: Page, tabIds: string[]): Promise<n
   )
 }
 
-async function waitForTabsParked(page: Page, tabIds: string[]): Promise<void> {
+// Why: the last-active tab per worktree is exempt from parking so returning to
+// it is instant, so one of the hidden scrollback tabs stays mounted. The
+// exempt one is the most-recently-hidden — here the last scrollback tab filled
+// before the visible tab was created — so we expect exactly one still mounted.
+async function waitForTabsParkedExceptLastActive(page: Page, tabIds: string[]): Promise<void> {
   await expect
     .poll(() => countMountedPaneManagers(page, tabIds), {
       timeout: Math.max(30_000, PARKING_DELAY_MS * 10),
-      message: 'hidden scrollback tabs did not all park (pane managers still mounted)'
+      message: 'hidden scrollback tabs did not park down to the last-active exemption'
     })
-    .toBe(0)
+    .toBe(1)
 }
 
 type ScrollbackTab = {
@@ -264,9 +269,16 @@ test.describe('Terminal parked memory', () => {
     try {
       const { worktreeId, scrollbackTabs } = await setUpScrollbackTabs(orcaPage, scriptPath, runId)
 
-      // A fresh 9th tab hides all 8 scrollback tabs.
+      // A fresh 9th tab hides all 8 scrollback tabs. The last one filled is the
+      // most-recently-hidden, so it stays warm under the last-active exemption;
+      // the other 7 park.
       const visibleTab = await createActiveTerminalTab(orcaPage, worktreeId)
-      await waitForTabsParked(
+      const lastActiveTab = scrollbackTabs.at(-1)
+      if (!lastActiveTab) {
+        throw new Error('parked memory spec: no scrollback tabs were created')
+      }
+      const parkableTabs = scrollbackTabs.slice(0, -1)
+      await waitForTabsParkedExceptLastActive(
         orcaPage,
         scrollbackTabs.map((tab) => tab.tabId)
       )
@@ -274,21 +286,22 @@ test.describe('Terminal parked memory', () => {
       const metrics = await sampleParkedMemoryMetrics(orcaPage)
       testInfo.annotations.push({
         type: 'opencode-parked-memory',
-        description: formatParkedMemoryAnnotation(metrics, scrollbackTabs.length)
+        description: formatParkedMemoryAnnotation(metrics, parkableTabs.length)
       })
 
-      // Structural assertions: all 8 parked (managers gone), and the only
-      // live xterm/pane manager belongs to the visible tab.
-      for (const tab of scrollbackTabs) {
+      // Structural assertions: the 7 non-last-active tabs parked (managers
+      // gone); the visible tab and the exempt last-active tab keep theirs.
+      for (const tab of parkableTabs) {
         expect((await readTerminalTabViewState(orcaPage, tab.tabId)).hasManager).toBe(false)
       }
+      expect((await readTerminalTabViewState(orcaPage, lastActiveTab.tabId)).hasManager).toBe(true)
       const visibleState = await readTerminalTabViewState(orcaPage, visibleTab.tabId)
       expect(visibleState.hasManager).toBe(true)
       expect(visibleState.paneCount).toBeGreaterThan(0)
-      // Why: design invariant 5 — renderer terminal views scale with visible
-      // panes, so parked tabs must leave no xterm DOM behind.
-      expect(metrics.liveTerminals).toBe(visibleState.paneCount)
-      expect(metrics.livePaneManagers).toBe(1)
+      // Why: design invariant 5 — renderer terminal views scale with mounted
+      // panes; only the visible tab and the exempt last-active tab keep an
+      // xterm and pane manager, everything else parks.
+      expect(metrics.livePaneManagers).toBe(2)
     } finally {
       rmSync(scriptPath, { force: true })
     }

--- a/tools/benchmarks/terminal-cold-park-resource-bench.mjs
+++ b/tools/benchmarks/terminal-cold-park-resource-bench.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+// Cold-park RESOURCE-BENEFIT benchmark: answers "is cold parking worth having?"
+// by measuring what it actually saves at many-worktree scale — renderer JS
+// heap, live WebGL contexts, and mounted pane managers — with parking OFF vs
+// ON in the SAME app session (toggled via the terminalHiddenViewParking
+// setting). The companion reveal-cost bench measures the price you pay on
+// reveal; this measures the benefit you get while backgrounded.
+//
+// Method: create N worktrees each with one terminal primed with scrollback,
+// leave one foreground and background the rest, then read resources in two
+// states:
+//   off — parking disabled: every hidden terminal stays fully mounted
+//   on  — parking enabled: hidden terminals past the (shrunk) hysteresis park
+// The off−on delta is the resource win parking buys.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import {
+  collectRendererDiagnostics,
+  connectToApp,
+  installRendererProbe,
+  launchDevApp,
+  pickFreePort,
+  stopDevApp,
+  waitForStoreReady
+} from '../../config/scripts/windows-apphang-repro/electron-dev-session.mjs'
+import { createCompletedOnboardingProfile } from '../../config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs'
+import {
+  pollUntil,
+  rendererActionTimeoutMs,
+  runWithTimeout,
+  setupTimeoutMs
+} from '../../config/scripts/windows-apphang-repro/repro-timing.mjs'
+import { safeRemoveLocalDirectory } from '../../config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs'
+
+const rootDir = path.resolve(fileURLToPath(new URL('../..', import.meta.url)))
+const PARK_DELAY_MS = 1_500
+const SETTLE_AFTER_PARK_MS = 4_000
+// Short root so the daemon Unix socket fits under the macOS 104-char limit;
+// the default /var/folders tmp path overruns it and the daemon fails, leaving
+// terminals non-snapshot-backed and therefore unparkable.
+const shortRoot = path.join(os.homedir(), '.ocpr')
+
+function parseArgs() {
+  const args = {
+    label: 'run',
+    worktrees: 8,
+    scrollbackLines: 5000,
+    reportPath: null,
+    keep: false
+  }
+  for (const arg of process.argv.slice(2)) {
+    if (arg === '--help' || arg === '-h') {
+      console.log(
+        'Usage: node tools/benchmarks/terminal-cold-park-resource-bench.mjs [--label=name] [--worktrees=N] [--scrollback-lines=N] [--report=path] [--keep]'
+      )
+      process.exit(0)
+    }
+    if (arg === '--keep') {
+      args.keep = true
+      continue
+    }
+    const [name, value] = arg.split('=', 2)
+    if (name === '--label') {
+      args.label = value?.trim() || 'run'
+    } else if (name === '--worktrees') {
+      args.worktrees = Math.max(2, Number(value) || 8)
+    } else if (name === '--scrollback-lines') {
+      args.scrollbackLines = Math.max(0, Number(value) || 0)
+    } else if (name === '--report') {
+      args.reportPath = value
+    }
+  }
+  return args
+}
+
+function git(cwd, ...cmd) {
+  execFileSync('git', cmd, { cwd, stdio: 'pipe' })
+}
+
+function createShortUserDataDirectory() {
+  mkdirSync(shortRoot, { recursive: true })
+  const userDataDir = mkdtempSync(path.join(shortRoot, 'ud-'))
+  createCompletedOnboardingProfile(userDataDir)
+  return userDataDir
+}
+
+function createLocalRepoFixture(worktreeCount) {
+  mkdirSync(shortRoot, { recursive: true })
+  const baseDir = mkdtempSync(path.join(shortRoot, 'fx-'))
+  const repoPath = path.join(baseDir, 'repo')
+  mkdirSync(repoPath, { recursive: true })
+  git(repoPath, 'init', '--initial-branch=main')
+  git(repoPath, 'config', 'user.email', 'bench@orca.local')
+  git(repoPath, 'config', 'user.name', 'Orca Bench')
+  writeFileSync(path.join(repoPath, 'README.md'), '# cold-park resource fixture\n')
+  git(repoPath, 'add', '.')
+  git(repoPath, 'commit', '-m', 'init', '--no-gpg-sign')
+  const worktreePaths = []
+  for (let i = 0; i < worktreeCount; i++) {
+    const worktreePath = path.join(baseDir, `wt-${i}`)
+    git(repoPath, 'worktree', 'add', worktreePath, '-b', `wt-${i}`)
+    worktreePaths.push(worktreePath)
+  }
+  return { baseDir, repoPath, worktreePaths }
+}
+
+async function setupWorkspaces(page, fixture) {
+  return await runWithTimeout(
+    'fixture registration in Orca',
+    () =>
+      page.evaluate(
+        async ({ repoPath, importedWorktreePaths }) => {
+          const store = window.__store
+          if (!store) {
+            throw new Error('window.__store is unavailable.')
+          }
+          await store.getState().fetchSettings?.()
+          const addResult = await window.api.repos.add({ path: repoPath, kind: 'git' })
+          if ('error' in addResult) {
+            throw new Error(addResult.error)
+          }
+          await store.getState().fetchRepos()
+          const state = store.getState()
+          const repo = state.repos.find((c) => c.path === repoPath) ?? addResult.repo
+          await state.updateRepo(repo.id, {
+            externalWorktreeVisibility: 'show',
+            externalWorktreeVisibilityPromptDismissedAt: Date.now(),
+            importedExternalWorktreePaths: importedWorktreePaths,
+            externalWorktreeInboxBaselinePaths: importedWorktreePaths
+          })
+          await store.getState().fetchWorktrees(repo.id, { requireAuthoritative: true })
+          const nextState = store.getState()
+          nextState.setSidebarOpen(true)
+          nextState.setGroupBy('none')
+          nextState.setSortBy('recent')
+          nextState.setShowActiveOnly(false)
+          nextState.setActiveView('terminal')
+          return { repoId: repo.id }
+        },
+        { repoPath: fixture.repoPath, importedWorktreePaths: fixture.worktreePaths }
+      ),
+    setupTimeoutMs
+  )
+}
+
+async function listWorktrees(page, repoId) {
+  return page.evaluate(async (id) => {
+    await window.__store
+      ?.getState?.()
+      ?.fetchWorktrees?.(id, { requireAuthoritative: true })
+      .catch(() => undefined)
+    const state = window.__store?.getState?.()
+    const list = state?.worktreesByRepo?.[id] ?? []
+    return list.map((w) => ({
+      id: w.id,
+      path: w.path,
+      isMainWorktree: w.isMainWorktree
+    }))
+  }, repoId)
+}
+
+async function clickWorktreeCard(page, worktreeId) {
+  const rect = await runWithTimeout(
+    `locate worktree card ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const rows = Array.from(document.querySelectorAll('[data-worktree-id]'))
+        const row = rows.find((c) => c.getAttribute('data-worktree-id') === id)
+        if (!row) {
+          return null
+        }
+        row.scrollIntoView({ block: 'center', inline: 'nearest' })
+        const surface = row.querySelector('[data-worktree-card-surface="true"]') ?? row
+        const bounds = surface.getBoundingClientRect()
+        if (bounds.width <= 0 || bounds.height <= 0) {
+          return null
+        }
+        return { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 }
+      }, worktreeId),
+    rendererActionTimeoutMs
+  )
+  if (!rect) {
+    throw new Error(`Could not find rendered worktree card for ${worktreeId}`)
+  }
+  await runWithTimeout(
+    `click worktree card ${worktreeId}`,
+    () => page.mouse.click(rect.x, rect.y),
+    rendererActionTimeoutMs
+  )
+}
+
+async function activateWorktreeTerminal(page, worktreeId) {
+  await clickWorktreeCard(page, worktreeId)
+  await pollUntil(
+    `active worktree ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        return state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+      }, worktreeId),
+    Boolean,
+    30_000
+  )
+}
+
+async function waitForBoundTerminal(page, worktreeId) {
+  return await pollUntil(
+    `pty bound ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        const tabId =
+          state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+            ? state.activeTabId
+            : (state?.activeTabIdByWorktree?.[id] ?? null)
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+        return pane?.container?.dataset?.ptyId ?? null
+      }, worktreeId),
+    Boolean,
+    30_000,
+    10
+  )
+}
+
+async function primeScrollback(page, worktreeId, lineCount) {
+  if (lineCount <= 0) {
+    return 0
+  }
+  const ptyId = await page.evaluate((id) => {
+    const state = window.__store?.getState?.()
+    const tabId =
+      state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+        ? state.activeTabId
+        : (state?.activeTabIdByWorktree?.[id] ?? null)
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+    return pane?.container?.dataset?.ptyId ?? null
+  }, worktreeId)
+  if (!ptyId) {
+    return 0
+  }
+  const cmd = `awk 'BEGIN{for(i=0;i<${lineCount};i++)printf "%04d %s\\n", i, "cold-park-resource-scrollback-priming-line-padding-to-eighty-cols"}'\n`
+  await page.evaluate(({ id, c }) => window.api.pty.write(id, c), { id: ptyId, c: cmd })
+  return await pollUntil(
+    `scrollback primed ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        const tabId =
+          state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+            ? state.activeTabId
+            : (state?.activeTabIdByWorktree?.[id] ?? null)
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+        return (pane?.serializeAddon?.serialize?.() ?? '').length
+      }, worktreeId),
+    (len) => Number.isFinite(len) && len > lineCount * 30,
+    20_000,
+    100
+  ).catch(() => 0)
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function setParkingEnabled(page, enabled) {
+  await page.evaluate(async (value) => {
+    const store = window.__store
+    await store.getState().updateSettings?.({ terminalHiddenViewParking: value })
+  }, enabled)
+}
+
+const toMB = (bytes) => (bytes == null ? null : Math.round((bytes / 1048576) * 10) / 10)
+
+/** Force GC repeatedly (detached xterm buffers are typed arrays that GC lazily),
+ *  then read whole-app process memory (main+renderer via getAppMetrics), renderer
+ *  JS heap, and pane/WebGL counts. */
+async function measureResources(page, cdp) {
+  // Why: one collectGarbage rarely reclaims freshly detached xterm typed-array
+  // buffers; drive several passes with settle gaps so the parked delta reflects
+  // reclaimed memory, not GC lag.
+  for (let i = 0; i < 4; i++) {
+    await cdp.send('HeapProfiler.collectGarbage').catch(() => undefined)
+    await sleep(400)
+  }
+  const metrics = await cdp.send('Performance.getMetrics').catch(() => ({ metrics: [] }))
+  const metricMap = Object.fromEntries((metrics.metrics ?? []).map((m) => [m.name, m.value]))
+  const renderer = await page.evaluate(async () => {
+    const managers = window.__paneManagers
+    let attachedWebgl = 0
+    let paneCount = 0
+    for (const [, manager] of managers?.entries?.() ?? []) {
+      const diags = manager?.getRenderingDiagnostics?.() ?? []
+      paneCount += diags.length
+      for (const d of diags) {
+        if (d.hasWebgl) {
+          attachedWebgl += 1
+        }
+      }
+    }
+    const mem = performance?.memory ?? null
+    // Whole-app process memory (main + renderer + other) from getAppMetrics —
+    // the number that captures the daemon-snapshot cost the renderer heap can't.
+    const snapshot = await window.api?.memory?.getSnapshot?.().catch(() => null)
+    return {
+      paneManagerCount: managers?.size ?? 0,
+      terminalPaneCount: paneCount,
+      attachedWebglContexts: attachedWebgl,
+      rendererJsHeapUsedMB: mem ? Math.round((mem.usedJSHeapSize / 1048576) * 10) / 10 : null,
+      appMemory: snapshot?.app
+        ? {
+            totalMB: Math.round(((snapshot.app.memory ?? 0) / 1048576) * 10) / 10,
+            mainMB: Math.round(((snapshot.app.main?.memory ?? 0) / 1048576) * 10) / 10,
+            rendererMB: Math.round(((snapshot.app.renderer?.memory ?? 0) / 1048576) * 10) / 10,
+            otherMB: Math.round(((snapshot.app.other?.memory ?? 0) / 1048576) * 10) / 10
+          }
+        : null
+    }
+  })
+  return {
+    ...renderer,
+    cdpJsHeapUsedMB: toMB(metricMap.JSHeapUsedSize),
+    cdpNodes: metricMap.Nodes ?? null,
+    cdpLayoutCount: metricMap.LayoutCount ?? null
+  }
+}
+
+async function main() {
+  const args = parseArgs()
+  const startedAt = Date.now()
+  const report = {
+    label: args.label,
+    startedAt: new Date(startedAt).toISOString(),
+    platform: `${process.platform} ${os.release()}`,
+    parkDelayMs: PARK_DELAY_MS,
+    args: { worktrees: args.worktrees, scrollbackLines: args.scrollbackLines },
+    states: {},
+    cleanupErrors: []
+  }
+  let fixture = null
+  let userDataDir = null
+  let launched = null
+  let browser = null
+  let page = null
+  try {
+    fixture = createLocalRepoFixture(args.worktrees)
+    const cdpPort = await pickFreePort()
+    userDataDir = createShortUserDataDirectory()
+    process.env.ORCA_E2E_TERMINAL_PARKING_DELAY_MS = String(PARK_DELAY_MS)
+    console.log(
+      `[cold-park-res] fixture=${fixture.baseDir} userData=${userDataDir} cdp=${cdpPort} worktrees=${args.worktrees}`
+    )
+    launched = launchDevApp({ cdpPort, userDataDir })
+    const connected = await connectToApp(cdpPort)
+    browser = connected.browser
+    page = connected.page
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Performance.enable').catch(() => undefined)
+    await cdp.send('HeapProfiler.enable').catch(() => undefined)
+    await waitForStoreReady(page)
+    await installRendererProbe(page)
+    const setup = await setupWorkspaces(page, fixture)
+    const worktrees = await pollUntil(
+      'worktrees registered',
+      () => listWorktrees(page, setup.repoId),
+      (list) => Array.isArray(list) && list.length >= args.worktrees,
+      45_000,
+      500
+    )
+    console.log(`[cold-park-res] ${worktrees.length} worktrees registered`)
+    const primary = worktrees.find((w) => w.isMainWorktree) ?? worktrees[0]
+    const anotherWorktree = worktrees.find((w) => w.id !== primary.id)
+
+    // Ensure parking is OFF while we mount + prime every terminal, so all N
+    // stay fully mounted for the baseline measurement.
+    await setParkingEnabled(page, false)
+    for (const wt of worktrees) {
+      await activateWorktreeTerminal(page, wt.id)
+      await waitForBoundTerminal(page, wt.id)
+      await primeScrollback(page, wt.id, args.scrollbackLines)
+    }
+    // Foreground the primary; the other N-1 are now backgrounded but — with
+    // parking OFF — still fully mounted.
+    await activateWorktreeTerminal(page, primary.id)
+    await sleep(SETTLE_AFTER_PARK_MS)
+    report.states.parkingOff = await measureResources(page, cdp)
+    console.log(`[cold-park-res] parkingOff: ${JSON.stringify(report.states.parkingOff)}`)
+
+    // Turn parking ON; the backgrounded worktrees pass the shrunk hysteresis
+    // and park. Nudge a re-evaluation by toggling focus so the park timers arm.
+    await setParkingEnabled(page, true)
+    await sleep(PARK_DELAY_MS + 500)
+    // Re-focus primary to trigger the park policy effect re-run for the others.
+    await activateWorktreeTerminal(page, anotherWorktree.id)
+    await activateWorktreeTerminal(page, primary.id)
+    await sleep(SETTLE_AFTER_PARK_MS)
+    report.states.parkingOn = await measureResources(page, cdp)
+    console.log(`[cold-park-res] parkingOn: ${JSON.stringify(report.states.parkingOn)}`)
+
+    const off = report.states.parkingOff
+    const on = report.states.parkingOn
+    const subMB = (a, b) => (a != null && b != null ? Math.round((a - b) * 10) / 10 : null)
+    report.delta = {
+      paneManagersReleased: off.paneManagerCount - on.paneManagerCount,
+      webglContextsReleased: off.attachedWebglContexts - on.attachedWebglContexts,
+      cdpJsHeapSavedMB: subMB(off.cdpJsHeapUsedMB, on.cdpJsHeapUsedMB),
+      rendererJsHeapSavedMB: subMB(off.rendererJsHeapUsedMB, on.rendererJsHeapUsedMB),
+      appTotalSavedMB: subMB(off.appMemory?.totalMB, on.appMemory?.totalMB),
+      appRendererSavedMB: subMB(off.appMemory?.rendererMB, on.appMemory?.rendererMB),
+      appMainSavedMB: subMB(off.appMemory?.mainMB, on.appMemory?.mainMB),
+      domNodesReleased: off.cdpNodes != null && on.cdpNodes != null ? off.cdpNodes - on.cdpNodes : null
+    }
+    report.finalDiagnostics = await collectRendererDiagnostics(page)
+  } finally {
+    report.elapsedMs = Date.now() - startedAt
+    if (browser) {
+      await browser.close().catch(() => undefined)
+    }
+    if (launched) {
+      try {
+        await stopDevApp(launched.child)
+        // Why: stopDevApp SIGTERMs only the top-level vite child on macOS/Linux;
+        // the spawned electron process tree (main, GPU, renderer, helpers)
+        // survives and accumulates across runs until the machine saturates.
+        // Best-effort reap the whole tree rooted at the launcher pid.
+        if (launched.child?.pid && process.platform !== 'win32') {
+          try {
+            execFileSync('pkill', ['-9', '-P', String(launched.child.pid)], { stdio: 'ignore' })
+          } catch {
+            /* no descendants left — fine */
+          }
+        }
+      } catch (error) {
+        report.cleanupErrors.push(error instanceof Error ? error.message : String(error))
+      }
+      report.appLogsTail = launched.logs.slice(-40)
+    }
+    if (!args.keep) {
+      if (fixture) {
+        safeRemoveLocalDirectory(fixture.baseDir, report.cleanupErrors)
+      }
+      if (userDataDir) {
+        safeRemoveLocalDirectory(userDataDir, report.cleanupErrors)
+      }
+    }
+    const stamp = new Date(startedAt).toISOString().replace(/[:.]/g, '-')
+    const reportPath = path.resolve(
+      args.reportPath ??
+        path.join(rootDir, 'tools', 'benchmarks', 'results', `cold-park-res-${args.label}-${stamp}.json`)
+    )
+    mkdirSync(path.dirname(reportPath), { recursive: true })
+    writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+    console.log(`[cold-park-res] report=${reportPath}`)
+    if (report.delta) {
+      const d = report.delta
+      console.log(
+        `[cold-park-res] DELTA (off−on): paneManagers=${d.paneManagersReleased} webglContexts=${d.webglContextsReleased} domNodes=${d.domNodesReleased}`
+      )
+      console.log(
+        `[cold-park-res]   memory saved: appTotal=${d.appTotalSavedMB}MB (renderer=${d.appRendererSavedMB}MB main=${d.appMainSavedMB}MB) rendererJsHeap=${d.rendererJsHeapSavedMB}MB cdpJsHeap=${d.cdpJsHeapSavedMB}MB`
+      )
+      if (report.states.parkingOff?.appMemory && report.states.parkingOn?.appMemory) {
+        console.log(
+          `[cold-park-res]   appTotal off=${report.states.parkingOff.appMemory.totalMB}MB on=${report.states.parkingOn.appMemory.totalMB}MB`
+        )
+      }
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error))
+  process.exit(1)
+})

--- a/tools/benchmarks/terminal-cold-park-reveal-bench.mjs
+++ b/tools/benchmarks/terminal-cold-park-reveal-bench.mjs
@@ -1,0 +1,608 @@
+#!/usr/bin/env node
+// Cold-park reveal-cost benchmark: measures the reveal latency a user pays when
+// returning to a terminal whose hidden view was cold-parked (React subtree
+// unmounted, xterm/buffers/WebGL released) versus a warm reveal where the tab
+// was still in the hot-retain working set. The stock terminal-perf-bench
+// workspace-switch scenario cycles 3 worktrees fast enough that parking never
+// fires, so it only ever measures warm reveals. This bench drives the
+// ORCA_E2E_TERMINAL_PARKING_DELAY_MS override to shrink the 30s hysteresis and
+// window.__terminalParkingDebug.parkedTabIds() to *confirm* a tab parked before
+// timing its reveal — so the cold vs warm delta is the real cost of parking.
+//
+// Output phases per reveal (ms from the switch-back click):
+//   activationMs   store activeWorktree flips to the target terminal
+//   ptyBindMs      the revealed pane has a bound ptyId (xterm remounted+attached)
+//   paintSettleMs  two RAFs after ptyBind (first painted frame settled)
+//
+// Arms:
+//   cold  — tab confirmed parked before reveal (park delay shrunk, wait to park)
+//   warm  — tab revealed before the park delay elapses (hot-retain hit)
+//   off   — parking disabled entirely (kill switch), reveal after the same idle
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import {
+  collectRendererDiagnostics,
+  connectToApp,
+  installRendererProbe,
+  launchDevApp,
+  pickFreePort,
+  stopDevApp,
+  waitForStoreReady
+} from '../../config/scripts/windows-apphang-repro/electron-dev-session.mjs'
+import { createCompletedOnboardingProfile } from '../../config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs'
+import {
+  pollUntil,
+  rendererActionTimeoutMs,
+  runWithTimeout,
+  setupTimeoutMs
+} from '../../config/scripts/windows-apphang-repro/repro-timing.mjs'
+import { safeRemoveLocalDirectory } from '../../config/scripts/windows-apphang-repro/wsl-workspace-fixture.mjs'
+
+const rootDir = path.resolve(fileURLToPath(new URL('../..', import.meta.url)))
+const scenarioTimeoutMs = 300_000
+
+// Short enough that a tab parks within a few seconds of being hidden, long
+// enough that the warm arm can reliably reveal before it elapses.
+const PARK_DELAY_MS = 1_500
+const WARM_REVEAL_AFTER_MS = 300
+const COLD_PARK_CONFIRM_TIMEOUT_MS = 15_000
+
+function parseArgs() {
+  const args = { label: 'run', cycles: 8, scrollbackLines: 0, reportPath: null, keep: false }
+  for (const arg of process.argv.slice(2)) {
+    if (arg === '--help' || arg === '-h') {
+      console.log(
+        'Usage: node tools/benchmarks/terminal-cold-park-reveal-bench.mjs [--label=name] [--cycles=N] [--scrollback-lines=N] [--report=path] [--keep]'
+      )
+      process.exit(0)
+    }
+    if (arg === '--keep') {
+      args.keep = true
+      continue
+    }
+    const [name, value] = arg.split('=', 2)
+    if (name === '--label') {
+      args.label = value?.trim() || 'run'
+    } else if (name === '--cycles') {
+      args.cycles = Math.max(1, Number(value) || 8)
+    } else if (name === '--scrollback-lines') {
+      args.scrollbackLines = Math.max(0, Number(value) || 0)
+    } else if (name === '--report') {
+      args.reportPath = value
+    }
+  }
+  return args
+}
+
+// Why: the daemon binds a Unix socket at <userData>/daemon/daemon-v20.sock.
+// macOS sun_path caps at ~104 chars; the default os.tmpdir() (/var/folders/…)
+// blows past it, the daemon fails EINVAL, terminals fall back to non-snapshot
+// PTYs, and cold parking (snapshot-backed only) can never engage. Root the
+// userData + fixture under a short ~/.ocpb path so the socket fits.
+const shortRoot = path.join(os.homedir(), '.ocpb')
+
+function createShortUserDataDirectory() {
+  mkdirSync(shortRoot, { recursive: true })
+  const userDataDir = mkdtempSync(path.join(shortRoot, 'ud-'))
+  createCompletedOnboardingProfile(userDataDir)
+  return userDataDir
+}
+
+function git(cwd, ...cmd) {
+  execFileSync('git', cmd, { cwd, stdio: 'pipe' })
+}
+
+function createLocalRepoFixture() {
+  mkdirSync(shortRoot, { recursive: true })
+  const baseDir = mkdtempSync(path.join(shortRoot, 'fx-'))
+  const repoPath = path.join(baseDir, 'repo')
+  mkdirSync(repoPath, { recursive: true })
+  git(repoPath, 'init', '--initial-branch=main')
+  git(repoPath, 'config', 'user.email', 'bench@orca.local')
+  git(repoPath, 'config', 'user.name', 'Orca Bench')
+  writeFileSync(path.join(repoPath, 'README.md'), '# cold-park fixture\n')
+  git(repoPath, 'add', '.')
+  git(repoPath, 'commit', '-m', 'init', '--no-gpg-sign')
+  const worktreePaths = []
+  for (const name of ['wt-one', 'wt-two']) {
+    const worktreePath = path.join(baseDir, name)
+    git(repoPath, 'worktree', 'add', worktreePath, '-b', name)
+    worktreePaths.push(worktreePath)
+  }
+  return { baseDir, repoPath, worktreePaths }
+}
+
+async function setupWorkspaces(page, fixture) {
+  return await runWithTimeout(
+    'fixture registration in Orca',
+    () =>
+      page.evaluate(
+        async ({ repoPath, importedWorktreePaths }) => {
+          const store = window.__store
+          if (!store) {
+            throw new Error('window.__store is unavailable.')
+          }
+          await store.getState().fetchSettings?.()
+          const addResult = await window.api.repos.add({ path: repoPath, kind: 'git' })
+          if ('error' in addResult) {
+            throw new Error(addResult.error)
+          }
+          await store.getState().fetchRepos()
+          const state = store.getState()
+          const repo = state.repos.find((c) => c.path === repoPath) ?? addResult.repo
+          await state.updateRepo(repo.id, {
+            externalWorktreeVisibility: 'show',
+            externalWorktreeVisibilityPromptDismissedAt: Date.now(),
+            importedExternalWorktreePaths: importedWorktreePaths,
+            externalWorktreeInboxBaselinePaths: importedWorktreePaths
+          })
+          await store.getState().fetchWorktrees(repo.id, { requireAuthoritative: true })
+          const nextState = store.getState()
+          nextState.setSidebarOpen(true)
+          nextState.setGroupBy('none')
+          nextState.setSortBy('recent')
+          nextState.setShowActiveOnly(false)
+          nextState.setActiveView('terminal')
+          const worktrees = nextState.worktreesByRepo[repo.id] ?? []
+          return {
+            repoId: repo.id,
+            worktrees: worktrees.map((w) => ({
+              id: w.id,
+              path: w.path,
+              displayName: w.displayName,
+              isMainWorktree: w.isMainWorktree
+            }))
+          }
+        },
+        { repoPath: fixture.repoPath, importedWorktreePaths: fixture.worktreePaths }
+      ),
+    setupTimeoutMs
+  )
+}
+
+async function clickWorktreeCard(page, worktreeId) {
+  const rect = await runWithTimeout(
+    `locate worktree card ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const rows = Array.from(document.querySelectorAll('[data-worktree-id]'))
+        const row = rows.find((c) => c.getAttribute('data-worktree-id') === id)
+        if (!row) {
+          return null
+        }
+        row.scrollIntoView({ block: 'center', inline: 'nearest' })
+        const surface = row.querySelector('[data-worktree-card-surface="true"]') ?? row
+        const bounds = surface.getBoundingClientRect()
+        if (bounds.width <= 0 || bounds.height <= 0) {
+          return null
+        }
+        return { x: bounds.left + bounds.width / 2, y: bounds.top + bounds.height / 2 }
+      }, worktreeId),
+    rendererActionTimeoutMs
+  )
+  if (!rect) {
+    throw new Error(`Could not find rendered worktree card for ${worktreeId}`)
+  }
+  await runWithTimeout(
+    `click worktree card ${worktreeId}`,
+    () => page.mouse.click(rect.x, rect.y),
+    rendererActionTimeoutMs
+  )
+}
+
+async function activateWorktreeTerminal(page, worktreeId) {
+  await clickWorktreeCard(page, worktreeId)
+  await pollUntil(
+    `active worktree ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        return state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+      }, worktreeId),
+    Boolean,
+    30_000
+  )
+}
+
+/** Wait until the active terminal pane of `worktreeId` has a bound ptyId — i.e.
+ *  its terminal actually exists and is warm before we start hiding it. */
+async function waitForBoundTerminal(page, worktreeId) {
+  return await pollUntil(
+    `pty bound ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        const tabId =
+          state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+            ? state.activeTabId
+            : (state?.activeTabIdByWorktree?.[id] ?? null)
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+        return pane?.container?.dataset?.ptyId ?? null
+      }, worktreeId),
+    Boolean,
+    30_000,
+    10
+  )
+}
+
+/** Fill the active pane's terminal with ~lineCount lines of output so the
+ *  parked snapshot (and thus the cold reveal replay) reflects a busy TUI-sized
+ *  buffer rather than an empty shell. Writes to the pty and waits for the
+ *  xterm buffer to grow. Returns the observed serialized length. */
+async function primeScrollback(page, worktreeId, lineCount) {
+  const ptyId = await page.evaluate((id) => {
+    const state = window.__store?.getState?.()
+    const tabId =
+      state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+        ? state.activeTabId
+        : (state?.activeTabIdByWorktree?.[id] ?? null)
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+    return pane?.container?.dataset?.ptyId ?? null
+  }, worktreeId)
+  if (!ptyId) {
+    throw new Error(`No pty to prime for ${worktreeId}`)
+  }
+  // A single command that emits many numbered 80-col lines. seq is POSIX-ish;
+  // fall back handled by awk for portability.
+  const cmd = `awk 'BEGIN{for(i=0;i<${lineCount};i++)printf "%04d %s\\n", i, "cold-park-scrollback-priming-line-padding-to-eighty-cols-000000"}'\n`
+  await page.evaluate(({ id, c }) => window.api.pty.write(id, c), { id: ptyId, c: cmd })
+  return await pollUntil(
+    `scrollback primed ${worktreeId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        const tabId =
+          state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+            ? state.activeTabId
+            : (state?.activeTabIdByWorktree?.[id] ?? null)
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+        const content = pane?.serializeAddon?.serialize?.() ?? ''
+        return content.length
+      }, worktreeId),
+    (len) => Number.isFinite(len) && len > lineCount * 40,
+    20_000,
+    100
+  ).catch(() => 0)
+}
+
+function activeTabIdFor(page, worktreeId) {
+  return page.evaluate((id) => {
+    const state = window.__store?.getState?.()
+    return (
+      (state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+        ? state.activeTabId
+        : (state?.activeTabIdByWorktree?.[id] ?? null)) ?? null
+    )
+  }, worktreeId)
+}
+
+/** Times a reveal of `targetId` (must currently be hidden). Returns the three
+ *  phase timings measured from the switch-back click. */
+async function timeReveal(page, targetId) {
+  const t0 = Date.now()
+  await clickWorktreeCard(page, targetId)
+  await pollUntil(
+    `reveal activation ${targetId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        return state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+      }, targetId),
+    Boolean,
+    30_000,
+    5
+  )
+  const activationMs = Date.now() - t0
+  await pollUntil(
+    `reveal pty ${targetId}`,
+    () =>
+      page.evaluate((id) => {
+        const state = window.__store?.getState?.()
+        const tabId =
+          state?.activeWorktreeId === id && state.activeTabType === 'terminal'
+            ? state.activeTabId
+            : (state?.activeTabIdByWorktree?.[id] ?? null)
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()?.[0] ?? null
+        return pane?.container?.isConnected ? (pane?.container?.dataset?.ptyId ?? null) : null
+      }, targetId),
+    Boolean,
+    30_000,
+    5
+  )
+  const ptyBindMs = Date.now() - t0
+  await runWithTimeout(
+    'reveal paint settle',
+    () =>
+      page.evaluate(
+        () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
+      ),
+    rendererActionTimeoutMs
+  )
+  const paintSettleMs = Date.now() - t0
+  return { activationMs, ptyBindMs, paintSettleMs }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+/** Parking signal that does not depend on the e2e debug handle: a parked tab's
+ *  TerminalPane unmounts, so its manager leaves window.__paneManagers AND the
+ *  overlay slot renders null (no [data-tab-id] container). Prefer the debug
+ *  handle when present, fall back to manager/DOM absence. */
+function isTabParked(page, tabId) {
+  return page.evaluate((id) => {
+    const handleIds = window.__terminalParkingDebug?.parkedTabIds?.()
+    if (Array.isArray(handleIds)) {
+      return { source: 'handle', parked: handleIds.includes(id) }
+    }
+    // Fallback (no debug handle): a parked tab's manager leaves __paneManagers.
+    const managerGone = !(window.__paneManagers && window.__paneManagers.has(id))
+    return { source: 'manager', parked: managerGone }
+  }, tabId)
+}
+
+async function debugSnapshot(page, tabId, worktreeId) {
+  return page.evaluate(
+    ({ id, wtId }) => {
+      const state = window.__store?.getState?.()
+      const tabsByWorktree = state?.tabsByWorktree ?? {}
+      const tab = Object.values(tabsByWorktree)
+        .flat()
+        .find((t) => t?.id === id)
+      const wtTabs = tabsByWorktree[wtId] ?? []
+      return {
+        handlePresent: typeof window.__terminalParkingDebug?.parkedTabIds === 'function',
+        parkDelayMs: window.__terminalParkingDebug?.parkDelayMs ?? null,
+        parkedHandleIds: window.__terminalParkingDebug?.parkedTabIds?.() ?? null,
+        managerPresent: Boolean(window.__paneManagers?.has(id)),
+        managerKeys: window.__paneManagers ? Array.from(window.__paneManagers.keys()) : null,
+        ptyId: tab?.ptyId ?? null,
+        worktreeTabCount: wtTabs.length,
+        worktreeTabPtyIds: wtTabs.map((t) => t?.ptyId ?? null),
+        activeTabIdByWorktree: state?.activeTabIdByWorktree?.[wtId] ?? null,
+        parkingEnabled: state?.settings?.terminalHiddenViewParking !== false
+      }
+    },
+    { id: tabId, wtId: worktreeId }
+  )
+}
+
+/** One cold cycle: focus target, hide it (switch to primary), wait until the
+ *  tab parks (debug handle or manager-absence), then time the reveal. */
+async function runColdCycle(page, primaryId, targetId, wantDebug, scrollbackLines) {
+  await activateWorktreeTerminal(page, targetId)
+  await waitForBoundTerminal(page, targetId)
+  if (scrollbackLines > 0) {
+    await primeScrollback(page, targetId, scrollbackLines)
+  }
+  const targetTabId = await activeTabIdFor(page, targetId)
+  await activateWorktreeTerminal(page, primaryId)
+  const parked = await pollUntil(
+    `cold-park ${targetTabId}`,
+    () => isTabParked(page, targetTabId),
+    (result) => result?.parked === true,
+    COLD_PARK_CONFIRM_TIMEOUT_MS,
+    50
+  ).then(
+    () => true,
+    () => false
+  )
+  const diag = wantDebug ? await debugSnapshot(page, targetTabId, targetId) : null
+  const timings = await timeReveal(page, targetId)
+  return { ...timings, parkedConfirmed: parked, diag }
+}
+
+/** One warm cycle: focus target, hide it briefly (under the park delay), reveal
+ *  before it can park. Asserts it did NOT park. */
+async function runWarmCycle(page, primaryId, targetId, scrollbackLines) {
+  await activateWorktreeTerminal(page, targetId)
+  await waitForBoundTerminal(page, targetId)
+  if (scrollbackLines > 0) {
+    await primeScrollback(page, targetId, scrollbackLines)
+  }
+  const targetTabId = await activeTabIdFor(page, targetId)
+  await activateWorktreeTerminal(page, primaryId)
+  await sleep(WARM_REVEAL_AFTER_MS)
+  const parked = await isTabParked(page, targetTabId)
+  const timings = await timeReveal(page, targetId)
+  return { ...timings, parkedConfirmed: parked?.parked === true }
+}
+
+function summarize(values) {
+  const sorted = values.filter(Number.isFinite).sort((a, b) => a - b)
+  if (!sorted.length) {
+    return null
+  }
+  const at = (f) => sorted[Math.min(sorted.length - 1, Math.round(f * (sorted.length - 1)))]
+  return { count: sorted.length, median: Math.round(at(0.5)), p95: Math.round(at(0.95)), max: sorted.at(-1) }
+}
+
+function summarizeArm(name, samples) {
+  const fields = {}
+  for (const key of ['activationMs', 'ptyBindMs', 'paintSettleMs']) {
+    fields[key] = summarize(samples.map((s) => s[key]))
+  }
+  return {
+    name,
+    samples: samples.length,
+    parkedConfirmed: samples.filter((s) => s.parkedConfirmed).length,
+    fields
+  }
+}
+
+async function main() {
+  const args = parseArgs()
+  const startedAt = Date.now()
+  const report = {
+    label: args.label,
+    startedAt: new Date(startedAt).toISOString(),
+    platform: `${process.platform} ${os.release()}`,
+    parkDelayMs: PARK_DELAY_MS,
+    args: { cycles: args.cycles, scrollbackLines: args.scrollbackLines },
+    arms: {},
+    summaries: [],
+    cleanupErrors: []
+  }
+  let fixture = null
+  let userDataDir = null
+  let launched = null
+  let browser = null
+  let page = null
+  try {
+    fixture = createLocalRepoFixture()
+    const cdpPort = await pickFreePort()
+    userDataDir = createShortUserDataDirectory()
+    // Shrink the 30s cold-park hysteresis + 5-min hot-retain so parking is
+    // observable in a benchmark run. Inherited by launchDevApp into the app.
+    process.env.ORCA_E2E_TERMINAL_PARKING_DELAY_MS = String(PARK_DELAY_MS)
+    console.log(
+      `[cold-park] fixture=${fixture.baseDir} userData=${userDataDir} cdp=${cdpPort} parkDelay=${PARK_DELAY_MS}ms`
+    )
+    launched = launchDevApp({ cdpPort, userDataDir })
+    const connected = await connectToApp(cdpPort)
+    browser = connected.browser
+    page = connected.page
+    await waitForStoreReady(page)
+    await installRendererProbe(page)
+    const setup = await setupWorkspaces(page, fixture)
+    let worktrees = setup.worktrees
+    // Why: worktree registration/fetch can lag the setup evaluate return; poll
+    // the store until the two external worktrees materialize before asserting.
+    if (worktrees.length < 2) {
+      // Why: the initial fetchWorktrees can return before the external-worktree
+      // scan surfaces the imported paths. Re-drive the fetch each poll (not just
+      // re-read the store) so a missed first scan self-heals.
+      worktrees = await pollUntil(
+        'worktrees registered',
+        () =>
+          page.evaluate(async (repoId) => {
+            await window.__store
+              ?.getState?.()
+              ?.fetchWorktrees?.(repoId, { requireAuthoritative: true })
+              .catch(() => undefined)
+            const state = window.__store?.getState?.()
+            const list = state?.worktreesByRepo?.[repoId] ?? []
+            return list.map((w) => ({
+              id: w.id,
+              path: w.path,
+              displayName: w.displayName,
+              isMainWorktree: w.isMainWorktree
+            }))
+          }, setup.repoId),
+        (list) => Array.isArray(list) && list.length >= 2,
+        30_000,
+        500
+      )
+    }
+    if (worktrees.length < 2) {
+      throw new Error(`Expected >=2 worktrees, got ${worktrees.length}`)
+    }
+    const primary = worktrees.find((w) => w.isMainWorktree) ?? worktrees[0]
+    const target = worktrees.find((w) => w.id !== primary.id)
+    await activateWorktreeTerminal(page, primary.id)
+    await waitForBoundTerminal(page, primary.id)
+
+    // Confirm the parking debug handle is present (exposeStore gate). It
+    // registers on first pane mount, so poll rather than read once.
+    const debugReady = await pollUntil(
+      'parking debug handle',
+      () =>
+        page.evaluate(() => typeof window.__terminalParkingDebug?.parkedTabIds === 'function'),
+      Boolean,
+      10_000,
+      100
+    ).then(
+      () => true,
+      () => false
+    )
+    report.parkingDebugHandlePresent = debugReady
+
+    const cold = []
+    const warm = []
+    console.log(`[cold-park] running ${args.cycles} cold + ${args.cycles} warm cycles`)
+    for (let i = 0; i < args.cycles; i++) {
+      warm.push(
+        await runWithTimeout(
+          `warm cycle ${i}`,
+          () => runWarmCycle(page, primary.id, target.id, args.scrollbackLines),
+          scenarioTimeoutMs
+        )
+      )
+      const coldResult = await runWithTimeout(
+        `cold cycle ${i}`,
+        () => runColdCycle(page, primary.id, target.id, i === 0, args.scrollbackLines),
+        scenarioTimeoutMs
+      )
+      if (i === 0 && coldResult.diag) {
+        report.firstColdDiag = coldResult.diag
+        console.log(`[cold-park] first-cold diag: ${JSON.stringify(coldResult.diag)}`)
+      }
+      cold.push(coldResult)
+    }
+    report.arms.cold = cold
+    report.arms.warm = warm
+    report.summaries.push(summarizeArm('cold', cold))
+    report.summaries.push(summarizeArm('warm', warm))
+    report.finalDiagnostics = await collectRendererDiagnostics(page)
+  } finally {
+    report.elapsedMs = Date.now() - startedAt
+    if (browser) {
+      await browser.close().catch(() => undefined)
+    }
+    if (launched) {
+      try {
+        await stopDevApp(launched.child)
+      } catch (error) {
+        report.cleanupErrors.push(error instanceof Error ? error.message : String(error))
+      }
+      report.appLogsTail = launched.logs.slice(-60)
+    }
+    if (!args.keep) {
+      if (fixture) {
+        safeRemoveLocalDirectory(fixture.baseDir, report.cleanupErrors)
+      }
+      if (userDataDir) {
+        safeRemoveLocalDirectory(userDataDir, report.cleanupErrors)
+      }
+    }
+    const stamp = new Date(startedAt).toISOString().replace(/[:.]/g, '-')
+    const reportPath = path.resolve(
+      args.reportPath ??
+        path.join(rootDir, 'tools', 'benchmarks', 'results', `cold-park-${args.label}-${stamp}.json`)
+    )
+    mkdirSync(path.dirname(reportPath), { recursive: true })
+    writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+    console.log(`[cold-park] report=${reportPath}`)
+    const coldArm = report.summaries.find((s) => s.name === 'cold')
+    if (coldArm && coldArm.parkedConfirmed < coldArm.samples) {
+      console.log(
+        `[cold-park] WARNING: only ${coldArm.parkedConfirmed}/${coldArm.samples} cold reveals were confirmed parked — treat unconfirmed samples with caution`
+      )
+    }
+    for (const summary of report.summaries) {
+      console.log(
+        `[cold-park] ${summary.name}: samples=${summary.samples} parkedConfirmed=${summary.parkedConfirmed}/${summary.samples}`
+      )
+      for (const [field, stats] of Object.entries(summary.fields)) {
+        if (stats) {
+          console.log(
+            `[cold-park]   ${field}: median=${stats.median}ms p95=${stats.p95}ms max=${stats.max}ms`
+          )
+        }
+      }
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error))
+  process.exit(1)
+})


### PR DESCRIPTION
## Why

The perf branch's cold parking drew field reports that **terminal mounting is jumpy — switching to a worktree after a while takes ~1s**. I benchmarked both sides of parking to decide data-first (see `docs/reference/terminal-cold-park-reveal-cost.md`):

- **Reveal cost is a flat ~170ms remount**, independent of scrollback size (empty / 5k / 20k lines all ~the same). So the cost is fixed remount overhead (React rebuild + xterm construct + WebGL attach + fit + reattach-reset), **not** snapshot replay. The lever is remount *frequency*, not replay size.
- **Parking is worth keeping**: `pnpm bench:cold-park-resource` shows it's the only mechanism that frees hidden terminals' view memory + DOM (8 pane managers + ~1550 DOM nodes released at 8 backgrounded worktrees). *WebGL-context protection is not parking's win* — suspend-on-hide already releases hidden panes' contexts (1 context across 9 mounted terminals with parking off).

The reports trace to the keep-warm caps being too tight for a many-worktree rotation: a 5th worktree evicts the oldest every switch, and a 5-minute TTL parks the whole warm set during a meeting.

## What

Three tuning changes in `terminal-hidden-view-parking.ts`:

| lever | before | after | why |
| --- | --- | --- | --- |
| worktree hot-retain limit | 4 | **8** | covers the ordinary working set; ~4–5MB renderer floor per hidden worktree, so parking still reclaims for the heavy tail |
| hot-retain TTL (worktree + tab) | 5 min | **15 min** | the cap, not the clock, is the primary evictor; a meeting-length absence no longer parks the warm set |
| last-active exemption | — | **new** | the single most-recently-hidden worktree/tab is never parked (TTL or cap), so returning to the view you just left is always instant |

Tab count cap stays **12** (already generous). The 30s cold-park delay is unchanged (quick-flip guard). **Not** doing pre-warm-on-predicted-reveal — it hides the cost behind navigation rather than removing it.

The last-active exemption lives in `selectIdsBeyondHotRetain`: it protects the most-recently-hidden candidate and counts it as one warm slot against the cap.

## Tests

- Unit: `terminal-hidden-view-parking.test.ts` — new coverage for the exemption (single last-active never parks; exemption counts against the cap; TTL still sweeps aged non-last-active). All 32 pass.
- E2E: `terminal-parked-memory.spec.ts` updated to the new invariant — last-active tab stays warm, so 7 of 8 park (`livePaneManagers === 2`).
- `pnpm typecheck` clean; `pnpm check:max-lines-ratchet` OK; oxlint clean.

## Benches added

`pnpm bench:cold-park-reveal` (reveal cost) and `pnpm bench:cold-park-resource` (resource benefit) — the data backing every number above.

## Notes for reviewers

- Cherry-picked onto `main` (cold-park feature is already peeled onto main); the parking files here are identical to main's, so the diff is exactly this tuning change.
- SSH / remote-runtime PTYs are excluded from parking entirely (unchanged) — the exemption only ever applies to snapshot-backed local candidates that already passed the eligibility gates.
- The settled whole-app memory figure from the upgraded resource bench still wants a re-run on a healthy machine (documented in the reveal-cost doc); the pane-manager / DOM release is the robust, reproduced part.