### PR TITLE
fix(serve): honor explicit --port over persisted mobile-ws fallback (#8535)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2091,6 +2091,10 @@ app.whenReady().then(async () => {
     ...(isE2E ? { wsPort: 0 } : {}),
     ...(devWsPort !== undefined ? { wsPort: devWsPort } : {}),
     ...(serveOptions?.wsPort !== undefined ? { wsPort: serveOptions.wsPort } : {}),
+    // Why: only an explicit `orca serve --port <P>` may override a persisted
+    // mobile-ws fallback port (#8535). isE2E/devWsPort are internal, not user
+    // pins, so they keep the default STA-1511 fallback behavior.
+    wsPortExplicit: serveOptions?.wsPort !== undefined,
     webClientRoot: getBundledWebClientRoot()
   })
   registerMobileHandlers(runtimeRpc)

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -2,7 +2,7 @@
 import { existsSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { createConnection, type Socket } from 'node:net'
+import { createConnection, createServer, type Socket } from 'node:net'
 import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 import WebSocket from 'ws'
@@ -24,6 +24,7 @@ import {
 } from '../../shared/terminal-stream-protocol'
 import { decrypt, deriveSharedKey, encrypt, generateKeyPair } from './rpc/e2ee-crypto'
 import { DeviceRegistry } from './device-registry'
+import { writeWsFallbackPort } from './rpc/ws-fallback-port-store'
 
 vi.mock('../git/worktree', () => ({
   listWorktrees: vi.fn().mockResolvedValue([
@@ -365,6 +366,75 @@ describe('OrcaRuntimeRpcServer', () => {
     }
 
     await server.stop()
+  })
+
+  // Why: an explicitly pinned `orca serve --port <P>` must win over a persisted
+  // mobile-ws fallback port (STA-1511) — otherwise the fallback is bound FIRST
+  // and silently overrides the port the operator asked for (#8535).
+  describe('explicit --port vs persisted mobile-ws fallback (#8535)', () => {
+    async function reserveFreePort(): Promise<number> {
+      return await new Promise<number>((resolve, reject) => {
+        const probe = createServer()
+        probe.once('error', reject)
+        // Why: bind 0.0.0.0 to match the WebSocket transport's bind host, so a
+        // port free here is actually free when the transport claims it.
+        probe.listen(0, '0.0.0.0', () => {
+          const address = probe.address()
+          const port = typeof address === 'object' && address ? address.port : 0
+          probe.close(() => resolve(port))
+        })
+      })
+    }
+
+    it('binds the explicitly pinned port instead of a persisted fallback', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const pinnedPort = await reserveFreePort()
+      const fallbackPort = await reserveFreePort()
+      expect(pinnedPort).not.toBe(fallbackPort)
+      // A prior session persisted a fallback port; without the fix the transport
+      // binds it BEFORE the explicitly pinned port and strands the pin.
+      writeWsFallbackPort(userDataPath, fallbackPort)
+
+      const runtime = new OrcaRuntimeService()
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        enableWebSocket: true,
+        wsPort: pinnedPort,
+        wsPortExplicit: true
+      })
+
+      try {
+        await server.start()
+        expect(server['wsTransport']?.resolvedPort).toBe(pinnedPort)
+      } finally {
+        await server.stop()
+      }
+    })
+
+    it('still honors a persisted fallback for a non-explicit (default) port', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const preferredPort = await reserveFreePort()
+      const fallbackPort = await reserveFreePort()
+      expect(preferredPort).not.toBe(fallbackPort)
+      writeWsFallbackPort(userDataPath, fallbackPort)
+
+      const runtime = new OrcaRuntimeService()
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        enableWebSocket: true,
+        wsPort: preferredPort
+        // wsPortExplicit omitted → false: the STA-1511 fallback still applies.
+      })
+
+      try {
+        await server.start()
+        expect(server['wsTransport']?.resolvedPort).toBe(fallbackPort)
+      } finally {
+        await server.stop()
+      }
+    })
   })
 
   it('includes a web client URL when the web bundle is served by the runtime', async () => {

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -36,6 +36,11 @@ type OrcaRuntimeRpcServerOptions = {
   platform?: NodeJS.Platform
   enableWebSocket?: boolean
   wsPort?: number
+  // Why: true only when the port came from an explicit `orca serve --port <P>`.
+  // An explicit pin must NOT be pre-empted by a persisted mobile-ws fallback
+  // port (#8535), so the raw explicit signal is threaded here to gate that.
+  // Defaults to false, so the internal default port keeps STA-1511 behavior.
+  wsPortExplicit?: boolean
   webClientRoot?: string
   // Why: test-only overrides for the two time-bound constants below.
   // Production callers must not pass these — defaults are set by the design
@@ -400,6 +405,7 @@ export class OrcaRuntimeRpcServer {
   private readonly platform: NodeJS.Platform
   private readonly enableWebSocket: boolean
   private readonly wsPort: number
+  private readonly wsPortExplicit: boolean
   private readonly webClientRoot: string | undefined
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
@@ -437,6 +443,7 @@ export class OrcaRuntimeRpcServer {
     platform = process.platform,
     enableWebSocket = false,
     wsPort = DEFAULT_WS_PORT,
+    wsPortExplicit = false,
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
     longPollCap = LONG_POLL_CAP
@@ -448,6 +455,7 @@ export class OrcaRuntimeRpcServer {
     this.platform = platform
     this.enableWebSocket = enableWebSocket
     this.wsPort = wsPort
+    this.wsPortExplicit = wsPortExplicit
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
     this.longPollCap = longPollCap
@@ -711,8 +719,11 @@ export class OrcaRuntimeRpcServer {
           // devices' stored endpoints stay valid (STA-1511) — the transport
           // binds a persisted fallback before the preferred port. wsPort 0
           // means the caller explicitly wants a random port (E2E) — don't
-          // pin it.
-          ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {})
+          // pin it. An explicit `--port` pin (#8535) likewise skips the
+          // fallback so the pinned port is never pre-empted by it.
+          ...(this.wsPort !== 0 && !this.wsPortExplicit
+            ? { fallbackPort: readWsFallbackPort(this.userDataPath) }
+            : {})
         })
         this.wsTransport = wsTransport
 
@@ -795,7 +806,10 @@ export class OrcaRuntimeRpcServer {
         })
 
         await wsTransport.start()
-        if (this.wsPort !== 0 && wsTransport.resolvedPort !== this.wsPort) {
+        // Why: only persist a fallback when the runtime picked a port itself.
+        // An explicit `--port` pin (#8535) must never write a fallback it will
+        // then ignore on the next launch.
+        if (this.wsPort !== 0 && !this.wsPortExplicit && wsTransport.resolvedPort !== this.wsPort) {
           writeWsFallbackPort(this.userDataPath, wsTransport.resolvedPort)
         }
         activeTransports.push(wsTransport)


### PR DESCRIPTION
## Summary

An explicitly pinned `orca serve --port <P>` now deterministically binds `<P>`. Previously a persisted mobile-ws fallback port (STA-1511, written to `<userData>/mobile-ws-fallback-port.json`) was bound **before** the pinned port (`candidatePorts = [fallback, pinned]`). Once that file recorded a stale port, every later `serve` bound the stale port and never attempted `<P>` — stranding already-paired clients that dial the pinned port, and breaking any health check or SSH tunnel targeting it. There was no CLI way to force the pinned port.

## Screenshots

No visual change — headless `serve` WebSocket transport behavior only.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — added `#8535` regression tests (2 passed, Node 24)
- [x] `pnpm build` — `build:desktop` passed (typecheck + relay + cli + electron-vite + web); `build:native` not run locally (no native code touched by this change)
- [x] Added high-quality regression tests: with a persisted fallback present, an explicit `--port` binds the **pinned** port; the default/unpinned case still honors the persisted fallback. Verified load-bearing — reverting only the fallback guard flips the first test to bind the fallback (`expected <pinned> to be <fallback>`).

## AI Review Report

**Root cause:** the "was the port set explicitly?" signal is erased before the transport sees it. `getServeOptions` leaves `wsPort` `undefined` when `--port` is absent, but the `OrcaRuntimeRpcServer` constructor applies `wsPort = DEFAULT_WS_PORT` (6768) — so by the time `ws-transport.start()` runs, an explicit `--port 6768` is indistinguishable from the default and the persisted fallback pre-empts it.

**Fix:** thread a `wsPortExplicit` boolean (`serveOptions?.wsPort !== undefined`) from `index.ts` through `OrcaRuntimeRpcServerOptions` to the runtime. For an explicit pin the runtime does **not** read/pass the persisted fallback (`candidatePorts = [pinned]`) and does **not** persist a fallback on divergence. Default/unpinned behavior and the `wsPort === 0` E2E path are unchanged, so STA-1511 paired-device stability is preserved.

Review explicitly checked:
- **Cross-platform (macOS / Linux / Windows):** pure boolean threading — no OS-specific paths, no `path`/shell/shortcut/Electron-accelerator surface touched. The Windows/Hyper-V `EACCES` fallback path and the `0.0.0.0` bind host in `ws-transport.ts` are untouched; behavior is identical on all three platforms.
- **SSH / remote / local:** `orca serve --port` is the remote-host case (operators pin the port for firewall rules and SSH tunnels). The fix makes the pin deterministic across relaunches; local and E2E paths unchanged.
- **Agent / integration compatibility:** no agent- or provider-specific code involved.
- **Performance:** no new work in any hot path — one boolean check at bind time.
- **UI quality:** N/A (no UI change).

## Security Audit

- **Exposure surface unchanged:** the transport still binds `0.0.0.0` exactly as before — not widened. Per-device tokens and E2EE are untouched.
- **Path / file handling:** an explicit pin now additionally does **not** write the fallback file, leaving no stale port state on disk; no new file paths are introduced.
- **Input handling / command execution / IPC / secrets / dependencies:** none affected. No new external inputs, no new dependencies, no new logging of sensitive data.

## Notes

- Reproduced on Orca 1.4.137 (Linux, headless); control 1.4.131 not affected. The STA-1511 persistence code has shipped since v1.4.130 (PR #7855); the fallback-first *binding order* was introduced by PR #7924.
- Workaround for anyone hitting this before upgrading: delete `<userData>/mobile-ws-fallback-port.json` before starting a pinned `serve`.

Closes #8535
