### PR TITLE
fix(sidebar): let project and group headers drag by their icon

### DIFF
--- a/src/renderer/src/components/sidebar/host-header-drag-dom.ts
+++ b/src/renderer/src/components/sidebar/host-header-drag-dom.ts
@@ -13,7 +13,9 @@ export function isHostHeaderActionTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement) || target === currentTarget) {
+  // Why: an <svg> icon inside a host action is an SVGElement, so match Element
+  // to still treat it as an action target and not arm a host drag.
+  if (!(target instanceof Element) || target === currentTarget) {
     return false
   }
   return currentTarget.contains(target) && target.closest(HOST_HEADER_ACTION_SELECTOR) !== null

--- a/src/renderer/src/components/sidebar/project-group-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-contract.ts
@@ -57,7 +57,10 @@ export function isProjectGroupHeaderDragHandleTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement)) {
+  // Why: the group icon renders as an <svg>, so pressing it makes the event
+  // target an SVGElement (not an HTMLElement). Match Element so dragging by the
+  // icon still arms the drag; closest/contains work on any Element.
+  if (!(target instanceof Element)) {
     return false
   }
   const dragHandle = target.closest(PROJECT_GROUP_HEADER_DRAG_HANDLE_SELECTOR)
@@ -68,7 +71,9 @@ export function isProjectGroupHeaderActionTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement) || target === currentTarget) {
+  // Why: an <svg> icon inside an action button is an SVGElement, so match
+  // Element to still treat it as an action target and not arm a drag.
+  if (!(target instanceof Element) || target === currentTarget) {
     return false
   }
   return (

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -54,7 +54,10 @@ export function isProjectHeaderDragHandleTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement)) {
+  // Why: the project icon renders as an <svg>, so pressing it makes the event
+  // target an SVGElement (not an HTMLElement). Match Element so dragging by the
+  // icon still arms the drag; closest/contains work on any Element.
+  if (!(target instanceof Element)) {
     return false
   }
   const dragHandle = target.closest(REPO_HEADER_DRAG_HANDLE_SELECTOR)
@@ -65,7 +68,9 @@ export function isRepoHeaderActionTarget(
   target: EventTarget | null,
   currentTarget: HTMLElement
 ): boolean {
-  if (!(target instanceof HTMLElement) || target === currentTarget) {
+  // Why: an <svg> icon inside an action button is an SVGElement, so match
+  // Element to still treat it as an action target and not arm a drag.
+  if (!(target instanceof Element) || target === currentTarget) {
     return false
   }
   return currentTarget.contains(target) && target.closest(REPO_HEADER_ACTION_SELECTOR) !== null

--- a/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
@@ -74,4 +74,67 @@ describe('createProjectHeaderDragSession', () => {
 
     expect(session?.repoId).toBe('repo-a')
   })
+
+  it('arms a drag session when pressing the project icon svg (SVGElement target)', () => {
+    const header = document.createElement('div')
+    header.setAttribute('data-repo-header-drag-handle', '')
+    // The project icon renders as an <svg>; pressing it makes the event target
+    // an SVGElement, which must still arm the drag.
+    const iconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    header.append(iconSvg)
+    const scrollContainer = document.createElement('div')
+    document.body.append(scrollContainer, header)
+
+    const repoById = new Map<string, Repo>([['repo-a', createRepo('repo-a')]])
+    const sidebarRepoHeaderIdsByBucket = new Map([['ungrouped', ['repo-a', 'repo-b']]])
+
+    const session = createProjectHeaderDragSession({
+      event: {
+        button: 0,
+        pointerId: 1,
+        clientX: 10,
+        clientY: 20,
+        target: iconSvg,
+        currentTarget: header
+      } as unknown as React.PointerEvent<HTMLElement>,
+      repoId: 'repo-a',
+      repoById,
+      sidebarRepoHeaderIdsByBucket,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session?.repoId).toBe('repo-a')
+  })
+
+  it('does not arm a drag session when pressing an svg icon inside an action button', () => {
+    const header = document.createElement('div')
+    header.setAttribute('data-repo-header-drag-handle', '')
+    const actionButton = document.createElement('button')
+    actionButton.setAttribute('data-repo-header-action', '')
+    const actionIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    actionButton.append(actionIcon)
+    header.append(actionButton)
+    const scrollContainer = document.createElement('div')
+    document.body.append(scrollContainer, header)
+
+    const repoById = new Map<string, Repo>([['repo-a', createRepo('repo-a')]])
+    const sidebarRepoHeaderIdsByBucket = new Map([['ungrouped', ['repo-a', 'repo-b']]])
+
+    const session = createProjectHeaderDragSession({
+      event: {
+        button: 0,
+        pointerId: 1,
+        clientX: 10,
+        clientY: 20,
+        target: actionIcon,
+        currentTarget: header
+      } as unknown as React.PointerEvent<HTMLElement>,
+      repoId: 'repo-a',
+      repoById,
+      sidebarRepoHeaderIdsByBucket,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary

Pressing a sidebar project or project-group header **icon** now correctly starts a drag to reorder, instead of doing nothing despite the grab cursor.

## ELI5

The little icon next to a project shows a "grab" hand, but grabbing it did nothing. Now you can actually drag a project around by its icon.

## Root cause & fix

The header drag-arming and action-target guards narrowed the pointerdown target with `target instanceof HTMLElement`. A header icon renders as an `<svg>`, so its event target is an `SVGElement` — not an `HTMLElement` — so the guard returned false and the drag never armed. The fix broadens the checks to `target instanceof Element` (`closest()`/`contains()` are `Element` methods, and `SVGElement extends Element`), applied symmetrically across the project, project-group, and host header guards.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Clean rebase onto `origin/main`.

- Scoped test file: `src/renderer/src/components/sidebar/project-header-drag-start.test.ts`
- On branch (fix present): **Tests 4 passed (4)**
- Fix reverted to `origin/main` (test kept): **1 failed, 3 passed** — proving the test guards the fix:

```
FAIL: arms a drag session when pressing the project icon svg (SVGElement target)
AssertionError: expected undefined to be 'repo-a'  (session?.repoId undefined)
```

- Lint: `npx oxlint` on the 3 changed source files — exit 0, clean.
- The "does not arm inside an action button" test still passes, confirming `<svg>`-inside-action exclusion still works.

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression rationale: `Element` is a superset of `HTMLElement`, so existing `HTMLElement` target paths are unchanged. Only the previously-broken `SVGElement` branch changes behavior, and action-target exclusion is preserved (proven by the still-passing action-button test).

_Credit to @stasmarkin for the original fix. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
