### PR TITLE
fix(mobile): resolve permission args when a new session launches an agent

### DIFF
--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -27,11 +27,7 @@ import {
   wasSetupHookPreviouslyApproved,
   type SetupHookTrust
 } from '../tasks/setup-hook-trust'
-import {
-  isMobileTuiAgent,
-  isMobileTuiAgentEnabled,
-  MOBILE_TUI_AGENT_LAUNCH_COMMANDS
-} from '../tasks/mobile-tui-agents'
+import { isMobileTuiAgentEnabled } from '../tasks/mobile-tui-agents'
 import type { PersistedTrustedOrcaHooks, TuiAgent } from '../../../src/shared/types'
 import type { SshConnectionState } from '../../../src/shared/ssh-types'
 import {
@@ -83,7 +79,6 @@ type SetupRunPolicy = 'ask' | 'run-by-default' | 'skip-by-default'
 type RuntimeSettings = {
   defaultTuiAgent?: TuiAgent | 'blank' | null
   disabledTuiAgents?: TuiAgent[]
-  agentCmdOverrides?: Record<string, string>
 }
 
 type RepoHooksResponse = {
@@ -628,14 +623,6 @@ function NewWorktreeModalContent({
         return
       }
 
-      const command =
-        selectedAgent.id !== '__blank__'
-          ? (latestRuntimeSettings?.agentCmdOverrides?.[selectedAgent.id] ??
-            (isMobileTuiAgent(selectedAgent.id)
-              ? MOBILE_TUI_AGENT_LAUNCH_COMMANDS[selectedAgent.id]
-              : undefined))
-          : undefined
-
       // Why: blank name field — match desktop behavior by computing the
       // next available marine-creature name at submit time and passing it
       // to the server. The server's worktree.create rejects empty/invalid
@@ -688,10 +675,7 @@ function NewWorktreeModalContent({
             selection: createSelection,
             targetRepoId: selectedRepo.id,
             setupDecision,
-            agent: {
-              choice: normalizeWorkspaceAgent(selectedAgent.id) ?? 'blank',
-              startupCommand: command
-            },
+            agent: { choice: normalizeWorkspaceAgent(selectedAgent.id) ?? 'blank' },
             workspaceName: trimmedName || undefined,
             note: trimmedNote,
             nameIsAutoManaged: composer.isNameAutoManaged,
@@ -701,7 +685,6 @@ function NewWorktreeModalContent({
             client,
             repoId: selectedRepo.id,
             baseName,
-            startupCommand: command,
             createdWithAgentId,
             comment: trimmedNote,
             setupDecision,

--- a/mobile/src/tasks/blank-workspace-create.test.ts
+++ b/mobile/src/tasks/blank-workspace-create.test.ts
@@ -23,7 +23,7 @@ function fakeClient(script: (method: string, call: number) => unknown, calls: Ca
 }
 
 describe('createBlankWorkspace', () => {
-  it('assembles exactly the params the modal historically sent, omitting empty extras', async () => {
+  it('sends no agent-launch fields for a blank workspace', async () => {
     const calls: Call[] = []
     const client = fakeClient(() => ({ worktree: { id: 'wt-1' } }), calls)
 
@@ -31,7 +31,6 @@ describe('createBlankWorkspace', () => {
       client,
       repoId: 'repo-1',
       baseName: 'octopus',
-      startupCommand: undefined,
       createdWithAgentId: undefined,
       comment: undefined,
       setupDecision: 'inherit',
@@ -44,7 +43,6 @@ describe('createBlankWorkspace', () => {
       method: 'worktree.create',
       params: {
         repo: 'id:repo-1',
-        startupCommand: undefined,
         setupDecision: 'inherit',
         name: 'octopus',
         // Idempotency key so a create interrupted by a connection migration can be
@@ -53,11 +51,14 @@ describe('createBlankWorkspace', () => {
       }
     })
     const params = calls[0]?.params as Record<string, unknown>
+    expect('startupAgent' in params).toBe(false)
     expect('createdWithAgent' in params).toBe(false)
     expect('comment' in params).toBe(false)
   })
 
-  it('includes createdWithAgent and comment only when provided', async () => {
+  it('sends startupAgent (not a pre-built command) so the host resolves launch args', async () => {
+    // Why: regression — the modal used to send a bare startupCommand ('claude')
+    // that skipped the host's default `--dangerously-skip-permissions`.
     const calls: Call[] = []
     const client = fakeClient(() => ({ worktree: { id: 'wt-2' } }), calls)
 
@@ -65,21 +66,22 @@ describe('createBlankWorkspace', () => {
       client,
       repoId: 'repo-2',
       baseName: 'manatee',
-      startupCommand: 'claude',
       createdWithAgentId: 'claude',
       comment: 'spike',
       setupDecision: 'run',
       supportsIdempotentCutoverRetry: true
     })
 
-    expect(calls[0]?.params).toMatchObject({
+    const params = calls[0]?.params as Record<string, unknown>
+    expect(params).toMatchObject({
       repo: 'id:repo-2',
       name: 'manatee',
-      startupCommand: 'claude',
+      startupAgent: 'claude',
       setupDecision: 'run',
       createdWithAgent: 'claude',
       comment: 'spike'
     })
+    expect('startupCommand' in params).toBe(false)
   })
 
   it('retries with a numeric suffix on a branch-collision error', async () => {
@@ -95,7 +97,6 @@ describe('createBlankWorkspace', () => {
       client,
       repoId: 'repo-1',
       baseName: 'octopus',
-      startupCommand: undefined,
       createdWithAgentId: undefined,
       comment: undefined,
       setupDecision: 'inherit',
@@ -121,7 +122,6 @@ describe('createBlankWorkspace', () => {
       client,
       repoId: 'repo-1',
       baseName: 'octopus',
-      startupCommand: undefined,
       createdWithAgentId: undefined,
       comment: undefined,
       setupDecision: 'inherit',
@@ -140,7 +140,6 @@ describe('createBlankWorkspace', () => {
       client,
       repoId: 'repo-1',
       baseName: 'octopus',
-      startupCommand: undefined,
       createdWithAgentId: undefined,
       comment: undefined,
       setupDecision: 'skip',

--- a/mobile/src/tasks/blank-workspace-create.ts
+++ b/mobile/src/tasks/blank-workspace-create.ts
@@ -1,7 +1,10 @@
 import type { TuiAgent } from '../../../src/shared/types'
 import type { RpcClient } from '../transport/rpc-client'
 import { createWorktreeWithNameRetry, type WorktreeCreateResult } from './worktree-create-retry'
-import type { WorkspaceCreateSetupDecision } from './workspace-create-params'
+import {
+  agentLaunchCreateFields,
+  type WorkspaceCreateSetupDecision
+} from './workspace-create-params'
 
 // The blank/named create path, extracted from NewWorktreeModal so the modal keeps
 // only the UI-coupled setup-trust flow. Assembles worktree.create params and
@@ -10,7 +13,6 @@ export async function createBlankWorkspace(args: {
   client: RpcClient
   repoId: string
   baseName: string
-  startupCommand: string | undefined
   createdWithAgentId: TuiAgent | undefined
   comment: string | undefined
   setupDecision: WorkspaceCreateSetupDecision
@@ -23,12 +25,9 @@ export async function createBlankWorkspace(args: {
     buildParams: (name) => {
       const params: Record<string, unknown> = {
         repo: `id:${args.repoId}`,
-        startupCommand: args.startupCommand,
         setupDecision: args.setupDecision,
-        name
-      }
-      if (args.createdWithAgentId) {
-        params.createdWithAgent = args.createdWithAgentId
+        name,
+        ...agentLaunchCreateFields(args.createdWithAgentId)
       }
       if (args.comment) {
         params.comment = args.comment

--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -109,44 +109,6 @@ export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>>
   openclaw: 'openclaw.ai'
 }
 
-export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
-  claude: 'claude',
-  'claude-agent-teams': 'orca claude-teams',
-  openclaude: 'openclaude',
-  codex: 'codex',
-  grok: 'grok',
-  copilot: 'copilot',
-  opencode: 'opencode',
-  'mimo-code': 'mimo',
-  ante: 'ante',
-  pi: 'pi',
-  omp: 'omp',
-  gemini: 'gemini',
-  antigravity: 'agy',
-  aider: 'aider',
-  goose: 'goose',
-  amp: 'amp',
-  kilo: 'kilo',
-  kiro: 'kiro-cli',
-  crush: 'crush',
-  aug: 'auggie',
-  autohand: 'autohand',
-  cline: 'cline',
-  codebuff: 'codebuff',
-  'command-code': 'command-code',
-  continue: 'continue',
-  cursor: 'cursor-agent',
-  droid: 'droid',
-  kimi: 'kimi',
-  'mistral-vibe': 'mistral-vibe',
-  // Why: QwenLM/qwen-code installs its CLI executable as `qwen`, not `qwen-code`.
-  'qwen-code': 'qwen',
-  rovo: 'rovo',
-  hermes: 'hermes',
-  devin: 'devin',
-  openclaw: 'openclaw'
-}
-
 export function isMobileTuiAgent(value: unknown): value is TuiAgent {
   return MOBILE_TUI_AGENT_AUTO_PICK_ORDER.includes(value as TuiAgent)
 }

--- a/mobile/src/tasks/source-workspace-create.test.ts
+++ b/mobile/src/tasks/source-workspace-create.test.ts
@@ -23,7 +23,7 @@ function fakeClient(handle: (method: string, call: number) => unknown, calls: Ca
   } as unknown as RpcClient
 }
 
-const agent = { choice: 'blank' as const, startupCommand: undefined }
+const agent = { choice: 'blank' as const }
 
 const baseArgs = {
   targetRepoId: 'repo-1',
@@ -217,5 +217,24 @@ describe('createWorkspaceFromComposerSource', () => {
       branchNameOverride: 'topic-2',
       name: 'topic-2'
     })
+  })
+
+  it('sends startupAgent (not a pre-built command) for a non-blank agent', async () => {
+    // Why: regression — a bare startupCommand skipped the host's default
+    // `--dangerously-skip-permissions`; the host must resolve the launch args.
+    const calls: Call[] = []
+    const client = fakeClient(() => ({ worktree: { id: 'wt-agent' } }), calls)
+    const selection: MobileComposerCreateSelection = { kind: 'new-branch', branchName: 'topic' }
+    await createWorkspaceFromComposerSource({
+      client,
+      selection,
+      ...baseArgs,
+      agent: { choice: 'claude' }
+    })
+    expect(calls[0]!.params).toMatchObject({
+      startupAgent: 'claude',
+      createdWithAgent: 'claude'
+    })
+    expect('startupCommand' in calls[0]!.params).toBe(false)
   })
 })

--- a/mobile/src/tasks/source-workspace-create.ts
+++ b/mobile/src/tasks/source-workspace-create.ts
@@ -7,18 +7,17 @@ import type {
 import { resolveMobileWorkspaceCreateName } from './mobile-workspace-name'
 import type { WorkspaceAgentChoice } from './workspace-agent-selection'
 import {
+  agentLaunchCreateFields,
   buildTaskWorkspaceCreateParams,
   type WorkspaceCreateSetupDecision,
   type WorkspaceCreateTaskItem
 } from './workspace-create-params'
 import { createWorktreeWithNameRetry, type WorktreeCreateResult } from './worktree-create-retry'
 
-// The agent bundle the modal already resolved: the choice drives
-// buildTaskWorkspaceCreateParams for work-item sources; the explicit launch
-// command is used for branch sources (which have no work-item URL to seed the draft).
+// The agent bundle the modal resolved: `choice` drives launch resolution — the
+// host applies the agent's launch args (permission flags) and shell quoting.
 export type WorkspaceCreateAgentBundle = {
   choice: WorkspaceAgentChoice
-  startupCommand: string | undefined
 }
 
 export type CreateWorkspaceFromComposerArgs = {
@@ -157,9 +156,7 @@ async function createBranchWorkspace(args: {
   const createdWithAgentId = agent.choice === 'blank' ? undefined : agent.choice
   const comment = note?.trim()
   const applyCommon = (params: Record<string, unknown>): Record<string, unknown> => {
-    if (createdWithAgentId) {
-      params.createdWithAgent = createdWithAgentId
-    }
+    Object.assign(params, agentLaunchCreateFields(createdWithAgentId))
     if (comment) {
       params.comment = comment
     }
@@ -185,8 +182,7 @@ async function createBranchWorkspace(args: {
           name,
           setupDecision,
           baseBranch: selection.refName,
-          branchNameOverride: selection.localBranchName,
-          startupCommand: agent.startupCommand
+          branchNameOverride: selection.localBranchName
         })
     })
   }
@@ -206,8 +202,7 @@ async function createBranchWorkspace(args: {
         repo: `id:${targetRepoId}`,
         name: candidate,
         setupDecision,
-        baseBranch: selection.baseBranch,
-        startupCommand: agent.startupCommand
+        baseBranch: selection.baseBranch
       }
       if (selection.branchNameOverride) {
         params.branchNameOverride = candidate
@@ -244,10 +239,7 @@ async function createNewBranchWorkspace(args: {
         name: candidate,
         setupDecision,
         branchNameOverride: candidate,
-        startupCommand: agent.startupCommand
-      }
-      if (createdWithAgentId) {
-        params.createdWithAgent = createdWithAgentId
+        ...agentLaunchCreateFields(createdWithAgentId)
       }
       if (comment) {
         params.comment = comment

--- a/mobile/src/tasks/workspace-create-params.test.ts
+++ b/mobile/src/tasks/workspace-create-params.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { buildTaskWorkspaceCreateParams } from './workspace-create-params'
+import { agentLaunchCreateFields, buildTaskWorkspaceCreateParams } from './workspace-create-params'
+
+describe('agentLaunchCreateFields', () => {
+  it('sends startupAgent + createdWithAgent so the host resolves launch args', () => {
+    expect(agentLaunchCreateFields('claude')).toEqual({
+      startupAgent: 'claude',
+      createdWithAgent: 'claude'
+    })
+  })
+
+  it('launches no agent when none was picked', () => {
+    expect(agentLaunchCreateFields(undefined)).toEqual({})
+  })
+})
 
 describe('task workspace create params', () => {
   it('passes a GitHub PR URL as an agent draft and links the PR', () => {

--- a/mobile/src/tasks/workspace-create-params.ts
+++ b/mobile/src/tasks/workspace-create-params.ts
@@ -57,6 +57,22 @@ export type WorkspaceCreateTaskItem =
 
 export type WorkspaceCreateParams = Record<string, unknown>
 
+/**
+ * `worktree.create` fields for launching the picked agent in a fresh session.
+ *
+ * Why: send the agent id so the host resolves launch args (permission flags)
+ * and host-shell quoting, matching the "+" new-tab and CLI paths.
+ */
+export function agentLaunchCreateFields(agentId: TuiAgent | undefined): {
+  startupAgent?: TuiAgent
+  createdWithAgent?: TuiAgent
+} {
+  if (!agentId) {
+    return {}
+  }
+  return { startupAgent: agentId, createdWithAgent: agentId }
+}
+
 export function buildTaskWorkspaceCreateParams(args: {
   item: WorkspaceCreateTaskItem
   targetRepoId: string

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -128,8 +128,9 @@ export const WorktreeCreate = z
       )
       .pipe(z.union([z.enum(['run', 'skip', 'inherit']), z.undefined()]))
       .optional(),
-    // Why: mobile clients pass a startup command (e.g. 'claude') so the first
-    // terminal pane launches the selected agent instead of an idle shell.
+    // Why: some clients (e.g. desktop) pass a pre-built launch command so the
+    // first terminal pane launches the selected agent instead of an idle shell.
+    // Clients that can't quote for the host shell send `startupAgent` instead.
     startupCommand: OptionalString,
     startupEnv: z.record(z.string(), z.string()).optional(),
     startupLaunchConfig: sleepingAgentLaunchConfigSchema,


### PR DESCRIPTION
## Summary

Fixes mobile "New Workspace" sessions launching a picked agent in the wrong permission mode versus opening the same agent from the tab bar's **+**.

## ELI5

On phones, starting Claude from the "new session" screen made it ask for permission on every action, while starting the same Claude from the **+** button didn't. Now both start it the same way.

## Root cause & fix

The mobile New Workspace modal built a bare launch command (e.g. `claude`) client-side from a static `MOBILE_TUI_AGENT_LAUNCH_COMMANDS` map and passed it as `startupCommand`, which the host runs verbatim — skipping default launch args (notably `--dangerously-skip-permissions`) and host-shell quoting. The **+** new-tab path instead sends only the agent id and lets the host resolve args. The fix makes every client create path send `startupAgent` via a shared `agentLaunchCreateFields(agentId)` helper (returning `{ startupAgent, createdWithAgent }`), so the host resolves launch command, args, env, and quoting through the same path as **+** and the CLI. The dead map and modal `agentCmdOverrides` type are removed.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Rebase was clean onto `origin/main`.

- Tests: `blank-workspace-create.test.ts`, `workspace-create-params.test.ts`, `source-workspace-create.test.ts` (run via vitest from `mobile/`).
- On branch: **3 test files passed, 21 tests passed**.
- With the fix reverted (tests kept), it fails as expected:

```
Test Files  3 failed (3)
Tests       4 failed | 17 passed (21)
 - source-workspace-create: toMatchObject missing "startupAgent": "claude"
 - blank-workspace-create: startupAgent not sent
 - workspace-create-params x2: agentLaunchCreateFields is not a function
```

- Lint: `oxlint` on the 6 changed source files — clean, no warnings/errors.
- Regression scan: no remaining references to `MOBILE_TUI_AGENT_LAUNCH_COMMANDS`; `agentCmdOverrides` only referenced in unrelated code; `isMobileTuiAgent` still exported for other modules.

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression rationale: only the client create paths change what they send (`startupAgent` instead of a pre-built `startupCommand`), converging on the already-correct host resolution used by **+** and the CLI. The host schema already accepted `startupAgent`; non-affected paths are unchanged. Proven by the passing branch tests and the reverted-fix failures. No dangling references were found.

_Credit to original author @kaynansc. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
