### PR TITLE
feat(terminal): trim scrollback of hidden SSH terminals after cold-park delay

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ssh-scrollback-trim.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ssh-scrollback-trim.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  SSH_HIDDEN_SCROLLBACK_TRIM_ROWS,
+  trimHiddenSshScrollback,
+  restoreHiddenSshScrollback,
+  useHiddenSshScrollbackTrim
+} from './terminal-ssh-scrollback-trim'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePane(id: number, scrollback = 5000) {
+  return { id, terminal: { options: { scrollback } } }
+}
+
+function makeSshTransport(id: number) {
+  return { getPtyId: (): string | null => `ssh:ssh-conn-${id}@@pty-${id}` }
+}
+
+function makeLocalTransport(id: number) {
+  return { getPtyId: (): string | null => `wt-${id}@@session-${id}` }
+}
+
+function makeNullTransport() {
+  return { getPtyId: (): string | null => null }
+}
+
+// ---------------------------------------------------------------------------
+// trimHiddenSshScrollback
+// ---------------------------------------------------------------------------
+
+describe('trimHiddenSshScrollback', () => {
+  it('trims SSH panes to trimRows', () => {
+    const pane = makePane(1, 5000)
+    const manager = { getPanes: () => [pane] }
+    const transports = new Map([[1, makeSshTransport(1)]])
+    trimHiddenSshScrollback(manager, transports, SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+    expect(pane.terminal.options.scrollback).toBe(SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+  })
+
+  it('does not touch local (non-SSH) panes', () => {
+    const pane = makePane(2, 5000)
+    const manager = { getPanes: () => [pane] }
+    const transports = new Map([[2, makeLocalTransport(2)]])
+    trimHiddenSshScrollback(manager, transports, SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('does not touch panes with no transport entry', () => {
+    const pane = makePane(3, 5000)
+    const manager = { getPanes: () => [pane] }
+    const transports = new Map<number, ReturnType<typeof makeSshTransport>>()
+    trimHiddenSshScrollback(manager, transports, 200)
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('does not touch panes whose transport returns null pty id', () => {
+    const pane = makePane(4, 5000)
+    const manager = { getPanes: () => [pane] }
+    const transports = new Map([[4, makeNullTransport()]])
+    trimHiddenSshScrollback(manager, transports, 200)
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('trims only SSH panes in a mixed-type set', () => {
+    const sshPane = makePane(1, 5000)
+    const localPane = makePane(2, 5000)
+    const manager = { getPanes: () => [sshPane, localPane] }
+    const transports = new Map([
+      [1, makeSshTransport(1)],
+      [2, makeLocalTransport(2)]
+    ])
+    trimHiddenSshScrollback(manager, transports, 200)
+    expect(sshPane.terminal.options.scrollback).toBe(200)
+    expect(localPane.terminal.options.scrollback).toBe(5000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// restoreHiddenSshScrollback
+// ---------------------------------------------------------------------------
+
+describe('restoreHiddenSshScrollback', () => {
+  it('restores a trimmed SSH pane back to configuredRows', () => {
+    const pane = makePane(1, SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+    const manager = { getPanes: () => [pane] }
+    const transports = new Map([[1, makeSshTransport(1)]])
+    restoreHiddenSshScrollback(manager, transports, 5000)
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('does not reduce a pane already at or above configuredRows', () => {
+    const pane = makePane(1, 5000)
+    const manager = { getPanes: () => [pane] }
+    const transports = new Map([[1, makeSshTransport(1)]])
+    restoreHiddenSshScrollback(manager, transports, 1000)
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('does not restore non-SSH panes', () => {
+    const pane = makePane(2, 100)
+    const manager = { getPanes: () => [pane] }
+    const transports = new Map([[2, makeLocalTransport(2)]])
+    restoreHiddenSshScrollback(manager, transports, 5000)
+    expect(pane.terminal.options.scrollback).toBe(100)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useHiddenSshScrollbackTrim hook
+// ---------------------------------------------------------------------------
+
+describe('useHiddenSshScrollbackTrim', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function setup(
+    isVisible: boolean,
+    configuredScrollbackRows = 5000,
+    coldParkDelayMs = 30_000
+  ) {
+    const pane = makePane(1, configuredScrollbackRows)
+    const manager = { getPanes: () => [pane] }
+    const transports = new Map([[1, makeSshTransport(1)]])
+    const managerRef = { current: manager }
+    const paneTransportsRef = { current: transports }
+
+    const hook = renderHook(
+      (props: { isVisible: boolean; configuredScrollbackRows: number }) =>
+        useHiddenSshScrollbackTrim({
+          managerRef,
+          paneTransportsRef,
+          isVisible: props.isVisible,
+          configuredScrollbackRows: props.configuredScrollbackRows,
+          coldParkDelayMs
+        }),
+      { initialProps: { isVisible, configuredScrollbackRows } }
+    )
+
+    return { hook, pane, managerRef, paneTransportsRef }
+  }
+
+  it('does not trim while visible', () => {
+    const { pane } = setup(true)
+    act(() => vi.advanceTimersByTime(60_000))
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('trims SSH panes after the cold-park delay when hidden', () => {
+    const { pane } = setup(false, 5000, 30_000)
+    expect(pane.terminal.options.scrollback).toBe(5000)
+    act(() => vi.advanceTimersByTime(30_000))
+    expect(pane.terminal.options.scrollback).toBe(SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+  })
+
+  it('does not trim before the cold-park delay elapses', () => {
+    const { pane } = setup(false, 5000, 30_000)
+    act(() => vi.advanceTimersByTime(29_999))
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('cancels pending trim and restores on re-reveal before timer fires', () => {
+    const { hook, pane } = setup(false, 5000, 30_000)
+    act(() => vi.advanceTimersByTime(15_000))
+    expect(pane.terminal.options.scrollback).toBe(5000)
+    // re-reveal before timer fires
+    act(() => hook.rerender({ isVisible: true, configuredScrollbackRows: 5000 }))
+    act(() => vi.advanceTimersByTime(30_000))
+    // timer was cancelled; pane should NOT be trimmed
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('restores scrollback when tab becomes visible after trim', () => {
+    const { hook, pane } = setup(false, 5000, 30_000)
+    act(() => vi.advanceTimersByTime(30_000))
+    expect(pane.terminal.options.scrollback).toBe(SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+    act(() => hook.rerender({ isVisible: true, configuredScrollbackRows: 5000 }))
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+
+  it('schedules a new trim when tab is hidden again after restore', () => {
+    const { hook, pane } = setup(false, 5000, 30_000)
+    // first hide → trim
+    act(() => vi.advanceTimersByTime(30_000))
+    expect(pane.terminal.options.scrollback).toBe(SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+    // reveal → restore
+    act(() => hook.rerender({ isVisible: true, configuredScrollbackRows: 5000 }))
+    expect(pane.terminal.options.scrollback).toBe(5000)
+    // hide again → should trim after delay
+    act(() => hook.rerender({ isVisible: false, configuredScrollbackRows: 5000 }))
+    act(() => vi.advanceTimersByTime(30_000))
+    expect(pane.terminal.options.scrollback).toBe(SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+  })
+
+  it('cancels the pending timer on unmount', () => {
+    const { hook, pane } = setup(false, 5000, 30_000)
+    act(() => vi.advanceTimersByTime(10_000))
+    hook.unmount()
+    act(() => vi.advanceTimersByTime(30_000))
+    // unmounted: timer should have been cleaned up
+    expect(pane.terminal.options.scrollback).toBe(5000)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ssh-scrollback-trim.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ssh-scrollback-trim.ts
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
+import { TERMINAL_TAB_COLD_PARK_DELAY_MS } from './terminal-hidden-view-parking'
+
+// Scrollback rows retained for a hidden SSH terminal after the cold-park
+// threshold. Large enough to cover a typical viewport (~50 rows) plus a
+// short scroll; small enough to free the bulk of history filled by agent
+// output (which commonly reaches the user's configured 1k–5k row limit).
+export const SSH_HIDDEN_SCROLLBACK_TRIM_ROWS = 200
+
+type TrimPaneManager = {
+  getPanes(): readonly { id: number; terminal: { options: { scrollback?: number } } }[]
+}
+
+type PtyIdProvider = { getPtyId(): string | null }
+
+// Why: these are pure helper functions (not hooks) so they can be tested
+// without a React render environment and called from non-hook contexts.
+
+export function trimHiddenSshScrollback(
+  manager: TrimPaneManager,
+  paneTransports: Map<number, PtyIdProvider>,
+  trimRows: number
+): void {
+  for (const pane of manager.getPanes()) {
+    const ptyId = paneTransports.get(pane.id)?.getPtyId() ?? null
+    if (ptyId !== null && parseAppSshPtyId(ptyId) !== null) {
+      pane.terminal.options.scrollback = trimRows
+    }
+  }
+}
+
+export function restoreHiddenSshScrollback(
+  manager: TrimPaneManager,
+  paneTransports: Map<number, PtyIdProvider>,
+  configuredRows: number
+): void {
+  for (const pane of manager.getPanes()) {
+    const ptyId = paneTransports.get(pane.id)?.getPtyId() ?? null
+    if (ptyId !== null && parseAppSshPtyId(ptyId) !== null) {
+      // Only bump up — never reduce a scrollback that is already at or above
+      // the configured value (e.g. the pane was never trimmed).
+      if ((pane.terminal.options.scrollback ?? configuredRows) < configuredRows) {
+        pane.terminal.options.scrollback = configuredRows
+      }
+    }
+  }
+}
+
+/**
+ * Bounds renderer heap for hidden SSH terminal panes by trimming their
+ * xterm.js scrollback buffer after the cold-park threshold.
+ *
+ * SSH PTYs are ineligible for full hidden-view parking (no daemon snapshot
+ * to re-hydrate from), so their xterm instances — and the complete scrollback
+ * buffers they hold — stay in the renderer heap indefinitely while hidden.
+ * At 1k–5k rows per terminal (the user's configured limit), a workflow with
+ * several SSH tabs can push the renderer heap to 100–250 MB.
+ *
+ * When the tab has been hidden for longer than coldParkDelayMs (default 30s,
+ * matching the parking hysteresis), all SSH panes have their scrollback
+ * trimmed to SSH_HIDDEN_SCROLLBACK_TRIM_ROWS. On reveal the buffer is
+ * restored to configuredScrollbackRows so new output can fill it again.
+ * History beyond SSH_HIDDEN_SCROLLBACK_TRIM_ROWS is lost on trim — the same
+ * trade-off full parking already accepts for local panes.
+ */
+export function useHiddenSshScrollbackTrim(args: {
+  managerRef: RefObject<TrimPaneManager | null>
+  paneTransportsRef: RefObject<Map<number, PtyIdProvider>>
+  isVisible: boolean
+  configuredScrollbackRows: number
+  coldParkDelayMs?: number
+}): void {
+  const { isVisible, configuredScrollbackRows, coldParkDelayMs, managerRef, paneTransportsRef } =
+    args
+  const trimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (isVisible) {
+      // Tab revealed: cancel any pending trim and restore SSH panes to the
+      // configured depth so the buffer can grow normally from this point.
+      if (trimTimerRef.current !== null) {
+        clearTimeout(trimTimerRef.current)
+        trimTimerRef.current = null
+      }
+      const manager = managerRef.current
+      if (manager) {
+        restoreHiddenSshScrollback(manager, paneTransportsRef.current, configuredScrollbackRows)
+      }
+      return
+    }
+
+    // Tab hidden: schedule a scrollback trim after the cold-park delay.
+    // Mirrors the cold-park hysteresis so a quick tab flip never trims.
+    const delay = coldParkDelayMs ?? TERMINAL_TAB_COLD_PARK_DELAY_MS
+    trimTimerRef.current = setTimeout(() => {
+      trimTimerRef.current = null
+      const manager = managerRef.current
+      if (manager) {
+        trimHiddenSshScrollback(manager, paneTransportsRef.current, SSH_HIDDEN_SCROLLBACK_TRIM_ROWS)
+      }
+    }, delay)
+
+    return (): void => {
+      if (trimTimerRef.current !== null) {
+        clearTimeout(trimTimerRef.current)
+        trimTimerRef.current = null
+      }
+    }
+    // Why: managerRef and paneTransportsRef are stable React refs whose
+    // identity never changes — including them would make deps harder to read
+    // without affecting correctness.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isVisible, configuredScrollbackRows, coldParkDelayMs])
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/pane-manager/pane-terminal-options'
 import { normalizeDesktopTerminalScrollbackRows } from '../../../../shared/terminal-scrollback-policy'
 import { configureTerminalOutputBacklogCap } from '@/lib/pane-manager/pane-terminal-output-scheduler'
+import { useHiddenSshScrollbackTrim } from './terminal-ssh-scrollback-trim'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { normalizeTerminalTuiMouseWheelMultiplier } from '@/lib/pane-manager/pane-terminal-mouse-wheel'
 import { buildWindowsPtyCompatibilityOptions } from '@/lib/pane-manager/windows-pty-compatibility'
@@ -570,6 +571,12 @@ export function useTerminalPaneLifecycle({
   // scrollback setting; applying it where the setting is read keeps the two
   // in lockstep without a separate settings subscription.
   configureTerminalOutputBacklogCap(settings?.terminalScrollbackRows)
+  useHiddenSshScrollbackTrim({
+    managerRef,
+    paneTransportsRef,
+    isVisible,
+    configuredScrollbackRows: terminalScrollbackRows
+  })
   const systemPrefersDarkRef = useRef(systemPrefersDark)
   systemPrefersDarkRef.current = systemPrefersDark
   const previousVisibleForReconcileRef = useRef<TerminalPaneVisibilitySnapshot | null>(null)


### PR DESCRIPTION
## Problem

SSH PTYs are excluded from hidden-view parking (`canParkTerminalTabRenderer()` returns `false` for any `ptyId` that matches `parseAppSshPtyId()`) because parking relies on a daemon snapshot for re-hydration and SSH PTYs have no such snapshot in the current phase.

As a result their xterm.js instances — and the full scrollback buffers they hold — remain in the renderer heap for as long as the tab stays hidden. At the default 5 000-row limit each SSH terminal occupies roughly 20–25 MB; a workflow with five or more SSH tabs can push the renderer heap past 100–250 MB without any unhandled rejections or other visible errors.

Log analysis from a production session (issue #8652) shows the renderer heap growing from 23 MB to **257 MB over 3 h** in a session with **zero unhandled rejections** and `terminalHiddenViewParking` enabled — confirming the parking exclusion as the dominant residual leak.

## Solution

Mirror the existing cold-park hysteresis (30 s, `TERMINAL_TAB_COLD_PARK_DELAY_MS`) with a matching scrollback-trim timer:

- After a tab has been hidden for ≥ 30 s all SSH panes have their xterm.js scrollback trimmed to **`SSH_HIDDEN_SCROLLBACK_TRIM_ROWS = 200`** rows. xterm.js applies this synchronously by trimming the circular buffer in place, freeing cell data immediately without discarding the process or terminal instance.
- When the tab is revealed the buffer limit is restored to the user's configured value so agent output can accumulate normally again.
- A quick tab flip (hide → show in < 30 s) never trims, matching how cold-park avoids parking transient hides.

200 rows is intentionally generous — enough to cover a full viewport plus a short scroll — while releasing > 95 % of the accumulated history that agent runs fill.

## Files changed

| File | Change |
|------|--------|
| `terminal-ssh-scrollback-trim.ts` | New module: `trimHiddenSshScrollback`, `restoreHiddenSshScrollback` (pure helpers, testable without React), `useHiddenSshScrollbackTrim` hook |
| `terminal-ssh-scrollback-trim.test.ts` | Unit tests: trim/restore helpers + timer behaviour (reveal cancel, re-trim after restore, unmount cleanup) |
| `use-terminal-pane-lifecycle.ts` | One import + a 6-line hook invocation after the existing scrollback-cap application |

## Expected outcome

In a session with 5 × SSH terminals each at 1 000-row scrollback the trimmed heap footprint per hidden terminal drops from ~5 MB to ~1 MB, reducing the total contribution of hidden terminals from ~25 MB to ~5 MB. At the previous 5 000-row default the saving is proportionally larger (~100 MB → ~5 MB for 5 terminals).

## Related

- Closes #8652
- Complements #8279 (unhandled-rejection heap leak)

## Test plan

- [ ] Open several SSH terminal tabs in ORCA
- [ ] Switch to a different tab and wait > 30 s
- [ ] Check heap in DevTools Memory → heap should shrink measurably after the 30 s delay
- [ ] Switch back to the SSH tab → scrollback limit should be restored (new output fills the buffer normally)
- [ ] Confirm a quick tab flip (hide → show in < 30 s) does NOT trim the buffer

## ELI5

Hidden SSH terminals kept huge scrollback in memory forever. After a delay, Orca trims that scrollback so idle SSH tabs use much less RAM.
