### PR TITLE
fix(sidebar): scope project display labels by execution host to prevent cross-host path collision (#8345)

### DIFF
--- a/src/renderer/src/components/repo/NestedRepoChecklist.tsx
+++ b/src/renderer/src/components/repo/NestedRepoChecklist.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, type Dispatch, type SetStateAction } from 'react'
 import { GitBranch } from 'lucide-react'
 import type { NestedRepoScanResult } from '../../../../shared/types'
 import { cn } from '@/lib/utils'
-import { getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
+import { getRepoDisplayLabelKey, getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import { translate } from '@/i18n/i18n'
 
 function NestedRepoSelectAllRow({
@@ -118,7 +118,7 @@ export function NestedRepoChecklist({
                   selectedPaths.has(repo.path) ? 'text-foreground' : 'text-muted-foreground'
                 )}
               >
-                {displayLabelsByPath.get(repo.path) ?? repo.displayName}
+                {displayLabelsByPath.get(getRepoDisplayLabelKey(repo)) ?? repo.displayName}
               </span>
             </label>
           </li>

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -32,7 +32,7 @@ import {
 import { cloneDefaultWorkspaceStatuses } from '../../../../shared/workspace-statuses'
 import type { AppState } from '../../store/types'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from '../../store/slices/github-cache-key'
-import { getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
+import { getRepoDisplayLabelKey, getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import { translate } from '@/i18n/i18n'
 import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
 import { parseWslUncPath } from '../../../../shared/wsl-paths'
@@ -709,7 +709,9 @@ function withRepoSectionDisplayLabels(entries: readonly OrderedGroupEntry[]): Or
   const labelsByPath = getRepoDisplayLabelsByPath(repos)
   return entries.map(([key, group]) => [
     key,
-    group.repo ? { ...group, label: labelsByPath.get(group.repo.path) ?? group.label } : group
+    group.repo
+      ? { ...group, label: labelsByPath.get(getRepoDisplayLabelKey(group.repo)) ?? group.label }
+      : group
   ])
 }
 

--- a/src/renderer/src/lib/repo-display-labels.test.ts
+++ b/src/renderer/src/lib/repo-display-labels.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getRepoDisplayLabelsByPath } from './repo-display-labels'
+import { getRepoDisplayLabelKey, getRepoDisplayLabelsByPath } from './repo-display-labels'
 
 describe('getRepoDisplayLabelsByPath', () => {
   it('keeps non-colliding repository names basename-only', () => {
@@ -8,8 +8,10 @@ describe('getRepoDisplayLabelsByPath', () => {
       { path: '/workspace/platform/worker', displayName: 'worker' }
     ])
 
-    expect(labels.get('/workspace/platform/web')).toBe('web')
-    expect(labels.get('/workspace/platform/worker')).toBe('worker')
+    expect(labels.get(getRepoDisplayLabelKey({ path: '/workspace/platform/web' }))).toBe('web')
+    expect(labels.get(getRepoDisplayLabelKey({ path: '/workspace/platform/worker' }))).toBe(
+      'worker'
+    )
   })
 
   it('adds the minimal real parent suffix only for colliding basenames', () => {
@@ -19,9 +21,13 @@ describe('getRepoDisplayLabelsByPath', () => {
       { path: '/workspace/platform/billing/api', displayName: 'api' }
     ])
 
-    expect(labels.get('/workspace/platform/web')).toBe('web')
-    expect(labels.get('/workspace/platform/payments/api')).toBe('payments/api')
-    expect(labels.get('/workspace/platform/billing/api')).toBe('billing/api')
+    expect(labels.get(getRepoDisplayLabelKey({ path: '/workspace/platform/web' }))).toBe('web')
+    expect(labels.get(getRepoDisplayLabelKey({ path: '/workspace/platform/payments/api' }))).toBe(
+      'payments/api'
+    )
+    expect(labels.get(getRepoDisplayLabelKey({ path: '/workspace/platform/billing/api' }))).toBe(
+      'billing/api'
+    )
   })
 
   it('expands colliding labels in lockstep without skipping shared segments', () => {
@@ -30,8 +36,24 @@ describe('getRepoDisplayLabelsByPath', () => {
       { path: '/workspace/team2/shared/api', displayName: 'api' }
     ])
 
-    expect(labels.get('/workspace/team1/shared/api')).toBe('team1/shared/api')
-    expect(labels.get('/workspace/team2/shared/api')).toBe('team2/shared/api')
+    expect(labels.get(getRepoDisplayLabelKey({ path: '/workspace/team1/shared/api' }))).toBe(
+      'team1/shared/api'
+    )
+    expect(labels.get(getRepoDisplayLabelKey({ path: '/workspace/team2/shared/api' }))).toBe(
+      'team2/shared/api'
+    )
+  })
+
+  it('scopes labels by execution host so same-path repos on different hosts do not collide', () => {
+    // Real SSH folder-repo shape: connectionId set, executionHostId unset — so
+    // it must fall back to the connection host, not look identical to a local repo.
+    const localRepo = { path: '/Users/alice', displayName: 'alice' }
+    const sshRepo = { path: '/Users/alice', displayName: 'alice-prod', connectionId: 'prod-ssh' }
+    const labels = getRepoDisplayLabelsByPath([localRepo, sshRepo])
+
+    expect(labels.get(getRepoDisplayLabelKey(localRepo))).toBe('alice')
+    expect(labels.get(getRepoDisplayLabelKey(sshRepo))).toBe('alice-prod')
+    expect(labels.size).toBe(2)
   })
 
   it('normalizes Windows separators to slash display labels', () => {
@@ -40,7 +62,11 @@ describe('getRepoDisplayLabelsByPath', () => {
       { path: 'C:\\workspace\\billing\\api', displayName: 'api' }
     ])
 
-    expect(labels.get('C:\\workspace\\payments\\api')).toBe('payments/api')
-    expect(labels.get('C:\\workspace\\billing\\api')).toBe('billing/api')
+    expect(labels.get(getRepoDisplayLabelKey({ path: 'C:\\workspace\\payments\\api' }))).toBe(
+      'payments/api'
+    )
+    expect(labels.get(getRepoDisplayLabelKey({ path: 'C:\\workspace\\billing\\api' }))).toBe(
+      'billing/api'
+    )
   })
 })

--- a/src/renderer/src/lib/repo-display-labels.test.ts
+++ b/src/renderer/src/lib/repo-display-labels.test.ts
@@ -56,6 +56,21 @@ describe('getRepoDisplayLabelsByPath', () => {
     expect(labels.size).toBe(2)
   })
 
+  it('keeps cross-host repos with identical path AND name as separate entries', () => {
+    // Hardening: when paths are byte-identical the same-name collision loop runs
+    // and re-sets each entry, so host scoping must survive that pass too — neither
+    // host may overwrite the other. Label text can still coincide; that residual is
+    // disambiguated by the host section/badge, not this map.
+    const localRepo = { path: '/Users/alice', displayName: 'home' }
+    const sshRepo = { path: '/Users/alice', displayName: 'home', connectionId: 'prod-ssh' }
+    const labels = getRepoDisplayLabelsByPath([localRepo, sshRepo])
+
+    expect(getRepoDisplayLabelKey(localRepo)).not.toBe(getRepoDisplayLabelKey(sshRepo))
+    expect(labels.size).toBe(2)
+    expect(labels.get(getRepoDisplayLabelKey(localRepo))).toBeDefined()
+    expect(labels.get(getRepoDisplayLabelKey(sshRepo))).toBeDefined()
+  })
+
   it('normalizes Windows separators to slash display labels', () => {
     const labels = getRepoDisplayLabelsByPath([
       { path: 'C:\\workspace\\payments\\api', displayName: 'api' },

--- a/src/renderer/src/lib/repo-display-labels.ts
+++ b/src/renderer/src/lib/repo-display-labels.ts
@@ -1,6 +1,21 @@
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
+
 type RepoDisplayLabelItem = {
   path: string
   displayName: string
+  connectionId?: string | null
+  executionHostId?: ExecutionHostId | null
+}
+
+// Why: two repos can share the same absolute path across hosts (e.g. a local
+// /Users/alice and an SSH host's /Users/alice). Keying labels by raw path alone
+// lets one repo's label overwrite the other's, so scope the key by execution
+// host. getRepoExecutionHostId returns 'local' for local repos and falls back to
+// the connectionId (ssh:<id>) for SSH folder-repos that leave executionHostId unset.
+export function getRepoDisplayLabelKey(
+  item: Pick<RepoDisplayLabelItem, 'path' | 'connectionId' | 'executionHostId'>
+): string {
+  return `${getRepoExecutionHostId(item)}::${item.path}`
 }
 
 function normalizePathSegments(path: string): string[] {
@@ -29,7 +44,7 @@ export function getRepoDisplayLabelsByPath(
 
   for (const item of items) {
     const displayName = item.displayName || item.path
-    labels.set(item.path, displayName)
+    labels.set(getRepoDisplayLabelKey(item), displayName)
     const colliding = itemsByName.get(displayName) ?? []
     colliding.push({ ...item, displayName })
     itemsByName.set(displayName, colliding)
@@ -49,7 +64,7 @@ export function getRepoDisplayLabelsByPath(
       nextLabels = collidingItems.map((item) => labelForDepth(item, depth))
     }
     collidingItems.forEach((item, index) => {
-      labels.set(item.path, nextLabels[index] ?? item.displayName)
+      labels.set(getRepoDisplayLabelKey(item), nextLabels[index] ?? item.displayName)
     })
   }
 


### PR DESCRIPTION
## Summary

Sidebar group-by-Project headers collide when two repos on **different hosts** share the same absolute path (for example a local `/Users/alice` and an SSH host's `/Users/alice`). One project's header silently shows the other project's name — one name effectively vanishes.

This scopes the display-label map key by **execution host**, using the canonical `getRepoExecutionHostId` helper, so same-path repos on different hosts no longer overwrite each other.

## Root cause

`getRepoDisplayLabelsByPath()` in `src/renderer/src/lib/repo-display-labels.ts` keyed its label map **only by raw filesystem path**:

- `repo-display-labels.ts:32` (initial `labels.set(item.path, ...)`)
- `repo-display-labels.ts:52` (collision-repair `labels.set(item.path, ...)`)

When a second item shares the first's path, its `labels.set(path, ...)` overwrites the first entry. The collision-repair loop only disambiguates items that share the same `displayName`, so a same-path / **different**-`displayName` cross-host collision is never detected. The sidebar header lookup at `src/renderer/src/components/sidebar/worktree-list-groups.ts:712` (`labelsByPath.get(group.repo.path)`) then reads the surviving (wrong) label. The Projects filter popover reads `repo.displayName` directly and is unaffected — matching the reporter.

## The fix

- Widen `RepoDisplayLabelItem` with optional `connectionId?` / `executionHostId?` (types identical to `Repo`'s fields).
- Add exported `getRepoDisplayLabelKey(item)` = `` `${getRepoExecutionHostId(item)}::${item.path}` ``. `getRepoExecutionHostId` (canonical helper, `src/shared/execution-host.ts:142`) returns `'local'` for local repos and, crucially, **falls back to `ssh:<connectionId>` for SSH folder-repos whose `executionHostId` is unset**.
- Key **both** `labels.set()` sites and **both** consumer lookups by that composite key: `worktree-list-groups.ts` and `src/renderer/src/components/repo/NestedRepoChecklist.tsx`.

**Why zero-regression:**
- Single-host unique-path cases keep their labels; the map key simply moves consistently from `path` → `local::path` on both the set and get sides (the only two consumers are updated in lockstep; nothing else reads the map keys).
- `NestedRepoCandidate` (path/displayName/depth, no host fields) resolves to `local::path` on both sides — behavior unchanged for a single-host folder scan.
- The `::` separator can never forge a collision: host ids are `local`, `ssh:<encodeURIComponent(id)>`, or `runtime:<encodeURIComponent(id)>`, and `encodeURIComponent` escapes `:` to `%3A`, so a host id never contains `::` even for a path that itself contains `::`.
- The collision-repair loop spreads `{ ...item, displayName }`, preserving host fields, so its set-site recomputes the same composite key.

## Evidence

UI verification would require standing up a live local + SSH cross-host repo set sharing one absolute path in headless CI — not feasible here — so the co-located unit test is the authoritative reproduction.

**Before** (raw-path keying — the local repo's label is lost; the map collapses to one entry):

```
 ❯ src/renderer/src/lib/repo-display-labels.test.ts (5 tests | 1 failed)
     × scopes labels by execution host so same-path repos on different hosts do not collide

 FAIL  … > scopes labels by execution host so same-path repos on different hosts do not collide
AssertionError: expected undefined to be 'alice' // Object.is equality
- Expected: "alice"
+ Received: undefined

 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

**After** (host-scoped keying):

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Nearby suites also green: `worktree-list-groups.test.ts` 90/90, `NestedRepoChecklist.test.tsx` 1/1. `pnpm run typecheck:tsc:web` exit 0; oxlint exit 0; oxfmt applied.

## ELI5

Two folders can have the exact same address (`/Users/alice`) — one on your Mac, one on a remote SSH machine. The sidebar used only the address to label each project, so the two "same-address" projects fought over one label and one name disappeared. Now the label also remembers **which machine** the folder lives on, so both projects keep their own name.

## Trade-offs

None. If two repos share the same path **and** the same `displayName` on different hosts, path-based disambiguation still can't tell them apart by text — but they now retain distinct map entries instead of one overwriting the other (strictly better than the pre-fix "vanish"), and the reported differing-name case is fully fixed.

## Relationship to existing PR

Builds on the same diagnosis as **#8375 by @sudoeren** — credit to them for spotting the raw-path keying. That PR is **incomplete for the reported scenario**: its `getRepoDisplayLabelKey` reads `item.executionHostId` **directly** and falls back to bare `path` when it's absent:

```ts
return item.executionHostId ? `${item.executionHostId}::${item.path}` : item.path
```

Real SSH folder-repos leave `executionHostId` **unset** (they carry only `connectionId`), so a local `/Users/alice` and an SSH `/Users/alice` both key to bare `/Users/alice` and **still collide** — the exact case in the issue. Its test hardcodes `executionHostId: 'ssh:my-host'`, which masks the gap. This PR routes through the canonical `getRepoExecutionHostId` helper (local→`local`, SSH folder-repo→`ssh:<connectionId>`), and its test uses the real folder-repo shape (`connectionId` set, `executionHostId` unset), so it fixes the reported cross-host collision.

## Review loops

1 (fresh reviewer, returned CLEAN).

> ⚠️ Bug-bash PR — please review; do not merge yet.

Fixes #8345

Made with [Orca](https://github.com/stablyai/orca) 🐋
