### PR TITLE
fix(agent-status): guard against re-entrant pending-status flush (crash 9fc89529)

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -4873,6 +4873,104 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
   })
 
+  it('does not recurse when flushing a pending status re-enters via the store subscriber', async () => {
+    // Repro for crash 9fc89529 (RangeError: Maximum call stack size exceeded):
+    // the store subscriber calls flushPendingAgentStatuses() on every update.
+    // flush -> applyAgentStatus -> store.setAgentStatus notifies subscribers
+    // synchronously (like Zustand) -> subscriber -> flush again while the same
+    // event is still queued -> infinite recursion. Model setAgentStatus with a
+    // real synchronous notify so the re-entrancy is exercised end to end.
+    const subscribeListenerRef: { current: StoreSubscribeListener | null } = { current: null }
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    let setAgentStatusCalls = 0
+    const notify = (): void => {
+      const listener = subscribeListenerRef.current
+      if (listener) {
+        listener(storeState, storeState)
+      }
+    }
+    const storeState: StoreLike = buildStoreState({
+      // Why: mirror Zustand — a state mutation notifies subscribers synchronously.
+      setAgentStatus: (paneKey: string, entry: unknown) => {
+        setAgentStatusCalls += 1
+        storeState.agentStatusByPaneKey = {
+          ...(storeState.agentStatusByPaneKey as Record<string, unknown>),
+          [paneKey]: entry
+        }
+        notify()
+      },
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      // Pane does not exist yet -> the incoming event is buffered as pending.
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn((listener: StoreSubscribeListener) => {
+          subscribeListenerRef.current = listener
+          return () => {
+            subscribeListenerRef.current = null
+          }
+        }),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+    if (typeof subscribeListenerRef.current !== 'function') {
+      throw new Error('Expected useAppStore.subscribe listener to be registered')
+    }
+
+    // Event lands before the tab exists -> buffered as a pending retry.
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'working',
+      prompt: 'p',
+      agentType: 'claude',
+      receivedAt: 1_700_000_000_100,
+      stateStartedAt: 1_699_999_999_100
+    })
+    expect(setAgentStatusCalls).toBe(0)
+
+    // Tab hydrates; the next store update flushes the pending event. Without the
+    // re-entrancy guard this overflows the stack instead of applying once.
+    storeState.tabsByWorktree = {
+      'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
+    }
+    storeState.terminalLayoutsByTabId = {
+      'tab-future': {
+        root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+        activeLeafId: FUTURE_LEAF_ID,
+        expandedLeafId: null
+      }
+    }
+
+    expect(() => notify()).not.toThrow()
+    // Applied exactly once — the re-entrant flush is a no-op, not a loop.
+    expect(setAgentStatusCalls).toBe(1)
+  })
+
   it('applies ready push events for an unmounted inactive terminal tab', async () => {
     const setAgentStatus = vi.fn()
     const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -842,6 +842,11 @@ export function useIpcEvents(): void {
     type AgentStatusApplyResult = 'applied' | 'pending' | 'dropped'
     const pendingAgentStatusEvents: PendingAgentStatusEvent[] = []
     let pendingAgentStatusRetryTimer: ReturnType<typeof setTimeout> | null = null
+    // Why: applyAgentStatus -> store.setAgentStatus notifies the store
+    // subscriber synchronously, which re-enters flushPendingAgentStatuses while
+    // the queue is still mid-drain. Guard against that re-entrancy so the same
+    // event is not reprocessed forever (crash 9fc89529: stack overflow).
+    let isFlushingAgentStatuses = false
 
     unsubs.push(attachMobileMarkdownBridge())
 
@@ -2917,25 +2922,37 @@ export function useIpcEvents(): void {
     }
 
     function flushPendingAgentStatuses(): void {
+      // Why: a re-entrant call (store subscriber firing during a setAgentStatus
+      // inside the loop below) must not reprocess the still-queued events — the
+      // outer flush already owns them. Bailing here breaks the infinite
+      // recursion without dropping work; the outer loop finishes the drain.
+      if (isFlushingAgentStatuses) {
+        return
+      }
       if (pendingAgentStatusEvents.length === 0) {
         return
       }
-      const now = Date.now()
-      const remaining: PendingAgentStatusEvent[] = []
-      for (const event of pendingAgentStatusEvents) {
-        if (now - event.firstSeenAt > PENDING_AGENT_STATUS_TTL_MS) {
-          continue
+      isFlushingAgentStatuses = true
+      try {
+        const now = Date.now()
+        const remaining: PendingAgentStatusEvent[] = []
+        for (const event of pendingAgentStatusEvents) {
+          if (now - event.firstSeenAt > PENDING_AGENT_STATUS_TTL_MS) {
+            continue
+          }
+          const result = applyAgentStatus(event.data, { retry: true })
+          if (result === 'pending') {
+            remaining.push(event)
+          }
         }
-        const result = applyAgentStatus(event.data, { retry: true })
-        if (result === 'pending') {
-          remaining.push(event)
+        pendingAgentStatusEvents.length = 0
+        pendingAgentStatusEvents.push(...remaining)
+        if (pendingAgentStatusEvents.length === 0 && pendingAgentStatusRetryTimer !== null) {
+          globalThis.clearTimeout(pendingAgentStatusRetryTimer)
+          pendingAgentStatusRetryTimer = null
         }
-      }
-      pendingAgentStatusEvents.length = 0
-      pendingAgentStatusEvents.push(...remaining)
-      if (pendingAgentStatusEvents.length === 0 && pendingAgentStatusRetryTimer !== null) {
-        globalThis.clearTimeout(pendingAgentStatusRetryTimer)
-        pendingAgentStatusRetryTimer = null
+      } finally {
+        isFlushingAgentStatuses = false
       }
       schedulePendingAgentStatusFlush()
     }


### PR DESCRIPTION
## What

Fixes a renderer crash — `RangeError: Maximum call stack size exceeded` — caused by an infinite recursion in the agent‑status pending‑retry flush (`useIpcEvents.ts`).

Crash report `9fc89529-b032-409b-a333-f6b247912a40` (macOS, prod build, `terminal.workbench` boundary):

```
RangeError: Maximum call stack size exceeded
    at applyAgentStatus
    at flushPendingAgentStatuses
    at ...
    at Set.forEach            ← Zustand notifying store subscribers
    at setState
    at Object.setAgentStatus
    at applyAgentStatus
    at flushPendingAgentStatuses
    ...
```

## Root cause

The store subscriber runs `flushPendingAgentStatuses()` on **every** store update:

```ts
useAppStore.subscribe((state, previousState) => {
  requestAgentStatusSnapshotIfReady()
  flushPendingAgentStatuses()
  syncAgentHookCompletionNotificationsForStoreUpdate(state, previousState)
})
```

`flushPendingAgentStatuses()` loops over the buffered events and calls `applyAgentStatus(event, { retry: true })`, which calls `store.setAgentStatus(...)`. Zustand notifies subscribers **synchronously**, so the same subscriber fires again and re‑enters `flushPendingAgentStatuses()` — **while the queue is still mid‑drain** (the queue is only cleared *after* the `for` loop). The re‑entrant call sees the same still‑queued event, applies it again, which notifies again… until the stack overflows.

This only triggers when a status event is buffered for a pane whose terminal tab hasn't hydrated yet (e.g. a hook event racing tab/layout hydration, or during SSH‑disconnect churn) and then the pane resolves. The crash report shows exactly that: `sshDisconnected=true` worktree activation + `fs_readdir_error` right before the overflow.

## The fix

A one‑boolean re‑entrancy guard. If a flush is already in progress, a nested call returns immediately — the in‑progress flush already owns the queue and its loop covers every buffered event.

```ts
let isFlushingAgentStatuses = false
function flushPendingAgentStatuses(): void {
  if (isFlushingAgentStatuses) return          // break the recursion
  if (pendingAgentStatusEvents.length === 0) return
  isFlushingAgentStatuses = true
  try {
    /* ...unchanged drain loop... */
  } finally {
    isFlushingAgentStatuses = false
  }
  schedulePendingAgentStatusFlush()
}
```

Nothing is dropped: a retry flush never enqueues new events (that path requires `retry !== true`), the outer loop finishes draining, and any residual events are retried by the existing 100 ms timer / next store update.

## ELI5

The app keeps a little "inbox" of agent‑status messages it couldn't deliver yet because the terminal tab wasn't ready. Every time anything in the app changed, it tried to empty the inbox. But emptying the inbox *itself* counts as a change, so it tried to empty the inbox again before it finished the first pass — over and over, like two mirrors facing each other — until it fell over. The fix is a "I'm already emptying the inbox, don't start again" sign. One pass empties it; the mirrors stop.

## Fix evidence (undeniable)

New regression test `useIpcEvents.test.ts › does not recurse when flushing a pending status re-enters via the store subscriber` drives the **real hook** with a store double whose `setAgentStatus` notifies subscribers synchronously (faithful to Zustand):

- **Before the fix** — `expect(() => notify()).not.toThrow()` fails with the exact production error:
  ```
  AssertionError: expected [Function] to not throw an error but
  'RangeError: Maximum call stack size exceeded' was thrown
  ```
- **After the fix** — passes; the pending event is applied **exactly once** (`setAgentStatusCalls === 1`), no overflow.

Full file: `74 passed (74)`. Typecheck (web) exit 0. oxlint + oxfmt clean.

## Trade-offs / behavior changes

- No user‑facing behavior change in the normal (non‑re‑entrant) path — the guard is a no‑op there; a pending event still applies exactly once with the same store state.
- The only difference is in the (previously crashing) re‑entrant case: extra events are no longer flushed *synchronously inside* a nested subscriber call. They are picked up by the outer drain loop, the 100 ms retry timer, or the next store update — a sub‑frame delay at most, bounded, and still within the existing 15 s TTL. No status, title, badge, or completion notification is dropped or duplicated.

## Adversarial review

**1 loop → clean.** 3 independent skeptic agents, each with a distinct lens, each tasked to *refute* the fix:

- **Correctness** — traced lost-flush / residual-rescheduling / mid-loop-throw exception safety / FIFO+starvation. Verdict: no defect. The re-entrant flush bails while the outer flush retains queue ownership and completes the drain + reschedule; a retry flush never enqueues (`retry === true` skips the enqueue path), so the queue can't grow-then-be-swallowed.
- **Re-entrancy completeness** — confirmed the guard cuts the exact reported cycle frame-for-frame; the subscriber's other two calls (`requestAgentStatusSnapshotIfReady`, `syncAgentHookCompletionNotificationsForStoreUpdate`) do **not** synchronously `setState`, so no second overflow is missed; the flag can't leak (fully synchronous body + `try/finally`, declared per-mount inside the effect); subscriber is torn down on cleanup (no double-subscribe).
- **Behavior regression** — proved the guard is a strict no-op on every non-re-entrant path (byte-identical store state, exactly-once application), residual pending events still retried at ≤100 ms and on every store update (TTL-capped at 15 s exactly as before), and no task-complete notification is missed or newly duplicated.

Only one non-blocking, pre-existing observation surfaced (not introduced here): `applyAgentStatus` isn't independently re-entrancy-guarded — safe today because `flushPendingAgentStatuses` is the only synchronous store-mutating re-entry from the subscriber. No must-fix or should-fix findings.

Made with [Orca](https://github.com/stablyai/orca) 🐋
