### PR TITLE
fix(runtime): stop remote sort-order refresh loops

### DIFF
--- a/docs/superpowers/plans/2026-07-11-remote-host-refresh-loop.md
+++ b/docs/superpowers/plans/2026-07-11-remote-host-refresh-loop.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- Run every Node-based command with `PATH=/opt/homebrew/opt/node@24/bin:$PATH`.
+- Run every Node-based command with the repository-required Node 24 toolchain.
 - Do not modify `WorktreeList.tsx`, Smart ordering classes, pairing, heartbeat, transport, UI preferences, or protocol schemas.
 - Keep local `worktrees:persistSortOrder` return behavior `void`; keep runtime `worktree.persistSortOrder` returning `{ updated: number }`.
 - Do not add max-lines suppressions or increase baseline entries.
@@ -56,7 +56,7 @@ it('preserves a runtime catalog when an older local refresh finishes last', asyn
 Run:
 
 ```bash
-PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
+pnpm exec vitest run \
   --config config/vitest.config.ts \
   src/renderer/src/store/slices/repos-stale-fetch.test.ts
 ```
@@ -131,7 +131,7 @@ Seed `getWorktreeMeta` with finite descending values. Add a second test for `ord
 Run:
 
 ```bash
-PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
+pnpm exec vitest run \
   --config config/vitest.config.ts \
   src/main/runtime/orca-runtime-sort-order.test.ts \
   src/main/ipc/worktrees-sort-order.test.ts
@@ -225,7 +225,7 @@ The shorter delegation must leave `src/main/ipc/worktrees.ts` at or below its `o
 Run:
 
 ```bash
-PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
+pnpm exec vitest run \
   --config config/vitest.config.ts \
   src/main/worktree-sort-order-persistence.test.ts \
   src/main/runtime/orca-runtime-sort-order.test.ts \
@@ -273,7 +273,7 @@ git commit -m "fix: stop remote sort-order refresh loops"
 - [ ] **Step 1: Run focused behavioral tests**
 
 ```bash
-PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
+pnpm exec vitest run \
   --config config/vitest.config.ts \
   src/renderer/src/store/slices/repos-all-hosts.test.ts \
   src/renderer/src/store/slices/repos-stale-fetch.test.ts \
@@ -293,10 +293,10 @@ Expected: all selected files pass with zero failed tests.
 - [ ] **Step 2: Run repository gates**
 
 ```bash
-PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm lint
-PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm typecheck
-PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm check:max-lines-ratchet
-PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm build
+pnpm lint
+pnpm typecheck
+pnpm check:max-lines-ratchet
+pnpm build
 git diff --check origin/main...HEAD
 ```
 

--- a/docs/superpowers/plans/2026-07-11-remote-host-refresh-loop.md
+++ b/docs/superpowers/plans/2026-07-11-remote-host-refresh-loop.md
@@ -1,0 +1,362 @@
+# Remote Host Refresh Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve cross-host repo rows during overlapping refreshes and stop unchanged Smart-order persistence from generating a remote `reposChanged` feedback loop.
+
+**Architecture:** Keep the renderer and protocol unchanged. Add one main-process domain module that recognizes a finite, strictly descending persisted order and writes timestamps only when the effective request order differs; route local IPC and runtime RPC persistence through it, and condition runtime cache invalidation/notification on `updated > 0`. Guard the latest-state repo merge already on `main` with an explicit local-versus-runtime overlap test.
+
+**Tech Stack:** TypeScript, Electron main process, Zustand store tests, Vitest, pnpm 10.24.0, Node 24.
+
+## Global Constraints
+
+- Run every Node-based command with `PATH=/opt/homebrew/opt/node@24/bin:$PATH`.
+- Do not modify `WorktreeList.tsx`, Smart ordering classes, pairing, heartbeat, transport, UI preferences, or protocol schemas.
+- Keep local `worktrees:persistSortOrder` return behavior `void`; keep runtime `worktree.persistSortOrder` returning `{ updated: number }`.
+- Do not add max-lines suppressions or increase baseline entries.
+- Keep all identifiers synthetic and omit incident IPs, usernames, hostnames, paths, runtime/device IDs, and repository names.
+- The owner runtime performs remote writes; PR validation must state that both test hosts need a build containing the fix.
+- Preserve unrelated worktree state and do not touch the original checkout's `HANDOFF.md` or `mobile/build/`.
+
+---
+
+### Task 1: Lock the cross-host repo race regression
+
+**Files:**
+- Modify: `src/renderer/src/store/slices/repos-all-hosts.test.ts`
+
+**Interfaces:**
+- Consumes: `fetchRepos(): Promise<void>` and `fetchRuntimeEnvironmentRepos(environmentId: string): Promise<Repo[]>` from `RepoSlice`.
+- Produces: a regression proving both `local` and `runtime:env-1` repo ownership survive when an older local request resolves last.
+
+- [ ] **Step 1: Add the overlap regression**
+
+Add this test inside `describe('fetchReposForAllHosts', ...)`, next to the existing targeted-runtime latest-state test:
+
+```ts
+it('preserves a runtime catalog when an older local refresh finishes last', async () => {
+  let resolveLocal!: (repos: Repo[]) => void
+  const localResponse = new Promise<Repo[]>((resolve) => {
+    resolveLocal = resolve
+  })
+  reposList.mockReturnValueOnce(localResponse)
+  const store = createTestStore()
+
+  const localLoad = store.getState().fetchRepos()
+  await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+  expect(store.getState().repos).toEqual([
+    { ...remoteRepo, executionHostId: 'runtime:env-1' }
+  ])
+
+  resolveLocal([localRepo])
+  await localLoad
+
+  expect(store.getState().repos).toEqual([
+    { ...remoteRepo, executionHostId: 'runtime:env-1' },
+    { ...localRepo, executionHostId: 'local' }
+  ])
+})
+```
+
+- [ ] **Step 2: Run the regression on current `main` behavior**
+
+Run:
+
+```bash
+PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
+  --config config/vitest.config.ts \
+  src/renderer/src/store/slices/repos-all-hosts.test.ts
+```
+
+Expected: PASS. This is coverage for the latest-state merge already delivered by `25ecf2eea`; no repo-slice production edit follows.
+
+- [ ] **Step 3: Commit the regression**
+
+```bash
+git add src/renderer/src/store/slices/repos-all-hosts.test.ts
+git commit -m "test: cover cross-host repo refresh race"
+```
+
+---
+
+### Task 2: Make worktree sort-order persistence idempotent
+
+**Files:**
+- Create: `src/main/worktree-sort-order-persistence.ts`
+- Create: `src/main/worktree-sort-order-persistence.test.ts`
+- Create: `src/main/runtime/orca-runtime-sort-order.test.ts`
+- Create: `src/main/ipc/worktrees-sort-order.test.ts`
+- Modify: `src/main/runtime/orca-runtime.ts:16283-16297`
+- Modify: `src/main/ipc/worktrees.ts:2064-2078`
+
+**Interfaces:**
+- Produces: `persistWorktreeSortOrderIfChanged(store, orderedIds, now?): { updated: number }`.
+- Consumes: structural store methods `getWorktreeMeta(id)` and `setWorktreeMeta(id, { sortOrder })`.
+- Runtime integration: skips cache invalidation and `notifyReposChanged()` when `updated === 0`.
+- Local integration: calls the same helper but retains `void` IPC behavior and the existing empty-input guard.
+- Test isolation: do not grow grandfathered `orca-runtime.test.ts` or `worktrees.test.ts`; use the focused new files above, and keep both grandfathered production files at or below their base line counts by replacing their existing loops with shorter delegations.
+
+- [ ] **Step 1: Add the runtime feedback-loop RED test**
+
+Create `src/main/runtime/orca-runtime-sort-order.test.ts`. Instantiate `OrcaRuntimeService` with a minimal structural store whose `setWorktreeMeta` updates an in-memory metadata map, subscribe with `onClientEvent`, and spy on the private cache invalidator through a narrow test-only structural cast. Do not attach a renderer notifier; the assertion must observe the remote client-event stream that drives the cross-host refresh.
+
+Add one sequential test with this exact lifecycle:
+
+```ts
+expect(runtime.persistManagedWorktreeSortOrder(['first', 'second'])).toEqual({ updated: 2 })
+expect(setWorktreeMeta).toHaveBeenCalledTimes(2)
+expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(1)
+expect(events).toEqual([{ type: 'reposChanged' }])
+
+expect(runtime.persistManagedWorktreeSortOrder(['first', 'second'])).toEqual({ updated: 0 })
+expect(setWorktreeMeta).toHaveBeenCalledTimes(2)
+expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(1)
+expect(events).toEqual([{ type: 'reposChanged' }])
+
+expect(runtime.persistManagedWorktreeSortOrder(['second', 'first'])).toEqual({ updated: 2 })
+expect(setWorktreeMeta).toHaveBeenCalledTimes(4)
+expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(2)
+expect(events).toEqual([{ type: 'reposChanged' }, { type: 'reposChanged' }])
+```
+
+Add a separate empty-input test that expects `{ updated: 0 }`, zero metadata writes, zero cache invalidations, and zero remote events.
+
+- [ ] **Step 2: Add the local IPC RED tests without growing the grandfathered suite**
+
+Create `src/main/ipc/worktrees-sort-order.test.ts`. Mock only Electron's `ipcMain.handle`/`removeHandler`, register `registerWorktreeHandlers` with structural `store` and `runtime` stubs, capture the actual `worktrees:persistSortOrder` callback, and assert:
+
+```ts
+const result = handler(null, { orderedIds: ['first', 'second'] })
+expect(result).toBeUndefined()
+expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+```
+
+Seed `getWorktreeMeta` with finite descending values. Add a second test for `orderedIds: []` proving the existing early return does not call `getWorktreeMeta` or `setWorktreeMeta` and remains `void`.
+
+- [ ] **Step 3: Run the integration tests RED**
+
+Run:
+
+```bash
+PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
+  --config config/vitest.config.ts \
+  src/main/runtime/orca-runtime-sort-order.test.ts \
+  src/main/ipc/worktrees-sort-order.test.ts
+```
+
+Expected: FAIL on the repeated runtime request, empty runtime request, and unchanged local request because the existing paths always rewrite and the runtime always invalidates/emits. The first-write, reorder, and local-empty assertions may already pass.
+
+- [ ] **Step 4: Add focused helper RED coverage**
+
+Create `src/main/worktree-sort-order-persistence.test.ts` before the module exists. Cover:
+
+- empty input and a singleton with any finite value return `{ updated: 0 }` without writes;
+- multiple finite values that are strictly descending, including non-1000 gaps, return `{ updated: 0 }` without writes;
+- missing, tied, non-finite, and non-descending values each rewrite every requested ID;
+- unrelated metadata outside `orderedIds` does not affect the decision;
+- a rewrite with injected `now = 5000` writes exactly `5000`, then `4000`, and returns the requested count.
+
+Run the test once and confirm it fails because the module is absent. Then create only a compiling throwing stub, rerun, and confirm the assertions still fail for the unimplemented behavior before writing the real implementation.
+
+- [ ] **Step 5: Implement the shared persistence module**
+
+Create `src/main/worktree-sort-order-persistence.ts`:
+
+```ts
+type WorktreeSortOrderStore = {
+  getWorktreeMeta(worktreeId: string): { sortOrder: number } | undefined
+  setWorktreeMeta(worktreeId: string, meta: { sortOrder: number }): unknown
+}
+
+function hasPersistedWorktreeSortOrder(
+  store: WorktreeSortOrderStore,
+  orderedIds: readonly string[]
+): boolean {
+  let previous = Number.POSITIVE_INFINITY
+  for (const id of orderedIds) {
+    const current = store.getWorktreeMeta(id)?.sortOrder
+    if (typeof current !== 'number' || !Number.isFinite(current) || current >= previous) {
+      return false
+    }
+    previous = current
+  }
+  return true
+}
+
+export function persistWorktreeSortOrderIfChanged(
+  store: WorktreeSortOrderStore,
+  orderedIds: readonly string[],
+  now = Date.now()
+): { updated: number } {
+  if (orderedIds.length === 0 || hasPersistedWorktreeSortOrder(store, orderedIds)) {
+    return { updated: 0 }
+  }
+  for (let index = 0; index < orderedIds.length; index += 1) {
+    store.setWorktreeMeta(orderedIds[index], { sortOrder: now - index * 1000 })
+  }
+  return { updated: orderedIds.length }
+}
+```
+
+- [ ] **Step 6: Integrate the runtime method**
+
+Import the helper from `../worktree-sort-order-persistence`, then replace the method body after the store guard with:
+
+```ts
+const result = persistWorktreeSortOrderIfChanged(this.store, orderedIds)
+if (result.updated === 0) {
+  // Why: refreshing unchanged timestamps would feed Smart sort back into this RPC.
+  return result
+}
+this.invalidateResolvedWorktreeCache()
+this.notifyReposChanged()
+return result
+```
+
+The new body plus import must not grow `src/main/runtime/orca-runtime.ts` relative to `origin/main`.
+
+- [ ] **Step 7: Integrate the local IPC handler**
+
+Import the helper from `../worktree-sort-order-persistence`, retain the existing malformed/empty guard, and replace the timestamp loop with:
+
+```ts
+persistWorktreeSortOrderIfChanged(store, args.orderedIds)
+```
+
+Do not return the helper result from the IPC handler.
+
+The shorter delegation must leave `src/main/ipc/worktrees.ts` at or below its `origin/main` line count.
+
+- [ ] **Step 8: Run GREEN**
+
+Run:
+
+```bash
+PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
+  --config config/vitest.config.ts \
+  src/main/worktree-sort-order-persistence.test.ts \
+  src/main/runtime/orca-runtime-sort-order.test.ts \
+  src/main/ipc/worktrees-sort-order.test.ts \
+  src/main/runtime/rpc/methods/worktree.test.ts
+```
+
+Expected: PASS, including first-write/repeat/reorder event sequencing, empty cache/event suppression, local `void` and early-return behavior, helper edge cases, and existing RPC result forwarding.
+
+Also run:
+
+```bash
+git diff --numstat origin/main -- \
+  src/main/runtime/orca-runtime.ts \
+  src/main/ipc/worktrees.ts
+```
+
+Expected: for each grandfathered production file, deleted lines are greater than or equal to added lines.
+
+- [ ] **Step 9: Commit the behavior fix**
+
+```bash
+git add \
+  src/main/worktree-sort-order-persistence.ts \
+  src/main/worktree-sort-order-persistence.test.ts \
+  src/main/runtime/orca-runtime.ts \
+  src/main/runtime/orca-runtime-sort-order.test.ts \
+  src/main/ipc/worktrees.ts \
+  src/main/ipc/worktrees-sort-order.test.ts
+git commit -m "fix: stop remote sort-order refresh loops"
+```
+
+---
+
+### Task 3: Verify, review, and publish the fix
+
+**Files:**
+- Inspect: all changes from `origin/main...HEAD`
+- Update only if review finds a confirmed defect: files named by that finding
+
+**Interfaces:**
+- Consumes: commits from Tasks 1 and 2.
+- Produces: a clean, source-backed PR linked to issue `#8272`.
+
+- [ ] **Step 1: Run focused behavioral tests**
+
+```bash
+PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
+  --config config/vitest.config.ts \
+  src/renderer/src/store/slices/repos-all-hosts.test.ts \
+  src/renderer/src/store/slices/repos-stale-fetch.test.ts \
+  src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts \
+  src/renderer/src/hooks/runtime-client-events-sync.test.ts \
+  src/renderer/src/components/sidebar/host-section-rows.test.ts \
+  src/main/worktree-sort-order-persistence.test.ts \
+  src/main/runtime/orca-runtime-sort-order.test.ts \
+  src/main/ipc/worktrees-sort-order.test.ts \
+  src/main/runtime/orca-runtime.test.ts \
+  src/main/runtime/rpc/methods/worktree.test.ts \
+  src/main/ipc/worktrees.test.ts
+```
+
+Expected: all selected files pass with zero failed tests.
+
+- [ ] **Step 2: Run repository gates**
+
+```bash
+PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm lint
+PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm typecheck
+PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm check:max-lines-ratchet
+PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm build
+git diff --check origin/main...HEAD
+```
+
+Expected: every command exits `0`; no max-lines baseline entry is added.
+
+- [ ] **Step 3: Inspect scope and privacy**
+
+```bash
+git status --short --branch
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- \
+  src/main \
+  src/renderer/src/store/slices/repos-all-hosts.test.ts \
+  docs/superpowers
+```
+
+Confirm the diff contains no renderer UI edit, dependency change, protocol schema change, or incident identifier. Record that dual-host installation smoke was not run unless both hosts were explicitly updated to this build.
+
+- [ ] **Step 4: Request an independent code review**
+
+Provide the reviewer with:
+
+```text
+Base: origin/main
+Head: HEAD
+Requirements: docs/superpowers/specs/2026-07-11-remote-host-refresh-loop-design.md
+Focus: idempotency correctness, notification/cache semantics, local void contract, cross-host race test, privacy, and max-lines compliance.
+```
+
+Fix every confirmed Critical or Important finding, then rerun Steps 1-3.
+
+- [ ] **Step 5: Push and open the linked PR**
+
+Push the branch to the authenticated fork and create a PR into `stablyai/orca:main`. The body must include:
+
+```markdown
+## Summary
+- preserve runtime repo rows when an older local refresh finishes last
+- make local and runtime Smart-order persistence idempotent
+- notify remote clients only when the effective order changes
+
+## Testing
+- focused Vitest suite
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm check:max-lines-ratchet`
+- `pnpm build`
+
+## Runtime note
+The metadata write occurs on the owner runtime. Both hosts must run a build containing this fix for dual-host validation; a client-only update does not stop the loop against an older runtime.
+
+Fixes #8272
+```
+
+After creation, verify the PR base/head branches, issue linkage, CI start, and that no sensitive incident data appears in the public diff or body.

--- a/docs/superpowers/plans/2026-07-11-remote-host-refresh-loop.md
+++ b/docs/superpowers/plans/2026-07-11-remote-host-refresh-loop.md
@@ -23,7 +23,7 @@
 ### Task 1: Lock the cross-host repo race regression
 
 **Files:**
-- Modify: `src/renderer/src/store/slices/repos-all-hosts.test.ts`
+- Modify: `src/renderer/src/store/slices/repos-stale-fetch.test.ts`
 
 **Interfaces:**
 - Consumes: `fetchRepos(): Promise<void>` and `fetchRuntimeEnvironmentRepos(environmentId: string): Promise<Repo[]>` from `RepoSlice`.
@@ -31,24 +31,16 @@
 
 - [ ] **Step 1: Add the overlap regression**
 
-Add this test inside `describe('fetchReposForAllHosts', ...)`, next to the existing targeted-runtime latest-state test:
+Add this test to the focused stale-fetch suite. Extend its `window.api` fixture with the minimal compatible `runtimeEnvironments.call` responses needed by `fetchRuntimeEnvironmentRepos`; do not grow the near-limit all-host test file.
 
 ```ts
 it('preserves a runtime catalog when an older local refresh finishes last', async () => {
-  let resolveLocal!: (repos: Repo[]) => void
-  const localResponse = new Promise<Repo[]>((resolve) => {
-    resolveLocal = resolve
-  })
+  const { promise: localResponse, resolve: resolveLocal } = Promise.withResolvers<Repo[]>()
   reposList.mockReturnValueOnce(localResponse)
   const store = createTestStore()
 
   const localLoad = store.getState().fetchRepos()
   await store.getState().fetchRuntimeEnvironmentRepos('env-1')
-
-  expect(store.getState().repos).toEqual([
-    { ...remoteRepo, executionHostId: 'runtime:env-1' }
-  ])
-
   resolveLocal([localRepo])
   await localLoad
 
@@ -66,7 +58,7 @@ Run:
 ```bash
 PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run \
   --config config/vitest.config.ts \
-  src/renderer/src/store/slices/repos-all-hosts.test.ts
+  src/renderer/src/store/slices/repos-stale-fetch.test.ts
 ```
 
 Expected: PASS. This is coverage for the latest-state merge already delivered by `25ecf2eea`; no repo-slice production edit follows.
@@ -74,7 +66,7 @@ Expected: PASS. This is coverage for the latest-state merge already delivered by
 - [ ] **Step 3: Commit the regression**
 
 ```bash
-git add src/renderer/src/store/slices/repos-all-hosts.test.ts
+git add src/renderer/src/store/slices/repos-stale-fetch.test.ts
 git commit -m "test: cover cross-host repo refresh race"
 ```
 

--- a/docs/superpowers/specs/2026-07-11-remote-host-refresh-loop-design.md
+++ b/docs/superpowers/specs/2026-07-11-remote-host-refresh-loop-design.md
@@ -1,0 +1,141 @@
+# Remote Host Refresh Loop Design
+
+**Issue:** [#8272](https://github.com/stablyai/orca/issues/8272)
+
+**Review state:** The implementation direction was approved on 2026-07-11; this written specification is awaiting final review before implementation planning.
+
+## Problem
+
+A macOS client connected to a Windows Orca runtime can briefly show the runtime's projects and then lose the runtime host section even though the connection and remote catalog remain healthy. The same session can also enter a Smart-order feedback loop that repeatedly rewrites remote `sortOrder` metadata, refreshes the remote catalog, and keeps the renderer busy.
+
+The incident exposed two related defects:
+
+1. Orca v1.4.135 merged local and runtime repo catalogs against a `repos` snapshot captured before an asynchronous fetch. A late local result could overwrite runtime repos added by an earlier-completing runtime result. Commit `25ecf2eea` already changed `main` to merge each catalog inside the Zustand state updater against the latest `state.repos`, but the local-versus-runtime overlap has no dedicated regression test.
+2. Smart ordering persists every recomputed `sortedIds` array to its owner host. The runtime always writes fresh timestamp-based `sortOrder` values and emits `reposChanged`, even when the effective order is unchanged. The client refreshes worktrees, sees the changed timestamps, increments `sortEpoch`, recomputes `sortedIds`, and persists again.
+
+## Goals
+
+- Preserve repos from every host when local and runtime catalog requests resolve out of order.
+- Make persistence of an already-recorded per-host worktree order a no-op.
+- Emit runtime catalog invalidation only when persistence changes the effective order.
+- Use the same idempotent persistence behavior for local IPC and runtime RPC callers.
+- Keep the runtime protocol compatible: `worktree.persistSortOrder` continues returning `{ updated: number }`, with `0` meaning no change.
+- Add tests that use synthetic identifiers and contain no private incident data.
+
+## Non-goals
+
+- Redesign Smart ordering, its attention classes, or its three-second settle window.
+- Change runtime pairing, transport, heartbeat, or reconnect behavior.
+- Add UI state, preferences, telemetry, dependencies, or platform-specific branches.
+- Rework project grouping or host-header presentation.
+- Duplicate the latest-state repo merge already present on `main`.
+
+## Constraints
+
+- The behavior must remain portable across macOS, Linux, and Windows and must work when the owner host is reached over the runtime transport.
+- No change may add a max-lines suppression or grow a grandfathered file without compensating extraction.
+- `WorktreeList.tsx` remains unchanged; it is already grandfathered by the max-lines ratchet.
+- Existing runtime error behavior remains unchanged: an unavailable store still raises `runtime_unavailable`, and malformed RPC input remains rejected by the existing schema.
+- The public issue, tests, commit, and PR must omit network addresses, usernames, hostnames, local paths, runtime/device IDs, and repository names from the observed environment.
+
+## Design
+
+### Shared idempotent persistence
+
+Create `src/main/worktree-sort-order-persistence.ts` with a small store-facing function:
+
+```ts
+type WorktreeSortOrderStore = {
+  getWorktreeMeta(worktreeId: string): { sortOrder: number } | undefined
+  setWorktreeMeta(worktreeId: string, meta: { sortOrder: number }): unknown
+}
+
+export function persistWorktreeSortOrderIfChanged(
+  store: WorktreeSortOrderStore,
+  orderedIds: readonly string[],
+  now: number = Date.now()
+): { updated: number }
+```
+
+The requested order is already persisted when every requested worktree has a finite `sortOrder` and those values are strictly descending in `orderedIds` order. Strict descent matters: equal or missing values cannot reliably restore the requested order after restart.
+
+When the order is already persisted, the function returns `{ updated: 0 }` without calling `setWorktreeMeta`. Otherwise it assigns `now - index * 1000` to every requested ID and returns the number written. Comparing relative order instead of exact timestamps makes repeated calls idempotent while preserving the existing cold-start ordering representation.
+
+The function intentionally evaluates only the IDs in the request. Hidden, archived, or other-host worktrees are outside that host-specific ordering request and must not force a rewrite.
+
+### Local IPC integration
+
+Replace the timestamp loop in `worktrees:persistSortOrder` with the shared function. The handler keeps its existing empty-input guard and return behavior. Local persistence does not emit a catalog event today, and this design does not add one; it only avoids redundant metadata writes.
+
+### Runtime RPC integration
+
+Replace `OrcaRuntimeService.persistManagedWorktreeSortOrder`'s timestamp loop with the shared function. When `updated === 0`, return immediately without invalidating the resolved-worktree cache or calling `notifyReposChanged()`. When `updated > 0`, retain the current cache invalidation and notification behavior exactly once.
+
+This terminates the feedback loop after at most one confirming no-op request:
+
+1. A changed order is persisted and emits `reposChanged`.
+2. The client refreshes and recomputes the same effective order.
+3. The follow-up persistence call returns `updated: 0` and emits no event.
+4. No further refresh is scheduled by this path.
+
+### Repo catalog regression coverage
+
+Add a store-level test that starts a deferred local `fetchRepos()`, completes `fetchRuntimeEnvironmentRepos()` first, and then completes the older local request. The final state must contain both local and runtime repos with their correct execution-host ownership.
+
+The test guards the latest-state merge already present on `main`. It should fail against the v1.4.135 implementation and pass without additional production changes to the repo slice.
+
+## Error Handling and Compatibility
+
+- Store absence continues to throw before persistence is attempted.
+- A no-op is a successful RPC response, not an error or timeout.
+- The response schema is unchanged; clients that only inspect `updated` remain compatible.
+- A real reorder still rewrites the complete requested host order, invalidates the runtime cache, and notifies connected clients.
+- Failed RPCs are not hidden or memoized in the renderer because no renderer-side deduplication state is introduced.
+
+## Testing
+
+### Required red-green coverage
+
+- Runtime persistence writes and notifies for the first effective order.
+- Repeating the same effective order returns `updated: 0`, performs no writes, and emits no second notification.
+- Reordering the same IDs writes again and emits one new notification.
+- Missing or tied stored order values are rewritten because they do not encode a stable requested order.
+
+The repeated-order runtime test must fail against the pre-change implementation before production code is modified.
+
+### Required regression coverage
+
+- A late local repo fetch cannot remove a runtime repo that completed first.
+- Existing runtime RPC dispatch coverage continues to return the runtime method result.
+- Existing scheduler, runtime-client-event, host-section, repo, and worktree tests remain green.
+
+### Repository checks
+
+- Focused Vitest tests for the new module, runtime method, repo race, RPC dispatch, scheduler, and host-section behavior.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm check:max-lines-ratchet`
+- `git diff --check`
+- A sanitized dual-host smoke test when a build containing the change is available; if no installable build is produced locally, record that limitation in the PR.
+
+All Node-based checks must run with the repository-required Node 24 toolchain.
+
+## Alternatives Considered
+
+### Renderer-side last-order tracking
+
+Remembering the last request in `WorktreeList` would avoid calls to older servers, but it needs explicit pending, failure, retry, and remount semantics. It also adds state around an already oversized component. Server-side idempotency is smaller and protects every RPC caller.
+
+### Remove `notifyReposChanged()` unconditionally
+
+This would stop the loop but would prevent other connected clients from learning about a real order change. Conditional notification preserves the existing synchronization contract.
+
+### Exact timestamp comparison
+
+Exact timestamps are regenerated on every write and therefore cannot establish idempotency. The persisted contract is relative order, so relative monotonicity is the correct comparison.
+
+## Delivery
+
+- One implementation PR from `bbingz/fix-8272-remote-host-refresh-loop` to `stablyai/orca:main`.
+- The PR body uses `Fixes #8272` and contains only sanitized reproduction evidence.
+- Commits remain scoped to the design/specification, tests, shared persistence behavior, and necessary call-site integration.

--- a/docs/superpowers/specs/2026-07-11-remote-host-refresh-loop-design.md
+++ b/docs/superpowers/specs/2026-07-11-remote-host-refresh-loop-design.md
@@ -142,6 +142,6 @@ Exact timestamps are regenerated on every write and therefore cannot establish i
 
 ## Delivery
 
-- One implementation PR from `bbingz/fix-8272-remote-host-refresh-loop` to `stablyai/orca:main`.
+- One implementation PR from the feature branch to the upstream default branch.
 - The PR body uses `Fixes #8272` and contains only sanitized reproduction evidence.
 - Commits remain scoped to the design/specification, tests, shared persistence behavior, and necessary call-site integration.

--- a/docs/superpowers/specs/2026-07-11-remote-host-refresh-loop-design.md
+++ b/docs/superpowers/specs/2026-07-11-remote-host-refresh-loop-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#8272](https://github.com/stablyai/orca/issues/8272)
 
-**Review state:** The implementation direction was approved on 2026-07-11; this written specification is awaiting final review before implementation planning.
+**Review state:** Approved for implementation on 2026-07-11 after an independent Grok review.
 
 ## Problem
 
@@ -37,6 +37,7 @@ The incident exposed two related defects:
 - `WorktreeList.tsx` remains unchanged; it is already grandfathered by the max-lines ratchet.
 - Existing runtime error behavior remains unchanged: an unavailable store still raises `runtime_unavailable`, and malformed RPC input remains rejected by the existing schema.
 - The public issue, tests, commit, and PR must omit network addresses, usernames, hostnames, local paths, runtime/device IDs, and repository names from the observed environment.
+- The owner runtime performs the remote metadata write. Dual-host validation and release notes must make clear that updating only the client does not stop the loop against an older runtime; both test hosts must run a build containing the fix.
 
 ## Design
 
@@ -59,17 +60,21 @@ export function persistWorktreeSortOrderIfChanged(
 
 The requested order is already persisted when every requested worktree has a finite `sortOrder` and those values are strictly descending in `orderedIds` order. Strict descent matters: equal or missing values cannot reliably restore the requested order after restart.
 
+Strict descent is the complete idempotency contract; existing values do not need to be exactly 1000 milliseconds apart. A one-item request with any finite `sortOrder` is already persisted. Empty input returns `{ updated: 0 }`. Missing, non-finite, tied, or non-descending values force a full rewrite of the requested IDs.
+
 When the order is already persisted, the function returns `{ updated: 0 }` without calling `setWorktreeMeta`. Otherwise it assigns `now - index * 1000` to every requested ID and returns the number written. Comparing relative order instead of exact timestamps makes repeated calls idempotent while preserving the existing cold-start ordering representation.
 
-The function intentionally evaluates only the IDs in the request. Hidden, archived, or other-host worktrees are outside that host-specific ordering request and must not force a rewrite.
+The function intentionally evaluates only the IDs in the request. Hidden, archived, or other-host worktrees are outside that host-specific ordering request and must not force a rewrite. The production caller supplies unique IDs; duplicate-ID validation is outside this change, so duplicate requests retain the existing rewrite behavior rather than gaining new protocol semantics.
 
 ### Local IPC integration
 
-Replace the timestamp loop in `worktrees:persistSortOrder` with the shared function. The handler keeps its existing empty-input guard and return behavior. Local persistence does not emit a catalog event today, and this design does not add one; it only avoids redundant metadata writes.
+Replace the timestamp loop in `worktrees:persistSortOrder` with the shared function. The handler keeps its existing empty-input guard and `void` return behavior; it must not change the preload contract merely to match the runtime RPC result. Local persistence does not emit a catalog event today, and this design does not add one; it only avoids redundant metadata writes.
 
 ### Runtime RPC integration
 
 Replace `OrcaRuntimeService.persistManagedWorktreeSortOrder`'s timestamp loop with the shared function. When `updated === 0`, return immediately without invalidating the resolved-worktree cache or calling `notifyReposChanged()`. When `updated > 0`, retain the current cache invalidation and notification behavior exactly once.
+
+Unlike the local IPC handler, the runtime method currently reaches cache invalidation and notification for an empty array. The shared function's `{ updated: 0 }` result must make that path an explicit no-op, and a runtime-level test must cover it.
 
 This terminates the feedback loop after at most one confirming no-op request:
 
@@ -100,6 +105,7 @@ The test guards the latest-state merge already present on `main`. It should fail
 - Repeating the same effective order returns `updated: 0`, performs no writes, and emits no second notification.
 - Reordering the same IDs writes again and emits one new notification.
 - Missing or tied stored order values are rewritten because they do not encode a stable requested order.
+- An empty runtime request returns `updated: 0` without cache invalidation or notification, while the local IPC handler remains `void` and keeps its existing early return.
 
 The repeated-order runtime test must fail against the pre-change implementation before production code is modified.
 
@@ -116,7 +122,7 @@ The repeated-order runtime test must fail against the pre-change implementation 
 - `pnpm typecheck`
 - `pnpm check:max-lines-ratchet`
 - `git diff --check`
-- A sanitized dual-host smoke test when a build containing the change is available; if no installable build is produced locally, record that limitation in the PR.
+- A sanitized dual-host smoke test with both client and owner runtime running a build containing the change; if no installable build is produced locally, record that limitation in the PR.
 
 All Node-based checks must run with the repository-required Node 24 toolchain.
 

--- a/src/main/ipc/worktrees-sort-order.test.ts
+++ b/src/main/ipc/worktrees-sort-order.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, removeHandlerMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock,
+    removeHandler: removeHandlerMock
+  }
+}))
+
+import { registerWorktreeHandlers } from './worktrees'
+
+type PersistSortOrderHandler = (event: unknown, args: { orderedIds: string[] }) => unknown
+
+function getPersistSortOrderHandler(): PersistSortOrderHandler {
+  const registration = handleMock.mock.calls.find(
+    ([channel]) => channel === 'worktrees:persistSortOrder'
+  )
+  expect(registration).toBeDefined()
+  return registration?.[1] as PersistSortOrderHandler
+}
+
+function registerWithMetadata(entries: readonly (readonly [string, number])[]) {
+  const metadata = new Map(entries.map(([id, sortOrder]) => [id, { sortOrder }]))
+  const store = {
+    getWorktreeMeta: vi.fn((worktreeId: string) => metadata.get(worktreeId)),
+    setWorktreeMeta: vi.fn()
+  }
+  registerWorktreeHandlers({} as never, store as never, {} as never)
+  return { handler: getPersistSortOrderHandler(), store }
+}
+
+describe('worktrees:persistSortOrder', () => {
+  beforeEach(() => {
+    handleMock.mockClear()
+    removeHandlerMock.mockClear()
+  })
+
+  it('keeps an unchanged finite descending order without metadata writes', () => {
+    const { handler, store } = registerWithMetadata([
+      ['first', 5000],
+      ['second', 4000]
+    ])
+
+    const result = handler(null, { orderedIds: ['first', 'second'] })
+
+    expect(result).toBeUndefined()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('keeps empty input as a void early return without metadata reads or writes', () => {
+    const { handler, store } = registerWithMetadata([])
+
+    const result = handler(null, { orderedIds: [] })
+
+    expect(result).toBeUndefined()
+    expect(store.getWorktreeMeta).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -4,6 +4,7 @@ import { ipcMain } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
+import { persistWorktreeSortOrderIfChanged } from '../worktree-sort-order-persistence'
 import { isFolderRepo } from '../../shared/repo-kind'
 import {
   isWorkspaceKey,
@@ -2066,13 +2067,7 @@ export function registerWorktreeHandlers(
     if (!Array.isArray(args?.orderedIds) || args.orderedIds.length === 0) {
       return
     }
-    const now = Date.now()
-    for (let i = 0; i < args.orderedIds.length; i++) {
-      // Descending timestamps so that the first item has the highest
-      // sortOrder value (most recent), making b.sortOrder - a.sortOrder
-      // a natural "first wins" comparator on cold start.
-      store.setWorktreeMeta(args.orderedIds[i], { sortOrder: now - i * 1000 })
-    }
+    persistWorktreeSortOrderIfChanged(store, args.orderedIds)
   })
 
   ipcMain.handle(

--- a/src/main/runtime/orca-runtime-sort-order.test.ts
+++ b/src/main/runtime/orca-runtime-sort-order.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeClientEvent } from '../../shared/runtime-client-events'
+import { OrcaRuntimeService } from './orca-runtime'
+
+function makeRuntime() {
+  const metadata = new Map<string, { sortOrder: number }>()
+  const setWorktreeMeta = vi.fn((worktreeId: string, meta: { sortOrder: number }) => {
+    metadata.set(worktreeId, meta)
+  })
+  const store = {
+    getWorktreeMeta: vi.fn((worktreeId: string) => metadata.get(worktreeId)),
+    setWorktreeMeta
+  }
+  const runtime = new OrcaRuntimeService(store as never)
+  const invalidateResolvedWorktreeCache = vi.spyOn(
+    runtime as unknown as { invalidateResolvedWorktreeCache: () => void },
+    'invalidateResolvedWorktreeCache'
+  )
+  const events: RuntimeClientEvent[] = []
+  runtime.onClientEvent((event) => events.push(event))
+
+  return { events, invalidateResolvedWorktreeCache, runtime, setWorktreeMeta }
+}
+
+describe('OrcaRuntimeService sort-order persistence', () => {
+  it('emits remote refreshes only when the requested order changes', () => {
+    const { events, invalidateResolvedWorktreeCache, runtime, setWorktreeMeta } = makeRuntime()
+
+    expect(runtime.persistManagedWorktreeSortOrder(['first', 'second'])).toEqual({ updated: 2 })
+    expect(setWorktreeMeta).toHaveBeenCalledTimes(2)
+    expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(1)
+    expect(events).toEqual([{ type: 'reposChanged' }])
+
+    expect(runtime.persistManagedWorktreeSortOrder(['first', 'second'])).toEqual({ updated: 0 })
+    expect(setWorktreeMeta).toHaveBeenCalledTimes(2)
+    expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(1)
+    expect(events).toEqual([{ type: 'reposChanged' }])
+
+    expect(runtime.persistManagedWorktreeSortOrder(['second', 'first'])).toEqual({ updated: 2 })
+    expect(setWorktreeMeta).toHaveBeenCalledTimes(4)
+    expect(invalidateResolvedWorktreeCache).toHaveBeenCalledTimes(2)
+    expect(events).toEqual([{ type: 'reposChanged' }, { type: 'reposChanged' }])
+  })
+
+  it('does not write, invalidate, or emit for empty input', () => {
+    const { events, invalidateResolvedWorktreeCache, runtime, setWorktreeMeta } = makeRuntime()
+
+    expect(runtime.persistManagedWorktreeSortOrder([])).toEqual({ updated: 0 })
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
+    expect(invalidateResolvedWorktreeCache).not.toHaveBeenCalled()
+    expect(events).toEqual([])
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -67,6 +67,7 @@ import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
 import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
+import { persistWorktreeSortOrderIfChanged } from '../worktree-sort-order-persistence'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
 import { OrchestrationDb } from './orchestration/db'
 import { formatMessagesForInjection } from './orchestration/formatter'
@@ -16284,15 +16285,14 @@ export class OrcaRuntimeService {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
-    const now = Date.now()
-    let updated = 0
-    for (let i = 0; i < orderedIds.length; i++) {
-      this.store.setWorktreeMeta(orderedIds[i], { sortOrder: now - i * 1000 })
-      updated++
+    const result = persistWorktreeSortOrderIfChanged(this.store, orderedIds)
+    if (result.updated === 0) {
+      // Why: refreshing unchanged timestamps would feed Smart sort back into this RPC.
+      return result
     }
     this.invalidateResolvedWorktreeCache()
     this.notifyReposChanged()
-    return { updated }
+    return result
   }
 
   async resolveManagedPrBase(args: {

--- a/src/main/worktree-sort-order-persistence.test.ts
+++ b/src/main/worktree-sort-order-persistence.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import { persistWorktreeSortOrderIfChanged } from './worktree-sort-order-persistence'
+
+function makeStore(entries: readonly (readonly [string, number])[] = []) {
+  const metadata = new Map(entries.map(([id, sortOrder]) => [id, { sortOrder }]))
+  return {
+    getWorktreeMeta: vi.fn((worktreeId: string) => metadata.get(worktreeId)),
+    setWorktreeMeta: vi.fn()
+  }
+}
+
+describe('persistWorktreeSortOrderIfChanged', () => {
+  it('keeps empty input without metadata reads or writes', () => {
+    const store = makeStore()
+
+    expect(persistWorktreeSortOrderIfChanged(store, [])).toEqual({ updated: 0 })
+    expect(store.getWorktreeMeta).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('keeps a singleton with a finite sort order without writes', () => {
+    const store = makeStore([['first', 42.5]])
+
+    expect(persistWorktreeSortOrderIfChanged(store, ['first'])).toEqual({ updated: 0 })
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('keeps strictly descending finite values with arbitrary gaps', () => {
+    const store = makeStore([
+      ['first', 9000],
+      ['second', 8999],
+      ['third', 100]
+    ])
+
+    expect(persistWorktreeSortOrderIfChanged(store, ['first', 'second', 'third'])).toEqual({
+      updated: 0
+    })
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      label: 'missing',
+      entries: [['first', 3000]] as const
+    },
+    {
+      label: 'tied',
+      entries: [
+        ['first', 3000],
+        ['second', 3000]
+      ] as const
+    },
+    {
+      label: 'non-finite',
+      entries: [
+        ['first', Number.NaN],
+        ['second', 2000]
+      ] as const
+    },
+    {
+      label: 'non-descending',
+      entries: [
+        ['first', 1000],
+        ['second', 2000]
+      ] as const
+    }
+  ])('rewrites every requested ID for $label values', ({ entries }) => {
+    const store = makeStore(entries)
+
+    expect(persistWorktreeSortOrderIfChanged(store, ['first', 'second'], 8000)).toEqual({
+      updated: 2
+    })
+    expect(store.setWorktreeMeta.mock.calls.map(([worktreeId]) => worktreeId)).toEqual([
+      'first',
+      'second'
+    ])
+  })
+
+  it('ignores metadata outside the requested IDs', () => {
+    const store = makeStore([
+      ['first', 5000],
+      ['second', 4500],
+      ['unrelated', Number.NaN]
+    ])
+
+    expect(persistWorktreeSortOrderIfChanged(store, ['first', 'second'])).toEqual({ updated: 0 })
+    expect(store.getWorktreeMeta).toHaveBeenCalledTimes(2)
+    expect(store.getWorktreeMeta).not.toHaveBeenCalledWith('unrelated')
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('writes descending timestamps from an injected clock', () => {
+    const store = makeStore()
+
+    expect(persistWorktreeSortOrderIfChanged(store, ['first', 'second'], 5000)).toEqual({
+      updated: 2
+    })
+    expect(store.setWorktreeMeta).toHaveBeenNthCalledWith(1, 'first', { sortOrder: 5000 })
+    expect(store.setWorktreeMeta).toHaveBeenNthCalledWith(2, 'second', { sortOrder: 4000 })
+    expect(store.setWorktreeMeta).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/worktree-sort-order-persistence.ts
+++ b/src/main/worktree-sort-order-persistence.ts
@@ -1,0 +1,33 @@
+type WorktreeSortOrderStore = {
+  getWorktreeMeta(worktreeId: string): { sortOrder: number } | undefined
+  setWorktreeMeta(worktreeId: string, meta: { sortOrder: number }): unknown
+}
+
+function hasPersistedWorktreeSortOrder(
+  store: WorktreeSortOrderStore,
+  orderedIds: readonly string[]
+): boolean {
+  let previous = Number.POSITIVE_INFINITY
+  for (const id of orderedIds) {
+    const current = store.getWorktreeMeta(id)?.sortOrder
+    if (typeof current !== 'number' || !Number.isFinite(current) || current >= previous) {
+      return false
+    }
+    previous = current
+  }
+  return true
+}
+
+export function persistWorktreeSortOrderIfChanged(
+  store: WorktreeSortOrderStore,
+  orderedIds: readonly string[],
+  now = Date.now()
+): { updated: number } {
+  if (orderedIds.length === 0 || hasPersistedWorktreeSortOrder(store, orderedIds)) {
+    return { updated: 0 }
+  }
+  for (let index = 0; index < orderedIds.length; index += 1) {
+    store.setWorktreeMeta(orderedIds[index], { sortOrder: now - index * 1000 })
+  }
+  return { updated: orderedIds.length }
+}

--- a/src/main/worktree-sort-order-persistence.ts
+++ b/src/main/worktree-sort-order-persistence.ts
@@ -10,6 +10,7 @@ function hasPersistedWorktreeSortOrder(
   let previous = Number.POSITIVE_INFINITY
   for (const id of orderedIds) {
     const current = store.getWorktreeMeta(id)?.sortOrder
+    // Why: timestamp gaps are a write format; idempotency only requires relative order.
     if (typeof current !== 'number' || !Number.isFinite(current) || current >= previous) {
       return false
     }

--- a/src/renderer/src/store/slices/repos-stale-fetch.test.ts
+++ b/src/renderer/src/store/slices/repos-stale-fetch.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { createTestStore } from './store-test-helpers'
 import type { Repo } from '../../../../shared/types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
 import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
 
 const localRepo: Repo = {
@@ -20,13 +24,40 @@ const remoteRepo: Repo = {
 }
 
 const reposList = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
 
 beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
   reposList.mockReset()
-  // Only repos.list is exercised here — the missing projects API makes
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    const compatibleStatus = createCompatibleRuntimeStatusResponseIfNeeded(args)
+    if (compatibleStatus) {
+      return compatibleStatus
+    }
+    if (args.method === 'repo.list') {
+      return {
+        id: 'rpc-repo-list',
+        ok: true,
+        result: { repos: [remoteRepo] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    }
+    return {
+      id: 'rpc-other',
+      ok: true,
+      result: { projects: [], setups: [] },
+      _meta: { runtimeId: 'runtime-remote' }
+    }
+  })
+  // Local fetches only exercise repos.list — the missing projects API makes
   // fetchProjectHostSetupCompatibility fall back to deriving from repos.
-  vi.stubGlobal('window', { api: { repos: { list: reposList } } })
+  vi.stubGlobal('window', {
+    api: {
+      repos: { list: reposList },
+      runtimeEnvironments: { call: runtimeEnvironmentCall }
+    }
+  })
 })
 
 // A repos:changed burst (deleting a project group with contained projects) starts
@@ -73,5 +104,23 @@ describe('repos slice stale-fetch race (#7020)', () => {
     resolveStale([localRepo, remoteRepo])
     await stale
     expect(store.getState().repos).toEqual([])
+  })
+})
+
+describe('repos slice cross-host stale-fetch race (#8272)', () => {
+  it('preserves a runtime catalog when an older local refresh finishes last', async () => {
+    const { promise: localResponse, resolve: resolveLocal } = Promise.withResolvers<Repo[]>()
+    reposList.mockReturnValueOnce(localResponse)
+    const store = createTestStore()
+
+    const localLoad = store.getState().fetchRepos()
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+    resolveLocal([localRepo])
+    await localLoad
+
+    expect(store.getState().repos).toEqual([
+      { ...remoteRepo, executionHostId: 'runtime:env-1' },
+      { ...localRepo, executionHostId: 'local' }
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- add a regression for an older local repo refresh completing after a runtime refresh
- make local and runtime Smart-order persistence idempotent
- invalidate and notify remote clients only when the effective order changes

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (exit 0; existing warnings remain in untouched files)
- [x] `pnpm typecheck`
- [ ] `pnpm test` — not run repository-wide; the focused suite passed 11 files and 906 tests
- [ ] `pnpm build` — desktop and web completed, but the unchanged native aggregation failed as described below
- [x] Added focused regression, helper edge-case, runtime event/cache, IPC contract, and RPC forwarding coverage
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff --check origin/main...HEAD`

## AI Review Report

- Grok reviewed and approved the written design before implementation.
- Independent task reviews and a final whole-branch review checked idempotency boundaries, runtime cache and local/remote notification behavior, the local IPC `void` contract, the cross-host fetch race, privacy, and max-lines compliance. One minor request for a why-comment was fixed and re-reviewed; no Critical or Important findings remain.
- CodeRabbit completed with no actionable comments.
- Cross-platform review explicitly checked macOS, Linux, and Windows behavior. This change adds no shortcuts, labels, shell commands, platform paths, or OS-specific branches; the owner-runtime path remains valid over SSH/runtime transport.

## Security Audit

- No dependency, authentication, pairing, protocol, command-execution, filesystem-path, or secret-handling changes.
- The existing malformed/empty IPC guard remains in place; the new helper only reads and updates requested worktree metadata IDs.
- The tracked diff and PR body were scanned for incident IPs, usernames, hostnames, local paths, runtime/device IDs, repository names, tokens, and private keys; no incident-sensitive values remain.

## Notes

- The metadata write occurs on the owner runtime. Both the client and owner runtime must run a build containing this fix for dual-host validation; a client-only update does not stop the loop against an older runtime.
- Dual-host installation smoke was not run because no local installable build was produced.
- `pnpm build` completed the desktop and web stages, then stopped in the unchanged native build script: the selected Xcode beta / Swift 6.4 toolchain reports `.build/out/Products/Release`, while the script expects `.build/<triple>/release`. PR CI on the supported toolchain remains the build gate.
- The upstream `PR Checks` workflow is awaiting maintainer approval for this fork PR.

Fixes #8272
