### PR TITLE
fix(sidebar): guard kanban worktree sort against undefined displayName (crash 99657ab1)

### DIFF
--- a/src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.test.ts
@@ -68,6 +68,57 @@ describe('groupWorkspaceKanbanWorktrees', () => {
     expect(grouped.get('doing')?.map((item) => item.id)).toEqual(['b', 'c', 'a'])
   })
 
+  it('does not crash when a worktree is missing its displayName under Manual sort', () => {
+    // Repro for crash 99657ab1: a worktree reached the sidebar with an
+    // undefined displayName, so `a.displayName.localeCompare(...)` threw
+    // `Cannot read properties of undefined (reading 'localeCompare')`.
+    expect(() =>
+      groupWorkspaceKanbanWorktrees({
+        worktrees: [
+          worktree({
+            id: 'a',
+            displayName: undefined as unknown as string,
+            workspaceStatus: 'doing',
+            manualOrder: 100
+          }),
+          worktree({
+            id: 'b',
+            displayName: undefined as unknown as string,
+            workspaceStatus: 'doing',
+            manualOrder: 100
+          })
+        ],
+        visibleWorktreeIds: new Set(['a', 'b']),
+        workspaceStatuses: statuses,
+        sortBy: 'manual'
+      })
+    ).not.toThrow()
+  })
+
+  it('does not crash when a worktree is missing its displayName outside Manual sort', () => {
+    expect(() =>
+      groupWorkspaceKanbanWorktrees({
+        worktrees: [
+          worktree({
+            id: 'a',
+            displayName: undefined as unknown as string,
+            workspaceStatus: 'doing',
+            lastActivityAt: 10
+          }),
+          worktree({
+            id: 'b',
+            displayName: undefined as unknown as string,
+            workspaceStatus: 'doing',
+            lastActivityAt: 10
+          })
+        ],
+        visibleWorktreeIds: new Set(['a', 'b']),
+        workspaceStatuses: statuses,
+        sortBy: 'recent'
+      })
+    ).not.toThrow()
+  })
+
   it('keeps pinned then recent ordering outside Manual sort', () => {
     const grouped = groupWorkspaceKanbanWorktrees({
       worktrees: [

--- a/src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.ts
@@ -2,15 +2,20 @@ import type { WorkspaceStatus, WorkspaceStatusDefinition, Worktree } from '../..
 import type { SortBy } from './smart-sort'
 import { getWorkspaceStatus } from './workspace-status'
 
+// Why: displayName is typed non-optional, but persisted/discovered worktrees
+// have reached the sidebar with an undefined name (crash 99657ab1), which made
+// `displayName.localeCompare(...)` throw and took down the sidebar. Compare on a
+// safe string so a missing name only affects tie-break order, never crashes.
+function compareDisplayName(a: Worktree, b: Worktree): number {
+  return (a.displayName ?? '').localeCompare(b.displayName ?? '')
+}
+
 function sortBoardWorktrees(a: Worktree, b: Worktree): number {
-  return b.lastActivityAt - a.lastActivityAt || a.displayName.localeCompare(b.displayName)
+  return b.lastActivityAt - a.lastActivityAt || compareDisplayName(a, b)
 }
 
 function sortManualBoardWorktrees(a: Worktree, b: Worktree): number {
-  return (
-    (b.manualOrder ?? b.sortOrder) - (a.manualOrder ?? a.sortOrder) ||
-    a.displayName.localeCompare(b.displayName)
-  )
+  return (b.manualOrder ?? b.sortOrder) - (a.manualOrder ?? a.sortOrder) || compareDisplayName(a, b)
 }
 
 export function groupWorkspaceKanbanWorktrees(params: {


### PR DESCRIPTION
@
## Description

Fixes Windows crash report **99657ab1** (react-error-boundary, `boundary_id: sidebar.worktrees`), version 1.4.137.

A worktree reached the sidebar with an **`undefined` `displayName`**. The kanban lane sort comparator then executed `a.displayName.localeCompare(b.displayName)` and threw:

```
TypeError: Cannot read properties of undefined (reading localeCompare)
  at sortManualBoardWorktrees
  at Array.sort (<anonymous>)
  at groupWorkspaceKanbanWorktrees
  at WorkspaceKanbanDrawer (useMemo)
```

This unmounted the entire `sidebar.worktrees` error boundary — the sidebar disappeared. Although the report is Windows-only, the bug is **cross-platform JS**: any worktree with a missing `displayName` triggers it on any OS.

Both kanban comparators (`sortManualBoardWorktrees` for Manual sort, `sortBoardWorktrees` for Recent/other sort) share the same unguarded call, so both paths are affected.

## Fix

Route both comparators through a single null-safe helper:

```ts
function compareDisplayName(a: Worktree, b: Worktree): number {
  return (a.displayName ?? ).localeCompare(b.displayName ?? )
}
```

A missing name now only affects tie-break ordering instead of crashing the sidebar. When `displayName` is present (the overwhelmingly common case), `(a.displayName ?? )` is identically `a.displayName`, so **sort order is unchanged**.

## Fix evidence (clear & undeniable)

Regression tests reproduce the exact crash, then verify the fix. The tests force the comparator to actually be *reached* (equal primary-sort term → falls through to the name tie-break) and give both worktrees an undefined name so the crash is deterministic regardless of V8 sort argument order.

**Before the fix** (repro confirmed — identical error string to the crash report):
```
× does not crash when a worktree is missing its displayName under Manual sort
× does not crash when a worktree is missing its displayName outside Manual sort
  TypeError: Cannot read properties of undefined (reading 'localeCompare')
```

**After the fix:**
```
✓ workspace-kanban-worktree-groups.test.ts (4 tests) — 4 passed
```

Also verified: `oxlint` clean on both files, `tsc --noEmit -p config/tsconfig.tc.web.json` exit 0.

## ELI5

Orca sorts the workspace cards in the sidebar by name. Sorting compares two names letter-by-letter. One workspace somehow had **no name at all** (blank/undefined), and asking a blank name to compare itself made the code explode — which knocked out the whole sidebar. Now we treat a missing name as an empty string, so sorting just puts it wherever and keeps calm instead of crashing.

## Trade-offs / behavior changes

- **None negative.** For worktrees with a normal name, sort output is byte-for-byte identical.
- A worktree with a genuinely missing name now sorts as if its name were `""` (it sorts first alphabetically within its lane) instead of taking down the sidebar. This is strictly better than the crash.
- This is a **leaf/crash-boundary guard**. The deeper question of *why* a worktree reaches the sidebar with an undefined `displayName` (the `Worktree` type declares it non-optional) is a separate, larger investigation and is intentionally out of scope for this crash fix.

## Adversarial review

Two independent adversarial review loops were run to clean:

- **Loop 1 (correctness lens):** Verified the fix closes the only `.localeCompare` path; confirmed undefined numeric fields (`lastActivityAt`, `sortOrder`) degrade to `NaN`→falsy tie-break rather than throwing; confirmed the regression tests genuinely reach the comparator and fail-before/pass-after. Result: **CLEAN**.
- **Loop 2 (sibling-crash-path lens):** Swept all sidebar render-path `displayName` method calls to check the boundary can't still crash via a different call. Found the list-view sort (`smart-sort.ts`) and card title (`worktree-card-title-display.ts`) already guard undefined names; confirmed no unguarded sibling call exists in the boundary's render path. Result: **CLEAN**.

Both loops flagged two *non-render-path* unguarded `.displayName.localeCompare` calls (`use-complete-git-repo-add.ts`, `add-repo-existing-workspaces-telemetry.ts`) as pre-existing, separate follow-ups — they run in async/telemetry paths and cannot reproduce this render crash, so they are left out to keep this PR tightly scoped.
@