### PR TITLE
feat(native-chat): add Codex session status footer

### DIFF
--- a/src/main/ipc/native-chat.ts
+++ b/src/main/ipc/native-chat.ts
@@ -1,5 +1,9 @@
 import { ipcMain, type IpcMainEvent, type WebContents } from 'electron'
-import type { AgentType, NativeChatMessage } from '../../shared/native-chat-types'
+import type {
+  AgentType,
+  NativeChatMessage,
+  NativeChatSessionMetadata
+} from '../../shared/native-chat-types'
 import {
   clearNativeChatTranscriptCache,
   readNativeChatTranscriptCached
@@ -61,6 +65,7 @@ export type NativeChatSubscribeArgs = {
 export type NativeChatAppendedPayload = {
   subscriptionId: string
   messages: NativeChatMessage[]
+  metadata?: NativeChatSessionMetadata
 }
 
 type LiveSubscription = {
@@ -154,11 +159,15 @@ async function handleSubscribe(event: IpcMainEvent, args: NativeChatSubscribeArg
       agent,
       sessionId,
       transcriptPath,
-      onAppend: (messages) => {
+      onAppend: (messages, metadata) => {
         if (sender.isDestroyed()) {
           return
         }
-        const payload: NativeChatAppendedPayload = { subscriptionId, messages }
+        const payload: NativeChatAppendedPayload = {
+          subscriptionId,
+          messages,
+          ...(metadata ? { metadata } : {})
+        }
         sender.send('nativeChat:appended', payload)
       }
     })

--- a/src/main/native-chat/transcript-line-decoders-codex.ts
+++ b/src/main/native-chat/transcript-line-decoders-codex.ts
@@ -1,6 +1,10 @@
 // Codex JSONL line → NativeChatMessage decoder.
 
-import type { NativeChatBlock, NativeChatMessage } from '../../shared/native-chat-types'
+import type {
+  NativeChatBlock,
+  NativeChatMessage,
+  NativeChatSessionMetadata
+} from '../../shared/native-chat-types'
 import {
   asRecord,
   extractString,
@@ -31,6 +35,50 @@ export function decodeCodexTranscriptLine(
     return codexEventMessage(payload, baseId, timestamp)
   }
   return null
+}
+
+export function decodeCodexTranscriptMetadataLine(line: string): NativeChatSessionMetadata | null {
+  const record = parseJsonObject(line)
+  const payload = asRecord(record?.payload)
+  if (!record || !payload) {
+    return null
+  }
+  if (record.type === 'turn_context') {
+    const collaborationMode = asRecord(payload.collaboration_mode)
+    const collaborationSettings = asRecord(collaborationMode?.settings)
+    return compactMetadata({
+      model: extractString(payload.model),
+      reasoningEffort:
+        extractString(payload.effort) ?? extractString(collaborationSettings?.reasoning_effort)
+    })
+  }
+  if (record.type !== 'event_msg' || payload.type !== 'token_count') {
+    return null
+  }
+  const info = asRecord(payload.info)
+  const lastUsage = asRecord(info?.last_token_usage)
+  const rateLimits = asRecord(payload.rate_limits)
+  const primary = asRecord(rateLimits?.primary)
+  const secondary = asRecord(rateLimits?.secondary)
+  return compactMetadata({
+    contextTokens: finiteNumber(lastUsage?.total_tokens),
+    contextWindowTokens: finiteNumber(info?.model_context_window),
+    sessionLimitUsedPercent: finiteNumber(primary?.used_percent),
+    weeklyLimitUsedPercent: finiteNumber(secondary?.used_percent)
+  })
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function compactMetadata(
+  metadata: Partial<Record<keyof NativeChatSessionMetadata, string | number | null | undefined>>
+): NativeChatSessionMetadata | null {
+  const entries = Object.entries(metadata).filter(
+    (entry) => entry[1] !== undefined && entry[1] !== null
+  )
+  return entries.length > 0 ? (Object.fromEntries(entries) as NativeChatSessionMetadata) : null
 }
 
 function codexResponseItem(

--- a/src/main/native-chat/transcript-line-decoders.ts
+++ b/src/main/native-chat/transcript-line-decoders.ts
@@ -10,5 +10,8 @@
 // under the max-lines limit while callers keep a single import path.
 
 export { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
-export { decodeCodexTranscriptLine } from './transcript-line-decoders-codex'
+export {
+  decodeCodexTranscriptLine,
+  decodeCodexTranscriptMetadataLine
+} from './transcript-line-decoders-codex'
 export { decodeGrokTranscriptLine } from './transcript-line-decoders-grok'

--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -173,6 +173,48 @@ describe('readNativeChatTranscript (claude)', () => {
 })
 
 describe('readNativeChatTranscript (codex)', () => {
+  it('returns the latest model, effort, context usage, and rate-limit metadata', async () => {
+    const filePath = await writeFixture('orca-native-chat-codex-metadata-', [
+      {
+        type: 'turn_context',
+        timestamp: '2026-06-01T10:00:00.000Z',
+        payload: {
+          model: 'gpt-5.6-sol',
+          effort: 'xhigh'
+        }
+      },
+      {
+        type: 'event_msg',
+        timestamp: '2026-06-01T10:00:01.000Z',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: { total_tokens: 77_000 },
+            model_context_window: 1_000_000
+          },
+          rate_limits: {
+            primary: { used_percent: 14 },
+            secondary: { used_percent: 5 }
+          }
+        }
+      }
+    ])
+
+    const result = await readNativeChatTranscript('codex', 'codex-sess', { filePath })
+    if (!('messages' in result)) {
+      throw new Error('expected transcript result')
+    }
+
+    expect(result.metadata).toEqual({
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'xhigh',
+      contextTokens: 77_000,
+      contextWindowTokens: 1_000_000,
+      sessionLimitUsedPercent: 14,
+      weeklyLimitUsedPercent: 5
+    })
+  })
+
   it('maps tool calls and results to tool-call/tool-result blocks', async () => {
     const filePath = await writeFixture('orca-native-chat-codex-', [
       {

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -1,15 +1,22 @@
 import { createReadStream } from 'node:fs'
-import type { AgentType, NativeChatMessage } from '../../shared/native-chat-types'
+import type {
+  AgentType,
+  NativeChatMessage,
+  NativeChatSessionMetadata
+} from '../../shared/native-chat-types'
 import { errorMessage } from '../ai-vault/session-scanner-values'
 import { resolveSessionFilePath, type ResolveSessionFileOptions } from './session-file-resolver'
 import {
   decodeClaudeTranscriptLine,
+  decodeCodexTranscriptMetadataLine,
   decodeCodexTranscriptLine,
   decodeGrokTranscriptLine
 } from './transcript-line-decoders'
 import { decodeTranscriptStream } from './transcript-stream-lines'
 
-export type ReadTranscriptResult = { messages: NativeChatMessage[] } | { error: string }
+export type ReadTranscriptResult =
+  | { messages: NativeChatMessage[]; metadata?: NativeChatSessionMetadata }
+  | { error: string }
 
 export type ReadTranscriptOptions = ResolveSessionFileOptions & {
   /** Resolve directly to this file, skipping path discovery (used by tests). */
@@ -34,13 +41,17 @@ export async function readNativeChatTranscript(
   }
   try {
     if (agent === 'claude') {
-      return { messages: await readTranscript(filePath, decodeClaudeTranscriptLine) }
+      return await readTranscript(filePath, decodeClaudeTranscriptLine)
     }
     if (agent === 'codex') {
-      return { messages: await readTranscript(filePath, decodeCodexTranscriptLine) }
+      return await readTranscript(
+        filePath,
+        decodeCodexTranscriptLine,
+        decodeCodexTranscriptMetadataLine
+      )
     }
     if (agent === 'grok') {
-      return { messages: await readTranscript(filePath, decodeGrokTranscriptLine) }
+      return await readTranscript(filePath, decodeGrokTranscriptLine)
     }
     return { error: `Unsupported agent for native chat transcript: ${agent}` }
   } catch (err) {
@@ -50,9 +61,17 @@ export async function readNativeChatTranscript(
 
 async function readTranscript(
   filePath: string,
-  decode: (line: string, fallbackId: string) => NativeChatMessage | null
-): Promise<NativeChatMessage[]> {
+  decode: (line: string, fallbackId: string) => NativeChatMessage | null,
+  decodeMetadata?: (line: string) => NativeChatSessionMetadata | null
+): Promise<{ messages: NativeChatMessage[]; metadata?: NativeChatSessionMetadata }> {
   const stream = createReadStream(filePath, { encoding: 'utf-8' })
-  const { messages } = await decodeTranscriptStream(stream, filePath, 0, decode, true)
-  return messages
+  const { messages, metadata } = await decodeTranscriptStream(
+    stream,
+    filePath,
+    0,
+    decode,
+    true,
+    decodeMetadata
+  )
+  return { messages, ...(metadata ? { metadata } : {}) }
 }

--- a/src/main/native-chat/transcript-stream-lines.ts
+++ b/src/main/native-chat/transcript-stream-lines.ts
@@ -1,17 +1,24 @@
 import type { Readable } from 'node:stream'
-import type { NativeChatMessage } from '../../shared/native-chat-types'
+import type { NativeChatMessage, NativeChatSessionMetadata } from '../../shared/native-chat-types'
 import { transcriptFallbackId } from './transcript-fallback-id'
 
 type TranscriptDecoder = (line: string, fallbackId: string) => NativeChatMessage | null
+type TranscriptMetadataDecoder = (line: string) => NativeChatSessionMetadata | null
 
 export async function decodeTranscriptStream(
   stream: Readable,
   filePath: string,
   start: number,
   decode: TranscriptDecoder,
-  includeTrailingLine: boolean
-): Promise<{ messages: NativeChatMessage[]; consumedBytes: number }> {
+  includeTrailingLine: boolean,
+  decodeMetadata?: TranscriptMetadataDecoder
+): Promise<{
+  messages: NativeChatMessage[]
+  consumedBytes: number
+  metadata?: NativeChatSessionMetadata
+}> {
   const messages: NativeChatMessage[] = []
+  const metadata: NativeChatSessionMetadata = {}
   let pending = ''
   let consumedBytes = 0
 
@@ -32,7 +39,11 @@ export async function decodeTranscriptStream(
     consumedBytes += Buffer.byteLength(pending, 'utf8')
   }
 
-  return { messages, consumedBytes }
+  return {
+    messages,
+    consumedBytes,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {})
+  }
 
   function decodeLine(rawLine: string, relativeOffset: number): void {
     const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
@@ -42,6 +53,10 @@ export async function decodeTranscriptStream(
     const message = decode(line, transcriptFallbackId(filePath, start + relativeOffset))
     if (message) {
       messages.push(message)
+    }
+    const metadataPatch = decodeMetadata?.(line)
+    if (metadataPatch) {
+      Object.assign(metadata, metadataPatch)
     }
   }
 }

--- a/src/main/native-chat/transcript-watch.test.ts
+++ b/src/main/native-chat/transcript-watch.test.ts
@@ -44,6 +44,45 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void
 }
 
 describe('subscribeNativeChatTranscript', () => {
+  it('emits Codex metadata changes even when no chat message was appended', async () => {
+    const filePath = await tempFile('')
+    const metadataBatches: unknown[] = []
+
+    const sub = await subscribeNativeChatTranscript({
+      agent: 'codex',
+      sessionId: 'ignored',
+      filePath,
+      onAppend: (_messages, metadata) => {
+        if (metadata) {
+          metadataBatches.push(metadata)
+        }
+      },
+      debounceMs: 5
+    })
+
+    await appendFile(
+      filePath,
+      `${JSON.stringify({
+        type: 'event_msg',
+        timestamp: '2026-06-01T10:00:00.000Z',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: { total_tokens: 88_000 },
+            model_context_window: 200_000
+          }
+        }
+      })}\n`
+    )
+    await waitFor(() => metadataBatches.length > 0)
+    sub.unsubscribe()
+
+    expect(metadataBatches.at(-1)).toMatchObject({
+      contextTokens: 88_000,
+      contextWindowTokens: 200_000
+    })
+  })
+
   it('re-emits from the top on first drain so appended turns are never dropped', async () => {
     const filePath = await tempFile(claudeLine('u-1', 'user', 'first'))
     const batches: NativeChatMessage[][] = []

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -10,10 +10,15 @@
 
 import { watch, type FSWatcher } from 'node:fs'
 import { open, stat } from 'node:fs/promises'
-import type { AgentType, NativeChatMessage } from '../../shared/native-chat-types'
+import type {
+  AgentType,
+  NativeChatMessage,
+  NativeChatSessionMetadata
+} from '../../shared/native-chat-types'
 import { resolveSessionFilePath, type ResolveSessionFileOptions } from './session-file-resolver'
 import {
   decodeClaudeTranscriptLine,
+  decodeCodexTranscriptMetadataLine,
   decodeCodexTranscriptLine,
   decodeGrokTranscriptLine
 } from './transcript-line-decoders'
@@ -24,7 +29,7 @@ export type SubscribeNativeChatTranscriptArgs = ResolveSessionFileOptions & {
   sessionId: string
   /** Called with the newly-appended messages whenever the file grows. Never
    *  called with an empty array. */
-  onAppend: (messages: NativeChatMessage[]) => void
+  onAppend: (messages: NativeChatMessage[], metadata?: NativeChatSessionMetadata) => void
   /** Resolve directly to this file, skipping path discovery (used by tests). */
   filePath?: string
   /** Coalesce window for rapid fs.watch events (ms). Defaults to 40ms. */
@@ -67,6 +72,12 @@ function lineDecoderForAgent(
   return null
 }
 
+function metadataDecoderForAgent(
+  agent: AgentType
+): ((line: string) => NativeChatSessionMetadata | null) | undefined {
+  return agent === 'codex' ? decodeCodexTranscriptMetadataLine : undefined
+}
+
 async function fileSize(filePath: string): Promise<number> {
   try {
     return (await stat(filePath)).size
@@ -85,8 +96,13 @@ async function fileSize(filePath: string): Promise<number> {
 async function readAppendedMessages(
   filePath: string,
   start: number,
-  decode: (line: string, fallbackId: string) => NativeChatMessage | null
-): Promise<{ messages: NativeChatMessage[]; consumedTo: number }> {
+  decode: (line: string, fallbackId: string) => NativeChatMessage | null,
+  decodeMetadata?: (line: string) => NativeChatSessionMetadata | null
+): Promise<{
+  messages: NativeChatMessage[]
+  consumedTo: number
+  metadata?: NativeChatSessionMetadata
+}> {
   const end = await fileSize(filePath)
   if (end <= start) {
     // File shrank (rotation/replacement) or unchanged — caller resets offset.
@@ -101,14 +117,15 @@ async function readAppendedMessages(
       end: end - 1,
       autoClose: false
     })
-    const { messages, consumedBytes } = await decodeTranscriptStream(
+    const { messages, consumedBytes, metadata } = await decodeTranscriptStream(
       stream,
       filePath,
       start,
       decode,
-      false
+      false,
+      decodeMetadata
     )
-    return { messages, consumedTo: start + consumedBytes }
+    return { messages, consumedTo: start + consumedBytes, ...(metadata ? { metadata } : {}) }
   } finally {
     await handle.close()
   }
@@ -127,6 +144,7 @@ export async function subscribeNativeChatTranscript(
 ): Promise<NativeChatTranscriptSubscription> {
   const { agent, sessionId, onAppend, debounceMs } = args
   const decode = lineDecoderForAgent(agent)
+  const decodeMetadata = metadataDecoderForAgent(agent)
   const filePath = args.filePath ?? (await resolveSessionFilePath(agent, sessionId, args))
 
   if (!filePath || !decode) {
@@ -166,10 +184,15 @@ export async function subscribeNativeChatTranscript(
             // Rotation/replacement/truncation: re-read from the top.
             offset = 0
           }
-          const { messages, consumedTo } = await readAppendedMessages(filePath!, offset, decode!)
+          const { messages, consumedTo, metadata } = await readAppendedMessages(
+            filePath!,
+            offset,
+            decode!,
+            decodeMetadata
+          )
           offset = consumedTo
-          if (!closed && messages.length > 0) {
-            onAppend(messages)
+          if (!closed && (messages.length > 0 || metadata)) {
+            onAppend(messages, metadata)
           }
         } catch {
           // Why: a transient read failure (EACCES/EIO/ENOENT during rotation)

--- a/src/main/runtime/rpc/methods/native-chat.ts
+++ b/src/main/runtime/rpc/methods/native-chat.ts
@@ -120,7 +120,10 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
       )
       // Window to the conversation tail (all clients); clip blocks for mobile only.
       return 'messages' in result
-        ? { messages: windowForClient(result.messages, clientKind, params.limit) }
+        ? {
+            messages: windowForClient(result.messages, clientKind, params.limit),
+            ...(result.metadata ? { metadata: result.metadata } : {})
+          }
         : result
     }
   }),
@@ -157,11 +160,15 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
         agent: params.agent,
         sessionId: params.sessionId,
         transcriptPath: params.transcriptPath,
-        onAppend: (messages) => {
+        onAppend: (messages, metadata) => {
           if (closed) {
             return
           }
-          emit({ type: 'appended', messages: windowForClient(messages, clientKind) })
+          emit({
+            type: 'appended',
+            messages: windowForClient(messages, clientKind),
+            ...(metadata ? { metadata } : {})
+          })
         }
       })
       // The connection may have closed while the file was being resolved.

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -417,7 +417,11 @@ import type {
   AiVaultSubagentListArgs,
   AiVaultSubagentListResult
 } from '../shared/ai-vault-types'
-import type { AgentType, NativeChatMessage } from '../shared/native-chat-types'
+import type {
+  AgentType,
+  NativeChatMessage,
+  NativeChatSessionMetadata
+} from '../shared/native-chat-types'
 import type { TelemetryConsentState } from '../shared/telemetry-consent-types'
 import type { AgentKind, LaunchSource, RequestKind } from '../shared/telemetry-events'
 import type { AppStarSource } from '../shared/gh-star-source'
@@ -812,7 +816,9 @@ export type AiVaultApi = {
   onWindowFocused: (callback: () => void) => () => void
 }
 
-export type NativeChatReadSessionResult = { messages: NativeChatMessage[] } | { error: string }
+export type NativeChatReadSessionResult =
+  | { messages: NativeChatMessage[]; metadata?: NativeChatSessionMetadata }
+  | { error: string }
 
 /** Messages appended to a live-tailed transcript since the previous emit. */
 export type NativeChatAppendedMessages = NativeChatMessage[]
@@ -821,6 +827,7 @@ export type NativeChatAppendedMessages = NativeChatMessage[]
 export type NativeChatAppendedPayload = {
   subscriptionId: string
   messages: NativeChatAppendedMessages
+  metadata?: NativeChatSessionMetadata
 }
 
 export type NativeChatSubscribeArgs = {
@@ -848,7 +855,7 @@ export type NativeChatApi = {
    *  messages. Returns an unsubscribe fn that closes the main-process watcher. */
   subscribe: (
     args: NativeChatSubscribeArgs,
-    onAppended: (messages: NativeChatAppendedMessages) => void
+    onAppended: (messages: NativeChatAppendedMessages, metadata?: NativeChatSessionMetadata) => void
   ) => () => void
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -171,7 +171,7 @@ import type {
 } from '../shared/automations-types'
 import type { KeybindingActionId, KeybindingFileSnapshot } from '../shared/keybindings'
 import type { AiVaultListArgs, AiVaultSubagentListArgs } from '../shared/ai-vault-types'
-import type { AgentType } from '../shared/native-chat-types'
+import type { AgentType, NativeChatSessionMetadata } from '../shared/native-chat-types'
 import type {
   NativeChatAppendedMessages,
   NativeChatAppendedPayload,
@@ -3861,11 +3861,14 @@ const api = {
         sessionId: string
         transcriptPath?: string
       },
-      onAppended: (messages: NativeChatAppendedMessages) => void
+      onAppended: (
+        messages: NativeChatAppendedMessages,
+        metadata?: NativeChatSessionMetadata
+      ) => void
     ): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, payload: NativeChatAppendedPayload) => {
         if (payload.subscriptionId === args.subscriptionId) {
-          onAppended(payload.messages)
+          onAppended(payload.messages, payload.metadata)
         }
       }
       ipcRenderer.on('nativeChat:appended', listener)

--- a/src/renderer/src/components/native-chat/NativeChatStatusFooter.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStatusFooter.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { NativeChatStatusFooter } from './NativeChatStatusFooter'
+
+describe('NativeChatStatusFooter', () => {
+  afterEach(cleanup)
+
+  it('renders two stable, scannable rows without changing the composer width', () => {
+    render(
+      <NativeChatStatusFooter
+        data={{
+          primary: ['gpt-5.6-sol', 'xhigh', '77k/1M', 'leo-corp +1'],
+          stage: 'разведка',
+          next: 'спека в issue #156',
+          questions: 0,
+          blocked: 0,
+          agents: 2
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('native-chat-status-primary')).toHaveTextContent(
+      'gpt-5.6-sol • xhigh • 77k/1M • leo-corp +1'
+    )
+    expect(screen.getByTestId('native-chat-status-stage')).toHaveTextContent(
+      'stage: разведка → спека в issue #156 · Q:0 B:0 Ag:2'
+    )
+    expect(screen.getByTestId('native-chat-status-footer')).toHaveClass('min-w-0')
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatStatusFooter.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStatusFooter.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useShallow } from 'zustand/react/shallow'
+import type { NativeChatSession } from '../../../../shared/native-chat-types'
+import { translate } from '../../i18n/i18n'
+import { useAppStore } from '../../store'
+import { resolveNativeChatFileLinkContext } from './native-chat-file-link'
+import type { NativeChatStatusFooterData } from './native-chat-status-footer'
+import { deriveNativeChatStatusFooter, nativeChatWorktreeName } from './native-chat-status-footer'
+
+export function NativeChatStatusFooter({
+  data
+}: {
+  data: NativeChatStatusFooterData
+}): React.JSX.Element {
+  useTranslation()
+
+  return (
+    <div
+      data-testid="native-chat-status-footer"
+      className="min-w-0 shrink-0 border-t border-border px-3 py-1 font-mono text-[11px] leading-4 tracking-normal text-muted-foreground"
+    >
+      <div data-testid="native-chat-status-primary" className="h-4 truncate whitespace-nowrap">
+        {data.primary.join(' • ')}
+      </div>
+      <div data-testid="native-chat-status-stage" className="h-4 truncate whitespace-nowrap">
+        {translate(
+          'auto.components.nativeChat.statusFooter.summary',
+          'stage: {{stage}} → {{next}} · Q:{{questions}} B:{{blocked}} Ag:{{agents}}',
+          data
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function NativeChatCodexStatusFooter({
+  paneKey,
+  terminalTabId,
+  session
+}: {
+  paneKey: string
+  terminalTabId: string
+  session: Pick<NativeChatSession, 'agent' | 'messages' | 'metadata'>
+}): React.JSX.Element {
+  const agentStatus = useAppStore((state) => state.agentStatusByPaneKey[paneKey])
+  const fileLinkContext = useAppStore(
+    useShallow((state) => resolveNativeChatFileLinkContext(state, terminalTabId))
+  )
+  const changedFiles = useAppStore((state) =>
+    fileLinkContext ? (state.gitStatusByWorktree[fileLinkContext.worktreeId]?.length ?? 0) : 0
+  )
+  const data = useMemo(
+    () =>
+      deriveNativeChatStatusFooter({
+        agent: session.agent,
+        metadata: session.metadata,
+        messages: session.messages,
+        agentStatus,
+        worktreeName: nativeChatWorktreeName(fileLinkContext?.worktreePath),
+        changedFiles
+      }),
+    [session, agentStatus, fileLinkContext?.worktreePath, changedFiles]
+  )
+
+  return <NativeChatStatusFooter data={data} />
+}

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -52,6 +52,7 @@ import { selectNativeChatRuntimeEnvironmentId } from './native-chat-runtime-owne
 import { useNativeChatPasteBridge } from './use-native-chat-paste-bridge'
 import type { CommentMarkdownLinkClickHandler } from '@/components/sidebar/CommentMarkdown'
 import { openDetectedFilePath } from '@/components/terminal-pane/terminal-file-open-routing'
+import { NativeChatCodexStatusFooter } from './NativeChatStatusFooter'
 
 const emptyNativeChatContextMenuActions: Omit<NativeChatContextMenuActions, 'onPaste'> = {
   onSplitRight: () => {},
@@ -438,6 +439,13 @@ function NativeChatResolvedView({
         onOptimisticSend={onOptimisticSend}
         onSlashCommand={onSlashCommand}
       />
+      {agent === 'codex' ? (
+        <NativeChatCodexStatusFooter
+          paneKey={paneKey}
+          terminalTabId={terminalTabId}
+          session={sessionWithPending}
+        />
+      ) : null}
       {contextMenu.menu}
     </div>
   )

--- a/src/renderer/src/components/native-chat/native-chat-session-transport.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-transport.ts
@@ -3,6 +3,7 @@ import type {
   NativeChatAppendedMessages,
   NativeChatReadSessionResult
 } from '../../../../preload/api-types'
+import type { NativeChatSessionMetadata } from '../../../../shared/native-chat-types'
 import { isWebClientLocation } from '@/lib/web-client-location'
 import {
   callRuntimeRpc,
@@ -108,9 +109,10 @@ function createRuntimeNativeChatTransport(environmentId: string): NativeChatSess
                 const frame = response.result as {
                   type?: string
                   messages?: NativeChatAppendedMessages
+                  metadata?: NativeChatSessionMetadata
                 }
                 if (frame?.type === 'appended' && Array.isArray(frame.messages)) {
-                  onAppended(frame.messages)
+                  onAppended(frame.messages, frame.metadata)
                 }
               },
               // Established-then-dropped: resume the tail. onClose also fires on our

--- a/src/renderer/src/components/native-chat/native-chat-status-footer.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-status-footer.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { deriveNativeChatStatusFooter } from './native-chat-status-footer'
+
+function assistant(text: string): NativeChatMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    source: 'transcript',
+    timestamp: 1,
+    blocks: [{ type: 'text', text }]
+  }
+}
+
+function status(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: '',
+    updatedAt: 1,
+    stateStartedAt: 1,
+    stateHistory: [],
+    paneKey: 'tab:leaf',
+    agentType: 'codex',
+    ...overrides
+  }
+}
+
+describe('deriveNativeChatStatusFooter', () => {
+  it('formats provider metadata, repository state, and the latest stage footer', () => {
+    const result = deriveNativeChatStatusFooter({
+      agent: 'codex',
+      metadata: {
+        model: 'gpt-5.6-sol',
+        reasoningEffort: 'xhigh',
+        contextTokens: 77_000,
+        contextWindowTokens: 1_000_000,
+        sessionLimitUsedPercent: 14,
+        weeklyLimitUsedPercent: 5
+      },
+      messages: [
+        assistant('Промежуточный статус.\nэтап: разведка → спека в issue #156 · Q:1 B:0 Ag:2')
+      ],
+      worktreeName: 'leo-corp',
+      changedFiles: 3,
+      agentStatus: status()
+    })
+
+    expect(result.primary).toEqual([
+      'gpt-5.6-sol',
+      'xhigh',
+      '77k/1M',
+      'leo-corp +3',
+      '5h 14%',
+      '7d 5%'
+    ])
+    expect(result.stage).toBe('разведка')
+    expect(result.next).toBe('спека в issue #156')
+    expect(result.questions).toBe(1)
+    expect(result.blocked).toBe(0)
+    expect(result.agents).toBe(2)
+  })
+
+  it('uses live hook facts ahead of stale counts in the assistant footer', () => {
+    const result = deriveNativeChatStatusFooter({
+      agent: 'codex',
+      messages: [assistant('этап: работа → проверка · вопросов 0 · blocked 0 · Ag:0')],
+      agentStatus: status({
+        state: 'blocked',
+        interactivePrompt: JSON.stringify({
+          questions: [{ question: 'Merge?' }, { question: 'Ship?' }]
+        }),
+        subagents: [
+          { id: 'a', state: 'working', startedAt: 1 },
+          { id: 'b', state: 'idle', startedAt: 1 }
+        ]
+      })
+    })
+
+    expect(result.questions).toBe(2)
+    expect(result.blocked).toBe(1)
+    expect(result.agents).toBe(1)
+  })
+
+  it('falls back to the live agent state before the first explicit stage line', () => {
+    const result = deriveNativeChatStatusFooter({
+      agent: 'codex',
+      messages: [],
+      agentStatus: status({ state: 'working' })
+    })
+
+    expect(result.stage).toBe('working')
+    expect(result.next).toBe('next agent update')
+  })
+
+  it('uses the working fallback before agent status is available', () => {
+    const result = deriveNativeChatStatusFooter({
+      agent: 'codex',
+      messages: []
+    })
+
+    expect(result.stage).toBe('working')
+    expect(result.next).toBe('next agent update')
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-status-footer.ts
+++ b/src/renderer/src/components/native-chat/native-chat-status-footer.ts
@@ -1,0 +1,180 @@
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import {
+  isTextBlock,
+  type AgentType,
+  type NativeChatMessage,
+  type NativeChatSessionMetadata
+} from '../../../../shared/native-chat-types'
+
+export type NativeChatStatusFooterData = {
+  primary: string[]
+  stage: string
+  next: string
+  questions: number
+  blocked: number
+  agents: number
+}
+
+export type NativeChatStatusFooterInput = {
+  agent: AgentType
+  metadata?: NativeChatSessionMetadata
+  messages: readonly NativeChatMessage[]
+  agentStatus?: AgentStatusEntry
+  worktreeName?: string
+  changedFiles?: number
+}
+
+type ParsedStageLine = {
+  stage: string
+  next: string
+  questions: number
+  blocked: number
+  agents: number
+}
+
+export function deriveNativeChatStatusFooter(
+  input: NativeChatStatusFooterInput
+): NativeChatStatusFooterData {
+  const parsed = findLatestStageLine(input)
+  const liveQuestions = countInteractiveQuestions(input.agentStatus?.interactivePrompt)
+  const liveAgents = input.agentStatus?.subagents?.filter(
+    (entry) => entry.state === 'working'
+  ).length
+  const liveBlocked = input.agentStatus?.state === 'blocked' ? 1 : 0
+  const fallback = fallbackStage(input.agentStatus?.state)
+
+  return {
+    primary: primarySegments(input),
+    stage: parsed?.stage ?? fallback.stage,
+    next: parsed?.next ?? fallback.next,
+    questions: liveQuestions ?? parsed?.questions ?? 0,
+    blocked: Math.max(liveBlocked, parsed?.blocked ?? 0),
+    agents: liveAgents ?? parsed?.agents ?? 0
+  }
+}
+
+export function nativeChatWorktreeName(pathValue: string | undefined): string | undefined {
+  return pathValue?.split(/[\\/]/).toReversed().find(Boolean)
+}
+
+function primarySegments(input: NativeChatStatusFooterInput): string[] {
+  const metadata = input.metadata
+  const segments = [metadata?.model ?? input.agent]
+  if (metadata?.reasoningEffort) {
+    segments.push(metadata.reasoningEffort)
+  }
+  if (metadata?.contextTokens !== undefined) {
+    const context = compactNumber(metadata.contextTokens)
+    segments.push(
+      metadata.contextWindowTokens !== undefined
+        ? `${context}/${compactNumber(metadata.contextWindowTokens)}`
+        : context
+    )
+  }
+  if (input.worktreeName) {
+    const dirty = input.changedFiles && input.changedFiles > 0 ? ` +${input.changedFiles}` : ''
+    segments.push(`${input.worktreeName}${dirty}`)
+  }
+  if (metadata?.sessionLimitUsedPercent !== undefined) {
+    segments.push(`5h ${compactPercent(metadata.sessionLimitUsedPercent)}`)
+  }
+  if (metadata?.weeklyLimitUsedPercent !== undefined) {
+    segments.push(`7d ${compactPercent(metadata.weeklyLimitUsedPercent)}`)
+  }
+  return segments
+}
+
+function compactNumber(value: number): string {
+  const absolute = Math.abs(value)
+  if (absolute >= 1_000_000) {
+    return `${formatDecimal(value / 1_000_000)}M`
+  }
+  if (absolute >= 1_000) {
+    return `${formatDecimal(value / 1_000)}k`
+  }
+  return Math.round(value).toString()
+}
+
+function formatDecimal(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1).replace(/\.0$/, '')
+}
+
+function compactPercent(value: number): string {
+  return `${Math.round(Math.max(0, Math.min(100, value)))}%`
+}
+
+function findLatestStageLine(input: NativeChatStatusFooterInput): ParsedStageLine | null {
+  const candidates = [
+    input.agentStatus?.lastAssistantMessage,
+    ...input.messages
+      .filter((message) => message.role === 'assistant')
+      .toReversed()
+      .map((message) =>
+        message.blocks
+          .filter(isTextBlock)
+          .map((block) => block.text)
+          .join('\n')
+      )
+  ]
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue
+    }
+    const lines = candidate.split(/\r?\n/).toReversed()
+    for (const line of lines) {
+      const parsed = parseStageLine(line.trim())
+      if (parsed) {
+        return parsed
+      }
+    }
+  }
+  return null
+}
+
+function parseStageLine(line: string): ParsedStageLine | null {
+  const match = /^(?:этап|stage):\s*(.*?)\s*(?:→|->)\s*(.*?)(?:\s*·|$)/i.exec(line)
+  if (!match?.[1] || !match[2]) {
+    return null
+  }
+  return {
+    stage: match[1].trim(),
+    next: match[2].trim(),
+    questions: readCount(line, /(?:Q\s*:|вопросов\s*:?)\s*(\d+)/i),
+    blocked: readCount(line, /(?:B\s*:|blocked\s*:?)\s*(\d+)/i),
+    agents: readCount(line, /(?:Ag\s*:|agents\s*:?|агентов\s*:?)\s*(\d+)/i)
+  }
+}
+
+function readCount(line: string, pattern: RegExp): number {
+  const value = pattern.exec(line)?.[1]
+  return value ? Number.parseInt(value, 10) : 0
+}
+
+function countInteractiveQuestions(value: string | undefined): number | null {
+  if (!value) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(value) as { questions?: unknown }
+    return Array.isArray(parsed.questions) ? parsed.questions.length : 1
+  } catch {
+    return 1
+  }
+}
+
+function fallbackStage(state: AgentStatusEntry['state'] | undefined): {
+  stage: string
+  next: string
+} {
+  switch (state) {
+    case undefined:
+    case 'working':
+      return { stage: 'working', next: 'next agent update' }
+    case 'blocked':
+      return { stage: 'blocked', next: 'operator action' }
+    case 'waiting':
+      return { stage: 'waiting', next: 'agent continuation' }
+    case 'done':
+      return { stage: 'done', next: 'next request' }
+  }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -191,6 +191,46 @@ describe('useNativeChatLiveSession — transport routing', () => {
     expect(transport.subscribe).toHaveBeenCalledOnce()
   })
 
+  it('keeps initial Codex metadata and applies live metadata patches', async () => {
+    const transport = getMockTransport('env-1')
+    transport.readSession.mockResolvedValueOnce({
+      messages: [],
+      metadata: {
+        model: 'gpt-5.6-sol',
+        reasoningEffort: 'xhigh',
+        contextTokens: 77_000,
+        contextWindowTokens: 1_000_000
+      }
+    })
+
+    await render({
+      paneKey: PANE,
+      agent: 'codex',
+      sessionId: SESSION,
+      runtimeEnvironmentId: 'env-1'
+    })
+
+    expect(latest?.metadata).toMatchObject({
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'xhigh',
+      contextTokens: 77_000
+    })
+
+    const onAppended = transport.subscribe.mock.calls[0]?.[1] as
+      | ((messages: NativeChatMessage[], metadata?: { contextTokens?: number }) => void)
+      | undefined
+    await act(async () => {
+      onAppended?.([], { contextTokens: 88_000 })
+    })
+
+    expect(latest?.metadata).toMatchObject({
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'xhigh',
+      contextTokens: 88_000,
+      contextWindowTokens: 1_000_000
+    })
+  })
+
   it('re-subscribes against the new owner on an owner flip (R5)', async () => {
     const root = await render({
       paneKey: PANE,

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -4,7 +4,8 @@ import {
   NATIVE_CHAT_SOURCE_PRIORITY,
   type AgentType,
   type NativeChatMessage,
-  type NativeChatSession
+  type NativeChatSession,
+  type NativeChatSessionMetadata
 } from '../../../../shared/native-chat-types'
 import {
   applyAppend,
@@ -78,7 +79,7 @@ function nextSubscriptionId(): string {
 
 type ReadState =
   | { phase: 'loading' }
-  | { phase: 'ready'; messages: NativeChatMessage[] }
+  | { phase: 'ready'; messages: NativeChatMessage[]; metadata?: NativeChatSessionMetadata }
   | { phase: 'error'; error: string }
 
 /**
@@ -125,6 +126,7 @@ export function useNativeChatLiveSession(
   // (re-emitted ids replace in place, no unbounded concat) and the bucket is
   // capped to the read window so a long run can't grow it without limit (#6).
   const [appended, setAppended] = useState<NativeChatMessage[]>([])
+  const [appendedMetadata, setAppendedMetadata] = useState<NativeChatSessionMetadata>({})
   // Stateful id-dedup merger backing `appended`; caches the id→index map so each
   // live frame costs O(incoming), not O(existing) (#18 parity for desktop).
   const appendMergerRef = useRef(createNativeChatMerger(NATIVE_CHAT_SOURCE_PRIORITY))
@@ -156,6 +158,7 @@ export function useNativeChatLiveSession(
       setRead({ phase: 'ready', messages: [] })
       replaceList(appendMergerRef.current, [])
       setAppended([])
+      setAppendedMetadata({})
       setHasMore(false)
       return
     }
@@ -165,6 +168,7 @@ export function useNativeChatLiveSession(
     setRead({ phase: 'loading' })
     replaceList(appendMergerRef.current, [])
     setAppended([])
+    setAppendedMetadata({})
     setHasMore(false)
 
     void transport
@@ -178,7 +182,11 @@ export function useNativeChatLiveSession(
           return
         }
         const messages = result?.messages ?? []
-        setRead({ phase: 'ready', messages })
+        setRead({
+          phase: 'ready',
+          messages,
+          ...(result?.metadata ? { metadata: result.metadata } : {})
+        })
         setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
       })
       .catch((err: unknown) => {
@@ -190,8 +198,11 @@ export function useNativeChatLiveSession(
     const subscriptionId = nextSubscriptionId()
     const unsubscribe = transport.subscribe(
       { subscriptionId, agent, sessionId, transcriptPath: transcriptPath ?? undefined },
-      (messages) => {
+      (messages, metadata) => {
         if (!cancelled) {
+          if (metadata) {
+            setAppendedMetadata((current) => ({ ...current, ...metadata }))
+          }
           // Merge by id (re-emits replace in place) then bound to the window so
           // the bucket can't grow without limit. The base read still holds older
           // turns, and the assembler re-dedups the concat, so trimming the recent
@@ -247,7 +258,11 @@ export function useNativeChatLiveSession(
         limitRef.current = nextLimit
         // Read results are an ordered tail — replace the base list so the older
         // page prepends in order; live appends stay in their separate bucket.
-        setRead({ phase: 'ready', messages: result.messages })
+        setRead({
+          phase: 'ready',
+          messages: result.messages,
+          ...(result.metadata ? { metadata: result.metadata } : {})
+        })
         setHasMore(hasMoreNativeChatHistory(result.messages.length, nextLimit))
       })
       .catch(() => {
@@ -307,6 +322,26 @@ export function useNativeChatLiveSession(
       loading: read.phase === 'loading',
       ...(read.phase === 'error' ? { error: read.error } : {})
     })
-    return { ...session, hasMore, loadingEarlier, loadEarlier }
-  }, [assembledMessages, read, sessionId, agent, hookState, hasMore, loadingEarlier, loadEarlier])
+    const metadata = {
+      ...(read.phase === 'ready' ? read.metadata : undefined),
+      ...appendedMetadata
+    }
+    return {
+      ...session,
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+      hasMore,
+      loadingEarlier,
+      loadEarlier
+    }
+  }, [
+    assembledMessages,
+    read,
+    appendedMetadata,
+    sessionId,
+    agent,
+    hookState,
+    hasMore,
+    loadingEarlier,
+    loadEarlier
+  ])
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12754,6 +12754,9 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "Copy"
+        },
+        "statusFooter": {
+          "summary": "stage: {{stage}} → {{next}} · Q:{{questions}} B:{{blocked}} Ag:{{agents}}"
         }
       },
       "orca": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12754,6 +12754,9 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "Copiar"
+        },
+        "statusFooter": {
+          "summary": "etapa: {{stage}} → {{next}} · P:{{questions}} B:{{blocked}} Ag:{{agents}}"
         }
       },
       "orca": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -12754,6 +12754,9 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "コピー"
+        },
+        "statusFooter": {
+          "summary": "段階: {{stage}} → {{next}} · Q:{{questions}} B:{{blocked}} Ag:{{agents}}"
         }
       },
       "orca": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -12754,6 +12754,9 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "복사"
+        },
+        "statusFooter": {
+          "summary": "단계: {{stage}} → {{next}} · Q:{{questions}} B:{{blocked}} Ag:{{agents}}"
         }
       },
       "orca": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -12754,6 +12754,9 @@
       "nativeChat": {
         "contextMenu": {
           "copy": "复制"
+        },
+        "statusFooter": {
+          "summary": "阶段: {{stage}} → {{next}} · Q:{{questions}} B:{{blocked}} Ag:{{agents}}"
         }
       },
       "orca": {

--- a/src/shared/native-chat-types.ts
+++ b/src/shared/native-chat-types.ts
@@ -88,6 +88,16 @@ export const NATIVE_CHAT_SESSION_STATUSES = [
 ] as const
 export type NativeChatSessionStatus = (typeof NATIVE_CHAT_SESSION_STATUSES)[number]
 
+/** Latest provider facts that belong to the session rather than a chat turn. */
+export type NativeChatSessionMetadata = {
+  model?: string
+  reasoningEffort?: string
+  contextTokens?: number
+  contextWindowTokens?: number
+  sessionLimitUsedPercent?: number
+  weeklyLimitUsedPercent?: number
+}
+
 export type NativeChatSession = {
   messages: NativeChatMessage[]
   status: NativeChatSessionStatus
@@ -95,6 +105,7 @@ export type NativeChatSession = {
    *  one (the view shows live hook state and backfills later). */
   sessionId: string | null
   agent: AgentType
+  metadata?: NativeChatSessionMetadata
   /** Human-readable error when `status === 'error'`. */
   error?: string
 }


### PR DESCRIPTION
## Summary

- Add a persistent two-row status footer below the composer in Codex native-chat sessions.
- Read model, reasoning effort, context usage, and 5-hour/weekly rate-limit usage from Codex JSONL metadata and propagate updates through local IPC and remote runtime transports.
- Show worktree dirtiness plus live question, blocked, and subagent counts. The stage row reads the latest assistant `stage:`/`этап:` line and falls back to live agent state.
- Keep Claude and other native-chat surfaces unchanged.

## Screenshots

- Visually verified in dark mode at 1280x600 and 375x400. Both rows keep stable height; narrow layouts truncate instead of resizing or overlapping the composer. Screenshots were captured locally but are not attached from the CLI.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — targeted native-chat suite: 8 files, 46 tests passed; the full repository suite was not run
- [ ] `pnpm build` — `pnpm build:electron-vite` passed; the full native/release build was not run
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the full metadata path from untrusted JSONL through stream decoding, cached reads, live watching, Electron IPC/preload, remote runtime RPC, renderer transport, session merging, and the Codex-only UI mount. Checked metadata-only live frames, stale/live precedence, truncation, and that non-Codex chats remain unchanged.

The review flagged three issues and they were fixed before submission: a non-exhaustive fallback state, unlocalized visible labels, and an unused `cwd` field that would have propagated a full local path.

Cross-platform review covered macOS, Linux, and Windows path separators, remote/SSH runtime propagation, and Electron IPC types. This change adds no shortcuts, shell commands, or platform-specific labels.

## Security Audit

The decoder accepts only known string fields and finite numeric values from the existing transcript trust boundary. No new command execution, dependencies, auth flow, secret handling, filesystem writes, or IPC endpoints are added. Full working-directory paths are deliberately not retained or transported.

## Notes

Codex currently reports its primary and secondary rate-limit windows as 5 hours and 7 days, which the compact footer labels as `5h` and `7d`. Explicit stage text remains agent-authored so teams can use their own workflow vocabulary.