### PR TITLE
fix(ssh): reconnect persisted PTYs after shutdown races

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -163,7 +163,11 @@ import {
   type KeybindingContext,
   type PhysicalModifierToken
 } from '../../shared/keybindings'
-import { toRuntimeExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
+import {
+  isRuntimeOwnedSshTargetId,
+  toRuntimeExecutionHostId,
+  type ExecutionHostId
+} from '../../shared/execution-host'
 import {
   ModifierDoubleTapDetector,
   toModifierDoubleTapEvent
@@ -1000,7 +1004,13 @@ function App(): React.JSX.Element {
           // tabs through pty.attach on the relay. Passphrase-protected targets
           // are deferred to tab focus to avoid stacking credential dialogs at
           // startup before the user has context.
-          const connectionIds = sessionRead.session.activeConnectionIdsAtShutdown ?? []
+          // Why: runtime-owned (ephemeral-VM) targets must never be dialed from
+          // the renderer — ssh.connect would dispose the runtime layer's live
+          // relay session. Main's windowless-promotion path can persist such
+          // ids into this list, so filter at the consumption boundary too.
+          const connectionIds = (sessionRead.session.activeConnectionIdsAtShutdown ?? []).filter(
+            (targetId) => !isRuntimeOwnedSshTargetId(targetId)
+          )
           if (connectionIds.length > 0) {
             try {
               const SSH_RECONNECT_TIMEOUT_MS = 15_000

--- a/src/renderer/src/lib/workspace-session-liveness.test.ts
+++ b/src/renderer/src/lib/workspace-session-liveness.test.ts
@@ -92,7 +92,7 @@ describe('workspace session live PTY persistence', () => {
     expect(payload.remoteSessionIdsByTabId).toBeUndefined()
   })
 
-  it('reconnects a persisted SSH PTY when shutdown observes the target as disconnected', () => {
+  it('reconnects a persisted SSH PTY when shutdown observes a transient relay drop', () => {
     const payload = buildWorkspaceSessionPayload(
       createSnapshot({
         tabsByWorktree: {
@@ -107,7 +107,10 @@ describe('workspace session live PTY persistence', () => {
         },
         ptyIdsByTabId: { 'tab-ssh': [] },
         lastKnownRelayPtyIdByTabId: { 'tab-ssh': 'ssh:conn-1@@pty-42' },
-        sshConnectionStates: new Map([['conn-1', { status: 'disconnected' } as never]]),
+        // Why 'reconnecting': an involuntary transport drop always lands in
+        // 'reconnecting' / 'reconnection-failed' / 'error' — never
+        // 'disconnected', which only an explicit user disconnect produces.
+        sshConnectionStates: new Map([['conn-1', { status: 'reconnecting' } as never]]),
         repos: [
           {
             id: 'repo-ssh',
@@ -128,5 +131,87 @@ describe('workspace session live PTY persistence', () => {
       'tab-ssh': 'ssh:conn-1@@pty-42'
     })
     expect(payload.activeConnectionIdsAtShutdown).toEqual(['conn-1'])
+  })
+
+  it('keeps explicitly disconnected hosts out of the startup reconnect list', () => {
+    const payload = buildWorkspaceSessionPayload(
+      createSnapshot({
+        tabsByWorktree: {
+          'wt-ssh': [
+            {
+              id: 'tab-ssh',
+              title: 'remote',
+              ptyId: null,
+              worktreeId: 'wt-ssh'
+            } as never
+          ]
+        },
+        ptyIdsByTabId: { 'tab-ssh': [] },
+        lastKnownRelayPtyIdByTabId: { 'tab-ssh': 'ssh:conn-1@@pty-42' },
+        // 'disconnected' = the user chose to take this host offline. The
+        // session id must still persist (restore-on-focus), but startup must
+        // not auto-dial the host against the user's intent.
+        sshConnectionStates: new Map([['conn-1', { status: 'disconnected' } as never]]),
+        repos: [
+          {
+            id: 'repo-ssh',
+            path: '/repo-ssh',
+            displayName: 'SSH',
+            badgeColor: '#fff',
+            addedAt: 1,
+            connectionId: 'conn-1'
+          }
+        ],
+        worktreesByRepo: {
+          'repo-ssh': [{ id: 'wt-ssh', repoId: 'repo-ssh' } as never]
+        }
+      })
+    )
+
+    expect(payload.remoteSessionIdsByTabId).toEqual({
+      'tab-ssh': 'ssh:conn-1@@pty-42'
+    })
+    expect(payload.activeConnectionIdsAtShutdown).toBeUndefined()
+  })
+
+  it('never derives runtime-owned SSH targets into the startup reconnect list', () => {
+    const payload = buildWorkspaceSessionPayload(
+      createSnapshot({
+        tabsByWorktree: {
+          'wt-vm': [
+            {
+              id: 'tab-vm',
+              title: 'vm',
+              ptyId: null,
+              worktreeId: 'wt-vm'
+            } as never
+          ]
+        },
+        ptyIdsByTabId: { 'tab-vm': [] },
+        lastKnownRelayPtyIdByTabId: { 'tab-vm': 'ssh:runtime-ssh-vm1@@pty-7' },
+        repos: [
+          {
+            id: 'repo-vm',
+            path: '/repo-vm',
+            displayName: 'VM',
+            badgeColor: '#fff',
+            addedAt: 1,
+            connectionId: 'runtime-ssh-vm1'
+          }
+        ],
+        worktreesByRepo: {
+          'repo-vm': [{ id: 'wt-vm', repoId: 'repo-vm' } as never]
+        }
+      })
+    )
+
+    // Why: the renderer must never drive startup ssh.connect for runtime-owned
+    // (ephemeral-VM) targets — their lifecycle belongs to the runtime layer,
+    // and ssh.listTargets() hides them so the connect would target a host the
+    // user cannot see or manage.
+    expect(payload.remoteSessionIdsByTabId).toEqual({
+      'tab-vm': 'ssh:runtime-ssh-vm1@@pty-7'
+    })
+    expect(payload.activeConnectionIdsAtShutdown).toBeUndefined()
   })
 })

--- a/src/renderer/src/lib/workspace-session-liveness.test.ts
+++ b/src/renderer/src/lib/workspace-session-liveness.test.ts
@@ -192,8 +192,13 @@ describe('workspace session live PTY persistence', () => {
         // Why a status entry: without one the status gate already excludes the
         // target and the runtime-owned check would be untested dead weight.
         // A pane-driven optimistic write CAN stamp runtime-owned states
-        // (TerminalSshReconnectOverlay), so pin the exclusion independently.
-        sshConnectionStates: new Map([['runtime-ssh-vm1', { status: 'reconnecting' } as never]]),
+        // (TerminalSshReconnectOverlay), so pin the exclusion independently —
+        // on both the session-id union path ('reconnecting') and the live
+        // connected-states path ('connected').
+        sshConnectionStates: new Map([
+          ['runtime-ssh-vm1', { status: 'reconnecting' } as never],
+          ['runtime-ssh-vm2', { status: 'connected' } as never]
+        ]),
         repos: [
           {
             id: 'repo-vm',

--- a/src/renderer/src/lib/workspace-session-liveness.test.ts
+++ b/src/renderer/src/lib/workspace-session-liveness.test.ts
@@ -91,4 +91,42 @@ describe('workspace session live PTY persistence', () => {
     expect(payload.activeWorktreeIdsOnShutdown).toEqual([])
     expect(payload.remoteSessionIdsByTabId).toBeUndefined()
   })
+
+  it('reconnects a persisted SSH PTY when shutdown observes the target as disconnected', () => {
+    const payload = buildWorkspaceSessionPayload(
+      createSnapshot({
+        tabsByWorktree: {
+          'wt-ssh': [
+            {
+              id: 'tab-ssh',
+              title: 'remote',
+              ptyId: null,
+              worktreeId: 'wt-ssh'
+            } as never
+          ]
+        },
+        ptyIdsByTabId: { 'tab-ssh': [] },
+        lastKnownRelayPtyIdByTabId: { 'tab-ssh': 'ssh:conn-1@@pty-42' },
+        sshConnectionStates: new Map([['conn-1', { status: 'disconnected' } as never]]),
+        repos: [
+          {
+            id: 'repo-ssh',
+            path: '/repo-ssh',
+            displayName: 'SSH',
+            badgeColor: '#fff',
+            addedAt: 1,
+            connectionId: 'conn-1'
+          }
+        ],
+        worktreesByRepo: {
+          'repo-ssh': [{ id: 'wt-ssh', repoId: 'repo-ssh' } as never]
+        }
+      })
+    )
+
+    expect(payload.remoteSessionIdsByTabId).toEqual({
+      'tab-ssh': 'ssh:conn-1@@pty-42'
+    })
+    expect(payload.activeConnectionIdsAtShutdown).toEqual(['conn-1'])
+  })
 })

--- a/src/renderer/src/lib/workspace-session-liveness.test.ts
+++ b/src/renderer/src/lib/workspace-session-liveness.test.ts
@@ -189,6 +189,11 @@ describe('workspace session live PTY persistence', () => {
         },
         ptyIdsByTabId: { 'tab-vm': [] },
         lastKnownRelayPtyIdByTabId: { 'tab-vm': 'ssh:runtime-ssh-vm1@@pty-7' },
+        // Why a status entry: without one the status gate already excludes the
+        // target and the runtime-owned check would be untested dead weight.
+        // A pane-driven optimistic write CAN stamp runtime-owned states
+        // (TerminalSshReconnectOverlay), so pin the exclusion independently.
+        sshConnectionStates: new Map([['runtime-ssh-vm1', { status: 'reconnecting' } as never]]),
         repos: [
           {
             id: 'repo-vm',

--- a/src/renderer/src/lib/workspace-session-patch.test.ts
+++ b/src/renderer/src/lib/workspace-session-patch.test.ts
@@ -205,6 +205,10 @@ describe('buildWorkspaceSessionPatch', () => {
 
     expect(Object.keys(patch).sort()).toEqual(
       [
+        // Why: the reconnect list derives from remote session ids, so any
+        // patch that rewrites remoteSessionIdsByTabId must carry it too —
+        // otherwise a crash between patches strands a stale target on disk.
+        'activeConnectionIdsAtShutdown',
         'activeWorktreeIdsOnShutdown',
         'remoteSessionIdsByTabId',
         'tabsByWorktree',
@@ -223,6 +227,25 @@ describe('buildWorkspaceSessionPatch', () => {
 
     expect(Object.hasOwn(patch, 'activeConnectionIdsAtShutdown')).toBe(true)
     expect(patch.activeConnectionIdsAtShutdown).toBeUndefined()
+  })
+
+  it('derives reconnect targets from surviving relay session ids in terminal-field patches', () => {
+    const patch = buildWorkspaceSessionPatch(
+      createSnapshot({
+        tabsByWorktree: {
+          'wt-ssh': [{ id: 'tab-ssh', title: 'remote', ptyId: null, worktreeId: 'wt-ssh' } as never]
+        },
+        ptyIdsByTabId: { 'tab-ssh': [] },
+        lastKnownRelayPtyIdByTabId: { 'tab-ssh': 'ssh:conn-1@@pty-42' },
+        sshConnectionStates: new Map([['conn-1', { status: 'reconnecting' } as never]]),
+        repos: [createRepo('repo-ssh', 'conn-1')],
+        worktreesByRepo: { 'repo-ssh': [{ id: 'wt-ssh', repoId: 'repo-ssh' } as never] }
+      }),
+      ['lastKnownRelayPtyIdByTabId']
+    )
+
+    expect(patch.remoteSessionIdsByTabId).toEqual({ 'tab-ssh': 'ssh:conn-1@@pty-42' })
+    expect(patch.activeConnectionIdsAtShutdown).toEqual(['conn-1'])
   })
 
   it('patches tab chrome as a sanitized bundle when split groups change', () => {

--- a/src/renderer/src/lib/workspace-session-patch.ts
+++ b/src/renderer/src/lib/workspace-session-patch.ts
@@ -83,7 +83,10 @@ export function buildWorkspaceSessionPatch(
       terminalSessionData.remoteSessionIdsByTabId ?? null
     )
   } else if (changed.has('sshConnectionStates')) {
-    patch.activeConnectionIdsAtShutdown = buildActiveConnectionIdsAtShutdown(snapshot)
+    patch.activeConnectionIdsAtShutdown = buildActiveConnectionIdsAtShutdown(
+      snapshot,
+      buildTerminalSessionData(snapshot).remoteSessionIdsByTabId ?? null
+    )
   }
   if (
     hasAnyChangedField(changed, [

--- a/src/renderer/src/lib/workspace-session-patch.ts
+++ b/src/renderer/src/lib/workspace-session-patch.ts
@@ -72,9 +72,17 @@ export function buildWorkspaceSessionPatch(
       'worktreesByRepo'
     ] as const)
   ) {
-    Object.assign(patch, buildTerminalSessionData(snapshot))
-  }
-  if (changed.has('sshConnectionStates')) {
+    const terminalSessionData = buildTerminalSessionData(snapshot)
+    Object.assign(patch, terminalSessionData)
+    // Why: the reconnect list is derived from persisted remote session ids as
+    // well as live SSH state. Recompute it alongside remoteSessionIdsByTabId
+    // so a crash between patches cannot leave a target on disk whose sessions
+    // were all closed (or vice versa).
+    patch.activeConnectionIdsAtShutdown = buildActiveConnectionIdsAtShutdown(
+      snapshot,
+      terminalSessionData.remoteSessionIdsByTabId ?? null
+    )
+  } else if (changed.has('sshConnectionStates')) {
     patch.activeConnectionIdsAtShutdown = buildActiveConnectionIdsAtShutdown(snapshot)
   }
   if (

--- a/src/renderer/src/lib/workspace-session-reconnect-targets.ts
+++ b/src/renderer/src/lib/workspace-session-reconnect-targets.ts
@@ -12,9 +12,13 @@ export function buildActiveConnectionIdsAtShutdown(
 ): WorkspaceSessionState['activeConnectionIdsAtShutdown'] {
   // Why: sshConnectionStates is a Map<string, SshConnectionState>, not a plain
   // object. Object.entries() on a Map returns [] — must use Array.from().
+  // Runtime-owned states are normally never broadcast to the renderer, but a
+  // pane-level optimistic write could stamp one; exclude them here too.
   const targetIds = new Set(
     Array.from(snapshot.sshConnectionStates.entries())
-      .filter(([, state]) => state.status === 'connected')
+      .filter(
+        ([targetId, state]) => state.status === 'connected' && !isRuntimeOwnedSshTargetId(targetId)
+      )
       .map(([targetId]) => targetId)
   )
 

--- a/src/renderer/src/lib/workspace-session-reconnect-targets.ts
+++ b/src/renderer/src/lib/workspace-session-reconnect-targets.ts
@@ -1,0 +1,43 @@
+import type { WorkspaceSessionState } from '../../../shared/types'
+import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
+import { isRuntimeOwnedSshTargetId } from '../../../shared/execution-host'
+import type { WorkspaceSessionSnapshot } from './workspace-session'
+
+export function buildActiveConnectionIdsAtShutdown(
+  snapshot: WorkspaceSessionSnapshot,
+  // Why: required (null = none) rather than defaulted — every caller already
+  // has the terminal session data in hand, and a default initializer would
+  // re-run the full repo/worktree scan on the shutdown-critical path.
+  remoteSessionIdsByTabId: WorkspaceSessionState['remoteSessionIdsByTabId'] | null
+): WorkspaceSessionState['activeConnectionIdsAtShutdown'] {
+  // Why: sshConnectionStates is a Map<string, SshConnectionState>, not a plain
+  // object. Object.entries() on a Map returns [] — must use Array.from().
+  const targetIds = new Set(
+    Array.from(snapshot.sshConnectionStates.entries())
+      .filter(([, state]) => state.status === 'connected')
+      .map(([targetId]) => targetId)
+  )
+
+  // Why: shutdown can observe SSH in a transient state (relay drop mid-quit,
+  // exhausted reconnect) after the socket closed but before the snapshot
+  // flushed. The durable PTY id still names the target Orca must reconnect to
+  // restore that surviving remote session. Two exclusions:
+  // 'disconnected'/'auth-failed'/never-observed usually mean an explicit user
+  // disconnect or a failed/cancelled connect — startup must not auto-dial a
+  // host the user left offline or stack credential dialogs (sessions still
+  // restore on tab focus via the deferred flow, so only eagerness is lost).
+  // Runtime-owned (ephemeral-VM) targets belong to the runtime layer; a
+  // renderer-driven ssh.connect would dispose the runtime's live relay session.
+  for (const sessionId of Object.values(remoteSessionIdsByTabId ?? {})) {
+    const connectionId = parseAppSshPtyId(sessionId)?.connectionId
+    if (!connectionId || isRuntimeOwnedSshTargetId(connectionId)) {
+      continue
+    }
+    const status = snapshot.sshConnectionStates.get(connectionId)?.status
+    if (status && status !== 'disconnected' && status !== 'auth-failed') {
+      targetIds.add(connectionId)
+    }
+  }
+
+  return targetIds.size > 0 ? Array.from(targetIds) : undefined
+}

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -12,8 +12,9 @@ import type { OpenFile } from '../store/slices/editor'
 import { buildPersistedUnifiedTabSessionData } from './workspace-session-unified-tabs'
 import { buildLastVisitedAtByWorktreeId } from './workspace-session-focus-recency'
 import { buildSleepingAgentSessionData } from './workspace-session-sleeping-agents'
-import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
-import { isRuntimeOwnedSshTargetId } from '../../../shared/execution-host'
+import { buildActiveConnectionIdsAtShutdown } from './workspace-session-reconnect-targets'
+
+export { buildActiveConnectionIdsAtShutdown }
 
 /** Why (issue #1158): the debounced + shutdown session writers share this
  *  gate so a hydration failure cannot overwrite orca-data.json with the
@@ -331,48 +332,6 @@ export function buildTerminalSessionData(
   }
 }
 
-export function buildActiveConnectionIdsAtShutdown(
-  snapshot: WorkspaceSessionSnapshot,
-  // Why: `null` means "computed and empty" — only recompute when the caller
-  // did not already run buildTerminalSessionData. A plain default parameter
-  // would re-run the full repo/worktree scan on the shutdown path whenever
-  // the map is legitimately undefined (no remote sessions).
-  remoteSessionIdsByTabId:
-    | WorkspaceSessionState['remoteSessionIdsByTabId']
-    | null = buildTerminalSessionData(snapshot).remoteSessionIdsByTabId ?? null
-): WorkspaceSessionState['activeConnectionIdsAtShutdown'] {
-  // Why: sshConnectionStates is a Map<string, SshConnectionState>, not a plain
-  // object. Object.entries() on a Map returns [] — must use Array.from().
-  const targetIds = new Set(
-    Array.from(snapshot.sshConnectionStates.entries())
-      .filter(([, state]) => state.status === 'connected')
-      .map(([targetId]) => targetId)
-  )
-
-  // Why: shutdown can observe SSH in a transient state (relay drop mid-quit,
-  // exhausted reconnect) after the socket closed but before the snapshot
-  // flushed. The durable PTY id still names the target Orca must reconnect to
-  // restore that surviving remote session. Two exclusions:
-  // 'disconnected'/'auth-failed'/never-observed usually mean an explicit user
-  // disconnect or a failed/cancelled connect — startup must not auto-dial a
-  // host the user left offline or stack credential dialogs (sessions still
-  // restore on tab focus via the deferred flow, so only eagerness is lost).
-  // Runtime-owned (ephemeral-VM) targets belong to the runtime layer; a
-  // renderer-driven ssh.connect would dispose the runtime's live relay session.
-  for (const sessionId of Object.values(remoteSessionIdsByTabId ?? {})) {
-    const connectionId = parseAppSshPtyId(sessionId)?.connectionId
-    if (!connectionId || isRuntimeOwnedSshTargetId(connectionId)) {
-      continue
-    }
-    const status = snapshot.sshConnectionStates.get(connectionId)?.status
-    if (status && status !== 'disconnected' && status !== 'auth-failed') {
-      targetIds.add(connectionId)
-    }
-  }
-
-  return targetIds.size > 0 ? Array.from(targetIds) : undefined
-}
-
 export function buildWorkspaceSessionPayload(
   snapshot: WorkspaceSessionSnapshot
 ): WorkspaceSessionState {
@@ -410,8 +369,6 @@ export function buildWorkspaceSessionPayload(
     // Persist only layouts backed by real tabs so a reload cannot restore a
     // blank split pane from that transient midpoint.
     ...buildPersistedUnifiedTabSessionData(snapshot),
-    // Why: `?? null` — an empty map is `undefined`, which would re-trigger the
-    // default initializer's second buildTerminalSessionData scan at shutdown.
     activeConnectionIdsAtShutdown: buildActiveConnectionIdsAtShutdown(
       snapshot,
       terminalSessionData.remoteSessionIdsByTabId ?? null

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -12,6 +12,7 @@ import type { OpenFile } from '../store/slices/editor'
 import { buildPersistedUnifiedTabSessionData } from './workspace-session-unified-tabs'
 import { buildLastVisitedAtByWorktreeId } from './workspace-session-focus-recency'
 import { buildSleepingAgentSessionData } from './workspace-session-sleeping-agents'
+import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
 
 /** Why (issue #1158): the debounced + shutdown session writers share this
  *  gate so a hydration failure cannot overwrite orca-data.json with the
@@ -330,15 +331,28 @@ export function buildTerminalSessionData(
 }
 
 export function buildActiveConnectionIdsAtShutdown(
-  snapshot: WorkspaceSessionSnapshot
+  snapshot: WorkspaceSessionSnapshot,
+  remoteSessionIdsByTabId = buildTerminalSessionData(snapshot).remoteSessionIdsByTabId
 ): WorkspaceSessionState['activeConnectionIdsAtShutdown'] {
   // Why: sshConnectionStates is a Map<string, SshConnectionState>, not a plain
   // object. Object.entries() on a Map returns [] — must use Array.from().
-  const connectedTargetIds = Array.from(snapshot.sshConnectionStates.entries())
-    .filter(([, state]) => state.status === 'connected')
-    .map(([targetId]) => targetId)
+  const targetIds = new Set(
+    Array.from(snapshot.sshConnectionStates.entries())
+      .filter(([, state]) => state.status === 'connected')
+      .map(([targetId]) => targetId)
+  )
 
-  return connectedTargetIds.length > 0 ? connectedTargetIds : undefined
+  // Why: shutdown can observe SSH as disconnected after the relay socket closes
+  // but before the session snapshot flushes. The durable PTY id still names the
+  // target Orca must reconnect to restore that surviving remote session.
+  for (const sessionId of Object.values(remoteSessionIdsByTabId ?? {})) {
+    const connectionId = parseAppSshPtyId(sessionId)?.connectionId
+    if (connectionId) {
+      targetIds.add(connectionId)
+    }
+  }
+
+  return targetIds.size > 0 ? Array.from(targetIds) : undefined
 }
 
 export function buildWorkspaceSessionPayload(
@@ -378,7 +392,10 @@ export function buildWorkspaceSessionPayload(
     // Persist only layouts backed by real tabs so a reload cannot restore a
     // blank split pane from that transient midpoint.
     ...buildPersistedUnifiedTabSessionData(snapshot),
-    activeConnectionIdsAtShutdown: buildActiveConnectionIdsAtShutdown(snapshot),
+    activeConnectionIdsAtShutdown: buildActiveConnectionIdsAtShutdown(
+      snapshot,
+      terminalSessionData.remoteSessionIdsByTabId
+    ),
     remoteSessionIdsByTabId: terminalSessionData.remoteSessionIdsByTabId,
     // Why: per-worktree focus-recency for Cmd+J's empty-query ordering.
     // Omit when empty so sessions written by builds that never stamped

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -352,13 +352,13 @@ export function buildActiveConnectionIdsAtShutdown(
   // Why: shutdown can observe SSH in a transient state (relay drop mid-quit,
   // exhausted reconnect) after the socket closed but before the snapshot
   // flushed. The durable PTY id still names the target Orca must reconnect to
-  // restore that surviving remote session. Two exclusions keep intent honest:
-  // 'disconnected'/'auth-failed'/never-observed only arise from an explicit
-  // user disconnect or a failed/cancelled connect, and startup must not dial a
-  // host the user chose to leave offline (its sessions still restore on tab
-  // focus via the deferred flow). Runtime-owned (ephemeral-VM) targets belong
-  // to the runtime layer; a renderer-driven ssh.connect would dispose the
-  // runtime's live relay session.
+  // restore that surviving remote session. Two exclusions:
+  // 'disconnected'/'auth-failed'/never-observed usually mean an explicit user
+  // disconnect or a failed/cancelled connect — startup must not auto-dial a
+  // host the user left offline or stack credential dialogs (sessions still
+  // restore on tab focus via the deferred flow, so only eagerness is lost).
+  // Runtime-owned (ephemeral-VM) targets belong to the runtime layer; a
+  // renderer-driven ssh.connect would dispose the runtime's live relay session.
   for (const sessionId of Object.values(remoteSessionIdsByTabId ?? {})) {
     const connectionId = parseAppSshPtyId(sessionId)?.connectionId
     if (!connectionId || isRuntimeOwnedSshTargetId(connectionId)) {

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -13,6 +13,7 @@ import { buildPersistedUnifiedTabSessionData } from './workspace-session-unified
 import { buildLastVisitedAtByWorktreeId } from './workspace-session-focus-recency'
 import { buildSleepingAgentSessionData } from './workspace-session-sleeping-agents'
 import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
+import { isRuntimeOwnedSshTargetId } from '../../../shared/execution-host'
 
 /** Why (issue #1158): the debounced + shutdown session writers share this
  *  gate so a hydration failure cannot overwrite orca-data.json with the
@@ -332,7 +333,13 @@ export function buildTerminalSessionData(
 
 export function buildActiveConnectionIdsAtShutdown(
   snapshot: WorkspaceSessionSnapshot,
-  remoteSessionIdsByTabId = buildTerminalSessionData(snapshot).remoteSessionIdsByTabId
+  // Why: `null` means "computed and empty" — only recompute when the caller
+  // did not already run buildTerminalSessionData. A plain default parameter
+  // would re-run the full repo/worktree scan on the shutdown path whenever
+  // the map is legitimately undefined (no remote sessions).
+  remoteSessionIdsByTabId:
+    | WorkspaceSessionState['remoteSessionIdsByTabId']
+    | null = buildTerminalSessionData(snapshot).remoteSessionIdsByTabId ?? null
 ): WorkspaceSessionState['activeConnectionIdsAtShutdown'] {
   // Why: sshConnectionStates is a Map<string, SshConnectionState>, not a plain
   // object. Object.entries() on a Map returns [] — must use Array.from().
@@ -342,12 +349,23 @@ export function buildActiveConnectionIdsAtShutdown(
       .map(([targetId]) => targetId)
   )
 
-  // Why: shutdown can observe SSH as disconnected after the relay socket closes
-  // but before the session snapshot flushes. The durable PTY id still names the
-  // target Orca must reconnect to restore that surviving remote session.
+  // Why: shutdown can observe SSH in a transient state (relay drop mid-quit,
+  // exhausted reconnect) after the socket closed but before the snapshot
+  // flushed. The durable PTY id still names the target Orca must reconnect to
+  // restore that surviving remote session. Two exclusions keep intent honest:
+  // 'disconnected'/'auth-failed'/never-observed only arise from an explicit
+  // user disconnect or a failed/cancelled connect, and startup must not dial a
+  // host the user chose to leave offline (its sessions still restore on tab
+  // focus via the deferred flow). Runtime-owned (ephemeral-VM) targets belong
+  // to the runtime layer; a renderer-driven ssh.connect would dispose the
+  // runtime's live relay session.
   for (const sessionId of Object.values(remoteSessionIdsByTabId ?? {})) {
     const connectionId = parseAppSshPtyId(sessionId)?.connectionId
-    if (connectionId) {
+    if (!connectionId || isRuntimeOwnedSshTargetId(connectionId)) {
+      continue
+    }
+    const status = snapshot.sshConnectionStates.get(connectionId)?.status
+    if (status && status !== 'disconnected' && status !== 'auth-failed') {
       targetIds.add(connectionId)
     }
   }
@@ -392,9 +410,11 @@ export function buildWorkspaceSessionPayload(
     // Persist only layouts backed by real tabs so a reload cannot restore a
     // blank split pane from that transient midpoint.
     ...buildPersistedUnifiedTabSessionData(snapshot),
+    // Why: `?? null` — an empty map is `undefined`, which would re-trigger the
+    // default initializer's second buildTerminalSessionData scan at shutdown.
     activeConnectionIdsAtShutdown: buildActiveConnectionIdsAtShutdown(
       snapshot,
-      terminalSessionData.remoteSessionIdsByTabId
+      terminalSessionData.remoteSessionIdsByTabId ?? null
     ),
     remoteSessionIdsByTabId: terminalSessionData.remoteSessionIdsByTabId,
     // Why: per-worktree focus-recency for Cmd+J's empty-query ordering.


### PR DESCRIPTION
## Summary

- preserve SSH reconnect targets when shutdown observes a transiently disconnected relay
- derive startup reconnect targets from durable remote PTY session IDs as well as live SSH state
- exclude runtime-owned (ephemeral-VM) targets and explicitly disconnected hosts from the eager startup dial
- keep the patch writer's reconnect list in sync with terminal-field patches
- add regression coverage for restart/update shutdown ordering, explicit-disconnect intent, runtime-owned exclusion (mutation-verified), and the patch-writer path

## Root cause

Orca already persisted the surviving remote PTY ID after an SSH transport drop, but `activeConnectionIdsAtShutdown` only reflected the instantaneous connection-state map. If shutdown captured after the target became disconnected, startup had the PTY ID but did not reconnect the host needed to attach it.

## Hardening added in review

- **Runtime-owned targets**: session ids like `ssh:runtime-ssh-*@@pty-N` parse to runtime-owned connection ids that the old connected-states source could never contain (their state is never broadcast to the renderer). A renderer-driven startup `ssh.connect` to one would dispose the runtime layer's live VM relay session (`doConnect` tears down existing sessions). Excluded in the builder and filtered again at the App.tsx consumption boundary (main's windowless-promotion path can persist such ids independently).
- **User intent**: an explicit Disconnect leaves `status: 'disconnected'` + a preserved relay session id — indistinguishable from the transient-drop shape by session data alone. Involuntary drops land in `reconnecting`/`reconnection-failed`/`error`, never `disconnected`, so the derivation requires a non-`disconnected`/`auth-failed` observed status. Excluded hosts still restore on tab focus via the deferred flow; only eagerness is withheld.
- **Patch-writer coherence**: the list now derives from terminal fields too, so terminal-field patches recompute it alongside `remoteSessionIdsByTabId` — a crash between patches can no longer strand a stale target on disk.
- **Perf**: the derivation takes the remote-session map as a required parameter (`null` = none), so the shutdown path never re-runs the repo/worktree scan (CodeRabbit's double-evaluation finding). Extracted to `workspace-session-reconnect-targets.ts` to stay within the max-lines budget.

## Tests

- `workspace-session-liveness.test.ts`: transient drop → included; explicit disconnect → excluded (session id still persisted); runtime-owned → excluded (mutation-verified: removing the guard fails the test)
- `workspace-session-patch.test.ts`: terminal-field patches carry the derived reconnect list
- Verified against a merge with current `main`: 419 tests across workspace-session/persistence/ssh-migration suites, web typecheck, oxlint, oxfmt, max-lines ratchet