### PR TITLE
feat(status-bar): show Cursor included, Auto, and On-demand usage

### DIFF
--- a/src/main/ipc/rate-limits.ts
+++ b/src/main/ipc/rate-limits.ts
@@ -25,4 +25,5 @@ export function registerRateLimitHandlers(rateLimits: RateLimitService): void {
   )
   ipcMain.handle('rateLimits:refreshMiniMax', () => rateLimits.refresh())
   ipcMain.handle('rateLimits:refreshGrok', () => rateLimits.refreshGrok())
+  ipcMain.handle('rateLimits:refreshCursor', () => rateLimits.refreshCursor())
 }

--- a/src/main/rate-limits/cursor-auth.test.ts
+++ b/src/main/rate-limits/cursor-auth.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getCursorStateDbPath, hasCursorAuthSession, readCursorAuthSession } from './cursor-auth'
+
+function createStateDb(dir: string, entries: Record<string, string>): string {
+  const dbPath = join(dir, 'state.vscdb')
+  const db = new DatabaseSync(dbPath)
+  db.exec('CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)')
+  const insert = db.prepare('INSERT INTO ItemTable (key, value) VALUES (?, ?)')
+  for (const [key, value] of Object.entries(entries)) {
+    insert.run(key, value)
+  }
+  db.close()
+  return dbPath
+}
+
+describe('cursor-auth', () => {
+  const dirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  function tempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-cursor-auth-test-'))
+    dirs.push(dir)
+    return dir
+  }
+
+  it('resolves a platform-specific state.vscdb path under the home Cursor install', () => {
+    const path = getCursorStateDbPath()
+    expect(path.endsWith(join('Cursor', 'User', 'globalStorage', 'state.vscdb'))).toBe(true)
+  })
+
+  it('returns missing when the database file is absent', () => {
+    expect(readCursorAuthSession({ stateDbPath: join(tempDir(), 'missing.vscdb') })).toEqual({
+      status: 'missing'
+    })
+  })
+
+  it('returns missing when the access token key is empty', () => {
+    const dbPath = createStateDb(tempDir(), {
+      'cursorAuth/accessToken': '',
+      'cursorAuth/cachedEmail': 'dev@example.com'
+    })
+    expect(readCursorAuthSession({ stateDbPath: dbPath })).toEqual({ status: 'missing' })
+    expect(hasCursorAuthSession({ stateDbPath: dbPath })).toBe(false)
+  })
+
+  it('reads access token, email, membership, and refresh token', () => {
+    const dbPath = createStateDb(tempDir(), {
+      'cursorAuth/accessToken': 'access-token',
+      'cursorAuth/refreshToken': 'refresh-token',
+      'cursorAuth/cachedEmail': 'dev@example.com',
+      'cursorAuth/stripeMembershipType': 'pro'
+    })
+    expect(readCursorAuthSession({ stateDbPath: dbPath })).toEqual({
+      status: 'ok',
+      session: {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        email: 'dev@example.com',
+        membershipType: 'pro'
+      }
+    })
+    expect(hasCursorAuthSession({ stateDbPath: dbPath })).toBe(true)
+  })
+
+  it('redacts filesystem details when the database cannot be opened', () => {
+    const dir = tempDir()
+    const badPath = join(dir, 'not-a-db.vscdb')
+    writeFileSync(badPath, 'not sqlite')
+    expect(readCursorAuthSession({ stateDbPath: badPath, tempRoot: dir })).toEqual({
+      status: 'error',
+      error: 'Unable to read Cursor auth'
+    })
+  })
+})

--- a/src/main/rate-limits/cursor-auth.ts
+++ b/src/main/rate-limits/cursor-auth.ts
@@ -1,0 +1,152 @@
+import { copyFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+const ACCESS_TOKEN_KEY = 'cursorAuth/accessToken'
+const EMAIL_KEY = 'cursorAuth/cachedEmail'
+const MEMBERSHIP_KEY = 'cursorAuth/stripeMembershipType'
+const REFRESH_TOKEN_KEY = 'cursorAuth/refreshToken'
+
+export type CursorAuthSession = {
+  accessToken: string
+  refreshToken: string | null
+  email: string | null
+  membershipType: string | null
+}
+
+export type CursorAuthReadResult =
+  | { status: 'missing' }
+  | { status: 'error'; error: string }
+  | { status: 'ok'; session: CursorAuthSession }
+
+export type CursorAuthPathOptions = {
+  /** Override the state.vscdb path (tests). */
+  stateDbPath?: string
+  /** Override temp root used when copying a locked DB (tests). */
+  tempRoot?: string
+}
+
+// Why: Cursor stores OAuth tokens in the IDE globalStorage SQLite DB, not a
+// plain JSON file like Grok — path must match each platform's Cursor install.
+export function getCursorStateDbPath(): string {
+  const home = homedir()
+  if (process.platform === 'darwin') {
+    return join(
+      home,
+      'Library',
+      'Application Support',
+      'Cursor',
+      'User',
+      'globalStorage',
+      'state.vscdb'
+    )
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || join(home, 'AppData', 'Roaming')
+    return join(appData, 'Cursor', 'User', 'globalStorage', 'state.vscdb')
+  }
+  return join(home, '.config', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
+}
+
+function getCursorAuthReadError(_err: unknown): string {
+  // Why: filesystem/sqlite errors often include the full home path; keep the
+  // status-bar error free of usernames.
+  return 'Unable to read Cursor auth'
+}
+
+function readItemValue(db: DatabaseSync, key: string): string | null {
+  const row = db.prepare('SELECT value FROM ItemTable WHERE key = ?').get(key) as
+    | { value: string | Uint8Array | null }
+    | undefined
+  if (!row || row.value == null) {
+    return null
+  }
+  if (typeof row.value === 'string') {
+    return row.value
+  }
+  if (row.value instanceof Uint8Array) {
+    return Buffer.from(row.value).toString('utf8')
+  }
+  return String(row.value)
+}
+
+function readSessionFromDb(dbPath: string): CursorAuthReadResult {
+  const db = new DatabaseSync(dbPath, { readOnly: true })
+  try {
+    const accessToken = readItemValue(db, ACCESS_TOKEN_KEY)?.trim() ?? ''
+    if (!accessToken) {
+      // Why: logged-out Cursor still has the DB; treat as unsigned-in, not error.
+      return { status: 'missing' }
+    }
+    const refreshToken = readItemValue(db, REFRESH_TOKEN_KEY)?.trim() || null
+    const email = readItemValue(db, EMAIL_KEY)?.trim() || null
+    const membershipType = readItemValue(db, MEMBERSHIP_KEY)?.trim() || null
+    return {
+      status: 'ok',
+      session: {
+        accessToken,
+        refreshToken,
+        email,
+        membershipType
+      }
+    }
+  } finally {
+    db.close()
+  }
+}
+
+function removeSnapshotDir(path: string): void {
+  rmSync(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
+}
+
+function readSessionViaTempCopy(
+  sourcePath: string,
+  tempRoot: string | undefined
+): CursorAuthReadResult {
+  const snapshotDir = mkdtempSync(join(tempRoot ?? tmpdir(), 'orca-cursor-auth-'))
+  const copyPath = join(snapshotDir, 'state.vscdb')
+  try {
+    copyFileSync(sourcePath, copyPath)
+    // Why: WAL sidecars may exist while Cursor is open; best-effort copy keeps
+    // a consistent view without failing when they are locked/missing.
+    for (const suffix of ['-wal', '-shm'] as const) {
+      const side = `${sourcePath}${suffix}`
+      if (existsSync(side)) {
+        try {
+          copyFileSync(side, `${copyPath}${suffix}`)
+        } catch {
+          /* ignore locked/missing sidecars */
+        }
+      }
+    }
+    return readSessionFromDb(copyPath)
+  } finally {
+    removeSnapshotDir(snapshotDir)
+  }
+}
+
+export function readCursorAuthSession(options: CursorAuthPathOptions = {}): CursorAuthReadResult {
+  const path = options.stateDbPath ?? getCursorStateDbPath()
+  if (!existsSync(path)) {
+    return { status: 'missing' }
+  }
+  try {
+    return readSessionFromDb(path)
+  } catch (directErr) {
+    // Why: Windows often locks state.vscdb while Cursor is running; a temp copy
+    // is the durable fallback used elsewhere for Chromium cookie DBs.
+    try {
+      return readSessionViaTempCopy(path, options.tempRoot)
+    } catch {
+      return {
+        status: 'error',
+        error: getCursorAuthReadError(directErr)
+      }
+    }
+  }
+}
+
+export function hasCursorAuthSession(options?: CursorAuthPathOptions): boolean {
+  return readCursorAuthSession(options).status === 'ok'
+}

--- a/src/main/rate-limits/cursor-fetcher.test.ts
+++ b/src/main/rate-limits/cursor-fetcher.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+const readCursorAuthSessionMock = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock }
+}))
+
+vi.mock('./cursor-auth', () => ({
+  readCursorAuthSession: readCursorAuthSessionMock
+}))
+
+import {
+  CURSOR_BUCKET_AUTO,
+  CURSOR_BUCKET_INCLUDED,
+  CURSOR_BUCKET_ON_DEMAND,
+  fetchCursorRateLimits
+} from './cursor-fetcher'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body
+  } as Response
+}
+
+const USAGE_RESPONSE = {
+  billingCycleStart: '1783588639000',
+  billingCycleEnd: '1786267039000',
+  planUsage: {
+    totalSpend: 4651,
+    includedSpend: 2000,
+    limit: 2000,
+    autoPercentUsed: 31,
+    apiPercentUsed: 0,
+    totalPercentUsed: 23.85
+  },
+  spendLimitUsage: {
+    individualLimit: 1000,
+    individualRemaining: 750,
+    limitType: 'user'
+  },
+  displayMessage: "You've used 67% of your included usage",
+  autoModelSelectedDisplayMessage: "You've used 24% of your included total usage",
+  namedModelSelectedDisplayMessage: "You've used 0% of your included API usage"
+}
+
+function signedInAuth() {
+  return {
+    status: 'ok' as const,
+    session: {
+      accessToken: 'access-token',
+      refreshToken: null,
+      email: 'dev@example.com',
+      membershipType: 'pro'
+    }
+  }
+}
+
+describe('fetchCursorRateLimits', () => {
+  beforeEach(() => {
+    netFetchMock.mockReset()
+    readCursorAuthSessionMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns unavailable when not signed in', async () => {
+    readCursorAuthSessionMock.mockReturnValue({ status: 'missing' })
+    const result = await fetchCursorRateLimits()
+    expect(result.provider).toBe('cursor')
+    expect(result.status).toBe('unavailable')
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps Included, Auto, and On-demand buckets from period usage', async () => {
+    readCursorAuthSessionMock.mockReturnValue(signedInAuth())
+    netFetchMock.mockResolvedValueOnce(jsonResponse(USAGE_RESPONSE))
+
+    const result = await fetchCursorRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly).toBeNull()
+    expect(result.session).toBeNull()
+    expect(result.buckets).toEqual([
+      expect.objectContaining({
+        name: CURSOR_BUCKET_INCLUDED,
+        usedPercent: 23.85,
+        windowMinutes: 44_640,
+        resetsAt: 1_786_267_039_000
+      }),
+      expect.objectContaining({
+        name: CURSOR_BUCKET_AUTO,
+        usedPercent: 31,
+        windowMinutes: 44_640
+      }),
+      expect.objectContaining({
+        name: CURSOR_BUCKET_ON_DEMAND,
+        usedPercent: 25,
+        windowMinutes: 44_640
+      })
+    ])
+    expect(result.usageMetadata).toEqual({
+      source: 'oauth',
+      authProvenance: 'dev@example.com (pro)'
+    })
+  })
+
+  it('prefers totalPercentUsed over displayMessage for Included', async () => {
+    readCursorAuthSessionMock.mockReturnValue(signedInAuth())
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        planUsage: { totalPercentUsed: 29, autoPercentUsed: 37, apiPercentUsed: 0 },
+        displayMessage: "You've used 67% of your included usage"
+      })
+    )
+
+    const result = await fetchCursorRateLimits()
+    expect(result.buckets?.[0]).toEqual(
+      expect.objectContaining({ name: CURSOR_BUCKET_INCLUDED, usedPercent: 29 })
+    )
+  })
+
+  it('ignores displayMessage when it is the only Included signal', async () => {
+    readCursorAuthSessionMock.mockReturnValue(signedInAuth())
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        planUsage: { autoPercentUsed: 10, apiPercentUsed: 3 },
+        displayMessage: "You've used 67% of your included usage"
+      })
+    )
+
+    const result = await fetchCursorRateLimits()
+    expect(result.buckets).toEqual([
+      expect.objectContaining({ name: CURSOR_BUCKET_AUTO, usedPercent: 10 })
+    ])
+  })
+
+  it('does not treat apiPercentUsed as On-demand', async () => {
+    readCursorAuthSessionMock.mockReturnValue(signedInAuth())
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        planUsage: { totalPercentUsed: 20, autoPercentUsed: 15, apiPercentUsed: 90 }
+      })
+    )
+
+    const result = await fetchCursorRateLimits()
+    expect(result.buckets?.some((bucket) => bucket.name === CURSOR_BUCKET_ON_DEMAND)).toBe(false)
+    expect(result.buckets).toEqual([
+      expect.objectContaining({ name: CURSOR_BUCKET_INCLUDED, usedPercent: 20 }),
+      expect.objectContaining({ name: CURSOR_BUCKET_AUTO, usedPercent: 15 })
+    ])
+  })
+
+  it('falls back to includedSpend/limit for Included when totalPercentUsed is absent', async () => {
+    readCursorAuthSessionMock.mockReturnValue({
+      status: 'ok',
+      session: {
+        accessToken: 'access-token',
+        refreshToken: null,
+        email: null,
+        membershipType: null
+      }
+    })
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        billingCycleStart: 1_000_000,
+        billingCycleEnd: 1_000_000 + 30 * 24 * 60 * 60 * 1000,
+        planUsage: { includedSpend: 500, limit: 2000, autoPercentUsed: 10 }
+      })
+    )
+
+    const result = await fetchCursorRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.buckets?.[0]).toEqual(
+      expect.objectContaining({ name: CURSOR_BUCKET_INCLUDED, usedPercent: 25 })
+    )
+    expect(result.buckets?.[1]).toEqual(
+      expect.objectContaining({ name: CURSOR_BUCKET_AUTO, usedPercent: 10 })
+    )
+    expect(result.usageMetadata?.authProvenance).toBe('Cursor account')
+  })
+
+  it('omits On-demand when spendLimitUsage is absent', async () => {
+    readCursorAuthSessionMock.mockReturnValue(signedInAuth())
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        planUsage: { totalPercentUsed: 12.5, autoPercentUsed: 8, apiPercentUsed: 3 }
+      })
+    )
+
+    const result = await fetchCursorRateLimits()
+    expect(result.buckets).toEqual([
+      expect.objectContaining({ name: CURSOR_BUCKET_INCLUDED, usedPercent: 12.5 }),
+      expect.objectContaining({ name: CURSOR_BUCKET_AUTO, usedPercent: 8 })
+    ])
+  })
+
+  it('prefers individualUsed over remaining for On-demand', async () => {
+    readCursorAuthSessionMock.mockReturnValue(signedInAuth())
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        planUsage: { totalPercentUsed: 10, autoPercentUsed: 5 },
+        spendLimitUsage: {
+          individualLimit: 1000,
+          individualUsed: 250,
+          individualRemaining: 800
+        }
+      })
+    )
+
+    const result = await fetchCursorRateLimits()
+    expect(result.buckets?.[2]).toEqual(
+      expect.objectContaining({ name: CURSOR_BUCKET_ON_DEMAND, usedPercent: 25 })
+    )
+  })
+
+  it('returns expired-session error on HTTP 401', async () => {
+    readCursorAuthSessionMock.mockReturnValue({
+      status: 'ok',
+      session: {
+        accessToken: 'stale',
+        refreshToken: null,
+        email: null,
+        membershipType: null
+      }
+    })
+    netFetchMock.mockResolvedValueOnce(jsonResponse({}, 401))
+
+    const result = await fetchCursorRateLimits()
+    expect(result.status).toBe('error')
+    expect(result.error).toContain('sign in again in Cursor')
+  })
+
+  it('returns unavailable when usage payload has no percent signals', async () => {
+    readCursorAuthSessionMock.mockReturnValue(signedInAuth())
+    netFetchMock.mockResolvedValueOnce(jsonResponse({ enabled: true }))
+
+    const result = await fetchCursorRateLimits()
+    expect(result.status).toBe('unavailable')
+    expect(result.buckets).toEqual([])
+  })
+})

--- a/src/main/rate-limits/cursor-fetcher.ts
+++ b/src/main/rate-limits/cursor-fetcher.ts
@@ -1,0 +1,281 @@
+import { net } from 'electron'
+import type { ProviderRateLimits, RateLimitBucket } from '../../shared/rate-limit-types'
+import {
+  readCursorAuthSession,
+  type CursorAuthReadResult,
+  type CursorAuthSession
+} from './cursor-auth'
+
+const USAGE_URL = 'https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage'
+const API_TIMEOUT_MS = 10_000
+const DEFAULT_CYCLE_MINUTES = 43_200 // 30d
+
+// Why: short labels keep three Cursor meters readable in the compact status bar
+// (mirrors Gemini's Flash/Pro bucket names).
+export const CURSOR_BUCKET_INCLUDED = 'Included'
+export const CURSOR_BUCKET_AUTO = 'Auto'
+export const CURSOR_BUCKET_ON_DEMAND = 'On-demand'
+
+type CursorPlanUsage = {
+  totalSpend?: number
+  includedSpend?: number
+  bonusSpend?: number
+  limit?: number
+  autoPercentUsed?: number
+  apiPercentUsed?: number
+  totalPercentUsed?: number
+}
+
+type CursorSpendLimitUsage = {
+  individualLimit?: number
+  individualUsed?: number
+  individualRemaining?: number
+  limitType?: string
+}
+
+type CursorPeriodUsageResponse = {
+  billingCycleStart?: string | number
+  billingCycleEnd?: string | number
+  planUsage?: CursorPlanUsage
+  spendLimitUsage?: CursorSpendLimitUsage
+  displayMessage?: string
+  autoModelSelectedDisplayMessage?: string
+  namedModelSelectedDisplayMessage?: string
+  enabled?: boolean
+}
+
+function result(status: ProviderRateLimits['status'], error: string | null): ProviderRateLimits {
+  return {
+    provider: 'cursor',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error,
+    status
+  }
+}
+
+function parseMs(value: string | number | undefined): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const asNumber = Number(value)
+    if (Number.isFinite(asNumber)) {
+      return asNumber
+    }
+    const parsed = Date.parse(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function parseResetDescription(resetsAt: number | null): string | null {
+  if (resetsAt === null) {
+    return null
+  }
+  const date = new Date(resetsAt)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  const isToday = date.toDateString() === new Date().toDateString()
+  return isToday
+    ? date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+    : date.toLocaleDateString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' })
+}
+
+function parsePercentFromDisplayMessage(message: string | undefined): number | null {
+  if (!message) {
+    return null
+  }
+  const match = message.match(/(\d+(?:\.\d+)?)\s*%/)
+  if (!match?.[1]) {
+    return null
+  }
+  const value = Number(match[1])
+  return Number.isFinite(value) ? value : null
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value))
+}
+
+function resolveIncludedPercent(data: CursorPeriodUsageResponse): number | null {
+  // Why: Cursor's displayMessage ("67% of your included usage") does not match
+  // the Included total meter in Cursor's own UI. That meter tracks
+  // totalPercentUsed / "included total usage" (~29%).
+  const plan = data.planUsage
+  if (plan && typeof plan.totalPercentUsed === 'number' && Number.isFinite(plan.totalPercentUsed)) {
+    return clampPercent(plan.totalPercentUsed)
+  }
+  const fromTotalMessage = parsePercentFromDisplayMessage(data.autoModelSelectedDisplayMessage)
+  if (fromTotalMessage !== null) {
+    return clampPercent(fromTotalMessage)
+  }
+  if (
+    plan &&
+    typeof plan.includedSpend === 'number' &&
+    typeof plan.limit === 'number' &&
+    plan.limit > 0
+  ) {
+    return clampPercent((plan.includedSpend / plan.limit) * 100)
+  }
+  // Why: displayMessage ("67% of your included usage") disagrees with Cursor's
+  // Included total meter — omit rather than show the wrong number.
+  return null
+}
+
+function resolveAutoPercent(data: CursorPeriodUsageResponse): number | null {
+  const plan = data.planUsage
+  if (plan && typeof plan.autoPercentUsed === 'number' && Number.isFinite(plan.autoPercentUsed)) {
+    return clampPercent(plan.autoPercentUsed)
+  }
+  // Why: autoModelSelectedDisplayMessage describes total included usage when
+  // Auto is selected — not the Auto+Composer pool — so it must not be a fallback.
+  return null
+}
+
+function resolveOnDemandPercent(data: CursorPeriodUsageResponse): number | null {
+  const spend = data.spendLimitUsage
+  if (!spend) {
+    return null
+  }
+  // Why: on-demand is the pay-as-you-go spend cap after included pools, not
+  // apiPercentUsed (that field is the included API pool).
+  if (
+    typeof spend.individualUsed === 'number' &&
+    typeof spend.individualLimit === 'number' &&
+    spend.individualLimit > 0
+  ) {
+    return clampPercent((spend.individualUsed / spend.individualLimit) * 100)
+  }
+  if (
+    typeof spend.individualLimit === 'number' &&
+    spend.individualLimit > 0 &&
+    typeof spend.individualRemaining === 'number'
+  ) {
+    return clampPercent(
+      ((spend.individualLimit - spend.individualRemaining) / spend.individualLimit) * 100
+    )
+  }
+  return null
+}
+
+function resolveWindowMinutes(startMs: number | null, endMs: number | null): number {
+  if (startMs !== null && endMs !== null && endMs > startMs) {
+    const minutes = Math.round((endMs - startMs) / 60_000)
+    if (minutes > 0) {
+      return minutes
+    }
+  }
+  return DEFAULT_CYCLE_MINUTES
+}
+
+function makeBucket(
+  name: string,
+  usedPercent: number,
+  windowMinutes: number,
+  resetsAt: number | null
+): RateLimitBucket {
+  return {
+    name,
+    usedPercent,
+    windowMinutes,
+    resetsAt,
+    resetDescription: parseResetDescription(resetsAt)
+  }
+}
+
+function mapUsageBuckets(data: CursorPeriodUsageResponse): RateLimitBucket[] {
+  const startMs = parseMs(data.billingCycleStart)
+  const endMs = parseMs(data.billingCycleEnd)
+  const windowMinutes = resolveWindowMinutes(startMs, endMs)
+  const buckets: RateLimitBucket[] = []
+
+  const included = resolveIncludedPercent(data)
+  if (included !== null) {
+    buckets.push(makeBucket(CURSOR_BUCKET_INCLUDED, included, windowMinutes, endMs))
+  }
+
+  const auto = resolveAutoPercent(data)
+  if (auto !== null) {
+    buckets.push(makeBucket(CURSOR_BUCKET_AUTO, auto, windowMinutes, endMs))
+  }
+
+  const onDemand = resolveOnDemandPercent(data)
+  if (onDemand !== null) {
+    buckets.push(makeBucket(CURSOR_BUCKET_ON_DEMAND, onDemand, windowMinutes, endMs))
+  }
+
+  return buckets
+}
+
+function mapUsageResponse(
+  data: CursorPeriodUsageResponse,
+  session: CursorAuthSession
+): ProviderRateLimits {
+  const buckets = mapUsageBuckets(data)
+  const plan = session.membershipType?.trim()
+  const authLabel = session.email?.trim() || 'Cursor account'
+  const provenance = plan ? `${authLabel} (${plan})` : authLabel
+  return {
+    provider: 'cursor',
+    session: null,
+    weekly: null,
+    buckets,
+    updatedAt: Date.now(),
+    error: buckets.length > 0 ? null : 'Cursor usage response did not include usage meters',
+    status: buckets.length > 0 ? 'ok' : 'unavailable',
+    usageMetadata: {
+      source: 'oauth',
+      authProvenance: provenance
+    }
+  }
+}
+
+// Why: Orca never runs Cursor login; it only reads the IDE session Cursor updates.
+export async function fetchCursorRateLimits(
+  options: {
+    signal?: AbortSignal
+    authReadResult?: CursorAuthReadResult
+  } = {}
+): Promise<ProviderRateLimits> {
+  const readResult = options.authReadResult ?? readCursorAuthSession()
+  if (readResult.status === 'missing') {
+    return result('unavailable', 'Not signed in to Cursor')
+  }
+  if (readResult.status === 'error') {
+    return result('error', readResult.error)
+  }
+  const session = readResult.session
+
+  try {
+    const signal = options.signal
+      ? AbortSignal.any([options.signal, AbortSignal.timeout(API_TIMEOUT_MS)])
+      : AbortSignal.timeout(API_TIMEOUT_MS)
+    const res = await net.fetch(USAGE_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'Connect-Protocol-Version': '1'
+      },
+      body: '{}',
+      signal
+    })
+    if (res.status === 401 || res.status === 403) {
+      return result('error', 'Cursor session expired — sign in again in Cursor')
+    }
+    if (!res.ok) {
+      return result('error', `Cursor usage request failed (HTTP ${res.status})`)
+    }
+    const data: unknown = await res.json()
+    return mapUsageResponse(
+      typeof data === 'object' && data !== null ? (data as CursorPeriodUsageResponse) : {},
+      session
+    )
+  } catch (err) {
+    return result('error', err instanceof Error ? err.message : 'Cursor usage request failed')
+  }
+}

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -13,6 +13,8 @@ import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
+import { fetchCursorRateLimits } from './cursor-fetcher'
+import { readCursorAuthSession } from './cursor-auth'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
 
@@ -47,6 +49,14 @@ vi.mock('./grok-fetcher', () => ({
 
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+}))
+
+vi.mock('./cursor-fetcher', () => ({
+  fetchCursorRateLimits: vi.fn()
+}))
+
+vi.mock('./cursor-auth', () => ({
+  readCursorAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))
 
 vi.mock('../minimax/minimax-cookie-store', () => ({
@@ -131,6 +141,7 @@ function mockFreshBackgroundProviderFetches(): void {
   vi.mocked(fetchKimiRateLimits).mockImplementation(async () => okProvider('kimi', 0))
   vi.mocked(fetchMiniMaxRateLimits).mockImplementation(async () => okProvider('minimax', 0))
   vi.mocked(fetchGrokRateLimits).mockImplementation(async () => unavailableProvider('grok'))
+  vi.mocked(fetchCursorRateLimits).mockImplementation(async () => unavailableProvider('cursor'))
 }
 
 function serviceInternals(service: RateLimitService): { fetchAll: () => Promise<void> } {
@@ -184,8 +195,17 @@ describe('RateLimitService', () => {
       error: null,
       status: 'unavailable'
     })
+    vi.mocked(fetchCursorRateLimits).mockResolvedValue({
+      provider: 'cursor',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'unavailable'
+    })
     vi.mocked(hasMiniMaxSessionCookie).mockReturnValue(false)
     vi.mocked(readGrokAuthSession).mockReturnValue({ status: 'missing' })
+    vi.mocked(readCursorAuthSession).mockReturnValue({ status: 'missing' })
   })
 
   it('does not reread Grok auth when callers read state snapshots', () => {
@@ -240,6 +260,34 @@ describe('RateLimitService', () => {
     expect(fetchMiniMaxRateLimits).not.toHaveBeenCalled()
     expect(service.getState().grokAuthConfigured).toBe(true)
     expect(service.getState().grok?.status).toBe('ok')
+  })
+
+  it('refreshes Cursor without refreshing other providers', async () => {
+    const authReadResult = {
+      status: 'ok' as const,
+      session: {
+        accessToken: 'token',
+        refreshToken: null,
+        email: 'dev@example.com',
+        membershipType: 'pro'
+      }
+    }
+    vi.mocked(readCursorAuthSession).mockReturnValue(authReadResult)
+    vi.mocked(fetchCursorRateLimits).mockResolvedValueOnce(okProvider('cursor', 67))
+    const service = new RateLimitService()
+
+    await service.refreshCursor()
+
+    expect(fetchCursorRateLimits).toHaveBeenCalledTimes(1)
+    expect(fetchCursorRateLimits).toHaveBeenCalledWith({
+      authReadResult,
+      signal: expect.any(AbortSignal)
+    })
+    expect(fetchClaudeRateLimits).not.toHaveBeenCalled()
+    expect(fetchCodexRateLimits).not.toHaveBeenCalled()
+    expect(fetchGrokRateLimits).not.toHaveBeenCalled()
+    expect(service.getState().cursorAuthConfigured).toBe(true)
+    expect(service.getState().cursor?.status).toBe('ok')
   })
 
   it('does not refetch Claude when a Codex account switch is queued during fetchAll', async () => {

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -23,6 +23,8 @@ import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
+import { fetchCursorRateLimits } from './cursor-fetcher'
+import { readCursorAuthSession } from './cursor-auth'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
@@ -89,7 +91,8 @@ const MAX_ACTIVE_FAILURE_STREAK = 8
 const INDIVIDUALLY_REFRESHABLE_PROVIDERS: ReadonlySet<ActiveRateLimitProvider> = new Set([
   'claude',
   'codex',
-  'grok'
+  'grok',
+  'cursor'
 ])
 const STALE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes — after this, stale data is dropped
 const INACTIVE_FETCH_DEBOUNCE_MS = 60 * 1000 // 60 seconds — debounce fetch-on-open
@@ -106,6 +109,7 @@ type InternalRateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  cursor: ProviderRateLimits | null
 }
 
 function normalizePollingInterval(ms: number): number {
@@ -140,9 +144,11 @@ export class RateLimitService {
     kimi: null,
     antigravity: null,
     minimax: null,
-    grok: null
+    grok: null,
+    cursor: null
   }
   private grokAuthConfigured = readGrokAuthSession().status === 'ok'
+  private cursorAuthConfigured = readCursorAuthSession().status === 'ok'
   private pollInterval: number = DEFAULT_POLL_MS
   private timer: ReturnType<typeof setInterval> | null = null
   private deferredStartupRefreshTimer: ReturnType<typeof setTimeout> | null = null
@@ -156,6 +162,7 @@ export class RateLimitService {
     kimi: 0,
     minimax: 0,
     grok: 0,
+    cursor: 0,
     antigravity: 0
   }
   // Why: consecutive applied failures per provider drive exponential backoff of
@@ -168,6 +175,7 @@ export class RateLimitService {
     kimi: 0,
     minimax: 0,
     grok: 0,
+    cursor: 0,
     antigravity: 0
   }
   private mainWindow: BrowserWindow | null = null
@@ -177,6 +185,7 @@ export class RateLimitService {
   private codexOnlyFetchQueued = false
   private claudeOnlyFetchQueued = false
   private grokOnlyFetchQueued = false
+  private cursorOnlyFetchQueued = false
   private activeFetchAbortControllers = new Set<AbortController>()
   private fetchIdleResolvers: (() => void)[] = []
   private codexFetchGeneration = 0
@@ -325,6 +334,7 @@ export class RateLimitService {
       // bar visible across reloads and between snapshot refreshes.
       minimaxCookieConfigured: hasMiniMaxSessionCookie(),
       grokAuthConfigured: this.grokAuthConfigured,
+      cursorAuthConfigured: this.cursorAuthConfigured,
       claudeTarget: this.claudeFetchTarget,
       codexTarget: this.codexFetchTarget,
       inactiveClaudeAccounts: this.buildInactiveArray(
@@ -357,6 +367,11 @@ export class RateLimitService {
 
   async refreshGrok(): Promise<RateLimitState> {
     await this.fetchGrokOnly({ force: true })
+    return this.getState()
+  }
+
+  async refreshCursor(): Promise<RateLimitState> {
+    await this.fetchCursorOnly({ force: true })
     return this.getState()
   }
 
@@ -774,6 +789,7 @@ export class RateLimitService {
       kimi: this.state.kimi,
       minimax: this.state.minimax,
       grok: this.state.grok,
+      cursor: this.state.cursor,
       antigravity: this.state.antigravity
     }
     return Object.entries(byProvider).map(([provider, limits]) => ({
@@ -868,6 +884,9 @@ export class RateLimitService {
     if (plan.providers.includes('grok')) {
       await this.fetchGrokOnly()
     }
+    if (plan.providers.includes('cursor')) {
+      await this.fetchCursorOnly()
+    }
   }
 
   private async refreshIfWindowActive(): Promise<void> {
@@ -930,6 +949,15 @@ export class RateLimitService {
             break
           }
         }
+        if (this.cursorOnlyFetchQueued) {
+          this.cursorOnlyFetchQueued = false
+          const cursorSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
+            this.runFetchCursorOnlyCycle(fetchSignal)
+          )
+          if (cursorSignal.aborted) {
+            break
+          }
+        }
       }
     } finally {
       this.isFetching = false
@@ -986,6 +1014,15 @@ export class RateLimitService {
             this.runFetchGrokOnlyCycle(fetchSignal)
           )
           if (grokSignal.aborted) {
+            break
+          }
+        }
+        if (this.cursorOnlyFetchQueued) {
+          this.cursorOnlyFetchQueued = false
+          const cursorSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
+            this.runFetchCursorOnlyCycle(fetchSignal)
+          )
+          if (cursorSignal.aborted) {
             break
           }
         }
@@ -1048,6 +1085,15 @@ export class RateLimitService {
             break
           }
         }
+        if (this.cursorOnlyFetchQueued) {
+          this.cursorOnlyFetchQueued = false
+          const cursorSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
+            this.runFetchCursorOnlyCycle(fetchSignal)
+          )
+          if (cursorSignal.aborted) {
+            break
+          }
+        }
       }
     } finally {
       this.isFetching = false
@@ -1107,6 +1153,83 @@ export class RateLimitService {
             break
           }
         }
+        if (this.cursorOnlyFetchQueued) {
+          this.cursorOnlyFetchQueued = false
+          const cursorSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
+            this.runFetchCursorOnlyCycle(fetchSignal)
+          )
+          if (cursorSignal.aborted) {
+            break
+          }
+        }
+      }
+    } finally {
+      this.isFetching = false
+      this.resolveFetchIdleWaiters()
+    }
+  }
+
+  private async fetchCursorOnly(options?: { force?: boolean }): Promise<void> {
+    if (this.isFetching) {
+      if (options?.force) {
+        this.cursorOnlyFetchQueued = true
+        return this.waitForFetchIdle()
+      }
+      return
+    }
+    this.isFetching = true
+
+    try {
+      let shouldContinue = true
+      while (shouldContinue) {
+        const signal = await this.runWithFetchAbortSignal((fetchSignal) =>
+          this.runFetchCursorOnlyCycle(fetchSignal)
+        )
+        shouldContinue = false
+        if (signal.aborted) {
+          break
+        }
+        if (this.fullFetchQueued) {
+          this.fullFetchQueued = false
+          const fullSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
+            this.runFetchAllCycle(fetchSignal)
+          )
+          if (fullSignal.aborted) {
+            break
+          }
+          continue
+        }
+        if (this.cursorOnlyFetchQueued) {
+          this.cursorOnlyFetchQueued = false
+          shouldContinue = true
+        }
+        if (this.codexOnlyFetchQueued) {
+          this.codexOnlyFetchQueued = false
+          const codexSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
+            this.runFetchCodexOnlyCycle(fetchSignal)
+          )
+          if (codexSignal.aborted) {
+            break
+          }
+        }
+        if (this.claudeOnlyFetchQueued) {
+          this.claudeOnlyFetchQueued = false
+          const claudeSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
+            this.runFetchClaudeOnlyCycle(fetchSignal)
+          )
+          if (claudeSignal.aborted) {
+            break
+          }
+        }
+        if (this.grokOnlyFetchQueued) {
+          this.grokOnlyFetchQueued = false
+          const grokSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
+            this.runFetchGrokOnlyCycle(fetchSignal)
+          )
+          if (grokSignal.aborted) {
+            break
+          }
+        }
       }
     } finally {
       this.isFetching = false
@@ -1120,7 +1243,8 @@ export class RateLimitService {
       !this.fullFetchQueued &&
       !this.codexOnlyFetchQueued &&
       !this.claudeOnlyFetchQueued &&
-      !this.grokOnlyFetchQueued
+      !this.grokOnlyFetchQueued &&
+      !this.cursorOnlyFetchQueued
     ) {
       return Promise.resolve()
     }
@@ -1138,7 +1262,8 @@ export class RateLimitService {
       this.fullFetchQueued ||
       this.codexOnlyFetchQueued ||
       this.claudeOnlyFetchQueued ||
-      this.grokOnlyFetchQueued
+      this.grokOnlyFetchQueued ||
+      this.cursorOnlyFetchQueued
     ) {
       return
     }
@@ -1183,6 +1308,7 @@ export class RateLimitService {
     this.codexOnlyFetchQueued = false
     this.claudeOnlyFetchQueued = false
     this.grokOnlyFetchQueued = false
+    this.cursorOnlyFetchQueued = false
   }
 
   private resolveAndClearFetchIdleWaiters(): void {
@@ -1319,6 +1445,7 @@ export class RateLimitService {
       | 'kimi'
       | 'minimax'
       | 'grok'
+      | 'cursor'
       | 'antigravity'
   ): ProviderRateLimits {
     if (!current) {
@@ -1369,6 +1496,8 @@ export class RateLimitService {
     // Grok's sync auth-file probe on fetch cycles instead of every state read.
     const grokAuthReadResult = readGrokAuthSession()
     this.grokAuthConfigured = grokAuthReadResult.status === 'ok'
+    const cursorAuthReadResult = readCursorAuthSession()
+    this.cursorAuthConfigured = cursorAuthReadResult.status === 'ok'
 
     // Detect if configuration changed — if it did, we must discard any stale
     // data because it belongs to a different session/workspace.
@@ -1404,7 +1533,8 @@ export class RateLimitService {
       minimax: miniMaxConfigChanged
         ? this.withFetchingStatus(null, 'minimax')
         : this.withFetchingStatus(previousState.minimax, 'minimax'),
-      grok: this.withFetchingStatus(previousState.grok, 'grok')
+      grok: this.withFetchingStatus(previousState.grok, 'grok'),
+      cursor: this.withFetchingStatus(previousState.cursor, 'cursor')
     })
 
     const missingWslCodexHome = codexHomePath
@@ -1413,6 +1543,13 @@ export class RateLimitService {
     const grokResultPromise = fetchGrokRateLimits({
       signal,
       authReadResult: grokAuthReadResult
+    }).then(
+      (value) => ({ status: 'fulfilled', value }) as const,
+      (reason) => ({ status: 'rejected', reason }) as const
+    )
+    const cursorResultPromise = fetchCursorRateLimits({
+      signal,
+      authReadResult: cursorAuthReadResult
     }).then(
       (value) => ({ status: 'fulfilled', value }) as const,
       (reason) => ({ status: 'rejected', reason }) as const
@@ -1618,6 +1755,27 @@ export class RateLimitService {
       ...this.state,
       grok: this.applyStalePolicy(grok, previousState.grok)
     })
+
+    const cursorResult = await cursorResultPromise
+    if (signal.aborted) {
+      return
+    }
+    const cursor =
+      cursorResult.status === 'fulfilled'
+        ? cursorResult.value
+        : ({
+            provider: 'cursor',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error:
+              cursorResult.reason instanceof Error ? cursorResult.reason.message : 'Unknown error',
+            status: 'error'
+          } satisfies ProviderRateLimits)
+    this.updateState({
+      ...this.state,
+      cursor: this.applyStalePolicy(cursor, previousState.cursor)
+    })
   }
 
   private async runFetchCodexOnlyCycle(signal: AbortSignal): Promise<void> {
@@ -1770,6 +1928,43 @@ export class RateLimitService {
     this.updateState({
       ...this.state,
       grok: this.applyStalePolicy(grok, previousState.grok)
+    })
+  }
+
+  private async runFetchCursorOnlyCycle(signal: AbortSignal): Promise<void> {
+    if (signal.aborted) {
+      return
+    }
+    const previousState = this.state
+    const cursorAuthReadResult = readCursorAuthSession()
+    this.cursorAuthConfigured = cursorAuthReadResult.status === 'ok'
+
+    this.updateState({
+      ...previousState,
+      cursor: this.withFetchingStatus(previousState.cursor, 'cursor')
+    })
+
+    const cursor = await fetchCursorRateLimits({
+      signal,
+      authReadResult: cursorAuthReadResult
+    }).catch(
+      (err): ProviderRateLimits => ({
+        provider: 'cursor',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: err instanceof Error ? err.message : 'Unknown error',
+        status: 'error'
+      })
+    )
+
+    if (signal.aborted) {
+      return
+    }
+
+    this.updateState({
+      ...this.state,
+      cursor: this.applyStalePolicy(cursor, previousState.cursor)
     })
   }
 

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -49,6 +49,7 @@ const StatusBarItem = z.enum([
   'kimi',
   'minimax',
   'grok',
+  'cursor',
   'ssh',
   'resource-usage',
   'ports'
@@ -214,6 +215,7 @@ export const UiUpdate = z
     _minimaxStatusBarDefaultAdded: z.boolean().optional(),
     _antigravityStatusBarDefaultAdded: z.boolean().optional(),
     _grokStatusBarDefaultAdded: z.boolean().optional(),
+    _cursorStatusBarDefaultAdded: z.boolean().optional(),
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     dismissedUpdateVersion: NullableString.optional(),

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -239,11 +239,12 @@ describe('client UI RPC methods', () => {
       ...getDefaultUIState(),
       worktreeCardProperties: ['status', 'branch', 'automation', 'inline-agents'],
       _worktreeCardModeDefaulted: true,
-      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'antigravity', 'ports'],
+      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'cursor', 'antigravity', 'ports'],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _grokStatusBarDefaultAdded: true,
+      _cursorStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
       taskResumeState: {
         githubMode: 'items',
@@ -280,11 +281,12 @@ describe('client UI RPC methods', () => {
     const payload = {
       worktreeCardProperties: ['status', 'branch', 'automation', 'inline-agents'],
       _worktreeCardModeDefaulted: true,
-      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'antigravity', 'ports'],
+      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'cursor', 'antigravity', 'ports'],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _grokStatusBarDefaultAdded: true,
+      _cursorStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
       taskResumeState: {
         githubMode: 'items',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3021,6 +3021,7 @@ export type PreloadApi = {
     fetchInactiveCodexAccounts: () => Promise<void>
     refreshMiniMax: () => Promise<RateLimitState>
     refreshGrok: () => Promise<RateLimitState>
+    refreshCursor: () => Promise<RateLimitState>
     onUpdate: (callback: (state: RateLimitState) => void) => () => void
   }
   minimaxCredentials: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4052,6 +4052,7 @@ const api = {
       ipcRenderer.invoke('rateLimits:fetchInactiveCodexAccounts'),
     refreshMiniMax: (): Promise<RateLimitState> => ipcRenderer.invoke('rateLimits:refreshMiniMax'),
     refreshGrok: (): Promise<RateLimitState> => ipcRenderer.invoke('rateLimits:refreshGrok'),
+    refreshCursor: (): Promise<RateLimitState> => ipcRenderer.invoke('rateLimits:refreshCursor'),
     onUpdate: (callback: (state: RateLimitState) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, state: RateLimitState) => callback(state)
       ipcRenderer.on('rateLimits:update', listener)

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -51,7 +51,8 @@ function recordStatusBarToggleInteraction(
     id === 'kimi' ||
     id === 'antigravity' ||
     id === 'minimax' ||
-    id === 'grok'
+    id === 'grok' ||
+    id === 'cursor'
   ) {
     recordFeatureInteraction('usage-tracking')
   }

--- a/src/renderer/src/components/settings/appearance-status-bar-cursor-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-cursor-toggle-search.ts
@@ -1,0 +1,39 @@
+import type { StatusBarItem } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getCursorStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'cursor',
+    title: translate('auto.components.settings.appearance.search.cursorUsageTitle', 'Cursor Usage'),
+    description: translate(
+      'auto.components.settings.appearance.search.cursorUsageDescription',
+      'Show Cursor included usage from the signed-in Cursor IDE account.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.cursorUsageKeyword',
+        'cursor'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.de586def95',
+        'subscription'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.cursorToggleDescription',
+      'Show Cursor included usage when signed in via the Cursor IDE.'
+    )
+  }
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-ports-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-ports-toggle-search.ts
@@ -1,0 +1,40 @@
+import type { StatusBarItem } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getPortsStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'ports',
+    title: translate('auto.components.settings.appearance.search.cf409b6c4d', 'Ports'),
+    description: translate(
+      'auto.components.settings.appearance.search.0ececfa190',
+      'Show live workspace ports in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.006e67b279', 'ports'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.46d21eef62',
+        'localhost'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.43cfba3b95', 'server'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.dc02c8759d',
+        'workspace'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.portsToggleDescription',
+      'Show live workspace ports. Click it for workspace-scoped ports and external listeners.'
+    )
+  }
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -3,7 +3,9 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getAntigravityStatusBarToggleSearchEntry } from './appearance-status-bar-antigravity-toggle-search'
+import { getCursorStatusBarToggleSearchEntry } from './appearance-status-bar-cursor-toggle-search'
 import { getGrokStatusBarToggleSearchEntry } from './appearance-status-bar-grok-toggle-search'
+import { getPortsStatusBarToggleSearchEntry } from './appearance-status-bar-ports-toggle-search'
 
 export const getStatusBarToggles = createLocalizedCatalog(
   (): readonly {
@@ -200,6 +202,7 @@ export const getStatusBarToggles = createLocalizedCatalog(
       )
     },
     getGrokStatusBarToggleSearchEntry(),
+    getCursorStatusBarToggleSearchEntry(),
     {
       id: 'ssh',
       title: translate('auto.components.settings.appearance.search.57fb424c56', 'Remote Hosts'),
@@ -265,36 +268,6 @@ export const getStatusBarToggles = createLocalizedCatalog(
         'Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.'
       )
     },
-    {
-      id: 'ports',
-      title: translate('auto.components.settings.appearance.search.cf409b6c4d', 'Ports'),
-      description: translate(
-        'auto.components.settings.appearance.search.0ececfa190',
-        'Show live workspace ports in the status bar.'
-      ),
-      keywords: [
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.896eb53fd4',
-          'status bar'
-        ),
-        ...translateSearchKeyword('auto.components.settings.appearance.search.006e67b279', 'ports'),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.46d21eef62',
-          'localhost'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.43cfba3b95',
-          'server'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.dc02c8759d',
-          'workspace'
-        )
-      ],
-      toggleDescription: translate(
-        'settings.appearance.statusBar.portsToggleDescription',
-        'Show live workspace ports. Click it for workspace-scoped ports and external listeners.'
-      )
-    }
+    getPortsStatusBarToggleSearchEntry()
   ]
 )

--- a/src/renderer/src/components/stats/GrokUsagePane.test.tsx
+++ b/src/renderer/src/components/stats/GrokUsagePane.test.tsx
@@ -37,8 +37,10 @@ const mockStoreState = {
       error: null,
       status: 'ok'
     },
+    cursor: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: true,
+    cursorAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },
     codexTarget: { runtime: 'host', wslDistro: null },
     inactiveClaudeAccounts: [],

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -974,29 +974,40 @@ export function InlineUsageBars({
   )
   // Why: the preference changes copy, while bar fill stays consumption-based
   // so empty/green and full/red keep the meter semantics introduced in #8167.
-  const usageWindows = [
-    limits.session
-      ? {
-          key: 'session',
-          used: clampUsedPercent(limits.session.usedPercent),
-          label: translate('auto.components.status.bar.StatusBar.d79c3362c4', '5h')
-        }
-      : null,
-    limits.weekly
-      ? {
-          key: 'weekly',
-          used: clampUsedPercent(limits.weekly.usedPercent),
-          label: translate('auto.components.status.bar.StatusBar.5c938d39ac', 'wk')
-        }
-      : null,
-    limits.fableWeekly
-      ? {
-          key: 'fableWeekly',
-          used: clampUsedPercent(limits.fableWeekly.usedPercent),
-          label: translate('auto.components.status.bar.StatusBar.54e8d6bb2d', 'Fable')
-        }
-      : null
-  ].filter((window): window is { key: string; used: number; label: string } => window !== null)
+  const bucketWindows =
+    limits.buckets?.map((bucket) => ({
+      key: `bucket:${bucket.name}`,
+      used: clampUsedPercent(bucket.usedPercent),
+      label: bucket.name
+    })) ?? []
+  const usageWindows =
+    bucketWindows.length > 0
+      ? bucketWindows
+      : [
+          limits.session
+            ? {
+                key: 'session',
+                used: clampUsedPercent(limits.session.usedPercent),
+                label: translate('auto.components.status.bar.StatusBar.d79c3362c4', '5h')
+              }
+            : null,
+          limits.weekly
+            ? {
+                key: 'weekly',
+                used: clampUsedPercent(limits.weekly.usedPercent),
+                label: translate('auto.components.status.bar.StatusBar.5c938d39ac', 'wk')
+              }
+            : null,
+          limits.fableWeekly
+            ? {
+                key: 'fableWeekly',
+                used: clampUsedPercent(limits.fableWeekly.usedPercent),
+                label: translate('auto.components.status.bar.StatusBar.54e8d6bb2d', 'Fable')
+              }
+            : null
+        ].filter(
+          (window): window is { key: string; used: number; label: string } => window !== null
+        )
 
   return (
     <div
@@ -1028,7 +1039,13 @@ export function InlineUsageBars({
 }
 
 function isUnavailableInactiveUsage(limits: ProviderRateLimits | null | undefined): boolean {
-  return limits?.status === 'error' && !limits.session && !limits.weekly && !limits.fableWeekly
+  return (
+    limits?.status === 'error' &&
+    !limits.session &&
+    !limits.weekly &&
+    !limits.fableWeekly &&
+    !(limits.buckets && limits.buckets.length > 0)
+  )
 }
 
 function InlineUsageSignInAction({
@@ -1112,7 +1129,14 @@ function WindowLabel({
 
 // Why: only Flash and the latest Pro are shown in the status bar —
 // the rest (Flash Lite, experimental) are secondary and would clutter the bar.
-const STATUS_BAR_BUCKET_NAMES = new Set(['Flash', 'Pro', '1.5 Pro'])
+const STATUS_BAR_BUCKET_NAMES = new Set([
+  'Flash',
+  'Pro',
+  '1.5 Pro',
+  'Included',
+  'Auto',
+  'On-demand'
+])
 
 export function ProviderSegment({
   p,
@@ -1137,7 +1161,14 @@ export function ProviderSegment({
   }
 
   // Fetching with no prior data
-  if (p.status === 'fetching' && !p.session && !p.weekly && !p.fableWeekly && !p.monthly) {
+  if (
+    p.status === 'fetching' &&
+    !p.session &&
+    !p.weekly &&
+    !p.fableWeekly &&
+    !p.monthly &&
+    !(p.buckets && p.buckets.length > 0)
+  ) {
     return (
       <span className="inline-flex items-center gap-1 text-muted-foreground">
         <ProviderIcon provider={provider} />
@@ -1156,7 +1187,14 @@ export function ProviderSegment({
   }
 
   // Error with no data
-  if (p.status === 'error' && !p.session && !p.weekly && !p.fableWeekly && !p.monthly) {
+  if (
+    p.status === 'error' &&
+    !p.session &&
+    !p.weekly &&
+    !p.fableWeekly &&
+    !p.monthly &&
+    !(p.buckets && p.buckets.length > 0)
+  ) {
     return (
       <span className="inline-flex items-center gap-1 text-muted-foreground">
         <ProviderIcon provider={provider} />
@@ -1793,7 +1831,7 @@ export function ProviderDetailsMenu({
           {iconOnly ? (
             <span className="inline-flex items-center gap-1">
               <span
-                className={`inline-block h-2 w-2 rounded-full ${provider.session || provider.weekly || provider.fableWeekly || provider.monthly ? 'bg-muted-foreground/60' : 'bg-muted-foreground/30'}`}
+                className={`inline-block h-2 w-2 rounded-full ${provider.session || provider.weekly || provider.fableWeekly || provider.monthly || (provider.buckets && provider.buckets.length > 0) ? 'bg-muted-foreground/60' : 'bg-muted-foreground/30'}`}
               />
               <span className="text-muted-foreground">
                 {provider.provider === 'claude'
@@ -1810,7 +1848,9 @@ export function ProviderDetailsMenu({
                             ? 'M'
                             : provider.provider === 'grok'
                               ? 'R'
-                              : 'X'}
+                              : provider.provider === 'cursor'
+                                ? 'U'
+                                : 'X'}
               </span>
             </span>
           ) : (
@@ -1960,7 +2000,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     return null
   }
 
-  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
+  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok, cursor } = rateLimits
 
   // Why: a provider earns a bar from either a usable live snapshot or durable
   // setup in Settings. The durable path keeps account switchers visible while
@@ -1981,7 +2021,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     ...settings,
     antigravityUsageConfigured,
     minimaxCookieConfigured: rateLimits.minimaxCookieConfigured,
-    grokAuthConfigured: rateLimits.grokAuthConfigured
+    grokAuthConfigured: rateLimits.grokAuthConfigured,
+    cursorAuthConfigured: rateLimits.cursorAuthConfigured
   }
   const visibleClaude = getVisibleUsageProvider('claude', claude, usageSettings)
   const visibleCodex = getVisibleUsageProvider('codex', codex, usageSettings)
@@ -1990,6 +2031,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const visibleAntigravity = getVisibleUsageProvider('antigravity', antigravity, usageSettings)
   const visibleMiniMax = getVisibleUsageProvider('minimax', minimax, usageSettings)
   const visibleGrok = getVisibleUsageProvider('grok', grok, usageSettings)
+  const visibleCursor = getVisibleUsageProvider('cursor', cursor, usageSettings)
   const showClaude =
     visibleClaude !== null &&
     statusBarItems.includes('claude') &&
@@ -2017,6 +2059,10 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     visibleGrok !== null &&
     statusBarItems.includes('grok') &&
     isStatusBarItemAvailable('grok', detectedAgentIds)
+  const showCursor =
+    visibleCursor !== null &&
+    statusBarItems.includes('cursor') &&
+    isStatusBarItemAvailable('cursor', detectedAgentIds)
   // Why: OpenCode Go is a web/cookie-auth provider, not a CLI on PATH, so
   // detection-gating doesn't apply.
   const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, usageSettings)
@@ -2037,14 +2083,15 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     showKimi ||
     showAntigravity ||
     showMiniMax ||
-    showGrok
+    showGrok ||
+    showCursor
   const anyVisible = hasVisibleUsageMeters || showResourceUsage
   // Why: a brand-new user with no provider configured would otherwise see an
   // empty left side of the status bar and wonder what's missing. Settings are
   // included because managed accounts are durable even when live usage
   // snapshots are still hydrating or unavailable after an update.
   const isEmptyUsageState = isUsageEmptyState(
-    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok },
+    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok, cursor },
     usageSettings
   )
   // Why: the teaching CTA is a one-time nudge — once the user hides it, keep it
@@ -2058,7 +2105,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     kimi?.status === 'fetching' ||
     antigravity?.status === 'fetching' ||
     minimax?.status === 'fetching' ||
-    grok?.status === 'fetching'
+    grok?.status === 'fetching' ||
+    cursor?.status === 'fetching'
 
   const compact = containerWidth < 900
   const iconOnly = containerWidth < 500
@@ -2168,6 +2216,17 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                 ariaLabel={translate(
                   'auto.components.status.bar.StatusBar.grokUsageAria',
                   'Open Grok usage details'
+                )}
+              />
+            )}
+            {showCursor && (
+              <ProviderDetailsMenu
+                provider={visibleCursor}
+                compact={compact}
+                iconOnly={iconOnly}
+                ariaLabel={translate(
+                  'auto.components.status.bar.StatusBar.cursorUsageAria',
+                  'Open Cursor usage details'
                 )}
               />
             )}
@@ -2349,6 +2408,18 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             >
               <AgentIcon agent="grok" size={14} />
               {translate('auto.components.status.bar.StatusBar.grokUsageMenu', 'Grok Usage')}
+            </DropdownMenuCheckboxItem>
+          )}
+          {isStatusBarItemAvailable('cursor', detectedAgentIds) && (
+            <DropdownMenuCheckboxItem
+              checked={statusBarItems.includes('cursor')}
+              onCheckedChange={() => {
+                recordFeatureInteraction('usage-tracking')
+                toggleStatusBarItem('cursor')
+              }}
+            >
+              <AgentIcon agent="cursor" size={14} />
+              {translate('auto.components.status.bar.StatusBar.cursorUsageMenu', 'Cursor Usage')}
             </DropdownMenuCheckboxItem>
           )}
           <DropdownMenuCheckboxItem

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -20,6 +20,7 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('gemini', null)).toBe(true)
     expect(isStatusBarItemAvailable('antigravity', null)).toBe(true)
     expect(isStatusBarItemAvailable('grok', null)).toBe(true)
+    expect(isStatusBarItemAvailable('cursor', null)).toBe(true)
   })
 
   it('hides CLI items not detected on PATH', () => {
@@ -28,6 +29,7 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('gemini', ['claude', 'codex'])).toBe(false)
     expect(isStatusBarItemAvailable('antigravity', ['claude', 'codex'])).toBe(false)
     expect(isStatusBarItemAvailable('grok', ['claude', 'kimi'])).toBe(false)
+    expect(isStatusBarItemAvailable('cursor', ['claude', 'kimi'])).toBe(false)
   })
 
   it('shows CLI items detected on PATH', () => {
@@ -36,5 +38,6 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('gemini', ['gemini'])).toBe(true)
     expect(isStatusBarItemAvailable('antigravity', ['antigravity'])).toBe(true)
     expect(isStatusBarItemAvailable('grok', ['grok'])).toBe(true)
+    expect(isStatusBarItemAvailable('cursor', ['cursor'])).toBe(true)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
@@ -12,7 +12,8 @@ const CLI_GATED_ITEMS: ReadonlySet<StatusBarItem> = new Set([
   'gemini',
   'kimi',
   'antigravity',
-  'grok'
+  'grok',
+  'cursor'
 ])
 
 export function isStatusBarItemAvailable(

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -73,6 +73,7 @@ function usageSettings(overrides: Partial<UsageProviderSettings> = {}): UsagePro
     antigravityUsageConfigured: false,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
+    cursorAuthConfigured: false,
     ...overrides
   }
 }
@@ -127,6 +128,7 @@ describe('hasUsageProviderSettings', () => {
     )
     expect(hasUsageProviderSettings(usageSettings({ minimaxCookieConfigured: true }))).toBe(true)
     expect(hasUsageProviderSettings(usageSettings({ grokAuthConfigured: true }))).toBe(true)
+    expect(hasUsageProviderSettings(usageSettings({ cursorAuthConfigured: true }))).toBe(true)
   })
 
   it('does not treat empty or unloaded settings as configured', () => {
@@ -201,6 +203,14 @@ describe('hasUsageProviderSettingsForProvider', () => {
     ).toBe(true)
     expect(hasUsageProviderSettingsForProvider('grok', usageSettings())).toBe(false)
     expect(hasUsageProviderSettingsForProvider('grok', null)).toBe(false)
+  })
+
+  it('treats cursorAuthConfigured as the durable signal for Cursor', () => {
+    expect(
+      hasUsageProviderSettingsForProvider('cursor', usageSettings({ cursorAuthConfigured: true }))
+    ).toBe(true)
+    expect(hasUsageProviderSettingsForProvider('cursor', usageSettings())).toBe(false)
+    expect(hasUsageProviderSettingsForProvider('cursor', null)).toBe(false)
   })
 })
 
@@ -365,7 +375,8 @@ describe('isUsageEmptyState', () => {
           kimi: null,
           antigravity: null,
           minimax: null,
-          grok: null
+          grok: null,
+          cursor: null
         },
         usageSettings()
       )
@@ -383,7 +394,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: provider('unavailable', { provider: 'antigravity' }),
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          cursor: provider('unavailable', { provider: 'cursor' })
         },
         usageSettings()
       )
@@ -401,7 +413,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: provider('unavailable', { provider: 'antigravity' }),
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          cursor: provider('unavailable', { provider: 'cursor' })
         },
         usageSettings({
           codexManagedAccounts: [
@@ -430,7 +443,8 @@ describe('isUsageEmptyState', () => {
           kimi: null,
           antigravity: null,
           minimax: null,
-          grok: null
+          grok: null,
+          cursor: null
         },
         null
       )
@@ -448,7 +462,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          cursor: provider('unavailable', { provider: 'cursor' })
         },
         usageSettings()
       )
@@ -466,6 +481,7 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           grok: provider('unavailable', { provider: 'grok' }),
+          cursor: provider('unavailable', { provider: 'cursor' }),
           minimax: provider('unavailable', { provider: 'minimax' })
         },
         usageSettings({ antigravityUsageConfigured: true, geminiCliOAuthEnabled: true })
@@ -486,6 +502,7 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           grok: provider('unavailable', { provider: 'grok' }),
+          cursor: provider('unavailable', { provider: 'cursor' }),
           minimax: provider('unavailable', { provider: 'minimax' })
         },
         usageSettings({ antigravityUsageConfigured: true })

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -14,9 +14,10 @@ export type UsageProviderSettings = Pick<
   // requires geminiCliOAuthEnabled — the snapshot mirrors the Gemini fetch,
   // which never yields data while that opt-in is off.
   antigravityUsageConfigured: boolean
-  // Why: MiniMax/Grok sign-in live on disk, not in settings; main sets these each poll.
+  // Why: MiniMax/Grok/Cursor sign-in live on disk, not in settings; main sets these each poll.
   minimaxCookieConfigured: boolean
   grokAuthConfigured: boolean
+  cursorAuthConfigured: boolean
 }
 
 type UsageProviderSnapshots = {
@@ -28,6 +29,7 @@ type UsageProviderSnapshots = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  cursor: ProviderRateLimits | null
 }
 
 type UsageProviderId = ProviderRateLimits['provider']
@@ -75,7 +77,8 @@ export function hasUsageProviderSettings(
     // Antigravity's durable signal requires geminiCliOAuthEnabled, so it is
     // already covered by the gemini term above.
     settings?.minimaxCookieConfigured === true ||
-    settings?.grokAuthConfigured === true
+    settings?.grokAuthConfigured === true ||
+    settings?.cursorAuthConfigured === true
   )
 }
 
@@ -110,6 +113,9 @@ export function hasUsageProviderSettingsForProvider(
   if (providerId === 'grok') {
     return settings.grokAuthConfigured === true
   }
+  if (providerId === 'cursor') {
+    return settings.cursorAuthConfigured === true
+  }
   return false
 }
 
@@ -119,7 +125,7 @@ function createPendingProviderSnapshot(providerId: UsageProviderId): ProviderRat
     session: null,
     weekly: null,
     ...(providerId === 'opencode-go' ? { monthly: null } : {}),
-    ...(providerId === 'gemini' ? { buckets: [] } : {}),
+    ...(providerId === 'gemini' || providerId === 'cursor' ? { buckets: [] } : {}),
     updatedAt: 0,
     error: null,
     status: 'fetching'
@@ -163,7 +169,8 @@ export function isUsageEmptyState(
     isProviderSnapshotPending(providers.kimi) ||
     antigravitySnapshotPending ||
     isProviderSnapshotPending(providers.minimax) ||
-    isProviderSnapshotPending(providers.grok)
+    isProviderSnapshotPending(providers.grok) ||
+    isProviderSnapshotPending(providers.cursor)
   ) {
     return false
   }
@@ -176,6 +183,7 @@ export function isUsageEmptyState(
     !isProviderConfigured(providers.kimi) &&
     !isProviderConfigured(providers.antigravity) &&
     !isProviderConfigured(providers.minimax) &&
-    !isProviderConfigured(providers.grok)
+    !isProviderConfigured(providers.grok) &&
+    !isProviderConfigured(providers.cursor)
   )
 }

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -303,8 +303,7 @@ describe('getWindowSections', () => {
     const sections = getWindowSections(p)
     expect(sections).toEqual([
       { label: 'Pro', window: p.buckets![0] },
-      { label: 'Flash', window: p.buckets![1] },
-      { label: 'Weekly', window: null }
+      { label: 'Flash', window: p.buckets![1] }
     ])
   })
 
@@ -422,7 +421,7 @@ describe('getWindowSections', () => {
       status: 'ok'
     }
     const sections = getWindowSections(p)
-    expect(sections).toHaveLength(2)
+    expect(sections).toHaveLength(1)
     expect(sections[0].label).toBe('Pro')
     expect(sections[0].window!.resetsAt).toBe(18000000)
     expect(sections[0].window!.resetDescription).toBe('5:00 PM')

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -95,6 +95,9 @@ export function ProviderIcon({ provider }: { provider: string }): React.JSX.Elem
   if (provider === 'grok') {
     return <AgentIcon agent="grok" size={13} />
   }
+  if (provider === 'cursor') {
+    return <AgentIcon agent="cursor" size={13} />
+  }
   return <ClaudeIcon size={13} />
 }
 
@@ -141,14 +144,10 @@ export function getWindowSections(
   p: ProviderRateLimits
 ): { label: string; window: RateLimitWindow | null }[] {
   if (p.buckets?.length) {
-    const bucketSections = p.buckets.map((b) => ({ label: b.name, window: b as RateLimitWindow }))
-    return [
-      ...bucketSections,
-      {
-        label: translate('auto.components.status.bar.tooltip.252c096536', 'Weekly'),
-        window: p.weekly
-      }
-    ]
+    // Why: Cursor (and Gemini) already encode every visible meter as a named
+    // bucket. Appending an empty Weekly section would paint a blank row in the
+    // detail popover.
+    return p.buckets.map((b) => ({ label: b.name, window: b as RateLimitWindow }))
   }
   const sections: { label: string; window: RateLimitWindow | null }[] = [
     {
@@ -241,21 +240,23 @@ export function ProviderPanel({
   }
 
   if (p.status === 'error' && !p.session && !p.weekly && !p.fableWeekly && !p.monthly) {
-    return (
-      <div className={`text-xs ${className ?? 'w-full'}`}>
-        <div className={`flex items-center gap-1.5 font-medium ${textClass}`}>
-          <ProviderIcon provider={p.provider} />
-          {name}
+    if (!(p.buckets && p.buckets.length > 0)) {
+      return (
+        <div className={`text-xs ${className ?? 'w-full'}`}>
+          <div className={`flex items-center gap-1.5 font-medium ${textClass}`}>
+            <ProviderIcon provider={p.provider} />
+            {name}
+          </div>
+          <div className="mt-2">
+            <ErrorMessage
+              label={getProviderUsageStatusLabel(p)}
+              message={getProviderUsageErrorMessage(p)}
+              inverted={inverted}
+            />
+          </div>
         </div>
-        <div className="mt-2">
-          <ErrorMessage
-            label={getProviderUsageStatusLabel(p)}
-            message={getProviderUsageErrorMessage(p)}
-            inverted={inverted}
-          />
-        </div>
-      </div>
-    )
+      )
+    }
   }
 
   const updatedAgo = p.updatedAt ? `Updated ${formatTimeAgo(p.updatedAt)}` : 'Not yet updated'
@@ -334,7 +335,15 @@ export function ProviderPanel({
       {p.error ? (
         <ErrorMessage
           message={p.error}
-          stale={!!(p.session || p.weekly || p.fableWeekly || p.monthly)}
+          stale={
+            !!(
+              p.session ||
+              p.weekly ||
+              p.fableWeekly ||
+              p.monthly ||
+              (p.buckets && p.buckets.length > 0)
+            )
+          }
           inverted={inverted}
         />
       ) : null}

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -26,6 +26,9 @@ export function getProviderDisplayName(provider: ProviderRateLimits['provider'])
   if (provider === 'grok') {
     return 'Grok'
   }
+  if (provider === 'cursor') {
+    return 'Cursor'
+  }
   return provider
 }
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -30,7 +30,8 @@
         "resourceUsageToggleDescription": "Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.",
         "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners.",
         "antigravityToggleDescription": "Show Antigravity subscription usage for the active workspace.",
-        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI."
+        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI.",
+        "cursorToggleDescription": "Show Cursor included usage when signed in via the Cursor IDE."
       }
     }
   },
@@ -3060,7 +3061,9 @@
             "antigravityUsage": "Antigravity Usage",
             "antigravityUsageDetails": "Open Antigravity usage details",
             "grokUsageAria": "Open Grok usage details",
-            "grokUsageMenu": "Grok Usage"
+            "grokUsageMenu": "Grok Usage",
+            "cursorUsageAria": "Open Cursor usage details",
+            "cursorUsageMenu": "Cursor Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -7270,6 +7273,9 @@
             "e7d1b0f3a5": "Show Grok weekly credit usage from Grok CLI OAuth.",
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
+            "cursorUsageTitle": "Cursor Usage",
+            "cursorUsageDescription": "Show Cursor included usage from the signed-in Cursor IDE account.",
+            "cursorUsageKeyword": "cursor",
             "usagePercentageDisplayTitle": "Usage percentages",
             "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
           }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -30,7 +30,8 @@
         "resourceUsageToggleDescription": "Muestra el Administrador de recursos. Haz clic para ver CPU, memoria, sesiones, controles del servicio en segundo plano y análisis de disco de los espacios de trabajo.",
         "portsToggleDescription": "Muestra los puertos activos de los espacios de trabajo. Haz clic para ver los puertos de cada espacio de trabajo y los puertos externos.",
         "antigravityToggleDescription": "Muestra el uso de suscripción de Antigravity para el espacio de trabajo activo.",
-        "grokToggleDescription": "Muestra el uso de créditos de suscripción de Grok cuando has iniciado sesión con Grok CLI."
+        "grokToggleDescription": "Muestra el uso de créditos de suscripción de Grok cuando has iniciado sesión con Grok CLI.",
+        "cursorToggleDescription": "Show Cursor included usage when signed in via the Cursor IDE."
       }
     }
   },
@@ -3060,7 +3061,9 @@
             "antigravityUsage": "Uso de Antigravity",
             "antigravityUsageDetails": "Abrir detalles de uso de Antigravity",
             "grokUsageAria": "Abrir detalles de uso de Grok",
-            "grokUsageMenu": "Uso de Grok"
+            "grokUsageMenu": "Uso de Grok",
+            "cursorUsageAria": "Open Cursor usage details",
+            "cursorUsageMenu": "Cursor Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",
@@ -7234,7 +7237,10 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Porcentajes de uso",
-            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante."
+            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante.",
+            "cursorUsageTitle": "Cursor Usage",
+            "cursorUsageDescription": "Show Cursor included usage from the signed-in Cursor IDE account.",
+            "cursorUsageKeyword": "cursor"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -30,7 +30,8 @@
         "resourceUsageToggleDescription": "リソースマネージャーを表示します。これをクリックすると、CPU、メモリ、セッション、デーモン コントロール、およびワークスペース ディスク スキャンが行われます。",
         "portsToggleDescription": "ライブワークスペースポートを表示します。ワークスペーススコープのポートと外部リスナーの場合はこれをクリックします。",
         "antigravityToggleDescription": "アクティブなワークスペースの Antigravity サブスクリプション使用量を表示します。",
-        "grokToggleDescription": "Grok CLI でサインインしている場合に Grok サブスクリプションのクレジット使用量を表示します。"
+        "grokToggleDescription": "Grok CLI でサインインしている場合に Grok サブスクリプションのクレジット使用量を表示します。",
+        "cursorToggleDescription": "Show Cursor included usage when signed in via the Cursor IDE."
       }
     }
   },
@@ -3060,7 +3061,9 @@
             "antigravityUsage": "Antigravity の使用状況",
             "antigravityUsageDetails": "Antigravity の使用状況詳細を開く",
             "grokUsageAria": "Grok の使用状況詳細を開く",
-            "grokUsageMenu": "Grok の使用状況"
+            "grokUsageMenu": "Grok の使用状況",
+            "cursorUsageAria": "Open Cursor usage details",
+            "cursorUsageMenu": "Cursor Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",
@@ -7256,7 +7259,10 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "使用率",
-            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。"
+            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。",
+            "cursorUsageTitle": "Cursor Usage",
+            "cursorUsageDescription": "Show Cursor included usage from the signed-in Cursor IDE account.",
+            "cursorUsageKeyword": "cursor"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -30,7 +30,8 @@
         "resourceUsageToggleDescription": "리소스 관리자를 표시합니다. 클릭하면 CPU, 메모리, 세션, 데몬 제어, 워크스페이스 디스크 스캔을 볼 수 있습니다.",
         "portsToggleDescription": "라이브 워크스페이스 포트를 표시합니다. 워크스페이스 범위 포트 및 외부 수신기를 보려면 클릭하세요.",
         "antigravityToggleDescription": "활성 워크스페이스에 대한 Antigravity 구독 사용량을 표시합니다.",
-        "grokToggleDescription": "Grok CLI로 로그인한 경우 Grok 구독 크레딧 사용량을 표시합니다."
+        "grokToggleDescription": "Grok CLI로 로그인한 경우 Grok 구독 크레딧 사용량을 표시합니다.",
+        "cursorToggleDescription": "Show Cursor included usage when signed in via the Cursor IDE."
       }
     }
   },
@@ -3060,7 +3061,9 @@
             "antigravityUsage": "Antigravity 사용량",
             "antigravityUsageDetails": "Antigravity 사용량 세부 정보 열기",
             "grokUsageAria": "Grok 사용량 세부 정보 열기",
-            "grokUsageMenu": "Grok 사용량"
+            "grokUsageMenu": "Grok 사용량",
+            "cursorUsageAria": "Open Cursor usage details",
+            "cursorUsageMenu": "Cursor Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",
@@ -7219,7 +7222,10 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "사용량 백분율",
-            "usagePercentageDisplayDescription": "공급자 한도를 사용한 비율 또는 남은 비율로 표시할지 선택합니다."
+            "usagePercentageDisplayDescription": "공급자 한도를 사용한 비율 또는 남은 비율로 표시할지 선택합니다.",
+            "cursorUsageTitle": "Cursor Usage",
+            "cursorUsageDescription": "Show Cursor included usage from the signed-in Cursor IDE account.",
+            "cursorUsageKeyword": "cursor"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -30,7 +30,8 @@
         "resourceUsageToggleDescription": "显示资源管理器。点击可查看 CPU、内存、会话、守护进程控制和工作区磁盘扫描。",
         "portsToggleDescription": "显示实时工作区端口。单击它可获取工作区范围的端口和外部侦听器。",
         "antigravityToggleDescription": "显示当前工作区的 Antigravity 订阅使用量。",
-        "grokToggleDescription": "通过 Grok CLI 登录后显示 Grok 订阅额度使用量。"
+        "grokToggleDescription": "通过 Grok CLI 登录后显示 Grok 订阅额度使用量。",
+        "cursorToggleDescription": "Show Cursor included usage when signed in via the Cursor IDE."
       }
     }
   },
@@ -3060,7 +3061,9 @@
             "antigravityUsage": "Antigravity 使用量",
             "antigravityUsageDetails": "打开 Antigravity 使用详情",
             "grokUsageAria": "打开 Grok 使用详情",
-            "grokUsageMenu": "Grok 使用量"
+            "grokUsageMenu": "Grok 使用量",
+            "cursorUsageAria": "Open Cursor usage details",
+            "cursorUsageMenu": "Cursor Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",
@@ -7219,7 +7222,10 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "用量百分比",
-            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。"
+            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。",
+            "cursorUsageTitle": "Cursor Usage",
+            "cursorUsageDescription": "Show Cursor included usage from the signed-in Cursor IDE account.",
+            "cursorUsageKeyword": "cursor"
           }
         },
         "auto": {

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -7,6 +7,7 @@ export type RateLimitSlice = {
   fetchRateLimits: () => Promise<void>
   refreshRateLimits: () => Promise<void>
   refreshGrokRateLimits: () => Promise<void>
+  refreshCursorRateLimits: () => Promise<void>
   refreshClaudeRateLimitsForTarget: (target: RateLimitRuntimeTarget) => Promise<void>
   refreshCodexRateLimitsForTarget: (target: RateLimitRuntimeTarget) => Promise<void>
   consumeCodexRateLimitResetCredit: () => Promise<void>
@@ -25,8 +26,10 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
     antigravity: null,
     minimax: null,
     grok: null,
+    cursor: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
+    cursorAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },
     codexTarget: { runtime: 'host', wslDistro: null },
     inactiveClaudeAccounts: [],
@@ -57,6 +60,15 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
       set({ rateLimits: state })
     } catch (error) {
       console.error('Failed to refresh Grok usage:', error)
+    }
+  },
+
+  refreshCursorRateLimits: async () => {
+    try {
+      const state = await window.api.rateLimits.refreshCursor()
+      set({ rateLimits: state })
+    } catch (error) {
+      console.error('Failed to refresh Cursor usage:', error)
     }
   },
 

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1324,7 +1324,8 @@ describe('createUISlice hydratePersistedUI', () => {
       'kimi',
       'minimax',
       'antigravity',
-      'grok'
+      'grok',
+      'cursor'
     ])
     expect(setUI).toHaveBeenCalledWith({
       statusBarItems: [
@@ -1334,13 +1335,15 @@ describe('createUISlice hydratePersistedUI', () => {
         'kimi',
         'minimax',
         'antigravity',
-        'grok'
+        'grok',
+        'cursor'
       ],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
-      _grokStatusBarDefaultAdded: true
+      _grokStatusBarDefaultAdded: true,
+      _cursorStatusBarDefaultAdded: true
     })
   })
 
@@ -1356,7 +1359,8 @@ describe('createUISlice hydratePersistedUI', () => {
         _kimiStatusBarDefaultAdded: true,
         _minimaxStatusBarDefaultAdded: true,
         _antigravityStatusBarDefaultAdded: true,
-        _grokStatusBarDefaultAdded: true
+        _grokStatusBarDefaultAdded: true,
+        _cursorStatusBarDefaultAdded: true
       })
     )
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -273,6 +273,7 @@ const DEFAULT_ON_KIMI_STATUS_BAR_ITEM: StatusBarItem = 'kimi'
 const DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM: StatusBarItem = 'minimax'
 const DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM: StatusBarItem = 'antigravity'
 const DEFAULT_ON_GROK_STATUS_BAR_ITEM: StatusBarItem = 'grok'
+const DEFAULT_ON_CURSOR_STATUS_BAR_ITEM: StatusBarItem = 'cursor'
 
 function normalizeHydratedVisibleWorkspaceHostIds(ui: PersistedUIState): VisibleWorkspaceHostIds {
   const visibleHostIds = normalizeVisibleExecutionHostIds(ui.visibleWorkspaceHostIds)
@@ -2413,22 +2414,28 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         ui._grokStatusBarDefaultAdded || statusBarItemsWithAntigravity.includes('grok')
           ? statusBarItemsWithAntigravity
           : [...statusBarItemsWithAntigravity, DEFAULT_ON_GROK_STATUS_BAR_ITEM]
+      const statusBarItemsWithCursor =
+        ui._cursorStatusBarDefaultAdded || statusBarItemsWithGrok.includes('cursor')
+          ? statusBarItemsWithGrok
+          : [...statusBarItemsWithGrok, DEFAULT_ON_CURSOR_STATUS_BAR_ITEM]
       if (
         (!ui._portsStatusBarDefaultAdded ||
           !ui._kimiStatusBarDefaultAdded ||
           !ui._minimaxStatusBarDefaultAdded ||
           !ui._antigravityStatusBarDefaultAdded ||
-          !ui._grokStatusBarDefaultAdded) &&
+          !ui._grokStatusBarDefaultAdded ||
+          !ui._cursorStatusBarDefaultAdded) &&
         typeof window !== 'undefined'
       ) {
         window.api.ui
           .set({
-            statusBarItems: statusBarItemsWithGrok,
+            statusBarItems: statusBarItemsWithCursor,
             _portsStatusBarDefaultAdded: true,
             _kimiStatusBarDefaultAdded: true,
             _minimaxStatusBarDefaultAdded: true,
             _antigravityStatusBarDefaultAdded: true,
-            _grokStatusBarDefaultAdded: true
+            _grokStatusBarDefaultAdded: true,
+            _cursorStatusBarDefaultAdded: true
           })
           .catch(console.error)
       }
@@ -2493,7 +2500,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
         workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(ui.workspaceBoardColumnWidth),
         syncTaskStatusFromWorkspaceBoard: ui.syncTaskStatusFromWorkspaceBoard === true,
-        statusBarItems: statusBarItemsWithGrok,
+        statusBarItems: statusBarItemsWithCursor,
         statusBarVisible: ui.statusBarVisible ?? true,
         usagePercentageDisplay: normalizeUsagePercentageDisplay(ui.usagePercentageDisplay),
         // Why: absent → true so existing users see the pet the first time

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2622,8 +2622,10 @@ function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimits']> {
     antigravity: null,
     minimax: null,
     grok: null,
+    cursor: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
+    cursorAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },
     codexTarget: { runtime: 'host', wslDistro: null },
     inactiveClaudeAccounts: [],
@@ -2642,6 +2644,7 @@ function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimits']> {
     fetchInactiveCodexAccounts: () => Promise.resolve(),
     refreshMiniMax: () => Promise.resolve(empty),
     refreshGrok: () => Promise.resolve(empty),
+    refreshCursor: () => Promise.resolve(empty),
     onUpdate: () => noopUnsubscribe
   }
 }

--- a/src/shared/rate-limit-types.test.ts
+++ b/src/shared/rate-limit-types.test.ts
@@ -16,8 +16,10 @@ describe('RateLimitState', () => {
       antigravity: null,
       minimax: null,
       grok: null,
+      cursor: null,
       minimaxCookieConfigured: false,
       grokAuthConfigured: false,
+      cursorAuthConfigured: false,
       claudeTarget: { runtime: 'host', wslDistro: null },
       codexTarget: { runtime: 'host', wslDistro: null },
       inactiveClaudeAccounts: [],
@@ -27,5 +29,7 @@ describe('RateLimitState', () => {
     expect(state.antigravity).toBeNull()
     expect(state.minimax).toBeNull()
     expect(state.minimaxCookieConfigured).toBe(false)
+    expect(state.cursor).toBeNull()
+    expect(state.cursorAuthConfigured).toBe(false)
   })
 })

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -52,6 +52,7 @@ export type ProviderRateLimits = {
     | 'kimi'
     | 'minimax'
     | 'grok'
+    | 'cursor'
     | 'antigravity'
   /** 5-hour session window, null if not available. */
   session: RateLimitWindow | null
@@ -120,6 +121,7 @@ export type RateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  cursor: ProviderRateLimits | null
   /**
    * True when a MiniMax session cookie is persisted on disk. The cookie lives
    * outside GlobalSettings, so this flag is the durable signal that the
@@ -129,6 +131,8 @@ export type RateLimitState = {
   minimaxCookieConfigured: boolean
   /** True when main finds a Grok CLI session file (~/.grok/auth.json or GROK_HOME). */
   grokAuthConfigured: boolean
+  /** True when main finds a Cursor IDE auth token in state.vscdb. */
+  cursorAuthConfigured: boolean
   claudeTarget: RateLimitRuntimeTarget
   codexTarget: RateLimitRuntimeTarget
   inactiveClaudeAccounts: InactiveAccountUsage[]

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -9,6 +9,7 @@ export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'kimi',
   'minimax',
   'grok',
+  'cursor',
   'ssh',
   'resource-usage',
   'ports'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3205,6 +3205,7 @@ export type StatusBarItem =
   | 'kimi'
   | 'minimax'
   | 'grok'
+  | 'cursor'
   | 'ssh'
   | 'resource-usage'
   | 'ports'
@@ -3340,6 +3341,8 @@ export type PersistedUIState = {
   _antigravityStatusBarDefaultAdded?: boolean
   /** One-shot migration flag for adding the default-on Grok status item. */
   _grokStatusBarDefaultAdded?: boolean
+  /** One-shot migration flag for adding the default-on Cursor status item. */
+  _cursorStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   /** Why: this is client-side presentation, not a provider/account or execution-host setting. */


### PR DESCRIPTION
## Summary

Show Cursor plan usage in the Orca status bar (same place as Claude/Codex/Grok), using the signed-in Cursor IDE account — no separate Orca login.

- Reads Cursor auth from the IDE `state.vscdb` and fetches `GetCurrentPeriodUsage`
- Compact meters: **Included**, **Auto**, and **On-demand**
- Appearance toggle + default-on migration for existing profiles
- Mapping matches Cursor’s own meters: `totalPercentUsed` → Included, `autoPercentUsed` → Auto, `spendLimitUsage` → On-demand (not `displayMessage` / `apiPercentUsed`)

## Screenshots

<img width="423" height="305" alt="Screenshot 2026-07-14 at 12 03 56" src="https://github.com/user-attachments/assets/f6507e10-e5c7-4ed8-aaf9-025b748d14b9" />

Status bar + detail popover showing **Included**, **Auto**, and **On-demand** meters from the signed-in Cursor IDE account.

## Testing

- [x] `pnpm lint` (oxlint on changed files + switch-exhaustiveness, reliability gates, max-lines ratchet, localization catalog/coverage; full `pnpm lint` OOM’d once in this environment, gates above passed)
- [x] `pnpm typecheck`
- [x] `pnpm test` (Cursor auth/fetcher, visibility, gating, ui hydrate, client-ui tests passed; full suite had unrelated flaky timeouts in daemon shell-ready / SSH transport)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added `cursor-auth` / `cursor-fetcher` unit tests covering platform DB path, signed-out/missing token, Included/`displayMessage` mismatch, On-demand from `spendLimitUsage` (not `apiPercentUsed`), plus visibility/gating/store coverage.

## AI Review Report

Reviewed usage field mapping, status-bar wiring, and auth path handling against CONTRIBUTING.

- **Cross-platform:** Cursor DB path uses `path.join` with darwin / win32 / Linux branches; Windows locked-DB temp-copy fallback; no new shortcuts or `metaKey` hardcoding.
- **SSH/remote/local:** Auth + fetch run in the desktop main process against the local Cursor IDE session (same pattern as other local OAuth usage meters); SSH worktrees do not change where Electron main runs.
- **Agents/integrations:** Cursor-only provider behind explicit `'cursor'` checks; other providers unchanged.
- **Performance:** Reuses existing rate-limit poll / refresh-cursor path; no hot-path work beyond the shared poller.
- **UI quality:** Reuses existing status-bar provider segment + Appearance toggle patterns; short bucket labels for compact bar.
- **Risks checked / fixed:** Wrong Included % from `displayMessage` (removed as fallback); Auto must not use `autoModelSelectedDisplayMessage`; On-demand must not use `apiPercentUsed`; max-lines on appearance search (extracted ports entry); locale parity synced for es/ja/ko/zh.

## Security Audit

- Access token is read only from the local Cursor IDE SQLite DB and sent as `Authorization: Bearer` to Cursor’s usage API; it is not logged in status-bar errors (filesystem paths redacted).
- No new IPC surface beyond extending the existing rate-limits refresh/state channel with a `cursor` provider.
- No command execution, dependency adds, or secret persistence in Orca’s own store — Orca never runs Cursor login; it only reads the IDE session Cursor updates.

## Notes

- Requires Cursor IDE signed in on the same machine.
- Packaged `/Applications/Orca.app` needs a build that includes this branch; local `pnpm start` / preview was used for verification.
- X: [@0xPresc](https://x.com/0xPresc)

Made with [Cursor](https://cursor.com)

## ELI5

The status bar can show Cursor plan usage (Included, Auto, On-demand) from your signed-in Cursor account. No separate Orca Cursor login is required.
