### PR TITLE
fix(codex): preserve WSL hook trust across launches

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -50,6 +50,7 @@
     "../src/main/codex/config-toml-trust.ts",
     "../src/main/codex/hook-service.ts",
     "../src/main/codex/hook-trust-promotion.ts",
+    "../src/main/codex/wsl-managed-hook-trust.ts",
     "../src/main/codex-accounts/fs-utils.ts",
     "../src/main/codex-accounts/wsl-codex-command.ts",
     "../src/main/codex-cli/command.ts",

--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -90,6 +90,7 @@
     "../src/main/codex/hook-service.ts",
     "../src/main/codex/hook-trust-promotion.ts",
     "../src/main/codex/managed-home-shell-preflight.ts",
+    "../src/main/codex/wsl-managed-hook-trust.ts",
     "../src/main/codex-accounts/fs-utils.ts",
     "../src/main/codex-accounts/wsl-codex-command.ts",
     "../src/main/codex-cli/command.ts",

--- a/src/main/codex/codex-hook-wsl-runtime.ts
+++ b/src/main/codex/codex-hook-wsl-runtime.ts
@@ -20,6 +20,7 @@ import {
   wrapReadablePosixHookCommand,
   writeCodexHooksJson
 } from './codex-hook-definition'
+import { createCodexHookTrustEntry } from './codex-hook-identity'
 import { grantManagedCodexHookTrust } from './codex-hook-trust-grant'
 import { getManagedScript } from './codex-hook-script'
 import {
@@ -28,6 +29,10 @@ import {
 } from './codex-hook-trust-cleanup'
 import { readCodexTrustGrantLedgerHomeForReconciliation } from './codex-managed-trust-reconciliation'
 import { runExclusivelyForCodexTrustConfig } from './codex-trust-config-mutation-queue'
+import {
+  preserveCodexWrittenWslManagedHookTrust,
+  type WslManagedHookTrustCandidate
+} from './wsl-managed-hook-trust'
 import type {
   CodexWslRuntimeHookInstallPlan,
   WslCanonicalPathSettlement
@@ -74,23 +79,39 @@ async function installManagedHooksIntoWslRuntimeExclusively(
     }
   }
 
-  const trustEntries: CodexTrustEntry[] = []
+  const trustCandidates: WslManagedHookTrustCandidate[] = []
   for (const eventName of CODEX_EVENTS) {
     const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
     const cleaned = removeManagedCommands(current, isManagedCommand)
+    const managedHook = buildManagedCommandHook(command)
     const definition: HookDefinition = {
-      hooks: [buildManagedCommandHook(command)]
+      hooks: [managedHook]
     }
     nextHooks[eventName] = [definition, ...cleaned]
-    trustEntries.push({
+    const next: CodexTrustEntry = {
       sourcePath: plan.trustConfigPath,
       eventLabel: CODEX_EVENT_LABEL[eventName],
       groupIndex: 0,
       handlerIndex: 0,
       command,
       timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
-    })
+    }
+    const previousDefinition = current[0]
+    const previousHook = previousDefinition?.hooks?.[0]
+    const previous =
+      previousDefinition && previousHook
+        ? createCodexHookTrustEntry(
+            plan.trustConfigPath,
+            eventName,
+            0,
+            0,
+            previousDefinition,
+            previousHook
+          )
+        : null
+    trustCandidates.push({ next, previous })
   }
+  const trustEntries = trustCandidates.map((candidate) => candidate.next)
 
   config.hooks = nextHooks
   writeManagedScript(plan.scriptPath, getManagedScript('posix'))
@@ -118,9 +139,15 @@ async function installManagedHooksIntoWslRuntimeExclusively(
       telemetryLane: 'managed'
     })
     if (grant.lane === 'fallback') {
+      // Why: when RPC grant is unavailable, keep a Codex-written hash if the
+      // managed hook content is unchanged so reinstalls do not force re-approval.
+      const preservedTrustEntries = preserveCodexWrittenWslManagedHookTrust(
+        plan.tomlPath,
+        trustCandidates
+      )
       // Why: WSL runtime homes may carry user hook approvals we did not rebuild
       // here; only upsert Orca's entries instead of sweeping the whole source.
-      upsertHookTrustEntries(plan.tomlPath, trustEntries)
+      upsertHookTrustEntries(plan.tomlPath, preservedTrustEntries)
     }
   } catch (error) {
     return {

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -25,7 +25,7 @@ import { codexAppServerCapabilityCache } from './codex-app-server-capability-cac
 import { _internals as trustGrantInternals } from './codex-hook-trust-grant'
 
 type HooksConfig = {
-  hooks: Record<string, { hooks?: { command?: string }[] }[]>
+  hooks: Record<string, { hooks?: { command?: string; timeout?: number }[] }[]>
 }
 
 const managedEvents = [
@@ -169,6 +169,28 @@ describe('Codex WSL runtime hook install', () => {
     expect(trustEntries.has(newKey)).toBe(true)
   })
 
+  it('keeps a Codex-written trust hash when the managed WSL hook is unchanged', () => {
+    const plan = createTestPlan()
+    writeFileSync(plan.configPath, '{"hooks":{}}\n', 'utf-8')
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    expect(_internals.installManagedHooksIntoWslRuntime(plan).state).toBe('installed')
+
+    const installed = JSON.parse(readFileSync(plan.configPath, 'utf-8')) as HooksConfig
+    const managedCommand = installed.hooks.UserPromptSubmit[0]?.hooks?.[0]?.command
+    const managedEntry = getManagedTrustEntry(plan, managedCommand!)
+    const codexWrittenHash = 'sha256:codex-wsl-authoritative'
+    upsertHookTrustEntries(plan.tomlPath, [
+      { ...managedEntry, trustedHash: codexWrittenHash, enabled: true }
+    ])
+
+    expect(_internals.installManagedHooksIntoWslRuntime(plan).state).toBe('installed')
+
+    expect(readHookTrustEntries(plan.tomlPath).get(computeTrustKey(managedEntry))).toEqual({
+      enabled: true,
+      trustedHash: codexWrittenHash
+    })
+  })
+
   it.skipIf(process.platform === 'win32')(
     'drains stdin when the WSL runtime script is missing',
     () => {
@@ -192,6 +214,32 @@ describe('Codex WSL runtime hook install', () => {
       expect(result.status).toBe(0)
     }
   )
+
+  it('recomputes WSL trust when the previously installed hook content changed', () => {
+    const plan = createTestPlan()
+    writeFileSync(plan.configPath, '{"hooks":{}}\n', 'utf-8')
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    expect(_internals.installManagedHooksIntoWslRuntime(plan).state).toBe('installed')
+
+    const installed = JSON.parse(readFileSync(plan.configPath, 'utf-8')) as HooksConfig
+    const definition = installed.hooks.UserPromptSubmit[0]!
+    const managedHook = definition.hooks![0]!
+    managedHook.timeout = MANAGED_HOOK_TIMEOUT_SECONDS + 1
+    writeFileSync(plan.configPath, `${JSON.stringify(installed)}\n`, 'utf-8')
+    const staleEntry = getManagedTrustEntry(plan, managedHook.command!)
+    staleEntry.timeoutSec = managedHook.timeout
+    upsertHookTrustEntries(plan.tomlPath, [
+      { ...staleEntry, trustedHash: 'sha256:stale-hook-content', enabled: true }
+    ])
+
+    expect(_internals.installManagedHooksIntoWslRuntime(plan).state).toBe('installed')
+
+    const currentEntry = { ...staleEntry, timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS }
+    expect(readHookTrustEntries(plan.tomlPath).get(computeTrustKey(currentEntry))).toEqual({
+      enabled: true,
+      trustedHash: computeTrustedHash(currentEntry)
+    })
+  })
 
   it('sweeps all managed WSL trust for disable or confirmed absence', () => {
     // Why: disable and confirmed absence intentionally pass []. Transient

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -23,6 +23,7 @@ import {
 import type { CodexHookTrustGrantRequest } from './codex-app-server-client'
 import { codexAppServerCapabilityCache } from './codex-app-server-capability-cache'
 import { _internals as trustGrantInternals } from './codex-hook-trust-grant'
+import { preserveCodexWrittenWslManagedHookTrust } from './wsl-managed-hook-trust'
 
 type HooksConfig = {
   hooks: Record<string, { hooks?: { command?: string; timeout?: number }[] }[]>
@@ -189,6 +190,20 @@ describe('Codex WSL runtime hook install', () => {
       enabled: true,
       trustedHash: codexWrittenHash
     })
+  })
+
+  it('does not carry Codex-written trust across managed WSL trust keys', () => {
+    const plan = createTestPlan()
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    const previous = getManagedTrustEntry(plan, expectedManagedCommand(plan.commandScriptPath))
+    const next = { ...previous, sourcePath: '/home/bob/.codex/hooks.json' }
+    upsertHookTrustEntries(plan.tomlPath, [
+      { ...previous, trustedHash: 'sha256:codex-wsl-authoritative', enabled: true }
+    ])
+
+    expect(preserveCodexWrittenWslManagedHookTrust(plan.tomlPath, [{ previous, next }])).toEqual([
+      next
+    ])
   })
 
   it.skipIf(process.platform === 'win32')(

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -302,6 +302,39 @@ describe('Codex WSL runtime hook install', () => {
     ])
   })
 
+  it('does not inherit a prior hash when the current trust entry is missing', () => {
+    const plan = createTestPlan()
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    const previous = {
+      ...getManagedTrustEntry(plan, expectedManagedCommand(plan.commandScriptPath)),
+      trustedHash: 'sha256:must-not-inherit'
+    }
+    const next = getManagedTrustEntry(plan, expectedManagedCommand(plan.commandScriptPath))
+
+    expect(preserveCodexWrittenWslManagedHookTrust(plan.tomlPath, [{ previous, next }])).toEqual([
+      next
+    ])
+  })
+
+  it('keeps enabled false when preserving an unchanged Codex-written hash', () => {
+    const plan = createTestPlan()
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    const next = getManagedTrustEntry(plan, expectedManagedCommand(plan.commandScriptPath))
+    upsertHookTrustEntries(plan.tomlPath, [
+      { ...next, trustedHash: 'sha256:codex-wsl-authoritative', enabled: false }
+    ])
+
+    expect(
+      preserveCodexWrittenWslManagedHookTrust(plan.tomlPath, [{ previous: next, next }])
+    ).toEqual([
+      {
+        ...next,
+        trustedHash: 'sha256:codex-wsl-authoritative',
+        enabled: false
+      }
+    ])
+  })
+
   it.skipIf(process.platform === 'win32')(
     'drains stdin when the WSL runtime script is missing',
     async () => {

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -26,7 +26,7 @@ import { codexAppServerCapabilityCache } from './codex-app-server-capability-cac
 import { _internals as trustGrantInternals } from './codex-hook-trust-grant'
 
 type HooksConfig = {
-  hooks: Record<string, { hooks?: { command?: string }[] }[]>
+  hooks: Record<string, { hooks?: { command?: string; timeout?: number }[] }[]>
 }
 
 const managedEvents = [
@@ -43,6 +43,7 @@ const managedEvents = [
 let tempRoots: string[] = []
 
 afterEach(() => {
+  vi.unstubAllEnvs()
   for (const root of tempRoots) {
     rmSync(root, { recursive: true, force: true })
   }
@@ -263,6 +264,29 @@ describe('Codex WSL runtime hook install', () => {
     expect(trustEntries.has(newKey)).toBe(true)
   })
 
+  it('keeps a Codex-written trust hash when the managed WSL hook is unchanged', async () => {
+    vi.stubEnv('ORCA_DISABLE_CODEX_TRUST_RPC', '1')
+    const plan = createTestPlan()
+    writeFileSync(plan.configPath, '{"hooks":{}}\n', 'utf-8')
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    expect((await _internals.installManagedHooksIntoWslRuntime(plan)).state).toBe('installed')
+
+    const installed = JSON.parse(readFileSync(plan.configPath, 'utf-8')) as HooksConfig
+    const managedCommand = installed.hooks.UserPromptSubmit[0]?.hooks?.[0]?.command
+    const managedEntry = getManagedTrustEntry(plan, managedCommand!)
+    const codexWrittenHash = 'sha256:codex-wsl-authoritative'
+    upsertHookTrustEntries(plan.tomlPath, [
+      { ...managedEntry, trustedHash: codexWrittenHash, enabled: true }
+    ])
+
+    expect((await _internals.installManagedHooksIntoWslRuntime(plan)).state).toBe('installed')
+
+    expect(readHookTrustEntries(plan.tomlPath).get(computeTrustKey(managedEntry))).toEqual({
+      enabled: true,
+      trustedHash: codexWrittenHash
+    })
+  })
+
   it.skipIf(process.platform === 'win32')(
     'drains stdin when the WSL runtime script is missing',
     async () => {
@@ -286,6 +310,33 @@ describe('Codex WSL runtime hook install', () => {
       expect(result.status).toBe(0)
     }
   )
+
+  it('recomputes WSL trust when the previously installed hook content changed', async () => {
+    vi.stubEnv('ORCA_DISABLE_CODEX_TRUST_RPC', '1')
+    const plan = createTestPlan()
+    writeFileSync(plan.configPath, '{"hooks":{}}\n', 'utf-8')
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    expect((await _internals.installManagedHooksIntoWslRuntime(plan)).state).toBe('installed')
+
+    const installed = JSON.parse(readFileSync(plan.configPath, 'utf-8')) as HooksConfig
+    const definition = installed.hooks.UserPromptSubmit[0]!
+    const managedHook = definition.hooks![0]!
+    managedHook.timeout = MANAGED_HOOK_TIMEOUT_SECONDS + 1
+    writeFileSync(plan.configPath, `${JSON.stringify(installed)}\n`, 'utf-8')
+    const staleEntry = getManagedTrustEntry(plan, managedHook.command!)
+    staleEntry.timeoutSec = managedHook.timeout
+    upsertHookTrustEntries(plan.tomlPath, [
+      { ...staleEntry, trustedHash: 'sha256:stale-hook-content', enabled: true }
+    ])
+
+    expect((await _internals.installManagedHooksIntoWslRuntime(plan)).state).toBe('installed')
+
+    const currentEntry = { ...staleEntry, timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS }
+    expect(readHookTrustEntries(plan.tomlPath).get(computeTrustKey(currentEntry))).toEqual({
+      enabled: true,
+      trustedHash: computeTrustedHash(currentEntry)
+    })
+  })
 
   it('sweeps all managed WSL trust for disable or confirmed absence', async () => {
     // Why: disable and confirmed absence intentionally pass []. Transient

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -24,6 +24,7 @@ import {
 import type { CodexHookTrustGrantRequest } from './codex-app-server-client'
 import { codexAppServerCapabilityCache } from './codex-app-server-capability-cache'
 import { _internals as trustGrantInternals } from './codex-hook-trust-grant'
+import { preserveCodexWrittenWslManagedHookTrust } from './wsl-managed-hook-trust'
 
 type HooksConfig = {
   hooks: Record<string, { hooks?: { command?: string; timeout?: number }[] }[]>
@@ -285,6 +286,20 @@ describe('Codex WSL runtime hook install', () => {
       enabled: true,
       trustedHash: codexWrittenHash
     })
+  })
+
+  it('does not carry Codex-written trust across managed WSL trust keys', () => {
+    const plan = createTestPlan()
+    writeFileSync(plan.tomlPath, '', 'utf-8')
+    const previous = getManagedTrustEntry(plan, expectedManagedCommand(plan.commandScriptPath))
+    const next = { ...previous, sourcePath: '/home/bob/.codex/hooks.json' }
+    upsertHookTrustEntries(plan.tomlPath, [
+      { ...previous, trustedHash: 'sha256:codex-wsl-authoritative', enabled: true }
+    ])
+
+    expect(preserveCodexWrittenWslManagedHookTrust(plan.tomlPath, [{ previous, next }])).toEqual([
+      next
+    ])
   })
 
   it.skipIf(process.platform === 'win32')(

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -81,6 +81,10 @@ import {
 } from './codex-managed-trust-reconciliation'
 import type { CodexTrustGrantLedgerHome } from './codex-trust-grant-ledger'
 import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-rebase'
+import {
+  preserveCodexWrittenWslManagedHookTrust,
+  type WslManagedHookTrustCandidate
+} from './wsl-managed-hook-trust'
 
 // Why: Pre/PostToolUse feed the live in-flight-tool readout; PermissionRequest exits with no decision so Codex still shows its approval UI while Orca flips the pane to waiting.
 const CODEX_EVENTS = [
@@ -876,23 +880,39 @@ function installManagedHooksIntoWslRuntime(
     }
   }
 
-  const trustEntries: CodexTrustEntry[] = []
+  const trustCandidates: WslManagedHookTrustCandidate[] = []
   for (const eventName of CODEX_EVENTS) {
     const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
     const cleaned = removeManagedCommands(current, isManagedCommand)
+    const managedHook = buildManagedCommandHook(command)
     const definition: HookDefinition = {
-      hooks: [buildManagedCommandHook(command)]
+      hooks: [managedHook]
     }
     nextHooks[eventName] = [definition, ...cleaned]
-    trustEntries.push({
+    const next: CodexTrustEntry = {
       sourcePath: plan.trustConfigPath,
       eventLabel: CODEX_EVENT_LABEL[eventName],
       groupIndex: 0,
       handlerIndex: 0,
       command,
       timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
-    })
+    }
+    const previousDefinition = current[0]
+    const previousHook = previousDefinition?.hooks?.[0]
+    const previous =
+      previousDefinition && previousHook
+        ? createCodexHookTrustEntry(
+            plan.trustConfigPath,
+            eventName,
+            0,
+            0,
+            previousDefinition,
+            previousHook
+          )
+        : null
+    trustCandidates.push({ next, previous })
   }
+  const trustEntries = trustCandidates.map((candidate) => candidate.next)
 
   config.hooks = nextHooks
   writeManagedScript(plan.scriptPath, getManagedScript('posix'))
@@ -920,9 +940,15 @@ function installManagedHooksIntoWslRuntime(
       telemetryLane: 'managed'
     })
     if (grant.lane === 'fallback') {
+      // Why: when RPC grant is unavailable, keep a Codex-written hash if the
+      // managed hook content is unchanged so reinstalls do not force re-approval.
+      const preservedTrustEntries = preserveCodexWrittenWslManagedHookTrust(
+        plan.tomlPath,
+        trustCandidates
+      )
       // Why: WSL runtime homes may carry user hook approvals we did not rebuild
       // here; only upsert Orca's entries instead of sweeping the whole source.
-      upsertHookTrustEntries(plan.tomlPath, trustEntries)
+      upsertHookTrustEntries(plan.tomlPath, preservedTrustEntries)
     }
   } catch (error) {
     return {

--- a/src/main/codex/wsl-managed-hook-trust.ts
+++ b/src/main/codex/wsl-managed-hook-trust.ts
@@ -13,7 +13,11 @@ export function preserveCodexWrittenWslManagedHookTrust(
 ): CodexTrustEntry[] {
   const existingTrust = readHookTrustEntries(tomlPath)
   return candidates.map(({ next, previous }) => {
-    if (!previous || getCodexHookTrustSignature(previous) !== getCodexHookTrustSignature(next)) {
+    if (
+      !previous ||
+      computeTrustKey(previous) !== computeTrustKey(next) ||
+      getCodexHookTrustSignature(previous) !== getCodexHookTrustSignature(next)
+    ) {
       return next
     }
     const state = existingTrust.get(computeTrustKey(previous))

--- a/src/main/codex/wsl-managed-hook-trust.ts
+++ b/src/main/codex/wsl-managed-hook-trust.ts
@@ -1,0 +1,31 @@
+import { computeTrustKey, readHookTrustEntries, type CodexTrustEntry } from './config-toml-trust'
+import { getCodexHookTrustSignature } from './codex-hook-identity'
+
+export type WslManagedHookTrustCandidate = {
+  next: CodexTrustEntry
+  previous: CodexTrustEntry | null
+}
+
+/** Keeps Codex-authored trust only while a managed WSL hook's content is unchanged. */
+export function preserveCodexWrittenWslManagedHookTrust(
+  tomlPath: string,
+  candidates: readonly WslManagedHookTrustCandidate[]
+): CodexTrustEntry[] {
+  const existingTrust = readHookTrustEntries(tomlPath)
+  return candidates.map(({ next, previous }) => {
+    if (!previous || getCodexHookTrustSignature(previous) !== getCodexHookTrustSignature(next)) {
+      return next
+    }
+    const state = existingTrust.get(computeTrustKey(previous))
+    if (!state?.trustedHash) {
+      return next
+    }
+    // Why: Codex is authoritative for its trust hash. Keep its approval only
+    // when the installed hook content and key are unchanged across reinstall.
+    return {
+      ...next,
+      trustedHash: state.trustedHash,
+      ...(state.enabled !== undefined ? { enabled: state.enabled } : {})
+    }
+  })
+}


### PR DESCRIPTION
Preserve Codex-written managed WSL hook hashes on repeated installs when the trust RPC falls back and both the existing hook key and content signature are unchanged. Read the hash and enabled state from the current TOML entry, including enabled:false. Changed keys/content and missing trust do not inherit prior approval. The successful RPC grant remains the final write and never receives the fallback upsert. Closes #8269.

Current main's stale-key cleanup, per-config mutation queue, canonical-path ledger reconciliation, and user-hook preservation remain intact. This change applies to the managed WSL fallback lane; native and SSH launch paths are unchanged.

Validation: Cursor supplied an explicit adversarial PASS tied to this exact SHA, covering key/content mismatch, missing trust, disabled entries and successful RPC ownership. Codex independently inspected those boundaries and ran 183 WSL-install/trust/grant tests across 10 files. Node and CLI non-composite typechecks and changed-file lint/format passed. No live Windows/WSL runtime was exercised.

Full repository suite/build and default composite typechecks were not run for this candidate. Known baseline TS2883 is not treated as passing; only the explicit non-composite checks above are claimed.

Cursor reviewed the final candidate; Codex independently reviewed the diff and raw checks. Reviewed commit: `5327acc701876345ca9d1e180b88bbcce7fb7ddd`; rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`.
