### PR TITLE
Cli destructive suggest

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -13,6 +13,9 @@ export type CommandSpec = {
   // or handler registrations.
   aliases?: string[][]
   argumentMode?: 'parsed' | 'passthrough'
+  // Why: irreversibly destroys persistent state — typo recovery must not steer a
+  // benign mistake into one of these via the agent nextSteps channel. #6303
+  destructive?: boolean
   summary: string
   usage: string
   allowedFlags: string[]

--- a/src/cli/command-suggestion.test.ts
+++ b/src/cli/command-suggestion.test.ts
@@ -6,7 +6,11 @@ import { levenshtein, suggestCommands, unknownCommandData } from './command-sugg
 const specs: CommandSpec[] = [
   {
     path: ['worktree', 'rm'],
-    aliases: [['worktree', 'remove']],
+    aliases: [
+      ['worktree', 'remove'],
+      ['worktree', 'delete']
+    ],
+    destructive: true,
     summary: 'Remove a worktree',
     usage: 'orca worktree rm',
     allowedFlags: []
@@ -21,6 +25,15 @@ const specs: CommandSpec[] = [
     path: ['terminal', 'send'],
     summary: 'Send input',
     usage: 'orca terminal send',
+    allowedFlags: []
+  },
+  {
+    // A destructive command outside the delete-family, to prove the guard keys
+    // off the spec flag rather than a hardcoded verb list.
+    path: ['emulator', 'kill'],
+    destructive: true,
+    summary: 'Kill the emulator',
+    usage: 'orca emulator kill',
     allowedFlags: []
   }
 ]
@@ -67,6 +80,37 @@ describe('suggestCommands', () => {
     const result = suggestCommands(specs, ['terminal', 'sen'])
     expect(result[0]).toBe('terminal send')
   })
+
+  it('never suggests a destructive command for a benign non-destructive typo', () => {
+    // `worktree move` sits distance 2 from `worktree remove`; without the
+    // guard it would sole-suggest an irreversible delete on blind retry. #6303
+    const result = suggestCommands(specs, ['worktree', 'move'])
+    expect(result).not.toContain('worktree remove')
+    expect(result).not.toContain('worktree rm')
+    expect(result).not.toContain('worktree delete')
+  })
+
+  it('still suggests remove for a near-miss of a destructive verb', () => {
+    const result = suggestCommands(specs, ['worktree', 'remov'])
+    expect(result).toContain('worktree rm')
+    expect(result).toContain('worktree remove')
+  })
+
+  it('still suggests delete for a near-miss of the delete alias', () => {
+    expect(suggestCommands(specs, ['worktree', 'delet'])).toContain('worktree delete')
+  })
+
+  it('guards destructive commands outside the delete-family via the spec flag', () => {
+    // `emulator ball` is a benign token, distance 2 from the flagged `emulator
+    // kill` — close enough to otherwise rank, so the guard must exclude it.
+    expect(suggestCommands(specs, ['emulator', 'ball'])).not.toContain('emulator kill')
+    // A genuine near-miss of the destructive verb still recovers.
+    expect(suggestCommands(specs, ['emulator', 'kil'])).toContain('emulator kill')
+  })
+
+  it('still recovers non-destructive near-misses', () => {
+    expect(suggestCommands(specs, ['worktree', 'lst'])).toContain('worktree list')
+  })
 })
 
 describe('unknownCommandData', () => {
@@ -81,5 +125,11 @@ describe('unknownCommandData', () => {
     const data = unknownCommandData(specs, ['worktree', 'zzzzz'])
     expect(data.suggestions).toEqual([])
     expect(data.nextSteps).toEqual([])
+  })
+
+  it('does not route a benign typo into a destructive nextStep', () => {
+    const data = unknownCommandData(specs, ['worktree', 'move'])
+    expect(data.suggestions).not.toContain('worktree remove')
+    expect(data.nextSteps.join(' ')).not.toContain('remove')
   })
 })

--- a/src/cli/command-suggestion.ts
+++ b/src/cli/command-suggestion.ts
@@ -12,7 +12,7 @@ const MAX_SUGGESTIONS = 3
 const DESTRUCTIVE_INTENT_THRESHOLD = 1
 
 function finalToken(path: string[]): string {
-  return path[path.length - 1]
+  return path.at(-1) ?? ''
 }
 
 // Why: destructiveness is declared on the spec (single source of truth); the

--- a/src/cli/command-suggestion.ts
+++ b/src/cli/command-suggestion.ts
@@ -6,6 +6,42 @@ import { specPaths } from './args'
 const SUGGESTION_THRESHOLD = 3
 const MAX_SUGGESTIONS = 3
 
+// Why: a close typo of a destructive verb (`remov`→`remove`) still signals that
+// intent, but `move` (distance 2 from `remove`) does not — keep this at 1 so
+// genuine recovery works while unrelated verbs stay locked out. #6303
+const DESTRUCTIVE_INTENT_THRESHOLD = 1
+
+function finalToken(path: string[]): string {
+  return path[path.length - 1]
+}
+
+// Why: destructiveness is declared on the spec (single source of truth); the
+// intent verbs are the final tokens of every destructive path/alias so the guard
+// tracks the registry instead of a hand-maintained list.
+function destructiveVerbs(specs: CommandSpec[]): Set<string> {
+  const verbs = new Set<string>()
+  for (const spec of specs) {
+    if (spec.destructive) {
+      for (const path of specPaths(spec)) {
+        verbs.add(finalToken(path))
+      }
+    }
+  }
+  return verbs
+}
+
+// Why: deletion is irreversible and suggestions flow into agents' recovery
+// channel (--json nextSteps), so only unlock destructive candidates when the
+// input token is itself a near-miss of a destructive verb. #6303
+function intendsDestruction(inputToken: string, verbs: Set<string>): boolean {
+  for (const verb of verbs) {
+    if (levenshtein(inputToken, verb) <= DESTRUCTIVE_INTENT_THRESHOLD) {
+      return true
+    }
+  }
+  return false
+}
+
 export type CommandErrorData = {
   suggestions: string[]
   nextSteps: string[]
@@ -47,9 +83,15 @@ function rankByDistance(scored: { label: string; distance: number }[]): string[]
 // Why: same-depth matching avoids suggesting parent groups or unrelated commands.
 export function suggestCommands(specs: CommandSpec[], commandPath: string[]): string[] {
   const input = commandPath.join(' ')
+  // Why: only surface destructive commands when the user actually reached for one;
+  // otherwise a benign typo could recover into an irreversible action. #6303
+  const allowDestructive = intendsDestruction(finalToken(commandPath), destructiveVerbs(specs))
   const seen = new Set<string>()
   const scored: { label: string; distance: number }[] = []
   for (const spec of specs) {
+    if (spec.destructive && !allowDestructive) {
+      continue
+    }
     const candidates = specPaths(spec).map((path) =>
       commandPath.length === 1 ? path.slice(0, 1) : path
     )

--- a/src/cli/specs/automations.ts
+++ b/src/cli/specs/automations.ts
@@ -90,6 +90,7 @@ export const AUTOMATION_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['automations', 'remove'],
+    destructive: true,
     summary: 'Remove an Orca automation and its run history',
     usage: 'orca automations remove <id> [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'id'],

--- a/src/cli/specs/browser-advanced.ts
+++ b/src/cli/specs/browser-advanced.ts
@@ -29,6 +29,7 @@ export const BROWSER_ADVANCED_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['cookie', 'delete'],
+    destructive: true,
     summary: 'Delete a cookie by name',
     usage:
       'orca cookie delete --name <n> [--domain <d>] [--url <u>] [--worktree <selector>] [--json]',
@@ -240,6 +241,7 @@ export const BROWSER_ADVANCED_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['storage', 'local', 'clear'],
+    destructive: true,
     summary: 'Clear all localStorage',
     usage: 'orca storage local clear [--worktree <selector>] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'worktree']
@@ -258,6 +260,7 @@ export const BROWSER_ADVANCED_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['storage', 'session', 'clear'],
+    destructive: true,
     summary: 'Clear all sessionStorage',
     usage: 'orca storage session clear [--worktree <selector>] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'worktree']

--- a/src/cli/specs/browser-basic.ts
+++ b/src/cli/specs/browser-basic.ts
@@ -195,6 +195,7 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['tab', 'profile', 'delete'],
+    destructive: true,
     summary: 'Delete a browser session profile used by browser tabs',
     usage: 'orca tab profile delete --profile <id> [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'profile']

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -164,6 +164,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       ['worktree', 'remove'],
       ['worktree', 'delete']
     ],
+    destructive: true,
     summary: 'Remove a worktree from Orca and git',
     usage: 'orca worktree rm --worktree <selector> [--force] [--run-hooks] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'force', 'run-hooks'],

--- a/src/cli/specs/environment.ts
+++ b/src/cli/specs/environment.ts
@@ -23,6 +23,7 @@ export const ENVIRONMENT_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['environment', 'rm'],
+    destructive: true,
     summary: 'Remove one saved Orca runtime environment',
     usage: 'orca environment rm --environment <selector> [--json]',
     allowedFlags: [...GLOBAL_FLAGS]

--- a/src/cli/specs/project.ts
+++ b/src/cli/specs/project.ts
@@ -101,6 +101,7 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['project', 'setup-delete'],
+    destructive: true,
     summary: 'Remove a project host setup',
     usage: 'orca project setup-delete --setup <setup-id> [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'setup'],


### PR DESCRIPTION
## Summary

Describe the user-visible change.

## Screenshots

- Add screenshots or a screen recording for any new or changed UI behavior.
- If there is no visual change, say `No visual change`.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Summarize the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or verified as a result.
Confirm that the review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and any Electron-specific platform differences touched by this PR.

## Security Audit

Provide a basic security audit summary from your AI coding agent. Call out any input handling, command execution, path handling, auth, secrets, dependency, or IPC risks that were reviewed, plus any follow-up needed.

## Notes

Call out any platform-specific behavior, risks, or follow-up work.
