### PR TITLE
test(runtime): complete terminal cwd store double

### DIFF
--- a/src/main/runtime/orca-runtime-terminal-cwd.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-cwd.test.ts
@@ -109,6 +109,7 @@ describe('OrcaRuntimeService terminal startup cwd', () => {
 
   it('materializes restored headless mobile tabs in the persisted startup cwd', async () => {
     const store = {
+      getRepo: () => undefined,
       getWorkspaceSession: () => ({
         activeRepoId: null,
         activeWorktreeId: 'wt-1',


### PR DESCRIPTION
## Summary

Add the required `getRepo` method to the narrow store double used by terminal startup cwd coverage.

Fixes #8363

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (2,713 files and 28,580 tests passed; 6 files and 40 tests skipped.)
- [ ] `pnpm build` (not rerun because this changes one test double only.)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Verified red-to-green evidence:

- On `origin/main` at `3090ff0ed`, the focused file reported one failure and three passes with `TypeError: this.store?.getRepo is not a function`.
- The full suite reproduced the same sole failure with 2,712 files and 28,581 tests passing.
- After this one-line fix, all four focused tests and the complete suite pass.
- `git diff --check` passes.

## AI Review Report

Independent review traced the first bad main commit, checked all production constructor paths, and verified the real store signature. It confirmed this is an incomplete test double, not a production crash. Making the production call optional would weaken the required contract, so the patch remains one test line.

Cross-platform review covered macOS, Linux, Windows, WSL, and SSH. This is test setup only and does not change paths, shells, shortcuts, labels, Git commands, or Electron behavior.

## Security Audit

Reviewed whether the failure represented a reachable malformed-store path, input validation gap, auth issue, secret exposure, command execution, dependency, or IPC risk. The only production constructor path passes the real store, whose required `getRepo` method returns `undefined` when missing. No runtime or security behavior changes.

## Notes

- The broader `store as never` fixture style is existing cleanup and is intentionally out of scope.

## ELI5

A unit-test double for the terminal cwd store was missing a required `getRepo` method, which broke coverage. The test double is completed so those tests run cleanly again with no product UI change.
