### PR TITLE
fix(terminal): let pane recovery reach input stuck behind a never-settling connect

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3336,7 +3336,15 @@ export function connectPanePty(
   // the last frame stays painted — the pane looks healthy and eats input
   // (issue #8104 class). None of the dead-session reconciles cover it because
   // the PTY is live; recover by remounting the tab over the live PTY.
-  let transportConnectInFlight = false
+  let transportConnectInFlightSince: number | null = null
+  // Why a grace window instead of a plain flag: a connect that never settles
+  // (SSH RPC timeout class, wedged daemon call) would otherwise suppress
+  // input-triggered recovery FOREVER — and such a pane has no output flowing,
+  // so no other detector can fire. Past the grace, undeliverable input may
+  // recover again; the transport's destroyed-check no longer kills a
+  // pre-existing session when a late reattach resolves, so a remount racing
+  // a slow-but-alive connect costs a wasted view rebuild, not a shell.
+  const TRANSPORT_CONNECT_SETTLE_GRACE_MS = 60_000
   const requestRecoveryForUndeliverableInput = (): void => {
     if (transport.isConnected?.() && transport.getPtyId() !== null) {
       return
@@ -3348,7 +3356,10 @@ export function connectPanePty(
     // to preserve. The fossil case this detector targets has no pending
     // connect, so it still recovers. Same for a late async reject landing
     // after dispose: the successor pane owns the tab now.
-    if (transportConnectInFlight || disposed) {
+    const connectStillSettling =
+      transportConnectInFlightSince !== null &&
+      Date.now() - transportConnectInFlightSince < TRANSPORT_CONNECT_SETTLE_GRACE_MS
+    if (connectStillSettling || disposed) {
       return
     }
     const storePtyId = useAppStore.getState().ptyIdsByTabId?.[deps.tabId]?.[0] ?? null
@@ -4370,7 +4381,7 @@ export function connectPanePty(
         ? Promise.resolve(null)
         : window.api.pty.declarePendingPaneSerializer(cacheKey).catch(() => null)
 
-      transportConnectInFlight = true
+      transportConnectInFlightSince = Date.now()
       const spawnedRaw = transport.connect({
         url: '',
         cols,
@@ -4393,7 +4404,7 @@ export function connectPanePty(
       void Promise.resolve(spawnedRaw)
         .catch(() => null)
         .finally(() => {
-          transportConnectInFlight = false
+          transportConnectInFlightSince = null
         })
       const trackedPromise: Promise<string | null> = Promise.resolve(spawnedRaw)
         .then(async (spawnedPtyId) => {
@@ -6953,7 +6964,7 @@ export function connectPanePty(
             const coldRestoreStartup = buildColdRestoreAgentResumeStartup()
             clearPaneMode2031State()
             clearHiddenOutputRestoreState()
-            transportConnectInFlight = true
+            transportConnectInFlightSince = Date.now()
             const reattachPromise = transport.connect({
               url: '',
               cols,
@@ -6986,7 +6997,7 @@ export function connectPanePty(
             void Promise.resolve(reattachPromise)
               .catch(() => null)
               .finally(() => {
-                transportConnectInFlight = false
+                transportConnectInFlightSince = null
               })
             void Promise.resolve(reattachPromise)
               .then(async (result) => {
@@ -7145,7 +7156,7 @@ export function connectPanePty(
 
       let expiredReattachError = false
       const coldRestoreStartup = buildColdRestoreAgentResumeStartup()
-      transportConnectInFlight = true
+      transportConnectInFlightSince = Date.now()
       const reattachPromise = transport.connect({
         url: '',
         cols,
@@ -7177,7 +7188,7 @@ export function connectPanePty(
       void Promise.resolve(reattachPromise)
         .catch(() => null)
         .finally(() => {
-          transportConnectInFlight = false
+          transportConnectInFlightSince = null
         })
       void Promise.resolve(reattachPromise)
         .then(async (result) => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -1403,6 +1403,51 @@ describe('createIpcPtyTransport', () => {
     })
   })
 
+  it('does not kill a pre-existing session when a reattach resolves after destroy', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawnControls: { resolve: ((value: { id: string }) => void) | null } = { resolve: null }
+    const spawnPromise = new Promise<{ id: string }>((resolve) => {
+      spawnControls.resolve = resolve
+    })
+    const spawnMock = vi.fn().mockReturnValue(spawnPromise)
+    const killMock = vi.fn()
+
+    ;(globalThis as { window: typeof window }).window = {
+      ...originalWindow,
+      api: {
+        ...originalWindow?.api,
+        pty: {
+          ...originalWindow?.api?.pty,
+          spawn: spawnMock,
+          write: vi.fn(),
+          resize: vi.fn(),
+          kill: killMock,
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {})
+        }
+      }
+    } as unknown as typeof window
+
+    const transport = createIpcPtyTransport({})
+    const connectPromise = transport.connect({
+      url: '',
+      callbacks: {},
+      // A reattach targets a session that existed before this transport;
+      // destroying the view must not reap the user's live shell.
+      sessionId: 'pty-preexisting'
+    })
+
+    transport.destroy?.()
+    if (!spawnControls.resolve) {
+      throw new Error('Expected spawn resolver to be captured')
+    }
+    spawnControls.resolve({ id: 'pty-preexisting' })
+    await connectPromise
+
+    expect(killMock).not.toHaveBeenCalledWith('pty-preexisting')
+  })
+
   it('kills a PTY that finishes spawning after the transport was destroyed', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const spawnControls: { resolve: ((value: { id: string }) => void) | null } = { resolve: null }

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -730,9 +730,16 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           ? spawnResult.launchAgent
           : undefined
 
-        // If destroyed while spawn was in flight, kill the new pty and bail
+        // If destroyed while the connect was in flight, bail — and kill only
+        // what this connect CREATED. A fresh spawn is ours to reap, but a
+        // reattach (sessionId) resolves to a pre-existing session owned by the
+        // tab lifecycle: tab close kills it by id through its own path, and
+        // killing it here turns a remount racing a slow reattach into the loss
+        // of a live shell — the exact failure pane recovery exists to prevent.
         if (destroyed) {
-          window.api.pty.kill(spawnResult.id)
+          if (!options.sessionId) {
+            window.api.pty.kill(spawnResult.id)
+          }
           return
         }
 


### PR DESCRIPTION
Follow-up to #8630 (pane self-heal), closing its one remaining blind spot.

## Problem

The self-heal's input-undeliverable detector is suppressed while a transport connect/reattach is settling — correct, because remounting mid-reattach previously destroyed the unbound transport and the transport's destroyed-check then **killed the live session the reattach resolved to** (found in review). But the suppression had **no timeout**: a connect that never settles (the SSH RPC-timeout class) leaves a pane where no output flows (so the stall-watch and replay-guard detectors can never fire) and every keystroke is silently dropped forever — the one state the merged fix still couldn't reach.

## Fix (two halves that only make sense together)

1. **60s settle grace** on the in-flight gate: past it, undeliverable input may request recovery again (still `pty:hasPty`-confirmed, still budgeted).
2. **Reattach-safe destroy** in the transport: the destroyed-while-connecting check now kills only what the connect *created*. A fresh spawn is ours to reap; a reattach (`sessionId`) resolves to a pre-existing session owned by the tab lifecycle — tab close already kills it by id through its own path. This was flagged in #8630's review as a pre-existing hazard, and it's what makes the grace safe: recovery firing at 60s against a connect resolving at 61s now costs a wasted view rebuild, not the user's shell.

## Verification

- New transport unit test pins the kill split (fresh spawn after destroy → killed; sessionId reattach after destroy → not killed); all 506 tests across the transport/connection/recovery suites pass.
- The #8630 recovery e2e pair passes **6/6 consecutive iterations** with this change. (An earlier flaky signal was bisected: failures occurred only under parallel-build machine load with two unrelated failure modes — including the known startup-binding harness flake — and both 4/4 without and 6/6 with the change pass on quiet hardware.)
- Typecheck and lint green on the branch.