### PR TITLE
Fix orchestration skill coverage for provider-home skill roots (#8256)

### DIFF
--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -57,6 +57,31 @@ describe('skill discovery', () => {
     expect(rootPaths).toContain('/workspace/current/.claude/skills')
   })
 
+  it('scans each provider home skill root that npx skills --global writes to', () => {
+    const roots = buildSkillDiscoverySources({
+      homeDir: '/home/test',
+      cwd: '/workspace/current'
+    })
+
+    const rootPaths = roots.map((root) => root.path.replace(/\\/g, '/'))
+    expect(rootPaths).toEqual(
+      expect.arrayContaining([
+        '/home/test/.grok/skills',
+        '/home/test/.config/opencode/skills',
+        '/home/test/.pi/agent/skills',
+        '/home/test/.gemini/antigravity/skills',
+        '/home/test/.cursor/skills'
+      ])
+    )
+    // Why: these live outside ~/.agents/skills, so they must carry the shared
+    // agent-skills provider to feed per-agent orchestration coverage.
+    for (const root of roots) {
+      if (root.path.replace(/\\/g, '/') === '/home/test/.grok/skills') {
+        expect(root.providers).toEqual(['agent-skills'])
+      }
+    }
+  })
+
   it('discovers skill packages through symlinked skill directories', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
     const home = join(root, 'home')
@@ -75,6 +100,27 @@ describe('skill discovery', () => {
     const skill = result.skills.find((entry) => entry.name === 'Orca CLI')
     expect(skill?.sourceKind).toBe('home')
     expect(skill?.directoryPath).toBe(linkedSkill)
+  })
+
+  it('discovers a symlinked skill inside a provider home root (#8256/#8503)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const realSkill = join(root, 'central-skills', 'orchestration')
+    const linkedSkill = join(home, '.pi', 'agent', 'skills', 'orchestration')
+    await mkdir(realSkill, { recursive: true })
+    await mkdir(join(home, '.pi', 'agent', 'skills'), { recursive: true })
+    await writeFile(join(realSkill, 'SKILL.md'), '# orchestration\n\nCoordinate agents.')
+    await symlink(realSkill, linkedSkill, process.platform === 'win32' ? 'junction' : 'dir')
+
+    const result = await discoverSkills({
+      homeDir: home,
+      cwd: join(root, 'missing-cwd')
+    })
+
+    const skill = result.skills.find((entry) => entry.name === 'orchestration')
+    expect(skill?.sourceKind).toBe('home')
+    expect(skill?.directoryPath).toBe(linkedSkill)
+    expect(skill?.providers).toEqual(['agent-skills'])
   })
 
   it('discovers worktree .agents skill symlinks from the requested cwd', async () => {

--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -69,6 +69,7 @@ describe('skill discovery', () => {
         '/home/test/.grok/skills',
         '/home/test/.config/opencode/skills',
         '/home/test/.pi/agent/skills',
+        '/home/test/.gemini/skills',
         '/home/test/.gemini/antigravity/skills',
         '/home/test/.cursor/skills'
       ])

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -41,7 +41,22 @@ export function buildSkillDiscoverySources(
       join(home, '.codex', 'plugins', 'cache'),
       'plugin',
       ['codex', 'agent-skills']
-    )
+    ),
+    // Why: `npx skills add --global` writes into each agent's own home skills
+    // directory, so coverage misses them unless we scan every provider root.
+    source('home-grok', 'Grok home', join(home, '.grok', 'skills'), 'home', ['agent-skills']),
+    source('home-opencode', 'OpenCode home', join(home, '.config', 'opencode', 'skills'), 'home', [
+      'agent-skills'
+    ]),
+    source('home-pi', 'Pi home', join(home, '.pi', 'agent', 'skills'), 'home', ['agent-skills']),
+    source(
+      'home-antigravity',
+      'Antigravity home',
+      join(home, '.gemini', 'antigravity', 'skills'),
+      'home',
+      ['agent-skills']
+    ),
+    source('home-cursor', 'Cursor home', join(home, '.cursor', 'skills'), 'home', ['agent-skills'])
   ]
 
   const projectPaths = new Set<string>()

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -49,6 +49,7 @@ export function buildSkillDiscoverySources(
       'agent-skills'
     ]),
     source('home-pi', 'Pi home', join(home, '.pi', 'agent', 'skills'), 'home', ['agent-skills']),
+    source('home-gemini', 'Gemini home', join(home, '.gemini', 'skills'), 'home', ['agent-skills']),
     source(
       'home-antigravity',
       'Antigravity home',

--- a/src/renderer/src/lib/orchestration-skill-coverage.test.ts
+++ b/src/renderer/src/lib/orchestration-skill-coverage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { DiscoveredSkill } from '../../../shared/skills'
+import type { TuiAgent } from '../../../shared/types'
 import {
   agentHasOrchestrationSkill,
   getOrchestrationSkillAgentStatuses
@@ -97,7 +98,71 @@ describe('orchestration skill agent coverage', () => {
     ).toBe(true)
   })
 
-  it('matches Windows skill paths', () => {
+  it('marks each provider-home agent from its own global skills location', () => {
+    const cases: { agent: TuiAgent; rootPath: string; directoryPath: string }[] = [
+      {
+        agent: 'grok',
+        rootPath: '/Users/test/.grok/skills',
+        directoryPath: '/Users/test/.grok/skills/orchestration'
+      },
+      {
+        agent: 'opencode',
+        rootPath: '/Users/test/.config/opencode/skills',
+        directoryPath: '/Users/test/.config/opencode/skills/orchestration'
+      },
+      {
+        agent: 'pi',
+        rootPath: '/Users/test/.pi/agent/skills',
+        directoryPath: '/Users/test/.pi/agent/skills/orchestration'
+      },
+      {
+        agent: 'antigravity',
+        rootPath: '/Users/test/.gemini/antigravity/skills',
+        directoryPath: '/Users/test/.gemini/antigravity/skills/orchestration'
+      },
+      {
+        agent: 'cursor',
+        rootPath: '/Users/test/.cursor/skills',
+        directoryPath: '/Users/test/.cursor/skills/orchestration'
+      }
+    ]
+    for (const { agent, rootPath, directoryPath } of cases) {
+      const skills = [
+        skill({ providers: ['agent-skills'], sourceKind: 'home', rootPath, directoryPath })
+      ]
+      expect(agentHasOrchestrationSkill(agent, skills)).toBe(true)
+      // Why: a provider-home install must not leak coverage to unrelated agents.
+      expect(agentHasOrchestrationSkill('claude', skills)).toBe(false)
+    }
+  })
+
+  it('marks a multi-segment provider-home agent from a Windows-style path', () => {
+    expect(
+      agentHasOrchestrationSkill('opencode', [
+        skill({
+          providers: ['agent-skills'],
+          sourceKind: 'home',
+          rootPath: 'C:\\Users\\test\\.config\\opencode\\skills',
+          directoryPath: 'C:\\Users\\test\\.config\\opencode\\skills\\orchestration'
+        })
+      ])
+    ).toBe(true)
+  })
+
+  it('marks Claude Agent Teams from ~/.claude/skills like Claude Code', () => {
+    const skills = [
+      skill({
+        providers: ['claude'],
+        sourceKind: 'home',
+        rootPath: '/Users/test/.claude/skills',
+        directoryPath: '/Users/test/.claude/skills/orchestration'
+      })
+    ]
+
+    expect(agentHasOrchestrationSkill('claude-agent-teams', skills)).toBe(true)
+  })
+
+  it('marks Windows skill paths', () => {
     expect(
       agentHasOrchestrationSkill('codex', [
         skill({

--- a/src/renderer/src/lib/orchestration-skill-coverage.test.ts
+++ b/src/renderer/src/lib/orchestration-skill-coverage.test.ts
@@ -116,6 +116,11 @@ describe('orchestration skill agent coverage', () => {
         directoryPath: '/Users/test/.pi/agent/skills/orchestration'
       },
       {
+        agent: 'gemini',
+        rootPath: '/Users/test/.gemini/skills',
+        directoryPath: '/Users/test/.gemini/skills/orchestration'
+      },
+      {
         agent: 'antigravity',
         rootPath: '/Users/test/.gemini/antigravity/skills',
         directoryPath: '/Users/test/.gemini/antigravity/skills/orchestration'
@@ -147,6 +152,32 @@ describe('orchestration skill agent coverage', () => {
         })
       ])
     ).toBe(true)
+  })
+
+  it('keeps Gemini and Antigravity distinct despite sharing the ~/.gemini root', () => {
+    const geminiInstall = [
+      skill({
+        providers: ['agent-skills'],
+        sourceKind: 'home',
+        rootPath: '/Users/test/.gemini/skills',
+        directoryPath: '/Users/test/.gemini/skills/orchestration'
+      })
+    ]
+    const antigravityInstall = [
+      skill({
+        providers: ['agent-skills'],
+        sourceKind: 'home',
+        rootPath: '/Users/test/.gemini/antigravity/skills',
+        directoryPath: '/Users/test/.gemini/antigravity/skills/orchestration'
+      })
+    ]
+
+    // Why: `.gemini/skills` and `.gemini/antigravity/skills` are siblings, so a
+    // segment matcher must not let one provider's install mark the other.
+    expect(agentHasOrchestrationSkill('gemini', geminiInstall)).toBe(true)
+    expect(agentHasOrchestrationSkill('antigravity', geminiInstall)).toBe(false)
+    expect(agentHasOrchestrationSkill('antigravity', antigravityInstall)).toBe(true)
+    expect(agentHasOrchestrationSkill('gemini', antigravityInstall)).toBe(false)
   })
 
   it('marks Claude Agent Teams from ~/.claude/skills like Claude Code', () => {

--- a/src/renderer/src/lib/orchestration-skill-coverage.ts
+++ b/src/renderer/src/lib/orchestration-skill-coverage.ts
@@ -9,6 +9,11 @@ export type OrchestrationSkillLocationId =
   | 'codex-home'
   | 'codex-plugin-cache'
   | 'agents-home'
+  | 'grok-home'
+  | 'opencode-home'
+  | 'pi-home'
+  | 'antigravity-home'
+  | 'cursor-home'
 
 export type OrchestrationSkillAgentStatus = {
   agent: TuiAgent
@@ -45,6 +50,35 @@ const ORCHESTRATION_SKILL_LOCATIONS: readonly OrchestrationSkillLocationDefiniti
     matchesSkill: (skill) =>
       isGlobalOrchestrationSkill(skill) &&
       pathContainsSegments(skill.rootPath, ['.agents', 'skills'])
+  },
+  {
+    id: 'grok-home',
+    matchesSkill: (skill) =>
+      isGlobalOrchestrationSkill(skill) && pathContainsSegments(skill.rootPath, ['.grok', 'skills'])
+  },
+  {
+    id: 'opencode-home',
+    matchesSkill: (skill) =>
+      isGlobalOrchestrationSkill(skill) &&
+      pathContainsSegments(skill.rootPath, ['.config', 'opencode', 'skills'])
+  },
+  {
+    id: 'pi-home',
+    matchesSkill: (skill) =>
+      isGlobalOrchestrationSkill(skill) &&
+      pathContainsSegments(skill.rootPath, ['.pi', 'agent', 'skills'])
+  },
+  {
+    id: 'antigravity-home',
+    matchesSkill: (skill) =>
+      isGlobalOrchestrationSkill(skill) &&
+      pathContainsSegments(skill.rootPath, ['.gemini', 'antigravity', 'skills'])
+  },
+  {
+    id: 'cursor-home',
+    matchesSkill: (skill) =>
+      isGlobalOrchestrationSkill(skill) &&
+      pathContainsSegments(skill.rootPath, ['.cursor', 'skills'])
   }
 ]
 
@@ -52,8 +86,15 @@ const ORCHESTRATION_SKILL_LOCATION_IDS_BY_AGENT: Partial<
   Record<TuiAgent, readonly OrchestrationSkillLocationId[]>
 > = {
   claude: ['claude-home', 'agents-home'],
+  // Why: Agent Teams runs Claude Code, so it reads the same ~/.claude skills.
+  'claude-agent-teams': ['claude-home', 'agents-home'],
   openclaude: ['claude-home', 'agents-home'],
-  codex: ['codex-home', 'codex-plugin-cache', 'agents-home']
+  codex: ['codex-home', 'codex-plugin-cache', 'agents-home'],
+  grok: ['grok-home', 'agents-home'],
+  opencode: ['opencode-home', 'agents-home'],
+  pi: ['pi-home', 'agents-home'],
+  antigravity: ['antigravity-home', 'agents-home'],
+  cursor: ['cursor-home', 'agents-home']
 }
 
 function normalizeSkillName(value: string): string {

--- a/src/renderer/src/lib/orchestration-skill-coverage.ts
+++ b/src/renderer/src/lib/orchestration-skill-coverage.ts
@@ -12,6 +12,7 @@ export type OrchestrationSkillLocationId =
   | 'grok-home'
   | 'opencode-home'
   | 'pi-home'
+  | 'gemini-home'
   | 'antigravity-home'
   | 'cursor-home'
 
@@ -69,6 +70,14 @@ const ORCHESTRATION_SKILL_LOCATIONS: readonly OrchestrationSkillLocationDefiniti
       pathContainsSegments(skill.rootPath, ['.pi', 'agent', 'skills'])
   },
   {
+    // Why: segment matching keeps `.gemini/skills` (Gemini CLI) distinct from the
+    // sibling `.gemini/antigravity/skills`, so the two never cross-mark each other.
+    id: 'gemini-home',
+    matchesSkill: (skill) =>
+      isGlobalOrchestrationSkill(skill) &&
+      pathContainsSegments(skill.rootPath, ['.gemini', 'skills'])
+  },
+  {
     id: 'antigravity-home',
     matchesSkill: (skill) =>
       isGlobalOrchestrationSkill(skill) &&
@@ -93,6 +102,7 @@ const ORCHESTRATION_SKILL_LOCATION_IDS_BY_AGENT: Partial<
   grok: ['grok-home', 'agents-home'],
   opencode: ['opencode-home', 'agents-home'],
   pi: ['pi-home', 'agents-home'],
+  gemini: ['gemini-home', 'agents-home'],
   antigravity: ['antigravity-home', 'agents-home'],
   cursor: ['cursor-home', 'agents-home']
 }


### PR DESCRIPTION
## Summary

The Orchestration → **Agent coverage** panel reported the orchestration skill as **Missing** for agents that actually have it installed. For a user who installed the skill for every agent, the panel showed only "2 of 8 detected agents have the skill" (Claude + Codex ready; Claude Agent Teams, Grok, OpenCode, Pi, Antigravity, Cursor all Missing).

This teaches skill discovery + coverage about each agent's own global skills directory, so an install performed with `npx skills add … --global` is credited to the right agent.

## Root cause

The reporter's **symlink framing is a red herring** — symlink following in `src/main/skills/discovery.ts` (`findSkillFiles`, lines ~101-127) is already correct and tested. The real cause is two gaps:

1. **`src/main/skills/skill-discovery-sources.ts:32-45`** — `buildSkillDiscoverySources` only scanned `~/.codex/skills`, `~/.agents/skills`, `~/.claude/skills`, and `~/.codex/plugins/cache`. It never scanned the per-provider home skill roots that `npx skills add --global` writes to, so those installs were never discovered.
2. **`src/renderer/src/lib/orchestration-skill-coverage.ts:24-57, :103`** — the coverage layer had no location definitions for those provider roots and no agent→location mappings, so every unmapped agent fell back to `['agents-home']`. `claude-agent-teams` was also unmapped despite reading the same `~/.claude/skills` as Claude Code.

Issue #8503 independently confirmed the exact symptom (`~/.pi/agent/skills/orchestration` present, Pi shown Missing).

## The fix

Added the provider home skill roots (provider `agent-skills`) to discovery, matching coverage location definitions, and per-agent mappings. Each path was verified against the repo's own config-path helpers (not blindly trusted):

| Agent | Skill root | Codebase evidence |
|---|---|---|
| `grok` | `~/.grok/skills` | `src/main/grok/hook-service.ts` (`${home}/.grok`) |
| `opencode` | `~/.config/opencode/skills` | `OPENCODE_CONFIG_DIR="$HOME/.config/opencode"` |
| `pi` | `~/.pi/agent/skills` | `PI_CODING_AGENT_DIR = ~/.pi/agent`; #8503 example |
| `antigravity` | `~/.gemini/antigravity/skills` | `src/main/antigravity/hook-service.ts` (`~/.gemini/…`) |
| `cursor` | `~/.cursor/skills` | `src/main/cursor/hook-service.ts` (`~/.cursor`) |

Each agent maps to `['<provider>-home', 'agents-home']`, and `claude-agent-teams` maps to `['claude-home', 'agents-home']` (it runs Claude Code). Coverage matching reuses the file's existing `pathContainsSegments` contiguous-segment matcher (case-insensitive, backslash-normalized) so Windows/SSH paths work, and the `sourceKind !== 'repo'` guard keeps repo-scoped installs from counting as global coverage.

Because the discovery fix scans these roots (with symlink following intact), this also resolves the sibling report **#8503** (Pi/OpenCode).

## Evidence

UI screenshot isn't feasible in headless CI — the co-located unit tests are authoritative.

**Before** (new tests fail against current `main`):

```
 FAIL  src/renderer/src/lib/orchestration-skill-coverage.test.ts > marks each provider-home agent from its own global skills location
   AssertionError: expected false to be true
 FAIL  src/renderer/src/lib/orchestration-skill-coverage.test.ts > marks Claude Agent Teams from ~/.claude/skills like Claude Code
   AssertionError: expected false to be true
 FAIL  src/main/skills/discovery.test.ts > scans each provider home skill root that npx skills --global writes to
   AssertionError: arrayContaining([...grok/opencode/pi/antigravity/cursor...])

 Test Files  2 failed (2)
      Tests  3 failed | 13 passed (16)
```

**After** (fix applied):

```
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

Also green: `pnpm run typecheck:tsc:node`, `pnpm run typecheck:tsc:web`, `oxlint` on all changed files, and the nearby skill suites (`src/main/skills`, `src/main/ipc/skills.test.ts`, `useInstalledAgentSkills.test.ts`, `agent-skill-cli-prerequisite.test.ts` — 37 passed).

## ELI5

Orca has a checklist that says which of your AI helpers already learned the "orchestration" trick. But Orca was only peeking into two of the drawers where the trick can be stored. If you put the trick in Grok's drawer or Pi's drawer, Orca didn't look there, so it said "missing" even though the helper had it. This makes Orca open every helper's own drawer before deciding.

## Trade-offs

None for the default layout. Known limitation (pre-existing, matches how the `.codex`/`.claude`/`.agents` roots already work): the roots are the default locations, so relocation env vars (`XDG_CONFIG_HOME`/`OPENCODE_CONFIG_DIR`, `GROK_HOME`, `PI_CODING_AGENT_DIR`) aren't honored for skill discovery yet — a reasonable follow-up.

## Relationship to existing PR

Connected PR **#8329** by @sdhilip200 targets the same bug. I implemented this independently first, then compared: our changes converge on the **exact same five provider paths, the same `pathContainsSegments` segment lists, and the same agent mappings** (including `claude-agent-teams`). That independent convergence is strong validation of the path list. **Decision: keep this PR independent.** It is functionally equivalent to #8329 but adds: a negative-leak assertion (a provider-home install must not mark unrelated agents), an end-to-end symlinked-discovery test tying #8256 + #8503 together, a Windows-backslash case for a multi-segment provider path, and "why" comments. Full credit to @sdhilip200 for the parallel diagnosis — either could land; if #8329 is preferred, the extra tests here are worth cherry-picking.

## Review loops

1 (a fresh independent reviewer returned CLEAN with no must-fix items; one non-blocking suggestion — a Windows-path case for the new multi-segment locations — was adopted).

> ⚠️ Bug-bash PR — please review; do not merge yet.

Fixes #8256

Made with [Orca](https://github.com/stablyai/orca) 🐋
