### PR TITLE
fix(settings): separate same-id projects by host

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -7484,6 +7484,52 @@ describe('registerWorktreeHandlers', () => {
     expect(hasHooksFileMock).not.toHaveBeenCalled()
   })
 
+  it('inspects setup imports on the requested host when repo ids collide', async () => {
+    const localRepo = {
+      id: 'repo-shared',
+      path: '/local/repo',
+      displayName: 'local',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    const sshRepo = { ...localRepo, path: '/remote/repo', connectionId: 'conn-1' }
+    const fsProvider = {
+      readFile: vi.fn().mockResolvedValue({
+        content: JSON.stringify({ packageManager: 'pnpm@10.0.0' }),
+        isBinary: false
+      })
+    }
+    store.getRepos.mockReturnValue([localRepo, sshRepo])
+    getSshFilesystemProviderMock.mockReturnValue(fsProvider)
+
+    await expect(
+      handlers['hooks:inspectSetupScriptImports'](null, {
+        repoId: 'repo-shared',
+        hostId: 'ssh:conn-1'
+      })
+    ).resolves.toContainEqual(
+      expect.objectContaining({ provider: 'package-manager', setup: 'pnpm install' })
+    )
+    expect(fsProvider.readFile).toHaveBeenCalledWith('/remote/repo/package.json')
+  })
+
+  it('skips setup import inspection when duplicate repo ids omit the host', async () => {
+    const localRepo = {
+      id: 'repo-shared',
+      path: '/local/repo',
+      displayName: 'local',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    const sshRepo = { ...localRepo, path: '/remote/repo', connectionId: 'conn-1' }
+    store.getRepos.mockReturnValue([localRepo, sshRepo])
+
+    await expect(
+      handlers['hooks:inspectSetupScriptImports'](null, { repoId: 'repo-shared' })
+    ).resolves.toEqual([])
+    expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
+  })
+
   it('does not coalesce forget requests for the same id on different hosts', async () => {
     const localRepo = {
       id: 'repo-shared',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -140,7 +140,7 @@ async function stopPtysForDestructiveWorktreeRemoval(
   }
 }
 
-function getRepoForWorktreeRemoval(
+function resolveRepoForHost(
   store: Store,
   repoId: string,
   hostId?: ExecutionHostId
@@ -1376,7 +1376,7 @@ export function registerWorktreeHandlers(
     'worktrees:remove',
     async (_event, args: RemoveWorktreeArgs): Promise<RemoveWorktreeResult> => {
       const { repoId, worktreePath } = parseWorktreeId(args.worktreeId)
-      const repo = getRepoForWorktreeRemoval(store, repoId, args.hostId)
+      const repo = resolveRepoForHost(store, repoId, args.hostId)
       if (!repo) {
         throw new Error(`Repo not found: ${repoId}`)
       }
@@ -1898,7 +1898,7 @@ export function registerWorktreeHandlers(
       args: Pick<RemoveWorktreeArgs, 'worktreeId' | 'hostId'>
     ): Promise<RemoveWorktreeResult> => {
       const { repoId } = parseWorktreeId(args.worktreeId)
-      const repo = getRepoForWorktreeRemoval(store, repoId, args.hostId)
+      const repo = resolveRepoForHost(store, repoId, args.hostId)
       if (!repo) {
         throw new Error(`Repo not found: ${repoId}`)
       }
@@ -2080,7 +2080,7 @@ export function registerWorktreeHandlers(
   ipcMain.handle(
     'hooks:check',
     async (_event, args: { repoId: string; hostId?: ExecutionHostId }) => {
-      const repo = getRepoForWorktreeRemoval(store, args.repoId, args.hostId)
+      const repo = resolveRepoForHost(store, args.repoId, args.hostId)
       if (!repo) {
         const repoIdExists = store.getRepos().some((candidate) => candidate.id === args.repoId)
         // Why: callers treat inspection errors as "skip", so a requested/ambiguous host must report error (fail closed), not hook-free.
@@ -2148,71 +2148,74 @@ export function registerWorktreeHandlers(
     }
   )
 
-  ipcMain.handle('hooks:inspectSetupScriptImports', async (_event, args: { repoId: string }) => {
-    const repo = store.getRepo(args.repoId)
-    if (!repo || isFolderRepo(repo)) {
-      return []
-    }
+  ipcMain.handle(
+    'hooks:inspectSetupScriptImports',
+    async (_event, args: { repoId: string; hostId?: ExecutionHostId }) => {
+      const repo = resolveRepoForHost(store, args.repoId, args.hostId)
+      if (!repo || isFolderRepo(repo)) {
+        return []
+      }
 
-    return inspectSetupScriptImportCandidates(
-      async (relativePath) => {
-        const filePath = joinWorktreeRelativePath(repo.path, relativePath)
-        if (repo.connectionId) {
-          const fsProvider = getSshFilesystemProvider(repo.connectionId)
-          if (!fsProvider) {
-            return null
-          }
-          try {
-            const result = await fsProvider.readFile(filePath)
-            return result.isBinary ? null : result.content
-          } catch {
-            return null
-          }
-        }
-
-        try {
-          return await readFile(filePath, 'utf-8')
-        } catch (error) {
-          if (!isENOENT(error)) {
-            console.warn('[hooks] Failed to inspect setup script import candidate:', error)
-          }
-          return null
-        }
-      },
-      {
-        fileExists: async (relativePath) => {
+      return inspectSetupScriptImportCandidates(
+        async (relativePath) => {
           const filePath = joinWorktreeRelativePath(repo.path, relativePath)
           if (repo.connectionId) {
             const fsProvider = getSshFilesystemProvider(repo.connectionId)
             if (!fsProvider) {
-              return false
+              return null
             }
             try {
-              const fileStat = await fsProvider.stat(filePath)
-              return fileStat.type !== 'directory'
+              const result = await fsProvider.readFile(filePath)
+              return result.isBinary ? null : result.content
             } catch {
-              return false
+              return null
             }
           }
 
           try {
-            const fileStat = await stat(filePath)
-            return !fileStat.isDirectory()
+            return await readFile(filePath, 'utf-8')
           } catch (error) {
             if (!isENOENT(error)) {
-              console.warn('[hooks] Failed to stat setup script import candidate:', error)
+              console.warn('[hooks] Failed to inspect setup script import candidate:', error)
             }
-            return false
+            return null
+          }
+        },
+        {
+          fileExists: async (relativePath) => {
+            const filePath = joinWorktreeRelativePath(repo.path, relativePath)
+            if (repo.connectionId) {
+              const fsProvider = getSshFilesystemProvider(repo.connectionId)
+              if (!fsProvider) {
+                return false
+              }
+              try {
+                const fileStat = await fsProvider.stat(filePath)
+                return fileStat.type !== 'directory'
+              } catch {
+                return false
+              }
+            }
+
+            try {
+              const fileStat = await stat(filePath)
+              return !fileStat.isDirectory()
+            } catch (error) {
+              if (!isENOENT(error)) {
+                console.warn('[hooks] Failed to stat setup script import candidate:', error)
+              }
+              return false
+            }
           }
         }
-      }
-    )
-  })
+      )
+    }
+  )
 
   ipcMain.handle(
     'hooks:readIssueCommand',
     async (_event, args: { repoId: string; hostId?: ExecutionHostId }) => {
-      const repo = getRepoForWorktreeRemoval(store, args.repoId, args.hostId)
+      const repo = resolveRepoForHost(store, args.repoId, args.hostId)
       if (!repo || isFolderRepo(repo)) {
         return {
           status: 'ok',
@@ -2279,7 +2282,7 @@ export function registerWorktreeHandlers(
   ipcMain.handle(
     'hooks:writeIssueCommand',
     async (_event, args: { repoId: string; content: string; hostId?: ExecutionHostId }) => {
-      const repo = getRepoForWorktreeRemoval(store, args.repoId, args.hostId)
+      const repo = resolveRepoForHost(store, args.repoId, args.hostId)
       if (!repo || isFolderRepo(repo)) {
         return
       }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2286,7 +2286,10 @@ export type PreloadApi = {
       hooks: OrcaHooks | null
       mayNeedUpdate: boolean
     }>
-    inspectSetupScriptImports: (args: { repoId: string }) => Promise<SetupScriptImportCandidate[]>
+    inspectSetupScriptImports: (args: {
+      repoId: string
+      hostId?: ExecutionHostId
+    }) => Promise<SetupScriptImportCandidate[]>
     createIssueCommandRunner: (args: {
       repoId: string
       worktreePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2639,8 +2639,10 @@ const api = {
       mayNeedUpdate: boolean
     }> => ipcRenderer.invoke('hooks:check', args),
 
-    inspectSetupScriptImports: (args: { repoId: string }): Promise<unknown[]> =>
-      ipcRenderer.invoke('hooks:inspectSetupScriptImports', args),
+    inspectSetupScriptImports: (args: {
+      repoId: string
+      hostId?: ExecutionHostId
+    }): Promise<unknown[]> => ipcRenderer.invoke('hooks:inspectSetupScriptImports', args),
 
     createIssueCommandRunner: (args: {
       repoId: string

--- a/src/renderer/src/components/feature-wall/FeatureWallSetupWorkflowActions.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallSetupWorkflowActions.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
 import { useAllWorktrees } from '@/store/selectors'
 import { getDefaultRepoHookSettings } from '../../../../shared/constants'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import type { Repo, RepoHookSettings, Worktree } from '../../../../shared/types'
 import { getRepositoryLocalCommandsSectionId } from '../settings/repository-settings-targets'
@@ -114,9 +115,11 @@ export function SetupScriptAction(): React.JSX.Element {
       return
     }
     setSettingsSearchQuery('')
+    const repoHostId = getRepoExecutionHostId(repo)
     openSettingsTarget({
       pane: 'repo',
       repoId: repo.id,
+      repoHostId,
       sectionId: getRepositoryLocalCommandsSectionId(repo.id)
     })
     closeModal()
@@ -141,7 +144,11 @@ export function SetupScriptAction(): React.JSX.Element {
         setup: setupScript.trim()
       }
     }
-    const updated = await updateRepo(repo.id, { hookSettings: nextHookSettings })
+    const updated = await updateRepo(
+      repo.id,
+      { hookSettings: nextHookSettings },
+      { hostId: getRepoExecutionHostId(repo) }
+    )
     if (updated) {
       toast.success(
         translate(

--- a/src/renderer/src/components/right-sidebar/source-control-ai-settings-navigation.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-ai-settings-navigation.ts
@@ -1,5 +1,6 @@
 import { getRepositorySourceControlAiSectionId } from '@/components/settings/repository-settings-targets'
 import type { AppState } from '@/store'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/types'
 
 export function openSourceControlAiSettingsTarget({
@@ -15,6 +16,7 @@ export function openSourceControlAiSettingsTarget({
     openSettingsTarget({
       pane: 'repo',
       repoId: activeRepo.id,
+      repoHostId: getRepoExecutionHostId(activeRepo),
       sectionId: getRepositorySourceControlAiSectionId(activeRepo.id)
     })
   } else {

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -22,7 +22,10 @@ import { RepositorySourceControlAiSection } from './RepositorySourceControlAiSec
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { useAppStore } from '../../store'
-import { getRepositoryIconSectionId } from './repository-settings-targets'
+import {
+  getRepositoryDisplayNameSectionId,
+  getRepositoryIconSectionId
+} from './repository-settings-targets'
 import { RepositoryIconPicker } from './RepositoryIconPicker'
 import { getRepositoryPaneSearchEntries } from './repository-search'
 import { RepositoryHostSetupsSection } from './RepositoryHostSetupsSection'
@@ -86,6 +89,7 @@ export function RepositoryPane({
   // host, not findRepoForHost's focused-host fallback (the same-id/self-pair
   // case where local and a runtime share one repo id).
   const selectedHostId = getRepoExecutionHostId(repo)
+  const displayNameInputId = getRepositoryDisplayNameSectionId(repo.id)
   const updateSelectedRepo = useCallback(
     (repoId: string, updates: RepositoryPaneRepoUpdate) =>
       updateRepo(repoId, updates, { hostId: selectedHostId }),
@@ -281,11 +285,11 @@ export function RepositoryPane({
           className="space-y-2"
           forceVisible={forceFullPaneForRepoMatch}
         >
-          <Label htmlFor={`repo-display-name-${repo.id}`} className="text-sm font-semibold">
+          <Label htmlFor={displayNameInputId} className="text-sm font-semibold">
             {translate('auto.components.settings.RepositoryPane.c7ef4415de', 'Display Name')}
           </Label>
           <RepoSettingsDraftInput
-            id={`repo-display-name-${repo.id}`}
+            id={displayNameInputId}
             repoId={repo.id}
             storeValue={repo.displayName}
             onTextChange={(text) => updateSelectedRepo(repo.id, { displayName: text })}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -114,12 +114,11 @@ import { translate } from '@/i18n/i18n'
 import { getProjectHostSetupProjectionFromState } from '../../store/selectors'
 import { getRepoHostIdentity } from '../../store/slices/repo-host-identity'
 import {
-  buildRepoIdToHostSelection,
   buildRepoIdToRepresentative,
   buildSettingsProjectList,
   getSettingsProjectHostRepo,
   removeSettingsProjectFromAllHosts,
-  resolveSettingsTargetRepoId
+  resolveSettingsTargetHostSelection
 } from './settings-project-list'
 
 const DevToolsPane = import.meta.env.DEV
@@ -304,11 +303,6 @@ function Settings(): React.JSX.Element {
   const settingsProjectList = useMemo(() => buildSettingsProjectList(repos), [repos])
   const repoIdToRepresentative = useMemo(
     () => buildRepoIdToRepresentative(settingsProjectList),
-    [settingsProjectList]
-  )
-  // Why: lets a deep-link's repoId select the owning project's host so host-specific subsection anchors exist.
-  const repoIdToHostSelection = useMemo(
-    () => buildRepoIdToHostSelection(settingsProjectList),
     [settingsProjectList]
   )
   // Why: pane-level "Remove Project" removes every host setup, not just the selected host (per-host remove lives in "Available Hosts").
@@ -628,15 +622,12 @@ function Settings(): React.JSX.Element {
       repoIdToRepresentative
     )
     // Why: select the target repo's host before scrolling so its host-specific subsection anchor renders and the scroll lands.
-    const targetRepoId = resolveSettingsTargetRepoId(
+    const hostSelection = resolveSettingsTargetHostSelection(
       settingsNavigationTarget,
-      repoIdToHostSelection.keys()
+      settingsProjectList
     )
-    if (targetRepoId) {
-      const hostSelection = repoIdToHostSelection.get(targetRepoId)
-      if (hostSelection) {
-        setSettingsProjectHostSelection(hostSelection.projectId, hostSelection.hostId)
-      }
+    if (hostSelection) {
+      setSettingsProjectHostSelection(hostSelection.projectId, hostSelection.hostId)
     }
     pendingNavSectionRef.current = paneSectionId
     pendingScrollTargetRef.current = settingsNavigationTarget.sectionId ?? paneSectionId
@@ -661,11 +652,11 @@ function Settings(): React.JSX.Element {
     clearSettingsTarget()
   }, [
     clearSettingsTarget,
-    repoIdToHostSelection,
     repoIdToRepresentative,
     setSettingsProjectHostSelection,
     settings,
-    settingsNavigationTarget
+    settingsNavigationTarget,
+    settingsProjectList
   ])
 
   // Why: recompute scrollback mode only when the row value changes, not on every settings mutation.

--- a/src/renderer/src/components/settings/repository-settings-targets.ts
+++ b/src/renderer/src/components/settings/repository-settings-targets.ts
@@ -4,6 +4,10 @@ export function getRepositoryLocalCommandsSectionId(repoId: string): string {
   return `repo-${repoId}-local-commands`
 }
 
+export function getRepositoryDisplayNameSectionId(repoId: string): string {
+  return `repo-display-name-${repoId}`
+}
+
 export function getRepositoryIconSectionId(repoId: string): string {
   return `repo-${repoId}-icon`
 }

--- a/src/renderer/src/components/settings/settings-project-list.test.ts
+++ b/src/renderer/src/components/settings/settings-project-list.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { ProjectHostSetup, Repo } from '../../../../shared/types'
 import {
-  buildRepoIdToHostSelection,
   buildRepoIdToRepresentative,
   buildSettingsProjectList,
   getSettingsProjectHostRepo,
   getSettingsProjectRepresentativeRepoId,
   removeSettingsProjectFromAllHosts,
   resolveEffectiveProjectHost,
+  resolveSettingsTargetHostSelection,
   resolveSettingsTargetRepoId
 } from './settings-project-list'
 
@@ -152,15 +152,36 @@ describe('deep-link resolution', () => {
   })
 
   it('maps a repoId to its owning project + host for selection', () => {
-    const map = buildRepoIdToHostSelection(projects)
-    expect(map.get('remote-9')).toEqual({
+    expect(resolveSettingsTargetHostSelection({ repoId: 'remote-9' }, projects)).toEqual({
       projectId: projects[0].projectId,
       hostId: 'runtime:home-mac'
     })
   })
 
+  it('uses an explicit host when local and remote setups share one repo id', () => {
+    const sameIdRepos = [
+      makeRepo({ id: 'same-repo', gitRemoteIdentity: gitRemote }),
+      makeRepo({
+        id: 'same-repo',
+        gitRemoteIdentity: gitRemote,
+        executionHostId: 'runtime:home-mac'
+      })
+    ]
+    const sameIdProjects = buildSettingsProjectList(sameIdRepos)
+
+    expect(
+      resolveSettingsTargetHostSelection(
+        { repoId: 'same-repo', repoHostId: 'runtime:home-mac' },
+        sameIdProjects
+      )
+    ).toEqual({
+      projectId: sameIdProjects[0].projectId,
+      hostId: 'runtime:home-mac'
+    })
+  })
+
   it('parses a repoId from a host-specific subsection sectionId', () => {
-    const repoIds = [...buildRepoIdToHostSelection(projects).keys()]
+    const repoIds = projects.flatMap((project) => project.setups.map((setup) => setup.repoId))
     expect(
       resolveSettingsTargetRepoId(
         { repoId: null, sectionId: 'repo-remote-9-source-control-ai' },
@@ -185,7 +206,7 @@ describe('deep-link resolution', () => {
   })
 
   it('resolves the remote host repo row when a remote host is selected', () => {
-    const hostSelection = buildRepoIdToHostSelection(projects).get('remote-9')
+    const hostSelection = resolveSettingsTargetHostSelection({ repoId: 'remote-9' }, projects)
     expect(getSettingsProjectHostRepo(projects[0], repos, hostSelection?.hostId)?.id).toBe(
       'remote-9'
     )

--- a/src/renderer/src/components/settings/settings-project-list.ts
+++ b/src/renderer/src/components/settings/settings-project-list.ts
@@ -107,20 +107,32 @@ export function buildRepoIdToRepresentative(
   return map
 }
 
-/** Maps each host's repoId to its owning project + host, so a deep link can
- *  select that host in the pane's "Available Hosts" switcher. */
-export function buildRepoIdToHostSelection(
+export function resolveSettingsTargetHostSelection(
+  target: {
+    repoId: string | null
+    repoHostId?: ExecutionHostId
+    sectionId?: string
+  },
   projects: readonly SettingsProject[]
-): Map<string, { projectId: string; hostId: ExecutionHostId }> {
-  const map = new Map<string, { projectId: string; hostId: ExecutionHostId }>()
-  for (const settingsProject of projects) {
-    for (const setup of settingsProject.setups) {
-      if (setup.repoId.trim().length > 0 && !map.has(setup.repoId)) {
-        map.set(setup.repoId, { projectId: settingsProject.projectId, hostId: setup.hostId })
-      }
+): { projectId: string; hostId: ExecutionHostId } | null {
+  const repoIds = projects.flatMap((project) => project.setups.map((setup) => setup.repoId))
+  const repoId = resolveSettingsTargetRepoId(target, repoIds)
+  if (!repoId) {
+    return null
+  }
+  for (const project of projects) {
+    // Why: same-id local/runtime setups need the caller's host; repoId alone
+    // preserves legacy links but cannot identify the intended setup.
+    const setup = project.setups.find(
+      (candidate) =>
+        candidate.repoId === repoId &&
+        (!target.repoHostId || candidate.hostId === target.repoHostId)
+    )
+    if (setup) {
+      return { projectId: project.projectId, hostId: setup.hostId }
     }
   }
-  return map
+  return null
 }
 
 /**

--- a/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
+++ b/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
@@ -9,16 +9,16 @@ import {
   formatCandidateSource,
   isSetupScriptPromptDismissed,
   ignoresSharedSetupScripts,
-  inspectSetupScriptPromptState,
+  inspectSetupScriptPromptRepo,
   type SetupScriptPromptInspection
 } from '@/lib/setup-script-prompt'
-import { checkRuntimeHooks, inspectRuntimeSetupScriptImports } from '@/runtime/runtime-hooks-client'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import type { SetupScriptImportCandidate } from '../../../../shared/setup-script-imports'
 import { buildSetupScriptPromptActionTelemetry } from '../../../../shared/setup-script-telemetry'
 import { SetupScriptPromptCardShell } from './SetupScriptPromptCardShell'
 import { showSavedInProjectSettingsToast } from './SetupScriptPromptToast'
-import { openSetupScriptSettings } from './open-setup-script-settings'
+import { findSetupScriptSettingsRepo, openSetupScriptSettings } from './open-setup-script-settings'
 import { trackSetupScriptPromptExposure } from './setup-script-prompt-exposure-telemetry'
 import {
   getRenderedSetupScriptPromptState,
@@ -35,7 +35,6 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
   const repos = useAppStore((s) => s.repos)
   const projectHostSetups = useAppStore((s) => s.projectHostSetups)
   const activeRepoId = useAppStore((s) => s.activeRepoId)
-  const settings = useAppStore((s) => s.settings)
   const updateRepo = useAppStore((s) => s.updateRepo)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
@@ -75,11 +74,7 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
     setPromptState(null)
 
     async function inspectRepoSetup(): Promise<void> {
-      const nextState = await inspectSetupScriptPromptState({
-        repo,
-        checkHooks: () => checkRuntimeHooks(settings, repo.id),
-        inspectImports: () => inspectRuntimeSetupScriptImports(settings, repo.id)
-      })
+      const nextState = await inspectSetupScriptPromptRepo(repo)
       if (!cancelled) {
         setPromptState(nextState)
         setDetectedSetupDraft(
@@ -95,18 +90,23 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
     return () => {
       cancelled = true
     }
-  }, [activeRepo, inspectionRetryKey, isDismissed, settings, sidebarOpen])
+  }, [activeRepo, inspectionRetryKey, isDismissed, sidebarOpen])
 
   const openLocalCommandSettings = useCallback(
-    (repoId: string) => {
+    (repoId: string, repoHostId: ExecutionHostId) => {
+      const savedRepo = findSetupScriptSettingsRepo(repos, repoId, repoHostId)
+      if (!savedRepo) {
+        return
+      }
       openSetupScriptSettings({
-        repoId,
+        repoId: savedRepo.id,
+        repoHostId: getRepoExecutionHostId(savedRepo),
         setSettingsSearchQuery,
         openSettingsTarget,
         openSettingsPage
       })
     },
-    [openSettingsPage, openSettingsTarget, setSettingsSearchQuery]
+    [openSettingsPage, openSettingsTarget, repos, setSettingsSearchQuery]
   )
 
   const handleRetryInspection = useCallback(() => {
@@ -151,7 +151,7 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
         })
       )
     }
-    openLocalCommandSettings(activeRepo.id)
+    openLocalCommandSettings(activeRepo.id, getRepoExecutionHostId(activeRepo))
   }, [activeRepo, openLocalCommandSettings, promptState])
 
   const handleDismiss = useCallback(() => {
@@ -188,8 +188,13 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
       setIsImporting(true)
       try {
         const importedRepoId = activeRepo.id
+        const importedRepoHostId = getRepoExecutionHostId(activeRepo)
         const nextSettings = buildImportedHookSettings(activeRepo, candidate, hasSharedHooks)
-        const didUpdate = await updateRepo(activeRepo.id, { hookSettings: nextSettings })
+        const didUpdate = await updateRepo(
+          activeRepo.id,
+          { hookSettings: nextSettings },
+          { hostId: importedRepoHostId }
+        )
         if (!didUpdate) {
           track(
             'setup_script_prompt_action',
@@ -233,7 +238,7 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
                 : current
             )
             showSavedInProjectSettingsToast({
-              onOpenSettings: () => openLocalCommandSettings(importedRepoId),
+              onOpenSettings: () => openLocalCommandSettings(importedRepoId, importedRepoHostId),
               description: translate(
                 'auto.components.sidebar.SetupScriptPromptCard.a49196d538',
                 'Runs when Orca creates a new worktree.'
@@ -250,7 +255,7 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
           )
           const skippedCount = candidate.unsupportedFields?.length ?? 0
           showSavedInProjectSettingsToast({
-            onOpenSettings: () => openLocalCommandSettings(importedRepoId),
+            onOpenSettings: () => openLocalCommandSettings(importedRepoId, importedRepoHostId),
             description:
               skippedCount > 0
                 ? `${skippedCount} unsupported field${skippedCount === 1 ? '' : 's'} skipped. Saved the setup command.`

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -622,7 +622,7 @@ type VirtualizedWorktreeViewportProps = {
   toggleGroup: (key: string) => void
   collapsedGroups: Set<string>
   handleCreateForRepo: (projectId: string) => void
-  handleOpenRepoSettings: (projectId: string, sectionId?: string) => void
+  handleOpenRepoSettings: (projectId: string, hostId: ExecutionHostId, sectionId?: string) => void
   handleOpenWorktreeVisibility: (projectId: string) => void
   handleShowImportedWorktrees: (projectId: string) => void
   handleKeepImportedWorktreesHidden: (projectId: string) => void
@@ -4526,7 +4526,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                             <DropdownMenuItem
                               onSelect={() => {
                                 if (row.repo) {
-                                  handleOpenRepoSettings(row.repo.id)
+                                  handleOpenRepoSettings(
+                                    row.repo.id,
+                                    getRepoExecutionHostId(row.repo)
+                                  )
                                 }
                               }}
                             >
@@ -4539,8 +4542,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                             <DropdownMenuItem
                               onSelect={() => {
                                 if (row.repo) {
+                                  const repoHostId = getRepoExecutionHostId(row.repo)
                                   handleOpenRepoSettings(
                                     row.repo.id,
+                                    repoHostId,
                                     getRepositoryIconSectionId(row.repo.id)
                                   )
                                 }
@@ -5950,8 +5955,13 @@ const WorktreeList = React.memo(function WorktreeList({
   )
 
   const handleOpenRepoSettings = useCallback(
-    (projectId: string, sectionId?: string) => {
-      openSettingsTarget({ pane: 'repo', repoId: projectId, ...(sectionId ? { sectionId } : {}) })
+    (projectId: string, repoHostId: ExecutionHostId, sectionId?: string) => {
+      openSettingsTarget({
+        pane: 'repo',
+        repoId: projectId,
+        repoHostId,
+        ...(sectionId ? { sectionId } : {})
+      })
       openSettingsPage()
     },
     [openSettingsPage, openSettingsTarget]

--- a/src/renderer/src/components/sidebar/open-setup-script-settings.test.ts
+++ b/src/renderer/src/components/sidebar/open-setup-script-settings.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import { findSetupScriptSettingsRepo, openSetupScriptSettings } from './open-setup-script-settings'
+
+const localRepo: Repo = {
+  id: 'shared-repo',
+  path: 'local-project',
+  displayName: 'Project',
+  badgeColor: '#000',
+  addedAt: 1,
+  executionHostId: 'local'
+}
+
+const remoteRepo: Repo = {
+  ...localRepo,
+  path: 'remote-project',
+  addedAt: 2,
+  executionHostId: 'runtime:home-mac'
+}
+
+describe('setup script Settings navigation', () => {
+  it('resolves the saved host even when a same-id repository is listed first', () => {
+    expect(
+      findSetupScriptSettingsRepo([localRepo, remoteRepo], remoteRepo.id, 'runtime:home-mac')
+    ).toBe(remoteRepo)
+  })
+
+  it('opens the selected host and local commands target', () => {
+    const setSettingsSearchQuery = vi.fn()
+    const openSettingsTarget = vi.fn()
+    const openSettingsPage = vi.fn()
+
+    openSetupScriptSettings({
+      repoId: remoteRepo.id,
+      repoHostId: 'runtime:home-mac',
+      setSettingsSearchQuery,
+      openSettingsTarget,
+      openSettingsPage
+    })
+
+    expect(setSettingsSearchQuery).toHaveBeenCalledWith('')
+    expect(openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'repo',
+      repoId: remoteRepo.id,
+      repoHostId: 'runtime:home-mac',
+      sectionId: 'repo-shared-repo-local-commands'
+    })
+    expect(openSettingsPage).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/sidebar/open-setup-script-settings.ts
+++ b/src/renderer/src/components/sidebar/open-setup-script-settings.ts
@@ -1,18 +1,37 @@
 import { getRepositoryLocalCommandsSectionId } from '@/components/settings/repository-settings-targets'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+
+export function findSetupScriptSettingsRepo(
+  repos: readonly Repo[],
+  repoId: string,
+  repoHostId: ExecutionHostId
+): Repo | null {
+  return (
+    repos.find((repo) => repo.id === repoId && getRepoExecutionHostId(repo) === repoHostId) ?? null
+  )
+}
 
 export function openSetupScriptSettings(input: {
   repoId: string
+  repoHostId: ExecutionHostId
   setSettingsSearchQuery: (query: string) => void
-  openSettingsTarget: (target: { pane: 'repo'; repoId: string; sectionId: string }) => void
+  openSettingsTarget: (target: {
+    pane: 'repo'
+    repoId: string
+    repoHostId: ExecutionHostId
+    sectionId: string
+  }) => void
   openSettingsPage: () => void
 }): void {
-  const { openSettingsPage, openSettingsTarget, repoId, setSettingsSearchQuery } = input
+  const { openSettingsPage, openSettingsTarget, repoHostId, repoId, setSettingsSearchQuery } = input
   // Why: imported setup commands are local repo settings; a stale Settings
   // search should not hide the exact editor this action opens.
   setSettingsSearchQuery('')
   openSettingsTarget({
     pane: 'repo',
     repoId,
+    repoHostId,
     sectionId: getRepositoryLocalCommandsSectionId(repoId)
   })
   openSettingsPage()

--- a/src/renderer/src/lib/setup-script-prompt.ts
+++ b/src/renderer/src/lib/setup-script-prompt.ts
@@ -2,7 +2,12 @@ import { getDefaultRepoHookSettings } from '../../../shared/constants'
 import { resolveHookCommandSourcePolicy } from '../../../shared/hook-command-source-policy'
 import type { SetupScriptImportCandidate } from '../../../shared/setup-script-imports'
 import type { Repo, RepoHookSettings } from '../../../shared/types'
-import type { HookCheckResult } from '@/runtime/runtime-hooks-client'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
+import {
+  checkRuntimeHooks,
+  inspectRuntimeSetupScriptImports,
+  type HookCheckResult
+} from '@/runtime/runtime-hooks-client'
 import { isRuntimeScopeForbiddenError } from '@/runtime/runtime-rpc-client'
 
 const SETUP_SCRIPT_PROMPT_DISMISSAL_PREFIX = 'generation-v1:'
@@ -67,6 +72,21 @@ export async function inspectSetupScriptPromptState({
     console.warn('[setup-script-prompt] Failed to inspect setup scripts:', error)
     return { status: 'error', repoId: repo.id }
   }
+}
+
+export function inspectSetupScriptPromptRepo(repo: Repo): Promise<SetupScriptPromptInspection> {
+  const hostId = getRepoExecutionHostId(repo)
+  const parsedHost = parseExecutionHostId(hostId)
+  // Why: prompt inspection must follow the displayed repo, not whichever
+  // runtime or same-id desktop row happens to be focused when the request runs.
+  const runtimeSettings = {
+    activeRuntimeEnvironmentId: parsedHost?.kind === 'runtime' ? parsedHost.environmentId : null
+  }
+  return inspectSetupScriptPromptState({
+    repo,
+    checkHooks: () => checkRuntimeHooks(runtimeSettings, repo.id, hostId),
+    inspectImports: () => inspectRuntimeSetupScriptImports(runtimeSettings, repo.id, hostId)
+  })
 }
 
 export function hasEffectiveSetupCommand(repo: Repo, hooksResult: HookCheckResult): boolean {

--- a/src/renderer/src/runtime/runtime-hooks-client.test.ts
+++ b/src/renderer/src/runtime/runtime-hooks-client.test.ts
@@ -111,6 +111,7 @@ describe('runtime hooks client', () => {
 
   it('forwards an explicit SSH host to local hook IPC', async () => {
     hooksCheck.mockResolvedValue({ hasHooks: false, hooks: null, mayNeedUpdate: false })
+    hooksInspectSetupScriptImports.mockResolvedValue([])
     hooksReadIssueCommand.mockResolvedValue({
       localContent: null,
       sharedContent: null,
@@ -120,6 +121,11 @@ describe('runtime hooks client', () => {
     })
 
     await checkRuntimeHooks({ activeRuntimeEnvironmentId: null }, 'same-repo', 'ssh:server')
+    await inspectRuntimeSetupScriptImports(
+      { activeRuntimeEnvironmentId: null },
+      'same-repo',
+      'ssh:server'
+    )
     await readRuntimeIssueCommand({ activeRuntimeEnvironmentId: null }, 'same-repo', 'ssh:server')
     await writeRuntimeIssueCommand(
       { activeRuntimeEnvironmentId: null },
@@ -129,6 +135,10 @@ describe('runtime hooks client', () => {
     )
 
     expect(hooksCheck).toHaveBeenCalledWith({ repoId: 'same-repo', hostId: 'ssh:server' })
+    expect(hooksInspectSetupScriptImports).toHaveBeenCalledWith({
+      repoId: 'same-repo',
+      hostId: 'ssh:server'
+    })
     expect(hooksReadIssueCommand).toHaveBeenCalledWith({
       repoId: 'same-repo',
       hostId: 'ssh:server'

--- a/src/renderer/src/runtime/runtime-hooks-client.ts
+++ b/src/renderer/src/runtime/runtime-hooks-client.ts
@@ -38,11 +38,12 @@ export async function checkRuntimeHooks(
 
 export async function inspectRuntimeSetupScriptImports(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
-  repoId: string
+  repoId: string,
+  hostId?: ExecutionHostId
 ): Promise<SetupScriptImportCandidate[]> {
   const target = getActiveRuntimeTarget(settings)
   if (target.kind !== 'environment') {
-    return window.api.hooks.inspectSetupScriptImports({ repoId })
+    return window.api.hooks.inspectSetupScriptImports({ repoId, ...(hostId ? { hostId } : {}) })
   }
   return callRuntimeRpc<SetupScriptImportCandidate[]>(
     target,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -732,6 +732,7 @@ export type UISlice = {
   settingsNavigationTarget: {
     pane: SettingsNavTarget
     repoId: string | null
+    repoHostId?: ExecutionHostId
     sectionId?: string
     intent?: 'add-quick-command'
   } | null


### PR DESCRIPTION
## Summary

- scope repository Settings section identities by both repository and execution host, so local and remote copies with the same repo ID no longer share React keys, DOM IDs, or navigation targets
- route project edits, removals, hooks, setup selection, deep links, and Source Control AI navigation through the selected host
- label remote same-name project entries with their host name while preserving legacy local Settings section IDs

Fixes #8566

## Screenshots

Manually verified in the macOS dev app with a deterministic local/remote same-ID fixture: the sidebar showed distinct `Issue 8566 Project` and `Issue 8566 Project · Home Mac` rows, and selecting either rendered exactly one pane with the matching host-specific path.

<img width="6016" height="3194" alt="Remote same-ID project settings selected independently" src="https://github.com/user-attachments/assets/3020a8a8-cb5e-4fe6-ae4b-c4e6eff78fb8" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2,757 files and 29,172 tests passed
- [x] `pnpm build`
- [x] Added focused regressions for host-qualified section identities, duplicate navigation metadata, host-specific setup selection, host-scoped updates/removals, Source Control AI targets, and distinct sidebar rows

## AI Review Report

Reviewed the complete diff and the duplicate-host reproduction path.

- **Cross-platform:** The change is platform-neutral TypeScript/React. It adds no shortcuts, platform labels, shell commands, filesystem path construction, or Electron-specific branching, so macOS, Linux, and Windows behavior remains aligned.
- **Local/SSH/remote:** Section identity and mutation routing use Orca's existing execution-host abstraction, covering local, runtime-server, and SSH-backed repositories. Legacy unqualified IDs prefer the local row for backward compatibility.
- **Agents/integrations/providers:** No agent protocol, Git provider, or integration behavior changes. Existing Source Control AI and setup-script Settings links were updated to preserve the selected host.
- **Performance:** Settings keeps lazy section mounting. Host-qualified hook checks are restricted to mounted repository sections; registry and navigation maps are only derived while Settings is rendered.
- **UI quality:** Uses existing sidebar typography and icon primitives. A concise host label disambiguates remote same-name rows without adding new colors, spacing, shadows, or interaction patterns.
- **Findings addressed:** The review identified host-agnostic mutation routing and hooks caches as secondary collision paths; both now use explicit host-qualified identities and have regression coverage.

## Security Audit

- Repository and host IDs are internal values encoded with `encodeURIComponent` before entering DOM/navigation IDs and decoded defensively.
- No new command execution, dependency, credential, auth, secret, network, or filesystem handling was introduced.
- Existing repository mutation IPC is now more narrowly scoped by explicit execution host, reducing the risk of changing or removing the wrong same-ID project.
- No follow-up security work is required.

## Notes

- Manually verified on macOS in the dev app with local and remote copies sharing one repo ID.
- No provider-specific or Git-version-specific behavior is changed.

## ELI5

Local and remote copies of the same repo shared Settings UI IDs, so clicks and edits could hit the wrong project. Settings now treat repo plus host as the identity, and remote entries show their host name so you can tell them apart.
