### PR TITLE
fix(mobile): re-fit terminal PTY when the frame height settles

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1080,16 +1080,13 @@ export default function SessionScreen() {
   // the row) without any window-dim change. Tracking the measured width lets the
   // refit hook re-fit the PTY on those resizes — see terminal-viewport-refit.ts.
   const [terminalFrameWidth, setTerminalFrameWidth] = useState(0)
-  // Why: a freshly-created agent terminal's first fit can run before the
-  // accessory/live-input dock has laid out, so the frame is briefly taller and
-  // the PTY is fit to too many rows. When the dock settles the frame shrinks,
-  // but height-only changes used to be ignored, so the PTY kept the taller row
-  // count and an agent TUI's bottom-pinned input box rendered behind the dock
-  // (leaving and re-entering re-measured and fixed it). Track the measured
-  // height so the refit hook re-fits on that settle. Keyboard open/close does
-  // not change this height (edge-to-edge IME overlays instead of resizing — see
-  // keyboardHeight above), so this never reflows the PTY while typing.
+  // Why: a new agent terminal can fit before the accessory/live-input dock lays
+  // out, over-fitting the PTY so its bottom-pinned input box hides behind the
+  // dock; tracking the settled height lets the refit hook correct it.
   const [terminalFrameHeight, setTerminalFrameHeight] = useState(0)
+  // Why: lets the height refit skip keyboard-driven resizes (never reflow the
+  // PTY per keystroke); mirrors keyboardHeight but readable synchronously.
+  const keyboardVisibleRef = useRef(false)
 
   const activeSessionTab = sessionTabs.find((tab) => tab.id === activeSessionTabId) ?? null
   const {
@@ -2613,15 +2610,18 @@ export default function SessionScreen() {
     textScale: terminalTextScale,
     terminalFrameWidth,
     terminalFrameHeight,
+    keyboardVisibleRef,
     unsubscribeTerminal,
     subscribeToTerminal
   })
 
   useEffect(() => {
     const onShow = (e: KeyboardEvent) => {
+      keyboardVisibleRef.current = true
       setKeyboardHeight(e.endCoordinates?.height ?? 0)
     }
     const onHide = () => {
+      keyboardVisibleRef.current = false
       setKeyboardHeight(0)
     }
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow'
@@ -4842,12 +4842,8 @@ export default function SessionScreen() {
                 style={styles.terminalFrame}
                 onLayout={(e) => {
                   terminalFrameHeightRef.current = e.nativeEvent.layout.height
-                  // Re-fit on width OR height changes. Width changes on sidebar
-                  // resize/fold/rotation; height changes when the accessory/
-                  // live-input dock settles after a new agent terminal's first
-                  // fit — refitting then stops the PTY from staying over-tall and
-                  // hiding the agent's bottom-pinned input box behind the dock.
-                  // The refit's row-count guard makes sub-row jitter a no-op.
+                  // Track width AND height so the refit hook re-fits on sidebar/
+                  // fold/rotation (width) and on the dock settling (height).
                   const nextWidth = Math.round(e.nativeEvent.layout.width)
                   const nextHeight = Math.round(e.nativeEvent.layout.height)
                   setTerminalFrameWidth((prev) => (prev === nextWidth ? prev : nextWidth))

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1080,6 +1080,16 @@ export default function SessionScreen() {
   // the row) without any window-dim change. Tracking the measured width lets the
   // refit hook re-fit the PTY on those resizes — see terminal-viewport-refit.ts.
   const [terminalFrameWidth, setTerminalFrameWidth] = useState(0)
+  // Why: a freshly-created agent terminal's first fit can run before the
+  // accessory/live-input dock has laid out, so the frame is briefly taller and
+  // the PTY is fit to too many rows. When the dock settles the frame shrinks,
+  // but height-only changes used to be ignored, so the PTY kept the taller row
+  // count and an agent TUI's bottom-pinned input box rendered behind the dock
+  // (leaving and re-entering re-measured and fixed it). Track the measured
+  // height so the refit hook re-fits on that settle. Keyboard open/close does
+  // not change this height (edge-to-edge IME overlays instead of resizing — see
+  // keyboardHeight above), so this never reflows the PTY while typing.
+  const [terminalFrameHeight, setTerminalFrameHeight] = useState(0)
 
   const activeSessionTab = sessionTabs.find((tab) => tab.id === activeSessionTabId) ?? null
   const {
@@ -2602,6 +2612,7 @@ export default function SessionScreen() {
     tabStripVisible: terminals.length > 1,
     textScale: terminalTextScale,
     terminalFrameWidth,
+    terminalFrameHeight,
     unsubscribeTerminal,
     subscribeToTerminal
   })
@@ -4831,10 +4842,16 @@ export default function SessionScreen() {
                 style={styles.terminalFrame}
                 onLayout={(e) => {
                   terminalFrameHeightRef.current = e.nativeEvent.layout.height
-                  // Trigger a refit only when the width actually changes (sidebar
-                  // resize, fold, rotation) — avoids churn on height-only changes.
+                  // Re-fit on width OR height changes. Width changes on sidebar
+                  // resize/fold/rotation; height changes when the accessory/
+                  // live-input dock settles after a new agent terminal's first
+                  // fit — refitting then stops the PTY from staying over-tall and
+                  // hiding the agent's bottom-pinned input box behind the dock.
+                  // The refit's row-count guard makes sub-row jitter a no-op.
                   const nextWidth = Math.round(e.nativeEvent.layout.width)
+                  const nextHeight = Math.round(e.nativeEvent.layout.height)
                   setTerminalFrameWidth((prev) => (prev === nextWidth ? prev : nextWidth))
+                  setTerminalFrameHeight((prev) => (prev === nextHeight ? prev : nextHeight))
                 }}
               >
                 {terminals.map((terminal) => (

--- a/mobile/src/terminal/terminal-viewport-refit-state.ts
+++ b/mobile/src/terminal/terminal-viewport-refit-state.ts
@@ -24,6 +24,20 @@ export function isTerminalUpdateViewportApplied(response: RpcResponse): boolean 
   return (response.result as { applied?: unknown }).applied === true
 }
 
+// Why: re-fit when the flex-bounded frame height settles, but never while the
+// keyboard is visible so an IME window resize (Android adjustResize) can't
+// reflow the PTY per keystroke — it re-fits again once the keyboard closes.
+export function shouldRefitOnFrameHeightChange(state: {
+  previousHeight: number
+  nextHeight: number
+  keyboardVisible: boolean
+}): boolean {
+  if (state.keyboardVisible) {
+    return false
+  }
+  return state.previousHeight !== state.nextHeight
+}
+
 export function isTerminalViewportRefitTargetCurrent(
   state: TerminalViewportRefitTargetState
 ): boolean {

--- a/mobile/src/terminal/terminal-viewport-refit.test.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.test.ts
@@ -48,11 +48,36 @@ describe('terminal viewport refit', () => {
     expect(textScaleEffect).toContain('[textScale, viewportMeasuredRef, scheduleViewportRefit]')
   })
 
+  it('refits when the terminal frame height settles after the first fit', () => {
+    // Why: a freshly-created agent terminal can fit before the accessory/
+    // live-input dock lays out, so the PTY is over-fit and the agent's
+    // bottom-pinned input box renders behind the dock. When the dock settles
+    // the frame height shrinks; refitting then restores the correct row count
+    // (the fix for the "leave and re-enter fixes it" symptom). Keyboard toggles
+    // do not change this height (edge-to-edge IME overlay), so it never reflows
+    // the PTY while typing.
+    const start = hookSource.indexOf('const prevFrameHeightRef = useRef(terminalFrameHeight)')
+    expect(start).toBeGreaterThanOrEqual(0)
+    const heightEffect = hookSource.slice(start, start + 400)
+    expect(heightEffect).toContain('prevFrameHeightRef.current === terminalFrameHeight')
+    expect(heightEffect).toContain('viewportMeasuredRef.current = false')
+    expect(heightEffect).toContain('scheduleViewportRefit()')
+    expect(heightEffect).toContain(
+      '[terminalFrameHeight, viewportMeasuredRef, scheduleViewportRefit]'
+    )
+  })
+
   it('is wired into the session screen', () => {
     expect(sessionSource).toContain('useTerminalViewportRefit({')
     expect(sessionSource).toContain('tabStripVisible: terminals.length > 1')
     expect(sessionSource).toContain('textScale: terminalTextScale')
     expect(sessionSource).toContain('connState,')
+    // The session must measure and feed the frame height, or the height effect
+    // never sees the dock settle. Both the hook prop and the onLayout setter.
+    expect(sessionSource).toContain('terminalFrameHeight,')
+    expect(sessionSource).toContain(
+      'setTerminalFrameHeight((prev) => (prev === nextHeight ? prev : nextHeight))'
+    )
   })
 
   it('forces a refit on iOS foreground and connection recovery', () => {

--- a/mobile/src/terminal/terminal-viewport-refit.test.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.test.ts
@@ -4,7 +4,8 @@ import type { RpcResponse } from '../transport/types'
 import {
   isTerminalUpdateViewportApplied,
   isTerminalUpdateViewportUpdated,
-  isTerminalViewportRefitTargetCurrent
+  isTerminalViewportRefitTargetCurrent,
+  shouldRefitOnFrameHeightChange
 } from './terminal-viewport-refit-state'
 
 const hookSource = readFileSync(new URL('./terminal-viewport-refit.ts', import.meta.url), 'utf8')
@@ -48,23 +49,44 @@ describe('terminal viewport refit', () => {
     expect(textScaleEffect).toContain('[textScale, viewportMeasuredRef, scheduleViewportRefit]')
   })
 
-  it('refits when the terminal frame height settles after the first fit', () => {
-    // Why: a freshly-created agent terminal can fit before the accessory/
-    // live-input dock lays out, so the PTY is over-fit and the agent's
-    // bottom-pinned input box renders behind the dock. When the dock settles
-    // the frame height shrinks; refitting then restores the correct row count
-    // (the fix for the "leave and re-enter fixes it" symptom). Keyboard toggles
-    // do not change this height (edge-to-edge IME overlay), so it never reflows
-    // the PTY while typing.
+  it('refits on a frame-height change only while the keyboard is closed', () => {
+    // The dock settling after a new agent terminal's first fit changes the frame
+    // height; refitting then stops the PTY over-fitting behind the dock. An IME
+    // that resizes the window (Android) must not reflow the PTY while typing.
+    // Height settled, keyboard closed → refit.
+    expect(
+      shouldRefitOnFrameHeightChange({
+        previousHeight: 600,
+        nextHeight: 520,
+        keyboardVisible: false
+      })
+    ).toBe(true)
+    // Unchanged height → no refit (don't churn on unrelated re-layouts).
+    expect(
+      shouldRefitOnFrameHeightChange({
+        previousHeight: 520,
+        nextHeight: 520,
+        keyboardVisible: false
+      })
+    ).toBe(false)
+    // Height changed while the keyboard is up → skip (never reflow while typing).
+    expect(
+      shouldRefitOnFrameHeightChange({
+        previousHeight: 600,
+        nextHeight: 320,
+        keyboardVisible: true
+      })
+    ).toBe(false)
+  })
+
+  it('routes the height effect through the keyboard-guarded decision helper', () => {
     const start = hookSource.indexOf('const prevFrameHeightRef = useRef(terminalFrameHeight)')
     expect(start).toBeGreaterThanOrEqual(0)
-    const heightEffect = hookSource.slice(start, start + 400)
-    expect(heightEffect).toContain('prevFrameHeightRef.current === terminalFrameHeight')
+    const heightEffect = hookSource.slice(start, start + 500)
+    expect(heightEffect).toContain('shouldRefitOnFrameHeightChange({')
+    expect(heightEffect).toContain('keyboardVisible: keyboardVisibleRef.current')
     expect(heightEffect).toContain('viewportMeasuredRef.current = false')
     expect(heightEffect).toContain('scheduleViewportRefit()')
-    expect(heightEffect).toContain(
-      '[terminalFrameHeight, viewportMeasuredRef, scheduleViewportRefit]'
-    )
   })
 
   it('is wired into the session screen', () => {
@@ -72,9 +94,11 @@ describe('terminal viewport refit', () => {
     expect(sessionSource).toContain('tabStripVisible: terminals.length > 1')
     expect(sessionSource).toContain('textScale: terminalTextScale')
     expect(sessionSource).toContain('connState,')
-    // The session must measure and feed the frame height, or the height effect
-    // never sees the dock settle. Both the hook prop and the onLayout setter.
+    // The session must feed the frame height and the keyboard-visible ref, or the
+    // guarded height effect never sees the dock settle / keyboard state.
     expect(sessionSource).toContain('terminalFrameHeight,')
+    expect(sessionSource).toContain('keyboardVisibleRef,')
+    expect(sessionSource).toContain('keyboardVisibleRef.current = true')
     expect(sessionSource).toContain(
       'setTerminalFrameHeight((prev) => (prev === nextHeight ? prev : nextHeight))'
     )

--- a/mobile/src/terminal/terminal-viewport-refit.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.ts
@@ -7,7 +7,8 @@ import { shouldRecoverTerminalOnAppStateChange } from './terminal-foreground-rec
 import {
   isTerminalUpdateViewportApplied,
   isTerminalUpdateViewportUpdated,
-  isTerminalViewportRefitTargetCurrent
+  isTerminalViewportRefitTargetCurrent,
+  shouldRefitOnFrameHeightChange
 } from './terminal-viewport-refit-state'
 
 export type TerminalViewportDims = { cols: number; rows: number }
@@ -32,14 +33,12 @@ type TerminalViewportRefitOptions = {
   // tab-strip change. Carries that measured width so those resizes re-fit the PTY;
   // the 150ms debounce coalesces the stream of drag widths into one settle-time refit.
   terminalFrameWidth: number
-  // Why: the terminal's measured frame height shrinks when the accessory/
-  // live-input dock lays out after a freshly-created agent terminal's first
-  // fit. Carrying that measured height re-fits the PTY so it stops rendering
-  // more rows than fit above the dock (the agent's bottom-pinned input box
-  // would otherwise sit behind it). Keyboard open/close does not change this
-  // height — the edge-to-edge IME overlays instead of resizing — so this does
-  // not reflow the PTY while typing.
+  // Why: the frame height settles when the accessory/live-input dock lays out
+  // after a new agent terminal's first fit; carrying it re-fits the PTY so its
+  // rows stop overflowing behind the dock. See shouldRefitOnFrameHeightChange.
   terminalFrameHeight: number
+  // Why: gate the height refit so a keyboard-driven resize never reflows the PTY.
+  keyboardVisibleRef: RefObject<boolean>
   unsubscribeTerminal: (handle: string) => void
   subscribeToTerminal: (handle: string) => void
 }
@@ -65,6 +64,7 @@ export function useTerminalViewportRefit(options: TerminalViewportRefitOptions):
     textScale,
     terminalFrameWidth,
     terminalFrameHeight,
+    keyboardVisibleRef,
     unsubscribeTerminal,
     subscribeToTerminal
   } = options
@@ -235,21 +235,26 @@ export function useTerminalViewportRefit(options: TerminalViewportRefitOptions):
     scheduleViewportRefit()
   }, [terminalFrameWidth, viewportMeasuredRef, scheduleViewportRefit])
 
-  // Why: the measured frame height shrinks when the accessory/live-input dock
-  // lays out after a new agent terminal's first fit. Without re-fitting, the
-  // PTY keeps its taller row count and the agent's bottom-pinned input box
-  // renders behind the dock. Mark un-measured and re-fit; the refit's
-  // row-count guard makes a height change that doesn't change the row count a
-  // no-op, so settled/jitter layouts don't churn the server PTY.
+  // Why: re-fit when the frame height settles after a new agent terminal's
+  // first fit so its rows stop overflowing behind the dock; the keyboard guard
+  // keeps an IME resize from reflowing the PTY. The refit's row-count guard
+  // makes a same-row height change a no-op.
   const prevFrameHeightRef = useRef(terminalFrameHeight)
   useEffect(() => {
-    if (prevFrameHeightRef.current === terminalFrameHeight) {
+    const previousHeight = prevFrameHeightRef.current
+    prevFrameHeightRef.current = terminalFrameHeight
+    if (
+      !shouldRefitOnFrameHeightChange({
+        previousHeight,
+        nextHeight: terminalFrameHeight,
+        keyboardVisible: keyboardVisibleRef.current
+      })
+    ) {
       return
     }
-    prevFrameHeightRef.current = terminalFrameHeight
     viewportMeasuredRef.current = false
     scheduleViewportRefit()
-  }, [terminalFrameHeight, viewportMeasuredRef, scheduleViewportRefit])
+  }, [terminalFrameHeight, keyboardVisibleRef, viewportMeasuredRef, scheduleViewportRefit])
 
   useEffect(() => {
     if (Platform.OS !== 'ios') {

--- a/mobile/src/terminal/terminal-viewport-refit.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.ts
@@ -32,6 +32,14 @@ type TerminalViewportRefitOptions = {
   // tab-strip change. Carries that measured width so those resizes re-fit the PTY;
   // the 150ms debounce coalesces the stream of drag widths into one settle-time refit.
   terminalFrameWidth: number
+  // Why: the terminal's measured frame height shrinks when the accessory/
+  // live-input dock lays out after a freshly-created agent terminal's first
+  // fit. Carrying that measured height re-fits the PTY so it stops rendering
+  // more rows than fit above the dock (the agent's bottom-pinned input box
+  // would otherwise sit behind it). Keyboard open/close does not change this
+  // height — the edge-to-edge IME overlays instead of resizing — so this does
+  // not reflow the PTY while typing.
+  terminalFrameHeight: number
   unsubscribeTerminal: (handle: string) => void
   subscribeToTerminal: (handle: string) => void
 }
@@ -56,6 +64,7 @@ export function useTerminalViewportRefit(options: TerminalViewportRefitOptions):
     tabStripVisible,
     textScale,
     terminalFrameWidth,
+    terminalFrameHeight,
     unsubscribeTerminal,
     subscribeToTerminal
   } = options
@@ -225,6 +234,22 @@ export function useTerminalViewportRefit(options: TerminalViewportRefitOptions):
     viewportMeasuredRef.current = false
     scheduleViewportRefit()
   }, [terminalFrameWidth, viewportMeasuredRef, scheduleViewportRefit])
+
+  // Why: the measured frame height shrinks when the accessory/live-input dock
+  // lays out after a new agent terminal's first fit. Without re-fitting, the
+  // PTY keeps its taller row count and the agent's bottom-pinned input box
+  // renders behind the dock. Mark un-measured and re-fit; the refit's
+  // row-count guard makes a height change that doesn't change the row count a
+  // no-op, so settled/jitter layouts don't churn the server PTY.
+  const prevFrameHeightRef = useRef(terminalFrameHeight)
+  useEffect(() => {
+    if (prevFrameHeightRef.current === terminalFrameHeight) {
+      return
+    }
+    prevFrameHeightRef.current = terminalFrameHeight
+    viewportMeasuredRef.current = false
+    scheduleViewportRefit()
+  }, [terminalFrameHeight, viewportMeasuredRef, scheduleViewportRefit])
 
   useEffect(() => {
     if (Platform.OS !== 'ios') {


### PR DESCRIPTION
Ref #7350 — candidate fix. Could not reproduce in the emulator (timing-dependent), so this intentionally does **not** auto-close the issue: it needs confirmation on a real device / next TestFlight before closing.

## Problem

On mobile, starting a Claude/Codex agent in a terminal renders the agent's input box **behind the accessory / live-input bar** — you can't see what you're typing. Leaving and re-entering the workspace fixes it (temporarily).


## Root cause

The mobile terminal fits the PTY to `rows = floor(frameHeight / cellHeight)` with **no bottom margin** — by design the accessory/live-input dock sits *below* the terminal frame (`terminal-webview-html.ts`). But a **freshly-created agent terminal fits before that dock has laid out**, so the frame is briefly too tall and the PTY gets too many rows. Claude/Codex pin their input box to the *bottom* of the grid, so those extra bottom rows — the input box + status lines — render behind the dock.

The refit hook then re-fit **only on width changes and deliberately ignored height-only changes**, so the over-fit was never corrected. Leaving and re-entering worked around it because re-entry re-subscribes → re-measures against the now-settled layout.

## Fix

Track the measured terminal-frame **height** and re-fit the PTY when it changes, mirroring the existing width path:

- `session/[worktreeId].tsx` — add `terminalFrameHeight` state, set it in the frame's `onLayout`, pass it to `useTerminalViewportRefit`.
- `terminal-viewport-refit.ts` — add a height-change effect that marks the viewport un-measured and re-fits (mirror of the width effect).

This makes the terminal self-correct when the dock settles — automatically doing what the manual leave/return did.

**Why it's safe:** Expo SDK 55's edge-to-edge IME **overlays instead of resizing** (see the `keyboardHeight` comment), so the frame height does **not** change on keyboard open/close on iOS or Android → the PTY is never reflowed while typing. The refit's existing row-count guard makes a height change that doesn't change the row count a no-op, so settled/jitter layouts don't churn the server PTY.

## Testing

- Added a behavioral test for the extracted decision helper (`shouldRefitOnFrameHeightChange`) — height transition, same-value no-op, and keyboard-open skip — plus structural tests for the wiring.
- `vitest run src/terminal src/session` → **700 passed**; `tsc --noEmit` clean; oxlint clean.
- **Emulator run (iOS Simulator, this branch, stable local host):** app is stable and a freshly-created Claude terminal renders its input box correctly above the bar — **no regression observed**. But I could **not reproduce the original bug** in the emulator: the input renders correctly *with and without* the fix. This is a **layout-timing race** (the terminal's first fit vs. the accessory/live-input dock laying out) that the fast local simulator doesn't lose — matching the reporter's *intermittent, "restart fixes it"* report on TestFlight over a real/remote connection.
- **⚠️ Not conclusively verified against the live bug.** The fix is justified by root-cause analysis + the reporter's signature + tests, and is low-risk (only adds a guarded refit that can't regress the passing case: a row-count no-op when rows are unchanged, and a keyboard guard so it never reflows the PTY while typing). **Authoritative check = a real device / next TestFlight:** create a fresh Claude terminal and confirm the input box sits above the bar on first entry.
