### PR TITLE
fix(terminal): stop leaking Shift+Enter CSI-u without Kitty handshake

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -67,11 +67,37 @@ describe('resolveTerminalShortcutAction', () => {
   })
 
   it('keeps shift-enter and delete helpers explicit', () => {
+    // Why: macOS CSI-u Shift+Enter only when the pane has enabled KKP; otherwise
+    // Esc+CR avoids the literal `[13;2u` leak in CSI-u-blind sessions.
     expect(
-      resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', shiftKey: true }), true)
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', shiftKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        undefined,
+        undefined,
+        () => true
+      )
     ).toEqual({
       type: 'sendInput',
       data: '\x1b[13;2u'
+    })
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', shiftKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        undefined,
+        undefined,
+        () => false
+      )
+    ).toEqual({
+      type: 'sendInput',
+      data: '\x1b\r'
     })
     expect(resolveTerminalShortcutAction(event({ key: 'Backspace', ctrlKey: true }), true)).toEqual(
       { type: 'sendInput', data: '\x17' }
@@ -164,7 +190,7 @@ describe('resolveTerminalShortcutAction', () => {
     expect(getWindowsShiftEnterEncoding).not.toHaveBeenCalled()
   })
 
-  it('always uses CSI-u Shift+Enter off Windows regardless of Windows encoding', () => {
+  it('uses CSI-u Shift+Enter off Windows only when Kitty keyboard is active', () => {
     for (const encoding of [() => 'csi-u' as const, () => 'alt-enter' as const, undefined]) {
       expect(
         resolveTerminalShortcutAction(
@@ -175,12 +201,53 @@ describe('resolveTerminalShortcutAction', () => {
           false,
           undefined,
           undefined,
-          undefined,
+          () => true,
           undefined,
           encoding
         )
       ).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
+      expect(
+        resolveTerminalShortcutAction(
+          event({ key: 'Enter', code: 'Enter', shiftKey: true }),
+          false,
+          'false',
+          0,
+          false,
+          undefined,
+          undefined,
+          () => false,
+          undefined,
+          encoding
+        )
+      ).toEqual({ type: 'sendInput', data: '\x1b\r' })
     }
+  })
+
+  it('does not inject Ctrl+Enter CSI-u when Kitty keyboard is inactive', () => {
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', ctrlKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        undefined,
+        undefined,
+        () => false
+      )
+    ).toBeNull()
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', ctrlKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        undefined,
+        undefined,
+        () => true
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
   })
 
   it('keeps ConPTY and agent lookups off unrelated keystrokes', () => {
@@ -243,12 +310,31 @@ describe('resolveTerminalShortcutAction', () => {
   it('forwards Ctrl+Enter as the kitty CSI-u chord so TUIs can cue instead of send', () => {
     // Why: xterm.js collapses Ctrl+Enter to a bare CR; intercept upstream and
     // emit the kitty sequence (modifier code 5 = Ctrl) so probing TUIs receive
-    // the distinct chord on every platform.
+    // the distinct chord when KKP is active.
+    const kittyActive = (): boolean => true
     expect(
-      resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', ctrlKey: true }), true)
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', ctrlKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        undefined,
+        undefined,
+        kittyActive
+      )
     ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
     expect(
-      resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', ctrlKey: true }), false)
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', ctrlKey: true }),
+        false,
+        'false',
+        0,
+        false,
+        undefined,
+        undefined,
+        kittyActive
+      )
     ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
     // Windows uses the same kitty sequence for now: no TUI is known to treat the
     // CSI-u Ctrl+Enter form as inert (cf. the Shift+Enter Codex-on-PowerShell case).
@@ -258,7 +344,10 @@ describe('resolveTerminalShortcutAction', () => {
         false,
         'false',
         0,
-        true
+        true,
+        undefined,
+        undefined,
+        kittyActive
       )
     ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -153,11 +153,19 @@ export function resolveTerminalShortcutAction(
     // Why: Droid needs CSI-u but Codex needs Esc+CR; preserve legacy bytes for
     // SSH/WSL/remote peers that cannot be safely classified from this client.
     const useLocalWindowsCapability = isWindows && isLocalWindowsConptyPane?.() !== false
-    const encoding = useLocalWindowsCapability
+    let encoding: WindowsShiftEnterEncoding = useLocalWindowsCapability
       ? (getWindowsShiftEnterEncoding?.() ?? 'alt-enter')
       : isWindows
         ? 'alt-enter'
         : 'csi-u'
+    // Why: unconditional CSI-u on macOS/Linux lands as the literal characters
+    // `[13;2u` when the app has not enabled Kitty keyboard (CSI > u). Grok and
+    // other CSI-u-blind states show that garbage in the composer / redraw.
+    // Windows agent-declared `csi-u` (Droid) still opts in without the tracker.
+    const kittyActive = isKittyKeyboardActivePane?.() === true
+    if (encoding === 'csi-u' && !useLocalWindowsCapability && !kittyActive) {
+      encoding = 'alt-enter'
+    }
     return { type: 'sendInput', data: encoding === 'csi-u' ? '\x1b[13;2u' : '\x1b\r' }
   }
 
@@ -172,9 +180,11 @@ export function resolveTerminalShortcutAction(
     // modified Enter chords never receive the distinct input and treat it as
     // plain Enter. Forward the kitty CSI-u sequence directly (modifier code
     // 5 = Ctrl; cf. 2 = Shift above) so cue/queue behavior reaches the TUI.
-    // Sibling of the Shift+Enter case; a Windows fallback is not added yet
-    // because, unlike #2418's Codex-on-PowerShell inertness, no Windows TUI is
-    // known to drop the CSI-u form for Ctrl+Enter.
+    // Why: only when KKP is active — otherwise `\x1b[13;5u` is the same class
+    // of literal leak as Shift+Enter's `[13;2u`.
+    if (isKittyKeyboardActivePane?.() !== true) {
+      return null
+    }
     return { type: 'sendInput', data: '\x1b[13;5u' }
   }
 

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -14,6 +14,15 @@ describe('resolveWindowsShiftEnterEncoding', () => {
     expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'droid' })).toBe('alt-enter')
   })
 
+  it('uses CSI-u for trusted Grok process evidence (Kitty Shift+Enter newline)', () => {
+    expect(
+      resolveWindowsShiftEnterEncoding({
+        foreground: { agent: 'grok', routingTrusted: true, shellForeground: false }
+      })
+    ).toBe('csi-u')
+    expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'grok' })).toBe('alt-enter')
+  })
+
   it('does not let hook or OSC-derived status forge Droid input routing', () => {
     const state = {
       paneForegroundAgentByPaneKey: {},

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -363,7 +363,10 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'argv',
     // Why: prompts such as `help` or `--version` otherwise select Grok CLI
     // syntax instead of starting an interactive turn with that literal text.
-    argvPromptSeparator: '--'
+    argvPromptSeparator: '--',
+    // Why: Grok decodes Kitty CSI-u for Shift+Enter newlines (and keeps KKP
+    // advertised on Windows ConPTY). Esc+CR is treated as submit, same as Droid.
+    windowsShiftEnterEncoding: 'csi-u'
   },
   devin: {
     detectCmd: 'devin',


### PR DESCRIPTION
## Summary

- Stop sending Shift+Enter as Kitty CSI-u (`\x1b[13;2u`) on macOS/Linux when the pane has **not** enabled Kitty keyboard — that path leaked as literal `[13;2u` (user-visible garble, especially in Grok).
- Same gate for Ctrl+Enter CSI-u (`\x1b[13;5u`).
- Mark trusted Grok on Windows as CSI-u Shift+Enter (same as Droid) so newline works when KKP is active.

Closes #8385.

## Screenshots

No visual design change. Before: Shift+Enter without KKP could paint `[13;2u` into the Grok composer. After: Esc+CR until KKP is active, then CSI-u.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] Focused Vitest: `terminal-shortcut-policy.test.ts` + `terminal-windows-shift-enter.test.ts` (42/42)
- [ ] `pnpm build`
- [x] Added regression coverage for inactive-KKP Shift+Enter → Esc+CR, Ctrl+Enter gate, and trusted Grok CSI-u encoding

```text
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
```

## AI Review Report

Reviewed against Grok-only, local macOS/Windows, terminal-TUI (not Native Chat). Confirmed the leaked text matches CSI-u Shift+Enter. Windows agent-declared CSI-u for Droid remains unconditional (#7620). Grok gets the same Windows declaration so trusted Grok newlines match its KKP path from #7944. Remote/SSH Windows clients still use Esc+CR when ConPTY classification is not local.

## Security Audit

No new IPC, filesystem, network, auth, secrets, or dependency surface. Only changes which already-trusted key chord bytes are written to an open PTY.