### PR TITLE
Refresh stale no-PR results when the Checks Panel opens

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -124,6 +124,7 @@ import {
   shouldPollChecksPanelRuntimeSshStatus,
   type ChecksPanelGitStatusSnapshot
 } from './checks-panel-git-status-snapshot'
+import { resolveChecksPanelPRRefreshRequest } from './checks-panel-pr-refresh-request'
 import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
@@ -471,6 +472,7 @@ export default function ChecksPanel(): React.JSX.Element {
   const confirm = useConfirmationDialog()
   const prevChecksRef = useRef<string>('')
   const conflictSummaryRefreshKeyRef = useRef<string | null>(null)
+  const panelVisibleSinceRef = useRef<number | null>(null)
   commentsRef.current = comments
   const prGenerationRecords = useAppStore((s) => s.pullRequestGenerationRecords)
   const allocatePullRequestGenerationRequestId = useAppStore(
@@ -652,6 +654,7 @@ export default function ChecksPanel(): React.JSX.Element {
   // the entry for the active repo and branch.
   const prCacheEntry = useAppStore((s) => selectReviewCacheEntry(s.prCache, prCacheKey || null))
   const pr: PRInfo | null = prCacheEntry?.data ?? null
+  const prCachedHasPR = prCacheEntry ? prCacheEntry.data !== null : null
   const hostedReview = useAppStore((s) =>
     hostedReviewCacheKey ? (s.hostedReviewCache[hostedReviewCacheKey]?.data ?? null) : null
   )
@@ -735,6 +738,14 @@ export default function ChecksPanel(): React.JSX.Element {
     rawPRRefreshState,
     repo?.id
   ])
+
+  useEffect(() => {
+    if (!isPanelVisible) {
+      panelVisibleSinceRef.current = null
+      return
+    }
+    panelVisibleSinceRef.current = Date.now()
+  }, [isPanelVisible, panelContextKey])
 
   // Why: select only timestamps (not whole cache records) so the entry-refresh
   // effect doesn't re-run on every cache mutation. See
@@ -1221,7 +1232,12 @@ export default function ChecksPanel(): React.JSX.Element {
         staleWhileRevalidate: true
       })
       if (activeWorktreeId && !isGitLabReviewContext) {
-        enqueueGitHubPRRefresh(activeWorktreeId, 'swr', 30)
+        const refreshRequest = resolveChecksPanelPRRefreshRequest({
+          cachedHasPR: prCachedHasPR,
+          cachedFetchedAt: prFetchedAt ?? null,
+          panelVisibleSince: panelVisibleSinceRef.current
+        })
+        enqueueGitHubPRRefresh(activeWorktreeId, refreshRequest.reason, refreshRequest.priority)
       }
     }
   }, [
@@ -1239,6 +1255,8 @@ export default function ChecksPanel(): React.JSX.Element {
     linkedGiteaPR,
     linkedGitLabMR,
     linkedPR,
+    prCachedHasPR,
+    prFetchedAt,
     repo
   ])
 

--- a/src/renderer/src/components/right-sidebar/checks-panel-pr-refresh-request.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-pr-refresh-request.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { resolveChecksPanelPRRefreshRequest } from './checks-panel-pr-refresh-request'
+
+describe('resolveChecksPanelPRRefreshRequest', () => {
+  it('uses an active refresh for a cached miss from before the checks panel became visible', () => {
+    expect(
+      resolveChecksPanelPRRefreshRequest({
+        cachedHasPR: false,
+        cachedFetchedAt: 100,
+        panelVisibleSince: 200
+      })
+    ).toEqual({ reason: 'active', priority: 80 })
+  })
+
+  it('keeps fresh empty lookups on the background path', () => {
+    expect(
+      resolveChecksPanelPRRefreshRequest({
+        cachedHasPR: false,
+        cachedFetchedAt: 200,
+        panelVisibleSince: 100
+      })
+    ).toEqual({ reason: 'swr', priority: 30 })
+  })
+
+  it('keeps populated or unknown cache entries on the background path', () => {
+    expect(
+      resolveChecksPanelPRRefreshRequest({
+        cachedHasPR: true,
+        cachedFetchedAt: 100,
+        panelVisibleSince: 200
+      })
+    ).toEqual({ reason: 'swr', priority: 30 })
+
+    expect(
+      resolveChecksPanelPRRefreshRequest({
+        cachedHasPR: null,
+        cachedFetchedAt: null,
+        panelVisibleSince: 200
+      })
+    ).toEqual({ reason: 'swr', priority: 30 })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/checks-panel-pr-refresh-request.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-pr-refresh-request.ts
@@ -1,0 +1,30 @@
+import type { GitHubPRRefreshReason } from '../../../../shared/types'
+
+type ChecksPanelPRRefreshRequestInput = {
+  cachedHasPR: boolean | null
+  cachedFetchedAt: number | null
+  panelVisibleSince: number | null
+}
+
+type ChecksPanelPRRefreshRequest = {
+  reason: GitHubPRRefreshReason
+  priority: number
+}
+
+export function resolveChecksPanelPRRefreshRequest(
+  input: ChecksPanelPRRefreshRequestInput
+): ChecksPanelPRRefreshRequest {
+  const cachedMissPredatesVisiblePanel =
+    input.cachedHasPR === false &&
+    input.cachedFetchedAt !== null &&
+    input.panelVisibleSince !== null &&
+    input.cachedFetchedAt < input.panelVisibleSince
+
+  if (cachedMissPredatesVisiblePanel) {
+    // Why: external agents can create/merge a PR after Orca cached "none";
+    // visible empty-state checks need one foreground lookup to recover.
+    return { reason: 'active', priority: 80 }
+  }
+
+  return { reason: 'swr', priority: 30 }
+}


### PR DESCRIPTION
## Summary

- Retry a cached “no pull request” result as an active refresh when it predates the Checks Panel becoming visible.
- Keep fresh empty results, populated results, and unknown cache entries on the normal background refresh path.
- Isolate the refresh-priority decision in a small tested function.

## Problem

If an external agent created or merged a pull request after Orca cached “no PR,” opening the Checks Panel could continue showing the empty state. The panel requested only a low-priority stale-while-revalidate refresh, so the visible state was not recovered promptly.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm run typecheck:web`
- [ ] `pnpm test` (full suite)
- [ ] `pnpm build`
- [x] Added focused regression coverage: 3 tests passed
- [x] `git diff --check`

## AI Review Report

Reviewed the post-rebase diff and conflict resolutions. The original worktree-HEAD portion of the branch was superseded by the base branch’s newer `currentHeadOid` implementation and was not replayed. The remaining change is limited to Checks Panel refresh scheduling.

The review checked timestamp ordering, fresh/populated/unknown cache behavior, dependency updates, and whether the change affects macOS, Linux, Windows, Electron IPC, remote runtimes, or SSH routing. No platform-specific behavior or routing changes remain in this PR.

## Security Audit

This is a renderer-only refresh-priority decision based on existing cache timestamps and panel visibility. It adds no new external input handling, filesystem paths, command execution, authentication, secrets, dependencies, or IPC surface.

## Notes

The commit message reflects the branch’s original pre-rebase scope, but the PR diff and this description reflect the final scope.