### PR TITLE
fix(daemon): resolve Unix shell fallback before node-pty spawn

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -221,6 +221,82 @@ describe('createPtySubprocess', () => {
     }
   })
 
+  it('derives shell-ready launch config from the resolved fallback shell', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    resolveUnixShellPathMock.mockReturnValue('/bin/sh')
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    const previousShell = process.env.SHELL
+    const previousMarker = process.env.ORCA_SHELL_READY_MARKER
+    const previousZdotdir = process.env.ZDOTDIR
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    delete process.env.SHELL
+    // Why: the test runner itself can execute inside an Orca-wrapped shell
+    // whose exported wrapper vars would leak through the process.env spread.
+    delete process.env.ORCA_SHELL_READY_MARKER
+    delete process.env.ZDOTDIR
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        env: {},
+        command: 'echo hi'
+      })
+
+      expect(handle.shellPath).toBe('/bin/sh')
+      const [shellPath, shellArgs, spawnOptions] = spawnMock.mock.calls[0]
+      expect(shellPath).toBe('/bin/sh')
+      expect(shellArgs).toEqual(['-l'])
+      // A launch config derived from the missing preferred zsh would inject
+      // ZDOTDIR and ORCA_SHELL_READY_MARKER; /bin/sh must spawn without them.
+      expect(spawnOptions.env.ZDOTDIR).toBeUndefined()
+      expect(spawnOptions.env.ORCA_SHELL_READY_MARKER).toBeUndefined()
+      expect(spawnOptions.env.SHELL).toBe('/bin/sh')
+    } finally {
+      warn.mockRestore()
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+      if (previousShell === undefined) {
+        delete process.env.SHELL
+      } else {
+        process.env.SHELL = previousShell
+      }
+      if (previousMarker === undefined) {
+        delete process.env.ORCA_SHELL_READY_MARKER
+      } else {
+        process.env.ORCA_SHELL_READY_MARKER = previousMarker
+      }
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+    }
+  })
+
+  it('surfaces the no-executable-shell error before node-pty forks', () => {
+    resolveUnixShellPathMock.mockImplementation(() => {
+      throw new Error('No executable Unix shell found (tried: /bin/zsh, /bin/bash, /bin/sh)')
+    })
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+
+    try {
+      expect(() => createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, env: {} })).toThrow(
+        'No executable Unix shell found'
+      )
+      expect(spawnMock).not.toHaveBeenCalled()
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('uses bundled ConPTY for native Windows daemon terminals', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -9,10 +9,12 @@ const {
   spawnMock,
   isPwshAvailableMock,
   validateWorkingDirectoryMock,
+  resolveUnixShellPathMock,
   resolveAgentForegroundProcessMock
 } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
   isPwshAvailableMock: vi.fn(),
+  resolveUnixShellPathMock: vi.fn((shellPath: string) => shellPath),
   resolveAgentForegroundProcessMock: vi.fn(),
   validateWorkingDirectoryMock: vi.fn((cwd: string) => {
     if (cwd.includes('definitely-missing')) {
@@ -51,6 +53,7 @@ vi.mock('../providers/local-pty-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof LocalPtyUtils>()
   return {
     ...actual,
+    resolveUnixShellPath: resolveUnixShellPathMock,
     validateWorkingDirectory: validateWorkingDirectoryMock
   }
 })
@@ -116,6 +119,8 @@ describe('createPtySubprocess', () => {
       async (_pid: number, fallbackProcess: string | null) => fallbackProcess
     )
     validateWorkingDirectoryMock.mockClear()
+    resolveUnixShellPathMock.mockReset()
+    resolveUnixShellPathMock.mockImplementation((shellPath: string) => shellPath)
     isPwshAvailableMock.mockReturnValue(false)
     previousUserDataPath = process.env.ORCA_USER_DATA_PATH
     previousPowerlevelWizardDisable = process.env[POWERLEVEL10K_WIZARD_DISABLE_ENV]
@@ -179,6 +184,41 @@ describe('createPtySubprocess', () => {
         name: 'xterm-256color'
       })
     )
+  })
+
+  it('resolves a missing Unix default before spawning node-pty', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    resolveUnixShellPathMock.mockReturnValue('/bin/sh')
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    const previousShell = process.env.SHELL
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    delete process.env.SHELL
+
+    try {
+      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24, env: {} })
+
+      expect(resolveUnixShellPathMock).toHaveBeenCalledWith('/bin/zsh')
+      expect(spawnMock).toHaveBeenCalledWith(
+        '/bin/sh',
+        ['-l'],
+        expect.objectContaining({ env: expect.objectContaining({ SHELL: '/bin/sh' }) })
+      )
+      expect(warn).toHaveBeenCalledWith(
+        '[daemon/pty] Preferred shell "/bin/zsh" is unavailable, fell back to "/bin/sh"'
+      )
+    } finally {
+      warn.mockRestore()
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+      if (previousShell === undefined) {
+        delete process.env.SHELL
+      } else {
+        process.env.SHELL = previousShell
+      }
+    }
   })
 
   it('uses bundled ConPTY for native Windows daemon terminals', () => {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -729,14 +729,6 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       addOrcaWslInteropEnv(env)
     }
   } else {
-    const preferredShellPath = shellPath
-    shellPath = resolveUnixShellPath(shellPath)
-    if (shellPath !== preferredShellPath) {
-      env.SHELL = shellPath
-      console.warn(
-        `[daemon/pty] Preferred shell "${preferredShellPath}" is unavailable, fell back to "${shellPath}"`
-      )
-    }
     // Why: relay-side launch modes can ask for host defaults to stay scrubbed
     // even after environment normalization above.
     for (const key of opts.envToDelete ?? []) {
@@ -744,6 +736,17 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     }
     if (opts.env?.TERM) {
       env.TERM = opts.env.TERM
+    }
+    // Why after the scrub: SHELL must reflect the shell that actually spawns,
+    // matching LocalPtyProvider; and before the launch-config derivation below
+    // so shell-ready wrappers target the resolved shell, not a missing one.
+    const preferredShellPath = shellPath
+    shellPath = resolveUnixShellPath(shellPath)
+    if (shellPath !== preferredShellPath) {
+      env.SHELL = shellPath
+      console.warn(
+        `[daemon/pty] Preferred shell "${preferredShellPath}" is unavailable, fell back to "${shellPath}"`
+      )
     }
     // Why: OpenCode/Codex path restoration and OMP's typed-command status
     // wrapper need shell-ready code after user startup files run.
@@ -1010,6 +1013,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
 
   return {
     pid: proc.pid,
+    shellPath,
     ...(startupCommandDeliveredInShellArgs ? { startupCommandDeliveredInShellArgs: true } : {}),
     getForegroundProcess: () => {
       // Why: node-pty's `.process` getter reports the PTY's live foreground

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -14,6 +14,7 @@ import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import {
   ensureNodePtySpawnHelperExecutable,
   getNodePtySpawnHelperCandidates,
+  resolveUnixShellPath,
   validateWorkingDirectory
 } from '../providers/local-pty-utils'
 import { wrapShellSpawnForMacosTccAttribution } from '../providers/macos-tcc-login-shell'
@@ -728,6 +729,14 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       addOrcaWslInteropEnv(env)
     }
   } else {
+    const preferredShellPath = shellPath
+    shellPath = resolveUnixShellPath(shellPath)
+    if (shellPath !== preferredShellPath) {
+      env.SHELL = shellPath
+      console.warn(
+        `[daemon/pty] Preferred shell "${preferredShellPath}" is unavailable, fell back to "${shellPath}"`
+      )
+    }
     // Why: relay-side launch modes can ask for host defaults to stay scrubbed
     // even after environment normalization above.
     for (const key of opts.envToDelete ?? []) {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -48,6 +48,10 @@ export type SubprocessHandle = {
   /** True when shell launch args already delivered the startup command, so the
    *  terminal host must skip its stdin fallback write. */
   startupCommandDeliveredInShellArgs?: boolean
+  /** Shell the subprocess actually spawned, after Unix/Windows fallbacks. The
+   *  host reconciles the caller's shell-ready assumption against it so a
+   *  fallback shell without a ready marker never gates startup commands. */
+  shellPath?: string
   write(data: string): void
   resize(cols: number, rows: number): void
   /** Stop reading the PTY fd (node-pty pause()) so the kernel/ConPTY buffer

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -348,13 +348,16 @@ export function resolvePtyShellPath(env: Record<string, string>): string {
   return env.SHELL || process.env.SHELL || '/bin/zsh'
 }
 
+export function shellPathSupportsPtyStartupBarrier(shellPath: string): boolean {
+  const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
+  return shellName === 'zsh' || shellName === 'bash'
+}
+
 export function supportsPtyStartupBarrier(env: Record<string, string>): boolean {
   if (process.platform === 'win32') {
     return false
   }
-  const resolvedShell = resolvePtyShellPath(env)
-  const shellName = pathWin32.basename(basename(resolvedShell)).toLowerCase()
-  return shellName === 'zsh' || shellName === 'bash'
+  return shellPathSupportsPtyStartupBarrier(resolvePtyShellPath(env))
 }
 
 type ShellLaunchConfig = {

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -3,7 +3,7 @@ import { Session, type SubprocessHandle } from './session'
 import { TerminalHost } from './terminal-host'
 
 function createMockSubprocess(
-  options: { startupCommandDeliveredInShellArgs?: boolean } = {}
+  options: { startupCommandDeliveredInShellArgs?: boolean; shellPath?: string } = {}
 ): SubprocessHandle {
   let onDataCb: ((data: string) => void) | null = null
   let onExitCb: ((code: number) => void) | null = null
@@ -12,6 +12,7 @@ function createMockSubprocess(
     ...(options.startupCommandDeliveredInShellArgs
       ? { startupCommandDeliveredInShellArgs: true }
       : {}),
+    ...(options.shellPath ? { shellPath: options.shellPath } : {}),
     getForegroundProcess: vi.fn(() => null),
     write: vi.fn(),
     resize: vi.fn(),
@@ -191,6 +192,88 @@ describe('TerminalHost', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+
+    it('delivers startup commands immediately when the spawned shell cannot emit the ready marker', async () => {
+      spawnFn = vi.fn(() => {
+        const sub = createMockSubprocess({ shellPath: '/bin/sh' }) as ReturnType<
+          typeof createMockSubprocess
+        > & {
+          _onDataCb: ((data: string) => void) | null
+          _onExitCb: ((code: number) => void) | null
+        }
+        lastSubprocess = sub
+        return sub
+      })
+      host.dispose()
+      host = new TerminalHost({ spawnSubprocess: spawnFn as MockSpawnFn })
+
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 80,
+        rows: 24,
+        command: 'echo hello',
+        shellReadySupported: true,
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+
+      expect(lastSubprocess.write).toHaveBeenCalledWith(
+        process.platform === 'win32' ? 'echo hello\r' : 'echo hello\n'
+      )
+    })
+
+    it('does not bracketed-paste-wrap multiline commands for a fallback shell without paste mode', async () => {
+      spawnFn = vi.fn(() => {
+        const sub = createMockSubprocess({ shellPath: '/bin/sh' }) as ReturnType<
+          typeof createMockSubprocess
+        > & {
+          _onDataCb: ((data: string) => void) | null
+          _onExitCb: ((code: number) => void) | null
+        }
+        lastSubprocess = sub
+        return sub
+      })
+      host.dispose()
+      host = new TerminalHost({ spawnSubprocess: spawnFn as MockSpawnFn })
+
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 80,
+        rows: 24,
+        command: 'claude "line one\nline two"',
+        shellReadySupported: true,
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+
+      const written = (lastSubprocess.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]
+      expect(written).not.toContain('\x1b[200~')
+      expect(written).toContain('line one\nline two')
+    })
+
+    it('keeps the shell-ready barrier when the spawned shell supports the marker', async () => {
+      spawnFn = vi.fn(() => {
+        const sub = createMockSubprocess({ shellPath: '/bin/bash' }) as ReturnType<
+          typeof createMockSubprocess
+        > & {
+          _onDataCb: ((data: string) => void) | null
+          _onExitCb: ((code: number) => void) | null
+        }
+        lastSubprocess = sub
+        return sub
+      })
+      host.dispose()
+      host = new TerminalHost({ spawnSubprocess: spawnFn as MockSpawnFn })
+
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 80,
+        rows: 24,
+        command: 'echo hello',
+        shellReadySupported: true,
+        streamClient: { onData: vi.fn(), onExit: vi.fn() }
+      })
+
+      expect(lastSubprocess.write).not.toHaveBeenCalled()
     })
 
     it('does not write startup commands already embedded in shell args', async () => {

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -1,5 +1,6 @@
 import { Session, type SubprocessHandle } from './session'
 import { normalizePtySize } from './daemon-pty-size'
+import { shellPathSupportsPtyStartupBarrier } from './shell-ready'
 import { resolveProcessCwd } from '../providers/process-cwd'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
@@ -104,6 +105,16 @@ export class TerminalHost {
       terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation
     })
 
+    // Why: the caller computed shellReadySupported from the preferred shell,
+    // before spawn. A Unix fallback (e.g. /bin/sh) never emits the ready
+    // marker, so keeping the stale flag would queue startup commands until the
+    // shell-ready timeout and bracketed-paste-wrap them for a line editor
+    // without paste mode.
+    const shellReadySupported =
+      (opts.shellReadySupported ?? false) &&
+      (subprocess.shellPath === undefined ||
+        shellPathSupportsPtyStartupBarrier(subprocess.shellPath))
+
     const session = new Session({
       sessionId: opts.sessionId,
       cols: size.cols,
@@ -111,7 +122,7 @@ export class TerminalHost {
       terminalHandle: opts.env?.ORCA_TERMINAL_HANDLE,
       launchAgent: opts.launchAgent,
       subprocess,
-      shellReadySupported: opts.shellReadySupported ?? false,
+      shellReadySupported,
       historySeed: opts.historySeed,
       // Why: reap the dead session (dispose emulator + drop from the map) the
       // moment its subprocess exits, instead of retaining it for the daemon's
@@ -143,7 +154,7 @@ export class TerminalHost {
       session.write(
         buildStartupCommandSubmission(opts.command, {
           submit,
-          bracketedPasteSafe: opts.shellReadySupported ?? false
+          bracketedPasteSafe: shellReadySupported
         })
       )
     }

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -138,6 +138,14 @@ describe('resolveUnixShellPath', () => {
       'No executable Unix shell found (tried: /missing/zsh, /bin/zsh, /bin/bash, /bin/sh)'
     )
   })
+
+  it('dedupes a preferred shell that is already a fallback candidate', () => {
+    existsSyncMock.mockImplementation((path) => path === '/bin/sh')
+    accessSyncMock.mockReturnValue(undefined)
+
+    expect(resolveUnixShellPath('/bin/sh')).toBe('/bin/sh')
+    expect(existsSyncMock.mock.calls.map(([path]) => path)).toEqual(['/bin/sh'])
+  })
 })
 
 describe('spawnShellWithFallback macOS TCC login wrapping', () => {

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -33,7 +33,11 @@ vi.mock('./macos-tcc-login-shell', () => ({
   wrapShellSpawnForMacosTccAttribution: wrapSpawnMock
 }))
 
-import { spawnShellWithFallback, validateWorkingDirectory } from './local-pty-utils'
+import {
+  resolveUnixShellPath,
+  spawnShellWithFallback,
+  validateWorkingDirectory
+} from './local-pty-utils'
 
 const WSL_UNC_DIR = '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo'
 const NATIVE_DIR = 'C:\\Users\\jin\\repo'
@@ -99,6 +103,40 @@ describe('validateWorkingDirectory', () => {
     statSyncMock.mockReturnValue(dirStats(false))
 
     expect(() => validateWorkingDirectory(NATIVE_DIR)).toThrow(/is not a directory/)
+  })
+})
+
+describe('resolveUnixShellPath', () => {
+  beforeEach(() => {
+    existsSyncMock.mockReset()
+    accessSyncMock.mockReset()
+  })
+
+  it('preserves non-absolute shells for execvp PATH and cwd resolution', () => {
+    expect(resolveUnixShellPath('bash')).toBe('bash')
+    expect(resolveUnixShellPath('./bin/custom-shell')).toBe('./bin/custom-shell')
+    expect(existsSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('selects an executable fallback before node-pty can fork a missing shell', () => {
+    existsSyncMock.mockImplementation((path) => path === '/bin/sh')
+    accessSyncMock.mockReturnValue(undefined)
+
+    expect(resolveUnixShellPath('/missing/zsh')).toBe('/bin/sh')
+    expect(existsSyncMock.mock.calls.map(([path]) => path)).toEqual([
+      '/missing/zsh',
+      '/bin/zsh',
+      '/bin/bash',
+      '/bin/sh'
+    ])
+  })
+
+  it('reports every attempted shell when no executable candidate exists', () => {
+    existsSyncMock.mockReturnValue(false)
+
+    expect(() => resolveUnixShellPath('/missing/zsh')).toThrow(
+      'No executable Unix shell found (tried: /missing/zsh, /bin/zsh, /bin/bash, /bin/sh)'
+    )
   })
 })
 

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,4 +1,4 @@
-import { basename, join } from 'node:path'
+import { basename, isAbsolute, join } from 'node:path'
 import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
 import type * as pty from 'node-pty'
 import { isWslUncPath } from '../../shared/wsl-paths'
@@ -6,6 +6,8 @@ import { wslUncDirectoryExists } from '../wsl'
 import { wrapShellSpawnForMacosTccAttribution } from './macos-tcc-login-shell'
 
 let didEnsureSpawnHelperExecutable = false
+
+const UNIX_SHELL_FALLBACKS = ['/bin/zsh', '/bin/bash', '/bin/sh'] as const
 
 function toUnpackedAsarPath(candidate: string): string {
   return candidate
@@ -44,6 +46,25 @@ export function getShellValidationError(shellPath: string): string | null {
     return `Shell "${shellPath}" is not executable. Check file permissions.`
   }
   return null
+}
+
+/**
+ * Resolves an absolute Unix shell before node-pty forks. Bare commands and
+ * relative paths stay untouched so execvp can resolve them against PATH or cwd.
+ */
+export function resolveUnixShellPath(shellPath: string): string {
+  if (!isAbsolute(shellPath)) {
+    return shellPath
+  }
+  const candidates = [
+    shellPath,
+    ...UNIX_SHELL_FALLBACKS.filter((candidate) => candidate !== shellPath)
+  ]
+  const resolved = candidates.find((candidate) => getShellValidationError(candidate) === null)
+  if (resolved) {
+    return resolved
+  }
+  throw new Error(`No executable Unix shell found (tried: ${candidates.join(', ')})`)
 }
 
 /**
@@ -252,7 +273,7 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
 
   // Try fallback shells on Unix
   if (process.platform !== 'win32') {
-    const fallbackShells = ['/bin/zsh', '/bin/bash', '/bin/sh'].filter((s) => s !== shellPath)
+    const fallbackShells = UNIX_SHELL_FALLBACKS.filter((candidate) => candidate !== shellPath)
     for (const fallback of fallbackShells) {
       if (getShellValidationError(fallback)) {
         continue


### PR DESCRIPTION
## Summary

On Linux, a failed `exec` inside node-pty's forked child does not throw — the child just dies, leaving a silently dead daemon terminal when the preferred shell (e.g. `/bin/zsh` default on hosts without zsh) is missing. This also hits SSH relay hosts, which run the same daemon spawn path.

- **Resolve the shell before spawning** (`resolveUnixShellPath`): validate the preferred shell pre-fork and fall back through `/bin/zsh` → `/bin/bash` → `/bin/sh`, matching `spawnShellWithFallback`'s local-provider chain. If nothing is executable, throw a clear error before node-pty forks (surfaced via the daemon RPC error path instead of a dead shell). Non-absolute shells are left untouched so execvp can resolve them against PATH/cwd. `env.SHELL` and the shell-ready launch config are derived from the resolved shell, matching LocalPtyProvider.
- **Reconcile the shell-ready barrier with the resolved shell**: the caller computes `shellReadySupported` from the preferred shell before spawn. A fallback shell without the ready marker (e.g. `/bin/sh`) would otherwise queue startup commands until the shell-ready timeout and bracketed-paste-wrap them for a line editor without paste mode. The subprocess handle now reports the shell that actually spawned, and `TerminalHost` drops the stale flag when that shell can't emit the marker.

## Testing

- `pnpm vitest run src/main/daemon src/main/providers` (1223 passed)
- `pnpm typecheck`, `pnpm exec oxlint` on touched files
- New unit coverage: fallback resolution order/dedupe/no-shell error, launch-config derivation from the resolved shell, and TerminalHost barrier reconciliation (immediate delivery + no paste-wrap for `/bin/sh`, barrier kept for bash).

Made with [Orca](https://github.com/stablyai/orca) 🐋
