### PR TITLE
fix(cli): preserve multiline arguments on Windows

### DIFF
--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -72,6 +72,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: >-
           pnpm vitest run
+          config/scripts/build-windows-cli-launcher.test.mjs
           config/scripts/computer-e2e-workflow.test.mjs
           config/scripts/computer-use-skill-guidance.test.mjs
           config/scripts/computer-use-smoke.test.mjs

--- a/.github/workflows/win-update-survival-e2e.yml
+++ b/.github/workflows/win-update-survival-e2e.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: dist/orca-windows-setup.exe
-          key: branch-installer-${{ hashFiles('src/**', 'config/**', 'package.json', 'pnpm-lock.yaml') }}
+          key: branch-installer-${{ hashFiles('src/**', 'config/**', 'native/**', 'resources/win32/**', 'package.json', 'pnpm-lock.yaml') }}
 
       - name: Build Windows installer (unsigned)
         if: steps.cache-installer.outputs.cache-hit != 'true'

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -186,6 +186,10 @@ module.exports = {
         to: 'bin/orca.cmd'
       },
       {
+        from: 'native/windows-cli-launcher/.build/orca.exe',
+        to: 'bin/orca.exe'
+      },
+      {
         from: 'node_modules/agent-browser/bin/agent-browser-win32-x64.exe',
         to: 'agent-browser-win32-x64.exe'
       },

--- a/config/scripts/build-native-for-platform.mjs
+++ b/config/scripts/build-native-for-platform.mjs
@@ -2,6 +2,11 @@
 
 import { spawnSync } from 'node:child_process'
 
+if (process.platform === 'win32') {
+  runNodeScript('config/scripts/build-windows-cli-launcher.mjs')
+  process.exit(0)
+}
+
 if (process.platform !== 'darwin') {
   console.log(`[native-build] no macOS native computer build required on ${process.platform}`)
   process.exit(0)
@@ -21,6 +26,16 @@ function runPnpmScript(scriptName) {
   const args = npmExecPath ? [npmExecPath, 'run', scriptName] : ['run', scriptName]
   const result = spawnSync(command, args, { stdio: 'inherit' })
 
+  if (result.signal) {
+    process.kill(process.pid, result.signal)
+  }
+  if (result.status !== 0 || result.error) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+function runNodeScript(scriptPath) {
+  const result = spawnSync(process.execPath, [scriptPath], { stdio: 'inherit' })
   if (result.signal) {
     process.kill(process.pid, result.signal)
   }

--- a/config/scripts/build-windows-cli-launcher.mjs
+++ b/config/scripts/build-windows-cli-launcher.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+if (process.platform !== 'win32') {
+  process.exit(0)
+}
+
+const repoRoot = resolve(import.meta.dirname, '../..')
+const sourcePath = join(repoRoot, 'native', 'windows-cli-launcher', 'OrcaCliLauncher.cs')
+const outputPath = readArg('--output') ?? defaultOutputPath(repoRoot)
+const compilerPath = findFrameworkCompiler(process.env)
+
+if (!compilerPath) {
+  throw new Error('Unable to find the .NET Framework C# compiler required for orca.exe.')
+}
+
+mkdirSync(dirname(outputPath), { recursive: true })
+const result = spawnSync(
+  compilerPath,
+  [
+    '/nologo',
+    '/target:exe',
+    '/optimize+',
+    '/deterministic+',
+    '/warnaserror+',
+    `/out:${outputPath}`,
+    sourcePath
+  ],
+  { cwd: repoRoot, stdio: 'inherit' }
+)
+
+if (result.signal) {
+  process.kill(process.pid, result.signal)
+}
+if (result.error) {
+  throw result.error
+}
+if (result.status !== 0) {
+  process.exit(result.status ?? 1)
+}
+
+function defaultOutputPath(projectRoot) {
+  return join(projectRoot, 'native', 'windows-cli-launcher', '.build', 'orca.exe')
+}
+
+function findFrameworkCompiler(env) {
+  const windowsDirectory = env.WINDIR ?? env.SystemRoot
+  if (!windowsDirectory) {
+    return null
+  }
+  const candidates = [
+    join(windowsDirectory, 'Microsoft.NET', 'Framework64', 'v4.0.30319', 'csc.exe'),
+    join(windowsDirectory, 'Microsoft.NET', 'Framework', 'v4.0.30319', 'csc.exe')
+  ]
+  return candidates.find((candidate) => existsSync(candidate)) ?? null
+}
+
+function readArg(name) {
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? process.argv[index + 1] : undefined
+}

--- a/config/scripts/build-windows-cli-launcher.mjs
+++ b/config/scripts/build-windows-cli-launcher.mjs
@@ -20,15 +20,7 @@ if (!compilerPath) {
 mkdirSync(dirname(outputPath), { recursive: true })
 const result = spawnSync(
   compilerPath,
-  [
-    '/nologo',
-    '/target:exe',
-    '/optimize+',
-    '/deterministic+',
-    '/warnaserror+',
-    `/out:${outputPath}`,
-    sourcePath
-  ],
+  ['/nologo', '/target:exe', '/optimize+', '/warnaserror+', `/out:${outputPath}`, sourcePath],
   { cwd: repoRoot, stdio: 'inherit' }
 )
 

--- a/config/scripts/build-windows-cli-launcher.test.mjs
+++ b/config/scripts/build-windows-cli-launcher.test.mjs
@@ -33,7 +33,7 @@ describe('Windows CLI launcher', () => {
         ['config/scripts/build-windows-cli-launcher.mjs', '--output', launcherPath],
         { cwd: projectRoot, encoding: 'utf8' }
       )
-      expect(build.status, build.stderr).toBe(0)
+      expect(build.status, `${build.stdout}\n${build.stderr}`).toBe(0)
 
       const body = 'paragraph one line one\nparagraph one line two\n\nparagraph two'
       const powershell = spawnSync(

--- a/config/scripts/build-windows-cli-launcher.test.mjs
+++ b/config/scripts/build-windows-cli-launcher.test.mjs
@@ -1,0 +1,69 @@
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+const itWindows = process.platform === 'win32' ? it : it.skip
+const projectRoot = resolve(import.meta.dirname, '../..')
+
+describe('Windows CLI launcher', () => {
+  itWindows('preserves a multiline argument from PowerShell through the native launcher', () => {
+    const appRoot = mkdtempSync(join(tmpdir(), 'orca cli launcher '))
+    try {
+      const resourcesPath = join(appRoot, 'resources')
+      const launcherPath = join(resourcesPath, 'bin', 'orca.exe')
+      const cliPath = join(resourcesPath, 'app.asar.unpacked', 'out', 'cli', 'index.js')
+      mkdirSync(join(resourcesPath, 'bin'), { recursive: true })
+      mkdirSync(dirname(cliPath), { recursive: true })
+      copyFileSync(process.execPath, join(appRoot, 'Orca.exe'))
+      writeFileSync(
+        cliPath,
+        `process.stdout.write(JSON.stringify({
+  argv: process.argv.slice(2),
+  electronRunAsNode: process.env.ELECTRON_RUN_AS_NODE,
+  nodeOptions: process.env.NODE_OPTIONS ?? null,
+  orcaNodeOptions: process.env.ORCA_NODE_OPTIONS ?? null
+}))\n`,
+        'utf8'
+      )
+
+      const build = spawnSync(
+        process.execPath,
+        ['config/scripts/build-windows-cli-launcher.mjs', '--output', launcherPath],
+        { cwd: projectRoot, encoding: 'utf8' }
+      )
+      expect(build.status, build.stderr).toBe(0)
+
+      const body = 'paragraph one line one\nparagraph one line two\n\nparagraph two'
+      const powershell = spawnSync(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          '& $env:ORCA_TEST_LAUNCHER orchestration send --body $env:ORCA_TEST_BODY --json'
+        ],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            NODE_OPTIONS: '--no-warnings',
+            ORCA_TEST_BODY: body,
+            ORCA_TEST_LAUNCHER: launcherPath
+          }
+        }
+      )
+
+      expect(powershell.status, powershell.stderr).toBe(0)
+      expect(JSON.parse(powershell.stdout)).toEqual({
+        argv: ['orchestration', 'send', '--body', body, '--json'],
+        electronRunAsNode: '1',
+        nodeOptions: null,
+        orcaNodeOptions: '--no-warnings'
+      })
+    } finally {
+      rmSync(appRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -58,6 +58,10 @@ describe('electron-builder config', () => {
         expect.objectContaining({
           from: 'native/computer-use-windows/runtime.ps1',
           to: 'computer-use-windows/runtime.ps1'
+        }),
+        expect.objectContaining({
+          from: 'native/windows-cli-launcher/.build/orca.exe',
+          to: 'bin/orca.exe'
         })
       ])
     )

--- a/config/scripts/electron-builder-native-rebuild.cjs
+++ b/config/scripts/electron-builder-native-rebuild.cjs
@@ -9,6 +9,12 @@ function electronBuilderNativeRebuild(context) {
 
 function runElectronBuilderNativeRebuild(context, runner = execFileSync) {
   const args = buildNativeRebuildArgs(context)
+  if (readPlatformName(context?.platform) === 'win32') {
+    runner(process.execPath, ['config/scripts/build-windows-cli-launcher.mjs'], {
+      cwd: projectDir,
+      stdio: 'inherit'
+    })
+  }
   runner(process.execPath, args, {
     cwd: projectDir,
     stdio: 'inherit'

--- a/config/scripts/electron-builder-native-rebuild.test.mjs
+++ b/config/scripts/electron-builder-native-rebuild.test.mjs
@@ -42,6 +42,31 @@ describe('electron-builder native rebuild hook', () => {
     ])
   })
 
+  it('builds the native CLI launcher before packaging Windows resources', () => {
+    const calls = []
+    const result = runElectronBuilderNativeRebuild(
+      {
+        platform: { nodeName: 'win32' },
+        arch: 'x64'
+      },
+      (...args) => calls.push(args)
+    )
+
+    expect(result).toBe(false)
+    expect(calls).toEqual([
+      [
+        process.execPath,
+        ['config/scripts/build-windows-cli-launcher.mjs'],
+        expect.objectContaining({ stdio: 'inherit' })
+      ],
+      [
+        process.execPath,
+        ['config/scripts/rebuild-native-deps.mjs', '--platform=win32', '--arch=x64', '--force'],
+        expect.objectContaining({ stdio: 'inherit' })
+      ]
+    ])
+  })
+
   it('rejects incomplete electron-builder contexts', () => {
     expect(() => buildNativeRebuildArgs({ arch: 'x64' })).toThrow(/platform/)
     expect(() => buildNativeRebuildArgs({ platform: { nodeName: 'linux' } })).toThrow(/arch/)

--- a/config/scripts/smoke-packaged-cli.mjs
+++ b/config/scripts/smoke-packaged-cli.mjs
@@ -25,7 +25,7 @@ function getPackagedCliPath(appDir) {
     return join(appDir, 'Contents', 'Resources', 'bin', 'orca')
   }
   if (process.platform === 'win32') {
-    return join(appDir, 'resources', 'bin', 'orca.cmd')
+    return join(appDir, 'resources', 'bin', 'orca.exe')
   }
   return join(appDir, 'resources', 'bin', 'orca-ide')
 }

--- a/native/windows-cli-launcher/OrcaCliLauncher.cs
+++ b/native/windows-cli-launcher/OrcaCliLauncher.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+internal static class OrcaCliLauncher
+{
+    private static int Main(string[] args)
+    {
+        try
+        {
+            string launcherDirectory = Path.GetDirectoryName(typeof(OrcaCliLauncher).Assembly.Location);
+            string resourcesDirectory = Directory.GetParent(launcherDirectory).FullName;
+            string appDirectory = Directory.GetParent(resourcesDirectory).FullName;
+            string electronPath = Path.Combine(appDirectory, "Orca.exe");
+            string cliPath = Path.Combine(
+                resourcesDirectory,
+                "app.asar.unpacked",
+                "out",
+                "cli",
+                "index.js"
+            );
+
+            if (!File.Exists(electronPath))
+            {
+                Console.Error.WriteLine("Unable to locate Orca.exe next to \"{0}\"", resourcesDirectory);
+                return 1;
+            }
+
+            if (!File.Exists(cliPath))
+            {
+                Console.Error.WriteLine("Unable to locate the Orca CLI entrypoint at \"{0}\"", cliPath);
+                return 1;
+            }
+
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = electronPath,
+                Arguments = BuildArguments(cliPath, args),
+                UseShellExecute = false
+            };
+
+            // Why: launching without cmd.exe preserves embedded newlines while matching the
+            // packaged batch launcher's Electron-as-Node environment contract.
+            MoveEnvironmentVariable(startInfo.EnvironmentVariables, "NODE_OPTIONS", "ORCA_NODE_OPTIONS");
+            MoveEnvironmentVariable(
+                startInfo.EnvironmentVariables,
+                "NODE_REPL_EXTERNAL_MODULE",
+                "ORCA_NODE_REPL_EXTERNAL_MODULE"
+            );
+            startInfo.EnvironmentVariables["ELECTRON_RUN_AS_NODE"] = "1";
+
+            using (Process child = Process.Start(startInfo))
+            {
+                child.WaitForExit();
+                return child.ExitCode;
+            }
+        }
+        catch (Exception error)
+        {
+            Console.Error.WriteLine("Unable to start the Orca CLI: {0}", error.Message);
+            return 1;
+        }
+    }
+
+    private static void MoveEnvironmentVariable(
+        StringDictionary environment,
+        string sourceName,
+        string targetName
+    )
+    {
+        string value = Environment.GetEnvironmentVariable(sourceName);
+        environment.Remove(sourceName);
+        environment.Remove(targetName);
+        if (value != null)
+        {
+            environment[targetName] = value;
+        }
+    }
+
+    private static string BuildArguments(string cliPath, string[] args)
+    {
+        StringBuilder commandLine = new StringBuilder(QuoteArgument(cliPath));
+        foreach (string arg in args)
+        {
+            commandLine.Append(' ');
+            commandLine.Append(QuoteArgument(arg));
+        }
+        return commandLine.ToString();
+    }
+
+    private static string QuoteArgument(string value)
+    {
+        bool requiresQuotes = value.Length == 0;
+        for (int index = 0; index < value.Length && !requiresQuotes; index += 1)
+        {
+            requiresQuotes = value[index] == '"' || Char.IsWhiteSpace(value[index]);
+        }
+        if (!requiresQuotes)
+        {
+            return value;
+        }
+
+        StringBuilder quoted = new StringBuilder("\"");
+        int backslashCount = 0;
+        foreach (char character in value)
+        {
+            if (character == '\\')
+            {
+                backslashCount += 1;
+                continue;
+            }
+
+            if (character == '"')
+            {
+                quoted.Append('\\', backslashCount * 2 + 1);
+                quoted.Append('"');
+            }
+            else
+            {
+                quoted.Append('\\', backslashCount);
+                quoted.Append(character);
+            }
+            backslashCount = 0;
+        }
+
+        quoted.Append('\\', backslashCount * 2);
+        quoted.Append('"');
+        return quoted.ToString();
+    }
+}

--- a/resources/win32/bin/orca.cmd
+++ b/resources/win32/bin/orca.cmd
@@ -1,28 +1,21 @@
 @echo off
 setlocal
 set "SCRIPT_DIR=%~dp0"
-for %%I in ("%SCRIPT_DIR%..") do set "RESOURCES_DIR=%%~fI"
-REM Why: once %%~fI canonicalizes RESOURCES_DIR it no longer ends with a slash,
-REM so Windows batch needs an explicit "\.." segment here. Without it the CLI
-REM launcher resolves APP_DIR back to resources/ and `orca open` cannot find
-REM Orca.exe on packaged Windows installs.
-for %%I in ("%RESOURCES_DIR%\..") do set "APP_DIR=%%~fI"
-set "ELECTRON=%APP_DIR%\Orca.exe"
+set "LAUNCHER=%SCRIPT_DIR%orca.exe"
 
-if not exist "%ELECTRON%" (
-  echo Unable to locate Orca.exe next to "%RESOURCES_DIR%" 1>&2
+if not exist "%LAUNCHER%" (
+  echo Unable to locate the native Orca CLI launcher at "%LAUNCHER%" 1>&2
   exit /b 1
 )
 
-REM Why: Orca packages the CLI entrypoint outside app.asar so the public shell
-REM command can execute it directly with ELECTRON_RUN_AS_NODE instead of
-REM depending on a separately installed Node CLI.
-set "CLI=%RESOURCES_DIR%\app.asar.unpacked\out\cli\index.js"
+REM Why: cmd.exe reparses %%* and can execute/truncate embedded newlines. The
+REM native launcher is the supported path for orchestration message bodies.
+if /I "%~1"=="orchestration" if /I "%~2"=="send" goto :unsafe_body
+if /I "%~1"=="orchestration" if /I "%~2"=="reply" goto :unsafe_body
 
-set "ORCA_NODE_OPTIONS=%NODE_OPTIONS%"
-set "ORCA_NODE_REPL_EXTERNAL_MODULE=%NODE_REPL_EXTERNAL_MODULE%"
-set NODE_OPTIONS=
-set NODE_REPL_EXTERNAL_MODULE=
-set ELECTRON_RUN_AS_NODE=1
+"%LAUNCHER%" %*
+exit /b %ERRORLEVEL%
 
-"%ELECTRON%" "%CLI%" %*
+:unsafe_body
+echo orca.cmd cannot safely forward orchestration message bodies. Use "%LAUNCHER%" instead. 1>&2
+exit /b 2

--- a/src/cli/handlers/orchestration.test.ts
+++ b/src/cli/handlers/orchestration.test.ts
@@ -135,6 +135,21 @@ describe('orchestration send structured payload flags', () => {
     })
   })
 
+  it('forwards multiline message bodies without normalization', async () => {
+    const body = 'paragraph one line one\nparagraph one line two\n\nparagraph two'
+
+    await invokeSend(
+      new Map<string, string | boolean>([
+        ['from', 'term_worker'],
+        ['to', 'term_coord'],
+        ['subject', 'multiline'],
+        ['body', body]
+      ])
+    )
+
+    expect(callMock).toHaveBeenCalledWith('orchestration.send', expect.objectContaining({ body }))
+  })
+
   it('rejects mixing raw payload with structured payload flags', async () => {
     await expect(
       invokeSend(

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -1174,12 +1174,12 @@ describe('CliInstaller', () => {
     }
   )
 
-  it('resolves packaged Windows command path to resources/bin/orca.cmd', async () => {
+  it('resolves packaged Windows command path to resources/bin/orca.exe', async () => {
     const fixture = await makeFixture()
     const localAppDataPath = fixture.root
     const resourcesPath = join(fixture.root, 'resources')
     await mkdir(join(resourcesPath, 'bin'), { recursive: true })
-    await writeFile(join(resourcesPath, 'bin', 'orca.cmd'), '@echo off\n', 'utf8')
+    await writeFile(join(resourcesPath, 'bin', 'orca.exe'), 'native launcher', 'utf8')
 
     const installer = new CliInstaller({
       platform: 'win32',
@@ -1195,7 +1195,7 @@ describe('CliInstaller', () => {
 
     const status = await installer.getStatus()
     expect(status.commandPath).toBe(
-      join(localAppDataPath, 'Programs', 'Orca', 'resources', 'bin', 'orca.cmd')
+      join(localAppDataPath, 'Programs', 'Orca', 'resources', 'bin', 'orca.exe')
     )
   })
 
@@ -1203,8 +1203,8 @@ describe('CliInstaller', () => {
     const fixture = await makeFixture()
     const localAppDataPath = fixture.root
     const resourcesPath = join(localAppDataPath, 'Programs', 'Orca', 'resources')
-    const bundledLauncher = join(resourcesPath, 'bin', 'orca.cmd')
-    const bundledContent = '@echo off\r\necho bundled-orca %*\r\n'
+    const bundledLauncher = join(resourcesPath, 'bin', 'orca.exe')
+    const bundledContent = 'native launcher'
     await mkdir(dirname(bundledLauncher), { recursive: true })
     await writeFile(bundledLauncher, bundledContent, 'utf8')
 

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -185,7 +185,7 @@ export class CliInstaller {
       await this.installAppImageWrapper(status.commandPath, status.launcherPath)
       await this.removeLegacyLinuxCommandIfManaged(status.launcherPath)
     } else if (this.isWindowsPackagedBundledCommand(status.commandPath, status.launcherPath)) {
-      // Why: packaged Windows already ships resources/bin/orca.cmd. Registration
+      // Why: packaged Windows already ships resources/bin/orca.exe. Registration
       // only owns the user PATH entry; rewriting the asset makes it recurse.
     } else {
       // Why: mkdir stays here for the Windows wrapper path — the target dir is
@@ -356,7 +356,7 @@ export class CliInstaller {
     }
 
     if (this.platform === 'win32') {
-      return join(this.localAppDataPath, 'Programs', 'Orca', 'resources', 'bin', 'orca.cmd')
+      return join(this.localAppDataPath, 'Programs', 'Orca', 'resources', 'bin', 'orca.exe')
     }
 
     return null
@@ -1183,7 +1183,7 @@ export function getBundledLauncherPath(
     return join(resourcesPath, 'bin', LINUX_COMMAND_NAME)
   }
   if (platform === 'win32') {
-    return join(resourcesPath, 'bin', 'orca.cmd')
+    return join(resourcesPath, 'bin', 'orca.exe')
   }
   return null
 }

--- a/src/main/cli/windows-launcher-asset.test.ts
+++ b/src/main/cli/windows-launcher-asset.test.ts
@@ -3,11 +3,12 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 describe('packaged Windows CLI launcher asset', () => {
-  it('walks from resources/bin back to the app root before locating Orca.exe', () => {
+  it('keeps the batch compatibility shim behind the newline-safe native launcher', () => {
     const launcherPath = join(process.cwd(), 'resources', 'win32', 'bin', 'orca.cmd')
     const launcher = readFileSync(launcherPath, 'utf8')
 
-    expect(launcher).toContain('for %%I in ("%RESOURCES_DIR%\\..") do set "APP_DIR=%%~fI"')
-    expect(launcher).not.toContain('for %%I in ("%RESOURCES_DIR%..") do set "APP_DIR=%%~fI"')
+    expect(launcher).toContain('set "LAUNCHER=%SCRIPT_DIR%orca.exe"')
+    expect(launcher).toContain('orca.cmd cannot safely forward orchestration message bodies')
+    expect(launcher).not.toContain('"%ELECTRON%" "%CLI%" %*')
   })
 })

--- a/src/main/runtime/claude-agent-teams-shim-env.ts
+++ b/src/main/runtime/claude-agent-teams-shim-env.ts
@@ -83,7 +83,7 @@ function bundledLauncherPath(): string | null {
     return join(process.resourcesPath, 'bin', 'orca-ide')
   }
   if (process.platform === 'win32') {
-    return join(process.resourcesPath, 'bin', 'orca.cmd')
+    return join(process.resourcesPath, 'bin', 'orca.exe')
   }
   return null
 }

--- a/src/main/startup/packaged-cli-entry-redirect.ts
+++ b/src/main/startup/packaged-cli-entry-redirect.ts
@@ -27,7 +27,7 @@ type RedirectOptions = {
 const REDIRECT_ATTEMPT_ENV = 'ORCA_PACKAGED_CLI_ENTRY_REDIRECTED'
 
 /**
- * Why: on Windows the bundled `orca.cmd` runs `Orca.exe <unpacked CLI entry>`
+ * Why: on Windows the bundled native launcher runs `Orca.exe <unpacked CLI entry>`
  * with ELECTRON_RUN_AS_NODE=1. When that env var is dropped (e.g. a wrapper or
  * shell that resets it), Orca boots as a GUI, loses the single-instance lock to
  * an already-running window, and exits silently with no stdout. This detects the


### PR DESCRIPTION
Closes #8369

## ELI5

The old Windows launcher treated each newline like the end of the command, so a multi-paragraph message arrived with only its first line. This replaces that launcher with one that carries the whole message as a single argument. If someone explicitly uses the old `.cmd` path for orchestration messages, Orca now stops with a clear instruction instead of pretending the truncated message was sent.

## Summary

- ship a native `orca.exe` launcher so PowerShell and Git Bash pass multiline arguments without `cmd.exe` reparsing `%*`
- make packaged CLI registration and smoke paths prefer the native launcher while retaining `orca.cmd` as a compatibility shim
- fail clearly when the legacy batch shim is used for orchestration message bodies instead of silently truncating them
- build the launcher in every Windows packaging path and cover the PowerShell multiline flow with a Windows-only end-to-end test

## Verification

- `pnpm typecheck`
- 109 targeted CLI/packaging tests passed (plus the Windows-only launcher test, skipped on macOS)
- 170 orchestration/runtime/package-contract tests passed
- targeted `oxlint`, `oxfmt`, and `git diff --check` passed