### PR TITLE
perf(emulator): stop serve-sim watcher waking the daemon 4×/sec when unused

### DIFF
--- a/src/main/emulator/serve-sim-state-watcher.test.ts
+++ b/src/main/emulator/serve-sim-state-watcher.test.ts
@@ -2,7 +2,11 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { ServeSimStateWatcher, type ServeSimStateDetectedEvent } from './serve-sim-state-watcher'
+import {
+  SERVE_SIM_STATE_DIR_EXISTENCE_POLL_MS,
+  ServeSimStateWatcher,
+  type ServeSimStateDetectedEvent
+} from './serve-sim-state-watcher'
 
 const TEST_UDID = '11111111-2222-3333-4444-555555555555'
 
@@ -45,7 +49,9 @@ describe('ServeSimStateWatcher', () => {
     const parentDir = await mkdtemp(join(tmpdir(), 'orca-serve-sim-watch-'))
     cleanupPaths.push(parentDir)
     const stateDir = join(parentDir, 'serve-sim')
-    const watcher = new ServeSimStateWatcher({ stateDir })
+    // Force darwin (the poll is macOS-only) and a fast interval so this
+    // cross-platform test exercises the existence-poll -> attach path quickly.
+    const watcher = new ServeSimStateWatcher({ stateDir, platform: 'darwin', existencePollMs: 50 })
     const events: ServeSimStateDetectedEvent[] = []
 
     watcher.bindPty('pty-1', 'worktree-1')
@@ -76,6 +82,29 @@ describe('ServeSimStateWatcher', () => {
     })
 
     watcher.stop()
+  })
+
+  it('does not arm the existence poll on non-macOS platforms', () => {
+    // serve-sim state never appears off macOS, so start() must not leave a
+    // recurring timer waking the daemon for a directory that can never exist.
+    for (const platform of ['win32', 'linux'] as const) {
+      const watcher = new ServeSimStateWatcher({
+        stateDir: join(tmpdir(), `orca-serve-sim-nonmac-${process.pid}-${platform}`),
+        platform
+      })
+      watcher.start()
+      const poll = (watcher as unknown as { stateDirPoll: unknown }).stateDirPoll
+      expect(poll).toBeNull()
+      watcher.stop()
+    }
+  })
+
+  it('defaults the existence poll to a coarse (battery-friendly) interval', () => {
+    expect(SERVE_SIM_STATE_DIR_EXISTENCE_POLL_MS).toBe(2_000)
+    const watcher = new ServeSimStateWatcher()
+    expect((watcher as unknown as { existencePollMs: number }).existencePollMs).toBe(
+      SERVE_SIM_STATE_DIR_EXISTENCE_POLL_MS
+    )
   })
 
   it('does not buffer repeated brace-free PTY output while waiting for metadata', () => {

--- a/src/main/emulator/serve-sim-state-watcher.ts
+++ b/src/main/emulator/serve-sim-state-watcher.ts
@@ -23,6 +23,10 @@ export type ServeSimStateDetectedEvent = {
 }
 
 const DEFAULT_STATE_DIR = join(tmpdir(), 'serve-sim')
+// Why: this only waits for a rarely-created dir to appear; sub-second detection
+// of a detached emulator is not user-perceptible, so a coarse interval avoids
+// waking the daemon 4x/sec for the whole session on machines that never use it.
+export const SERVE_SIM_STATE_DIR_EXISTENCE_POLL_MS = 2_000
 const STATE_FILE_RE = /^server-([0-9A-F-]{36})\.json$/i
 const PTY_JSON_RE = /\{[^{}]*"streamUrl"\s*:\s*"[^"]+"[^{}]*"wsUrl"\s*:\s*"[^"]+"[^{}]*\}/g
 
@@ -73,6 +77,8 @@ function trailingIncompletePtyJsonObject(data: string): string {
 
 export class ServeSimStateWatcher {
   private readonly stateDir: string
+  private readonly platform: NodeJS.Platform
+  private readonly existencePollMs: number
   private readonly ptyToWorktree = new Map<string, string>()
   private readonly ptyBuffers = new Map<string, string>()
   private readonly seenExternalKeys = new Set<string>()
@@ -81,8 +87,12 @@ export class ServeSimStateWatcher {
   private stateWatcher: FSWatcher | null = null
   private stateDirPoll: ReturnType<typeof setInterval> | null = null
 
-  constructor(options: { stateDir?: string } = {}) {
+  constructor(
+    options: { stateDir?: string; platform?: NodeJS.Platform; existencePollMs?: number } = {}
+  ) {
     this.stateDir = options.stateDir ?? DEFAULT_STATE_DIR
+    this.platform = options.platform ?? process.platform
+    this.existencePollMs = options.existencePollMs ?? SERVE_SIM_STATE_DIR_EXISTENCE_POLL_MS
   }
 
   onDetected(listener: (event: ServeSimStateDetectedEvent) => void): () => void {
@@ -171,6 +181,13 @@ export class ServeSimStateWatcher {
     if (this.stateDirPoll || this.stateWatcher) {
       return
     }
+    // Why: serve-sim (the iOS Simulator bridge) only ever writes state on macOS,
+    // so $TMPDIR/serve-sim never appears on Windows/Linux. Skip arming the
+    // existence poll there instead of waking the daemon every interval for a
+    // directory that can never exist.
+    if (this.platform !== 'darwin') {
+      return
+    }
     try {
       // Why: $TMPDIR/serve-sim/ may not exist until the first terminal `serve-sim --detach`.
       // Poll for it instead of fs.watch on the parent tmpdir: watching $TMPDIR
@@ -182,13 +199,16 @@ export class ServeSimStateWatcher {
         return
       }
 
+      // attachStateDirWatch() clears this poll once the dir appears and the
+      // native watcher takes over, so it only ticks while waiting for a
+      // rarely-created dir — a coarse interval keeps that wait off the idle floor.
       this.stateDirPoll = setInterval(() => {
         this.attachStateDirWatch()
         this.scanExistingStateFiles()
-      }, 250)
+      }, this.existencePollMs)
       this.stateDirPoll.unref?.()
     } catch {
-      // Non-mac or permission issues: watcher is best-effort.
+      // Permission issues: watcher is best-effort.
     }
   }
 


### PR DESCRIPTION
## Description

The serve-sim (iOS Simulator bridge) state watcher armed a **250 ms (4 Hz) existence poll at startup** and kept it running for the entire session whenever `$TMPDIR/serve-sim/` never appears. That directory is only created when someone runs `serve-sim --detach`, so for the **vast majority of users who never launch the mobile emulator the poll ticks forever doing nothing** — and it does so on **Windows and Linux too, where the feature is macOS-only and the directory can never exist**.

This is a pure main/daemon-process idle-floor cost: the main process is not Chromium-throttled, so those 4 wakeups/sec keep firing even when the window is hidden and nothing is happening, preventing the CPU from reaching deeper idle states.

Two minimal changes:
- **Skip arming the poll entirely off macOS** — serve-sim is macOS-only (`src/main/index.ts:1921`: *"macOS-only feature"*), so on Windows/Linux `start()` is now a no-op.
- **Back the existence-poll interval off from 250 ms → 2 s.** Detecting a detached background emulator is not latency-critical.

Once serve-sim *is* used, `attachStateDirWatch()` already swaps to a native `fs.watch` and clears the poll, so the steady-state detection path is unchanged.

## Evidence of improvement

Daemon timer wakeups from this watcher, per user, over an 8-hour session:

| Scenario (emulator never launched) | Before | After | Saved |
|---|---|---|---|
| macOS | 4 wakeups/s (≈115,200 / 8 h) | 0.5 wakeups/s (≈14,400 / 8 h) | **8× fewer** |
| Windows / Linux | 4 wakeups/s (≈115,200 / 8 h) | **0** (poll never arms) | **100% eliminated** |

These are exactly the timer wakeups that keep the CPU out of deep idle C‑states — the direct mechanism behind timer-driven battery drain. This watcher applies to essentially all users, since the emulator is a niche feature.

## ELI5

Orca had a tiny helper that checked *four times every second, forever* whether you'd started a phone simulator — even on Windows and Linux where phone simulators don't exist. Almost nobody uses that feature, so it was knocking on an empty door 4×/second all day. Now it doesn't knock at all on Windows/Linux, and on Macs it checks once every 2 seconds instead of 4×/second. When you *do* start a simulator, Orca still notices and switches to an instant, event-based notifier — so nothing you can see changes.

## Proof of no regressions

- **Unit tests: 8/8 pass** (`src/main/emulator/serve-sim-state-watcher.test.ts`), including:
  - the existing *"attaches to the serve-sim state directory when it appears after startup"* test (still green; now injects `platform: 'darwin'` + a fast interval so it exercises the poll→attach path on every CI platform),
  - **new:** *"does not arm the existence poll on non-macOS platforms"* (asserts `stateDirPoll` stays `null` for `win32`/`linux`),
  - **new:** *"defaults the existence poll to a coarse (battery-friendly) interval"* (asserts the 2 s default).
- **Typecheck** (`tsc -p config/tsconfig.node.json`): clean.
- **Steady-state unchanged:** once the state dir exists, behavior is byte-for-byte identical — the native `fs.watch` handles detection and the poll self-clears, exactly as before.

## Trade-offs (target: zero regressions)

- **macOS:** detection latency for a *freshly* detached emulator moves from ≤250 ms to ≤2 s. This is a background emulator tab auto-opening slightly later; not user-perceptible.
- **Windows/Linux:** **zero functional change** — the state dir never existed there, so the watcher never detected anything; it now simply stops waking the daemon to confirm that.
- **Regression risk: effectively zero.** No change to the PTY-ingestion detection path (which is how Orca-managed emulators are already found), no change to steady-state, covered by tests on all platforms.

---
🔋 Part of a battery/energy audit. Draft — do not merge without maintainer review.

Made with [Orca](https://github.com/stablyai/orca) 🐋
