### PR TITLE
fix(agents): recover Codex startup draft delivery

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1958,7 +1958,7 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('1')
   })
 
-  it('uses shell-ready wrapper for Codex native prefill flags', () => {
+  it('uses shell-ready wrapper for Codex positional prompts when the plan opts in', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -1970,7 +1970,8 @@ describe('createPtySubprocess', () => {
         cols: 80,
         rows: 24,
         cwd: '/repo',
-        command: "codex --prefill 'linked issue context'",
+        command: "codex 'linked issue context'",
+        startupCommandDelivery: 'shell-ready',
         env: { SHELL: '/bin/zsh' }
       })
     } finally {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -11469,7 +11469,7 @@ describe('registerPtyHandlers', () => {
     }
   )
 
-  posixOnlyIt('waits for shell-ready when Codex uses the native prefill flag', async () => {
+  posixOnlyIt('waits for shell-ready when a Codex positional prompt opts in', async () => {
     vi.useFakeTimers()
     const mockProc = createMockProc()
     spawnMock.mockReturnValue(mockProc.proc)
@@ -11480,7 +11480,8 @@ describe('registerPtyHandlers', () => {
         cols: 80,
         rows: 24,
         cwd: '/tmp',
-        command: "codex --prefill 'linked issue context'"
+        command: "codex 'linked issue context'",
+        startupCommandDelivery: 'shell-ready'
       })
 
       const [, , options] = spawnMock.mock.calls[0]!
@@ -11491,7 +11492,7 @@ describe('registerPtyHandlers', () => {
       await Promise.resolve()
       vi.runAllTimers()
       await Promise.resolve()
-      expect(mockProc.proc.write).toHaveBeenCalledWith("codex --prefill 'linked issue context'\n")
+      expect(mockProc.proc.write).toHaveBeenCalledWith("codex 'linked issue context'\n")
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -39999,7 +39999,11 @@ describe('OrcaRuntimeService', () => {
     )
     expect(metaById[result.worktree.id]).toMatchObject({ createdWithAgent: 'codex' })
 
-    runtime.onPtyData('pty-startup-draft', '\x1b[?2004h›', Date.now())
+    runtime.onPtyData(
+      'pty-startup-draft',
+      '\x1b[?2004h\x1b[1m›\x1b[0m Ask Codex to do anything',
+      Date.now()
+    )
     await vi.waitFor(() => {
       expect(write).toHaveBeenCalledWith('pty-startup-draft', `\x1b[200~${draftUrl}\x1b[201~`)
     })
@@ -40603,7 +40607,11 @@ describe('OrcaRuntimeService', () => {
     )
     expect(metaById[result.worktree.id]).toMatchObject({ createdWithAgent: 'codex' })
 
-    runtime.onPtyData('pty-explicit-draft', '\x1b[?2004h›', Date.now())
+    runtime.onPtyData(
+      'pty-explicit-draft',
+      '\x1b[?2004h\x1b[1m›\x1b[0m Ask Codex to do anything',
+      Date.now()
+    )
     await vi.waitFor(() => {
       expect(write).toHaveBeenCalledWith('pty-explicit-draft', `\x1b[200~${draftUrl}\x1b[201~`)
     })

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -875,18 +875,19 @@ describe('PtyHandler', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
-    'emits shell-ready markers for renderer-delivered Codex native prefill commands',
+    'emits shell-ready markers for renderer-delivered Codex positional prompt commands',
     async () => {
       const oldShell = process.env.SHELL
       const oldHome = process.env.HOME
-      const homeDir = mkdtempSync(join(tmpdir(), 'relay-codex-prefill-spawn-'))
+      const homeDir = mkdtempSync(join(tmpdir(), 'relay-codex-prompt-spawn-'))
 
       process.env.SHELL = '/bin/bash'
       process.env.HOME = homeDir
       try {
         await dispatcher.callRequest('pty.spawn', {
           env: { HOME: homeDir },
-          command: "codex --prefill 'linked issue context'"
+          command: "codex 'linked issue context'",
+          startupCommandDelivery: 'shell-ready'
         })
       } finally {
         if (oldShell === undefined) {
@@ -960,10 +961,11 @@ describe('PtyHandler', () => {
         await dispatcher.callRequest('pty.spawn', {
           env: {
             HOME: homeDir,
-            [SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]: "codex --prefill 'linked issue context'"
+            [SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]: "codex 'linked issue context'"
           },
           command: 'bash -lc wait-for-setup-wrapper',
-          commandDelivery: 'provider'
+          commandDelivery: 'provider',
+          startupCommandDelivery: 'shell-ready'
         })
       } finally {
         if (oldShell === undefined) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6690,7 +6690,12 @@ describe('connectPanePty', () => {
       await flushAsyncTicks()
 
       expect(sendDraft).toHaveBeenCalledTimes(2)
-      expect(sendDraft).toHaveBeenLastCalledWith(expect.anything(), 'pty-codex', 'linked draft')
+      expect(sendDraft).toHaveBeenLastCalledWith(
+        expect.anything(),
+        'pty-codex',
+        'linked draft',
+        expect.any(Function)
+      )
       expect(
         beginCurrentDeliveryAttempt({
           worktreeId: 'wt-1',

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -123,7 +123,7 @@ async function renderHeadlessTerminalState(
   }
 }
 
-const toastInfo = vi.fn()
+const { toastInfo } = vi.hoisted(() => ({ toastInfo: vi.fn() }))
 const notifyCodexPaneBoundForStaleSweep = vi.fn()
 const LEAF_1 = '11111111-1111-4111-8111-111111111111' as const
 const LEAF_2 = '22222222-2222-4222-8222-222222222222' as const
@@ -6636,7 +6636,7 @@ describe('connectPanePty', () => {
     capturedDataCallback.current?.('\x1b[?2004hWaiting for setup to finish...')
     expect(transport.sendInputAccepted).not.toHaveBeenCalled()
 
-    capturedDataCallback.current?.('\x1b[?2004h\x1b[2K› ')
+    capturedDataCallback.current?.('\x1b[?2004h\x1b[2K› Ask Codex')
     await flushAsyncTicks()
 
     expect(transport.sendInputAccepted).toHaveBeenCalledTimes(1)
@@ -6645,7 +6645,6 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('releases startup draft delivery when disposed before deferred connect starts', async () => {
   it('retries the same startup draft after an explicit no-write result', async () => {
     const draftPaste = await import('@/lib/agent-draft-paste-content')
     const sendDraft = vi
@@ -6923,7 +6922,7 @@ describe('connectPanePty', () => {
     }
   })
 
-  it('does not consume startup draft delivery before deferred connect starts', async () => {
+  it('releases startup draft delivery when disposed before deferred connect starts', async () => {
     const { connectPanePty } = await import('./pty-connection')
     globalThis.requestAnimationFrame = vi.fn(() => 1)
     const transport = createMockTransport('pty-codex')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -27,6 +27,7 @@ import {
   beginAgentStartupDeliveryAttempt,
   resetAgentStartupDelayedDeliveryForTests
 } from '@/lib/agent-startup-delayed-delivery'
+import type { AgentDraftPasteContentOutcome } from '@/lib/agent-draft-paste-content'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 // Repro command:
@@ -232,7 +233,17 @@ type StoreState = {
   suppressedPtyExitIds: Record<string, true>
   agentLaunchConfigByPaneKey: Record<
     string,
-    { launchConfig: unknown; identity?: { agentType?: string } }
+    {
+      launchConfig: unknown
+      registeredAt?: number
+      identity?: {
+        agentType?: string
+        launchToken?: string
+        tabId?: string
+        leafId?: string
+        terminalHandle?: string
+      }
+    }
   >
   getAgentLaunchConfigForStatusEntry: ReturnType<typeof vi.fn>
   getAgentLaunchConfigForStatusMetadata: ReturnType<typeof vi.fn>
@@ -361,6 +372,37 @@ vi.mock('./terminal-webgl-atlas-recovery', () => ({
 function notifyStoreSubscribers(): void {
   for (const listener of storeSubscribers.slice()) {
     listener(mockStoreState)
+  }
+}
+
+function seedLaunchBoundStartupDraftState(
+  ptyId = 'pty-codex',
+  launchToken = 'launch-token-1'
+): void {
+  mockStoreState = {
+    ...mockStoreState,
+    tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+    repos: [{ id: 'repo1', connectionId: null }],
+    ptyIdsByTabId: { 'tab-1': [ptyId] },
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: { type: 'leaf', leafId: LEAF_1 },
+        activeLeafId: LEAF_1,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_1]: ptyId }
+      }
+    },
+    agentLaunchConfigByPaneKey: {
+      [makePaneKey('tab-1', LEAF_1)]: {
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: {
+          tabId: 'tab-1',
+          leafId: LEAF_1,
+          launchToken
+        }
+      }
+    }
   }
 }
 
@@ -6520,7 +6562,7 @@ describe('connectPanePty', () => {
       }
     ).mock.calls[0]?.[0]('USER_DRAFT')
     ;(mockStoreState.recordTerminalInput as ReturnType<typeof vi.fn>).mockClear()
-    capturedDataCallback.current?.('\x1b[?2004h\x1b[2K› ')
+    capturedDataCallback.current?.('\x1b[?2004h\x1b[2K\x1b[1m›\x1b[0m Ask Codex to do anything')
     await flushAsyncTicks()
 
     expect(transport.sendInputAccepted).toHaveBeenCalledWith(
@@ -6604,6 +6646,279 @@ describe('connectPanePty', () => {
   })
 
   it('releases startup draft delivery when disposed before deferred connect starts', async () => {
+  it('retries the same startup draft after an explicit no-write result', async () => {
+    const draftPaste = await import('@/lib/agent-draft-paste-content')
+    const sendDraft = vi
+      .spyOn(draftPaste, 'sendAgentDraftPasteContentWithOutcome')
+      .mockResolvedValueOnce('not-written')
+      .mockResolvedValueOnce('delivered')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const { beginAgentStartupDeliveryAttempt: beginCurrentDeliveryAttempt } =
+        await import('@/lib/agent-startup-delayed-delivery')
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      const transport = createMockTransport('pty-codex')
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-codex'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      seedLaunchBoundStartupDraftState()
+
+      connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        createDeps({
+          startup: {
+            command: 'codex',
+            launchAgent: 'codex',
+            launchConfig: { agentArgs: '', agentEnv: {} },
+            launchToken: 'launch-token-1',
+            draftPrompt: 'linked draft'
+          }
+        }) as never
+      )
+      await flushAsyncTicks()
+
+      capturedDataCallback.current?.('\x1b[?2004h› Ask Codex')
+      await flushAsyncTicks()
+      expect(sendDraft).toHaveBeenCalledTimes(2)
+
+      capturedDataCallback.current?.('composer redraw')
+      await flushAsyncTicks()
+
+      expect(sendDraft).toHaveBeenCalledTimes(2)
+      expect(sendDraft).toHaveBeenLastCalledWith(expect.anything(), 'pty-codex', 'linked draft')
+      expect(
+        beginCurrentDeliveryAttempt({
+          worktreeId: 'wt-1',
+          tabId: 'tab-1',
+          launchToken: 'launch-token-1'
+        })
+      ).toBe(false)
+    } finally {
+      sendDraft.mockRestore()
+    }
+  })
+
+  it.each(['delivery-uncertain', 'rejected promise'] as const)(
+    'does not retry a startup draft after %s',
+    async (failureMode) => {
+      const draftPaste = await import('@/lib/agent-draft-paste-content')
+      const sendDraft = vi.spyOn(draftPaste, 'sendAgentDraftPasteContentWithOutcome')
+      if (failureMode === 'rejected promise') {
+        sendDraft.mockRejectedValueOnce(new Error('runtime acknowledgement lost'))
+      } else {
+        sendDraft.mockResolvedValueOnce(failureMode)
+      }
+      try {
+        const { connectPanePty } = await import('./pty-connection')
+        const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+        const transport = createMockTransport('pty-codex')
+        transport.connect.mockImplementation(
+          async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+            capturedDataCallback.current = callbacks.onData ?? null
+            return 'pty-codex'
+          }
+        )
+        transportFactoryQueue.push(transport)
+        seedLaunchBoundStartupDraftState()
+
+        connectPanePty(
+          createPane(1) as never,
+          createManager(1) as never,
+          createDeps({
+            startup: {
+              command: 'codex',
+              launchAgent: 'codex',
+              launchConfig: { agentArgs: '', agentEnv: {} },
+              launchToken: 'launch-token-1',
+              draftPrompt: 'linked draft'
+            }
+          }) as never
+        )
+        await flushAsyncTicks()
+
+        capturedDataCallback.current?.('\x1b[?2004h› Ask Codex')
+        await flushAsyncTicks()
+        capturedDataCallback.current?.('composer redraw')
+        await flushAsyncTicks()
+
+        expect(sendDraft).toHaveBeenCalledTimes(1)
+      } finally {
+        sendDraft.mockRestore()
+      }
+    }
+  )
+
+  it.each(['delivered', 'not-written', 'delivery-uncertain', 'rejected promise'] as const)(
+    'keeps startup draft ownership across dispose and remount until an in-flight write settles with %s',
+    async (outcome) => {
+      vi.useFakeTimers()
+      globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+      let resolveFirstWrite!: (value: AgentDraftPasteContentOutcome) => void
+      let rejectFirstWrite!: (reason: unknown) => void
+      let firstWriteSettled = false
+      const firstWrite = new Promise<AgentDraftPasteContentOutcome>((resolve, reject) => {
+        resolveFirstWrite = resolve
+        rejectFirstWrite = reject
+      })
+      const settleFirstWrite = (): void => {
+        firstWriteSettled = true
+        if (outcome === 'rejected promise') {
+          rejectFirstWrite(new Error('late write rejection'))
+        } else {
+          resolveFirstWrite(outcome)
+        }
+      }
+      const draftPaste = await import('@/lib/agent-draft-paste-content')
+      const sendDraft = vi
+        .spyOn(draftPaste, 'sendAgentDraftPasteContentWithOutcome')
+        .mockImplementationOnce(() => firstWrite)
+        .mockResolvedValueOnce('delivered')
+      let remountedBinding: { dispose: () => void } | null = null
+      try {
+        const { connectPanePty } = await import('./pty-connection')
+        const { beginAgentStartupDeliveryAttempt: beginCurrentDeliveryAttempt } =
+          await import('@/lib/agent-startup-delayed-delivery')
+        const dataCallbacks: ((data: string) => void)[] = []
+        const createConnectedTransport = (): MockTransport => {
+          const transport = createMockTransport('pty-codex')
+          transport.connect.mockImplementation(
+            async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+              if (callbacks.onData) {
+                dataCallbacks.push(callbacks.onData)
+              }
+              return 'pty-codex'
+            }
+          )
+          return transport
+        }
+        const startup = {
+          command: 'codex',
+          launchAgent: 'codex' as const,
+          launchConfig: { agentArgs: '', agentEnv: {} },
+          launchToken: 'launch-token-1',
+          draftPrompt: 'linked draft'
+        }
+        seedLaunchBoundStartupDraftState()
+
+        transportFactoryQueue.push(createConnectedTransport())
+        const firstBinding = connectPanePty(
+          createPane(1) as never,
+          createManager(1) as never,
+          createDeps({ startup }) as never
+        )
+        await vi.advanceTimersByTimeAsync(20)
+        await flushAsyncTicks()
+        dataCallbacks[0]?.('\x1b[?2004h› Ask Codex')
+        await flushAsyncTicks()
+        expect(sendDraft).toHaveBeenCalledTimes(1)
+
+        firstBinding.dispose()
+        transportFactoryQueue.push(createConnectedTransport())
+        remountedBinding = connectPanePty(
+          createPane(1) as never,
+          createManager(1) as never,
+          createDeps({ startup }) as never
+        )
+        await vi.advanceTimersByTimeAsync(20)
+        await flushAsyncTicks()
+        dataCallbacks[1]?.('\x1b[?2004h› Ask Codex')
+        await flushAsyncTicks()
+
+        expect(sendDraft).toHaveBeenCalledTimes(1)
+        settleFirstWrite()
+        await flushAsyncTicks()
+        dataCallbacks[1]?.('composer redraw')
+        await flushAsyncTicks()
+
+        expect(sendDraft).toHaveBeenCalledTimes(outcome === 'not-written' ? 2 : 1)
+        expect(
+          beginCurrentDeliveryAttempt({
+            worktreeId: 'wt-1',
+            tabId: 'tab-1',
+            launchToken: 'launch-token-1'
+          })
+        ).toBe(false)
+      } finally {
+        if (!firstWriteSettled) {
+          resolveFirstWrite('delivered')
+        }
+        remountedBinding?.dispose()
+        await flushAsyncTicks()
+        vi.clearAllTimers()
+        sendDraft.mockRestore()
+      }
+    }
+  )
+
+  it('drops a failed startup draft retry after its tab is deleted', async () => {
+    const firstWrite = createDeferred<AgentDraftPasteContentOutcome>()
+    const draftPaste = await import('@/lib/agent-draft-paste-content')
+    const sendDraft = vi
+      .spyOn(draftPaste, 'sendAgentDraftPasteContentWithOutcome')
+      .mockImplementationOnce(() => firstWrite.promise)
+      .mockResolvedValueOnce('delivered')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      const transport = createMockTransport('pty-codex')
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-codex'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      seedLaunchBoundStartupDraftState()
+
+      connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        createDeps({
+          startup: {
+            command: 'codex',
+            launchAgent: 'codex',
+            launchConfig: { agentArgs: '', agentEnv: {} },
+            launchToken: 'launch-token-1',
+            draftPrompt: 'linked draft'
+          }
+        }) as never
+      )
+      await flushAsyncTicks()
+
+      capturedDataCallback.current?.('\x1b[?2004h› Ask Codex')
+      await flushAsyncTicks()
+      expect(sendDraft).toHaveBeenCalledTimes(1)
+
+      mockStoreState = {
+        ...mockStoreState,
+        tabsByWorktree: { 'wt-1': [] }
+      }
+      firstWrite.resolve('not-written')
+      await flushAsyncTicks()
+
+      mockStoreState = {
+        ...mockStoreState,
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] }
+      }
+      notifyStoreSubscribers()
+      capturedDataCallback.current?.('composer redraw')
+      await flushAsyncTicks()
+
+      expect(sendDraft).toHaveBeenCalledTimes(1)
+    } finally {
+      sendDraft.mockRestore()
+    }
+  })
+
+  it('does not consume startup draft delivery before deferred connect starts', async () => {
     const { connectPanePty } = await import('./pty-connection')
     globalThis.requestAnimationFrame = vi.fn(() => 1)
     const transport = createMockTransport('pty-codex')
@@ -6756,7 +7071,7 @@ describe('connectPanePty', () => {
     }
   })
 
-  it('waits for shell-ready for SSH Codex native prefill commands without an explicit hint', async () => {
+  it('waits for shell-ready for SSH Codex positional prompts when the plan opts in', async () => {
     const pendingTimeouts: (() => void)[] = []
     const originalSetTimeout = globalThis.setTimeout
     globalThis.setTimeout = vi.fn((fn: () => void) => {
@@ -6789,7 +7104,10 @@ describe('connectPanePty', () => {
       const pane = createPane(1)
       const manager = createManager(1)
       const deps = createDeps({
-        startup: { command: "codex --prefill 'linked issue context'" }
+        startup: {
+          command: "codex 'linked issue context'",
+          startupCommandDelivery: 'shell-ready'
+        }
       })
 
       connectPanePty(pane as never, manager as never, deps as never)
@@ -6804,7 +7122,7 @@ describe('connectPanePty', () => {
         fn()
       }
 
-      expect(transport.sendInput).toHaveBeenCalledWith("codex --prefill 'linked issue context'\r")
+      expect(transport.sendInput).toHaveBeenCalledWith("codex 'linked issue context'\r")
     } finally {
       globalThis.setTimeout = originalSetTimeout
     }
@@ -6846,8 +7164,9 @@ describe('connectPanePty', () => {
       const deps = createDeps({
         startup: {
           command: wrapperCommand,
+          startupCommandDelivery: 'shell-ready',
           env: {
-            [SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]: "codex --prefill 'linked issue context'"
+            [SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]: "codex 'linked issue context'"
           }
         }
       })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4739,7 +4739,6 @@ export function connectPanePty(
       : null
     let startupDraftReadinessArmed = false
     let startupDraftPasteSettled = !ownsStartupDraftPaste
-    let startupDraftPasteInFlight = false
     let startupDraftInputRecorded = false
     let startupDraftQuietTimer: ReturnType<typeof setTimeout> | null = null
     let startupDraftHardTimer: ReturnType<typeof setTimeout> | null = null

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -301,11 +301,14 @@ import type { SetupSplitDirection, TuiAgent } from '../../../../shared/types'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import { createDraftPasteReadyScanner } from '../../../../shared/draft-paste-ready-scanner'
-import { sendAgentDraftPasteContent } from '@/lib/agent-draft-paste-content'
+import { sendAgentDraftPasteContentWithOutcome } from '@/lib/agent-draft-paste-content'
 import { writeTerminalPastePtyInput } from './terminal-pty-paste-writer'
+import { pasteDraftToAgentPtyWhenReadyWithOutcome } from '@/lib/agent-paste-draft'
 import {
   beginAgentStartupDeliveryAttempt,
-  releaseAgentStartupDeliveryAttempt
+  queuePendingAgentStartupDelivery,
+  releaseAgentStartupDeliveryAttempt,
+  type AgentStartupDeliveryOutcome
 } from '@/lib/agent-startup-delayed-delivery'
 import {
   AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS,
@@ -1239,7 +1242,9 @@ export function connectPanePty(
     !startupDraftAgentConfig?.draftPromptFlag &&
     !startupDraftAgentConfig?.draftPromptEnvVar
   let startupDraftDeliveryClaimed = false
-  let startupDraftPasteAttempted = false
+  let startupDraftPasteDelivered = false
+  let startupDraftPasteDeliveryUncertain = false
+  let startupDraftPasteInFlight = false
   const claimStartupDraftPasteDelivery = (): boolean => {
     if (!startupDraftPromptNeedsPaste || launchToken === undefined) {
       return false
@@ -1257,8 +1262,14 @@ export function connectPanePty(
     })
     return startupDraftDeliveryClaimed
   }
-  const releaseUnattemptedStartupDraftPasteDelivery = (): void => {
-    if (!startupDraftDeliveryClaimed || startupDraftPasteAttempted || launchToken === undefined) {
+  const releaseUndeliveredStartupDraftPasteDelivery = (): void => {
+    if (
+      !startupDraftDeliveryClaimed ||
+      startupDraftPasteDelivered ||
+      startupDraftPasteDeliveryUncertain ||
+      startupDraftPasteInFlight ||
+      launchToken === undefined
+    ) {
       return
     }
     releaseAgentStartupDeliveryAttempt({
@@ -4743,6 +4754,16 @@ export function connectPanePty(
       }
     }
     cleanupStartupDraftPasteTimers = clearStartupDraftPasteTimers
+    const writeStartupDraftPtyInput = async (data: string): Promise<boolean> => {
+      const accepted = await writeTerminalPastePtyInput(transport, data)
+      if (accepted && !startupDraftInputRecorded) {
+        // Why: this transport write bypasses xterm's user-input signal; keep
+        // the composed draft from being discarded by later hibernation.
+        startupDraftInputRecorded = true
+        recordTerminalInputForHibernation()
+      }
+      return accepted
+    }
     const getStartupDraftPtyId = (): string | null => {
       const ptyId = transport.getPtyId()
       if (
@@ -4754,6 +4775,59 @@ export function connectPanePty(
         return null
       }
       return ptyId
+    }
+    const handOffFailedStartupDraftPaste = (failedPtyId: string): void => {
+      startupDraftPasteSettled = true
+      cleanupStartupDraftPasteTimers()
+      releaseUndeliveredStartupDraftPasteDelivery()
+      if (
+        !startupDraftPrompt ||
+        !startupDraftAgent ||
+        !startupDraftAgentConfig ||
+        !paneStartup?.launchConfig ||
+        launchToken === undefined
+      ) {
+        return
+      }
+      const retryStartup = {
+        agent: startupDraftAgent,
+        launchCommand: paneStartup.command,
+        expectedProcess: startupDraftAgentConfig.expectedProcess,
+        followupPrompt: null,
+        launchConfig: paneStartup.launchConfig,
+        launchToken,
+        draftPrompt: startupDraftPrompt
+      }
+      // Why: the composer was ready on the failed PTY, so retry it directly;
+      // a replacement PTY must pass the normal readiness gate first.
+      queuePendingAgentStartupDelivery({
+        worktreeId: deps.worktreeId,
+        tabId: deps.tabId,
+        launchToken,
+        startup: retryStartup,
+        deliver: async (retryTabId, retryPtyId): Promise<AgentStartupDeliveryOutcome> => {
+          const outcome =
+            retryPtyId === failedPtyId
+              ? await sendAgentDraftPasteContentWithOutcome(
+                  getSettingsForWorktreeRuntimeOwner(useAppStore.getState(), deps.worktreeId),
+                  retryPtyId,
+                  startupDraftPrompt,
+                  writeStartupDraftPtyInput
+                )
+              : await pasteDraftToAgentPtyWhenReadyWithOutcome({
+                  tabId: retryTabId,
+                  ptyId: retryPtyId,
+                  content: startupDraftPrompt,
+                  agent: startupDraftAgent,
+                  forcePaste: true
+                })
+          return outcome === 'delivered'
+            ? { kind: 'delivered' }
+            : outcome === 'not-written'
+              ? { kind: 'retryable', startup: retryStartup }
+              : { kind: 'delivery-uncertain' }
+        }
+      })
     }
     const sendStartupDraftPaste = (): void => {
       if (
@@ -4769,26 +4843,39 @@ export function connectPanePty(
         return
       }
       startupDraftPasteInFlight = true
-      startupDraftPasteSettled = true
-      startupDraftPasteAttempted = true
-      cleanupStartupDraftPasteTimers()
       const settings = getSettingsForWorktreeRuntimeOwner(useAppStore.getState(), deps.worktreeId)
       // Why: xterm focus reports share this transport queue. Bypassing it can
       // race CSI I against the draft on ConPTY and expose a literal `[I` prefix.
-      void sendAgentDraftPasteContent(settings, ptyId, startupDraftPrompt, async (data) => {
-        const accepted = await writeTerminalPastePtyInput(transport, data)
-        if (accepted && !startupDraftInputRecorded) {
-          // Why: this transport write bypasses xterm's user-input signal; keep
-          // the composed draft from being discarded by later hibernation.
-          startupDraftInputRecorded = true
-          recordTerminalInputForHibernation()
-        }
-        return accepted
-      })
-        .catch(() => false)
-        .finally(() => {
+      void sendAgentDraftPasteContentWithOutcome(
+        settings,
+        ptyId,
+        startupDraftPrompt,
+        writeStartupDraftPtyInput
+      ).then(
+        (outcome) => {
           startupDraftPasteInFlight = false
-        })
+          if (outcome === 'delivered') {
+            startupDraftPasteDelivered = true
+            startupDraftPasteSettled = true
+            cleanupStartupDraftPasteTimers()
+          } else if (outcome === 'not-written') {
+            handOffFailedStartupDraftPaste(ptyId)
+          } else {
+            // Why: an acknowledgement can be lost after bytes reached the PTY.
+            // Consume the launch instead of duplicating an ambiguous draft.
+            startupDraftPasteDeliveryUncertain = true
+            startupDraftPasteSettled = true
+            cleanupStartupDraftPasteTimers()
+          }
+        },
+        (error) => {
+          startupDraftPasteInFlight = false
+          startupDraftPasteDeliveryUncertain = true
+          startupDraftPasteSettled = true
+          cleanupStartupDraftPasteTimers()
+          console.warn('Startup draft paste delivery failed', error)
+        }
+      )
     }
     const deliverStartupDraftIfAgentOwnsPty = async (): Promise<void> => {
       if (!startupDraftAgentConfig || startupDraftPasteSettled) {
@@ -5062,7 +5149,7 @@ export function connectPanePty(
           if (submitted) {
             armStartupDraftReadinessObservation()
           } else {
-            releaseUnattemptedStartupDraftPasteDelivery()
+            releaseUndeliveredStartupDraftPasteDelivery()
           }
           pendingStartupCommand = null
         })()
@@ -9040,7 +9127,7 @@ export function connectPanePty(
         sshShellReadyFallbackTimer = null
       }
       cleanupStartupDraftPasteTimers()
-      releaseUnattemptedStartupDraftPasteDelivery()
+      releaseUndeliveredStartupDraftPasteDelivery()
       unregisterAgentHookTerminalLifecycle()
       clearSuppressedTitleSideEffects()
       clearPendingAgentTaskCompleteNotification()

--- a/src/renderer/src/lib/agent-draft-paste-content.ts
+++ b/src/renderer/src/lib/agent-draft-paste-content.ts
@@ -20,6 +20,7 @@ const AGENT_DRAFT_PASTE_INERT_ESCAPE_CODE_POINT = 0x241b
 const AGENT_DRAFT_PASTE_INERT_ESCAPE = '\u241b'
 
 export type AgentDraftPtyInputWriter = (data: string) => boolean | Promise<boolean>
+export type AgentDraftPasteContentOutcome = 'delivered' | 'not-written' | 'delivery-uncertain'
 
 export async function sendAgentDraftPasteContent(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
@@ -27,6 +28,18 @@ export async function sendAgentDraftPasteContent(
   content: string,
   writePty?: AgentDraftPtyInputWriter
 ): Promise<boolean> {
+  return (
+    (await sendAgentDraftPasteContentWithOutcome(settings, ptyId, content, writePty)) ===
+    'delivered'
+  )
+}
+
+export async function sendAgentDraftPasteContentWithOutcome(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  ptyId: string,
+  content: string,
+  writePty?: AgentDraftPtyInputWriter
+): Promise<AgentDraftPasteContentOutcome> {
   return await runTerminalPtyInputTransaction(ptyId, () =>
     sendAgentDraftPasteContentNow(settings, ptyId, content, writePty)
   )
@@ -39,9 +52,9 @@ export async function sendAgentDraftPasteContentNow(
   ptyId: string,
   content: string,
   writePty?: AgentDraftPtyInputWriter
-): Promise<boolean> {
+): Promise<AgentDraftPasteContentOutcome> {
   if (content.length > AGENT_DRAFT_PASTE_MAX_BYTES) {
-    return false
+    return 'not-written'
   }
 
   const terminalContent = normalizeTerminalPasteLineEndings(content)
@@ -49,21 +62,30 @@ export async function sendAgentDraftPasteContentNow(
     stopAfterBytes: AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES
   })
   if (!directMeasurement.exceededLimit) {
-    return await writeAgentDraftPtyInput(
-      settings,
-      ptyId,
-      wrapTerminalBracketedPasteText(terminalContent),
-      writePty
-    )
+    try {
+      return (await writeAgentDraftPtyInput(
+        settings,
+        ptyId,
+        wrapTerminalBracketedPasteText(terminalContent),
+        writePty
+      ))
+        ? 'delivered'
+        : 'not-written'
+    } catch {
+      // Why: a remote timeout can lose only the acknowledgement; replaying the
+      // same prompt could duplicate bytes that already reached the terminal.
+      return 'delivery-uncertain'
+    }
   }
 
   // Why: generated prompts can be paste-sized; yield during accepted-size
   // preflight before starting any PTY writes so the renderer is not pinned.
   if (await isSanitizedDraftPasteOverLimit(terminalContent, AGENT_DRAFT_PASTE_MAX_BYTES)) {
-    return false
+    return 'not-written'
   }
 
   let bracketedPasteOpen = false
+  let deliveryStarted = false
   for (const chunk of iterateAgentDraftPasteContentChunks(terminalContent)) {
     let accepted = false
     try {
@@ -72,21 +94,22 @@ export async function sendAgentDraftPasteContentNow(
       if (bracketedPasteOpen && chunk !== BRACKETED_PASTE_END) {
         await closeAgentDraftBracketedPaste(settings, ptyId, writePty)
       }
-      return false
+      return 'delivery-uncertain'
     }
     if (!accepted) {
       if (bracketedPasteOpen && chunk !== BRACKETED_PASTE_END) {
         await closeAgentDraftBracketedPaste(settings, ptyId, writePty)
       }
-      return false
+      return deliveryStarted ? 'delivery-uncertain' : 'not-written'
     }
+    deliveryStarted = true
     if (chunk === BRACKETED_PASTE_START) {
       bracketedPasteOpen = true
     } else if (chunk === BRACKETED_PASTE_END) {
       bracketedPasteOpen = false
     }
   }
-  return true
+  return 'delivered'
 }
 
 export function chunkAgentDraftPasteContent(

--- a/src/renderer/src/lib/agent-followup-delivery.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.ts
@@ -11,20 +11,34 @@ import type { GlobalSettings } from '../../../shared/types'
 
 type RuntimeOwnerSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
 
+export type AgentFollowupDeliveryOutcome = 'delivered' | 'not-written' | 'delivery-uncertain'
+
 export async function sendFollowupPromptWhenAgentReady(args: {
   ptyId: string
   expectedProcess: string
   prompt: string
   settings: RuntimeOwnerSettings
 }): Promise<boolean> {
+  return (await sendFollowupPromptWhenAgentReadyWithOutcome(args)) === 'delivered'
+}
+
+export async function sendFollowupPromptWhenAgentReadyWithOutcome(args: {
+  ptyId: string
+  expectedProcess: string
+  prompt: string
+  settings: RuntimeOwnerSettings
+}): Promise<AgentFollowupDeliveryOutcome> {
   const { ptyId, expectedProcess, prompt, settings } = args
   if (!(await waitForAgentForeground(ptyId, expectedProcess, settings))) {
-    return false
+    return 'not-written'
   }
   try {
-    return await sendRuntimePtyInputVerified(settings, ptyId, `${prompt}\r`)
+    return (await sendRuntimePtyInputVerified(settings, ptyId, `${prompt}\r`))
+      ? 'delivered'
+      : 'not-written'
   } catch {
-    return false
+    // A timed-out acknowledgement cannot prove that the PTY did not receive it.
+    return 'delivery-uncertain'
   }
 }
 

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -10,6 +10,7 @@ import {
   pasteDraftWhenAgentReady,
   POST_PASTE_SUBMIT_DELAY_MS,
   sendAgentDraftPasteContent,
+  sendAgentDraftPasteContentWithOutcome,
   sendBracketedPasteToRunningAgent,
   submitPromptToAgentPty
 } from './agent-paste-draft'
@@ -97,7 +98,7 @@ describe('pasteDraftWhenAgentReady', () => {
     vi.useRealTimers()
   })
 
-  it('pastes into Codex as soon as its composer prompt renders after bracketed paste is enabled', async () => {
+  it('pastes into Codex only after its glyph and idle placeholder render after bracketed paste', async () => {
     const promise = pasteDraftWhenAgentReady({
       tabId: 'tab-1',
       content: ISSUE_URL,
@@ -110,6 +111,10 @@ describe('pasteDraftWhenAgentReady', () => {
     expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
 
     testState.ptyObserver?.(DECSET_BRACKETED_PASTE)
+    await flushMicrotasks()
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    testState.ptyObserver?.('›')
     await flushMicrotasks()
     expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
 
@@ -352,7 +357,7 @@ describe('pasteDraftWhenAgentReady', () => {
       'pty-1',
       PASTED_ISSUE_URL
     )
-    await vi.advanceTimersByTimeAsync(49)
+    await vi.advanceTimersByTimeAsync(499)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledTimes(1)
     await vi.advanceTimersByTimeAsync(1)
     await expect(promise).resolves.toBe(true)
@@ -533,7 +538,7 @@ describe('pasteDraftWhenAgentReady', () => {
     )
 
     await flushMicrotasks()
-    await vi.advanceTimersByTimeAsync(49)
+    await vi.advanceTimersByTimeAsync(499)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledTimes(1)
     await vi.advanceTimersByTimeAsync(1)
 
@@ -588,7 +593,7 @@ describe('pasteDraftWhenAgentReady', () => {
     })
 
     await flushMicrotasks()
-    await vi.advanceTimersByTimeAsync(50)
+    await vi.advanceTimersByTimeAsync(500)
 
     await expect(promise).resolves.toBe(true)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
@@ -629,7 +634,7 @@ describe('pasteDraftWhenAgentReady', () => {
       expect((call[2] as string).length).toBeLessThanOrEqual(AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES)
     }
 
-    await vi.advanceTimersByTimeAsync(50)
+    await vi.advanceTimersByTimeAsync(500)
 
     await expect(promise).resolves.toBe(true)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenLastCalledWith({}, 'pty-1', '\r')
@@ -646,7 +651,7 @@ describe('pasteDraftWhenAgentReady', () => {
       'pty-1',
       '\x1b[200~line one\rline two\rline three\x1b[201~'
     )
-    await vi.advanceTimersByTimeAsync(50)
+    await vi.advanceTimersByTimeAsync(500)
     await expect(promise).resolves.toBe(true)
   })
 
@@ -671,6 +676,30 @@ describe('pasteDraftWhenAgentReady', () => {
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(3, {}, 'pty-1', '[201~')
     expect(testState.sendRuntimePtyInputVerified.mock.calls.some((call) => call[2] === '\r')).toBe(
       false
+    )
+  })
+
+  it('marks a rejected chunk after the opener as delivery-uncertain', async () => {
+    testState.sendRuntimePtyInputVerified
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+    const content = 'x'.repeat(
+      AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES + 7
+    )
+
+    await expect(sendAgentDraftPasteContentWithOutcome({}, 'pty-1', content)).resolves.toBe(
+      'delivery-uncertain'
+    )
+  })
+
+  it('marks a lost direct-write acknowledgement as delivery-uncertain', async () => {
+    testState.sendRuntimePtyInputVerified.mockRejectedValueOnce(
+      new Error('runtime acknowledgement lost')
+    )
+
+    await expect(sendAgentDraftPasteContentWithOutcome({}, 'pty-1', 'linked draft')).resolves.toBe(
+      'delivery-uncertain'
     )
   })
 

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -13,17 +13,22 @@ import {
 import { runTerminalPtyInputTransaction } from '@/components/terminal-pane/terminal-pty-input-transaction'
 import { waitForAgentReady } from './agent-ready-wait'
 import { getSettingsForWorktreeRuntimeOwner } from './worktree-runtime-owner'
-import { sendAgentDraftPasteContentNow } from './agent-draft-paste-content'
+import {
+  sendAgentDraftPasteContentNow,
+  type AgentDraftPasteContentOutcome
+} from './agent-draft-paste-content'
 import { agentDeliversDraftViaNativePrefill } from './agent-native-draft-prefill'
 import { waitForAgentDraftInputReady } from './agent-draft-readiness'
 import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
+import { AGENT_PROMPT_SUBMIT_DELAY_MS } from '../../../shared/agent-prompt-injection'
 export {
   AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES,
   AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES,
   AGENT_DRAFT_PASTE_MAX_BYTES,
   chunkAgentDraftPasteContent,
   iterateAgentDraftPasteContentChunks,
-  sendAgentDraftPasteContent
+  sendAgentDraftPasteContent,
+  sendAgentDraftPasteContentWithOutcome
 } from './agent-draft-paste-content'
 
 // Why: bracketed paste markers let modern TUIs (Claude Code / Codex / Pi /
@@ -32,7 +37,8 @@ export {
 // line-edit shortcuts. Callers choose whether to append Enter after the paste.
 export const BRACKETED_PASTE_BEGIN = BRACKETED_PASTE_START
 export { BRACKETED_PASTE_END }
-export const POST_PASTE_SUBMIT_DELAY_MS = 50
+// Why: let the TUI leave bracketed-paste mode before Enter is interpreted.
+export const POST_PASTE_SUBMIT_DELAY_MS = AGENT_PROMPT_SUBMIT_DELAY_MS
 
 export function sanitizeBracketedPasteContent(content: string): string {
   return sanitizeTerminalPasteText(content)
@@ -138,11 +144,24 @@ export async function pasteDraftToAgentPtyWhenReady(args: {
   timeoutMs?: number
   onTimeout?: () => void
 }): Promise<boolean> {
+  return (await pasteDraftToAgentPtyWhenReadyWithOutcome(args)) === 'delivered'
+}
+
+export async function pasteDraftToAgentPtyWhenReadyWithOutcome(args: {
+  tabId: string
+  ptyId: string
+  content: string
+  agent?: TuiAgent
+  submit?: boolean
+  forcePaste?: boolean
+  timeoutMs?: number
+  onTimeout?: () => void
+}): Promise<AgentDraftPasteContentOutcome> {
   const { tabId, ptyId, content, agent, submit, forcePaste, timeoutMs, onTimeout } = args
   const agentConfig = agent ? TUI_AGENT_CONFIG[agent] : null
 
   if (agentDeliversDraftViaNativePrefill(agent, forcePaste)) {
-    return false
+    return 'not-written'
   }
 
   const budget = timeoutMs ?? READINESS_TIMEOUT_MS
@@ -155,11 +174,11 @@ export async function pasteDraftToAgentPtyWhenReady(args: {
       : false
     if (!fallbackReady) {
       onTimeout?.()
-      return false
+      return 'not-written'
     }
   }
 
-  return await sendBracketedPasteToAgent({
+  return await sendBracketedPasteToAgentWithOutcome({
     settings,
     ptyId,
     content,
@@ -193,13 +212,22 @@ async function sendBracketedPasteToAgent(args: {
   content: string
   submit: boolean
 }): Promise<boolean> {
+  return (await sendBracketedPasteToAgentWithOutcome(args)) === 'delivered'
+}
+
+async function sendBracketedPasteToAgentWithOutcome(args: {
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  ptyId: string
+  content: string
+  submit: boolean
+}): Promise<AgentDraftPasteContentOutcome> {
   const { settings = useAppStore.getState().settings, ptyId, content, submit } = args
   try {
     // Why: paste + Enter must be one transaction, or a concurrent paste on this PTY
     // can slip between them and submit a half-written prompt.
     return await runTerminalPtyInputTransaction(ptyId, async () => {
       const pasted = await sendAgentDraftPasteContentNow(settings, ptyId, content)
-      if (!pasted || !submit) {
+      if (pasted !== 'delivered' || !submit) {
         return pasted
       }
 
@@ -207,10 +235,12 @@ async function sendBracketedPasteToAgent(args: {
       // Enter arrive in the same PTY write. Split the submit into the next turn so
       // the TUI processes bracketed-paste termination before handling Enter.
       await new Promise<void>((resolve) => window.setTimeout(resolve, POST_PASTE_SUBMIT_DELAY_MS))
-      return await sendRuntimePtyInputVerified(settings, ptyId, '\r')
+      return (await sendRuntimePtyInputVerified(settings, ptyId, '\r'))
+        ? 'delivered'
+        : 'delivery-uncertain'
     })
   } catch {
-    return false
+    return 'delivery-uncertain'
   }
 }
 

--- a/src/renderer/src/lib/agent-startup-delayed-delivery-perf.test.ts
+++ b/src/renderer/src/lib/agent-startup-delayed-delivery-perf.test.ts
@@ -1,4 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { mockShowAutomationPromptNotSentToast } = vi.hoisted(() => ({
+  mockShowAutomationPromptNotSentToast: vi.fn()
+}))
+
+vi.mock('@/lib/agent-background-session-timeout-toast', () => ({
+  showAutomationPromptNotSentToast: mockShowAutomationPromptNotSentToast
+}))
+
 import { useAppStore } from '@/store'
 import {
   queuePendingAgentStartupDelivery,
@@ -82,6 +91,7 @@ function countedLaunchConfigs(count: number): {
 afterEach(() => {
   resetAgentStartupDelayedDeliveryForTests()
   useAppStore.setState(originalState, true)
+  vi.clearAllMocks()
 })
 
 describe('delayed agent startup subscription', () => {
@@ -152,7 +162,7 @@ describe('delayed agent startup subscription', () => {
   it('does not requeue a failed delivery after its startup tab is removed', async () => {
     seedPendingState()
     let resolveDelivery!: (outcome: { kind: 'retryable'; startup: never }) => void
-    const startup = {} as never
+    const startup = { agent: 'codex' } as never
     const deliver = vi.fn(
       () =>
         new Promise<{ kind: 'retryable'; startup: never }>((resolve) => {
@@ -177,6 +187,7 @@ describe('delayed agent startup subscription', () => {
     seedPendingState()
     bindPendingPty()
     expect(deliver).toHaveBeenCalledTimes(1)
+    expect(mockShowAutomationPromptNotSentToast).toHaveBeenCalledExactlyOnceWith('codex')
   })
 
   it('drops a delivery when its tab is removed before PTY binding', () => {

--- a/src/renderer/src/lib/agent-startup-delayed-delivery-perf.test.ts
+++ b/src/renderer/src/lib/agent-startup-delayed-delivery-perf.test.ts
@@ -108,7 +108,7 @@ describe('delayed agent startup subscription', () => {
 
   it('delivers when launch registration, PTY ownership, and layout binding arrive', () => {
     seedPendingState()
-    const deliver = vi.fn().mockResolvedValue(undefined)
+    const deliver = vi.fn().mockResolvedValue({ kind: 'delivered' })
     const startup = {} as never
     queuePendingAgentStartupDelivery({
       worktreeId: 'wt-background',
@@ -123,9 +123,65 @@ describe('delayed agent startup subscription', () => {
     expect(deliver).toHaveBeenCalledWith('tab-background', 'pty-background', startup)
   })
 
+  it('requeues a failed delivery for the next relevant startup-state change', async () => {
+    seedPendingState()
+    const startup = {} as never
+    const deliver = vi
+      .fn()
+      .mockResolvedValueOnce({ kind: 'retryable', startup })
+      .mockResolvedValueOnce({ kind: 'delivered' })
+    queuePendingAgentStartupDelivery({
+      worktreeId: 'wt-background',
+      tabId: 'tab-background',
+      launchToken: 'target-launch',
+      startup,
+      deliver
+    })
+
+    bindPendingPty()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(deliver).toHaveBeenCalledTimes(1)
+
+    useAppStore.setState({ ptyIdsByTabId: { 'tab-background': ['pty-background'] } } as never)
+    await Promise.resolve()
+
+    expect(deliver).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not requeue a failed delivery after its startup tab is removed', async () => {
+    seedPendingState()
+    let resolveDelivery!: (outcome: { kind: 'retryable'; startup: never }) => void
+    const startup = {} as never
+    const deliver = vi.fn(
+      () =>
+        new Promise<{ kind: 'retryable'; startup: never }>((resolve) => {
+          resolveDelivery = resolve
+        })
+    )
+    queuePendingAgentStartupDelivery({
+      worktreeId: 'wt-background',
+      tabId: 'tab-background',
+      launchToken: 'target-launch',
+      startup,
+      deliver
+    })
+
+    bindPendingPty()
+    expect(deliver).toHaveBeenCalledTimes(1)
+    useAppStore.setState({ tabsByWorktree: {} })
+    resolveDelivery({ kind: 'retryable', startup })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    seedPendingState()
+    bindPendingPty()
+    expect(deliver).toHaveBeenCalledTimes(1)
+  })
+
   it('drops a delivery when its tab is removed before PTY binding', () => {
     seedPendingState()
-    const deliver = vi.fn().mockResolvedValue(undefined)
+    const deliver = vi.fn().mockResolvedValue({ kind: 'delivered' })
     queuePendingAgentStartupDelivery({
       worktreeId: 'wt-background',
       tabId: 'tab-background',
@@ -143,7 +199,7 @@ describe('delayed agent startup subscription', () => {
 
   it('drops a delivery when a newer pending launch token replaces it', () => {
     seedPendingState()
-    const deliver = vi.fn().mockResolvedValue(undefined)
+    const deliver = vi.fn().mockResolvedValue({ kind: 'delivered' })
     queuePendingAgentStartupDelivery({
       worktreeId: 'wt-background',
       tabId: 'tab-background',

--- a/src/renderer/src/lib/agent-startup-delayed-delivery.ts
+++ b/src/renderer/src/lib/agent-startup-delayed-delivery.ts
@@ -11,12 +11,21 @@ import {
 
 type AppStoreSnapshot = ReturnType<typeof useAppStore.getState>
 
+export type AgentStartupDeliveryOutcome =
+  | { kind: 'delivered' }
+  | { kind: 'retryable'; startup: AgentStartupPlan }
+  | { kind: 'delivery-uncertain' }
+
 type PendingAgentStartupDelivery = {
   worktreeId: string
   tabId: string
   launchToken: string
   startup: AgentStartupPlan
-  deliver: (tabId: string, ptyId: string, startup: AgentStartupPlan) => Promise<void>
+  deliver: (
+    tabId: string,
+    ptyId: string,
+    startup: AgentStartupPlan
+  ) => Promise<AgentStartupDeliveryOutcome>
 }
 
 const pendingAgentStartupDeliveries = new Map<string, PendingAgentStartupDelivery>()
@@ -173,6 +182,28 @@ export function releaseAgentStartupDeliveryAttempt(args: {
   releaseAgentStartupDeliveryConsumed(deliveryKey(args))
 }
 
+function requeueFailedAgentStartupDelivery(
+  key: string,
+  delivery: PendingAgentStartupDelivery,
+  retryStartup: AgentStartupPlan
+): void {
+  releaseAgentStartupDeliveryAttempt(delivery)
+  const retryDelivery = { ...delivery, startup: retryStartup }
+  const state = useAppStore.getState()
+  const queuedLaunchToken = getPendingStartupLaunchToken(state, delivery.tabId)
+  const launchRegistered = hasRegisteredStartupLaunch(state, delivery.tabId, delivery.launchToken)
+  // Why: the attempt removed this entry; keep it pending so a later
+  // launch/PTY state change can retry instead of silently losing the draft.
+  if (
+    worktreeStillOwnsStartupTab(state, delivery.worktreeId, delivery.tabId) &&
+    (queuedLaunchToken === delivery.launchToken || launchRegistered) &&
+    !isAgentStartupDeliveryConsumed(key)
+  ) {
+    pendingAgentStartupDeliveries.set(key, retryDelivery)
+    ensurePendingAgentStartupSubscription()
+  }
+}
+
 function flushPendingAgentStartupDeliveries(): void {
   const state = useAppStore.getState()
   for (const [key, delivery] of pendingAgentStartupDeliveries) {
@@ -198,11 +229,21 @@ function flushPendingAgentStartupDeliveries(): void {
     }
     // Why: once the launch-bound PTY exists, the bounded readiness/paste path
     // owns success or failure. Consume before awaiting so store churn cannot
-    // duplicate a linked-work-item draft.
+    // duplicate a linked-work-item draft. Only an explicit no-write outcome
+    // can requeue; a rejected or partial write has ambiguous delivery.
     if (beginAgentStartupDeliveryAttempt(delivery)) {
-      void delivery.deliver(tabId, ptyId, delivery.startup).catch((error) => {
-        console.warn('Queued agent startup delivery failed', error)
-      })
+      void delivery
+        .deliver(tabId, ptyId, delivery.startup)
+        .then((outcome) => {
+          if (outcome.kind === 'retryable') {
+            requeueFailedAgentStartupDelivery(key, delivery, outcome.startup)
+          }
+        })
+        .catch((error) => {
+          // Why: rejection cannot prove whether a remote write took effect.
+          // Keep the launch consumed instead of replaying user/task text.
+          console.warn('Queued agent startup delivery failed', error)
+        })
     }
   }
   stopPendingAgentStartupSubscriptionIfIdle()

--- a/src/renderer/src/lib/agent-startup-delayed-delivery.ts
+++ b/src/renderer/src/lib/agent-startup-delayed-delivery.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from '@/store'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+import { showAutomationPromptNotSentToast } from '@/lib/agent-background-session-timeout-toast'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import {
   agentStartupDeliveryKey as deliveryKey,
@@ -201,7 +202,9 @@ function requeueFailedAgentStartupDelivery(
   ) {
     pendingAgentStartupDeliveries.set(key, retryDelivery)
     ensurePendingAgentStartupSubscription()
+    return
   }
+  showAutomationPromptNotSentToast(retryStartup.agent)
 }
 
 function flushPendingAgentStartupDeliveries(): void {

--- a/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
@@ -269,12 +269,12 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
     }
   })
 
-  it('waits for shell-ready for SSH background Codex native prefill commands without a hint', async () => {
+  it('keeps empty Codex override launches on the fast SSH path', async () => {
     vi.useFakeTimers()
     try {
       state.repos = [{ id: 'repo-1', connectionId: 'ssh-1', path: '/repo' }]
       state.settings = {
-        agentCmdOverrides: { codex: "codex --prefill 'draft from override'" },
+        agentCmdOverrides: { codex: 'codex --model gpt-5' },
         activeRuntimeEnvironmentId: null,
         terminalMainSideEffectAuthority: undefined
       }
@@ -288,22 +288,17 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
 
       expect(mockSpawn.mock.calls[0]?.[0]).toEqual(
         expect.objectContaining({
-          command:
-            "codex --prefill 'draft from override' '--dangerously-bypass-approvals-and-sandbox'"
+          command: "codex --model gpt-5 '--dangerously-bypass-approvals-and-sandbox'"
         })
       )
       expect(mockSpawn.mock.calls[0]?.[0]).not.toHaveProperty('startupCommandDelivery')
       const dataSidecar = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
       dataSidecar('user@remote repo % ')
       vi.advanceTimersByTime(50)
-      expect(mockWrite).not.toHaveBeenCalled()
-
-      dataSidecar('\x1b]777;orca-shell-ready\x07user@remote repo % ')
-      vi.advanceTimersByTime(50)
 
       expect(mockWrite).toHaveBeenCalledWith(
         'pty-1',
-        "codex --prefill 'draft from override' '--dangerously-bypass-approvals-and-sandbox'\r"
+        "codex --model gpt-5 '--dangerously-bypass-approvals-and-sandbox'\r"
       )
     } finally {
       vi.useRealTimers()

--- a/src/renderer/src/lib/new-workspace.test.ts
+++ b/src/renderer/src/lib/new-workspace.test.ts
@@ -314,7 +314,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
   })
 
-  it('surfaces the not-sent toast when a follow-up prompt is dropped', async () => {
+  it('does not toast while a dropped follow-up prompt remains retryable', async () => {
     // Foreground never becomes a recognized agent and there is no live child,
     // so the readiness wait times out and the prompt is not delivered.
     mockInspectRuntimeTerminalProcess.mockResolvedValue({
@@ -334,7 +334,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
     })
 
     expect(mockSendRuntimePtyInputVerified).not.toHaveBeenCalled()
-    expect(mockShowAutomationPromptNotSentToast).toHaveBeenCalledWith('aider')
+    expect(mockShowAutomationPromptNotSentToast).not.toHaveBeenCalled()
   })
 
   it('does not toast when a follow-up prompt is delivered', async () => {
@@ -350,27 +350,6 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
     })
 
     expect(mockShowAutomationPromptNotSentToast).not.toHaveBeenCalled()
-  })
-
-  it('passes an onTimeout that surfaces the not-sent toast to the draft paste path', async () => {
-    await ensureAgentStartupInTerminal({
-      worktreeId: 'wt-1',
-      startup: {
-        agent: 'claude',
-        launchCommand: 'claude',
-        expectedProcess: 'claude',
-        followupPrompt: null,
-        launchConfig: { agentArgs: '', agentEnv: {} },
-        draftPrompt: 'review this before sending'
-      }
-    })
-
-    const call = mockPasteDraftToAgentPtyWhenReadyWithOutcome.mock.calls.at(-1)?.[0] as
-      | { onTimeout?: () => void }
-      | undefined
-    expect(call?.onTimeout).toBeTypeOf('function')
-    call?.onTimeout?.()
-    expect(mockShowAutomationPromptNotSentToast).toHaveBeenCalledWith('claude')
   })
 
   it('does not track when follow-up prompt delivery rejects', async () => {
@@ -411,8 +390,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       ptyId: 'pty-1',
       content: 'review this before sending',
       agent: 'claude',
-      forcePaste: true,
-      onTimeout: expect.any(Function)
+      forcePaste: true
     })
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
   })
@@ -455,8 +433,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       ptyId: 'agent-pty',
       content: 'Linear context draft',
       agent: 'codex',
-      forcePaste: true,
-      onTimeout: expect.any(Function)
+      forcePaste: true
     })
   })
 
@@ -512,8 +489,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       ptyId: 'pty-delayed',
       content: 'https://github.com/stablyai/orca/pull/2051',
       agent: 'codex',
-      forcePaste: true,
-      onTimeout: expect.any(Function)
+      forcePaste: true
     })
   })
 
@@ -594,8 +570,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       ptyId: 'startup-pty',
       content: 'linked draft',
       agent: 'codex',
-      forcePaste: true,
-      onTimeout: expect.any(Function)
+      forcePaste: true
     })
   })
 
@@ -674,7 +649,10 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
 
   it('automatically requeues a failed immediate delivery for the same launch', async () => {
     mockPasteDraftToAgentPtyWhenReadyWithOutcome
-      .mockResolvedValueOnce('not-written')
+      .mockImplementationOnce(async (args: { onTimeout?: () => void }) => {
+        args.onTimeout?.()
+        return 'not-written'
+      })
       .mockResolvedValueOnce('delivered')
     const startup = {
       agent: 'codex' as const,
@@ -695,6 +673,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
     await Promise.resolve()
 
     expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledTimes(2)
+    expect(mockShowAutomationPromptNotSentToast).not.toHaveBeenCalled()
   })
 
   it('does not resend a delivered follow-up when only the draft is retryable', async () => {

--- a/src/renderer/src/lib/new-workspace.test.ts
+++ b/src/renderer/src/lib/new-workspace.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   mockInspectRuntimeTerminalProcess,
   mockSendRuntimePtyInputVerified,
-  mockPasteDraftToAgentPtyWhenReady,
+  mockPasteDraftToAgentPtyWhenReadyWithOutcome,
   mockShowAutomationPromptNotSentToast,
   mockTrack,
   store,
@@ -12,7 +12,7 @@ const {
 } = vi.hoisted(() => ({
   mockInspectRuntimeTerminalProcess: vi.fn(),
   mockSendRuntimePtyInputVerified: vi.fn(),
-  mockPasteDraftToAgentPtyWhenReady: vi.fn(),
+  mockPasteDraftToAgentPtyWhenReadyWithOutcome: vi.fn(),
   mockShowAutomationPromptNotSentToast: vi.fn(),
   mockTrack: vi.fn(),
   storeListeners: new Set<(state: unknown, previousState: unknown) => void>(),
@@ -79,7 +79,7 @@ vi.mock('@/runtime/runtime-terminal-inspection', () => ({
 
 vi.mock('@/lib/agent-paste-draft', () => ({
   getSettingsForAgentTabRuntimeOwner: () => store.settings,
-  pasteDraftToAgentPtyWhenReady: mockPasteDraftToAgentPtyWhenReady
+  pasteDraftToAgentPtyWhenReadyWithOutcome: mockPasteDraftToAgentPtyWhenReadyWithOutcome
 }))
 
 vi.mock('@/lib/browser-uuid', () => ({
@@ -273,7 +273,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       hasChildProcesses: true
     })
     mockSendRuntimePtyInputVerified.mockResolvedValue(true)
-    mockPasteDraftToAgentPtyWhenReady.mockResolvedValue(true)
+    mockPasteDraftToAgentPtyWhenReadyWithOutcome.mockResolvedValue('delivered')
   })
 
   afterEach(() => {
@@ -365,7 +365,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       }
     })
 
-    const call = mockPasteDraftToAgentPtyWhenReady.mock.calls.at(-1)?.[0] as
+    const call = mockPasteDraftToAgentPtyWhenReadyWithOutcome.mock.calls.at(-1)?.[0] as
       | { onTimeout?: () => void }
       | undefined
     expect(call?.onTimeout).toBeTypeOf('function')
@@ -390,6 +390,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
     ).resolves.toBeUndefined()
 
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
+    expect(mockShowAutomationPromptNotSentToast).not.toHaveBeenCalled()
   })
 
   it('does not track draft prompt delivery as a sent prompt', async () => {
@@ -405,7 +406,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       }
     })
 
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledWith({
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledWith({
       tabId: 'tab-1',
       ptyId: 'pty-1',
       content: 'review this before sending',
@@ -449,7 +450,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       }
     })
 
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledWith({
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledWith({
       tabId: 'agent-tab',
       ptyId: 'agent-pty',
       content: 'Linear context draft',
@@ -482,7 +483,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
     await vi.advanceTimersByTimeAsync(5_000)
     await delivery
 
-    expect(mockPasteDraftToAgentPtyWhenReady).not.toHaveBeenCalled()
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).not.toHaveBeenCalled()
 
     store.ptyIdsByTabId = { 'tab-1': ['pty-delayed'] }
     store.pendingStartupByTabId = {}
@@ -505,8 +506,8 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       listener(store, store)
     }
 
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledWith({
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledTimes(1)
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledWith({
       tabId: 'tab-1',
       ptyId: 'pty-delayed',
       content: 'https://github.com/stablyai/orca/pull/2051',
@@ -560,7 +561,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       listener(store, store)
     }
 
-    expect(mockPasteDraftToAgentPtyWhenReady).not.toHaveBeenCalled()
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).not.toHaveBeenCalled()
 
     store.ptyIdsByTabId = { 'tab-1': ['split-pty', 'startup-pty'] }
     store.terminalLayoutsByTabId = {
@@ -587,8 +588,8 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       listener(store, store)
     }
 
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledWith({
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledTimes(1)
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledWith({
       tabId: 'tab-1',
       ptyId: 'startup-pty',
       content: 'linked draft',
@@ -643,7 +644,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       listener(store, store)
     }
 
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledTimes(1)
   })
 
   it('does not duplicate immediate delivery for the same launch token', async () => {
@@ -668,7 +669,57 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       startup
     })
 
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledTimes(1)
+  })
+
+  it('automatically requeues a failed immediate delivery for the same launch', async () => {
+    mockPasteDraftToAgentPtyWhenReadyWithOutcome
+      .mockResolvedValueOnce('not-written')
+      .mockResolvedValueOnce('delivered')
+    const startup = {
+      agent: 'codex' as const,
+      launchCommand: 'codex',
+      expectedProcess: 'codex',
+      followupPrompt: null,
+      launchConfig: { agentArgs: '', agentEnv: {} },
+      draftPrompt: 'linked draft',
+      launchToken: 'launch-token-1'
+    }
+
+    await ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not resend a delivered follow-up when only the draft is retryable', async () => {
+    mockPasteDraftToAgentPtyWhenReadyWithOutcome
+      .mockResolvedValueOnce('not-written')
+      .mockResolvedValueOnce('delivered')
+
+    await ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup: {
+        agent: 'aider',
+        launchCommand: 'aider',
+        expectedProcess: 'aider',
+        followupPrompt: 'fix the spinner',
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        draftPrompt: 'linked draft',
+        launchToken: 'launch-token-1'
+      }
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockSendRuntimePtyInputVerified).toHaveBeenCalledTimes(1)
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledTimes(2)
   })
 
   it('keeps one delayed subscription and tears it down after delivery drains', async () => {
@@ -724,7 +775,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       listener(store, store)
     }
 
-    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).toHaveBeenCalledTimes(1)
     expect(storeListeners.size).toBe(0)
   })
 
@@ -778,7 +829,7 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       listener(store, store)
     }
 
-    expect(mockPasteDraftToAgentPtyWhenReady).not.toHaveBeenCalled()
+    expect(mockPasteDraftToAgentPtyWhenReadyWithOutcome).not.toHaveBeenCalled()
   })
 
   it('does not write a delayed follow-up prompt on readiness timeout', async () => {

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -4,7 +4,6 @@ import {
   pasteDraftToAgentPtyWhenReadyWithOutcome
 } from '@/lib/agent-paste-draft'
 import { sendFollowupPromptWhenAgentReadyWithOutcome } from '@/lib/agent-followup-delivery'
-import { showAutomationPromptNotSentToast } from '@/lib/agent-background-session-timeout-toast'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import type { LinkedWorkItemContext } from '@/lib/linked-work-item-context'
 import {
@@ -338,7 +337,6 @@ async function deliverAgentStartupToTerminal(
     if (followupOutcome !== 'delivered') {
       if (followupOutcome === 'not-written') {
         // Why: only a confirmed no-write can invite retry; a lost ACK may mean delivery succeeded.
-        showAutomationPromptNotSentToast(startup.agent)
         return { kind: 'retryable', startup }
       }
       return { kind: 'delivery-uncertain' }
@@ -359,9 +357,7 @@ async function deliverAgentStartupToTerminal(
       agent: startup.agent,
       // Why: startup.draftPrompt is only attached after native draft launch
       // planning is unavailable, so this paste is the first delivery attempt.
-      forcePaste: true,
-      // Why: surface a dropped draft instead of silently losing it.
-      onTimeout: () => showAutomationPromptNotSentToast(startup.agent)
+      forcePaste: true
     })
     if (draftOutcome !== 'delivered') {
       return draftOutcome === 'not-written'

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -1,9 +1,9 @@
 import { useAppStore } from '@/store'
 import {
   getSettingsForAgentTabRuntimeOwner,
-  pasteDraftToAgentPtyWhenReady
+  pasteDraftToAgentPtyWhenReadyWithOutcome
 } from '@/lib/agent-paste-draft'
-import { sendFollowupPromptWhenAgentReady } from '@/lib/agent-followup-delivery'
+import { sendFollowupPromptWhenAgentReadyWithOutcome } from '@/lib/agent-followup-delivery'
 import { showAutomationPromptNotSentToast } from '@/lib/agent-background-session-timeout-toast'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import type { LinkedWorkItemContext } from '@/lib/linked-work-item-context'
@@ -11,7 +11,9 @@ import {
   beginAgentStartupDeliveryAttempt,
   getAgentStartupTabPtyId,
   queuePendingAgentStartupDelivery,
-  resolveAgentStartupTabId
+  releaseAgentStartupDeliveryAttempt,
+  resolveAgentStartupTabId,
+  type AgentStartupDeliveryOutcome
 } from '@/lib/agent-startup-delayed-delivery'
 import type { FolderWorkspaceLinkedTask, OrcaHooks, TaskViewPresetId } from '../../../shared/types'
 import { resolveHookCommandSourcePolicy } from '../../../shared/hook-command-source-policy'
@@ -295,7 +297,24 @@ export async function ensureAgentStartupInTerminal(args: {
   }
 
   if (beginAgentStartupDeliveryAttempt({ worktreeId, tabId, launchToken })) {
-    await deliverAgentStartupToTerminal(tabId, ptyId, startup)
+    const outcome = await deliverAgentStartupToTerminal(tabId, ptyId, startup).catch((error) => {
+      // A rejected remote write has ambiguous delivery; do not replay it.
+      console.warn('Immediate agent startup delivery failed', error)
+      return null
+    })
+    if (outcome?.kind === 'retryable') {
+      // Why: a readiness/write failure is not final delivery. Requeue once
+      // through the launch-token gate; repeated failures then wait for the
+      // next relevant startup-state change instead of spinning.
+      releaseAgentStartupDeliveryAttempt({ worktreeId, tabId, launchToken })
+      queuePendingAgentStartupDelivery({
+        worktreeId,
+        tabId,
+        launchToken,
+        startup: outcome.startup,
+        deliver: deliverAgentStartupToTerminal
+      })
+    }
   }
 }
 
@@ -303,34 +322,40 @@ async function deliverAgentStartupToTerminal(
   tabId: string,
   ptyId: string,
   startup: AgentStartupPlan
-): Promise<void> {
-  const draftPrompt = startup.draftPrompt ?? null
+): Promise<AgentStartupDeliveryOutcome> {
   const runtimeSettings = getSettingsForAgentTabRuntimeOwner(tabId)
+  let remainingStartup = startup
   // Why: followupPrompt is the legacy path for stdin-after-start agents
   // (aider, goose, etc.) that need their initial prompt typed into the live
   // session and submitted. Wait until the agent owns the PTY before writing.
   if (startup.followupPrompt) {
-    const delivered = await sendFollowupPromptWhenAgentReady({
+    const followupOutcome = await sendFollowupPromptWhenAgentReadyWithOutcome({
       ptyId,
       expectedProcess: startup.expectedProcess,
       prompt: startup.followupPrompt,
       settings: runtimeSettings
     })
-    // Why: a dropped follow-up is otherwise silent — surface the same toast the
-    // draft path uses so the user knows to open the workspace and paste it.
-    if (!delivered) {
-      showAutomationPromptNotSentToast(startup.agent)
+    if (followupOutcome !== 'delivered') {
+      if (followupOutcome === 'not-written') {
+        // Why: only a confirmed no-write can invite retry; a lost ACK may mean delivery succeeded.
+        showAutomationPromptNotSentToast(startup.agent)
+        return { kind: 'retryable', startup }
+      }
+      return { kind: 'delivery-uncertain' }
     }
+    // Why: a later draft retry must not resubmit a follow-up that already
+    // reached the live agent.
+    remainingStartup = { ...startup, followupPrompt: null }
   }
 
   // Why: draftPrompt uses bracketed-paste so the URL lands atomically in the
   // agent's input buffer (no per-char echo, no auto-submit). Shared with the
   // launch-work-item-direct flow so both behave identically.
-  if (draftPrompt) {
-    await pasteDraftToAgentPtyWhenReady({
+  if (startup.draftPrompt) {
+    const draftOutcome = await pasteDraftToAgentPtyWhenReadyWithOutcome({
       tabId,
       ptyId,
-      content: draftPrompt,
+      content: startup.draftPrompt,
       agent: startup.agent,
       // Why: startup.draftPrompt is only attached after native draft launch
       // planning is unavailable, so this paste is the first delivery attempt.
@@ -338,7 +363,13 @@ async function deliverAgentStartupToTerminal(
       // Why: surface a dropped draft instead of silently losing it.
       onTimeout: () => showAutomationPromptNotSentToast(startup.agent)
     })
+    if (draftOutcome !== 'delivered') {
+      return draftOutcome === 'not-written'
+        ? { kind: 'retryable', startup: remainingStartup }
+        : { kind: 'delivery-uncertain' }
+    }
   }
+  return { kind: 'delivered' }
 }
 
 function ensureStartupLaunchToken(startup: AgentStartupPlan): string {

--- a/src/shared/agent-draft-platform-limit.ts
+++ b/src/shared/agent-draft-platform-limit.ts
@@ -1,9 +1,13 @@
+import type { AgentStartupShell } from './tui-agent-startup-shell'
+
 const WIN32_INLINE_DRAFT_LIMIT_CHARS = 24_000
+const WIN32_CMD_INLINE_DRAFT_LIMIT_CHARS = 7_500
 
 export function inlineAgentDraftFitsPlatform(args: {
   command: string
   env?: Record<string, string>
   platform: NodeJS.Platform
+  shell?: AgentStartupShell
 }): boolean {
   if (args.platform !== 'win32') {
     return true
@@ -12,7 +16,9 @@ export function inlineAgentDraftFitsPlatform(args: {
     (total, [key, value]) => total + key.length + value.length,
     0
   )
-  // Why: Windows CreateProcess/env blocks have tight length ceilings. Large
-  // generated drafts should use the existing post-ready paste fallback.
-  return args.command.length + envChars <= WIN32_INLINE_DRAFT_LIMIT_CHARS
+  // Why: cmd.exe caps command lines at 8191 chars; other Windows launch paths
+  // still need headroom for CreateProcess and its environment block.
+  const limit =
+    args.shell === 'cmd' ? WIN32_CMD_INLINE_DRAFT_LIMIT_CHARS : WIN32_INLINE_DRAFT_LIMIT_CHARS
+  return args.command.length + envChars <= limit
 }

--- a/src/shared/codex-startup-delivery.test.ts
+++ b/src/shared/codex-startup-delivery.test.ts
@@ -1,28 +1,45 @@
 import { describe, expect, it } from 'vitest'
-import { hasCodexNativeDraftFlag } from './codex-startup-delivery'
+import { shouldUseShellReadyStartupDelivery } from './codex-startup-delivery'
 
-describe('hasCodexNativeDraftFlag', () => {
-  it('matches Codex --prefill option tokens', () => {
-    expect(hasCodexNativeDraftFlag("codex --prefill 'linked issue context'")).toBe(true)
-    expect(hasCodexNativeDraftFlag("codex --model gpt-5 --prefill 'draft'")).toBe(true)
+describe('shouldUseShellReadyStartupDelivery', () => {
+  it('honors explicit shell-ready startup plans', () => {
+    expect(
+      shouldUseShellReadyStartupDelivery({
+        command: "codex 'fix it'",
+        startupCommandDelivery: 'shell-ready'
+      })
+    ).toBe(true)
   })
 
-  it('matches Codex --prefill=value option tokens', () => {
-    expect(hasCodexNativeDraftFlag('codex --prefill=review')).toBe(true)
-    expect(hasCodexNativeDraftFlag("codex --prefill='linked issue context'")).toBe(true)
+  it('stays on the fast path without an explicit shell-ready hint', () => {
+    expect(shouldUseShellReadyStartupDelivery({ command: 'codex' })).toBe(false)
+    expect(
+      shouldUseShellReadyStartupDelivery({
+        command: "codex 'please compare --prefill behavior'"
+      })
+    ).toBe(false)
   })
 
-  it('does not match quoted prompt text mentioning prefill', () => {
-    expect(hasCodexNativeDraftFlag("codex 'please compare --prefill behavior'")).toBe(false)
-    expect(hasCodexNativeDraftFlag("codex '--prefill=not-an-option'")).toBe(false)
+  it('does not treat mythical Codex --prefill tokens as native draft delivery', () => {
+    // Why: Codex has no --prefill flag. Only a startup plan that actually
+    // carries positional PROMPT may opt into shell-ready command delivery.
+    expect(
+      shouldUseShellReadyStartupDelivery({
+        command: "codex --prefill 'linked issue context'"
+      })
+    ).toBe(false)
+    expect(
+      shouldUseShellReadyStartupDelivery({
+        command: 'codex --prefill=review'
+      })
+    ).toBe(false)
   })
 
-  it('does not match non-Codex commands', () => {
-    expect(hasCodexNativeDraftFlag("claude --prefill 'review this'")).toBe(false)
-  })
-
-  it('leaves plain Codex and normal Codex arguments on the fast path', () => {
-    expect(hasCodexNativeDraftFlag('codex')).toBe(false)
-    expect(hasCodexNativeDraftFlag('codex --model gpt-5')).toBe(false)
+  it('does not force shell-ready for Claude native prefill', () => {
+    expect(
+      shouldUseShellReadyStartupDelivery({
+        command: "claude --prefill 'review this'"
+      })
+    ).toBe(false)
   })
 })

--- a/src/shared/codex-startup-delivery.ts
+++ b/src/shared/codex-startup-delivery.ts
@@ -1,82 +1,11 @@
-import { recognizeAgentProcessFromCommandLine } from './agent-process-recognition'
-
 export type StartupCommandDelivery = 'fast' | 'shell-ready'
 
-type CommandToken = {
-  value: string
-  startsQuoted: boolean
-}
-
-function tokenizeCommandWithQuoteMetadata(command: string): CommandToken[] {
-  const tokens: CommandToken[] = []
-  let current = ''
-  let inToken = false
-  let startsQuoted = false
-  let quote: '"' | "'" | null = null
-  let escaped = false
-
-  for (let index = 0; index < command.length; index += 1) {
-    const char = command[index]
-    if (escaped) {
-      current += char
-      escaped = false
-      continue
-    }
-    if (char === '\\' && quote !== "'") {
-      const next = command[index + 1]
-      if (next && (/\s/.test(next) || next === '"' || next === "'" || next === '\\')) {
-        escaped = true
-        inToken = true
-        continue
-      }
-    }
-    if ((char === '"' || char === "'") && quote === null) {
-      if (!inToken) {
-        startsQuoted = true
-      }
-      quote = char
-      inToken = true
-      continue
-    }
-    if (quote === char) {
-      quote = null
-      continue
-    }
-    if (/\s/.test(char) && quote === null) {
-      if (inToken) {
-        tokens.push({ value: current, startsQuoted })
-        current = ''
-        inToken = false
-        startsQuoted = false
-      }
-      continue
-    }
-    current += char
-    inToken = true
-  }
-
-  if (inToken) {
-    tokens.push({ value: current, startsQuoted })
-  }
-  return tokens
-}
-
-export function hasCodexNativeDraftFlag(command: string | null | undefined): boolean {
-  if (recognizeAgentProcessFromCommandLine(command)?.agent !== 'codex' || !command) {
-    return false
-  }
-  const tokens = tokenizeCommandWithQuoteMetadata(command)
-  return tokens.some(
-    (token, index) =>
-      index > 0 &&
-      !token.startsQuoted &&
-      (token.value === '--prefill' || token.value.startsWith('--prefill='))
-  )
-}
-
 export function shouldUseShellReadyStartupDelivery(args: {
-  command: string | null | undefined
+  command?: string | null | undefined
   startupCommandDelivery?: StartupCommandDelivery
 }): boolean {
-  return args.startupCommandDelivery === 'shell-ready' || hasCodexNativeDraftFlag(args.command)
+  // Why: Codex has no native draft-prefill flag. Only startup plans carrying
+  // positional PROMPT explicitly opt in after the shell startup files run.
+  void args.command
+  return args.startupCommandDelivery === 'shell-ready'
 }

--- a/src/shared/draft-paste-ready-scanner.test.ts
+++ b/src/shared/draft-paste-ready-scanner.test.ts
@@ -4,7 +4,9 @@ import { createDraftPasteReadyScanner } from './draft-paste-ready-scanner'
 const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
 const SHOW_CURSOR = '\x1b[?25h'
 const HIDE_CURSOR = '\x1b[?25l'
-const CODEX_PROMPT = '\x1b[1m›\x1b[0m Ask Codex to do anything'
+const CODEX_GLYPH = '›'
+const CODEX_PLACEHOLDER = 'Ask Codex to do anything'
+const CODEX_PROMPT = `\x1b[1m${CODEX_GLYPH}\x1b[0m ${CODEX_PLACEHOLDER}`
 
 describe('createDraftPasteReadyScanner', () => {
   describe('render-cursor-after-bracketed-paste (opencode / mimo-code)', () => {
@@ -92,21 +94,37 @@ describe('createDraftPasteReadyScanner', () => {
     })
   })
 
-  describe('codex-composer-prompt (unchanged behavior)', () => {
-    it('is ready on the composer glyph after bracketed paste and never arms the quiet timer', () => {
+  describe('codex-composer-prompt (multi-signal gate)', () => {
+    it('is ready only when glyph and idle placeholder both render after bracketed paste', () => {
       const scanner = createDraftPasteReadyScanner('codex-composer-prompt')
       expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({
         ready: false,
         armQuietTimer: false
       })
-      expect(scanner.observe(CODEX_PROMPT)).toEqual({ ready: true, armQuietTimer: false })
+      // Why: Codex can render a bare glyph during hooks review before its idle
+      // composer owns input, so that glyph must not unlock a linked draft.
+      expect(scanner.observe(CODEX_GLYPH)).toEqual({ ready: false, armQuietTimer: false })
+      expect(scanner.observe(CODEX_PLACEHOLDER)).toEqual({ ready: true, armQuietTimer: false })
     })
 
-    it('detects the composer glyph inside a large first render chunk', () => {
+    it('detects the full idle composer prompt inside a large first render chunk', () => {
       const scanner = createDraftPasteReadyScanner('codex-composer-prompt')
       expect(scanner.observe(`${DECSET_BRACKETED_PASTE}${CODEX_PROMPT}${'x'.repeat(900)}`)).toEqual(
         { ready: true, armQuietTimer: false }
       )
+    })
+
+    it('does not fire on glyph alone or placeholder alone', () => {
+      const glyphOnly = createDraftPasteReadyScanner('codex-composer-prompt')
+      glyphOnly.observe(DECSET_BRACKETED_PASTE)
+      expect(glyphOnly.observe(CODEX_GLYPH)).toEqual({ ready: false, armQuietTimer: false })
+
+      const placeholderOnly = createDraftPasteReadyScanner('codex-composer-prompt')
+      placeholderOnly.observe(DECSET_BRACKETED_PASTE)
+      expect(placeholderOnly.observe(CODEX_PLACEHOLDER)).toEqual({
+        ready: false,
+        armQuietTimer: false
+      })
     })
 
     it('never arms the quiet-window fallback', () => {

--- a/src/shared/draft-paste-ready-scanner.ts
+++ b/src/shared/draft-paste-ready-scanner.ts
@@ -4,7 +4,8 @@ import type { DraftPasteReadySignal } from './tui-agent-config'
 // actually mounted/focused. These markers let the scanner detect the real
 // "input is ready" moment per agent instead of guessing from output silence.
 const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
-const CODEX_COMPOSER_PROMPT = '›'
+const CODEX_COMPOSER_GLYPH = '›'
+const CODEX_COMPOSER_PLACEHOLDER = 'Ask Codex'
 // Why: opencode emits the DECTCEM show-cursor only once the composer row is
 // mounted and the text cursor is placed in it — a "composer ready" signal,
 // analogous to Codex's prompt glyph. It fires ~2s after bracketed paste is
@@ -28,8 +29,8 @@ export type DraftPasteReadyScanResult = {
  * and return types differ.
  *
  * Per agent signal:
- *   - `codex-composer-prompt`: ready when the `›` glyph renders after DECSET
- *     2004; never arms the quiet window (`armQuietTimer` stays false).
+ *   - `codex-composer-prompt`: ready when the `›` glyph and idle "Ask Codex"
+ *     placeholder render after DECSET 2004; never arms the quiet window.
  *   - `render-cursor-after-bracketed-paste`: ready when DECTCEM show-cursor
  *     (`\x1b[?25h`) renders after DECSET 2004. Like Codex it does NOT arm the
  *     quiet window: opencode stays silent for ~1.5-2s between enabling
@@ -49,13 +50,21 @@ export function createDraftPasteReadyScanner(readySignal: DraftPasteReadySignal)
   let recent = ''
   let postHandshakeRecent = ''
   let saw2004 = false
+  let sawCodexGlyph = false
+  let sawCodexPlaceholder = false
 
-  const signalMarker =
-    readySignal === 'codex-composer-prompt'
-      ? CODEX_COMPOSER_PROMPT
-      : readySignal === 'render-cursor-after-bracketed-paste'
-        ? DECTCEM_SHOW_CURSOR
-        : null
+  const usesCursorMarker = readySignal === 'render-cursor-after-bracketed-paste'
+  const usesCodexComposer = readySignal === 'codex-composer-prompt'
+  const usesMarker = usesCursorMarker || usesCodexComposer
+
+  const observeCodexMarkers = (chunk: string): void => {
+    if (!sawCodexGlyph && chunk.includes(CODEX_COMPOSER_GLYPH)) {
+      sawCodexGlyph = true
+    }
+    if (!sawCodexPlaceholder && chunk.includes(CODEX_COMPOSER_PLACEHOLDER)) {
+      sawCodexPlaceholder = true
+    }
+  }
 
   return {
     observe(data: string): DraftPasteReadyScanResult {
@@ -68,27 +77,34 @@ export function createDraftPasteReadyScanner(readySignal: DraftPasteReadySignal)
         }
         saw2004 = true
         const postHandshakeChunk = combined.slice(markerIndex + DECSET_BRACKETED_PASTE.length)
-        if (signalMarker !== null && postHandshakeChunk.includes(signalMarker)) {
+        if (usesCodexComposer) {
+          observeCodexMarkers(postHandshakeChunk)
+          if (sawCodexGlyph && sawCodexPlaceholder) {
+            return { ready: true, armQuietTimer: false }
+          }
+        } else if (usesCursorMarker && postHandshakeChunk.includes(DECTCEM_SHOW_CURSOR)) {
           return { ready: true, armQuietTimer: false }
         }
         postHandshakeRecent = postHandshakeChunk.slice(-512)
       } else {
-        if (
-          signalMarker !== null &&
-          (data.includes(signalMarker) || (postHandshakeRecent + data).includes(signalMarker))
+        if (usesCodexComposer) {
+          observeCodexMarkers(data)
+          observeCodexMarkers(postHandshakeRecent + data)
+          if (sawCodexGlyph && sawCodexPlaceholder) {
+            return { ready: true, armQuietTimer: false }
+          }
+        } else if (
+          usesCursorMarker &&
+          (data.includes(DECTCEM_SHOW_CURSOR) ||
+            (postHandshakeRecent + data).includes(DECTCEM_SHOW_CURSOR))
         ) {
           return { ready: true, armQuietTimer: false }
         }
         postHandshakeRecent = (postHandshakeRecent + data).slice(-512)
       }
-      // Why: marker-based signals (Codex glyph, opencode show-cursor) must NOT
-      // arm the quiet window. opencode goes silent for ~1.5-2s between enabling
-      // bracketed paste and mounting its composer, so a quiet window would fire
-      // during that gap — before the composer exists — and pre-empt the marker.
-      // These signals wait for their marker, bounded only by the caller's hard
-      // timeout (and the caller's best-effort process-ownership paste after it).
-      // Only the default signal, which has no marker, uses the quiet window.
-      return { ready: false, armQuietTimer: signalMarker === null && saw2004 }
+      // Why: marker-gated agents can be quiet before their composer mounts;
+      // only the default signal may use that quiet period as readiness.
+      return { ready: false, armQuietTimer: !usesMarker && saw2004 }
     }
   }
 }

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -37,7 +37,10 @@ export type TuiAgentConfig = {
   draftPromptEnvVar?: string
   /** Pre-write a trust artifact so the agent's first-launch "trust this folder?" menu doesn't consume the bracketed paste (see agent-trust-presets.ts). */
   preflightTrust?: 'cursor' | 'copilot' | 'codex'
-  /** Renderer-specific signal that the composer is ready for paste, stronger than the default quiet-render window. */
+  /** Why: most TUIs need both bracketed-paste enablement and a quiet render
+   * window before pasted bytes reliably land in the composer. Codex waits for
+   * both the `›` glyph and idle "Ask Codex" placeholder because hooks review
+   * can render a bare glyph before the composer owns input. */
   draftPasteReadySignal?: DraftPasteReadySignal
   /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
   windowsShiftEnterEncoding?: 'csi-u'

--- a/src/shared/tui-agent-draft-launch-plan.ts
+++ b/src/shared/tui-agent-draft-launch-plan.ts
@@ -1,0 +1,100 @@
+import { inlineAgentDraftFitsPlatform } from './agent-draft-platform-limit'
+import type { SleepingAgentLaunchConfig } from './agent-session-resume'
+import type { SessionOptionValue } from './native-chat-session-options'
+import { buildSleepingAgentLaunchConfig } from './sleeping-agent-launch-config'
+import { TUI_AGENT_CONFIG } from './tui-agent-config'
+import { resolveAgentLaunchCommand } from './tui-agent-launch-command'
+import {
+  clearEnvCommand,
+  commandSeparator,
+  quoteStartupArg,
+  resolveStartupShell,
+  type AgentStartupShell
+} from './tui-agent-startup-shell'
+import type { StartupCommandDelivery } from './codex-startup-delivery'
+import type { TuiAgent } from './types'
+
+export type AgentDraftLaunchPlan = {
+  agent: TuiAgent
+  launchCommand: string
+  expectedProcess: string
+  launchConfig: SleepingAgentLaunchConfig
+  env?: Record<string, string>
+  startupCommandDelivery?: StartupCommandDelivery
+  sessionOptions?: Record<string, SessionOptionValue>
+}
+
+function appliedSessionOptionProps(
+  values: Record<string, SessionOptionValue>
+): Pick<AgentDraftLaunchPlan, 'sessionOptions'> {
+  return Object.keys(values).length > 0 ? { sessionOptions: { ...values } } : {}
+}
+
+export function buildAgentDraftLaunchPlan(args: {
+  agent: TuiAgent
+  draft: string
+  cmdOverrides: Partial<Record<TuiAgent, string>>
+  platform: NodeJS.Platform
+  shell?: AgentStartupShell
+  agentArgs?: string | null
+  agentEnv?: Record<string, string> | null
+  sessionOptions?: Record<string, SessionOptionValue>
+  /** Why: remote launches use the plain `orca` shim, not the Linux-only `orca-ide` rename. */
+  isRemote?: boolean
+}): AgentDraftLaunchPlan | null {
+  const { agent, draft, cmdOverrides, platform } = args
+  const shell = resolveStartupShell(platform, args.shell)
+  const config = TUI_AGENT_CONFIG[agent]
+  const trimmed = draft.trim()
+  if (!trimmed) {
+    return null
+  }
+  const baseCommand = resolveAgentLaunchCommand({
+    agent,
+    cmdOverrides,
+    platform,
+    shell,
+    agentArgs: args.agentArgs,
+    sessionOptions: args.sessionOptions,
+    isRemote: args.isRemote
+  })
+  if (!baseCommand.ok) {
+    return null
+  }
+  const launchConfig = buildSleepingAgentLaunchConfig({
+    ...args,
+    // Why: resume must not replay one-time picker flags.
+    agentCommand: baseCommand.commandWithoutSessionOptions
+  })
+  let plan: AgentDraftLaunchPlan | null = null
+  if (config.draftPromptFlag) {
+    const quoted = quoteStartupArg(trimmed, shell)
+    plan = {
+      agent,
+      launchCommand: `${baseCommand.command} ${config.draftPromptFlag} ${quoted}`,
+      expectedProcess: config.expectedProcess,
+      launchConfig,
+      ...appliedSessionOptionProps(baseCommand.appliedSessionOptions),
+      // Why: native draft flags carry user text on argv and must survive rc-file startup.
+      ...(agent === 'codex' ? { startupCommandDelivery: 'shell-ready' as const } : {}),
+      ...(args.agentEnv ? { env: { ...args.agentEnv } } : {})
+    }
+  } else if (config.draftPromptEnvVar) {
+    const clearVar = clearEnvCommand(config.draftPromptEnvVar, shell)
+    plan = {
+      agent,
+      launchCommand: `${baseCommand.command}${commandSeparator(shell)}${clearVar}`,
+      expectedProcess: config.expectedProcess,
+      launchConfig,
+      ...appliedSessionOptionProps(baseCommand.appliedSessionOptions),
+      env: { ...args.agentEnv, [config.draftPromptEnvVar]: trimmed }
+    }
+  }
+  if (
+    !plan ||
+    !inlineAgentDraftFitsPlatform({ command: plan.launchCommand, env: plan.env, platform, shell })
+  ) {
+    return null
+  }
+  return plan
+}

--- a/src/shared/tui-agent-draft-launch-plan.ts
+++ b/src/shared/tui-agent-draft-launch-plan.ts
@@ -75,8 +75,6 @@ export function buildAgentDraftLaunchPlan(args: {
       expectedProcess: config.expectedProcess,
       launchConfig,
       ...appliedSessionOptionProps(baseCommand.appliedSessionOptions),
-      // Why: native draft flags carry user text on argv and must survive rc-file startup.
-      ...(agent === 'codex' ? { startupCommandDelivery: 'shell-ready' as const } : {}),
       ...(args.agentEnv ? { env: { ...args.agentEnv } } : {})
     }
   } else if (config.draftPromptEnvVar) {

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -419,6 +419,35 @@ describe('tui agent startup plans', () => {
     expect(plan?.startupCommandDelivery).toBe('shell-ready')
   })
 
+  it('falls back to post-ready delivery when a Codex prompt exceeds the Windows argv budget', () => {
+    const prompt = 'x'.repeat(25_000)
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt,
+      cmdOverrides: {},
+      platform: 'win32'
+    })
+
+    expect(plan?.launchCommand).toBe('codex')
+    expect(plan?.followupPrompt).toBe(prompt)
+    expect(plan?.startupCommandDelivery).toBeUndefined()
+  })
+
+  it('uses the lower cmd.exe argv budget for Codex startup prompts', () => {
+    const prompt = 'x'.repeat(7_600)
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt,
+      cmdOverrides: {},
+      platform: 'win32',
+      shell: 'cmd'
+    })
+
+    expect(plan?.launchCommand).toBe('codex')
+    expect(plan?.followupPrompt).toBe(prompt)
+    expect(plan?.startupCommandDelivery).toBeUndefined()
+  })
+
   it('keeps plain empty Codex startup on the fast delivery path', () => {
     const plan = buildAgentStartupPlan({
       agent: 'codex',
@@ -815,6 +844,18 @@ describe('tui agent startup plans', () => {
         draft: 'x'.repeat(25_000),
         cmdOverrides: {},
         platform: 'win32'
+      })
+    ).toBeNull()
+  })
+
+  it('uses the lower cmd.exe argv budget for native draft flags', () => {
+    expect(
+      buildAgentDraftLaunchPlan({
+        agent: 'claude',
+        draft: 'x'.repeat(7_600),
+        cmdOverrides: {},
+        platform: 'win32',
+        shell: 'cmd'
       })
     ).toBeNull()
   })

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -6,8 +6,6 @@ import {
   type SleepingAgentLaunchConfig
 } from './agent-session-resume'
 import {
-  clearEnvCommand,
-  commandSeparator,
   quoteStartupArg,
   resolveStartupShell,
   type AgentStartupShell
@@ -99,9 +97,30 @@ export function buildAgentStartupPlan(args: {
 
   if (config.promptInjectionMode === 'argv') {
     const promptSeparator = config.argvPromptSeparator ? ` ${config.argvPromptSeparator}` : ''
+    const launchCommand = `${baseCommand.command}${promptSeparator} ${quotedPrompt}`
+    if (
+      !inlineAgentDraftFitsPlatform({
+        command: launchCommand,
+        env: args.agentEnv ?? undefined,
+        platform,
+        shell
+      })
+    ) {
+      // Why: oversized Windows argv must fall back to post-ready stdin rather
+      // than being truncated or rejected by CreateProcess/cmd.exe.
+      return {
+        agent,
+        launchCommand: baseCommand.command,
+        expectedProcess: config.expectedProcess,
+        followupPrompt: trimmedPrompt,
+        launchConfig,
+        ...appliedSessionOptionProps(baseCommand.appliedSessionOptions),
+        ...(args.agentEnv ? { env: { ...args.agentEnv } } : {})
+      }
+    }
     return {
       agent,
-      launchCommand: `${baseCommand.command}${promptSeparator} ${quotedPrompt}`,
+      launchCommand,
       expectedProcess: config.expectedProcess,
       followupPrompt: null,
       launchConfig,
@@ -237,86 +256,8 @@ export function buildAgentResumeStartupPlan(args: {
   }
 }
 
-export type AgentDraftLaunchPlan = {
-  agent: TuiAgent
-  launchCommand: string
-  expectedProcess: string
-  launchConfig: SleepingAgentLaunchConfig
-  env?: Record<string, string>
-  startupCommandDelivery?: StartupCommandDelivery
-  sessionOptions?: Record<string, SessionOptionValue>
-}
-
-export function buildAgentDraftLaunchPlan(args: {
-  agent: TuiAgent
-  draft: string
-  cmdOverrides: Partial<Record<TuiAgent, string>>
-  platform: NodeJS.Platform
-  shell?: AgentStartupShell
-  agentArgs?: string | null
-  agentEnv?: Record<string, string> | null
-  sessionOptions?: Record<string, SessionOptionValue>
-  /** Why: see buildAgentStartupPlan — remote launches use the plain `orca` shim. */
-  isRemote?: boolean
-}): AgentDraftLaunchPlan | null {
-  const { agent, draft, cmdOverrides, platform } = args
-  const shell = resolveStartupShell(platform, args.shell)
-  const config = TUI_AGENT_CONFIG[agent]
-  const trimmed = draft.trim()
-  if (!trimmed) {
-    return null
-  }
-  const baseCommand = resolveAgentLaunchCommand({
-    agent,
-    cmdOverrides,
-    platform,
-    shell,
-    agentArgs: args.agentArgs,
-    sessionOptions: args.sessionOptions,
-    isRemote: args.isRemote
-  })
-  if (!baseCommand.ok) {
-    return null
-  }
-  const launchConfig = buildSleepingAgentLaunchConfig({
-    ...args,
-    // Why: see the new-session path above — resume must not replay picker flags.
-    agentCommand: baseCommand.commandWithoutSessionOptions
-  })
-  let plan: AgentDraftLaunchPlan | null = null
-  if (config.draftPromptFlag) {
-    const quoted = quoteStartupArg(trimmed, shell)
-    plan = {
-      agent,
-      launchCommand: `${baseCommand.command} ${config.draftPromptFlag} ${quoted}`,
-      expectedProcess: config.expectedProcess,
-      launchConfig,
-      ...appliedSessionOptionProps(baseCommand.appliedSessionOptions),
-      // Why: native draft flags carry user text on argv and must survive rc-file startup.
-      ...(agent === 'codex' ? { startupCommandDelivery: 'shell-ready' as const } : {}),
-      ...(args.agentEnv ? { env: { ...args.agentEnv } } : {})
-    }
-  } else if (config.draftPromptEnvVar) {
-    const clearVar = clearEnvCommand(config.draftPromptEnvVar, shell)
-    plan = {
-      agent,
-      launchCommand: `${baseCommand.command}${commandSeparator(shell)}${clearVar}`,
-      expectedProcess: config.expectedProcess,
-      launchConfig,
-      ...appliedSessionOptionProps(baseCommand.appliedSessionOptions),
-      env: { ...args.agentEnv, [config.draftPromptEnvVar]: trimmed }
-    }
-  }
-  if (
-    !plan ||
-    !inlineAgentDraftFitsPlatform({ command: plan.launchCommand, env: plan.env, platform })
-  ) {
-    return null
-  }
-  return plan
-}
-
 export { isShellProcess }
+export { buildAgentDraftLaunchPlan, type AgentDraftLaunchPlan } from './tui-agent-draft-launch-plan'
 export {
   buildShellCommandFromArgv,
   planAgentCliArgsSuffix,


### PR DESCRIPTION
## Summary

Replacement slice for #7950, limited to Codex startup commands and draft delivery.

- replace the removed `codex --prefill` assumption with explicit positional-prompt startup planning
- fall back from oversized Windows argv to paste-submit delivery
- require the real Codex composer-ready state before pasting linked drafts
- preserve launch-bound delivery ownership across PTY dispose/remount and delayed background workspace activation
- distinguish `not-written` from `delivery-uncertain`: retry only when no bytes were accepted, never replay partial writes or a request whose acknowledgement was lost
- preserve successful follow-up component state so a later draft-only retry cannot submit the follow-up twice
- discard delayed work when its tab is gone and re-run readiness checks when the PTY is replaced

## Why this is separate

#7950 combined unrelated hook, auth/rate-limit, session/native-chat, and startup behavior. This PR contains only the startup/drafts slice so its delivery ownership and side-effect boundary can be reviewed and reverted independently.

## Correctness and compatibility

- explicit readiness timeout or terminal rejection before any write can requeue the remaining payload
- partial chunk delivery, remote acknowledgement loss, or Promise rejection remains consumed; the client does not automatically replay ambiguous user/task text
- an uncertain result does not show the “was not sent, paste manually” toast, which could otherwise induce a duplicate
- the automatic no-write retry is bounded: a second no-write result waits for a later relevant state transition and does not spin
- a replacement PTY never inherits the old PTY's readiness decision
- existing boolean paste/follow-up APIs remain compatible; the structured outcome is used only where retry safety needs it
- Windows command-length fallback uses the existing paste-submit transport; macOS, Linux, local, and SSH launch paths keep their platform gates

## Testing

- [x] original focused startup suite: 12 files / 1,681 tests
- [x] side-effect-aware delivery suite: 4 files / 76 tests
- [x] focused PTY retry/ownership cases: 8 tests
- [x] transient unrelated Droid timer case rerun: passed
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] targeted `oxfmt --check`
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff --check origin/main...HEAD`
- [x] independent spec gate: PASS
- [x] independent code-quality re-gate: APPROVED
- [ ] Electron/E2E/GUI
- [ ] Windows/SSH live smoke

## AI Review Report

The first independent gate approved the original startup split. After submission, CodeRabbit correctly identified that a boolean failure could represent either zero writes or partial delivery. The fix introduces an explicit side-effect-aware outcome through the paste/follow-up and delayed-delivery boundary.

A second independent gate verified that only `not-written` requeues; partial chunks, lost acknowledgements, and rejected Promises do not replay; successful follow-up state is removed from a draft retry; and dispose/remount cannot release an uncertain claim. Its only follow-up was to avoid the existing manual-paste toast for uncertain delivery; that was fixed and the final re-gate ended APPROVED.

## Security Audit

Generated task text is never replayed when delivery may already have occurred. The change adds no credentials, commands, IPC methods, dependencies, or persisted data, and keeps the existing PTY/runtime ownership checks.

## Notes

The full 430-test PTY file had one unrelated timer-sensitive Droid assertion fail in the combined run; that exact test passed immediately in isolation. No assertion or production behavior was weakened. Validation used Node 26.5.0 while the repository declares Node 24.

## ELI5

Codex startup could fail to deliver the first prompt/draft (especially on Windows or after remounts) after the old `--prefill` path went away. Startup planning, paste-when-ready, and ownership across dispose/remount are fixed so drafts actually reach the composer.
