### PR TITLE
fix(orchestration): compare stale-dispatch timestamps with julianday

### DIFF
--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -6,6 +6,20 @@ import Database from '../../sqlite/sync-database'
 import { OrchestrationDb } from './db'
 import type { MessageType } from './db'
 
+// Overwrites the datetime('now')-seeded timestamps with explicit fixture values
+// so stale-detection assertions stay deterministic (no wall clock).
+function setDispatchTimes(
+  d: OrchestrationDb,
+  id: string,
+  dispatchedAt: string,
+  heartbeatAt: string | null = null
+): void {
+  const sqlite = (d as unknown as { db: Database.Database }).db
+  sqlite
+    .prepare('UPDATE dispatch_contexts SET dispatched_at = ?, last_heartbeat_at = ? WHERE id = ?')
+    .run(dispatchedAt, heartbeatAt, id)
+}
+
 describe('OrchestrationDb', () => {
   let db: OrchestrationDb | undefined
 
@@ -694,6 +708,67 @@ describe('OrchestrationDb', () => {
 
       const stale = d.getStaleDispatches(iso(10 * 60 * 1000))
       expect(stale.map((s) => s.id)).toEqual([ctxB.id])
+    })
+
+    // Regression for #8452: dispatched_at / last_heartbeat_at are written by
+    // datetime('now') (space-format, e.g. "2026-07-12 12:00:00") while the
+    // threshold is ISO ("...T11:55:00.000Z"). Raw TEXT ordering ranks the space
+    // (0x20) below the 'T' (0x54) at index 10, flagging fresh same-date rows.
+    it('getStaleDispatches ignores fresh SQLite space-format timestamps (#8452)', () => {
+      const d = createDb()
+
+      // Fresh worker: dispatched 12:00, heartbeat 12:05 (space-format), both
+      // after the 11:55 threshold → NOT stale.
+      const fresh = d.createDispatchContext(d.createTask({ spec: 'fresh' }).id, 'term_fresh')
+      setDispatchTimes(d, fresh.id, '2026-07-12 12:00:00', '2026-07-12 12:05:00')
+
+      // Legacy ISO-format fresh row (mixed-format table) stays fresh too.
+      const legacy = d.createDispatchContext(d.createTask({ spec: 'legacy' }).id, 'term_legacy')
+      setDispatchTimes(d, legacy.id, '2026-07-12T12:00:00.000Z', '2026-07-12T12:05:00.000Z')
+
+      // Genuinely hung: dispatched + heartbeated at 10:00, ~2h before threshold.
+      const hung = d.createDispatchContext(d.createTask({ spec: 'hung' }).id, 'term_hung')
+      setDispatchTimes(d, hung.id, '2026-07-12 10:00:00', '2026-07-12 10:00:00')
+
+      const stale = d.getStaleDispatches('2026-07-12T11:55:00.000Z')
+      expect(stale.map((s) => s.id)).toEqual([hung.id])
+    })
+
+    it('getStaleDispatches keeps a just-dispatched space-format row in the grace window (#8452)', () => {
+      const d = createDb()
+
+      // Space-format dispatched_at one minute after the threshold, no heartbeat
+      // yet → still inside the grace window, must not be flagged.
+      const ctx = d.createDispatchContext(d.createTask({ spec: 'x' }).id, 'term_x')
+      setDispatchTimes(d, ctx.id, '2026-07-12 12:00:00')
+
+      const stale = d.getStaleDispatches('2026-07-12T11:59:00.000Z')
+      expect(stale).toEqual([])
+    })
+
+    // Same-UTC-date midnight threshold: keeps the buggy space-vs-'T' compare in
+    // play so this guards the fix at a day boundary (#8452; idea from @KMGeon's #8453).
+    it('getStaleDispatches keeps a fresh row just after a UTC-midnight threshold (#8452)', () => {
+      const d = createDb()
+
+      const ctx = d.createDispatchContext(d.createTask({ spec: 'midnight' }).id, 'term_midnight')
+      setDispatchTimes(d, ctx.id, '2026-05-04 00:04:00')
+
+      const stale = d.getStaleDispatches('2026-05-04T00:00:00.000Z')
+      expect(stale).toEqual([])
+    })
+
+    // Guards the last_heartbeat_at half of the fix on its own: a worker
+    // dispatched long before the threshold (stale under either format) that
+    // just sent a fresh space-format heartbeat must stay fresh (#8452).
+    it('getStaleDispatches keeps a live worker with a fresh space-format heartbeat (#8452)', () => {
+      const d = createDb()
+
+      const ctx = d.createDispatchContext(d.createTask({ spec: 'live' }).id, 'term_live')
+      setDispatchTimes(d, ctx.id, '2026-07-12 10:00:00', '2026-07-12 11:59:00')
+
+      const stale = d.getStaleDispatches('2026-07-12T11:55:00.000Z')
+      expect(stale).toEqual([])
     })
 
     it('getThreadMessagesFor returns only same-thread replies to a handle', () => {

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -798,17 +798,20 @@ export class OrchestrationDb {
   // failed / circuit_broken row with an old-or-null last_heartbeat_at would
   // warn every tick (warning storm). Without `dispatched_at < :threshold`,
   // a freshly-dispatched worker would trip the warning during its first
-  // heartbeat interval (false positive). Callers supply the threshold as an
-  // ISO timestamp so the SQLite string-compare ordering works correctly
-  // (ISO-8601 compares lexicographically in time order).
+  // heartbeat interval (false positive). The stored columns are space-format
+  // (datetime('now'), "2026-07-12 12:00:00") while the threshold is ISO-Z, so
+  // raw TEXT ordering compares ' ' (0x20) below 'T' (0x54) at index 10 and
+  // flags fresh same-date rows as stale (#8452). julianday() parses both
+  // formats as UTC for a correct numeric comparison; a malformed timestamp
+  // yields NULL, so that row simply isn't flagged.
   getStaleDispatches(thresholdIso: string): DispatchContextRow[] {
     return this.db
       .prepare(
         `SELECT * FROM dispatch_contexts
          WHERE status = 'dispatched'
            AND dispatched_at IS NOT NULL
-           AND dispatched_at < ?
-           AND (last_heartbeat_at IS NULL OR last_heartbeat_at < ?)`
+           AND julianday(dispatched_at) < julianday(?)
+           AND (last_heartbeat_at IS NULL OR julianday(last_heartbeat_at) < julianday(?))`
       )
       .all(thresholdIso, thresholdIso) as DispatchContextRow[]
   }


### PR DESCRIPTION
## Summary

`getStaleDispatches()` was flagging fresh orchestration dispatches/heartbeats as stale, producing a false `Warning: worker … has not sent a heartbeat` on every coordinator tick. The root cause is a timestamp-format mismatch resolved by comparing with SQLite `julianday()` instead of raw TEXT ordering.

## Root cause

`src/main/runtime/orchestration/db.ts` — `getStaleDispatches()` (lines 807-817).

- `dispatched_at` is written by `datetime('now')` (`db.ts:688`) and `last_heartbeat_at` from `msg.created_at`, also `datetime('now')` (`lifecycle-reconciliation.ts:151`). Both are **space-format**, e.g. `"2026-07-12 17:25:00"`.
- The threshold comes from `coordinator.ts:237` as `new Date(Date.now() - HUNG_THRESHOLD_MS).toISOString()`, i.e. **ISO-Z**, e.g. `"2026-07-12T17:15:00.000Z"`.
- The query compared them with raw TEXT ordering (`dispatched_at < ?`, `last_heartbeat_at < ?`). At index 10 the stored `' '` (0x20) sorts **below** the ISO `'T'` (0x54), so any stored timestamp on the same UTC date is deemed less-than the threshold — a fresh, seconds-old dispatch is classified stale, every tick.

## The fix

Wrap both column comparisons **and** both bound threshold params in `julianday()`:

```sql
AND julianday(dispatched_at) < julianday(?)
AND (last_heartbeat_at IS NULL OR julianday(last_heartbeat_at) < julianday(?))
```

`julianday()` parses both the space format and the ISO-Z format as UTC, giving a correct numeric comparison.

Why zero-regression:
- The only consumer is `Coordinator.warnStaleDispatches()` → `onLog` (a warning; it deliberately does **not** auto-fail), so behavior change is confined to when that warning fires.
- Genuinely stale rows are still detected (the numeric comparison agrees with the old one for real time gaps).
- A malformed timestamp makes `julianday()` return `NULL`, so the row is simply not flagged — safe for a warning-only path, and unreachable for real data since production always writes valid `datetime('now')`.
- The table is tiny and has no index on these columns, so wrapping them in a function changes no query plan (the `status = 'dispatched'` filter still uses `idx_dispatch_status`). Embedded SQLite means identical behavior on macOS/Linux/Windows and over SSH (the DB runs in the main process, not on the remote host).

## Evidence

Backend/logic bug — no UI to screenshot; the co-located tests are authoritative. Each new test was confirmed to fail on the unpatched raw-compare query and pass with `julianday()`.

Before (production SQL temporarily reverted to raw compare):

```
 ❯ src/main/runtime/orchestration/db.test.ts (61 tests | 4 failed | 57 skipped)
       × getStaleDispatches ignores fresh SQLite space-format timestamps (#8452)
       × getStaleDispatches keeps a just-dispatched space-format row in the grace window (#8452)
       × getStaleDispatches keeps a fresh row just after a UTC-midnight threshold (#8452)
       × getStaleDispatches keeps a live worker with a fresh space-format heartbeat (#8452)
      Tests  4 failed | 57 skipped (61)
```

After (fix applied):

```
 Test Files  1 passed (1)
      Tests  61 passed (61)
```

Full orchestration suite + node typecheck + oxlint + oxfmt all green:

```
 Test Files  6 passed (6)
      Tests  159 passed (159)
```

## ELI5

The database saves the time a worker started using a plain format like `2026-07-12 17:25:00` (with a space in the middle). The checker asked "is this older than 10 minutes ago?" but wrote the cutoff time with a `T` in the middle (`...T17:15:00Z`) and compared them letter-by-letter like words in a dictionary. A space comes before the letter `T` in that ordering, so the computer thought the worker's start time was "smaller" — i.e. older — even when it had just started a second ago. It then cried "this worker looks stuck!" over and over. The fix converts both times into real numbers before comparing, so brand-new workers are correctly seen as fresh.

## Trade-offs

None.

## Relationship to existing PR

PR #8453 by @KMGeon independently lands the exact same production fix (`julianday()` on both columns and both bound params) — the convergence is strong confirmation of correctness. I developed this fix independently from the root cause and then reconciled: I kept my own implementation (identical SQL) and adopted the spirit of @KMGeon's UTC-midnight boundary test, but corrected its fixture — as written in #8453 the midnight threshold sits on the *previous* UTC date, so the lexicographic compare resolves at the day digit (index 9) *before* the space-vs-`T` mismatch at index 10, meaning that test passes even on the buggy code and guards nothing. My version keeps the threshold on the same UTC date so it is a real regression guard, and I additionally added a test that isolates the `last_heartbeat_at` half of the fix. Credit to @KMGeon for the boundary-case idea.

## Review loops

Reviewed by an independent agent 3 times until clean (iteration 1: corrected a non-guarding midnight test; iteration 2: added an isolated `last_heartbeat_at`-clause guard; iteration 3: CLEAN).

> ⚠️ Bug-bash PR — please review; do not merge yet.

Fixes #8452

Made with [Orca](https://github.com/stablyai/orca) 🐋
