### PR TITLE
fix(i18n): localize the terminal tab unread-completion aria-label

### DIFF
--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx
@@ -5,6 +5,7 @@ import type { TerminalTab, TuiAgent } from '../../../../shared/types'
 import { FilledBellIcon } from '../sidebar/WorktreeCardHelpers'
 import { ShellIcon } from './shell-icons'
 import type { TerminalTabActivityStatus } from './terminal-tab-activity-status'
+import { translate } from '@/i18n/i18n'
 
 type TerminalTabLeadingIconProps = {
   agent: TuiAgent | null
@@ -70,7 +71,10 @@ export function TerminalTabLeadingIcon({
     return (
       <span
         data-testid="tab-activity-bell"
-        aria-label="Unread agent completion"
+        aria-label={translate(
+          'auto.components.tab.bar.TerminalTabLeadingIcon.7ab2964bea',
+          'Unread agent completion'
+        )}
         className="mr-1 inline-flex shrink-0 items-center gap-1"
       >
         <FilledBellIcon className="size-3 text-amber-500 drop-shadow-sm" />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2884,6 +2884,9 @@
           },
           "TerminalTabSplitMenuSection": {
             "splitTerminal": "Split terminal"
+          },
+          "TerminalTabLeadingIcon": {
+            "7ab2964bea": "Unread agent completion"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2884,6 +2884,9 @@
           },
           "TerminalTabSplitMenuSection": {
             "splitTerminal": "Dividir terminal"
+          },
+          "TerminalTabLeadingIcon": {
+            "7ab2964bea": "Finalización de agente sin leer"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2884,6 +2884,9 @@
           },
           "TerminalTabSplitMenuSection": {
             "splitTerminal": "ターミナルを分割"
+          },
+          "TerminalTabLeadingIcon": {
+            "7ab2964bea": "未読のエージェント完了"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2884,6 +2884,9 @@
           },
           "TerminalTabSplitMenuSection": {
             "splitTerminal": "터미널 분할"
+          },
+          "TerminalTabLeadingIcon": {
+            "7ab2964bea": "읽지 않은 에이전트 완료"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2884,6 +2884,9 @@
           },
           "TerminalTabSplitMenuSection": {
             "splitTerminal": "拆分终端"
+          },
+          "TerminalTabLeadingIcon": {
+            "7ab2964bea": "未读的代理完成"
           }
         }
       },


### PR DESCRIPTION
Main currently fails `verify:localization-coverage` on `TerminalTabLeadingIcon.tsx:73` — the unread-activity bell's `aria-label="Unread agent completion"` landed hardcoded, and since `verify` doesn't run on pushes to main the break landed silently and now fails CI for every PR based on current main (reproduced on pristine `origin/main` after #8660).

Fix: route the label through `translate()` per house convention and add catalog entries for all five locales (real translations, not English placeholders — matching how sibling tab-bar labels are catalogued).

Verified on the branch: `verify:localization-catalog` (locale parity, 10,575 keys), `verify:localization-coverage` (passes with 0 allowlisted candidates), oxlint on the touched file, and the web typecheck project.