### PR TITLE
Fail loudly on chmod errors in remote CLI launcher install

### DIFF
--- a/src/main/ssh/ssh-remote-cli-launcher.ts
+++ b/src/main/ssh/ssh-remote-cli-launcher.ts
@@ -232,6 +232,7 @@ export function createRemoteCliInstallPlan(env: RemoteCliInstallEnv): RemoteCliI
         ].join('\n')
       }
     ],
-    postWriteCommands: [`chmod +x ${quoteSh(launcherPath)} 2>/dev/null; true`]
+    // Surface chmod failures: a non-executable launcher must fail install loudly, not silently.
+    postWriteCommands: [`chmod +x ${quoteSh(launcherPath)}`]
   }
 }


### PR DESCRIPTION
## What

The SSH remote CLI launcher's post-write command was `chmod +x <path> 2>/dev/null; true`. Because `execCommand` rejects on a non-zero exit, the trailing `; true` silently swallowed any `chmod` failure — letting an install succeed while leaving a non-executable launcher, which surfaces later as a confusing runtime error instead of a clear install-time failure.

This drops the suppression so a failed `chmod` propagates as an install error.

```diff
-    postWriteCommands: [`chmod +x ${quoteSh(launcherPath)} 2>/dev/null; true`]
+    postWriteCommands: [`chmod +x ${quoteSh(launcherPath)}`]
```

## Why

Raised in review of #8638. Split into its own PR.

## Testing

- `vitest run src/main/ssh/ssh-remote-cli-launcher.test.ts` — pass
- `git diff --check` — clean

Made with [Orca](https://github.com/stablyai/orca) 🐋
