### PR TITLE
fix(preflight): do not pin empty WSL/local agent detection (#8366)

### DIFF
--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -93,6 +93,46 @@ describe('detectWslCommandsOnPath', () => {
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
     expect(found).toEqual(new Set())
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries once on ETIMEDOUT cold-start and returns the second probe result', async () => {
+    const timeoutError = Object.assign(new Error('Timed out running wsl.exe'), {
+      code: 'ETIMEDOUT'
+    })
+    execFileAsyncMock.mockRejectedValueOnce(timeoutError).mockResolvedValueOnce({
+      stdout: '__ORCA_AGENT_PATH__grok\t/home/user/.local/bin/grok\n',
+      stderr: ''
+    })
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['grok'])
+
+    expect(found).toEqual(new Set(['grok']))
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries once when the child is killed by the timeout path', async () => {
+    const killedError = Object.assign(new Error('spawn wsl.exe ETIMEDOUT'), {
+      killed: true
+    })
+    execFileAsyncMock.mockRejectedValueOnce(killedError).mockResolvedValueOnce({
+      stdout: '__ORCA_AGENT_PATH__claude\t/usr/bin/claude\n',
+      stderr: ''
+    })
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    expect(found).toEqual(new Set(['claude']))
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry non-timeout probe failures', async () => {
+    execFileAsyncMock.mockRejectedValue(new Error("zsh:1: parse error near `done'"))
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    expect(found).toEqual(new Set())
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('skips the probe entirely when no commands are requested', async () => {

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -123,6 +123,45 @@ describe('detectWslCommandsOnPath', () => {
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
     expect(found).toEqual(new Set())
+    expect(runWslProcessMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries once on a timed-out cold-start and returns the second probe result', async () => {
+    runWslProcessMock
+      .mockResolvedValueOnce({
+        environmentResolved: true,
+        code: null,
+        stdout: '',
+        stderr: '',
+        timedOut: true
+      })
+      .mockResolvedValueOnce({
+        environmentResolved: true,
+        code: 0,
+        stdout: '__ORCA_AGENT_PATH__grok\t/home/user/.local/bin/grok\n',
+        stderr: '',
+        timedOut: false
+      })
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['grok'])
+
+    expect(found).toEqual(new Set(['grok']))
+    expect(runWslProcessMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry a non-timeout probe failure', async () => {
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: true,
+      code: 1,
+      stdout: '',
+      stderr: "zsh:1: parse error near `done'",
+      timedOut: false
+    })
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    expect(found).toEqual(new Set())
+    expect(runWslProcessMock).toHaveBeenCalledTimes(1)
   })
 
   it('skips the probe entirely when no commands are requested', async () => {

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -43,10 +43,40 @@ export async function detectWslCommandsOnPath(
     // Why: WSL cold-start plus many parallel wsl.exe probes can timeout and
     // cache an empty result. One probe through the distro user's login shell
     // matches zsh/bash PATH customizations from their normal terminals.
-    const { stdout } = await execWslAgentDetectionCommand(wslTarget, script)
+    // One ETIMEDOUT/killed retry absorbs a single cold-start miss without
+    // turning every hard shell failure into a multi-second hang.
+    const { stdout } = await execWslAgentDetectionCommandWithColdStartRetry(wslTarget, script)
     return parseWslDetectedCommands(stdout)
   } catch {
     return new Set()
+  }
+}
+
+function isWslAgentDetectionTimeoutError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+  const code = (error as { code?: unknown }).code
+  // Why: Node's execFile timeout sets code=ETIMEDOUT; our Promise.race wrapper
+  // does the same. A killed child may surface as 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
+  // rarely, but the kill-signal path commonly uses code null with killed=true.
+  if (code === 'ETIMEDOUT') {
+    return true
+  }
+  return (error as { killed?: unknown }).killed === true
+}
+
+async function execWslAgentDetectionCommandWithColdStartRetry(
+  target: WslPreflightTarget,
+  command: string
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execWslAgentDetectionCommand(target, command)
+  } catch (error) {
+    if (!isWslAgentDetectionTimeoutError(error)) {
+      throw error
+    }
+    return await execWslAgentDetectionCommand(target, command)
   }
 }
 

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -57,9 +57,10 @@ function isWslAgentDetectionTimeoutError(error: unknown): boolean {
     return false
   }
   const code = (error as { code?: unknown }).code
-  // Why: Node's execFile timeout sets code=ETIMEDOUT; our Promise.race wrapper
-  // does the same. A killed child may surface as 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
-  // rarely, but the kill-signal path commonly uses code null with killed=true.
+  // Why: the two cold-start timeout paths surface differently — the Promise.race
+  // wrapper rejects with code=ETIMEDOUT, while Node's execFile `timeout` kills the
+  // child (code=null, killed=true). Retry on both; a real shell failure (non-zero
+  // exit / ENOENT) matches neither and propagates without a wasted retry.
   if (code === 'ETIMEDOUT') {
     return true
   }

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -44,16 +44,10 @@ export async function detectWslCommandsOnPath(
   ].join('\n')
 
   try {
-    // Why probe: the cached login PATH gives the user's real nvm/mise/asdf PATH
-    // with no shell in the loop, so there is no rc/motd banner to land in stdout.
-    const result = await runWslProcess({
-      distro: wslTarget.distro,
-      loginPath: 'preferred',
-      script,
-      // POSIX `command -v` loop; declared because the payload is opaque here.
-      shell: 'sh',
-      timeoutMs: WSL_AGENT_DETECTION_TIMEOUT_MS
-    })
+    // Why: WSL cold-start plus many parallel wsl.exe probes can timeout and
+    // cache an empty result. One timedOut retry absorbs a single miss without
+    // turning every hard shell failure into a multi-second hang.
+    const result = await runWslAgentDetectionWithColdStartRetry(wslTarget, script)
     // runProcess resolves on a timeout and on a non-zero exit, so partial
     // stdout would otherwise read as a complete answer.
     if (result.timedOut || result.code !== 0) {
@@ -63,6 +57,28 @@ export async function detectWslCommandsOnPath(
   } catch {
     return new Set()
   }
+}
+
+async function runWslAgentDetectionWithColdStartRetry(
+  wslTarget: WslPreflightTarget,
+  script: string
+) {
+  const runOnce = () =>
+    runWslProcess({
+      distro: wslTarget.distro,
+      loginPath: 'preferred',
+      script,
+      // POSIX `command -v` loop; declared because the payload is opaque here.
+      shell: 'sh',
+      timeoutMs: WSL_AGENT_DETECTION_TIMEOUT_MS
+    })
+  const first = await runOnce()
+  // Why: runWslProcess resolves on timeout (timedOut=true) instead of throwing
+  // ETIMEDOUT; retry that miss once, not a non-zero shell failure.
+  if (!first.timedOut) {
+    return first
+  }
+  return await runOnce()
 }
 
 function shellQuote(value: string): string {

--- a/src/renderer/src/hooks/useDetectedAgents.test.tsx
+++ b/src/renderer/src/hooks/useDetectedAgents.test.tsx
@@ -253,6 +253,45 @@ describe('useDetectedAgents (unresolved target)', () => {
   })
 })
 
+describe('useDetectedAgents (local call site)', () => {
+  it('fires local detection once on mount and does not thrash after an empty result', async () => {
+    detectLocalAgents.mockReset().mockResolvedValue([])
+    const root = await renderProbe({ kind: 'local' })
+
+    expect(detectLocalAgents).toHaveBeenCalledTimes(1)
+    expect(useAppStore.getState().detectedAgentIds).toEqual([])
+
+    await act(async () => {
+      root.render(createElement(HookProbe, { target: { kind: 'local' } }))
+    })
+    await flushEffects()
+
+    // Same mounted surface: empty remount-retry marks once; re-render must not thrash.
+    expect(detectLocalAgents).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a cached empty local result when the launch surface is reopened', async () => {
+    // Why: WSL/local cold-start soft-fails to [] (#8366). Reopening TabBar /
+    // QuickLaunch must re-enter ensureDetectedAgents without a project switch.
+    detectLocalAgents.mockReset().mockResolvedValue([])
+    const firstRoot = await renderProbe({ kind: 'local' })
+
+    expect(detectLocalAgents).toHaveBeenCalledTimes(1)
+    expect(useAppStore.getState().detectedAgentIds).toEqual([])
+
+    await act(async () => {
+      firstRoot.unmount()
+    })
+    roots.splice(roots.indexOf(firstRoot), 1)
+    detectLocalAgents.mockResolvedValueOnce(['grok'])
+
+    await renderProbe({ kind: 'local' })
+
+    expect(detectLocalAgents).toHaveBeenCalledTimes(2)
+    expect(useAppStore.getState().detectedAgentIds).toEqual(['grok'])
+  })
+})
+
 describe('useDetectedAgents (runtime call site)', () => {
   it('distinguishes an initial remote failure from the pre-effect loading state', async () => {
     runtimeEnvironmentCall.mockRejectedValue(new Error('runtime disconnected'))

--- a/src/renderer/src/hooks/useDetectedAgents.test.tsx
+++ b/src/renderer/src/hooks/useDetectedAgents.test.tsx
@@ -290,6 +290,90 @@ describe('useDetectedAgents (local call site)', () => {
     expect(detectLocalAgents).toHaveBeenCalledTimes(2)
     expect(useAppStore.getState().detectedAgentIds).toEqual(['grok'])
   })
+
+  it('retries each distinct cached-empty local context once on the same surface', async () => {
+    detectLocalAgents.mockReset().mockResolvedValue([])
+    useAppStore.setState({
+      projects: [
+        {
+          id: 'repo-a',
+          localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+        },
+        {
+          id: 'repo-b',
+          localWindowsRuntimePreference: { kind: 'wsl', distro: 'Debian' }
+        }
+      ],
+      repos: [
+        {
+          id: 'repo-a',
+          path: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\a',
+          displayName: 'WSL A',
+          badgeColor: '#000000',
+          addedAt: 0
+        },
+        {
+          id: 'repo-b',
+          path: '\\\\wsl.localhost\\Debian\\home\\alice\\b',
+          displayName: 'WSL B',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: {
+        'repo-a': [
+          {
+            id: 'wt-a',
+            repoId: 'repo-a',
+            path: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\a',
+            displayName: 'main'
+          }
+        ],
+        'repo-b': [
+          {
+            id: 'wt-b',
+            repoId: 'repo-b',
+            path: '\\\\wsl.localhost\\Debian\\home\\alice\\b',
+            displayName: 'main'
+          }
+        ]
+      },
+      localDetectedAgentIdsByContext: {
+        'repo-a:wsl:Ubuntu': [],
+        'repo-b:wsl:Debian': []
+      },
+      isDetectingLocalAgentsByContext: {
+        'repo-a:wsl:Ubuntu': false,
+        'repo-b:wsl:Debian': false
+      }
+    } as never)
+
+    const targetA = {
+      kind: 'local',
+      worktreeId: 'wt-a',
+      contextKey: 'repo-a:wsl:Ubuntu'
+    } as AgentDetectionTarget
+    const targetB = {
+      kind: 'local',
+      worktreeId: 'wt-b',
+      contextKey: 'repo-b:wsl:Debian'
+    } as AgentDetectionTarget
+
+    const root = await renderProbe(targetA)
+    expect(detectLocalAgents).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      root.render(createElement(HookProbe, { target: targetB }))
+    })
+    await flushEffects()
+    expect(detectLocalAgents).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      root.render(createElement(HookProbe, { target: targetA }))
+    })
+    await flushEffects()
+    expect(detectLocalAgents).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('useDetectedAgents (runtime call site)', () => {

--- a/src/renderer/src/hooks/useDetectedAgents.ts
+++ b/src/renderer/src/hooks/useDetectedAgents.ts
@@ -54,6 +54,10 @@ export function useDetectedAgents(
 ): UseDetectedAgentsResult {
   const target = normalizeAgentDetectionTarget(connectionId)
   const observedRemoteTargetKeysRef = useRef<Set<string>>(new Set())
+  // Why: remounted local launch surfaces (TabBar/QuickLaunch) must re-probe after
+  // a cold-start empty [] without requiring a project/context switch (#8366).
+  // null = this mount has not yet claimed the local empty-retry slot.
+  const localEmptyRetryKeyRef = useRef<string | null>(null)
   // Why: undefined means "store not yet hydrated" — we don't know if the
   // worktree is local or remote yet. This prevents flashing local agents for
   // remote worktrees during hydration.
@@ -169,7 +173,15 @@ export function useDetectedAgents(
         void state.ensureRuntimeDetectedAgents(targetId)
       }
     } else {
+      // Why: local/WSL cold-start soft-fails to [] (#8366). Store non-sticky empty
+      // is not enough — TabBar/QuickLaunch only re-enter via this hook, so mirror
+      // SSH/runtime: one fresh probe when a launch surface remounts on [].
+      const emptyRetryKey = 'local'
       if (detectedIds === null) {
+        localEmptyRetryKeyRef.current = emptyRetryKey
+        void state.ensureDetectedAgents(localWorktreeId)
+      } else if (detectedIds.length === 0 && localEmptyRetryKeyRef.current !== emptyRetryKey) {
+        localEmptyRetryKeyRef.current = emptyRetryKey
         void state.ensureDetectedAgents(localWorktreeId)
       }
     }

--- a/src/renderer/src/hooks/useDetectedAgents.ts
+++ b/src/renderer/src/hooks/useDetectedAgents.ts
@@ -56,8 +56,9 @@ export function useDetectedAgents(
   const observedRemoteTargetKeysRef = useRef<Set<string>>(new Set())
   // Why: remounted local launch surfaces (TabBar/QuickLaunch) must re-probe after
   // a cold-start empty [] without requiring a project/context switch (#8366).
-  // null = this mount has not yet claimed the local empty-retry slot.
-  const localEmptyRetryKeyRef = useRef<string | null>(null)
+  // Observe each local context once so A → B still retries B, and A → B → A
+  // does not thrash. A new mount still has an empty set, so remount retries.
+  const observedLocalEmptyRetryKeysRef = useRef<Set<string>>(new Set())
   // Why: undefined means "store not yet hydrated" — we don't know if the
   // worktree is local or remote yet. This prevents flashing local agents for
   // remote worktrees during hydration.
@@ -175,13 +176,14 @@ export function useDetectedAgents(
     } else {
       // Why: local/WSL cold-start soft-fails to [] (#8366). Store non-sticky empty
       // is not enough — TabBar/QuickLaunch only re-enter via this hook, so mirror
-      // SSH/runtime: one fresh probe when a launch surface remounts on [].
-      const emptyRetryKey = 'local'
+      // SSH/runtime: one fresh probe per observed local context, including remount.
+      const emptyRetryKey = `local:${localContextKey ?? ''}:${localWorktreeId ?? ''}`
+      const isNewLocalContext = !observedLocalEmptyRetryKeysRef.current.has(emptyRetryKey)
       if (detectedIds === null) {
-        localEmptyRetryKeyRef.current = emptyRetryKey
+        observedLocalEmptyRetryKeysRef.current.add(emptyRetryKey)
         void state.ensureDetectedAgents(localWorktreeId)
-      } else if (detectedIds.length === 0 && localEmptyRetryKeyRef.current !== emptyRetryKey) {
-        localEmptyRetryKeyRef.current = emptyRetryKey
+      } else if (detectedIds.length === 0 && isNewLocalContext) {
+        observedLocalEmptyRetryKeysRef.current.add(emptyRetryKey)
         void state.ensureDetectedAgents(localWorktreeId)
       }
     }

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -453,6 +453,35 @@ describe('createDetectedAgentsSlice WSL context', () => {
     expect(detectAgents).toHaveBeenCalledTimes(2)
   })
 
+  it('re-runs local detection after an empty result instead of pinning it', async () => {
+    const store = createTestStore({
+      repos: [makeRepo({ id: 'repo-1', path: 'C:\\repo' })],
+      activeRepoId: 'repo-1',
+      activeWorktreeId: null
+    })
+    // Why: detectPromise / detectedContextKey are module-scoped and can leak
+    // from earlier cases with the same local preflight context.
+    store.getState().clearLocalDetectedAgents()
+    // An empty [] is truthy, so a prior "no agents found" (including WSL
+    // cold-start soft-fails) must not short-circuit later probes.
+    detectAgents
+      .mockReset()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(['grok'])
+      .mockResolvedValue(['claude'])
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual([])
+    expect(store.getState().detectedAgentIds).toEqual([])
+    expect(detectAgents).toHaveBeenCalledTimes(1)
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual(['grok'])
+    expect(detectAgents).toHaveBeenCalledTimes(2)
+    expect(store.getState().detectedAgentIds).toEqual(['grok'])
+    // Why: module-scoped detectPromise would otherwise short-circuit the next
+    // case that shares the same local preflight context.
+    store.getState().clearLocalDetectedAgents()
+  })
+
   it('ignores in-flight local detection results after a project runtime switch', async () => {
     let resolveDetection: (agents: string[]) => void = () => {}
     detectAgents.mockReturnValueOnce(

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -454,6 +454,35 @@ describe('createDetectedAgentsSlice WSL context', () => {
     expect(detectAgents).toHaveBeenCalledTimes(2)
   })
 
+  it('re-runs local detection after an empty result instead of pinning it', async () => {
+    const store = createTestStore({
+      repos: [makeRepo({ id: 'repo-1', path: 'C:\\repo' })],
+      activeRepoId: 'repo-1',
+      activeWorktreeId: null
+    })
+    // Why: detectPromise / detectedContextKey are module-scoped and can leak
+    // from earlier cases with the same local preflight context.
+    store.getState().clearLocalDetectedAgents()
+    // An empty [] is truthy, so a prior "no agents found" (including WSL
+    // cold-start soft-fails) must not short-circuit later probes.
+    detectAgents
+      .mockReset()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(['grok'])
+      .mockResolvedValue(['claude'])
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual([])
+    expect(store.getState().detectedAgentIds).toEqual([])
+    expect(detectAgents).toHaveBeenCalledTimes(1)
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual(['grok'])
+    expect(detectAgents).toHaveBeenCalledTimes(2)
+    expect(store.getState().detectedAgentIds).toEqual(['grok'])
+    // Why: module-scoped detectPromise would otherwise short-circuit the next
+    // case that shares the same local preflight context.
+    store.getState().clearLocalDetectedAgents()
+  })
+
   it('ignores in-flight local detection results after a project runtime switch', async () => {
     let resolveDetection: (agents: string[]) => void = () => {}
     detectAgents.mockReturnValueOnce(

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -454,35 +454,6 @@ describe('createDetectedAgentsSlice WSL context', () => {
     expect(detectAgents).toHaveBeenCalledTimes(2)
   })
 
-  it('re-runs local detection after an empty result instead of pinning it', async () => {
-    const store = createTestStore({
-      repos: [makeRepo({ id: 'repo-1', path: 'C:\\repo' })],
-      activeRepoId: 'repo-1',
-      activeWorktreeId: null
-    })
-    // Why: detectPromise / detectedContextKey are module-scoped and can leak
-    // from earlier cases with the same local preflight context.
-    store.getState().clearLocalDetectedAgents()
-    // An empty [] is truthy, so a prior "no agents found" (including WSL
-    // cold-start soft-fails) must not short-circuit later probes.
-    detectAgents
-      .mockReset()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(['grok'])
-      .mockResolvedValue(['claude'])
-
-    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual([])
-    expect(store.getState().detectedAgentIds).toEqual([])
-    expect(detectAgents).toHaveBeenCalledTimes(1)
-
-    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual(['grok'])
-    expect(detectAgents).toHaveBeenCalledTimes(2)
-    expect(store.getState().detectedAgentIds).toEqual(['grok'])
-    // Why: module-scoped detectPromise would otherwise short-circuit the next
-    // case that shares the same local preflight context.
-    store.getState().clearLocalDetectedAgents()
-  })
-
   it('ignores in-flight local detection results after a project runtime switch', async () => {
     let resolveDetection: (agents: string[]) => void = () => {}
     detectAgents.mockReturnValueOnce(

--- a/src/renderer/src/store/slices/local-detected-agent-state.test.ts
+++ b/src/renderer/src/store/slices/local-detected-agent-state.test.ts
@@ -219,4 +219,27 @@ describe('local detected agent context lifecycle', () => {
     expect(detectAgents).toHaveBeenCalledTimes(2)
     expect(store.getState().localDetectedAgentIdsByContext.host).toEqual(['claude'])
   })
+
+  it('re-runs local detection after an empty result instead of pinning it', async () => {
+    const store = createTestStore([makeRepo('repo-1')])
+    // Why: detectPromise / detectedContextKey are module-scoped and can leak
+    // from earlier cases with the same local preflight context.
+    store.getState().clearLocalDetectedAgents()
+    // An empty [] is truthy, so a prior "no agents found" (including WSL
+    // cold-start soft-fails) must not short-circuit later probes.
+    detectAgents
+      .mockReset()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(['grok'])
+      .mockResolvedValue(['claude'])
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual([])
+    expect(store.getState().detectedAgentIds).toEqual([])
+    expect(detectAgents).toHaveBeenCalledTimes(1)
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual(['grok'])
+    expect(detectAgents).toHaveBeenCalledTimes(2)
+    expect(store.getState().detectedAgentIds).toEqual(['grok'])
+    store.getState().clearLocalDetectedAgents()
+  })
 })

--- a/src/renderer/src/store/slices/local-detected-agent-state.ts
+++ b/src/renderer/src/store/slices/local-detected-agent-state.ts
@@ -37,7 +37,9 @@ export const createLocalDetectedAgentState: LocalDetectedAgentStateCreator = (se
         }
         return inflightRefresh
       }
-      if (existing != null && !failedDetectContextKeys.has(contextKey)) {
+      // Why: [] is truthy; WSL cold-start soft-fails must not pin an empty
+      // cache. Match remote/runtime non-sticky empty (#8366 / #8391).
+      if (existing?.length && !failedDetectContextKeys.has(contextKey)) {
         if (!isFloating) {
           detectedContextKey = contextKey
           const state = get()
@@ -148,7 +150,7 @@ export const createLocalDetectedAgentState: LocalDetectedAgentStateCreator = (se
       const context = getLocalAgentPreflightContext(get(), undefined, undefined, worktreeId)
       const contextKey = localPreflightContextKey(context)
       const cached = get().localDetectedAgentIdsByContext[contextKey]
-      const hadUsableCache = cached != null && !failedDetectContextKeys.has(contextKey)
+      const hadUsableCache = Boolean(cached?.length) && !failedDetectContextKeys.has(contextKey)
       const requestGeneration = localDetectionGeneration
       const exposeInflightToLegacy = (): void => {
         if (!isFloating) {


### PR DESCRIPTION
An empty local/WSL agent-detection result no longer permanently suppresses later probes. Retry one timed-out WSL cold-start probe, retain the single attempt for non-timeout failures, and allow an empty local cache to be refreshed when a launch surface opens again. Each mounted surface retries each distinct local context once, so A -> B probes B while A -> B -> A does not loop. Closes #8366; #8336 remains independent and #8110 is outside this fix.

The rebase preserves current per-context caches, in-flight deduplication, stale-result fencing, SSH/runtime detection branches, and the current WSL process wrapper. Codex found the first candidate's constant local retry key would suppress the first retry in context B; Cursor added the A/B/A regression and corrected the key. The new empty-cache store test moved to the existing local-state test module to respect max-lines. Main's existing assertions are unchanged.

Validation: Cursor and Codex each passed the final 68 tests across 4 files, covering WSL timeout behavior, local caches and the rendered React hook harness. Node/Web non-composite typechecks and changed-file lint/format passed. No live Windows/WSL/SSH or rendered Orca Electron session was exercised.

Full repository suite/build and default composite typechecks were not run for this candidate. Known baseline TS2883 is not treated as passing; only the explicit non-composite checks above are claimed.

Cursor reviewed the final candidate; Codex independently reviewed the diff and raw checks. Reviewed commit: `4d49dcff6ceeb7763492d1a35b9c4477a506186b`; rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`.
