### PR TITLE
fix(terminal): gate Shift+Enter CSI-u on active protocol

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -66,12 +66,12 @@ describe('resolveTerminalShortcutAction', () => {
     ).toEqual({ type: 'focusPane', direction: 'next' })
   })
 
-  it('keeps shift-enter and delete helpers explicit', () => {
+  it('keeps inactive shift-enter and delete helpers explicit', () => {
     expect(
       resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', shiftKey: true }), true)
     ).toEqual({
       type: 'sendInput',
-      data: '\x1b[13;2u'
+      data: '\x1b\r'
     })
     expect(resolveTerminalShortcutAction(event({ key: 'Backspace', ctrlKey: true }), true)).toEqual(
       { type: 'sendInput', data: '\x17' }
@@ -164,9 +164,9 @@ describe('resolveTerminalShortcutAction', () => {
     expect(getWindowsShiftEnterEncoding).not.toHaveBeenCalled()
   })
 
-  it('always uses CSI-u Shift+Enter off Windows regardless of Windows encoding', () => {
+  it('uses CSI-u Shift+Enter off Windows only while Kitty keyboard is active', () => {
     for (const encoding of [() => 'csi-u' as const, () => 'alt-enter' as const, undefined]) {
-      expect(
+      const resolve = (kittyActive: boolean) =>
         resolveTerminalShortcutAction(
           event({ key: 'Enter', code: 'Enter', shiftKey: true }),
           false,
@@ -175,11 +175,12 @@ describe('resolveTerminalShortcutAction', () => {
           false,
           undefined,
           undefined,
-          undefined,
+          () => kittyActive,
           undefined,
           encoding
         )
-      ).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
+      expect(resolve(true)).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
+      expect(resolve(false)).toEqual({ type: 'sendInput', data: '\x1b\r' })
     }
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -158,7 +158,11 @@ export function resolveTerminalShortcutAction(
       : isWindows
         ? 'alt-enter'
         : 'csi-u'
-    return { type: 'sendInput', data: encoding === 'csi-u' ? '\x1b[13;2u' : '\x1b\r' }
+    // Why: CSI-u is application input, not a universal terminal sequence. Off
+    // Windows, only send it while the pane's application has KKP active.
+    const canSendCsiU =
+      encoding === 'csi-u' && (useLocalWindowsCapability || isKittyKeyboardActivePane?.() === true)
+    return { type: 'sendInput', data: canSendCsiU ? '\x1b[13;2u' : '\x1b\r' }
   }
 
   if (

--- a/tests/e2e/terminal-shortcuts.spec.ts
+++ b/tests/e2e/terminal-shortcuts.spec.ts
@@ -518,19 +518,26 @@ test.describe('Terminal Shortcuts', () => {
     await waitForPaneCount(orcaPage, 1, 30_000)
   })
 
-  test('Shift+Enter writes the platform newline chord for terminal TUIs', async ({
-    orcaPage,
-    electronApp
-  }) => {
+  test('Shift+Enter follows the pane Kitty keyboard state', async ({ orcaPage, electronApp }) => {
     await installMainProcessPtyWriteSpy(electronApp)
-    await waitForActivePanePtyId(orcaPage)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
 
-    await pressAndExpectWrite(
-      orcaPage,
-      electronApp,
-      'Shift+Enter',
-      process.platform === 'win32' ? '\x1b\r' : '\x1b[13;2u'
-    )
+    await pressAndExpectWrite(orcaPage, electronApp, 'Shift+Enter', '\x1b\r')
+    if (process.platform === 'win32') {
+      return
+    }
+
+    // Why: exercise the production PTY-output tracker, not xterm's renderer-
+    // local flag state, so the test covers the bytes the shortcut policy sees.
+    await execInTerminal(orcaPage, ptyId, "printf '\\033[>1u'")
+    await expect.poll(() => getKittyKeyboardFlags(orcaPage)).toBe(1)
+    await pressAndExpectWrite(orcaPage, electronApp, 'Shift+Enter', '\x1b[13;2u')
+
+    // The shell is only standing in for a KKP-aware TUI and does not consume
+    // the CSI-u input above, so cancel that synthetic line before its reset.
+    await execInTerminal(orcaPage, ptyId, "\x03printf '\\033[<u'")
+    await expect.poll(() => getKittyKeyboardFlags(orcaPage)).toBe(0)
+    await pressAndExpectWrite(orcaPage, electronApp, 'Shift+Enter', '\x1b\r')
   })
 
   test('Droid gets CSI-u Shift+Enter on Windows without changing Antigravity', async ({
@@ -769,14 +776,8 @@ test.describe('Terminal Shortcuts', () => {
     // Ctrl+Backspace → \x17 (unix-word-rubout).
     await pressAndExpectWrite(orcaPage, electronApp, 'Control+Backspace', '\x17')
 
-    // Shift+Enter stays distinct; Windows keeps Esc+CR unless the active agent
-    // explicitly requires CSI-u (currently Droid, #7620).
-    await pressAndExpectWrite(
-      orcaPage,
-      electronApp,
-      'Shift+Enter',
-      process.platform === 'win32' ? '\x1b\r' : '\x1b[13;2u'
-    )
+    // The shell has not enabled KKP, so Shift+Enter must not leak CSI-u text.
+    await pressAndExpectWrite(orcaPage, electronApp, 'Shift+Enter', '\x1b\r')
 
     // --- send-input chords (macOS-only) ---
 


### PR DESCRIPTION
## Description

Fixes the literal `[13;2u` Shift+Enter leak without broadening terminal byte routing.

- On macOS/Linux, send Kitty CSI-u (`ESC [ 13 ; 2 u`) only while the pane's application has active Kitty keyboard flags.
- Before negotiation and after a protocol reset, use the existing `Esc+CR` fallback.
- Preserve current Windows behavior, including the trusted Droid-only CSI-u exception and the conservative SSH/WSL/remote fallback.
- Keep Ctrl+Enter unchanged because the installed Grok CLI decodes it without advertising active Kitty flags; gating it would collapse the chord to plain Enter.

Closes #8385.

## Evidence

### Real Grok CLI

Tested the installed `grok 0.2.93 (f00f96316d4b)` in a real PTY:

- `PRE` + CSI-u Shift+Enter + `POST` rendered as two composer lines.
- `Esc+CR` + `ALT` also rendered a new composer line, confirming the safe fallback preserves Grok multiline input.
- This Grok build emitted no Kitty push/set activation sequence during startup, which is why the broader Ctrl+Enter gate from #8386 was not taken.

### Electron / PTY end to end

`pnpm run test:e2e -- tests/e2e/terminal-shortcuts.spec.ts --workers=1`

- 7 passed, 1 Windows-only test skipped on macOS.
- The regression test drives the real DOM keydown → shortcut policy → transport → IPC path and proves:
  1. inactive flags → `Esc+CR`
  2. PTY-output `CSI > 1 u` activation → CSI-u Shift+Enter
  3. PTY-output reset/pop → `Esc+CR`
- The complete terminal shortcut suite also confirms Ctrl+Enter, Ctrl+C, layout input, scrolling, and other chords remain intact.

### Automated checks

- `pnpm test`: 2,721 files passed; 28,730 tests passed; 8 files / 40 tests skipped.
- Focused protocol/shortcut Vitest: 53 tests passed.
- `pnpm run typecheck`: passed.
- `pnpm run lint`: passed (pre-existing unrelated warnings only).
- `pnpm exec oxfmt --check ...`: passed.
- Electron `--mode e2e` build: passed.

## ELI5

CSI-u is like speaking a special keyboard language. Orca used to say “Shift+Enter” in that language even when the program had not said it understood it, so the program could print part of the instruction as `[13;2u`. Orca now checks the live “I understand Kitty keyboard” flag first. If it is absent, Orca uses the older safe newline chord instead.

## Trade-offs

- A TUI that understands CSI-u but never activates Kitty keyboard now receives `Esc+CR` for Shift+Enter. That is intentional protocol hygiene; the real Grok version was verified to treat the fallback as a newline.
- Ctrl+Enter remains unconditional CSI-u. Changing it is outside the reported `[13;2u` bug and #8386's proposed gate would regress the installed Grok build to plain Enter because it does not publish active flags.
- Windows routing remains agent-aware rather than handshake-gated. This preserves the hardened Droid path from #7668 and avoids making Grok an unconditional Windows CSI-u exception that could recreate the leak after exit/reset.
- This fixes the identified control-byte injection path. It does not claim to fix an unrelated long-output renderer bug if one exists independently of the leaked input.

## Review of #8386

Kept the core insight: live Kitty state should gate off-Windows Shift+Enter CSI-u. Reworked the patch on current `main` and omitted two risky additions:

- gating Ctrl+Enter, which regresses real Grok when it has no active Kitty flags;
- declaring Grok as unconditional Windows CSI-u, which bypasses live state and can recreate the exact post-reset leak.

## Security

No new IPC, filesystem, network, dependency, authentication, or secret surface. The change only selects between two existing key encodings for an already-open PTY.
