### PR TITLE
fix(terminal): stop wheel replay when mouse reporting is disabled

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -393,6 +393,7 @@ describe('terminal mouse wheel multiplier', () => {
           handlers.push(handler)
         },
         element: target,
+        modes: { mouseTrackingMode: 'any' },
         rows: 24
       },
       { getTuiMouseWheelMultiplier: () => 1 }
@@ -418,6 +419,81 @@ describe('terminal mouse wheel multiplier', () => {
     expect(shouldMultiplyTerminalMouseWheel(dispatched[0]!, target)).toBe(false)
   })
 
+  it('does not replay with a stale active mouse-reporting class', async () => {
+    vi.stubGlobal('WheelEvent', TestWheelEvent)
+    const handlers: ((event: WheelEvent) => boolean)[] = []
+    const target = Object.assign(new EventTarget(), {
+      classList: {
+        contains: (className: string) => className === 'enable-mouse-events'
+      }
+    }) as unknown as EventTarget & HTMLElement
+    const dispatched: WheelEvent[] = []
+    target.addEventListener('wheel', (event) => dispatched.push(event as WheelEvent))
+    const terminal = {
+      attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
+        handlers.push(handler)
+      },
+      element: target,
+      modes: { mouseTrackingMode: 'none' as const },
+      rows: 24
+    }
+    attachTerminalMouseWheelMultiplier(terminal)
+
+    const event = new TestWheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaMode: DOM_DELTA_PIXEL,
+      deltaY: 12
+    }) as WheelEvent
+    Object.defineProperty(event, 'wheelDeltaY', {
+      configurable: true,
+      value: -120
+    })
+
+    expect(handlers[0]?.(event)).toBe(true)
+    await Promise.resolve()
+
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('discards pending replay when mouse reporting turns off before drain', async () => {
+    vi.stubGlobal('WheelEvent', TestWheelEvent)
+    const handlers: ((event: WheelEvent) => boolean)[] = []
+    const target = Object.assign(new EventTarget(), {
+      classList: {
+        contains: (className: string) => className === 'enable-mouse-events'
+      }
+    }) as unknown as EventTarget & HTMLElement
+    const dispatched: WheelEvent[] = []
+    target.addEventListener('wheel', (event) => dispatched.push(event as WheelEvent))
+    const terminal = {
+      attachCustomWheelEventHandler: (handler: (event: WheelEvent) => boolean) => {
+        handlers.push(handler)
+      },
+      element: target,
+      modes: { mouseTrackingMode: 'any' as 'any' | 'none' },
+      rows: 24
+    }
+    attachTerminalMouseWheelMultiplier(terminal)
+
+    const event = new TestWheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaMode: DOM_DELTA_PIXEL,
+      deltaY: 12
+    }) as WheelEvent
+    Object.defineProperty(event, 'wheelDeltaY', {
+      configurable: true,
+      value: -120
+    })
+
+    expect(handlers[0]?.(event)).toBe(false)
+    terminal.modes.mouseTrackingMode = 'none'
+    await Promise.resolve()
+
+    expect(dispatched).toHaveLength(0)
+  })
+
   it('replays trackpad-like TUI pixel scrolling with responsive direction reversal', async () => {
     vi.stubGlobal('WheelEvent', TestWheelEvent)
     const handlers: ((event: WheelEvent) => boolean)[] = []
@@ -434,6 +510,7 @@ describe('terminal mouse wheel multiplier', () => {
           handlers.push(handler)
         },
         element: target,
+        modes: { mouseTrackingMode: 'any' },
         rows: 24
       },
       { getTuiMouseWheelMultiplier: () => 1 }
@@ -486,6 +563,7 @@ describe('terminal mouse wheel multiplier', () => {
           handlers.push(handler)
         },
         element: target,
+        modes: { mouseTrackingMode: 'any' },
         rows: 24
       },
       { getTuiMouseWheelMultiplier: () => 1 }
@@ -520,6 +598,7 @@ describe('terminal mouse wheel multiplier', () => {
           handlers.push(handler)
         },
         element: target,
+        modes: { mouseTrackingMode: 'any' },
         rows: 24
       },
       {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
@@ -21,7 +21,9 @@ const XTERM_MOUSE_REPORTING_CLASS = 'enable-mouse-events'
 const REPLAYED_WHEEL_EVENT_PROPERTY = '__orcaReplayedTerminalWheelEvent'
 const DOM_DELTA_LINE = 1
 
-type TerminalWheelTarget = Pick<Terminal, 'attachCustomWheelEventHandler' | 'element' | 'rows'>
+type TerminalWheelTarget = Pick<Terminal, 'attachCustomWheelEventHandler' | 'element' | 'rows'> & {
+  modes: Pick<Terminal['modes'], 'mouseTrackingMode'>
+}
 
 type TerminalMouseWheelMultiplierOptions = {
   getTuiMouseWheelMultiplier?: () => number | undefined
@@ -117,11 +119,23 @@ export function shouldMultiplyTerminalMouseWheel(
   return true
 }
 
-function drainTerminalTuiWheelReports(state: TerminalTuiMouseWheelReplayState): void {
+function drainTerminalTuiWheelReports(
+  state: TerminalTuiMouseWheelReplayState,
+  terminal: TerminalWheelTarget
+): void {
   const target = state.pendingTarget
   const event = state.pendingEvent
   if (!target || !event || state.pendingReports <= 0) {
     state.drainScheduled = false
+    return
+  }
+
+  if (terminal.modes.mouseTrackingMode === 'none') {
+    state.pendingReports = 0
+    state.drainScheduled = false
+    state.pendingDirection = 0
+    state.pendingEvent = null
+    state.pendingTarget = null
     return
   }
 
@@ -138,6 +152,7 @@ function drainTerminalTuiWheelReports(state: TerminalTuiMouseWheelReplayState): 
 
 function queueTerminalTuiWheelReports(
   state: TerminalTuiMouseWheelReplayState,
+  terminal: TerminalWheelTarget,
   target: EventTarget,
   event: WheelEvent,
   reportCount: number
@@ -164,7 +179,7 @@ function queueTerminalTuiWheelReports(
   // Why: dispatch after xterm returns from the original wheel handler, but do
   // not frame-cap reports; fullscreen TUIs need the full wheel distance.
   queueMicrotask(() => {
-    drainTerminalTuiWheelReports(state)
+    drainTerminalTuiWheelReports(state, terminal)
   })
 }
 
@@ -174,7 +189,10 @@ export function attachTerminalMouseWheelMultiplier(
 ): void {
   const replayState = createTerminalTuiMouseWheelReplayState()
   terminal.attachCustomWheelEventHandler((event) => {
-    if (!shouldMultiplyTerminalMouseWheel(event, terminal.element)) {
+    if (
+      terminal.modes.mouseTrackingMode === 'none' ||
+      !shouldMultiplyTerminalMouseWheel(event, terminal.element)
+    ) {
       return true
     }
 
@@ -195,7 +213,7 @@ export function attachTerminalMouseWheelMultiplier(
         rows: terminal.rows
       }
     )
-    queueTerminalTuiWheelReports(replayState, target, event, reportCount)
+    queueTerminalTuiWheelReports(replayState, terminal, target, event, reportCount)
 
     return false
   })


### PR DESCRIPTION
# fix(terminal): stop wheel replay when mouse reporting is disabled

## Summary

Prevents Orca's multiplied wheel-scroll replay from being dispatched into a terminal after xterm mouse reporting has already been disabled.

## ELI5

When you scroll over a terminal, Orca sometimes replays extra scroll events. If the terminal had just turned scroll-reporting off, those leftover events were still getting sent to the wrong place. This makes them stop.

## Root cause & fix

The wheel multiplier trusted the `enable-mouse-events` DOM class and never re-checked xterm's live mouse-reporting mode before a queued replay drained on the next microtask. That stale state could dispatch replay into a terminal that should have fallen back to normal scrollback. The fix makes the live xterm mouse-reporting mode the replay authority and re-validates it immediately before queued dispatch — if reporting is off, the pending replay is dropped instead of sent.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test file: `src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts`
- On branch: **28 passed (28)**, 1 file passed.
- Reverting the fix fails 2 targeted assertions, proving the "1 replay on main → 0 with fix" behavior:

```
FIX REVERTED: 2 failed
  - "does not replay with a stale active mouse-reporting class"
      (expected false to be true)
  - "discards pending replay when mouse reporting turns off before drain"
      (expected [ …(1) ] to have length +0 but got 1)
```

- `pnpm run typecheck:web` clean.

## Trade-offs

None — pure fix. Active mouse reporting still drains its existing report count unchanged.

## Regression risk

Zero-regression by construction: only the buggy replay branch changes behavior, gated on a re-check of live reporting mode. Shift-wheel, replay suppression, and fullscreen TUI replay paths are unaffected and covered by the passing suite. Residual risk is limited to xterm mode transitions during the synchronous dispatch loop, which the pre-drain check covers.

_Credit to @rodboev for the original fix. Scope is honest and narrower than issue #8563 (labeled cannot_repro): that scenario had mouse reporting never enabled, whereas this fixes a stale-class/microtask race. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
