### PR TITLE
fix(e2e): compare store repo paths with normalized separators on Windows

### DIFF
--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -280,6 +280,9 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     }
 
     const repoPath = isValidGitRepo(testRepoPath) ? testRepoPath : createSeededTestRepo()
+    // Why: the store returns forward-slash-normalized paths on Windows, so
+    // comparing against the Node-side C:\ form fails every fixture boot there.
+    const storeRepoPath = repoPath.replace(/\\/g, '/')
 
     // Add the test repo via the IPC bridge
     // Why: calling window.api.repos.add() goes through the same code path as
@@ -314,7 +317,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
             // repos hide those by default after the visibility rollout.
             await store.getState().updateRepo(repo.id, { externalWorktreeVisibility: 'show' })
             return true
-          }, repoPath),
+          }, storeRepoPath),
         {
           timeout: 30_000,
           message: `Expected e2e repo to be loaded: ${repoPath}`
@@ -356,7 +359,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
             }
             await store.getState().fetchWorktrees(repo.id)
             return store.getState().worktreesByRepo[repo.id]?.length ?? 0
-          }, repoPath),
+          }, storeRepoPath),
         {
           timeout: 30_000,
           message: 'seeded e2e worktrees did not load'
@@ -392,7 +395,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
       if (testWorktree) {
         state.setActiveWorktree(testWorktree.id)
       }
-    }, repoPath)
+    }, storeRepoPath)
 
     // Best-effort seed of a baseline terminal tab when a fresh isolated
     // profile has none yet.


### PR DESCRIPTION
## Summary

Every e2e spec using the shared `orca-app` fixture fails during boot on Windows: the fixture strict-compares the store's forward-slash-normalized repo/worktree paths against the Node-side `C:\...` form (three sites in `tests/e2e/helpers/orca-app.ts`), so `fetchRepos`/worktree polls never match and specs die before their first real assertion.

Normalize the host path once (`storeRepoPath`) and use it for the three store comparisons; `repos.add()` keeps the native form.

Found while running the PR #8502 Windows verification: a Windows agent confirmed 0/6 target specs boot on `main`, and that with an equivalent temporary normalization diagnostic in place the fixture boots and 5/6 specs pass (the sixth is an unrelated Windows PowerShell OSC-title issue, filed separately). This unblocks Windows e2e gating for terminal work generally.

## Screenshots

No visual change (test harness only).

## Testing

- [x] `pnpm exec oxlint` / `oxfmt --check` on the changed file
- [x] Behavior-equivalent normalization verified on Windows 11 (build 26200) by the reporting agent: fixture boots, 5/6 target specs pass
- [ ] macOS/Linux e2e unaffected (`replace(/\\/g, '/')` is a no-op on POSIX paths) — CI will confirm
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed (harness fix; the regression signal is every fixture-based spec on Windows)

## AI Review Report

Reviewed the fixture's path flow: `testRepoPath` (worker fixture) → `repoPath` → three renderer-store comparisons + one `repos.add` IPC. Only the store comparisons receive the normalized form; `repos.add`, filesystem seeding, and cleanup keep native separators. POSIX behavior is unchanged (no backslashes to replace). No product code touched.

## Security Audit

Test-harness-only change; no input handling, exec, or IPC surface changes.

## Notes

Sibling Windows harness issue (not addressed here): the hidden-TUI side-effect burst helper's `node -e` quoting appears to break under PowerShell, leaving the OSC title at the shell executable path — being filed as a separate issue.