### PR TITLE
fix(shortcuts): preserve native input-source switching

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -6,7 +6,11 @@ import type { IDisposable } from '@xterm/xterm'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
 import { safeFind } from '../terminal-search-safe-find'
-import { resolveTerminalShortcutAction } from './terminal-shortcut-policy'
+import {
+  consumeNativeOnlyTerminalShortcutCompanion,
+  getTerminalShortcutKeyIdentity,
+  resolveTerminalShortcutAction
+} from './terminal-shortcut-policy'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
 import {
   keybindingMatchesAction,
@@ -229,6 +233,7 @@ export function useTerminalKeyboardShortcuts({
     // held. To distinguish left vs right Option, we record the Option key's
     // location from its own keydown event and clear it on keyup.
     let optionKeyLocation = 0
+    const pendingNativeOnlyShortcutKeys = new Set<string>()
     const onModifierDown = (e: KeyboardEvent): void => {
       if (e.key === 'Alt') {
         optionKeyLocation = e.location
@@ -254,6 +259,8 @@ export function useTerminalKeyboardShortcuts({
     }
 
     const onKeyDown = (e: KeyboardEvent): void => {
+      const shortcutKeyIdentity = getTerminalShortcutKeyIdentity(e)
+      pendingNativeOnlyShortcutKeys.delete(shortcutKeyIdentity)
       const manager = managerRef.current
       if (!manager) {
         return
@@ -348,6 +355,14 @@ export function useTerminalKeyboardShortcuts({
         getActivePaneWindowsShiftEnterEncoding
       )
       if (!action) {
+        return
+      }
+
+      if (action.type === 'switchInputSource') {
+        // Why: the OS must receive its default action, while xterm must receive
+        // none of the keydown, keypress, or keyup sequence.
+        pendingNativeOnlyShortcutKeys.add(shortcutKeyIdentity)
+        e.stopImmediatePropagation()
         return
       }
 
@@ -560,13 +575,28 @@ export function useTerminalKeyboardShortcuts({
       }
     }
 
+    const onNativeOnlyShortcutCompanion = (e: KeyboardEvent): void => {
+      if (consumeNativeOnlyTerminalShortcutCompanion(e, pendingNativeOnlyShortcutKeys)) {
+        // Why: canceling only the companion keypress prevents Chromium's text
+        // insertion without canceling the keydown default used by the OS switch.
+        if (e.type === 'keypress') {
+          e.preventDefault()
+        }
+        e.stopImmediatePropagation()
+      }
+    }
+
     window.addEventListener('keydown', onModifierDown, { capture: true })
     window.addEventListener('keyup', onModifierUp, { capture: true })
     window.addEventListener('keydown', onKeyDown, { capture: true })
+    window.addEventListener('keypress', onNativeOnlyShortcutCompanion, { capture: true })
+    window.addEventListener('keyup', onNativeOnlyShortcutCompanion, { capture: true })
     return () => {
       window.removeEventListener('keydown', onModifierDown, { capture: true })
       window.removeEventListener('keyup', onModifierUp, { capture: true })
       window.removeEventListener('keydown', onKeyDown, { capture: true })
+      window.removeEventListener('keypress', onNativeOnlyShortcutCompanion, { capture: true })
+      window.removeEventListener('keyup', onNativeOnlyShortcutCompanion, { capture: true })
     }
   }, [
     isActive,

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  consumeNativeOnlyTerminalShortcutCompanion,
+  getTerminalShortcutKeyIdentity,
   resolveTerminalShortcutAction,
   type TerminalShortcutEvent
 } from './terminal-shortcut-policy'
@@ -644,6 +646,60 @@ describe('resolveTerminalShortcutAction', () => {
         true
       )
     ).toEqual({ type: 'splitActivePane', direction: 'horizontal' })
+  })
+
+  it('resolves terminal.switchInputSource via explicit override (for OS input-source chords)', () => {
+    // Why: the configured chord must route to the native-only handler rather
+    // than the terminal shortcut paths that cancel the browser default.
+    const overrides = { 'terminal.switchInputSource': ['Shift+Space'] }
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: ' ', code: 'Space', shiftKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        overrides
+      )
+    ).toEqual({ type: 'switchInputSource' })
+
+    const otherChord = { 'terminal.switchInputSource': ['Ctrl+Space'] }
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: ' ', code: 'Space', ctrlKey: true }),
+        false,
+        'false',
+        0,
+        false,
+        otherChord
+      )
+    ).toEqual({ type: 'switchInputSource' })
+  })
+
+  it('does not resolve switchInputSource for ordinary chords without override', () => {
+    expect(
+      resolveTerminalShortcutAction(event({ key: ' ', code: 'Space', shiftKey: true }), true)
+    ).toBeNull()
+  })
+
+  it('suppresses the full companion event sequence for a native-only shortcut', () => {
+    const pendingKeys = new Set([
+      getTerminalShortcutKeyIdentity(event({ key: ' ', code: 'Space', shiftKey: true }))
+    ])
+
+    expect(
+      consumeNativeOnlyTerminalShortcutCompanion(
+        { type: 'keypress', key: ' ', code: 'Space' },
+        pendingKeys
+      )
+    ).toBe(true)
+    expect(
+      consumeNativeOnlyTerminalShortcutCompanion(
+        { type: 'keyup', key: ' ', code: 'Space' },
+        pendingKeys
+      )
+    ).toBe(true)
+    expect(pendingKeys.size).toBe(0)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -11,6 +11,10 @@ export type TerminalShortcutEvent = {
   repeat?: boolean
 }
 
+type TerminalShortcutCompanionEvent = Pick<TerminalShortcutEvent, 'key' | 'code'> & {
+  type: string
+}
+
 export type MacOptionAsAlt = 'true' | 'false' | 'left' | 'right'
 
 // Why: macOS composition replaces event.key for punctuation, so we map
@@ -42,6 +46,30 @@ export type TerminalShortcutAction =
   | { type: 'splitActivePane'; direction: 'vertical' | 'horizontal' }
   | { type: 'scrollViewport'; position: 'top' | 'bottom' }
   | { type: 'sendInput'; data: string }
+  | { type: 'switchInputSource' }
+
+export function getTerminalShortcutKeyIdentity(
+  event: Pick<TerminalShortcutEvent, 'key' | 'code'>
+): string {
+  return event.code || event.key
+}
+
+export function consumeNativeOnlyTerminalShortcutCompanion(
+  event: TerminalShortcutCompanionEvent,
+  pendingKeys: Set<string>
+): boolean {
+  if (event.type !== 'keypress' && event.type !== 'keyup') {
+    return false
+  }
+  const identity = getTerminalShortcutKeyIdentity(event)
+  if (!pendingKeys.has(identity)) {
+    return false
+  }
+  if (event.type === 'keyup') {
+    pendingKeys.delete(identity)
+  }
+  return true
+}
 
 /** Kitty keyboard protocol modifier field: 1 + shift(1) + alt(2). */
 function kittyAltModifiers(shiftKey: boolean): number {
@@ -93,6 +121,13 @@ export function resolveTerminalShortcutAction(
   getWindowsShiftEnterEncoding?: () => WindowsShiftEnterEncoding
 ): TerminalShortcutAction | null {
   const platform: NodeJS.Platform = isMac ? 'darwin' : isWindows ? 'win32' : 'linux'
+
+  // Why: native-only chords must be captured even on repeat without blocking
+  // the OS default that performs the input-source switch.
+  if (keybindingMatchesAction('terminal.switchInputSource', event, platform, keybindings)) {
+    return { type: 'switchInputSource' }
+  }
+
   if (!event.repeat) {
     if (keybindingMatchesAction('terminal.copySelection', event, platform, keybindings)) {
       return { type: 'copySelection' }

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts
@@ -145,6 +145,12 @@ describe('shouldBypassXtermKeyboardEvent — Windows/Linux', () => {
       shouldBypassXtermKeyboardEvent(event({ key: 'c', code: 'KeyC', metaKey: true }), noSel)
     ).toBe(false)
   })
+
+  it('leaves ordinary Shift+Space available to the terminal', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(event({ key: ' ', code: 'Space', shiftKey: true }), noSel)
+    ).toBe(false)
+  })
 })
 
 describe('shouldSuppressTerminalImeKeyboardEvent — Windows/Linux', () => {

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -148,6 +148,12 @@ describe('shouldBypassXtermKeyboardEvent — macOS', () => {
       shouldBypassXtermKeyboardEvent(event({ key: 'A', code: 'KeyA', shiftKey: true }), opts)
     ).toBe(false)
   })
+
+  it('leaves ordinary Shift+Space available to the terminal', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(event({ key: ' ', code: 'Space', shiftKey: true }), opts)
+    ).toBe(false)
+  })
 })
 
 describe('shouldSuppressTerminalImeKeyboardEvent — macOS', () => {

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -78,6 +78,22 @@ describe('keybindings', () => {
     })
   })
 
+  it('allows Shift-only chords only for native input-source switching', () => {
+    const shiftSpace = {
+      key: ' ',
+      code: 'Space',
+      control: false,
+      meta: false,
+      alt: false,
+      shift: true
+    }
+
+    expect(keybindingFromInput(shiftSpace, 'darwin')).toMatchObject({ ok: false })
+    expect(
+      keybindingFromInputForAction('terminal.switchInputSource', shiftSpace, 'darwin')
+    ).toEqual({ ok: true, value: 'Shift+Space' })
+  })
+
   it('captures key events into canonical editable shortcuts', () => {
     expect(
       keybindingFromInput(

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -109,6 +109,7 @@ export type KeybindingActionId =
   | 'terminal.closePane'
   | 'terminal.splitRight'
   | 'terminal.splitDown'
+  | 'terminal.switchInputSource'
 
 export type KeybindingOverrides = Partial<Record<KeybindingActionId, string[]>>
 
@@ -144,6 +145,7 @@ export type KeybindingDefinition = {
   defaultBindings: PlatformBindings
   allowInTerminal?: boolean
   allowBareKeybindings?: boolean
+  allowShiftOnlyKeybindings?: boolean
   conflictGroup?: string
 }
 
@@ -177,6 +179,7 @@ type ParsedKeybinding = {
 
 type NormalizeKeybindingOptions = {
   allowBareKeybindings?: boolean
+  allowShiftOnlyKeybindings?: boolean
 }
 
 export type KeybindingValidationResult = { ok: true; value: string } | { ok: false; error: string }
@@ -1003,6 +1006,32 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
       win32: ['Alt+Shift+D']
     }
   },
+  {
+    id: 'terminal.switchInputSource',
+    title: 'Switch input source / language (native)',
+    group: 'Terminal Panes',
+    scope: 'terminal',
+    searchKeywords: [
+      'shortcut',
+      'input',
+      'source',
+      'language',
+      'korean',
+      'english',
+      'ime',
+      'switch',
+      'hangul',
+      'layout'
+    ],
+    defaultBindings: {
+      darwin: [],
+      linux: [],
+      win32: []
+    },
+    // Why: macOS permits Shift+Space as an input-source shortcut, while normal
+    // Orca actions reject Shift-only bindings to avoid stealing typed text.
+    allowShiftOnlyKeybindings: true
+  },
   ...buildAgentTabKeybindingDefinitions()
 ]
 
@@ -1337,13 +1366,21 @@ function normalizeKeybindingWithOptions(
   }
   const isShiftInsert = parsed.shift && parsed.key === 'Insert'
   const isBareAllowed = options.allowBareKeybindings === true && isSafeBareKey(parsed)
+  const isShiftOnlyAllowed =
+    options.allowShiftOnlyKeybindings === true &&
+    parsed.shift &&
+    !parsed.mod &&
+    !parsed.meta &&
+    !parsed.control &&
+    !parsed.alt
   if (
     !parsed.mod &&
     !parsed.meta &&
     !parsed.control &&
     !parsed.alt &&
     !isShiftInsert &&
-    !isBareAllowed
+    !isBareAllowed &&
+    !isShiftOnlyAllowed
   ) {
     return { ok: false, error: 'Include at least one modifier key.' }
   }
@@ -1403,8 +1440,10 @@ function normalizeKeybindingArrayWithOptions(
 }
 
 function normalizeOptionsForAction(actionId: KeybindingActionId): NormalizeKeybindingOptions {
+  const definition = DEFINITIONS_BY_ID.get(actionId)
   return {
-    allowBareKeybindings: DEFINITIONS_BY_ID.get(actionId)?.allowBareKeybindings === true
+    allowBareKeybindings: definition?.allowBareKeybindings === true,
+    allowShiftOnlyKeybindings: definition?.allowShiftOnlyKeybindings === true
   }
 }
 
@@ -1713,7 +1752,8 @@ export function keybindingFromInputForAction(
 function getDefaultBindings(definition: KeybindingDefinition, platform: NodeJS.Platform): string[] {
   return definition.defaultBindings[getKeybindingPlatform(platform)].map((binding) => {
     const normalized = normalizeKeybindingWithOptions(binding, {
-      allowBareKeybindings: definition.allowBareKeybindings === true
+      allowBareKeybindings: definition.allowBareKeybindings === true,
+      allowShiftOnlyKeybindings: definition.allowShiftOnlyKeybindings === true
     })
     return normalized.ok ? normalized.value : binding
   })


### PR DESCRIPTION
## Summary

Fixes #8299.

- add an unassigned terminal shortcut action for native input-source/language switching
- allow Shift-only chords such as `Shift+Space` only for that explicitly configured action
- suppress the matching `keydown`, `keypress`, and `keyup` sequence before xterm/PTY input while leaving the native keydown default available to macOS
- preserve ordinary `Shift+Space` terminal input for users who do not configure the action

The root cause was that stopping only xterm's keydown path was insufficient: Chromium/xterm could still emit the literal space through the companion keypress/input path, and Kitty keyboard mode could emit a key release. The native-only action now tracks the physical chord through keyup and cancels text insertion only on the companion keypress, after macOS has had the keydown default available for input-source switching.

## Screenshots

No visual design change. The existing Shortcuts settings UI automatically surfaces the new unassigned Terminal Panes action.

## Testing

- [x] `pnpm lint` (Node 24.18.0)
- [x] `pnpm typecheck` (Node 24.18.0; also run as part of the production build)
- [x] `pnpm test` (Node 24.18.0: 2,054 files and 20,802 tests passed)
- [x] `pnpm build` (Node 24.18.0)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Regression coverage verifies action-specific `Shift+Space` normalization, shortcut resolution, full keypress/keyup companion suppression, and that ordinary `Shift+Space` remains available on macOS, Linux, and Windows when the action is unassigned.

Manual macOS verification confirmed both halves of the flow:

- configured `Shift+Space` no longer inserts a literal space in a focused terminal
- binding the native-only action to the system's `Control+Space` input-source chord switches languages without terminal input

## AI Review Report

Reviewed the complete diff and event flow from window capture through xterm and PTY delivery.

- Cross-platform: checked macOS, Linux, and Windows matching and labels. The action is unassigned on every platform, uses the shared runtime platform resolver, and does not globally steal `Shift+Space`.
- Local/remote/SSH: interception happens in renderer keyboard routing before xterm and PTY transport, so behavior is identical for local shells, SSH terminals, and remote/agent sessions.
- Agents/integrations/providers: behavior is terminal-scoped and independent of CLI agent, integration, and git provider.
- Electron/Kitty: the full keydown/keypress/keyup sequence is covered, including Kitty release-event leakage. `preventDefault()` is intentionally avoided on keydown so the OS/IME can switch input sources.
- Performance: the active terminal handler adds a small in-memory set and two capture listeners with constant-time lookup; listeners are removed with the existing effect cleanup.
- UI quality: no new layout, styling, tokens, or primitives; the existing Shortcuts UI renders the registry entry.

No blocking issues remained after review. The main product constraint is explicit: users must configure the Orca native-only action to the same chord consumed by their OS or IME.

## Security Audit

Reviewed keyboard input handling, keybinding parsing, and event propagation. The change adds no command execution, filesystem or path handling, network access, authentication, secrets, dependency changes, IPC, or privilege boundary. User-provided shortcut strings continue through the existing normalized keybinding parser and action-scoped validation. No new security risk or follow-up was identified.

## Notes

- Platform-specific behavior: the reported case is macOS input-source switching, while the configurable native-only action remains available across platforms for custom IMEs.
- Remote/SSH behavior: no transport-specific branch is needed because the event is consumed before PTY delivery.
- X (Twitter) handle: not provided; the contributor's GitHub profile does not list one.
