### PR TITLE
feat(editor): add file editor word wrap preference

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -147,6 +147,8 @@ export default function MonacoEditor({
     settings?.terminalFontSize ?? 13,
     editorFontZoomLevel
   )
+  const editorFontFamily = settings?.terminalFontFamily || 'monospace'
+  const editorWordWrap = settings?.editorWordWrap
   const estimatedAutoHeight = useMemo(() => {
     if (!autoHeight) {
       return null
@@ -708,15 +710,15 @@ export default function MonacoEditor({
 
   // Update editor options when settings change
   useEffect(() => {
-    if (!editorRef.current || !settings) {
+    if (!editorRef.current) {
       return
     }
     editorRef.current.updateOptions({
       fontSize: editorFontSize,
-      fontFamily: settings.terminalFontFamily || 'monospace',
-      ...buildFileEditorWordWrapOptions(settings.editorWordWrap)
+      fontFamily: editorFontFamily,
+      ...buildFileEditorWordWrapOptions(editorWordWrap)
     })
-  }, [editorFontSize, settings])
+  }, [editorFontFamily, editorFontSize, editorWordWrap])
 
   useEffect(() => {
     markdownDocLinkDecorationsRef.current?.refresh()
@@ -835,9 +837,9 @@ export default function MonacoEditor({
           // setting into DiffViewer/DiffSectionItem would have no effect.
           minimap: { enabled: settings?.editorMinimapEnabled ?? false },
           scrollBeyondLastLine: false,
-          ...buildFileEditorWordWrapOptions(settings?.editorWordWrap),
+          ...buildFileEditorWordWrapOptions(editorWordWrap),
           fontSize: editorFontSize,
-          fontFamily: settings?.terminalFontFamily || 'monospace',
+          fontFamily: editorFontFamily,
           lineNumbers: 'on',
           renderLineHighlight: 'line',
           automaticLayout: true,

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -52,6 +52,7 @@ import {
 } from './monaco-markdown-selection-annotation'
 import { translate } from '@/i18n/i18n'
 import { handleMonacoLargeTextPaste } from './monaco-large-text-paste'
+import { buildFileEditorWordWrapOptions } from './file-editor-word-wrap-options'
 import {
   clampMonacoAutoHeight,
   getMonacoAutoHeightForContent,
@@ -712,7 +713,8 @@ export default function MonacoEditor({
     }
     editorRef.current.updateOptions({
       fontSize: editorFontSize,
-      fontFamily: settings.terminalFontFamily || 'monospace'
+      fontFamily: settings.terminalFontFamily || 'monospace',
+      ...buildFileEditorWordWrapOptions(settings.editorWordWrap)
     })
   }, [editorFontSize, settings])
 
@@ -833,7 +835,7 @@ export default function MonacoEditor({
           // setting into DiffViewer/DiffSectionItem would have no effect.
           minimap: { enabled: settings?.editorMinimapEnabled ?? false },
           scrollBeyondLastLine: false,
-          wordWrap: 'on',
+          ...buildFileEditorWordWrapOptions(settings?.editorWordWrap),
           fontSize: editorFontSize,
           fontFamily: settings?.terminalFontFamily || 'monospace',
           lineNumbers: 'on',

--- a/src/renderer/src/components/editor/file-editor-word-wrap-options.test.ts
+++ b/src/renderer/src/components/editor/file-editor-word-wrap-options.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { buildFileEditorWordWrapOptions } from './file-editor-word-wrap-options'
+
+describe('buildFileEditorWordWrapOptions', () => {
+  it('keeps wrapping enabled for existing profiles without the preference', () => {
+    expect(buildFileEditorWordWrapOptions(undefined)).toEqual({ wordWrap: 'on' })
+    expect(buildFileEditorWordWrapOptions(true)).toEqual({ wordWrap: 'on' })
+  })
+
+  it('disables wrapping for horizontal file-editor scrolling', () => {
+    expect(buildFileEditorWordWrapOptions(false)).toEqual({ wordWrap: 'off' })
+  })
+})

--- a/src/renderer/src/components/editor/file-editor-word-wrap-options.ts
+++ b/src/renderer/src/components/editor/file-editor-word-wrap-options.ts
@@ -1,0 +1,8 @@
+import type { editor } from 'monaco-editor'
+
+export function buildFileEditorWordWrapOptions(
+  editorWordWrap: boolean | undefined
+): Pick<editor.IStandaloneEditorConstructionOptions, 'wordWrap'> {
+  // Why: profiles saved before this preference existed must retain Orca's previous wrapped default.
+  return { wordWrap: editorWordWrap === false ? 'off' : 'on' }
+}

--- a/src/renderer/src/components/settings/EditorWordWrapSetting.test.tsx
+++ b/src/renderer/src/components/settings/EditorWordWrapSetting.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { join } from 'node:path'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -31,7 +32,7 @@ function renderSetting(editorWordWrap: boolean | undefined, updateSettings = vi.
   act(() => {
     root?.render(
       <EditorWordWrapSetting
-        settings={{ ...getDefaultSettings('/tmp'), editorWordWrap }}
+        settings={{ ...getDefaultSettings(join('test', 'home')), editorWordWrap }}
         updateSettings={updateSettings}
       />
     )

--- a/src/renderer/src/components/settings/EditorWordWrapSetting.test.tsx
+++ b/src/renderer/src/components/settings/EditorWordWrapSetting.test.tsx
@@ -50,6 +50,15 @@ describe('EditorWordWrapSetting', () => {
     expect(on?.getAttribute('aria-checked')).toBe('true')
   })
 
+  it('shows wrapping as off when the preference is disabled', () => {
+    const { container } = renderSetting(false)
+    const off = [...container.querySelectorAll('[role="radio"]')].find(
+      (button) => button.textContent === 'Off'
+    )
+
+    expect(off?.getAttribute('aria-checked')).toBe('true')
+  })
+
   it('persists the off choice for horizontal scrolling', () => {
     const updateSettings = vi.fn()
     const { container } = renderSetting(true, updateSettings)
@@ -60,5 +69,17 @@ describe('EditorWordWrapSetting', () => {
     act(() => off?.click())
 
     expect(updateSettings).toHaveBeenCalledWith({ editorWordWrap: false })
+  })
+
+  it('persists the on choice without changing the diff preference', () => {
+    const updateSettings = vi.fn()
+    const { container } = renderSetting(false, updateSettings)
+    const on = [...container.querySelectorAll<HTMLButtonElement>('[role="radio"]')].find(
+      (button) => button.textContent === 'On'
+    )
+
+    act(() => on?.click())
+
+    expect(updateSettings).toHaveBeenCalledWith({ editorWordWrap: true })
   })
 })

--- a/src/renderer/src/components/settings/EditorWordWrapSetting.test.tsx
+++ b/src/renderer/src/components/settings/EditorWordWrapSetting.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { settingsSearchQuery: string }) => unknown) =>
+    selector({ settingsSearchQuery: '' })
+}))
+
+import { EditorWordWrapSetting } from './EditorWordWrapSetting'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount())
+  }
+  container?.remove()
+  root = null
+  container = null
+})
+
+function renderSetting(editorWordWrap: boolean | undefined, updateSettings = vi.fn()) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(
+      <EditorWordWrapSetting
+        settings={{ ...getDefaultSettings('/tmp'), editorWordWrap }}
+        updateSettings={updateSettings}
+      />
+    )
+  })
+  return { container, updateSettings }
+}
+
+describe('EditorWordWrapSetting', () => {
+  it('shows wrapping as on for profiles saved before the preference existed', () => {
+    const { container } = renderSetting(undefined)
+    const on = [...container.querySelectorAll('[role="radio"]')].find(
+      (button) => button.textContent === 'On'
+    )
+
+    expect(on?.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('persists the off choice for horizontal scrolling', () => {
+    const updateSettings = vi.fn()
+    const { container } = renderSetting(true, updateSettings)
+    const off = [...container.querySelectorAll<HTMLButtonElement>('[role="radio"]')].find(
+      (button) => button.textContent === 'Off'
+    )
+
+    act(() => off?.click())
+
+    expect(updateSettings).toHaveBeenCalledWith({ editorWordWrap: false })
+  })
+})

--- a/src/renderer/src/components/settings/EditorWordWrapSetting.tsx
+++ b/src/renderer/src/components/settings/EditorWordWrapSetting.tsx
@@ -1,0 +1,69 @@
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { Label } from '../ui/label'
+import { SettingsSegmentedControl } from './SettingsFormControls'
+
+type EditorWordWrapSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function EditorWordWrapSetting({
+  settings,
+  updateSettings
+}: EditorWordWrapSettingProps): React.JSX.Element {
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.7ddd66fede',
+        'Editor Word Wrap'
+      )}
+      description={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.9b18de6eea',
+        'Wrap long lines in file editors instead of requiring horizontal scrolling.'
+      )}
+      keywords={['editor', 'code', 'word wrap', 'wrap', 'horizontal scroll', 'long lines']}
+      className="flex items-center justify-between gap-4 py-2"
+    >
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <Label>
+          {translate(
+            'auto.components.settings.GeneralEditorSettingsSection.7ddd66fede',
+            'Editor Word Wrap'
+          )}
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.GeneralEditorSettingsSection.9b18de6eea',
+            'Wrap long lines in file editors instead of requiring horizontal scrolling.'
+          )}
+        </p>
+      </div>
+      <SettingsSegmentedControl
+        ariaLabel={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.7ddd66fede',
+          'Editor Word Wrap'
+        )}
+        value={settings.editorWordWrap === false ? 'off' : 'on'}
+        onChange={(option) => updateSettings({ editorWordWrap: option === 'on' })}
+        options={[
+          {
+            value: 'off',
+            label: translate(
+              'auto.components.settings.GeneralEditorSettingsSection.bf16ef0af2',
+              'Off'
+            )
+          },
+          {
+            value: 'on',
+            label: translate(
+              'auto.components.settings.GeneralEditorSettingsSection.3f6892f307',
+              'On'
+            )
+          }
+        ]}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -17,6 +17,7 @@ import {
 } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
+import { EditorWordWrapSetting } from './EditorWordWrapSetting'
 
 export type AutoSaveDelayDraftState = {
   sourceDelayMs: number
@@ -247,6 +248,8 @@ export function GeneralEditorSettingsSection({
           ]}
         />
       </SearchableSetting>
+
+      <EditorWordWrapSetting settings={settings} updateSettings={updateSettings} />
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/components/settings/GeneralPane.test.ts
+++ b/src/renderer/src/components/settings/GeneralPane.test.ts
@@ -95,6 +95,13 @@ describe('GeneralPane search entries', () => {
     expect(matchesSettingsSearch('wsl', entries)).toBe(true)
   })
 
+  it('includes file-editor word-wrap and horizontal-scroll keywords', () => {
+    const entries = getGeneralPaneSearchEntries()
+
+    expect(matchesSettingsSearch('editor word wrap', entries)).toBe(true)
+    expect(matchesSettingsSearch('horizontal scroll', entries)).toBe(true)
+  })
+
   it('includes rich Markdown spellcheck keywords', () => {
     const entries = getGeneralPaneSearchEntries()
 

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -30,6 +30,17 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate('auto.components.settings.general.search.e61157e926', 'Editor Word Wrap'),
+    description: translate(
+      'auto.components.settings.general.search.005be5c699',
+      'Wrap long lines in file editors instead of requiring horizontal scrolling.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.e1ee631696', 'editor'),
+      ...translateSearchKeyword('auto.components.settings.general.search.3ca5ab78a5', 'code')
+    ]
+  },
+  {
     title: translate('auto.components.settings.general.search.2760c9933f', 'Default Diff View'),
     description: translate(
       'auto.components.settings.general.search.ecb9415c80',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5394,7 +5394,9 @@
           "bf16ef0af2": "Off",
           "3f6892f307": "On",
           "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+          "7ddd66fede": "Editor Word Wrap",
+          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -7709,7 +7711,9 @@
             "defaultProjectRuntime": "Default Project Runtime",
             "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+            "e61157e926": "Editor Word Wrap",
+            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5394,7 +5394,9 @@
           "bf16ef0af2": "Desactivado",
           "3f6892f307": "Activado",
           "b82f86d7d2": "Corrector ortográfico de Rich Markdown",
-          "5195f0b9ef": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown."
+          "5195f0b9ef": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
+          "7ddd66fede": "Editor Word Wrap",
+          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -7672,7 +7674,9 @@
             "defaultProjectRuntime": "Runtime de proyecto predeterminado",
             "defaultProjectRuntimeDescription": "Elige el runtime que heredarán los proyectos locales de Windows.",
             "d2d2d929c0": "Corrector ortográfico de Rich Markdown",
-            "4497e2e2bb": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown."
+            "4497e2e2bb": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
+            "e61157e926": "Editor Word Wrap",
+            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5402,8 +5402,8 @@
           "3f6892f307": "Activado",
           "b82f86d7d2": "Corrector ortográfico de Rich Markdown",
           "5195f0b9ef": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
-          "7ddd66fede": "Editor Word Wrap",
-          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+          "7ddd66fede": "Ajuste de línea en el editor",
+          "9b18de6eea": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -7682,8 +7682,8 @@
             "defaultProjectRuntimeDescription": "Elige el runtime que heredarán los proyectos locales de Windows.",
             "d2d2d929c0": "Corrector ortográfico de Rich Markdown",
             "4497e2e2bb": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
-            "e61157e926": "Editor Word Wrap",
-            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+            "e61157e926": "Ajuste de línea en el editor",
+            "005be5c699": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5379,7 +5379,9 @@
           "bf16ef0af2": "オフ",
           "3f6892f307": "オン",
           "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+          "7ddd66fede": "Editor Word Wrap",
+          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "ローカルホスト、127.0.0.1、*.internal",
@@ -7694,7 +7696,9 @@
             "defaultProjectRuntime": "Default Project Runtime",
             "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+            "e61157e926": "Editor Word Wrap",
+            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5387,8 +5387,8 @@
           "3f6892f307": "オン",
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
-          "7ddd66fede": "Editor Word Wrap",
-          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+          "7ddd66fede": "エディターのワードラップ",
+          "9b18de6eea": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "ローカルホスト、127.0.0.1、*.internal",
@@ -7704,8 +7704,8 @@
             "defaultProjectRuntimeDescription": "Choose the runtime inherited by local Windows projects.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
-            "e61157e926": "Editor Word Wrap",
-            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+            "e61157e926": "エディターのワードラップ",
+            "005be5c699": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5387,8 +5387,8 @@
           "3f6892f307": "~에",
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
-          "7ddd66fede": "Editor Word Wrap",
-          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+          "7ddd66fede": "편집기 자동 줄 바꿈",
+          "9b18de6eea": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "로컬호스트, 127.0.0.1, *.internal",
@@ -7667,8 +7667,8 @@
             "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
-            "e61157e926": "Editor Word Wrap",
-            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+            "e61157e926": "편집기 자동 줄 바꿈",
+            "005be5c699": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5379,7 +5379,9 @@
           "bf16ef0af2": "끄다",
           "3f6892f307": "~에",
           "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown."
+          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+          "7ddd66fede": "Editor Word Wrap",
+          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "로컬호스트, 127.0.0.1, *.internal",
@@ -7657,7 +7659,9 @@
             "defaultProjectRuntime": "기본 프로젝트 런타임",
             "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다.",
             "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown."
+            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+            "e61157e926": "Editor Word Wrap",
+            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5379,7 +5379,9 @@
           "bf16ef0af2": "关闭",
           "3f6892f307": "开启",
           "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。"
+          "5195f0b9ef": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
+          "7ddd66fede": "Editor Word Wrap",
+          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "本地主机，127.0.0.1，*.internal",
@@ -7657,7 +7659,9 @@
             "defaultProjectRuntime": "默认项目运行时",
             "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。",
             "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。"
+            "4497e2e2bb": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
+            "e61157e926": "Editor Word Wrap",
+            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5387,8 +5387,8 @@
           "3f6892f307": "开启",
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
-          "7ddd66fede": "Editor Word Wrap",
-          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+          "7ddd66fede": "编辑器自动换行",
+          "9b18de6eea": "在文件编辑器中自动换行长行，而无需水平滚动。"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "本地主机，127.0.0.1，*.internal",
@@ -7667,8 +7667,8 @@
             "defaultProjectRuntimeDescription": "选择本地 Windows 项目继承的运行时。",
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
-            "e61157e926": "Editor Word Wrap",
-            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+            "e61157e926": "编辑器自动换行",
+            "005be5c699": "在文件编辑器中自动换行长行，而无需水平滚动。"
           }
         },
         "git": {

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -52,6 +52,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').confirmClosePinnedTab).toBe(true)
   })
 
+  it('keeps file-editor word wrapping enabled by default', () => {
+    expect(getDefaultSettings('/tmp').editorWordWrap).toBe(true)
+  })
+
   it('keeps rich Markdown spellcheck enabled by default', () => {
     expect(getDefaultSettings('/tmp').richMarkdownSpellcheckEnabled).toBe(true)
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -208,6 +208,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
     editorMinimapEnabled: false,
+    editorWordWrap: true,
     richMarkdownSpellcheckEnabled: true,
     markdownReviewToolsEnabled: true,
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2512,6 +2512,8 @@ export type GlobalSettings = {
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number
   editorMinimapEnabled: boolean
+  /** Defaults on for profiles saved before file-editor wrapping became configurable. */
+  editorWordWrap?: boolean
   /** Persisted opt-out for browser spellcheck noise in rich Markdown editing surfaces. */
   richMarkdownSpellcheckEnabled?: boolean
   /** Whether local markdown review note controls and the review panel are shown. */


### PR DESCRIPTION
## Summary

Fixes #8402.

Add a persistent **Editor Word Wrap** preference under **Settings → General → Editor**:

- **On** preserves Orca's existing behavior and remains the default for new and upgraded profiles.
- **Off** keeps each source line on one visual row and enables Monaco's horizontal scrollbar.
- Changes apply to already-mounted file editors as well as newly opened files.
- Git diff wrapping remains controlled independently by the existing **Diff Word Wrap** preference.

## Screenshots

Searchable preference — the existing file-editor default remains **On**, while **Diff Word Wrap** stays independently configurable:

![Settings filtered to Editor Word Wrap and Diff Word Wrap](https://github.com/stablyai/orca/blob/511552c68c9ccf1dd7e61717a9d37a0849f8fd2a/pr8423-settings-word-wrap.png?raw=true)

| On — long lines wrap in the mounted editor | Off — source lines stay on one row and the horizontal scrollbar appears |
|---|---|
| ![File editor with word wrap on](https://github.com/stablyai/orca/blob/511552c68c9ccf1dd7e61717a9d37a0849f8fd2a/pr8423-editor-wrap-on.png?raw=true) | ![File editor with word wrap off and horizontal scrollbar visible](https://github.com/stablyai/orca/blob/511552c68c9ccf1dd7e61717a9d37a0849f8fd2a/pr8423-editor-wrap-off.png?raw=true) |

Captured from the macOS dev app after toggling the preference with the same `MonacoEditor.tsx` tab already open.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 2,718 files / 28,691 tests passed; 28 unrelated renderer tests failed because `window.localStorage` is unavailable under the local unsupported Node 26 runtime. The focused regression suites pass 40/40.
- [x] `pnpm build`
- [x] Added regression coverage for legacy-profile defaults, Monaco option mapping, persisted Off selection, and Settings search discovery

Manual macOS validation:

1. Confirmed **Editor Word Wrap** appears under **Settings → General → Editor** using the existing accessible Off/On segmented control.
2. Set it to **Off**, opened a source file with long lines, and confirmed lines stayed on one row with a horizontal scrollbar.
3. Set it back to **On** and confirmed the preference persisted.

## AI Review Report

Reviewed settings persistence, Monaco option updates, localization, search discovery, and the existing diff-wrap boundary.

- **Correctness:** upgraded profiles with no stored value resolve to On, preserving current behavior. Explicit Off maps to Monaco `wordWrap: 'off'`, and the live editor update effect applies changes without requiring a restart.
- **Cross-platform:** this uses Monaco's platform-neutral editor option and existing Settings controls. It adds no shortcuts, shortcut labels, path assumptions, shell behavior, or Electron-specific platform branches, so behavior is identical on macOS, Linux, and Windows.
- **Local/SSH/remote:** wrapping is renderer presentation state only. Local, SSH, WSL, paired, and remote-runtime files use the same Monaco editor and do not require host-specific handling.
- **Agents and integrations:** file contents and save behavior are unchanged. CLI agents, git providers, diff editors, rich Markdown mode, and terminal integrations are unaffected.
- **Performance:** the preference adds one constant-time Monaco option update when settings change. No polling, listeners, network calls, or unbounded state were added.
- **UI quality:** the control reuses Orca's existing `SearchableSetting` and `SettingsSegmentedControl`, follows the adjacent Diff Word Wrap pattern, is keyboard/screen-reader accessible, and is included in localized Settings search.

No blocking issue remained after review.

## Security Audit

The change adds no command execution, filesystem access, path handling, network requests, authentication, secrets, dependencies, IPC channels, or privilege changes. The new value is a boolean persisted through the existing settings update path and only controls Monaco rendering. File content, editor writes, and trust boundaries are unchanged. No security follow-up is needed.

## Notes

- The setting controls regular file editors only. **Diff Word Wrap** remains separate so users can choose different behavior for source editing and review.
- Existing users retain word wrapping after upgrade until they explicitly select Off.
- X (Twitter): [@gatsby74](https://x.com/gatsby74)
