### PR TITLE
Fix zero-percent Grok usage visibility

### DIFF
--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -100,6 +100,26 @@ describe('fetchGrokRateLimits', () => {
     )
   })
 
+  it('maps omitted proto3 credit usage to zero for a weekly period', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        config: {
+          currentPeriod: {
+            type: 'USAGE_PERIOD_TYPE_WEEKLY',
+            start: '2026-07-07T18:36:14.268512+00:00',
+            end: '2026-07-14T18:36:14.268512+00:00'
+          },
+          subscriptionTier: 'SuperGrok'
+        }
+      })
+    )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(0)
+  })
+
   it('returns unavailable when not signed in even if a token-less auth file exists', async () => {
     authState.file = JSON.stringify({})
     const result = await fetchGrokRateLimits()

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -67,7 +67,13 @@ function parseResetDescription(isoString: string | undefined): string | null {
 }
 
 function mapWeeklyCredits(config: GrokBillingConfig): RateLimitWindow | null {
-  const usedPercent = config.creditUsagePercent
+  // Why: proto3 JSON omits a zero-valued percentage; a weekly period still
+  // identifies a valid credit window whose usage is exactly zero.
+  const usedPercent =
+    config.creditUsagePercent === undefined &&
+    config.currentPeriod?.type === 'USAGE_PERIOD_TYPE_WEEKLY'
+      ? 0
+      : config.creditUsagePercent
   if (typeof usedPercent !== 'number' || !Number.isFinite(usedPercent)) {
     return null
   }


### PR DESCRIPTION
## Summary

- treat an omitted Grok `creditUsagePercent` as zero when the billing response declares a weekly credit period
- preserve the existing unavailable state for billing configs that do not expose a weekly credit window
- add regression coverage for Grok's proto3 zero-value omission

Closes #8278

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/grok-fetcher.test.ts src/main/rate-limits/grok-auth.test.ts src/main/rate-limits/service.test.ts src/renderer/src/components/stats/GrokUsagePane.test.tsx src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts` (86 tests passed)
- [x] `pnpm typecheck`
- [x] `pnpm build` (desktop, web, and native builds passed)
- [x] changed-file `oxfmt`, `oxlint`, and `git diff --check`
- [ ] `pnpm lint` — existing missing localization keys in `UsagePercentageDisplayChangeNotice.tsx`, unrelated to this change
- [ ] `pnpm test` — 28,481 passed; 29 unrelated failures across five suites under unsupported Node 26, plus one asynchronous renderer-test cleanup error

## AI Review Report

- **Cross-platform:** no path, process, or platform-specific behavior changed.
- **Remote/SSH:** Grok usage remains a main-process account fetch; remote and SSH session routing are unchanged.
- **Provider compatibility:** the change is restricted to Grok's weekly billing mapper and does not affect other usage providers.
- **Performance:** no additional requests, polling, or persistent state were introduced.
- **Security:** authentication headers, credential parsing, endpoint selection, and renderer exposure are unchanged.
- **UI:** no layout change; valid zero-percent weekly usage now produces the existing Grok meter instead of an unavailable state.

## Notes

Grok's billing endpoint is proto3 JSON, which omits scalar fields at their default value. A declared weekly period with no `creditUsagePercent` therefore represents 0% usage, not a missing quota.

The repository requests Node 24; the full local suite was run on Node 26.0.0. The focused regression tests, typecheck, and full build pass in that environment.
