### PR TITLE
fix(agent): show Codex subagents in sidebar status

### DIFF
--- a/scripts/simulate-codex-subagents.mjs
+++ b/scripts/simulate-codex-subagents.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * Simulate Codex subagent reporting for testing the fix in #8251.
+ *
+ * Usage (while Orca dev app is running with a terminal open):
+ *   node scripts/simulate-codex-subagents.mjs <port> <token> <paneKey> <worktreeId>
+ *
+ * Example:
+ *   # In a terminal inside Orca, run:
+ *   env | grep ORCA_AGENT_HOOK
+ *   # Get paneKey from Orca dev tools or terminal list CLI
+ *   node scripts/simulate-codex-subagents.mjs 12345 abc123def \
+ *     "tab-abc:leaf-123" "repo-id::/absolute/worktree/path"
+ *
+ * Then check the sidebar in Orca for the hierarchy under the worktree/agent.
+ */
+
+// Uses global fetch (available in Node 18+ / 26 here)
+
+const [port, token, paneKey, worktreeId] = process.argv.slice(2)
+
+if (!port || !token || !paneKey || !worktreeId) {
+  console.error(
+    'Usage: node scripts/simulate-codex-subagents.mjs <port> <token> <paneKey> <worktreeId>'
+  )
+  console.error('Get port/token from env in a terminal inside Orca: env | grep ORCA_AGENT_HOOK')
+  console.error('Get paneKey from app (e.g. via terminal list or dev tools inspecting the pane).')
+  process.exit(1)
+}
+
+const url = `http://127.0.0.1:${port}/hook/codex`
+
+const events = [
+  {
+    hook_event_name: 'UserPromptSubmit',
+    prompt: 'Simulate three Codex collaboration agents'
+  },
+  ...['app_motion_audit', 'lovable_pattern_research', 'trading_animation_ideas'].map(
+    (taskName) => ({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'collaborationspawn_agent',
+      tool_input: { task_name: taskName }
+    })
+  )
+]
+
+console.log('Posting simulated Codex collaboration hook sequence...')
+console.log('URL:', url)
+console.log('Pane:', paneKey)
+console.log('Spawn events:', events.length - 1)
+
+try {
+  for (const payload of events) {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Orca-Agent-Hook-Token': token
+      },
+      body: new URLSearchParams({
+        paneKey,
+        tabId: paneKey.split(':')[0],
+        worktreeId,
+        env: 'development',
+        version: '1',
+        payload: JSON.stringify(payload)
+      })
+    })
+    if (response.status !== 204) {
+      throw new Error(`hook returned HTTP ${response.status}`)
+    }
+  }
+  console.log('Success! The sidebar should show 3 working children under the Codex row.')
+} catch (err) {
+  console.error('Error posting hook:', err instanceof Error ? err.message : String(err))
+  console.log('Make sure the app is running and the endpoint values are fresh.')
+  process.exitCode = 1
+}

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -4193,6 +4193,119 @@ describe('Codex hook normalization', () => {
     expect(result?.payload.state).toBe('working')
     expect(result?.payload.prompt).toBe('')
   })
+
+  it('tracks Codex collaboration spawn tools until the root Stop drains the turn', () => {
+    _internals.normalizeHookPayload(
+      'codex',
+      buildBody({
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Spawn two subagents'
+      }),
+      'production'
+    )
+    const first = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'collaborationspawn_agent',
+        tool_input: { task_name: 'repo_map', fork_turns: 'all', message: 'encrypted' }
+      }),
+      'production'
+    )
+    expect(first?.payload.subagents).toEqual([
+      expect.objectContaining({
+        id: 'repo_map',
+        state: 'working',
+        agentType: 'codex',
+        description: 'repo_map'
+      })
+    ])
+    expect(first?.payload.toolInput).toBe('repo_map')
+
+    const second = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'collaboration.spawn_agent',
+        tool_input: { task_name: 'test_scan' }
+      }),
+      'production'
+    )
+    expect(second?.payload.subagents?.map((subagent) => subagent.id)).toEqual([
+      'repo_map',
+      'test_scan'
+    ])
+
+    const waiting = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'collaborationwait_agent',
+        tool_input: { timeout_ms: 30_000 }
+      }),
+      'production'
+    )
+    expect(waiting?.payload.subagents).toHaveLength(2)
+    expect(waiting?.payload.subagents?.every((subagent) => subagent.state === 'working')).toBe(true)
+
+    const stop = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({
+        hook_event_name: 'Stop',
+        last_assistant_message: 'Both subagents completed.'
+      }),
+      'production'
+    )
+    expect(stop?.payload.state).toBe('done')
+    expect(stop?.payload.subagents?.every((subagent) => subagent.state === 'idle')).toBe(true)
+  })
+
+  it('clears completed Codex collaboration rows on the next user prompt', () => {
+    _internals.normalizeHookPayload(
+      'codex',
+      buildBody({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'collaborationspawn_agent',
+        tool_input: { task_name: 'docs_scan' }
+      }),
+      'production'
+    )
+    _internals.normalizeHookPayload('codex', buildBody({ hook_event_name: 'Stop' }), 'production')
+
+    const nextTurn = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({ hook_event_name: 'UserPromptSubmit', prompt: 'New task' }),
+      'production'
+    )
+    expect(nextTurn?.payload.subagents).toBeUndefined()
+  })
+
+  it('idles the exact Codex collaboration target after interrupt_agent completes', () => {
+    for (const taskName of ['repo_map', 'test_scan']) {
+      _internals.normalizeHookPayload(
+        'codex',
+        buildBody({
+          hook_event_name: 'PreToolUse',
+          tool_name: 'collaborationspawn_agent',
+          tool_input: { task_name: taskName }
+        }),
+        'production'
+      )
+    }
+    const interrupted = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'collaborationinterrupt_agent',
+        tool_input: { target: '/root/repo_map' }
+      }),
+      'production'
+    )
+    expect(interrupted?.payload.subagents).toEqual([
+      expect.objectContaining({ id: 'repo_map', state: 'idle' }),
+      expect.objectContaining({ id: 'test_scan', state: 'working' })
+    ])
+  })
 })
 
 describe('Gemini hook normalization', () => {
@@ -5928,6 +6041,62 @@ describe('Last-status persistence', () => {
           agentType: 'claude'
         })
       ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('reseeds Codex collaboration rows before the next hook after restart', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    const receivedAt = recentTs()
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          [PANE]: {
+            paneKey: PANE,
+            tabId: 'tab-1',
+            worktreeId: 'wt-1',
+            receivedAt,
+            stateStartedAt: receivedAt,
+            payload: {
+              state: 'working',
+              prompt: 'parallel review',
+              agentType: 'codex',
+              subagents: [
+                {
+                  id: 'repo_map',
+                  state: 'working',
+                  startedAt: receivedAt - 1_000,
+                  agentType: 'codex',
+                  description: 'repo_map'
+                }
+              ]
+            }
+          }
+        }
+      }),
+      'utf8'
+    )
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      const response = await postHookEvent(
+        server,
+        buildBody({
+          hook_event_name: 'PreToolUse',
+          tool_name: 'collaborationwait_agent',
+          tool_input: { timeout_ms: 30_000 }
+        }),
+        '/hook/codex'
+      )
+      expect(response.status).toBe(204)
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        subagents: [expect.objectContaining({ id: 'repo_map', state: 'working' })]
+      })
     } finally {
       server.stop()
     }

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -6046,7 +6046,7 @@ describe('Last-status persistence', () => {
     }
   })
 
-  it('reseeds Codex collaboration rows before the next hook after restart', async () => {
+  it('hydrates Codex collaboration rows as idle and keeps them idle until a new spawn', async () => {
     mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
     const receivedAt = recentTs()
     writeFileSync(
@@ -6083,6 +6083,10 @@ describe('Last-status persistence', () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production', userDataPath })
     try {
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'working',
+        subagents: [expect.objectContaining({ id: 'repo_map', state: 'idle' })]
+      })
       const response = await postHookEvent(
         server,
         buildBody({
@@ -6095,7 +6099,7 @@ describe('Last-status persistence', () => {
       expect(response.status).toBe(204)
       expect(server.getStatusSnapshot()[0]).toMatchObject({
         state: 'working',
-        subagents: [expect.objectContaining({ id: 'repo_map', state: 'working' })]
+        subagents: [expect.objectContaining({ id: 'repo_map', state: 'idle' })]
       })
     } finally {
       server.stop()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -242,6 +242,27 @@ function sanitizeHydratedEntry(
   }
 }
 
+function idleHydratedCodexSubagents(
+  entry: EnrichedAgentHookEventPayload
+): EnrichedAgentHookEventPayload {
+  const subagents = entry.payload.subagents
+  if (
+    entry.payload.agentType !== 'codex' ||
+    !subagents?.some((subagent) => subagent.state === 'working')
+  ) {
+    return entry
+  }
+  // Why: after an app restart, Codex cannot replay child completion events.
+  // Keep the rows for context without presenting stale work as still running.
+  return {
+    ...entry,
+    payload: {
+      ...entry.payload,
+      subagents: subagents.map((subagent) => ({ ...subagent, state: 'idle' as const }))
+    }
+  }
+}
+
 function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentStatusIpcPayload {
   return {
     paneKey: entry.paneKey,
@@ -1567,6 +1588,7 @@ export class AgentHookServer {
     }
     let hydrated = 0
     let dropped = 0
+    let normalized = 0
     // Why: bound disk growth — drop anything older than HYDRATE_MAX_AGE_MS so
     // entries from worktrees archived weeks ago do not pile up forever. Use
     // Date.now() once to keep the cutoff consistent across all entries this
@@ -1578,8 +1600,12 @@ export class AgentHookServer {
         resolvedPaneKey === paneKey || typeof rawEntry !== 'object' || rawEntry === null
           ? rawEntry
           : { ...(rawEntry as Record<string, unknown>), paneKey: resolvedPaneKey }
-      const entry = sanitizeHydratedEntry(resolvedPaneKey, rawResolvedEntry)
-      if (entry && entry.receivedAt >= ttlCutoff) {
+      const sanitizedEntry = sanitizeHydratedEntry(resolvedPaneKey, rawResolvedEntry)
+      if (sanitizedEntry && sanitizedEntry.receivedAt >= ttlCutoff) {
+        const entry = idleHydratedCodexSubagents(sanitizedEntry)
+        if (entry !== sanitizedEntry) {
+          normalized += 1
+        }
         this.state.lastStatusByPaneKey.set(resolvedPaneKey, entry)
         // Why: in-memory provider rosters die with the process. Reseed the
         // matching tracker so the next hook does not drop replayed child rows.
@@ -1606,17 +1632,16 @@ export class AgentHookServer {
         `[agent-hooks] last-status hydrate dropped ${dropped} entries (kept ${hydrated})`
       )
     }
-    if (hydrated > 0 && dropped === 0) {
+    if (hydrated > 0 && dropped === 0 && normalized === 0) {
       // Why: prime from the raw on-disk bytes (not a re-serialization) so the
       // dedup is robust against future shape drift in serializeStatusFile.
-      // Only prime when hydration was lossless — if entries were dropped
-      // during sanitize, the in-memory map diverges from the on-disk bytes.
+      // Only prime when hydration was lossless — dropped or normalized entries
+      // make the in-memory map diverge from the on-disk bytes.
       this.lastWrittenJson = raw
-    } else if (dropped > 0) {
+    } else if (dropped > 0 || normalized > 0) {
       // Why: clean the stale on-disk file now so a user who has not run an
-      // agent in 8+ days does not re-drop the same entries on every cold
-      // boot. Synchronous variant is safe at start time and avoids
-      // unref'd-timer-during-quit edge cases.
+      // agent in 8+ days or has stale Codex workers does not repeat the same
+      // repair on every cold boot. Synchronous variant avoids quit-time races.
       this.runStatusPersist()
     }
   }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -34,6 +34,7 @@ import {
   resolveHookSource,
   preparePendingGrokResultDiscovery,
   seedClaudeSubagentRosterFromSnapshots,
+  seedCodexCollaborationRosterFromSnapshots,
   warnOnHookEnvOrVersionMismatch,
   writeEndpointFile,
   type AgentHookEventPayload,
@@ -1580,11 +1581,15 @@ export class AgentHookServer {
       const entry = sanitizeHydratedEntry(resolvedPaneKey, rawResolvedEntry)
       if (entry && entry.receivedAt >= ttlCutoff) {
         this.state.lastStatusByPaneKey.set(resolvedPaneKey, entry)
-        // Why: the in-memory subagent roster died with the previous process.
-        // Reseed it from the persisted snapshot so the next teammate-bearing
-        // Stop (whose task ids never match lifecycle ids) doesn't silently
-        // drop the replayed child rows.
-        if (entry.payload.subagents) {
+        // Why: in-memory provider rosters die with the process. Reseed the
+        // matching tracker so the next hook does not drop replayed child rows.
+        if (entry.payload.subagents && entry.payload.agentType === 'codex') {
+          seedCodexCollaborationRosterFromSnapshots(
+            this.state,
+            resolvedPaneKey,
+            entry.payload.subagents
+          )
+        } else if (entry.payload.subagents) {
           seedClaudeSubagentRosterFromSnapshots(
             this.state,
             resolvedPaneKey,

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -90,6 +90,27 @@ function makeSplitPaneLayout(firstLeafId: string, secondLeafId: string): Termina
 }
 
 describe('buildWorktreeAgentRows', () => {
+  it('deduplicates a pane present in both live and orchestration entry sources', () => {
+    const live = makeEntry(PANE_KEY_1, 1000, { state: 'working' })
+    const duplicate = makeEntry(PANE_KEY_1, 1000, {
+      state: 'working',
+      orchestration: {
+        taskId: 'task-duplicate',
+        dispatchId: 'dispatch-duplicate',
+        parentPaneKey: PANE_KEY_2
+      }
+    })
+
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [live, duplicate],
+      retained: [],
+      now: 2000
+    })
+
+    expect(rows.map((row) => row.paneKey)).toEqual([PANE_KEY_1])
+  })
+
   it('includes retained rows even when their original tab is no longer current', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1')],

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -4,6 +4,7 @@ import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { useAppStore } from '@/store'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import {
   selectLivePtyIdsForWorktree,
   selectRuntimePaneTitlesForWorktree
@@ -74,6 +75,27 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
     useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
   )
+  // Why: dispatched workers may live in another worktree but still belong
+  // under the coordinator row in this worktree's agent status view.
+  const orchestratedChildEntries = useAppStore(
+    useShallow((s) => {
+      if (!active) {
+        return []
+      }
+      const orchestrationByPaneKey = selectRuntimeAgentOrchestrationForWorktree(s, worktreeId)
+      const out: AgentStatusEntry[] = []
+      for (const [childPaneKey, orchestration] of Object.entries(orchestrationByPaneKey)) {
+        if (!orchestration.parentPaneKey) {
+          continue
+        }
+        const entry = s.agentStatusByPaneKey[childPaneKey]
+        if (entry) {
+          out.push(entry)
+        }
+      }
+      return out
+    })
+  )
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
@@ -89,12 +111,13 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
       migrationUnsupported.length > 0
         ? [
             ...liveEntries,
+            ...orchestratedChildEntries,
             ...migrationUnsupported.flatMap((unsupported) => {
               const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
               return entry ? [entry] : []
             })
           ]
-        : liveEntries
+        : [...liveEntries, ...orchestratedChildEntries]
     return applyAgentRowLineage(
       buildWorktreeAgentRows({
         tabs: tabs ?? [],
@@ -112,6 +135,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     active,
     tabs,
     liveEntries,
+    orchestratedChildEntries,
     migrationUnsupported,
     retained,
     runtimePaneTitlesByTabId,

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -213,6 +213,7 @@ export function buildWorktreeAgentRows(args: {
 }): DashboardAgentRow[] {
   const rows: DashboardAgentRow[] = []
   const seenPaneKeys = new Set<string>()
+  const indexedPaneKeys = new Set<string>()
   const currentTabIds = new Set(args.tabs.map((tab) => tab.id))
 
   const entriesByTabId = new Map<string, AgentStatusEntry[]>()
@@ -221,6 +222,12 @@ export function buildWorktreeAgentRows(args: {
     if (!parsed) {
       continue
     }
+    // Why: a same-worktree orchestration child can arrive through both the
+    // worktree status index and the coordinator overlay. One pane is one row.
+    if (indexedPaneKeys.has(entry.paneKey)) {
+      continue
+    }
+    indexedPaneKeys.add(entry.paneKey)
     const bucket = entriesByTabId.get(parsed.tabId)
     if (bucket) {
       bucket.push(entry)

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -46,7 +46,6 @@ import {
   type ClaudeSubagentRoster
 } from './claude-subagent-roster'
 import {
-  codexCollaborationRosterHasWorkingTask,
   codexCollaborationRosterToSnapshots,
   markAllCodexCollaborationTasksIdle,
   markCodexCollaborationTaskIdle,
@@ -3126,15 +3125,10 @@ function normalizeCodexEvent(
     { resetOnNewTurn: isNewTurnEvent('codex', eventName) }
   )
   const subagents = updateCodexCollaborationRoster(state, eventName, paneKey, hookPayload)
-  const resolvedState =
-    stateName === 'done' &&
-    codexCollaborationRosterHasWorkingTask(state.codexCollaborationRosterByPaneKey.get(paneKey))
-      ? 'working'
-      : stateName
 
   return parseAgentStatusPayload(
     JSON.stringify({
-      state: resolvedState,
+      state: stateName,
       prompt: resolvePrompt(state, paneKey, promptText, {
         resetOnNewTurn: isNewTurnEvent('codex', eventName)
       }),
@@ -3200,7 +3194,9 @@ export function seedCodexCollaborationRosterFromSnapshots(
   }
   const roster = getOrCreateCodexCollaborationRoster(state, paneKey)
   for (const snapshot of snapshots) {
-    roster.set(snapshot.id, { ...snapshot })
+    // Why: Codex has no child completion replay after an Orca restart. A
+    // persisted working state is not authoritative, so only new hooks revive it.
+    roster.set(snapshot.id, { ...snapshot, state: 'idle' })
   }
 }
 

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -45,6 +45,16 @@ import {
   upsertWorkingClaudeSubagent,
   type ClaudeSubagentRoster
 } from './claude-subagent-roster'
+import {
+  codexCollaborationRosterHasWorkingTask,
+  codexCollaborationRosterToSnapshots,
+  markAllCodexCollaborationTasksIdle,
+  markCodexCollaborationTaskIdle,
+  readCodexInterruptedTaskName,
+  readCodexSpawnTaskName,
+  upsertWorkingCodexCollaborationTask,
+  type CodexCollaborationRoster
+} from './codex-collaboration-roster'
 import { ORCA_HOOK_PROTOCOL_VERSION } from './agent-hook-types'
 import { REMOTE_AGENT_HOOK_ENV, type AgentHookSource } from './agent-hook-relay'
 import {
@@ -107,6 +117,9 @@ export type HookListenerState = {
   /** Live subagents/teammates per Claude pane. Survives turn boundaries —
    *  background children outlive the lead turn that spawned them. */
   claudeSubagentRosterByPaneKey: Map<string, ClaudeSubagentRoster>
+  /** Codex collaboration tools report task starts but no child lifecycle
+   *  hooks. Keep a pane roster until the root Stop drains the turn. */
+  codexCollaborationRosterByPaneKey: Map<string, CodexCollaborationRoster>
   /** Last state derived from the LEAD session's own events (subagent-origin
    *  events carry `agent_id` and are excluded). Needed so a SubagentStop can
    *  re-emit the pane status without inventing a lead state. `interrupted`
@@ -140,6 +153,7 @@ export function createHookListenerState(): HookListenerState {
     antigravityCompletedTranscriptByPaneKey: new Map(),
     ampCompletedCacheKeys: new Set(),
     claudeSubagentRosterByPaneKey: new Map(),
+    codexCollaborationRosterByPaneKey: new Map(),
     claudeLeadStateByPaneKey: new Map()
   }
 }
@@ -151,6 +165,7 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   deletePaneScopedCacheEntry(state.antigravityCompletedTranscriptByPaneKey, paneKey)
   deletePaneScopedSetEntry(state.ampCompletedCacheKeys, paneKey)
   state.claudeSubagentRosterByPaneKey.delete(paneKey)
+  state.codexCollaborationRosterByPaneKey.delete(paneKey)
   state.claudeLeadStateByPaneKey.delete(paneKey)
 }
 
@@ -190,6 +205,7 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.warnedVersions.clear()
   state.warnedEnvs.clear()
   state.claudeSubagentRosterByPaneKey.clear()
+  state.codexCollaborationRosterByPaneKey.clear()
   state.claudeLeadStateByPaneKey.clear()
 }
 
@@ -546,6 +562,10 @@ const TOOL_INPUT_KEYS_BY_TOOL: Record<string, readonly string[]> = {
   web_fetch: ['url'],
   google_web_search: ['query'],
   exec_command: ['cmd', 'command'],
+  collaborationspawn_agent: ['task_name'],
+  collaborationinterrupt_agent: ['target'],
+  collaborationfollowup_task: ['target'],
+  collaborationsend_message: ['target'],
   shell_command: ['cmd', 'command'],
   run_terminal_cmd: ['command'],
   // Why: Grok maps Bash/Edit/Write to snake_case first-party tool names
@@ -3105,10 +3125,16 @@ function normalizeCodexEvent(
     extractToolFields('codex', eventName, hookPayload),
     { resetOnNewTurn: isNewTurnEvent('codex', eventName) }
   )
+  const subagents = updateCodexCollaborationRoster(state, eventName, paneKey, hookPayload)
+  const resolvedState =
+    stateName === 'done' &&
+    codexCollaborationRosterHasWorkingTask(state.codexCollaborationRosterByPaneKey.get(paneKey))
+      ? 'working'
+      : stateName
 
   return parseAgentStatusPayload(
     JSON.stringify({
-      state: stateName,
+      state: resolvedState,
       prompt: resolvePrompt(state, paneKey, promptText, {
         resetOnNewTurn: isNewTurnEvent('codex', eventName)
       }),
@@ -3116,9 +3142,66 @@ function normalizeCodexEvent(
       toolName: snapshot.toolName,
       toolInput: snapshot.toolInput,
       interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
+      lastAssistantMessage: snapshot.lastAssistantMessage,
+      subagents
     })
   )
+}
+
+function updateCodexCollaborationRoster(
+  state: HookListenerState,
+  eventName: unknown,
+  paneKey: string,
+  hookPayload: Record<string, unknown>
+): AgentSubagentSnapshot[] | undefined {
+  if (eventName === 'SessionStart' || eventName === 'UserPromptSubmit') {
+    state.codexCollaborationRosterByPaneKey.delete(paneKey)
+  }
+  const spawnTaskName = readCodexSpawnTaskName(hookPayload)
+  if (spawnTaskName && (eventName === 'PreToolUse' || eventName === 'PostToolUse')) {
+    const roster = getOrCreateCodexCollaborationRoster(state, paneKey)
+    upsertWorkingCodexCollaborationTask(roster, spawnTaskName, Date.now())
+  }
+  const interruptedTaskName = readCodexInterruptedTaskName(hookPayload)
+  if (interruptedTaskName && eventName === 'PostToolUse') {
+    const roster = state.codexCollaborationRosterByPaneKey.get(paneKey)
+    if (roster) {
+      markCodexCollaborationTaskIdle(roster, interruptedTaskName)
+    }
+  }
+  const roster = state.codexCollaborationRosterByPaneKey.get(paneKey)
+  if (eventName === 'Stop' && roster) {
+    // Why: Codex emits no per-child completion hooks; the root Stop is the
+    // first authoritative signal that its collaboration turn has drained.
+    markAllCodexCollaborationTasksIdle(roster)
+  }
+  return codexCollaborationRosterToSnapshots(roster)
+}
+
+function getOrCreateCodexCollaborationRoster(
+  state: HookListenerState,
+  paneKey: string
+): CodexCollaborationRoster {
+  let roster = state.codexCollaborationRosterByPaneKey.get(paneKey)
+  if (!roster) {
+    roster = new Map()
+    state.codexCollaborationRosterByPaneKey.set(paneKey, roster)
+  }
+  return roster
+}
+
+export function seedCodexCollaborationRosterFromSnapshots(
+  state: HookListenerState,
+  paneKey: string,
+  snapshots: readonly AgentSubagentSnapshot[]
+): void {
+  if (snapshots.length === 0 || state.codexCollaborationRosterByPaneKey.has(paneKey)) {
+    return
+  }
+  const roster = getOrCreateCodexCollaborationRoster(state, paneKey)
+  for (const snapshot of snapshots) {
+    roster.set(snapshot.id, { ...snapshot })
+  }
 }
 
 function normalizeOpenCodeFamilyEvent(

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -83,9 +83,10 @@ export type AgentStatusOrchestrationContext = {
 export type AgentSubagentState = 'working' | 'idle'
 
 /** A live in-process subagent/teammate spawned by the pane's agent session
- *  (reported by Claude's SubagentStart/SubagentStop hooks and the
- *  `background_tasks` field on Stop). Rendered as an indented child row under
- *  the owning pane's sidebar row — these children have no PTY of their own. */
+ *  (reported via provider hooks like Claude's Subagent* / background_tasks,
+ *  or Codex equivalent sub/worker info in payloads). Rendered as an indented
+ *  child row under the owning pane's sidebar row — these children have no PTY
+ *  of their own. */
 export type AgentSubagentSnapshot = {
   /** Provider-assigned id (Claude hook `agent_id`). */
   id: string

--- a/src/shared/codex-collaboration-roster.ts
+++ b/src/shared/codex-collaboration-roster.ts
@@ -1,0 +1,131 @@
+import { AGENT_STATUS_MAX_SUBAGENTS, type AgentSubagentSnapshot } from './agent-status-types'
+
+const CODEX_COLLABORATION_TASK_ID_MAX_LENGTH = 64
+
+export type CodexCollaborationRoster = Map<string, AgentSubagentSnapshot>
+
+export function readCodexSpawnTaskName(hookPayload: Record<string, unknown>): string | undefined {
+  const toolName = readNormalizedToolName(hookPayload)
+  if (toolName !== 'collaborationspawnagent' && toolName !== 'spawnagent') {
+    return undefined
+  }
+  const input = readToolInput(hookPayload)
+  const taskName = readString(input, 'task_name') ?? readString(input, 'taskName')
+  return normalizeTaskName(taskName)
+}
+
+export function readCodexInterruptedTaskName(
+  hookPayload: Record<string, unknown>
+): string | undefined {
+  const toolName = readNormalizedToolName(hookPayload)
+  if (toolName !== 'collaborationinterruptagent' && toolName !== 'interruptagent') {
+    return undefined
+  }
+  const input = readToolInput(hookPayload)
+  return normalizeTaskName(readString(input, 'target'))
+}
+
+export function upsertWorkingCodexCollaborationTask(
+  roster: CodexCollaborationRoster,
+  taskName: string,
+  now: number
+): void {
+  if (taskName.length === 0 || taskName.length > CODEX_COLLABORATION_TASK_ID_MAX_LENGTH) {
+    return
+  }
+  const existing = roster.get(taskName)
+  if (existing) {
+    existing.state = 'working'
+    return
+  }
+  if (roster.size >= AGENT_STATUS_MAX_SUBAGENTS && !evictOldestIdleTask(roster)) {
+    return
+  }
+  roster.set(taskName, {
+    id: taskName,
+    state: 'working',
+    startedAt: now,
+    agentType: 'codex',
+    description: taskName
+  })
+}
+
+export function markCodexCollaborationTaskIdle(
+  roster: CodexCollaborationRoster,
+  taskName: string
+): void {
+  const task = roster.get(taskName)
+  if (task) {
+    task.state = 'idle'
+  }
+}
+
+export function markAllCodexCollaborationTasksIdle(roster: CodexCollaborationRoster): void {
+  for (const task of roster.values()) {
+    task.state = 'idle'
+  }
+}
+
+export function codexCollaborationRosterHasWorkingTask(
+  roster: CodexCollaborationRoster | undefined
+): boolean {
+  if (!roster) {
+    return false
+  }
+  for (const task of roster.values()) {
+    if (task.state === 'working') {
+      return true
+    }
+  }
+  return false
+}
+
+export function codexCollaborationRosterToSnapshots(
+  roster: CodexCollaborationRoster | undefined
+): AgentSubagentSnapshot[] | undefined {
+  if (!roster || roster.size === 0) {
+    return undefined
+  }
+  return [...roster.values()]
+    .map((task) => ({ ...task }))
+    .sort((a, b) => a.startedAt - b.startedAt || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+}
+
+function readNormalizedToolName(hookPayload: Record<string, unknown>): string | undefined {
+  const toolName = readString(hookPayload, 'tool_name') ?? readString(hookPayload, 'name')
+  return toolName?.replaceAll(/[^a-z0-9]/gi, '').toLowerCase()
+}
+
+function readToolInput(hookPayload: Record<string, unknown>): Record<string, unknown> {
+  const input = hookPayload.tool_input ?? hookPayload.input ?? hookPayload.arguments
+  return typeof input === 'object' && input !== null ? (input as Record<string, unknown>) : {}
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function normalizeTaskName(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+  // Why: interrupt targets use canonical paths such as `/root/repo_map`, while
+  // spawn inputs use the sibling name. One stable leaf id lets both events match.
+  const leaf = value.slice(value.lastIndexOf('/') + 1).trim()
+  return leaf.length > 0 ? leaf : undefined
+}
+
+function evictOldestIdleTask(roster: CodexCollaborationRoster): boolean {
+  let oldest: AgentSubagentSnapshot | undefined
+  for (const task of roster.values()) {
+    if (task.state === 'idle' && (!oldest || task.startedAt < oldest.startedAt)) {
+      oldest = task
+    }
+  }
+  if (!oldest) {
+    return false
+  }
+  roster.delete(oldest.id)
+  return true
+}

--- a/src/shared/codex-collaboration-roster.ts
+++ b/src/shared/codex-collaboration-roster.ts
@@ -66,20 +66,6 @@ export function markAllCodexCollaborationTasksIdle(roster: CodexCollaborationRos
   }
 }
 
-export function codexCollaborationRosterHasWorkingTask(
-  roster: CodexCollaborationRoster | undefined
-): boolean {
-  if (!roster) {
-    return false
-  }
-  for (const task of roster.values()) {
-    if (task.state === 'working') {
-      return true
-    }
-  }
-  return false
-}
-
 export function codexCollaborationRosterToSnapshots(
   roster: CodexCollaborationRoster | undefined
 ): AgentSubagentSnapshot[] | undefined {


### PR DESCRIPTION
## Summary

- Show Codex collaboration workers as indented child rows beneath their owning agent in the sidebar.
- Build a bounded, pane-scoped roster from real `collaborationspawn_agent` and `collaborationinterrupt_agent` hook events because Codex does not emit the `subagents` payload used by other providers.
- Preserve the roster through wait hooks and listener restarts, mark workers idle at the authoritative root `Stop`, and clear stale workers on the next turn.
- Include orchestrated child panes from other worktrees under their coordinator row.

Fixes #8251.

## Screenshots

Codex collaboration workers appear as indented child rows beneath their owning agent.

<img width="274" height="370" alt="Codex collaboration workers shown in the Orca sidebar" src="https://github.com/user-attachments/assets/3544d0c7-b3b0-421f-927c-16fc706a315f" />

## Testing

- [ ] `pnpm lint` — the changed files pass oxlint/oxfmt and the max-lines ratchet; the repository-wide command is blocked by an unrelated existing interpolation mismatch in `ko.json` for `auto.components.orca.profiles.project.transfer.confirm.move.description`.
- [x] `pnpm typecheck`
- [x] `fnm exec --using=24.18.0 pnpm test` — 2,676 files passed, 28,128 tests passed, 5 files/39 tests skipped.
- [x] `pnpm build`
- [x] Added regression coverage for spawn de-duplication, wait continuity, exact-target interrupt, root-stop idle state, turn reset, pane isolation, bounded rosters, and persisted-state hydration.
- [x] Verified in the macOS dev app with a genuine Codex session spawning three workers: all appeared as working child rows, then remained visible as idle rows after the root stopped.

## AI Review Report

- Correctness: reviewed duplicate pre/post hook delivery, provider-specific hydration, pane cleanup, restart behavior, and the lack of per-worker completion hooks in Codex.
- Performance: the roster is bounded by the existing subagent limit and updates only when hook events arrive; no polling or additional IPC was added.
- Cross-platform and remote: the normalizer is shared by local, WSL, and SSH hook relay paths and does not add platform-specific filesystem or keyboard behavior.
- Provider compatibility: Codex handling is gated by the explicit Codex source/type; Claude and other providers continue using their existing lifecycle paths.

## Security Audit

- Treats hook payloads as untrusted input: tool names are normalized, task identifiers are trimmed and length-limited, and roster size is bounded.
- Persisted snapshots continue through the existing sanitization path before hydration.
- Adds no new network listener, IPC method, command execution, credential storage, or authorization path.

## Notes

- Codex currently provides worker-start events but no authoritative per-worker completion event. Child rows therefore remain working until the root `Stop`, then become idle until the next user turn.
- `scripts/simulate-codex-subagents.mjs` is included for deterministic manual verification against a running dev app; it requires the caller's ephemeral hook endpoint values.
- X/Twitter handle: not provided.

## ELI5

Codex collaboration workers now show as indented child rows under the main agent in the sidebar. The roster comes from real spawn/interrupt hooks, survives waits and restarts, and clears when the root turn stops so you can see nested agent work.
