### PR TITLE
fix(terminal): retain pane scale across Agents view

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-font-size-overrides.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-font-size-overrides.ts
@@ -1,0 +1,29 @@
+import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
+
+// Why: moving a live pane into or out of the Agents view remounts TerminalPane.
+// Keep session-only zoom by durable leaf ID so that UI move does not reset it.
+const fontSizeByLeafId = new Map<TerminalLeafId, number>()
+
+export function hydrateTerminalFontSizeOverride(
+  pane: { id: number; leafId: TerminalLeafId },
+  paneFontSizes: Map<number, number>
+): void {
+  const fontSize = fontSizeByLeafId.get(pane.leafId)
+  if (fontSize === undefined) {
+    paneFontSizes.delete(pane.id)
+    return
+  }
+  paneFontSizes.set(pane.id, fontSize)
+}
+
+export function setTerminalFontSizeOverride(leafId: TerminalLeafId, fontSize: number): void {
+  fontSizeByLeafId.set(leafId, fontSize)
+}
+
+export function clearTerminalFontSizeOverride(leafId: TerminalLeafId): void {
+  fontSizeByLeafId.delete(leafId)
+}
+
+export function resetTerminalFontSizeOverridesForTest(): void {
+  fontSizeByLeafId.clear()
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -157,6 +157,10 @@ import {
   resolveTabTitleAfterPaneClose,
   shouldClearLaunchAgentForClosedPane
 } from './terminal-pane-close-identity'
+import {
+  clearTerminalFontSizeOverride,
+  hydrateTerminalFontSizeOverride
+} from './terminal-font-size-overrides'
 
 export function resetTerminalKeyboardProtocolAfterInterrupt(terminal: Terminal): void {
   // Guarded output path so a throwing xterm can't escape the key handler.
@@ -946,6 +950,7 @@ export function useTerminalPaneLifecycle({
     const manager = new PaneManager(container, {
       // `spawnHints.cwd` (from Split actions) lets the new PTY inherit the source pane's cwd — see docs/ssh-split-pane-inherit-cwd.md.
       onPaneCreated: (pane, spawnHints) => {
+        hydrateTerminalFontSizeOverride(pane, paneFontSizesRef.current)
         // OSC 52 — TUI-initiated clipboard writes (Zellij/tmux/nvim/fzf/ssh).
         // Why: read settingsRef at fire time so mid-session gate toggles apply; return true in both paths so xterm doesn't fall through.
         const osc52Disposable = pane.terminal.parser.registerOscHandler(
@@ -1415,6 +1420,7 @@ export function useTerminalPaneLifecycle({
           // Why: revoke only this pane's authority; an exact tombstone blocks queued hooks without suppressing siblings.
           const paneKey = makePaneKey(tabId, leafId)
           useAppStore.getState().retireAgentPaneAuthority(paneKey)
+          clearTerminalFontSizeOverride(leafId)
         }
         if (transport && !isRetiredSurface) {
           if (isDetachedToTab) {
@@ -1823,6 +1829,23 @@ export function useTerminalPaneLifecycle({
       const tabStillExists = Boolean(
         currentWorktreeTabs?.some((candidate) => candidate.id === tabId)
       )
+      if (!tabStillExists) {
+        for (const pane of manager.getPanes()) {
+          const ptyId = paneTransports.get(pane.id)?.getPtyId() ?? null
+          // Why: a mirrored replacement can take ownership during this unmount;
+          // preserve its zoom just as the transport path preserves its PTY.
+          if (
+            !shouldDetachPaneTransportOnUnmount({
+              tabStillExists,
+              tabId,
+              ptyId,
+              worktreeTabs: currentWorktreeTabs
+            })
+          ) {
+            clearTerminalFontSizeOverride(pane.leafId)
+          }
+        }
+      }
       unregisterRuntimeTab()
       if (resizeRaf !== null) {
         cancelAnimationFrame(resizeRaf)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -127,6 +127,10 @@ import { acquireWebviewsDragPassthrough } from '../browser-pane/webview-registry
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { seedStartupSessionRestoredBanner } from './session-restored-banner-pane-state'
+import {
+  clearTerminalFontSizeOverride,
+  hydrateTerminalFontSizeOverride
+} from './terminal-font-size-overrides'
 
 export function recordRuntimeCreatedTerminalPaneSplit(
   createdPane: unknown,
@@ -794,6 +798,7 @@ export function useTerminalPaneLifecycle({
       // Split actions so the new PTY inherits the source pane's live cwd.
       // Split-pane CWD inheritance — see docs/ssh-split-pane-inherit-cwd.md.
       onPaneCreated: (pane, spawnHints) => {
+        hydrateTerminalFontSizeOverride(pane, paneFontSizesRef.current)
         // Install mode 2031 parser handlers before PTY attach so the child's
         // initial CSI ?2031h (sent at startup) is captured.
         const mode2031Disposables = installMode2031Handlers({
@@ -1295,6 +1300,7 @@ export function useTerminalPaneLifecycle({
           clearTerminalPaneUnread(paneKey)
           useAppStore.getState().dropAgentStatus(paneKey)
           useAppStore.getState().clearPaneForegroundAgent(paneKey)
+          clearTerminalFontSizeOverride(leafId)
         }
         if (transport) {
           if (isDetachedToTab) {
@@ -1721,6 +1727,23 @@ export function useTerminalPaneLifecycle({
       const tabStillExists = Boolean(
         currentWorktreeTabs?.some((candidate) => candidate.id === tabId)
       )
+      if (!tabStillExists) {
+        for (const pane of manager.getPanes()) {
+          const ptyId = paneTransports.get(pane.id)?.getPtyId() ?? null
+          // Why: a mirrored replacement can take ownership during this unmount;
+          // preserve its zoom just as the transport path preserves its PTY.
+          if (
+            !shouldDetachPaneTransportOnUnmount({
+              tabStillExists,
+              tabId,
+              ptyId,
+              worktreeTabs: currentWorktreeTabs
+            })
+          ) {
+            clearTerminalFontSizeOverride(pane.leafId)
+          }
+        }
+      }
       unregisterRuntimeTab()
       if (resizeRaf !== null) {
         cancelAnimationFrame(resizeRaf)

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
@@ -1,7 +1,15 @@
 // @vitest-environment happy-dom
 import type * as ReactModule from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import { useTerminalFontZoom } from './useTerminalFontZoom'
+import {
+  hydrateTerminalFontSizeOverride,
+  resetTerminalFontSizeOverridesForTest
+} from './terminal-font-size-overrides'
+
+const TEST_LEAF_ID = '00000000-0000-4000-8000-000000000001' as TerminalLeafId
+const OTHER_TEST_LEAF_ID = '00000000-0000-4000-8000-000000000002' as TerminalLeafId
 
 const mocks = vi.hoisted(() => ({
   captureScrollState: vi.fn(() => ({ wasAtBottom: true })),
@@ -35,6 +43,7 @@ describe('useTerminalFontZoom', () => {
     terminalZoomListeners = []
     document.body.replaceChildren()
     vi.clearAllMocks()
+    resetTerminalFontSizeOverridesForTest()
     vi.stubGlobal('window', {
       api: {
         ui: {
@@ -61,7 +70,7 @@ describe('useTerminalFontZoom', () => {
       containerRef: { current: container },
       managerRef: {
         current: {
-          getActivePane: () => ({ id: 1, terminal })
+          getActivePane: () => ({ id: 1, leafId: TEST_LEAF_ID, terminal })
         }
       } as never,
       paneFontSizesRef: { current: new Map() },
@@ -95,6 +104,22 @@ describe('useTerminalFontZoom', () => {
     expect(mocks.dispatchZoomLevelChanged).toHaveBeenCalledWith('terminal', 107)
   })
 
+  it('retains a pane font override when the pane remounts with a new runtime id', () => {
+    const helper = document.createElement('textarea')
+    helper.className = 'xterm-helper-textarea'
+    const { listener } = useMountedTerminalFontZoom(helper)
+
+    listener('in')
+
+    const remountedFontSizes = new Map<number, number>()
+    hydrateTerminalFontSizeOverride({ id: 9, leafId: TEST_LEAF_ID }, remountedFontSizes)
+    expect(remountedFontSizes.get(9)).toBe(15)
+
+    listener('reset')
+    hydrateTerminalFontSizeOverride({ id: 9, leafId: TEST_LEAF_ID }, remountedFontSizes)
+    expect(remountedFontSizes.has(9)).toBe(false)
+  })
+
   it('only lets the pane owning the focused helper apply terminal font zoom', () => {
     const inactiveContainer = document.createElement('div')
     const activeContainer = document.createElement('div')
@@ -111,7 +136,11 @@ describe('useTerminalFontZoom', () => {
       containerRef: { current: inactiveContainer },
       managerRef: {
         current: {
-          getActivePane: () => ({ id: 1, terminal: inactiveTerminal })
+          getActivePane: () => ({
+            id: 1,
+            leafId: TEST_LEAF_ID,
+            terminal: inactiveTerminal
+          })
         }
       } as never,
       paneFontSizesRef: { current: new Map() },
@@ -122,7 +151,11 @@ describe('useTerminalFontZoom', () => {
       containerRef: { current: activeContainer },
       managerRef: {
         current: {
-          getActivePane: () => ({ id: 2, terminal: activeTerminal })
+          getActivePane: () => ({
+            id: 2,
+            leafId: OTHER_TEST_LEAF_ID,
+            terminal: activeTerminal
+          })
         }
       } as never,
       paneFontSizesRef: { current: new Map() },

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
@@ -4,6 +4,10 @@ import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { overridePendingPaneMetricOptions } from '@/lib/pane-manager/pane-metric-options-deferral'
 import { getPaneOwnedActiveHelperTextarea } from './regular-terminal-focus-ownership'
+import {
+  clearTerminalFontSizeOverride,
+  setTerminalFontSizeOverride
+} from './terminal-font-size-overrides'
 
 type FontZoomDeps = {
   isActive: boolean
@@ -49,12 +53,15 @@ export function useTerminalFontZoom({
       if (direction === 'reset') {
         nextSize = globalSize
         paneFontSizesRef.current.delete(pane.id)
+        clearTerminalFontSizeOverride(pane.leafId)
       } else if (direction === 'in') {
         nextSize = Math.min(MAX_FONT_SIZE, currentSize + FONT_SIZE_STEP)
         paneFontSizesRef.current.set(pane.id, nextSize)
+        setTerminalFontSizeOverride(pane.leafId, nextSize)
       } else {
         nextSize = Math.max(MIN_FONT_SIZE, currentSize - FONT_SIZE_STEP)
         paneFontSizesRef.current.set(pane.id, nextSize)
+        setTerminalFontSizeOverride(pane.leafId, nextSize)
       }
 
       pane.terminal.options.fontSize = nextSize

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
@@ -3,6 +3,10 @@ import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { captureScrollState, restoreScrollState, safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { getPaneOwnedActiveHelperTextarea } from './regular-terminal-focus-ownership'
+import {
+  clearTerminalFontSizeOverride,
+  setTerminalFontSizeOverride
+} from './terminal-font-size-overrides'
 
 type FontZoomDeps = {
   isActive: boolean
@@ -48,12 +52,15 @@ export function useTerminalFontZoom({
       if (direction === 'reset') {
         nextSize = globalSize
         paneFontSizesRef.current.delete(pane.id)
+        clearTerminalFontSizeOverride(pane.leafId)
       } else if (direction === 'in') {
         nextSize = Math.min(MAX_FONT_SIZE, currentSize + FONT_SIZE_STEP)
         paneFontSizesRef.current.set(pane.id, nextSize)
+        setTerminalFontSizeOverride(pane.leafId, nextSize)
       } else {
         nextSize = Math.max(MIN_FONT_SIZE, currentSize - FONT_SIZE_STEP)
         paneFontSizesRef.current.set(pane.id, nextSize)
+        setTerminalFontSizeOverride(pane.leafId, nextSize)
       }
 
       pane.terminal.options.fontSize = nextSize


### PR DESCRIPTION
## Summary

- retain per-pane terminal font zoom by durable terminal leaf ID while a live pane remounts
- restore the zoom override before terminal appearance is applied after moving into or out of the Agents view
- clear overrides when users reset zoom, close panes, or remove tabs while preserving detach/mirrored ownership transfers

Fixes #8516.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — targeted tests pass; the full suite reached 29,137 passing tests but 28 unrelated tests failed because `window.localStorage` is unavailable under the locally installed unsupported Node 26 runtime (the project requires Node 24)
- [x] `pnpm build`
- [x] Added a regression test that zooms a pane, remounts it under a different runtime pane ID, verifies the durable override is restored, and verifies reset clears it

Targeted validation:

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts \
  src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
# 2 files passed, 25 tests passed
```

## AI Review Report

Reviewed the remount, pane-close, tab-close, pane-detach, mirrored replacement, reset, settings-update, and split-pane paths. The main risk was leaking session-only zoom state or clearing it during an ownership transfer; the implementation keys overrides by durable leaf ID, clears true teardown paths, and retains detach/mirror paths.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This change is renderer-only and does not alter shortcuts, shortcut labels, paths, shell commands, or Electron platform-specific behavior. Local, WSL, SSH, and remote-runtime terminals use the same stable leaf identity, so no host-local assumption was introduced. It is agent- and integration-neutral, does not affect Git providers, and adds only constant-time map operations on zoom/remount/teardown paths. No visual styling changed.

## Security Audit

No new input, command execution, path handling, authentication, secret, dependency, network, or IPC surface was added. Cached values originate from Orca's bounded terminal zoom controls and remain renderer-process-local. Overrides are removed on reset and true pane/tab teardown.

## Notes

The override remains session-only, matching existing terminal pane zoom semantics; it is not persisted across app restarts. No platform-specific or SSH-specific follow-up is needed.

## ELI5

Zooming a terminal pane, then switching into or out of the Agents view, used to reset the font size. Orca now remembers each pane's zoom by its terminal ID and restores it after remounts, until you reset zoom or close the pane.
