### PR TITLE
fix(codex): label weekly-only rate limits correctly

### DIFF
--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -97,6 +97,47 @@ describe('Codex backend rate-limit requests', () => {
     )
   })
 
+  it('classifies a sole seven-day backend primary window as weekly', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        tokens: { access_token: 'access-token', account_id: 'account-id' }
+      })
+    )
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          plan_type: 'plus',
+          rate_limit: {
+            primary_window: {
+              used_percent: 37,
+              limit_window_seconds: 7 * 24 * 60 * 60,
+              reset_at: 1_800_000_000
+            }
+          },
+          rate_limit_reset_credits: { available_count: 0 }
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available_count: 0, credits: [] })
+      } as Response)
+
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex'
+      })
+    ).resolves.toMatchObject({
+      session: null,
+      weekly: {
+        usedPercent: 37,
+        windowMinutes: 10_080,
+        resetsAt: 1_800_000_000_000
+      },
+      status: 'ok'
+    })
+  })
+
   it('aborts callers while sharing one stalled backend auth read', async () => {
     let resolveRead!: (content: string) => void
     readFileMock.mockImplementation(

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -368,6 +368,50 @@ describe('fetchCodexRateLimits', () => {
     expect(result.weekly?.windowMinutes).toBe(10080)
   })
 
+  it('classifies a sole RPC weekly primary window as weekly', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    rpcChild.stdin.write.mockImplementation((line: string) => {
+      const msg = JSON.parse(line) as { id?: number; method?: string }
+      if (msg.method === 'initialize') {
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
+          )
+        }, 0)
+      }
+      if (msg.method === 'account/rateLimits/read') {
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(
+              `${JSON.stringify({
+                jsonrpc: '2.0',
+                id: msg.id,
+                result: {
+                  rateLimits: {
+                    primary: { usedPercent: 37, windowDurationMins: 10_079 }
+                  }
+                }
+              })}\n`
+            )
+          )
+        }, 0)
+      }
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: null,
+      weekly: { usedPercent: 37, windowMinutes: 10_080 },
+      status: 'ok'
+    })
+  })
+
   it('fills reset-credit count from the backend when the installed app-server omits it', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -325,7 +325,7 @@ describe('fetchCodexRateLimits', () => {
     expect(ptySpawnMock).not.toHaveBeenCalled()
   })
 
-  it('normalizes Codex RPC remaining-minute windows to fixed display durations', async () => {
+  it('normalizes floor-rounded Codex RPC window durations to canonical display durations', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)
     rpcChild.stdin.write.mockImplementation((line: string) => {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -28,6 +28,12 @@ import {
   createAuthFilesystemOperation,
   type SharedAuthFilesystemOperation
 } from './auth-filesystem-operation'
+import {
+  classifyCodexRateLimitWindows,
+  CODEX_SESSION_WINDOW_MINUTES,
+  CODEX_WEEKLY_WINDOW_MINUTES,
+  isCodexWeeklyWindowDuration
+} from './codex-rate-limit-window-classification'
 
 const RPC_TIMEOUT_MS = 10_000
 const WSL_RPC_TIMEOUT_MS = 25_000
@@ -528,10 +534,14 @@ async function fetchViaBackend(
   if (typeof payload.plan_type !== 'string') {
     return null
   }
+  const { session, weekly } = classifyCodexRateLimitWindows(
+    mapBackendUsageWindow(payload.rate_limit?.primary_window, CODEX_SESSION_WINDOW_MINUTES),
+    mapBackendUsageWindow(payload.rate_limit?.secondary_window, CODEX_WEEKLY_WINDOW_MINUTES)
+  )
   return {
     provider: 'codex',
-    session: mapBackendUsageWindow(payload.rate_limit?.primary_window, 300),
-    weekly: mapBackendUsageWindow(payload.rate_limit?.secondary_window, 10080),
+    session,
+    weekly,
     // Surfaced for the status-bar Usage row (e.g. "Codex · Plus").
     planType: payload.plan_type,
     ...(payload.rate_limit_reset_credits !== undefined
@@ -701,8 +711,15 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
 
             const wrapper = msg.result as RpcRateLimitsResponse | undefined
             const result = wrapper?.rateLimits
-            const session = mapRpcWindow(result?.primary, 300)
-            const weekly = mapRpcWindow(result?.secondary, 10080)
+            const primaryWindowMinutes = isCodexWeeklyWindowDuration(
+              result?.primary?.windowDurationMins
+            )
+              ? CODEX_WEEKLY_WINDOW_MINUTES
+              : CODEX_SESSION_WINDOW_MINUTES
+            const { session, weekly } = classifyCodexRateLimitWindows(
+              mapRpcWindow(result?.primary, primaryWindowMinutes),
+              mapRpcWindow(result?.secondary, CODEX_WEEKLY_WINDOW_MINUTES)
+            )
             const rateLimitResetCredits = mapRpcRateLimitResetCredits(
               wrapper?.rateLimitResetCredits
             )

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -482,7 +482,7 @@ function mapRpcWindow(
 
   return {
     usedPercent: Math.min(100, Math.max(0, raw.usedPercent)),
-    // Why: windowDurationMins reports remaining minutes, but the UI needs the fixed bucket duration for "5h"/"wk" labels.
+    // Why: windowDurationMins is a fixed per-window bucket size that legacy Codex paths floor-round (e.g. 299, 10079); normalize to the canonical duration for stable "5h"/"wk" labels.
     windowMinutes: expectedWindowMinutes,
     resetsAt,
     resetDescription

--- a/src/main/rate-limits/codex-rate-limit-window-classification.test.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import type { RateLimitWindow } from '../../shared/rate-limit-types'
+import {
+  classifyCodexRateLimitWindows,
+  isCodexWeeklyWindowDuration
+} from './codex-rate-limit-window-classification'
+
+function window(windowMinutes: number): RateLimitWindow {
+  return {
+    usedPercent: 25,
+    windowMinutes,
+    resetsAt: null,
+    resetDescription: null
+  }
+}
+
+describe('Codex rate-limit window classification', () => {
+  it('recognizes exact and RPC-rounded weekly durations', () => {
+    expect(isCodexWeeklyWindowDuration(10_080)).toBe(true)
+    expect(isCodexWeeklyWindowDuration(10_079)).toBe(true)
+    expect(isCodexWeeklyWindowDuration(300)).toBe(false)
+  })
+
+  it('classifies a sole weekly primary window as weekly', () => {
+    const weekly = window(10_080)
+
+    expect(classifyCodexRateLimitWindows(weekly, null)).toEqual({
+      session: null,
+      weekly
+    })
+  })
+
+  it('keeps a sole five-hour primary window as the session limit', () => {
+    const session = window(300)
+
+    expect(classifyCodexRateLimitWindows(session, null)).toEqual({
+      session,
+      weekly: null
+    })
+  })
+
+  it('keeps the traditional primary and secondary positions when both exist', () => {
+    const session = window(300)
+    const weekly = window(10_080)
+
+    expect(classifyCodexRateLimitWindows(session, weekly)).toEqual({ session, weekly })
+  })
+})

--- a/src/main/rate-limits/codex-rate-limit-window-classification.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.ts
@@ -1,0 +1,28 @@
+import type { RateLimitWindow } from '../../shared/rate-limit-types'
+
+export const CODEX_SESSION_WINDOW_MINUTES = 300
+export const CODEX_WEEKLY_WINDOW_MINUTES = 10_080
+
+const CODEX_RPC_WINDOW_ROUNDING_TOLERANCE_MINUTES = 1
+
+export function isCodexWeeklyWindowDuration(windowMinutes: number | undefined): boolean {
+  return (
+    typeof windowMinutes === 'number' &&
+    Number.isFinite(windowMinutes) &&
+    Math.abs(windowMinutes - CODEX_WEEKLY_WINDOW_MINUTES) <=
+      CODEX_RPC_WINDOW_ROUNDING_TOLERANCE_MINUTES
+  )
+}
+
+export function classifyCodexRateLimitWindows(
+  primary: RateLimitWindow | null,
+  secondary: RateLimitWindow | null
+): { session: RateLimitWindow | null; weekly: RateLimitWindow | null } {
+  // Why: newer Codex plans can expose their sole weekly quota as the primary
+  // window, so field position alone no longer identifies a five-hour session.
+  if (primary && !secondary && isCodexWeeklyWindowDuration(primary.windowMinutes)) {
+    return { session: null, weekly: primary }
+  }
+
+  return { session: primary, weekly: secondary }
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1009,7 +1009,7 @@ export function InlineUsageBars({
       ? {
           key: 'weekly',
           used: clampUsedPercent(limits.weekly.usedPercent),
-          label: translate('auto.components.status.bar.StatusBar.5c938d39ac', 'wk')
+          label: formatWindowLabel(limits.weekly.windowMinutes)
         }
       : null,
     limits.fableWeekly
@@ -1238,10 +1238,13 @@ function VerboseProviderUsage({
     return window !== null
   })
 
+  // Why: weekly-only plans have no session window; the mini meter follows the first visible window instead of vanishing.
+  const primaryVisibleWindow = visibleWindows[0]?.window
+
   return (
     <>
-      {p.session && !compact ? (
-        <MiniBar usedPct={clampUsedPercent(p.session.usedPercent)} display={display} />
+      {primaryVisibleWindow && !compact ? (
+        <MiniBar usedPct={clampUsedPercent(primaryVisibleWindow.usedPercent)} display={display} />
       ) : null}
       {visibleWindows.map((window, index) => (
         <React.Fragment key={window.key}>

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,7 +63,7 @@ import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
-import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
+import { formatRateLimitWindowChipLabel, formatWindowLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
@@ -1238,13 +1238,13 @@ function VerboseProviderUsage({
     return window !== null
   })
 
-  // Why: weekly-only plans have no session window; the mini meter follows the first visible window instead of vanishing.
-  const primaryVisibleWindow = visibleWindows[0]?.window
+  // Why: weekly-only plans have no session window; the mini meter follows the weekly quota instead of vanishing.
+  const meterWindow = p.session ?? p.weekly
 
   return (
     <>
-      {primaryVisibleWindow && !compact ? (
-        <MiniBar usedPct={clampUsedPercent(primaryVisibleWindow.usedPercent)} display={display} />
+      {meterWindow && !compact ? (
+        <MiniBar usedPct={clampUsedPercent(meterWindow.usedPercent)} display={display} />
       ) : null}
       {visibleWindows.map((window, index) => (
         <React.Fragment key={window.key}>

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,7 +63,7 @@ import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
-import { formatRateLimitWindowChipLabel, formatWindowLabel } from '@/lib/window-label-formatter'
+import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
@@ -1009,7 +1009,7 @@ export function InlineUsageBars({
       ? {
           key: 'weekly',
           used: clampUsedPercent(limits.weekly.usedPercent),
-          label: formatWindowLabel(limits.weekly.windowMinutes)
+          label: translate('auto.components.status.bar.StatusBar.5c938d39ac', 'wk')
         }
       : null,
     limits.fableWeekly

--- a/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
+++ b/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
@@ -99,17 +99,18 @@ describe('InlineUsageBars', () => {
     expect(markup).toContain('32% used now')
   })
 
-  it('uses the reported duration for a sole Codex weekly primary window', async () => {
+  it('labels a sole Codex weekly window as weekly, not a 5h session', async () => {
     const { InlineUsageBars } = await import('./StatusBar')
+    // Shape the classifier emits for a weekly-only plan: session cleared, weekly set.
     const limits: ProviderRateLimits = {
       provider: 'codex',
-      session: {
+      session: null,
+      weekly: {
         usedPercent: 37,
         windowMinutes: 10_080,
         resetsAt: null,
         resetDescription: null
       },
-      weekly: null,
       updatedAt: Date.now(),
       error: null,
       status: 'ok'

--- a/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
+++ b/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
@@ -99,6 +99,58 @@ describe('InlineUsageBars', () => {
     expect(markup).toContain('32% used now')
   })
 
+  it('uses the reported duration for a sole Codex weekly primary window', async () => {
+    const { InlineUsageBars } = await import('./StatusBar')
+    const limits: ProviderRateLimits = {
+      provider: 'codex',
+      session: {
+        usedPercent: 37,
+        windowMinutes: 10_080,
+        resetsAt: null,
+        resetDescription: null
+      },
+      weekly: null,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    }
+
+    const markup = renderToStaticMarkup(<InlineUsageBars limits={limits} isFetching={false} />)
+
+    expect(markup).toContain('37% used wk')
+    expect(markup).not.toContain('37% used 5h')
+  })
+
+  it('keeps the mini meter when Codex exposes only a weekly window', async () => {
+    const { ProviderDetailsMenu } = await import('./StatusBar')
+    const limits: ProviderRateLimits = {
+      provider: 'codex',
+      session: null,
+      weekly: {
+        usedPercent: 37,
+        windowMinutes: 10_080,
+        resetsAt: null,
+        resetDescription: null
+      },
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    }
+
+    const markup = renderToStaticMarkup(
+      <ProviderDetailsMenu
+        provider={limits}
+        compact={false}
+        iconOnly={false}
+        ariaLabel="Open Codex usage details"
+      />
+    )
+
+    expect(markup).toContain('w-[48px] h-[6px]')
+    expect(markup).toContain('width:37%')
+    expect(markup).toContain('37% used wk')
+  })
+
   it('shows remaining copy and remaining meter fill', async () => {
     mocks.usagePercentageDisplay = 'remaining'
     const { InlineUsageBars } = await import('./StatusBar')


### PR DESCRIPTION
## Summary

- classify a sole seven-day Codex primary window as weekly usage
- handle both backend and app-server RPC rate-limit responses
- derive inactive-account labels and the compact mini meter from the first visible quota window
- preserve the existing five-hour session behavior when it returns, including plans with both 5h and weekly limits

## User-visible change

Codex plans that expose only a weekly quota no longer show that quota as a five-hour session limit. The compact usage bar remains visible and follows the weekly percentage when no five-hour window exists.

## Screenshots

| Before | After |
| --- | --- |
| <img width="298" height="42" alt="Screenshot 2026-07-13 at 14-47-35" src="https://github.com/user-attachments/assets/3ec1b98e-f610-4b18-a47c-e5c738368bb7" /> | <img width="304" height="42" alt="Screenshot 2026-07-13 at 14-48-07" src="https://github.com/user-attachments/assets/1b70865b-3df6-4c03-ad8e-591f77629271" /> |

## Testing

- [x] Focused Vitest: 4 files / 32 tests
- [x] `pnpm lint` (passes with repository-existing warnings)
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm check:max-lines-ratchet`
- [x] `git diff --check origin/main...HEAD`
- [ ] Full `pnpm test`: the workstation suite has unrelated Git environment/hook and UTF-8 fixture failures; all changed-area tests pass

## AI Review Report

- **Cross-platform:** Pure duration classification and existing renderer primitives; no platform-specific APIs or shortcuts.
- **SSH / remote / local:** Covers the direct backend path used for WSL and the app-server RPC path used by local/remote Codex runtimes.
- **Agents / integrations:** Explicitly scoped to Codex. Claude, Gemini, other agents, GitHub, and GitLab behavior is unchanged.
- **Performance:** Constant-time classification during the existing rate-limit refresh; no new polling, I/O, or allocations in hot loops.
- **UI quality:** Reuses the existing window-label formatter and status-bar mini meter. No new colors, typography, spacing, shadows, or design tokens.
- **Security:** No credential, endpoint, IPC, command execution, or persistence changes.

## Compatibility notes

A sole 5h primary window remains `session`. When 5h and weekly windows both exist, 5h remains first and drives the compact mini meter. A sole weekly primary window is reclassified as `weekly` and drives that same meter.

Related to #8378 and #8293.

No release/version changes.

X: [@KyungyeolB](https://x.com/KyungyeolB)

## ELI5

Codex plans that only have a weekly usage quota were wrongly shown as a five-hour session limit. The meter and labels now treat a lone seven-day window as weekly, while still handling plans that have both 5-hour and weekly limits.
