### PR TITLE
fix: use dynamic agent name in orca-cli worktree fallback

### DIFF
--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -126,7 +126,7 @@ orca worktree create --name task --run-hooks --json
 - `--run-hooks` is a legacy alias for `--setup run`; it also reveals/activates the new worktree.
 - `--agent`, `--activate`, and `--run-hooks` reveal the new worktree. Plain create stays in the background.
 - Let Orca choose setup terminal placement from repo settings, including tab vs split behavior. Do not manually create extra setup terminals.
-- If an older installed CLI rejects `--agent`, `--prompt`, or `--setup`, create the worktree normally, then run `orca terminal create --worktree <selector> --command "codex"` and `orca terminal send` if a prompt is needed.
+- If an older installed CLI rejects `--agent`, `--prompt`, or `--setup`, create the worktree normally, then run `orca terminal create --worktree <selector> --command "<requested-agent>"` and `orca terminal send` if a prompt is needed. This can leave a fallback shell when no default tabs are configured; close it only after confirming it is unused.
 - `worktree create` creates a new checkout. For a fresh agent in the current checkout, use `orca terminal create --worktree active --command "codex" --json`.
 
 ## Worktree Comments


### PR DESCRIPTION
## Summary
- Updates the fallback terminal command in orca-cli skill documentation to use a dynamic agent name instead of hardcoded "codex"
- Adds note about potential fallback shell cleanup when default tabs are not configured

## Changes
- skills/orca-cli/SKILL.md:129 - Changed the fallback terminal creation guidance to use dynamic agent name

Made with [Orca](https://github.com/stablyai/orca) 🐋
