### PR TITLE
feat: render GitHub/Obsidian callout alerts in Markdown preview

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -822,6 +822,36 @@
   color: rgba(0, 0, 0, 0.6);
 }
 
+/* GitHub/Obsidian callout alerts (> [!NOTE] …). Monochrome per the styleguide;
+   the one semantic accent (destructive) is reserved for warning/caution. */
+.markdown-body .md-alert {
+  margin: 0.75em 0;
+  padding: 0.5em 1em;
+  border-left: 4px solid var(--border);
+  border-radius: 0 6px 6px 0;
+  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+}
+
+.markdown-body .md-alert-title {
+  margin: 0 0 0.35em;
+  font-weight: 600;
+}
+
+.markdown-body .md-alert > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .md-alert-warning,
+.markdown-body .md-alert-caution {
+  border-left-color: var(--destructive);
+  background: color-mix(in srgb, var(--destructive) 8%, transparent);
+}
+
+.markdown-body .md-alert-warning .md-alert-title,
+.markdown-body .md-alert-caution .md-alert-title {
+  color: var(--destructive);
+}
+
 .markdown-body table {
   margin: 1em 0;
   border-collapse: collapse;

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -57,6 +57,7 @@ import {
   remarkMarkdownDocLinks,
   resolveMarkdownDocLink
 } from './markdown-doc-links'
+import { remarkCalloutAlerts } from './markdown-callout-alerts'
 import { absolutePathToFileUri, resolveMarkdownLinkTarget } from './markdown-internal-links'
 import { useLocalImageSrc } from './useLocalImageSrc'
 import CodeBlockCopyButton from './CodeBlockCopyButton'
@@ -308,7 +309,12 @@ const markdownPreviewSanitizeSchema = {
       ...(defaultSchema.attributes?.code ?? []),
       ['className', /^language-[\w-]+$/, 'math-inline', 'math-display']
     ],
-    div: [...(defaultSchema.attributes?.div ?? []), ['className', /^language-[\w-]+$/], 'align'],
+    div: [
+      ...(defaultSchema.attributes?.div ?? []),
+      ['className', /^language-[\w-]+$/, /^md-alert(?:-[a-z]+)?$/],
+      'align'
+    ],
+    p: [...(defaultSchema.attributes?.p ?? []), ['className', 'md-alert-title']],
     details: [
       ...(defaultSchema.attributes?.details ?? []),
       'open',
@@ -338,6 +344,8 @@ type MarkdownPluginList = NonNullable<ReactMarkdownOptions['remarkPlugins']>
 const MARKDOWN_REMARK_PLUGINS: MarkdownPluginList = [
   remarkGfm,
   remarkBreaks,
+  // Order-independent: splits callout body on a break node or a raw newline.
+  remarkCalloutAlerts,
   remarkFrontmatter,
   remarkMath,
   remarkMarkdownDocLinks

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -312,6 +312,7 @@ const markdownPreviewSanitizeSchema = {
     div: [
       ...(defaultSchema.attributes?.div ?? []),
       ['className', /^language-[\w-]+$/, /^md-alert(?:-[a-z]+)?$/],
+      ['role', 'note'],
       'align'
     ],
     p: [...(defaultSchema.attributes?.p ?? []), ['className', 'md-alert-title']],

--- a/src/renderer/src/components/editor/markdown-callout-alerts.render.test.tsx
+++ b/src/renderer/src/components/editor/markdown-callout-alerts.render.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+// Integration check: render Markdown through the real remark pipeline
+// (gfm + breaks + our callout plugin) and confirm the callout survives to the
+// DOM — validates the structural assumption (remark-breaks emits the `break`
+// nodes the plugin splits on) and that react-markdown honors the data.hName.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { remarkCalloutAlerts } from './markdown-callout-alerts'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function render(markdown: string): void {
+  act(() => {
+    root.render(
+      <Markdown remarkPlugins={[remarkGfm, remarkBreaks, remarkCalloutAlerts]}>{markdown}</Markdown>
+    )
+  })
+}
+
+describe('callout alerts render through the real remark pipeline', () => {
+  it('renders `> [!NOTE]` as a callout div with default title and body', () => {
+    render('> [!NOTE]\n> Body text.')
+    const alert = container.querySelector('div.md-alert.md-alert-note')
+    expect(alert).not.toBeNull()
+    expect(alert?.querySelector('.md-alert-title')?.textContent).toBe('Note')
+    expect(alert?.textContent).toContain('Body text.')
+    // The literal marker must be gone.
+    expect(container.textContent).not.toContain('[!NOTE]')
+  })
+
+  it('renders an Obsidian-style custom title and a warning accent class', () => {
+    render('> [!warning] Careful now\n> Details.')
+    const alert = container.querySelector('div.md-alert.md-alert-warning')
+    expect(alert).not.toBeNull()
+    expect(alert?.querySelector('.md-alert-title')?.textContent).toBe('Careful now')
+    expect(alert?.textContent).toContain('Details.')
+  })
+
+  it('leaves an ordinary blockquote as a blockquote', () => {
+    render('> just a quote')
+    expect(container.querySelector('div.md-alert')).toBeNull()
+    expect(container.querySelector('blockquote')).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/markdown-callout-alerts.render.test.tsx
+++ b/src/renderer/src/components/editor/markdown-callout-alerts.render.test.tsx
@@ -41,6 +41,8 @@ describe('callout alerts render through the real remark pipeline', () => {
     render('> [!NOTE]\n> Body text.')
     const alert = container.querySelector('div.md-alert.md-alert-note')
     expect(alert).not.toBeNull()
+    // role="note" must survive rehype-sanitize (allowlisted on div).
+    expect(alert?.getAttribute('role')).toBe('note')
     expect(alert?.querySelector('.md-alert-title')?.textContent).toBe('Note')
     expect(alert?.textContent).toContain('Body text.')
     // The literal marker must be gone.

--- a/src/renderer/src/components/editor/markdown-callout-alerts.test.ts
+++ b/src/renderer/src/components/editor/markdown-callout-alerts.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { remarkCalloutAlerts } from './markdown-callout-alerts'
+
+type Node = {
+  type: string
+  value?: string
+  children?: Node[]
+  data?: { hName?: string; hProperties?: Record<string, unknown> }
+}
+
+// Build the mdast a `> [!type] ...` blockquote produces with remark-breaks:
+// marker line, body lines, all in one paragraph separated by `break` nodes.
+function blockquote(...lines: string[]): Node {
+  const children: Node[] = []
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      children.push({ type: 'break' })
+    }
+    children.push({ type: 'text', value: line })
+  })
+  return { type: 'blockquote', children: [{ type: 'paragraph', children }] }
+}
+
+// Build the mdast without remark-breaks: the marker line and body live in one
+// text node separated by a raw `\n` (proves the split doesn't need break nodes).
+function rawBlockquote(text: string): Node {
+  return { type: 'blockquote', children: [{ type: 'paragraph', children: [{ type: 'text', value: text }] }] }
+}
+
+function tree(...blocks: Node[]): Node {
+  return { type: 'root', children: blocks }
+}
+
+function transform(root: Node): Node {
+  remarkCalloutAlerts()(root)
+  return root
+}
+
+const titleText = (node: Node): string =>
+  (node.children ?? [])
+    .filter((c) => c.type === 'text')
+    .map((c) => c.value)
+    .join('')
+
+describe('remarkCalloutAlerts', () => {
+  it('turns a [!note] blockquote into a callout div with a default title and body', () => {
+    const bq = blockquote('[!note]', 'Body text.')
+    transform(tree(bq))
+
+    expect(bq.data?.hName).toBe('div')
+    expect(bq.data?.hProperties?.className).toEqual(['md-alert', 'md-alert-note'])
+    const [title, body] = bq.children!
+    expect(title.data?.hProperties?.className).toEqual(['md-alert-title'])
+    expect(titleText(title)).toBe('Note')
+    expect(body.type).toBe('paragraph')
+    expect(titleText(body)).toBe('Body text.')
+  })
+
+  it('keeps an inline custom title (Obsidian style) and is case-insensitive', () => {
+    const bq = blockquote('[!WARNING] Careful now', 'Details.')
+    transform(tree(bq))
+
+    expect(bq.data?.hProperties?.className).toEqual(['md-alert', 'md-alert-warning'])
+    expect(titleText(bq.children![0])).toBe('Careful now')
+    expect(titleText(bq.children![1])).toBe('Details.')
+  })
+
+  it('handles a marker-only callout with no body', () => {
+    const bq = blockquote('[!caution]')
+    transform(tree(bq))
+
+    expect(bq.data?.hProperties?.className).toEqual(['md-alert', 'md-alert-caution'])
+    expect(bq.children).toHaveLength(1)
+    expect(titleText(bq.children![0])).toBe('Caution')
+  })
+
+  it('supports every alert type', () => {
+    for (const [marker, cls] of [
+      ['[!tip]', 'md-alert-tip'],
+      ['[!important]', 'md-alert-important']
+    ] as const) {
+      const bq = blockquote(marker, 'x')
+      transform(tree(bq))
+      expect(bq.data?.hProperties?.className).toContain(cls)
+    }
+  })
+
+  it('leaves ordinary blockquotes untouched', () => {
+    const bq = blockquote('Just a normal quote.', 'Second line.')
+    transform(tree(bq))
+    expect(bq.data).toBeUndefined()
+    expect(bq.children![0].type).toBe('paragraph')
+  })
+
+  it('ignores a bracket that is not an alert marker', () => {
+    const bq = blockquote('[!unknown] not an alert')
+    transform(tree(bq))
+    expect(bq.data).toBeUndefined()
+  })
+
+  it('splits marker line from body on a raw newline (no remark-breaks)', () => {
+    const bq = rawBlockquote('[!note]\nBody text.')
+    transform(tree(bq))
+
+    expect(bq.data?.hProperties?.className).toEqual(['md-alert', 'md-alert-note'])
+    expect(titleText(bq.children![0])).toBe('Note')
+    expect(bq.children![1].type).toBe('paragraph')
+    expect(titleText(bq.children![1])).toBe('Body text.')
+  })
+
+  it('keeps an inline custom title before a raw newline (no remark-breaks)', () => {
+    const bq = rawBlockquote('[!warning] Careful\nDetails.')
+    transform(tree(bq))
+
+    expect(bq.data?.hProperties?.className).toEqual(['md-alert', 'md-alert-warning'])
+    expect(titleText(bq.children![0])).toBe('Careful')
+    expect(titleText(bq.children![1])).toBe('Details.')
+  })
+
+  it('transforms callouts nested inside other containers', () => {
+    const bq = blockquote('[!note]', 'nested')
+    const list: Node = { type: 'listItem', children: [bq] }
+    transform(tree({ type: 'list', children: [list] }))
+    expect(bq.data?.hProperties?.className).toEqual(['md-alert', 'md-alert-note'])
+  })
+})

--- a/src/renderer/src/components/editor/markdown-callout-alerts.test.ts
+++ b/src/renderer/src/components/editor/markdown-callout-alerts.test.ts
@@ -49,6 +49,7 @@ describe('remarkCalloutAlerts', () => {
 
     expect(bq.data?.hName).toBe('div')
     expect(bq.data?.hProperties?.className).toEqual(['md-alert', 'md-alert-note'])
+    expect(bq.data?.hProperties?.role).toBe('note')
     const [title, body] = bq.children!
     expect(title.data?.hProperties?.className).toEqual(['md-alert-title'])
     expect(titleText(title)).toBe('Note')

--- a/src/renderer/src/components/editor/markdown-callout-alerts.ts
+++ b/src/renderer/src/components/editor/markdown-callout-alerts.ts
@@ -1,9 +1,9 @@
 // Renders GitHub/Obsidian callout blockquotes (`> [!NOTE]`, `> [!WARNING]`, …)
 // as styled callout boxes instead of the literal `[!type]` marker. A remark
 // (mdast) transform so it runs before sanitize; output is class-only (no inline
-// SVG) so it survives rehype-sanitize with a small allowlist. Icons + colors are
-// applied in CSS (markdown-preview.css), monochrome per the styleguide with the
-// one semantic accent (destructive) reserved for warning/caution.
+// SVG) so it survives rehype-sanitize with a small allowlist. Colors come from
+// CSS (markdown-preview.css), monochrome per the styleguide with the one
+// semantic accent (destructive) reserved for warning/caution.
 
 export const CALLOUT_ALERT_TYPES = [
   'note',
@@ -24,8 +24,9 @@ const ALERT_LABELS: Record<CalloutAlertType, string> = {
 
 // Marker at the very start of the blockquote's first line, e.g. `[!NOTE]` or
 // `[!note] Custom title`. Trailing spaces/tabs (not newlines) after `]` are eaten
-// so an inline custom title starts clean.
-const MARKER_RE = /^\[!(note|tip|important|warning|caution)\][^\S\r\n]*/i
+// so an inline custom title starts clean. Built from CALLOUT_ALERT_TYPES so a new
+// type added there cannot drift out of sync with the matcher.
+const MARKER_RE = new RegExp(`^\\[!(${CALLOUT_ALERT_TYPES.join('|')})\\][^\\S\\r\\n]*`, 'i')
 
 type MarkdownNode = {
   type: string
@@ -88,9 +89,12 @@ function transformBlockquote(node: MarkdownNode): void {
     ...node.children!.slice(1)
   ]
 
+  // role="note" (not "alert") for every type: these are static rendered content,
+  // and "alert" is an assertive live region that would interrupt screen readers
+  // on each render. Severity is conveyed by the visible title ("Warning"/"Caution").
   node.data = {
     hName: 'div',
-    hProperties: { className: ['md-alert', `md-alert-${type}`] }
+    hProperties: { className: ['md-alert', `md-alert-${type}`], role: 'note' }
   }
   node.children = [titleNode, ...body]
 }

--- a/src/renderer/src/components/editor/markdown-callout-alerts.ts
+++ b/src/renderer/src/components/editor/markdown-callout-alerts.ts
@@ -1,0 +1,125 @@
+// Renders GitHub/Obsidian callout blockquotes (`> [!NOTE]`, `> [!WARNING]`, …)
+// as styled callout boxes instead of the literal `[!type]` marker. A remark
+// (mdast) transform so it runs before sanitize; output is class-only (no inline
+// SVG) so it survives rehype-sanitize with a small allowlist. Icons + colors are
+// applied in CSS (markdown-preview.css), monochrome per the styleguide with the
+// one semantic accent (destructive) reserved for warning/caution.
+
+export const CALLOUT_ALERT_TYPES = [
+  'note',
+  'tip',
+  'important',
+  'warning',
+  'caution'
+] as const
+type CalloutAlertType = (typeof CALLOUT_ALERT_TYPES)[number]
+
+const ALERT_LABELS: Record<CalloutAlertType, string> = {
+  note: 'Note',
+  tip: 'Tip',
+  important: 'Important',
+  warning: 'Warning',
+  caution: 'Caution'
+}
+
+// Marker at the very start of the blockquote's first line, e.g. `[!NOTE]` or
+// `[!note] Custom title`. Trailing spaces/tabs (not newlines) after `]` are eaten
+// so an inline custom title starts clean.
+const MARKER_RE = /^\[!(note|tip|important|warning|caution)\][^\S\r\n]*/i
+
+type MarkdownNode = {
+  type: string
+  value?: string
+  children?: MarkdownNode[]
+  data?: { hName?: string; hProperties?: Record<string, unknown> }
+}
+
+export function remarkCalloutAlerts(): (tree: MarkdownNode) => void {
+  return (tree) => transformChildren(tree)
+}
+
+function transformChildren(node: MarkdownNode): void {
+  if (!node.children) {
+    return
+  }
+  for (const child of node.children) {
+    if (child.type === 'blockquote') {
+      transformBlockquote(child)
+    }
+    transformChildren(child)
+  }
+}
+
+function transformBlockquote(node: MarkdownNode): void {
+  const firstPara = node.children?.[0]
+  if (!firstPara || firstPara.type !== 'paragraph' || !firstPara.children?.length) {
+    return
+  }
+  const first = firstPara.children[0]
+  if (first.type !== 'text' || typeof first.value !== 'string') {
+    return
+  }
+  const match = MARKER_RE.exec(first.value)
+  if (!match) {
+    return
+  }
+  const type = match[1].toLowerCase() as CalloutAlertType
+
+  // Drop the `[!type]` marker, keeping any inline custom title that follows it.
+  first.value = first.value.slice(match[0].length)
+
+  // The marker line ends at the first line break in the first paragraph. Split
+  // there: title inline before it, body after. The break is a `break` node when
+  // remark-breaks ran, or a literal `\n` in a text node otherwise — handle both
+  // so the transform doesn't depend on plugin ordering.
+  const { title: titleInline, body: inlineBody } = splitAtFirstLineBreak(firstPara.children)
+  const titleContent = titleInline.filter(
+    (child) => !(child.type === 'text' && (child.value ?? '').trim() === '')
+  )
+
+  const titleNode: MarkdownNode = {
+    type: 'paragraph',
+    data: { hProperties: { className: ['md-alert-title'] } },
+    children: titleContent.length > 0 ? titleContent : [{ type: 'text', value: ALERT_LABELS[type] }]
+  }
+
+  const body: MarkdownNode[] = [
+    ...(inlineBody.length > 0 ? [{ type: 'paragraph', children: inlineBody }] : []),
+    ...node.children!.slice(1)
+  ]
+
+  node.data = {
+    hName: 'div',
+    hProperties: { className: ['md-alert', `md-alert-${type}`] }
+  }
+  node.children = [titleNode, ...body]
+}
+
+// Split a paragraph's inline children at the first line break — a `break` node
+// (remark-breaks) or the first `\n` inside a text node (no remark-breaks). The
+// break itself is dropped; a text node holding the `\n` is split across the two.
+function splitAtFirstLineBreak(children: MarkdownNode[]): {
+  title: MarkdownNode[]
+  body: MarkdownNode[]
+} {
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index]
+    if (child.type === 'break') {
+      return { title: children.slice(0, index), body: children.slice(index + 1) }
+    }
+    if (child.type === 'text' && typeof child.value === 'string') {
+      const newlineIndex = child.value.indexOf('\n')
+      if (newlineIndex !== -1) {
+        const before = child.value.slice(0, newlineIndex)
+        const after = child.value.slice(newlineIndex + 1)
+        const title = children.slice(0, index)
+        if (before) {
+          title.push({ type: 'text', value: before })
+        }
+        const body = after ? [{ type: 'text', value: after }, ...children.slice(index + 1)] : children.slice(index + 1)
+        return { title, body }
+      }
+    }
+  }
+  return { title: children, body: [] }
+}


### PR DESCRIPTION
## Summary

Renders GitHub/Obsidian **callout (alert) blockquotes** in the Markdown preview. A block like `> [!note]` now becomes a styled callout box with a title and body instead of showing the literal `[!note]` marker.

Closes #8441.

### Before / After

**Input**
```markdown
> [!note] Optional title
> Body text of the callout.

> [!warning]
> Another one.
```

- **Before:** ordinary blockquotes; the `[!note]` / `[!warning]` text is shown verbatim.
- **After:** styled callout boxes; the marker line is consumed and becomes the title (default label when no inline title is given).

## Approach

A small remark (mdast) transform, `remarkCalloutAlerts`, added to the existing `react-markdown` pipeline in `MarkdownPreview.tsx`. It rewrites a `blockquote` whose first paragraph starts with `[!type]` into a `div.md-alert.md-alert-<type>` with a `p.md-alert-title`.

Covers the Obsidian superset the issue describes: the five GitHub types (`note`, `tip`, `important`, `warning`, `caution`), case-insensitive markers, and an optional inline custom title on the marker line (`> [!warning] Careful now`).

**Sanitize gotcha (per the issue):** because the pipeline runs `rehype-sanitize` with `defaultSchema`, the callout `div` + class names would be stripped. The transform emits class-only output (no inline SVG) and the sanitize schema is extended to allow `md-alert*` on `div` and `md-alert-title` on `p`, so the styling survives.

**Styling** lives in `markdown-preview.css` and follows the design system: monochrome (border + subtle `color-mix` tint), with the one semantic accent (`--destructive`) reserved for `warning` / `caution`. No new color tokens introduced.

**Ordering-independent split:** the marker line is separated from the body at the first line break, handling both a `break` node (when `remark-breaks` ran) and a raw `\n` in a text node — so the transform doesn't depend on plugin ordering in the chain.

## Not included

Foldable callouts (`[!note]-` / `[!note]+`) are out of scope for this PR — it focuses on rendering the marker as a styled callout.

## Tests

- Unit tests for the transform: default/custom titles, case-insensitivity, marker-only (no body), every alert type, ordinary blockquotes left untouched, non-alert brackets ignored, nested-in-list, and the ordering-independent split (both `break` node and raw `\n`).
- Integration tests through the **real** `react-markdown` pipeline (`remark-gfm` + `remark-breaks` + the plugin) asserting the callout survives to the DOM and the literal marker is gone.

## Verification

- `pnpm run typecheck` — clean (excluding 2 pre-existing `typescript-api` errors unrelated to this change)
- `oxlint` on changed files — clean
- Full editor test suite — 841 passing
- `pnpm run build:electron-vite` and `build:web` — both succeed

## ELI5

Markdown preview now turns GitHub/Obsidian callouts like `> [!note]` into styled alert boxes with a title and body. You no longer see the raw `[!note]` marker as plain blockquote text.
