### PR TITLE
Fix folder workspace Git status path

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -185,6 +185,19 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
   })
 
+  it('runs Git against the backing folder for a folder-workspace instance id', async () => {
+    // Why: instance ids carry a synthetic `::workspace:<uuid>` suffix that is not
+    // a real directory. The Git cwd must resolve to the folder or `rev-parse`
+    // spawns against a nonexistent path (ENOENT).
+    const instanceId = `${WORKTREE_ID}::workspace:123e4567-e89b-12d3-a456-426614174000`
+    const { deps } = makeDeps({ resolveWorktreeIdForTab: () => instanceId })
+    await maybeAutoRenameBranchOnFirstWork(workingEvent({ worktreeId: undefined }), deps)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['branch', '-m', 'you/fix-auth'],
+      expect.objectContaining({ cwd: '/repo/wt' })
+    )
+  })
+
   it('skips when no worktree can be resolved for the tab', async () => {
     const { deps } = makeDeps({ resolveWorktreeIdForTab: () => undefined })
     await maybeAutoRenameBranchOnFirstWork(workingEvent({ worktreeId: undefined }), deps)

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -4,7 +4,7 @@
 // owns the orchestration: gate on the signal, enforce the safety guardrails,
 // summarize the prompt via the configured agent, and rename.
 import type { GlobalSettings, Repo } from '../../shared/types'
-import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import { parsePaneKey } from '../../shared/stable-pane-id'
 import {
@@ -180,7 +180,10 @@ async function runAutoRename(
   }
 
   const repo = deps.getRepo(getRepoIdFromWorktreeId(worktreeId))
-  const parsed = splitWorktreeId(worktreeId)
+  // Why: worktreePath is a Git subprocess cwd. Folder-workspace instance IDs
+  // carry a synthetic `::workspace:<uuid>` suffix that is not a real directory,
+  // so resolve to the backing folder or Git spawns against a nonexistent cwd.
+  const parsed = splitWorktreeIdForFilesystem(worktreeId)
   if (!repo || !parsed) {
     return stop('unresolved repo or worktree id')
   }

--- a/src/main/agent-hooks/first-work-folder-rename.test.ts
+++ b/src/main/agent-hooks/first-work-folder-rename.test.ts
@@ -8,6 +8,7 @@ import {
 const REPO = { id: 'repo1', path: '/repos/orca', connectionId: null } as unknown as Repo
 const SETTINGS = { nestWorkspaces: false, workspaceDir: '/ws' } as unknown as GlobalSettings
 const OLD_ID = 'repo1::/ws/cunner'
+const FOLDER_WORKSPACE_ID = 'repo1::/ws/cunner::workspace:12345678-1234-1234-1234-123456789abc'
 
 function makeDeps(overrides: Partial<FirstWorkFolderRenameDeps> = {}): FirstWorkFolderRenameDeps {
   return {
@@ -47,6 +48,25 @@ describe('renameWorktreeFolderOnFirstWork', () => {
       'repo1',
       OLD_ID,
       'repo1::/ws/worktree-creation-spinner'
+    )
+  })
+
+  it('preserves the folder-workspace instance suffix in the migrated identity', async () => {
+    const deps = makeDeps()
+    const result = await renameWorktreeFolderOnFirstWork(
+      FOLDER_WORKSPACE_ID,
+      'worktree-creation-spinner',
+      deps
+    )
+    expect(result).toBe(true)
+    expect(deps.migrateWorktreeIdentity).toHaveBeenCalledWith(
+      FOLDER_WORKSPACE_ID,
+      'repo1::/ws/worktree-creation-spinner::workspace:12345678-1234-1234-1234-123456789abc'
+    )
+    expect(deps.notifyWorktreeRenamed).toHaveBeenCalledWith(
+      'repo1',
+      FOLDER_WORKSPACE_ID,
+      'repo1::/ws/worktree-creation-spinner::workspace:12345678-1234-1234-1234-123456789abc'
     )
   })
 

--- a/src/main/agent-hooks/first-work-folder-rename.ts
+++ b/src/main/agent-hooks/first-work-folder-rename.ts
@@ -6,7 +6,11 @@
 // best-effort and local-only — remote/Windows/locked/dest-taken all degrade to
 // "folder kept" without disturbing the rename that already succeeded.
 import type { GlobalSettings, Repo } from '../../shared/types'
-import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
+import {
+  FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  getRepoIdFromWorktreeId,
+  splitWorktreeIdForFilesystem
+} from '../../shared/worktree-id'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { planWorktreeFolderRename } from '../ipc/worktree-folder-rename-target'
 
@@ -46,9 +50,9 @@ export async function renameWorktreeFolderOnFirstWork(
     repoId: repo.id,
     repoPath: repo.path,
     oldWorktreePath: parsed.worktreePath,
-    worktreeIdSuffix: parsed.worktreePath.slice(
-      parsed.worktreePath.replace(/::workspace:[0-9a-f-]{36}$/, '').length
-    ),
+    worktreeIdSuffix: worktreeId.includes(FOLDER_WORKSPACE_INSTANCE_SEPARATOR)
+      ? `${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${worktreeId.split(FOLDER_WORKSPACE_INSTANCE_SEPARATOR).at(-1)}`
+      : undefined,
     newLeaf,
     settings: deps.getSettings(),
     platform: process.platform,

--- a/src/main/agent-hooks/first-work-folder-rename.ts
+++ b/src/main/agent-hooks/first-work-folder-rename.ts
@@ -6,7 +6,7 @@
 // best-effort and local-only — remote/Windows/locked/dest-taken all degrade to
 // "folder kept" without disturbing the rename that already succeeded.
 import type { GlobalSettings, Repo } from '../../shared/types'
-import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { planWorktreeFolderRename } from '../ipc/worktree-folder-rename-target'
 
@@ -35,7 +35,10 @@ export async function renameWorktreeFolderOnFirstWork(
   deps: FirstWorkFolderRenameDeps
 ): Promise<boolean> {
   const repo = deps.getRepo(getRepoIdFromWorktreeId(worktreeId))
-  const parsed = splitWorktreeId(worktreeId)
+  // Why: oldWorktreePath feeds an on-disk folder move. Resolve the synthetic
+  // `::workspace:<uuid>` suffix to the backing folder; identity is migrated
+  // separately via the untouched worktreeId.
+  const parsed = splitWorktreeIdForFilesystem(worktreeId)
   if (!repo || !parsed) {
     return false
   }

--- a/src/main/agent-hooks/first-work-folder-rename.ts
+++ b/src/main/agent-hooks/first-work-folder-rename.ts
@@ -46,6 +46,9 @@ export async function renameWorktreeFolderOnFirstWork(
     repoId: repo.id,
     repoPath: repo.path,
     oldWorktreePath: parsed.worktreePath,
+    worktreeIdSuffix: parsed.worktreePath.slice(
+      parsed.worktreePath.replace(/::workspace:[0-9a-f-]{36}$/, '').length
+    ),
     newLeaf,
     settings: deps.getSettings(),
     platform: process.platform,

--- a/src/main/ipc/worktree-folder-rename-target.ts
+++ b/src/main/ipc/worktree-folder-rename-target.ts
@@ -26,6 +26,7 @@ export function planWorktreeFolderRename(args: {
   repoId: string
   repoPath: string
   oldWorktreePath: string
+  worktreeIdSuffix?: string
   newLeaf: string
   settings: WorktreePathSettings
   platform: NodeJS.Platform
@@ -49,6 +50,8 @@ export function planWorktreeFolderRename(args: {
   return {
     oldPath: args.oldWorktreePath,
     newPath,
-    newWorktreeId: `${args.repoId}${WORKTREE_ID_SEPARATOR}${newPath}`
+    // Why: folder workspaces can have multiple live instances backed by the
+    // same folder path, so preserve any synthetic instance suffix when re-keying.
+    newWorktreeId: `${args.repoId}${WORKTREE_ID_SEPARATOR}${newPath}${args.worktreeIdSuffix ?? ''}`
   }
 }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -15,7 +15,7 @@ import { resolveProcessCwd } from './process-cwd'
 import { existsSync } from 'node:fs'
 import * as pty from 'node-pty'
 import { parseWslPath, isWslAvailable } from '../wsl'
-import { splitWorktreeId } from '../../shared/worktree-id'
+import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import {
   injectHistoryEnv,
   updateHistFileForFallback,
@@ -154,7 +154,11 @@ function runPtyCleanup(id: string): void {
 function getWslContextFromWorktreeId(
   worktreeId: string | undefined
 ): { distro: string; treatPosixCwdAsWsl: true } | undefined {
-  const worktreePath = worktreeId ? splitWorktreeId(worktreeId)?.worktreePath : undefined
+  // Why: strip any synthetic `::workspace:<uuid>` folder-workspace suffix so WSL
+  // detection parses the real path, not a nonexistent identifier.
+  const worktreePath = worktreeId
+    ? splitWorktreeIdForFilesystem(worktreeId)?.worktreePath
+    : undefined
   const wslInfo = worktreePath ? parseWslPath(worktreePath) : null
   return wslInfo ? { distro: wslInfo.distro, treatPosixCwdAsWsl: true } : undefined
 }

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -120,6 +120,28 @@ describe('runtime git client', () => {
     })
   })
 
+  it('uses the backing folder path for other local folder-workspace git ops', async () => {
+    // Why: status is not the only command run as a subprocess cwd. Every local
+    // op (diff, submodule status, upstream, stage, …) must strip the synthetic
+    // `::workspace:<uuid>` suffix or Git spawns against a nonexistent directory.
+    gitDiff.mockResolvedValue({ hunks: [] })
+    gitSubmoduleStatus.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000'
+    const context = {
+      settings: { activeRuntimeEnvironmentId: null },
+      worktreeId: `folder-repo::/home/user::workspace:${workspaceId}`,
+      worktreePath: `/home/user::workspace:${workspaceId}`
+    }
+
+    await getRuntimeGitDiff(context, { filePath: 'a.ts', staged: false })
+    await getRuntimeGitSubmoduleStatus(context, 'sub')
+
+    expect(gitDiff).toHaveBeenCalledWith(expect.objectContaining({ worktreePath: '/home/user' }))
+    expect(gitSubmoduleStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreePath: '/home/user' })
+    )
+  })
+
   it('forwards includeIgnored to local git status only when enabled', async () => {
     gitStatus.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
 

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -104,6 +104,22 @@ describe('runtime git client', () => {
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
 
+  it('uses the backing folder path for local folder-workspace status', async () => {
+    gitStatus.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000'
+
+    await getRuntimeGitStatus({
+      settings: { activeRuntimeEnvironmentId: null },
+      worktreeId: `folder-repo::/home/user::workspace:${workspaceId}`,
+      worktreePath: `/home/user::workspace:${workspaceId}`
+    })
+
+    expect(gitStatus).toHaveBeenCalledWith({
+      worktreePath: '/home/user',
+      connectionId: undefined
+    })
+  })
+
   it('forwards includeIgnored to local git status only when enabled', async () => {
     gitStatus.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
 

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -22,7 +22,7 @@ import type { HostedReviewProvider } from '../../../shared/hosted-review'
 import type { ResolvedSourceControlAiGenerationParams } from '../../../shared/source-control-ai'
 import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../shared/commit-message-host-key'
 import type { GitHistoryOptions, GitHistoryResult } from '../../../shared/git-history'
-import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../../shared/worktree-id'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 
@@ -130,8 +130,11 @@ export async function getRuntimeGitStatus(
     ? { bypassEffectiveUpstreamNegativeCache: true }
     : {}
   if (target.kind === 'local' || !context.worktreeId) {
+    const worktreePath = context.worktreeId
+      ? (splitWorktreeIdForFilesystem(context.worktreeId)?.worktreePath ?? context.worktreePath)
+      : context.worktreePath
     return window.api.git.status({
-      worktreePath: context.worktreePath,
+      worktreePath,
       connectionId: context.connectionId,
       ...includeIgnoredArgs,
       ...upstreamCacheBypassArgs

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -72,6 +72,17 @@ export type RuntimeGitContext = {
   connectionId?: string
 }
 
+// Why: folder-workspace instance IDs carry a synthetic `::workspace:<uuid>`
+// suffix for identity, and store placeholders surface that suffix on
+// `worktree.path`. Every local Git op runs `worktreePath` as a subprocess cwd,
+// so resolve the real filesystem path here or Git spawns against a nonexistent
+// directory (ENOENT). Ordinary worktrees keep their parsed path unchanged.
+function resolveLocalWorktreePath(context: RuntimeGitContext): string {
+  return context.worktreeId
+    ? (splitWorktreeIdForFilesystem(context.worktreeId)?.worktreePath ?? context.worktreePath)
+    : context.worktreePath
+}
+
 export type RuntimeGenerateCommitMessageOverrides = {
   sourceControlAiResolvedParams?: ResolvedSourceControlAiGenerationParams
   sourceControlAi?: GlobalSettings['sourceControlAi']
@@ -130,11 +141,8 @@ export async function getRuntimeGitStatus(
     ? { bypassEffectiveUpstreamNegativeCache: true }
     : {}
   if (target.kind === 'local' || !context.worktreeId) {
-    const worktreePath = context.worktreeId
-      ? (splitWorktreeIdForFilesystem(context.worktreeId)?.worktreePath ?? context.worktreePath)
-      : context.worktreePath
     return window.api.git.status({
-      worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       ...includeIgnoredArgs,
       ...upstreamCacheBypassArgs
@@ -160,7 +168,7 @@ export async function getRuntimeGitSubmoduleStatus(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.submoduleStatus({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       submodulePath,
       connectionId: context.connectionId,
       area
@@ -188,7 +196,7 @@ export async function getRuntimeGitIgnoredPaths(
   }
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.checkIgnored({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       paths
     })
@@ -208,7 +216,7 @@ export async function getRuntimeGitHistory(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.history({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       ...options
     })
@@ -227,7 +235,7 @@ export async function getRuntimeGitConflictOperation(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.conflictOperation({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId
     })
   }
@@ -243,7 +251,7 @@ export async function abortRuntimeGitMerge(context: RuntimeGitContext): Promise<
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.abortMerge({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId
     })
     return
@@ -260,7 +268,7 @@ export async function abortRuntimeGitRebase(context: RuntimeGitContext): Promise
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.abortRebase({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId
     })
     return
@@ -280,7 +288,7 @@ export async function getRuntimeGitDiff(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.diff({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       filePath: args.filePath,
       staged: args.staged,
       compareAgainstHead: args.compareAgainstHead,
@@ -302,7 +310,7 @@ export async function getRuntimeGitBranchCompare(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.branchCompare({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       baseRef,
       connectionId: context.connectionId
     })
@@ -322,7 +330,7 @@ export async function getRuntimeGitCommitCompare(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.commitCompare({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       commitId,
       connectionId: context.connectionId
     })
@@ -342,7 +350,7 @@ export async function getRuntimeGitUpstreamStatus(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.upstreamStatus({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       ...(pushTarget ? { pushTarget } : {})
     })
@@ -365,7 +373,7 @@ export async function fetchRuntimeGit(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.fetch({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       ...(pushTarget ? { pushTarget } : {})
     })
@@ -389,7 +397,7 @@ export async function syncRuntimeGitForkDefaultBranch(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.syncFork({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       expectedUpstream
     })
@@ -412,7 +420,7 @@ export async function pullRuntimeGit(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.pull({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       ...(pushTarget ? { pushTarget } : {})
     })
@@ -436,7 +444,7 @@ export async function fastForwardRuntimeGit(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.fastForward({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       ...(pushTarget ? { pushTarget } : {})
     })
@@ -460,7 +468,7 @@ export async function rebaseRuntimeGitFromBase(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.rebaseFromBase({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       baseRef,
       connectionId: context.connectionId
     })
@@ -481,7 +489,7 @@ export async function pushRuntimeGit(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.push({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId,
       ...(args.publish !== undefined ? { publish: args.publish } : {}),
       ...(args.pushTarget !== undefined ? { pushTarget: args.pushTarget } : {}),
@@ -513,7 +521,7 @@ export async function getRuntimeGitBranchDiff(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.branchDiff({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       compare: args.compare,
       filePath: args.filePath,
       oldPath: args.oldPath,
@@ -540,7 +548,7 @@ export async function getRuntimeGitCommitDiff(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.commitDiff({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       commitOid: args.commitOid,
       parentOid: args.parentOid,
       filePath: args.filePath,
@@ -563,7 +571,7 @@ export async function commitRuntimeGit(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.commit({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       message,
       connectionId: context.connectionId
     })
@@ -583,7 +591,7 @@ export async function generateRuntimeCommitMessage(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.generateCommitMessage({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       repoId: context.worktreeId ? getRepoIdFromWorktreeId(context.worktreeId) : undefined,
       connectionId: context.connectionId,
       ...(overrides?.sourceControlAiResolvedParams
@@ -617,7 +625,7 @@ export async function discoverRuntimeCommitMessageModels(
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.discoverCommitMessageModels({
       agentId,
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId
     }) as Promise<RuntimeDiscoverCommitMessageModelsResult>
   }
@@ -641,7 +649,7 @@ export async function cancelRuntimeGenerateCommitMessage(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.cancelGenerateCommitMessage({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId
     })
     return
@@ -662,7 +670,7 @@ export async function generateRuntimePullRequestFields(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.generatePullRequestFields({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       repoId: context.worktreeId ? getRepoIdFromWorktreeId(context.worktreeId) : undefined,
       connectionId: context.connectionId,
       ...input,
@@ -696,7 +704,7 @@ export async function cancelRuntimeGeneratePullRequestFields(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.cancelGeneratePullRequestFields({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       connectionId: context.connectionId
     })
     return
@@ -716,7 +724,7 @@ export async function stageRuntimeGitPath(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.stage({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       filePath,
       connectionId: context.connectionId
     })
@@ -737,7 +745,7 @@ export async function bulkStageRuntimeGitPaths(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.bulkStage({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       filePaths,
       connectionId: context.connectionId
     })
@@ -758,7 +766,7 @@ export async function unstageRuntimeGitPath(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.unstage({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       filePath,
       connectionId: context.connectionId
     })
@@ -779,7 +787,7 @@ export async function bulkUnstageRuntimeGitPaths(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.bulkUnstage({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       filePaths,
       connectionId: context.connectionId
     })
@@ -800,7 +808,7 @@ export async function bulkDiscardRuntimeGitPaths(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.bulkDiscard({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       filePaths,
       connectionId: context.connectionId
     })
@@ -821,7 +829,7 @@ export async function discardRuntimeGitPath(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.discard({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       filePath,
       connectionId: context.connectionId
     })
@@ -842,7 +850,7 @@ export async function getRuntimeGitRemoteFileUrl(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.remoteFileUrl({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       relativePath: args.relativePath,
       line: args.line,
       connectionId: context.connectionId
@@ -867,7 +875,7 @@ export async function getRuntimeGitRemoteCommitUrl(
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.remoteCommitUrl({
-      worktreePath: context.worktreePath,
+      worktreePath: resolveLocalWorktreePath(context),
       sha: args.sha,
       connectionId: context.connectionId
     })

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -197,6 +197,38 @@ describe('hydrateWorkspaceSession', () => {
     ])
   })
 
+  it('strips the synthetic workspace suffix from folder-workspace instance placeholders', () => {
+    const store = createTestStore()
+    const workspaceUuid = '123e4567-e89b-12d3-a456-426614174000'
+    const worktreeId = `folder-repo::/home/user::workspace:${workspaceUuid}`
+    const session: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: 'folder-repo',
+      activeWorktreeId: worktreeId,
+      activeTabId: 'folder-tab',
+      activeWorktreeIdsOnShutdown: [worktreeId],
+      tabsByWorktree: {
+        [worktreeId]: [makeTab({ id: 'folder-tab', worktreeId, ptyId: 'folder-session' })]
+      }
+    }
+
+    store.getState().hydrateWorkspaceSession(session, {
+      runtimeHostIdByWorkspaceSessionKey: {
+        [worktreeWorkspaceKey(worktreeId)]: 'runtime:env-1'
+      }
+    })
+
+    // Why: `id` keeps the `::workspace:<uuid>` identity suffix, but `path` and
+    // `displayName` must resolve to the real folder so Git and other filesystem
+    // callers never spawn against a nonexistent cwd.
+    expect(store.getState().worktreesByRepo['folder-repo']).toEqual([
+      expect.objectContaining({ id: worktreeId, path: '/home/user', displayName: 'user' })
+    ])
+    expect(store.getState().repos).toEqual([
+      expect.objectContaining({ id: 'folder-repo', path: '/home/user' })
+    ])
+  })
+
   it('avoids duplicate repo placeholders when a same-id local repo is already loaded', () => {
     const store = createTestStore()
     const worktreeId = 'same-repo::/srv/remote-wt'

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -34,7 +34,10 @@ import {
   parsePaneKey
 } from '../../../../shared/stable-pane-id'
 import { isValidHostTerminalTabId, isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
-import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../../../shared/worktree-id'
+import {
+  getRepoIdFromWorktreeId,
+  splitWorktreeIdForFilesystem
+} from '../../../../shared/worktree-id'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
@@ -168,7 +171,11 @@ function buildRuntimeSessionPlaceholders({
     }
     const worktreeId =
       workspaceScope?.type === 'worktree' ? workspaceScope.worktreeId : workspaceSessionKey
-    const parsed = splitWorktreeId(worktreeId)
+    // Why: folder-workspace instance IDs carry a synthetic `::workspace:<uuid>`
+    // suffix. The placeholder's `id` keeps it for identity, but `path`/display
+    // must be the real folder path so Git and other filesystem callers do not
+    // spawn against a nonexistent cwd — matching the authoritative worktree.
+    const parsed = splitWorktreeIdForFilesystem(worktreeId)
     if (!parsed) {
       continue
     }
@@ -3203,7 +3210,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         if (existing) {
           continue
         }
-        const path = splitWorktreeId(worktreeId)?.worktreePath ?? ''
+        // Why: strip the synthetic `::workspace:<uuid>` folder-workspace suffix
+        // so the placeholder path is a real cwd; `id` above keeps it for identity.
+        const path = splitWorktreeIdForFilesystem(worktreeId)?.worktreePath ?? ''
         // Why: SSH worktree paths may use backslash separators on Windows remotes.
         const displayName = path.split(/[/\\]/).pop() || path
         const placeholder: Worktree = {


### PR DESCRIPTION
## Summary

Folder-workspace instance IDs include a `::workspace:<uuid>` suffix for identity, but local Git status treated that synthetic ID as a filesystem path. Git then retried `rev-parse` with a nonexistent cwd.

Local status now resolves the worktree ID through the existing filesystem-aware parser before invoking Git. Ordinary worktrees retain their parsed path, and remote runtime status routing is unchanged.

Closes #8283

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — branch checks pass; the aggregate command stops on five missing localization keys in `UsagePercentageDisplayChangeNotice.tsx` already present on `main`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused suite passes; the full suite is blocked in this environment by unrelated socket/Electron/network timeouts
- [x] `pnpm build`
- [x] Added regression coverage for a local folder-workspace instance ID

Focused test: `pnpm exec vitest run src/renderer/src/runtime/runtime-git-client.test.ts` (16/16)

## AI Review Report

Reviewed the path flow from renderer status polling to local Git IPC. The change reuses the existing filesystem-aware worktree parser and does not add path parsing rules.

Cross-platform review covered POSIX paths, Windows paths, local and SSH-backed status calls, and remote runtime routing. The local IPC branch changes only the cwd derived from a worktree ID; remote environments continue routing by worktree selector. There are no shortcut, label, shell, provider, or Electron lifecycle changes.

## Security Audit

The change narrows a command-execution input from a synthetic workspace identifier to its registered filesystem path. It does not add commands, interpolate shell input, change IPC exposure, access credentials, add dependencies, or alter authentication. Existing worktree-ID validation remains authoritative.

## Notes

No release or version changes. X handle: not provided.
