### PR TITLE
fix(agents): recognize OpenCode native tab titles

### DIFF
--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -258,6 +258,18 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('claude')
   })
 
+  it('uses OpenCode native session titles to replace stale Claude launch identity', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'OC | Understand about the plugin',
+        hookAgent: null,
+        launchAgent: 'claude'
+      })
+    ).toBe('opencode')
+  })
+
   it('does not let an explicit title override launch identity before any activity is observed', () => {
     expect(
       resolveTabAgentFromSignals({

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -14,6 +14,7 @@ export {
   isCursorAgentTitle,
   isCursorNativeAgentTitle,
   isGeminiTerminalTitle,
+  isOpenCodeNativeTitle,
   isPiTerminalTitle,
   STRONG_IDLE_KEYWORDS_RE,
   STRONG_WORKING_KEYWORDS_RE

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -109,6 +109,12 @@ export function isCursorNativeAgentTitle(title: string): boolean {
   return title.trim().toLowerCase() === CURSOR_NATIVE_TITLE_LOWER
 }
 
+// Why: OpenCode abbreviates its native session titles as `OC | …`, which has
+// no agent-name token and otherwise lets stale pane identity paint the tab.
+export function isOpenCodeNativeTitle(title: string): boolean {
+  return /(?:^| \| )OC \| \S/.test(title.trim())
+}
+
 // Why: `cursor` is also an ordinary editor noun that other agents type into their own
 // task-summary titles, so a name token is not identity. Cursor's identifying titles are
 // a closed set (the native literal plus the labels Orca synthesizes from Cursor hooks),

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -112,7 +112,7 @@ export function isCursorNativeAgentTitle(title: string): boolean {
 // Why: OpenCode abbreviates its native session titles as `OC | …`, which has
 // no agent-name token and otherwise lets stale pane identity paint the tab.
 export function isOpenCodeNativeTitle(title: string): boolean {
-  return /(?:^| \| )OC \| \S/.test(title.trim())
+  return /^(?:[^|\s]+ \| )?OC \| \S/.test(title.trim())
 }
 
 // Why: `cursor` is also an ordinary editor noun that other agents type into their own

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -7,6 +7,7 @@ import {
   isClaudeManagementTitle,
   isCursorAgentTitle,
   isGeminiTerminalTitle,
+  isOpenCodeNativeTitle,
   isPiAgentTitle,
   titleHasAgentName
 } from './agent-title-core'
@@ -87,7 +88,7 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
   }
-  if (titleHasAgentName(title, 'opencode')) {
+  if (titleHasAgentName(title, 'opencode') || isOpenCodeNativeTitle(title)) {
     return 'OpenCode'
   }
   if (titleHasAgentName(title, 'mimo')) {

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -47,6 +47,11 @@ export function getAgentLabel(title: string): string | null {
   if (isClaudeManagementTitle(title)) {
     return null
   }
+  // Why: the native marker owns the whole title; its session text may name or
+  // include status glyphs from other agents without changing OpenCode identity.
+  if (isOpenCodeNativeTitle(title)) {
+    return 'OpenCode'
+  }
   // Why: Claude task titles can mention another CLI; the prefix is the identity
   // signal, not arbitrary task text.
   if (
@@ -88,7 +93,7 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
   }
-  if (titleHasAgentName(title, 'opencode') || isOpenCodeNativeTitle(title)) {
+  if (titleHasAgentName(title, 'opencode')) {
     return 'OpenCode'
   }
   if (titleHasAgentName(title, 'mimo')) {

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { isOpenCodeNativeTitle } from './agent-title-core'
+import { getAgentLabel as getSharedAgentLabel } from './agent-title-identity'
 import {
   isClaudeAgent,
   isGrokRotatingWorkingTitle,
@@ -51,12 +53,21 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
     expect(resolveExplicitTerminalTitleAgentType('* Review Codex behavior')).toBeNull()
   })
 
-  it('resolves OpenCode native abbreviated session titles', () => {
+  it('resolves OpenCode native abbreviated session titles before task-text identities', () => {
     expect(resolveExplicitTerminalTitleAgentType('OC | Understand about the plugin')).toBe(
       'opencode'
     )
+    expect(resolveExplicitTerminalTitleAgentType('OC | Compare Codex and Claude')).toBe('opencode')
+    expect(resolveExplicitTerminalTitleAgentType('OC | ✦ Gemini CLI')).toBe('opencode')
+    expect(getSharedAgentLabel('OC | Compare Codex and Claude')).toBe('OpenCode')
+    expect(getSharedAgentLabel('OC | ✦ Gemini CLI')).toBe('OpenCode')
     expect(resolveExplicitTerminalTitleAgentType('tmux | OC | ses_123')).toBe('opencode')
     expect(resolveExplicitTerminalTitleAgentType('oc | Understand about the plugin')).toBeNull()
+  })
+
+  it('does not find an OpenCode marker inside another agent task title', () => {
+    expect(isOpenCodeNativeTitle('⠋ Fix foo | OC | bar')).toBe(false)
+    expect(resolveExplicitTerminalTitleAgentType('⠋ Fix foo | OC | bar')).toBeNull()
   })
 
   it('still resolves Claude when the title explicitly names Claude', () => {

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -51,6 +51,14 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
     expect(resolveExplicitTerminalTitleAgentType('* Review Codex behavior')).toBeNull()
   })
 
+  it('resolves OpenCode native abbreviated session titles', () => {
+    expect(resolveExplicitTerminalTitleAgentType('OC | Understand about the plugin')).toBe(
+      'opencode'
+    )
+    expect(resolveExplicitTerminalTitleAgentType('tmux | OC | ses_123')).toBe('opencode')
+    expect(resolveExplicitTerminalTitleAgentType('oc | Understand about the plugin')).toBeNull()
+  })
+
   it('still resolves Claude when the title explicitly names Claude', () => {
     expect(resolveExplicitTerminalTitleAgentType('. Claude Code compare Opencode')).toBe('claude')
   })

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -124,6 +124,11 @@ export function getAgentLabel(title: string): string | null {
   if (isClaudeManagementTitle(title)) {
     return null
   }
+  // Why: the native marker owns the whole title; its session text may name or
+  // include status glyphs from other agents without changing OpenCode identity.
+  if (isOpenCodeNativeTitle(title)) {
+    return 'OpenCode'
+  }
   // Why: Claude Code title text is often the task title. If that task mentions
   // another CLI, the Claude-specific prefix is the identity signal, not the words.
   if (
@@ -171,7 +176,7 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
   }
-  if (titleHasAgentName(title, 'opencode') || isOpenCodeNativeTitle(title)) {
+  if (titleHasAgentName(title, 'opencode')) {
     return 'OpenCode'
   }
   if (titleHasAgentName(title, 'mimo')) {

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -4,7 +4,7 @@ import {
   HERMES_AGENT_NAME_RE,
   titleHasAgentName
 } from './agent-name-token-match'
-import { isCursorAgentTitle } from './agent-title-core'
+import { isCursorAgentTitle, isOpenCodeNativeTitle } from './agent-title-core'
 import {
   getPiCompatibleSyntheticAgentLabel,
   isLegacyPiCompatibleTitle
@@ -171,7 +171,7 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
   }
-  if (titleHasAgentName(title, 'opencode')) {
+  if (titleHasAgentName(title, 'opencode') || isOpenCodeNativeTitle(title)) {
     return 'OpenCode'
   }
   if (titleHasAgentName(title, 'mimo')) {


### PR DESCRIPTION
## Summary

- recognize OpenCode's native `OC | …` terminal-title format as OpenCode identity
- preserve recognition when a multiplexer prefixes the native title
- let current OpenCode title evidence replace stale Claude launch identity in a reused tab

Fixes #8478.

## Screenshots

**Before:** [issue screenshot](https://github.com/user-attachments/assets/d790a39d-9453-45fe-bbde-66631fb09ae9) shows the Claude glyph on an OpenCode tab.

**After:** manually verified in the macOS dev build by emitting OpenCode's native `OC | Understand about the plugin` OSC title into a terminal with no launch or process identity; the tab rendered the existing OpenCode glyph.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (29,168 passed, 40 skipped)
- [x] `pnpm build`
- [x] Added regression coverage for native and multiplexer-prefixed OpenCode titles, lookalike rejection, and replacement of stale Claude launch identity

## AI Review Report

Reviewed the title-classification and tab-agent precedence paths. CodeRabbit flagged an unanchored false-positive case and native-title precedence when task text names another agent; both were fixed with a start-anchored matcher, negative coverage, and early native-marker resolution in both title classifiers. The matcher is limited to OpenCode's exact uppercase `OC | …` native marker with an optional single-token multiplexer prefix, so ordinary task text and other agents retain their existing classification. The change performs one bounded regex check per terminal-title classification and does not add polling or hot-path allocation beyond the existing title parse.

Cross-platform review covered macOS, Linux, and Windows. The change is platform-neutral and does not touch shortcuts, shortcut labels, paths, shell quoting, or Electron platform branches. SSH/remote behavior was checked explicitly: multiplexer-prefixed titles are covered, and title evidence remains available where local foreground-process probing is intentionally disabled. Existing Claude, Codex, Pi/OMP, Cursor, Gemini, and custom-agent precedence is unchanged. UI review confirmed that this reuses the existing OpenCode glyph without layout, color, spacing, or theme changes.

## Security Audit

Terminal OSC titles are untrusted input. The new handling only applies a fixed, non-backtracking regular expression and maps a match to an existing enum value. It does not render title content as HTML, execute commands, resolve paths, cross IPC/auth boundaries, access credentials, add dependencies, or expose secrets. No follow-up security work is needed.

## Notes

Validated on macOS with OpenCode 1.17.19 and a direct native-title probe. The parsing fix is shared by local, SSH, WSL, and mirrored title consumers.
