### PR TITLE
fix(windows): detect Cursor Agent Node wrapper

### DIFF
--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -289,6 +289,55 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe('codex')
   })
 
+  it('recognizes the native Windows Cursor launcher process tree', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    mockPs(
+      windowsProcessJsonRows([
+        {
+          CommandLine: 'powershell.exe',
+          Name: 'powershell.exe',
+          ParentProcessId: 99,
+          ProcessId: 100
+        },
+        {
+          CommandLine: 'cmd.exe /c cursor-agent.cmd',
+          Name: 'cmd.exe',
+          ParentProcessId: 100,
+          ProcessId: 101
+        },
+        {
+          CommandLine:
+            'powershell.exe -File C:\\Users\\dev\\AppData\\Local\\cursor-agent\\cursor-agent.ps1',
+          Name: 'powershell.exe',
+          ParentProcessId: 101,
+          ProcessId: 102
+        },
+        {
+          CommandLine:
+            'node.exe C:\\Users\\dev\\AppData\\Local\\cursor-agent\\versions\\2026.07.09-a3815c0\\index.js',
+          Name: 'node.exe',
+          ParentProcessId: 102,
+          ProcessId: 103
+        },
+        {
+          CommandLine:
+            'node.exe C:\\Users\\dev\\AppData\\Local\\cursor-agent\\versions\\2026.07.09-a3815c0\\index.js worker-server',
+          Name: 'node.exe',
+          ParentProcessId: 103,
+          ProcessId: 104
+        },
+        {
+          CommandLine: 'C:\\Users\\dev\\.grok\\bin\\agent.exe',
+          Name: 'agent.exe',
+          ParentProcessId: 100,
+          ProcessId: 105
+        }
+      ])
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe('cursor-agent')
+  })
+
   it('recognizes Windows Git Bash shell-rooted agent launches', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     execFileMock.mockImplementation(

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -212,6 +212,24 @@ describe('agent process recognition', () => {
     expect(recognizeAgentProcessFromCommandLine('node /usr/local/bin/orca status')).toBeNull()
   })
 
+  it('recognizes the versioned Cursor Node wrapper without accepting generic agent processes', () => {
+    const cursorEntrypoint = String.raw`C:\Users\dev\AppData\Local\cursor-agent\versions\2026.07.09-a3815c0\index.js`
+
+    expect(recognizeAgentProcessFromCommandLine(`node.exe ${cursorEntrypoint}`)).toEqual({
+      agent: 'cursor',
+      processName: 'cursor-agent'
+    })
+    expect(
+      recognizeAgentProcessFromCommandLine(`node.exe ${cursorEntrypoint} worker-server`)
+    ).toEqual({ agent: 'cursor', processName: 'cursor-agent' })
+    expect(
+      recognizeAgentProcessFromCommandLine(String.raw`node.exe C:\repo\cursor-agent\index.js`)
+    ).toBeNull()
+    expect(
+      recognizeAgentProcessFromCommandLine(String.raw`C:\Users\dev\.grok\bin\agent.exe`)
+    ).toBeNull()
+  })
+
   it('does not classify prompt text as a wrapped agent command', () => {
     expect(
       recognizeAgentProcessFromCommandLine(

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -52,6 +52,7 @@ const NODE_PACKAGE_SCRIPT_ENTRYPOINTS: Record<string, readonly string[]> = {
   codex: ['node_modules/@openai/codex/'],
   gemini: ['node_modules/@google/gemini-cli/']
 }
+const CURSOR_AGENT_NODE_ENTRYPOINT_RE = /(?:^|\/)cursor-agent\/versions\/[^/]+\/index\.js$/
 const PYTHON_SCRIPT_ENTRYPOINT_DIRECTORIES = ['/bin/', '/scripts/', '/site-packages/']
 
 const PROCESS_TO_AGENT = new Map<string, TuiAgent>()
@@ -93,6 +94,11 @@ function agentForNormalizedProcess(normalized: string): TuiAgent | undefined {
     return PROCESS_TO_AGENT.get('grok')
   }
   return undefined
+}
+
+function recognizedAgentForProcess(normalized: string): RecognizedAgentProcess | null {
+  const agent = agentForNormalizedProcess(normalized)
+  return agent ? { agent, processName: normalized } : null
 }
 
 function tokenizeCommandLine(commandLine: string): string[] {
@@ -197,20 +203,21 @@ function comparablePath(token: string): string {
 }
 
 function recognizeNodeScriptEntrypoint(token: string): RecognizedAgentProcess | null {
+  const path = comparablePath(token)
+  // Why: Cursor's native Windows launcher runs a generic versioned index.js,
+  // so its install path is the only stable identity that avoids ordinary Node apps.
+  if (CURSOR_AGENT_NODE_ENTRYPOINT_RE.test(path)) {
+    return { agent: 'cursor', processName: 'cursor-agent' }
+  }
   const normalized = normalizeProcessName(token, { stripInterpreterScriptExtension: true })
   const markers = NODE_PACKAGE_SCRIPT_ENTRYPOINTS[normalized]
   if (!markers) {
     return null
   }
-  const path = comparablePath(token)
   if (!markers.some((marker) => path.includes(marker))) {
     return null
   }
-  const agent = agentForNormalizedProcess(normalized)
-  if (!agent) {
-    return null
-  }
-  return { agent, processName: normalized }
+  return recognizedAgentForProcess(normalized)
 }
 
 function recognizePythonModule(
@@ -220,11 +227,7 @@ function recognizePythonModule(
     return null
   }
   const normalized = moduleName.split('.', 1)[0]?.toLowerCase() ?? ''
-  const agent = agentForNormalizedProcess(normalized)
-  if (!agent) {
-    return null
-  }
-  return { agent, processName: normalized }
+  return recognizedAgentForProcess(normalized)
 }
 
 function recognizePythonScriptEntrypoint(token: string): RecognizedAgentProcess | null {
@@ -237,11 +240,7 @@ function recognizePythonScriptEntrypoint(token: string): RecognizedAgentProcess 
   }
   const basename = path.split('/').pop() ?? ''
   const normalized = basename.replace(PYTHON_SCRIPT_EXTENSION_RE, '')
-  const agent = agentForNormalizedProcess(normalized)
-  if (!agent) {
-    return null
-  }
-  return { agent, processName: normalized }
+  return recognizedAgentForProcess(normalized)
 }
 
 function recognizePythonEntrypoint(
@@ -274,11 +273,7 @@ export function recognizeAgentProcess(
   processName: string | null | undefined
 ): RecognizedAgentProcess | null {
   const normalized = normalizeProcessName(processName)
-  const agent = agentForNormalizedProcess(normalized)
-  if (!agent) {
-    return null
-  }
-  return { agent, processName: normalized }
+  return recognizedAgentForProcess(normalized)
 }
 
 export function recognizeAgentProcessFromCommandLine(


### PR DESCRIPTION
# fix(windows): detect Cursor Agent Node wrapper

## Summary

On Windows, a running Cursor Agent was not recognized as an active agent, so `orca worktree ps` reported `agents: []` even while Cursor's Node processes were live.

## ELI5

When you ran Cursor's AI agent on Windows, Orca couldn't tell it was running and showed nothing. This teaches Orca to spot it, so it shows up correctly.

## Root cause & fix

On Windows, Cursor Agent launches through a versioned Node wrapper (`node.exe .../cursor-agent/versions/<version>/index.js`) rather than a recognizably named binary, so the command-line recognizer classified both the interactive parent and its `worker-server` child as `null`. The fix anchors a suffix match to Cursor's official versioned install layout and maps both processes to the single canonical `cursor-agent` identity, while leaving generic Node entrypoints and unrelated `Agent.exe` binaries unclassified.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Scoped `vitest` on branch: **2 files passed, 53 tests passed** (`agent-process-recognition.test.ts`, `agent-foreground-process.test.ts`). Tests are not win32-gated — they run `recognizeAgentProcessFromCommandLine` on command-line strings directly, so they truly execute on macOS.
- Fail-when-reverted proof: reverting only `agent-process-recognition.ts` to `origin/main` made the Cursor wrapper test fail (`expected {agent:'cursor', processName:'cursor-agent'}, received null`), 52 passed; restoring the fix returned to 53 passed.
- Lint clean: `oxlint` exits 0 across all three files, `max-lines` clean with no disable.

```text
Result on branch: 2 files passed, 53 tests passed.
Reverted fix -> 1 failed (Cursor wrapper test: received null), 52 passed.
Restored fix -> 53 passed.
```

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression: only the previously-unhandled Cursor wrapper branch is added; generic Node entrypoints and unrelated `Agent.exe` binaries stay unclassified, covered by negative tests. Non-affected recognition paths are behavior-identical, proven by the full 53-test pass.

---

_Original fix by @bbingz. Validated, rebased, and hardened via automated bug-bash review; original fix design preserved. The rebase conflict in `agent-process-recognition.test.ts` was resolved by union (both test blocks kept). This session also added a behavior-preserving DRY refactor: the fix's 4 new lines tripped a new `max-lines` violation, so the duplicated recognition tail was extracted into a single `recognizedAgentForProcess` helper rather than disabling the rule._
