### PR TITLE
fix(grok): don't tell users to re-run grok login on refreshable token expiry

### DIFF
--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -159,6 +159,10 @@ describe('fetchGrokRateLimits', () => {
     const result = await fetchGrokRateLimits()
     expect(result.status).toBe('error')
     expect(result.error).toMatch(/expired/i)
+    // Why: a stored-but-expired access token is refreshed by Grok CLI on next
+    // use (a genuine sign-out returns 'missing'), so the message must not tell
+    // users to re-run `grok login` (#8497).
+    expect(result.error).not.toMatch(/grok login/i)
     expect(netFetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -145,7 +145,10 @@ export async function fetchGrokRateLimits(
   }
   const session = readResult.session
   if (!isGrokAccessTokenFresh(session)) {
-    return result('error', 'Grok session expired — run grok login to refresh')
+    // Why: a genuine sign-out returns 'missing' earlier, so reaching here always
+    // means a stored, refreshable session — Grok CLI refreshes the access token
+    // on its next run, so don't tell users to re-run `grok login` (#8497).
+    return result('error', 'Grok access token expired — Grok CLI will refresh it on next use')
   }
 
   try {

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -135,6 +135,21 @@ describe('provider usage error copy', () => {
     )
   })
 
+  it('keeps the reworded Grok expired-token error classified as an auth failure (#8497)', () => {
+    // Why: the fix (grok-fetcher.ts) dropped the "run grok login" wording that
+    // used to trigger auth classification; this pins that the new copy still
+    // resolves to the softer refresh message instead of leaking the raw string.
+    const grok = provider({
+      provider: 'grok',
+      error: 'Grok access token expired — Grok CLI will refresh it on next use'
+    })
+
+    expect(getProviderUsageStatusLabel(grok)).toBe('Refresh failed')
+    expect(getProviderUsageErrorMessage(grok)).toBe(
+      'Grok usage could not be refreshed. Agent sessions may still be signed in.'
+    )
+  })
+
   it('frames known Codex auth refresh failures as auth-shaped usage failures', () => {
     const cases = [
       'Please reauthenticate before checking usage.',


### PR DESCRIPTION
## Summary

The Grok usage panel repeatedly told users to run `grok login` roughly every ~6 hours, even though they were still signed in. This rewords the single misleading error message so a routine, auto-refreshable access-token expiry is no longer surfaced as a full logout.

## Root cause

`fetchGrokRateLimits` in `src/main/rate-limits/grok-fetcher.ts:147-148` hard-errors with:

```
Grok session expired — run grok login to refresh
```

whenever the stored access token is past `expires_at` (minus a 5-min skew, `isGrokAccessTokenFresh`). That branch is only reachable when a **stored session token exists but is merely expired** — a genuine sign-out already returns `status:'missing'` earlier (`readGrokAuthSession` in `src/main/rate-limits/grok-auth.ts:118-124`, gated by `isGrokAccessTokenFresh` at `:139-145`), which `fetchGrokRateLimits` maps to `'unavailable'` at `:140-142`.

Grok CLI keeps a long-lived refresh token in `~/.grok/auth.json` and silently mints a new access token on its next invocation. So Orca was misclassifying a normal ~6h refreshable gap as a logout and instructing users to re-authenticate. The raw string is surfaced verbatim in `src/renderer/src/components/stats/GrokUsagePane.tsx:72-76` (interpolated into a translated ` • {{value0}}` template) and in the Accounts section (`GrokAccountsSection.tsx:133`, `status.error`).

## The fix

Reword **only** the message at `grok-fetcher.ts:148`:

```
Grok access token expired — Grok CLI will refresh it on next use
```

Why this is zero-regression:
- **Keeps `status:'error'`** — the pill/alert signal is unchanged (flipping to `'unavailable'` would hide the pill; that would be a signal regression).
- **Keeps the word "expired"** — the existing `/expired/i` test stays green.
- **Still classifies as an auth error.** `isUsageAuthError` (`usage-error-copy.ts:56`) previously matched via the `\blog[ -]?in\b` pattern ("login"). The new text still matches via the `(?:access token|…) …(?:…|expired|…)` pattern ("access token expired"), so the status-bar tooltip copy is byte-for-byte unchanged.
- Matches the sibling raw-string (non-`translate()`) pattern of the other error strings in the same main-process file (`:141`, `:160`, `:163`) — no new untranslated user string introduced, no locale-catalog change needed.

Scope is one line + a one-line "why" comment.

## Evidence

Test-driven. Extended the existing expired-token test with an assertion capturing the bug (the message must not instruct `grok login`).

**Before** (`node_modules/.bin/vitest run --config config/vitest.config.ts src/main/rate-limits/grok-fetcher.test.ts`):

```
 FAIL  src/main/rate-limits/grok-fetcher.test.ts > fetchGrokRateLimits > returns error when the session token is expired
AssertionError: expected 'Grok session expired — run grok login…' not to match /grok login/i
+ Received:
"Grok session expired — run grok login to refresh"
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

**After**:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Also green: `grok-auth.test.ts`, `usage-error-copy.test.ts`, `pnpm run typecheck:tsc:node`, and `oxlint` on the changed files.

Old vs new message string:
- Old: `Grok session expired — run grok login to refresh`
- New: `Grok access token expired — Grok CLI will refresh it on next use`

A UI screenshot of the Grok pane is not feasible here (requires live Grok OAuth creds in headless CI), so the unit test is the authoritative evidence.

## ELI5

Your Grok login is like a day pass that expires every few hours, but you also have a season ticket that quietly prints a fresh day pass whenever you next walk in. Orca saw the expired day pass and yelled "you're logged out, go buy a new ticket!" — even though the season ticket had it covered. Now it just says "your pass expired; Grok will print a new one next time," and stops nagging you to log in again.

## Trade-offs

None. Message wording only; status, error classification, and control flow are unchanged.

## Relationship to existing PR

No open PR touches the token-expiry gate. `#8298` (billing `creditUsagePercent` fallbacks) and `#8336` (zero-percent usage visibility) both modify `grok-fetcher.ts`, but only the billing-mapping / HTTP-status branches and other test regions — neither touches `isGrokAccessTokenFresh` at `:147-151`. No logical conflict; at most a trivial textual merge in the same file. Coordinating so this lands independently of the billing work.

The separate `tokenFresh`-gated copy in `GrokAccountsSection.tsx:113` ("Session expired — run grok login in a terminal to refresh.") carries similar wording but is a distinct, out-of-scope string for this minimal fix; noted for a possible follow-up.

## Review loops

1 (fresh opus reviewer, returned CLEAN — verified diagnosis, the `isUsageAuthError` regex walk, retained `error`/`expired`/no-fetch contract, no other assertion on the old string, and raw-string consistency).

> ⚠️ Bug-bash PR — please review; do not merge yet.

Fixes #8497

Made with [Orca](https://github.com/stablyai/orca) 🐋
