### PR TITLE
fix(grok): stop treating a refreshable expired token as a logout

### DIFF
--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -161,4 +161,20 @@ describe('fetchGrokRateLimits', () => {
     expect(result.error).toMatch(/expired/i)
     expect(netFetchMock).not.toHaveBeenCalled()
   })
+
+  it('does not demand an interactive login when the access token is only expired', async () => {
+    // Why: Grok CLI owns token rotation via its stored refresh token and
+    // refreshes ~/.grok/auth.json on its next run (like Kimi). An expired
+    // short-lived access token must not tell the user to run `grok login`.
+    authState.file = JSON.stringify({
+      'https://auth.x.ai::client': {
+        key: 'stale',
+        expires_at: '2000-01-01T00:00:00.000Z'
+      }
+    })
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('error')
+    expect(result.error).not.toMatch(/grok login/i)
+    expect(result.error).toMatch(/open grok/i)
+  })
 })

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -145,7 +145,10 @@ export async function fetchGrokRateLimits(
   }
   const session = readResult.session
   if (!isGrokAccessTokenFresh(session)) {
-    return result('error', 'Grok session expired — run grok login to refresh')
+    // Why: Grok CLI owns token rotation via its stored refresh token and
+    // refreshes auth.json on its next run (like Kimi). An expired short-lived
+    // access token is not a logout — don't force an interactive `grok login`.
+    return result('error', 'Grok token expired — open Grok to refresh')
   }
 
   try {


### PR DESCRIPTION
## Problem
When the short-lived Grok OAuth access token in `~/.grok/auth.json` passes its `expires_at`, the usage panel reports "run grok login to refresh" and forces a full interactive browser login every ~6 hours — even though the Grok CLI silently refreshes the token via its stored refresh token on the next run (#8497).

## Fix
Stop treating a refreshable expired token as a logout. The expired-token branch now returns "Grok token expired — open Grok to refresh" (keeping the `error` status so the last good snapshot is retained), matching the sibling `kimi-fetcher.ts`, which already handles the identical CLI-owned-auth / refresh-token pattern correctly. Signed-out / token-less cases are still handled separately as `unavailable`.

## Testing
Added a regression test in `grok-fetcher.test.ts` asserting the expiry message does not demand `grok login` (red before, green after). Full rate-limits suite (294 tests) passes; lint/format clean.

Closes #8497

X: [@mark86202384100](https://x.com/mark86202384100)
