### PR TITLE
[Feature]: open markdown file shortcut does nothing in main window

### DIFF
--- a/src/main/ipc/app.test.ts
+++ b/src/main/ipc/app.test.ts
@@ -356,4 +356,49 @@ describe('registerAppHandlers', () => {
     })
     expect(grantFloatingWorkspaceDirectoryMock).toHaveBeenCalledWith(store, '/Users/kaylee/notes')
   })
+
+  it('picks a markdown file rooted at the given worktree cwd', async () => {
+    showOpenDialogMock.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/Users/kaylee/repo/docs/notes.md']
+    })
+    registerAppHandlers({} as never)
+
+    await expect(
+      handlers.get('app:pickWorktreeMarkdownDocument')?.({ sender: {} }, '/Users/kaylee/repo')
+    ).resolves.toMatchObject({
+      filePath: '/Users/kaylee/repo/docs/notes.md',
+      relativePath: 'docs/notes.md',
+      basename: 'notes.md',
+      name: 'notes'
+    })
+    expect(showOpenDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultPath: '/Users/kaylee/repo',
+        properties: ['openFile'],
+        filters: [{ name: 'Markdown', extensions: ['md', 'mdx', 'markdown'] }]
+      })
+    )
+  })
+
+  it('returns null when the markdown file picker is cancelled', async () => {
+    showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] })
+    registerAppHandlers({} as never)
+
+    await expect(
+      handlers.get('app:pickWorktreeMarkdownDocument')?.({ sender: {} }, '/Users/kaylee/repo')
+    ).resolves.toBeNull()
+  })
+
+  it('rejects a picked file that is not a markdown document', async () => {
+    showOpenDialogMock.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/Users/kaylee/repo/notes.txt']
+    })
+    registerAppHandlers({} as never)
+
+    await expect(
+      handlers.get('app:pickWorktreeMarkdownDocument')?.({ sender: {} }, '/Users/kaylee/repo')
+    ).rejects.toThrow('Selected file is not a markdown document.')
+  })
 })

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -37,10 +37,10 @@ type RegisterAppHandlersOptions = {
   onBeforeRelaunch?: () => void | Promise<void>
 }
 
-async function pickFloatingMarkdownDocument(
-  event: IpcMainInvokeEvent
+async function pickMarkdownDocumentAt(
+  event: IpcMainInvokeEvent,
+  cwd: string
 ): Promise<MarkdownDocument | null> {
-  const cwd = await ensureDefaultFloatingWorkspacePath()
   const options = {
     defaultPath: cwd,
     properties: ['openFile'],
@@ -59,6 +59,20 @@ async function pickFloatingMarkdownDocument(
   }
   authorizeExternalPath(filePath)
   return markdownDocumentFromFilePath(cwd, filePath, { outsideRootRelativePath: 'basename' })
+}
+
+async function pickFloatingMarkdownDocument(
+  event: IpcMainInvokeEvent
+): Promise<MarkdownDocument | null> {
+  const cwd = await ensureDefaultFloatingWorkspacePath()
+  return pickMarkdownDocumentAt(event, cwd)
+}
+
+async function pickWorktreeMarkdownDocument(
+  event: IpcMainInvokeEvent,
+  cwd: string
+): Promise<MarkdownDocument | null> {
+  return pickMarkdownDocumentAt(event, cwd)
 }
 
 async function pickFloatingWorkspaceDirectory(
@@ -341,6 +355,10 @@ export function registerAppHandlers(store: Store, options: RegisterAppHandlersOp
   ipcMain.handle('app:getFloatingMarkdownDirectory', () => ensureDefaultFloatingWorkspacePath())
 
   ipcMain.handle('app:pickFloatingMarkdownDocument', (event) => pickFloatingMarkdownDocument(event))
+
+  ipcMain.handle('app:pickWorktreeMarkdownDocument', (event, cwd: string) =>
+    pickWorktreeMarkdownDocument(event, cwd)
+  )
 
   ipcMain.handle('app:pickFloatingWorkspaceDirectory', (event) =>
     pickFloatingWorkspaceDirectory(event, store)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -891,6 +891,9 @@ export type AppApi = {
   /** Opens a native picker for markdown documents, rooted in the floating
    *  workspace, and authorizes the selected file for editor reads/writes. */
   pickFloatingMarkdownDocument: () => Promise<MarkdownDocument | null>
+  /** Opens a native picker for markdown documents, rooted in the given
+   *  worktree path, and authorizes the selected file for editor reads/writes. */
+  pickWorktreeMarkdownDocument: (cwd: string) => Promise<MarkdownDocument | null>
   /** Opens a native directory picker and authorizes the selected directory
    *  for Floating Workspace markdown file creation. */
   pickFloatingWorkspaceDirectory: () => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -500,6 +500,8 @@ const api = {
       ipcRenderer.invoke('app:getFloatingMarkdownDirectory'),
     pickFloatingMarkdownDocument: (): Promise<MarkdownDocument | null> =>
       ipcRenderer.invoke('app:pickFloatingMarkdownDocument'),
+    pickWorktreeMarkdownDocument: (cwd: string): Promise<MarkdownDocument | null> =>
+      ipcRenderer.invoke('app:pickWorktreeMarkdownDocument', cwd),
     pickFloatingWorkspaceDirectory: (): Promise<string | null> =>
       ipcRenderer.invoke('app:pickFloatingWorkspaceDirectory')
   },

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -111,6 +111,7 @@ import {
   createFloatingWorkspaceTerminalTab,
   handleEmptyFloatingWorkspacePanelCloseShortcut,
   isFloatingWorkspacePanelFocused,
+  openFloatingWorkspaceMarkdownTab,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
 import {
@@ -290,6 +291,7 @@ function Terminal(): React.JSX.Element | null {
     (s) => s.openNewBrowserTabInActiveWorkspace
   )
   const openNewMarkdownInActiveWorkspace = useAppStore((s) => s.openNewMarkdownInActiveWorkspace)
+  const openMarkdownFileInActiveWorkspace = useAppStore((s) => s.openMarkdownFileInActiveWorkspace)
   const openNewTerminalTabInActiveWorkspace = useAppStore(
     (s) => s.openNewTerminalTabInActiveWorkspace
   )
@@ -1253,6 +1255,19 @@ function Terminal(): React.JSX.Element | null {
     await openNewMarkdownInActiveWorkspace(targetGroupId)
   }, [activeWorktreeId, openNewMarkdownInActiveWorkspace])
 
+  const handleOpenFile = useCallback(async () => {
+    if (!activeWorktreeId) {
+      return
+    }
+    const targetGroupId =
+      useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId] ??
+      useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
+    if (!targetGroupId) {
+      return
+    }
+    await openMarkdownFileInActiveWorkspace(targetGroupId)
+  }, [activeWorktreeId, openMarkdownFileInActiveWorkspace])
+
   const handleCloseTab = useCallback((tabId: string) => {
     closeTerminalTab(tabId)
   }, [])
@@ -1703,6 +1718,24 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
+      // Cmd/Ctrl+Shift+O - open existing markdown file
+      if (!e.repeat && matchShortcut('tab.openMarkdown')) {
+        e.preventDefault()
+        notifyTerminalCapture('tab.openMarkdown')
+        if (floatingWorkspaceFocused) {
+          void openFloatingWorkspaceMarkdownTab(useAppStore.getState()).catch((err) => {
+            toast.error(
+              err instanceof Error
+                ? err.message
+                : translate('auto.components.Terminal.3a460c3322', 'Failed to open markdown file.')
+            )
+          })
+          return
+        }
+        void handleOpenFile()
+        return
+      }
+
       if (handleEmptyFloatingWorkspacePanelCloseShortcut(e, shortcutPlatform, keybindings)) {
         return
       }
@@ -1844,6 +1877,7 @@ function Terminal(): React.JSX.Element | null {
     handleNewBrowserTab,
     handleNewSimulatorTab,
     handleNewFile,
+    handleOpenFile,
     handleNewTab,
     handleNewAgentTab,
     handleCloseTab,
@@ -2003,6 +2037,7 @@ function Terminal(): React.JSX.Element | null {
             onNewSimulatorTab={mobileEmulatorEnabled ? handleNewSimulatorTab : undefined}
             onOpenEntry={handleOpenEntry}
             onNewFileTab={handleNewFile}
+            onOpenFileTab={handleOpenFile}
             onSetCustomTitle={setTabCustomTitle}
             onSetTabColor={setTabColor}
             expandedPaneByTabId={expandedPaneByTabId}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1769,7 +1769,8 @@
         "61ed600d29": "\"{{value0}}\" has unsaved changes. Do you want to save before closing?",
         "cdc9ac4b2d": "editor",
         "e57db40c11": "Could not build launch command for {{value0}}.",
-        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings.",
+        "3a460c3322": "Failed to open markdown file."
       },
       "TerminalSearch": {
         "db234b7519": "Close",

--- a/src/renderer/src/lib/floating-workspace-tab-creation.ts
+++ b/src/renderer/src/lib/floating-workspace-tab-creation.ts
@@ -82,3 +82,28 @@ export async function createFloatingWorkspaceMarkdownTab(
     }
   )
 }
+
+export async function openFloatingWorkspaceMarkdownTab(
+  store: FloatingWorkspaceMarkdownStore
+): Promise<void> {
+  const targetGroupId = store.activeGroupIdByWorktree[FLOATING_TERMINAL_WORKTREE_ID]
+  const document = await window.api.app.pickFloatingMarkdownDocument()
+  if (!document) {
+    return
+  }
+  store.openFile(
+    {
+      filePath: document.filePath,
+      relativePath: document.relativePath,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      language: detectLanguage(document.relativePath),
+      mode: 'edit',
+      runtimeEnvironmentId: null
+    },
+    {
+      preview: false,
+      targetGroupId,
+      suppressActiveRuntimeFallback: true
+    }
+  )
+}

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -14,7 +14,8 @@ import { keybindingMatchesAction, type KeybindingOverrides } from '../../../shar
 export {
   createFloatingWorkspaceBrowserTab,
   createFloatingWorkspaceMarkdownTab,
-  createFloatingWorkspaceTerminalTab
+  createFloatingWorkspaceTerminalTab,
+  openFloatingWorkspaceMarkdownTab
 } from './floating-workspace-tab-creation'
 export {
   isFloatingWorkspacePanelShortcut,

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -1891,6 +1891,15 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     if (!worktree) {
       return
     }
+    // Why: the picker uses a local Electron file dialog, which can't browse a
+    // remote host's filesystem. Guard remote worktrees instead of letting the
+    // user pick a local file that doesn't belong to the remote worktree.
+    const connectionId =
+      state.repos.find((entry) => entry.id === worktree.repoId)?.connectionId ?? undefined
+    if (connectionId) {
+      toast.error('Opening a markdown file is not supported for remote worktrees yet.')
+      return
+    }
     try {
       const document = await window.api.app.pickWorktreeMarkdownDocument(worktree.path)
       if (!document) {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -490,6 +490,7 @@ export type EditorSlice = {
     }
   ) => void
   openNewMarkdownInActiveWorkspace: (groupId: string) => Promise<void>
+  openMarkdownFileInActiveWorkspace: (groupId: string) => Promise<void>
   // Why: dispatcher for markdown link activation. Lives on the slice because it
   // sequences openFile, setMarkdownViewMode, and setPendingEditorReveal around
   // an async Monaco remount — all reading/writing state in this slice. See
@@ -1877,6 +1878,37 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       get().recordFeatureInteraction('markdown-file-created')
     } catch (err) {
       toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))
+    }
+  },
+
+  openMarkdownFileInActiveWorkspace: async (groupId) => {
+    const state = get()
+    const worktreeId = state.activeWorktreeId
+    if (!worktreeId) {
+      return
+    }
+    const worktree = state.getKnownWorktreeById(worktreeId)
+    if (!worktree) {
+      return
+    }
+    try {
+      const document = await window.api.app.pickWorktreeMarkdownDocument(worktree.path)
+      if (!document) {
+        return
+      }
+      get().openFile(
+        {
+          filePath: document.filePath,
+          relativePath: document.relativePath,
+          worktreeId,
+          language: detectLanguage(document.relativePath),
+          mode: 'edit',
+          runtimeEnvironmentId: null
+        },
+        { preview: false, targetGroupId: groupId }
+      )
+    } catch (err) {
+      toast.error(extractIpcErrorMessage(err, 'Failed to open markdown file.'))
     }
   },
 

--- a/src/renderer/src/store/slices/open-markdown-file.test.ts
+++ b/src/renderer/src/store/slices/open-markdown-file.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { toast } from 'sonner'
+import { createTestStore, makeWorktree, TEST_REPO } from './store-test-helpers'
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+const wt1 = makeWorktree({ id: 'wt-1', repoId: TEST_REPO.id, path: '/repo1/wt1' })
+
+function seedActiveWorktree(store: ReturnType<typeof createTestStore>): void {
+  store.setState({
+    repos: [TEST_REPO],
+    worktreesByRepo: { [TEST_REPO.id]: [wt1] },
+    activeWorktreeId: wt1.id
+  })
+}
+
+describe('openMarkdownFileInActiveWorkspace', () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear()
+  })
+
+  it('opens the picked file rooted at the active worktree path', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn().mockResolvedValue({
+      filePath: '/repo1/wt1/notes.md',
+      relativePath: 'notes.md'
+    })
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    seedActiveWorktree(store)
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(pickWorktreeMarkdownDocument).toHaveBeenCalledWith(wt1.path)
+    expect(store.getState().openFiles).toHaveLength(1)
+    expect(store.getState().openFiles[0]).toMatchObject({
+      filePath: '/repo1/wt1/notes.md',
+      relativePath: 'notes.md',
+      worktreeId: wt1.id,
+      language: 'markdown',
+      mode: 'edit'
+    })
+  })
+
+  it('does nothing when the picker is cancelled', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn().mockResolvedValue(null)
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    seedActiveWorktree(store)
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+
+  it('does nothing when there is no active worktree', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn()
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    store.setState({ repos: [TEST_REPO], activeWorktreeId: null })
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(pickWorktreeMarkdownDocument).not.toHaveBeenCalled()
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+
+  it('shows a toast error when the picker rejects', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn().mockRejectedValue(new Error('boom'))
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    seedActiveWorktree(store)
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(toast.error).toHaveBeenCalledWith('boom')
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+})

--- a/src/renderer/src/store/slices/open-markdown-file.test.ts
+++ b/src/renderer/src/store/slices/open-markdown-file.test.ts
@@ -82,6 +82,27 @@ describe('openMarkdownFileInActiveWorkspace', () => {
     expect(store.getState().openFiles).toHaveLength(0)
   })
 
+  it('guards remote worktrees instead of opening the local file dialog', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn()
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    const remoteRepo = { ...TEST_REPO, connectionId: 'conn-1' }
+    store.setState({
+      repos: [remoteRepo],
+      worktreesByRepo: { [remoteRepo.id]: [wt1] },
+      activeWorktreeId: wt1.id
+    })
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(pickWorktreeMarkdownDocument).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalled()
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+
   it('shows a toast error when the picker rejects', async () => {
     const pickWorktreeMarkdownDocument = vi.fn().mockRejectedValue(new Error('boom'))
     globalThis.window.api = {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -497,6 +497,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       getFloatingTerminalCwd: () => Promise.resolve(''),
       getFloatingMarkdownDirectory: () => Promise.resolve(''),
       pickFloatingMarkdownDocument: () => Promise.resolve(null),
+      pickWorktreeMarkdownDocument: () => Promise.resolve(null),
       pickFloatingWorkspaceDirectory: () => Promise.resolve(null)
     },
     starNag: {


### PR DESCRIPTION
## Summary
- Cmd/Ctrl+Shift+O (`tab.openMarkdown`) only had a handler inside the Floating Terminal panel's own keydown listener, so pressing it with a normal worktree tab focused did nothing.
- Adds a main-window path: an IPC picker rooted at the active worktree, a store action to open the picked file, and a keydown branch in Terminal.tsx — mirroring the existing `tab.newMarkdown` wiring.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `oxlint` clean on all touched files
- [x] New unit tests: `src/main/ipc/app.test.ts` (picker IPC handler), `src/renderer/src/store/slices/open-markdown-file.test.ts` (store action)
- [x] Manual: Cmd/Ctrl+Shift+O in a normal worktree tab opens a markdown file picker and loads the selected file into a tab
- [x] Manual: Cmd/Ctrl+Shift+O still works as before when the Floating Terminal panel is focused

Fixes #8532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

The shortcut to open a markdown file (Cmd/Ctrl+Shift+O) only worked inside the floating terminal, so it did nothing in a normal worktree tab. It now opens a file picker for the active worktree from the main window, same idea as new-markdown.
