### PR TITLE
fix(codex): debounce auto-resolved approval notifications (#8387)

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -40,6 +40,7 @@ function createRejectableDeferred<T>(): {
 }
 
 const HOOK_DONE_QUIET_MS = 1_500
+const CODEX_ATTENTION_QUIET_MS = 1_500
 
 describe('agent completion coordinator', () => {
   beforeEach(() => {
@@ -1432,6 +1433,174 @@ describe('agent completion coordinator', () => {
     )
   })
 
+  it('cancels a transient Codex waiting attention when work resumes before the quiet window', () => {
+    const dispatchCompletion = vi.fn()
+    const dispatchAttention = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      dispatchAttention,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'implement notifications',
+      agentType: 'codex'
+    })
+    coordinator.observeHookStatus({
+      state: 'waiting',
+      prompt: 'implement notifications',
+      agentType: 'codex',
+      toolName: 'Bash',
+      toolInput: 'npm run test:submit'
+    })
+
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS - 1)
+    expect(dispatchAttention).not.toHaveBeenCalled()
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'implement notifications',
+      agentType: 'codex',
+      toolName: 'Bash',
+      toolInput: 'npm run test:submit'
+    })
+    vi.advanceTimersByTime(1)
+
+    expect(dispatchAttention).not.toHaveBeenCalled()
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('cancels a transient Codex blocked attention when work resumes before the quiet window', () => {
+    const dispatchCompletion = vi.fn()
+    const dispatchAttention = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      dispatchAttention,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'implement notifications',
+      agentType: 'codex'
+    })
+    coordinator.observeHookStatus({
+      state: 'blocked',
+      prompt: 'implement notifications',
+      agentType: 'codex',
+      toolName: 'Bash',
+      toolInput: 'rm file'
+    })
+
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS - 1)
+    expect(dispatchAttention).not.toHaveBeenCalled()
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'implement notifications',
+      agentType: 'codex',
+      toolName: 'Bash',
+      toolInput: 'rm file'
+    })
+    vi.advanceTimersByTime(1)
+
+    expect(dispatchAttention).not.toHaveBeenCalled()
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('delays a persistent Codex waiting attention until the quiet window expires', () => {
+    const dispatchCompletion = vi.fn()
+    const dispatchAttention = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      dispatchAttention,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'implement notifications',
+      agentType: 'codex'
+    })
+    coordinator.observeHookStatus({
+      state: 'waiting',
+      prompt: 'implement notifications',
+      agentType: 'codex',
+      toolName: 'Bash',
+      toolInput: 'npm run test:submit'
+    })
+
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS - 1)
+    expect(dispatchAttention).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(dispatchAttention).toHaveBeenCalledTimes(1)
+    expect(dispatchAttention).toHaveBeenCalledWith(
+      'codex',
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({
+          state: 'waiting',
+          agentType: 'codex',
+          toolInput: 'npm run test:submit'
+        })
+      })
+    )
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('keeps non-Codex waiting attention immediate', () => {
+    const dispatchCompletion = vi.fn()
+    const dispatchAttention = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      dispatchAttention,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'fix the bug',
+      agentType: 'claude'
+    })
+    coordinator.observeHookStatus({
+      state: 'waiting',
+      prompt: 'fix the bug',
+      agentType: 'claude',
+      toolName: 'Shell',
+      toolInput: 'pnpm test'
+    })
+
+    expect(dispatchAttention).toHaveBeenCalledTimes(1)
+    expect(dispatchAttention).toHaveBeenCalledWith(
+      'claude',
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({
+          state: 'waiting',
+          agentType: 'claude'
+        })
+      })
+    )
+  })
+
   it('suppresses the attention dispatch when shouldSuppressHookCompletion matches', () => {
     // Why: guards the merge seam where the suppressor must short-circuit before
     // the attention path, so auto-approved Codex pauses never notify.
@@ -1471,6 +1640,35 @@ describe('agent completion coordinator', () => {
 
     expect(dispatchAttention).not.toHaveBeenCalled()
     expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('clears a pending Codex attention timer on dispose', () => {
+    const dispatchAttention = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion: vi.fn(),
+      dispatchAttention,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'implement notifications',
+      agentType: 'codex'
+    })
+    coordinator.observeHookStatus({
+      state: 'waiting',
+      prompt: 'implement notifications',
+      agentType: 'codex'
+    })
+
+    coordinator.dispose()
+    vi.advanceTimersByTime(CODEX_ATTENTION_QUIET_MS)
+
+    expect(dispatchAttention).not.toHaveBeenCalled()
   })
 
   it('does not dispatch completion when a blocked state arrives mid-turn', () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -61,6 +61,7 @@ const PENDING_TITLE_TTL_MS = Math.max(2_000, INSPECTION_TIMEOUT_MS + 500)
 const PENDING_TITLE_MAX_TTL_MS = Math.max(30_000, PENDING_TITLE_TTL_MS)
 const COMPLETION_REPLAY_GUARD_MS = 1_000
 const HOOK_DONE_QUIET_MS = 1_500
+const CODEX_ATTENTION_QUIET_MS = 1_500
 
 const POLL_TIER_INTERVAL_MS: Record<PollCadenceTier, number> = {
   active: ACTIVE_POLL_INTERVAL_MS,
@@ -106,6 +107,8 @@ export function createAgentCompletionCoordinator(
   let pendingHookDoneTimer: ReturnType<typeof setTimeout> | null = null
   let pendingHookDoneTitle: string | null = null
   let pendingHookDonePayload: AgentCompletionStatusSnapshot | null = null
+  let pendingAttentionTimer: ReturnType<typeof setTimeout> | null = null
+  let pendingAttentionPayload: AgentCompletionStatusSnapshot | null = null
   let pendingProcessExitAgent: RecognizedAgentProcess | null = null
   let pendingTitleSequence = 0
   let pendingTitle: {
@@ -153,6 +156,14 @@ export function createAgentCompletionCoordinator(
     }
     pendingHookDoneTitle = null
     pendingHookDonePayload = null
+  }
+
+  function clearPendingAttention(): void {
+    if (pendingAttentionTimer !== null) {
+      clearTimeout(pendingAttentionTimer)
+      pendingAttentionTimer = null
+    }
+    pendingAttentionPayload = null
   }
 
   function establishAgentEvidence(): void {
@@ -282,6 +293,7 @@ export function createAgentCompletionCoordinator(
       completionIdentity?: LastCompletionIdentity | null
     } = {}
   ): void {
+    clearPendingAttention()
     if (source !== 'hook' && pendingHookDoneTimer !== null) {
       return
     }
@@ -338,6 +350,21 @@ export function createAgentCompletionCoordinator(
       source: 'hook',
       agentStatus: payload
     })
+  }
+
+  function scheduleCodexAttention(payload: AgentCompletionStatusSnapshot): void {
+    pendingAttentionPayload = payload
+    if (pendingAttentionTimer !== null) {
+      return
+    }
+    pendingAttentionTimer = setTimeout(() => {
+      pendingAttentionTimer = null
+      const pendingPayload = pendingAttentionPayload
+      pendingAttentionPayload = null
+      if (pendingPayload) {
+        dispatchAttention(pendingPayload)
+      }
+    }, CODEX_ATTENTION_QUIET_MS)
   }
 
   function scheduleHookDoneCompletion(title: string, payload: AgentCompletionStatusSnapshot): void {
@@ -789,6 +816,7 @@ export function createAgentCompletionCoordinator(
       // so the quiet-window timer never fires a false completion notification.
       if (isAttentionHookState(payload.state)) {
         clearPendingHookDone()
+        clearPendingAttention()
       }
       return
     }
@@ -797,6 +825,7 @@ export function createAgentCompletionCoordinator(
     }
     if (payload.state === 'working') {
       clearPendingHookDone()
+      clearPendingAttention()
       workingStatusObserved = true
       requiresFreshWorking = false
       lastCompletionIdentity = null
@@ -810,10 +839,15 @@ export function createAgentCompletionCoordinator(
       // Why: a permission/elicitation pause arriving before the quiet window
       // must cancel a provisional 'done' so it never becomes a false completion.
       clearPendingHookDone()
-      dispatchAttention(payload)
+      if (payload.agentType === 'codex') {
+        scheduleCodexAttention(payload)
+      } else {
+        dispatchAttention(payload)
+      }
       return
     }
     if (isCompletionHookState(payload.state)) {
+      clearPendingAttention()
       if (isRecognizedAgentType(payload.agentType)) {
         establishAgentEvidence()
       }
@@ -885,6 +919,7 @@ export function createAgentCompletionCoordinator(
 
   function resetCompletionState(options: { requireFreshWorking?: boolean } = {}): void {
     clearPendingHookDone()
+    clearPendingAttention()
     dropPendingTitle()
     agentIdentityEstablished = false
     hasAgentRunEvidence = false
@@ -905,6 +940,7 @@ export function createAgentCompletionCoordinator(
     disposed = true
     clearPollTimer()
     clearPendingHookDone()
+    clearPendingAttention()
     dropPendingTitle()
     // Why: the dedup identity is module-scoped so it survives a live-stream remount
     // (dispose-then-recreate with the same paneKey while isLive() stays true). Only


### PR DESCRIPTION
## Summary

- Codex under "Approve for me" no longer produces false approval-required desktop notifications when its review agent approves and the pane resumes automatically.
- Root cause: Orca only suppressed yolo launches and otherwise notified immediately on permission attention, with no chance to observe the later resume hook.

Closes #8387.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/components/terminal-pane/codex-auto-approval-notification-suppression.test.ts` - passed
- `pnpm run typecheck:web` - passed

## AI Review Report

- The discriminator is normalized agent type plus an observed resume hook, not policy-string parsing or title inference.
- The quiet window is scoped to Codex only. Non-Codex attention remains immediate.
- Yolo remains suppressed by the existing predicate.
- The diff stays in the coordinator that already owns notification cadence.

## Security Audit

- No new network, auth, filesystem, or command-execution surface.
- The change only delays or cancels a notification. It does not grant approval or send input.
- Worst case is a delayed genuine approval notification or a still-false notification if Codex fails to emit a resume hook.

## Notes

- The originally suggested `orca-runtime.ts` anchor was stale on current main. The live owner is the terminal-pane coordinator.
- Real-session proof that Codex emits a timely resume hook is provider-owned and remains a manual follow-up item.
