### PR TITLE
fix(sidebar): scope project group display labels by host to prevent cross-host path collision (#8345)

### DIFF
--- a/src/renderer/src/components/repo/NestedRepoChecklist.tsx
+++ b/src/renderer/src/components/repo/NestedRepoChecklist.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, type Dispatch, type SetStateAction } from 'react'
 import { GitBranch } from 'lucide-react'
 import type { NestedRepoScanResult } from '../../../../shared/types'
 import { cn } from '@/lib/utils'
-import { getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
+import { getRepoDisplayLabelKey, getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import { translate } from '@/i18n/i18n'
 
 function NestedRepoSelectAllRow({
@@ -118,7 +118,7 @@ export function NestedRepoChecklist({
                   selectedPaths.has(repo.path) ? 'text-foreground' : 'text-muted-foreground'
                 )}
               >
-                {displayLabelsByPath.get(repo.path) ?? repo.displayName}
+                {displayLabelsByPath.get(getRepoDisplayLabelKey(repo)) ?? repo.displayName}
               </span>
             </label>
           </li>

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -32,7 +32,7 @@ import {
 import { cloneDefaultWorkspaceStatuses } from '../../../../shared/workspace-statuses'
 import type { AppState } from '../../store/types'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from '../../store/slices/github-cache-key'
-import { getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
+import { getRepoDisplayLabelKey, getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import { translate } from '@/i18n/i18n'
 import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
 import { parseWslUncPath } from '../../../../shared/wsl-paths'
@@ -706,10 +706,12 @@ function withRepoSectionDisplayLabels(entries: readonly OrderedGroupEntry[]): Or
   if (repos.length < 2) {
     return [...entries]
   }
-  const labelsByPath = getRepoDisplayLabelsByPath(repos)
+  const labelsByKey = getRepoDisplayLabelsByPath(repos)
   return entries.map(([key, group]) => [
     key,
-    group.repo ? { ...group, label: labelsByPath.get(group.repo.path) ?? group.label } : group
+    group.repo
+      ? { ...group, label: labelsByKey.get(getRepoDisplayLabelKey(group.repo)) ?? group.label }
+      : group
   ])
 }
 

--- a/src/renderer/src/lib/repo-display-labels.test.ts
+++ b/src/renderer/src/lib/repo-display-labels.test.ts
@@ -34,6 +34,22 @@ describe('getRepoDisplayLabelsByPath', () => {
     expect(labels.get('/workspace/team2/shared/api')).toBe('team2/shared/api')
   })
 
+  it('scopes same-path repos from different hosts separately', () => {
+    const labels = getRepoDisplayLabelsByPath([
+      { path: '/Users/alice', displayName: 'host-a home', executionHostId: 'local' },
+      { path: '/Users/alice', displayName: 'host-b home', executionHostId: 'ssh:my-host' }
+    ])
+
+    expect(labels.get('local::/Users/alice')).toBe('host-a home')
+    expect(labels.get('ssh:my-host::/Users/alice')).toBe('host-b home')
+  })
+
+  it('falls back to path-only key when executionHostId is absent', () => {
+    const labels = getRepoDisplayLabelsByPath([{ path: '/workspace/web', displayName: 'web' }])
+
+    expect(labels.get('/workspace/web')).toBe('web')
+  })
+
   it('normalizes Windows separators to slash display labels', () => {
     const labels = getRepoDisplayLabelsByPath([
       { path: 'C:\\workspace\\payments\\api', displayName: 'api' },

--- a/src/renderer/src/lib/repo-display-labels.ts
+++ b/src/renderer/src/lib/repo-display-labels.ts
@@ -1,6 +1,17 @@
 type RepoDisplayLabelItem = {
   path: string
   displayName: string
+  executionHostId?: string | null
+}
+
+// Why: composite key scopes the label map by host so repos on different hosts
+// with the same absolute path (e.g. local /Users/alice and ssh://host /Users/alice)
+// do not overwrite each other's display label.
+export function getRepoDisplayLabelKey(item: {
+  path: string
+  executionHostId?: string | null
+}): string {
+  return item.executionHostId ? `${item.executionHostId}::${item.path}` : item.path
 }
 
 function normalizePathSegments(path: string): string[] {
@@ -29,7 +40,8 @@ export function getRepoDisplayLabelsByPath(
 
   for (const item of items) {
     const displayName = item.displayName || item.path
-    labels.set(item.path, displayName)
+    const key = getRepoDisplayLabelKey(item)
+    labels.set(key, displayName)
     const colliding = itemsByName.get(displayName) ?? []
     colliding.push({ ...item, displayName })
     itemsByName.set(displayName, colliding)
@@ -49,7 +61,8 @@ export function getRepoDisplayLabelsByPath(
       nextLabels = collidingItems.map((item) => labelForDepth(item, depth))
     }
     collidingItems.forEach((item, index) => {
-      labels.set(item.path, nextLabels[index] ?? item.displayName)
+      const key = getRepoDisplayLabelKey(item)
+      labels.set(key, nextLabels[index] ?? item.displayName)
     })
   }
 


### PR DESCRIPTION
## Summary

Fixes #8345.

When two repos on different hosts share the same absolute path string, the sidebar group-by-Project headers show the same display name for both groups — one project's header silently overwrites the other.

Root cause: `getRepoDisplayLabelsByPath()` keys its map solely by `item.path`. A later item with the same path on another host overwrites the earlier entry. The collision-handling logic only disambiguates same-`displayName` items, so same-path-different-displayName collisions are never detected.

## Fix

- Added `executionHostId?: string | null` to `RepoDisplayLabelItem`
- Exported `getRepoDisplayLabelKey()` producing a composite key `{executionHostId}::{path}` when a host is known, falling back to bare `path`
- `getRepoDisplayLabelsByPath()` now uses the composite key for both storage and disambiguation updates
- Callers (`withRepoSectionDisplayLabels` in `worktree-list-groups.ts`, `NestedRepoChecklist.tsx`) use `getRepoDisplayLabelKey()` for map lookups

## Changes

| File | Change |
|------|--------|
| `src/renderer/src/lib/repo-display-labels.ts` | Add `executionHostId` to type, export key helper, use composite key |
| `src/renderer/src/lib/repo-display-labels.test.ts` | 2 new tests: same-path-different-host + absent-hostId fallback |
| `src/renderer/src/components/sidebar/worktree-list-groups.ts` | Use `getRepoDisplayLabelKey()` for lookup |
| `src/renderer/src/components/repo/NestedRepoChecklist.tsx` | Use `getRepoDisplayLabelKey()` for lookup |

## Testing

- `pnpm test`: 6/6 pass (4 existing + 2 new)
- `pnpm lint`: 0 warnings, 0 errors
- `pnpm typecheck`: passing

## No visual change

No visual change for users without cross-host same-path repos. The fix prevents label collisions that already corrupt display.

## Cross-platform / SSH / remote notes

The bug is most likely to trigger on SSH hosts where home directories share the same absolute path as the local machine. The fix scopes the map key with `executionHostId` (`local`, `ssh:...`, or `runtime:...`). `NestedRepoChecklist` is unaffected because `NestedRepoCandidate` does not carry `executionHostId` — the key falls back to bare path, preserving existing behavior.
