### PR TITLE
fix(terminal): stop leaking xterm.js XTVERSION reply onto the shell prompt

### DIFF
--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -8,6 +8,7 @@ import {
   serializeWithAbsoluteCursor
 } from '../../shared/terminal-serialize-absolute-cursor'
 import { advancePartialEscapeTail } from '../../shared/terminal-partial-escape-tail'
+import { isXtversionReply } from '../../shared/terminal-query-reply'
 import type { TerminalViewAttributes } from '../../shared/terminal-view-attributes'
 import { collectHeadlessOscLinkRanges } from './headless-osc-link-ranges'
 import { buildRehydrateSequences } from './terminal-mode-rehydrate-sequences'
@@ -208,7 +209,11 @@ export class HeadlessEmulator {
   }
 
   private emitQueryReply(reply: string): void {
-    if (this.queryReplyForwardingDepth > 0 && this.onQueryReply) {
+    // Why suppress XTVERSION: it never unblocks a hidden program (non-blocking
+    // identity probe) and Orca already advertises identity via TERM_PROGRAM. A
+    // forwarded reply is gated behind the daemon shell-ready write queue, so at
+    // fresh spawn it lands on the shell prompt as `>|xterm.js(...)` (#7839).
+    if (this.queryReplyForwardingDepth > 0 && this.onQueryReply && !isXtversionReply(reply)) {
       this.onQueryReply(reply)
     }
   }

--- a/src/main/runtime/terminal-query-responder.test.ts
+++ b/src/main/runtime/terminal-query-responder.test.ts
@@ -139,7 +139,6 @@ describe('reply parity for hidden-dropped chunks', () => {
     ['DECRQSS DECSCUSR default cursor', '\x1bP$q q\x1b\\', ['\x1bP1$r2 q\x1b\\']],
     ['DECRQSS DECSCA', '\x1bP$q"q\x1b\\', ['\x1bP1$r0"q\x1b\\']],
     ['DECRQSS SGR', '\x1bP$qm\x1b\\', ['\x1bP1$r0m\x1b\\']],
-    ['XTVERSION', '\x1b[>0q', ['\x1bP>|xterm.js(6.0.0)\x1b\\']],
     ['kitty CSI ? u default flags', '\x1b[?u', ['\x1b[?0u']],
     ['kitty CSI ? u reports pushed flags', '\x1b[=5;1u\x1b[?u', ['\x1b[?5u']]
   ])('%s', async (_label, chunk, expectedReplies) => {
@@ -155,6 +154,10 @@ describe('reply parity for hidden-dropped chunks', () => {
 
   it.each([
     ['XTWINOPS', '\x1b[14t'],
+    // XTVERSION is deliberately silenced: Orca advertises identity via
+    // TERM_PROGRAM, and a forwarded `xterm.js(...)` reply gated behind the
+    // daemon shell-ready write queue leaks onto the fresh prompt (#7839).
+    ['XTVERSION', '\x1b[>0q'],
     ['XTGETTCAP', '\x1bP+q544e\x1b\\'],
     ['DSR ?15n printer status', '\x1b[?15n'],
     ['DSR ?25n UDK status', '\x1b[?25n'],

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6164,12 +6164,15 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).toHaveBeenCalledWith('\x1b[A')
     expect(transport.sendInputImmediate).not.toHaveBeenCalled()
 
-    // terminal-query-reply.test proves real xterm emits this as one fully framed
-    // onData reply; this pins that production-shaped reply to the immediate path.
+    // XTVERSION reply is dropped, never forwarded: Orca brands via TERM_PROGRAM,
+    // and a forwarded `xterm.js(...)` reply only leaks onto the shell prompt when
+    // the querying startup program is gone by reply time (#7839).
+    transport.sendInput.mockClear()
     transport.sendInputImmediate.mockClear()
     const xtversionReply = '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\'
     sendTerminalInputThroughPane(pane, xtversionReply)
-    expect(transport.sendInputImmediate).toHaveBeenCalledWith(xtversionReply)
+    expect(transport.sendInputImmediate).not.toHaveBeenCalled()
+    expect(transport.sendInput).not.toHaveBeenCalled()
 
     // Printable input is user-owned. Remote cooked echo comes back through PTY
     // output, not onData, so xterm/OSC-looking text must stay on normal input.

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../../shared/terminal-reply-query-extraction'
 import { takeCurrentPtyDeliveryAckCredit } from './terminal-pty-ack-gate'
 import { serializeWithAbsoluteCursor } from '../../../../shared/terminal-serialize-absolute-cursor'
-import { isTerminalQueryReply } from '../../../../shared/terminal-query-reply'
+import { isTerminalQueryReply, isXtversionReply } from '../../../../shared/terminal-query-reply'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
@@ -3369,6 +3369,13 @@ export function connectPanePty(
     // isTerminalQueryReply (it requires length >= 3 and a full reply grammar),
     // so a real keystroke never reaches this branch.
     if (isTerminalQueryReply(data)) {
+      // Why drop XTVERSION: it is a non-blocking identity probe and Orca already
+      // brands itself via TERM_PROGRAM=Orca, so forwarding xterm's bare
+      // `xterm.js(...)` reply only leaks onto the shell prompt when the querying
+      // startup program is gone by reply time (#7839). See isXtversionReply.
+      if (isXtversionReply(data)) {
+        return
+      }
       sendDesktopQueryReplyImmediate(data)
       return
     }

--- a/src/shared/terminal-query-reply.test.ts
+++ b/src/shared/terminal-query-reply.test.ts
@@ -1,6 +1,6 @@
 import { Terminal } from '@xterm/headless'
 import { describe, expect, it } from 'vitest'
-import { isTerminalQueryReply } from './terminal-query-reply'
+import { isTerminalQueryReply, isXtversionReply } from './terminal-query-reply'
 
 describe('isTerminalQueryReply', () => {
   it('matches synthetic query replies that must be sent immediately', () => {
@@ -95,5 +95,27 @@ describe('isTerminalQueryReply', () => {
     // Incomplete / non-terminated OSC and DCS must not match.
     expect(isTerminalQueryReply('\x1b]11;rgb:2828/2c2c/3434')).toBe(false)
     expect(isTerminalQueryReply('\x1bP1$r2 q')).toBe(false)
+  })
+})
+
+describe('isXtversionReply', () => {
+  it('matches the framed XTVERSION reply so it is suppressed, not forwarded', () => {
+    expect(isXtversionReply('\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\')).toBe(true)
+    expect(isXtversionReply('\x1bP>|xterm.js(5.6.0)\x1b\\')).toBe(true)
+    // Any terminal identity string inside the ESC P > | ... ST frame.
+    expect(isXtversionReply('\x1bP>|WezTerm 20240203\x1b\\')).toBe(true)
+  })
+
+  it('does NOT match other DCS replies or the ESC-stripped body', () => {
+    // DECRQSS cursor-style / SGR reports share the DCS frame but are not XTVERSION.
+    expect(isXtversionReply('\x1bP1$r2 q\x1b\\')).toBe(false)
+    expect(isXtversionReply('\x1bP0$r\x1b\\')).toBe(false)
+    // The printable body with framing already stripped is user-owned text.
+    expect(isXtversionReply('>|xterm.js(6.1.0-beta.287)')).toBe(false)
+    // Unterminated frame must not match.
+    expect(isXtversionReply('\x1bP>|xterm.js(6.1.0-beta.287)')).toBe(false)
+    // Other query replies stay forwardable (only XTVERSION is dropped).
+    expect(isXtversionReply('\x1b[?1;2c')).toBe(false)
+    expect(isXtversionReply('\x1b[>0;276;0c')).toBe(false)
   })
 })

--- a/src/shared/terminal-query-reply.ts
+++ b/src/shared/terminal-query-reply.ts
@@ -41,6 +41,8 @@ const OSC_RESPONSE_RE = new RegExp('^\\u001b\\][0-9]+;[^\\u0007\\u001b]*(?:\\u00
 // DCS-framed reports xterm emits: DECRQSS "ESC P 1 $ r Pt ST" / "ESC P 0 $ r ST"
 // (vim queries cursor style this way) and XTVERSION "ESC P > | text ST".
 const DCS_RESPONSE_RE = new RegExp('^\\u001bP(?:[01]\\$r[^\\u001b]*|>\\|[^\\u001b]*)\\u001b\\\\$')
+// XTVERSION reply alone: "ESC P > | <name(version)> ESC \\" (e.g. xterm.js(6.1.0)).
+const XTVERSION_RESPONSE_RE = new RegExp('^\\u001bP>\\|[^\\u001b]*\\u001b\\\\$')
 /* oxlint-enable no-control-regex */
 
 /**
@@ -66,4 +68,19 @@ export function isTerminalQueryReply(data: string): boolean {
     OSC_RESPONSE_RE.test(data) ||
     DCS_RESPONSE_RE.test(data)
   )
+}
+
+/**
+ * True when `data` is xterm's XTVERSION reply ("ESC P > | xterm.js(<ver>) ST").
+ *
+ * Orca must NOT forward this to the PTY. XTVERSION is a non-blocking identity
+ * probe (nothing hangs without a reply, unlike DA1/CPR/DSR), and Orca already
+ * advertises its identity via TERM_PROGRAM=Orca / TERM_PROGRAM_VERSION. The bare
+ * `xterm.js(...)` reply is both misleading (Orca is not raw xterm.js) and the
+ * recurring source of a prompt leak (#7839): on a fresh spawn the startup
+ * program that probed is gone by the time the reply clears the daemon
+ * shell-ready write gate, so it lands on the shell prompt as `>|xterm.js(...)`.
+ */
+export function isXtversionReply(data: string): boolean {
+  return data.length >= 3 && data[0] === ESC && XTVERSION_RESPONSE_RE.test(data)
 }


### PR DESCRIPTION
## Summary

Fixes the recurring leak where xterm.js's **XTVERSION reply** lands on the shell's input line as `>|xterm.js(6.1.0-beta.287)`, mangling the next command (e.g. `claude --dangerously-skip-permissions>|xterm.js(6.1.0-beta.287)` → `zsh: unknown file attribute: 6`). Same class as #7839 (whose fix PR was closed unmerged); reproduced here on a **local daemon PTY, fresh terminal spawn**.

### Root cause

On a fresh spawn a startup XTVERSION probe (`CSI >0q`) is answered by either:
- **main's query responder** (hidden-marked pane) → `HeadlessEmulator.emitQueryReply` → `ptyController.write`, or
- **the renderer's xterm** (visible pane) → `onData` → `sendInputImmediate`.

Both answer paths funnel into the daemon `Session.write`, which **queues stdin behind the shell-ready gate** (`preReadyStdinQueue`, `session.ts:202`) and flushes it onto the freshly-drawn prompt — *after* the querying startup program is gone. The framed reply `ESC P > | xterm.js(…) ESC \` then sits on the shell's input line. The existing comment (`orca-runtime.ts:6872`) treats "delayed, not lost" as safe, but for a **non-blocking** identity query, delayed = leaked.

### Fix

XTVERSION is a non-blocking identity probe — nothing hangs without a reply (unlike DA1/CPR/DSR), and Orca already advertises identity via `TERM_PROGRAM=Orca` / `TERM_PROGRAM_VERSION`. The bare `xterm.js(…)` reply is therefore both **misleading** (Orca is not raw xterm.js) and **leak-prone**. Suppress it at both answer sources via a shared matcher:

| Change | Why |
| --- | --- |
| `isXtversionReply()` in `src/shared/terminal-query-reply.ts` | One matcher for the framed `ESC P > \| … ESC \` reply, used by both sides |
| Drop in renderer `pty-connection.ts` `onData` | Covers the visible-pane path + the restore-salvage / queued-live-chunk writes, which all re-enter `onData` |
| Drop in `HeadlessEmulator.emitQueryReply` | Covers the hidden-dropped-chunk path (main responder). Daemon emulator has no reply sink, so its never-answers invariant is untouched |

Blocking/state replies (DA1, CPR/DSR, DECRPM, DECRQSS, kitty flags, view-attribute) are unchanged — only XTVERSION is silenced.

## Screenshots

No visual change (terminal input sanitization only). User-visible effect: the stray `>|xterm.js(…)` no longer appears on the prompt. Repro screenshot attached in the PR conversation.

## Testing

- [x] `pnpm lint` — oxlint, switch-exhaustiveness, styled-scrollbars, reliability-gates, and **max-lines ratchet** all pass on the touched files. (Full `pnpm lint` currently fails only on a **pre-existing, unrelated** localization-catalog gap in `status-bar/UsagePercentageDisplayChangeNotice.tsx` from #8319 — not touched here.)
- [x] `pnpm typecheck` — node + web + cli projects clean.
- [x] `pnpm test` (affected suites): `terminal-query-reply` + `terminal-query-responder` (100 passed), `headless-emulator` (54 passed), and the `pty-connection` onData routing test. Full suite not run locally.
- [ ] `pnpm build` — not run locally (Electron package build); typecheck across all three projects passes.
- [x] Added/updated tests: XTVERSION now asserted **dropped** (renderer onData), **silent** (main responder), plus `isXtversionReply` matcher coverage (framed reply matched; DECRQSS/ESC-stripped body/other replies not matched).

## AI Review Report

Reviewed the change against the terminal query-authority design (`docs/reference/terminal-query-authority.md`):

- **Cross-platform (macOS/Linux/Windows):** the fix is a platform-agnostic string classifier; XTVERSION reply grammar is identical everywhere. No `metaKey`/path/label code. The daemon shell-ready gate that delays the reply is POSIX (bash/zsh); Windows ConPTY answers DA1 (still forwarded, not XTVERSION), so ConPTY spawn-blocking is unaffected.
- **SSH / remote / local:** renderer `onData` drop applies to all transports (local IPC, remote-runtime, SSH). Remote-runtime PTYs are never hidden-marked, so main never answers them — their visible renderer path is covered by the same drop. This also addresses the original remote-Mac report (#7839).
- **Agent / integration compatibility:** XTVERSION is an optional probe for tmux/neovim/Claude/Grok; all fall back gracefully when unanswered (and Orca still sets `TERM_PROGRAM`). No agent blocks on a missing XTVERSION reply.
- **Performance:** one anchored regex test per query-reply event only (query replies are rare, not steady output). No hot-path cost.
- **UI quality:** no UI surface touched.
- **Exactly-once invariant:** unchanged — this only removes one reply class from the forward, at the two existing answer sources; it never adds a second answerer.

## Security Audit

No new IPC surface. The change strictly **reduces** bytes injected into the shell's stdin (it drops a reply that would otherwise be written to the PTY input line), so it removes an input-injection vector rather than adding one. No auth, secrets, path, command-execution, or dependency changes.

## Notes

- **Out of scope / follow-up:** the mobile/remote-view answer path (`terminal.send` `inputKind: query-reply`) is separate code and untouched — worth a follow-up for full parity, though the reported bug is local desktop.
- Verified at unit level at both answer chokepoints; a live in-app repro (spawn a terminal where a prompt/plugin probes XTVERSION and confirm no `>|xterm.js(…)`) is the natural manual confirmation.

Refs #7839

## ELI5

A version probe reply from xterm could leak onto the shell prompt as `>|xterm.js(...)`, mangling your next command. That XTVERSION reply is suppressed so it never lands on the input line after a fresh terminal spawn.
