### PR TITLE
fix(daemon): reattach live PTY sessions after reconnect

### DIFF
--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -59,6 +59,10 @@ export class DaemonClient {
     return this.connected
   }
 
+  getConnectionGeneration(): number {
+    return this.connectionGeneration
+  }
+
   async ensureConnected(): Promise<void> {
     if (this.connected) {
       return

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -572,20 +572,23 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         ensureConnected: () => Promise<void>
       }
 
-      requestSpy.mockClear()
-      await internals.ensureConnected()
+      try {
+        requestSpy.mockClear()
+        await internals.ensureConnected()
 
-      expect(
-        requestSpy.mock.calls.filter(
-          ([type, payload]) =>
-            type === 'createOrAttach' &&
-            typeof payload === 'object' &&
-            payload !== null &&
-            'sessionId' in payload &&
-            (payload as { sessionId: string }).sessionId === id
-        )
-      ).toHaveLength(0)
-      requestSpy.mockRestore()
+        expect(
+          requestSpy.mock.calls.filter(
+            ([type, payload]) =>
+              type === 'createOrAttach' &&
+              typeof payload === 'object' &&
+              payload !== null &&
+              'sessionId' in payload &&
+              (payload as { sessionId: string }).sessionId === id
+          )
+        ).toHaveLength(0)
+      } finally {
+        requestSpy.mockRestore()
+      }
     })
 
     it('skips tombstoned session ids during reconnect reattach', async () => {
@@ -598,23 +601,78 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         killedSessionTombstones: Map<string, number>
       }
 
-      internals.killedSessionTombstones.set(id, Date.now())
-      internals.activeSessionIds.add(id)
-      requestSpy.mockClear()
-      internals.client.disconnect()
-      await internals.ensureConnected()
+      try {
+        internals.killedSessionTombstones.set(id, Date.now())
+        internals.activeSessionIds.add(id)
+        requestSpy.mockClear()
+        internals.client.disconnect()
+        await internals.ensureConnected()
 
-      expect(
-        requestSpy.mock.calls.filter(
-          ([type, payload]) =>
+        expect(
+          requestSpy.mock.calls.filter(
+            ([type, payload]) =>
+              type === 'createOrAttach' &&
+              typeof payload === 'object' &&
+              payload !== null &&
+              'sessionId' in payload &&
+              (payload as { sessionId: string }).sessionId === id
+          )
+        ).toHaveLength(0)
+      } finally {
+        requestSpy.mockRestore()
+      }
+    })
+
+    it('continues reattaching active sessions after one session fails', async () => {
+      const firstId = 'reconnect-failed-first'
+      const secondId = 'reconnect-succeeds-second'
+      await adapter.spawn({ cols: 80, rows: 24, sessionId: firstId })
+      await adapter.spawn({ cols: 80, rows: 24, sessionId: secondId })
+      const originalRequest = DaemonClient.prototype.request
+      const requestSpy = vi.spyOn(DaemonClient.prototype, 'request')
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const internals = adapter as unknown as {
+        client: DaemonClient
+        ensureConnected: () => Promise<void>
+      }
+      const reattachError = new Error('first reattach failed')
+
+      try {
+        requestSpy.mockImplementation(function (this: DaemonClient, type, payload) {
+          if (
             type === 'createOrAttach' &&
             typeof payload === 'object' &&
             payload !== null &&
             'sessionId' in payload &&
-            (payload as { sessionId: string }).sessionId === id
+            (payload as { sessionId: string }).sessionId === firstId
+          ) {
+            return Promise.reject(reattachError)
+          }
+          return originalRequest.call(this, type, payload)
+        })
+
+        internals.client.disconnect()
+        await expect(internals.ensureConnected()).resolves.toBeUndefined()
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[daemon] reconnect reattach failed:',
+          firstId,
+          reattachError
         )
-      ).toHaveLength(0)
-      requestSpy.mockRestore()
+        expect(
+          requestSpy.mock.calls.some(
+            ([type, payload]) =>
+              type === 'createOrAttach' &&
+              typeof payload === 'object' &&
+              payload !== null &&
+              'sessionId' in payload &&
+              (payload as { sessionId: string }).sessionId === secondId
+          )
+        ).toBe(true)
+      } finally {
+        warnSpy.mockRestore()
+        requestSpy.mockRestore()
+      }
     })
   })
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -547,6 +547,75 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       adapter2.dispose()
     })
+
+    it('reattaches active sessions after a fresh reconnect', async () => {
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      const dataPayloads: { id: string; data: string }[] = []
+      adapter.onData((payload) => dataPayloads.push(payload))
+      const internals = adapter as unknown as {
+        client: DaemonClient
+        ensureConnected: () => Promise<void>
+      }
+
+      internals.client.disconnect()
+      await internals.ensureConnected()
+
+      lastSubprocess._simulateData('after-reconnect')
+      await waitFor(() => dataPayloads.length > 0)
+      expect(dataPayloads.at(-1)).toEqual({ id, data: 'after-reconnect' })
+    })
+
+    it('does not reattach again on same-connection ensureConnected calls', async () => {
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      const requestSpy = vi.spyOn(DaemonClient.prototype, 'request')
+      const internals = adapter as unknown as {
+        ensureConnected: () => Promise<void>
+      }
+
+      requestSpy.mockClear()
+      await internals.ensureConnected()
+
+      expect(
+        requestSpy.mock.calls.filter(
+          ([type, payload]) =>
+            type === 'createOrAttach' &&
+            typeof payload === 'object' &&
+            payload !== null &&
+            'sessionId' in payload &&
+            (payload as { sessionId: string }).sessionId === id
+        )
+      ).toHaveLength(0)
+      requestSpy.mockRestore()
+    })
+
+    it('skips tombstoned session ids during reconnect reattach', async () => {
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      const requestSpy = vi.spyOn(DaemonClient.prototype, 'request')
+      const internals = adapter as unknown as {
+        client: DaemonClient
+        ensureConnected: () => Promise<void>
+        activeSessionIds: Set<string>
+        killedSessionTombstones: Map<string, number>
+      }
+
+      internals.killedSessionTombstones.set(id, Date.now())
+      internals.activeSessionIds.add(id)
+      requestSpy.mockClear()
+      internals.client.disconnect()
+      await internals.ensureConnected()
+
+      expect(
+        requestSpy.mock.calls.filter(
+          ([type, payload]) =>
+            type === 'createOrAttach' &&
+            typeof payload === 'object' &&
+            payload !== null &&
+            'sessionId' in payload &&
+            (payload as { sessionId: string }).sessionId === id
+        )
+      ).toHaveLength(0)
+      requestSpy.mockRestore()
+    })
   })
 
   describe('listProcesses', () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -939,7 +939,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
       if (this.killedSessionTombstones.has(id)) {
         continue
       }
-      await this.requestAttach(id)
+      try {
+        await this.requestAttach(id)
+      } catch (err) {
+        console.warn('[daemon] reconnect reattach failed:', id, err)
+      }
     }
   }
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -130,6 +130,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // resume died with the connection. Owe those sessions a resume on the next
   // connect; the daemon's 5s failsafe covers the window in between.
   private producerResumesOwedOnReconnect = new Set<string>()
+  private lastConnectionGeneration = 0
   private static CHECKPOINT_INTERVAL_MS = 5_000
   // Why: a streaming session (build logs, `yes`) re-triggers a full multi-MB
   // snapshot checkpoint on every 5s tick via pending-buffer overflow or the
@@ -429,12 +430,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     if (!this.supportsAuthoritativeBufferSnapshots) {
       this.setPtyBackgrounded(id, false)
     }
-
-    await this.client.request<CreateOrAttachResult>('createOrAttach', {
-      sessionId: id,
-      cols: 80,
-      rows: 24
-    })
+    await this.requestAttach(id)
   }
 
   hasPty(id: string): boolean {
@@ -910,23 +906,40 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   private async ensureConnected(): Promise<void> {
     await this.client.ensureConnected()
-    // Why sampled before setupEventRouting: routing is (re)installed exactly
-    // once per connection, so "no listener yet" identifies a fresh connect —
-    // the only time the daemon-side backgrounded set needs a resync (it is
-    // process state that died with the previous daemon/socket).
-    const isFreshConnection = this.removeEventListener === null
+    const connectionGeneration = this.client.getConnectionGeneration()
+    const isFreshConnection = connectionGeneration !== this.lastConnectionGeneration
+    this.lastConnectionGeneration = connectionGeneration
     this.setupEventRouting()
     this.scheduleCheckpointTimer()
     this.flushOwedProducerResumes()
     if (isFreshConnection) {
       this.resyncBackgroundedSessions()
+      await this.reattachActiveSessionsOnFreshReconnect()
     }
+  }
+
+  private async requestAttach(id: string): Promise<void> {
+    await this.client.request<CreateOrAttachResult>('createOrAttach', {
+      sessionId: id,
+      cols: 80,
+      rows: 24
+    })
   }
 
   private resyncBackgroundedSessions(): void {
     for (const id of this.backgroundedSessionIds) {
       // Harmless no-op for sessions the daemon doesn't know (yet).
       this.client.notify('setSessionBackground', { sessionId: id, background: true })
+    }
+  }
+
+  private async reattachActiveSessionsOnFreshReconnect(): Promise<void> {
+    const activeSessionIds = [...this.activeSessionIds]
+    for (const id of activeSessionIds) {
+      if (this.killedSessionTombstones.has(id)) {
+        continue
+      }
+      await this.requestAttach(id)
     }
   }
 

--- a/src/main/daemon/issue-8335-reconnect-reattach.test.ts
+++ b/src/main/daemon/issue-8335-reconnect-reattach.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdtempSync, rmSync } from 'node:fs'
+import type { DaemonClient } from './client'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { DaemonServer } from './daemon-server'
+import { getDaemonSocketPath } from './daemon-spawner'
+import type { SubprocessHandle } from './session'
+
+function createTestDir(): string {
+  return mkdtempSync(join(tmpdir(), 'issue-8335-repro-'))
+}
+
+function createMockSubprocess(): SubprocessHandle & {
+  _simulateData: (data: string) => void
+} {
+  let onDataCb: ((data: string) => void) | null = null
+  return {
+    pid: 999_999_999,
+    getForegroundProcess: () => null,
+    write() {},
+    resize() {},
+    kill() {},
+    forceKill() {},
+    signal() {},
+    onData(cb) {
+      onDataCb = cb
+    },
+    onExit(cb) {
+      void cb
+    },
+    dispose() {},
+    _simulateData(data: string) {
+      onDataCb?.(data)
+    }
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out')
+    }
+    await new Promise((r) => setTimeout(r, 10))
+  }
+}
+
+describe('issue #8335 repro: reconnect reattaches live daemon PTYs', () => {
+  let dir: string
+  let socketPath: string
+  let tokenPath: string
+  let server: DaemonServer
+  let adapter: DaemonPtyAdapter
+  let lastSubprocess: ReturnType<typeof createMockSubprocess>
+
+  beforeEach(async () => {
+    dir = createTestDir()
+    socketPath = getDaemonSocketPath(dir)
+    tokenPath = join(dir, 'daemon.token')
+    server = new DaemonServer({
+      socketPath,
+      tokenPath,
+      spawnSubprocess: () => {
+        lastSubprocess = createMockSubprocess()
+        return lastSubprocess
+      }
+    })
+    await server.start()
+    adapter = new DaemonPtyAdapter({ socketPath, tokenPath })
+  })
+
+  afterEach(async () => {
+    adapter.dispose()
+    await server.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('restores live output after the client socket reconnects', async () => {
+    const { id } = await adapter.spawn({ cols: 80, rows: 24, sessionId: 'issue-8335' })
+    const dataPayloads: { id: string; data: string }[] = []
+    adapter.onData((payload) => dataPayloads.push(payload))
+    const internals = adapter as unknown as {
+      client: DaemonClient
+      ensureConnected: () => Promise<void>
+    }
+
+    internals.client.disconnect()
+    await internals.ensureConnected()
+
+    lastSubprocess._simulateData('restored-after-reconnect')
+    await waitFor(() => dataPayloads.length > 0)
+    expect(dataPayloads.at(-1)).toEqual({
+      id,
+      data: 'restored-after-reconnect'
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Reattach surviving daemon-backed PTY sessions after a fresh reconnect so background or App Nap socket loss does not leave the pane permanently stuck.
- Root cause: `ensureConnected()` restored listeners and background flags, but never reissued the existing `attach` / `createOrAttach` bind path for already-mounted sessions. The follow-up fix makes reconnect reattachment best-effort per session, so one failed attach no longer blocks later sessions or the operation that triggered reconnect.

Closes #8335.

The reconnect root-cause isolation and live-daemon reproduction came from @handlecusion's issue investigation on https://github.com/stablyai/orca/issues/8335.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/issue-8335-reconnect-reattach.test.ts` - passed
- `pnpm run typecheck:node` - passed
- `git diff --check origin/main...HEAD` - passed

## AI Review Report

- Fresh reconnect still rebinds surviving active session ids through the existing `createOrAttach` path.
- Reconnect reattachment is now isolated per session, so one failed attach is warned and skipped without blocking later sessions.
- Same-connection `ensureConnected()` calls stay quiet.
- Tombstoned ids remain excluded, so explicit user kills are not resurrected.

## Security Audit

- No new IPC or subprocess surface.
- Reconnect only rebinds session ids already owned by the adapter.
- Tombstone checks prevent killed sessions from being reattached.

## Notes

This fix intentionally excludes the secondary mouse-reporting echo the reporter split out. The scope is only the dead-socket reattach failure on fresh reconnect.

## ELI5

After the daemon reconnected (for example after App Nap), live terminal panes could stay stuck because Orca restored listeners but never reattached existing PTY sessions. Reconnect now best-effort reattaches each session so panes keep working.
