### PR TITLE
fix(sidebar): drop orphaned worktree buckets to kill "Unknown" ghost rows

### DIFF
--- a/src/renderer/src/store/slices/repos-remove-project-orphan-ghost.test.ts
+++ b/src/renderer/src/store/slices/repos-remove-project-orphan-ghost.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Ghost "Unknown" sidebar row regression: removing a project must drop its whole
+ * worktree bucket when the repo id no longer survives on any host.
+ *
+ * `removeProject` filtered `worktreesByRepo[projectId]` host-scoped only and kept
+ * the bucket whenever any host-mismatched worktree remained — even after the repo
+ * id was fully removed from `repos`. A worktree left stamped with an abandoned
+ * host (e.g. a removed SSH connection the user reached as "M424") then survived in
+ * the bucket with no repo to render under, so the sidebar labeled it "Unknown"
+ * (worktree-list-groups.ts `repo?.displayName ?? 'Unknown'`). The persisted
+ * lastVisited timestamps already cascaded on `repoIdFullyRemoved`; the worktree
+ * bucket did not. This mirrors the reported flow: an M424-connection worktree was
+ * left behind after the repo was re-homed/removed, surfacing as a ghost row.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createTestStore, makeWorktree } from './store-test-helpers'
+import type { Repo } from '../../../../shared/types'
+
+// Single repo entry, homed on the local host (its M424 connection is long gone).
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/r1',
+  displayName: 'R1',
+  badgeColor: '#000',
+  addedAt: 1,
+  executionHostId: 'local'
+}
+
+const reposRemove = vi.fn().mockResolvedValue(undefined)
+const ptyKill = vi.fn()
+
+beforeEach(() => {
+  reposRemove.mockReset().mockResolvedValue(undefined)
+  ptyKill.mockReset()
+  vi.stubGlobal('window', {
+    api: {
+      repos: { remove: reposRemove },
+      pty: { kill: ptyKill },
+      runtimeEnvironments: { call: vi.fn() }
+    }
+  })
+})
+
+// Owner-host worktree (local) plus a leftover stamped with the abandoned
+// "M424" SSH connection host that no longer exists.
+const WLOCAL = 'repo-1::/r1/wt-local'
+const WGHOST = 'repo-1::/r1/wt-m424'
+
+describe('removeProject drops orphaned worktree buckets (Unknown ghost regression)', () => {
+  it('deletes the whole bucket when the repo id is fully removed', async () => {
+    const store = createTestStore()
+    store.setState({
+      repos: [repo],
+      worktreesByRepo: {
+        [repo.id]: [
+          makeWorktree({ id: WLOCAL, repoId: repo.id, path: '/r1/wt-local' }),
+          makeWorktree({
+            id: WGHOST,
+            repoId: repo.id,
+            path: '/r1/wt-m424',
+            hostId: 'ssh:m424'
+          })
+        ]
+      },
+      detectedWorktreesByRepo: {
+        [repo.id]: {
+          worktrees: [
+            makeWorktree({
+              id: WGHOST,
+              repoId: repo.id,
+              path: '/r1/wt-m424',
+              hostId: 'ssh:m424'
+            })
+          ]
+        } as never
+      }
+    })
+
+    await store.getState().removeProject(repo.id)
+
+    const s = store.getState()
+    // No repo owns 'repo-1' anymore, so no host-mismatched leftover may remain.
+    expect(s.repos.some((r) => r.id === repo.id)).toBe(false)
+    expect(s.worktreesByRepo[repo.id]).toBeUndefined()
+    expect(s.detectedWorktreesByRepo[repo.id]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2826,11 +2826,18 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       get().purgeWorktreeTerminalState(worktreeIds)
 
       set((s) => {
+        // Why: compute repo survival up front so worktree/detected buckets can be
+        // dropped wholesale when the repo id is gone from every host. A leftover
+        // worktree stamped with an abandoned host (e.g. a removed SSH connection)
+        // otherwise lingers in worktreesByRepo with no repo to render under and
+        // surfaces as an "Unknown" ghost row in the sidebar.
+        const nextRepos = s.repos.filter((r) => !repoMatchesHostIdentity(r, projectId, ownerHostId))
+        const repoIdFullyRemoved = !nextRepos.some((r) => r.id === projectId)
         const nextWorktrees = { ...s.worktreesByRepo }
         const remainingWorktrees = (nextWorktrees[projectId] ?? []).filter(
           (worktree) => !worktreeBelongsToHost(worktree, ownerHostId)
         )
-        if (remainingWorktrees.length > 0) {
+        if (remainingWorktrees.length > 0 && !repoIdFullyRemoved) {
           nextWorktrees[projectId] = remainingWorktrees
         } else {
           delete nextWorktrees[projectId]
@@ -2841,7 +2848,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           const remainingDetected = detected.worktrees.filter(
             (worktree) => !worktreeBelongsToHost(worktree, ownerHostId)
           )
-          if (remainingDetected.length > 0) {
+          if (remainingDetected.length > 0 && !repoIdFullyRemoved) {
             nextDetectedWorktrees[projectId] = { ...detected, worktrees: remainingDetected }
           } else {
             delete nextDetectedWorktrees[projectId]
@@ -2874,13 +2881,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         const activeFileCleared = s.activeFileId
           ? s.openFiles.some((f) => f.id === s.activeFileId && worktreeIdSet.has(f.worktreeId))
           : false
-        const nextRepos = s.repos.filter((r) => !repoMatchesHostIdentity(r, projectId, ownerHostId))
         // Why: when no sibling host still owns this repo id, drop every persisted
         // timestamp for the repo's worktrees — including unhydrated SSH/remote ones
         // absent from worktreeIdSet, which pruneLastVisitedTimestamps would otherwise
         // defer forever as "not yet hydrated" after the repo is gone. When a duplicate
         // id remains on another host, stay host-scoped via worktreeIdSet.
-        const repoIdFullyRemoved = !nextRepos.some((r) => r.id === projectId)
+        // (nextRepos / repoIdFullyRemoved are derived above to gate bucket cleanup.)
         let nextLastVisitedAtByWorktreeId = s.lastVisitedAtByWorktreeId
         for (const id of Object.keys(s.lastVisitedAtByWorktreeId)) {
           if (


### PR DESCRIPTION
## Problem

A zombie worktree row labeled **"Unknown"** can linger in the left sidebar and cannot be removed.

### Repro (reported by a user with SSH remotes)
A remote machine is reachable two ways: a plain SSH host and a separate Orca SSH *connection*. After the connection can't find the repo's git, the user deletes the worktree that lived under that connection and re-homes the repo. A residual "Unknown" row is left behind in the sidebar.

## Root cause

`removeProject` (`src/renderer/src/store/slices/repos.ts`) filters `worktreesByRepo[projectId]` **host-scoped only**, keeping the whole bucket whenever any host-mismatched worktree remains — even after the repo id has been fully removed from every host in `repos`.

A worktree still stamped with the **abandoned host** (the removed SSH connection) then survives in the bucket with no repo to render under → `getProjectGroupingForRepo` falls back to `repo?.displayName ?? 'Unknown'` (`worktree-list-groups.ts`), and the row can't be deleted (`worktrees:remove` throws `Repo not found`).

The same function already cascades `lastVisitedAtByWorktreeId` on `repoIdFullyRemoved` — the worktree/detected buckets were simply missing that same invariant.

## Fix

Compute `repoIdFullyRemoved` up front and drop both `worktreesByRepo` and `detectedWorktreesByRepo` buckets wholesale when the repo id survives on no host, while keeping host-scoped entries when a duplicate id remains on a sibling host (host-split repos are unaffected).

## Tests

- New regression test `repos-remove-project-orphan-ghost.test.ts` covering the abandoned-SSH-connection flow (fails before, passes after).
- Existing host-identity / remove-project suites unaffected — full `src/renderer/src/store/slices/` suite: **1678 passed**.
- `oxlint` clean; the changed files typecheck clean.

## Scope / safety

- Pure renderer store-state fix; touches no disk or git operations, and does not prune persisted `worktreeMeta` (so `reassignSshTargetId`'s no-matching-repo contract is preserved).
- Considers the SSH use case: a disconnected SSH repo still lives in `repos`, so its bucket is never dropped — only genuinely repo-less orphans are.

## ELI5

Sometimes a leftover worktree row named "Unknown" stayed in the left sidebar and you could not remove it, especially after SSH connection mix-ups. This fix drops orphaned worktree buckets when their project is gone, so those ghost rows disappear.
