### PR TITLE
Resolve terminal tab activity via the canonical worktree-status engine

### DIFF
--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -100,6 +100,7 @@ export default function SortableTab({
     resolveTerminalTabActivityStatus({
       tab,
       agentStatusByPaneKey: s.agentStatusByPaneKey,
+      agentStatusEpoch: s.agentStatusEpoch,
       runtimePaneTitlesByTabId: s.runtimePaneTitlesByTabId,
       ptyIdsByTabId: s.ptyIdsByTabId,
       terminalLayout: s.terminalLayoutsByTabId?.[tab.id]

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
@@ -108,6 +108,33 @@ describe('resolveTerminalTabActivityStatus', () => {
     ).toBe('working')
   })
 
+  it('de-spins a stale working tab on an epoch bump without a new map reference', () => {
+    // Why: the freshness scheduler bumps agentStatusEpoch (not the map ref) at
+    // the 30m stale boundary. The flag cache must invalidate on that bump, or an
+    // abandoned tab keeps spinning while the sidebar (epoch-keyed) de-spins.
+    const working = entry(FIRST_LEAF_ID, 'working')
+    const agentStatusByPaneKey = { [working.paneKey]: working }
+    expect(
+      resolveTerminalTabActivityStatus({
+        tab: TAB,
+        agentStatusByPaneKey,
+        agentStatusEpoch: 0,
+        ptyIdsByTabId: LIVE_PTY
+      })
+    ).toBe('working')
+
+    vi.setSystemTime(31 * 60 * 1000)
+    // Same map reference, bumped epoch — the entry is now stale.
+    expect(
+      resolveTerminalTabActivityStatus({
+        tab: TAB,
+        agentStatusByPaneKey,
+        agentStatusEpoch: 1,
+        ptyIdsByTabId: LIVE_PTY
+      })
+    ).toBe('active')
+  })
+
   it('does not treat a preserved title on a sleeping tab as activity', () => {
     expect(
       resolveTerminalTabActivityStatus({

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -25,6 +25,7 @@ type TerminalTabActivityFlags = {
 
 type FlagsCache = {
   agentStatusByPaneKey: Record<string, AgentStatusEntry> | undefined
+  agentStatusEpoch: number | undefined
   flagsByTabId: Map<string, TerminalTabActivityFlags>
 }
 
@@ -35,9 +36,19 @@ type FlagsCache = {
 let flagsCache: FlagsCache | null = null
 
 function getTerminalTabActivityFlags(
-  agentStatusByPaneKey: Record<string, AgentStatusEntry> | undefined
+  agentStatusByPaneKey: Record<string, AgentStatusEntry> | undefined,
+  agentStatusEpoch: number | undefined
 ): Map<string, TerminalTabActivityFlags> {
-  if (flagsCache && flagsCache.agentStatusByPaneKey === agentStatusByPaneKey) {
+  // Why: freshness is time-based, so the store bumps agentStatusEpoch without
+  // replacing the map at the 30m stale boundary (createFreshnessScheduler).
+  // Keying on the map reference alone would keep serving flags computed at the
+  // old `now`, spinning an abandoned tab forever while the sidebar — which keys
+  // on agentStatusEpoch — correctly de-spins. Invalidate on either changing.
+  if (
+    flagsCache &&
+    flagsCache.agentStatusByPaneKey === agentStatusByPaneKey &&
+    flagsCache.agentStatusEpoch === agentStatusEpoch
+  ) {
     return flagsCache.flagsByTabId
   }
 
@@ -74,7 +85,7 @@ function getTerminalTabActivityFlags(
     }
   }
 
-  flagsCache = { agentStatusByPaneKey, flagsByTabId }
+  flagsCache = { agentStatusByPaneKey, agentStatusEpoch, flagsByTabId }
   return flagsByTabId
 }
 
@@ -95,6 +106,9 @@ const EMPTY_PANE_IDS: ReadonlySet<string> = new Set()
 type TerminalTabActivityInput = {
   tab: Pick<TerminalTab, 'id' | 'title'>
   agentStatusByPaneKey?: Record<string, AgentStatusEntry>
+  // Why: the store bumps this at the 30m stale boundary without replacing the
+  // pane-status map; it is the flag cache's invalidation key (see above).
+  agentStatusEpoch?: number
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayout?: TerminalLayoutSnapshot
@@ -109,11 +123,12 @@ type TerminalTabActivityInput = {
 export function resolveTerminalTabActivityStatus({
   tab,
   agentStatusByPaneKey,
+  agentStatusEpoch,
   runtimePaneTitlesByTabId,
   ptyIdsByTabId,
   terminalLayout
 }: TerminalTabActivityInput): TerminalTabActivityStatus {
-  const flags = getTerminalTabActivityFlags(agentStatusByPaneKey).get(tab.id)
+  const flags = getTerminalTabActivityFlags(agentStatusByPaneKey, agentStatusEpoch).get(tab.id)
   return resolveWorktreeStatus({
     tabs: [tab],
     browserTabs: [],


### PR DESCRIPTION
## Summary
This follow-up refactors the terminal tab activity resolver to reuse the canonical `resolveWorktreeStatus` engine from the sidebar, eliminating a fourth parallel copy of the pane-iteration/freshness/title-heuristic loop and its divergences (novel blocked>waiting split, phantom 'interrupted' state).

Terminal tabs now speak the same WorktreeStatus vocabulary as the sidebar card, ensuring live states never disagree.

### Changes
- Replace hand-rolled `resolveTerminalTabAgentActivityState` with `resolveTerminalTabActivityStatus` 
- Map WorktreeStatus → AgentStateDot: working=spinner, permission=amber, done=check
- Parse legacy numeric pane keys for restored/imported sessions
- Fix activity-status cache invalidation on freshness updates (O(tabs+agents) instead of O(tabs*agents))

## Test plan
- [ ] Terminal tabs display activity state correctly
- [ ] Live state matches sidebar worktree card
- [ ] Cache invalidates properly on 30m stale boundary

Made with [Orca](https://github.com/stablyai/orca) 🐋
