### PR TITLE
feat: keep serving remote clients when the main window closes (keepServingOnClose)

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -781,8 +781,9 @@ describe('Store', () => {
     expect(store.getUI().usagePercentageDisplayChangeNoticeDismissed).toBe(true)
   })
 
-  it('defaults minimizeToTrayOnClose to false when unset', async () => {
+  it('defaults keepServingOnClose and its legacy alias to false when unset', async () => {
     const store = await createStore()
+    expect(store.getSettings().keepServingOnClose).toBe(false)
     expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
   })
 
@@ -796,7 +797,47 @@ describe('Store', () => {
 
     const store = await createStore()
 
+    expect(store.getSettings().keepServingOnClose).toBe(false)
     expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
+  })
+
+  it('migrates a legacy minimizeToTrayOnClose=true into the canonical setting', async () => {
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      settings: {
+        minimizeToTrayOnClose: true
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().keepServingOnClose).toBe(true)
+    expect(store.getSettings().minimizeToTrayOnClose).toBe(true)
+    store.flush()
+    expect((readDataFile() as PersistedState).settings).toMatchObject({
+      keepServingOnClose: true,
+      minimizeToTrayOnClose: true
+    })
+  })
+
+  it('lets an explicit canonical false repair a stale legacy true', async () => {
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      settings: {
+        keepServingOnClose: false,
+        minimizeToTrayOnClose: true
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().keepServingOnClose).toBe(false)
+    expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
+    store.flush()
+    expect((readDataFile() as PersistedState).settings).toMatchObject({
+      keepServingOnClose: false,
+      minimizeToTrayOnClose: false
+    })
   })
 
   it('persists minimizeToTrayOnClose true/false round-trip', async () => {
@@ -806,6 +847,24 @@ describe('Store', () => {
     store.flush()
     expect((readDataFile() as PersistedState).settings.minimizeToTrayOnClose).toBe(true)
     store.updateSettings({ minimizeToTrayOnClose: false })
+    expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
+  })
+
+  it('mirrors canonical keepServingOnClose writes into the legacy alias', async () => {
+    const store = await createStore()
+    store.updateSettings({ keepServingOnClose: true })
+    expect(store.getSettings().keepServingOnClose).toBe(true)
+    expect(store.getSettings().minimizeToTrayOnClose).toBe(true)
+    store.updateSettings({ keepServingOnClose: false })
+    expect(store.getSettings().keepServingOnClose).toBe(false)
+    expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
+  })
+
+  it('mirrors legacy minimizeToTrayOnClose writes into the canonical setting', async () => {
+    const store = await createStore()
+    store.updateSettings({ keepServingOnClose: true })
+    store.updateSettings({ minimizeToTrayOnClose: false })
+    expect(store.getSettings().keepServingOnClose).toBe(false)
     expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
   })
 
@@ -842,6 +901,13 @@ describe('Store', () => {
     store.updateSettings({ minimizeToTrayOnClose: 1 as unknown as boolean })
     expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
     store.updateSettings({ minimizeToTrayOnClose: null as unknown as boolean })
+    expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
+  })
+
+  it('coerces non-boolean keepServingOnClose payloads to a strict boolean', async () => {
+    const store = await createStore()
+    store.updateSettings({ keepServingOnClose: 'true' as unknown as boolean })
+    expect(store.getSettings().keepServingOnClose).toBe(false)
     expect(store.getSettings().minimizeToTrayOnClose).toBe(false)
   })
 

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3325,6 +3325,20 @@ export class Store {
         ) {
           this.loadNeedsSave = true
         }
+        const storedKeepServingOnClose = parsed.settings?.keepServingOnClose
+        const storedMinimizeToTrayOnClose = parsed.settings?.minimizeToTrayOnClose
+        const keepServingOnClose =
+          storedKeepServingOnClose === undefined
+            ? storedMinimizeToTrayOnClose === true
+            : storedKeepServingOnClose === true
+        if (
+          storedKeepServingOnClose !== keepServingOnClose ||
+          storedMinimizeToTrayOnClose !== keepServingOnClose
+        ) {
+          // Why: older builds read only the legacy alias, so persist one
+          // canonical value for both fields instead of retaining a split pair.
+          this.loadNeedsSave = true
+        }
         result = {
           ...defaults,
           ...parsed,
@@ -3401,8 +3415,10 @@ export class Store {
             appIcon: normalizeAppIconId(parsed.settings?.appIcon),
             mobilePairingCustomAddress,
             mobilePairingCustomAddresses,
-            // Why: persisted settings may be hand-edited or from older builds; keep tray-minimize false unless stored value is true.
-            minimizeToTrayOnClose: parsed.settings?.minimizeToTrayOnClose === true,
+            // Why: write the canonical setting and its Windows legacy alias as
+            // one value so upgrades and downgrades cannot split their behavior.
+            minimizeToTrayOnClose: keepServingOnClose,
+            keepServingOnClose,
             // Why: missing means default-on; round-trips unchanged on non-mac since darwin consumers gate the effect.
             showMenuBarIcon: parsed.settings?.showMenuBarIcon !== false,
             uiLanguage: normalizeUiLanguage(parsed.settings?.uiLanguage),
@@ -5693,7 +5709,18 @@ export class Store {
     const sanitizedUpdates = stripRetiredSettingsFields(updates)
     // Why: coerce to boolean here (not the IPC edge) so every write path is covered and a truthy non-bool can't persist as "tray-minimize on".
     if ('minimizeToTrayOnClose' in updates) {
-      sanitizedUpdates.minimizeToTrayOnClose = updates.minimizeToTrayOnClose === true
+      const enabled = updates.minimizeToTrayOnClose === true
+      sanitizedUpdates.minimizeToTrayOnClose = enabled
+      // Why: mirror the canonical flag so a bare legacy write cannot leave the
+      // two persisted compatibility fields split.
+      sanitizedUpdates.keepServingOnClose = enabled
+    }
+    if ('keepServingOnClose' in updates) {
+      const enabled = updates.keepServingOnClose === true
+      sanitizedUpdates.keepServingOnClose = enabled
+      // Why: mirror the legacy alias so a stale minimizeToTrayOnClose cannot
+      // re-enable a preference that the canonical setting disabled.
+      sanitizedUpdates.minimizeToTrayOnClose = enabled
     }
     if ('showMenuBarIcon' in updates) {
       sanitizedUpdates.showMenuBarIcon = updates.showMenuBarIcon === true

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -3668,7 +3668,7 @@ describe('createMainWindow', () => {
     })
   })
 
-  describe('minimize to tray on close (win32)', () => {
+  describe('keep serving on close (all platforms)', () => {
     const originalPlatform = process.platform
 
     function setPlatform(platform: NodeJS.Platform): void {
@@ -3718,10 +3718,18 @@ describe('createMainWindow', () => {
       return { windowHandlers, webContents, instance }
     }
 
-    function makeStore(minimizeToTrayOnClose: boolean, trayMinimizeNoticeShown: boolean) {
+    function makeStore(
+      minimizeToTrayOnClose: boolean,
+      trayMinimizeNoticeShown: boolean,
+      keepServingOnClose = false
+    ) {
       return {
         getUI: vi.fn(() => ({ trayMinimizeNoticeShown })),
-        getSettings: vi.fn(() => ({ windowBackgroundBlur: false, minimizeToTrayOnClose })),
+        getSettings: vi.fn(() => ({
+          windowBackgroundBlur: false,
+          minimizeToTrayOnClose,
+          keepServingOnClose
+        })),
         updateUI: vi.fn()
       }
     }
@@ -3733,7 +3741,7 @@ describe('createMainWindow', () => {
     it('hides to the tray instead of closing when the setting is on', () => {
       setPlatform('win32')
       const { windowHandlers, webContents, instance } = setupCloseWindow()
-      const store = makeStore(true, true)
+      const store = makeStore(true, true, true)
 
       createMainWindow(store as never, { getIsQuitting: () => false })
       const preventDefault = vi.fn()
@@ -3744,6 +3752,36 @@ describe('createMainWindow', () => {
       expect(webContents.send).not.toHaveBeenCalledWith('window:close-requested', expect.anything())
       // Notice already shown, so it must not fire again.
       expect(notificationMock).not.toHaveBeenCalled()
+    })
+
+    it('hides on win32 with only keepServingOnClose set (legacy alias off)', () => {
+      setPlatform('win32')
+      const { windowHandlers, instance } = setupCloseWindow()
+      // Canonical flag on, legacy minimizeToTrayOnClose off — the guard reads the
+      // canonical flag only, so this must still hide.
+      const store = makeStore(false, true, true)
+
+      createMainWindow(store as never, { getIsQuitting: () => false })
+      windowHandlers.close({ preventDefault: vi.fn() } as never)
+
+      expect(instance.hide).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not hide when keepServingOnClose is false even if the legacy alias is stuck on', () => {
+      setPlatform('win32')
+      const { windowHandlers, webContents, instance } = setupCloseWindow()
+      // A desynced on-disk pair the load migration can produce for legacy data;
+      // the explicit canonical false must win over the stale alias.
+      const store = makeStore(true, true, false)
+
+      createMainWindow(store as never, { getIsQuitting: () => false })
+      windowHandlers.close({ preventDefault: vi.fn() } as never)
+
+      expect(instance.hide).not.toHaveBeenCalled()
+      expect(webContents.send).toHaveBeenCalledWith('window:close-requested', {
+        isQuitting: false,
+        requestId: expect.any(Number)
+      })
     })
 
     it('keeps the normal close flow when the setting is off', () => {
@@ -3764,7 +3802,7 @@ describe('createMainWindow', () => {
     it('does not hide on a real quit even with the setting on', () => {
       setPlatform('win32')
       const { windowHandlers, webContents, instance } = setupCloseWindow()
-      const store = makeStore(true, true)
+      const store = makeStore(true, true, true)
 
       createMainWindow(store as never, { getIsQuitting: () => true })
       windowHandlers.close({ preventDefault: vi.fn() } as never)
@@ -3780,7 +3818,7 @@ describe('createMainWindow', () => {
       setPlatform('win32')
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
       const { windowHandlers, instance } = setupCloseWindow()
-      const store = makeStore(true, true)
+      const store = makeStore(true, true, true)
 
       createMainWindow(store as never, { getIsQuitting: () => false })
       windowHandlers['render-process-gone']?.(
@@ -3798,7 +3836,7 @@ describe('createMainWindow', () => {
     it('shows the first-run notification once and persists the flag', () => {
       setPlatform('win32')
       const { windowHandlers } = setupCloseWindow()
-      const store = makeStore(true, false)
+      const store = makeStore(true, false, true)
 
       createMainWindow(store as never, { getIsQuitting: () => false })
       windowHandlers.close({ preventDefault: vi.fn() } as never)
@@ -3808,10 +3846,78 @@ describe('createMainWindow', () => {
       expect(store.updateUI).toHaveBeenCalledWith({ trayMinimizeNoticeShown: true })
     })
 
-    it('leaves the close handler unchanged off win32', () => {
+    it('hides on darwin when keepServingOnClose is on', () => {
       setPlatform('darwin')
       const { windowHandlers, webContents, instance } = setupCloseWindow()
-      const store = makeStore(true, true)
+      const store = makeStore(false, true, true)
+
+      createMainWindow(store as never, { getIsQuitting: () => false })
+      const preventDefault = vi.fn()
+      windowHandlers.close({ preventDefault } as never)
+
+      expect(preventDefault).toHaveBeenCalled()
+      expect(instance.hide).toHaveBeenCalledTimes(1)
+      expect(webContents.send).not.toHaveBeenCalledWith('window:close-requested', expect.anything())
+    })
+
+    it('hides on linux when keepServingOnClose is on', () => {
+      setPlatform('linux')
+      const { windowHandlers, webContents, instance } = setupCloseWindow()
+      const store = makeStore(false, true, true)
+
+      createMainWindow(store as never, { getIsQuitting: () => false })
+      windowHandlers.close({ preventDefault: vi.fn() } as never)
+
+      expect(instance.hide).toHaveBeenCalledTimes(1)
+      expect(webContents.send).not.toHaveBeenCalledWith('window:close-requested', expect.anything())
+    })
+
+    it('tells packaged Linux users to launch Orca without naming the screen-reader command', () => {
+      setPlatform('linux')
+      const { windowHandlers } = setupCloseWindow()
+      const store = makeStore(false, false, true)
+
+      createMainWindow(store as never, { getIsQuitting: () => false })
+      windowHandlers.close({ preventDefault: vi.fn() } as never)
+
+      expect(notificationMock).toHaveBeenCalledWith({
+        title: 'Orca',
+        body: 'Orca is still running and serving remote clients. Launch Orca again to reopen.'
+      })
+    })
+
+    it('does not hide on darwin when only the legacy alias is set (canonical off)', () => {
+      setPlatform('darwin')
+      const { windowHandlers, instance } = setupCloseWindow()
+      // The window layer trusts the canonical keepServingOnClose flag; the legacy
+      // alias reaches the hide path only through persistence load-migration.
+      const store = makeStore(true, true, false)
+
+      createMainWindow(store as never, { getIsQuitting: () => false })
+      windowHandlers.close({ preventDefault: vi.fn() } as never)
+
+      expect(instance.hide).not.toHaveBeenCalled()
+    })
+
+    it('does not hide on darwin during a real quit even with keepServingOnClose on', () => {
+      setPlatform('darwin')
+      const { windowHandlers, webContents, instance } = setupCloseWindow()
+      const store = makeStore(false, true, true)
+
+      createMainWindow(store as never, { getIsQuitting: () => true })
+      windowHandlers.close({ preventDefault: vi.fn() } as never)
+
+      expect(instance.hide).not.toHaveBeenCalled()
+      expect(webContents.send).toHaveBeenCalledWith('window:close-requested', {
+        isQuitting: true,
+        requestId: expect.any(Number)
+      })
+    })
+
+    it('keeps the normal close flow on darwin when neither setting is on', () => {
+      setPlatform('darwin')
+      const { windowHandlers, webContents, instance } = setupCloseWindow()
+      const store = makeStore(false, true, false)
 
       createMainWindow(store as never, { getIsQuitting: () => false })
       windowHandlers.close({ preventDefault: vi.fn() } as never)
@@ -3839,7 +3945,20 @@ describe('createMainWindow', () => {
       setPlatform('win32')
       const ipcHandlers = captureIpcHandlers()
       const { webContents, instance } = setupCloseWindow()
-      const store = makeStore(true, true)
+      const store = makeStore(true, true, true)
+
+      createMainWindow(store as never, { getIsQuitting: () => false })
+      ipcHandlers['window:request-close']?.()
+
+      expect(instance.hide).toHaveBeenCalledTimes(1)
+      expect(webContents.send).not.toHaveBeenCalledWith('window:close-requested', expect.anything())
+    })
+
+    it('hides on linux when the renderer-drawn X requests close', () => {
+      setPlatform('linux')
+      const ipcHandlers = captureIpcHandlers()
+      const { webContents, instance } = setupCloseWindow()
+      const store = makeStore(false, true, true)
 
       createMainWindow(store as never, { getIsQuitting: () => false })
       ipcHandlers['window:request-close']?.()

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -183,6 +183,25 @@ function syncTrafficLightPosition(win: BrowserWindow, zoomFactor: number): void 
   win.setWindowButtonPosition({ x: TRAFFIC_LIGHT_X, y })
 }
 
+// Why: the hide-on-close notice must name the correct restore path per platform
+// (Dock on macOS, tray on Windows, launching Orca on Linux) instead of the
+// old Windows-only "system tray" wording.
+function keepServingNoticeBody(): string {
+  if (process.platform === 'darwin') {
+    return translateMain(
+      'tray.keepServingNotice.macos',
+      'Orca is still running and serving remote clients. Reopen it from the Dock.'
+    )
+  }
+  if (process.platform === 'win32') {
+    return translateMain('tray.minimizeNotice.body', 'Orca is still running in the system tray')
+  }
+  return translateMain(
+    'tray.keepServingNotice.linux',
+    'Orca is still running and serving remote clients. Launch Orca again to reopen.'
+  )
+}
+
 type CreateMainWindowOptions = {
   /** Returns true when a manual app.quit() (Cmd+Q) is in progress, so the renderer skips the running-process confirm dialog. */
   getIsQuitting?: () => boolean
@@ -979,29 +998,32 @@ export function createMainWindow(
     }
   }
 
-  // Windows minimize-to-tray: hide instead of close when enabled; returns true when it hid so callers skip their close path.
+  // Why: keepServingOnClose (all platforms) HIDES the window instead of closing
+  // so the renderer stays alive and remote/SSH clients keep working. It reads the
+  // canonical flag only — persistence load-migration + updateSettings mirroring
+  // keep it authoritative over the legacy minimizeToTrayOnClose alias, so a stored
+  // explicit false wins even if the alias is stale. Skipped on a real quit (Cmd+Q /
+  // tray "Quit" set getIsQuitting) and when the renderer is gone/crashed. Returns
+  // true when it handled the close by hiding, so callers skip their normal close
+  // path. Shared by BOTH the renderer-drawn X (window:request-close) and the native
+  // close event (Alt+F4 / macOS traffic light).
   const hideToTrayIfEnabled = (): boolean => {
     const isRendererCrashed = mainWindow.webContents.isCrashed?.() ?? false
+    const settings = store?.getSettings()
     if (
-      process.platform !== 'win32' ||
       rendererProcessGone ||
       isRendererCrashed ||
       opts?.getIsQuitting?.() === true ||
-      store?.getSettings().minimizeToTrayOnClose !== true
+      settings?.keepServingOnClose !== true
     ) {
       return false
     }
     mainWindow.hide()
-    // Why: notify once that closing only hid the window; the persisted flag stops it repeating on every later minimize.
-    if (store.getUI().trayMinimizeNoticeShown !== true) {
+    // Why: tell the user once that closing only hid the window; the persisted
+    // flag stops the notice from repeating on every later close.
+    if (store && store.getUI().trayMinimizeNoticeShown !== true) {
       try {
-        new Notification({
-          title: 'Orca',
-          body: translateMain(
-            'tray.minimizeNotice.body',
-            'Orca is still running in the system tray'
-          )
-        }).show()
+        new Notification({ title: 'Orca', body: keepServingNoticeBody() }).show()
       } catch {
         // Notification is best-effort — never block hiding the window.
       }
@@ -1011,7 +1033,8 @@ export function createMainWindow(
   }
 
   mainWindow.on('close', (e) => {
-    // Why: Alt+F4/programmatic closes hit the native event; apply the same minimize-to-tray guard the renderer-drawn X uses.
+    // Why: Alt+F4 and programmatic closes reach the native event; apply the same
+    // hide-on-close guard the renderer-drawn X uses via onRequestClose.
     if (!windowCloseConfirmed && hideToTrayIfEnabled()) {
       e.preventDefault()
       return
@@ -1094,7 +1117,9 @@ export function createMainWindow(
     if (mainWindow.isDestroyed()) {
       return
     }
-    // Why: renderer-drawn X routes here (not the native close event), so the minimize-to-tray guard must also run here.
+    // Why: the renderer-drawn X on Windows routes here (not the native close
+    // event), so the minimize-to-tray guard must run on this path too — hide
+    // instead of asking the renderer to close.
     if (hideToTrayIfEnabled()) {
       return
     }

--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -39,8 +39,8 @@ type AppearanceInterfaceSectionProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
   applyTheme: (theme: 'system' | 'dark' | 'light') => void
   fontSuggestions: string[]
+  isDesktop: boolean
   isDesktopMac: boolean
-  isDesktopWindows: boolean
   onRequestFontSuggestions?: () => void
   forceVisiblePrimary?: boolean
 }
@@ -50,8 +50,8 @@ export function AppearanceInterfaceSection({
   updateSettings,
   applyTheme,
   fontSuggestions,
+  isDesktop,
   isDesktopMac,
-  isDesktopWindows,
   onRequestFontSuggestions,
   forceVisiblePrimary = false
 }: AppearanceInterfaceSectionProps): React.JSX.Element {
@@ -70,7 +70,7 @@ export function AppearanceInterfaceSection({
   const zoomEntry = getZoomEntries()[0]
   const advancedEntries = [
     ...getTitlebarEntries(),
-    ...getSystemTrayEntries({ showSystemTray: isDesktopWindows }),
+    ...getSystemTrayEntries({ showSystemTray: isDesktop }),
     ...getMenuBarIconEntries({ showMenuBarIcon: isDesktopMac })
   ]
   const showAdvanced = !isSearching || matchesSettingsSearch(searchQuery, advancedEntries)
@@ -218,29 +218,29 @@ export function AppearanceInterfaceSection({
               />
             </SearchableSetting>
 
-            {isDesktopWindows ? (
+            {isDesktop ? (
               <SearchableSetting
                 title={translate(
-                  'auto.components.settings.AppearancePane.2edf606c46',
-                  'Minimize to Tray on Close'
+                  'auto.components.settings.AppearancePane.keepServingOnClose.title',
+                  'Keep Serving on Close'
                 )}
                 description={systemTrayEntry?.description}
-                keywords={systemTrayEntry?.keywords ?? ['tray', 'minimize', 'close']}
+                keywords={systemTrayEntry?.keywords ?? ['tray', 'serving', 'remote', 'close']}
               >
                 <SettingsSwitchRow
                   label={translate(
-                    'auto.components.settings.AppearancePane.2edf606c46',
-                    'Minimize to Tray on Close'
+                    'auto.components.settings.AppearancePane.keepServingOnClose.title',
+                    'Keep Serving on Close'
                   )}
-                  // Why: platform constraint + "close keeps Orca running" consequence are
-                  // both non-obvious from the label alone.
+                  // Why: the "close keeps Orca serving remote clients" consequence is
+                  // not obvious from the label alone.
                   description={translate(
-                    'auto.components.settings.AppearancePane.b707773a0d',
-                    'When enabled, closing the window keeps Orca running in the system tray instead of quitting.'
+                    'auto.components.settings.AppearancePane.keepServingOnClose.description',
+                    'When enabled, closing the window keeps Orca running so remote, mobile, and SSH clients stay served, instead of quitting.'
                   )}
-                  checked={settings.minimizeToTrayOnClose === true}
+                  checked={settings.keepServingOnClose === true}
                   onChange={() =>
-                    updateSettings({ minimizeToTrayOnClose: !settings.minimizeToTrayOnClose })
+                    updateSettings({ keepServingOnClose: !settings.keepServingOnClose })
                   }
                 />
               </SearchableSetting>

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -475,6 +475,22 @@ describe('AppearancePane', () => {
     expect(updateSettings).toHaveBeenCalledWith({ showMenuBarIcon: false })
   })
 
+  it('shows and updates keep-serving-on-close on desktop Linux', async () => {
+    mocks.state.appPlatform = 'linux'
+    mocks.state.settingsSearchQuery = 'keep serving'
+    const updateSettings = vi.fn()
+    const container = await renderAppearancePane(getDefaultSettings('/tmp'), updateSettings)
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="Keep Serving on Close"]'
+    )
+
+    expect(toggle).not.toBeNull()
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(updateSettings).toHaveBeenCalledWith({ keepServingOnClose: true })
+  })
+
   it('keeps description-only search matches visible after helper text is hidden', async () => {
     mocks.state.settingsSearchQuery = 'app window'
     const container = await renderAppearancePane(getDefaultSettings('/tmp'))

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -80,9 +80,7 @@ export function AppearancePane({
   )
   const isSearching = normalizeSettingsSearchQuery(searchQuery).length > 0
   const isWebClient = isWebClientLocation()
-  // Why: the system tray behavior is desktop-Electron Windows-only; a Windows
-  // browser web client has no local tray to control.
-  const isDesktopWindows = getRendererAppPlatform() === 'win32' && !isWebClient
+  const isDesktop = !isWebClient
   const isDesktopMac = getRendererAppPlatform() === 'darwin' && !isWebClient
 
   // Why: Terminal / Window settings were too easy to miss when only Interface
@@ -142,7 +140,7 @@ export function AppearancePane({
     ...getTypographyEntries(),
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),
     ...getTitlebarEntries(),
-    ...getSystemTrayEntries({ showSystemTray: isDesktopWindows }),
+    ...getSystemTrayEntries({ showSystemTray: !isWebClient }),
     ...getMenuBarIconEntries({ showMenuBarIcon: isDesktopMac })
   ]
   const terminalSearchEntries = [
@@ -222,8 +220,8 @@ export function AppearancePane({
             applyTheme={applyTheme}
             fontSuggestions={fontSuggestions}
             onRequestFontSuggestions={onRequestFontSuggestions}
+            isDesktop={isDesktop}
             isDesktopMac={isDesktopMac}
-            isDesktopWindows={isDesktopWindows}
             forceVisiblePrimary={interfaceLabelMatches}
           />
         </AppearanceSection>

--- a/src/renderer/src/components/settings/appearance-system-presence-search.ts
+++ b/src/renderer/src/components/settings/appearance-system-presence-search.ts
@@ -8,12 +8,12 @@ import { translateSearchKeyword } from './settings-search-keywords'
 const getSystemTrayEntryCatalog = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate(
-      'auto.components.settings.appearance.search.9a115966d3',
-      'Minimize to Tray on Close'
+      'auto.components.settings.AppearancePane.keepServingOnClose.title',
+      'Keep Serving on Close'
     ),
     description: translate(
-      'auto.components.settings.appearance.search.4d5b9427b5',
-      'When enabled, closing the window keeps Orca running in the system tray instead of quitting.'
+      'auto.components.settings.AppearancePane.keepServingOnClose.description',
+      'When enabled, closing the window keeps Orca running so remote, mobile, and SSH clients stay served, instead of quitting.'
     ),
     keywords: [
       ...translateSearchKeyword('auto.components.settings.appearance.search.tray.tray', 'tray', {
@@ -25,8 +25,8 @@ const getSystemTrayEntryCatalog = createLocalizedCatalog((): SettingsSearchEntry
         { englishOnly: true }
       ),
       ...translateSearchKeyword(
-        'auto.components.settings.appearance.search.tray.minimize',
-        'minimize',
+        'auto.components.settings.appearance.search.tray.serving',
+        'keep serving remote',
         { englishOnly: true }
       ),
       ...translateSearchKeyword('auto.components.settings.appearance.search.tray.close', 'close', {
@@ -89,8 +89,9 @@ export function getSystemTrayEntries(
 ): SettingsSearchEntry[] {
   const show =
     options.showSystemTray ??
-    // Why: a Windows web client can report win32, but it has no local tray.
-    (getRendererAppPlatform() === 'win32' && !isWebClientLocation())
+    // Why: the close behavior is available on every desktop platform, while a
+    // web client has no local window lifecycle to control.
+    !isWebClientLocation()
   return show ? getSystemTrayEntryCatalog() : []
 }
 

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -165,12 +165,12 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(webEntries.some((entry) => entry.title === 'Import from Ghostty')).toBe(true)
   })
 
-  it('includes the system tray appearance entry only when desktop tray controls are shown', () => {
+  it('includes the keep-serving-on-close appearance entry only when desktop controls are shown', () => {
     const desktopEntries = getAppearancePaneSearchEntries({ showSystemTray: true })
     const webEntries = getAppearancePaneSearchEntries({ showSystemTray: false })
 
-    expect(desktopEntries.some((entry) => entry.title === 'Minimize to Tray on Close')).toBe(true)
-    expect(webEntries.some((entry) => entry.title === 'Minimize to Tray on Close')).toBe(false)
+    expect(desktopEntries.some((entry) => entry.title === 'Keep Serving on Close')).toBe(true)
+    expect(webEntries.some((entry) => entry.title === 'Keep Serving on Close')).toBe(false)
     expect(matchesSettingsSearch('tray', desktopEntries)).toBe(true)
     expect(matchesSettingsSearch('tray', webEntries)).toBe(false)
   })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -99,6 +99,10 @@
     "minimizeNotice": {
       "body": "Orca is still running in the system tray"
     },
+    "keepServingNotice": {
+      "macos": "Orca is still running and serving remote clients. Reopen it from the Dock.",
+      "linux": "Orca is still running and serving remote clients. Launch Orca again to reopen."
+    },
     "activityWaiting": "Orca - activity waiting",
     "activityWaitingSuffix": "activity waiting"
   },
@@ -5581,6 +5585,10 @@
           "statusBarCount": "{{value0}} indicators visible.",
           "gitIgnoredGlossary": "Files matched by .gitignore.",
           "statusBarDescription": "Choose which indicators appear in the status bar.",
+          "keepServingOnClose": {
+            "title": "Keep Serving on Close",
+            "description": "When enabled, closing the window keeps Orca running so remote, mobile, and SSH clients stay served, instead of quitting."
+          },
           "showPinnedWorktreesInGroups": {
             "title": "Also show pinned worktrees in their original lists",
             "description": "Pinned worktrees stay in Pinned and also appear in All, Project, Status, and PR."

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -72,6 +72,10 @@
     "minimizeNotice": {
       "body": "Orca sigue ejecutándose en la bandeja del sistema"
     },
+    "keepServingNotice": {
+      "macos": "Orca sigue ejecutándose y atendiendo a clientes remotos. Vuelve a abrirlo desde el Dock.",
+      "linux": "Orca sigue ejecutándose y atendiendo a clientes remotos. Inicia Orca de nuevo para volver a abrirlo."
+    },
     "activityWaiting": "Orca: actividad en espera",
     "activityWaitingSuffix": "activity waiting"
   },
@@ -5415,6 +5419,10 @@
           "statusBarCount": "{{value0}} indicadores visibles.",
           "gitIgnoredGlossary": "Archivos que coinciden con .gitignore.",
           "statusBarDescription": "Elige qué indicadores aparecen en la barra de estado.",
+          "keepServingOnClose": {
+            "title": "Seguir ofreciendo servicio al cerrar",
+            "description": "Cuando está activado, cerrar la ventana mantiene Orca en ejecución para seguir atendiendo a clientes remotos, móviles y SSH, en lugar de salir."
+          },
           "showPinnedWorktreesInGroups": {
             "title": "Mostrar también los worktrees fijados en sus listas originales",
             "description": "Los worktrees fijados permanecen en Fijados y también aparecen en Todos, Proyecto, Estado y PR."

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -72,6 +72,10 @@
     "minimizeNotice": {
       "body": "Orcaはシステムトレイで実行中です"
     },
+    "keepServingNotice": {
+      "macos": "Orca は引き続き実行され、リモートクライアントにサービスを提供しています。Dock から再度開けます。",
+      "linux": "Orca は引き続き実行され、リモートクライアントにサービスを提供しています。Orca をもう一度起動すると再度開けます。"
+    },
     "activityWaiting": "Orca - アクティビティ待機中",
     "activityWaitingSuffix": "activity waiting"
   },
@@ -5400,6 +5404,10 @@
           "statusBarCount": "{{value0}} 個のインジケーターが表示中。",
           "gitIgnoredGlossary": ".gitignore に一致するファイル。",
           "statusBarDescription": "Choose which indicators appear in the status bar.",
+          "keepServingOnClose": {
+            "title": "閉じた後もサービスを継続",
+            "description": "有効にすると、ウインドウを閉じても Orca は終了せず、リモート、モバイル、SSH クライアントへのサービスを継続します。"
+          },
           "showPinnedWorktreesInGroups": {
             "title": "ピン留めしたワークツリーを元のリストにも表示",
             "description": "ピン留めしたワークツリーを Pinned に残したまま、すべて、プロジェクト、ステータス、PR にも表示します。"

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -72,6 +72,10 @@
     "minimizeNotice": {
       "body": "Orca가 시스템 트레이에서 계속 실행 중입니다"
     },
+    "keepServingNotice": {
+      "macos": "Orca가 계속 실행되며 원격 클라이언트에 서비스를 제공하고 있습니다. Dock에서 다시 열 수 있습니다.",
+      "linux": "Orca가 계속 실행되며 원격 클라이언트에 서비스를 제공하고 있습니다. Orca를 다시 실행하면 창이 열립니다."
+    },
     "activityWaiting": "Orca - 활동 대기 중",
     "activityWaitingSuffix": "activity waiting"
   },
@@ -5400,6 +5404,10 @@
           "statusBarCount": "{{value0}}개 표시기가 보입니다.",
           "gitIgnoredGlossary": ".gitignore와 일치하는 파일.",
           "statusBarDescription": "상태 표시줄에 표시할 항목을 선택합니다.",
+          "keepServingOnClose": {
+            "title": "창을 닫아도 서비스 계속 제공",
+            "description": "활성화하면 창을 닫아도 Orca가 종료되지 않고 원격, 모바일 및 SSH 클라이언트에 계속 서비스를 제공합니다."
+          },
           "showPinnedWorktreesInGroups": {
             "title": "고정된 워크트리를 원래 목록에도 표시",
             "description": "고정된 워크트리는 Pinned에 유지하면서 전체, 프로젝트, 상태 및 PR에도 표시합니다."

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -72,6 +72,10 @@
     "minimizeNotice": {
       "body": "Orca 仍在系统托盘中运行"
     },
+    "keepServingNotice": {
+      "macos": "Orca 仍在运行并为远程客户端提供服务。可从程序坞重新打开。",
+      "linux": "Orca 仍在运行并为远程客户端提供服务。再次启动 Orca 即可重新打开。"
+    },
     "activityWaiting": "Orca - 活动等待中",
     "activityWaitingSuffix": "activity waiting"
   },
@@ -5412,6 +5416,10 @@
           "statusBarCount": "显示 {{value0}} 个指示器。",
           "gitIgnoredGlossary": "与 .gitignore 匹配的文件。",
           "statusBarDescription": "选择状态栏中显示哪些指示器。",
+          "keepServingOnClose": {
+            "title": "关闭窗口后继续提供服务",
+            "description": "启用后，关闭窗口不会退出 Orca，远程、移动端和 SSH 客户端仍可继续使用服务。"
+          },
           "showPinnedWorktreesInGroups": {
             "title": "也在原来的列表中显示已固定的工作树",
             "description": "已固定的工作树会保留在 Pinned 中，同时也显示在全部、项目、状态和 PR 中。"

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -244,6 +244,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFocusFollowsMouse: false,
     windowBackgroundBlur: false,
     minimizeToTrayOnClose: false,
+    keepServingOnClose: false,
     // Why: default-on everywhere so it round-trips across platforms; only darwin acts on it.
     showMenuBarIcon: true,
     terminalClipboardOnSelect: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2821,8 +2821,13 @@ export type GlobalSettings = {
   terminalCursorOpacity?: number
   terminalQuickCommands?: TerminalQuickCommand[]
   windowBackgroundBlur?: boolean
-  /** Windows-only: close (X) hides to tray instead of quitting; the tray icon is always present regardless. */
+  /** Why: Windows-only legacy alias of keepServingOnClose. Kept so existing
+   *  Windows users' stored preference still applies; new writes mirror
+   *  keepServingOnClose. The Windows tray icon is always present regardless. */
   minimizeToTrayOnClose?: boolean
+  /** Why: hiding instead of destroying the window preserves the renderer-owned
+   *  runtime graph that serves remote, mobile, and SSH clients. */
+  keepServingOnClose?: boolean
   /** macOS: toggles the additive menu-bar entry (Orca survives last-window close); doesn't change Dock behavior. */
   showMenuBarIcon?: boolean
   /** Windows convention: right-click pastes; macOS/Linux keep the context menu. */


### PR DESCRIPTION
## Summary

**Problem:** Closing the host window drops paired mobile/CLI clients because the desktop app quits (or tears down the renderer) even when remote sessions are still connected.

**Repro (2 lines):**
1. Pair a phone or connect a remote client while the desktop host is running.
2. Close the main window (without Quit) — the remote client loses the host.

This PR adds `keepServingOnClose` (canonical; `minimizeToTrayOnClose` remains the Windows legacy alias, mirrored on load/update). When enabled, the close path **hides** the window instead of destroying it so the renderer/runtime keep serving remotes. Notices reuse main’s tray/Dock restore copy (macOS Dock / Windows tray / Linux relaunch).

**Reuses main’s affordances:** `hideToTrayIfEnabled` / close-handler path in `createMainWindow.ts`, `showMenuBarIcon` / system tray already on main — no parallel tray icon modules.

## Screenshots

No visual design change beyond a settings row under Appearance (system presence).

## Testing

- [x] `src/main/window/createMainWindow.test.ts` + `src/main/persistence.test.ts` + `window-all-closed-quit-policy.test.ts` + `AppearancePane.test.tsx` — **563/563 pass**
- [ ] Full suite / typecheck / build — not run

## ELI5

There’s a setting that means “when I close the window, keep Orca running in the background so my phone stays connected.” On Windows it still uses the tray; on Mac you reopen from the Dock.

## AI Review Report

Close-path + settings schema + Appearance UI + i18n only. Cross-platform hide-on-close with platform-specific notice text; no new tray binaries. Dropped old parallel tray modules (main already ships tray/menu-bar).

## Security Audit

No new IPC surface. Setting is boolean persisted locally. Notifications are best-effort.

## Notes

Re-port onto current main as one clean commit (old branch was far behind). Does not reintroduce `showTrayIconWhileClosed`, `mac-template-icon.ts`, `tray-attention-icon.ts`, `activate-window-policy.ts`, or `keep-serving-search.ts`.
