### PR TITLE
fix(ssh): enable server-owned SSH projects in paired clients

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -147,6 +147,7 @@ import {
   getLocalPtyProvider,
   registerHeadlessPtyRuntime
 } from './ipc/pty'
+import { registerSshHandlers } from './ipc/ssh'
 import { AgentBrowserBridge } from './browser/agent-browser-bridge'
 import { EmulatorBridge } from './emulator/emulator-bridge'
 import { serveSimStateWatcher } from './emulator/serve-sim-state-watcher'
@@ -2101,6 +2102,9 @@ app.whenReady().then(async () => {
       (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target),
       store
     )
+    // Why: serve has no BrowserWindow, so desktop startup never installs the
+    // SSH managers required by runtime RPC clients and SSH-backed projects.
+    registerSshHandlers(store, () => null, runtime)
     // Why: headless servers have no renderer to mount <webview> browser panes.
     // Back them with main-process offscreen WebContents instead, so this host can
     // own browser pages and advertise browser.headless.v1 — but only when a

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -234,6 +234,7 @@ async function addLocalRepoFromPath(
   return { repo, alreadyExisted: false }
 }
 
+/** Add an SSH-hosted Git repository or folder to the persisted project catalog. */
 export async function addRemoteRepoFromPath(
   store: Store,
   args: {
@@ -1014,6 +1015,7 @@ async function resolveSshProjectGroupPath(connectionId: string, path: string): P
   return path
 }
 
+/** Scan a local or SSH-owned directory using the filesystem providers available to IPC callers. */
 export async function scanNestedReposForIpc(args: {
   path: string
   connectionId?: string

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -234,7 +234,7 @@ async function addLocalRepoFromPath(
   return { repo, alreadyExisted: false }
 }
 
-async function addRemoteRepoFromPath(
+export async function addRemoteRepoFromPath(
   store: Store,
   args: {
     connectionId: string
@@ -1014,7 +1014,7 @@ async function resolveSshProjectGroupPath(connectionId: string, path: string): P
   return path
 }
 
-async function scanNestedReposForIpc(args: {
+export async function scanNestedReposForIpc(args: {
   path: string
   connectionId?: string
   options?: unknown

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -51,40 +51,46 @@ export function registerSshBrowseHandler(
     async (
       _event,
       args: { targetId: string; dirPath: string }
-    ): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> => {
-      const mgr = getConnectionManager()
-      if (!mgr) {
-        throw new Error('SSH connection manager not initialized')
-      }
-      const conn = mgr.getConnection(args.targetId)
-      if (!conn) {
-        throw new Error(`SSH connection "${args.targetId}" not found`)
-      }
-
-      try {
-        return await browseWithPosixShell(conn, args.dirPath)
-      } catch (posixError) {
-        // Why: a Windows login shell (cmd.exe/PowerShell) rejects Orca's POSIX
-        // `exec` wrapper, and the only locale-independent signal for that is "the
-        // remote command executed and exited non-zero" (RemoteBrowseError). Its
-        // stderr prose is localized, and cmd.exe's 9009 ERRORLEVEL never reaches
-        // us (sshd forwards process exit 1). Transport errors/timeouts aren't
-        // RemoteBrowseErrors, so a dropped connection is never retried as Windows.
-        if (!(posixError instanceof RemoteBrowseError)) {
-          throw posixError
-        }
-        try {
-          return await browseWithWindowsPowerShell(conn, args.dirPath)
-        } catch (fallbackError) {
-          // Why: if the login shell couldn't find powershell.exe (exit 127) the
-          // host isn't Windows — surface the original POSIX failure rather than a
-          // misleading "powershell.exe: not found". Otherwise PowerShell genuinely
-          // ran and its error (e.g. "Cannot find path") is the real cause.
-          throw isPosixCommandNotFound(fallbackError) ? posixError : fallbackError
-        }
-      }
-    }
+    ): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> =>
+      browseSshDirectory(getConnectionManager(), args.targetId, args.dirPath)
   )
+}
+
+export async function browseSshDirectory(
+  manager: SshConnectionManager | null,
+  targetId: string,
+  dirPath: string
+): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> {
+  if (!manager) {
+    throw new Error('SSH connection manager not initialized')
+  }
+  const conn = manager.getConnection(targetId)
+  if (!conn) {
+    throw new Error(`SSH connection "${targetId}" not found`)
+  }
+
+  try {
+    return await browseWithPosixShell(conn, dirPath)
+  } catch (posixError) {
+    // Why: a Windows login shell (cmd.exe/PowerShell) rejects Orca's POSIX
+    // `exec` wrapper, and the only locale-independent signal for that is "the
+    // remote command executed and exited non-zero" (RemoteBrowseError). Its
+    // stderr prose is localized, and cmd.exe's 9009 ERRORLEVEL never reaches
+    // us (sshd forwards process exit 1). Transport errors/timeouts aren't
+    // RemoteBrowseErrors, so a dropped connection is never retried as Windows.
+    if (!(posixError instanceof RemoteBrowseError)) {
+      throw posixError
+    }
+    try {
+      return await browseWithWindowsPowerShell(conn, dirPath)
+    } catch (fallbackError) {
+      // Why: if the login shell couldn't find powershell.exe (exit 127) the
+      // host isn't Windows — surface the original POSIX failure rather than a
+      // misleading "powershell.exe: not found". Otherwise PowerShell genuinely
+      // ran and its error (e.g. "Cannot find path") is the real cause.
+      throw isPosixCommandNotFound(fallbackError) ? posixError : fallbackError
+    }
+  }
 }
 
 type SshBrowseConnection = NonNullable<ReturnType<SshConnectionManager['getConnection']>>

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -56,6 +56,7 @@ export function registerSshBrowseHandler(
   )
 }
 
+/** List a remote directory before a repository root has been registered with the SSH relay. */
 export async function browseSshDirectory(
   manager: SshConnectionManager | null,
   targetId: string,

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -213,7 +213,12 @@ vi.mock('../ssh/ssh-port-scanner', () => ({
   }
 }))
 
-import { getSshConnectionManager, registerSshHandlers, resetSshHandlerStateForTests } from './ssh'
+import {
+  connectRegisteredSshTarget,
+  getSshConnectionManager,
+  registerSshHandlers,
+  resetSshHandlerStateForTests
+} from './ssh'
 import { SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD, type SshTarget } from '../../shared/ssh-types'
 import {
   clearProviderPtyState,
@@ -496,6 +501,35 @@ describe('SSH IPC handlers', () => {
     await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
 
     expect(mockConnectionManager.connect).toHaveBeenCalledWith(target)
+  })
+
+  it('connects registered targets without a BrowserWindow', async () => {
+    const runtime = {
+      notifySshStateChanged: vi.fn()
+    }
+    registerSshHandlers(mockStore as never, () => null, runtime as never)
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Headless Server Target',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    const connectedState = {
+      targetId: 'ssh-1',
+      status: 'connected' as const,
+      error: null,
+      reconnectAttempt: 0
+    }
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue({})
+    mockConnectionManager.getState.mockReturnValue(connectedState)
+
+    await expect(connectRegisteredSshTarget('ssh-1')).resolves.toEqual(connectedState)
+
+    expect(mockConnectionManager.connect).toHaveBeenCalledWith(target)
+    expect(runtime.notifySshStateChanged).toHaveBeenCalledWith('ssh-1', connectedState)
+    expect(mockWindow.webContents.send).not.toHaveBeenCalled()
   })
 
   it('ssh:connect exposes the detected remote platform in public state', async () => {

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -101,6 +101,45 @@ export function listRegisteredRemovedSshTargetLabels(): Record<string, string> {
   return sshStore?.listRemovedTargetLabels() ?? {}
 }
 
+function takeRegisteredRepoReadoptions(): SshRepoReadoption[] {
+  if (!sshStore || sshStore.lastRepoReadoptions.length === 0) {
+    return []
+  }
+  const repoReadoptions = sshStore.lastRepoReadoptions
+  sshStore.lastRepoReadoptions = []
+  // Why: add/import can re-adopt repositories from a removed target id. The
+  // desktop event remains best-effort; paired clients receive the same changes
+  // from the runtime repo catalog refresh after their management action.
+  const win = getCurrentMainWindow()
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('repos:changed')
+  }
+  currentRuntime?.notifyReposChanged()
+  return repoReadoptions
+}
+
+export function addRegisteredSshTarget(target: Omit<SshTarget, 'id'>): {
+  target: SshTarget
+  repoReadoptions: SshRepoReadoption[]
+} {
+  if (!sshStore) {
+    throw new Error('ssh_handlers_not_registered')
+  }
+  const added = sshStore.addTarget(target)
+  return { target: added, repoReadoptions: takeRegisteredRepoReadoptions() }
+}
+
+export function importRegisteredSshConfig(options?: { reAdopt?: boolean }): {
+  targets: SshTarget[]
+  repoReadoptions: SshRepoReadoption[]
+} {
+  if (!sshStore) {
+    throw new Error('ssh_handlers_not_registered')
+  }
+  const targets = sshStore.importFromSshConfig(options)
+  return { targets, repoReadoptions: takeRegisteredRepoReadoptions() }
+}
+
 export async function disconnectRegisteredSshTarget(targetId: string): Promise<void> {
   if (!connectionManager) {
     return
@@ -742,22 +781,6 @@ export function registerSshHandlers(
 
   // ── Target CRUD ────────────────────────────────────────────────────
 
-  // Why: SSH target add/import can re-adopt workspaces orphaned on a removed
-  // target id (see ssh-target-readoption). When that re-points repos, the
-  // renderer must refresh its repo list to surface the reattached workspaces.
-  function takeRepoReadoptions(): SshRepoReadoption[] {
-    if (!sshStore || sshStore.lastRepoReadoptions.length === 0) {
-      return []
-    }
-    const repoReadoptions = sshStore.lastRepoReadoptions
-    sshStore.lastRepoReadoptions = []
-    const win = getCurrentMainWindow()
-    if (win && !win.isDestroyed()) {
-      win.webContents.send('repos:changed')
-    }
-    return repoReadoptions
-  }
-
   ipcMain.handle('ssh:listTargets', () => {
     return sshStore!.listTargets()
   })
@@ -767,12 +790,7 @@ export function registerSshHandlers(
   })
 
   ipcMain.handle('ssh:addTarget', (_event, args: { target: Omit<SshTarget, 'id'> }) => {
-    const target = sshStore!.addTarget(args.target)
-    // Why: re-adding a removed host can re-adopt orphaned workspaces (re-point
-    // repos/worktrees off the dead id). Refresh the renderer's repo list so the
-    // reattached workspaces move from grey ghosts back onto the live host.
-    const repoReadoptions = takeRepoReadoptions()
-    return { target, repoReadoptions }
+    return addRegisteredSshTarget(args.target)
   })
 
   ipcMain.handle(
@@ -787,9 +805,7 @@ export function registerSshHandlers(
   })
 
   ipcMain.handle('ssh:importConfig', (_event, args?: { reAdopt?: boolean }) => {
-    const targets = sshStore!.importFromSshConfig(args)
-    const repoReadoptions = takeRepoReadoptions()
-    return { targets, repoReadoptions }
+    return importRegisteredSshConfig(args)
   })
 
   // ── Connection lifecycle ───────────────────────────────────────────

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -101,6 +101,7 @@ export function listRegisteredRemovedSshTargetLabels(): Record<string, string> {
   return sshStore?.listRemovedTargetLabels() ?? {}
 }
 
+/** Drain repository re-adoptions produced by the most recent SSH target mutation. */
 function takeRegisteredRepoReadoptions(): SshRepoReadoption[] {
   if (!sshStore || sshStore.lastRepoReadoptions.length === 0) {
     return []
@@ -118,6 +119,7 @@ function takeRegisteredRepoReadoptions(): SshRepoReadoption[] {
   return repoReadoptions
 }
 
+/** Add an SSH target through the process-wide registry used by desktop and runtime RPC. */
 export function addRegisteredSshTarget(target: Omit<SshTarget, 'id'>): {
   target: SshTarget
   repoReadoptions: SshRepoReadoption[]
@@ -129,6 +131,7 @@ export function addRegisteredSshTarget(target: Omit<SshTarget, 'id'>): {
   return { target: added, repoReadoptions: takeRegisteredRepoReadoptions() }
 }
 
+/** Import OpenSSH hosts through the process-wide registry used by desktop and runtime RPC. */
 export function importRegisteredSshConfig(options?: { reAdopt?: boolean }): {
   targets: SshTarget[]
   repoReadoptions: SshRepoReadoption[]

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -670,6 +670,7 @@ import {
   WORKTREE_CREATE_MAX_SUFFIX_ATTEMPTS
 } from '../worktree-create-candidates'
 import { normalizeSparseDirectories } from '../ipc/sparse-checkout-directories'
+import { addRemoteRepoFromPath, scanNestedReposForIpc } from '../ipc/repos'
 import type { Store } from '../persistence'
 import type { StatsCollector } from '../stats/collector'
 import { AgentDetector } from '../stats/agent-detector'
@@ -3002,7 +3003,7 @@ export class OrcaRuntimeService {
     this.emitClientEvent({ type: 'worktreesChanged', repoId })
   }
 
-  private notifyReposChanged(): void {
+  notifyReposChanged(): void {
     this.notifier?.reposChanged()
     this.emitClientEvent({ type: 'reposChanged' })
   }
@@ -11572,11 +11573,34 @@ export class OrcaRuntimeService {
     return { deleted }
   }
 
-  async scanNestedRepos(path: string): Promise<NestedRepoScanResult> {
+  async scanNestedRepos(path: string, connectionId?: string): Promise<NestedRepoScanResult> {
+    if (connectionId) {
+      return scanNestedReposForIpc({ path, connectionId, options: { timeoutMs: 15_000 } })
+    }
     if (!isAbsolute(path)) {
       throw new Error('Project path must be an absolute path')
     }
     return scanNestedRepos({ path, options: { timeoutMs: 15_000 } })
+  }
+
+  async addSshRepo(args: {
+    connectionId: string
+    remotePath: string
+    displayName?: string
+    kind?: 'git' | 'folder'
+  }): Promise<{ repo: Repo } | { error: string }> {
+    if (!this.store) {
+      throw new Error('runtime_unavailable')
+    }
+    // Why: runtime RPC and desktop IPC must persist identical SSH repo
+    // metadata so a project added from a paired desktop behaves like one added
+    // directly on the server.
+    const result = await addRemoteRepoFromPath(this.store as Store, args)
+    if ('error' in result) {
+      return result
+    }
+    this.notifyReposChanged()
+    return { repo: result.repo }
   }
 
   async browseServerDir(pathValue: string): Promise<{ resolvedPath: string; entries: DirEntry[] }> {

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -9,6 +9,54 @@ function makeRequest(method: string, params?: unknown): RpcRequest {
 }
 
 describe('repo RPC methods', () => {
+  it('adds an existing project through an SSH target owned by the runtime server', async () => {
+    const result = {
+      repo: {
+        id: 'repo-p8',
+        path: '/srv/project',
+        connectionId: 'ssh-p8',
+        kind: 'git'
+      }
+    }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      addSshRepo: vi.fn().mockResolvedValue(result)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: REPO_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('repo.addRemote', {
+        connectionId: 'ssh-p8',
+        remotePath: '/srv/project'
+      })
+    )
+
+    expect(runtime.addSshRepo).toHaveBeenCalledWith({
+      connectionId: 'ssh-p8',
+      remotePath: '/srv/project'
+    })
+    expect(response).toMatchObject({ ok: true, result })
+  })
+
+  it('scans nested projects through the selected runtime SSH target', async () => {
+    const scan = { selectedPath: '/srv', selectedPathKind: 'non_git_folder', repos: [] }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      scanNestedRepos: vi.fn().mockResolvedValue(scan)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: REPO_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('projectGroup.scanNested', {
+        path: '/srv',
+        connectionId: 'ssh-p8'
+      })
+    )
+
+    expect(runtime.scanNestedRepos).toHaveBeenCalledWith('/srv', 'ssh-p8')
+    expect(response).toMatchObject({ ok: true, result: scan })
+  })
+
   it('updates project runtime preferences on the runtime server', async () => {
     const project = {
       id: 'project-1',

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -14,6 +14,13 @@ const RepoPath = z.object({
   kind: z.enum(['git', 'folder']).optional()
 })
 
+const SshRepoPath = z.object({
+  connectionId: requiredString('Missing SSH target'),
+  remotePath: requiredString('Missing remote path'),
+  displayName: OptionalString,
+  kind: z.enum(['git', 'folder']).optional()
+})
+
 const RepoCreate = z.object({
   parentPath: requiredString('Missing parent path'),
   name: requiredString('Missing repo name'),
@@ -74,7 +81,8 @@ const ProjectGroupMoveProject = z.object({
 })
 
 const ProjectGroupScanNested = z.object({
-  path: requiredString('Missing folder path')
+  path: requiredString('Missing folder path'),
+  connectionId: OptionalString
 })
 
 const ProjectGroupImportNested = z.discriminatedUnion('mode', [
@@ -149,7 +157,8 @@ export const REPO_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'projectGroup.scanNested',
     params: ProjectGroupScanNested,
-    handler: async (params, { runtime }) => runtime.scanNestedRepos(params.path)
+    handler: async (params, { runtime }) =>
+      runtime.scanNestedRepos(params.path, params.connectionId)
   }),
   defineMethod({
     name: 'projectGroup.importNested',
@@ -180,6 +189,11 @@ export const REPO_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) => ({
       repo: await runtime.addRepo(params.path, params.kind)
     })
+  }),
+  defineMethod({
+    name: 'repo.addRemote',
+    params: SshRepoPath,
+    handler: async (params, { runtime }) => runtime.addSshRepo(params)
   }),
   defineMethod({
     name: 'repo.create',

--- a/src/main/runtime/rpc/methods/ssh.test.ts
+++ b/src/main/runtime/rpc/methods/ssh.test.ts
@@ -1,26 +1,41 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { SSH_METHODS } from './ssh'
 
 const {
+  addRegisteredSshTargetMock,
+  browseSshDirectoryMock,
   connectRegisteredSshTargetMock,
+  getSshConnectionManagerMock,
   getRegisteredSshStateMock,
+  importRegisteredSshConfigMock,
   listRegisteredSshTargetsMock,
   listRegisteredRemovedSshTargetLabelsMock
 } = vi.hoisted(() => ({
+  addRegisteredSshTargetMock: vi.fn(),
+  browseSshDirectoryMock: vi.fn(),
   connectRegisteredSshTargetMock: vi.fn(),
+  getSshConnectionManagerMock: vi.fn(),
   getRegisteredSshStateMock: vi.fn(),
+  importRegisteredSshConfigMock: vi.fn(),
   listRegisteredSshTargetsMock: vi.fn(),
   listRegisteredRemovedSshTargetLabelsMock: vi.fn()
 }))
 
 vi.mock('../../../ipc/ssh', () => ({
+  addRegisteredSshTarget: addRegisteredSshTargetMock,
   connectRegisteredSshTarget: connectRegisteredSshTargetMock,
+  getSshConnectionManager: getSshConnectionManagerMock,
   getRegisteredSshState: getRegisteredSshStateMock,
+  importRegisteredSshConfig: importRegisteredSshConfigMock,
   listRegisteredSshTargets: listRegisteredSshTargetsMock,
   listRegisteredRemovedSshTargetLabels: listRegisteredRemovedSshTargetLabelsMock
+}))
+
+vi.mock('../../../ipc/ssh-browse', () => ({
+  browseSshDirectory: browseSshDirectoryMock
 }))
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
@@ -28,6 +43,10 @@ function makeRequest(method: string, params?: unknown): RpcRequest {
 }
 
 describe('ssh RPC methods', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('returns the registered SSH target state', async () => {
     const state = {
       targetId: 'ssh-1',
@@ -92,5 +111,76 @@ describe('ssh RPC methods', () => {
     const response = await dispatcher.dispatch(makeRequest('ssh.listRemovedTargetLabels'))
 
     expect(response).toMatchObject({ ok: true, result: { labels } })
+  })
+
+  it('adds a validated manual target on the runtime host', async () => {
+    const target = {
+      label: 'p8',
+      configHost: 'p8',
+      host: '192.0.2.8',
+      port: 22,
+      username: 'jae',
+      identityFile: '~/.ssh/id_ed25519_p8'
+    }
+    const result = { target: { id: 'ssh-p8', ...target }, repoReadoptions: [] }
+    addRegisteredSshTargetMock.mockReturnValueOnce(result)
+    const runtime = { getRuntimeId: () => 'test-runtime' } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SSH_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest('ssh.addTarget', { target }))
+
+    expect(addRegisteredSshTargetMock).toHaveBeenCalledWith(target)
+    expect(response).toMatchObject({ ok: true, result })
+  })
+
+  it('rejects runtime-owned target fields from paired clients', async () => {
+    const runtime = { getRuntimeId: () => 'test-runtime' } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SSH_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('ssh.addTarget', {
+        target: {
+          label: 'hidden',
+          host: 'example.com',
+          port: 22,
+          username: 'me',
+          owner: { type: 'on-demand-runtime', runtimeId: 'spoofed' }
+        }
+      })
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+    expect(addRegisteredSshTargetMock).not.toHaveBeenCalled()
+  })
+
+  it('imports the runtime host SSH config', async () => {
+    const result = { targets: [], repoReadoptions: [] }
+    importRegisteredSshConfigMock.mockReturnValueOnce(result)
+    const runtime = { getRuntimeId: () => 'test-runtime' } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SSH_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest('ssh.importConfig'))
+
+    expect(importRegisteredSshConfigMock).toHaveBeenCalledWith({})
+    expect(response).toMatchObject({ ok: true, result })
+  })
+
+  it('browses a connected target through the runtime host', async () => {
+    const manager = { name: 'manager' }
+    const listing = {
+      resolvedPath: '/home/jae',
+      entries: [{ name: 'project', isDirectory: true }]
+    }
+    getSshConnectionManagerMock.mockReturnValueOnce(manager)
+    browseSshDirectoryMock.mockResolvedValueOnce(listing)
+    const runtime = { getRuntimeId: () => 'test-runtime' } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SSH_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('ssh.browseDir', { targetId: 'ssh-p8', dirPath: '~' })
+    )
+
+    expect(browseSshDirectoryMock).toHaveBeenCalledWith(manager, 'ssh-p8', '~')
+    expect(response).toMatchObject({ ok: true, result: listing })
   })
 })

--- a/src/main/runtime/rpc/methods/ssh.ts
+++ b/src/main/runtime/rpc/methods/ssh.ts
@@ -1,14 +1,48 @@
 import { z } from 'zod'
 import {
+  addRegisteredSshTarget,
   connectRegisteredSshTarget,
+  getSshConnectionManager,
   getRegisteredSshState,
+  importRegisteredSshConfig,
   listRegisteredRemovedSshTargetLabels,
   listRegisteredSshTargets
 } from '../../../ipc/ssh'
+import { browseSshDirectory } from '../../../ipc/ssh-browse'
 import { defineMethod, type RpcMethod } from '../core'
+import {
+  MAX_SSH_RELAY_GRACE_PERIOD_SECONDS,
+  MIN_SSH_RELAY_GRACE_PERIOD_SECONDS
+} from '../../../../shared/ssh-types'
 
 const SshTarget = z.object({
   targetId: z.string().min(1)
+})
+
+const ManualSshTarget = z
+  .object({
+    label: z.string().trim().min(1).max(200),
+    configHost: z.string().trim().min(1).max(512).optional(),
+    host: z.string().trim().min(1).max(512),
+    port: z.number().int().min(1).max(65_535),
+    username: z.string().trim().max(200),
+    identityFile: z.string().trim().min(1).max(4096).optional(),
+    relayGracePeriodSeconds: z
+      .number()
+      .int()
+      .min(0)
+      .max(MAX_SSH_RELAY_GRACE_PERIOD_SECONDS)
+      .refine(
+        (value) => value === 0 || value >= MIN_SSH_RELAY_GRACE_PERIOD_SECONDS,
+        `Relay grace period must be 0 or at least ${MIN_SSH_RELAY_GRACE_PERIOD_SECONDS}`
+      )
+      .optional(),
+    systemSshConnectionReuse: z.boolean().optional()
+  })
+  .strict()
+
+const SshBrowse = SshTarget.extend({
+  dirPath: z.string().min(1).max(4096)
 })
 
 export const SSH_METHODS: RpcMethod[] = [
@@ -31,5 +65,21 @@ export const SSH_METHODS: RpcMethod[] = [
     name: 'ssh.listRemovedTargetLabels',
     params: null,
     handler: () => ({ labels: listRegisteredRemovedSshTargetLabels() })
+  }),
+  defineMethod({
+    name: 'ssh.addTarget',
+    params: z.object({ target: ManualSshTarget }).strict(),
+    handler: (params) => addRegisteredSshTarget(params.target)
+  }),
+  defineMethod({
+    name: 'ssh.importConfig',
+    params: z.object({ reAdopt: z.boolean().optional() }).strict().optional(),
+    handler: (params) => importRegisteredSshConfig(params)
+  }),
+  defineMethod({
+    name: 'ssh.browseDir',
+    params: SshBrowse,
+    handler: (params) =>
+      browseSshDirectory(getSshConnectionManager(), params.targetId, params.dirPath)
   })
 ]

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -78,4 +78,20 @@ describe('desktop startup ordering', () => {
     expect(desktopSetWebContents).toBeGreaterThanOrEqual(0)
     expect(desktopAutomationStart).toBeGreaterThan(desktopSetWebContents)
   })
+
+  it('registers SSH handlers before the headless runtime starts accepting requests', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const serveStart = source.indexOf('if (serveOptions) {')
+    const serveReturn = source.indexOf(
+      'return',
+      source.indexOf('await printServeReady', serveStart)
+    )
+    const serveStartup = source.slice(serveStart, serveReturn)
+    const sshHandlers = serveStartup.indexOf('registerSshHandlers(store, () => null, runtime)')
+    const runtimeRpcStart = serveStartup.indexOf('await runtimeRpc.start()')
+
+    expect(serveStart).toBeGreaterThanOrEqual(0)
+    expect(sshHandlers).toBeGreaterThanOrEqual(0)
+    expect(runtimeRpcStart).toBeGreaterThan(sshHandlers)
+  })
 })

--- a/src/renderer/src/components/cmd-j/quick-action-context.ts
+++ b/src/renderer/src/components/cmd-j/quick-action-context.ts
@@ -4,6 +4,7 @@ import type { Worktree } from '../../../../shared/types'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
 import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { selectRuntimeAwareSshStatus } from '@/store/slices/runtime-environment-ssh'
+import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
 
 export type CmdJUnavailableReason =
   | 'loading'
@@ -88,10 +89,7 @@ export function getActiveWorktreeSshStatus(
   if (!connectionId) {
     return null
   }
-  const isPairedWebClient = Boolean(
-    (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
-  )
-  const sshOwnerEnvironmentId = isPairedWebClient
+  const sshOwnerEnvironmentId = isPairedWebClientWindow()
     ? null
     : getExplicitRuntimeEnvironmentIdForWorktree(state, activeWorktree.id)
   return selectRuntimeAwareSshStatus(state, sshOwnerEnvironmentId, connectionId)

--- a/src/renderer/src/components/cmd-j/quick-action-context.ts
+++ b/src/renderer/src/components/cmd-j/quick-action-context.ts
@@ -2,6 +2,8 @@ import type { AppState } from '@/store/types'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import type { Worktree } from '../../../../shared/types'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { selectRuntimeAwareSshStatus } from '@/store/slices/runtime-environment-ssh'
 
 export type CmdJUnavailableReason =
   | 'loading'
@@ -75,7 +77,7 @@ export function captureCmdJActiveGroupSnapshot(
 }
 
 export function getActiveWorktreeSshStatus(
-  state: Pick<AppState, 'repos' | 'sshConnectionStates' | 'worktreesByRepo'>,
+  state: AppState,
   activeWorktree: Worktree | null
 ): SshConnectionStatus | null {
   if (!activeWorktree) {
@@ -86,7 +88,13 @@ export function getActiveWorktreeSshStatus(
   if (!connectionId) {
     return null
   }
-  return state.sshConnectionStates.get(connectionId)?.status ?? 'disconnected'
+  const isPairedWebClient = Boolean(
+    (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+  )
+  const sshOwnerEnvironmentId = isPairedWebClient
+    ? null
+    : getExplicitRuntimeEnvironmentIdForWorktree(state, activeWorktree.id)
+  return selectRuntimeAwareSshStatus(state, sshOwnerEnvironmentId, connectionId)
 }
 
 export function getWorkspaceScopedActionAvailability(

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -15,6 +15,9 @@ import {
 import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-owner'
 import { useGitStatusFileWatchRefresh } from './git-status-file-watch-refresh'
 import { useGitStatusPushSignalRefresh } from './git-status-push-signal-refresh'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { selectRuntimeAwareSshStatus } from '@/store/slices/runtime-environment-ssh'
+import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
 
 const MIN_STATUS_REFRESH_INTERVAL_MS = 3000
 const INTERACTIVE_STATUS_POLL_INTERVAL_MS = MIN_STATUS_REFRESH_INTERVAL_MS
@@ -46,6 +49,8 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
   const setConflictOperation = useAppStore((s) => s.setConflictOperation)
   const conflictOperationByWorktree = useAppStore((s) => s.gitConflictOperationByWorktree)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
+  const sshStateByEnvironment = useAppStore((s) => s.sshStateByEnvironment)
+  const runtimeStatusByEnvironmentId = useAppStore((s) => s.runtimeStatusByEnvironmentId)
   const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const rightSidebarExplorerView = useAppStore((s) => s.rightSidebarExplorerView)
@@ -59,9 +64,29 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
   const activeRepoSupportsGit = activeRepo ? isGitRepoKind(activeRepo) : false
   const activeConnectionId = activeRepo?.connectionId ?? null
   const isConnectionReady = useCallback(
-    (connectionId: string | null | undefined): boolean =>
-      !connectionId || sshConnectionStates.get(connectionId)?.status === 'connected',
-    [sshConnectionStates]
+    (connectionId: string | null | undefined, worktreeId = activeWorktreeId): boolean => {
+      if (!connectionId) {
+        return true
+      }
+      const state = useAppStore.getState()
+      const sshOwnerEnvironmentId =
+        worktreeId && !isPairedWebClientWindow()
+          ? getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId)
+          : null
+      return (
+        selectRuntimeAwareSshStatus(
+          {
+            ...state,
+            runtimeStatusByEnvironmentId,
+            sshConnectionStates,
+            sshStateByEnvironment
+          },
+          sshOwnerEnvironmentId,
+          connectionId
+        ) === 'connected'
+      )
+    },
+    [activeWorktreeId, runtimeStatusByEnvironmentId, sshConnectionStates, sshStateByEnvironment]
   )
   const activeGitStatusPollingArgs = {
     activeWorktreeId,
@@ -240,7 +265,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
           const connectionId = getConnectionId(id) ?? undefined
           // Why: after explicit SSH disconnect the provider is intentionally
           // gone; keep remote polling quiet until the target reconnects.
-          if (!isConnectionReady(connectionId)) {
+          if (!isConnectionReady(connectionId, id)) {
             continue
           }
           const op = (await getRuntimeGitConflictOperation({

--- a/src/renderer/src/components/sidebar/AddRemoteHostDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRemoteHostDialog.tsx
@@ -20,17 +20,25 @@ import {
 } from '../settings/ssh-target-draft'
 import { MAX_SSH_RELAY_GRACE_PERIOD_SECONDS, type SshTarget } from '../../../../shared/ssh-types'
 import { RemoteServerFields, SshHostFields } from './AddRemoteHostFields'
+import { hydrateRuntimeEnvironmentSshState } from '@/runtime/runtime-environment-ssh-state'
+import {
+  addSshTargetForOwner,
+  importSshConfigForOwner,
+  type SshTargetOwnerEnvironment
+} from '@/runtime/runtime-ssh-target-management'
 
 export type AddRemoteHostMode = 'ssh' | 'server'
 
 type AddRemoteHostDialogProps = {
   mode: AddRemoteHostMode | null
   onOpenChange: (mode: AddRemoteHostMode | null) => void
+  sshOwnerEnvironment?: SshTargetOwnerEnvironment | null
 }
 
 export function AddRemoteHostDialog({
   mode,
-  onOpenChange
+  onOpenChange,
+  sshOwnerEnvironment = null
 }: AddRemoteHostDialogProps): React.JSX.Element {
   const open = mode !== null
   const [sshForm, setSshForm] = useState<EditingTarget>(EMPTY_FORM)
@@ -58,6 +66,10 @@ export function AddRemoteHostDialog({
   }
 
   const refreshSshTargetMetadata = async () => {
+    if (sshOwnerEnvironment) {
+      await hydrateRuntimeEnvironmentSshState(sshOwnerEnvironment.id, { force: true })
+      return
+    }
     const targets = (await window.api.ssh.listTargets()) as SshTarget[]
     setSshTargetsMetadata(targets)
   }
@@ -107,8 +119,10 @@ export function AddRemoteHostDialog({
 
     setIsSaving(true)
     try {
-      const result = await window.api.ssh.addTarget({ target })
-      recordSshRepoReadoptions(result.repoReadoptions)
+      const result = await addSshTargetForOwner(sshOwnerEnvironment, target)
+      if (!sshOwnerEnvironment) {
+        recordSshRepoReadoptions(result.repoReadoptions)
+      }
       await refreshSshTargetMetadata()
       recordFeatureInteraction('ssh')
       toast.success(
@@ -133,9 +147,11 @@ export function AddRemoteHostDialog({
   const importSshConfig = async () => {
     setIsImporting(true)
     try {
-      const result = await window.api.ssh.importConfig()
+      const result = await importSshConfigForOwner(sshOwnerEnvironment)
       const synced = result.targets
-      recordSshRepoReadoptions(result.repoReadoptions)
+      if (!sshOwnerEnvironment) {
+        recordSshRepoReadoptions(result.repoReadoptions)
+      }
       await refreshSshTargetMetadata()
       recordFeatureInteraction('ssh')
       if (synced.length === 0) {
@@ -228,7 +244,13 @@ export function AddRemoteHostDialog({
                   'auto.components.sidebar.AddRemoteHostDialog.serverTitle',
                   'Add remote server'
                 )
-              : translate('auto.components.sidebar.AddRemoteHostDialog.sshTitle', 'Add SSH host')}
+              : sshOwnerEnvironment
+                ? translate(
+                    'auto.components.sidebar.AddRemoteHostDialog.sshServerTitle',
+                    'Add SSH host to {{value0}}',
+                    { value0: sshOwnerEnvironment.label }
+                  )
+                : translate('auto.components.sidebar.AddRemoteHostDialog.sshTitle', 'Add SSH host')}
           </DialogTitle>
           <DialogDescription>
             {mode === 'server'
@@ -236,10 +258,16 @@ export function AddRemoteHostDialog({
                   'auto.components.sidebar.AddRemoteHostDialog.serverDescription',
                   'Pair with Orca running on another computer.'
                 )
-              : translate(
-                  'auto.components.sidebar.AddRemoteHostDialog.sshDescription',
-                  'Add a persistent machine you can log into over SSH.'
-                )}
+              : sshOwnerEnvironment
+                ? translate(
+                    'auto.components.sidebar.AddRemoteHostDialog.sshServerDescription',
+                    'Save this SSH machine on {{value0}} so projects and workspaces run through that server.',
+                    { value0: sshOwnerEnvironment.label }
+                  )
+                : translate(
+                    'auto.components.sidebar.AddRemoteHostDialog.sshDescription',
+                    'Add a persistent machine you can log into over SSH.'
+                  )}
           </DialogDescription>
         </DialogHeader>
 

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -94,7 +94,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     (repoId) => completeGitRepoAdd(repoId, 'ssh_remote_path'),
     scanNestedRepos,
     showRemoteNestedRepoReview,
-    trackRemoteNestedScanResult
+    trackRemoteNestedScanResult,
+    selectedRuntimeEnvironmentId
   )
 
   const {
@@ -328,7 +329,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
         createError={createError}
         isCreating={isCreating}
         hostSelector={<AddRepoHostSelectorSlot hostSelection={hostSelection} />}
-        showRemoteAction={false}
+        showRemoteAction={selectedHostKind === 'runtime'}
         browseHostKind={
           selectedHostKind === 'ssh' || selectedHostKind === 'runtime' ? selectedHostKind : 'local'
         }
@@ -366,6 +367,10 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
         }}
         onAddRemoteRepo={handleAddRemoteRepo}
         onOpenSshSettings={() => {
+          if (selectedRuntimeEnvironmentId) {
+            setStep('add')
+            return
+          }
           closeModal()
           openSettingsTarget({ pane: 'ssh', repoId: null, sectionId: 'ssh' })
           openSettingsPage()

--- a/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
@@ -190,6 +190,7 @@ export function AddRepoDialogStepContent({
     return (
       <RemoteStep
         sshTargets={sshTargets}
+        runtimeEnvironmentId={activeRuntimeEnvironmentId}
         selectedTargetId={selectedTargetId}
         lockSshTargetSelection={lockSshTargetSelection}
         remotePath={remotePath}

--- a/src/renderer/src/components/sidebar/AddRepoHostSelectorSlot.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoHostSelectorSlot.tsx
@@ -9,6 +9,15 @@ export function AddRepoHostSelectorSlot({
   hostSelection: ReturnType<typeof useAddRepoHostSelection>
 }) {
   const [addRemoteHostMode, setAddRemoteHostMode] = useState<AddRemoteHostMode | null>(null)
+  const selectedRuntimeEnvironment =
+    hostSelection.selectedParsedHost?.kind === 'runtime'
+      ? {
+          id: hostSelection.selectedParsedHost.environmentId,
+          label:
+            hostSelection.hostOptions.find((host) => host.id === hostSelection.selectedHostId)
+              ?.label ?? hostSelection.selectedParsedHost.environmentId
+        }
+      : null
 
   return (
     <>
@@ -22,7 +31,11 @@ export function AddRepoHostSelectorSlot({
         onAddSshHost={() => setAddRemoteHostMode('ssh')}
         onAddRemoteServer={() => setAddRemoteHostMode('server')}
       />
-      <AddRemoteHostDialog mode={addRemoteHostMode} onOpenChange={setAddRemoteHostMode} />
+      <AddRemoteHostDialog
+        mode={addRemoteHostMode}
+        onOpenChange={setAddRemoteHostMode}
+        sshOwnerEnvironment={selectedRuntimeEnvironment}
+      />
     </>
   )
 }

--- a/src/renderer/src/components/sidebar/AddRepoRemoteStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoRemoteStep.tsx
@@ -10,6 +10,7 @@ import { translate } from '@/i18n/i18n'
 
 type RemoteStepProps = {
   sshTargets: (SshTarget & { state?: SshConnectionState })[]
+  runtimeEnvironmentId?: string | null
   selectedTargetId: string | null
   lockSshTargetSelection?: boolean
   remotePath: string
@@ -26,6 +27,7 @@ type RemoteStepProps = {
 
 export function RemoteStep({
   sshTargets,
+  runtimeEnvironmentId,
   selectedTargetId,
   lockSshTargetSelection = false,
   remotePath,
@@ -68,6 +70,7 @@ export function RemoteStep({
         </DialogHeader>
         <RemoteFileBrowser
           targetId={selectedTargetId}
+          runtimeEnvironmentId={runtimeEnvironmentId ?? undefined}
           initialPath={remotePath || '~'}
           onSelect={(path) => {
             onRemotePathChange(path)
@@ -111,10 +114,15 @@ export function RemoteStep({
             {sshTargets.length === 0 ? (
               <div className="space-y-1.5 py-1">
                 <p className="text-xs text-muted-foreground">
-                  {translate(
-                    'auto.components.sidebar.AddRepoRemoteStep.df6fbcf880',
-                    'No SSH targets configured.'
-                  )}
+                  {runtimeEnvironmentId
+                    ? translate(
+                        'auto.components.sidebar.AddRepoRemoteStep.noServerSshTargets',
+                        'No SSH targets configured on this Orca server.'
+                      )
+                    : translate(
+                        'auto.components.sidebar.AddRepoRemoteStep.df6fbcf880',
+                        'No SSH targets configured.'
+                      )}
                 </p>
                 <Button
                   variant="outline"
@@ -123,10 +131,15 @@ export function RemoteStep({
                   onClick={onOpenSshSettings}
                 >
                   <Settings className="size-3.5" />
-                  {translate(
-                    'auto.components.sidebar.AddRepoRemoteStep.0416bde073',
-                    'Add in Settings'
-                  )}
+                  {runtimeEnvironmentId
+                    ? translate(
+                        'auto.components.sidebar.AddRepoRemoteStep.backToHostMenu',
+                        'Back to host menu'
+                      )
+                    : translate(
+                        'auto.components.sidebar.AddRepoRemoteStep.0416bde073',
+                        'Add in Settings'
+                      )}
                 </Button>
               </div>
             ) : (

--- a/src/renderer/src/components/sidebar/AddRepoSteps.default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.default-checkout.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   addRemote: vi.fn(),
   listTargets: vi.fn(),
   getState: vi.fn(),
+  runtimeRpc: vi.fn(),
   onStateChanged: vi.fn(() => vi.fn()),
   fetchWorktrees: vi.fn(),
   onGitRepoReady: vi.fn()
@@ -48,6 +49,10 @@ vi.mock('react', async (importOriginal) => {
 
 vi.mock('@/hooks/useMountedRef', () => ({
   useMountedRef: () => ({ current: true })
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  callRuntimeRpc: mocks.runtimeRpc
 }))
 
 vi.mock('@/store', () => {
@@ -101,6 +106,7 @@ describe('useRemoteRepo default-checkout handoff', () => {
       { id: 'ssh-2', label: 'Builder 2' }
     ])
     mocks.getState.mockResolvedValue({ status: 'connected' })
+    mocks.runtimeRpc.mockReset()
     vi.stubGlobal('window', {
       api: {
         ssh: {
@@ -187,5 +193,80 @@ describe('useRemoteRepo default-checkout handoff', () => {
     expect(mocks.getState).toHaveBeenCalledWith({ targetId: 'ssh-1' })
     expect(mocks.getState).toHaveBeenCalledWith({ targetId: 'ssh-2' })
     expect(mocks.stateSetters[1]).toHaveBeenCalledWith('ssh-2')
+  })
+
+  it('loads SSH targets from the selected runtime server', async () => {
+    mocks.stateValues = [[], null, '~/', null, false, null]
+    mocks.runtimeRpc.mockImplementation(
+      (_target: unknown, method: string, params?: { targetId?: string }) => {
+        if (method === 'ssh.listTargets') {
+          return Promise.resolve({ targets: [{ id: 'ssh-p8', label: 'p8' }] })
+        }
+        if (method === 'ssh.getState') {
+          return Promise.resolve({
+            state: {
+              targetId: params?.targetId,
+              status: 'connected',
+              error: null,
+              reconnectAttempt: 0
+            }
+          })
+        }
+        throw new Error(`Unexpected method: ${method}`)
+      }
+    )
+    const { useRemoteRepo } = await import('./AddRepoSteps')
+
+    const result = useRemoteRepo(
+      mocks.fetchWorktrees,
+      vi.fn(),
+      vi.fn(),
+      mocks.onGitRepoReady,
+      vi.fn().mockResolvedValue(null),
+      undefined,
+      undefined,
+      'env-linux'
+    )
+    await result.handleOpenRemoteStep('ssh-p8')
+
+    expect(mocks.runtimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-linux' },
+      'ssh.listTargets'
+    )
+    expect(mocks.runtimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-linux' },
+      'ssh.getState',
+      { targetId: 'ssh-p8' }
+    )
+    expect(mocks.listTargets).not.toHaveBeenCalled()
+    expect(mocks.stateSetters[1]).toHaveBeenCalledWith('ssh-p8')
+  })
+
+  it('adds an SSH project through the selected runtime server', async () => {
+    const repo = makeRepo({ connectionId: 'ssh-p8', executionHostId: 'runtime:env-linux' })
+    mocks.stateValues = [[], 'ssh-p8', '/srv/repo', null, false, null]
+    mocks.runtimeRpc.mockResolvedValue({ repo })
+    mocks.fetchWorktrees.mockResolvedValue(true)
+    const { useRemoteRepo } = await import('./AddRepoSteps')
+
+    const result = useRemoteRepo(
+      mocks.fetchWorktrees,
+      vi.fn(),
+      vi.fn(),
+      mocks.onGitRepoReady,
+      vi.fn().mockResolvedValue(null),
+      undefined,
+      undefined,
+      'env-linux'
+    )
+    await result.handleAddRemoteRepo()
+
+    expect(mocks.runtimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-linux' },
+      'repo.addRemote',
+      { connectionId: 'ssh-p8', remotePath: '/srv/repo' }
+    )
+    expect(mocks.addRemote).not.toHaveBeenCalled()
+    expect(mocks.onGitRepoReady).toHaveBeenCalledWith(repo.id)
   })
 })

--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -2,12 +2,13 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { useMountedRef } from '@/hooks/useMountedRef'
-import type { NestedRepoScanResult } from '../../../../shared/types'
+import type { NestedRepoScanResult, Repo } from '../../../../shared/types'
 import type { SshTarget, SshConnectionState } from '../../../../shared/ssh-types'
 import { createNestedRepoTelemetryAttemptId } from '../../../../shared/nested-repo-telemetry'
 import { translate } from '@/i18n/i18n'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { upsertAddedRepoWithProjectHostSetup } from './add-repo-store-upsert'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 
 // ── SSH host project hook ───────────────────────────────────────────
 
@@ -32,7 +33,8 @@ export function useRemoteRepo(
     inProgress: boolean,
     scanId: string | null
   ) => void,
-  onNestedScanResult?: (scan: NestedRepoScanResult | null, attemptId: string) => void
+  onNestedScanResult?: (scan: NestedRepoScanResult | null, attemptId: string) => void,
+  runtimeEnvironmentId?: string | null
 ) {
   const [sshTargets, setSshTargets] = useState<(SshTarget & { state?: SshConnectionState })[]>([])
   const [selectedTargetId, setSelectedTargetId] = useState<string | null>(null)
@@ -69,15 +71,30 @@ export function useRemoteRepo(
       const gen = ++remoteGenRef.current
       setStep('remote')
       try {
-        const targets = (await window.api.ssh.listTargets()) as SshTarget[]
+        const targets = runtimeEnvironmentId
+          ? (
+              await callRuntimeRpc<{ targets: SshTarget[] }>(
+                { kind: 'environment', environmentId: runtimeEnvironmentId },
+                'ssh.listTargets'
+              )
+            ).targets
+          : ((await window.api.ssh.listTargets()) as SshTarget[])
         if (gen !== remoteGenRef.current) {
           return
         }
         const withState = await Promise.all(
           targets.map(async (t) => {
-            const state = (await window.api.ssh.getState({
-              targetId: t.id
-            })) as SshConnectionState | null
+            const state = runtimeEnvironmentId
+              ? (
+                  await callRuntimeRpc<{ state: SshConnectionState | null }>(
+                    { kind: 'environment', environmentId: runtimeEnvironmentId },
+                    'ssh.getState',
+                    { targetId: t.id }
+                  )
+                ).state
+              : ((await window.api.ssh.getState({
+                  targetId: t.id
+                })) as SshConnectionState | null)
             return { ...t, state: state ?? undefined }
           })
         )
@@ -103,13 +120,18 @@ export function useRemoteRepo(
         setSshTargets([])
       }
     },
-    [setStep]
+    [runtimeEnvironmentId, setStep]
   )
 
   // Why: keep the target list's connection state in sync while the dialog is
   // open, so clicking the inline Connect button below updates the dot/label
   // live without the user reopening the step.
   useEffect(() => {
+    if (runtimeEnvironmentId) {
+      // Remote-runtime SSH events hydrate the environment-scoped store bucket;
+      // never mix same-named local target events into this server-owned list.
+      return
+    }
     const unsubscribe = window.api.ssh.onStateChanged(({ targetId, state }) => {
       setSshTargets((prev) => prev.map((t) => (t.id === targetId ? { ...t, state } : t)))
       if (state.status === 'connected') {
@@ -117,19 +139,36 @@ export function useRemoteRepo(
       }
     })
     return unsubscribe
-  }, [])
+  }, [runtimeEnvironmentId])
 
-  const handleConnectTarget = useCallback(async (targetId: string) => {
-    try {
-      await window.api.ssh.connect({ targetId })
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : translate('auto.components.sidebar.AddRepoSteps.3e64e8a70d', 'Connection failed')
-      )
-    }
-  }, [])
+  const handleConnectTarget = useCallback(
+    async (targetId: string) => {
+      try {
+        const state = runtimeEnvironmentId
+          ? (
+              await callRuntimeRpc<{ state: SshConnectionState | null }>(
+                { kind: 'environment', environmentId: runtimeEnvironmentId },
+                'ssh.connect',
+                { targetId },
+                { timeoutMs: 60_000 }
+              )
+            ).state
+          : await window.api.ssh.connect({ targetId })
+        if (state) {
+          setSshTargets((prev) =>
+            prev.map((target) => (target.id === targetId ? { ...target, state } : target))
+          )
+        }
+      } catch (err) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : translate('auto.components.sidebar.AddRepoSteps.3e64e8a70d', 'Connection failed')
+        )
+      }
+    },
+    [runtimeEnvironmentId]
+  )
 
   const handleAddRemoteRepo = useCallback(async () => {
     if (!selectedTargetId || !remotePath.trim()) {
@@ -175,10 +214,19 @@ export function useRemoteRepo(
         return
       }
       setRemoteNestedScanId(null)
-      const result = await window.api.repos.addRemote({
-        connectionId: selectedTargetId,
-        remotePath: trimmedRemotePath
-      })
+      const result = runtimeEnvironmentId
+        ? await callRuntimeRpc<{ repo: Repo } | { error: string }>(
+            { kind: 'environment', environmentId: runtimeEnvironmentId },
+            'repo.addRemote',
+            {
+              connectionId: selectedTargetId,
+              remotePath: trimmedRemotePath
+            }
+          )
+        : await window.api.repos.addRemote({
+            connectionId: selectedTargetId,
+            remotePath: trimmedRemotePath
+          })
       if ('error' in result) {
         throw new Error(result.error)
       }
@@ -236,7 +284,8 @@ export function useRemoteRepo(
     fetchWorktrees,
     mountedRef,
     closeModal,
-    onGitRepoReady
+    onGitRepoReady,
+    runtimeEnvironmentId
   ])
 
   return {

--- a/src/renderer/src/components/sidebar/ForgetSshWorkspaceDialog.tsx
+++ b/src/renderer/src/components/sidebar/ForgetSshWorkspaceDialog.tsx
@@ -15,6 +15,11 @@ import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { runWorktreeDeleteWithToast } from './delete-worktree-flow'
 import type { SshWorkspaceForgetResolution } from './ssh-workspace-forget-resolution'
+import {
+  connectRuntimeEnvironmentSshTarget,
+  resyncRuntimeEnvironmentSshTargets
+} from '@/runtime/runtime-environment-ssh-state'
+import { selectRuntimeAwareSshTargetLabel } from '@/store/slices/runtime-environment-ssh'
 
 type ForgetSshWorkspaceModalData = {
   worktreeId: string
@@ -39,9 +44,11 @@ export function ForgetSshWorkspaceDialog(): React.JSX.Element | null {
     if (!targetId) {
       return ''
     }
+    const sshOwnerEnvironmentId =
+      resolution?.kind !== 'not-ssh' ? resolution?.sshOwnerEnvironmentId : null
     // Prefer the live label, then the removed target's last known label (ghost
     // host), then the raw id as a last resort.
-    return s.sshTargetLabels.get(targetId) ?? s.removedSshTargetLabels.get(targetId) ?? targetId
+    return selectRuntimeAwareSshTargetLabel(s, sshOwnerEnvironmentId ?? null, targetId)
   })
   const [busy, setBusy] = useState<null | 'reconnect' | 'forget'>(null)
   const mountedRef = useMountedRef()
@@ -66,8 +73,13 @@ export function ForgetSshWorkspaceDialog(): React.JSX.Element | null {
     }
     setBusy('reconnect')
     try {
-      await window.api.ssh.connect({ targetId: resolution.targetId })
+      await (resolution.sshOwnerEnvironmentId
+        ? connectRuntimeEnvironmentSshTarget(resolution.sshOwnerEnvironmentId, resolution.targetId)
+        : window.api.ssh.connect({ targetId: resolution.targetId }))
     } catch (err) {
+      if (resolution.sshOwnerEnvironmentId) {
+        void resyncRuntimeEnvironmentSshTargets(resolution.sshOwnerEnvironmentId).catch(() => {})
+      }
       if (mountedRef.current) {
         setBusy(null)
       }

--- a/src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
+++ b/src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
@@ -17,12 +17,15 @@ import {
   shouldDeferRemoteFileBrowserPasteResolve,
   type DirEntry
 } from './remote-file-browser-helpers'
-import { browseRuntimeServerDirectory } from '@/runtime/runtime-server-directory-browser'
+import {
+  browseRuntimeServerDirectory,
+  browseRuntimeSshDirectory
+} from '@/runtime/runtime-server-directory-browser'
 import { translate } from '@/i18n/i18n'
 
 type RemoteFileBrowserProps = (
-  | { targetId: string; runtimeEnvironmentId?: never }
-  | { runtimeEnvironmentId: string; targetId?: never }
+  | { targetId: string; runtimeEnvironmentId?: string }
+  | { targetId?: never; runtimeEnvironmentId: string }
 ) & {
   initialPath?: string
   onSelect: (path: string) => void
@@ -124,7 +127,9 @@ export function RemoteFileBrowser({
         return cached
       }
       const result = targetId
-        ? await window.api.ssh.browseDir({ targetId, dirPath })
+        ? runtimeEnvironmentId
+          ? await browseRuntimeSshDirectory(runtimeEnvironmentId, targetId, dirPath)
+          : await window.api.ssh.browseDir({ targetId, dirPath })
         : await browseRuntimeServerDirectory(
             requireRuntimeEnvironmentId(runtimeEnvironmentId),
             dirPath

--- a/src/renderer/src/components/sidebar/SshDisconnectedDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/SshDisconnectedDialog.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SshDisconnectedDialog } from './SshDisconnectedDialog'
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn()
+}))
+
+const environmentSshMocks = vi.hoisted(() => ({
+  connectRuntimeEnvironmentSshTarget: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastMocks.error
+  }
+}))
+
+vi.mock('@/runtime/runtime-environment-ssh-state', () => environmentSshMocks)
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+describe('SshDisconnectedDialog', () => {
+  beforeEach(() => {
+    toastMocks.error.mockReset()
+    environmentSshMocks.connectRuntimeEnvironmentSshTarget.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('keeps the dialog open when a runtime reconnect does not reach connected', async () => {
+    environmentSshMocks.connectRuntimeEnvironmentSshTarget.mockResolvedValue(null)
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <SshDisconnectedDialog
+        open
+        onOpenChange={onOpenChange}
+        targetId="ssh-p8"
+        targetLabel="p8"
+        status="disconnected"
+        sshOwnerEnvironmentId="linux-jae"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Reconnect' }))
+
+    await waitFor(() => expect(toastMocks.error).toHaveBeenCalledWith('Reconnection failed'))
+    expect(onOpenChange).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeEnabled()
+  })
+
+  it('closes the dialog after a runtime reconnect reaches connected', async () => {
+    environmentSshMocks.connectRuntimeEnvironmentSshTarget.mockResolvedValue({
+      targetId: 'ssh-p8',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0,
+      remotePlatform: 'linux'
+    })
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <SshDisconnectedDialog
+        open
+        onOpenChange={onOpenChange}
+        targetId="ssh-p8"
+        targetLabel="p8"
+        status="disconnected"
+        sshOwnerEnvironmentId="linux-jae"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Reconnect' }))
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
+++ b/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
@@ -76,9 +76,22 @@ export function SshDisconnectedDialog({
   const handleReconnect = useCallback(async () => {
     setConnecting(true)
     try {
-      await (sshOwnerEnvironmentId
-        ? connectRuntimeEnvironmentSshTarget(sshOwnerEnvironmentId, targetId)
-        : window.api.ssh.connect({ targetId }))
+      if (sshOwnerEnvironmentId) {
+        const connectedState = await connectRuntimeEnvironmentSshTarget(
+          sshOwnerEnvironmentId,
+          targetId
+        )
+        if (connectedState?.status !== 'connected') {
+          throw new Error(
+            translate(
+              'auto.components.sidebar.SshDisconnectedDialog.656368f3a2',
+              'Reconnection failed'
+            )
+          )
+        }
+      } else {
+        await window.api.ssh.connect({ targetId })
+      }
       if (mountedRef.current) {
         onOpenChange(false)
       }

--- a/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
+++ b/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
@@ -14,6 +14,7 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import { statusColor } from '@/components/settings/SshTargetCard'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
 import { translate } from '@/i18n/i18n'
+import { connectRuntimeEnvironmentSshTarget } from '@/runtime/runtime-environment-ssh-state'
 
 type SshDisconnectedDialogProps = {
   open: boolean
@@ -21,6 +22,7 @@ type SshDisconnectedDialogProps = {
   targetId: string
   targetLabel: string
   status: SshConnectionStatus
+  sshOwnerEnvironmentId?: string | null
 }
 
 const STATUS_MESSAGES: Partial<Record<SshConnectionStatus, string>> = {
@@ -65,7 +67,8 @@ export function SshDisconnectedDialog({
   onOpenChange,
   targetId,
   targetLabel,
-  status
+  status,
+  sshOwnerEnvironmentId = null
 }: SshDisconnectedDialogProps): React.JSX.Element {
   const [connecting, setConnecting] = useState(false)
   const mountedRef = useMountedRef()
@@ -73,7 +76,9 @@ export function SshDisconnectedDialog({
   const handleReconnect = useCallback(async () => {
     setConnecting(true)
     try {
-      await window.api.ssh.connect({ targetId })
+      await (sshOwnerEnvironmentId
+        ? connectRuntimeEnvironmentSshTarget(sshOwnerEnvironmentId, targetId)
+        : window.api.ssh.connect({ targetId }))
       if (mountedRef.current) {
         onOpenChange(false)
       }
@@ -91,7 +96,7 @@ export function SshDisconnectedDialog({
         setConnecting(false)
       }
     }
-  }, [mountedRef, targetId, onOpenChange])
+  }, [mountedRef, onOpenChange, sshOwnerEnvironmentId, targetId])
 
   const isConnecting =
     connecting ||

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -83,6 +83,13 @@ import { recordRendererCrashBreadcrumb } from '@/lib/crash-diagnostics'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { isRuntimeOwnedSshTargetId, parseExecutionHostId } from '../../../../shared/execution-host'
 import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constants'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  selectRuntimeAwareSshStatus,
+  selectRuntimeAwareSshTargetLabel
+} from '@/store/slices/runtime-environment-ssh'
+import { hydrateRuntimeEnvironmentSshState } from '@/runtime/runtime-environment-ssh-state'
+import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
 
 type WorktreeRenameRequest = {
   worktreeId: string
@@ -332,6 +339,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
   )
 
   // SSH disconnected state
+  const sshOwnerEnvironmentId = useAppStore((s) =>
+    repo?.connectionId && !isPairedWebClientWindow()
+      ? getExplicitRuntimeEnvironmentIdForWorktree(s, worktree.id)
+      : null
+  )
   const sshStatus = useAppStore((s) => {
     // Why: runtime-owned (per-workspace-env) SSH targets are hidden and their relay health is
     // owned by the runtime layer — Orca suppresses their ssh:state-changed broadcasts, so their
@@ -339,8 +351,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     if (!repo?.connectionId || isRuntimeOwnedSshTargetId(repo.connectionId)) {
       return null
     }
-    const state = s.sshConnectionStates.get(repo.connectionId)
-    return state?.status ?? 'disconnected'
+    return selectRuntimeAwareSshStatus(s, sshOwnerEnvironmentId, repo.connectionId)
   })
   const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
   // Why: a terminal view already carries its own in-pane reconnect overlay, so
@@ -372,8 +383,16 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // Why: read the target label from the store (populated during hydration in
   // useIpcEvents.ts) instead of calling listTargets IPC per card instance.
   const sshTargetLabel = useAppStore((s) =>
-    repo?.connectionId ? (s.sshTargetLabels.get(repo.connectionId) ?? '') : ''
+    repo?.connectionId
+      ? selectRuntimeAwareSshTargetLabel(s, sshOwnerEnvironmentId, repo.connectionId)
+      : ''
   )
+  useEffect(() => {
+    if (!sshOwnerEnvironmentId) {
+      return
+    }
+    void hydrateRuntimeEnvironmentSshState(sshOwnerEnvironmentId).catch(() => {})
+  }, [sshOwnerEnvironmentId])
 
   const gitIdentityDisplay = getWorktreeGitIdentityDisplay(worktree)
   const detachedHeadDisplay = gitIdentityDisplay?.kind === 'detached' ? gitIdentityDisplay : null
@@ -1933,6 +1952,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
           targetId={repo.connectionId}
           targetLabel={sshTargetLabel || repo.displayName}
           status={sshStatus ?? 'disconnected'}
+          sshOwnerEnvironmentId={sshOwnerEnvironmentId}
         />
       )}
 

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -208,8 +208,11 @@ import {
   ALL_EXECUTION_HOSTS_SCOPE,
   getRepoExecutionHostId,
   getSettingsFocusedExecutionHostId,
+  parseExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
+import { selectRuntimeAwareSshStatus } from '@/store/slices/runtime-environment-ssh'
+import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
 import { getRepoHeaderCreateState } from './repo-header-create-state'
 import type { PendingSidebarRowReveal, PendingSidebarWorktreeReveal } from '@/store/slices/ui'
 import { getRepositoryIconSectionId } from '@/components/settings/repository-settings-targets'
@@ -1765,6 +1768,31 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const activeStickyHostIndexRef = useRef<number | null>(null)
   const stickyRangeStartIndexRef = useRef(0)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
+  const sshStateByEnvironment = useAppStore((s) => s.sshStateByEnvironment)
+  const runtimeStatusByEnvironmentId = useAppStore((s) => s.runtimeStatusByEnvironmentId)
+  const getRepoSshStatus = useCallback(
+    (repo: Repo): ReturnType<typeof selectRuntimeAwareSshStatus> => {
+      if (!repo.connectionId) {
+        return null
+      }
+      const parsedOwner = parseExecutionHostId(getRepoExecutionHostId(repo))
+      const sshOwnerEnvironmentId =
+        !isPairedWebClientWindow() && parsedOwner?.kind === 'runtime'
+          ? parsedOwner.environmentId
+          : null
+      return selectRuntimeAwareSshStatus(
+        {
+          ...useAppStore.getState(),
+          runtimeStatusByEnvironmentId,
+          sshConnectionStates,
+          sshStateByEnvironment
+        },
+        sshOwnerEnvironmentId,
+        repo.connectionId
+      )
+    },
+    [runtimeStatusByEnvironmentId, sshConnectionStates, sshStateByEnvironment]
+  )
   const {
     folderWorkspacePathStatuses,
     fetchFolderWorkspacePathStatus,
@@ -4137,9 +4165,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 ? getRepoHeaderCreateState({
                     repo: row.repo,
                     label: row.label,
-                    sshStatus: row.repo.connectionId
-                      ? (sshConnectionStates.get(row.repo.connectionId)?.status ?? null)
-                      : null
+                    sshStatus: getRepoSshStatus(row.repo)
                   })
                 : null
               const projectGroupPathStatus =

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -6,7 +6,7 @@ import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { prepareActiveWorktreeFocusAfterDelete } from './active-worktree-focus-after-delete'
 import { showDeleteWorktreeFailureToast } from './delete-worktree-failure-toast'
 import { getWorkspaceDeleteLineage } from './workspace-delete-lineage'
-import { resolveSshWorkspaceForget } from './ssh-workspace-forget-resolution'
+import { resolveRuntimeAwareSshWorkspaceForget } from './runtime-aware-ssh-workspace-forget'
 import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
 import {
   isPathInsideOrEqual,
@@ -275,11 +275,7 @@ export function runWorktreeDelete(worktreeId: string): void {
       : null
   const sshResolution = isPairedWebClientWindow()
     ? { kind: 'not-ssh' as const }
-    : resolveSshWorkspaceForget({
-        repo,
-        sshConnectionStates: state.sshConnectionStates,
-        sshTargetLabels: state.sshTargetLabels
-      })
+    : resolveRuntimeAwareSshWorkspaceForget(state, repo, worktreeId)
   if (sshResolution.kind === 'ghost' || sshResolution.kind === 'disconnected') {
     // Why no lineage-children warning here (unlike the normal path below):
     // forget-local is metadata-only and per-worktree, so it can't fail on a

--- a/src/renderer/src/components/sidebar/runtime-aware-ssh-workspace-forget.ts
+++ b/src/renderer/src/components/sidebar/runtime-aware-ssh-workspace-forget.ts
@@ -1,0 +1,35 @@
+import type { AppState } from '@/store/types'
+import type { Repo } from '../../../../shared/types'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  selectRuntimeAwareSshStatus,
+  selectRuntimeAwareSshTargetRemoved
+} from '@/store/slices/runtime-environment-ssh'
+import {
+  resolveSshWorkspaceForget,
+  type SshWorkspaceForgetResolution
+} from './ssh-workspace-forget-resolution'
+
+export function resolveRuntimeAwareSshWorkspaceForget(
+  state: AppState,
+  repo: Pick<Repo, 'connectionId'> | null,
+  worktreeId: string
+): SshWorkspaceForgetResolution {
+  const sshOwnerEnvironmentId = repo?.connectionId
+    ? getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    : null
+  const connectionStatus = repo?.connectionId
+    ? selectRuntimeAwareSshStatus(state, sshOwnerEnvironmentId, repo.connectionId)
+    : null
+  const targetRemoved = repo?.connectionId
+    ? selectRuntimeAwareSshTargetRemoved(state, sshOwnerEnvironmentId, repo.connectionId)
+    : false
+
+  return resolveSshWorkspaceForget({
+    repo,
+    sshConnectionStates: state.sshConnectionStates,
+    sshTargetLabels: state.sshTargetLabels,
+    sshOwnerEnvironmentId,
+    ...(sshOwnerEnvironmentId ? { targetConfigured: !targetRemoved, connectionStatus } : {})
+  })
+}

--- a/src/renderer/src/components/sidebar/runtime-aware-ssh-workspace-forget.ts
+++ b/src/renderer/src/components/sidebar/runtime-aware-ssh-workspace-forget.ts
@@ -10,6 +10,7 @@ import {
   type SshWorkspaceForgetResolution
 } from './ssh-workspace-forget-resolution'
 
+/** Resolve workspace deletion behavior against the SSH state owned by its execution runtime. */
 export function resolveRuntimeAwareSshWorkspaceForget(
   state: AppState,
   repo: Pick<Repo, 'connectionId'> | null,

--- a/src/renderer/src/components/sidebar/ssh-workspace-forget-resolution.test.ts
+++ b/src/renderer/src/components/sidebar/ssh-workspace-forget-resolution.test.ts
@@ -67,4 +67,20 @@ describe('resolveSshWorkspaceForget', () => {
     })
     expect(result).toEqual({ kind: 'disconnected', targetId: 'ssh-live', status: 'disconnected' })
   })
+
+  it('uses the owning runtime SSH state instead of same-named local state', () => {
+    const result = resolveSshWorkspaceForget({
+      repo: { connectionId: 'ssh-p8' },
+      sshConnectionStates: stateMap({ 'ssh-p8': 'auth-failed' }),
+      sshTargetLabels: new Map(),
+      sshOwnerEnvironmentId: 'env-linux',
+      targetConfigured: true,
+      connectionStatus: 'connected'
+    })
+    expect(result).toEqual({
+      kind: 'connected',
+      targetId: 'ssh-p8',
+      sshOwnerEnvironmentId: 'env-linux'
+    })
+  })
 })

--- a/src/renderer/src/components/sidebar/ssh-workspace-forget-resolution.ts
+++ b/src/renderer/src/components/sidebar/ssh-workspace-forget-resolution.ts
@@ -1,5 +1,5 @@
 import type { Repo } from '../../../../shared/types'
-import type { SshConnectionState } from '../../../../shared/ssh-types'
+import type { SshConnectionState, SshConnectionStatus } from '../../../../shared/ssh-types'
 import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 
 /**
@@ -11,19 +11,27 @@ import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 export type SshWorkspaceForgetResolution =
   | { kind: 'not-ssh' }
   // Target exists and the relay is connected — normal remote removal works.
-  | { kind: 'connected'; targetId: string }
+  | { kind: 'connected'; targetId: string; sshOwnerEnvironmentId?: string | null }
   // Target still configured but not connected — offer Reconnect & Delete plus
   // a local-only forget fallback.
-  | { kind: 'disconnected'; targetId: string; status: SshConnectionState['status'] }
+  | {
+      kind: 'disconnected'
+      targetId: string
+      status: SshConnectionState['status']
+      sshOwnerEnvironmentId?: string | null
+    }
   // Target was removed; only a project-only "ghost" host remains. Reconnect is
   // impossible, so forget-from-Orca is the only path.
-  | { kind: 'ghost'; targetId: string }
+  | { kind: 'ghost'; targetId: string; sshOwnerEnvironmentId?: string | null }
 
 export function resolveSshWorkspaceForget(args: {
   repo: Pick<Repo, 'connectionId'> | null | undefined
   sshConnectionStates: ReadonlyMap<string, SshConnectionState>
   // Keys are configured SSH target ids (targets that still exist in settings).
   sshTargetLabels: ReadonlyMap<string, string>
+  sshOwnerEnvironmentId?: string | null
+  targetConfigured?: boolean
+  connectionStatus?: SshConnectionStatus | null
 }): SshWorkspaceForgetResolution {
   const connectionId = args.repo?.connectionId?.trim()
   // Why: runtime-owned (ephemeral-VM) SSH targets manage their own lifecycle and
@@ -32,19 +40,27 @@ export function resolveSshWorkspaceForget(args: {
     return { kind: 'not-ssh' }
   }
 
-  const isConfigured = args.sshTargetLabels.has(connectionId)
-  const status = args.sshConnectionStates.get(connectionId)?.status
+  const isConfigured = args.targetConfigured ?? args.sshTargetLabels.has(connectionId)
+  const status = args.connectionStatus ?? args.sshConnectionStates.get(connectionId)?.status
+  const ownership = args.sshOwnerEnvironmentId
+    ? { sshOwnerEnvironmentId: args.sshOwnerEnvironmentId }
+    : {}
 
   // Why: a target the user removed leaves repos pinned to a dead id with no
   // configured target — the grey ghost host. Reconnect can never succeed, so
   // the only escape is to forget it from Orca.
   if (!isConfigured) {
-    return { kind: 'ghost', targetId: connectionId }
+    return { kind: 'ghost', targetId: connectionId, ...ownership }
   }
 
   if (status === 'connected') {
-    return { kind: 'connected', targetId: connectionId }
+    return { kind: 'connected', targetId: connectionId, ...ownership }
   }
 
-  return { kind: 'disconnected', targetId: connectionId, status: status ?? 'disconnected' }
+  return {
+    kind: 'disconnected',
+    targetId: connectionId,
+    status: status ?? 'disconnected',
+    ...ownership
+  }
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -6691,6 +6691,7 @@ export function connectPanePty(
       // (Guard the map's presence for minimal test stubs that omit it; an absent
       // map is "not hydrated", not "target gone".)
       if (
+        runtimeEnvironmentId === null &&
         !isRuntimeOwnedSshTargetId(connectionId) &&
         storeState.sshTargetLabels instanceof Map &&
         !storeState.sshTargetLabels.has(connectionId)
@@ -6703,6 +6704,7 @@ export function connectPanePty(
           : null
       const gate = resolveSshPaneConnectGate({
         connectionId,
+        sshOwnerEnvironmentId: runtimeEnvironmentId,
         sshStatus: storeState.sshConnectionStates.get(connectionId)?.status,
         isDeferredTarget: storeState.deferredSshReconnectTargets.includes(connectionId),
         restoredLeafSessionId,

--- a/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.test.ts
@@ -84,4 +84,19 @@ describe('resolveSshPaneConnectGate', () => {
     })
     expect(gate.enterDeferredFlow).toBe(false)
   })
+
+  it('does not use the desktop SSH gate for a target owned by a remote Orca server', () => {
+    const gate = resolveSshPaneConnectGate({
+      ...BASE,
+      connectionId: 'ssh-p8',
+      sshOwnerEnvironmentId: 'env-linux',
+      isDeferredTarget: true,
+      deferredTabSessionId: 'ssh:ssh-p8@@local-session'
+    })
+    expect(gate).toEqual({
+      pendingSessionId: null,
+      enterDeferredFlow: false,
+      sshConnected: false
+    })
+  })
 })

--- a/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.ts
+++ b/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.ts
@@ -16,6 +16,7 @@ export type SshPaneConnectGate = {
 // deferred-connect flow first and which session it should reattach.
 export function resolveSshPaneConnectGate(input: {
   connectionId: string
+  sshOwnerEnvironmentId?: string | null
   sshStatus: string | undefined
   isDeferredTarget: boolean
   restoredLeafSessionId: string | null
@@ -24,6 +25,11 @@ export function resolveSshPaneConnectGate(input: {
   hasLeafSessionMap: boolean
 }): SshPaneConnectGate {
   const sshConnected = input.sshStatus === 'connected'
+  if (input.sshOwnerEnvironmentId) {
+    // Nested SSH is owned by the remote Orca runtime and has no local relay or
+    // persisted local SSH PTY id for this renderer to reconnect.
+    return { pendingSessionId: null, enterDeferredFlow: false, sshConnected }
+  }
   // Why: the deferred maps can miss a tab (e.g. activeConnectionIdsAtShutdown
   // wasn't persisted, so restore registered no deferred target). The tab's own
   // restored app SSH pty id still names the session — reattach it rather than

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -23,6 +23,12 @@ import {
 } from '@/components/automations/automation-run-output-snapshot'
 import { translate } from '@/i18n/i18n'
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import { getExplicitRuntimeOwnerEnvironmentId } from '@/lib/repo-runtime-owner'
+import {
+  connectRuntimeEnvironmentSshTarget,
+  hydrateRuntimeEnvironmentSshState
+} from '@/runtime/runtime-environment-ssh-state'
+import { selectRuntimeAwareSshStatus } from '@/store/slices/runtime-environment-ssh'
 
 const AUTOMATIONS_CHANGED_EVENT = 'orca:automations-changed'
 const activeReuseDispatchTabIds = new Set<string>()
@@ -86,26 +92,45 @@ export function useAutomationDispatchEvents(): void {
 
         try {
           if (repo.connectionId) {
-            const needsPrompt = await window.api.ssh.needsPassphrasePrompt({
-              targetId: repo.connectionId
-            })
-            if (needsPrompt) {
-              await markDispatchResult({
-                runId: run.id,
-                status: 'skipped_needs_interactive_auth',
-                workspaceId: dispatchWorkspaceId,
-                workspaceDisplayName: dispatchWorkspaceDisplayName,
-                error: translate(
-                  'auto.hooks.useAutomationDispatchEvents.16a21d6413',
-                  'SSH reconnect requires interactive credentials.'
-                )
+            const sshOwnerEnvironmentId = getExplicitRuntimeOwnerEnvironmentId(
+              { repos: [repo], settings: state.settings },
+              repo.id
+            )
+            if (sshOwnerEnvironmentId) {
+              await hydrateRuntimeEnvironmentSshState(sshOwnerEnvironmentId)
+            } else {
+              const needsPrompt = await window.api.ssh.needsPassphrasePrompt({
+                targetId: repo.connectionId
               })
-              return
+              if (needsPrompt) {
+                await markDispatchResult({
+                  runId: run.id,
+                  status: 'skipped_needs_interactive_auth',
+                  workspaceId: dispatchWorkspaceId,
+                  workspaceDisplayName: dispatchWorkspaceDisplayName,
+                  error: translate(
+                    'auto.hooks.useAutomationDispatchEvents.16a21d6413',
+                    'SSH reconnect requires interactive credentials.'
+                  )
+                })
+                return
+              }
             }
-            const sshState = await window.api.ssh.getState({ targetId: repo.connectionId })
-            if (sshState?.status !== 'connected') {
+            const sshStatus = sshOwnerEnvironmentId
+              ? selectRuntimeAwareSshStatus(
+                  useAppStore.getState(),
+                  sshOwnerEnvironmentId,
+                  repo.connectionId
+                )
+              : (await window.api.ssh.getState({ targetId: repo.connectionId }))?.status
+            if (sshStatus !== 'connected') {
               try {
-                const connected = await window.api.ssh.connect({ targetId: repo.connectionId })
+                const connected = sshOwnerEnvironmentId
+                  ? await connectRuntimeEnvironmentSshTarget(
+                      sshOwnerEnvironmentId,
+                      repo.connectionId
+                    )
+                  : await window.api.ssh.connect({ targetId: repo.connectionId })
                 if (connected?.status !== 'connected') {
                   throw new Error('SSH target is unavailable.')
                 }

--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -159,37 +159,55 @@ describe('useComposerState host-context boundaries', () => {
     expect(submitSection).toContain('runtimeEnvironmentId: folderTargetRuntimeEnvironmentId')
   })
 
-  it('detects composer agents against the repo host: SSH, then runtime, then local (#7082)', () => {
+  it('detects composer agents against the repo owner, including runtime-owned SSH (#7082)', () => {
     // Why: a repo owned by a paired runtime must show the runtime's agents, not
-    // the local machine's. SSH stays first priority; runtime falls through before
-    // local so an SSH repo never double-detects. Regression guard for #7082.
+    // the local machine's. A connectionId nested under that runtime is sent to
+    // the runtime's remote-agent probe, never the desktop SSH provider.
     const selectorSection = sourceBetween(
       HOOK_SOURCE,
       'const detectedAgentList = useAppStore',
       'const ensureDetectedAgents = useAppStore'
     )
+    expect(selectorSection).toContain('if (runtimeAgentDetectionKey) {')
+    expect(selectorSection).toContain('s.runtimeDetectedAgentIds[runtimeAgentDetectionKey]')
     expect(selectorSection).toContain('if (isRemote) {')
     expect(selectorSection).toContain('s.remoteDetectedAgentIds[connectionId]')
-    expect(selectorSection).toContain('if (runtimeEnvironmentId) {')
-    expect(selectorSection).toContain('s.runtimeDetectedAgentIds[runtimeEnvironmentId]')
     expect(selectorSection).toContain('return s.detectedAgentIds')
-    // SSH branch is checked before the runtime branch.
-    expect(selectorSection.indexOf('if (isRemote) {')).toBeLessThan(
-      selectorSection.indexOf('if (runtimeEnvironmentId) {')
+    expect(selectorSection.indexOf('if (runtimeAgentDetectionKey) {')).toBeLessThan(
+      selectorSection.indexOf('if (isRemote) {')
     )
 
     expect(HOOK_SOURCE).toContain(
       'const runtimeEnvironmentId = selectedRepoSettings?.activeRuntimeEnvironmentId?.trim() || null'
     )
 
-    // Detection effect fans out to the same three hosts in the same order and
-    // re-runs when the runtime environment changes.
-    const detectSection = sourceBetween(HOOK_SOURCE, 'const detect = isRemote', 'void detect.then')
+    const detectSection = sourceBetween(
+      HOOK_SOURCE,
+      'const detect = runtimeEnvironmentId',
+      'void detect.then'
+    )
+    expect(detectSection).toContain(
+      'ensureRuntimeDetectedAgents(runtimeEnvironmentId, connectionId)'
+    )
     expect(detectSection).toContain('ensureRemoteDetectedAgents(connectionId)')
-    expect(detectSection).toContain('ensureRuntimeDetectedAgents(runtimeEnvironmentId)')
     expect(detectSection).toContain('ensureDetectedAgents()')
     expect(HOOK_SOURCE).toContain(
       '}, [connectionId, runtimeEnvironmentId, isRemote, selectedRepoSshStatus, disabledTuiAgents])'
+    )
+  })
+
+  it('routes a runtime-owned repo SSH gate through the owning Orca server', () => {
+    const connectSection = sourceBetween(
+      HOOK_SOURCE,
+      'const onConnectSelectedRepo',
+      'const onConnectSelectedProjectGroup'
+    )
+    expect(connectSection).toContain('getRuntimeEnvironmentIdForRepo')
+    expect(connectSection).toContain('selectRuntimeAwareSshStatus')
+    expect(connectSection).toContain('connectRuntimeEnvironmentSshTarget')
+    expect(connectSection).toContain('window.api.ssh.connect({ targetId })')
+    expect(connectSection.indexOf('connectRuntimeEnvironmentSshTarget')).toBeLessThan(
+      connectSection.indexOf('window.api.ssh.connect({ targetId })')
     )
   })
 

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -30,6 +30,10 @@ import {
 import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import {
+  connectRuntimeEnvironmentSshTarget,
+  hydrateRuntimeEnvironmentSshState
+} from '@/runtime/runtime-environment-ssh-state'
 import { resolveWorktreeCreateBaseBranch } from '@/runtime/worktree-create-base'
 import {
   buildTaskSourceContextFromRepo,
@@ -142,7 +146,12 @@ import {
 } from '../../../shared/execution-host'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
 import { queueNewWorkspaceTerminalFocus } from '@/lib/new-workspace-terminal-focus'
-import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import {
+  getRuntimeEnvironmentIdForRepo,
+  getSettingsForRepoRuntimeOwner
+} from '@/lib/repo-runtime-owner'
+import { selectRuntimeAwareSshStatus } from '@/store/slices/runtime-environment-ssh'
+import { getRuntimeAgentDetectionKey } from '@/lib/runtime-agent-detection-key'
 import { getSuggestedCreatureName } from '@/components/sidebar/worktree-name-suggestions'
 import type { SmartWorkspaceNameSelection } from '@/components/new-workspace/SmartWorkspaceNameField'
 import type { SmartNameMode } from '@/components/new-workspace/smart-workspace-source-results'
@@ -847,6 +856,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       selectedRepo?.id ?? null
     )
   }, [selectedRepo, settings])
+  const runtimeEnvironmentId = selectedRepoSettings?.activeRuntimeEnvironmentId?.trim() || null
   // Why: key the recipe load on the repo's stable identity, not the whole repo
   // object. `updateRepo` (e.g. saving the setup-startup policy from this very
   // composer, or a GitHub upstream backfill) replaces the selected repo object
@@ -916,14 +926,25 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     selectedRepoIsGit
   ])
   const selectedRepoConnectionId = selectedRepo?.connectionId ?? null
-  const selectedRepoSshState = selectedRepoConnectionId
-    ? (sshConnectionStates.get(selectedRepoConnectionId) ?? null)
-    : null
+  const selectedRepoOwnerSshStatus = useAppStore((state) =>
+    selectedRepoConnectionId
+      ? selectRuntimeAwareSshStatus(state, runtimeEnvironmentId, selectedRepoConnectionId)
+      : null
+  )
   const { selectedRepoSshStatus, selectedRepoRequiresConnection, selectedRepoConnectInProgress } =
     getSelectedRepoSshGate({
       connectionId: selectedRepoConnectionId,
-      status: selectedRepoSshState?.status ?? null
+      status: selectedRepoOwnerSshStatus
     })
+  useEffect(() => {
+    if (!runtimeEnvironmentId || !selectedRepoConnectionId) {
+      return
+    }
+    // A repo can be owned by a paired Orca server while its connectionId names
+    // an SSH target configured on that server. Hydrate that server's bucket so
+    // the composer never consults the desktop's unrelated local SSH map.
+    void hydrateRuntimeEnvironmentSshState(runtimeEnvironmentId).catch(() => {})
+  }, [runtimeEnvironmentId, selectedRepoConnectionId])
   const repoIdRef = useRef(repoId)
   repoIdRef.current = repoId
   const setRepoId = useCallback(
@@ -1134,13 +1155,15 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // not the local machine.
   const connectionId = selectedRepoConnectionId
   const isRemote = typeof connectionId === 'string'
-  const runtimeEnvironmentId = selectedRepoSettings?.activeRuntimeEnvironmentId?.trim() || null
+  const runtimeAgentDetectionKey = runtimeEnvironmentId
+    ? getRuntimeAgentDetectionKey(runtimeEnvironmentId, connectionId)
+    : null
   const detectedAgentList = useAppStore((s) => {
+    if (runtimeAgentDetectionKey) {
+      return s.runtimeDetectedAgentIds[runtimeAgentDetectionKey] ?? null
+    }
     if (isRemote) {
       return s.remoteDetectedAgentIds[connectionId] ?? null
-    }
-    if (runtimeEnvironmentId) {
-      return s.runtimeDetectedAgentIds[runtimeEnvironmentId] ?? null
     }
     return s.detectedAgentIds
   })
@@ -1714,10 +1737,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       return
     }
     let cancelled = false
-    const detect = isRemote
-      ? ensureRemoteDetectedAgents(connectionId)
-      : runtimeEnvironmentId
-        ? ensureRuntimeDetectedAgents(runtimeEnvironmentId)
+    const detect = runtimeEnvironmentId
+      ? ensureRuntimeDetectedAgents(runtimeEnvironmentId, connectionId)
+      : isRemote
+        ? ensureRemoteDetectedAgents(connectionId)
         : ensureDetectedAgents()
     void detect.then((ids) => {
       if (cancelled) {
@@ -1818,13 +1841,21 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     if (liveRepo?.connectionId !== targetId) {
       return
     }
-    const liveStatus = liveState.sshConnectionStates.get(targetId)?.status ?? null
+    const sshOwnerEnvironmentId = liveRepo
+      ? getRuntimeEnvironmentIdForRepo(
+          { repos: [liveRepo], settings: liveState.settings },
+          liveRepo.id
+        )
+      : null
+    const liveStatus = selectRuntimeAwareSshStatus(liveState, sshOwnerEnvironmentId, targetId)
     if (liveStatus === 'connected' || isSshConnectInProgress(liveStatus)) {
       return
     }
 
     try {
-      await window.api.ssh.connect({ targetId })
+      await (sshOwnerEnvironmentId
+        ? connectRuntimeEnvironmentSshTarget(sshOwnerEnvironmentId, targetId)
+        : window.api.ssh.connect({ targetId }))
     } catch (error) {
       toast.error(
         error instanceof Error

--- a/src/renderer/src/hooks/useDetectedAgents.ts
+++ b/src/renderer/src/hooks/useDetectedAgents.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useAppStore } from '@/store'
 import type { TuiAgent } from '../../../shared/types'
+import { getRuntimeAgentDetectionKey } from '@/lib/runtime-agent-detection-key'
 
 export type UseDetectedAgentsResult = {
   /** Null while detection is in flight on first load. */
@@ -16,7 +17,7 @@ export type UseDetectedAgentsResult = {
 export type AgentDetectionTarget =
   | { kind: 'local' }
   | { kind: 'ssh'; connectionId: string }
-  | { kind: 'runtime'; environmentId: string }
+  | { kind: 'runtime'; environmentId: string; connectionId?: string | null }
 
 function normalizeAgentDetectionTarget(
   target: AgentDetectionTarget | string | null | undefined
@@ -62,6 +63,11 @@ export function useDetectedAgents(
       : target?.kind === 'runtime'
         ? target.environmentId
         : null
+  const runtimeDetectionKey =
+    target?.kind === 'runtime'
+      ? getRuntimeAgentDetectionKey(target.environmentId, target.connectionId)
+      : null
+  const runtimeConnectionId = target?.kind === 'runtime' ? target.connectionId : null
 
   const detectedIds = useAppStore((s) => {
     if (isUnknown) {
@@ -70,8 +76,8 @@ export function useDetectedAgents(
     if (targetKind === 'ssh' && targetId) {
       return s.remoteDetectedAgentIds[targetId] ?? null
     }
-    if (targetKind === 'runtime' && targetId) {
-      return s.runtimeDetectedAgentIds[targetId] ?? null
+    if (targetKind === 'runtime' && runtimeDetectionKey) {
+      return s.runtimeDetectedAgentIds[runtimeDetectionKey] ?? null
     }
     return s.detectedAgentIds
   })
@@ -82,8 +88,8 @@ export function useDetectedAgents(
     if (targetKind === 'ssh' && targetId) {
       return s.isDetectingRemoteAgents[targetId] ?? false
     }
-    if (targetKind === 'runtime' && targetId) {
-      return s.isDetectingRuntimeAgents[targetId] ?? false
+    if (targetKind === 'runtime' && runtimeDetectionKey) {
+      return s.isDetectingRuntimeAgents[runtimeDetectionKey] ?? false
     }
     return s.isDetectingAgents
   })
@@ -100,8 +106,8 @@ export function useDetectedAgents(
     const emptyRetryKey =
       targetKind === 'ssh' && targetId
         ? `ssh:${targetId}`
-        : targetKind === 'runtime' && targetId
-          ? `runtime:${targetId}`
+        : targetKind === 'runtime' && runtimeDetectionKey
+          ? `runtime:${runtimeDetectionKey}`
           : null
     if (targetKind === 'ssh' && targetId) {
       if (detectedIds === null) {
@@ -116,19 +122,29 @@ export function useDetectedAgents(
     } else if (targetKind === 'runtime' && targetId) {
       if (detectedIds === null) {
         retriedEmptyTargetRef.current = emptyRetryKey
-        void ensureRuntime(targetId)
+        void ensureRuntime(targetId, runtimeConnectionId)
       } else if (detectedIds.length === 0 && retriedEmptyTargetRef.current !== emptyRetryKey) {
         // Why: remote `orca serve` users can install/fix PATH without reconnecting;
         // retry once per mounted surface so the menu can pick that up.
         retriedEmptyTargetRef.current = emptyRetryKey
-        void ensureRuntime(targetId)
+        void ensureRuntime(targetId, runtimeConnectionId)
       }
     } else {
       if (detectedIds === null) {
         void ensureLocal()
       }
     }
-  }, [isUnknown, targetKind, targetId, detectedIds, ensureLocal, ensureRemote, ensureRuntime])
+  }, [
+    isUnknown,
+    targetKind,
+    targetId,
+    runtimeDetectionKey,
+    runtimeConnectionId,
+    detectedIds,
+    ensureLocal,
+    ensureRemote,
+    ensureRuntime
+  ])
 
   return { detectedIds, isLoading, isRefreshing, refresh }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3690,7 +3690,9 @@
           "35831a7312": "Adding...",
           "lockedDescription": "Enter the path to a Git repository on {{value0}}.",
           "lockedDisconnected": "{{value0}} is disconnected.",
-          "93e0221434": "Connect"
+          "93e0221434": "Connect",
+          "noServerSshTargets": "No SSH targets configured on this Orca server.",
+          "backToHostMenu": "Back to host menu"
         },
         "AddRepoServerStartStep": {
           "ae990c86a0": "Back to add options",
@@ -4667,7 +4669,9 @@
           "sshImportSynced": "Synced {{value0}} host{{value1}}.",
           "sshImportFailed": "Failed to import SSH config.",
           "importing": "Importing...",
-          "importSshConfig": "Import ~/.ssh/config"
+          "importSshConfig": "Import ~/.ssh/config",
+          "sshServerTitle": "Add SSH host to {{value0}}",
+          "sshServerDescription": "Save this SSH machine on {{value0}} so projects and workspaces run through that server."
         },
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "Reconnection failed",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3675,7 +3675,9 @@
           "35831a7312": "Agregando...",
           "lockedDescription": "Introduce la ruta a un repositorio Git en {{value0}}.",
           "lockedDisconnected": "{{value0}} está desconectado.",
-          "93e0221434": "Conectar"
+          "93e0221434": "Conectar",
+          "noServerSshTargets": "No SSH targets configured on this Orca server.",
+          "backToHostMenu": "Back to host menu"
         },
         "AddRepoServerStartStep": {
           "ae990c86a0": "Volver a opciones de agregado",
@@ -4667,7 +4669,9 @@
           "sshImportFailed": "No se pudo importar la configuración SSH.",
           "importing": "Importando...",
           "importSshConfig": "Importar ~/.ssh/config",
-          "sshPersistenceDefault": "Los terminales remotos en este host seguirán activos hasta que los cierres o restablezcas el relay."
+          "sshPersistenceDefault": "Los terminales remotos en este host seguirán activos hasta que los cierres o restablezcas el relay.",
+          "sshServerTitle": "Add SSH host to {{value0}}",
+          "sshServerDescription": "Save this SSH machine on {{value0}} so projects and workspaces run through that server."
         },
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "Error de reconexión",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3656,7 +3656,9 @@
           "35831a7312": "追加中...",
           "lockedDescription": "{{value0}} 上の Git リポジトリへのパスを入力してください。",
           "lockedDisconnected": "{{value0}} は切断されています。",
-          "93e0221434": "接続"
+          "93e0221434": "接続",
+          "noServerSshTargets": "No SSH targets configured on this Orca server.",
+          "backToHostMenu": "Back to host menu"
         },
         "AddRepoServerStartStep": {
           "ae990c86a0": "オプションの追加に戻る",
@@ -4667,7 +4669,9 @@
           "sshImportFailed": "SSH 構成のインポートに失敗しました。",
           "importing": "インポート中...",
           "importSshConfig": "~/.ssh/config をインポートします",
-          "sshPersistenceDefault": "このホスト上のリモートターミナルは、終了するかリレーをリセットするまで動作し続けます。"
+          "sshPersistenceDefault": "このホスト上のリモートターミナルは、終了するかリレーをリセットするまで動作し続けます。",
+          "sshServerTitle": "Add SSH host to {{value0}}",
+          "sshServerDescription": "Save this SSH machine on {{value0}} so projects and workspaces run through that server."
         },
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "再接続に失敗しました",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3656,7 +3656,9 @@
           "35831a7312": "추가 중...",
           "lockedDescription": "{{value0}}의 Git 리포지토리 경로를 입력하세요.",
           "lockedDisconnected": "{{value0}} 연결이 끊어졌습니다.",
-          "93e0221434": "연결"
+          "93e0221434": "연결",
+          "noServerSshTargets": "No SSH targets configured on this Orca server.",
+          "backToHostMenu": "Back to host menu"
         },
         "AddRepoServerStartStep": {
           "ae990c86a0": "옵션 추가로 돌아가기",
@@ -4667,7 +4669,9 @@
           "sshImportFailed": "SSH 구성을 가져오지 못했습니다.",
           "importing": "가져오는 중...",
           "importSshConfig": "~/.ssh/config 가져오기",
-          "sshPersistenceDefault": "이 호스트의 원격 터미널은 종료하거나 릴레이를 재설정할 때까지 계속 실행됩니다."
+          "sshPersistenceDefault": "이 호스트의 원격 터미널은 종료하거나 릴레이를 재설정할 때까지 계속 실행됩니다.",
+          "sshServerTitle": "Add SSH host to {{value0}}",
+          "sshServerDescription": "Save this SSH machine on {{value0}} so projects and workspaces run through that server."
         },
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "재연결 실패",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3656,7 +3656,9 @@
           "35831a7312": "添加...",
           "lockedDescription": "输入 {{value0}} 上 Git 仓库的路径。",
           "lockedDisconnected": "{{value0}} 已断开连接。",
-          "93e0221434": "连接"
+          "93e0221434": "连接",
+          "noServerSshTargets": "No SSH targets configured on this Orca server.",
+          "backToHostMenu": "Back to host menu"
         },
         "AddRepoServerStartStep": {
           "ae990c86a0": "返回添加选项",
@@ -4667,7 +4669,9 @@
           "sshImportFailed": "导入 SSH 配置失败。",
           "importing": "正在导入...",
           "importSshConfig": "导入 ~/.ssh/config",
-          "sshPersistenceDefault": "此主机上的远程终端会保持运行，直到你结束它们或重置中继。"
+          "sshPersistenceDefault": "此主机上的远程终端会保持运行，直到你结束它们或重置中继。",
+          "sshServerTitle": "Add SSH host to {{value0}}",
+          "sshServerDescription": "Save this SSH machine on {{value0}} so projects and workspaces run through that server."
         },
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "重新连接失败",

--- a/src/renderer/src/lib/runtime-agent-detection-key.ts
+++ b/src/renderer/src/lib/runtime-agent-detection-key.ts
@@ -14,11 +14,13 @@ export function getRuntimeAgentDetectionKey(
   return targetId ? `${environmentId}${RUNTIME_SSH_AGENT_KEY_SEPARATOR}${targetId}` : environmentId
 }
 
+/** Extract the owning runtime environment from a direct or nested-SSH agent cache key. */
 export function getRuntimeAgentDetectionEnvironmentId(key: string): string {
   const separatorIndex = key.indexOf(RUNTIME_SSH_AGENT_KEY_SEPARATOR)
   return separatorIndex === -1 ? key : key.slice(0, separatorIndex)
 }
 
+/** Test whether an agent cache key belongs to a runtime host or one of its SSH targets. */
 export function runtimeAgentDetectionKeyMatches(
   key: string,
   environmentId: string,

--- a/src/renderer/src/lib/runtime-agent-detection-key.ts
+++ b/src/renderer/src/lib/runtime-agent-detection-key.ts
@@ -1,0 +1,30 @@
+const RUNTIME_SSH_AGENT_KEY_SEPARATOR = '\u0000ssh:'
+
+/**
+ * Runtime agent probes normally key by environment id. A repo reached through
+ * an SSH target owned by that runtime needs a distinct cache entry, otherwise
+ * the runtime host's own agents can be reused for the nested SSH host (or vice
+ * versa) when the user switches projects.
+ */
+export function getRuntimeAgentDetectionKey(
+  environmentId: string,
+  connectionId?: string | null
+): string {
+  const targetId = connectionId?.trim()
+  return targetId ? `${environmentId}${RUNTIME_SSH_AGENT_KEY_SEPARATOR}${targetId}` : environmentId
+}
+
+export function getRuntimeAgentDetectionEnvironmentId(key: string): string {
+  const separatorIndex = key.indexOf(RUNTIME_SSH_AGENT_KEY_SEPARATOR)
+  return separatorIndex === -1 ? key : key.slice(0, separatorIndex)
+}
+
+export function runtimeAgentDetectionKeyMatches(
+  key: string,
+  environmentId: string,
+  connectionId?: string | null
+): boolean {
+  return connectionId
+    ? key === getRuntimeAgentDetectionKey(environmentId, connectionId)
+    : getRuntimeAgentDetectionEnvironmentId(key) === environmentId
+}

--- a/src/renderer/src/runtime/runtime-environment-ssh-state.test.ts
+++ b/src/renderer/src/runtime/runtime-environment-ssh-state.test.ts
@@ -8,6 +8,7 @@ import {
   resyncRuntimeEnvironmentSshTargets
 } from './runtime-environment-ssh-state'
 import { callRuntimeRpc } from './runtime-rpc-client'
+import { getRuntimeAgentDetectionKey } from '@/lib/runtime-agent-detection-key'
 
 vi.mock('./runtime-rpc-client', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
@@ -134,6 +135,19 @@ describe('hydrateRuntimeEnvironmentSshState', () => {
 })
 
 describe('applyRuntimeEnvironmentSshStateChanged', () => {
+  it('clears the nested target agent cache when its relay disconnects', () => {
+    const envId = nextEnvId()
+    const detectionKey = getRuntimeAgentDetectionKey(envId, 'ssh-1')
+    useAppStore.setState({ runtimeDetectedAgentIds: { [detectionKey]: ['codex'] } })
+    useAppStore
+      .getState()
+      .setEnvironmentSshTargetsMetadata(envId, [{ id: 'ssh-1', label: 'devbox' }])
+
+    applyRuntimeEnvironmentSshStateChanged(envId, 'ssh-1', connState('ssh-1', 'disconnected'))
+
+    expect(useAppStore.getState().runtimeDetectedAgentIds[detectionKey]).toBeUndefined()
+  })
+
   it('applies a known target state directly into the owning bucket without RPC', () => {
     const envId = nextEnvId()
     useAppStore

--- a/src/renderer/src/runtime/runtime-environment-ssh-state.ts
+++ b/src/renderer/src/runtime/runtime-environment-ssh-state.ts
@@ -131,6 +131,11 @@ export function applyRuntimeEnvironmentSshStateChanged(
   state: SshConnectionState
 ): void {
   const store = useAppStore.getState()
+  if (state.status !== 'connected') {
+    // Agent availability on a nested SSH host is tied to its live relay; a
+    // reconnect must probe the host again instead of reusing the old result.
+    store.clearRuntimeDetectedAgents(environmentId, targetId)
+  }
   const bucket = store.sshStateByEnvironment.get(environmentId)
   if (bucket?.targetsHydrated && bucket.targetLabels.has(targetId)) {
     store.setEnvironmentSshConnectionState(environmentId, targetId, state)

--- a/src/renderer/src/runtime/runtime-server-directory-browser.test.ts
+++ b/src/renderer/src/runtime/runtime-server-directory-browser.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { browseRuntimeServerDirectory } from './runtime-server-directory-browser'
+import {
+  browseRuntimeServerDirectory,
+  browseRuntimeSshDirectory
+} from './runtime-server-directory-browser'
 import { clearRuntimeCompatibilityCacheForTests } from './runtime-rpc-client'
 import {
   MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
@@ -53,6 +56,20 @@ describe('runtime server directory browser', () => {
       selector: 'env-1',
       method: 'files.browseServerDir',
       params: { path: '~' },
+      timeoutMs: 15_000
+    })
+  })
+
+  it('routes SSH browse requests through the selected runtime environment', async () => {
+    await expect(browseRuntimeSshDirectory('env-1', 'ssh-p8', '~/src')).resolves.toEqual({
+      resolvedPath: '/home/me',
+      entries: [{ name: 'repo', isDirectory: true, isSymlink: false }]
+    })
+
+    expect(runtimeEnvironmentCall).toHaveBeenLastCalledWith({
+      selector: 'env-1',
+      method: 'ssh.browseDir',
+      params: { targetId: 'ssh-p8', dirPath: '~/src' },
       timeoutMs: 15_000
     })
   })

--- a/src/renderer/src/runtime/runtime-server-directory-browser.ts
+++ b/src/renderer/src/runtime/runtime-server-directory-browser.ts
@@ -18,6 +18,7 @@ export async function browseRuntimeServerDirectory(
   )
 }
 
+/** Browse an SSH target through the paired runtime environment that owns it. */
 export async function browseRuntimeSshDirectory(
   environmentId: string,
   targetId: string,

--- a/src/renderer/src/runtime/runtime-server-directory-browser.ts
+++ b/src/renderer/src/runtime/runtime-server-directory-browser.ts
@@ -17,3 +17,16 @@ export async function browseRuntimeServerDirectory(
     { timeoutMs: 15_000 }
   )
 }
+
+export async function browseRuntimeSshDirectory(
+  environmentId: string,
+  targetId: string,
+  dirPath: string
+): Promise<RuntimeServerDirectoryListing> {
+  return callRuntimeRpc<RuntimeServerDirectoryListing>(
+    { kind: 'environment', environmentId },
+    'ssh.browseDir',
+    { targetId, dirPath },
+    { timeoutMs: 15_000 }
+  )
+}

--- a/src/renderer/src/runtime/runtime-ssh-target-management.test.ts
+++ b/src/renderer/src/runtime/runtime-ssh-target-management.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { addSshTargetForOwner, importSshConfigForOwner } from './runtime-ssh-target-management'
+
+const { callRuntimeRpcMock } = vi.hoisted(() => ({
+  callRuntimeRpcMock: vi.fn()
+}))
+
+vi.mock('./runtime-rpc-client', () => ({
+  callRuntimeRpc: callRuntimeRpcMock
+}))
+
+const target = {
+  label: 'p8',
+  configHost: 'p8',
+  host: '192.0.2.8',
+  port: 22,
+  username: 'jae',
+  identityFile: '~/.ssh/id_ed25519_p8'
+}
+
+describe('runtime SSH target management', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('window', {
+      api: {
+        ssh: {
+          addTarget: vi.fn(),
+          importConfig: vi.fn()
+        }
+      }
+    })
+  })
+
+  it('saves a target on the selected Orca server', async () => {
+    const result = { target: { id: 'ssh-p8', ...target }, repoReadoptions: [] }
+    callRuntimeRpcMock.mockResolvedValueOnce(result)
+
+    await expect(
+      addSshTargetForOwner({ id: 'env-linux', label: 'linux-jae' }, target)
+    ).resolves.toEqual(result)
+
+    expect(callRuntimeRpcMock).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-linux' },
+      'ssh.addTarget',
+      { target }
+    )
+    expect(window.api.ssh.addTarget).not.toHaveBeenCalled()
+  })
+
+  it('imports SSH config on the selected Orca server', async () => {
+    const result = { targets: [], repoReadoptions: [] }
+    callRuntimeRpcMock.mockResolvedValueOnce(result)
+
+    await expect(importSshConfigForOwner({ id: 'env-linux', label: 'linux-jae' })).resolves.toEqual(
+      result
+    )
+
+    expect(callRuntimeRpcMock).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-linux' },
+      'ssh.importConfig'
+    )
+    expect(window.api.ssh.importConfig).not.toHaveBeenCalled()
+  })
+
+  it('keeps local SSH management on the desktop host', async () => {
+    const result = { target: { id: 'ssh-local', ...target }, repoReadoptions: [] }
+    vi.mocked(window.api.ssh.addTarget).mockResolvedValueOnce(result)
+
+    await expect(addSshTargetForOwner(null, target)).resolves.toEqual(result)
+
+    expect(window.api.ssh.addTarget).toHaveBeenCalledWith({ target })
+    expect(callRuntimeRpcMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/runtime/runtime-ssh-target-management.ts
+++ b/src/renderer/src/runtime/runtime-ssh-target-management.ts
@@ -7,6 +7,7 @@ import { callRuntimeRpc } from './runtime-rpc-client'
 
 export type SshTargetOwnerEnvironment = { id: string; label: string }
 
+/** Add an SSH target locally or through the paired runtime selected by the caller. */
 export function addSshTargetForOwner(
   owner: SshTargetOwnerEnvironment | null,
   target: Omit<SshTarget, 'id'>
@@ -21,6 +22,7 @@ export function addSshTargetForOwner(
   )
 }
 
+/** Import OpenSSH hosts locally or through the paired runtime selected by the caller. */
 export function importSshConfigForOwner(
   owner: SshTargetOwnerEnvironment | null
 ): Promise<SshConfigImportResult> {

--- a/src/renderer/src/runtime/runtime-ssh-target-management.ts
+++ b/src/renderer/src/runtime/runtime-ssh-target-management.ts
@@ -1,0 +1,34 @@
+import type {
+  SshConfigImportResult,
+  SshTarget,
+  SshTargetAddResult
+} from '../../../shared/ssh-types'
+import { callRuntimeRpc } from './runtime-rpc-client'
+
+export type SshTargetOwnerEnvironment = { id: string; label: string }
+
+export function addSshTargetForOwner(
+  owner: SshTargetOwnerEnvironment | null,
+  target: Omit<SshTarget, 'id'>
+): Promise<SshTargetAddResult> {
+  if (!owner) {
+    return window.api.ssh.addTarget({ target })
+  }
+  return callRuntimeRpc<SshTargetAddResult>(
+    { kind: 'environment', environmentId: owner.id },
+    'ssh.addTarget',
+    { target }
+  )
+}
+
+export function importSshConfigForOwner(
+  owner: SshTargetOwnerEnvironment | null
+): Promise<SshConfigImportResult> {
+  if (!owner) {
+    return window.api.ssh.importConfig()
+  }
+  return callRuntimeRpc<SshConfigImportResult>(
+    { kind: 'environment', environmentId: owner.id },
+    'ssh.importConfig'
+  )
+}

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -12,6 +12,7 @@ import {
   RUNTIME_PROTOCOL_VERSION
 } from '../../../../shared/protocol-version'
 import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
+import { getRuntimeAgentDetectionKey } from '@/lib/runtime-agent-detection-key'
 
 const detectAgents = vi.fn()
 const refreshAgents = vi.fn()
@@ -521,6 +522,67 @@ describe('createDetectedAgentsSlice remote detection', () => {
       params: undefined,
       timeoutMs: undefined
     })
+  })
+
+  it('detects agents through an SSH target owned by the runtime', async () => {
+    const store = createTestStore()
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      const result =
+        method === 'status.get'
+          ? {
+              runtimeId: 'remote-runtime',
+              rendererGraphEpoch: 1,
+              graphStatus: 'ready',
+              authoritativeWindowId: null,
+              liveTabCount: 0,
+              liveLeafCount: 0,
+              runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+              minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+            }
+          : ['codex']
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result,
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    await expect(
+      store.getState().ensureRuntimeDetectedAgents('env-linux', 'ssh-p8')
+    ).resolves.toEqual(['codex'])
+
+    const detectionKey = getRuntimeAgentDetectionKey('env-linux', 'ssh-p8')
+    expect(store.getState().runtimeDetectedAgentIds[detectionKey]).toEqual(['codex'])
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
+      selector: 'env-linux',
+      method: 'preflight.detectRemoteAgents',
+      params: { connectionId: 'ssh-p8' },
+      timeoutMs: undefined
+    })
+    expect(store.getState().runtimeDetectedAgentIds['env-linux']).toBeUndefined()
+  })
+
+  it('clears only the disconnected SSH target agent cache inside a runtime', () => {
+    const store = createTestStore()
+    const p8Key = getRuntimeAgentDetectionKey('env-linux', 'ssh-p8')
+    const p9Key = getRuntimeAgentDetectionKey('env-linux', 'ssh-p9')
+    store.setState({
+      runtimeDetectedAgentIds: {
+        'env-linux': ['claude'],
+        [p8Key]: ['codex'],
+        [p9Key]: ['kilo']
+      },
+      isDetectingRuntimeAgents: { [p8Key]: false, [p9Key]: false }
+    } as Partial<AppState>)
+
+    store.getState().clearRuntimeDetectedAgents('env-linux', 'ssh-p8')
+
+    expect(store.getState().runtimeDetectedAgentIds).toEqual({
+      'env-linux': ['claude'],
+      [p9Key]: ['kilo']
+    })
+    expect(store.getState().isDetectingRuntimeAgents).toEqual({ [p9Key]: false })
   })
 
   it('re-runs runtime detection after an empty result instead of pinning it', async () => {

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -513,14 +513,13 @@ describe('createDetectedAgentsSlice remote detection', () => {
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
       selector: 'env-1',
       method: 'status.get',
-      params: undefined,
-      timeoutMs: undefined
+      timeoutMs: 30_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
       method: 'preflight.detectAgents',
       params: undefined,
-      timeoutMs: undefined
+      timeoutMs: 30_000
     })
   })
 
@@ -558,7 +557,7 @@ describe('createDetectedAgentsSlice remote detection', () => {
       selector: 'env-linux',
       method: 'preflight.detectRemoteAgents',
       params: { connectionId: 'ssh-p8' },
-      timeoutMs: undefined
+      timeoutMs: 30_000
     })
     expect(store.getState().runtimeDetectedAgentIds['env-linux']).toBeUndefined()
   })

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -275,7 +275,8 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
     const pending = callRuntimeRpc<TuiAgent[]>(
       { kind: 'environment', environmentId },
       remoteConnectionId ? 'preflight.detectRemoteAgents' : 'preflight.detectAgents',
-      remoteConnectionId ? { connectionId: remoteConnectionId } : undefined
+      remoteConnectionId ? { connectionId: remoteConnectionId } : undefined,
+      { timeoutMs: 30_000 }
     )
       .then((ids) => {
         const typed = ids as TuiAgent[]

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -6,6 +6,11 @@ import {
   localPreflightContextKey
 } from '@/lib/local-preflight-context'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import {
+  getRuntimeAgentDetectionEnvironmentId,
+  getRuntimeAgentDetectionKey,
+  runtimeAgentDetectionKeyMatches
+} from '@/lib/runtime-agent-detection-key'
 
 export type DetectedAgentsSlice = {
   detectedAgentIds: TuiAgent[] | null
@@ -34,12 +39,17 @@ export type DetectedAgentsSlice = {
   ensureRemoteDetectedAgents: (connectionId: string) => Promise<TuiAgent[]>
   clearRemoteDetectedAgents: (connectionId: string) => void
 
-  // Why: remote runtime hosts are not SSH connections, but their tab-bar
+  // Why: remote runtime hosts are not local SSH connections, but their tab-bar
   // launch menu still has to probe the host where the workspace actually runs.
+  // Keys are either an environment id or an environment + server-owned SSH
+  // target composite produced by getRuntimeAgentDetectionKey().
   runtimeDetectedAgentIds: Record<string, TuiAgent[] | null>
   isDetectingRuntimeAgents: Record<string, boolean>
-  ensureRuntimeDetectedAgents: (environmentId: string) => Promise<TuiAgent[]>
-  clearRuntimeDetectedAgents: (environmentId: string) => void
+  ensureRuntimeDetectedAgents: (
+    environmentId: string,
+    connectionId?: string | null
+  ) => Promise<TuiAgent[]>
+  clearRuntimeDetectedAgents: (environmentId: string, connectionId?: string | null) => void
   /** Drops runtime detected-agent caches for environments not in the kept set.
    *  Wired into setRuntimeEnvironments so removed environments don't leak their
    *  detected-agent entries for the renderer session. */
@@ -243,36 +253,39 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
     })
   },
 
-  ensureRuntimeDetectedAgents: (environmentId: string) => {
-    const existing = get().runtimeDetectedAgentIds[environmentId]
+  ensureRuntimeDetectedAgents: (environmentId: string, connectionId?: string | null) => {
+    const detectionKey = getRuntimeAgentDetectionKey(environmentId, connectionId)
+    const existing = get().runtimeDetectedAgentIds[detectionKey]
     // Why: an empty result ([]) is truthy, so a prior "no agents found" detection
     // must not be treated as cached — re-detect so a later install / PATH fix is
     // picked up without a reconnect. Non-empty results still short-circuit.
     if (existing?.length) {
       return Promise.resolve(existing)
     }
-    const inflight = runtimeDetectPromises.get(environmentId)
+    const inflight = runtimeDetectPromises.get(detectionKey)
     if (inflight) {
       return inflight
     }
 
     set((s) => ({
-      isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [environmentId]: true }
+      isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [detectionKey]: true }
     }))
 
+    const remoteConnectionId = connectionId?.trim() || null
     const pending = callRuntimeRpc<TuiAgent[]>(
       { kind: 'environment', environmentId },
-      'preflight.detectAgents'
+      remoteConnectionId ? 'preflight.detectRemoteAgents' : 'preflight.detectAgents',
+      remoteConnectionId ? { connectionId: remoteConnectionId } : undefined
     )
       .then((ids) => {
         const typed = ids as TuiAgent[]
         // Why: skip committing if the environment was removed (retained out)
         // while the detect was in flight — otherwise it re-adds a stale entry
         // that retainRuntimeDetectedAgents just pruned.
-        if (runtimeDetectPromises.get(environmentId) === pending) {
+        if (runtimeDetectPromises.get(detectionKey) === pending) {
           set((s) => ({
-            runtimeDetectedAgentIds: { ...s.runtimeDetectedAgentIds, [environmentId]: typed },
-            isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [environmentId]: false }
+            runtimeDetectedAgentIds: { ...s.runtimeDetectedAgentIds, [detectionKey]: typed },
+            isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [detectionKey]: false }
           }))
         }
         return typed
@@ -284,52 +297,66 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
         // retained out mid-detect, don't re-add the isDetecting entry that
         // retainRuntimeDetectedAgents just pruned (and don't clobber a freshly
         // started detect's spinner).
-        if (runtimeDetectPromises.get(environmentId) === pending) {
+        if (runtimeDetectPromises.get(detectionKey) === pending) {
           set((s) => ({
-            isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [environmentId]: false }
+            isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [detectionKey]: false }
           }))
         }
         return [] as TuiAgent[]
       })
       .finally(() => {
-        if (runtimeDetectPromises.get(environmentId) === pending) {
-          runtimeDetectPromises.delete(environmentId)
+        if (runtimeDetectPromises.get(detectionKey) === pending) {
+          runtimeDetectPromises.delete(detectionKey)
         }
       })
 
-    runtimeDetectPromises.set(environmentId, pending)
+    runtimeDetectPromises.set(detectionKey, pending)
     return pending
   },
 
-  clearRuntimeDetectedAgents: (environmentId: string) => {
-    runtimeDetectPromises.delete(environmentId)
+  clearRuntimeDetectedAgents: (environmentId: string, connectionId?: string | null) => {
+    for (const key of runtimeDetectPromises.keys()) {
+      if (runtimeAgentDetectionKeyMatches(key, environmentId, connectionId)) {
+        runtimeDetectPromises.delete(key)
+      }
+    }
     set((s) => {
-      const { [environmentId]: _, ...restAgents } = s.runtimeDetectedAgentIds
-      const { [environmentId]: __, ...restLoading } = s.isDetectingRuntimeAgents
+      const restAgents = { ...s.runtimeDetectedAgentIds }
+      const restLoading = { ...s.isDetectingRuntimeAgents }
+      for (const key of Object.keys(restAgents)) {
+        if (runtimeAgentDetectionKeyMatches(key, environmentId, connectionId)) {
+          delete restAgents[key]
+        }
+      }
+      for (const key of Object.keys(restLoading)) {
+        if (runtimeAgentDetectionKeyMatches(key, environmentId, connectionId)) {
+          delete restLoading[key]
+        }
+      }
       return { runtimeDetectedAgentIds: restAgents, isDetectingRuntimeAgents: restLoading }
     })
   },
 
   retainRuntimeDetectedAgents: (environmentIds: Iterable<string>) => {
     const keep = new Set(environmentIds)
-    for (const id of runtimeDetectPromises.keys()) {
-      if (!keep.has(id)) {
-        runtimeDetectPromises.delete(id)
+    for (const key of runtimeDetectPromises.keys()) {
+      if (!keep.has(getRuntimeAgentDetectionEnvironmentId(key))) {
+        runtimeDetectPromises.delete(key)
       }
     }
     set((s) => {
       let changed = false
       const nextAgents = { ...s.runtimeDetectedAgentIds }
       const nextLoading = { ...s.isDetectingRuntimeAgents }
-      for (const id of Object.keys(nextAgents)) {
-        if (!keep.has(id)) {
-          delete nextAgents[id]
+      for (const key of Object.keys(nextAgents)) {
+        if (!keep.has(getRuntimeAgentDetectionEnvironmentId(key))) {
+          delete nextAgents[key]
           changed = true
         }
       }
-      for (const id of Object.keys(nextLoading)) {
-        if (!keep.has(id)) {
-          delete nextLoading[id]
+      for (const key of Object.keys(nextLoading)) {
+        if (!keep.has(getRuntimeAgentDetectionEnvironmentId(key))) {
+          delete nextLoading[key]
           changed = true
         }
       }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1966,7 +1966,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         await callRuntimeRpc<NestedRepoScanResult>(
           target,
           'projectGroup.scanNested',
-          { path },
+          { path, connectionId },
           // Why: older runtime servers cannot stream or cancel scans, so the
           // renderer must retain a bounded failure path for large folders.
           { timeoutMs: 20_000 }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -78,7 +78,10 @@ import { getFolderWorkspaceConnectionId } from '@/lib/folder-workspace-connectio
 import { hasWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import { sanitizeTerminalLayoutPaneTitles } from '@/lib/terminal-pane-title-sanitization'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
-import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree
+} from '@/lib/worktree-runtime-owner'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import type { NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
 import {
@@ -3412,8 +3415,18 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // SSH connection is active. Without the active-connection check, we'd try
       // to reattach to a relay that isn't connected yet (the deferred/passphrase
       // targets), which would fail.
-      const sshState = repo?.connectionId ? get().sshConnectionStates.get(repo.connectionId) : null
-      const sshConnected = repo?.connectionId != null && sshState?.status === 'connected'
+      const sshOwnerEnvironmentId = repo?.connectionId
+        ? getExplicitRuntimeEnvironmentIdForWorktree(get(), worktreeId)
+        : null
+      const sshState =
+        repo?.connectionId && !sshOwnerEnvironmentId
+          ? get().sshConnectionStates.get(repo.connectionId)
+          : null
+      const sshConnected =
+        repo?.connectionId != null &&
+        (sshOwnerEnvironmentId !== null || sshState?.status === 'connected')
+      // Runtime-owned SSH terminals restore through runtime handles; only
+      // desktop-owned SSH sessions depend on the local provider being ready.
       const supportsDeferredReattach = !repo?.connectionId || sshConnected
       console.debug(
         `[reconnect-terminals] worktree=${worktreeId} connectionId=${repo?.connectionId} sshStatus=${sshState?.status} supportsDeferredReattach=${supportsDeferredReattach}`
@@ -3491,6 +3504,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
       const repo = repoId ? get().repos.find((entry) => entry.id === repoId) : null
       if (!repo?.connectionId) {
+        continue
+      }
+      if (getExplicitRuntimeEnvironmentIdForWorktree(get(), worktreeId)) {
         continue
       }
       const sshConnected = get().sshConnectionStates.get(repo.connectionId)?.status === 'connected'

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -3951,6 +3951,48 @@ describe('worktree remote runtime mutations', () => {
     expect(store.getState().worktreesByRepo.repo1).toEqual([wt])
   })
 
+  it('creates a server-owned SSH repo worktree through its owning runtime', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/home/jae/feature',
+      repoId: 'repo1',
+      path: '/home/jae/feature'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create',
+      ok: true,
+      result: { worktree: wt },
+      _meta: { runtimeId: 'runtime-linux' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'focused-elsewhere' } as never,
+      repos: [
+        {
+          id: 'repo1',
+          path: '/home/jae/project',
+          displayName: 'p8 project',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-p8',
+          executionHostId: 'runtime:env-linux'
+        }
+      ],
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+
+    await store.getState().createWorktree('repo1', 'feature', 'origin/main', 'skip')
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: 'env-linux',
+        method: 'worktree.create',
+        params: expect.objectContaining({ repo: 'repo1', name: 'feature' })
+      })
+    )
+    expect(mockApi.worktrees.create).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1).toEqual([{ ...wt, hostId: 'runtime:env-linux' }])
+  })
+
   it('passes startup commands through remote runtime worktree creation', async () => {
     const store = createTestStore()
     const wt = makeWorktree({


### PR DESCRIPTION
## Summary

- Initialize Orca's existing SSH provider stack before a headless `orca serve` runtime accepts requests.
- Extend authenticated paired-Desktop runtime RPC with server-owned SSH target add/import, connection, directory browsing, nested scanning, and SSH-project creation.
- Route the existing Add Project UI through the selected Orca server: select a server, add/import its SSH host, browse that host, add the project, and create a workspace/session.
- Preserve composite ownership for nested operations (`Desktop → paired runtime → SSH host`), including connect/status, agent detection, terminals, worktree creation, polling, deletion, and automation dispatch.
- Keep local Desktop SSH behavior unchanged and keep the new management methods outside the phone/mobile RPC allowlist.

Fixes #8489.

## Screenshots

This change reuses Orca's existing Add Project, host selector, Add SSH Host, and Remote File Browser surfaces instead of introducing a standalone screen. Visible changes are contextual:

- selecting a paired server now exposes **Project on SSH host**;
- **Add SSH host to `<server>`** makes ownership explicit;
- an empty server-owned target list explains that no SSH targets are configured on that Orca server.

An end-to-end static screenshot would require committing pairing credentials or server state, so the conditional UI and routing are covered by renderer tests instead.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (29,137 passed, 40 skipped)
- [x] macOS arm64 app packaging and deep code-sign verification
- [x] Linux x64 AppImage packaging and live systemd deployment
- [x] Focused SSH/runtime/renderer suites passed, including composite connect, agent, terminal, worktree, lifecycle, and cache-ownership regressions
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed the headless and desktop startup paths, SSH manager lifecycle, runtime RPC ordering, environment-scoped renderer routing, repository persistence, and the null-`BrowserWindow` path. The review covered macOS, Linux, and Windows behavior; local, paired-server, and SSH execution hosts; POSIX and PowerShell remote directory browsing; nested repository scanning; session creation dependencies; and unchanged local Desktop flows.

The implementation reuses existing SSH, Git, filesystem, PTY, repository, and UI primitives. Server-scoped actions are selected only when a runtime environment owns the operation; local SSH IPC remains the fallback. Tests verify server and local routing, SSH target management, connection/browse behavior, remote repository creation, nested scans, and startup registration order.

CodeRabbit follow-up review was addressed by keeping failed runtime reconnect dialogs open, bounding runtime agent detection to 30 seconds, and reusing the centralized paired-client detector. Dedicated dialog tests cover unsuccessful and successful runtime reconnect results.

## Security Audit

Reviewed RPC authorization, input validation, target ownership, paths, credentials, command construction, secrets, dependencies, and mobile exposure.

- The new methods use the existing authenticated runtime channel for paired Desktop clients.
- They are intentionally absent from `MOBILE_RPC_METHOD_ALLOWLIST`, so phone/mobile pairing cannot manage server SSH targets or add server projects.
- Manual target input is strict and bounded; internal `owner` fields and config-derived proxy/jump fields cannot be injected by the client.
- Directory browsing and project creation reuse existing SSH providers, escaping, target lookup, persistence, and host-key/key-file handling.
- No new dependency, credential transport, shell-command construction, or authentication bypass was added.
- Headless credential prompts that require a desktop window resolve as cancelled rather than hanging.

No follow-up security work was identified.

## Notes

- Reproduced the original Linux failure as `ssh_handlers_not_registered` while direct SSH connectivity worked.
- Reproduced the installed paired-client failure as local Electron IPC resolving server-owned `ssh-p8`; the fixed build routes it through the owning runtime RPC instead.
- Live E2E validation created a p8 worktree and opened its Claude terminal session and remote file explorer from the paired macOS client.
- Build warnings were limited to existing bundle-size/dynamic-import warnings and a non-fatal development CLI symlink permission warning.
- X (Twitter): Not provided

## ELI5

Paired desktop clients can now add and use SSH projects that live on an Orca remote server. You pick the server, add or import an SSH host, browse folders, and create the project without doing that only on the server machine itself.
