### PR TITLE
fix(sidebar): raise selected workspace contrast in dark mode

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1108,26 +1108,34 @@
   background: color-mix(in srgb, var(--sidebar-accent) 40%, transparent);
 }
 
+/* Why: mixing into the concrete sidebar surface keeps selected contrast stable,
+   including when a custom translucent sidebar theme is active. */
 [data-worktree-card-surface][data-worktree-card-active='primary'] {
-  border-color: color-mix(in srgb, var(--sidebar-border) 40%, transparent);
-  background: color-mix(in srgb, var(--sidebar-foreground) 8%, transparent);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--sidebar-foreground) 4%, transparent);
+  border-color: color-mix(in srgb, var(--worktree-sidebar-border) 40%, transparent);
+  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 8%, var(--worktree-sidebar));
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--worktree-sidebar-foreground) 4%, transparent);
 }
 
 .dark [data-worktree-card-surface][data-worktree-card-active='primary'] {
-  background: color-mix(in srgb, var(--sidebar-foreground) 10%, transparent);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--sidebar-foreground) 3%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--worktree-sidebar-foreground) 18%,
+    var(--worktree-sidebar-border)
+  );
+  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 16%, var(--worktree-sidebar));
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--worktree-sidebar-foreground) 3%, transparent);
 }
 
 [data-worktree-card-surface][data-worktree-card-active='secondary'] {
   border-color: color-mix(in srgb, var(--sidebar-ring) 25%, transparent);
   background: color-mix(in srgb, var(--sidebar-accent) 45%, transparent);
-  box-shadow: none;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--sidebar-ring) 15%, transparent);
 }
 
 .dark [data-worktree-card-surface][data-worktree-card-active='secondary'] {
   border-color: color-mix(in srgb, var(--sidebar-ring) 28%, transparent);
   background: color-mix(in srgb, var(--sidebar-accent) 34%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--sidebar-ring) 18%, transparent);
 }
 
 .worktree-agent-row-hover:hover {

--- a/src/renderer/src/assets/worktree-card-active-style.test.ts
+++ b/src/renderer/src/assets/worktree-card-active-style.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const mainCss = fs.readFileSync(new URL('./main.css', import.meta.url), 'utf8')
+
+function getCssRuleBody(selector: string): string {
+  const ruleMarker = mainCss.indexOf(`\n${selector} {`)
+  expect(ruleMarker).toBeGreaterThanOrEqual(0)
+
+  const ruleStart = ruleMarker + 1
+  const bodyStart = mainCss.indexOf('{', ruleStart) + 1
+  const bodyEnd = mainCss.indexOf('}', bodyStart)
+  return mainCss.slice(bodyStart, bodyEnd)
+}
+
+describe('worktree card active styling', () => {
+  it('mixes the primary selection into the worktree sidebar surface', () => {
+    const primary = getCssRuleBody(
+      "[data-worktree-card-surface][data-worktree-card-active='primary']"
+    )
+    const darkPrimary = getCssRuleBody(
+      ".dark [data-worktree-card-surface][data-worktree-card-active='primary']"
+    )
+
+    expect(primary).toContain('var(--worktree-sidebar-foreground) 8%')
+    expect(primary).toContain('var(--worktree-sidebar)')
+    expect(darkPrimary).toContain('var(--worktree-sidebar-foreground) 16%')
+    expect(darkPrimary).toContain('var(--worktree-sidebar-border)')
+  })
+
+  it('keeps the secondary selection ring when CSS owns the active state', () => {
+    const secondary = getCssRuleBody(
+      "[data-worktree-card-surface][data-worktree-card-active='secondary']"
+    )
+    const darkSecondary = getCssRuleBody(
+      ".dark [data-worktree-card-surface][data-worktree-card-active='secondary']"
+    )
+
+    expect(secondary).toContain('var(--sidebar-ring) 15%')
+    expect(darkSecondary).toContain('var(--sidebar-ring) 18%')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -180,8 +180,23 @@ describe('WorktreeCard quick actions', () => {
     )
 
     expect(markup).toContain('data-worktree-card-active="secondary"')
-    expect(markup).toContain('bg-sidebar-accent/45')
     expect(markup).not.toContain('bg-black/[0.08]')
+    expect(markup).not.toContain('dark:bg-white/[0.10]')
+    expect(markup).not.toContain('bg-sidebar-accent/45')
+    expect(markup).not.toContain('border-sidebar-ring/25')
+    expect(markup).not.toContain('ring-sidebar-ring/15')
+  })
+
+  it('marks the primary active workspace for token-driven selected styling', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive />
+    )
+
+    expect(markup).toContain('data-worktree-card-active="primary"')
+    expect(markup).toContain('data-worktree-card-surface="true"')
+    expect(markup).not.toContain('bg-black/[0.08]')
+    expect(markup).not.toContain('dark:bg-white/[0.10]')
+    expect(markup).not.toContain('border-black/[0.015]')
   })
 
   it('renders folder directory name in the detailed metadata row without a Folder badge', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -243,7 +243,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const projectGroups = useAppStore((s) => s.projectGroups)
   const newCardStyle = settings?.experimentalNewWorktreeCardStyle === true
   const compactCards = !newCardStyle && settings?.compactWorktreeCards === true
-  const activeSurfaceIsSecondary = isActiveSurface && activeSurfaceVariant === 'secondary'
   const handleEditIssue = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -1789,12 +1788,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
         titleOnlyCard ? 'py-2' : 'pt-1.25 pb-1.5',
         flushSurface ? 'ml-1 w-[calc(100%-0.25rem)]' : 'ml-1',
         'rounded-lg',
+        // Why: the live data attribute updates before React state during navigation,
+        // so it must own the complete active style without stale utility classes.
         isLineageDropTarget
           ? 'border border-accent-foreground/20 bg-accent/80'
           : isActiveSurface
-            ? activeSurfaceIsSecondary
-              ? 'border border-sidebar-ring/25 bg-sidebar-accent/45 shadow-none ring-1 ring-sidebar-ring/15'
-              : 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
+            ? 'border border-transparent'
             : isMultiSelected
               ? 'border border-worktree-sidebar-ring/35 bg-worktree-sidebar-accent/70 ring-1 ring-worktree-sidebar-ring/30'
               : 'border border-transparent worktree-sidebar-card-hover',


### PR DESCRIPTION
## Summary

Fixes #6213 — in dark mode, the selected workspace card was hard to distinguish from the worktree sidebar.

**Root cause:** selected cards used a ~10% white wash (`dark:bg-white/[0.10]` / `color-mix` into transparent), which nearly vanishes on `--worktree-sidebar` (`#2a2a2a`).

**Fix:**
- Drive primary selection through token-based `color-mix` into `--worktree-sidebar` (16% foreground wash + clearer border) so the selected card reads cleanly in dark mode.
- Light mode keeps an equivalent fill-based wash (same 8% strength, more predictable than transparent).
- Remove Tailwind bg/border/shadow overrides for the active surface so CSS owns the state (STYLEGUIDE sidebar tokens).
- Secondary active surface keeps a CSS ring so we don't rely on Tailwind for that state either.

## Screenshots (dark mode)

Captured on Electron against the PR base vs this branch. Same workspace selected in each pair.

### Selected inactive workspace (`pr-4415-…`)

| Before (base) | After (this PR) |
|---|---|
| ![before-selected-workspace](https://github.com/user-attachments/assets/d2aade94-328d-4e21-8179-a08b70aa54e5) | ![after-selected-workspace](https://github.com/user-attachments/assets/1c3f56d4-aff3-4e2d-8c71-97ddb5c125ec) |

### Selected primary workspace (`orca`)

| Before (base) | After (this PR) |
|---|---|
| ![before-selected-primary](https://github.com/user-attachments/assets/dfddd846-68d4-47f7-961f-081c6025a8f6) | ![after-selected-primary](https://github.com/user-attachments/assets/e1344bda-22e7-4e70-84f7-d017840a8d75) |

**Measured selected-card background (dark):**
- Before: `color(srgb 0.98 0.98 0.98 / 0.10)` — 10% white wash on transparent (nearly invisible on `#2a2a2a`)
- After: `color(srgb 0.295 0.295 0.295)` — token-based `color-mix` into `--worktree-sidebar` with stronger border

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx` (26 passed)
- [x] Manual: dark mode, select a workspace in the sidebar — selected card clearly distinct from neighbors (before/after screenshots above)

## Notes

Claimed on the issue before starting; no other open PRs referenced #6213.
