### PR TITLE
Add Cursor orchestration group routing

### DIFF
--- a/config/scripts/orchestration-skill-guidance.test.mjs
+++ b/config/scripts/orchestration-skill-guidance.test.mjs
@@ -198,6 +198,13 @@ describe('orchestration skill guidance', () => {
     expect(messaging).toContain('`@grok`')
   })
 
+  it('documents @cursor in the Messaging group address list', () => {
+    const skill = readSkill()
+    const messaging = getSection(skill, 'Messaging')
+
+    expect(messaging).toContain('`@cursor`')
+  })
+
   it('keeps agent-first launch, handle recovery, and inbox injection distinct', () => {
     const skill = readSkill()
     const messaging = getSection(skill, 'Messaging')

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -96,7 +96,7 @@ Rules:
 - Heartbeats and visible terminal activity mean the worker is alive, not done. Do not stop, close, kill, or restart a worker just because it has not produced a completion message yet.
 - Use `ask` when a worker needs a blocking answer from the coordinator; it waits for the reply and returns the answer directly.
 - `check --wait` returns one message at a time. If N workers may finish together, loop N times and dispatch newly ready tasks after each completion.
-- Group addresses include `@all`, `@idle`, `@claude`, `@codex`, `@opencode`, `@gemini`, `@droid`, `@grok`, and `@worktree:<id>`.
+- Group addresses include `@all`, `@idle`, `@claude`, `@codex`, `@opencode`, `@gemini`, `@droid`, `@grok`, `@cursor`, and `@worktree:<id>`.
 - Message types include `status`, `dispatch`, `worker_done`, `merge_ready`, `escalation`, `handoff`, `decision_gate`, and `heartbeat`.
 - Use group addresses only for messages that are genuinely useful to many terminals, such as `status` broadcasts or intentional fan-out questions. Do not send dispatch lifecycle messages to groups.
 - `worker_done` must target the concrete coordinator handle from the live preamble. It is completion authority for one dispatch; group fanout would create false lifecycle mail in unrelated terminals.

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4,6 +4,7 @@
 import {
   detectAgentStatusFromTitle,
   isClaudeManagementTitle,
+  isCursorAgentTitle,
   isCursorNativeAgentTitle,
   isShellProcess,
   normalizeTerminalTitle
@@ -965,24 +966,6 @@ function isCursorAgentOrchestrationTarget(
   tabTitle: string | null | undefined
 ): boolean {
   return [leaf.lastOscTitle, leaf.paneTitle, tabTitle].some(isCursorAgentTitle)
-}
-
-function isCursorAgentTitle(title: string | null | undefined): boolean {
-  if (typeof title !== 'string') {
-    return false
-  }
-  const trimmed = title.trim()
-  const lower = trimmed.toLowerCase()
-  if (
-    lower === 'cursor agent' ||
-    lower === 'cursor ready' ||
-    lower === 'cursor - action required'
-  ) {
-    return true
-  }
-  // Why: display labels can mention Cursor in another agent's task text. Only
-  // treat the controlled synthetic Cursor spinner title as Cursor identity.
-  return /^[\u2800-\u28ff] Cursor Agent$/u.test(trimmed)
 }
 
 type RuntimePtyWorktreeRecord = {

--- a/src/main/runtime/orchestration/groups.test.ts
+++ b/src/main/runtime/orchestration/groups.test.ts
@@ -31,6 +31,7 @@ describe('isGroupAddress', () => {
     expect(isGroupAddress('@claude')).toBe(true)
     expect(isGroupAddress('@droid')).toBe(true)
     expect(isGroupAddress('@grok')).toBe(true)
+    expect(isGroupAddress('@cursor')).toBe(true)
     expect(isGroupAddress('@worktree:wt_1')).toBe(true)
   })
 
@@ -217,6 +218,88 @@ describe('resolveGroupAddress', () => {
       const result = resolveGroupAddress('@grok', 'coordinator', terminals, noStatus)
 
       expect(result).toEqual(['term_exe', 'term_cmd'])
+    })
+
+    // Why: these are the titles cursor-agent natively emits and the ones Orca synthesizes
+    // from Cursor hooks, so each must resolve.
+    it('matches native and Orca-synthesized Cursor titles', () => {
+      const terminals = [
+        makeSummary('coordinator', { title: 'Coordinator' }),
+        makeSummary('term_native', { title: 'Cursor Agent' }),
+        makeSummary('term_working', { title: '⠋ Cursor Agent' }),
+        makeSummary('term_idle', { title: 'Cursor ready' }),
+        makeSummary('term_permission', { title: 'Cursor - action required' })
+      ]
+
+      const result = resolveGroupAddress('@cursor', 'coordinator', terminals, noStatus)
+
+      expect(result).toEqual(['term_native', 'term_working', 'term_idle', 'term_permission'])
+    })
+
+    it('is case-insensitive for @cursor', () => {
+      const terminals = [
+        makeSummary('coordinator', { title: 'Coordinator' }),
+        makeSummary('term_b', { title: 'CURSOR READY' })
+      ]
+
+      const result = resolveGroupAddress('@CuRsOr', 'coordinator', terminals, noStatus)
+
+      expect(result).toEqual(['term_b'])
+    })
+
+    // Why: this is the false positive that a whole-token matcher cannot catch. Claude
+    // and Codex put their task summary in the OSC title, and none of Claude's status
+    // prefixes carries its own name, so "cursor" as ordinary editor vocabulary is the
+    // only agent token such a title has. Routing @cursor there would write into a live
+    // non-Cursor agent's prompt.
+    it('does not match another agent whose task title mentions a text cursor', () => {
+      const terminals = [
+        makeSummary('coordinator', { title: 'Coordinator' }),
+        makeSummary('term_claude_working', {
+          title: '⠋ preserve cursor visibility across replays'
+        }),
+        makeSummary('term_claude_idle', { title: '✳ Fix the text cursor blink' }),
+        makeSummary('term_claude_dot', { title: '. fix cursor position' }),
+        makeSummary('term_claude_star', { title: '* cursor rendering done' }),
+        makeSummary('term_codex', { title: '⠋ Codex: fix cursor offsets' }),
+        makeSummary('term_grok', { title: '⠋ - restoring cursor state - grok' }),
+        makeSummary('term_shell', { title: 'Terminal Cursor and Orca slows down' })
+      ]
+
+      const result = resolveGroupAddress('@cursor', 'coordinator', terminals, noStatus)
+
+      expect(result).toEqual([])
+    })
+
+    // Why: pin the deliberate tradeoff. A renamed Cursor pane outranks its OSC title, so it
+    // is group-unaddressable and resolves to nothing instead of resolving loosely. A silent
+    // miss (address it by handle) is preferred over delivering into another agent's prompt.
+    it('does not match a renamed Cursor terminal or the bare process name', () => {
+      const terminals = [
+        makeSummary('coordinator', { title: 'Coordinator' }),
+        makeSummary('term_renamed', { title: 'Cursor - reviewer' }),
+        makeSummary('term_worker', { title: 'cursor worker 2' }),
+        makeSummary('term_process', { title: 'cursor-agent' })
+      ]
+
+      const result = resolveGroupAddress('@cursor', 'coordinator', terminals, noStatus)
+
+      expect(result).toEqual([])
+    })
+
+    it('does not match cursor paths, hyphenated compounds, or dotted tokens', () => {
+      const terminals = [
+        makeSummary('coordinator', { title: 'Coordinator' }),
+        makeSummary('term_rules', { title: '~/cursor-rules' }),
+        makeSummary('term_path', { title: '/tmp/cursor' }),
+        makeSummary('term_worker', { title: 'my-cursor-worker' }),
+        makeSummary('term_file', { title: 'render-cursor-after-bracketed-paste' }),
+        makeSummary('term_dotted', { title: 'cursor.ts' })
+      ]
+
+      const result = resolveGroupAddress('@cursor', 'coordinator', terminals, noStatus)
+
+      expect(result).toEqual([])
     })
   })
 

--- a/src/main/runtime/orchestration/groups.ts
+++ b/src/main/runtime/orchestration/groups.ts
@@ -1,3 +1,4 @@
+import { isCursorAgentTitle } from '../../../shared/agent-title-core'
 import { buildAgentNameRe } from '../../../shared/agent-name-token-match'
 import type { RuntimeTerminalSummary } from '../../../shared/runtime-types'
 
@@ -13,20 +14,31 @@ const AGENT_NAME_GROUPS = [
   'mimo',
   'gemini',
   'droid',
-  'grok'
+  'grok',
+  'cursor'
 ] as const
 
-export type GroupAddress =
-  | '@all'
-  | '@idle'
-  | `@${(typeof AGENT_NAME_GROUPS)[number]}`
-  | `@worktree:${string}`
+type AgentNameGroup = (typeof AGENT_NAME_GROUPS)[number]
+
+export type GroupAddress = '@all' | '@idle' | `@${AgentNameGroup}` | `@worktree:${string}`
 
 export function isGroupAddress(to: string): boolean {
   return to.startsWith('@')
 }
 
+// Why: a name token identifies an agent only when the name is a coined word. `cursor` is
+// also ordinary vocabulary in another agent's task-summary title ("fix the text cursor
+// blink"), so token-matching it would route @cursor into a live Claude/Codex prompt. Names
+// with that ambiguity register the identity predicate delivery already applies to them.
+const GROUP_TITLE_MATCHERS: Partial<Record<AgentNameGroup, (title: string) => boolean>> = {
+  cursor: isCursorAgentTitle
+}
+
 function titleMatchesAgentNameGroup(title: string, agentName: string): boolean {
+  const identityMatcher = GROUP_TITLE_MATCHERS[agentName as AgentNameGroup]
+  if (identityMatcher) {
+    return identityMatcher(title)
+  }
   // Why: reuse the shared whole-token matcher so orchestration groups honor the
   // same Windows launcher-suffix rule (e.g. `grok.exe`) as the rest of Orca's
   // agent-title detection, instead of maintaining a divergent regex here.

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -372,6 +372,23 @@ describe('orchestration RPC methods', () => {
       expect(result.messages[0].to_handle).toBe('term_b')
     })
 
+    it('fans out @cursor by title match without claiming a cursor-mentioning title', async () => {
+      setupWithTerminals([
+        makeSummary('term_a', { title: 'Codex' }),
+        makeSummary('term_b', { title: 'Cursor ready' }),
+        makeSummary('term_c', { title: '✳ Fix the text cursor blink' })
+      ])
+
+      const result = (await call('orchestration.send', {
+        from: 'term_a',
+        to: '@cursor',
+        subject: 'cursor only'
+      })) as { messages: { to_handle: string }[]; recipients: number }
+
+      expect(result.recipients).toBe(1)
+      expect(result.messages[0].to_handle).toBe('term_b')
+    })
+
     it('fans out @worktree:<id> to matching worktree', async () => {
       setupWithTerminals([
         makeSummary('term_a', { worktreeId: 'wt_1' }),

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -504,7 +504,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         if (!hasAgent) {
           throw new Error(
             `Cannot dispatch --inject to terminal ${to}: no recognized agent detected. ` +
-              'Start an agent CLI (e.g. claude, codex, gemini, droid) in the terminal first, ' +
+              'Start an agent CLI (e.g. claude, codex, gemini, droid, cursor) in the terminal first, ' +
               'or dispatch without --inject and send the prompt manually.'
           )
         }

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -5,6 +5,7 @@ import {
   extractAllOscTitles,
   extractLastOscTitle,
   getAgentLabel,
+  isCursorAgentTitle,
   MAX_OSC_TITLE_CHARS,
   normalizeTerminalTitle
 } from './agent-detection'
@@ -14,6 +15,7 @@ import {
   normalizeCompatibleAgentTitleForOwner,
   resolveCompatibleAgentTypeForOwner
 } from './agent-title-owner'
+import { SYNTHETIC_AGENT_TITLE_PROFILES } from './synthetic-agent-title'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -176,4 +178,51 @@ describe('Pi-compatible title detection', () => {
       expect(detectAgentStatusFromTitle(title)).toBeNull()
     }
   )
+})
+
+describe('Cursor agent title identity', () => {
+  // Why: the accepted vocabulary is the set of labels Orca actually synthesizes for Cursor.
+  // Pin it to that profile so renaming a label there cannot silently drop @cursor to zero
+  // recipients (and desync the auto-Enter suppression that shares this predicate).
+  it('accepts every label Orca synthesizes for Cursor', () => {
+    const profile = SYNTHETIC_AGENT_TITLE_PROFILES.cursor
+
+    for (const label of [
+      profile.workingLabel,
+      `⠋ ${profile.workingLabel}`,
+      profile.idleLabel,
+      profile.permissionLabel
+    ]) {
+      expect(isCursorAgentTitle(label)).toBe(true)
+    }
+  })
+
+  it.each([
+    'Cursor Agent',
+    '  cursor agent  ',
+    '⠋ Cursor Agent',
+    '⣿ Cursor Agent',
+    'Cursor ready',
+    'Cursor - action required'
+  ])('accepts the native or Orca-synthesized Cursor title %j', (title) => {
+    expect(isCursorAgentTitle(title)).toBe(true)
+  })
+
+  // Why: "cursor" is ordinary editor vocabulary in another agent's task-summary title,
+  // so a whole-token name match is not Cursor identity.
+  it.each([
+    '⠋ fix the text cursor blink',
+    '✳ Fix the text cursor blink',
+    '. fix cursor position',
+    '* cursor rendering done',
+    'Terminal Cursor and Orca slows down',
+    'cursor-agent',
+    'cursor.exe',
+    '~/cursor-rules',
+    '',
+    null,
+    undefined
+  ])('rejects the non-Cursor title %j', (title) => {
+    expect(isCursorAgentTitle(title)).toBe(false)
+  })
 })

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -11,6 +11,7 @@
 export type { AgentStatus } from './agent-title-core'
 export {
   isClaudeManagementTitle,
+  isCursorAgentTitle,
   isCursorNativeAgentTitle,
   isGeminiTerminalTitle,
   isPiTerminalTitle,

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -108,3 +108,25 @@ export function isClaudeManagementTitle(title: string): boolean {
 export function isCursorNativeAgentTitle(title: string): boolean {
   return title.trim().toLowerCase() === CURSOR_NATIVE_TITLE_LOWER
 }
+
+// Why: `cursor` is also an ordinary editor noun that other agents type into their own
+// task-summary titles, so a name token is not identity. Cursor's identifying titles are
+// a closed set (the native literal plus the labels Orca synthesizes from Cursor hooks),
+// so match that vocabulary instead.
+export function isCursorAgentTitle(title: string | null | undefined): boolean {
+  if (typeof title !== 'string') {
+    return false
+  }
+  const trimmed = title.trim()
+  const lower = trimmed.toLowerCase()
+  if (
+    lower === CURSOR_NATIVE_TITLE_LOWER ||
+    lower === 'cursor ready' ||
+    lower === 'cursor - action required'
+  ) {
+    return true
+  }
+  // Why: display labels can mention Cursor in another agent's task text. Only
+  // treat the controlled synthetic Cursor spinner title as Cursor identity.
+  return /^[\u2800-\u28ff] Cursor Agent$/u.test(trimmed)
+}


### PR DESCRIPTION
## Summary

- add `@cursor` to the orchestration agent-name groups, so it resolves to running Cursor terminals instead of zero recipients
- resolve it by Cursor title identity rather than a name token, because `cursor` is the one group name that is also ordinary vocabulary in another agent's task title
- reuse the identity predicate orchestration delivery already applies to Cursor, by hoisting `isCursorAgentTitle` out of `orca-runtime.ts` into `src/shared/agent-title-core.ts`
- cover Cursor's real titles plus caret-text, path, hyphen, and dotted false positives

Cursor was already first class everywhere else: launchable in `tui-agent-config.ts`, managed status hooks, title detection, and `--inject` accepts it via `isTerminalRunningAgent`. Only the group allowlist omitted it.

## Design

`grok`, `droid`, `codex`, `mimo`, `gemini` are coined names. `cursor` is an English noun, in a terminal app, that agents type into their own OSC titles constantly. It is the only entry in `AGENT_NAMES` with that property, and it is why this group cannot use `buildAgentNameRe`.

`buildAgentNameRe('cursor')` returns true for all three titles below. None is a Cursor terminal:

| Title | Actual owner |
| --- | --- |
| `⠋ preserve cursor visibility across replays` | Claude Code (working) |
| `⠋ Codex: fix cursor offsets` | Codex |
| `Terminal Cursor and Orca slows down` | plain shell or tab title |

None of Claude Code's four title prefixes (`✳`, `. `, `* `, braille spinner) contains its own name, so in a Claude terminal working on caret code, "cursor" is the only agent-like token the title has. Group resolution is a routing authority: delivery writes the message into the target terminal's live prompt, so a false positive types into another agent's session. Anyone using Orca to work on Orca hits this, since the codebase talks about cursors constantly.

So ambiguous names register an identity matcher instead of a token regex. The resolver keeps no agent-specific branch, and every other group's matching is byte-for-byte unchanged:

```ts
const GROUP_TITLE_MATCHERS: Partial<Record<AgentNameGroup, (title: string) => boolean>> = {
  cursor: isCursorAgentTitle
}
```

`isCursorAgentTitle` is not new. It already existed privately in `orca-runtime.ts`, where delivery uses it to suppress synthesized Enter, since Cursor treats injected PTY text as editable prompt input. Its comment names this exact hazard: "display labels can mention Cursor in another agent's task text." Moving it into shared means routing and delivery share one predicate rather than growing a second, weaker one. It is behavior-identical; the only edit is the inline `'cursor agent'` literal collapsing into the `CURSOR_NATIVE_TITLE_LOWER` constant already in that file.

That also answers the brittleness question. Delivery's auto-Enter suppression already depends on this vocabulary, so a Cursor label change breaks there first and louder. The vocabulary already had to be maintained; this makes it one place instead of two, and a test pins it against `SYNTHETIC_AGENT_TITLE_PROFILES.cursor`.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added tests that would catch a regression

**`orca-runtime.test.ts` is not touched by this PR and passes unchanged (660 tests).** Its existing case "still auto-submits to a non-Cursor agent when its idle title mentions Cursor Agent" is exactly the delivery behavior the hoist had to preserve, so the pre-existing suite validates it with zero test edits.

Dev Electron/runtime validation with live `@cursor` routing: with one real `cursor-agent` terminal and one decoy titled `⠋ preserve cursor visibility across replays`, `orchestration send --to @cursor` resolved `recipients=1` to the Cursor terminal and excluded the decoy. `orchestration dispatch --inject` returned `injected=true`, and Cursor executed the task and reported `worker_done`. 0 console errors.

## Screenshots

No visual change.

## AI Review Report

Reviewed the diff with three independent agents before filing (Codex GPT-5.6 Sol at max reasoning, Grok 4.5 xhigh, and Composer 2.5), each asked to attack the design rather than confirm it, with every finding required to cite `file:line` and an exact triggering title. All three returned ship with no material findings. Risks checked:

- **Cross-platform (macOS, Linux, Windows) and SSH/remote:** no paths, shell behavior, shortcuts, or labels are touched. The Cursor label vocabulary is synthesized by main from hook events and is identical on all platforms and over SSH; only the hook script filename differs, which this PR does not touch. Other groups keep the Windows launcher-suffix rule (`grok.exe`); Cursor's binary is `cursor-agent`, so that rule was never load-bearing for it.
- **Agent and integration compatibility:** only `cursor` registers a matcher. A generic `resolveTerminalTitleAgentType(title) === agentName` guard was tried first and rejected, because it silently breaks `@mimo`: the group name is `mimo` but its TuiAgent id is `mimo-code`. It also still mislabels `⠋ preserve cursor visibility across replays` as Cursor.
- **Performance:** one string compare or one anchored regex per terminal, on a list already being iterated.
- **Security:** no new input parsing, command execution, path handling, auth, secrets, or IPC surface. The change tightens routing authority rather than loosening it: fewer titles can attract `@cursor` traffic into a live prompt. Residual, and shared with every other group: a user who renames a terminal to an exact agent label can still make it addressable.

## Notes

- `@cursor` is deliberately less rename-tolerant than other groups. A manually renamed Cursor pane (`Cursor - reviewer`) is group-unaddressable and resolves to 0 recipients rather than misdelivering; address it by handle. A test pins this so the tradeoff lives in code, not just here.
- `Cursor - action required` is accepted but not reachable today, since no subscribed Cursor hook event maps to a blocked state. Kept so the group works unchanged if Cursor ships a permission hook.
- Display surfaces still token-match `cursor` in `terminal-title-agent-type.ts`, so a cursor-mentioning Claude title is labeled Cursor in the UI while `@cursor` will not deliver to it. Routing is deliberately the stricter of the two. Pre-existing and out of scope; happy to follow up separately.
