### PR TITLE
fix(mobile): keep browser tab active during navigation

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -186,6 +186,7 @@ import {
   confirmsMirroredTabSelection,
   type AppliedSnapshotMarker
 } from '../../../../src/session/session-tab-snapshot-gate'
+import { resolveActiveSessionTab } from '../../../../src/session/active-session-tab'
 import {
   buildMarkdownDiskFallbackDoc,
   shouldReadMarkdownFromDiskAfterReadTabFailure
@@ -1870,26 +1871,27 @@ export default function SessionScreen() {
       const snapshotActive = nextTabs.find((tab) => tab.isActive) ?? nextTabs[0] ?? null
       const pendingActiveSessionTabId = pendingActiveSessionTabIdRef.current
       const pendingActiveTerminalHandle = pendingActiveTerminalHandleRef.current
-      let active = snapshotActive
-      let selectionSource = 'snapshot'
-      if (pendingActiveSessionTabId) {
-        if (snapshotActive?.id === pendingActiveSessionTabId) {
-          if (confirmsMirroredTabSelection(result.publicationEpoch)) {
-            pendingActiveSessionTabIdRef.current = null
-          } else {
-            selectionSource = 'pending-tab-local-ack'
-          }
+      const resolvedActive = resolveActiveSessionTab(nextTabs, {
+        pendingActiveSessionTabId,
+        currentActiveSessionTabId: activeSessionTabIdRef.current
+      })
+      let active = resolvedActive.activeTab
+      let selectionSource =
+        active?.id === snapshotActive?.id
+          ? 'snapshot'
+          : active?.id === pendingActiveSessionTabId
+            ? 'pending-tab'
+            : active?.type === 'browser' && active?.id === activeSessionTabIdRef.current
+              ? 'current-browser-tab'
+              : 'snapshot'
+      if (pendingActiveSessionTabId && snapshotActive?.id === pendingActiveSessionTabId) {
+        if (confirmsMirroredTabSelection(result.publicationEpoch)) {
+          pendingActiveSessionTabIdRef.current = null
         } else {
-          const pendingTab = nextTabs.find((tab) => tab.id === pendingActiveSessionTabId)
-          if (pendingTab) {
-            // Why: desktop tab snapshots can lag a mobile tap while activate RPC
-            // is in flight. Keep the locally selected tab to avoid snapping back.
-            active = pendingTab
-            selectionSource = 'pending-tab'
-          } else {
-            pendingActiveSessionTabIdRef.current = null
-          }
+          selectionSource = 'pending-tab-local-ack'
         }
+      } else if (resolvedActive.clearPendingActiveSessionTabId) {
+        pendingActiveSessionTabIdRef.current = null
       }
       if (pendingActiveTerminalHandle) {
         const pendingTerminalTab = nextTabs.find(
@@ -1899,14 +1901,15 @@ export default function SessionScreen() {
         const pendingTerminalExists = mergedTerminalsForActive.some(
           (terminal) => terminal.handle === pendingActiveTerminalHandle
         )
-        if (
-          snapshotActive?.type === 'terminal' &&
-          snapshotActive.terminal === pendingActiveTerminalHandle
-        ) {
-          if (confirmsMirroredTabSelection(result.publicationEpoch)) {
-            pendingActiveTerminalHandleRef.current = null
-          } else {
+        if (active?.type === 'terminal' && active.terminal === pendingActiveTerminalHandle) {
+          if (
+            snapshotActive?.type === 'terminal' &&
+            snapshotActive.terminal === pendingActiveTerminalHandle &&
+            !confirmsMirroredTabSelection(result.publicationEpoch)
+          ) {
             selectionSource = 'pending-handle-local-ack'
+          } else {
+            pendingActiveTerminalHandleRef.current = null
           }
         } else if (pendingTerminalTab) {
           // Why: desktop active flags can lag a mobile terminal tap. Key by

--- a/mobile/src/session/active-session-tab.test.ts
+++ b/mobile/src/session/active-session-tab.test.ts
@@ -104,4 +104,16 @@ describe('resolveActiveSessionTab', () => {
       clearPendingActiveSessionTabId: true
     })
   })
+
+  it('clears a stale pending activation when its tab is gone and no browser tab is current', () => {
+    const result = resolveActiveSessionTab([terminalTab('agent', true)], {
+      pendingActiveSessionTabId: 'removed-tab',
+      currentActiveSessionTabId: 'agent'
+    })
+
+    expect(result).toEqual({
+      activeTab: expect.objectContaining({ id: 'agent', type: 'terminal' }),
+      clearPendingActiveSessionTabId: true
+    })
+  })
 })

--- a/mobile/src/session/active-session-tab.test.ts
+++ b/mobile/src/session/active-session-tab.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import type { MobileBrowserTab } from '../browser/MobileBrowserPane'
+import { resolveActiveSessionTab } from './active-session-tab'
+
+type SessionTab =
+  | { type: 'terminal'; id: string; title: string; terminal: string | null; isActive: boolean }
+  | { type: 'markdown'; id: string; title: string; isActive: boolean }
+  | MobileBrowserTab
+
+function browserTab(id: string, isActive: boolean): MobileBrowserTab {
+  return {
+    type: 'browser',
+    id,
+    title: id,
+    browserWorkspaceId: 'browser-workspace',
+    browserPageId: id,
+    url: `https://${id}.example.com/`,
+    loading: false,
+    canGoBack: false,
+    canGoForward: false,
+    isActive
+  }
+}
+
+function terminalTab(id: string, isActive: boolean): Extract<SessionTab, { type: 'terminal' }> {
+  return {
+    type: 'terminal',
+    id,
+    title: id,
+    terminal: id,
+    isActive
+  }
+}
+
+describe('resolveActiveSessionTab', () => {
+  it('keeps a still-present browser tab active when a later snapshot marks Agent active', () => {
+    const result = resolveActiveSessionTab(
+      [terminalTab('agent', true), browserTab('browser', false)],
+      {
+        pendingActiveSessionTabId: null,
+        currentActiveSessionTabId: 'browser'
+      }
+    )
+
+    expect(result).toEqual({
+      activeTab: expect.objectContaining({ id: 'browser', type: 'browser' }),
+      clearPendingActiveSessionTabId: false
+    })
+  })
+
+  it('falls back to the snapshot when the current browser tab is gone', () => {
+    const result = resolveActiveSessionTab([terminalTab('agent', true)], {
+      pendingActiveSessionTabId: null,
+      currentActiveSessionTabId: 'browser'
+    })
+
+    expect(result).toEqual({
+      activeTab: expect.objectContaining({ id: 'agent', type: 'terminal' }),
+      clearPendingActiveSessionTabId: false
+    })
+  })
+
+  it('keeps non-browser current tabs under snapshot control', () => {
+    const result = resolveActiveSessionTab(
+      [terminalTab('agent', false), terminalTab('shell', true)],
+      {
+        pendingActiveSessionTabId: null,
+        currentActiveSessionTabId: 'agent'
+      }
+    )
+
+    expect(result).toEqual({
+      activeTab: expect.objectContaining({ id: 'shell', type: 'terminal' }),
+      clearPendingActiveSessionTabId: false
+    })
+  })
+
+  it('keeps a pending activation authoritative until the snapshot catches up', () => {
+    const result = resolveActiveSessionTab(
+      [terminalTab('agent', true), browserTab('browser', false)],
+      {
+        pendingActiveSessionTabId: 'browser',
+        currentActiveSessionTabId: 'agent'
+      }
+    )
+
+    expect(result).toEqual({
+      activeTab: expect.objectContaining({ id: 'browser', type: 'browser' }),
+      clearPendingActiveSessionTabId: false
+    })
+  })
+
+  it('clears a pending activation once the snapshot acknowledges it', () => {
+    const result = resolveActiveSessionTab(
+      [browserTab('browser', true), terminalTab('agent', false)],
+      {
+        pendingActiveSessionTabId: 'browser',
+        currentActiveSessionTabId: 'agent'
+      }
+    )
+
+    expect(result).toEqual({
+      activeTab: expect.objectContaining({ id: 'browser', type: 'browser' }),
+      clearPendingActiveSessionTabId: true
+    })
+  })
+})

--- a/mobile/src/session/active-session-tab.ts
+++ b/mobile/src/session/active-session-tab.ts
@@ -28,6 +28,9 @@ export function resolveActiveSessionTab<T extends SessionTabLike>(
     }
   }
 
+  // Why: only browser tabs need client-side stickiness. Their snapshot `isActive`
+  // flag can lag the user's current selection across refresh and navigation.
+  // Terminal, markdown, and file tabs stay under snapshot authority.
   const currentActiveTab =
     tabs.find((tab) => tab.id === opts.currentActiveSessionTabId && tab.type === 'browser') ?? null
   if (currentActiveTab) {

--- a/mobile/src/session/active-session-tab.ts
+++ b/mobile/src/session/active-session-tab.ts
@@ -1,0 +1,41 @@
+type SessionTabLike = {
+  id: string
+  type: 'terminal' | 'markdown' | 'file' | 'browser'
+  isActive: boolean
+}
+
+export type ResolveActiveSessionTabResult<T extends SessionTabLike> = {
+  activeTab: T | null
+  clearPendingActiveSessionTabId: boolean
+}
+
+export function resolveActiveSessionTab<T extends SessionTabLike>(
+  tabs: readonly T[],
+  opts: {
+    pendingActiveSessionTabId: string | null
+    currentActiveSessionTabId: string | null
+  }
+): ResolveActiveSessionTabResult<T> {
+  const snapshotActive = tabs.find((tab) => tab.isActive) ?? tabs[0] ?? null
+  const pendingActiveSessionTabId = opts.pendingActiveSessionTabId
+  if (pendingActiveSessionTabId) {
+    if (snapshotActive?.id === pendingActiveSessionTabId) {
+      return { activeTab: snapshotActive, clearPendingActiveSessionTabId: true }
+    }
+    const pendingTab = tabs.find((tab) => tab.id === pendingActiveSessionTabId) ?? null
+    if (pendingTab) {
+      return { activeTab: pendingTab, clearPendingActiveSessionTabId: false }
+    }
+  }
+
+  const currentActiveTab =
+    tabs.find((tab) => tab.id === opts.currentActiveSessionTabId && tab.type === 'browser') ?? null
+  if (currentActiveTab) {
+    return { activeTab: currentActiveTab, clearPendingActiveSessionTabId: false }
+  }
+
+  return {
+    activeTab: snapshotActive,
+    clearPendingActiveSessionTabId: pendingActiveSessionTabId !== null
+  }
+}


### PR DESCRIPTION
## Summary

- Keep the active Orca Mobile browser tab selected when its page refreshes or changes route.
- Root cause: after the pending mobile activation marker cleared, `applySessionTabs()` fell back to the snapshot's `isActive` tab or the first tab, which did not reliably reflect the phone's current browser selection.

Closes #8364.

## Screenshots

Pending iOS recording showing refresh and route navigation with the browser tab remaining selected.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run src/session/active-session-tab.test.ts` (run in `mobile/`) - passed
- `pnpm run typecheck:web` - passed
- `pnpm exec oxlint mobile/src/session/active-session-tab.ts mobile/src/session/active-session-tab.test.ts "mobile/app/h/[hostId]/session/[worktreeId].tsx"` - passed
- `pnpm exec oxfmt --check mobile/src/session/active-session-tab.ts mobile/src/session/active-session-tab.test.ts "mobile/app/h/[hostId]/session/[worktreeId].tsx"` - passed

## AI Review Report

- The new helper preserves the existing pending-marker rule and adds browser stickiness only when the current browser tab still exists in the accepted snapshot.
- Non-browser tabs still follow snapshot authority.
- Removed browser tabs fall back to the snapshot, so the phone cannot retain an id that no longer exists.

## Security Audit

- No new IPC, filesystem, auth, or browser-permission surface.
- The change is a pure selection helper over an already accepted session-tab snapshot.
- The helper can only return a tab present in the current snapshot.

## Notes

Rendered iOS confirmation still requires a run on a real iOS device. Android should inherit the fix through the shared code path, but on-device parity remains unverified in this change.

## ELI5

On Orca Mobile, refreshing or navigating in the browser could deselect the tab you were actually on and jump to another. The active browser tab now stays selected through refresh and route changes.
