### PR TITLE
fix(browser): handle Cmd-click popups without adopted WebContents

### DIFF
--- a/src/main/browser/popup-origin-bar-window.test.ts
+++ b/src/main/browser/popup-origin-bar-window.test.ts
@@ -53,6 +53,11 @@ const { fakeElectron } = vi.hoisted(() => {
     webContents: FakeWebContents
     setBounds = vi.fn()
     constructor(options: { webContents?: FakeWebContents; webPreferences?: unknown }) {
+      // Why: Electron rejects explicit undefined instead of treating it as
+      // omitted, which the popup fallback path depends on.
+      if (Object.hasOwn(options, 'webContents') && options.webContents === undefined) {
+        throw new TypeError('options.webContents must be a WebContents')
+      }
       this.options = options
       this.webContents = options.webContents ?? createFakeWebContents()
       FakeWebContentsView.instances.push(this)
@@ -186,6 +191,7 @@ describe('openPopupWithOriginBar', () => {
 
   it('loads the target itself only when no pre-created contents were provided', () => {
     const popup = openPopupWithOriginBar({}, 'https://example.com/login')
+    expect(lastViews().content.options).not.toHaveProperty('webContents')
     expect(popup.contentWebContents.loadURL).toHaveBeenCalledWith('https://example.com/login')
   })
 

--- a/src/main/browser/popup-origin-bar-window.ts
+++ b/src/main/browser/popup-origin-bar-window.ts
@@ -120,7 +120,9 @@ export function openPopupWithOriginBar(
     webPreferences: { contextIsolation: true, nodeIntegration: false, sandbox: true }
   })
   const contentView = new WebContentsView({
-    webContents: options.webContents,
+    // Why: Electron rejects an explicitly undefined webContents; omitting it
+    // lets WebContentsView create contents for Cmd/Ctrl-click popups.
+    ...(options.webContents === undefined ? {} : { webContents: options.webContents }),
     webPreferences: options.webPreferences
   })
   window.contentView.addChildView(contentView)


### PR DESCRIPTION
## Summary

- omit the optional `webContents` key when Electron should create popup contents for Cmd/Ctrl-click
- preserve adoption of pre-created WebContents for OAuth session and `window.opener` behavior
- make the popup constructor mock enforce Electron's omission-vs-explicit-undefined contract

## Reproduction

Real headful Electron 43.1.0 reproduced the regression from #8343 before the fix:

```text
TypeError: options.webContents must be a WebContents
```

The strengthened no-precreated-WebContents regression test failed at the same constructor before the source change. A post-fix headful embedded-browser check sent a platform-correct Cmd/Ctrl-click to a real guest WebContents and observed the expected origin-bar and content views.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/popup-origin-bar-window.test.ts src/main/browser/browser-manager.test.ts` (61 passed)
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/browser/popup-origin-bar-window.ts src/main/browser/popup-origin-bar-window.test.ts`
- `pnpm exec oxfmt --check src/main/browser/popup-origin-bar-window.ts src/main/browser/popup-origin-bar-window.test.ts`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋
