### PR TITLE
fix(agents): open the Orca browser from Agents View terminal links (#7813)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -67,6 +67,9 @@ import { MarkdownTemplatePicker } from './components/editor/MarkdownTemplatePick
 import { FloatingTerminalToggleButton } from './components/floating-terminal/FloatingTerminalToggleButton'
 import { OrcaProfileSwitcher } from './components/orca-profiles/OrcaProfileSwitcher'
 import {
+  OPEN_FLOATING_TERMINAL_EVENT,
+  shouldForceCloseFloatingTerminal,
+  shouldOpenFloatingTerminalOnRequest,
   TOGGLE_FLOATING_TERMINAL_EVENT,
   requestFloatingTerminalOpenMaximized
 } from '@/lib/floating-terminal'
@@ -539,8 +542,7 @@ function App(): React.JSX.Element {
   // Why: a closed empty floating workspace is not startup-critical. Once it owns
   // tabs, keep it mounted while closed so hidden terminal/browser/editor panes
   // retain their local state.
-  const shouldMountFloatingTerminalPanel =
-    floatingTerminalEnabled && (floatingTerminalOpen || floatingVisibleTabCount > 0)
+  const shouldMountFloatingTerminalPanel = floatingTerminalEnabled || floatingVisibleTabCount > 0
   // Why: the floating workspace is a transient overlay; hotkey minimize should
   // return keyboard focus to the surface the user was working in before it.
   const floatingTerminalReturnFocusRef = useRef<HTMLElement | null>(null)
@@ -621,15 +623,36 @@ function App(): React.JSX.Element {
         setFloatingTerminalOpenWithFocus((open) => !open)
       }
     }
+    const openFloatingTerminal = (): void => {
+      const liveState = useAppStore.getState()
+      const liveFloatingVisibleTabCount = selectFloatingVisibleTabCount(liveState)
+      if (
+        shouldOpenFloatingTerminalOnRequest({
+          enabled: liveState.settings?.floatingTerminalEnabled === true,
+          visibleTabCount: liveFloatingVisibleTabCount
+        })
+      ) {
+        setFloatingTerminalOpenWithFocus(true)
+      }
+    }
+    window.addEventListener(OPEN_FLOATING_TERMINAL_EVENT, openFloatingTerminal)
     window.addEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
-    return () => window.removeEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
+    return () => {
+      window.removeEventListener(OPEN_FLOATING_TERMINAL_EVENT, openFloatingTerminal)
+      window.removeEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
+    }
   }, [floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
 
   useEffect(() => {
-    if (!floatingTerminalEnabled) {
+    if (
+      shouldForceCloseFloatingTerminal({
+        enabled: floatingTerminalEnabled,
+        visibleTabCount: floatingVisibleTabCount
+      })
+    ) {
       setFloatingTerminalOpenWithFocus(false)
     }
-  }, [floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
+  }, [floatingTerminalEnabled, floatingVisibleTabCount, setFloatingTerminalOpenWithFocus])
 
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -69,6 +69,7 @@ import { OrcaProfileSwitcher } from './components/orca-profiles/OrcaProfileSwitc
 import {
   OPEN_FLOATING_TERMINAL_EVENT,
   shouldForceCloseFloatingTerminal,
+  shouldMountFloatingTerminalPanel,
   shouldOpenFloatingTerminalOnRequest,
   TOGGLE_FLOATING_TERMINAL_EVENT,
   requestFloatingTerminalOpenMaximized
@@ -542,7 +543,11 @@ function App(): React.JSX.Element {
   // Why: a closed empty floating workspace is not startup-critical. Once it owns
   // tabs, keep it mounted while closed so hidden terminal/browser/editor panes
   // retain their local state.
-  const shouldMountFloatingTerminalPanel = floatingTerminalEnabled || floatingVisibleTabCount > 0
+  const shouldMountFloatingTerminalPanelForState = shouldMountFloatingTerminalPanel({
+    enabled: floatingTerminalEnabled,
+    open: floatingTerminalOpen,
+    visibleTabCount: floatingVisibleTabCount
+  })
   // Why: the floating workspace is a transient overlay; hotkey minimize should
   // return keyboard focus to the surface the user was working in before it.
   const floatingTerminalReturnFocusRef = useRef<HTMLElement | null>(null)
@@ -2519,7 +2524,7 @@ function App(): React.JSX.Element {
                 ) : null}
               </div>
             </RecoverableRenderErrorBoundary>
-            {shouldMountFloatingTerminalPanel ? (
+            {shouldMountFloatingTerminalPanelForState ? (
               <Suspense fallback={null}>
                 <RecoverableRenderErrorBoundary
                   boundaryId="overlay.floating-workspace"

--- a/src/renderer/src/lib/floating-terminal.test.ts
+++ b/src/renderer/src/lib/floating-terminal.test.ts
@@ -3,6 +3,7 @@ import {
   consumeFloatingTerminalOpenMaximizedIntent,
   requestFloatingTerminalOpenMaximized,
   shouldForceCloseFloatingTerminal,
+  shouldMountFloatingTerminalPanel,
   shouldOpenFloatingTerminalOnRequest
 } from './floating-terminal'
 
@@ -59,5 +60,23 @@ describe('floating terminal open-maximized intent', () => {
 
   it('force-closes only when disabled and empty', () => {
     expect(shouldForceCloseFloatingTerminal({ enabled: false, visibleTabCount: 0 })).toBe(true)
+  })
+
+  it('does not mount while enabled, closed, and empty', () => {
+    expect(
+      shouldMountFloatingTerminalPanel({ enabled: true, open: false, visibleTabCount: 0 })
+    ).toBe(false)
+  })
+
+  it('mounts while enabled and open', () => {
+    expect(
+      shouldMountFloatingTerminalPanel({ enabled: true, open: true, visibleTabCount: 0 })
+    ).toBe(true)
+  })
+
+  it('keeps visible floating tabs mounted while disabled and closed', () => {
+    expect(
+      shouldMountFloatingTerminalPanel({ enabled: false, open: false, visibleTabCount: 1 })
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/lib/floating-terminal.test.ts
+++ b/src/renderer/src/lib/floating-terminal.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   consumeFloatingTerminalOpenMaximizedIntent,
-  requestFloatingTerminalOpenMaximized
+  requestFloatingTerminalOpenMaximized,
+  shouldForceCloseFloatingTerminal,
+  shouldOpenFloatingTerminalOnRequest
 } from './floating-terminal'
 
 describe('floating terminal open-maximized intent', () => {
@@ -41,5 +43,21 @@ describe('floating terminal open-maximized intent', () => {
     vi.advanceTimersByTime(50)
 
     expect(consumeFloatingTerminalOpenMaximizedIntent()).toBe(true)
+  })
+
+  it('opens on request when the preference is enabled', () => {
+    expect(shouldOpenFloatingTerminalOnRequest({ enabled: true, visibleTabCount: 0 })).toBe(true)
+  })
+
+  it('opens on request when floating tabs already exist', () => {
+    expect(shouldOpenFloatingTerminalOnRequest({ enabled: false, visibleTabCount: 1 })).toBe(true)
+  })
+
+  it('does not force-close while floating tabs remain', () => {
+    expect(shouldForceCloseFloatingTerminal({ enabled: false, visibleTabCount: 1 })).toBe(false)
+  })
+
+  it('force-closes only when disabled and empty', () => {
+    expect(shouldForceCloseFloatingTerminal({ enabled: false, visibleTabCount: 0 })).toBe(true)
   })
 })

--- a/src/renderer/src/lib/floating-terminal.ts
+++ b/src/renderer/src/lib/floating-terminal.ts
@@ -1,3 +1,4 @@
+export const OPEN_FLOATING_TERMINAL_EVENT = 'orca-open-floating-terminal'
 export const TOGGLE_FLOATING_TERMINAL_EVENT = 'orca-toggle-floating-terminal'
 
 // Why: maximize/restore lives in the panel's own keydown handler, but that
@@ -14,8 +15,26 @@ let openMaximizedIntentAt: number | null = null
 // into a later ordinary open and maximizing it unexpectedly.
 const OPEN_MAXIMIZED_INTENT_TTL_MS = 2000
 
+export function requestOpenFloatingTerminal(): void {
+  window.dispatchEvent(new Event(OPEN_FLOATING_TERMINAL_EVENT))
+}
+
 export function requestFloatingTerminalOpenMaximized(): void {
   openMaximizedIntentAt = Date.now()
+}
+
+export function shouldOpenFloatingTerminalOnRequest(opts: {
+  enabled: boolean
+  visibleTabCount: number
+}): boolean {
+  return opts.enabled || opts.visibleTabCount > 0
+}
+
+export function shouldForceCloseFloatingTerminal(opts: {
+  enabled: boolean
+  visibleTabCount: number
+}): boolean {
+  return !opts.enabled && opts.visibleTabCount === 0
 }
 
 export function consumeFloatingTerminalOpenMaximizedIntent(): boolean {

--- a/src/renderer/src/lib/floating-terminal.ts
+++ b/src/renderer/src/lib/floating-terminal.ts
@@ -37,6 +37,14 @@ export function shouldForceCloseFloatingTerminal(opts: {
   return !opts.enabled && opts.visibleTabCount === 0
 }
 
+export function shouldMountFloatingTerminalPanel(opts: {
+  enabled: boolean
+  open: boolean
+  visibleTabCount: number
+}): boolean {
+  return (opts.enabled && opts.open) || opts.visibleTabCount > 0
+}
+
 export function consumeFloatingTerminalOpenMaximizedIntent(): boolean {
   if (openMaximizedIntentAt === null) {
     return false

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -11,6 +11,7 @@ const openUrlMock = vi.fn()
 const registerLocalhostLabelMock = vi.fn()
 const setActiveWorktreeMock = vi.fn()
 const createBrowserTabMock = vi.fn()
+const dispatchEventMock = vi.fn()
 
 const storeState = {
   settings: undefined as
@@ -32,6 +33,7 @@ const storeState = {
   allWorktrees: vi.fn(
     () => [] as { id: string; projectId?: string; repoId?: string; displayName?: string }[]
   ),
+  activeView: undefined as string | undefined,
   workspacePortScan: null as { result: WorkspacePortScanResult } | null,
   workspacePortScansByKey: {} as Record<string, WorkspacePortScanResult>
 }
@@ -39,6 +41,7 @@ const storeState = {
 beforeEach(() => {
   vi.clearAllMocks()
   storeState.settings = undefined
+  storeState.activeView = undefined
   storeState.workspacePortScansByKey = {}
   registerHttpLinkStoreAccessor(() => storeState)
   vi.stubGlobal('window', {
@@ -49,7 +52,8 @@ beforeEach(() => {
       localhostWorktreeLabels: {
         register: registerLocalhostLabelMock
       }
-    }
+    },
+    dispatchEvent: dispatchEventMock
   })
 })
 
@@ -91,6 +95,23 @@ describe('openHttpLink', () => {
       { activate: true }
     )
     expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('routes activity-view local links into the floating workspace and requests the panel open', () => {
+    storeState.settings = { openLinksInApp: true }
+    storeState.activeView = 'activity'
+
+    openHttpLink('https://example.com/', { worktreeId: 'wt-1' })
+
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'https://example.com/',
+      { activate: true }
+    )
+    expect(dispatchEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'orca-open-floating-terminal' })
+    )
   })
 
   it('routes to the system browser when openLinksInApp is off', () => {
@@ -291,6 +312,65 @@ describe('openHttpLink', () => {
       })
     )
     expect(openUrlMock).toHaveBeenCalledWith('http://analytics.orca.localhost:60016/episodes')
+  })
+
+  it('routes activity-view labeled localhost links into the floating workspace', async () => {
+    storeState.settings = { openLinksInApp: true, localhostWorktreeLabelsEnabled: true }
+    storeState.activeView = 'activity'
+    storeState.repos = [
+      {
+        id: 'repo-1',
+        displayName: 'snapstudio',
+        repoIcon: null,
+        badgeColor: '#f97316'
+      }
+    ]
+    storeState.worktreesByRepo = {
+      'repo-1': [
+        {
+          id: 'wt-analytics',
+          repoId: 'repo-1',
+          projectId: 'repo-1',
+          displayName: 'analytics'
+        }
+      ]
+    }
+    storeState.workspacePortScan = {
+      result: {
+        platform: 'darwin',
+        scannedAt: 1,
+        ports: [
+          {
+            id: 'tcp:5180',
+            kind: 'workspace',
+            port: 5180,
+            protocol: 'http',
+            bindHost: '127.0.0.1',
+            connectHost: 'localhost',
+            owner: {
+              repoId: 'repo-1',
+              worktreeId: 'wt-analytics',
+              displayName: 'analytics',
+              path: '/repo/analytics',
+              confidence: 'cwd'
+            }
+          }
+        ]
+      }
+    }
+    registerLocalhostLabelMock.mockResolvedValue({
+      url: 'http://analytics.orca.localhost:60016/episodes'
+    })
+
+    openHttpLink('http://localhost:5180/episodes', { worktreeId: 'wt-analytics' })
+    await Promise.resolve()
+
+    expect(createBrowserTabMock).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'http://analytics.orca.localhost:60016/episodes',
+      { activate: true }
+    )
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
   })
 
   it('resolves display URLs for labeled localhost links without opening them', async () => {

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import type { TopLevelView } from '../../../shared/types'
 import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
 import {
   openHttpLink,
@@ -33,7 +34,7 @@ const storeState = {
   allWorktrees: vi.fn(
     () => [] as { id: string; projectId?: string; repoId?: string; displayName?: string }[]
   ),
-  activeView: undefined as string | undefined,
+  activeView: undefined as TopLevelView | undefined,
   workspacePortScan: null as { result: WorkspacePortScanResult } | null,
   workspacePortScansByKey: {} as Record<string, WorkspacePortScanResult>
 }

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -3,7 +3,7 @@ import {
   parseLoopbackUrlWithPort,
   type LocalhostWorktreeLabelRoute
 } from '../../../shared/localhost-worktree-labels'
-import type { GlobalSettings } from '../../../shared/types'
+import type { GlobalSettings, TopLevelView } from '../../../shared/types'
 import type { WorkspacePort, WorkspacePortScanResult } from '../../../shared/workspace-ports'
 import { requestOpenFloatingTerminal } from './floating-terminal'
 
@@ -26,7 +26,7 @@ type StoreAccessor = () => {
       'openLinksInApp' | 'activeRuntimeEnvironmentId' | 'localhostWorktreeLabelsEnabled'
     >
   > | null
-  activeView?: string
+  activeView?: TopLevelView
   setActiveWorktree: (worktreeId: string) => void
   createBrowserTab: (worktreeId: string, url: string, opts: { activate: boolean }) => unknown
   repos?: LocalhostLinkRepo[]

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../shared/localhost-worktree-labels'
 import type { GlobalSettings } from '../../../shared/types'
 import type { WorkspacePort, WorkspacePortScanResult } from '../../../shared/workspace-ports'
+import { requestOpenFloatingTerminal } from './floating-terminal'
 
 export type OpenHttpLinkOptions = {
   worktreeId?: string | null
@@ -25,6 +26,7 @@ type StoreAccessor = () => {
       'openLinksInApp' | 'activeRuntimeEnvironmentId' | 'localhostWorktreeLabelsEnabled'
     >
   > | null
+  activeView?: string
   setActiveWorktree: (worktreeId: string) => void
   createBrowserTab: (worktreeId: string, url: string, opts: { activate: boolean }) => unknown
   repos?: LocalhostLinkRepo[]
@@ -78,22 +80,30 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
     state?.settings?.openLinksInApp === true
 
   if (routeToOrca && worktreeId && state) {
+    const isActivityView = state.activeView === 'activity'
+    const targetWorktreeId = isActivityView ? FLOATING_TERMINAL_WORKTREE_ID : worktreeId
+    const createInAppBrowserTab = (browserUrl: string): void => {
+      state.createBrowserTab(targetWorktreeId, browserUrl, { activate: true })
+      if (isActivityView) {
+        requestOpenFloatingTerminal()
+      }
+    }
     // Why: http clicks from inside a worktree should not push a worktree-switch
     // history entry — the user isn't changing worktrees, they're opening a tab
     // in the one they're already in. activateAndRevealWorktree is reserved for
     // file-link jumps that genuinely switch worktrees.
-    if (worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
+    if (!isActivityView && worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
       // Why: the floating workspace uses a synthetic worktree id. Promoting it
       // to the global activeWorktreeId deselects the real repo workspace.
       state.setActiveWorktree(worktreeId)
     }
     const localhostRoute = localhostLabelRouteForHttpLink(url, state, sourceOwner)
     if (!localhostRoute) {
-      state.createBrowserTab(worktreeId, url, { activate: true })
+      createInAppBrowserTab(url)
       return
     }
     void openLabeledLocalhostLink(url, localhostRoute, (labeledUrl) => {
-      state.createBrowserTab(worktreeId, labeledUrl, { activate: true })
+      createInAppBrowserTab(labeledUrl)
     })
     return
   }


### PR DESCRIPTION
## Summary

- Terminal links opened while Agents View is active now route to the floating browser workspace and force that panel open, so the browser is reachable without leaving Agents View.
- Root cause: the existing route created the tab on the real worktree workspace, whose browser chrome only renders in terminal view. The follow-up fix restores the lazy mount guard so an enabled but closed and empty floating panel stays unmounted until it is opened or owns visible floating tabs.

Closes #7813.

This is the focused browser-routing slice from closed PR #7838. It intentionally excludes the superseded #7791 Pi hook work. Maintainer @AmethystLiang asked for this focused split in issue #7813.

## Screenshots

Attach a short recording that shows a terminal link opened from Agents View appearing in the floating browser panel while Agents View stays active.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/http-link-routing.test.ts src/renderer/src/lib/floating-terminal.test.ts` - passed
- `pnpm run typecheck:web` - passed
- `pnpm exec oxlint src/renderer/src/App.tsx src/renderer/src/lib/floating-terminal.ts src/renderer/src/lib/floating-terminal.test.ts` - passed
- `pnpm exec oxfmt --check src/renderer/src/App.tsx src/renderer/src/lib/floating-terminal.ts src/renderer/src/lib/floating-terminal.test.ts` - passed

## AI Review Report

- The discriminator is authoritative store state, `activeView === 'activity'`.
- The fix keeps all non-activity routes unchanged.
- The open-request listener reads live store state so it observes the just-created floating tab.
- The floating panel now mounts only while it is open and enabled, or while visible floating tabs already exist.
- The diff stays out of Pi hook state and other unrelated browser surfaces.

## Security Audit

- No new network, auth, command execution, or cross-process surface.
- The custom open event is renderer-local and carries no payload.
- URL ownership and system-browser fallbacks remain unchanged.

## Notes

- Out of scope: `src/shared/agent-hook-listener.ts`, `src/main/agent-hooks/server.test.ts`, and any Pi `session_shutdown` work.
- Verifying visible browser access inside Agents View requires a manual recording, not a browserless test.

## ELI5

Clicking a link in a terminal while Agents View was open put the browser on a workspace you could not reach without leaving Agents View. Links now open the floating browser and force that panel open so you can browse without leaving.
