### PR TITLE
Contain rejected terminal process inspections

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-process-inspection-queue.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-process-inspection-queue.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  enqueueAgentProcessInspection,
+  resetAgentProcessInspectionQueueForTests
+} from './agent-process-inspection-queue'
+
+describe('agent process inspection queue', () => {
+  afterEach(() => {
+    resetAgentProcessInspectionQueueForTests()
+    vi.restoreAllMocks()
+  })
+
+  it('contains rejected fire-and-forget inspections', async () => {
+    const completed = vi.fn()
+    enqueueAgentProcessInspection({
+      priority: 'cadence',
+      run: () => Promise.reject(new Error('remote runtime unavailable'))
+    })
+    enqueueAgentProcessInspection({
+      priority: 'cadence',
+      run: async () => completed()
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(completed).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/agent-process-inspection-queue.ts
+++ b/src/renderer/src/components/terminal-pane/agent-process-inspection-queue.ts
@@ -52,12 +52,19 @@ function pumpInspectionQueue(): void {
 
   activeInspections += 1
   inspectionStarts.push(now)
-  void next.run().finally(() => {
-    activeInspections = Math.max(0, activeInspections - 1)
-    if (inspectionQueue.length > 0) {
-      scheduleInspectionPump()
-    }
-  })
+  void next
+    .run()
+    .catch(() => {
+      // Why: this queue is the fire-and-forget boundary. Individual coordinators
+      // own error/backoff policy, but an unexpected rejection must not become a
+      // renderer-wide unhandled rejection and feed crash diagnostics forever.
+    })
+    .finally(() => {
+      activeInspections = Math.max(0, activeInspections - 1)
+      if (inspectionQueue.length > 0) {
+        scheduleInspectionPump()
+      }
+    })
 
   if (inspectionQueue.length > 0) {
     scheduleInspectionPump()


### PR DESCRIPTION
## What changed

- catch rejected agent process-inspection tasks at the queue's fire-and-forget boundary
- preserve queue accounting and scheduling through the existing `finally` cleanup
- add regression coverage proving a rejected remote inspection does not stop later queued work

## Why

An unreachable Remote Orca Server can reject `terminal.inspectProcess` calls. The global inspection queue launched task promises with `.finally()` but no rejection handler, so an unexpected rejection escaped as `renderer_unhandled_rejection`. Repeated cadence probes could then continuously feed renderer crash diagnostics while the remote remained unavailable.

Coordinator-specific error and backoff behavior remains unchanged. This only contains errors that reach the queue boundary.

## User impact

Remote runtime interruptions no longer turn rejected terminal process inspections into renderer-global unhandled promise rejections, reducing diagnostic churn and runaway renderer resource usage.

## Validation

- focused Vitest regression: 1 passed
- oxlint on both touched files: passed
- oxfmt check on both touched files: passed
- `git diff --check`: passed

Local install used Node 26 although the repository requests Node 24; dependency installation emitted an engine warning, while the focused checks passed.

Fixes #8414

## ELI5

If inspecting a remote terminal process failed hard, that rejection could stop later inspection work in the global queue. Failures are caught at the fire-and-forget boundary so one unreachable server does not stall the rest of the queue.
