### PR TITLE
feat(mobile): add option to wrap terminal accessory keys in multiple …

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -54,7 +54,9 @@ import {
   loadTerminalTextScale,
   HOST_DOCK_MIN_WIDTH,
   saveTerminalTextScale,
-  type MobileTerminalLinkOpenMode
+  type MobileTerminalLinkOpenMode,
+  loadTerminalAccessoryWrapMode,
+  type TerminalAccessoryWrapMode
 } from '../../../../src/storage/preferences'
 import {
   useHostClient,
@@ -903,6 +905,7 @@ export default function SessionScreen() {
   const [autocompleteEnabled, setAutocompleteEnabled] = useState(false)
   const [terminalLinkOpenMode, setTerminalLinkOpenMode] =
     useState<MobileTerminalLinkOpenMode>('orca-browser')
+  const [accessoryWrapMode, setAccessoryWrapMode] = useState<TerminalAccessoryWrapMode>('scroll')
   const [liveInputCapture, setLiveInputCapture] = useState('')
   const {
     clearTerminalLiveInputDefault,
@@ -2855,8 +2858,7 @@ export default function SessionScreen() {
     }, [connState, fetchSessionTabs, fetchTerminals])
   )
 
-  // Why: pick up the Settings → Terminal text size when returning here — the
-  // terminal panes stay mounted, so they update in place.
+  // Why: pick up local user preferences (text scale, autocomplete, link open mode, accessory layout) on focus.
   useFocusEffect(
     useCallback(() => {
       let active = true
@@ -2865,34 +2867,19 @@ export default function SessionScreen() {
           setTerminalTextScale(scale)
         }
       })
-      return () => {
-        active = false
-      }
-    }, [])
-  )
-
-  // Why: pick up the Settings → Terminal autocomplete toggle when returning here.
-  useFocusEffect(
-    useCallback(() => {
-      let active = true
       void loadTerminalAutocompleteEnabled().then((enabled) => {
         if (active) {
           setAutocompleteEnabled(enabled)
         }
       })
-      return () => {
-        active = false
-      }
-    }, [])
-  )
-
-  // Why: link routing is a phone-local choice; reload after Settings → Browser.
-  useFocusEffect(
-    useCallback(() => {
-      let active = true
       void loadTerminalLinkOpenMode().then((mode) => {
         if (active) {
           setTerminalLinkOpenMode(mode)
+        }
+      })
+      void loadTerminalAccessoryWrapMode().then((mode) => {
+        if (active) {
+          setAccessoryWrapMode(mode)
         }
       })
       return () => {
@@ -4884,7 +4871,12 @@ export default function SessionScreen() {
                 ]}
               >
                 {/* Accessory keys */}
-                <View style={styles.accessoryBar}>
+                <View
+                  style={[
+                    styles.accessoryBar,
+                    accessoryWrapMode === 'wrap' && { alignItems: 'flex-start' }
+                  ]}
+                >
                   {/* Why: a fixed, always-visible escape hatch from the open
                   keyboard. Kept outside the horizontal ScrollView so it does
                   not scroll away, and out of the terminal-byte shortcut path so
@@ -4915,169 +4907,183 @@ export default function SessionScreen() {
                   {/* Why: with default tap handling the first tap on any accessory
                   key dismisses the open keyboard and is swallowed, so live
                   input lost its keyboard on every Esc/Tab press (#5106). */}
-                  <ScrollView
-                    style={styles.accessoryScroll}
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    contentContainerStyle={styles.accessoryContent}
-                    keyboardShouldPersistTaps="always"
-                  >
-                    <Pressable
-                      style={({ pressed }) => [
-                        styles.accessoryKey,
-                        pressed && styles.accessoryKeyPressed,
-                        !canSend && styles.accessoryKeyDisabled
-                      ]}
-                      disabled={!canSend}
-                      onPress={() => {
-                        if (activeHandle) {
-                          void toggleDisplayMode(activeHandle)
-                        }
-                      }}
-                      accessibilityLabel={
-                        isPhoneMode(activeHandle)
-                          ? 'Switch to desktop mode'
-                          : 'Switch to phone mode'
-                      }
-                    >
-                      {isPhoneMode(activeHandle) ? (
-                        <Monitor
-                          size={14}
-                          color={canSend ? colors.textSecondary : colors.textMuted}
-                        />
-                      ) : (
-                        <Smartphone
-                          size={14}
-                          color={canSend ? colors.textSecondary : colors.textMuted}
-                        />
-                      )}
-                    </Pressable>
-                    <Pressable
-                      style={({ pressed }) => [
-                        styles.accessoryKey,
-                        liveInputEnabled && styles.accessoryKeyActive,
-                        pressed && styles.accessoryKeyPressed,
-                        !canSend && styles.accessoryKeyDisabled
-                      ]}
-                      disabled={!canSend}
-                      onPress={toggleLiveInput}
-                      accessibilityLabel={
-                        liveInputEnabled
-                          ? 'Switch to buffered command input'
-                          : 'Switch to live terminal input'
-                      }
-                    >
-                      <ChevronsRight
-                        size={14}
-                        color={
-                          liveInputEnabled
-                            ? colors.bgBase
-                            : canSend
-                              ? colors.textSecondary
-                              : colors.textMuted
-                        }
-                      />
-                    </Pressable>
-                    {canPaste && (
-                      <Pressable
-                        style={({ pressed }) => [
-                          styles.accessoryKey,
-                          pressed && styles.accessoryKeyPressed,
-                          !canSend && styles.accessoryKeyDisabled
-                        ]}
-                        disabled={!canSend}
-                        onPress={() => void handlePaste()}
-                        accessibilityLabel="Paste from clipboard"
-                      >
-                        <Text
-                          style={[
-                            styles.accessoryKeyText,
-                            !canSend && styles.accessoryKeyTextDisabled
+                  {(() => {
+                    const keys = (
+                      <>
+                        <Pressable
+                          style={({ pressed }) => [
+                            styles.accessoryKey,
+                            pressed && styles.accessoryKeyPressed,
+                            !canSend && styles.accessoryKeyDisabled
                           ]}
+                          disabled={!canSend}
+                          onPress={() => {
+                            if (activeHandle) {
+                              void toggleDisplayMode(activeHandle)
+                            }
+                          }}
+                          accessibilityLabel={
+                            isPhoneMode(activeHandle)
+                              ? 'Switch to desktop mode'
+                              : 'Switch to phone mode'
+                          }
                         >
-                          Paste
-                        </Text>
-                      </Pressable>
-                    )}
-                    {visibleBuiltInAccessoryKeys.map((key) => (
-                      <Pressable
-                        key={key.id}
-                        style={({ pressed }) => [
-                          styles.accessoryKey,
-                          pressed && styles.accessoryKeyPressed,
-                          !canSend && styles.accessoryKeyDisabled
-                        ]}
-                        disabled={!canSend}
-                        onPressIn={() => {
-                          if (!key.repeatable) {
-                            return
-                          }
-                          const input = createTerminalLiveAccessoryInput(key)
-                          void handleAccessoryKey(input)
-                          startAccessoryRepeat(input)
-                        }}
-                        onPressOut={() => {
-                          if (key.repeatable) {
-                            stopAccessoryRepeat()
-                          }
-                        }}
-                        onPress={() => {
-                          if (key.repeatable) {
-                            return
-                          }
-                          void handleAccessoryKey(createTerminalLiveAccessoryInput(key))
-                        }}
-                        accessibilityLabel={key.accessibilityLabel ?? `Send ${key.label}`}
-                      >
-                        <Text
-                          style={[
-                            styles.accessoryKeyText,
-                            !canSend && styles.accessoryKeyTextDisabled
+                          {isPhoneMode(activeHandle) ? (
+                            <Monitor
+                              size={14}
+                              color={canSend ? colors.textSecondary : colors.textMuted}
+                            />
+                          ) : (
+                            <Smartphone
+                              size={14}
+                              color={canSend ? colors.textSecondary : colors.textMuted}
+                            />
+                          )}
+                        </Pressable>
+                        <Pressable
+                          style={({ pressed }) => [
+                            styles.accessoryKey,
+                            liveInputEnabled && styles.accessoryKeyActive,
+                            pressed && styles.accessoryKeyPressed,
+                            !canSend && styles.accessoryKeyDisabled
                           ]}
+                          disabled={!canSend}
+                          onPress={toggleLiveInput}
+                          accessibilityLabel={
+                            liveInputEnabled
+                              ? 'Switch to buffered command input'
+                              : 'Switch to live terminal input'
+                          }
                         >
-                          {key.label}
-                        </Text>
-                      </Pressable>
-                    ))}
-                    {customKeys.map((key) => (
-                      <Pressable
-                        key={key.id}
-                        style={({ pressed }) => [
-                          styles.accessoryKey,
-                          styles.customAccessoryKey,
-                          pressed && styles.accessoryKeyPressed,
-                          !canSend && styles.accessoryKeyDisabled
-                        ]}
-                        disabled={!canSend}
-                        onPress={() => void handleAccessoryKey({ bytes: key.bytes })}
-                        onLongPress={() => {
-                          triggerMediumImpact()
-                          setDeleteKeyTarget(key)
-                        }}
-                        delayLongPress={400}
-                        accessibilityLabel={`Send ${key.label}`}
-                      >
-                        <Text
-                          style={[
-                            styles.accessoryKeyText,
-                            !canSend && styles.accessoryKeyTextDisabled
+                          <ChevronsRight
+                            size={14}
+                            color={
+                              liveInputEnabled
+                                ? colors.bgBase
+                                : canSend
+                                  ? colors.textSecondary
+                                  : colors.textMuted
+                            }
+                          />
+                        </Pressable>
+                        {canPaste && (
+                          <Pressable
+                            style={({ pressed }) => [
+                              styles.accessoryKey,
+                              pressed && styles.accessoryKeyPressed,
+                              !canSend && styles.accessoryKeyDisabled
+                            ]}
+                            disabled={!canSend}
+                            onPress={() => void handlePaste()}
+                            accessibilityLabel="Paste from clipboard"
+                          >
+                            <Text
+                              style={[
+                                styles.accessoryKeyText,
+                                !canSend && styles.accessoryKeyTextDisabled
+                              ]}
+                            >
+                              Paste
+                            </Text>
+                          </Pressable>
+                        )}
+                        {visibleBuiltInAccessoryKeys.map((key) => (
+                          <Pressable
+                            key={key.id}
+                            style={({ pressed }) => [
+                              styles.accessoryKey,
+                              pressed && styles.accessoryKeyPressed,
+                              !canSend && styles.accessoryKeyDisabled
+                            ]}
+                            disabled={!canSend}
+                            onPressIn={() => {
+                              if (!key.repeatable) {
+                                return
+                              }
+                              const input = createTerminalLiveAccessoryInput(key)
+                              void handleAccessoryKey(input)
+                              startAccessoryRepeat(input)
+                            }}
+                            onPressOut={() => {
+                              if (key.repeatable) {
+                                stopAccessoryRepeat()
+                              }
+                            }}
+                            onPress={() => {
+                              if (key.repeatable) {
+                                return
+                              }
+                              void handleAccessoryKey(createTerminalLiveAccessoryInput(key))
+                            }}
+                            accessibilityLabel={key.accessibilityLabel ?? `Send ${key.label}`}
+                          >
+                            <Text
+                              style={[
+                                styles.accessoryKeyText,
+                                !canSend && styles.accessoryKeyTextDisabled
+                              ]}
+                            >
+                              {key.label}
+                            </Text>
+                          </Pressable>
+                        ))}
+                        {customKeys.map((key) => (
+                          <Pressable
+                            key={key.id}
+                            style={({ pressed }) => [
+                              styles.accessoryKey,
+                              styles.customAccessoryKey,
+                              pressed && styles.accessoryKeyPressed,
+                              !canSend && styles.accessoryKeyDisabled
+                            ]}
+                            disabled={!canSend}
+                            onPress={() => void handleAccessoryKey({ bytes: key.bytes })}
+                            onLongPress={() => {
+                              triggerMediumImpact()
+                              setDeleteKeyTarget(key)
+                            }}
+                            delayLongPress={400}
+                            accessibilityLabel={`Send ${key.label}`}
+                          >
+                            <Text
+                              style={[
+                                styles.accessoryKeyText,
+                                !canSend && styles.accessoryKeyTextDisabled
+                              ]}
+                            >
+                              {key.label}
+                            </Text>
+                          </Pressable>
+                        ))}
+                        <Pressable
+                          style={({ pressed }) => [
+                            styles.accessoryKey,
+                            pressed && styles.accessoryKeyPressed
                           ]}
+                          onPress={() => setShowCustomKeyModal(true)}
+                          accessibilityLabel="Add custom shortcut"
                         >
-                          {key.label}
-                        </Text>
-                      </Pressable>
-                    ))}
-                    <Pressable
-                      style={({ pressed }) => [
-                        styles.accessoryKey,
-                        pressed && styles.accessoryKeyPressed
-                      ]}
-                      onPress={() => setShowCustomKeyModal(true)}
-                      accessibilityLabel="Add custom shortcut"
-                    >
-                      <Plus size={14} color={colors.textSecondary} strokeWidth={2.2} />
-                    </Pressable>
-                  </ScrollView>
+                          <Plus size={14} color={colors.textSecondary} strokeWidth={2.2} />
+                        </Pressable>
+                      </>
+                    )
+
+                    if (accessoryWrapMode === 'wrap') {
+                      return <View style={styles.accessoryWrap}>{keys}</View>
+                    }
+
+                    return (
+                      <ScrollView
+                        style={styles.accessoryScroll}
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={styles.accessoryContent}
+                        keyboardShouldPersistTaps="always"
+                      >
+                        {keys}
+                      </ScrollView>
+                    )
+                  })()}
                 </View>
 
                 {/* Input bar */}

--- a/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
+++ b/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
@@ -78,6 +78,14 @@ export const mobileSessionCommandInputStyles = StyleSheet.create({
     flex: 1,
     minWidth: 0
   },
+  accessoryWrap: {
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    gap: spacing.xs
+  },
   accessoryContent: {
     paddingHorizontal: spacing.sm,
     paddingVertical: spacing.xs,

--- a/mobile/app/terminal-settings.tsx
+++ b/mobile/app/terminal-settings.tsx
@@ -21,7 +21,10 @@ import {
   loadTerminalAutocompleteEnabled,
   loadTerminalTextScale,
   saveTerminalAutocompleteEnabled,
-  saveTerminalTextScale
+  saveTerminalTextScale,
+  loadTerminalAccessoryWrapMode,
+  saveTerminalAccessoryWrapMode,
+  type TerminalAccessoryWrapMode
 } from '../src/storage/preferences'
 
 type RestoreValue = 'indefinite' | '60s' | '5m' | '30m'
@@ -174,6 +177,26 @@ export default function TerminalSettingsScreen() {
     userToggledAutocompleteRef.current = true
     setAutocompleteEnabled(next)
     void saveTerminalAutocompleteEnabled(next)
+  }, [])
+
+  const [accessoryWrapMode, setAccessoryWrapMode] = useState<TerminalAccessoryWrapMode>('scroll')
+  const userToggledAccessoryWrapModeRef = useRef(false)
+  useEffect(() => {
+    let stale = false
+    void loadTerminalAccessoryWrapMode().then((mode) => {
+      if (!stale && !userToggledAccessoryWrapModeRef.current) {
+        setAccessoryWrapMode(mode)
+      }
+    })
+    return () => {
+      stale = true
+    }
+  }, [])
+  const toggleAccessoryWrapMode = useCallback((next: boolean) => {
+    userToggledAccessoryWrapModeRef.current = true
+    const mode: TerminalAccessoryWrapMode = next ? 'wrap' : 'scroll'
+    setAccessoryWrapMode(mode)
+    void saveTerminalAccessoryWrapMode(mode)
   }, [])
 
   useEffect(() => {
@@ -342,6 +365,21 @@ export default function TerminalSettingsScreen() {
             <Switch
               value={autocompleteEnabled}
               onValueChange={toggleAutocomplete}
+              trackColor={{ false: colors.bgRaised, true: colors.textSecondary }}
+              thumbColor={colors.textPrimary}
+            />
+          </View>
+          <View style={styles.separator} />
+          <View style={styles.row}>
+            <View style={styles.rowContent}>
+              <Text style={styles.rowLabel}>Wrap accessory keys</Text>
+              <Text style={styles.rowSublabel}>
+                {accessoryWrapMode === 'wrap' ? 'Wrap in multiple rows' : 'Scroll horizontally'}
+              </Text>
+            </View>
+            <Switch
+              value={accessoryWrapMode === 'wrap'}
+              onValueChange={toggleAccessoryWrapMode}
               trackColor={{ false: colors.bgRaised, true: colors.textSecondary }}
               thumbColor={colors.textPrimary}
             />

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -10,11 +10,13 @@ import {
   clampHostSidebarWidth,
   loadDisabledTerminalLiveInputHandles,
   loadHostSidebarWidth,
+  loadTerminalAccessoryWrapMode,
   loadTerminalAutocompleteEnabled,
   loadTerminalLinkOpenMode,
   readDisabledTerminalLiveInputHandlesPreference,
   saveDisabledTerminalLiveInputHandles,
   saveHostSidebarWidth,
+  saveTerminalAccessoryWrapMode,
   saveTerminalAutocompleteEnabled,
   saveTerminalLinkOpenMode
 } from './preferences'
@@ -201,5 +203,39 @@ describe('terminal link open mode preference', () => {
     await saveTerminalLinkOpenMode('phone-browser')
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith('orca:terminalLinkOpenMode', 'phone-browser')
+  })
+})
+
+describe('terminal accessory wrap mode preference', () => {
+  beforeEach(() => {
+    vi.mocked(AsyncStorage.getItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockReset()
+  })
+
+  it('defaults to scroll when unset', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(null)
+
+    await expect(loadTerminalAccessoryWrapMode()).resolves.toBe('scroll')
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('orca:terminalAccessoryWrapMode')
+  })
+
+  it('loads only known modes', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue('wrap')
+    await expect(loadTerminalAccessoryWrapMode()).resolves.toBe('wrap')
+
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue('sideways')
+    await expect(loadTerminalAccessoryWrapMode()).resolves.toBe('scroll')
+  })
+
+  it('falls back to scroll when storage cannot be read', async () => {
+    vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
+
+    await expect(loadTerminalAccessoryWrapMode()).resolves.toBe('scroll')
+  })
+
+  it('persists the selected mode', async () => {
+    await saveTerminalAccessoryWrapMode('wrap')
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('orca:terminalAccessoryWrapMode', 'wrap')
   })
 })

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -204,6 +204,26 @@ export async function saveTerminalLinkOpenMode(mode: MobileTerminalLinkOpenMode)
   await AsyncStorage.setItem(TERMINAL_LINK_OPEN_MODE_KEY, mode)
 }
 
+export type TerminalAccessoryWrapMode = 'scroll' | 'wrap'
+
+const TERMINAL_ACCESSORY_WRAP_MODE_KEY = 'orca:terminalAccessoryWrapMode'
+export const DEFAULT_TERMINAL_ACCESSORY_WRAP_MODE: TerminalAccessoryWrapMode = 'scroll'
+
+export async function loadTerminalAccessoryWrapMode(): Promise<TerminalAccessoryWrapMode> {
+  try {
+    const raw = await AsyncStorage.getItem(TERMINAL_ACCESSORY_WRAP_MODE_KEY)
+    return raw === 'wrap' || raw === 'scroll' ? raw : DEFAULT_TERMINAL_ACCESSORY_WRAP_MODE
+  } catch {
+    return DEFAULT_TERMINAL_ACCESSORY_WRAP_MODE
+  }
+}
+
+export async function saveTerminalAccessoryWrapMode(
+  mode: TerminalAccessoryWrapMode
+): Promise<void> {
+  await AsyncStorage.setItem(TERMINAL_ACCESSORY_WRAP_MODE_KEY, mode)
+}
+
 function stringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === 'string')


### PR DESCRIPTION
## Summary

Adds a toggle in Terminal settings to wrap the accessory keys onto multiple rows. Default is the current horizontal scroll; turning it on lays the keys out across rows instead.

## Screenshots
<img width="360" alt="Simulator Screenshot - Iphone17 gg - 2026-07-13 at 17 55 53" src="https://github.com/user-attachments/assets/452d04af-ce0f-4c30-ac4d-11ef52223f4b" />

<img width="360" alt="Simulator Screenshot - Iphone17 gg - 2026-07-13 at 17 55 46" src="https://github.com/user-attachments/assets/adc0a692-d539-4e4e-bdae-134b7f5af5b2" />



## Testing

- [x] `pnpm lint` (oxlint — clean)
- [x] `pnpm typecheck` (`tsc --noEmit` — no errors)
- [x] `pnpm test` (mobile: 1493 passed, 2 skipped)
- [ ] `pnpm build` — N/A: mobile-only change, targets desktop/native
- [x] Added tests for the new preference (default / whitelist / storage-error / persist), mirroring the existing link-open-mode suite
- [x] Manual test — wrap mode + open keyboard, first Esc/Tab tap registers without dismissing (#5106 not regressed). Android: physical device, iOS: Simulator

## AI Review Report

Reviewed with Codex and Claude. This is a pure RN layout + AsyncStorage change — it doesn't touch shortcuts, paths, shell, or Electron, and the key-send path is unchanged so local/SSH/remote behave the same. Codex flagged that renaming the storage key could drop saved values, but this setting is new in this PR so there's nothing persisted to migrate.

## Security Audit

The stored value is restricted to `'scroll' | 'wrap'` and falls back to the default otherwise. No command execution, path, auth, or IPC changes.

## Notes

Wrap is opt-in, so the default behavior is unchanged.

## ELI5

On mobile, accessory keys under the terminal used to only scroll sideways. There is a Terminal setting to wrap those keys onto multiple rows so more keys are visible at once without horizontal scrolling.
