### PR TITLE
fix: harden orchestration lifecycle messages

### DIFF
--- a/config/scripts/orchestration-skill-guidance.test.mjs
+++ b/config/scripts/orchestration-skill-guidance.test.mjs
@@ -11,7 +11,9 @@ function readSkill() {
 
 function getSection(markdown, heading) {
   const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const match = markdown.match(new RegExp(`## ${escapedHeading}\\n([\\s\\S]*?)(?=\\n## |$)`))
+  const match = markdown.match(
+    new RegExp(`## ${escapedHeading}\\r?\\n([\\s\\S]*?)(?=\\r?\\n## |$)`)
+  )
 
   expect(match).not.toBeNull()
 
@@ -181,6 +183,12 @@ describe('orchestration skill guidance', () => {
     const skill = readSkill()
     const agentGuidance = getSection(skill, 'Agent Guidance')
 
+    expect(agentGuidance).toContain('--task-id <task_id> --dispatch-id <dispatch_id>')
+    expect(agentGuidance).toContain('--files-modified "path/a"')
+    expect(agentGuidance).toContain('--phase "implementing"')
+    expect(agentGuidance).toContain('live injected preamble as authoritative')
+    expect(agentGuidance).toContain('Do not use raw `--payload` JSON for lifecycle messages')
+    expect(agentGuidance).not.toContain(`--payload '{"taskId"`)
     expect(agentGuidance).toContain('After sending `worker_done`, end your turn')
     expect(agentGuidance).toContain('idle at the agent prompt')
     expect(agentGuidance).toContain('Do not poll or keep calling `orca orchestration check`')
@@ -189,12 +197,21 @@ describe('orchestration skill guidance', () => {
     expect(skill).not.toContain('every 2 minutes')
   })
 
+  it('uses Windows-safe task result guidance', () => {
+    const skill = readSkill()
+    const tasks = getSection(skill, 'Tasks And Dispatch')
+
+    expect(tasks).toContain('--result <json> | --result-file <path>')
+    expect(tasks).toContain('prefer `--result-file` for task results')
+    expect(tasks).toContain('inline JSON quotes can be stripped')
+  })
+
   it('keeps agent-first launch, handle recovery, and inbox injection distinct', () => {
     const skill = readSkill()
     const messaging = getSection(skill, 'Messaging')
     const workerTerminals = getSection(skill, 'Worker Terminals')
     const agentFirstExample = workerTerminals.match(
-      /```bash\norca worktree create --name <task-name> --agent codex --json\n[\s\S]*?```/
+      /```bash\r?\norca worktree create --name <task-name> --agent codex --json\r?\n[\s\S]*?```/
     )?.[0]
 
     expect(workerTerminals).toContain('Agent-first (required for ordinary agent workers)')

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -108,12 +108,14 @@ A task is the work item, a dispatch assigns it to a terminal, and a gate blocks 
 ```bash
 orca orchestration task-create --spec <text> [--deps <json_array>] [--parent <task_id>] [--json]
 orca orchestration task-list [--status <status>] [--ready] [--json]
-orca orchestration task-update --id <task_id> --status <status> [--result <json>] [--json]
+orca orchestration task-update --id <task_id> --status <status> [--result <json> | --result-file <path>] [--json]
 orca orchestration dispatch --task <task_id> --to <handle> [--from <handle>] [--inject] [--json]
 orca orchestration dispatch-show --task <task_id> [--json]
 ```
 
 Task statuses: `pending`, `ready`, `dispatched`, `completed`, `failed`, `blocked`.
+
+On Windows PowerShell, prefer `--result-file` for task results; inline JSON quotes can be stripped.
 
 Dispatch rules:
 
@@ -222,10 +224,11 @@ Wait for `tui-idle` before dispatching. Always pass `--timeout-ms`; real coding 
 ## Agent Guidance
 
 - Workers with a valid live preamble must send `worker_done` exactly once, even on failure:
-  `orca orchestration send --to <coordinator_handle> --type worker_done --subject "<short status>" --body "<3-sentence summary: what you did, what you found, what's left>" --payload '{"taskId":"<task_id>","dispatchId":"<dispatch_id>","filesModified":["path/a"],"reportPath":"<optional>"}' --json`
+  `orca orchestration send --to <coordinator_handle> --type worker_done --subject "<short status>" --body "<3-sentence summary: what you did, what you found, what's left>" --task-id <task_id> --dispatch-id <dispatch_id> --files-modified "path/a" --report-path "<optional>" --json`
+- Treat the live injected preamble as authoritative over generic skill examples. Do not use raw `--payload` JSON for lifecycle messages; PowerShell can strip its quotes.
 - After sending `worker_done`, end your turn and idle at the agent prompt. Do not poll or keep calling `orca orchestration check`; the coordinator re-engages you with a fresh preamble + TASK block delivered as new terminal input.
 - For long tasks, send heartbeat/status only when the preamble asks for it, including both IDs:
-  `orca orchestration send --to <coordinator_handle> --type heartbeat --subject "alive" --payload '{"taskId":"<task_id>","dispatchId":"<dispatch_id>","phase":"implementing"}' --json`
+  `orca orchestration send --to <coordinator_handle> --type heartbeat --subject "alive" --task-id <task_id> --dispatch-id <dispatch_id> --phase "implementing" --json`
 - If blocked before completion, use `ask`; use `escalation` only when ownership is valid and the coordinator must intervene.
 - Treat preambles inherited through terminal history or full handoffs as stale unless the current prompt explicitly keeps that coordinator in the loop.
 - Coordinators should use `task-list --ready` as external memory, dispatch parallel waves, and avoid dependency chains deeper than 3-4 steps.

--- a/src/cli/handlers/orchestration.test.ts
+++ b/src/cli/handlers/orchestration.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 const callMock = vi.fn()
 const getTerminalHandleMock = vi.hoisted(() => vi.fn())
@@ -150,6 +153,36 @@ describe('orchestration send structured payload flags', () => {
     expect(callMock).not.toHaveBeenCalled()
   })
 
+  it('rejects malformed raw lifecycle JSON before calling the runtime', async () => {
+    await expect(
+      invokeSend(
+        new Map<string, string | boolean>([
+          ['from', 'term_worker'],
+          ['to', 'term_coord'],
+          ['subject', 'done'],
+          ['type', 'worker_done'],
+          ['payload', '{taskId:task_1,dispatchId:ctx_1}']
+        ])
+      )
+    ).rejects.toThrow(/Use --task-id and --dispatch-id/)
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('requires both lifecycle identifiers', async () => {
+    await expect(
+      invokeSend(
+        new Map<string, string | boolean>([
+          ['from', 'term_worker'],
+          ['to', 'term_coord'],
+          ['subject', 'alive'],
+          ['type', 'heartbeat'],
+          ['task-id', 'task_1']
+        ])
+      )
+    ).rejects.toThrow(/dispatchId must be a non-empty string/)
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
   it('rejects worker_done group sends before resolving a sender handle', async () => {
     getTerminalHandleMock.mockRejectedValue(new Error('sender resolution should not run'))
 
@@ -190,13 +223,15 @@ describe('orchestration send structured payload flags', () => {
     expect(callMock).not.toHaveBeenCalled()
   })
 
-  it('continues to allow worker_done to a concrete terminal handle', async () => {
+  it('allows worker_done with valid authority fields to a concrete terminal handle', async () => {
     await invokeSend(
       new Map<string, string | boolean>([
         ['from', 'term_worker'],
         ['to', 'term_coord'],
         ['subject', 'done'],
-        ['type', 'worker_done']
+        ['type', 'worker_done'],
+        ['task-id', 'task_1'],
+        ['dispatch-id', 'ctx_1']
       ])
     )
 
@@ -208,7 +243,7 @@ describe('orchestration send structured payload flags', () => {
       type: 'worker_done',
       priority: undefined,
       threadId: undefined,
-      payload: undefined,
+      payload: JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1' }),
       devMode: false
     })
   })
@@ -220,7 +255,9 @@ describe('orchestration send structured payload flags', () => {
       new Map<string, string | boolean>([
         ['to', 'term_coord'],
         ['subject', 'done'],
-        ['type', 'worker_done']
+        ['type', 'worker_done'],
+        ['task-id', 'task_1'],
+        ['dispatch-id', 'ctx_1']
       ])
     )
 
@@ -233,7 +270,7 @@ describe('orchestration send structured payload flags', () => {
       type: 'worker_done',
       priority: undefined,
       threadId: undefined,
-      payload: undefined,
+      payload: JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1' }),
       devMode: false
     })
   })
@@ -255,6 +292,71 @@ describe('orchestration send structured payload flags', () => {
       code: 'no_active_sender_terminal',
       message: expect.stringContaining('Pass --from')
     })
+    expect(callMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('orchestration task-update result JSON', () => {
+  beforeEach(() => {
+    callMock
+      .mockReset()
+      .mockResolvedValue({ result: { task: { id: 'task_1', status: 'completed' } } })
+  })
+
+  const invokeUpdate = (flags: Map<string, string | boolean>) =>
+    ORCHESTRATION_HANDLERS['orchestration task-update']({
+      flags,
+      client: { call: callMock },
+      json: true
+    } as never)
+
+  it('normalizes a valid result file before sending it to the runtime', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-task-result-'))
+    const resultFile = join(dir, 'result.json')
+    writeFileSync(resultFile, '{\n  "filesModified": []\n}', 'utf8')
+    try {
+      await invokeUpdate(
+        new Map([
+          ['id', 'task_1'],
+          ['status', 'completed'],
+          ['result-file', resultFile]
+        ])
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+
+    expect(callMock).toHaveBeenCalledWith('orchestration.taskUpdate', {
+      id: 'task_1',
+      status: 'completed',
+      result: '{"filesModified":[]}'
+    })
+  })
+
+  it('rejects malformed inline result JSON', async () => {
+    await expect(
+      invokeUpdate(
+        new Map([
+          ['id', 'task_1'],
+          ['status', 'completed'],
+          ['result', '{completedBy:term_worker}']
+        ])
+      )
+    ).rejects.toThrow(/Task result must be valid JSON/)
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects mixing inline and file result sources', async () => {
+    await expect(
+      invokeUpdate(
+        new Map([
+          ['id', 'task_1'],
+          ['status', 'completed'],
+          ['result', '{}'],
+          ['result-file', 'result.json']
+        ])
+      )
+    ).rejects.toThrow(/either --result or --result-file/)
     expect(callMock).not.toHaveBeenCalled()
   })
 })

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines -- Why: orchestration CLI handlers share flag-parsing helpers and dispatch/preamble logic; splitting by verb would fragment the RuntimeClient call shape without reducing complexity. */
+import { readFileSync } from 'node:fs'
 import type { CommandHandler } from '../dispatch'
 import { printResult } from '../format'
 import {
@@ -8,6 +9,10 @@ import {
 } from '../flags'
 import { RuntimeClientError } from '../runtime-client'
 import { getTerminalHandle } from '../selectors'
+import {
+  isLifecycleMessageType,
+  validateLifecyclePayload
+} from '../../shared/orchestration-lifecycle-payload'
 
 // Why: 15 s is well under Claude Code's empirical ~2 min Bash-tool silence
 // budget and generates only ~40 lines per 10 min wait — enough to assure the
@@ -76,7 +81,8 @@ type MessageSummary = {
 }
 
 function getOptionalStructuredMessagePayload(
-  flags: Map<string, string | boolean>
+  flags: Map<string, string | boolean>,
+  type: string | undefined
 ): string | undefined {
   const rawPayload = getOptionalStringFlag(flags, 'payload')
   const taskId = getOptionalStringFlag(flags, 'task-id')
@@ -90,10 +96,7 @@ function getOptionalStructuredMessagePayload(
     filesModified !== undefined ||
     reportPath !== undefined ||
     phase !== undefined
-  if (!hasStructuredPayload) {
-    return rawPayload
-  }
-  if (rawPayload !== undefined) {
+  if (hasStructuredPayload && rawPayload !== undefined) {
     throw new RuntimeClientError(
       'invalid_argument',
       'Use either --payload or structured payload flags, not both.'
@@ -101,26 +104,72 @@ function getOptionalStructuredMessagePayload(
   }
   // Why: raw JSON arguments are fragile in Windows PowerShell; these flags let
   // workers send parseable orchestration payloads without shell-specific quoting.
-  const payload: Record<string, string | string[]> = {}
-  if (taskId) {
-    payload.taskId = taskId
+  let resolvedPayload = rawPayload
+  if (hasStructuredPayload) {
+    const payload: Record<string, string | string[]> = {}
+    if (taskId) {
+      payload.taskId = taskId
+    }
+    if (dispatchId) {
+      payload.dispatchId = dispatchId
+    }
+    if (filesModified) {
+      payload.filesModified = filesModified
+        .split(',')
+        .map((file) => file.trim())
+        .filter(Boolean)
+    }
+    if (reportPath) {
+      payload.reportPath = reportPath
+    }
+    if (phase) {
+      payload.phase = phase
+    }
+    resolvedPayload = JSON.stringify(payload)
   }
-  if (dispatchId) {
-    payload.dispatchId = dispatchId
+
+  if (isLifecycleMessageType(type)) {
+    const validation = validateLifecyclePayload(type, resolvedPayload)
+    if (!validation.ok) {
+      throw new RuntimeClientError('invalid_argument', validation.message)
+    }
   }
-  if (filesModified) {
-    payload.filesModified = filesModified
-      .split(',')
-      .map((file) => file.trim())
-      .filter(Boolean)
+  return resolvedPayload
+}
+
+function getOptionalTaskResult(flags: Map<string, string | boolean>): string | undefined {
+  const inlineResult = getOptionalStringFlag(flags, 'result')
+  const resultFile = getOptionalStringFlag(flags, 'result-file')
+  if (inlineResult !== undefined && resultFile !== undefined) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Use either --result or --result-file, not both.'
+    )
   }
-  if (reportPath) {
-    payload.reportPath = reportPath
+
+  let rawResult = inlineResult
+  if (resultFile !== undefined) {
+    try {
+      rawResult = readFileSync(resultFile, 'utf8')
+    } catch (error) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        `Unable to read --result-file ${resultFile}: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
   }
-  if (phase) {
-    payload.phase = phase
+  if (rawResult === undefined) {
+    return undefined
   }
-  return JSON.stringify(payload)
+
+  try {
+    return JSON.stringify(JSON.parse(rawResult))
+  } catch {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Task result must be valid JSON. On Windows PowerShell, prefer --result-file.'
+    )
+  }
 }
 
 async function resolveOrchestrationTerminalHandle(
@@ -359,7 +408,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       type,
       priority: getOptionalStringFlag(flags, 'priority'),
       threadId: getOptionalStringFlag(flags, 'thread-id'),
-      payload: getOptionalStructuredMessagePayload(flags),
+      payload: getOptionalStructuredMessagePayload(flags, type),
       devMode: isDevCliInvocation()
     })
     printResult(result, json, (r) => {
@@ -521,7 +570,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       {
         id: getRequiredStringFlag(flags, 'id'),
         status,
-        result: getOptionalStringFlag(flags, 'result')
+        result: getOptionalTaskResult(flags)
       }
     )
     printResult(result, json, (r) => `Updated ${r.task.id} -> ${r.task.status}`)

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -83,9 +83,12 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     path: ['orchestration', 'task-update'],
     summary: 'Update a task status',
     usage:
-      'orca orchestration task-update --id <task_id> --status <status> [--result <json>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'id', 'status', 'result'],
-    notes: ['Valid --status values: pending, ready, dispatched, completed, failed, blocked.']
+      'orca orchestration task-update --id <task_id> --status <status> [--result <json> | --result-file <path>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'id', 'status', 'result', 'result-file'],
+    notes: [
+      'Valid --status values: pending, ready, dispatched, completed, failed, blocked.',
+      'On Windows PowerShell, prefer --result-file because inline JSON quotes may be stripped.'
+    ]
   },
   {
     path: ['orchestration', 'dispatch'],

--- a/src/main/runtime/orchestration-cli-subprocess.test.ts
+++ b/src/main/runtime/orchestration-cli-subprocess.test.ts
@@ -16,7 +16,7 @@
 // `pnpm run build:cli`. The verification gate explicitly builds the CLI
 // before running this file.
 import { spawn } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -63,6 +63,34 @@ async function runBuiltCli(
     stdout: stdoutChunks.join(''),
     stderr: stderrChunks.join('')
   }
+}
+
+async function runBuiltCliViaPowerShell(
+  userDataPath: string,
+  args: string[]
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const quote = (value: string) => `'${value.replaceAll("'", "''")}'`
+  const command = ['&', quote(process.execPath), quote(CLI_PATH), ...args.map(quote)].join(' ')
+  const child = spawn('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command], {
+    env: {
+      ...process.env,
+      ORCA_USER_DATA_PATH: userDataPath,
+      ORCA_TERMINAL_HANDLE: 'term_cli'
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+
+  const stdoutChunks: string[] = []
+  const stderrChunks: string[] = []
+  child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
+  child.stdout.on('data', (data) => stdoutChunks.push(data))
+  child.stderr.on('data', (data) => stderrChunks.push(data))
+  const exitCode = await new Promise<number>((resolveExit, rejectExit) => {
+    child.once('exit', (code) => resolveExit(code ?? 1))
+    child.once('error', rejectExit)
+  })
+  return { exitCode, stdout: stdoutChunks.join(''), stderr: stderrChunks.join('') }
 }
 
 describeIfBuilt('orca orchestration check --wait subprocess (§3.4)', () => {
@@ -187,6 +215,142 @@ describeIfBuilt('orca orchestration check --wait subprocess (§3.4)', () => {
     } finally {
       db.close()
       await server.stop()
+    }
+  }, 30_000)
+})
+
+const describeWindowsIfBuilt =
+  existsSync(CLI_PATH) && process.platform === 'win32' ? describe : describe.skip
+
+describeWindowsIfBuilt('orca orchestration lifecycle payloads through PowerShell', () => {
+  it('completes with structured flags and rejects quote-stripped raw JSON', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-cli-lifecycle-'))
+    const runtime = new OrcaRuntimeService()
+    const db = new OrchestrationDb(':memory:')
+    runtime.setOrchestrationDb(db)
+    const server = new OrcaRuntimeRpcServer({ runtime, userDataPath })
+    await server.start()
+
+    try {
+      const task = db.createTask({ spec: 'PowerShell lifecycle completion' })
+      const dispatch = db.createDispatchContext(task.id, 'term_cli')
+      const valid = await runBuiltCliViaPowerShell(userDataPath, [
+        'orchestration',
+        'send',
+        '--to',
+        'term_coord',
+        '--subject',
+        'done',
+        '--type',
+        'worker_done',
+        '--task-id',
+        task.id,
+        '--dispatch-id',
+        dispatch.id,
+        '--files-modified',
+        'src/a.ts,src/b.ts',
+        '--json'
+      ])
+
+      expect(valid.exitCode, valid.stderr).toBe(0)
+      expect(db.getTask(task.id)?.status).toBe('completed')
+      expect(JSON.parse(db.getTask(task.id)?.result ?? '{}')).toMatchObject({
+        completedBy: 'term_cli',
+        filesModified: ['src/a.ts', 'src/b.ts']
+      })
+
+      const rejectedTask = db.createTask({ spec: 'Reject malformed lifecycle payload' })
+      const rejectedDispatch = db.createDispatchContext(rejectedTask.id, 'term_cli')
+      const malformed = await runBuiltCliViaPowerShell(userDataPath, [
+        'orchestration',
+        'send',
+        '--to',
+        'term_coord',
+        '--subject',
+        'bad completion',
+        '--type',
+        'worker_done',
+        '--payload',
+        `{taskId:${rejectedTask.id},dispatchId:${rejectedDispatch.id}}`,
+        '--json'
+      ])
+
+      expect(malformed.exitCode).toBe(1)
+      expect(malformed.stdout).toContain('Use --task-id and --dispatch-id')
+      expect(db.getTask(rejectedTask.id)?.status).toBe('dispatched')
+      expect(db.getInbox().filter((message) => message.subject === 'bad completion')).toHaveLength(
+        0
+      )
+
+      const resultTask = db.createTask({ spec: 'PowerShell result file' })
+      const resultFile = join(userDataPath, 'task-result.json')
+      writeFileSync(resultFile, '{\n  "filesModified": []\n}', 'utf8')
+      const resultUpdate = await runBuiltCliViaPowerShell(userDataPath, [
+        'orchestration',
+        'task-update',
+        '--id',
+        resultTask.id,
+        '--status',
+        'completed',
+        '--result-file',
+        resultFile,
+        '--json'
+      ])
+      expect(resultUpdate.exitCode, resultUpdate.stderr).toBe(0)
+      expect(db.getTask(resultTask.id)?.result).toBe('{"filesModified":[]}')
+
+      const unreadableTask = db.createTask({ spec: 'Unreadable result file' })
+      const unreadable = await runBuiltCliViaPowerShell(userDataPath, [
+        'orchestration',
+        'task-update',
+        '--id',
+        unreadableTask.id,
+        '--status',
+        'completed',
+        '--result-file',
+        join(userDataPath, 'missing.json'),
+        '--json'
+      ])
+      expect(unreadable.exitCode).toBe(1)
+      expect(db.getTask(unreadableTask.id)?.status).toBe('ready')
+
+      const malformedFile = join(userDataPath, 'malformed.json')
+      writeFileSync(malformedFile, '{completedBy:term_cli}', 'utf8')
+      const malformedTask = db.createTask({ spec: 'Malformed result file' })
+      const malformedResult = await runBuiltCliViaPowerShell(userDataPath, [
+        'orchestration',
+        'task-update',
+        '--id',
+        malformedTask.id,
+        '--status',
+        'completed',
+        '--result-file',
+        malformedFile,
+        '--json'
+      ])
+      expect(malformedResult.exitCode).toBe(1)
+      expect(db.getTask(malformedTask.id)?.status).toBe('ready')
+
+      const conflictTask = db.createTask({ spec: 'Conflicting result inputs' })
+      const conflict = await runBuiltCliViaPowerShell(userDataPath, [
+        'orchestration',
+        'task-update',
+        '--id',
+        conflictTask.id,
+        '--status',
+        'completed',
+        '--result',
+        '{}',
+        '--result-file',
+        resultFile,
+        '--json'
+      ])
+      expect(conflict.exitCode).toBe(1)
+      expect(db.getTask(conflictTask.id)?.status).toBe('ready')
+    } finally {
+      db.close()
+      await server.stop()
+      rmSync(userDataPath, { recursive: true, force: true })
     }
   }, 30_000)
 })

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -359,6 +359,20 @@ export class OrchestrationDb {
     return this.db.prepare('SELECT * FROM messages WHERE id = ?').get(id) as MessageRow | undefined
   }
 
+  getWorkerDoneMessageForDispatch(dispatchId: string): MessageRow | undefined {
+    const messages = this.db
+      .prepare("SELECT * FROM messages WHERE type = 'worker_done' ORDER BY sequence ASC")
+      .all() as MessageRow[]
+    return messages.find((message) => {
+      try {
+        const payload = JSON.parse(message.payload ?? '') as Record<string, unknown>
+        return payload.dispatchId === dispatchId
+      } catch {
+        return false
+      }
+    })
+  }
+
   markAsRead(ids: string[]): void {
     if (ids.length === 0) {
       return

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.ts
@@ -1,5 +1,9 @@
 import type { OrchestrationDb } from './db'
 import type { MessageRow } from './types'
+import {
+  isLifecycleMessageType,
+  validateLifecyclePayload
+} from '../../../shared/orchestration-lifecycle-payload'
 
 export type LifecycleReconciliationResult =
   | { action: 'ignored' }
@@ -9,6 +13,55 @@ export type LifecycleReconciliationResult =
 type LogFn = (msg: string) => void
 
 const noopLog: LogFn = () => {}
+
+export function getLifecycleMessageAuthorityError(
+  db: OrchestrationDb,
+  msg: Pick<MessageRow, 'type' | 'from_handle' | 'payload'>
+): string | undefined {
+  if (!isLifecycleMessageType(msg.type)) {
+    return undefined
+  }
+
+  const validation = validateLifecyclePayload(msg.type, msg.payload ?? undefined)
+  if (!validation.ok) {
+    return validation.message
+  }
+
+  const { taskId, dispatchId } = validation.payload
+  const task = db.getTask(taskId)
+  if (!task) {
+    return `${msg.type} references unknown task ${taskId}`
+  }
+
+  const dispatch = db.getDispatchContextById(dispatchId)
+  if (!dispatch) {
+    return `${msg.type} references unknown dispatch ${dispatchId}`
+  }
+  if (dispatch.task_id !== taskId) {
+    return `${msg.type} dispatch ${dispatchId} belongs to ${dispatch.task_id}, not ${taskId}`
+  }
+  if (dispatch.assignee_handle !== msg.from_handle) {
+    return `${msg.type} for dispatch ${dispatchId} came from ${msg.from_handle}, expected ${dispatch.assignee_handle ?? '<unknown>'}`
+  }
+
+  if (db.getDispatchContext(taskId)?.id !== dispatchId) {
+    return `${msg.type} references stale dispatch ${dispatchId}`
+  }
+  if (
+    msg.type === 'worker_done' &&
+    dispatch.status === 'completed' &&
+    task.status === 'completed'
+  ) {
+    return undefined
+  }
+  if (dispatch.status !== 'dispatched') {
+    return `${msg.type} references inactive dispatch ${dispatchId}`
+  }
+  if (task.status !== 'dispatched') {
+    return `${msg.type} references stale dispatch ${dispatchId}`
+  }
+  return undefined
+}
 
 function parseObjectPayload(msg: MessageRow, onInvalidJson: () => void): Record<string, unknown> {
   if (!msg.payload) {

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -253,20 +253,117 @@ describe('orchestration RPC methods', () => {
       expect(db.getInbox(100)).toHaveLength(0)
     })
 
-    it('continues to send worker_done to a concrete terminal handle', async () => {
+    it('sends an authorized worker_done to a concrete terminal handle', async () => {
       setup()
+      const task = db.createTask({ spec: 'concrete completion' })
+      const dispatch = db.createDispatchContext(task.id, 'term_worker')
 
       const result = (await call('orchestration.send', {
         from: 'term_worker',
         to: 'term_coord',
         subject: 'done',
         type: 'worker_done',
-        payload: JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1' })
+        payload: JSON.stringify({ taskId: task.id, dispatchId: dispatch.id })
       })) as { message: { to_handle: string; type: string; payload: string | null } }
 
       expect(result.message.to_handle).toBe('term_coord')
       expect(result.message.type).toBe('worker_done')
-      expect(result.message.payload).toBe(JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1' }))
+      expect(result.message.payload).toBe(
+        JSON.stringify({ taskId: task.id, dispatchId: dispatch.id })
+      )
+    })
+
+    it('rejects malformed lifecycle JSON without inserting a message', async () => {
+      setup()
+
+      await expect(
+        call('orchestration.send', {
+          from: 'term_worker',
+          to: 'term_coord',
+          subject: 'done',
+          type: 'worker_done',
+          payload: '{taskId:task_1,dispatchId:ctx_1}'
+        })
+      ).rejects.toThrow(/Use --task-id and --dispatch-id/)
+
+      expect(db.getInbox(100)).toHaveLength(0)
+    })
+
+    it('rejects lifecycle payloads missing either authority identifier', async () => {
+      setup()
+
+      await expect(
+        call('orchestration.send', {
+          from: 'term_worker',
+          to: 'term_coord',
+          subject: 'alive',
+          type: 'heartbeat',
+          payload: JSON.stringify({ taskId: 'task_1' })
+        })
+      ).rejects.toThrow(/dispatchId must be a non-empty string/)
+
+      expect(db.getInbox(100)).toHaveLength(0)
+    })
+
+    it('rejects lifecycle messages from the wrong assignee without inserting a message', async () => {
+      setup()
+      const task = db.createTask({ spec: 'authority check' })
+      const dispatch = db.createDispatchContext(task.id, 'term_owner')
+
+      await expect(
+        call('orchestration.send', {
+          from: 'term_intruder',
+          to: 'term_coord',
+          subject: 'done',
+          type: 'worker_done',
+          payload: JSON.stringify({ taskId: task.id, dispatchId: dispatch.id })
+        })
+      ).rejects.toThrow(/came from term_intruder, expected term_owner/)
+
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getInbox(100)).toHaveLength(0)
+    })
+
+    it('rejects mismatched task and dispatch authority without inserting a message', async () => {
+      setup()
+      const claimedTask = db.createTask({ spec: 'claimed task' })
+      const actualTask = db.createTask({ spec: 'actual task' })
+      const dispatch = db.createDispatchContext(actualTask.id, 'term_worker')
+
+      await expect(
+        call('orchestration.send', {
+          from: 'term_worker',
+          to: 'term_coord',
+          subject: 'done',
+          type: 'worker_done',
+          payload: JSON.stringify({ taskId: claimedTask.id, dispatchId: dispatch.id })
+        })
+      ).rejects.toThrow(/belongs to .* not/)
+
+      expect(db.getTask(claimedTask.id)?.status).toBe('ready')
+      expect(db.getTask(actualTask.id)?.status).toBe('dispatched')
+      expect(db.getInbox(100)).toHaveLength(0)
+    })
+
+    it('rejects stale lifecycle authority without inserting a message', async () => {
+      setup()
+      const task = db.createTask({ spec: 'retried task' })
+      const staleDispatch = db.createDispatchContext(task.id, 'term_old')
+      db.failDispatch(staleDispatch.id, 'retry')
+      db.createDispatchContext(task.id, 'term_current')
+
+      await expect(
+        call('orchestration.send', {
+          from: 'term_old',
+          to: 'term_coord',
+          subject: 'late completion',
+          type: 'worker_done',
+          payload: JSON.stringify({ taskId: task.id, dispatchId: staleDispatch.id })
+        })
+      ).rejects.toThrow(/stale dispatch/)
+
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getInbox(100)).toHaveLength(0)
     })
 
     it('fans out @idle to only idle agents', async () => {
@@ -400,6 +497,66 @@ describe('orchestration RPC methods', () => {
       // Lock released — a new dispatch to the same terminal must succeed.
       const t2 = db.createTask({ spec: 'follow-up work' })
       expect(() => db.createDispatchContext(t2.id, 'term_worker')).not.toThrow()
+    })
+
+    it('keeps repeated authorized worker_done sends idempotent', async () => {
+      setup()
+      const task = db.createTask({ spec: 'idempotent completion' })
+      const dispatch = db.createDispatchContext(task.id, 'term_worker')
+      const deliver = vi
+        .spyOn(runtime, 'deliverPendingMessagesForHandle')
+        .mockImplementation(() => {})
+      const notify = vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+      const payload = JSON.stringify({ taskId: task.id, dispatchId: dispatch.id })
+
+      await call('orchestration.send', {
+        from: 'term_worker',
+        to: 'term_coord',
+        subject: 'done',
+        type: 'worker_done',
+        payload
+      })
+      const completedAt = db.getTask(task.id)?.completed_at
+      const result = db.getTask(task.id)?.result
+
+      await call('orchestration.send', {
+        from: 'term_worker',
+        to: 'term_coord',
+        subject: 'done again',
+        type: 'worker_done',
+        payload
+      })
+
+      expect(db.getTask(task.id)?.completed_at).toBe(completedAt)
+      expect(db.getTask(task.id)?.result).toBe(result)
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+      expect(db.getInbox().filter((message) => message.type === 'worker_done')).toHaveLength(1)
+      expect(deliver).toHaveBeenCalledTimes(1)
+      expect(notify).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects a completed worker_done after a newer dispatch exists', async () => {
+      setup()
+      const task = db.createTask({ spec: 'reopened task' })
+      const oldDispatch = db.createDispatchContext(task.id, 'term_old')
+      db.updateTaskStatus(task.id, 'completed', '{}')
+      db.updateTaskStatus(task.id, 'ready')
+      db.createDispatchContext(task.id, 'term_current')
+
+      await expect(
+        call('orchestration.send', {
+          from: 'term_old',
+          to: 'term_coord',
+          subject: 'late duplicate',
+          type: 'worker_done',
+          payload: JSON.stringify({ taskId: task.id, dispatchId: oldDispatch.id })
+        })
+      ).rejects.toThrow(/stale dispatch/)
+
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getInbox().filter((message) => message.subject === 'late duplicate')).toHaveLength(
+        0
+      )
     })
 
     it('records heartbeat when heartbeat is sent via send', async () => {
@@ -781,6 +938,9 @@ describe('orchestration RPC methods', () => {
 
     it('keeps waiting for requested types when an unrelated heartbeat arrives', async () => {
       setup()
+      const task = db.createTask({ spec: 'filtered lifecycle wait' })
+      const dispatch = db.createDispatchContext(task.id, 'worker')
+      const payload = JSON.stringify({ taskId: task.id, dispatchId: dispatch.id })
 
       const waitPromise = call('orchestration.check', {
         terminal: 'coord',
@@ -794,7 +954,8 @@ describe('orchestration RPC methods', () => {
         from: 'worker',
         to: 'coord',
         subject: 'alive',
-        type: 'heartbeat'
+        type: 'heartbeat',
+        payload
       })
 
       const early = await Promise.race([
@@ -807,7 +968,8 @@ describe('orchestration RPC methods', () => {
         from: 'worker',
         to: 'coord',
         subject: 'done',
-        type: 'worker_done'
+        type: 'worker_done',
+        payload
       })
 
       const result = await waitPromise
@@ -1012,7 +1174,23 @@ describe('orchestration RPC methods', () => {
       })) as { task: { status: string; result: string } }
 
       expect(result.task.status).toBe('completed')
-      expect(result.task.result).toBe('{"ok": true}')
+      expect(result.task.result).toBe('{"ok":true}')
+    })
+
+    it('rejects malformed task result JSON without updating the task', async () => {
+      setup()
+      const task = db.createTask({ spec: 'work' })
+
+      await expect(
+        call('orchestration.taskUpdate', {
+          id: task.id,
+          status: 'completed',
+          result: '{completedBy:term_worker}'
+        })
+      ).rejects.toThrow(/Task result must be valid JSON/)
+
+      expect(db.getTask(task.id)?.status).toBe('ready')
+      expect(db.getTask(task.id)?.result).toBeNull()
     })
 
     it('completion frees the active dispatch context', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -1,13 +1,20 @@
 /* eslint-disable max-lines -- Why: RPC method definitions co-locate param schemas with handlers; splitting by method would scatter the shared enums and Zod transforms without reducing complexity. */
 import { z } from 'zod'
-import { defineMethod, type RpcMethod } from '../core'
+import { defineMethod, InvalidArgumentError, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, OptionalBoolean, requiredString } from '../schemas'
 import type { MessageType, MessagePriority, TaskStatus } from '../../orchestration/db'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { formatMessageBanner } from '../../orchestration/formatter'
 import { isGroupAddress, resolveGroupAddress } from '../../orchestration/groups'
-import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
+import {
+  getLifecycleMessageAuthorityError,
+  reconcileLifecycleMessage
+} from '../../orchestration/lifecycle-reconciliation'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
+import {
+  isLifecycleMessageType,
+  validateLifecyclePayload
+} from '../../../../shared/orchestration-lifecycle-payload'
 
 const MESSAGE_TYPES: MessageType[] = [
   'status',
@@ -57,19 +64,29 @@ const SendParams = z
     devMode: OptionalBoolean
   })
   .superRefine((params, ctx) => {
-    if (
-      (params.type !== 'worker_done' && params.type !== 'heartbeat') ||
-      !isGroupAddress(params.to)
-    ) {
+    if (!isLifecycleMessageType(params.type)) {
       return
     }
-    // Why: dispatch lifecycle messages are authority/liveness signals for one
-    // coordinator. Fanout creates lifecycle mail in unrelated terminals.
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: getLifecycleGroupRecipientError(params.type),
-      path: ['to']
-    })
+
+    if (isGroupAddress(params.to)) {
+      // Why: dispatch lifecycle messages are authority/liveness signals for one
+      // coordinator. Fanout creates lifecycle mail in unrelated terminals.
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: getLifecycleGroupRecipientError(params.type),
+        path: ['to']
+      })
+      return
+    }
+
+    const validation = validateLifecyclePayload(params.type, params.payload)
+    if (!validation.ok) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: validation.message,
+        path: ['payload']
+      })
+    }
   })
 
 const CheckParams = z.object({
@@ -113,6 +130,24 @@ const TaskListParams = z.object({
   ready: OptionalBoolean
 })
 
+const OptionalTaskResult = z
+  .string()
+  .optional()
+  .transform((value, ctx) => {
+    if (value === undefined) {
+      return undefined
+    }
+    try {
+      return JSON.stringify(JSON.parse(value))
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Task result must be valid JSON.'
+      })
+      return z.NEVER
+    }
+  })
+
 const TaskUpdateParams = z.object({
   id: requiredString('Missing --id'),
   status: z
@@ -128,7 +163,7 @@ const TaskUpdateParams = z.object({
         message: 'Missing --status'
       })
     ),
-  result: OptionalString
+  result: OptionalTaskResult
 })
 
 const DispatchParams = z.object({
@@ -186,6 +221,26 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       const from = params.from ?? 'unknown'
 
       if (!isGroupAddress(params.to)) {
+        if (isLifecycleMessageType(params.type)) {
+          const authorityError = getLifecycleMessageAuthorityError(db, {
+            type: params.type,
+            from_handle: from,
+            payload: params.payload ?? null
+          })
+          if (authorityError) {
+            throw new InvalidArgumentError(authorityError)
+          }
+          if (params.type === 'worker_done') {
+            const payload = validateLifecyclePayload(params.type, params.payload)
+            if (payload.ok) {
+              const existing = db.getWorkerDoneMessageForDispatch(payload.payload.dispatchId)
+              if (existing) {
+                return { message: existing, duplicate: true }
+              }
+            }
+          }
+        }
+
         // Point-to-point — existing single-recipient behavior
         const msg = db.insertMessage({
           from,

--- a/src/shared/orchestration-lifecycle-payload.test.ts
+++ b/src/shared/orchestration-lifecycle-payload.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { validateLifecyclePayload } from './orchestration-lifecycle-payload'
+
+describe('validateLifecyclePayload', () => {
+  it('accepts worker completion metadata and preserves forward-compatible fields', () => {
+    const result = validateLifecyclePayload(
+      'worker_done',
+      JSON.stringify({
+        taskId: 'task_1',
+        dispatchId: 'ctx_1',
+        filesModified: ['src/a.ts'],
+        reportPath: 'reports/done.md',
+        extensionField: true
+      })
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      payload: {
+        taskId: 'task_1',
+        dispatchId: 'ctx_1',
+        filesModified: ['src/a.ts'],
+        reportPath: 'reports/done.md',
+        extensionField: true
+      }
+    })
+  })
+
+  it.each([
+    [undefined, /JSON object payload is required/],
+    ['{taskId:task_1}', /expected valid JSON/],
+    ['[]', /expected a JSON object/],
+    [JSON.stringify({ dispatchId: 'ctx_1' }), /taskId must be a non-empty string/],
+    [JSON.stringify({ taskId: 'task_1' }), /dispatchId must be a non-empty string/],
+    [
+      JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1', filesModified: 'src/a.ts' }),
+      /filesModified must be an array of strings/
+    ]
+  ])('rejects invalid lifecycle payload %s', (payload, message) => {
+    expect(validateLifecyclePayload('worker_done', payload)).toEqual({
+      ok: false,
+      message: expect.stringMatching(message)
+    })
+  })
+
+  it('validates heartbeat phase type', () => {
+    expect(
+      validateLifecyclePayload(
+        'heartbeat',
+        JSON.stringify({ taskId: 'task_1', dispatchId: 'ctx_1', phase: 2 })
+      )
+    ).toEqual({
+      ok: false,
+      message: expect.stringMatching(/phase must be a string/)
+    })
+  })
+})

--- a/src/shared/orchestration-lifecycle-payload.ts
+++ b/src/shared/orchestration-lifecycle-payload.ts
@@ -1,0 +1,67 @@
+export type LifecycleMessageType = 'worker_done' | 'heartbeat'
+
+export type LifecyclePayload = Record<string, unknown> & {
+  taskId: string
+  dispatchId: string
+}
+
+export type LifecyclePayloadValidation =
+  | { ok: true; payload: LifecyclePayload }
+  | { ok: false; message: string }
+
+export function isLifecycleMessageType(type: string | undefined): type is LifecycleMessageType {
+  return type === 'worker_done' || type === 'heartbeat'
+}
+
+function invalidPayload(type: LifecycleMessageType, detail: string): LifecyclePayloadValidation {
+  return {
+    ok: false,
+    message:
+      `Invalid ${type} payload: ${detail}. ` +
+      'Use --task-id and --dispatch-id instead of raw --payload JSON.'
+  }
+}
+
+export function validateLifecyclePayload(
+  type: LifecycleMessageType,
+  rawPayload: string | undefined
+): LifecyclePayloadValidation {
+  if (!rawPayload) {
+    return invalidPayload(type, 'a JSON object payload is required')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(rawPayload)
+  } catch {
+    return invalidPayload(type, 'expected valid JSON')
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return invalidPayload(type, 'expected a JSON object')
+  }
+
+  const payload = parsed as Record<string, unknown>
+  if (typeof payload.taskId !== 'string' || payload.taskId.trim().length === 0) {
+    return invalidPayload(type, 'taskId must be a non-empty string')
+  }
+  if (typeof payload.dispatchId !== 'string' || payload.dispatchId.trim().length === 0) {
+    return invalidPayload(type, 'dispatchId must be a non-empty string')
+  }
+
+  if (
+    payload.filesModified !== undefined &&
+    (!Array.isArray(payload.filesModified) ||
+      !payload.filesModified.every((file) => typeof file === 'string'))
+  ) {
+    return invalidPayload(type, 'filesModified must be an array of strings')
+  }
+  if (payload.reportPath !== undefined && typeof payload.reportPath !== 'string') {
+    return invalidPayload(type, 'reportPath must be a string')
+  }
+  if (payload.phase !== undefined && typeof payload.phase !== 'string') {
+    return invalidPayload(type, 'phase must be a string')
+  }
+
+  return { ok: true, payload: payload as LifecyclePayload }
+}


### PR DESCRIPTION
## Summary

- Reject malformed, unauthorized, and stale orchestration lifecycle messages before they mutate task state.
- Make repeated `worker_done` delivery idempotent and prevent older dispatch completions from re-entering the coordinator inbox.
- Add validated `task-update --result-file` support and teach agents to use PowerShell-safe structured lifecycle flags.

Root cause: the orchestration skill demonstrated a raw JSON payload command that PowerShell could quote-strip. The runtime accepted that lifecycle message too late in the flow, leaving the worker task unreconciled and allowing malformed or repeated completions into the audit stream.

User impact: Windows orchestration workers can now report lifecycle state with structured flags, malformed completions fail without state or inbox mutation, and safe retries do not duplicate coordinator mail.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (targeted oxlint and the max-lines ratchet passed)
- [ ] `pnpm typecheck` (`typecheck:node` and `typecheck:cli` passed; web was not affected)
- [ ] `pnpm test` (focused suite passed: 5 files, 167 tests)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Additional validation:

- Real Windows PowerShell subprocess coverage for structured completion, quote-stripped malformed JSON, result-file success, unreadable/malformed files, and inline/file conflicts.
- Repository and installed orchestration skills passed `quick_validate.py`.
- `git diff --check` and the repository pre-commit lint/format hook passed.

## AI Review Report

Two independent read-only AI reviews were run. The first found no blocker and flagged stale/duplicate completion handling plus missing end-to-end `--result-file` coverage; both findings were fixed and retested. The follow-up review verified latest-dispatch enforcement, retry idempotency, PowerShell result paths, and the focused test evidence, with no blocker remaining.

Cross-platform review explicitly considered macOS, Linux, and Windows. The changed runtime validation uses platform-neutral TypeScript/Node behavior. Windows PowerShell shell quoting and file paths are exercised end to end. No keyboard shortcuts, UI labels, renderer behavior, or Electron-specific platform behavior changed.

## Security Audit

Review covered lifecycle payload parsing, RPC/IPC input validation, sender/task/dispatch authority, stale-message rejection, duplicate delivery, explicit result-file path handling, and failure atomicity. Malformed input is rejected before message insertion or task mutation. No dependencies, credentials, secrets, authentication behavior, or command execution were added.

Follow-up: a direct RPC client can still address an otherwise valid lifecycle message to the wrong concrete coordinator handle because dispatch rows do not persist coordinator identity. Fully binding recipient authority requires a dispatch-schema migration and is intentionally deferred from this no-migration fix.

## Notes

This PR adds no database migration. Existing dispatch storage remains compatible.

## ELI5

Orchestration lifecycle messages could be malformed, unauthorized, or stale and still change task state, and PowerShell quoting could break structured flags. Messages are validated first, repeated worker_done is idempotent, and agents get safer PowerShell-friendly lifecycle flags.
