### PR TITLE
fix(terminal): widen enclosed ambiguous glyphs (①②③…) so they don't overlap

### DIFF
--- a/src/main/daemon/headless-emulator-unicode-width.test.ts
+++ b/src/main/daemon/headless-emulator-unicode-width.test.ts
@@ -25,4 +25,15 @@ describe('headless emulator unicode widths', () => {
     expect(emulator.getVisibleLines()[0]).toBe('\u{1F469}\u{200D}\u{1F4BB}Y')
     emulator.dispose()
   })
+
+  it('advances circled numbers as two cells so trailing ASCII does not overlap', async () => {
+    const emulator = new HeadlessEmulator({ cols: 40, rows: 4 })
+    // ① is EAW=Ambiguous — Unicode 11 budgets it 1 cell while fonts draw it
+    // full-width, so ①-then-ASCII overlaps. Widened to 2 cells, "A" is at
+    // column 3, "B" at 4, and column 5 lands just past "B".
+    await emulator.write('\x1b[H①AB')
+    await emulator.write('\x1b[1;5HZ')
+    expect(emulator.getVisibleLines()[0]).toBe('①ABZ')
+    emulator.dispose()
+  })
 })

--- a/src/shared/terminal-unicode-provider.test.ts
+++ b/src/shared/terminal-unicode-provider.test.ts
@@ -1,0 +1,69 @@
+import { Unicode11Addon } from '@xterm/addon-unicode11'
+import { Terminal } from '@xterm/headless'
+import { describe, expect, it } from 'vitest'
+import { activateOrcaTerminalUnicodeProvider } from './terminal-unicode-provider'
+
+// Why: xterm's public IUnicodeHandling exposes only register/activeVersion, but
+// the buffer layout (charProperties) and width-measuring paths run through the
+// internal UnicodeService. Exercising it is what actually proves cell widths.
+type UnicodeService = {
+  wcwidth(codepoint: number): 0 | 1 | 2
+  getStringCellWidth(text: string): number
+}
+
+function makeUnicodeService(): UnicodeService {
+  const terminal = new Terminal({ allowProposedApi: true, cols: 80, rows: 24 })
+  terminal.loadAddon(new Unicode11Addon())
+  activateOrcaTerminalUnicodeProvider(terminal as never)
+  return (terminal as unknown as { _core: { unicodeService: UnicodeService } })._core.unicodeService
+}
+
+describe('OrcaUnicodeProvider enclosed-ambiguous width', () => {
+  it('budgets enclosed alphanumerics as two cells so their full-width glyph fits', () => {
+    const svc = makeUnicodeService()
+    expect(svc.wcwidth(0x2460)).toBe(2) // ①
+    expect(svc.wcwidth(0x2473)).toBe(2) // ⑳
+    expect(svc.wcwidth(0x24e9)).toBe(2) // ⓩ (end of the first ambiguous run)
+    expect(svc.wcwidth(0x24ff)).toBe(2) // ◿ block end (ambiguous)
+    expect(svc.wcwidth(0x1f130)).toBe(2) // 🄰 Enclosed Alphanumeric Supplement
+  })
+
+  it('measures a circled number before ASCII as 2+1 cells (the overlap case)', () => {
+    const svc = makeUnicodeService()
+    expect(svc.getStringCellWidth('①')).toBe(2)
+    // ① takes two cells, so the trailing "A" lands past it instead of overlapping.
+    expect(svc.getStringCellWidth('①A')).toBe(3)
+  })
+
+  it('widens an astral enclosed glyph through the layout (charProperties) path', () => {
+    const svc = makeUnicodeService()
+    // 🄰 U+1F130 is astral (surrogate pair), decoded before the width lookup.
+    expect(svc.getStringCellWidth('\u{1F130}')).toBe(2)
+    expect(svc.getStringCellWidth('\u{1F130}A')).toBe(3)
+  })
+
+  it('keeps a combining mark after a widened glyph at zero added width', () => {
+    const svc = makeUnicodeService()
+    // ① (U+2460) widened to 2 cells; the combining grave (U+0300) inherits and
+    // contributes 0, so the total stays 2 (and 3 with a trailing ASCII). Built
+    // from char codes because a literal combining mark is invisible in source.
+    const circledWithGrave = String.fromCharCode(0x2460, 0x0300)
+    expect(svc.getStringCellWidth(circledWithGrave)).toBe(2)
+    expect(svc.getStringCellWidth(`${circledWithGrave}A`)).toBe(3)
+  })
+
+  it('leaves non-ambiguous and ASCII code points unchanged', () => {
+    const svc = makeUnicodeService()
+    expect(svc.wcwidth(0x3251)).toBe(2) // ㉑ already wide (EAW=Wide) in unicode11
+    expect(svc.wcwidth(0x3231)).toBe(2) // ㈱ already wide
+    // ⓪ is EAW=Neutral (not Ambiguous), so Unicode calls it narrow — not widened.
+    expect(svc.wcwidth(0x24ea)).toBe(1) // ⓪
+    expect(svc.wcwidth(0x41)).toBe(1) // A
+    expect(svc.getStringCellWidth('AB')).toBe(2)
+  })
+
+  it('still joins ZWJ emoji into one wide pair', () => {
+    const svc = makeUnicodeService()
+    expect(svc.getStringCellWidth('\u{1F469}\u{200D}\u{1F4BB}')).toBe(2) // 👩‍💻
+  })
+})

--- a/src/shared/terminal-unicode-provider.ts
+++ b/src/shared/terminal-unicode-provider.ts
@@ -13,6 +13,40 @@ const ORCA_UNICODE_VERSION = 'orca-11-zwj'
 const UNICODE11_VERSION = '11'
 const ZERO_WIDTH_JOINER = 0x200d
 
+// East_Asian_Width=Ambiguous enclosed glyphs (①, 🄰…) that unicode11 budgets as
+// one cell though fonts draw them full-width, so ①-before-ASCII overlaps.
+// Regenerate: EastAsianWidth.txt category A ∩ unicode11 wcwidth==1 over blocks
+// U+2460–24FF, U+3200–32FF, U+1F100–1F1FF, U+1F200–1F2FF (last yields none);
+// pinned to Unicode 17.0.0. Sorted, non-overlapping, inclusive ranges.
+const ENCLOSED_AMBIGUOUS_WIDE_RANGES: readonly (readonly [number, number])[] = [
+  [0x2460, 0x24e9],
+  [0x24eb, 0x24ff],
+  [0x3248, 0x324f],
+  [0x1f100, 0x1f10a],
+  [0x1f110, 0x1f12d],
+  [0x1f130, 0x1f169],
+  [0x1f170, 0x1f18d],
+  [0x1f18f, 0x1f190],
+  [0x1f19b, 0x1f1ac]
+]
+
+function isEnclosedAmbiguousWide(codepoint: number): boolean {
+  let low = 0
+  let high = ENCLOSED_AMBIGUOUS_WIDE_RANGES.length - 1
+  while (low <= high) {
+    const mid = (low + high) >> 1
+    const [start, end] = ENCLOSED_AMBIGUOUS_WIDE_RANGES[mid]
+    if (codepoint < start) {
+      high = mid - 1
+    } else if (codepoint > end) {
+      low = mid + 1
+    } else {
+      return true
+    }
+  }
+  return false
+}
+
 function extractWidth(properties: number): 0 | 1 | 2 {
   return ((properties >> 1) & 3) as 0 | 1 | 2
 }
@@ -31,7 +65,11 @@ class OrcaUnicodeProvider implements IUnicodeVersionProvider {
   public constructor(private readonly baseProvider: IUnicodeVersionProvider) {}
 
   public wcwidth(codepoint: number): 0 | 1 | 2 {
-    return this.baseProvider.wcwidth(codepoint)
+    const base = this.baseProvider.wcwidth(codepoint)
+    if (base === 1 && isEnclosedAmbiguousWide(codepoint)) {
+      return 2
+    }
+    return base
   }
 
   public charProperties(codepoint: number, preceding: number): number {
@@ -48,7 +86,14 @@ class OrcaUnicodeProvider implements IUnicodeVersionProvider {
       return createProperties(codepoint, precedingWidth, true)
     }
 
-    return this.baseProvider.charProperties(codepoint, preceding)
+    const properties = this.baseProvider.charProperties(codepoint, preceding)
+    // Why: xterm lays out cells from charProperties, not wcwidth, so an enclosed
+    // ambiguous glyph must be widened here too. Only bump the specific narrow
+    // enclosed code points; never touch the combining/join widths the base set.
+    if (extractWidth(properties) === 1 && isEnclosedAmbiguousWide(codepoint)) {
+      return createProperties(extractCharKind(properties), 2, Boolean(properties & 1))
+    }
+    return properties
   }
 }
 


### PR DESCRIPTION
## Problem

Characters in the Unicode "Enclosed Alphanumerics" block (`①` U+2460–U+24FF, etc.) render overlapping/garbled in the integrated terminal. Each is budgeted a single (narrow) cell while the font draws a full-width glyph, so the glyph bleeds into the next cell. The overlap is only *visible* when the following character is narrow (ASCII) — after a space the bleed just covers empty space and looks fine.

Root cause: these code points are East-Asian-Width = **Ambiguous**. `@xterm/addon-unicode11` sizes ambiguous as narrow (1 cell), matching upstream xterm.js / VS Code defaults, but the substituted glyph is drawn full-width.

Only the code points unicode11 actually sizes as narrow are affected. Circled numbers ≥ `㉑` (U+3250+) are already wide in unicode11 and render fine today; the real gap is `①`–`⑳` and the other enclosed-ambiguous strays.

## Fix

Extend the existing `OrcaUnicodeProvider` (`src/shared/terminal-unicode-provider.ts`, which already wraps unicode11 to fix ZWJ emoji) to budget the enclosed-ambiguous code points as **two cells**. The width is applied in both `wcwidth` and `charProperties` — xterm core lays out cells from `charProperties`, so both must agree or cursor/serialize math tears.

The code-point set is **derived, not hand-picked**: Unicode 17.0.0 `EastAsianWidth.txt` category `A`, intersected with `unicode11.wcwidth == 1`, over the four enclosed blocks (U+2460–24FF, U+3200–32FF, U+1F100–1F1FF, U+1F200–1F2FF) — 316 code points across 9 sorted, non-overlapping ranges. The regeneration recipe is in a comment above the table.

Because the fix lives in the shared provider, the on-screen terminal (`pane-lifecycle.ts`) and the headless agent-TUI width mirror (`headless-emulator.ts`) stay consistent automatically. No `config/patches` change is needed.

## Scope & tradeoff

- **Always-on, no setting.** This mirrors how the provider already handles emoji/ZWJ widths always-on. The affected glyphs are ones fonts draw full-width regardless, so widening the cell to match is a rendering-consistency fix, not a locale preference.
- **Enclosed subset only**, not the full ambiguous set — deliberately narrow to minimize regression surface.
- **SSH / remote-TUI note (per AGENTS.md):** unicode11 (and most terminals' default) treat ambiguous as narrow. A remote TUI (vim, tmux) that assumes narrow for these code points and does its own cursor math will diverge for them. This is defensible — the font already draws them full-width, so such a TUI was *already* overlapping; matching the cell width to the glyph is the correct call. The bump is gated on `unicode11 wcwidth == 1`, so if xterm ever ships these as natively wide, Orca automatically stops double-bumping them (graceful degradation).

## Tests

- `src/shared/terminal-unicode-provider.test.ts` (new): widths through the real `getStringCellWidth` (`charProperties`) path, astral decode (`🄰` U+1F130), combining-mark-after-widened, plus regression guards for already-wide (`㉑`), ASCII, ZWJ join, and the deliberate EAW=Neutral exclusion of `⓪` U+24EA.
- `src/main/daemon/headless-emulator-unicode-width.test.ts`: adds a `①AB` + reposition oracle proving `①` occupies two cells so trailing ASCII no longer overlaps.

Full unit suite green; typecheck, oxlint, and max-lines ratchet clean.

## Repro

```
echo "①②③④⑤ ⑳"
```
Overlapped before, distinct after.

## ELI5

Circled numbers and similar enclosed characters drew full-width glyphs in a single narrow cell, so they overlapped the next character. Those ambiguous glyphs are treated as wide enough so they no longer smash into following text.
