### PR TITLE
fix(lint): cover active/inactive in the terminal tab activity switch

### DIFF
--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx
@@ -35,7 +35,8 @@ function activityDotState(status: TerminalTabActivityStatus): AgentDotState | nu
       return 'permission'
     case 'done':
       return 'done'
-    default:
+    case 'active':
+    case 'inactive':
       return null
   }
 }


### PR DESCRIPTION
Main currently fails `lint:switch-exhaustiveness` on `TerminalTabLeadingIcon.tsx` — the `WorktreeStatus` union feeding `activityDotState` widened while the switch wasn't updated, and since `verify` doesn't run on pushes to main, the break landed silently and now fails CI for every PR based on current main (reproduced on pristine `origin/main` at v1.4.139-rc.2).

Two-line fix matching the function's documented intent: `active` and `inactive` carry no activity glyph, so they return `null` explicitly; the now-unreachable `default` is removed (the gate flags it once the switch is exhaustive).

Verified: `oxlint --type-aware --config config/oxlint-switch-exhaustiveness.json` clean on the touched directory.