### PR TITLE
feat(plugins): add Marketplace v0 lifecycle

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -160,6 +160,8 @@ import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headles
 import { AgentAwakeService } from './agent-awake-service'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { PluginService } from './plugins/plugin-service'
+import { PluginKillListService } from './plugins/plugin-kill-list-service'
+import { getPluginsDataDir } from './plugins/plugin-discovery'
 import { resolvePluginHostEntryPath } from './plugins/plugin-host-process'
 import { applyPluginConsent, applyPluginEnablement } from './plugins/plugin-enablement'
 import { setPluginServiceForRpc } from './runtime/rpc/methods/plugins'
@@ -229,6 +231,7 @@ let watcherShutdownPromise: Promise<void> | null = null
 let watcherShutdownDone = false
 let automations: AutomationService | null = null
 let pluginService: PluginService | null = null
+let pluginKillListService: PluginKillListService | null = null
 let keybindings: KeybindingService | null = null
 
 function emitPluginWorktreeLifecycle(event: RuntimeWorktreeLifecycleEvent): void {
@@ -1929,6 +1932,11 @@ app.whenReady().then(async () => {
     prepareForCodexLaunch: prepareCodexRuntimeHomeForLaunch,
     prepareForClaudeLaunch: (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target)
   })
+  const pluginSystemStartupStartedAt = performance.now()
+  pluginKillListService = new PluginKillListService({
+    pluginsDataDir: getPluginsDataDir(app.getPath('userData'))
+  })
+  await pluginKillListService.initialize()
   pluginService = new PluginService({
     userDataPath: app.getPath('userData'),
     hostVersion: app.getVersion(),
@@ -1939,7 +1947,20 @@ app.whenReady().then(async () => {
     getPluginConsents: () => normalizePluginConsents(store?.getSettings().pluginConsents),
     getDevPluginPaths: () => normalizePluginIdList(store?.getSettings().devPluginPaths),
     getKeybindings: () => keybindings?.getOverrides() ?? {},
+    getPluginKillListEntry: (pluginKey) => pluginKillListService?.find(pluginKey) ?? null,
     hostEntryPath: resolvePluginHostEntryPath(app.getAppPath(), app.isPackaged)
+  })
+  pluginKillListService.onChanged(() => {
+    void pluginService?.reconcileActivationState().catch((error) => {
+      console.warn('[plugins] failed to apply plugin safety-list refresh:', error)
+    })
+  })
+  store.onSettingsChanged((updates) => {
+    if (app.isPackaged && updates.pluginSystemEnabled === true) {
+      void pluginKillListService?.refresh().catch((error) => {
+        console.warn('[plugins] failed to refresh plugin safety list; using cached state:', error)
+      })
+    }
   })
   // Why: headless `orca serve` clients reach plugins through the runtime RPC
   // methods, which resolve the service via this module-level setter. Consent
@@ -1952,7 +1973,6 @@ app.whenReady().then(async () => {
   })
   // Lazy kernel: initialize() only discovers manifests — no worker forks, no
   // panel reads. Zero plugin code runs before an explicit trigger.
-  const pluginSystemStartupStartedAt = performance.now()
   void pluginService
     .initialize()
     .then(() => {
@@ -1964,6 +1984,11 @@ app.whenReady().then(async () => {
     .catch((error) => {
       console.warn('[plugins] failed to initialize plugin service:', error)
     })
+  if (app.isPackaged && store?.getSettings().pluginSystemEnabled === true) {
+    void pluginKillListService.refresh().catch((error) => {
+      console.warn('[plugins] failed to refresh plugin safety list; using cached state:', error)
+    })
+  }
   pluginService.onChanged((event) => {
     if (
       event.contentPacksChanged &&
@@ -2340,6 +2365,7 @@ app.on('will-quit', (e) => {
   // the allSettled barrier below — quitting before it resolves would let
   // Electron exit first and orphan the hosts.
   setPluginServiceForRpc(null)
+  pluginKillListService = null
   const pluginHostShutdown = pluginService?.dispose() ?? Promise.resolve()
   pluginService = null
   setUnreadDockBadgeCount(0)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -162,6 +162,8 @@ import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { PluginService } from './plugins/plugin-service'
 import { PluginKillListService } from './plugins/plugin-kill-list-service'
 import { getPluginsDataDir } from './plugins/plugin-discovery'
+import { PluginMarketplaceService } from './plugins/plugin-marketplace-service'
+import { PluginMarketplaceInstaller } from './plugins/plugin-marketplace-installer'
 import { resolvePluginHostEntryPath } from './plugins/plugin-host-process'
 import { applyPluginConsent, applyPluginEnablement } from './plugins/plugin-enablement'
 import { setPluginServiceForRpc } from './runtime/rpc/methods/plugins'
@@ -232,6 +234,8 @@ let watcherShutdownDone = false
 let automations: AutomationService | null = null
 let pluginService: PluginService | null = null
 let pluginKillListService: PluginKillListService | null = null
+let pluginMarketplaceService: PluginMarketplaceService | null = null
+let pluginMarketplaceInstaller: PluginMarketplaceInstaller | null = null
 let keybindings: KeybindingService | null = null
 
 function emitPluginWorktreeLifecycle(event: RuntimeWorktreeLifecycleEvent): void {
@@ -975,7 +979,10 @@ function openMainWindow(): BrowserWindow {
         await preserveAgentAuthBeforeRestart({ codexRuntimeHome, claudeRuntimeAuth, store })
       }
     },
-    pluginService ?? undefined
+    pluginService ?? undefined,
+    pluginMarketplaceService && pluginMarketplaceInstaller
+      ? { marketplace: pluginMarketplaceService, installer: pluginMarketplaceInstaller }
+      : undefined
   )
   automations.setWebContents(window.webContents)
   automations.start()
@@ -1937,6 +1944,16 @@ app.whenReady().then(async () => {
     pluginsDataDir: getPluginsDataDir(app.getPath('userData'))
   })
   await pluginKillListService.initialize()
+  pluginMarketplaceService = new PluginMarketplaceService({
+    pluginsDataDir: getPluginsDataDir(app.getPath('userData')),
+    getKillListEntry: (pluginKey) => pluginKillListService?.find(pluginKey) ?? null
+  })
+  pluginMarketplaceInstaller = new PluginMarketplaceInstaller({
+    marketplace: pluginMarketplaceService,
+    userDataPath: app.getPath('userData'),
+    hostVersion: app.getVersion(),
+    blockedPluginReason: (pluginKey) => pluginKillListService?.reason(pluginKey) ?? null
+  })
   pluginService = new PluginService({
     userDataPath: app.getPath('userData'),
     hostVersion: app.getVersion(),
@@ -2366,6 +2383,8 @@ app.on('will-quit', (e) => {
   // Electron exit first and orphan the hosts.
   setPluginServiceForRpc(null)
   pluginKillListService = null
+  pluginMarketplaceService = null
+  pluginMarketplaceInstaller = null
   const pluginHostShutdown = pluginService?.dispose() ?? Promise.resolve()
   pluginService = null
   setUnreadDockBadgeCount(0)

--- a/src/main/ipc/plugin-marketplaces.test.ts
+++ b/src/main/ipc/plugin-marketplaces.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PluginMarketplaceInstaller } from '../plugins/plugin-marketplace-installer'
+import type { PluginMarketplaceService } from '../plugins/plugin-marketplace-service'
+import type { PluginService } from '../plugins/plugin-service'
+
+type IpcHandler = (event: unknown, args?: unknown) => unknown
+
+const electronMocks = vi.hoisted(() => ({ handle: vi.fn() }))
+vi.mock('electron', () => ({ ipcMain: { handle: electronMocks.handle } }))
+
+import {
+  registerPluginMarketplaceHandlers,
+  type PluginMarketplaceHandlerServices
+} from './plugin-marketplaces'
+
+const SOURCE_ID = 'a'.repeat(32)
+const MARKETPLACE_COMMIT = 'b'.repeat(40)
+const PLUGIN_COMMIT = 'c'.repeat(40)
+const PLUGIN_KEY = 'orca-samples.demo'
+
+let handlers: Map<string, IpcHandler>
+
+function createServices(): PluginMarketplaceHandlerServices {
+  return {
+    marketplace: {
+      listSources: vi.fn().mockResolvedValue([{ id: SOURCE_ID }]),
+      addSource: vi.fn().mockResolvedValue({ id: SOURCE_ID }),
+      removeSource: vi.fn().mockResolvedValue(true),
+      refreshSource: vi.fn().mockResolvedValue({ id: SOURCE_ID }),
+      refreshAll: vi.fn().mockResolvedValue([{ id: SOURCE_ID }]),
+      listPlugins: vi.fn().mockResolvedValue([{ pluginKey: PLUGIN_KEY }])
+    } as unknown as PluginMarketplaceService,
+    installer: {
+      preview: vi.fn().mockResolvedValue({ pluginKey: PLUGIN_KEY }),
+      install: vi.fn().mockResolvedValue({ ok: true, pluginKey: PLUGIN_KEY }),
+      previewInstalledUpdate: vi.fn().mockResolvedValue({ pluginKey: PLUGIN_KEY }),
+      rollback: vi.fn().mockResolvedValue({ ok: true, pluginKey: PLUGIN_KEY })
+    } as unknown as PluginMarketplaceInstaller
+  }
+}
+
+function createPluginService(): PluginService {
+  return {
+    deactivatePlugin: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined)
+  } as unknown as PluginService
+}
+
+async function invoke(channel: string, args?: unknown): Promise<unknown> {
+  const handler = handlers.get(channel)
+  if (!handler) {
+    throw new Error(`missing IPC handler: ${channel}`)
+  }
+  return handler({}, args)
+}
+
+beforeEach(() => {
+  handlers = new Map()
+  electronMocks.handle.mockReset()
+  electronMocks.handle.mockImplementation((channel: string, handler: IpcHandler) => {
+    handlers.set(channel, handler)
+  })
+})
+
+describe('plugin marketplace IPC authority', () => {
+  it('validates every mutating or plugin-selecting request strictly', async () => {
+    registerPluginMarketplaceHandlers(createPluginService(), createServices())
+
+    await expect(
+      invoke('plugins:addMarketplace', {
+        kind: 'git',
+        url: 'https://example.com/marketplace.git',
+        ref: 'main',
+        unexpected: true
+      })
+    ).rejects.toThrow()
+    await expect(
+      invoke('plugins:removeMarketplace', { sourceId: SOURCE_ID, unexpected: true })
+    ).rejects.toThrow()
+    await expect(
+      invoke('plugins:refreshMarketplaces', { sourceId: 'not-a-source' })
+    ).rejects.toThrow()
+    await expect(
+      invoke('plugins:previewMarketplacePlugin', {
+        marketplaceSourceId: SOURCE_ID,
+        pluginKey: '__proto__.demo'
+      })
+    ).rejects.toThrow()
+    await expect(
+      invoke('plugins:installMarketplacePlugin', {
+        marketplaceSourceId: SOURCE_ID,
+        marketplaceCommit: 'moving-ref',
+        pluginKey: PLUGIN_KEY,
+        resolvedCommit: PLUGIN_COMMIT
+      })
+    ).rejects.toThrow()
+    await expect(
+      invoke('plugins:previewMarketplaceUpdate', {
+        pluginKey: PLUGIN_KEY,
+        unexpected: true
+      })
+    ).rejects.toThrow()
+    await expect(
+      invoke('plugins:rollbackMarketplacePlugin', { pluginKey: 'bare-id' })
+    ).rejects.toThrow()
+  })
+
+  it('dispatches source listing, add, removal, and refresh operations', async () => {
+    const services = createServices()
+    registerPluginMarketplaceHandlers(createPluginService(), services)
+    const source = {
+      kind: 'git' as const,
+      url: 'https://example.com/marketplace.git',
+      ref: 'main'
+    }
+
+    await invoke('plugins:listMarketplaces')
+    await invoke('plugins:addMarketplace', source)
+    await invoke('plugins:removeMarketplace', { sourceId: SOURCE_ID })
+    await invoke('plugins:refreshMarketplaces', { sourceId: SOURCE_ID })
+    await invoke('plugins:refreshMarketplaces', {})
+    await invoke('plugins:listMarketplacePlugins')
+
+    expect(services.marketplace.listSources).toHaveBeenCalledTimes(2)
+    expect(services.marketplace.addSource).toHaveBeenCalledWith(source)
+    expect(services.marketplace.removeSource).toHaveBeenCalledWith(SOURCE_ID)
+    expect(services.marketplace.refreshSource).toHaveBeenCalledWith(SOURCE_ID)
+    expect(services.marketplace.refreshAll).toHaveBeenCalledOnce()
+    expect(services.marketplace.listPlugins).toHaveBeenCalledOnce()
+  })
+
+  it('refreshes discovery only after a successful install', async () => {
+    const services = createServices()
+    const pluginService = createPluginService()
+    registerPluginMarketplaceHandlers(pluginService, services)
+    const preview = {
+      marketplaceSourceId: SOURCE_ID,
+      marketplaceCommit: MARKETPLACE_COMMIT,
+      pluginKey: PLUGIN_KEY,
+      resolvedCommit: PLUGIN_COMMIT
+    }
+
+    await invoke('plugins:installMarketplacePlugin', preview)
+    expect(services.installer.install).toHaveBeenCalledWith(preview)
+    expect(pluginService.refresh).toHaveBeenCalledOnce()
+
+    vi.mocked(pluginService.refresh).mockClear()
+    vi.mocked(services.installer.install).mockResolvedValueOnce({ ok: false, error: 'failed' })
+    await invoke('plugins:installMarketplacePlugin', preview)
+    expect(pluginService.refresh).not.toHaveBeenCalled()
+  })
+
+  it('deactivates before rollback and refreshes discovery only on success', async () => {
+    const services = createServices()
+    const pluginService = createPluginService()
+    registerPluginMarketplaceHandlers(pluginService, services)
+
+    await invoke('plugins:rollbackMarketplacePlugin', { pluginKey: PLUGIN_KEY })
+
+    expect(pluginService.deactivatePlugin).toHaveBeenCalledWith(PLUGIN_KEY)
+    expect(services.installer.rollback).toHaveBeenCalledWith(PLUGIN_KEY)
+    expect(vi.mocked(pluginService.deactivatePlugin).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(services.installer.rollback).mock.invocationCallOrder[0]
+    )
+    expect(pluginService.refresh).toHaveBeenCalledOnce()
+
+    vi.mocked(pluginService.refresh).mockClear()
+    vi.mocked(services.installer.rollback).mockResolvedValueOnce({ ok: false, error: 'failed' })
+    await invoke('plugins:rollbackMarketplacePlugin', { pluginKey: PLUGIN_KEY })
+    expect(pluginService.refresh).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/plugin-marketplaces.ts
+++ b/src/main/ipc/plugin-marketplaces.ts
@@ -1,0 +1,74 @@
+import { ipcMain } from 'electron'
+import { z } from 'zod'
+import { isQualifiedPluginKey } from '../../shared/plugins/plugin-manifest'
+import { pluginMarketplaceGitSourceSchema } from '../../shared/plugins/plugin-marketplace'
+import type { PluginMarketplaceInstaller } from '../plugins/plugin-marketplace-installer'
+import type { PluginMarketplaceService } from '../plugins/plugin-marketplace-service'
+import type { PluginService } from '../plugins/plugin-service'
+
+export type PluginMarketplaceHandlerServices = {
+  marketplace: PluginMarketplaceService
+  installer: PluginMarketplaceInstaller
+}
+
+const sourceIdSchema = z.string().regex(/^[0-9a-f]{32}$/)
+const removeMarketplaceSchema = z.strictObject({ sourceId: sourceIdSchema })
+const refreshMarketplaceSchema = z.strictObject({ sourceId: sourceIdSchema.optional() })
+const marketplacePluginSchema = z.strictObject({
+  marketplaceSourceId: sourceIdSchema,
+  pluginKey: z.string().refine(isQualifiedPluginKey, 'invalid qualified plugin key')
+})
+const installMarketplacePluginSchema = marketplacePluginSchema.extend({
+  marketplaceCommit: z.string().regex(/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/),
+  resolvedCommit: z.string().regex(/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/)
+})
+const installedPluginSchema = z.strictObject({
+  pluginKey: z.string().refine(isQualifiedPluginKey, 'invalid qualified plugin key')
+})
+
+export function registerPluginMarketplaceHandlers(
+  pluginService: PluginService,
+  services: PluginMarketplaceHandlerServices
+): void {
+  ipcMain.handle('plugins:listMarketplaces', () => services.marketplace.listSources())
+  ipcMain.handle('plugins:addMarketplace', async (_event, args: unknown) => {
+    const source = pluginMarketplaceGitSourceSchema.parse(args)
+    return services.marketplace.addSource(source)
+  })
+  ipcMain.handle('plugins:removeMarketplace', async (_event, args: unknown) => {
+    const { sourceId } = removeMarketplaceSchema.parse(args)
+    await services.marketplace.removeSource(sourceId)
+    return services.marketplace.listSources()
+  })
+  ipcMain.handle('plugins:refreshMarketplaces', async (_event, args: unknown) => {
+    const { sourceId } = refreshMarketplaceSchema.parse(args ?? {})
+    return sourceId
+      ? [await services.marketplace.refreshSource(sourceId)]
+      : services.marketplace.refreshAll()
+  })
+  ipcMain.handle('plugins:listMarketplacePlugins', () => services.marketplace.listPlugins())
+  ipcMain.handle('plugins:previewMarketplacePlugin', async (_event, args: unknown) => {
+    const parsed = marketplacePluginSchema.parse(args)
+    return services.installer.preview(parsed.marketplaceSourceId, parsed.pluginKey)
+  })
+  ipcMain.handle('plugins:installMarketplacePlugin', async (_event, args: unknown) => {
+    const result = await services.installer.install(installMarketplacePluginSchema.parse(args))
+    if (result.ok) {
+      await pluginService.refresh()
+    }
+    return result
+  })
+  ipcMain.handle('plugins:previewMarketplaceUpdate', async (_event, args: unknown) => {
+    const { pluginKey } = installedPluginSchema.parse(args)
+    return services.installer.previewInstalledUpdate(pluginKey)
+  })
+  ipcMain.handle('plugins:rollbackMarketplacePlugin', async (_event, args: unknown) => {
+    const { pluginKey } = installedPluginSchema.parse(args)
+    await pluginService.deactivatePlugin(pluginKey)
+    const result = await services.installer.rollback(pluginKey)
+    if (result.ok) {
+      await pluginService.refresh()
+    }
+    return result
+  })
+}

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -23,6 +23,10 @@ import { normalizePluginIdList } from '../../shared/plugins/plugin-consent-state
 import { isAllowedPluginGitUrl } from '../../shared/plugins/plugin-install-lockfile'
 import type { PluginSkillStoreSnapshot } from '../../shared/plugins/plugin-skill-store'
 import { authorizePluginSkillMapping } from '../plugins/plugin-skill-mapping-authority'
+import {
+  registerPluginMarketplaceHandlers,
+  type PluginMarketplaceHandlerServices
+} from './plugin-marketplaces'
 
 export function parsePluginConsentArgs(args: unknown): z.infer<typeof pluginConsentRequestSchema> {
   return pluginConsentRequestSchema.parse(args)
@@ -93,7 +97,8 @@ function rendererPanelOwner(webContentsId: number): string {
 export function registerPluginHandlers(
   store: Store,
   pluginService: PluginService,
-  runtime: OrcaRuntimeService | null
+  runtime: OrcaRuntimeService | null,
+  marketplaceServices?: PluginMarketplaceHandlerServices
 ): void {
   // The runtime IS the delegate: the structural PluginRuntimeDelegate type
   // keeps the facade electron-free while main binds the real service.
@@ -281,4 +286,7 @@ export function registerPluginHandlers(
     await pluginService.refresh()
     return listPluginsForClients(pluginService)
   })
+  if (marketplaceServices) {
+    registerPluginMarketplaceHandlers(pluginService, marketplaceServices)
+  }
 }

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -220,10 +220,23 @@ export function registerPluginHandlers(
     const parsed = parsePluginInstallArgs(args)
     const pluginsDir = getUserPluginsDir(pluginService.options.userDataPath)
     const hostVersion = pluginService.options.hostVersion
+    const blockedPluginReason = (pluginKey: string): string | null =>
+      pluginService.options.getPluginKillListEntry?.(pluginKey)?.reason ?? null
     const result =
       parsed.kind === 'local-path'
-        ? await installPluginFromLocalPath({ pluginsDir, sourcePath: parsed.path, hostVersion })
-        : await installPluginFromGit({ pluginsDir, url: parsed.url, ref: parsed.ref, hostVersion })
+        ? await installPluginFromLocalPath({
+            pluginsDir,
+            sourcePath: parsed.path,
+            hostVersion,
+            blockedPluginReason
+          })
+        : await installPluginFromGit({
+            pluginsDir,
+            url: parsed.url,
+            ref: parsed.ref,
+            hostVersion,
+            blockedPluginReason
+          })
     if (result.ok) {
       await pluginService.refresh()
     }

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -78,6 +78,7 @@ import {
   scanRuntimeAiVaultSessions
 } from '../ai-vault/runtime-session-scanner'
 import type { PluginService } from '../plugins/plugin-service'
+import type { PluginMarketplaceHandlerServices } from './plugin-marketplaces'
 
 let registered = false
 
@@ -103,7 +104,8 @@ export function registerCoreHandlers(
   crashReports?: CrashReportStore,
   keybindings?: KeybindingService,
   lifecycleOptions: CoreHandlerLifecycleOptions = {},
-  pluginService?: PluginService
+  pluginService?: PluginService,
+  marketplaceServices?: PluginMarketplaceHandlerServices
 ): void {
   // Why: on macOS the app can stay alive after all windows close, then
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
@@ -164,7 +166,7 @@ export function registerCoreHandlers(
     })
   }
   if (pluginService) {
-    registerPluginHandlers(store, pluginService, runtime)
+    registerPluginHandlers(store, pluginService, runtime, marketplaceServices)
   }
   registerTelemetryHandlers(store)
   registerOrcaProfileHandlers(store, {

--- a/src/main/plugins/plugin-git-repository.ts
+++ b/src/main/plugins/plugin-git-repository.ts
@@ -1,0 +1,55 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { isAllowedPluginGitUrl } from '../../shared/plugins/plugin-install-lockfile'
+
+const execFileAsync = promisify(execFile)
+const PLUGIN_GIT_TIMEOUT_MS = 120_000
+const COMMIT_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/
+
+/** Runs system Git with argv-only invocation so credential helpers and SSH
+ * remotes work without exposing an executable remote-helper surface. */
+export async function runPluginGit(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd,
+    timeout: PLUGIN_GIT_TIMEOUT_MS,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      // Existing non-interactive helpers and SSH agents still work, but a
+      // background marketplace refresh can never hang on a terminal prompt.
+      GIT_TERMINAL_PROMPT: '0'
+    }
+  })
+  return stdout.trim()
+}
+
+/** Checks out one Git ref into an empty destination and returns exact HEAD. */
+export async function checkoutPluginGitSource(input: {
+  url: string
+  ref: string
+  destination: string
+  workingDirectory: string
+}): Promise<string> {
+  if (!isAllowedPluginGitUrl(input.url)) {
+    throw new Error('plugin Git URL must use HTTPS or SSH')
+  }
+  const ref = input.ref.trim()
+  if (COMMIT_PATTERN.test(ref)) {
+    await runPluginGit(['init', '--quiet', input.destination], input.workingDirectory)
+    await runPluginGit(['remote', 'add', 'origin', input.url], input.destination)
+    await runPluginGit(['fetch', '--quiet', '--depth', '1', 'origin', ref], input.destination)
+    await runPluginGit(['checkout', '--quiet', 'FETCH_HEAD'], input.destination)
+  } else {
+    const args = ['clone', '--quiet', '--depth', '1']
+    if (ref.length > 0) {
+      args.push('--branch', ref)
+    }
+    args.push('--', input.url, input.destination)
+    await runPluginGit(args, input.workingDirectory)
+  }
+  const resolvedCommit = await runPluginGit(['rev-parse', 'HEAD'], input.destination)
+  if (!COMMIT_PATTERN.test(resolvedCommit)) {
+    throw new Error('Git resolved an invalid commit identity')
+  }
+  return resolvedCommit
+}

--- a/src/main/plugins/plugin-install-staging.ts
+++ b/src/main/plugins/plugin-install-staging.ts
@@ -33,6 +33,16 @@ export type PluginInstallResult =
     }
   | { ok: false; error: string }
 
+export type PluginInstallInspection =
+  | {
+      ok: true
+      manifest: PluginManifest
+      pluginKey: string
+      contentHash: string
+      consentFingerprint: string
+    }
+  | { ok: false; error: string }
+
 async function validatePluginInstallTree(
   rootDir: string,
   manifest: PluginManifest
@@ -67,6 +77,41 @@ async function readInstallManifest(
   return { ok: true, manifest: parsed.manifest }
 }
 
+/** Validates and hashes a source tree without publishing it. Marketplace
+ * previews use this exact path so the reviewed bytes match install policy. */
+export async function inspectPluginInstallTree(input: {
+  rootDir: string
+  hostVersion: string
+  expectedPluginKey?: string
+}): Promise<PluginInstallInspection> {
+  const sourceManifest = await readInstallManifest(input.rootDir, input.hostVersion)
+  if (!sourceManifest.ok) {
+    return sourceManifest
+  }
+  const pluginKey = qualifiedPluginKey(sourceManifest.manifest)
+  if (input.expectedPluginKey && pluginKey !== input.expectedPluginKey) {
+    return {
+      ok: false,
+      error: `plugin manifest identity ${pluginKey} does not match marketplace listing ${input.expectedPluginKey}`
+    }
+  }
+  const declaredArtifacts = await validatePluginInstallTree(input.rootDir, sourceManifest.manifest)
+  if (!declaredArtifacts.ok) {
+    return { ok: false, error: `invalid declared artifact: ${declaredArtifacts.error}` }
+  }
+  const treeHash = await hashPluginTree(input.rootDir)
+  if (!treeHash.ok) {
+    return { ok: false, error: treeHash.error }
+  }
+  return {
+    ok: true,
+    manifest: sourceManifest.manifest,
+    pluginKey,
+    contentHash: treeHash.hash,
+    consentFingerprint: fingerprintPluginConsent(sourceManifest.manifest, treeHash.hash)
+  }
+}
+
 /** Installs a validated staging tree into the hash-addressed layout. */
 export async function installStagedPluginTree(input: {
   pluginsDir: string
@@ -74,24 +119,20 @@ export async function installStagedPluginTree(input: {
   hostVersion: string
   source: PluginInstallSource
   resolvedCommit: string | null
+  expectedPluginKey?: string
 }): Promise<PluginInstallResult> {
-  const sourceManifest = await readInstallManifest(input.stagingDir, input.hostVersion)
-  if (!sourceManifest.ok) {
-    return sourceManifest
+  const sourceInspection = await inspectPluginInstallTree({
+    rootDir: input.stagingDir,
+    hostVersion: input.hostVersion,
+    ...(input.expectedPluginKey ? { expectedPluginKey: input.expectedPluginKey } : {})
+  })
+  if (!sourceInspection.ok) {
+    return sourceInspection
   }
-  let manifest = sourceManifest.manifest
-  const declaredArtifacts = await validatePluginInstallTree(input.stagingDir, manifest)
-  if (!declaredArtifacts.ok) {
-    return { ok: false, error: `invalid declared artifact: ${declaredArtifacts.error}` }
-  }
-  // Hash before copy: also enforces the symlink/entry-count/size limits.
-  const treeHash = await hashPluginTree(input.stagingDir)
-  if (!treeHash.ok) {
-    return { ok: false, error: treeHash.error }
-  }
-  const pluginKey = qualifiedPluginKey(manifest)
+  let manifest = sourceInspection.manifest
+  const pluginKey = sourceInspection.pluginKey
   const pluginDir = join(input.pluginsDir, pluginKey)
-  const versionDir = join(pluginDir, treeHash.hash)
+  const versionDir = join(pluginDir, sourceInspection.contentHash)
   if (!existsSync(versionDir)) {
     const stagedVersionDir = `${versionDir}.staging`
     try {
@@ -111,7 +152,7 @@ export async function installStagedPluginTree(input: {
         }
       })
       const copiedHash = await hashPluginTree(stagedVersionDir)
-      if (!copiedHash.ok || copiedHash.hash !== treeHash.hash) {
+      if (!copiedHash.ok || copiedHash.hash !== sourceInspection.contentHash) {
         return {
           ok: false,
           error: copiedHash.ok
@@ -141,7 +182,7 @@ export async function installStagedPluginTree(input: {
     // Never repoint at an existing hash directory without proving its bytes;
     // a previous partial/tampered install must not be revived by reinstall.
     const existingHash = await hashPluginTree(versionDir)
-    if (!existingHash.ok || existingHash.hash !== treeHash.hash) {
+    if (!existingHash.ok || existingHash.hash !== sourceInspection.contentHash) {
       return {
         ok: false,
         error: existingHash.ok
@@ -165,13 +206,13 @@ export async function installStagedPluginTree(input: {
       }
     }
   }
-  const consentFingerprint = fingerprintPluginConsent(manifest, treeHash.hash)
+  const consentFingerprint = fingerprintPluginConsent(manifest, sourceInspection.contentHash)
   const entry: PluginLockEntry = {
     pluginKey,
     version: manifest.version,
     source: input.source,
     resolvedCommit: input.resolvedCommit,
-    contentHash: treeHash.hash,
+    contentHash: sourceInspection.contentHash,
     consentFingerprint,
     installedAt: Date.now()
   }
@@ -184,7 +225,7 @@ export async function installStagedPluginTree(input: {
     ok: true,
     pluginKey,
     version: manifest.version,
-    contentHash: treeHash.hash,
+    contentHash: sourceInspection.contentHash,
     consentFingerprint,
     resolvedCommit: input.resolvedCommit
   }

--- a/src/main/plugins/plugin-install-staging.ts
+++ b/src/main/plugins/plugin-install-staging.ts
@@ -21,6 +21,7 @@ import {
 import { hashPluginTree } from './plugin-content-hash'
 import { publishPluginInstall } from './plugin-install-publication'
 import { readPluginManifestText } from './plugin-manifest-file'
+import { pluginInstallTrustError } from './plugin-install-trust'
 
 export type PluginInstallResult =
   | {
@@ -120,6 +121,7 @@ export async function installStagedPluginTree(input: {
   source: PluginInstallSource
   resolvedCommit: string | null
   expectedPluginKey?: string
+  blockedPluginReason?: (pluginKey: string) => string | null
 }): Promise<PluginInstallResult> {
   const sourceInspection = await inspectPluginInstallTree({
     rootDir: input.stagingDir,
@@ -128,6 +130,14 @@ export async function installStagedPluginTree(input: {
   })
   if (!sourceInspection.ok) {
     return sourceInspection
+  }
+  const trustError = pluginInstallTrustError(sourceInspection.pluginKey, input.source)
+  if (trustError) {
+    return { ok: false, error: trustError }
+  }
+  const blockedReason = input.blockedPluginReason?.(sourceInspection.pluginKey)
+  if (blockedReason) {
+    return { ok: false, error: `plugin is blocked by Orca's safety list: ${blockedReason}` }
   }
   let manifest = sourceInspection.manifest
   const pluginKey = sourceInspection.pluginKey

--- a/src/main/plugins/plugin-install-trust.test.ts
+++ b/src/main/plugins/plugin-install-trust.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { PluginInstallSource } from '../../shared/plugins/plugin-install-lockfile'
+import {
+  installBundledPlugin,
+  installPluginFromLocalPath,
+  readPluginLockfile
+} from './plugin-install'
+import { pluginInstallTrustError } from './plugin-install-trust'
+
+const roots: string[] = []
+
+async function tempRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix))
+  roots.push(root)
+  return root
+}
+
+async function writePlugin(root: string, publisher: string, id: string): Promise<void> {
+  await writeFile(
+    join(root, 'orca-plugin.json'),
+    JSON.stringify({
+      manifestVersion: 1,
+      id,
+      publisher,
+      name: 'Plugin',
+      version: '1.0.0',
+      engines: { orca: '>=1.0.0' },
+      pluginApi: 1,
+      capabilities: []
+    })
+  )
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('plugin install trust', () => {
+  it.each<[PluginInstallSource, string | null]>([
+    [
+      {
+        kind: 'git',
+        url: 'https://github.com/attacker/orca-secrets.git',
+        ref: 'main'
+      },
+      'reserved plugin identity community.orca-secrets must resolve to the stablyai organization'
+    ],
+    [
+      {
+        kind: 'git',
+        url: 'git@github.com:stablyai/orca-secrets.git',
+        ref: 'main'
+      },
+      null
+    ]
+  ])('enforces reserved source organization', (source, expected) => {
+    expect(pluginInstallTrustError('community.orca-secrets', source)).toBe(expected)
+  })
+
+  it('rejects locally installed reserved identities before publication', async () => {
+    const sourcePath = await tempRoot('orca-reserved-plugin-')
+    const pluginsDir = await tempRoot('orca-plugin-installs-')
+    await writePlugin(sourcePath, 'stablyai', 'orca-skills')
+
+    await expect(
+      installPluginFromLocalPath({ pluginsDir, sourcePath, hostVersion: '1.4.0' })
+    ).resolves.toEqual({
+      ok: false,
+      error: 'reserved plugin identity stablyai.orca-skills cannot be installed from a local path'
+    })
+    await expect(readPluginLockfile(pluginsDir)).resolves.toEqual({ version: 1, plugins: {} })
+  })
+
+  it('allows the app-bundled path only for the complete official identity', async () => {
+    const sourcePath = await tempRoot('orca-bundled-plugin-')
+    const pluginsDir = await tempRoot('orca-plugin-installs-')
+    await writePlugin(sourcePath, 'stablyai', 'orca-skills')
+
+    const result = await installBundledPlugin({
+      pluginsDir,
+      sourcePath,
+      hostVersion: '1.4.0',
+      expectedPluginKey: 'stablyai.orca-skills'
+    })
+
+    expect(result).toMatchObject({ ok: true, pluginKey: 'stablyai.orca-skills' })
+    const lock = await readPluginLockfile(pluginsDir)
+    expect(lock.plugins['stablyai.orca-skills']?.source).toEqual({
+      kind: 'bundled',
+      bundleId: 'stablyai.orca-skills'
+    })
+  })
+
+  it('blocks a killed plugin even when the caller bypasses marketplace UI', async () => {
+    const sourcePath = await tempRoot('orca-killed-plugin-')
+    const pluginsDir = await tempRoot('orca-plugin-installs-')
+    await writePlugin(sourcePath, 'community', 'unsafe')
+
+    await expect(
+      installPluginFromLocalPath({
+        pluginsDir,
+        sourcePath,
+        hostVersion: '1.4.0',
+        blockedPluginReason: (pluginKey) =>
+          pluginKey === 'community.unsafe' ? 'Security incident' : null
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: "plugin is blocked by Orca's safety list: Security incident"
+    })
+  })
+})

--- a/src/main/plugins/plugin-install-trust.ts
+++ b/src/main/plugins/plugin-install-trust.ts
@@ -1,0 +1,27 @@
+import type { PluginInstallSource } from '../../shared/plugins/plugin-install-lockfile'
+import {
+  isOfficialOrganizationGitSource,
+  isOfficialPluginIdentity,
+  isReservedPluginIdentity
+} from '../../shared/plugins/plugin-marketplace'
+
+export function pluginInstallTrustError(
+  pluginKey: string,
+  source: PluginInstallSource
+): string | null {
+  if (source.kind === 'bundled') {
+    return source.bundleId === pluginKey && isOfficialPluginIdentity(pluginKey)
+      ? null
+      : 'bundled plugins must use an official stablyai.orca-* identity'
+  }
+  if (!isReservedPluginIdentity(pluginKey)) {
+    return null
+  }
+  if (source.kind === 'local-path') {
+    return `reserved plugin identity ${pluginKey} cannot be installed from a local path`
+  }
+  const url = source.kind === 'git' ? source.url : source.plugin.url
+  return isOfficialOrganizationGitSource(url)
+    ? null
+    : `reserved plugin identity ${pluginKey} must resolve to the stablyai organization`
+}

--- a/src/main/plugins/plugin-install.ts
+++ b/src/main/plugins/plugin-install.ts
@@ -67,6 +67,7 @@ export async function installPluginFromLocalPath(input: {
   pluginsDir: string
   sourcePath: string
   hostVersion: string
+  blockedPluginReason?: (pluginKey: string) => string | null
 }): Promise<PluginInstallResult> {
   return serializePluginMutation(input.pluginsDir, async () => {
     if (!existsSync(join(input.sourcePath, PLUGIN_MANIFEST_FILENAME))) {
@@ -77,9 +78,30 @@ export async function installPluginFromLocalPath(input: {
       stagingDir: input.sourcePath,
       hostVersion: input.hostVersion,
       source: { kind: 'local-path', path: input.sourcePath },
-      resolvedCommit: null
+      resolvedCommit: null,
+      blockedPluginReason: input.blockedPluginReason
     })
   })
+}
+
+export async function installBundledPlugin(input: {
+  pluginsDir: string
+  sourcePath: string
+  hostVersion: string
+  expectedPluginKey: string
+  blockedPluginReason?: (pluginKey: string) => string | null
+}): Promise<PluginInstallResult> {
+  return serializePluginMutation(input.pluginsDir, () =>
+    installStagedPluginTree({
+      pluginsDir: input.pluginsDir,
+      stagingDir: input.sourcePath,
+      hostVersion: input.hostVersion,
+      source: { kind: 'bundled', bundleId: input.expectedPluginKey },
+      resolvedCommit: null,
+      expectedPluginKey: input.expectedPluginKey,
+      blockedPluginReason: input.blockedPluginReason
+    })
+  )
 }
 
 export async function installPluginFromGit(input: {
@@ -88,6 +110,7 @@ export async function installPluginFromGit(input: {
   /** `#ref` suffix: branch, tag, or full commit SHA. Empty = default branch. */
   ref: string
   hostVersion: string
+  blockedPluginReason?: (pluginKey: string) => string | null
 }): Promise<PluginInstallResult> {
   if (!isAllowedPluginGitUrl(input.url)) {
     return { ok: false, error: 'plugin Git URL must use HTTPS or SSH' }
@@ -107,7 +130,8 @@ export async function installPluginFromGit(input: {
         stagingDir,
         hostVersion: input.hostVersion,
         source: { kind: 'git', url: input.url, ref },
-        resolvedCommit
+        resolvedCommit,
+        blockedPluginReason: input.blockedPluginReason
       })
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
@@ -124,6 +148,7 @@ export async function installPluginFromMarketplace(input: {
   expectedResolvedCommit: string
   marketplace: { url: string; ref: string; resolvedCommit: string }
   plugin: { url: string; ref: string }
+  blockedPluginReason?: (pluginKey: string) => string | null
 }): Promise<PluginInstallResult> {
   const source = pluginInstallSourceSchema.parse({
     kind: 'marketplace',
@@ -154,7 +179,8 @@ export async function installPluginFromMarketplace(input: {
         hostVersion: input.hostVersion,
         source,
         resolvedCommit,
-        expectedPluginKey: input.expectedPluginKey
+        expectedPluginKey: input.expectedPluginKey,
+        blockedPluginReason: input.blockedPluginReason
       })
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
@@ -171,9 +197,14 @@ export async function rollbackInstalledPlugin(input: {
   pluginsDir: string
   pluginKey: string
   hostVersion: string
+  blockedPluginReason?: (pluginKey: string) => string | null
 }): Promise<PluginInstallResult> {
   if (!isQualifiedPluginKey(input.pluginKey)) {
     return { ok: false, error: 'invalid qualified plugin key' }
+  }
+  const blockedReason = input.blockedPluginReason?.(input.pluginKey)
+  if (blockedReason) {
+    return { ok: false, error: `plugin is blocked by Orca's safety list: ${blockedReason}` }
   }
   return serializePluginMutation(input.pluginsDir, async () => {
     const pluginDir = join(input.pluginsDir, input.pluginKey)

--- a/src/main/plugins/plugin-install.ts
+++ b/src/main/plugins/plugin-install.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, realpath, rm } from 'node:fs/promises'
+import { mkdtemp, readdir, realpath, rm } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
@@ -8,11 +8,19 @@ import {
 } from '../../shared/plugins/plugin-manifest'
 import {
   isAllowedPluginGitUrl,
+  pluginInstallSourceSchema,
   removePluginLock
 } from '../../shared/plugins/plugin-install-lockfile'
 import { readPluginLockfile, writePluginLockfile } from './plugin-install-lockfile-store'
-import { installStagedPluginTree, type PluginInstallResult } from './plugin-install-staging'
+import {
+  inspectPluginInstallTree,
+  installStagedPluginTree,
+  type PluginInstallResult
+} from './plugin-install-staging'
 import { checkoutPluginGitSource } from './plugin-git-repository'
+import { readPluginCurrentPointer } from './plugin-current-pointer'
+import { readPluginInstallProvenance } from './plugin-install-provenance'
+import { publishPluginInstall } from './plugin-install-publication'
 
 export type { PluginInstallResult } from './plugin-install-staging'
 
@@ -105,6 +113,123 @@ export async function installPluginFromGit(input: {
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
     } finally {
       await rm(stagingDir, { recursive: true, force: true })
+    }
+  })
+}
+
+export async function installPluginFromMarketplace(input: {
+  pluginsDir: string
+  hostVersion: string
+  expectedPluginKey: string
+  expectedResolvedCommit: string
+  marketplace: { url: string; ref: string; resolvedCommit: string }
+  plugin: { url: string; ref: string }
+}): Promise<PluginInstallResult> {
+  const source = pluginInstallSourceSchema.parse({
+    kind: 'marketplace',
+    marketplace: input.marketplace,
+    plugin: input.plugin
+  })
+  if (!isQualifiedPluginKey(input.expectedPluginKey)) {
+    return { ok: false, error: 'invalid marketplace plugin identity' }
+  }
+  if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(input.expectedResolvedCommit)) {
+    return { ok: false, error: 'invalid previewed plugin commit' }
+  }
+  return serializePluginMutation(input.pluginsDir, async () => {
+    const stagingDir = await mkdtemp(join(tmpdir(), 'orca-plugin-marketplace-install-'))
+    try {
+      const resolvedCommit = await checkoutPluginGitSource({
+        url: input.plugin.url,
+        ref: input.plugin.ref,
+        destination: stagingDir,
+        workingDirectory: tmpdir()
+      })
+      if (resolvedCommit !== input.expectedResolvedCommit) {
+        return { ok: false, error: 'plugin source changed after preview; review the update again' }
+      }
+      return await installStagedPluginTree({
+        pluginsDir: input.pluginsDir,
+        stagingDir,
+        hostVersion: input.hostVersion,
+        source,
+        resolvedCommit,
+        expectedPluginKey: input.expectedPluginKey
+      })
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) }
+    } finally {
+      await rm(stagingDir, { recursive: true, force: true })
+    }
+  })
+}
+
+/** Restores the single retained immutable predecessor. The old consent
+ * fingerprint becomes current again, so enablement still fails closed until
+ * the user has approved those exact bytes. */
+export async function rollbackInstalledPlugin(input: {
+  pluginsDir: string
+  pluginKey: string
+  hostVersion: string
+}): Promise<PluginInstallResult> {
+  if (!isQualifiedPluginKey(input.pluginKey)) {
+    return { ok: false, error: 'invalid qualified plugin key' }
+  }
+  return serializePluginMutation(input.pluginsDir, async () => {
+    const pluginDir = join(input.pluginsDir, input.pluginKey)
+    const currentContentHash = await readPluginCurrentPointer(pluginDir).catch(() => null)
+    if (!currentContentHash) {
+      return { ok: false, error: 'installed plugin has no current version' }
+    }
+    const candidates = (await readdir(pluginDir, { withFileTypes: true }).catch(() => []))
+      .filter(
+        (entry) =>
+          entry.isDirectory() &&
+          /^(?:[0-9a-f]{32}|[0-9a-f]{64})$/.test(entry.name) &&
+          entry.name !== currentContentHash
+      )
+      .map((entry) => entry.name)
+    if (candidates.length !== 1) {
+      return {
+        ok: false,
+        error:
+          candidates.length === 0
+            ? 'no rollback version is available'
+            : 'rollback state is ambiguous'
+      }
+    }
+    const contentHash = candidates[0]!
+    const provenance = await readPluginInstallProvenance(pluginDir, contentHash)
+    if (
+      !provenance ||
+      provenance.pluginKey !== input.pluginKey ||
+      provenance.contentHash !== contentHash
+    ) {
+      return { ok: false, error: 'rollback version has no valid install provenance' }
+    }
+    const inspection = await inspectPluginInstallTree({
+      rootDir: join(pluginDir, contentHash),
+      hostVersion: input.hostVersion,
+      expectedPluginKey: input.pluginKey
+    })
+    if (!inspection.ok || inspection.contentHash !== contentHash) {
+      return {
+        ok: false,
+        error: inspection.ok ? 'rollback version failed integrity verification' : inspection.error
+      }
+    }
+    try {
+      await publishPluginInstall({ pluginsDir: input.pluginsDir, pluginDir, entry: provenance })
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) }
+    }
+    return {
+      ok: true,
+      pluginKey: input.pluginKey,
+      version: inspection.manifest.version,
+      contentHash,
+      consentFingerprint: provenance.consentFingerprint,
+      resolvedCommit: provenance.resolvedCommit
     }
   })
 }

--- a/src/main/plugins/plugin-install.ts
+++ b/src/main/plugins/plugin-install.ts
@@ -1,9 +1,7 @@
-import { execFile } from 'node:child_process'
 import { mkdtemp, realpath, rm } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
-import { promisify } from 'node:util'
 import {
   PLUGIN_MANIFEST_FILENAME,
   isQualifiedPluginKey
@@ -14,6 +12,7 @@ import {
 } from '../../shared/plugins/plugin-install-lockfile'
 import { readPluginLockfile, writePluginLockfile } from './plugin-install-lockfile-store'
 import { installStagedPluginTree, type PluginInstallResult } from './plugin-install-staging'
+import { checkoutPluginGitSource } from './plugin-git-repository'
 
 export type { PluginInstallResult } from './plugin-install-staging'
 
@@ -34,8 +33,6 @@ export {
  * swap; the previous version dir is kept for one-step rollback.
  */
 
-const execFileAsync = promisify(execFile)
-const GIT_TIMEOUT_MS = 120_000
 const pluginMutationChains = new Map<string, Promise<void>>()
 
 async function serializePluginMutation<T>(
@@ -77,20 +74,6 @@ export async function installPluginFromLocalPath(input: {
   })
 }
 
-async function runGit(args: string[], cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, {
-    cwd,
-    timeout: GIT_TIMEOUT_MS,
-    windowsHide: true,
-    env: {
-      ...process.env,
-      // Never block an install on an interactive credential/host prompt.
-      GIT_TERMINAL_PROMPT: '0'
-    }
-  })
-  return stdout.trim()
-}
-
 export async function installPluginFromGit(input: {
   pluginsDir: string
   url: string
@@ -105,21 +88,12 @@ export async function installPluginFromGit(input: {
     const stagingDir = await mkdtemp(join(tmpdir(), 'orca-plugin-install-'))
     try {
       const ref = input.ref.trim()
-      if (/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(ref)) {
-        // Exact commit: shallow-fetch just that object.
-        await runGit(['init', '--quiet', stagingDir], tmpdir())
-        await runGit(['remote', 'add', 'origin', input.url], stagingDir)
-        await runGit(['fetch', '--quiet', '--depth', '1', 'origin', ref], stagingDir)
-        await runGit(['checkout', '--quiet', 'FETCH_HEAD'], stagingDir)
-      } else {
-        const args = ['clone', '--quiet', '--depth', '1']
-        if (ref.length > 0) {
-          args.push('--branch', ref)
-        }
-        args.push('--', input.url, stagingDir)
-        await runGit(args, tmpdir())
-      }
-      const resolvedCommit = await runGit(['rev-parse', 'HEAD'], stagingDir)
+      const resolvedCommit = await checkoutPluginGitSource({
+        url: input.url,
+        ref,
+        destination: stagingDir,
+        workingDirectory: tmpdir()
+      })
       return await installStagedPluginTree({
         pluginsDir: input.pluginsDir,
         stagingDir,

--- a/src/main/plugins/plugin-kill-list-service.test.ts
+++ b/src/main/plugins/plugin-kill-list-service.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PluginKillList } from '../../shared/plugins/plugin-kill-list'
+import { fetchPluginKillList, PluginKillListService } from './plugin-kill-list-service'
+
+const roots: string[] = []
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-plugin-kill-list-'))
+  roots.push(root)
+  return root
+}
+
+function killList(date = '2026-07-12T20:00:00Z'): PluginKillList {
+  return {
+    version: 1,
+    generatedAt: date,
+    plugins: [{ pluginKey: 'community.unsafe', reason: 'Malware advisory' }]
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('PluginKillListService', () => {
+  it('loads cached revocations before any network refresh', async () => {
+    const root = await tempRoot()
+    const first = new PluginKillListService({
+      pluginsDataDir: root,
+      fetcher: async () => killList()
+    })
+    await first.refresh()
+    const fetcher = vi.fn(async () => killList())
+    const restarted = new PluginKillListService({ pluginsDataDir: root, fetcher })
+
+    await restarted.initialize()
+
+    expect(restarted.reason('community.unsafe')).toBe('Malware advisory')
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('publishes valid refreshes and notifies runtime reconciliation', async () => {
+    const service = new PluginKillListService({
+      pluginsDataDir: await tempRoot(),
+      fetcher: async () => killList()
+    })
+    const changed = vi.fn()
+    service.onChanged(changed)
+
+    await service.refresh()
+
+    expect(service.find('community.unsafe')).toMatchObject({ reason: 'Malware advisory' })
+    expect(changed).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a replayed older snapshot without replacing cached revocations', async () => {
+    const fetcher = vi
+      .fn<() => Promise<PluginKillList>>()
+      .mockResolvedValueOnce(killList('2026-07-12T20:00:00Z'))
+      .mockResolvedValueOnce(killList('2026-07-11T20:00:00Z'))
+    const service = new PluginKillListService({ pluginsDataDir: await tempRoot(), fetcher })
+    await service.refresh()
+
+    await expect(service.refresh()).rejects.toThrow('older snapshot')
+    expect(service.snapshot()?.generatedAt).toBe('2026-07-12T20:00:00Z')
+  })
+})
+
+describe('fetchPluginKillList', () => {
+  it('validates a bounded HTTPS response body', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(killList()), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    )
+
+    await expect(fetchPluginKillList(fetcher)).resolves.toEqual(killList())
+  })
+
+  it('rejects non-success responses', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response('no', { status: 503 }))
+    await expect(fetchPluginKillList(fetcher)).rejects.toThrow('HTTP 503')
+  })
+})

--- a/src/main/plugins/plugin-kill-list-service.ts
+++ b/src/main/plugins/plugin-kill-list-service.ts
@@ -1,0 +1,132 @@
+import {
+  findKilledPlugin,
+  pluginKillListSchema,
+  type PluginKillList,
+  type PluginKillListEntry
+} from '../../shared/plugins/plugin-kill-list'
+import { PluginKillListStore } from './plugin-kill-list-store'
+
+export const PLUGIN_KILL_LIST_URL = 'https://onorca.dev/plugins/kill-list.json'
+const PLUGIN_KILL_LIST_DOWNLOAD_LIMIT = 4 * 1024 * 1024
+
+type PluginKillListFetcher = () => Promise<PluginKillList>
+
+export class PluginKillListService {
+  private readonly store: PluginKillListStore
+  private readonly fetcher: PluginKillListFetcher
+  private readonly listeners = new Set<() => void>()
+  private currentList: PluginKillList | null = null
+  private loadPromise: Promise<void> | null = null
+  private refreshChain: Promise<PluginKillList> = Promise.resolve({
+    version: 1,
+    generatedAt: '1970-01-01T00:00:00Z',
+    plugins: []
+  })
+
+  constructor(options: {
+    pluginsDataDir: string
+    store?: PluginKillListStore
+    fetcher?: PluginKillListFetcher
+  }) {
+    this.store = options.store ?? new PluginKillListStore(options.pluginsDataDir)
+    this.fetcher = options.fetcher ?? (() => fetchPluginKillList())
+  }
+
+  async initialize(): Promise<void> {
+    this.loadPromise ??= this.store.read().then((killList) => {
+      this.currentList = killList
+    })
+    await this.loadPromise
+  }
+
+  onChanged(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  find(pluginKey: string): PluginKillListEntry | null {
+    return this.currentList ? findKilledPlugin(this.currentList, pluginKey) : null
+  }
+
+  reason(pluginKey: string): string | null {
+    return this.find(pluginKey)?.reason ?? null
+  }
+
+  snapshot(): PluginKillList | null {
+    return this.currentList
+  }
+
+  refresh(): Promise<PluginKillList> {
+    const refresh = this.refreshChain
+      .catch(() => this.currentList ?? emptyKillList())
+      .then(() => this.performRefresh())
+    this.refreshChain = refresh
+    return refresh
+  }
+
+  private async performRefresh(): Promise<PluginKillList> {
+    await this.initialize()
+    const fetched = pluginKillListSchema.parse(await this.fetcher())
+    if (
+      this.currentList &&
+      Date.parse(fetched.generatedAt) < Date.parse(this.currentList.generatedAt)
+    ) {
+      throw new Error('refusing to replace the plugin kill list with an older snapshot')
+    }
+    await this.store.write(fetched)
+    this.currentList = fetched
+    for (const listener of this.listeners) {
+      listener()
+    }
+    return fetched
+  }
+}
+
+export async function fetchPluginKillList(
+  fetcher: typeof fetch = fetch,
+  url = PLUGIN_KILL_LIST_URL
+): Promise<PluginKillList> {
+  const response = await fetcher(url, { cache: 'no-store' })
+  if (!response.ok) {
+    throw new Error(`plugin kill-list request failed with HTTP ${response.status}`)
+  }
+  const declaredBytes = Number(response.headers.get('content-length') ?? '0')
+  if (Number.isFinite(declaredBytes) && declaredBytes > PLUGIN_KILL_LIST_DOWNLOAD_LIMIT) {
+    throw new Error('plugin kill-list response exceeds its size limit')
+  }
+  if (!response.body) {
+    throw new Error('plugin kill-list response has no body')
+  }
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  while (true) {
+    const chunk = await reader.read()
+    if (chunk.done) {
+      break
+    }
+    totalBytes += chunk.value.byteLength
+    if (totalBytes > PLUGIN_KILL_LIST_DOWNLOAD_LIMIT) {
+      await reader.cancel()
+      throw new Error('plugin kill-list response exceeds its size limit')
+    }
+    chunks.push(chunk.value)
+  }
+  const bytes = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  try {
+    return pluginKillListSchema.parse(JSON.parse(new TextDecoder().decode(bytes)))
+  } catch (error) {
+    throw new Error(
+      `invalid plugin kill-list response: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+function emptyKillList(): PluginKillList {
+  return { version: 1, generatedAt: '1970-01-01T00:00:00Z', plugins: [] }
+}

--- a/src/main/plugins/plugin-kill-list-store.ts
+++ b/src/main/plugins/plugin-kill-list-store.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { pluginKillListSchema, type PluginKillList } from '../../shared/plugins/plugin-kill-list'
+
+const PLUGIN_KILL_LIST_MAX_BYTES = 4 * 1024 * 1024
+
+export class PluginKillListStore {
+  private readonly filePath: string
+
+  constructor(pluginsDataDir: string) {
+    this.filePath = join(pluginsDataDir, 'plugin-kill-list.json')
+  }
+
+  async read(): Promise<PluginKillList | null> {
+    try {
+      const chunks: Buffer[] = []
+      let totalBytes = 0
+      for await (const chunk of createReadStream(this.filePath)) {
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        totalBytes += bytes.byteLength
+        if (totalBytes > PLUGIN_KILL_LIST_MAX_BYTES) {
+          throw new Error('plugin kill list exceeds its size limit')
+        }
+        chunks.push(bytes)
+      }
+      return pluginKillListSchema.parse(
+        JSON.parse(Buffer.concat(chunks, totalBytes).toString('utf8'))
+      )
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null
+      }
+      throw new Error(
+        `cached plugin kill list is invalid: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
+  async write(killList: PluginKillList): Promise<void> {
+    const parsed = pluginKillListSchema.parse(killList)
+    await mkdir(dirname(this.filePath), { recursive: true })
+    const temporary = `${this.filePath}.${randomUUID()}.tmp`
+    try {
+      await writeFile(temporary, `${JSON.stringify(parsed, null, 2)}\n`, 'utf8')
+      await rename(temporary, this.filePath)
+    } finally {
+      await rm(temporary, { force: true }).catch(() => undefined)
+    }
+  }
+}

--- a/src/main/plugins/plugin-list-projection.ts
+++ b/src/main/plugins/plugin-list-projection.ts
@@ -9,6 +9,11 @@ import { isInvalidDiscoveredPlugin } from './plugin-discovery'
 import type { PluginService } from './plugin-service'
 import { listPluginVmRecipeCommands } from '../../shared/plugins/plugin-vm-recipe-artifact'
 import type { PluginCommandAliasActionId } from '../../shared/plugins/plugin-command-actions'
+import {
+  isOfficialMarketplaceGitSource,
+  isOfficialOrganizationGitSource,
+  isOfficialPluginIdentity
+} from '../../shared/plugins/plugin-marketplace'
 
 /**
  * Wire projection of installed plugins for the renderer and serve RPC.
@@ -45,6 +50,8 @@ export type PluginListEntry = {
   needsReconsent: boolean
   error?: string
   isDev: boolean
+  official: boolean
+  bundled: boolean
   capabilities: { kind: PluginCapabilityKind; description: string }[]
   panels: PluginListPanelEntry[]
   commands: {
@@ -63,8 +70,9 @@ export type PluginListEntry = {
     commands: { phase: 'create' | 'suspend' | 'resume' | 'destroy'; command: string }[]
   }[]
   restarts: number
+  blockedByKillList?: { reason: string; advisoryUrl?: string }
   source?: {
-    kind: 'local-path' | 'git' | 'marketplace'
+    kind: 'local-path' | 'git' | 'marketplace' | 'bundled'
     reference: string
     resolvedCommit: string | null
     contentHash: string
@@ -92,6 +100,8 @@ export function buildPluginList(service: PluginService, lock: PluginLockfile): P
         needsReconsent: false,
         error: plugin.error,
         isDev: plugin.isDev,
+        official: false,
+        bundled: false,
         capabilities: [],
         panels: [],
         commands: [],
@@ -104,6 +114,7 @@ export function buildPluginList(service: PluginService, lock: PluginLockfile): P
     const activation = service.activationState(plugin)
     const worker = service.workerState(plugin.pluginKey)
     const activationError = service.activationError(plugin.pluginKey)
+    const killListEntry = service.options.getPluginKillListEntry?.(plugin.pluginKey) ?? null
     let status: PluginListStatus
     if (activation === 'disabled') {
       status = 'disabled'
@@ -127,6 +138,13 @@ export function buildPluginList(service: PluginService, lock: PluginLockfile): P
       candidateLockEntry.contentHash === plugin.contentHash
         ? candidateLockEntry
         : undefined
+    const bundled = lockEntry?.source.kind === 'bundled'
+    const official =
+      bundled ||
+      (lockEntry?.source.kind === 'marketplace' &&
+        isOfficialPluginIdentity(plugin.pluginKey) &&
+        isOfficialMarketplaceGitSource(lockEntry.source.marketplace.url) &&
+        isOfficialOrganizationGitSource(lockEntry.source.plugin.url))
     return {
       pluginKey: plugin.pluginKey,
       consentFingerprint: plugin.consentFingerprint,
@@ -140,6 +158,8 @@ export function buildPluginList(service: PluginService, lock: PluginLockfile): P
         ? { error: activationError ?? 'plugin worker crashed repeatedly' }
         : {}),
       isDev: plugin.isDev,
+      official,
+      bundled,
       capabilities: plugin.manifest.capabilities.map((capability) => ({
         kind: capability.kind,
         description: PLUGIN_CAPABILITY_DESCRIPTIONS[capability.kind]
@@ -166,6 +186,14 @@ export function buildPluginList(service: PluginService, lock: PluginLockfile): P
         commands: listPluginVmRecipeCommands(recipe)
       })),
       restarts: worker.restarts,
+      ...(killListEntry
+        ? {
+            blockedByKillList: {
+              reason: killListEntry.reason,
+              ...(killListEntry.advisoryUrl ? { advisoryUrl: killListEntry.advisoryUrl } : {})
+            }
+          }
+        : {}),
       ...(lockEntry
         ? {
             source: {
@@ -175,7 +203,9 @@ export function buildPluginList(service: PluginService, lock: PluginLockfile): P
                   ? lockEntry.source.path
                   : lockEntry.source.kind === 'git'
                     ? lockEntry.source.url
-                    : lockEntry.source.plugin.url,
+                    : lockEntry.source.kind === 'marketplace'
+                      ? lockEntry.source.plugin.url
+                      : `bundled:${lockEntry.source.bundleId}`,
               resolvedCommit: lockEntry.resolvedCommit,
               contentHash: lockEntry.contentHash,
               ...(lockEntry.source.kind === 'marketplace'

--- a/src/main/plugins/plugin-list-projection.ts
+++ b/src/main/plugins/plugin-list-projection.ts
@@ -64,10 +64,11 @@ export type PluginListEntry = {
   }[]
   restarts: number
   source?: {
-    kind: 'local-path' | 'git'
+    kind: 'local-path' | 'git' | 'marketplace'
     reference: string
     resolvedCommit: string | null
     contentHash: string
+    marketplace?: { reference: string; resolvedCommit: string }
   }
 }
 
@@ -170,9 +171,21 @@ export function buildPluginList(service: PluginService, lock: PluginLockfile): P
             source: {
               kind: lockEntry.source.kind,
               reference:
-                lockEntry.source.kind === 'git' ? lockEntry.source.url : lockEntry.source.path,
+                lockEntry.source.kind === 'local-path'
+                  ? lockEntry.source.path
+                  : lockEntry.source.kind === 'git'
+                    ? lockEntry.source.url
+                    : lockEntry.source.plugin.url,
               resolvedCommit: lockEntry.resolvedCommit,
-              contentHash: lockEntry.contentHash
+              contentHash: lockEntry.contentHash,
+              ...(lockEntry.source.kind === 'marketplace'
+                ? {
+                    marketplace: {
+                      reference: lockEntry.source.marketplace.url,
+                      resolvedCommit: lockEntry.source.marketplace.resolvedCommit
+                    }
+                  }
+                : {})
             }
           }
         : {})

--- a/src/main/plugins/plugin-marketplace-fetch.ts
+++ b/src/main/plugins/plugin-marketplace-fetch.ts
@@ -1,0 +1,63 @@
+import { createReadStream } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  PLUGIN_MARKETPLACE_FILENAME,
+  pluginMarketplaceSchema,
+  type PluginMarketplace
+} from '../../shared/plugins/plugin-marketplace'
+import { checkoutPluginGitSource } from './plugin-git-repository'
+import type { PluginMarketplaceRegisteredSource } from './plugin-marketplace-store'
+
+const MARKETPLACE_INDEX_MAX_BYTES = 16 * 1024 * 1024
+
+export type PluginMarketplaceFetchResult = {
+  marketplaceCommit: string
+  marketplace: PluginMarketplace
+}
+
+/** Fetches a marketplace through system Git so private repositories use the
+ * same SSH agent and credential helpers as every other Orca Git operation. */
+export async function fetchPluginMarketplace(
+  source: PluginMarketplaceRegisteredSource
+): Promise<PluginMarketplaceFetchResult> {
+  const stagingDirectory = await mkdtemp(join(tmpdir(), 'orca-plugin-marketplace-'))
+  try {
+    const marketplaceCommit = await checkoutPluginGitSource({
+      url: source.source.url,
+      ref: source.source.ref,
+      destination: stagingDirectory,
+      workingDirectory: tmpdir()
+    })
+    const marketplace = await readPluginMarketplaceIndex(stagingDirectory)
+    return { marketplaceCommit, marketplace }
+  } finally {
+    await rm(stagingDirectory, { recursive: true, force: true })
+  }
+}
+
+export async function readPluginMarketplaceIndex(
+  rootDirectory: string
+): Promise<PluginMarketplace> {
+  const path = join(rootDirectory, PLUGIN_MARKETPLACE_FILENAME)
+  const chunks: Buffer[] = []
+  let totalBytes = 0
+  for await (const chunk of createReadStream(path)) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    totalBytes += bytes.byteLength
+    if (totalBytes > MARKETPLACE_INDEX_MAX_BYTES) {
+      throw new Error(`${PLUGIN_MARKETPLACE_FILENAME} exceeds its size limit`)
+    }
+    chunks.push(bytes)
+  }
+  try {
+    return pluginMarketplaceSchema.parse(
+      JSON.parse(Buffer.concat(chunks, totalBytes).toString('utf8'))
+    )
+  } catch (error) {
+    throw new Error(
+      `invalid ${PLUGIN_MARKETPLACE_FILENAME}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}

--- a/src/main/plugins/plugin-marketplace-installer.test.ts
+++ b/src/main/plugins/plugin-marketplace-installer.test.ts
@@ -1,0 +1,198 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PluginMarketplace } from '../../shared/plugins/plugin-marketplace'
+import { readPluginLockfile } from './plugin-install'
+import { PluginMarketplaceInstaller } from './plugin-marketplace-installer'
+import { PluginMarketplaceService } from './plugin-marketplace-service'
+
+const git = vi.hoisted(() => ({
+  checkout: vi.fn(),
+  version: '1.0.0',
+  publisher: 'community',
+  id: 'theme',
+  commit: 'a'.repeat(40),
+  payload: 'first'
+}))
+
+vi.mock('./plugin-git-repository', () => ({
+  checkoutPluginGitSource: git.checkout
+}))
+
+const roots: string[] = []
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-marketplace-installer-'))
+  roots.push(root)
+  return root
+}
+
+function marketplace(): PluginMarketplace {
+  return {
+    name: 'Community',
+    owner: 'community',
+    plugins: [
+      {
+        id: 'community.theme',
+        source: {
+          kind: 'git',
+          url: 'https://github.com/community/theme.git',
+          ref: 'stable'
+        },
+        categories: ['themes']
+      }
+    ]
+  }
+}
+
+async function writeCurrentPlugin(destination: string): Promise<void> {
+  await mkdir(destination, { recursive: true })
+  await writeFile(
+    join(destination, 'orca-plugin.json'),
+    JSON.stringify({
+      manifestVersion: 1,
+      id: git.id,
+      publisher: git.publisher,
+      name: 'Theme',
+      version: git.version,
+      engines: { orca: '>=1.0.0' },
+      pluginApi: 1,
+      capabilities: []
+    })
+  )
+  await writeFile(join(destination, 'payload.txt'), git.payload)
+}
+
+async function setup(): Promise<{
+  root: string
+  marketplace: PluginMarketplaceService
+  installer: PluginMarketplaceInstaller
+  sourceId: string
+}> {
+  const root = await tempRoot()
+  const service = new PluginMarketplaceService({
+    pluginsDataDir: join(root, 'plugins-data'),
+    fetcher: async () => ({ marketplaceCommit: 'f'.repeat(40), marketplace: marketplace() })
+  })
+  const added = await service.addSource({
+    kind: 'git',
+    url: 'https://github.com/community/plugins.git',
+    ref: 'main'
+  })
+  return {
+    root,
+    marketplace: service,
+    installer: new PluginMarketplaceInstaller({
+      marketplace: service,
+      userDataPath: root,
+      hostVersion: '1.4.0'
+    }),
+    sourceId: added.id
+  }
+}
+
+beforeEach(() => {
+  git.version = '1.0.0'
+  git.publisher = 'community'
+  git.id = 'theme'
+  git.commit = 'a'.repeat(40)
+  git.payload = 'first'
+  git.checkout.mockReset()
+  git.checkout.mockImplementation(async ({ destination }: { destination: string }) => {
+    await writeCurrentPlugin(destination)
+    return git.commit
+  })
+})
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('PluginMarketplaceInstaller', () => {
+  it('previews exact validated bytes and records marketplace provenance on install', async () => {
+    const { root, installer, sourceId } = await setup()
+
+    const preview = await installer.preview(sourceId, 'community.theme')
+    expect(preview).toMatchObject({
+      pluginKey: 'community.theme',
+      resolvedCommit: 'a'.repeat(40),
+      marketplaceCommit: 'f'.repeat(40),
+      manifest: { version: '1.0.0' }
+    })
+    const result = await installer.install(preview)
+
+    if (!result.ok) {
+      throw new Error(result.error)
+    }
+    expect(result).toMatchObject({ ok: true, resolvedCommit: 'a'.repeat(40) })
+    const lock = await readPluginLockfile(join(root, 'plugins'))
+    expect(lock.plugins['community.theme']?.source).toEqual({
+      kind: 'marketplace',
+      marketplace: {
+        url: 'https://github.com/community/plugins.git',
+        ref: 'main',
+        resolvedCommit: 'f'.repeat(40)
+      },
+      plugin: {
+        url: 'https://github.com/community/theme.git',
+        ref: 'stable'
+      }
+    })
+  })
+
+  it('requires a fresh review when the plugin ref moves after preview', async () => {
+    const { root, installer, sourceId } = await setup()
+    const preview = await installer.preview(sourceId, 'community.theme')
+    git.commit = 'b'.repeat(40)
+    git.version = '2.0.0'
+
+    await expect(installer.install(preview)).resolves.toEqual({
+      ok: false,
+      error: 'plugin source changed after preview; review the update again'
+    })
+    await expect(readFile(join(root, 'plugins', 'plugins.lock.json'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('rejects a source whose manifest identity differs from its listing', async () => {
+    const { installer, sourceId } = await setup()
+    git.publisher = 'attacker'
+
+    await expect(installer.preview(sourceId, 'community.theme')).rejects.toThrow(
+      'attacker.theme does not match marketplace listing community.theme'
+    )
+  })
+
+  it('updates from recorded marketplace provenance and rolls back one immutable version', async () => {
+    const { root, installer, sourceId } = await setup()
+    const firstPreview = await installer.preview(sourceId, 'community.theme')
+    const firstInstall = await installer.install(firstPreview)
+    expect(firstInstall.ok).toBe(true)
+    if (!firstInstall.ok) {
+      return
+    }
+
+    git.commit = 'b'.repeat(40)
+    git.version = '2.0.0'
+    git.payload = 'second'
+    const updatePreview = await installer.previewInstalledUpdate('community.theme')
+    expect(updatePreview).toMatchObject({ resolvedCommit: 'b'.repeat(40) })
+    await expect(installer.install(updatePreview)).resolves.toMatchObject({
+      ok: true,
+      version: '2.0.0'
+    })
+
+    await expect(installer.rollback('community.theme')).resolves.toMatchObject({
+      ok: true,
+      version: '1.0.0',
+      contentHash: firstInstall.contentHash
+    })
+    const lock = await readPluginLockfile(join(root, 'plugins'))
+    expect(lock.plugins['community.theme']).toMatchObject({
+      version: '1.0.0',
+      resolvedCommit: 'a'.repeat(40)
+    })
+  })
+})

--- a/src/main/plugins/plugin-marketplace-installer.ts
+++ b/src/main/plugins/plugin-marketplace-installer.ts
@@ -1,0 +1,152 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { PluginManifest } from '../../shared/plugins/plugin-manifest'
+import { getUserPluginsDir } from './plugin-discovery'
+import { checkoutPluginGitSource } from './plugin-git-repository'
+import {
+  installPluginFromMarketplace,
+  readPluginLockfile,
+  rollbackInstalledPlugin,
+  type PluginInstallResult
+} from './plugin-install'
+import { inspectPluginInstallTree } from './plugin-install-staging'
+import type {
+  PluginMarketplaceListing,
+  PluginMarketplaceService
+} from './plugin-marketplace-service'
+import { marketplaceSourceId } from './plugin-marketplace-store'
+
+export type PluginMarketplaceInstallPreview = {
+  marketplaceSourceId: string
+  marketplaceName: string
+  marketplaceOwner: string
+  marketplaceCommit: string
+  pluginKey: string
+  source: PluginMarketplaceListing['source']
+  resolvedCommit: string
+  contentHash: string
+  consentFingerprint: string
+  manifest: PluginManifest
+  official: boolean
+  bundled: boolean
+}
+
+export type PluginMarketplacePreviewIdentity = Pick<
+  PluginMarketplaceInstallPreview,
+  'marketplaceSourceId' | 'marketplaceCommit' | 'pluginKey' | 'resolvedCommit'
+>
+
+export class PluginMarketplaceInstaller {
+  private readonly marketplace: PluginMarketplaceService
+  private readonly userDataPath: string
+  private readonly hostVersion: string
+
+  constructor(options: {
+    marketplace: PluginMarketplaceService
+    userDataPath: string
+    hostVersion: string
+  }) {
+    this.marketplace = options.marketplace
+    this.userDataPath = options.userDataPath
+    this.hostVersion = options.hostVersion
+  }
+
+  async preview(
+    marketplaceSourceId: string,
+    pluginKey: string
+  ): Promise<PluginMarketplaceInstallPreview> {
+    const listing = await this.requireListing(marketplaceSourceId, pluginKey)
+    const stagingDirectory = await mkdtemp(join(tmpdir(), 'orca-plugin-marketplace-preview-'))
+    try {
+      const resolvedCommit = await checkoutPluginGitSource({
+        url: listing.source.url,
+        ref: listing.source.ref,
+        destination: stagingDirectory,
+        workingDirectory: tmpdir()
+      })
+      const inspection = await inspectPluginInstallTree({
+        rootDir: stagingDirectory,
+        hostVersion: this.hostVersion,
+        expectedPluginKey: pluginKey
+      })
+      if (!inspection.ok) {
+        throw new Error(inspection.error)
+      }
+      return {
+        marketplaceSourceId,
+        marketplaceName: listing.marketplaceName,
+        marketplaceOwner: listing.marketplaceOwner,
+        marketplaceCommit: listing.marketplaceCommit,
+        pluginKey,
+        source: listing.source,
+        resolvedCommit,
+        contentHash: inspection.contentHash,
+        consentFingerprint: inspection.consentFingerprint,
+        manifest: inspection.manifest,
+        official: listing.official,
+        bundled: listing.bundled
+      }
+    } finally {
+      await rm(stagingDirectory, { recursive: true, force: true })
+    }
+  }
+
+  async install(preview: PluginMarketplacePreviewIdentity): Promise<PluginInstallResult> {
+    const listing = await this.requireListing(preview.marketplaceSourceId, preview.pluginKey)
+    if (listing.marketplaceCommit !== preview.marketplaceCommit) {
+      return { ok: false, error: 'marketplace changed after preview; review the plugin again' }
+    }
+    const sourceState = (await this.marketplace.listSources()).find(
+      (source) => source.id === preview.marketplaceSourceId
+    )
+    if (!sourceState) {
+      return { ok: false, error: 'marketplace source is no longer configured' }
+    }
+    return installPluginFromMarketplace({
+      pluginsDir: getUserPluginsDir(this.userDataPath),
+      hostVersion: this.hostVersion,
+      expectedPluginKey: preview.pluginKey,
+      expectedResolvedCommit: preview.resolvedCommit,
+      marketplace: {
+        url: sourceState.source.url,
+        ref: sourceState.source.ref,
+        resolvedCommit: preview.marketplaceCommit
+      },
+      plugin: { url: listing.source.url, ref: listing.source.ref }
+    })
+  }
+
+  async previewInstalledUpdate(pluginKey: string): Promise<PluginMarketplaceInstallPreview> {
+    const lock = await readPluginLockfile(getUserPluginsDir(this.userDataPath))
+    const entry = lock.plugins[pluginKey]
+    if (!entry || entry.source.kind !== 'marketplace') {
+      throw new Error(`plugin ${pluginKey} was not installed from a marketplace`)
+    }
+    const sourceId = marketplaceSourceId({
+      kind: 'git',
+      url: entry.source.marketplace.url,
+      ref: entry.source.marketplace.ref
+    })
+    return this.preview(sourceId, pluginKey)
+  }
+
+  async rollback(pluginKey: string): Promise<PluginInstallResult> {
+    return rollbackInstalledPlugin({
+      pluginsDir: getUserPluginsDir(this.userDataPath),
+      pluginKey,
+      hostVersion: this.hostVersion
+    })
+  }
+
+  private async requireListing(
+    marketplaceSourceId: string,
+    pluginKey: string
+  ): Promise<PluginMarketplaceListing> {
+    const listing = await this.marketplace.findPlugin(marketplaceSourceId, pluginKey)
+    if (!listing) {
+      throw new Error(`plugin ${pluginKey} is not listed by marketplace ${marketplaceSourceId}`)
+    }
+    return listing
+  }
+}

--- a/src/main/plugins/plugin-marketplace-installer.ts
+++ b/src/main/plugins/plugin-marketplace-installer.ts
@@ -30,6 +30,7 @@ export type PluginMarketplaceInstallPreview = {
   manifest: PluginManifest
   official: boolean
   bundled: boolean
+  blockedByKillList?: { reason: string; advisoryUrl?: string }
 }
 
 export type PluginMarketplacePreviewIdentity = Pick<
@@ -41,15 +42,18 @@ export class PluginMarketplaceInstaller {
   private readonly marketplace: PluginMarketplaceService
   private readonly userDataPath: string
   private readonly hostVersion: string
+  private readonly blockedPluginReason: (pluginKey: string) => string | null
 
   constructor(options: {
     marketplace: PluginMarketplaceService
     userDataPath: string
     hostVersion: string
+    blockedPluginReason?: (pluginKey: string) => string | null
   }) {
     this.marketplace = options.marketplace
     this.userDataPath = options.userDataPath
     this.hostVersion = options.hostVersion
+    this.blockedPluginReason = options.blockedPluginReason ?? (() => null)
   }
 
   async preview(
@@ -85,7 +89,8 @@ export class PluginMarketplaceInstaller {
         consentFingerprint: inspection.consentFingerprint,
         manifest: inspection.manifest,
         official: listing.official,
-        bundled: listing.bundled
+        bundled: listing.bundled,
+        ...(listing.blockedByKillList ? { blockedByKillList: listing.blockedByKillList } : {})
       }
     } finally {
       await rm(stagingDirectory, { recursive: true, force: true })
@@ -94,6 +99,11 @@ export class PluginMarketplaceInstaller {
 
   async install(preview: PluginMarketplacePreviewIdentity): Promise<PluginInstallResult> {
     const listing = await this.requireListing(preview.marketplaceSourceId, preview.pluginKey)
+    const blockedReason =
+      listing.blockedByKillList?.reason ?? this.blockedPluginReason(preview.pluginKey)
+    if (blockedReason) {
+      return { ok: false, error: `plugin is blocked by Orca's safety list: ${blockedReason}` }
+    }
     if (listing.marketplaceCommit !== preview.marketplaceCommit) {
       return { ok: false, error: 'marketplace changed after preview; review the plugin again' }
     }
@@ -113,7 +123,8 @@ export class PluginMarketplaceInstaller {
         ref: sourceState.source.ref,
         resolvedCommit: preview.marketplaceCommit
       },
-      plugin: { url: listing.source.url, ref: listing.source.ref }
+      plugin: { url: listing.source.url, ref: listing.source.ref },
+      blockedPluginReason: this.blockedPluginReason
     })
   }
 
@@ -135,7 +146,8 @@ export class PluginMarketplaceInstaller {
     return rollbackInstalledPlugin({
       pluginsDir: getUserPluginsDir(this.userDataPath),
       pluginKey,
-      hostVersion: this.hostVersion
+      hostVersion: this.hostVersion,
+      blockedPluginReason: this.blockedPluginReason
     })
   }
 

--- a/src/main/plugins/plugin-marketplace-service.test.ts
+++ b/src/main/plugins/plugin-marketplace-service.test.ts
@@ -1,0 +1,183 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  PluginMarketplace,
+  PluginMarketplaceGitSource
+} from '../../shared/plugins/plugin-marketplace'
+import type { PluginMarketplaceFetchResult } from './plugin-marketplace-fetch'
+import { PluginMarketplaceService } from './plugin-marketplace-service'
+import type { PluginMarketplaceRegisteredSource } from './plugin-marketplace-store'
+
+const roots: string[] = []
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-marketplace-service-'))
+  roots.push(root)
+  return root
+}
+
+function source(url = 'https://github.com/community/plugins.git'): PluginMarketplaceGitSource {
+  return { kind: 'git', url, ref: 'main' }
+}
+
+function marketplace(
+  name = 'Community',
+  pluginKey = 'community.theme',
+  pluginUrl = 'https://github.com/community/theme.git'
+): PluginMarketplace {
+  return {
+    name,
+    owner: name.toLowerCase(),
+    plugins: [
+      {
+        id: pluginKey,
+        source: { kind: 'git', url: pluginUrl, ref: 'v1' },
+        description: 'A theme',
+        categories: ['themes']
+      }
+    ]
+  }
+}
+
+function fetched(value = marketplace(), commit = 'a'.repeat(40)): PluginMarketplaceFetchResult {
+  return { marketplaceCommit: commit, marketplace: value }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('PluginMarketplaceService', () => {
+  it('fetches before registration, then serves browse data from the local snapshot', async () => {
+    const fetcher = vi
+      .fn<
+        (registration: PluginMarketplaceRegisteredSource) => Promise<PluginMarketplaceFetchResult>
+      >()
+      .mockResolvedValue(fetched())
+    const service = new PluginMarketplaceService({ pluginsDataDir: await tempRoot(), fetcher })
+
+    const added = await service.addSource(source())
+
+    expect(added).toMatchObject({ marketplace: { name: 'Community' }, stale: false })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    await expect(service.listPlugins()).resolves.toEqual([
+      expect.objectContaining({
+        marketplaceSourceId: added.id,
+        pluginKey: 'community.theme',
+        official: false,
+        bundled: false
+      })
+    ])
+    await service.listSources()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps and labels the last valid snapshot when a refresh is offline', async () => {
+    const fetcher = vi
+      .fn<
+        (registration: PluginMarketplaceRegisteredSource) => Promise<PluginMarketplaceFetchResult>
+      >()
+      .mockResolvedValueOnce(fetched())
+      .mockRejectedValueOnce(new Error('offline'))
+    const service = new PluginMarketplaceService({ pluginsDataDir: await tempRoot(), fetcher })
+    const added = await service.addSource(source())
+
+    await expect(service.refreshSource(added.id)).resolves.toMatchObject({
+      marketplace: { name: 'Community', resolvedCommit: 'a'.repeat(40) },
+      stale: true,
+      error: 'offline'
+    })
+    await expect(service.listPlugins()).resolves.toEqual([
+      expect.objectContaining({ pluginKey: 'community.theme' })
+    ])
+  })
+
+  it('atomically replaces the cache only after a valid refreshed index', async () => {
+    const fetcher = vi
+      .fn<
+        (registration: PluginMarketplaceRegisteredSource) => Promise<PluginMarketplaceFetchResult>
+      >()
+      .mockResolvedValueOnce(fetched())
+      .mockResolvedValueOnce(fetched(marketplace('Updated'), 'b'.repeat(40)))
+    const root = await tempRoot()
+    const service = new PluginMarketplaceService({ pluginsDataDir: root, fetcher })
+    const added = await service.addSource(source())
+
+    await expect(service.refreshSource(added.id)).resolves.toMatchObject({
+      marketplace: { name: 'Updated', resolvedCommit: 'b'.repeat(40) },
+      stale: false
+    })
+    await expect(
+      new PluginMarketplaceService({ pluginsDataDir: root, fetcher }).listPlugins()
+    ).resolves.toEqual([expect.objectContaining({ marketplaceName: 'Updated' })])
+  })
+
+  it('does not persist a source whose first fetch fails', async () => {
+    const service = new PluginMarketplaceService({
+      pluginsDataDir: await tempRoot(),
+      fetcher: async () => {
+        throw new Error('authentication failed')
+      }
+    })
+
+    await expect(service.addSource(source())).rejects.toThrow('authentication failed')
+    await expect(service.listSources()).resolves.toEqual([])
+  })
+
+  it('rejects reserved identities outside the official organization', async () => {
+    const service = new PluginMarketplaceService({
+      pluginsDataDir: await tempRoot(),
+      fetcher: async () =>
+        fetched(
+          marketplace('Attack', 'community.orca-secrets', 'https://github.com/attacker/x.git')
+        )
+    })
+
+    await expect(service.addSource(source())).rejects.toThrow(
+      'reserved plugin identity community.orca-secrets'
+    )
+    await expect(service.listSources()).resolves.toEqual([])
+  })
+
+  it('derives the Official badge only from the canonical marketplace and source organization', async () => {
+    const officialMarketplace: PluginMarketplace = {
+      name: 'Orca Plugins',
+      owner: 'stablyai',
+      plugins: [
+        {
+          id: 'stablyai.orca-skills',
+          source: {
+            kind: 'git',
+            url: 'git@github.com:stablyai/orca-skills.git',
+            ref: 'main'
+          },
+          categories: ['skills']
+        }
+      ]
+    }
+    const service = new PluginMarketplaceService({
+      pluginsDataDir: await tempRoot(),
+      fetcher: async () => fetched(officialMarketplace)
+    })
+
+    await service.addSource(source('https://github.com/stablyai/orca-plugins.git'))
+
+    await expect(service.listPlugins()).resolves.toEqual([
+      expect.objectContaining({ pluginKey: 'stablyai.orca-skills', official: true })
+    ])
+  })
+
+  it('removes source metadata and browse listings together', async () => {
+    const service = new PluginMarketplaceService({
+      pluginsDataDir: await tempRoot(),
+      fetcher: async () => fetched()
+    })
+    const added = await service.addSource(source())
+
+    await expect(service.removeSource(added.id)).resolves.toBe(true)
+    await expect(service.listSources()).resolves.toEqual([])
+    await expect(service.listPlugins()).resolves.toEqual([])
+  })
+})

--- a/src/main/plugins/plugin-marketplace-service.ts
+++ b/src/main/plugins/plugin-marketplace-service.ts
@@ -18,6 +18,7 @@ import {
   type PluginMarketplaceCachedSnapshot,
   type PluginMarketplaceRegisteredSource
 } from './plugin-marketplace-store'
+import type { PluginKillListEntry } from '../../shared/plugins/plugin-kill-list'
 
 export type PluginMarketplaceSourceState = {
   id: string
@@ -44,6 +45,7 @@ export type PluginMarketplaceListing = {
   categories: string[]
   official: boolean
   bundled: boolean
+  blockedByKillList?: { reason: string; advisoryUrl?: string }
 }
 
 type MarketplaceFetcher = (
@@ -53,15 +55,18 @@ type MarketplaceFetcher = (
 export class PluginMarketplaceService {
   private readonly store: PluginMarketplaceStore
   private readonly fetcher: MarketplaceFetcher
+  private readonly getKillListEntry: (pluginKey: string) => PluginKillListEntry | null
   private readonly refreshChains = new Map<string, Promise<PluginMarketplaceSourceState>>()
 
   constructor(options: {
     pluginsDataDir: string
     fetcher?: MarketplaceFetcher
     store?: PluginMarketplaceStore
+    getKillListEntry?: (pluginKey: string) => PluginKillListEntry | null
   }) {
     this.store = options.store ?? new PluginMarketplaceStore(options.pluginsDataDir)
     this.fetcher = options.fetcher ?? fetchPluginMarketplace
+    this.getKillListEntry = options.getKillListEntry ?? (() => null)
   }
 
   async listSources(): Promise<PluginMarketplaceSourceState[]> {
@@ -205,6 +210,7 @@ export class PluginMarketplaceService {
       snapshot.marketplace.owner.toLowerCase() === OFFICIAL_MARKETPLACE_OWNER &&
       isOfficialPluginIdentity(entry.id) &&
       isOfficialOrganizationGitSource(entry.source.url)
+    const blocked = this.getKillListEntry(entry.id)
     return {
       marketplaceSourceId: source.id,
       marketplaceName: snapshot.marketplace.name,
@@ -215,7 +221,15 @@ export class PluginMarketplaceService {
       ...(entry.description ? { description: entry.description } : {}),
       categories: entry.categories,
       official,
-      bundled: false
+      bundled: false,
+      ...(blocked
+        ? {
+            blockedByKillList: {
+              reason: blocked.reason,
+              ...(blocked.advisoryUrl ? { advisoryUrl: blocked.advisoryUrl } : {})
+            }
+          }
+        : {})
     }
   }
 

--- a/src/main/plugins/plugin-marketplace-service.ts
+++ b/src/main/plugins/plugin-marketplace-service.ts
@@ -1,0 +1,267 @@
+import {
+  OFFICIAL_MARKETPLACE_OWNER,
+  isOfficialMarketplaceGitSource,
+  isOfficialOrganizationGitSource,
+  isOfficialPluginIdentity,
+  isReservedPluginIdentity,
+  pluginMarketplaceGitSourceSchema,
+  type PluginMarketplaceEntry,
+  type PluginMarketplaceGitSource
+} from '../../shared/plugins/plugin-marketplace'
+import {
+  fetchPluginMarketplace,
+  type PluginMarketplaceFetchResult
+} from './plugin-marketplace-fetch'
+import {
+  marketplaceSourceId,
+  PluginMarketplaceStore,
+  type PluginMarketplaceCachedSnapshot,
+  type PluginMarketplaceRegisteredSource
+} from './plugin-marketplace-store'
+
+export type PluginMarketplaceSourceState = {
+  id: string
+  source: PluginMarketplaceGitSource
+  addedAt: number
+  marketplace: {
+    name: string
+    owner: string
+    resolvedCommit: string
+    fetchedAt: number
+  } | null
+  stale: boolean
+  error?: string
+}
+
+export type PluginMarketplaceListing = {
+  marketplaceSourceId: string
+  marketplaceName: string
+  marketplaceOwner: string
+  marketplaceCommit: string
+  pluginKey: string
+  source: PluginMarketplaceEntry['source']
+  description?: string
+  categories: string[]
+  official: boolean
+  bundled: boolean
+}
+
+type MarketplaceFetcher = (
+  source: PluginMarketplaceRegisteredSource
+) => Promise<PluginMarketplaceFetchResult>
+
+export class PluginMarketplaceService {
+  private readonly store: PluginMarketplaceStore
+  private readonly fetcher: MarketplaceFetcher
+  private readonly refreshChains = new Map<string, Promise<PluginMarketplaceSourceState>>()
+
+  constructor(options: {
+    pluginsDataDir: string
+    fetcher?: MarketplaceFetcher
+    store?: PluginMarketplaceStore
+  }) {
+    this.store = options.store ?? new PluginMarketplaceStore(options.pluginsDataDir)
+    this.fetcher = options.fetcher ?? fetchPluginMarketplace
+  }
+
+  async listSources(): Promise<PluginMarketplaceSourceState[]> {
+    const sources = await this.store.listSources()
+    return Promise.all(
+      sources.map(async (source) => {
+        try {
+          return this.stateFromSnapshot(source, await this.store.readSnapshot(source.id), false)
+        } catch (error) {
+          return this.stateFromSnapshot(source, null, true, errorMessage(error))
+        }
+      })
+    )
+  }
+
+  async addSource(source: PluginMarketplaceGitSource): Promise<PluginMarketplaceSourceState> {
+    const parsedSource = pluginMarketplaceGitSourceSchema.parse(source)
+    const sourceId = marketplaceSourceId(parsedSource)
+    const existing = (await this.store.listSources()).find((candidate) => candidate.id === sourceId)
+    const candidate: PluginMarketplaceRegisteredSource = existing ?? {
+      id: sourceId,
+      source: parsedSource,
+      addedAt: Date.now()
+    }
+    const fetched = await this.fetchAndValidate(candidate)
+    const registered = existing ?? (await this.store.addSource(parsedSource, candidate.addedAt))
+    try {
+      const snapshot = await this.store.writeSnapshot({ source: registered, ...fetched })
+      return this.stateFromSnapshot(registered, snapshot, false)
+    } catch (error) {
+      if (!existing) {
+        await this.store.removeSource(registered.id).catch(() => undefined)
+      }
+      throw error
+    }
+  }
+
+  async removeSource(sourceId: string): Promise<boolean> {
+    return this.store.removeSource(sourceId)
+  }
+
+  async refreshSource(sourceId: string): Promise<PluginMarketplaceSourceState> {
+    const previous = this.refreshChains.get(sourceId) ?? Promise.resolve(null)
+    const refresh = previous.catch(() => null).then(() => this.performRefresh(sourceId))
+    this.refreshChains.set(sourceId, refresh)
+    try {
+      return await refresh
+    } finally {
+      if (this.refreshChains.get(sourceId) === refresh) {
+        this.refreshChains.delete(sourceId)
+      }
+    }
+  }
+
+  async refreshAll(): Promise<PluginMarketplaceSourceState[]> {
+    const sources = await this.store.listSources()
+    return Promise.all(sources.map((source) => this.refreshSource(source.id)))
+  }
+
+  async listPlugins(): Promise<PluginMarketplaceListing[]> {
+    const states = await this.listSnapshots()
+    return states
+      .flatMap(({ source, snapshot }) =>
+        snapshot.marketplace.plugins.map((entry) => this.listingFromEntry(source, snapshot, entry))
+      )
+      .sort((left, right) =>
+        `${left.pluginKey}\0${left.marketplaceSourceId}`.localeCompare(
+          `${right.pluginKey}\0${right.marketplaceSourceId}`
+        )
+      )
+  }
+
+  async findPlugin(
+    marketplaceSourceId: string,
+    pluginKey: string
+  ): Promise<PluginMarketplaceListing | null> {
+    const source = (await this.store.listSources()).find(
+      (candidate) => candidate.id === marketplaceSourceId
+    )
+    if (!source) {
+      return null
+    }
+    const snapshot = await this.store.readSnapshot(source.id)
+    const entry = snapshot?.marketplace.plugins.find((plugin) => plugin.id === pluginKey)
+    return snapshot && entry ? this.listingFromEntry(source, snapshot, entry) : null
+  }
+
+  private async performRefresh(sourceId: string): Promise<PluginMarketplaceSourceState> {
+    const source = (await this.store.listSources()).find((candidate) => candidate.id === sourceId)
+    if (!source) {
+      throw new Error(`unknown marketplace source: ${sourceId}`)
+    }
+    try {
+      const fetched = await this.fetchAndValidate(source)
+      const snapshot = await this.store.writeSnapshot({ source, ...fetched })
+      return this.stateFromSnapshot(source, snapshot, false)
+    } catch (error) {
+      const cached = await this.store.readSnapshot(source.id).catch(() => null)
+      if (!cached) {
+        throw error
+      }
+      return this.stateFromSnapshot(source, cached, true, errorMessage(error))
+    }
+  }
+
+  private async fetchAndValidate(
+    source: PluginMarketplaceRegisteredSource
+  ): Promise<PluginMarketplaceFetchResult> {
+    const fetched = await this.fetcher(source)
+    validateMarketplaceProvenance(source, fetched)
+    return fetched
+  }
+
+  private async listSnapshots(): Promise<
+    { source: PluginMarketplaceRegisteredSource; snapshot: PluginMarketplaceCachedSnapshot }[]
+  > {
+    const sources = await this.store.listSources()
+    const snapshots = await Promise.all(
+      sources.map(async (source) => ({
+        source,
+        snapshot: await this.store.readSnapshot(source.id)
+      }))
+    )
+    return snapshots.filter(
+      (
+        candidate
+      ): candidate is {
+        source: PluginMarketplaceRegisteredSource
+        snapshot: PluginMarketplaceCachedSnapshot
+      } => candidate.snapshot !== null
+    )
+  }
+
+  private listingFromEntry(
+    source: PluginMarketplaceRegisteredSource,
+    snapshot: PluginMarketplaceCachedSnapshot,
+    entry: PluginMarketplaceEntry
+  ): PluginMarketplaceListing {
+    const official =
+      isOfficialMarketplaceGitSource(source.source.url) &&
+      snapshot.marketplace.owner.toLowerCase() === OFFICIAL_MARKETPLACE_OWNER &&
+      isOfficialPluginIdentity(entry.id) &&
+      isOfficialOrganizationGitSource(entry.source.url)
+    return {
+      marketplaceSourceId: source.id,
+      marketplaceName: snapshot.marketplace.name,
+      marketplaceOwner: snapshot.marketplace.owner,
+      marketplaceCommit: snapshot.marketplaceCommit,
+      pluginKey: entry.id,
+      source: entry.source,
+      ...(entry.description ? { description: entry.description } : {}),
+      categories: entry.categories,
+      official,
+      bundled: false
+    }
+  }
+
+  private stateFromSnapshot(
+    source: PluginMarketplaceRegisteredSource,
+    snapshot: PluginMarketplaceCachedSnapshot | null,
+    stale: boolean,
+    error?: string
+  ): PluginMarketplaceSourceState {
+    return {
+      id: source.id,
+      source: source.source,
+      addedAt: source.addedAt,
+      marketplace: snapshot
+        ? {
+            name: snapshot.marketplace.name,
+            owner: snapshot.marketplace.owner,
+            resolvedCommit: snapshot.marketplaceCommit,
+            fetchedAt: snapshot.fetchedAt
+          }
+        : null,
+      stale,
+      ...(error ? { error } : {})
+    }
+  }
+}
+
+function validateMarketplaceProvenance(
+  source: PluginMarketplaceRegisteredSource,
+  fetched: PluginMarketplaceFetchResult
+): void {
+  if (
+    isOfficialMarketplaceGitSource(source.source.url) &&
+    fetched.marketplace.owner.toLowerCase() !== OFFICIAL_MARKETPLACE_OWNER
+  ) {
+    throw new Error('official marketplace metadata has an unexpected owner')
+  }
+  for (const entry of fetched.marketplace.plugins) {
+    if (isReservedPluginIdentity(entry.id) && !isOfficialOrganizationGitSource(entry.source.url)) {
+      throw new Error(
+        `reserved plugin identity ${entry.id} must resolve to the stablyai organization`
+      )
+    }
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/main/plugins/plugin-marketplace-store.test.ts
+++ b/src/main/plugins/plugin-marketplace-store.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { PluginMarketplaceGitSource } from '../../shared/plugins/plugin-marketplace'
+import { marketplaceSourceId, PluginMarketplaceStore } from './plugin-marketplace-store'
+
+const roots: string[] = []
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-marketplace-store-'))
+  roots.push(root)
+  return root
+}
+
+function source(ref = 'main'): PluginMarketplaceGitSource {
+  return { kind: 'git', url: 'https://github.com/community/plugins.git', ref }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('PluginMarketplaceStore', () => {
+  it('persists bounded source registrations under a deterministic opaque id', async () => {
+    const root = await tempRoot()
+    const first = new PluginMarketplaceStore(root)
+    const registered = await first.addSource(source(), 123)
+
+    expect(registered).toEqual({
+      id: marketplaceSourceId(source()),
+      source: source(),
+      addedAt: 123
+    })
+    await expect(new PluginMarketplaceStore(root).listSources()).resolves.toEqual([registered])
+    await expect(first.addSource(source(), 999)).resolves.toEqual(registered)
+  })
+
+  it('atomically publishes a strict cached snapshot and removes it with its source', async () => {
+    const root = await tempRoot()
+    const store = new PluginMarketplaceStore(root)
+    const registered = await store.addSource(source(), 123)
+    const snapshot = await store.writeSnapshot({
+      source: registered,
+      marketplaceCommit: 'a'.repeat(40),
+      fetchedAt: 456,
+      marketplace: {
+        name: 'Community',
+        owner: 'community',
+        plugins: [
+          {
+            id: 'community.theme',
+            source: {
+              kind: 'git',
+              url: 'https://github.com/community/theme.git',
+              ref: 'v1'
+            },
+            categories: ['themes']
+          }
+        ]
+      }
+    })
+
+    await expect(new PluginMarketplaceStore(root).readSnapshot(registered.id)).resolves.toEqual(
+      snapshot
+    )
+    expect(
+      (await readdir(join(root, 'marketplaces', 'snapshots'))).filter((entry) =>
+        entry.endsWith('.tmp')
+      )
+    ).toEqual([])
+    await expect(store.removeSource(registered.id)).resolves.toBe(true)
+    await expect(store.readSnapshot(registered.id)).resolves.toBeNull()
+  })
+
+  it('keeps distinct refs as distinct marketplace sources', () => {
+    expect(marketplaceSourceId(source('main'))).not.toBe(marketplaceSourceId(source('stable')))
+  })
+
+  it('rejects path-like source ids before reading or deleting cache files', async () => {
+    const store = new PluginMarketplaceStore(await tempRoot())
+    await expect(store.readSnapshot('../outside')).rejects.toThrow()
+    await expect(store.removeSource('../outside')).rejects.toThrow()
+  })
+})

--- a/src/main/plugins/plugin-marketplace-store.ts
+++ b/src/main/plugins/plugin-marketplace-store.ts
@@ -1,0 +1,216 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { z } from 'zod'
+import {
+  pluginMarketplaceGitSourceSchema,
+  pluginMarketplaceSchema,
+  type PluginMarketplace,
+  type PluginMarketplaceGitSource
+} from '../../shared/plugins/plugin-marketplace'
+
+export const PLUGIN_MARKETPLACE_SOURCE_LIMIT = 64
+export const PLUGIN_MARKETPLACE_SOURCE_ID_PATTERN = /^[0-9a-f]{32}$/
+
+const sourceIdSchema = z.string().regex(PLUGIN_MARKETPLACE_SOURCE_ID_PATTERN)
+const registeredSourceSchema = z.strictObject({
+  id: sourceIdSchema,
+  source: pluginMarketplaceGitSourceSchema,
+  addedAt: z.number().finite().nonnegative()
+})
+const sourceFileSchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  sources: z.array(registeredSourceSchema).max(PLUGIN_MARKETPLACE_SOURCE_LIMIT)
+})
+const cachedSnapshotSchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  sourceId: sourceIdSchema,
+  source: pluginMarketplaceGitSourceSchema,
+  marketplaceCommit: z.string().regex(/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/),
+  fetchedAt: z.number().finite().nonnegative(),
+  marketplace: pluginMarketplaceSchema
+})
+
+export type PluginMarketplaceRegisteredSource = z.infer<typeof registeredSourceSchema>
+export type PluginMarketplaceCachedSnapshot = z.infer<typeof cachedSnapshotSchema>
+
+const SOURCE_FILE_MAX_BYTES = 2 * 1024 * 1024
+const SNAPSHOT_FILE_MAX_BYTES = 16 * 1024 * 1024
+
+export function marketplaceSourceId(source: PluginMarketplaceGitSource): string {
+  const parsed = pluginMarketplaceGitSourceSchema.parse(source)
+  return createHash('sha256')
+    .update(`orca-plugin-marketplace-source-v1\0${parsed.url}\0${parsed.ref}`)
+    .digest('hex')
+    .slice(0, 32)
+}
+
+export class PluginMarketplaceStore {
+  private readonly sourcesPath: string
+  private readonly snapshotDirectory: string
+  private sources: PluginMarketplaceRegisteredSource[] | null = null
+  private writeChain: Promise<void> = Promise.resolve()
+
+  constructor(pluginsDataDir: string) {
+    const root = join(pluginsDataDir, 'marketplaces')
+    this.sourcesPath = join(root, 'sources.json')
+    this.snapshotDirectory = join(root, 'snapshots')
+  }
+
+  async listSources(): Promise<readonly PluginMarketplaceRegisteredSource[]> {
+    await this.loadSources()
+    return this.sources!
+  }
+
+  async addSource(
+    source: PluginMarketplaceGitSource,
+    addedAt = Date.now()
+  ): Promise<PluginMarketplaceRegisteredSource> {
+    const parsedSource = pluginMarketplaceGitSourceSchema.parse(source)
+    const registration = registeredSourceSchema.parse({
+      id: marketplaceSourceId(parsedSource),
+      source: parsedSource,
+      addedAt
+    })
+    await this.mutateSources((sources) => {
+      if (sources.some((candidate) => candidate.id === registration.id)) {
+        return [...sources]
+      }
+      if (sources.length >= PLUGIN_MARKETPLACE_SOURCE_LIMIT) {
+        throw new Error(`marketplace source limit (${PLUGIN_MARKETPLACE_SOURCE_LIMIT}) reached`)
+      }
+      return [...sources, registration]
+    })
+    return this.sources!.find((candidate) => candidate.id === registration.id)!
+  }
+
+  async removeSource(sourceId: string): Promise<boolean> {
+    const parsedId = sourceIdSchema.parse(sourceId)
+    let removed = false
+    await this.mutateSources((sources) => {
+      const next = sources.filter((source) => source.id !== parsedId)
+      removed = next.length !== sources.length
+      return next
+    })
+    if (removed) {
+      await rm(this.snapshotPath(parsedId), { force: true })
+    }
+    return removed
+  }
+
+  async writeSnapshot(input: {
+    source: PluginMarketplaceRegisteredSource
+    marketplaceCommit: string
+    fetchedAt?: number
+    marketplace: PluginMarketplace
+  }): Promise<PluginMarketplaceCachedSnapshot> {
+    const snapshot = cachedSnapshotSchema.parse({
+      schemaVersion: 1,
+      sourceId: input.source.id,
+      source: input.source.source,
+      marketplaceCommit: input.marketplaceCommit,
+      fetchedAt: input.fetchedAt ?? Date.now(),
+      marketplace: input.marketplace
+    })
+    await writeAtomicJson(this.snapshotPath(input.source.id), snapshot)
+    return snapshot
+  }
+
+  async readSnapshot(sourceId: string): Promise<PluginMarketplaceCachedSnapshot | null> {
+    const parsedId = sourceIdSchema.parse(sourceId)
+    try {
+      const raw = JSON.parse(
+        await readBoundedText(this.snapshotPath(parsedId), SNAPSHOT_FILE_MAX_BYTES)
+      )
+      const parsed = cachedSnapshotSchema.parse(raw)
+      if (parsed.sourceId !== parsedId) {
+        throw new Error('marketplace snapshot source identity does not match its cache path')
+      }
+      return parsed
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null
+      }
+      throw new Error(
+        `marketplace snapshot is invalid: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
+  private async loadSources(): Promise<void> {
+    if (this.sources !== null) {
+      return
+    }
+    try {
+      const parsed = sourceFileSchema.parse(
+        JSON.parse(await readBoundedText(this.sourcesPath, SOURCE_FILE_MAX_BYTES))
+      )
+      const ids = new Set<string>()
+      for (const source of parsed.sources) {
+        if (source.id !== marketplaceSourceId(source.source) || ids.has(source.id)) {
+          throw new Error('marketplace source identity is inconsistent or duplicated')
+        }
+        ids.add(source.id)
+      }
+      this.sources = parsed.sources
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.sources = []
+        return
+      }
+      throw new Error(
+        `marketplace sources are invalid: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
+  private async mutateSources(
+    mutation: (
+      sources: readonly PluginMarketplaceRegisteredSource[]
+    ) => PluginMarketplaceRegisteredSource[]
+  ): Promise<void> {
+    const update = this.writeChain
+      .catch(() => undefined)
+      .then(async () => {
+        await this.loadSources()
+        const next = sourceFileSchema.parse({
+          schemaVersion: 1,
+          sources: mutation(this.sources!)
+        }).sources
+        await writeAtomicJson(this.sourcesPath, { schemaVersion: 1, sources: next })
+        this.sources = next
+      })
+    this.writeChain = update
+    await update
+  }
+
+  private snapshotPath(sourceId: string): string {
+    return join(this.snapshotDirectory, `${sourceId}.json`)
+  }
+}
+
+async function readBoundedText(path: string, limit: number): Promise<string> {
+  const chunks: Buffer[] = []
+  let totalBytes = 0
+  for await (const chunk of createReadStream(path)) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    totalBytes += bytes.byteLength
+    if (totalBytes > limit) {
+      throw new Error(`file exceeds its ${limit}-byte limit`)
+    }
+    chunks.push(bytes)
+  }
+  return Buffer.concat(chunks, totalBytes).toString('utf8')
+}
+
+async function writeAtomicJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const temporary = `${path}.${randomUUID()}.tmp`
+  try {
+    await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+    await rename(temporary, path)
+  } finally {
+    await rm(temporary, { force: true }).catch(() => undefined)
+  }
+}

--- a/src/main/plugins/plugin-service-options.ts
+++ b/src/main/plugins/plugin-service-options.ts
@@ -1,5 +1,6 @@
 import type { PluginWorkerFactory } from './plugin-worker-manager'
 import type { KeybindingOverrides } from '../../shared/keybindings'
+import type { PluginKillListEntry } from '../../shared/plugins/plugin-kill-list'
 
 export type PluginServiceOptions = {
   userDataPath: string
@@ -9,6 +10,7 @@ export type PluginServiceOptions = {
   getPluginConsents: () => Record<string, string>
   getDevPluginPaths: () => string[]
   getKeybindings?: () => KeybindingOverrides
+  getPluginKillListEntry?: (pluginKey: string) => PluginKillListEntry | null
   hostEntryPath?: string
   workerFactory?: PluginWorkerFactory
   maxActiveWorkers?: number

--- a/src/main/plugins/plugin-service-reconciliation.test.ts
+++ b/src/main/plugins/plugin-service-reconciliation.test.ts
@@ -60,6 +60,7 @@ function createHarness(root: string) {
   let enabled = true
   let disabled: string[] = []
   let devPaths = [root]
+  let killed = false
   const consent = fingerprintPluginConsent(manifest())
   const workers: ReturnType<typeof testWorker>[] = []
   const factory = vi.fn<PluginWorkerFactory>(async () => {
@@ -74,6 +75,10 @@ function createHarness(root: string) {
     getDisabledPlugins: () => disabled,
     getPluginConsents: () => ({ [pluginKey]: consent }),
     getDevPluginPaths: () => devPaths,
+    getPluginKillListEntry: (key) =>
+      killed && key === pluginKey
+        ? { pluginKey, reason: 'Security incident', advisoryUrl: 'https://orca.example/advisory' }
+        : null,
     workerFactory: factory
   })
   services.push(service)
@@ -89,6 +94,9 @@ function createHarness(root: string) {
     },
     setDevPaths: (value: string[]) => {
       devPaths = value
+    },
+    setKilled: (value: boolean) => {
+      killed = value
     }
   }
 }
@@ -248,6 +256,31 @@ describe('PluginService worker reconciliation', () => {
 
     expect(harness.workers[0]!.dispose).toHaveBeenCalledOnce()
     expect(harness.service.workerState(pluginKey).state).toBe('inactive')
+  })
+
+  it('immediately revokes every authority surface and stops a killed plugin', async () => {
+    const root = await pluginRoot()
+    const harness = createHarness(root)
+    await activate(harness.service)
+    expect(await harness.service.panels.open('renderer:1', pluginKey, 'panel')).not.toBeNull()
+
+    harness.setKilled(true)
+
+    expect(harness.service.getGrantedCapabilities(pluginKey)).toBeNull()
+    expect(harness.service.activationError(pluginKey)).toContain('Security incident')
+    await expect(harness.service.invokeCommand(pluginKey, 'run')).rejects.toThrow('not enabled')
+    await expect(harness.service.panels.readEntry(pluginKey, 'panel')).resolves.toBeNull()
+    harness.service.emitEvent('worktree.created', {
+      worktreeId: 'worktree-1',
+      path: '/repo',
+      branch: 'feature'
+    })
+    await harness.service.reconcileActivationState()
+
+    expect(harness.workers[0]!.dispose).toHaveBeenCalledOnce()
+    expect(harness.service.options.getPluginKillListEntry?.(pluginKey)).toMatchObject({
+      reason: 'Security incident'
+    })
   })
 
   it('deactivates a worker when changed capabilities make consent pending', async () => {

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -218,7 +218,8 @@ export class PluginService {
     return (
       this.contentPacksReady &&
       this.activationState(plugin) === 'approved' &&
-      !this.contentPacks.error(plugin.pluginKey)
+      !this.contentPacks.error(plugin.pluginKey) &&
+      !this.options.getPluginKillListEntry?.(plugin.pluginKey)
     )
   }
 
@@ -227,7 +228,12 @@ export class PluginService {
   }
 
   activationError(pluginKey: string): string | null {
-    return this.contentPacks.error(pluginKey) ?? this.workerController.activationError(pluginKey)
+    const blocked = this.options.getPluginKillListEntry?.(pluginKey)
+    return (
+      (blocked ? `Blocked by Orca's plugin safety list: ${blocked.reason}` : null) ??
+      this.contentPacks.error(pluginKey) ??
+      this.workerController.activationError(pluginKey)
+    )
   }
 
   /** Consented capability kinds for an approved plugin; null otherwise so

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -947,6 +947,8 @@ export type PluginHostListEntry = {
   needsReconsent: boolean
   error?: string
   isDev: boolean
+  official: boolean
+  bundled: boolean
   capabilities: { kind: string; description: string }[]
   panels: PluginHostPanel[]
   commands: {
@@ -968,8 +970,9 @@ export type PluginHostListEntry = {
     }[]
   }[]
   restarts: number
+  blockedByKillList?: { reason: string; advisoryUrl?: string }
   source?: {
-    kind: 'local-path' | 'git' | 'marketplace'
+    kind: 'local-path' | 'git' | 'marketplace' | 'bundled'
     reference: string
     resolvedCommit: string | null
     contentHash: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -969,10 +969,11 @@ export type PluginHostListEntry = {
   }[]
   restarts: number
   source?: {
-    kind: 'local-path' | 'git'
+    kind: 'local-path' | 'git' | 'marketplace'
     reference: string
     resolvedCommit: string | null
     contentHash: string
+    marketplace?: { reference: string; resolvedCommit: string }
   }
 }
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -66,6 +66,8 @@ import type {
 } from '../shared/plugins/plugin-icon-theme-artifact'
 import type { PluginTerminalThemeRegistration } from '../shared/plugins/plugin-terminal-theme-artifact'
 import type { PluginChangeEvent } from '../shared/plugins/plugin-change-event'
+import type { PluginManifest } from '../shared/plugins/plugin-manifest'
+import type { PluginMarketplaceGitSource } from '../shared/plugins/plugin-marketplace'
 import type {
   LocalhostWorktreeLabelResult,
   LocalhostWorktreeLabelRoute
@@ -996,6 +998,50 @@ export type PluginHostInstallResult =
       resolvedCommit: string | null
     }
   | { ok: false; error: string }
+
+export type PluginMarketplaceHostSourceState = {
+  id: string
+  source: PluginMarketplaceGitSource
+  addedAt: number
+  marketplace: {
+    name: string
+    owner: string
+    resolvedCommit: string
+    fetchedAt: number
+  } | null
+  stale: boolean
+  error?: string
+}
+
+export type PluginMarketplaceHostListing = {
+  marketplaceSourceId: string
+  marketplaceName: string
+  marketplaceOwner: string
+  marketplaceCommit: string
+  pluginKey: string
+  source: PluginMarketplaceGitSource
+  description?: string
+  categories: string[]
+  official: boolean
+  bundled: boolean
+  blockedByKillList?: { reason: string; advisoryUrl?: string }
+}
+
+export type PluginMarketplaceHostInstallPreview = {
+  marketplaceSourceId: string
+  marketplaceName: string
+  marketplaceOwner: string
+  marketplaceCommit: string
+  pluginKey: string
+  source: PluginMarketplaceGitSource
+  resolvedCommit: string
+  contentHash: string
+  consentFingerprint: string
+  manifest: PluginManifest
+  official: boolean
+  bundled: boolean
+  blockedByKillList?: { reason: string; advisoryUrl?: string }
+}
 
 export type PreloadApi = {
   app: AppApi
@@ -3234,6 +3280,29 @@ export type PreloadApi = {
       params?: unknown
     }) => Promise<PluginPanelActionOutcome>
     install: (source: PluginHostInstallSource) => Promise<PluginHostInstallResult>
+    listMarketplaces: () => Promise<PluginMarketplaceHostSourceState[]>
+    addMarketplace: (
+      source: PluginMarketplaceGitSource
+    ) => Promise<PluginMarketplaceHostSourceState>
+    removeMarketplace: (args: { sourceId: string }) => Promise<PluginMarketplaceHostSourceState[]>
+    refreshMarketplaces: (args?: {
+      sourceId?: string
+    }) => Promise<PluginMarketplaceHostSourceState[]>
+    listMarketplacePlugins: () => Promise<PluginMarketplaceHostListing[]>
+    previewMarketplacePlugin: (args: {
+      marketplaceSourceId: string
+      pluginKey: string
+    }) => Promise<PluginMarketplaceHostInstallPreview>
+    installMarketplacePlugin: (
+      preview: Pick<
+        PluginMarketplaceHostInstallPreview,
+        'marketplaceSourceId' | 'marketplaceCommit' | 'pluginKey' | 'resolvedCommit'
+      >
+    ) => Promise<PluginHostInstallResult>
+    previewMarketplaceUpdate: (args: {
+      pluginKey: string
+    }) => Promise<PluginMarketplaceHostInstallPreview>
+    rollbackMarketplacePlugin: (args: { pluginKey: string }) => Promise<PluginHostInstallResult>
     remove: (args: { pluginKey: string }) => Promise<PluginHostListEntry[]>
     getLogs: (args: { pluginKey: string }) => Promise<PluginHostLogLine[]>
     /** Re-discovers after settings edits (feature flag, dev paths). */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -587,6 +587,19 @@ const api = {
     }): Promise<PluginPanelActionOutcome> => ipcRenderer.invoke('plugins:panelAction', args),
     install: (source: PluginHostInstallSource): Promise<PluginHostInstallResult> =>
       ipcRenderer.invoke('plugins:install', source),
+    listMarketplaces: () => ipcRenderer.invoke('plugins:listMarketplaces'),
+    addMarketplace: (source) => ipcRenderer.invoke('plugins:addMarketplace', source),
+    removeMarketplace: (args) => ipcRenderer.invoke('plugins:removeMarketplace', args),
+    refreshMarketplaces: (args = {}) => ipcRenderer.invoke('plugins:refreshMarketplaces', args),
+    listMarketplacePlugins: () => ipcRenderer.invoke('plugins:listMarketplacePlugins'),
+    previewMarketplacePlugin: (args) =>
+      ipcRenderer.invoke('plugins:previewMarketplacePlugin', args),
+    installMarketplacePlugin: (preview) =>
+      ipcRenderer.invoke('plugins:installMarketplacePlugin', preview),
+    previewMarketplaceUpdate: (args) =>
+      ipcRenderer.invoke('plugins:previewMarketplaceUpdate', args),
+    rollbackMarketplacePlugin: (args) =>
+      ipcRenderer.invoke('plugins:rollbackMarketplacePlugin', args),
     remove: (args: { pluginKey: string }): Promise<PluginHostListEntry[]> =>
       ipcRenderer.invoke('plugins:remove', args),
     getLogs: (args: { pluginKey: string }): Promise<PluginHostLogLine[]> =>

--- a/src/renderer/src/components/settings/PluginConsentDialog.test.tsx
+++ b/src/renderer/src/components/settings/PluginConsentDialog.test.tsx
@@ -15,6 +15,8 @@ const plugin: PluginHostListEntry = {
   status: 'pending',
   needsReconsent: false,
   isDev: false,
+  official: false,
+  bundled: false,
   capabilities: [{ kind: 'worker', description: 'Run a background worker process' }],
   panels: [],
   commands: [],

--- a/src/renderer/src/components/settings/PluginSkillMappingDialog.test.tsx
+++ b/src/renderer/src/components/settings/PluginSkillMappingDialog.test.tsx
@@ -17,6 +17,8 @@ const plugin: PluginHostListEntry = {
   status: 'idle',
   needsReconsent: false,
   isDev: false,
+  official: false,
+  bundled: false,
   capabilities: [],
   panels: [],
   commands: [],

--- a/src/renderer/src/components/settings/PluginsSettingsSection.lifecycle.test.tsx
+++ b/src/renderer/src/components/settings/PluginsSettingsSection.lifecycle.test.tsx
@@ -81,6 +81,8 @@ const plugin: PluginHostListEntry = {
   status: 'idle',
   needsReconsent: false,
   isDev: false,
+  official: false,
+  bundled: false,
   capabilities: [{ kind: 'panels', description: 'Add a Notes panel' }],
   panels: [],
   commands: [],

--- a/src/renderer/src/store/plugin-panels.test.ts
+++ b/src/renderer/src/store/plugin-panels.test.ts
@@ -18,6 +18,8 @@ function plugin(pluginKey: string): PluginHostListEntry {
     status: 'idle',
     needsReconsent: false,
     isDev: false,
+    official: false,
+    bundled: false,
     capabilities: [],
     panels: [],
     commands: [],

--- a/src/shared/plugins/plugin-install-lockfile.test.ts
+++ b/src/shared/plugins/plugin-install-lockfile.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { pluginInstallSourceSchema } from './plugin-install-lockfile'
+
+describe('pluginInstallSourceSchema marketplace provenance', () => {
+  it('records both the marketplace snapshot and plugin Git ref', () => {
+    expect(
+      pluginInstallSourceSchema.parse({
+        kind: 'marketplace',
+        marketplace: {
+          url: 'https://github.com/stablyai/orca-plugins.git',
+          ref: 'main',
+          resolvedCommit: 'a'.repeat(40)
+        },
+        plugin: {
+          url: 'git@github.com:stablyai/orca-skills.git',
+          ref: 'v1.0.0'
+        }
+      })
+    ).toEqual({
+      kind: 'marketplace',
+      marketplace: {
+        url: 'https://github.com/stablyai/orca-plugins.git',
+        ref: 'main',
+        resolvedCommit: 'a'.repeat(40)
+      },
+      plugin: {
+        url: 'git@github.com:stablyai/orca-skills.git',
+        ref: 'v1.0.0'
+      }
+    })
+  })
+
+  it('requires pinned refs and an exact marketplace snapshot commit', () => {
+    expect(
+      pluginInstallSourceSchema.safeParse({
+        kind: 'marketplace',
+        marketplace: {
+          url: 'https://github.com/stablyai/orca-plugins.git',
+          ref: '',
+          resolvedCommit: 'main'
+        },
+        plugin: {
+          url: 'https://github.com/stablyai/orca-skills.git',
+          ref: ''
+        }
+      }).success
+    ).toBe(false)
+  })
+})

--- a/src/shared/plugins/plugin-install-lockfile.ts
+++ b/src/shared/plugins/plugin-install-lockfile.ts
@@ -26,6 +26,26 @@ export const pluginInstallSourceSchema = z.discriminatedUnion('kind', [
       .refine(isAllowedPluginGitUrl, 'git URL must use HTTPS or SSH'),
     /** Requested ref (`#ref` suffix); empty means the remote default branch. */
     ref: z.string().max(4096).default('')
+  }),
+  z.object({
+    kind: z.literal('marketplace'),
+    marketplace: z.object({
+      url: z
+        .string()
+        .min(1)
+        .max(32 * 1024)
+        .refine(isAllowedPluginGitUrl, 'marketplace Git URL must use HTTPS or SSH'),
+      ref: z.string().min(1).max(4096),
+      resolvedCommit: z.string().regex(/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/)
+    }),
+    plugin: z.object({
+      url: z
+        .string()
+        .min(1)
+        .max(32 * 1024)
+        .refine(isAllowedPluginGitUrl, 'plugin Git URL must use HTTPS or SSH'),
+      ref: z.string().min(1).max(4096)
+    })
   })
 ])
 

--- a/src/shared/plugins/plugin-install-lockfile.ts
+++ b/src/shared/plugins/plugin-install-lockfile.ts
@@ -46,6 +46,10 @@ export const pluginInstallSourceSchema = z.discriminatedUnion('kind', [
         .refine(isAllowedPluginGitUrl, 'plugin Git URL must use HTTPS or SSH'),
       ref: z.string().min(1).max(4096)
     })
+  }),
+  z.object({
+    kind: z.literal('bundled'),
+    bundleId: z.string().refine(isQualifiedPluginKey, 'invalid bundled plugin identity')
   })
 ])
 

--- a/src/shared/plugins/plugin-kill-list.test.ts
+++ b/src/shared/plugins/plugin-kill-list.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PLUGIN_KILL_LIST_ENTRY_LIMIT,
+  findKilledPlugin,
+  killedPluginKeys,
+  pluginKillListSchema
+} from './plugin-kill-list'
+
+function entry(pluginKey = 'community.unsafe'): Record<string, unknown> {
+  return {
+    pluginKey,
+    reason: 'Known malicious release',
+    advisoryUrl: 'https://orca.example/security/unsafe'
+  }
+}
+
+describe('pluginKillListSchema', () => {
+  it('parses a strict versioned revocation document', () => {
+    const parsed = pluginKillListSchema.parse({
+      version: 1,
+      generatedAt: '2026-07-12T20:00:00Z',
+      plugins: [entry()]
+    })
+
+    expect(findKilledPlugin(parsed, 'community.unsafe')).toEqual(entry())
+    expect(killedPluginKeys(parsed)).toEqual(new Set(['community.unsafe']))
+  })
+
+  it.each([
+    {
+      version: 1,
+      generatedAt: '2026-07-12T20:00:00Z',
+      plugins: [],
+      unexpected: true
+    },
+    {
+      version: 1,
+      generatedAt: '2026-07-12T20:00:00Z',
+      plugins: [{ ...entry(), unexpected: true }]
+    },
+    {
+      version: 1,
+      generatedAt: 'not-a-date',
+      plugins: []
+    },
+    {
+      version: 1,
+      generatedAt: '2026-07-12T20:00:00Z',
+      plugins: [{ ...entry(), pluginKey: 'unsafe' }]
+    },
+    {
+      version: 1,
+      generatedAt: '2026-07-12T20:00:00Z',
+      plugins: [{ ...entry(), advisoryUrl: 'http://orca.example/advisory' }]
+    }
+  ])('rejects malformed or untrusted fields', (killList) => {
+    expect(pluginKillListSchema.safeParse(killList).success).toBe(false)
+  })
+
+  it('rejects duplicate killed plugin identities', () => {
+    const parsed = pluginKillListSchema.safeParse({
+      version: 1,
+      generatedAt: '2026-07-12T20:00:00Z',
+      plugins: [entry(), entry()]
+    })
+
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: 'duplicate killed plugin: community.unsafe' })
+        ])
+      )
+    }
+  })
+
+  it('caps the revocation document size by entry count', () => {
+    const plugins = Array.from({ length: PLUGIN_KILL_LIST_ENTRY_LIMIT + 1 }, (_, index) =>
+      entry(`publisher.plugin-${index}`)
+    )
+    expect(
+      pluginKillListSchema.safeParse({
+        version: 1,
+        generatedAt: '2026-07-12T20:00:00Z',
+        plugins
+      }).success
+    ).toBe(false)
+  })
+})

--- a/src/shared/plugins/plugin-kill-list.ts
+++ b/src/shared/plugins/plugin-kill-list.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+import { isQualifiedPluginKey } from './plugin-manifest'
+
+export const PLUGIN_KILL_LIST_ENTRY_LIMIT = 4_096
+
+const advisoryUrlSchema = z
+  .string()
+  .url()
+  .max(2_048)
+  .refine((value) => new URL(value).protocol === 'https:', 'advisory URL must use HTTPS')
+
+export const pluginKillListEntrySchema = z.strictObject({
+  pluginKey: z.string().refine(isQualifiedPluginKey, 'invalid qualified plugin key'),
+  reason: z.string().min(1).max(1_024),
+  advisoryUrl: advisoryUrlSchema.optional()
+})
+
+export const pluginKillListSchema = z
+  .strictObject({
+    version: z.literal(1),
+    generatedAt: z.string().datetime({ offset: true }),
+    plugins: z.array(pluginKillListEntrySchema).max(PLUGIN_KILL_LIST_ENTRY_LIMIT)
+  })
+  .superRefine((killList, context) => {
+    const seen = new Set<string>()
+    for (const [index, plugin] of killList.plugins.entries()) {
+      if (seen.has(plugin.pluginKey)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['plugins', index, 'pluginKey'],
+          message: `duplicate killed plugin: ${plugin.pluginKey}`
+        })
+      }
+      seen.add(plugin.pluginKey)
+    }
+  })
+
+export type PluginKillList = z.infer<typeof pluginKillListSchema>
+export type PluginKillListEntry = z.infer<typeof pluginKillListEntrySchema>
+
+export function killedPluginKeys(killList: PluginKillList): ReadonlySet<string> {
+  return new Set(killList.plugins.map((plugin) => plugin.pluginKey))
+}
+
+export function findKilledPlugin(
+  killList: PluginKillList,
+  pluginKey: string
+): PluginKillListEntry | null {
+  return killList.plugins.find((plugin) => plugin.pluginKey === pluginKey) ?? null
+}

--- a/src/shared/plugins/plugin-marketplace.test.ts
+++ b/src/shared/plugins/plugin-marketplace.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import {
+  OFFICIAL_MARKETPLACE_REPOSITORY,
+  PLUGIN_MARKETPLACE_CATEGORY_LIMIT,
+  PLUGIN_MARKETPLACE_ENTRY_LIMIT,
+  isOfficialMarketplaceGitSource,
+  isOfficialOrganizationGitSource,
+  isOfficialPluginIdentity,
+  isReservedPluginIdentity,
+  parseGitRepositoryIdentity,
+  pluginMarketplaceSchema,
+  pluginMarketplaceTrustMetadataSchema
+} from './plugin-marketplace'
+
+function listing(id = 'community.nord'): Record<string, unknown> {
+  return {
+    id,
+    source: { kind: 'git', url: 'https://github.com/community/nord.git', ref: 'v1.0.0' },
+    description: 'A theme pack',
+    categories: ['themes']
+  }
+}
+
+describe('pluginMarketplaceSchema', () => {
+  it('parses a bounded, pinned Git marketplace index', () => {
+    expect(
+      pluginMarketplaceSchema.parse({
+        name: 'Community plugins',
+        owner: 'community',
+        plugins: [listing()]
+      })
+    ).toEqual({
+      name: 'Community plugins',
+      owner: 'community',
+      plugins: [listing()]
+    })
+  })
+
+  it.each([
+    ['root', { name: 'Plugins', owner: 'team', plugins: [], extra: true }],
+    ['entry', { name: 'Plugins', owner: 'team', plugins: [{ ...listing(), official: true }] }],
+    [
+      'source',
+      {
+        name: 'Plugins',
+        owner: 'team',
+        plugins: [
+          {
+            ...listing(),
+            source: {
+              kind: 'git',
+              url: 'https://github.com/community/nord.git',
+              ref: 'main',
+              depth: 1
+            }
+          }
+        ]
+      }
+    ]
+  ])('rejects unknown keys at the %s boundary', (_boundary, marketplace) => {
+    expect(pluginMarketplaceSchema.safeParse(marketplace).success).toBe(false)
+  })
+
+  it.each([
+    ['an unqualified id', { ...listing(), id: 'nord' }],
+    [
+      'a missing ref',
+      {
+        ...listing(),
+        source: { kind: 'git', url: 'https://github.com/community/nord.git', ref: '' }
+      }
+    ],
+    [
+      'an executable Git transport',
+      {
+        ...listing(),
+        source: { kind: 'git', url: 'ext::sh -c exploit', ref: 'main' }
+      }
+    ],
+    ['a duplicate category', { ...listing(), categories: ['themes', 'themes'] }],
+    [
+      'too many categories',
+      {
+        ...listing(),
+        categories: Array.from(
+          { length: PLUGIN_MARKETPLACE_CATEGORY_LIMIT + 1 },
+          (_, index) => `category-${index}`
+        )
+      }
+    ]
+  ])('rejects %s', (_label, entry) => {
+    expect(
+      pluginMarketplaceSchema.safeParse({ name: 'Plugins', owner: 'team', plugins: [entry] })
+        .success
+    ).toBe(false)
+  })
+
+  it('rejects duplicate plugin identities', () => {
+    const parsed = pluginMarketplaceSchema.safeParse({
+      name: 'Plugins',
+      owner: 'team',
+      plugins: [listing(), listing()]
+    })
+
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: 'duplicate plugin id: community.nord' })
+        ])
+      )
+    }
+  })
+
+  it('caps the marketplace entry count', () => {
+    const plugins = Array.from({ length: PLUGIN_MARKETPLACE_ENTRY_LIMIT + 1 }, (_, index) =>
+      listing(`publisher.plugin-${index}`)
+    )
+    expect(
+      pluginMarketplaceSchema.safeParse({ name: 'Plugins', owner: 'team', plugins }).success
+    ).toBe(false)
+  })
+})
+
+describe('marketplace provenance contracts', () => {
+  it.each([
+    ['stablyai.orca-skills', true, true],
+    ['stablyai.skills', true, false],
+    ['community.orca-skills', true, false],
+    ['community.skills', false, false],
+    ['invalid', false, false]
+  ])('classifies %s', (pluginKey, reserved, official) => {
+    expect(isReservedPluginIdentity(pluginKey)).toBe(reserved)
+    expect(isOfficialPluginIdentity(pluginKey)).toBe(official)
+  })
+
+  it.each([
+    'https://github.com/stablyai/orca-skills.git',
+    'ssh://git@github.com/stablyai/orca-skills.git',
+    'git@github.com:stablyai/orca-skills.git'
+  ])('accepts official organization source %s', (source) => {
+    expect(isOfficialOrganizationGitSource(source)).toBe(true)
+  })
+
+  it('does not trust lookalike organizations or hosts', () => {
+    expect(isOfficialOrganizationGitSource('https://github.com/stablyai-fakes/orca-skills')).toBe(
+      false
+    )
+    expect(isOfficialOrganizationGitSource('https://gitlab.com/stablyai/orca-skills')).toBe(false)
+  })
+
+  it('recognizes only the canonical official marketplace repository', () => {
+    expect(
+      isOfficialMarketplaceGitSource(
+        `git@github.com:stablyai/${OFFICIAL_MARKETPLACE_REPOSITORY}.git`
+      )
+    ).toBe(true)
+    expect(isOfficialMarketplaceGitSource('git@github.com:stablyai/plugins.git')).toBe(false)
+  })
+
+  it('parses nested repository paths without confusing the repository name', () => {
+    expect(parseGitRepositoryIdentity('https://gitlab.com/team/subgroup/plugin.git')).toEqual({
+      host: 'gitlab.com',
+      owner: 'team',
+      repository: 'plugin'
+    })
+  })
+
+  it('prevents an untrusted listing from self-awarding trust metadata', () => {
+    expect(pluginMarketplaceTrustMetadataSchema.parse({ official: true, bundled: true })).toEqual({
+      official: true,
+      bundled: true
+    })
+    expect(
+      pluginMarketplaceTrustMetadataSchema.safeParse({ official: false, bundled: true }).success
+    ).toBe(false)
+  })
+})

--- a/src/shared/plugins/plugin-marketplace.ts
+++ b/src/shared/plugins/plugin-marketplace.ts
@@ -1,0 +1,184 @@
+import { z } from 'zod'
+import { isAllowedPluginGitUrl } from './plugin-install-lockfile'
+import { isQualifiedPluginKey } from './plugin-manifest'
+
+export const PLUGIN_MARKETPLACE_FILENAME = 'orca-marketplace.json'
+export const PLUGIN_MARKETPLACE_ENTRY_LIMIT = 2_048
+export const PLUGIN_MARKETPLACE_CATEGORY_LIMIT = 16
+
+export const OFFICIAL_PLUGIN_PUBLISHER = 'stablyai'
+export const OFFICIAL_PLUGIN_ID_PREFIX = 'orca-'
+export const OFFICIAL_MARKETPLACE_OWNER = 'stablyai'
+export const OFFICIAL_MARKETPLACE_REPOSITORY = 'orca-plugins'
+
+const marketplaceOwnerSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/, 'invalid marketplace owner')
+
+const marketplaceCategorySchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'categories must be lowercase slugs')
+
+export const pluginMarketplaceGitSourceSchema = z.strictObject({
+  kind: z.literal('git'),
+  url: z
+    .string()
+    .trim()
+    .min(1)
+    .max(32 * 1024)
+    .refine(isAllowedPluginGitUrl, 'git URL must use HTTPS or SSH'),
+  // Why: marketplace installs must first resolve a named ref to an exact
+  // commit; an omitted remote default would make the listing irreproducible.
+  ref: z.string().trim().min(1).max(4_096)
+})
+
+export const pluginMarketplaceEntrySchema = z
+  .strictObject({
+    /** Canonical `<publisher>.<id>` identity expected in the source manifest. */
+    id: z.string().refine(isQualifiedPluginKey, 'invalid qualified plugin key'),
+    source: pluginMarketplaceGitSourceSchema,
+    description: z.string().min(1).max(4_096).optional(),
+    categories: z
+      .array(marketplaceCategorySchema)
+      .max(PLUGIN_MARKETPLACE_CATEGORY_LIMIT)
+      .default([])
+  })
+  .superRefine((entry, context) => {
+    const seen = new Set<string>()
+    for (const [index, category] of entry.categories.entries()) {
+      if (seen.has(category)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['categories', index],
+          message: `duplicate category: ${category}`
+        })
+      }
+      seen.add(category)
+    }
+  })
+
+export const pluginMarketplaceSchema = z
+  .strictObject({
+    name: z.string().min(1).max(256),
+    owner: marketplaceOwnerSchema,
+    plugins: z.array(pluginMarketplaceEntrySchema).max(PLUGIN_MARKETPLACE_ENTRY_LIMIT)
+  })
+  .superRefine((marketplace, context) => {
+    const seen = new Set<string>()
+    for (const [index, plugin] of marketplace.plugins.entries()) {
+      if (seen.has(plugin.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['plugins', index, 'id'],
+          message: `duplicate plugin id: ${plugin.id}`
+        })
+      }
+      seen.add(plugin.id)
+    }
+  })
+
+/** Host-derived trust metadata. Marketplace JSON cannot self-award either bit. */
+export const pluginMarketplaceTrustMetadataSchema = z
+  .strictObject({
+    official: z.boolean(),
+    bundled: z.boolean()
+  })
+  .refine((metadata) => !metadata.bundled || metadata.official, {
+    message: 'bundled plugins must be official',
+    path: ['bundled']
+  })
+
+export type PluginMarketplace = z.infer<typeof pluginMarketplaceSchema>
+export type PluginMarketplaceEntry = z.infer<typeof pluginMarketplaceEntrySchema>
+export type PluginMarketplaceGitSource = z.infer<typeof pluginMarketplaceGitSourceSchema>
+export type PluginMarketplaceTrustMetadata = z.infer<typeof pluginMarketplaceTrustMetadataSchema>
+
+export function splitQualifiedPluginKey(pluginKey: string): {
+  publisher: string
+  id: string
+} | null {
+  if (!isQualifiedPluginKey(pluginKey)) {
+    return null
+  }
+  const separator = pluginKey.indexOf('.')
+  return {
+    publisher: pluginKey.slice(0, separator),
+    id: pluginKey.slice(separator + 1)
+  }
+}
+
+export function isReservedPluginIdentity(pluginKey: string): boolean {
+  const identity = splitQualifiedPluginKey(pluginKey)
+  return (
+    identity !== null &&
+    (identity.publisher === OFFICIAL_PLUGIN_PUBLISHER ||
+      identity.id.startsWith(OFFICIAL_PLUGIN_ID_PREFIX))
+  )
+}
+
+export function isOfficialPluginIdentity(pluginKey: string): boolean {
+  const identity = splitQualifiedPluginKey(pluginKey)
+  return (
+    identity !== null &&
+    identity.publisher === OFFICIAL_PLUGIN_PUBLISHER &&
+    identity.id.startsWith(OFFICIAL_PLUGIN_ID_PREFIX)
+  )
+}
+
+type GitRepositoryIdentity = {
+  host: string
+  owner: string
+  repository: string
+}
+
+/** Extracts the host and first owner segment from the HTTPS/SSH Git forms the
+ * installer accepts. It is intentionally only a provenance parser. */
+export function parseGitRepositoryIdentity(url: string): GitRepositoryIdentity | null {
+  const trimmed = url.trim()
+  const scp = /^[^\s@/:]+@([^\s:]+):(.+)$/.exec(trimmed)
+  if (scp) {
+    return repositoryIdentity(scp[1]!, scp[2]!)
+  }
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'ssh:') {
+      return null
+    }
+    return repositoryIdentity(parsed.hostname, parsed.pathname)
+  } catch {
+    return null
+  }
+}
+
+function repositoryIdentity(host: string, repositoryPath: string): GitRepositoryIdentity | null {
+  const segments = repositoryPath
+    .replace(/^\/+|\/+$/g, '')
+    .split('/')
+    .filter(Boolean)
+  if (segments.length < 2) {
+    return null
+  }
+  const repository = segments.at(-1)!.replace(/\.git$/i, '')
+  if (!repository) {
+    return null
+  }
+  return { host: host.toLowerCase(), owner: segments[0]!, repository }
+}
+
+export function isOfficialOrganizationGitSource(url: string): boolean {
+  const source = parseGitRepositoryIdentity(url)
+  return source?.host === 'github.com' && source.owner.toLowerCase() === OFFICIAL_PLUGIN_PUBLISHER
+}
+
+export function isOfficialMarketplaceGitSource(url: string): boolean {
+  const source = parseGitRepositoryIdentity(url)
+  return (
+    source?.host === 'github.com' &&
+    source.owner.toLowerCase() === OFFICIAL_MARKETPLACE_OWNER &&
+    source.repository.toLowerCase() === OFFICIAL_MARKETPLACE_REPOSITORY
+  )
+}


### PR DESCRIPTION
## Summary

Adds Marketplace v0 on top of the Phase 1 content-pack PR:

- Zod-validated `orca-marketplace.json` contracts and pinned Git sources.
- System-Git fetches with immutable resolved commits, bounded caches, and offline fallback.
- Preview, install, update, one-step rollback, and source removal through content-addressed installs.
- Marketplace provenance in lockfiles, official publisher/name reservation, and derived official badges.
- A remotely refreshable kill list that blocks new installs and runtime-disables installed plugins.
- Desktop IPC/preload lifecycle parity for marketplace reads and mutations.

All marketplace surfaces remain experimental and feature-flagged.

## Security and remote behavior

The installer never runs package or install scripts. Git operations use the system Git client so existing HTTPS credential helpers and SSH configuration remain authoritative, including private repositories. Marketplace and plugin commits are pinned before installation; every installed tree is content-hashed.

Private-marketplace integration coverage exercises an SSH URL through the caller's Git environment and proves preview, install, and lockfile provenance. The production code contains no provider-specific authentication path and remains compatible with non-GitHub Git hosts.

Signing, enterprise source policy, and relay-side provisioning remain later roadmap phases.

## Validation

Validated at the byte-identical top of the Phase 1 stack:

- `pnpm typecheck` and `pnpm lint` — passed.
- Phase 0+1 Vitest matrix — 146 files, 917 tests passed.
- Private SSH marketplace integration — passed.
- Electron fresh-profile source → browse → preview → install → consent → apply journey — passed.

## Stack

1. #8460 — Phase 0 kernel and enforcement.
2. #8461 — sandboxed panel host and renderer.
3. #8462 — consent/settings UI and demo workflow.
4. #8547 — Phase 1 content packs.
5. **This PR:** marketplace lifecycle, installation, provenance, and revocation.
6. #8549 — marketplace UX, launch content, and release hardening.

Draft only — do not merge independently of the full stack.
