### PR TITLE
fix: stop renderer heap leak from unhandled terminal teardown rejections (#8260)

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -1217,6 +1217,21 @@ describe('createFilePathLinkProvider range bounds', () => {
     )
   })
 
+  it('recovers with no links when a path-existence probe rejects (SSH teardown)', async () => {
+    // Regression: a rejected probe used to escape the void Promise.all as an
+    // unhandled rejection the crash-breadcrumb buffer retained, leaking heap (#8260).
+    const shellPathExists = vi.mocked(window.api.shell.pathExists)
+    shellPathExists.mockRejectedValueOnce(new Error('Remote connection dropped/reconnecting'))
+    const { provider } = createProviderSetup([makeBufferLine('CLAUDE.md')], new Map())
+
+    const links = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(links).toEqual([])
+    expect(shellPathExists).toHaveBeenCalled()
+  })
+
   it('shows switch and external-open hint for known worktree root hover', async () => {
     setPlatform('Macintosh')
     storeState.worktreesByRepo = {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -214,23 +214,31 @@ export function createFilePathLinkProvider(
             }
           )
         )
-      ).then((resolvedLinks) => {
-        const latestFingerprints = new Set(
-          buildCandidateLogicalLinesForBufferPosition(buffer, bufferLineNumber).map(
-            (logicalLine) => logicalLine.fingerprint
+      )
+        .then((resolvedLinks) => {
+          const latestFingerprints = new Set(
+            buildCandidateLogicalLinesForBufferPosition(buffer, bufferLineNumber).map(
+              (logicalLine) => logicalLine.fingerprint
+            )
           )
-        )
-        const providedLinks = resolvedLinks.filter(
-          (link): link is ProvidedFileLink => link !== null
-        )
-        const links = preferLongestNonOverlappingLinks(providedLinks)
-          .filter(({ logicalLine }) => latestFingerprints.has(logicalLine.fingerprint))
-          .map(({ link }) => link)
-        if (providedLinks.length > 0 && links.length === 0) {
-          return
-        }
-        callback(links.length > 0 ? links : undefined)
-      })
+          const providedLinks = resolvedLinks.filter(
+            (link): link is ProvidedFileLink => link !== null
+          )
+          const links = preferLongestNonOverlappingLinks(providedLinks)
+            .filter(({ logicalLine }) => latestFingerprints.has(logicalLine.fingerprint))
+            .map(({ link }) => link)
+          if (providedLinks.length > 0 && links.length === 0) {
+            return
+          }
+          callback(links.length > 0 ? links : undefined)
+        })
+        .catch(() => {
+          // Why: remote path-existence probes reject with "Remote connection
+          // dropped/reconnecting" during SSH teardown. Without a catch the
+          // rejected Promise.all is unhandled and the crash-breadcrumb buffer
+          // retains it, growing the renderer heap until it crashes (#8260).
+          callback(undefined)
+        })
     }
   }
 }

--- a/src/renderer/src/lib/crash-diagnostics.test.ts
+++ b/src/renderer/src/lib/crash-diagnostics.test.ts
@@ -116,6 +116,20 @@ describe('renderer crash diagnostics', () => {
     })
   })
 
+  it('suppresses benign ResizeObserver loop errors instead of recording them', () => {
+    diagnostics.installRendererCrashDiagnostics()
+    recordBreadcrumbMock.mockClear()
+
+    const preventDefault = vi.fn()
+    listeners.get('error')?.[0]?.({
+      message: 'ResizeObserver loop completed with undelivered notifications.',
+      preventDefault
+    })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(recordBreadcrumbMock).not.toHaveBeenCalled()
+  })
+
   it('disposes global listeners and the memory interval', () => {
     diagnostics.installRendererCrashDiagnostics()
 

--- a/src/renderer/src/lib/crash-diagnostics.ts
+++ b/src/renderer/src/lib/crash-diagnostics.ts
@@ -64,6 +64,13 @@ if (typeof import.meta !== 'undefined' && import.meta.hot) {
 }
 
 function recordRendererError(event: ErrorEvent): void {
+  // Why: "ResizeObserver loop completed" is a benign, self-resolving Chromium
+  // quirk. Recording it fills the breadcrumb buffer and inflates the error
+  // count without diagnostic value, contributing to renderer heap growth (#8260).
+  if (/ResizeObserver loop/i.test(event.message)) {
+    event.preventDefault()
+    return
+  }
   recordRendererCrashBreadcrumb(
     'renderer_error',
     compactBreadcrumbData({


### PR DESCRIPTION
## What this fixes

Two renderer paths let Promise rejections escape unhandled, where the crash-breadcrumb system retains them and grows the renderer heap until it white-screens (#8260):

1. **Terminal file-link probe (SSH):** `createFilePathLinkProvider` fired a `void Promise.all(...)` whose async mappers probe path existence over the runtime. On SSH teardown these reject with "Remote connection dropped/reconnecting" (the `fs:pathExists` flood in the reporter's trace). Added a `.catch` that resolves the link callback with no links so the rejection is handled.
2. **ResizeObserver noise:** "ResizeObserver loop completed" is a benign Chromium quirk. Suppress it in `crash-diagnostics` so it stops filling the breadcrumb buffer and inflating the renderer error count.

Both are covered by new regression tests.

## Scope note

This PR was reset from an earlier 122-commit revision that bundled a large terminal-teardown/retry-ownership refactor. That work turned out to be largely redundant with fixes that landed on `main` independently during the same window (session retirement #8628, pane self-heal #8630, recovery-behind-stuck-connect #8673), and much of the original #8260 fix had *also* already reached `main`:

- Windows `pty:kill` signal handling (`killPtyProcess` / `isPtyAlreadyGoneError`) — already on `main` (v1.4.135).
- The ResizeObserver **loop** itself is already broken at the source on `main` by the `arePaneTitleOverlayRectsEqual` bail-out (#2756), so the double-rAF was dropped as redundant.
- The renderer `pty.kill` `.catch` guards were dropped because the main-side kill handler now swallows those rejections itself.

So this PR carries only the two guards still genuinely missing upstream.

The prior 122-commit revision is preserved at `archive/pr-8279-review-session` for reference; the Windows node-pty pre-ready-shutdown patch and the SSH lease-generation fencing from it are the only pieces worth potentially extracting as separate, independently-reviewed PRs.

## Verification

- 85 renderer unit tests pass (`terminal-link-handlers`, `crash-diagnostics`), including the two new regression tests.
- `tsc` (web config) clean; oxlint/oxfmt clean.
- Note: the underlying symptom is a slow multi-hour heap leak that can't be observed live in a short session; verification here exercises the exact rejection/suppression mechanisms via unit tests rather than a live soak.

## Not claimed

This does not by itself close the broader #8260 white-screen / OOM / ResizeObserver investigation; it removes two confirmed unhandled-rejection leak sources. #8260 stays open.
