### PR TITLE
feat(command-code): SessionStart hook + ask_user_question waiting parity

### DIFF
--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -394,7 +394,7 @@ describe('remote hook service installers', () => {
     ) as {
       hooks: Record<string, { matcher?: string; hooks?: { command: string }[] }[]>
     }
-    for (const eventName of ['PreToolUse', 'PostToolUse', 'Stop']) {
+    for (const eventName of ['PreToolUse', 'PostToolUse', 'Stop', 'SessionStart']) {
       const definition = commandCodeConfig.hooks[eventName]?.[0]
       const command = definition?.hooks?.[0]?.command
       expect(command).toContain('/home/dev/.orca/agent-hooks/command-code-hook.sh')
@@ -403,6 +403,7 @@ describe('remote hook service installers', () => {
     expect(commandCodeConfig.hooks.PreToolUse?.[0]?.matcher).toBe('.*')
     expect(commandCodeConfig.hooks.PostToolUse?.[0]?.matcher).toBe('.*')
     expect(commandCodeConfig.hooks.Stop?.[0]?.matcher).toBeUndefined()
+    expect(commandCodeConfig.hooks.SessionStart?.[0]?.matcher).toBeUndefined()
 
     const grokConfig = JSON.parse(grok.fs.files.get('/home/dev/.grok/hooks/orca-status.json')!) as {
       hooks: Record<string, { matcher?: string; hooks?: { command: string }[] }[]>

--- a/src/main/command-code/hook-service.test.ts
+++ b/src/main/command-code/hook-service.test.ts
@@ -47,10 +47,13 @@ describe('CommandCodeHookService', () => {
     ) as {
       hooks: Record<string, { matcher?: string; hooks: { command: string }[] }[]>
     }
-    expect(Object.keys(config.hooks).sort()).toEqual(['PostToolUse', 'PreToolUse', 'Stop'].sort())
+    expect(Object.keys(config.hooks).sort()).toEqual(
+      ['PostToolUse', 'PreToolUse', 'SessionStart', 'Stop'].sort()
+    )
     expect(config.hooks.PreToolUse[0].matcher).toBe('.*')
     expect(config.hooks.PostToolUse[0].matcher).toBe('.*')
     expect(config.hooks.Stop[0].matcher).toBeUndefined()
+    expect(config.hooks.SessionStart[0].matcher).toBeUndefined()
     expect(config.hooks.PreToolUse[0].hooks[0].command).toMatch(
       process.platform === 'win32' ? WINDOWS_POWERSHELL_LAUNCHER : /command-code-hook/
     )

--- a/src/main/command-code/hook-service.ts
+++ b/src/main/command-code/hook-service.ts
@@ -30,7 +30,11 @@ const COMMAND_CODE_EVENTS = [
     eventName: 'PostToolUse',
     definition: { matcher: '.*', hooks: [{ type: 'command', command: '' }] }
   },
-  { eventName: 'Stop', definition: { hooks: [{ type: 'command', command: '' }] } }
+  { eventName: 'Stop', definition: { hooks: [{ type: 'command', command: '' }] } },
+  // Why: Command Code 0.44+ fires SessionStart (source: startup/resume/clear).
+  // Older builds reject unknown events with a skip-warning, so installing it is
+  // forward-safe and lets Orca reset stale turn state on resume like Claude/Codex.
+  { eventName: 'SessionStart', definition: { hooks: [{ type: 'command', command: '' }] } }
 ] as const
 
 function getConfigPath(): string {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -558,6 +558,68 @@ describe('shared agent-hook-listener', () => {
     }
   })
 
+  it('maps Command Code ask_user_question to waiting with the question card', () => {
+    const askState = createHookListenerState()
+    const questionInput = {
+      questions: [
+        {
+          question: 'Which line is your favorite?',
+          header: 'Favorite',
+          options: [{ label: 'Line 1' }, { label: 'Line 2' }]
+        }
+      ]
+    }
+    const waiting = normalizeHookPayload(
+      askState,
+      'command-code',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'ask_user_question',
+          tool_display_name: 'QUESTION',
+          tool_input: questionInput
+        }
+      },
+      'production'
+    )
+    expect(waiting?.payload).toMatchObject({ state: 'waiting', agentType: 'command-code' })
+    expect(waiting?.payload.interactivePrompt).toBe(JSON.stringify(questionInput))
+
+    // Answering the question (PostToolUse) returns to working and clears the card.
+    const answered = normalizeHookPayload(
+      askState,
+      'command-code',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PostToolUse',
+          tool_name: 'ask_user_question',
+          tool_display_name: 'QUESTION',
+          tool_input: questionInput,
+          tool_response: 'Line 2'
+        }
+      },
+      'production'
+    )
+    expect(answered?.payload.state).toBe('working')
+    expect(answered?.payload.interactivePrompt).toBeUndefined()
+  })
+
+  it('resets Command Code turn state on SessionStart without painting a row', () => {
+    const sessionState = createHookListenerState()
+    const result = normalizeHookPayload(
+      sessionState,
+      'command-code',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'SessionStart', source: 'resume' }
+      },
+      'production'
+    )
+    expect(result).toBeNull()
+  })
+
   it('reads newline-heavy Command Code transcripts without line-array splitting', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'orca-command-code-large-transcript-'))
     const transcriptPath = join(tmpDir, 'transcript.jsonl')

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1965,8 +1965,12 @@ function extractCommandCodeToolFields(
     const toolInput =
       deriveToolInputPreview(toolName, hookPayload.tool_input) ??
       deriveFallbackToolInputPreview(hookPayload.tool_input)
+    // Why: ask_user_question arrives as PreToolUse then blocks on the user's
+    // answer. Capture the full question payload so the live card can render the
+    // options, matching the Claude/Grok interactive-question path.
+    const interactivePrompt = deriveInteractivePrompt(toolName, hookPayload.tool_input, eventName)
     const update: ToolSnapshot = toolUpdate(
-      { toolName, toolInput },
+      { toolName, toolInput, interactivePrompt },
       { hasToolInputField: hasOwnField(hookPayload, 'tool_input') }
     )
     if (eventName === 'PostToolUse') {
@@ -3422,8 +3426,26 @@ function normalizeCommandCodeEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
-  const stateName =
-    eventName === 'PreToolUse' || eventName === 'PostToolUse'
+  // Why: Command Code 0.44+ fires SessionStart (source: startup/resume/clear) on
+  // (re)start. Reset stale per-turn state without painting a working row before a
+  // real turn, matching Codex/Grok session handling.
+  if (eventName === 'SessionStart') {
+    clearPaneTurnCacheState(state, paneKey)
+    return null
+  }
+
+  const toolName =
+    readString(hookPayload, 'tool_name') ??
+    readString(hookPayload, 'toolName') ??
+    readString(hookPayload, 'tool_display_name')
+  // Why: ask_user_question fires PreToolUse then blocks awaiting the user's
+  // answer (no PostToolUse/Stop until answered). Surface it as `waiting` so the
+  // sidebar flags attention, matching Claude PermissionRequest / Grok / Kimi.
+  const isUserInputPreTool = eventName === 'PreToolUse' && isAskUserQuestionTool(toolName)
+
+  const stateName = isUserInputPreTool
+    ? 'waiting'
+    : eventName === 'PreToolUse' || eventName === 'PostToolUse'
       ? 'working'
       : eventName === 'Stop'
         ? 'done'


### PR DESCRIPTION
## Summary

Command Code updated its hook surface in recent releases. As of **v0.44.1** it fires **`SessionStart`** (with `source: startup | resume | clear`) in addition to `PreToolUse` / `PostToolUse` / `Stop`. Orca only installed and handled the original three, so it missed the new session lifecycle event and didn't distinguish Command Code's user-question wait from ordinary work. This brings Command Code to parity with our Claude / Grok / Codex handling.

## What changed

| Area | Change |
|------|--------|
| `src/main/command-code/hook-service.ts` | Install the **`SessionStart`** managed hook. Forward-safe — older Command Code builds reject unknown events with a skip-warning (same pattern as Claude's `StopFailure`). Installed locally and over SSH. |
| `src/shared/agent-hook-listener.ts` | Normalize **`SessionStart`** → clear stale per-turn state and emit no row (no phantom `working` before a real turn), matching Codex/Grok. Map **`PreToolUse(ask_user_question)` → `waiting`** so the sidebar flags attention while the agent blocks on the user's answer, and capture the question payload as the interactive card via the shared `deriveInteractivePrompt`. |

Other Command Code payload fields were already handled: `extractCommandCodeToolFields` already reads `tool_name` / `tool_display_name` / `tool_input` / `tool_response`.

## Why (ELI5)

Command Code doesn't have a "user submitted a prompt" hook, but it now tells us when a session **starts or resumes**, and it uses an `ask_user_question` tool when it needs the human to choose something. Before this change Orca ignored session starts and showed "asking you a question" as plain "working", so those worktrees didn't rise in the attention sort. Now a resumed session doesn't leave a stale spinner, and a worktree waiting on your answer surfaces to the top like Claude/Grok do.

## Verification (real Command Code v0.44.1)

Captured hook payloads from a live interactive Command Code session (driven through a PTY):

- **SessionStart** fires on startup: `{ hook_event_name: "SessionStart", source: "startup", session_id, transcript_path, cwd, permission_mode }`.
- **PreToolUse(`ask_user_question`, display `QUESTION`)** fires, then **no further hook** (`PostToolUse`/`Stop`) is emitted until the question is answered — proving the agent is blocked/waiting, so `waiting` is the correct state.
- `PreToolUse`/`PostToolUse`/`Stop` unchanged: `tool_name`, `tool_display_name`, `tool_input`, `tool_response`, `stop_hook_active` as before.

Automated:

```
pnpm exec vitest run --config config/vitest.config.ts \
  src/shared/agent-hook-listener.test.ts \
  src/main/command-code/hook-service.test.ts \
  src/main/agent-hooks/remote-hook-service-installers.test.ts \
  src/main/agent-hooks/server.test.ts   # (Command Code cases)
# passed

pnpm run typecheck   # passed
pnpm exec oxlint <changed files>   # clean
```

New tests cover `SessionStart` → no row, `ask_user_question` → `waiting` + question card, answering → back to `working` + card cleared, and remote `SessionStart` install.

## Known limitation

Command Code exposes **no** hook event for its own tool-permission prompt (unlike Claude's `PermissionRequest`). Only `ask_user_question` is deterministically a wait, so ordinary shell/tool permission prompts still read as `working`. Detecting them from a generic `PreToolUse` would falsely mark every tool as waiting, so this is intentionally scoped to `ask_user_question`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
