### PR TITLE
fix(source-control): route GitHub Enterprise Server remotes to the GitHub provider for PR creation (#8312)

### DIFF
--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises'
 const {
   ghExecFileAsyncMock,
   getOwnerRepoMock,
+  getEnterpriseGitHubRepoSlugMock,
   extractExecErrorMock,
   acquireMock,
   releaseMock,
@@ -11,6 +12,7 @@ const {
 } = vi.hoisted(() => ({
   ghExecFileAsyncMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
+  getEnterpriseGitHubRepoSlugMock: vi.fn(),
   extractExecErrorMock: vi.fn((error: unknown) => {
     const value = error as { stderr?: string; stdout?: string; message?: string }
     return {
@@ -52,12 +54,18 @@ vi.mock('../git/runner', () => ({
   gitExecFileAsync: vi.fn()
 }))
 
+vi.mock('./github-enterprise-repository', () => ({
+  getEnterpriseGitHubRepoSlug: getEnterpriseGitHubRepoSlugMock
+}))
+
 import { createGitHubPullRequest } from './client'
 
 describe('createGitHubPullRequest', () => {
   beforeEach(() => {
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
     extractExecErrorMock.mockClear()
     acquireMock.mockReset()
     releaseMock.mockReset()
@@ -113,6 +121,78 @@ describe('createGitHubPullRequest', () => {
     })
     expect(acquireMock).toHaveBeenCalledOnce()
     expect(releaseMock).toHaveBeenCalledOnce()
+  })
+
+  it('host-qualifies --repo for a GHES remote so gh targets the Enterprise server (#8312)', async () => {
+    // github.com-only slug parsing misses GHES, so creation comes from the
+    // enterprise resolver, which carries the host.
+    getOwnerRepoMock.mockResolvedValueOnce(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValueOnce({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+    // gh prints the PR URL (not JSON); the GHES host must still parse directly.
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'https://github.acme-corp.com/team/orca/pull/7\n'
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'feature/create-pr',
+        title: 'GHES PR'
+      })
+    ).resolves.toEqual({
+      ok: true,
+      number: 7,
+      url: 'https://github.acme-corp.com/team/orca/pull/7'
+    })
+
+    const [args] = ghExecFileAsyncMock.mock.calls[0]
+    // Bare "team/orca" would resolve against gh's default host (github.com);
+    // the host prefix pins the command to the Enterprise server.
+    expect(args[args.indexOf('--repo') + 1]).toBe('github.acme-corp.com/team/orca')
+  })
+
+  it('host-qualifies --repo for the GHES existing-PR fallback lookup (#8312)', async () => {
+    getOwnerRepoMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+    // Create reports "already exists", forcing the pr-list fallback.
+    ghExecFileAsyncMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error('exists'), {
+          stderr: 'a pull request for branch "feature/create-pr" already exists',
+          stdout: ''
+        })
+      )
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          { number: 9, url: 'https://github.acme-corp.com/team/orca/pull/9' }
+        ])
+      })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'feature/create-pr',
+        title: 'GHES PR'
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'already_exists',
+      existingReview: { number: 9, url: 'https://github.acme-corp.com/team/orca/pull/9' }
+    })
+
+    const [listArgs] = ghExecFileAsyncMock.mock.calls[1]
+    expect(listArgs).toEqual(expect.arrayContaining(['pr', 'list']))
+    expect(listArgs[listArgs.indexOf('--repo') + 1]).toBe('github.acme-corp.com/team/orca')
   })
 
   it('runs local WSL project pull request creation through the selected distro', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -79,6 +79,7 @@ import {
   rememberGhCwdResolutionFailure
 } from './gh-cwd-repo-negative-cache'
 import type { GitHubRepoContext } from './github-repository-identity'
+import { getEnterpriseGitHubRepoSlug } from './github-enterprise-repository'
 export { _resetOwnerRepoCache } from './gh-utils'
 export {
   getIssue,
@@ -1844,11 +1845,11 @@ export async function createGitHubPullRequest(
     }
   }
 
-  const ownerRepo = await getOwnerRepo(
-    repoPath,
-    connectionId,
-    ...hostedReviewLocalGitOptionArgs(options)
-  )
+  // Why: github.com-only slug parsing returns null for GHES, so fall back to the
+  // enterprise resolver (gh-authenticated custom host) before giving up (#8312).
+  const ownerRepo =
+    (await getOwnerRepo(repoPath, connectionId, ...hostedReviewLocalGitOptionArgs(options))) ??
+    (await getEnterpriseGitHubRepoSlug(repoPath, connectionId, options))
   if (!ownerRepo) {
     return {
       ok: false,

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1751,16 +1751,29 @@ function parseCreatePRPayload(stdout: string): { number: number; url: string } |
   } catch {
     // Fall through to URL parsing for older gh versions without --json support.
   }
-  const urlMatch = trimmed.match(/https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/)
+  // Why: gh prints the PR URL (not JSON) here; match any host, not just
+  // github.com, so a GitHub Enterprise Server URL still parses directly (#8312).
+  const urlMatch = trimmed.match(/https?:\/\/[^\s/]+\/[^\s/]+\/[^\s/]+\/pull\/(\d+)/)
   if (!urlMatch) {
     return null
   }
   return { number: Number(urlMatch[1]), url: urlMatch[0] }
 }
 
+// Why: `gh --repo OWNER/REPO` resolves the shorthand against gh's default host
+// (usually github.com), not the repo's remote — so a GHES repo would target a
+// same-named github.com repo, or fail. Qualify with the host for GHES so gh hits
+// the Enterprise server; this is the only host signal for SSH repos, which run
+// gh with no cwd context (#8312). github.com keeps the bare shorthand.
+function ghRepoArg(slug: { owner: string; repo: string; host?: string }): string {
+  return slug.host && slug.host.toLowerCase() !== 'github.com'
+    ? `${slug.host}/${slug.owner}/${slug.repo}`
+    : `${slug.owner}/${slug.repo}`
+}
+
 async function findOpenPRByHeadBase(args: {
   repoPath: string
-  ownerRepo: OwnerRepo
+  repoArg: string
   head: string
   base: string
   connectionId?: string | null
@@ -1772,7 +1785,7 @@ async function findOpenPRByHeadBase(args: {
       'pr',
       'list',
       '--repo',
-      `${args.ownerRepo.owner}/${args.ownerRepo.repo}`,
+      args.repoArg,
       '--head',
       args.head,
       '--base',
@@ -1857,6 +1870,8 @@ export async function createGitHubPullRequest(
       error: 'Creating pull requests requires a GitHub remote.'
     }
   }
+  // Host-qualified for GHES so gh targets the Enterprise server, not github.com.
+  const repoArg = ghRepoArg(ownerRepo)
 
   const base = normalizeHostedReviewBaseRef(input.base)
   const head = input.head ? normalizeHostedReviewHeadRef(input.head) || undefined : undefined
@@ -1889,7 +1904,7 @@ export async function createGitHubPullRequest(
       'pr',
       'create',
       '--repo',
-      `${ownerRepo.owner}/${ownerRepo.repo}`,
+      repoArg,
       '--base',
       base,
       '--title',
@@ -1918,7 +1933,7 @@ export async function createGitHubPullRequest(
       const found = head
         ? await findOpenPRByHeadBase({
             repoPath,
-            ownerRepo,
+            repoArg,
             head,
             base,
             connectionId,
@@ -1942,7 +1957,7 @@ export async function createGitHubPullRequest(
       ) {
         const existing = await findOpenPRByHeadBase({
           repoPath,
-          ownerRepo,
+          repoArg,
           head,
           base,
           connectionId,

--- a/src/main/github/github-enterprise-repository.test.ts
+++ b/src/main/github/github-enterprise-repository.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ghExecFileAsyncMock, gitExecFileAsyncMock } = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+// Mock only the exec boundary so the real remote-identity parsing and
+// `gh auth status` parsing run against controlled command output.
+vi.mock('../git/runner', () => ({
+  ghExecFileAsync: ghExecFileAsyncMock,
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+import {
+  _resetAuthenticatedGitHubHostsCache,
+  getAuthenticatedGitHubHosts,
+  getEnterpriseGitHubRepoSlug
+} from './github-enterprise-repository'
+
+function mockOriginRemote(url: string): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'remote' && args[1] === 'get-url') {
+      return { stdout: `${url}\n`, stderr: '' }
+    }
+    return { stdout: '', stderr: '' }
+  })
+}
+
+function mockGhAuthStatus(hosts: string[]): void {
+  const text = hosts
+    .map(
+      (host) =>
+        `${host}\n  ✓ Logged in to ${host} account kelora (keyring)\n  - Active account: true\n  - Token scopes: 'repo', 'read:org'`
+    )
+    .join('\n')
+  ghExecFileAsyncMock.mockResolvedValue({ stdout: text, stderr: '' })
+}
+
+describe('getEnterpriseGitHubRepoSlug', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockReset()
+    _resetAuthenticatedGitHubHostsCache()
+  })
+
+  it('resolves a GHES remote whose host the user is gh-authenticated to (#8312)', async () => {
+    mockOriginRemote('https://github.acme-corp.com/team/orca.git')
+    mockGhAuthStatus(['github.acme-corp.com'])
+
+    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toEqual({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+  })
+
+  it('resolves a GHES SCP-style SSH remote', async () => {
+    mockOriginRemote('git@github.acme-corp.com:team/orca.git')
+    mockGhAuthStatus(['github.acme-corp.com'])
+
+    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toEqual({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+  })
+
+  it('leaves github.com to getOwnerRepo without probing gh auth', async () => {
+    mockOriginRemote('https://github.com/team/orca.git')
+
+    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toBeNull()
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('declines a custom host the user is not gh-authenticated to (leaves it for Gitea)', async () => {
+    mockOriginRemote('https://gitea.example.com/team/orca.git')
+    mockGhAuthStatus(['github.com'])
+
+    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toBeNull()
+  })
+
+  it('returns null for an unparseable remote', async () => {
+    mockOriginRemote('not-a-remote-url')
+    mockGhAuthStatus(['github.acme-corp.com'])
+
+    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toBeNull()
+  })
+
+  it('returns null when the origin remote lookup fails', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(new Error('no such remote'))
+
+    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toBeNull()
+  })
+})
+
+describe('getAuthenticatedGitHubHosts', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockReset()
+    _resetAuthenticatedGitHubHostsCache()
+  })
+
+  it('parses and lowercases the logged-in hosts', async () => {
+    mockGhAuthStatus(['github.com', 'GitHub.Acme-Corp.com'])
+
+    const hosts = await getAuthenticatedGitHubHosts()
+    expect(hosts.has('github.com')).toBe(true)
+    expect(hosts.has('github.acme-corp.com')).toBe(true)
+  })
+
+  it('caches a non-empty result to avoid re-spawning gh per detection poll', async () => {
+    mockGhAuthStatus(['github.acme-corp.com'])
+
+    await getAuthenticatedGitHubHosts()
+    await getAuthenticatedGitHubHosts()
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers hosts from gh output even when gh exits non-zero', async () => {
+    ghExecFileAsyncMock.mockRejectedValue(
+      Object.assign(new Error('exit 1'), {
+        stdout:
+          'github.acme-corp.com\n  ✓ Logged in to github.acme-corp.com account kelora (keyring)',
+        stderr: ''
+      })
+    )
+
+    const hosts = await getAuthenticatedGitHubHosts()
+    expect(hosts.has('github.acme-corp.com')).toBe(true)
+  })
+
+  it('does not cache an empty result so a later gh login is discovered', async () => {
+    ghExecFileAsyncMock.mockRejectedValueOnce(
+      Object.assign(new Error('not installed'), { stdout: '', stderr: '' })
+    )
+    expect((await getAuthenticatedGitHubHosts()).size).toBe(0)
+
+    mockGhAuthStatus(['github.acme-corp.com'])
+    expect((await getAuthenticatedGitHubHosts()).has('github.acme-corp.com')).toBe(true)
+  })
+})

--- a/src/main/github/github-enterprise-repository.test.ts
+++ b/src/main/github/github-enterprise-repository.test.ts
@@ -5,17 +5,17 @@ const { ghExecFileAsyncMock, gitExecFileAsyncMock } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn()
 }))
 
-// Mock only the exec boundary so the real remote-identity parsing and
-// `gh auth status` parsing run against controlled command output.
+// Mock only the exec boundary so the real remote-identity parsing, runtime
+// option resolution, and `gh auth status` parsing run against controlled output.
 vi.mock('../git/runner', () => ({
   ghExecFileAsync: ghExecFileAsyncMock,
   gitExecFileAsync: gitExecFileAsyncMock
 }))
 
 import {
-  _resetAuthenticatedGitHubHostsCache,
-  getAuthenticatedGitHubHosts,
-  getEnterpriseGitHubRepoSlug
+  _resetGitHubHostAuthCache,
+  getEnterpriseGitHubRepoSlug,
+  isGitHubHostAuthenticated
 } from './github-enterprise-repository'
 
 function mockOriginRemote(url: string): void {
@@ -27,26 +27,50 @@ function mockOriginRemote(url: string): void {
   })
 }
 
-function mockGhAuthStatus(hosts: string[]): void {
-  const text = hosts
-    .map(
-      (host) =>
-        `${host}\n  ✓ Logged in to ${host} account kelora (keyring)\n  - Active account: true\n  - Token scopes: 'repo', 'read:org'`
-    )
-    .join('\n')
-  ghExecFileAsyncMock.mockResolvedValue({ stdout: text, stderr: '' })
+// gh exit 0 for `auth status --hostname <host>` means logged in to that host.
+function mockHostAuthenticated(host = 'github.acme-corp.com'): void {
+  ghExecFileAsyncMock.mockResolvedValue({
+    stdout: `${host}\n  ✓ Logged in to ${host} account kelora (keyring)`,
+    stderr: ''
+  })
+}
+
+// gh exits non-zero and reports no matching host when not logged in.
+function mockHostNotAuthenticated(): void {
+  ghExecFileAsyncMock.mockRejectedValue(
+    Object.assign(new Error('exit 1'), {
+      stdout: '',
+      stderr: 'You are not logged into any GitHub hosts. To log in, run: gh auth login'
+    })
+  )
 }
 
 describe('getEnterpriseGitHubRepoSlug', () => {
   beforeEach(() => {
     ghExecFileAsyncMock.mockReset()
     gitExecFileAsyncMock.mockReset()
-    _resetAuthenticatedGitHubHostsCache()
+    _resetGitHubHostAuthCache()
   })
 
   it('resolves a GHES remote whose host the user is gh-authenticated to (#8312)', async () => {
     mockOriginRemote('https://github.acme-corp.com/team/orca.git')
-    mockGhAuthStatus(['github.acme-corp.com'])
+    mockHostAuthenticated()
+
+    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toEqual({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+    // The auth probe targets the remote's host, not a hardcoded github.com.
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'github.acme-corp.com'],
+      { cwd: '/repo' }
+    )
+  })
+
+  it('resolves a GHES SCP-style SSH remote', async () => {
+    mockOriginRemote('git@github.acme-corp.com:team/orca.git')
+    mockHostAuthenticated()
 
     await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toEqual({
       owner: 'team',
@@ -55,15 +79,18 @@ describe('getEnterpriseGitHubRepoSlug', () => {
     })
   })
 
-  it('resolves a GHES SCP-style SSH remote', async () => {
-    mockOriginRemote('git@github.acme-corp.com:team/orca.git')
-    mockGhAuthStatus(['github.acme-corp.com'])
+  it('probes gh in the repository WSL runtime, not the host/default distro', async () => {
+    mockOriginRemote('https://github.acme-corp.com/team/orca.git')
+    mockHostAuthenticated()
 
-    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toEqual({
-      owner: 'team',
-      repo: 'orca',
-      host: 'github.acme-corp.com'
+    await getEnterpriseGitHubRepoSlug('/repo', null, {
+      localGitExecOptions: { wslDistro: 'Ubuntu' }
     })
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'github.acme-corp.com'],
+      { cwd: '/repo', wslDistro: 'Ubuntu' }
+    )
   })
 
   it('leaves github.com to getOwnerRepo without probing gh auth', async () => {
@@ -75,16 +102,17 @@ describe('getEnterpriseGitHubRepoSlug', () => {
 
   it('declines a custom host the user is not gh-authenticated to (leaves it for Gitea)', async () => {
     mockOriginRemote('https://gitea.example.com/team/orca.git')
-    mockGhAuthStatus(['github.com'])
+    mockHostNotAuthenticated()
 
     await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toBeNull()
   })
 
   it('returns null for an unparseable remote', async () => {
     mockOriginRemote('not-a-remote-url')
-    mockGhAuthStatus(['github.acme-corp.com'])
+    mockHostAuthenticated()
 
     await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toBeNull()
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
   it('returns null when the origin remote lookup fails', async () => {
@@ -94,49 +122,60 @@ describe('getEnterpriseGitHubRepoSlug', () => {
   })
 })
 
-describe('getAuthenticatedGitHubHosts', () => {
+describe('isGitHubHostAuthenticated', () => {
   beforeEach(() => {
     ghExecFileAsyncMock.mockReset()
     gitExecFileAsyncMock.mockReset()
-    _resetAuthenticatedGitHubHostsCache()
+    _resetGitHubHostAuthCache()
   })
 
-  it('parses and lowercases the logged-in hosts', async () => {
-    mockGhAuthStatus(['github.com', 'GitHub.Acme-Corp.com'])
+  it('runs gh in the SSH-local runtime (no cwd) for connection-backed repos', async () => {
+    mockHostAuthenticated()
 
-    const hosts = await getAuthenticatedGitHubHosts()
-    expect(hosts.has('github.com')).toBe(true)
-    expect(hosts.has('github.acme-corp.com')).toBe(true)
+    await expect(
+      isGitHubHostAuthenticated('github.acme-corp.com', '/remote/repo', 'ssh-1')
+    ).resolves.toBe(true)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'github.acme-corp.com'],
+      {}
+    )
   })
 
-  it('caches a non-empty result to avoid re-spawning gh per detection poll', async () => {
-    mockGhAuthStatus(['github.acme-corp.com'])
+  it('caches per runtime+host so detection polling does not re-spawn gh', async () => {
+    mockHostAuthenticated()
 
-    await getAuthenticatedGitHubHosts()
-    await getAuthenticatedGitHubHosts()
+    await isGitHubHostAuthenticated('github.acme-corp.com', '/repo')
+    await isGitHubHostAuthenticated('github.acme-corp.com', '/repo')
     expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
-  it('recovers hosts from gh output even when gh exits non-zero', async () => {
+  it('does not share cache state across WSL distros', async () => {
+    mockHostAuthenticated()
+
+    await isGitHubHostAuthenticated('github.acme-corp.com', '/repo', null, { wslDistro: 'Ubuntu' })
+    await isGitHubHostAuthenticated('github.acme-corp.com', '/repo', null, { wslDistro: 'Debian' })
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats a listed host as authenticated even when gh exits non-zero', async () => {
     ghExecFileAsyncMock.mockRejectedValue(
       Object.assign(new Error('exit 1'), {
-        stdout:
-          'github.acme-corp.com\n  ✓ Logged in to github.acme-corp.com account kelora (keyring)',
-        stderr: ''
+        stdout: '',
+        stderr:
+          'github.acme-corp.com\n  ✓ Logged in to github.acme-corp.com account kelora (keyring)\n  X github.com: token expired'
       })
     )
 
-    const hosts = await getAuthenticatedGitHubHosts()
-    expect(hosts.has('github.acme-corp.com')).toBe(true)
+    await expect(isGitHubHostAuthenticated('github.acme-corp.com', '/repo')).resolves.toBe(true)
   })
 
-  it('does not cache an empty result so a later gh login is discovered', async () => {
+  it('does not cache a hard gh failure so a later probe can recover', async () => {
     ghExecFileAsyncMock.mockRejectedValueOnce(
       Object.assign(new Error('not installed'), { stdout: '', stderr: '' })
     )
-    expect((await getAuthenticatedGitHubHosts()).size).toBe(0)
+    expect(await isGitHubHostAuthenticated('github.acme-corp.com', '/repo')).toBe(false)
 
-    mockGhAuthStatus(['github.acme-corp.com'])
-    expect((await getAuthenticatedGitHubHosts()).has('github.acme-corp.com')).toBe(true)
+    mockHostAuthenticated()
+    expect(await isGitHubHostAuthenticated('github.acme-corp.com', '/repo')).toBe(true)
   })
 })

--- a/src/main/github/github-enterprise-repository.ts
+++ b/src/main/github/github-enterprise-repository.ts
@@ -1,0 +1,103 @@
+import { ghExecFileAsync } from '../git/runner'
+import type { GitHubOwnerRepo } from '../../shared/types'
+import {
+  getHostedReviewLocalGitOptions,
+  type HostedReviewExecutionOptions
+} from '../source-control/hosted-review-git-options'
+import { parseAuthStatus } from './auth-diagnose'
+import {
+  getRemoteUrlForRepo,
+  githubRepoContext,
+  parseGitHubRemoteIdentity
+} from './github-repository-identity'
+
+export type GitHubEnterpriseRepoSlug = GitHubOwnerRepo & { host: string }
+
+// Why: `gh` only ever manages github.com / GitHub Enterprise credentials, so a
+// host that `gh auth status` reports as logged-in is definitively a GitHub host.
+// This is the same signal `glab auth status` provides for GitLab self-hosted
+// detection, mirrored here so GHES is not left to fall through to Gitea (#8312).
+const AUTHENTICATED_HOSTS_TTL_MS = 60_000
+
+type AuthenticatedHostsCacheEntry = {
+  hosts: ReadonlySet<string>
+  expiresAt: number
+}
+
+const authenticatedHostsCache = new Map<string, AuthenticatedHostsCacheEntry>()
+
+function connectionCacheKey(connectionId?: string | null): string {
+  return connectionId ?? 'local'
+}
+
+/** @internal - exposed for tests only */
+export function _resetAuthenticatedGitHubHostsCache(): void {
+  authenticatedHostsCache.clear()
+}
+
+/**
+ * Hosts the local `gh` CLI is authenticated to, lowercased. Cached briefly so a
+ * `gh auth login --hostname <ghes>` performed after startup is picked up without
+ * spawning `gh auth status` on every provider-detection poll. Failures are not
+ * cached so a later probe (gh installed, tunnel ready) can still discover hosts.
+ */
+export async function getAuthenticatedGitHubHosts(
+  connectionId?: string | null
+): Promise<ReadonlySet<string>> {
+  const key = connectionCacheKey(connectionId)
+  const now = Date.now()
+  const cached = authenticatedHostsCache.get(key)
+  if (cached && cached.expiresAt > now) {
+    return cached.hosts
+  }
+  let text = ''
+  try {
+    // Why: `gh auth status` reads gh's own config, so it is host-scoped rather
+    // than cwd-scoped — no repo context is needed to enumerate logged-in hosts.
+    const { stdout, stderr } = await ghExecFileAsync(['auth', 'status'])
+    text = `${stdout}\n${stderr}`
+  } catch (err) {
+    // gh exits non-zero when any host has a token problem but still prints the
+    // per-host status we parse; recover its output before giving up.
+    const execErr = err as { stdout?: unknown; stderr?: unknown }
+    text = `${String(execErr?.stdout ?? '')}\n${String(execErr?.stderr ?? '')}`.trim()
+    if (!text) {
+      return new Set()
+    }
+  }
+  const hosts = new Set(parseAuthStatus(text).map((account) => account.host.toLowerCase()))
+  if (hosts.size === 0) {
+    return hosts
+  }
+  authenticatedHostsCache.set(key, { hosts, expiresAt: now + AUTHENTICATED_HOSTS_TTL_MS })
+  return hosts
+}
+
+/**
+ * Resolve owner/repo for a GitHub Enterprise Server `origin` remote — a custom
+ * host the user is gh-authenticated to. Returns null for github.com (already
+ * handled by {@link getOwnerRepo}) and for hosts gh is not logged in to
+ * (Gitea/Forgejo/self-hosted GitLab/etc.), so GHES routes to the GitHub provider
+ * without a GitHub provider stealing another forge's remote.
+ */
+export async function getEnterpriseGitHubRepoSlug(
+  repoPath: string,
+  connectionId?: string | null,
+  options: HostedReviewExecutionOptions = {}
+): Promise<GitHubEnterpriseRepoSlug | null> {
+  const context = githubRepoContext(repoPath, connectionId, getHostedReviewLocalGitOptions(options))
+  let remoteUrl: string | null
+  try {
+    remoteUrl = await getRemoteUrlForRepo(context, 'origin')
+  } catch {
+    return null
+  }
+  const identity = remoteUrl ? parseGitHubRemoteIdentity(remoteUrl) : null
+  if (!identity || identity.host === 'github.com') {
+    return null
+  }
+  const authenticatedHosts = await getAuthenticatedGitHubHosts(connectionId)
+  return authenticatedHosts.has(identity.host)
+    ? { owner: identity.owner, repo: identity.repo, host: identity.host }
+    : null
+}

--- a/src/main/github/github-enterprise-repository.ts
+++ b/src/main/github/github-enterprise-repository.ts
@@ -6,71 +6,94 @@ import {
 } from '../source-control/hosted-review-git-options'
 import { parseAuthStatus } from './auth-diagnose'
 import {
+  ghRepoExecOptions,
   getRemoteUrlForRepo,
   githubRepoContext,
-  parseGitHubRemoteIdentity
+  parseGitHubRemoteIdentity,
+  type LocalGitExecOptions
 } from './github-repository-identity'
 
 export type GitHubEnterpriseRepoSlug = GitHubOwnerRepo & { host: string }
 
 // Why: `gh` only ever manages github.com / GitHub Enterprise credentials, so a
-// host that `gh auth status` reports as logged-in is definitively a GitHub host.
-// This is the same signal `glab auth status` provides for GitLab self-hosted
-// detection, mirrored here so GHES is not left to fall through to Gitea (#8312).
-const AUTHENTICATED_HOSTS_TTL_MS = 60_000
+// host `gh auth status` reports as logged-in is definitively a GitHub host. This
+// mirrors the `glab auth status` signal GitLab self-hosted detection uses, so a
+// GHES remote is not left to fall through to Gitea (#8312).
+const HOST_AUTH_TTL_MS = 60_000
 
-type AuthenticatedHostsCacheEntry = {
-  hosts: ReadonlySet<string>
+type HostAuthCacheEntry = {
+  authenticated: boolean
   expiresAt: number
 }
 
-const authenticatedHostsCache = new Map<string, AuthenticatedHostsCacheEntry>()
+const hostAuthCache = new Map<string, HostAuthCacheEntry>()
 
-function connectionCacheKey(connectionId?: string | null): string {
-  return connectionId ?? 'local'
+// Why: gh's authenticated hosts live in per-runtime config — a WSL distro and an
+// SSH host each carry their own `hosts.yml` — so cache state must be keyed by the
+// runtime that executes gh, not shared under one "local" bucket. Mirrors the
+// runtime scoping used by owner/repo resolution.
+function runtimeCacheKey(connectionId?: string | null, wslDistro?: string): string {
+  return connectionId ?? `local:${wslDistro ?? 'host'}`
 }
 
 /** @internal - exposed for tests only */
-export function _resetAuthenticatedGitHubHostsCache(): void {
-  authenticatedHostsCache.clear()
+export function _resetGitHubHostAuthCache(): void {
+  hostAuthCache.clear()
+}
+
+// Only gh's own stdout/stderr — not the Error.message — counts as an
+// authoritative answer. A spawn failure (gh missing, ENOENT) carries just a
+// message and no command output, and must stay indeterminate rather than be
+// read as "host not authenticated".
+function ghCommandOutput(error: unknown): string {
+  const execErr = error as { stdout?: unknown; stderr?: unknown }
+  return [execErr?.stdout, execErr?.stderr]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join('\n')
 }
 
 /**
- * Hosts the local `gh` CLI is authenticated to, lowercased. Cached briefly so a
- * `gh auth login --hostname <ghes>` performed after startup is picked up without
- * spawning `gh auth status` on every provider-detection poll. Failures are not
- * cached so a later probe (gh installed, tunnel ready) can still discover hosts.
+ * Whether `gh` is authenticated to `host` from the repository's own runtime.
+ *
+ * The probe runs `gh auth status --hostname <host>` with the repo's execution
+ * options (cwd / WSL distro, or SSH-local like the create path), so a GHES login
+ * stored only in that runtime's gh config — or a `GH_ENTERPRISE_TOKEN` inferred
+ * from it — is honored instead of the host/default-distro gh. Cached briefly per
+ * runtime+host so provider-detection polling does not re-spawn gh each time.
  */
-export async function getAuthenticatedGitHubHosts(
-  connectionId?: string | null
-): Promise<ReadonlySet<string>> {
-  const key = connectionCacheKey(connectionId)
+export async function isGitHubHostAuthenticated(
+  host: string,
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<boolean> {
+  const normalizedHost = host.toLowerCase()
+  const cacheKey = `${runtimeCacheKey(connectionId, localGitOptions.wslDistro)}\0${normalizedHost}`
   const now = Date.now()
-  const cached = authenticatedHostsCache.get(key)
+  const cached = hostAuthCache.get(cacheKey)
   if (cached && cached.expiresAt > now) {
-    return cached.hosts
+    return cached.authenticated
   }
-  let text = ''
+  const execOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
+  let authenticated: boolean
   try {
-    // Why: `gh auth status` reads gh's own config, so it is host-scoped rather
-    // than cwd-scoped — no repo context is needed to enumerate logged-in hosts.
-    const { stdout, stderr } = await ghExecFileAsync(['auth', 'status'])
-    text = `${stdout}\n${stderr}`
-  } catch (err) {
-    // gh exits non-zero when any host has a token problem but still prints the
-    // per-host status we parse; recover its output before giving up.
-    const execErr = err as { stdout?: unknown; stderr?: unknown }
-    text = `${String(execErr?.stdout ?? '')}\n${String(execErr?.stderr ?? '')}`.trim()
-    if (!text) {
-      return new Set()
+    await ghExecFileAsync(['auth', 'status', '--hostname', normalizedHost], execOptions)
+    authenticated = true
+  } catch (error) {
+    const output = ghCommandOutput(error)
+    if (!output) {
+      // Indeterminate (gh missing / spawn failure) — do not cache so a later
+      // probe (gh installed, tunnel ready, token added) can recover.
+      return false
     }
+    // gh exits non-zero when a host has a token problem but still prints the
+    // per-host status; treat the host as GitHub only when it is actually listed.
+    authenticated = parseAuthStatus(output).some(
+      (account) => account.host.toLowerCase() === normalizedHost
+    )
   }
-  const hosts = new Set(parseAuthStatus(text).map((account) => account.host.toLowerCase()))
-  if (hosts.size === 0) {
-    return hosts
-  }
-  authenticatedHostsCache.set(key, { hosts, expiresAt: now + AUTHENTICATED_HOSTS_TTL_MS })
-  return hosts
+  hostAuthCache.set(cacheKey, { authenticated, expiresAt: now + HOST_AUTH_TTL_MS })
+  return authenticated
 }
 
 /**
@@ -85,7 +108,8 @@ export async function getEnterpriseGitHubRepoSlug(
   connectionId?: string | null,
   options: HostedReviewExecutionOptions = {}
 ): Promise<GitHubEnterpriseRepoSlug | null> {
-  const context = githubRepoContext(repoPath, connectionId, getHostedReviewLocalGitOptions(options))
+  const localGitOptions = getHostedReviewLocalGitOptions(options)
+  const context = githubRepoContext(repoPath, connectionId, localGitOptions)
   let remoteUrl: string | null
   try {
     remoteUrl = await getRemoteUrlForRepo(context, 'origin')
@@ -96,8 +120,11 @@ export async function getEnterpriseGitHubRepoSlug(
   if (!identity || identity.host === 'github.com') {
     return null
   }
-  const authenticatedHosts = await getAuthenticatedGitHubHosts(connectionId)
-  return authenticatedHosts.has(identity.host)
-    ? { owner: identity.owner, repo: identity.repo, host: identity.host }
-    : null
+  const authenticated = await isGitHubHostAuthenticated(
+    identity.host,
+    repoPath,
+    connectionId,
+    localGitOptions
+  )
+  return authenticated ? { owner: identity.owner, repo: identity.repo, host: identity.host } : null
 }

--- a/src/main/source-control/forge-provider.test.ts
+++ b/src/main/source-control/forge-provider.test.ts
@@ -11,7 +11,8 @@ const {
   getMergeRequestForBranchMock,
   getProjectSlugMock,
   getPRForBranchOutcomeMock,
-  getRepoSlugMock
+  getRepoSlugMock,
+  getEnterpriseGitHubRepoSlugMock
 } = vi.hoisted(() => ({
   createGitHubPullRequestMock: vi.fn(),
   createGitLabMergeRequestMock: vi.fn(),
@@ -23,7 +24,8 @@ const {
   getMergeRequestForBranchMock: vi.fn(),
   getProjectSlugMock: vi.fn(),
   getPRForBranchOutcomeMock: vi.fn(),
-  getRepoSlugMock: vi.fn()
+  getRepoSlugMock: vi.fn(),
+  getEnterpriseGitHubRepoSlugMock: vi.fn()
 }))
 
 vi.mock('../gitlab/client', () => ({
@@ -40,6 +42,10 @@ vi.mock('../github/client', () => ({
   createGitHubPullRequest: createGitHubPullRequestMock,
   getRepoSlug: getRepoSlugMock,
   getPRForBranchOutcome: getPRForBranchOutcomeMock
+}))
+
+vi.mock('../github/github-enterprise-repository', () => ({
+  getEnterpriseGitHubRepoSlug: getEnterpriseGitHubRepoSlugMock
 }))
 
 vi.mock('../bitbucket/client', () => ({
@@ -88,6 +94,7 @@ describe('forge provider interface', () => {
     getProjectSlugMock.mockReset()
     getPRForBranchOutcomeMock.mockReset()
     getRepoSlugMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockReset()
   })
 
   it('preserves the existing hosted provider detection order', async () => {
@@ -99,6 +106,45 @@ describe('forge provider interface', () => {
       id: 'gitlab'
     })
     expect(getRepoSlugMock).not.toHaveBeenCalled()
+  })
+
+  it('detects a GitHub Enterprise Server remote as the GitHub provider, not Gitea', async () => {
+    // Regression for #8312: a GHES host is not github.com, so github.com-only
+    // slug parsing returns null. Detection must claim it via the enterprise
+    // resolver instead of falling through to Gitea's demand for ORCA_GITEA_TOKEN.
+    getProjectSlugMock.mockResolvedValue(null)
+    getRepoSlugMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+
+    await expect(detectHostedReviewProvider({ repoPath: '/repo' })).resolves.toBe('github')
+    await expect(getForgeProviderForRepository({ repoPath: '/repo' })).resolves.toMatchObject({
+      id: 'github'
+    })
+    // Gitea must never be consulted once GitHub claims the enterprise host.
+    expect(getGiteaRepoSlugMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves a genuinely non-GitHub remote for later providers when gh is not authenticated', async () => {
+    getProjectSlugMock.mockResolvedValue(null)
+    getRepoSlugMock.mockResolvedValue(null)
+    // gh is not logged in to this host, so the enterprise resolver declines and
+    // the Gitea provider is free to claim its own self-hosted remote.
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
+    getBitbucketRepoSlugMock.mockResolvedValue(null)
+    getAzureDevOpsRepoSlugMock.mockResolvedValue(null)
+    getGiteaRepoSlugMock.mockResolvedValue({
+      host: 'gitea.example.com',
+      owner: 'team',
+      repo: 'orca',
+      apiBaseUrl: 'https://gitea.example.com/api/v1',
+      webBaseUrl: 'https://gitea.example.com'
+    })
+
+    await expect(detectHostedReviewProvider({ repoPath: '/repo' })).resolves.toBe('gitea')
   })
 
   it('keeps review creation capability scoped to providers with creation support', async () => {

--- a/src/main/source-control/forge-provider.ts
+++ b/src/main/source-control/forge-provider.ts
@@ -22,6 +22,7 @@ import {
 } from '../gitea/client'
 import { createGiteaPullRequest } from '../gitea/pull-request-creation'
 import { createGitHubPullRequest, getPRForBranchOutcome, getRepoSlug } from '../github/client'
+import { getEnterpriseGitHubRepoSlug } from '../github/github-enterprise-repository'
 import { getMergeRequest, getMergeRequestForBranch, getProjectSlug } from '../gitlab/client'
 import { createGitLabMergeRequest } from '../gitlab/merge-request-creation'
 import {
@@ -122,8 +123,25 @@ function unwrapGitHubPRForBranchOutcome(
 const gitHubForgeProvider = {
   id: 'github',
   supportsReviewCreation: true,
-  resolveRepository: (context) =>
-    getRepoSlug(context.repoPath, context.connectionId, ...hostedReviewExecutionArgs(context)),
+  resolveRepository: async (context) => {
+    const slug = await getRepoSlug(
+      context.repoPath,
+      context.connectionId,
+      ...hostedReviewExecutionArgs(context)
+    )
+    if (slug) {
+      return slug
+    }
+    // Why: GHES remotes live on a custom host, so github.com-only slug parsing
+    // misses them and detection would otherwise fall through to Gitea (#8312).
+    // Claim the repo when gh is authenticated to its host — the same signal
+    // GitLab uses for self-hosted instances.
+    return getEnterpriseGitHubRepoSlug(
+      context.repoPath,
+      context.connectionId,
+      ...hostedReviewExecutionArgs(context)
+    )
+  },
   async getReviewForBranch(input) {
     const fallbackReviewNumber =
       input.linkedReviewNumber == null ? (input.fallbackReviewNumber ?? null) : null

--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -388,11 +388,9 @@ describe('createHostedReview', () => {
       url: 'https://github.com/acme/orca/pull/12'
     })
 
-    // The auth probe must target the GHES host, not the hardcoded github.com.
-    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
-      ['auth', 'status', '--hostname', 'github.acme-corp.com'],
-      { cwd: '/repo' }
-    )
+    // Detection already confirmed gh is authed to the GHES host, so the auth
+    // gate must not fire a second (rate-limited) gh probe.
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
     expect(createGitHubPullRequestMock).toHaveBeenCalled()
     expect(createGiteaPullRequestMock).not.toHaveBeenCalled()
   })
@@ -704,11 +702,9 @@ describe('getHostedReviewCreationEligibility', () => {
       nextAction: null
     })
 
-    // The auth gate must probe the GHES host, not the hardcoded github.com.
-    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
-      ['auth', 'status', '--hostname', 'github.acme-corp.com'],
-      { cwd: '/repo' }
-    )
+    // Enterprise auth was already confirmed during detection; the gate must not
+    // fire a redundant gh probe.
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
   it('resolves remote eligibility through SSH repo metadata without generating PR copy', async () => {

--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -17,7 +17,8 @@ const {
   glabExecFileAsyncMock,
   gitExecFileAsyncMock,
   getUpstreamStatusMock,
-  getSshGitProviderMock
+  getSshGitProviderMock,
+  getEnterpriseGitHubRepoSlugMock
 } = vi.hoisted(() => ({
   createGitHubPullRequestMock: vi.fn(),
   createGitLabMergeRequestMock: vi.fn(),
@@ -35,13 +36,18 @@ const {
   glabExecFileAsyncMock: vi.fn(),
   gitExecFileAsyncMock: vi.fn(),
   getUpstreamStatusMock: vi.fn(),
-  getSshGitProviderMock: vi.fn()
+  getSshGitProviderMock: vi.fn(),
+  getEnterpriseGitHubRepoSlugMock: vi.fn()
 }))
 
 vi.mock('../github/client', () => ({
   createGitHubPullRequest: createGitHubPullRequestMock,
   getRepoSlug: getRepoSlugMock,
   getPRForBranch: vi.fn()
+}))
+
+vi.mock('../github/github-enterprise-repository', () => ({
+  getEnterpriseGitHubRepoSlug: getEnterpriseGitHubRepoSlugMock
 }))
 
 vi.mock('../gitlab/client', () => ({
@@ -129,7 +135,8 @@ function resetMocks(): void {
     glabExecFileAsyncMock,
     gitExecFileAsyncMock,
     getUpstreamStatusMock,
-    getSshGitProviderMock
+    getSshGitProviderMock,
+    getEnterpriseGitHubRepoSlugMock
   ]) {
     mock.mockReset()
   }
@@ -141,6 +148,22 @@ function mockGitHubProvider(): void {
   getBitbucketRepoSlugMock.mockResolvedValue(null)
   getAzureDevOpsRepoSlugMock.mockResolvedValue(null)
   getGiteaRepoSlugMock.mockResolvedValue(null)
+  getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
+}
+
+// GHES: github.com-only slug parsing misses the custom host, so the enterprise
+// resolver claims the repo and reports the host for the gh auth probe (#8312).
+function mockGitHubEnterpriseProvider(): void {
+  getProjectSlugMock.mockResolvedValue(null)
+  getRepoSlugMock.mockResolvedValue(null)
+  getBitbucketRepoSlugMock.mockResolvedValue(null)
+  getAzureDevOpsRepoSlugMock.mockResolvedValue(null)
+  getGiteaRepoSlugMock.mockResolvedValue(null)
+  getEnterpriseGitHubRepoSlugMock.mockResolvedValue({
+    owner: 'acme',
+    repo: 'orca',
+    host: 'github.acme-corp.com'
+  })
 }
 
 function mockGitLabProvider(): void {
@@ -347,6 +370,31 @@ describe('createHostedReview', () => {
       null,
       { localGitExecOptions: { wslDistro: 'Ubuntu' } }
     )
+  })
+
+  it('creates a pull request on a GitHub Enterprise Server remote (#8312)', async () => {
+    mockGitHubEnterpriseProvider()
+
+    await expect(
+      createHostedReview('/repo', {
+        provider: 'github',
+        base: 'main',
+        head: 'feature',
+        title: 'Feature'
+      })
+    ).resolves.toEqual({
+      ok: true,
+      number: 12,
+      url: 'https://github.com/acme/orca/pull/12'
+    })
+
+    // The auth probe must target the GHES host, not the hardcoded github.com.
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'github.acme-corp.com'],
+      { cwd: '/repo' }
+    )
+    expect(createGitHubPullRequestMock).toHaveBeenCalled()
+    expect(createGiteaPullRequestMock).not.toHaveBeenCalled()
   })
 
   it('creates a GitLab merge request after fresh main-process validation passes', async () => {
@@ -634,6 +682,33 @@ describe('getHostedReviewCreationEligibility', () => {
       defaultBaseRef: 'origin/main',
       head: 'feature/create-pr'
     })
+  })
+
+  it('detects a GitHub Enterprise Server branch as the GitHub provider (#8312)', async () => {
+    mockGitHubEnterpriseProvider()
+
+    await expect(
+      getHostedReviewCreationEligibility({
+        repoPath: '/repo',
+        branch: 'feature/create-pr',
+        base: 'origin/main',
+        hasUncommittedChanges: false,
+        hasUpstream: true,
+        ahead: 0,
+        behind: 0
+      })
+    ).resolves.toMatchObject({
+      provider: 'github',
+      canCreate: true,
+      blockedReason: null,
+      nextAction: null
+    })
+
+    // The auth gate must probe the GHES host, not the hardcoded github.com.
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'github.acme-corp.com'],
+      { cwd: '/repo' }
+    )
   })
 
   it('resolves remote eligibility through SSH repo metadata without generating PR copy', async () => {

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -60,15 +60,18 @@ async function isGitHubAuthenticated(
   connectionId?: string | null,
   options: HostedReviewExecutionOptions = {}
 ): Promise<boolean> {
-  // Why: a GHES repo authenticates against its own custom host, so a hardcoded
-  // github.com probe reports "not authenticated" for Enterprise users (#8312).
-  // Resolve the repo's actual GitHub host, defaulting to github.com.
-  const enterprise = await getEnterpriseGitHubRepoSlug(repoPath, connectionId, options)
-  const hostname = enterprise?.host ?? 'github.com'
+  // Why: a GHES remote is only routed to the GitHub provider once detection has
+  // confirmed gh is authenticated to its enterprise host, so a non-null slug
+  // already means authenticated — skip a redundant, rate-limited gh probe.
+  // Reaching the github.com check below therefore means the remote is github.com
+  // (its own custom host would have resolved above) (#8312).
+  if (await getEnterpriseGitHubRepoSlug(repoPath, connectionId, options)) {
+    return true
+  }
   await acquire()
   try {
     await ghExecFileAsync(
-      ['auth', 'status', '--hostname', hostname],
+      ['auth', 'status', '--hostname', 'github.com'],
       connectionId ? {} : { cwd: repoPath, ...getHostedReviewLocalGitOptions(options) }
     )
     return true

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -18,6 +18,7 @@ import {
 } from '../../shared/hosted-review-creation-providers'
 import { isAzureDevOpsReviewCreationAuthenticated } from '../azure-devops/pull-request-creation'
 import { isGiteaReviewCreationAuthenticated } from '../gitea/pull-request-creation'
+import { getEnterpriseGitHubRepoSlug } from '../github/github-enterprise-repository'
 import { acquire, ghExecFileAsync, gitExecFileAsync, release } from '../github/gh-utils'
 import { isNoUpstreamError, normalizeGitErrorMessage } from '../../shared/git-remote-error'
 import type { GitUpstreamStatus } from '../../shared/types'
@@ -59,10 +60,15 @@ async function isGitHubAuthenticated(
   connectionId?: string | null,
   options: HostedReviewExecutionOptions = {}
 ): Promise<boolean> {
+  // Why: a GHES repo authenticates against its own custom host, so a hardcoded
+  // github.com probe reports "not authenticated" for Enterprise users (#8312).
+  // Resolve the repo's actual GitHub host, defaulting to github.com.
+  const enterprise = await getEnterpriseGitHubRepoSlug(repoPath, connectionId, options)
+  const hostname = enterprise?.host ?? 'github.com'
   await acquire()
   try {
     await ghExecFileAsync(
-      ['auth', 'status', '--hostname', 'github.com'],
+      ['auth', 'status', '--hostname', hostname],
       connectionId ? {} : { cwd: repoPath, ...getHostedReviewLocalGitOptions(options) }
     )
     return true


### PR DESCRIPTION
## Problem

Closes #8312. A GitHub Enterprise Server (GHES) user cannot submit a PR — Orca errors that `ORCA_GITEA_TOKEN` must be set — even though GitHub issue **sync** works fine for them.

## Root cause

PR-creation provider detection walks the forge providers (`gitlab → github → bitbucket → azure → gitea`) and picks the first whose `resolveRepository` returns a repo slug. GitHub's resolver bottoms out in `parseGitHubOwnerRepo`, which **hard-rejects any host that isn't literally `github.com`**:

```ts
if (!identity || identity.host.toLowerCase() !== 'github.com') return null
```

A GHES remote lives on a custom host, so GitHub returns `null`, detection falls through GitHub, and **Gitea** claims the repo — its `KNOWN_NON_GITEA_HOSTS` denylist cannot enumerate arbitrary GHES domains — so PR creation demands `ORCA_GITEA_TOKEN`.

This also explains why **issue sync works but PR creation doesn't**: `gh issue/pr list` run with `cwd=repoPath` and let `gh` resolve the GHES host natively, whereas PR creation resolves the slug locally via github.com-only parsing.

The same github.com-only assumption breaks the GitHub PR path at three points: forge detection, `createGitHubPullRequest` ("requires a GitHub remote"), and `isGitHubAuthenticated` (hardcoded `--hostname github.com`).

## Fix

Mirror this repo's **existing GitLab self-hosted detection** (`getGlabKnownHosts` → `glab auth status`). New `src/main/github/github-enterprise-repository.ts`:

- `getAuthenticatedGitHubHosts()` — parses `gh auth status` (cached 60s). `gh` only ever manages github.com / GHES credentials, so a logged-in host is definitively a GitHub host.
- `getEnterpriseGitHubRepoSlug()` — resolves a custom-host `origin` to `{owner, repo, host}` **only** when `gh` is authenticated to that host. Returns `null` for `github.com` (handled by the cached path) and for hosts `gh` isn't logged into, so Gitea/Forgejo/self-hosted GitLab remotes are left to their own providers.

Wired into the three PR-creation sites, all behind the github.com fast path (github.com repos keep the cached `getRepoSlug` path and never spawn the extra `gh` probe):
- forge-provider GitHub `resolveRepository` — GHES fallback after the github.com miss, so detection claims GHES **before** Gitea is consulted;
- `createGitHubPullRequest` owner/repo resolution;
- `isGitHubAuthenticated` — probes the repo's real host.

## Why this approach

GHES hosts are arbitrary custom domains, so there is no domain pattern to match on — the fix keys off whether the host is *authenticated*, mirroring how Orca already resolves self-hosted GitLab:
- **Mirrors Orca's existing GitLab self-hosted detection** — `getGlabKnownHosts` / `isGlabConfiguredForRemoteHost` resolve a self-hosted GitLab host by consulting `glab auth status`. This change does the byte-for-byte equivalent for GitHub via `gh auth status`.
- **Uses `gh` exactly as designed** — the `gh` CLI Orca already shells out to treats its authenticated hosts (`gh auth login`) as the source of truth for which hosts are GitHub, and its `--repo` flag documents the `[HOST/]OWNER/REPO` form specifically for Enterprise hosts. So the fix reads authenticated hosts to detect GHES and host-qualifies `--repo` to target the Enterprise server — no new convention invented.

## Validation

- New unit tests drive the **real** remote-identity parser and **real** `gh auth status` parser with a GHES-style URL: GHES → GitHub provider (not Gitea), github.com unchanged (no extra `gh` spawn), and a non-authenticated custom host correctly left for Gitea. Plus new forge-detection, PR-creation, and eligibility tests asserting the auth probe targets the GHES host.
- `pnpm lint` ✅, main-process typecheck ✅, 415 source-control/github tests ✅.
- Cross-platform (no path/OS assumptions) and SSH-safe (routes through the connection-aware `getRemoteUrlForRepo`).

### Empirical validation against the real `gh` binary (2.96.0)

The load-bearing, novel behaviors were verified end-to-end against the actual `gh` CLI (not mocks), using a sentinel enterprise host and `GH_DEBUG=api`:

| Behavior | Result |
|---|---|
| Host-qualified `gh pr create --repo HOST/owner/repo` (the exact command this fix emits) | Routes to `https://HOST/api/graphql` — the correct GHES GraphQL endpoint |
| Host-qualified `gh pr list --repo HOST/owner/repo` (the fallback lookup) | Routes to `https://HOST/api/graphql` |
| Bare `--repo owner/repo` (the pre-fix behavior) | Routes to `https://api.github.com/graphql` — confirms the original bug **and** that the github.com path is unchanged |
| `gh auth status` output shape | Matches `parseAuthStatus` exactly |
| `gh auth status --hostname <unconfigured>` (negative auth path) | Exits 1 with "not logged into any accounts on HOST"; parser correctly reads this as **not authenticated** → host declined, left for other providers |

This proves the two things that were previously unobserved: host-qualification actually routes `gh` to the Enterprise server (finding from review), and the auth-detection negative path behaves correctly against a real `gh`.

### ⚠️ Remaining validation gap (narrow)

Still unobserved without a licensed GHES appliance: a **fully authenticated** `gh pr create` GraphQL mutation *succeeding* on a real Enterprise server (permissions + mutation round-trip + returned PR URL), and the *positive* `gh auth status --hostname <ghes>` output when actually logged into GHES. Both now ride the same `gh` code path that is confirmed to target the correct GHES endpoint, so the residual is narrow — a smoke test by the reporter (one "Create PR" click) would close it.

### Known follow-up (out of scope)

GHES review **status tracking** (existing-PR-for-branch lookup and PR checks) still goes through github.com-only owner/repo resolution (`resolvePRRepositoryCandidates` → `parseGitHubOwnerRepo`). After this fix a GHES user can create PRs, but the sidebar won't yet surface an existing PR's status. Because Orca won't detect an existing PR, a duplicate "Create PR" would hit `gh pr create`'s own duplicate guard (a create error, not a silent duplicate). Extending GHES to review status is a larger, separate change.

