### PR TITLE
feat(orchestration): add bounded task inventory

### DIFF
--- a/src/cli/handlers/orchestration-bounded-inventory.test.ts
+++ b/src/cli/handlers/orchestration-bounded-inventory.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+import { printResult } from '../format'
+
+describe('orchestration task-list bounded inventory', () => {
+  const invokeTaskList = (flags: Map<string, string | boolean>) =>
+    ORCHESTRATION_HANDLERS['orchestration task-list']({
+      flags,
+      client: { call: callMock },
+      json: true
+    } as never)
+
+  beforeEach(() => {
+    callMock.mockReset().mockResolvedValue({
+      result: {
+        tasks: [{ id: 'task_1', title: 'Task task_1', status: 'ready' }],
+        totalCount: 2,
+        nextCursor: 'next-cursor',
+        truncated: true
+      }
+    })
+    vi.mocked(printResult).mockClear()
+  })
+
+  it('maps canonical limit and cursor flags to the bounded RPC request', async () => {
+    await invokeTaskList(
+      new Map<string, string | boolean>([
+        ['limit', '1'],
+        ['cursor', 'next-cursor']
+      ])
+    )
+
+    expect(callMock).toHaveBeenCalledWith('orchestration.taskList', {
+      limit: 1,
+      cursor: 'next-cursor'
+    })
+    expect(vi.mocked(printResult).mock.calls[0]?.[0]).toMatchObject({
+      result: { totalCount: 2, truncated: true }
+    })
+  })
+
+  it('fails closed when an older runtime returns the legacy task shape', async () => {
+    callMock.mockResolvedValueOnce({
+      result: {
+        tasks: [{ id: 'task_1', spec: 'private task specification', status: 'ready' }],
+        count: 1
+      }
+    })
+
+    await expect(invokeTaskList(new Map([['limit', '1']]))).rejects.toThrow(/bounded inventory/)
+    expect(vi.mocked(printResult)).not.toHaveBeenCalled()
+  })
+
+  it.each(['01', '1e2', '0', '1001'])('rejects non-canonical bounded limit %s', async (limit) => {
+    await expect(invokeTaskList(new Map([['limit', limit]]))).rejects.toThrow(/--limit/)
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    new Map<string, string | boolean>([['cursor', 'next-cursor']]),
+    new Map<string, string | boolean>([
+      ['limit', '1'],
+      ['status', 'ready']
+    ]),
+    new Map<string, string | boolean>([
+      ['limit', '1'],
+      ['ready', true]
+    ]),
+    new Map<string, string | boolean>([
+      ['limit', '1'],
+      ['brief', true]
+    ])
+  ])('rejects bounded inventory flag conflicts', async (flags) => {
+    await expect(invokeTaskList(flags)).rejects.toThrow()
+    expect(callMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -80,6 +80,67 @@ type MessageSummary = {
   read?: number
 }
 
+type BoundedTaskInventoryResult = {
+  tasks: { id: string; title: string; status: string }[]
+  totalCount: number
+  nextCursor: string | null
+  truncated: boolean
+}
+
+function getBoundedTaskInventoryResult(value: unknown): BoundedTaskInventoryResult {
+  if (!isBoundedTaskInventoryResult(value)) {
+    throw new RuntimeClientError(
+      'invalid_response',
+      'Runtime did not return a valid bounded inventory response.'
+    )
+  }
+  return value
+}
+
+function isBoundedTaskInventoryResult(value: unknown): value is BoundedTaskInventoryResult {
+  if (!hasExactKeys(value, ['tasks', 'totalCount', 'nextCursor', 'truncated'])) {
+    return false
+  }
+  const { tasks, totalCount, nextCursor, truncated } = value
+  return (
+    Array.isArray(tasks) &&
+    tasks.length <= 1000 &&
+    tasks.every(isBoundedTaskInventoryTask) &&
+    typeof totalCount === 'number' &&
+    Number.isSafeInteger(totalCount) &&
+    totalCount >= tasks.length &&
+    (nextCursor === null || (typeof nextCursor === 'string' && nextCursor.length <= 512)) &&
+    typeof truncated === 'boolean' &&
+    truncated === (nextCursor !== null)
+  )
+}
+
+function isBoundedTaskInventoryTask(
+  value: unknown
+): value is BoundedTaskInventoryResult['tasks'][number] {
+  if (!hasExactKeys(value, ['id', 'title', 'status'])) {
+    return false
+  }
+  return (
+    typeof value.id === 'string' &&
+    value.id.length > 0 &&
+    value.id.length <= 256 &&
+    typeof value.title === 'string' &&
+    value.title.length > 0 &&
+    value.title.length <= 512 &&
+    typeof value.status === 'string' &&
+    TASK_STATUS_VALUES.includes(value.status as (typeof TASK_STATUS_VALUES)[number])
+  )
+}
+
+function hasExactKeys(value: unknown, expectedKeys: string[]): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+  const keys = Object.keys(value)
+  return keys.length === expectedKeys.length && keys.every((key) => expectedKeys.includes(key))
+}
+
 function getOptionalStructuredMessagePayload(
   flags: Map<string, string | boolean>
 ): string | undefined {
@@ -335,6 +396,31 @@ function getOptionalPositiveIntegerValueFlag(
   return value
 }
 
+function getBoundedTaskInventoryLimit(flags: Map<string, string | boolean>): number | undefined {
+  if (!flags.has('limit')) {
+    return undefined
+  }
+  const raw = flags.get('limit')
+  if (typeof raw !== 'string' || !/^(?:[1-9]\d{0,2}|1000)$/.test(raw)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      '--limit must be a canonical integer from 1 to 1000.'
+    )
+  }
+  return Number(raw)
+}
+
+function getBoundedTaskInventoryCursor(flags: Map<string, string | boolean>): string | undefined {
+  if (!flags.has('cursor')) {
+    return undefined
+  }
+  const raw = flags.get('cursor')
+  if (typeof raw !== 'string' || raw.length === 0 || raw.length > 512) {
+    throw new RuntimeClientError('invalid_argument', 'Invalid --cursor.')
+  }
+  return raw
+}
+
 function rejectLifecycleGroupRecipient(type: string | undefined, to: string): void {
   if ((type === 'worker_done' || type === 'heartbeat') && to.startsWith('@')) {
     throw new RuntimeClientError('invalid_argument', getLifecycleGroupRecipientError(type))
@@ -533,6 +619,32 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
   },
 
   'orchestration task-list': async ({ flags, client, json }) => {
+    const limit = getBoundedTaskInventoryLimit(flags)
+    const cursor = getBoundedTaskInventoryCursor(flags)
+    if (cursor !== undefined && limit === undefined) {
+      throw new RuntimeClientError('invalid_argument', '--cursor requires --limit.')
+    }
+    // Why: retain this guard alongside RPC validation so older runtimes cannot silently ignore conflicts.
+    if (limit !== undefined && (flags.has('status') || flags.has('ready') || flags.has('brief'))) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        '--limit cannot be combined with --status, --ready, or --brief.'
+      )
+    }
+    if (limit !== undefined) {
+      const response = await client.call<unknown>('orchestration.taskList', { limit, cursor })
+      // Why: older runtimes strip unknown params and return full task rows; bounded
+      // mode must reject that shape rather than printing a private legacy projection.
+      const result = { ...response, result: getBoundedTaskInventoryResult(response.result) }
+      printResult(result, json, (r) => {
+        if (r.tasks.length === 0) {
+          return 'No tasks.'
+        }
+        const tasks = r.tasks.map((task) => `${task.id} [${task.status}] ${task.title}`).join('\n')
+        return r.truncated ? `${tasks}\n${r.totalCount} total; more available.` : tasks
+      })
+      return
+    }
     const brief = flags.has('brief')
     const result = await client.call<{
       tasks: {

--- a/src/cli/help-bounded-inventory.test.ts
+++ b/src/cli/help-bounded-inventory.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { formatCommandHelp } from './help'
+import { ORCHESTRATION_COMMAND_SPECS } from './specs/orchestration'
+
+describe('bounded task inventory help', () => {
+  it('describes the task-list cursor as an opaque pagination token', () => {
+    const taskList = ORCHESTRATION_COMMAND_SPECS.find(
+      (spec) => spec.path.join(' ') === 'orchestration task-list'
+    )
+
+    const help = formatCommandHelp(taskList!)
+
+    expect(help).toContain('--cursor <opaque>')
+    expect(help).toContain('Opaque pagination cursor from a previous bounded task-list page')
+    expect(help).not.toContain('Line cursor from a previous read')
+  })
+})

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -454,6 +454,9 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   if (command === 'orchestration task-create' && flag === 'display-name') {
     return '--display-name <text> UI label shown for dispatched worker rows'
   }
+  if (command === 'orchestration task-list' && flag === 'cursor') {
+    return '--cursor <opaque>      Opaque pagination cursor from a previous bounded task-list page'
+  }
   if (flag === 'key' && command === 'computer hotkey') {
     return '--key <key-combo>      Modifier chord with one key, e.g. CmdOrCtrl+A'
   }

--- a/src/cli/specs/orchestration.test.ts
+++ b/src/cli/specs/orchestration.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { ORCHESTRATION_COMMAND_SPECS } from './orchestration'
+
+describe('orchestration task-list command specification', () => {
+  it('advertises bounded inventory pagination separately from legacy filters', () => {
+    const taskList = ORCHESTRATION_COMMAND_SPECS.find(
+      (spec) => spec.path.join(' ') === 'orchestration task-list'
+    )
+
+    expect(taskList?.usage).toContain('--limit <1..1000>')
+    expect(taskList?.usage).toContain('--cursor <opaque>')
+    expect(taskList?.allowedFlags).toEqual(expect.arrayContaining(['limit', 'cursor']))
+    expect(taskList?.notes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('--limit cannot be combined with --status, --ready, or --brief')
+      ])
+    )
+  })
+})

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -80,9 +80,14 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['orchestration', 'task-list'],
     summary: 'List orchestration tasks',
-    usage: 'orca orchestration task-list [--status <status>] [--ready] [--brief] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'status', 'ready', 'brief'],
-    notes: ['--brief collapses whitespace and caps each spec at 160 characters.']
+    usage:
+      'orca orchestration task-list [--status <status>] [--ready] [--brief] [--json]\n' +
+      '  orca orchestration task-list --limit <1..1000> [--cursor <opaque>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'status', 'ready', 'brief', 'limit', 'cursor'],
+    notes: [
+      '--limit cannot be combined with --status, --ready, or --brief.',
+      '--brief collapses whitespace and caps each spec at 160 characters.'
+    ]
   },
   {
     path: ['orchestration', 'task-update'],

--- a/src/main/attribution/terminal-attribution.test.ts
+++ b/src/main/attribution/terminal-attribution.test.ts
@@ -305,6 +305,9 @@ exit 1
     const repo = join(root, 'repo')
     mkdirSync(repo)
     runGit(repo, ['init'])
+    // Why: a user-level core.hooksPath would otherwise bypass this fixture's
+    // repository-local commit-msg hook and make the test host-dependent.
+    runGit(repo, ['config', 'core.hooksPath', join(repo, '.git', 'hooks')])
     runGit(repo, ['config', 'user.name', 'Orca Test'])
     runGit(repo, ['config', 'user.email', 'orca-test@example.com'])
     const hookPath = join(repo, '.git', 'hooks', 'commit-msg')

--- a/src/main/runtime/orchestration/bounded-task-inventory.test.ts
+++ b/src/main/runtime/orchestration/bounded-task-inventory.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { OrchestrationDb } from './db'
+
+describe('bounded task inventory', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+    db = undefined
+  })
+
+  function createDb(): OrchestrationDb {
+    db = new OrchestrationDb(':memory:')
+    return db
+  }
+
+  it('returns a bounded inventory page without task content', () => {
+    const d = createDb()
+    const first = d.createTask({ spec: 'secret task specification' })
+    const second = d.createTask({ spec: 'another secret specification' })
+    d.updateTaskStatus(second.id, 'completed', '{"secret":"result"}')
+
+    const page = d.listBoundedTaskInventory({ limit: 1 })
+
+    expect(page).toMatchObject({
+      tasks: [{ id: first.id, title: `Task ${first.id}`, status: 'ready' }],
+      totalCount: 2,
+      truncated: true
+    })
+    expect(typeof page.nextCursor).toBe('string')
+    expect(JSON.stringify(page)).not.toContain('secret task specification')
+    expect(JSON.stringify(page)).not.toContain('another secret specification')
+    expect(JSON.stringify(page)).not.toContain('"result"')
+    expect(Object.keys(page.tasks[0] ?? {})).toEqual(['id', 'title', 'status'])
+  })
+
+  it('continues one bounded inventory snapshot without including concurrent tasks', () => {
+    const d = createDb()
+    const first = d.createTask({ spec: 'first secret' })
+    const second = d.createTask({ spec: 'second secret' })
+    const third = d.createTask({ spec: 'third secret' })
+
+    const firstPage = d.listBoundedTaskInventory({ limit: 2 })
+    const concurrent = d.createTask({ spec: 'concurrent secret' })
+    const secondPage = d.listBoundedTaskInventory({
+      limit: 2,
+      cursor: firstPage.nextCursor ?? ''
+    })
+
+    expect([...firstPage.tasks, ...secondPage.tasks].map((task) => task.id)).toEqual([
+      first.id,
+      second.id,
+      third.id
+    ])
+    expect(secondPage.totalCount).toBe(3)
+    expect(secondPage.truncated).toBe(false)
+    expect(JSON.stringify(secondPage)).not.toContain(concurrent.id)
+  })
+
+  it('fails closed when a bounded inventory cursor no longer matches its snapshot', () => {
+    const d = createDb()
+    d.createTask({ spec: 'first secret' })
+    d.createTask({ spec: 'second secret' })
+
+    const firstPage = d.listBoundedTaskInventory({ limit: 1 })
+    d.resetTasks()
+
+    expect(() =>
+      d.listBoundedTaskInventory({ limit: 1, cursor: firstPage.nextCursor ?? '' })
+    ).toThrow('Invalid bounded task inventory cursor')
+  })
+
+  it('rejects malformed bounded inventory cursors', () => {
+    const d = createDb()
+    d.createTask({ spec: 'secret' })
+
+    expect(() => d.listBoundedTaskInventory({ limit: 1, cursor: 'not-a-cursor!' })).toThrow(
+      'Invalid bounded task inventory cursor'
+    )
+  })
+
+  it('rejects a valid-shaped cursor altered after issuance', () => {
+    const d = createDb()
+    d.createTask({ spec: 'first secret' })
+    d.createTask({ spec: 'second secret' })
+
+    const firstPage = d.listBoundedTaskInventory({ limit: 1 })
+    const payload = JSON.parse(
+      Buffer.from(firstPage.nextCursor ?? '', 'base64url').toString('utf8')
+    ) as { lastRowId: number }
+    payload.lastRowId = 0
+    const alteredCursor = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')
+
+    expect(() => d.listBoundedTaskInventory({ limit: 1, cursor: alteredCursor })).toThrow(
+      'Invalid bounded task inventory cursor'
+    )
+  })
+
+  it('rejects a cursor with duplicate JSON members', () => {
+    const d = createDb()
+    d.createTask({ spec: 'first secret' })
+    d.createTask({ spec: 'second secret' })
+
+    const firstPage = d.listBoundedTaskInventory({ limit: 1 })
+    const decoded = Buffer.from(firstPage.nextCursor ?? '', 'base64url').toString('utf8')
+    const duplicateMember = decoded.replace(/"lastRowId":\d+/, (member) => `${member},${member}`)
+    const malformedCursor = Buffer.from(duplicateMember, 'utf8').toString('base64url')
+
+    expect(() => d.listBoundedTaskInventory({ limit: 1, cursor: malformedCursor })).toThrow(
+      'Invalid bounded task inventory cursor'
+    )
+  })
+
+  it('invalidates an outstanding cursor after a runtime restart', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-bounded-inventory-'))
+    const dbPath = join(root, 'orchestration.db')
+    const initial = new OrchestrationDb(dbPath)
+    initial.createTask({ spec: 'first secret' })
+    initial.createTask({ spec: 'second secret' })
+    const firstPage = initial.listBoundedTaskInventory({ limit: 1 })
+    initial.close()
+
+    const restarted = new OrchestrationDb(dbPath)
+    try {
+      expect(() =>
+        restarted.listBoundedTaskInventory({ limit: 1, cursor: firstPage.nextCursor ?? '' })
+      ).toThrow('Invalid bounded task inventory cursor')
+    } finally {
+      restarted.close()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('works inside a caller-owned transaction', () => {
+    const d = createDb()
+    d.createTask({ spec: 'first secret' })
+    d.createTask({ spec: 'second secret' })
+    const connection = d as unknown as { db: { exec(sql: string): void } }
+
+    connection.db.exec('BEGIN')
+    try {
+      expect(d.listBoundedTaskInventory({ limit: 1 })).toMatchObject({
+        totalCount: 2,
+        truncated: true
+      })
+    } finally {
+      connection.db.exec('ROLLBACK')
+    }
+  })
+})

--- a/src/main/runtime/orchestration/bounded-task-inventory.ts
+++ b/src/main/runtime/orchestration/bounded-task-inventory.ts
@@ -1,0 +1,161 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import type { TaskStatus } from './types'
+
+const CURSOR_VERSION = 1
+const MAX_CURSOR_LENGTH = 512
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/
+
+export const BOUNDED_TASK_INVENTORY_CURSOR_ERROR = 'Invalid bounded task inventory cursor'
+
+export type BoundedTaskInventoryTask = {
+  id: string
+  title: string
+  status: TaskStatus
+}
+
+export type BoundedTaskInventoryPage = {
+  tasks: BoundedTaskInventoryTask[]
+  totalCount: number
+  nextCursor: string | null
+  truncated: boolean
+}
+
+export type BoundedTaskInventoryCursor = {
+  version: typeof CURSOR_VERSION
+  ceilingRowId: number
+  anchorId: string
+  totalCount: number
+  lastRowId: number
+}
+
+type SignedBoundedTaskInventoryCursor = BoundedTaskInventoryCursor & {
+  signature: string
+}
+
+export function createBoundedTaskInventoryCursor(
+  cursor: BoundedTaskInventoryCursor,
+  secret: Uint8Array
+): string {
+  const signed: SignedBoundedTaskInventoryCursor = {
+    ...cursor,
+    signature: signCursor(cursor, secret)
+  }
+  const encoded = Buffer.from(serializeSignedCursor(signed), 'utf8').toString('base64url')
+  if (encoded.length > MAX_CURSOR_LENGTH) {
+    throwInvalidCursor()
+  }
+  return encoded
+}
+
+export function parseBoundedTaskInventoryCursor(
+  cursor: string,
+  secret: Uint8Array
+): BoundedTaskInventoryCursor {
+  if (cursor.length === 0 || cursor.length > MAX_CURSOR_LENGTH || !BASE64URL_PATTERN.test(cursor)) {
+    throwInvalidCursor()
+  }
+
+  let decoded: string
+  try {
+    const bytes = Buffer.from(cursor, 'base64url')
+    if (bytes.toString('base64url') !== cursor) {
+      throwInvalidCursor()
+    }
+    decoded = bytes.toString('utf8')
+  } catch {
+    throwInvalidCursor()
+  }
+
+  let value: unknown
+  try {
+    value = JSON.parse(decoded)
+  } catch {
+    throwInvalidCursor()
+  }
+
+  if (!isSignedBoundedTaskInventoryCursor(value)) {
+    throwInvalidCursor()
+  }
+  if (decoded !== serializeSignedCursor(value)) {
+    throwInvalidCursor()
+  }
+  const { signature, ...unsigned } = value
+  if (!hasValidSignature(unsigned, signature, secret)) {
+    throwInvalidCursor()
+  }
+  return unsigned
+}
+
+function isSignedBoundedTaskInventoryCursor(
+  value: unknown
+): value is SignedBoundedTaskInventoryCursor {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+  const record = value as Record<string, unknown>
+  const keys = Object.keys(record).sort()
+  if (
+    keys.length !== 6 ||
+    keys.join(',') !== 'anchorId,ceilingRowId,lastRowId,signature,totalCount,version'
+  ) {
+    return false
+  }
+  return (
+    record.version === CURSOR_VERSION &&
+    isPositiveSafeInteger(record.ceilingRowId) &&
+    typeof record.anchorId === 'string' &&
+    record.anchorId.length > 0 &&
+    record.anchorId.length <= 256 &&
+    isPositiveSafeInteger(record.totalCount) &&
+    isNonNegativeSafeInteger(record.lastRowId) &&
+    record.lastRowId < record.ceilingRowId &&
+    typeof record.signature === 'string' &&
+    /^[A-Za-z0-9_-]{43}$/.test(record.signature)
+  )
+}
+
+function signCursor(cursor: BoundedTaskInventoryCursor, secret: Uint8Array): string {
+  return createHmac('sha256', secret).update(serializeCursor(cursor), 'utf8').digest('base64url')
+}
+
+function hasValidSignature(
+  cursor: BoundedTaskInventoryCursor,
+  signature: string,
+  secret: Uint8Array
+): boolean {
+  const expected = signCursor(cursor, secret)
+  return timingSafeEqual(Buffer.from(signature, 'ascii'), Buffer.from(expected, 'ascii'))
+}
+
+function serializeCursor(cursor: BoundedTaskInventoryCursor): string {
+  return JSON.stringify({
+    version: cursor.version,
+    ceilingRowId: cursor.ceilingRowId,
+    anchorId: cursor.anchorId,
+    totalCount: cursor.totalCount,
+    lastRowId: cursor.lastRowId
+  })
+}
+
+function serializeSignedCursor(cursor: SignedBoundedTaskInventoryCursor): string {
+  return JSON.stringify({
+    version: cursor.version,
+    ceilingRowId: cursor.ceilingRowId,
+    anchorId: cursor.anchorId,
+    totalCount: cursor.totalCount,
+    lastRowId: cursor.lastRowId,
+    signature: cursor.signature
+  })
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}
+
+function throwInvalidCursor(): never {
+  throw new Error(BOUNDED_TASK_INVENTORY_CURSOR_ERROR)
+}

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -16,6 +16,12 @@ import type {
 } from './types'
 import { buildOrchestrationTaskDisplayMetadata } from '../../../shared/orchestration-task-display'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
+import {
+  createBoundedTaskInventoryCursor,
+  parseBoundedTaskInventoryCursor,
+  type BoundedTaskInventoryCursor,
+  type BoundedTaskInventoryPage
+} from './bounded-task-inventory'
 
 // Why: leaf UUID is the remint-stable pane identity; the tab half changes on
 // break-out. Exact string match covers legacy/unparseable keys.
@@ -60,6 +66,7 @@ const SCHEMA_VERSION = 6
 
 export class OrchestrationDb {
   private db: Database.Database
+  private readonly boundedTaskInventoryCursorSecret = randomBytes(32)
 
   constructor(dbPath: string | ':memory:') {
     this.db = new Database(dbPath)
@@ -518,6 +525,117 @@ export class OrchestrationDb {
         .all(filter.status) as TaskRow[]
     }
     return this.db.prepare('SELECT * FROM tasks ORDER BY created_at').all() as TaskRow[]
+  }
+
+  listBoundedTaskInventory(input: { limit: number; cursor?: string }): BoundedTaskInventoryPage {
+    if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > 1000) {
+      throw new Error('Invalid bounded task inventory limit')
+    }
+    const cursor =
+      input.cursor === undefined
+        ? undefined
+        : parseBoundedTaskInventoryCursor(input.cursor, this.boundedTaskInventoryCursorSecret)
+    const savepoint = `bounded_task_inventory_${randomBytes(6).toString('hex')}`
+    let savepointOpen = false
+    // Why: this keeps the page reads on one snapshot while composing with a
+    // caller-owned transaction; BEGIN would reject that nested use.
+    this.db.exec(`SAVEPOINT ${savepoint}`)
+    savepointOpen = true
+    try {
+      const snapshot = cursor ?? this.createBoundedTaskInventorySnapshot()
+      if (cursor) {
+        this.verifyBoundedTaskInventorySnapshot(cursor)
+      }
+
+      let page: BoundedTaskInventoryPage
+      if (!snapshot) {
+        page = { tasks: [], totalCount: 0, nextCursor: null, truncated: false }
+      } else {
+        // Why: this projection deliberately bypasses task display metadata because
+        // legacy metadata can be derived from a task's private specification.
+        const rows = this.db
+          .prepare(
+            `SELECT rowid AS row_id, id, status
+             FROM tasks
+             WHERE rowid <= ? AND rowid > ?
+             ORDER BY rowid ASC
+             LIMIT ?`
+          )
+          .all(snapshot.ceilingRowId, snapshot.lastRowId, input.limit + 1) as {
+          row_id: number
+          id: string
+          status: TaskStatus
+        }[]
+        const hasNextPage = rows.length > input.limit
+        const taskRows = hasNextPage ? rows.slice(0, input.limit) : rows
+        const lastRow = taskRows.at(-1)
+        const nextCursor =
+          hasNextPage && lastRow
+            ? createBoundedTaskInventoryCursor(
+                {
+                  ...snapshot,
+                  lastRowId: lastRow.row_id
+                },
+                this.boundedTaskInventoryCursorSecret
+              )
+            : null
+        page = {
+          tasks: taskRows.map((row) => ({
+            id: row.id,
+            title: `Task ${row.id}`,
+            status: row.status
+          })),
+          totalCount: snapshot.totalCount,
+          nextCursor,
+          truncated: nextCursor !== null
+        }
+      }
+      this.db.exec(`RELEASE SAVEPOINT ${savepoint}`)
+      savepointOpen = false
+      return page
+    } catch (err) {
+      if (savepointOpen) {
+        try {
+          this.db.exec(`ROLLBACK TO SAVEPOINT ${savepoint}`)
+        } finally {
+          this.db.exec(`RELEASE SAVEPOINT ${savepoint}`)
+        }
+      }
+      throw err
+    }
+  }
+
+  private createBoundedTaskInventorySnapshot(): BoundedTaskInventoryCursor | undefined {
+    const anchor = this.db
+      .prepare('SELECT rowid AS row_id, id FROM tasks ORDER BY rowid DESC LIMIT 1')
+      .get() as { row_id: number; id: string } | undefined
+    if (!anchor) {
+      return undefined
+    }
+    const count = this.db
+      .prepare('SELECT COUNT(*) AS total_count FROM tasks WHERE rowid <= ?')
+      .get(anchor.row_id) as { total_count: number }
+    return {
+      version: 1,
+      ceilingRowId: anchor.row_id,
+      anchorId: anchor.id,
+      totalCount: count.total_count,
+      lastRowId: 0
+    }
+  }
+
+  private verifyBoundedTaskInventorySnapshot(cursor: BoundedTaskInventoryCursor): void {
+    // Why: anchor + count turn task resets, deletions, and rowid rewrites into
+    // an explicit invalid cursor instead of silently changing page membership.
+    const anchor = this.db
+      .prepare('SELECT id FROM tasks WHERE rowid = ?')
+      .get(cursor.ceilingRowId) as { id: string } | undefined
+    const count = this.db
+      .prepare('SELECT COUNT(*) AS total_count FROM tasks WHERE rowid <= ?')
+      .get(cursor.ceilingRowId) as { total_count: number }
+    if (anchor?.id !== cursor.anchorId || count.total_count !== cursor.totalCount) {
+      throw new Error('Invalid bounded task inventory cursor')
+    }
   }
 
   // Why: surfaces the active dispatch (assignee handle + dispatch context id)

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1060,6 +1060,74 @@ describe('orchestration RPC methods', () => {
       expect(() => method.params!.parse({ status: 'done-ish' })).toThrow()
     })
 
+    it('returns a bounded inventory projection without task content', async () => {
+      setup()
+      const first = db.createTask({ spec: 'private task specification' })
+      const second = db.createTask({ spec: 'another private specification' })
+      db.updateTaskStatus(second.id, 'completed', '{"private":"result"}')
+
+      const result = (await call('orchestration.taskList', { limit: 1 })) as {
+        tasks: { id: string; title: string; status: string }[]
+        totalCount: number
+        nextCursor: string | null
+        truncated: boolean
+      }
+
+      expect(result).toMatchObject({
+        tasks: [{ id: first.id, title: `Task ${first.id}`, status: 'ready' }],
+        totalCount: 2,
+        truncated: true
+      })
+      expect(typeof result.nextCursor).toBe('string')
+      expect(Object.keys(result)).toEqual(['tasks', 'totalCount', 'nextCursor', 'truncated'])
+      expect(JSON.stringify(result)).not.toContain('private task specification')
+      expect(JSON.stringify(result)).not.toContain('another private specification')
+      expect(JSON.stringify(result)).not.toContain('"result"')
+    })
+
+    it('continues a bounded inventory cursor', async () => {
+      setup()
+      const first = db.createTask({ spec: 'first private task' })
+      const second = db.createTask({ spec: 'second private task' })
+
+      const initial = (await call('orchestration.taskList', { limit: 1 })) as {
+        tasks: { id: string }[]
+        nextCursor: string | null
+      }
+      const continued = (await call('orchestration.taskList', {
+        limit: 1,
+        cursor: initial.nextCursor
+      })) as { tasks: { id: string }[]; totalCount: number; nextCursor: string | null }
+
+      expect([...initial.tasks, ...continued.tasks].map((task) => task.id)).toEqual([
+        first.id,
+        second.id
+      ])
+      expect(continued.totalCount).toBe(2)
+      expect(continued.nextCursor).toBeNull()
+    })
+
+    it.each([
+      { limit: 0 },
+      { limit: 1001 },
+      { cursor: 'cursor-without-limit' },
+      { limit: 1, status: 'ready' },
+      { limit: 1, ready: true },
+      { limit: 1, brief: true }
+    ])('rejects invalid bounded inventory parameters %j', (params) => {
+      const method = findMethod('orchestration.taskList')
+      expect(() => method.params!.parse(params)).toThrow()
+    })
+
+    it('fails closed for a malformed bounded inventory cursor', async () => {
+      setup()
+      db.createTask({ spec: 'private task' })
+
+      await expect(
+        call('orchestration.taskList', { limit: 1, cursor: 'not-a-cursor!' })
+      ).rejects.toThrow('Invalid bounded task inventory cursor')
+    })
+
     it('includes assignee_handle and dispatch_id for dispatched tasks', async () => {
       setup()
       const t1 = db.createTask({ spec: 'ready work' })

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -130,13 +130,34 @@ const TaskCreateParams = z.object({
   callerTerminalHandle: OptionalString
 })
 
-const TaskListParams = z.object({
-  status: z.enum(['pending', 'ready', 'dispatched', 'completed', 'failed', 'blocked']).optional(),
-  ready: OptionalBoolean,
-  // Why: truncating specs server-side keeps `--brief` cheap over SSH/relay
-  // transports instead of shipping full specs the CLI then throws away.
-  brief: OptionalBoolean
-})
+const TaskListParams = z
+  .object({
+    status: z.enum(['pending', 'ready', 'dispatched', 'completed', 'failed', 'blocked']).optional(),
+    ready: OptionalBoolean,
+    // Why: truncating specs server-side keeps `--brief` cheap over SSH/relay
+    // transports instead of shipping full specs the CLI then throws away.
+    brief: OptionalBoolean,
+    limit: z.number().int().min(1).max(1000).optional(),
+    cursor: z.string().min(1).max(512).optional()
+  })
+  .superRefine((params, ctx) => {
+    if (params.cursor !== undefined && params.limit === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '--cursor requires --limit',
+        path: ['cursor']
+      })
+    }
+    if (
+      params.limit !== undefined &&
+      (params.status !== undefined || params.ready !== undefined || params.brief !== undefined)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '--limit cannot be combined with --status, --ready, or --brief'
+      })
+    }
+  })
 
 const TaskUpdateParams = z.object({
   id: requiredString('Missing --id'),
@@ -423,6 +444,9 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
     params: TaskListParams,
     handler: (params, { runtime }) => {
       const db = runtime.getOrchestrationDb()
+      if (params.limit !== undefined) {
+        return db.listBoundedTaskInventory({ limit: params.limit, cursor: params.cursor })
+      }
       // Why: listTasksWithDispatch returns the same rows as listTasks plus
       // assignee_handle + dispatch_id joined in for tasks that currently have an
       // active dispatch. Non-dispatched tasks get NULL for those fields, so


### PR DESCRIPTION
## Summary

Adds an opt-in bounded public JSON inventory command:

```text
orca orchestration task-list --limit <1..1000> [--cursor <opaque>] --json
```

The bounded projection contains only `id`, a non-spec synthetic `title`, and `status`, plus `totalCount`, `nextCursor`, and `truncated`. It deliberately excludes task specs, results, terminal previews, and legacy metadata that can derive from task specifications.

Cursor continuations are canonical, HMAC-protected, bounded, and fail closed on malformed, altered, duplicate-member, reset, deletion, or restart-invalidated state. Continuations exclude concurrently created tasks. The CLI and RPC reject incompatible flags and reject older runtime responses that leak legacy task rows.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (28,761 passed; 38 declared skips)
- [x] `pnpm build:electron-vite`
- [x] CLI TypeScript build and whitespace diff check
- [x] Added bounded cursor, continuation, malformed/tampered cursor, duplicate JSON-member, restart, caller-owned transaction, CLI, RPC, help, and host-independent hook-fixture regressions

## AI Review Report

Claude Sonnet independently reviewed the complete tracked and untracked artifact packet. It checked pagination boundaries, concurrent inserts, cursor tampering/replay, canonical JSON, nested transactions, legacy-runtime fail-closed behavior, and host-global Git hook isolation. It returned `VERDICT: READY` with no critical or important findings.

Cross-platform review: this change is Node/SQLite/CLI-only. It adds no platform paths, shortcuts, Electron UI, shell execution, or platform-specific behavior. The database test uses the OS temporary directory and Node path utilities.

## Security Audit

- Cursor state is integrity-protected with a runtime-local HMAC secret and compared with `timingSafeEqual`.
- Cursor parsing rejects noncanonical base64url, malformed JSON, duplicate/reordered members, unknown fields, unsafe integers, and invalid signatures.
- The bounded SQL projection selects only `rowid`, `id`, and `status`; it never reads task specs, results, display metadata, terminal previews, or transcripts.
- The CLI exact-shape validator rejects a legacy/unbounded response rather than projecting it.
- No new dependencies, shell command construction, path input, credentials, IPC permissions, or network calls were added.

## Notes

- Runtime restarts deliberately invalidate outstanding cursors; callers must restart reconciliation.
- A release is maintainer-managed. This PR intentionally contains no version bump, tag, release, or application replacement.
- X handle: not provided in the contributor GitHub profile.
