### PR TITLE
fix(i18n): format relative times with the configured UI language

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -226,6 +226,7 @@ import {
   validateTaskPageGitHubDuplicateTarget,
   type TaskPageGitHubCloseAction
 } from '@/components/task-page-github-status-actions'
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 // Why: the GH item dialog can be opened from any work-item list surface and
 // doesn't have the full owner/repo context the list's cache entry carries.
@@ -345,7 +346,7 @@ function formatRelativeTime(input: string): string {
   }
   const diffMs = date.getTime() - Date.now()
   const diffMinutes = Math.round(diffMs / 60_000)
-  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  const formatter = getUiRelativeTimeFormatter()
   if (Math.abs(diffMinutes) < 60) {
     return formatter.format(diffMinutes, 'minute')
   }

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -226,7 +226,7 @@ import {
   validateTaskPageGitHubDuplicateTarget,
   type TaskPageGitHubCloseAction
 } from '@/components/task-page-github-status-actions'
-import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
 
 // Why: the GH item dialog can be opened from any work-item list surface and
 // doesn't have the full owner/repo context the list's cache entry carries.
@@ -340,22 +340,7 @@ type GitHubItemDialogProps = {
 }
 
 function formatRelativeTime(input: string): string {
-  const date = new Date(input)
-  if (Number.isNaN(date.getTime())) {
-    return 'recently'
-  }
-  const diffMs = date.getTime() - Date.now()
-  const diffMinutes = Math.round(diffMs / 60_000)
-  const formatter = getUiRelativeTimeFormatter()
-  if (Math.abs(diffMinutes) < 60) {
-    return formatter.format(diffMinutes, 'minute')
-  }
-  const diffHours = Math.round(diffMinutes / 60)
-  if (Math.abs(diffHours) < 24) {
-    return formatter.format(diffHours, 'hour')
-  }
-  const diffDays = Math.round(diffHours / 24)
-  return formatter.format(diffDays, 'day')
+  return formatUiRelativeTimeFromDate(input)
 }
 
 function getStateLabel(item: GitHubWorkItem): string {

--- a/src/renderer/src/components/JiraIssueWorkspace.tsx
+++ b/src/renderer/src/components/JiraIssueWorkspace.tsx
@@ -62,15 +62,16 @@ function formatRelativeTime(input: string): string {
   if (Number.isNaN(date.getTime())) {
     return 'recently'
   }
+  const formatter = getUiRelativeTimeFormatter()
   const diffMinutes = Math.round((date.getTime() - Date.now()) / 60_000)
   if (Math.abs(diffMinutes) < 60) {
-    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
+    return formatter.format(diffMinutes, 'minute')
   }
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
+    return formatter.format(diffHours, 'hour')
   }
-  return getUiRelativeTimeFormatter().format(Math.round(diffHours / 24), 'day')
+  return formatter.format(Math.round(diffHours / 24), 'day')
 }
 
 function buildJiraBranchName(issue: JiraIssue): string {

--- a/src/renderer/src/components/JiraIssueWorkspace.tsx
+++ b/src/renderer/src/components/JiraIssueWorkspace.tsx
@@ -48,6 +48,7 @@ import type {
 } from '../../../shared/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 type JiraIssueWorkspaceProps = {
   issue: JiraIssue | null
@@ -56,8 +57,6 @@ type JiraIssueWorkspaceProps = {
   sourceContext?: TaskSourceContext | null
 }
 
-const relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
-
 function formatRelativeTime(input: string): string {
   const date = new Date(input)
   if (Number.isNaN(date.getTime())) {
@@ -65,13 +64,13 @@ function formatRelativeTime(input: string): string {
   }
   const diffMinutes = Math.round((date.getTime() - Date.now()) / 60_000)
   if (Math.abs(diffMinutes) < 60) {
-    return relativeFormatter.format(diffMinutes, 'minute')
+    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
   }
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return relativeFormatter.format(diffHours, 'hour')
+    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
   }
-  return relativeFormatter.format(Math.round(diffHours / 24), 'day')
+  return getUiRelativeTimeFormatter().format(Math.round(diffHours / 24), 'day')
 }
 
 function buildJiraBranchName(issue: JiraIssue): string {

--- a/src/renderer/src/components/JiraIssueWorkspace.tsx
+++ b/src/renderer/src/components/JiraIssueWorkspace.tsx
@@ -48,7 +48,7 @@ import type {
 } from '../../../shared/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
-import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
 
 type JiraIssueWorkspaceProps = {
   issue: JiraIssue | null
@@ -58,20 +58,7 @@ type JiraIssueWorkspaceProps = {
 }
 
 function formatRelativeTime(input: string): string {
-  const date = new Date(input)
-  if (Number.isNaN(date.getTime())) {
-    return 'recently'
-  }
-  const formatter = getUiRelativeTimeFormatter()
-  const diffMinutes = Math.round((date.getTime() - Date.now()) / 60_000)
-  if (Math.abs(diffMinutes) < 60) {
-    return formatter.format(diffMinutes, 'minute')
-  }
-  const diffHours = Math.round(diffMinutes / 60)
-  if (Math.abs(diffHours) < 24) {
-    return formatter.format(diffHours, 'hour')
-  }
-  return formatter.format(Math.round(diffHours / 24), 'day')
+  return formatUiRelativeTimeFromDate(input)
 }
 
 function buildJiraBranchName(issue: JiraIssue): string {

--- a/src/renderer/src/components/LinearItemDrawer.tsx
+++ b/src/renderer/src/components/LinearItemDrawer.tsx
@@ -50,7 +50,7 @@ import {
   linearUpdateIssue
 } from '@/runtime/runtime-linear-client'
 import { translate } from '@/i18n/i18n'
-import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
 
 function LinearIcon({ className }: { className?: string }): React.JSX.Element {
   return (
@@ -102,22 +102,7 @@ function LinearEditChipAdornment({
 }
 
 function formatRelativeTime(input: string): string {
-  const date = new Date(input)
-  if (Number.isNaN(date.getTime())) {
-    return 'recently'
-  }
-  const diffMs = date.getTime() - Date.now()
-  const diffMinutes = Math.round(diffMs / 60_000)
-  const formatter = getUiRelativeTimeFormatter()
-  if (Math.abs(diffMinutes) < 60) {
-    return formatter.format(diffMinutes, 'minute')
-  }
-  const diffHours = Math.round(diffMinutes / 60)
-  if (Math.abs(diffHours) < 24) {
-    return formatter.format(diffHours, 'hour')
-  }
-  const diffDays = Math.round(diffHours / 24)
-  return formatter.format(diffDays, 'day')
+  return formatUiRelativeTimeFromDate(input)
 }
 
 type LinearItemDrawerProps = {

--- a/src/renderer/src/components/LinearItemDrawer.tsx
+++ b/src/renderer/src/components/LinearItemDrawer.tsx
@@ -50,6 +50,7 @@ import {
   linearUpdateIssue
 } from '@/runtime/runtime-linear-client'
 import { translate } from '@/i18n/i18n'
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 function LinearIcon({ className }: { className?: string }): React.JSX.Element {
   return (
@@ -107,7 +108,7 @@ function formatRelativeTime(input: string): string {
   }
   const diffMs = date.getTime() - Date.now()
   const diffMinutes = Math.round(diffMs / 60_000)
-  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  const formatter = getUiRelativeTimeFormatter()
   if (Math.abs(diffMinutes) < 60) {
     return formatter.format(diffMinutes, 'minute')
   }

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -222,7 +222,7 @@ import {
 } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
-import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
 
 // Why: the GH item dialog can be opened from any work-item list surface and
 // doesn't have the full owner/repo context the list's cache entry carries.
@@ -327,22 +327,7 @@ type PullRequestPageProps = {
 }
 
 function formatRelativeTime(input: string): string {
-  const date = new Date(input)
-  if (Number.isNaN(date.getTime())) {
-    return 'recently'
-  }
-  const diffMs = date.getTime() - Date.now()
-  const diffMinutes = Math.round(diffMs / 60_000)
-  const formatter = getUiRelativeTimeFormatter()
-  if (Math.abs(diffMinutes) < 60) {
-    return formatter.format(diffMinutes, 'minute')
-  }
-  const diffHours = Math.round(diffMinutes / 60)
-  if (Math.abs(diffHours) < 24) {
-    return formatter.format(diffHours, 'hour')
-  }
-  const diffDays = Math.round(diffHours / 24)
-  return formatter.format(diffDays, 'day')
+  return formatUiRelativeTimeFromDate(input)
 }
 
 function findMentionQuery(value: string, caret: number): MentionQuery | null {

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -222,6 +222,7 @@ import {
 } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 // Why: the GH item dialog can be opened from any work-item list surface and
 // doesn't have the full owner/repo context the list's cache entry carries.
@@ -332,7 +333,7 @@ function formatRelativeTime(input: string): string {
   }
   const diffMs = date.getTime() - Date.now()
   const diffMinutes = Math.round(diffMs / 60_000)
-  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  const formatter = getUiRelativeTimeFormatter()
   if (Math.abs(diffMinutes) < 60) {
     return formatter.format(diffMinutes, 'minute')
   }

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -364,7 +364,7 @@ import {
   type LinearOrderBy,
   type LinearViewMode
 } from '@/components/task-page-localized-options'
-import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
 
 function isGitLabMRFilter(value: GitLabTaskFilter | GitLabIssueFilter): value is GitLabTaskFilter {
   return value === 'opened' || value === 'merged' || value === 'closed' || value === 'all'
@@ -572,26 +572,7 @@ function scopeGitHubTaskSearch(query: string, kind: GitHubTaskKind): string {
 }
 
 function formatRelativeTime(input: string): string {
-  const date = new Date(input)
-  if (Number.isNaN(date.getTime())) {
-    return 'recently'
-  }
-
-  const formatter = getUiRelativeTimeFormatter()
-  const diffMs = date.getTime() - Date.now()
-  const diffMinutes = Math.round(diffMs / 60_000)
-
-  if (Math.abs(diffMinutes) < 60) {
-    return formatter.format(diffMinutes, 'minute')
-  }
-
-  const diffHours = Math.round(diffMinutes / 60)
-  if (Math.abs(diffHours) < 24) {
-    return formatter.format(diffHours, 'hour')
-  }
-
-  const diffDays = Math.round(diffHours / 24)
-  return formatter.format(diffDays, 'day')
+  return formatUiRelativeTimeFromDate(input)
 }
 
 type LinearProjectTab = 'overview' | 'issues'

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -364,6 +364,7 @@ import {
   type LinearOrderBy,
   type LinearViewMode
 } from '@/components/task-page-localized-options'
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 function isGitLabMRFilter(value: GitLabTaskFilter | GitLabIssueFilter): value is GitLabTaskFilter {
   return value === 'opened' || value === 'merged' || value === 'closed' || value === 'all'
@@ -570,11 +571,6 @@ function scopeGitHubTaskSearch(query: string, kind: GitHubTaskKind): string {
   return `${inferredKind === 'prs' ? 'is:pr' : 'is:issue'} ${trimmed}`
 }
 
-// Why: Intl.RelativeTimeFormat allocation is non-trivial, and previously we
-// built a new formatter per work-item row render. Hoisting to module scope
-// means all rows share one instance — zero per-row allocation cost.
-const relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
-
 function formatRelativeTime(input: string): string {
   const date = new Date(input)
   if (Number.isNaN(date.getTime())) {
@@ -585,16 +581,16 @@ function formatRelativeTime(input: string): string {
   const diffMinutes = Math.round(diffMs / 60_000)
 
   if (Math.abs(diffMinutes) < 60) {
-    return relativeTimeFormatter.format(diffMinutes, 'minute')
+    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
   }
 
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return relativeTimeFormatter.format(diffHours, 'hour')
+    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
   }
 
   const diffDays = Math.round(diffHours / 24)
-  return relativeTimeFormatter.format(diffDays, 'day')
+  return getUiRelativeTimeFormatter().format(diffDays, 'day')
 }
 
 type LinearProjectTab = 'overview' | 'issues'

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -577,20 +577,21 @@ function formatRelativeTime(input: string): string {
     return 'recently'
   }
 
+  const formatter = getUiRelativeTimeFormatter()
   const diffMs = date.getTime() - Date.now()
   const diffMinutes = Math.round(diffMs / 60_000)
 
   if (Math.abs(diffMinutes) < 60) {
-    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
+    return formatter.format(diffMinutes, 'minute')
   }
 
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
+    return formatter.format(diffHours, 'hour')
   }
 
   const diffDays = Math.round(diffHours / 24)
-  return getUiRelativeTimeFormatter().format(diffDays, 'day')
+  return formatter.format(diffDays, 'day')
 }
 
 type LinearProjectTab = 'overview' | 'issues'

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -73,7 +73,7 @@ import {
   resolveActivityThreadStatusPreview
 } from '@/lib/activity-thread-display'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
-import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
+import { formatUiRelativeTime } from '@/i18n/relative-time-format'
 
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityGroupBy = 'status' | 'project' | 'worktree' | 'agent'
@@ -171,18 +171,7 @@ function formatAbsoluteDate(timestamp: number): string {
 }
 
 function formatRelativeTime(timestamp: number): string {
-  const formatter = getUiRelativeTimeFormatter()
-  const diffMs = timestamp - Date.now()
-  const diffMinutes = Math.round(diffMs / 60_000)
-  if (Math.abs(diffMinutes) < 60) {
-    return formatter.format(diffMinutes, 'minute')
-  }
-  const diffHours = Math.round(diffMinutes / 60)
-  if (Math.abs(diffHours) < 24) {
-    return formatter.format(diffHours, 'hour')
-  }
-  const diffDays = Math.round(diffHours / 24)
-  return formatter.format(diffDays, 'day')
+  return formatUiRelativeTime(timestamp - Date.now())
 }
 
 function findActivityTerminalPane(

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -73,6 +73,7 @@ import {
   resolveActivityThreadStatusPreview
 } from '@/lib/activity-thread-display'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityGroupBy = 'status' | 'project' | 'worktree' | 'agent'
@@ -165,8 +166,6 @@ const absoluteDateFormatter = new Intl.DateTimeFormat(undefined, {
   minute: '2-digit'
 })
 
-const relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
-
 function formatAbsoluteDate(timestamp: number): string {
   return absoluteDateFormatter.format(new Date(timestamp))
 }
@@ -175,14 +174,14 @@ function formatRelativeTime(timestamp: number): string {
   const diffMs = timestamp - Date.now()
   const diffMinutes = Math.round(diffMs / 60_000)
   if (Math.abs(diffMinutes) < 60) {
-    return relativeTimeFormatter.format(diffMinutes, 'minute')
+    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
   }
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return relativeTimeFormatter.format(diffHours, 'hour')
+    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
   }
   const diffDays = Math.round(diffHours / 24)
-  return relativeTimeFormatter.format(diffDays, 'day')
+  return getUiRelativeTimeFormatter().format(diffDays, 'day')
 }
 
 function findActivityTerminalPane(

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -171,17 +171,18 @@ function formatAbsoluteDate(timestamp: number): string {
 }
 
 function formatRelativeTime(timestamp: number): string {
+  const formatter = getUiRelativeTimeFormatter()
   const diffMs = timestamp - Date.now()
   const diffMinutes = Math.round(diffMs / 60_000)
   if (Math.abs(diffMinutes) < 60) {
-    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
+    return formatter.format(diffMinutes, 'minute')
   }
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
+    return formatter.format(diffHours, 'hour')
   }
   const diffDays = Math.round(diffHours / 24)
-  return getUiRelativeTimeFormatter().format(diffDays, 'day')
+  return formatter.format(diffDays, 'day')
 }
 
 function findActivityTerminalPane(

--- a/src/renderer/src/components/linear-issue-workspace-text.ts
+++ b/src/renderer/src/components/linear-issue-workspace-text.ts
@@ -1,24 +1,9 @@
 import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 import type { LinearIssue } from '../../../shared/types'
-import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
 
 export function formatLinearIssueRelativeTime(input: string): string {
-  const date = new Date(input)
-  if (Number.isNaN(date.getTime())) {
-    return 'recently'
-  }
-  const formatter = getUiRelativeTimeFormatter()
-  const diffMs = date.getTime() - Date.now()
-  const diffMinutes = Math.round(diffMs / 60_000)
-  if (Math.abs(diffMinutes) < 60) {
-    return formatter.format(diffMinutes, 'minute')
-  }
-  const diffHours = Math.round(diffMinutes / 60)
-  if (Math.abs(diffHours) < 24) {
-    return formatter.format(diffHours, 'hour')
-  }
-  const diffDays = Math.round(diffHours / 24)
-  return formatter.format(diffDays, 'day')
+  return formatUiRelativeTimeFromDate(input)
 }
 
 export function buildLinearIssueBranchName(issue: LinearIssue): string {

--- a/src/renderer/src/components/linear-issue-workspace-text.ts
+++ b/src/renderer/src/components/linear-issue-workspace-text.ts
@@ -7,17 +7,18 @@ export function formatLinearIssueRelativeTime(input: string): string {
   if (Number.isNaN(date.getTime())) {
     return 'recently'
   }
+  const formatter = getUiRelativeTimeFormatter()
   const diffMs = date.getTime() - Date.now()
   const diffMinutes = Math.round(diffMs / 60_000)
   if (Math.abs(diffMinutes) < 60) {
-    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
+    return formatter.format(diffMinutes, 'minute')
   }
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
+    return formatter.format(diffHours, 'hour')
   }
   const diffDays = Math.round(diffHours / 24)
-  return getUiRelativeTimeFormatter().format(diffDays, 'day')
+  return formatter.format(diffDays, 'day')
 }
 
 export function buildLinearIssueBranchName(issue: LinearIssue): string {

--- a/src/renderer/src/components/linear-issue-workspace-text.ts
+++ b/src/renderer/src/components/linear-issue-workspace-text.ts
@@ -1,7 +1,6 @@
 import { getLinearIssueWorkspaceName } from '../../../shared/workspace-name'
 import type { LinearIssue } from '../../../shared/types'
-
-const relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 export function formatLinearIssueRelativeTime(input: string): string {
   const date = new Date(input)
@@ -11,14 +10,14 @@ export function formatLinearIssueRelativeTime(input: string): string {
   const diffMs = date.getTime() - Date.now()
   const diffMinutes = Math.round(diffMs / 60_000)
   if (Math.abs(diffMinutes) < 60) {
-    return relativeTimeFormatter.format(diffMinutes, 'minute')
+    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
   }
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return relativeTimeFormatter.format(diffHours, 'hour')
+    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
   }
   const diffDays = Math.round(diffHours / 24)
-  return relativeTimeFormatter.format(diffDays, 'day')
+  return getUiRelativeTimeFormatter().format(diffDays, 'day')
 }
 
 export function buildLinearIssueBranchName(issue: LinearIssue): string {

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -82,6 +82,7 @@ import {
   selectCodexProviderAccount,
   watchProviderAccounts
 } from '@/runtime/runtime-provider-accounts-client'
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 export { getAccountsPaneSearchEntries }
 
@@ -93,7 +94,7 @@ function formatMiniMaxRelativeRefresh(updatedAt: number, now: number): string {
   if (diffMs < 60_000) {
     return translate('auto.components.settings.AccountsPane.3a30aaf526', 'just now')
   }
-  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  const formatter = getUiRelativeTimeFormatter()
   const minutes = Math.round(diffMs / 60_000)
   if (minutes < 60) {
     return formatter.format(-minutes, 'minute')

--- a/src/renderer/src/components/status-bar/workspace-space-format.test.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-format.test.ts
@@ -22,7 +22,9 @@ describe('workspace space format helpers', () => {
 
   it('formats scan times as relative age labels', () => {
     const now = new Date('2026-05-14T22:15:00Z').getTime()
-    const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+    // Why: scan-time labels follow the configured UI language (English in
+    // tests), not the machine's OS locale.
+    const formatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
 
     expect(getWorkspaceSpaceScanTimeLabel(now - 2 * 60_000, now)).toBe(
       formatter.format(-2, 'minute')

--- a/src/renderer/src/components/status-bar/workspace-space-format.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-format.ts
@@ -41,19 +41,20 @@ export function formatCompactCount(count: number): string {
 }
 
 export function getWorkspaceSpaceScanTimeLabel(scannedAt: number, now = Date.now()): string {
+  const formatter = getUiRelativeTimeFormatter()
   const diffMs = scannedAt - now
   const diffMinutes = Math.round(diffMs / 60_000)
   if (Math.abs(diffMinutes) < 60) {
-    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
+    return formatter.format(diffMinutes, 'minute')
   }
 
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
+    return formatter.format(diffHours, 'hour')
   }
 
   const diffDays = Math.round(diffHours / 24)
-  return getUiRelativeTimeFormatter().format(diffDays, 'day')
+  return formatter.format(diffDays, 'day')
 }
 
 export function getWorkspaceSpaceScanDateTimeLabel(scannedAt: number): string {

--- a/src/renderer/src/components/status-bar/workspace-space-format.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-format.ts
@@ -3,9 +3,9 @@ import type {
   WorkspaceSpaceScanStatus,
   WorkspaceSpaceWorktree
 } from '../../../../shared/workspace-space-types'
+import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
 
 const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
-const relativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
 const fullDateTimeFormatter = new Intl.DateTimeFormat(undefined, {
   dateStyle: 'medium',
   timeStyle: 'short'
@@ -44,16 +44,16 @@ export function getWorkspaceSpaceScanTimeLabel(scannedAt: number, now = Date.now
   const diffMs = scannedAt - now
   const diffMinutes = Math.round(diffMs / 60_000)
   if (Math.abs(diffMinutes) < 60) {
-    return relativeTimeFormatter.format(diffMinutes, 'minute')
+    return getUiRelativeTimeFormatter().format(diffMinutes, 'minute')
   }
 
   const diffHours = Math.round(diffMinutes / 60)
   if (Math.abs(diffHours) < 24) {
-    return relativeTimeFormatter.format(diffHours, 'hour')
+    return getUiRelativeTimeFormatter().format(diffHours, 'hour')
   }
 
   const diffDays = Math.round(diffHours / 24)
-  return relativeTimeFormatter.format(diffDays, 'day')
+  return getUiRelativeTimeFormatter().format(diffDays, 'day')
 }
 
 export function getWorkspaceSpaceScanDateTimeLabel(scannedAt: number): string {

--- a/src/renderer/src/components/status-bar/workspace-space-format.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-format.ts
@@ -3,7 +3,7 @@ import type {
   WorkspaceSpaceScanStatus,
   WorkspaceSpaceWorktree
 } from '../../../../shared/workspace-space-types'
-import { getUiRelativeTimeFormatter } from '@/i18n/relative-time-format'
+import { formatUiRelativeTime } from '@/i18n/relative-time-format'
 
 const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
 const fullDateTimeFormatter = new Intl.DateTimeFormat(undefined, {
@@ -41,20 +41,7 @@ export function formatCompactCount(count: number): string {
 }
 
 export function getWorkspaceSpaceScanTimeLabel(scannedAt: number, now = Date.now()): string {
-  const formatter = getUiRelativeTimeFormatter()
-  const diffMs = scannedAt - now
-  const diffMinutes = Math.round(diffMs / 60_000)
-  if (Math.abs(diffMinutes) < 60) {
-    return formatter.format(diffMinutes, 'minute')
-  }
-
-  const diffHours = Math.round(diffMinutes / 60)
-  if (Math.abs(diffHours) < 24) {
-    return formatter.format(diffHours, 'hour')
-  }
-
-  const diffDays = Math.round(diffHours / 24)
-  return formatter.format(diffDays, 'day')
+  return formatUiRelativeTime(scannedAt - now)
 }
 
 export function getWorkspaceSpaceScanDateTimeLabel(scannedAt: number): string {

--- a/src/renderer/src/i18n/relative-time-format.test.ts
+++ b/src/renderer/src/i18n/relative-time-format.test.ts
@@ -6,7 +6,11 @@ const { mockI18n } = vi.hoisted(() => ({
 
 vi.mock('./i18n', () => ({ i18n: mockI18n }))
 
-import { getUiRelativeTimeFormatter } from './relative-time-format'
+import {
+  formatUiRelativeTime,
+  formatUiRelativeTimeFromDate,
+  getUiRelativeTimeFormatter
+} from './relative-time-format'
 
 describe('getUiRelativeTimeFormatter', () => {
   it('formats with the configured UI language instead of the OS locale', () => {
@@ -32,5 +36,27 @@ describe('getUiRelativeTimeFormatter', () => {
     mockI18n.resolvedLanguage = undefined
     mockI18n.language = 'ja'
     expect(getUiRelativeTimeFormatter().format(-1, 'day')).toBe('昨日')
+  })
+})
+
+describe('formatUiRelativeTime', () => {
+  it('picks the minute/hour/day unit from the signed millisecond delta', () => {
+    mockI18n.resolvedLanguage = 'en'
+    expect(formatUiRelativeTime(-5 * 60_000)).toBe('5 minutes ago')
+    expect(formatUiRelativeTime(-3 * 3_600_000)).toBe('3 hours ago')
+    expect(formatUiRelativeTime(-2 * 86_400_000)).toBe('2 days ago')
+  })
+
+  it('formats future deltas', () => {
+    mockI18n.resolvedLanguage = 'en'
+    expect(formatUiRelativeTime(2 * 86_400_000)).toBe('in 2 days')
+  })
+})
+
+describe('formatUiRelativeTimeFromDate', () => {
+  it('returns the fallback for an invalid date', () => {
+    mockI18n.resolvedLanguage = 'en'
+    expect(formatUiRelativeTimeFromDate('not-a-date')).toBe('recently')
+    expect(formatUiRelativeTimeFromDate('not-a-date', 'unknown')).toBe('unknown')
   })
 })

--- a/src/renderer/src/i18n/relative-time-format.test.ts
+++ b/src/renderer/src/i18n/relative-time-format.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mockI18n = { language: 'en', resolvedLanguage: 'en' as string | undefined }
+
+vi.mock('./i18n', () => ({ i18n: mockI18n }))
+
+import { getUiRelativeTimeFormatter } from './relative-time-format'
+
+describe('getUiRelativeTimeFormatter', () => {
+  it('formats with the configured UI language instead of the OS locale', () => {
+    mockI18n.resolvedLanguage = 'en'
+    expect(getUiRelativeTimeFormatter().format(-1, 'day')).toBe('yesterday')
+  })
+
+  it('reuses the cached formatter while the language is unchanged', () => {
+    mockI18n.resolvedLanguage = 'en'
+    expect(getUiRelativeTimeFormatter()).toBe(getUiRelativeTimeFormatter())
+  })
+
+  it('rebuilds the formatter after a runtime language switch', () => {
+    mockI18n.resolvedLanguage = 'en'
+    const english = getUiRelativeTimeFormatter()
+    mockI18n.resolvedLanguage = 'ko'
+    const korean = getUiRelativeTimeFormatter()
+    expect(korean).not.toBe(english)
+    expect(korean.format(-1, 'day')).toBe('어제')
+  })
+
+  it('falls back to the active language when resolvedLanguage is unset', () => {
+    mockI18n.resolvedLanguage = undefined
+    mockI18n.language = 'ja'
+    expect(getUiRelativeTimeFormatter().format(-1, 'day')).toBe('昨日')
+  })
+})

--- a/src/renderer/src/i18n/relative-time-format.test.ts
+++ b/src/renderer/src/i18n/relative-time-format.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const mockI18n = { language: 'en', resolvedLanguage: 'en' as string | undefined }
+const { mockI18n } = vi.hoisted(() => ({
+  mockI18n: { language: 'en', resolvedLanguage: 'en' as string | undefined }
+}))
 
 vi.mock('./i18n', () => ({ i18n: mockI18n }))
 

--- a/src/renderer/src/i18n/relative-time-format.ts
+++ b/src/renderer/src/i18n/relative-time-format.ts
@@ -12,3 +12,28 @@ export function getUiRelativeTimeFormatter(): Intl.RelativeTimeFormat {
   }
   return cached.formatter
 }
+
+// Format a signed millisecond delta (future positive, past negative) at
+// minute/hour/day granularity in the configured UI language.
+export function formatUiRelativeTime(diffMs: number): string {
+  const formatter = getUiRelativeTimeFormatter()
+  const diffMinutes = Math.round(diffMs / 60_000)
+  if (Math.abs(diffMinutes) < 60) {
+    return formatter.format(diffMinutes, 'minute')
+  }
+  const diffHours = Math.round(diffMinutes / 60)
+  if (Math.abs(diffHours) < 24) {
+    return formatter.format(diffHours, 'hour')
+  }
+  return formatter.format(Math.round(diffHours / 24), 'day')
+}
+
+// Parse a date string and format it relative to now; returns `fallback` (default
+// "recently") when the input isn't a valid date.
+export function formatUiRelativeTimeFromDate(input: string, fallback = 'recently'): string {
+  const date = new Date(input)
+  if (Number.isNaN(date.getTime())) {
+    return fallback
+  }
+  return formatUiRelativeTime(date.getTime() - Date.now())
+}

--- a/src/renderer/src/i18n/relative-time-format.ts
+++ b/src/renderer/src/i18n/relative-time-format.ts
@@ -1,0 +1,14 @@
+import { i18n } from './i18n'
+
+// Why: relative times are language words ("2 days ago" / "그저께"), so they must
+// follow the configured UI language rather than the OS locale, and the UI
+// language can change at runtime — cache per resolved locale, not per module.
+let cached: { locale: string | undefined; formatter: Intl.RelativeTimeFormat } | null = null
+
+export function getUiRelativeTimeFormatter(): Intl.RelativeTimeFormat {
+  const locale = i18n.resolvedLanguage ?? i18n.language
+  if (!cached || cached.locale !== locale) {
+    cached = { locale, formatter: new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }) }
+  }
+  return cached.formatter
+}


### PR DESCRIPTION
## Summary

With the UI language explicitly set to English on a Korean-locale machine, relative timestamps still render in Korean — the Tasks issue list shows `그저께` / `5일 전` / `34일 전` in the UPDATED column while every other label is English.

Eight renderer call sites built `new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })`; the `undefined` locale resolves to the Chromium/OS locale, not the configured UI language. Affected surfaces: the Tasks UPDATED column, GitHub/Linear/Jira item views, PR page timestamps, account usage rows, workspace-space labels, and the activity page.

Unlike `Intl.DateTimeFormat` (where following the OS region for numeric date *shapes* is conventional — those call sites are intentionally unchanged), `RelativeTimeFormat` emits **language words** ("2 days ago" / "그저께"), so it must follow the UI language — consistent with the direction already established when #7188 made the configured UI language win over the OS language.

The fix replaces the per-module formatter constants with one shared locale-keyed cached getter (`getUiRelativeTimeFormatter`). This keeps the zero per-row allocation behavior `TaskPage` relied on, while staying correct across runtime language switches — which module-scope constants could not, since they froze the locale at import time.

## Screenshots

| Before (UI language: English) | After (UI language: English) |
| --- | --- |
| <img width="1211" height="478" alt="before" src="https://github.com/user-attachments/assets/06f1f1e6-f0f2-4f76-8abf-7d6e95d451bd" /> | <img width="1197" height="480" alt="after" src="https://github.com/user-attachments/assets/dc041d55-7c91-4250-8d2d-9e9f67eab70c" /> |


## Testing

- [x] `pnpm lint` / `pnpm typecheck`
- [x] `pnpm test` — new unit tests for the helper (UI-language formatting, cache reuse, runtime language switch, resolvedLanguage fallback) plus all touched-area suites (TaskPage/task-page-cache, AccountsPane, status-bar, activity — 350+ tests) pass; full-run failures are the workstation's pre-existing environment-dependent ones, identical on `main`
- [x] `pnpm build`
- [x] Verified in the running dev app: with UI language English on a Korean-locale macOS, the Tasks UPDATED column renders English relative times

## AI Review Report

- Swept the renderer for every `Intl.RelativeTimeFormat` construction (9 sites including two found beyond the initially reported one) and confirmed no `undefined`-locale constructions remain.
- All supported UI locales (`en`/`zh`/`ko`/`ja`/`es`) and the pseudo-localization locale (`en-XA`) are valid BCP-47 tags, so the constructor cannot throw; the "System" language resolves to a concrete locale before reaching i18n.
- One existing test compared against an OS-locale formatter (`workspace-space-format.test.ts`); it now pins `'en'`, which also makes it deterministic on non-English machines.
- Cross-platform: locale resolution is identical on macOS/Linux/Windows; no shortcuts, paths, or platform APIs touched.

## Security Audit

No new inputs, IPC, or command execution — the change only threads the app's existing i18n locale string into `Intl.RelativeTimeFormat` construction.

## Notes

`Intl.DateTimeFormat(undefined, ...)` call sites are deliberately out of scope: numeric date/time shapes following the OS region is defensible and changing them is a broader product decision. If maintainers want those unified too, the same locale-keyed getter pattern extends naturally.

## ELI5

Relative times (“5 days ago”) followed the OS language even when the UI was set to English. They now follow your configured Orca language everywhere those timestamps appear.
