### PR TITLE
Fix Windows Codex hook shell compatibility

### DIFF
--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -13,7 +13,7 @@ import {
 import { homedir, tmpdir } from 'node:os'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { createManagedCommandMatcher, wrapPosixHookCommand } from '../agent-hooks/installer-utils'
@@ -246,11 +246,10 @@ describe('CodexHookService', () => {
     }
   )
 
-  // Why: the common case — a profile path with no spaces or cmd metacharacters
-  // — must launch the .cmd directly with no PowerShell, restoring the pre-#6078
-  // speed that Codex 0.140's synchronous "Running <event> hook" rows expose.
+  // Why: Codex can execute Windows hooks through PowerShell. A raw cmd.exe
+  // `if exist` guard fails to parse there before the managed script can run.
   it.skipIf(process.platform !== 'win32')(
-    'launches the managed .cmd directly when the profile path is cmd-safe',
+    'runs the managed command through PowerShell when the profile path is cmd-safe',
     () => {
       const status = new CodexHookService().install()
       expect(status.state).toBe('installed')
@@ -260,16 +259,30 @@ describe('CodexHookService', () => {
         readFileSync(join(managedCodexHome, 'hooks.json'), 'utf-8')
       ) as { hooks: Record<string, { hooks?: { command?: string }[] }[]> }
 
-      // Why: the temp home is normally cmd-safe; guard so a runner whose tmpdir
-      // holds an exotic character still asserts the correct (fallback) branch.
       const command = hooksConfig.hooks.Stop?.[0]?.hooks?.[0]?.command ?? ''
-      const cmdSafe = /^[A-Za-z0-9_.:\\~-]+$/.test(join(tmpHome, '.orca', 'agent-hooks'))
-      if (cmdSafe) {
-        expect(command).not.toMatch(/powershell/i)
-        expect(command).toMatch(/\\agent-hooks\\codex-hook\.cmd$/)
-      } else {
-        expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
+      expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
+
+      const cleanEnv = { ...process.env }
+      for (const key of Object.keys(cleanEnv)) {
+        if (key.startsWith('ORCA_')) {
+          delete cleanEnv[key]
+        }
       }
+
+      const powershellPath = join(
+        process.env.SystemRoot ?? 'C:\\Windows',
+        'System32',
+        'WindowsPowerShell',
+        'v1.0',
+        'powershell.exe'
+      )
+      const result = spawnSync(powershellPath, ['-NoProfile', '-Command', command], {
+        env: cleanEnv,
+        input: Buffer.from('{}')
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(0)
     }
   )
 

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -246,10 +246,11 @@ describe('CodexHookService', () => {
     }
   )
 
-  // Why: Codex can execute Windows hooks through PowerShell. A raw cmd.exe
-  // `if exist` guard fails to parse there before the managed script can run.
+  // Why: Codex executes hooks through the active turn shell, which is
+  // PowerShell for Orca's native Windows sessions, and falls back to cmd.exe
+  // when no turn shell is available. The managed command must survive both.
   it.skipIf(process.platform !== 'win32')(
-    'runs the managed command through PowerShell when the profile path is cmd-safe',
+    'runs the managed command from both Codex Windows shells',
     () => {
       const status = new CodexHookService().install()
       expect(status.state).toBe('installed')
@@ -276,13 +277,20 @@ describe('CodexHookService', () => {
         'v1.0',
         'powershell.exe'
       )
-      const result = spawnSync(powershellPath, ['-NoProfile', '-Command', command], {
-        env: cleanEnv,
-        input: Buffer.from('{}')
-      })
+      const cmdPath = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'cmd.exe')
+      const shellCases = [
+        { name: 'PowerShell', executable: powershellPath, args: ['-NoProfile', '-Command'] },
+        { name: 'cmd.exe', executable: cmdPath, args: ['/d', '/c'] }
+      ]
+      for (const shellCase of shellCases) {
+        const result = spawnSync(shellCase.executable, [...shellCase.args, command], {
+          env: cleanEnv,
+          input: Buffer.from('{}')
+        })
 
-      expect(result.error).toBeUndefined()
-      expect(result.status).toBe(0)
+        expect(result.error, `${shellCase.name} spawn error`).toBeUndefined()
+        expect(result.status, `${shellCase.name} exit code`).toBe(0)
+      }
     }
   )
 

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -246,11 +246,12 @@ describe('CodexHookService', () => {
     }
   )
 
-  // Why: Codex executes hooks through the active turn shell, which is
-  // PowerShell for Orca's native Windows sessions, and falls back to cmd.exe
-  // when no turn shell is available. The managed command must survive both.
+  // Why: Codex executes hooks through the active turn shell, which can be
+  // Windows PowerShell or PowerShell 7 for native Windows sessions, and falls
+  // back to cmd.exe when no turn shell is available. The managed command must
+  // survive every available Windows shell without requiring optional pwsh.
   it.skipIf(process.platform !== 'win32')(
-    'runs the managed command from both Codex Windows shells',
+    'runs the managed command from Codex Windows shells',
     () => {
       const status = new CodexHookService().install()
       expect(status.state).toBe('installed')
@@ -265,7 +266,7 @@ describe('CodexHookService', () => {
 
       const cleanEnv = { ...process.env }
       for (const key of Object.keys(cleanEnv)) {
-        if (key.startsWith('ORCA_')) {
+        if (key.toUpperCase().startsWith('ORCA_')) {
           delete cleanEnv[key]
         }
       }
@@ -277,11 +278,24 @@ describe('CodexHookService', () => {
         'v1.0',
         'powershell.exe'
       )
+      const pwshPath = join(
+        process.env.ProgramFiles ?? 'C:\\Program Files',
+        'PowerShell',
+        '7',
+        'pwsh.exe'
+      )
       const cmdPath = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'cmd.exe')
       const shellCases = [
         { name: 'PowerShell', executable: powershellPath, args: ['-NoProfile', '-Command'] },
         { name: 'cmd.exe', executable: cmdPath, args: ['/d', '/c'] }
       ]
+      if (existsSync(pwshPath)) {
+        shellCases.splice(1, 0, {
+          name: 'PowerShell 7',
+          executable: pwshPath,
+          args: ['-NoProfile', '-Command']
+        })
+      }
       for (const shellCase of shellCases) {
         const result = spawnSync(shellCase.executable, [...shellCase.args, command], {
           env: cleanEnv,

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -13,7 +13,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
-  wrapWindowsCmdHookCommand,
+  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -132,7 +132,7 @@ function getManagedScriptPath(): string {
 
 function getManagedCommand(scriptPath: string): string {
   return process.platform === 'win32'
-    ? wrapWindowsCmdHookCommand(scriptPath)
+    ? wrapWindowsHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
 }
 


### PR DESCRIPTION
## Summary

Fix Windows Codex lifecycle hooks failing with exit code 1 when Orca launches Codex with a PowerShell turn shell.

- replace Codex's raw cmd.exe-only hook guard with the existing encoded Windows launcher
- preserve missing-script stdin draining, absolute executable resolution, path hardening, and hook exit codes
- execute the generated command in Windows PowerShell 5.1, optional PowerShell 7, and Codex's cmd.exe fallback

Fixes #8645

## Root cause

Codex runs command hooks through the active turn shell. Orca native Windows sessions can use Windows PowerShell or PowerShell 7; when no turn shell is available, Codex falls back to cmd.exe /C. The previous raw cmd.exe if-exist expression was rejected by PowerShell before codex-hook.cmd started, so every lifecycle event exited 1 and Orca lost status updates.

Relevant upstream execution paths:

- https://github.com/openai/codex/blob/main/codex-rs/hooks/src/engine/command_runner.rs
- https://github.com/openai/codex/blob/main/codex-rs/core/src/session/mod.rs

## Screenshots

No visual change.

## Testing

- [ ] pnpm lint - full-repository lint not run locally; targeted oxlint and pre-commit oxlint passed
- [ ] pnpm typecheck - full aggregate not run; pnpm run typecheck:node passed
- [ ] pnpm test - full suite not run; focused Windows hook suites below passed
- [ ] pnpm build - not run locally
- [x] Added or updated high-quality tests that would catch regressions

Focused verification:

- src/main/codex/hook-service.test.ts: 28 passed
- generated launcher executed successfully from Windows PowerShell 5.1, installed PowerShell 7, and cmd.exe /C
- src/main/agent-hooks/installer-utils.test.ts -t wrapWindowsHookCommand: 5 passed
- real codex-cli 0.144.1 ephemeral smoke triggered SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, and Stop; the tool call completed, Codex returned DONE, exited 0, and emitted no hook failure
- loopback HTTP relay coverage preserves UTF-8 payloads and metadata containing spaces and ampersands

## AI Review Report

The AI review checked the Codex active-shell implementation, Windows command parsing, optional PowerShell 7 behavior, cmd.exe fallback behavior, arbitrary profile paths, missing-script stdin ownership, exit-code propagation, and relay payload integrity.

- Windows: verified Windows PowerShell 5.1, PowerShell 7 when installed, and cmd.exe /C
- macOS/Linux: unchanged because the implementation remains guarded by process.platform === win32; the existing POSIX launcher is untouched
- SSH/remote/WSL: unchanged; remote Codex installation continues to use wrapPosixHookCommand and codex-hook.sh
- agents/integrations: only Codex switches wrappers; other agent hook services are unchanged
- performance: restores correctness at the cost of Windows PowerShell startup for Codex lifecycle hooks; no additional process is added inside codex-hook.cmd
- UI/Electron: no renderer, shortcut, label, or Electron UI behavior changed

CodeRabbit flagged case-sensitive ORCA_ environment cleanup in the regression test. The follow-up commit now normalizes each key with toUpperCase before removal.

## Security Audit

- command execution: uses the existing encoded launcher instead of interpolating a raw cmd.exe expression across shells
- executable resolution: uses the absolute SystemRoot Windows PowerShell 5.1 path, avoiding PATH hijacking
- path handling: encoded UTF-16LE payload preserves spaces, percent signs, carets, and literal quotes in user profile paths
- optional PowerShell 7: supported as an active outer shell when present, but is not resolved from PATH and is not a runtime dependency
- stdin: missing managed scripts drain hook stdin and exit 0, avoiding EPIPE and stale-config failure loops
- auth/secrets: no auth, token, secret, IPC, dependency, or network surface changes; existing loopback relay behavior is unchanged
- rejected alternative: no trusted environment-variable command trampoline was introduced, avoiding an environment-controlled command injection surface

## Notes

- Windows PowerShell 5.1 is the inbox launcher on supported Windows desktop releases; PowerShell 7 remains optional.
- Reduced-footprint Windows images without inbox Windows PowerShell are outside Orca's native desktop path.
- Full repository CI requires upstream approval for this external-fork workflow.
- X/Twitter handle: not provided.

## ELI5

Codex lifecycle hooks on Windows failed when the turn shell was PowerShell. Hooks use a proper encoded launcher so they succeed across PowerShell and cmd.
