### PR TITLE
fix(build): rebuild @parcel/watcher from source for Electron N-API compatibility

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -9,7 +9,8 @@ const {
 const {
   createPackagedRuntimeNodeModuleResources,
   prunePackagedRuntimeNodeModules,
-  verifyPackagedMainRuntimeDeps
+  verifyPackagedMainRuntimeDeps,
+  verifyPackagedParcelWatcherBinding
 } = require('./packaged-runtime-node-modules.cjs')
 
 const isMacRelease = process.env.ORCA_MAC_RELEASE === '1'
@@ -134,6 +135,7 @@ module.exports = {
     }
     prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName, context.arch)
     verifyPackagedMainRuntimeDeps(resourcesDir)
+    verifyPackagedParcelWatcherBinding(resourcesDir, context.electronPlatformName)
     // Why: boot the packaged daemon-entry under plain Node, but only for the
     // slice matching the packaging host's arch — daemon-entry.js is JS, yet it
     // require()s the native (N-API) node-pty for the TARGET arch, which the host

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -135,7 +135,7 @@ module.exports = {
     }
     prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName, context.arch)
     verifyPackagedMainRuntimeDeps(resourcesDir)
-    verifyPackagedParcelWatcherBinding(resourcesDir, context.electronPlatformName)
+    verifyPackagedParcelWatcherBinding(resourcesDir, context.electronPlatformName, context.arch)
     // Why: boot the packaged daemon-entry under plain Node, but only for the
     // slice matching the packaging host's arch — daemon-entry.js is JS, yet it
     // require()s the native (N-API) node-pty for the TARGET arch, which the host

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -239,6 +239,44 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
   }
 }
 
+// Why: only enforced on Linux. Empirically, legitimate N-API prebuilds on
+// darwin commonly omit the `napi_register_module_v1` export entirely (e.g.
+// @napi-rs/canvas's darwin-x64 binary) without any known runtime failure —
+// Electron's module loader on macOS/Windows tolerates the older
+// constructor-based N-API registration path. Linux (specifically inside an
+// AppImage) does not: a missing `napi_register_module_v1` export there is a
+// confirmed load failure (stablyai/orca#8540), and known-good Linux N-API
+// prebuilds (e.g. sherpa-onnx, lightningcss) do consistently export it. A
+// global cross-platform gate would false-fail correct darwin/win32 builds.
+function verifyPackagedParcelWatcherBinding(resourcesDir, electronPlatformName) {
+  if (electronPlatformName !== 'linux') {
+    return
+  }
+
+  const parcelDir = join(resourcesDir, 'node_modules', '@parcel')
+  if (!existsSync(parcelDir)) {
+    return
+  }
+
+  for (const entry of readdirSync(parcelDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('watcher-linux')) {
+      continue
+    }
+    const bindingPath = join(parcelDir, entry.name, 'watcher.node')
+    if (!existsSync(bindingPath)) {
+      continue
+    }
+    if (!readFileSync(bindingPath).includes('napi_register_module_v1')) {
+      throw new Error(
+        `Packaged @parcel/${entry.name}/watcher.node is missing the napi_register_module_v1 ` +
+          'export and will fail to load in the Electron AppImage runtime. Rebuild @parcel/watcher ' +
+          'from source against this Electron version before packaging (see ' +
+          'config/scripts/rebuild-native-deps.mjs).'
+      )
+    }
+  }
+}
+
 function normalizeNodePtyWindowsArch(electronArch) {
   if (electronArch === 'x64' || electronArch === 1) {
     return 'x64'
@@ -419,5 +457,6 @@ module.exports = {
   prunePackagedSherpaOnnx,
   prunePackagedRuntimeTypeDeclarations,
   prunePackagedZodSources,
-  verifyPackagedMainRuntimeDeps
+  verifyPackagedMainRuntimeDeps,
+  verifyPackagedParcelWatcherBinding
 }

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -248,32 +248,70 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
 // confirmed load failure (stablyai/orca#8540), and known-good Linux N-API
 // prebuilds (e.g. sherpa-onnx, lightningcss) do consistently export it. A
 // global cross-platform gate would false-fail correct darwin/win32 builds.
-function verifyPackagedParcelWatcherBinding(resourcesDir, electronPlatformName) {
+//
+// Why only the build-target subpackage: config/scripts/rebuild-native-deps.mjs
+// rebuilds and copies over exactly one subpackage per build — the one matching
+// this build's arch and the build host's libc (watcher-linux-<arch>-<libc>).
+// The packaged app still ships the sibling linux prebuilds we do NOT rebuild
+// (the other libc, and cross-arch slices), and those legitimately keep the
+// upstream constructor-based binary that lacks this export. Gating on every
+// watcher-linux* dir would therefore false-fail every real Linux build, so we
+// verify only the subpackage the rebuild guarantees — the one an equal-libc
+// host actually loads at runtime.
+function verifyPackagedParcelWatcherBinding(resourcesDir, electronPlatformName, electronArch) {
   if (electronPlatformName !== 'linux') {
     return
   }
 
-  const parcelDir = join(resourcesDir, 'node_modules', '@parcel')
-  if (!existsSync(parcelDir)) {
+  const subpackageName = rebuiltParcelWatcherLinuxSubpackage(electronArch)
+  if (!subpackageName) {
     return
   }
 
-  for (const entry of readdirSync(parcelDir, { withFileTypes: true })) {
-    if (!entry.isDirectory() || !entry.name.startsWith('watcher-linux')) {
-      continue
-    }
-    const bindingPath = join(parcelDir, entry.name, 'watcher.node')
-    if (!existsSync(bindingPath)) {
-      continue
-    }
-    if (!readFileSync(bindingPath).includes('napi_register_module_v1')) {
-      throw new Error(
-        `Packaged @parcel/${entry.name}/watcher.node is missing the napi_register_module_v1 ` +
-          'export and will fail to load in the Electron AppImage runtime. Rebuild @parcel/watcher ' +
-          'from source against this Electron version before packaging (see ' +
-          'config/scripts/rebuild-native-deps.mjs).'
-      )
-    }
+  const bindingPath = join(resourcesDir, 'node_modules', '@parcel', subpackageName, 'watcher.node')
+  if (!existsSync(bindingPath)) {
+    return
+  }
+
+  if (!readFileSync(bindingPath).includes('napi_register_module_v1')) {
+    throw new Error(
+      `Packaged @parcel/${subpackageName}/watcher.node is missing the napi_register_module_v1 ` +
+        'export and will fail to load in the Electron AppImage runtime. Rebuild @parcel/watcher ' +
+        'from source against this Electron version before packaging (see ' +
+        'config/scripts/rebuild-native-deps.mjs).'
+    )
+  }
+}
+
+// Why: name the exact subpackage rebuild-native-deps.mjs rebuilds — the build
+// arch (electron-builder passes the Arch enum: x64=1, arm64=3) plus the build
+// host's libc, detected the same way the rebuild does so the two never disagree.
+function rebuiltParcelWatcherLinuxSubpackage(electronArch) {
+  const arch =
+    electronArch === 'arm64' || electronArch === 3
+      ? 'arm64'
+      : electronArch === 'x64' || electronArch === 1
+        ? 'x64'
+        : null
+  if (!arch) {
+    return null
+  }
+  return `watcher-linux-${arch}-${detectBuildHostLinuxLibc()}`
+}
+
+function detectBuildHostLinuxLibc() {
+  try {
+    // Why: resolve detect-libc from @parcel/watcher's own closure (mirrors
+    // rebuild-native-deps.mjs) rather than assuming a hoisted copy at the root.
+    const requireFromParcelWatcher = createRequire(
+      join(projectDir, 'node_modules', '@parcel', 'watcher', 'package.json')
+    )
+    const { familySync, MUSL } = requireFromParcelWatcher('detect-libc')
+    return familySync() === MUSL ? 'musl' : 'glibc'
+  } catch {
+    // Why: detect-libc unavailable (or a non-Linux build host cross-building
+    // Linux) — Orca's Linux target is glibc, so default to it.
+    return 'glibc'
   }
 }
 

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -294,6 +294,9 @@ function rebuiltParcelWatcherLinuxSubpackage(electronArch) {
         ? 'x64'
         : null
   if (!arch) {
+    // Why: x64 and arm64 are the only Linux slices Orca ships, so any other
+    // arch has no rebuilt binary to gate. If a linux armv7l/ia32 target is ever
+    // added, extend this map so the gate does not silently go dark for it.
     return null
   }
   return `watcher-linux-${arch}-${detectBuildHostLinuxLibc()}`

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -15,7 +15,8 @@ const {
   prunePackagedSherpaOnnx,
   prunePackagedRuntimeTypeDeclarations,
   prunePackagedZodSources,
-  verifyPackagedMainRuntimeDeps
+  verifyPackagedMainRuntimeDeps,
+  verifyPackagedParcelWatcherBinding
 } = require('../packaged-runtime-node-modules.cjs')
 
 describe('electron-builder config', () => {
@@ -289,6 +290,65 @@ describe('electron-builder config', () => {
         'watcher',
         'watcher-linux-x64-glibc'
       ])
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('throws when a packaged Linux @parcel/watcher binding lacks napi_register_module_v1 (stablyai/orca#8540)', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-'))
+    try {
+      const bindingDir = join(resourcesDir, 'node_modules', '@parcel', 'watcher-linux-x64-glibc')
+      await mkdir(bindingDir, { recursive: true })
+      await writeFile(join(bindingDir, 'watcher.node'), 'not a real napi module')
+
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux')).toThrow(
+        /napi_register_module_v1/
+      )
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('passes when a packaged Linux @parcel/watcher binding exports napi_register_module_v1', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-ok-'))
+    try {
+      const bindingDir = join(resourcesDir, 'node_modules', '@parcel', 'watcher-linux-x64-glibc')
+      await mkdir(bindingDir, { recursive: true })
+      await writeFile(
+        join(bindingDir, 'watcher.node'),
+        Buffer.concat([
+          Buffer.from('\0\0\0'),
+          Buffer.from('napi_register_module_v1'),
+          Buffer.from('\0\0\0')
+        ])
+      )
+
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux')).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('skips the napi_register_module_v1 gate on non-Linux platforms', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-darwin-'))
+    try {
+      const bindingDir = join(resourcesDir, 'node_modules', '@parcel', 'watcher-darwin-arm64')
+      await mkdir(bindingDir, { recursive: true })
+      // Why: real darwin N-API prebuilds (e.g. @napi-rs/canvas) can legitimately
+      // lack this export; only Linux is a confirmed failure mode.
+      await writeFile(join(bindingDir, 'watcher.node'), 'not a real napi module')
+
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'darwin')).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('is a no-op when no @parcel directory was packaged', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-absent-'))
+    try {
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux')).not.toThrow()
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -295,14 +295,37 @@ describe('electron-builder config', () => {
     }
   })
 
-  it('throws when a packaged Linux @parcel/watcher binding lacks napi_register_module_v1 (stablyai/orca#8540)', async () => {
+  // Why: create both libc variants of the target arch so these gate tests are
+  // deterministic no matter the test host's own libc (glibc CI or a musl runner);
+  // the gate resolves the build host's libc, and only that variant drives the
+  // result — the other is ignored.
+  async function writeParcelWatcherBinding(resourcesDir, subpackageName, { exportsSymbol }) {
+    const bindingDir = join(resourcesDir, 'node_modules', '@parcel', subpackageName)
+    await mkdir(bindingDir, { recursive: true })
+    await writeFile(
+      join(bindingDir, 'watcher.node'),
+      exportsSymbol
+        ? Buffer.concat([
+            Buffer.from('\0\0\0'),
+            Buffer.from('napi_register_module_v1'),
+            Buffer.from('\0\0\0')
+          ])
+        : 'not a real napi module'
+    )
+  }
+
+  it('throws when the build-target Linux @parcel/watcher binding lacks napi_register_module_v1 (stablyai/orca#8540)', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-'))
     try {
-      const bindingDir = join(resourcesDir, 'node_modules', '@parcel', 'watcher-linux-x64-glibc')
-      await mkdir(bindingDir, { recursive: true })
-      await writeFile(join(bindingDir, 'watcher.node'), 'not a real napi module')
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-x64-glibc', {
+        exportsSymbol: false
+      })
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-x64-musl', {
+        exportsSymbol: false
+      })
 
-      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux')).toThrow(
+      // Arch enum 1 = x64.
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux', 1)).toThrow(
         /napi_register_module_v1/
       )
     } finally {
@@ -310,21 +333,67 @@ describe('electron-builder config', () => {
     }
   })
 
-  it('passes when a packaged Linux @parcel/watcher binding exports napi_register_module_v1', async () => {
+  it('passes when the build-target Linux @parcel/watcher binding exports napi_register_module_v1', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-ok-'))
     try {
-      const bindingDir = join(resourcesDir, 'node_modules', '@parcel', 'watcher-linux-x64-glibc')
-      await mkdir(bindingDir, { recursive: true })
-      await writeFile(
-        join(bindingDir, 'watcher.node'),
-        Buffer.concat([
-          Buffer.from('\0\0\0'),
-          Buffer.from('napi_register_module_v1'),
-          Buffer.from('\0\0\0')
-        ])
-      )
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-x64-glibc', {
+        exportsSymbol: true
+      })
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-x64-musl', {
+        exportsSymbol: true
+      })
 
-      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux')).not.toThrow()
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux', 1)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores sibling linux subpackages the rebuild never replaces (only the build-target arch+libc is gated)', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-siblings-'))
+    try {
+      // Why: an x64 build rebuilds only its own arch+libc binary. The other libc
+      // and the cross-arch arm64 slices still ship the upstream constructor-based
+      // prebuild that lacks the export; gating on them would false-fail every real
+      // Linux AppImage build. This is the regression the original #8540 fix carried.
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-x64-glibc', {
+        exportsSymbol: true
+      })
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-x64-musl', {
+        exportsSymbol: true
+      })
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-arm64-glibc', {
+        exportsSymbol: false
+      })
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-arm64-musl', {
+        exportsSymbol: false
+      })
+
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux', 1)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('gates the binding for the arch of this build slice, not another arch', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-arch-'))
+    try {
+      // Why: an arm64 slice must verify the arm64 binary even if a healthy x64
+      // binary is also present in the shared node_modules.
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-arm64-glibc', {
+        exportsSymbol: false
+      })
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-arm64-musl', {
+        exportsSymbol: false
+      })
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-linux-x64-glibc', {
+        exportsSymbol: true
+      })
+
+      // Arch enum 3 = arm64.
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux', 3)).toThrow(
+        /watcher-linux-arm64/
+      )
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }
@@ -333,22 +402,22 @@ describe('electron-builder config', () => {
   it('skips the napi_register_module_v1 gate on non-Linux platforms', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-darwin-'))
     try {
-      const bindingDir = join(resourcesDir, 'node_modules', '@parcel', 'watcher-darwin-arm64')
-      await mkdir(bindingDir, { recursive: true })
       // Why: real darwin N-API prebuilds (e.g. @napi-rs/canvas) can legitimately
       // lack this export; only Linux is a confirmed failure mode.
-      await writeFile(join(bindingDir, 'watcher.node'), 'not a real napi module')
+      await writeParcelWatcherBinding(resourcesDir, 'watcher-darwin-arm64', {
+        exportsSymbol: false
+      })
 
-      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'darwin')).not.toThrow()
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'darwin', 3)).not.toThrow()
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }
   })
 
-  it('is a no-op when no @parcel directory was packaged', async () => {
+  it('is a no-op when the build-target subpackage was not packaged', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-parcel-watcher-verify-absent-'))
     try {
-      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux')).not.toThrow()
+      expect(() => verifyPackagedParcelWatcherBinding(resourcesDir, 'linux', 1)).not.toThrow()
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }

--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -20,7 +20,16 @@
 
 import { rebuild } from '@electron/rebuild'
 import { execFileSync, spawnSync } from 'node:child_process'
-import { existsSync, globSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  copyFileSync,
+  existsSync,
+  globSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { createRequire } from 'node:module'
 import { platform as osPlatform } from 'node:os'
 import { resolve } from 'node:path'
 
@@ -49,7 +58,16 @@ if (ignoreModules.length > 0) {
 // modules inside pnpm's .pnpm/ store. Passing an explicit list of modules to
 // rebuild via `onlyModules` ensures they're recompiled against Electron's Node
 // ABI regardless of the package manager's store layout.
-const NATIVE_MODULES = ['node-pty', 'cpu-features']
+//
+// Why @parcel/watcher is included: the platform-specific optionalDependency
+// packages (e.g. @parcel/watcher-linux-x64-glibc) ship prebuilt .node binaries
+// from upstream that can lack the modern `napi_register_module_v1` export
+// (relying instead on constructor-based N-API registration). That prebuild
+// loads fine under plain Node but fails silently or crashes under Electron's
+// context-aware module loading in the packaged Linux AppImage (stablyai/orca#8540).
+// Rebuilding from @parcel/watcher's own source against Electron's headers
+// produces a binary with the correct entry point.
+const NATIVE_MODULES = ['node-pty', 'cpu-features', '@parcel/watcher']
 const onlyModules = NATIVE_MODULES.filter((m) => !ignoreModules.includes(m))
 const forceRebuild =
   process.env.ORCA_FORCE_NATIVE_REBUILD === '1' ||
@@ -124,6 +142,9 @@ try {
     // Node before postinstall runs this script.
     force: true
   })
+  if (onlyModules.includes('@parcel/watcher')) {
+    copyRebuiltParcelWatcherBinding(rebuildPlatform, rebuildArch)
+  }
 } catch (/** @type {any} */ err) {
   console.error('[rebuild] Native module rebuild failed:', err?.message ?? err)
   if (isWindowsNativeLockError(err)) {
@@ -141,6 +162,54 @@ try {
     }
   }
   process.exit(1)
+}
+
+// Why: @parcel/watcher's index.js resolves its native binding by requiring
+// the platform-specific optionalDependency package (e.g.
+// @parcel/watcher-linux-x64-glibc) FIRST, only falling back to
+// ./build/Release/watcher.node if that require() throws MODULE_NOT_FOUND.
+// Since the platform package is present (just built with a broken registration
+// entry point upstream), that fallback never triggers. Overwrite the platform
+// package's binary in place with our Electron-targeted rebuild so the existing
+// resolution order picks it up unmodified.
+function copyRebuiltParcelWatcherBinding(platform, arch) {
+  const builtBindingPath = resolve(
+    projectDir,
+    'node_modules/@parcel/watcher/build/Release/watcher.node'
+  )
+  if (!existsSync(builtBindingPath)) {
+    console.log('[rebuild] @parcel/watcher rebuild did not produce build/Release/watcher.node.')
+    return
+  }
+
+  const subpackageName = parcelWatcherSubpackageName(platform, arch)
+  const subpackageDir = resolve(projectDir, 'node_modules', ...subpackageName.split('/'))
+  if (!existsSync(subpackageDir)) {
+    console.log(
+      `[rebuild] Skipping @parcel/watcher binding copy; ${subpackageName} is not installed.`
+    )
+    return
+  }
+
+  copyFileSync(builtBindingPath, resolve(subpackageDir, 'watcher.node'))
+  console.log(
+    `[rebuild] Replaced ${subpackageName}/watcher.node with the Electron-targeted rebuild.`
+  )
+}
+
+function parcelWatcherSubpackageName(platform, arch) {
+  let name = `@parcel/watcher-${platform}-${arch}`
+  if (platform === 'linux') {
+    // Why: resolve detect-libc from @parcel/watcher's own dependency closure
+    // rather than assuming it is hoisted to the project root, since pnpm does
+    // not guarantee that for transitive dependencies.
+    const requireFromParcelWatcher = createRequire(
+      resolve(projectDir, 'node_modules/@parcel/watcher/package.json')
+    )
+    const { familySync, MUSL } = requireFromParcelWatcher('detect-libc')
+    name += familySync() === MUSL ? '-musl' : '-glibc'
+  }
+  return name
 }
 
 function ensureElectronPackageInstalled() {

--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -191,7 +191,14 @@ function copyRebuiltParcelWatcherBinding(platform, arch) {
     return
   }
 
-  copyFileSync(builtBindingPath, resolve(subpackageDir, 'watcher.node'))
+  // Why: the subpackage's watcher.node is hard-linked from pnpm's global
+  // content-addressed store on Linux/Windows (macOS reflinks it copy-on-write).
+  // Copying in place would rewrite that shared inode and corrupt the cached
+  // prebuild for every other project that links the same package version, so
+  // unlink first to break the link and land a fresh, isolated file.
+  const destBindingPath = resolve(subpackageDir, 'watcher.node')
+  rmSync(destBindingPath, { force: true })
+  copyFileSync(builtBindingPath, destBindingPath)
   console.log(
     `[rebuild] Replaced ${subpackageName}/watcher.node with the Electron-targeted rebuild.`
   )

--- a/config/scripts/rebuild-native-deps.test.mjs
+++ b/config/scripts/rebuild-native-deps.test.mjs
@@ -3,6 +3,7 @@ import {
   chmodSync,
   copyFileSync,
   existsSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -237,6 +238,40 @@ describe('rebuild-native-deps @parcel/watcher binding replacement (stablyai/orca
           'utf8'
         )
       ).toBe('FAKE_REBUILT_BINARY_MARKER')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('replaces the hard-linked prebuild without rewriting the shared pnpm store blob', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeUsableElectronPackage(projectDir)
+      writeFakeElectronRebuild(projectDir, { createParcelWatcherBuildOutput: true })
+      writeFakeParcelWatcherSource(projectDir)
+      writeFakeParcelWatcherSubpackage(projectDir, '@parcel/watcher-linux-x64-glibc')
+
+      // Why: emulate pnpm's Linux/Windows layout where the subpackage's
+      // watcher.node is hard-linked from the global content-addressed store. A
+      // naive in-place copy would rewrite that shared inode and corrupt the
+      // cached prebuild for every other project; point a second "store" path at
+      // the same inode and assert the rebuild leaves it byte-for-byte intact.
+      const subpackageBinding = join(
+        projectDir,
+        'node_modules',
+        '@parcel',
+        'watcher-linux-x64-glibc',
+        'watcher.node'
+      )
+      const storeBlob = join(projectDir, 'fake-pnpm-store-watcher.node')
+      linkSync(subpackageBinding, storeBlob)
+
+      const result = runRebuildScript(projectDir, {}, ['--platform=linux', '--arch=x64', '--force'])
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(readFileSync(subpackageBinding, 'utf8')).toBe('FAKE_REBUILT_BINARY_MARKER')
+      expect(readFileSync(storeBlob, 'utf8')).toBe('stale prebuild\n')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }

--- a/config/scripts/rebuild-native-deps.test.mjs
+++ b/config/scripts/rebuild-native-deps.test.mjs
@@ -146,7 +146,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         )
 
         const rebuildCall = JSON.parse(readFileSync(rebuildLogPath, 'utf8').trim())
-        expect(rebuildCall.onlyModules).toEqual(['node-pty'])
+        expect(rebuildCall.onlyModules).toEqual(['node-pty', '@parcel/watcher'])
         expect(rebuildCall.ignoreModules).toEqual(['cpu-features'])
         expect(rebuildCall.force).toBe(true)
       } finally {
@@ -167,6 +167,7 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         writeFakeLoadableNodePty(projectDir, { nativeDir: '../build/Release/' })
         writeNodePtyPatchFile(projectDir)
         writePatchedNodePtyBuildArtifacts(projectDir)
+        writeFakeLoadableParcelWatcher(projectDir)
 
         const result = runRebuildScript(projectDir, {
           ORCA_REBUILD_TEST_LOG: rebuildLogPath
@@ -205,13 +206,66 @@ describe('rebuild-native-deps patched node-pty rebuild', () => {
         expect(result.stdout).toContain("expected build/Release so Orca's node-pty patch is active")
 
         const rebuildCall = JSON.parse(readFileSync(rebuildLogPath, 'utf8').trim())
-        expect(rebuildCall.onlyModules).toEqual(['node-pty'])
+        expect(rebuildCall.onlyModules).toEqual(['node-pty', '@parcel/watcher'])
         expect(rebuildCall.force).toBe(true)
       } finally {
         rmSync(projectDir, { recursive: true, force: true })
       }
     }
   )
+})
+
+describe('rebuild-native-deps @parcel/watcher binding replacement (stablyai/orca#8540)', () => {
+  it('copies the Electron-targeted rebuild over the matching Linux glibc subpackage', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeUsableElectronPackage(projectDir)
+      writeFakeElectronRebuild(projectDir, { createParcelWatcherBuildOutput: true })
+      writeFakeParcelWatcherSource(projectDir)
+      writeFakeParcelWatcherSubpackage(projectDir, '@parcel/watcher-linux-x64-glibc')
+
+      const result = runRebuildScript(projectDir, {}, ['--platform=linux', '--arch=x64', '--force'])
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout).toContain(
+        'Replaced @parcel/watcher-linux-x64-glibc/watcher.node with the Electron-targeted rebuild.'
+      )
+      expect(
+        readFileSync(
+          join(projectDir, 'node_modules', '@parcel', 'watcher-linux-x64-glibc', 'watcher.node'),
+          'utf8'
+        )
+      ).toBe('FAKE_REBUILT_BINARY_MARKER')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves the subpackage untouched when it is not installed for this build', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeUsableElectronPackage(projectDir)
+      writeFakeElectronRebuild(projectDir, { createParcelWatcherBuildOutput: true })
+      writeFakeParcelWatcherSource(projectDir)
+      // Why: darwin build targeting a linux CI box; the darwin subpackage is
+      // absent here on purpose.
+
+      const result = runRebuildScript(projectDir, {}, [
+        '--platform=linux',
+        '--arch=arm64',
+        '--force'
+      ])
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout).toContain(
+        'Skipping @parcel/watcher binding copy; @parcel/watcher-linux-arm64-glibc is not installed.'
+      )
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
 })
 
 function mkTempProject() {
@@ -225,7 +279,7 @@ function mkTempProject() {
   return projectDir
 }
 
-function runRebuildScript(projectDir, extraEnv = {}) {
+function runRebuildScript(projectDir, extraEnv = {}, extraArgs = []) {
   const env = {
     ...process.env,
     npm_config_platform: 'linux',
@@ -239,7 +293,7 @@ function runRebuildScript(projectDir, extraEnv = {}) {
       delete env[key]
     }
   }
-  return spawnSync(process.execPath, ['config/scripts/rebuild-native-deps.mjs'], {
+  return spawnSync(process.execPath, ['config/scripts/rebuild-native-deps.mjs', ...extraArgs], {
     cwd: projectDir,
     encoding: 'utf8',
     env: {
@@ -328,35 +382,50 @@ module.exports = async function extract(_zipPath, options) {
   chmodSync(join(extractDir, 'index.js'), 0o755)
 }
 
-function writeFakeElectronRebuild(projectDir, { logPathEnv = null } = {}) {
+function writeFakeElectronRebuild(
+  projectDir,
+  { logPathEnv = null, createParcelWatcherBuildOutput = false } = {}
+) {
   const rebuildDir = join(projectDir, 'node_modules', '@electron', 'rebuild')
   mkdirSync(rebuildDir, { recursive: true })
   writeFileSync(join(rebuildDir, 'package.json'), JSON.stringify({ type: 'module' }))
+  const parcelWatcherBuildOutputStatement = createParcelWatcherBuildOutput
+    ? `
+  if (options.onlyModules.includes('@parcel/watcher')) {
+    mkdirSync('node_modules/@parcel/watcher/build/Release', { recursive: true })
+    writeFileSync('node_modules/@parcel/watcher/build/Release/watcher.node', 'FAKE_REBUILT_BINARY_MARKER')
+  }
+`
+    : ''
   writeFileSync(
     join(rebuildDir, 'index.js'),
     logPathEnv
       ? `
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs'
 
 export async function rebuild(options) {
   const logPath = process.env[${JSON.stringify(logPathEnv)}]
-  if (!logPath) {
-    return
+  if (logPath) {
+    appendFileSync(
+      logPath,
+      JSON.stringify({
+        arch: options.arch,
+        electronVersion: options.electronVersion,
+        force: options.force,
+        ignoreModules: options.ignoreModules,
+        onlyModules: options.onlyModules,
+        platform: options.platform
+      }) + '\\n'
+    )
   }
-  appendFileSync(
-    logPath,
-    JSON.stringify({
-      arch: options.arch,
-      electronVersion: options.electronVersion,
-      force: options.force,
-      ignoreModules: options.ignoreModules,
-      onlyModules: options.onlyModules,
-      platform: options.platform
-    }) + '\\n'
-  )
-}
+${parcelWatcherBuildOutputStatement}}
 `
-      : 'export async function rebuild() {}\n'
+      : `
+import { mkdirSync, writeFileSync } from 'node:fs'
+
+export async function rebuild(options) {
+${parcelWatcherBuildOutputStatement}}
+`
   )
 }
 
@@ -415,4 +484,47 @@ function writePatchedNodePtyBuildArtifacts(projectDir) {
   if (process.platform === 'darwin') {
     writeFileSync(join(buildDir, 'spawn-helper'), '')
   }
+}
+
+function writeFakeLoadableParcelWatcher(projectDir) {
+  const watcherDir = join(projectDir, 'node_modules', '@parcel', 'watcher')
+  mkdirSync(watcherDir, { recursive: true })
+  writeFileSync(
+    join(watcherDir, 'package.json'),
+    JSON.stringify({ name: '@parcel/watcher', version: '2.5.6', main: 'index.js' })
+  )
+  writeFileSync(join(watcherDir, 'index.js'), 'module.exports = {}\n')
+}
+
+function writeFakeParcelWatcherSource(projectDir) {
+  const watcherDir = join(projectDir, 'node_modules', '@parcel', 'watcher')
+  mkdirSync(watcherDir, { recursive: true })
+  writeFileSync(
+    join(watcherDir, 'package.json'),
+    JSON.stringify({
+      name: '@parcel/watcher',
+      version: '2.5.6',
+      dependencies: { 'detect-libc': '^2.0.3' }
+    })
+  )
+  const detectLibcDir = join(watcherDir, 'node_modules', 'detect-libc')
+  mkdirSync(detectLibcDir, { recursive: true })
+  writeFileSync(
+    join(detectLibcDir, 'package.json'),
+    JSON.stringify({ name: 'detect-libc', main: 'index.js' })
+  )
+  writeFileSync(
+    join(detectLibcDir, 'index.js'),
+    "exports.MUSL = 'musl'\nexports.familySync = function familySync() { return null }\n"
+  )
+}
+
+function writeFakeParcelWatcherSubpackage(
+  projectDir,
+  subpackageName,
+  contents = 'stale prebuild\n'
+) {
+  const dir = join(projectDir, 'node_modules', ...subpackageName.split('/'))
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'watcher.node'), contents)
 }


### PR DESCRIPTION
## Summary

Fixes #8540. The `@parcel/watcher-<platform>-<arch>` optionalDependency prebuilds published upstream register via the older constructor-based N-API path and omit the modern `napi_register_module_v1` export. Electron's context-aware module loader requires that export, so the packaged Linux AppImage's `watcher.node` fails to load — even though the runtime dependency closure fix from #4851 / #4860 correctly ships the package files.

Confirmed empirically before fixing: `nm -D node_modules/@parcel/watcher-linux-x64-glibc/watcher.node | grep napi_register_module_v1` returns nothing on the currently published `@parcel/watcher@2.5.6` prebuild, while its own source (`src/binding.cc:268`) does use `NODE_API_MODULE(watcher, Init)` — meaning a from-source rebuild against Electron's headers produces a correctly-registering binary.

No visual change.

## Changes

- **`config/scripts/rebuild-native-deps.mjs`**: add `@parcel/watcher` to the Electron-targeted native rebuild (`NATIVE_MODULES`) for all three packaged platforms (darwin/win32/linux). After `@electron/rebuild` compiles `node_modules/@parcel/watcher/build/Release/watcher.node` against Electron's headers, copy it over the matching `@parcel/watcher-<platform>-<arch>[-glibc|-musl]` subpackage's `watcher.node` — `index.js`'s `require()` resolution order tries that subpackage *before* falling back to a local build, so the platform subpackage must be the one carrying the fix.
- **`config/packaged-runtime-node-modules.cjs`**: add `verifyPackagedParcelWatcherBinding`, called from the `afterPack` hook. It asserts the packaged Linux `watcher.node` actually exports `napi_register_module_v1`, failing the build early instead of silently shipping a broken binary. Scoped to Linux only: known-good N-API prebuilds on darwin (e.g. `@napi-rs/canvas`'s darwin-x64 binary) legitimately omit this export with no observed runtime failure there, so a cross-platform gate would false-fail correct macOS/Windows builds.
- **`config/electron-builder.config.cjs`**: wire the new verification into `afterPack`.
- Test coverage added/updated in `config/scripts/rebuild-native-deps.test.mjs` and `config/scripts/electron-builder-config.test.mjs` for the copy-into-subpackage behavior and the Linux-scoped verification gate (pass/fail/no-op cases).

## AI Code Review Summary

- **Cross-platform compatibility**: the rebuild-and-copy step in `rebuild-native-deps.mjs` runs on all three packaged platforms (darwin/win32/linux) via the existing `rebuildPlatform`/`osPlatform()` plumbing, so darwin and win32 builds also get a freshly-rebuilt, correctly-registering `watcher.node`. The new packaging-time verification gate (`verifyPackagedParcelWatcherBinding`) is intentionally Linux-only, because known-good darwin N-API prebuilds (e.g. `@napi-rs/canvas`) legitimately omit `napi_register_module_v1` with no observed runtime failure — a cross-platform gate would false-fail correct macOS/Windows builds.
- **SSH/remote/local compatibility**: this is a build-time/packaging-time change only (native module rebuild + `afterPack` verification). It does not touch any runtime code path Orca executes against local, remote, or SSH-backed repositories, so there's no SSH/remote-specific behavior to test here.
- **Supported agent and integration compatibility**: N/A — no agent, CLI-agent-integration, or git-provider code is touched by this change.
- **Performance risk**: adds one additional native module (`@parcel/watcher`) to the existing `@electron/rebuild` invocation and one directory scan + file read in `afterPack`. Both are one-time costs at packaging time, not at app runtime — no measurable user-facing performance impact.
- **UI quality**: N/A, no UI change (see "No visual change" above).
- **Security risk**: rebuilds `@parcel/watcher` from its own already-vendored npm source against Electron's official headers (`https://electronjs.org/headers/`) — the same trusted source and rebuild mechanism already used for `node-pty` and `cpu-features` in this file. No new dependency, no new network target, no expanded attack surface.

## Test plan

- [x] `pnpm lint` — clean (pre-existing warnings only, in files unrelated to this change: `src/main/providers/ssh-git-provider.test.ts`, `src/main/browser/agent-browser-bridge.test.ts`, `src/renderer/src/components/terminal-pane/keyboard-handlers.ts`)
- [x] `pnpm typecheck` — clean, no errors
- [x] `pnpm test` — 29,153 passed, 40 skipped, **7 pre-existing failures** in `src/relay/pty-shell-launch.test.ts` (4) and `src/main/providers/local-pty-shell-ready.test.ts` (3). All 7 are bash-OSC133-lifecycle assertions (`expect(output.split(oscC)).toHaveLength(4)` getting 5) unrelated to this change — verified they reproduce identically on a clean `upstream/main` checkout with none of this PR's changes applied, in an isolated `git worktree`. Consistent with a local bash-version difference on the machine running the tests, not a regression from this PR (this PR touches only `config/electron-builder.config.cjs`, `config/packaged-runtime-node-modules.cjs`, and the two `config/scripts/*.mjs`/`*.test.mjs` files listed above — none of which are anywhere near PTY/bash prompt handling).
- [x] `pnpm build` — full `build:desktop` + `build:native`, exit 0
- [x] CI: Linux `AppImage` build should now fail-fast in `afterPack` if `napi_register_module_v1` is ever missing again, and should succeed once the rebuild is wired in

**X (Twitter) handle:** @LesleyMurfin
