### PR TITLE
feat(sidebar): left sidebar edge peek when collapsed

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -49,6 +49,7 @@ import RetainedAgentsSyncGate from './components/dashboard/RetainedAgentsSyncGat
 import { AgentHibernationGate } from './components/AgentHibernationGate'
 import { ActivityTitlebarControls } from './components/activity/ActivityTitlebarControls'
 import Sidebar from './components/Sidebar'
+import { LeftSidebarEdgePeekZone } from './components/sidebar/left-sidebar-edge-peek'
 import { shutdownBufferCaptures } from './components/terminal-pane/shutdown-buffer-captures'
 import { dispatchWindowCloseRequest } from './components/window-close-request-coordinator'
 import {
@@ -2254,7 +2255,10 @@ function App(): React.JSX.Element {
                 'The app is still running. Retry the shell or use the menu to report the crash details.'
               )}
             >
-              <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+              {/* Why: relative anchors the left-sidebar edge-peek overlay to
+              this row, so a peek spans the same height as the docked sidebar
+              and ends above the status bar. */}
+              <div className="relative flex flex-row flex-1 min-h-0 overflow-hidden">
                 {/* Why: the non-workspace titlebar lives inside this left+center
               wrapper so it does not span over the right-sidebar column —
               when the right sidebar is open, its own header anchors at the
@@ -2271,10 +2275,12 @@ function App(): React.JSX.Element {
                       {titlebarMainStrip}
                     </div>
                   ) : null}
-                  <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+                  <div className="relative flex flex-row flex-1 min-h-0 overflow-hidden">
                     {showSidebar ? (
-                      leftTitlebarChromeLayout.shouldMount ? (
-                        /* Why: left column wraps the sidebar with a titlebar-height
+                      <>
+                        <LeftSidebarEdgePeekZone />
+                        {leftTitlebarChromeLayout.shouldMount ? (
+                          /* Why: left column wraps the sidebar with a titlebar-height
                      header above it. The header holds the same controls
                      (traffic lights, sidebar toggle, "Orca" title, agent badge)
                      that the full-width titlebar held while the center and right
@@ -2282,84 +2288,89 @@ function App(): React.JSX.Element {
                      When the sidebar is collapsed, take this header out of flex
                      layout so the terminal/editor reclaim the left edge instead of
                      leaving behind a content-width blank strip. */
-                        <div
-                          className={`flex min-h-0 flex-col shrink-0${sidebarOpen ? '' : ' relative w-0 overflow-visible'}`}
-                        >
                           <div
-                            // Why: when the sidebar is collapsed, titlebar-left floats
-                            // absolutely on top of the center column's own `border-l`
-                            // (see TabGroupSplitLayout), occluding that seam. Add a
-                            // `border-r` in the floating state so the vertical line
-                            // between the traffic-light/nav cluster and the tab strip
-                            // stays visible in both states. w-max keeps the floating
-                            // header sized to its own controls instead of the w-0
-                            // sidebar wrapper.
-                            className={`titlebar-left${
-                              leftTitlebarChromeLayout.isFloating
-                                ? ' titlebar-left-floating absolute top-0 left-0 z-10 w-max border-r border-border'
-                                : ''
-                            }`}
-                            style={{
-                              // Why: custom sidebar appearances are scoped to the sidebar
-                              // root, so mirror those variables onto the open header that
-                              // visually belongs to the same left-column panel.
-                              ...(sidebarOpen ? leftSidebarStyle : undefined),
-                              // Why: the Sidebar resize hook updates the sidebar DOM width
-                              // directly during drag and only persists to Zustand on
-                              // mouseup. In workspace view, size this header from the
-                              // wrapper's live width so it tracks those in-flight resizes
-                              // instead of leaving a stale-width gap until the drag ends.
-                              width: sidebarOpen ? '100%' : undefined
-                            }}
+                            className={`flex min-h-0 flex-col shrink-0${sidebarOpen ? '' : ' relative w-0 overflow-visible'}`}
                           >
-                            {titlebarLeftControls}
-                          </div>
-                          <div className="flex min-h-0 flex-1">
-                            {/* Why: the workspace-view wrapper adds a fixed 36px header
+                            <div
+                              // Why: when the sidebar is collapsed, titlebar-left floats
+                              // absolutely on top of the center column's own `border-l`
+                              // (see TabGroupSplitLayout), occluding that seam. Add a
+                              // `border-r` in the floating state so the vertical line
+                              // between the traffic-light/nav cluster and the tab strip
+                              // stays visible in both states. w-max keeps the floating
+                              // header sized to its own controls instead of the w-0
+                              // sidebar wrapper. z-40 keeps it above an edge-peek panel
+                              // (z-30) so traffic lights / toggle stay clickable.
+                              className={`titlebar-left${
+                                leftTitlebarChromeLayout.isFloating
+                                  ? ' titlebar-left-floating absolute top-0 left-0 z-40 w-max border-r border-border'
+                                  : ''
+                              }`}
+                              style={{
+                                // Why: custom sidebar appearances are scoped to the sidebar
+                                // root, so mirror those variables onto the open header that
+                                // visually belongs to the same left-column panel.
+                                ...(sidebarOpen ? leftSidebarStyle : undefined),
+                                // Why: the Sidebar resize hook updates the sidebar DOM width
+                                // directly during drag and only persists to Zustand on
+                                // mouseup. In workspace view, size this header from the
+                                // wrapper's live width so it tracks those in-flight resizes
+                                // instead of leaving a stale-width gap until the drag ends.
+                                width: sidebarOpen ? '100%' : undefined
+                              }}
+                            >
+                              {titlebarLeftControls}
+                            </div>
+                            <div className="relative flex min-h-0 flex-1 overflow-visible">
+                              {/* Why: the workspace-view wrapper adds a fixed 36px header
                           above the sidebar. Without a flex-1/min-h-0 slot here,
                           the sidebar falls back to its content height, so the
                           worktree list loses its scroll viewport and the fixed
-                          bottom toolbar (including Add Project) gets pushed offscreen. */}
-                            <RecoverableRenderErrorBoundary
-                              boundaryId="sidebar.worktrees"
-                              surface="sidebar"
-                              resetKey={activeView}
-                              title={translate(
-                                'auto.App.1468601e7b',
-                                'The workspace list hit an error.'
-                              )}
-                              description={translate(
-                                'auto.App.bdc71dddc9',
-                                'The active workspace remains open. Retry the list or switch views.'
-                              )}
-                            >
-                              <Sidebar
-                                worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
-                                worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
-                              />
-                            </RecoverableRenderErrorBoundary>
+                          bottom toolbar (including Add Project) gets pushed offscreen.
+                          relative + overflow-visible anchors the edge-peek overlay
+                          without clipping it when the column is collapsed to w-0. */}
+                              <RecoverableRenderErrorBoundary
+                                boundaryId="sidebar.worktrees"
+                                surface="sidebar"
+                                resetKey={activeView}
+                                title={translate(
+                                  'auto.App.1468601e7b',
+                                  'The workspace list hit an error.'
+                                )}
+                                description={translate(
+                                  'auto.App.bdc71dddc9',
+                                  'The active workspace remains open. Retry the list or switch views.'
+                                )}
+                              >
+                                <Sidebar
+                                  worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
+                                  worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
+                                  peekBelowFloatingTitlebar={leftTitlebarChromeLayout.isFloating}
+                                />
+                              </RecoverableRenderErrorBoundary>
+                            </div>
                           </div>
-                        </div>
-                      ) : (
-                        <RecoverableRenderErrorBoundary
-                          boundaryId="sidebar.worktrees"
-                          surface="sidebar"
-                          resetKey={activeView}
-                          title={translate(
-                            'auto.App.1468601e7b',
-                            'The workspace list hit an error.'
-                          )}
-                          description={translate(
-                            'auto.App.cba0fafda5',
-                            'The active page remains open. Retry the list or switch views.'
-                          )}
-                        >
-                          <Sidebar
-                            worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
-                            worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
-                          />
-                        </RecoverableRenderErrorBoundary>
-                      )
+                        ) : (
+                          <RecoverableRenderErrorBoundary
+                            boundaryId="sidebar.worktrees"
+                            surface="sidebar"
+                            resetKey={activeView}
+                            title={translate(
+                              'auto.App.1468601e7b',
+                              'The workspace list hit an error.'
+                            )}
+                            description={translate(
+                              'auto.App.cba0fafda5',
+                              'The active page remains open. Retry the list or switch views.'
+                            )}
+                          >
+                            <Sidebar
+                              worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
+                              worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
+                            />
+                          </RecoverableRenderErrorBoundary>
+                        )}
+                      </>
                     ) : null}
                     <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
                       {stackedSidebarOpen ? (

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -16,6 +16,11 @@ import { useWorkspaceBoardPanel } from './useWorkspaceBoardPanel'
 import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
+import {
+  LEFT_SIDEBAR_PEEK_BELOW_TITLEBAR_CLASS_NAME,
+  LEFT_SIDEBAR_PEEK_OVERLAY_CLASS_NAME,
+  useLeftSidebarEdgePeekDismiss
+} from './left-sidebar-edge-peek'
 
 const WorktreeMetaDialog = lazyWithRetry(() => import('./WorktreeMetaDialog'))
 const RemoveFolderDialog = lazyWithRetry(() => import('./RemoveFolderDialog'))
@@ -35,13 +40,22 @@ export const WORKTREE_SIDEBAR_RESIZE_HANDLE_LINE_CLASS_NAME =
 type SidebarProps = {
   worktreeScrollOffsetRef: React.MutableRefObject<number>
   worktreeScrollAnchorRef: React.MutableRefObject<VirtualizedScrollAnchor>
+  /**
+   * When true, the collapsed titlebar chrome stays floating above the peek
+   * (keeps the tab strip spacer stable). The peek panel then starts below that
+   * 36px row so Tasks/nav remain visible.
+   */
+  peekBelowFloatingTitlebar?: boolean
 }
 
 function Sidebar({
   worktreeScrollOffsetRef,
-  worktreeScrollAnchorRef
+  worktreeScrollAnchorRef,
+  peekBelowFloatingTitlebar = false
 }: SidebarProps): React.JSX.Element {
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
+  const sidebarPeek = useAppStore((s) => s.sidebarPeek)
+  const setSidebarPeek = useAppStore((s) => s.setSidebarPeek)
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const setSidebarWidth = useAppStore((s) => s.setSidebarWidth)
   const repos = useAppStore((s) => s.repos)
@@ -68,6 +82,11 @@ function Sidebar({
     solidifyWorkspaceBoardFromDrag,
     cancelWorkspaceBoardDragPreview
   } = useWorkspaceBoardPanel()
+
+  // An edge-hover peek shows the same content as a pinned-open sidebar; only
+  // the positioning differs (floating overlay vs in-flow panel).
+  const isPeeking = sidebarPeek && !sidebarOpen
+  const sidebarVisible = sidebarOpen || isPeeking
 
   const setLiveSidebarWidth = React.useCallback((width: number) => {
     document.documentElement.style.setProperty('--workspace-sidebar-live-width', `${width}px`)
@@ -121,7 +140,7 @@ function Sidebar({
   }, [closeWorkspaceBoard, sidebarOpen, workspaceBoardRenderedOpen])
 
   const { containerRef, onResizeStart, isResizing } = useSidebarResize<HTMLDivElement>({
-    isOpen: sidebarOpen,
+    isOpen: sidebarVisible,
     width: sidebarWidth,
     minWidth: MIN_WIDTH,
     maxWidth: MAX_WIDTH,
@@ -129,17 +148,33 @@ function Sidebar({
     setWidth: setSidebarWidth,
     onDraftWidthChange: setLiveSidebarWidth
   })
+  useLeftSidebarEdgePeekDismiss({
+    isPeeking,
+    isResizing,
+    setPeek: setSidebarPeek,
+    overlayRef: containerRef
+  })
 
   return (
     <TooltipProvider delayDuration={400}>
       <div
         ref={containerRef}
-        data-native-file-drop-target={sidebarOpen ? nativeDropTarget : undefined}
-        className="relative min-h-0 flex-shrink-0 bg-worktree-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent"
+        data-native-file-drop-target={sidebarVisible ? nativeDropTarget : undefined}
+        className={cn(
+          'min-h-0 flex-shrink-0 bg-worktree-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent',
+          // Why: peek floats over the workspace (no reflow) so the tab strip
+          // spacer stays put. When a floating collapsed titlebar is present,
+          // start below it so Tasks/nav are not covered.
+          isPeeking
+            ? peekBelowFloatingTitlebar
+              ? LEFT_SIDEBAR_PEEK_BELOW_TITLEBAR_CLASS_NAME
+              : LEFT_SIDEBAR_PEEK_OVERLAY_CLASS_NAME
+            : 'relative'
+        )}
         style={leftSidebarStyle}
         {...dropHandlers}
       >
-        {sidebarOpen && (
+        {sidebarVisible && (
           <>
             {/* Fixed controls */}
             <SidebarNav />
@@ -165,7 +200,7 @@ function Sidebar({
           </>
         )}
 
-        {sidebarOpen && affordance.visible ? (
+        {sidebarVisible && affordance.visible ? (
           <div
             className={cn(
               'pointer-events-none absolute inset-2 z-20 flex flex-col items-center justify-center gap-1.5 rounded-md border bg-worktree-sidebar-accent/95 px-4 text-center text-worktree-sidebar-accent-foreground shadow-xs',
@@ -185,7 +220,7 @@ function Sidebar({
         ) : null}
 
         {/* Resize handle */}
-        {sidebarOpen && (
+        {sidebarVisible && (
           <div
             data-sidebar-resize-handle=""
             className={cn(WORKTREE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME, isResizing && 'bg-ring/10')}

--- a/src/renderer/src/components/sidebar/left-sidebar-edge-peek.test.tsx
+++ b/src/renderer/src/components/sidebar/left-sidebar-edge-peek.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment happy-dom
+
+import { act, fireEvent, render, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import {
+  PEEK_CLOSE_DELAY_MS,
+  PEEK_OPEN_DELAY_MS,
+  LeftSidebarEdgePeekZone,
+  useLeftSidebarEdgePeekDismiss
+} from './left-sidebar-edge-peek'
+
+const initialAppState = useAppStore.getInitialState()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  useAppStore.setState({ sidebarOpen: false, sidebarPeek: false })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  useAppStore.setState(initialAppState, true)
+})
+
+function makeOverlayRef(right: number): React.RefObject<HTMLElement | null> {
+  return makeMovingOverlayRef(() => right)
+}
+
+// Overlay whose measured right edge changes between reads (e.g. the slide-in
+// entrance transform still translating the panel when first measured).
+function makeMovingOverlayRef(readRight: () => number): React.RefObject<HTMLElement | null> {
+  return {
+    current: { getBoundingClientRect: () => ({ right: readRight() }) } as unknown as HTMLElement
+  }
+}
+
+const LEFT_EDGE_X = 1
+const BELOW_TITLEBAR_Y = 100
+
+function moveMouse(clientX: number, clientY: number, buttons = 0): void {
+  act(() => {
+    fireEvent.mouseMove(window, { clientX, clientY, buttons })
+  })
+}
+
+describe('LeftSidebarEdgePeekZone', () => {
+  it('renders nothing (no DOM strip that could swallow edge clicks)', () => {
+    const { container } = render(<LeftSidebarEdgePeekZone />)
+    expect(container.firstElementChild).toBeNull()
+  })
+
+  it('arms the peek after the pointer hovers the left edge for the open delay', () => {
+    render(<LeftSidebarEdgePeekZone />)
+
+    moveMouse(LEFT_EDGE_X, BELOW_TITLEBAR_Y)
+    expect(useAppStore.getState().sidebarPeek).toBe(false)
+
+    vi.advanceTimersByTime(PEEK_OPEN_DELAY_MS)
+    expect(useAppStore.getState().sidebarPeek).toBe(true)
+  })
+
+  it('cancels an armed peek when the pointer leaves the edge before the delay', () => {
+    render(<LeftSidebarEdgePeekZone />)
+
+    moveMouse(LEFT_EDGE_X, BELOW_TITLEBAR_Y)
+    vi.advanceTimersByTime(PEEK_OPEN_DELAY_MS - 1)
+    moveMouse(LEFT_EDGE_X + 200, BELOW_TITLEBAR_Y)
+    vi.advanceTimersByTime(PEEK_OPEN_DELAY_MS)
+
+    expect(useAppStore.getState().sidebarPeek).toBe(false)
+  })
+
+  it('ignores the top titlebar zone so window controls stay clickable', () => {
+    render(<LeftSidebarEdgePeekZone />)
+
+    moveMouse(LEFT_EDGE_X, 10)
+    vi.advanceTimersByTime(PEEK_OPEN_DELAY_MS)
+
+    expect(useAppStore.getState().sidebarPeek).toBe(false)
+  })
+
+  it('does not arm while a mouse button is held (drag near the edge)', () => {
+    render(<LeftSidebarEdgePeekZone />)
+
+    moveMouse(LEFT_EDGE_X, BELOW_TITLEBAR_Y, 1)
+    vi.advanceTimersByTime(PEEK_OPEN_DELAY_MS)
+
+    expect(useAppStore.getState().sidebarPeek).toBe(false)
+  })
+
+  it('does not arm while the sidebar is already open', () => {
+    useAppStore.setState({ sidebarOpen: true })
+    render(<LeftSidebarEdgePeekZone />)
+
+    moveMouse(LEFT_EDGE_X, BELOW_TITLEBAR_Y)
+    vi.advanceTimersByTime(PEEK_OPEN_DELAY_MS)
+
+    expect(useAppStore.getState().sidebarPeek).toBe(false)
+  })
+
+  it('clears an active peek when the zone unmounts on a view change', () => {
+    const { unmount } = render(<LeftSidebarEdgePeekZone />)
+
+    moveMouse(LEFT_EDGE_X, BELOW_TITLEBAR_Y)
+    vi.advanceTimersByTime(PEEK_OPEN_DELAY_MS)
+    expect(useAppStore.getState().sidebarPeek).toBe(true)
+
+    unmount()
+
+    // A surviving flag would render a ghost peek when the user returns to a
+    // sidebar-capable view.
+    expect(useAppStore.getState().sidebarPeek).toBe(false)
+  })
+
+  it('clears an armed timer if the sidebar opens before it fires', () => {
+    const { rerender } = render(<LeftSidebarEdgePeekZone />)
+
+    moveMouse(LEFT_EDGE_X, BELOW_TITLEBAR_Y)
+    act(() => {
+      useAppStore.setState({ sidebarOpen: true })
+    })
+    rerender(<LeftSidebarEdgePeekZone />)
+    vi.advanceTimersByTime(PEEK_OPEN_DELAY_MS)
+
+    // The pending open timer must not flip peek on after the sidebar opened.
+    expect(useAppStore.getState().sidebarPeek).toBe(false)
+  })
+})
+
+describe('useLeftSidebarEdgePeekDismiss', () => {
+  it('dismisses after the pointer stays right of the overlay for the close delay', () => {
+    const setPeek = vi.fn()
+    renderHook(() =>
+      useLeftSidebarEdgePeekDismiss({
+        isPeeking: true,
+        isResizing: false,
+        setPeek,
+        overlayRef: makeOverlayRef(280)
+      })
+    )
+
+    fireEvent.mouseMove(window, { clientX: 400 })
+    vi.advanceTimersByTime(PEEK_CLOSE_DELAY_MS)
+
+    expect(setPeek).toHaveBeenCalledWith(false)
+  })
+
+  it('keeps the peek when the pointer returns to the overlay before the delay', () => {
+    const setPeek = vi.fn()
+    renderHook(() =>
+      useLeftSidebarEdgePeekDismiss({
+        isPeeking: true,
+        isResizing: false,
+        setPeek,
+        overlayRef: makeOverlayRef(280)
+      })
+    )
+
+    fireEvent.mouseMove(window, { clientX: 400 })
+    vi.advanceTimersByTime(PEEK_CLOSE_DELAY_MS - 1)
+    fireEvent.mouseMove(window, { clientX: 100 })
+    vi.advanceTimersByTime(PEEK_CLOSE_DELAY_MS)
+
+    expect(setPeek).not.toHaveBeenCalled()
+  })
+
+  it('does not dismiss when the boundary was measured mid entrance animation', () => {
+    const setPeek = vi.fn()
+    // First read happens during the slide-in: the overlay still sits near the
+    // window's left edge. By the time the close timer re-measures, the
+    // animation has settled at its real position.
+    let overlayRight = 10
+    renderHook(() =>
+      useLeftSidebarEdgePeekDismiss({
+        isPeeking: true,
+        isResizing: false,
+        setPeek,
+        overlayRef: makeMovingOverlayRef(() => overlayRight)
+      })
+    )
+
+    // The pointer moves into the settled overlay area (right of the stale
+    // mid-animation boundary), which schedules a close against stale geometry.
+    fireEvent.mouseMove(window, { clientX: 120 })
+    overlayRight = 280
+    vi.advanceTimersByTime(PEEK_CLOSE_DELAY_MS)
+
+    // The re-measure inside the close timer sees the settled boundary and
+    // keeps the peek open.
+    expect(setPeek).not.toHaveBeenCalled()
+
+    // The refreshed cache now classifies the same position as inside.
+    fireEvent.mouseMove(window, { clientX: 120 })
+    vi.advanceTimersByTime(PEEK_CLOSE_DELAY_MS)
+    expect(setPeek).not.toHaveBeenCalled()
+
+    // A genuine exit still dismisses.
+    fireEvent.mouseMove(window, { clientX: 400 })
+    vi.advanceTimersByTime(PEEK_CLOSE_DELAY_MS)
+    expect(setPeek).toHaveBeenCalledWith(false)
+  })
+
+  it('does not dismiss while a resize drag travels past the overlay edge', () => {
+    const setPeek = vi.fn()
+    renderHook(() =>
+      useLeftSidebarEdgePeekDismiss({
+        isPeeking: true,
+        isResizing: true,
+        setPeek,
+        overlayRef: makeOverlayRef(280)
+      })
+    )
+
+    fireEvent.mouseMove(window, { clientX: 600 })
+    vi.advanceTimersByTime(PEEK_CLOSE_DELAY_MS)
+
+    expect(setPeek).not.toHaveBeenCalled()
+  })
+
+  it('dismisses immediately when the window loses focus', () => {
+    const setPeek = vi.fn()
+    renderHook(() =>
+      useLeftSidebarEdgePeekDismiss({
+        isPeeking: true,
+        isResizing: false,
+        setPeek,
+        overlayRef: makeOverlayRef(280)
+      })
+    )
+
+    fireEvent.blur(window)
+
+    expect(setPeek).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/left-sidebar-edge-peek.tsx
+++ b/src/renderer/src/components/sidebar/left-sidebar-edge-peek.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useRef } from 'react'
+import { useAppStore } from '@/store'
+
+// Arc-style edge peek: hovering the window's left edge while the sidebar is
+// closed reveals it as a floating overlay instead of reflowing the workspace.
+// The enter delay keeps accidental edge grazes from flashing the sidebar open.
+export const PEEK_OPEN_DELAY_MS = 250
+export const PEEK_CLOSE_DELAY_MS = 300
+// Floating elevation from docs/STYLEGUIDE.md — reserved for overlays that
+// escape the editor surface.
+export const LEFT_SIDEBAR_PEEK_OVERLAY_CLASS_NAME =
+  'absolute inset-y-0 left-0 z-30 shadow-[0_10px_24px_rgba(0,0,0,0.18)] animate-in slide-in-from-left duration-200 motion-reduce:animate-none'
+// Why: when the collapsed titlebar stays floating (so the tab spacer width
+// does not jump), the peek panel starts below that 36px chrome so Tasks/nav
+// are not covered by traffic lights / sidebar toggle.
+export const LEFT_SIDEBAR_PEEK_BELOW_TITLEBAR_CLASS_NAME =
+  'absolute bottom-0 left-0 top-[36px] z-30 shadow-[0_10px_24px_rgba(0,0,0,0.18)] animate-in slide-in-from-left duration-200 motion-reduce:animate-none'
+// The leftmost band that arms the peek, and the top zone it excludes.
+const PEEK_EDGE_TRIGGER_PX = 6
+const PEEK_TITLEBAR_ZONE_PX = 36
+
+/**
+ * Arms the edge peek while the sidebar is fully hidden. Detection is
+ * geometry-based (a window mousemove comparing clientX against the left edge)
+ * rather than an invisible DOM strip: a strip would swallow every mousedown in
+ * the leftmost pixels, blocking clicks flush against the window edge (and Mac
+ * traffic-light hit targets that extend below the titlebar on some builds).
+ * Renders nothing.
+ */
+export function LeftSidebarEdgePeekZone(): React.JSX.Element | null {
+  const sidebarOpen = useAppStore((s) => s.sidebarOpen)
+  const sidebarPeek = useAppStore((s) => s.sidebarPeek)
+  const setSidebarPeek = useAppStore((s) => s.setSidebarPeek)
+
+  useEffect(() => {
+    // Why: the zone unmounts on full-page views that remove the sidebar; a
+    // peek flag surviving that would render a ghost peek when returning.
+    return () => setSidebarPeek(false)
+  }, [setSidebarPeek])
+
+  useEffect(() => {
+    // The revealed overlay covers the edge, so arming is only needed while the
+    // sidebar is fully hidden. Skipping the listener here also guarantees an
+    // armed timer can't fire after the sidebar opens (the cleanup clears it).
+    if (sidebarOpen || sidebarPeek) {
+      return
+    }
+    let openTimer: number | null = null
+    const clearOpenTimer = (): void => {
+      if (openTimer !== null) {
+        window.clearTimeout(openTimer)
+        openTimer = null
+      }
+    }
+    const onMouseMove = (event: MouseEvent): void => {
+      // Why: ignore button-down moves so a drag that starts near the left edge
+      // (scrollbar, text selection, pane resize) does not arm the peek.
+      if (event.buttons !== 0) {
+        clearOpenTimer()
+        return
+      }
+      // Why: exclude the top 36px titlebar row so the peek never arms over
+      // window controls (macOS traffic lights / Windows-Linux custom chrome).
+      const inEdgeBand =
+        event.clientY >= PEEK_TITLEBAR_ZONE_PX && event.clientX <= PEEK_EDGE_TRIGGER_PX
+      if (!inEdgeBand) {
+        clearOpenTimer()
+        return
+      }
+      if (openTimer === null) {
+        openTimer = window.setTimeout(() => {
+          openTimer = null
+          setSidebarPeek(true)
+        }, PEEK_OPEN_DELAY_MS)
+      }
+    }
+    window.addEventListener('mousemove', onMouseMove)
+    return () => {
+      clearOpenTimer()
+      window.removeEventListener('mousemove', onMouseMove)
+    }
+  }, [sidebarOpen, sidebarPeek, setSidebarPeek])
+
+  return null
+}
+
+/**
+ * Dismisses an active peek once the pointer moves right of the revealed
+ * overlay. Dismissal is geometry-based (window mousemove) rather than
+ * mouseleave-based: tooltips and menus portal outside the overlay element,
+ * and a mouseleave dismiss would close the peek under an open popover.
+ */
+export function useLeftSidebarEdgePeekDismiss(args: {
+  isPeeking: boolean
+  isResizing: boolean
+  setPeek: (peek: boolean) => void
+  overlayRef: React.RefObject<HTMLElement | null>
+}): void {
+  const { isPeeking, isResizing, setPeek, overlayRef } = args
+  // Why: the dismiss watcher reads resize state inside window listeners; a ref
+  // avoids re-subscribing them on every drag frame.
+  const isResizingRef = useRef(isResizing)
+  isResizingRef.current = isResizing
+
+  useEffect(() => {
+    if (!isPeeking) {
+      return
+    }
+    let closeTimer: number | null = null
+    let lastClientX: number | null = null
+    // Why: measuring the overlay on every mousemove forces layout. Cache its
+    // right edge and invalidate only when it can move (a resize drag or a
+    // window resize), so the common per-frame move reads no geometry.
+    let cachedOverlayRight: number | null = null
+    const invalidateOverlayRight = (): void => {
+      cachedOverlayRight = null
+    }
+    const cancelClose = (): void => {
+      if (closeTimer !== null) {
+        window.clearTimeout(closeTimer)
+        closeTimer = null
+      }
+    }
+    const scheduleClose = (): void => {
+      if (closeTimer === null) {
+        closeTimer = window.setTimeout(() => {
+          closeTimer = null
+          // Why: the cached boundary may have been measured mid slide-in (the
+          // entrance transform puts the rect near the window edge). Re-measure
+          // and re-check here so a stale cache self-heals instead of
+          // dismissing the peek under the cursor.
+          const overlayRight = overlayRef.current?.getBoundingClientRect().right ?? null
+          cachedOverlayRight = overlayRight
+          if (overlayRight !== null && lastClientX !== null && lastClientX <= overlayRight) {
+            return
+          }
+          setPeek(false)
+        }, PEEK_CLOSE_DELAY_MS)
+      }
+    }
+    const onMouseMove = (event: MouseEvent): void => {
+      lastClientX = event.clientX
+      // A resize drag legitimately travels right of the overlay edge.
+      if (isResizingRef.current) {
+        invalidateOverlayRight()
+        cancelClose()
+        return
+      }
+      if (cachedOverlayRight === null) {
+        cachedOverlayRight = overlayRef.current?.getBoundingClientRect().right ?? null
+      }
+      if (cachedOverlayRight === null || event.clientX <= cachedOverlayRight) {
+        cancelClose()
+      } else {
+        scheduleClose()
+      }
+    }
+    const onWindowBlur = (): void => setPeek(false)
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('blur', onWindowBlur)
+    window.addEventListener('resize', invalidateOverlayRight)
+    return () => {
+      cancelClose()
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('blur', onWindowBlur)
+      window.removeEventListener('resize', invalidateOverlayRight)
+    }
+  }, [isPeeking, overlayRef, setPeek])
+}

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -3042,7 +3042,9 @@ describe('createUISlice contextual tours', () => {
     stubContextualTourTargets([
       '[data-contextual-tour-target="terminal-pane-split-target"], [data-contextual-tour-target="workspace-agent-terminal-tip"]'
     ])
-    store.setState({ sidebarOpen: false })
+    // Why: tour reveal must clear a mid-hover edge peek so the sidebar pins
+    // open instead of leaving a stale overlay flag behind.
+    store.setState({ sidebarOpen: false, sidebarPeek: true })
     store.getState().hydratePersistedUI(makeAutoTourEligibleUI())
     store
       .getState()
@@ -3053,6 +3055,7 @@ describe('createUISlice contextual tours', () => {
     store.getState().recordFeatureInteraction('terminal-pane-split')
 
     expect(store.getState().sidebarOpen).toBe(true)
+    expect(store.getState().sidebarPeek).toBe(false)
     expect(store.getState().activeContextualTourId).toBe('workspace-agent-sessions')
     expect(store.getState().activeContextualTourStepIndex).toBe(1)
     expect(store.getState().contextualToursSeenIds).toEqual([])

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -604,9 +604,12 @@ function sanitizeTaskResumeState(value: unknown): TaskResumeState | undefined {
 
 export type UISlice = {
   sidebarOpen: boolean
+  /** Transient edge-hover reveal; cleared when the sidebar is pinned open/closed. */
+  sidebarPeek: boolean
   sidebarWidth: number
   toggleSidebar: () => void
   setSidebarOpen: (open: boolean) => void
+  setSidebarPeek: (peek: boolean) => void
   setSidebarWidth: (width: number) => void
   agentSendPopoverTargetMode: AgentSendPopoverTargetMode | null
   openAgentSendPopoverTargetMode: (args: OpenAgentSendPopoverTargetModeArgs) => void
@@ -1017,9 +1020,11 @@ export type UISlice = {
 
 export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get) => ({
   sidebarOpen: true,
+  sidebarPeek: false,
   sidebarWidth: 280,
-  toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
-  setSidebarOpen: (open) => set({ sidebarOpen: open }),
+  toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen, sidebarPeek: false })),
+  setSidebarOpen: (open) => set({ sidebarOpen: open, sidebarPeek: false }),
+  setSidebarPeek: (peek) => set({ sidebarPeek: peek }),
   setSidebarWidth: (width) => set({ sidebarWidth: width }),
   agentSendPopoverTargetMode: null,
   openAgentSendPopoverTargetMode: (args) => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1635,9 +1635,12 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       if (tourProgression === 'reveal-sidebar-and-advance') {
         // Why: the split can be triggered by keyboard/menu paths while the
         // sidebar is closed, but the next tour target lives in the sidebar.
+        // Clear peek so a mid-hover edge peek cannot leave a stale overlay flag
+        // after the tour pins the sidebar open.
         return {
           featureInteractions: next,
           sidebarOpen: true,
+          sidebarPeek: false,
           activeContextualTourStepIndex: s.activeContextualTourStepIndex + 1
         }
       }


### PR DESCRIPTION
## Summary

Feature request: when the left workspace sidebar is collapsed, hovering near the left window edge temporarily reveals it as a floating overlay (Arc-style edge peek) so you can browse/switch worktrees without pinning the sidebar open permanently.

- Hover within ~6px of the left edge (below the 36px titlebar) for 250ms to peek
- Move away to auto-hide after 300ms; Cmd/Ctrl+B or the sidebar toggle pins it open
- Peek does not reflow the tab strip; when floating titlebar chrome is present the peek starts below it so Tasks/nav stay visible
- Workspace board stays pinned-open-only (unchanged)

## Screenshots

UI behavior change — please review in a local build:

1. Collapse the left sidebar
2. Hover the left window edge below the titlebar
3. Confirm the sidebar peeks as an overlay, Tasks remains clickable, and tabs do not shift
4. Move the pointer away and confirm it auto-hides

## Testing

- [x] `pnpm lint` (oxlint + switch-exhaustiveness, scrollbars, reliability gates, max-lines ratchet, localization catalog/coverage)
- [x] `pnpm typecheck`
- [x] `pnpm test` (focused peek/sidebar tests passed; full suite had unrelated flaky/timeout failures in daemon shell-ready, relay, node-pty fd leak, and pi titlebar migration)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added `left-sidebar-edge-peek.test.tsx` covering arm/cancel/open delay, titlebar exclusion, button-down ignore, unmount cleanup, dismiss geometry (including mid-animation remasure), resize drag, and blur dismiss.

## AI Review Report

Reviewed the change for overlay layout, tab-spacer stability, and dismiss timing.

- **Cross-platform:** Titlebar exclusion uses a fixed 36px top band so macOS traffic lights and Windows/Linux custom chrome stay clickable; no hardcoded `metaKey`; no path/`CmdOrCtrl` changes.
- **SSH/remote/local:** Peek is renderer UI only; worktree list/content still come from existing store paths (local, remote server, SSH unchanged).
- **Agents/integrations/git providers:** No agent, integration, or provider-specific logic.
- **Performance:** Geometry is cached on dismiss; arming listener is only attached while fully collapsed; timers cleaned on unmount/open.
- **UI quality:** Uses STYLEGUIDE floating shadow `0 10px 24px rgba(0,0,0,0.18)`, `motion-reduce` disables slide-in, peek is absolute so tab spacer width does not jump.
- **Risks checked:** Floating titlebar covering Tasks (mitigated with below-titlebar peek), tab strip jitter from remasuring collapsed header width (avoided by keeping floating chrome), workspace board during peek (left pinned-open-only by design).

## Security Audit

No new IPC, auth, secrets, command execution, or filesystem paths. Peek is driven by window `mousemove`/`blur`/`resize` listeners only; listeners are removed on cleanup. No elevated privileges or untrusted input handling added.

## Notes

- Feature request / enhancement (no existing left-sidebar peek issue found; closest prior art is right-sidebar edge peek in #7424 / #8015).
- Platform note: left-edge arming intentionally ignores the top 36px and button-down drags.
- Follow-up idea (not in this PR): optional settings toggle to disable edge peek.
- X: [@0xPresc](https://x.com/0xPresc)


Made with [Cursor](https://cursor.com)

## ELI5

When the left sidebar is collapsed, hover near the left edge of the window and it peeks open as a floating overlay (like Arc). You can switch worktrees without pinning the sidebar open all the time.
