### PR TITLE
fix(agent-status): label Cursor by identity, not a bare "cursor" token

### DIFF
--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -533,6 +533,19 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('Aider idle')).toBe('Aider')
     expect(getAgentLabel('Devin working')).toBe('Devin')
   })
+
+  // Why: `cursor` is ordinary editor vocabulary in another agent's task title, so a
+  // bare token is not Cursor identity — a Claude tab working on cursor code was being
+  // mislabeled Cursor on the worktree card. Match Cursor's closed title set only.
+  it('labels Cursor by identity, not a bare "cursor" token in another agent title', () => {
+    expect(getAgentLabel('Cursor Agent')).toBe('Cursor')
+    expect(getAgentLabel('⠋ Cursor Agent')).toBe('Cursor')
+    expect(getAgentLabel('Cursor ready')).toBe('Cursor')
+    expect(getAgentLabel('Cursor - action required')).toBe('Cursor')
+    expect(getAgentLabel('⠋ preserve cursor visibility across replays')).toBe('Claude Code')
+    expect(getAgentLabel('⠋ Codex: fix cursor offsets')).toBe('Codex')
+    expect(getAgentLabel('Terminal Cursor and Orca slows down')).toBeNull()
+  })
 })
 
 describe('isClaudeAgent', () => {
@@ -540,6 +553,13 @@ describe('isClaudeAgent', () => {
     expect(isClaudeAgent('⠋ Claude Code')).toBe(true)
     expect(isClaudeAgent('⠋ OpenClaude')).toBe(false)
     expect(isClaudeAgent('OpenClaude ready')).toBe(false)
+  })
+
+  // Why: a braille Claude title merely mentioning a text cursor is still Claude, so its
+  // prompt-cache paths must fire; only Cursor's own identity titles are excluded.
+  it('counts cursor-mentioning Claude braille titles as Claude, excludes real Cursor', () => {
+    expect(isClaudeAgent('⠋ preserve cursor visibility across replays')).toBe(true)
+    expect(isClaudeAgent('⠋ Cursor Agent')).toBe(false)
   })
 
   it('does not classify non-prefix Claude mentions as Claude agent titles', () => {

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -5,6 +5,7 @@ import {
   HERMES_AGENT_NAME_RE,
   containsBrailleSpinner,
   isClaudeManagementTitle,
+  isCursorAgentTitle,
   isGeminiTerminalTitle,
   isPiAgentTitle,
   titleHasAgentName
@@ -30,7 +31,10 @@ export function isClaudeAgent(title: string): boolean {
     return true
   }
   if (containsBrailleSpinner(title)) {
-    return !lower.includes('cursor') && !lower.includes('openclaude')
+    // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
+    // identity titles (not the token) so a Claude title merely mentioning a text
+    // cursor still resolves as Claude; openclaude stays a token guard.
+    return !isCursorAgentTitle(title) && !lower.includes('openclaude')
   }
 
   const trimmedTitle = title.trimStart()
@@ -93,8 +97,10 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
-  // Why: match explicit names before Claude's generic braille heuristic.
-  if (titleHasAgentName(title, 'cursor')) {
+  // Why: `cursor` is ordinary editor vocabulary in another agent's task title, so a
+  // name token is not identity. Match Cursor's closed native/synthesized title set
+  // instead, mirroring @cursor orchestration routing.
+  if (isCursorAgentTitle(title)) {
     return 'Cursor'
   }
   if (DROID_AGENT_NAME_RE.test(title)) {

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -32,8 +32,7 @@ export function isClaudeAgent(title: string): boolean {
   }
   if (containsBrailleSpinner(title)) {
     // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
-    // identity titles (not the token) so a Claude title merely mentioning a text
-    // cursor still resolves as Claude; openclaude stays a token guard.
+    // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
     return !isCursorAgentTitle(title) && !lower.includes('openclaude')
   }
 
@@ -97,9 +96,8 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
-  // Why: `cursor` is ordinary editor vocabulary in another agent's task title, so a
-  // name token is not identity. Match Cursor's closed native/synthesized title set
-  // instead, mirroring @cursor orchestration routing.
+  // Why: `cursor` is ordinary editor vocabulary, not identity. Match Cursor's closed
+  // title set (mirrors @cursor routing), before `isClaudeAgent` claims the braille frame.
   if (isCursorAgentTitle(title)) {
     return 'Cursor'
   }

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   isGrokRotatingWorkingTitle,
-  resolveExplicitTerminalTitleAgentType
+  resolveExplicitTerminalTitleAgentType,
+  resolveTerminalTitleAgentType
 } from './terminal-title-agent-type'
 
 describe('isGrokRotatingWorkingTitle', () => {
@@ -56,5 +57,32 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
   it('returns null for plain shell and unknown titles', () => {
     expect(resolveExplicitTerminalTitleAgentType('Terminal 1')).toBeNull()
     expect(resolveExplicitTerminalTitleAgentType('zsh')).toBeNull()
+  })
+
+  // Why: `cursor` is ordinary editor vocabulary, so a name token is not identity.
+  // A Claude/Codex tab working on cursor code must not commit to Cursor identity.
+  it('resolves Cursor by its identity titles, never a bare cursor token', () => {
+    expect(resolveExplicitTerminalTitleAgentType('Cursor Agent')).toBe('cursor')
+    expect(resolveExplicitTerminalTitleAgentType('⠋ Cursor Agent')).toBe('cursor')
+    expect(resolveExplicitTerminalTitleAgentType('Cursor ready')).toBe('cursor')
+    expect(resolveExplicitTerminalTitleAgentType('Cursor - action required')).toBe('cursor')
+    // A Claude tab whose task text mentions a text cursor is not Cursor identity.
+    expect(
+      resolveExplicitTerminalTitleAgentType('⠋ preserve cursor visibility across replays')
+    ).toBeNull()
+    expect(resolveExplicitTerminalTitleAgentType('~/cursor-rules')).toBeNull()
+  })
+})
+
+describe('resolveTerminalTitleAgentType', () => {
+  // Why: the activity facet keeps Claude's braille prefix as Claude — but only when
+  // the "cursor" it mentions is task text, not Cursor's own identity title.
+  it('labels cursor-mentioning agent tabs by their true agent, real Cursor as cursor', () => {
+    expect(resolveTerminalTitleAgentType('⠋ Cursor Agent')).toBe('cursor')
+    expect(resolveTerminalTitleAgentType('Cursor ready')).toBe('cursor')
+    expect(resolveTerminalTitleAgentType('⠋ preserve cursor visibility across replays')).toBe(
+      'claude'
+    )
+    expect(resolveTerminalTitleAgentType('⠋ Codex: fix cursor offsets')).toBe('codex')
   })
 })

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isClaudeAgent,
   isGrokRotatingWorkingTitle,
   resolveExplicitTerminalTitleAgentType,
   resolveTerminalTitleAgentType
@@ -79,10 +80,23 @@ describe('resolveTerminalTitleAgentType', () => {
   // the "cursor" it mentions is task text, not Cursor's own identity title.
   it('labels cursor-mentioning agent tabs by their true agent, real Cursor as cursor', () => {
     expect(resolveTerminalTitleAgentType('⠋ Cursor Agent')).toBe('cursor')
+    expect(resolveTerminalTitleAgentType('Cursor Agent')).toBe('cursor')
     expect(resolveTerminalTitleAgentType('Cursor ready')).toBe('cursor')
+    expect(resolveTerminalTitleAgentType('Cursor - action required')).toBe('cursor')
     expect(resolveTerminalTitleAgentType('⠋ preserve cursor visibility across replays')).toBe(
       'claude'
     )
     expect(resolveTerminalTitleAgentType('⠋ Codex: fix cursor offsets')).toBe('codex')
+  })
+})
+
+// Why: this module carries its own isClaudeAgent copy parallel to agent-title-identity.ts;
+// both got the identical isCursorAgentTitle guard, so pin this copy directly to catch drift.
+describe('isClaudeAgent', () => {
+  it('excludes real Cursor identity titles, keeps cursor-mentioning Claude braille titles', () => {
+    expect(isClaudeAgent('⠋ Cursor Agent')).toBe(false)
+    expect(isClaudeAgent('Cursor ready')).toBe(false)
+    expect(isClaudeAgent('⠋ preserve cursor visibility across replays')).toBe(true)
+    expect(isClaudeAgent('⠋ OpenClaude')).toBe(false)
   })
 })

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -4,6 +4,7 @@ import {
   HERMES_AGENT_NAME_RE,
   titleHasAgentName
 } from './agent-name-token-match'
+import { isCursorAgentTitle } from './agent-title-core'
 import {
   getPiCompatibleSyntheticAgentLabel,
   isLegacyPiCompatibleTitle
@@ -98,8 +99,10 @@ export function isClaudeAgent(title: string): boolean {
   }
   if (containsBrailleSpinner(title)) {
     // Why: named non-Claude agents can carry braille spinners too; Claude-only
-    // prompt-cache paths must not fire for those explicit agent titles.
-    return !lower.includes('cursor') && !lower.includes('openclaude')
+    // prompt-cache paths must not fire for those explicit agent titles. Gate Cursor
+    // by its identity titles (not the token) so a Claude title merely mentioning a
+    // text cursor still resolves as Claude; openclaude stays a token guard.
+    return !isCursorAgentTitle(title) && !lower.includes('openclaude')
   }
   // Why: permission/action-required Claude titles can omit the usual prefixes.
   // Token-match so cwd/worktree titles like "claude-scratch" do not become
@@ -179,14 +182,12 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
-  // Why: the cursor-agent native title is the literal string "Cursor Agent"
-  // (verified against the 2026.04.17 release) — Orca synthesizes the same
-  // label from hook events so the braille-spinner + agent-name path lights
-  // up working/permission/idle transitions in the renderer. Match before
-  // `isClaudeAgent` because Claude's generic braille heuristic would
-  // otherwise claim every "⠋ Cursor Agent" frame as Claude. Token-match so a
-  // cwd like "~/cursor-rules" can't masquerade as a Cursor agent.
-  if (titleHasAgentName(title, 'cursor')) {
+  // Why: `cursor` is ordinary editor vocabulary in another agent's task title, so a
+  // name token is not identity — token-matching it labels a Claude/Codex tab working
+  // on cursor code as Cursor. Match Cursor's closed native/synthesized title set
+  // instead (mirrors @cursor orchestration routing), before `isClaudeAgent` so a real
+  // "⠋ Cursor Agent" frame isn't claimed by Claude's generic braille heuristic.
+  if (isCursorAgentTitle(title)) {
     return 'Cursor'
   }
   // Why: synthesized "⠋ Droid" working title needs to be matched before Claude's braille heuristic.

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -98,10 +98,8 @@ export function isClaudeAgent(title: string): boolean {
     return true
   }
   if (containsBrailleSpinner(title)) {
-    // Why: named non-Claude agents can carry braille spinners too; Claude-only
-    // prompt-cache paths must not fire for those explicit agent titles. Gate Cursor
-    // by its identity titles (not the token) so a Claude title merely mentioning a
-    // text cursor still resolves as Claude; openclaude stays a token guard.
+    // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
+    // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
     return !isCursorAgentTitle(title) && !lower.includes('openclaude')
   }
   // Why: permission/action-required Claude titles can omit the usual prefixes.
@@ -182,11 +180,8 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
-  // Why: `cursor` is ordinary editor vocabulary in another agent's task title, so a
-  // name token is not identity — token-matching it labels a Claude/Codex tab working
-  // on cursor code as Cursor. Match Cursor's closed native/synthesized title set
-  // instead (mirrors @cursor orchestration routing), before `isClaudeAgent` so a real
-  // "⠋ Cursor Agent" frame isn't claimed by Claude's generic braille heuristic.
+  // Why: `cursor` is ordinary editor vocabulary, not identity. Match Cursor's closed
+  // title set (mirrors @cursor routing), before `isClaudeAgent` claims the braille frame.
   if (isCursorAgentTitle(title)) {
     return 'Cursor'
   }


### PR DESCRIPTION
## Summary

The worktree card (and status bar / mobile) derive an agent label from the terminal title via `getAgentLabel` → `resolveTitleActivityLabel`, and identity via `resolveExplicitTerminalTitleAgentType`. Both resolvers matched Cursor with `titleHasAgentName(title, 'cursor')` — a whole-token match.

But `cursor` is ordinary editor vocabulary. Anyone using Orca to work on Orca (whose codebase mentions cursors constantly) hits this: a **Claude/Codex tab** with a title like `⠋ preserve cursor visibility across replays` token-matches `cursor` and gets **mislabeled as Cursor** on the worktree card. The generic braille-spinner Claude fallback even carried a `!lower.includes('cursor')` guard — a workaround for this same ambiguity — that then dropped such titles to *no* label at all.

This is the display-side follow-up flagged in #8436 (which tightened `@cursor` orchestration *routing* to an identity predicate and noted display still token-matched).

## Change

Gate Cursor on its **closed identity title set** via `isCursorAgentTitle` — the exact predicate `@cursor` routing uses — in both parallel resolvers (`agent-title-identity.ts` and `terminal-title-agent-type.ts`), and relax the braille `isClaudeAgent` guard to the same predicate.

| Title | Before | After |
| --- | --- | --- |
| `⠋ Cursor Agent` (real Cursor working) | Cursor | **Cursor** (unchanged) |
| `Cursor ready` / `Cursor - action required` | Cursor | **Cursor** (unchanged) |
| `⠋ preserve cursor visibility across replays` (Claude) | Cursor ❌ | **Claude Code** ✅ |
| `⠋ Codex: fix cursor offsets` (Codex) | Codex | **Codex** (unchanged) |
| `Terminal Cursor and Orca slows down` (shell) | null | **null** (unchanged) |

A real cursor-agent terminal still shows as Cursor across working/idle/permission; a non-Cursor tab that merely mentions a text cursor reverts to its true agent. Committed identity (`resolveExplicitTerminalTitleAgentType`) returns null for the Claude-on-cursor title (can't prove Claude from a bare braille title, definitely not Cursor).

## Testing

- [x] `pnpm typecheck` (node + web)
- [x] `oxlint` / `oxfmt` (pre-commit)
- [x] Added regression tests: `getAgentLabel`, `isClaudeAgent`, `resolveTerminalTitleAgentType`, `resolveExplicitTerminalTitleAgentType`
- [x] Full `src/shared` suite: 2348 passed; downstream consumers (worktree-title-derived-agent-rows, pane-agent-evidence, use-tab-agent, notes-send-agent-targets) all green

Swept the codebase — these two resolvers were the only remaining loose `cursor` token/substring matches in non-test source.

## Notes

- `isClaudeAgent` now counts a cursor-mentioning braille Claude title as Claude (previously it returned false). This is a latent correctness improvement: those sessions now correctly get Claude-only prompt-cache-timer treatment. Real `⠋ Cursor Agent` still returns false.

Made with [Orca](https://github.com/stablyai/orca) 🐋
