### PR TITLE
fix(terminal): suppress fresh-working false completion notifications (#4375)

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -673,7 +673,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('allows confirmed process-exit completion while fresh hook state is still active', () => {
+  it('suppresses process-exit completion while authoritative hook state is still working', () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
       prompt: 'agent crashed before its done hook',
@@ -689,20 +689,42 @@ describe('dispatchTerminalNotification', () => {
       agentCompletionSource: 'process-exit'
     })
 
-    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        source: 'agent-task-complete',
-        worktreeId: 'wt-primary',
-        paneKey,
-        terminalTitle: 'codex'
-      })
-    )
-    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
-    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
-    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
-    const dispatchArgs = getLastNotificationDispatchArg()
-    expect(dispatchArgs?.agentState).toBeUndefined()
-    expect(dispatchArgs?.agentPrompt).toBeUndefined()
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('suppresses snapshot-bearing completion while authoritative hook state is still working', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      prompt: 'still running',
+      updatedAt: Date.now() - 60_000,
+      stateStartedAt: Date.now() - 60_000,
+      lastAssistantMessage: undefined,
+      toolName: 'Bash',
+      toolInput: 'npm run test:submit'
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'danmaku_monitor / main - Codex finished',
+      paneKey,
+      agentCompletionSource: 'hook',
+      agentStatusSnapshot: {
+        state: 'working',
+        prompt: 'still running',
+        agentType: 'codex',
+        toolName: 'Bash',
+        toolInput: 'npm run test:submit',
+        stateStartedAt: Date.now() - 60_000
+      }
+    })
+
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
   it.each([undefined, 'unknown'] as const)(
@@ -767,6 +789,63 @@ describe('dispatchTerminalNotification', () => {
     })
 
     expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+  })
+
+  it('allows process-exit completion after a working hook status becomes stale', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      updatedAt: Date.now() - AGENT_STATUS_STALE_AFTER_MS - 1,
+      stateStartedAt: Date.now() - AGENT_STATUS_STALE_AFTER_MS - 1,
+      lastAssistantMessage: undefined
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentCompletionSource: 'process-exit'
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        terminalTitle: 'codex'
+      })
+    )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+  })
+
+  it('does not swallow a waiting completion snapshot while stored hook state is working', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      updatedAt: Date.now() - 60_000,
+      stateStartedAt: Date.now() - 60_000,
+      lastAssistantMessage: undefined
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'waiting',
+        prompt: 'needs approval',
+        agentType: 'codex',
+        stateStartedAt: Date.now() - 30_000
+      }
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        agentState: 'waiting'
+      })
+    )
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
   })
 

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -849,6 +849,37 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
   })
 
+  it('does not swallow a blocked completion snapshot while stored hook state is working', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      updatedAt: Date.now() - 60_000,
+      stateStartedAt: Date.now() - 60_000,
+      lastAssistantMessage: undefined
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'blocked',
+        prompt: 'needs approval',
+        agentType: 'codex',
+        stateStartedAt: Date.now() - 30_000
+      }
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        agentState: 'blocked'
+      })
+    )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+  })
+
   it('drops a delayed completion snapshot when the pane has already started a newer turn', () => {
     const previousDoneStartedAt = Date.now() - 10_000
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -580,7 +580,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('allows confirmed process-exit completion while fresh hook state is still active', () => {
+  it('suppresses process-exit completion while authoritative hook state is still working', () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
       prompt: 'agent crashed before its done hook',
@@ -596,20 +596,42 @@ describe('dispatchTerminalNotification', () => {
       agentCompletionSource: 'process-exit'
     })
 
-    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        source: 'agent-task-complete',
-        worktreeId: 'wt-primary',
-        paneKey,
-        terminalTitle: 'codex'
-      })
-    )
-    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
-    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
-    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
-    const dispatchArgs = getLastNotificationDispatchArg()
-    expect(dispatchArgs?.agentState).toBeUndefined()
-    expect(dispatchArgs?.agentPrompt).toBeUndefined()
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('suppresses snapshot-bearing completion while authoritative hook state is still working', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      prompt: 'still running',
+      updatedAt: Date.now() - 60_000,
+      stateStartedAt: Date.now() - 60_000,
+      lastAssistantMessage: undefined,
+      toolName: 'Bash',
+      toolInput: 'npm run test:submit'
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'danmaku_monitor / main - Codex finished',
+      paneKey,
+      agentCompletionSource: 'hook',
+      agentStatusSnapshot: {
+        state: 'working',
+        prompt: 'still running',
+        agentType: 'codex',
+        toolName: 'Bash',
+        toolInput: 'npm run test:submit',
+        stateStartedAt: Date.now() - 60_000
+      }
+    })
+
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
   it.each([undefined, 'unknown'] as const)(
@@ -674,6 +696,63 @@ describe('dispatchTerminalNotification', () => {
     })
 
     expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+  })
+
+  it('allows process-exit completion after a working hook status becomes stale', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      updatedAt: Date.now() - AGENT_STATUS_STALE_AFTER_MS - 1,
+      stateStartedAt: Date.now() - AGENT_STATUS_STALE_AFTER_MS - 1,
+      lastAssistantMessage: undefined
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentCompletionSource: 'process-exit'
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        terminalTitle: 'codex'
+      })
+    )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+  })
+
+  it('does not swallow a waiting completion snapshot while stored hook state is working', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      updatedAt: Date.now() - 60_000,
+      stateStartedAt: Date.now() - 60_000,
+      lastAssistantMessage: undefined
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'waiting',
+        prompt: 'needs approval',
+        agentType: 'codex',
+        stateStartedAt: Date.now() - 30_000
+      }
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        agentState: 'waiting'
+      })
+    )
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
   })
 

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -756,6 +756,37 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
   })
 
+  it('does not swallow a blocked completion snapshot while stored hook state is working', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      updatedAt: Date.now() - 60_000,
+      stateStartedAt: Date.now() - 60_000,
+      lastAssistantMessage: undefined
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'blocked',
+        prompt: 'needs approval',
+        agentType: 'codex',
+        stateStartedAt: Date.now() - 30_000
+      }
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        agentState: 'blocked'
+      })
+    )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+  })
+
   it('drops a delayed completion snapshot when the pane has already started a newer turn', () => {
     const previousDoneStartedAt = Date.now() - 10_000
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -52,6 +52,17 @@ function hasFreshActiveHookStatus(
   return Boolean(isFreshNonDoneAgentStatus(snapshot) && !titleNamesDifferentKnownAgent)
 }
 
+function hasFreshWorkingHookStatus(
+  snapshot: Pick<AgentStatusEntry, 'state' | 'updatedAt' | 'agentType'> | undefined,
+  explicitTitleAgentType: string | null
+): boolean {
+  return snapshot?.state === 'working' && hasFreshActiveHookStatus(snapshot, explicitTitleAgentType)
+}
+
+function isAttentionAgentSnapshot(snapshot: AgentCompletionStatusSnapshot | undefined): boolean {
+  return snapshot?.state === 'waiting' || snapshot?.state === 'blocked'
+}
+
 export type TerminalNotificationEvent = {
   source: 'terminal-bell' | 'agent-task-complete'
   terminalTitle?: string
@@ -117,6 +128,14 @@ export function dispatchTerminalNotification(
   if (
     event.source === 'agent-task-complete' &&
     isSupersededAgentCompletionSnapshot(storedAgentStatus, eventAgentStatusSnapshot)
+  ) {
+    return
+  }
+  if (
+    event.source === 'agent-task-complete' &&
+    hasFreshWorkingHookStatus(storedAgentStatus, explicitTitleAgentType) &&
+    eventAgentStatusSnapshot?.state !== 'done' &&
+    !isAttentionAgentSnapshot(eventAgentStatusSnapshot)
   ) {
     return
   }


### PR DESCRIPTION
## Summary

- Orca no longer fires `agent-task-complete` desktop notifications while the pane's authoritative hook status is still `working`, for example during a long-running Bash or tool step.
- Root cause: the dispatcher only blocked completions that were neither `process-exit` nor snapshot-bearing, so both of those shapes could still notify while stored hook state contradicted them.

Closes #4375.

This builds on closed PR #6573, which fixed the `waiting` and `blocked` slice. This PR closes the remaining fresh-`working` case reported by @mitsuksw and confirmed again on Windows.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts` - passed
- `pnpm run typecheck:web` - passed

## AI Review Report

- The gate keys on authoritative hook state, not title text.
- The diff is intentionally limited to the final notification authority.
- `waiting` and `blocked` attention is untouched and remains #8387 territory.
- Genuine `done` completions and stale crash fallback still notify.
- Cross-platform review stayed clean on macOS, Linux, and Windows: the change lives in shared renderer notification logic, adds no platform-specific path, shortcut, shell, or Electron-branch behavior, and keeps the same result across those clients.

## Security Audit

- No new network, auth, filesystem, or command-execution surface.
- The change is a pure early return in an existing renderer notification path.
- Worst case is an over-suppressed completion notification. Turn-end and crash fallback remain available.

## Notes

- Out of scope: deeper process-cadence misclassification in the coordinator. This PR closes the leak at the final dispatcher.
- The test fixture is derived from the reporter's issue comment rather than synthesized.

## ELI5

Orca could fire a "task complete" desktop notification while the agent was still working on a long Bash or tool step. Notifications are blocked when hook status is still working, so you only get told when work really finished.
