### PR TITLE
fix(workspaces): stop unchanged smart-sort refresh loops

### DIFF
--- a/src/main/ipc/worktrees-sort-order.test.ts
+++ b/src/main/ipc/worktrees-sort-order.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, removeHandlerMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock,
+    removeHandler: removeHandlerMock
+  }
+}))
+
+import { registerWorktreeHandlers } from './worktrees'
+
+type PersistSortOrderHandler = (event: unknown, args: { orderedIds: string[] }) => unknown
+
+function getPersistSortOrderHandler(): PersistSortOrderHandler {
+  const registration = handleMock.mock.calls.find(
+    ([channel]) => channel === 'worktrees:persistSortOrder'
+  )
+  expect(registration).toBeDefined()
+  return registration?.[1] as PersistSortOrderHandler
+}
+
+function registerWithMetadata(entries: readonly (readonly [string, number])[]) {
+  const metadata = new Map(entries.map(([id, sortOrder]) => [id, { sortOrder }]))
+  const store = {
+    getWorktreeMeta: vi.fn((worktreeId: string) => metadata.get(worktreeId)),
+    setWorktreeMeta: vi.fn()
+  }
+  registerWorktreeHandlers({} as never, store as never, {} as never)
+  return { handler: getPersistSortOrderHandler(), store }
+}
+
+describe('worktrees:persistSortOrder', () => {
+  beforeEach(() => {
+    handleMock.mockClear()
+    removeHandlerMock.mockClear()
+  })
+
+  it('keeps an unchanged finite descending order without metadata writes', () => {
+    const { handler, store } = registerWithMetadata([
+      ['first', 5000],
+      ['second', 4000]
+    ])
+
+    const result = handler(null, { orderedIds: ['first', 'second'] })
+
+    expect(result).toBeUndefined()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('keeps empty input as a void early return without metadata reads or writes', () => {
+    const { handler, store } = registerWithMetadata([])
+
+    const result = handler(null, { orderedIds: [] })
+
+    expect(result).toBeUndefined()
+    expect(store.getWorktreeMeta).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable max-lines */
 import { ipcMain, type BrowserWindow } from 'electron'
+import { persistWorktreeSortOrder } from '../worktree-sort-order-persistence'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
@@ -3069,19 +3070,10 @@ export function registerWorktreeHandlers(
     if (!Array.isArray(args?.orderedIds) || args.orderedIds.length === 0) {
       return
     }
-    const now = Date.now()
-    for (let i = 0; i < args.orderedIds.length; i++) {
-      // Why: a sidebar-order snapshot must only reorder worktrees that already
-      // exist — it must never create one. Without this guard a stale id the
-      // renderer still lists (e.g. a removed repo's `${repoId}::${path}`) gets a
-      // fresh worktreeMeta entry minted here, resurrecting an orphan/duplicate
-      // workspace on the next launch. setWorktreeMeta has no repo-existence check.
-      if (!store.getWorktreeMeta(args.orderedIds[i])) {
-        continue
-      }
-      // Descending timestamps: first item gets highest sortOrder so b - a sorts first-wins on cold start.
-      store.setWorktreeMeta(args.orderedIds[i], { sortOrder: now - i * 1000 })
-    }
+    // Why: Smart sort recomputes fresh arrays after metadata refreshes. Avoid
+    // turning an unchanged order into another persistence/refresh cycle. Also
+    // never mint worktreeMeta for unknown ids (#9342).
+    persistWorktreeSortOrder(store, args.orderedIds)
   })
 
   // Why: full failure output lives only in main memory (not worktree metadata), so the dialog pulls it on demand.

--- a/src/main/runtime/orca-runtime-sort-order.test.ts
+++ b/src/main/runtime/orca-runtime-sort-order.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeClientEvent } from '../../shared/runtime-client-events'
+import { OrcaRuntimeService } from './orca-runtime'
+
+function makeRuntime() {
+  const metadata = new Map<string, { sortOrder: number }>()
+  const setWorktreeMeta = vi.fn((worktreeId: string, meta: { sortOrder: number }) => {
+    metadata.set(worktreeId, meta)
+  })
+  const store = {
+    getWorktreeMeta: vi.fn((worktreeId: string) => metadata.get(worktreeId)),
+    setWorktreeMeta
+  }
+  const runtime = new OrcaRuntimeService(store as never)
+  const invalidateResolvedWorktreeCache = vi.spyOn(
+    runtime as unknown as { invalidateResolvedWorktreeCache: () => void },
+    'invalidateResolvedWorktreeCache'
+  )
+  const events: RuntimeClientEvent[] = []
+  runtime.onClientEvent((event) => events.push(event))
+
+  return { events, invalidateResolvedWorktreeCache, runtime, setWorktreeMeta }
+}
+
+describe('OrcaRuntimeService sort-order persistence', () => {
+  it('emits remote refreshes only when the requested order changes', () => {
+    const { events, invalidateResolvedWorktreeCache, runtime, setWorktreeMeta } = makeRuntime()
+
+    expect(runtime.persistManagedWorktreeSortOrder(['first', 'second'])).toEqual({ updated: 2 })
+    expect(setWorktreeMeta).toHaveBeenCalledTimes(2)
+    expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(1)
+    expect(events).toEqual([{ type: 'reposChanged' }])
+
+    expect(runtime.persistManagedWorktreeSortOrder(['first', 'second'])).toEqual({ updated: 0 })
+    expect(setWorktreeMeta).toHaveBeenCalledTimes(2)
+    expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(1)
+    expect(events).toEqual([{ type: 'reposChanged' }])
+
+    expect(runtime.persistManagedWorktreeSortOrder(['second', 'first'])).toEqual({ updated: 2 })
+    expect(setWorktreeMeta).toHaveBeenCalledTimes(4)
+    expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(2)
+    expect(events).toEqual([{ type: 'reposChanged' }, { type: 'reposChanged' }])
+  })
+
+  it('does not write, invalidate, or emit for empty input', () => {
+    const { events, invalidateResolvedWorktreeCache, runtime, setWorktreeMeta } = makeRuntime()
+
+    expect(runtime.persistManagedWorktreeSortOrder([])).toEqual({ updated: 0 })
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
+    expect(invalidateResolvedWorktreeCache).not.toHaveBeenCalled()
+    expect(events).toEqual([])
+  })
+})

--- a/src/main/runtime/orca-runtime-sort-order.test.ts
+++ b/src/main/runtime/orca-runtime-sort-order.test.ts
@@ -25,6 +25,11 @@ function makeRuntime() {
 describe('OrcaRuntimeService sort-order persistence', () => {
   it('emits remote refreshes only when the requested order changes', () => {
     const { events, invalidateResolvedWorktreeCache, runtime, setWorktreeMeta } = makeRuntime()
+    // Why: sort-order snapshots only rewrite existing meta (#9342); seed entries first.
+    // Seed inverted ranks so the first request actually needs a write.
+    setWorktreeMeta('first', { sortOrder: 0 })
+    setWorktreeMeta('second', { sortOrder: 1 })
+    setWorktreeMeta.mockClear()
 
     expect(runtime.persistManagedWorktreeSortOrder(['first', 'second'])).toEqual({ updated: 2 })
     expect(setWorktreeMeta).toHaveBeenCalledTimes(2)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -992,6 +992,7 @@ import {
 } from '../speech/speech-model-deletion'
 import type { CommitMessageAgentEnvironmentResolvers } from '../text-generation/commit-message-agent-environment'
 import { scanNestedRepos } from '../project-groups/nested-repo-discovery'
+import { persistWorktreeSortOrder } from '../worktree-sort-order-persistence'
 import {
   createNestedProjectGroupResolver,
   resolveNestedRepoSelection
@@ -23386,17 +23387,10 @@ export class OrcaRuntimeService {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
-    const now = Date.now()
-    let updated = 0
-    for (let i = 0; i < orderedIds.length; i++) {
-      // Why: a sort-order snapshot must only reorder existing worktrees, never
-      // mint new meta — a stale id would otherwise resurrect an orphan workspace
-      // (setWorktreeMeta has no repo-existence check).
-      if (!this.store.getWorktreeMeta(orderedIds[i])) {
-        continue
-      }
-      this.store.setWorktreeMeta(orderedIds[i], { sortOrder: now - i * 1000 })
-      updated++
+    // Why: skip no-op smart-sort rewrites (#8277) and never mint meta for unknown ids (#9342).
+    const updated = persistWorktreeSortOrder(this.store, orderedIds)
+    if (updated === 0) {
+      return { updated: 0 }
     }
     this.invalidateResolvedWorktreeCache()
     this.notifyReposChanged()

--- a/src/main/worktree-sort-order-persistence.test.ts
+++ b/src/main/worktree-sort-order-persistence.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { WorktreeMeta } from '../shared/types'
+import { persistWorktreeSortOrder } from './worktree-sort-order-persistence'
+
+function createReader(sortOrders: Record<string, number | undefined>) {
+  const writes: { worktreeId: string; sortOrder: number | undefined }[] = []
+  return {
+    writes,
+    getWorktreeMeta: (worktreeId: string) =>
+      sortOrders[worktreeId] === undefined
+        ? undefined
+        : ({ sortOrder: sortOrders[worktreeId] } as WorktreeMeta),
+    setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+      writes.push({ worktreeId, sortOrder: meta.sortOrder })
+      return { sortOrder: meta.sortOrder } as WorktreeMeta
+    }
+  }
+}
+
+describe('worktree sort order persistence', () => {
+  it('skips an order already represented by strictly descending persisted ranks', () => {
+    const store = createReader({ first: 3000, second: 2000, third: 1000 })
+
+    expect(persistWorktreeSortOrder(store, ['first', 'second', 'third'], 9000)).toBe(0)
+    expect(store.writes).toEqual([])
+  })
+
+  it.each([
+    ['changed order', { first: 3000, second: 1000, third: 2000 }, ['first', 'second', 'third']],
+    ['missing rank', { first: 3000, second: undefined }, ['first', 'second']],
+    ['tied ranks', { first: 3000, second: 3000 }, ['first', 'second']],
+    ['duplicate id', { first: 3000 }, ['first', 'first']]
+  ])('persists %s', (_label, sortOrders, orderedIds) => {
+    const store = createReader(sortOrders)
+
+    expect(persistWorktreeSortOrder(store, orderedIds, 9000)).toBe(orderedIds.length)
+    expect(store.writes.map(({ worktreeId }) => worktreeId)).toEqual(orderedIds)
+  })
+
+  it('writes changed ranks in strict descending order', () => {
+    const store = createReader({ first: 1000, second: 2000 })
+
+    expect(persistWorktreeSortOrder(store, ['first', 'second'], 9000)).toBe(2)
+    expect(store.writes).toEqual([
+      { worktreeId: 'first', sortOrder: 9000 },
+      { worktreeId: 'second', sortOrder: 8000 }
+    ])
+  })
+})

--- a/src/main/worktree-sort-order-persistence.test.ts
+++ b/src/main/worktree-sort-order-persistence.test.ts
@@ -2,14 +2,16 @@ import { describe, expect, it } from 'vitest'
 import type { WorktreeMeta } from '../shared/types'
 import { persistWorktreeSortOrder } from './worktree-sort-order-persistence'
 
-function createReader(sortOrders: Record<string, number | undefined>) {
+function createReader(sortOrders: Record<string, number | undefined | 'absent'>) {
   const writes: { worktreeId: string; sortOrder: number | undefined }[] = []
   return {
     writes,
-    getWorktreeMeta: (worktreeId: string) =>
-      sortOrders[worktreeId] === undefined
-        ? undefined
-        : ({ sortOrder: sortOrders[worktreeId] } as WorktreeMeta),
+    getWorktreeMeta: (worktreeId: string) => {
+      if (!(worktreeId in sortOrders) || sortOrders[worktreeId] === 'absent') {
+        return undefined
+      }
+      return { sortOrder: sortOrders[worktreeId] } as WorktreeMeta
+    },
     setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
       writes.push({ worktreeId, sortOrder: meta.sortOrder })
       return { sortOrder: meta.sortOrder } as WorktreeMeta
@@ -26,15 +28,23 @@ describe('worktree sort order persistence', () => {
   })
 
   it.each([
-    ['changed order', { first: 3000, second: 1000, third: 2000 }, ['first', 'second', 'third']],
-    ['missing rank', { first: 3000, second: undefined }, ['first', 'second']],
-    ['tied ranks', { first: 3000, second: 3000 }, ['first', 'second']],
-    ['duplicate id', { first: 3000 }, ['first', 'first']]
-  ])('persists %s', (_label, sortOrders, orderedIds) => {
-    const store = createReader(sortOrders)
+    ['changed order', { first: 3000, second: 1000, third: 2000 }, ['first', 'second', 'third'], 3],
+    ['missing rank on existing meta', { first: 3000, second: undefined }, ['first', 'second'], 2],
+    ['tied ranks', { first: 3000, second: 3000 }, ['first', 'second'], 2],
+    ['duplicate id', { first: 3000 }, ['first', 'first'], 2]
+  ] as const)('persists %s', (_label, sortOrders, orderedIds, expectedWrites) => {
+    const store = createReader(sortOrders as Record<string, number | undefined>)
 
-    expect(persistWorktreeSortOrder(store, orderedIds, 9000)).toBe(orderedIds.length)
-    expect(store.writes.map(({ worktreeId }) => worktreeId)).toEqual(orderedIds)
+    expect(persistWorktreeSortOrder(store, orderedIds, 9000)).toBe(expectedWrites)
+    expect(store.writes).toHaveLength(expectedWrites)
+  })
+
+  it('does not mint worktreeMeta for unknown ids (#9342)', () => {
+    // first/second inverted so a rewrite is required; ghost must still be skipped.
+    const store = createReader({ first: 1000, second: 2000, ghost: 'absent' })
+
+    expect(persistWorktreeSortOrder(store, ['first', 'ghost', 'second'], 9000)).toBe(2)
+    expect(store.writes.map(({ worktreeId }) => worktreeId)).toEqual(['first', 'second'])
   })
 
   it('writes changed ranks in strict descending order', () => {

--- a/src/main/worktree-sort-order-persistence.ts
+++ b/src/main/worktree-sort-order-persistence.ts
@@ -16,7 +16,7 @@ function worktreeSortOrderNeedsPersistence(
       return true
     }
     seen.add(worktreeId)
-    // Why: never mint meta for ids the store does not already know (#9342).
+    // Why: never mint meta for unknown ids (#9342); only evaluate existing entries.
     const meta = store.getWorktreeMeta(worktreeId)
     if (!meta) {
       continue
@@ -49,12 +49,10 @@ export function persistWorktreeSortOrder(
   for (let index = 0; index < orderedIds.length; index++) {
     const worktreeId = orderedIds[index]!
     // Why: a sort-order snapshot must only reorder existing worktrees, never
-    // mint new meta — a stale id would otherwise resurrect an orphan workspace
-    // (setWorktreeMeta has no repo-existence check) (#9342).
+    // mint new meta (#9342).
     if (!store.getWorktreeMeta(worktreeId)) {
       continue
     }
-    // Descending timestamps make the first requested item win on cold start.
     store.setWorktreeMeta(worktreeId, { sortOrder: now - index * 1000 })
     updated += 1
   }

--- a/src/main/worktree-sort-order-persistence.ts
+++ b/src/main/worktree-sort-order-persistence.ts
@@ -1,0 +1,62 @@
+import type { WorktreeMeta } from '../shared/types'
+
+type WorktreeSortOrderReader = {
+  getWorktreeMeta(worktreeId: string): WorktreeMeta | undefined
+  setWorktreeMeta(worktreeId: string, meta: Partial<WorktreeMeta>): WorktreeMeta
+}
+
+function worktreeSortOrderNeedsPersistence(
+  store: WorktreeSortOrderReader,
+  orderedIds: readonly string[]
+): boolean {
+  let previousSortOrder = Number.POSITIVE_INFINITY
+  const seen = new Set<string>()
+  for (const worktreeId of orderedIds) {
+    if (seen.has(worktreeId)) {
+      return true
+    }
+    seen.add(worktreeId)
+    // Why: never mint meta for ids the store does not already know (#9342).
+    const meta = store.getWorktreeMeta(worktreeId)
+    if (!meta) {
+      continue
+    }
+    const sortOrder = meta.sortOrder
+    // Why: persisted ranks are strictly descending. Missing, invalid, or tied
+    // ranks cannot reliably restore the renderer's requested relative order.
+    if (
+      typeof sortOrder !== 'number' ||
+      !Number.isFinite(sortOrder) ||
+      sortOrder >= previousSortOrder
+    ) {
+      return true
+    }
+    previousSortOrder = sortOrder
+  }
+  return false
+}
+
+/** Persists a changed worktree order and returns the number of updated entries. */
+export function persistWorktreeSortOrder(
+  store: WorktreeSortOrderReader,
+  orderedIds: readonly string[],
+  now = Date.now()
+): number {
+  if (!worktreeSortOrderNeedsPersistence(store, orderedIds)) {
+    return 0
+  }
+  let updated = 0
+  for (let index = 0; index < orderedIds.length; index++) {
+    const worktreeId = orderedIds[index]!
+    // Why: a sort-order snapshot must only reorder existing worktrees, never
+    // mint new meta — a stale id would otherwise resurrect an orphan workspace
+    // (setWorktreeMeta has no repo-existence check) (#9342).
+    if (!store.getWorktreeMeta(worktreeId)) {
+      continue
+    }
+    // Descending timestamps make the first requested item win on cold start.
+    store.setWorktreeMeta(worktreeId, { sortOrder: now - index * 1000 })
+    updated += 1
+  }
+  return updated
+}

--- a/src/renderer/src/store/slices/repos-cross-host-fetch-race.test.ts
+++ b/src/renderer/src/store/slices/repos-cross-host-fetch-race.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import { createCompatibleRuntimeStatusResponseIfNeeded } from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const localRepo: Repo = {
+  id: 'local-repo',
+  path: '/local',
+  displayName: 'Local',
+  badgeColor: '#000',
+  addedAt: 1
+}
+
+const remoteRepo: Repo = {
+  id: 'remote-repo',
+  path: '/remote',
+  displayName: 'Remote',
+  badgeColor: '#111',
+  addedAt: 2
+}
+
+let resolveLocalRepos: (repos: Repo[]) => void
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  const localRepos = new Promise<Repo[]>((resolve) => {
+    resolveLocalRepos = resolve
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: { list: () => localRepos },
+      projects: { list: async () => [], listHostSetups: async () => [] },
+      projectGroups: { list: async () => [] },
+      folderWorkspaces: { list: async () => [] },
+      runtimeEnvironments: {
+        call: async (request: { id: string; method: string }) => {
+          const compatibility = createCompatibleRuntimeStatusResponseIfNeeded(request)
+          if (compatibility) {
+            return compatibility
+          }
+          return {
+            id: request.id,
+            ok: true,
+            result: request.method === 'repo.list' ? { repos: [remoteRepo] } : {},
+            _meta: { runtimeId: 'runtime-remote' }
+          }
+        }
+      }
+    }
+  })
+})
+
+describe('repos slice cross-host fetch race', () => {
+  it('keeps a runtime catalog that resolves before an older local catalog', async () => {
+    const store = createTestStore()
+
+    const localLoad = store.getState().fetchRepos()
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+    expect(store.getState().repos).toEqual([{ ...remoteRepo, executionHostId: 'runtime:env-1' }])
+
+    resolveLocalRepos([localRepo])
+    await localLoad
+
+    expect(store.getState().repos).toEqual([
+      { ...remoteRepo, executionHostId: 'runtime:env-1' },
+      { ...localRepo, executionHostId: 'local' }
+    ])
+  })
+})


### PR DESCRIPTION
Closes #8272.

## Summary

- Make worktree sort-order persistence a no-op when existing per-host ranks already encode the requested order.
- Share the same persistence boundary between local IPC and remote runtimes; remote runtimes now skip cache invalidation and `reposChanged` broadcasts for unchanged orders.
- Add the missing deterministic regression where a runtime catalog resolves before an older local catalog and both hosts remain in renderer state.

Composition with #9342 (merged 2026-07-24): that fix added the same no-mint guard separately at each call site. Its guard and this PR's skip-unchanged short-circuit are complementary — one decides which ids may be written, the other whether any write is needed — and both now live in a single `persistWorktreeSortOrder` helper (`src/main/worktree-sort-order-persistence.ts`) called from `src/main/ipc/worktrees.ts` and `src/main/runtime/orca-runtime.ts`, instead of two overlapping call-site guards.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — not run in full; the five affected suites re-run post-rebase at 23439b88a: 286/286 passed.
- [ ] `pnpm build` — not run; no build-system or packaging behavior changed.
- [x] Added high-quality tests for the cross-host fetch race and unchanged/changed persistence boundaries.

Targeted command:

```text
pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktrees.test.ts src/renderer/src/store/slices/repos-all-hosts.test.ts src/renderer/src/store/slices/repos-cross-host-fetch-race.test.ts src/main/worktree-sort-order-persistence.test.ts src/main/runtime/rpc/methods/worktree.test.ts
```

## AI Review Report

Reviewed both loops described in #8272. Current `main` already merges fetched catalogs inside `set(state)`, so the stale local-vs-runtime overwrite is structurally fixed; the new race test locks that behavior. The remaining loop came from every Smart-order effect call replacing all ranks with fresh timestamps and the runtime broadcasting `reposChanged`, even when relative order was unchanged.

The persistence review checked first-time/missing ranks, changed order, tied or invalid ranks, duplicate IDs, single-host and split-host calls, local IPC, remote runtime notification behavior, and concurrent repeated calls. Only a complete strictly descending rank sequence is considered unchanged; ambiguous state is repaired rather than skipped.

Cross-platform behavior was checked explicitly. The helper is path- and platform-neutral, uses owner-host metadata only, and does not alter shortcuts, labels, filesystem paths, shells, SSH routing, or git-provider behavior. It applies equally to macOS/Linux local hosts and Windows/remote runtimes.

## Security Audit

The change reads existing worktree metadata and writes the same bounded `sortOrder` fields as before. It adds no command execution, IPC surface, authentication, secrets, filesystem access, or dependencies. Malformed duplicate IDs, missing metadata, non-finite ranks, and ties fail toward re-persistence rather than suppressing an update. No security follow-up is required.

## Notes

For a genuinely changed order, ranks are still rewritten and the remote runtime still invalidates its resolved cache and emits `reposChanged`. For an unchanged order, the runtime returns `{ updated: 0 }` without a broad refresh, breaking the `persist -> reposChanged -> refresh -> sortEpoch -> persist` cycle.

## ELI5

Smart-sort could keep rewriting worktree order and broadcasting changes even when the order had not really changed, causing refresh loops. Persistence is a no-op when ranks already match, including on remote runtimes, so the UI stops thrashing.
