### PR TITLE
Fix diff routing to follow the worktree owner, not the global default runtime (#8484)

### DIFF
--- a/src/renderer/src/lib/worktree-runtime-owner-host-split.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-host-split.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getExecutionHostIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree,
+  type WorktreeRuntimeOwnerState
+} from './worktree-runtime-owner'
+
+// Repro + regression guard for #8484: the same project is registered on BOTH
+// local desktop and a paired runtime. Two repo records share the repoId; each
+// host's worktree lives at a distinct filesystem path and (as with legacy /
+// pre-project-host metadata) carries no explicit hostId. Diff routing must
+// follow the worktree's owning host, not the global default runtime.
+const LOCAL_WORKTREE = 'proj::/Users/me/GitHub/.orca-worktrees/proj-wt'
+const RUNTIME_WORKTREE = 'proj::/home/user/orca-worktrees/proj-wt'
+
+function buildHostSplitState(
+  activeRuntimeEnvironmentId: string | null,
+  repoOrder: 'local-first' | 'legacy-first'
+): WorktreeRuntimeOwnerState {
+  const localRepo = {
+    id: 'proj',
+    connectionId: null,
+    executionHostId: 'local' as const,
+    path: '/Users/me/GitHub/proj'
+  }
+  const runtimeRepo = {
+    id: 'proj',
+    connectionId: null,
+    executionHostId: 'runtime:env-1' as const,
+    path: '/home/user/proj'
+  }
+  const legacyRepo = { id: 'proj', connectionId: null, executionHostId: null, path: '' }
+  const repos =
+    repoOrder === 'local-first' ? [localRepo, runtimeRepo] : [legacyRepo, localRepo, runtimeRepo]
+  return {
+    settings: { activeRuntimeEnvironmentId },
+    repos,
+    worktreesByRepo: {
+      proj: [
+        { id: LOCAL_WORKTREE, repoId: 'proj' },
+        { id: RUNTIME_WORKTREE, repoId: 'proj' }
+      ]
+    }
+  }
+}
+
+describe('#8484 diff routing follows the worktree owner, not the global default', () => {
+  it('routes each host-split worktree by its own path while the runtime is default', () => {
+    const state = buildHostSplitState('env-1', 'local-first')
+    expect(getRuntimeEnvironmentIdForWorktree(state, LOCAL_WORKTREE)).toBeNull()
+    expect(getExecutionHostIdForWorktree(state, LOCAL_WORKTREE)).toBe('local')
+    expect(getRuntimeEnvironmentIdForWorktree(state, RUNTIME_WORKTREE)).toBe('env-1')
+    expect(getExecutionHostIdForWorktree(state, RUNTIME_WORKTREE)).toBe('runtime:env-1')
+  })
+
+  it('routes each host-split worktree by its own path while local is default', () => {
+    const state = buildHostSplitState(null, 'local-first')
+    expect(getRuntimeEnvironmentIdForWorktree(state, LOCAL_WORKTREE)).toBeNull()
+    expect(getRuntimeEnvironmentIdForWorktree(state, RUNTIME_WORKTREE)).toBe('env-1')
+  })
+
+  it('still resolves the runtime worktree past a legacy null-host record for the same repoId', () => {
+    const localDefault = buildHostSplitState(null, 'legacy-first')
+    expect(getRuntimeEnvironmentIdForWorktree(localDefault, LOCAL_WORKTREE)).toBeNull()
+    expect(getRuntimeEnvironmentIdForWorktree(localDefault, RUNTIME_WORKTREE)).toBe('env-1')
+
+    const runtimeDefault = buildHostSplitState('env-1', 'legacy-first')
+    // The local worktree must stay local even when the runtime is the global default.
+    expect(getRuntimeEnvironmentIdForWorktree(runtimeDefault, LOCAL_WORKTREE)).toBeNull()
+    expect(getExecutionHostIdForWorktree(runtimeDefault, LOCAL_WORKTREE)).toBe('local')
+    expect(getRuntimeEnvironmentIdForWorktree(runtimeDefault, RUNTIME_WORKTREE)).toBe('env-1')
+  })
+
+  it('an explicit worktree hostId still wins over path inference', () => {
+    const state = buildHostSplitState('env-1', 'local-first')
+    const withHostId: WorktreeRuntimeOwnerState = {
+      ...state,
+      worktreesByRepo: {
+        proj: [
+          { id: LOCAL_WORKTREE, repoId: 'proj', hostId: 'runtime:env-1' },
+          { id: RUNTIME_WORKTREE, repoId: 'proj', hostId: 'local' }
+        ]
+      }
+    }
+    expect(getRuntimeEnvironmentIdForWorktree(withHostId, LOCAL_WORKTREE)).toBe('env-1')
+    expect(getRuntimeEnvironmentIdForWorktree(withHostId, RUNTIME_WORKTREE)).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/worktree-runtime-owner-index.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.ts
@@ -1,7 +1,8 @@
 import type { FolderWorkspace, ProjectGroup, Repo, Worktree } from '../../../shared/types'
 
 type WorktreeOwnerRecord = Pick<Worktree, 'id' | 'repoId' | 'hostId'>
-type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> &
+  Partial<Pick<Repo, 'path'>>
 type FolderWorkspaceOwnerRecord = Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'>
 type ProjectGroupOwnerRecord = Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>
 
@@ -11,9 +12,11 @@ const worktreeOwnerIndexCache = new WeakMap<
   Record<string, readonly WorktreeOwnerRecord[]>,
   ReadonlyMap<string, WorktreeOwnerRecord>
 >()
+// Why: a project shared across hosts has several repo records under one id, so
+// the repo index groups every record per id (built once per immutable array).
 const repoOwnerIndexCache = new WeakMap<
   readonly RepoOwnerRecord[],
-  ReadonlyMap<string, RepoOwnerRecord>
+  ReadonlyMap<string, readonly RepoOwnerRecord[]>
 >()
 const folderWorkspaceOwnerIndexCache = new WeakMap<
   readonly FolderWorkspaceOwnerRecord[],
@@ -72,11 +75,36 @@ export function findIndexedWorktreeOwner(
   return index.get(worktreeId) ?? null
 }
 
-export function findIndexedRepoOwner(
+function getRepoOwnerIndex(
+  repos: readonly RepoOwnerRecord[]
+): ReadonlyMap<string, readonly RepoOwnerRecord[]> {
+  let index = repoOwnerIndexCache.get(repos)
+  if (!index) {
+    const next = new Map<string, RepoOwnerRecord[]>()
+    for (const record of repos) {
+      const recordId = record.id
+      const existing = next.get(recordId)
+      if (existing) {
+        existing.push(record)
+      } else {
+        next.set(recordId, [record])
+      }
+    }
+    index = next
+    repoOwnerIndexCache.set(repos, index)
+  }
+  return index
+}
+
+export function findIndexedRepoOwners(
   repos: readonly RepoOwnerRecord[] | undefined,
   repoId: string
-): RepoOwnerRecord | null {
-  return findIndexedOwnerRecord(repos, repoId, repoOwnerIndexCache)
+): readonly RepoOwnerRecord[] {
+  if (!repos) {
+    return []
+  }
+  // The first entry preserves the prior Array.find "first matching id" behavior.
+  return getRepoOwnerIndex(repos).get(repoId) ?? []
 }
 
 export function findIndexedFolderWorkspaceOwner(

--- a/src/renderer/src/lib/worktree-runtime-owner-repo-match.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-repo-match.ts
@@ -1,0 +1,54 @@
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import type { Repo } from '../../../shared/types'
+import { splitWorktreeId } from '../../../shared/worktree-id'
+import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
+import { findIndexedRepoOwners } from './worktree-runtime-owner-index'
+
+type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> &
+  Partial<Pick<Repo, 'path'>>
+
+function countSharedPathSegments(repoPath: string, worktreePath: string): number {
+  const repoSegments = normalizeRuntimePathForComparison(repoPath).split('/').filter(Boolean)
+  const worktreeSegments = normalizeRuntimePathForComparison(worktreePath)
+    .split('/')
+    .filter(Boolean)
+  let shared = 0
+  const limit = Math.min(repoSegments.length, worktreeSegments.length)
+  while (shared < limit && repoSegments[shared] === worktreeSegments[shared]) {
+    shared += 1
+  }
+  return shared
+}
+
+// Why: one project can be registered on both local and a paired runtime under a
+// shared repoId (#8484). When a worktree carries no explicit hostId, resolve the
+// owning repo record by the worktree's own filesystem path so it routes to the
+// host that owns it, not the first-indexed record or the global default runtime.
+export function findRepoOwnerRecordForWorktree(
+  repos: readonly RepoOwnerRecord[] | undefined,
+  worktreeId: string,
+  repoId: string
+): RepoOwnerRecord | null {
+  const matches = findIndexedRepoOwners(repos, repoId)
+  if (matches.length <= 1) {
+    return matches[0] ?? null
+  }
+  const worktreePath = splitWorktreeId(worktreeId)?.worktreePath?.trim()
+  if (worktreePath) {
+    const scored = matches
+      .map((repo) => ({
+        repo,
+        score: repo.path?.trim() ? countSharedPathSegments(repo.path, worktreePath) : 0
+      }))
+      .filter((entry) => entry.score > 0)
+    const topScore = scored.reduce((max, entry) => Math.max(max, entry.score), 0)
+    const leaders = scored.filter((entry) => entry.score === topScore)
+    const leaderHostIds = new Set(leaders.map((entry) => getRepoExecutionHostId(entry.repo)))
+    // Only trust the path match when it points at a single host; a cross-host
+    // tie stays ambiguous and defers to the prior first-indexed behavior.
+    if (leaders.length > 0 && leaderHostIds.size === 1) {
+      return leaders[0].repo
+    }
+  }
+  return matches[0] ?? null
+}

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -17,14 +17,15 @@ import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
 import {
   findIndexedFolderWorkspaceOwner,
   findIndexedProjectGroupOwner,
-  findIndexedRepoOwner as findRepoRecord,
   findIndexedWorktreeOwner as findWorktreeRecord
 } from './worktree-runtime-owner-index'
+import { findRepoOwnerRecordForWorktree } from './worktree-runtime-owner-repo-match'
 
 type RuntimeExecutionHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
 
 export type WorktreeRuntimeOwnerState = {
-  repos?: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
+  repos?: readonly (Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> &
+    Partial<Pick<Repo, 'path'>>)[]
   settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
   worktreesByRepo?: Record<string, readonly Pick<Worktree, 'id' | 'repoId' | 'hostId'>[]>
   folderWorkspaces?: readonly Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'>[]
@@ -170,7 +171,7 @@ export function getRuntimeEnvironmentIdForWorktree(
     return worktreeRuntimeEnvironmentId
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = findRepoRecord(state.repos, repoId)
+  const repo = findRepoOwnerRecordForWorktree(state.repos, worktreeId, repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
@@ -198,7 +199,7 @@ export function getExplicitRuntimeEnvironmentIdForWorktree(
     return getExplicitRuntimeEnvironmentIdFromHost(worktree.hostId)
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = findRepoRecord(state.repos, repoId)
+  const repo = findRepoOwnerRecordForWorktree(state.repos, worktreeId, repoId)
   if (!repo) {
     return null
   }
@@ -264,7 +265,7 @@ export function getExecutionHostIdForWorktree(
     return worktreeHostId
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = findRepoRecord(state.repos, repoId)
+  const repo = findRepoOwnerRecordForWorktree(state.repos, worktreeId, repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     return getRepoExecutionHostId(repo)

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -456,7 +456,9 @@ describe('createEditorSlice openDiff', () => {
     expect(store.getState().openFiles).toEqual([
       expect.objectContaining({
         id: 'wt-1::diff::unstaged::file.ts',
-        runtimeEnvironmentId: undefined
+        // A worktree with no explicit runtime owner stamps `null` (local), which
+        // routes to local IPC instead of the global default runtime (#8484).
+        runtimeEnvironmentId: null
       }),
       expect.objectContaining({
         id: 'editor-diff:wt-1:env-1:unstaged:file.ts',
@@ -496,6 +498,40 @@ describe('createEditorSlice openDiff', () => {
         runtimeEnvironmentId: 'env-1'
       })
     )
+  })
+
+  it('routes host-split diffs by the worktree owner, not the global default runtime (#8484)', () => {
+    const store = createEditorStore()
+    // Same project registered on both local and a paired runtime under one
+    // repoId; each host's worktree carries no explicit hostId (legacy metadata).
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as unknown as AppState['settings'],
+      repos: [
+        { id: 'proj', executionHostId: 'local', path: '/Users/me/proj' },
+        { id: 'proj', executionHostId: 'runtime:env-1', path: '/srv/proj' }
+      ] as unknown as AppState['repos'],
+      worktreesByRepo: {
+        proj: [
+          { id: 'proj::/Users/me/proj-wt', repoId: 'proj' },
+          { id: 'proj::/srv/proj-wt', repoId: 'proj' }
+        ]
+      } as unknown as AppState['worktreesByRepo']
+    })
+
+    store
+      .getState()
+      .openDiff('proj::/Users/me/proj-wt', '/Users/me/proj-wt/a.ts', 'a.ts', 'typescript', false)
+    store
+      .getState()
+      .openDiff('proj::/srv/proj-wt', '/srv/proj-wt/a.ts', 'a.ts', 'typescript', false)
+
+    const byWorktree = Object.fromEntries(
+      store.getState().openFiles.map((file) => [file.worktreeId, file.runtimeEnvironmentId])
+    )
+    // Local worktree stays local even though the runtime is the global default.
+    expect(byWorktree['proj::/Users/me/proj-wt']).toBeNull()
+    // Runtime worktree routes to its owner rather than falling to the default.
+    expect(byWorktree['proj::/srv/proj-wt']).toBe('env-1')
   })
 
   it('repairs an existing diff tab entry to the correct mode and staged state', () => {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -335,9 +335,11 @@ function resolveDiffRuntimeEnvironmentId(
   if (explicitRuntimeEnvironmentId !== undefined) {
     return explicitRuntimeEnvironmentId
   }
-  // Why: Source Control callers often know only the worktree. Runtime-host
-  // diffs still need their owner stamped so content loads through runtime RPC.
-  return getRuntimeEnvironmentIdForWorktree(state, worktreeId) ?? undefined
+  // Why: Source Control callers often know only the worktree. Stamp the
+  // worktree's resolved owner verbatim — a `null` owner means explicit local,
+  // so it must not collapse to `undefined` (which routes to the global default
+  // runtime) when a runtime is the default and the worktree is local (#8484).
+  return getRuntimeEnvironmentIdForWorktree(state, worktreeId)
 }
 
 export type PendingEditorReveal = {


### PR DESCRIPTION
## Summary

When the same Git project is set up on **both** a local host and a paired remote Orca runtime, the built-in diff viewer routed file/diff requests by the global **Settings → Remote Orca Servers → Advanced → Default runtime** value instead of the **selected worktree's owning host**. This made local and remote diffs mutually exclusive: whichever host was the global default worked, and the worktree on the other host failed (`fs:readFile` "Access denied" one way, `RuntimeRpcCallError: selector_not_found` the other). Fixes #8484.

Diffs now route by the worktree's owner; the global default is used only as a genuine last resort.

### Root cause (two layers)

1. **Host-blind repo resolution.** A project shared across hosts has multiple `repos` records under one `repoId` (one per host — see also #8566). When a worktree had no explicit `hostId` (common for legacy / pre-project-host metadata), `getRuntimeEnvironmentIdForWorktree` looked the repo up by bare `repoId` via an index that returns the *first* record, so it matched the wrong host's record or fell through to the global `activeRuntimeEnvironmentId`.
2. **`null` → `undefined` collapse.** `resolveDiffRuntimeEnvironmentId` did `getRuntimeEnvironmentIdForWorktree(...) ?? undefined`, turning an explicit-local `null` owner into `undefined` — which `settingsForRuntimeOwner` treats as "use the global default." So even a correctly-resolved local worktree routed to the default runtime.

### Fix

- New `worktree-runtime-owner-repo-match.ts`: when a worktree lacks a `hostId` and its `repoId` spans multiple host records, pick the owning repo by the worktree's own filesystem path (longest shared path-segment prefix, via the existing `normalizeRuntimePathForComparison`). A cross-host tie stays ambiguous and defers to the prior first-indexed behavior. Single-host resolution is byte-for-byte unchanged.
- `worktree-runtime-owner-index.ts`: the repo index is made group-aware (records-per-id, built once per immutable array) so the new lookup stays O(1) for the common single-host case, preserving the existing perf guard.
- `worktree-runtime-owner.ts`: all three resolvers now go through the host-aware helper.
- `editor.ts`: `resolveDiffRuntimeEnvironmentId` stamps the resolved owner verbatim (preserving `null` = explicit local), matching how the edit-file path already treats `null`.

## Screenshots

No standalone visual change (routing/behavioral fix). Validated live in a running Orca dev build (see Testing → Live app): driving the real `openDiff` action on a host-split store, the local worktree stamps `runtimeEnvironmentId: null` (→ local IPC) and the runtime worktree stamps the runtime id (→ runtime RPC) — both correct in the same session, no toggling of the default runtime.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — ran the directly-affected suites (owner resolution, `repos*` host suites, `editor`, `useEditorPanelContentState`, `runtime/`, `components/editor/`): ~1,450 tests green. Full suite runs in CI.
- [x] `pnpm build`
- [x] Added high-quality regression tests
- [x] **Live app (Electron, CDP)** — launched a dev build from this branch and drove the real `openDiff` store action against an injected host-split state (same `repoId` on local + a runtime, hostless worktrees, runtime as the global default). Result: local worktree → `runtimeEnvironmentId: null`; runtime worktree → the runtime id; no errors. This exercises the actual bundled fix through the real diff-open path.

### Tests added
- `worktree-runtime-owner-host-split.test.ts` — reproduces both failing directions and asserts each worktree routes by its owning host regardless of the global default; verifies an explicit worktree `hostId` still wins over path inference.
- `editor.test.ts` — a store-level `openDiff` integration case that drives the real action with a host-split store and asserts the local worktree stamps `null` (local) and the runtime worktree stamps the runtime id.

## AI Review Report

Ran `/code-review high` (8 finder angles) over the diff. Main risks checked: inverted/wrong owner resolution, removed-guard regressions in the index change, cross-file callers of the changed index/resolver functions, and the `null`-vs-`undefined` semantic change in `editor.ts`.

Flagged and resolved:
- **Dead code** — `findIndexedRepoOwner` became unused after the swap; removed it.
- **Known limitation (documented, not a regression)** — if both hosts use identical absolute path roots (e.g. a self-paired runtime on the same machine), the path score ties and resolution falls back to the prior first-indexed record. Degrades to today's behavior for that sub-case rather than regressing. Worktrees in that setup typically still carry an explicit `hostId`, which wins before path inference.

No correctness regressions found. Verified the single-host path is unchanged (`matches.length <= 1 → matches[0]`), tab identity is unchanged (`buildDiffEditorFileId` maps both `null` and `undefined` to the same legacy id), and owner-matching (`runtimeOwnerKey`) treats `null`/`undefined` identically.

**Cross-platform (macOS/Linux/Windows):** path comparison uses the shared `normalizeRuntimePathForComparison` (normalizes separators, lower-cases Windows drive paths) and splits only after normalization — no hardcoded `/`. SSH/runtime paths are POSIX and handled the same way. No shortcuts, labels, or shell behavior touched.

## Security Audit

Low risk. This is pure in-renderer owner-resolution logic — no new input handling, command execution, secrets, auth, or IPC surface. Path strings are compared (segment prefix) but never executed or used to read files directly; the resolved owner only selects an already-authorized IPC/RPC channel. No dependency changes. No follow-up needed.

## Notes

- **Validated live** in a running dev build via the Electron/CDP skill — the host-split routing *decision* (the exact defect) is proven in the real bundled code, not just unit tests.
- **Remaining gap:** did not render actual two-host diff *content* on screen. The only reachable paired runtime in the test environment was self-paired on the same machine (identical paths → the documented tie edge, and its worktrees carry explicit `hostId`), so it doesn't exercise cross-host path disambiguation with rendered remote content.
- Related: #6440 / #6562 / #6942 (prior remote file/diff routing fixes) and #8566 (same shared-`repo.id` across hosts model).
