### PR TITLE
fix(dev): prevent Electron crash during worktree deletion

### DIFF
--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -110,6 +110,54 @@ function sanitizeMacAppBundleName(value) {
   )
 }
 
+function pruneRemovedWorktreeElectronApps(cacheRoot, currentDistDir) {
+  if (!existsSync(cacheRoot)) {
+    return
+  }
+
+  let runningCommands = ''
+  try {
+    runningCommands = execFileSync('/bin/ps', ['-axo', 'command='], { encoding: 'utf8' })
+  } catch {
+    // Keep stale bundles when process inspection is unavailable rather than
+    // deleting a helper executable that another dev instance may still need.
+    return
+  }
+
+  for (const entry of readdirSync(cacheRoot, { withFileTypes: true })) {
+    const distDir = path.join(cacheRoot, entry.name)
+    if (!entry.isDirectory() || distDir === currentDistDir) {
+      continue
+    }
+
+    try {
+      const marker = JSON.parse(
+        readFileSync(path.join(distDir, 'orca-dev-electron-app.json'), 'utf8')
+      )
+      if (
+        typeof marker.sourceAppPath !== 'string' ||
+        typeof marker.appBundleName !== 'string' ||
+        existsSync(marker.sourceAppPath)
+      ) {
+        continue
+      }
+      const executablePath = path.join(
+        distDir,
+        marker.appBundleName,
+        'Contents',
+        'MacOS',
+        'Electron'
+      )
+      if (runningCommands.includes(executablePath)) {
+        continue
+      }
+      rmSync(distDir, { recursive: true, force: true })
+    } catch {
+      // Only prune cache entries carrying a valid Orca-owned marker.
+    }
+  }
+}
+
 function prepareMacDevElectronApp() {
   if (process.platform !== 'darwin') {
     return
@@ -138,12 +186,17 @@ function prepareMacDevElectronApp() {
     )
     .digest('hex')
     .slice(0, 12)
-  const distDir = path.join(repoRoot, 'out', 'electron-dev', hash)
+  // Why: Orca can delete a worktree while its dev app is still shutting down.
+  // Keep Electron's helper executables outside that worktree so Chromium can
+  // finish teardown without tripping its missing/unexpected-helper CHECK.
+  const cacheRoot = path.join(getDevUserDataPath(), 'electron-dev-apps')
+  const distDir = path.join(cacheRoot, hash)
   // Why: macOS Dock hover uses the bundle's filesystem display name for
   // electron-vite's direct binary launch path, even when Info.plist is patched.
   const appBundleName = `${sanitizeMacAppBundleName(title)}.app`
   const appPath = path.join(distDir, appBundleName)
   const markerPath = path.join(distDir, 'orca-dev-electron-app.json')
+  pruneRemovedWorktreeElectronApps(cacheRoot, distDir)
   // Why: one stable id for every dev instance. Per-instance ids registered a
   // new macOS Notification Settings entry for each branch × Electron version,
   // piling up "Orca: <branch>" rows forever and breaking the notification

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -115,9 +115,11 @@ function pruneRemovedWorktreeElectronApps(cacheRoot, currentDistDir) {
     return
   }
 
-  let runningCommands = ''
+  let runningExecutables = []
   try {
-    runningCommands = execFileSync('/bin/ps', ['-axo', 'command='], { encoding: 'utf8' })
+    runningExecutables = execFileSync('/bin/ps', ['-axo', 'comm='], { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean)
   } catch {
     // Keep stale bundles when process inspection is unavailable rather than
     // deleting a helper executable that another dev instance may still need.
@@ -141,14 +143,15 @@ function pruneRemovedWorktreeElectronApps(cacheRoot, currentDistDir) {
       ) {
         continue
       }
-      const executablePath = path.join(
-        distDir,
-        marker.appBundleName,
-        'Contents',
-        'MacOS',
-        'Electron'
-      )
-      if (runningCommands.includes(executablePath)) {
+      const appPath = path.join(distDir, marker.appBundleName)
+      // Why: Chromium helpers run executables elsewhere in the app bundle and
+      // can outlive the browser briefly, so any live bundle executable protects it.
+      if (
+        runningExecutables.some(
+          (executablePath) =>
+            executablePath === appPath || executablePath.startsWith(`${appPath}${path.sep}`)
+        )
+      ) {
         continue
       }
       rmSync(distDir, { recursive: true, force: true })

--- a/src/main/startup/run-electron-vite-dev.test.ts
+++ b/src/main/startup/run-electron-vite-dev.test.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -350,6 +351,18 @@ describe('run-electron-vite-dev', () => {
       const fakeCliPath = resolve('src/main/startup/__fixtures__/fake-electron-vite-dev-cli.mjs')
       const userDataPath = join(tempDir, 'userData')
       const staleDistDir = join(userDataPath, 'electron-dev-apps', 'removed-worktree')
+      const liveDistDir = join(userDataPath, 'electron-dev-apps', 'live-helper')
+      const liveAppBundleName = 'Orca live.app'
+      const liveHelperPath = join(
+        liveDistDir,
+        liveAppBundleName,
+        'Contents',
+        'Frameworks',
+        'Orca Helper.app',
+        'Contents',
+        'MacOS',
+        'Orca Helper'
+      )
       mkdirSync(staleDistDir, { recursive: true })
       writeFileSync(
         join(staleDistDir, 'orca-dev-electron-app.json'),
@@ -358,6 +371,24 @@ describe('run-electron-vite-dev', () => {
           appBundleName: 'Orca stale.app'
         })
       )
+      mkdirSync(dirname(liveHelperPath), { recursive: true })
+      symlinkSync(process.execPath, liveHelperPath)
+      writeFileSync(
+        join(liveDistDir, 'orca-dev-electron-app.json'),
+        JSON.stringify({
+          sourceAppPath: join(tempDir, 'deleted-live-worktree', 'node_modules', 'electron', 'dist'),
+          appBundleName: liveAppBundleName
+        })
+      )
+      const liveHelper = spawn(liveHelperPath, ['-e', 'setInterval(() => {}, 1000)'], {
+        stdio: 'ignore'
+      })
+      expect(liveHelper.pid).toBeTypeOf('number')
+      processesToCleanUp.add(liveHelper.pid!)
+      await new Promise<void>((resolveSpawn, rejectSpawn) => {
+        liveHelper.once('spawn', resolveSpawn)
+        liveHelper.once('error', rejectSpawn)
+      })
       const baseEnv = devWrapperTestEnv({
         ORCA_DEV_USER_DATA_PATH: userDataPath,
         ORCA_ELECTRON_VITE_CLI: fakeCliPath,
@@ -401,13 +432,12 @@ describe('run-electron-vite-dev', () => {
         return { electronExecPath: envSnapshot.electronExecPath! }
       }
 
-      let distDir: string | null = null
       try {
         const firstRun = await runWrapper('first')
         expect(firstRun.electronExecPath).toContain(join(userDataPath, 'electron-dev-apps'))
         expect(existsSync(staleDistDir)).toBe(false)
+        expect(existsSync(liveDistDir)).toBe(true)
         const appPath = dirname(dirname(dirname(firstRun.electronExecPath)))
-        distDir = dirname(appPath)
         const icuDataPath = join(
           appPath,
           'Contents',
@@ -421,13 +451,20 @@ describe('run-electron-vite-dev', () => {
         rmSync(icuDataPath, { force: true })
         expect(existsSync(icuDataPath)).toBe(false)
 
+        liveHelper.kill('SIGKILL')
+        await waitFor(() => !processExists(liveHelper.pid!))
+        processesToCleanUp.delete(liveHelper.pid!)
+
         const secondRun = await runWrapper('second')
         expect(secondRun.electronExecPath).toBe(firstRun.electronExecPath)
+        expect(existsSync(liveDistDir)).toBe(false)
         expect(existsSync(icuDataPath)).toBe(true)
       } finally {
-        if (distDir) {
-          rmSync(distDir, { recursive: true, force: true })
+        if (liveHelper.pid && processExists(liveHelper.pid)) {
+          liveHelper.kill('SIGKILL')
+          processesToCleanUp.delete(liveHelper.pid)
         }
+        rmSync(tempDir, { recursive: true, force: true })
       }
     },
     30000

--- a/src/main/startup/run-electron-vite-dev.test.ts
+++ b/src/main/startup/run-electron-vite-dev.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { spawn, type ChildProcess } from 'node:child_process'
@@ -335,12 +343,23 @@ describe('run-electron-vite-dev', () => {
   })
 
   it.skipIf(process.platform !== 'darwin')(
-    'rebuilds the copied Electron app when Chromium resources are missing',
+    'stages Electron outside the worktree, prunes stale copies, and rebuilds missing resources',
     async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'orca-dev-wrapper-'))
       const wrapperPath = resolve('config/scripts/run-electron-vite-dev.mjs')
       const fakeCliPath = resolve('src/main/startup/__fixtures__/fake-electron-vite-dev-cli.mjs')
+      const userDataPath = join(tempDir, 'userData')
+      const staleDistDir = join(userDataPath, 'electron-dev-apps', 'removed-worktree')
+      mkdirSync(staleDistDir, { recursive: true })
+      writeFileSync(
+        join(staleDistDir, 'orca-dev-electron-app.json'),
+        JSON.stringify({
+          sourceAppPath: join(tempDir, 'deleted-worktree', 'node_modules', 'electron', 'dist'),
+          appBundleName: 'Orca stale.app'
+        })
+      )
       const baseEnv = devWrapperTestEnv({
+        ORCA_DEV_USER_DATA_PATH: userDataPath,
         ORCA_ELECTRON_VITE_CLI: fakeCliPath,
         ORCA_SKIP_DEV_CLI_PREPARE: '1',
         ORCA_SKIP_DEV_WEB_PREPARE: '1',
@@ -385,6 +404,8 @@ describe('run-electron-vite-dev', () => {
       let distDir: string | null = null
       try {
         const firstRun = await runWrapper('first')
+        expect(firstRun.electronExecPath).toContain(join(userDataPath, 'electron-dev-apps'))
+        expect(existsSync(staleDistDir)).toBe(false)
         const appPath = dirname(dirname(dirname(firstRun.electronExecPath)))
         distDir = dirname(appPath)
         const icuDataPath = join(
@@ -420,10 +441,12 @@ describe('run-electron-vite-dev', () => {
       const envFile = join(tempDir, 'env.json')
       const wrapperPath = resolve('config/scripts/run-electron-vite-dev.mjs')
       const fakeCliPath = resolve('src/main/startup/__fixtures__/fake-electron-vite-dev-cli.mjs')
+      const userDataPath = join(tempDir, 'userData')
 
       const wrapper = spawn(process.execPath, [wrapperPath, '--remote-debugging-port=9448'], {
         cwd: resolve('.'),
         env: devWrapperTestEnv({
+          ORCA_DEV_USER_DATA_PATH: userDataPath,
           ORCA_ELECTRON_VITE_CLI: fakeCliPath,
           ORCA_SKIP_DEV_CLI_PREPARE: '1',
           ORCA_SKIP_DEV_WEB_PREPARE: '1',


### PR DESCRIPTION
## Summary

- Stage custom macOS dev Electron bundles under Orca's dev user-data directory instead of inside the worktree that owns the running app.
- Prevent Chromium's helper-executable validation from trapping when that worktree is deleted during asynchronous Electron shutdown.
- Prune cached bundles from removed worktrees only after no running process references their Electron executable.

Fixes #8594

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2,756 files passed; 29,164 tests passed
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Regression coverage verifies that the copied Electron bundle is staged under isolated user data rather than the worktree, removed-worktree cache entries are pruned, missing Chromium resources still force a rebuild, and framework symlinks remain valid.

## AI Review Report

Reviewed the shutdown race, cache lifecycle, and affected platform boundaries.

- **Cross-platform:** The behavior remains behind the existing macOS runtime guard. Linux and Windows startup, shell behavior, shortcuts, labels, and Electron executable selection are unchanged. New paths use `path.join`.
- **Local / SSH / remote:** This changes only local macOS `pnpm dev` app staging. Production worktree removal, Git commands, SSH worktrees, WSL, and remote runtime behavior are unchanged.
- **Agents / integrations / providers:** No agent launch, terminal protocol, integration, or Git-provider behavior changes.
- **Performance:** Cache inspection runs once at macOS dev startup, outside hot paths. It performs one fixed `ps` query and scans only Orca-owned dev bundle cache entries.
- **UI quality:** No UI or interaction changes.
- **Risk found and addressed:** Moving bundles outside worktrees could leave stale copies. The implementation prunes only marked cache directories whose source bundle is gone, and preserves any bundle whose executable still appears in the running process list. Inspection failures keep data rather than risking deletion of a live bundle.

## Security Audit

- The process query uses `execFileSync` with a fixed `/bin/ps` executable and fixed arguments; no shell or user-controlled command interpolation is involved.
- Recursive deletion is restricted to direct directories beneath Orca's dev bundle cache and requires a parseable Orca marker. Symlink entries are not treated as directories.
- Marker paths are used only for existence and live-process checks; the deletion target remains the already-enumerated cache directory.
- No authentication, secrets, network requests, dependencies, renderer IPC, or production data paths are added or changed.
- No follow-up security work identified.

## Notes

- macOS dev-only fix; production builds and non-macOS development flows are unchanged.
- Root cause was confirmed by symbolizing two matching Electron 43.1.0 crash reports: the browser process trapped in `ElectronBrowserClient::AppendExtraCommandLineSwitches` after the in-worktree helper bundle had been removed.

## ELI5

In dev mode on Mac, deleting a worktree while Electron was still shutting down could crash the app, because Chromium still pointed at files inside that worktree. Custom Electron bundles are now staged outside the worktree and only cleaned up when nothing is still using them.
