### PR TITLE
fix(updater): force-exit the stale old process so update install can relaunch

### DIFF
--- a/src/main/update-install-exit-watchdog.test.ts
+++ b/src/main/update-install-exit-watchdog.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appMock, recordUpdaterLifecycleMock } = vi.hoisted(() => ({
+  appMock: { exit: vi.fn() },
+  recordUpdaterLifecycleMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({ app: appMock }))
+vi.mock('./updater-lifecycle-diagnostics', () => ({
+  recordUpdaterLifecycle: recordUpdaterLifecycleMock
+}))
+
+import {
+  armUpdateInstallExitWatchdog,
+  disarmUpdateInstallExitWatchdog,
+  UPDATE_INSTALL_EXIT_TIMEOUT_MS
+} from './update-install-exit-watchdog'
+
+describe('update install exit watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    appMock.exit.mockClear()
+    recordUpdaterLifecycleMock.mockClear()
+  })
+
+  afterEach(() => {
+    disarmUpdateInstallExitWatchdog()
+    vi.useRealTimers()
+  })
+
+  it('force-exits with code 0 when the deadline passes', () => {
+    armUpdateInstallExitWatchdog()
+
+    vi.advanceTimersByTime(UPDATE_INSTALL_EXIT_TIMEOUT_MS - 1)
+    expect(appMock.exit).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(appMock.exit).toHaveBeenCalledExactlyOnceWith(0)
+    expect(recordUpdaterLifecycleMock).toHaveBeenCalledWith(
+      'install_exit_watchdog_fired',
+      { timeoutMs: UPDATE_INSTALL_EXIT_TIMEOUT_MS },
+      expect.objectContaining({ level: 'warn' })
+    )
+  })
+
+  it('re-arming does not extend the original deadline', () => {
+    armUpdateInstallExitWatchdog()
+    vi.advanceTimersByTime(UPDATE_INSTALL_EXIT_TIMEOUT_MS - 1)
+
+    armUpdateInstallExitWatchdog()
+    vi.advanceTimersByTime(1)
+
+    expect(appMock.exit).toHaveBeenCalledExactlyOnceWith(0)
+  })
+
+  it('disarm cancels the forced exit', () => {
+    armUpdateInstallExitWatchdog()
+    disarmUpdateInstallExitWatchdog()
+
+    vi.advanceTimersByTime(UPDATE_INSTALL_EXIT_TIMEOUT_MS * 2)
+    expect(appMock.exit).not.toHaveBeenCalled()
+  })
+
+  it('can be armed again after a disarm (install recovery then retry)', () => {
+    armUpdateInstallExitWatchdog()
+    disarmUpdateInstallExitWatchdog()
+    armUpdateInstallExitWatchdog()
+
+    vi.advanceTimersByTime(UPDATE_INSTALL_EXIT_TIMEOUT_MS)
+    expect(appMock.exit).toHaveBeenCalledExactlyOnceWith(0)
+  })
+})

--- a/src/main/update-install-exit-watchdog.ts
+++ b/src/main/update-install-exit-watchdog.ts
@@ -1,0 +1,51 @@
+import { app } from 'electron'
+import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
+
+// Why 20s: comfortably above a healthy shutdown (renderer buffer capture,
+// daemon final checkpoints, bounded 2s telemetry flush) but bounded — a wedged
+// teardown otherwise keeps the old process alive forever and the installer
+// never replaces the bundle or relaunches (issue #4438).
+export const UPDATE_INSTALL_EXIT_TIMEOUT_MS = 20_000
+
+let exitTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Guarantee the old app process exits once an update install has committed.
+ *
+ * Squirrel's ShipIt on macOS (and the Win/Linux installers) wait for the old
+ * app process to exit before installing the staged update and relaunching.
+ * The normal quit path defers exit behind unbounded async teardown — daemon
+ * checkpoint RPCs (30s timeout each, per session), SSH disconnects, watcher
+ * and emulator shutdown. If any of those wedge, the app looks closed (windows
+ * gone) but the process survives, ShipIt stalls, and the update never applies.
+ * Once armed, the process force-exits after the deadline if it is still alive.
+ */
+export function armUpdateInstallExitWatchdog(timeoutMs = UPDATE_INSTALL_EXIT_TIMEOUT_MS): void {
+  if (exitTimer) {
+    return
+  }
+  exitTimer = setTimeout(() => {
+    recordUpdaterLifecycle(
+      'install_exit_watchdog_fired',
+      { timeoutMs },
+      {
+        level: 'warn',
+        message: `Shutdown did not finish within ${timeoutMs}ms of committing the update install; forcing exit so the installer can relaunch`
+      }
+    )
+    // Why exit(0): the quit is already committed and cleanup is wedged, not
+    // failed — a clean code keeps ShipIt/launchd on the normal relaunch path.
+    app.exit(0)
+  }, timeoutMs)
+  // Why unref: the watchdog must never be the thing keeping the process alive.
+  exitTimer.unref?.()
+}
+
+/** Cancel the watchdog when install recovery re-opens the app (pre-commit
+ * native errors on macOS reset quit state and keep the session running). */
+export function disarmUpdateInstallExitWatchdog(): void {
+  if (exitTimer) {
+    clearTimeout(exitTimer)
+    exitTimer = null
+  }
+}

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -130,6 +130,16 @@ vi.mock('./updater-nudge', () => ({
   shouldApplyNudge: shouldApplyNudgeMock
 }))
 
+const { armExitWatchdogMock, disarmExitWatchdogMock } = vi.hoisted(() => ({
+  armExitWatchdogMock: vi.fn(),
+  disarmExitWatchdogMock: vi.fn()
+}))
+
+vi.mock('./update-install-exit-watchdog', () => ({
+  armUpdateInstallExitWatchdog: armExitWatchdogMock,
+  disarmUpdateInstallExitWatchdog: disarmExitWatchdogMock
+}))
+
 const { fetchNewerReleaseTagsMock } = vi.hoisted(() => ({
   fetchNewerReleaseTagsMock: vi.fn()
 }))
@@ -158,6 +168,8 @@ describe('updater', () => {
     appMock.isPackaged = true
     isMock.dev = false
     killAllPtyMock.mockReset()
+    armExitWatchdogMock.mockReset()
+    disarmExitWatchdogMock.mockReset()
     powerMonitorOnMock.mockReset()
     fetchNudgeMock.mockReset().mockResolvedValue(null)
     shouldApplyNudgeMock.mockReset().mockReturnValue(false)
@@ -1337,6 +1349,79 @@ describe('updater', () => {
     // Why: handoff still owns the process after commit — no recovery message
     // and no general check/download error status either.
     expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('arms the forced-exit watchdog once the install commits', async () => {
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: ['v1.0.61'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu, quitAndInstall } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.61',
+        changelog: null
+      })
+    })
+
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    // Why: on macOS install only commits once Squirrel is ready; mark it ready
+    // so this test covers the committed path on all platforms.
+    if (process.platform === 'darwin') {
+      const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+        ([eventName]) => eventName === 'update-downloaded'
+      )?.[1] as (() => void) | undefined
+      expect(nativeDownloadedHandler).toBeTypeOf('function')
+      nativeDownloadedHandler?.()
+    }
+
+    expect(armExitWatchdogMock).not.toHaveBeenCalled()
+
+    quitAndInstall()
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+    })
+
+    // Why: the installer (ShipIt/NSIS) waits for this process to exit; the
+    // watchdog guarantees a wedged async shutdown cannot strand the update.
+    expect(armExitWatchdogMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('disarms the forced-exit watchdog when sync install error recovery keeps the app open', async () => {
+    vi.useFakeTimers()
+
+    autoUpdaterMock.quitAndInstall.mockImplementation(() => {
+      autoUpdaterMock.emit(
+        'error',
+        new Error("No update filepath provided, can't quit and install")
+      )
+    })
+
+    const mainWindow = { webContents: { send: vi.fn() } }
+    const { setupAutoUpdater, quitAndInstall, isQuittingForUpdate } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never)
+    quitAndInstall()
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(isQuittingForUpdate()).toBe(false)
+    // Why: recovery leaves the app running — a live watchdog would force-exit
+    // a healthy session 20s later.
+    expect(armExitWatchdogMock).not.toHaveBeenCalled()
+    expect(disarmExitWatchdogMock).toHaveBeenCalled()
   })
 
   it('does not treat pre-native autoUpdater errors as quitAndInstall recovery', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -13,6 +13,10 @@ import {
   markMacQuitAndInstallInFlight,
   resetMacInstallState
 } from './updater-mac-install'
+import {
+  armUpdateInstallExitWatchdog,
+  disarmUpdateInstallExitWatchdog
+} from './update-install-exit-watchdog'
 import { registerAutoUpdaterHandlers } from './updater-events'
 import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
 import {
@@ -635,6 +639,10 @@ async function performQuitAndInstall(): Promise<void> {
       // still recover flags (PTYs may already be dead — residual OK).
       if (process.platform !== 'darwin' || isMacInstallerReady()) {
         updateInstallCommitted = true
+        // Why: past this point recovery is forbidden and the installer waits
+        // for this process to exit; a wedged async shutdown would otherwise
+        // strand the user with no app and no update (#4438).
+        armUpdateInstallExitWatchdog()
       }
     })
   } catch (error) {
@@ -658,6 +666,7 @@ function resetQuitForUpdateState(): void {
   quittingForUpdate = false
   updateInstallCommitted = false
   quitAndInstallNativeInvoked = false
+  disarmUpdateInstallExitWatchdog()
   resetMacInstallState()
 }
 


### PR DESCRIPTION
Fixes #4438

## What was happening ("Idk what ShipIt" — plain-English version)

On macOS, Electron updates work like this: Orca downloads the new version, then hands it to a small Apple-style helper process called **ShipIt** (part of Squirrel, the macOS auto-update framework Electron uses). ShipIt's job is to wait for the old Orca process to fully exit, swap the `.app` bundle on disk, and relaunch the new version. Windows/Linux installers behave the same way — they wait for the old process to die first.

The bug: clicking **Install** closed all Orca windows, so the app *looked* closed — but the old process never actually exited. ShipIt sat there waiting forever ("Detected this as an install request"… nothing), so the update never installed and nothing ever relaunched. A packaged repro of exactly this is recorded on the issue ([comment](https://github.com/stablyai/orca/issues/4438#issuecomment-4934218725)): the old process stayed alive **>2.5 minutes** after `quitAndInstall()`, and manually killing it made ShipIt immediately install and relaunch.

## Root cause

The `will-quit` handler in `src/main/index.ts` calls `e.preventDefault()` and waits on an **unbounded** `Promise.allSettled` of async teardown before letting Electron exit: daemon final-checkpoint RPCs (30s timeout *each*, per terminal session, with limited concurrency — a wedged daemon and ~20 sessions multiplies to minutes), SSH daemon disconnects, runtime RPC stop, file-watcher and emulator shutdown. Every step of the updater path before that is bounded (pre-quit cleanup has a 2.5s cap), but the final exit barrier is not. If any teardown wedges, the old process survives indefinitely and the installer can never proceed.

## Fix

Arm a **20s unref'd exit watchdog** (`src/main/update-install-exit-watchdog.ts`) at the exact point `performQuitAndInstall` *commits* the install — the same line that sets `updateInstallCommitted = true`, after which recovery is already forbidden and the process **must** exit for the installer to work. If the shutdown pipeline hasn't finished within 20s, the watchdog records an updater-lifecycle breadcrumb and calls `app.exit(0)` so ShipIt/NSIS can install and relaunch. It's disarmed in `resetQuitForUpdateState()` so pre-commit recovery (e.g. the sync "no staged update" error on macOS) can never leave a timer that would kill a healthy, recovered session.

Why this shape:
- **Committed installs only** — normal quits keep the existing unbounded, data-preserving teardown; behavior changes only on the path where the alternative is "no app and no update".
- **Healthy shutdowns are untouched** — 20s is well above the normal buffer-capture + checkpoint + 2s telemetry flush; the watchdog only fires when teardown is wedged (where checkpoint RPCs are dead anyway).
- **`exit(0)`** keeps ShipIt/launchd on the normal relaunch path.
- **`unref()`** so the watchdog can never itself keep the process alive.

Prior art: #4450 / #2308 proposed a much larger durable-marker + relaunch-guard system (19 files); this lands the one guard that matches the confirmed repro. The reporter's Login Items observation is a plausible secondary factor but the recorded repro pins the stale-process cause.

## Evidence

**Mechanism reproduced and fix proven in a real Electron main process** (this repo's Electron 43), since unref'd-timer + `app.exit` semantics inside a prevented quit are exactly what unit tests can't prove:

Control (today's behavior — wedged teardown, no watchdog): process never exits, killed by 15s harness timeout:
```
[harness] ready; committing update quit
[harness] will-quit prevented; teardown wedged forever (no watchdog)
exit=124 (still alive after 15s — the stale process that blocks ShipIt)
```

With the fix (3s deadline for the harness): clean self-exit:
```
[harness] ready; committing update quit
[harness] will-quit prevented; teardown wedged forever
[harness] watchdog fired; app.exit(0)
exit=0 after 5s
```

**Tests** (all green, 162 tests across updater suites):
- `update-install-exit-watchdog.test.ts` — fires `app.exit(0)` at the deadline, idempotent arming doesn't extend the deadline, disarm cancels, re-arm after disarm works.
- `updater.test.ts` — watchdog arms exactly once at install commit (not before), and is disarmed when sync install-error recovery keeps the app open.

`pnpm typecheck` clean; oxlint/oxfmt clean.

**Note on end-to-end verification:** the full relaunch flow only exists in a signed packaged build updating between published releases — it can't be exercised from a dev Electron session (and running it would terminate this session). The exact packaged failure was already reproduced and recorded on the issue on Jul 10; this PR's harness reproduces the process-level mechanism deterministically.

Made with [Orca](https://github.com/stablyai/orca) 🐋
