### PR TITLE
fix(remote-runtime): don't paint a red banner on a recoverable liveness reset

### DIFF
--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -728,7 +728,14 @@ class RemoteRuntimeTerminalMultiplexer {
     this.readyResolver = null
     this.readyRejecter = null
     for (const stream of this.streams.values()) {
-      stream.callbacks.onError?.(error.message)
+      // Why: a stream with an onTransportClose resubscribe handler recovers from
+      // a liveness reset on its own (#7718). Surfacing onError here paints a red
+      // xterm banner that survives the successful resubscribe and must be
+      // dismissed by hand. Only surface the error for streams that cannot
+      // recover -- parity with handleClose's guard.
+      if (!stream.callbacks.onTransportClose) {
+        stream.callbacks.onError?.(error.message)
+      }
     }
     this.subscription?.unsubscribe()
     this.handleClose()


### PR DESCRIPTION
failConnection() surfaced onError to every stream unconditionally, painting a red xterm banner even for streams that own an onTransportClose resubscribe handler and recover on their own. handleClose() already guards this behind !canHandleClose (#7718); this applies the same guard to failConnection so a transient liveness reset resubscribes silently instead of leaving a stale banner the user must dismiss by hand.

## ELI5

A brief remote connection blip could paint a scary red error banner even when the terminal was about to reconnect on its own. Recoverable liveness resets now resubscribe quietly so you are not stuck dismissing a false alarm.
