### PR TITLE
Review: Orca Relay mobile pairing endpoints and racing

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -11,6 +11,7 @@ import { RpcClientProvider } from '../src/transport/client-context'
 import { getNotificationNavigationPath } from '../src/notifications/notification-routing'
 import { loadHosts } from '../src/transport/host-store'
 import { extractPairingCodeFromUrl } from '../src/transport/pairing'
+import { recoverMobileRelayPairing } from '../src/transport/mobile-relay-pairing-recovery'
 
 // Why: keeps the native splash screen visible until the React tree is mounted
 // and ready to render. Without this the user sees a blank white/black frame
@@ -34,6 +35,12 @@ Notifications.setNotificationHandler({
 export default function RootLayout() {
   const router = useRouter()
   const handledNotificationIdsRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    // Why: pairing publication is journaled across process death; startup must
+    // reconcile the server result before another scan can replace that journal.
+    void recoverMobileRelayPairing()
+  }, [])
 
   // Why: route `orca://pair?...` deep links to the confirm screen so
   // the same pairing flow runs whether the link arrived via QR scan,

--- a/mobile/app/pair-confirm.tsx
+++ b/mobile/app/pair-confirm.tsx
@@ -5,12 +5,10 @@ import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft } from 'lucide-react-native'
 import { resolvePairConfirmRouteState } from '../src/transport/pair-confirm-state'
 import {
-  startPairingConnectionAttempt,
-  type PairingConnectionAttempt
-} from '../src/transport/pairing-connection-attempt'
-import { connect } from '../src/transport/rpc-client'
-import { saveHost, getNextHostName } from '../src/transport/host-store'
-import type { ConnectionLogEntry, RpcResponse } from '../src/transport/types'
+  startPreProfilePairing,
+  type PreProfilePairingAttempt
+} from '../src/transport/pre-profile-pairing-coordinator'
+import type { ConnectionLogEntry } from '../src/transport/types'
 import { colors, spacing, radii, typography } from '../src/theme/mobile-theme'
 import { ConnectionLog } from '../src/components/ConnectionLog'
 
@@ -35,7 +33,7 @@ export default function PairConfirmScreen() {
   // batch fewer setState calls when entries arrive in bursts.
   const logsRef = useRef<ConnectionLogEntry[]>([])
   const mountedRef = useRef(true)
-  const activePairingAttemptRef = useRef<PairingConnectionAttempt | null>(null)
+  const activePairingAttemptRef = useRef<PreProfilePairingAttempt | null>(null)
 
   const routeState = resolvePairConfirmRouteState(params.code)
   const offer = routeState.offer
@@ -79,20 +77,12 @@ export default function PairConfirmScreen() {
     setStatus('connecting')
     logsRef.current = []
     setLogs([])
-    let client: ReturnType<typeof connect> | null = null
     activePairingAttemptRef.current?.dispose()
 
-    // Why: split the try/catch around the network call vs the local save
-    // so a Keychain or AsyncStorage failure doesn't masquerade as a
-    // "Cannot connect" error.
-    let response: RpcResponse
-    const attempt = startPairingConnectionAttempt({
+    const attempt = startPreProfilePairing({
+      offer,
       timeoutMs: PAIRING_OVERALL_TIMEOUT_MS,
-      closeClient: () => client?.close()
-    })
-    activePairingAttemptRef.current = attempt
-    try {
-      client = connect(offer.endpoint, offer.deviceToken, offer.publicKeyB64, {
+      connectOptions: {
         onLog: (entry) => {
           if (!mountedRef.current || activePairingAttemptRef.current !== attempt) {
             return
@@ -100,8 +90,11 @@ export default function PairConfirmScreen() {
           logsRef.current = [...logsRef.current, entry]
           setLogs(logsRef.current)
         }
-      })
-      response = await client.sendRequest('status.get')
+      }
+    })
+    activePairingAttemptRef.current = attempt
+    try {
+      const { hostId } = await attempt.result
       const attemptIsCurrent = activePairingAttemptRef.current === attempt
       attempt.dispose()
       if (activePairingAttemptRef.current === attempt) {
@@ -110,6 +103,7 @@ export default function PairConfirmScreen() {
       if (!mountedRef.current || !attemptIsCurrent) {
         return
       }
+      router.replace(`/h/${hostId}`)
     } catch (err) {
       const timedOut = attempt.timedOut
       const attemptIsCurrent = activePairingAttemptRef.current === attempt
@@ -125,47 +119,7 @@ export default function PairConfirmScreen() {
       setErrorMessage(
         timedOut
           ? `Couldn't connect within ${PAIRING_OVERALL_TIMEOUT_MS / 1000}s — see log below for where it stalled`
-          : 'Cannot connect — check that your computer is on the same network'
-      )
-      return
-    }
-
-    if (!response.ok) {
-      if (!mountedRef.current) {
-        return
-      }
-      setStatus('error')
-      setErrorMessage(
-        response.error.code === 'unauthorized'
-          ? 'Authentication failed — token may be expired'
-          : `Server error: ${response.error.message}`
-      )
-      return
-    }
-
-    try {
-      const hostId = `host-${Date.now()}`
-      const hostName = await getNextHostName()
-      await saveHost({
-        id: hostId,
-        name: hostName,
-        endpoint: offer.endpoint,
-        deviceToken: offer.deviceToken,
-        publicKeyB64: offer.publicKeyB64,
-        lastConnected: Date.now()
-      })
-      if (!mountedRef.current) {
-        return
-      }
-      router.replace(`/h/${hostId}`)
-    } catch (err) {
-      if (!mountedRef.current) {
-        return
-      }
-      console.warn('[pair-confirm] save failed', err)
-      setStatus('error')
-      setErrorMessage(
-        `Pairing succeeded but couldn't save the host: ${err instanceof Error ? err.message : String(err)}`
+          : `Pairing failed: ${err instanceof Error ? err.message : String(err)}`
       )
     }
   }

--- a/mobile/app/pair-scan.tsx
+++ b/mobile/app/pair-scan.tsx
@@ -14,12 +14,10 @@ import { useRouter } from 'expo-router'
 import { ChevronLeft, Clipboard as ClipboardIcon, QrCode } from 'lucide-react-native'
 import { decodePairingUrl, parsePairingCode } from '../src/transport/pairing'
 import {
-  startPairingConnectionAttempt,
-  type PairingConnectionAttempt
-} from '../src/transport/pairing-connection-attempt'
-import { connect } from '../src/transport/rpc-client'
-import { saveHost, getNextHostName } from '../src/transport/host-store'
-import type { ConnectionLogEntry, PairingOffer, RpcResponse } from '../src/transport/types'
+  startPreProfilePairing,
+  type PreProfilePairingAttempt
+} from '../src/transport/pre-profile-pairing-coordinator'
+import type { ConnectionLogEntry, PairingOffer } from '../src/transport/types'
 import { colors, spacing, radii, typography } from '../src/theme/mobile-theme'
 import { TextInputModal } from '../src/components/TextInputModal'
 import { ConnectionLog } from '../src/components/ConnectionLog'
@@ -54,7 +52,7 @@ export default function PairScanScreen() {
   const logsRef = useRef<ConnectionLogEntry[]>([])
   const processingRef = useRef(false)
   const mountedRef = useRef(true)
-  const activePairingAttemptRef = useRef<PairingConnectionAttempt | null>(null)
+  const activePairingAttemptRef = useRef<PreProfilePairingAttempt | null>(null)
 
   const setPairScanRootRef = useCallback((node: View | null): void => {
     if (node !== null) {
@@ -123,21 +121,12 @@ export default function PairScanScreen() {
     setStatus('connecting')
     logsRef.current = []
     setLogs([])
-    let client: ReturnType<typeof connect> | null = null
     activePairingAttemptRef.current?.dispose()
 
-    // Why: split the try/catch around the network call vs the local save
-    // so a Keychain or AsyncStorage failure doesn't masquerade as a
-    // "Cannot connect — same network?" error. Pairing reached the
-    // desktop fine; the failure is local persistence.
-    let response: RpcResponse
-    const attempt = startPairingConnectionAttempt({
+    const attempt = startPreProfilePairing({
+      offer,
       timeoutMs: PAIRING_OVERALL_TIMEOUT_MS,
-      closeClient: () => client?.close()
-    })
-    activePairingAttemptRef.current = attempt
-    try {
-      client = connect(offer.endpoint, offer.deviceToken, offer.publicKeyB64, {
+      connectOptions: {
         onLog: (entry) => {
           if (!mountedRef.current || activePairingAttemptRef.current !== attempt) {
             return
@@ -145,8 +134,11 @@ export default function PairScanScreen() {
           logsRef.current = [...logsRef.current, entry]
           setLogs(logsRef.current)
         }
-      })
-      response = await client.sendRequest('status.get')
+      }
+    })
+    activePairingAttemptRef.current = attempt
+    try {
+      const { hostId } = await attempt.result
       const attemptIsCurrent = activePairingAttemptRef.current === attempt
       attempt.dispose()
       if (activePairingAttemptRef.current === attempt) {
@@ -155,6 +147,7 @@ export default function PairScanScreen() {
       if (!mountedRef.current || !attemptIsCurrent) {
         return
       }
+      router.replace(`/h/${hostId}`)
     } catch (err) {
       const timedOut = attempt.timedOut
       const attemptIsCurrent = activePairingAttemptRef.current === attempt
@@ -170,51 +163,7 @@ export default function PairScanScreen() {
       setErrorMessage(
         timedOut
           ? `Couldn't connect within ${PAIRING_OVERALL_TIMEOUT_MS / 1000}s — see log below for where it stalled`
-          : 'Cannot connect — check that your computer is on the same network'
-      )
-      processingRef.current = false
-      return
-    }
-
-    if (!response.ok) {
-      if (!mountedRef.current) {
-        return
-      }
-      if (response.error.code === 'unauthorized') {
-        setStatus('error')
-        setErrorMessage('Authentication failed — token may be expired')
-        processingRef.current = false
-        return
-      }
-      setStatus('error')
-      setErrorMessage(`Server error: ${response.error.message}`)
-      processingRef.current = false
-      return
-    }
-
-    try {
-      const hostId = `host-${Date.now()}`
-      const hostName = await getNextHostName()
-      await saveHost({
-        id: hostId,
-        name: hostName,
-        endpoint: offer.endpoint,
-        deviceToken: offer.deviceToken,
-        publicKeyB64: offer.publicKeyB64,
-        lastConnected: Date.now()
-      })
-      if (!mountedRef.current) {
-        return
-      }
-      router.replace(`/h/${hostId}`)
-    } catch (err) {
-      if (!mountedRef.current) {
-        return
-      }
-      console.warn('[pair] save failed', err)
-      setStatus('error')
-      setErrorMessage(
-        `Pairing succeeded but couldn't save the host: ${err instanceof Error ? err.message : String(err)}`
+          : `Pairing failed: ${err instanceof Error ? err.message : String(err)}`
       )
       processingRef.current = false
     }

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MobileRelayHostOverlay } from './mobile-relay-host-overlay'
 
 const asyncStorageMock = vi.hoisted(() => ({
   getItem: vi.fn(),
@@ -32,9 +33,17 @@ vi.mock('./host-credential-cleanup', () => ({
   retryPendingHostCredentialCleanups: vi.fn()
 }))
 
-import { removeHost, renameHost, resetHostStoreForTests, updateLastConnected } from './host-store'
+import {
+  loadHosts,
+  removeHost,
+  renameHost,
+  resetHostStoreForTests,
+  updateLastConnected
+} from './host-store'
+import { resetMobileRelayHostOverlayStoreForTests } from './mobile-relay-host-overlay-store'
 
 const HOSTS_STORAGE_KEY = 'orca:hosts'
+const OVERLAY_STORAGE_KEY = 'orca:mobile-relay:host-overlays:v2'
 const HOST_ONE = {
   id: 'host-1',
   name: 'Host 1',
@@ -52,16 +61,22 @@ const HOST_TWO = {
 
 describe('host-store list mutations', () => {
   let storedHostsRaw: string
+  let storedOverlayRaw: string | null
 
   beforeEach(() => {
     vi.clearAllMocks()
     resetHostStoreForTests()
+    resetMobileRelayHostOverlayStoreForTests()
     scheduleCleanupMock.mockReset()
     scheduleCleanupMock.mockResolvedValue(undefined)
     storedHostsRaw = JSON.stringify([HOST_ONE, HOST_TWO])
+    storedOverlayRaw = null
     asyncStorageMock.getItem.mockImplementation(async (key: string) => {
       if (key === HOSTS_STORAGE_KEY) {
         return storedHostsRaw
+      }
+      if (key === OVERLAY_STORAGE_KEY) {
+        return storedOverlayRaw
       }
       return null
     })
@@ -70,6 +85,9 @@ describe('host-store list mutations', () => {
         storedHostsRaw = raw
       }
     })
+    secureStoreMock.getItemAsync.mockImplementation(async (key: string) =>
+      key.endsWith(HOST_ONE.id) || key.endsWith(HOST_TWO.id) ? `token-${key.at(-1)}` : null
+    )
   })
 
   it('commits the removal when credential cleanup scheduling rejects', async () => {
@@ -79,6 +97,40 @@ describe('host-store list mutations', () => {
 
     expect(JSON.parse(storedHostsRaw)).toEqual([HOST_TWO])
     expect(scheduleCleanupMock).toHaveBeenCalledWith(HOST_ONE.id, expect.any(Function))
+  })
+
+  it('merges v2 endpoints only onto an existing legacy base host', async () => {
+    const overlay: MobileRelayHostOverlay = {
+      v: 2,
+      hostId: HOST_ONE.id,
+      endpoints: [
+        { id: 'direct-primary', kind: 'lan', url: HOST_ONE.endpoint },
+        {
+          id: 'relay-primary',
+          kind: 'relay',
+          url: 'wss://relay-c1.onorca.dev/v1/connect/AbCdEf0123_-xyZ9'
+        }
+      ],
+      relayHostId: 'AbCdEf0123_-xyZ9',
+      relay: {
+        v: 1,
+        directorUrl: 'https://relay.onorca.dev',
+        cellUrl: 'https://relay-c1.onorca.dev',
+        assignmentEpoch: 7,
+        relayHostId: 'AbCdEf0123_-xyZ9',
+        e2eeFraming: 2
+      }
+    }
+    storedOverlayRaw = JSON.stringify([overlay, { ...overlay, hostId: 'removed-by-old-build' }])
+
+    const hosts = await loadHosts()
+
+    expect(hosts.find(({ id }) => id === HOST_ONE.id)).toMatchObject({
+      endpoints: overlay.endpoints,
+      relayHostId: overlay.relayHostId,
+      relay: overlay.relay
+    })
+    expect(hosts.some(({ id }) => id === 'removed-by-old-build')).toBe(false)
   })
 
   it('awaits cleanup scheduling after metadata commit', async () => {

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -12,6 +12,12 @@ import {
   retryPendingHostCredentialCleanups,
   scheduleHostCredentialCleanup
 } from './host-credential-cleanup'
+import {
+  loadMobileRelayHostOverlays,
+  removeMobileRelayHostOverlay,
+  saveMobileRelayHostOverlay
+} from './mobile-relay-host-overlay-store'
+import { deleteMobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
 
 const STORAGE_KEY = 'orca:hosts'
 // Why: SecureStore keys must match [A-Za-z0-9._-]; colons are rejected.
@@ -59,6 +65,11 @@ async function deleteDeviceToken(hostId: string): Promise<void> {
     return
   }
   await SecureStore.deleteItemAsync(tokenKey(hostId), KEYCHAIN_OPTIONS)
+}
+
+async function deleteHostCredentials(hostId: string): Promise<void> {
+  await deleteDeviceToken(hostId)
+  await deleteMobileRelayCredentialBundle(hostId)
 }
 
 // Why: SecureStore reads on Android Keystore can take 50-200ms each, and
@@ -120,6 +131,7 @@ async function doLoadHosts(): Promise<HostProfile[]> {
   if (!storedHosts) {
     return []
   }
+  const overlays = await loadMobileRelayHostOverlays(new Set(storedHosts.map(({ id }) => id)))
 
   const out: HostProfile[] = []
   for (const stored of storedHosts) {
@@ -144,7 +156,18 @@ async function doLoadHosts(): Promise<HostProfile[]> {
       token = fetched
       tokenCache.set(stored.id, token)
     }
-    out.push({ ...stored, deviceToken: token })
+    const overlay = overlays.get(stored.id)
+    out.push({
+      ...stored,
+      deviceToken: token,
+      ...(overlay
+        ? {
+            endpoints: overlay.endpoints,
+            relayHostId: overlay.relayHostId,
+            relay: overlay.relay
+          }
+        : {})
+    })
   }
   return out
 }
@@ -215,15 +238,30 @@ export async function saveHost(host: HostProfile): Promise<void> {
   // from current metadata.
   await writeDeviceToken(stored.id, validated.deviceToken)
   tokenCache.set(stored.id, validated.deviceToken)
+  if (validated.endpoints) {
+    await saveMobileRelayHostOverlay({
+      v: 2,
+      hostId: stored.id,
+      endpoints: validated.endpoints,
+      relayHostId: validated.relayHostId,
+      relay: validated.relay
+    })
+  }
 }
 
 export async function removeHost(hostId: string): Promise<void> {
   await mutateStoredHosts((hosts) => hosts.filter((h) => h.id !== hostId))
   tokenCache.delete(hostId)
+  try {
+    await removeMobileRelayHostOverlay(hostId)
+  } catch {
+    // The missing legacy base is authoritative, so a retained overlay cannot
+    // resurrect this host and can be cleaned on a later explicit retry.
+  }
   // Why: await only the durable cleanup intent (AsyncStorage). Native keychain
   // delete can reject or stall and must not freeze removeHost / the UI.
   try {
-    await scheduleHostCredentialCleanup(hostId, deleteDeviceToken)
+    await scheduleHostCredentialCleanup(hostId, deleteHostCredentials)
   } catch {
     // Metadata is already committed; orphan-token recovery is best-effort.
   }
@@ -234,7 +272,7 @@ export async function retryPendingHostCredentialCleanup(): Promise<{
   remainingIds: string[]
   storageUnreadable: boolean
 }> {
-  return retryPendingHostCredentialCleanups(deleteDeviceToken)
+  return retryPendingHostCredentialCleanups(deleteHostCredentials)
 }
 
 export async function renameHost(hostId: string, newName: string): Promise<void> {

--- a/mobile/src/transport/mobile-relay-credential-bundle.test.ts
+++ b/mobile/src/transport/mobile-relay-credential-bundle.test.ts
@@ -43,6 +43,7 @@ const journal = {
       e2eeFraming: 2
     },
     installReqId: 'install-1',
+    resumeConfirmReqId: 'confirm-1',
     pendingResumeTokenHash: 'B'.repeat(43),
     winner: 'direct',
     authorizationMode: 'authenticated-direct'

--- a/mobile/src/transport/mobile-relay-credential-bundle.test.ts
+++ b/mobile/src/transport/mobile-relay-credential-bundle.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const secureStore = vi.hoisted(() => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn()
+}))
+const platform = vi.hoisted(() => ({ OS: 'ios' }))
+
+vi.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+  ...secureStore
+}))
+vi.mock('react-native', () => ({ Platform: platform }))
+
+import {
+  deleteMobileRelayCredentialBundle,
+  promotePairingJournalCredential,
+  readMobileRelayCredentialBundle,
+  writeMobileRelayCredentialBundle
+} from './mobile-relay-credential-bundle'
+import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+
+const journal = {
+  metadata: {
+    v: 1,
+    journalId: 'pair-1',
+    offerFingerprint: 'A'.repeat(43),
+    host: {
+      id: 'host-1',
+      name: 'Blue Whale',
+      endpoint: 'ws://192.168.1.10:6768',
+      publicKeyB64: 'A'.repeat(44),
+      lastConnected: 1
+    },
+    relay: {
+      v: 1,
+      directorUrl: 'https://relay.onorca.dev',
+      cellUrl: 'https://relay-c1.onorca.dev',
+      assignmentEpoch: 7,
+      relayHostId: 'AbCdEf0123_-xyZ9',
+      inviteExpiresAt: 10_000,
+      e2eeFraming: 2
+    },
+    installReqId: 'install-1',
+    pendingResumeTokenHash: 'B'.repeat(43),
+    winner: 'direct',
+    authorizationMode: 'authenticated-direct'
+  },
+  secrets: {
+    v: 1,
+    journalId: 'pair-1',
+    deviceToken: 'device-token',
+    inviteToken: 'C'.repeat(43),
+    pendingResumeToken: 'D'.repeat(43)
+  }
+} satisfies MobileRelayPairingJournal
+
+describe('mobile relay credential bundle', () => {
+  let stored: string | null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    platform.OS = 'ios'
+    stored = null
+    secureStore.getItemAsync.mockImplementation(async () => stored)
+    secureStore.setItemAsync.mockImplementation(async (_key: string, value: string) => {
+      stored = value
+    })
+    secureStore.deleteItemAsync.mockImplementation(async () => {
+      stored = null
+    })
+  })
+
+  it('promotes only a matching committed install result to current', async () => {
+    const bundle = promotePairingJournalCredential({
+      journal,
+      installed: {
+        v: 1,
+        reqId: 'install-1',
+        authorizationMode: 'authenticated-direct',
+        currentVersion: 3,
+        resumeExpiresAt: 50_000
+      }
+    })
+    await writeMobileRelayCredentialBundle(bundle)
+
+    await expect(readMobileRelayCredentialBundle('host-1')).resolves.toEqual(bundle)
+    expect(stored).toContain(journal.secrets.pendingResumeToken)
+    expect(stored).not.toContain(journal.secrets.inviteToken)
+  })
+
+  it('rejects a result from another request or authorization mode', () => {
+    expect(() =>
+      promotePairingJournalCredential({
+        journal,
+        installed: {
+          v: 1,
+          reqId: 'other-request',
+          authorizationMode: 'relay-basis',
+          currentVersion: 1,
+          resumeExpiresAt: 50_000
+        }
+      })
+    ).toThrow(/does not match/)
+  })
+
+  it('deletes the namespaced bundle and never enables it on web', async () => {
+    await deleteMobileRelayCredentialBundle('host-1')
+    expect(secureStore.deleteItemAsync).toHaveBeenCalledWith(
+      'orca.mobile-relay.credentials.host-1',
+      expect.any(Object)
+    )
+    platform.OS = 'web'
+    await expect(readMobileRelayCredentialBundle('host-1')).rejects.toThrow(/native secret store/)
+  })
+})

--- a/mobile/src/transport/mobile-relay-credential-bundle.ts
+++ b/mobile/src/transport/mobile-relay-credential-bundle.ts
@@ -1,0 +1,112 @@
+import * as SecureStore from 'expo-secure-store'
+import { Platform } from 'react-native'
+import { z } from 'zod'
+import type { DeviceCredentialInstalled } from '../../../src/shared/mobile-relay-credential-contract'
+import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+
+const Base64Url32ByteSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/)
+const ResumeCredentialSchema = z
+  .object({
+    token: Base64Url32ByteSchema,
+    hash: Base64Url32ByteSchema,
+    version: z.number().int().positive(),
+    expiresAt: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const MobileRelayCredentialBundleSchema = z
+  .object({
+    v: z.literal(1),
+    hostId: z.string().min(1),
+    deviceToken: z.string().min(1),
+    current: ResumeCredentialSchema,
+    grace: ResumeCredentialSchema.optional(),
+    pending: z
+      .object({
+        token: Base64Url32ByteSchema,
+        hash: Base64Url32ByteSchema,
+        reqId: z.string().min(1)
+      })
+      .strict()
+      .optional(),
+    invite: z
+      .object({ token: Base64Url32ByteSchema, expiresAt: z.number().int().positive() })
+      .strict()
+      .optional()
+  })
+  .strict()
+
+export type MobileRelayCredentialBundle = z.infer<typeof MobileRelayCredentialBundleSchema>
+
+const KEYCHAIN_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY
+}
+
+function credentialKey(hostId: string): string {
+  return `orca.mobile-relay.credentials.${hostId}`
+}
+
+export function promotePairingJournalCredential(args: {
+  journal: MobileRelayPairingJournal
+  installed: DeviceCredentialInstalled
+}): MobileRelayCredentialBundle {
+  const { journal, installed } = args
+  if (
+    installed.reqId !== journal.metadata.installReqId ||
+    installed.authorizationMode !== journal.metadata.authorizationMode
+  ) {
+    throw new Error('relay credential install result does not match pairing journal')
+  }
+  return MobileRelayCredentialBundleSchema.parse({
+    v: 1,
+    hostId: journal.metadata.host.id,
+    deviceToken: journal.secrets.deviceToken,
+    current: {
+      token: journal.secrets.pendingResumeToken,
+      hash: journal.metadata.pendingResumeTokenHash,
+      version: installed.currentVersion,
+      expiresAt: installed.resumeExpiresAt
+    }
+  })
+}
+
+export async function readMobileRelayCredentialBundle(
+  hostId: string
+): Promise<MobileRelayCredentialBundle | null> {
+  requireNativeSecretStore()
+  const raw = await SecureStore.getItemAsync(credentialKey(hostId), KEYCHAIN_OPTIONS)
+  if (raw === null) {
+    return null
+  }
+  try {
+    const result = MobileRelayCredentialBundleSchema.safeParse(JSON.parse(raw))
+    return result.success && result.data.hostId === hostId ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+export async function writeMobileRelayCredentialBundle(
+  bundle: MobileRelayCredentialBundle
+): Promise<void> {
+  requireNativeSecretStore()
+  const validated = MobileRelayCredentialBundleSchema.parse(bundle)
+  await SecureStore.setItemAsync(
+    credentialKey(validated.hostId),
+    JSON.stringify(validated),
+    KEYCHAIN_OPTIONS
+  )
+}
+
+export async function deleteMobileRelayCredentialBundle(hostId: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    return
+  }
+  await SecureStore.deleteItemAsync(credentialKey(hostId), KEYCHAIN_OPTIONS)
+}
+
+function requireNativeSecretStore(): void {
+  if (Platform.OS === 'web') {
+    throw new Error('Orca Relay credentials require a native secret store')
+  }
+}

--- a/mobile/src/transport/mobile-relay-host-overlay-store.test.ts
+++ b/mobile/src/transport/mobile-relay-host-overlay-store.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const asyncStorage = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn()
+}))
+
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStorage }))
+
+import {
+  loadMobileRelayHostOverlays,
+  resetMobileRelayHostOverlayStoreForTests,
+  saveMobileRelayHostOverlay
+} from './mobile-relay-host-overlay-store'
+import type { MobileRelayHostOverlay } from './mobile-relay-host-overlay'
+
+const STORAGE_KEY = 'orca:mobile-relay:host-overlays:v2'
+const OVERLAY: MobileRelayHostOverlay = {
+  v: 2,
+  hostId: 'host-1',
+  endpoints: [
+    { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.10:6768' },
+    {
+      id: 'relay-primary',
+      kind: 'relay',
+      url: 'wss://relay-c1.onorca.dev/v1/connect/AbCdEf0123_-xyZ9'
+    }
+  ],
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  relay: {
+    v: 1,
+    directorUrl: 'https://relay.onorca.dev',
+    cellUrl: 'https://relay-c1.onorca.dev',
+    assignmentEpoch: 7,
+    relayHostId: 'AbCdEf0123_-xyZ9',
+    e2eeFraming: 2
+  }
+}
+
+describe('mobile relay host overlay store', () => {
+  let stored: string | null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMobileRelayHostOverlayStoreForTests()
+    stored = null
+    asyncStorage.getItem.mockImplementation(async (key: string) =>
+      key === STORAGE_KEY ? stored : null
+    )
+    asyncStorage.setItem.mockImplementation(async (key: string, value: string) => {
+      if (key === STORAGE_KEY) {
+        stored = value
+      }
+    })
+  })
+
+  it('round-trips v2 metadata in a namespace legacy builds do not rewrite', async () => {
+    await saveMobileRelayHostOverlay(OVERLAY)
+
+    await expect(loadMobileRelayHostOverlays(new Set(['host-1']))).resolves.toEqual(
+      new Map([['host-1', OVERLAY]])
+    )
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, expect.any(String))
+  })
+
+  it('never overlays or resurrects a host whose legacy base was removed', async () => {
+    stored = JSON.stringify([OVERLAY])
+
+    await expect(loadMobileRelayHostOverlays(new Set())).resolves.toEqual(new Map())
+    expect(asyncStorage.setItem).not.toHaveBeenCalled()
+    expect(JSON.parse(stored)).toEqual([OVERLAY])
+  })
+
+  it('refuses to overwrite unreadable overlay storage', async () => {
+    stored = '{'
+
+    await expect(saveMobileRelayHostOverlay(OVERLAY)).rejects.toThrow(/unreadable/)
+    expect(asyncStorage.setItem).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/mobile-relay-host-overlay-store.ts
+++ b/mobile/src/transport/mobile-relay-host-overlay-store.ts
@@ -1,0 +1,85 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  MobileRelayHostOverlaySchema,
+  type MobileRelayHostOverlay
+} from './mobile-relay-host-overlay'
+
+const OVERLAY_STORAGE_KEY = 'orca:mobile-relay:host-overlays:v2'
+let overlayMutation: Promise<void> = Promise.resolve()
+
+function parseOverlays(raw: string | null): MobileRelayHostOverlay[] | null {
+  if (raw === null) {
+    return []
+  }
+  try {
+    const value = JSON.parse(raw) as unknown
+    if (!Array.isArray(value)) {
+      return null
+    }
+    return value.flatMap((item) => {
+      const result = MobileRelayHostOverlaySchema.safeParse(item)
+      return result.success ? [result.data] : []
+    })
+  } catch {
+    return null
+  }
+}
+
+async function readOverlaysForMutation(): Promise<MobileRelayHostOverlay[]> {
+  const overlays = parseOverlays(await AsyncStorage.getItem(OVERLAY_STORAGE_KEY))
+  if (!overlays) {
+    // Why: never rewrite an unreadable v2 namespace as an empty list; doing so
+    // would destroy relay recovery data during an unrelated host mutation.
+    throw new Error('mobile relay host overlay storage unreadable')
+  }
+  return overlays
+}
+
+async function mutateOverlays(
+  update: (overlays: MobileRelayHostOverlay[]) => MobileRelayHostOverlay[]
+): Promise<void> {
+  const mutation = overlayMutation.then(async () => {
+    const current = await readOverlaysForMutation()
+    await AsyncStorage.setItem(OVERLAY_STORAGE_KEY, JSON.stringify(update(current)))
+  })
+  overlayMutation = mutation.catch(() => {})
+  return mutation
+}
+
+export async function loadMobileRelayHostOverlays(
+  existingHostIds: ReadonlySet<string>
+): Promise<Map<string, MobileRelayHostOverlay>> {
+  await overlayMutation
+  const overlays = parseOverlays(await AsyncStorage.getItem(OVERLAY_STORAGE_KEY)) ?? []
+  const active = new Map<string, MobileRelayHostOverlay>()
+  for (const overlay of overlays) {
+    // Why: an older app can remove the legacy base without knowing this
+    // namespace; never let the retained overlay resurrect that host later.
+    if (existingHostIds.has(overlay.hostId)) {
+      active.set(overlay.hostId, overlay)
+    }
+  }
+  return active
+}
+
+export async function saveMobileRelayHostOverlay(overlay: MobileRelayHostOverlay): Promise<void> {
+  const validated = MobileRelayHostOverlaySchema.parse(overlay)
+  return mutateOverlays((overlays) => {
+    const index = overlays.findIndex(({ hostId }) => hostId === validated.hostId)
+    if (index < 0) {
+      return [...overlays, validated]
+    }
+    const next = overlays.slice()
+    next[index] = validated
+    return next
+  })
+}
+
+export function removeMobileRelayHostOverlay(hostId: string): Promise<void> {
+  return mutateOverlays((overlays) => overlays.filter((overlay) => overlay.hostId !== hostId))
+}
+
+/** Test-only: drain the module mutation chain between cases. */
+export function resetMobileRelayHostOverlayStoreForTests(): void {
+  overlayMutation = Promise.resolve()
+}

--- a/mobile/src/transport/mobile-relay-host-overlay.ts
+++ b/mobile/src/transport/mobile-relay-host-overlay.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+import { MobileRelayEndpointSchema } from '../../../src/shared/mobile-relay-credential-contract'
+
+export const MobileAccessEndpointSchema = z
+  .object({
+    id: z.string().min(1).max(128),
+    kind: z.enum(['lan', 'tailscale', 'relay']),
+    url: z.string().min(1).max(2048)
+  })
+  .strict()
+
+export const MobileRelayHostOverlaySchema = z
+  .object({
+    v: z.literal(2),
+    hostId: z.string().min(1),
+    endpoints: z.array(MobileAccessEndpointSchema).min(1).max(16),
+    relayHostId: z
+      .string()
+      .regex(/^[A-Za-z0-9_-]{16}$/)
+      .optional(),
+    relay: MobileRelayEndpointSchema.optional()
+  })
+  .strict()
+  .superRefine((overlay, context) => {
+    if ((overlay.relayHostId === undefined) !== (overlay.relay === undefined)) {
+      context.addIssue({ code: 'custom', message: 'Relay identity and endpoint must coexist' })
+      return
+    }
+    if (overlay.relay && overlay.relay.relayHostId !== overlay.relayHostId) {
+      context.addIssue({
+        code: 'custom',
+        path: ['relayHostId'],
+        message: 'Relay host identity mismatch'
+      })
+    }
+    const relayEndpointCount = overlay.endpoints.filter(({ kind }) => kind === 'relay').length
+    if (relayEndpointCount !== (overlay.relay ? 1 : 0)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['endpoints'],
+        message: 'Expected exactly one endpoint for configured relay metadata'
+      })
+    }
+  })
+
+export type MobileAccessEndpoint = z.infer<typeof MobileAccessEndpointSchema>
+export type MobileRelayHostOverlay = z.infer<typeof MobileRelayHostOverlaySchema>

--- a/mobile/src/transport/mobile-relay-invite-director.test.ts
+++ b/mobile/src/transport/mobile-relay-invite-director.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePairingInviteThroughDirector } from './mobile-relay-invite-director'
+
+class FakeSocket {
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: ((event: { code: number }) => void) | null = null
+  send(value: string): void {
+    this.sent.push(value)
+  }
+  close(): void {}
+}
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  inviteToken: 'abcdefghijklmnopqrstuvwxyzABCDEFGH012345678',
+  inviteExpiresAt: Date.now() + 300_000,
+  e2eeFraming: 2 as const
+}
+
+describe('pairing invite director resolution', () => {
+  it('authenticates only to the configured director and accepts a strictly newer move', async () => {
+    const socket = new FakeSocket()
+    let url = ''
+    const resolving = resolvePairingInviteThroughDirector({
+      relay,
+      createSocket: (value) => {
+        url = value
+        return socket as unknown as WebSocket
+      }
+    })
+    socket.onopen?.()
+    expect(url).toBe('wss://relay.onorca.dev/v1/connect/AbCdEf0123_-xyZ9')
+    expect(url).not.toContain('?')
+    expect(JSON.parse(socket.sent[0]!)).toEqual({
+      type: 'relay-auth',
+      v: 1,
+      mode: 'connect',
+      credential: relay.inviteToken
+    })
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: 'relay-moved',
+        v: 1,
+        cellUrl: 'https://relay-c2.onorca.dev',
+        assignmentEpoch: 8
+      })
+    })
+
+    await expect(resolving).resolves.toMatchObject({
+      cellUrl: 'https://relay-c2.onorca.dev',
+      assignmentEpoch: 8
+    })
+  })
+
+  it('rejects same/older epochs and untrusted extra fields', async () => {
+    const socket = new FakeSocket()
+    const resolving = resolvePairingInviteThroughDirector({
+      relay,
+      createSocket: () => socket as unknown as WebSocket
+    })
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: 'relay-moved',
+        v: 1,
+        cellUrl: 'https://relay-c2.onorca.dev',
+        assignmentEpoch: 7,
+        targetFromCell: true
+      })
+    })
+
+    await expect(resolving).rejects.toThrow(/not strictly newer/)
+  })
+})

--- a/mobile/src/transport/mobile-relay-invite-director.ts
+++ b/mobile/src/transport/mobile-relay-invite-director.ts
@@ -1,0 +1,78 @@
+import type { PairingRelay } from '../../../src/shared/mobile-relay-pairing-offer'
+import { RelayMovedSchema } from '../../../src/shared/mobile-relay-phone-protocol'
+
+export function resolvePairingInviteThroughDirector(args: {
+  relay: PairingRelay
+  timeoutMs?: number
+  createSocket?: (url: string) => WebSocket
+}): Promise<PairingRelay> {
+  const socket = (args.createSocket ?? ((url) => new WebSocket(url)))(
+    directorWebSocketUrl(args.relay)
+  )
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const timeout = setTimeout(
+      () => finish(new Error('relay director resolution timed out')),
+      args.timeoutMs ?? 5_000
+    )
+    socket.onopen = () => {
+      socket.send(
+        JSON.stringify({
+          type: 'relay-auth',
+          v: 1,
+          mode: 'connect',
+          credential: args.relay.inviteToken
+        })
+      )
+    }
+    socket.onmessage = (event) => {
+      if (typeof event.data !== 'string') {
+        finish(new Error('invalid relay director move'))
+        return
+      }
+      let value: unknown
+      try {
+        value = JSON.parse(event.data)
+      } catch {
+        finish(new Error('invalid relay director move'))
+        return
+      }
+      const moved = RelayMovedSchema.safeParse(value)
+      if (!moved.success || moved.data.assignmentEpoch <= args.relay.assignmentEpoch) {
+        finish(new Error('relay director move was not strictly newer'))
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      socket.close()
+      resolve({
+        ...args.relay,
+        cellUrl: moved.data.cellUrl,
+        assignmentEpoch: moved.data.assignmentEpoch
+      })
+    }
+    socket.onerror = () => finish(new Error('relay director transport error'))
+    socket.onclose = (event) => {
+      if (!settled) {
+        finish(new Error(`relay director closed before move: ${event.code || 1006}`))
+      }
+    }
+
+    function finish(error: Error): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      socket.close()
+      reject(error)
+    }
+  })
+}
+
+export function directorWebSocketUrl(relay: PairingRelay): string {
+  const url = new URL(relay.directorUrl)
+  url.protocol = 'wss:'
+  url.pathname = `/v1/connect/${encodeURIComponent(relay.relayHostId)}`
+  return url.toString()
+}

--- a/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
@@ -130,6 +130,30 @@ describe('mobile relay pairing journal store', () => {
     expect(metadataRaw).toBeNull()
   })
 
+  it('cleans mismatched secret records and refuses to replace a recoverable journal', async () => {
+    const journal = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-1',
+      hostName: 'Blue Whale',
+      randomBytes: (length) => new Uint8Array(length).fill(10)
+    })
+    metadataRaw = JSON.stringify(journal.metadata)
+    secretRaw = JSON.stringify({ ...journal.secrets, journalId: 'different-journal' })
+    await expect(loadMobileRelayPairingJournal()).resolves.toBeNull()
+    expect(metadataRaw).toBeNull()
+    expect(secretRaw).toBeNull()
+
+    await saveMobileRelayPairingJournal(journal)
+    const replacement = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-2',
+      hostName: 'Red Panda',
+      randomBytes: (length) => new Uint8Array(length).fill(12)
+    })
+    await expect(saveMobileRelayPairingJournal(replacement)).rejects.toThrow(/recovery pending/)
+    await expect(loadMobileRelayPairingJournal()).resolves.toEqual(journal)
+  })
+
   it('clears metadata before deleting its secret and keeps relay unavailable on web', async () => {
     const journal = createMobileRelayPairingJournal({
       offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },

--- a/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const asyncStorage = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn()
+}))
+const secureStore = vi.hoisted(() => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn()
+}))
+const platform = vi.hoisted(() => ({ OS: 'ios' }))
+
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStorage }))
+vi.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+  ...secureStore
+}))
+vi.mock('expo-crypto', () => ({ getRandomBytes: vi.fn() }))
+vi.mock('react-native', () => ({ Platform: platform }))
+
+import { createMobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+import {
+  clearMobileRelayPairingJournal,
+  loadMobileRelayPairingJournal,
+  resetMobileRelayPairingJournalStoreForTests,
+  saveMobileRelayPairingJournal,
+  updateMobileRelayPairingJournal
+} from './mobile-relay-pairing-journal-store'
+import type { PairingOffer } from './types'
+
+const now = Date.UTC(2026, 6, 13)
+const offer = {
+  v: 2,
+  endpoint: 'ws://192.168.1.10:6768',
+  deviceToken: 'device-token-secret',
+  publicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+  relay: {
+    v: 1,
+    directorUrl: 'https://relay.onorca.dev',
+    cellUrl: 'https://relay-c1.onorca.dev',
+    assignmentEpoch: 7,
+    relayHostId: 'AbCdEf0123_-xyZ9',
+    inviteToken: 'abcdefghijklmnopqrstuvwxyzABCDEFGH012345678',
+    inviteExpiresAt: now + 300_000,
+    e2eeFraming: 2
+  }
+} satisfies PairingOffer
+
+describe('mobile relay pairing journal store', () => {
+  let metadataRaw: string | null
+  let secretRaw: string | null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMobileRelayPairingJournalStoreForTests()
+    platform.OS = 'ios'
+    metadataRaw = null
+    secretRaw = null
+    asyncStorage.getItem.mockImplementation(async () => metadataRaw)
+    asyncStorage.setItem.mockImplementation(async (_key: string, value: string) => {
+      metadataRaw = value
+    })
+    asyncStorage.removeItem.mockImplementation(async () => {
+      metadataRaw = null
+    })
+    secureStore.getItemAsync.mockImplementation(async () => secretRaw)
+    secureStore.setItemAsync.mockImplementation(async (_key: string, value: string) => {
+      secretRaw = value
+    })
+    secureStore.deleteItemAsync.mockImplementation(async () => {
+      secretRaw = null
+    })
+  })
+
+  it('persists metadata before secrets and never places bearers in AsyncStorage', async () => {
+    const journal = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-1',
+      hostName: 'Blue Whale',
+      now,
+      randomBytes: (length) => new Uint8Array(length).fill(length)
+    })
+
+    await saveMobileRelayPairingJournal(journal)
+
+    expect(asyncStorage.setItem.mock.invocationCallOrder[0]).toBeLessThan(
+      secureStore.setItemAsync.mock.invocationCallOrder[0]!
+    )
+    expect(metadataRaw).not.toContain(offer.deviceToken)
+    expect(metadataRaw).not.toContain(offer.relay.inviteToken)
+    expect(metadataRaw).not.toContain(journal.secrets.pendingResumeToken)
+    await expect(loadMobileRelayPairingJournal()).resolves.toEqual(journal)
+  })
+
+  it('records a provisional winner only for the active journal identity', async () => {
+    const journal = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-1',
+      hostName: 'Blue Whale',
+      randomBytes: (length) => new Uint8Array(length).fill(7)
+    })
+    await saveMobileRelayPairingJournal(journal)
+
+    await updateMobileRelayPairingJournal(journal.metadata.journalId, (metadata) => ({
+      ...metadata,
+      winner: 'direct',
+      authorizationMode: 'authenticated-direct'
+    }))
+    await expect(
+      updateMobileRelayPairingJournal('stale-journal', (metadata) => metadata)
+    ).rejects.toThrow(/stale/)
+    expect(JSON.parse(metadataRaw!)).toMatchObject({
+      winner: 'direct',
+      authorizationMode: 'authenticated-direct'
+    })
+  })
+
+  it('treats metadata without its secret record as an incomplete crash', async () => {
+    const journal = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-1',
+      hostName: 'Blue Whale',
+      randomBytes: (length) => new Uint8Array(length).fill(9)
+    })
+    metadataRaw = JSON.stringify(journal.metadata)
+
+    await expect(loadMobileRelayPairingJournal()).resolves.toBeNull()
+    expect(metadataRaw).toBeNull()
+  })
+
+  it('clears metadata before deleting its secret and keeps relay unavailable on web', async () => {
+    const journal = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-1',
+      hostName: 'Blue Whale',
+      randomBytes: (length) => new Uint8Array(length).fill(11)
+    })
+    await saveMobileRelayPairingJournal(journal)
+    await clearMobileRelayPairingJournal(journal.metadata.journalId)
+    expect(asyncStorage.removeItem.mock.invocationCallOrder[0]).toBeLessThan(
+      secureStore.deleteItemAsync.mock.invocationCallOrder[0]!
+    )
+
+    platform.OS = 'web'
+    await expect(saveMobileRelayPairingJournal(journal)).rejects.toThrow(/native secret store/)
+  })
+})

--- a/mobile/src/transport/mobile-relay-pairing-journal-store.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal-store.ts
@@ -25,6 +25,11 @@ export async function saveMobileRelayPairingJournal(
     throw new Error('mobile relay pairing journal identity mismatch')
   }
   const mutation = journalMutation.then(async () => {
+    const existingRaw = await AsyncStorage.getItem(JOURNAL_STORAGE_KEY)
+    const existing = existingRaw ? parseMetadata(existingRaw) : null
+    if (existing && existing.journalId !== metadata.journalId) {
+      throw new Error('mobile relay pairing recovery pending')
+    }
     // Why: metadata-first makes a crash before the keychain write recover as
     // an incomplete journal, never as an untracked bearer secret.
     await AsyncStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(metadata))
@@ -44,6 +49,7 @@ export async function loadMobileRelayPairingJournal(): Promise<MobileRelayPairin
   }
   const metadata = parseMetadata(rawMetadata)
   if (!metadata) {
+    await removeIncompleteJournal()
     return null
   }
   const rawSecrets = await SecureStore.getItemAsync(JOURNAL_SECRET_KEY, KEYCHAIN_OPTIONS)
@@ -53,9 +59,17 @@ export async function loadMobileRelayPairingJournal(): Promise<MobileRelayPairin
   }
   const secrets = parseSecrets(rawSecrets)
   if (!secrets || secrets.journalId !== metadata.journalId) {
+    await removeIncompleteJournal()
     return null
   }
   return { metadata, secrets }
+}
+
+async function removeIncompleteJournal(): Promise<void> {
+  // Why: metadata is the discoverable cleanup pointer; remove it before the
+  // native secret so a second crash can only leave a self-cleaning orphan.
+  await AsyncStorage.removeItem(JOURNAL_STORAGE_KEY)
+  await SecureStore.deleteItemAsync(JOURNAL_SECRET_KEY, KEYCHAIN_OPTIONS).catch(() => {})
 }
 
 export async function updateMobileRelayPairingJournal(

--- a/mobile/src/transport/mobile-relay-pairing-journal-store.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal-store.ts
@@ -1,0 +1,122 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import * as SecureStore from 'expo-secure-store'
+import { Platform } from 'react-native'
+import {
+  MobileRelayPairingJournalMetadataSchema,
+  MobileRelayPairingJournalSecretsSchema,
+  type MobileRelayPairingJournal,
+  type MobileRelayPairingJournalMetadata
+} from './mobile-relay-pairing-journal'
+
+const JOURNAL_STORAGE_KEY = 'orca:mobile-relay:pairing-journal:v1'
+const JOURNAL_SECRET_KEY = 'orca.mobile-relay.pairing-journal.v1'
+const KEYCHAIN_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY
+}
+let journalMutation: Promise<void> = Promise.resolve()
+
+export async function saveMobileRelayPairingJournal(
+  journal: MobileRelayPairingJournal
+): Promise<void> {
+  requireNativeSecretStore()
+  const metadata = MobileRelayPairingJournalMetadataSchema.parse(journal.metadata)
+  const secrets = MobileRelayPairingJournalSecretsSchema.parse(journal.secrets)
+  if (metadata.journalId !== secrets.journalId) {
+    throw new Error('mobile relay pairing journal identity mismatch')
+  }
+  const mutation = journalMutation.then(async () => {
+    // Why: metadata-first makes a crash before the keychain write recover as
+    // an incomplete journal, never as an untracked bearer secret.
+    await AsyncStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(metadata))
+    await SecureStore.setItemAsync(JOURNAL_SECRET_KEY, JSON.stringify(secrets), KEYCHAIN_OPTIONS)
+  })
+  journalMutation = mutation.catch(() => {})
+  return mutation
+}
+
+export async function loadMobileRelayPairingJournal(): Promise<MobileRelayPairingJournal | null> {
+  requireNativeSecretStore()
+  await journalMutation
+  const rawMetadata = await AsyncStorage.getItem(JOURNAL_STORAGE_KEY)
+  if (rawMetadata === null) {
+    await SecureStore.deleteItemAsync(JOURNAL_SECRET_KEY, KEYCHAIN_OPTIONS).catch(() => {})
+    return null
+  }
+  const metadata = parseMetadata(rawMetadata)
+  if (!metadata) {
+    return null
+  }
+  const rawSecrets = await SecureStore.getItemAsync(JOURNAL_SECRET_KEY, KEYCHAIN_OPTIONS)
+  if (rawSecrets === null) {
+    await AsyncStorage.removeItem(JOURNAL_STORAGE_KEY)
+    return null
+  }
+  const secrets = parseSecrets(rawSecrets)
+  if (!secrets || secrets.journalId !== metadata.journalId) {
+    return null
+  }
+  return { metadata, secrets }
+}
+
+export async function updateMobileRelayPairingJournal(
+  journalId: string,
+  update: (metadata: MobileRelayPairingJournalMetadata) => MobileRelayPairingJournalMetadata
+): Promise<void> {
+  const mutation = journalMutation.then(async () => {
+    const raw = await AsyncStorage.getItem(JOURNAL_STORAGE_KEY)
+    const current = raw ? parseMetadata(raw) : null
+    if (!current || current.journalId !== journalId) {
+      throw new Error('stale mobile relay pairing journal')
+    }
+    const next = MobileRelayPairingJournalMetadataSchema.parse(update(current))
+    if (next.journalId !== journalId) {
+      throw new Error('mobile relay pairing journal identity mismatch')
+    }
+    await AsyncStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(next))
+  })
+  journalMutation = mutation.catch(() => {})
+  return mutation
+}
+
+export async function clearMobileRelayPairingJournal(journalId: string): Promise<void> {
+  const mutation = journalMutation.then(async () => {
+    const raw = await AsyncStorage.getItem(JOURNAL_STORAGE_KEY)
+    const current = raw ? parseMetadata(raw) : null
+    if (current && current.journalId !== journalId) {
+      throw new Error('stale mobile relay pairing journal')
+    }
+    await AsyncStorage.removeItem(JOURNAL_STORAGE_KEY)
+    await SecureStore.deleteItemAsync(JOURNAL_SECRET_KEY, KEYCHAIN_OPTIONS)
+  })
+  journalMutation = mutation.catch(() => {})
+  return mutation
+}
+
+function parseMetadata(raw: string): MobileRelayPairingJournalMetadata | null {
+  try {
+    const result = MobileRelayPairingJournalMetadataSchema.safeParse(JSON.parse(raw))
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+function parseSecrets(raw: string) {
+  try {
+    const result = MobileRelayPairingJournalSecretsSchema.safeParse(JSON.parse(raw))
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+function requireNativeSecretStore(): void {
+  if (Platform.OS === 'web') {
+    throw new Error('Orca Relay pairing requires a native secret store')
+  }
+}
+
+/** Test-only: drain the module mutation chain between cases. */
+export function resetMobileRelayPairingJournalStoreForTests(): void {
+  journalMutation = Promise.resolve()
+}

--- a/mobile/src/transport/mobile-relay-pairing-journal.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal.ts
@@ -31,6 +31,7 @@ export const MobileRelayPairingJournalMetadataSchema = z
       })
       .strict(),
     installReqId: z.string().min(1).max(128),
+    resumeConfirmReqId: z.string().min(1).max(128),
     pendingResumeTokenHash: Base64Url32ByteSchema,
     winner: z.enum(['direct', 'relay']).optional(),
     authorizationMode: z.enum(['authenticated-direct', 'relay-basis']).optional()
@@ -69,6 +70,7 @@ export function createMobileRelayPairingJournal(args: {
   const pendingResumeToken = encodeBase64Url(randomBytes(32))
   const journalId = `pair-${encodeBase64Url(randomBytes(16))}`
   const installReqId = `install-${encodeBase64Url(randomBytes(16))}`
+  const resumeConfirmReqId = `confirm-${encodeBase64Url(randomBytes(16))}`
   const { inviteToken, ...relayMetadata } = args.offer.relay
   return {
     metadata: MobileRelayPairingJournalMetadataSchema.parse({
@@ -84,6 +86,7 @@ export function createMobileRelayPairingJournal(args: {
       },
       relay: relayMetadata,
       installReqId,
+      resumeConfirmReqId,
       pendingResumeTokenHash: encodeBase64Url(sha256(decodeBase64Url(pendingResumeToken)))
     }),
     secrets: {

--- a/mobile/src/transport/mobile-relay-pairing-journal.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal.ts
@@ -1,0 +1,112 @@
+import * as ExpoCrypto from 'expo-crypto'
+import { sha256 } from '@noble/hashes/sha256'
+import { z } from 'zod'
+import type { PairingOffer, PairingRelay } from './types'
+
+const Base64Url32ByteSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/)
+
+export const MobileRelayPairingJournalMetadataSchema = z
+  .object({
+    v: z.literal(1),
+    journalId: z.string().min(1).max(128),
+    offerFingerprint: Base64Url32ByteSchema,
+    host: z
+      .object({
+        id: z.string().min(1),
+        name: z.string().min(1),
+        endpoint: z.string().min(1),
+        publicKeyB64: z.string().min(1),
+        lastConnected: z.number().int().nonnegative()
+      })
+      .strict(),
+    relay: z
+      .object({
+        v: z.literal(1),
+        directorUrl: z.string().min(1),
+        cellUrl: z.string().min(1),
+        assignmentEpoch: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+        relayHostId: z.string().regex(/^[A-Za-z0-9_-]{16}$/),
+        inviteExpiresAt: z.number().int().positive(),
+        e2eeFraming: z.literal(2)
+      })
+      .strict(),
+    installReqId: z.string().min(1).max(128),
+    pendingResumeTokenHash: Base64Url32ByteSchema,
+    winner: z.enum(['direct', 'relay']).optional(),
+    authorizationMode: z.enum(['authenticated-direct', 'relay-basis']).optional()
+  })
+  .strict()
+
+export const MobileRelayPairingJournalSecretsSchema = z
+  .object({
+    v: z.literal(1),
+    journalId: z.string().min(1).max(128),
+    deviceToken: z.string().min(1),
+    inviteToken: Base64Url32ByteSchema,
+    pendingResumeToken: Base64Url32ByteSchema
+  })
+  .strict()
+
+export type MobileRelayPairingJournalMetadata = z.infer<
+  typeof MobileRelayPairingJournalMetadataSchema
+>
+export type MobileRelayPairingJournalSecrets = z.infer<
+  typeof MobileRelayPairingJournalSecretsSchema
+>
+export type MobileRelayPairingJournal = {
+  metadata: MobileRelayPairingJournalMetadata
+  secrets: MobileRelayPairingJournalSecrets
+}
+
+export function createMobileRelayPairingJournal(args: {
+  offer: PairingOffer & { relay: PairingRelay }
+  hostId: string
+  hostName: string
+  now?: number
+  randomBytes?: (length: number) => Uint8Array
+}): MobileRelayPairingJournal {
+  const randomBytes = args.randomBytes ?? ExpoCrypto.getRandomBytes
+  const pendingResumeToken = encodeBase64Url(randomBytes(32))
+  const journalId = `pair-${encodeBase64Url(randomBytes(16))}`
+  const installReqId = `install-${encodeBase64Url(randomBytes(16))}`
+  const { inviteToken, ...relayMetadata } = args.offer.relay
+  return {
+    metadata: MobileRelayPairingJournalMetadataSchema.parse({
+      v: 1,
+      journalId,
+      offerFingerprint: encodeBase64Url(sha256(JSON.stringify(args.offer))),
+      host: {
+        id: args.hostId,
+        name: args.hostName,
+        endpoint: args.offer.endpoint,
+        publicKeyB64: args.offer.publicKeyB64,
+        lastConnected: args.now ?? Date.now()
+      },
+      relay: relayMetadata,
+      installReqId,
+      pendingResumeTokenHash: encodeBase64Url(sha256(decodeBase64Url(pendingResumeToken)))
+    }),
+    secrets: {
+      v: 1,
+      journalId,
+      deviceToken: args.offer.deviceToken,
+      inviteToken,
+      pendingResumeToken
+    }
+  }
+}
+
+function encodeBase64Url(value: Uint8Array | string): string {
+  const bytes = typeof value === 'string' ? new TextEncoder().encode(value) : value
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = `${base64}${'='.repeat((4 - (base64.length % 4)) % 4)}`
+  return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0))
+}

--- a/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { createMobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+import {
+  recoverMobileRelayPairing,
+  resetMobileRelayPairingRecoveryForTests
+} from './mobile-relay-pairing-recovery'
+import type { PairingCandidateClient } from './mobile-relay-physical-client'
+import type { PairingOffer, RpcResponse } from './types'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: vi.fn() }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED' }))
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: {} }))
+
+const now = Date.UTC(2026, 6, 13)
+const offer = {
+  v: 2,
+  endpoint: 'ws://192.168.1.10:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+  relay: {
+    v: 1,
+    directorUrl: 'https://relay.onorca.dev',
+    cellUrl: 'https://relay-c1.onorca.dev',
+    assignmentEpoch: 7,
+    relayHostId: 'AbCdEf0123_-xyZ9',
+    inviteToken: 'abcdefghijklmnopqrstuvwxyzABCDEFGH012345678',
+    inviteExpiresAt: now + 300_000,
+    e2eeFraming: 2
+  }
+} satisfies PairingOffer
+
+function response(result: unknown): RpcResponse {
+  return { id: 'rpc-1', ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+}
+
+function installed(
+  journal: ReturnType<typeof journal>,
+  mode: 'authenticated-direct' | 'relay-basis'
+) {
+  return {
+    v: 1 as const,
+    reqId: journal.metadata.installReqId,
+    authorizationMode: mode,
+    currentVersion: 1,
+    resumeExpiresAt: now + 86_400_000
+  }
+}
+
+function endpoints(
+  journal: ReturnType<typeof journal>,
+  state: { state: 'not-found' } | { state: 'committed'; result: ReturnType<typeof installed> }
+) {
+  return {
+    v: 1 as const,
+    relay: {
+      v: 1 as const,
+      directorUrl: offer.relay.directorUrl,
+      cellUrl: offer.relay.cellUrl,
+      assignmentEpoch: offer.relay.assignmentEpoch,
+      relayHostId: offer.relay.relayHostId,
+      e2eeFraming: 2 as const
+    },
+    installStatus: { v: 1 as const, reqId: journal.metadata.installReqId, ...state }
+  }
+}
+
+function journal(mode: 'authenticated-direct' | 'relay-basis' = 'authenticated-direct') {
+  const value = createMobileRelayPairingJournal({
+    offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+    hostId: 'host-1',
+    hostName: 'Blue Whale',
+    now,
+    randomBytes: (length) => new Uint8Array(length).fill(length)
+  })
+  return {
+    ...value,
+    metadata: {
+      ...value.metadata,
+      winner: mode === 'authenticated-direct' ? ('direct' as const) : ('relay' as const),
+      authorizationMode: mode
+    }
+  }
+}
+
+function client(handler: (method: string, params: unknown) => Promise<RpcResponse>) {
+  return { sendRequest: vi.fn(handler), close: vi.fn() } satisfies PairingCandidateClient
+}
+
+function dependencies(args: {
+  journal: ReturnType<typeof journal>
+  connectRelay: ReturnType<typeof vi.fn>
+  bundle?: MobileRelayCredentialBundle | null
+}) {
+  return {
+    loadJournal: vi.fn(async () => args.journal),
+    updateJournal: vi.fn(async (_id, update) => {
+      Object.assign(args.journal.metadata, update(args.journal.metadata))
+    }),
+    clearJournal: vi.fn(async () => {}),
+    readCredentialBundle: vi.fn(async () => args.bundle ?? null),
+    writeCredentialBundle: vi.fn(async () => {}),
+    loadHosts: vi.fn(async () => []),
+    saveHost: vi.fn(async () => {}),
+    connectRelay: args.connectRelay,
+    resolveInviteDirector: vi.fn(async () => {
+      throw new Error('director not needed')
+    }),
+    now: () => now,
+    platform: 'ios'
+  }
+}
+
+describe('mobile relay pairing recovery', () => {
+  beforeEach(() => {
+    resetMobileRelayPairingRecoveryForTests()
+  })
+
+  it('recovers a lost direct-install response with the pending credential first', async () => {
+    const saved = journal()
+    const committed = installed(saved, 'authenticated-direct')
+    const pending = client(async (method, params) => {
+      expect(method).toBe('pairing.getEndpoints')
+      expect(params).toEqual({
+        installReqId: saved.metadata.installReqId,
+        resumeConfirmReqId: saved.metadata.resumeConfirmReqId
+      })
+      return response(endpoints(saved, { state: 'committed', result: committed }))
+    })
+    const connectRelay = vi.fn(() => pending)
+    const deps = dependencies({ journal: saved, connectRelay })
+
+    await expect(recoverMobileRelayPairing(deps)).resolves.toBe('recovered')
+    expect(connectRelay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credential: saved.secrets.pendingResumeToken,
+        expectedCredentialKind: 'resume'
+      })
+    )
+    expect(deps.writeCredentialBundle).toHaveBeenCalledOnce()
+    expect(deps.saveHost).toHaveBeenCalledOnce()
+    expect(deps.clearJournal).toHaveBeenCalledOnce()
+  })
+
+  it('tries pending then current before an unexpired invite and transitions after not-found', async () => {
+    const saved = journal()
+    const currentToken = 'C'.repeat(43)
+    const bundle: MobileRelayCredentialBundle = {
+      v: 1,
+      hostId: 'host-1',
+      deviceToken: offer.deviceToken,
+      current: {
+        token: currentToken,
+        hash: 'D'.repeat(43),
+        version: 1,
+        expiresAt: now + 60_000
+      }
+    }
+    const failed = () =>
+      client(async () => {
+        throw new Error('resume rejected')
+      })
+    const relayInstalled = installed(saved, 'relay-basis')
+    let statusCalls = 0
+    const invite = client(async (method) => {
+      if (method === 'pairing.getEndpoints') {
+        statusCalls += 1
+        return response(
+          statusCalls === 1
+            ? endpoints(saved, { state: 'not-found' })
+            : endpoints(saved, { state: 'committed', result: relayInstalled })
+        )
+      }
+      expect(saved.metadata.authorizationMode).toBe('relay-basis')
+      return response(relayInstalled)
+    })
+    const seenCredentials: (string | undefined)[] = []
+    const connectRelay = vi.fn((args) => {
+      seenCredentials.push(args.credential)
+      return args.credential ? failed() : invite
+    })
+    const deps = dependencies({ journal: saved, connectRelay, bundle })
+
+    await expect(recoverMobileRelayPairing(deps)).resolves.toBe('recovered')
+    expect(seenCredentials).toEqual([saved.secrets.pendingResumeToken, currentToken, undefined])
+    expect(deps.updateJournal).toHaveBeenCalledWith(saved.metadata.journalId, expect.any(Function))
+    expect(invite.sendRequest).toHaveBeenCalledWith('pairing.provisionRelay', {
+      reqId: saved.metadata.installReqId,
+      newResumeTokenHash: saved.metadata.pendingResumeTokenHash
+    })
+  })
+
+  it('accepts the one late direct result after invite fallback observed not-found', async () => {
+    const saved = journal()
+    const directInstalled = installed(saved, 'authenticated-direct')
+    const failedPending = client(async () => {
+      throw new Error('pending unavailable')
+    })
+    let statusCalls = 0
+    const invite = client(async (method) => {
+      if (method === 'pairing.getEndpoints') {
+        statusCalls += 1
+        return response(
+          statusCalls === 1
+            ? endpoints(saved, { state: 'not-found' })
+            : endpoints(saved, { state: 'committed', result: directInstalled })
+        )
+      }
+      return response(directInstalled)
+    })
+    const deps = dependencies({
+      journal: saved,
+      connectRelay: vi.fn((args) => (args.credential ? failedPending : invite))
+    })
+
+    await expect(recoverMobileRelayPairing(deps)).resolves.toBe('recovered')
+    const written = deps.writeCredentialBundle.mock.calls[0]![0]
+    expect(written.current.token).toBe(saved.secrets.pendingResumeToken)
+    expect(saved.metadata.authorizationMode).toBe('authenticated-direct')
+    expect(deps.updateJournal).toHaveBeenCalledTimes(2)
+  })
+})

--- a/mobile/src/transport/mobile-relay-pairing-recovery.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.ts
@@ -1,0 +1,296 @@
+import { Platform } from 'react-native'
+import {
+  DeviceCredentialInstalledSchema,
+  PairingGetEndpointsResultSchema,
+  type DeviceCredentialInstalled,
+  type MobileRelayEndpoint
+} from '../../../src/shared/mobile-relay-credential-contract'
+import type { PairingRelay } from '../../../src/shared/mobile-relay-pairing-offer'
+import { loadHosts, saveHost } from './host-store'
+import {
+  promotePairingJournalCredential,
+  readMobileRelayCredentialBundle,
+  writeMobileRelayCredentialBundle,
+  type MobileRelayCredentialBundle
+} from './mobile-relay-credential-bundle'
+import { resolvePairingInviteThroughDirector } from './mobile-relay-invite-director'
+import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+import {
+  clearMobileRelayPairingJournal,
+  loadMobileRelayPairingJournal,
+  updateMobileRelayPairingJournal
+} from './mobile-relay-pairing-journal-store'
+import {
+  connectMobileRelayForPairing,
+  type PairingCandidateClient
+} from './mobile-relay-physical-client'
+import { createRecoveringPairingRelayCandidate } from './pairing-relay-candidate'
+import type { HostProfile, RpcResponse } from './types'
+
+export type MobileRelayPairingRecoveryResult = 'none' | 'recovered' | 'deferred'
+
+type RecoveryDependencies = {
+  loadJournal: typeof loadMobileRelayPairingJournal
+  updateJournal: typeof updateMobileRelayPairingJournal
+  clearJournal: typeof clearMobileRelayPairingJournal
+  readCredentialBundle: typeof readMobileRelayCredentialBundle
+  writeCredentialBundle: typeof writeMobileRelayCredentialBundle
+  loadHosts: typeof loadHosts
+  saveHost: typeof saveHost
+  connectRelay: typeof connectMobileRelayForPairing
+  resolveInviteDirector: typeof resolvePairingInviteThroughDirector
+  now: () => number
+  platform: string
+}
+
+const defaultDependencies: RecoveryDependencies = {
+  loadJournal: loadMobileRelayPairingJournal,
+  updateJournal: updateMobileRelayPairingJournal,
+  clearJournal: clearMobileRelayPairingJournal,
+  readCredentialBundle: readMobileRelayCredentialBundle,
+  writeCredentialBundle: writeMobileRelayCredentialBundle,
+  loadHosts,
+  saveHost,
+  connectRelay: connectMobileRelayForPairing,
+  resolveInviteDirector: resolvePairingInviteThroughDirector,
+  now: Date.now,
+  platform: Platform.OS
+}
+
+let recoveryPromise: Promise<MobileRelayPairingRecoveryResult> | null = null
+
+export function recoverMobileRelayPairing(
+  overrides: Partial<RecoveryDependencies> = {}
+): Promise<MobileRelayPairingRecoveryResult> {
+  if (recoveryPromise) {
+    return recoveryPromise
+  }
+  const dependencies = { ...defaultDependencies, ...overrides }
+  recoveryPromise = runRecovery(dependencies).finally(() => {
+    recoveryPromise = null
+  })
+  return recoveryPromise
+}
+
+async function runRecovery(
+  dependencies: RecoveryDependencies
+): Promise<MobileRelayPairingRecoveryResult> {
+  if (dependencies.platform === 'web') {
+    return 'none'
+  }
+  let journal: MobileRelayPairingJournal | null
+  try {
+    journal = await dependencies.loadJournal()
+  } catch {
+    return 'deferred'
+  }
+  if (!journal) {
+    return 'none'
+  }
+  const bundle = await dependencies.readCredentialBundle(journal.metadata.host.id).catch(() => null)
+  const hosts = await dependencies.loadHosts().catch(() => [])
+  const existing = hosts.find(({ id }) => id === journal!.metadata.host.id)
+  if (existing?.relayHostId === journal.metadata.relay.relayHostId && bundle) {
+    await dependencies.clearJournal(journal.metadata.journalId)
+    return 'recovered'
+  }
+
+  const credentials = recoveryCredentials(journal, bundle, dependencies.now())
+  for (const credential of credentials) {
+    let client: PairingCandidateClient | null = null
+    try {
+      client =
+        credential.kind === 'invite'
+          ? createInviteClient(journal, dependencies, (next) => {
+              journal = next
+            })
+          : dependencies.connectRelay({
+              relay: pairingRelay(journal),
+              deviceToken: journal.secrets.deviceToken,
+              desktopPublicKeyB64: journal.metadata.host.publicKeyB64,
+              credential: credential.token,
+              expectedCredentialKind: 'resume'
+            })
+      const endpoints = await getRecoveryStatus(client, journal, credential.kind)
+      if (endpoints.installStatus?.state === 'committed') {
+        await publishCommitted(journal, endpoints, dependencies)
+        return 'recovered'
+      }
+      if (credential.kind === 'invite' && endpoints.installStatus?.state === 'not-found') {
+        journal = await transitionToInviteAuthorization(journal, dependencies)
+        const installed = DeviceCredentialInstalledSchema.parse(
+          requireSuccess(
+            await client.sendRequest('pairing.provisionRelay', {
+              reqId: journal.metadata.installReqId,
+              newResumeTokenHash: journal.metadata.pendingResumeTokenHash
+            })
+          )
+        )
+        const reconciled = await getRecoveryStatus(client, journal, 'invite')
+        assertCommitted(reconciled, installed)
+        await publishCommitted(journal, reconciled, dependencies)
+        return 'recovered'
+      }
+    } catch {
+      // Why: ambiguous pairing state advances only by credential priority and
+      // authoritative status; a transport failure never rewrites the journal.
+    } finally {
+      client?.close()
+    }
+  }
+  return 'deferred'
+}
+
+function recoveryCredentials(
+  journal: MobileRelayPairingJournal,
+  bundle: MobileRelayCredentialBundle | null,
+  now: number
+): { kind: 'resume' | 'invite'; token: string }[] {
+  const credentials: { kind: 'resume' | 'invite'; token: string }[] = [
+    { kind: 'resume', token: journal.secrets.pendingResumeToken }
+  ]
+  if (bundle?.current.token && bundle.current.token !== journal.secrets.pendingResumeToken) {
+    credentials.push({ kind: 'resume', token: bundle.current.token })
+  }
+  if (journal.metadata.relay.inviteExpiresAt > now) {
+    credentials.push({ kind: 'invite', token: journal.secrets.inviteToken })
+  }
+  return credentials
+}
+
+function createInviteClient(
+  journal: MobileRelayPairingJournal,
+  dependencies: RecoveryDependencies,
+  replaceJournal: (journal: MobileRelayPairingJournal) => void
+): PairingCandidateClient {
+  return createRecoveringPairingRelayCandidate({
+    journal,
+    connect: (relay) =>
+      dependencies.connectRelay({
+        relay,
+        deviceToken: journal.secrets.deviceToken,
+        desktopPublicKeyB64: journal.metadata.host.publicKeyB64
+      }),
+    resolveDirector: (relay) => dependencies.resolveInviteDirector({ relay }),
+    persistMove: async (relay) => {
+      const next = {
+        ...journal,
+        metadata: {
+          ...journal.metadata,
+          relay: {
+            ...journal.metadata.relay,
+            cellUrl: relay.cellUrl,
+            assignmentEpoch: relay.assignmentEpoch
+          }
+        }
+      }
+      await dependencies.updateJournal(journal.metadata.journalId, () => next.metadata)
+      replaceJournal(next)
+    },
+    now: dependencies.now
+  })
+}
+
+async function getRecoveryStatus(
+  client: PairingCandidateClient,
+  journal: MobileRelayPairingJournal,
+  kind: 'resume' | 'invite'
+) {
+  return PairingGetEndpointsResultSchema.parse(
+    requireSuccess(
+      await client.sendRequest('pairing.getEndpoints', {
+        installReqId: journal.metadata.installReqId,
+        ...(kind === 'resume' ? { resumeConfirmReqId: journal.metadata.resumeConfirmReqId } : {})
+      })
+    )
+  )
+}
+
+async function transitionToInviteAuthorization(
+  journal: MobileRelayPairingJournal,
+  dependencies: RecoveryDependencies
+): Promise<MobileRelayPairingJournal> {
+  const next: MobileRelayPairingJournal = {
+    ...journal,
+    metadata: {
+      ...journal.metadata,
+      winner: 'relay',
+      authorizationMode: 'relay-basis'
+    }
+  }
+  // Why: the branch change becomes durable only after authoritative not-found.
+  await dependencies.updateJournal(journal.metadata.journalId, () => next.metadata)
+  return next
+}
+
+async function publishCommitted(
+  journal: MobileRelayPairingJournal,
+  endpoints: ReturnType<typeof PairingGetEndpointsResultSchema.parse>,
+  dependencies: RecoveryDependencies
+): Promise<void> {
+  if (endpoints.installStatus?.state !== 'committed' || !endpoints.relay) {
+    throw new Error('relay pairing recovery was not committed')
+  }
+  const installed = endpoints.installStatus.result
+  const reconciledJournal: MobileRelayPairingJournal = {
+    ...journal,
+    metadata: {
+      ...journal.metadata,
+      winner: installed.authorizationMode === 'authenticated-direct' ? 'direct' : 'relay',
+      authorizationMode: installed.authorizationMode
+    }
+  }
+  if (journal.metadata.authorizationMode !== installed.authorizationMode) {
+    await dependencies.updateJournal(journal.metadata.journalId, () => reconciledJournal.metadata)
+  }
+  await dependencies.writeCredentialBundle(
+    promotePairingJournalCredential({ journal: reconciledJournal, installed })
+  )
+  await dependencies.saveHost(relayHost(reconciledJournal, endpoints.relay))
+  await dependencies.clearJournal(journal.metadata.journalId)
+}
+
+function relayHost(journal: MobileRelayPairingJournal, relay: MobileRelayEndpoint): HostProfile {
+  const host = journal.metadata.host
+  const url = new URL(relay.cellUrl)
+  url.protocol = 'wss:'
+  url.pathname = `/v1/connect/${encodeURIComponent(relay.relayHostId)}`
+  return {
+    ...host,
+    deviceToken: journal.secrets.deviceToken,
+    endpoints: [
+      { id: 'direct-primary', kind: 'lan', url: host.endpoint },
+      { id: 'relay-primary', kind: 'relay', url: url.toString() }
+    ],
+    relayHostId: relay.relayHostId,
+    relay
+  }
+}
+
+function pairingRelay(journal: MobileRelayPairingJournal): PairingRelay {
+  return { ...journal.metadata.relay, inviteToken: journal.secrets.inviteToken }
+}
+
+function requireSuccess(response: RpcResponse): unknown {
+  if (!response.ok) {
+    throw new Error(`${response.error.code}: ${response.error.message}`)
+  }
+  return response.result
+}
+
+function assertCommitted(
+  endpoints: ReturnType<typeof PairingGetEndpointsResultSchema.parse>,
+  installed: DeviceCredentialInstalled
+): void {
+  if (
+    endpoints.installStatus?.state !== 'committed' ||
+    JSON.stringify(endpoints.installStatus.result) !== JSON.stringify(installed)
+  ) {
+    throw new Error('relay pairing recovery install was not authoritatively committed')
+  }
+}
+
+/** Test-only: clear the startup single-flight between cases. */
+export function resetMobileRelayPairingRecoveryForTests(): void {
+  recoveryPromise = null
+}

--- a/mobile/src/transport/mobile-relay-physical-client.test.ts
+++ b/mobile/src/transport/mobile-relay-physical-client.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fakes = vi.hoisted(() => ({
+  channelOptions: null as null | {
+    onAuthenticated(): void
+    onText(value: string): void
+  },
+  start: vi.fn(),
+  handleMessage: vi.fn(),
+  sendText: vi.fn(() => true),
+  dispose: vi.fn()
+}))
+
+vi.mock('./mobile-e2ee-v2-client-session', () => ({
+  MobileE2EEV2ClientSession: { create: vi.fn(() => ({ hello: {} })) }
+}))
+vi.mock('./mobile-e2ee-v2-physical-channel', () => ({
+  MobileE2EEV2PhysicalChannel: class {
+    constructor(options: NonNullable<typeof fakes.channelOptions>) {
+      fakes.channelOptions = options
+    }
+    start = fakes.start
+    handleMessage = fakes.handleMessage
+    sendText = fakes.sendText
+    dispose = fakes.dispose
+  }
+}))
+
+import { connectMobileRelayForPairing, RelayOuterError } from './mobile-relay-physical-client'
+
+class FakeSocket {
+  readonly OPEN = 1
+  readyState = 1
+  bufferedAmount = 0
+  sent: unknown[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: ((event: { code: number }) => void) | null = null
+
+  send(value: unknown): void {
+    this.sent.push(value)
+  }
+
+  close(): void {}
+
+  receive(data: unknown): void {
+    this.onmessage?.({ data })
+  }
+}
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  inviteToken: 'abcdefghijklmnopqrstuvwxyzABCDEFGH012345678',
+  inviteExpiresAt: Date.now() + 300_000,
+  e2eeFraming: 2 as const
+}
+
+describe('mobile relay physical pairing client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fakes.channelOptions = null
+    fakes.sendText.mockReturnValue(true)
+  })
+
+  it('uses first-frame outer auth, waits for host attach, then carries RPC over E2EE v2', async () => {
+    const socket = new FakeSocket()
+    let openedUrl = ''
+    const client = connectMobileRelayForPairing({
+      relay,
+      deviceToken: 'device-token',
+      desktopPublicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+      createSocket: (url) => {
+        openedUrl = url
+        return socket as unknown as WebSocket
+      }
+    })
+    socket.onopen?.()
+    expect(openedUrl).toBe('wss://relay-c1.onorca.dev/v1/connect/AbCdEf0123_-xyZ9')
+    expect(openedUrl).not.toContain('?')
+    expect(JSON.parse(socket.sent[0] as string)).toEqual({
+      type: 'relay-auth',
+      v: 1,
+      mode: 'connect',
+      credential: relay.inviteToken
+    })
+
+    socket.receive(
+      JSON.stringify({
+        type: 'relay-hello',
+        ok: true,
+        credentialKind: 'invite',
+        leaseExpiresAt: Date.now() + 60_000
+      })
+    )
+    await vi.waitFor(() => expect(fakes.start).toHaveBeenCalledOnce())
+    fakes.channelOptions!.onAuthenticated()
+    const responsePromise = client.sendRequest('status.get')
+    await vi.waitFor(() => expect(fakes.sendText).toHaveBeenCalledOnce())
+    const request = JSON.parse(fakes.sendText.mock.calls[0]![0] as string)
+    expect(request).toEqual({
+      id: 'relay-pair-1',
+      deviceToken: 'device-token',
+      method: 'status.get'
+    })
+    fakes.channelOptions!.onText(
+      JSON.stringify({
+        id: request.id,
+        ok: true,
+        result: { path: 'relay' },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    await expect(responsePromise).resolves.toMatchObject({ ok: true, result: { path: 'relay' } })
+  })
+
+  it('surfaces a typed endpoint-scoped outer rejection before E2EE', async () => {
+    const socket = new FakeSocket()
+    const client = connectMobileRelayForPairing({
+      relay,
+      deviceToken: 'device-token',
+      desktopPublicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+      createSocket: () => socket as unknown as WebSocket
+    })
+    const status = client.sendRequest('status.get')
+    socket.receive(JSON.stringify({ type: 'relay-hello', ok: false, code: 4404 }))
+
+    await expect(status).rejects.toEqual(new RelayOuterError(4404))
+    expect(fakes.start).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/mobile-relay-physical-client.ts
+++ b/mobile/src/transport/mobile-relay-physical-client.ts
@@ -27,6 +27,8 @@ export function connectMobileRelayForPairing(args: {
   relay: PairingRelay
   deviceToken: string
   desktopPublicKeyB64: string
+  credential?: string
+  expectedCredentialKind?: 'invite' | 'resume'
   requestTimeoutMs?: number
   createSocket?: (url: string) => WebSocket
 }): PairingCandidateClient {
@@ -85,7 +87,7 @@ export function connectMobileRelayForPairing(args: {
         type: 'relay-auth',
         v: 1,
         mode: 'connect',
-        credential: args.relay.inviteToken
+        credential: args.credential ?? args.relay.inviteToken
       })
     )
   }
@@ -124,8 +126,8 @@ export function connectMobileRelayForPairing(args: {
     if (!parsed.data.ok) {
       throw new RelayOuterError(parsed.data.code)
     }
-    if (parsed.data.credentialKind !== 'invite') {
-      throw new Error('pairing invite resolved as an unexpected credential kind')
+    if (parsed.data.credentialKind !== (args.expectedCredentialKind ?? 'invite')) {
+      throw new Error('relay credential resolved as an unexpected credential kind')
     }
     outerReady = true
     channel.start()

--- a/mobile/src/transport/mobile-relay-physical-client.ts
+++ b/mobile/src/transport/mobile-relay-physical-client.ts
@@ -1,0 +1,184 @@
+import type { PairingRelay } from '../../../src/shared/mobile-relay-pairing-offer'
+import { RelayPhoneHelloSchema } from '../../../src/shared/mobile-relay-phone-protocol'
+import { MobileE2EEV2ClientSession } from './mobile-e2ee-v2-client-session'
+import { MobileE2EEV2PhysicalChannel } from './mobile-e2ee-v2-physical-channel'
+import { isRpcResponse } from './rpc-response-shape'
+import type { RpcResponse } from './types'
+import { websocketPayloadToUint8 } from './websocket-payload-bytes'
+
+type PendingRequest = {
+  resolve: (response: RpcResponse) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+export type PairingCandidateClient = {
+  sendRequest(method: string, params?: unknown): Promise<RpcResponse>
+  close(): void
+}
+
+export class RelayOuterError extends Error {
+  constructor(readonly code: number) {
+    super(`relay_outer_${code}`)
+  }
+}
+
+export function connectMobileRelayForPairing(args: {
+  relay: PairingRelay
+  deviceToken: string
+  desktopPublicKeyB64: string
+  requestTimeoutMs?: number
+  createSocket?: (url: string) => WebSocket
+}): PairingCandidateClient {
+  const requestTimeoutMs = args.requestTimeoutMs ?? 30_000
+  const socketUrl = relayPhoneWebSocketUrl(args.relay)
+  const socket = (args.createSocket ?? ((url) => new WebSocket(url)))(socketUrl)
+  const session = MobileE2EEV2ClientSession.create({
+    desktopPublicKeyB64: args.desktopPublicKeyB64,
+    transport: 'relay',
+    relayHostId: args.relay.relayHostId
+  })
+  const pending = new Map<string, PendingRequest>()
+  let requestCounter = 0
+  let closed = false
+  let outerReady = false
+  let authenticated = false
+  let resolveAuthenticated!: () => void
+  let rejectAuthenticated!: (error: Error) => void
+  const authenticatedPromise = new Promise<void>((resolve, reject) => {
+    resolveAuthenticated = resolve
+    rejectAuthenticated = reject
+  })
+  const channel = new MobileE2EEV2PhysicalChannel({
+    session,
+    socket,
+    deviceToken: args.deviceToken,
+    decodeBinary: websocketPayloadToUint8,
+    onAuthenticated: () => {
+      authenticated = true
+      resolveAuthenticated()
+    },
+    onText: (plaintext) => {
+      let value: unknown
+      try {
+        value = JSON.parse(plaintext)
+      } catch {
+        return
+      }
+      if (!isRpcResponse(value)) {
+        return
+      }
+      const request = pending.get(value.id)
+      if (request) {
+        clearTimeout(request.timer)
+        pending.delete(value.id)
+        request.resolve(value)
+      }
+    },
+    onBinary: () => {},
+    onError: fail
+  })
+
+  socket.onopen = () => {
+    socket.send(
+      JSON.stringify({
+        type: 'relay-auth',
+        v: 1,
+        mode: 'connect',
+        credential: args.relay.inviteToken
+      })
+    )
+  }
+  let inboundChain: Promise<void> = Promise.resolve()
+  socket.onmessage = (event) => {
+    inboundChain = inboundChain
+      .then(async () => {
+        if (closed) {
+          return
+        }
+        if (!outerReady) {
+          acceptRelayHello(event.data)
+          return
+        }
+        await channel.handleMessage(event.data)
+      })
+      .catch((error: unknown) => fail(asError(error)))
+  }
+  socket.onerror = () => fail(new Error('relay transport error'))
+  socket.onclose = (event) => fail(new RelayOuterError(event.code || 1006))
+
+  function acceptRelayHello(raw: unknown): void {
+    if (typeof raw !== 'string') {
+      throw new Error('expected plaintext relay hello')
+    }
+    let value: unknown
+    try {
+      value = JSON.parse(raw)
+    } catch {
+      throw new Error('invalid relay hello JSON')
+    }
+    const parsed = RelayPhoneHelloSchema.safeParse(value)
+    if (!parsed.success) {
+      throw new Error('invalid relay hello')
+    }
+    if (!parsed.data.ok) {
+      throw new RelayOuterError(parsed.data.code)
+    }
+    if (parsed.data.credentialKind !== 'invite') {
+      throw new Error('pairing invite resolved as an unexpected credential kind')
+    }
+    outerReady = true
+    channel.start()
+  }
+
+  function fail(error: Error): void {
+    if (closed) {
+      return
+    }
+    closed = true
+    channel.dispose()
+    rejectAuthenticated(error)
+    for (const request of pending.values()) {
+      clearTimeout(request.timer)
+      request.reject(error)
+    }
+    pending.clear()
+    socket.close()
+  }
+
+  return {
+    async sendRequest(method, params) {
+      await authenticatedPromise
+      if (closed || !authenticated) {
+        throw new Error('relay pairing client closed')
+      }
+      const id = `relay-pair-${++requestCounter}`
+      return new Promise<RpcResponse>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id)
+          reject(new Error(`relay pairing RPC timed out: ${method}`))
+        }, requestTimeoutMs)
+        pending.set(id, { resolve, reject, timer })
+        if (
+          !channel.sendText(JSON.stringify({ id, deviceToken: args.deviceToken, method, params }))
+        ) {
+          clearTimeout(timer)
+          pending.delete(id)
+          reject(new Error('relay E2EE channel not ready'))
+        }
+      })
+    },
+    close: () => fail(new Error('relay pairing client closed'))
+  }
+}
+
+export function relayPhoneWebSocketUrl(relay: PairingRelay): string {
+  const url = new URL(relay.cellUrl)
+  url.protocol = 'wss:'
+  url.pathname = `/v1/connect/${encodeURIComponent(relay.relayHostId)}`
+  return url.toString()
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/mobile/src/transport/pairing-candidate-race.ts
+++ b/mobile/src/transport/pairing-candidate-race.ts
@@ -1,0 +1,59 @@
+import type { PairingCandidateClient } from './mobile-relay-physical-client'
+
+export type PairingCandidate = {
+  path: 'direct' | 'relay'
+  client: PairingCandidateClient
+}
+
+export function racePairingCandidates(
+  candidates: readonly PairingCandidate[]
+): Promise<PairingCandidate> {
+  return new Promise((resolve, reject) => {
+    const successes: PairingCandidate[] = []
+    let failures = 0
+    let settled = false
+    let selectionQueued = false
+    for (const candidate of candidates) {
+      void candidate.client.sendRequest('status.get').then(
+        (response) => {
+          if (!response.ok) {
+            failures++
+            rejectIfFinished()
+            return
+          }
+          successes.push(candidate)
+          if (selectionQueued) {
+            return
+          }
+          selectionQueued = true
+          // Why: defer one microtask so simultaneous successes are visible and
+          // direct deterministically wins the exact tie regardless of callback order.
+          queueMicrotask(() => {
+            if (settled) {
+              return
+            }
+            settled = true
+            const winner = successes.find(({ path }) => path === 'direct') ?? successes[0]!
+            for (const loser of candidates) {
+              if (loser !== winner) {
+                loser.client.close()
+              }
+            }
+            resolve(winner)
+          })
+        },
+        () => {
+          failures++
+          rejectIfFinished()
+        }
+      )
+    }
+
+    function rejectIfFinished(): void {
+      if (!settled && failures === candidates.length && successes.length === 0) {
+        settled = true
+        reject(new Error('direct and relay pairing paths both failed'))
+      }
+    }
+  })
+}

--- a/mobile/src/transport/pairing-relay-candidate.test.ts
+++ b/mobile/src/transport/pairing-relay-candidate.test.ts
@@ -103,6 +103,36 @@ describe('recovering pairing relay candidate', () => {
     expect(resolveDirector).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['wrong cell', new RelayOuterError(4409)],
+    ['planned drain', new RelayOuterError(4503)],
+    ['opaque close', new RelayOuterError(1006)],
+    ['HTTP 503', new Error('HTTP 503')],
+    ['HTTP 504', new Error('HTTP 504')],
+    ['transport failure', new Error('relay transport error')]
+  ])('uses the configured director after %s before E2EE', async (_name, failure) => {
+    const stale = client(Promise.reject(failure))
+    const target = client(Promise.resolve(success()))
+    const resolveDirector = vi.fn(async (relay) => ({
+      ...relay,
+      cellUrl: 'https://relay-c2.onorca.dev',
+      assignmentEpoch: 8
+    }))
+    let connects = 0
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: () => (connects++ === 0 ? stale : target),
+      resolveDirector,
+      persistMove: vi.fn(async () => {}),
+      now: () => 1,
+      random: () => 0,
+      sleep: async () => {}
+    })
+
+    await expect(candidate.sendRequest('status.get')).resolves.toEqual(success())
+    expect(resolveDirector).toHaveBeenCalledOnce()
+  })
+
   it('bounds director recovery and applies full jitter to failures and target retries', async () => {
     const stale = client(Promise.reject(new Error('HTTP 503')))
     const target = client(Promise.resolve(success()))

--- a/mobile/src/transport/pairing-relay-candidate.test.ts
+++ b/mobile/src/transport/pairing-relay-candidate.test.ts
@@ -31,6 +31,7 @@ const journal = {
       e2eeFraming: 2
     },
     installReqId: 'install-1',
+    resumeConfirmReqId: 'confirm-1',
     pendingResumeTokenHash: 'B'.repeat(43)
   },
   secrets: {
@@ -77,7 +78,9 @@ describe('recovering pairing relay candidate', () => {
       persistMove: async (relay) => {
         events.push(`persist:${relay.assignmentEpoch}`)
       },
-      now: () => 1
+      now: () => 1,
+      random: () => 0,
+      sleep: async () => {}
     })
 
     await expect(candidate.sendRequest('status.get')).resolves.toEqual(success())
@@ -98,5 +101,35 @@ describe('recovering pairing relay candidate', () => {
 
     await expect(candidate.sendRequest('status.get')).rejects.toEqual(new RelayOuterError(4404))
     expect(resolveDirector).not.toHaveBeenCalled()
+  })
+
+  it('bounds director recovery and applies full jitter to failures and target retries', async () => {
+    const stale = client(Promise.reject(new Error('HTTP 503')))
+    const target = client(Promise.resolve(success()))
+    const resolveDirector = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('HTTP 504'))
+      .mockRejectedValueOnce(new RelayOuterError(1006))
+      .mockImplementationOnce(async (relay) => ({
+        ...relay,
+        cellUrl: 'https://relay-c2.onorca.dev',
+        assignmentEpoch: 8
+      }))
+    const sleep = vi.fn(async () => {})
+    let connects = 0
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: () => (connects++ === 0 ? stale : target),
+      resolveDirector,
+      persistMove: vi.fn(async () => {}),
+      now: () => 1,
+      random: () => 0.5,
+      sleep,
+      maxRecoveryAttempts: 3
+    })
+
+    await expect(candidate.sendRequest('status.get')).resolves.toEqual(success())
+    expect(resolveDirector).toHaveBeenCalledTimes(3)
+    expect(sleep.mock.calls.map(([delay]) => delay)).toEqual([50, 100, 200])
   })
 })

--- a/mobile/src/transport/pairing-relay-candidate.test.ts
+++ b/mobile/src/transport/pairing-relay-candidate.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PairingCandidateClient } from './mobile-relay-physical-client'
+import { RelayOuterError } from './mobile-relay-physical-client'
+import { createRecoveringPairingRelayCandidate } from './pairing-relay-candidate'
+import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: (length: number) => new Uint8Array(length).fill(length)
+}))
+
+const journal = {
+  metadata: {
+    v: 1,
+    journalId: 'pair-1',
+    offerFingerprint: 'A'.repeat(43),
+    host: {
+      id: 'host-1',
+      name: 'Blue Whale',
+      endpoint: 'ws://192.168.1.10:6768',
+      publicKeyB64: 'A'.repeat(44),
+      lastConnected: 1
+    },
+    relay: {
+      v: 1,
+      directorUrl: 'https://relay.onorca.dev',
+      cellUrl: 'https://relay-c1.onorca.dev',
+      assignmentEpoch: 7,
+      relayHostId: 'AbCdEf0123_-xyZ9',
+      inviteExpiresAt: 10_000,
+      e2eeFraming: 2
+    },
+    installReqId: 'install-1',
+    pendingResumeTokenHash: 'B'.repeat(43)
+  },
+  secrets: {
+    v: 1,
+    journalId: 'pair-1',
+    deviceToken: 'device-token',
+    inviteToken: 'C'.repeat(43),
+    pendingResumeToken: 'D'.repeat(43)
+  }
+} satisfies MobileRelayPairingJournal
+
+function client(
+  result: Promise<never> | Promise<ReturnType<typeof success>>
+): PairingCandidateClient {
+  return { sendRequest: vi.fn(() => result), close: vi.fn() }
+}
+
+function success() {
+  return {
+    id: 'rpc-1',
+    ok: true as const,
+    result: { path: 'relay' },
+    _meta: { runtimeId: 'runtime-1' }
+  }
+}
+
+describe('recovering pairing relay candidate', () => {
+  it('persists a strictly-newer director move before retrying the target', async () => {
+    const events: string[] = []
+    const stale = client(Promise.reject(new RelayOuterError(4409)))
+    const target = client(Promise.resolve(success()))
+    let connects = 0
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: (relay) => {
+        events.push(`connect:${relay.assignmentEpoch}`)
+        return connects++ === 0 ? stale : target
+      },
+      resolveDirector: async (relay) => ({
+        ...relay,
+        cellUrl: 'https://relay-c2.onorca.dev',
+        assignmentEpoch: 8
+      }),
+      persistMove: async (relay) => {
+        events.push(`persist:${relay.assignmentEpoch}`)
+      },
+      now: () => 1
+    })
+
+    await expect(candidate.sendRequest('status.get')).resolves.toEqual(success())
+    expect(events).toEqual(['connect:7', 'persist:8', 'connect:8'])
+    expect(stale.close).toHaveBeenCalledOnce()
+  })
+
+  it('does not ask the director to reinterpret endpoint-scoped host-offline', async () => {
+    const offline = client(Promise.reject(new RelayOuterError(4404)))
+    const resolveDirector = vi.fn()
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: () => offline,
+      resolveDirector,
+      persistMove: vi.fn(),
+      now: () => 1
+    })
+
+    await expect(candidate.sendRequest('status.get')).rejects.toEqual(new RelayOuterError(4404))
+    expect(resolveDirector).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/pairing-relay-candidate.ts
+++ b/mobile/src/transport/pairing-relay-candidate.ts
@@ -8,10 +8,12 @@ export function createRecoveringPairingRelayCandidate(args: {
   resolveDirector: (relay: PairingRelay) => Promise<PairingRelay>
   persistMove: (relay: PairingRelay) => Promise<void>
   now: () => number
+  random?: () => number
+  sleep?: (delayMs: number) => Promise<void>
+  maxRecoveryAttempts?: number
 }): PairingCandidateClient {
   let relay = pairingRelayFromJournal(args.journal)
   let client = args.connect(relay)
-  let recoveryAttempted = false
   let closed = false
 
   return {
@@ -21,28 +23,55 @@ export function createRecoveringPairingRelayCandidate(args: {
       } catch (error) {
         if (
           method !== 'status.get' ||
-          recoveryAttempted ||
           closed ||
           relay.inviteExpiresAt <= args.now() ||
           !isDirectorRecoverable(error)
         ) {
           throw error
         }
-        recoveryAttempted = true
-        const moved = await args.resolveDirector(relay)
-        // Why: the authenticated newer assignment must be durable before a
-        // target dial so a crash cannot revert to the known-stale cell.
-        await args.persistMove(moved)
-        client.close()
-        relay = moved
-        client = args.connect(relay)
-        return client.sendRequest(method, params)
+        return recoverThroughDirector(method, params, error)
       }
     },
     close() {
       closed = true
       client.close()
     }
+  }
+
+  async function recoverThroughDirector(method: string, params: unknown, initialError: unknown) {
+    const maxAttempts = args.maxRecoveryAttempts ?? 3
+    const random = args.random ?? Math.random
+    const sleep =
+      args.sleep ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)))
+    let lastError = initialError
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      if (closed || relay.inviteExpiresAt <= args.now()) {
+        throw lastError
+      }
+      try {
+        const moved = await args.resolveDirector(relay)
+        // Why: the authenticated newer assignment must be durable before a
+        // target dial so a crash cannot revert to the known-stale cell.
+        await args.persistMove(moved)
+        client.close()
+        relay = moved
+        const capMs = Math.min(2_000, 100 * 2 ** attempt)
+        await sleep(Math.floor(random() * (capMs + 1)))
+        if (closed) {
+          throw new Error('relay pairing client closed')
+        }
+        client = args.connect(relay)
+        return await client.sendRequest(method, params)
+      } catch (error) {
+        lastError = error
+        if (!isDirectorRecoverable(error) || attempt + 1 >= maxAttempts) {
+          throw error
+        }
+        const capMs = Math.min(2_000, 100 * 2 ** attempt)
+        await sleep(Math.floor(random() * (capMs + 1)))
+      }
+    }
+    throw lastError
   }
 }
 

--- a/mobile/src/transport/pairing-relay-candidate.ts
+++ b/mobile/src/transport/pairing-relay-candidate.ts
@@ -1,0 +1,61 @@
+import type { PairingRelay } from '../../../src/shared/mobile-relay-pairing-offer'
+import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+import { RelayOuterError, type PairingCandidateClient } from './mobile-relay-physical-client'
+
+export function createRecoveringPairingRelayCandidate(args: {
+  journal: MobileRelayPairingJournal
+  connect: (relay: PairingRelay) => PairingCandidateClient
+  resolveDirector: (relay: PairingRelay) => Promise<PairingRelay>
+  persistMove: (relay: PairingRelay) => Promise<void>
+  now: () => number
+}): PairingCandidateClient {
+  let relay = pairingRelayFromJournal(args.journal)
+  let client = args.connect(relay)
+  let recoveryAttempted = false
+  let closed = false
+
+  return {
+    async sendRequest(method, params) {
+      try {
+        return await client.sendRequest(method, params)
+      } catch (error) {
+        if (
+          method !== 'status.get' ||
+          recoveryAttempted ||
+          closed ||
+          relay.inviteExpiresAt <= args.now() ||
+          !isDirectorRecoverable(error)
+        ) {
+          throw error
+        }
+        recoveryAttempted = true
+        const moved = await args.resolveDirector(relay)
+        // Why: the authenticated newer assignment must be durable before a
+        // target dial so a crash cannot revert to the known-stale cell.
+        await args.persistMove(moved)
+        client.close()
+        relay = moved
+        client = args.connect(relay)
+        return client.sendRequest(method, params)
+      }
+    },
+    close() {
+      closed = true
+      client.close()
+    }
+  }
+}
+
+function pairingRelayFromJournal(journal: MobileRelayPairingJournal): PairingRelay {
+  return {
+    ...journal.metadata.relay,
+    inviteToken: journal.secrets.inviteToken
+  }
+}
+
+function isDirectorRecoverable(error: unknown): boolean {
+  if (!(error instanceof RelayOuterError)) {
+    return true
+  }
+  return error.code === 4409 || error.code === 4503 || error.code === 1006
+}

--- a/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
@@ -61,6 +61,9 @@ function dependencies(client: RpcClient, events: string[]) {
   return {
     connectDirect: vi.fn(() => (events.push('connect'), client)),
     connectRelay: vi.fn(() => unavailableRelay),
+    resolveInviteDirector: vi.fn(async () => {
+      throw new Error('director unavailable')
+    }),
     getNextHostName: vi.fn(async () => 'Blue Whale'),
     saveHost: vi.fn(async (_host: HostProfile) => {
       events.push('save-host')

--- a/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+import { startPreProfilePairing } from './pre-profile-pairing-coordinator'
+import type { HostProfile, PairingOffer, RpcResponse } from './types'
+import type { RpcClient } from './rpc-client'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: (length: number) => new Uint8Array(length).fill(length)
+}))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED' }))
+
+const now = Date.UTC(2026, 6, 13)
+const directOffer: PairingOffer = {
+  v: 2,
+  endpoint: 'ws://192.168.1.10:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+}
+const relayOffer: PairingOffer = {
+  ...directOffer,
+  relay: {
+    v: 1,
+    directorUrl: 'https://relay.onorca.dev',
+    cellUrl: 'https://relay-c1.onorca.dev',
+    assignmentEpoch: 7,
+    relayHostId: 'AbCdEf0123_-xyZ9',
+    inviteToken: 'abcdefghijklmnopqrstuvwxyzABCDEFGH012345678',
+    inviteExpiresAt: now + 300_000,
+    e2eeFraming: 2
+  }
+}
+
+function success(result: unknown): RpcResponse {
+  return { id: 'rpc-1', ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+}
+
+function failure(code: string): RpcResponse {
+  return {
+    id: 'rpc-1',
+    ok: false,
+    error: { code, message: code },
+    _meta: { runtimeId: 'runtime-1' }
+  }
+}
+
+function fakeClient(responses: RpcResponse[]) {
+  return {
+    sendRequest: vi.fn().mockImplementation(async () => responses.shift()!),
+    close: vi.fn()
+  } as unknown as RpcClient
+}
+
+function dependencies(client: RpcClient, events: string[]) {
+  return {
+    connectDirect: vi.fn(() => (events.push('connect'), client)),
+    getNextHostName: vi.fn(async () => 'Blue Whale'),
+    saveHost: vi.fn(async (_host: HostProfile) => {
+      events.push('save-host')
+    }),
+    saveJournal: vi.fn(async (_journal: MobileRelayPairingJournal) => {
+      events.push('save-journal')
+    }),
+    updateJournal: vi.fn(async () => {
+      events.push('update-journal')
+    }),
+    clearJournal: vi.fn(async () => {
+      events.push('clear-journal')
+    }),
+    writeCredentialBundle: vi.fn(async (_bundle: MobileRelayCredentialBundle) => {
+      events.push('write-credential')
+    }),
+    now: () => now,
+    platform: 'ios'
+  }
+}
+
+describe('pre-profile pairing coordinator', () => {
+  it('keeps a legacy offer direct-only through the shared path', async () => {
+    const events: string[] = []
+    const client = fakeClient([success({ version: '1.0.0' })])
+    const deps = dependencies(client, events)
+
+    const attempt = startPreProfilePairing({
+      offer: directOffer,
+      timeoutMs: 5_000,
+      dependencies: deps
+    })
+
+    await expect(attempt.result).resolves.toEqual({ hostId: `host-${now}` })
+    expect(deps.saveHost).toHaveBeenCalledWith({
+      id: `host-${now}`,
+      name: 'Blue Whale',
+      endpoint: directOffer.endpoint,
+      deviceToken: directOffer.deviceToken,
+      publicKeyB64: directOffer.publicKeyB64,
+      lastConnected: now
+    })
+    expect(events).toEqual(['connect', 'save-host'])
+  })
+
+  it('journals before connecting and publishes only after authoritative direct install', async () => {
+    const events: string[] = []
+    let journal: MobileRelayPairingJournal | null = null
+    const client = {
+      sendRequest: vi.fn(async (method: string) => {
+        if (method === 'status.get') {
+          return success({ version: '1.0.0' })
+        }
+        if (!journal) {
+          throw new Error('journal was not saved before RPC')
+        }
+        const installed = {
+          v: 1 as const,
+          reqId: journal.metadata.installReqId,
+          authorizationMode: 'authenticated-direct' as const,
+          currentVersion: 1,
+          resumeExpiresAt: now + 86_400_000
+        }
+        if (method === 'pairing.provisionRelay') {
+          return success(installed)
+        }
+        return success({
+          v: 1,
+          relay: {
+            v: 1,
+            directorUrl: relayOffer.relay!.directorUrl,
+            cellUrl: relayOffer.relay!.cellUrl,
+            assignmentEpoch: 7,
+            relayHostId: relayOffer.relay!.relayHostId,
+            e2eeFraming: 2
+          },
+          installStatus: {
+            v: 1,
+            reqId: journal.metadata.installReqId,
+            state: 'committed',
+            result: installed
+          }
+        })
+      }),
+      close: vi.fn()
+    } as unknown as RpcClient
+    const deps = dependencies(client, events)
+    deps.saveJournal.mockImplementation(async (value) => {
+      journal = value
+      events.push('save-journal')
+    })
+
+    const attempt = startPreProfilePairing({
+      offer: relayOffer,
+      timeoutMs: 5_000,
+      dependencies: deps
+    })
+    await expect(attempt.result).resolves.toEqual({ hostId: `host-${now}` })
+
+    expect(journal).not.toBeNull()
+    expect(events).toEqual([
+      'save-journal',
+      'connect',
+      'update-journal',
+      'write-credential',
+      'save-host',
+      'clear-journal'
+    ])
+    expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'pairing.provisionRelay', {
+      reqId: journal!.metadata.installReqId,
+      newResumeTokenHash: journal!.metadata.pendingResumeTokenHash
+    })
+    expect(deps.saveHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `host-${now}`,
+        endpoint: directOffer.endpoint,
+        relayHostId: relayOffer.relay!.relayHostId,
+        endpoints: [
+          { id: 'direct-primary', kind: 'lan', url: directOffer.endpoint },
+          {
+            id: 'relay-primary',
+            kind: 'relay',
+            url: `wss://relay-c1.onorca.dev/v1/connect/${relayOffer.relay!.relayHostId}`
+          }
+        ]
+      })
+    )
+  })
+
+  it('tolerates an old desktop method_not_found and commits a direct-only host', async () => {
+    const events: string[] = []
+    const client = fakeClient([success({ version: '1.0.0' }), failure('method_not_found')])
+    const deps = dependencies(client, events)
+
+    const attempt = startPreProfilePairing({
+      offer: relayOffer,
+      timeoutMs: 5_000,
+      dependencies: deps
+    })
+    await expect(attempt.result).resolves.toEqual({ hostId: `host-${now}` })
+
+    expect(deps.saveHost).toHaveBeenCalledWith(
+      expect.not.objectContaining({ endpoints: expect.anything() })
+    )
+    expect(events).toEqual([
+      'save-journal',
+      'connect',
+      'update-journal',
+      'save-host',
+      'clear-journal'
+    ])
+  })
+
+  it('cancels the disposable physical client without publishing a host', async () => {
+    let resolveStatus!: (response: RpcResponse) => void
+    const status = new Promise<RpcResponse>((resolve) => {
+      resolveStatus = resolve
+    })
+    const client = fakeClient([])
+    ;(client.sendRequest as ReturnType<typeof vi.fn>).mockReturnValue(status)
+    const deps = dependencies(client, [])
+    const attempt = startPreProfilePairing({
+      offer: directOffer,
+      timeoutMs: 5_000,
+      dependencies: deps
+    })
+    await vi.waitFor(() => expect(client.sendRequest).toHaveBeenCalledWith('status.get'))
+    attempt.dispose()
+    resolveStatus(success({ version: '1.0.0' }))
+
+    await expect(attempt.result).rejects.toThrow(/cancelled/)
+    expect(client.close).toHaveBeenCalledOnce()
+    expect(deps.saveHost).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
 import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
+import { racePairingCandidates } from './pairing-candidate-race'
 import { startPreProfilePairing } from './pre-profile-pairing-coordinator'
 import type { HostProfile, PairingOffer, RpcResponse } from './types'
 import type { RpcClient } from './rpc-client'
@@ -53,8 +54,13 @@ function fakeClient(responses: RpcResponse[]) {
 }
 
 function dependencies(client: RpcClient, events: string[]) {
+  const unavailableRelay = fakeClient([])
+  ;(unavailableRelay.sendRequest as ReturnType<typeof vi.fn>).mockRejectedValue(
+    new Error('relay unavailable')
+  )
   return {
     connectDirect: vi.fn(() => (events.push('connect'), client)),
+    connectRelay: vi.fn(() => unavailableRelay),
     getNextHostName: vi.fn(async () => 'Blue Whale'),
     saveHost: vi.fn(async (_host: HostProfile) => {
       events.push('save-host')
@@ -77,6 +83,33 @@ function dependencies(client: RpcClient, events: string[]) {
 }
 
 describe('pre-profile pairing coordinator', () => {
+  it('chooses direct when both post-E2EE status successes settle in the same turn', async () => {
+    let resolveDirect!: (response: RpcResponse) => void
+    let resolveRelay!: (response: RpcResponse) => void
+    const direct = fakeClient([])
+    const relay = fakeClient([])
+    ;(direct.sendRequest as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<RpcResponse>((resolve) => {
+        resolveDirect = resolve
+      })
+    )
+    ;(relay.sendRequest as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<RpcResponse>((resolve) => {
+        resolveRelay = resolve
+      })
+    )
+    const racing = racePairingCandidates([
+      { path: 'direct', client: direct },
+      { path: 'relay', client: relay }
+    ])
+    resolveRelay(success({ path: 'relay' }))
+    resolveDirect(success({ path: 'direct' }))
+
+    await expect(racing).resolves.toMatchObject({ path: 'direct' })
+    expect(relay.close).toHaveBeenCalledOnce()
+    expect(direct.close).not.toHaveBeenCalled()
+  })
+
   it('keeps a legacy offer direct-only through the shared path', async () => {
     const events: string[] = []
     const client = fakeClient([success({ version: '1.0.0' })])
@@ -206,6 +239,68 @@ describe('pre-profile pairing coordinator', () => {
       'save-host',
       'clear-journal'
     ])
+  })
+
+  it('uses relay-basis provisioning when only the relay reaches post-E2EE status', async () => {
+    const direct = fakeClient([])
+    ;(direct.sendRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('LAN down'))
+    let journal: MobileRelayPairingJournal | null = null
+    const relay = {
+      sendRequest: vi.fn(async (method: string) => {
+        if (method === 'status.get') {
+          return success({ path: 'relay' })
+        }
+        const installed = {
+          v: 1 as const,
+          reqId: journal!.metadata.installReqId,
+          authorizationMode: 'relay-basis' as const,
+          currentVersion: 1,
+          resumeExpiresAt: now + 86_400_000
+        }
+        if (method === 'pairing.provisionRelay') {
+          return success(installed)
+        }
+        return success({
+          v: 1,
+          relay: {
+            v: 1,
+            directorUrl: relayOffer.relay!.directorUrl,
+            cellUrl: relayOffer.relay!.cellUrl,
+            assignmentEpoch: 7,
+            relayHostId: relayOffer.relay!.relayHostId,
+            e2eeFraming: 2
+          },
+          installStatus: {
+            v: 1,
+            reqId: journal!.metadata.installReqId,
+            state: 'committed',
+            result: installed
+          }
+        })
+      }),
+      close: vi.fn()
+    } as unknown as RpcClient
+    const deps = dependencies(direct, [])
+    deps.connectRelay.mockReturnValue(relay)
+    deps.saveJournal.mockImplementation(async (value) => {
+      journal = value
+    })
+
+    const attempt = startPreProfilePairing({
+      offer: relayOffer,
+      timeoutMs: 5_000,
+      dependencies: deps
+    })
+    await expect(attempt.result).resolves.toEqual({ hostId: `host-${now}` })
+
+    expect(direct.close).toHaveBeenCalled()
+    expect(relay.sendRequest).toHaveBeenNthCalledWith(2, 'pairing.provisionRelay', {
+      reqId: journal!.metadata.installReqId,
+      newResumeTokenHash: journal!.metadata.pendingResumeTokenHash
+    })
+    expect(deps.writeCredentialBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ current: expect.objectContaining({ version: 1 }) })
+    )
   })
 
   it('cancels the disposable physical client without publishing a host', async () => {

--- a/mobile/src/transport/pre-profile-pairing-coordinator.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.ts
@@ -1,0 +1,257 @@
+import { Platform } from 'react-native'
+import {
+  DeviceCredentialInstalledSchema,
+  PairingGetEndpointsResultSchema,
+  type DeviceCredentialInstalled,
+  type MobileRelayEndpoint
+} from '../../../src/shared/mobile-relay-credential-contract'
+import { connect, type ConnectOptions, type RpcClient } from './rpc-client'
+import { getNextHostName, saveHost } from './host-store'
+import type { HostProfile, PairingOffer, RpcResponse } from './types'
+import {
+  createMobileRelayPairingJournal,
+  type MobileRelayPairingJournal
+} from './mobile-relay-pairing-journal'
+import {
+  clearMobileRelayPairingJournal,
+  saveMobileRelayPairingJournal,
+  updateMobileRelayPairingJournal
+} from './mobile-relay-pairing-journal-store'
+import {
+  promotePairingJournalCredential,
+  writeMobileRelayCredentialBundle
+} from './mobile-relay-credential-bundle'
+
+export type PreProfilePairingAttempt = {
+  readonly result: Promise<{ hostId: string }>
+  readonly timedOut: boolean
+  dispose(): void
+}
+
+type Dependencies = {
+  connectDirect: typeof connect
+  getNextHostName: typeof getNextHostName
+  saveHost: typeof saveHost
+  saveJournal: typeof saveMobileRelayPairingJournal
+  updateJournal: typeof updateMobileRelayPairingJournal
+  clearJournal: typeof clearMobileRelayPairingJournal
+  writeCredentialBundle: typeof writeMobileRelayCredentialBundle
+  now: () => number
+  platform: string
+}
+
+const defaultDependencies: Dependencies = {
+  connectDirect: connect,
+  getNextHostName,
+  saveHost,
+  saveJournal: saveMobileRelayPairingJournal,
+  updateJournal: updateMobileRelayPairingJournal,
+  clearJournal: clearMobileRelayPairingJournal,
+  writeCredentialBundle: writeMobileRelayCredentialBundle,
+  now: Date.now,
+  platform: Platform.OS
+}
+
+export function startPreProfilePairing(args: {
+  offer: PairingOffer
+  timeoutMs: number
+  connectOptions?: ConnectOptions
+  dependencies?: Partial<Dependencies>
+}): PreProfilePairingAttempt {
+  const dependencies = { ...defaultDependencies, ...args.dependencies }
+  const clients = new Set<RpcClient>()
+  let disposed = false
+  let timedOut = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const dispose = (): void => {
+    if (disposed) {
+      return
+    }
+    disposed = true
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+    for (const client of clients) {
+      client.close()
+    }
+    clients.clear()
+  }
+
+  timer = setTimeout(() => {
+    timedOut = true
+    dispose()
+  }, args.timeoutMs)
+
+  const result = runPairing(args.offer, args.connectOptions, dependencies, clients, () => disposed)
+    .catch((error: unknown) => {
+      if (timedOut) {
+        throw new Error('mobile pairing timed out')
+      }
+      throw error
+    })
+    .finally(() => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      for (const client of clients) {
+        client.close()
+      }
+      clients.clear()
+    })
+
+  return {
+    result,
+    get timedOut() {
+      return timedOut
+    },
+    dispose
+  }
+}
+
+async function runPairing(
+  offer: PairingOffer,
+  connectOptions: ConnectOptions | undefined,
+  dependencies: Dependencies,
+  clients: Set<RpcClient>,
+  isDisposed: () => boolean
+): Promise<{ hostId: string }> {
+  const now = dependencies.now()
+  const hostId = `host-${now}`
+  const hostName = await dependencies.getNextHostName()
+  assertActive(isDisposed)
+  let journal: MobileRelayPairingJournal | null = null
+  if (offer.relay && dependencies.platform !== 'web') {
+    journal = createMobileRelayPairingJournal({
+      offer: { ...offer, relay: offer.relay },
+      hostId,
+      hostName,
+      now
+    })
+    await dependencies.saveJournal(journal)
+    assertActive(isDisposed)
+  }
+
+  const client = dependencies.connectDirect(
+    offer.endpoint,
+    offer.deviceToken,
+    offer.publicKeyB64,
+    connectOptions
+  )
+  clients.add(client)
+  requireSuccess(await client.sendRequest('status.get'))
+  assertActive(isDisposed)
+
+  if (!journal) {
+    await dependencies.saveHost(baseHost(offer, hostId, hostName, now))
+    return { hostId }
+  }
+
+  journal = {
+    ...journal,
+    metadata: {
+      ...journal.metadata,
+      winner: 'direct',
+      authorizationMode: 'authenticated-direct'
+    }
+  }
+  await dependencies.updateJournal(journal.metadata.journalId, () => journal!.metadata)
+  const provision = await client.sendRequest('pairing.provisionRelay', {
+    reqId: journal.metadata.installReqId,
+    newResumeTokenHash: journal.metadata.pendingResumeTokenHash
+  })
+  if (isMethodNotFound(provision)) {
+    await dependencies.saveHost(baseHost(offer, hostId, hostName, now))
+    await dependencies.clearJournal(journal.metadata.journalId)
+    return { hostId }
+  }
+  const installed = DeviceCredentialInstalledSchema.parse(requireSuccess(provision))
+  const endpoints = PairingGetEndpointsResultSchema.parse(
+    requireSuccess(
+      await client.sendRequest('pairing.getEndpoints', {
+        installReqId: journal.metadata.installReqId
+      })
+    )
+  )
+  assertCommittedInstall(endpoints.installStatus, installed)
+  if (!endpoints.relay) {
+    throw new Error('desktop returned no relay endpoint after credential install')
+  }
+  assertActive(isDisposed)
+  await dependencies.writeCredentialBundle(promotePairingJournalCredential({ journal, installed }))
+  await dependencies.saveHost(relayHost(journal, endpoints.relay))
+  await dependencies.clearJournal(journal.metadata.journalId)
+  return { hostId }
+}
+
+function baseHost(
+  offer: PairingOffer,
+  hostId: string,
+  name: string,
+  lastConnected: number
+): HostProfile {
+  return {
+    id: hostId,
+    name,
+    endpoint: offer.endpoint,
+    deviceToken: offer.deviceToken,
+    publicKeyB64: offer.publicKeyB64,
+    lastConnected
+  }
+}
+
+function relayHost(journal: MobileRelayPairingJournal, relay: MobileRelayEndpoint): HostProfile {
+  const host = journal.metadata.host
+  return {
+    ...host,
+    deviceToken: journal.secrets.deviceToken,
+    endpoints: [
+      { id: 'direct-primary', kind: 'lan', url: host.endpoint },
+      { id: 'relay-primary', kind: 'relay', url: relayWebSocketUrl(relay) }
+    ],
+    relayHostId: relay.relayHostId,
+    relay
+  }
+}
+
+function relayWebSocketUrl(relay: MobileRelayEndpoint): string {
+  const url = new URL(relay.cellUrl)
+  url.protocol = 'wss:'
+  url.pathname = `/v1/connect/${encodeURIComponent(relay.relayHostId)}`
+  return url.toString()
+}
+
+function requireSuccess(response: RpcResponse): unknown {
+  if (!response.ok) {
+    throw new Error(`${response.error.code}: ${response.error.message}`)
+  }
+  return response.result
+}
+
+function isMethodNotFound(response: RpcResponse): boolean {
+  return !response.ok && response.error.code === 'method_not_found'
+}
+
+function assertCommittedInstall(
+  status:
+    | { state: 'not-found' }
+    | { state: 'committed'; result: DeviceCredentialInstalled }
+    | undefined,
+  installed: DeviceCredentialInstalled
+): void {
+  if (
+    !status ||
+    status.state !== 'committed' ||
+    JSON.stringify(status.result) !== JSON.stringify(installed)
+  ) {
+    throw new Error('relay credential install was not authoritatively reconciled')
+  }
+}
+
+function assertActive(isDisposed: () => boolean): void {
+  if (isDisposed()) {
+    throw new Error('mobile pairing cancelled')
+  }
+}

--- a/mobile/src/transport/pre-profile-pairing-coordinator.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.ts
@@ -26,6 +26,8 @@ import {
   type PairingCandidateClient
 } from './mobile-relay-physical-client'
 import { racePairingCandidates, type PairingCandidate } from './pairing-candidate-race'
+import { resolvePairingInviteThroughDirector } from './mobile-relay-invite-director'
+import { createRecoveringPairingRelayCandidate } from './pairing-relay-candidate'
 
 export type PreProfilePairingAttempt = {
   readonly result: Promise<{ hostId: string }>
@@ -36,6 +38,7 @@ export type PreProfilePairingAttempt = {
 type Dependencies = {
   connectDirect: typeof connect
   connectRelay: typeof connectMobileRelayForPairing
+  resolveInviteDirector: typeof resolvePairingInviteThroughDirector
   getNextHostName: typeof getNextHostName
   saveHost: typeof saveHost
   saveJournal: typeof saveMobileRelayPairingJournal
@@ -49,6 +52,7 @@ type Dependencies = {
 const defaultDependencies: Dependencies = {
   connectDirect: connect,
   connectRelay: connectMobileRelayForPairing,
+  resolveInviteDirector: resolvePairingInviteThroughDirector,
   getNextHostName,
   saveHost,
   saveJournal: saveMobileRelayPairingJournal,
@@ -150,10 +154,30 @@ async function runPairing(
   clients.add(directClient)
   const candidates: PairingCandidate[] = [{ path: 'direct', client: directClient }]
   if (journal) {
-    const relayClient = dependencies.connectRelay({
-      relay: offer.relay!,
-      deviceToken: offer.deviceToken,
-      desktopPublicKeyB64: offer.publicKeyB64
+    const relayClient = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: (relay) =>
+        dependencies.connectRelay({
+          relay,
+          deviceToken: offer.deviceToken,
+          desktopPublicKeyB64: offer.publicKeyB64
+        }),
+      resolveDirector: (relay) => dependencies.resolveInviteDirector({ relay }),
+      persistMove: async (relay) => {
+        journal = {
+          ...journal!,
+          metadata: {
+            ...journal!.metadata,
+            relay: {
+              ...journal!.metadata.relay,
+              cellUrl: relay.cellUrl,
+              assignmentEpoch: relay.assignmentEpoch
+            }
+          }
+        }
+        await dependencies.updateJournal(journal.metadata.journalId, () => journal!.metadata)
+      },
+      now: dependencies.now
     })
     clients.add(relayClient)
     candidates.push({ path: 'relay', client: relayClient })

--- a/mobile/src/transport/pre-profile-pairing-coordinator.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.ts
@@ -5,7 +5,7 @@ import {
   type DeviceCredentialInstalled,
   type MobileRelayEndpoint
 } from '../../../src/shared/mobile-relay-credential-contract'
-import { connect, type ConnectOptions, type RpcClient } from './rpc-client'
+import { connect, type ConnectOptions } from './rpc-client'
 import { getNextHostName, saveHost } from './host-store'
 import type { HostProfile, PairingOffer, RpcResponse } from './types'
 import {
@@ -21,6 +21,11 @@ import {
   promotePairingJournalCredential,
   writeMobileRelayCredentialBundle
 } from './mobile-relay-credential-bundle'
+import {
+  connectMobileRelayForPairing,
+  type PairingCandidateClient
+} from './mobile-relay-physical-client'
+import { racePairingCandidates, type PairingCandidate } from './pairing-candidate-race'
 
 export type PreProfilePairingAttempt = {
   readonly result: Promise<{ hostId: string }>
@@ -30,6 +35,7 @@ export type PreProfilePairingAttempt = {
 
 type Dependencies = {
   connectDirect: typeof connect
+  connectRelay: typeof connectMobileRelayForPairing
   getNextHostName: typeof getNextHostName
   saveHost: typeof saveHost
   saveJournal: typeof saveMobileRelayPairingJournal
@@ -42,6 +48,7 @@ type Dependencies = {
 
 const defaultDependencies: Dependencies = {
   connectDirect: connect,
+  connectRelay: connectMobileRelayForPairing,
   getNextHostName,
   saveHost,
   saveJournal: saveMobileRelayPairingJournal,
@@ -59,7 +66,7 @@ export function startPreProfilePairing(args: {
   dependencies?: Partial<Dependencies>
 }): PreProfilePairingAttempt {
   const dependencies = { ...defaultDependencies, ...args.dependencies }
-  const clients = new Set<RpcClient>()
+  const clients = new Set<PairingCandidateClient>()
   let disposed = false
   let timedOut = false
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -115,7 +122,7 @@ async function runPairing(
   offer: PairingOffer,
   connectOptions: ConnectOptions | undefined,
   dependencies: Dependencies,
-  clients: Set<RpcClient>,
+  clients: Set<PairingCandidateClient>,
   isDisposed: () => boolean
 ): Promise<{ hostId: string }> {
   const now = dependencies.now()
@@ -134,14 +141,24 @@ async function runPairing(
     assertActive(isDisposed)
   }
 
-  const client = dependencies.connectDirect(
+  const directClient = dependencies.connectDirect(
     offer.endpoint,
     offer.deviceToken,
     offer.publicKeyB64,
     connectOptions
   )
-  clients.add(client)
-  requireSuccess(await client.sendRequest('status.get'))
+  clients.add(directClient)
+  const candidates: PairingCandidate[] = [{ path: 'direct', client: directClient }]
+  if (journal) {
+    const relayClient = dependencies.connectRelay({
+      relay: offer.relay!,
+      deviceToken: offer.deviceToken,
+      desktopPublicKeyB64: offer.publicKeyB64
+    })
+    clients.add(relayClient)
+    candidates.push({ path: 'relay', client: relayClient })
+  }
+  const winner = await racePairingCandidates(candidates)
   assertActive(isDisposed)
 
   if (!journal) {
@@ -153,16 +170,19 @@ async function runPairing(
     ...journal,
     metadata: {
       ...journal.metadata,
-      winner: 'direct',
-      authorizationMode: 'authenticated-direct'
+      winner: winner.path,
+      authorizationMode: winner.path === 'direct' ? 'authenticated-direct' : 'relay-basis'
     }
   }
   await dependencies.updateJournal(journal.metadata.journalId, () => journal!.metadata)
-  const provision = await client.sendRequest('pairing.provisionRelay', {
+  const provision = await winner.client.sendRequest('pairing.provisionRelay', {
     reqId: journal.metadata.installReqId,
     newResumeTokenHash: journal.metadata.pendingResumeTokenHash
   })
   if (isMethodNotFound(provision)) {
+    if (winner.path !== 'direct') {
+      throw new Error('relay pairing RPC unavailable after relay path authentication')
+    }
     await dependencies.saveHost(baseHost(offer, hostId, hostName, now))
     await dependencies.clearJournal(journal.metadata.journalId)
     return { hostId }
@@ -170,7 +190,7 @@ async function runPairing(
   const installed = DeviceCredentialInstalledSchema.parse(requireSuccess(provision))
   const endpoints = PairingGetEndpointsResultSchema.parse(
     requireSuccess(
-      await client.sendRequest('pairing.getEndpoints', {
+      await winner.client.sendRequest('pairing.getEndpoints', {
         installReqId: journal.metadata.installReqId
       })
     )

--- a/mobile/src/transport/types.ts
+++ b/mobile/src/transport/types.ts
@@ -3,6 +3,12 @@ import {
   PairingOfferSchema,
   type PairingOffer
 } from '../../../src/shared/mobile-relay-pairing-offer'
+import {
+  MobileAccessEndpointSchema,
+  type MobileAccessEndpoint,
+  type MobileRelayHostOverlay
+} from './mobile-relay-host-overlay'
+import { MobileRelayEndpointSchema } from '../../../src/shared/mobile-relay-credential-contract'
 
 export { PairingOfferSchema }
 export type { PairingOffer }
@@ -60,6 +66,9 @@ export type HostProfile = {
   deviceToken: string
   publicKeyB64: string
   lastConnected: number
+  endpoints?: MobileAccessEndpoint[]
+  relayHostId?: MobileRelayHostOverlay['relayHostId']
+  relay?: MobileRelayHostOverlay['relay']
 }
 
 export const HostProfileSchema = z.object({
@@ -68,7 +77,13 @@ export const HostProfileSchema = z.object({
   endpoint: z.string().min(1),
   deviceToken: z.string().min(1),
   publicKeyB64: z.string().min(1),
-  lastConnected: z.number().finite()
+  lastConnected: z.number().finite(),
+  endpoints: z.array(MobileAccessEndpointSchema).min(1).max(16).optional(),
+  relayHostId: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]{16}$/)
+    .optional(),
+  relay: MobileRelayEndpointSchema.optional()
 })
 
 // Why: persisted host record after the v0.0.3 keychain split. The

--- a/src/shared/mobile-relay-phone-protocol.test.ts
+++ b/src/shared/mobile-relay-phone-protocol.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { RelayPhoneHelloSchema } from './mobile-relay-phone-protocol'
+
+describe('relay phone outer protocol', () => {
+  it('accepts only exact invite, resume, and failure hello variants', () => {
+    expect(
+      RelayPhoneHelloSchema.safeParse({
+        type: 'relay-hello',
+        ok: true,
+        credentialKind: 'invite',
+        leaseExpiresAt: 1
+      }).success
+    ).toBe(true)
+    expect(
+      RelayPhoneHelloSchema.safeParse({
+        type: 'relay-hello',
+        ok: false,
+        code: 4404,
+        cellUrl: 'https://untrusted.example'
+      }).success
+    ).toBe(false)
+    expect(
+      RelayPhoneHelloSchema.safeParse({
+        type: 'relay-hello',
+        ok: true,
+        credentialKind: 'resume',
+        leaseExpiresAt: 10,
+        acceptedCredentialVersion: 2,
+        acceptedAs: 'grace',
+        resumeExpiresAt: 8
+      }).success
+    ).toBe(true)
+  })
+})

--- a/src/shared/mobile-relay-phone-protocol.ts
+++ b/src/shared/mobile-relay-phone-protocol.ts
@@ -33,3 +33,19 @@ export const RelayPhoneHelloSchema = z.union([
 ])
 
 export type RelayPhoneHello = z.infer<typeof RelayPhoneHelloSchema>
+
+export const RelayMovedSchema = z
+  .object({
+    type: z.literal('relay-moved'),
+    v: z.literal(1),
+    cellUrl: z.string().refine((value) => {
+      try {
+        const parsed = new URL(value)
+        return parsed.protocol === 'https:' && parsed.origin === value
+      } catch {
+        return false
+      }
+    }),
+    assignmentEpoch: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
+  })
+  .strict()

--- a/src/shared/mobile-relay-phone-protocol.ts
+++ b/src/shared/mobile-relay-phone-protocol.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+const EpochMsSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
+
+export const RelayPhoneHelloSchema = z.union([
+  z
+    .object({
+      type: z.literal('relay-hello'),
+      ok: z.literal(false),
+      code: z.number().int().min(4000).max(4999)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('relay-hello'),
+      ok: z.literal(true),
+      credentialKind: z.literal('invite'),
+      leaseExpiresAt: EpochMsSchema
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('relay-hello'),
+      ok: z.literal(true),
+      credentialKind: z.literal('resume'),
+      leaseExpiresAt: EpochMsSchema,
+      acceptedCredentialVersion: z.number().int().positive(),
+      acceptedAs: z.enum(['current', 'grace']),
+      resumeExpiresAt: EpochMsSchema,
+      graceExpiresAt: EpochMsSchema.optional()
+    })
+    .strict()
+])
+
+export type RelayPhoneHello = z.infer<typeof RelayPhoneHelloSchema>


### PR DESCRIPTION
Review-only mobile pairing/endpoints slice stacked on #8529. Do not merge directly; the combined relay PR remains the single merge PR.

Scope:
- durable pre-profile journal and native secret bundles
- direct/relay race through authenticated `status.get`
- atomic install recovery and no-resurrection host overlay
- configured-director invite recovery for 4409/4503/1006/503/504/transport failures
- strict newer-epoch persistence before retry with bounded full jitter

Validation:
- 26 focused mobile pairing/store/recovery tests
- full mobile suite on combined branch: 1,566 passing, 2 skipped
- `pnpm typecheck`
- pre-commit mobile oxlint/oxfmt gates

Made with [Orca](https://github.com/stablyai/orca) 🐋
