### PR TITLE
fix: stop Cmd+Shift+E opening the mobile emulator instead of Explorer

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1652,7 +1652,7 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
-      // Cmd/Ctrl+Shift+E — new mobile emulator tab (macOS only)
+      // Cmd/Ctrl+Shift+S — new mobile emulator tab (macOS only)
       if (!e.repeat && mobileEmulatorEnabled && matchShortcut('tab.newSimulator')) {
         e.preventDefault()
         notifyTerminalCapture('tab.newSimulator')

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -764,6 +764,21 @@ describe('keybindings', () => {
     })
   })
 
+  it('keeps the mobile emulator tab off the Show Explorer chord (#4754 regression)', () => {
+    expect(getEffectiveKeybindingsForAction('tab.newSimulator', 'darwin')).toEqual(['Mod+Shift+S'])
+    expect(getEffectiveKeybindingsForAction('sidebar.explorer.toggle', 'darwin')).toEqual([
+      'Mod+Shift+E'
+    ])
+
+    // conflictGroup: 'global' makes rebinding it back onto Cmd+Shift+E a reported conflict.
+    expect(findKeybindingConflicts('darwin', { 'tab.newSimulator': ['Mod+Shift+E'] })).toContainEqual(
+      {
+        binding: 'Mod+Shift+E',
+        actionIds: expect.arrayContaining(['sidebar.explorer.toggle', 'tab.newSimulator'])
+      }
+    )
+  })
+
   it('keeps Orca-first terminal context backward compatible', () => {
     const ctrlP = {
       key: 'p',

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -566,9 +566,12 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     title: 'New mobile emulator tab',
     group: 'Tabs',
     scope: 'tabs',
+    // Why: routed from terminal focus, so it competes with global chords;
+    // flag overlaps (e.g. the former Cmd+Shift+E clash with Show Explorer).
+    conflictGroup: 'global',
     searchKeywords: ['shortcut', 'tab', 'simulator', 'emulator', 'mobile', 'ios', 'new'],
     defaultBindings: {
-      darwin: ['Mod+Shift+E'],
+      darwin: ['Mod+Shift+S'],
       linux: [],
       win32: []
     }


### PR DESCRIPTION
## What & why

On macOS, pressing **Cmd+Shift+E** opened a new **mobile emulator tab** instead of toggling the **Explorer**, even though Cmd+Shift+E is the documented "Show Explorer" chord (and the VS Code standard users expect).

**Root cause:** two actions default to the same chord on macOS:

| Action | Scope | macOS default |
|--------|-------|---------------|
| `sidebar.explorer.toggle` (Show Explorer) | `global` | `Mod+Shift+E` |
| `tab.newSimulator` (New mobile emulator tab) | `tabs` | `Mod+Shift+E` |

Show Explorer had the chord first (added in #2581). #4754 (Add mobile emulator) reused it for the emulator. When focus is in a terminal, the terminal-scope keydown handler in `Terminal.tsx` runs first, calls `e.preventDefault()`, and opens the emulator — so the global Show Explorer toggle in `App.tsx` never runs.

`findKeybindingConflicts` never flagged this because the two actions live in different scopes (`tabs` vs `global`), and `tab.newSimulator` — unlike the comparable `tab.openQuickCommandsMenu` action — never declared `conflictGroup: 'global'` despite being routed from terminal focus.

## Change

- Move `tab.newSimulator`'s macOS default to **`Mod+Shift+S`** (S = Simulator; the chord is free and no menu accelerator uses it). **Cmd+Shift+E stays on Show Explorer.**
- Add `conflictGroup: 'global'` to `tab.newSimulator` so `findKeybindingConflicts` and the Settings → Shortcuts UI flag any future overlap with a global chord — the same mechanism `tab.openQuickCommandsMenu` already uses.
- Add a regression test.

The TabBar label uses `useShortcutLabel('tab.newSimulator')`, so it now renders `⌘⇧S` automatically — no hardcoded label change needed.

## Testing

- `pnpm test` — `keybindings.test.ts` passes (61/61), including the new regression test which asserts (a) the emulator default is `Mod+Shift+S`, and (b) rebinding it back onto `Mod+Shift+E` now reports a conflict with `sidebar.explorer.toggle` (proving the new guard works).
- `pnpm typecheck` — clean.
- `oxlint` on the changed files — clean.

## Screenshots / recording

Cmd+Shift+E now surfaces **Explorer (⌘⇧E)** — no longer captured by the mobile emulator tab:

<img width="970" height="110" alt="스크린샷 2026-07-13 16 39 36" src="https://github.com/user-attachments/assets/d75dd030-387c-43ef-85a4-11343e034deb" />


## AI code-review summary

- **Cross-platform:** Change is macOS-only (`tab.newSimulator` only has a darwin default; linux/win32 are empty and untouched). `sidebar.explorer.toggle` remains `Mod+Shift+E` on all platforms. No `metaKey`/`ctrlKey` hardcoding introduced.
- **Performance:** None — a static default-binding value change plus one metadata field; no runtime hot-path impact.
- **Security:** None — no I/O, no external input, no new dependencies.
- **SSH / remote:** Keybinding defaults are client-side and identical for local, remote-server, and SSH worktrees; unaffected.

## Contributor

X handle: <!-- TODO: @your_handle -->

## ELI5

On Mac, Cmd+Shift+E was supposed to show the Explorer, but it opened a mobile emulator tab instead because two actions shared the same shortcut. The emulator default is changed so Explorer gets the chord users expect.
