### PR TITLE
Fix CJK IME newline: defer Shift/Ctrl+Enter until composition commits

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -8,6 +8,7 @@ import type { PtyTransport } from './pty-transport'
 import { safeFind } from '../terminal-search-safe-find'
 import { resolveTerminalShortcutAction } from './terminal-shortcut-policy'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
+import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newline'
 import {
   keybindingMatchesAction,
   type KeybindingOverrides,
@@ -399,24 +400,40 @@ export function useTerminalKeyboardShortcuts({
       }
 
       if (action.type === 'sendInput') {
+        // preventDefault here does not cancel a pending IME commit (the
+        // compositionend still fires and xterm forwards the glyph), so it is safe
+        // to consume the chord even mid-composition — it just stops a stray
+        // browser newline from also reaching the helper textarea.
         e.preventDefault()
         e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return
         }
-        const sent = paneTransportsRef.current.get(pane.id)?.sendInput(action.data) === true
-        if (sent) {
-          recordTerminalUserInputForLeaf(tabId, pane.leafId)
-          if (action.data === '\x1b[13;2u') {
-            // Why: this direct shortcut write does not pass through PTY onData,
-            // so no-OSC shells need an explicit post-write confirmation ladder.
-            const binding = panePtyBindingsRef.current.get(pane.id) as
-              | (IDisposable & { requestDroidReconfirmation?: () => void })
-              | undefined
-            binding?.requestDroidReconfirmation?.()
+        const sendResolvedInput = (): void => {
+          const sent = paneTransportsRef.current.get(pane.id)?.sendInput(action.data) === true
+          if (sent) {
+            recordTerminalUserInputForLeaf(tabId, pane.leafId)
+            if (action.data === '\x1b[13;2u') {
+              // Why: this direct shortcut write does not pass through PTY onData,
+              // so no-OSC shells need an explicit post-write confirmation ladder.
+              const binding = panePtyBindingsRef.current.get(pane.id) as
+                | (IDisposable & { requestDroidReconfirmation?: () => void })
+                | undefined
+              binding?.requestDroidReconfirmation?.()
+            }
           }
         }
+        // Why: Shift+Enter / Ctrl+Enter pressed while an IME composition is open
+        // is the committing keystroke — sending the newline now races ahead of
+        // the pending commit and pushes the composed CJK glyph below it. Forward
+        // the newline once the composition ends so the glyph lands first (the
+        // committed char + newline, matching a non-composing Shift+Enter).
+        if (e.isComposing && e.key === 'Enter') {
+          sendTerminalInputAfterComposition(pane.terminal.element, sendResolvedInput)
+          return
+        }
+        sendResolvedInput()
         return
       }
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newline'
+
+describe('sendTerminalInputAfterComposition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the newline one macrotask after compositionend so the glyph flushes first', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(new Event('compositionend'))
+    // Deferred a macrotask so xterm's own post-compositionend flush runs first.
+    expect(send).not.toHaveBeenCalled()
+
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to sending when no compositionend arrives', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    vi.runAllTimers()
+
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends only once and drops the listener after firing', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    // A later composition on the same terminal must not re-fire the stale newline.
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not double-send when compositionend arrives after the fallback fired', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('still delivers the input on the next macrotask without a terminal element', () => {
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(null, send)
+    expect(send).not.toHaveBeenCalled()
+
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -1,0 +1,55 @@
+// Why: a newline chord (Shift+Enter / Ctrl+Enter) pressed while an IME
+// composition is still open must reach the PTY *after* the composed glyph
+// commits. The window-level terminal shortcut handler runs on the keydown, which
+// fires before compositionend, so sending the newline there races ahead of the
+// pending commit — the composed CJK character is then forwarded after the
+// newline and appears pushed down a line. Instead we wait for the composition to
+// commit and forward the newline once the glyph is on its way.
+
+// Why: compositionend fires within the same event-loop turn as the committing
+// key, so a real commit always resolves well under this bound. The fallback only
+// guards against an IME that never emits compositionend, so the newline is not
+// silently swallowed.
+export const TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS = 200
+
+/**
+ * Forwards a terminal byte sequence once, after the active IME composition ends.
+ *
+ * xterm flushes the committed glyph asynchronously (on the next `input` event or
+ * its own `setTimeout(0)` after `compositionend`), so a bubble-phase
+ * `compositionend` listener plus one more macrotask hop orders `send()` strictly
+ * after xterm's flush. With no terminal element (or no composition to wait on),
+ * `send()` runs on the next macrotask so callers get uniform async behavior.
+ */
+export function sendTerminalInputAfterComposition(
+  terminalElement: HTMLElement | null | undefined,
+  send: () => void,
+  options?: { fallbackMs?: number }
+): void {
+  if (!terminalElement) {
+    window.setTimeout(send, 0)
+    return
+  }
+
+  const fallbackMs = options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS
+  let done = false
+
+  const finish = (): void => {
+    if (done) {
+      return
+    }
+    done = true
+    terminalElement.removeEventListener('compositionend', onCompositionEnd)
+    window.clearTimeout(fallbackTimer)
+    // Defer one macrotask so xterm's own post-compositionend glyph flush runs
+    // before our newline reaches the PTY.
+    window.setTimeout(send, 0)
+  }
+
+  const onCompositionEnd = (): void => finish()
+
+  // Bubble phase (not capture) so this runs after xterm's textarea-level
+  // compositionend handler, keeping our deferred send ordered after its flush.
+  terminalElement.addEventListener('compositionend', onCompositionEnd)
+  const fallbackTimer = window.setTimeout(finish, fallbackMs)
+}


### PR DESCRIPTION
## Summary

In the terminal pane, pressing **Shift+Enter** (or **Ctrl+Enter**) while a CJK IME composition is still open — a Korean syllable mid-composition, or highlighted Japanese conversion text — pushed the in-progress character down a line instead of inserting a clean newline after it. The window-level terminal shortcut handler resolves the newline on `keydown`, which fires *before* `compositionend`, so the CSI-u newline was written to the PTY ahead of the pending commit and the composed glyph landed after the newline. This now yields "committed character + newline", matching a non-composing Shift+Enter (and matching cmux's behavior).

## Screenshots

No visual change to the app UI. The fix changes byte ordering sent to the PTY for a CJK IME + Shift/Ctrl+Enter keystroke. Before: composing a Hangul syllable and pressing Shift+Enter left the syllable pushed below a blank line. After: the syllable commits in place and a single newline follows.

## Testing

- [ ] `pnpm lint` (ran `oxlint` on changed files — no new findings; one pre-existing `exhaustive-deps` warning on `panePtyBindingsRef.current` is unrelated and present on `main`)
- [x] `pnpm typecheck` (`tsc --noEmit -p config/tsconfig.tc.web.json` — 0 errors)
- [x] `pnpm test` (ran the affected suites: `terminal-ime-deferred-newline`, `terminal-shortcut-policy`, `keyboard-handlers`, `terminal-windows-shift-enter`, `terminal-ime-composition-tracker`, `xterm-bypass-policy` — all pass)
- [ ] `pnpm build`
- [x] Added tests: `terminal-ime-deferred-newline.test.ts` covers ordering (send deferred one macrotask past `compositionend`), the no-`compositionend` fallback, single-fire + listener cleanup, and the no-element path.

## AI Review Report

Reviewed with an AI coding agent. Main risks checked: (1) event ordering — verified the deferred newline is delivered strictly after xterm's asynchronous composed-glyph flush under both flush paths (the follow-up `input` event and xterm's own `setTimeout(0)` fallback), by attaching the `compositionend` listener in the bubble phase and hopping one macrotask; (2) IME commit safety — `preventDefault` is retained because it does not cancel the IME commit (the prior buggy behavior proved the glyph still committed under `preventDefault`), and it blocks a stray browser newline in the helper textarea; (3) listener leaks / double-send — the helper is one-shot with a fallback timer and a `done` guard; (4) scope — the deferral only triggers for `event.isComposing && event.key === 'Enter'`, so non-composing Shift/Ctrl+Enter and all other shortcuts are unchanged. Cross-platform: the change is platform-agnostic and does not alter which byte is sent (CSI-u vs Esc+CR vs the Windows encodings) — it only delays *when* the resolved byte is sent while an IME composition is active, so macOS/Linux/Windows keyboard routing and the Windows Shift+Enter encoding path are untouched.

## Security Audit

No new IPC, command execution, secrets, path handling, or dependency surface. The change only reorders an already-authorized terminal input byte (the resolved Shift/Ctrl+Enter sequence) relative to the IME composition commit, both of which already flow to the PTY today. Input handling: the deferred send re-reads the active pane transport at send time and no-ops if the transport is gone. No follow-up needed.

## Notes

- Applies to any CJK/IME user on any platform; the underlying macOS system-IME ↔ Chromium interaction is what surfaced it, but the fix is platform-neutral.
- Ctrl+Enter (the sibling CSI-u chord) is fixed by the same code path.
- The new `terminal-ime-deferred-newline.ts` helper isolates the DOM/timing logic so it is unit-testable without driving a live IME.
