### PR TITLE
fix(ssh): reap detached relay after failed reconnect

### DIFF
--- a/src/main/ssh/ssh-relay-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-deploy.test.ts
@@ -153,6 +153,88 @@ describe('deployAndLaunchRelay', () => {
     expect(progress).toContain('Starting relay...')
   })
 
+  it('reaps a detached Unix relay before relaunching after reconnect failure', async () => {
+    const conn = makeMockConnection()
+    const mockExecCommand = vi.mocked(execCommand)
+    vi.mocked(waitForSentinel)
+      .mockRejectedValueOnce(new Error('stale daemon handshake failed'))
+      .mockResolvedValueOnce({
+        write: vi.fn(),
+        onData: vi.fn(),
+        onClose: vi.fn()
+      })
+    mockExecCommand
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      .mockResolvedValueOnce('/home/user')
+      .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
+      .mockResolvedValueOnce('ALIVE')
+      .mockResolvedValueOnce('4242\n')
+      .mockResolvedValueOnce('ORCA_RELAY_PID_MATCH')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('READY')
+
+    await deployAndLaunchRelay(conn)
+
+    const cleanupCommands = mockExecCommand.mock.calls
+      .map(([, command]) => command as string)
+      .filter((command) => command.includes('.pid') || command.includes('kill -TERM'))
+    expect(cleanupCommands[0]).toContain('cat ')
+    expect(cleanupCommands[0]).toContain('.pid')
+    expect(cleanupCommands[1]).toBe('kill -TERM 4242')
+    expect(cleanupCommands[2]).toContain('rm -f ')
+    expect(cleanupCommands[2]).toContain('.pid')
+    expect(cleanupCommands[2]).toContain('.sock')
+  })
+
+  it('does not reap a stale pidfile when the pid belongs to another command', async () => {
+    const conn = makeMockConnection()
+    const mockExecCommand = vi.mocked(execCommand)
+    vi.mocked(waitForSentinel)
+      .mockRejectedValueOnce(new Error('stale daemon handshake failed'))
+      .mockResolvedValueOnce({
+        write: vi.fn(),
+        onData: vi.fn(),
+        onClose: vi.fn()
+      })
+    mockExecCommand
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      .mockResolvedValueOnce('/home/user')
+      .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
+      .mockResolvedValueOnce('ALIVE')
+      .mockResolvedValueOnce('4242\n')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('READY')
+
+    await deployAndLaunchRelay(conn)
+
+    const commands = mockExecCommand.mock.calls.map(([, command]) => command as string)
+    expect(commands.some((command) => command.includes('kill -TERM 4242'))).toBe(false)
+    expect(commands.some((command) => command.includes('rm -f '))).toBe(true)
+    expect(commands.some((command) => command.includes('.pid'))).toBe(true)
+  })
+
+  it('does not reap or relaunch after a successful Unix relay reconnect', async () => {
+    const conn = makeMockConnection()
+    const mockExecCommand = vi.mocked(execCommand)
+    mockExecCommand
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      .mockResolvedValueOnce('/home/user')
+      .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
+      .mockResolvedValueOnce('ALIVE')
+
+    await deployAndLaunchRelay(conn)
+
+    expect(vi.mocked(conn.exec)).toHaveBeenCalledTimes(1)
+    expect(mockExecCommand.mock.calls.map(([, command]) => command as string)).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('kill -TERM')])
+    )
+    expect(mockExecCommand.mock.calls.map(([, command]) => command as string)).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('.pid')])
+    )
+  })
+
   it('resolves the remote node path once per deploy', async () => {
     const conn = makeMockConnection()
     const mockExecCommand = vi.mocked(execCommand)

--- a/src/main/ssh/ssh-relay-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-deploy.test.ts
@@ -176,11 +176,17 @@ describe('deployAndLaunchRelay', () => {
 
     await deployAndLaunchRelay(conn)
 
-    const cleanupCommands = mockExecCommand.mock.calls
-      .map(([, command]) => command as string)
-      .filter((command) => command.includes('.pid') || command.includes('kill -TERM'))
+    const commands = mockExecCommand.mock.calls.map(([, command]) => command as string)
+    const cleanupCommands = commands.filter(
+      (command) => command.includes('.pid') || command.includes('kill -TERM')
+    )
+    const ownershipCheckCommand = commands.find((command) => command.includes('grep -Eq --')) ?? ''
     expect(cleanupCommands[0]).toContain('cat ')
     expect(cleanupCommands[0]).toContain('.pid')
+    expect(ownershipCheckCommand).toContain(
+      "grep -Eq -- '(^|[[:space:]])relay\\.js([[:space:]]|$)'"
+    )
+    expect(ownershipCheckCommand).toContain('--sock-path[[:space:]]+')
     expect(cleanupCommands[1]).toBe('kill -TERM 4242')
     expect(cleanupCommands[2]).toContain('rm -f ')
     expect(cleanupCommands[2]).toContain('.pid')

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -736,9 +736,26 @@ async function launchRelay(
           '[ssh-relay] Socket reconnect failed, launching fresh relay:',
           err instanceof Error ? err.message : String(err)
         )
-        // Why: stale socket from a crashed relay — remove it so the
-        // fresh launch can bind a new socket at the same path.
-        await execCommand(conn, `rm -f ${shellEscape(sockFile)}`).catch(() => {})
+        // Why: unlinking a Unix socket does not stop the detached relay that
+        // owns it, so reap that process before rebinding the path.
+        const pidFile = `${sockFile}.pid`
+        const pidOutput = await execCommand(conn, `cat ${shellEscape(pidFile)} 2>/dev/null`).catch(
+          () => ''
+        )
+        const pid = pidOutput.trim()
+        if (/^[1-9]\d*$/.test(pid)) {
+          const relayCommandMarker = 'ORCA_RELAY_PID_MATCH'
+          const commandLine = await execCommand(
+            conn,
+            `ps -ww -p ${pid} -o command= 2>/dev/null | grep -F -- ${shellEscape('relay.js')} | grep -F -- ${shellEscape(`--sock-path ${sockFile}`)} >/dev/null && echo ${relayCommandMarker} || true`
+          ).catch(() => '')
+          if (commandLine.trim() === relayCommandMarker) {
+            await execCommand(conn, `kill -TERM ${pid}`).catch(() => {})
+          }
+        }
+        await execCommand(conn, `rm -f ${shellEscape(sockFile)} ${shellEscape(pidFile)}`).catch(
+          () => {}
+        )
       }
     }
   } catch {

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -56,6 +56,10 @@ import {
   MIN_SSH_RELAY_GRACE_PERIOD_SECONDS
 } from '../../shared/ssh-types'
 
+function escapePosixExtendedRegex(value: string): string {
+  return value.replace(/[.[\]{}()*+?^$|\\]/g, '\\$&')
+}
+
 export type RelayDeployResult = {
   transport: MultiplexerTransport
   platform: RelayPlatform
@@ -745,9 +749,16 @@ async function launchRelay(
         const pid = pidOutput.trim()
         if (/^[1-9]\d*$/.test(pid)) {
           const relayCommandMarker = 'ORCA_RELAY_PID_MATCH'
+          const relayScriptPattern = '(^|[[:space:]])relay\\.js([[:space:]]|$)'
+          const sockPathPattern =
+            `(^|[[:space:]])--sock-path[[:space:]]+` +
+            `${escapePosixExtendedRegex(sockFile)}([[:space:]]|$)`
           const commandLine = await execCommand(
             conn,
-            `ps -ww -p ${pid} -o command= 2>/dev/null | grep -F -- ${shellEscape('relay.js')} | grep -F -- ${shellEscape(`--sock-path ${sockFile}`)} >/dev/null && echo ${relayCommandMarker} || true`
+            `cmd="$(ps -ww -p ${pid} -o command= 2>/dev/null)" && ` +
+              `printf '%s\\n' "$cmd" | grep -Eq -- ${shellEscape(relayScriptPattern)} && ` +
+              `printf '%s\\n' "$cmd" | grep -Eq -- ${shellEscape(sockPathPattern)} ` +
+              `>/dev/null && echo ${relayCommandMarker} || true`
           ).catch(() => '')
           if (commandLine.trim() === relayCommandMarker) {
             await execCommand(conn, `kill -TERM ${pid}`).catch(() => {})

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -842,8 +842,16 @@ async function main(): Promise<void> {
         if (detached && !isWindowsNamedPipePath(sockPath)) {
           try {
             writeFileSync(pidFile, `${process.pid}\n`)
-          } catch {
-            // Best effort: relay operation does not depend on the pidfile.
+          } catch (err) {
+            const pidWriteErr = err instanceof Error ? err : new Error(String(err))
+            relayLogLine(
+              `[relay] Socket server error before ready: failed to write pidfile ${pidFile}: ${pidWriteErr.message}`
+            )
+            server.close(() => {
+              cleanupOwnedSocket()
+              reject(pidWriteErr as NodeJS.ErrnoException)
+            })
+            return
           }
         }
         server.on('error', (err) => {

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -22,7 +22,7 @@
 import { createServer, createConnection, type Socket, type Server } from 'node:net'
 import { homedir } from 'node:os'
 import { resolve, join } from 'node:path'
-import { unlinkSync, existsSync, statSync } from 'node:fs'
+import { unlinkSync, existsSync, statSync, writeFileSync } from 'node:fs'
 import {
   RELAY_SENTINEL,
   FrameDecoder,
@@ -347,6 +347,7 @@ async function main(): Promise<void> {
 
   let ownsSocketPath = false
   let ownedSocketIdentity: SocketIdentity | null = null
+  const pidFile = `${sockPath}.pid`
   const ownsCurrentSocketPath = (): boolean => {
     if (isWindowsNamedPipePath(sockPath)) {
       return ownsSocketPath
@@ -362,6 +363,13 @@ async function main(): Promise<void> {
   const cleanupOwnedSocket = (): void => {
     if (ownsCurrentSocketPath()) {
       cleanupSocket(sockPath)
+      if (!isWindowsNamedPipePath(sockPath)) {
+        try {
+          unlinkSync(pidFile)
+        } catch {
+          // Best effort: the pidfile may already be gone after a stale cleanup.
+        }
+      }
     }
     ownsSocketPath = false
     ownedSocketIdentity = null
@@ -831,6 +839,13 @@ async function main(): Promise<void> {
         restoreUmask()
         ownsSocketPath = true
         ownedSocketIdentity = readSocketIdentity(sockPath)
+        if (detached && !isWindowsNamedPipePath(sockPath)) {
+          try {
+            writeFileSync(pidFile, `${process.pid}\n`)
+          } catch {
+            // Best effort: relay operation does not depend on the pidfile.
+          }
+        }
         server.on('error', (err) => {
           relayLogLine(`[relay] Socket server error: ${err.message}`)
         })

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -346,6 +346,66 @@ describe('Subprocess: Relay entry point', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
+    'fails detached startup when pidfile creation fails',
+    async () => {
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-pidfile-fail-'))
+      const sockPath = path.join(tmpDir, 'relay.sock')
+      const pidPath = `${sockPath}.pid`
+      const preloadPath = path.join(tmpDir, 'fail-pidfile-write.js')
+      writeFileSync(
+        preloadPath,
+        [
+          "const fs = require('node:fs')",
+          'const originalWriteFileSync = fs.writeFileSync',
+          'fs.writeFileSync = function patchedWriteFileSync(file, ...rest) {',
+          "  if (String(file).endsWith('.pid')) {",
+          "    const err = new Error('pidfile write blocked')",
+          "    err.code = 'EACCES'",
+          '    throw err',
+          '  }',
+          '  return originalWriteFileSync.call(this, file, ...rest)',
+          '}'
+        ].join('\n')
+      )
+
+      let stderr = ''
+      const proc = spawnChild(
+        'node',
+        [relayEntry, '--detached', '--grace-time', '10', '--sock-path', sockPath],
+        {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env: {
+            ...process.env,
+            NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require ${preloadPath}`]
+              .filter(Boolean)
+              .join(' ')
+          }
+        }
+      )
+      proc.stderr!.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8')
+      })
+
+      let code: number | null
+      let signal: NodeJS.Signals | null
+      try {
+        ;({ code, signal } = await waitForChildExit(proc))
+      } finally {
+        if (proc.exitCode === null && proc.signalCode === null) {
+          proc.kill('SIGKILL')
+        }
+      }
+
+      expect(code).toBe(1)
+      expect(signal).toBeNull()
+      expect(existsSync(sockPath)).toBe(false)
+      expect(existsSync(pidPath)).toBe(false)
+      expect(stderr).toContain('failed to write pidfile')
+    },
+    10_000
+  )
+
+  it.skipIf(process.platform === 'win32')(
     'does not unlink a newer relay socket when an older relay exits',
     async () => {
       tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-rebound-'))

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -328,6 +328,24 @@ describe('Subprocess: Relay entry point', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
+    'writes and removes the pidfile for a detached relay',
+    async () => {
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-pidfile-'))
+      const sockPath = path.join(tmpDir, 'relay.sock')
+      const pidPath = `${sockPath}.pid`
+      relay = spawn(['--detached', '--grace-time', '10', '--sock-path', sockPath])
+
+      await relay.sentinelReceived
+      expect(readFileSync(pidPath, 'utf8').trim()).toBe(String(relay.proc.pid))
+
+      relay.kill('SIGTERM')
+      await relay.waitForExit(2000)
+      expect(existsSync(pidPath)).toBe(false)
+    },
+    10_000
+  )
+
+  it.skipIf(process.platform === 'win32')(
     'does not unlink a newer relay socket when an older relay exits',
     async () => {
       tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-rebound-'))


### PR DESCRIPTION
## Summary

- Reap the old detached SSH relay before Orca removes its Unix socket and launches a replacement after reconnect failure.
- Root cause: reconnect failure currently only unlinks the socket and relaunches. The detached relay process stays alive, keeps its PTYs and child processes, and becomes unreachable because the new relay reuses the socket path.
- Fix: the detached relay now writes a pidfile next to its owned socket and removes it on graceful shutdown. The reconnect-failure path reads that pidfile, sends `SIGTERM` to the owning relay when present, then removes socket and pidfile before relaunch.

Closes #8585.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation to run:

- Passed, `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-deploy.test.ts src/relay/relay-handshake-roundtrip.test.ts src/relay/subprocess.test.ts`; 3 files passed, 44 tests passed, 7 skipped on Windows-only branches.
- Passed, `pnpm run typecheck:node`.
- Passed, `pnpm exec oxlint src/main/ssh/ssh-relay-deploy.ts src/relay/relay.ts src/main/ssh/ssh-relay-deploy.test.ts src/relay/relay-handshake-roundtrip.test.ts src/relay/subprocess.test.ts`.
- Passed, `git diff --check`.

## AI Review Report

Passed review: pidfile writes are limited to detached Unix socket ownership; cleanup uses the existing socket identity guard; reconnect accepts only a positive decimal pid, verifies the live command line contains `relay.js` and the exact `--sock-path`, then sends `SIGTERM`; successful reconnect returns before any reap or replacement launch; Windows named-pipe code is unchanged. The subprocess regression test verifies pidfile creation and graceful removal, and the deploy test covers a pid reused by another command. macOS and Linux share this Unix path. No unrelated files changed.

## Security Audit

Passed security review: the remote pid is accepted only as a positive decimal integer read from the exact socket-adjacent pidfile. Before signaling, `ps -ww` must report a command line containing both `relay.js` and the exact shell-escaped `--sock-path` argument for this target; a failed or unavailable check skips the signal. Socket and pidfile paths continue through the existing shell-escaping helper. Cleanup remains best-effort, and a missing, malformed, stale, or mismatched pidfile cannot block relaunch. No new dependency, auth, secret, browser, or SSH protocol surface is introduced.

## Notes

Relays created before this fix will not have pidfiles, so the first reconnect after rollout can still degrade to today’s unlink-and-relaunch behavior for that old process. A stale pidfile is now treated the same way when its pid belongs to a different command or socket target. From the next detached launch onward, the pidfile and command-line ownership check are in place.

## Freshness and Competition Gates

- Passed on 2026-07-13: issue #8585 is open and updated at `2026-07-13T18:15:58Z`.
- Passed on 2026-07-13: no open or closed PR search result fixes #8585; the related open draft #8403 changes renderer shutdown state and does not touch relay socket ownership or reconnect cleanup.

## Diff Summary

- `src/relay/relay.ts`: write a detached Unix relay pidfile after listen ownership and remove it with guarded socket cleanup.
- `src/main/ssh/ssh-relay-deploy.ts`: verify command-line ownership before reaping on Unix reconnect failure, then remove socket and pidfile.
- `src/main/ssh/ssh-relay-deploy.test.ts`: cover reap ordering, successful reconnect preservation, and stale pidfile rejection.
- `src/relay/subprocess.test.ts`: cover detached pidfile creation and graceful removal.

## Residual Risk

- A relay killed before graceful shutdown can leave a stale pidfile; reconnect now signals only when the recorded pid's command line still identifies `relay.js` with the exact socket argument. Command-line identity remains the bounded ownership check, followed by best-effort cleanup.
- Relays started before this change have no marker and retain the previous fallback behavior.

## ELI5

When SSH reconnect fails, Orca used to leave the old relay process running while starting a new one on the same socket, so terminals and child processes got stuck and unreachable. This change saves the relay's process ID and kills that old process before replacing it, so reconnect failures clean up properly.
