### PR TITLE
Show browsers in Resource Manager

### DIFF
--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx
@@ -4,6 +4,7 @@ import React, { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ORPHAN_WORKTREE_ID } from '../../../../shared/constants'
+import type { BrowserWorkspace } from '../../../../shared/types'
 import type { UnifiedSessionRow, UnifiedWorktreeRow } from './resource-usage-merge-types'
 
 vi.mock('@/store', () => {
@@ -64,6 +65,7 @@ function makeWorktree(overrides: Partial<UnifiedWorktreeRow>): UnifiedWorktreeRo
     hasLocalSamples: true,
     isRemote: false,
     sessions: [],
+    browsers: [],
     ...overrides
   }
 }
@@ -130,5 +132,30 @@ describe('resource manager row presentation', () => {
     )
 
     expect(container.querySelector('button[aria-label="Kill session orphan-a"]')).not.toBeNull()
+  })
+
+  it('shows browsers as read-only workspace resources', () => {
+    renderWorktreeRow(
+      makeWorktree({
+        browsers: [
+          {
+            id: 'browser-1',
+            worktreeId: 'wt-1',
+            title: 'Orca docs',
+            url: 'https://docs.orca.dev',
+            loading: false,
+            faviconUrl: null,
+            canGoBack: false,
+            canGoForward: false,
+            loadError: null,
+            createdAt: 1
+          } as BrowserWorkspace
+        ]
+      })
+    )
+
+    expect(container.textContent).toContain('Orca docs')
+    expect(container.querySelector('.lucide-globe')).not.toBeNull()
+    expect(container.querySelector('button[aria-label^="Open browser"]')).toBeNull()
   })
 })

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -9,6 +9,7 @@ import {
   AlertTriangle,
   ChevronDown,
   ChevronRight,
+  Globe,
   LoaderCircle,
   MemoryStick,
   RotateCw,
@@ -35,7 +36,7 @@ import { useAppStore } from '../../store'
 import { useWorktreeMap } from '../../store/selectors'
 import { runWorktreeDelete } from '../sidebar/delete-worktree-flow'
 import { useDaemonActions, DaemonActionDialog } from '../shared/useDaemonActions'
-import type { AppMemory, UsageValues, Worktree } from '../../../../shared/types'
+import type { AppMemory, BrowserWorkspace, UsageValues, Worktree } from '../../../../shared/types'
 import { ORPHAN_WORKTREE_ID } from '../../../../shared/constants'
 import { getRepoExecutionHostId, parseExecutionHostId } from '../../../../shared/execution-host'
 import { isFolderRepo } from '../../../../shared/repo-kind'
@@ -56,6 +57,7 @@ import {
 } from './resource-session-navigation'
 import {
   getResourceUsageAllWorktrees,
+  getResourceUsageBrowserTabsByWorktree,
   getResourceUsagePtyIdsByTabId,
   getResourceUsageRepos,
   getResourceUsageRuntimePaneTitlesByTabId,
@@ -438,6 +440,18 @@ export function SessionRow({
   )
 }
 
+function BrowserRow({ browser }: { browser: BrowserWorkspace }): React.JSX.Element {
+  const label = browser.title?.trim() || browser.label?.trim() || browser.url
+  return (
+    <div className="flex items-center gap-2 pl-10 pr-3 py-1.5">
+      <Globe className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">{label}</span>
+      <MetricPair cpu={null} memory={null} size="small" />
+      <span className={ROW_TRAILING_GUTTER_CLS} aria-hidden />
+    </div>
+  )
+}
+
 // ─── Worktree row ───────────────────────────────────────────────────
 
 export function WorktreeRow({
@@ -461,7 +475,7 @@ export function WorktreeRow({
   onKillSession: (session: UnifiedSessionRow) => void
   navigateToTab: (tabId: string, paneKey: string | null) => void
 }): React.JSX.Element {
-  const hasSessions = worktree.sessions.length > 0
+  const hasResources = worktree.sessions.length > 0 || worktree.browsers.length > 0
   // Why: synthetic buckets (orphan/unattributed) have no sidebar target to
   // reveal. Real and SSH-resolved worktrees both qualify for navigation —
   // navigateToWorktree handles the no-store-record case internally by
@@ -481,7 +495,7 @@ export function WorktreeRow({
   return (
     <div className="border-b border-border/20 last:border-b-0">
       <div className="group/wtrow flex items-center ml-2 transition-colors hover:bg-muted/60">
-        {hasSessions ? (
+        {hasResources ? (
           <button
             type="button"
             onClick={onToggle}
@@ -606,6 +620,8 @@ export function WorktreeRow({
             onKill={onKillSession}
           />
         ))}
+      {!isCollapsed &&
+        worktree.browsers.map((browser) => <BrowserRow key={browser.id} browser={browser} />)}
     </div>
   )
 }
@@ -776,6 +792,7 @@ export function ResourceUsageStatusSegment({
   const repos = useAppStore((s) => getResourceUsageRepos(s, open))
   const allWorktrees = useAppStore((s) => getResourceUsageAllWorktrees(s, open))
   const tabsByWorktree = useAppStore((s) => getResourceUsageTabsByWorktree(s, open))
+  const browserTabsByWorktree = useAppStore((s) => getResourceUsageBrowserTabsByWorktree(s, open))
   // Why: the closed trigger owns a scalar selector. Full binding maps stay
   // behind open sentinels so unchanged counts do not rerender the segment.
   const ptyIdsByTabId = useAppStore((s) => getResourceUsagePtyIdsByTabId(s, open))
@@ -922,6 +939,10 @@ export function ResourceUsageStatusSegment({
   }, [repos])
 
   const repoById = useMemo(() => new Map(repos.map((repo) => [repo.id, repo])), [repos])
+  const worktreeById = useMemo(
+    () => new Map(allWorktrees.map((worktree) => [worktree.id, worktree])),
+    [allWorktrees]
+  )
 
   const oldWorkspaceCount = useMemo(() => {
     const now = Date.now()
@@ -954,7 +975,9 @@ export function ResourceUsageStatusSegment({
             workspaceSessionReady,
             repoDisplayNameById,
             repoConnectionIdById,
-            repoRuntimeScopedById
+            repoRuntimeScopedById,
+            browserTabsByWorktree,
+            worktreeById
           })
         : [],
     [
@@ -968,7 +991,9 @@ export function ResourceUsageStatusSegment({
       workspaceSessionReady,
       repoDisplayNameById,
       repoConnectionIdById,
-      repoRuntimeScopedById
+      repoRuntimeScopedById,
+      browserTabsByWorktree,
+      worktreeById
     ]
   )
 
@@ -1252,10 +1277,7 @@ export function ResourceUsageStatusSegment({
           <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium text-foreground">
             <MemoryStick className="size-3 shrink-0 text-muted-foreground" />
             <span className="truncate">
-              {translate(
-                'auto.components.status.bar.ResourceUsageStatusSegment.6d9793d4bc',
-                'Resource Manager - Terminals'
-              )}
+              {translate('auto.components.status.bar.StatusBar.d1e1a7a6bf', 'Resource Manager')}
             </span>
           </div>
 

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import type { MemorySnapshot, TerminalTab, WorktreeMemory } from '../../../../shared/types'
+import type {
+  BrowserWorkspace,
+  MemorySnapshot,
+  TerminalTab,
+  Worktree,
+  WorktreeMemory
+} from '../../../../shared/types'
 import { mergeSnapshotAndSessions, UNATTRIBUTED_REPO_ID } from './mergeSnapshotAndSessions'
 import type { DaemonSession, MergeContext } from './resource-usage-merge-types'
 
@@ -57,6 +63,48 @@ const baseCtx = (overrides: Partial<MergeContext> = {}): MergeContext => ({
 describe('mergeSnapshotAndSessions', () => {
   it('returns empty list when both inputs are empty', () => {
     expect(mergeSnapshotAndSessions(null, [], baseCtx())).toEqual([])
+  })
+
+  it('includes browser-only workspaces in their repo', () => {
+    const worktree = {
+      id: 'orca::/Users/me/browser-only',
+      repoId: 'orca',
+      displayName: 'browser-only'
+    } as Worktree
+    const browser = {
+      id: 'browser-1',
+      worktreeId: worktree.id,
+      title: 'Orca docs',
+      url: 'https://docs.orca.dev',
+      loading: false,
+      faviconUrl: null,
+      canGoBack: false,
+      canGoForward: false,
+      loadError: null,
+      createdAt: 1
+    } as BrowserWorkspace
+    const out = mergeSnapshotAndSessions(
+      null,
+      [],
+      baseCtx({
+        repoDisplayNameById: new Map([['orca', 'ORCA']]),
+        worktreeById: new Map([[worktree.id, worktree]]),
+        browserTabsByWorktree: { [worktree.id]: [browser] }
+      })
+    )
+
+    expect(out[0]).toMatchObject({
+      repoId: 'orca',
+      repoName: 'ORCA',
+      worktrees: [
+        {
+          worktreeId: worktree.id,
+          worktreeName: 'browser-only',
+          sessions: [],
+          browsers: [browser]
+        }
+      ]
+    })
   })
 
   it('passes through snapshot worktrees with numeric metrics and hasLocalSamples', () => {

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -218,7 +218,8 @@ export function mergeSnapshotAndSessions(
         history: wt.history,
         hasLocalSamples: true,
         isRemote: isRepoRemote(wt.repoId),
-        sessions
+        sessions,
+        browsers: []
       })
     }
   }
@@ -276,7 +277,8 @@ export function mergeSnapshotAndSessions(
         history: [],
         hasLocalSamples: false,
         isRemote: repoIsRemote,
-        sessions: []
+        sessions: [],
+        browsers: []
       }
       repo.worktrees.push(row)
     }
@@ -294,7 +296,35 @@ export function mergeSnapshotAndSessions(
     })
   }
 
-  // ── Step 3: per-repo aggregates. Remote children are identified by the
+  // ── Step 3: add browser resources, including browser-only workspaces.
+  for (const [worktreeId, browsers] of Object.entries(ctx.browserTabsByWorktree ?? {})) {
+    const worktree = ctx.worktreeById?.get(worktreeId)
+    if (!worktree || browsers.length === 0) {
+      continue
+    }
+    const repoName = ctx.repoDisplayNameById.get(worktree.repoId) || worktree.repoId
+    const repo = ensureRepo(worktree.repoId, repoName)
+    let row = findWorktreeRow(repo, worktreeId)
+    if (!row) {
+      row = {
+        worktreeId,
+        worktreeName: worktree.displayName,
+        repoId: worktree.repoId,
+        repoName,
+        cpu: null,
+        memory: null,
+        history: [],
+        hasLocalSamples: false,
+        isRemote: isRepoRemote(worktree.repoId),
+        sessions: [],
+        browsers: []
+      }
+      repo.worktrees.push(row)
+    }
+    row.browsers = browsers
+  }
+
+  // ── Step 4: per-repo aggregates. Remote children are identified by the
   //   repo's connectionId, not by missing data — `!hasLocalSamples` would
   //   mislabel warm-reattached local PTYs. The aggregate still skips rows
   //   we can't sample (worktree.cpu === null) so the numbers stay honest.

--- a/src/renderer/src/components/status-bar/resource-usage-merge-types.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-merge-types.ts
@@ -1,4 +1,9 @@
-import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/types'
+import type {
+  BrowserWorkspace,
+  TerminalLayoutSnapshot,
+  TerminalTab,
+  Worktree
+} from '../../../../shared/types'
 
 /** `null` === "no local sample" (e.g. SSH PTY); UI renders as em-dash. */
 export type Metric = number | null
@@ -33,6 +38,7 @@ export type UnifiedWorktreeRow = {
   /** Why: repo connectionId, not sample presence, drives the remote chip. */
   isRemote: boolean
   sessions: UnifiedSessionRow[]
+  browsers: BrowserWorkspace[]
 }
 
 export type UnifiedProjectGroup = {
@@ -62,4 +68,8 @@ export type MergeContext = {
   repoConnectionIdById: Map<string, string | null>
   /** Repo runtime-host scope by repo id (missing == keep row). */
   repoRuntimeScopedById: Map<string, boolean>
+  /** Browser inventory is open-only; the Resource Manager never scans it in the background. */
+  browserTabsByWorktree?: Record<string, BrowserWorkspace[]>
+  /** Canonical worktrees keep browser-only workspace rows out of synthetic buckets. */
+  worktreeById?: ReadonlyMap<string, Worktree>
 }

--- a/src/renderer/src/components/status-bar/resource-usage-open-slices.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-open-slices.ts
@@ -5,6 +5,7 @@ const EMPTY_TABS_BY_WORKTREE: AppState['tabsByWorktree'] = {}
 const EMPTY_PTY_IDS_BY_TAB_ID: AppState['ptyIdsByTabId'] = {}
 const EMPTY_TERMINAL_LAYOUTS_BY_TAB_ID: AppState['terminalLayoutsByTabId'] = {}
 const EMPTY_RUNTIME_PANE_TITLES_BY_TAB_ID: AppState['runtimePaneTitlesByTabId'] = {}
+const EMPTY_BROWSER_TABS_BY_WORKTREE: AppState['browserTabsByWorktree'] = {}
 const EMPTY_REPOS: AppState['repos'] = []
 const EMPTY_WORKTREES: ReturnType<typeof getAllWorktreesFromState> = []
 
@@ -34,6 +35,13 @@ export function getResourceUsageRuntimePaneTitlesByTabId(
   open: boolean
 ): AppState['runtimePaneTitlesByTabId'] {
   return open ? state.runtimePaneTitlesByTabId : EMPTY_RUNTIME_PANE_TITLES_BY_TAB_ID
+}
+
+export function getResourceUsageBrowserTabsByWorktree(
+  state: Pick<AppState, 'browserTabsByWorktree'>,
+  open: boolean
+): AppState['browserTabsByWorktree'] {
+  return open ? state.browserTabsByWorktree : EMPTY_BROWSER_TABS_BY_WORKTREE
 }
 
 export function getResourceUsageRepos(


### PR DESCRIPTION
Fixes #5095

## Summary

- Show each workspace browser tab in Resource Manager alongside its terminal sessions.
- Reuse the existing browser icon and resource-row layout.
- Keep v1 read-only: no sidebar indicators, counts, activation, close actions, or runtime lifecycle behavior.

## Validation

- 22 focused Resource Manager tests passed.
- Oxlint, React Doctor, formatting, and max-lines checks passed.
- Full typecheck remains blocked by the existing missing `typescript-api` dependency on main.