### PR TITLE
Review: Orca Relay mobile logical connect and migration

### DIFF
--- a/mobile/app/connection-log.tsx
+++ b/mobile/app/connection-log.tsx
@@ -9,11 +9,11 @@ import { colors, spacing, typography } from '../src/theme/mobile-theme'
 import { ConnectionLog } from '../src/components/ConnectionLog'
 import { loadHosts } from '../src/transport/host-store'
 import { connectionLogStore } from '../src/transport/connection-log-buffer'
+import { useHostClient } from '../src/transport/client-context'
 import {
-  useHostClient,
   useLastConnectedAt,
   useReconnectAttempt
-} from '../src/transport/client-context'
+} from '../src/transport/client-context-connection-metrics'
 import { buildConnectionDiagnosticsReport } from '../src/diagnostics/connection-diagnostics-report'
 import type { ConnectionLogEntry, HostProfile } from '../src/transport/types'
 

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -33,10 +33,12 @@ import { removeHostAndCloseClient } from '../../../src/transport/host-removal-li
 import {
   useHostClient,
   useCloseHost,
-  useForceReconnect,
-  useReconnectAttempt,
-  useLastConnectedAt
+  useForceReconnect
 } from '../../../src/transport/client-context'
+import {
+  useLastConnectedAt,
+  useReconnectAttempt
+} from '../../../src/transport/client-context-connection-metrics'
 import {
   classifyConnection,
   type ConnectionVerdict

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -56,12 +56,11 @@ import {
   saveTerminalTextScale,
   type MobileTerminalLinkOpenMode
 } from '../../../../src/storage/preferences'
+import { useHostClient, useForceReconnect } from '../../../../src/transport/client-context'
 import {
-  useHostClient,
-  useForceReconnect,
-  useReconnectAttempt,
-  useLastConnectedAt
-} from '../../../../src/transport/client-context'
+  useLastConnectedAt,
+  useReconnectAttempt
+} from '../../../../src/transport/client-context-connection-metrics'
 import {
   classifyConnection,
   verdictDisplayLabel

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -34,11 +34,11 @@ import {
 } from 'lucide-react-native'
 import type { RpcClient } from '../../../src/transport/rpc-client'
 import type { RpcSuccess } from '../../../src/transport/types'
+import { useHostClient } from '../../../src/transport/client-context'
 import {
-  useHostClient,
   useLastConnectedAt,
   useReconnectAttempt
-} from '../../../src/transport/client-context'
+} from '../../../src/transport/client-context-connection-metrics'
 import { classifyConnection } from '../../../src/transport/connection-health'
 import { StatusDot } from '../../../src/components/StatusDot'
 import { ActionSheetModal } from '../../../src/components/ActionSheetModal'

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -3,7 +3,6 @@ import { View, Text, StyleSheet, Pressable, FlatList, Alert } from 'react-native
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter, useFocusEffect } from 'expo-router'
 import {
-  Monitor,
   QrCode,
   Settings,
   ChevronRight,
@@ -35,12 +34,12 @@ import {
   useForceReconnect,
   usePrimeHosts
 } from '../src/transport/client-context'
-import { classifyConnection, verdictDisplayLabel } from '../src/transport/connection-health'
+import { classifyConnection } from '../src/transport/connection-health'
 import { subscribeToDesktopNotifications } from '../src/notifications/mobile-notifications'
 import type { ConnectionState, HostProfile } from '../src/transport/types'
 import { triggerMediumImpact } from '../src/platform/haptics'
 import { OrcaLogo } from '../src/components/OrcaLogo'
-import { StatusDot } from '../src/components/StatusDot'
+import { MobileHostCard } from '../src/components/MobileHostCard'
 import { TaskProviderLogo } from '../src/components/TaskProviderLogo'
 import { TextInputModal } from '../src/components/TextInputModal'
 import { ActionSheetModal, type ActionSheetAction } from '../src/components/ActionSheetModal'
@@ -324,6 +323,10 @@ export default function HomeScreen() {
   // docs/mobile-shared-client-per-host.md.
   const hostIds = useMemo(() => hosts.map((h) => h.id), [hosts])
   const allClients = useAllHostClients(hostIds)
+  const hostPaths = useMemo(
+    () => Object.fromEntries(allClients.map(({ hostId, path }) => [hostId, path])),
+    [allClients]
+  )
   const closeHostClient = useCloseHost()
   const forceReconnectHost = useForceReconnect()
   const primeHosts = usePrimeHosts()
@@ -824,7 +827,6 @@ export default function HomeScreen() {
             const state = hostStates[item.id] ?? 'connecting'
             const attempts = hostAttempts[item.id] ?? 0
             const lastConnectedAt = hostLastConnected[item.id] ?? null
-            const connected = state === 'connected'
             const info = worktreeInfo[item.id]
             const verdict = classifyConnection({
               state,
@@ -832,45 +834,21 @@ export default function HomeScreen() {
               lastConnectedAt,
               endpoint: item.endpoint
             })
-            const isError =
-              verdict.kind === 'warning' ||
-              verdict.kind === 'unreachable' ||
-              verdict.kind === 'auth-failed'
             return (
-              <Pressable
-                style={({ pressed }) => [styles.hostCard, pressed && styles.hostCardPressed]}
+              <MobileHostCard
+                host={item}
+                state={state}
+                verdict={verdict}
+                path={hostPaths[item.id] ?? 'lan'}
+                worktreeCounts={
+                  info ? { total: info.totalWorktrees, active: info.activeCount } : undefined
+                }
                 onPress={() => router.push(`/h/${item.id}`)}
                 onLongPress={() => {
                   triggerMediumImpact()
                   setActionTarget(item)
                 }}
-                delayLongPress={400}
-              >
-                <View style={styles.hostIcon}>
-                  <Monitor
-                    size={20}
-                    color={connected ? colors.textPrimary : colors.textSecondary}
-                  />
-                </View>
-                <View style={styles.hostMain}>
-                  <Text
-                    style={[styles.hostName, !connected && { color: colors.textSecondary }]}
-                    numberOfLines={1}
-                  >
-                    {item.name}
-                  </Text>
-                  <View style={styles.hostMeta}>
-                    <StatusDot state={state} verdict={verdict} />
-                    <Text style={[styles.hostMetaItem, isError && { color: colors.statusRed }]}>
-                      {verdictDisplayLabel(verdict)}
-                      {connected && info
-                        ? ` · ${info.totalWorktrees} worktree${info.totalWorktrees !== 1 ? 's' : ''}${info.activeCount > 0 ? ` · ${info.activeCount} active` : ''}`
-                        : ''}
-                    </Text>
-                  </View>
-                </View>
-                <ChevronRight size={16} color={colors.textMuted} />
-              </Pressable>
+              />
             )
           }}
           ListFooterComponent={
@@ -1244,62 +1222,8 @@ const styles = StyleSheet.create({
   },
 
   /* ─── Host cards ─── */
-  hostCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingLeft: spacing.md,
-    paddingRight: spacing.md,
-    paddingVertical: 12,
-    borderRadius: radii.card,
-    backgroundColor: colors.bgPanel,
-    borderWidth: 1,
-    borderColor: colors.borderSubtle
-  },
   hostCardPressed: {
     backgroundColor: colors.bgRaised
-  },
-  hostIcon: {
-    width: 46,
-    height: 46,
-    borderRadius: 13,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: colors.bgRaised,
-    marginRight: 14,
-    position: 'relative'
-  },
-  hostMain: {
-    flex: 1,
-    minWidth: 0,
-    marginRight: spacing.sm
-  },
-  hostName: {
-    color: colors.textPrimary,
-    fontSize: 15,
-    fontWeight: '600',
-    lineHeight: 20
-  },
-  hostMeta: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    marginTop: 3
-  },
-  hostMetaItem: {
-    fontSize: 12,
-    color: colors.textSecondary
-  },
-  hostMetaDot: {
-    width: 3,
-    height: 3,
-    borderRadius: 1.5,
-    backgroundColor: colors.textMuted,
-    marginHorizontal: 8
-  },
-  statusDot: {
-    width: 7,
-    height: 7,
-    borderRadius: 3.5
   },
 
   /* ─── Resume card ─── */

--- a/mobile/src/components/MobileHostCard.tsx
+++ b/mobile/src/components/MobileHostCard.tsx
@@ -1,0 +1,91 @@
+import { ChevronRight, Monitor } from 'lucide-react-native'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import type { ConnectionVerdict } from '../transport/connection-health'
+import { verdictDisplayLabel } from '../transport/connection-health'
+import { mobileConnectionPathLabel } from '../transport/mobile-connection-path-label'
+import type { MobileConnectionPath } from '../transport/stable-logical-rpc-client'
+import type { ConnectionState, HostProfile } from '../transport/types'
+import { colors, radii, spacing } from '../theme/mobile-theme'
+import { StatusDot } from './StatusDot'
+
+export function MobileHostCard(props: {
+  host: HostProfile
+  state: ConnectionState
+  verdict: ConnectionVerdict
+  path: MobileConnectionPath
+  worktreeCounts?: { total: number; active: number }
+  onPress: () => void
+  onLongPress: () => void
+}) {
+  const connected = props.state === 'connected'
+  const isError = ['warning', 'unreachable', 'auth-failed'].includes(props.verdict.kind)
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+      onPress={props.onPress}
+      onLongPress={props.onLongPress}
+      delayLongPress={400}
+    >
+      <View style={styles.icon}>
+        <Monitor size={20} color={connected ? colors.textPrimary : colors.textSecondary} />
+      </View>
+      <View style={styles.main}>
+        <Text
+          style={[styles.name, !connected && { color: colors.textSecondary }]}
+          numberOfLines={1}
+        >
+          {props.host.name}
+        </Text>
+        <View style={styles.meta}>
+          <StatusDot state={props.state} verdict={props.verdict} />
+          <Text style={[styles.metaText, isError && { color: colors.statusRed }]}>
+            {verdictDisplayLabel(props.verdict)}
+            {connected ? ` · ${mobileConnectionPathLabel(props.path)}` : ''}
+            {connected && props.worktreeCounts
+              ? ` · ${props.worktreeCounts.total} worktree${props.worktreeCounts.total !== 1 ? 's' : ''}${props.worktreeCounts.active > 0 ? ` · ${props.worktreeCounts.active} active` : ''}`
+              : ''}
+          </Text>
+        </View>
+        {props.verdict.kind === 'unreachable' && !props.host.relay ? (
+          <Text style={styles.discoveryHint} numberOfLines={2}>
+            Update desktop Orca and sign in to connect from anywhere
+          </Text>
+        ) : null}
+      </View>
+      <ChevronRight size={16} color={colors.textMuted} />
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: 12,
+    borderRadius: radii.card,
+    backgroundColor: colors.bgPanel,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle
+  },
+  cardPressed: { backgroundColor: colors.bgRaised },
+  icon: {
+    width: 46,
+    height: 46,
+    borderRadius: 13,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgRaised,
+    marginRight: 14
+  },
+  main: { flex: 1, minWidth: 0, marginRight: spacing.sm },
+  name: { color: colors.textPrimary, fontSize: 15, fontWeight: '600', lineHeight: 20 },
+  meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 3 },
+  metaText: { fontSize: 12, color: colors.textSecondary },
+  discoveryHint: {
+    marginTop: spacing.xs,
+    fontSize: 11,
+    lineHeight: 15,
+    color: colors.textMuted
+  }
+})

--- a/mobile/src/transport/client-context-connection-metrics.ts
+++ b/mobile/src/transport/client-context-connection-metrics.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { useRpcClientContext, type RpcClientContextValue } from './client-context'
+
+export function useReconnectAttempt(hostId: string | undefined): number {
+  return useHostMetric(hostId, (context, id) => context.getReconnectAttempt(id), 0)
+}
+
+export function useLastConnectedAt(hostId: string | undefined): number | null {
+  return useHostMetric(hostId, (context, id) => context.getLastConnectedAt(id), null)
+}
+
+function useHostMetric<T>(
+  hostId: string | undefined,
+  read: (context: RpcClientContextValue, hostId: string) => T,
+  fallback: T
+): T {
+  const context = useRpcClientContext()
+  const [, force] = useState(0)
+  useEffect(() => {
+    if (!hostId) {
+      return
+    }
+    return context.subscribeHostState(hostId, () => force((count) => count + 1))
+  }, [context, hostId])
+  return hostId ? read(context, hostId) : fallback
+}

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -131,7 +131,7 @@ describe('useHostClient', () => {
     loadHostsMock.mockResolvedValue([HOST])
 
     const harness = await renderHarness(HOST.id)
-    expect(harness.hook.client).toBe(fake)
+    expect(harness.hook.client).not.toBeNull()
     expect(harness.hook.state).toBe('connected')
 
     // Regression (STA-1511): closeHost deletes the entry; before the fix the

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -10,6 +10,9 @@ const loadHostsMock = vi.fn()
 vi.mock('./rpc-client', () => ({
   connect: (...args: unknown[]) => connectMock(...args)
 }))
+vi.mock('./host-logical-client', () => ({
+  openHostLogicalClient: (...args: unknown[]) => connectMock(...args)
+}))
 vi.mock('./host-store', () => ({
   loadHosts: () => loadHostsMock()
 }))

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -25,6 +25,7 @@ import { subscribeConnectionRevivalTriggers } from './connection-revival-trigger
 import { HostClientOpenRegistry } from './host-client-open-registry'
 import { loadHosts } from './host-store'
 import { openHostLogicalClient } from './host-logical-client'
+import type { MobileConnectionPath, StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ConnectionState, HostProfile } from './types'
 
 type StoreEntry = {
@@ -34,7 +35,7 @@ type StoreEntry = {
   unsubState: () => void
 }
 
-type ContextValue = {
+export type RpcClientContextValue = {
   acquire: (hostId: string, host?: HostProfile) => RpcClient | null
   release: (hostId: string) => void
   forceReconnect: (hostId: string) => Promise<void>
@@ -46,6 +47,7 @@ type ContextValue = {
   // Used by the UI to escalate "Reconnecting…" into a "host appears
   // unreachable, re-pair?" prompt.
   getLastConnectedAt: (hostId: string) => number | null
+  getActivePath: (hostId: string) => MobileConnectionPath
   subscribeHostState: (hostId: string, listener: (state: ConnectionState) => void) => () => void
   getAllClients: () => Array<{ hostId: string; client: RpcClient }>
   subscribeAllHosts: (listener: () => void) => () => void
@@ -55,7 +57,7 @@ type ContextValue = {
   primeHosts: (hosts: HostProfile[]) => void
 }
 
-const Ctx = createContext<ContextValue | null>(null)
+const Ctx = createContext<RpcClientContextValue | null>(null)
 
 export function RpcClientProvider({ children }: { children: ReactNode }) {
   // Why: entries live in a ref so updates don't force re-renders of the
@@ -275,6 +277,10 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     return storeRef.current.get(hostId)?.client.getLastConnectedAt() ?? null
   }, [])
 
+  const getActivePath = useCallback((hostId: string): MobileConnectionPath => {
+    return clientActivePath(storeRef.current.get(hostId)?.client)
+  }, [])
+
   const subscribeHostState = useCallback(
     (hostId: string, listener: (state: ConnectionState) => void) => {
       let set = stateListenersRef.current.get(hostId)
@@ -344,7 +350,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
-  const value = useMemo<ContextValue>(
+  const value = useMemo<RpcClientContextValue>(
     () => ({
       acquire,
       release,
@@ -353,6 +359,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       getState,
       getReconnectAttempt,
       getLastConnectedAt,
+      getActivePath,
       subscribeHostState,
       getAllClients,
       subscribeAllHosts,
@@ -366,6 +373,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       getState,
       getReconnectAttempt,
       getLastConnectedAt,
+      getActivePath,
       subscribeHostState,
       getAllClients,
       subscribeAllHosts,
@@ -376,7 +384,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>
 }
 
-function useCtx(): ContextValue {
+export function useRpcClientContext(): RpcClientContextValue {
   const ctx = useContext(Ctx)
   if (!ctx) {
     throw new Error('useHostClient must be used inside <RpcClientProvider>')
@@ -391,7 +399,7 @@ export function useHostClient(hostId: string | undefined): {
   client: RpcClient | null
   state: ConnectionState
 } {
-  const ctx = useCtx()
+  const ctx = useRpcClientContext()
   const [, force] = useState(0)
   const [state, setState] = useState<ConnectionState>(() =>
     hostId ? ctx.getState(hostId) : 'disconnected'
@@ -449,8 +457,9 @@ export function useAllHostClients(hostIds: string[]): Array<{
   hostId: string
   client: RpcClient
   state: ConnectionState
+  path: MobileConnectionPath
 }> {
-  const ctx = useCtx()
+  const ctx = useRpcClientContext()
   // Stable key so we don't tear down on every render of the array.
   const key = useMemo(() => [...hostIds].sort().join(','), [hostIds])
   const [tick, setTick] = useState(0)
@@ -479,11 +488,21 @@ export function useAllHostClients(hostIds: string[]): Array<{
   }, [key])
 
   return useMemo(() => {
-    const out: Array<{ hostId: string; client: RpcClient; state: ConnectionState }> = []
+    const out: Array<{
+      hostId: string
+      client: RpcClient
+      state: ConnectionState
+      path: MobileConnectionPath
+    }> = []
     for (const id of hostIds) {
       const all = ctx.getAllClients().find((entry) => entry.hostId === id)
       if (all) {
-        out.push({ hostId: id, client: all.client, state: ctx.getState(id) })
+        out.push({
+          hostId: id,
+          client: all.client,
+          state: ctx.getState(id),
+          path: ctx.getActivePath(id)
+        })
       }
     }
     return out
@@ -495,13 +514,13 @@ export function useAllHostClients(hostIds: string[]): Array<{
 // host-store has no React-side handle. Expose a hook that lets callers
 // close a host after removal.
 export function useCloseHost(): (hostId: string) => void {
-  const ctx = useCtx()
+  const ctx = useRpcClientContext()
   return ctx.closeHost
 }
 
 // Why: future-proof "Connection issues — try again" affordance.
 export function useForceReconnect(): (hostId: string) => Promise<void> {
-  const ctx = useCtx()
+  const ctx = useRpcClientContext()
   return ctx.forceReconnect
 }
 
@@ -509,41 +528,11 @@ export function useForceReconnect(): (hostId: string) => Promise<void> {
 // provider can skip its own loadHosts() pass when it eventually opens
 // each host — collapses two serial Keychain reads on cold-start into one.
 export function usePrimeHosts(): (hosts: HostProfile[]) => void {
-  const ctx = useCtx()
+  const ctx = useRpcClientContext()
   return ctx.primeHosts
 }
 
-// Why: lets the home/host-detail UI escalate "Reconnecting…" to a more
-// alarming "Can't connect" once the rpc-client has cycled enough times to
-// indicate something's actually wrong (wrong port, server down, network
-// loss). Reads through the context so it stays in sync with the live
-// rpc-client instance even after forceReconnect swaps the underlying
-// client.
-export function useReconnectAttempt(hostId: string | undefined): number {
-  const ctx = useCtx()
-  const [, force] = useState(0)
-  useEffect(() => {
-    if (!hostId) {
-      return
-    }
-    return ctx.subscribeHostState(hostId, () => force((n) => n + 1))
-  }, [ctx, hostId])
-  return hostId ? ctx.getReconnectAttempt(hostId) : 0
-}
-
-// Why: timestamp of last successful connect for this host, or null if
-// the client has never connected. Combined with reconnectAttempt this
-// distinguishes "transient blip" (recently connected) from "host
-// appears unreachable" (never connected, or hasn't connected in N
-// seconds despite many retry attempts).
-export function useLastConnectedAt(hostId: string | undefined): number | null {
-  const ctx = useCtx()
-  const [, force] = useState(0)
-  useEffect(() => {
-    if (!hostId) {
-      return
-    }
-    return ctx.subscribeHostState(hostId, () => force((n) => n + 1))
-  }, [ctx, hostId])
-  return hostId ? ctx.getLastConnectedAt(hostId) : null
+function clientActivePath(client: RpcClient | undefined): MobileConnectionPath {
+  const logical = client as Partial<StableLogicalRpcClient> | undefined
+  return typeof logical?.getActivePath === 'function' ? logical.getActivePath() : 'lan'
 }

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -19,11 +19,12 @@ import {
   useState,
   type ReactNode
 } from 'react'
-import { connect, type RpcClient } from './rpc-client'
+import type { RpcClient } from './rpc-client'
 import { connectionLogStore } from './connection-log-buffer'
 import { subscribeConnectionRevivalTriggers } from './connection-revival-triggers'
 import { HostClientOpenRegistry } from './host-client-open-registry'
 import { loadHosts } from './host-store'
+import { openHostLogicalClient } from './host-logical-client'
 import type { ConnectionState, HostProfile } from './types'
 
 type StoreEntry = {
@@ -155,12 +156,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
 
       let client: RpcClient
       try {
-        client = connect(host.endpoint, host.deviceToken, host.publicKeyB64, {
-          // Why: retain reconnect lifecycle events for the Connection Log
-          // screen — without this the reasons a host is stuck live only in
-          // console.log, which users can't see or share.
-          onLog: (entry) => connectionLogStore.append(hostId, entry)
-        })
+        client = openHostLogicalClient(host, (entry) => connectionLogStore.append(hostId, entry))
       } catch {
         // Why: connect() can throw synchronously if the public key is
         // malformed or the endpoint URL is invalid. Notify so the UI

--- a/mobile/src/transport/host-logical-client.ts
+++ b/mobile/src/transport/host-logical-client.ts
@@ -1,12 +1,64 @@
+import * as ExpoCrypto from 'expo-crypto'
+import { AppState, Platform } from 'react-native'
 import { connect, type RpcClient } from './rpc-client'
 import { createStableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ConnectionLogSink, HostProfile } from './types'
+import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
+import { directPathForEndpoint } from './mobile-endpoint-supervisor-support'
+import { connectMobileRelayRpcSession } from './mobile-relay-rpc-session'
+import { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
+import {
+  readMobileRelayCredentialBundle,
+  writeMobileRelayCredentialBundle
+} from './mobile-relay-credential-bundle'
+import { saveHost } from './host-store'
 
 export function openHostLogicalClient(host: HostProfile, onLog: ConnectionLogSink): RpcClient {
   // Why: the stable facade owns app-visible RPC/subscription state while the
   // direct socket remains a replaceable first physical generation.
-  return createStableLogicalRpcClient(
+  const logical = createStableLogicalRpcClient(
     connect(host.endpoint, host.deviceToken, host.publicKeyB64, { onLog }),
-    'direct'
+    directPathForEndpoint(host, host.endpoint)
   )
+  if (Platform.OS === 'web' || !host.relay) {
+    return logical
+  }
+
+  const supervisor = new MobileEndpointSupervisor(logical, host, {
+    openDirect: (endpoint) => connect(endpoint, host.deviceToken, host.publicKeyB64, { onLog }),
+    openRelay: (relay, credential, confirmReqId) =>
+      connectMobileRelayRpcSession({
+        relay,
+        resumeToken: credential.token,
+        resumeCredentialVersion: credential.version,
+        resumeConfirmReqId: confirmReqId,
+        deviceToken: host.deviceToken,
+        desktopPublicKeyB64: host.publicKeyB64
+      }),
+    resolveRelay: resolveMobileRelayEndpoint,
+    readBundle: readMobileRelayCredentialBundle,
+    writeBundle: writeMobileRelayCredentialBundle,
+    saveHost,
+    now: Date.now,
+    randomBytes: ExpoCrypto.getRandomBytes,
+    setTimer: setTimeout,
+    clearTimer: clearTimeout
+  })
+  supervisor.setForeground(AppState.currentState === 'active')
+  const appStateSubscription = AppState.addEventListener('change', (state) => {
+    supervisor.setForeground(state === 'active')
+  })
+  const closeLogical = logical.close
+  logical.close = () => {
+    appStateSubscription.remove()
+    supervisor.stop()
+    closeLogical()
+  }
+  const notifyLogicalForeground = logical.notifyForeground
+  logical.notifyForeground = () => {
+    supervisor.setForeground(true)
+    notifyLogicalForeground()
+  }
+  void supervisor.start()
+  return logical
 }

--- a/mobile/src/transport/host-logical-client.ts
+++ b/mobile/src/transport/host-logical-client.ts
@@ -1,0 +1,12 @@
+import { connect, type RpcClient } from './rpc-client'
+import { createStableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { ConnectionLogSink, HostProfile } from './types'
+
+export function openHostLogicalClient(host: HostProfile, onLog: ConnectionLogSink): RpcClient {
+  // Why: the stable facade owns app-visible RPC/subscription state while the
+  // direct socket remains a replaceable first physical generation.
+  return createStableLogicalRpcClient(
+    connect(host.endpoint, host.deviceToken, host.publicKeyB64, { onLog }),
+    'direct'
+  )
+}

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -13,11 +13,12 @@ import {
   scheduleHostCredentialCleanup
 } from './host-credential-cleanup'
 import {
-  loadMobileRelayHostOverlays,
+  loadMobileRelayHostOverlayState,
   removeMobileRelayHostOverlay,
   saveMobileRelayHostOverlay
 } from './mobile-relay-host-overlay-store'
 import { deleteMobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { scheduleOrphanedMobileRelayCleanup } from './mobile-relay-orphan-cleanup'
 
 const STORAGE_KEY = 'orca:hosts'
 // Why: SecureStore keys must match [A-Za-z0-9._-]; colons are rejected.
@@ -131,7 +132,14 @@ async function doLoadHosts(): Promise<HostProfile[]> {
   if (!storedHosts) {
     return []
   }
-  const overlays = await loadMobileRelayHostOverlays(new Set(storedHosts.map(({ id }) => id)))
+  const overlayState = await loadMobileRelayHostOverlayState(
+    new Set(storedHosts.map(({ id }) => id))
+  )
+  await scheduleOrphanedMobileRelayCleanup({
+    hostIds: overlayState.orphanHostIds,
+    deleteCredential: deleteHostCredentials
+  })
+  const overlays = overlayState.overlays
 
   const out: HostProfile[] = []
   for (const stored of storedHosts) {

--- a/mobile/src/transport/mobile-connection-path-label.test.ts
+++ b/mobile/src/transport/mobile-connection-path-label.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { mobileConnectionPathLabel } from './mobile-connection-path-label'
+
+describe('mobile connection path label', () => {
+  it('distinguishes LAN, Tailscale, and the relay without exposing transport errors', () => {
+    expect(mobileConnectionPathLabel('lan')).toBe('Direct · LAN')
+    expect(mobileConnectionPathLabel('tailscale')).toBe('Direct · Tailscale')
+    expect(mobileConnectionPathLabel('relay')).toBe('Via Orca Relay')
+  })
+})

--- a/mobile/src/transport/mobile-connection-path-label.ts
+++ b/mobile/src/transport/mobile-connection-path-label.ts
@@ -1,0 +1,8 @@
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
+
+export function mobileConnectionPathLabel(path: MobileConnectionPath): string {
+  if (path === 'relay') {
+    return 'Via Orca Relay'
+  }
+  return path === 'tailscale' ? 'Direct · Tailscale' : 'Direct · LAN'
+}

--- a/mobile/src/transport/mobile-e2ee-v2-physical-channel.test.ts
+++ b/mobile/src/transport/mobile-e2ee-v2-physical-channel.test.ts
@@ -18,6 +18,7 @@ import { deriveSharedKey } from './e2ee'
 import { MobileE2EEV2ClientSession } from './mobile-e2ee-v2-client-session'
 import { deriveMobileE2EEV2KeySchedule } from './mobile-e2ee-v2-key-schedule'
 import {
+  MobileE2EEAuthenticationError,
   MobileE2EEV2PhysicalChannel,
   type MobileE2EEV2Socket
 } from './mobile-e2ee-v2-physical-channel'
@@ -119,6 +120,24 @@ describe('mobile E2EE v2 physical channel', () => {
     expect(typeof ctx.sent[1]).toBe('string')
     expect(ctx.onAuthenticated).toHaveBeenCalledOnce()
     expect(ctx.onError).not.toHaveBeenCalled()
+  })
+
+  it('classifies the encrypted desktop device-token rejection as global auth failure', async () => {
+    const ctx = setup(async () => null)
+    await ctx.channel.handleMessage(JSON.stringify(ctx.ready))
+    const rejection = serverFrame(
+      new TextEncoder().encode(
+        JSON.stringify({ type: 'e2ee_error', error: { code: 'unauthorized' } })
+      ),
+      'text',
+      0n,
+      ctx.schedule
+    )
+
+    await ctx.channel.handleMessage(Buffer.from(rejection).toString('base64'))
+
+    expect(ctx.onError.mock.calls[0]![0]).toBeInstanceOf(MobileE2EEAuthenticationError)
+    expect(ctx.onAuthenticated).not.toHaveBeenCalled()
   })
 
   it('serializes delayed binary conversion before a later text counter', async () => {

--- a/mobile/src/transport/mobile-e2ee-v2-physical-channel.ts
+++ b/mobile/src/transport/mobile-e2ee-v2-physical-channel.ts
@@ -7,6 +7,12 @@ import type { MobileE2EEV2ClientSession } from './mobile-e2ee-v2-client-session'
 type ChannelState = 'awaiting-ready' | 'awaiting-authenticated' | 'ready'
 type OutboundItem = { kind: 'text'; plaintext: string } | { kind: 'binary'; plaintext: Uint8Array }
 
+export class MobileE2EEAuthenticationError extends Error {
+  constructor() {
+    super('E2EE device authentication rejected')
+  }
+}
+
 export type MobileE2EEV2Socket = {
   readonly OPEN: number
   readonly readyState: number
@@ -98,6 +104,9 @@ export class MobileE2EEV2PhysicalChannel {
       return
     }
     if (this.state === 'awaiting-authenticated') {
+      if (typeof plaintext === 'string' && isAuthenticationRejection(plaintext)) {
+        throw new MobileE2EEAuthenticationError()
+      }
       if (typeof plaintext !== 'string' || !this.isAuthenticated(plaintext)) {
         throw new Error('Invalid E2EE v2 authenticated response')
       }
@@ -163,5 +172,14 @@ export class MobileE2EEV2PhysicalChannel {
     }
     this.outboundQueue.enqueue(item)
     return true
+  }
+}
+
+function isAuthenticationRejection(plaintext: string): boolean {
+  try {
+    const message = JSON.parse(plaintext) as Record<string, unknown>
+    return message.type === 'e2ee_error'
+  } catch {
+    return false
   }
 }

--- a/mobile/src/transport/mobile-endpoint-hysteresis.test.ts
+++ b/mobile/src/transport/mobile-endpoint-hysteresis.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
+
+const options = {
+  directSuccessesRequired: 3,
+  directObservationMs: 30_000,
+  failureCooldownMs: 60_000,
+  minimumDwellMs: 60_000
+}
+
+describe('mobile endpoint hysteresis', () => {
+  it('requires three authenticated direct successes across the observation and dwell windows', () => {
+    const policy = new MobileEndpointHysteresis(0, options)
+
+    expect(policy.recordDirectSuccess(60_000)).toBe(false)
+    expect(policy.recordDirectSuccess(75_000)).toBe(false)
+    expect(policy.recordDirectSuccess(90_000)).toBe(true)
+  })
+
+  it('resets progress and observes cooldown after a failure', () => {
+    const policy = new MobileEndpointHysteresis(0, options)
+    policy.recordDirectSuccess(60_000)
+    policy.recordDirectFailure(61_000)
+
+    expect(policy.canProbe(120_999)).toBe(false)
+    expect(policy.canProbe(121_000)).toBe(true)
+    expect(policy.recordDirectSuccess(121_000)).toBe(false)
+    expect(policy.recordDirectSuccess(136_000)).toBe(false)
+    expect(policy.recordDirectSuccess(151_000)).toBe(true)
+  })
+})

--- a/mobile/src/transport/mobile-endpoint-hysteresis.ts
+++ b/mobile/src/transport/mobile-endpoint-hysteresis.ts
@@ -1,0 +1,52 @@
+export type EndpointHysteresisOptions = {
+  directSuccessesRequired: number
+  directObservationMs: number
+  failureCooldownMs: number
+  minimumDwellMs: number
+}
+
+export class MobileEndpointHysteresis {
+  private consecutiveDirectSuccesses = 0
+  private directObservationStartedAt: number | null = null
+  private cooldownUntil = 0
+  private lastMigrationAt: number
+
+  constructor(
+    startedAt: number,
+    private readonly options: EndpointHysteresisOptions
+  ) {
+    this.lastMigrationAt = startedAt
+  }
+
+  recordDirectSuccess(now: number): boolean {
+    if (now < this.cooldownUntil) {
+      return false
+    }
+    if (this.consecutiveDirectSuccesses === 0) {
+      this.directObservationStartedAt = now
+    }
+    this.consecutiveDirectSuccesses += 1
+    return (
+      this.consecutiveDirectSuccesses >= this.options.directSuccessesRequired &&
+      this.directObservationStartedAt !== null &&
+      now - this.directObservationStartedAt >= this.options.directObservationMs &&
+      now - this.lastMigrationAt >= this.options.minimumDwellMs
+    )
+  }
+
+  recordDirectFailure(now: number): void {
+    this.consecutiveDirectSuccesses = 0
+    this.directObservationStartedAt = null
+    this.cooldownUntil = now + this.options.failureCooldownMs
+  }
+
+  recordMigration(now: number): void {
+    this.lastMigrationAt = now
+    this.consecutiveDirectSuccesses = 0
+    this.directObservationStartedAt = null
+  }
+
+  canProbe(now: number): boolean {
+    return now >= this.cooldownUntil
+  }
+}

--- a/mobile/src/transport/mobile-endpoint-supervisor-support.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-support.ts
@@ -1,0 +1,97 @@
+import { RelayOuterError } from './mobile-relay-e2ee-link'
+import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
+import type { RpcClient } from './rpc-client'
+import type { HostProfile } from './types'
+import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+import type { MobileConnectionPath } from './stable-logical-rpc-client'
+
+export function directEndpointUrls(host: HostProfile): string[] {
+  const endpoints =
+    host.endpoints?.filter(({ kind }) => kind !== 'relay').map(({ url }) => url) ?? []
+  return [...new Set([host.endpoint, ...endpoints])]
+}
+
+export function directPathForEndpoint(
+  host: HostProfile,
+  endpoint: string
+): Exclude<MobileConnectionPath, 'relay'> {
+  const configured = host.endpoints?.find((candidate) => candidate.url === endpoint)
+  if (configured?.kind === 'tailscale') {
+    return 'tailscale'
+  }
+  try {
+    const hostname = new URL(endpoint).hostname
+    if (hostname.endsWith('.ts.net') || /^100\.(?:\d{1,3}\.){2}\d{1,3}$/.test(hostname)) {
+      return 'tailscale'
+    }
+  } catch {}
+  return 'lan'
+}
+
+export function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Promise<void> {
+  if (session.getState() === 'connected') {
+    return Promise.resolve()
+  }
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const unsubscribe = session.onStateChange((state) => {
+      if (state === 'connected') {
+        finish()
+        resolve()
+      } else if (state === 'disconnected' || state === 'auth-failed') {
+        finish()
+        reject(new Error(`probe session ${state}`))
+      }
+    })
+    timer = setTimeout(() => {
+      finish()
+      reject(new Error('probe session authentication timed out'))
+    }, timeoutMs)
+    function finish(): void {
+      if (timer) {
+        clearTimeout(timer)
+      }
+      unsubscribe()
+    }
+  })
+}
+
+export function isDirectorResolutionFailure(error: Error): boolean {
+  return (
+    !(error instanceof MobileE2EEAuthenticationError) &&
+    (!(error instanceof RelayOuterError) || [4409, 4503, 1006].includes(error.code))
+  )
+}
+
+export function relayWebSocketUrl(relay: { cellUrl: string; relayHostId: string }): string {
+  const url = new URL(relay.cellUrl)
+  url.protocol = 'wss:'
+  url.pathname = `/v1/connect/${encodeURIComponent(relay.relayHostId)}`
+  return url.toString()
+}
+
+export async function persistRelayHost(
+  host: HostProfile,
+  relay: MobileRelayEndpoint,
+  saveHost: (host: HostProfile) => Promise<void>
+): Promise<HostProfile> {
+  const endpoints = [
+    ...(host.endpoints ?? [{ id: 'direct-primary', kind: 'lan' as const, url: host.endpoint }])
+  ].filter(({ kind }) => kind !== 'relay')
+  endpoints.push({ id: 'relay-primary', kind: 'relay', url: relayWebSocketUrl(relay) })
+  const updated = { ...host, endpoints, relayHostId: relay.relayHostId, relay }
+  await saveHost(updated)
+  return updated
+}
+
+export function encodeBase64Url(value: Uint8Array): string {
+  let binary = ''
+  for (const byte of value) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
+import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
+import {
+  MobileEndpointSupervisor,
+  type MobileEndpointSupervisorDependencies
+} from './mobile-endpoint-supervisor'
+import type { RpcClient } from './rpc-client'
+import type { MobileConnectionPath, StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { ConnectionState, HostProfile, RpcResponse } from './types'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+
+class FakeSession implements RpcClient {
+  readonly sendRequest = vi.fn(
+    async (): Promise<RpcResponse> => ({
+      id: 'rpc-1',
+      ok: true,
+      result: {},
+      _meta: { runtimeId: 'runtime-1' }
+    })
+  )
+  readonly subscribe = vi.fn(() => () => {})
+  readonly updateTerminalSubscriptionViewport = vi.fn()
+  readonly notifyForeground = vi.fn()
+  readonly close = vi.fn()
+  private readonly listeners = new Set<(state: ConnectionState) => void>()
+
+  constructor(private state: ConnectionState) {}
+
+  getState = () => this.state
+  getReconnectAttempt = () => 0
+  getLastConnectedAt = () => null
+  onStateChange = (listener: (state: ConnectionState) => void) => {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+}
+
+class FakeRelaySession extends FakeSession implements MobileRelayRpcSession {
+  constructor(
+    state: ConnectionState,
+    private readonly failure: Error | null = null,
+    private readonly lease = Date.now() + 120_000
+  ) {
+    super(state)
+  }
+  getLeaseExpiresAt = () => this.lease
+  getResumeConfirmation = () => ({
+    v: 1 as const,
+    reqId: 'confirm-1',
+    currentVersion: 2,
+    acceptedAs: 'current' as const,
+    renewed: true,
+    resumeExpiresAt: Date.now() + 300_000
+  })
+  getFailure = () => this.failure
+}
+
+class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
+  private path: MobileConnectionPath
+  private generation = 1
+
+  constructor(state: ConnectionState, path: MobileConnectionPath) {
+    super(state)
+    this.path = path
+  }
+
+  migrateTo = vi.fn(async (session: RpcClient, path: MobileConnectionPath) => {
+    if (session.getState() !== 'connected') {
+      session.close()
+      throw new Error(`replacement session ${session.getState()}`)
+    }
+    this.path = path
+    this.generation += 1
+  })
+  getActivePath = () => this.path
+  getGeneration = () => this.generation
+}
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  e2eeFraming: 2 as const
+}
+const host: HostProfile = {
+  id: 'host-1',
+  name: 'Blue Whale',
+  endpoint: 'ws://192.168.1.10:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'A'.repeat(44),
+  lastConnected: 1,
+  endpoints: [
+    { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.10:6768' },
+    { id: 'relay-primary', kind: 'relay', url: 'wss://relay-c1.onorca.dev/v1/connect/id' }
+  ],
+  relayHostId: relay.relayHostId,
+  relay
+}
+const bundle: MobileRelayCredentialBundle = {
+  v: 1,
+  hostId: host.id,
+  deviceToken: host.deviceToken,
+  current: {
+    token: 'A'.repeat(43),
+    hash: 'B'.repeat(43),
+    version: 2,
+    expiresAt: Number.MAX_SAFE_INTEGER
+  }
+}
+
+function dependencies(
+  overrides: Partial<MobileEndpointSupervisorDependencies> = {}
+): MobileEndpointSupervisorDependencies {
+  return {
+    openDirect: vi.fn(() => new FakeSession('connected')),
+    openRelay: vi.fn(() => new FakeRelaySession('connected')),
+    resolveRelay: vi.fn(async ({ relay }) => relay),
+    readBundle: vi.fn(async () => bundle),
+    writeBundle: vi.fn(async () => {}),
+    saveHost: vi.fn(async () => {}),
+    now: Date.now,
+    randomBytes: (length) => new Uint8Array(length).fill(1),
+    setTimer: setTimeout,
+    clearTimer: clearTimeout,
+    ...overrides
+  }
+}
+
+describe('mobile endpoint supervisor', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-13T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fails over to a confirmed relay session and persists its renewed expiry', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const deps = dependencies()
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(logical.migrateTo).toHaveBeenCalledWith(expect.any(FakeRelaySession), 'relay')
+    expect(logical.getActivePath()).toBe('relay')
+    expect(deps.writeBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ current: expect.objectContaining({ version: 2 }) })
+    )
+    supervisor.stop()
+  })
+
+  it('uses POST resolve for wrong-cell recovery and persists the authoritative target', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4409)))
+      .mockReturnValueOnce(new FakeRelaySession('connected'))
+    const resolved = { ...relay, cellUrl: 'https://relay-c2.onorca.dev', assignmentEpoch: 8 }
+    const deps = dependencies({
+      openRelay,
+      resolveRelay: vi.fn(async () => resolved)
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(deps.resolveRelay).toHaveBeenCalledOnce()
+    expect(openRelay).toHaveBeenLastCalledWith(resolved, expect.any(Object), expect.any(String))
+    expect(deps.saveHost).toHaveBeenCalledWith(
+      expect.objectContaining({ relay: resolved, endpoint: host.endpoint })
+    )
+    supervisor.stop()
+  })
+
+  it('promotes direct only after repeated foreground authenticated probes and dwell', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const deps = dependencies()
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+
+    await vi.advanceTimersByTimeAsync(45_000)
+    expect(logical.getActivePath()).toBe('relay')
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(logical.getActivePath()).toBe('lan')
+    expect(deps.openDirect).toHaveBeenCalledTimes(4)
+    supervisor.stop()
+  })
+})

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -1,0 +1,316 @@
+import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
+import {
+  directEndpointUrls,
+  directPathForEndpoint,
+  encodeBase64Url,
+  isDirectorResolutionFailure,
+  persistRelayHost,
+  toError,
+  waitForAuthenticatedSession
+} from './mobile-endpoint-supervisor-support'
+import {
+  applyResumeConfirmation,
+  rotateMobileRelayCredential
+} from './mobile-relay-credential-rotation'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
+import { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
+import type { RpcClient } from './rpc-client'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { HostProfile } from './types'
+
+const DIRECT_PROBE_INTERVAL_MS = 15_000
+const DIRECT_OBSERVATION_MS = 30_000
+const MINIMUM_DWELL_MS = 60_000
+const FAILURE_COOLDOWN_MS = 60_000
+const LEASE_ROTATION_MARGIN_MS = 30_000
+const CREDENTIAL_ROTATION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
+
+export type MobileEndpointSupervisorDependencies = {
+  openDirect: (endpoint: string) => RpcClient
+  openRelay: (
+    relay: MobileRelayEndpoint,
+    credential: { token: string; version: number },
+    confirmReqId: string
+  ) => MobileRelayRpcSession
+  resolveRelay: typeof resolveMobileRelayEndpoint
+  readBundle: (hostId: string) => Promise<MobileRelayCredentialBundle | null>
+  writeBundle: (bundle: MobileRelayCredentialBundle) => Promise<void>
+  saveHost: (host: HostProfile) => Promise<void>
+  now: () => number
+  randomBytes: (length: number) => Uint8Array
+  setTimer: typeof setTimeout
+  clearTimer: typeof clearTimeout
+}
+
+export class MobileEndpointSupervisor {
+  private host: HostProfile
+  private bundle: MobileRelayCredentialBundle | null = null
+  private stopped = false
+  private foreground = true
+  private operationInFlight = false
+  private credentialRotationInFlight = false
+  private relayRotationPending = false
+  private probeTimer: ReturnType<typeof setTimeout> | null = null
+  private leaseTimer: ReturnType<typeof setTimeout> | null = null
+  private unsubscribeState: (() => void) | null = null
+  private readonly hysteresis: MobileEndpointHysteresis
+
+  constructor(
+    private readonly logical: StableLogicalRpcClient,
+    host: HostProfile,
+    private readonly dependencies: MobileEndpointSupervisorDependencies
+  ) {
+    this.host = host
+    this.hysteresis = new MobileEndpointHysteresis(dependencies.now(), {
+      directSuccessesRequired: 3,
+      directObservationMs: DIRECT_OBSERVATION_MS,
+      failureCooldownMs: FAILURE_COOLDOWN_MS,
+      minimumDwellMs: MINIMUM_DWELL_MS
+    })
+  }
+
+  async start(): Promise<void> {
+    this.bundle = await this.dependencies.readBundle(this.host.id).catch(() => null)
+    if (this.stopped || !this.bundle || !this.host.relay) {
+      return
+    }
+    this.unsubscribeState = this.logical.onStateChange((state) => {
+      if (state === 'connected') {
+        if (this.logical.getActivePath() !== 'relay') {
+          void this.rotateCredentialIfNeeded()
+        }
+        this.scheduleDirectProbe()
+      } else if (state === 'disconnected' || state === 'auth-failed') {
+        void this.recoverRelay()
+      }
+    })
+    if (this.logical.getState() === 'disconnected') {
+      await this.recoverRelay()
+    } else {
+      this.scheduleDirectProbe()
+    }
+  }
+
+  setForeground(foreground: boolean): void {
+    this.foreground = foreground
+    if (foreground) {
+      void this.recoverRelay(this.relayRotationPending)
+      this.scheduleDirectProbe(0)
+    } else if (this.probeTimer) {
+      this.dependencies.clearTimer(this.probeTimer)
+      this.probeTimer = null
+    }
+  }
+
+  stop(): void {
+    this.stopped = true
+    this.unsubscribeState?.()
+    this.unsubscribeState = null
+    if (this.probeTimer) {
+      this.dependencies.clearTimer(this.probeTimer)
+      this.probeTimer = null
+    }
+    this.clearLeaseTimer()
+  }
+
+  private async recoverRelay(forceReplacement = false): Promise<void> {
+    if (
+      this.stopped ||
+      !this.foreground ||
+      this.operationInFlight ||
+      !this.bundle ||
+      !this.host.relay ||
+      (!forceReplacement && this.logical.getState() === 'connected')
+    ) {
+      return
+    }
+    this.operationInFlight = true
+    try {
+      const credentials = [this.bundle.current, this.bundle.grace].filter(
+        (credential): credential is NonNullable<typeof credential> =>
+          Boolean(credential && credential.expiresAt > this.dependencies.now())
+      )
+      for (const credential of credentials) {
+        if (await this.tryRelayCredential(credential)) {
+          return
+        }
+      }
+    } finally {
+      this.operationInFlight = false
+      if (forceReplacement && this.relayRotationPending && !this.stopped && !this.leaseTimer) {
+        this.leaseTimer = this.dependencies.setTimer(() => {
+          this.leaseTimer = null
+          void this.recoverRelay(true)
+        }, 5000)
+      }
+    }
+  }
+
+  private async tryRelayCredential(credential: {
+    token: string
+    version: number
+  }): Promise<boolean> {
+    const first = await this.openAndMigrateRelay(credential)
+    if (first.ok) {
+      return true
+    }
+    if (!isDirectorResolutionFailure(first.error) || !this.host.relay) {
+      return false
+    }
+    try {
+      const resolved = await this.dependencies.resolveRelay({
+        relay: this.host.relay,
+        resumeToken: credential.token
+      })
+      this.host = await persistRelayHost(this.host, resolved, this.dependencies.saveHost)
+      return (await this.openAndMigrateRelay(credential)).ok
+    } catch {
+      return false
+    }
+  }
+
+  private async openAndMigrateRelay(credential: {
+    token: string
+    version: number
+  }): Promise<{ ok: true } | { ok: false; error: Error }> {
+    if (!this.host.relay || !this.bundle) {
+      return { ok: false, error: new Error('relay state missing') }
+    }
+    const session = this.dependencies.openRelay(
+      this.host.relay,
+      credential,
+      `confirm-${encodeBase64Url(this.dependencies.randomBytes(16))}`
+    )
+    try {
+      await this.logical.migrateTo(session, 'relay')
+      this.relayRotationPending = false
+      this.hysteresis.recordMigration(this.dependencies.now())
+      const confirmation = session.getResumeConfirmation()
+      if (confirmation) {
+        this.bundle = applyResumeConfirmation(this.bundle, credential.version, confirmation)
+        await this.dependencies.writeBundle(this.bundle)
+      }
+      this.scheduleLeaseRotation(session)
+      this.scheduleDirectProbe()
+      return { ok: true }
+    } catch (error) {
+      return { ok: false, error: session.getFailure() ?? toError(error) }
+    }
+  }
+
+  private scheduleDirectProbe(delayMs = DIRECT_PROBE_INTERVAL_MS): void {
+    if (
+      this.stopped ||
+      !this.foreground ||
+      this.logical.getActivePath() !== 'relay' ||
+      this.probeTimer
+    ) {
+      return
+    }
+    this.probeTimer = this.dependencies.setTimer(() => {
+      this.probeTimer = null
+      void this.probeDirect()
+    }, delayMs)
+  }
+
+  private async probeDirect(): Promise<void> {
+    if (
+      this.stopped ||
+      !this.foreground ||
+      this.operationInFlight ||
+      !this.hysteresis.canProbe(this.dependencies.now())
+    ) {
+      this.scheduleDirectProbe()
+      return
+    }
+    this.operationInFlight = true
+    let successful: RpcClient | null = null
+    let successfulPath: 'lan' | 'tailscale' = 'lan'
+    try {
+      for (const endpoint of directEndpointUrls(this.host)) {
+        const candidate = this.dependencies.openDirect(endpoint)
+        try {
+          await waitForAuthenticatedSession(candidate, 12_000)
+          successful = candidate
+          successfulPath = directPathForEndpoint(this.host, endpoint)
+          break
+        } catch {
+          candidate.close()
+        }
+      }
+      if (!successful) {
+        this.hysteresis.recordDirectFailure(this.dependencies.now())
+        return
+      }
+      if (!this.hysteresis.recordDirectSuccess(this.dependencies.now())) {
+        successful.close()
+        return
+      }
+      await this.logical.migrateTo(successful, successfulPath)
+      successful = null
+      this.hysteresis.recordMigration(this.dependencies.now())
+      this.clearLeaseTimer()
+      this.relayRotationPending = false
+      await this.rotateCredentialIfNeeded()
+    } finally {
+      successful?.close()
+      this.operationInFlight = false
+      if (this.relayRotationPending) {
+        void this.recoverRelay(true)
+      }
+      this.scheduleDirectProbe()
+    }
+  }
+
+  private async rotateCredentialIfNeeded(): Promise<void> {
+    if (
+      this.stopped ||
+      this.credentialRotationInFlight ||
+      !this.bundle ||
+      this.logical.getActivePath() === 'relay' ||
+      (!this.bundle.pending &&
+        this.bundle.current.expiresAt - this.dependencies.now() > CREDENTIAL_ROTATION_WINDOW_MS)
+    ) {
+      return
+    }
+    this.credentialRotationInFlight = true
+    try {
+      const result = await rotateMobileRelayCredential({
+        client: this.logical,
+        bundle: this.bundle,
+        writeBundle: this.dependencies.writeBundle,
+        randomBytes: this.dependencies.randomBytes
+      })
+      this.bundle = result.bundle
+      this.host = await persistRelayHost(this.host, result.relay, this.dependencies.saveHost)
+    } catch {
+      // Why: pending material remains durable; the next authenticated direct
+      // opportunity must reconcile it before creating another install key.
+    } finally {
+      this.credentialRotationInFlight = false
+    }
+  }
+
+  private scheduleLeaseRotation(session: MobileRelayRpcSession): void {
+    this.clearLeaseTimer()
+    const deadline = session.getLeaseExpiresAt()
+    if (!deadline) {
+      return
+    }
+    const delay = Math.max(1000, deadline - this.dependencies.now() - LEASE_ROTATION_MARGIN_MS)
+    this.leaseTimer = this.dependencies.setTimer(() => {
+      this.leaseTimer = null
+      this.relayRotationPending = true
+      void this.recoverRelay(true)
+    }, delay)
+  }
+
+  private clearLeaseTimer(): void {
+    if (this.leaseTimer) {
+      this.dependencies.clearTimer(this.leaseTimer)
+      this.leaseTimer = null
+    }
+  }
+}

--- a/mobile/src/transport/mobile-relay-credential-rotation.test.ts
+++ b/mobile/src/transport/mobile-relay-credential-rotation.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from './rpc-client'
+import {
+  applyResumeConfirmation,
+  rotateMobileRelayCredential
+} from './mobile-relay-credential-rotation'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { RpcResponse } from './types'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  e2eeFraming: 2 as const
+}
+
+const bundle: MobileRelayCredentialBundle = {
+  v: 1,
+  hostId: 'host-1',
+  deviceToken: 'device-token',
+  current: {
+    token: 'A'.repeat(43),
+    hash: 'B'.repeat(43),
+    version: 2,
+    expiresAt: 50_000
+  }
+}
+
+function success(result: unknown): RpcResponse {
+  return { id: 'rpc-1', ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+}
+
+function install(reqId: string) {
+  return {
+    v: 1 as const,
+    reqId,
+    authorizationMode: 'authenticated-direct' as const,
+    currentVersion: 3,
+    resumeExpiresAt: 100_000,
+    graceExpiresAt: 70_000
+  }
+}
+
+function fakeClient(responses: RpcResponse[]): RpcClient {
+  return {
+    sendRequest: vi.fn(async () => responses.shift()!),
+    subscribe: vi.fn(() => () => {}),
+    updateTerminalSubscriptionViewport: vi.fn(),
+    getState: () => 'connected',
+    getReconnectAttempt: () => 0,
+    getLastConnectedAt: () => 1,
+    onStateChange: () => () => {},
+    notifyForeground: vi.fn(),
+    close: vi.fn()
+  }
+}
+
+describe('mobile relay credential rotation', () => {
+  it('persists pending material before install and promotes only committed status', async () => {
+    const installed = install('rotate-CAgICAgICAgICAgICAgICA')
+    const client = fakeClient([
+      success({ v: 1, relay, installStatus: { v: 1, reqId: installed.reqId, state: 'not-found' } }),
+      success(installed),
+      success({
+        v: 1,
+        relay,
+        installStatus: { v: 1, reqId: installed.reqId, state: 'committed', result: installed }
+      })
+    ])
+    const writes: MobileRelayCredentialBundle[] = []
+
+    const result = await rotateMobileRelayCredential({
+      client,
+      bundle,
+      writeBundle: async (value) => {
+        writes.push(value)
+      },
+      randomBytes: (length) => new Uint8Array(length).fill(length === 32 ? 7 : 8)
+    })
+
+    expect(writes).toHaveLength(2)
+    expect(writes[0]!.pending).toMatchObject({ reqId: installed.reqId })
+    expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'pairing.provisionRelay', {
+      reqId: installed.reqId,
+      newResumeTokenHash: writes[0]!.pending!.hash,
+      expectedCurrentHash: bundle.current.hash
+    })
+    expect(result.bundle).toMatchObject({
+      current: { version: 3, expiresAt: 100_000 },
+      grace: { version: 2, expiresAt: 70_000 }
+    })
+    expect(result.bundle.pending).toBeUndefined()
+  })
+
+  it('reconciles a committed lost response without issuing a second install', async () => {
+    const pendingBundle: MobileRelayCredentialBundle = {
+      ...bundle,
+      pending: { token: 'C'.repeat(43), hash: 'D'.repeat(43), reqId: 'rotate-existing' }
+    }
+    const installed = install('rotate-existing')
+    const client = fakeClient([
+      success({
+        v: 1,
+        relay,
+        installStatus: { v: 1, reqId: installed.reqId, state: 'committed', result: installed }
+      })
+    ])
+    const writeBundle = vi.fn(async () => {})
+
+    await rotateMobileRelayCredential({ client, bundle: pendingBundle, writeBundle })
+
+    expect(client.sendRequest).toHaveBeenCalledOnce()
+    expect(client.sendRequest).toHaveBeenCalledWith('pairing.getEndpoints', {
+      installReqId: 'rotate-existing'
+    })
+    expect(writeBundle).toHaveBeenCalledOnce()
+  })
+
+  it('applies only authoritative current or grace confirmation expiries', () => {
+    const withGrace: MobileRelayCredentialBundle = {
+      ...bundle,
+      grace: { token: 'C'.repeat(43), hash: 'D'.repeat(43), version: 1, expiresAt: 40_000 }
+    }
+    const renewed = applyResumeConfirmation(withGrace, 2, {
+      v: 1,
+      reqId: 'confirm-current',
+      currentVersion: 2,
+      acceptedAs: 'current',
+      renewed: true,
+      resumeExpiresAt: 120_000,
+      graceExpiresAt: 40_000
+    })
+    const grace = applyResumeConfirmation(renewed, 1, {
+      v: 1,
+      reqId: 'confirm-grace',
+      currentVersion: 2,
+      acceptedAs: 'grace',
+      renewed: false,
+      resumeExpiresAt: 120_000,
+      graceExpiresAt: 45_000
+    })
+
+    expect(renewed.current.expiresAt).toBe(120_000)
+    expect(grace.grace?.expiresAt).toBe(45_000)
+    expect(applyResumeConfirmation(grace, 99, { ...graceConfirmation(), reqId: 'other' })).toBe(
+      grace
+    )
+  })
+})
+
+function graceConfirmation() {
+  return {
+    v: 1 as const,
+    reqId: 'confirm',
+    currentVersion: 2,
+    acceptedAs: 'grace' as const,
+    renewed: false,
+    resumeExpiresAt: 120_000,
+    graceExpiresAt: 45_000
+  }
+}

--- a/mobile/src/transport/mobile-relay-credential-rotation.ts
+++ b/mobile/src/transport/mobile-relay-credential-rotation.ts
@@ -1,0 +1,136 @@
+import * as ExpoCrypto from 'expo-crypto'
+import { sha256 } from '@noble/hashes/sha256'
+import {
+  DeviceCredentialInstalledSchema,
+  PairingGetEndpointsResultSchema,
+  type DeviceResumeConfirmed,
+  type MobileRelayEndpoint
+} from '../../../src/shared/mobile-relay-credential-contract'
+import {
+  MobileRelayCredentialBundleSchema,
+  type MobileRelayCredentialBundle
+} from './mobile-relay-credential-bundle'
+import type { RpcClient } from './rpc-client'
+
+type RotationResult = {
+  bundle: MobileRelayCredentialBundle
+  relay: MobileRelayEndpoint
+}
+
+export async function rotateMobileRelayCredential(args: {
+  client: RpcClient
+  bundle: MobileRelayCredentialBundle
+  writeBundle: (bundle: MobileRelayCredentialBundle) => Promise<void>
+  randomBytes?: (length: number) => Uint8Array
+}): Promise<RotationResult> {
+  let bundle = args.bundle
+  if (!bundle.pending) {
+    const randomBytes = args.randomBytes ?? ExpoCrypto.getRandomBytes
+    const token = encodeBase64Url(randomBytes(32))
+    bundle = MobileRelayCredentialBundleSchema.parse({
+      ...bundle,
+      pending: {
+        token,
+        hash: encodeBase64Url(sha256(decodeBase64Url(token))),
+        reqId: `rotate-${encodeBase64Url(randomBytes(16))}`
+      }
+    })
+    // Why: a crash or lost response must leave enough material to query the
+    // one global install key before any second authorization attempt.
+    await args.writeBundle(bundle)
+  }
+
+  const pending = bundle.pending
+  if (!pending) {
+    throw new Error('relay credential rotation pending state missing')
+  }
+  let endpoints = await getEndpoints(args.client, pending.reqId)
+  if (endpoints.installStatus?.state !== 'committed') {
+    const response = await args.client.sendRequest('pairing.provisionRelay', {
+      reqId: pending.reqId,
+      newResumeTokenHash: pending.hash,
+      expectedCurrentHash: bundle.current.hash
+    })
+    if (!response.ok) {
+      throw new Error(`${response.error.code}: ${response.error.message}`)
+    }
+    const installed = DeviceCredentialInstalledSchema.parse(response.result)
+    endpoints = await getEndpoints(args.client, pending.reqId)
+    if (
+      endpoints.installStatus?.state !== 'committed' ||
+      JSON.stringify(endpoints.installStatus.result) !== JSON.stringify(installed)
+    ) {
+      throw new Error('relay credential rotation was not authoritatively committed')
+    }
+  }
+  if (!endpoints.relay || endpoints.installStatus?.state !== 'committed') {
+    throw new Error('relay credential rotation endpoint state missing')
+  }
+  const installed = endpoints.installStatus.result
+  const next = MobileRelayCredentialBundleSchema.parse({
+    ...bundle,
+    current: {
+      token: pending.token,
+      hash: pending.hash,
+      version: installed.currentVersion,
+      expiresAt: installed.resumeExpiresAt
+    },
+    ...(installed.graceExpiresAt
+      ? { grace: { ...bundle.current, expiresAt: installed.graceExpiresAt } }
+      : { grace: undefined }),
+    pending: undefined
+  })
+  await args.writeBundle(next)
+  return { bundle: next, relay: endpoints.relay }
+}
+
+export function applyResumeConfirmation(
+  bundle: MobileRelayCredentialBundle,
+  usedCredentialVersion: number,
+  confirmation: DeviceResumeConfirmed
+): MobileRelayCredentialBundle {
+  if (
+    confirmation.acceptedAs === 'current' &&
+    confirmation.renewed &&
+    bundle.current.version === usedCredentialVersion &&
+    confirmation.currentVersion === usedCredentialVersion
+  ) {
+    return MobileRelayCredentialBundleSchema.parse({
+      ...bundle,
+      current: { ...bundle.current, expiresAt: confirmation.resumeExpiresAt }
+    })
+  }
+  if (
+    confirmation.acceptedAs === 'grace' &&
+    bundle.grace?.version === usedCredentialVersion &&
+    confirmation.graceExpiresAt
+  ) {
+    return MobileRelayCredentialBundleSchema.parse({
+      ...bundle,
+      grace: { ...bundle.grace, expiresAt: confirmation.graceExpiresAt }
+    })
+  }
+  return bundle
+}
+
+async function getEndpoints(client: RpcClient, installReqId: string) {
+  const response = await client.sendRequest('pairing.getEndpoints', { installReqId })
+  if (!response.ok) {
+    throw new Error(`${response.error.code}: ${response.error.message}`)
+  }
+  return PairingGetEndpointsResultSchema.parse(response.result)
+}
+
+function encodeBase64Url(value: Uint8Array): string {
+  let binary = ''
+  for (const byte of value) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = `${base64}${'='.repeat((4 - (base64.length % 4)) % 4)}`
+  return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0))
+}

--- a/mobile/src/transport/mobile-relay-e2ee-link.ts
+++ b/mobile/src/transport/mobile-relay-e2ee-link.ts
@@ -1,0 +1,151 @@
+import {
+  RelayPhoneHelloSchema,
+  type RelayPhoneHello
+} from '../../../src/shared/mobile-relay-phone-protocol'
+import { MobileE2EEV2ClientSession } from './mobile-e2ee-v2-client-session'
+import { MobileE2EEV2PhysicalChannel } from './mobile-e2ee-v2-physical-channel'
+import { websocketPayloadToUint8 } from './websocket-payload-bytes'
+
+export class RelayOuterError extends Error {
+  constructor(readonly code: number) {
+    super(`relay_outer_${code}`)
+  }
+}
+
+type MobileRelayE2eeLinkOptions = {
+  endpoint: { cellUrl: string; relayHostId: string }
+  credential: string
+  expectedCredentialKind: 'invite' | 'resume'
+  deviceToken: string
+  desktopPublicKeyB64: string
+  onAuthenticated: () => void
+  onText: (plaintext: string) => void
+  onBinary: (plaintext: Uint8Array) => void
+  onHello?: (hello: Extract<RelayPhoneHello, { ok: true }>) => void
+  onError: (error: Error) => void
+  createSocket?: (url: string) => WebSocket
+}
+
+export class MobileRelayE2eeLink {
+  private readonly options: MobileRelayE2eeLinkOptions
+  private readonly socket: WebSocket
+  private readonly channel: MobileE2EEV2PhysicalChannel
+  private outerReady = false
+  private closed = false
+  private inboundChain: Promise<void> = Promise.resolve()
+
+  constructor(options: MobileRelayE2eeLinkOptions) {
+    this.options = options
+    this.socket = (options.createSocket ?? ((url) => new WebSocket(url)))(
+      relaySocketUrl(options.endpoint)
+    )
+    const session = MobileE2EEV2ClientSession.create({
+      desktopPublicKeyB64: options.desktopPublicKeyB64,
+      transport: 'relay',
+      relayHostId: options.endpoint.relayHostId
+    })
+    this.channel = new MobileE2EEV2PhysicalChannel({
+      session,
+      socket: this.socket,
+      deviceToken: options.deviceToken,
+      decodeBinary: websocketPayloadToUint8,
+      onAuthenticated: options.onAuthenticated,
+      onText: options.onText,
+      onBinary: options.onBinary,
+      onError: (error) => this.fail(error)
+    })
+    this.bindSocket()
+  }
+
+  sendText(plaintext: string): boolean {
+    return !this.closed && this.channel.sendText(plaintext)
+  }
+
+  sendBinary(plaintext: Uint8Array): boolean {
+    return !this.closed && this.channel.sendBinary(plaintext)
+  }
+
+  close(): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    this.channel.dispose()
+    this.socket.close()
+  }
+
+  private bindSocket(): void {
+    this.socket.onopen = () => {
+      this.socket.send(
+        JSON.stringify({
+          type: 'relay-auth',
+          v: 1,
+          mode: 'connect',
+          credential: this.options.credential
+        })
+      )
+    }
+    this.socket.onmessage = (event) => {
+      this.inboundChain = this.inboundChain
+        .then(async () => {
+          if (this.closed) {
+            return
+          }
+          if (!this.outerReady) {
+            this.acceptHello(event.data)
+          } else {
+            await this.channel.handleMessage(event.data)
+          }
+        })
+        .catch((error: unknown) => this.fail(asError(error)))
+    }
+    this.socket.onerror = () => this.fail(new Error('relay transport error'))
+    this.socket.onclose = (event) => this.fail(new RelayOuterError(event.code || 1006))
+  }
+
+  private acceptHello(raw: unknown): void {
+    if (typeof raw !== 'string') {
+      throw new Error('expected plaintext relay hello')
+    }
+    let value: unknown
+    try {
+      value = JSON.parse(raw)
+    } catch {
+      throw new Error('invalid relay hello JSON')
+    }
+    const parsed = RelayPhoneHelloSchema.safeParse(value)
+    if (!parsed.success) {
+      throw new Error('invalid relay hello')
+    }
+    if (!parsed.data.ok) {
+      throw new RelayOuterError(parsed.data.code)
+    }
+    if (parsed.data.credentialKind !== this.options.expectedCredentialKind) {
+      throw new Error('relay credential resolved as an unexpected credential kind')
+    }
+    this.outerReady = true
+    this.options.onHello?.(parsed.data)
+    this.channel.start()
+  }
+
+  private fail(error: Error): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    this.channel.dispose()
+    this.options.onError(error)
+    this.socket.close()
+  }
+}
+
+function relaySocketUrl(endpoint: { cellUrl: string; relayHostId: string }): string {
+  const url = new URL(endpoint.cellUrl)
+  url.protocol = 'wss:'
+  url.pathname = `/v1/connect/${encodeURIComponent(endpoint.relayHostId)}`
+  return url.toString()
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/mobile/src/transport/mobile-relay-host-overlay-store.ts
+++ b/mobile/src/transport/mobile-relay-host-overlay-store.ts
@@ -49,17 +49,26 @@ async function mutateOverlays(
 export async function loadMobileRelayHostOverlays(
   existingHostIds: ReadonlySet<string>
 ): Promise<Map<string, MobileRelayHostOverlay>> {
+  return (await loadMobileRelayHostOverlayState(existingHostIds)).overlays
+}
+
+export async function loadMobileRelayHostOverlayState(
+  existingHostIds: ReadonlySet<string>
+): Promise<{ overlays: Map<string, MobileRelayHostOverlay>; orphanHostIds: string[] }> {
   await overlayMutation
   const overlays = parseOverlays(await AsyncStorage.getItem(OVERLAY_STORAGE_KEY)) ?? []
   const active = new Map<string, MobileRelayHostOverlay>()
+  const orphanHostIds: string[] = []
   for (const overlay of overlays) {
     // Why: an older app can remove the legacy base without knowing this
     // namespace; never let the retained overlay resurrect that host later.
     if (existingHostIds.has(overlay.hostId)) {
       active.set(overlay.hostId, overlay)
+    } else {
+      orphanHostIds.push(overlay.hostId)
     }
   }
-  return active
+  return { overlays: active, orphanHostIds }
 }
 
 export async function saveMobileRelayHostOverlay(overlay: MobileRelayHostOverlay): Promise<void> {

--- a/mobile/src/transport/mobile-relay-orphan-cleanup.test.ts
+++ b/mobile/src/transport/mobile-relay-orphan-cleanup.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+import { scheduleOrphanedMobileRelayCleanup } from './mobile-relay-orphan-cleanup'
+
+describe('mobile relay orphan cleanup', () => {
+  it('durably schedules credential deletion before removing an orphan overlay pointer', async () => {
+    const order: string[] = []
+    const deleteCredential = vi.fn(async () => {})
+    const scheduleCleanup = vi.fn(async (hostId: string) => {
+      order.push(`schedule:${hostId}`)
+    })
+    const removeOverlay = vi.fn(async (hostId: string) => {
+      order.push(`overlay:${hostId}`)
+    })
+
+    await scheduleOrphanedMobileRelayCleanup({
+      hostIds: ['host-1', 'host-1'],
+      deleteCredential,
+      scheduleCleanup,
+      removeOverlay
+    })
+
+    expect(order).toEqual(['schedule:host-1', 'overlay:host-1'])
+    expect(scheduleCleanup).toHaveBeenCalledWith('host-1', deleteCredential)
+  })
+
+  it('retains the overlay pointer when durable cleanup scheduling fails', async () => {
+    const removeOverlay = vi.fn(async () => {})
+    await scheduleOrphanedMobileRelayCleanup({
+      hostIds: ['host-1'],
+      deleteCredential: vi.fn(async () => {}),
+      scheduleCleanup: vi.fn(async () => {
+        throw new Error('storage unavailable')
+      }),
+      removeOverlay
+    })
+
+    expect(removeOverlay).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/mobile-relay-orphan-cleanup.ts
+++ b/mobile/src/transport/mobile-relay-orphan-cleanup.ts
@@ -1,0 +1,22 @@
+import { scheduleHostCredentialCleanup } from './host-credential-cleanup'
+import { removeMobileRelayHostOverlay } from './mobile-relay-host-overlay-store'
+
+export async function scheduleOrphanedMobileRelayCleanup(args: {
+  hostIds: string[]
+  deleteCredential: (hostId: string) => Promise<void>
+  scheduleCleanup?: typeof scheduleHostCredentialCleanup
+  removeOverlay?: typeof removeMobileRelayHostOverlay
+}): Promise<void> {
+  const scheduleCleanup = args.scheduleCleanup ?? scheduleHostCredentialCleanup
+  const removeOverlay = args.removeOverlay ?? removeMobileRelayHostOverlay
+  for (const hostId of new Set(args.hostIds)) {
+    try {
+      // Why: an older build may remove the legacy host while retaining the v2
+      // namespace; persist keychain cleanup intent before dropping that pointer.
+      await scheduleCleanup(hostId, args.deleteCredential)
+      await removeOverlay(hostId)
+    } catch {
+      // Retain the overlay pointer if durable cleanup intent could not be recorded.
+    }
+  }
+}

--- a/mobile/src/transport/mobile-relay-physical-client.ts
+++ b/mobile/src/transport/mobile-relay-physical-client.ts
@@ -5,6 +5,8 @@ import { MobileE2EEV2PhysicalChannel } from './mobile-e2ee-v2-physical-channel'
 import { isRpcResponse } from './rpc-response-shape'
 import type { RpcResponse } from './types'
 import { websocketPayloadToUint8 } from './websocket-payload-bytes'
+export { RelayOuterError } from './mobile-relay-e2ee-link'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
 
 type PendingRequest = {
   resolve: (response: RpcResponse) => void
@@ -15,12 +17,6 @@ type PendingRequest = {
 export type PairingCandidateClient = {
   sendRequest(method: string, params?: unknown): Promise<RpcResponse>
   close(): void
-}
-
-export class RelayOuterError extends Error {
-  constructor(readonly code: number) {
-    super(`relay_outer_${code}`)
-  }
 }
 
 export function connectMobileRelayForPairing(args: {

--- a/mobile/src/transport/mobile-relay-resume-director.test.ts
+++ b/mobile/src/transport/mobile-relay-resume-director.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-old.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  e2eeFraming: 2 as const
+}
+
+describe('mobile relay resume director', () => {
+  it('uses a bounded POST body and never puts the bearer in the URL', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            v: 1,
+            cellUrl: 'https://relay-c2.onorca.dev',
+            assignmentEpoch: 8,
+            leaseExpiresAt: Date.now() + 60_000
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+    )
+
+    await expect(
+      resolveMobileRelayEndpoint({ relay, resumeToken: 'A'.repeat(43), fetchImpl })
+    ).resolves.toMatchObject({ cellUrl: 'https://relay-c2.onorca.dev', assignmentEpoch: 8 })
+    const [url, init] = fetchImpl.mock.calls[0]!
+    expect(url).toBe('https://relay.onorca.dev/v1/resolve')
+    expect(url).not.toContain('A'.repeat(43))
+    expect(init).toMatchObject({ method: 'POST' })
+    expect(JSON.parse(init!.body as string)).toEqual({
+      v: 1,
+      relayHostId: relay.relayHostId,
+      resumeToken: 'A'.repeat(43)
+    })
+  })
+
+  it('rejects non-canonical targets and oversized bodies', async () => {
+    const badTarget = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            v: 1,
+            cellUrl: 'http://relay-c2.onorca.dev',
+            assignmentEpoch: 8,
+            leaseExpiresAt: 1
+          })
+        )
+    )
+    await expect(
+      resolveMobileRelayEndpoint({ relay, resumeToken: 'A'.repeat(43), fetchImpl: badTarget })
+    ).rejects.toThrow()
+
+    const oversized = vi.fn(
+      async () =>
+        new Response('x'.repeat(16 * 1024 + 1), { headers: { 'content-length': '16385' } })
+    )
+    await expect(
+      resolveMobileRelayEndpoint({ relay, resumeToken: 'A'.repeat(43), fetchImpl: oversized })
+    ).rejects.toThrow(/too large/)
+  })
+})

--- a/mobile/src/transport/mobile-relay-resume-director.ts
+++ b/mobile/src/transport/mobile-relay-resume-director.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod'
+import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+
+const MAX_RESPONSE_BYTES = 16 * 1024
+const ResolveResponseSchema = z
+  .object({
+    v: z.literal(1),
+    cellUrl: z.string().refine(isCanonicalHttpsOrigin),
+    assignmentEpoch: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    leaseExpiresAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
+  })
+  .strict()
+
+export async function resolveMobileRelayEndpoint(args: {
+  relay: MobileRelayEndpoint
+  resumeToken: string
+  fetchImpl?: typeof fetch
+  timeoutMs?: number
+}): Promise<MobileRelayEndpoint> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), args.timeoutMs ?? 5000)
+  try {
+    const url = new URL('/v1/resolve', args.relay.directorUrl)
+    const response = await (args.fetchImpl ?? fetch)(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        v: 1,
+        relayHostId: args.relay.relayHostId,
+        resumeToken: args.resumeToken
+      }),
+      signal: controller.signal
+    })
+    if (!response.ok) {
+      throw new Error(`relay director resolve failed (${response.status})`)
+    }
+    const declaredLength = Number(response.headers.get('content-length') ?? 0)
+    if (declaredLength > MAX_RESPONSE_BYTES) {
+      throw new Error('relay director resolve response too large')
+    }
+    const raw = await response.text()
+    if (new TextEncoder().encode(raw).byteLength > MAX_RESPONSE_BYTES) {
+      throw new Error('relay director resolve response too large')
+    }
+    const resolved = ResolveResponseSchema.parse(JSON.parse(raw) as unknown)
+    return {
+      ...args.relay,
+      cellUrl: resolved.cellUrl,
+      assignmentEpoch: resolved.assignmentEpoch
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function isCanonicalHttpsOrigin(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'https:' && parsed.origin === value
+  } catch {
+    return false
+  }
+}

--- a/mobile/src/transport/mobile-relay-rpc-session.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  BrowserScreencastOpcode,
+  encodeBrowserScreencastFrame
+} from '../../../src/shared/browser-screencast-protocol'
+import { encodeTerminalStreamFrame, TerminalStreamOpcode } from './terminal-stream-protocol'
+
+const fakes = vi.hoisted(() => ({
+  linkOptions: null as null | {
+    endpoint: { cellUrl: string; relayHostId: string }
+    credential: string
+    expectedCredentialKind: string
+    onHello(value: unknown): void
+    onAuthenticated(): void
+    onText(value: string): void
+    onBinary(value: Uint8Array): void
+    onError(error: Error): void
+  },
+  sendText: vi.fn(() => true),
+  close: vi.fn()
+}))
+
+vi.mock('./mobile-relay-e2ee-link', () => ({
+  MobileRelayE2eeLink: class {
+    constructor(options: NonNullable<typeof fakes.linkOptions>) {
+      fakes.linkOptions = options
+    }
+    sendText = fakes.sendText
+    close = fakes.close
+  }
+}))
+
+import { connectMobileRelayRpcSession } from './mobile-relay-rpc-session'
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  e2eeFraming: 2 as const
+}
+
+function openSession() {
+  return connectMobileRelayRpcSession({
+    relay,
+    resumeToken: 'resume-secret',
+    resumeCredentialVersion: 3,
+    resumeConfirmReqId: 'confirm-1',
+    deviceToken: 'device-token',
+    desktopPublicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+    requestTimeoutMs: 1000
+  })
+}
+
+async function authenticateSession() {
+  const session = openSession()
+  fakes.linkOptions!.onHello({
+    type: 'relay-hello',
+    ok: true,
+    credentialKind: 'resume',
+    leaseExpiresAt: Date.now() + 60_000,
+    acceptedCredentialVersion: 3,
+    acceptedAs: 'current',
+    resumeExpiresAt: Date.now() + 300_000
+  })
+  expect(session.getState()).toBe('handshaking')
+  fakes.linkOptions!.onAuthenticated()
+  await vi.waitFor(() => expect(fakes.sendText).toHaveBeenCalledOnce())
+  const request = JSON.parse(fakes.sendText.mock.calls[0]![0] as string) as {
+    id: string
+    method: string
+    params: unknown
+  }
+  fakes.linkOptions!.onText(
+    JSON.stringify({
+      id: request.id,
+      ok: true,
+      result: {
+        v: 1,
+        relay,
+        resumeConfirmation: {
+          v: 1,
+          reqId: 'confirm-1',
+          currentVersion: 3,
+          acceptedAs: 'current',
+          renewed: true,
+          resumeExpiresAt: Date.now() + 300_000
+        }
+      },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+  )
+  await vi.waitFor(() => expect(session.getState()).toBe('connected'))
+  fakes.sendText.mockClear()
+  return { session, confirmationRequest: request }
+}
+
+describe('mobile relay RPC session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fakes.linkOptions = null
+    fakes.sendText.mockReturnValue(true)
+  })
+
+  it('requires exact resume observations and confirms by request ID before becoming connected', async () => {
+    const { session, confirmationRequest } = await authenticateSession()
+
+    expect(fakes.linkOptions).toMatchObject({
+      endpoint: relay,
+      credential: 'resume-secret',
+      expectedCredentialKind: 'resume'
+    })
+    expect(confirmationRequest).toMatchObject({
+      method: 'pairing.getEndpoints',
+      params: { resumeConfirmReqId: 'confirm-1' },
+      deviceToken: 'device-token'
+    })
+    expect(confirmationRequest.params).not.toHaveProperty('relayDeviceId')
+    expect(confirmationRequest.params).not.toHaveProperty('acceptedCredentialVersion')
+    expect(session.getLeaseExpiresAt()).toEqual(expect.any(Number))
+  })
+
+  it('rejects a mismatched outer credential version and closes the physical link', () => {
+    const session = openSession()
+    fakes.linkOptions!.onHello({
+      type: 'relay-hello',
+      ok: true,
+      credentialKind: 'resume',
+      leaseExpiresAt: Date.now() + 60_000,
+      acceptedCredentialVersion: 2,
+      acceptedAs: 'grace',
+      resumeExpiresAt: Date.now() + 300_000
+    })
+
+    expect(session.getState()).toBe('disconnected')
+    expect(fakes.close).toHaveBeenCalledOnce()
+    expect(fakes.sendText).not.toHaveBeenCalled()
+  })
+
+  it('routes terminal and browser binary streams after confirmation', async () => {
+    const { session } = await authenticateSession()
+    const terminalListener = vi.fn()
+    session.subscribe('terminal.subscribe', { terminal: 'term-1' }, terminalListener)
+    await vi.waitFor(() => expect(fakes.sendText).toHaveBeenCalledOnce())
+    const terminalRequest = JSON.parse(fakes.sendText.mock.calls[0]![0] as string) as {
+      id: string
+    }
+    fakes.linkOptions!.onText(
+      JSON.stringify({
+        id: terminalRequest.id,
+        ok: true,
+        result: { streamId: 42 },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    fakes.linkOptions!.onBinary(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.Output,
+        streamId: 42,
+        seq: 1,
+        payload: new TextEncoder().encode('hello')
+      })
+    )
+    expect(terminalListener).toHaveBeenLastCalledWith({
+      type: 'data',
+      streamId: 42,
+      chunk: 'hello'
+    })
+
+    fakes.sendText.mockClear()
+    const onBinaryFrame = vi.fn()
+    session.subscribe('browser.screencast', {}, vi.fn(), { onBinaryFrame })
+    await vi.waitFor(() => expect(fakes.sendText).toHaveBeenCalledOnce())
+    const browserRequest = JSON.parse(fakes.sendText.mock.calls[0]![0] as string) as { id: string }
+    fakes.linkOptions!.onText(
+      JSON.stringify({
+        id: browserRequest.id,
+        ok: true,
+        result: { subscriptionId: 'browser-1' },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    fakes.linkOptions!.onBinary(
+      encodeBrowserScreencastFrame({
+        opcode: BrowserScreencastOpcode.Frame,
+        seq: 9,
+        format: 'jpeg',
+        metadata: { imageWidth: 800 },
+        image: new Uint8Array([1, 2, 3])
+      })
+    )
+    expect(onBinaryFrame).toHaveBeenCalledWith(
+      expect.objectContaining({ seq: 9, format: 'jpeg', image: new Uint8Array([1, 2, 3]) })
+    )
+  })
+
+  it('rejects pending RPC work when the physical link fails', async () => {
+    const { session } = await authenticateSession()
+    const pending = session.sendRequest('status.get')
+    await vi.waitFor(() => expect(fakes.sendText).toHaveBeenCalledOnce())
+    fakes.linkOptions!.onError(new Error('relay transport error'))
+
+    await expect(pending).rejects.toThrow('relay transport error')
+    expect(session.getState()).toBe('disconnected')
+  })
+})

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -1,9 +1,11 @@
 import {
   PairingGetEndpointsResultSchema,
+  type DeviceResumeConfirmed,
   type MobileRelayEndpoint
 } from '../../../src/shared/mobile-relay-credential-contract'
 import { MobileRelayE2eeLink } from './mobile-relay-e2ee-link'
 import { MobileRelayRpcStreams } from './mobile-relay-rpc-streams'
+import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
 import { isRpcResponse } from './rpc-response-shape'
 import type { RpcClient } from './rpc-client'
 import type { ConnectionState, RpcResponse } from './types'
@@ -16,6 +18,8 @@ type PendingRequest = {
 
 export type MobileRelayRpcSession = RpcClient & {
   getLeaseExpiresAt(): number | null
+  getResumeConfirmation(): DeviceResumeConfirmed | null
+  getFailure(): Error | null
 }
 
 export function connectMobileRelayRpcSession(args: {
@@ -35,6 +39,8 @@ export function connectMobileRelayRpcSession(args: {
   let requestCounter = 0
   let lastConnectedAt: number | null = null
   let leaseExpiresAt: number | null = null
+  let resumeConfirmation: DeviceResumeConfirmed | null = null
+  let failure: Error | null = null
   let closed = false
   const streams = new MobileRelayRpcStreams({
     nextId,
@@ -100,7 +106,9 @@ export function connectMobileRelayRpcSession(args: {
       streams.clear()
       publishState('disconnected')
     },
-    getLeaseExpiresAt: () => leaseExpiresAt
+    getLeaseExpiresAt: () => leaseExpiresAt,
+    getResumeConfirmation: () => resumeConfirmation,
+    getFailure: () => failure
   }
   return client
 
@@ -119,6 +127,7 @@ export function connectMobileRelayRpcSession(args: {
       if (!result.resumeConfirmation || result.relay?.relayHostId !== args.relay.relayHostId) {
         throw new Error('relay resume confirmation missing')
       }
+      resumeConfirmation = result.resumeConfirmation
       lastConnectedAt = Date.now()
       publishState('connected')
     } catch (error) {
@@ -221,9 +230,10 @@ export function connectMobileRelayRpcSession(args: {
       return
     }
     closed = true
+    failure = error
     link.close()
     rejectPending(error)
-    publishState('disconnected')
+    publishState(error instanceof MobileE2EEAuthenticationError ? 'auth-failed' : 'disconnected')
   }
 
   function rejectPending(error: Error): void {

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -1,0 +1,244 @@
+import {
+  PairingGetEndpointsResultSchema,
+  type MobileRelayEndpoint
+} from '../../../src/shared/mobile-relay-credential-contract'
+import { MobileRelayE2eeLink } from './mobile-relay-e2ee-link'
+import { MobileRelayRpcStreams } from './mobile-relay-rpc-streams'
+import { isRpcResponse } from './rpc-response-shape'
+import type { RpcClient } from './rpc-client'
+import type { ConnectionState, RpcResponse } from './types'
+
+type PendingRequest = {
+  resolve: (response: RpcResponse) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+export type MobileRelayRpcSession = RpcClient & {
+  getLeaseExpiresAt(): number | null
+}
+
+export function connectMobileRelayRpcSession(args: {
+  relay: MobileRelayEndpoint
+  resumeToken: string
+  resumeCredentialVersion: number
+  resumeConfirmReqId: string
+  deviceToken: string
+  desktopPublicKeyB64: string
+  requestTimeoutMs?: number
+  createSocket?: (url: string) => WebSocket
+}): MobileRelayRpcSession {
+  const requestTimeoutMs = args.requestTimeoutMs ?? 30_000
+  const pending = new Map<string, PendingRequest>()
+  const stateListeners = new Set<(state: ConnectionState) => void>()
+  let state: ConnectionState = 'connecting'
+  let requestCounter = 0
+  let lastConnectedAt: number | null = null
+  let leaseExpiresAt: number | null = null
+  let closed = false
+  const streams = new MobileRelayRpcStreams({
+    nextId,
+    sendFrame,
+    waitForConnected: () => waitForConnected()
+  })
+
+  const link = new MobileRelayE2eeLink({
+    endpoint: args.relay,
+    credential: args.resumeToken,
+    expectedCredentialKind: 'resume',
+    deviceToken: args.deviceToken,
+    desktopPublicKeyB64: args.desktopPublicKeyB64,
+    createSocket: args.createSocket,
+    onHello: (hello) => {
+      if (
+        hello.credentialKind !== 'resume' ||
+        hello.acceptedCredentialVersion !== args.resumeCredentialVersion
+      ) {
+        fail(new Error('relay resume credential version mismatch'))
+        return
+      }
+      leaseExpiresAt = hello.leaseExpiresAt
+      publishState('handshaking')
+    },
+    onAuthenticated: () => void confirmResume(),
+    onText: handleText,
+    onBinary: handleBinary,
+    onError: fail
+  })
+
+  const client: MobileRelayRpcSession = {
+    async sendRequest(method, params, options) {
+      await waitForConnected(options?.timeoutMs)
+      return sendRpc(method, params, options?.timeoutMs)
+    },
+
+    subscribe(method, params, listener, options) {
+      if (closed) {
+        return () => {}
+      }
+      return streams.subscribe(method, params, listener, options)
+    },
+
+    updateTerminalSubscriptionViewport(terminal, viewport) {
+      streams.updateTerminalViewport(terminal, viewport)
+    },
+    getState: () => state,
+    getReconnectAttempt: () => 0,
+    getLastConnectedAt: () => lastConnectedAt,
+    onStateChange(listener) {
+      stateListeners.add(listener)
+      return () => stateListeners.delete(listener)
+    },
+    notifyForeground: () => {},
+    close() {
+      if (closed) {
+        return
+      }
+      closed = true
+      link.close()
+      rejectPending(new Error('Client closed'))
+      streams.clear()
+      publishState('disconnected')
+    },
+    getLeaseExpiresAt: () => leaseExpiresAt
+  }
+  return client
+
+  async function confirmResume(): Promise<void> {
+    try {
+      const response = await sendRpc(
+        'pairing.getEndpoints',
+        { resumeConfirmReqId: args.resumeConfirmReqId },
+        requestTimeoutMs,
+        true
+      )
+      if (!response.ok) {
+        throw new Error(response.error.code)
+      }
+      const result = PairingGetEndpointsResultSchema.parse(response.result)
+      if (!result.resumeConfirmation || result.relay?.relayHostId !== args.relay.relayHostId) {
+        throw new Error('relay resume confirmation missing')
+      }
+      lastConnectedAt = Date.now()
+      publishState('connected')
+    } catch (error) {
+      fail(asError(error))
+    }
+  }
+
+  function sendRpc(
+    method: string,
+    params: unknown,
+    timeoutMs = requestTimeoutMs,
+    beforeConnected = false
+  ): Promise<RpcResponse> {
+    if (closed || (!beforeConnected && state !== 'connected')) {
+      return Promise.reject(new Error('relay session not connected'))
+    }
+    const id = nextId()
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id)
+        reject(new Error(`relay RPC timed out: ${method}`))
+      }, timeoutMs)
+      pending.set(id, { resolve, reject, timer })
+      if (!sendFrame({ id, method, params })) {
+        clearTimeout(timer)
+        pending.delete(id)
+        reject(new Error('relay E2EE channel not ready'))
+      }
+    })
+  }
+
+  function sendFrame(request: { id: string; method: string; params?: unknown }): boolean {
+    return link.sendText(JSON.stringify({ ...request, deviceToken: args.deviceToken }))
+  }
+
+  function handleText(plaintext: string): void {
+    let value: unknown
+    try {
+      value = JSON.parse(plaintext)
+    } catch {
+      return
+    }
+    if (!isRpcResponse(value)) {
+      return
+    }
+    const request = pending.get(value.id)
+    if (request) {
+      clearTimeout(request.timer)
+      pending.delete(value.id)
+      request.resolve(value)
+      return
+    }
+    streams.handleResponse(value)
+  }
+
+  function handleBinary(bytes: Uint8Array): void {
+    streams.handleBinary(bytes)
+  }
+
+  function waitForConnected(timeoutMs = requestTimeoutMs): Promise<void> {
+    if (state === 'connected') {
+      return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null
+      const unsubscribe = client.onStateChange((next) => {
+        if (next === 'connected') {
+          finish()
+          resolve()
+        } else if (next === 'disconnected' || next === 'auth-failed') {
+          finish()
+          reject(new Error(`relay session ${next}`))
+        }
+      })
+      timer = setTimeout(() => {
+        finish()
+        reject(new Error('relay session connection timed out'))
+      }, timeoutMs)
+      function finish(): void {
+        if (timer) {
+          clearTimeout(timer)
+        }
+        unsubscribe()
+      }
+    })
+  }
+
+  function publishState(next: ConnectionState): void {
+    if (state === next) {
+      return
+    }
+    state = next
+    for (const listener of stateListeners) {
+      listener(next)
+    }
+  }
+
+  function fail(error: Error): void {
+    if (closed) {
+      return
+    }
+    closed = true
+    link.close()
+    rejectPending(error)
+    publishState('disconnected')
+  }
+
+  function rejectPending(error: Error): void {
+    for (const request of pending.values()) {
+      clearTimeout(request.timer)
+      request.reject(error)
+    }
+    pending.clear()
+  }
+
+  function nextId(): string {
+    return `relay-rpc-${++requestCounter}-${Date.now()}`
+  }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/mobile/src/transport/mobile-relay-rpc-streams.ts
+++ b/mobile/src/transport/mobile-relay-rpc-streams.ts
@@ -1,0 +1,165 @@
+import { decodeBrowserScreencastFrame } from './browser-screencast-protocol'
+import {
+  handleTerminalBinaryFrame,
+  type TerminalSnapshotState
+} from './rpc-client-terminal-binary-frame'
+import {
+  buildTerminalUnsubscribeParams,
+  updateTerminalSubscriptionViewport
+} from './rpc-client-terminal-subscription'
+import type { RpcClient } from './rpc-client'
+import type { RpcResponse, RpcSuccess } from './types'
+
+type StreamRecord = {
+  method: string
+  params: unknown
+  listener: (result: unknown) => void
+  onBinaryFrame?: Parameters<RpcClient['subscribe']>[3] extends
+    | { onBinaryFrame?: infer Listener }
+    | undefined
+    ? Listener
+    : never
+  streamIds: Set<number>
+  subscriptionId?: string
+  cancelled: boolean
+}
+
+type StreamManagerOptions = {
+  nextId: () => string
+  sendFrame: (request: { id: string; method: string; params?: unknown }) => boolean
+  waitForConnected: () => Promise<void>
+}
+
+export class MobileRelayRpcStreams {
+  private readonly streams = new Map<string, StreamRecord>()
+  private readonly terminalListeners = new Map<number, (result: unknown) => void>()
+  private readonly terminalSnapshots = new Map<number, TerminalSnapshotState>()
+  private activeBrowserStream: StreamRecord | null = null
+
+  constructor(private readonly options: StreamManagerOptions) {}
+
+  subscribe(
+    method: string,
+    params: unknown,
+    listener: (result: unknown) => void,
+    subscribeOptions?: Parameters<RpcClient['subscribe']>[3]
+  ): () => void {
+    const id = this.options.nextId()
+    const stream: StreamRecord = {
+      method,
+      params,
+      listener,
+      onBinaryFrame: subscribeOptions?.onBinaryFrame,
+      streamIds: new Set(),
+      cancelled: false
+    }
+    this.streams.set(id, stream)
+    void this.options
+      .waitForConnected()
+      .then(() => {
+        if (!stream.cancelled && !this.options.sendFrame({ id, method, params: stream.params })) {
+          this.remove(id)
+        }
+      })
+      .catch(() => this.remove(id))
+    return () => this.cancel(id)
+  }
+
+  updateTerminalViewport(terminal: string, viewport: { cols: number; rows: number }): void {
+    updateTerminalSubscriptionViewport(this.streams.values(), terminal, viewport)
+  }
+
+  handleResponse(response: RpcResponse): boolean {
+    const stream = this.streams.get(response.id)
+    if (!stream) {
+      return false
+    }
+    if (!response.ok) {
+      this.remove(response.id)
+      return true
+    }
+    const result = (response as RpcSuccess).result
+    if (result && typeof result === 'object') {
+      const metadata = result as { subscriptionId?: unknown; streamId?: unknown; type?: unknown }
+      if (typeof metadata.subscriptionId === 'string') {
+        stream.subscriptionId = metadata.subscriptionId
+      }
+      if (typeof metadata.streamId === 'number') {
+        stream.streamIds.add(metadata.streamId)
+        this.terminalListeners.set(metadata.streamId, stream.listener)
+      }
+      if (stream.method === 'browser.screencast') {
+        this.activeBrowserStream = stream
+      }
+      if (metadata.type === 'end') {
+        stream.listener(result)
+        this.remove(response.id)
+        return true
+      }
+    }
+    if (!stream.cancelled) {
+      stream.listener(result)
+    }
+    return true
+  }
+
+  handleBinary(bytes: Uint8Array): void {
+    const browserFrame = decodeBrowserScreencastFrame(bytes)
+    if (browserFrame && this.activeBrowserStream?.onBinaryFrame) {
+      this.activeBrowserStream.onBinaryFrame(browserFrame)
+      return
+    }
+    handleTerminalBinaryFrame(bytes, {
+      terminalSnapshots: this.terminalSnapshots,
+      getListener: (streamId) => this.terminalListeners.get(streamId),
+      recordValidatedInboundTraffic: () => {}
+    })
+  }
+
+  clear(): void {
+    this.streams.clear()
+    this.terminalListeners.clear()
+    this.terminalSnapshots.clear()
+    this.activeBrowserStream = null
+  }
+
+  private cancel(id: string): void {
+    const stream = this.streams.get(id)
+    if (!stream || stream.cancelled) {
+      return
+    }
+    stream.cancelled = true
+    if (stream.method === 'terminal.subscribe') {
+      const params = buildTerminalUnsubscribeParams(stream.params)
+      if (params) {
+        this.options.sendFrame({
+          id: this.options.nextId(),
+          method: 'terminal.unsubscribe',
+          params
+        })
+      }
+    } else if (stream.subscriptionId) {
+      this.options.sendFrame({
+        id: this.options.nextId(),
+        method: stream.method.replace(/\.subscribe$/, '.unsubscribe'),
+        params: { subscriptionId: stream.subscriptionId }
+      })
+    }
+    this.remove(id)
+  }
+
+  private remove(id: string): void {
+    const stream = this.streams.get(id)
+    if (!stream) {
+      return
+    }
+    for (const streamId of stream.streamIds) {
+      this.terminalListeners.delete(streamId)
+      this.terminalSnapshots.delete(streamId)
+    }
+    if (this.activeBrowserStream === stream) {
+      this.activeBrowserStream = null
+    }
+    this.streams.delete(id)
+  }
+}

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ConnectionState, RpcResponse } from './types'
+import type { RpcClient } from './rpc-client'
+import {
+  createStableLogicalRpcClient,
+  LogicalClientCutoverError
+} from './stable-logical-rpc-client'
+
+class FakeSession implements RpcClient {
+  readonly sendRequest =
+    vi.fn<
+      (method: string, params?: unknown, options?: { timeoutMs?: number }) => Promise<RpcResponse>
+    >()
+  readonly subscribe = vi.fn<RpcClient['subscribe']>()
+  readonly updateTerminalSubscriptionViewport =
+    vi.fn<RpcClient['updateTerminalSubscriptionViewport']>()
+  readonly notifyForeground = vi.fn()
+  readonly close = vi.fn()
+  private state: ConnectionState
+  private readonly stateListeners = new Set<(state: ConnectionState) => void>()
+  private readonly streamListeners = new Set<(result: unknown) => void>()
+
+  constructor(state: ConnectionState) {
+    this.state = state
+    this.subscribe.mockImplementation((_method, _params, listener) => {
+      this.streamListeners.add(listener)
+      return () => this.streamListeners.delete(listener)
+    })
+  }
+
+  getState = (): ConnectionState => this.state
+  getReconnectAttempt = (): number => 0
+  getLastConnectedAt = (): number | null => null
+  onStateChange = (listener: (state: ConnectionState) => void): (() => void) => {
+    this.stateListeners.add(listener)
+    return () => this.stateListeners.delete(listener)
+  }
+
+  setState(state: ConnectionState): void {
+    this.state = state
+    for (const listener of this.stateListeners) {
+      listener(state)
+    }
+  }
+
+  emitStream(value: unknown): void {
+    for (const listener of this.streamListeners) {
+      listener(value)
+    }
+  }
+}
+
+function success(value: unknown): RpcResponse {
+  return { id: 'rpc-1', ok: true, result: value, _meta: { runtimeId: 'runtime-1' } }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe('stable logical RPC client', () => {
+  it('makes before break, rejects in-flight work, and replays subscriptions', async () => {
+    const oldSession = new FakeSession('connected')
+    const nextSession = new FakeSession('connecting')
+    const pending = deferred<RpcResponse>()
+    oldSession.sendRequest.mockReturnValue(pending.promise)
+    nextSession.sendRequest.mockResolvedValue(success('next'))
+    const client = createStableLogicalRpcClient(oldSession, 'direct')
+    const stream = vi.fn()
+    client.subscribe('terminal.subscribe', { terminal: 'term-1' }, stream)
+    const request = client.sendRequest('worktree.create', { name: 'new' })
+
+    const migrating = client.migrateTo(nextSession, 'relay')
+    expect(oldSession.close).not.toHaveBeenCalled()
+    expect(nextSession.subscribe).not.toHaveBeenCalled()
+    nextSession.setState('connected')
+    await migrating
+
+    await expect(request).rejects.toBeInstanceOf(LogicalClientCutoverError)
+    expect(nextSession.subscribe).toHaveBeenCalledWith(
+      'terminal.subscribe',
+      { terminal: 'term-1' },
+      expect.any(Function),
+      undefined
+    )
+    expect(oldSession.close).toHaveBeenCalledOnce()
+    expect(client.getActivePath()).toBe('relay')
+    expect(client.getGeneration()).toBe(2)
+    oldSession.emitStream('stale')
+    nextSession.emitStream('current')
+    expect(stream).toHaveBeenCalledOnce()
+    expect(stream).toHaveBeenCalledWith('current')
+    pending.resolve(success('late'))
+  })
+
+  it('keeps replies that commit before cutover and carries viewport state into replay', async () => {
+    const oldSession = new FakeSession('connected')
+    const nextSession = new FakeSession('connected')
+    oldSession.sendRequest.mockResolvedValue(success('old'))
+    const client = createStableLogicalRpcClient(oldSession, 'direct')
+    client.subscribe(
+      'terminal.subscribe',
+      { terminal: 'term-1', viewport: { cols: 80, rows: 24 } },
+      vi.fn()
+    )
+    client.updateTerminalSubscriptionViewport('term-1', { cols: 120, rows: 40 })
+
+    await expect(client.sendRequest('status.get')).resolves.toEqual(success('old'))
+    await client.migrateTo(nextSession, 'relay')
+    expect(nextSession.subscribe).toHaveBeenCalledWith(
+      'terminal.subscribe',
+      { terminal: 'term-1', viewport: { cols: 120, rows: 40 } },
+      expect.any(Function),
+      undefined
+    )
+  })
+
+  it('closes a replacement that fails authentication and preserves the active session', async () => {
+    const oldSession = new FakeSession('connected')
+    const replacement = new FakeSession('connecting')
+    const client = createStableLogicalRpcClient(oldSession, 'direct')
+    const migrating = client.migrateTo(replacement, 'relay')
+    replacement.setState('auth-failed')
+
+    await expect(migrating).rejects.toThrow(/auth-failed/)
+    expect(replacement.close).toHaveBeenCalledOnce()
+    expect(oldSession.close).not.toHaveBeenCalled()
+    expect(client.getActivePath()).toBe('direct')
+    expect(client.getGeneration()).toBe(1)
+  })
+})

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -69,7 +69,7 @@ describe('stable logical RPC client', () => {
     const pending = deferred<RpcResponse>()
     oldSession.sendRequest.mockReturnValue(pending.promise)
     nextSession.sendRequest.mockResolvedValue(success('next'))
-    const client = createStableLogicalRpcClient(oldSession, 'direct')
+    const client = createStableLogicalRpcClient(oldSession, 'lan')
     const stream = vi.fn()
     client.subscribe('terminal.subscribe', { terminal: 'term-1' }, stream)
     const request = client.sendRequest('worktree.create', { name: 'new' })
@@ -101,7 +101,7 @@ describe('stable logical RPC client', () => {
     const oldSession = new FakeSession('connected')
     const nextSession = new FakeSession('connected')
     oldSession.sendRequest.mockResolvedValue(success('old'))
-    const client = createStableLogicalRpcClient(oldSession, 'direct')
+    const client = createStableLogicalRpcClient(oldSession, 'lan')
     client.subscribe(
       'terminal.subscribe',
       { terminal: 'term-1', viewport: { cols: 80, rows: 24 } },
@@ -122,14 +122,14 @@ describe('stable logical RPC client', () => {
   it('closes a replacement that fails authentication and preserves the active session', async () => {
     const oldSession = new FakeSession('connected')
     const replacement = new FakeSession('connecting')
-    const client = createStableLogicalRpcClient(oldSession, 'direct')
+    const client = createStableLogicalRpcClient(oldSession, 'lan')
     const migrating = client.migrateTo(replacement, 'relay')
     replacement.setState('auth-failed')
 
     await expect(migrating).rejects.toThrow(/auth-failed/)
     expect(replacement.close).toHaveBeenCalledOnce()
     expect(oldSession.close).not.toHaveBeenCalled()
-    expect(client.getActivePath()).toBe('direct')
+    expect(client.getActivePath()).toBe('lan')
     expect(client.getGeneration()).toBe(1)
   })
 })

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -1,7 +1,7 @@
 import type { ConnectionState, RpcResponse } from './types'
 import type { RpcClient } from './rpc-client'
 
-export type MobileConnectionPath = 'direct' | 'relay'
+export type MobileConnectionPath = 'lan' | 'tailscale' | 'relay'
 
 export class LogicalClientCutoverError extends Error {
   constructor() {

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -1,0 +1,260 @@
+import type { ConnectionState, RpcResponse } from './types'
+import type { RpcClient } from './rpc-client'
+
+export type MobileConnectionPath = 'direct' | 'relay'
+
+export class LogicalClientCutoverError extends Error {
+  constructor() {
+    super('RPC interrupted by connection migration')
+  }
+}
+
+type SubscriptionRecord = {
+  method: string
+  params: unknown
+  listener: (result: unknown) => void
+  options?: Parameters<RpcClient['subscribe']>[3]
+  disposePhysical: (() => void) | null
+  cancelled: boolean
+}
+
+type PendingRequest = {
+  reject: (error: Error) => void
+}
+
+export type StableLogicalRpcClient = RpcClient & {
+  migrateTo(session: RpcClient, path: MobileConnectionPath, timeoutMs?: number): Promise<void>
+  getActivePath(): MobileConnectionPath
+  getGeneration(): number
+}
+
+export function createStableLogicalRpcClient(
+  initialSession: RpcClient,
+  initialPath: MobileConnectionPath
+): StableLogicalRpcClient {
+  let activeSession = initialSession
+  let activePath = initialPath
+  let generation = 1
+  let closed = false
+  let nextSubscriptionId = 0
+  let activeStateUnsubscribe: (() => void) | null = null
+  const subscriptions = new Map<number, SubscriptionRecord>()
+  const pendingRequests = new Set<PendingRequest>()
+  const stateListeners = new Set<(state: ConnectionState) => void>()
+  let state = initialSession.getState()
+
+  bindActiveState(initialSession, generation)
+
+  const logical: StableLogicalRpcClient = {
+    sendRequest(method, params, options) {
+      if (closed) {
+        return Promise.reject(new Error('Client closed'))
+      }
+      const requestGeneration = generation
+      const session = activeSession
+      return new Promise<RpcResponse>((resolve, reject) => {
+        const pending = { reject }
+        pendingRequests.add(pending)
+        void session.sendRequest(method, params, options).then(
+          (response) => {
+            pendingRequests.delete(pending)
+            if (closed) {
+              reject(new Error('Client closed'))
+            } else if (requestGeneration !== generation) {
+              reject(new LogicalClientCutoverError())
+            } else {
+              resolve(response)
+            }
+          },
+          (error: unknown) => {
+            pendingRequests.delete(pending)
+            reject(error)
+          }
+        )
+      })
+    },
+
+    subscribe(method, params, listener, options) {
+      if (closed) {
+        return () => {}
+      }
+      const id = ++nextSubscriptionId
+      const record: SubscriptionRecord = {
+        method,
+        params,
+        listener,
+        options,
+        disposePhysical: null,
+        cancelled: false
+      }
+      subscriptions.set(id, record)
+      attachSubscription(record, activeSession, generation)
+      return () => {
+        if (record.cancelled) {
+          return
+        }
+        record.cancelled = true
+        record.disposePhysical?.()
+        record.disposePhysical = null
+        subscriptions.delete(id)
+      }
+    },
+
+    updateTerminalSubscriptionViewport(terminal, viewport) {
+      for (const record of subscriptions.values()) {
+        if (
+          record.params &&
+          typeof record.params === 'object' &&
+          'terminal' in record.params &&
+          record.params.terminal === terminal
+        ) {
+          record.params = { ...record.params, viewport }
+        }
+      }
+      activeSession.updateTerminalSubscriptionViewport(terminal, viewport)
+    },
+
+    getState: () => state,
+    getReconnectAttempt: () => activeSession.getReconnectAttempt(),
+    getLastConnectedAt: () => activeSession.getLastConnectedAt(),
+    onStateChange(listener) {
+      stateListeners.add(listener)
+      return () => stateListeners.delete(listener)
+    },
+    notifyForeground: () => activeSession.notifyForeground(),
+    close() {
+      if (closed) {
+        return
+      }
+      closed = true
+      activeStateUnsubscribe?.()
+      activeStateUnsubscribe = null
+      for (const pending of pendingRequests) {
+        pending.reject(new Error('Client closed'))
+      }
+      pendingRequests.clear()
+      for (const record of subscriptions.values()) {
+        record.disposePhysical?.()
+      }
+      subscriptions.clear()
+      activeSession.close()
+      publishState('disconnected')
+    },
+
+    async migrateTo(nextSession, path, timeoutMs = 12_000) {
+      if (closed) {
+        nextSession.close()
+        throw new Error('Client closed')
+      }
+      try {
+        await waitForAuthenticated(nextSession, timeoutMs)
+      } catch (error) {
+        nextSession.close()
+        throw error
+      }
+      if (closed) {
+        nextSession.close()
+        throw new Error('Client closed')
+      }
+      const previous = activeSession
+      const previousStateUnsubscribe = activeStateUnsubscribe
+      const nextGeneration = generation + 1
+
+      // Why: replay on the authenticated replacement before closing the old
+      // session, but fence callbacks until the generation becomes current.
+      for (const record of subscriptions.values()) {
+        const disposePrevious = record.disposePhysical
+        attachSubscription(record, nextSession, nextGeneration)
+        disposePrevious?.()
+      }
+      generation = nextGeneration
+      activeSession = nextSession
+      activePath = path
+      previousStateUnsubscribe?.()
+      bindActiveState(nextSession, nextGeneration)
+      for (const pending of pendingRequests) {
+        pending.reject(new LogicalClientCutoverError())
+      }
+      pendingRequests.clear()
+      state = nextSession.getState()
+      for (const listener of stateListeners) {
+        listener(state)
+      }
+      previous.close()
+    },
+
+    getActivePath: () => activePath,
+    getGeneration: () => generation
+  }
+
+  return logical
+
+  function attachSubscription(
+    record: SubscriptionRecord,
+    session: RpcClient,
+    subscriptionGeneration: number
+  ): void {
+    record.disposePhysical = session.subscribe(
+      record.method,
+      record.params,
+      (result) => {
+        if (!closed && !record.cancelled && generation === subscriptionGeneration) {
+          record.listener(result)
+        }
+      },
+      record.options
+    )
+  }
+
+  function bindActiveState(session: RpcClient, sessionGeneration: number): void {
+    activeStateUnsubscribe = session.onStateChange((next) => {
+      if (!closed && generation === sessionGeneration && session === activeSession) {
+        publishState(next)
+      }
+    })
+  }
+
+  function publishState(next: ConnectionState): void {
+    if (state === next) {
+      return
+    }
+    state = next
+    for (const listener of stateListeners) {
+      listener(next)
+    }
+  }
+}
+
+function waitForAuthenticated(session: RpcClient, timeoutMs: number): Promise<void> {
+  if (session.getState() === 'connected') {
+    return Promise.resolve()
+  }
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const unsubscribe = session.onStateChange((state) => {
+      if (state === 'connected') {
+        finish()
+        resolve()
+      } else if (state === 'auth-failed' || state === 'disconnected') {
+        finish()
+        reject(new Error(`replacement session ${state}`))
+      }
+    })
+    timer = setTimeout(() => {
+      finish()
+      reject(new Error('replacement session authentication timed out'))
+    }, timeoutMs)
+
+    function finish(): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+      unsubscribe()
+    }
+  })
+}


### PR DESCRIPTION
Review-only mobile relay-connect slice stacked on #8530. Do not merge directly; the combined relay PR remains the single merge PR.

Scope:
- relay first-frame auth and required E2EE v2 physical sessions
- stable logical RPC client with generation fencing and subscription replay
- foreground-aware endpoint supervisor and authenticated direct-promotion hysteresis
- conservative pair rotation, resume director resolution, credential reconciliation, and orphan cleanup
- active-path and update/sign-in discovery hints

Validation:
- 19 focused logical-session/supervisor/rotation/cleanup tests
- full mobile suite on combined branch: 1,566 passing, 2 skipped
- `pnpm typecheck`
- pre-commit mobile oxlint/oxfmt gates

Made with [Orca](https://github.com/stablyai/orca) 🐋
