### PR TITLE
Assign GitHub issue types via issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report a problem with Orca
 title: '[Bug]: '
+type: Bug
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature request
 description: Suggest an improvement for Orca
 title: '[Feature]: '
+type: Feature
 labels:
   - enhancement
 body:


### PR DESCRIPTION
## Summary
- Add `type: Bug` to the bug report issue template and `type: Feature` to the feature request template, so new issues created from these forms automatically get the correct GitHub issue Type (in addition to the existing `bug`/`enhancement` labels).
- The "Other" template intentionally gets no type — those issues are triaged manually.

## Context
Historic issues (~1,480 untyped) were backfilled separately via the GraphQL API using label signals (`bug` → Bug, `enhancement` → Feature) and title-based classification for early free-form issues.

Made with [Orca](https://github.com/stablyai/orca) 🐋
