### PR TITLE
fix(agent-status): clear answered Claude question waits

### DIFF
--- a/src/main/agent-hooks/server.claude-interactive-question.test.ts
+++ b/src/main/agent-hooks/server.claude-interactive-question.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { AgentHookServer } from './server'
+
+const PANE_KEY = makePaneKey('tab-question', '11111111-1111-4111-8111-111111111111')
+
+function ingestClaudeStatus(
+  server: AgentHookServer,
+  event: {
+    state: 'working' | 'waiting'
+    hookEventName: 'PermissionRequest' | 'PreToolUse'
+    toolName: string
+    toolUseId: string
+  }
+): void {
+  server.ingestRemote(
+    {
+      paneKey: PANE_KEY,
+      tabId: 'tab-question',
+      worktreeId: 'worktree-question',
+      hookEventName: event.hookEventName,
+      toolUseId: event.toolUseId,
+      payload: {
+        state: event.state,
+        agentType: 'claude',
+        toolName: event.toolName
+      }
+    },
+    'connection-1'
+  )
+}
+
+describe('Claude interactive-question status transitions', () => {
+  it('clears an AskUserQuestion wait when later tool work starts', () => {
+    const server = new AgentHookServer()
+
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PreToolUse',
+      toolName: 'AskUserQuestion',
+      toolUseId: 'tool-question'
+    })
+    ingestClaudeStatus(server, {
+      state: 'working',
+      hookEventName: 'PreToolUse',
+      toolName: 'Read',
+      toolUseId: 'tool-after-answer'
+    })
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE_KEY,
+        state: 'working',
+        agentType: 'claude',
+        toolName: 'Read'
+      })
+    ])
+  })
+
+  it('keeps an actual permission request sticky during unrelated tool work', () => {
+    const server = new AgentHookServer()
+
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PermissionRequest',
+      toolName: 'Bash',
+      toolUseId: 'tool-needs-permission'
+    })
+    ingestClaudeStatus(server, {
+      state: 'working',
+      hookEventName: 'PreToolUse',
+      toolName: 'Read',
+      toolUseId: 'tool-unrelated'
+    })
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE_KEY,
+        state: 'waiting',
+        agentType: 'claude',
+        toolName: 'Bash'
+      })
+    ])
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -314,6 +314,7 @@ function shouldKeepClaudePermissionVisible(
   if (
     previous?.payload.agentType !== 'claude' ||
     previous.payload.state !== 'waiting' ||
+    previous.hookEventName !== 'PermissionRequest' ||
     next.payload.agentType !== 'claude' ||
     next.payload.state !== 'working'
   ) {
@@ -325,9 +326,8 @@ function shouldKeepClaudePermissionVisible(
   if (isClaudePermissionResumingApprovedTool(previous, next)) {
     return false
   }
-  // Why: Claude can run subagents concurrently in one pane. Keep permission
-  // sticky unless the next hook has a source-level execution id that the
-  // PermissionRequest event itself does not expose.
+  // Why: only real permission requests stay sticky across concurrent subagent
+  // activity; interactive questions clear on the next working hook.
   return true
 }
 


### PR DESCRIPTION
## Summary

Clear Claude's needs-attention state after the user answers an interactive question and subsequent tool work begins.

`AskUserQuestion` waits arrive as `PreToolUse`, but the hook server previously treated every Claude `waiting → working` transition as a sticky permission request. A later `Read`, `Bash`, or `Edit` event therefore could not replace the stale wait unless it matched the original tool identity.

This change limits sticky retention to actual `PermissionRequest` events. Answered interactive questions can return to the existing working state, while genuine permission requests remain visible during unrelated tool activity.

Closes #8310.

## Screenshots

No visual change. The existing animated working indicator now resumes at the correct state transition.

Prior bug captured example: 
<img width="527" height="423" alt="image" src="https://github.com/user-attachments/assets/6de57cbd-9ec6-463a-baeb-91c2c43ebe8b" />


## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation completed with Node 24:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.claude-interactive-question.test.ts src/main/agent-hooks/server.test.ts src/shared/agent-hook-listener.test.ts --maxWorkers=1` — 319 tests passed
- `pnpm run typecheck:node`
- `pnpm exec oxfmt --check src/main/agent-hooks/server.ts src/main/agent-hooks/server.claude-interactive-question.test.ts`
- `pnpm exec oxlint src/main/agent-hooks/server.ts src/main/agent-hooks/server.claude-interactive-question.test.ts`
- `pnpm run check:max-lines-ratchet`

The full repository lint, typecheck, test, and build commands were not run locally; the corresponding checklist items remain unchecked.

## AI Review Report

Reviewed the final two-file diff and the surrounding Claude permission-retention logic.

- **Cross-platform:** The change adds one event-name comparison in platform-neutral TypeScript. It does not touch shortcuts, labels, paths, shells, or Electron platform APIs, so behavior is consistent on macOS, Linux, and Windows.
- **Local and SSH/remote:** Both local HTTP hook events and remote relay events converge on the same `applyNormalizedStatus` guard. The regression test exercises the remote ingestion path; the existing shared normalization and server suites cover the local normalization and permission behavior.
- **Agents and integrations:** The guard remains scoped to `agentType === 'claude'`. Other supported agents and integrations are unchanged. A control test verifies that genuine Claude `PermissionRequest` state remains sticky during unrelated tool work.
- **Performance:** The hot-path impact is a single string comparison only during Claude `waiting → working` transitions. No polling, allocation, or rendering work was added.
- **UI quality:** No layout, styling, copy, or component behavior changed. The fix only selects the already-existing working status at the correct time.

No additional issues were found during review.

## Security Audit

The change introduces no new commands, filesystem paths, dependencies, authentication behavior, secrets, network requests, or IPC surfaces. It compares the already-normalized `hookEventName` against the existing `PermissionRequest` event name before deciding whether to retain cached status. Input validation and trust-boundary normalization remain unchanged.

No security follow-up is needed.

## Notes

- Reproduced with Claude on a local macOS worktree in Orca 1.4.136-rc.0.
- The corrected transition is shared by local and SSH/remote hook ingestion.
- Pressing Esc and submitting another prompt already reset the stale status because those actions created explicit state boundaries; this fix handles the normal answer-and-continue path directly.
- X (Twitter) handle: not provided.
