### PR TITLE
fix(settings): keep Shortcuts rows visible on pane-title-only search

### DIFF
--- a/src/renderer/src/components/settings/ShortcutCommandBlock.tsx
+++ b/src/renderer/src/components/settings/ShortcutCommandBlock.tsx
@@ -106,6 +106,8 @@ export function ShortcutCommandBlock({
     />
   )
 
+  // Why: ShortcutsPane already filters rows against the global query;
+  // forceVisible skips the re-match here that would hide rows it kept.
   return (
     <SearchableSetting
       title={item.title}
@@ -115,6 +117,7 @@ export function ShortcutCommandBlock({
         { value0: groupTitle }
       )}
       keywords={[...item.searchKeywords]}
+      forceVisible
       className="group/shortcut flex max-w-none flex-col"
     >
       <div className="flex min-h-9 items-center gap-3 rounded-md px-2 py-1 transition-colors hover:bg-accent/40 focus-within:bg-accent/40">

--- a/src/renderer/src/components/settings/ShortcutFilterRail.test.ts
+++ b/src/renderer/src/components/settings/ShortcutFilterRail.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { KeybindingActionId } from '../../../../shared/keybindings'
 import {
   SHORTCUT_LOCAL_SEARCH_QUERY_MAX_BYTES,
+  buildShortcutGlobalSearchMatcher,
   isShortcutLocalSearchQueryTooLarge,
   matchesShortcutLocalSearch,
   normalizeShortcutLocalSearchQuery,
@@ -50,6 +51,40 @@ describe('ShortcutFilterRail search helpers', () => {
     expect(query.length).toBe(SHORTCUT_LOCAL_SEARCH_QUERY_MAX_BYTES)
     expect(isShortcutLocalSearchQueryTooLarge(query)).toBe(true)
     expect(normalizeShortcutLocalSearchQuery(query)).toBeNull()
+  })
+
+  it('narrows rows when the global settings query matches specific rows', () => {
+    const settingsRow = createShortcutRow()
+    const worktreeRow: ShortcutRowModel = {
+      ...createShortcutRow(),
+      item: {
+        ...createShortcutRow().item,
+        id: 'worktree.create' as KeybindingActionId,
+        title: 'Create worktree',
+        searchKeywords: ['worktree', 'create']
+      }
+    }
+
+    const matcher = buildShortcutGlobalSearchMatcher([settingsRow, worktreeRow], 'worktree')
+
+    expect(matcher(settingsRow)).toBe(false)
+    expect(matcher(worktreeRow)).toBe(true)
+  })
+
+  it('keeps every row visible on a pane-title-only global query', () => {
+    const rows = [createShortcutRow()]
+
+    // Mirrors sidebar search selecting the pane with a query that matches only
+    // pane-level metadata (e.g. a localized pane title) and no row metadata.
+    const matcher = buildShortcutGlobalSearchMatcher(rows, '단축키')
+
+    expect(matcher(rows[0])).toBe(true)
+  })
+
+  it('keeps every row visible when the global query is empty', () => {
+    const rows = [createShortcutRow()]
+
+    expect(buildShortcutGlobalSearchMatcher(rows, '')(rows[0])).toBe(true)
   })
 
   it('rejects oversized pasted shortcut searches before reading row metadata', () => {

--- a/src/renderer/src/components/settings/ShortcutFilterRail.tsx
+++ b/src/renderer/src/components/settings/ShortcutFilterRail.tsx
@@ -6,7 +6,7 @@ import { cn } from '../../lib/utils'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import type { ShortcutTerminalStatus } from './shortcut-terminal-status'
-import type { SettingsSearchEntry } from './settings-search'
+import { matchesSettingsSearch, type SettingsSearchEntry } from './settings-search'
 import { translate } from '@/i18n/i18n'
 
 export type ShortcutFilter = 'all' | 'modified' | 'unassigned' | 'conflicts'
@@ -58,6 +58,17 @@ export function getShortcutSearchEntry(row: ShortcutRowModel): SettingsSearchEnt
     ),
     keywords: [...row.item.searchKeywords]
   }
+}
+
+// Why: a sidebar query can select this pane by title alone while matching zero
+// rows; that would blank the list, so zero-row queries keep every row visible.
+export function buildShortcutGlobalSearchMatcher(
+  rows: readonly ShortcutRowModel[],
+  searchQuery: string
+): (row: ShortcutRowModel) => boolean {
+  const rowMatches = (row: ShortcutRowModel): boolean =>
+    matchesSettingsSearch(searchQuery, getShortcutSearchEntry(row))
+  return rows.some(rowMatches) ? rowMatches : () => true
 }
 
 export function matchesShortcutFilter(row: ShortcutRowModel, filter: ShortcutFilter): boolean {

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -25,7 +25,7 @@ import {
   sameBindings
 } from './keybinding-override-edits'
 import {
-  getShortcutSearchEntry,
+  buildShortcutGlobalSearchMatcher,
   matchesShortcutFilter,
   matchesShortcutLocalSearch,
   normalizeShortcutLocalSearchQuery,
@@ -138,9 +138,10 @@ export function ShortcutsPane(): React.JSX.Element {
   )
   const shortcutSearchQuery = normalizeShortcutLocalSearchQuery(shortcutQuery)
   const shortcutRows = shortcutGroups.flatMap((group) => group.rows)
+  const matchesShortcutGlobalSearch = buildShortcutGlobalSearchMatcher(shortcutRows, searchQuery)
   const matchesShortcutSearch = (row: ShortcutRowsByGroup['rows'][number]): boolean =>
     shortcutSearchQuery !== null &&
-    matchesSettingsSearch(searchQuery, getShortcutSearchEntry(row)) &&
+    matchesShortcutGlobalSearch(row) &&
     matchesShortcutLocalSearch(row, shortcutSearchQuery, platform)
   const baseVisibleRows = shortcutRows.filter((row) => matchesShortcutSearch(row))
   const filterCounts: Record<ShortcutFilter, number> = {

--- a/tests/e2e/settings-search-shortcuts-pane.spec.ts
+++ b/tests/e2e/settings-search-shortcuts-pane.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+test.describe('Settings sidebar search on the Shortcuts pane', () => {
+  test('pane-title-only query keeps rows visible and local search usable', async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+
+    await orcaPage.evaluate(async () => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      // Why: the spec asserts on English strings; the host machine may run a
+      // non-English system locale, which 'system' would follow.
+      await store.getState().updateSettings({ uiLanguage: 'en' })
+      store.getState().openSettingsPage()
+    })
+
+    const searchInput = orcaPage.getByPlaceholder('Search settings')
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill('shortcuts')
+
+    // The query matches the pane title, so the Shortcuts pane auto-activates.
+    await expect(orcaPage.getByRole('heading', { name: 'Shortcuts', exact: true })).toBeVisible()
+
+    // Regression: a pane-title-only query used to blank the whole list (0/112).
+    await expect(orcaPage.getByText('Go to File', { exact: true })).toBeVisible()
+    await expect(orcaPage.getByText('No shortcuts match those filters.')).not.toBeVisible()
+
+    // Regression: the pane's own search was dead while the global query was
+    // active, because it intersected with an already-empty base list.
+    const localSearch = orcaPage.getByPlaceholder('Search command or keys')
+    await localSearch.fill('go to')
+    await expect(orcaPage.getByText('Go to File', { exact: true })).toBeVisible()
+    await expect(orcaPage.getByText('Force Reload', { exact: true })).not.toBeVisible()
+
+    // A row-matching global query still narrows the list as before.
+    await localSearch.clear()
+    await searchInput.fill('worktree')
+    await expect(orcaPage.getByText('Create worktree', { exact: true })).toBeVisible()
+    await expect(orcaPage.getByText('Go to File', { exact: true })).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #8577.

Typing a Settings sidebar query that matches the Shortcuts pane only by its pane title (e.g. `shortcuts`) auto-opens the Shortcuts pane with every row filtered out: the list renders `0/112` / "No shortcuts match those filters.", all status counts show 0, and the pane's own "Find shortcuts" search can never return a result because it intersects with an already-empty base list. The only recovery was clicking the sidebar item, which clears the query.

The sidebar ranks panes with a pane-level entry included (`getSettingsSectionSearchEntries`), so a query can legitimately select the pane while matching zero rows — but the pane reused that same query as a row filter. `settings-search.ts` already documents the hazard: "pane-title-only hits can rank but render blank."

The fix keeps both behaviors intact:

- A query that matches at least one row still narrows the list as before (`worktree` → 12 rows).
- A query that matches no row at all is treated as a pane-level hit: every row stays visible and the local search works normally.

Two layers needed the fix:

1. `ShortcutsPane` row filtering — new `buildShortcutGlobalSearchMatcher` in `ShortcutFilterRail.tsx` falls back to keep-all when the query matches zero rows.
2. `ShortcutCommandBlock` — each row is wrapped in `SearchableSetting`, which independently re-applies the global query and hid rows the pane had decided to show (found by driving the built app: counts and group headers rendered, but every row was gone). It now passes `forceVisible`; row visibility is owned by the pane's filter.

In the spirit of dogfooding: this fix was developed with Claude Code (Fable 5) running inside Orca itself — including the investigation, the e2e run that exposed the second filter layer, and the review below.

## Screenshots

### Before (v1.4.137 — same screenshots as the issue)

`shortcuts` typed in the sidebar — the pane auto-opens blank at 0/112:

<img alt="before: pane blank at 0/112" src="https://github.com/user-attachments/assets/72d1d7e4-5586-4056-a8b9-ebfc263b95a8" />

The pane's own search is dead under the active sidebar query (`go to` normally finds "Go to File"):

<img alt="before: local search returns nothing" src="https://github.com/user-attachments/assets/4eeb9f4a-6e85-45c8-b5cb-ed073b1f0296" />

---

### After (this branch)

Same `shortcuts` query — every row stays visible:

<img alt="after: rows visible under pane-title-only query" src="https://github.com/user-attachments/assets/c89a55be-2e7e-4911-b389-5bb9a486e69e" />

Local search works while the sidebar query stays active — `go to` narrows to "Go to File" (1/113):

<img alt="after: local search narrows to Go to File" src="https://github.com/user-attachments/assets/92fdd63e-6f46-453e-ac53-c700bd4b6c8b" />

A row-matching sidebar query (`worktree`) still narrows the list (12/113):

<img alt="after: row-matching query still narrows" src="https://github.com/user-attachments/assets/6d5b2eac-5433-4ee9-b528-a439ad755490" />

Manual check on a dev build (dark theme), same scenario at 114/114:

<img alt="after: manual dev-build check, dark theme" src="https://github.com/user-attachments/assets/2e972b4d-fc95-429a-96f1-eccf87ca051c" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added tests:

- Unit (`ShortcutFilterRail.test.ts`): the matcher narrows on row-matching queries, keeps all rows on a pane-title-only query (including a non-English example), and keeps all rows on an empty query.
- E2E (`tests/e2e/settings-search-shortcuts-pane.spec.ts`): drives the built app through the full flow — pane-title-only query keeps rows visible, local search narrows under an active sidebar query, and a row-matching query still narrows. The `SearchableSetting` double-filter regression is only observable in the composed UI (unit suites passed while the real app rendered blank rows), so the e2e spec is the test that would actually catch it.

Full suite: 28,681 passed. One unrelated flaky file (`pty-connection.test.ts`, terminal idle-exit timing) failed intermittently under full parallel load only; it passes 3/3 consecutive runs in isolation and failed/passed independently of this diff.

## AI Review Report

Reviewed with Claude Code (Fable 5) running inside Orca. Checks and outcomes:

- Cross-platform (macOS/Linux/Windows): pure renderer filter logic; no platform APIs, shortcuts, labels, paths, or shell behavior touched. The e2e spec pins `uiLanguage: 'en'` so it is host-locale-independent (it initially failed on a Korean-locale host following the system language).
- SSH/remote/local: no assumptions about processes, files, or network; settings search runs entirely in the renderer.
- Agent/integration/git-provider compatibility: not applicable — no provider-facing code paths touched.
- Performance: one extra `rows.some()` scan (~112 rows) per render in the Shortcuts pane, same order as the existing per-row filter; no hot paths affected.
- UI quality: verified in the built app via the e2e run and a manual dev-build pass; list rendering, counts, status filters, and local search behave correctly in the three scenarios above. No visual/style changes.
- Flagged during review and fixed: the initial pane-level fix alone left rows hidden by the `SearchableSetting` wrapper's independent re-filter (caught by running the real app, not by unit tests) — resolved with `forceVisible`.

## Security Audit

- Input handling: search queries continue to flow through the existing byte-limit guard (`isSettingsSearchQueryTooLarge`) before any row metadata is read; oversized pasted queries short-circuit as before.
- No command execution, path handling, auth, secrets, dependency, or IPC changes. `updateSettings({ uiLanguage })` in the e2e spec uses the existing sanitized settings IPC path.
- No new attack surface identified; no follow-up needed.

## Notes

- Row search metadata (titles/keywords) is English-only, so on localized UIs any non-English query (e.g. the Korean pane title `단축키`, where this was originally noticed) is a pane-title-only hit — the fix makes that case show the full list rather than narrowing. Localizing row metadata would be a separate follow-up, if it's wanted at all.
- The sidebar-click path already clears the query on explicit selection (`scrollToSection`); this PR intentionally does not clear the query on auto-activation, since the user is still typing — it fixes the content side instead.
- Design note: this PR intentionally keeps the existing behavior where a row-matching sidebar query (e.g. `worktree`) also narrows the Shortcuts list, for consistency with how the other panes filter their content. If you'd prefer the sidebar search to only select the pane — leaving all row narrowing to the pane's own "Find shortcuts" filter — I'd be happy to adjust this PR (or follow up) in that direction.

---

X handle: [@__making](https://x.com/__making)

