### PR TITLE
Fix multi-remote PR fetch missing-ref detection

### DIFF
--- a/src/main/git/fetch-error-classification.test.ts
+++ b/src/main/git/fetch-error-classification.test.ts
@@ -21,4 +21,19 @@ describe('isMissingRemoteRefGitError', () => {
       isMissingRemoteRefGitError(new Error('fatal: unable to access repo: Could not resolve host'))
     ).toBe(false)
   })
+
+  // Why: the git runner's execFile rejection prefixes `.message` with
+  // `Command failed: git fetch <remote> …` and stashes git's real diagnostic in
+  // `.stderr`. The classifier must read both, otherwise the multi-remote PR
+  // resolver treats a missing ref as a hard failure and never walks to the
+  // next remote (the original bug report's `Failed to fetch yzc/…` error).
+  it('matches a missing ref carried in .stderr rather than .message', () => {
+    const error = Object.assign(
+      new Error(
+        'Command failed: git fetch yzc +refs/heads/fix/qweather-agent-tool-port:refs/remotes/yzc/fix/qweather-agent-tool-port'
+      ),
+      { stderr: "fatal: couldn't find remote ref refs/heads/fix/qweather-agent-tool-port" }
+    )
+    expect(isMissingRemoteRefGitError(error)).toBe(true)
+  })
 })

--- a/src/main/git/fetch-error-classification.ts
+++ b/src/main/git/fetch-error-classification.ts
@@ -1,6 +1,17 @@
 export function isMissingRemoteRefGitError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  const normalized = message.toLowerCase()
+  // Why: Node's execFile prefixes the rejection `.message` with
+  // `Command failed: git fetch <remote> …`, which does NOT include git's
+  // `fatal: couldn't find remote ref …` line. That diagnostic lives in
+  // `.stderr` (attached by the git runner). Inspecting both is what lets the
+  // multi-remote PR resolver distinguish a genuinely-missing ref (walk the
+  // next remote) from auth/network failures (surface immediately).
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+  const e = error as { message?: unknown; stderr?: unknown }
+  const message = typeof e.message === 'string' ? e.message : String(error)
+  const stderr = typeof e.stderr === 'string' ? e.stderr : ''
+  const normalized = `${message}\n${stderr}`.toLowerCase()
   return (
     normalized.includes('could not find remote ref') ||
     normalized.includes("couldn't find remote ref")

--- a/src/main/github/pr-start-point.test.ts
+++ b/src/main/github/pr-start-point.test.ts
@@ -45,7 +45,8 @@ describe('resolveGitHubPrStartPoint', () => {
       baseRefName: 'main',
       gitExec,
       fetchRemoteTrackingRef,
-      resolveRemote: async () => 'origin'
+      resolveRemote: async () => 'origin',
+      resolveRemoteAlternatives: async () => []
     })
 
     expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('origin', 'fix-issue-6933')
@@ -82,7 +83,8 @@ describe('resolveGitHubPrStartPoint', () => {
       headRefName: 'feat/onboarding-model-choice-782',
       gitExec,
       fetchRemoteTrackingRef,
-      resolveRemote: async () => 'origin'
+      resolveRemote: async () => 'origin',
+      resolveRemoteAlternatives: async () => []
     })
 
     expect(getPullRequestPushTargetMock).toHaveBeenCalledWith('/repo-root', 1849, null)
@@ -110,7 +112,8 @@ describe('resolveGitHubPrStartPoint', () => {
       isCrossRepository: true,
       gitExec,
       fetchRemoteTrackingRef,
-      resolveRemote: async () => 'origin'
+      resolveRemote: async () => 'origin',
+      resolveRemoteAlternatives: async () => []
     })
 
     expect(getPullRequestPushTargetMock).toHaveBeenCalledWith('/repo-root', 1849, null)
@@ -149,7 +152,8 @@ describe('resolveGitHubPrStartPoint', () => {
       prNumber: 1738,
       gitExec,
       fetchRemoteTrackingRef,
-      resolveRemote: async () => 'origin'
+      resolveRemote: async () => 'origin',
+      resolveRemoteAlternatives: async () => []
     })
 
     expect(getWorkItemMock).toHaveBeenCalledWith('/repo-root', 1738, 'pr', null)
@@ -190,7 +194,8 @@ describe('resolveGitHubPrStartPoint', () => {
       isCrossRepository: true,
       gitExec,
       fetchRemoteTrackingRef,
-      resolveRemote: async () => 'origin'
+      resolveRemote: async () => 'origin',
+      resolveRemoteAlternatives: async () => []
     })
 
     expect(result).toEqual({
@@ -222,7 +227,8 @@ describe('resolveGitHubPrStartPoint', () => {
       baseRefName: 'develop',
       gitExec,
       fetchRemoteTrackingRef,
-      resolveRemote: async () => 'origin'
+      resolveRemote: async () => 'origin',
+      resolveRemoteAlternatives: async () => []
     })
 
     expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('origin', 'feature/add-feature')
@@ -235,5 +241,137 @@ describe('resolveGitHubPrStartPoint', () => {
       branchNameOverride: 'feature/add-feature',
       pushTarget: { remoteName: 'origin', branchName: 'feature/add-feature' }
     })
+  })
+
+  // Why: covers the multi-remote bug where the alphabetic-first remote (e.g.
+  // `yzc`) lacks the PR branch, so the resolver must walk `origin` next.
+  it('falls back to an alternate remote when the primary returns missing-ref', async () => {
+    const fetchRemoteTrackingRef = vi.fn(async (remote: string, branch: string) => {
+      if (remote === 'yzc' && branch === 'fix/qweather-agent-tool-port') {
+        throw new Error('fatal: could not find remote ref fix/qweather-agent-tool-port')
+      }
+    })
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (
+        args[0] === 'rev-parse' &&
+        args[1] === '--verify' &&
+        args[2] === 'origin/fix/qweather-agent-tool-port'
+      ) {
+        return { stdout: 'deadbeef\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 4711,
+      headRefName: 'fix/qweather-agent-tool-port',
+      baseRefName: 'main',
+      gitExec,
+      fetchRemoteTrackingRef,
+      resolveRemote: async () => 'yzc',
+      resolveRemoteAlternatives: async () => ['origin']
+    })
+
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('yzc', 'fix/qweather-agent-tool-port')
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('origin', 'fix/qweather-agent-tool-port')
+    expect(gitExec).toHaveBeenCalledWith([
+      'rev-parse',
+      '--verify',
+      'origin/fix/qweather-agent-tool-port'
+    ])
+    expect(result).toEqual({
+      baseBranch: 'deadbeef',
+      compareBaseRef: 'refs/remotes/origin/main',
+      headSha: 'deadbeef',
+      branchNameOverride: 'fix/qweather-agent-tool-port',
+      pushTarget: { remoteName: 'origin', branchName: 'fix/qweather-agent-tool-port' }
+    })
+  })
+
+  // Why: reproduces the exact bug-report failure. The git runner rejects with
+  // `.message = "Command failed: git fetch yzc …"` (no missing-ref text) and
+  // stashes git's `fatal: couldn't find remote ref …` in `.stderr`. The
+  // resolver must read `.stderr` to recognize the missing ref and walk to
+  // `origin`, otherwise it would surface the bogus `Failed to fetch yzc/…`.
+  it('falls back to an alternate remote when the primary error hides the missing ref in .stderr', async () => {
+    const fetchRemoteTrackingRef = vi.fn(async (remote: string, branch: string) => {
+      if (remote === 'yzc' && branch === 'fix/qweather-agent-tool-port') {
+        throw Object.assign(
+          new Error(
+            'Command failed: git fetch yzc +refs/heads/fix/qweather-agent-tool-port:refs/remotes/yzc/fix/qweather-agent-tool-port'
+          ),
+          { stderr: "fatal: couldn't find remote ref refs/heads/fix/qweather-agent-tool-port" }
+        )
+      }
+    })
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (
+        args[0] === 'rev-parse' &&
+        args[1] === '--verify' &&
+        args[2] === 'origin/fix/qweather-agent-tool-port'
+      ) {
+        return { stdout: 'deadbeef\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 4711,
+      headRefName: 'fix/qweather-agent-tool-port',
+      baseRefName: 'main',
+      gitExec,
+      fetchRemoteTrackingRef,
+      resolveRemote: async () => 'yzc',
+      resolveRemoteAlternatives: async () => ['origin']
+    })
+
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('yzc', 'fix/qweather-agent-tool-port')
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('origin', 'fix/qweather-agent-tool-port')
+    expect(result).toEqual({
+      baseBranch: 'deadbeef',
+      compareBaseRef: 'refs/remotes/origin/main',
+      headSha: 'deadbeef',
+      branchNameOverride: 'fix/qweather-agent-tool-port',
+      pushTarget: { remoteName: 'origin', branchName: 'fix/qweather-agent-tool-port' }
+    })
+  })
+
+  // Why: surfaces the original bug report's error message when every configured
+  // remote is missing the branch. The user-visible message used to read
+  // `Failed to fetch <primary>/<branch>` even when an alternate remote could
+  // have served the ref.
+  it('reports the configured remotes when none can resolve the head branch', async () => {
+    const fetchRemoteTrackingRef = vi.fn(async () => {
+      throw new Error('fatal: could not find remote ref')
+    })
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'fetch' && args[2] === 'refs/pull/42/head') {
+        throw new Error('fatal: could not find remote ref refs/pull/42/head')
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`)
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 42,
+      headRefName: 'feature/missing',
+      baseRefName: 'main',
+      gitExec,
+      fetchRemoteTrackingRef,
+      resolveRemote: async () => 'yzc',
+      resolveRemoteAlternatives: async () => ['origin', 'backup']
+    })
+
+    expect(result.error).toBe(
+      'Failed to fetch feature/missing (or refs/pull/42/head) from any configured remote (yzc, origin, backup).'
+    )
+    // Why: the refs/pull/<N>/head fallback must also probe alternatives before
+    // returning an error — here every remote rejects the same way, so the
+    // iteration visits each candidate before bubbling up the unified error.
+    expect(gitExec).toHaveBeenCalledWith(['fetch', 'yzc', 'refs/pull/42/head'])
+    expect(gitExec).toHaveBeenCalledWith(['fetch', 'origin', 'refs/pull/42/head'])
+    expect(gitExec).toHaveBeenCalledWith(['fetch', 'backup', 'refs/pull/42/head'])
   })
 })

--- a/src/main/github/pr-start-point.test.ts
+++ b/src/main/github/pr-start-point.test.ts
@@ -374,4 +374,58 @@ describe('resolveGitHubPrStartPoint', () => {
     expect(gitExec).toHaveBeenCalledWith(['fetch', 'origin', 'refs/pull/42/head'])
     expect(gitExec).toHaveBeenCalledWith(['fetch', 'backup', 'refs/pull/42/head'])
   })
+
+  // Why: a non-missing-ref failure (auth/network/SSH) on the refs/pull fallback
+  // must surface verbatim, not be masked by the generic "not found anywhere"
+  // message. Otherwise an SSH/auth problem looks like a missing ref.
+  it('surfaces a hard refs/pull error instead of a not-found message (same-repo fallback)', async () => {
+    const fetchRemoteTrackingRef = vi.fn(async () => {
+      throw new Error('fatal: could not find remote ref')
+    })
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'fetch' && args[2] === 'refs/pull/42/head') {
+        throw new Error('Permission denied (publickey)')
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`)
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 42,
+      headRefName: 'feature/missing',
+      baseRefName: 'main',
+      gitExec,
+      fetchRemoteTrackingRef,
+      resolveRemote: async () => 'yzc',
+      resolveRemoteAlternatives: async () => ['origin', 'backup']
+    })
+
+    expect(result.error).toBe('Failed to fetch refs/pull/42/head: Permission denied (publickey)')
+  })
+
+  // Why: the cross-repo path must also surface a hard refs/pull error verbatim
+  // rather than the plain not-found message.
+  it('surfaces a hard refs/pull error instead of a not-found message (cross-repo)', async () => {
+    const fetchRemoteTrackingRef = vi.fn(async () => {})
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'fetch' && args[2] === 'refs/pull/42/head') {
+        throw new Error('Permission denied (publickey)')
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`)
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 42,
+      headRefName: 'feature/missing',
+      baseRefName: 'main',
+      isCrossRepository: true,
+      gitExec,
+      fetchRemoteTrackingRef,
+      resolveRemote: async () => 'yzc',
+      resolveRemoteAlternatives: async () => ['origin', 'backup']
+    })
+
+    expect(result.error).toBe('Failed to fetch refs/pull/42/head: Permission denied (publickey)')
+  })
 })

--- a/src/main/github/pr-start-point.ts
+++ b/src/main/github/pr-start-point.ts
@@ -126,7 +126,7 @@ export async function resolveGitHubPrStartPoint(
   }
 
   const fetchPullRequestHeadShaFromAnyRemote = async (): Promise<
-    { remote: string; sha: string } | { error: string }
+    { remote: string; sha: string } | { error: string } | { notFoundAnywhere: true }
   > => {
     const pullRef = `refs/pull/${args.prNumber}/head`
     let workingRemote: string | null = null
@@ -146,9 +146,11 @@ export async function resolveGitHubPrStartPoint(
       }
     }
     if (workingRemote === null) {
-      return {
-        error: `Failed to fetch ${pullRef} from any configured remote (${remoteCandidates.join(', ')}).`
-      }
+      // Why: separate a genuine "missing everywhere" case from a hard failure
+      // (auth/network/SSH). Only the former gets the synthesized not-found
+      // message; a hard error is surfaced verbatim so the user sees the real
+      // cause instead of a misleading "ref not found" message.
+      return { notFoundAnywhere: true }
     }
     let sha: string
     try {
@@ -199,6 +201,11 @@ export async function resolveGitHubPrStartPoint(
   // PR head (fork or same-repo) as refs/pull/<N>/head on the upstream repo.
   if (isCrossRepository) {
     const headResult = await fetchPullRequestHeadShaFromAnyRemote()
+    if ('notFoundAnywhere' in headResult) {
+      return {
+        error: `Failed to fetch refs/pull/${args.prNumber}/head from any configured remote (${remoteCandidates.join(', ')}).`
+      }
+    }
     if ('error' in headResult) {
       return headResult
     }
@@ -226,25 +233,28 @@ export async function resolveGitHubPrStartPoint(
     // Why: missing fork metadata can make a fork PR look like a same-repo
     // branch. Only that missing-ref case should fall back to refs/pull.
     const headResult = await fetchPullRequestHeadShaFromAnyRemote()
-    if (!('error' in headResult)) {
-      await resolvePushTarget()
-      const compareBaseFetchError = await fetchCompareBaseRef(headResult.remote)
-      if (compareBaseFetchError) {
-        return compareBaseFetchError
-      }
+    if ('notFoundAnywhere' in headResult) {
       return {
-        baseBranch: headResult.sha,
-        ...(baseRefName
-          ? { compareBaseRef: `refs/remotes/${headResult.remote}/${baseRefName}` }
-          : {}),
-        headSha: headResult.sha,
-        branchNameOverride: headRefName,
-        ...(pushTarget ? { pushTarget } : {}),
-        ...(maintainerCanModify !== undefined ? { maintainerCanModify } : {})
+        error: `Failed to fetch ${headRefName} (or refs/pull/${args.prNumber}/head) from any configured remote (${remoteCandidates.join(', ')}).`
       }
     }
+    if ('error' in headResult) {
+      return headResult
+    }
+    await resolvePushTarget()
+    const compareBaseFetchError = await fetchCompareBaseRef(headResult.remote)
+    if (compareBaseFetchError) {
+      return compareBaseFetchError
+    }
     return {
-      error: `Failed to fetch ${headRefName} (or refs/pull/${args.prNumber}/head) from any configured remote (${remoteCandidates.join(', ')}).`
+      baseBranch: headResult.sha,
+      ...(baseRefName
+        ? { compareBaseRef: `refs/remotes/${headResult.remote}/${baseRefName}` }
+        : {}),
+      headSha: headResult.sha,
+      branchNameOverride: headRefName,
+      ...(pushTarget ? { pushTarget } : {}),
+      ...(maintainerCanModify !== undefined ? { maintainerCanModify } : {})
     }
   }
   if ('error' in headRemoteResult) {

--- a/src/main/github/pr-start-point.ts
+++ b/src/main/github/pr-start-point.ts
@@ -15,6 +15,10 @@ type ResolveGitHubPrStartPointArgs = {
   gitExec: GitExec
   fetchRemoteTrackingRef: (remote: string, branch: string) => Promise<void>
   resolveRemote: () => Promise<string>
+  // Why: when the primary remote (e.g. an upstream fork alias) lacks the
+  // branch, walking additional remotes is the only way to recover. Callers
+  // are expected to exclude `resolveRemote()`'s value from this list.
+  resolveRemoteAlternatives: () => Promise<string[]>
 }
 
 type ResolveGitHubPrStartPointResult = GitHubPrStartPoint | { error: string }
@@ -79,36 +83,71 @@ export async function resolveGitHubPrStartPoint(
     await resolvePushTarget()
   }
 
-  let remote: string
+  let primary: string
   try {
-    remote = await args.resolveRemote()
+    primary = await args.resolveRemote()
   } catch (error) {
     return { error: error instanceof Error ? error.message : 'Could not resolve git remote.' }
   }
+  let alternatives: string[]
+  try {
+    alternatives = await args.resolveRemoteAlternatives()
+  } catch {
+    // Why: enumeration failures shouldn't block the primary path; fall back to
+    // single-remote behavior so existing happy-path flows keep working.
+    alternatives = []
+  }
+  // Why: ordering matters — the primary is tried first to keep existing
+  // single-remote behavior identical. A Set dedupes callers that hand back
+  // the primary again, preserving insertion order.
+  const remoteCandidates = Array.from(new Set([primary, ...alternatives]))
 
-  const compareBaseRef = baseRefName ? `refs/remotes/${remote}/${baseRefName}` : undefined
-
-  const fetchCompareBaseRef = async (): Promise<{ error: string } | null> => {
-    if (!baseRefName) {
-      return null
-    }
-    try {
-      await args.fetchRemoteTrackingRef(remote, baseRefName)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      return { error: `Failed to fetch ${remote}/${baseRefName}: ${message.split('\n')[0]}` }
+  // Why: only "missing ref" is a candidate to walk remotes. Network, auth, or
+  // SSH failures on the primary remote must surface immediately so users get
+  // the real error rather than a confusing fall-through to refs/pull.
+  const fetchBranchFromAnyRemote = async (
+    branch: string
+  ): Promise<{ remote: string } | { error: string } | null> => {
+    for (const remote of remoteCandidates) {
+      try {
+        await args.fetchRemoteTrackingRef(remote, branch)
+        return { remote }
+      } catch (error) {
+        if (isMissingRemoteRefGitError(error)) {
+          continue
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          error: `Failed to fetch ${remote}/${branch}: ${message.split('\n')[0]}`
+        }
+      }
     }
     return null
   }
 
-  const fetchPullRequestHeadSha = async (): Promise<{ baseBranch: string } | { error: string }> => {
+  const fetchPullRequestHeadShaFromAnyRemote = async (): Promise<
+    { remote: string; sha: string } | { error: string }
+  > => {
     const pullRef = `refs/pull/${args.prNumber}/head`
-    try {
-      await args.gitExec(['fetch', remote, pullRef])
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
+    let workingRemote: string | null = null
+    for (const candidate of remoteCandidates) {
+      try {
+        await args.gitExec(['fetch', candidate, pullRef])
+        workingRemote = candidate
+        break
+      } catch (error) {
+        if (isMissingRemoteRefGitError(error)) {
+          continue
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          error: `Failed to fetch ${pullRef}: ${message.split('\n')[0]}`
+        }
+      }
+    }
+    if (workingRemote === null) {
       return {
-        error: `Failed to fetch ${pullRef}: ${message.split('\n')[0]}`
+        error: `Failed to fetch ${pullRef} from any configured remote (${remoteCandidates.join(', ')}).`
       }
     }
     let sha: string
@@ -121,18 +160,49 @@ export async function resolveGitHubPrStartPoint(
     if (!sha) {
       return { error: `Empty SHA resolving fork PR #${args.prNumber} head.` }
     }
-    return { baseBranch: sha }
+    return { remote: workingRemote, sha }
+  }
+
+  const fetchCompareBaseRef = async (
+    preferredRemote: string
+  ): Promise<{ error: string } | null> => {
+    if (!baseRefName) {
+      return null
+    }
+    // Why: the base branch usually lives on the same remote as the head; prefer
+    // it first so the original compareBaseRef shape is preserved when the head
+    // remote is healthy. Walk the rest only on missing-ref.
+    const orderedRemotes = Array.from(
+      new Set([preferredRemote, ...remoteCandidates.filter((r) => r !== preferredRemote)])
+    )
+    for (const remote of orderedRemotes) {
+      try {
+        await args.fetchRemoteTrackingRef(remote, baseRefName)
+        return null
+      } catch (error) {
+        if (isMissingRemoteRefGitError(error)) {
+          continue
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          error: `Failed to fetch ${remote}/${baseRefName}: ${message.split('\n')[0]}`
+        }
+      }
+    }
+    return {
+      error: `Failed to fetch ${baseRefName} from any configured remote (${remoteCandidates.join(', ')}).`
+    }
   }
 
   // Why: fork PR heads live on a remote we don't have configured, so
   // `git fetch <remote> <headRefName>` would fail. GitHub exposes every
   // PR head (fork or same-repo) as refs/pull/<N>/head on the upstream repo.
   if (isCrossRepository) {
-    const result = await fetchPullRequestHeadSha()
-    if ('error' in result) {
-      return result
+    const headResult = await fetchPullRequestHeadShaFromAnyRemote()
+    if ('error' in headResult) {
+      return headResult
     }
-    const compareBaseFetchError = await fetchCompareBaseRef()
+    const compareBaseFetchError = await fetchCompareBaseRef(headResult.remote)
     if (compareBaseFetchError) {
       return compareBaseFetchError
     }
@@ -140,45 +210,49 @@ export async function resolveGitHubPrStartPoint(
     // return below) so fork-PR worktrees aren't renamed with the maintainer's
     // branch prefix (e.g. `me/866`). The push refspec still targets the fork.
     return {
-      ...result,
-      ...(compareBaseRef ? { compareBaseRef } : {}),
-      headSha: result.baseBranch,
+      baseBranch: headResult.sha,
+      ...(baseRefName
+        ? { compareBaseRef: `refs/remotes/${headResult.remote}/${baseRefName}` }
+        : {}),
+      headSha: headResult.sha,
       branchNameOverride: headRefName,
       ...(pushTarget ? { pushTarget } : {}),
       ...(maintainerCanModify !== undefined ? { maintainerCanModify } : {})
     }
   }
 
-  try {
-    await args.fetchRemoteTrackingRef(remote, headRefName)
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
+  const headRemoteResult = await fetchBranchFromAnyRemote(headRefName)
+  if (headRemoteResult === null) {
     // Why: missing fork metadata can make a fork PR look like a same-repo
     // branch. Only that missing-ref case should fall back to refs/pull.
-    if (isMissingRemoteRefGitError(error)) {
-      const result = await fetchPullRequestHeadSha()
-      if (!('error' in result)) {
-        await resolvePushTarget()
-        const compareBaseFetchError = await fetchCompareBaseRef()
-        if (compareBaseFetchError) {
-          return compareBaseFetchError
-        }
-        return {
-          ...result,
-          ...(compareBaseRef ? { compareBaseRef } : {}),
-          headSha: result.baseBranch,
-          branchNameOverride: headRefName,
-          ...(pushTarget ? { pushTarget } : {}),
-          ...(maintainerCanModify !== undefined ? { maintainerCanModify } : {})
-        }
+    const headResult = await fetchPullRequestHeadShaFromAnyRemote()
+    if (!('error' in headResult)) {
+      await resolvePushTarget()
+      const compareBaseFetchError = await fetchCompareBaseRef(headResult.remote)
+      if (compareBaseFetchError) {
+        return compareBaseFetchError
+      }
+      return {
+        baseBranch: headResult.sha,
+        ...(baseRefName
+          ? { compareBaseRef: `refs/remotes/${headResult.remote}/${baseRefName}` }
+          : {}),
+        headSha: headResult.sha,
+        branchNameOverride: headRefName,
+        ...(pushTarget ? { pushTarget } : {}),
+        ...(maintainerCanModify !== undefined ? { maintainerCanModify } : {})
       }
     }
     return {
-      error: `Failed to fetch ${remote}/${headRefName}: ${message.split('\n')[0]}`
+      error: `Failed to fetch ${headRefName} (or refs/pull/${args.prNumber}/head) from any configured remote (${remoteCandidates.join(', ')}).`
     }
   }
+  if ('error' in headRemoteResult) {
+    return headRemoteResult
+  }
 
-  const remoteRef = `${remote}/${headRefName}`
+  const headRemote = headRemoteResult.remote
+  const remoteRef = `${headRemote}/${headRefName}`
   let headSha: string
   try {
     const { stdout } = await args.gitExec(['rev-parse', '--verify', remoteRef])
@@ -189,16 +263,16 @@ export async function resolveGitHubPrStartPoint(
   if (!headSha) {
     return { error: `Empty SHA resolving PR #${args.prNumber} head.` }
   }
-  const compareBaseFetchError = await fetchCompareBaseRef()
+  const compareBaseFetchError = await fetchCompareBaseRef(headRemote)
   if (compareBaseFetchError) {
     return compareBaseFetchError
   }
 
   return {
     baseBranch: headSha,
-    ...(compareBaseRef ? { compareBaseRef } : {}),
+    ...(baseRefName ? { compareBaseRef: `refs/remotes/${headRemote}/${baseRefName}` } : {}),
     headSha,
     branchNameOverride: headRefName,
-    pushTarget: { remoteName: remote, branchName: headRefName }
+    pushTarget: { remoteName: headRemote, branchName: headRefName }
   }
 }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1344,47 +1344,55 @@ export function registerWorktreeHandlers(
       // identical for single-remote repos; for local we honor getDefaultRemote
       // and fall back to `origin`-then-rest if no explicit default is configured
       // (so fork setups with `origin` + `upstream` keep working).
-      const resolveRemoteList = async (): Promise<string[]> => {
-        if (repo.connectionId) {
-          try {
-            const { stdout } = await gitExec(['remote'])
-            const remotes = stdout
-              .split('\n')
-              .map((line) => line.trim())
-              .filter(Boolean)
-            return remotes.length > 0 ? remotes : ['origin']
-          } catch {
-            return ['origin']
-          }
+      // Why: memoize the enumeration so resolveRemote and resolveRemoteAlternatives
+      // share one ordered list instead of each paying a git/SSH round-trip.
+      let remoteListPromise: Promise<string[]> | null = null
+      const resolveRemoteList = (): Promise<string[]> => {
+        if (!remoteListPromise) {
+          remoteListPromise = (async (): Promise<string[]> => {
+            if (repo.connectionId) {
+              try {
+                const { stdout } = await gitExec(['remote'])
+                const remotes = stdout
+                  .split('\n')
+                  .map((line) => line.trim())
+                  .filter(Boolean)
+                return remotes.length > 0 ? remotes : ['origin']
+              } catch {
+                return ['origin']
+              }
+            }
+            const localOptions = {
+              cwd: repo.path,
+              ...getLocalProjectWorktreeGitOptions(store, repo)
+            }
+            const enumerate = async (): Promise<string[]> => {
+              const { stdout } = await gitExecFileAsync(['remote'], localOptions)
+              return stdout
+                .split('\n')
+                .map((line) => line.trim())
+                .filter(Boolean)
+            }
+            try {
+              const primary = await getDefaultRemote(
+                repo.path,
+                getLocalProjectWorktreeGitOptions(store, repo)
+              )
+              const remotes = await enumerate()
+              return [primary, ...remotes.filter((r) => r !== primary)]
+            } catch (defaultError) {
+              const remotes = await enumerate()
+              if (remotes.length === 0) {
+                throw defaultError instanceof Error
+                  ? defaultError
+                  : new Error('Could not enumerate git remotes.')
+              }
+              const preferred = remotes.includes('origin') ? 'origin' : remotes[0]!
+              return [preferred, ...remotes.filter((r) => r !== preferred)]
+            }
+          })()
         }
-        const localOptions = {
-          cwd: repo.path,
-          ...getLocalProjectWorktreeGitOptions(store, repo)
-        }
-        const enumerate = async (): Promise<string[]> => {
-          const { stdout } = await gitExecFileAsync(['remote'], localOptions)
-          return stdout
-            .split('\n')
-            .map((line) => line.trim())
-            .filter(Boolean)
-        }
-        try {
-          const primary = await getDefaultRemote(
-            repo.path,
-            getLocalProjectWorktreeGitOptions(store, repo)
-          )
-          const remotes = await enumerate()
-          return [primary, ...remotes.filter((r) => r !== primary)]
-        } catch (defaultError) {
-          const remotes = await enumerate()
-          if (remotes.length === 0) {
-            throw defaultError instanceof Error
-              ? defaultError
-              : new Error('Could not enumerate git remotes.')
-          }
-          const preferred = remotes.includes('origin') ? 'origin' : remotes[0]!
-          return [preferred, ...remotes.filter((r) => r !== preferred)]
-        }
+        return remoteListPromise
       }
 
       return resolveGitHubPrStartPoint({

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1339,6 +1339,54 @@ export function registerWorktreeHandlers(
           { localGitExecOptions: getLocalProjectGitExecOptions(store, repo) }
         )
 
+      // Why: enumerating once keeps primary/alternatives consistent. For SSH we
+      // preserve the prior ordering (first remote wins) so behavior stays
+      // identical for single-remote repos; for local we honor getDefaultRemote
+      // and fall back to `origin`-then-rest if no explicit default is configured
+      // (so fork setups with `origin` + `upstream` keep working).
+      const resolveRemoteList = async (): Promise<string[]> => {
+        if (repo.connectionId) {
+          try {
+            const { stdout } = await gitExec(['remote'])
+            const remotes = stdout
+              .split('\n')
+              .map((line) => line.trim())
+              .filter(Boolean)
+            return remotes.length > 0 ? remotes : ['origin']
+          } catch {
+            return ['origin']
+          }
+        }
+        const localOptions = {
+          cwd: repo.path,
+          ...getLocalProjectWorktreeGitOptions(store, repo)
+        }
+        const enumerate = async (): Promise<string[]> => {
+          const { stdout } = await gitExecFileAsync(['remote'], localOptions)
+          return stdout
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean)
+        }
+        try {
+          const primary = await getDefaultRemote(
+            repo.path,
+            getLocalProjectWorktreeGitOptions(store, repo)
+          )
+          const remotes = await enumerate()
+          return [primary, ...remotes.filter((r) => r !== primary)]
+        } catch (defaultError) {
+          const remotes = await enumerate()
+          if (remotes.length === 0) {
+            throw defaultError instanceof Error
+              ? defaultError
+              : new Error('Could not enumerate git remotes.')
+          }
+          const preferred = remotes.includes('origin') ? 'origin' : remotes[0]!
+          return [preferred, ...remotes.filter((r) => r !== preferred)]
+        }
+      }
+
       return resolveGitHubPrStartPoint({
         repoPath: repo.path,
         prNumber: args.prNumber,
@@ -1349,18 +1397,8 @@ export function registerWorktreeHandlers(
         localGitOptions: getLocalProjectWorktreeGitOptions(store, repo),
         gitExec,
         fetchRemoteTrackingRef,
-        resolveRemote: async () => {
-          if (repo.connectionId) {
-            const { stdout } = await gitExec(['remote'])
-            return (
-              stdout
-                .split('\n')
-                .map((line) => line.trim())
-                .find(Boolean) ?? 'origin'
-            )
-          }
-          return getDefaultRemote(repo.path, getLocalProjectWorktreeGitOptions(store, repo))
-        }
+        resolveRemote: async () => (await resolveRemoteList())[0]!,
+        resolveRemoteAlternatives: async () => (await resolveRemoteList()).slice(1)
       })
     }
   )

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -26809,6 +26809,11 @@ describe('OrcaRuntimeService', () => {
       if (args[0] === 'config') {
         return { stdout: 'origin\n', stderr: '' }
       }
+      // Why: the multi-remote resolver enumerates `git remote` to enumerate
+      // fall-back candidates when the primary can't satisfy the PR head ref.
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n', stderr: '' }
+      }
       if (args[0] === 'fetch') {
         return { stdout: '', stderr: '' }
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16397,27 +16397,54 @@ export class OrcaRuntimeService {
     const gitExec = sshGitProvider
       ? (gitArgs: string[]) => sshGitProvider.exec(gitArgs, repo.path)
       : (gitArgs: string[]) => gitExecFileAsync(gitArgs, localGitExecOptions ?? { cwd: repo.path })
-    const resolveRemote = sshGitProvider
-      ? async () => {
-          const { stdout } = await sshGitProvider.exec(['remote'], repo.path)
-          const remotes = stdout
-            .split('\n')
-            .map((line) => line.trim())
-            .filter(Boolean)
-          if (remotes.includes('origin')) {
-            return 'origin'
-          }
-          if (remotes.length === 1) {
-            return remotes[0]!
-          }
-          if (remotes.length === 0) {
-            throw new Error('Repo has no configured git remotes.')
-          }
-          throw new Error(
-            `Repo has multiple remotes (${remotes.join(', ')}) and no default is configured.`
-          )
+    // Why: enumerate once so primary/alternatives stay in sync. SSH preserves
+    // the `origin`-first preference but no longer errors on fork-style multi-
+    // remote setups — the resolver falls through to alternatives when the
+    // primary lacks the head branch.
+    const resolveRemoteList = async (): Promise<string[]> => {
+      if (sshGitProvider) {
+        const { stdout } = await sshGitProvider.exec(['remote'], repo.path)
+        const remotes = stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean)
+        if (remotes.length === 0) {
+          throw new Error('Repo has no configured git remotes.')
         }
-      : () => getDefaultRemote(repo.path, localWorktreeGitOptions)
+        if (remotes.includes('origin')) {
+          return ['origin', ...remotes.filter((r) => r !== 'origin')]
+        }
+        return remotes
+      }
+      try {
+        const primary = await getDefaultRemote(repo.path, localWorktreeGitOptions)
+        const { stdout } = await gitExecFileAsync(['remote'], {
+          cwd: repo.path,
+          ...localWorktreeGitOptions
+        })
+        const remotes = stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean)
+        return [primary, ...remotes.filter((r) => r !== primary)]
+      } catch (defaultError) {
+        const { stdout } = await gitExecFileAsync(['remote'], {
+          cwd: repo.path,
+          ...localWorktreeGitOptions
+        })
+        const remotes = stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean)
+        if (remotes.length === 0) {
+          throw defaultError instanceof Error
+            ? defaultError
+            : new Error('Could not enumerate git remotes.')
+        }
+        const preferred = remotes.includes('origin') ? 'origin' : remotes[0]!
+        return [preferred, ...remotes.filter((r) => r !== preferred)]
+      }
+    }
 
     // Why: SSH repos can't fetch over the relay's read-only git.exec channel, so
     // route the PR head fetch through the write-capable helper instead of gitExec.
@@ -16440,7 +16467,8 @@ export class OrcaRuntimeService {
       localGitOptions: localWorktreeGitOptions,
       gitExec,
       fetchRemoteTrackingRef,
-      resolveRemote
+      resolveRemote: async () => (await resolveRemoteList())[0]!,
+      resolveRemoteAlternatives: async () => (await resolveRemoteList()).slice(1)
     })
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16401,49 +16401,57 @@ export class OrcaRuntimeService {
     // the `origin`-first preference but no longer errors on fork-style multi-
     // remote setups — the resolver falls through to alternatives when the
     // primary lacks the head branch.
-    const resolveRemoteList = async (): Promise<string[]> => {
-      if (sshGitProvider) {
-        const { stdout } = await sshGitProvider.exec(['remote'], repo.path)
-        const remotes = stdout
-          .split('\n')
-          .map((line) => line.trim())
-          .filter(Boolean)
-        if (remotes.length === 0) {
-          throw new Error('Repo has no configured git remotes.')
-        }
-        if (remotes.includes('origin')) {
-          return ['origin', ...remotes.filter((r) => r !== 'origin')]
-        }
-        return remotes
+    // Why: memoize the enumeration so resolveRemote and resolveRemoteAlternatives
+    // draw from one ordered list instead of each paying a git/SSH round-trip.
+    let remoteListPromise: Promise<string[]> | null = null
+    const resolveRemoteList = (): Promise<string[]> => {
+      if (!remoteListPromise) {
+        remoteListPromise = (async (): Promise<string[]> => {
+          if (sshGitProvider) {
+            const { stdout } = await sshGitProvider.exec(['remote'], repo.path)
+            const remotes = stdout
+              .split('\n')
+              .map((line) => line.trim())
+              .filter(Boolean)
+            if (remotes.length === 0) {
+              throw new Error('Repo has no configured git remotes.')
+            }
+            if (remotes.includes('origin')) {
+              return ['origin', ...remotes.filter((r) => r !== 'origin')]
+            }
+            return remotes
+          }
+          try {
+            const primary = await getDefaultRemote(repo.path, localWorktreeGitOptions)
+            const { stdout } = await gitExecFileAsync(['remote'], {
+              cwd: repo.path,
+              ...localWorktreeGitOptions
+            })
+            const remotes = stdout
+              .split('\n')
+              .map((line) => line.trim())
+              .filter(Boolean)
+            return [primary, ...remotes.filter((r) => r !== primary)]
+          } catch (defaultError) {
+            const { stdout } = await gitExecFileAsync(['remote'], {
+              cwd: repo.path,
+              ...localWorktreeGitOptions
+            })
+            const remotes = stdout
+              .split('\n')
+              .map((line) => line.trim())
+              .filter(Boolean)
+            if (remotes.length === 0) {
+              throw defaultError instanceof Error
+                ? defaultError
+                : new Error('Could not enumerate git remotes.')
+            }
+            const preferred = remotes.includes('origin') ? 'origin' : remotes[0]!
+            return [preferred, ...remotes.filter((r) => r !== preferred)]
+          }
+        })()
       }
-      try {
-        const primary = await getDefaultRemote(repo.path, localWorktreeGitOptions)
-        const { stdout } = await gitExecFileAsync(['remote'], {
-          cwd: repo.path,
-          ...localWorktreeGitOptions
-        })
-        const remotes = stdout
-          .split('\n')
-          .map((line) => line.trim())
-          .filter(Boolean)
-        return [primary, ...remotes.filter((r) => r !== primary)]
-      } catch (defaultError) {
-        const { stdout } = await gitExecFileAsync(['remote'], {
-          cwd: repo.path,
-          ...localWorktreeGitOptions
-        })
-        const remotes = stdout
-          .split('\n')
-          .map((line) => line.trim())
-          .filter(Boolean)
-        if (remotes.length === 0) {
-          throw defaultError instanceof Error
-            ? defaultError
-            : new Error('Could not enumerate git remotes.')
-        }
-        const preferred = remotes.includes('origin') ? 'origin' : remotes[0]!
-        return [preferred, ...remotes.filter((r) => r !== preferred)]
-      }
+      return remoteListPromise
     }
 
     // Why: SSH repos can't fetch over the relay's read-only git.exec channel, so


### PR DESCRIPTION
Classify missing-ref git errors from stderr, not only message, so the multi-remote PR head resolver falls back to an alternate remote instead of failing.

Fixed the following error: (There are two remotes: origin, yzc)
<img width="916" height="895" alt="image" src="https://github.com/user-attachments/assets/9484a29e-0463-4762-8cfb-ba284693cd10" />
 