### PR TITLE
fix(terminal): prevent Windows multiline paste submission

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-send.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send.test.ts
@@ -23,12 +23,12 @@ describe('buildNativeChatPasteBytes', () => {
   })
 
   it('multi-line text is bracketed-paste wrapped with NO trailing submit', () => {
-    const text = 'line one\nline two'
-    expect(buildNativeChatPasteBytes(text)).toBe(`${BEGIN}${text}${END}`)
+    const text = 'line one\r\nline two\nline three'
+    expect(buildNativeChatPasteBytes(text)).toBe(`${BEGIN}line one\rline two\rline three${END}`)
   })
 
   it('treats a trailing newline as multi-line', () => {
-    expect(buildNativeChatPasteBytes('a\n')).toBe(`${BEGIN}a\n${END}`)
+    expect(buildNativeChatPasteBytes('a\n')).toBe(`${BEGIN}a\r${END}`)
   })
 
   it('sanitizes an embedded bracketed-paste end and bare ESC before framing', () => {
@@ -67,11 +67,11 @@ describe('buildNativeChatSendBytes', () => {
 
   it('multi-line text is bracketed-paste wrapped then submitted', () => {
     const text = 'line one\nline two'
-    expect(buildNativeChatSendBytes(text)).toBe(`${BEGIN}${text}${END}\r`)
+    expect(buildNativeChatSendBytes(text)).toBe(`${BEGIN}line one\rline two${END}\r`)
   })
 
   it('treats a trailing newline as multi-line', () => {
-    expect(buildNativeChatSendBytes('a\n')).toBe(`${BEGIN}a\n${END}\r`)
+    expect(buildNativeChatSendBytes('a\n')).toBe(`${BEGIN}a\r${END}\r`)
   })
 
   it('handles CR-style line breaks as multi-line', () => {

--- a/src/renderer/src/components/native-chat/native-chat-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send.ts
@@ -1,14 +1,10 @@
 // Pure: turn raw composer text into the exact PTY bytes to write. Kept separate
 // from the React composer so the byte rules are unit-testable without a DOM.
 
-import { sanitizeBracketedPasteText } from '../terminal-pane/terminal-bracketed-paste'
-
-// Why: bracketed-paste markers let modern agent TUIs (Claude / Codex / etc.)
-// treat injected multi-line text as one atomic paste instead of running each
-// embedded newline as a line-edit / submit. Mirrors agent-paste-draft.ts and
-// terminal-bracketed-paste.ts so native input is byte-identical to a real paste.
-const BRACKETED_PASTE_BEGIN = '\x1b[200~'
-const BRACKETED_PASTE_END = '\x1b[201~'
+import {
+  sanitizeBracketedPasteText,
+  wrapTerminalBracketedPasteText
+} from '../terminal-pane/terminal-bracketed-paste'
 
 // Why: carriage return (not \n) is what xterm/agent composers treat as the
 // submit/Enter key over a PTY.
@@ -36,20 +32,18 @@ export const NATIVE_CHAT_SUBMIT = SUBMIT
  * write (mirrors orca-runtime's writeTerminalAction Enter handling).
  */
 export function buildNativeChatPasteBytes(text: string): string {
-  // Why: a stray ESC in the draft (e.g. pasted scrollback carrying its own
-  // `\x1b[201~`) would otherwise close the bracketed-paste frame early and run
-  // the tail as live keystrokes. Sanitize ESC on both branches before framing.
-  const safe = sanitizeBracketedPasteText(text)
-  if (isMultilineDraft(safe)) {
-    return `${BRACKETED_PASTE_BEGIN}${safe}${BRACKETED_PASTE_END}`
+  if (isMultilineDraft(text)) {
+    return wrapTerminalBracketedPasteText(text)
   }
-  return safe
+  // Why: sanitize even unframed text so pasted scrollback cannot carry a raw
+  // terminal escape into the agent composer.
+  return sanitizeBracketedPasteText(text)
 }
 
 /** Image attachments must look like a real terminal image paste to Claude/Codex
  *  TUIs. A plain typed path (or @file mention) is treated as text/file-read. */
 export function buildNativeChatImagePasteBytes(filePath: string): string {
-  return `${BRACKETED_PASTE_BEGIN}${sanitizeBracketedPasteText(filePath)}${BRACKETED_PASTE_END}`
+  return wrapTerminalBracketedPasteText(filePath)
 }
 
 /**

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
@@ -89,6 +89,17 @@ describe('terminal bracketed paste policy', () => {
     expect(terminal.options.ignoreBracketedPasteMode).toBe(false)
   })
 
+  it('normalizes forced Windows multiline paste like xterm native paste', () => {
+    const terminal = createTerminal(false)
+
+    pasteTerminalText(terminal, 'one\r\ntwo\nthree', {
+      forceBracketedPaste: true
+    })
+
+    expect(terminal.input).toHaveBeenCalledWith('\x1b[200~one\rtwo\rthree\x1b[201~')
+    expect(terminal.paste).not.toHaveBeenCalled()
+  })
+
   it('renders embedded escape bytes inert when forcing bracketed paste', () => {
     const terminal = createTerminal(false)
 

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -66,8 +66,15 @@ export function sanitizeTerminalPasteText(text: string): string {
   return sanitizeBracketedPasteText(text)
 }
 
+export function normalizeTerminalPasteLineEndings(text: string): string {
+  // Why: xterm's native paste path converts every clipboard newline to CR.
+  // Direct frames must match it or ConPTY TUIs can treat raw LF as submit.
+  return text.replace(/\r?\n/g, '\r')
+}
+
 export function wrapTerminalBracketedPasteText(text: string): string {
-  return `${BRACKETED_PASTE_START}${sanitizeBracketedPasteText(text)}${BRACKETED_PASTE_END}`
+  const normalizedText = normalizeTerminalPasteLineEndings(text)
+  return `${BRACKETED_PASTE_START}${sanitizeBracketedPasteText(normalizedText)}${BRACKETED_PASTE_END}`
 }
 
 function forceBracketedPaste(terminal: PasteTerminal, text: string): void {

--- a/src/renderer/src/components/terminal-pane/terminal-paste-chunks.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-chunks.ts
@@ -1,4 +1,8 @@
-import { BRACKETED_PASTE_END, BRACKETED_PASTE_START } from './terminal-bracketed-paste'
+import {
+  BRACKETED_PASTE_END,
+  BRACKETED_PASTE_START,
+  normalizeTerminalPasteLineEndings
+} from './terminal-bracketed-paste'
 import { TERMINAL_PASTE_CHUNK_MAX_BYTES } from './terminal-paste-limits'
 import type { TerminalPastePlan } from './terminal-paste-coordinator'
 
@@ -12,10 +16,16 @@ export function chunkTerminalPastePlan(plan: TerminalPastePlan): string[] {
 
 export function* iterateTerminalPastePlanChunks(plan: TerminalPastePlan): Generator<string> {
   const maxChunkBytes = Math.max(4, plan.maxChunkBytes ?? TERMINAL_PASTE_CHUNK_MAX_BYTES)
+  // Why: normalize before chunking — a per-chunk pass could split a CRLF pair
+  // across a boundary and leak the LF half to ConPTY as a submit.
+  const text =
+    plan.newlinePolicy === 'terminal-cr'
+      ? normalizeTerminalPasteLineEndings(plan.payload.plainText)
+      : plan.payload.plainText
   if (plan.bracketed) {
     yield BRACKETED_PASTE_START
   }
-  yield* iterateTextByUtf8Bytes(plan.payload.plainText, maxChunkBytes, plan.bracketed)
+  yield* iterateTextByUtf8Bytes(text, maxChunkBytes, plan.bracketed)
   if (plan.bracketed) {
     yield BRACKETED_PASTE_END
   }

--- a/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.test.ts
@@ -204,6 +204,27 @@ describe('terminal paste coordinator', () => {
     expect(chunks.slice(1, -1).join('')).not.toContain('\x1b[201~')
   })
 
+  it('normalizes forced multiline chunked paste line endings like xterm native paste', () => {
+    // Why: 4-byte chunks would split this CRLF pair ('abc\r' | '\ndef'), so the
+    // pre-chunk normalization is what keeps the LF half away from ConPTY.
+    const plan = planTerminalPaste({
+      text: 'abc\r\ndef\nghi',
+      source: 'keyboard',
+      target: terminalTarget(),
+      forceBracketedPasteForMultiline: true,
+      maxDirectBytes: 4,
+      maxChunkBytes: 4
+    })
+    const chunks = chunkTerminalPastePlan(plan)
+
+    expect(plan.mode).toBe('chunked')
+    expect(plan.newlinePolicy).toBe('terminal-cr')
+    expect(chunks[0]).toBe(BRACKETED_PASTE_START)
+    expect(chunks.at(-1)).toBe(BRACKETED_PASTE_END)
+    expect(chunks.slice(1, -1).join('')).toBe('abc\rdef\rghi')
+    expect(chunks.join('')).not.toContain('\n')
+  })
+
   it('chunks escape-heavy bracketed paste without per-character string sanitizer scans', () => {
     const text = Array.from({ length: 64 }, (_value, index) => `part-${index}\x1b[201~`).join('')
     const plan = planTerminalPaste({

--- a/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.ts
@@ -173,7 +173,7 @@ function buildTerminalPastePlan({
     target,
     payload,
     mode,
-    newlinePolicy: 'preserve',
+    newlinePolicy: effectiveForceBracketedPaste ? 'terminal-cr' : 'preserve',
     runtimeKey: target.runtime.runtimeKey,
     ...(shouldChunk ? { maxChunkBytes } : {}),
     bracketed: mode === 'bracketed-terminal' || (mode === 'chunked' && shouldBracketChunk),

--- a/src/renderer/src/components/terminal-pane/terminal-paste-model.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-model.ts
@@ -35,7 +35,9 @@ export type TerminalPastePlan = {
   target: TerminalPasteTarget
   payload: TerminalPastePayload
   mode: 'direct' | 'chunked' | 'bracketed-terminal' | 'reject'
-  newlinePolicy: 'preserve' | 'windows-crlf' | 'posix-lf' | 'target-default'
+  // Why: 'terminal-cr' marks plans whose paste bytes Orca constructs itself, so
+  // every write path applies xterm's native \r?\n -> \r before ConPTY sees LF.
+  newlinePolicy: 'preserve' | 'terminal-cr'
   runtimeKey: string
   maxChunkBytes?: number
   bracketed: boolean

--- a/src/renderer/src/components/terminal-pane/terminal-paste-multiline-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-multiline-policy.test.ts
@@ -48,6 +48,8 @@ describe('terminal paste multiline policy', () => {
 
     expect(multilinePlan.mode).toBe('bracketed-terminal')
     expect(singleLinePlan.mode).toBe('direct')
+    expect(multilinePlan.newlinePolicy).toBe('terminal-cr')
+    expect(singleLinePlan.newlinePolicy).toBe('preserve')
     expect(pasteText).toHaveBeenNthCalledWith(1, 'one\r\ntwo', { forceBracketedPaste: true })
     expect(pasteText).toHaveBeenNthCalledWith(2, 'one', { forceBracketedPaste: false })
   })

--- a/src/renderer/src/lib/agent-draft-paste-content.ts
+++ b/src/renderer/src/lib/agent-draft-paste-content.ts
@@ -2,7 +2,8 @@ import type { GlobalSettings } from '../../../shared/types'
 import {
   BRACKETED_PASTE_END,
   BRACKETED_PASTE_START,
-  sanitizeTerminalPasteText
+  normalizeTerminalPasteLineEndings,
+  wrapTerminalBracketedPasteText
 } from '@/components/terminal-pane/terminal-bracketed-paste'
 import { sendRuntimePtyInputVerified } from '@/runtime/runtime-terminal-inspection'
 
@@ -28,26 +29,27 @@ export async function sendAgentDraftPasteContent(
     return false
   }
 
-  const directMeasurement = measureSanitizedUtf8ByteLength(content, {
+  const terminalContent = normalizeTerminalPasteLineEndings(content)
+  const directMeasurement = measureSanitizedUtf8ByteLength(terminalContent, {
     stopAfterBytes: AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES
   })
   if (!directMeasurement.exceededLimit) {
     return await writeAgentDraftPtyInput(
       settings,
       ptyId,
-      [BRACKETED_PASTE_START, sanitizeTerminalPasteText(content), BRACKETED_PASTE_END].join(''),
+      wrapTerminalBracketedPasteText(terminalContent),
       writePty
     )
   }
 
   // Why: generated prompts can be paste-sized; yield during accepted-size
   // preflight before starting any PTY writes so the renderer is not pinned.
-  if (await isSanitizedDraftPasteOverLimit(content, AGENT_DRAFT_PASTE_MAX_BYTES)) {
+  if (await isSanitizedDraftPasteOverLimit(terminalContent, AGENT_DRAFT_PASTE_MAX_BYTES)) {
     return false
   }
 
   let bracketedPasteOpen = false
-  for (const chunk of iterateAgentDraftPasteContentChunks(content)) {
+  for (const chunk of iterateAgentDraftPasteContentChunks(terminalContent)) {
     let accepted = false
     try {
       accepted = await writeAgentDraftPtyInput(settings, ptyId, chunk, writePty)
@@ -85,16 +87,19 @@ export function* iterateAgentDraftPasteContentChunks(
 ): Generator<string> {
   const safeMaxChunkBytes = Math.max(4, maxChunkBytes)
   yield BRACKETED_PASTE_START
+  // Why: normalize the complete draft before chunking so a CRLF pair cannot
+  // straddle chunks and leak its LF half to a Windows ConPTY agent.
+  const terminalContent = normalizeTerminalPasteLineEndings(content)
   let chunk = ''
   let chunkBytes = 0
 
-  for (let index = 0; index < content.length; index += 1) {
-    const codePoint = content.codePointAt(index) ?? 0
+  for (let index = 0; index < terminalContent.length; index += 1) {
+    const codePoint = terminalContent.codePointAt(index) ?? 0
     const codeUnitLength = codePoint > 0xffff ? 2 : 1
     const sanitizedEscape = codePoint === AGENT_DRAFT_PASTE_ESCAPE_CODE_POINT
     const sanitized = sanitizedEscape
       ? AGENT_DRAFT_PASTE_INERT_ESCAPE
-      : content.slice(index, index + codeUnitLength)
+      : terminalContent.slice(index, index + codeUnitLength)
     const characterBytes = getUtf8ByteLengthForCodePoint(
       sanitizedEscape ? AGENT_DRAFT_PASTE_INERT_ESCAPE_CODE_POINT : codePoint
     )

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -605,6 +605,21 @@ describe('pasteDraftWhenAgentReady', () => {
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenLastCalledWith({}, 'pty-1', '\r')
   })
 
+  it('normalizes multiline running-agent drafts like terminal paste', async () => {
+    const promise = sendBracketedPasteToRunningAgent({
+      ptyId: 'pty-1',
+      content: 'line one\r\nline two\nline three'
+    })
+
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      '\x1b[200~line one\rline two\rline three\x1b[201~'
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    await expect(promise).resolves.toBe(true)
+  })
+
   it('closes bracketed paste and does not submit when a chunked draft write is rejected', async () => {
     testState.sendRuntimePtyInputVerified
       .mockResolvedValueOnce(true)
@@ -636,6 +651,13 @@ describe('pasteDraftWhenAgentReady', () => {
     expect(chunks.at(-1)).toBe('\x1b[201~')
     expect(chunks.slice(1, -1).join('')).toBe('before␛[201~after😀')
     expect(chunks.slice(1, -1).join('')).not.toContain('\x1b[201~')
+  })
+
+  it('normalizes agent draft line endings before a CRLF chunk boundary', () => {
+    const chunks = chunkAgentDraftPasteContent('abc\r\ndef\nghi', 4)
+
+    expect(chunks).toEqual(['\x1b[200~', 'abc\r', 'def\r', 'ghi', '\x1b[201~'])
+    expect(chunks.join('')).not.toContain('\n')
   })
 
   it('chunks escape-heavy agent draft paste without per-character string sanitizer scans', () => {

--- a/tests/e2e/terminal-paste-ownership.spec.ts
+++ b/tests/e2e/terminal-paste-ownership.spec.ts
@@ -312,7 +312,7 @@ test.describe('terminal paste ownership', () => {
     }
   })
 
-  test('Windows multiline keyboard paste preserves terminal content with one PTY owner', async ({
+  test('Windows multiline keyboard paste normalizes terminal newlines with one PTY owner', async ({
     electronApp,
     orcaPage,
     testRepoPath
@@ -336,8 +336,11 @@ test.describe('terminal paste ownership', () => {
       'Unicode: caf\u00e9 \u4f60\u597d \u0645\u0631\u062d\u0628\u0627 \ud83d\ude00',
       `mixed-newline-before\r\nlf-line\ncrlf-line\r\n${sentinel}`
     ].join('\n')
+    // Why: xterm translates clipboard line endings to terminal Enter bytes;
+    // Orca's direct Windows bracketed-paste path must produce the same bytes.
+    const terminalText = payload.replace(/\r?\n/g, '\r')
     const scriptPath = path.join(testRepoPath, `.orca-paste-multiline-${runId}.mjs`)
-    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, payload))
+    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, terminalText))
     let scriptStarted = false
 
     try {
@@ -353,7 +356,7 @@ test.describe('terminal paste ownership', () => {
       await waitForTerminalOutput(orcaPage, `PASTE_COMPLETE_${runId}:MATCH`, 10_000, 12_000)
 
       const writes = (await readTerminalPtyWrites(electronApp)).join('')
-      expect(countOccurrences(writes, payload), 'multiline payload PTY write count').toBe(1)
+      expect(countOccurrences(writes, terminalText), 'multiline payload PTY write count').toBe(1)
     } finally {
       if (scriptStarted) {
         await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)

--- a/tests/e2e/terminal-windows-codex-multiline-paste.spec.ts
+++ b/tests/e2e/terminal-windows-codex-multiline-paste.spec.ts
@@ -1,3 +1,6 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import {
   focusActiveTerminalInput,
@@ -12,7 +15,7 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 const DRAFT = 'ORCA_CODEX_PASTE_DRAFT_SHOULD_STAY_UNSENT'
 const CODEX_TRUST_PROMPT_RE = /Do[\s\S]*you[\s\S]*trust[\s\S]*contents/i
 
-function pastePayload(): string {
+function pastePayload(repeats = 4): string {
   const lines = [
     'Repository: stablyai/orca',
     '',
@@ -44,7 +47,68 @@ function pastePayload(): string {
     '',
     'If anything fails, include the first useful stack trace and distinguish product failure from test-harness or environmental failure.'
   ]
-  return Array.from({ length: 4 }, () => lines.join('\r\n')).join('\r\n\r\n')
+  return Array.from({ length: repeats }, () => lines.join('\r\n')).join('\r\n\r\n')
+}
+
+async function activateTestRepository(
+  page: Parameters<typeof focusActiveTerminalInput>[0],
+  repoPath: string
+): Promise<void> {
+  await page.evaluate(async (targetRepoPath) => {
+    const normalizePath = (value: string): string => value.replaceAll('\\', '/').toLowerCase()
+    await window.api.repos.add({ path: targetRepoPath })
+    const store = window.__store
+    if (!store) {
+      throw new Error('Orca store unavailable')
+    }
+    await store.getState().fetchRepos()
+    const repo = store
+      .getState()
+      .repos.find((candidate) => normalizePath(candidate.path) === normalizePath(targetRepoPath))
+    if (!repo) {
+      throw new Error('Seeded repository unavailable')
+    }
+    await store.getState().updateRepo(repo.id, { externalWorktreeVisibility: 'show' })
+    await store.getState().fetchWorktrees(repo.id)
+    const worktree = store
+      .getState()
+      .worktreesByRepo[repo.id]?.find(
+        (candidate) => normalizePath(candidate.path) === normalizePath(targetRepoPath)
+      )
+    if (!worktree) {
+      throw new Error('Seeded worktree unavailable')
+    }
+    store.getState().setActiveWorktree(worktree.id)
+    store.getState().createTab(worktree.id)
+  }, repoPath)
+}
+
+function pasteCollectorScript(
+  expectedLength: number,
+  expectedHash: string,
+  marker: string
+): string {
+  return `
+import { createHash } from 'node:crypto'
+process.stdin.setEncoding('utf8')
+if (process.stdin.isTTY) process.stdin.setRawMode(true)
+process.stdin.resume()
+let received = ''
+const start = String.fromCharCode(27) + '[200~'
+const end = String.fromCharCode(27) + '[201~'
+process.stdout.write(${JSON.stringify(`${marker}_READY`)} + '\\n')
+process.stdin.on('data', (chunk) => {
+  received += chunk
+  const startIndex = received.indexOf(start)
+  const endIndex = received.indexOf(end, Math.max(0, startIndex + start.length))
+  if (startIndex === -1 || endIndex === -1) return
+  const body = received.slice(startIndex + start.length, endIndex)
+  const hash = createHash('sha256').update(body).digest('hex')
+  const matches = body.length === ${expectedLength} && hash === ${JSON.stringify(expectedHash)}
+  process.stdout.write(${JSON.stringify(`${marker}_RESULT:`)} + (matches ? 'MATCH' : 'MISMATCH') + ':' + body.length + ':' + hash + '\\n')
+  process.exit(matches ? 0 : 1)
+})
+`
 }
 
 async function enableTerminalAccessibilityDom(
@@ -69,6 +133,17 @@ async function enableTerminalAccessibilityDom(
   ).toBeAttached({ timeout: 10_000 })
 }
 
+async function waitForCodexComposerReady(
+  page: Parameters<typeof focusActiveTerminalInput>[0]
+): Promise<void> {
+  // Why: Codex can render its header before delayed MCP startup takes over the
+  // composer. Let that startup begin, then paste only after the TUI is idle.
+  await page.waitForTimeout(5_000)
+  await expect
+    .poll(async () => await getTerminalContent(page, 12_000), { timeout: 60_000 })
+    .not.toMatch(/Booting MCP server|tab to queue message/i)
+}
+
 test.describe('Windows Codex multiline paste', () => {
   test.use({ seedTestRepo: false })
 
@@ -84,33 +159,7 @@ test.describe('Windows Codex multiline paste', () => {
     test.slow()
 
     await waitForSessionReady(orcaPage)
-    await orcaPage.evaluate(async (repoPath) => {
-      const normalizePath = (value: string): string => value.replaceAll('\\', '/').toLowerCase()
-      await window.api.repos.add({ path: repoPath })
-      const store = window.__store
-      if (!store) {
-        throw new Error('Orca store unavailable')
-      }
-      await store.getState().fetchRepos()
-      const repo = store
-        .getState()
-        .repos.find((candidate) => normalizePath(candidate.path) === normalizePath(repoPath))
-      if (!repo) {
-        throw new Error('Seeded repository unavailable')
-      }
-      await store.getState().updateRepo(repo.id, { externalWorktreeVisibility: 'show' })
-      await store.getState().fetchWorktrees(repo.id)
-      const worktree = store
-        .getState()
-        .worktreesByRepo[repo.id]?.find(
-          (candidate) => normalizePath(candidate.path) === normalizePath(repoPath)
-        )
-      if (!worktree) {
-        throw new Error('Seeded worktree unavailable')
-      }
-      store.getState().setActiveWorktree(worktree.id)
-      store.getState().createTab(worktree.id)
-    }, testRepoPath)
+    await activateTestRepository(orcaPage, testRepoPath)
     await waitForActiveWorktree(orcaPage)
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage, 30_000)
@@ -124,6 +173,7 @@ test.describe('Windows Codex multiline paste', () => {
       await sendToTerminal(orcaPage, ptyId, '\r')
     }
     await waitForTerminalOutput(orcaPage, 'OpenAI Codex', 20_000, 30_000)
+    await waitForCodexComposerReady(orcaPage)
     await enableTerminalAccessibilityDom(orcaPage, ptyId)
     await focusActiveTerminalInput(orcaPage)
     await orcaPage.keyboard.type(DRAFT)
@@ -139,5 +189,44 @@ test.describe('Windows Codex multiline paste', () => {
     await orcaPage.waitForTimeout(2_000)
     await expect(terminalDom).not.toContainText('Working')
     await expect(terminalDom).not.toContainText('unexpected status 404')
+  })
+
+  test('delivers a normalized large paste through native ConPTY', async ({
+    orcaPage,
+    testRepoPath
+  }) => {
+    test.skip(process.platform !== 'win32', 'Windows ConPTY coverage is Windows-only')
+    test.slow()
+
+    await waitForSessionReady(orcaPage)
+    await activateTestRepository(orcaPage, testRepoPath)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const payload = pastePayload(100)
+    const expectedText = payload.replace(/\r?\n/g, '\r')
+    expect(Buffer.byteLength(payload, 'utf8')).toBeGreaterThan(64 * 1024)
+    const expectedHash = createHash('sha256').update(expectedText).digest('hex')
+    const marker = `ORCA_LARGE_PASTE_${randomUUID().replaceAll('-', '')}`
+    const scriptPath = path.join(testRepoPath, `.${marker}.mjs`)
+    writeFileSync(scriptPath, pasteCollectorScript(expectedText.length, expectedHash, marker))
+
+    try {
+      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      await waitForTerminalOutput(orcaPage, `${marker}_READY`, 10_000, 12_000)
+      await enableTerminalAccessibilityDom(orcaPage, ptyId)
+      await focusActiveTerminalInput(orcaPage)
+      await orcaPage.evaluate((text) => window.api.ui.writeClipboardText(text), payload)
+
+      await orcaPage.keyboard.press('Control+V')
+      const terminalDom = orcaPage.locator(
+        `[data-pty-id=${JSON.stringify(ptyId)}] .xterm-accessibility-tree`
+      )
+      await expect(terminalDom).toContainText(`${marker}_RESULT:MATCH`, { timeout: 30_000 })
+    } finally {
+      rmSync(scriptPath, { force: true })
+    }
   })
 })

--- a/tests/e2e/terminal-windows-codex-multiline-paste.spec.ts
+++ b/tests/e2e/terminal-windows-codex-multiline-paste.spec.ts
@@ -142,6 +142,12 @@ async function waitForCodexComposerReady(
   await expect
     .poll(async () => await getTerminalContent(page, 12_000), { timeout: 60_000 })
     .not.toMatch(/Booting MCP server|tab to queue message/i)
+  // Why: absence of boot states alone can pass on an empty screen; the idle
+  // composer placeholder is the positive ready marker (mirrors the product's
+  // codex-composer-prompt draft-paste signal).
+  await expect
+    .poll(async () => await getTerminalContent(page, 12_000), { timeout: 60_000 })
+    .toMatch(/Ask Codex/i)
 }
 
 test.describe('Windows Codex multiline paste', () => {
@@ -205,9 +211,12 @@ test.describe('Windows Codex multiline paste', () => {
     await waitForActiveTerminalManager(orcaPage, 30_000)
 
     const ptyId = await waitForActivePanePtyId(orcaPage)
-    const payload = pastePayload(100)
+    const payload = pastePayload(110)
     const expectedText = payload.replace(/\r?\n/g, '\r')
-    expect(Buffer.byteLength(payload, 'utf8')).toBeGreaterThan(64 * 1024)
+    // Why: assert on the normalized size so the payload keeps exercising the
+    // chunked (>64 KiB direct-max) lane even if planning ever measures
+    // post-normalization bytes.
+    expect(Buffer.byteLength(expectedText, 'utf8')).toBeGreaterThan(64 * 1024)
     const expectedHash = createHash('sha256').update(expectedText).digest('hex')
     const marker = `ORCA_LARGE_PASTE_${randomUUID().replaceAll('-', '')}`
     const scriptPath = path.join(testRepoPath, `.${marker}.mjs`)

--- a/tests/e2e/terminal-windows-codex-multiline-paste.spec.ts
+++ b/tests/e2e/terminal-windows-codex-multiline-paste.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from './helpers/orca-app'
+import {
+  focusActiveTerminalInput,
+  getTerminalContent,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const DRAFT = 'ORCA_CODEX_PASTE_DRAFT_SHOULD_STAY_UNSENT'
+const CODEX_TRUST_PROMPT_RE = /Do[\s\S]*you[\s\S]*trust[\s\S]*contents/i
+
+function pastePayload(): string {
+  const lines = [
+    'Repository: stablyai/orca',
+    '',
+    'Required exact revision:',
+    '',
+    '0123456789abcdef0123456789abcdef01234567',
+    '',
+    'This is validation only:',
+    '',
+    '- Do not modify files.',
+    '',
+    '- Do not commit or push.',
+    '',
+    '- If the worktree is dirty before starting, stop and report it.',
+    '',
+    '- Use native Windows PowerShell, Node 24, and pnpm 10.',
+    '',
+    '- Confirm the checked-out full SHA before testing.',
+    '',
+    'Run:',
+    '',
+    '1. pnpm typecheck',
+    '',
+    '2. pnpm lint',
+    '',
+    '3. Run the focused Node 24 suite and report every result.',
+    '',
+    '4. Run the registered Electron gate exactly as written.',
+    '',
+    'If anything fails, include the first useful stack trace and distinguish product failure from test-harness or environmental failure.'
+  ]
+  return Array.from({ length: 4 }, () => lines.join('\r\n')).join('\r\n\r\n')
+}
+
+async function enableTerminalAccessibilityDom(
+  page: Parameters<typeof focusActiveTerminalInput>[0],
+  ptyId: string
+): Promise<void> {
+  await page.evaluate((targetPtyId) => {
+    const managers = Array.from(window.__paneManagers?.values() ?? [])
+    const pane = managers
+      .flatMap((manager) => manager.getPanes?.() ?? [])
+      .find((candidate) => candidate.container.dataset.ptyId === targetPtyId)
+    if (!pane) {
+      throw new Error(`Terminal pane ${targetPtyId} is unavailable`)
+    }
+    // Why: xterm paints to canvas by default. Screen-reader mode mirrors the
+    // visible prompt into DOM rows so the regression assertions stay user-facing.
+    pane.terminal.options.screenReaderMode = true
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+  }, ptyId)
+  await expect(
+    page.locator(`[data-pty-id=${JSON.stringify(ptyId)}] .xterm-accessibility-tree`)
+  ).toBeAttached({ timeout: 10_000 })
+}
+
+test.describe('Windows Codex multiline paste', () => {
+  test.use({ seedTestRepo: false })
+
+  test('multiline Ctrl+V keeps the existing Codex draft unsent @local-real-codex', async ({
+    orcaPage,
+    testRepoPath
+  }) => {
+    test.skip(process.platform !== 'win32', 'Windows ConPTY coverage is Windows-only')
+    test.skip(
+      process.env.ORCA_E2E_REAL_CODEX !== '1',
+      'Set ORCA_E2E_REAL_CODEX=1 to exercise the locally installed Codex TUI'
+    )
+    test.slow()
+
+    await waitForSessionReady(orcaPage)
+    await orcaPage.evaluate(async (repoPath) => {
+      const normalizePath = (value: string): string => value.replaceAll('\\', '/').toLowerCase()
+      await window.api.repos.add({ path: repoPath })
+      const store = window.__store
+      if (!store) {
+        throw new Error('Orca store unavailable')
+      }
+      await store.getState().fetchRepos()
+      const repo = store
+        .getState()
+        .repos.find((candidate) => normalizePath(candidate.path) === normalizePath(repoPath))
+      if (!repo) {
+        throw new Error('Seeded repository unavailable')
+      }
+      await store.getState().updateRepo(repo.id, { externalWorktreeVisibility: 'show' })
+      await store.getState().fetchWorktrees(repo.id)
+      const worktree = store
+        .getState()
+        .worktreesByRepo[repo.id]?.find(
+          (candidate) => normalizePath(candidate.path) === normalizePath(repoPath)
+        )
+      if (!worktree) {
+        throw new Error('Seeded worktree unavailable')
+      }
+      store.getState().setActiveWorktree(worktree.id)
+      store.getState().createTab(worktree.id)
+    }, testRepoPath)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    await sendToTerminal(orcaPage, ptyId, 'codex -m orca-e2e-invalid-model\r')
+    await expect
+      .poll(() => getTerminalContent(orcaPage, 12_000), { timeout: 20_000 })
+      .toMatch(/Do[\s\S]*you[\s\S]*trust[\s\S]*contents|OpenAI Codex/i)
+    if (CODEX_TRUST_PROMPT_RE.test(await getTerminalContent(orcaPage, 12_000))) {
+      await sendToTerminal(orcaPage, ptyId, '\r')
+    }
+    await waitForTerminalOutput(orcaPage, 'OpenAI Codex', 20_000, 30_000)
+    await enableTerminalAccessibilityDom(orcaPage, ptyId)
+    await focusActiveTerminalInput(orcaPage)
+    await orcaPage.keyboard.type(DRAFT)
+    const terminalDom = orcaPage.locator(
+      `[data-pty-id=${JSON.stringify(ptyId)}] .xterm-accessibility-tree`
+    )
+    await expect(terminalDom).toContainText(DRAFT, { timeout: 10_000 })
+    await orcaPage.evaluate((text) => window.api.ui.writeClipboardText(text), pastePayload())
+
+    await orcaPage.keyboard.press('Control+V')
+    await expect(terminalDom).toContainText('[Pasted Content', { timeout: 10_000 })
+    await expect(terminalDom).toContainText(DRAFT)
+    await orcaPage.waitForTimeout(2_000)
+    await expect(terminalDom).not.toContainText('Working')
+    await expect(terminalDom).not.toContainText('unexpected status 404')
+  })
+})


### PR DESCRIPTION
## Summary

- normalize CRLF/LF to terminal CR whenever Orca directly constructs bracketed paste bytes
- cover clipboard, chunked clipboard, agent-draft, native-chat, and image-path send paths without changing unforced xterm-managed paste bytes
- add deterministic native Windows ConPTY coverage for a >64 KiB payload and harden the real-Codex regression against delayed MCP startup

## Root cause

On Windows, Orca forces multiline clipboard text through a directly constructed bracketed-paste frame. Unlike xterm's native paste path, that frame retained CRLF bytes. The LF byte reached Codex through ConPTY and was interpreted as submission input even though the paste was bracketed.

The follow-up review found the same manual-frame gap in agent-draft and native-chat sends. Those paths now reuse the shared terminal wrapper; chunked agent drafts normalize the complete text before splitting so a CRLF pair cannot straddle a chunk boundary.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused Vitest coverage used instead: 6 files, 102 tests passed
- [ ] `pnpm build` — E2E-mode Electron build used instead: `pnpm exec electron-vite build --mode e2e`
- [x] Added or updated high-quality tests that would catch regressions

Windows 11 Pro 10.0.26200, PowerShell 7.6.3, Node 24.18.0, pnpm 10.24.0:

- focused Vitest: 6 files, 102 tests passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed (pre-existing warnings only)
- E2E-mode Electron build: passed
- `electron-headless`, one worker: 2 tests passed
  - real Codex 0.144.3 kept the existing draft and pasted content unsent
  - native ConPTY collector received the exact normalized >64 KiB payload (length + SHA-256)
- no new Electron, daemon, or Codex processes remained after teardown

Tested commit: `4500b153f752ecc8ddaaaf4e2c13665ec9c70e40`.

## AI Review Report

The review checked byte normalization before and after the 64 KiB chunk threshold, CRLF pairs split at chunk boundaries, control-sequence sanitization, direct agent-draft sends, native-chat sends, Windows ConPTY ownership, Codex startup races, and remote runtime preservation. CodeRabbit flagged agent-draft's hand-built frame; the review found and fixed the equivalent native-chat path.

Cross-platform review covered macOS, Linux, Windows, SSH, WSL, and remote-runtime identities. Unforced xterm-managed and non-bracketed chunked paste bytes retain their existing `preserve` policy. No shortcut, label, UI layout, or platform path behavior changed.

## Security Audit

Clipboard and programmatic paste text still replace embedded ESC bytes before framing, preventing pasted terminal output from closing the bracketed-paste frame and injecting live control input. Normalization occurs before chunking, so no LF half can escape a split CRLF pair. No auth, secret, dependency, network, or production command-execution behavior changed. The E2E collector script is created only inside the isolated seeded repository and removed in `finally`.

## Notes

This is a recent regression from #5291, merged June 12, 2026 and released in v1.4.66. That Windows multiline-paste fix began constructing bracketed-paste input directly, bypassing xterm's newline normalization.

Codex 0.144.3 does not reliably render a single >64 KiB bracketed-paste event even though the deterministic child process proves ConPTY receives every normalized byte. Bounded multi-frame experiments did not prove full Codex composer preservation, so no speculative framing change is included here. The reported payload and normal-size real-Codex path pass without auto-submission.
