### PR TITLE
fix(relay): treat staging paths as literals

### DIFF
--- a/src/relay/git-handler-staging.test.ts
+++ b/src/relay/git-handler-staging.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for GitHandler commit and bulk-staging operations.
+ * Tests for GitHandler commit and staging operations.
  *
  * Why: split from git-handler.test.ts to stay under the oxlint max-lines (300) limit.
  */
@@ -18,6 +18,32 @@ import {
   type MockDispatcher,
   type RelayDispatcher
 } from './git-handler-test-setup'
+
+const PATHSPEC_SELECTED_FILE = '[k]eep.log'
+const PATHSPEC_MATCHING_FILE = 'keep.log'
+const PATHSPEC_MUTATION_CASES = [
+  {
+    mode: 'single-file',
+    stageMethod: 'git.stage',
+    unstageMethod: 'git.unstage',
+    selection: { filePath: PATHSPEC_SELECTED_FILE }
+  },
+  {
+    mode: 'bulk',
+    stageMethod: 'git.bulkStage',
+    unstageMethod: 'git.bulkUnstage',
+    selection: { filePaths: [PATHSPEC_SELECTED_FILE] }
+  }
+] as const
+
+function createPathspecCollisionChanges(dir: string): void {
+  gitInit(dir)
+  writeFileSync(path.join(dir, PATHSPEC_SELECTED_FILE), 'selected')
+  writeFileSync(path.join(dir, PATHSPEC_MATCHING_FILE), 'matching')
+  gitCommit(dir, 'initial')
+  writeFileSync(path.join(dir, PATHSPEC_SELECTED_FILE), 'selected modified')
+  writeFileSync(path.join(dir, PATHSPEC_MATCHING_FILE), 'matching modified')
+}
 
 describe('GitHandler — commit & staging', () => {
   let dispatcher: MockDispatcher
@@ -77,7 +103,38 @@ describe('GitHandler — commit & staging', () => {
     })
   })
 
-  describe('bulkStage and bulkUnstage', () => {
+  describe('stage and unstage', () => {
+    it.each(PATHSPEC_MUTATION_CASES)(
+      'treats $mode stage paths with Git glob characters as literals',
+      async ({ stageMethod, selection }) => {
+        createPathspecCollisionChanges(tmpDir)
+
+        await dispatcher.callRequest(stageMethod, { worktreePath: tmpDir, ...selection })
+
+        const output = execFileSync('git', ['diff', '--cached', '--name-only'], {
+          cwd: tmpDir,
+          encoding: 'utf-8'
+        })
+        expect(output.trim()).toBe(PATHSPEC_SELECTED_FILE)
+      }
+    )
+
+    it.each(PATHSPEC_MUTATION_CASES)(
+      'treats $mode unstage paths with Git glob characters as literals',
+      async ({ unstageMethod, selection }) => {
+        createPathspecCollisionChanges(tmpDir)
+        execFileSync('git', ['add', '.'], { cwd: tmpDir, stdio: 'pipe' })
+
+        await dispatcher.callRequest(unstageMethod, { worktreePath: tmpDir, ...selection })
+
+        const output = execFileSync('git', ['diff', '--cached', '--name-only'], {
+          cwd: tmpDir,
+          encoding: 'utf-8'
+        })
+        expect(output.trim()).toBe(PATHSPEC_MATCHING_FILE)
+      }
+    )
+
     it('stages multiple files', async () => {
       gitInit(tmpDir)
       writeFileSync(path.join(tmpDir, 'a.txt'), 'a')

--- a/src/relay/git-handler-staging.test.ts
+++ b/src/relay/git-handler-staging.test.ts
@@ -36,7 +36,6 @@ const PATHSPEC_MUTATION_CASES = [
   }
 ] as const
 
-/** Builds the collision that proves staging does not expand Git pathspec syntax. */
 function createPathspecCollisionChanges(dir: string): void {
   gitInit(dir)
   writeFileSync(path.join(dir, PATHSPEC_SELECTED_FILE), 'selected')

--- a/src/relay/git-handler-staging.test.ts
+++ b/src/relay/git-handler-staging.test.ts
@@ -36,6 +36,7 @@ const PATHSPEC_MUTATION_CASES = [
   }
 ] as const
 
+/** Builds the collision that proves staging does not expand Git pathspec syntax. */
 function createPathspecCollisionChanges(dir: string): void {
   gitInit(dir)
   writeFileSync(path.join(dir, PATHSPEC_SELECTED_FILE), 'selected')

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -1192,7 +1192,7 @@ describe('GitHandler', () => {
       await Promise.all([first, second])
 
       expect(gitBufferSpy).toHaveBeenCalledTimes(2)
-      expect(gitSpy).toHaveBeenCalledWith(['add', '--', 'src/file.ts'], tmpDir)
+      expect(gitSpy).toHaveBeenCalledWith(['add', '--', ':(literal)src/file.ts'], tmpDir)
       const submodulePathReads = gitSpy.mock.calls.filter(
         ([args]) => args[0] === 'config' && args.includes('.gitmodules')
       )

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -488,7 +488,7 @@ export class GitHandler {
     const worktreePath = params.worktreePath as string
     const filePath = params.filePath as string
     try {
-      await this.git(['add', '--', filePath], worktreePath)
+      await this.git(['add', '--', this.literalPathspec(filePath)], worktreePath)
     } finally {
       this.clearGitMutationReadCaches()
     }
@@ -512,7 +512,7 @@ export class GitHandler {
     const worktreePath = params.worktreePath as string
     const filePath = params.filePath as string
     try {
-      await this.git(['restore', '--staged', '--', filePath], worktreePath)
+      await this.git(['restore', '--staged', '--', this.literalPathspec(filePath)], worktreePath)
     } finally {
       this.clearGitMutationReadCaches()
     }
@@ -525,7 +525,10 @@ export class GitHandler {
     try {
       for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
         const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
-        await this.git(['add', '--', ...chunk], worktreePath)
+        await this.git(
+          ['add', '--', ...chunk.map((filePath) => this.literalPathspec(filePath))],
+          worktreePath
+        )
       }
     } finally {
       this.clearGitMutationReadCaches()
@@ -539,7 +542,10 @@ export class GitHandler {
     try {
       for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
         const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
-        await this.git(['restore', '--staged', '--', ...chunk], worktreePath)
+        await this.git(
+          ['restore', '--staged', '--', ...chunk.map((filePath) => this.literalPathspec(filePath))],
+          worktreePath
+        )
       }
     } finally {
       this.clearGitMutationReadCaches()

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -483,6 +483,7 @@ export class GitHandler {
     return this.maybeStreamResponse(result, params, context)
   }
 
+  /** Stages one path without interpreting Git pathspec syntax. */
   private async stage(params: Record<string, unknown>) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -507,6 +508,7 @@ export class GitHandler {
     }
   }
 
+  /** Unstages one path without interpreting Git pathspec syntax. */
   private async unstage(params: Record<string, unknown>) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -518,6 +520,7 @@ export class GitHandler {
     }
   }
 
+  /** Stages paths in bounded batches while treating every path as literal. */
   private async bulkStage(params: Record<string, unknown>) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -535,6 +538,7 @@ export class GitHandler {
     }
   }
 
+  /** Unstages paths in bounded batches while treating every path as literal. */
   private async bulkUnstage(params: Record<string, unknown>) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -483,7 +483,6 @@ export class GitHandler {
     return this.maybeStreamResponse(result, params, context)
   }
 
-  /** Stages one path without interpreting Git pathspec syntax. */
   private async stage(params: Record<string, unknown>) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -508,7 +507,6 @@ export class GitHandler {
     }
   }
 
-  /** Unstages one path without interpreting Git pathspec syntax. */
   private async unstage(params: Record<string, unknown>) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -520,7 +518,6 @@ export class GitHandler {
     }
   }
 
-  /** Stages paths in bounded batches while treating every path as literal. */
   private async bulkStage(params: Record<string, unknown>) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
@@ -538,7 +535,6 @@ export class GitHandler {
     }
   }
 
-  /** Unstages paths in bounded batches while treating every path as literal. */
   private async bulkUnstage(params: Record<string, unknown>) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string


### PR DESCRIPTION
## Summary

- Treat relay single-file and bulk stage or unstage selections as literal Git paths.
- Prevent a selected filename such as `[k]eep.log` from also mutating a sibling such as `keep.log`.
- Reuse the existing relay pathspec helper instead of adding another implementation.

Fixes #8356.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (all lint gates before localization passed; the command stops on five missing English keys in the untouched `UsagePercentageDisplayChangeNotice.tsx`)
- [x] `pnpm typecheck`
- [x] `pnpm test` (2,713 files and 28,569 tests passed; 6 files and 40 tests skipped)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Regression proof:

- Before the production change, all four new cases failed: single and bulk stage selected two colliding paths, while single and bulk unstage removed both.
- After the change, the relay suite passes 130 tests.
- The exact pathspec behavior also passed against a compiled Git 2.25.5 binary.
- `pnpm audit --audit-level low` reports no known vulnerabilities.

## AI Review Report

The review checked every relay stage and unstage mutation, existing assertions, and other local, WSL, and relay implementations. It found no remaining raw relay mutation path, no duplicate helper, and no blocker.

Cross-platform review covered macOS, Linux, Windows, WSL, and SSH. Arguments remain shell-free arrays, path joining remains platform-native, bulk chunking is unchanged, and no keyboard, label, or Electron behavior is touched. Native and WSL staging already use literal pathspecs; this PR brings SSH relay staging to the same contract.

## Security Audit

Reviewed path input, Git command construction, shell execution, IPC shape, auth, secrets, dependencies, and performance. The existing `:(literal)` helper prevents Git glob and pathspec-magic expansion without adding a process, dependency, privilege, or network call. Commands remain argv-based and do not invoke a shell. No auth, secret, provider, or persistence behavior changes.

## Notes

- Git 2.25 compatibility is preserved and verified.
- Build completed with existing chunk warnings and the optional `/usr/local/bin/orca-dev` symlink permission warning.
- No screenshot is applicable because this is a source-control correctness fix.