### PR TITLE
feat: persist AI Vault view options across worktrees

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -173,6 +173,17 @@ const UiUpdate = z
     rightSidebarExplorerView: z.enum(['files', 'search']).optional(),
     rightSidebarWidth: z.number().finite().optional(),
     markdownTocPanelWidth: z.number().finite().optional(),
+    aiVaultViewOptions: z
+      .object({
+        // Disabled agents (see AiVaultViewOptions); lenient on ids so persisted
+        // state survives agent-catalog changes.
+        disabledAgents: z.array(z.string()),
+        sort: z.enum(['updated', 'created']),
+        group: z.enum(['project', 'folder', 'agent']),
+        hideEmptySessions: z.boolean()
+      })
+      .strict()
+      .optional(),
     groupBy: z.enum(['none', 'workspace-status', 'repo', 'pr-status']).optional(),
     showWorkspaceLineage: z.boolean().optional(),
     sortBy: z.enum(['name', 'smart', 'recent', 'repo', 'manual']).optional(),

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../shared/tui-agent-launch-defaults'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import { isTaskProvider } from '../../../../shared/task-providers'
+import { AI_VAULT_GROUPS, AI_VAULT_SORTS } from '../../../../shared/ai-vault-types'
 import { normalizeDisabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import { normalizeWorktreeCardProperties } from '../../../../shared/worktree-card-properties'
 import type { PersistedUIState, TaskProvider } from '../../../../shared/types'
@@ -178,8 +179,8 @@ const UiUpdate = z
         // Disabled agents (see AiVaultViewOptions); lenient on ids so persisted
         // state survives agent-catalog changes.
         disabledAgents: z.array(z.string()),
-        sort: z.enum(['updated', 'created']),
-        group: z.enum(['project', 'folder', 'agent']),
+        sort: z.enum(AI_VAULT_SORTS),
+        group: z.enum(AI_VAULT_GROUPS),
         hideEmptySessions: z.boolean()
       })
       .strict()

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -20,12 +20,7 @@ import {
   getRestorableAiVaultScope,
   normalizeAiVaultScopeForContext
 } from './ai-vault-scope-state'
-import {
-  countAiVaultViewAdjustments,
-  DEFAULT_AI_VAULT_GROUP,
-  DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS,
-  DEFAULT_AI_VAULT_SORT
-} from './ai-vault-view-defaults'
+import { countAiVaultViewAdjustments } from './ai-vault-view-defaults'
 import { buildAiVaultProjectContext } from './ai-vault-session-projects'
 import {
   resolveAiVaultSessionResumeActions,
@@ -35,14 +30,9 @@ import { useAiVaultSessionLaunchActions } from './ai-vault-session-launch-action
 import { useAiVaultSessionWorktreeMap } from './ai-vault-session-worktree'
 import { openAiVaultSessionLogInOrca } from './ai-vault-session-log-open'
 import { useAiVaultOriginalPaneActions } from './ai-vault-original-pane-actions'
-import {
-  AI_VAULT_AGENTS,
-  type AiVaultAgent,
-  type AiVaultGroup,
-  type AiVaultScope,
-  type AiVaultSession,
-  type AiVaultSort
-} from '../../../../shared/ai-vault-types'
+import type { AiVaultScope, AiVaultSession } from '../../../../shared/ai-vault-types'
+import { enabledAiVaultAgents } from '../../../../shared/ai-vault-view-options'
+import { useAiVaultViewOptionActions } from './use-ai-vault-view-option-actions'
 import { translate } from '@/i18n/i18n'
 import { AiVaultPanelHeader } from './AiVaultPanelHeader'
 import { AiVaultSessionVirtualList } from './AiVaultSessionVirtualList'
@@ -75,10 +65,17 @@ export default function AiVaultPanel(): React.JSX.Element {
     useAiVaultOriginalPaneActions()
   const [query, setQuery] = useState('')
   const [scope, setScope] = useState<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
-  const [sort, setSort] = useState<AiVaultSort>(DEFAULT_AI_VAULT_SORT)
-  const [group, setGroup] = useState<AiVaultGroup>(DEFAULT_AI_VAULT_GROUP)
-  const [hideEmptySessions, setHideEmptySessions] = useState(DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS)
-  const [agents, setAgents] = useState<AiVaultAgent[]>([...AI_VAULT_AGENTS])
+  // Agent filter / sort / grouping / hide-empty persist across worktree switches
+  // and panel reopens (issue #8146); scope and the query stay per-session.
+  const aiVaultViewOptions = useAppStore((s) => s.aiVaultViewOptions)
+  const setAiVaultViewOptions = useAppStore((s) => s.setAiVaultViewOptions)
+  const { sort, group, hideEmptySessions } = aiVaultViewOptions
+  // Enabled agents derive from the persisted disable-list so newly-shipped
+  // agents are on by default (see AiVaultViewOptions).
+  const agents = useMemo(
+    () => enabledAiVaultAgents(aiVaultViewOptions.disabledAgents),
+    [aiVaultViewOptions.disabledAgents]
+  )
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set())
   const userChangedScopeRef = useRef(false)
   const preferredScopeRef = useRef<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
@@ -281,22 +278,8 @@ export default function AiVaultPanel(): React.JSX.Element {
     ]
   )
 
-  const setAgentEnabled = useCallback((agent: AiVaultAgent, enabled: boolean) => {
-    setAgents((current) => {
-      if (enabled) {
-        return current.includes(agent) ? current : [...current, agent]
-      }
-      const next = current.filter((entry) => entry !== agent)
-      return next.length > 0 ? next : current
-    })
-  }, [])
-
-  const resetViewOptions = useCallback(() => {
-    setAgents([...AI_VAULT_AGENTS])
-    setSort(DEFAULT_AI_VAULT_SORT)
-    setGroup(DEFAULT_AI_VAULT_GROUP)
-    setHideEmptySessions(DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS)
-  }, [])
+  const { setSort, setGroup, setHideEmptySessions, setAgentEnabled, resetViewOptions } =
+    useAiVaultViewOptionActions(aiVaultViewOptions, setAiVaultViewOptions)
 
   const handleScopeChange = useCallback((nextScope: AiVaultScope) => {
     preferredScopeRef.current = nextScope

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-defaults.ts
@@ -4,12 +4,14 @@ import {
   type AiVaultGroup,
   type AiVaultSort
 } from '../../../../shared/ai-vault-types'
+import { DEFAULT_AI_VAULT_VIEW_OPTIONS } from '../../../../shared/ai-vault-view-options'
 
 // Why: hide-empty used to default true; keep initial state, badge count, and Reset view
 // on one constant so a default flip cannot leave Reset pointing at the old value.
-export const DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS = false
-export const DEFAULT_AI_VAULT_SORT: AiVaultSort = 'updated'
-export const DEFAULT_AI_VAULT_GROUP: AiVaultGroup = 'project'
+// Derived from the shared DEFAULT_AI_VAULT_VIEW_OPTIONS so persistence + UI agree.
+export const DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS = DEFAULT_AI_VAULT_VIEW_OPTIONS.hideEmptySessions
+export const DEFAULT_AI_VAULT_SORT: AiVaultSort = DEFAULT_AI_VAULT_VIEW_OPTIONS.sort
+export const DEFAULT_AI_VAULT_GROUP: AiVaultGroup = DEFAULT_AI_VAULT_VIEW_OPTIONS.group
 
 export function countAiVaultViewAdjustments(options: {
   agents: readonly AiVaultAgent[]

--- a/src/renderer/src/components/right-sidebar/use-ai-vault-view-option-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-ai-vault-view-option-actions.ts
@@ -1,0 +1,63 @@
+import { useCallback } from 'react'
+import type { AiVaultAgent, AiVaultGroup, AiVaultSort } from '../../../../shared/ai-vault-types'
+import {
+  cloneDefaultAiVaultViewOptions,
+  enabledAiVaultAgents,
+  type AiVaultViewOptions
+} from '../../../../shared/ai-vault-view-options'
+
+// The AI Vault view-menu handlers, each persisting through setOptions. The agent
+// toggle edits the disable-list (see AiVaultViewOptions) and keeps at least one
+// agent enabled.
+export function useAiVaultViewOptionActions(
+  options: AiVaultViewOptions,
+  setOptions: (next: AiVaultViewOptions) => void
+): {
+  setSort: (sort: AiVaultSort) => void
+  setGroup: (group: AiVaultGroup) => void
+  setHideEmptySessions: (hide: boolean) => void
+  setAgentEnabled: (agent: AiVaultAgent, enabled: boolean) => void
+  resetViewOptions: () => void
+} {
+  const setSort = useCallback(
+    (sort: AiVaultSort) => setOptions({ ...options, sort }),
+    [options, setOptions]
+  )
+
+  const setGroup = useCallback(
+    (group: AiVaultGroup) => setOptions({ ...options, group }),
+    [options, setOptions]
+  )
+
+  const setHideEmptySessions = useCallback(
+    (hide: boolean) => setOptions({ ...options, hideEmptySessions: hide }),
+    [options, setOptions]
+  )
+
+  const setAgentEnabled = useCallback(
+    (agent: AiVaultAgent, enabled: boolean) => {
+      const disabled = options.disabledAgents
+      const isDisabled = disabled.includes(agent)
+      // Already in the desired state → nothing to persist.
+      if (enabled === !isDisabled) {
+        return
+      }
+      const nextDisabled = enabled
+        ? disabled.filter((entry) => entry !== agent)
+        : [...disabled, agent]
+      // Keep at least one agent enabled.
+      if (enabledAiVaultAgents(nextDisabled).length === 0) {
+        return
+      }
+      setOptions({ ...options, disabledAgents: nextDisabled })
+    },
+    [options, setOptions]
+  )
+
+  const resetViewOptions = useCallback(
+    () => setOptions(cloneDefaultAiVaultViewOptions()),
+    [setOptions]
+  )
+
+  return { setSort, setGroup, setHideEmptySessions, setAgentEnabled, resetViewOptions }
+}

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -2,6 +2,10 @@
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultUIState, getWorktreeCardModeProperties } from '../../../../shared/constants'
+import {
+  cloneDefaultAiVaultViewOptions,
+  type AiVaultViewOptions
+} from '../../../../shared/ai-vault-view-options'
 import type {
   GitHubWorkItem,
   JiraIssue,
@@ -907,6 +911,43 @@ describe('createUISlice hydratePersistedUI', () => {
       workspaceHostScope: 'runtime:env-1',
       visibleWorkspaceHostIds: ['runtime:env-1']
     })
+  })
+
+  it('defaults AI Vault view options to all agents, updated sort, project grouping, hide-empty off', () => {
+    expect(createUIStore().getState().aiVaultViewOptions).toEqual(cloneDefaultAiVaultViewOptions())
+  })
+
+  it('hydrates persisted AI Vault view options', () => {
+    const store = createUIStore()
+    const persisted: AiVaultViewOptions = {
+      disabledAgents: ['codex'],
+      sort: 'created',
+      group: 'agent',
+      hideEmptySessions: true
+    }
+    store.getState().hydratePersistedUI(makePersistedUI({ aiVaultViewOptions: persisted }))
+    expect(store.getState().aiVaultViewOptions).toEqual(persisted)
+  })
+
+  it('falls back to default AI Vault view options when older persisted state omits them', () => {
+    const store = createUIStore()
+    store.getState().hydratePersistedUI(makePersistedUI({ aiVaultViewOptions: undefined }))
+    expect(store.getState().aiVaultViewOptions).toEqual(cloneDefaultAiVaultViewOptions())
+  })
+
+  it('persists AI Vault view option changes', () => {
+    const setUI = vi.fn(() => Promise.resolve())
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+    const next: AiVaultViewOptions = {
+      disabledAgents: ['gemini'],
+      sort: 'created',
+      group: 'folder',
+      hideEmptySessions: true
+    }
+    store.getState().setAiVaultViewOptions(next)
+    expect(store.getState().aiVaultViewOptions).toEqual(next)
+    expect(setUI).toHaveBeenCalledWith({ aiVaultViewOptions: next })
   })
 
   it('persists visible workspace host changes independently of focused host', () => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1943,8 +1943,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
 
   aiVaultViewOptions: cloneDefaultAiVaultViewOptions(),
   setAiVaultViewOptions: (options) => {
-    window.api.ui.set({ aiVaultViewOptions: options }).catch(console.error)
-    set({ aiVaultViewOptions: options })
+    // Normalize before persisting (like the sibling setters) so a partially
+    // built object from a future caller can't write an invalid shape to disk.
+    const normalized = normalizeAiVaultViewOptions(options)
+    window.api.ui.set({ aiVaultViewOptions: normalized }).catch(console.error)
+    set({ aiVaultViewOptions: normalized })
   },
 
   sortBy: 'recent',

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -66,6 +66,11 @@ import {
   normalizeWorktreeCardProperties
 } from '../../../../shared/constants'
 import {
+  cloneDefaultAiVaultViewOptions,
+  normalizeAiVaultViewOptions,
+  type AiVaultViewOptions
+} from '../../../../shared/ai-vault-view-options'
+import {
   DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
   normalizeBrowserPageZoomLevel
 } from '../../../../shared/browser-page-zoom'
@@ -826,6 +831,8 @@ export type UISlice = {
   dismissUsageEmptyState: () => void
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   setGroupBy: (g: UISlice['groupBy']) => void
+  aiVaultViewOptions: AiVaultViewOptions
+  setAiVaultViewOptions: (options: AiVaultViewOptions) => void
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   setSortBy: (s: UISlice['sortBy']) => void
   projectOrderBy: ProjectOrderBy
@@ -1934,6 +1941,12 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ groupBy: g, collapsedGroups: new Set<string>() })
   },
 
+  aiVaultViewOptions: cloneDefaultAiVaultViewOptions(),
+  setAiVaultViewOptions: (options) => {
+    window.api.ui.set({ aiVaultViewOptions: options }).catch(console.error)
+    set({ aiVaultViewOptions: options })
+  },
+
   sortBy: 'recent',
   setSortBy: (s) => set({ sortBy: s }),
 
@@ -2365,6 +2378,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         rightSidebarTab: rightSidebarRoute.rightSidebarTab,
         rightSidebarExplorerView: rightSidebarRoute.rightSidebarExplorerView,
         groupBy: (ui.groupBy as UISlice['groupBy'] | 'parent') === 'parent' ? 'repo' : ui.groupBy,
+        aiVaultViewOptions: normalizeAiVaultViewOptions(ui.aiVaultViewOptions),
         sortBy,
         // Why: main-process getUI() already normalized this to a valid value
         // (defaulting to 'manual'); read it through without migrating sortBy.

--- a/src/shared/ai-vault-types.test.ts
+++ b/src/shared/ai-vault-types.test.ts
@@ -1,10 +1,79 @@
 import { describe, expect, it } from 'vitest'
 import {
   aiVaultSessionRecoverableSignalCount,
+  AI_VAULT_AGENTS,
   isAiVaultSessionRecoverableEmpty,
   isAiVaultSessionResumableContent,
   type AiVaultSessionPreviewMessage
 } from './ai-vault-types'
+import {
+  cloneDefaultAiVaultViewOptions,
+  DEFAULT_AI_VAULT_VIEW_OPTIONS,
+  enabledAiVaultAgents,
+  normalizeAiVaultViewOptions
+} from './ai-vault-view-options'
+
+describe('cloneDefaultAiVaultViewOptions', () => {
+  it('returns the documented defaults (no agents disabled)', () => {
+    expect(cloneDefaultAiVaultViewOptions()).toEqual({
+      disabledAgents: [],
+      sort: 'updated',
+      group: 'project',
+      hideEmptySessions: false
+    })
+  })
+
+  it('returns a fresh copy whose disabledAgents array is not shared with the default', () => {
+    const clone = cloneDefaultAiVaultViewOptions()
+    clone.disabledAgents.push('claude')
+    expect(DEFAULT_AI_VAULT_VIEW_OPTIONS.disabledAgents).toEqual([])
+    expect(cloneDefaultAiVaultViewOptions().disabledAgents).toEqual([])
+  })
+})
+
+describe('enabledAiVaultAgents', () => {
+  it('enables the whole catalog when nothing is disabled', () => {
+    expect(enabledAiVaultAgents([])).toEqual([...AI_VAULT_AGENTS])
+  })
+
+  it('drops disabled agents but keeps catalog order (so new agents stay enabled)', () => {
+    const enabled = enabledAiVaultAgents(['codex'])
+    expect(enabled).not.toContain('codex')
+    // Every other catalog agent — including any future addition — remains enabled.
+    expect(enabled).toEqual(AI_VAULT_AGENTS.filter((agent) => agent !== 'codex'))
+  })
+})
+
+describe('normalizeAiVaultViewOptions', () => {
+  it('passes through a valid value', () => {
+    const value = {
+      disabledAgents: ['codex'],
+      sort: 'created',
+      group: 'agent',
+      hideEmptySessions: true
+    }
+    expect(normalizeAiVaultViewOptions(value)).toEqual(value)
+  })
+
+  it('falls back to defaults for corrupt / hand-edited state', () => {
+    expect(normalizeAiVaultViewOptions({ disabledAgents: 42, sort: 'nope', group: 5 })).toEqual(
+      cloneDefaultAiVaultViewOptions()
+    )
+    expect(normalizeAiVaultViewOptions(undefined)).toEqual(cloneDefaultAiVaultViewOptions())
+    expect(normalizeAiVaultViewOptions('claude')).toEqual(cloneDefaultAiVaultViewOptions())
+  })
+
+  it('strips unknown agent ids from the disabled set', () => {
+    expect(
+      normalizeAiVaultViewOptions({
+        disabledAgents: ['codex', 'not-an-agent', 7],
+        sort: 'updated',
+        group: 'project',
+        hideEmptySessions: false
+      }).disabledAgents
+    ).toEqual(['codex'])
+  })
+})
 
 type SignalFields = {
   messageCount: number

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -32,8 +32,12 @@ export const AI_VAULT_SCOPE_PATHS_MAX_COUNT = 64
 
 export type AiVaultAgent = (typeof AI_VAULT_AGENTS)[number]
 export type AiVaultScope = 'workspace' | 'project' | 'all'
-export type AiVaultSort = 'updated' | 'created'
-export type AiVaultGroup = 'project' | 'folder' | 'agent'
+// Runtime tuples so the RPC Zod schema can reuse the same allowed values
+// instead of re-listing them (single source of truth for sort/group).
+export const AI_VAULT_SORTS = ['updated', 'created'] as const
+export const AI_VAULT_GROUPS = ['project', 'folder', 'agent'] as const
+export type AiVaultSort = (typeof AI_VAULT_SORTS)[number]
+export type AiVaultGroup = (typeof AI_VAULT_GROUPS)[number]
 
 export const AI_VAULT_AGENT_LABELS = {
   claude: 'Claude',

--- a/src/shared/ai-vault-view-options.ts
+++ b/src/shared/ai-vault-view-options.ts
@@ -1,0 +1,52 @@
+import { AI_VAULT_AGENTS, type AiVaultAgent, type AiVaultGroup, type AiVaultSort } from './ai-vault-types'
+
+// The Agent Session History view options that persist across worktree switches
+// and panel reopens (issue #8146). Scope and the search query stay per-session.
+export type AiVaultViewOptions = {
+  // Agents the user turned OFF, persisted as a disable-list (not an enable-list)
+  // so agents added to AI_VAULT_AGENTS in a later release stay visible by default
+  // instead of silently vanishing from an existing user's frozen enabled-list.
+  disabledAgents: AiVaultAgent[]
+  sort: AiVaultSort
+  group: AiVaultGroup
+  hideEmptySessions: boolean
+}
+
+// Single source of truth for the view-option defaults (see the renderer's
+// ai-vault-view-defaults.ts, which derives its constants from this).
+export const DEFAULT_AI_VAULT_VIEW_OPTIONS: AiVaultViewOptions = {
+  disabledAgents: [],
+  sort: 'updated',
+  group: 'project',
+  hideEmptySessions: false
+}
+
+export function cloneDefaultAiVaultViewOptions(): AiVaultViewOptions {
+  return { ...DEFAULT_AI_VAULT_VIEW_OPTIONS, disabledAgents: [] }
+}
+
+// Enabled agents = the current catalog minus the persisted disabled set, in
+// catalog order. New agents are enabled by default; agents dropped from the
+// catalog fall away.
+export function enabledAiVaultAgents(disabledAgents: readonly AiVaultAgent[]): AiVaultAgent[] {
+  const disabled = new Set<string>(disabledAgents)
+  return AI_VAULT_AGENTS.filter((agent) => !disabled.has(agent))
+}
+
+// Shape-guard for at-rest / hand-edited persisted state (the write path is
+// Zod-validated, but a corrupt state file must not crash or blank the panel).
+export function normalizeAiVaultViewOptions(value: unknown): AiVaultViewOptions {
+  const record = value && typeof value === 'object' ? (value as Partial<AiVaultViewOptions>) : {}
+  const catalog = new Set<string>(AI_VAULT_AGENTS)
+  const disabledAgents = Array.isArray(record.disabledAgents)
+    ? record.disabledAgents.filter(
+        (agent): agent is AiVaultAgent => typeof agent === 'string' && catalog.has(agent)
+      )
+    : []
+  return {
+    disabledAgents,
+    sort: record.sort === 'created' ? 'created' : 'updated',
+    group: record.group === 'folder' || record.group === 'agent' ? record.group : 'project',
+    hideEmptySessions: record.hideEmptySessions === true
+  }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -10,6 +10,7 @@ import type {
   WorkspaceSessionState,
   AgentActivityDisplayMode
 } from './types'
+import { cloneDefaultAiVaultViewOptions } from './ai-vault-view-options'
 import { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
 import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
@@ -466,6 +467,7 @@ export function getDefaultUIState(): PersistedUIState {
     rightSidebarExplorerView: 'files',
     rightSidebarWidth: 350,
     markdownTocPanelWidth: 240,
+    aiVaultViewOptions: cloneDefaultAiVaultViewOptions(),
     groupBy: 'repo',
     sortBy: 'recent',
     projectOrderBy: 'manual',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import type { AiVaultViewOptions } from './ai-vault-view-options'
 import type { ExecutionHostId } from './execution-host'
 import type { RemovedSshTargetTombstone, SshRemotePtyLease, SshTarget } from './ssh-types'
 import type { Automation, AutomationExecutionTargetType, AutomationRun } from './automations-types'
@@ -3239,6 +3240,9 @@ export type PersistedUIState = {
   rightSidebarExplorerView: RightSidebarExplorerView
   rightSidebarWidth: number
   markdownTocPanelWidth?: number
+  /** Persisted Agent Session History (AI Vault) view options — agent filter,
+   *  sort, grouping, hide-empty — kept across worktree switches and reopens. */
+  aiVaultViewOptions?: AiVaultViewOptions
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   /** Project header ordering in `groupBy: 'repo'`, independent of workspace


### PR DESCRIPTION
## What

Persists the **Agent Session History** (AI Vault) view options — agent filter, sort, grouping, and hide-empty — so they survive worktree switches, panel reopens, and app restarts instead of resetting to defaults each time.

Closes #8146.

## Why

The view options were component-local `useState`, re-seeded on every mount. Users who work with a small subset of agents had to re-apply their agent filter / sort / grouping every time they switched context or reopened the panel — the exact pain the issue describes.

## How

- Adds `aiVaultViewOptions` to `PersistedUIState` (default in `constants.ts`), a validated field on the `ui.set` RPC schema (`client-ui.ts`), and state + setter + hydration in the UI store slice. `AiVaultPanel` now reads/writes the persisted value; scope and the search query stay per-session by design.
- **The agent filter is persisted as the set of _disabled_ agents, not an enabled allowlist.** This keeps agents added to `AI_VAULT_AGENTS` in a later release enabled by default for existing users, rather than silently vanishing from a frozen list — the same guarantee the app already provides for status-bar items. Enabled agents are derived as `catalog − disabled`.
- A `normalizeAiVaultViewOptions` shape-guard on the read/hydration path keeps a corrupt or legacy (hand-edited / older-schema) persisted value from crashing or blanking the panel; the write path is Zod-validated.
- View-option defaults are single-sourced in `shared/ai-vault-view-options.ts`; the view-menu handlers moved to a focused hook.

## Testing

- New unit tests: the shared view-options helpers (defaults, enabled-derivation keeping new agents on, normalizer rejecting corrupt/legacy shapes and stripping unknown agent ids), and the store slice (default, hydration, legacy-fallback, and persistence of changes).
- `typecheck`, `oxlint`, the AI Vault + right-sidebar + UI-store suites (1390 tests), and both `electron-vite` and web builds pass.
- Verified live: changed the options (disabled two agents, Created sort, Folder grouping, hide-empty on), reloaded the renderer, and confirmed the options were restored from persistence rather than reset; the legacy on-disk value was migrated cleanly by the normalizer.

Screenshot below.