### PR TITLE
fix(shortcuts): reserve Cmd/Ctrl+0 for zoom reset

### DIFF
--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -645,6 +645,15 @@ describe('keybindings', () => {
     )
   })
 
+  it('reserves Mod+0 for zoom reset instead of advertising an unreachable worktree-list shortcut', () => {
+    const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
+
+    for (const platform of platforms) {
+      expect(getEffectiveKeybindingsForAction('sidebar.focusWorktreeList', platform)).toEqual([])
+      expect(getEffectiveKeybindingsForAction('zoom.reset', platform)).toEqual(['Mod+0'])
+    }
+  })
+
   it('defines floating workspace panel action metadata', () => {
     const actionIds = [
       'floatingWorkspace.maximize' as KeybindingActionId,

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -426,7 +426,9 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Global',
     scope: 'global',
     searchKeywords: ['shortcut', 'sidebar', 'worktree', 'focus'],
-    defaultBindings: platformBindings(['Mod+0'])
+    // Why: Mod+0 belongs to conventional zoom reset, and no replacement chord
+    // is consistently safe across Orca's desktop platforms and native menus.
+    defaultBindings: platformBindings([])
   },
   {
     id: 'floatingTerminal.toggle',


### PR DESCRIPTION
## Summary

Fixes #8584.

- Reserve `Cmd/Ctrl+0` for the conventional **Reset Size** action.
- Remove the conflicting default from **Focus worktree list**, which could never fire because main-process zoom handling consumed the chord first.
- Leave worktree-list focus explicitly unassigned instead of introducing another default that conflicts with native menus or platform conventions.
- Add regression coverage across macOS, Linux, and Windows.

Users who want a dedicated worktree-list focus shortcut can still assign one in Settings → Shortcuts.

## Screenshots

No visual design change. The existing **Focus worktree list** row now displays **Unassigned**, while **Reset Size** continues to display `⌘0` on macOS and `Ctrl+0` on Linux/Windows.

## Testing

- [x] `pnpm lint` — Node 24.18.0
- [x] `pnpm typecheck` — Node 24.18.0
- [x] `pnpm test` — Node 24.18.0: 2,756 files passed, 29,165 tests passed, 8 files / 42 tests skipped
- [x] `pnpm build` — Node 24.18.0
- [x] Added regression coverage that verifies `zoom.reset` retains `Mod+0` and `sidebar.focusWorktreeList` is unassigned on macOS, Linux, and Windows

Manual macOS verification confirmed that `Cmd+0` still resets zoom and Settings no longer advertises the same chord for worktree-list focus. A proposed `Cmd+Shift+L` replacement was also tested and rejected because it did not reliably reach Orca through native shortcut handling.

## AI Review Report

Reviewed the shared keybinding registry, main-process shortcut resolution order, renderer worktree-list focus handler, terminal behavior, and browser-guest zoom routing.

- **Correctness:** `zoom.reset` remains on the established `Mod+0` default. The shadowed worktree-focus default is removed, so Settings no longer advertises an action that cannot execute.
- **Cross-platform:** the registry change applies consistently to macOS, Linux, and Windows. Platform formatting still renders `⌘0` or `Ctrl+0` through the shared formatter. No hardcoded modifier checks, menu accelerators, paths, or shell behavior were added.
- **Local/SSH/remote:** this changes application-level shortcut metadata only. Local, WSL, SSH, paired, and remote-runtime workspaces use the same registry and are unaffected by execution host.
- **Agents and integrations:** no agent, terminal transport, mobile emulator, integration, or git-provider behavior changed.
- **Electron behavior:** the fix preserves main-process zoom ownership instead of adding a replacement chord that could be intercepted by native menus before renderer handling.
- **Performance:** this removes one static default string and adds no listeners, polling, IPC, allocations, or runtime work.
- **UI quality:** no layout or styling changed. The existing Shortcuts UI already communicates unassigned actions and supports user customization.

No blocking review issue remains.

## Security Audit

The change adds no command execution, input parsing, filesystem or path handling, network access, authentication, secrets, dependencies, IPC channels, or privilege changes. Existing custom keybindings continue through the same normalization, validation, and persistence paths. No security follow-up is needed.

## Notes

- Existing explicit user overrides for **Focus worktree list** are preserved.
- A future default can be considered separately if maintainers identify a safe, intuitive chord across all supported desktop platforms.
