### PR TITLE
fix(source-control): huge-status flag permanently disabled all status refresh — commits in the terminal never surfaced

### DIFF
--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
@@ -47,6 +47,7 @@ async function usePollingOnce(
     enabled?: boolean
     expectStatusCall?: boolean
     stateOverrides?: Partial<PollState>
+    documentStub?: object
   } = {}
 ): Promise<{ state: PollState; gitStatus: ReturnType<typeof vi.fn> }> {
   vi.resetModules()
@@ -123,12 +124,15 @@ async function usePollingOnce(
     removeEventListener: vi.fn()
   })
 
-  vi.stubGlobal('document', {
-    visibilityState: 'visible',
-    hasFocus: () => true,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn()
-  })
+  vi.stubGlobal(
+    'document',
+    options.documentStub ?? {
+      visibilityState: 'visible',
+      hasFocus: () => true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+  )
   vi.stubGlobal('setInterval', vi.fn())
   vi.stubGlobal('clearInterval', vi.fn())
 
@@ -652,6 +656,73 @@ describe('useGitStatusPolling', () => {
     await vi.waitFor(() => expect(gitStatus).toHaveBeenCalledTimes(callsBeforeDebounceFires + 1))
 
     vi.useRealTimers()
+  })
+
+  it('refreshes on repo metadata push signals while the huge flag is set so the flag can clear', async () => {
+    const { gitStatus } = await usePollingOnce(
+      {
+        entries: [],
+        conflictOperation: 'unknown',
+        head: 'abc123',
+        branch: 'refs/heads/main'
+      },
+      {
+        expectStatusCall: false,
+        stateOverrides: {
+          gitStatusHugeByWorktree: { [worktree.id]: { limit: 10_000 } }
+        }
+      }
+    )
+
+    // The huge flag must only pause evidence-free interval polling.
+    expect(globalThis.setInterval).not.toHaveBeenCalled()
+    expect(gitStatus).not.toHaveBeenCalled()
+
+    // Push signals (e.g. a commit's metadata write) must stay subscribed while
+    // huge — a fresh non-huge status result is the only way the flag clears.
+    const onChanged = window.api.worktrees.onChanged as ReturnType<typeof vi.fn>
+    expect(onChanged).toHaveBeenCalledTimes(1)
+    const handleRepoSignal = onChanged.mock.calls[0][0] as (payload: { repoId: string }) => void
+    handleRepoSignal({ repoId: repo.id })
+
+    await vi.waitFor(() => expect(gitStatus).toHaveBeenCalledTimes(1))
+  })
+
+  it('catches up on becoming visible while the huge flag is set', async () => {
+    const documentListeners = new Map<string, EventListener[]>()
+    const visibilityDocument = {
+      visibilityState: 'hidden',
+      hasFocus: () => false,
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        documentListeners.set(type, [...(documentListeners.get(type) ?? []), listener])
+      }),
+      removeEventListener: vi.fn()
+    }
+    const { gitStatus } = await usePollingOnce(
+      {
+        entries: [],
+        conflictOperation: 'unknown',
+        head: 'abc123',
+        branch: 'refs/heads/main'
+      },
+      {
+        expectStatusCall: false,
+        documentStub: visibilityDocument,
+        stateOverrides: {
+          gitStatusHugeByWorktree: { [worktree.id]: { limit: 10_000 } }
+        }
+      }
+    )
+    // Signals dropped while the window was hidden must be caught up on
+    // reveal so the huge flag can still clear.
+    expect(gitStatus).not.toHaveBeenCalled()
+
+    visibilityDocument.visibilityState = 'visible'
+    for (const listener of documentListeners.get('visibilitychange') ?? []) {
+      listener(new Event('visibilitychange'))
+    }
+
+    await vi.waitFor(() => expect(gitStatus).toHaveBeenCalledTimes(1))
   })
 
   it('does not overlap slow visible git status polls and runs one trailing refresh', async () => {

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -72,13 +72,20 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     openFiles
   }
   const isActiveConnectionReady = isConnectionReady(activeConnectionId)
-  const shouldPollActiveWorktreeGitStatus =
+  const canFetchActiveWorktreeGitStatus =
     enabled &&
     !!activeWorktreeId &&
     !!worktreePath &&
     activeRepoSupportsGit &&
     shouldPollActiveGitStatus(activeGitStatusPollingArgs) &&
-    isActiveConnectionReady &&
+    isActiveConnectionReady
+  // Why: the huge flag must only pause evidence-free polling, not push-signal
+  // refreshes — a fresh non-huge status result is the only thing that can
+  // clear the flag, so gating every lane on it would deadlock the worktree
+  // into stale status until an app restart.
+  const shouldPollActiveWorktreeGitStatus =
+    canFetchActiveWorktreeGitStatus &&
+    !!activeWorktreeId &&
     !gitStatusHugeByWorktree?.[activeWorktreeId]
   const activeStatusPollIntervalMs = hasInteractiveActiveGitStatusConsumer(
     activeGitStatusPollingArgs
@@ -116,7 +123,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     if (!isWindowVisible()) {
       return
     }
-    if (!shouldPollActiveWorktreeGitStatus || !activeWorktreeId || !worktreePath) {
+    if (!canFetchActiveWorktreeGitStatus || !activeWorktreeId || !worktreePath) {
       return
     }
     try {
@@ -141,7 +148,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     activePushTarget,
     activeWorktreeId,
     fetchUpstreamStatus,
-    shouldPollActiveWorktreeGitStatus,
+    canFetchActiveWorktreeGitStatus,
     worktreePath,
     setGitStatus,
     setUpstreamStatus,
@@ -180,6 +187,29 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     statusPollRunnerRef.current?.run({ changeSignal: true })
   }, [])
 
+  // Why: while huge, the visibility interval below is not installed, and push
+  // signals are dropped while hidden — e.g. an agent committing behind a
+  // minimized window. Catch up on reveal so the huge flag can still clear.
+  const hugeStatusPauseActive = canFetchActiveWorktreeGitStatus && !activeStatusPollScope
+  useEffect(() => {
+    if (
+      !hugeStatusPauseActive ||
+      typeof document === 'undefined' ||
+      typeof document.addEventListener !== 'function'
+    ) {
+      return
+    }
+    const catchUpOnReveal = (): void => {
+      if (isWindowVisible()) {
+        fetchStatusOnChangeSignal()
+      }
+    }
+    document.addEventListener('visibilitychange', catchUpOnReveal)
+    return () => {
+      document.removeEventListener('visibilitychange', catchUpOnReveal)
+    }
+  }, [hugeStatusPauseActive, fetchStatusOnChangeSignal])
+
   useEffect(() => {
     if (!activeStatusPollScope) {
       return
@@ -213,7 +243,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
   useGitStatusPushSignalRefresh({
     activeRepoId,
     activeWorktreeId,
-    enabled: shouldPollActiveWorktreeGitStatus,
+    enabled: canFetchActiveWorktreeGitStatus,
     fetchStatus: fetchStatusOnChangeSignal
   })
 


### PR DESCRIPTION
## Summary

Once `git status` hits the 10,000-entry limit (`DEFAULT_GIT_STATUS_LIMIT`), the huge flag (`gitStatusHugeByWorktree`) disabled **every** status-refresh lane for that worktree — interval polling, the 30s terminal-only backstop, file-watch refreshes, and the push signals (repo-metadata watcher, terminal command-finished). But the flag only clears when a fresh status result arrives with `didHitLimit=false`, so the worktree deadlocked into permanently stale Source Control and file-explorer badges: commits made in the integrated terminal were never reflected until an app restart. The remaining escape hatches (the one-shot .gitignore toast, a git mutation through Orca's UI) don't fire for terminal-driven workflows, and the toast doesn't appear at all when the over-limit state was transient (`findHugeFoldersToIgnore` finds nothing).

**Repro (before this fix):** create >10,000 untracked files in a worktree → banner appears → remove/commit them from the integrated terminal → `git status` is clean but the panel and explorer badges keep the stale entries indefinitely; only an app restart recovers.

The fix splits the gate in `useGitStatusPolling`:

- `shouldPollActiveWorktreeGitStatus` (includes the huge check) still gates evidence-free interval polling — the #7983 idle-CPU protection is preserved: while huge, no timers run.
- `canFetchActiveWorktreeGitStatus` (everything except the huge check) now gates `runFetchStatus` and the push-signal subscription, so signals that carry evidence of a change (a commit's `.git` metadata write, a finished shell command) ride the coalesced change-signal lane, run one status, and let a non-huge result clear the flag and resume normal polling.
- A `visibilitychange` catch-up listener (active only while huge pauses polling) covers signals dropped behind a hidden window — e.g. an agent committing while Orca is minimized — matching the becoming-visible catch-up semantics the normal lane already has via `installWindowVisibilityInterval`.

File-watch refreshes stay gated on the huge flag (unchanged): file churn is high-frequency on exactly the repos that trip the limit. Push signals are low-frequency and paced by the coalescer's 3s floor plus the slow-task backoff.

## Screenshots

No visual change (the existing "too many changes" banner now clears itself once a signal-triggered status runs).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — all renderer suites pass (right-sidebar: 150 files / 1,259 tests). 17 pre-existing failures in `src/main`/`src/relay` real-git-binary integration tests reproduce identically on a pristine `main` checkout on this machine (git 2.55.0, macOS) and are unrelated to this renderer-only change.
- [x] `pnpm build`
- [x] Added regression tests (written first, red on the old gate): with the huge flag set, no interval polling is installed, but (1) a repo-metadata push signal still triggers a git status refresh, and (2) a hidden→visible transition triggers a catch-up refresh.

## AI Review Report

Ran an adversarial review of the branch (Codex, plus the authoring agent's own pass). Focus areas and results:

- **Correctness of the gate split** — confirmed sound: `runFetchStatus` no longer checks the huge flag, so a trailing coalesced run can clear it; push subscriptions stay keyed to repo/worktree identity; no stale closures or listener leaks found; worktree-switch traces (huge→huge, huge→non-huge, hidden transitions) behave correctly.
- **`document` availability** — the review flagged that the new visibility effect accessed `document` unguarded, unlike `installWindowVisibilityInterval`; fixed by adding the same defensive existence check.
- **Cross-platform (macOS/Linux/Windows)** — renderer-only change; no shortcuts, labels, paths, shell, or Electron platform APIs touched. `visibilitychange`/`document.visibilityState` are standard DOM APIs identical across platforms.
- **SSH/remote/local** — the gate keeps the existing `isActiveConnectionReady` condition, so disconnected SSH targets still skip refreshes; push signals for remote repos flow through the same IPC channels as before.
- **Performance vs #7983** — while huge, idle cost remains zero (no timers). Under continuous terminal signals on a still-huge repo the change-signal backoff (1× previous run duration, 3s floor) bounds worst-case duty cycle; see Notes for the residual trade-off the review flagged.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or dependency changes. The change rearranges existing renderer-side gating of already-established IPC subscriptions (`worktrees:onChanged`, `worktrees:onGitStatusMetadataChanged`, DOM `visibilitychange`); no new IPC surface, no new data crosses the preload bridge, and payload handling (`repoId` comparison) is unchanged.

## Notes

Two residual limitations surfaced by the adversarial review, left out of scope to keep this PR minimal (both are strictly better than the current permanently-stuck behavior; happy to follow up if maintainers have a preferred pacing design):

1. **File-only recovery:** if a huge worktree becomes non-huge purely through file changes made outside any terminal (e.g. deleting a generated folder in Finder) while the window stays visible, no push signal fires and the flag clears only on the next signal (any terminal command / metadata write / window reveal). A low-frequency probe lane while huge would close this.
2. **Terminal-signal pacing while still huge:** terminal command-finished events fire for every command, so a chatty agent on a genuinely-still-huge repo can drive status runs at up to ~50% duty cycle (bounded by the 1× slow-task backoff). Distinct huge-mode pacing for terminal-finished signals (metadata signals keeping short latency) would tighten this.
