### PR TITLE
fix(keyboard-input): preserve composed @ in Kitty terminals

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -777,6 +777,23 @@ describe('kitty keyboard protocol panes', () => {
     })
   })
 
+  it('sends German Option+L @ as text in compose mode', () => {
+    expect(resolveKitty(event({ key: '@', code: 'KeyL', altKey: true }))).toEqual({
+      type: 'sendInput',
+      data: '@'
+    })
+
+    // A designated Meta-side Option remains a shortcut, while the compose side types @.
+    expect(resolveKitty(event({ key: '@', code: 'KeyL', altKey: true }), 'left', 1)).toEqual({
+      type: 'sendInput',
+      data: '\x1b[108;3u'
+    })
+    expect(resolveKitty(event({ key: '@', code: 'KeyL', altKey: true }), 'left', 2)).toEqual({
+      type: 'sendInput',
+      data: '@'
+    })
+  })
+
   it('includes shift in the kitty modifier field', () => {
     expect(resolveKitty(event({ key: '∏', code: 'KeyP', altKey: true, shiftKey: true }))).toEqual({
       type: 'sendInput',

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -681,6 +681,23 @@ describe('kitty keyboard protocol panes', () => {
     })
   })
 
+  it('sends German Option+L @ as text in compose mode', () => {
+    expect(resolveKitty(event({ key: '@', code: 'KeyL', altKey: true }))).toEqual({
+      type: 'sendInput',
+      data: '@'
+    })
+
+    // A designated Meta-side Option remains a shortcut, while the compose side types @.
+    expect(resolveKitty(event({ key: '@', code: 'KeyL', altKey: true }), 'left', 1)).toEqual({
+      type: 'sendInput',
+      data: '\x1b[108;3u'
+    })
+    expect(resolveKitty(event({ key: '@', code: 'KeyL', altKey: true }), 'left', 2)).toEqual({
+      type: 'sendInput',
+      data: '@'
+    })
+  })
+
   it('includes shift in the kitty modifier field', () => {
     expect(resolveKitty(event({ key: '∏', code: 'KeyP', altKey: true, shiftKey: true }))).toEqual({
       type: 'sendInput',

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -296,8 +296,19 @@ export function resolveTerminalShortcutAction(
 
   // Why: macOptionIsMeta stays off so non-US layouts can compose @/€; match event.code since composition rewrites event.key.
   if (isMac && !event.metaKey && !event.ctrlKey && event.altKey && macOptionAsAlt !== 'true') {
+    // Why: event.location reflects the char key, not the held modifier, so the caller supplies Option's tracked keydown location.
+    const isLeftOption = optionKeyLocation === 1
+    const isRightOption = optionKeyLocation === 2
+    const shouldActAsMeta =
+      (macOptionAsAlt === 'left' && isLeftOption) || (macOptionAsAlt === 'right' && isRightOption)
+
     // Why: kitty pane — encode the physical base key as CSI-u; the composed codepoint (alt+π) binds nothing, Dead keys exempt to keep composition.
     if (event.key !== 'Dead' && isKittyKeyboardActivePane?.()) {
+      // Why: Pi enables kitty mode, whose Alt encoding makes composed `@`
+      // non-textual. Compose-side Option must match native macOS terminals.
+      if (!shouldActAsMeta && event.key === '@') {
+        return { type: 'sendInput', data: event.key }
+      }
       const baseCharacter =
         (event.code ? layoutBaseCharacterForCode?.(event.code) : undefined) ??
         resolveUnshiftedCharacterForCode(event.code)
@@ -310,13 +321,6 @@ export function resolveTerminalShortcutAction(
     }
 
     if (!event.shiftKey) {
-      // Why: event.location reflects the char key, not the held modifier, so the caller supplies Option's tracked keydown location.
-      const isLeftOption = optionKeyLocation === 1
-      const isRightOption = optionKeyLocation === 2
-
-      const shouldActAsMeta =
-        (macOptionAsAlt === 'left' && isLeftOption) || (macOptionAsAlt === 'right' && isRightOption)
-
       if (shouldActAsMeta) {
         const character = resolveUnshiftedCharacterForCode(event.code)
         if (character) {

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -289,17 +289,30 @@ export function resolveTerminalShortcutAction(
   // The handling depends on the macOptionAsAlt setting (mirrors Ghostty):
   // - 'true':  xterm handles all Option as Meta natively; nothing to do here.
   // - kitty-protocol pane (any other mode): the TUI asked for modifier-accurate
-  //   keys, so every Option chord is encoded as kitty CSI-u with the physical
-  //   base key (Option+P → \x1b[112;3u). Without this, xterm's kitty encoder
-  //   reports the composed codepoint (alt+π), which no TUI binds — the chord
-  //   neither triggers the hotkey nor types the character (issue: OMP Alt+P /
-  //   Alt+M dead on compose layouts). Dead keys are exempt so composition
-  //   (Option+E → ´) keeps working.
+  //   keys, so Option chords are encoded as kitty CSI-u with the physical base
+  //   key (Option+P → \x1b[112;3u). Without this, xterm's kitty encoder reports
+  //   the composed codepoint (alt+π), which no TUI binds. Layout-produced `@`
+  //   stays text on the compose-side Option key because it is essential input,
+  //   not an Alt shortcut (German Option+L, Turkish Option+Q).
   // - 'false': compensate the three most critical readline shortcuts (B/F/D).
   // - 'left'/'right': the designated Option key acts as full Meta (emit Esc+
   //   for any single letter); the other key composes, with B/F/D compensated.
   if (isMac && !event.metaKey && !event.ctrlKey && event.altKey && macOptionAsAlt !== 'true') {
+    // Why: event.location on a character key reports that key's position
+    // (always 0 for standard keys), NOT which modifier is held. The caller
+    // must track the Option key's own keydown location and pass it as
+    // optionKeyLocation.
+    const isLeftOption = optionKeyLocation === 1
+    const isRightOption = optionKeyLocation === 2
+    const shouldActAsMeta =
+      (macOptionAsAlt === 'left' && isLeftOption) || (macOptionAsAlt === 'right' && isRightOption)
+
     if (event.key !== 'Dead' && isKittyKeyboardActivePane?.()) {
+      // Why: Pi enables kitty mode, whose Alt encoding makes composed `@`
+      // non-textual. Compose-side Option must match native macOS terminals.
+      if (!shouldActAsMeta && event.key === '@') {
+        return { type: 'sendInput', data: event.key }
+      }
       const baseCharacter =
         (event.code ? layoutBaseCharacterForCode?.(event.code) : undefined) ??
         resolveUnshiftedCharacterForCode(event.code)
@@ -312,16 +325,6 @@ export function resolveTerminalShortcutAction(
     }
 
     if (!event.shiftKey) {
-      // Why: event.location on a character key reports that key's position
-      // (always 0 for standard keys), NOT which modifier is held. The caller
-      // must track the Option key's own keydown location and pass it as
-      // optionKeyLocation.
-      const isLeftOption = optionKeyLocation === 1
-      const isRightOption = optionKeyLocation === 2
-
-      const shouldActAsMeta =
-        (macOptionAsAlt === 'left' && isLeftOption) || (macOptionAsAlt === 'right' && isRightOption)
-
       if (shouldActAsMeta) {
         // Emit Esc+key (e.g. Option+B → \x1bb) for letters, digits, and
         // mapped punctuation.


### PR DESCRIPTION
## Summary

Fixes #8399.

When a terminal app such as Pi enables the Kitty keyboard protocol, Orca translated every macOS Option chord into a physical-key Alt sequence. On a German layout, that changed `Option+L` from the composed `@` character into `Alt+L`, so Pi received a shortcut instead of text.

This change sends a layout-produced `@` as plain text when the active Option key is configured to compose characters. Explicit **Both**, **Left**, and **Right** Option-as-Alt behavior remains respected, and other Kitty Option shortcuts keep their existing physical-key encoding.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 2,713 files / 28,653 tests passed; 28 unrelated renderer tests failed because `window.localStorage` is unavailable under the local unsupported Node 26 runtime. The focused regression suite passes 34/34.
- [x] `pnpm build`
- [x] Added regression coverage for German `Option+L`, including compose-side and explicitly designated Meta-side Option behavior

Manual verification in the macOS dev app with the German keyboard layout confirmed that `Option+L` inserts `@` in Pi after it enables Kitty keyboard mode.

## AI Review Report

Reviewed the terminal keyboard path from the window capture handler through shortcut resolution and PTY input.

- **Correctness:** verified the exception applies only to a composed `@` on a compose-side Option key. A designated Meta-side Option still emits Kitty `Alt+L`, while **Both** continues to defer to xterm's Option-as-Meta handling.
- **Cross-platform:** the behavior remains inside the existing runtime macOS guard. Linux and Windows keyboard handling, shortcut labels, shell behavior, and Electron platform branches are unchanged.
- **Local/SSH/remote:** translation happens in the renderer before PTY transport, so local, SSH, WSL, and remote terminals receive the same corrected text without host assumptions.
- **Agents and integrations:** Pi's Kitty mode now preserves composed `@`; existing Kitty Option hotkeys for OMP and other terminal apps remain unchanged except where the user-selected compose-side Option produces `@` text.
- **Performance:** adds only constant-time boolean and character comparisons to the existing Option-key hot path. No listeners, polling, allocation growth, or IPC were added.
- **UI quality:** no layout, styling, copy, or component behavior changed.

No blocking issue remained after review.

## Security Audit

The change adds no command execution, filesystem or path handling, network access, authentication, secrets, dependencies, IPC surfaces, or privilege changes. It forwards one browser-produced character through the existing bounded terminal input transport and does not broaden input trust or bypass terminal ownership checks. No security follow-up is needed.

## Notes

- Platform-specific: this fixes macOS keyboard layouts where Option composes `@`, including German `Option+L` and Turkish `Option+Q`.
- Set **Settings → Terminal → Option as Alt** to **Auto** or **Off** to use composition. Explicit Meta-side settings continue to take precedence.
- X (Twitter): [@gatsby74](https://x.com/gatsby74)

## ELI5

With the Kitty keyboard protocol, Option+L on a German layout sent Alt+L instead of the composed `@` character, so apps got a shortcut instead of text. When Option is set to compose characters, layout-produced `@` is sent as plain text; explicit Option-as-Alt modes still work.
