### PR TITLE
fix(shortcuts): resolve macOS Explorer binding conflict

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1652,7 +1652,6 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
-      // Cmd/Ctrl+Shift+E — new mobile emulator tab (macOS only)
       if (!e.repeat && mobileEmulatorEnabled && matchShortcut('tab.newSimulator')) {
         e.preventDefault()
         notifyTerminalCapture('tab.newSimulator')

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -717,6 +717,17 @@ describe('keybindings', () => {
     ).toBe(true)
   })
 
+  it('keeps the macOS simulator shortcut distinct from the Explorer shortcut', () => {
+    expect(getEffectiveKeybindingsForAction('sidebar.explorer.toggle', 'darwin')).toEqual([
+      'Mod+Shift+E'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.newSimulator', 'darwin')).toEqual([
+      'Mod+Alt+Shift+E'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.newSimulator', 'linux')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('tab.newSimulator', 'win32')).toEqual([])
+  })
+
   it('defines an unassigned per-agent tab action for every TUI agent', () => {
     for (const agent of ALL_TUI_AGENTS) {
       const actionId = agentTabActionId(agent)

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -567,8 +567,10 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tabs',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'simulator', 'emulator', 'mobile', 'ios', 'new'],
+    // Why: Option keeps the macOS-only simulator action distinct from the
+    // cross-platform Explorer shortcut on Cmd/Ctrl+Shift+E.
     defaultBindings: {
-      darwin: ['Mod+Shift+E'],
+      darwin: ['Mod+Alt+Shift+E'],
       linux: [],
       win32: []
     }


### PR DESCRIPTION
## Summary

Fixes #8533.

- Keep **Show Explorer** on its established macOS shortcut, `Cmd+Shift+E`.
- Move the macOS-only **New mobile emulator tab** default to `Cmd+Option+Shift+E`, so both actions remain reachable.
- Leave the simulator action unassigned by default on Linux and Windows.
- Add regression coverage for the distinct platform defaults.

## Screenshots

No visual design change. Existing shortcut labels now show `⌘⇧E` for Explorer and `⌘⌥⇧E` for the mobile emulator action.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 2,753 files / 29,139 tests passed; 28 unrelated renderer tests failed because `window.localStorage` is unavailable under the local unsupported Node 26 runtime. The focused shortcut, browser guest, and main-window suites pass 156/156.
- [x] `pnpm build`
- [x] Added regression coverage that verifies Explorer retains `Mod+Shift+E`, the simulator moves to `Mod+Alt+Shift+E` on macOS, and Linux/Windows remain unassigned

Manual macOS verification in the dev app confirmed:

1. `Cmd+Shift+E` opens the File Explorer without creating a mobile emulator tab.
2. `Cmd+Option+Shift+E` opens a mobile emulator tab.
3. Settings displays the two distinct default shortcuts.

## AI Review Report

Reviewed the central shortcut registry and each consumer of the simulator binding in the renderer and Electron browser-guest path.

- **Correctness:** the conflict is removed at the shared default-binding source, so Settings labels and all runtime matchers resolve the same new simulator chord while Explorer keeps its established shortcut.
- **Cross-platform:** macOS now uses `Mod+Alt+Shift+E` for the simulator. Linux and Windows remain explicitly unassigned for that action, while their existing `Mod+Shift+E` Explorer shortcut is unchanged. Labels continue through the shared platform formatter, with no hardcoded `metaKey`, accelerator, path, or shell behavior added.
- **Local/SSH/remote:** shortcut dispatch is renderer/application UI behavior and does not depend on where the active workspace executes. Local, SSH, WSL, and paired workspaces use the same binding registry.
- **Agents and integrations:** no agent, integration, git provider, terminal transport, or mobile-emulator control protocol changed; only the default activation chord changed.
- **Electron behavior:** the renderer and browser-guest interception paths both query the central registry, so neither retains the conflicting chord.
- **Performance:** this is a static binding change with no new listeners, polling, allocations, or hot-path work.
- **UI quality:** no layout, styling, or component changes. Existing shortcut surfaces automatically render the corrected label.

No blocking review issue remains.

## Security Audit

The change adds no command execution, input parsing, filesystem or path handling, network access, authentication, secrets, dependencies, IPC channels, or privilege changes. It only changes a normalized static shortcut string and adds tests. Existing user keybinding overrides continue through the same validation and persistence paths. No security follow-up is needed.

## Notes

- Platform-specific: the default change applies only to macOS.
- Existing explicit user overrides are preserved.
