### PR TITLE
fix: resolve 4 Windows agent bugs — DeepSeek missing, Hermes/Claude icon swap, missing Kimi/Qwen status, MiniMax .com quota (#8302)

### DIFF
--- a/src/main/rate-limits/minimax-fetcher.ts
+++ b/src/main/rate-limits/minimax-fetcher.ts
@@ -7,6 +7,7 @@ import {
   logMiniMaxFetchFailure,
   makeMiniMaxRequestHeaders,
   MINIMAX_USAGE_ENDPOINT,
+  MINIMAX_USAGE_ENDPOINT_COM,
   normalizeMiniMaxCookieHeader,
   redactMiniMaxSecret,
   type MiniMaxFetchResponse
@@ -19,6 +20,22 @@ export {
 } from './minimax-request-context'
 
 const API_TIMEOUT_MS = 15_000
+
+// Why: China (.com) MiniMax accounts use platform.minimax.com; .io accounts
+// use platform.minimax.io. Both share the same API path. Try the .io endpoint
+// first; retry with .com on non-auth server errors so .com users get quota
+// without manual configuration.
+// Why: China (.com) MiniMax accounts use the same API path on a different origin;
+// hold the secondary endpoint so the retry logic can reference it without importing
+// MINIMAX_USAGE_ENDPOINT_COM at the call site in fetchMiniMaxRateLimits.
+const SECONDARY_ENDPOINT = MINIMAX_USAGE_ENDPOINT_COM
+
+// Why: distinguish auth failures (stale token) from transient server errors so the
+// endpoint-retry logic does not retry with a different origin when the credential
+// itself is invalid — that would waste a request and return the same auth error.
+function hasAuthError(error: ProviderRateLimits): boolean {
+  return error.usageMetadata?.failureKind === 'stale-token'
+}
 
 type MiniMaxUsageItem = {
   model_name?: unknown
@@ -215,26 +232,22 @@ function handleMiniMaxPayloadError(
   return makeError(redactMiniMaxSecret(message), 'usage-unavailable')
 }
 
-export async function fetchMiniMaxRateLimits(
-  options: FetchMiniMaxRateLimitsOptions
+// Why: extracted so fetchMiniMaxRateLimits can call this with different endpoints
+// (primary .io, fallback .com) without duplicating the fetch-and-parse pipeline.
+async function tryFetchMiniMaxRateLimits(
+  options: FetchMiniMaxRateLimitsOptions,
+  endpoint: string
 ): Promise<ProviderRateLimits> {
-  const rawCookie = options.cookie.trim()
-  if (!rawCookie) {
-    return makeUnavailable('MiniMax session cookie not configured')
-  }
-  const cookie = normalizeMiniMaxCookieHeader(rawCookie)
-  if (!extractMiniMaxCookieValue(cookie, '_token')) {
-    return makeError(
-      'MiniMax auth cookie not found — paste a Cookie header with _token',
-      'missing-credentials'
-    )
-  }
   const groupId =
-    options.groupId?.trim() || extractMiniMaxCookieValue(cookie, 'minimax_group_id_v2')
+    options.groupId?.trim() ||
+    extractMiniMaxCookieValue(
+      normalizeMiniMaxCookieHeader(options.cookie.trim()),
+      'minimax_group_id_v2'
+    )
   try {
     const fetchResult = await fetchMiniMaxResponse({
-      cookie,
-      endpoint: options.endpoint ?? MINIMAX_USAGE_ENDPOINT,
+      cookie: normalizeMiniMaxCookieHeader(options.cookie.trim()),
+      endpoint,
       groupId,
       signal: AbortSignal.timeout(API_TIMEOUT_MS)
     })
@@ -276,4 +289,37 @@ export async function fetchMiniMaxRateLimits(
     const message = error instanceof Error ? error.message : 'Unknown MiniMax usage error'
     return makeError(redactMiniMaxSecret(message), 'network')
   }
+}
+
+export async function fetchMiniMaxRateLimits(
+  options: FetchMiniMaxRateLimitsOptions
+): Promise<ProviderRateLimits> {
+  const rawCookie = options.cookie.trim()
+  if (!rawCookie) {
+    return makeUnavailable('MiniMax session cookie not configured')
+  }
+  const cookie = normalizeMiniMaxCookieHeader(rawCookie)
+  if (!extractMiniMaxCookieValue(cookie, '_token')) {
+    return makeError(
+      'MiniMax auth cookie not found — paste a Cookie header with _token',
+      'missing-credentials'
+    )
+  }
+  const primaryEndpoint = options.endpoint ?? MINIMAX_USAGE_ENDPOINT
+  const primaryResult = await tryFetchMiniMaxRateLimits(options, primaryEndpoint)
+  // Why: retry with the .com endpoint when the .io endpoint fails with a
+  // non-auth server error. This covers China (.com) MiniMax accounts whose
+  // API origin differs from .io accounts.
+  if (
+    primaryResult.status !== 'ok' &&
+    !hasAuthError(primaryResult) &&
+    primaryEndpoint !== SECONDARY_ENDPOINT
+  ) {
+    console.warn('[minimax] primary endpoint failed; retrying with secondary', {
+      primaryError: primaryResult.error,
+      secondaryEndpoint: SECONDARY_ENDPOINT
+    })
+    return await tryFetchMiniMaxRateLimits(options, SECONDARY_ENDPOINT)
+  }
+  return primaryResult
 }

--- a/src/main/rate-limits/minimax-request-context.ts
+++ b/src/main/rate-limits/minimax-request-context.ts
@@ -3,6 +3,12 @@ import { session, type Session } from 'electron'
 export const MINIMAX_USAGE_ENDPOINT =
   'https://platform.minimax.io/v1/api/openplatform/coding_plan/remains'
 
+// Why: China (.com) MiniMax accounts use a different API origin than .io
+// accounts. Try .io first; fall back to .com when the .io endpoint returns a
+// server-side error (not auth), since the API path and contract are identical.
+export const MINIMAX_USAGE_ENDPOINT_COM =
+  'https://platform.minimax.com/v1/api/openplatform/coding_plan/remains'
+
 const MINIMAX_ORIGIN = 'https://platform.minimax.io'
 const MINIMAX_REFERER = 'https://platform.minimax.io/console/usage'
 const MINIMAX_SESSION_PARTITION = 'orca-minimax-rate-limit-fetch'

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -37,6 +37,8 @@ const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   Cursor: 'cursor',
   Droid: 'droid',
   Hermes: 'hermes',
+  Kimi: 'kimi',
+  Qwen: 'qwen-code',
   Pi: 'pi',
   OMP: 'omp'
 }

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -283,6 +283,13 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     homepageUrl: 'https://devin.ai/cli'
   },
   {
+    id: 'deepseek',
+    label: translate('auto.lib.agent.catalog.deepseek_label', 'DeepSeek'),
+    cmd: 'deepseek',
+    faviconDomain: 'deepseek.com',
+    homepageUrl: 'https://docs.deepseek.com/cli'
+  },
+  {
     id: 'openclaw',
     label: translate('auto.lib.agent.catalog.5dff448636', 'OpenClaw'),
     cmd: 'openclaw',

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -125,7 +125,8 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   hermes: 'Hermes',
   devin: 'Devin',
   ante: 'Ante',
-  kimi: 'Kimi'
+  kimi: 'Kimi',
+  deepseek: 'DeepSeek'
 }
 
 export function formatAgentTypeLabel(agentType: AgentType | null | undefined): string {
@@ -183,7 +184,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   copilot: true,
   grok: true,
   devin: true,
-  ante: true
+  ante: true,
+  deepseek: true
 }
 
 export function agentTypeToIconAgent(agentType: AgentType | null | undefined): TuiAgent | null {

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -126,6 +126,7 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   devin: 'Devin',
   ante: 'Ante',
   kimi: 'Kimi',
+  'qwen-code': 'Qwen',
   deepseek: 'DeepSeek'
 }
 

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -47,7 +47,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   copilot: 'copilot',
   grok: 'grok',
   devin: 'devin',
-  ante: 'ante'
+  ante: 'ante',
+  deepseek: 'deepseek'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -61,9 +61,23 @@ export function titleHasAnyLegacyAgentName(title: string): boolean {
 
 // Why: `android` contains `droid`; like the legacy names above, Droid must be
 // token-matched so Android terminal titles do not become agent status.
-export const DROID_AGENT_NAME_RE = /(?<![\w./\\-])droid(?![\w./\\-])/i
+// Why: Windows launcher processes surface the .exe suffix in terminal titles.
+// Without the executable suffix, `droid.exe` titles fail to match on Windows
+// and fall through to other agent heuristics (braille spinner → Claude Code).
+export const DROID_AGENT_NAME_RE = new RegExp(
+  `(?<![\\w./\\\\-])droid(?:${WINDOWS_EXECUTABLE_SUFFIX_RE})?(?![\\w./\\\\-])`,
+  'i'
+)
 
 // Why: Hermes/agy are safe to token-match but unsafe as substrings because
 // cwd/path titles like `~/hermes/working` would otherwise count as activity.
-export const HERMES_AGENT_NAME_RE = /(?<![\w./\\-])hermes(?![\w./\\-])/i
-export const AGY_AGENT_NAME_RE = /(?<![\w./\\-])agy(?![\w./\\-])/i
+// Why: same Windows .exe suffix issue — `hermes.exe` titles on Windows are
+// not detected as Hermes, falling through to Claude's braille spinner heuristic.
+export const HERMES_AGENT_NAME_RE = new RegExp(
+  `(?<![\\w./\\\\-])hermes(?:${WINDOWS_EXECUTABLE_SUFFIX_RE})?(?![\\w./\\\\-])`,
+  'i'
+)
+export const AGY_AGENT_NAME_RE = new RegExp(
+  `(?<![\\w./\\\\-])agy(?:${WINDOWS_EXECUTABLE_SUFFIX_RE})?(?![\\w./\\\\-])`,
+  'i'
+)

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -26,7 +26,9 @@ export const AGENT_NAMES = [
   'openclaw',
   'aider',
   'grok',
-  'devin'
+  'devin',
+  'kimi',
+  'qwen'
 ]
 
 // Why: Windows agent titles can surface launcher process names such as

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -103,6 +103,12 @@ export function getAgentLabel(title: string): string | null {
   if (HERMES_AGENT_NAME_RE.test(title)) {
     return 'Hermes'
   }
+  if (titleHasAgentName(title, 'kimi')) {
+    return 'Kimi'
+  }
+  if (titleHasAgentName(title, 'qwen')) {
+    return 'Qwen'
+  }
   if (isClaudeAgent(title)) {
     return 'Claude Code'
   }

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -103,6 +103,7 @@ export const AGENT_KIND_VALUES = [
   'grok',
   'devin',
   'ante',
+  'deepseek',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -199,6 +199,12 @@ export function getAgentLabel(title: string): string | null {
   if (HERMES_AGENT_NAME_RE.test(title)) {
     return 'Hermes'
   }
+  if (titleHasAgentName(title, 'kimi')) {
+    return 'Kimi'
+  }
+  if (titleHasAgentName(title, 'qwen')) {
+    return 'Qwen'
+  }
   if (isClaudeAgent(title)) {
     return 'Claude Code'
   }
@@ -225,6 +231,8 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   Cursor: 'cursor',
   Droid: 'droid',
   Hermes: 'hermes',
+  Kimi: 'kimi',
+  Qwen: 'qwen-code',
   Pi: 'pi',
   OMP: 'omp'
 }

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -374,6 +374,18 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // `followupPrompt` to the PTY as plain input + Enter after startup (not
     // bracketed paste). Use `draftPrompt` / agent-paste-draft for review-before-send.
     promptInjectionMode: 'stdin-after-start'
+  },
+  deepseek: {
+    // Why: the official DeepSeek Code CLI (`pip install deepseek-code`) is
+    // installed by the user manually; no npm/homebrew/curl-sh installer exists
+    // as of 2026. Detect via the documented binary name.
+    detectCmd: 'deepseek',
+    launchCmd: 'deepseek',
+    expectedProcess: 'deepseek',
+    // Why: `deepseek --prompt <text>` runs non-interactively and exits, which
+    // would kill the TUI session Orca is hosting. `-i/--interactive <prompt>`
+    // starts an interactive session — the behavior Orca needs.
+    promptInjectionMode: 'flag-interactive'
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2380,6 +2380,7 @@ export type TuiAgent =
   | 'grok' // xAI Grok CLI
   | 'devin' // Devin CLI
   | 'ante' // Ante (Antigma Labs)
+  | 'deepseek' // DeepSeek
 
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'
 


### PR DESCRIPTION
## Summary

Fixes #8302 — 4 Windows agent bugs in one PR, each as a separate commit.

---

### Commit 1: Add DeepSeek as a built-in agent

The Windows agent list was missing DeepSeek. Added `deepseek` to `TuiAgent`, `AgentKind`, `TUI_AGENT_CONFIG`, agent catalog, and icon/status mappings.

### Commit 2: Fix Hermes/Claude icon swap on Windows

`HERMES_AGENT_NAME_RE`, `DROID_AGENT_NAME_RE`, and `AGY_AGENT_NAME_RE` lacked the Windows executable suffix (`.exe`, `.cmd`, `.bat`, `.ps1`). Terminal titles like `hermes.exe` or `⠋ hermes.exe` failed to match, falling through to Claude's braille-spinner heuristic — causing Hermes sessions to show the Claude icon. Fixed by rebuilding the three regexes with the same `WINDOWS_EXECUTABLE_SUFFIX_RE` used by `buildAgentNameRe()`.

### Commit 3: Add Kimi and Qwen to title-based agent status detection

Kimi and Qwen showed no execution status indicators because their agent names were not in `AGENT_NAMES` and had no explicit checks in `getAgentLabel()`. Added both to `AGENT_NAMES`, added label checks before the Claude fallback in both `getAgentLabel()` copies, and added them to the `TITLE_LABEL_TO_AGENT` / `TITLE_AGENT_LABEL_TO_TYPE` maps.

### Commit 4: Retry MiniMax quota fetch with .com endpoint for China users

China (.com) MiniMax accounts use `platform.minimax.com` instead of `platform.minimax.io`. Added `MINIMAX_USAGE_ENDPOINT_COM` and a retry: if the `.io` endpoint fails with a non-auth server error, the fetcher retries with `.com`.

## Testing

- `pnpm lint`: 0 warnings, 0 errors
- `pnpm typecheck`: passing

## No visual change

No visual change for users not affected by the specific bugs. Existing behavior is preserved.

## AI Review Report

### Cross-platform compatibility
- DeepSeek addition: cross-platform, no platform-specific code
- Windows exe suffix regex: the `(?:\.(?:exe|cmd|bat|ps1))?` pattern is a no-op on macOS/Linux — it simply never matches
- Kimi/Qwen title detection: cross-platform, uses same `titleHasAgentName` pattern as all other agents
- MiniMax endpoint retry: cross-platform, Electron fetch API

### SSH/remote/local compatibility
- All changes are in agent detection (title parsing) and rate-limit fetching — both run locally where the Orca process executes. No SSH-specific paths affected.
- Agent title detection runs on terminal titles from any host (local, WSL, SSH). Regex changes apply uniformly.

### Agent and integration compatibility
- DeepSeek: new agent, no existing integrations affected
- Hermes/Droid/Antigravity: regex fix only applies to Windows `.exe` titles; macOS/Linux behavior unchanged
- Kimi/Qwen: newly detected agents, no existing integrations affected
- MiniMax: retry logic is additive; `.io` users see no change

### Performance risk
- Agent title regexes are tested on every terminal title update (bounded by user typing speed). The added `(?:...)?` wrapper adds negligible overhead.
- MiniMax retry adds at most one extra HTTP request only when the primary endpoint fails — rare in practice

### UI quality
- No UI changes

### Basic security risk
- MiniMax secondary endpoint uses the same HTTPS protocol and cookie authentication as the primary. No new credential exposure.
- No new user input or shell execution paths

## Security Audit

- No new dependencies introduced
- No new IPC or network listeners
- No new file system access or shell execution
- MiniMax cookie handling unchanged — same cookie sent to both endpoints with same HTTPS protection
- All changes are in shared library code or renderer logic; no elevation of privilege

## ELI5

On Windows, DeepSeek was missing from the agent list, Hermes and Claude icons could swap because of `.exe`/`.cmd` matching gaps, some agents lacked status wiring, and MiniMax `.com` quota was wrong. Four focused fixes restore correct agents, icons, status, and quota on Windows.
