### PR TITLE
fix(resource-manager): sample memory from active runtime environment

### DIFF
--- a/src/main/ipc/memory.test.ts
+++ b/src/main/ipc/memory.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { collectMemorySnapshotMock, callRuntimeEnvironmentMock, handleMock, getPathMock } =
+  vi.hoisted(() => ({
+    collectMemorySnapshotMock: vi.fn(),
+    callRuntimeEnvironmentMock: vi.fn(),
+    handleMock: vi.fn(),
+    getPathMock: vi.fn(() => '/tmp/orca-user-data')
+  }))
+
+vi.mock('electron', () => ({
+  app: { getPath: getPathMock },
+  ipcMain: {
+    handle: handleMock
+  }
+}))
+
+vi.mock('../memory/collector', () => ({
+  collectMemorySnapshot: collectMemorySnapshotMock
+}))
+
+vi.mock('./runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: callRuntimeEnvironmentMock
+}))
+
+import { registerMemoryHandlers } from './memory'
+
+describe('memory:getSnapshot', () => {
+  beforeEach(() => {
+    handleMock.mockReset()
+    collectMemorySnapshotMock.mockReset()
+    callRuntimeEnvironmentMock.mockReset()
+    getPathMock.mockReturnValue('/tmp/orca-user-data')
+  })
+
+  function getHandler(): () => Promise<unknown> {
+    registerMemoryHandlers({
+      getSettings: () => ({ activeRuntimeEnvironmentId: null })
+    } as never)
+    const entry = handleMock.mock.calls.find((call) => call[0] === 'memory:getSnapshot')
+    expect(entry).toBeTruthy()
+    return entry![1] as () => Promise<unknown>
+  }
+
+  it('uses the local collector when no runtime environment is focused', async () => {
+    const localSnap = { collectedAt: 1, worktrees: [] }
+    collectMemorySnapshotMock.mockResolvedValue(localSnap)
+    const handler = getHandler()
+    await expect(handler()).resolves.toBe(localSnap)
+    expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
+    expect(collectMemorySnapshotMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('proxies diagnostics.memory to the active runtime environment', async () => {
+    handleMock.mockReset()
+    const remoteSnap = {
+      collectedAt: 99,
+      worktrees: [
+        {
+          worktreeId: 'r::/wt',
+          worktreeName: 'wt',
+          repoId: 'r',
+          repoName: 'r',
+          cpu: 12,
+          memory: 1000,
+          history: [],
+          sessions: []
+        }
+      ]
+    }
+    callRuntimeEnvironmentMock.mockResolvedValue({ ok: true, result: remoteSnap })
+    registerMemoryHandlers({
+      getSettings: () => ({ activeRuntimeEnvironmentId: 'env-lxc1' })
+    } as never)
+    const entry = handleMock.mock.calls.find((call) => call[0] === 'memory:getSnapshot')
+    const handler = entry![1] as () => Promise<unknown>
+    await expect(handler()).resolves.toEqual(remoteSnap)
+    expect(callRuntimeEnvironmentMock).toHaveBeenCalledWith(
+      '/tmp/orca-user-data',
+      'env-lxc1',
+      'diagnostics.memory',
+      null
+    )
+    expect(collectMemorySnapshotMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the local collector when the runtime call fails', async () => {
+    handleMock.mockReset()
+    const localSnap = { collectedAt: 2, worktrees: [] }
+    collectMemorySnapshotMock.mockResolvedValue(localSnap)
+    callRuntimeEnvironmentMock.mockRejectedValue(new Error('offline'))
+    registerMemoryHandlers({
+      getSettings: () => ({ activeRuntimeEnvironmentId: 'env-lxc1' })
+    } as never)
+    const entry = handleMock.mock.calls.find((call) => call[0] === 'memory:getSnapshot')
+    const handler = entry![1] as () => Promise<unknown>
+    await expect(handler()).resolves.toBe(localSnap)
+    expect(collectMemorySnapshotMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/memory.ts
+++ b/src/main/ipc/memory.ts
@@ -1,8 +1,43 @@
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
 import type { MemorySnapshot } from '../../shared/types'
 import type { Store } from '../persistence'
 import { collectMemorySnapshot } from '../memory/collector'
+import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
 
+function isMemorySnapshot(value: unknown): value is MemorySnapshot {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const record = value as Record<string, unknown>
+  return Array.isArray(record.worktrees) && typeof record.collectedAt === 'number'
+}
+
+/**
+ * Resource Manager memory samples.
+ *
+ * When a runtime environment is focused (e.g. LXC1 via Orca serve), the local
+ * Mac collector cannot see remote PTYs — by design it only samples this host.
+ * Proxy `diagnostics.memory` to the active runtime so the Resource Manager
+ * popover lists sessions/CPU/mem for the environment the user is actually using.
+ */
 export function registerMemoryHandlers(store: Store): void {
-  ipcMain.handle('memory:getSnapshot', (): Promise<MemorySnapshot> => collectMemorySnapshot(store))
+  ipcMain.handle('memory:getSnapshot', async (): Promise<MemorySnapshot> => {
+    const environmentId = store.getSettings()?.activeRuntimeEnvironmentId?.trim()
+    if (environmentId) {
+      try {
+        const response = await callRuntimeEnvironment(
+          app.getPath('userData'),
+          environmentId,
+          'diagnostics.memory',
+          null
+        )
+        if (response.ok === true && isMemorySnapshot(response.result)) {
+          return response.result
+        }
+      } catch {
+        // Fall through to the local collector so the popover still opens.
+      }
+    }
+    return collectMemorySnapshot(store)
+  })
 }

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -927,8 +927,10 @@ export function ResourceUsageStatusSegment({
     return map
   }, [repos])
 
-  // Why: runtime-hosted repos never have local daemon samples or killable
-  // local sessions; this map drives their per-row exclusion in the merge.
+  // Why: still used to mark runtime-hosted repos for kill-safety on *local*
+  // daemon session ingest. Snapshot rows from the focused runtime host are
+  // no longer excluded in merge (see mergeSnapshotAndSessions) so Resource
+  // Manager works under activeRuntimeEnvironmentId.
   const repoRuntimeScopedById = useMemo(() => {
     const map = new Map<string, boolean>()
     for (const repo of repos) {

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -297,7 +297,10 @@ describe('mergeSnapshotAndSessions', () => {
     expect(remote.worktrees[0].isRemote).toBe(true)
   })
 
-  it('excludes runtime-scoped rows while preserving SSH and unattributed sessions', () => {
+  it('includes runtime-scoped snapshot samples while still filtering local-daemon runtime rows', () => {
+    // Why: Resource Manager must show runtime-host PTYs when diagnostics.memory
+    // is collected on that host. Local daemon sessions that only *look* like
+    // runtime ids stay excluded (kill safety).
     const runtimeWt: WorktreeMemory = {
       worktreeId: 'runtime-repo::/runtime/Wt',
       worktreeName: 'Wt',
@@ -326,8 +329,18 @@ describe('mergeSnapshotAndSessions', () => {
 
     const out = mergeSnapshotAndSessions(makeSnapshot([runtimeWt]), sessions, ctx)
 
-    expect(out.map((repo) => repo.repoId)).toEqual(['ssh-repo', UNATTRIBUTED_REPO_ID])
-    expect(out.find((repo) => repo.repoId === 'runtime-repo')).toBeUndefined()
+    expect(out.map((repo) => repo.repoId).sort()).toEqual(
+      ['runtime-repo', 'ssh-repo', UNATTRIBUTED_REPO_ID].sort()
+    )
+    const runtime = out.find((repo) => repo.repoId === 'runtime-repo')!
+    expect(runtime.worktrees[0]).toMatchObject({
+      worktreeId: 'runtime-repo::/runtime/Wt',
+      cpu: 5,
+      memory: 500_000_000,
+      hasLocalSamples: true
+    })
+    // Local daemon must not add a second session under the runtime repo.
+    expect(runtime.worktrees[0].sessions.map((s) => s.sessionId)).toEqual(['runtime-pty'])
 
     const ssh = out.find((repo) => repo.repoId === 'ssh-repo')!
     expect(ssh.hasRemoteChildren).toBe(true)

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -184,14 +184,14 @@ export function mergeSnapshotAndSessions(
     return repo.worktrees.find((w) => w.worktreeId === worktreeId)
   }
 
-  // ── Step 1: ingest snapshot worktrees as the local-truth foundation.
+  // ── Step 1: ingest snapshot worktrees as the sample foundation.
+  // Why: do not filter by runtime-scoped repo id here. When the focused
+  // environment is a runtime host, `memory:getSnapshot` proxies
+  // `diagnostics.memory` there and the snapshot rows are honest samples from
+  // that host. Filtering them out left Resource Manager empty under LXC/remote
+  // focus ("Nothing running right now") while the environment was busy.
   if (snapshot) {
     for (const wt of snapshot.worktrees as readonly WorktreeMemory[]) {
-      // Why: local snapshot data must never render under a runtime-hosted repo
-      // row; belt-and-braces with the matching session-ingest guard below.
-      if (isRuntimeScopedRepo(wt.repoId)) {
-        continue
-      }
       const repo = ensureRepo(wt.repoId, wt.repoName)
       const sessions: UnifiedSessionRow[] = wt.sessions.map((s) => {
         seenSessionIds.add(s.sessionId)


### PR DESCRIPTION
## Summary
- When `activeRuntimeEnvironmentId` is set (e.g. Orca serve / LXC), `memory:getSnapshot` proxies `diagnostics.memory` to that runtime instead of only sampling the local Mac.
- Resource Manager merge no longer drops **snapshot** rows for runtime-scoped repos (those samples are now from the runtime host). Local daemon sessions that only *look* runtime-scoped stay excluded for kill safety.
- Fixes the empty Resource Manager state (**Nothing running right now**) while a remote environment is focused and busy.

## Problem
Installed desktop Orca connected to a remote runtime (LXC1) showed Resource Manager with local Orca process only and **no** remote terminals, while `orca terminal list --environment <id>` listed dozens of PTYs. Space reclaim stayed at 0 B because the panel is local-scoped; the session list emptiness was a real product bug given runtime focus.

## Test plan
- [x] `vitest` `mergeSnapshotAndSessions.test.ts` (16)
- [x] `vitest` `memory.test.ts` (3)
- [ ] Manual: Mac Orca + remote env focused → open Resource Manager → expect remote worktree/session rows with CPU/mem from runtime (not empty)
- [ ] Manual: no remote env focused → Resource Manager still shows local samples only
- [ ] Manual: offline remote → falls back to local snapshot without crash

## Notes
- Space disk scan is still host-local (separate follow-up if desired).
- Kill affordances for runtime PTYs may still need runtime `terminal.stop` wiring; this PR unblocks visibility/metrics first.
- Skill `orca-finish-archive` (SiteUP) documents finish→archive so remote vite/puma do not linger after orchestration.

## ELI5

Resource Manager memory sampling only looked at your local Mac, so with a remote Orca runtime it could show "Nothing running" even when the remote host was busy. Memory snapshots now come from the active runtime environment when one is selected.
