### PR TITLE
fix(mobile): resync worktree list + idempotent notification replay on reconnect (#8498 #8129)

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -6,7 +6,8 @@ import {
   SectionList,
   Pressable,
   ActivityIndicator,
-  Alert
+  Alert,
+  RefreshControl
 } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useFocusEffect, useLocalSearchParams, usePathname, useRouter } from 'expo-router'
@@ -37,6 +38,7 @@ import {
   useReconnectAttempt,
   useLastConnectedAt
 } from '../../../src/transport/client-context'
+import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
 import {
   classifyConnection,
   type ConnectionVerdict
@@ -59,7 +61,7 @@ import { ProtocolBlockScreen } from '../../../src/components/ProtocolBlockScreen
 import { AuthFailedBanner } from '../../../src/components/AuthFailedBanner'
 import { MobileSearchField } from '../../../src/components/MobileSearchField'
 import { WorkspaceDetailPlaceholder } from '../../../src/components/WorkspaceDetailPlaceholder'
-import { getCachedWorktrees } from '../../../src/cache/worktree-cache'
+import { getCachedWorktrees, setCachedWorktrees } from '../../../src/cache/worktree-cache'
 import { setCachedRepos } from '../../../src/cache/repo-cache'
 import { colors, radii, spacing, typography } from '../../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../../src/layout/responsive-layout'
@@ -459,6 +461,14 @@ export function HostScreen({
             areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
           )
           setWorktreesLoaded(true)
+          // Why (#8498): the host detail screen seeds its list from the
+          // home-written cache, so a partial home fetch could poison it until a
+          // focus poll corrected it. Write the confirmed snapshot back through
+          // the same cache so a reconnect refetch (or a remount) can't serve a
+          // stale worktree list.
+          if (hostId) {
+            setCachedWorktrees(hostId, result.worktrees)
+          }
           // Drop the optimistic active override once the host confirms it (the
           // activate RPC has landed and worktree.ps now reports it active), so we
           // stop overriding and respect any later desktop-driven change.
@@ -612,6 +622,17 @@ export function HostScreen({
     }, 3000)
     return () => clearInterval(interval)
   }, [embedded, connState, fetchWorktrees, fetchRepoMetadata, syncViewSettingsFromDesktop])
+
+  // Why (#8498): reconnect refetch + manual pull-to-refresh, extracted to
+  // useWorktreeResync so this screen stays under its max-lines budget. The
+  // steady-state focus/embedded polls don't cover the transition INTO
+  // 'connected' after a background/sleep, which is when the cache is stalest.
+  const { refreshing, onRefresh } = useWorktreeResync({
+    client,
+    connState,
+    fetchWorktrees,
+    fetchRepoMetadata
+  })
 
   const updateLocalPins = useCallback(
     (worktreeId: string, pinned: boolean) => {
@@ -1229,6 +1250,16 @@ export function HostScreen({
             )
           }}
           ItemSeparatorComponent={ListSeparator}
+          // Why (#8498): manual pull-to-refresh forces a fresh worktree
+          // snapshot after a reconnect or whenever the cache looks stale.
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.textSecondary}
+              colors={[colors.textSecondary]}
+            />
+          }
           renderItem={({ item }) => (
             <WorktreeListRow
               item={item}

--- a/mobile/src/cache/worktree-cache.test.ts
+++ b/mobile/src/cache/worktree-cache.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { setCachedWorktrees, getCachedWorktrees } from './worktree-cache'
+
+// Why: AC #8498 guarantees a reconnect refetch writes through the
+// same cache path the host detail screen seeds from, so a reconnect can't
+// serve a stale snapshot. This unit pins the write-through contract.
+describe('worktree-cache write-through', () => {
+  it('returns the most-recently written snapshot, not a stale one', () => {
+    const hostId = 'host-write-through'
+    const stale = [{ worktreeId: 'a', name: 'stale' }]
+    const fresh = [
+      { worktreeId: 'a', name: 'fresh' },
+      { worktreeId: 'b', name: 'added' }
+    ]
+
+    setCachedWorktrees(hostId, stale)
+    expect(getCachedWorktrees(hostId)).toEqual(stale)
+
+    // Why: simulates the reconnect refetch write-through — the fresh
+    // worktree.ps snapshot must fully replace the poisoned cache entry.
+    setCachedWorktrees(hostId, fresh)
+    expect(getCachedWorktrees(hostId)).toEqual(fresh)
+    expect(getCachedWorktrees(hostId)).not.toEqual(stale)
+  })
+
+  it('exposes a fresh snapshot to a remounting screen after reconnect', () => {
+    // Why: the host detail screen reads getCachedWorktrees(hostId)
+    // on (re)mount as its initialCache. A reconnect that writes
+    // through must therefore surface here instead of the pre-reconnect data.
+    const hostId = 'host-remount'
+    setCachedWorktrees(hostId, [{ worktreeId: 'old', name: 'pre-reconnect' }])
+
+    // Reconnect refetch lands a fresh snapshot and writes it through.
+    const reconnected = [
+      { worktreeId: 'old', name: 'post-reconnect' },
+      { worktreeId: 'new', name: 'now-visible' }
+    ]
+    setCachedWorktrees(hostId, reconnected)
+
+    // A fresh screen mount reads the cache — must see the connected set.
+    expect(getCachedWorktrees(hostId)).toEqual(reconnected)
+  })
+})

--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -4,6 +4,7 @@ import {
   setScheduledNotificationsMaxForTests,
   subscribeToDesktopNotifications
 } from './mobile-notifications'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { RpcClient } from '../transport/rpc-client'
 import { loadPushNotificationsEnabled } from '../storage/preferences'
 
@@ -18,6 +19,16 @@ vi.mock('expo-notifications', () => ({
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' }
+}))
+
+// Why: mobile-notifications now persists the catch-up watermark to
+// AsyncStorage. The package isn't resolvable in the node test env (other
+// mobile tests mock it the same way), so we provide a no-op mock.
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(async () => null),
+    setItem: vi.fn(async () => undefined)
+  }
 }))
 
 vi.mock('../storage/preferences', () => ({
@@ -314,5 +325,290 @@ describe('subscribeToDesktopNotifications', () => {
     } finally {
       setScheduledNotificationsMaxForTests()
     }
+  })
+})
+
+// Why: #8129 catch-up. On a reconnect the live stream re-emits `ready`; the
+// client must fetch missed notifications from its watermark and push exactly
+// the ones it had not yet delivered — never re-pushing an already-delivered id.
+describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
+  const AsyncStorageMock = vi.mocked(AsyncStorage)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    AsyncStorageMock.getItem.mockResolvedValue(null)
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+  })
+
+  function flushAsync(): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 10)
+    })
+  }
+
+  function makeClient() {
+    let onData: ((data: unknown) => void) | null = null
+    const sentRequests: { method: string; params: unknown }[] = []
+    const client = {
+      subscribe: vi.fn((_method: string, _params: unknown, cb: (data: unknown) => void) => {
+        onData = cb
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn(
+        async (method: string, _params: unknown = {}) =>
+          ({
+            ok: true,
+            result: method === 'notifications.getMissedSince' ? { notifications: [] } : undefined
+          }) as never
+      )
+    }
+    // Why: onData is captured live via a getter (not destructured) because the
+    // subscribe mock assigns it asynchronously as a side effect of
+    // subscribeToDesktopNotifications calling client.subscribe.
+    return {
+      client: client as unknown as RpcClient,
+      get onData() {
+        return onData
+      },
+      sentRequests
+    }
+  }
+
+  it('does not fetch missed notifications on the first (cold-open) ready', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    // First ready = cold open.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+
+    expect(sub.client.sendRequest).not.toHaveBeenCalledWith(
+      'notifications.getMissedSince',
+      expect.anything()
+    )
+  })
+
+  it('fetches only notifications after the delivered watermark (idempotent catch-up)', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
+
+    const sub = makeClient()
+    // The desktop honours the watermark: only seq 10 (agent:missed) is returned
+    // because seq 11 (agent:dup) was already delivered on the live stream and
+    // advanced lastDeliveredSeq to 11. So the replay never re-includes it.
+    sub.client.sendRequest = vi.fn(async (method: string) => {
+      if (method === 'notifications.getMissedSince') {
+        return {
+          ok: true,
+          result: {
+            notifications: [
+              {
+                type: 'notification',
+                title: 'missed',
+                body: 'b',
+                notificationId: 'agent:missed',
+                notificationSeq: 10
+              }
+            ]
+          }
+        } as never
+      }
+      return { ok: true, result: undefined } as never
+    })
+
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    // First ready = cold open (no fetch).
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    // Live stream already delivered agent:dup (seq 11) before reap.
+    sub.onData?.({
+      type: 'notification',
+      title: 'dup',
+      body: 'b',
+      notificationId: 'agent:dup',
+      notificationSeq: 11
+    })
+    await flushAsync()
+    // Reconnect ready → fetchMissed sends the watermark (11).
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    await flushAsync()
+
+    // The watermark passed to getMissedSince is the delivered seq.
+    const missedCall = vi
+      .mocked(sub.client.sendRequest)
+      .mock.calls.find((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    expect(missedCall?.[1]).toEqual({ lastSeenSeq: 11 })
+    // Only agent:missed was pushed; agent:dup appears exactly once (live only).
+    const scheduledIds = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map(
+        (call) =>
+          (call[0] as { content: { data: { notificationId: string } } }).content.data.notificationId
+      )
+    expect(scheduledIds).toEqual(['agent:dup', 'agent:missed'])
+    expect(scheduledIds.filter((id) => id === 'agent:dup')).toHaveLength(1)
+  })
+
+  it('drops an already-seen id if a replay re-includes it (defense-in-depth)', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+
+    const sub = makeClient()
+    // Simulate the bounded-buffer edge: the desktop returns seq 11 again
+    // (already delivered live) alongside a new seq 12.
+    sub.client.sendRequest = vi.fn(async (method: string) => {
+      if (method === 'notifications.getMissedSince') {
+        return {
+          ok: true,
+          result: {
+            notifications: [
+              {
+                type: 'notification',
+                title: 'dup',
+                body: 'b',
+                notificationId: 'agent:dup',
+                notificationSeq: 11
+              },
+              {
+                type: 'notification',
+                title: 'new',
+                body: 'b',
+                notificationId: 'agent:new',
+                notificationSeq: 12
+              }
+            ]
+          }
+        } as never
+      }
+      return { ok: true, result: undefined } as never
+    })
+
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    // Live stream delivered agent:dup (seq 11) before reap.
+    sub.onData?.({
+      type: 'notification',
+      title: 'dup',
+      body: 'b',
+      notificationId: 'agent:dup',
+      notificationSeq: 11
+    })
+    await flushAsync()
+    // Reconnect replay re-includes seq 11 (must be dropped) + new seq 12.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    await flushAsync()
+
+    const scheduledIds = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map(
+        (call) =>
+          (call[0] as { content: { data: { notificationId: string } } }).content.data.notificationId
+      )
+    expect(scheduledIds).toEqual(['agent:dup', 'agent:new'])
+    expect(scheduledIds.filter((id) => id === 'agent:dup')).toHaveLength(1)
+  })
+
+  it('persists the highest delivered seq so a later reconnect resumes from it', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    // Live stream delivers seq 5.
+    sub.onData?.({
+      type: 'notification',
+      title: 't',
+      body: 'b',
+      notificationId: 'agent:live',
+      notificationSeq: 5
+    })
+    await flushAsync()
+
+    expect(AsyncStorageMock.setItem).toHaveBeenCalledWith(
+      'orca:mobileNotificationsLastSeq:host-1',
+      '5'
+    )
+  })
+
+  // Why: a replay-ONLY delivery (nothing arrived live first) must still advance
+  // and persist the watermark. This is the exact case the seq/notificationSeq
+  // field mismatch broke — the desktop replay path returns `notificationSeq`
+  // (matching the live fan-out), so the client watermark moves and the next
+  // reconnect resumes from it instead of re-fetching from 0.
+  it('advances + persists the watermark from a replay-only delivery (#8129 field-mismatch regression)', async () => {
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+
+    const sub = makeClient()
+    // Desktop replay returns events keyed by notificationSeq (the fixed shape).
+    sub.client.sendRequest = vi.fn(async (method: string) => {
+      if (method === 'notifications.getMissedSince') {
+        return {
+          ok: true,
+          result: {
+            notifications: [
+              {
+                type: 'notification',
+                title: 'missed',
+                body: 'b',
+                notificationId: 'agent:missed',
+                notificationSeq: 8
+              }
+            ]
+          }
+        } as never
+      }
+      return { ok: true, result: undefined } as never
+    })
+
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    // First reconnect → replay delivers seq 8 (no prior live delivery).
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    await flushAsync()
+
+    // Watermark advanced to the replayed seq and was persisted.
+    expect(AsyncStorageMock.setItem).toHaveBeenCalledWith(
+      'orca:mobileNotificationsLastSeq:host-1',
+      '8'
+    )
+
+    // Second reconnect resumes from the advanced watermark, not 0.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    const missedCalls = vi
+      .mocked(sub.client.sendRequest)
+      .mock.calls.filter((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    expect(missedCalls.at(-1)?.[1]).toEqual({ lastSeenSeq: 8 })
   })
 })

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -3,6 +3,12 @@ import { Platform } from 'react-native'
 import type { RpcClient } from '../transport/rpc-client'
 import { loadPushNotificationsEnabled } from '../storage/preferences'
 import { buildLocalNotificationData, type DesktopNotificationSource } from './notification-routing'
+import {
+  createSeenNotificationGuard,
+  loadLastSeenSeq,
+  saveLastSeenSeq,
+  seenKeyForEvent
+} from './notification-reconnect-catchup'
 
 type NotificationEvent = {
   type: 'notification'
@@ -11,11 +17,16 @@ type NotificationEvent = {
   body: string
   worktreeId?: string
   notificationId?: string
+  // Mirrors the desktop-assigned MobileNotificationEvent.notificationSeq used
+  // for reconnect catch-up (#8129). Optional because older runtimes / non-
+  // replay events may omit it.
+  notificationSeq?: number
 }
 
 type DismissNotificationEvent = {
   type: 'dismiss'
   notificationId: string
+  notificationSeq?: number
 }
 
 type SubscribeResult = {
@@ -223,18 +234,105 @@ async function dismissLocalNotification(
 
 // Why: each host connection gets its own notification subscription. When the
 // connection drops, the unsubscribe function cleans up the streaming RPC.
+// On reconnect the same subscribe stream is re-established by the RPC client;
+// we use its `ready` event to trigger catch-up (#8129): fetch notifications
+// dispatched while the socket was reaped, watermarked by the last seq we
+// already delivered so the desktop never re-sends an already-pushed one.
 // Returns an unsubscribe function.
 export function subscribeToDesktopNotifications(client: RpcClient, hostId: string): () => void {
   configureNotificationChannel()
 
   let subscriptionId: string | null = null
   let disposed = false
+  // Highest seq delivered on the live stream or replay for this connection.
+  // Persisted per-host so a cold app start still resumes from the right cut.
+  let lastDeliveredSeq = 0
+  // Why: per-connection dedup guard applied ONLY to the replay path
+  // (fetchMissed), never the live stream. The desktop already guarantees the
+  // replay cannot contain an event with seq <= lastDeliveredSeq (both live and
+  // replay advance the same watermark), so live + replay never overlap there.
+  // This set is defense-in-depth: if the desktop's bounded buffer evicted an
+  // old entry and a reconnect re-fetches across a boundary, an id delivered in
+  // the same connection isn't pushed twice. Bounded (RECENTLY_SEEN_CAP) so a
+  // long-lived session can't grow without limit.
+  const seenReplay = createSeenNotificationGuard()
+
+  function deliverLive(
+    type: 'notification' | 'dismiss',
+    event: NotificationEvent | DismissNotificationEvent
+  ): Promise<void> {
+    if (event.notificationSeq != null && event.notificationSeq > lastDeliveredSeq) {
+      lastDeliveredSeq = event.notificationSeq
+      void saveLastSeenSeq(hostId, lastDeliveredSeq)
+    }
+    // Why (#8129 dedup): mark the event seen on EVERY delivery path (live AND
+    // replay) so a replay that re-includes an id already pushed live in this
+    // connection is dropped instead of double-pushed. fetchMissed also
+    // pre-checks seenReplay, but without this the live path never populated it.
+    const key = seenKeyForEvent(event)
+    if (key) {
+      seenReplay.add(key)
+    }
+    if (type === 'notification') {
+      return showLocalNotification(event as NotificationEvent, hostId)
+    }
+    return dismissLocalNotification(event as DismissNotificationEvent, hostId)
+  }
+
+  // Why: on a reconnect `ready` the desktop has already dispatched whatever we
+  // missed; ask for it from our persisted watermark. Because the desktop cuts
+  // by seq > lastSeenSeq this is idempotent — we only ever get events we have
+  // not delivered before. The seenReplay guard is a second layer so a replay
+  // that somehow re-includes an id already delivered this connection is
+  // dropped instead of double-pushed.
+  async function fetchMissed(): Promise<void> {
+    if (disposed) {
+      return
+    }
+    const missed = await client
+      .sendRequest('notifications.getMissedSince', { lastSeenSeq: lastDeliveredSeq })
+      .then((response) => {
+        if (!response.ok) {
+          return []
+        }
+        const result = response.result as { notifications?: unknown[] } | undefined
+        return Array.isArray(result?.notifications) ? result.notifications : []
+      })
+      .catch(() => [])
+    for (const raw of missed) {
+      const event = raw as NotificationEvent | DismissNotificationEvent
+      const key = seenKeyForEvent(event)
+      if (key && seenReplay.has(key)) {
+        continue
+      }
+      if (key) {
+        seenReplay.add(key)
+      }
+      if (event.type === 'notification') {
+        await deliverLive('notification', event)
+      } else if (event.type === 'dismiss') {
+        await deliverLive('dismiss', event)
+      }
+    }
+  }
+
+  // Why: lazily seed the watermark from durable storage on first use so we
+  // don't block subscribe() on an AsyncStorage read. The first `ready` (cold
+  // open) does NOT need catch-up — the live stream starts fresh; only
+  // subsequent reconnect `ready` events fetch missed notifications.
+  let watermarkLoaded = false
+  void loadLastSeenSeq(hostId).then((seq) => {
+    lastDeliveredSeq = Math.max(lastDeliveredSeq, seq)
+    watermarkLoaded = true
+  })
+
   function unsubscribeServer(id: string) {
     if (client.getState() === 'connected') {
       client.sendRequest('notifications.unsubscribe', { subscriptionId: id }).catch(() => {})
     }
   }
 
+  let reconnectReadyCount = 0
   const unsubscribeStream = client.subscribe('notifications.subscribe', {}, (data: unknown) => {
     const event = data as
       | NotificationEvent
@@ -243,9 +341,18 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
       | { type: 'end' }
     if (event.type === 'ready') {
       subscriptionId = (event as SubscribeResult).subscriptionId
+      reconnectReadyCount += 1
       if (disposed) {
         unsubscribeServer(subscriptionId)
         unsubscribeStream()
+        return
+      }
+      // Why: first ready is the cold-open live stream — no catch-up needed.
+      // Every later ready is a reconnect; fetch what we missed from the
+      // watermark. Guard on watermarkLoaded so a fast reconnect doesn't
+      // fetch from a stale 0 watermark (which would re-push everything).
+      if (reconnectReadyCount > 1 && watermarkLoaded) {
+        void fetchMissed()
       }
       return
     }
@@ -259,9 +366,9 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
       return
     }
     if (event.type === 'notification') {
-      void showLocalNotification(event as NotificationEvent, hostId)
+      void deliverLive('notification', event as NotificationEvent)
     } else if (event.type === 'dismiss') {
-      void dismissLocalNotification(event as DismissNotificationEvent, hostId)
+      void deliverLive('dismiss', event as DismissNotificationEvent)
     }
   })
 

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -1,0 +1,97 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+// Why: the reconnect catch-up watermark + dedup helpers for #8129, extracted
+// from mobile-notifications.ts so that file stays under its max-lines budget.
+// The highest desktop notification seq this device has delivered is persisted
+// per-host so it survives app restarts. On reconnect we send it to
+// notifications.getMissedSince as the catch-up watermark — the desktop then
+// returns only notifications dispatched after it, so we never re-push a
+// notification we already delivered. The in-memory seen-set is a second guard
+// against double-delivery for events that arrive on both the live stream and a
+// replay (e.g. a brief liveness spell before a reap).
+const LAST_SEQ_STORAGE_KEY_PREFIX = 'orca:mobileNotificationsLastSeq:'
+
+function lastSeqStorageKey(hostId: string): string {
+  return LAST_SEQ_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
+}
+
+export async function loadLastSeenSeq(hostId: string): Promise<number> {
+  try {
+    const raw = await AsyncStorage.getItem(lastSeqStorageKey(hostId))
+    const parsed = raw == null ? 0 : Number(raw)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+  } catch {
+    return 0
+  }
+}
+
+export async function saveLastSeenSeq(hostId: string, seq: number): Promise<void> {
+  if (!Number.isFinite(seq) || seq <= 0) {
+    return
+  }
+  try {
+    await AsyncStorage.setItem(lastSeqStorageKey(hostId), String(seq))
+  } catch {
+    // Why: persisting the watermark is best-effort. If it fails (or lags), the
+    // stored value stays BELOW what we delivered, so a later cold start can
+    // re-fetch — and, once the in-memory seen-set is gone, re-show — an already
+    // delivered notification. That's the accepted at-least-once trade-off;
+    // within a live session the in-memory watermark is authoritative, so only
+    // post-restart reconnects are affected.
+  }
+}
+
+// Why: bounded in-memory dedup window for notificationIds/dismiss ids observed
+// on the current connection. The desktop already dedupes by seq on replay, but
+// a socket that flickers background→foreground→background can deliver an event
+// on the live stream and again in a replay; the seen-set guarantees each
+// notificationId maps to at most one local push for the connection lifetime.
+// Bounded so a long-lived session can't grow without limit — a 2x superset of
+// the desktop's 256-entry replay buffer and the 256 scheduled-notification cap.
+const RECENTLY_SEEN_CAP = 512
+
+export function createSeenNotificationGuard(): {
+  has: (id: string) => boolean
+  add: (id: string) => void
+} {
+  const seen = new Set<string>()
+  return {
+    has(id: string): boolean {
+      return seen.has(id)
+    },
+    add(id: string): void {
+      seen.add(id)
+      if (seen.size > RECENTLY_SEEN_CAP) {
+        // Why: insertion order; the oldest entries are first. Drop one to stay
+        // bounded without disturbing the more-recently-relevant keys.
+        const first = seen.values().next().value
+        if (first !== undefined) {
+          seen.delete(first)
+        }
+      }
+    }
+  }
+}
+
+// Why: key for the replay dedup guard. Uses notificationId when present, but
+// disambiguates by seq so a legitimate live re-delivery of the same id at a
+// NEW seq (content refresh, allowed by the existing behaviour) is NOT treated
+// as a duplicate, while a replay re-returning the SAME id+seq already delivered
+// live is suppressed. Replay events always carry a seq (the desktop assigns
+// one), so the guard is effective on the reconnect path.
+export function seenKeyForEvent(event: {
+  notificationId?: string
+  notificationSeq?: number
+}): string | null {
+  const id = event.notificationId
+  if (id != null && event.notificationSeq != null) {
+    return `id:${id}#${event.notificationSeq}`
+  }
+  if (id != null) {
+    return `id:${id}`
+  }
+  if (event.notificationSeq != null) {
+    return `seq:${event.notificationSeq}`
+  }
+  return null
+}

--- a/mobile/src/transport/use-worktree-resync.ts
+++ b/mobile/src/transport/use-worktree-resync.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { RpcClient } from './rpc-client'
+import type { ConnectionState } from './types'
+
+// Why (#8498): extracted from HostScreen so the file stays under its
+// max-lines budget. Handles the reconnect edge (refetch on transition into
+// 'connected') and manual pull-to-refresh, neither of which the steady-state
+// focus/embedded polls cover.
+export function useWorktreeResync(args: {
+  client: RpcClient | null
+  connState: ConnectionState
+  fetchWorktrees: (opts?: { allowDuringModal?: boolean }) => Promise<void>
+  fetchRepoMetadata: () => Promise<void>
+}): { refreshing: boolean; onRefresh: () => Promise<void> } {
+  const { client, connState, fetchWorktrees, fetchRepoMetadata } = args
+
+  // Why (#8498): socket-only reconnect left a stale cached snapshot after
+  // background/sleep. Refetch on the transition INTO 'connected', not every poll tick.
+  const prevConnStateRef = useRef(connState)
+  useEffect(() => {
+    const prev = prevConnStateRef.current
+    prevConnStateRef.current = connState
+    if (prev !== 'connected' && connState === 'connected' && client) {
+      void fetchWorktrees({ allowDuringModal: true })
+      void fetchRepoMetadata()
+    }
+  }, [connState, client, fetchWorktrees, fetchRepoMetadata])
+
+  const [refreshing, setRefreshing] = useState(false)
+  // Why (#8498): let the user force a fresh snapshot instead of the possibly-poisoned cache.
+  const onRefresh = useCallback(async () => {
+    if (!client || connState !== 'connected') {
+      return
+    }
+    setRefreshing(true)
+    try {
+      await fetchWorktrees({ allowDuringModal: true })
+      await fetchRepoMetadata()
+    } finally {
+      setRefreshing(false)
+    }
+  }, [client, connState, fetchWorktrees, fetchRepoMetadata])
+
+  return { refreshing, onRefresh }
+}

--- a/src/main/runtime/mobile-notification-replay.test.ts
+++ b/src/main/runtime/mobile-notification-replay.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MobileNotificationReplayBuffer,
+  type ReplayableMobileNotification
+} from './mobile-notification-replay'
+import type { MobileNotificationDispatchEvent } from './orca-runtime'
+
+function dispatch(
+  buffer: MobileNotificationReplayBuffer,
+  partial: Partial<MobileNotificationDispatchEvent> = {}
+): ReplayableMobileNotification {
+  const event: MobileNotificationDispatchEvent = {
+    type: 'notification',
+    source: 'agent-task-complete',
+    title: 'Done',
+    body: 'Finished.',
+    ...partial
+  }
+  buffer.record(event)
+  return buffer.getMissedSince(0).at(-1) as ReplayableMobileNotification
+}
+
+describe('MobileNotificationReplayBuffer', () => {
+  it('assigns a strictly increasing monotonic notificationSeq to every recorded event', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const a = dispatch(buffer, { notificationId: 'agent:one' })
+    const b = dispatch(buffer, { notificationId: 'agent:two' })
+    const c = dispatch(buffer, { notificationId: 'agent:three' })
+    expect(a.notificationSeq).toBe(1)
+    expect(b.notificationSeq).toBe(2)
+    expect(c.notificationSeq).toBe(3)
+    expect(c.notificationSeq).toBeGreaterThan(b.notificationSeq)
+    expect(b.notificationSeq).toBeGreaterThan(a.notificationSeq)
+  })
+
+  // Why: the client watermarks + dedups on `notificationSeq` (the same field
+  // the live fan-out tags). Replayed events must expose that exact field —
+  // returning a bare `seq` here silently breaks watermark advance on a
+  // replay-only delivery (regression guard for the #8129 field mismatch).
+  it('exposes the client-facing `notificationSeq` field on replayed events', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const a = dispatch(buffer, { notificationId: 'agent:one' })
+    expect(a.notificationSeq).toBe(1)
+    expect((a as Record<string, unknown>).seq).toBeUndefined()
+  })
+
+  it('returns missed notifications that were dispatched after the watermark', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    dispatch(buffer, { notificationId: 'agent:one' })
+    const b = dispatch(buffer, { notificationId: 'agent:two' })
+    dispatch(buffer, { notificationId: 'agent:three' })
+
+    // Client reconnected having delivered up to seq 1.
+    const missed = buffer.getMissedSince(b.notificationSeq - 1)
+    expect(missed.map((e) => e.notificationId)).toEqual(['agent:two', 'agent:three'])
+  })
+
+  it('does NOT return already-delivered notifications (dedupe regression)', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const a = dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+    dispatch(buffer, { notificationId: 'agent:three' })
+
+    // Client already delivered everything up to seq 3, then reconnects again.
+    const missed = buffer.getMissedSince(a.notificationSeq + 2)
+    expect(missed).toEqual([])
+  })
+
+  it('is idempotent: the same watermark always yields the same set', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+    dispatch(buffer, { notificationId: 'agent:three' })
+
+    const first = buffer.getMissedSince(1)
+    const second = buffer.getMissedSince(1)
+    expect(second).toEqual(first)
+    expect(second.map((e) => e.notificationId)).toEqual(['agent:two', 'agent:three'])
+  })
+
+  it('does not duplicate an event that arrived on both live stream and replay', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const a = dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+
+    // Live stream delivered seq 1 (agent:one) during a brief liveness spell.
+    // Reconnect asks for everything after 0 — must include agent:one exactly
+    // once, never twice.
+    const missed = buffer.getMissedSince(a.notificationSeq - 1)
+    const ids = missed.map((e) => e.notificationId)
+    expect(ids).toEqual(['agent:one', 'agent:two'])
+    expect(ids.filter((id) => id === 'agent:one')).toHaveLength(1)
+  })
+
+  it('returns the whole buffer when the watermark is 0 (cold open)', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+    expect(buffer.getMissedSince(0).map((e) => e.notificationId)).toEqual([
+      'agent:one',
+      'agent:two'
+    ])
+  })
+
+  it('evicts oldest entries once the capacity is exceeded', () => {
+    const buffer = new MobileNotificationReplayBuffer(2)
+    dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+    dispatch(buffer, { notificationId: 'agent:three' })
+
+    // Capacity is 2, so the first entry is evicted; even from watermark 0 we
+    // only get the two retained plus the newest.
+    const retained = buffer.getMissedSince(0).map((e) => e.notificationId)
+    expect(retained).toEqual(['agent:two', 'agent:three'])
+    expect(buffer.size).toBe(2)
+  })
+})

--- a/src/main/runtime/mobile-notification-replay.ts
+++ b/src/main/runtime/mobile-notification-replay.ts
@@ -1,0 +1,70 @@
+import type { MobileNotificationEvent } from './orca-runtime'
+
+// Why: when a mobile client's socket is reaped (background/sleep, or a warm
+// proxy that delays the heartbeat reap), notifications dispatched in that
+// window are lost — there is no queue. This buffer is the catch-up source of
+// truth on the desktop: every notification that flows through
+// dispatchMobileNotification is recorded with a monotonic seq, and a reconnecting
+// client asks for everything after the seq it last acknowledged.
+//
+// Idempotency (the adversarial-review gate for #8129): replay is keyed by a
+// global monotonic seq, not by wall-clock. getMissedSince(lastSeenSeq) returns
+// exactly the events with seq > lastSeenSeq. Re-requesting with the same
+// watermark returns the same set; requesting with the client's true watermark
+// can never return an already-delivered event. The client additionally tracks
+// seen ids, so even a buffer-cap overlap cannot double-push.
+//
+// Why the field is `notificationSeq` (not `seq`): the live fan-out in
+// dispatchMobileNotification tags each event with `notificationSeq`, and the
+// mobile client watermarks + dedups on that exact field. Replayed events MUST
+// carry the same field name or the client can't advance its watermark from a
+// replay-only delivery (it would re-fetch/re-push across a restart). Keeping a
+// single field name end-to-end is what makes live and replay interchangeable.
+export type ReplayableMobileNotification = MobileNotificationEvent & {
+  notificationSeq: number
+}
+
+// Why: bound the buffer. 256 completes a few minutes of real agent activity and
+// tracks the client's existing MAX_SCHEDULED_NOTIFICATIONS (256) cap, far beyond
+// any background window a reconnect can still salvage. Beyond the cap we evict
+// oldest-first; a reconnect after that long is effectively a cold open and the
+// live stream resumes from current, so dropping older entries is acceptable.
+const DEFAULT_CAPACITY = 256
+
+export class MobileNotificationReplayBuffer {
+  private readonly capacity: number
+  private seq = 0
+  private readonly buffer: ReplayableMobileNotification[] = []
+
+  constructor(capacity: number = DEFAULT_CAPACITY) {
+    this.capacity = capacity
+  }
+
+  // Records a dispatched event and returns the monotonic seq assigned to it.
+  // Callers surface the seq so clients can watermark their last-seen position
+  // (both on the live fan-out and on explicit catch-up requests).
+  record(event: MobileNotificationEvent): number {
+    const seq = ++this.seq
+    this.buffer.push({ ...event, notificationSeq: seq })
+    if (this.buffer.length > this.capacity) {
+      // Why: insertion-order array; oldest entries sit at the front.
+      this.buffer.splice(0, this.buffer.length - this.capacity)
+    }
+    return seq
+  }
+
+  // Returns every recorded event with seq strictly greater than lastSeenSeq.
+  // Because seq is monotonic and global, this is an exact, idempotent cut:
+  // the same lastSeenSeq always yields the same result.
+  getMissedSince(lastSeenSeq: number): ReplayableMobileNotification[] {
+    if (lastSeenSeq >= this.seq) {
+      return []
+    }
+    return this.buffer.filter((entry) => entry.notificationSeq > lastSeenSeq)
+  }
+
+  // Test/inspection helper: number of events currently retained.
+  get size(): number {
+    return this.buffer.length
+  }
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -725,6 +725,10 @@ import {
   registerTerminalViewAttributesApplier
 } from './terminal-view-attribute-store'
 import { killAllProcessesForWorktree } from './worktree-teardown'
+import {
+  MobileNotificationReplayBuffer,
+  type ReplayableMobileNotification
+} from './mobile-notification-replay'
 import { MOBILE_SUBSCRIBE_SCROLLBACK_ROWS } from './scrollback-limits'
 import {
   createMobileSessionTabsNotifyCoalescer,
@@ -2040,6 +2044,10 @@ type ResolvedWorktreeInFlight = {
   promise: Promise<ResolvedWorktreeSnapshot>
 }
 
+// Why: notificationSeq is the desktop-assigned monotonic sequence used for
+// mobile reconnect catch-up (#8129). It is added on dispatch (and replay) so a
+// client can watermark the last event it delivered and request exactly the
+// events after it — idempotent, no duplicate local pushes.
 export type MobileNotificationDispatchEvent = {
   type: 'notification'
   source: 'agent-task-complete' | 'terminal-bell' | 'test'
@@ -2047,11 +2055,13 @@ export type MobileNotificationDispatchEvent = {
   body: string
   worktreeId?: string
   notificationId?: string
+  notificationSeq?: number
 }
 
 export type MobileNotificationDismissEvent = {
   type: 'dismiss'
   notificationId: string
+  notificationSeq?: number
 }
 
 export type MobileNotificationEvent =
@@ -7469,10 +7479,28 @@ export class OrcaRuntimeService {
     return this.notificationListeners.size
   }
 
+  // Why: bounded replay buffer for the mobile reconnect catch-up (#8129).
+  // Every dispatched notification is recorded with a monotonic seq so a
+  // reconnecting client can fetch exactly the events it missed. Kept on the
+  // service instance (not per-client) because the buffer is a global,
+  // idempotent-by-seq source of truth; clients watermark their own position.
+  private readonly mobileNotificationReplay = new MobileNotificationReplayBuffer()
+
   dispatchMobileNotification(event: MobileNotificationEvent): void {
+    const seq = this.mobileNotificationReplay.record(event)
     for (const listener of this.notificationListeners) {
-      listener(event)
+      // Why: surface the desktop-assigned seq to live listeners so they can
+      // watermark the last event delivered and feed it back to getMissedSince
+      // on reconnect (idempotent catch-up, no duplicate local pushes).
+      listener({ ...event, notificationSeq: seq })
     }
+  }
+
+  // Returns notifications dispatched after lastSeenSeq. Idempotent: the same
+  // watermark always yields the same set, so a client cannot be re-pushed an
+  // already-delivered event (the adversarial-review gate for #8129).
+  getMissedNotificationsSince(lastSeenSeq: number): ReplayableMobileNotification[] {
+    return this.mobileNotificationReplay.getMissedSince(lastSeenSeq)
   }
 
   dismissMobileNotification(notificationId: string): void {

--- a/src/main/runtime/rpc/methods/notifications.ts
+++ b/src/main/runtime/rpc/methods/notifications.ts
@@ -13,6 +13,17 @@ const NotificationUnsubscribeParams = z.object({
     .pipe(z.string().min(1, 'Missing subscriptionId'))
 })
 
+// Why: notifications.getMissedSince is the catch-up RPC for mobile reconnect
+// (#8129). The client passes the highest seq it has already delivered; the
+// runtime returns only notifications dispatched after that seq. Because the
+// desktop assigns a monotonic seq to every dispatched notification, the cut is
+// exact and idempotent — re-requesting with the same watermark can never
+// return an already-delivered event, so reconnects never duplicate local
+// pushes (the adversarial-review gate for #8129).
+const NotificationGetMissedSinceParams = z.object({
+  lastSeenSeq: z.number().int().min(0, 'lastSeenSeq must be a non-negative integer')
+})
+
 // Why: notifications.subscribe streams desktop notification events to mobile
 // clients over WebSocket. The mobile client shows a local push notification
 // for each event. This avoids requiring Firebase/APNs — the existing
@@ -51,6 +62,17 @@ export const NOTIFICATION_METHODS: readonly RpcAnyMethod[] = [
     handler: async (params, { runtime }) => {
       runtime.cleanupSubscription(params.subscriptionId)
       return { unsubscribed: true }
+    }
+  }),
+  defineMethod({
+    name: 'notifications.getMissedSince',
+    params: NotificationGetMissedSinceParams,
+    // Why: returns only notifications with seq > lastSeenSeq. The runtime owns
+    // the monotonic seq, so this is the single source of truth for what the
+    // client missed while its socket was reaped.
+    handler: async (params, { runtime }) => {
+      const missed = runtime.getMissedNotificationsSince(params.lastSeenSeq)
+      return { notifications: missed }
     }
   })
 ]

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -285,6 +285,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'linear.updateIssue',
   'markdown.readTab',
   'markdown.saveTab',
+  'notifications.getMissedSince',
   'notifications.subscribe',
   'notifications.unsubscribe',
   'preflight.check',


### PR DESCRIPTION
## Summary

Take-over of @branben's mobile-reconnect work from #8605 / #8591. Ships the **two fixes that are correct, on-target, and clear of the in-flight relay PR (#8536)**, corrected so mobile CI actually passes:

- **`fix(mobile): resync worktree list on reconnect + pull-to-refresh (#8498)`**
- **`fix(mobile): replay missed notifications idempotently on reconnect (#8129, partial)`**

**Deliberately NOT included** (see *Scope* below): #6784 (raw connection-error surfacing) and #4500 (ws-transport pong-liveness) — both touch connection-health / connection-lifecycle code owned by the relay PR **#8536**. Kept out to avoid stepping on that work.

Two isolated commits for clean review/rollback. `Closes #8498.`

## What was wrong with the original PR (#8605)

The original bundle was verified against source and found to have defects the author's own checks missed (they ran the **root** typecheck, which does not cover `mobile/` — mobile is typechecked separately by `mobile.yml`):

1. **Three app-breaking mobile imports** (all in the #6784 files, now dropped): `use-host-connection-state.ts` imported `./transport/types` / `./transport/rpc-client` (→ nonexistent `transport/transport/…`), and `use-last-connection-error.ts` imported `useCtx` from `client-context` where it is **not exported** (runtime crash on every host/session/tasks screen). Confirmed by running `cd mobile && npx tsc --noEmit`.
2. **A notification field mismatch** (in #8129): the live fan-out tags events `notificationSeq`, but the desktop **replay** path returned `seq`, and the mobile client only reads `notificationSeq`. So a replay-only delivery never advanced or persisted the client watermark → latent duplicate-push across restarts (the #5070 class). The original test hid it by mocking the wrong field shape; the CodeRabbit comment that flagged this was wrongly dismissed. **Proven with a failing repro before fixing.**
3. **`mobile-notifications.ts` over the 300-line oxlint `max-lines` limit** (348 counted) — another mobile-only gate the author's desktop ratchet didn't catch.

## Fixes in this PR

**#8498 — worktree resync**
- Refetch worktrees + repo metadata on the transition **into** `connected` (not every 3s poll tick), via a small extracted `useWorktreeResync` hook.
- Pull-to-refresh (`RefreshControl`) on the worktree `SectionList`.
- Write the confirmed snapshot back through `setCachedWorktrees` from the host screen, so a reconnect refetch or remount can't serve a poisoned/partial cache.

**#8129 — notification replay (partial; catches up on reconnect)**
- Desktop `MobileNotificationReplayBuffer` (monotonic seq, cap 256, oldest-first evict) + `notifications.getMissedSince(seq)` — returns exactly `seq > watermark`, idempotent by construction, auth-gated identically to `notifications.subscribe`.
- Mobile persists `lastSeenSeq` per host; on a reconnect `ready` it fetches missed events from that watermark and dedups by `id#seq`.
- **Field-mismatch fix:** the replay buffer now exposes `notificationSeq` end-to-end, so a replay-only delivery advances + persists the watermark. Regression-tested on both sides.
- Reconnect catch-up helpers extracted to `notification-reconnect-catchup.ts` to keep `mobile-notifications.ts` under its max-lines budget (no suppression added).

## Evidence

- Desktop: `mobile-notification-replay.test.ts` **8/8**; `tsc -p config/tsconfig.node.json` **0 errors**.
- Mobile: `mobile-notifications.test.ts` **12/12** + `worktree-cache.test.ts` **2/2**; `cd mobile && npx tsc --noEmit` clean; `oxlint` + `oxfmt --check .` clean; full mobile suite **1471 pass**.
- `check-max-lines-ratchet` OK (no new bypasses/suppressions).
- Independent adversarial review (Opus) re-ran every gate and returned **SHIP**: no blocker, no security issue, no leak, no revert, no relay-territory violation.

## ELI5

Your phone shows a stale project list and drops "agent done" pings when it wakes from sleep, because on reconnect it just re-opens the socket and asks for nothing it missed. This PR makes it **catch up**: on reconnect it re-fetches the worktree list (and you can pull-to-refresh), and it asks the desktop "what notifications did I miss since #N?" and shows exactly those — never the same one twice.

## Scope — why #6784 and #4500 are held back

The relay PR **#8536** rewrites `mobile/app/index.tsx`, `client-context.tsx`, `types.ts`, all four screens, and adds a whole connection-supervisor layer. #6784 (connection-health error UX) and #4500 (ws heartbeat / connection lifecycle) live squarely in that surface, so changing them now would conflict with and complicate the relay landing. They're left for relay-aware follow-ups. (#6784's original raw-error approach was also misaligned with the issue, which asks for a Tailscale recommendation; #4500's confirmed repro is renderer-side and already addressed by #8630/#8673.)

## Trade-offs / user-regressions

- **#8129 is partial, not a close.** This catches up on **reconnect** (foreground within a live process — the common iOS app-switch case). It does **not** deliver while backgrounded/killed; that needs real push (Expo/APNs/FCM) as the issue requests. Left open.
- **Cold-open does not catch up** (by design): the first `ready` after a full app relaunch skips the fetch to avoid a burst of stale notifications. Missed-while-killed events are not replayed on a cold start.
- **At-least-once, not exactly-once:** the persisted watermark is best-effort. In a narrow window (hard-kill within the few-ms async-persist gap, same desktop process, entry still in the 256-buffer, then a reconnect blip) 1–2 already-shown notifications can reappear once, then self-heal. Documented in code.
- No other regressions: additive-only, no connectivity/transport behavior changed, RPC auth unchanged.

---
Co-authored-by: Brandon Bennett (@branben) — original architecture from #8605.

Made with [Orca](https://github.com/stablyai/orca) 🐋
