### PR TITLE
fix: fall back to a letter badge when an agent favicon fails to load

### DIFF
--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -4,6 +4,7 @@ import openClaudeLogoUrl from '../../../../resources/openclaude-logo.png?url'
 import type { TuiAgent } from '../../../shared/types'
 import { getTuiAgentLaunchCommand, TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import {
+  AgentFaviconIcon,
   AgentLetterIcon,
   AiderIcon,
   CopilotIcon,
@@ -351,20 +352,17 @@ export function AgentIcon({
       />
     )
   }
+  const label = catalogEntry?.label ?? agent
   if (catalogEntry?.faviconDomain) {
-    // Why: agents without a published SVG icon use their site favicon via
-    // Google's favicon service — same source the README uses for the agent badge list.
+    // Agents without a published SVG icon use their site favicon via Google's
+    // favicon service, falling back to the letter badge if that request fails.
     return (
-      <img
-        src={`https://www.google.com/s2/favicons?domain=${catalogEntry.faviconDomain}&sz=64`}
-        width={size}
-        height={size}
-        alt=""
-        aria-hidden
-        style={{ borderRadius: 2 }}
+      <AgentFaviconIcon
+        domain={catalogEntry.faviconDomain}
+        fallbackLetter={label.charAt(0).toUpperCase()}
+        size={size}
       />
     )
   }
-  const label = catalogEntry?.label ?? agent
   return <AgentLetterIcon letter={label.charAt(0).toUpperCase()} size={size} />
 }

--- a/src/renderer/src/lib/agent-icon-glyphs.test.tsx
+++ b/src/renderer/src/lib/agent-icon-glyphs.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+// Agent logos fetched from Google's favicon service render a broken-image glyph
+// when Google is unreachable (offline, firewall, blocked region, SSH host). These
+// tests pin the onError fallback that swaps the broken image for a letter badge.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { AgentFaviconIcon } from './agent-icon-glyphs'
+import { AgentIcon } from './agent-catalog'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function failFavicon(): void {
+  const img = container.querySelector('img')
+  if (!img) {
+    throw new Error('expected a favicon <img> before the error event')
+  }
+  act(() => {
+    img.dispatchEvent(new Event('error'))
+  })
+}
+
+describe('AgentFaviconIcon', () => {
+  it('renders the favicon image at the requested size from the Google favicon service', () => {
+    act(() => root.render(<AgentFaviconIcon domain="cursor.com" fallbackLetter="C" size={20} />))
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    // sz=64 keeps the favicon crisp when scaled down; size forwards to the box.
+    expect(img?.getAttribute('src')).toBe('https://www.google.com/s2/favicons?domain=cursor.com&sz=64')
+    expect(img?.getAttribute('width')).toBe('20')
+    expect(img?.getAttribute('height')).toBe('20')
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('falls back to the letter badge when the favicon fails to load', () => {
+    act(() => root.render(<AgentFaviconIcon domain="cursor.com" fallbackLetter="C" />))
+    failFavicon()
+    expect(container.querySelector('img')).toBeNull()
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg?.textContent).toBe('C')
+  })
+
+  it('evaluates each agent independently as the same slot switches domains', () => {
+    // First agent fails -> its letter badge.
+    act(() => root.render(<AgentFaviconIcon domain="cursor.com" fallbackLetter="C" />))
+    failFavicon()
+    expect(container.querySelector('img')).toBeNull()
+
+    // Switching to a second agent retries the favicon, and that agent can fall
+    // back on its own error rather than inheriting the first agent's failure.
+    act(() => root.render(<AgentFaviconIcon domain="x.ai" fallbackLetter="G" />))
+    expect(container.querySelector('img')?.getAttribute('src')).toContain('domain=x.ai')
+    failFavicon()
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('svg')?.textContent).toBe('G')
+
+    // Switching back retries the favicon instead of staying on the letter.
+    act(() => root.render(<AgentFaviconIcon domain="cursor.com" fallbackLetter="C" />))
+    expect(container.querySelector('img')?.getAttribute('src')).toContain('domain=cursor.com')
+  })
+})
+
+describe('AgentIcon wiring for favicon-based agents', () => {
+  it('renders a favicon-based agent and degrades to its initial on error', () => {
+    act(() => root.render(<AgentIcon agent="grok" />))
+    expect(container.querySelector('img')?.getAttribute('src')).toContain('domain=x.ai')
+    failFavicon()
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('svg')?.textContent).toBe('G')
+  })
+})

--- a/src/renderer/src/lib/agent-icon-glyphs.tsx
+++ b/src/renderer/src/lib/agent-icon-glyphs.tsx
@@ -168,3 +168,37 @@ export function AgentLetterIcon({
     </svg>
   )
 }
+
+// Agents without a bundled SVG use their site favicon, fetched from Google's
+// favicon service at runtime. That request fails whenever Google is unreachable
+// — offline, behind a corporate firewall, in a region that blocks Google, or on
+// a remote SSH host with no egress — which otherwise leaves a broken-image
+// glyph. Fall back to the letter badge so the icon degrades cleanly.
+export function AgentFaviconIcon({
+  domain,
+  fallbackLetter,
+  size = 14
+}: {
+  domain: string
+  fallbackLetter: string
+  size?: number
+}): React.JSX.Element {
+  // Track the domain that failed rather than a bare boolean so switching the
+  // icon to a different agent (same component slot) retries its favicon instead
+  // of inheriting the previous agent's failure.
+  const [failedDomain, setFailedDomain] = React.useState<string | null>(null)
+  if (failedDomain === domain) {
+    return <AgentLetterIcon letter={fallbackLetter} size={size} />
+  }
+  return (
+    <img
+      src={`https://www.google.com/s2/favicons?domain=${domain}&sz=64`}
+      width={size}
+      height={size}
+      alt=""
+      aria-hidden
+      style={{ borderRadius: 2 }}
+      onError={() => setFailedDomain(domain)}
+    />
+  )
+}


### PR DESCRIPTION
Closes #8451.

## Summary

Agent logos are missing on the agent settings page, and the broken-image glyph also shows on the terminal title bar and bottom status bar.

**Root cause:** agents without a bundled SVG icon load their logo from Google's favicon service at runtime (`https://www.google.com/s2/favicons?domain=<domain>&sz=64`) — 24 of the catalog's agents. The `<img>` had no `onError` handler, so whenever Google is unreachable — offline, behind a corporate firewall, in a region that blocks Google, or on a remote SSH host with no egress — every one of those icons renders as a broken image.

`AgentIcon` (`src/renderer/src/lib/agent-catalog.tsx`) is the single render path shared by all three surfaces in the report, so the fix lands in one place.

## Fix

Extract an `AgentFaviconIcon` component (`src/renderer/src/lib/agent-icon-glyphs.tsx`) that renders the favicon `<img>` with an `onError` handler falling back to the existing `AgentLetterIcon` — the agent's initial in a monochrome badge — instead of a broken image. `AgentIcon` uses it for `faviconDomain`-based agents.

The failure is tracked per-domain rather than as a bare boolean, so when the same icon slot switches to a different agent it retries that agent's favicon instead of inheriting the previous agent's failure.

The happy path is unchanged: when Google is reachable the same favicon `<img>` renders with identical `src`/size/attributes; the `onError` handler is inert until a load actually fails.

## Not included / known limitation

- When Google *is* reachable but a domain has no discoverable favicon, the service returns HTTP 200 with a generic globe image. That is a successful load, so `onError` does not fire and the letter badge is not shown for that specific case. Detecting the generic globe reliably would need a fragile heuristic, so it is intentionally out of scope for this fix (which targets the broken-image / failed-load case the issue reports).
- The same runtime-favicon pattern exists for open-in-app icons (`OpenInApplicationIcon` in `open-in-app-catalog.tsx`), which has no `onError` fallback either. Left as a follow-up to keep this change scoped to the reported agent-icon surfaces; the extracted fallback approach generalizes to it cleanly.

## Tests

`src/renderer/src/lib/agent-icon-glyphs.test.tsx` (new, happy-dom):

- renders the favicon image at the requested size with the `sz=64` param
- falls back to the letter badge when the favicon load errors
- evaluates each agent independently as the slot switches domains (second agent retries and can fall back on its own error; switching back retries rather than staying on the letter)
- `AgentIcon` wiring: a favicon-based agent (`grok`) degrades to its initial on error

## Verification

- `pnpm run typecheck` — clean (excluding 2 pre-existing `typescript-api` errors unrelated to this change)
- `oxlint` on changed files — clean
- `src/renderer/src/lib` test suite — 2455 passing
- `pnpm run build:electron-vite` and `build:web` — both succeed
