### PR TITLE
fix(cli): stop ELECTRON_RUN_AS_NODE leaking into orca claude-teams child

### DIFF
--- a/src/cli/handlers/core.test.ts
+++ b/src/cli/handlers/core.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+// The claude-teams handler spawns `claude` via node:child_process; mock it so we
+// can inspect the child env without launching a real process.
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+// Keep the socket runtime client out of the import graph; only the error type
+// and serveOrcaApp binding are referenced by the module under test.
+vi.mock('../runtime-client', () => ({
+  RuntimeClientError: class RuntimeClientError extends Error {
+    readonly code: string
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  },
+  serveOrcaApp: vi.fn()
+}))
+
+import { CORE_HANDLERS } from './core'
+import type { HandlerContext } from '../dispatch'
+import type { RuntimeClient } from '../runtime-client'
+
+type SpawnEnv = Record<string, string | undefined>
+
+// Minimal child stub: the handler only awaits `exit`, so resolve it on the next
+// microtask to complete the spawned-process promise deterministically.
+function mockClaudeChild(): { once: (event: string, cb: (...args: unknown[]) => void) => unknown } {
+  const child = {
+    once(event: string, cb: (...args: unknown[]) => void) {
+      if (event === 'exit') {
+        queueMicrotask(() => cb(0, null))
+      }
+      return child
+    }
+  }
+  return child
+}
+
+describe('orca claude-teams CLI handler', () => {
+  const isWindows = process.platform === 'win32'
+  let previousRunAsNode: string | undefined
+  let previousPaneKey: string | undefined
+  let previousExitCode: typeof process.exitCode
+
+  const callMock = vi.fn()
+  const client = { call: callMock } as unknown as RuntimeClient
+
+  function runClaudeTeams(): Promise<void> {
+    const ctx: HandlerContext = {
+      flags: new Map(),
+      client,
+      cwd: '/tmp/repo',
+      json: false,
+      rawArgs: []
+    }
+    return CORE_HANDLERS['claude-teams'](ctx)
+  }
+
+  beforeEach(() => {
+    spawnMock.mockReset()
+    spawnMock.mockImplementation(() => mockClaudeChild())
+    callMock.mockReset()
+    callMock.mockResolvedValue({
+      result: { launch: { env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1', PATH: '/shim:/usr/bin' } } }
+    })
+    previousRunAsNode = process.env.ELECTRON_RUN_AS_NODE
+    previousPaneKey = process.env.ORCA_PANE_KEY
+    previousExitCode = process.exitCode
+    // The `orca` launcher runs Orca's Electron binary as Node, so the CLI process
+    // itself carries ELECTRON_RUN_AS_NODE=1. Reproduce that inherited flag here.
+    process.env.ELECTRON_RUN_AS_NODE = '1'
+    process.env.ORCA_PANE_KEY = 'tab-1:leaf-1'
+  })
+
+  afterEach(() => {
+    if (previousRunAsNode === undefined) {
+      delete process.env.ELECTRON_RUN_AS_NODE
+    } else {
+      process.env.ELECTRON_RUN_AS_NODE = previousRunAsNode
+    }
+    if (previousPaneKey === undefined) {
+      delete process.env.ORCA_PANE_KEY
+    } else {
+      process.env.ORCA_PANE_KEY = previousPaneKey
+    }
+    process.exitCode = previousExitCode
+  })
+
+  // Guarded to non-Windows: the handler early-returns unsupported_platform on
+  // win32, so the leak path never runs there.
+  it.skipIf(isWindows)(
+    'does not leak ELECTRON_RUN_AS_NODE into the spawned claude child',
+    async () => {
+      await runClaudeTeams()
+
+      expect(spawnMock).toHaveBeenCalledWith('claude', expect.any(Array), expect.any(Object))
+      const spawnEnv = spawnMock.mock.calls.at(-1)?.[2].env as SpawnEnv
+      expect(spawnEnv.ELECTRON_RUN_AS_NODE).toBeUndefined()
+
+      // The prepareLaunch request env is built from the same helper, so it must
+      // be sanitized too.
+      const prepareLaunchEnv = (callMock.mock.calls[0][1] as { env: SpawnEnv }).env
+      expect(prepareLaunchEnv.ELECTRON_RUN_AS_NODE).toBeUndefined()
+    }
+  )
+
+  it.skipIf(isWindows)(
+    'still forwards non-Electron parent env and prepareLaunch env to claude',
+    async () => {
+      const previousMarker = process.env.ORCA_TEST_MARKER
+      process.env.ORCA_TEST_MARKER = 'keep-me'
+      try {
+        await runClaudeTeams()
+      } finally {
+        if (previousMarker === undefined) {
+          delete process.env.ORCA_TEST_MARKER
+        } else {
+          process.env.ORCA_TEST_MARKER = previousMarker
+        }
+      }
+
+      const spawnEnv = spawnMock.mock.calls.at(-1)?.[2].env as SpawnEnv
+      expect(spawnEnv.ORCA_TEST_MARKER).toBe('keep-me')
+      expect(spawnEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).toBe('1')
+      expect(spawnEnv.PATH).toBe('/shim:/usr/bin')
+    }
+  )
+})

--- a/src/cli/handlers/core.ts
+++ b/src/cli/handlers/core.ts
@@ -2,10 +2,16 @@ import { spawn } from 'node:child_process'
 import type { CommandHandler } from '../dispatch'
 import { formatCliStatus, formatStatus, printResult } from '../format'
 import { RuntimeClientError, serveOrcaApp } from '../runtime-client'
+import { stripElectronRunAsNode } from '../runtime/launch'
 
 function envRecord(): Record<string, string> {
+  // Why: the `orca` launcher runs Orca's Electron binary as Node, so this CLI
+  // process carries ELECTRON_RUN_AS_NODE=1. Strip it before it reaches the
+  // spawned `claude` (and any nested Electron it launches), which would
+  // otherwise be forced into headless plain-Node mode.
+  const env = stripElectronRunAsNode(process.env)
   return Object.fromEntries(
-    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
+    Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined)
   )
 }
 

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -266,7 +266,7 @@ function resolveForegroundOrcaExecutable(): string {
   )
 }
 
-function stripElectronRunAsNode(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+export function stripElectronRunAsNode(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const next = { ...env }
   delete next.ELECTRON_RUN_AS_NODE
   return next


### PR DESCRIPTION
## Summary

`orca claude-teams` leaks `ELECTRON_RUN_AS_NODE=1` into the spawned `claude` process. Orca's Electron binary doubles as the CLI's Node runtime, so the launcher injects `ELECTRON_RUN_AS_NODE=1` for the CLI process itself — correct for the CLI, but it must not flow into `claude` or anything `claude` spawns. When it does, a nested Electron command (e.g. `pnpm dev`) is forced into headless plain-Node mode and never opens a window.

This mirrors the already-merged daemon→PTY sibling fix (`src/main/daemon/pty-subprocess.ts`, test at `pty-subprocess.test.ts:1049`).

## Root cause

- `src/main/cli/cli-installer.ts:931` (Unix) / `:953` (Windows) inject `ELECTRON_RUN_AS_NODE=1` so the packaged Electron binary runs the CLI as Node — correct for the CLI process.
- `src/cli/handlers/core.ts:6` — `envRecord()` spread `process.env` verbatim (no strip) and is used both for the `agentTeams.prepareLaunch` request env and as the base env for the spawned `claude` (`core.ts:73` and `:76-82`).
- `prepareClaudeAgentTeamsLeader` → `ClaudeAgentTeamsService.createLaunchEnv` (`src/main/runtime/claude-agent-teams-service.ts:37`) returns an explicitly-enumerated env that never contains `ELECTRON_RUN_AS_NODE`, so it does not overwrite the inherited flag in the spread `{ ...envRecord(), ...launch.env }`. Result: `claude` (and its children) inherit `ELECTRON_RUN_AS_NODE=1`.
- Windows never hits this: the `claude-teams` handler early-returns `unsupported_platform` (`core.ts:56-61`), so the leak path is macOS/Linux only.

## The fix

Reuse the existing sanctioned helper `stripElectronRunAsNode` (`src/cli/runtime/launch.ts:269`, already used by the `open`/`serve` paths). Export it and apply it inside `envRecord()` so the flag is removed before the record is built.

Why it is zero-regression:
- `envRecord()` is referenced **only** by the `claude-teams` handler (grep-confirmed), so `open`/`serve`/`status` are untouched. `serve` already strips independently via `serveOrcaApp`.
- `stripElectronRunAsNode` is non-mutating (`{ ...env }` then `delete`), so it cleans the **child** env only and never alters the CLI process's own environment.
- Both consumers of `envRecord()` (the prepareLaunch request env and the `claude` spawn base env) are now clean.

## Evidence

A real nested-Electron repro needs a GUI/desktop session and is not feasible in headless CI. The authoritative check is a co-located unit test that asserts the spawned `claude` env carries no `ELECTRON_RUN_AS_NODE` (and that the prepareLaunch request env is likewise clean), guarded with `skipIf(win32)` to match the handler's Windows early-return.

Before the fix:

```
 FAIL  src/cli/handlers/core.test.ts > orca claude-teams CLI handler > does not leak ELECTRON_RUN_AS_NODE into the spawned claude child
AssertionError: expected '1' to be undefined
- Expected: undefined
+ Received: "1"
 ❯ src/cli/handlers/core.test.ts:101:45
    101|       expect(spawnEnv.ELECTRON_RUN_AS_NODE).toBeUndefined()
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

After the fix:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Nearby suites (`src/cli/handlers`, `src/cli/runtime`, incl. `launch.test.ts` covering the exported helper): **19 files / 175 tests passed**. `typecheck:tsc:cli` + `typecheck:tsc:node` clean; oxlint clean on changed files.

## ELI5

Orca tells its own app "pretend you're plain Node" so it can run the little `orca` command. But when `orca claude-teams` starts the real `claude` program, it accidentally handed that "pretend you're plain Node" sticky note to `claude` too — so any app `claude` later started (like the dev server) opened invisibly with no window. This peels the sticky note off before `claude` starts.

## Trade-offs

None. The strip is scoped to the single handler that was leaking, and the helper is already the sanctioned strip used elsewhere.

## Relationship to existing PR

Connected PR #7774 by @sundevilyang applies the same minimal, correct change (export `stripElectronRunAsNode`, apply in `envRecord()`). That PR is a cross-repo fork, so its CI needs maintainer approval. This PR is an independent, convergent implementation from a maintainer branch; the production change matches theirs, and the test is co-located in `src/cli/handlers/core.test.ts` (invoking the handler directly) rather than in `src/cli/index.test.ts`, and additionally asserts the prepareLaunch request env is sanitized and non-Electron parent env is still forwarded. Full credit to @sundevilyang for the original diagnosis and fix. If maintainers prefer, either can be merged — they are equivalent.

## Review loops

1 (a fresh independent reviewer returned CLEAN on the first round after verifying leak reproduction, the scoping/zero-regression claim, cross-platform guard, and test strength).

> ⚠️ Bug-bash PR — please review; do not merge yet.

Fixes #7768

Made with [Orca](https://github.com/stablyai/orca) 🐋
