### PR TITLE
fix(codex): use PowerShell-safe Windows hooks

### DIFF
--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -38,7 +38,7 @@ vi.mock('os', async (importOriginal) => {
   }
 })
 
-import { CodexHookService } from './hook-service'
+import { CodexHookService, _internals } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
   /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
@@ -246,30 +246,16 @@ describe('CodexHookService', () => {
     }
   )
 
-  // Why: the common case — a profile path with no spaces or cmd metacharacters
-  // — must launch the .cmd directly with no PowerShell, restoring the pre-#6078
-  // speed that Codex 0.140's synchronous "Running <event> hook" rows expose.
+  // Why: Codex runs Windows hook command strings through PowerShell. Even a
+  // cmd-safe script path must avoid cmd.exe-only `if exist (...)` syntax.
   it.skipIf(process.platform !== 'win32')(
-    'launches the managed .cmd directly when the profile path is cmd-safe',
+    'uses a PowerShell-safe launcher when the profile path is cmd-safe',
     () => {
-      const status = new CodexHookService().install()
-      expect(status.state).toBe('installed')
-
-      const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
-      const hooksConfig = JSON.parse(
-        readFileSync(join(managedCodexHome, 'hooks.json'), 'utf-8')
-      ) as { hooks: Record<string, { hooks?: { command?: string }[] }[]> }
-
-      // Why: the temp home is normally cmd-safe; guard so a runner whose tmpdir
-      // holds an exotic character still asserts the correct (fallback) branch.
-      const command = hooksConfig.hooks.Stop?.[0]?.hooks?.[0]?.command ?? ''
-      const cmdSafe = /^[A-Za-z0-9_.:\\~-]+$/.test(join(tmpHome, '.orca', 'agent-hooks'))
-      if (cmdSafe) {
-        expect(command).not.toMatch(/powershell/i)
-        expect(command).toMatch(/\\agent-hooks\\codex-hook\.cmd$/)
-      } else {
-        expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
-      }
+      const command = _internals.getManagedCommand(
+        'C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd'
+      )
+      expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
+      expect(command).not.toMatch(/^if exist\b/i)
     }
   )
 

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -13,7 +13,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
-  wrapWindowsCmdHookCommand,
+  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -132,7 +132,7 @@ function getManagedScriptPath(): string {
 
 function getManagedCommand(scriptPath: string): string {
   return process.platform === 'win32'
-    ? wrapWindowsCmdHookCommand(scriptPath)
+    ? wrapWindowsHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
 }
 
@@ -1563,6 +1563,7 @@ export class CodexHookService {
 export const codexHookService = new CodexHookService()
 
 export const _internals = {
+  getManagedCommand,
   getManagedScript,
   installManagedHooksIntoWslRuntime,
   refreshWslRuntimeUserHooks,


### PR DESCRIPTION
## Summary

Fix Orca-managed Codex hooks on native Windows by selecting the existing encoded PowerShell launcher instead of the CMD-only fast path.

Codex receives Windows hook commands through PowerShell. For CMD-safe profile paths, Orca previously emitted `if exist (...) call ...`, which PowerShell rejects with exit code 1. The failure affected lifecycle events including `SessionStart`, `UserPromptSubmit`, and `Stop`.

This change:

- uses `wrapWindowsHookCommand` for native Windows Codex hooks
- leaves macOS, Linux, WSL, SSH/remote, and other agents' wrappers unchanged
- replaces the old CMD-fast-path expectation with a deterministic regression using a fixed CMD-safe path

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — the full Windows run completed with 29,104 passed, 96 failed, and 316 skipped; failures were outside this diff and included POSIX-only `/bin/sh` assumptions, path/line-ending expectations, and existing environment-sensitive tests
- [ ] `pnpm build` — not run
- [x] Added or updated high-quality tests that would catch regressions

Focused validation:

- `pnpm test --run src/main/codex/hook-service.test.ts` — 28 passed
- pre-fix regression run produced the exact CMD command (`if exist ... call ...`) and failed the PowerShell-launcher assertion
- lint-staged checks passed for both changed files

## AI Review Report

Ran separate standards and spec reviews against `upstream/main`.

- Standards review found no documented-standard violations or code smells.
- Spec review initially found that the temp-directory fixture was not deterministically CMD-safe. The test was changed to call the existing `_internals.getManagedCommand` seam with `C:\Users\alice\.orca\agent-hooks\codex-hook.cmd`; the amended review found no remaining issues.
- Cross-platform review confirmed macOS/Linux retain `wrapPosixHookCommand`, while WSL and SSH/remote continue through their separate POSIX paths. Only local native-Windows Codex selection changes.

## Security Audit

The change reuses Orca's existing hardened Windows launcher. It fully qualifies Windows PowerShell, Base64-encodes the UTF-16 command, checks the managed script with `Test-Path -LiteralPath`, and escapes single quotes in the path. This reduces shell splitting and metacharacter-expansion risk. No auth, secrets, dependencies, IPC schema, or network behavior changed.

## Notes

Reproduced with Orca 1.4.138 and OpenAI Codex 0.144.4 on Windows. This production command-selection fix is separate from #8629 and #8631, which address lifecycle-test isolation.
