### PR TITLE
feat(status-bar): notify upgraded users usage meters show % used

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -562,6 +562,50 @@ describe('Store', () => {
     expect(ui.setupGuideSidebarDismissed).toBe(false)
     expect(ui.setupGuideBrowserMilestoneMigrated).toBe(true)
     expect(ui.setupGuideBrowserMilestoneLegacyComplete).toBe(false)
+    // Why: brand-new profiles never saw remaining-as-default.
+    expect(ui.usagePercentageDisplayChangeNoticeDismissed).toBe(true)
+  })
+
+  it('surfaces the usage percentage display change notice for upgraded profiles', async () => {
+    const persisted = getDefaultPersistedState(testState.dir)
+    writeDataFile({
+      ...persisted,
+      onboarding: {
+        ...persisted.onboarding,
+        closedAt: 1,
+        outcome: 'completed'
+      },
+      ui: {
+        ...persisted.ui,
+        // Why: omit the notice key so load resolves eligibility for existing profiles.
+        usagePercentageDisplayChangeNoticeDismissed: undefined
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getUI().usagePercentageDisplayChangeNoticeDismissed).toBe(false)
+  })
+
+  it('keeps the usage percentage display change notice dismissed when remaining was chosen', async () => {
+    const persisted = getDefaultPersistedState(testState.dir)
+    writeDataFile({
+      ...persisted,
+      onboarding: {
+        ...persisted.onboarding,
+        closedAt: 1,
+        outcome: 'completed'
+      },
+      ui: {
+        ...persisted.ui,
+        usagePercentageDisplay: 'remaining',
+        usagePercentageDisplayChangeNoticeDismissed: undefined
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getUI().usagePercentageDisplayChangeNoticeDismissed).toBe(true)
   })
 
   it('defaults minimizeToTrayOnClose to false when unset', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -105,6 +105,8 @@ import {
 } from '../shared/constants'
 import { parseWorkspaceSession } from '../shared/workspace-session-schema'
 import { normalizeUsagePercentageDisplay } from '../shared/usage-percentage-display'
+import { isExistingPersistedProfile } from '../shared/project-order-manual-default-notice'
+import { resolveUsagePercentageDisplayChangeNoticeDismissed } from '../shared/usage-percentage-display-change-notice'
 import {
   LOCAL_EXECUTION_HOST_ID,
   normalizeExecutionHostOrder,
@@ -3306,6 +3308,25 @@ export class Store {
             ) {
               this.loadNeedsSave = true
             }
+            // Why: only upgraded profiles that still use the new default get
+            // the one-time usage-display change notice; brand-new profiles and
+            // users who already chose remaining stay quiet.
+            const usagePercentageDisplayChangeNoticeDismissed =
+              resolveUsagePercentageDisplayChangeNoticeDismissed({
+                rawDismissed: parsed.ui?.usagePercentageDisplayChangeNoticeDismissed,
+                rawUsagePercentageDisplay: parsed.ui?.usagePercentageDisplay,
+                isExistingProfile: isExistingPersistedProfile({
+                  repoCount: parsed.repos?.length ?? 0,
+                  onboardingClosedAt: normalizedOnboarding.closedAt,
+                  ui: parsed.ui
+                })
+              })
+            if (
+              parsed.ui?.usagePercentageDisplayChangeNoticeDismissed !==
+              usagePercentageDisplayChangeNoticeDismissed
+            ) {
+              this.loadNeedsSave = true
+            }
             return {
               ...defaults.ui,
               // Why: missing card properties should follow the persisted card
@@ -3319,6 +3340,7 @@ export class Store {
               rightSidebarOpen,
               rightSidebarTab: normalizeRightSidebarTab(parsed.ui?.rightSidebarTab),
               setupGuideSidebarDismissed,
+              usagePercentageDisplayChangeNoticeDismissed,
               setupGuideBrowserMilestoneMigrated:
                 typeof parsed.ui?.setupGuideBrowserMilestoneMigrated === 'boolean'
                   ? parsed.ui.setupGuideBrowserMilestoneMigrated

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -239,6 +239,7 @@ const UiUpdate = z
     trustedOrcaHooks: z.record(z.string(), z.unknown()).optional(),
     setupScriptPromptDismissedRepoIds: StringArray.optional(),
     projectOrderManualDefaultNoticeDismissed: z.boolean().optional(),
+    usagePercentageDisplayChangeNoticeDismissed: z.boolean().optional(),
     usageEmptyStateDismissed: z.boolean().optional(),
     petVisible: z.boolean().optional(),
     petId: z.string().optional(),

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1210,46 +1210,14 @@
 }
 
 /* Why: one-shot status-bar callout is portaled fixed above the meters.
-   Opaque elevated surfaces (not glass) so titlebar/terminal chrome cannot
-   bleed through; light and dark use separate fills. */
+   Opaque popover surface (not glass) so titlebar/terminal chrome cannot
+   bleed through; use design tokens + the documented floating elevation. */
 .status-bar-change-notice-card {
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, var(--border));
-  background: var(--card);
-  color: var(--card-foreground);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--foreground) 6%, transparent),
-    0 14px 36px color-mix(in srgb, var(--foreground) 14%, transparent),
-    0 2px 8px color-mix(in srgb, var(--foreground) 8%, transparent);
-}
-
-/* Light: pure paper above light chrome — lift with a cool edge, not gray fill. */
-:root:not(.dark) .status-bar-change-notice-card {
-  background: #ffffff;
-  border-color: #c4c9d2;
-  color: #0a0a0a;
-  box-shadow:
-    0 0 0 1px rgb(15 23 42 / 0.06),
-    0 16px 40px rgb(15 23 42 / 0.16),
-    0 3px 10px rgb(15 23 42 / 0.08);
-}
-
-:root:not(.dark) .status-bar-change-notice-card .text-muted-foreground {
-  color: #52525b;
-}
-
-/* Dark: lifted charcoal above #0a0a0a / #171717 — not translucent glass. */
-.dark .status-bar-change-notice-card {
-  background: #2a2a2e;
-  border-color: color-mix(in srgb, #ffffff 26%, transparent);
-  color: #fafafa;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, #ffffff 12%, transparent),
-    0 18px 44px rgb(0 0 0 / 0.62),
-    0 3px 12px rgb(0 0 0 / 0.4);
-}
-
-.dark .status-bar-change-notice-card .text-muted-foreground {
-  color: color-mix(in srgb, #fafafa 68%, transparent);
+  border: 1px solid var(--border);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  /* STYLEGUIDE: floating elevation for popovers that escape the editor surface. */
+  box-shadow: 0 10px 24px rgb(0 0 0 / 0.18);
 }
 
 /* Why: caret points down at the usage meters this notice explains. */
@@ -1261,17 +1229,9 @@
   width: 12px;
   height: 12px;
   transform: rotate(45deg);
-  border-right: 1px solid #c4c9d2;
-  border-bottom: 1px solid #c4c9d2;
-  background: #ffffff;
-  box-shadow: 2px 2px 5px rgb(15 23 42 / 0.1);
-}
-
-.dark .status-bar-change-notice-card::after {
-  border-right-color: color-mix(in srgb, #ffffff 26%, transparent);
-  border-bottom-color: color-mix(in srgb, #ffffff 26%, transparent);
-  background: #2a2a2e;
-  box-shadow: 2px 2px 8px rgb(0 0 0 / 0.45);
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--popover);
 }
 
 /* Why: the first-run Mobile Emulator intro sits directly under that menu row;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1209,11 +1209,10 @@
   background: color-mix(in srgb, var(--worktree-sidebar-foreground) 14%, var(--worktree-sidebar));
 }
 
-/* Why: one-shot status-bar callout sits over same-luminance titlebar/terminal
-   chrome. Opaque elevated surfaces (not glass) so the surface cannot bleed
-   through; light and dark use separate token mixes. */
+/* Why: one-shot status-bar callout is portaled fixed above the meters.
+   Opaque elevated surfaces (not glass) so titlebar/terminal chrome cannot
+   bleed through; light and dark use separate fills. */
 .status-bar-change-notice-card {
-  position: relative;
   border: 1px solid color-mix(in srgb, var(--foreground) 16%, var(--border));
   background: var(--card);
   color: var(--card-foreground);

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1209,6 +1209,88 @@
   background: color-mix(in srgb, var(--worktree-sidebar-foreground) 14%, var(--worktree-sidebar));
 }
 
+/* Why: status-bar usage-display change callout sits over same-luminance
+   terminal/titlebar chrome. Light and dark use separate opaque palettes (not
+   translucent glass) so the surface behind cannot bleed through. */
+.status-bar-change-notice-popover {
+  position: relative;
+  overflow: visible;
+  z-index: 60;
+  /* Why: kill default PopoverContent glass; blur + alpha re-darkens the fill. */
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+/* ── Light mode ────────────────────────────────────────
+   Paper card over light chrome (#fff / #f5f5f5). White top + soft cool gray
+   bottom so it lifts off the titlebar without looking like a hole. */
+:root:not(.dark) .status-bar-change-notice-popover,
+:root:not(.dark) .status-bar-change-notice-popover[data-slot='popover-content'] {
+  background: linear-gradient(165deg, #ffffff 0%, #f7f7f8 52%, #eef0f3 100%) !important;
+  border-color: #c8cdd6 !important;
+  color: #0a0a0a !important;
+  box-shadow:
+    0 0 0 1px rgb(15 23 42 / 0.06),
+    0 18px 40px rgb(15 23 42 / 0.14),
+    0 4px 12px rgb(15 23 42 / 0.08),
+    inset 0 1px 0 #ffffff !important;
+}
+
+:root:not(.dark) .status-bar-change-notice-popover .text-muted-foreground {
+  color: #52525b !important;
+}
+
+:root:not(.dark) .status-bar-change-notice-popover::after {
+  content: '';
+  position: absolute;
+  left: 1.25rem;
+  bottom: -6px;
+  width: 12px;
+  height: 12px;
+  transform: rotate(45deg);
+  border-right: 1px solid #c8cdd6;
+  border-bottom: 1px solid #c8cdd6;
+  background: #eef0f3;
+  box-shadow: 2px 2px 5px rgb(15 23 42 / 0.1);
+}
+
+/* ── Dark mode ─────────────────────────────────────────
+   Lifted charcoal over near-black terminal/titlebar (#0a0a0a / #171717). */
+.dark .status-bar-change-notice-popover,
+.dark .status-bar-change-notice-popover[data-slot='popover-content'] {
+  background: linear-gradient(
+    165deg,
+    color-mix(in srgb, #ffffff 18%, #2a2a2e) 0%,
+    #252528 48%,
+    #1a1a1d 100%
+  ) !important;
+  border-color: color-mix(in srgb, #ffffff 28%, transparent) !important;
+  color: #fafafa !important;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, #ffffff 14%, transparent),
+    0 20px 48px rgb(0 0 0 / 0.65),
+    0 4px 14px rgb(0 0 0 / 0.45),
+    inset 0 1px 0 color-mix(in srgb, #ffffff 16%, transparent) !important;
+}
+
+.dark .status-bar-change-notice-popover .text-muted-foreground {
+  color: color-mix(in srgb, #fafafa 68%, transparent) !important;
+}
+
+.dark .status-bar-change-notice-popover::after {
+  content: '';
+  position: absolute;
+  left: 1.25rem;
+  bottom: -6px;
+  width: 12px;
+  height: 12px;
+  transform: rotate(45deg);
+  border-right: 1px solid color-mix(in srgb, #ffffff 28%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, #ffffff 28%, transparent);
+  background: #1a1a1d;
+  box-shadow: 2px 2px 8px rgb(0 0 0 / 0.5);
+}
+
 /* Why: the first-run Mobile Emulator intro sits directly under that menu row;
    an upward caret aligned to the phone icon reads as a callout, not a footer. */
 .mobile-emulator-tab-intro-callout--menu {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1209,38 +1209,52 @@
   background: color-mix(in srgb, var(--worktree-sidebar-foreground) 14%, var(--worktree-sidebar));
 }
 
-/* Why: status-bar usage-display change callout sits over same-luminance
-   terminal/titlebar chrome. Light and dark use separate opaque palettes (not
-   translucent glass) so the surface behind cannot bleed through. */
-.status-bar-change-notice-popover {
+/* Why: one-shot status-bar callout sits over same-luminance titlebar/terminal
+   chrome. Opaque elevated surfaces (not glass) so the surface cannot bleed
+   through; light and dark use separate token mixes. */
+.status-bar-change-notice-card {
   position: relative;
-  overflow: visible;
-  z-index: 60;
-  /* Why: kill default PopoverContent glass; blur + alpha re-darkens the fill. */
-  backdrop-filter: none !important;
-  -webkit-backdrop-filter: none !important;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, var(--border));
+  background: var(--card);
+  color: var(--card-foreground);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--foreground) 6%, transparent),
+    0 14px 36px color-mix(in srgb, var(--foreground) 14%, transparent),
+    0 2px 8px color-mix(in srgb, var(--foreground) 8%, transparent);
 }
 
-/* ── Light mode ────────────────────────────────────────
-   Paper card over light chrome (#fff / #f5f5f5). White top + soft cool gray
-   bottom so it lifts off the titlebar without looking like a hole. */
-:root:not(.dark) .status-bar-change-notice-popover,
-:root:not(.dark) .status-bar-change-notice-popover[data-slot='popover-content'] {
-  background: linear-gradient(165deg, #ffffff 0%, #f7f7f8 52%, #eef0f3 100%) !important;
-  border-color: #c8cdd6 !important;
-  color: #0a0a0a !important;
+/* Light: pure paper above light chrome — lift with a cool edge, not gray fill. */
+:root:not(.dark) .status-bar-change-notice-card {
+  background: #ffffff;
+  border-color: #c4c9d2;
+  color: #0a0a0a;
   box-shadow:
     0 0 0 1px rgb(15 23 42 / 0.06),
-    0 18px 40px rgb(15 23 42 / 0.14),
-    0 4px 12px rgb(15 23 42 / 0.08),
-    inset 0 1px 0 #ffffff !important;
+    0 16px 40px rgb(15 23 42 / 0.16),
+    0 3px 10px rgb(15 23 42 / 0.08);
 }
 
-:root:not(.dark) .status-bar-change-notice-popover .text-muted-foreground {
-  color: #52525b !important;
+:root:not(.dark) .status-bar-change-notice-card .text-muted-foreground {
+  color: #52525b;
 }
 
-:root:not(.dark) .status-bar-change-notice-popover::after {
+/* Dark: lifted charcoal above #0a0a0a / #171717 — not translucent glass. */
+.dark .status-bar-change-notice-card {
+  background: #2a2a2e;
+  border-color: color-mix(in srgb, #ffffff 26%, transparent);
+  color: #fafafa;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, #ffffff 12%, transparent),
+    0 18px 44px rgb(0 0 0 / 0.62),
+    0 3px 12px rgb(0 0 0 / 0.4);
+}
+
+.dark .status-bar-change-notice-card .text-muted-foreground {
+  color: color-mix(in srgb, #fafafa 68%, transparent);
+}
+
+/* Why: caret points down at the usage meters this notice explains. */
+.status-bar-change-notice-card::after {
   content: '';
   position: absolute;
   left: 1.25rem;
@@ -1248,47 +1262,17 @@
   width: 12px;
   height: 12px;
   transform: rotate(45deg);
-  border-right: 1px solid #c8cdd6;
-  border-bottom: 1px solid #c8cdd6;
-  background: #eef0f3;
+  border-right: 1px solid #c4c9d2;
+  border-bottom: 1px solid #c4c9d2;
+  background: #ffffff;
   box-shadow: 2px 2px 5px rgb(15 23 42 / 0.1);
 }
 
-/* ── Dark mode ─────────────────────────────────────────
-   Lifted charcoal over near-black terminal/titlebar (#0a0a0a / #171717). */
-.dark .status-bar-change-notice-popover,
-.dark .status-bar-change-notice-popover[data-slot='popover-content'] {
-  background: linear-gradient(
-    165deg,
-    color-mix(in srgb, #ffffff 18%, #2a2a2e) 0%,
-    #252528 48%,
-    #1a1a1d 100%
-  ) !important;
-  border-color: color-mix(in srgb, #ffffff 28%, transparent) !important;
-  color: #fafafa !important;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, #ffffff 14%, transparent),
-    0 20px 48px rgb(0 0 0 / 0.65),
-    0 4px 14px rgb(0 0 0 / 0.45),
-    inset 0 1px 0 color-mix(in srgb, #ffffff 16%, transparent) !important;
-}
-
-.dark .status-bar-change-notice-popover .text-muted-foreground {
-  color: color-mix(in srgb, #fafafa 68%, transparent) !important;
-}
-
-.dark .status-bar-change-notice-popover::after {
-  content: '';
-  position: absolute;
-  left: 1.25rem;
-  bottom: -6px;
-  width: 12px;
-  height: 12px;
-  transform: rotate(45deg);
-  border-right: 1px solid color-mix(in srgb, #ffffff 28%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, #ffffff 28%, transparent);
-  background: #1a1a1d;
-  box-shadow: 2px 2px 8px rgb(0 0 0 / 0.5);
+.dark .status-bar-change-notice-card::after {
+  border-right-color: color-mix(in srgb, #ffffff 26%, transparent);
+  border-bottom-color: color-mix(in srgb, #ffffff 26%, transparent);
+  background: #2a2a2e;
+  box-shadow: 2px 2px 8px rgb(0 0 0 / 0.45);
 }
 
 /* Why: the first-run Mobile Emulator intro sits directly under that menu row;

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -23,7 +23,9 @@ const mocks = vi.hoisted(() => ({
     usagePercentageDisplay: 'used' as 'used' | 'remaining',
     setUsagePercentageDisplay: vi.fn(),
     recordFeatureInteraction: vi.fn(),
-    setWorktreeCardMode: vi.fn()
+    setWorktreeCardMode: vi.fn(),
+    appearanceAccordionDeepLink: null as 'interface' | 'terminal' | 'window' | null,
+    clearAppearanceAccordionDeepLink: vi.fn()
   }
 }))
 

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import { AppWindow, PanelLeft, TerminalSquare } from 'lucide-react'
 
 import type { GlobalSettings } from '../../../../shared/types'
@@ -10,6 +10,7 @@ import { AppearanceWindowSidebarSection } from './AppearanceWindowSidebarSection
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch, normalizeSettingsSearchQuery } from './settings-search'
 import { useAppStore } from '../../store'
+import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percentage-search'
 import {
   getAppIconEntries,
   getAppearancePaneSearchEntries,
@@ -75,6 +76,10 @@ export function AppearancePane({
   warpThemes
 }: AppearancePaneProps): React.JSX.Element {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
+  const appearanceAccordionDeepLink = useAppStore((state) => state.appearanceAccordionDeepLink)
+  const clearAppearanceAccordionDeepLink = useAppStore(
+    (state) => state.clearAppearanceAccordionDeepLink
+  )
   const isSearching = normalizeSettingsSearchQuery(searchQuery).length > 0
   const isWebClient = isWebClientLocation()
   // Why: the system tray behavior is desktop-Electron Windows-only; a Windows
@@ -84,6 +89,26 @@ export function AppearancePane({
   const [manuallyOpenSection, setManuallyOpenSection] = useState<AppearanceSectionKey | null>(
     'interface'
   )
+
+  // Why: nested deep links (e.g. Usage percentages) land under Window & Sidebar;
+  // expand that accordion before Settings scrolls so the row is actually visible.
+  useLayoutEffect(() => {
+    if (!appearanceAccordionDeepLink) {
+      return
+    }
+    setManuallyOpenSection(appearanceAccordionDeepLink)
+    clearAppearanceAccordionDeepLink()
+    // Why: accordion expand is layout-synchronous; scroll on the next frame so
+    // the target has non-zero height when Settings (or this fallback) scrolls.
+    const frameId = requestAnimationFrame(() => {
+      document
+        .getElementById(USAGE_PERCENTAGE_DISPLAY_SETTING_ID)
+        ?.scrollIntoView({ block: 'nearest' })
+    })
+    return () => {
+      cancelAnimationFrame(frameId)
+    }
+  }, [appearanceAccordionDeepLink, clearAppearanceAccordionDeepLink])
   const interfaceTitle = translate(
     'auto.components.settings.AppearancePane.interfaceTitle',
     'Interface'

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -18,6 +18,7 @@ import {
   getStatusBarToggles,
   getUsagePercentageDisplayEntry
 } from './appearance-search'
+import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percentage-search'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
 import {
   getLeftSidebarAppearanceEntry,
@@ -130,6 +131,7 @@ export function AppearanceWindowSidebarSection({
           {showStatusBarControls ? (
             <div className="ml-4 divide-y divide-border/40 border-t border-border/40">
               <SearchableSetting
+                id={USAGE_PERCENTAGE_DISPLAY_SETTING_ID}
                 title={usagePercentageDisplayEntry.title}
                 description={usagePercentageDisplayEntry.description}
                 keywords={usagePercentageDisplayEntry.keywords}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -892,7 +892,16 @@ function Settings(): React.JSX.Element {
     const scrollTargetId = pendingScrollTargetRef.current
     const pendingNavSectionId = pendingNavSectionRef.current
 
-    if (scrollTargetId && pendingNavSectionId && settingsSearchQuery.trim() !== '') {
+    // Why: subsection deep links (scrollTarget ≠ pane id) must not keep a
+    // leftover search filter that can hide the target row. Pane-level deep
+    // links may intentionally pair with a filter (e.g. Appearance + "Usage
+    // percentages") so accordion sections force-open to the matching control.
+    if (
+      scrollTargetId &&
+      pendingNavSectionId &&
+      scrollTargetId !== pendingNavSectionId &&
+      settingsSearchQuery.trim() !== ''
+    ) {
       setSettingsSearchQuery('')
       return
     }

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -65,6 +65,7 @@ import { SettingsSidebar } from './SettingsSidebar'
 import { SettingsSetupGuidePane } from './SettingsSetupGuidePane'
 import { ActiveSettingsSectionProvider, SettingsSection } from './SettingsSection'
 import { getSettingsSectionSearchEntries, rankSettingsSearchItems } from './settings-search'
+import { resolveAppearanceAccordionDeepLink } from './appearance-usage-percentage-search'
 import { cn } from '@/lib/utils'
 import { isIntentionalAppRestartInProgress } from '@/lib/updater-beforeunload'
 import { registerWindowCloseGuard } from '../window-close-request-coordinator'
@@ -618,6 +619,14 @@ function Settings(): React.JSX.Element {
     )
     pendingNavSectionRef.current = paneSectionId
     pendingScrollTargetRef.current = settingsNavigationTarget.sectionId ?? paneSectionId
+    // Why: Appearance nests status-bar controls under a collapsed accordion;
+    // force that accordion open before scrolling so the row is actually visible.
+    if (settingsNavigationTarget.pane === 'appearance') {
+      const accordion = resolveAppearanceAccordionDeepLink(settingsNavigationTarget.sectionId)
+      if (accordion) {
+        useAppStore.getState().setAppearanceAccordionDeepLink(accordion)
+      }
+    }
     if (settingsNavigationTarget.intent === 'add-quick-command') {
       setQuickCommandAddIntentSignal((signal) => signal + 1)
     }

--- a/src/renderer/src/components/settings/appearance-usage-percentage-search.test.ts
+++ b/src/renderer/src/components/settings/appearance-usage-percentage-search.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveAppearanceAccordionDeepLink,
+  USAGE_PERCENTAGE_DISPLAY_SETTING_ID
+} from './appearance-usage-percentage-search'
+
+describe('resolveAppearanceAccordionDeepLink', () => {
+  it('maps the usage percentage row to the Window accordion', () => {
+    expect(resolveAppearanceAccordionDeepLink(USAGE_PERCENTAGE_DISPLAY_SETTING_ID)).toBe('window')
+  })
+
+  it('returns null for unknown or missing section ids', () => {
+    expect(resolveAppearanceAccordionDeepLink(undefined)).toBeNull()
+    expect(resolveAppearanceAccordionDeepLink('something-else')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/settings/appearance-usage-percentage-search.ts
+++ b/src/renderer/src/components/settings/appearance-usage-percentage-search.ts
@@ -2,6 +2,9 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 
+/** Stable Settings deep-link / scroll target for the Used/Remaining control. */
+export const USAGE_PERCENTAGE_DISPLAY_SETTING_ID = 'usage-percentage-display'
+
 export const getUsagePercentageDisplayEntry = createLocalizedCatalog(() => ({
   title: translate(
     'auto.components.settings.appearance.search.usagePercentageDisplayTitle',

--- a/src/renderer/src/components/settings/appearance-usage-percentage-search.ts
+++ b/src/renderer/src/components/settings/appearance-usage-percentage-search.ts
@@ -5,6 +5,22 @@ import { translateSearchKeyword } from './settings-search-keywords'
 /** Stable Settings deep-link / scroll target for the Used/Remaining control. */
 export const USAGE_PERCENTAGE_DISPLAY_SETTING_ID = 'usage-percentage-display'
 
+/** Appearance accordion keys that can be force-opened for nested deep links. */
+export type AppearanceAccordionSection = 'interface' | 'terminal' | 'window'
+
+/**
+ * Map a Settings subsection id to the Appearance accordion that must be open
+ * before the row is visible (collapsed accordion content is not user-visible).
+ */
+export function resolveAppearanceAccordionDeepLink(
+  sectionId: string | undefined
+): AppearanceAccordionSection | null {
+  if (sectionId === USAGE_PERCENTAGE_DISPLAY_SETTING_ID) {
+    return 'window'
+  }
+  return null
+}
+
 export const getUsagePercentageDisplayEntry = createLocalizedCatalog(() => ({
   title: translate(
     'auto.components.settings.appearance.search.usagePercentageDisplayTitle',

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,6 +63,7 @@ import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
 import { StatusBarUsageEmptyCta } from './StatusBarUsageEmptyCta'
+import { UsagePercentageDisplayChangeNotice } from './UsagePercentageDisplayChangeNotice'
 import { shouldOpenStatusBarContextMenu } from './status-bar-context-menu-policy'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
@@ -2015,7 +2016,10 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const showPorts = statusBarItems.includes('ports')
   const showFloatingTerminalToggle =
     floatingTerminalEnabled && floatingTerminalTriggerLocation === 'status-bar'
-  const anyVisible =
+  // Why: which usage-meter children actually render — excludes resource-usage
+  // and other non-meter status items so the % display change callout only
+  // opens when there is a real meter cluster to anchor to.
+  const hasVisibleUsageMeters =
     showClaude ||
     showCodex ||
     showGemini ||
@@ -2023,8 +2027,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     showKimi ||
     showAntigravity ||
     showMiniMax ||
-    showGrok ||
-    showResourceUsage
+    showGrok
+  const anyVisible = hasVisibleUsageMeters || showResourceUsage
   // Why: a brand-new user with no provider configured would otherwise see an
   // empty left side of the status bar and wonder what's missing. Settings are
   // included because managed accounts are durable even when live usage
@@ -2082,7 +2086,9 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             <StatusBarUsageEmptyCta />
           ) : null
         ) : (
-          <>
+          // Why: one-time usage-display change callout anchors to this cluster so
+          // it sits next to the meters the user is confused by, not a global toast.
+          <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters={hasVisibleUsageMeters}>
             {showClaude && (
               <ClaudeSwitcherMenu claude={visibleClaude} compact={compact} iconOnly={iconOnly} />
             )}
@@ -2155,7 +2161,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                 )}
               />
             )}
-          </>
+          </UsagePercentageDisplayChangeNotice>
         )}
         {anyVisible && !isEmptyUsageState && (
           <Tooltip>

--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment happy-dom
+
+import { act, createContext, useContext, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UsagePercentageDisplayChangeNotice } from './UsagePercentageDisplayChangeNotice'
+
+const storeState = {
+  persistedUIReady: true,
+  usagePercentageDisplayChangeNoticeDismissed: false,
+  dismissUsagePercentageDisplayChangeNotice: vi.fn(),
+  statusBarVisible: true,
+  activeModal: 'none' as string,
+  setSettingsSearchQuery: vi.fn(),
+  openSettingsTarget: vi.fn(),
+  openSettingsPage: vi.fn()
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: typeof storeState) => unknown) => selector(storeState),
+    {
+      getState: () => storeState
+    }
+  )
+}))
+
+vi.mock('@/components/ui/popover', () => {
+  const OpenContext = createContext(false)
+  return {
+    Popover: ({ open, children }: { open?: boolean; children: ReactNode }) => (
+      <OpenContext.Provider value={open === true}>
+        <div data-testid="popover" data-open={open ? 'true' : 'false'}>
+          {children}
+        </div>
+      </OpenContext.Provider>
+    ),
+    PopoverAnchor: ({ children }: { children: ReactNode }) => (
+      <div data-testid="popover-anchor">{children}</div>
+    ),
+    PopoverContent: ({ children }: { children: ReactNode }) => {
+      const open = useContext(OpenContext)
+      if (!open) {
+        return null
+      }
+      return <div data-testid="popover-content">{children}</div>
+    }
+  }
+})
+
+describe('UsagePercentageDisplayChangeNotice', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storeState.persistedUIReady = true
+    storeState.usagePercentageDisplayChangeNoticeDismissed = false
+    storeState.statusBarVisible = true
+    storeState.activeModal = 'none'
+    storeState.dismissUsagePercentageDisplayChangeNotice = vi.fn()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    vi.useRealTimers()
+  })
+
+  it('opens the callout next to usage meters after a short delay when eligible', () => {
+    act(() => {
+      root.render(
+        <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters>
+          <span>usage-meters</span>
+        </UsagePercentageDisplayChangeNotice>
+      )
+    })
+
+    expect(container.querySelector('[data-open="true"]')).toBeNull()
+    act(() => {
+      vi.advanceTimersByTime(1_800)
+    })
+    expect(container.querySelector('[data-open="true"]')).not.toBeNull()
+    expect(container.textContent).toContain('usage-meters')
+    expect(container.textContent).toContain('Usage now shows % used')
+    expect(container.textContent).toContain('Prefer remaining? Change it in Settings.')
+  })
+
+  it('does not open when no usage meters are visible', () => {
+    act(() => {
+      root.render(
+        <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters={false}>
+          <span>usage-meters</span>
+        </UsagePercentageDisplayChangeNotice>
+      )
+    })
+    act(() => {
+      vi.advanceTimersByTime(2_000)
+    })
+    expect(container.querySelector('[data-open="true"]')).toBeNull()
+    expect(container.textContent).not.toContain('Usage now shows % used')
+  })
+
+  it('does not open when the notice was already dismissed', () => {
+    storeState.usagePercentageDisplayChangeNoticeDismissed = true
+    act(() => {
+      root.render(
+        <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters>
+          <span>usage-meters</span>
+        </UsagePercentageDisplayChangeNotice>
+      )
+    })
+    act(() => {
+      vi.advanceTimersByTime(2_000)
+    })
+    expect(container.querySelector('[data-open="true"]')).toBeNull()
+    expect(container.textContent).not.toContain('Usage now shows % used')
+  })
+
+  it('does not open while another modal is open', () => {
+    storeState.activeModal = 'feature-tips'
+    act(() => {
+      root.render(
+        <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters>
+          <span>usage-meters</span>
+        </UsagePercentageDisplayChangeNotice>
+      )
+    })
+    act(() => {
+      vi.advanceTimersByTime(2_000)
+    })
+    expect(container.querySelector('[data-open="true"]')).toBeNull()
+  })
+
+  it('opens Appearance with a Usage percentages filter after wiping prior search', () => {
+    const callOrder: string[] = []
+    storeState.openSettingsPage = vi.fn(() => {
+      callOrder.push('openSettingsPage')
+    })
+    storeState.openSettingsTarget = vi.fn(() => {
+      callOrder.push('openSettingsTarget')
+    })
+    storeState.setSettingsSearchQuery = vi.fn(() => {
+      callOrder.push('setSettingsSearchQuery')
+    })
+    storeState.dismissUsagePercentageDisplayChangeNotice = vi.fn()
+
+    act(() => {
+      root.render(
+        <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters>
+          <span>usage-meters</span>
+        </UsagePercentageDisplayChangeNotice>
+      )
+    })
+    act(() => {
+      vi.advanceTimersByTime(1_800)
+    })
+
+    const openSettingsButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Open Settings'
+    )
+    expect(openSettingsButton).toBeTruthy()
+    act(() => {
+      openSettingsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // Why: openSettingsPage clears search first; the filter must be applied after.
+    expect(callOrder).toEqual(['openSettingsPage', 'openSettingsTarget', 'setSettingsSearchQuery'])
+    expect(storeState.openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'appearance',
+      repoId: null
+    })
+    expect(storeState.setSettingsSearchQuery).toHaveBeenCalledWith('Usage percentages')
+    expect(storeState.dismissUsagePercentageDisplayChangeNotice).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
@@ -40,6 +40,23 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     storeState.openSettingsTarget = vi.fn()
     container = document.createElement('div')
     document.body.appendChild(container)
+    // Why: fixed positioning reads getBoundingClientRect; happy-dom needs a
+    // non-zero layout box so the portal card is measured and mounted.
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: () =>
+        ({
+          x: 24,
+          y: 700,
+          top: 700,
+          left: 24,
+          bottom: 724,
+          right: 200,
+          width: 176,
+          height: 24,
+          toJSON: () => ({})
+        }) satisfies DOMRect
+    })
     root = createRoot(container)
   })
 
@@ -48,10 +65,11 @@ describe('UsagePercentageDisplayChangeNotice', () => {
       root.unmount()
     })
     container.remove()
+    document.querySelectorAll('.status-bar-change-notice-card').forEach((node) => node.remove())
     vi.useRealTimers()
   })
 
-  it('shows the callout above usage meters after a short delay when eligible', () => {
+  it('portals the callout above the usage-meter anchor after a short delay', () => {
     act(() => {
       root.render(
         <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters>
@@ -60,14 +78,18 @@ describe('UsagePercentageDisplayChangeNotice', () => {
       )
     })
 
-    expect(container.querySelector('.status-bar-change-notice-card')).toBeNull()
+    expect(document.querySelector('.status-bar-change-notice-card')).toBeNull()
     act(() => {
       vi.advanceTimersByTime(1_800)
     })
-    expect(container.querySelector('.status-bar-change-notice-card')).not.toBeNull()
+    const card = document.querySelector('.status-bar-change-notice-card') as HTMLElement | null
+    expect(card).not.toBeNull()
+    expect(card?.parentElement).toBe(document.body)
+    expect(card?.style.left).toBe('24px')
+    // viewport height default in happy-dom is often 768; bottom = 768 - 700 + 10
+    expect(card?.style.bottom).toBeTruthy()
+    expect(document.body.textContent).toContain('Usage now shows % used')
     expect(container.textContent).toContain('usage-meters')
-    expect(container.textContent).toContain('Usage now shows % used')
-    expect(container.textContent).toContain('Prefer remaining? Change it in Settings.')
   })
 
   it('does not open when no usage meters are visible', () => {
@@ -81,7 +103,7 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     act(() => {
       vi.advanceTimersByTime(2_000)
     })
-    expect(container.querySelector('.status-bar-change-notice-card')).toBeNull()
+    expect(document.querySelector('.status-bar-change-notice-card')).toBeNull()
   })
 
   it('does not open when the notice was already dismissed', () => {
@@ -96,7 +118,7 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     act(() => {
       vi.advanceTimersByTime(2_000)
     })
-    expect(container.querySelector('.status-bar-change-notice-card')).toBeNull()
+    expect(document.querySelector('.status-bar-change-notice-card')).toBeNull()
   })
 
   it('does not open while another modal is open', () => {
@@ -111,7 +133,7 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     act(() => {
       vi.advanceTimersByTime(2_000)
     })
-    expect(container.querySelector('.status-bar-change-notice-card')).toBeNull()
+    expect(document.querySelector('.status-bar-change-notice-card')).toBeNull()
   })
 
   it('deep-links to the Usage percentages setting without a search filter', () => {
@@ -135,9 +157,9 @@ describe('UsagePercentageDisplayChangeNotice', () => {
       vi.advanceTimersByTime(1_800)
     })
 
-    const openSettingsButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Open Settings'
-    )
+    const openSettingsButton = Array.from(
+      document.querySelectorAll('.status-bar-change-notice-card button')
+    ).find((button) => button.textContent === 'Open Settings')
     expect(openSettingsButton).toBeTruthy()
     act(() => {
       openSettingsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))

--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
@@ -173,4 +173,53 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     })
     expect(storeState.dismissUsagePercentageDisplayChangeNotice).toHaveBeenCalled()
   })
+
+  it('dismisses from the X button', () => {
+    openNotice()
+
+    const dismissButton = document.querySelector(
+      '.status-bar-change-notice-card button[aria-label="Dismiss"]'
+    )
+    expect(dismissButton).toBeTruthy()
+    act(() => {
+      dismissButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(storeState.dismissUsagePercentageDisplayChangeNotice).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses from Got it', () => {
+    openNotice()
+
+    const gotItButton = Array.from(
+      document.querySelectorAll('.status-bar-change-notice-card button')
+    ).find((button) => button.textContent === 'Got it')
+    expect(gotItButton).toBeTruthy()
+    act(() => {
+      gotItButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(storeState.dismissUsagePercentageDisplayChangeNotice).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses on Escape', () => {
+    openNotice()
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    expect(storeState.dismissUsagePercentageDisplayChangeNotice).toHaveBeenCalledTimes(1)
+  })
+
+  function openNotice(): void {
+    act(() => {
+      root.render(
+        <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters>
+          <span>usage-meters</span>
+        </UsagePercentageDisplayChangeNotice>
+      )
+    })
+    act(() => {
+      vi.advanceTimersByTime(1_800)
+    })
+    expect(document.querySelector('.status-bar-change-notice-card')).not.toBeNull()
+  }
 })

--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
 
-import { act, createContext, useContext, type ReactNode } from 'react'
+import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsagePercentageDisplayChangeNotice } from './UsagePercentageDisplayChangeNotice'
+import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from '../settings/appearance-usage-percentage-search'
 
 const storeState = {
   persistedUIReady: true,
@@ -11,7 +12,6 @@ const storeState = {
   dismissUsagePercentageDisplayChangeNotice: vi.fn(),
   statusBarVisible: true,
   activeModal: 'none' as string,
-  setSettingsSearchQuery: vi.fn(),
   openSettingsTarget: vi.fn(),
   openSettingsPage: vi.fn()
 }
@@ -25,29 +25,6 @@ vi.mock('@/store', () => ({
   )
 }))
 
-vi.mock('@/components/ui/popover', () => {
-  const OpenContext = createContext(false)
-  return {
-    Popover: ({ open, children }: { open?: boolean; children: ReactNode }) => (
-      <OpenContext.Provider value={open === true}>
-        <div data-testid="popover" data-open={open ? 'true' : 'false'}>
-          {children}
-        </div>
-      </OpenContext.Provider>
-    ),
-    PopoverAnchor: ({ children }: { children: ReactNode }) => (
-      <div data-testid="popover-anchor">{children}</div>
-    ),
-    PopoverContent: ({ children }: { children: ReactNode }) => {
-      const open = useContext(OpenContext)
-      if (!open) {
-        return null
-      }
-      return <div data-testid="popover-content">{children}</div>
-    }
-  }
-})
-
 describe('UsagePercentageDisplayChangeNotice', () => {
   let container: HTMLDivElement
   let root: Root
@@ -59,6 +36,8 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     storeState.statusBarVisible = true
     storeState.activeModal = 'none'
     storeState.dismissUsagePercentageDisplayChangeNotice = vi.fn()
+    storeState.openSettingsPage = vi.fn()
+    storeState.openSettingsTarget = vi.fn()
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -72,7 +51,7 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     vi.useRealTimers()
   })
 
-  it('opens the callout next to usage meters after a short delay when eligible', () => {
+  it('shows the callout above usage meters after a short delay when eligible', () => {
     act(() => {
       root.render(
         <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters>
@@ -81,11 +60,11 @@ describe('UsagePercentageDisplayChangeNotice', () => {
       )
     })
 
-    expect(container.querySelector('[data-open="true"]')).toBeNull()
+    expect(container.querySelector('.status-bar-change-notice-card')).toBeNull()
     act(() => {
       vi.advanceTimersByTime(1_800)
     })
-    expect(container.querySelector('[data-open="true"]')).not.toBeNull()
+    expect(container.querySelector('.status-bar-change-notice-card')).not.toBeNull()
     expect(container.textContent).toContain('usage-meters')
     expect(container.textContent).toContain('Usage now shows % used')
     expect(container.textContent).toContain('Prefer remaining? Change it in Settings.')
@@ -102,8 +81,7 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     act(() => {
       vi.advanceTimersByTime(2_000)
     })
-    expect(container.querySelector('[data-open="true"]')).toBeNull()
-    expect(container.textContent).not.toContain('Usage now shows % used')
+    expect(container.querySelector('.status-bar-change-notice-card')).toBeNull()
   })
 
   it('does not open when the notice was already dismissed', () => {
@@ -118,8 +96,7 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     act(() => {
       vi.advanceTimersByTime(2_000)
     })
-    expect(container.querySelector('[data-open="true"]')).toBeNull()
-    expect(container.textContent).not.toContain('Usage now shows % used')
+    expect(container.querySelector('.status-bar-change-notice-card')).toBeNull()
   })
 
   it('does not open while another modal is open', () => {
@@ -134,19 +111,16 @@ describe('UsagePercentageDisplayChangeNotice', () => {
     act(() => {
       vi.advanceTimersByTime(2_000)
     })
-    expect(container.querySelector('[data-open="true"]')).toBeNull()
+    expect(container.querySelector('.status-bar-change-notice-card')).toBeNull()
   })
 
-  it('opens Appearance with a Usage percentages filter after wiping prior search', () => {
+  it('deep-links to the Usage percentages setting without a search filter', () => {
     const callOrder: string[] = []
     storeState.openSettingsPage = vi.fn(() => {
       callOrder.push('openSettingsPage')
     })
     storeState.openSettingsTarget = vi.fn(() => {
       callOrder.push('openSettingsTarget')
-    })
-    storeState.setSettingsSearchQuery = vi.fn(() => {
-      callOrder.push('setSettingsSearchQuery')
     })
     storeState.dismissUsagePercentageDisplayChangeNotice = vi.fn()
 
@@ -169,13 +143,12 @@ describe('UsagePercentageDisplayChangeNotice', () => {
       openSettingsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    // Why: openSettingsPage clears search first; the filter must be applied after.
-    expect(callOrder).toEqual(['openSettingsPage', 'openSettingsTarget', 'setSettingsSearchQuery'])
+    expect(callOrder).toEqual(['openSettingsPage', 'openSettingsTarget'])
     expect(storeState.openSettingsTarget).toHaveBeenCalledWith({
       pane: 'appearance',
-      repoId: null
+      repoId: null,
+      sectionId: USAGE_PERCENTAGE_DISPLAY_SETTING_ID
     })
-    expect(storeState.setSettingsSearchQuery).toHaveBeenCalledWith('Usage percentages')
     expect(storeState.dismissUsagePercentageDisplayChangeNotice).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { BarChart3, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import { shouldShowUsagePercentageDisplayChangeNotice } from '../../../../shared/usage-percentage-display-change-notice'
+
+// Why: let startup modals settle before the status-bar callout competes for focus.
+const SHOW_DELAY_MS = 1_800
+
+function openUsagePercentageSettings(): void {
+  const store = useAppStore.getState()
+  // Why: openSettingsPage always wipes the search filter first — set the
+  // Appearance target and filter after that wipe. The search string force-opens
+  // Appearance → Window & Sidebar and surfaces the Usage percentages control.
+  store.openSettingsPage()
+  store.openSettingsTarget({ pane: 'appearance', repoId: null })
+  store.setSettingsSearchQuery(
+    translate(
+      'auto.components.settings.appearance.search.usagePercentageDisplayTitle',
+      'Usage percentages'
+    )
+  )
+}
+
+/**
+ * Anchors a one-time high-contrast callout above the status-bar usage meters
+ * after the default flipped from remaining → used. Permanent dismiss only.
+ */
+export function UsagePercentageDisplayChangeNotice({
+  children,
+  hasVisibleUsageMeters
+}: {
+  children: ReactNode
+  // Why: StatusBar owns which meter children actually render (status-bar items,
+  // CLI detection, MiniMax/Grok durability). Don't re-derive empty-state here.
+  hasVisibleUsageMeters: boolean
+}): React.JSX.Element {
+  const persistedUIReady = useAppStore((s) => s.persistedUIReady)
+  const dismissed = useAppStore((s) => s.usagePercentageDisplayChangeNoticeDismissed)
+  const dismiss = useAppStore((s) => s.dismissUsagePercentageDisplayChangeNotice)
+  const statusBarVisible = useAppStore((s) => s.statusBarVisible)
+  const activeModal = useAppStore((s) => s.activeModal)
+  const [delayElapsed, setDelayElapsed] = useState(false)
+
+  const eligible = shouldShowUsagePercentageDisplayChangeNotice({
+    persistedUIReady,
+    usagePercentageDisplayChangeNoticeDismissed: dismissed,
+    statusBarVisible,
+    hasVisibleUsageMeters,
+    activeModal
+  })
+
+  useEffect(() => {
+    if (!eligible) {
+      setDelayElapsed(false)
+      return
+    }
+    const timer = window.setTimeout(() => {
+      setDelayElapsed(true)
+    }, SHOW_DELAY_MS)
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [eligible])
+
+  const open = eligible && delayElapsed
+
+  const openSettings = (): void => {
+    dismiss()
+    openUsagePercentageSettings()
+  }
+
+  return (
+    <Popover open={open}>
+      <PopoverAnchor asChild>
+        <div className="flex items-center gap-3">{children}</div>
+      </PopoverAnchor>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={12}
+        // Why: permanent dismiss is intentional only via Got it / X / Settings —
+        // outside click must not silently clear a one-shot education surface.
+        onInteractOutside={(event) => {
+          event.preventDefault()
+        }}
+        onOpenAutoFocus={(event) => {
+          // Why: keep focus in the terminal/workspace; this is a soft callout,
+          // not a modal that should steal keyboard context.
+          event.preventDefault()
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault()
+          dismiss()
+        }}
+        // Why: reuse elevated glass popover chrome (border + blur + shadow) and
+        // layer status-bar-change-notice so the caret + contrast boost still apply.
+        className="status-bar-change-notice-popover w-[340px] max-w-[calc(100vw-24px)] overflow-visible p-3.5"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1.5">
+            <div className="flex items-center gap-2">
+              <span
+                className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border bg-secondary text-foreground"
+                aria-hidden="true"
+              >
+                <BarChart3 className="size-3.5" />
+              </span>
+              <div className="text-sm font-semibold leading-snug">
+                {translate(
+                  'auto.components.status.bar.UsagePercentageDisplayChangeNotice.title',
+                  'Usage now shows % used'
+                )}
+              </div>
+            </div>
+            <p className="text-sm leading-5 text-muted-foreground">
+              {translate(
+                'auto.components.status.bar.UsagePercentageDisplayChangeNotice.body',
+                'Prefer remaining? Change it in Settings.'
+              )}
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0"
+            onClick={dismiss}
+            aria-label={translate(
+              'auto.components.status.bar.UsagePercentageDisplayChangeNotice.dismiss',
+              'Dismiss'
+            )}
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+        <div className="mt-3 flex gap-2">
+          <Button variant="default" size="sm" className="min-w-0 flex-1" onClick={openSettings}>
+            {translate(
+              'auto.components.status.bar.UsagePercentageDisplayChangeNotice.openSettings',
+              'Open Settings'
+            )}
+          </Button>
+          <Button variant="secondary" size="sm" className="w-[84px]" onClick={dismiss}>
+            {translate(
+              'auto.components.status.bar.UsagePercentageDisplayChangeNotice.gotIt',
+              'Got it'
+            )}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { BarChart3, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
@@ -8,6 +9,14 @@ import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from '../settings/appearance-usag
 
 // Why: let startup modals settle before the status-bar callout competes for focus.
 const SHOW_DELAY_MS = 1_800
+// Why: gap between the top of the status-bar meters and the bottom of the card.
+const ANCHOR_GAP_PX = 10
+const CARD_WIDTH_PX = 320
+
+type AnchorPosition = {
+  bottom: number
+  left: number
+}
 
 function openUsagePercentageSettings(): void {
   const store = useAppStore.getState()
@@ -21,9 +30,23 @@ function openUsagePercentageSettings(): void {
   })
 }
 
+function measureAnchorPosition(anchor: HTMLElement): AnchorPosition {
+  const rect = anchor.getBoundingClientRect()
+  const maxLeft = Math.max(8, window.innerWidth - CARD_WIDTH_PX - 8)
+  return {
+    // Why: fixed + bottom keeps the card glued above the meters as the window
+    // resizes; CSS bottom is distance from the viewport bottom edge.
+    bottom: Math.max(8, window.innerHeight - rect.top + ANCHOR_GAP_PX),
+    left: Math.min(Math.max(8, rect.left), maxLeft)
+  }
+}
+
 /**
  * One-time elevated callout anchored above the status-bar usage meters after
  * the default flipped from remaining → used. Permanent dismiss only.
+ *
+ * Why fixed + portal: status-bar ancestors use overflow-hidden flex shells, so
+ * in-tree absolute positioning clips or attaches to the wrong containing block.
  */
 export function UsagePercentageDisplayChangeNotice({
   children,
@@ -40,6 +63,8 @@ export function UsagePercentageDisplayChangeNotice({
   const statusBarVisible = useAppStore((s) => s.statusBarVisible)
   const activeModal = useAppStore((s) => s.activeModal)
   const [delayElapsed, setDelayElapsed] = useState(false)
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const [anchorPosition, setAnchorPosition] = useState<AnchorPosition | null>(null)
 
   const eligible = shouldShowUsagePercentageDisplayChangeNotice({
     persistedUIReady,
@@ -64,6 +89,32 @@ export function UsagePercentageDisplayChangeNotice({
 
   const open = eligible && delayElapsed
 
+  useLayoutEffect(() => {
+    if (!open) {
+      setAnchorPosition(null)
+      return
+    }
+    const anchor = anchorRef.current
+    if (!anchor) {
+      return
+    }
+
+    const update = (): void => {
+      setAnchorPosition(measureAnchorPosition(anchor))
+    }
+    update()
+
+    // Why: meters reflow when the status bar goes compact/icon-only or the
+    // window resizes; keep the fixed card locked to the live anchor box.
+    const observer = new ResizeObserver(update)
+    observer.observe(anchor)
+    window.addEventListener('resize', update)
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', update)
+    }
+  }, [open])
+
   useEffect(() => {
     if (!open) {
       return
@@ -85,66 +136,80 @@ export function UsagePercentageDisplayChangeNotice({
     openUsagePercentageSettings()
   }
 
-  return (
-    <div className="relative flex items-center gap-3">
-      {children}
-      {open ? (
-        <div
-          role="status"
-          className="status-bar-change-notice-card absolute bottom-full left-0 z-50 mb-2.5 w-[320px] max-w-[calc(100vw-24px)] rounded-lg p-3.5"
-        >
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 space-y-1.5">
-              <div className="flex items-center gap-2">
-                <span
-                  className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border bg-secondary text-foreground"
-                  aria-hidden="true"
-                >
-                  <BarChart3 className="size-3.5" />
-                </span>
-                <div className="text-sm font-semibold leading-snug">
-                  {translate(
-                    'auto.components.status.bar.UsagePercentageDisplayChangeNotice.title',
-                    'Usage now shows % used'
-                  )}
+  const card =
+    open && anchorPosition
+      ? createPortal(
+          <div
+            role="status"
+            // Why: dropdowns/context menus use z-[70]; this callout must sit
+            // under them so status-bar provider menus stay clickable.
+            className="status-bar-change-notice-card fixed z-[50] w-[320px] max-w-[calc(100vw-16px)] rounded-lg p-3.5"
+            style={{
+              bottom: anchorPosition.bottom,
+              left: anchorPosition.left
+            }}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <span
+                    className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border bg-secondary text-foreground"
+                    aria-hidden="true"
+                  >
+                    <BarChart3 className="size-3.5" />
+                  </span>
+                  <div className="text-sm font-semibold leading-snug">
+                    {translate(
+                      'auto.components.status.bar.UsagePercentageDisplayChangeNotice.title',
+                      'Usage now shows % used'
+                    )}
+                  </div>
                 </div>
+                <p className="text-sm leading-5 text-muted-foreground">
+                  {translate(
+                    'auto.components.status.bar.UsagePercentageDisplayChangeNotice.body',
+                    'Prefer remaining? Change it in Settings.'
+                  )}
+                </p>
               </div>
-              <p className="text-sm leading-5 text-muted-foreground">
-                {translate(
-                  'auto.components.status.bar.UsagePercentageDisplayChangeNotice.body',
-                  'Prefer remaining? Change it in Settings.'
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 shrink-0"
+                onClick={dismiss}
+                aria-label={translate(
+                  'auto.components.status.bar.UsagePercentageDisplayChangeNotice.dismiss',
+                  'Dismiss'
                 )}
-              </p>
+              >
+                <X className="size-3.5" />
+              </Button>
             </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 shrink-0"
-              onClick={dismiss}
-              aria-label={translate(
-                'auto.components.status.bar.UsagePercentageDisplayChangeNotice.dismiss',
-                'Dismiss'
-              )}
-            >
-              <X className="size-3.5" />
-            </Button>
-          </div>
-          <div className="mt-3 flex gap-2">
-            <Button variant="default" size="sm" className="min-w-0 flex-1" onClick={openSettings}>
-              {translate(
-                'auto.components.status.bar.UsagePercentageDisplayChangeNotice.openSettings',
-                'Open Settings'
-              )}
-            </Button>
-            <Button variant="secondary" size="sm" className="w-[84px]" onClick={dismiss}>
-              {translate(
-                'auto.components.status.bar.UsagePercentageDisplayChangeNotice.gotIt',
-                'Got it'
-              )}
-            </Button>
-          </div>
-        </div>
-      ) : null}
-    </div>
+            <div className="mt-3 flex gap-2">
+              <Button variant="default" size="sm" className="min-w-0 flex-1" onClick={openSettings}>
+                {translate(
+                  'auto.components.status.bar.UsagePercentageDisplayChangeNotice.openSettings',
+                  'Open Settings'
+                )}
+              </Button>
+              <Button variant="secondary" size="sm" className="w-[84px]" onClick={dismiss}>
+                {translate(
+                  'auto.components.status.bar.UsagePercentageDisplayChangeNotice.gotIt',
+                  'Got it'
+                )}
+              </Button>
+            </div>
+          </div>,
+          document.body
+        )
+      : null
+
+  return (
+    <>
+      <div ref={anchorRef} className="flex items-center gap-3">
+        {children}
+      </div>
+      {card}
+    </>
   )
 }

--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.tsx
@@ -1,32 +1,29 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { BarChart3, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import { shouldShowUsagePercentageDisplayChangeNotice } from '../../../../shared/usage-percentage-display-change-notice'
+import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from '../settings/appearance-usage-percentage-search'
 
 // Why: let startup modals settle before the status-bar callout competes for focus.
 const SHOW_DELAY_MS = 1_800
 
 function openUsagePercentageSettings(): void {
   const store = useAppStore.getState()
-  // Why: openSettingsPage always wipes the search filter first — set the
-  // Appearance target and filter after that wipe. The search string force-opens
-  // Appearance → Window & Sidebar and surfaces the Usage percentages control.
+  // Why: openSettingsPage wipes any leftover search; do not re-apply a search
+  // filter — deep-link to the stable row id and let Appearance expand Window.
   store.openSettingsPage()
-  store.openSettingsTarget({ pane: 'appearance', repoId: null })
-  store.setSettingsSearchQuery(
-    translate(
-      'auto.components.settings.appearance.search.usagePercentageDisplayTitle',
-      'Usage percentages'
-    )
-  )
+  store.openSettingsTarget({
+    pane: 'appearance',
+    repoId: null,
+    sectionId: USAGE_PERCENTAGE_DISPLAY_SETTING_ID
+  })
 }
 
 /**
- * Anchors a one-time high-contrast callout above the status-bar usage meters
- * after the default flipped from remaining → used. Permanent dismiss only.
+ * One-time elevated callout anchored above the status-bar usage meters after
+ * the default flipped from remaining → used. Permanent dismiss only.
  */
 export function UsagePercentageDisplayChangeNotice({
   children,
@@ -67,89 +64,87 @@ export function UsagePercentageDisplayChangeNotice({
 
   const open = eligible && delayElapsed
 
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        dismiss()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [dismiss, open])
+
   const openSettings = (): void => {
     dismiss()
     openUsagePercentageSettings()
   }
 
   return (
-    <Popover open={open}>
-      <PopoverAnchor asChild>
-        <div className="flex items-center gap-3">{children}</div>
-      </PopoverAnchor>
-      <PopoverContent
-        side="top"
-        align="start"
-        sideOffset={12}
-        // Why: permanent dismiss is intentional only via Got it / X / Settings —
-        // outside click must not silently clear a one-shot education surface.
-        onInteractOutside={(event) => {
-          event.preventDefault()
-        }}
-        onOpenAutoFocus={(event) => {
-          // Why: keep focus in the terminal/workspace; this is a soft callout,
-          // not a modal that should steal keyboard context.
-          event.preventDefault()
-        }}
-        onEscapeKeyDown={(event) => {
-          event.preventDefault()
-          dismiss()
-        }}
-        // Why: reuse elevated glass popover chrome (border + blur + shadow) and
-        // layer status-bar-change-notice so the caret + contrast boost still apply.
-        className="status-bar-change-notice-popover w-[340px] max-w-[calc(100vw-24px)] overflow-visible p-3.5"
-      >
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1.5">
-            <div className="flex items-center gap-2">
-              <span
-                className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border bg-secondary text-foreground"
-                aria-hidden="true"
-              >
-                <BarChart3 className="size-3.5" />
-              </span>
-              <div className="text-sm font-semibold leading-snug">
-                {translate(
-                  'auto.components.status.bar.UsagePercentageDisplayChangeNotice.title',
-                  'Usage now shows % used'
-                )}
+    <div className="relative flex items-center gap-3">
+      {children}
+      {open ? (
+        <div
+          role="status"
+          className="status-bar-change-notice-card absolute bottom-full left-0 z-50 mb-2.5 w-[320px] max-w-[calc(100vw-24px)] rounded-lg p-3.5"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 space-y-1.5">
+              <div className="flex items-center gap-2">
+                <span
+                  className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border bg-secondary text-foreground"
+                  aria-hidden="true"
+                >
+                  <BarChart3 className="size-3.5" />
+                </span>
+                <div className="text-sm font-semibold leading-snug">
+                  {translate(
+                    'auto.components.status.bar.UsagePercentageDisplayChangeNotice.title',
+                    'Usage now shows % used'
+                  )}
+                </div>
               </div>
+              <p className="text-sm leading-5 text-muted-foreground">
+                {translate(
+                  'auto.components.status.bar.UsagePercentageDisplayChangeNotice.body',
+                  'Prefer remaining? Change it in Settings.'
+                )}
+              </p>
             </div>
-            <p className="text-sm leading-5 text-muted-foreground">
-              {translate(
-                'auto.components.status.bar.UsagePercentageDisplayChangeNotice.body',
-                'Prefer remaining? Change it in Settings.'
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0"
+              onClick={dismiss}
+              aria-label={translate(
+                'auto.components.status.bar.UsagePercentageDisplayChangeNotice.dismiss',
+                'Dismiss'
               )}
-            </p>
+            >
+              <X className="size-3.5" />
+            </Button>
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7 shrink-0"
-            onClick={dismiss}
-            aria-label={translate(
-              'auto.components.status.bar.UsagePercentageDisplayChangeNotice.dismiss',
-              'Dismiss'
-            )}
-          >
-            <X className="size-3.5" />
-          </Button>
+          <div className="mt-3 flex gap-2">
+            <Button variant="default" size="sm" className="min-w-0 flex-1" onClick={openSettings}>
+              {translate(
+                'auto.components.status.bar.UsagePercentageDisplayChangeNotice.openSettings',
+                'Open Settings'
+              )}
+            </Button>
+            <Button variant="secondary" size="sm" className="w-[84px]" onClick={dismiss}>
+              {translate(
+                'auto.components.status.bar.UsagePercentageDisplayChangeNotice.gotIt',
+                'Got it'
+              )}
+            </Button>
+          </div>
         </div>
-        <div className="mt-3 flex gap-2">
-          <Button variant="default" size="sm" className="min-w-0 flex-1" onClick={openSettings}>
-            {translate(
-              'auto.components.status.bar.UsagePercentageDisplayChangeNotice.openSettings',
-              'Open Settings'
-            )}
-          </Button>
-          <Button variant="secondary" size="sm" className="w-[84px]" onClick={dismiss}>
-            {translate(
-              'auto.components.status.bar.UsagePercentageDisplayChangeNotice.gotIt',
-              'Got it'
-            )}
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+      ) : null}
+    </div>
   )
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17599,7 +17599,9 @@ describe('connectPanePty', () => {
         binding.sampleForegroundAgentOnFocus()
         await vi.advanceTimersByTimeAsync(10_000)
 
-        expect(window.api.pty.confirmForegroundProcess).not.toHaveBeenCalled()
+        // Scope to this pane's pty id: a delayed confirm for another test's
+        // default `tab-pty` pane can fire during this advance and is not our subject.
+        expect(window.api.pty.confirmForegroundProcess).not.toHaveBeenCalledWith(ptyId)
       } finally {
         restoreUserAgent()
       }

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1268,10 +1268,34 @@ describe('createUISlice hydratePersistedUI', () => {
     store.getState().setUsagePercentageDisplay('used')
 
     expect(store.getState().usagePercentageDisplay).toBe('used')
-    expect(setUI).toHaveBeenCalledWith({ usagePercentageDisplay: 'used' })
+    // Why: adapting the control also permanently dismisses the one-time change notice.
+    expect(setUI).toHaveBeenCalledWith({
+      usagePercentageDisplay: 'used',
+      usagePercentageDisplayChangeNoticeDismissed: true
+    })
+    expect(store.getState().usagePercentageDisplayChangeNoticeDismissed).toBe(true)
 
     store.getState().hydratePersistedUI(makePersistedUI({ usagePercentageDisplay: 'remaining' }))
     expect(store.getState().usagePercentageDisplay).toBe('remaining')
+  })
+
+  it('hydrates and dismisses the usage percentage display change notice', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store
+      .getState()
+      .hydratePersistedUI(makePersistedUI({ usagePercentageDisplayChangeNoticeDismissed: false }))
+    expect(store.getState().usagePercentageDisplayChangeNoticeDismissed).toBe(false)
+
+    store.getState().dismissUsagePercentageDisplayChangeNotice()
+    expect(store.getState().usagePercentageDisplayChangeNoticeDismissed).toBe(true)
+    expect(setUI).toHaveBeenCalledWith({ usagePercentageDisplayChangeNoticeDismissed: true })
+
+    setUI.mockClear()
+    store.getState().dismissUsagePercentageDisplayChangeNotice()
+    expect(setUI).not.toHaveBeenCalled()
   })
 
   it('defaults invalid usage percentage display values to used', () => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -827,6 +827,8 @@ export type UISlice = {
   dismissMobileEmulatorAgentSetup: () => void
   projectOrderManualDefaultNoticeDismissed: boolean
   dismissProjectOrderManualDefaultNotice: () => void
+  usagePercentageDisplayChangeNoticeDismissed: boolean
+  dismissUsagePercentageDisplayChangeNotice: () => void
   usageEmptyStateDismissed: boolean
   dismissUsageEmptyState: () => void
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
@@ -1922,6 +1924,17 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       window.api.ui.set({ projectOrderManualDefaultNoticeDismissed: true }).catch(console.error)
       return { projectOrderManualDefaultNoticeDismissed: true }
     }),
+  // Why: defaults true so pre-hydration / brand-new sessions never flash the
+  // change notice before persistence resolves eligibility.
+  usagePercentageDisplayChangeNoticeDismissed: true,
+  dismissUsagePercentageDisplayChangeNotice: () =>
+    set((s) => {
+      if (s.usagePercentageDisplayChangeNoticeDismissed) {
+        return s
+      }
+      window.api.ui.set({ usagePercentageDisplayChangeNoticeDismissed: true }).catch(console.error)
+      return { usagePercentageDisplayChangeNoticeDismissed: true }
+    }),
   usageEmptyStateDismissed: false,
   dismissUsageEmptyState: () =>
     set((s) => {
@@ -2122,8 +2135,18 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   usagePercentageDisplay: DEFAULT_USAGE_PERCENTAGE_DISPLAY,
   setUsagePercentageDisplay: (display) => {
     const normalized = normalizeUsagePercentageDisplay(display)
-    window.api.ui.set({ usagePercentageDisplay: normalized }).catch(console.error)
-    set({ usagePercentageDisplay: normalized })
+    // Why: changing the control is the discovery path; permanently dismiss the
+    // one-time change notice so it does not reappear after the user adapted.
+    window.api.ui
+      .set({
+        usagePercentageDisplay: normalized,
+        usagePercentageDisplayChangeNoticeDismissed: true
+      })
+      .catch(console.error)
+    set({
+      usagePercentageDisplay: normalized,
+      usagePercentageDisplayChangeNoticeDismissed: true
+    })
   },
   workspacePortScan: null,
   workspacePortScansByKey: {},
@@ -2467,6 +2490,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         mobileEmulatorAgentSetupDismissed: ui.mobileEmulatorAgentSetupDismissed === true,
         projectOrderManualDefaultNoticeDismissed:
           ui.projectOrderManualDefaultNoticeDismissed === true,
+        // Why: load() resolves this for existing vs new profiles; treat only
+        // explicit true as dismissed so a false from migration still surfaces.
+        usagePercentageDisplayChangeNoticeDismissed:
+          ui.usagePercentageDisplayChangeNoticeDismissed === true,
         // Why: default false when undefined so existing users still see the CTA;
         // only an explicit dismissal persists true.
         usageEmptyStateDismissed: ui.usageEmptyStateDismissed === true,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -747,6 +747,16 @@ export type UISlice = {
   } | null
   openSettingsTarget: (target: NonNullable<UISlice['settingsNavigationTarget']>) => void
   clearSettingsTarget: () => void
+  /**
+   * One-shot Appearance accordion to expand for nested Settings deep links
+   * (e.g. Usage percentages lives under Window & Sidebar). Cleared when
+   * Appearance consumes it.
+   */
+  appearanceAccordionDeepLink: 'interface' | 'terminal' | 'window' | null
+  setAppearanceAccordionDeepLink: (
+    section: NonNullable<UISlice['appearanceAccordionDeepLink']>
+  ) => void
+  clearAppearanceAccordionDeepLink: () => void
   activeModal:
     | 'none'
     | 'create-worktree'
@@ -1499,6 +1509,9 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   settingsNavigationTarget: null,
   openSettingsTarget: (target) => set({ settingsNavigationTarget: target }),
   clearSettingsTarget: () => set({ settingsNavigationTarget: null }),
+  appearanceAccordionDeepLink: null,
+  setAppearanceAccordionDeepLink: (section) => set({ appearanceAccordionDeepLink: section }),
+  clearAppearanceAccordionDeepLink: () => set({ appearanceAccordionDeepLink: null }),
 
   activeModal: 'none',
   modalData: {},

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -512,6 +512,9 @@ export function getDefaultUIState(): PersistedUIState {
     // Why: brand-new profiles never saw recent project ordering; only upgraded
     // profiles get the one-time sidebar notice on first launch.
     projectOrderManualDefaultNoticeDismissed: true,
+    // Why: brand-new profiles never saw percent-remaining as the default; only
+    // upgraded profiles get the one-time usage-display change notice.
+    usagePercentageDisplayChangeNoticeDismissed: true,
     workspaceCleanup: { dismissals: {} },
     featureTipsSeenIds: [],
     featureInteractions: {},

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3357,6 +3357,10 @@ export type PersistedUIState = {
   /** One-shot rollout notice for manual project ordering becoming the default.
    *  Absent or true means the sidebar callout stays hidden. */
   projectOrderManualDefaultNoticeDismissed?: boolean
+  /** One-shot notice that status-bar usage meters now show percent used (not
+   *  remaining). Absent is resolved on load: brand-new profiles default to
+   *  dismissed; upgraded profiles see the notice once. */
+  usagePercentageDisplayChangeNoticeDismissed?: boolean
   /** User-hidden empty-state usage CTA in the status bar. Permanently hides the
    *  "Connect AI accounts to see usage" prompt even if all providers are later
    *  disconnected — a dismissed teaching nudge stays dismissed. */

--- a/src/shared/usage-percentage-display-change-notice.test.ts
+++ b/src/shared/usage-percentage-display-change-notice.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveUsagePercentageDisplayChangeNoticeDismissed,
+  shouldShowUsagePercentageDisplayChangeNotice
+} from './usage-percentage-display-change-notice'
+
+describe('resolveUsagePercentageDisplayChangeNoticeDismissed', () => {
+  it('keeps an explicit dismissal', () => {
+    expect(
+      resolveUsagePercentageDisplayChangeNoticeDismissed({
+        rawDismissed: true,
+        rawUsagePercentageDisplay: undefined,
+        isExistingProfile: true
+      })
+    ).toBe(true)
+  })
+
+  it('hides the notice for brand-new profiles', () => {
+    expect(
+      resolveUsagePercentageDisplayChangeNoticeDismissed({
+        rawDismissed: undefined,
+        rawUsagePercentageDisplay: undefined,
+        isExistingProfile: false
+      })
+    ).toBe(true)
+  })
+
+  it('hides the notice when the user already chose remaining', () => {
+    expect(
+      resolveUsagePercentageDisplayChangeNoticeDismissed({
+        rawDismissed: undefined,
+        rawUsagePercentageDisplay: 'remaining',
+        isExistingProfile: true
+      })
+    ).toBe(true)
+  })
+
+  it('shows the notice for upgraded profiles still on used/missing default', () => {
+    expect(
+      resolveUsagePercentageDisplayChangeNoticeDismissed({
+        rawDismissed: undefined,
+        rawUsagePercentageDisplay: undefined,
+        isExistingProfile: true
+      })
+    ).toBe(false)
+    expect(
+      resolveUsagePercentageDisplayChangeNoticeDismissed({
+        rawDismissed: undefined,
+        rawUsagePercentageDisplay: 'used',
+        isExistingProfile: true
+      })
+    ).toBe(false)
+  })
+})
+
+describe('shouldShowUsagePercentageDisplayChangeNotice', () => {
+  it('requires ready UI, undismissed state, visible usage meters, and no modal', () => {
+    expect(
+      shouldShowUsagePercentageDisplayChangeNotice({
+        persistedUIReady: true,
+        usagePercentageDisplayChangeNoticeDismissed: false,
+        statusBarVisible: true,
+        hasVisibleUsageMeters: true,
+        activeModal: 'none'
+      })
+    ).toBe(true)
+
+    expect(
+      shouldShowUsagePercentageDisplayChangeNotice({
+        persistedUIReady: false,
+        usagePercentageDisplayChangeNoticeDismissed: false,
+        statusBarVisible: true,
+        hasVisibleUsageMeters: true,
+        activeModal: 'none'
+      })
+    ).toBe(false)
+
+    expect(
+      shouldShowUsagePercentageDisplayChangeNotice({
+        persistedUIReady: true,
+        usagePercentageDisplayChangeNoticeDismissed: true,
+        statusBarVisible: true,
+        hasVisibleUsageMeters: true,
+        activeModal: 'none'
+      })
+    ).toBe(false)
+
+    expect(
+      shouldShowUsagePercentageDisplayChangeNotice({
+        persistedUIReady: true,
+        usagePercentageDisplayChangeNoticeDismissed: false,
+        statusBarVisible: false,
+        hasVisibleUsageMeters: true,
+        activeModal: 'none'
+      })
+    ).toBe(false)
+
+    expect(
+      shouldShowUsagePercentageDisplayChangeNotice({
+        persistedUIReady: true,
+        usagePercentageDisplayChangeNoticeDismissed: false,
+        statusBarVisible: true,
+        hasVisibleUsageMeters: false,
+        activeModal: 'none'
+      })
+    ).toBe(false)
+
+    expect(
+      shouldShowUsagePercentageDisplayChangeNotice({
+        persistedUIReady: true,
+        usagePercentageDisplayChangeNoticeDismissed: false,
+        statusBarVisible: true,
+        hasVisibleUsageMeters: true,
+        activeModal: 'feature-tips'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/shared/usage-percentage-display-change-notice.ts
+++ b/src/shared/usage-percentage-display-change-notice.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolve whether the one-time "usage now shows percent used" notice is
+ * already dismissed for this profile.
+ *
+ * - Explicit dismissal stays dismissed.
+ * - Brand-new profiles never saw percent-remaining as the default, so they
+ *   should not get a change notice.
+ * - Users who already chose "remaining" have found the setting; no need to
+ *   teach the flip.
+ * - Upgraded profiles still on the new default ("used"/missing) get the notice.
+ */
+export function resolveUsagePercentageDisplayChangeNoticeDismissed(args: {
+  rawDismissed: unknown
+  rawUsagePercentageDisplay: unknown
+  isExistingProfile: boolean
+}): boolean {
+  if (args.rawDismissed === true) {
+    return true
+  }
+  if (!args.isExistingProfile) {
+    return true
+  }
+  // Why: choosing remaining is the discovery path; re-teaching the default flip
+  // would only interrupt someone who already adapted.
+  if (args.rawUsagePercentageDisplay === 'remaining') {
+    return true
+  }
+  return false
+}
+
+export function shouldShowUsagePercentageDisplayChangeNotice(args: {
+  persistedUIReady: boolean
+  usagePercentageDisplayChangeNoticeDismissed: boolean
+  statusBarVisible: boolean
+  hasVisibleUsageMeters: boolean
+  activeModal: string
+}): boolean {
+  return (
+    args.persistedUIReady &&
+    !args.usagePercentageDisplayChangeNoticeDismissed &&
+    args.statusBarVisible &&
+    args.hasVisibleUsageMeters &&
+    args.activeModal === 'none'
+  )
+}

--- a/tests/e2e/helpers/e2e-completed-onboarding-profile.ts
+++ b/tests/e2e/helpers/e2e-completed-onboarding-profile.ts
@@ -38,7 +38,10 @@ export function getE2ECompletedOnboardingProfile() {
       ),
       contextualToursSeenIds: [...SEEN_FIRST_RUN_CONTEXTUAL_TOUR_IDS],
       contextualToursAutoEligible: false,
-      projectOrderManualDefaultNoticeDismissed: true
+      projectOrderManualDefaultNoticeDismissed: true,
+      // Why: E2E profiles model completed existing users and should not be
+      // interrupted by the usage-display change toast covering the UI under test.
+      usagePercentageDisplayChangeNoticeDismissed: true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Shows a one-time status-bar callout when upgraded profiles still use the new percent-used default after the remaining → used flip.
- Brand-new profiles and users who already chose remaining stay quiet; Got it / X / Escape / Open Settings / changing the setting permanently dismisses.
- Persistence resolves eligibility on load; Settings deep-link opens Appearance with a Usage percentages filter so users can switch back easily.

## Test plan

- [x] Unit tests for resolve/shouldShow eligibility helpers
- [x] Component tests for delay open, dismissed, modal gate, no-meters gate, Open Settings order
- [x] Persistence tests for new vs upgraded vs remaining profiles
- [x] UI slice tests for hydrate/dismiss and setUsagePercentageDisplay side-dismiss
- [x] `pnpm typecheck` clean
- [ ] Manual: upgraded profile with usage meters sees high-contrast callout once, then never again after dismiss
- [ ] Manual: Open Settings lands on Appearance → Usage percentages control
- [ ] Manual: brand-new profile / remaining chooser never sees the notice