### PR TITLE
fix(agent-status): surface tool-failure errors across Cursor/Copilot/Grok

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -4551,6 +4551,36 @@ describe('Cursor hook normalization', () => {
     expect(result?.payload.toolInput).toBe('/repo/src/app.ts')
   })
 
+  it('postToolUseFailure surfaces the error and clears stale tool fields', () => {
+    _internals.normalizeHookPayload(
+      'cursor',
+      buildBody({
+        hook_event_name: 'preToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: '/repo/src/app.ts' }
+      }),
+      'production'
+    )
+    const failed = _internals.normalizeHookPayload(
+      'cursor',
+      buildBody({
+        hook_event_name: 'postToolUseFailure',
+        tool_name: 'Read',
+        tool_input: { file_path: '/repo/src/app.ts' },
+        error_message: 'file not found'
+      }),
+      'production'
+    )
+    // Why: keeping toolName set would let the compact sidebar show the tool
+    // instead of the failure text, hiding the error from the user.
+    expect(failed?.payload).toMatchObject({
+      state: 'working',
+      lastAssistantMessage: 'file not found'
+    })
+    expect(failed?.payload.toolName).toBeUndefined()
+    expect(failed?.payload.toolInput).toBeUndefined()
+  })
+
   it('afterAgentResponse carries text into lastAssistantMessage', () => {
     const result = _internals.normalizeHookPayload(
       'cursor',
@@ -5187,6 +5217,36 @@ describe('Copilot hook normalization', () => {
     expect(result?.payload.state).toBe('working')
     expect(result?.payload.toolName).toBe('bash')
     expect(result?.payload.toolInput).toBe('pnpm test')
+  })
+
+  it('PostToolUseFailure surfaces the error and clears stale tool fields', () => {
+    _internals.normalizeHookPayload(
+      'copilot',
+      buildBody({
+        hook_event_name: 'PreToolUse',
+        toolName: 'bash',
+        toolInput: { command: 'pnpm test' }
+      }),
+      'production'
+    )
+    const failed = _internals.normalizeHookPayload(
+      'copilot',
+      buildBody({
+        hook_event_name: 'PostToolUseFailure',
+        toolName: 'bash',
+        toolInput: { command: 'pnpm test' },
+        error_message: 'command not found'
+      }),
+      'production'
+    )
+    // Why: keeping toolName set would let the compact sidebar show the tool
+    // instead of the failure text, hiding the error from the user.
+    expect(failed?.payload).toMatchObject({
+      state: 'working',
+      lastAssistantMessage: 'command not found'
+    })
+    expect(failed?.payload.toolName).toBeUndefined()
+    expect(failed?.payload.toolInput).toBeUndefined()
   })
 
   it('PreToolUse ask_user maps to blocked and surfaces the question', () => {

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -3791,8 +3791,17 @@ describe('Claude hook normalization', () => {
     expect(result?.payload.toolInput).toBeUndefined()
   })
 
-  it('PostToolUseFailure surfaces the error text as lastAssistantMessage', () => {
-    const result = _internals.normalizeHookPayload(
+  it('PostToolUseFailure clears stale tool fields until the next PreToolUse', () => {
+    _internals.normalizeHookPayload(
+      'claude',
+      buildBody({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Edit',
+        tool_input: { file_path: '/src/config.ts' }
+      }),
+      'production'
+    )
+    const failed = _internals.normalizeHookPayload(
       'claude',
       buildBody({
         hook_event_name: 'PostToolUseFailure',
@@ -3802,9 +3811,27 @@ describe('Claude hook normalization', () => {
       }),
       'production'
     )
-    expect(result?.payload.state).toBe('working')
-    expect(result?.payload.toolName).toBe('Edit')
-    expect(result?.payload.lastAssistantMessage).toBe('file is read-only')
+    expect(failed?.payload).toMatchObject({
+      state: 'working',
+      lastAssistantMessage: 'file is read-only'
+    })
+    expect(failed?.payload.toolName).toBeUndefined()
+    expect(failed?.payload.toolInput).toBeUndefined()
+
+    const retry = _internals.normalizeHookPayload(
+      'claude',
+      buildBody({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: '/src/config.ts' }
+      }),
+      'production'
+    )
+    expect(retry?.payload).toMatchObject({
+      state: 'working',
+      toolName: 'Read',
+      toolInput: '/src/config.ts'
+    })
   })
 
   it('PreToolUse normalizes to working + tool fields', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -1639,6 +1639,44 @@ describe('shared agent-hook-listener', () => {
     expect(event?.payload.interactivePrompt).toBeUndefined()
   })
 
+  it('surfaces the Grok tool-failure error and clears stale tool fields', () => {
+    normalizeHookPayload(
+      state,
+      'grok',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hookEventName: 'pre_tool_use',
+          toolName: 'run_terminal_command',
+          toolInput: { command: 'pnpm build' }
+        }
+      },
+      'production'
+    )
+    const failed = normalizeHookPayload(
+      state,
+      'grok',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hookEventName: 'post_tool_use_failure',
+          toolName: 'run_terminal_command',
+          toolInput: { command: 'pnpm build' },
+          error: 'command exited with code 1'
+        }
+      },
+      'production'
+    )
+    // Why: keeping toolName set would let the compact sidebar show the tool
+    // instead of the failure text, hiding the error from the user.
+    expect(failed?.payload).toMatchObject({
+      state: 'working',
+      lastAssistantMessage: 'command exited with code 1'
+    })
+    expect(failed?.payload.toolName).toBeUndefined()
+    expect(failed?.payload.toolInput).toBeUndefined()
+  })
+
   it('maps Grok StopFailure to done', () => {
     normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1375,10 +1375,19 @@ function extractClaudeToolFields(
   hookPayload: Record<string, unknown>
 ): ToolSnapshot {
   const update: ToolSnapshot = {}
-  if (
+  if (eventName === 'PostToolUseFailure') {
+    // Why: the compact sidebar prioritizes current-tool metadata over the
+    // failure message, so a completed failed tool must no longer look active.
+    Object.assign(
+      update,
+      toolUpdate(
+        { toolName: undefined, toolInput: undefined, interactivePrompt: undefined },
+        { hasToolInputField: true }
+      )
+    )
+  } else if (
     eventName === 'PreToolUse' ||
     eventName === 'PostToolUse' ||
-    eventName === 'PostToolUseFailure' ||
     eventName === 'PermissionRequest'
   ) {
     const toolName = readString(hookPayload, 'tool_name')

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -692,6 +692,17 @@ function toolUpdate(
   }
 }
 
+/** Clear the active-tool metadata (name/input/prompt) so a just-failed tool
+ *  stops looking in-flight. Why: the compact sidebar prioritizes current-tool
+ *  metadata over the failure message, so a completed failed tool must no
+ *  longer look active or the error text stays hidden behind the tool name. */
+function clearActiveToolFieldsUpdate(): ToolSnapshot {
+  return toolUpdate(
+    { toolName: undefined, toolInput: undefined, interactivePrompt: undefined },
+    { hasToolInputField: true }
+  )
+}
+
 /** True for the AskUserQuestion tool across the casing variants different
  *  agents emit (`AskUserQuestion` / `ask_user_question` / `askUserQuestion`).
  *  Why: this is the structured "pick an option" prompt whose full input the
@@ -1376,15 +1387,7 @@ function extractClaudeToolFields(
 ): ToolSnapshot {
   const update: ToolSnapshot = {}
   if (eventName === 'PostToolUseFailure') {
-    // Why: the compact sidebar prioritizes current-tool metadata over the
-    // failure message, so a completed failed tool must no longer look active.
-    Object.assign(
-      update,
-      toolUpdate(
-        { toolName: undefined, toolInput: undefined, interactivePrompt: undefined },
-        { hasToolInputField: true }
-      )
-    )
+    Object.assign(update, clearActiveToolFieldsUpdate())
   } else if (
     eventName === 'PreToolUse' ||
     eventName === 'PostToolUse' ||
@@ -1609,12 +1612,20 @@ function extractCursorToolFields(
     eventName === 'postToolUse' ||
     eventName === 'postToolUseFailure'
   ) {
-    const toolName = readString(hookPayload, 'tool_name')
-    const toolInput = deriveToolInputPreview(toolName, hookPayload.tool_input)
-    const update: ToolSnapshot = toolUpdate(
-      { toolName, toolInput },
-      { hasToolInputField: hasOwnField(hookPayload, 'tool_input') }
-    )
+    const update: ToolSnapshot = {}
+    if (eventName === 'postToolUseFailure') {
+      Object.assign(update, clearActiveToolFieldsUpdate())
+    } else {
+      const toolName = readString(hookPayload, 'tool_name')
+      const toolInput = deriveToolInputPreview(toolName, hookPayload.tool_input)
+      Object.assign(
+        update,
+        toolUpdate(
+          { toolName, toolInput },
+          { hasToolInputField: hasOwnField(hookPayload, 'tool_input') }
+        )
+      )
+    }
     if (eventName === 'postToolUse') {
       const responseText = extractToolResponseText(hookPayload.tool_output)
       if (responseText) {
@@ -1759,10 +1770,11 @@ function extractCopilotToolFields(
   hookPayload: Record<string, unknown>
 ): ToolSnapshot {
   const update: ToolSnapshot = {}
-  if (
+  if (eventName === 'PostToolUseFailure' || eventName === 'ErrorOccurred') {
+    Object.assign(update, clearActiveToolFieldsUpdate())
+  } else if (
     eventName === 'PreToolUse' ||
     eventName === 'PostToolUse' ||
-    eventName === 'PostToolUseFailure' ||
     eventName === 'PermissionRequest'
   ) {
     const copilotToolCall = readCopilotToolCall(hookPayload)
@@ -2025,29 +2037,40 @@ function extractGrokToolFields(
   grokHome?: string
 ): ToolSnapshot {
   if (isGrokEvent(eventName, 'pre_tool_use', 'post_tool_use', 'post_tool_use_failure')) {
-    const toolName =
-      readString(hookPayload, 'toolName') ??
-      readString(hookPayload, 'tool_name') ??
-      readString(hookPayload, 'name')
-    const rawInput =
-      hookPayload.toolInput ?? hookPayload.tool_input ?? hookPayload.input ?? hookPayload.arguments
-    const toolInput =
-      deriveToolInputPreview(toolName, rawInput) ?? deriveFallbackToolInputPreview(rawInput)
-    // Why: Grok's ask_user_question is auto-allowed and arrives as PreToolUse
-    // (not PermissionRequest). Capture the full question payload so the live
-    // card path can render options instead of only a waiting Notification.
-    const interactivePrompt = deriveInteractivePrompt(toolName, rawInput, eventName)
-    const update: ToolSnapshot = toolUpdate(
-      { toolName, toolInput, interactivePrompt },
-      {
-        hasToolInputField: hasAnyOwnField(hookPayload, [
-          'toolInput',
-          'tool_input',
-          'input',
-          'arguments'
-        ])
-      }
-    )
+    const update: ToolSnapshot = {}
+    if (isGrokEvent(eventName, 'post_tool_use_failure')) {
+      Object.assign(update, clearActiveToolFieldsUpdate())
+    } else {
+      const toolName =
+        readString(hookPayload, 'toolName') ??
+        readString(hookPayload, 'tool_name') ??
+        readString(hookPayload, 'name')
+      const rawInput =
+        hookPayload.toolInput ??
+        hookPayload.tool_input ??
+        hookPayload.input ??
+        hookPayload.arguments
+      const toolInput =
+        deriveToolInputPreview(toolName, rawInput) ?? deriveFallbackToolInputPreview(rawInput)
+      // Why: Grok's ask_user_question is auto-allowed and arrives as PreToolUse
+      // (not PermissionRequest). Capture the full question payload so the live
+      // card path can render options instead of only a waiting Notification.
+      const interactivePrompt = deriveInteractivePrompt(toolName, rawInput, eventName)
+      Object.assign(
+        update,
+        toolUpdate(
+          { toolName, toolInput, interactivePrompt },
+          {
+            hasToolInputField: hasAnyOwnField(hookPayload, [
+              'toolInput',
+              'tool_input',
+              'input',
+              'arguments'
+            ])
+          }
+        )
+      )
+    }
     if (isGrokEvent(eventName, 'post_tool_use', 'post_tool_use_failure')) {
       const responseText =
         extractToolResponseText(hookPayload.toolResponse) ??


### PR DESCRIPTION
## What & why

When an agent's tool call fails, the compact sidebar was showing the stale tool name/input instead of the failure error, hiding the error from the user. The sidebar prioritizes active-tool metadata over the failure message, so a just-failed tool that still looks "in-flight" masks the error text.

This extracts a shared `clearActiveToolFieldsUpdate()` helper in `src/shared/agent-hook-listener.ts` that clears `toolName` / `toolInput` / `interactivePrompt` on tool-failure events, so the failure message surfaces instead. It's applied uniformly across the agents that emit tool-failure hooks:

- **Claude** — `PostToolUseFailure`
- **Cursor** — `postToolUseFailure`
- **Copilot** — `PostToolUseFailure` and `ErrorOccurred`
- **Grok** — `post_tool_use_failure`

The failure error text is still surfaced as `lastAssistantMessage` for every agent (that logic runs after the clear and is unchanged). The clear composes with `resolveToolState`'s existing `clearsUnidentifiedTool` / `clearsUnpreviewableInput` paths so the fields drop rather than inheriting stale values, and a subsequent `PreToolUse` restores normal tool display.

## Testing

- Added normalization tests for Claude, Cursor, Copilot, and Grok asserting the failure clears `toolName`/`toolInput` while surfacing the error, plus a Claude retry case confirming the next `PreToolUse` restores tool fields.
- `pnpm typecheck` passes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
