### PR TITLE
fix(mobile): handle base_not_on_remote in PR-create block message

### DIFF
--- a/mobile/src/source-control/mobile-pr-create.ts
+++ b/mobile/src/source-control/mobile-pr-create.ts
@@ -66,6 +66,8 @@ export function getMobilePrCreateBlockMessage(prefill: MobilePrPrefill): string 
       return `A ${copy.reviewLabel} already exists for this branch.`
     case 'fork_head_unsupported':
       return `Creating a ${copy.reviewLabel} from this fork is not supported.`
+    case 'base_not_on_remote':
+      return `Push the base branch before creating a ${copy.reviewLabel}.`
     case 'needs_push':
     case null:
     case undefined:


### PR DESCRIPTION
## Problem

`main` currently fails typecheck:

```
mobile/src/source-control/mobile-pr-create.ts(45): TS2366: Function lacks ending return statement and return type does not include 'undefined'.
```

#8651 added `'base_not_on_remote'` to `HostedReviewCreationBlockedReason` but didn't add a matching `case` to `getMobilePrCreateBlockMessage`. That makes the `switch` non-exhaustive, so the function can fall through and implicitly return `undefined` — which its `string | null` return type disallows.

`verify` doesn't run on direct pushes to `main`, so this slipped in there and only surfaces on PR **merge-commit** type-checks (it's currently failing every open PR's `verify`).

## Fix

Add the missing case with terse, actionable copy consistent with the mobile switch's other messages and #8651's desktop create-time wording (*"the base branch … hasn't been pushed to the remote. Choose a pushed base or push it first."*):

```ts
case 'base_not_on_remote':
  return `Push the base branch before creating a ${copy.reviewLabel}.`
```

## Notes

- One-line completion of #8651; same class of merge-race switch break as #8660.
- Unblocks `verify` on other open PRs once merged.