### PR TITLE
fix(cli): wait for valid serve recipe JSON

### DIFF
--- a/src/cli/runtime/launch.test.ts
+++ b/src/cli/runtime/launch.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../../shared/pairing'
 
 const { spawnMock } = vi.hoisted(() => ({
   spawnMock: vi.fn()
@@ -16,6 +17,32 @@ class FakeChildProcess extends EventEmitter {
   stdout = new EventEmitter()
   kill = vi.fn()
   unref = vi.fn()
+}
+
+const RECIPE_JSON = JSON.stringify({
+  schemaVersion: 1,
+  pairingCode: encodePairingOffer({
+    v: PAIRING_OFFER_VERSION,
+    endpoint: 'wss://sandbox.example.com',
+    deviceToken: 'token',
+    publicKeyB64: 'public-key'
+  }),
+  projectRoot: '/workspace/repo'
+})
+const SERVE_INSTALL_STATUS = '[serve] orca CLI install: installed'
+const SSH_RECIPE_JSON =
+  '{"schemaVersion":1,"connection":{"type":"ssh","target":{"label":"Sandbox","host":"sandbox.example.com","port":22,"username":"root"},"projectRoot":"/workspace/repo"}}'
+
+function startRecipeJsonServer() {
+  const child = new FakeChildProcess()
+  spawnMock.mockReturnValue(child)
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  const result = serveOrcaApp({
+    recipeJson: true,
+    projectRoot: '/workspace/repo'
+  })
+  return { child, result, stdoutSpy, stderrSpy }
 }
 
 describe('serveOrcaApp', () => {
@@ -133,10 +160,7 @@ describe('serveOrcaApp', () => {
       projectRoot: '/workspace/repo'
     })
     queueMicrotask(() => {
-      child.stdout.emit(
-        'data',
-        '{"schemaVersion":1,"pairingCode":"orca://pair?code=abc","projectRoot":"/workspace/repo"}\n'
-      )
+      child.stdout.emit('data', `${RECIPE_JSON}\n`)
     })
 
     await expect(result).resolves.toBe(0)
@@ -157,10 +181,59 @@ describe('serveOrcaApp', () => {
         stdio: ['ignore', 'pipe', 'inherit']
       })
     )
-    expect(writeSpy).toHaveBeenCalledWith(
-      '{"schemaVersion":1,"pairingCode":"orca://pair?code=abc","projectRoot":"/workspace/repo"}\n'
-    )
+    expect(writeSpy).toHaveBeenCalledWith(`${RECIPE_JSON}\n`)
     expect(child.unref).toHaveBeenCalled()
+  })
+
+  it('waits past startup status lines for valid recipe JSON', async () => {
+    const { child, result, stdoutSpy, stderrSpy } = startRecipeJsonServer()
+    queueMicrotask(() => {
+      child.stdout.emit(
+        'data',
+        `${SERVE_INSTALL_STATUS}\n${SSH_RECIPE_JSON}\n${RECIPE_JSON.slice(0, 40)}`
+      )
+      child.stdout.emit('data', `${RECIPE_JSON.slice(40)}\n`)
+    })
+
+    await expect(result).resolves.toBe(0)
+
+    expect(stderrSpy).toHaveBeenCalledWith(`${SERVE_INSTALL_STATUS}\n`)
+    expect(stderrSpy).toHaveBeenCalledWith(`${SSH_RECIPE_JSON}\n`)
+    expect(stdoutSpy).toHaveBeenCalledTimes(1)
+    expect(stdoutSpy).toHaveBeenCalledWith(`${RECIPE_JSON}\n`)
+    expect(child.unref).toHaveBeenCalledOnce()
+  })
+
+  it('rejects when the server exits without valid recipe JSON', async () => {
+    const { child, result, stdoutSpy, stderrSpy } = startRecipeJsonServer()
+    queueMicrotask(() => {
+      child.stdout.emit('data', `${SERVE_INSTALL_STATUS}\nnot recipe JSON\n`)
+      child.emit('exit', 0, null)
+      child.emit('close', 0, null)
+    })
+
+    await expect(result).rejects.toMatchObject({
+      code: 'runtime_serve_failed',
+      message: 'Orca serve exited before printing valid recipe JSON with code 0.'
+    })
+    expect(stdoutSpy).not.toHaveBeenCalled()
+    expect(stderrSpy).toHaveBeenCalledWith(`${SERVE_INSTALL_STATUS}\n`)
+    expect(stderrSpy).toHaveBeenCalledWith('not recipe JSON\n')
+    expect(child.unref).not.toHaveBeenCalled()
+  })
+
+  it('accepts valid recipe JSON at exit without a trailing newline', async () => {
+    const { child, result, stdoutSpy } = startRecipeJsonServer()
+    queueMicrotask(() => {
+      child.emit('exit', 0, null)
+      child.stdout.emit('data', RECIPE_JSON)
+      child.emit('close', 0, null)
+    })
+
+    await expect(result).resolves.toBe(0)
+
+    expect(stdoutSpy).toHaveBeenCalledWith(`${RECIPE_JSON}\n`)
+    expect(child.unref).toHaveBeenCalledOnce()
   })
 
   it('uses a shell when a Windows npm command shim is the Electron executable', async () => {

--- a/src/cli/runtime/launch.test.ts
+++ b/src/cli/runtime/launch.test.ts
@@ -30,8 +30,33 @@ const RECIPE_JSON = JSON.stringify({
   projectRoot: '/workspace/repo'
 })
 const SERVE_INSTALL_STATUS = '[serve] orca CLI install: installed'
-const SSH_RECIPE_JSON =
-  '{"schemaVersion":1,"connection":{"type":"ssh","target":{"label":"Sandbox","host":"sandbox.example.com","port":22,"username":"root"},"projectRoot":"/workspace/repo"}}'
+const SSH_PRIVATE_KEY = 'TOP-SECRET-PRIVATE-KEY'
+const SSH_AUTHORIZATION = 'Bearer TOP-SECRET-AUTHORIZATION'
+const SSH_PASSPHRASE = 'TOP-SECRET-PASSPHRASE'
+const SSH_COOKIE = 'session=TOP-SECRET-COOKIE'
+const SSH_RECIPE_JSON = JSON.stringify({
+  schemaVersion: 1,
+  connection: {
+    type: 'ssh',
+    target: {
+      label: 'Sandbox',
+      host: 'sandbox.example.com',
+      port: 22,
+      username: 'root'
+    },
+    projectRoot: '/workspace/repo'
+  },
+  userData: {
+    credentials: {
+      privateKey: SSH_PRIVATE_KEY,
+      authorization: SSH_AUTHORIZATION,
+      passphrase: SSH_PASSPHRASE,
+      cookie: SSH_COOKIE
+    }
+  }
+})
+const INVALID_SSH_RECIPE_JSON = SSH_RECIPE_JSON.replace('/workspace/repo', 'relative/repo')
+const IGNORED_NON_RECIPE_STDOUT = '[serve] ignored non-recipe stdout'
 
 function startRecipeJsonServer() {
   const child = new FakeChildProcess()
@@ -190,24 +215,52 @@ describe('serveOrcaApp', () => {
     queueMicrotask(() => {
       child.stdout.emit(
         'data',
-        `${SERVE_INSTALL_STATUS}\n${SSH_RECIPE_JSON}\n${RECIPE_JSON.slice(0, 40)}`
+        `${SERVE_INSTALL_STATUS}\n${INVALID_SSH_RECIPE_JSON}\n${SSH_RECIPE_JSON}\n${RECIPE_JSON.slice(0, 40)}`
       )
       child.stdout.emit('data', `${RECIPE_JSON.slice(40)}\n`)
     })
 
     await expect(result).resolves.toBe(0)
 
-    expect(stderrSpy).toHaveBeenCalledWith(`${SERVE_INSTALL_STATUS}\n`)
-    expect(stderrSpy).toHaveBeenCalledWith(`${SSH_RECIPE_JSON}\n`)
+    expect(stderrSpy).toHaveBeenNthCalledWith(1, `${IGNORED_NON_RECIPE_STDOUT}\n`)
+    expect(stderrSpy).toHaveBeenNthCalledWith(2, `${IGNORED_NON_RECIPE_STDOUT}\n`)
+    expect(stderrSpy).toHaveBeenNthCalledWith(3, `${IGNORED_NON_RECIPE_STDOUT}\n`)
+    for (const secret of [SSH_PRIVATE_KEY, SSH_AUTHORIZATION, SSH_PASSPHRASE, SSH_COOKIE]) {
+      expect(stderrSpy).not.toHaveBeenCalledWith(expect.stringContaining(secret))
+    }
     expect(stdoutSpy).toHaveBeenCalledTimes(1)
     expect(stdoutSpy).toHaveBeenCalledWith(`${RECIPE_JSON}\n`)
     expect(child.unref).toHaveBeenCalledOnce()
   })
 
+  it('preserves UTF-8 recipe JSON split across Buffer chunks', async () => {
+    const { child, result, stdoutSpy } = startRecipeJsonServer()
+    const unicodeRecipeJson = RECIPE_JSON.replace('/workspace/repo', '/workspace/café')
+    const recipeBuffer = Buffer.from(`${unicodeRecipeJson}\n`)
+    const splitIndex = recipeBuffer.indexOf(Buffer.from('é')) + 1
+    queueMicrotask(() => {
+      child.stdout.emit('data', recipeBuffer.subarray(0, splitIndex))
+      child.stdout.emit('data', recipeBuffer.subarray(splitIndex))
+    })
+
+    await expect(result).resolves.toBe(0)
+
+    expect(stdoutSpy).toHaveBeenCalledWith(`${unicodeRecipeJson}\n`)
+    expect(child.unref).toHaveBeenCalledOnce()
+  })
+
   it('rejects when the server exits without valid recipe JSON', async () => {
     const { child, result, stdoutSpy, stderrSpy } = startRecipeJsonServer()
+    const secrets = ['UPPER-SECRET', 'SLASH-SECRET', 'LEGACY-SECRET', 'PRIVATE-SECRET']
+    const untrustedLines = [
+      'ORCA://pair?code=UPPER-SECRET',
+      'orca://pair/?code=SLASH-SECRET',
+      'orca://pair#LEGACY-SECRET',
+      '"embedded privateKey PRIVATE-SECRET"',
+      '{privateKey:"PRIVATE-SECRET"}'
+    ].join('\n')
     queueMicrotask(() => {
-      child.stdout.emit('data', `${SERVE_INSTALL_STATUS}\nnot recipe JSON\n`)
+      child.stdout.emit('data', `${untrustedLines}\n`)
       child.emit('exit', 0, null)
       child.emit('close', 0, null)
     })
@@ -217,8 +270,11 @@ describe('serveOrcaApp', () => {
       message: 'Orca serve exited before printing valid recipe JSON with code 0.'
     })
     expect(stdoutSpy).not.toHaveBeenCalled()
-    expect(stderrSpy).toHaveBeenCalledWith(`${SERVE_INSTALL_STATUS}\n`)
-    expect(stderrSpy).toHaveBeenCalledWith('not recipe JSON\n')
+    expect(stderrSpy).toHaveBeenCalledTimes(5)
+    expect(stderrSpy).toHaveBeenCalledWith(`${IGNORED_NON_RECIPE_STDOUT}\n`)
+    for (const secret of secrets) {
+      expect(stderrSpy).not.toHaveBeenCalledWith(expect.stringContaining(secret))
+    }
     expect(child.unref).not.toHaveBeenCalled()
   })
 

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -1,5 +1,10 @@
 import { spawn as spawnProcess, type SpawnOptions } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
+import {
+  getEphemeralVmRecipeResultConnection,
+  parseEphemeralVmRecipeResult,
+  redactEphemeralVmRecipeDiagnosticText
+} from '../../shared/ephemeral-vm-recipes'
 import { RuntimeClientError } from './types'
 
 export function launchOrcaApp(): void {
@@ -155,7 +160,7 @@ function waitForRecipeJson(child: ReturnType<typeof spawnProcess>): Promise<numb
       clearTimeout(timeout)
       child.stdout?.off('data', onData)
       child.off('error', onError)
-      child.off('exit', onExit)
+      child.off('close', onClose)
       if (error) {
         reject(error)
         return
@@ -164,42 +169,63 @@ function waitForRecipeJson(child: ReturnType<typeof spawnProcess>): Promise<numb
       child.unref()
       resolve(0)
     }
-    const emitLine = (line: string): void => {
-      process.stdout.write(`${line}\n`)
+    const processRecipeOutputLine = (line: string): void => {
+      const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
+      if (!normalizedLine.trim()) {
+        return
+      }
+      const parsed = parseEphemeralVmRecipeResult(normalizedLine)
+      if (
+        !parsed.ok ||
+        getEphemeralVmRecipeResultConnection(parsed.result).type !== 'orca-server'
+      ) {
+        // Why: serve can only produce Orca-server readiness. Other recipe shapes
+        // and headless startup chatter are diagnostics that belong on stderr.
+        process.stderr.write(`${redactEphemeralVmRecipeDiagnosticText(normalizedLine)}\n`)
+        return
+      }
+      process.stdout.write(`${normalizedLine.trim()}\n`)
       finish()
     }
     const onData = (chunk: Buffer | string): void => {
       output += chunk.toString()
-      const newlineIndex = output.indexOf('\n')
-      if (newlineIndex === -1) {
-        return
+      while (!settled) {
+        const newlineIndex = output.indexOf('\n')
+        if (newlineIndex === -1) {
+          return
+        }
+        const line = output.slice(0, newlineIndex)
+        output = output.slice(newlineIndex + 1)
+        processRecipeOutputLine(line)
       }
-      emitLine(output.slice(0, newlineIndex))
     }
     const onError = (error: Error): void => {
       finish(error)
     }
-    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
       if (settled) {
         return
       }
-      const trimmed = output.trim()
-      if (trimmed) {
-        emitLine(trimmed)
+      if (output.trim()) {
+        processRecipeOutputLine(output)
+      }
+      if (settled) {
         return
       }
       finish(
         new RuntimeClientError(
           'runtime_serve_failed',
           typeof code === 'number'
-            ? `Orca serve exited before printing recipe JSON with code ${code}.`
-            : `Orca serve exited before printing recipe JSON via ${signal}.`
+            ? `Orca serve exited before printing valid recipe JSON with code ${code}.`
+            : `Orca serve exited before printing valid recipe JSON via ${signal}.`
         )
       )
     }
     child.stdout?.on('data', onData)
     child.once('error', onError)
-    child.once('exit', onExit)
+    // Why: `exit` can precede the final piped stdout data. `close` waits until
+    // stdio closes so a last recipe chunk is not mistaken for missing output.
+    child.once('close', onClose)
   })
 }
 

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -1,11 +1,13 @@
 import { spawn as spawnProcess, type SpawnOptions } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
 import {
   getEphemeralVmRecipeResultConnection,
-  parseEphemeralVmRecipeResult,
-  redactEphemeralVmRecipeDiagnosticText
+  parseEphemeralVmRecipeResult
 } from '../../shared/ephemeral-vm-recipes'
 import { RuntimeClientError } from './types'
+
+const IGNORED_NON_RECIPE_STDOUT = '[serve] ignored non-recipe stdout'
 
 export function launchOrcaApp(): void {
   const overrideCommand = process.env.ORCA_OPEN_COMMAND
@@ -169,26 +171,31 @@ function waitForRecipeJson(child: ReturnType<typeof spawnProcess>): Promise<numb
       child.unref()
       resolve(0)
     }
+    const writeIgnoredRecipeStdout = (): void => {
+      // Why: non-readiness child stdout is untrusted and cannot be safely
+      // redacted, including schema-valid results with arbitrary user data.
+      process.stderr.write(`${IGNORED_NON_RECIPE_STDOUT}\n`)
+    }
     const processRecipeOutputLine = (line: string): void => {
       const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line
       if (!normalizedLine.trim()) {
         return
       }
       const parsed = parseEphemeralVmRecipeResult(normalizedLine)
-      if (
-        !parsed.ok ||
-        getEphemeralVmRecipeResultConnection(parsed.result).type !== 'orca-server'
-      ) {
-        // Why: serve can only produce Orca-server readiness. Other recipe shapes
-        // and headless startup chatter are diagnostics that belong on stderr.
-        process.stderr.write(`${redactEphemeralVmRecipeDiagnosticText(normalizedLine)}\n`)
+      if (!parsed.ok) {
+        writeIgnoredRecipeStdout()
+        return
+      }
+      if (getEphemeralVmRecipeResultConnection(parsed.result).type !== 'orca-server') {
+        writeIgnoredRecipeStdout()
         return
       }
       process.stdout.write(`${normalizedLine.trim()}\n`)
       finish()
     }
+    const stdoutDecoder = new StringDecoder('utf8')
     const onData = (chunk: Buffer | string): void => {
-      output += chunk.toString()
+      output += typeof chunk === 'string' ? chunk : stdoutDecoder.write(chunk)
       while (!settled) {
         const newlineIndex = output.indexOf('\n')
         if (newlineIndex === -1) {
@@ -206,6 +213,7 @@ function waitForRecipeJson(child: ReturnType<typeof spawnProcess>): Promise<numb
       if (settled) {
         return
       }
+      output += stdoutDecoder.end()
       if (output.trim()) {
         processRecipeOutputLine(output)
       }


### PR DESCRIPTION
## Summary

- Keep reading complete child stdout lines until `orca serve --recipe-json` emits a schema-valid Orca server recipe result.
- Send startup chatter and non-Orca recipe shapes to stderr through the existing secret redactor.
- Wait for the child `close` event so final piped output is not lost after `exit`.
- Reject clean exits that never emit valid recipe JSON.

Fixes #8359

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` (2,712 files and 28,581 tests passed; one unrelated current-main test failed and reproduced on `origin/main`. Tracked in #8363 and fixed separately by #8365.)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional evidence:

- All 33 CLI files and 458 CLI tests pass after rebasing onto current `main`.
- Regression coverage includes startup status lines, a valid non-Orca recipe decoy, JSON split across stdout chunks, invalid output followed by exit, and valid final JSON without a trailing newline.
- `pnpm audit --audit-level low` reports no known vulnerabilities.
- `pnpm check:max-lines-ratchet` and `git diff --check` pass.

## AI Review Report

The review checked stdout chunking, complete-line framing, child event ordering, Orca versus SSH result discrimination, diagnostic redaction, and cleanup. Independent review caught the `exit` versus `close` ordering risk, which was fixed and covered by a regression test. A second review found no remaining blocker or duplicate parser.

Cross-platform review covered macOS, Linux, and Windows. The macOS and Linux install-status line triggered the bug, while the parser and child-process fix are platform-neutral. Existing Windows npm shim behavior remains covered and unchanged. No shortcut, label, path separator, or Electron platform behavior changes.

## Security Audit

Reviewed child-process input, untrusted stdout, secret-bearing diagnostics, shell execution, dependencies, IPC, auth, and persistence. Invalid lines are sent through the existing recipe diagnostic redactor. Only a strict schema-valid Orca server result reaches stdout. The patch adds no dependency, shell invocation, IPC surface, auth flow, or stored data.

## Notes

- Current-main test regression #8363 is separate and has a one-line fix in #8365.
- Build completed with existing chunk warnings and the optional `/usr/local/bin/orca-dev` symlink permission warning.
- X handle: SiddharthInk_
