### PR TITLE
fix(agent-status): clear answered Claude and Codex waits

### DIFF
--- a/src/main/agent-hooks/server.claude-interactive-question.test.ts
+++ b/src/main/agent-hooks/server.claude-interactive-question.test.ts
@@ -8,9 +8,9 @@ function ingestClaudeStatus(
   server: AgentHookServer,
   event: {
     state: 'working' | 'waiting'
-    hookEventName: 'PermissionRequest' | 'PreToolUse'
+    hookEventName: 'PermissionRequest' | 'PreToolUse' | 'PostToolUse'
     toolName: string
-    toolUseId: string
+    toolUseId?: string
     interactivePrompt?: string
   }
 ): void {
@@ -83,6 +83,41 @@ describe('Claude interactive-question status transitions', () => {
         state: 'working',
         agentType: 'claude',
         toolName: 'Read'
+      })
+    ])
+  })
+
+  it('clears an AskUserQuestion wait that arrived as a PermissionRequest when the answer lands', () => {
+    const server = new AgentHookServer()
+
+    // Why: real Claude emits PreToolUse then, ~120ms later, a PermissionRequest
+    // for the auto-allowed AskUserQuestion. Orca registers PermissionRequest, so
+    // it overwrites the PreToolUse as `previous` — and it carries no tool_use_id,
+    // so a resuming-tool id match can never clear it. The answer's PostToolUse
+    // 'working' hook must still drop the wait.
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PreToolUse',
+      toolName: 'AskUserQuestion',
+      toolUseId: 'tool-question'
+    })
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PermissionRequest',
+      toolName: 'AskUserQuestion'
+    })
+    ingestClaudeStatus(server, {
+      state: 'working',
+      hookEventName: 'PostToolUse',
+      toolName: 'AskUserQuestion',
+      toolUseId: 'tool-question'
+    })
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE_KEY,
+        state: 'working',
+        agentType: 'claude'
       })
     ])
   })

--- a/src/main/agent-hooks/server.claude-interactive-question.test.ts
+++ b/src/main/agent-hooks/server.claude-interactive-question.test.ts
@@ -8,9 +8,9 @@ function ingestClaudeStatus(
   server: AgentHookServer,
   event: {
     state: 'working' | 'waiting'
-    hookEventName: 'PermissionRequest' | 'PreToolUse'
+    hookEventName: 'PermissionRequest' | 'PreToolUse' | 'PostToolUse'
     toolName: string
-    toolUseId: string
+    toolUseId?: string
   }
 ): void {
   server.ingestRemote(
@@ -53,6 +53,41 @@ describe('Claude interactive-question status transitions', () => {
         state: 'working',
         agentType: 'claude',
         toolName: 'Read'
+      })
+    ])
+  })
+
+  it('clears an AskUserQuestion wait that arrived as a PermissionRequest when the answer lands', () => {
+    const server = new AgentHookServer()
+
+    // Why: real Claude emits PreToolUse then, ~120ms later, a PermissionRequest
+    // for the auto-allowed AskUserQuestion. Orca registers PermissionRequest, so
+    // it overwrites the PreToolUse as `previous` — and it carries no tool_use_id,
+    // so a resuming-tool id match can never clear it. The answer's PostToolUse
+    // 'working' hook must still drop the wait.
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PreToolUse',
+      toolName: 'AskUserQuestion',
+      toolUseId: 'tool-question'
+    })
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PermissionRequest',
+      toolName: 'AskUserQuestion'
+    })
+    ingestClaudeStatus(server, {
+      state: 'working',
+      hookEventName: 'PostToolUse',
+      toolName: 'AskUserQuestion',
+      toolUseId: 'tool-question'
+    })
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE_KEY,
+        state: 'working',
+        agentType: 'claude'
       })
     ])
   })

--- a/src/main/agent-hooks/server.codex-permission-resume.test.ts
+++ b/src/main/agent-hooks/server.codex-permission-resume.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { AgentHookServer } from './server'
+
+const PANE_KEY = makePaneKey('tab-codex', '11111111-1111-4111-8111-111111111111')
+
+function ingestCodexPermission(server: AgentHookServer): void {
+  server.ingestRemote(
+    {
+      paneKey: PANE_KEY,
+      tabId: 'tab-codex',
+      worktreeId: 'worktree-codex',
+      hookEventName: 'PermissionRequest',
+      providerSession: { key: 'session_id', id: 'codex-session-1' },
+      payload: {
+        state: 'waiting',
+        prompt: 'Run the approved command',
+        agentType: 'codex',
+        toolName: 'Bash',
+        toolInput: 'sleep 10',
+        interactivePrompt: JSON.stringify({ approval: { tool: 'Bash', summary: 'sleep 10' } })
+      }
+    },
+    'connection-1'
+  )
+}
+
+describe('Codex permission resume from terminal title', () => {
+  it('moves a live PermissionRequest wait back to working', () => {
+    const server = new AgentHookServer()
+    const listener = vi.fn()
+    server.setListener(listener)
+    ingestCodexPermission(server)
+
+    expect(server.resumeCodexPermissionWaitFromTerminalTitle(PANE_KEY)).toBe(true)
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE_KEY,
+        state: 'working',
+        prompt: 'Run the approved command',
+        agentType: 'codex',
+        toolName: 'Bash',
+        toolInput: 'sleep 10',
+        interactivePrompt: undefined,
+        providerSession: { key: 'session_id', id: 'codex-session-1' }
+      })
+    ])
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: expect.objectContaining({ state: 'working' }) })
+    )
+  })
+
+  it('ignores other agents and Codex states that are not permission waits', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        hookEventName: 'PermissionRequest',
+        payload: { state: 'waiting', prompt: 'Approve', agentType: 'claude' }
+      },
+      'connection-1'
+    )
+    expect(server.resumeCodexPermissionWaitFromTerminalTitle(PANE_KEY)).toBe(false)
+
+    const codexServer = new AgentHookServer()
+    ingestCodexPermission(codexServer)
+    expect(codexServer.resumeCodexPermissionWaitFromTerminalTitle(PANE_KEY)).toBe(true)
+    expect(codexServer.resumeCodexPermissionWaitFromTerminalTitle(PANE_KEY)).toBe(false)
+    expect(codexServer.resumeCodexPermissionWaitFromTerminalTitle('missing:1')).toBe(false)
+  })
+})

--- a/src/main/agent-hooks/server.codex-permission-resume.test.ts
+++ b/src/main/agent-hooks/server.codex-permission-resume.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../shared/agent-status-types'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import { AgentHookServer } from './server'
 
 const PANE_KEY = makePaneKey('tab-codex', '11111111-1111-4111-8111-111111111111')
 
+/** Seed the exact Codex PermissionRequest shape that remains waiting after approval. */
 function ingestCodexPermission(server: AgentHookServer): void {
   server.ingestRemote(
     {
@@ -68,5 +70,33 @@ describe('Codex permission resume from terminal title', () => {
     expect(codexServer.resumeCodexPermissionWaitFromTerminalTitle(PANE_KEY)).toBe(true)
     expect(codexServer.resumeCodexPermissionWaitFromTerminalTitle(PANE_KEY)).toBe(false)
     expect(codexServer.resumeCodexPermissionWaitFromTerminalTitle('missing:1')).toBe(false)
+  })
+
+  it('ignores stale Codex permission waits', () => {
+    vi.useFakeTimers()
+    try {
+      const server = new AgentHookServer()
+      ingestCodexPermission(server)
+
+      vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS + 1)
+
+      expect(server.resumeCodexPermissionWaitFromTerminalTitle(PANE_KEY)).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores Codex waits that did not come from PermissionRequest', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        hookEventName: 'AskUserQuestion',
+        payload: { state: 'waiting', prompt: 'Answer me', agentType: 'codex' }
+      },
+      'connection-1'
+    )
+
+    expect(server.resumeCodexPermissionWaitFromTerminalTitle(PANE_KEY)).toBe(false)
   })
 })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -475,6 +475,11 @@ function shouldKeepClaudePermissionVisible(
     previous?.payload.agentType !== 'claude' ||
     previous.payload.state !== 'waiting' ||
     previous.hookEventName !== 'PermissionRequest' ||
+    // Why: AskUserQuestion is auto-allowed but still emits a PermissionRequest
+    // (carrying no tool_use_id) right after its PreToolUse, so its wait can't be
+    // cleared by a resuming-tool id match. It's an interactive question, not an
+    // Allow/Deny gate — clear it on the answer's 'working' hook, never pin it.
+    isAskUserQuestionTool(previous.payload.toolName) ||
     next.payload.agentType !== 'claude' ||
     next.payload.state !== 'working'
   ) {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -779,6 +779,39 @@ export class AgentHookServer {
     return Object.freeze({ paneKey, source: 'current_hook' })
   }
 
+  resumeCodexPermissionWaitFromTerminalTitle(paneKey: string): boolean {
+    const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+    const existing = this.state.lastStatusByPaneKey.get(resolvedPaneKey) as
+      | EnrichedAgentHookEventPayload
+      | undefined
+    if (
+      existing?.payload.agentType !== 'codex' ||
+      existing.payload.state !== 'waiting' ||
+      existing.hookEventName !== 'PermissionRequest' ||
+      Date.now() - existing.receivedAt > AGENT_STATUS_STALE_AFTER_MS
+    ) {
+      return false
+    }
+
+    // Why: Codex emits no execution-start hook after approval; its working
+    // terminal title is the first authoritative signal before PostToolUse.
+    const resumed = this.applyNormalizedStatus({
+      paneKey: resolvedPaneKey,
+      connectionId: existing.connectionId,
+      ...(existing.launchToken ? { launchToken: existing.launchToken } : {}),
+      ...(existing.tabId ? { tabId: existing.tabId } : {}),
+      ...(existing.worktreeId ? { worktreeId: existing.worktreeId } : {}),
+      ...(existing.providerSession ? { providerSession: existing.providerSession } : {}),
+      hookEventName: 'TerminalTitleWorking',
+      payload: {
+        ...existing.payload,
+        state: 'working',
+        interactivePrompt: undefined
+      }
+    })
+    return resumed.payload.state === 'working'
+  }
+
   inferInterrupt(request: AgentInterruptInferenceRequest): boolean {
     if (!isValidPaneKey(request.paneKey)) {
       return false

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -779,6 +779,8 @@ export class AgentHookServer {
     return Object.freeze({ paneKey, source: 'current_hook' })
   }
 
+  /** Resume a fresh Codex permission wait when terminal activity proves the
+   * approved command started before Codex can emit its completion hook. */
   resumeCodexPermissionWaitFromTerminalTitle(paneKey: string): boolean {
     const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
     const existing = this.state.lastStatusByPaneKey.get(resolvedPaneKey) as

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -524,6 +524,8 @@ export class AgentHookServer {
     )
   }
 
+  /** Resume a fresh Codex permission wait when terminal activity proves the
+   * approved command started before Codex can emit its completion hook. */
   resumeCodexPermissionWaitFromTerminalTitle(paneKey: string): boolean {
     const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
     const existing = this.state.lastStatusByPaneKey.get(resolvedPaneKey) as

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -28,6 +28,7 @@ import {
   HOOK_REQUEST_SLOWLORIS_MS,
   markClaudeLeadTurnInterrupted,
   MAX_PANE_KEY_LEN,
+  isAskUserQuestionTool,
   normalizeHookPayload,
   parseFormEncodedBody,
   readRequestBody,
@@ -315,6 +316,11 @@ function shouldKeepClaudePermissionVisible(
     previous?.payload.agentType !== 'claude' ||
     previous.payload.state !== 'waiting' ||
     previous.hookEventName !== 'PermissionRequest' ||
+    // Why: AskUserQuestion is auto-allowed but still emits a PermissionRequest
+    // (carrying no tool_use_id) right after its PreToolUse, so its wait can't be
+    // cleared by a resuming-tool id match. It's an interactive question, not an
+    // Allow/Deny gate — clear it on the answer's 'working' hook, never pin it.
+    isAskUserQuestionTool(previous.payload.toolName) ||
     next.payload.agentType !== 'claude' ||
     next.payload.state !== 'working'
   ) {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -524,6 +524,39 @@ export class AgentHookServer {
     )
   }
 
+  resumeCodexPermissionWaitFromTerminalTitle(paneKey: string): boolean {
+    const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+    const existing = this.state.lastStatusByPaneKey.get(resolvedPaneKey) as
+      | EnrichedAgentHookEventPayload
+      | undefined
+    if (
+      existing?.payload.agentType !== 'codex' ||
+      existing.payload.state !== 'waiting' ||
+      existing.hookEventName !== 'PermissionRequest' ||
+      Date.now() - existing.receivedAt > AGENT_STATUS_STALE_AFTER_MS
+    ) {
+      return false
+    }
+
+    // Why: Codex emits no execution-start hook after approval; its working
+    // terminal title is the first authoritative signal before PostToolUse.
+    const resumed = this.applyNormalizedStatus({
+      paneKey: resolvedPaneKey,
+      connectionId: existing.connectionId,
+      ...(existing.launchToken ? { launchToken: existing.launchToken } : {}),
+      ...(existing.tabId ? { tabId: existing.tabId } : {}),
+      ...(existing.worktreeId ? { worktreeId: existing.worktreeId } : {}),
+      ...(existing.providerSession ? { providerSession: existing.providerSession } : {}),
+      hookEventName: 'TerminalTitleWorking',
+      payload: {
+        ...existing.payload,
+        state: 'working',
+        interactivePrompt: undefined
+      }
+    })
+    return resumed.payload.state === 'working'
+  }
+
   inferInterrupt(request: AgentInterruptInferenceRequest): boolean {
     if (!isValidPaneKey(request.paneKey)) {
       return false

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2540,6 +2540,8 @@ void app.whenReady().then(async () => {
       agentHookServer.getStatusSnapshotForPane(paneKey),
     attestAgentHookCompatibilityAuthority: (candidate) =>
       agentHookServer.attestCompatibilityAuthority(candidate),
+    resumeCodexPermissionWait: (paneKey) =>
+      agentHookServer.resumeCodexPermissionWaitFromTerminalTitle(paneKey),
     retireAgentHookCompatibilityAuthority: (paneKey) =>
       agentHookServer.retirePaneAuthority(paneKey),
     canRecoverPersistentLocalPtys: () => getDaemonProvider() !== null,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1757,6 +1757,8 @@ app.whenReady().then(async () => {
     // Why: hook-reported agent status is the same source the desktop sidebar
     // reads. worktree.ps pulls it at query time so mobile shows the same agents.
     getAgentStatusSnapshot: () => agentHookServer.getStatusSnapshot(),
+    resumeCodexPermissionWait: (paneKey) =>
+      agentHookServer.resumeCodexPermissionWaitFromTerminalTitle(paneKey),
     // Why: source codex-home here (runs in BOTH window and serve modes) so the
     // aiVault.listSessions RPC includes managed-Codex sessions on remote/SSH
     // hosts; the window-only registerCoreHandlers path never runs under serve.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -9931,6 +9931,18 @@ describe('OrcaRuntimeService', () => {
       ])
     })
 
+    it('routes working titles to the Codex permission-resume owner', () => {
+      const resumeCodexPermissionWait = vi.fn(() => true)
+      const runtime = new OrcaRuntimeService(store, undefined, { resumeCodexPermissionWait })
+      syncSinglePty(runtime)
+
+      runtime.onPtyData('pty-1', '\x1b]0;Codex - action required\x07', 100)
+      expect(resumeCodexPermissionWait).not.toHaveBeenCalled()
+
+      runtime.onPtyData('pty-1', '\x1b]0;⠋ Codex\x07', 101)
+      expect(resumeCodexPermissionWait).toHaveBeenCalledWith('tab-1:1')
+    })
+
     it('carries the synthetic permission BEL as a bell fact', () => {
       const { runtime, batches } = createSideEffectRuntime()
       syncSinglePty(runtime)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -9299,6 +9299,22 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  describe('Codex permission resume routing', () => {
+    it('routes only the transition into a working title', () => {
+      const resumeCodexPermissionWait = vi.fn(() => true)
+      const runtime = new OrcaRuntimeService(store, undefined, { resumeCodexPermissionWait })
+      syncSinglePty(runtime)
+
+      runtime.onPtyData('pty-1', '\x1b]0;Codex - action required\x07', 100)
+      expect(resumeCodexPermissionWait).not.toHaveBeenCalled()
+
+      runtime.onPtyData('pty-1', '\x1b]0;⠋ Codex\x07', 101)
+      runtime.onPtyData('pty-1', '\x1b]0;⠙ Codex\x07', 102)
+      expect(resumeCodexPermissionWait).toHaveBeenCalledTimes(1)
+      expect(resumeCodexPermissionWait).toHaveBeenCalledWith('tab-1:1')
+    })
+  })
+
   // ─── pty:sideEffect channel (terminal-side-effect-authority.md, slice 2) ──
   describe('terminal side-effect fact channel', () => {
     function createSideEffectRuntime(): {
@@ -9931,7 +9947,7 @@ describe('OrcaRuntimeService', () => {
       ])
     })
 
-    it('routes working titles to the Codex permission-resume owner', () => {
+    it('routes only the transition into a working title', () => {
       const resumeCodexPermissionWait = vi.fn(() => true)
       const runtime = new OrcaRuntimeService(store, undefined, { resumeCodexPermissionWait })
       syncSinglePty(runtime)
@@ -9940,6 +9956,8 @@ describe('OrcaRuntimeService', () => {
       expect(resumeCodexPermissionWait).not.toHaveBeenCalled()
 
       runtime.onPtyData('pty-1', '\x1b]0;⠋ Codex\x07', 101)
+      runtime.onPtyData('pty-1', '\x1b]0;⠙ Codex\x07', 102)
+      expect(resumeCodexPermissionWait).toHaveBeenCalledTimes(1)
       expect(resumeCodexPermissionWait).toHaveBeenCalledWith('tab-1:1')
     })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6972,6 +6972,18 @@ describe('OrcaRuntimeService', () => {
       expect(runtime.getPtyOutputSequence('pty-1')).toBe(0)
     })
 
+    it('routes working titles to the Codex permission-resume owner', () => {
+      const resumeCodexPermissionWait = vi.fn(() => true)
+      const runtime = new OrcaRuntimeService(store, undefined, { resumeCodexPermissionWait })
+      syncSinglePty(runtime)
+
+      runtime.onPtyData('pty-1', '\x1b]0;Codex - action required\x07', 100)
+      expect(resumeCodexPermissionWait).not.toHaveBeenCalled()
+
+      runtime.onPtyData('pty-1', '\x1b]0;⠋ Codex\x07', 101)
+      expect(resumeCodexPermissionWait).toHaveBeenCalledWith('tab-1:1')
+    })
+
     it('carries the synthetic permission BEL as a bell fact', () => {
       const { runtime, batches } = createSideEffectRuntime()
       syncSinglePty(runtime)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6861,6 +6861,22 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  describe('Codex permission resume routing', () => {
+    it('routes only the transition into a working title', () => {
+      const resumeCodexPermissionWait = vi.fn(() => true)
+      const runtime = new OrcaRuntimeService(store, undefined, { resumeCodexPermissionWait })
+      syncSinglePty(runtime)
+
+      runtime.onPtyData('pty-1', '\x1b]0;Codex - action required\x07', 100)
+      expect(resumeCodexPermissionWait).not.toHaveBeenCalled()
+
+      runtime.onPtyData('pty-1', '\x1b]0;⠋ Codex\x07', 101)
+      runtime.onPtyData('pty-1', '\x1b]0;⠙ Codex\x07', 102)
+      expect(resumeCodexPermissionWait).toHaveBeenCalledTimes(1)
+      expect(resumeCodexPermissionWait).toHaveBeenCalledWith('tab-1:1')
+    })
+  })
+
   // ─── pty:sideEffect channel (terminal-side-effect-authority.md, slice 2) ──
   describe('terminal side-effect fact channel', () => {
     function createSideEffectRuntime(): {
@@ -6970,18 +6986,6 @@ describe('OrcaRuntimeService', () => {
       // Synthetic frames are fabricated by main: they must not advance the
       // metered output sequence the renderer ACK budget is based on.
       expect(runtime.getPtyOutputSequence('pty-1')).toBe(0)
-    })
-
-    it('routes working titles to the Codex permission-resume owner', () => {
-      const resumeCodexPermissionWait = vi.fn(() => true)
-      const runtime = new OrcaRuntimeService(store, undefined, { resumeCodexPermissionWait })
-      syncSinglePty(runtime)
-
-      runtime.onPtyData('pty-1', '\x1b]0;Codex - action required\x07', 100)
-      expect(resumeCodexPermissionWait).not.toHaveBeenCalled()
-
-      runtime.onPtyData('pty-1', '\x1b]0;⠋ Codex\x07', 101)
-      expect(resumeCodexPermissionWait).toHaveBeenCalledWith('tab-1:1')
     })
 
     it('carries the synthetic permission BEL as a bell fact', () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3389,6 +3389,7 @@ export class OrcaRuntimeService {
     | null
   private readonly retireAgentHookCompatibilityAuthorityFn: ((paneKey: string) => void) | null
   private readonly canRecoverPersistentLocalPtysFn: () => boolean
+  private readonly resumeCodexPermissionWaitFn: ((paneKey: string) => boolean) | null
   private readonly buildAgentHookPtyEnv: (() => Record<string, string>) | null
   private readonly getDesktopWindowStatusFn: () => RuntimeDesktopWindowStatus
   private readonly prepareAiVaultSessionResumeFn:
@@ -3463,6 +3464,7 @@ export class OrcaRuntimeService {
       }) => AgentHookAuthorityAttestation | null
       retireAgentHookCompatibilityAuthority?: (paneKey: string) => void
       canRecoverPersistentLocalPtys?: () => boolean
+      resumeCodexPermissionWait?: (paneKey: string) => boolean
       // Why: codex-home paths for the Agent Session History scan must be sourced
       // here, not via the window-only registerCoreHandlers path — that path never
       // runs under `orca serve`, so remote/SSH hosts would silently drop
@@ -3500,6 +3502,7 @@ export class OrcaRuntimeService {
     this.retireAgentHookCompatibilityAuthorityFn =
       deps?.retireAgentHookCompatibilityAuthority ?? null
     this.canRecoverPersistentLocalPtysFn = deps?.canRecoverPersistentLocalPtys ?? (() => true)
+    this.resumeCodexPermissionWaitFn = deps?.resumeCodexPermissionWait ?? null
     // Why: configure the shared AiVault scan cache from a serve-mode-reachable
     // seam so the aiVault.listSessions RPC includes managed-Codex + WSL sessions
     // even on headless `orca serve` hosts where registerCoreHandlers never runs.
@@ -10671,6 +10674,9 @@ export class OrcaRuntimeService {
     const identityOnlyTitle = this.isLiveCursorNativeTitle(rawTitle, meta)
     const recordedTitle = identityOnlyTitle ? null : normalizedTitle
     const agentStatus = identityOnlyTitle ? null : detectAgentStatusFromTitle(rawTitle)
+    if (agentStatus === 'working') {
+      this.resumeCodexPermissionWaitForPty(ptyId)
+    }
     let ptyRecordChanged = false
     const pty = this.ptysById.get(ptyId)
     if (pty) {
@@ -10765,6 +10771,24 @@ export class OrcaRuntimeService {
       }
     }
     return ptyRecordChanged
+  }
+
+  private resumeCodexPermissionWaitForPty(ptyId: string): void {
+    if (!this.resumeCodexPermissionWaitFn) {
+      return
+    }
+    const paneKeys = new Set(
+      this.getLeavesForPty(ptyId).map((leaf) => this.makeRuntimePaneKey(leaf))
+    )
+    if (paneKeys.size === 0) {
+      const paneKey = this.ptysById.get(ptyId)?.paneKey
+      if (paneKey) {
+        paneKeys.add(paneKey)
+      }
+    }
+    for (const paneKey of paneKeys) {
+      this.resumeCodexPermissionWaitFn(paneKey)
+    }
   }
 
   /** Cancel the per-PTY title tracker (stale-title timer included) on PTY

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3464,6 +3464,7 @@ export class OrcaRuntimeService {
       }) => AgentHookAuthorityAttestation | null
       retireAgentHookCompatibilityAuthority?: (paneKey: string) => void
       canRecoverPersistentLocalPtys?: () => boolean
+      /** Clear the hook-owned Codex wait once a working title proves approval. */
       resumeCodexPermissionWait?: (paneKey: string) => boolean
       // Why: codex-home paths for the Agent Session History scan must be sourced
       // here, not via the window-only registerCoreHandlers path — that path never
@@ -10674,11 +10675,13 @@ export class OrcaRuntimeService {
     const identityOnlyTitle = this.isLiveCursorNativeTitle(rawTitle, meta)
     const recordedTitle = identityOnlyTitle ? null : normalizedTitle
     const agentStatus = identityOnlyTitle ? null : detectAgentStatusFromTitle(rawTitle)
-    if (agentStatus === 'working') {
+    const pty = this.ptysById.get(ptyId)
+    const previousAgentStatus =
+      pty?.lastAgentStatus ?? this.getLeavesForPty(ptyId)[0]?.lastAgentStatus ?? null
+    if (agentStatus === 'working' && previousAgentStatus !== 'working') {
       this.resumeCodexPermissionWaitForPty(ptyId)
     }
     let ptyRecordChanged = false
-    const pty = this.ptysById.get(ptyId)
     if (pty) {
       const prevStatus = pty.lastAgentStatus
       const prevTitle = pty.lastOscTitle
@@ -10773,6 +10776,8 @@ export class OrcaRuntimeService {
     return ptyRecordChanged
   }
 
+  /** Route a Codex permission resume through stable mounted-pane identity,
+   * falling back to the spawn-time pane key for parked terminals. */
   private resumeCodexPermissionWaitForPty(ptyId: string): void {
     if (!this.resumeCodexPermissionWaitFn) {
       return

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2528,6 +2528,7 @@ export class OrcaRuntimeService {
       // terminal output. worktree.ps reads this at query time so mobile shows the
       // same inline agent rows the desktop sidebar does — same source, 1:1.
       getAgentStatusSnapshot?: () => AgentStatusIpcPayload[]
+      /** Clear the hook-owned Codex wait once a working title proves approval. */
       resumeCodexPermissionWait?: (paneKey: string) => boolean
       // Why: codex-home paths for the Agent Session History scan must be sourced
       // here, not via the window-only registerCoreHandlers path — that path never
@@ -6205,11 +6206,13 @@ export class OrcaRuntimeService {
     // store the NORMALIZED title so rotating Grok/Pi/Gemini frames collapse to
     // one stable stored label (#7880) instead of churning `ps`/mobile tabs.
     const agentStatus = detectAgentStatusFromTitle(rawTitle)
-    if (agentStatus === 'working') {
+    const pty = this.ptysById.get(ptyId)
+    const previousAgentStatus =
+      pty?.lastAgentStatus ?? this.getLeavesForPty(ptyId)[0]?.lastAgentStatus ?? null
+    if (agentStatus === 'working' && previousAgentStatus !== 'working') {
       this.resumeCodexPermissionWaitForPty(ptyId)
     }
     let ptyRecordChanged = false
-    const pty = this.ptysById.get(ptyId)
     if (pty) {
       const prevStatus = pty.lastAgentStatus
       const prevTitle = pty.lastOscTitle
@@ -6276,6 +6279,8 @@ export class OrcaRuntimeService {
     return ptyRecordChanged
   }
 
+  /** Route a Codex permission resume through stable mounted-pane identity,
+   * falling back to the spawn-time pane key for parked terminals. */
   private resumeCodexPermissionWaitForPty(ptyId: string): void {
     if (!this.resumeCodexPermissionWaitFn) {
       return

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2499,6 +2499,7 @@ export class OrcaRuntimeService {
   private readonly onTerminalAgentStatus: ((event: RuntimeTerminalAgentStatusEvent) => void) | null
   private readonly onTerminalSideEffects: ((batch: TerminalSideEffectBatch) => void) | null
   private readonly getAgentStatusSnapshotFn: (() => AgentStatusIpcPayload[]) | null
+  private readonly resumeCodexPermissionWaitFn: ((paneKey: string) => boolean) | null
   private readonly buildAgentHookPtyEnv: (() => Record<string, string>) | null
   private accountServices: RuntimeAccountServices | null = null
   private commitMessageAgentEnv: CommitMessageAgentEnvironmentResolvers | null = null
@@ -2527,6 +2528,7 @@ export class OrcaRuntimeService {
       // terminal output. worktree.ps reads this at query time so mobile shows the
       // same inline agent rows the desktop sidebar does — same source, 1:1.
       getAgentStatusSnapshot?: () => AgentStatusIpcPayload[]
+      resumeCodexPermissionWait?: (paneKey: string) => boolean
       // Why: codex-home paths for the Agent Session History scan must be sourced
       // here, not via the window-only registerCoreHandlers path — that path never
       // runs under `orca serve`, so remote/SSH hosts would silently drop
@@ -2541,6 +2543,7 @@ export class OrcaRuntimeService {
       this.agentDetector = new AgentDetector(stats)
     }
     this.getAgentStatusSnapshotFn = deps?.getAgentStatusSnapshot ?? null
+    this.resumeCodexPermissionWaitFn = deps?.resumeCodexPermissionWait ?? null
     // Why: configure the shared AiVault scan cache from a serve-mode-reachable
     // seam so the aiVault.listSessions RPC includes managed-Codex + WSL sessions
     // even on headless `orca serve` hosts where registerCoreHandlers never runs.
@@ -6202,6 +6205,9 @@ export class OrcaRuntimeService {
     // store the NORMALIZED title so rotating Grok/Pi/Gemini frames collapse to
     // one stable stored label (#7880) instead of churning `ps`/mobile tabs.
     const agentStatus = detectAgentStatusFromTitle(rawTitle)
+    if (agentStatus === 'working') {
+      this.resumeCodexPermissionWaitForPty(ptyId)
+    }
     let ptyRecordChanged = false
     const pty = this.ptysById.get(ptyId)
     if (pty) {
@@ -6268,6 +6274,24 @@ export class OrcaRuntimeService {
       }
     }
     return ptyRecordChanged
+  }
+
+  private resumeCodexPermissionWaitForPty(ptyId: string): void {
+    if (!this.resumeCodexPermissionWaitFn) {
+      return
+    }
+    const paneKeys = new Set(
+      this.getLeavesForPty(ptyId).map((leaf) => this.makeRuntimePaneKey(leaf))
+    )
+    if (paneKeys.size === 0) {
+      const paneKey = this.ptysById.get(ptyId)?.paneKey
+      if (paneKey) {
+        paneKeys.add(paneKey)
+      }
+    }
+    for (const paneKey of paneKeys) {
+      this.resumeCodexPermissionWaitFn(paneKey)
+    }
   }
 
   /** Cancel the per-PTY title tracker (stale-title timer included) on PTY

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -696,7 +696,7 @@ function toolUpdate(
  *  agents emit (`AskUserQuestion` / `ask_user_question` / `askUserQuestion`).
  *  Why: this is the structured "pick an option" prompt whose full input the
  *  clients render as a live card. */
-function isAskUserQuestionTool(toolName: string | undefined): boolean {
+export function isAskUserQuestionTool(toolName: string | undefined): boolean {
   return toolName?.replaceAll(/[^a-z0-9]/gi, '').toLowerCase() === 'askuserquestion'
 }
 

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -1,6 +1,7 @@
 // ─── Explicit agent status (reported via native agent hooks → IPC) ──────────
 // Why: status comes from hooks (Claude, Codex, etc.) — never inferred from terminal titles;
-// a narrow interrupt fallback synthesizes a final `done` when an agent misses its cancellation hook.
+// interrupt and Codex permission-resume fallbacks may synthesize a transition when the
+// provider omits its corresponding lifecycle hook.
 
 import type { AgentProviderSessionMetadata } from './agent-session-resume'
 import {

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -1,9 +1,9 @@
 // ─── Explicit agent status (reported via native agent hooks → IPC) ──────────
 // These types define the normalized status that Orca receives from Claude,
 // Codex, and other explicit integrations. Agent state normally comes from
-// hooks; a narrow interrupt fallback may synthesize a final done state when an
-// agent misses its own cancellation hook. We still do not infer status from
-// terminal titles anywhere in the data flow.
+// hooks; narrow interrupt and Codex permission-resume fallbacks may synthesize
+// a transition when the provider omits its corresponding lifecycle hook. We do
+// not use terminal titles as a general status source.
 
 import type { AgentProviderSessionMetadata } from './agent-session-resume'
 import {


### PR DESCRIPTION
## Summary

Fixes two related agent-status waits that stayed amber after the user answered:

- Claude `AskUserQuestion` can emit a trailing `PermissionRequest` without a `tool_use_id`, so Orca could not match the answer to the waiting tool.
- Codex command approval emits `PermissionRequest`, but Codex 0.144.1 emits no execution-start hook after approval. Its next hook is `PostToolUse`, after the command finishes, so the row stayed waiting throughout execution.

## Fix

- Treat Claude `AskUserQuestion` permission events as interactive questions so the next working hook clears the wait.
- When the main runtime observes the transition into a working terminal title for a fresh Codex `PermissionRequest`, synthesize the missing waiting-to-working transition in the hook-status owner.
- Clear the interactive prompt while preserving prompt, tool, routing, and provider-session metadata.
- Keep the Codex fallback narrowly gated to fresh Codex `PermissionRequest` waits; other agents and states are unchanged.

The Codex transition lives in the main runtime and hook server, so desktop, parked terminals, `worktree ps`, headless serve, and SSH/remote runtimes read the same corrected state.

## Root cause

Claude and Codex expose different incomplete lifecycle sequences around user input. Claude supplies an answer hook but its preceding `AskUserQuestion` permission event lacks the identifier used by the sticky-permission guard. Codex supplies the permission hook but no hook when approval resumes execution. In both cases Orca retained a valid waiting event after the terminal had already resumed.

## Screenshots

No layout or styling change. The visible behavior changes from an amber waiting dot remaining during command execution to the normal working indicator immediately after approval.

## Testing

- [x] `pnpm run lint`
- [x] `pnpm run typecheck:web`
- [x] `pnpm run check:max-lines-ratchet`
- [x] 668 targeted tests across the agent-hook server and main runtime
- [x] Formatting and `git diff --check`
- [x] Live dev-app reproduction with this worktree CLI and Codex 0.144.1

Live Codex validation used an on-request session and an approved `sleep 15` command:

1. Before approval: terminal title was `Action Required`; `worktree ps` reported `waiting`.
2. Immediately after approval: ten consecutive samples during the still-running command reported `working`.
3. After `PostToolUse` and completion: the row moved to `done` with `MAIN_FIX_COMPLETE`.

## AI Review Report

CodeRabbit review feedback was applied:

- The resume callback now runs only on the transition into `working`, not on every spinner frame.
- Regression coverage now includes stale waits and Codex waits not originating from `PermissionRequest`.
- The runtime routing test was moved into a dedicated describe block and asserts spinner frames do not retrigger the callback.
- New production and test helpers include focused documentation.

No conflicting reviewer guidance or unresolved inline review threads remain.

## Security Audit

No new command execution, authentication, filesystem access, dependency, or public IPC surface was added. The fallback only transforms an already-normalized, fresh Codex status row after a pane-scoped runtime title transition. Existing payload caps and pane-key validation remain in force.

## Compatibility and risk

- Cross-platform title classification and pane routing are reused.
- The runtime path is shared by local and serve-mode hosts, covering SSH without local-only assumptions.
- Genuine Claude tool permission gates remain sticky; the existing regression test continues to cover that behavior.
- Spinner animation frames are transition-gated and do not repeatedly enter the hook server.

## Notes

- Codex 0.144.1 was used for the live reproduction and verification.
- This extends the original Claude-focused fix in the same PR because both symptoms come from missing provider lifecycle information around answered prompts.
- No visual assets or localization changes are required.

## ELI5

After you answered a Claude question or approved a Codex command, the agent row could stay amber as if still waiting. Matching is fixed for Claude permission requests without tool IDs, and Codex no longer stays waiting until a late PostToolUse when approval already happened.
