### PR TITLE
feat(speech): add Korean streaming Zipformer

### DIFF
--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -122,6 +122,28 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     modelingUnit: 'cjkchar'
   },
   {
+    id: 'zipformer-streaming-ko',
+    label: 'Zipformer Streaming KO',
+    description: 'Korean only. Low-latency real-time streaming.',
+    type: 'transducer',
+    provider: 'local',
+    language: 'ko',
+    sizeBytes: 418_218_652,
+    downloadUrl:
+      'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-korean-2024-06-16.tar.bz2',
+    archiveSha256: 'e346a5882a409650472be17326237e24df7bf409db6b4a8a52e1a61422bf2500',
+    archiveFormat: 'tar.bz2',
+    files: [
+      'encoder-epoch-99-avg-1.int8.onnx',
+      'decoder-epoch-99-avg-1.onnx',
+      'joiner-epoch-99-avg-1.int8.onnx',
+      'tokens.txt'
+    ],
+    sampleRate: 16000,
+    streaming: true,
+    modelingUnit: 'cjkchar'
+  },
+  {
     id: 'whisper-tiny',
     label: 'Whisper Tiny',
     description: '90+ languages. Lower accuracy than Parakeet but broadest language coverage.',

--- a/src/main/speech/model-manager.test.ts
+++ b/src/main/speech/model-manager.test.ts
@@ -65,6 +65,41 @@ describe('ModelManager', () => {
     }
   })
 
+  it('recognizes Korean streaming Zipformer after its required files are installed', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))
+    try {
+      const manifest = SPEECH_MODEL_CATALOG.find((model) => model.id === 'zipformer-streaming-ko')
+      expect(manifest).toMatchObject({
+        provider: 'local',
+        language: 'ko',
+        type: 'transducer',
+        streaming: true,
+        modelingUnit: 'cjkchar'
+      })
+      expect(manifest?.files).toEqual([
+        'encoder-epoch-99-avg-1.int8.onnx',
+        'decoder-epoch-99-avg-1.onnx',
+        'joiner-epoch-99-avg-1.int8.onnx',
+        'tokens.txt'
+      ])
+
+      const manager = new ModelManager(dir)
+      const modelDir = manager.getModelDir(manifest!.id)
+      for (const file of manifest!.files ?? []) {
+        const path = join(modelDir, file)
+        mkdirSync(dirname(path), { recursive: true })
+        writeFileSync(path, 'model file')
+      }
+
+      await expect(manager.getModelState(manifest!.id)).resolves.toEqual({
+        id: manifest!.id,
+        status: 'ready'
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('verifies downloaded archive hashes before extraction', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))
     try {


### PR DESCRIPTION
## Summary

- Add `Zipformer Streaming KO` as a built-in local streaming Korean STT model.
- Pin the upstream sherpa-onnx archive URL, 418,218,652-byte download size, SHA-256, required model files, 16 kHz sample rate, and `cjkchar` modeling unit.
- Cover the model's required-file installation contract through `ModelManager`.

## Screenshots

Manual desktop verification was completed locally in the isolated Orca development app. The Voice settings catalog displayed the model and the user confirmed dictation behavior after selecting it. No screenshot is attached because this CLI PR flow cannot upload local QA captures.

## Tests

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (2,738 passed, 7 skipped; 28,930 passed, 38 skipped)
- `pnpm build`
- Native runtime archive check: streamed SHA-256 and required-file layout matched the manifest; an OnlineRecognizer loaded the model and produced Korean output from the archive test audio.
- Manual QA: local Orca app, Settings > Voice > select `Zipformer Streaming KO`, user-confirmed dictation test.

## AI Review Report

- Cross-platform: no platform-specific code was added; the manifest follows the existing local transducer path. The repository's existing Windows ARM64 native-addon limitation remains unchanged and is outside this PR.
- Local / remote / SSH / integrations: no IPC, SSH, relay, account, or cloud-provider behavior changed.
- Performance: one on-demand 418 MB model download; no bundled weights or startup work added.
- UI: the existing model catalog renders the new entry without a new UI surface.
- Security: HTTPS download, pinned SHA-256, expected-size check, verified tar extraction, and required-file validation use the existing ModelManager safeguards.

## Security Audit

- No new dependencies, permissions, IPC handlers, or external executable paths.
- The model archive is fetched on demand and is not committed or redistributed by this PR.

## Notes

- The upstream sherpa-onnx project is Apache-2.0, but the downloaded Korean model artifact does not carry a separate LICENSE/NOTICE and its model card has no explicit license metadata. Maintainers should confirm model-weight and KsponSpeech-derived data usage terms before merge.
- X handle: not provided.

## ELI5

Orca adds a built-in local Korean speech-to-text model (Zipformer Streaming KO). You can install it from Voice settings and use on-device Korean streaming recognition without a cloud STT service.
