### PR TITLE
fix(mobile): host Create Workspace drawers in one Modal so dropdowns open

### DIFF
--- a/mobile/src/components/BottomDrawer.tsx
+++ b/mobile/src/components/BottomDrawer.tsx
@@ -24,6 +24,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import { colors, spacing } from '../theme/mobile-theme'
 import { resolveBottomDrawerMounted } from './bottom-drawer-mount-state'
+import { useInsideBottomDrawerModalHost } from './bottom-drawer-modal-host'
 import { useResponsiveLayout } from '../layout/responsive-layout'
 
 const DISMISS_THRESHOLD = 80
@@ -107,6 +108,7 @@ function MountedBottomDrawer({
   // center it horizontally. Vertical bottom-anchoring (and all the drag/keyboard
   // transforms below) is unchanged, so phone behavior stays identical.
   const { isWideLayout, modalMaxWidth } = useResponsiveLayout()
+  const insideModalHost = useInsideBottomDrawerModalHost()
 
   useEffect(() => {
     if (visible) {
@@ -265,104 +267,114 @@ function MountedBottomDrawer({
     return { opacity: progress.value * dragFade }
   })
 
-  // Why: rendering through a full-screen Modal lifts the sheet into its own
-  // native window so it always covers the viewport — even when the drawer is
-  // mounted deep inside a ScrollView, where a plain absolute overlay anchors to
-  // the scrolled content and clips the sheet. The Modal stays mounted (visible)
-  // for the whole life of MountedBottomDrawer so the reanimated exit animation
-  // runs before the parent unmounts us; show/hide is driven by `progress`, so
-  // animationType stays "none". onRequestClose handles the Android back button.
+  // Why: the sheet renders through a full-screen native window (its own Modal
+  // below, or the shared BottomDrawerModalHost) so it always covers the viewport
+  // — even when mounted deep inside a ScrollView, where a plain absolute overlay
+  // anchors to the scrolled content and clips the sheet. Show/hide is driven by
+  // `progress` (animationType "none") so the reanimated exit animation runs before
+  // the parent unmounts us.
+  const overlay = (
+    <Animated.View
+      pointerEvents={visible ? 'auto' : 'none'}
+      style={[styles.overlay, { zIndex, elevation: zIndex }]}
+      accessibilityViewIsModal
+      aria-modal
+    >
+      <GestureHandlerRootView style={styles.root}>
+        <Animated.View style={[styles.backdrop, backdropStyle]}>
+          <Pressable style={StyleSheet.absoluteFill} onPress={dismiss} />
+        </Animated.View>
+
+        <View style={[styles.anchor, isWideLayout && styles.anchorWide]} pointerEvents="box-none">
+          <Animated.View
+            style={[
+              styles.drawer,
+              {
+                width: '100%',
+                maxWidth: isWideLayout ? modalMaxWidth : undefined,
+                maxHeight: screenHeight - insets.top - spacing.lg,
+                paddingBottom: insets.bottom + spacing.lg
+              },
+              drawerStyle
+            ]}
+          >
+            {!contentScrollable ? (
+              <>
+                <GestureDetector gesture={handlePanGesture}>
+                  <Animated.View
+                    style={styles.handleHitArea}
+                    accessibilityRole="button"
+                    accessibilityLabel="Dismiss drawer"
+                  >
+                    <View style={styles.handle} />
+                  </Animated.View>
+                </GestureDetector>
+                <View style={styles.staticContent}>{children}</View>
+              </>
+            ) : dragContentToDismiss ? (
+              <>
+                <GestureDetector gesture={handlePanGesture}>
+                  <Animated.View
+                    style={styles.handleHitArea}
+                    accessibilityRole="button"
+                    accessibilityLabel="Dismiss drawer"
+                  >
+                    <View style={styles.handle} />
+                  </Animated.View>
+                </GestureDetector>
+                <GestureDetector gesture={contentPanGesture}>
+                  <Animated.View collapsable={false}>
+                    <GestureDetector gesture={scrollGesture}>
+                      <Animated.ScrollView
+                        bounces={false}
+                        keyboardShouldPersistTaps="handled"
+                        onScroll={scrollHandler}
+                        scrollEventThrottle={16}
+                        showsVerticalScrollIndicator={false}
+                      >
+                        {children}
+                      </Animated.ScrollView>
+                    </GestureDetector>
+                  </Animated.View>
+                </GestureDetector>
+              </>
+            ) : (
+              <>
+                <GestureDetector gesture={handlePanGesture}>
+                  <Animated.View
+                    style={styles.handleHitArea}
+                    accessibilityRole="button"
+                    accessibilityLabel="Dismiss drawer"
+                  >
+                    <View style={styles.handle} />
+                  </Animated.View>
+                </GestureDetector>
+                <ScrollView
+                  bounces={false}
+                  keyboardShouldPersistTaps="handled"
+                  showsVerticalScrollIndicator={false}
+                >
+                  {children}
+                </ScrollView>
+              </>
+            )}
+            <View style={styles.bottomExtension} />
+          </Animated.View>
+        </View>
+      </GestureHandlerRootView>
+    </Animated.View>
+  )
+
+  // Why: inside a BottomDrawerModalHost the host owns the single native Modal;
+  // rendering our own would stack modals and reintroduce the iOS present/dismiss
+  // race the host exists to avoid. The host handles the Android back button.
+  if (insideModalHost) {
+    return overlay
+  }
+
   return (
     <Modal visible transparent animationType="none" statusBarTranslucent onRequestClose={dismiss}>
-      <Animated.View
-        pointerEvents={visible ? 'auto' : 'none'}
-        style={[styles.overlay, { zIndex, elevation: zIndex }]}
-        accessibilityViewIsModal
-        aria-modal
-      >
-        <GestureHandlerRootView style={styles.root}>
-          <Animated.View style={[styles.backdrop, backdropStyle]}>
-            <Pressable style={StyleSheet.absoluteFill} onPress={dismiss} />
-          </Animated.View>
-
-          <View style={[styles.anchor, isWideLayout && styles.anchorWide]} pointerEvents="box-none">
-            <Animated.View
-              style={[
-                styles.drawer,
-                {
-                  width: '100%',
-                  maxWidth: isWideLayout ? modalMaxWidth : undefined,
-                  maxHeight: screenHeight - insets.top - spacing.lg,
-                  paddingBottom: insets.bottom + spacing.lg
-                },
-                drawerStyle
-              ]}
-            >
-              {!contentScrollable ? (
-                <>
-                  <GestureDetector gesture={handlePanGesture}>
-                    <Animated.View
-                      style={styles.handleHitArea}
-                      accessibilityRole="button"
-                      accessibilityLabel="Dismiss drawer"
-                    >
-                      <View style={styles.handle} />
-                    </Animated.View>
-                  </GestureDetector>
-                  <View style={styles.staticContent}>{children}</View>
-                </>
-              ) : dragContentToDismiss ? (
-                <>
-                  <GestureDetector gesture={handlePanGesture}>
-                    <Animated.View
-                      style={styles.handleHitArea}
-                      accessibilityRole="button"
-                      accessibilityLabel="Dismiss drawer"
-                    >
-                      <View style={styles.handle} />
-                    </Animated.View>
-                  </GestureDetector>
-                  <GestureDetector gesture={contentPanGesture}>
-                    <Animated.View collapsable={false}>
-                      <GestureDetector gesture={scrollGesture}>
-                        <Animated.ScrollView
-                          bounces={false}
-                          keyboardShouldPersistTaps="handled"
-                          onScroll={scrollHandler}
-                          scrollEventThrottle={16}
-                          showsVerticalScrollIndicator={false}
-                        >
-                          {children}
-                        </Animated.ScrollView>
-                      </GestureDetector>
-                    </Animated.View>
-                  </GestureDetector>
-                </>
-              ) : (
-                <>
-                  <GestureDetector gesture={handlePanGesture}>
-                    <Animated.View
-                      style={styles.handleHitArea}
-                      accessibilityRole="button"
-                      accessibilityLabel="Dismiss drawer"
-                    >
-                      <View style={styles.handle} />
-                    </Animated.View>
-                  </GestureDetector>
-                  <ScrollView
-                    bounces={false}
-                    keyboardShouldPersistTaps="handled"
-                    showsVerticalScrollIndicator={false}
-                  >
-                    {children}
-                  </ScrollView>
-                </>
-              )}
-              <View style={styles.bottomExtension} />
-            </Animated.View>
-          </View>
-        </GestureHandlerRootView>
-      </Animated.View>
+      {overlay}
     </Modal>
   )
 }

--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -15,6 +15,7 @@ import type { RpcClient } from '../transport/rpc-client'
 import type { RpcResponse, RpcSuccess } from '../transport/types'
 import { colors, spacing, radii, typography } from '../theme/mobile-theme'
 import { BottomDrawer, BOTTOM_DRAWER_HIDE_DURATION_MS } from './BottomDrawer'
+import { BottomDrawerModalHost } from './bottom-drawer-modal-host'
 import { PickerListDrawer } from './PickerListDrawer'
 import { MobileAgentIcon } from './MobileAgentIcon'
 import { getSuggestedCreatureName } from './worktree-name-suggestion'
@@ -814,7 +815,20 @@ function NewWorktreeModalContent({
   }
 
   return (
-    <>
+    // Why: hosting the form and every picker in one persistent native Modal makes
+    // form → repo/agent transitions in-window view swaps, avoiding the iOS
+    // dismiss-then-present race that left the dropdowns unresponsive. Back routes
+    // to the form from a picker, or closes the flow from the form.
+    <BottomDrawerModalHost
+      visible={visible}
+      onRequestClose={() => {
+        if (drawerView === 'form') {
+          onClose()
+        } else {
+          transitionDrawer('form')
+        }
+      }}
+    >
       <BottomDrawer visible={visible && drawerView === 'form'} onClose={onClose}>
         <View style={styles.header}>
           <Text style={styles.title}>Create Workspace</Text>
@@ -1088,7 +1102,7 @@ function NewWorktreeModalContent({
         onDontRun={skipSetupTrust}
         onClose={closeSetupTrust}
       />
-    </>
+    </BottomDrawerModalHost>
   )
 }
 

--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -817,13 +817,16 @@ function NewWorktreeModalContent({
   return (
     // Why: hosting the form and every picker in one persistent native Modal makes
     // form → repo/agent transitions in-window view swaps, avoiding the iOS
-    // dismiss-then-present race that left the dropdowns unresponsive. Back routes
-    // to the form from a picker, or closes the flow from the form.
+    // dismiss-then-present race that left the dropdowns unresponsive. Native back
+    // closes the flow from the form, routes the trust prompt through its in-flight
+    // guard, and otherwise returns to the form from a picker.
     <BottomDrawerModalHost
       visible={visible}
       onRequestClose={() => {
         if (drawerView === 'form') {
           onClose()
+        } else if (drawerView === 'trust') {
+          closeSetupTrust()
         } else {
           transitionDrawer('form')
         }
@@ -1050,7 +1053,7 @@ function NewWorktreeModalContent({
       </BottomDrawer>
 
       {/* Why: list drawers stay outside the form's ScrollView, and the transition
-          state prevents overlapping native modals from swallowing iOS taps. */}
+          state lets each hosted overlay finish hiding before the next appears. */}
       <SmartWorkspaceSourceDrawer
         visible={visible && drawerView === 'source'}
         client={client}

--- a/mobile/src/components/bottom-drawer-modal-host.tsx
+++ b/mobile/src/components/bottom-drawer-modal-host.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import { Modal } from 'react-native'
+
+const BottomDrawerModalHostContext = createContext(false)
+
+/** True when a BottomDrawer is rendered inside a shared BottomDrawerModalHost and
+ *  must therefore skip its own native Modal (the host owns the single Modal). */
+export function useInsideBottomDrawerModalHost(): boolean {
+  return useContext(BottomDrawerModalHostContext)
+}
+
+type Props = {
+  visible: boolean
+  onRequestClose: () => void
+  children: ReactNode
+}
+
+// Why: iOS cannot reliably dismiss one native modal and present another in the same
+// beat. Flows that swap between sibling drawer modals (e.g. the Create Workspace form
+// → its repository/agent pickers) dropped the incoming modal, leaving the sheet dead
+// to taps. Hosting every drawer in ONE persistent native Modal makes those swaps
+// in-window view changes instead, so no present/dismiss race can eat the transition.
+export function BottomDrawerModalHost({ visible, onRequestClose, children }: Props) {
+  if (!visible) {
+    return null
+  }
+  return (
+    <Modal
+      visible
+      transparent
+      animationType="none"
+      statusBarTranslucent
+      onRequestClose={onRequestClose}
+    >
+      <BottomDrawerModalHostContext.Provider value={true}>
+        {children}
+      </BottomDrawerModalHostContext.Provider>
+    </Modal>
+  )
+}


### PR DESCRIPTION
## Problem

On mobile, the **Repository** and **Agent** dropdown selectors in the "Create Workspace" sheet don't respond to taps — nothing opens. On a real device it fails every time; reported by a user and reproduced on the iOS simulator (where it was intermittent).

## Root cause

The Create Workspace form and each of its pickers (repository, agent, source, trust) are all rendered through `BottomDrawer`, and since #8236 each `BottomDrawer` renders its **own native `<Modal>`**. Opening a dropdown runs form → transition → picker:

- the form's Modal is dismissed (`BOTTOM_DRAWER_HIDE_DURATION_MS` = 150ms), and
- the picker's Modal is presented ~166ms later (`NEW_WORKTREE_DRAWER_TRANSITION_MS`, only a 16ms margin).

iOS cannot present one native modal while another is being dismissed, so the incoming picker Modal is dropped and the form collapses — the dropdown appears dead. The existing comment at `NewWorktreeModal.tsx` even warned about "overlapping native modals swallowing iOS taps"; the timing guard was simply too thin for real hardware.

## Fix

Host the entire flow in **one persistent native Modal** instead of swapping between sibling modals:

- **`bottom-drawer-modal-host.tsx`** (new) — a React context + `BottomDrawerModalHost` that renders a single native `<Modal>` and marks its subtree as hosted.
- **`BottomDrawer.tsx`** — when it detects it is inside a host, it renders its sheet **without** its own `<Modal>` (the host owns the one Modal). Standalone behavior is unchanged.
- **`NewWorktreeModal.tsx`** — wraps the form + all pickers in `BottomDrawerModalHost`. Form → repo/agent is now an **in-window view swap** with no native present/dismiss, so the race can't happen. Back routes to the form from a picker, or closes the flow from the form.

The change is additive and backward-compatible: the context defaults to off, so every `BottomDrawer` elsewhere in the app keeps its own Modal, and `PickerListDrawer` / `SmartWorkspaceSourceDrawer` / `SetupHookTrustDrawer` need no changes (the context propagates through them).

## Verification

- `oxlint` / `oxfmt` clean (pre-commit hook).
- Deterministic render probe (`react-dom/server` with lightweight RN mocks): a standalone drawer renders exactly **1** Modal; inside the host there is **1** Modal total (the drawer adds none) and its content still renders — confirming the swap-race is eliminated with no change for other consumers.
- Note: this environment can't run `tsc`/`vitest` (pre-existing unresolved `expo/tsconfig.base.json` fails config-parse for every file); CI runs them.

## Test plan

- [ ] On device/sim: open Create Workspace → tap **Repository** → picker opens; pick a repo → returns to form.
- [ ] Tap **Agent** → picker opens; pick an agent → returns to form.
- [ ] Back button from a picker returns to the form; back from the form closes the sheet.
- [ ] Other bottom drawers across the app (diff review, PR compose, action sheets, etc.) still open/close normally.