### PR TITLE
Create PR: auto-prepare behind-only branches and return remote errors inline

### DIFF
--- a/src/main/keybindings/keybinding-file.test.ts
+++ b/src/main/keybindings/keybinding-file.test.ts
@@ -368,6 +368,17 @@ describe('keybinding-file', () => {
     })
   })
 
+  it('throws instead of freezing the seed when a legacy binding fails normalization', () => {
+    // A dropped pin must not be silent: the service catches the throw and keeps
+    // the cohort pending so a corrected build can retry the seed.
+    expect(() =>
+      seedLegacyTabSwitchBindings(filePath, 'darwin', {
+        'tab.nextSameType': ['J']
+      })
+    ).toThrow(/normalize/i)
+    expect(readKeybindingFile(filePath, 'darwin').platformOverrides.darwin).toEqual({})
+  })
+
   it('does not replace an unreadable keybindings file while seeding', () => {
     const unreadableContents = '{{{not json'
     writeFileSync(filePath, unreadableContents, 'utf8')

--- a/src/main/keybindings/keybinding-file.ts
+++ b/src/main/keybindings/keybinding-file.ts
@@ -353,16 +353,47 @@ export function seedLegacyTabSwitchBindings(
     return { seeded: false, snapshot: current }
   }
 
+  // Why: never freeze the one-shot after dropping a pin — a normalization
+  // failure must throw so the cohort stays pending and a fixed build retries.
+  const pins = toSeed.map((actionId) => {
+    const normalized = normalizeKeybindingArrayForAction(actionId, legacyBindings[actionId] ?? [])
+    if (!Array.isArray(normalized)) {
+      throw new Error(`Could not normalize legacy binding for "${actionId}".`)
+    }
+    return [actionId, normalized] as const
+  })
+  const snapshot = writeActivePlatformSection(
+    path,
+    platform,
+    current.commonOverrides,
+    (activePlatform) => {
+      for (const [actionId, normalized] of pins) {
+        activePlatform[actionId] = normalized
+      }
+    }
+  )
+  return { seeded: true, snapshot }
+}
+
+// Why: the one-shot seed migration and Settings writes must produce the same
+// on-disk document shape; a single assembly path keeps them from drifting.
+function writeActivePlatformSection(
+  path: string,
+  platform: NodeJS.Platform,
+  fallbackCommonOverrides: KeybindingOverrides,
+  mutateActivePlatform: (activePlatform: JsonObject) => void
+): KeybindingFileSnapshot {
+  const keybindingPlatform = getKeybindingPlatform(platform)
   const readResult = readJsonDocument(path)
   if (!readResult.document) {
-    // Why: migration must never replace a user-owned file that could not be
-    // parsed; leaving the cohort pending allows a safe retry after repair.
+    // Why: writes must never replace a user-owned file that could not be
+    // parsed; callers surface the error (or retry the migration) after repair.
     throw new Error(readResult.error ?? 'Could not read keybindings file.')
   }
   const document = { ...readResult.document }
   const common = isJsonObject(document.keybindings)
     ? { ...document.keybindings }
-    : { ...current.commonOverrides }
+    : { ...fallbackCommonOverrides }
   for (const rootKey of Object.keys(document)) {
     if (isKeybindingActionId(rootKey)) {
       delete document[rootKey]
@@ -372,12 +403,7 @@ export function seedLegacyTabSwitchBindings(
   const activePlatform = isJsonObject(platforms[keybindingPlatform])
     ? { ...(platforms[keybindingPlatform] as JsonObject) }
     : {}
-  for (const actionId of toSeed) {
-    const normalized = normalizeKeybindingArrayForAction(actionId, legacyBindings[actionId] ?? [])
-    if (Array.isArray(normalized)) {
-      activePlatform[actionId] = normalized
-    }
-  }
+  mutateActivePlatform(activePlatform)
 
   document.version = FILE_VERSION
   document.keybindings = common
@@ -389,7 +415,7 @@ export function seedLegacyTabSwitchBindings(
     [keybindingPlatform]: activePlatform
   }
   writeJsonDocument(path, document)
-  return { seeded: true, snapshot: readKeybindingFile(path, platform) }
+  return readKeybindingFile(path, platform)
 }
 
 export function writeKeybindingOverride(
@@ -420,44 +446,19 @@ export function writeKeybindingOverride(
     )
   }
 
-  const readResult = readJsonDocument(path)
-  if (!readResult.document) {
-    throw new Error(readResult.error ?? 'Could not read keybindings file.')
-  }
-
-  const document = { ...readResult.document }
-  const common = isJsonObject(document.keybindings)
-    ? { ...document.keybindings }
-    : { ...currentSnapshot.commonOverrides }
-  for (const rootKey of Object.keys(document)) {
-    if (isKeybindingActionId(rootKey)) {
-      delete document[rootKey]
+  return writeActivePlatformSection(
+    path,
+    platform,
+    currentSnapshot.commonOverrides,
+    (activePlatform) => {
+      if (normalizedBindings === null) {
+        // Why: Settings edits are scoped to the current platform. A hand-authored
+        // common binding may be intentional for other OSes, so reset only removes
+        // the platform-specific mask instead of deleting the shared value.
+        delete activePlatform[actionId]
+      } else {
+        activePlatform[actionId] = normalizedBindings
+      }
     }
-  }
-  const platforms = isJsonObject(document.platforms) ? { ...document.platforms } : {}
-  const activePlatform = isJsonObject(platforms[keybindingPlatform])
-    ? { ...(platforms[keybindingPlatform] as JsonObject) }
-    : {}
-
-  if (normalizedBindings === null) {
-    // Why: Settings edits are scoped to the current platform. A hand-authored
-    // common binding may be intentional for other OSes, so reset only removes
-    // the platform-specific mask instead of deleting the shared value.
-    delete activePlatform[actionId]
-  } else {
-    activePlatform[actionId] = normalizedBindings
-  }
-
-  document.version = FILE_VERSION
-  document.keybindings = common
-  document.platforms = {
-    ...platforms,
-    darwin: isJsonObject(platforms.darwin) ? platforms.darwin : {},
-    linux: isJsonObject(platforms.linux) ? platforms.linux : {},
-    win32: isJsonObject(platforms.win32) ? platforms.win32 : {},
-    [keybindingPlatform]: activePlatform
-  }
-
-  writeJsonDocument(path, document)
-  return readKeybindingFile(path, platform)
+  )
 }

--- a/src/main/keybindings/keybinding-service.ts
+++ b/src/main/keybindings/keybinding-service.ts
@@ -42,7 +42,13 @@ export class KeybindingService {
     // instead of silently dropping the pin.
     if (options.legacyTabSwitchSeed?.isPending()) {
       try {
-        seedLegacyTabSwitchBindings(this.configPath, this.platform, LEGACY_TAB_SWITCH_BINDINGS)
+        // Why: the seed already read the file to build its snapshot — prime the
+        // lazy cache with it instead of re-reading on the first getSnapshot().
+        this.snapshot = seedLegacyTabSwitchBindings(
+          this.configPath,
+          this.platform,
+          LEGACY_TAB_SWITCH_BINDINGS
+        ).snapshot
         options.legacyTabSwitchSeed.markSeeded()
       } catch (error) {
         console.error('Failed to seed legacy tab-switch keybindings:', error)

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -258,6 +258,7 @@ import {
   createPrIntentRunTokenMatches,
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
+  isCreatePrIntentSyncConflictError,
   resolveCreatePrIntentReviewBase,
   resolveCreatePrIntentRemoteStep,
   type CreatePrIntentRunToken
@@ -1081,6 +1082,12 @@ function SourceControlInner(): React.JSX.Element {
     Record<string, SourceControlActionError | null>
   >({})
   const remoteActionErrorSequenceByWorktreeRef = useRef<Record<string, number>>({})
+  // Why: runCreatePrIntent closes over a stale `remoteActionErrors` (it is not a
+  // callback dep), so mirror the latest remote-action failure into a ref the
+  // intent runner can read synchronously after runRemoteAction resolves.
+  const lastRemoteActionErrorByWorktreeRef = useRef<
+    Record<string, SourceControlActionError | null>
+  >({})
   const previousConflictOperationsRef = useRef<Record<string, GitConflictOperation>>({})
   // Why: keep commit-in-flight state per-worktree. A single boolean would be
   // cleared when the user switched worktrees, letting them double-click Commit
@@ -2511,6 +2518,7 @@ function SourceControlInner(): React.JSX.Element {
           : []
       )
       const failureBranchName = targetIsActiveWorktree ? branchName || null : null
+      lastRemoteActionErrorByWorktreeRef.current[target.worktreeId] = null
       setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
       try {
         if (kind === 'publish') {
@@ -2609,6 +2617,7 @@ function SourceControlInner(): React.JSX.Element {
           }
         )
         if (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] === sequence) {
+          lastRemoteActionErrorByWorktreeRef.current[target.worktreeId] = null
           setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
         }
         return true
@@ -2620,20 +2629,19 @@ function SourceControlInner(): React.JSX.Element {
         if (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] !== sequence) {
           return false
         }
-        setRemoteActionErrors((prev) => ({
-          ...prev,
-          [target.worktreeId]: {
-            kind,
-            message: resolveRemoteActionError(kind, error),
-            rawError: error instanceof Error ? error.message : String(error),
-            syncPushStage: kind === 'sync' ? isSyncPushStageError(error) : false,
-            branchName: failureBranchName,
-            worktreePath: target.worktreePath,
-            entriesSnapshot: recoveryEntrySnapshot.entries,
-            entriesSnapshotTotalCount: recoveryEntrySnapshot.totalCount,
-            sequence
-          }
-        }))
+        const actionError: SourceControlActionError = {
+          kind,
+          message: resolveRemoteActionError(kind, error),
+          rawError: error instanceof Error ? error.message : String(error),
+          syncPushStage: kind === 'sync' ? isSyncPushStageError(error) : false,
+          branchName: failureBranchName,
+          worktreePath: target.worktreePath,
+          entriesSnapshot: recoveryEntrySnapshot.entries,
+          entriesSnapshotTotalCount: recoveryEntrySnapshot.totalCount,
+          sequence
+        }
+        lastRemoteActionErrorByWorktreeRef.current[target.worktreeId] = actionError
+        setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: actionError }))
         return false
       } finally {
         if (!options?.target) {
@@ -4013,15 +4021,14 @@ function SourceControlInner(): React.JSX.Element {
         hasCurrentBranch: Boolean(token.branch)
       })
       if (remoteStep === 'blocked' || remoteStep === 'none') {
+        // Why: `needs_sync` now resolves to the auto 'sync'/'force_push' steps, so
+        // it never reaches this branch — the remaining blockers are simply not
+        // ready to create a review (e.g. auth_required, default_branch).
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
           tone: 'muted',
           message: translate(
-            eligibility.blockedReason === 'needs_sync'
-              ? 'auto.components.right.sidebar.SourceControl.createPrIntentNeedsSync'
-              : 'auto.components.right.sidebar.SourceControl.createPrIntentBranchNotReady',
-            eligibility.blockedReason === 'needs_sync'
-              ? 'Sync this branch before creating a review.'
-              : 'Branch is not ready to create a review yet.'
+            'auto.components.right.sidebar.SourceControl.createPrIntentBranchNotReady',
+            'Branch is not ready to create a review yet.'
           )
         })
         return
@@ -4029,18 +4036,28 @@ function SourceControlInner(): React.JSX.Element {
 
       setCreatePrIntentNoticeForWorktree(token.worktreeId, {
         tone: 'muted',
-        message: translate(
+        // Why: keep each translate() call on a string-literal key so the
+        // localization-catalog verifier can statically detect every key.
+        message:
           remoteStep === 'publish'
-            ? 'auto.components.right.sidebar.SourceControl.createPrIntentPublishing'
+            ? translate(
+                'auto.components.right.sidebar.SourceControl.createPrIntentPublishing',
+                'Publishing branch…'
+              )
             : remoteStep === 'force_push'
-              ? 'auto.components.right.sidebar.SourceControl.createPrIntentForcePushing'
-              : 'auto.components.right.sidebar.SourceControl.createPrIntentPushing',
-          remoteStep === 'publish'
-            ? 'Publishing branch…'
-            : remoteStep === 'force_push'
-              ? 'Force pushing with lease…'
-              : 'Pushing commits…'
-        )
+              ? translate(
+                  'auto.components.right.sidebar.SourceControl.createPrIntentForcePushing',
+                  'Force pushing with lease…'
+                )
+              : remoteStep === 'sync'
+                ? translate(
+                    'auto.components.right.sidebar.SourceControl.createPrIntentSyncing',
+                    'Syncing branch…'
+                  )
+                : translate(
+                    'auto.components.right.sidebar.SourceControl.createPrIntentPushing',
+                    'Pushing commits…'
+                  )
       })
       const remoteOk = await runRemoteAction(remoteStep, {
         target: operationTarget,
@@ -4050,12 +4067,21 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
       if (!remoteOk) {
+        const remoteError = lastRemoteActionErrorByWorktreeRef.current[token.worktreeId]
+        // A sync push-stage rejection is not a conflict — it falls to the generic
+        // copy so the push-recovery panel drives the fix.
+        const isSyncConflict = isCreatePrIntentSyncConflictError(remoteError)
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
           tone: 'destructive',
-          message: translate(
-            'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
-            'Could not update the remote branch. Retry Create PR.'
-          )
+          message: isSyncConflict
+            ? translate(
+                'auto.components.right.sidebar.SourceControl.createPrIntentSyncConflicts',
+                'Sync hit conflicts. Resolve them, then retry Create PR.'
+              )
+            : translate(
+                'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
+                'Could not update the remote branch. Retry Create PR.'
+              )
         })
         return
       }

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -258,7 +258,8 @@ import {
   createPrIntentRunTokenMatches,
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
-  isCreatePrIntentSyncConflictError,
+  resolveCreatePrIntentProgressStep,
+  resolveCreatePrIntentRemoteFailureNoticeKind,
   resolveCreatePrIntentReviewBase,
   resolveCreatePrIntentRemoteStep,
   type CreatePrIntentRunToken
@@ -2035,6 +2036,11 @@ function SourceControlInner(): React.JSX.Element {
     for (const key of Object.keys(remoteActionErrorSequenceByWorktreeRef.current)) {
       if (!worktreeMap.has(key)) {
         delete remoteActionErrorSequenceByWorktreeRef.current[key]
+      }
+    }
+    for (const key of Object.keys(lastRemoteActionErrorByWorktreeRef.current)) {
+      if (!worktreeMap.has(key)) {
+        delete lastRemoteActionErrorByWorktreeRef.current[key]
       }
     }
     for (const key of Object.keys(generateInFlightRef.current)) {
@@ -4034,22 +4040,23 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
 
+      const progressStep = resolveCreatePrIntentProgressStep(remoteStep)
       setCreatePrIntentNoticeForWorktree(token.worktreeId, {
         tone: 'muted',
         // Why: keep each translate() call on a string-literal key so the
         // localization-catalog verifier can statically detect every key.
         message:
-          remoteStep === 'publish'
+          progressStep === 'publish'
             ? translate(
                 'auto.components.right.sidebar.SourceControl.createPrIntentPublishing',
                 'Publishing branch…'
               )
-            : remoteStep === 'force_push'
+            : progressStep === 'force_push'
               ? translate(
                   'auto.components.right.sidebar.SourceControl.createPrIntentForcePushing',
                   'Force pushing with lease…'
                 )
-              : remoteStep === 'sync'
+              : progressStep === 'sync'
                 ? translate(
                     'auto.components.right.sidebar.SourceControl.createPrIntentSyncing',
                     'Syncing branch…'
@@ -4070,18 +4077,19 @@ function SourceControlInner(): React.JSX.Element {
         const remoteError = lastRemoteActionErrorByWorktreeRef.current[token.worktreeId]
         // A sync push-stage rejection is not a conflict — it falls to the generic
         // copy so the push-recovery panel drives the fix.
-        const isSyncConflict = isCreatePrIntentSyncConflictError(remoteError)
+        const failureNoticeKind = resolveCreatePrIntentRemoteFailureNoticeKind(remoteError)
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
           tone: 'destructive',
-          message: isSyncConflict
-            ? translate(
-                'auto.components.right.sidebar.SourceControl.createPrIntentSyncConflicts',
-                'Sync hit conflicts. Resolve them, then retry Create PR.'
-              )
-            : translate(
-                'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
-                'Could not update the remote branch. Retry Create PR.'
-              )
+          message:
+            failureNoticeKind === 'sync_conflict'
+              ? translate(
+                  'auto.components.right.sidebar.SourceControl.createPrIntentSyncConflicts',
+                  'Sync hit conflicts. Resolve them, then retry Create PR.'
+                )
+              : translate(
+                  'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
+                  'Could not update the remote branch. Retry Create PR.'
+                )
         })
         return
       }

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -258,8 +258,7 @@ import {
   createPrIntentRunTokenMatches,
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
-  resolveCreatePrIntentProgressStep,
-  resolveCreatePrIntentRemoteFailureNoticeKind,
+  isCreatePrIntentSyncConflictError,
   resolveCreatePrIntentReviewBase,
   resolveCreatePrIntentRemoteStep,
   type CreatePrIntentRunToken
@@ -1083,12 +1082,6 @@ function SourceControlInner(): React.JSX.Element {
     Record<string, SourceControlActionError | null>
   >({})
   const remoteActionErrorSequenceByWorktreeRef = useRef<Record<string, number>>({})
-  // Why: runCreatePrIntent closes over a stale `remoteActionErrors` (it is not a
-  // callback dep), so mirror the latest remote-action failure into a ref the
-  // intent runner can read synchronously after runRemoteAction resolves.
-  const lastRemoteActionErrorByWorktreeRef = useRef<
-    Record<string, SourceControlActionError | null>
-  >({})
   const previousConflictOperationsRef = useRef<Record<string, GitConflictOperation>>({})
   // Why: keep commit-in-flight state per-worktree. A single boolean would be
   // cleared when the user switched worktrees, letting them double-click Commit
@@ -2038,11 +2031,6 @@ function SourceControlInner(): React.JSX.Element {
         delete remoteActionErrorSequenceByWorktreeRef.current[key]
       }
     }
-    for (const key of Object.keys(lastRemoteActionErrorByWorktreeRef.current)) {
-      if (!worktreeMap.has(key)) {
-        delete lastRemoteActionErrorByWorktreeRef.current[key]
-      }
-    }
     for (const key of Object.keys(generateInFlightRef.current)) {
       if (!worktreeMap.has(key)) {
         delete generateInFlightRef.current[key]
@@ -2496,7 +2484,10 @@ function SourceControlInner(): React.JSX.Element {
         target?: SourceControlOperationTarget
         baseRef?: string | null
       }
-    ): Promise<boolean> => {
+      // Why: return the failure inline (null error = success or superseded) so
+      // callers like the Create PR intent flow can classify it without a
+      // stale-prone mirror of remoteActionErrors.
+    ): Promise<{ ok: boolean; error: SourceControlActionError | null }> => {
       const target =
         options?.target ??
         (activeWorktreeId && worktreePath
@@ -2509,7 +2500,7 @@ function SourceControlInner(): React.JSX.Element {
             }
           : null)
       if (!target) {
-        return false
+        return { ok: false, error: null }
       }
       const sequence = (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] ?? 0) + 1
       remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] = sequence
@@ -2524,7 +2515,6 @@ function SourceControlInner(): React.JSX.Element {
           : []
       )
       const failureBranchName = targetIsActiveWorktree ? branchName || null : null
-      lastRemoteActionErrorByWorktreeRef.current[target.worktreeId] = null
       setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
       try {
         if (kind === 'publish') {
@@ -2536,7 +2526,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { runtimeTargetSettings: target.settings }
           )
-          return true
+          return { ok: true, error: null }
         }
         if (kind === 'push') {
           // Why: kind 'push' must stay a regular push. Force-with-lease is only
@@ -2551,7 +2541,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { runtimeTargetSettings: target.settings }
           )
-          return true
+          return { ok: true, error: null }
         }
         if (kind === 'force_push') {
           await pushBranch(
@@ -2562,7 +2552,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { forceWithLease: true, runtimeTargetSettings: target.settings }
           )
-          return true
+          return { ok: true, error: null }
         }
         if (kind === 'pull') {
           await pullBranch(
@@ -2574,7 +2564,7 @@ function SourceControlInner(): React.JSX.Element {
               runtimeTargetSettings: target.settings
             }
           )
-          return true
+          return { ok: true, error: null }
         }
         if (kind === 'fast_forward') {
           await fastForwardBranch(
@@ -2584,7 +2574,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { runtimeTargetSettings: target.settings }
           )
-          return true
+          return { ok: true, error: null }
         }
         if (kind === 'fetch') {
           await fetchBranch(
@@ -2596,12 +2586,12 @@ function SourceControlInner(): React.JSX.Element {
               runtimeTargetSettings: target.settings
             }
           )
-          return true
+          return { ok: true, error: null }
         }
         if (kind === 'rebase') {
           const baseRef = options?.baseRef ?? effectiveBaseRef
           if (!baseRef) {
-            return false
+            return { ok: false, error: null }
           }
           await rebaseFromBase(
             target.worktreeId,
@@ -2611,7 +2601,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { runtimeTargetSettings: target.settings }
           )
-          return true
+          return { ok: true, error: null }
         }
         await syncBranch(
           target.worktreeId,
@@ -2623,17 +2613,16 @@ function SourceControlInner(): React.JSX.Element {
           }
         )
         if (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] === sequence) {
-          lastRemoteActionErrorByWorktreeRef.current[target.worktreeId] = null
           setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
         }
-        return true
+        return { ok: true, error: null }
       } catch (error) {
         // Why: remote action failures are surfaced by editor-slice actions to keep
         // one consistent toast path and avoid duplicate notifications in the UI.
         // Keep the latest failure inline too: dropdown-only actions like Fetch can
         // otherwise look like nothing happened once the menu closes.
         if (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] !== sequence) {
-          return false
+          return { ok: false, error: null }
         }
         const actionError: SourceControlActionError = {
           kind,
@@ -2646,9 +2635,8 @@ function SourceControlInner(): React.JSX.Element {
           entriesSnapshotTotalCount: recoveryEntrySnapshot.totalCount,
           sequence
         }
-        lastRemoteActionErrorByWorktreeRef.current[target.worktreeId] = actionError
         setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: actionError }))
-        return false
+        return { ok: false, error: actionError }
       } finally {
         if (!options?.target) {
           refreshSourceControlAfterRemoteAction({
@@ -4027,36 +4015,40 @@ function SourceControlInner(): React.JSX.Element {
         hasCurrentBranch: Boolean(token.branch)
       })
       if (remoteStep === 'blocked' || remoteStep === 'none') {
-        // Why: `needs_sync` now resolves to the auto 'sync'/'force_push' steps, so
-        // it never reaches this branch — the remaining blockers are simply not
-        // ready to create a review (e.g. auth_required, default_branch).
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
           tone: 'muted',
-          message: translate(
-            'auto.components.right.sidebar.SourceControl.createPrIntentBranchNotReady',
-            'Branch is not ready to create a review yet.'
-          )
+          // Why: a diverged branch is deliberately not auto-synced (that would
+          // merge without consent), so keep the explicit sync-first guidance.
+          message:
+            eligibility.blockedReason === 'needs_sync'
+              ? translate(
+                  'auto.components.right.sidebar.SourceControl.createPrIntentNeedsSync',
+                  'Sync this branch before creating a review.'
+                )
+              : translate(
+                  'auto.components.right.sidebar.SourceControl.createPrIntentBranchNotReady',
+                  'Branch is not ready to create a review yet.'
+                )
         })
         return
       }
 
-      const progressStep = resolveCreatePrIntentProgressStep(remoteStep)
       setCreatePrIntentNoticeForWorktree(token.worktreeId, {
         tone: 'muted',
         // Why: keep each translate() call on a string-literal key so the
         // localization-catalog verifier can statically detect every key.
         message:
-          progressStep === 'publish'
+          remoteStep === 'publish'
             ? translate(
                 'auto.components.right.sidebar.SourceControl.createPrIntentPublishing',
                 'Publishing branch…'
               )
-            : progressStep === 'force_push'
+            : remoteStep === 'force_push'
               ? translate(
                   'auto.components.right.sidebar.SourceControl.createPrIntentForcePushing',
                   'Force pushing with lease…'
                 )
-              : progressStep === 'sync'
+              : remoteStep === 'sync'
                 ? translate(
                     'auto.components.right.sidebar.SourceControl.createPrIntentSyncing',
                     'Syncing branch…'
@@ -4066,30 +4058,27 @@ function SourceControlInner(): React.JSX.Element {
                     'Pushing commits…'
                   )
       })
-      const remoteOk = await runRemoteAction(remoteStep, {
+      const remoteResult = await runRemoteAction(remoteStep, {
         target: operationTarget,
         baseRef: token.baseRef
       })
       if (abortIfStale()) {
         return
       }
-      if (!remoteOk) {
-        const remoteError = lastRemoteActionErrorByWorktreeRef.current[token.worktreeId]
+      if (!remoteResult.ok) {
         // A sync push-stage rejection is not a conflict — it falls to the generic
         // copy so the push-recovery panel drives the fix.
-        const failureNoticeKind = resolveCreatePrIntentRemoteFailureNoticeKind(remoteError)
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
           tone: 'destructive',
-          message:
-            failureNoticeKind === 'sync_conflict'
-              ? translate(
-                  'auto.components.right.sidebar.SourceControl.createPrIntentSyncConflicts',
-                  'Sync hit conflicts. Resolve them, then retry Create PR.'
-                )
-              : translate(
-                  'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
-                  'Could not update the remote branch. Retry Create PR.'
-                )
+          message: isCreatePrIntentSyncConflictError(remoteResult.error)
+            ? translate(
+                'auto.components.right.sidebar.SourceControl.createPrIntentSyncConflicts',
+                'Sync hit conflicts. Resolve them, then retry Create PR.'
+              )
+            : translate(
+                'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
+                'Could not update the remote branch. Retry Create PR.'
+              )
         })
         return
       }

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
@@ -7,6 +7,7 @@ import {
   createPrIntentRunTokenMatches,
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
+  isCreatePrIntentSyncConflictError,
   resolveCreatePrIntentReviewBase,
   resolveCreatePrIntentRemoteStep
 } from './source-control-create-pr-intent-flow'
@@ -229,7 +230,7 @@ describe('source-control Create PR intent flow helpers', () => {
     ).toBe('force_push')
   })
 
-  it('blocks ordinary diverged branches and unpublished branches without commits', () => {
+  it('syncs ordinary behind branches and blocks unpublished branches without commits', () => {
     expect(
       resolveCreatePrIntentRemoteStep({
         upstreamStatus: { hasUpstream: true, ahead: 1, behind: 1 },
@@ -242,7 +243,22 @@ describe('source-control Create PR intent flow helpers', () => {
           nextAction: 'sync'
         }
       })
-    ).toBe('blocked')
+    ).toBe('sync')
+
+    // Behind with no local commits (pure fast-forward case) also auto-syncs.
+    expect(
+      resolveCreatePrIntentRemoteStep({
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 3 },
+        hasCurrentBranch: true,
+        hostedReviewCreation: {
+          provider: 'github',
+          review: null,
+          canCreate: false,
+          blockedReason: 'needs_sync',
+          nextAction: 'sync'
+        }
+      })
+    ).toBe('sync')
 
     expect(
       resolveCreatePrIntentRemoteStep({
@@ -277,5 +293,56 @@ describe('source-control Create PR intent flow helpers', () => {
         withSummary: (summary) => `localized ${summary}`
       })
     ).toBe('localized Pre-commit hook failed.')
+  })
+
+  it('treats only a genuine merge-conflict sync failure as a conflict for notice copy', () => {
+    // Pull/merge conflict from this sync: the user must resolve conflicts.
+    expect(
+      isCreatePrIntentSyncConflictError({
+        kind: 'sync',
+        syncPushStage: false,
+        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
+      })
+    ).toBe(true)
+    // An unconcluded prior merge also counts as a conflict to resolve.
+    expect(
+      isCreatePrIntentSyncConflictError({
+        kind: 'sync',
+        rawError: 'error: you have not concluded your merge (MERGE_HEAD exists).'
+      })
+    ).toBe(true)
+
+    // A fetch/network/auth failure during sync is NOT a conflict, even though it
+    // is not marked as the push stage — it must fall to the generic copy.
+    expect(
+      isCreatePrIntentSyncConflictError({
+        kind: 'sync',
+        syncPushStage: false,
+        rawError: 'fatal: Authentication failed for remote'
+      })
+    ).toBe(false)
+    // No raw error at all is not a conflict.
+    expect(isCreatePrIntentSyncConflictError({ kind: 'sync' })).toBe(false)
+
+    // Push-stage rejection during sync is a push failure, not a conflict.
+    expect(
+      isCreatePrIntentSyncConflictError({
+        kind: 'sync',
+        syncPushStage: true,
+        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
+      })
+    ).toBe(false)
+
+    // Non-sync remote failures never use the conflict copy.
+    expect(isCreatePrIntentSyncConflictError({ kind: 'push' })).toBe(false)
+    expect(
+      isCreatePrIntentSyncConflictError({
+        kind: 'force_push',
+        syncPushStage: false,
+        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
+      })
+    ).toBe(false)
+    expect(isCreatePrIntentSyncConflictError(null)).toBe(false)
+    expect(isCreatePrIntentSyncConflictError(undefined)).toBe(false)
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
@@ -8,8 +8,6 @@ import {
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
   isCreatePrIntentSyncConflictError,
-  resolveCreatePrIntentProgressStep,
-  resolveCreatePrIntentRemoteFailureNoticeKind,
   resolveCreatePrIntentReviewBase,
   resolveCreatePrIntentRemoteStep
 } from './source-control-create-pr-intent-flow'
@@ -232,7 +230,9 @@ describe('source-control Create PR intent flow helpers', () => {
     ).toBe('force_push')
   })
 
-  it('syncs ordinary behind branches and blocks unpublished branches without commits', () => {
+  it('syncs behind-only branches, blocks diverged and unpublished-without-commits branches', () => {
+    // Genuinely diverged (local + non-equivalent remote commits): auto-syncing
+    // would merge without consent, so the intent flow keeps the explicit stop.
     expect(
       resolveCreatePrIntentRemoteStep({
         upstreamStatus: { hasUpstream: true, ahead: 1, behind: 1 },
@@ -245,9 +245,9 @@ describe('source-control Create PR intent flow helpers', () => {
           nextAction: 'sync'
         }
       })
-    ).toBe('sync')
+    ).toBe('blocked')
 
-    // Behind with no local commits (pure fast-forward case) also auto-syncs.
+    // Behind with no local commits (pure fast-forward case) auto-syncs.
     expect(
       resolveCreatePrIntentRemoteStep({
         upstreamStatus: { hasUpstream: true, ahead: 0, behind: 3 },
@@ -372,44 +372,5 @@ describe('source-control Create PR intent flow helpers', () => {
         rawError: "error: path 'src/app.ts' needs merge"
       })
     ).toBe(true)
-  })
-
-  it('maps each actionable remote step to its progress notice', () => {
-    expect(resolveCreatePrIntentProgressStep('publish')).toBe('publish')
-    expect(resolveCreatePrIntentProgressStep('force_push')).toBe('force_push')
-    expect(resolveCreatePrIntentProgressStep('sync')).toBe('sync')
-    // 'push' and any step that is not publish/force_push/sync render the push copy.
-    expect(resolveCreatePrIntentProgressStep('push')).toBe('push')
-    expect(resolveCreatePrIntentProgressStep('blocked')).toBe('push')
-    expect(resolveCreatePrIntentProgressStep('none')).toBe('push')
-  })
-
-  it('picks the sync-conflict notice only for a genuine sync merge conflict', () => {
-    expect(
-      resolveCreatePrIntentRemoteFailureNoticeKind({
-        kind: 'sync',
-        syncPushStage: false,
-        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
-      })
-    ).toBe('sync_conflict')
-    // Push-stage sync rejection -> generic copy so push recovery drives the fix.
-    expect(
-      resolveCreatePrIntentRemoteFailureNoticeKind({
-        kind: 'sync',
-        syncPushStage: true,
-        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
-      })
-    ).toBe('remote_failed')
-    // Fetch/auth failures and missing errors -> generic copy.
-    expect(
-      resolveCreatePrIntentRemoteFailureNoticeKind({
-        kind: 'sync',
-        syncPushStage: false,
-        rawError: 'fatal: Authentication failed for remote'
-      })
-    ).toBe('remote_failed')
-    expect(resolveCreatePrIntentRemoteFailureNoticeKind({ kind: 'push' })).toBe('remote_failed')
-    expect(resolveCreatePrIntentRemoteFailureNoticeKind(null)).toBe('remote_failed')
-    expect(resolveCreatePrIntentRemoteFailureNoticeKind(undefined)).toBe('remote_failed')
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
@@ -8,6 +8,8 @@ import {
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
   isCreatePrIntentSyncConflictError,
+  resolveCreatePrIntentProgressStep,
+  resolveCreatePrIntentRemoteFailureNoticeKind,
   resolveCreatePrIntentReviewBase,
   resolveCreatePrIntentRemoteStep
 } from './source-control-create-pr-intent-flow'
@@ -344,5 +346,70 @@ describe('source-control Create PR intent flow helpers', () => {
     ).toBe(false)
     expect(isCreatePrIntentSyncConflictError(null)).toBe(false)
     expect(isCreatePrIntentSyncConflictError(undefined)).toBe(false)
+  })
+
+  it('recognizes every merge-conflict wording git can emit during sync', () => {
+    // The fresh-conflict pattern's other alternatives: "Automatic merge failed"
+    // and "fix conflicts" are the most common real pull output.
+    expect(
+      isCreatePrIntentSyncConflictError({
+        kind: 'sync',
+        syncPushStage: false,
+        rawError: 'Automatic merge failed; fix conflicts and then commit the result.'
+      })
+    ).toBe(true)
+    // The unconcluded-merge pattern's other alternatives: "unmerged files" and
+    // "needs merge".
+    expect(
+      isCreatePrIntentSyncConflictError({
+        kind: 'sync',
+        rawError: 'error: Pulling is not possible because you have unmerged files.'
+      })
+    ).toBe(true)
+    expect(
+      isCreatePrIntentSyncConflictError({
+        kind: 'sync',
+        rawError: "error: path 'src/app.ts' needs merge"
+      })
+    ).toBe(true)
+  })
+
+  it('maps each actionable remote step to its progress notice', () => {
+    expect(resolveCreatePrIntentProgressStep('publish')).toBe('publish')
+    expect(resolveCreatePrIntentProgressStep('force_push')).toBe('force_push')
+    expect(resolveCreatePrIntentProgressStep('sync')).toBe('sync')
+    // 'push' and any step that is not publish/force_push/sync render the push copy.
+    expect(resolveCreatePrIntentProgressStep('push')).toBe('push')
+    expect(resolveCreatePrIntentProgressStep('blocked')).toBe('push')
+    expect(resolveCreatePrIntentProgressStep('none')).toBe('push')
+  })
+
+  it('picks the sync-conflict notice only for a genuine sync merge conflict', () => {
+    expect(
+      resolveCreatePrIntentRemoteFailureNoticeKind({
+        kind: 'sync',
+        syncPushStage: false,
+        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
+      })
+    ).toBe('sync_conflict')
+    // Push-stage sync rejection -> generic copy so push recovery drives the fix.
+    expect(
+      resolveCreatePrIntentRemoteFailureNoticeKind({
+        kind: 'sync',
+        syncPushStage: true,
+        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
+      })
+    ).toBe('remote_failed')
+    // Fetch/auth failures and missing errors -> generic copy.
+    expect(
+      resolveCreatePrIntentRemoteFailureNoticeKind({
+        kind: 'sync',
+        syncPushStage: false,
+        rawError: 'fatal: Authentication failed for remote'
+      })
+    ).toBe('remote_failed')
+    expect(resolveCreatePrIntentRemoteFailureNoticeKind({ kind: 'push' })).toBe('remote_failed')
+    expect(resolveCreatePrIntentRemoteFailureNoticeKind(null)).toBe('remote_failed')
+    expect(resolveCreatePrIntentRemoteFailureNoticeKind(undefined)).toBe('remote_failed')
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
@@ -147,10 +147,16 @@ export function resolveCreatePrIntentRemoteStep({
   }
 
   if (hostedReviewCreation.blockedReason === 'needs_sync') {
-    // Why: patch-equivalent divergence (extra remote commits already applied
-    // locally) resolves by force-pushing with lease; any other behind branch is
-    // resolved by running the existing sync (fetch → pull → conditional push).
-    return shouldForcePushWithLeaseForUpstream(upstreamStatus) ? 'force_push' : 'sync'
+    if (shouldForcePushWithLeaseForUpstream(upstreamStatus)) {
+      return 'force_push'
+    }
+    // Why: auto-sync only a behind-only branch, where the pull is a fast-forward
+    // that cannot create a merge commit or strand the worktree mid-merge. A
+    // genuinely diverged branch keeps the explicit sync-first stop so Create PR
+    // never merges without consent.
+    return upstreamStatus?.hasUpstream && upstreamStatus.ahead === 0 && upstreamStatus.behind > 0
+      ? 'sync'
+      : 'blocked'
   }
 
   return 'none'
@@ -172,27 +178,6 @@ export function isCreatePrIntentSyncConflictError(error: CreatePrIntentRemoteFai
     return false
   }
   return isMergeConflictErrorMessage(error.rawError ?? '')
-}
-
-// The actionable remote steps that show an in-progress notice while running.
-export type CreatePrIntentProgressStep = 'publish' | 'force_push' | 'sync' | 'push'
-
-export function resolveCreatePrIntentProgressStep(
-  remoteStep: CreatePrIntentRemoteStep
-): CreatePrIntentProgressStep {
-  // Why: 'blocked'/'none' are handled before this runs, so every remaining step
-  // is actionable; anything that is not publish/force_push/sync is a plain push.
-  return remoteStep === 'publish' || remoteStep === 'force_push' || remoteStep === 'sync'
-    ? remoteStep
-    : 'push'
-}
-
-export function resolveCreatePrIntentRemoteFailureNoticeKind(
-  error: CreatePrIntentRemoteFailure
-): 'sync_conflict' | 'remote_failed' {
-  // Why: only a genuine sync merge-conflict earns the "resolve conflicts" notice;
-  // push-stage rejections and fetch/network/auth failures fall to generic copy.
-  return isCreatePrIntentSyncConflictError(error) ? 'sync_conflict' : 'remote_failed'
 }
 
 export function getCreatePrIntentCommitFailureNoticeMessage(

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
@@ -156,13 +156,13 @@ export function resolveCreatePrIntentRemoteStep({
   return 'none'
 }
 
-export function isCreatePrIntentSyncConflictError(
-  error:
-    | (Pick<SourceControlActionError, 'kind' | 'syncPushStage'> &
-        Partial<Pick<SourceControlActionError, 'rawError'>>)
-    | null
-    | undefined
-): boolean {
+export type CreatePrIntentRemoteFailure =
+  | (Pick<SourceControlActionError, 'kind' | 'syncPushStage'> &
+      Partial<Pick<SourceControlActionError, 'rawError'>>)
+  | null
+  | undefined
+
+export function isCreatePrIntentSyncConflictError(error: CreatePrIntentRemoteFailure): boolean {
   // Why: only a genuine merge conflict earns the "resolve conflicts" copy. A
   // sync push-stage rejection is a push failure, and a fetch/network/auth
   // failure during sync is neither a conflict nor push-stage — both must fall
@@ -172,6 +172,27 @@ export function isCreatePrIntentSyncConflictError(
     return false
   }
   return isMergeConflictErrorMessage(error.rawError ?? '')
+}
+
+// The actionable remote steps that show an in-progress notice while running.
+export type CreatePrIntentProgressStep = 'publish' | 'force_push' | 'sync' | 'push'
+
+export function resolveCreatePrIntentProgressStep(
+  remoteStep: CreatePrIntentRemoteStep
+): CreatePrIntentProgressStep {
+  // Why: 'blocked'/'none' are handled before this runs, so every remaining step
+  // is actionable; anything that is not publish/force_push/sync is a plain push.
+  return remoteStep === 'publish' || remoteStep === 'force_push' || remoteStep === 'sync'
+    ? remoteStep
+    : 'push'
+}
+
+export function resolveCreatePrIntentRemoteFailureNoticeKind(
+  error: CreatePrIntentRemoteFailure
+): 'sync_conflict' | 'remote_failed' {
+  // Why: only a genuine sync merge-conflict earns the "resolve conflicts" notice;
+  // push-stage rejections and fetch/network/auth failures fall to generic copy.
+  return isCreatePrIntentSyncConflictError(error) ? 'sync_conflict' : 'remote_failed'
 }
 
 export function getCreatePrIntentCommitFailureNoticeMessage(

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
@@ -5,10 +5,18 @@ import {
   normalizeHostedReviewHeadRef
 } from '../../../../shared/hosted-review-refs'
 import type { GitStatusEntry, GitUpstreamStatus } from '../../../../shared/types'
+import { isMergeConflictErrorMessage } from '../../lib/source-control-remote-error'
+import type { SourceControlActionError } from './source-control-action-error'
 import { summarizeCommitFailure } from './commit-failure-summary'
 import { getStageAllPaths } from './discard-all-sequence'
 
-export type CreatePrIntentRemoteStep = 'publish' | 'push' | 'force_push' | 'blocked' | 'none'
+export type CreatePrIntentRemoteStep =
+  | 'publish'
+  | 'push'
+  | 'force_push'
+  | 'sync'
+  | 'blocked'
+  | 'none'
 
 export type CreatePrIntentRunToken = {
   repoId: string
@@ -138,18 +146,32 @@ export function resolveCreatePrIntentRemoteStep({
     return 'push'
   }
 
-  if (
-    hostedReviewCreation.blockedReason === 'needs_sync' &&
-    shouldForcePushWithLeaseForUpstream(upstreamStatus)
-  ) {
-    return 'force_push'
-  }
-
   if (hostedReviewCreation.blockedReason === 'needs_sync') {
-    return 'blocked'
+    // Why: patch-equivalent divergence (extra remote commits already applied
+    // locally) resolves by force-pushing with lease; any other behind branch is
+    // resolved by running the existing sync (fetch → pull → conditional push).
+    return shouldForcePushWithLeaseForUpstream(upstreamStatus) ? 'force_push' : 'sync'
   }
 
   return 'none'
+}
+
+export function isCreatePrIntentSyncConflictError(
+  error:
+    | (Pick<SourceControlActionError, 'kind' | 'syncPushStage'> &
+        Partial<Pick<SourceControlActionError, 'rawError'>>)
+    | null
+    | undefined
+): boolean {
+  // Why: only a genuine merge conflict earns the "resolve conflicts" copy. A
+  // sync push-stage rejection is a push failure, and a fetch/network/auth
+  // failure during sync is neither a conflict nor push-stage — both must fall
+  // to the generic remote-failed notice, so match the raw git output rather
+  // than assuming every non-push-stage sync failure is a conflict.
+  if (error?.kind !== 'sync' || error.syncPushStage === true) {
+    return false
+  }
+  return isMergeConflictErrorMessage(error.rawError ?? '')
 }
 
 export function getCreatePrIntentCommitFailureNoticeMessage(

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
@@ -71,6 +71,33 @@ describe('resolvePrimaryAction Create PR intent', () => {
     expect(result.disabled).toBe(false)
   })
 
+  it('returns Create PR intent for a behind-only branch (fast-forward sync)', () => {
+    const input = inputs({
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'origin/feature',
+        ahead: 0,
+        behind: 3
+      },
+      hostedReviewCreation: {
+        provider: 'github',
+        review: null,
+        canCreate: false,
+        blockedReason: 'needs_sync',
+        nextAction: 'sync'
+      }
+    })
+    const result = resolvePrimaryAction(input)
+    expect(result.kind).toBe('create_pr_intent')
+    expect(result.disabled).toBe(false)
+    expect(resolveCreatePrHeaderAction(input)).toEqual({
+      kind: 'create_pr_intent',
+      label: 'Create PR',
+      title: 'Prepare this branch and create a pull request',
+      disabled: false
+    })
+  })
+
   it('returns Create PR intent for a branch that needs a safe push before review', () => {
     const input = inputs({
       upstreamStatus: { hasUpstream: true, ahead: 2, behind: 0 },

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17442,6 +17442,11 @@ describe('connectPanePty', () => {
     const transport = createMockTransport('pty-replaced-codex')
     transportFactoryQueue.push(transport)
     vi.useFakeTimers()
+    // Why: the process-cadence poll interval carries ±10% Math.random jitter, so
+    // pin it to nominal cadence — otherwise the second null-foreground sample can
+    // land in the first advance window, confirming exit before the replacement
+    // hook owner is set and racing the very veto this test asserts.
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
     const getForegroundProcess = vi.mocked(window.api.pty.getForegroundProcess)
     getForegroundProcess.mockResolvedValue('codex')
     const paneKey = makePaneKey('tab-1', LEAF_1)
@@ -17499,6 +17504,7 @@ describe('connectPanePty', () => {
       RESET_TERMINAL_CURSOR_STYLE,
       expect.any(Function)
     )
+    randomSpy.mockRestore()
   })
 
   it('preserves replacement-agent title side effects through the process replacement veto', async () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9678,6 +9678,7 @@
             "createPrIntentConfigureAi": "Add a commit message or configure Source Control AI settings.",
             "createPrIntentGenerateFailed": "Could not generate a commit message. Add one and retry.",
             "createPrIntentCommitFailed": "Could not commit changes. Fix the issue, then retry Create PR.",
+            "createPrIntentNeedsSync": "Sync this branch before creating a review.",
             "createPrIntentBranchNotReady": "Branch is not ready to create a review yet.",
             "createPrIntentPublishing": "Publishing branch…",
             "createPrIntentForcePushing": "Force pushing with lease…",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9678,7 +9678,6 @@
             "createPrIntentConfigureAi": "Add a commit message or configure Source Control AI settings.",
             "createPrIntentGenerateFailed": "Could not generate a commit message. Add one and retry.",
             "createPrIntentCommitFailed": "Could not commit changes. Fix the issue, then retry Create PR.",
-            "createPrIntentNeedsSync": "Sync this branch before creating a review.",
             "createPrIntentBranchNotReady": "Branch is not ready to create a review yet.",
             "createPrIntentPublishing": "Publishing branch…",
             "createPrIntentForcePushing": "Force pushing with lease…",
@@ -9715,7 +9714,9 @@
               "a9bf7c171a": "Push Failed",
               "834cb3f23d": "Fix with AI",
               "783a808870": "Close"
-            }
+            },
+            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
+            "createPrIntentSyncing": "Syncing branch…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Could not start the selected agent.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9655,6 +9655,7 @@
             "createPrIntentConfigureAi": "Agrega un mensaje de commit o configura la IA de Source Control.",
             "createPrIntentGenerateFailed": "No se pudo generar un mensaje de commit. Agrega uno y vuelve a intentarlo.",
             "createPrIntentCommitFailed": "No se pudo hacer commit de los cambios. Corrige el issue y vuelve a intentar Crear PR.",
+            "createPrIntentNeedsSync": "Sincroniza esta rama antes de crear una revisión.",
             "createPrIntentBranchNotReady": "La rama aún no está lista para crear una revisión.",
             "createPrIntentPublishing": "Publicando rama…",
             "createPrIntentForcePushing": "Haciendo force push con lease…",
@@ -9692,8 +9693,8 @@
               "834cb3f23d": "Corregir con AI",
               "783a808870": "Cerrar"
             },
-            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
-            "createPrIntentSyncing": "Syncing branch…"
+            "createPrIntentSyncConflicts": "La sincronización encontró conflictos. Resuélvelos y vuelve a intentar Crear PR.",
+            "createPrIntentSyncing": "Sincronizando rama…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "No se pudo iniciar el agente seleccionado.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9655,7 +9655,6 @@
             "createPrIntentConfigureAi": "Agrega un mensaje de commit o configura la IA de Source Control.",
             "createPrIntentGenerateFailed": "No se pudo generar un mensaje de commit. Agrega uno y vuelve a intentarlo.",
             "createPrIntentCommitFailed": "No se pudo hacer commit de los cambios. Corrige el issue y vuelve a intentar Crear PR.",
-            "createPrIntentNeedsSync": "Sincroniza esta rama antes de crear una revisión.",
             "createPrIntentBranchNotReady": "La rama aún no está lista para crear una revisión.",
             "createPrIntentPublishing": "Publicando rama…",
             "createPrIntentForcePushing": "Haciendo force push con lease…",
@@ -9692,7 +9691,9 @@
               "a9bf7c171a": "Push fallido",
               "834cb3f23d": "Corregir con AI",
               "783a808870": "Cerrar"
-            }
+            },
+            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
+            "createPrIntentSyncing": "Syncing branch…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "No se pudo iniciar el agente seleccionado.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9655,7 +9655,6 @@
             "createPrIntentConfigureAi": "commit メッセージを追加するか、Source Control AI 設定を構成してください。",
             "createPrIntentGenerateFailed": "commit メッセージを生成できませんでした。追加してから再試行してください。",
             "createPrIntentCommitFailed": "変更を commit できませんでした。問題を修正してから Create PR を再試行してください。",
-            "createPrIntentNeedsSync": "レビューを作成する前にこのブランチを同期してください。",
             "createPrIntentBranchNotReady": "このブランチはまだレビューを作成できる状態ではありません。",
             "createPrIntentPublishing": "ブランチを公開中…",
             "createPrIntentForcePushing": "lease 付きで強制プッシュ中…",
@@ -9692,7 +9691,9 @@
               "a9bf7c171a": "プッシュ失敗",
               "834cb3f23d": "AIで修正",
               "783a808870": "閉じる"
-            }
+            },
+            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
+            "createPrIntentSyncing": "Syncing branch…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "選択した agent を開始できませんでした。",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9655,6 +9655,7 @@
             "createPrIntentConfigureAi": "commit メッセージを追加するか、Source Control AI 設定を構成してください。",
             "createPrIntentGenerateFailed": "commit メッセージを生成できませんでした。追加してから再試行してください。",
             "createPrIntentCommitFailed": "変更を commit できませんでした。問題を修正してから Create PR を再試行してください。",
+            "createPrIntentNeedsSync": "レビューを作成する前にこのブランチを同期してください。",
             "createPrIntentBranchNotReady": "このブランチはまだレビューを作成できる状態ではありません。",
             "createPrIntentPublishing": "ブランチを公開中…",
             "createPrIntentForcePushing": "lease 付きで強制プッシュ中…",
@@ -9692,8 +9693,8 @@
               "834cb3f23d": "AIで修正",
               "783a808870": "閉じる"
             },
-            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
-            "createPrIntentSyncing": "Syncing branch…"
+            "createPrIntentSyncConflicts": "同期で競合が発生しました。解決してから Create PR を再試行してください。",
+            "createPrIntentSyncing": "ブランチを同期中…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "選択した agent を開始できませんでした。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9655,6 +9655,7 @@
             "createPrIntentConfigureAi": "commit 메시지를 추가하거나 Source Control AI 설정을 구성하세요.",
             "createPrIntentGenerateFailed": "commit 메시지를 생성할 수 없습니다. 메시지를 추가한 다음 다시 시도하세요.",
             "createPrIntentCommitFailed": "변경 사항을 commit 할 수 없습니다. 문제를 수정한 다음 Create PR을 다시 시도하세요.",
+            "createPrIntentNeedsSync": "리뷰를 만들기 전에 이 브랜치를 동기화하세요.",
             "createPrIntentBranchNotReady": "브랜치가 아직 리뷰를 만들 준비가 되지 않았습니다.",
             "createPrIntentPublishing": "브랜치를 게시하는 중…",
             "createPrIntentForcePushing": "lease로 강제 푸시하는 중…",
@@ -9692,8 +9693,8 @@
               "834cb3f23d": "AI로 수정",
               "783a808870": "닫기"
             },
-            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
-            "createPrIntentSyncing": "Syncing branch…"
+            "createPrIntentSyncConflicts": "동기화 중 충돌이 발생했습니다. 해결한 다음 Create PR을 다시 시도하세요.",
+            "createPrIntentSyncing": "브랜치를 동기화하는 중…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "선택한 agent를 시작할 수 없습니다.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9655,7 +9655,6 @@
             "createPrIntentConfigureAi": "commit 메시지를 추가하거나 Source Control AI 설정을 구성하세요.",
             "createPrIntentGenerateFailed": "commit 메시지를 생성할 수 없습니다. 메시지를 추가한 다음 다시 시도하세요.",
             "createPrIntentCommitFailed": "변경 사항을 commit 할 수 없습니다. 문제를 수정한 다음 Create PR을 다시 시도하세요.",
-            "createPrIntentNeedsSync": "리뷰를 만들기 전에 이 브랜치를 동기화하세요.",
             "createPrIntentBranchNotReady": "브랜치가 아직 리뷰를 만들 준비가 되지 않았습니다.",
             "createPrIntentPublishing": "브랜치를 게시하는 중…",
             "createPrIntentForcePushing": "lease로 강제 푸시하는 중…",
@@ -9692,7 +9691,9 @@
               "a9bf7c171a": "푸시 실패",
               "834cb3f23d": "AI로 수정",
               "783a808870": "닫기"
-            }
+            },
+            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
+            "createPrIntentSyncing": "Syncing branch…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "선택한 agent를 시작할 수 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9655,7 +9655,6 @@
             "createPrIntentConfigureAi": "请添加提交信息或配置源代码管理 AI 设置。",
             "createPrIntentGenerateFailed": "无法生成提交信息。请添加一条信息后重试。",
             "createPrIntentCommitFailed": "无法提交更改。请修复问题后重试创建 PR。",
-            "createPrIntentNeedsSync": "创建评审前请先同步此分支。",
             "createPrIntentBranchNotReady": "分支尚未准备好创建评审。",
             "createPrIntentPublishing": "正在发布分支…",
             "createPrIntentForcePushing": "正在使用 lease 强制推送…",
@@ -9692,7 +9691,9 @@
               "a9bf7c171a": "推送失败",
               "834cb3f23d": "使用 AI 修复",
               "783a808870": "关闭"
-            }
+            },
+            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
+            "createPrIntentSyncing": "Syncing branch…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "无法启动选定的智能体。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9655,6 +9655,7 @@
             "createPrIntentConfigureAi": "请添加提交信息或配置源代码管理 AI 设置。",
             "createPrIntentGenerateFailed": "无法生成提交信息。请添加一条信息后重试。",
             "createPrIntentCommitFailed": "无法提交更改。请修复问题后重试创建 PR。",
+            "createPrIntentNeedsSync": "创建评审前请先同步此分支。",
             "createPrIntentBranchNotReady": "分支尚未准备好创建评审。",
             "createPrIntentPublishing": "正在发布分支…",
             "createPrIntentForcePushing": "正在使用 lease 强制推送…",
@@ -9692,8 +9693,8 @@
               "834cb3f23d": "使用 AI 修复",
               "783a808870": "关闭"
             },
-            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
-            "createPrIntentSyncing": "Syncing branch…"
+            "createPrIntentSyncConflicts": "同步遇到冲突。请解决后重试创建 PR。",
+            "createPrIntentSyncing": "正在同步分支…"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "无法启动选定的智能体。",

--- a/src/renderer/src/lib/source-control-remote-error.ts
+++ b/src/renderer/src/lib/source-control-remote-error.ts
@@ -110,6 +110,17 @@ export function isSyncPushStageError(error: unknown): boolean {
   )
 }
 
+// Why: detects "the working tree has merge conflicts the user must resolve" —
+// both an unconcluded prior merge and a fresh conflict from this operation.
+// Lets the Create PR flow tell a real sync conflict apart from a
+// fetch/network/auth/push failure that only looks similar.
+export function isMergeConflictErrorMessage(message: string): boolean {
+  return (
+    /unmerged files|needs merge|you have not concluded your merge/i.test(message) ||
+    /automatic merge failed|CONFLICT \(|fix conflicts/i.test(message)
+  )
+}
+
 export function resolveRemoteOperationErrorMessage(
   error: unknown,
   options?: RemoteOperationErrorOptions

--- a/src/renderer/src/lib/source-control-remote-error.ts
+++ b/src/renderer/src/lib/source-control-remote-error.ts
@@ -110,14 +110,21 @@ export function isSyncPushStageError(error: unknown): boolean {
   )
 }
 
+// Why: shared patterns so conflict classification and toast copy cannot drift.
+// Unconcluded prior merge vs. a fresh conflict from this operation produce
+// different user-facing messages, but Create PR treats both as "sync conflict".
+const UNCONCLUDED_MERGE_ERROR_PATTERN =
+  /unmerged files|needs merge|you have not concluded your merge/i
+const FRESH_MERGE_CONFLICT_ERROR_PATTERN = /automatic merge failed|CONFLICT \(|fix conflicts/i
+
 // Why: detects "the working tree has merge conflicts the user must resolve" —
 // both an unconcluded prior merge and a fresh conflict from this operation.
 // Lets the Create PR flow tell a real sync conflict apart from a
 // fetch/network/auth/push failure that only looks similar.
 export function isMergeConflictErrorMessage(message: string): boolean {
   return (
-    /unmerged files|needs merge|you have not concluded your merge/i.test(message) ||
-    /automatic merge failed|CONFLICT \(|fix conflicts/i.test(message)
+    UNCONCLUDED_MERGE_ERROR_PATTERN.test(message) ||
+    FRESH_MERGE_CONFLICT_ERROR_PATTERN.test(message)
   )
 }
 
@@ -129,7 +136,7 @@ export function resolveRemoteOperationErrorMessage(
     return REMOTE_OPERATION_FAILED_MESSAGE
   }
 
-  if (/unmerged files|needs merge|you have not concluded your merge/i.test(error.message)) {
+  if (UNCONCLUDED_MERGE_ERROR_PATTERN.test(error.message)) {
     if (options?.isRebase) {
       return 'Rebase blocked — resolve existing conflicts first.'
     }
@@ -138,7 +145,7 @@ export function resolveRemoteOperationErrorMessage(
       : 'Pull blocked — resolve existing merge conflicts first.'
   }
 
-  if (/automatic merge failed|CONFLICT \(|fix conflicts/i.test(error.message)) {
+  if (FRESH_MERGE_CONFLICT_ERROR_PATTERN.test(error.message)) {
     if (options?.isRebase) {
       return 'Rebase stopped with conflicts. Resolve them in Source Control, then continue the rebase.'
     }

--- a/src/shared/source-control-create-review-intent.ts
+++ b/src/shared/source-control-create-review-intent.ts
@@ -9,6 +9,7 @@ export type CreateReviewIntentKind =
   | 'message_required'
   | 'no_upstream'
   | 'needs_push'
+  | 'needs_sync'
   | 'force_push'
 
 export type CreateReviewIntentEligibility = {
@@ -69,6 +70,19 @@ export function resolveCreateReviewIntentEligibility({
     shouldForcePushWithLeaseForUpstream(upstreamStatus)
   ) {
     return { eligible: true, kind: 'force_push' }
+  }
+
+  // Why: a behind-only branch (no local commits) is safe to prepare with a
+  // fast-forward sync, so the intent flow can handle it in one click. A
+  // genuinely diverged branch stays ineligible — syncing it would merge
+  // without consent, so the user keeps the explicit sync-first step.
+  if (
+    hostedReviewCreation.blockedReason === 'needs_sync' &&
+    upstreamStatus?.hasUpstream === true &&
+    upstreamStatus.ahead === 0 &&
+    upstreamStatus.behind > 0
+  ) {
+    return { eligible: true, kind: 'needs_sync' }
   }
 
   return { eligible: false, kind: null }


### PR DESCRIPTION
## Summary

Create PR intent can prepare **behind-only** branches in one click instead of blocking with “Sync this branch first,” and remote-action failures are returned **inline** so the flow can classify them without a stale error mirror.

### What changed
- **Behind-only auto-prepare:** when hosted review is blocked on `needs_sync` and the branch is purely behind (ahead = 0), Create PR runs the remote prepare step instead of dead-ending.
- **Diverged branches stay blocked:** ahead + behind still requires explicit Sync so Create PR never merges without consent; patch-equivalent divergence still uses force-with-lease.
- **Inline remote errors:** `runRemoteAction` returns the failure object to callers (no `lastRemoteActionErrorByWorktreeRef` race).
- **Conflict vs generic copy:** distinguish genuine merge-conflict sync failures from push-stage / network / auth failures in the intent notice.
- **Also included:** keybinding write-path consolidation + legacy seed hardening; flaky process-replacement test pin for `Math.random`.

## Test plan
- [x] Unit tests for remote-step resolution, eligibility (`needs_sync` / behind-only), and conflict classifier
- [x] Keybinding seed / write tests
- [ ] Manually: clean branch behind upstream → Create PR fast-prepares and opens composer/review
- [ ] Manually: diverged branch still shows “Sync this branch before creating a review”
- [ ] Manually: dirty behind-only path (note: follow-up hardens this further)

## Follow-up
A safety fix landed locally after this squash: route behind-only through `git pull --ff-only` (not merge-capable `sync`), fast-forward **before** commit for dirty trees, and discriminate `runRemoteAction` outcomes (`ok` / `failed` / `superseded` / `skipped`). That will ship in a separate PR.