### PR TITLE
test(agent-hooks): isolate managed hook user data

### DIFF
--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -2,9 +2,17 @@
 // matrix catches an unread early exit without duplicating template assertions.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawn } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type * as osModule from 'node:os'
 
@@ -231,17 +239,34 @@ function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
 describe('Windows managed hook stdin structure', () => {
   it('routes every batch guard to a shared drain epilogue', () => {
     const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-windows-'))
+    const inheritedUserData = mkdtempSync(join(tmpdir(), 'orca-hook-inherited-user-data-'))
+    const inheritedHooksPath = join(inheritedUserData, 'codex-runtime-home', 'home', 'hooks.json')
+    const inheritedHooks = '{"hooks":{"Stop":[]}}\n'
+    mkdirSync(dirname(inheritedHooksPath), { recursive: true })
+    writeFileSync(inheritedHooksPath, inheritedHooks, 'utf8')
     homedirMock.mockReturnValue(home)
+    const previousOrcaUserDataPath = process.env.ORCA_USER_DATA_PATH
     const previousGrokHome = process.env.GROK_HOME
     const previousKimiHome = process.env.KIMI_CODE_HOME
+    process.env.ORCA_USER_DATA_PATH = inheritedUserData
     delete process.env.GROK_HOME
     delete process.env.KIMI_CODE_HOME
     try {
+      // Why: Orca terminals export their live userData path; installer tests
+      // must redirect it before simulating another platform.
+      process.env.ORCA_USER_DATA_PATH = join(home, 'orca-user-data')
       withPlatform('win32', () => {
         for (const entry of LOCAL_INSTALLERS) {
           expect(entry.install().state, `${entry.agent} install status`).toBe('installed')
         }
       })
+      expect(readFileSync(inheritedHooksPath, 'utf8')).toBe(inheritedHooks)
+      expect(
+        readFileSync(
+          join(home, 'orca-user-data', 'codex-runtime-home', 'home', 'hooks.json'),
+          'utf8'
+        )
+      ).toContain('WindowsPowerShell')
       const hooksDir = join(home, '.orca', 'agent-hooks')
       const fileNames = readdirSync(hooksDir)
       const mainBatchScripts = fileNames.filter(
@@ -277,6 +302,11 @@ describe('Windows managed hook stdin structure', () => {
       expect(kimi.indexOf('payload=$(cat)')).toBeLessThan(kimi.indexOf('exit 0'))
     } finally {
       homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+      if (previousOrcaUserDataPath === undefined) {
+        delete process.env.ORCA_USER_DATA_PATH
+      } else {
+        process.env.ORCA_USER_DATA_PATH = previousOrcaUserDataPath
+      }
       if (previousGrokHome === undefined) {
         delete process.env.GROK_HOME
       } else {
@@ -288,6 +318,7 @@ describe('Windows managed hook stdin structure', () => {
         process.env.KIMI_CODE_HOME = previousKimiHome
       }
       rmSync(home, { recursive: true, force: true })
+      rmSync(inheritedUserData, { recursive: true, force: true })
     }
   })
 
@@ -296,6 +327,8 @@ describe('Windows managed hook stdin structure', () => {
     async () => {
       const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-windows-live-'))
       homedirMock.mockReturnValue(home)
+      const previousOrcaUserDataPath = process.env.ORCA_USER_DATA_PATH
+      process.env.ORCA_USER_DATA_PATH = join(home, 'orca-user-data')
       try {
         const gitBash = findGitBash()
         for (const entry of LOCAL_INSTALLERS) {
@@ -360,6 +393,11 @@ describe('Windows managed hook stdin structure', () => {
         }
       } finally {
         homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+        if (previousOrcaUserDataPath === undefined) {
+          delete process.env.ORCA_USER_DATA_PATH
+        } else {
+          process.env.ORCA_USER_DATA_PATH = previousOrcaUserDataPath
+        }
         rmSync(home, { recursive: true, force: true })
       }
     }

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -241,9 +241,12 @@ describe('Windows managed hook stdin structure', () => {
     const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-windows-'))
     const inheritedUserData = mkdtempSync(join(tmpdir(), 'orca-hook-inherited-user-data-'))
     const inheritedHooksPath = join(inheritedUserData, 'codex-runtime-home', 'home', 'hooks.json')
+    const inheritedConfigPath = join(inheritedUserData, 'codex-runtime-home', 'home', 'config.toml')
     const inheritedHooks = '{"hooks":{"Stop":[]}}\n'
+    const inheritedConfig = 'model = "gpt-5.6-sol"\n\n[features]\nhooks = true\n'
     mkdirSync(dirname(inheritedHooksPath), { recursive: true })
     writeFileSync(inheritedHooksPath, inheritedHooks, 'utf8')
+    writeFileSync(inheritedConfigPath, inheritedConfig, 'utf8')
     homedirMock.mockReturnValue(home)
     const previousOrcaUserDataPath = process.env.ORCA_USER_DATA_PATH
     const previousGrokHome = process.env.GROK_HOME
@@ -260,6 +263,7 @@ describe('Windows managed hook stdin structure', () => {
           expect(entry.install().state, `${entry.agent} install status`).toBe('installed')
         }
       })
+      expect(readFileSync(inheritedConfigPath, 'utf8')).toBe(inheritedConfig)
       expect(readFileSync(inheritedHooksPath, 'utf8')).toBe(inheritedHooks)
       expect(
         readFileSync(


### PR DESCRIPTION
## Summary

- Prevent the Windows managed-hook lifecycle test from inheriting an Orca-launched terminal's live `ORCA_USER_DATA_PATH`.
- Route both local-installer test paths to fixture-owned temporary user data and restore the inherited environment afterward.
- Add a sentinel assertion proving an inherited Codex `hooks.json` remains unchanged while the Windows fixture is still generated.

Fixes #8629.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the focused affected suites were run instead: 28 passed, 6 skipped
- [ ] `pnpm build` — test-only change; no production or build inputs changed
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional verifier: the live managed Codex `hooks.json` had the same SHA-256 before and after the affected lifecycle suite.

## AI Review Report

Reviewed the final one-file diff for environment leakage, cleanup on assertion failure, and fixture ownership. The original risk was that an Orca-launched terminal exports its real user-data path; the Windows simulation then called production local installers against that path. The fix redirects both installer loops before invocation, restores the prior value in `finally`, and verifies a separate inherited sentinel file is untouched.

Cross-platform review covered macOS/Linux host execution, the simulated Windows path, `path.join` usage, generated PowerShell hook configuration, shell behavior, and Electron user-data path handling. This PR does not touch shortcuts, labels, renderer UI, SSH execution, or production hook templates.

## Security Audit

No dependencies, auth, IPC, network requests, secrets, or production command templates changed. The path-handling review confirmed all new paths are fixture-owned temporary directories and cleanup is recursive in `finally`. The regression assertion uses sanitized sentinel content and specifically guards against writes to inherited external user data.

## Notes

The real Windows shell execution case remains platform-gated and will run on Windows CI. Local verification on macOS covered the generated Windows configuration and proved the live managed runtime file was not modified.
