### PR TITLE
fix(rate-limits): classify Codex weekly-duration primary window as weekly

### DIFF
--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -95,6 +95,39 @@ describe('Codex backend rate-limit requests', () => {
     )
   })
 
+  it('classifies a weekly-duration backend primary window as weekly', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        tokens: { access_token: 'access-token', account_id: 'account-id' }
+      })
+    )
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        plan_type: 'pro',
+        rate_limit: {
+          primary_window: {
+            used_percent: 72,
+            limit_window_seconds: 604_800,
+            reset_at: 1_784_503_944
+          },
+          secondary_window: null
+        },
+        rate_limit_reset_credits: { available_count: 0 }
+      })
+    } as Response)
+
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\account\\home'
+      })
+    ).resolves.toMatchObject({
+      session: null,
+      weekly: { usedPercent: 72, windowMinutes: 10080, resetsAt: 1_784_503_944_000 },
+      status: 'ok'
+    })
+  })
+
   it('aborts callers while sharing one stalled backend auth read', async () => {
     let resolveRead!: (content: string) => void
     readFileMock.mockImplementation(

--- a/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
+++ b/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
@@ -76,4 +76,40 @@ describe('fetchCodexRateLimits PTY settle timers', () => {
       status: 'ok'
     })
   })
+
+  it('keeps the reset text on the weekly window for weekly-only plans', async () => {
+    const ptyHandlers: { onData?: (data: string) => void } = {}
+
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockReturnValue({
+      onData: vi.fn((callback) => {
+        ptyHandlers.onData = callback
+        return makeDisposable()
+      }),
+      onExit: vi.fn(() => makeDisposable()),
+      write: vi.fn(),
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const onPtyData = ptyHandlers.onData
+    if (!onPtyData) {
+      throw new Error('PTY data handler was not registered')
+    }
+
+    onPtyData('>')
+    onPtyData('Weekly limit: 76%\nResets in 5d 23h\n')
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: null,
+      weekly: { usedPercent: 76, resetDescription: '5d 23h' },
+      status: 'ok'
+    })
+  })
 })

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -368,6 +368,57 @@ describe('fetchCodexRateLimits', () => {
     expect(result.weekly?.windowMinutes).toBe(10080)
   })
 
+  it('classifies a weekly-duration primary window as weekly when no session window exists', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    rpcChild.stdin.write.mockImplementation((line: string) => {
+      const msg = JSON.parse(line) as { id?: number; method?: string }
+      if (msg.method === 'initialize') {
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
+          )
+        }, 0)
+      }
+      if (msg.method === 'account/rateLimits/read') {
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(
+              `${JSON.stringify({
+                jsonrpc: '2.0',
+                id: msg.id,
+                result: {
+                  rateLimits: {
+                    primary: {
+                      usedPercent: 72,
+                      windowDurationMins: 10080,
+                      resetsAt: 1_784_503_944
+                    },
+                    secondary: null
+                  }
+                }
+              })}\n`
+            )
+          )
+        }, 0)
+      }
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+    const result = await resultPromise
+
+    expect(result.session).toBeNull()
+    expect(result.weekly).toMatchObject({
+      usedPercent: 72,
+      windowMinutes: 10080,
+      resetsAt: 1_784_503_944_000
+    })
+  })
+
   it('fills reset-credit count from the backend when the installed app-server omits it', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -73,8 +73,8 @@ type RateLimitResetCredits = {
 }
 
 type RpcRateLimitsResult = {
-  primary?: RpcRateWindow
-  secondary?: RpcRateWindow
+  primary?: RpcRateWindow | null
+  secondary?: RpcRateWindow | null
 }
 
 // Why: the Codex app-server wraps rate limit data inside a `rateLimits` key.
@@ -454,8 +454,18 @@ export async function consumeCodexRateLimitResetCredit(options: {
   return mapBackendConsumeOutcome(payload.code)
 }
 
+const MAX_SESSION_WINDOW_MINUTES = 1440
+
+function isWeeklyWindowDuration(windowMinutes: number | undefined): boolean {
+  return (
+    typeof windowMinutes === 'number' &&
+    Number.isFinite(windowMinutes) &&
+    windowMinutes > MAX_SESSION_WINDOW_MINUTES
+  )
+}
+
 function mapRpcWindow(
-  raw: RpcRateWindow | undefined,
+  raw: RpcRateWindow | null | undefined,
   expectedWindowMinutes: number
 ): RateLimitWindow | null {
   if (!raw || typeof raw.usedPercent !== 'number' || !Number.isFinite(raw.usedPercent)) {
@@ -483,27 +493,54 @@ function mapRpcWindow(
 
   return {
     usedPercent: Math.min(100, Math.max(0, raw.usedPercent)),
-    // Why: Codex currently reports remaining minutes in `windowDurationMins`.
-    // Orca's UI needs the fixed bucket duration so labels stay "5h" / "wk".
+    // Why: older Codex CLIs report *remaining* minutes in `windowDurationMins`
+    // while newer ones report the bucket duration. Orca's UI needs the fixed
+    // bucket duration so labels stay "5h" / "wk".
     windowMinutes: expectedWindowMinutes,
     resetsAt,
     resetDescription
   }
 }
 
+// Why: plans without a 5h bucket report the weekly limit as *primary*. Windows
+// longer than a day are always weekly; shorter ones keep slot order because
+// older CLIs report *remaining* minutes in the duration field.
+function classifyCodexWindows<T>(
+  primary: T | null | undefined,
+  secondary: T | null | undefined,
+  durationMinutesOf: (window: T | null | undefined) => number | undefined,
+  map: (window: T | null | undefined, expectedWindowMinutes: number) => RateLimitWindow | null
+): { session: RateLimitWindow | null; weekly: RateLimitWindow | null } {
+  if (isWeeklyWindowDuration(durationMinutesOf(primary))) {
+    return {
+      session: isWeeklyWindowDuration(durationMinutesOf(secondary)) ? null : map(secondary, 300),
+      weekly: map(primary, 10080)
+    }
+  }
+  return {
+    session: map(primary, 300),
+    weekly: map(secondary, 10080)
+  }
+}
+
+function backendWindowDurationMinutes(
+  raw: BackendRateLimitWindow | null | undefined
+): number | undefined {
+  const limitWindowSeconds = raw?.limit_window_seconds
+  // Match Codex backend-client's `window_minutes_from_seconds`: the backend
+  // field is the actual bucket duration and rounds partial minutes upward.
+  return typeof limitWindowSeconds === 'number' &&
+    Number.isFinite(limitWindowSeconds) &&
+    limitWindowSeconds > 0
+    ? Math.ceil(limitWindowSeconds / 60)
+    : undefined
+}
+
 function mapBackendUsageWindow(
   raw: BackendRateLimitWindow | null | undefined,
   fallbackWindowMinutes: number
 ): RateLimitWindow | null {
-  const limitWindowSeconds = raw?.limit_window_seconds
-  // Match Codex backend-client's `window_minutes_from_seconds`: the backend
-  // field is the actual bucket duration and rounds partial minutes upward.
-  const windowMinutes =
-    typeof limitWindowSeconds === 'number' &&
-    Number.isFinite(limitWindowSeconds) &&
-    limitWindowSeconds > 0
-      ? Math.ceil(limitWindowSeconds / 60)
-      : fallbackWindowMinutes
+  const windowMinutes = backendWindowDurationMinutes(raw) ?? fallbackWindowMinutes
   return mapRpcWindow(
     raw
       ? {
@@ -542,8 +579,12 @@ async function fetchViaBackend(
   }
   return {
     provider: 'codex',
-    session: mapBackendUsageWindow(payload.rate_limit?.primary_window, 300),
-    weekly: mapBackendUsageWindow(payload.rate_limit?.secondary_window, 10080),
+    ...classifyCodexWindows(
+      payload.rate_limit?.primary_window,
+      payload.rate_limit?.secondary_window,
+      backendWindowDurationMinutes,
+      mapBackendUsageWindow
+    ),
     ...(payload.rate_limit_reset_credits !== undefined
       ? {
           rateLimitResetCredits:
@@ -724,8 +765,12 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
 
             const wrapper = msg.result as RpcRateLimitsResponse | undefined
             const result = wrapper?.rateLimits
-            const session = mapRpcWindow(result?.primary, 300)
-            const weekly = mapRpcWindow(result?.secondary, 10080)
+            const { session, weekly } = classifyCodexWindows(
+              result?.primary,
+              result?.secondary,
+              (window) => window?.windowDurationMins,
+              mapRpcWindow
+            )
             const rateLimitResetCredits = mapRpcRateLimitResetCredits(
               wrapper?.rateLimitResetCredits
             )
@@ -827,10 +872,12 @@ function parsePtyStatus(output: string): {
       }
     : null
 
-  // Try to extract reset time from surrounding text
+  // Try to extract reset time from surrounding text. Weekly-only plans have
+  // no session window, so fall back to the weekly one instead of dropping it.
   const resetMatch = RESET_TEXT_RE.exec(output)
-  if (resetMatch && session) {
-    session.resetDescription = resetMatch[1].trim()
+  const resetTarget = session ?? weekly
+  if (resetMatch && resetTarget) {
+    resetTarget.resetDescription = resetMatch[1].trim()
   }
 
   return { session, weekly }

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -351,7 +351,9 @@ export class RateLimitService {
     const nextTarget = normalizeCodexAccountSelectionTarget(target)
     if (
       outgoingAccountId &&
-      this.state.codex?.session &&
+      // Why: plans without a session bucket report weekly-only limits; those
+      // snapshots are still worth caching for the inactive-account view.
+      (this.state.codex?.session || this.state.codex?.weekly) &&
       this.isSameCodexTarget(this.codexFetchTarget, nextTarget)
     ) {
       this.inactiveCodexCache.set(outgoingAccountId, this.state.codex)

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1221,7 +1221,11 @@ function ProviderSegment({
   return (
     <span className="inline-flex items-center gap-1.5">
       <ProviderIcon provider={provider} />
-      {p.session && !compact && <MiniBar usedPct={clampUsedPercent(p.session.usedPercent)} />}
+      {/* Why: plans without a session bucket (e.g. Codex Pro) only report a
+          weekly window; fall back to the first window so the gauge stays. */}
+      {visibleWindows[0] && !compact && (
+        <MiniBar usedPct={clampUsedPercent(visibleWindows[0].window.usedPercent)} />
+      )}
       {visibleWindows.map((window, index) => (
         <React.Fragment key={window.key}>
           {index > 0 && <span className="text-muted-foreground">·</span>}


### PR DESCRIPTION
## Summary

Codex plans without a 5h session bucket (e.g. the current Pro plan) report the **weekly** limit as the *primary* rate-limit window with a null secondary. Orca slotted windows by position (`primary → session`, `secondary → weekly`), so the weekly limit was mislabeled as the session window: the status bar showed `5h` and the usage popup showed "Session" with a reset countdown ~6 days away, while the Codex dashboard calls the same number the weekly limit.

This PR classifies windows by their reported duration instead of slot position:

- Any window longer than a day (`> 1440` minutes) goes to the `weekly` slot.
- Shorter durations keep the slot-based fallback, because older Codex CLIs report *remaining* minutes in `windowDurationMins` (a nearly-expired weekly window can carry a small value there), so duration alone can't be trusted below a day.
- One shared classifier (`classifyCodexWindows`) covers both the app-server RPC path (`windowDurationMins`) and the backend usage path (`limit_window_seconds`) used for WSL accounts, so the two transports can't diverge.

Also fixed for weekly-only plans:

- The PTY `/status` fallback now attaches the parsed reset text to the weekly window instead of silently dropping it when there is no session window.
- The status-bar mini gauge falls back to the first available window instead of disappearing.
- The inactive-account snapshot cache in `RateLimitsService` no longer requires a session window to keep a snapshot.

### Evidence

Live `account/rateLimits/read` response from a Pro-plan account (Codex CLI 0.14x):

```json
"primary": { "usedPercent": 72, "windowDurationMins": 10080, "resetsAt": 1784503944 },
"secondary": null
```

`windowDurationMins: 10080` is exactly 7 days and `resetsAt` matches the dashboard's weekly reset. In current `openai/codex`, `window_minutes_from_seconds` in `codex-rs/backend-client/src/client.rs` propagates the backend's `limit_window_seconds` (the actual bucket duration) into this field. The remaining-minutes behavior of older CLIs is documented by Orca's own #2107, which recorded values like 299/10079 — that regression case is kept as a test.

## Screenshots

Before: status bar shows `76% used 5h`, popup shows "Session · Resets in 5d 23h" for what is actually the weekly limit.
<img width="306" height="390" alt="SCR-20260714-iwhl" src="https://github.com/user-attachments/assets/3a781a0d-09f2-4e2a-ab16-231dfd79332e" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (10 pre-existing environment-dependent failures — git pathspec/relay/ssh/pty suites — fail identically on `main`; all rate-limits and status-bar suites pass)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions
  - RPC: weekly-duration primary with null secondary → weekly slot (new)
  - RPC: old-CLI remaining-minutes windows (299/10079) keep session/weekly slots (existing, unchanged)
  - Backend: `limit_window_seconds: 604800` primary → weekly slot (new)
  - Backend: 1h/1d windows keep position-based slots (existing, unchanged)
  - PTY: weekly-only output keeps the reset text on the weekly window (new)
- [x] End-to-end: ran the modified fetcher against the real local Codex CLI; a live Pro account now returns `session: null` and a correctly labeled weekly window.

## AI Review Report

Ran a multi-angle review (line-by-line diff scan, removed-behavior audit, cross-file consumer trace, reuse/simplification/efficiency/altitude/conventions) with per-finding verification:

- **Cross-file trace**: audited every consumer of `ProviderRateLimits.session` (tooltip `getWindowSections`, `InlineUsageBars`, feature-wall usage tracking, `status-bar-provider-visibility`, `RateLimitsService` caching). All handle a null session with a present weekly via optional chaining; the two sites that assumed a session window (status-bar MiniBar, inactive-account cache gate) are fixed in this PR.
- **Flagged and fixed**: duplicated classification policy across RPC/backend paths (unified into one generic helper); PTY fallback dropping reset text for weekly-only plans (fixed + test).
- **Known residual edge (documented, not fixable with available data)**: on older CLIs that report remaining minutes, a weekly-only plan inside the final 24h of its window is indistinguishable from a 5h session window and falls back to the session slot. Before this PR that case was mislabeled 100% of the time; now only in that final-day window on outdated CLIs.
- **Cross-platform**: no shortcuts, labels, or path handling changed. The WSL backend path and the win32 RPC/PTY spawn paths are untouched apart from the slot assignment; classification logic is platform-independent. SSH/relay code paths do not consume these slots differently.

## Security Audit

- No new input surfaces: the change reinterprets fields already parsed from the Codex app-server RPC and the `chatgpt.com/backend-api/wham/usage` response; both were already trusted/validated by the existing guards (`plan_type` check, `Number.isFinite` window validation).
- No changes to command execution, spawn arguments, env handling, auth/token reading, or IPC contracts.
- `RpcRateLimitsResult` was widened to accept explicit JSON `null` windows (matching the live payload), which strictly tightens type accuracy; runtime null handling already existed.

## Notes

- If Codex reintroduces the 5h session bucket (the current removal appears to be temporary), the classifier automatically returns to the two-row session + weekly display with no further changes.
- Model-scoped limits (`rateLimitsByLimitId`, e.g. GPT-5.3-Codex-Spark) are still not surfaced; that needs UI-type changes and is left for a follow-up.
