### PR TITLE
fix(window): extend startup reveal fallback to Linux so first launch never stays hidden

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -424,7 +424,7 @@ if (app.isPackaged && process.platform !== 'win32') {
 configureDevUserDataPath(is.dev)
 configureOrcaUserDataPathEnv()
 
-// Why: just past createMainWindow's win32 10s ready-to-show reveal fallback,
+// Why: just past createMainWindow's 10s ready-to-show reveal fallback,
 // so a window revealed on that path still gets its tray icon.
 const TRAY_CREATE_FALLBACK_MS = 12_000
 
@@ -865,7 +865,7 @@ function openMainWindow(): BrowserWindow {
   // seconds while explorer.exe's notification area is busy (part of issue
   // #7225's pre-paint stall), so create it after first paint. The timer
   // fallback covers windows revealed without ready-to-show ever firing
-  // (createMainWindow's win32 10s reveal fallback) — those can still be
+  // (createMainWindow's 10s reveal fallback) — those can still be
   // hidden to the tray on close, so the icon must exist by then.
   let trayCreated = false
   const createSystemTrayDeferred = (): void => {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2837,11 +2837,39 @@ describe('createMainWindow', () => {
     })
   })
 
-  it('does not install the startup reveal fallback off Windows', () => {
+  it('reveals the startup window on Linux when ready-to-show never fires', () => {
     vi.useFakeTimers()
     const { browserWindowInstance } = createStartupRevealWindowFixture()
 
     withPlatform('linux', () => {
+      createMainWindow(null)
+      vi.advanceTimersByTime(9_999)
+      expect(browserWindowInstance.show).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+
+      expect(browserWindowInstance.show).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('cancels the Linux startup reveal fallback after ready-to-show', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
+
+    withPlatform('linux', () => {
+      createMainWindow(null)
+      windowHandlers['ready-to-show']()
+      vi.advanceTimersByTime(10_000)
+
+      expect(browserWindowInstance.show).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not install the startup reveal fallback on macOS', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance } = createStartupRevealWindowFixture()
+
+    withPlatform('darwin', () => {
       createMainWindow(null)
       vi.advanceTimersByTime(10_000)
 
@@ -2892,6 +2920,57 @@ describe('createMainWindow', () => {
     const { browserWindowInstance } = createStartupRevealWindowFixture()
 
     withPlatform('win32', () => {
+      createMainWindow(createStartupRevealStore(true) as never)
+      browserWindowInstance.isDestroyed.mockReturnValue(true)
+      vi.advanceTimersByTime(10_000)
+
+      expect(browserWindowInstance.show).not.toHaveBeenCalled()
+      expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+    })
+  })
+
+  it('keeps the headless E2E window hidden when the Linux fallback fires', () => {
+    vi.useFakeTimers()
+    const previousHeadless = process.env.ORCA_E2E_HEADLESS
+    process.env.ORCA_E2E_HEADLESS = '1'
+    const { browserWindowInstance } = createStartupRevealWindowFixture()
+
+    try {
+      withPlatform('linux', () => {
+        createMainWindow(createStartupRevealStore(true) as never)
+        vi.advanceTimersByTime(10_000)
+
+        expect(browserWindowInstance.show).not.toHaveBeenCalled()
+        expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+      })
+    } finally {
+      if (previousHeadless === undefined) {
+        delete process.env.ORCA_E2E_HEADLESS
+      } else {
+        process.env.ORCA_E2E_HEADLESS = previousHeadless
+      }
+    }
+  })
+
+  it('clears the Linux startup reveal fallback when the window is closed', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
+
+    withPlatform('linux', () => {
+      createMainWindow(createStartupRevealStore(true) as never)
+      windowHandlers.closed()
+      vi.advanceTimersByTime(10_000)
+
+      expect(browserWindowInstance.show).not.toHaveBeenCalled()
+      expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+    })
+  })
+
+  it('does not show or maximize a destroyed window when the Linux fallback fires', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance } = createStartupRevealWindowFixture()
+
+    withPlatform('linux', () => {
       createMainWindow(createStartupRevealStore(true) as never)
       browserWindowInstance.isDestroyed.mockReturnValue(true)
       vi.advanceTimersByTime(10_000)

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -337,10 +337,11 @@ export function createMainWindow(
   // the window back to full-screen after the user already resized it (#591).
   let handledInitialReadyToShow = false
   let initialRevealFallbackTimer: ReturnType<typeof setTimeout> | null =
-    process.platform === 'win32'
+    process.platform === 'win32' || process.platform === 'linux'
       ? setTimeout(() => {
-          // Why: GPU/driver failures on Windows can prevent ready-to-show forever,
-          // leaving the only app window hidden while the main process stays alive.
+          // Why: GPU/driver failures on Windows and Linux/X11 can prevent
+          // ready-to-show forever, leaving the only app window hidden while the
+          // main process stays alive (#8421).
           initialRevealFallbackTimer = null
           revealInitialWindow()
         }, 10_000)


### PR DESCRIPTION
## Summary

Fixes #8421.

On Linux/X11, the first launch could leave the only `BrowserWindow` hidden forever: the window is created with `show: false` and revealed on `ready-to-show`, but when that event never fires (GPU/driver quirks — e.g. NVIDIA on X11), nothing else reveals it. A second launch "worked" only because the `second-instance` handler explicitly calls `show()`/`focus()`.

This PR extends the existing bounded 10s initial-reveal fallback timer — introduced for the same failure mode on Windows — to Linux (`process.platform === 'win32' || process.platform === 'linux'` in `src/main/window/createMainWindow.ts`). No new logic: the existing `handledInitialReadyToShow` one-shot guard, destroyed-window check, headless E2E guard, `clearInitialRevealFallbackTimer` cleanup, and timer `unref()` all apply unchanged.

## Screenshots

No visual change. The fix only affects the degraded Linux case where `ready-to-show` never fires: the window now appears after at most 10 s instead of never (previously it required launching the app a second time). On a healthy environment the timer is cancelled by `ready-to-show` and startup behavior is byte-for-byte identical, so there is no capturable before/after UI difference.

Regression-test proof (new test vs. base implementation):

```text
# base (origin/main implementation, new tests only)
× reveals the startup window on Linux when ready-to-show never fires
Tests  1 failed | 68 passed (69)

# with this fix
Tests  72 passed (72)
```

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (2722 files, 28 734 tests passed)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New tests mirror the existing Windows fallback suite for Linux (fake timers + `withPlatform('linux', ...)`):

- reveals the startup window on Linux when `ready-to-show` never fires (fails on `main`, passes with the fix)
- cancels the Linux startup reveal fallback after `ready-to-show`
- keeps the headless E2E window hidden when the Linux fallback fires
- clears the Linux startup reveal fallback when the window is closed
- does not show or maximize a destroyed window when the Linux fallback fires
- the previous "does not install the startup reveal fallback off Windows" test now asserts macOS specifically

Also ran the Playwright E2E harness locally (`tests/e2e/file-open.spec.ts`, electron-headless, 4/4 passed) as an app-startup smoke test.

## AI Review Report

Two-axis review (repo standards + issue spec) with independent reviewer agents, adjudicated before opening this PR:

- **Cross-platform (macOS/Linux/Windows)**: behavior is gated by an explicit `process.platform` runtime check (not `!== 'darwin'`). Windows path untouched and still covered by its original tests; macOS covered by a new explicit "does not install the fallback on macOS" test.
- **SSH/remote/local**: not implicated — the change is main-process window lifecycle only; no Git, terminal, daemon, or network path is touched.
- **Agent/integration compatibility**: none affected; no IPC or renderer surface changed.
- **Performance**: one `setTimeout` at startup, `unref()`'d and cleared on `ready-to-show`/window close; no hot-path or teardown-leak risk.
- **UI quality / E2E**: the shared headless guard keeps the window hidden in E2E mode when the fallback fires — now explicitly tested for Linux.
- **Flagged and addressed**: the review found that the closed-window/destroyed-window/headless guards were only proven for win32; Linux mirror tests were added in response.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The diff widens one platform conditional around an existing, already-guarded window-reveal call and adds tests; it introduces no new attack surface. No follow-up needed.

## Notes

- Linux-specific behavior change only; Windows keeps its identical fallback and macOS intentionally gets none (no known `ready-to-show` starvation there — preserving current behavior).
- The 10 s bound matches the Windows precedent deliberately; the issue's alternative (reveal on `dom-ready`/`did-finish-load`) was not taken so the two platforms share one code path and failure model.
- The fallback applies to Linux broadly (X11 and Wayland), matching the Windows precedent of not gating on the GPU/driver specifics that cause the starvation.

X handle: [@KaynanSampaio1](https://x.com/KaynanSampaio1)
