### PR TITLE
fix(terminal): keep pinned panes off the scrollback top across streaming snapshot restores

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -110,6 +110,11 @@ import {
   captureTerminalWriteScrollIntent,
   enforceTerminalWriteScrollIntent
 } from '@/lib/pane-manager/terminal-scroll-intent'
+import {
+  beginTerminalScrollIntentBufferRebuild,
+  endTerminalScrollIntentBufferRebuild
+} from '@/lib/pane-manager/terminal-scroll-intent-rebuild'
+import { runGuardedWriteCompletionStep } from '@/lib/pane-manager/xterm-write-callback-guard'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { makePaneKey, parseLegacyNumericPaneKey } from '../../../../shared/stable-pane-id'
 import {
@@ -263,6 +268,9 @@ const HIDDEN_OUTPUT_RESTORE_FOREGROUND_TIMEOUT_MS = 750
 // markers inside it must not re-arm restores; live bytes write through and
 // ONE deferred repaint (when the window closes) heals the visual gap.
 const HIDDEN_OUTPUT_RESTORE_FLOOD_SUPPRESS_MS = 2000
+// Fallback for the snapshot-restore scroll-intent bracket when the write
+// pipeline wedges and the FIFO completion callback never fires.
+const SNAPSHOT_RESTORE_SCROLL_INTENT_SETTLE_MS = 2000
 // Backstop for the same loop: a single in-flight restore task may re-iterate
 // (fresh-snapshot marks, unmappable slices) only this many times before it
 // abandons and lets live bytes flow.
@@ -5983,6 +5991,25 @@ export function connectPanePty(
       pendingEscapeTailAnsi?: string
     }): void {
       const scrollIntent = captureTerminalWriteScrollIntent(pane.terminal)
+      // Why: the replay below parses asynchronously. Until it has, viewportY/
+      // baseY describe a half-cleared buffer; any intent capture/enforce that
+      // races it (live stream batches, safeFit, visibility resume) latches
+      // "pinned at line 0" and parks the pane at the top of the scrollback.
+      beginTerminalScrollIntentBufferRebuild(pane.terminal)
+      let scrollIntentRestored = false
+      const finishScrollIntentRestore = (): void => {
+        if (scrollIntentRestored) {
+          return
+        }
+        scrollIntentRestored = true
+        endTerminalScrollIntentBufferRebuild(pane.terminal)
+        enforceTerminalWriteScrollIntent(pane.terminal, scrollIntent, {
+          restoreBy: 'bottomOffset'
+        })
+      }
+      // Why: if the write pipeline wedges, the FIFO completion below never
+      // fires; the rebuild bracket must not suppress intent forever.
+      setTimeout(finishScrollIntentRestore, SNAPSHOT_RESTORE_SCROLL_INTENT_SETTLE_MS)
       const colsBeforeReplay = pane.terminal.cols
       const rowsBeforeReplay = pane.terminal.rows
       const hasSnapshotDimensions =
@@ -6062,11 +6089,16 @@ export function connectPanePty(
         }
         scheduleReattachIdleAgentCursorReset()
       }
-      // Why: snapshot replay clears and rebuilds xterm state; re-apply the
-      // user's scroll intent once so hidden catch-up cannot repin the viewport.
-      // Restore by bottom offset — the rebuilt buffer renumbers every row, so
-      // the pre-replay absolute viewport line points at arbitrary content.
-      enforceTerminalWriteScrollIntent(pane.terminal, scrollIntent, { restoreBy: 'bottomOffset' })
+      // Why: re-apply the pre-replay scroll intent only after xterm has parsed
+      // the replay; an empty write's completion is FIFO-certified to run after
+      // every replay byte queued above (same contract as the replay guard).
+      try {
+        pane.terminal.write('', () =>
+          runGuardedWriteCompletionStep('snapshot-restore-scroll-intent', finishScrollIntentRestore)
+        )
+      } catch {
+        finishScrollIntentRestore()
+      }
     }
 
     function requestHiddenOutputRestoreIfNeeded(opts?: { bypassScheduler?: boolean }): boolean {

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -7,7 +7,7 @@ import {
 import { clearPendingSplitScrollRestore } from './pane-split-scroll'
 import { activateOrcaTerminalUnicodeProvider } from '../../../../shared/terminal-unicode-provider'
 import { attachTerminalMouseWheelMultiplier } from './pane-terminal-mouse-wheel'
-import { attachTerminalScrollIntentTracking } from './terminal-scroll-intent'
+import { attachTerminalScrollIntentTracking } from './terminal-scroll-intent-dom-tracking'
 import { attachDomRendererFocusClassSync } from './pane-dom-focus-class-sync'
 import { attachWebgl, cancelPendingWebglRefresh, disposeWebgl } from './pane-webgl-renderer'
 import { configureLazyArabicShapingJoiner } from './terminal-arabic-shaping-joiner'

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-dom-tracking.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-dom-tracking.ts
@@ -1,0 +1,81 @@
+import type { IDisposable } from '@xterm/xterm'
+import {
+  bindTerminalScrollIntentKey,
+  markTerminalPinnedViewport,
+  syncTerminalScrollIntentFromViewport,
+  syncTerminalScrollIntentSoon
+} from './terminal-scroll-intent'
+import type { TerminalScrollIntentKey, TerminalScrollIntentTarget } from './terminal-scroll-intent'
+
+const XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES = [
+  'xterm-viewport',
+  'xterm-scrollbar',
+  'xterm-slider'
+] as const
+const XTERM_SCROLL_INTENT_POINTER_TARGET_SELECTOR = XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES.map(
+  (className) => `.${className}`
+).join(',')
+
+function isTerminalScrollIntentPointerTarget(target: EventTarget | null): target is Element {
+  if (typeof Element === 'undefined' || !(target instanceof Element)) {
+    return false
+  }
+  // xterm's custom scrollbar uses separate thumb/track nodes from the viewport.
+  return target.closest(XTERM_SCROLL_INTENT_POINTER_TARGET_SELECTOR) !== null
+}
+
+/** Wires the user-driven scroll signals (wheel, scrollbar pointer drags) that
+ *  are allowed to change a terminal's scroll intent. Output-driven scroll
+ *  events deliberately do not update intent (see terminal-scroll-intent.ts). */
+export function attachTerminalScrollIntentTracking(
+  terminal: TerminalScrollIntentTarget,
+  host: HTMLElement,
+  intentKey?: TerminalScrollIntentKey
+): IDisposable {
+  if (!bindTerminalScrollIntentKey(terminal, intentKey)) {
+    syncTerminalScrollIntentFromViewport(terminal)
+  }
+  let pointerScrollActive = false
+
+  const onWheel = (event: WheelEvent): void => {
+    if (event.deltaY < 0) {
+      markTerminalPinnedViewport(terminal)
+      syncTerminalScrollIntentSoon(terminal, { preservePinnedAtBottom: true })
+      return
+    }
+    syncTerminalScrollIntentSoon(terminal)
+  }
+
+  const onPointerDown = (event: PointerEvent): void => {
+    pointerScrollActive = isTerminalScrollIntentPointerTarget(event.target)
+  }
+
+  const onPointerDone = (): void => {
+    if (!pointerScrollActive) {
+      return
+    }
+    pointerScrollActive = false
+    syncTerminalScrollIntentFromViewport(terminal)
+  }
+
+  const onScroll = (): void => {
+    if (pointerScrollActive) {
+      syncTerminalScrollIntentFromViewport(terminal)
+    }
+  }
+
+  host.addEventListener('wheel', onWheel, { capture: true, passive: true })
+  host.addEventListener('pointerdown', onPointerDown, true)
+  host.addEventListener('scroll', onScroll, true)
+  globalThis.addEventListener?.('pointerup', onPointerDone, true)
+  globalThis.addEventListener?.('pointercancel', onPointerDone, true)
+  return {
+    dispose: () => {
+      host.removeEventListener('wheel', onWheel, true)
+      host.removeEventListener('pointerdown', onPointerDown, true)
+      host.removeEventListener('scroll', onScroll, true)
+      globalThis.removeEventListener?.('pointerup', onPointerDone, true)
+      globalThis.removeEventListener?.('pointercancel', onPointerDone, true)
+    }
+  }
+}

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-rebuild.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-rebuild.ts
@@ -1,0 +1,23 @@
+// Why: buffer rebuilds (snapshot replay clear + rewrite) parse asynchronously.
+// Until the rebuild's bytes have parsed, viewportY/baseY describe a transient
+// half-cleared buffer; any intent capture/enforce latched from it pins the
+// terminal at line 0. Callers bracket the rebuild and re-apply intent once
+// after parse (see terminal-scroll-intent.ts).
+const terminalScrollIntentRebuilds = new WeakMap<object, number>()
+
+export function beginTerminalScrollIntentBufferRebuild(terminal: object): void {
+  terminalScrollIntentRebuilds.set(terminal, (terminalScrollIntentRebuilds.get(terminal) ?? 0) + 1)
+}
+
+export function endTerminalScrollIntentBufferRebuild(terminal: object): void {
+  const count = terminalScrollIntentRebuilds.get(terminal) ?? 0
+  if (count <= 1) {
+    terminalScrollIntentRebuilds.delete(terminal)
+    return
+  }
+  terminalScrollIntentRebuilds.set(terminal, count - 1)
+}
+
+export function isTerminalScrollIntentRebuildInFlight(terminal: object): boolean {
+  return (terminalScrollIntentRebuilds.get(terminal) ?? 0) > 0
+}

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  attachTerminalScrollIntentTracking,
   captureTerminalWriteScrollIntent,
   enforceTerminalCurrentScrollIntent,
   enforceTerminalWriteScrollIntent,
@@ -10,6 +9,11 @@ import {
   syncTerminalScrollIntentFromViewport,
   syncTerminalScrollIntentSoon
 } from './terminal-scroll-intent'
+import { attachTerminalScrollIntentTracking } from './terminal-scroll-intent-dom-tracking'
+import {
+  beginTerminalScrollIntentBufferRebuild,
+  endTerminalScrollIntentBufferRebuild
+} from './terminal-scroll-intent-rebuild'
 
 function createTerminal({
   viewportY,
@@ -468,6 +472,63 @@ describe('terminal scroll intent', () => {
 
     expect(terminal.scrollToLine).toHaveBeenLastCalledWith(150)
     expect(terminal.buffer.active.viewportY).toBe(150)
+  })
+
+  it('does not re-latch a pinned intent from a transiently shorter rebuilt buffer', () => {
+    const terminal = createTerminal({ viewportY: 248, baseY: 254 })
+    markTerminalPinnedViewport(terminal)
+    const snapshot = captureTerminalWriteScrollIntent(terminal)
+
+    // Snapshot replay cleared the buffer; enforcement races the async parse.
+    terminal.buffer.active.baseY = 0
+    terminal.buffer.active.viewportY = 0
+    enforceTerminalWriteScrollIntent(terminal, snapshot)
+
+    // The replay finishes parsing and the scrollback regrows past the pin.
+    terminal.buffer.active.baseY = 284
+    terminal.buffer.active.viewportY = 284
+    enforceTerminalCurrentScrollIntent(terminal)
+
+    expect(terminal.scrollToLine).toHaveBeenLastCalledWith(248)
+    expect(terminal.buffer.active.viewportY).toBe(248)
+  })
+
+  it('keeps a pinned intent when capture races a cleared unparsed buffer', () => {
+    const terminal = createTerminal({ viewportY: 248, baseY: 254 })
+    markTerminalPinnedViewport(terminal)
+
+    // A live write batch captures while the rebuilt buffer is still empty; the
+    // at-bottom(0/0) reading is transient and must not convert the pin.
+    terminal.buffer.active.baseY = 0
+    terminal.buffer.active.viewportY = 0
+    const snapshot = captureTerminalWriteScrollIntent(terminal)
+    expect(snapshot?.kind).toBe('pinnedViewport')
+  })
+
+  it('suspends intent capture and enforcement while a buffer rebuild is in flight', () => {
+    const terminal = createTerminal({ viewportY: 248, baseY: 254 })
+    markTerminalPinnedViewport(terminal)
+    const preReplay = captureTerminalWriteScrollIntent(terminal)
+    beginTerminalScrollIntentBufferRebuild(terminal)
+
+    terminal.buffer.active.baseY = 0
+    terminal.buffer.active.viewportY = 0
+    expect(captureTerminalWriteScrollIntent(terminal)).toBeNull()
+    enforceTerminalCurrentScrollIntent(terminal)
+
+    // A live streaming batch lands while the replay is partially parsed.
+    terminal.buffer.active.baseY = 284
+    terminal.buffer.active.viewportY = 0
+    enforceTerminalWriteScrollIntent(terminal, preReplay)
+    expect(terminal.scrollToLine).not.toHaveBeenCalled()
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled()
+
+    terminal.buffer.active.viewportY = 284
+    endTerminalScrollIntentBufferRebuild(terminal)
+    enforceTerminalWriteScrollIntent(terminal, preReplay, { restoreBy: 'bottomOffset' })
+    expect(terminal.scrollToLine).toHaveBeenLastCalledWith(278)
+    expect(terminal.buffer.active.viewportY).toBe(278)
+    expect(getTerminalScrollIntentKind(terminal)).toBe('pinnedViewport')
   })
 
   it('supports bottom-offset restore for buffer-rebuild write paths', () => {

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -1,10 +1,10 @@
-import type { IDisposable } from '@xterm/xterm'
+import { isTerminalScrollIntentRebuildInFlight } from './terminal-scroll-intent-rebuild'
 
 type TerminalScrollIntentKind = 'followOutput' | 'pinnedViewport'
 
 type BufferType = 'normal' | 'alternate'
 
-type TerminalScrollIntentTarget = {
+export type TerminalScrollIntentTarget = {
   buffer?: {
     active?: {
       type?: string
@@ -16,7 +16,7 @@ type TerminalScrollIntentTarget = {
   scrollToLine?: (line: number) => void
 }
 
-type TerminalScrollIntentKey = string
+export type TerminalScrollIntentKey = string
 
 type TerminalScrollIntent = {
   kind: TerminalScrollIntentKind
@@ -50,14 +50,6 @@ const terminalScrollIntentKeyByTerminal = new WeakMap<
 const terminalScrollIntentByKey = new Map<TerminalScrollIntentKey, TerminalScrollIntent>()
 
 const BOTTOM_TOLERANCE_ROWS = 1
-const XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES = [
-  'xterm-viewport',
-  'xterm-scrollbar',
-  'xterm-slider'
-] as const
-const XTERM_SCROLL_INTENT_POINTER_TARGET_SELECTOR = XTERM_SCROLL_INTENT_POINTER_TARGET_CLASSES.map(
-  (className) => `.${className}`
-).join(',')
 
 function readBufferSnapshot(
   terminal: TerminalScrollIntentTarget
@@ -105,7 +97,7 @@ function readStoredIntent(terminal: TerminalScrollIntentTarget): TerminalScrollI
   return key ? terminalScrollIntentByKey.get(key) : undefined
 }
 
-function bindTerminalScrollIntentKey(
+export function bindTerminalScrollIntentKey(
   terminal: TerminalScrollIntentTarget,
   key: TerminalScrollIntentKey | undefined
 ): TerminalScrollIntent | undefined {
@@ -134,14 +126,6 @@ function safeScrollCall(fn: () => void): boolean {
     }
     throw err
   }
-}
-
-function isTerminalScrollIntentPointerTarget(target: EventTarget | null): target is Element {
-  if (typeof Element === 'undefined' || !(target instanceof Element)) {
-    return false
-  }
-  // xterm's custom scrollbar uses separate thumb/track nodes from the viewport.
-  return target.closest(XTERM_SCROLL_INTENT_POINTER_TARGET_SELECTOR) !== null
 }
 
 export function markTerminalFollowOutput(terminal: TerminalScrollIntentTarget): void {
@@ -212,6 +196,9 @@ export function getTerminalScrollIntentKind(
 export function captureTerminalWriteScrollIntent(
   terminal: TerminalScrollIntentTarget
 ): TerminalScrollIntentWriteSnapshot | null {
+  if (isTerminalScrollIntentRebuildInFlight(terminal)) {
+    return null
+  }
   const snapshot = readBufferSnapshot(terminal)
   if (!snapshot) {
     return null
@@ -222,8 +209,14 @@ export function captureTerminalWriteScrollIntent(
     (isAtBottom(snapshot.viewportY, snapshot.baseY) ? 'followOutput' : 'pinnedViewport')
   // Why: a pinned intent whose live viewport still sits at the bottom is a
   // phantom pin (the user's scroll never detached the viewport). Enforcing it
-  // would freeze the terminal at the current line on every write batch.
-  if (kind === 'pinnedViewport' && isAtBottom(snapshot.viewportY, snapshot.baseY)) {
+  // would freeze the terminal at the current line on every write batch. Only
+  // trust the at-bottom reading when the scrollback is at least as long as the
+  // pin's — a shorter one is a cleared buffer that has not finished parsing.
+  if (
+    kind === 'pinnedViewport' &&
+    isAtBottom(snapshot.viewportY, snapshot.baseY) &&
+    (!existing || snapshot.baseY >= existing.baseY)
+  ) {
     kind = 'followOutput'
   }
   return {
@@ -239,7 +232,7 @@ export function enforceTerminalWriteScrollIntent(
   snapshot: TerminalScrollIntentWriteSnapshot | null,
   options: TerminalScrollIntentEnforceOptions = {}
 ): void {
-  if (!snapshot) {
+  if (!snapshot || isTerminalScrollIntentRebuildInFlight(terminal)) {
     return
   }
   const current = readBufferSnapshot(terminal)
@@ -260,10 +253,20 @@ export function enforceTerminalWriteScrollIntent(
   if (current.viewportY !== targetY) {
     safeScrollCall(() => terminal.scrollToLine?.(targetY))
   }
+  const existing = readStoredIntent(terminal)
+  // Why: a scrollback shorter than the stored pin means the buffer is being
+  // rebuilt; re-latching from it would overwrite the durable line with the
+  // cleared buffer's line 0.
+  if (existing?.kind === 'pinnedViewport' && current.baseY < existing.baseY) {
+    return
+  }
   writeIntent(terminal, 'pinnedViewport')
 }
 
 export function enforceTerminalCurrentScrollIntent(terminal: TerminalScrollIntentTarget): void {
+  if (isTerminalScrollIntentRebuildInFlight(terminal)) {
+    return
+  }
   const existing = readStoredIntent(terminal)
   if (!existing) {
     enforceTerminalWriteScrollIntent(terminal, captureTerminalWriteScrollIntent(terminal))
@@ -288,57 +291,4 @@ export function enforceTerminalCurrentScrollIntent(terminal: TerminalScrollInten
       ? 'bottomOffset'
       : 'viewportLine'
   enforceTerminalWriteScrollIntent(terminal, snapshot, { restoreBy })
-}
-
-export function attachTerminalScrollIntentTracking(
-  terminal: TerminalScrollIntentTarget,
-  host: HTMLElement,
-  intentKey?: TerminalScrollIntentKey
-): IDisposable {
-  if (!bindTerminalScrollIntentKey(terminal, intentKey)) {
-    syncTerminalScrollIntentFromViewport(terminal)
-  }
-  let pointerScrollActive = false
-
-  const onWheel = (event: WheelEvent): void => {
-    if (event.deltaY < 0) {
-      markTerminalPinnedViewport(terminal)
-      syncTerminalScrollIntentSoon(terminal, { preservePinnedAtBottom: true })
-      return
-    }
-    syncTerminalScrollIntentSoon(terminal)
-  }
-
-  const onPointerDown = (event: PointerEvent): void => {
-    pointerScrollActive = isTerminalScrollIntentPointerTarget(event.target)
-  }
-
-  const onPointerDone = (): void => {
-    if (!pointerScrollActive) {
-      return
-    }
-    pointerScrollActive = false
-    syncTerminalScrollIntentFromViewport(terminal)
-  }
-
-  const onScroll = (): void => {
-    if (pointerScrollActive) {
-      syncTerminalScrollIntentFromViewport(terminal)
-    }
-  }
-
-  host.addEventListener('wheel', onWheel, { capture: true, passive: true })
-  host.addEventListener('pointerdown', onPointerDown, true)
-  host.addEventListener('scroll', onScroll, true)
-  globalThis.addEventListener?.('pointerup', onPointerDone, true)
-  globalThis.addEventListener?.('pointercancel', onPointerDone, true)
-  return {
-    dispose: () => {
-      host.removeEventListener('wheel', onWheel, true)
-      host.removeEventListener('pointerdown', onPointerDown, true)
-      host.removeEventListener('scroll', onScroll, true)
-      globalThis.removeEventListener?.('pointerup', onPointerDone, true)
-      globalThis.removeEventListener?.('pointercancel', onPointerDone, true)
-    }
-  }
 }

--- a/tests/e2e/terminal-pinned-viewport-streaming-switch.spec.ts
+++ b/tests/e2e/terminal-pinned-viewport-streaming-switch.spec.ts
@@ -1,0 +1,206 @@
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getAllWorktreeIds,
+  switchToWorktree,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  getTerminalContent,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { nodeTerminalCommand } from './terminal-node-command'
+import { waitForPtyShellEcho } from './terminal-pty-readiness'
+
+// A Codex-like agent: pre-fills scrollback, then keeps streaming — commits a
+// row and redraws a synchronized-output "Working…" status frame every tick.
+// The stream continues while the pane is hidden, which is what routes the
+// return through the hidden-output snapshot restore.
+function streamingAgentFixtureScript(runId: string): string {
+  return `
+async function writeStdout(chunk) {
+  await new Promise((resolve) => process.stdout.write(chunk, resolve))
+}
+let row = 0
+let pre = ''
+for (; row < 300; row += 1) {
+  pre += 'STREAMING_SWITCH_${runId}_ROW_' + String(row).padStart(4, '0') + '\\n'
+}
+await writeStdout(pre + 'STREAMING_SWITCH_${runId}_PRESTREAM_DONE\\n')
+const spinner = ['|', '/', '-', '\\\\']
+for (let tick = 0; tick < 800; tick += 1) {
+  let frame = '\\x1b[?2026h'
+  if (tick % 3 === 0) {
+    frame += '\\r\\x1b[2KSTREAMING_SWITCH_${runId}_ROW_' + String(row).padStart(4, '0') + '\\n'
+    row += 1
+  }
+  frame += '\\r\\x1b[2KWorking… ' + spinner[tick % 4] + ' tick=' + tick + '\\x1b[?2026l'
+  await writeStdout(frame)
+  await new Promise((resolve) => setTimeout(resolve, 50))
+}
+`
+}
+
+async function closeFeatureTips(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = window.__store
+    store?.getState().markFeatureTipsSeen(['orca-cli', 'cmd-j-palette', 'voice-dictation'])
+    if (store?.getState().activeModal === 'feature-tips') {
+      store.getState().closeModal()
+    }
+  })
+}
+
+async function pinActiveTerminalNearBottom(page: Page): Promise<{
+  tabId: string
+  targetViewportY: number
+  baseY: number
+}> {
+  return page.evaluate(() => {
+    const store = window.__store
+    const state = store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!tabId || !pane) {
+      throw new Error('Active terminal pane unavailable')
+    }
+    const target = pane.container.querySelector<HTMLElement>('.xterm') ?? pane.container
+    target.dispatchEvent(
+      new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+        deltaY: -240
+      })
+    )
+    const buffer = pane.terminal.buffer.active
+    const targetViewportY = Math.max(0, buffer.baseY - 6)
+    pane.terminal.scrollToLine(targetViewportY)
+    pane.container
+      .querySelector<HTMLElement>('.xterm-viewport')
+      ?.dispatchEvent(new Event('scroll', { bubbles: true }))
+    return { tabId, targetViewportY, baseY: buffer.baseY }
+  })
+}
+
+async function readSettledViewport(
+  page: Page,
+  tabId: string
+): Promise<{ viewportY: number; baseY: number }> {
+  // Wait until the replay has actually parsed (scrollback regrew) and the
+  // viewport stopped moving, then report where it settled.
+  let last: { viewportY: number; baseY: number } | null = null
+  let stableCount = 0
+  await expect
+    .poll(
+      async () => {
+        const current = await page.evaluate((tabId) => {
+          const manager = window.__paneManagers?.get(tabId)
+          const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+          const buffer = pane?.terminal?.buffer?.active
+          return buffer ? { viewportY: buffer.viewportY, baseY: buffer.baseY } : null
+        }, tabId)
+        if (!current || current.baseY < 100) {
+          stableCount = 0
+          last = current
+          return false
+        }
+        if (last && current.viewportY === last.viewportY) {
+          stableCount += 1
+        } else {
+          stableCount = 0
+        }
+        last = current
+        return stableCount >= 3
+      },
+      {
+        timeout: 20_000,
+        intervals: [250],
+        message: 'terminal viewport did not settle after returning to the streaming worktree'
+      }
+    )
+    .toBe(true)
+  if (!last) {
+    throw new Error('viewport settle poll finished without a sample')
+  }
+  return last
+}
+
+test.describe('Terminal pinned viewport with streaming agent across worktree switch', () => {
+  test('returning to a pinned pane with an active stream does not land at the top', async ({
+    orcaPage,
+    testRepoPath
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await closeFeatureTips(orcaPage)
+    const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+    const secondWorktreeId = (await getAllWorktreeIds(orcaPage)).find(
+      (id) => id !== firstWorktreeId
+    )
+    test.skip(!secondWorktreeId, 'streaming pinned repro needs the seeded secondary worktree')
+    if (!secondWorktreeId) {
+      return
+    }
+
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    await waitForPtyShellEcho(orcaPage, ptyId, 15_000)
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-streaming-switch-${runId}.mjs`)
+    writeFileSync(scriptPath, streamingAgentFixtureScript(runId))
+
+    try {
+      await sendToTerminal(orcaPage, ptyId, `${nodeTerminalCommand([scriptPath])}\r`)
+      await expect
+        .poll(() => getTerminalContent(orcaPage, 30_000), {
+          timeout: 15_000,
+          message: 'streaming fixture did not reach terminal scrollback'
+        })
+        .toContain(`STREAMING_SWITCH_${runId}_PRESTREAM_DONE`)
+
+      const pinned = await pinActiveTerminalNearBottom(orcaPage)
+      expect(pinned.baseY).toBeGreaterThan(100)
+      await orcaPage.waitForTimeout(150)
+
+      // Stream continues while hidden; hidden byte drops mark the pane for a
+      // snapshot restore on return.
+      await switchToWorktree(orcaPage, secondWorktreeId)
+      await waitForActiveTerminalManager(orcaPage, 30_000)
+      await orcaPage.waitForTimeout(3_000)
+
+      await switchToWorktree(orcaPage, firstWorktreeId)
+      await ensureTerminalVisible(orcaPage)
+      await waitForActiveTerminalManager(orcaPage, 30_000)
+
+      const settled = await readSettledViewport(orcaPage, pinned.tabId)
+      const bottomDistance = settled.baseY - settled.viewportY
+      // The user pinned six rows above the bottom. A faithful restore keeps
+      // them near the pin; the bug clamps to the very top of the scrollback.
+      expect(
+        settled.viewportY,
+        `settled at viewportY=${settled.viewportY} baseY=${settled.baseY} (pinned ${JSON.stringify(pinned)})`
+      ).toBeGreaterThan(20)
+      expect(
+        bottomDistance,
+        `settled ${bottomDistance} rows above the bottom (pinned 6 rows above)`
+      ).toBeLessThan(80)
+    } finally {
+      rmSync(scriptPath, { force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Symptom (reported on v1.4.139-rc.2, which includes #8625)

With a Codex agent actively running ("Working…" animation), pin the terminal slightly above the bottom, switch to another workspace, then return: the terminal is scrolled to the **very top** of the scrollback.

## Why #8625 doesn't cover it

A pane whose agent keeps streaming while hidden comes back through the hidden-output **snapshot restore** (`applyMainBufferSnapshot`): the xterm buffer is discarded, cleared (`2J/3J/H`), and rewritten from the serialized snapshot. Those bytes parse **asynchronously** — but several scroll-intent actors run against the half-parsed buffer in that window:

- the restore's own synchronous `enforceTerminalWriteScrollIntent` at the end of `applyMainBufferSnapshot`,
- the `safeFit` inside it (captures + enforces internally),
- visibility-resume's `enforceTerminalCurrentScrollIntent`,
- and — decisive in the streaming case — **live PTY write batches that keep arriving during the replay**, each doing capture→enforce.

Any of them that reads the buffer mid-parse sees `viewportY=0` with a partially regrown `baseY`, re-latches the intent as "pinned at line 0", and every subsequent batch holds the viewport there. Deterministic e2e on current main settles at `viewportY=0, baseY=284` after pinning at 248.

## Fix

1. **Rebuild bracket** (`terminal-scroll-intent-rebuild.ts`): `applyMainBufferSnapshot` marks the terminal's buffer rebuild in flight. While marked, `captureTerminalWriteScrollIntent` returns null and enforcement no-ops — no racer (stream batches, safeFit, visibility resume) can latch transient coordinates.
2. **Post-parse restore**: the pre-replay intent is applied exactly once, from an empty-write completion callback that xterm's FIFO write queue certifies runs after every replay byte has parsed (same contract as the replay guard), restoring pinned panes by bottom offset. A 2s timeout fallback ends the bracket if the write pipeline wedges.
3. **Defense-in-depth** for unbracketed rebuild paths: enforcement no longer re-latches a pinned intent from a scrollback shorter than the stored pin's (mirrors the existing sync-side guard), and capture only normalizes pinned-at-bottom→follow when the scrollback is at least as long as the pin's — so #8625's phantom-pin healing can't misfire against a cleared buffer.
4. `terminal-scroll-intent.ts` crossed the 300-line limit; the DOM wheel/pointer tracking moved to `terminal-scroll-intent-dom-tracking.ts` (no `max-lines` disables per AGENTS.md).

## Deterministic reproduction

New e2e `terminal-pinned-viewport-streaming-switch.spec.ts` + inline fixture: 300 rows of scrollback, then a continuous synchronized-output "Working…" stream (frame every 50ms) that keeps running while hidden; pin 6 rows above bottom, switch worktree, wait 3s, return, wait for the viewport to settle.
- **Before this fix (current main): settles at viewportY=0 (top), baseY=284 — fails.**
- **After: restores near the pin — passes.**

Three new unit tests cover the same shapes at module level (transient-shrink re-latch, capture racing a cleared buffer, full suspend/restore bracket); all were red before the fix.

## Verification

- pane-manager + terminal-pane unit suites: 2,504 tests pass (two consecutive clean runs).
- e2e: new repro spec + #8625's `terminal-scroll-intent-follow.spec.ts`, `terminal-pinned-viewport-worktree-switch.spec.ts`, TUI wheel reports/drain, long-table scroll restore — all pass.
- `pnpm typecheck` passes. `pnpm lint`'s only failure is a pre-existing warning in `src/main/browser/agent-browser-bridge.test.ts` (untouched by this PR).

Made with [Orca](https://github.com/stablyai/orca) 🐋
