### PR TITLE
feat(mobile): show all usage providers on mobile with a per-provider visibility filter

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -175,6 +175,7 @@ export default function RootLayout() {
           <Stack.Screen name="terminal-settings" options={{ headerShown: false }} />
           <Stack.Screen name="browser-settings" options={{ headerShown: false }} />
           <Stack.Screen name="voice-settings" options={{ headerShown: false }} />
+          <Stack.Screen name="account-usage-settings" options={{ headerShown: false }} />
           <Stack.Screen name="notifications" options={{ headerShown: false }} />
           <Stack.Screen name="troubleshoot" options={{ headerShown: false }} />
           <Stack.Screen name="connection-log" options={{ headerShown: false }} />

--- a/mobile/app/account-usage-settings.tsx
+++ b/mobile/app/account-usage-settings.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { View, Text, StyleSheet, Pressable, Switch, ScrollView } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useRouter, useFocusEffect } from 'expo-router'
+import { useRouter } from 'expo-router'
 import { ChevronLeft } from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
 import {
@@ -9,46 +9,52 @@ import {
   DEFAULT_VISIBLE_USAGE_PROVIDERS,
   type UsageProviderKey
 } from '../src/components/AccountUsage'
-import { loadVisibleUsageProviders, saveVisibleUsageProviders } from '../src/storage/preferences'
+import {
+  loadVisibleUsageProvidersSettled,
+  setUsageProviderVisible
+} from '../src/storage/preferences'
 
 export default function AccountUsageSettingsScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const [visible, setVisible] = useState<Set<UsageProviderKey>>(
-    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
-  )
-  // Why: a fast toggle before the initial load resolves must win — otherwise
-  // the delayed read would clobber it with the stored value (mirrors the
-  // Settings → Terminal autocomplete toggle guard).
-  const userToggledRef = useRef(false)
+  // Why: null until the stored set loads. Switches stay disabled while null so a
+  // tap can't persist against the default base and silently drop a stored-only
+  // provider (e.g. an opted-in Grok); the load resolves within a frame or two.
+  const [visible, setVisible] = useState<Set<UsageProviderKey> | null>(null)
 
-  useFocusEffect(
-    useCallback(() => {
-      let active = true
-      void loadVisibleUsageProviders().then((set) => {
-        if (active && !userToggledRef.current) {
-          setVisible(set)
-        }
-      })
-      return () => {
-        active = false
+  // Why: this screen is the only writer of the visibility set, so load once on
+  // mount rather than on every focus — a focus-reload could resolve mid-toggle
+  // and overwrite the optimistic UI with a pre-write snapshot. The settled read
+  // also waits for any in-flight toggle so a quick leave/return shows the latest.
+  useEffect(() => {
+    let active = true
+    void loadVisibleUsageProvidersSettled().then((stored) => {
+      if (active) {
+        setVisible(stored)
       }
-    }, [])
-  )
+    })
+    return () => {
+      active = false
+    }
+  }, [])
 
   const toggle = useCallback((id: UsageProviderKey, value: boolean) => {
-    userToggledRef.current = true
+    // Optimistic UI; the storage-level toggle re-reads the latest stored set and
+    // changes only this provider, so it survives an unmount and never clobbers
+    // one the user didn't touch. Swallow a write failure so the UI stays put.
     setVisible((prev) => {
+      if (!prev) {
+        return prev
+      }
       const next = new Set(prev)
       if (value) {
         next.add(id)
       } else {
         next.delete(id)
       }
-      // Swallow a storage write failure so the UI stays on the user's choice.
-      void saveVisibleUsageProviders(next).catch(() => {})
       return next
     })
+    void setUsageProviderVisible(id, value).catch(() => {})
   }, [])
 
   return (
@@ -75,8 +81,13 @@ export default function AccountUsageSettingsScreen() {
               <View style={styles.row}>
                 <Text style={styles.rowLabel}>{descriptor.label}</Text>
                 <Switch
-                  value={visible.has(descriptor.id)}
+                  value={
+                    visible
+                      ? visible.has(descriptor.id)
+                      : DEFAULT_VISIBLE_USAGE_PROVIDERS.includes(descriptor.id)
+                  }
                   onValueChange={(v) => toggle(descriptor.id, v)}
+                  disabled={visible === null}
                   trackColor={{ false: colors.bgRaised, true: colors.textSecondary }}
                   thumbColor={colors.textPrimary}
                 />

--- a/mobile/app/account-usage-settings.tsx
+++ b/mobile/app/account-usage-settings.tsx
@@ -81,6 +81,7 @@ export default function AccountUsageSettingsScreen() {
               <View style={styles.row}>
                 <Text style={styles.rowLabel}>{descriptor.label}</Text>
                 <Switch
+                  accessibilityLabel={`Show ${descriptor.label} usage`}
                   value={
                     visible
                       ? visible.has(descriptor.id)

--- a/mobile/app/account-usage-settings.tsx
+++ b/mobile/app/account-usage-settings.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useRef, useState } from 'react'
+import { View, Text, StyleSheet, Pressable, Switch, ScrollView } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useRouter, useFocusEffect } from 'expo-router'
+import { ChevronLeft } from 'lucide-react-native'
+import { colors, spacing, typography } from '../src/theme/mobile-theme'
+import {
+  USAGE_PROVIDERS,
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
+  type UsageProviderKey
+} from '../src/components/AccountUsage'
+import { loadVisibleUsageProviders, saveVisibleUsageProviders } from '../src/storage/preferences'
+
+export default function AccountUsageSettingsScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const [visible, setVisible] = useState<Set<UsageProviderKey>>(
+    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  )
+  // Why: a fast toggle before the initial load resolves must win — otherwise
+  // the delayed read would clobber it with the stored value (mirrors the
+  // Settings → Terminal autocomplete toggle guard).
+  const userToggledRef = useRef(false)
+
+  useFocusEffect(
+    useCallback(() => {
+      let active = true
+      void loadVisibleUsageProviders().then((set) => {
+        if (active && !userToggledRef.current) {
+          setVisible(set)
+        }
+      })
+      return () => {
+        active = false
+      }
+    }, [])
+  )
+
+  const toggle = useCallback((id: UsageProviderKey, value: boolean) => {
+    userToggledRef.current = true
+    setVisible((prev) => {
+      const next = new Set(prev)
+      if (value) {
+        next.add(id)
+      } else {
+        next.delete(id)
+      }
+      // Swallow a storage write failure so the UI stays on the user's choice.
+      void saveVisibleUsageProviders(next).catch(() => {})
+      return next
+    })
+  }, [])
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
+      <View style={styles.topRow}>
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+          <ChevronLeft size={22} color={colors.textSecondary} />
+        </Pressable>
+        <Text style={styles.heading}>Account usage</Text>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: insets.bottom + spacing.xl }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.intro}>
+          Choose which providers appear in the Account usage cards and the per-host accounts screen.
+        </Text>
+
+        <View style={styles.section}>
+          {USAGE_PROVIDERS.map((descriptor, index) => (
+            <View key={descriptor.id}>
+              {index > 0 ? <View style={styles.separator} /> : null}
+              <View style={styles.row}>
+                <Text style={styles.rowLabel}>{descriptor.label}</Text>
+                <Switch
+                  value={visible.has(descriptor.id)}
+                  onValueChange={(v) => toggle(descriptor.id, v)}
+                  trackColor={{ false: colors.bgRaised, true: colors.textSecondary }}
+                  thumbColor={colors.textPrimary}
+                />
+              </View>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgBase,
+    padding: spacing.lg
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.lg
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.sm
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.textPrimary
+  },
+  intro: {
+    fontSize: typography.metaSize,
+    color: colors.textMuted,
+    lineHeight: 18,
+    marginBottom: spacing.md
+  },
+  section: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: 12,
+    overflow: 'hidden'
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  rowLabel: {
+    flex: 1,
+    fontSize: typography.bodySize,
+    fontWeight: '500',
+    color: colors.textPrimary
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.borderSubtle,
+    marginLeft: spacing.md + 2
+  }
+})

--- a/mobile/app/h/[hostId]/accounts.tsx
+++ b/mobile/app/h/[hostId]/accounts.tsx
@@ -9,22 +9,29 @@ import {
   Alert
 } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useLocalSearchParams, useRouter } from 'expo-router'
-import { ChevronLeft, Check, RefreshCw, User } from 'lucide-react-native'
+import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router'
+import { ChevronLeft, Check, RefreshCw, User, Gauge } from 'lucide-react-native'
 import { loadHosts } from '../../../src/transport/host-store'
 import { useHostClient } from '../../../src/transport/client-context'
 import type { RpcSuccess } from '../../../src/transport/types'
 import { colors, spacing } from '../../../src/theme/mobile-theme'
 import { styles } from './accounts-screen-styles'
 import { ClaudeIcon, OpenAIIcon } from '../../../src/components/AgentIcons'
+import { loadVisibleUsageProviders } from '../../../src/storage/preferences'
 import {
   type AccountsSnapshot,
   type ProviderKey,
+  type UsageProviderKey,
+  type UsageProviderDescriptor,
+  USAGE_PROVIDERS,
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
   getActiveProviderRateLimits,
   getInactiveProviderUsage,
+  getProviderUsageWindows,
   getUsageBarState,
   hasActiveProviderUsage,
-  UsageBar
+  UsageBar,
+  UsageWindowBars
 } from '../../../src/components/AccountUsage'
 
 export default function AccountsScreen() {
@@ -39,6 +46,26 @@ export default function AccountsScreen() {
   const [error, setError] = useState<string | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [busyAccountId, setBusyAccountId] = useState<string | null>(null)
+  const [visibleProviders, setVisibleProviders] = useState<Set<UsageProviderKey>>(
+    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  )
+
+  // Why: reload on focus so a change made in Settings → Account usage is
+  // reflected when the user navigates back — the screen stays mounted and
+  // updates in place (mirrors how the terminal picks up Settings → Terminal).
+  useFocusEffect(
+    useCallback(() => {
+      let active = true
+      void loadVisibleUsageProviders().then((set) => {
+        if (active) {
+          setVisibleProviders(set)
+        }
+      })
+      return () => {
+        active = false
+      }
+    }, [])
+  )
 
   useEffect(() => {
     if (!hostId) {
@@ -138,7 +165,7 @@ export default function AccountsScreen() {
     const activeWeeklyBar = getUsageBarState(activeUsage, 'weekly')
     const Icon = provider === 'claude' ? ClaudeIcon : OpenAIIcon
     return (
-      <View style={styles.section}>
+      <View style={styles.section} key={provider}>
         <View style={styles.sectionHeader}>
           <Icon size={14} />
           <Text style={styles.sectionHeading}>{title}</Text>
@@ -241,6 +268,49 @@ export default function AccountsScreen() {
     )
   }
 
+  // Why: display-only providers (Gemini/OpenCode Go/Kimi/MiniMax/Grok) have no
+  // Orca-managed accounts and no interactive switching, so the section is a
+  // non-pressable card that just surfaces the system-default target's usage.
+  // Rendered windows come from getProviderUsageWindows so Gemini buckets and
+  // OpenCode Go monthly show instead of two hardcoded 5h/7d bars.
+  const renderDisplayProviderSection = (descriptor: UsageProviderDescriptor) => {
+    if (!snapshot) {
+      return null
+    }
+    const usage = getActiveProviderRateLimits(snapshot, descriptor.id)
+    // Why: show a configured provider that is still loading or transiently
+    // failing (spinner / error copy below); only hide a genuinely
+    // unconfigured provider (no data and not fetching/error).
+    const renderable =
+      hasActiveProviderUsage(usage) || usage?.status === 'fetching' || usage?.status === 'error'
+    if (!renderable) {
+      return null
+    }
+    const windows = getProviderUsageWindows(usage)
+    const fetching = usage?.status === 'fetching'
+    return (
+      <View style={styles.section} key={descriptor.id}>
+        <View style={styles.sectionHeader}>
+          <Gauge size={14} color={colors.textMuted} />
+          <Text style={styles.sectionHeading}>{descriptor.label}</Text>
+        </View>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <View style={styles.rowMain}>
+              <Text style={styles.rowTitle}>System default</Text>
+              <UsageWindowBars windows={windows} fetching={fetching} />
+              {usage?.error ? (
+                <Text style={styles.errorText} numberOfLines={1}>
+                  {usage.error}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        </View>
+      </View>
+    )
+  }
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.topRow}>
@@ -294,8 +364,11 @@ export default function AccountsScreen() {
           </View>
         ) : (
           <>
-            {renderProviderSection('claude', 'Claude')}
-            {renderProviderSection('codex', 'Codex')}
+            {USAGE_PROVIDERS.filter((p) => visibleProviders.has(p.id)).map((p) =>
+              p.id === 'claude' || p.id === 'codex'
+                ? renderProviderSection(p.id, p.label)
+                : renderDisplayProviderSection(p)
+            )}
             <View style={styles.footerHint}>
               <User size={14} color={colors.textMuted} />
               <Text style={styles.footerHintText}>

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -14,16 +14,15 @@ import {
   Edit3,
   ListTodo
 } from 'lucide-react-native'
-import { ClaudeIcon, OpenAIIcon } from '../src/components/AgentIcons'
 import {
   type AccountsSnapshot,
-  type ProviderKey,
-  getActiveProviderRateLimits,
-  getUsageBarState,
-  hasActiveProviderUsage,
-  hasRenderableUsage,
-  UsageBar
+  type UsageProviderKey,
+  USAGE_PROVIDERS,
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
+  hasRenderableUsage
 } from '../src/components/AccountUsage'
+import { HomeAccountUsageCard } from '../src/components/HomeAccountUsageCard'
+import { loadVisibleUsageProviders } from '../src/storage/preferences'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { loadHosts, renameHost } from '../src/transport/host-store'
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
@@ -314,6 +313,9 @@ export default function HomeScreen() {
   const [stats, setStats] = useState<StatsSummary | null>(null)
   const [worktreeInfo, setWorktreeInfo] = useState<Record<string, HostWorktreeInfo>>({})
   const [accountsByHost, setAccountsByHost] = useState<Record<string, AccountsSnapshot>>({})
+  const [visibleUsageProviders, setVisibleUsageProviders] = useState<Set<UsageProviderKey>>(
+    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  )
   const [taskProvidersByHost, setTaskProvidersByHost] = useState<Record<string, TaskProvider[]>>({})
   const [lastVisited, setLastVisited] = useState<{ hostId: string; worktreeId: string } | null>(
     null
@@ -395,6 +397,11 @@ export default function HomeScreen() {
       void loadHosts().then((h) => {
         if (!stale) {
           setHosts(h)
+        }
+      })
+      void loadVisibleUsageProviders().then((set) => {
+        if (!stale) {
+          setVisibleUsageProviders(set)
         }
       })
       void AsyncStorage.getItem('orca:last-visited-worktree').then((raw) => {
@@ -616,12 +623,17 @@ export default function HomeScreen() {
       // Why: also show hosts whose only usage is the system-default login
       // (no Orca-managed accounts but live rate-limit data for the active
       // target), otherwise system-default users see no usage section at all.
-      if (hasRenderableUsage(snap, 'claude') || hasRenderableUsage(snap, 'codex')) {
+      // Gated by the per-device visibility filter so hidden providers don't
+      // keep the section alive.
+      const anyVisible = USAGE_PROVIDERS.some(
+        (p) => visibleUsageProviders.has(p.id) && hasRenderableUsage(snap, p.id)
+      )
+      if (anyVisible) {
         items.push({ host, snapshot: snap })
       }
     }
     return items
-  }, [sortedHosts, hostStates, accountsByHost])
+  }, [sortedHosts, hostStates, accountsByHost, visibleUsageProviders])
 
   const primaryConnectedHost = useMemo(
     () => sortedHosts.find((host) => hostStates[host.id] === 'connected') ?? null,
@@ -958,78 +970,16 @@ export default function HomeScreen() {
                   <Text style={[styles.sectionHeading, { marginTop: spacing.xl }]}>
                     Account usage
                   </Text>
-                  {accountsHosts.map(({ host, snapshot }) => {
-                    const claudeActiveId = snapshot.claude.activeAccountId
-                    const claudeActive =
-                      snapshot.claude.accounts.find((a) => a.id === claudeActiveId) ?? null
-                    const codexActiveId = snapshot.codex.activeAccountId
-                    const codexActive =
-                      snapshot.codex.accounts.find((a) => a.id === codexActiveId) ?? null
-                    const showHostName = accountsHosts.length > 1
-                    return (
-                      <Pressable
-                        key={host.id}
-                        style={({ pressed }) => [
-                          styles.accountsCard,
-                          pressed && styles.hostCardPressed
-                        ]}
-                        onPress={() => router.push(`/h/${host.id}/accounts`)}
-                      >
-                        {showHostName ? (
-                          <Text style={styles.accountsHostLabel} numberOfLines={1}>
-                            {host.name}
-                          </Text>
-                        ) : null}
-                        {(['claude', 'codex'] as ProviderKey[]).map((provider) => {
-                          const active = provider === 'claude' ? claudeActive : codexActive
-                          const accounts =
-                            provider === 'claude'
-                              ? snapshot.claude.accounts
-                              : snapshot.codex.accounts
-                          const limits = getActiveProviderRateLimits(snapshot, provider)
-                          // Why: with no managed accounts, still render a
-                          // "System default" row when the active target has
-                          // live usage data; the row label already falls back
-                          // to "System default" below.
-                          if (accounts.length === 0 && !hasActiveProviderUsage(limits)) {
-                            return null
-                          }
-                          const sessionBar = getUsageBarState(limits, 'session')
-                          const weeklyBar = getUsageBarState(limits, 'weekly')
-                          return (
-                            <View key={provider} style={styles.accountsRow}>
-                              <View style={styles.accountsIcon}>
-                                {provider === 'claude' ? (
-                                  <ClaudeIcon size={18} />
-                                ) : (
-                                  <OpenAIIcon size={18} color={colors.textPrimary} />
-                                )}
-                              </View>
-                              <View style={styles.accountsInfo}>
-                                <Text style={styles.accountsEmail} numberOfLines={1}>
-                                  {active?.email ?? 'System default'}
-                                </Text>
-                                <View style={styles.accountsBars}>
-                                  <UsageBar
-                                    label="5h"
-                                    usedPercent={sessionBar.usedPercent}
-                                    unavailable={sessionBar.unavailable}
-                                    loading={sessionBar.loading}
-                                  />
-                                  <UsageBar
-                                    label="7d"
-                                    usedPercent={weeklyBar.usedPercent}
-                                    unavailable={weeklyBar.unavailable}
-                                    loading={weeklyBar.loading}
-                                  />
-                                </View>
-                              </View>
-                            </View>
-                          )
-                        })}
-                      </Pressable>
-                    )
-                  })}
+                  {accountsHosts.map(({ host, snapshot }) => (
+                    <HomeAccountUsageCard
+                      key={host.id}
+                      snapshot={snapshot}
+                      visibleProviders={visibleUsageProviders}
+                      showHostName={accountsHosts.length > 1}
+                      hostName={host.name}
+                      onPress={() => router.push(`/h/${host.id}/accounts`)}
+                    />
+                  ))}
                 </>
               ) : null}
             </View>
@@ -1409,52 +1359,6 @@ const styles = StyleSheet.create({
   },
 
   /* ─── Account usage ─── */
-  accountsCard: {
-    backgroundColor: colors.bgPanel,
-    borderWidth: 1,
-    borderColor: colors.borderSubtle,
-    borderRadius: radii.card,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm + 2,
-    gap: spacing.sm,
-    marginBottom: spacing.sm
-  },
-  accountsHostLabel: {
-    fontSize: 11,
-    color: colors.textMuted,
-    fontWeight: '500',
-    textTransform: 'uppercase',
-    letterSpacing: 0.4
-  },
-  accountsRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm + 2
-  },
-  accountsIcon: {
-    width: 32,
-    height: 32,
-    borderRadius: 9,
-    backgroundColor: colors.bgRaised,
-    alignItems: 'center',
-    justifyContent: 'center'
-  },
-  accountsInfo: {
-    flex: 1,
-    minWidth: 0,
-    gap: 2
-  },
-  accountsEmail: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: colors.textPrimary
-  },
-  accountsBars: {
-    flexDirection: 'row',
-    gap: spacing.md,
-    marginTop: 4
-  },
-
   /* ─── Quick actions ─── */
   quickActions: {
     flexDirection: 'row',

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -21,7 +21,8 @@ import {
   Mic,
   Globe,
   Terminal as TerminalIcon,
-  KeyRound
+  KeyRound,
+  Gauge
 } from 'lucide-react-native'
 import { colors, radii, spacing, typography } from '../src/theme/mobile-theme'
 import {
@@ -129,6 +130,15 @@ export default function SettingsScreen() {
           >
             <Mic size={16} color={colors.textSecondary} />
             <Text style={styles.rowLabel}>Voice</Text>
+            <ChevronRight size={16} color={colors.textMuted} />
+          </Pressable>
+          <View style={styles.separator} />
+          <Pressable
+            style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+            onPress={() => router.push('/account-usage-settings')}
+          >
+            <Gauge size={16} color={colors.textSecondary} />
+            <Text style={styles.rowLabel}>Account usage</Text>
             <ChevronRight size={16} color={colors.textMuted} />
           </Pressable>
           <View style={styles.separator} />

--- a/mobile/src/components/AccountUsage.tsx
+++ b/mobile/src/components/AccountUsage.tsx
@@ -47,8 +47,12 @@ export function UsageBar({
   loading?: boolean
   labelWidth?: number
 }) {
-  // Why: round then clamp so bar width, color, and label share one value (desktop parity).
-  const used = usedPercent == null ? null : Math.max(0, Math.min(100, Math.round(usedPercent)))
+  // Round+clamp so width/color/label share one value (desktop parity); a
+  // non-finite value counts as no data so the bar never renders `width: "NaN%"`.
+  const used =
+    usedPercent == null || !Number.isFinite(usedPercent)
+      ? null
+      : Math.max(0, Math.min(100, Math.round(usedPercent)))
   // Why: same consumption bands as desktop barColor (green <60, amber <80, red ≥80).
   const barColor =
     used == null

--- a/mobile/src/components/AccountUsage.tsx
+++ b/mobile/src/components/AccountUsage.tsx
@@ -1,5 +1,6 @@
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native'
 import { colors, spacing, typography } from '../theme/mobile-theme'
+import type { UsageWindowRow } from './account-usage-state'
 
 // Pure types and selectors live in account-usage-state.ts (no RN imports) so
 // they are unit-testable; re-exported here so existing import sites are stable.
@@ -11,11 +12,20 @@ export type {
   CodexAccountSummary,
   AccountsSnapshot,
   ProviderKey,
+  ManagedAccountProviderKey,
+  UsageProviderKey,
+  UsageProviderDescriptor,
+  UsageWindowRow,
   UsageBarState
 } from './account-usage-state'
 export {
+  USAGE_PROVIDERS,
+  USAGE_PROVIDER_IDS,
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
+  getUsageProviderDescriptor,
   getActiveProviderRateLimits,
   getInactiveProviderUsage,
+  getProviderUsageWindows,
   getUsageBarState,
   hasActiveProviderUsage,
   hasRenderableUsage
@@ -28,12 +38,14 @@ export function UsageBar({
   label,
   usedPercent,
   unavailable,
-  loading
+  loading,
+  labelWidth
 }: {
   label: string
   usedPercent: number | null
   unavailable: boolean
   loading?: boolean
+  labelWidth?: number
 }) {
   // Why: round then clamp so bar width, color, and label share one value (desktop parity).
   const used = usedPercent == null ? null : Math.max(0, Math.min(100, Math.round(usedPercent)))
@@ -48,7 +60,12 @@ export function UsageBar({
           : colors.statusGreen
   return (
     <View style={styles.usageBar}>
-      <Text style={styles.usageLabel}>{label}</Text>
+      <Text
+        style={[styles.usageLabel, labelWidth != null ? { width: labelWidth } : null]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
       <View style={styles.usageTrack}>
         <View
           style={[
@@ -69,7 +86,44 @@ export function UsageBar({
   )
 }
 
+// Why: display-only providers can report a variable set of windows (Gemini
+// named buckets, OpenCode Go monthly, others session/weekly). Render one bar
+// per window stacked full-width, or a single loading/unavailable bar when a
+// provider is mid-fetch with nothing yet.
+export function UsageWindowBars({
+  windows,
+  fetching
+}: {
+  windows: UsageWindowRow[]
+  fetching?: boolean
+}) {
+  if (windows.length === 0) {
+    return <UsageBar label="—" usedPercent={null} unavailable={!fetching} loading={fetching} />
+  }
+  // Widen the label column for named buckets (e.g. "3.1 Flash Lite") so they
+  // don't wrap in the 22px slot sized for "5h"/"7d".
+  const labelWidth = windows.some((w) => w.label.length > 4) ? 76 : undefined
+  return (
+    <>
+      {windows.map((w) => (
+        <View style={styles.windowRow} key={w.key}>
+          <UsageBar
+            label={w.label}
+            usedPercent={w.usedPercent}
+            unavailable={false}
+            labelWidth={labelWidth}
+          />
+        </View>
+      ))}
+    </>
+  )
+}
+
 const styles = StyleSheet.create({
+  windowRow: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
   usageBar: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/mobile/src/components/HomeAccountUsageCard.tsx
+++ b/mobile/src/components/HomeAccountUsageCard.tsx
@@ -54,10 +54,15 @@ export function HomeAccountUsageCard({
             : descriptor.id === 'codex'
               ? snapshot.codex.accounts
               : []
-        // Hide a provider with neither a managed account nor live usage; a
-        // managed provider still shows a "System default" row when the active
-        // target has data.
-        if (managedAccounts.length === 0 && !hasActiveProviderUsage(limits)) {
+        // Hide a provider with no managed account and no usage — but keep a
+        // display-only one visible while fetching/error, matching the accounts screen.
+        const displayOnlyPending =
+          !descriptor.managed && (limits?.status === 'fetching' || limits?.status === 'error')
+        if (
+          managedAccounts.length === 0 &&
+          !hasActiveProviderUsage(limits) &&
+          !displayOnlyPending
+        ) {
           return null
         }
         const active =

--- a/mobile/src/components/HomeAccountUsageCard.tsx
+++ b/mobile/src/components/HomeAccountUsageCard.tsx
@@ -1,0 +1,168 @@
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { Gauge } from 'lucide-react-native'
+import { colors, spacing, radii } from '../theme/mobile-theme'
+import { ClaudeIcon, OpenAIIcon } from './AgentIcons'
+import {
+  type AccountsSnapshot,
+  type UsageProviderKey,
+  USAGE_PROVIDERS,
+  getActiveProviderRateLimits,
+  getProviderUsageWindows,
+  getUsageBarState,
+  hasActiveProviderUsage,
+  UsageBar,
+  UsageWindowBars
+} from './AccountUsage'
+
+// Why: one host's Account-usage card on the home screen. Extracted from
+// app/index.tsx to keep that screen under the max-lines ratchet and to house
+// the multi-provider rendering (managed Claude/Codex switch summary + the
+// display-only providers gated by the per-device visibility filter).
+export function HomeAccountUsageCard({
+  snapshot,
+  visibleProviders,
+  showHostName,
+  hostName,
+  onPress
+}: {
+  snapshot: AccountsSnapshot
+  visibleProviders: Set<UsageProviderKey>
+  showHostName: boolean
+  hostName: string
+  onPress: () => void
+}) {
+  const claudeActiveId = snapshot.claude.activeAccountId
+  const claudeActive = snapshot.claude.accounts.find((a) => a.id === claudeActiveId) ?? null
+  const codexActiveId = snapshot.codex.activeAccountId
+  const codexActive = snapshot.codex.accounts.find((a) => a.id === codexActiveId) ?? null
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+      onPress={onPress}
+    >
+      {showHostName ? (
+        <Text style={styles.hostLabel} numberOfLines={1}>
+          {hostName}
+        </Text>
+      ) : null}
+      {USAGE_PROVIDERS.filter((p) => visibleProviders.has(p.id)).map((descriptor) => {
+        const limits = getActiveProviderRateLimits(snapshot, descriptor.id)
+        const managedAccounts =
+          descriptor.id === 'claude'
+            ? snapshot.claude.accounts
+            : descriptor.id === 'codex'
+              ? snapshot.codex.accounts
+              : []
+        // Hide a provider with neither a managed account nor live usage; a
+        // managed provider still shows a "System default" row when the active
+        // target has data.
+        if (managedAccounts.length === 0 && !hasActiveProviderUsage(limits)) {
+          return null
+        }
+        const active =
+          descriptor.id === 'claude' ? claudeActive : descriptor.id === 'codex' ? codexActive : null
+        const sessionBar = getUsageBarState(limits, 'session')
+        const weeklyBar = getUsageBarState(limits, 'weekly')
+        return (
+          <View key={descriptor.id} style={styles.row}>
+            <View style={styles.icon}>
+              {descriptor.id === 'claude' ? (
+                <ClaudeIcon size={18} />
+              ) : descriptor.id === 'codex' ? (
+                <OpenAIIcon size={18} color={colors.textPrimary} />
+              ) : (
+                <Gauge size={18} color={colors.textSecondary} />
+              )}
+            </View>
+            <View style={styles.info}>
+              <Text style={styles.email} numberOfLines={1}>
+                {descriptor.managed ? (active?.email ?? 'System default') : descriptor.label}
+              </Text>
+              {descriptor.managed ? (
+                <View style={styles.bars}>
+                  <UsageBar
+                    label="5h"
+                    usedPercent={sessionBar.usedPercent}
+                    unavailable={sessionBar.unavailable}
+                    loading={sessionBar.loading}
+                  />
+                  <UsageBar
+                    label="7d"
+                    usedPercent={weeklyBar.usedPercent}
+                    unavailable={weeklyBar.unavailable}
+                    loading={weeklyBar.loading}
+                  />
+                </View>
+              ) : (
+                <View style={styles.windows}>
+                  <UsageWindowBars
+                    windows={getProviderUsageWindows(limits)}
+                    fetching={limits?.status === 'fetching'}
+                  />
+                </View>
+              )}
+            </View>
+          </View>
+        )
+      })}
+    </Pressable>
+  )
+}
+
+// Mirrors the styles this card used when it lived inline in app/index.tsx, so
+// the visual result is unchanged by the extraction.
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.bgPanel,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radii.card,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm + 2,
+    gap: spacing.sm,
+    marginBottom: spacing.sm
+  },
+  cardPressed: {
+    backgroundColor: colors.bgRaised
+  },
+  hostLabel: {
+    fontSize: 11,
+    color: colors.textMuted,
+    fontWeight: '500',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm + 2
+  },
+  icon: {
+    width: 32,
+    height: 32,
+    borderRadius: 9,
+    backgroundColor: colors.bgRaised,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  info: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2
+  },
+  email: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textPrimary
+  },
+  bars: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginTop: 4
+  },
+  windows: {
+    marginTop: 4,
+    gap: 4
+  }
+})

--- a/mobile/src/components/account-usage-state.test.ts
+++ b/mobile/src/components/account-usage-state.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getActiveProviderRateLimits,
   getInactiveProviderUsage,
+  getProviderUsageWindows,
   getUsageBarState,
   hasActiveProviderUsage,
   hasRenderableUsage,
+  USAGE_PROVIDER_IDS,
   type AccountsSnapshot,
   type InactiveAccountUsage,
   type ProviderRateLimits
@@ -27,6 +30,8 @@ function makeSnapshot(
   overrides: {
     claudeLimits?: ProviderRateLimits | null
     codexLimits?: ProviderRateLimits | null
+    geminiLimits?: ProviderRateLimits | null
+    grokLimits?: ProviderRateLimits | null
     claudeAccounts?: AccountsSnapshot['claude']['accounts']
     codexAccounts?: AccountsSnapshot['codex']['accounts']
     inactiveClaudeAccounts?: InactiveAccountUsage[]
@@ -39,10 +44,16 @@ function makeSnapshot(
     rateLimits: {
       claude: overrides.claudeLimits ?? null,
       codex: overrides.codexLimits ?? null,
+      gemini: overrides.geminiLimits ?? null,
+      grok: overrides.grokLimits ?? null,
       inactiveClaudeAccounts: overrides.inactiveClaudeAccounts ?? [],
       inactiveCodexAccounts: overrides.inactiveCodexAccounts ?? []
     }
   }
+}
+
+function window(usedPercent: number, windowMinutes = 300) {
+  return { usedPercent, windowMinutes, resetsAt: null, resetDescription: null }
 }
 
 describe('hasActiveProviderUsage', () => {
@@ -137,5 +148,127 @@ describe('getUsageBarState', () => {
       unavailable: false,
       loading: true
     })
+  })
+})
+
+describe('getActiveProviderRateLimits', () => {
+  it('reads a display-only provider (grok) via its descriptor field', () => {
+    const grok = makeLimits({ provider: 'grok', status: 'ok', session: window(15) })
+    expect(getActiveProviderRateLimits(makeSnapshot({ grokLimits: grok }), 'grok')).toBe(grok)
+  })
+
+  it('maps opencode-go wire id to the opencodeGo snapshot field', () => {
+    const snapshot = makeSnapshot()
+    const openCode = makeLimits({
+      provider: 'opencode-go',
+      status: 'ok',
+      monthly: window(30, 43200)
+    })
+    ;(snapshot.rateLimits as { opencodeGo?: ProviderRateLimits }).opencodeGo = openCode
+    expect(getActiveProviderRateLimits(snapshot, 'opencode-go')).toBe(openCode)
+  })
+
+  // Old home-snapshot-cache v1 entries predate these fields; a missing field
+  // must normalize to null instead of undefined so cold-start hydration can't
+  // throw when a selector dereferences it.
+  it('returns null for a provider field absent from an old cached snapshot', () => {
+    const legacy = {
+      claude: { accounts: [], activeAccountId: null },
+      codex: { accounts: [], activeAccountId: null },
+      rateLimits: {
+        claude: null,
+        codex: null,
+        inactiveClaudeAccounts: [],
+        inactiveCodexAccounts: []
+      }
+    } as AccountsSnapshot
+    expect(getActiveProviderRateLimits(legacy, 'gemini')).toBeNull()
+    expect(getActiveProviderRateLimits(legacy, 'minimax')).toBeNull()
+  })
+})
+
+describe('getProviderUsageWindows', () => {
+  it('returns no rows for missing limits', () => {
+    expect(getProviderUsageWindows(null)).toEqual([])
+  })
+
+  it('expands Gemini named buckets with index-stable keys', () => {
+    const gemini = makeLimits({
+      provider: 'gemini',
+      status: 'ok',
+      buckets: [
+        { name: 'Pro', ...window(20) },
+        { name: 'Flash', ...window(5) }
+      ]
+    })
+    expect(getProviderUsageWindows(gemini)).toEqual([
+      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20 },
+      { key: 'bucket:1:Flash', label: 'Flash', usedPercent: 5 }
+    ])
+  })
+
+  // The host sets session = deriveSessionSummary(buckets) (the most-constrained
+  // bucket), so buckets are authoritative and the synthesized session row must
+  // not double-show it.
+  it('omits the derived session row when Gemini reports buckets', () => {
+    const gemini = makeLimits({
+      provider: 'gemini',
+      status: 'ok',
+      session: window(20), // mirrors the worst bucket
+      buckets: [
+        { name: 'Pro', ...window(20) },
+        { name: 'Flash', ...window(5) }
+      ]
+    })
+    expect(getProviderUsageWindows(gemini)).toEqual([
+      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20 },
+      { key: 'bucket:1:Flash', label: 'Flash', usedPercent: 5 }
+    ])
+  })
+
+  it('includes OpenCode Go monthly window', () => {
+    const openCode = makeLimits({
+      provider: 'opencode-go',
+      status: 'ok',
+      monthly: window(42, 43200)
+    })
+    expect(getProviderUsageWindows(openCode)).toEqual([
+      { key: 'monthly', label: '30d', usedPercent: 42 }
+    ])
+  })
+
+  it('returns session and weekly rows for the classic two-window shape', () => {
+    const claude = makeLimits({ status: 'ok', session: window(10), weekly: window(60, 10080) })
+    expect(getProviderUsageWindows(claude)).toEqual([
+      { key: 'session', label: '5h', usedPercent: 10 },
+      { key: 'weekly', label: '7d', usedPercent: 60 }
+    ])
+  })
+})
+
+describe('hasRenderableUsage for display-only providers', () => {
+  it('is true for grok when the system-default target has active usage', () => {
+    const snapshot = makeSnapshot({
+      grokLimits: makeLimits({ provider: 'grok', status: 'ok', weekly: window(33, 10080) })
+    })
+    expect(hasRenderableUsage(snapshot, 'grok')).toBe(true)
+  })
+
+  it('is false for a display-only provider with no data (no managed-account fallback)', () => {
+    expect(hasRenderableUsage(makeSnapshot(), 'grok')).toBe(false)
+  })
+})
+
+describe('USAGE_PROVIDER_IDS', () => {
+  it('covers all seven providers the desktop tracks', () => {
+    expect(USAGE_PROVIDER_IDS).toEqual([
+      'claude',
+      'codex',
+      'gemini',
+      'opencode-go',
+      'kimi',
+      'minimax',
+      'grok'
+    ])
   })
 })

--- a/mobile/src/components/account-usage-state.ts
+++ b/mobile/src/components/account-usage-state.ts
@@ -13,7 +13,7 @@ export type RateLimitWindow = {
 }
 
 export type ProviderRateLimits = {
-  provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi'
+  provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi' | 'minimax' | 'grok'
   session: RateLimitWindow | null
   weekly: RateLimitWindow | null
   monthly?: RateLimitWindow | null
@@ -42,18 +42,86 @@ export type CodexAccountSummary = {
   workspaceLabel?: string | null
 }
 
+// Why: the host sends the full RateLimitState in every snapshot, so the extra
+// providers' data already arrives on the phone. The new fields are optional so
+// an old cached snapshot (home-snapshot-cache v1) that predates them stays a
+// valid value — selectors normalize a missing field to null via `?? null`.
 export type AccountsSnapshot = {
   claude: { accounts: ClaudeAccountSummary[]; activeAccountId: string | null }
   codex: { accounts: CodexAccountSummary[]; activeAccountId: string | null }
   rateLimits: {
     claude: ProviderRateLimits | null
     codex: ProviderRateLimits | null
+    gemini?: ProviderRateLimits | null
+    opencodeGo?: ProviderRateLimits | null
+    kimi?: ProviderRateLimits | null
+    minimax?: ProviderRateLimits | null
+    grok?: ProviderRateLimits | null
     inactiveClaudeAccounts: InactiveAccountUsage[]
     inactiveCodexAccounts: InactiveAccountUsage[]
   }
 }
 
-export type ProviderKey = 'claude' | 'codex'
+// Why: only Claude and Codex have Orca-managed accounts and interactive
+// switching (add/re-auth stays desktop-only). Everything else is display-only
+// usage, so account-switching selectors accept only this narrow type — a
+// display-only provider can never route to accounts.selectClaude/selectCodex.
+export type ManagedAccountProviderKey = 'claude' | 'codex'
+export type UsageProviderKey =
+  | ManagedAccountProviderKey
+  | 'gemini'
+  | 'opencode-go'
+  | 'kimi'
+  | 'minimax'
+  | 'grok'
+
+// Kept as an alias so existing switching call sites stay constrained to the
+// two managed providers.
+export type ProviderKey = ManagedAccountProviderKey
+
+// The snapshot rateLimits field a provider's usage lives under. Distinct from
+// the wire id: OpenCode Go's id is 'opencode-go' but its field is 'opencodeGo'.
+type ProviderSnapshotField =
+  | 'claude'
+  | 'codex'
+  | 'gemini'
+  | 'opencodeGo'
+  | 'kimi'
+  | 'minimax'
+  | 'grok'
+
+export type UsageProviderDescriptor = {
+  id: UsageProviderKey
+  label: string
+  snapshotField: ProviderSnapshotField
+  managed: boolean
+}
+
+// Single source that maps the stable preference/wire id to its snapshot field,
+// label, and whether it supports account switching. Drives iteration order,
+// visibility toggles, and field lookup.
+export const USAGE_PROVIDERS: readonly UsageProviderDescriptor[] = [
+  { id: 'claude', label: 'Claude', snapshotField: 'claude', managed: true },
+  { id: 'codex', label: 'Codex', snapshotField: 'codex', managed: true },
+  { id: 'gemini', label: 'Gemini', snapshotField: 'gemini', managed: false },
+  { id: 'opencode-go', label: 'OpenCode Go', snapshotField: 'opencodeGo', managed: false },
+  { id: 'kimi', label: 'Kimi', snapshotField: 'kimi', managed: false },
+  { id: 'minimax', label: 'MiniMax', snapshotField: 'minimax', managed: false },
+  { id: 'grok', label: 'Grok', snapshotField: 'grok', managed: false }
+]
+
+export const USAGE_PROVIDER_IDS: readonly UsageProviderKey[] = USAGE_PROVIDERS.map((p) => p.id)
+
+// Providers shown by default when the user has never opened the filter — the
+// two primary agents, matching the phone's historical behavior and the rule
+// that the phone must not surface every provider at once.
+export const DEFAULT_VISIBLE_USAGE_PROVIDERS: readonly UsageProviderKey[] = ['claude', 'codex']
+
+export function getUsageProviderDescriptor(
+  provider: UsageProviderKey
+): UsageProviderDescriptor | null {
+  return USAGE_PROVIDERS.find((p) => p.id === provider) ?? null
+}
 
 export type UsageBarState = {
   usedPercent: number | null
@@ -63,14 +131,19 @@ export type UsageBarState = {
 
 export function getActiveProviderRateLimits(
   snapshot: AccountsSnapshot,
-  provider: ProviderKey
+  provider: UsageProviderKey
 ): ProviderRateLimits | null {
-  return provider === 'claude' ? snapshot.rateLimits.claude : snapshot.rateLimits.codex
+  const field = getUsageProviderDescriptor(provider)?.snapshotField
+  if (!field) {
+    return null
+  }
+  // `?? null` normalizes a field missing from an old cached snapshot.
+  return snapshot.rateLimits[field] ?? null
 }
 
 export function getInactiveProviderUsage(
   snapshot: AccountsSnapshot,
-  provider: ProviderKey,
+  provider: ManagedAccountProviderKey,
   accountId: string
 ): InactiveAccountUsage | null {
   const list =
@@ -117,13 +190,59 @@ export function getUsageBarState(
   }
 }
 
+export type UsageWindowRow = {
+  key: string
+  label: string
+  usedPercent: number
+}
+
+// Why: providers do not share one fixed pair of windows. Gemini reports named
+// per-model buckets, OpenCode Go reports a monthly window, others report
+// session (5h) / weekly (7d). Return the labelled rows a provider actually has
+// so display-only sections render each provider's real usage instead of two
+// hardcoded 5h/7d bars that would show dashes for buckets/monthly.
+export function getProviderUsageWindows(limits: ProviderRateLimits | null): UsageWindowRow[] {
+  if (!limits) {
+    return []
+  }
+  const buckets = limits.buckets ?? []
+  // Why: when named buckets exist they are authoritative. Gemini's `session`
+  // is derived from the most-constrained bucket (host deriveSessionSummary), so
+  // emitting both would show that worst bucket twice under a false "5h" label.
+  // Key includes the index so two buckets with the same name stay distinct.
+  if (buckets.length > 0) {
+    return buckets.map((bucket, index) => ({
+      key: `bucket:${index}:${bucket.name}`,
+      label: bucket.name,
+      usedPercent: bucket.usedPercent
+    }))
+  }
+  const rows: UsageWindowRow[] = []
+  if (limits.session) {
+    rows.push({ key: 'session', label: '5h', usedPercent: limits.session.usedPercent })
+  }
+  if (limits.weekly) {
+    rows.push({ key: 'weekly', label: '7d', usedPercent: limits.weekly.usedPercent })
+  }
+  if (limits.monthly) {
+    rows.push({ key: 'monthly', label: '30d', usedPercent: limits.monthly.usedPercent })
+  }
+  return rows
+}
+
 // Why: the usage UI must render for the system-default login, not only for
 // Orca-managed accounts. Show a provider when it has at least one managed
 // account OR active rate-limit data for the system-default target.
-export function hasRenderableUsage(snapshot: AccountsSnapshot, provider: ProviderKey): boolean {
-  const accounts = provider === 'claude' ? snapshot.claude.accounts : snapshot.codex.accounts
-  if (accounts.length > 0) {
-    return true
+export function hasRenderableUsage(
+  snapshot: AccountsSnapshot,
+  provider: UsageProviderKey
+): boolean {
+  const descriptor = getUsageProviderDescriptor(provider)
+  if (descriptor?.managed) {
+    const accounts = provider === 'claude' ? snapshot.claude.accounts : snapshot.codex.accounts
+    if (accounts.length > 0) {
+      return true
+    }
   }
   return hasActiveProviderUsage(getActiveProviderRateLimits(snapshot, provider))
 }

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -12,11 +12,13 @@ import {
   loadHostSidebarWidth,
   loadTerminalAutocompleteEnabled,
   loadTerminalLinkOpenMode,
+  loadVisibleUsageProviders,
   readDisabledTerminalLiveInputHandlesPreference,
   saveDisabledTerminalLiveInputHandles,
   saveHostSidebarWidth,
   saveTerminalAutocompleteEnabled,
-  saveTerminalLinkOpenMode
+  saveTerminalLinkOpenMode,
+  saveVisibleUsageProviders
 } from './preferences'
 
 vi.mock('@react-native-async-storage/async-storage', () => ({
@@ -201,5 +203,55 @@ describe('terminal link open mode preference', () => {
     await saveTerminalLinkOpenMode('phone-browser')
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith('orca:terminalLinkOpenMode', 'phone-browser')
+  })
+})
+
+describe('visible usage providers preference', () => {
+  beforeEach(() => {
+    vi.mocked(AsyncStorage.getItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockReset()
+  })
+
+  it('defaults to Claude + Codex when never set', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(null)
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('orca:visibleUsageProviders')
+  })
+
+  it('round-trips a saved set in canonical order', async () => {
+    await saveVisibleUsageProviders(new Set(['grok', 'claude', 'gemini']))
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'orca:visibleUsageProviders',
+      JSON.stringify(['claude', 'gemini', 'grok'])
+    )
+  })
+
+  it('drops unknown or stale ids on load', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(
+      JSON.stringify(['claude', 'opencodeGo', 'bogus', 'grok'])
+    )
+
+    // 'opencodeGo' (field name, not the wire id) and 'bogus' are dropped.
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'grok']))
+  })
+
+  it('preserves an explicit empty set as "show none"', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify([]))
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set())
+  })
+
+  it('falls back to the default set for non-array corrupted JSON', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({}))
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
+  })
+
+  it('falls back to the default set when storage cannot be read', async () => {
+    vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
   })
 })

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -13,12 +13,14 @@ import {
   loadTerminalAutocompleteEnabled,
   loadTerminalLinkOpenMode,
   loadVisibleUsageProviders,
+  loadVisibleUsageProvidersSettled,
   readDisabledTerminalLiveInputHandlesPreference,
   saveDisabledTerminalLiveInputHandles,
   saveHostSidebarWidth,
   saveTerminalAutocompleteEnabled,
   saveTerminalLinkOpenMode,
-  saveVisibleUsageProviders
+  saveVisibleUsageProviders,
+  setUsageProviderVisible
 } from './preferences'
 
 vi.mock('@react-native-async-storage/async-storage', () => ({
@@ -253,5 +255,86 @@ describe('visible usage providers preference', () => {
     vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
 
     await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
+  })
+})
+
+describe('setUsageProviderVisible (serialized read-modify-write)', () => {
+  // Back the mock with an in-memory value so a toggle's read sees the prior
+  // write — the whole point of the serialized read-modify-write.
+  let store: string | null
+  beforeEach(() => {
+    store = null
+    vi.mocked(AsyncStorage.getItem)
+      .mockReset()
+      .mockImplementation(async () => store)
+    vi.mocked(AsyncStorage.setItem)
+      .mockReset()
+      .mockImplementation(async (_key, value) => {
+        store = value as string
+      })
+  })
+
+  // The bug: a toggle that persisted the whole set against a stale base dropped
+  // a provider it never touched. Re-reading the latest set keeps it.
+  it('adds a provider without dropping a stored-only one (the Grok race)', async () => {
+    store = JSON.stringify(['claude', 'codex', 'grok'])
+
+    const result = await setUsageProviderVisible('gemini', true)
+
+    expect(result).toEqual(new Set(['claude', 'codex', 'gemini', 'grok']))
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(
+      new Set(['claude', 'codex', 'gemini', 'grok'])
+    )
+  })
+
+  it('removes only the toggled provider', async () => {
+    store = JSON.stringify(['claude', 'codex', 'grok'])
+
+    await setUsageProviderVisible('grok', false)
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
+  })
+
+  it('serializes concurrent toggles so neither is lost', async () => {
+    store = JSON.stringify(['claude', 'codex'])
+
+    await Promise.all([
+      setUsageProviderVisible('grok', true),
+      setUsageProviderVisible('gemini', true)
+    ])
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(
+      new Set(['claude', 'codex', 'gemini', 'grok'])
+    )
+  })
+
+  it('aborts the write (keeps the stored set) when the read fails', async () => {
+    store = JSON.stringify(['claude', 'codex', 'grok'])
+    vi.mocked(AsyncStorage.getItem).mockRejectedValueOnce(new Error('read blip'))
+
+    await expect(setUsageProviderVisible('gemini', true)).rejects.toThrow()
+    // The stored set is untouched — a transient read failure must not persist
+    // the default and drop Grok.
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex', 'grok']))
+  })
+
+  it('self-heals malformed stored JSON by re-basing on the default', async () => {
+    store = 'not json{'
+
+    await setUsageProviderVisible('grok', true)
+
+    // Malformed content is corrupt, not an I/O failure: re-base on the default
+    // and rewrite so the toggle repairs the stored value instead of rejecting.
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex', 'grok']))
+  })
+
+  it('loadVisibleUsageProvidersSettled waits for an in-flight toggle', async () => {
+    store = JSON.stringify(['claude', 'codex'])
+
+    const pending = setUsageProviderVisible('grok', true)
+    const settled = await loadVisibleUsageProvidersSettled()
+    await pending
+
+    expect(settled).toEqual(new Set(['claude', 'codex', 'grok']))
   })
 })

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -1,4 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
+  USAGE_PROVIDER_IDS,
+  type UsageProviderKey
+} from '../components/account-usage-state'
 
 const PINS_PREFIX = 'orca:pins:'
 const NOTIF_KEY = 'orca:pushNotificationsEnabled'
@@ -224,4 +229,39 @@ export async function loadPinnedIds(hostId: string): Promise<Set<string>> {
 
 export async function savePinnedIds(hostId: string, ids: Set<string>): Promise<void> {
   await AsyncStorage.setItem(PINS_PREFIX + hostId, JSON.stringify([...ids]))
+}
+
+const VISIBLE_USAGE_PROVIDERS_KEY = 'orca:visibleUsageProviders'
+
+// Why: intersect stored ids with the known descriptor ids so a removed,
+// misspelled, or future id can't linger in the set or silently re-enable a
+// provider after an id is reused. An explicit empty set is a valid "show none".
+function knownVisibleUsageProviders(ids: string[]): UsageProviderKey[] {
+  return USAGE_PROVIDER_IDS.filter((id) => ids.includes(id))
+}
+
+export async function loadVisibleUsageProviders(): Promise<Set<UsageProviderKey>> {
+  try {
+    const raw = await AsyncStorage.getItem(VISIBLE_USAGE_PROVIDERS_KEY)
+    if (raw === null) {
+      return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+    }
+    const parsed: unknown = JSON.parse(raw)
+    // Only a real array carries the "explicit empty set = show none" semantics;
+    // corrupted non-array JSON (e.g. `{}`) falls back to the default instead.
+    if (!Array.isArray(parsed)) {
+      return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+    }
+    return new Set(knownVisibleUsageProviders(stringArray(parsed)))
+  } catch {
+    return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  }
+}
+
+export async function saveVisibleUsageProviders(ids: ReadonlySet<UsageProviderKey>): Promise<void> {
+  // Persist in canonical descriptor order so the stored value is stable.
+  await AsyncStorage.setItem(
+    VISIBLE_USAGE_PROVIDERS_KEY,
+    JSON.stringify(USAGE_PROVIDER_IDS.filter((id) => ids.has(id)))
+  )
 }

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -240,19 +240,34 @@ function knownVisibleUsageProviders(ids: string[]): UsageProviderKey[] {
   return USAGE_PROVIDER_IDS.filter((id) => ids.includes(id))
 }
 
+// Distinguishes an I/O read failure from corrupt content. Only the I/O failure
+// propagates: a write must abort on it (it can't know the real stored set), but
+// corrupt content — missing, malformed JSON, or a non-array — normalizes to the
+// default so a toggle can self-heal it. loadVisibleUsageProviders maps the I/O
+// failure to the default for display; a write re-bases on the default and
+// rewrites, which repairs the stored value.
+async function readVisibleUsageProviders(): Promise<Set<UsageProviderKey>> {
+  const raw = await AsyncStorage.getItem(VISIBLE_USAGE_PROVIDERS_KEY)
+  if (raw === null) {
+    return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  }
+  // Only a real array carries the "explicit empty set = show none" semantics;
+  // corrupted non-array JSON (e.g. `{}`) falls back to the default instead.
+  if (!Array.isArray(parsed)) {
+    return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  }
+  return new Set(knownVisibleUsageProviders(stringArray(parsed)))
+}
+
 export async function loadVisibleUsageProviders(): Promise<Set<UsageProviderKey>> {
   try {
-    const raw = await AsyncStorage.getItem(VISIBLE_USAGE_PROVIDERS_KEY)
-    if (raw === null) {
-      return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
-    }
-    const parsed: unknown = JSON.parse(raw)
-    // Only a real array carries the "explicit empty set = show none" semantics;
-    // corrupted non-array JSON (e.g. `{}`) falls back to the default instead.
-    if (!Array.isArray(parsed)) {
-      return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
-    }
-    return new Set(knownVisibleUsageProviders(stringArray(parsed)))
+    return await readVisibleUsageProviders()
   } catch {
     return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
   }
@@ -264,4 +279,38 @@ export async function saveVisibleUsageProviders(ids: ReadonlySet<UsageProviderKe
     VISIBLE_USAGE_PROVIDERS_KEY,
     JSON.stringify(USAGE_PROVIDER_IDS.filter((id) => ids.has(id)))
   )
+}
+
+// Serialize toggles so two fast switches can't lose each other through a
+// read-modify-write race on the same key: each toggle re-reads the latest
+// stored set and changes only its own provider, so it never clobbers a
+// provider it didn't touch. ponytail: a module-level chain is enough for the
+// single settings screen; revisit if more writers appear.
+let visibleUsageWrite: Promise<Set<UsageProviderKey>> = Promise.resolve(new Set())
+
+export function setUsageProviderVisible(
+  id: UsageProviderKey,
+  value: boolean
+): Promise<Set<UsageProviderKey>> {
+  visibleUsageWrite = visibleUsageWrite
+    .catch(() => undefined)
+    .then(async () => {
+      // Strict read: if the read fails, abort the write rather than clobber the
+      // stored set with the default (which would drop stored-only providers).
+      const next = await readVisibleUsageProviders()
+      if (value) {
+        next.add(id)
+      } else {
+        next.delete(id)
+      }
+      await saveVisibleUsageProviders(next)
+      return next
+    })
+  return visibleUsageWrite
+}
+
+// Read after any in-flight toggle settles, so a screen that re-mounts right
+// after a toggle sees the just-written value instead of a pre-write snapshot.
+export function loadVisibleUsageProvidersSettled(): Promise<Set<UsageProviderKey>> {
+  return visibleUsageWrite.catch(() => undefined).then(() => loadVisibleUsageProviders())
 }


### PR DESCRIPTION
## Summary

Mobile only showed **Claude** and **Codex** usage, even though the host already streams the full `RateLimitState` for every provider in the `accounts.list` / `accounts.subscribe` snapshot. This PR surfaces the rest — **Gemini, OpenCode Go, Kimi, MiniMax, Grok** — on mobile, plus a per-provider visibility filter under **Settings → Account usage** (defaults to Claude + Codex only; the others are opt-in so the phone isn't flooded).

Pure client change — no backend or protocol change. Highlights:

- Splits `ManagedAccountProviderKey` (switchable: Claude/Codex) from `UsageProviderKey` (display-only), so a display-only provider can never route into account-switching selectors.
- A canonical provider descriptor maps the stable wire id to its snapshot field and label (resolving the `opencode-go` / `opencodeGo` mismatch); new snapshot fields are optional and normalized with `?? null`, so an old cached snapshot stays valid.
- `getProviderUsageWindows` renders each provider's *real* windows (Gemini named buckets, OpenCode Go monthly, others session/weekly) instead of two hardcoded 5h/7d bars.

### Bug fixed along the way: visibility toggle could drop an opted-in provider

**Problem** — On the settings screen, a toggle fired *before* the stored visibility set finished loading persisted the whole set against the default `{claude, codex}` base, silently dropping any provider that lived only in the stored set (e.g. an opted-in Grok).

**Root cause** — The screen started on the default set while the stored set loaded asynchronously; the pre-load toggle wrote that stale default plus the one change.

**Fix**
- Gate the switches until the stored set loads, so no toggle can persist against the default base.
- Move persistence to a serialized read-modify-write in `preferences.ts` (`setUsageProviderVisible`): each toggle re-reads the latest stored set and changes only its own provider, so concurrent toggles can't clobber each other and the write survives an unmount.
- Load once on mount via a settled read (the screen is the sole writer), so a focus-reload can't overwrite the optimistic UI with a pre-write snapshot.
- Distinguish an I/O read failure (abort the write — don't clobber the stored set with the default) from corrupt content (missing / malformed JSON / non-array → re-base on the default and self-heal).

Follow-up review fixes: the Home usage card now keeps a display-only provider visible while fetching/on error (matching the accounts screen) instead of hiding it; each visibility `Switch` gets an `accessibilityLabel`; `UsageBar` treats a non-finite percent as no data so it never renders `width: "NaN%"`.

## Screenshots

Mobile UI change (new **Settings → Account usage** filter screen; Home card and per-host accounts screen now list opted-in providers). Before/after captures to be added from a device/simulator — no desktop-renderable surface.

## Testing

- [x] `pnpm typecheck` — clean on all changed files (`tsc --noEmit -p mobile/tsconfig.json`)
- [ ] `pnpm lint` — changed files pass oxlint + oxfmt via the husky pre-commit hook; full-repo lint not run
- [ ] `pnpm test` — ran the focused suites below (49 passed); full suite not run
- [ ] `pnpm build` — not run locally; relying on CI
- [x] Added regression tests that fail without the fix (verified by reverting each fix)

Focused tests (from `mobile/`):

```
pnpm exec vitest run src/storage/preferences.test.ts src/components/account-usage-state.test.ts
```

New tests cover: a stored-only provider (Grok) survives a pre-load toggle; concurrent toggles serialize without loss; an I/O read failure aborts the write and leaves the stored set intact; malformed stored JSON self-heals. Each was confirmed to fail before its fix.

## AI Review Report

Reviewed with Codex (GPT-5.6) across several independent adversarial passes:

- **Data flow** — Verified the "pure client" premise end to end: the host's `getAccountsSnapshot()` returns `rateLimits.getState()` whole (Grok included) and `accounts.subscribe` broadcasts it unmodified, so no host/protocol change is needed.
- **Concurrency / lifecycle** — Iterated on the settings-screen load/toggle race until the load-gate + serialized read-modify-write closed every flagged path (pre-load overwrite, unmount loss, focus late-load overwrite, I/O-failure clobber, malformed-JSON lockout).
- **UI consistency & a11y** — Flagged and fixed a Home-vs-accounts display divergence for fetching/error display-only providers, a missing switch `accessibilityLabel`, and a `NaN%` bar-width edge case.
- **Cross-platform** — This is React Native mobile code with no OS-specific branches, shortcuts, labels, or path handling; nothing Electron/macOS/Linux/Windows-specific is touched.

## Security Audit

No new input parsing from untrusted sources, no command execution, no path handling, no secrets, and no new IPC/RPC surface. Visibility preferences are stored locally in `AsyncStorage`; the usage data already arrives in the existing accounts snapshot. Stored preferences are defensively validated (unknown ids filtered, corrupt content normalized).

## Notes

- Related to #7954 (open — adds a usage reset countdown on the accounts screen). Different goal (that adds a countdown row; this adds providers + a visibility filter), but both touch `AccountUsage.tsx` / `account-usage-state.ts`, so expect a small rebase if one lands first. No functional overlap.
- No existing mobile issue to `Closes`; the desktop provider-usage work that populated the host `RateLimitState` is already merged, so this is purely the mobile client catching up.
- Known trade-off: the optimistic toggle swallows a storage-write failure (best-effort, matching the app's existing preference-save convention) rather than rolling back the UI.
