### PR TITLE
fix(grok): tolerate missing creditUsagePercent in billing API

### DIFF
--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -98,6 +98,8 @@ describe('fetchGrokRateLimits', () => {
         })
       })
     )
+    // Why: primary response already has creditUsagePercent — no fallback fetch.
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('returns unavailable when not signed in even if a token-less auth file exists', async () => {
@@ -107,9 +109,121 @@ describe('fetchGrokRateLimits', () => {
     expect(netFetchMock).not.toHaveBeenCalled()
   })
 
-  it('returns unavailable when billing has no credit usage', async () => {
+  it('treats unified weekly config without counters as 0% used after fallback', async () => {
     authState.file = freshAuthJson()
-    netFetchMock.mockResolvedValueOnce(jsonResponse({ config: { subscriptionTier: 'Enterprise' } }))
+    netFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          config: {
+            currentPeriod: {
+              type: 'USAGE_PERIOD_TYPE_WEEKLY',
+              start: '2026-07-11T10:28:18.446096+00:00',
+              end: '2026-07-18T10:28:18.446096+00:00'
+            },
+            isUnifiedBillingUser: true,
+            prepaidBalance: { val: 0 }
+          },
+          subscriptionTier: 'SuperGrok'
+        })
+      )
+      // Fallback also has no counters — still show 0% with weekly reset.
+      .mockResolvedValueOnce(jsonResponse({ config: { prepaidBalance: { val: 0 } } }))
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(0)
+    expect(result.weekly?.resetsAt).toBe(Date.parse('2026-07-18T10:28:18.446096+00:00'))
+    expect(result.usageMetadata?.authProvenance).toContain('SuperGrok')
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('merges weekly period from credits with used/limit from default billing', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          config: {
+            currentPeriod: {
+              type: 'USAGE_PERIOD_TYPE_WEEKLY',
+              end: '2026-07-18T10:28:18.446096+00:00'
+            },
+            isUnifiedBillingUser: true
+          },
+          subscriptionTier: 'SuperGrok'
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          config: {
+            monthlyLimit: { val: 15000 },
+            used: { val: 1500 },
+            billingPeriodEnd: '2026-08-01T00:00:00+00:00'
+          }
+        })
+      )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(10)
+    // Prefer weekly reset from format=credits over monthly billing end.
+    expect(result.weekly?.resetsAt).toBe(Date.parse('2026-07-18T10:28:18.446096+00:00'))
+    expect(result.usageMetadata?.authProvenance).toContain('SuperGrok')
+  })
+
+  it('maps productUsage percents when creditUsagePercent is missing', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        config: {
+          currentPeriod: {
+            type: 'USAGE_PERIOD_TYPE_WEEKLY',
+            end: '2026-07-18T10:28:18.446096+00:00'
+          },
+          productUsage: [
+            { product: 'GrokBuild', usagePercent: 3 },
+            { product: 'Chat', usagePercent: 2 }
+          ],
+          isUnifiedBillingUser: true
+        }
+      })
+    )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(5)
+  })
+
+  it('falls back to default billing used/monthlyLimit when credits omit usage', async () => {
+    authState.file = freshAuthJson()
+    // First response: non-unified shell with no usable percent — forces fallback path.
+    netFetchMock
+      .mockResolvedValueOnce(jsonResponse({ config: { subscriptionTier: 'Enterprise' } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          config: {
+            monthlyLimit: { val: 15000 },
+            used: { val: 1500 },
+            billingPeriodEnd: '2026-08-01T00:00:00+00:00'
+          }
+        })
+      )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(10)
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
+    expect(netFetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://cli-chat-proxy.grok.com/v1/billing',
+      expect.anything()
+    )
+  })
+
+  it('returns unavailable when billing has no credit usage and no fallback data', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock
+      .mockResolvedValueOnce(jsonResponse({ config: { subscriptionTier: 'Enterprise' } }))
+      .mockResolvedValueOnce(jsonResponse({ config: { subscriptionTier: 'Enterprise' } }))
 
     const result = await fetchGrokRateLimits()
     expect(result.status).toBe('unavailable')
@@ -118,7 +232,9 @@ describe('fetchGrokRateLimits', () => {
 
   it('returns unavailable when billing response has no config', async () => {
     authState.file = freshAuthJson()
-    netFetchMock.mockResolvedValueOnce(jsonResponse({}))
+    netFetchMock
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({}))
 
     const result = await fetchGrokRateLimits()
     expect(result.status).toBe('unavailable')

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -12,6 +12,9 @@ const GROK_CLI_PROXY_BASE =
   process.env.GROK_CLI_CHAT_PROXY_BASE_URL?.trim().replace(/\/$/, '') ||
   'https://cli-chat-proxy.grok.com/v1'
 const BILLING_CREDITS_URL = `${GROK_CLI_PROXY_BASE}/billing?format=credits`
+// Why: SuperGrok unified billing sometimes omits creditUsagePercent on
+// format=credits; the default billing payload still has used/monthlyLimit.
+const BILLING_DEFAULT_URL = `${GROK_CLI_PROXY_BASE}/billing`
 const API_TIMEOUT_MS = 10_000
 const WEEKLY_WINDOW_MINUTES = 10_080
 
@@ -25,6 +28,11 @@ type GrokUsagePeriod = {
   end?: string
 }
 
+type GrokProductUsage = {
+  product?: string
+  usagePercent?: number
+}
+
 type GrokBillingConfig = {
   creditUsagePercent?: number
   currentPeriod?: GrokUsagePeriod
@@ -35,10 +43,15 @@ type GrokBillingConfig = {
   onDemandUsed?: GrokMoneyVal
   prepaidBalance?: GrokMoneyVal
   isUnifiedBillingUser?: boolean
+  productUsage?: GrokProductUsage[]
+  used?: GrokMoneyVal | number
+  monthlyLimit?: GrokMoneyVal | number
+  limit?: GrokMoneyVal | number
 }
 
 type GrokBillingResponse = GrokBillingConfig & {
   config?: GrokBillingConfig
+  subscriptionTier?: string
 }
 
 function result(status: ProviderRateLimits['status'], error: string | null): ProviderRateLimits {
@@ -66,9 +79,89 @@ function parseResetDescription(isoString: string | undefined): string | null {
     : date.toLocaleDateString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' })
 }
 
+function unwrapMoneyVal(value: GrokMoneyVal | number | undefined): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'object' && value !== null) {
+    const raw = value.val
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      return raw
+    }
+    if (typeof raw === 'string' && raw.trim()) {
+      const parsed = Number(raw)
+      return Number.isFinite(parsed) ? parsed : null
+    }
+  }
+  return null
+}
+
+// Why: xAI has shipped several shapes for the same quota:
+// 1) creditUsagePercent on format=credits (preferred)
+// 2) productUsage[].usagePercent (per-product shares of the weekly pool)
+// 3) used / monthlyLimit money wrappers on the default billing endpoint
+function resolveUsedPercent(config: GrokBillingConfig): number | null {
+  if (typeof config.creditUsagePercent === 'number' && Number.isFinite(config.creditUsagePercent)) {
+    return config.creditUsagePercent
+  }
+
+  if (Array.isArray(config.productUsage) && config.productUsage.length > 0) {
+    let total = 0
+    let found = false
+    for (const entry of config.productUsage) {
+      if (typeof entry?.usagePercent === 'number' && Number.isFinite(entry.usagePercent)) {
+        total += entry.usagePercent
+        found = true
+      }
+    }
+    if (found) {
+      return total
+    }
+  }
+
+  const used = unwrapMoneyVal(config.used)
+  // Why: prefer monthlyLimit / limit. Do not use onDemandCap as a denominator —
+  // it is often 0 even when the weekly pool is active.
+  const resolvedLimit = unwrapMoneyVal(config.monthlyLimit) ?? unwrapMoneyVal(config.limit)
+  if (used !== null && resolvedLimit !== null && resolvedLimit > 0) {
+    return (used / resolvedLimit) * 100
+  }
+
+  return null
+}
+
+function hasExplicitUsageCounters(config: GrokBillingConfig | null): boolean {
+  if (!config) {
+    return false
+  }
+  if (typeof config.creditUsagePercent === 'number' && Number.isFinite(config.creditUsagePercent)) {
+    return true
+  }
+  if (
+    Array.isArray(config.productUsage) &&
+    config.productUsage.some(
+      (entry) => typeof entry?.usagePercent === 'number' && Number.isFinite(entry.usagePercent)
+    )
+  ) {
+    return true
+  }
+  return unwrapMoneyVal(config.used) !== null
+}
+
+function hasWeeklyPoolMetadata(config: GrokBillingConfig): boolean {
+  return (
+    config.isUnifiedBillingUser === true || config.currentPeriod?.type === 'USAGE_PERIOD_TYPE_WEEKLY'
+  )
+}
+
 function mapWeeklyCredits(config: GrokBillingConfig): RateLimitWindow | null {
-  const usedPercent = config.creditUsagePercent
-  if (typeof usedPercent !== 'number' || !Number.isFinite(usedPercent)) {
+  let usedPercent = resolveUsedPercent(config)
+  // Why: unified weekly users can receive a config shell with period metadata
+  // before usage counters are populated. After fallback merge, treat that as 0%.
+  if (usedPercent === null && hasWeeklyPoolMetadata(config)) {
+    usedPercent = 0
+  }
+  if (usedPercent === null) {
     return null
   }
   const periodEnd = config.currentPeriod?.end ?? config.billingPeriodEnd
@@ -95,19 +188,62 @@ function grokRequestHeaders(session: GrokAuthSession): Record<string, string> {
 
 function resolveBillingConfig(data: GrokBillingResponse): GrokBillingConfig | null {
   if (data.config) {
-    return data.config
+    // Why: subscriptionTier is sometimes a sibling of config, not nested inside it.
+    return {
+      ...data.config,
+      subscriptionTier: data.config.subscriptionTier ?? data.subscriptionTier
+    }
   }
-  if (typeof data.creditUsagePercent === 'number') {
+  if (
+    typeof data.creditUsagePercent === 'number' ||
+    Array.isArray(data.productUsage) ||
+    data.used !== undefined ||
+    data.monthlyLimit !== undefined
+  ) {
     return data
   }
   return null
 }
 
+function mergeBillingConfigs(
+  primary: GrokBillingConfig | null,
+  fallback: GrokBillingConfig | null
+): GrokBillingConfig | null {
+  if (!primary && !fallback) {
+    return null
+  }
+  if (!primary) {
+    return fallback
+  }
+  if (!fallback) {
+    return primary
+  }
+  return {
+    ...fallback,
+    ...primary,
+    // Prefer primary period / percent; fill gaps from fallback.
+    creditUsagePercent: primary.creditUsagePercent ?? fallback.creditUsagePercent,
+    productUsage: primary.productUsage ?? fallback.productUsage,
+    used: primary.used ?? fallback.used,
+    monthlyLimit: primary.monthlyLimit ?? fallback.monthlyLimit,
+    limit: primary.limit ?? fallback.limit,
+    currentPeriod: primary.currentPeriod ?? fallback.currentPeriod,
+    billingPeriodStart: primary.billingPeriodStart ?? fallback.billingPeriodStart,
+    billingPeriodEnd: primary.billingPeriodEnd ?? fallback.billingPeriodEnd,
+    subscriptionTier: primary.subscriptionTier ?? fallback.subscriptionTier,
+    isUnifiedBillingUser: primary.isUnifiedBillingUser ?? fallback.isUnifiedBillingUser
+  }
+}
+
 function mapBillingResponse(
   data: GrokBillingResponse,
-  session: GrokAuthSession
+  session: GrokAuthSession,
+  fallbackData?: GrokBillingResponse | null
 ): ProviderRateLimits {
-  const config = resolveBillingConfig(data)
+  const config = mergeBillingConfigs(
+    resolveBillingConfig(data),
+    fallbackData ? resolveBillingConfig(fallbackData) : null
+  )
   // Why: a 200 without credit usage means the plan has no weekly credits —
   // 'unavailable' hides the bar (like Claude on API-key billing); 'error'
   // would paint a permanent alert for a signed-in account that has no quota.
@@ -132,6 +268,32 @@ function mapBillingResponse(
   }
 }
 
+async function fetchBillingJson(
+  url: string,
+  session: GrokAuthSession,
+  signal: AbortSignal
+): Promise<{ ok: true; data: GrokBillingResponse } | { ok: false; status: number } | { ok: false; error: string }> {
+  try {
+    const res = await net.fetch(url, {
+      headers: grokRequestHeaders(session),
+      signal
+    })
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, error: `Grok usage request unauthorized (HTTP ${res.status})` }
+    }
+    if (!res.ok) {
+      return { ok: false, status: res.status }
+    }
+    const data: unknown = await res.json()
+    return {
+      ok: true,
+      data: typeof data === 'object' && data !== null ? (data as GrokBillingResponse) : {}
+    }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'Grok usage request failed' }
+  }
+}
+
 // Why: Orca never runs grok login; it only reads the session file the CLI updates.
 export async function fetchGrokRateLimits(
   options: { signal?: AbortSignal; authReadResult?: GrokAuthReadResult } = {}
@@ -152,21 +314,31 @@ export async function fetchGrokRateLimits(
     const signal = options.signal
       ? AbortSignal.any([options.signal, AbortSignal.timeout(API_TIMEOUT_MS)])
       : AbortSignal.timeout(API_TIMEOUT_MS)
-    const res = await net.fetch(BILLING_CREDITS_URL, {
-      headers: grokRequestHeaders(session),
-      signal
-    })
-    if (res.status === 401 || res.status === 403) {
-      return result('error', `Grok usage request unauthorized (HTTP ${res.status})`)
+
+    const credits = await fetchBillingJson(BILLING_CREDITS_URL, session, signal)
+    if (!credits.ok) {
+      if ('error' in credits && credits.error) {
+        return result('error', credits.error)
+      }
+      return result(
+        'error',
+        `Grok usage request failed (HTTP ${'status' in credits ? credits.status : 'unknown'})`
+      )
     }
-    if (!res.ok) {
-      return result('error', `Grok usage request failed (HTTP ${res.status})`)
+
+    const primaryConfig = resolveBillingConfig(credits.data)
+    if (hasExplicitUsageCounters(primaryConfig)) {
+      return mapBillingResponse(credits.data, session)
     }
-    const data: unknown = await res.json()
-    return mapBillingResponse(
-      typeof data === 'object' && data !== null ? (data as GrokBillingResponse) : {},
-      session
-    )
+
+    // Why: format=credits can return period metadata without usage counters.
+    // Fall back to default /billing which exposes used/monthlyLimit.
+    const fallback = await fetchBillingJson(BILLING_DEFAULT_URL, session, signal)
+    if (fallback.ok) {
+      return mapBillingResponse(credits.data, session, fallback.data)
+    }
+
+    return mapBillingResponse(credits.data, session)
   } catch (err) {
     return result('error', err instanceof Error ? err.message : 'Grok usage request failed')
   }


### PR DESCRIPTION
## Problem
Orca status bar Grok usage shows: `Grok billing response did not include credit usage`.

Root cause: SuperGrok unified billing (`/v1/billing?format=credits`) sometimes omits `creditUsagePercent` while still returning weekly period metadata. Orca treated that as unavailable.

## Fix
- Prefer `creditUsagePercent` when present
- Fall back to `productUsage[].usagePercent` sum
- If counters are missing, also fetch default `/v1/billing` and use `used` / `monthlyLimit` 
- If weekly pool metadata exists without counters after merge, show 0% instead of an error
- Read `subscriptionTier` from response root when nested under `config` is absent

## Test plan
- [x] Unit tests updated in `grok-fetcher.test.ts`
- [ ] Manual: SuperGrok account shows percent after restart
- [ ] Manual: missing `creditUsagePercent` no longer errors

## ELI5

The Grok usage meter could show an error when SuperGrok billing omitted `creditUsagePercent` even though other usage fields were present. Orca now falls back to product usage percents and alternate billing fields so the status bar still shows real usage.
