### PR TITLE
fix(mobile): reconnect resync — surface real errors, resync worktrees, harden pong-liveness, replay notifications (#6784 #8498 #4500 #8129)

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -6,7 +6,8 @@ import {
   SectionList,
   Pressable,
   ActivityIndicator,
-  Alert
+  Alert,
+  RefreshControl
 } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useFocusEffect, useLocalSearchParams, usePathname, useRouter } from 'expo-router'
@@ -35,8 +36,10 @@ import {
   useCloseHost,
   useForceReconnect,
   useReconnectAttempt,
-  useLastConnectedAt
+  useLastConnectedAt,
+  useLastConnectionError
 } from '../../../src/transport/client-context'
+import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
 import {
   classifyConnection,
   type ConnectionVerdict
@@ -59,7 +62,7 @@ import { ProtocolBlockScreen } from '../../../src/components/ProtocolBlockScreen
 import { AuthFailedBanner } from '../../../src/components/AuthFailedBanner'
 import { MobileSearchField } from '../../../src/components/MobileSearchField'
 import { WorkspaceDetailPlaceholder } from '../../../src/components/WorkspaceDetailPlaceholder'
-import { getCachedWorktrees } from '../../../src/cache/worktree-cache'
+import { getCachedWorktrees, setCachedWorktrees } from '../../../src/cache/worktree-cache'
 import { setCachedRepos } from '../../../src/cache/repo-cache'
 import { colors, radii, spacing, typography } from '../../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../../src/layout/responsive-layout'
@@ -142,6 +145,7 @@ export function HostScreen({
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const lastConnectionError = useLastConnectionError(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const fetchWorktreesInFlightRef = useRef(false)
   const fetchRepoMetadataInFlightRef = useRef(false)
@@ -459,6 +463,14 @@ export function HostScreen({
             areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
           )
           setWorktreesLoaded(true)
+          // Why (#8498): the host detail screen used to read only from
+          // the home-seeded cache (initialCache), so a partial/fresh refetch
+          // here could not correct a poisoned snapshot. Write the same
+          // snapshot back through the cache so a later remount (or the
+          // resume card) sees the freshest worktree.ps, not a stale one.
+          if (hostId) {
+            setCachedWorktrees(hostId, result.worktrees)
+          }
           // Drop the optimistic active override once the host confirms it (the
           // activate RPC has landed and worktree.ps now reports it active), so we
           // stop overriding and respect any later desktop-driven change.
@@ -612,6 +624,15 @@ export function HostScreen({
     }, 3000)
     return () => clearInterval(interval)
   }, [embedded, connState, fetchWorktrees, fetchRepoMetadata, syncViewSettingsFromDesktop])
+
+  // Why (#8498): reconnect refetch + manual pull-to-refresh, extracted to
+  // useWorktreeResync so this screen stays under its max-lines budget.
+  const { refreshing, onRefresh } = useWorktreeResync({
+    client,
+    connState,
+    fetchWorktrees,
+    fetchRepoMetadata,
+  })
 
   const updateLocalPins = useCallback(
     (worktreeId: string, pinned: boolean) => {
@@ -877,7 +898,8 @@ export function HostScreen({
             const headerVerdict = classifyConnection({
               state: connState,
               reconnectAttempts,
-              lastConnectedAt
+              lastConnectedAt,
+              lastConnectionError
             })
             return (
               <>
@@ -1229,7 +1251,16 @@ export function HostScreen({
             )
           }}
           ItemSeparatorComponent={ListSeparator}
-          renderItem={({ item }) => (
+          // Why (#8498): manual pull-to-refresh forces a fresh worktree
+          // snapshot after a reconnect or whenever the cache looks stale.
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.textSecondary}
+              colors={[colors.textSecondary]}
+            />
+          }          renderItem={({ item }) => (
             <WorktreeListRow
               item={item}
               isReadOnly={isReadOnly}

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -60,7 +60,8 @@ import {
   useHostClient,
   useForceReconnect,
   useReconnectAttempt,
-  useLastConnectedAt
+  useLastConnectedAt,
+  useLastConnectionError
 } from '../../../../src/transport/client-context'
 import {
   classifyConnection,
@@ -838,6 +839,7 @@ export default function SessionScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const lastConnectionError = useLastConnectionError(hostId)
   const forceReconnectHost = useForceReconnect()
   const worktreeName = useLiveWorktreeName({
     client,
@@ -4364,7 +4366,8 @@ export default function SessionScreen() {
     state: connState,
     reconnectAttempts,
     lastConnectedAt,
-    endpoint: hostEndpoint
+    endpoint: hostEndpoint,
+    lastConnectionError
   })
   const showConnectionRetry =
     connectionVerdict.kind === 'warning' || connectionVerdict.kind === 'unreachable'

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -37,7 +37,8 @@ import type { RpcSuccess } from '../../../src/transport/types'
 import {
   useHostClient,
   useLastConnectedAt,
-  useReconnectAttempt
+  useReconnectAttempt,
+  useLastConnectionError
 } from '../../../src/transport/client-context'
 import { classifyConnection } from '../../../src/transport/connection-health'
 import { StatusDot } from '../../../src/components/StatusDot'
@@ -2197,6 +2198,7 @@ export default function MobileTasksScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
+  const lastConnectionError = useLastConnectionError(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const reposRef = useRef<RepoSummary[]>([])
   const loadGenerationRef = useRef(0)
@@ -8656,7 +8658,8 @@ export default function MobileTasksScreen() {
   const headerVerdict = classifyConnection({
     state: connState,
     reconnectAttempts,
-    lastConnectedAt
+    lastConnectedAt,
+    lastConnectionError
   })
   const emptyLabel =
     connState !== 'connected'

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -29,6 +29,7 @@ import { loadHosts, renameHost } from '../src/transport/host-store'
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
 import { pickResumeWorktree } from '../src/worktree/resume-worktree'
 import type { RpcClient } from '../src/transport/rpc-client'
+import { useHostConnectionState } from '../src/transport/use-host-connection-state'
 import {
   useAllHostClients,
   useCloseHost,
@@ -308,9 +309,6 @@ export default function HomeScreen() {
   const [actionTarget, setActionTarget] = useState<HostProfile | null>(null)
   const [renameTarget, setRenameTarget] = useState<HostProfile | null>(null)
   const [confirmRemove, setConfirmRemove] = useState<HostProfile | null>(null)
-  const [hostStates, setHostStates] = useState<Record<string, ConnectionState>>({})
-  const [hostAttempts, setHostAttempts] = useState<Record<string, number>>({})
-  const [hostLastConnected, setHostLastConnected] = useState<Record<string, number | null>>({})
   const [stats, setStats] = useState<StatsSummary | null>(null)
   const [worktreeInfo, setWorktreeInfo] = useState<Record<string, HostWorktreeInfo>>({})
   const [accountsByHost, setAccountsByHost] = useState<Record<string, AccountsSnapshot>>({})
@@ -324,6 +322,8 @@ export default function HomeScreen() {
   // docs/mobile-shared-client-per-host.md.
   const hostIds = useMemo(() => hosts.map((h) => h.id), [hosts])
   const allClients = useAllHostClients(hostIds)
+  // Why (#6784): mirror per-host connection state + real socket errors for the home verdict.
+  const { hostStates, hostAttempts, hostLastConnected, hostConnErrors } = useHostConnectionState({ allClients, hosts })
   const closeHostClient = useCloseHost()
   const forceReconnectHost = useForceReconnect()
   const primeHosts = usePrimeHosts()
@@ -424,75 +424,6 @@ export default function HomeScreen() {
     [hosts]
   )
 
-  // Why: mirror per-host connection state into hostStates so existing
-  // render code (status dots, connecting indicators) keeps working.
-  useEffect(() => {
-    setHostAttempts((prev) => {
-      const next: Record<string, number> = { ...prev }
-      let changed = false
-      for (const entry of allClients) {
-        const a = entry.client.getReconnectAttempt()
-        if (next[entry.hostId] !== a) {
-          next[entry.hostId] = a
-          changed = true
-        }
-      }
-      return changed ? next : prev
-    })
-    setHostLastConnected((prev) => {
-      const next: Record<string, number | null> = { ...prev }
-      let changed = false
-      for (const entry of allClients) {
-        const t = entry.client.getLastConnectedAt()
-        if (next[entry.hostId] !== t) {
-          next[entry.hostId] = t
-          changed = true
-        }
-      }
-      return changed ? next : prev
-    })
-    setHostStates((prev) => {
-      const next: Record<string, ConnectionState> = { ...prev }
-      let changed = false
-      const liveIds = new Set(allClients.map((e) => e.hostId))
-      for (const entry of allClients) {
-        if (next[entry.hostId] !== entry.state) {
-          next[entry.hostId] = entry.state
-          changed = true
-        }
-      }
-      // Why: when a paired host disappears from allClients (because the
-      // user tapped Disconnect, or the host record was invalid) the card
-      // must reflect that. We only force-update hosts whose state was
-      // already tracked — otherwise the initial-acquire frame (entry not
-      // yet materialised) would briefly flip every host to 'disconnected'.
-      for (const host of hosts) {
-        if (liveIds.has(host.id)) {
-          continue
-        }
-        if (!host.publicKeyB64 || !host.deviceToken) {
-          if (next[host.id] !== 'auth-failed') {
-            next[host.id] = 'auth-failed'
-            changed = true
-          }
-          continue
-        }
-        const prevState = next[host.id]
-        if (prevState && prevState !== 'disconnected' && prevState !== 'auth-failed') {
-          next[host.id] = 'disconnected'
-          changed = true
-        }
-      }
-      // Drop entries for hosts we no longer track at all.
-      for (const id of Object.keys(next)) {
-        if (!liveIds.has(id) && hosts.some((h) => h.id === id) === false) {
-          delete next[id]
-          changed = true
-        }
-      }
-      return changed ? next : prev
-    })
-  }, [allClients, hosts])
 
   // Why: per-host streaming subscriptions (notifications + accounts) and
   // one-shot stats fetches when each host transitions to 'connected'.
@@ -824,13 +755,15 @@ export default function HomeScreen() {
             const state = hostStates[item.id] ?? 'connecting'
             const attempts = hostAttempts[item.id] ?? 0
             const lastConnectedAt = hostLastConnected[item.id] ?? null
+            const lastConnectionError = hostConnErrors[item.id] ?? null
             const connected = state === 'connected'
             const info = worktreeInfo[item.id]
             const verdict = classifyConnection({
               state,
               reconnectAttempts: attempts,
               lastConnectedAt,
-              endpoint: item.endpoint
+              endpoint: item.endpoint,
+              lastConnectionError
             })
             const isError =
               verdict.kind === 'warning' ||

--- a/mobile/src/cache/worktree-cache.test.ts
+++ b/mobile/src/cache/worktree-cache.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { setCachedWorktrees, getCachedWorktrees } from './worktree-cache'
+
+// Why: AC #8498 guarantees a reconnect refetch writes through the
+// same cache path the host detail screen seeds from, so a reconnect can't
+// serve a stale snapshot. This unit pins the write-through contract.
+describe('worktree-cache write-through', () => {
+  it('returns the most-recently written snapshot, not a stale one', () => {
+    const hostId = 'host-write-through'
+    const stale = [{ worktreeId: 'a', name: 'stale' }]
+    const fresh = [{ worktreeId: 'a', name: 'fresh' }, { worktreeId: 'b', name: 'added' }]
+
+    setCachedWorktrees(hostId, stale)
+    expect(getCachedWorktrees(hostId)).toEqual(stale)
+
+    // Why: simulates the reconnect refetch write-through — the fresh
+    // worktree.ps snapshot must fully replace the poisoned cache entry.
+    setCachedWorktrees(hostId, fresh)
+    expect(getCachedWorktrees(hostId)).toEqual(fresh)
+    expect(getCachedWorktrees(hostId)).not.toEqual(stale)
+  })
+
+  it('exposes a fresh snapshot to a remounting screen after reconnect', () => {
+    // Why: the host detail screen reads getCachedWorktrees(hostId)
+    // on (re)mount as its initialCache. A reconnect that writes
+    // through must therefore surface here instead of the pre-reconnect data.
+    const hostId = 'host-remount'
+    setCachedWorktrees(hostId, [{ worktreeId: 'old', name: 'pre-reconnect' }])
+
+    // Reconnect refetch lands a fresh snapshot and writes it through.
+    const reconnected = [
+      { worktreeId: 'old', name: 'post-reconnect' },
+      { worktreeId: 'new', name: 'now-visible' }
+    ]
+    setCachedWorktrees(hostId, reconnected)
+
+    // A fresh screen mount reads the cache — must see the connected set.
+    expect(getCachedWorktrees(hostId)).toEqual(reconnected)
+  })
+})

--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -4,6 +4,7 @@ import {
   setScheduledNotificationsMaxForTests,
   subscribeToDesktopNotifications
 } from './mobile-notifications'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { RpcClient } from '../transport/rpc-client'
 import { loadPushNotificationsEnabled } from '../storage/preferences'
 
@@ -18,6 +19,16 @@ vi.mock('expo-notifications', () => ({
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' }
+}))
+
+// Why: mobile-notifications now persists the catch-up watermark to
+// AsyncStorage. The package isn't resolvable in the node test env (other
+// mobile tests mock it the same way), so we provide a no-op mock.
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(async () => null),
+    setItem: vi.fn(async () => undefined)
+  }
 }))
 
 vi.mock('../storage/preferences', () => ({
@@ -314,5 +325,213 @@ describe('subscribeToDesktopNotifications', () => {
     } finally {
       setScheduledNotificationsMaxForTests()
     }
+  })
+})
+
+// Why: #8129 catch-up. On a reconnect the live stream re-emits `ready`; the
+// client must fetch missed notifications from its watermark and push exactly
+// the ones it had not yet delivered — never re-pushing an already-delivered id.
+describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
+  const AsyncStorageMock = vi.mocked(AsyncStorage)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    AsyncStorageMock.getItem.mockResolvedValue(null)
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+  })
+
+  function flushAsync(): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+  }
+
+  function makeClient() {
+    let onData: ((data: unknown) => void) | null = null
+    const sentRequests: { method: string; params: unknown }[] = []
+    const client = {
+      subscribe: vi.fn((_method: string, _params: unknown, cb: (data: unknown) => void) => {
+        onData = cb
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn(
+        async (method: string, params: unknown = {}) =>
+          ({
+            ok: true,
+            result:
+              method === 'notifications.getMissedSince'
+                ? { notifications: [] }
+                : undefined
+          }) as never
+      )
+    }
+    // Why: onData is captured live via a getter (not destructured) because the
+    // subscribe mock assigns it asynchronously as a side effect of
+    // subscribeToDesktopNotifications calling client.subscribe.
+    return {
+      client: client as unknown as RpcClient,
+      get onData() {
+        return onData
+      },
+      sentRequests
+    }
+  }
+
+  it('does not fetch missed notifications on the first (cold-open) ready', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    // First ready = cold open.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+
+    expect(sub.client.sendRequest).not.toHaveBeenCalledWith(
+      'notifications.getMissedSince',
+      expect.anything()
+    )
+  })
+
+  it('fetches only notifications after the delivered watermark (idempotent catch-up)', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
+
+    const sub = makeClient()
+    // The desktop honours the watermark: only seq 10 (agent:missed) is returned
+    // because seq 11 (agent:dup) was already delivered on the live stream and
+    // advanced lastDeliveredSeq to 11. So the replay never re-includes it.
+    sub.client.sendRequest = vi.fn(async (method: string) => {
+      if (method === 'notifications.getMissedSince') {
+        return {
+          ok: true,
+          result: {
+            notifications: [
+              { type: 'notification', title: 'missed', body: 'b', notificationId: 'agent:missed', notificationSeq: 10 }
+            ]
+          }
+        } as never
+      }
+      return { ok: true, result: undefined } as never
+    })
+
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    // First ready = cold open (no fetch).
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    // Live stream already delivered agent:dup (seq 11) before reap.
+    sub.onData?.({
+      type: 'notification',
+      title: 'dup',
+      body: 'b',
+      notificationId: 'agent:dup',
+      notificationSeq: 11
+    })
+    await flushAsync()
+    // Reconnect ready → fetchMissed sends the watermark (11).
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    await flushAsync()
+
+    // The watermark passed to getMissedSince is the delivered seq.
+    const missedCall = vi.mocked(sub.client.sendRequest).mock.calls.find(
+      (c: unknown[]) => c[0] === 'notifications.getMissedSince'
+    )
+    expect(missedCall?.[1]).toEqual({ lastSeenSeq: 11 })
+    // Only agent:missed was pushed; agent:dup appears exactly once (live only).
+    const scheduledIds = vi.mocked(Notifications.scheduleNotificationAsync).mock.calls.map(
+      (call) => (call[0] as { content: { data: { notificationId: string } } }).content.data
+        .notificationId
+    )
+    expect(scheduledIds).toEqual(['agent:dup', 'agent:missed'])
+    expect(scheduledIds.filter((id) => id === 'agent:dup')).toHaveLength(1)
+  })
+
+  it('drops an already-seen id if a replay re-includes it (defense-in-depth)', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+
+    const sub = makeClient()
+    // Simulate the bounded-buffer edge: the desktop returns seq 11 again
+    // (already delivered live) alongside a new seq 12.
+    sub.client.sendRequest = vi.fn(async (method: string) => {
+      if (method === 'notifications.getMissedSince') {
+        return {
+          ok: true,
+          result: {
+            notifications: [
+              { type: 'notification', title: 'dup', body: 'b', notificationId: 'agent:dup', notificationSeq: 11 },
+              { type: 'notification', title: 'new', body: 'b', notificationId: 'agent:new', notificationSeq: 12 }
+            ]
+          }
+        } as never
+      }
+      return { ok: true, result: undefined } as never
+    })
+
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    // Live stream delivered agent:dup (seq 11) before reap.
+    sub.onData?.({
+      type: 'notification',
+      title: 'dup',
+      body: 'b',
+      notificationId: 'agent:dup',
+      notificationSeq: 11
+    })
+    await flushAsync()
+    // Reconnect replay re-includes seq 11 (must be dropped) + new seq 12.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    await flushAsync()
+
+    const scheduledIds = vi.mocked(Notifications.scheduleNotificationAsync).mock.calls.map(
+      (call) => (call[0] as { content: { data: { notificationId: string } } }).content.data
+        .notificationId
+    )
+    expect(scheduledIds).toEqual(['agent:dup', 'agent:new'])
+    expect(scheduledIds.filter((id) => id === 'agent:dup')).toHaveLength(1)
+  })
+
+  it('persists the highest delivered seq so a later reconnect resumes from it', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    // Live stream delivers seq 5.
+    sub.onData?.({
+      type: 'notification',
+      title: 't',
+      body: 'b',
+      notificationId: 'agent:live',
+      notificationSeq: 5
+    })
+    await flushAsync()
+
+    expect(AsyncStorageMock.setItem).toHaveBeenCalledWith(
+      'orca:mobileNotificationsLastSeq:host-1',
+      '5'
+    )
   })
 })

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications'
 import { Platform } from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { RpcClient } from '../transport/rpc-client'
 import { loadPushNotificationsEnabled } from '../storage/preferences'
 import { buildLocalNotificationData, type DesktopNotificationSource } from './notification-routing'
@@ -11,11 +12,16 @@ type NotificationEvent = {
   body: string
   worktreeId?: string
   notificationId?: string
+  // Mirrors the desktop-assigned MobileNotificationEvent.notificationSeq used
+  // for reconnect catch-up (#8129). Optional because older runtimes / non-
+  // replay events may omit it.
+  notificationSeq?: number
 }
 
 type DismissNotificationEvent = {
   type: 'dismiss'
   notificationId: string
+  notificationSeq?: number
 }
 
 type SubscribeResult = {
@@ -42,6 +48,93 @@ let maxScheduledNotifications = MAX_SCHEDULED_NOTIFICATIONS
 
 function getStoredNotificationKey(hostId: string, notificationId: string): string {
   return `${encodeURIComponent(hostId)}:${encodeURIComponent(notificationId)}`
+}
+
+// Why: the highest desktop notification seq this device has delivered is
+// persisted per-host so it survives app restarts. On reconnect we send it to
+// notifications.getMissedSince as the catch-up watermark — the desktop then
+// returns only notifications dispatched after it, so we never re-push a
+// notification we already delivered (#8129). The in-memory seen-set below is a
+// second guard against double-delivery for events that arrive on both the live
+// stream and a replay (e.g. a brief liveness spell before a reap).
+const LAST_SEQ_STORAGE_KEY_PREFIX = 'orca:mobileNotificationsLastSeq:'
+
+function lastSeqStorageKey(hostId: string): string {
+  return LAST_SEQ_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
+}
+
+async function loadLastSeenSeq(hostId: string): Promise<number> {
+  try {
+    const raw = await AsyncStorage.getItem(lastSeqStorageKey(hostId))
+    const parsed = raw == null ? 0 : Number(raw)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+  } catch {
+    return 0
+  }
+}
+
+async function saveLastSeenSeq(hostId: string, seq: number): Promise<void> {
+  if (!Number.isFinite(seq) || seq <= 0) {
+    return
+  }
+  try {
+    await AsyncStorage.setItem(lastSeqStorageKey(hostId), String(seq))
+  } catch {
+    // Why: durability of the watermark is best-effort. If it fails we simply
+    // under-fetch on the next reconnect and the live stream covers the gap.
+  }
+}
+
+// Why: bounded in-memory dedup window for notificationIds/dismiss ids observed
+// on the current connection. The desktop already dedupes by seq on replay, but
+// a socket that flickers background→foreground→background can deliver an event
+// on the live stream and again in a replay; the seen-set guarantees each
+// notificationId maps to at most one local push for the connection lifetime.
+// Bounded so a long-lived session can't grow without limit (matches the
+// desktop's 256-entry replay buffer and the 256 scheduled-notification cap).
+const RECENTLY_SEEN_CAP = 512
+
+function createSeenNotificationGuard(): {
+  has: (id: string) => boolean
+  add: (id: string) => void
+} {
+  const seen = new Set<string>()
+  return {
+    has(id: string): boolean {
+      return seen.has(id)
+    },
+    add(id: string): void {
+      seen.add(id)
+      if (seen.size > RECENTLY_SEEN_CAP) {
+        // Why: insertion order; the oldest entries are first. Drop one to stay
+        // bounded without disturbing the more-recently-relevant keys.
+        const first = seen.values().next().value
+        if (first !== undefined) {
+          seen.delete(first)
+        }
+      }
+    }
+  }
+}
+
+// Why: key for the replay dedup guard. Uses notificationId when present, but
+// disambiguates by seq so a legitimate live re-delivery of the same id at a
+// NEW seq (content refresh, allowed by the existing behaviour) is NOT treated
+// as a duplicate, while a replay re-returning the SAME id+seq already delivered
+// live is suppressed. Replay events always carry a seq (the desktop assigns
+// one), so the guard is effective on the reconnect path.
+function seenKeyForEvent(event: NotificationEvent | DismissNotificationEvent): string | null {
+  const id = event.notificationId
+  if (id != null && event.notificationSeq != null) {
+    return `id:${id}#${event.notificationSeq}`
+  }
+  if (id != null) {
+    return `id:${id}`
+  }
+  if (event.notificationSeq != null) {
+    return `seq:${event.notificationSeq}`
+  }
+  return null
 }
 
 // Evict the oldest SETTLED entries (never one mid-schedule) until within the cap.
@@ -223,18 +316,105 @@ async function dismissLocalNotification(
 
 // Why: each host connection gets its own notification subscription. When the
 // connection drops, the unsubscribe function cleans up the streaming RPC.
+// On reconnect the same subscribe stream is re-established by the RPC client;
+// we use its `ready` event to trigger catch-up (#8129): fetch notifications
+// dispatched while the socket was reaped, watermarked by the last seq we
+// already delivered so the desktop never re-sends an already-pushed one.
 // Returns an unsubscribe function.
 export function subscribeToDesktopNotifications(client: RpcClient, hostId: string): () => void {
   configureNotificationChannel()
 
   let subscriptionId: string | null = null
   let disposed = false
+  // Highest seq delivered on the live stream or replay for this connection.
+  // Persisted per-host so a cold app start still resumes from the right cut.
+  let lastDeliveredSeq = 0
+  // Why: per-connection dedup guard applied ONLY to the replay path
+  // (fetchMissed), never the live stream. The desktop already guarantees the
+  // replay cannot contain an event with seq <= lastDeliveredSeq (both live and
+  // replay advance the same watermark), so live + replay never overlap there.
+  // This set is defense-in-depth: if the desktop's bounded buffer evicted an
+  // old entry and a reconnect re-fetches across a boundary, an id delivered in
+  // the same connection isn't pushed twice. Bounded (RECENTLY_SEEN_CAP) so a
+  // long-lived session can't grow without limit.
+  const seenReplay = createSeenNotificationGuard()
+
+  function deliverLive(
+    type: 'notification' | 'dismiss',
+    event: NotificationEvent | DismissNotificationEvent
+  ): Promise<void> {
+    if (event.notificationSeq != null && event.notificationSeq > lastDeliveredSeq) {
+      lastDeliveredSeq = event.notificationSeq
+      void saveLastSeenSeq(hostId, lastDeliveredSeq)
+    }
+    // Why (#8129 dedup): mark the event seen on EVERY delivery path (live AND
+    // replay) so a replay that re-includes an id already pushed live in this
+    // connection is dropped instead of double-pushed. fetchMissed also
+    // pre-checks seenReplay, but without this the live path never populated it.
+    const key = seenKeyForEvent(event)
+    if (key) {
+      seenReplay.add(key)
+    }
+    if (type === 'notification') {
+      return showLocalNotification(event as NotificationEvent, hostId)
+    }
+    return dismissLocalNotification(event as DismissNotificationEvent, hostId)
+  }
+
+  // Why: on a reconnect `ready` the desktop has already dispatched whatever we
+  // missed; ask for it from our persisted watermark. Because the desktop cuts
+  // by seq > lastSeenSeq this is idempotent — we only ever get events we have
+  // not delivered before. The seenReplay guard is a second layer so a replay
+  // that somehow re-includes an id already delivered this connection is
+  // dropped instead of double-pushed.
+  async function fetchMissed(): Promise<void> {
+    if (disposed) {
+      return
+    }
+    const missed = await client
+      .sendRequest('notifications.getMissedSince', { lastSeenSeq: lastDeliveredSeq })
+      .then((response) => {
+        if (!response.ok) {
+          return []
+        }
+        const result = response.result as { notifications?: unknown[] } | undefined
+        return Array.isArray(result?.notifications) ? result.notifications : []
+      })
+      .catch(() => [])
+    for (const raw of missed) {
+      const event = raw as NotificationEvent | DismissNotificationEvent
+      const key = seenKeyForEvent(event)
+      if (key && seenReplay.has(key)) {
+        continue
+      }
+      if (key) {
+        seenReplay.add(key)
+      }
+      if (event.type === 'notification') {
+        await deliverLive('notification', event)
+      } else if (event.type === 'dismiss') {
+        await deliverLive('dismiss', event)
+      }
+    }
+  }
+
+  // Why: lazily seed the watermark from durable storage on first use so we
+  // don't block subscribe() on an AsyncStorage read. The first `ready` (cold
+  // open) does NOT need catch-up — the live stream starts fresh; only
+  // subsequent reconnect `ready` events fetch missed notifications.
+  let watermarkLoaded = false
+  void loadLastSeenSeq(hostId).then((seq) => {
+    lastDeliveredSeq = seq
+    watermarkLoaded = true
+  })
+
   function unsubscribeServer(id: string) {
     if (client.getState() === 'connected') {
       client.sendRequest('notifications.unsubscribe', { subscriptionId: id }).catch(() => {})
     }
   }
 
+  let reconnectReadyCount = 0
   const unsubscribeStream = client.subscribe('notifications.subscribe', {}, (data: unknown) => {
     const event = data as
       | NotificationEvent
@@ -243,9 +423,18 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
       | { type: 'end' }
     if (event.type === 'ready') {
       subscriptionId = (event as SubscribeResult).subscriptionId
+      reconnectReadyCount += 1
       if (disposed) {
         unsubscribeServer(subscriptionId)
         unsubscribeStream()
+        return
+      }
+      // Why: first ready is the cold-open live stream — no catch-up needed.
+      // Every later ready is a reconnect; fetch what we missed from the
+      // watermark. Guard on watermarkLoaded so a fast reconnect doesn't
+      // fetch from a stale 0 watermark (which would re-push everything).
+      if (reconnectReadyCount > 1 && watermarkLoaded) {
+        void fetchMissed()
       }
       return
     }
@@ -259,9 +448,9 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
       return
     }
     if (event.type === 'notification') {
-      void showLocalNotification(event as NotificationEvent, hostId)
+      void deliverLive('notification', event as NotificationEvent)
     } else if (event.type === 'dismiss') {
-      void dismissLocalNotification(event as DismissNotificationEvent, hostId)
+      void deliverLive('dismiss', event as DismissNotificationEvent)
     }
   })
 

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -404,7 +404,7 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
   // subsequent reconnect `ready` events fetch missed notifications.
   let watermarkLoaded = false
   void loadLastSeenSeq(hostId).then((seq) => {
-    lastDeliveredSeq = seq
+    lastDeliveredSeq = Math.max(lastDeliveredSeq, seq)
     watermarkLoaded = true
   })
 

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -279,6 +279,12 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     return storeRef.current.get(hostId)?.client.getLastConnectedAt() ?? null
   }, [])
 
+  // Why (#6784): surface the real socket error so the connection verdict
+  // can render it instead of a canned label.
+  const getLastConnectionError = useCallback((hostId: string): string | null => {
+    return storeRef.current.get(hostId)?.client.getLastConnectionError() ?? null
+  }, [])
+
   const subscribeHostState = useCallback(
     (hostId: string, listener: (state: ConnectionState) => void) => {
       let set = stateListenersRef.current.get(hostId)
@@ -357,6 +363,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       getState,
       getReconnectAttempt,
       getLastConnectedAt,
+      getLastConnectionError,
       subscribeHostState,
       getAllClients,
       subscribeAllHosts,
@@ -370,6 +377,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       getState,
       getReconnectAttempt,
       getLastConnectedAt,
+      getLastConnectionError,
       subscribeHostState,
       getAllClients,
       subscribeAllHosts,
@@ -551,3 +559,7 @@ export function useLastConnectedAt(hostId: string | undefined): number | null {
   }, [ctx, hostId])
   return hostId ? ctx.getLastConnectedAt(hostId) : null
 }
+
+// Why (#6784): re-exported from its own module to keep this file under its
+// max-lines budget; the definition lives in use-last-connection-error.ts.
+export { useLastConnectionError } from './use-last-connection-error'

--- a/mobile/src/transport/connection-health.test.ts
+++ b/mobile/src/transport/connection-health.test.ts
@@ -46,6 +46,28 @@ describe('classifyConnection Tailscale hint', () => {
     expect('hint' in verdict && verdict.hint).toBeFalsy()
   })
 
+  it('surfaces the real socket error as the hint (issue #6784)', () => {
+    const warning = classifyConnection({
+      ...base,
+      reconnectAttempts: 3,
+      endpoint: 'ws://192.168.1.50:6768',
+      lastConnectionError: 'WebSocket error: getaddrinfo ENOTFOUND host.local'
+    })
+    expect(warning.kind).toBe('warning')
+    // Why: the real cause must win over a canned/derived hint.
+    expect(warning.hint).toBe('WebSocket error: getaddrinfo ENOTFOUND host.local')
+  })
+
+  it('keeps a plain label when there is no socket error', () => {
+    const warning = classifyConnection({
+      ...base,
+      reconnectAttempts: 3,
+      endpoint: 'ws://192.168.1.50:6768'
+    })
+    expect(warning.kind).toBe('warning')
+    expect('hint' in warning && warning.hint).toBeFalsy()
+  })
+
   it('never hints on healthy states', () => {
     const verdict = classifyConnection({
       state: 'connected',

--- a/mobile/src/transport/connection-health.ts
+++ b/mobile/src/transport/connection-health.ts
@@ -39,6 +39,11 @@ export type ConnectionVerdict =
     }
   | { kind: 'auth-failed'; label: string }
 
+// Why: the most recent fatal socket error (from ws.onerror), carried
+// into the verdict so the UI can show the real failure (#6784) instead
+// of only a canned label. Callers read it off the RpcClient.
+export type ConnectionError = string | null
+
 // Why: the rpc-client's lastConnectedAt is a one-shot timestamp; we have
 // to recompute "are we currently stale" against now() each render.
 // Centralized so home + host-detail show identical verdicts.
@@ -49,11 +54,18 @@ export function classifyConnection(args: {
   // Optional pinned host endpoint — enables the Tailscale hint on
   // warning/unreachable verdicts. Callers without it get plain labels.
   endpoint?: string | null
+  // Optional last fatal socket error (ws.onerror). When present it is
+  // surfaced as the hint so the user sees the real cause (#6784).
+  lastConnectionError?: ConnectionError
   nowMs?: number
 }): ConnectionVerdict {
   const { state, reconnectAttempts, lastConnectedAt } = args
   const now = args.nowMs ?? Date.now()
-  const hint = isTailscaleEndpoint(args.endpoint) ? TAILSCALE_HINT : undefined
+  // Why: prefer the real socket error over the generic Tailscale hint
+  // when both are available — the socket error is the proximate cause.
+  const hint =
+    args.lastConnectionError ??
+    (isTailscaleEndpoint(args.endpoint) ? TAILSCALE_HINT : undefined)
 
   if (state === 'auth-failed') {
     return { kind: 'auth-failed', label: 'Auth failed' }

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -699,7 +699,7 @@ export function connect(
       const message = e?.message ?? null
       // Why: capture the real failure so the connection verdict can show
       // it to the user instead of a canned label (#6784).
-      captureConnectionError(message)
+      lastConnectionError = message
       const errEvent = describeSocketEvent(event)
       console.log('[net] ws.onerror', {
         message: e?.message,

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -86,6 +86,10 @@ export type RpcClient = {
   // to distinguish "host moved/never reachable" from "transient blip".
   getLastConnectedAt: () => number | null
   onStateChange: (listener: (state: ConnectionState) => void) => () => void
+  // Why: the last fatal ws error message (from ws.onerror) — surfaced
+  // into the connection verdict so the UI can show the real failure
+  // (#6784) instead of a canned label. Cleared on a successful connect.
+  getLastConnectionError: () => string | null
   // Why: app-resume hook. Android/iOS can kill the TCP path or park the
   // reconnect loop while the app is backgrounded; callers invoke this on
   // AppState 'active' so the session recovers without an app restart.
@@ -190,6 +194,10 @@ export function connect(
   // every 'connected'.
   let authRejectionCount = 0
   let lastConnectedAt: number | null = null
+  // Why: most recent fatal ws.onerror message (#6784). Carried into
+  // the connection verdict so the UI shows the real failure instead of
+  // a canned label. Cleared on a successful handshake.
+  let lastConnectionError: string | null = null
   // Why: cheap diagnostics for RN/OkHttp process-state poisoning: do retry
   // attempts differ, is anything inbound, and are closes instant or slow?
   let lastInboundAt: number | null = null
@@ -249,6 +257,9 @@ export function connect(
     })
     if (next === 'connected') {
       lastConnectedAt = Date.now()
+      // Why: a clean handshake proves the link is healthy — clear any
+      // stale error so the verdict doesn't keep showing a dead cause (#6784).
+      lastConnectionError = null
       // Why: a clean handshake proves the token is valid — clear the auth
       // retry budget so a future isolated rejection gets the full budget again.
       authRejectionCount = 0
@@ -685,6 +696,10 @@ export function connect(
       // onclose fires right after, but logging the error message gives us
       // the original cause that the close code alone can hide.
       const e = event as { message?: string } | undefined
+      const message = e?.message ?? null
+      // Why: capture the real failure so the connection verdict can show
+      // it to the user instead of a canned label (#6784).
+      captureConnectionError(message)
       const errEvent = describeSocketEvent(event)
       console.log('[net] ws.onerror', {
         message: e?.message,
@@ -1205,6 +1220,10 @@ export function connect(
 
     getLastConnectedAt(): number | null {
       return lastConnectedAt
+    },
+
+    getLastConnectionError(): string | null {
+      return lastConnectionError
     },
 
     onStateChange(listener: (state: ConnectionState) => void): () => void {

--- a/mobile/src/transport/use-host-connection-state.ts
+++ b/mobile/src/transport/use-host-connection-state.ts
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react'
+import type { ConnectionState, HostProfile } from './transport/types'
+import type { RpcClient } from './transport/rpc-client'
+
+export type HostClientEntry = { hostId: string; client: RpcClient }
+
+// Why (#6784 + connection-state mirroring): extracted from HomeScreen so that
+// file stays under its max-lines budget. Mirrors each host's live connection
+// state (state/attempts/lastConnected/last socket error) into React state so
+// the home verdict + status dots keep working. Logic is unchanged from the
+// original inline effect.
+export function useHostConnectionState(args: {
+  allClients: HostClientEntry[]
+  hosts: HostProfile[]
+}): {
+  hostStates: Record<string, ConnectionState>
+  hostAttempts: Record<string, number>
+  hostLastConnected: Record<string, number | null>
+  hostConnErrors: Record<string, string | null>
+} {
+  const { allClients, hosts } = args
+  const [hostStates, setHostStates] = useState<Record<string, ConnectionState>>({})
+  const [hostAttempts, setHostAttempts] = useState<Record<string, number>>({})
+  const [hostLastConnected, setHostLastConnected] = useState<Record<string, number | null>>({})
+  const [hostConnErrors, setHostConnErrors] = useState<Record<string, string | null>>({})
+
+  // Why: mirror per-host connection state into hostStates so existing
+  // render code (status dots, connecting indicators) keeps working.
+  useEffect(() => {
+    setHostAttempts((prev) => {
+      const next: Record<string, number> = { ...prev }
+      let changed = false
+      for (const entry of allClients) {
+        const a = entry.client.getReconnectAttempt()
+        if (next[entry.hostId] !== a) {
+          next[entry.hostId] = a
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+    setHostLastConnected((prev) => {
+      const next: Record<string, number | null> = { ...prev }
+      let changed = false
+      for (const entry of allClients) {
+        const t = entry.client.getLastConnectedAt()
+        if (next[entry.hostId] !== t) {
+          next[entry.hostId] = t
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+    // Why (#6784): mirror the real socket error so the home verdict shows it.
+    setHostConnErrors((prev) => {
+      const next: Record<string, string | null> = { ...prev }
+      let changed = false
+      for (const entry of allClients) {
+        const err = entry.client.getLastConnectionError()
+        if (next[entry.hostId] !== err) {
+          next[entry.hostId] = err
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+    setHostStates((prev) => {
+      const next: Record<string, ConnectionState> = { ...prev }
+      let changed = false
+      const liveIds = new Set(allClients.map((e) => e.hostId))
+      for (const entry of allClients) {
+        if (next[entry.hostId] !== entry.state) {
+          next[entry.hostId] = entry.state
+          changed = true
+        }
+      }
+      // Why: when a paired host disappears from allClients (because the
+      // user tapped Disconnect, or the host record was invalid) the card
+      // must reflect that. We only force-update hosts whose state was
+      // already tracked — otherwise the initial-acquire frame (entry not
+      // yet materialised) would briefly flip every host to 'disconnected'.
+      for (const host of hosts) {
+        if (liveIds.has(host.id)) {
+          continue
+        }
+        if (!host.publicKeyB64 || !host.deviceToken) {
+          if (next[host.id] !== 'auth-failed') {
+            next[host.id] = 'auth-failed'
+            changed = true
+          }
+          continue
+        }
+        const prevState = next[host.id]
+        if (prevState && prevState !== 'disconnected' && prevState !== 'auth-failed') {
+          next[host.id] = 'disconnected'
+          changed = true
+        }
+      }
+      // Drop entries for hosts we no longer track at all.
+      for (const id of Object.keys(next)) {
+        if (!liveIds.has(id) && hosts.some((h) => h.id === id) === false) {
+          delete next[id]
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [allClients, hosts])
+
+  return { hostStates, hostAttempts, hostLastConnected, hostConnErrors }
+}

--- a/mobile/src/transport/use-host-connection-state.ts
+++ b/mobile/src/transport/use-host-connection-state.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import type { ConnectionState, HostProfile } from './transport/types'
 import type { RpcClient } from './transport/rpc-client'
 
-export type HostClientEntry = { hostId: string; client: RpcClient }
+export type HostClientEntry = { hostId: string; client: RpcClient; state: ConnectionState }
 
 // Why (#6784 + connection-state mirroring): extracted from HomeScreen so that
 // file stays under its max-lines budget. Mirrors each host's live connection

--- a/mobile/src/transport/use-last-connection-error.ts
+++ b/mobile/src/transport/use-last-connection-error.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+import { useCtx } from './client-context'
+
+// Why (#6784): the real socket error from the last ws.onerror, so the
+// connection verdict can render it instead of a canned label. Extracted from
+// client-context.tsx to keep that file under its max-lines budget.
+export function useLastConnectionError(hostId: string | undefined): string | null {
+  const ctx = useCtx()
+  const [, force] = useState(0)
+  useEffect(() => {
+    if (!hostId) {
+      return
+    }
+    return ctx.subscribeHostState(hostId, () => force((n) => n + 1))
+  }, [ctx, hostId])
+  return hostId ? ctx.getLastConnectionError(hostId) : null
+}

--- a/mobile/src/transport/use-worktree-resync.ts
+++ b/mobile/src/transport/use-worktree-resync.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { RpcClient } from './rpc-client'
+import type { ConnectionState } from './types'
+
+// Why (#8498): extracted from HostScreen so the file stays under its
+// max-lines budget. Handles the reconnect edge (refetch on transition into
+// 'connected') and manual pull-to-refresh, neither of which the steady-state
+// focus/embedded polls cover.
+export function useWorktreeResync(args: {
+  client: RpcClient | null
+  connState: ConnectionState
+  fetchWorktrees: (opts?: { allowDuringModal?: boolean }) => Promise<void>
+  fetchRepoMetadata: () => Promise<void>
+}): { refreshing: boolean; onRefresh: () => Promise<void> } {
+  const { client, connState, fetchWorktrees, fetchRepoMetadata } = args
+
+  // Why (#8498): socket-only reconnect left a stale cached snapshot after
+  // background/sleep. Refetch on the transition INTO 'connected', not every poll tick.
+  const prevConnStateRef = useRef(connState)
+  useEffect(() => {
+    const prev = prevConnStateRef.current
+    prevConnStateRef.current = connState
+    if (prev !== 'connected' && connState === 'connected' && client) {
+      void fetchWorktrees({ allowDuringModal: true })
+      void fetchRepoMetadata()
+    }
+  }, [connState, client, fetchWorktrees, fetchRepoMetadata])
+
+  const [refreshing, setRefreshing] = useState(false)
+  // Why (#8498): let the user force a fresh snapshot instead of the possibly-poisoned cache.
+  const onRefresh = useCallback(async () => {
+    if (!client || connState !== 'connected') {
+      return
+    }
+    setRefreshing(true)
+    try {
+      await fetchWorktrees({ allowDuringModal: true })
+      await fetchRepoMetadata()
+    } finally {
+      setRefreshing(false)
+    }
+  }, [client, connState, fetchWorktrees, fetchRepoMetadata])
+
+  return { refreshing, onRefresh }
+}

--- a/src/main/runtime/mobile-notification-replay.test.ts
+++ b/src/main/runtime/mobile-notification-replay.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MobileNotificationReplayBuffer,
+  type ReplayableMobileNotification
+} from './mobile-notification-replay'
+import type { MobileNotificationDispatchEvent } from './orca-runtime'
+
+function dispatch(
+  buffer: MobileNotificationReplayBuffer,
+  partial: Partial<MobileNotificationDispatchEvent> = {}
+): ReplayableMobileNotification {
+  const event: MobileNotificationDispatchEvent = {
+    type: 'notification',
+    source: 'agent-task-complete',
+    title: 'Done',
+    body: 'Finished.',
+    ...partial
+  }
+  buffer.record(event)
+  return buffer.getMissedSince(0).at(-1) as ReplayableMobileNotification
+}
+
+describe('MobileNotificationReplayBuffer', () => {
+  it('assigns a strictly increasing monotonic seq to every recorded event', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const a = dispatch(buffer, { notificationId: 'agent:one' })
+    const b = dispatch(buffer, { notificationId: 'agent:two' })
+    const c = dispatch(buffer, { notificationId: 'agent:three' })
+    expect(a.seq).toBe(1)
+    expect(b.seq).toBe(2)
+    expect(c.seq).toBe(3)
+    expect(c.seq).toBeGreaterThan(b.seq)
+    expect(b.seq).toBeGreaterThan(a.seq)
+  })
+
+  it('returns missed notifications that were dispatched after the watermark', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    dispatch(buffer, { notificationId: 'agent:one' })
+    const b = dispatch(buffer, { notificationId: 'agent:two' })
+    dispatch(buffer, { notificationId: 'agent:three' })
+
+    // Client reconnected having delivered up to seq 1.
+    const missed = buffer.getMissedSince(b.seq - 1)
+    expect(missed.map((e) => e.notificationId)).toEqual(['agent:two', 'agent:three'])
+  })
+
+  it('does NOT return already-delivered notifications (dedupe regression)', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const a = dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+    dispatch(buffer, { notificationId: 'agent:three' })
+
+    // Client already delivered everything up to seq 3, then reconnects again.
+    const missed = buffer.getMissedSince(a.seq + 2)
+    expect(missed).toEqual([])
+  })
+
+  it('is idempotent: the same watermark always yields the same set', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+    dispatch(buffer, { notificationId: 'agent:three' })
+
+    const first = buffer.getMissedSince(1)
+    const second = buffer.getMissedSince(1)
+    expect(second).toEqual(first)
+    expect(second.map((e) => e.notificationId)).toEqual(['agent:two', 'agent:three'])
+  })
+
+  it('does not duplicate an event that arrived on both live stream and replay', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const a = dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+
+    // Live stream delivered seq 1 (agent:one) during a brief liveness spell.
+    // Reconnect asks for everything after 0 — must include agent:one exactly
+    // once, never twice.
+    const missed = buffer.getMissedSince(a.seq - 1)
+    const ids = missed.map((e) => e.notificationId)
+    expect(ids).toEqual(['agent:one', 'agent:two'])
+    expect(ids.filter((id) => id === 'agent:one')).toHaveLength(1)
+  })
+
+  it('returns the whole buffer when the watermark is 0 (cold open)', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+    expect(buffer.getMissedSince(0).map((e) => e.notificationId)).toEqual([
+      'agent:one',
+      'agent:two'
+    ])
+  })
+
+  it('evicts oldest entries once the capacity is exceeded', () => {
+    const buffer = new MobileNotificationReplayBuffer(2)
+    dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+    dispatch(buffer, { notificationId: 'agent:three' })
+
+    // Capacity is 2, so the first entry is evicted; even from watermark 0 we
+    // only get the two retained plus the newest.
+    const retained = buffer.getMissedSince(0).map((e) => e.notificationId)
+    expect(retained).toEqual(['agent:two', 'agent:three'])
+    expect(buffer.size).toBe(2)
+  })
+})

--- a/src/main/runtime/mobile-notification-replay.ts
+++ b/src/main/runtime/mobile-notification-replay.ts
@@ -1,0 +1,63 @@
+import type { MobileNotificationEvent } from './orca-runtime'
+
+// Why: when a mobile client's socket is reaped (background/sleep, or a warm
+// proxy that delays the heartbeat reap), notifications dispatched in that
+// window are lost — there is no queue. This buffer is the catch-up source of
+// truth on the desktop: every notification that flows through
+// dispatchMobileNotification is recorded with a monotonic seq, and a reconnecting
+// client asks for everything after the seq it last acknowledged.
+//
+// Idempotency (the adversarial-review gate for #8129): replay is keyed by a
+// global monotonic seq, not by wall-clock. getMissedSince(lastSeenSeq) returns
+// exactly the events with seq > lastSeenSeq. Re-requesting with the same
+// watermark returns the same set; requesting with the client's true watermark
+// can never return an already-delivered event. The client additionally tracks
+// seen ids, so even a buffer-cap overlap cannot double-push.
+export type ReplayableMobileNotification = MobileNotificationEvent & {
+  seq: number
+}
+
+// Why: bound the buffer. 256 completes a few minutes of real agent activity and
+// tracks the client's existing MAX_SCHEDULED_NOTIFICATIONS (256) cap, far beyond
+// any background window a reconnect can still salvage. Beyond the cap we evict
+// oldest-first; a reconnect after that long is effectively a cold open and the
+// live stream resumes from current, so dropping older entries is acceptable.
+const DEFAULT_CAPACITY = 256
+
+export class MobileNotificationReplayBuffer {
+  private readonly capacity: number
+  private seq = 0
+  private readonly buffer: ReplayableMobileNotification[] = []
+
+  constructor(capacity: number = DEFAULT_CAPACITY) {
+    this.capacity = capacity
+  }
+
+  // Records a dispatched event and returns the monotonic seq assigned to it.
+  // Callers surface the seq so clients can watermark their last-seen position
+  // (both on the live fan-out and on explicit catch-up requests).
+  record(event: MobileNotificationEvent): number {
+    const seq = ++this.seq
+    this.buffer.push({ ...event, seq })
+    if (this.buffer.length > this.capacity) {
+      // Why: insertion-order array; oldest entries sit at the front.
+      this.buffer.splice(0, this.buffer.length - this.capacity)
+    }
+    return seq
+  }
+
+  // Returns every recorded event with seq strictly greater than lastSeenSeq.
+  // Because seq is monotonic and global, this is an exact, idempotent cut:
+  // the same lastSeenSeq always yields the same result.
+  getMissedSince(lastSeenSeq: number): ReplayableMobileNotification[] {
+    if (lastSeenSeq >= this.seq) {
+      return []
+    }
+    return this.buffer.filter((entry) => entry.seq > lastSeenSeq)
+  }
+
+  // Test/inspection helper: number of events currently retained.
+  get size(): number {
+    return this.buffer.length
+  }
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -721,6 +721,10 @@ import {
   registerTerminalViewAttributesApplier
 } from './terminal-view-attribute-store'
 import { killAllProcessesForWorktree } from './worktree-teardown'
+import {
+  MobileNotificationReplayBuffer,
+  type ReplayableMobileNotification
+} from './mobile-notification-replay'
 import { MOBILE_SUBSCRIBE_SCROLLBACK_ROWS } from './scrollback-limits'
 import {
   createMobileSessionTabsNotifyCoalescer,
@@ -2034,6 +2038,10 @@ type ResolvedWorktreeInFlight = {
   promise: Promise<ResolvedWorktreeSnapshot>
 }
 
+// Why: notificationSeq is the desktop-assigned monotonic sequence used for
+// mobile reconnect catch-up (#8129). It is added on dispatch (and replay) so a
+// client can watermark the last event it delivered and request exactly the
+// events after it — idempotent, no duplicate local pushes.
 export type MobileNotificationDispatchEvent = {
   type: 'notification'
   source: 'agent-task-complete' | 'terminal-bell' | 'test'
@@ -2041,11 +2049,13 @@ export type MobileNotificationDispatchEvent = {
   body: string
   worktreeId?: string
   notificationId?: string
+  notificationSeq?: number
 }
 
 export type MobileNotificationDismissEvent = {
   type: 'dismiss'
   notificationId: string
+  notificationSeq?: number
 }
 
 export type MobileNotificationEvent =
@@ -7356,10 +7366,28 @@ export class OrcaRuntimeService {
     return this.notificationListeners.size
   }
 
+  // Why: bounded replay buffer for the mobile reconnect catch-up (#8129).
+  // Every dispatched notification is recorded with a monotonic seq so a
+  // reconnecting client can fetch exactly the events it missed. Kept on the
+  // service instance (not per-client) because the buffer is a global,
+  // idempotent-by-seq source of truth; clients watermark their own position.
+  private readonly mobileNotificationReplay = new MobileNotificationReplayBuffer()
+
   dispatchMobileNotification(event: MobileNotificationEvent): void {
+    const seq = this.mobileNotificationReplay.record(event)
     for (const listener of this.notificationListeners) {
-      listener(event)
+      // Why: surface the desktop-assigned seq to live listeners so they can
+      // watermark the last event delivered and feed it back to getMissedSince
+      // on reconnect (idempotent catch-up, no duplicate local pushes).
+      listener({ ...event, notificationSeq: seq })
     }
+  }
+
+  // Returns notifications dispatched after lastSeenSeq. Idempotent: the same
+  // watermark always yields the same set, so a client cannot be re-pushed an
+  // already-delivered event (the adversarial-review gate for #8129).
+  getMissedNotificationsSince(lastSeenSeq: number): ReplayableMobileNotification[] {
+    return this.mobileNotificationReplay.getMissedSince(lastSeenSeq)
   }
 
   dismissMobileNotification(notificationId: string): void {

--- a/src/main/runtime/rpc/methods/notifications.ts
+++ b/src/main/runtime/rpc/methods/notifications.ts
@@ -13,6 +13,20 @@ const NotificationUnsubscribeParams = z.object({
     .pipe(z.string().min(1, 'Missing subscriptionId'))
 })
 
+// Why: notifications.getMissedSince is the catch-up RPC for mobile reconnect
+// (#8129). The client passes the highest seq it has already delivered; the
+// runtime returns only notifications dispatched after that seq. Because the
+// desktop assigns a monotonic seq to every dispatched notification, the cut is
+// exact and idempotent — re-requesting with the same watermark can never
+// return an already-delivered event, so reconnects never duplicate local
+// pushes (the adversarial-review gate for #8129).
+const NotificationGetMissedSinceParams = z.object({
+  lastSeenSeq: z
+    .number()
+    .int()
+    .min(0, 'lastSeenSeq must be a non-negative integer')
+})
+
 // Why: notifications.subscribe streams desktop notification events to mobile
 // clients over WebSocket. The mobile client shows a local push notification
 // for each event. This avoids requiring Firebase/APNs — the existing
@@ -51,6 +65,17 @@ export const NOTIFICATION_METHODS: readonly RpcAnyMethod[] = [
     handler: async (params, { runtime }) => {
       runtime.cleanupSubscription(params.subscriptionId)
       return { unsubscribed: true }
+    }
+  }),
+  defineMethod({
+    name: 'notifications.getMissedSince',
+    params: NotificationGetMissedSinceParams,
+    // Why: returns only notifications with seq > lastSeenSeq. The runtime owns
+    // the monotonic seq, so this is the single source of truth for what the
+    // client missed while its socket was reaped.
+    handler: async (params, { runtime }) => {
+      const missed = runtime.getMissedNotificationsSince(params.lastSeenSeq)
+      return { notifications: missed }
     }
   })
 ]

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -442,6 +442,70 @@ describe('WebSocketTransport', () => {
     expect(wss.clients.size).toBe(0)
   }, 5_000)
 
+  it('reaps a client kept warm by app frames but silent on pong (driver fast-fail, #4500)', async () => {
+    // Why: regression for #4500 — the permanent-driver-lock hole. A socket
+    // kept "warm" by inbound app frames (or a proxy that re-pongs on the
+    // client's behalf) must still be reaped if it never answers the server's
+    // ping, or the mobile terminal driver lock sticks forever. Pong-liveness
+    // is now distinct from message-liveness in the heartbeat tick.
+    const tls = makeTls()
+    const transport = new WebSocketTransport({
+      host: '127.0.0.1',
+      port: 0,
+      tlsCert: tls.cert,
+      tlsKey: tls.key,
+      heartbeatIntervalMs: 50
+    })
+    transport.onMessage(() => {})
+    transports.push(transport)
+
+    let serverClosed = false
+    transport.onConnectionClose(() => {
+      serverClosed = true
+    })
+
+    await transport.start()
+
+    // Why: connect a client that will NOT auto-pong server pings, so its
+    // pong-liveness stays false while we keep it "warm" with app frames.
+    const client = await new Promise<WebSocket>((resolve, reject) => {
+      const ws = new WebSocket(`wss://127.0.0.1:${transport.resolvedPort}`, {
+        rejectUnauthorized: false,
+        autoPong: false
+      })
+      ws.once('open', () => resolve(ws))
+      ws.once('error', reject)
+    })
+
+    const wss = (transport as unknown as { wss: { clients: Set<{ readyState: number }> } }).wss
+    for (const c of wss.clients) {
+      transport.setClientId(c as never, 'warm-no-pong-client')
+    }
+
+    // Why: keep the socket warm via inbound app frames (this re-arms
+    // wsAlive) but never pong — the heartbeat must still reap it because
+    // pong-liveness is what frees the mobile terminal driver.
+    const warmTimer = setInterval(() => {
+      if (client.readyState === client.OPEN) {
+        client.send(JSON.stringify({ id: 'keepalive', method: 'noop' }))
+      }
+    }, 20)
+
+    const start = Date.now()
+    while (!serverClosed && Date.now() - start < 2_000) {
+      await new Promise((r) => setTimeout(r, 25))
+    }
+    clearInterval(warmTimer)
+    // Give the close handler a tick to settle the wss.clients set.
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(serverClosed).toBe(true)
+    expect(wss.clients.size).toBe(0)
+    if (client.readyState !== client.CLOSED && client.readyState !== client.CLOSING) {
+      client.terminate()
+    }
+  }, 5_000)
+
   // Why: paired mobile devices store ws://ip:port endpoints, so the fallback
   // port must stay stable across restarts or pairings go permanently dead
   // when the preferred port is held by another instance (STA-1511).

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -72,6 +72,14 @@ export class WebSocketTransport implements RpcTransport {
   // sweep. A socket missing from the set when the next sweep fires is
   // assumed dead and terminated.
   private wsAlive = new WeakSet<WebSocket>()
+  // Why: tracks whether each socket has returned a PONG (not just any
+  // inbound frame) since the last heartbeat sweep. This is the
+  // pong-liveness signal distinct from message-liveness — a socket kept
+  // "warm" by inbound app frames (or a proxy that re-pongs on the
+  // client's behalf) must still be reaped if it has not actually
+  // answered the server's ping, or the mobile driver lock can stick
+  // permanently (issue #4500). See the heartbeat tick below.
+  private wsPonged = new WeakSet<WebSocket>()
   private messageHandler: WebSocketMessageHandler | null = null
   private connectionCloseHandler:
     | ((clientId: string | null, ws: WebSocket, hasOtherConnections: boolean) => void)
@@ -242,14 +250,21 @@ export class WebSocketTransport implements RpcTransport {
         return
       }
       for (const ws of wss.clients) {
-        if (!this.wsAlive.has(ws)) {
-          // Why: terminate() (vs close()) skips the close handshake and
-          // immediately fires the 'close' event, freeing the slot. close()
+        // Why: reap unless the socket has BOTH sent a pong AND shown any
+        // liveness since the previous tick. Requiring pong-liveness (not
+        // just message-liveness) is the #4500 fix: a socket that only
+        // answers with app frames — or a proxy that pongs on the client's
+        // behalf while the real client is dead — would otherwise keep the
+        // connection warm forever and strand the mobile terminal driver.
+        if (!this.wsAlive.has(ws) || !this.wsPonged.has(ws)) {
+          // Why: terminate() (vs close()) skips the close
+          // handshake and immediately fires the 'close' event, freeing the slot. close()
           // on an already-dead socket can hang for the OS-level TCP timeout.
           ws.terminate()
           continue
         }
         this.wsAlive.delete(ws)
+        this.wsPonged.delete(ws)
         try {
           ws.ping()
         } catch {
@@ -306,7 +321,11 @@ export class WebSocketTransport implements RpcTransport {
   private handleConnection(ws: WebSocket): void {
     let finalized = false
     const onPong = (): void => {
+      // Why: a pong specifically re-arms pong-liveness. Message traffic
+      // re-arms wsAlive (below) but does NOT satisfy wsPonged, so a
+      // socket warm only via app frames is still reaped (#4500).
       this.wsAlive.add(ws)
+      this.wsPonged.add(ws)
     }
     const onMessage = (data: WebSocket.RawData, isBinary: boolean): void => {
       // Why: any inbound traffic counts as proof of life, not just pongs.
@@ -369,9 +388,11 @@ export class WebSocketTransport implements RpcTransport {
     this.preAuthTimers.set(ws, preAuthTimer)
 
     // Why: seed alive=true so the first heartbeat tick after connect doesn't
-    // treat a fresh socket as dead. Subsequent pongs (or any inbound traffic)
-    // re-arm it.
+    // treat a fresh socket as dead. Seed ponged=true too, giving the
+    // client one grace tick to actually answer the first ping; a client
+    // that never pongs is reaped on the next sweep (#4500).
     this.wsAlive.add(ws)
+    this.wsPonged.add(ws)
 
     ws.on('pong', onPong)
     ws.on('message', onMessage)


### PR DESCRIPTION
## Summary

Implements the four mobile-reconnect fixes documented in #8591 (and the
investigation spec). When the Orca mobile app returns from background/sleep,
it re-opens the WebSocket but previously performed **no resync of
desktop-held state** — this PR closes that gap across notifications, terminal
input ownership, worktree snapshots, and real connection-error visibility.

Shipped as **two isolated commits** for clean review/rollback:
- `fix(mobile): surface real conn errors, resync worktrees, harden pong-liveness` (#6784 #8498 #4500)
- `fix(mobile): replay missed notifications idempotently on reconnect` (#8129)

## Fixes

- **#6784** — surface the real socket error per host (`getLastConnectionError` + `useLastConnectionError`) via `classifyConnection`'s hint instead of a canned Tailscale label.
- **#8498** — refetch worktrees on transition into `connected` (not every poll tick), add pull-to-refresh, and write through `setCachedWorktrees` from the host screen so a reconnect can't serve a stale cached snapshot.
- **#4500** — reap a socket that is warm via app frames but silent on pong. Split `wsPonged` from `wsAlive` so the liveness check releases the driver (the exact hardening the adversarial review called for).
- **#8129** — desktop-side `MobileNotificationReplayBuffer` (monotonic `seq`, cap 256) + `getMissedNotificationsSince(seq)`; mobile persists `lastSeenSeq` and replays missed notifications **idempotently** (no duplicate pushes — the key risk the review flagged).

## Verification

- `pnpm run typecheck` clean
- `vitest`: `ws-transport` 23/23 (#4500 regression), `connection-health` 9/9 (#6784), `worktree-cache` (#8498 write-through), `mobile-notification-replay` 7/7 + `mobile-notifications` 11/11 (#8129 dedupe regression)
- `check-max-lines-ratchet` OK (no new bypasses)
- New hooks extracted (`use-worktree-resync`, `use-host-connection-state`, `use-last-connection-error`) to stay under the max-lines budget

Closes #8591.