### PR TITLE
Use native CODEX_HOME for system-default Codex without losing Orca hooks

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -215,6 +215,51 @@ function createManagedAuth(rootDir: string, accountId: string, auth: string): st
   return managedHomePath
 }
 
+function createSelectedHostCodexSettings(rootDir: string): GlobalSettings {
+  const managedHomePath = createManagedAuth(rootDir, 'account-1', '{"account":"managed"}\n')
+  return createSettings({
+    codexManagedAccounts: [
+      {
+        id: 'account-1',
+        email: 'managed@example.com',
+        managedHomePath,
+        providerAccountId: null,
+        workspaceLabel: null,
+        workspaceAccountId: null,
+        createdAt: 1,
+        updatedAt: 1,
+        lastAuthenticatedAt: 1
+      }
+    ],
+    activeCodexManagedAccountId: 'account-1',
+    activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+  })
+}
+
+function createSelectedWslCodexSettings(rootDir: string, distro = 'Ubuntu'): GlobalSettings {
+  const managedHomePath = createManagedAuth(rootDir, 'wsl-account', '{"account":"managed"}\n')
+  return createSettings({
+    codexManagedAccounts: [
+      {
+        id: 'wsl-account',
+        email: 'managed@example.com',
+        managedHomePath,
+        managedHomeRuntime: 'wsl',
+        wslDistro: distro,
+        wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/wsl-account/home',
+        providerAccountId: null,
+        workspaceLabel: null,
+        workspaceAccountId: null,
+        createdAt: 1,
+        updatedAt: 1,
+        lastAuthenticatedAt: 1
+      }
+    ],
+    activeCodexManagedAccountId: null,
+    activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { [distro]: 'wsl-account' } }
+  })
+}
+
 function encodeJwtPart(value: Record<string, unknown>): string {
   return Buffer.from(JSON.stringify(value)).toString('base64url')
 }
@@ -499,12 +544,7 @@ describe('CodexRuntimeHomeService', () => {
     const wslSystemHomePath = join(wslHome, '.codex')
     mkdirSync(wslSystemHomePath, { recursive: true })
     writeFileSync(join(wslSystemHomePath, 'AGENTS.md'), '# WSL instructions\n', 'utf-8')
-    const store = createStore(
-      createSettings({
-        activeCodexManagedAccountId: null,
-        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
-      })
-    )
+    const store = createStore(createSelectedWslCodexSettings(testState.userDataDir))
 
     try {
       const { CodexRuntimeHomeService } = await import('./runtime-home-service')
@@ -550,12 +590,7 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
-    const store = createStore(
-      createSettings({
-        activeCodexManagedAccountId: null,
-        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
-      })
-    )
+    const store = createStore(createSelectedWslCodexSettings(testState.userDataDir))
     const wslSystemConfigPath = join(wslHome, '.codex', 'config.toml')
     mkdirSync(join(wslHome, '.codex'), { recursive: true })
     writeFileSync(wslSystemConfigPath, 'model = "gpt-5"\n', 'utf-8')
@@ -619,14 +654,10 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
-    const store = createStore(
-      createSettings({
-        activeCodexManagedAccountId: null,
-        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } },
-        // Why: the override is a Linux path inside the distro, not <wslHome>/.codex.
-        codexSessionSourceHome: { wsl: { Ubuntu: '/home/me/.config/codex' } }
-      })
-    )
+    const settings = createSelectedWslCodexSettings(testState.userDataDir)
+    // Why: the override is a Linux path inside the distro, not <wslHome>/.codex.
+    settings.codexSessionSourceHome = { wsl: { Ubuntu: '/home/me/.config/codex' } }
+    const store = createStore(settings)
 
     try {
       const { CodexRuntimeHomeService } = await import('./runtime-home-service')
@@ -981,14 +1012,46 @@ describe('CodexRuntimeHomeService', () => {
     expect(existsSync(runtimeAuthPath)).toBe(false)
   })
 
-  it('returns the Orca-managed runtime home for Codex launch and rate-limit preparation', async () => {
+  it('leaves host Codex on its native home when no managed account is selected', async () => {
     const store = createStore(createSettings())
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     const service = new CodexRuntimeHomeService(store as never)
 
-    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-    expect(service.prepareForRateLimitFetch()).toBe(getRuntimeCodexHomePath())
+    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(service.prepareForRateLimitFetch()).toBeNull()
     expect(existsSync(getRuntimeCodexHomePath())).toBe(true)
+  })
+
+  it('leaves WSL Codex on its native home when no managed account is selected', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const wslHome = join(testState.userDataDir, 'wsl-home')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => wslHome
+    }))
+    const store = createStore(
+      createSettings({
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+      })
+    )
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
+
+      expect(service.prepareForCodexLaunch(target)).toBe(join(wslHome, '.codex'))
+      expect(service.prepareForRateLimitFetch(target)).toBe(join(wslHome, '.codex'))
+      expect(
+        existsSync(join(wslHome, '.local', 'share', 'orca', 'codex-runtime-home', 'home'))
+      ).toBe(false)
+    } finally {
+      vi.doUnmock('../wsl')
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
   })
 
   it('uses the same host CODEX_HOME after switching managed Codex accounts', async () => {
@@ -1317,7 +1380,7 @@ describe('CodexRuntimeHomeService', () => {
     const systemCodexHome = getSystemCodexHomePath()
     mkdirSync(systemCodexHome, { recursive: true })
     writeFileSync(join(systemCodexHome, 'config.toml'), 'model = "first"\n', 'utf-8')
-    const store = createStore(createSettings())
+    const store = createStore(createSelectedHostCodexSettings(testState.userDataDir))
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     const service = new CodexRuntimeHomeService(store as never)
 
@@ -1337,7 +1400,7 @@ describe('CodexRuntimeHomeService', () => {
     mkdirSync(join(systemCodexHome, 'plugins'), { recursive: true })
     writeFileSync(join(systemCodexHome, 'plugins', 'plugin.json'), '{"name":"plugin"}\n', 'utf-8')
     writeFileSync(join(systemCodexHome, 'profile-v2'), 'profile\n', 'utf-8')
-    const store = createStore(createSettings())
+    const store = createStore(createSelectedHostCodexSettings(testState.userDataDir))
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     const service = new CodexRuntimeHomeService(store as never)
 
@@ -1420,14 +1483,14 @@ describe('CodexRuntimeHomeService', () => {
     writeFileSync(join(systemCodexHome, 'skills', 'system.md'), 'system\n', 'utf-8')
     writeFileSync(join(getRuntimeCodexHomePath(), 'hooks.json'), '{"hooks":{"Stop":[]}}\n', 'utf-8')
     writeFileSync(join(getRuntimeCodexHomePath(), 'history.jsonl'), '{"id":"runtime"}\n', 'utf-8')
-    const store = createStore(createSettings())
+    const store = createStore(createSelectedHostCodexSettings(testState.userDataDir))
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     const service = new CodexRuntimeHomeService(store as never)
 
     service.prepareForCodexLaunch()
 
     expect(readFileSync(join(getRuntimeCodexHomePath(), 'auth.json'), 'utf-8')).toBe(
-      '{"account":"system"}\n'
+      '{"account":"managed"}\n'
     )
     expect(readFileSync(join(getRuntimeCodexHomePath(), 'hooks.json'), 'utf-8')).toBe(
       '{"hooks":{"Stop":[]}}\n'
@@ -1492,14 +1555,14 @@ describe('CodexRuntimeHomeService', () => {
       )
 
       expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe('{"account":"host-system"}\n')
-      expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+      expect(service.prepareForCodexLaunch()).toBeNull()
       expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
         wslRuntimeHomePath
       )
       expect(readFileSync(join(wslRuntimeHomePath, 'auth.json'), 'utf-8')).toBe(
         '{"account":"wsl"}\n'
       )
-      expect(service.prepareForRateLimitFetch()).toBe(getRuntimeCodexHomePath())
+      expect(service.prepareForRateLimitFetch()).toBeNull()
       expect(service.prepareForRateLimitFetch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
         wslRuntimeHomePath
       )
@@ -1564,7 +1627,7 @@ describe('CodexRuntimeHomeService', () => {
       )
 
       expect(service.prepareForCodexLaunch({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe(
-        wslRuntimeHomePath
+        systemCodexHomePath
       )
       expect(store.updateSettings).toHaveBeenCalledWith({
         activeCodexManagedAccountId: null,
@@ -1602,7 +1665,7 @@ describe('CodexRuntimeHomeService', () => {
       ].join('\n'),
       'utf-8'
     )
-    const store = createStore(createSettings())
+    const store = createStore(createSelectedWslCodexSettings(testState.userDataDir))
 
     try {
       const { CodexRuntimeHomeService } = await import('./runtime-home-service')
@@ -2150,7 +2213,7 @@ describe('CodexRuntimeHomeService', () => {
     }
   })
 
-  it('reads WSL system-default token refreshes back to WSL system auth', async () => {
+  it('lets WSL system-default token refreshes stay in the native home', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     const wslHome = join(testState.userDataDir, 'wsl-home')
@@ -2179,21 +2242,14 @@ describe('CodexRuntimeHomeService', () => {
       const { CodexRuntimeHomeService } = await import('./runtime-home-service')
       const service = new CodexRuntimeHomeService(store as never)
       const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
-      const wslRuntimeHomePath = join(
-        wslHome,
-        '.local',
-        'share',
-        'orca',
-        'codex-runtime-home',
-        'home'
-      )
+      expect(service.prepareForCodexLaunch(target)).toBe(systemCodexHomePath)
+      writeFileSync(join(systemCodexHomePath, 'auth.json'), refreshedAuth, 'utf-8')
 
-      expect(service.prepareForCodexLaunch(target)).toBe(wslRuntimeHomePath)
-      writeFileSync(join(wslRuntimeHomePath, 'auth.json'), refreshedAuth, 'utf-8')
-
-      expect(service.prepareForCodexLaunch(target)).toBe(wslRuntimeHomePath)
+      expect(service.prepareForCodexLaunch(target)).toBe(systemCodexHomePath)
       expect(readFileSync(join(systemCodexHomePath, 'auth.json'), 'utf-8')).toBe(refreshedAuth)
-      expect(readFileSync(join(wslRuntimeHomePath, 'auth.json'), 'utf-8')).toBe(refreshedAuth)
+      expect(
+        existsSync(join(wslHome, '.local', 'share', 'orca', 'codex-runtime-home', 'home'))
+      ).toBe(false)
     } finally {
       if (originalPlatform) {
         Object.defineProperty(process, 'platform', originalPlatform)
@@ -2201,7 +2257,7 @@ describe('CodexRuntimeHomeService', () => {
     }
   })
 
-  it('preserves WSL system-default token refreshes after app restart', async () => {
+  it('ignores stale WSL runtime auth when the system-default account is selected', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     const wslHome = join(testState.userDataDir, 'wsl-home')
@@ -2241,8 +2297,8 @@ describe('CodexRuntimeHomeService', () => {
       const service = new CodexRuntimeHomeService(store as never)
       const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
 
-      expect(service.prepareForCodexLaunch(target)).toBe(wslRuntimeHomePath)
-      expect(readFileSync(join(systemCodexHomePath, 'auth.json'), 'utf-8')).toBe(refreshedAuth)
+      expect(service.prepareForCodexLaunch(target)).toBe(systemCodexHomePath)
+      expect(readFileSync(join(systemCodexHomePath, 'auth.json'), 'utf-8')).toBe(systemAuth)
       expect(readFileSync(join(wslRuntimeHomePath, 'auth.json'), 'utf-8')).toBe(refreshedAuth)
     } finally {
       if (originalPlatform) {

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -141,13 +141,30 @@ export class CodexRuntimeHomeService {
   prepareForCodexLaunch(target?: CodexAccountSelectionTarget): string | null {
     if (target?.runtime === 'wsl') {
       const wslTarget = this.resolveWslDefaultTarget(target)
+      if (this.getSelectedAccountId(wslTarget) === null) {
+        // Why: account isolation must not relocate ordinary WSL Codex state.
+        // Without a managed selection, let Codex keep using its native ~/.codex.
+        return this.getWslSystemCodexHomePath(wslTarget)
+      }
       const syncedRuntimeHomePath = this.syncWslRuntimeForCurrentSelection(wslTarget)
+      if (this.getSelectedAccountId(wslTarget) === null) {
+        return this.getWslSystemCodexHomePath(wslTarget)
+      }
       this.syncWslConfigAndGlobalInstructionsForLaunch(wslTarget, syncedRuntimeHomePath)
       const runtimeHomePath = syncedRuntimeHomePath ?? this.getWslSystemCodexHomePath(wslTarget)
       this.startWslSessionBridgeForLaunch(wslTarget, runtimeHomePath)
       return runtimeHomePath
     }
+    const hostTarget = { runtime: 'host' } as const
+    if (this.getSelectedAccountId(hostTarget) === null) {
+      // Why: CODEX_HOME relocates sessions and every other Codex state file,
+      // so only opt into Orca's runtime home for an explicitly managed account.
+      return null
+    }
     this.syncForCurrentSelection()
+    if (this.getSelectedAccountId(hostTarget) === null) {
+      return null
+    }
     syncSystemCodexResourcesIntoManagedHome()
     syncSystemConfigIntoManagedCodexHome()
     // Why: historical Codex sessions can be large; bridge them after launch
@@ -255,7 +272,14 @@ export class CodexRuntimeHomeService {
       const syncedRuntimeHomePath = this.getPreparedWslRateLimitHomePath(wslTarget)
       return syncedRuntimeHomePath ?? this.getWslSystemCodexHomePath(wslTarget)
     }
+    const hostTarget = { runtime: 'host' } as const
+    if (this.getSelectedAccountId(hostTarget) === null) {
+      return null
+    }
     this.syncForCurrentSelection()
+    if (this.getSelectedAccountId(hostTarget) === null) {
+      return null
+    }
     syncSystemCodexResourcesIntoManagedHome()
     syncSystemConfigIntoManagedCodexHome()
     return this.getRuntimeHomePath()
@@ -338,10 +362,9 @@ export class CodexRuntimeHomeService {
           this.persistRuntimeLogoutMarker(null)
           this.lastWrittenAuthJson = null
         } else if (this.lastWrittenAuthJson === null) {
-          // Why: Orca-launched Codex sessions now use an Orca-owned CODEX_HOME
-          // even when no managed account is selected. Seed that runtime home
-          // from the user's current system-default auth once so dev/prod Orca
-          // terminals stay logged in without mutating ~/.codex on startup.
+          // Why: explicit account-transition syncs may still need a coherent
+          // fallback runtime snapshot, even though system launches now use
+          // native ~/.codex and do not enter this path during ordinary startup.
           this.restoreSystemDefaultSnapshot({ detectExternalLogin: false })
         } else {
           this.persistRuntimeLogoutMarker()
@@ -516,6 +539,10 @@ export class CodexRuntimeHomeService {
       return null
     }
     return accounts.find((account) => account.id === activeAccountId) ?? null
+  }
+
+  private getSelectedAccountId(target: CodexAccountSelectionTarget): string | null {
+    return getSelectedCodexAccountIdForTarget(this.store.getSettings(), target)
   }
 
   private getWslManagedHomePath(account: CodexManagedAccount | null): string | null {

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -129,6 +129,75 @@ function localManagedCodexEvents(): string[] {
 }
 
 describe('CodexHookService', () => {
+  it('installs guarded status hooks into the native home for system-default launches', () => {
+    const systemCodexHome = join(tmpHome, '.codex')
+    const systemHooksPath = join(systemCodexHome, 'hooks.json')
+    mkdirSync(systemCodexHome, { recursive: true })
+    writeFileSync(
+      systemHooksPath,
+      `${JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ command: 'printf user-stop' }] }]
+        }
+      })}\n`,
+      'utf-8'
+    )
+    const userStopTrust = {
+      sourcePath: systemHooksPath,
+      eventLabel: 'stop' as const,
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'printf user-stop'
+    }
+    const userTrustConfig = upsertHookTrustEntriesInContent('model = "gpt-5.2-codex"\n', [
+      userStopTrust
+    ])
+    writeFileSync(
+      join(systemCodexHome, 'config.toml'),
+      markHookTrustDisabled(userTrustConfig, hookTrustHeader(`${systemHooksPath}:stop:0:0`)),
+      'utf-8'
+    )
+
+    const service = new CodexHookService()
+    const status = service.installForLaunchHome(null, { runtime: 'host' })
+
+    expect(status.detail).toBeNull()
+    expect(status.state).toBe('installed')
+    const hooksConfig = JSON.parse(readFileSync(join(systemCodexHome, 'hooks.json'), 'utf-8')) as {
+      hooks: Record<string, { hooks?: { command?: string }[] }[]>
+    }
+    expect(Object.keys(hooksConfig.hooks).sort()).toEqual(localManagedCodexEvents())
+    expect(isCodexManagedCommand(hooksConfig.hooks.Stop?.[0]?.hooks?.[0]?.command)).toBe(true)
+    expect(hooksConfig.hooks.Stop?.[1]?.hooks?.[0]?.command).toBe('printf user-stop')
+
+    const trustConfig = readFileSync(join(systemCodexHome, 'config.toml'), 'utf-8')
+    expect(trustConfig).toContain('model = "gpt-5.2-codex"')
+    expect(trustConfig).toContain(':permission_request:0:0')
+    const movedUserTrustHeader = hookTrustHeader(`${systemHooksPath}:stop:1:0`)
+    expect(trustConfig).toContain(movedUserTrustHeader)
+    expect(trustConfig.slice(trustConfig.indexOf(movedUserTrustHeader))).toContain(
+      'enabled = false'
+    )
+    expect(trustConfig).toContain(`trusted_hash = "${computeTrustedHash(userStopTrust)}"`)
+    expect(existsSync(join(userDataDir, 'codex-runtime-home', 'home', 'hooks.json'))).toBe(false)
+
+    expect(service.install().state).toBe('installed')
+    const nativeHooksAfterManagedSelection = JSON.parse(readFileSync(systemHooksPath, 'utf-8')) as {
+      hooks: Record<string, { hooks?: { command?: string }[] }[]>
+    }
+    expect(nativeHooksAfterManagedSelection.hooks.Stop).toHaveLength(1)
+    expect(nativeHooksAfterManagedSelection.hooks.Stop?.[0]?.hooks?.[0]?.command).toBe(
+      'printf user-stop'
+    )
+    expect(
+      Object.values(nativeHooksAfterManagedSelection.hooks).some((definitions) =>
+        definitions.some((definition) =>
+          definition.hooks?.some((hook) => isCodexManagedCommand(hook.command))
+        )
+      )
+    ).toBe(false)
+  })
+
   it('installs PermissionRequest with trust so Codex approval prompts reach Orca', () => {
     const systemCodexHome = join(tmpHome, '.codex')
     mkdirSync(systemCodexHome, { recursive: true })

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -129,6 +129,67 @@ function localManagedCodexEvents(): string[] {
 }
 
 describe('CodexHookService', () => {
+  it('installs system-default hooks into an explicit native CODEX_HOME', () => {
+    const customCodexHome = join(tmpHome, 'custom-codex-home')
+    const customHooksPath = join(customCodexHome, 'hooks.json')
+    mkdirSync(customCodexHome, { recursive: true })
+    writeFileSync(
+      customHooksPath,
+      `${JSON.stringify({ hooks: { Stop: [{ hooks: [{ command: 'printf custom-stop' }] }] } })}\n`,
+      'utf-8'
+    )
+    const customUserTrust = {
+      sourcePath: customHooksPath,
+      eventLabel: 'stop' as const,
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'printf custom-stop'
+    }
+    writeFileSync(
+      join(customCodexHome, 'config.toml'),
+      upsertHookTrustEntriesInContent('', [customUserTrust]),
+      'utf-8'
+    )
+
+    const service = new CodexHookService()
+    const status = service.installForLaunchHome(null, { runtime: 'host' }, customCodexHome)
+
+    expect(status.state).toBe('installed')
+    expect(existsSync(join(customCodexHome, 'hooks.json'))).toBe(true)
+    expect(existsSync(join(customCodexHome, 'config.toml'))).toBe(true)
+    expect(existsSync(join(tmpHome, '.codex', 'hooks.json'))).toBe(false)
+    expect(readFileSync(join(customCodexHome, 'config.toml'), 'utf-8')).toContain(
+      hookTrustHeader(`${customHooksPath}:stop:1:0`)
+    )
+
+    expect(
+      service.installForLaunchHome('/orca/managed/codex-home', { runtime: 'host' }, customCodexHome)
+        .state
+    ).toBe('installed')
+    const customHooksAfterManagedSelection = JSON.parse(readFileSync(customHooksPath, 'utf-8')) as {
+      hooks: Record<string, { hooks?: { command?: string }[] }[]>
+    }
+    expect(customHooksAfterManagedSelection.hooks.Stop).toHaveLength(1)
+    expect(customHooksAfterManagedSelection.hooks.Stop?.[0]?.hooks?.[0]?.command).toBe(
+      'printf custom-stop'
+    )
+
+    expect(service.installForLaunchHome(null, { runtime: 'host' }, customCodexHome).state).toBe(
+      'installed'
+    )
+    service.refreshForLaunchHome(null, { runtime: 'host' }, customCodexHome)
+    const customHooksAfterDisabling = JSON.parse(readFileSync(customHooksPath, 'utf-8')) as {
+      hooks: Record<string, { hooks?: { command?: string }[] }[]>
+    }
+    expect(
+      Object.values(customHooksAfterDisabling.hooks).some((definitions) =>
+        definitions.some((definition) =>
+          definition.hooks?.some((hook) => isCodexManagedCommand(hook.command))
+        )
+      )
+    ).toBe(false)
+  })
+
   it('installs guarded status hooks into the native home for system-default launches', () => {
     const systemCodexHome = join(tmpHome, '.codex')
     const systemHooksPath = join(systemCodexHome, 'hooks.json')

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -307,12 +307,13 @@ type TrustedSystemHookSignatureState = {
 function getTrustedSystemUserHookSignatures(
   systemConfigPath: string,
   systemHooks: Record<string, HookDefinition[]>,
-  isManagedCommand: (command: string | undefined) => boolean
+  isManagedCommand: (command: string | undefined) => boolean,
+  systemTomlPath = getSystemCodexConfigTomlPath()
 ): Map<string, TrustedSystemHookSignatureState> {
   const signatures = new Map<string, TrustedSystemHookSignatureState>()
   let trustEntries: Map<string, CodexHookTrustState>
   try {
-    trustEntries = readHookTrustEntries(getSystemCodexConfigTomlPath())
+    trustEntries = readHookTrustEntries(systemTomlPath)
   } catch (error) {
     // Why: a hand-broken system config.toml should only disable user-hook
     // trust mirroring; Orca's managed runtime hooks can still be installed.
@@ -532,8 +533,8 @@ function dedupeHookDefinitions(definitions: readonly HookDefinition[]): HookDefi
   })
 }
 
-function cleanupLegacySystemManagedHooks(): void {
-  const legacyConfigPath = getSystemConfigPath()
+function cleanupLegacySystemManagedHooks(systemHomePath = getSystemCodexHomePath()): void {
+  const legacyConfigPath = join(systemHomePath, 'hooks.json')
   const runtimeConfigPath = getConfigPath()
   if (legacyConfigPath === runtimeConfigPath) {
     return
@@ -580,7 +581,7 @@ function cleanupLegacySystemManagedHooks(): void {
     // Remove only stale Orca hook entries and preserve other managers' metadata.
     writeHooksJson(legacyConfigPath, { ...config, hooks: nextHooks })
   }
-  removeMatchingTrustEntries(getSystemCodexConfigTomlPath(), trustEntries)
+  removeMatchingTrustEntries(join(systemHomePath, 'config.toml'), trustEntries)
 }
 
 function stripLegacyManagedProfileBlock(content: string): string {
@@ -1093,7 +1094,8 @@ export class CodexHookService {
 
   installForLaunchHome(
     runtimeHomePath: string | null | undefined,
-    target?: CodexWslRuntimeHookTarget
+    target?: CodexWslRuntimeHookTarget,
+    nativeHostHomePath?: string
   ): AgentHookInstallStatus {
     const runtimeStatus = this.installForRuntimeHome(runtimeHomePath, target)
     if (runtimeStatus) {
@@ -1101,9 +1103,14 @@ export class CodexHookService {
     }
     // Why: a host system-default launch intentionally has no Orca CODEX_HOME.
     // Put the guarded status hook where that native Codex process will read it.
-    return !runtimeHomePath && target?.runtime !== 'wsl'
-      ? this.installForSystemHome()
-      : this.install()
+    if (!runtimeHomePath && target?.runtime !== 'wsl') {
+      return this.installForSystemHome(nativeHostHomePath)
+    }
+    const status = this.install()
+    if (nativeHostHomePath) {
+      cleanupLegacySystemManagedHooks(nativeHostHomePath)
+    }
+    return status
   }
 
   refreshRuntimeUserHooksForRuntimeHome(
@@ -1113,6 +1120,22 @@ export class CodexHookService {
     this.supersedeWslReconciliation(runtimeHomePath)
     const wslPlan = createCodexWslRuntimeHookInstallPlan(runtimeHomePath, target)
     return wslPlan ? refreshWslRuntimeUserHooks(wslPlan) : null
+  }
+
+  refreshForLaunchHome(
+    runtimeHomePath: string | null | undefined,
+    target?: CodexWslRuntimeHookTarget,
+    nativeHostHomePath?: string
+  ): AgentHookInstallStatus {
+    const runtimeStatus = this.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath, target)
+    if (runtimeStatus) {
+      return runtimeStatus
+    }
+    const status = this.refreshRuntimeUserHooks()
+    if (nativeHostHomePath) {
+      cleanupLegacySystemManagedHooks(nativeHostHomePath)
+    }
+    return status
   }
 
   getStatus(): AgentHookInstallStatus {
@@ -1241,13 +1264,15 @@ export class CodexHookService {
     return this.installIntoHostHome('managed')
   }
 
-  installForSystemHome(): AgentHookInstallStatus {
-    return this.installIntoHostHome('system')
+  installForSystemHome(codexHomePath = getSystemCodexHomePath()): AgentHookInstallStatus {
+    return this.installIntoHostHome('system', codexHomePath)
   }
 
-  private installIntoHostHome(mode: 'managed' | 'system'): AgentHookInstallStatus {
-    const codexHomePath =
-      mode === 'managed' ? getOrcaManagedCodexHomePath() : getSystemCodexHomePath()
+  private installIntoHostHome(
+    mode: 'managed' | 'system',
+    systemHomePath = getSystemCodexHomePath()
+  ): AgentHookInstallStatus {
+    const codexHomePath = mode === 'managed' ? getOrcaManagedCodexHomePath() : systemHomePath
     const configPath = join(codexHomePath, 'hooks.json')
     const scriptPath = getManagedScriptPath()
     // Why: must run before this install rewrites hooks.json/config.toml —
@@ -1344,7 +1369,8 @@ export class CodexHookService {
       const trustedUserHookSignatures = getTrustedSystemUserHookSignatures(
         configPath,
         config.hooks ?? {},
-        isManagedCommand
+        isManagedCommand,
+        join(codexHomePath, 'config.toml')
       )
       mirroredUserTrustEntries = collectMirroredRuntimeUserHookTrustEntries(
         configPath,

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -573,8 +573,8 @@ function cleanupLegacySystemManagedHooks(): void {
     }
   }
 
-  // Why: Codex hooks moved to Orca's managed CODEX_HOME; old entries in
-  // ~/.codex would keep external Codex sessions reporting into Orca.
+  // Why: managed-account launches return to Orca's isolated CODEX_HOME.
+  // Remove the native entry so outside Codex stops loading Orca's hook too.
   if (removedManagedHook) {
     // Why: this is the user's system hooks file, not Orca's runtime copy.
     // Remove only stale Orca hook entries and preserve other managers' metadata.
@@ -1091,6 +1091,21 @@ export class CodexHookService {
     return wslPlan ? installManagedHooksIntoWslRuntime(wslPlan) : null
   }
 
+  installForLaunchHome(
+    runtimeHomePath: string | null | undefined,
+    target?: CodexWslRuntimeHookTarget
+  ): AgentHookInstallStatus {
+    const runtimeStatus = this.installForRuntimeHome(runtimeHomePath, target)
+    if (runtimeStatus) {
+      return runtimeStatus
+    }
+    // Why: a host system-default launch intentionally has no Orca CODEX_HOME.
+    // Put the guarded status hook where that native Codex process will read it.
+    return !runtimeHomePath && target?.runtime !== 'wsl'
+      ? this.installForSystemHome()
+      : this.install()
+  }
+
   refreshRuntimeUserHooksForRuntimeHome(
     runtimeHomePath: string | null | undefined,
     target?: CodexWslRuntimeHookTarget
@@ -1101,7 +1116,11 @@ export class CodexHookService {
   }
 
   getStatus(): AgentHookInstallStatus {
-    const configPath = getConfigPath()
+    return this.getStatusForHome(getOrcaManagedCodexHomePath())
+  }
+
+  private getStatusForHome(codexHomePath: string): AgentHookInstallStatus {
+    const configPath = join(codexHomePath, 'hooks.json')
     const scriptPath = getManagedScriptPath()
     const config = readHooksJson(configPath)
     if (!config) {
@@ -1118,7 +1137,7 @@ export class CodexHookService {
     // trust entries are missing/stale. Codex 0.129+ silently drops untrusted
     // hooks, so a green status without trust verification is misleading.
     const command = getManagedCommand(scriptPath)
-    const tomlPath = getCodexConfigTomlPath()
+    const tomlPath = join(codexHomePath, 'config.toml')
     // Why: an unreadable config.toml (EACCES/EIO) is distinct from "file
     // absent" (which returns an empty Map without throwing). Hooks.json may
     // still be fine, so report partial with a specific reason rather than
@@ -1219,13 +1238,25 @@ export class CodexHookService {
   }
 
   install(): AgentHookInstallStatus {
-    const configPath = getConfigPath()
+    return this.installIntoHostHome('managed')
+  }
+
+  installForSystemHome(): AgentHookInstallStatus {
+    return this.installIntoHostHome('system')
+  }
+
+  private installIntoHostHome(mode: 'managed' | 'system'): AgentHookInstallStatus {
+    const codexHomePath =
+      mode === 'managed' ? getOrcaManagedCodexHomePath() : getSystemCodexHomePath()
+    const configPath = join(codexHomePath, 'hooks.json')
     const scriptPath = getManagedScriptPath()
     // Why: must run before this install rewrites hooks.json/config.toml —
     // approvals the user made inside Orca-launched Codex are keyed to the
     // previous launch's runtime layout, and stale-trust cleanup below would
     // delete them once the system config stops backing them.
-    promoteCodexRuntimeHookApprovalsToSystem()
+    if (mode === 'managed') {
+      promoteCodexRuntimeHookApprovalsToSystem()
+    }
     const config = readHooksJson(configPath)
     if (!config) {
       return {
@@ -1243,7 +1274,10 @@ export class CodexHookService {
     // accumulate duplicate hook entries pointing at defunct scripts.
     const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())
     const command = getManagedCommand(scriptPath)
-    const hookPlan = getRuntimeHooksWithSystemUserHooks(config.hooks, isManagedCommand)
+    const hookPlan =
+      mode === 'managed'
+        ? getRuntimeHooksWithSystemUserHooks(config.hooks, isManagedCommand)
+        : { hooks: { ...config.hooks }, trustEntries: [] }
     const nextHooks = hookPlan.hooks
     const managedEvents = new Set<string>(CODEX_EVENTS)
 
@@ -1274,12 +1308,14 @@ export class CodexHookService {
     // hook sits in the "review required" pile. We compute the trust hash for
     // each managed entry as we install it and persist it alongside hooks.json
     // so the user does not have to /hooks-approve after every install.
-    const mirroredUserTrustEntries = moveMirroredRuntimeUserTrustAfterManagedStatusHook(
-      hookPlan.trustEntries
-    )
-    const trustEntries: CodexTrustEntry[] = mirroredUserTrustEntries.map(({ entry }) => entry)
+    let mirroredUserTrustEntries =
+      mode === 'managed'
+        ? moveMirroredRuntimeUserTrustAfterManagedStatusHook(hookPlan.trustEntries)
+        : []
+    const trustEntries: CodexTrustEntry[] = []
     for (const eventName of CODEX_EVENTS) {
       const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
+      const managedHookAlreadyOwnsFirstSlot = isManagedCommand(current[0]?.hooks?.[0]?.command)
       const cleaned = removeManagedCommands(current, isManagedCommand)
       const definition: HookDefinition = {
         hooks: [buildManagedCommandHook(command)]
@@ -1296,9 +1332,28 @@ export class CodexHookService {
         groupIndex: 0,
         handlerIndex: 0,
         command,
-        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS,
+        // Why: prepending into native hooks reuses the old first user hook's
+        // trust key. Do not mistake that user's disabled state for an Orca
+        // hook toggle; later installs still preserve a disabled Orca entry.
+        ...(mode === 'system' && !managedHookAlreadyOwnsFirstSlot ? { enabled: true } : {})
       })
     }
+
+    if (mode === 'system') {
+      const trustedUserHookSignatures = getTrustedSystemUserHookSignatures(
+        configPath,
+        config.hooks ?? {},
+        isManagedCommand
+      )
+      mirroredUserTrustEntries = collectMirroredRuntimeUserHookTrustEntries(
+        configPath,
+        nextHooks,
+        trustedUserHookSignatures,
+        isManagedCommand
+      )
+    }
+    trustEntries.unshift(...mirroredUserTrustEntries.map(({ entry }) => entry))
 
     config.hooks = nextHooks
     writeManagedScript(scriptPath, getManagedScript())
@@ -1307,13 +1362,13 @@ export class CodexHookService {
     // pointing at a hook that doesn't exist. Surface failures — without this,
     // getStatus would report green for a hook Codex won't actually fire.
     try {
-      const tomlPath = getCodexConfigTomlPath()
-      syncSystemConfigIntoManagedCodexHome()
-      // Why: system user hook approvals are mirrored into runtime CODEX_HOME.
-      // If the user later revokes approval in ~/.codex/config.toml, preserving
-      // all old runtime [hooks.state.*] blocks would keep Orca Codex trusted.
-      // Upsert first so duplicate repair can preserve a disabled managed copy
-      // before stale cleanup removes old managed hook keys.
+      const tomlPath = join(codexHomePath, 'config.toml')
+      if (mode === 'managed') {
+        syncSystemConfigIntoManagedCodexHome()
+      }
+      // Why: prepending the status hook shifts user-hook trust keys in either
+      // home. Upsert their new positions before stale-key cleanup removes the
+      // old positions, preserving explicit user enable/disable decisions.
       upsertHookTrustEntries(tomlPath, trustEntries)
       removeStaleRuntimeHookTrustEntries(tomlPath, configPath, trustEntries)
       applyMirroredRuntimeUserHookTrustStates(tomlPath, mirroredUserTrustEntries)
@@ -1326,14 +1381,18 @@ export class CodexHookService {
         detail: `Hooks installed but trust entries could not be written: ${error instanceof Error ? error.message : String(error)}. Run /hooks in Codex to approve.`
       }
     }
-    snapshotCodexRuntimeHookTrustProvenance()
+    if (mode === 'managed') {
+      snapshotCodexRuntimeHookTrustProvenance()
+    }
     try {
-      cleanupLegacySystemManagedHooks()
+      if (mode === 'managed') {
+        cleanupLegacySystemManagedHooks()
+      }
       cleanupLegacyCodexProfileHooks()
     } catch (error) {
       console.warn('[codex-hook-service] failed to clean legacy Codex hooks', error)
     }
-    return this.getStatus()
+    return this.getStatusForHome(codexHomePath)
   }
 
   async installRemote(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -718,8 +718,7 @@ function prepareCodexRuntimeHomeForLaunch(target?: CodexAccountSelectionTarget):
     // Why: launch prep is reachable after startup via PTY/runtime paths; honor
     // the persisted off switch so those launches cannot reinstall removed hooks.
     const status = hooksEnabled
-      ? (codexHookService.installForRuntimeHome(runtimeHomePath, hookTarget) ??
-        codexHookService.install())
+      ? codexHookService.installForLaunchHome(runtimeHomePath, hookTarget)
       : (codexHookService.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath, hookTarget) ??
         codexHookService.refreshRuntimeUserHooks())
     if (status.state === 'error') {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -704,7 +704,10 @@ async function startServeAgentHookServer(): Promise<void> {
   }
 }
 
-function prepareCodexRuntimeHomeForLaunch(target?: CodexAccountSelectionTarget): string | null {
+function prepareCodexRuntimeHomeForLaunch(
+  target?: CodexAccountSelectionTarget,
+  nativeHostHomePath?: string
+): string | null {
   const runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target)
   const hookTarget =
     target?.runtime === 'wsl'
@@ -718,9 +721,8 @@ function prepareCodexRuntimeHomeForLaunch(target?: CodexAccountSelectionTarget):
     // Why: launch prep is reachable after startup via PTY/runtime paths; honor
     // the persisted off switch so those launches cannot reinstall removed hooks.
     const status = hooksEnabled
-      ? codexHookService.installForLaunchHome(runtimeHomePath, hookTarget)
-      : (codexHookService.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath, hookTarget) ??
-        codexHookService.refreshRuntimeUserHooks())
+      ? codexHookService.installForLaunchHome(runtimeHomePath, hookTarget, nativeHostHomePath)
+      : codexHookService.refreshForLaunchHome(runtimeHomePath, hookTarget, nativeHostHomePath)
     if (status.state === 'error') {
       console.warn(
         `[codex-hook-service] failed to ${

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -903,25 +903,32 @@ describe('registerPtyHandlers', () => {
     })
 
     it('drops an inherited Orca Codex home when the system account is selected', async () => {
+      const getSelectedCodexHomePath = vi.fn(() => null)
       const env = await spawnAndGetEnv(
         { CODEX_HOME: TEST_CODEX_HOME, ORCA_CODEX_HOME: TEST_CODEX_HOME },
         undefined,
-        () => null
+        getSelectedCodexHomePath
       )
 
       expect(env.CODEX_HOME).toBeUndefined()
       expect(env.ORCA_CODEX_HOME).toBeUndefined()
+      expect(getSelectedCodexHomePath).toHaveBeenCalledWith({ runtime: 'host' }, undefined)
     })
 
     it('preserves a user CODEX_HOME when the system account is selected', async () => {
+      const getSelectedCodexHomePath = vi.fn(() => null)
       const env = await spawnAndGetEnv(
         { CODEX_HOME: '/tmp/user-codex-home' },
         undefined,
-        () => null
+        getSelectedCodexHomePath
       )
 
       expect(env.CODEX_HOME).toBe('/tmp/user-codex-home')
       expect(env.ORCA_CODEX_HOME).toBeUndefined()
+      expect(getSelectedCodexHomePath).toHaveBeenCalledWith(
+        { runtime: 'host' },
+        '/tmp/user-codex-home'
+      )
     })
 
     it('injects the OpenCode hook env into Orca terminal PTYs', async () => {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -902,6 +902,28 @@ describe('registerPtyHandlers', () => {
       expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
     })
 
+    it('drops an inherited Orca Codex home when the system account is selected', async () => {
+      const env = await spawnAndGetEnv(
+        { CODEX_HOME: TEST_CODEX_HOME, ORCA_CODEX_HOME: TEST_CODEX_HOME },
+        undefined,
+        () => null
+      )
+
+      expect(env.CODEX_HOME).toBeUndefined()
+      expect(env.ORCA_CODEX_HOME).toBeUndefined()
+    })
+
+    it('preserves a user CODEX_HOME when the system account is selected', async () => {
+      const env = await spawnAndGetEnv(
+        { CODEX_HOME: '/tmp/user-codex-home' },
+        undefined,
+        () => null
+      )
+
+      expect(env.CODEX_HOME).toBe('/tmp/user-codex-home')
+      expect(env.ORCA_CODEX_HOME).toBeUndefined()
+    })
+
     it('injects the OpenCode hook env into Orca terminal PTYs', async () => {
       // Why: clear any ambient OPENCODE_CONFIG_DIR so the mock's value is used
       const env = await spawnAndGetEnv(undefined, { OPENCODE_CONFIG_DIR: undefined })

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -918,7 +918,7 @@ describe('registerPtyHandlers', () => {
     it('preserves a user CODEX_HOME when the system account is selected', async () => {
       const getSelectedCodexHomePath = vi.fn(() => null)
       const env = await spawnAndGetEnv(
-        { CODEX_HOME: '/tmp/user-codex-home' },
+        { CODEX_HOME: '/tmp/user-codex-home', ORCA_CODEX_HOME: TEST_CODEX_HOME },
         undefined,
         getSelectedCodexHomePath
       )

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3,7 +3,7 @@ main-process module so spawn-time environment scoping, lifecycle cleanup,
 foreground-process inspection, and renderer IPC stay behind a single audited
 boundary. Splitting it by line count would scatter tightly coupled terminal
 process behavior across files without a cleaner ownership seam. */
-import { join, delimiter } from 'node:path'
+import { join, delimiter, isAbsolute } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { statSync } from 'node:fs'
 import {
@@ -612,7 +612,10 @@ function shouldSkipCodexHomeEnvForWindowsShell(
 }
 
 const CODEX_HOME_ENV_KEYS = ['CODEX_HOME', 'ORCA_CODEX_HOME'] as const
-type GetSelectedCodexHomePath = (target?: CodexAccountSelectionTarget) => string | null
+type GetSelectedCodexHomePath = (
+  target?: CodexAccountSelectionTarget,
+  nativeHostHomePath?: string
+) => string | null
 type PrepareClaudeAuth = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
@@ -650,6 +653,20 @@ function readEnvWithProcessFallback(
   key: string
 ): string | undefined {
   return baseEnv[key] ?? process.env[key]
+}
+
+function getNativeHostCodexHomePath(
+  baseEnv: Record<string, string>,
+  target: CodexAccountSelectionTarget
+): string | undefined {
+  if (target.runtime === 'wsl') {
+    return undefined
+  }
+  const codexHome = readEnvWithProcessFallback(baseEnv, 'CODEX_HOME')?.trim()
+  const orcaCodexHome = readEnvWithProcessFallback(baseEnv, 'ORCA_CODEX_HOME')?.trim()
+  // Why: only an absolute, user-owned value identifies the same directory the
+  // child Codex will read. Orca-owned inheritance is removed for system default.
+  return codexHome && codexHome !== orcaCodexHome && isAbsolute(codexHome) ? codexHome : undefined
 }
 
 function resolvePiAgentSourceDir(
@@ -1547,7 +1564,10 @@ export function registerPtyHandlers(
             : { runtime: 'host' }
         const selectedCodexHomePath = getCompatibleSelectedCodexHomePath(
           codexSelectionTarget,
-          getSelectedCodexHomePath?.(codexSelectionTarget) ?? null
+          getSelectedCodexHomePath?.(
+            codexSelectionTarget,
+            getNativeHostCodexHomePath(baseEnv, codexSelectionTarget)
+          ) ?? null
         )
         const env = buildPtyHostEnv(id, baseEnv, {
           isPackaged: app.isPackaged,
@@ -3021,7 +3041,10 @@ export function registerPtyHandlers(
       const selectedCodexHomePath = isDaemonHostSpawn
         ? getCompatibleSelectedCodexHomePath(
             codexSelectionTarget,
-            getSelectedCodexHomePath?.(codexSelectionTarget) ?? null
+            getSelectedCodexHomePath?.(
+              codexSelectionTarget,
+              getNativeHostCodexHomePath(env ?? {}, codexSelectionTarget)
+            ) ?? null
           )
         : null
       const skipCodexHomeEnv =
@@ -3863,7 +3886,10 @@ export function registerPtyHandlers(
       const selectedCodexHomePath = isDaemonHostSpawn
         ? getCompatibleSelectedCodexHomePath(
             codexSelectionTarget,
-            getSelectedCodexHomePath?.(codexSelectionTarget) ?? null
+            getSelectedCodexHomePath?.(
+              codexSelectionTarget,
+              getNativeHostCodexHomePath(baseEnv ?? {}, codexSelectionTarget)
+            ) ?? null
           )
         : null
       const skipCodexHomeEnv =

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -975,6 +975,14 @@ export function buildPtyHostEnv(
     // Why: user startup files may re-export CODEX_HOME; shell-ready wrappers
     // restore this runtime home before Codex can be launched from the prompt.
     baseEnv.ORCA_CODEX_HOME = opts.selectedCodexHomePath
+  } else if (baseEnv.ORCA_CODEX_HOME) {
+    // Why: a nested Orca can inherit the parent's managed home. Once the system
+    // account is selected, remove only that Orca-owned override and preserve a
+    // distinct user-configured CODEX_HOME.
+    if (baseEnv.CODEX_HOME === baseEnv.ORCA_CODEX_HOME) {
+      delete baseEnv.CODEX_HOME
+    }
+    delete baseEnv.ORCA_CODEX_HOME
   }
 
   // Why: WSL shells need the managed userData root for shell-ready wrappers; dev-mode terminals need the same export so `orca` targets the live dev instance.


### PR DESCRIPTION
## Summary

Use the provider-native Codex state directory when Orca's **system-default** Codex account is selected, without dropping Orca's agent-status hooks.

- Host system-default launches no longer receive Orca's private `CODEX_HOME`; they use an inherited user `CODEX_HOME` or Codex's normal `~/.codex`.
- WSL system-default launches use that distro user's native `~/.codex`.
- Explicit Orca-managed accounts keep the stable isolated runtime home used for account switching and refreshed-token persistence.
- Rate-limit reads follow the same account/home routing as launches.
- Nested Orca processes remove only an inherited Orca-owned override and preserve a distinct user-owned `CODEX_HOME`.
- Agent-status hooks are installed into the effective native home for system-default launches, including an absolute custom `CODEX_HOME`, so the sidebar behavior remains available.

## The original private `CODEX_HOME` was intentional

This PR is not treating the existing design as an accident.

The app-owned home was introduced deliberately in #2350 to isolate Orca's hook configuration and trust state from Codex sessions launched outside Orca. It avoided hook-review noise and callbacks aimed at a dead Orca process. Later work kept one stable Orca runtime home so managed-account hot-swap, open PTYs, rate-limit polling, and refreshed-token read-back all agreed on one location.

That solved real problems and remains the right behavior for an explicitly managed account.

The issue is the boundary. `CODEX_HOME` is not an auth-only directory. It owns configuration, authentication, sessions/history, logs, skills, and other metadata. Applying the isolated home to the system-default account therefore split all native Codex state even though that selection does not need credential isolation. This is also the root condition behind the native/runtime OAuth refresh-token conflict tracked in #5370.

Official reference: [Codex environment variables](https://learn.chatgpt.com/docs/config-file/environment-variables)

## Why this change

For system default, the provider-native directory should be the source of truth:

- `codex resume` sees the same sessions inside and outside Orca.
- Models, MCP config, skills, global instructions, logs, and metadata no longer diverge by launch surface.
- OAuth refreshes and quota reads no longer race a mirrored runtime credential for the same system account.
- Users with an absolute custom `CODEX_HOME` keep using that exact directory.

Managed accounts still need isolation, so this PR preserves the existing managed runtime mechanism rather than replacing it globally.

| Runtime | Selected account | Effective Codex home |
| --- | --- | --- |
| Host | System default | User `CODEX_HOME`, otherwise native `~/.codex` |
| Host | Orca-managed | Orca runtime home |
| WSL | System default | Distro-native `~/.codex` |
| WSL | Orca-managed | Distro-local Orca runtime home |

## Preserving Orca behavior

Simply removing the override would have broken Codex agent-status tracking: Orca previously installed its hook only in the private runtime home. This PR closes that gap.

- Before a system-default launch, Orca installs its trusted status hook into the effective native Codex home.
- Existing user hook definitions, trust hashes, and explicit enable/disable states are preserved when Orca's hook is placed first.
- The managed script requires Orca's endpoint token and pane identity. Outside an Orca terminal those variables are absent, so it drains stdin and exits successfully without a network callback.
- Switching a host launch back to a managed account removes only Orca's hook/trust entries from the native or custom home. Turning agent-status hooks off does the same.
- Managed-account launches continue using the private runtime hook configuration exactly as before.

A Codex profile was considered, but it is not behaviorally equivalent: Codex selects one profile, so forcing an Orca profile can conflict with a user's own `--profile`, and it would not reliably cover every manually typed or resumed Codex command. Installing the guarded hook in the home the process actually reads preserves those flows.

### Deliberate tradeoff

While system default is selected, native `hooks.json` and `config.toml` contain a trusted Orca entry. A normal Codex process outside Orca can load and invoke that entry, but the environment guard prevents it from contacting Orca. This relaxes #2350's strict “no native hook footprint” isolation in exchange for keeping the rest of native Codex state unified. The write is surgical: non-Orca hooks and trust state are preserved, and host managed selection or the hooks-off setting removes Orca's entries.

## How this differs from related PRs

- #5594 adds an opt-in setting for the default config directory.
- #6577 adds a broader default-home mode and intentionally disables host managed-account switching/previews in that mode.
- This PR is selection-driven: **system default means native home automatically; explicit managed accounts remain isolated and switchable.** It adds no global mode or settings UI.

This PR does not supersede or close those contributions; it proposes a narrower account-ownership boundary.

## User impact

- One continuous native Codex session history.
- One source of truth for native configuration and metadata.
- Less auth and quota drift for the system account.
- No loss of Orca's Codex status tracking.
- No loss of managed multi-account switching.
- No destructive migration: historical Orca runtime sessions remain discoverable, and existing runtime data is retained.

## Screenshots

No visual change. The change is limited to Codex state routing, PTY environment ownership, and hook installation.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2,766 files / 29,272 tests passed; 7 files / 40 tests skipped
- [x] `pnpm build`
- [x] Focused Codex hook/runtime-home/PTY regression tests

Coverage includes:

- Host and WSL system-default launches resolve to provider-native state.
- Host and WSL managed selections continue resolving to isolated Orca homes.
- Rate-limit polling follows the same provenance as launches.
- Nested Orca removes only an Orca-owned inherited override.
- An absolute custom `CODEX_HOME` remains the launch and hook source of truth.
- Native user hooks and trust state survive Orca hook insertion and removal.
- System-default status hooks are trusted and installed before user hooks.
- Host managed-account selection and the hooks-off path remove native Orca entries.

## Cross-platform and SSH review

- Host paths use Node path semantics on macOS, Linux, and Windows.
- WSL continues using the existing distro-home and guest-hook installation abstractions.
- Windows daemon-backed WSL spawns still reject host-only Codex-home injection.
- SSH behavior is unchanged; remote Codex hook installation already targets the remote native/runtime home explicitly.

## Security

- No new IPC endpoint, dependency, or externally reachable service was added.
- Managed credentials remain isolated under the existing runtime-home permissions and token read-back rules.
- Native hook writes preserve non-Orca definitions and remove only entries identified by Orca's managed command and trust hashes.
- Outside Orca, the managed hook has no endpoint token or pane identity and exits without a callback.

## Notes

- This remains separate from #8406 so usage-history/provider UI work can be reviewed independently from Codex runtime-state ownership.
- The existing non-destructive system-auth snapshot remains for managed-account transition and logout recovery; it is no longer used as the system-default launch home.

Closes #8612

## ELI5

When you pick the system-default Codex account, Orca now uses Codex's normal home directory on your machine (or in WSL) instead of a private Orca-only folder. You keep Orca's status hooks, while Orca-managed accounts still stay isolated for switching accounts safely.
