### PR TITLE
feat(mobile): report paired device identity

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -32,6 +32,7 @@
     "expo-constants": "^55.0.16",
     "expo-crypto": "^55.0.14",
     "expo-dev-client": "~55.0.35",
+    "expo-device": "^55.0.14",
     "expo-document-picker": "^55.0.13",
     "expo-file-system": "55.0.19",
     "expo-haptics": "^55.0.14",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       expo-dev-client:
         specifier: ~55.0.35
         version: 55.0.35(expo@55.0.27)
+      expo-device:
+        specifier: ^55.0.14
+        version: 55.0.18(expo@55.0.27)
       expo-document-picker:
         specifier: ^55.0.13
         version: 55.0.13(expo@55.0.27)
@@ -4203,6 +4206,11 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-device@55.0.18:
+    resolution: {integrity: sha512-MEdnb+Si3VICmJzzSVsQyo90LQg8cG5h9to2tcaHFXPX31yOolYJXbHGN5bmR9MjKOgw6d6h7Ow/kMTnSwZrPQ==}
+    peerDependencies:
+      expo: '*'
+
   expo-document-picker@55.0.13:
     resolution: {integrity: sha512-IhswJElhdzs3fKDEKW8KXYRoFkWGEsXRMYAZT46Yo56zqqy8yQXrczo33RSwD2hFzNQBdLT97SJL9N311UyS3g==}
     peerDependencies:
@@ -6659,6 +6667,10 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ua-parser-js@0.7.41:
+    resolution: {integrity: sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==}
     hasBin: true
 
   ua-parser-js@1.0.41:
@@ -11878,6 +11890,11 @@ snapshots:
       expo: 55.0.27(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       expo-dev-menu-interface: 55.0.2(expo@55.0.27)
 
+  expo-device@55.0.18(expo@55.0.27):
+    dependencies:
+      expo: 55.0.27(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      ua-parser-js: 0.7.41
+
   expo-document-picker@55.0.13(expo@55.0.27):
     dependencies:
       expo: 55.0.27(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
@@ -14961,6 +14978,8 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  ua-parser-js@0.7.41: {}
 
   ua-parser-js@1.0.41: {}
 

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -19,6 +19,9 @@ vi.mock('./host-store', () => ({
 vi.mock('./connection-revival-triggers', () => ({
   subscribeConnectionRevivalTriggers: () => () => {}
 }))
+vi.mock('./device-identity', () => ({
+  resolveMobileDeviceDisplayName: () => 'Test Phone'
+}))
 
 import { RpcClientProvider, useCloseHost, useForceReconnect, useHostClient } from './client-context'
 
@@ -220,7 +223,12 @@ describe('useHostClient', () => {
     loadHostsMock.mockResolvedValue([HOST])
 
     const harness = await renderHarness(HOST.id)
-    expect(harness.hook.client).not.toBeNull()
+    expect(connectMock).toHaveBeenCalledWith(
+      HOST,
+      expect.any(Function),
+      expect.objectContaining({ deviceName: 'Test Phone' })
+    )
+    expect(harness.hook.client).toBe(fake)
     expect(harness.hook.state).toBe('connected')
 
     // Regression (STA-1511): closeHost deletes the entry; before the fix the

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -61,11 +61,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
   const primedHostsRef = useRef<Map<string, HostProfile>>(new Map())
 
   function notifyHostState(hostId: string, state: ConnectionState) {
-    const set = stateListenersRef.current.get(hostId)
-    if (!set) {
-      return
-    }
-    for (const listener of set) {
+    for (const listener of stateListenersRef.current.get(hostId) ?? []) {
       listener(state)
     }
   }

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -13,6 +13,7 @@ import {
 import type { RpcClient } from './rpc-client'
 import { connectionLogStore } from './connection-log-buffer'
 import { subscribeConnectionRevivalTriggers } from './connection-revival-triggers'
+import { resolveMobileDeviceDisplayName } from './device-identity'
 import { HostClientOpenRegistry } from './host-client-open-registry'
 import { loadHosts } from './host-store'
 import { openHostLogicalClient } from './host-logical-client'
@@ -133,7 +134,9 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
 
       let client: RpcClient
       try {
-        client = openHostLogicalClient(host, (entry) => connectionLogStore.append(hostId, entry))
+        client = openHostLogicalClient(host, (entry) => connectionLogStore.append(hostId, entry), {
+          deviceName: resolveMobileDeviceDisplayName()
+        })
       } catch {
         // Why: openHostLogicalClient can throw synchronously (bad public key / invalid URL); notify so the UI leaves 'connecting'.
         notifyHostState(hostId, 'disconnected')

--- a/mobile/src/transport/device-identity.test.ts
+++ b/mobile/src/transport/device-identity.test.ts
@@ -23,6 +23,13 @@ describe('sanitizeDeviceDisplayName', () => {
     expect(sanitizeDeviceDisplayName('x'.repeat(80))).toHaveLength(64)
   })
 
+  it('caps by Unicode code point without splitting an emoji', () => {
+    const sanitized = sanitizeDeviceDisplayName(`${'x'.repeat(63)}😀z`)
+
+    expect(sanitized).toBe(`${'x'.repeat(63)}😀`)
+    expect(Array.from(sanitized ?? '')).toHaveLength(64)
+  })
+
   it('rejects empty / control-only strings', () => {
     expect(sanitizeDeviceDisplayName('   ')).toBeNull()
     expect(sanitizeDeviceDisplayName('\u0000\u0001')).toBeNull()

--- a/mobile/src/transport/device-identity.test.ts
+++ b/mobile/src/transport/device-identity.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const deviceMock = vi.hoisted(() => ({
+  modelName: null as string | null
+}))
+
+const platformMock = vi.hoisted(() => ({
+  OS: 'ios' as string,
+  constants: {} as Record<string, string>
+}))
+
+vi.mock('expo-device', () => deviceMock)
+
+vi.mock('react-native', () => ({
+  Platform: platformMock
+}))
+
+import { resolveMobileDeviceDisplayName, sanitizeDeviceDisplayName } from './device-identity'
+
+describe('sanitizeDeviceDisplayName', () => {
+  it('trims and caps length', () => {
+    expect(sanitizeDeviceDisplayName('  iPhone 15 Pro Max  ')).toBe('iPhone 15 Pro Max')
+    expect(sanitizeDeviceDisplayName('x'.repeat(80))).toHaveLength(64)
+  })
+
+  it('rejects empty / control-only strings', () => {
+    expect(sanitizeDeviceDisplayName('   ')).toBeNull()
+    expect(sanitizeDeviceDisplayName('\u0000\u0001')).toBeNull()
+  })
+})
+
+describe('resolveMobileDeviceDisplayName', () => {
+  afterEach(() => {
+    platformMock.OS = 'ios'
+    platformMock.constants = {}
+    deviceMock.modelName = null
+  })
+
+  it('prefers iOS marketing model from expo-device', () => {
+    platformMock.OS = 'ios'
+    deviceMock.modelName = 'iPhone 15 Pro Max'
+    expect(resolveMobileDeviceDisplayName()).toBe('iPhone 15 Pro Max')
+  })
+
+  it('falls back to iPhone when model is unavailable', () => {
+    platformMock.OS = 'ios'
+    deviceMock.modelName = null
+    expect(resolveMobileDeviceDisplayName()).toBe('iPhone')
+  })
+
+  it('uses Android brand + model when present', () => {
+    platformMock.OS = 'android'
+    platformMock.constants = { Brand: 'Google', Model: 'Pixel 8' }
+    expect(resolveMobileDeviceDisplayName()).toBe('Google Pixel 8')
+  })
+
+  it('avoids duplicating brand when model already includes it', () => {
+    platformMock.OS = 'android'
+    platformMock.constants = { Brand: 'Samsung', Model: 'Samsung Galaxy S24' }
+    expect(resolveMobileDeviceDisplayName()).toBe('Samsung Galaxy S24')
+  })
+})

--- a/mobile/src/transport/device-identity.ts
+++ b/mobile/src/transport/device-identity.ts
@@ -24,7 +24,6 @@ export function resolveMobileDeviceDisplayName(): string {
     const constants = Platform.constants as {
       Brand?: string
       Model?: string
-      Manufacturer?: string
     }
     const brand = typeof constants.Brand === 'string' ? constants.Brand.trim() : ''
     const model = typeof constants.Model === 'string' ? constants.Model.trim() : ''
@@ -45,16 +44,17 @@ export function resolveMobileDeviceDisplayName(): string {
 export function sanitizeDeviceDisplayName(raw: string): string | null {
   // Why: device metadata is untrusted display text; remove terminal/control
   // bytes without a control-character regex that cross-platform lint rejects.
-  const cleaned = raw
-    .split('')
+  const normalized = Array.from(raw)
     .filter((character) => {
-      const code = character.charCodeAt(0)
-      return code > 0x1f && code !== 0x7f
+      const codePoint = character.codePointAt(0)
+      return codePoint !== undefined && codePoint > 0x1f && codePoint !== 0x7f
     })
     .join('')
     .replace(/\s+/g, ' ')
     .trim()
-    .slice(0, MAX_DEVICE_NAME_LENGTH)
+  // Why: String.slice counts UTF-16 code units and can leave a lone surrogate
+  // at the boundary; the protocol limit is shared with the server by code point.
+  const cleaned = Array.from(normalized).slice(0, MAX_DEVICE_NAME_LENGTH).join('')
   return cleaned.length > 0 ? cleaned : null
 }
 

--- a/mobile/src/transport/device-identity.ts
+++ b/mobile/src/transport/device-identity.ts
@@ -1,0 +1,69 @@
+import * as Device from 'expo-device'
+import { Platform } from 'react-native'
+
+// Why: desktop Settings → Paired Devices currently shows the placeholder name
+// minted at QR time ("Mobile 7/3/2026"). The phone can report a human model
+// on e2ee_auth so the desktop renames the registry entry after first connect.
+
+const MAX_DEVICE_NAME_LENGTH = 64
+
+export function resolveMobileDeviceDisplayName(): string {
+  // Why: expo-constants dropped Constants.platform.ios.model in SDK 52+; use
+  // expo-device's marketing name so iOS reports "iPhone 15 Pro" instead of
+  // the bare "iPhone" fallback.
+  if (Platform.OS === 'ios') {
+    const modelName = typeof Device.modelName === 'string' ? Device.modelName.trim() : ''
+    if (modelName) {
+      return sanitizeDeviceDisplayName(modelName) ?? fallbackPlatformLabel()
+    }
+  }
+
+  // Why: AndroidManifest in expo-constants has no marketing model field, but
+  // RN Platform.constants exposes Brand/Model on Android native builds.
+  if (Platform.OS === 'android') {
+    const constants = Platform.constants as {
+      Brand?: string
+      Model?: string
+      Manufacturer?: string
+    }
+    const brand = typeof constants.Brand === 'string' ? constants.Brand.trim() : ''
+    const model = typeof constants.Model === 'string' ? constants.Model.trim() : ''
+    if (brand && model && !model.toLowerCase().startsWith(brand.toLowerCase())) {
+      return sanitizeDeviceDisplayName(`${brand} ${model}`) ?? fallbackPlatformLabel()
+    }
+    if (model) {
+      return sanitizeDeviceDisplayName(model) ?? fallbackPlatformLabel()
+    }
+    if (brand) {
+      return sanitizeDeviceDisplayName(brand) ?? fallbackPlatformLabel()
+    }
+  }
+
+  return fallbackPlatformLabel()
+}
+
+export function sanitizeDeviceDisplayName(raw: string): string | null {
+  // Why: device metadata is untrusted display text; remove terminal/control
+  // bytes without a control-character regex that cross-platform lint rejects.
+  const cleaned = raw
+    .split('')
+    .filter((character) => {
+      const code = character.charCodeAt(0)
+      return code > 0x1f && code !== 0x7f
+    })
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_DEVICE_NAME_LENGTH)
+  return cleaned.length > 0 ? cleaned : null
+}
+
+function fallbackPlatformLabel(): string {
+  if (Platform.OS === 'ios') {
+    return 'iPhone'
+  }
+  if (Platform.OS === 'android') {
+    return 'Android'
+  }
+  return 'Mobile'
+}

--- a/mobile/src/transport/host-logical-client.ts
+++ b/mobile/src/transport/host-logical-client.ts
@@ -5,11 +5,18 @@ import type { ConnectionLogSink, HostProfile } from './types'
 import { directPathForEndpoint } from './mobile-direct-endpoint-probe'
 import { startMobileEndpointLifecycle } from './mobile-endpoint-lifecycle'
 
-export function openHostLogicalClient(host: HostProfile, onLog: ConnectionLogSink): RpcClient {
+export function openHostLogicalClient(
+  host: HostProfile,
+  onLog: ConnectionLogSink,
+  options?: { deviceName?: string }
+): RpcClient {
   // Why: the stable facade owns app-visible RPC/subscription state while the
   // direct socket remains a replaceable first physical generation.
   const logical = createStableLogicalRpcClient(
-    connect(host.endpoint, host.deviceToken, host.publicKeyB64, { onLog }),
+    connect(host.endpoint, host.deviceToken, host.publicKeyB64, {
+      onLog,
+      ...(options?.deviceName ? { deviceName: options.deviceName } : {})
+    }),
     directPathForEndpoint(host, host.endpoint)
   )
   if (Platform.OS === 'web') {

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -194,6 +194,22 @@ describe('mobile rpc-client connection timeout', () => {
     client.close()
   })
 
+  it('includes the supplied device name in encrypted auth', () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key', {
+      deviceName: 'iPhone 15 Pro Max'
+    })
+    const socket = mockSockets[0]!
+
+    socket.open()
+    socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+
+    expect(socket.sent).toContain(
+      'encrypted:{"type":"e2ee_auth","deviceToken":"token","deviceName":"iPhone 15 Pro Max"}'
+    )
+
+    client.close()
+  })
+
   it('sends session tabs unsubscribe when a session tab stream is disposed', () => {
     const client = connect('ws://desktop.invalid', 'token', 'server-key')
     const socket = mockSockets[0]!

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -134,6 +134,9 @@ export type ConnectOptions = {
   onStateChange?: (state: ConnectionState) => void
   // Fires for every lifecycle event so the UI can show where 'Connecting…' is stuck (e.g. broken Tailscale route).
   onLog?: ConnectionLogSink
+  // Why: the caller owns platform metadata so this transport stays usable in
+  // non-React-Native tests and tools without importing native modules.
+  deviceName?: string
 }
 
 export function connect(
@@ -149,6 +152,7 @@ export function connect(
       : (optionsOrLegacy ?? {})
   const onStateChange = options.onStateChange
   const onLog = options.onLog
+  const deviceName = options.deviceName
   let logCounter = 0
   function emitLog(level: ConnectionLogLevel, message: string, detail?: string) {
     if (!onLog) {
@@ -395,7 +399,14 @@ export function connect(
           const msg = JSON.parse(raw)
           if (msg.type === 'e2ee_ready') {
             emitLog('success', 'Received e2ee_ready', 'Sending device token')
-            sendEncrypted({ type: 'e2ee_auth', deviceToken })
+            // Why: report the marketing model (e.g. "iPhone 15 Pro Max") so the
+            // desktop Paired Devices list can replace the QR-time placeholder
+            // name "Mobile <date>". Optional on the wire for older desktops.
+            sendEncrypted({
+              type: 'e2ee_auth',
+              deviceToken,
+              ...(deviceName ? { deviceName } : {})
+            })
             return
           }
         } catch {

--- a/src/main/runtime/device-registry-name.test.ts
+++ b/src/main/runtime/device-registry-name.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { DeviceRegistry } from './device-registry'
+
+describe('DeviceRegistry.updateName', () => {
+  const dirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  function createRegistry(): DeviceRegistry {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-device-registry-'))
+    dirs.push(dir)
+    return new DeviceRegistry(dir)
+  }
+
+  it('renames a device and persists across reload', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-device-registry-'))
+    dirs.push(dir)
+    const registry = new DeviceRegistry(dir)
+    const device = registry.addDevice('Mobile 7/3/2026', 'mobile')
+
+    expect(registry.updateName(device.deviceId, 'iPhone 15 Pro Max')).toBe(true)
+    expect(registry.getDevice(device.deviceId)?.name).toBe('iPhone 15 Pro Max')
+
+    const reloaded = new DeviceRegistry(dir)
+    expect(reloaded.getDevice(device.deviceId)?.name).toBe('iPhone 15 Pro Max')
+  })
+
+  it('no-ops when the name is unchanged', () => {
+    const registry = createRegistry()
+    const device = registry.addDevice('iPhone 15 Pro Max', 'mobile')
+    expect(registry.updateName(device.deviceId, 'iPhone 15 Pro Max')).toBe(false)
+  })
+
+  it('rejects empty names', () => {
+    const registry = createRegistry()
+    const device = registry.addDevice('Mobile 1/1/2026', 'mobile')
+    expect(registry.updateName(device.deviceId, '   ')).toBe(false)
+    expect(registry.getDevice(device.deviceId)?.name).toBe('Mobile 1/1/2026')
+  })
+})

--- a/src/main/runtime/device-registry.ts
+++ b/src/main/runtime/device-registry.ts
@@ -273,6 +273,24 @@ export class DeviceRegistry {
     }
   }
 
+  // Why: mobile clients report a marketing model (e.g. "iPhone 15 Pro Max")
+  // during e2ee_auth. Replace the QR-time placeholder ("Mobile <date>") so
+  // Settings → Paired Devices is recognizable. No-op when the name is empty
+  // or unchanged so reconnects do not thrash the registry file.
+  updateName(deviceId: string, name: string): boolean {
+    const device = this.devices.find((d) => d.deviceId === deviceId)
+    if (!device) {
+      return false
+    }
+    const next = name.trim()
+    if (!next || next === device.name) {
+      return false
+    }
+    device.name = next
+    this.save()
+    return true
+  }
+
   private load(): void {
     if (!existsSync(this.registryPath)) {
       this.devices = []

--- a/src/main/runtime/rpc/e2ee-channel.test.ts
+++ b/src/main/runtime/rpc/e2ee-channel.test.ts
@@ -79,6 +79,7 @@ describe('E2EEChannel', () => {
       })
       expect(ctx.onError).not.toHaveBeenCalled()
       expect(ctx.channel.deviceToken).toBe('valid-token')
+      expect(ctx.channel.reportedDeviceName).toBeNull()
 
       const readyMsg = JSON.parse(ctx.ws.sent[0]!)
       expect(readyMsg).toEqual({ type: 'e2ee_ready' })
@@ -87,6 +88,30 @@ describe('E2EEChannel', () => {
         deriveSharedKey(ctx.clientKeys.secretKey, ctx.serverKeys.publicKey)
       )
       expect(JSON.parse(authMsg!)).toEqual({ type: 'e2ee_authenticated' })
+    })
+
+    it('captures optional deviceName from e2ee_auth', () => {
+      const ctx = setup()
+      ctx.channel.handleRawMessage(
+        JSON.stringify({
+          type: 'e2ee_hello',
+          publicKeyB64: publicKeyToBase64(ctx.clientKeys.publicKey)
+        })
+      )
+      const shared = deriveSharedKey(ctx.clientKeys.secretKey, ctx.serverKeys.publicKey)
+      ctx.channel.handleRawMessage(
+        encrypt(
+          JSON.stringify({
+            type: 'e2ee_auth',
+            deviceToken: 'valid-token',
+            deviceName: '  iPhone 15 Pro Max  '
+          }),
+          shared
+        )
+      )
+
+      expect(ctx.onReady).toHaveBeenCalled()
+      expect(ctx.channel.reportedDeviceName).toBe('iPhone 15 Pro Max')
     })
 
     it('does not authenticate from plaintext hello alone', () => {

--- a/src/main/runtime/rpc/e2ee-channel.test.ts
+++ b/src/main/runtime/rpc/e2ee-channel.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import type { WebSocket } from 'ws'
-import { E2EEChannel, sanitizeReportedDeviceName, type E2EEChannelOptions } from './e2ee-channel'
+import { E2EEChannel, type E2EEChannelOptions } from './e2ee-channel'
 import { generateKeyPair, deriveSharedKey, encrypt, decrypt, encryptBytes } from './e2ee-crypto'
+import { sanitizeReportedDeviceName } from './mobile-device-name'
 import {
   REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES,
   REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES

--- a/src/main/runtime/rpc/e2ee-channel.test.ts
+++ b/src/main/runtime/rpc/e2ee-channel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import type { WebSocket } from 'ws'
-import { E2EEChannel, type E2EEChannelOptions } from './e2ee-channel'
+import { E2EEChannel, sanitizeReportedDeviceName, type E2EEChannelOptions } from './e2ee-channel'
 import { generateKeyPair, deriveSharedKey, encrypt, decrypt, encryptBytes } from './e2ee-crypto'
 import {
   REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES,
@@ -57,6 +57,15 @@ function doHandshake(ctx: ReturnType<typeof setup>) {
   )
   return sharedKey
 }
+
+describe('sanitizeReportedDeviceName', () => {
+  it('caps by Unicode code point without splitting an emoji', () => {
+    const sanitized = sanitizeReportedDeviceName(`${'x'.repeat(63)}😀z`)
+
+    expect(sanitized).toBe(`${'x'.repeat(63)}😀`)
+    expect(Array.from(sanitized ?? '')).toHaveLength(64)
+  })
+})
 
 describe('E2EEChannel', () => {
   beforeEach(() => {

--- a/src/main/runtime/rpc/e2ee-channel.ts
+++ b/src/main/runtime/rpc/e2ee-channel.ts
@@ -18,29 +18,10 @@ import type { MobileE2EEOutboundMemoryBudget } from './mobile-e2ee-outbound-memo
 import { MobileE2EEDesktopOutboundOwner } from './mobile-e2ee-desktop-outbound-owner'
 import { parseRuntimeClientCapabilities } from './runtime-client-capabilities'
 import type { RuntimeCapability } from '../../../shared/protocol-version'
+import { sanitizeReportedDeviceName } from './mobile-device-name'
 
 const HANDSHAKE_TIMEOUT_MS = 10_000
 const MAX_CONSECUTIVE_DECRYPT_FAILURES = 5
-
-const MAX_REPORTED_DEVICE_NAME_LENGTH = 64
-
-export function sanitizeReportedDeviceName(raw: unknown): string | null {
-  if (typeof raw !== 'string') {
-    return null
-  }
-  const normalized = Array.from(raw)
-    .filter((character) => {
-      const codePoint = character.codePointAt(0)
-      return codePoint !== undefined && codePoint > 0x1f && codePoint !== 0x7f
-    })
-    .join('')
-    .replace(/\s+/g, ' ')
-    .trim()
-  // Why: String.slice counts UTF-16 code units and can leave a lone surrogate
-  // at the boundary; match the mobile sender's code-point limit.
-  const cleaned = Array.from(normalized).slice(0, MAX_REPORTED_DEVICE_NAME_LENGTH).join('')
-  return cleaned.length > 0 ? cleaned : null
-}
 
 export type E2EEChannelOptions = {
   serverSecretKey: Uint8Array

--- a/src/main/runtime/rpc/e2ee-channel.ts
+++ b/src/main/runtime/rpc/e2ee-channel.ts
@@ -28,7 +28,7 @@ export function sanitizeReportedDeviceName(raw: unknown): string | null {
   if (typeof raw !== 'string') {
     return null
   }
-  const cleaned = Array.from(raw)
+  const normalized = Array.from(raw)
     .filter((character) => {
       const codePoint = character.codePointAt(0)
       return codePoint !== undefined && codePoint > 0x1f && codePoint !== 0x7f
@@ -36,7 +36,9 @@ export function sanitizeReportedDeviceName(raw: unknown): string | null {
     .join('')
     .replace(/\s+/g, ' ')
     .trim()
-    .slice(0, MAX_REPORTED_DEVICE_NAME_LENGTH)
+  // Why: String.slice counts UTF-16 code units and can leave a lone surrogate
+  // at the boundary; match the mobile sender's code-point limit.
+  const cleaned = Array.from(normalized).slice(0, MAX_REPORTED_DEVICE_NAME_LENGTH).join('')
   return cleaned.length > 0 ? cleaned : null
 }
 

--- a/src/main/runtime/rpc/e2ee-channel.ts
+++ b/src/main/runtime/rpc/e2ee-channel.ts
@@ -22,6 +22,24 @@ import type { RuntimeCapability } from '../../../shared/protocol-version'
 const HANDSHAKE_TIMEOUT_MS = 10_000
 const MAX_CONSECUTIVE_DECRYPT_FAILURES = 5
 
+const MAX_REPORTED_DEVICE_NAME_LENGTH = 64
+
+export function sanitizeReportedDeviceName(raw: unknown): string | null {
+  if (typeof raw !== 'string') {
+    return null
+  }
+  const cleaned = Array.from(raw)
+    .filter((character) => {
+      const codePoint = character.codePointAt(0)
+      return codePoint !== undefined && codePoint > 0x1f && codePoint !== 0x7f
+    })
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_REPORTED_DEVICE_NAME_LENGTH)
+  return cleaned.length > 0 ? cleaned : null
+}
+
 export type E2EEChannelOptions = {
   serverSecretKey: Uint8Array
   resolveAuthenticatedDevice: (token: string) => E2EEAuthenticatedDevice | null
@@ -65,6 +83,7 @@ export class E2EEChannel {
   deviceToken: string | null = null
   authenticatedDevice: E2EEAuthenticatedDevice | null = null
   clientCapabilities: readonly RuntimeCapability[] = []
+  reportedDeviceName: string | null = null
 
   constructor(ws: WebSocket, options: E2EEChannelOptions) {
     this.ws = ws
@@ -252,6 +271,7 @@ export class E2EEChannel {
     this.clientCapabilities = parseRuntimeClientCapabilities(authentication.auth.clientCapabilities)
     this.deviceToken = authenticatedDevice.deviceToken
     this.authenticatedDevice = authenticatedDevice
+    this.reportedDeviceName = sanitizeReportedDeviceName(authentication.auth.deviceName)
     this.state = 'ready'
 
     if (this.handshakeTimer) {
@@ -324,6 +344,7 @@ export class E2EEChannel {
     }
     this.sharedKey = null
     this.authenticatedDevice = null
+    this.reportedDeviceName = null
     this.v2Session = null
     this.messageHandler = null
     this.binaryMessageHandler = null

--- a/src/main/runtime/rpc/mobile-device-name.ts
+++ b/src/main/runtime/rpc/mobile-device-name.ts
@@ -1,0 +1,19 @@
+const MAX_REPORTED_DEVICE_NAME_LENGTH = 64
+
+export function sanitizeReportedDeviceName(raw: unknown): string | null {
+  if (typeof raw !== 'string') {
+    return null
+  }
+  const normalized = Array.from(raw)
+    .filter((character) => {
+      const codePoint = character.codePointAt(0)
+      return codePoint !== undefined && codePoint > 0x1f && codePoint !== 0x7f
+    })
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim()
+  // Why: String.slice counts UTF-16 code units and can leave a lone surrogate
+  // at the boundary; match the mobile sender's code-point limit.
+  const cleaned = Array.from(normalized).slice(0, MAX_REPORTED_DEVICE_NAME_LENGTH).join('')
+  return cleaned.length > 0 ? cleaned : null
+}

--- a/src/main/runtime/rpc/mobile-e2ee-auth-validation.ts
+++ b/src/main/runtime/rpc/mobile-e2ee-auth-validation.ts
@@ -8,6 +8,8 @@ export type MobileE2EEAuth = {
   clientCapabilities?: unknown
   v?: 2
   transcriptHashB64?: string
+  // Why: optional marketing model from the phone so desktop can rename "Mobile <date>".
+  deviceName?: string
 }
 
 export function isValidMobileE2EEAuthVersion(
@@ -17,12 +19,12 @@ export function isValidMobileE2EEAuthVersion(
   if (!v2Session) {
     return auth.v === undefined && auth.transcriptHashB64 === undefined
   }
+  const keys = Object.keys(auth).sort().join(',')
   // Why: mobile v2 keeps an exact transcript-bound shape; runtime capabilities use legacy paired-runtime auth.
-  return (
-    Object.keys(auth).sort().join(',') === 'deviceToken,transcriptHashB64,type,v' &&
-    auth.v === 2 &&
-    auth.transcriptHashB64 === v2Session.transcriptHashB64
-  )
+  const allowed =
+    keys === 'deviceToken,transcriptHashB64,type,v' ||
+    keys === 'deviceName,deviceToken,transcriptHashB64,type,v'
+  return allowed && auth.v === 2 && auth.transcriptHashB64 === v2Session.transcriptHashB64
 }
 
 export function authenticateMobileE2EE<TDevice extends { deviceToken: string }>(args: {

--- a/src/main/runtime/rpc/mobile-socket-wiring.ts
+++ b/src/main/runtime/rpc/mobile-socket-wiring.ts
@@ -170,8 +170,12 @@ export class MobileSocketWiring {
           }
           this.authenticatedSockets.set(ws, socket)
           transport.setClientId(ws, device.deviceToken)
-          // Why: deferred — the client's e2ee_authenticated must not wait on a secure-file rewrite.
+// Why: deferred — the client's e2ee_authenticated must not wait on a secure-file rewrite.
           this.deviceRegistry.updateLastSeenDeferred(device.deviceId)
+          // Why: phone reports marketing model on auth so Settings stops showing QR-time "Mobile <date>".
+          if (channel.reportedDeviceName) {
+            this.deviceRegistry.updateName(device.deviceId, channel.reportedDeviceName)
+          }
           this.onReady?.(socket)
         },
         onError: (code, reason) => {


### PR DESCRIPTION
## Summary

- collect a bounded mobile device model/name in the React client context
- inject it into transport connect options instead of importing React Native from the low-level RPC client
- send the optional device name only inside the existing encrypted `e2ee_auth` payload
- validate and sanitize the name on the runtime before updating the already-authenticated device record
- cap client and runtime values by Unicode code point so a 64-character boundary cannot split an emoji surrogate pair

This is the device-identity replacement extracted from #7949. It intentionally excludes host editing and iOS scene-lifecycle work.

Refs #7949

## Screenshots

No visual redesign. The existing paired-device surface displays the additional sanitized name.

## Testing

- [x] mobile Vitest: 6 files / 45 passed / 2 skipped
- [x] desktop Vitest: 3 files / 62 passed
- [x] mobile TypeScript 6 and targeted `oxlint`
- [x] root Node typecheck and targeted `oxlint`
- [x] `oxfmt --check` and max-lines ratchet
- [x] `git diff --check`
- [x] RED-to-GREEN Unicode boundary coverage on both client and runtime
- [x] rebased on current `origin/main`; retained the latest host-client open registry and connection logging
- [ ] full repository test/lint aggregate
- [ ] mobile simulator/device
- [ ] Electron/E2E/GUI

## AI Review Report

Independent review ended spec PASS / quality APPROVED. It verified the latest-main conflict resolution, additive protocol compatibility, encrypted transport, token-to-device binding, secure persistence, and matching client/runtime Unicode sanitizers.

Review also found and fixed a functional boundary bug: UTF-16 `String.slice()` could leave a lone surrogate when an emoji crossed the 64-character limit. Both sanitizers now truncate an `Array.from()` code-point array and have regression tests.

## Security Audit

- device name is optional display metadata and does not participate in pairing or authorization
- it is carried inside the existing encrypted E2EE authentication message
- the runtime validates the token before updating that token's device record
- both client and runtime remove C0/DEL controls, normalize whitespace, and cap the value at 64 Unicode code points
- the value is not logged and contains model/platform fallback metadata, not hostname, serial number, or account data
- this adds the direct `expo-device` dependency needed for the iOS marketing model; it adds no credential, permission, command, or IPC method

## Compatibility

The field is additive and optional, so older mobile clients continue without it and older runtimes ignore it. Desktop, SSH, keyboard, filesystem, and Git-provider paths are unchanged.

## Notes

Validation used the repository-declared Node 24 toolchain. Full Electron/E2E and physical mobile-device verification were intentionally not run in this review cycle.

## ELI5

Paired phones can send a short device model/name during auth so the host can show which device is connected. The name is optional, sanitized, and length-capped so emoji and weird characters do not break the pairing record.
