### PR TITLE
perf(ssh): merge the two identical 5s keepalive timers into one per connection

### DIFF
--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -305,6 +305,25 @@ describe('SshChannelMultiplexer', () => {
       expect(() => vi.advanceTimersByTime(5_000)).not.toThrow()
       expect(mux.isDisposed()).toBe(true)
     })
+
+    it('drives keepalive sends AND dead-link detection from a single interval', () => {
+      // The keepalive send and the liveness/timeout check were merged from two
+      // 5s intervals into one; there must be exactly one recurring timer.
+      expect(vi.getTimerCount()).toBe(1)
+
+      // Send half: a keepalive is written on the tick.
+      const before = transport.written.length
+      vi.advanceTimersByTime(5_000)
+      expect(transport.written.length).toBeGreaterThan(before)
+      expect(transport.written.at(-1)![0]).toBe(MessageType.KeepAlive)
+      expect(vi.getTimerCount()).toBe(1)
+
+      // Check half: with no inbound frames or acks, the same interval declares
+      // the link dead (no-data + oldest-unacked both exceed the 20s window).
+      expect(mux.isDisposed()).toBe(false)
+      vi.advanceTimersByTime(25_000)
+      expect(mux.isDisposed()).toBe(true)
+    })
   })
 
   describe('wake guard (timer pause across system sleep, #7773)', () => {

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -54,7 +54,7 @@ export class SshChannelMultiplexer {
   // generic notification listener that already serves fs.changed.
   private methodNotificationHandlers = new Map<string, Set<MethodNotificationHandler>>()
   private disposeHandlers: ((reason: 'shutdown' | 'connection_lost') => void)[] = []
-  private keepaliveTimer: ReturnType<typeof setInterval> | null = null
+  private connectionHealthTimer: ReturnType<typeof setInterval> | null = null
   private disposed = false
 
   // Track the oldest unacked outgoing message timestamp
@@ -87,7 +87,7 @@ export class SshChannelMultiplexer {
     if (this.disposed) {
       return
     }
-    this.startKeepalive()
+    this.startConnectionHealthTimer()
   }
 
   onNotification(handler: NotificationHandler): () => void {
@@ -274,9 +274,9 @@ export class SshChannelMultiplexer {
     }
     this.disposed = true
 
-    if (this.keepaliveTimer) {
-      clearInterval(this.keepaliveTimer)
-      this.keepaliveTimer = null
+    if (this.connectionHealthTimer) {
+      clearInterval(this.connectionHealthTimer)
+      this.connectionHealthTimer = null
     }
 
     // Why: the renderer uses the error code to distinguish temporary disconnects
@@ -482,14 +482,15 @@ export class SshChannelMultiplexer {
     }
   }
 
-  private startKeepalive(): void {
-    // Why: the periodic keepalive send and the liveness/timeout check ran as two
-    // separate 5s intervals that always fired back-to-back (keepalive created
-    // first). Fold them into one 5s tick — send first (as the keepalive timer
-    // did), then run the check (as the timeout timer did) — to halve the
-    // per-connection timer count with identical behavior.
+  // Why: one 5s interval owns BOTH the periodic keepalive send and the
+  // liveness/dead-link check. They used to be two separate 5s intervals that
+  // always fired back-to-back (keepalive created first); folding them into one
+  // tick — send first (as the keepalive timer did), then run the check (as the
+  // timeout timer did) — halves the per-connection timer count with identical
+  // behavior, including the #7773 wake-gap recovery below.
+  private startConnectionHealthTimer(): void {
     let lastTickAt = Date.now()
-    this.keepaliveTimer = setInterval(() => {
+    this.connectionHealthTimer = setInterval(() => {
       this.sendKeepAlive()
 
       if (this.disposed) {

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -55,7 +55,6 @@ export class SshChannelMultiplexer {
   private methodNotificationHandlers = new Map<string, Set<MethodNotificationHandler>>()
   private disposeHandlers: ((reason: 'shutdown' | 'connection_lost') => void)[] = []
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null
-  private timeoutTimer: ReturnType<typeof setInterval> | null = null
   private disposed = false
 
   // Track the oldest unacked outgoing message timestamp
@@ -89,7 +88,6 @@ export class SshChannelMultiplexer {
       return
     }
     this.startKeepalive()
-    this.startTimeoutCheck()
   }
 
   onNotification(handler: NotificationHandler): () => void {
@@ -279,10 +277,6 @@ export class SshChannelMultiplexer {
     if (this.keepaliveTimer) {
       clearInterval(this.keepaliveTimer)
       this.keepaliveTimer = null
-    }
-    if (this.timeoutTimer) {
-      clearInterval(this.timeoutTimer)
-      this.timeoutTimer = null
     }
 
     // Why: the renderer uses the error code to distinguish temporary disconnects
@@ -489,14 +483,15 @@ export class SshChannelMultiplexer {
   }
 
   private startKeepalive(): void {
+    // Why: the periodic keepalive send and the liveness/timeout check ran as two
+    // separate 5s intervals that always fired back-to-back (keepalive created
+    // first). Fold them into one 5s tick — send first (as the keepalive timer
+    // did), then run the check (as the timeout timer did) — to halve the
+    // per-connection timer count with identical behavior.
+    let lastTickAt = Date.now()
     this.keepaliveTimer = setInterval(() => {
       this.sendKeepAlive()
-    }, KEEPALIVE_SEND_MS)
-  }
 
-  private startTimeoutCheck(): void {
-    let lastTickAt = Date.now()
-    this.timeoutTimer = setInterval(() => {
       if (this.disposed) {
         return
       }


### PR DESCRIPTION
## Description

Every live SSH / relay connection (`SshChannelMultiplexer`) ran **two** `setInterval(…, 5000)` timers:
- `startKeepalive()` — sends the keepalive frame every 5 s.
- `startTimeoutCheck()` — runs the liveness / dead-connection check every 5 s (including the #7773 post-sleep wake-gap recovery).

They are created back-to-back in the constructor (keepalive first), so Node fires them **in that order on the same 5 s tick**. This PR folds them into a **single** 5 s interval — *send first (exactly as the keepalive timer did), then run the check (exactly as the timeout timer did)* — halving the per-connection timer/wakeup count.

## Evidence of improvement

- **One recurring timer per connection instead of two.** For a user with N connected remote worktrees, that's N fewer 5 s wakeups (main process). A new test asserts `vi.getTimerCount() === 1` after construction.
- Main-process timers aren't Chromium-throttled, so these fire regardless of window state — this is a real, continuous wakeup reduction for anyone using SSH remotes (a core Orca workflow).

## ELI5

Each remote connection had two little alarm clocks that both went off every 5 seconds — one to say "still here?" and one to check "did they answer?". They always rang one right after the other, so we combined them into a single alarm that does both. Nothing about how connections stay alive or get dropped changes; there's just one alarm instead of two.

## Proof of no regressions (behavior is byte-identical)

The merge preserves the exact observable sequence:
- **Order:** `sendKeepAlive()` runs first, then the check — the same order the two separate timers fired in.
- **Wake-gap (#7773):** on a post-sleep tick, the keepalive send + the wake-branch's second send still produce **two** keepalives, last-frame-is-keepalive, and reset unacked timestamps identically.
- **Disposed handling:** `sendKeepAlive()` already early-returns when `disposed`, and the check half keeps its `if (this.disposed) return` — matching both original callbacks.
- **`lastTickAt`** is still initialized at construction, so wake-gap detection is unchanged.

Verification:
- **All 27 existing multiplexer tests pass unchanged** — keepalive periodicity, the three #7773 wake-guard cases, the no-ack dead-link kill, write-failure→connection-loss, probeLiveness, dispose, transport-close.
- **+1 new test** locks the merge: one interval drives both the keepalive send *and* the dead-link detection/dispose.
- **Typecheck** (node) and **oxlint** clean.

## Trade-offs

- **None.** This is a pure timer-count reduction with identical behavior. The only structural change is one fewer field (`timeoutTimer`) and one fewer `clearInterval` in `dispose()`.

---
🔋 Part of a battery/energy audit. Draft — do not merge without maintainer review. Undergoing multi-round adversarial review.

Made with [Orca](https://github.com/stablyai/orca) 🐋
