### PR TITLE
test(terminal): dispose foreground trackers between cases

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -26,6 +26,7 @@ import {
   resetAgentStartupDelayedDeliveryForTests
 } from '@/lib/agent-startup-delayed-delivery'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type { createPaneForegroundAgentTracker } from './pane-foreground-agent-tracker'
 
 // Repro command:
 //   pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "OpenTUI-style small ANSI redraw"
@@ -257,6 +258,12 @@ let mockStoreState: StoreState
 let transportFactoryQueue: MockTransport[] = []
 let createdTransportOptions: Record<string, unknown>[] = []
 let storeSubscribers: ((state: StoreState) => void)[] = []
+type PaneForegroundAgentTrackerFactory = typeof createPaneForegroundAgentTracker
+type PaneForegroundAgentTracker = ReturnType<PaneForegroundAgentTrackerFactory>
+type PaneForegroundAgentTrackerModule = {
+  createPaneForegroundAgentTracker: PaneForegroundAgentTrackerFactory
+}
+const paneForegroundAgentTrackers = new Set<PaneForegroundAgentTracker>()
 
 vi.mock('@/runtime/sync-runtime-graph', () => ({
   scheduleRuntimeGraphSync
@@ -277,6 +284,20 @@ vi.mock('@/store', () => ({
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
   scheduleTerminalWebglAtlasRecovery
 }))
+
+vi.mock('./pane-foreground-agent-tracker', async (importOriginal) => {
+  const actual = await importOriginal<PaneForegroundAgentTrackerModule>()
+  return {
+    ...actual,
+    createPaneForegroundAgentTracker: (
+      ...args: Parameters<typeof actual.createPaneForegroundAgentTracker>
+    ) => {
+      const tracker = actual.createPaneForegroundAgentTracker(...args)
+      paneForegroundAgentTrackers.add(tracker)
+      return tracker
+    }
+  }
+})
 
 function notifyStoreSubscribers(): void {
   for (const listener of storeSubscribers.slice()) {
@@ -894,6 +915,12 @@ describe('connectPanePty', () => {
   })
 
   afterEach(() => {
+    // Why: most cases do not retain their pane binding; cancel its delayed reads
+    // before they can publish into the next case's freshly reset store mock.
+    for (const tracker of paneForegroundAgentTrackers) {
+      tracker.dispose()
+    }
+    paneForegroundAgentTrackers.clear()
     vi.useRealTimers()
     if (originalRequestAnimationFrame) {
       globalThis.requestAnimationFrame = originalRequestAnimationFrame


### PR DESCRIPTION
## Summary

`pty-connection.test.ts` creates real pane foreground-agent trackers, but most cases do not retain and dispose the pane binding. Their delayed process reads can therefore settle after `beforeEach` replaces the shared store mock for the next case.

Exact-head CI for #8072 exposed the leak: a test that creates only `tab-1/LEAF_1` received five `clearAgentLaunchConfig` calls, including two for `tab-1/LEAF_2`. The current test cannot create `LEAF_2`; those calls came from an earlier case's fixed 350/1200/6000 ms foreground-tracker ladder.

This fixture wraps the real tracker factory, records each tracker, and disposes all of them in `afterEach` before the next store mock is installed.

## Testing

- [x] `pty-connection.test.ts` + `pane-foreground-agent-tracker.test.ts`: 457/457 passed.
- [x] `pnpm run typecheck`.
- [x] `oxlint` on the changed test.
- [x] `oxfmt --check` on the changed test.
- [x] `git diff --check`.

## Evidence limitation

The exact CI failure is authoritative, but the leak did not reproduce locally under Node 26. The fix is based on the impossible cross-pane callback arguments and the tracker's deterministic delayed-read ladder; Node 24 PR Checks remain the final verifier.

## Scope

Test fixture lifecycle only; no runtime behavior changes.
