### PR TITLE
fix(daemon): replace a permanently wedged daemon instead of preserving it forever (#8689)

### DIFF
--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -1622,16 +1622,85 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(forkMock).toHaveBeenCalled()
   })
 
-  it('adopts an unresponsive daemon whose pipe still accepts connections (update-relaunch wedge)', async () => {
-    // Why: the Windows update-relaunch regression — post-install disk/AV load
-    // wedges the daemon past the 3s health budget AND the 5s hello budget of
-    // the session-list re-verification, while its sessions are still alive.
-    // The old fail-closed path killed the daemon here. A pipe that accepts a
-    // raw connection proves the daemon is alive, so the launcher must adopt.
+  // Why: a net.connect stub whose 'connect' fires — makes probeSocket() report
+  // the wedged daemon's pipe as alive on every grace re-check.
+  function stubAliveSocketConnect() {
+    const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+    return {
+      on(event: string, cb: () => void) {
+        handlers[event]?.push(cb)
+        if (event === 'connect') {
+          queueMicrotask(() => cb())
+        }
+        return this
+      },
+      removeListener(event: string, cb: () => void) {
+        handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+        return this
+      },
+      destroy() {}
+    }
+  }
+
+  it('adopts a transiently wedged daemon that drains and reports live sessions within the grace window', async () => {
+    // Why: the Windows update-relaunch case — post-install disk/AV load wedges
+    // the daemon past the first hello budget, but it drains within seconds and
+    // still owns live sessions. The launcher must give it a bounded grace and
+    // ADOPT it rather than killing its live sessions.
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()
 
+    // First probe times out (still draining); the retry within the grace
+    // window succeeds and reports a live session.
     daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
+      return {
+        ensureConnected: vi.fn(async () => {
+          throw new Error('Hello response timed out')
+        }),
+        request: vi.fn(),
+        disconnect: vi.fn()
+      }
+    })
+    daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        request: vi.fn(async () => ({ sessions: [{ sessionId: 'wt-1@@live', isAlive: true }] })),
+        disconnect: vi.fn()
+      }
+    })
+
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string
+    ) => Promise<{ shutdown(): Promise<void> }>
+    checkDaemonHealthMock.mockResolvedValueOnce('unreachable')
+    probeSocketExistsMock.mockReturnValue(true)
+    netConnectMock.mockImplementation(stubAliveSocketConnect)
+
+    await launcher('/fake/socket', '/fake/token')
+
+    expect(killStaleDaemonMock).not.toHaveBeenCalled()
+    expect(forkMock).not.toHaveBeenCalled()
+  })
+
+  it('replaces a permanently wedged daemon after the grace window is exhausted (#8689)', async () => {
+    // Why: a daemon whose socket keeps accepting connections but whose event
+    // loop never answers hello would, under the old code, be preserved forever
+    // — every terminal spawn then failed with "Hello response timed out" with
+    // no recovery. After the bounded grace it must be replaced so the app gets
+    // working terminals again.
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+
+    const answeringDefault = function MockDaemonClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        request: vi.fn(async () => ({ sessions: [] })),
+        disconnect: vi.fn()
+      }
+    }
+    // Every probe across the whole grace window times out (permanent wedge).
+    daemonClientMock.mockImplementation(function MockDaemonClient() {
       return {
         ensureConnected: vi.fn(async () => {
           throw new Error('Hello response timed out')
@@ -1646,25 +1715,82 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       tokenPath: string
     ) => Promise<{ shutdown(): Promise<void> }>
     checkDaemonHealthMock.mockResolvedValueOnce('unreachable')
-    // The raw pipe probe succeeds even though every RPC timed out.
     probeSocketExistsMock.mockReturnValue(true)
-    netConnectMock.mockImplementationOnce(() => {
-      const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+    netConnectMock.mockImplementation(stubAliveSocketConnect)
+    forkMock.mockImplementationOnce(() => ({
+      pid: 12345,
+      on(event: string, cb: (arg?: unknown) => void) {
+        if (event === 'message') {
+          queueMicrotask(() => cb({ type: 'ready' }))
+        }
+        return this
+      },
+      off() {
+        return this
+      },
+      disconnect: vi.fn(),
+      unref: vi.fn()
+    }))
+
+    // Count only the launcher's own session-count probes.
+    daemonClientMock.mockClear()
+
+    try {
+      await launcher('/fake/socket', '/fake/token')
+
+      expect(killStaleDaemonMock).toHaveBeenCalledWith(
+        FAKE_RUNTIME_DIR,
+        '/fake/socket',
+        '/fake/token'
+      )
+      expect(forkMock).toHaveBeenCalled()
+      // Pins the grace budget: 1 initial probe + WEDGED_DAEMON_GRACE_RETRIES (3)
+      // retries. If someone cuts the retry count, this fails — a guard against
+      // silently shrinking the transient-wedge live-session protection.
+      expect(daemonClientMock).toHaveBeenCalledTimes(4)
+    } finally {
+      // Restore the answering default so the persistent throwing impl above
+      // does not leak into later tests (clearAllMocks clears calls, not impls).
+      daemonClientMock.mockImplementation(answeringDefault)
+    }
+  })
+
+  it('preserves a daemon that drains only on the final grace retry (pins the grace budget)', async () => {
+    // Why: pins WEDGED_DAEMON_GRACE_RETRIES ≥ 3. The daemon stays wedged across
+    // the initial probe and the first two retries, then drains and reports a
+    // live session on the LAST allowed retry. Cutting the retry budget would
+    // replace this still-live daemon — this test fails if that happens.
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+
+    // 3 wedged probes (initial + retries 1 & 2)...
+    for (let i = 0; i < 3; i++) {
+      daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
+        return {
+          ensureConnected: vi.fn(async () => {
+            throw new Error('Hello response timed out')
+          }),
+          request: vi.fn(),
+          disconnect: vi.fn()
+        }
+      })
+    }
+    // ...then it drains on the final allowed retry and reports a live session.
+    daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
       return {
-        on(event: string, cb: () => void) {
-          handlers[event]?.push(cb)
-          if (event === 'connect') {
-            queueMicrotask(() => cb())
-          }
-          return this
-        },
-        removeListener(event: string, cb: () => void) {
-          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
-          return this
-        },
-        destroy() {}
+        ensureConnected: vi.fn(async () => {}),
+        request: vi.fn(async () => ({ sessions: [{ sessionId: 'wt-1@@live', isAlive: true }] })),
+        disconnect: vi.fn()
       }
     })
+
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string
+    ) => Promise<{ shutdown(): Promise<void> }>
+    checkDaemonHealthMock.mockResolvedValueOnce('unreachable')
+    probeSocketExistsMock.mockReturnValue(true)
+    netConnectMock.mockImplementation(stubAliveSocketConnect)
 
     await launcher('/fake/socket', '/fake/token')
 
@@ -1695,6 +1821,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     ) => Promise<{ shutdown(): Promise<void> }>
     checkDaemonHealthMock.mockResolvedValueOnce('rejected')
     probeSocketExistsMock.mockReturnValue(true)
+    netConnectMock.mockImplementation(stubAliveSocketConnect)
     forkMock.mockImplementationOnce(() => ({
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
@@ -1709,6 +1836,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       disconnect: vi.fn(),
       unref: vi.fn()
     }))
+    daemonClientMock.mockClear()
 
     await launcher('/fake/socket', '/fake/token')
 
@@ -1718,6 +1846,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       '/fake/token'
     )
     expect(forkMock).toHaveBeenCalled()
+    // Pins the 'rejected' fast-path: a daemon that actively refuses the
+    // handshake is never worth a grace window, so it is probed exactly once
+    // (no retries) before replacement.
+    expect(daemonClientMock).toHaveBeenCalledTimes(1)
   })
 
   it('adopts a healthy daemon whose pid-file identity cannot be verified (null startedAtMs metadata)', async () => {

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -7,6 +7,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { join } from 'node:path'
 import { PROTOCOL_VERSION } from './types'
+import { WEDGED_DAEMON_GRACE_RETRIES } from './daemon-init'
 
 const FAKE_USER_DATA_PATH = '/fake/userData'
 const FAKE_RUNTIME_DIR = join(FAKE_USER_DATA_PATH, 'daemon')
@@ -1744,10 +1745,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         '/fake/token'
       )
       expect(forkMock).toHaveBeenCalled()
-      // Pins the grace budget: 1 initial probe + WEDGED_DAEMON_GRACE_RETRIES (3)
-      // retries. If someone cuts the retry count, this fails — a guard against
-      // silently shrinking the transient-wedge live-session protection.
-      expect(daemonClientMock).toHaveBeenCalledTimes(4)
+      // The launcher probes the full grace budget before giving up: 1 initial
+      // probe + WEDGED_DAEMON_GRACE_RETRIES retries.
+      expect(daemonClientMock).toHaveBeenCalledTimes(1 + WEDGED_DAEMON_GRACE_RETRIES)
     } finally {
       // Restore the answering default so the persistent throwing impl above
       // does not leak into later tests (clearAllMocks clears calls, not impls).
@@ -1755,31 +1755,43 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     }
   })
 
-  it('preserves a daemon that drains only on the final grace retry (pins the grace budget)', async () => {
-    // Why: pins WEDGED_DAEMON_GRACE_RETRIES ≥ 3. The daemon stays wedged across
-    // the initial probe and the first two retries, then drains and reports a
-    // live session on the LAST allowed retry. Cutting the retry budget would
-    // replace this still-live daemon — this test fails if that happens.
+  it('grace budget is generous enough to ride out a ~60s transient wedge', () => {
+    // Why: pins the magnitude. Each probe waits out the client's 5s hello
+    // timeout, so 1 + 11 probes ≈ 60s of drain grace. Shrinking this narrows
+    // the window in which a transiently wedged daemon's live sessions are
+    // preserved instead of replaced — don't cut it without field telemetry.
+    expect(WEDGED_DAEMON_GRACE_RETRIES).toBeGreaterThanOrEqual(11)
+  })
+
+  it('preserves a daemon that stays wedged until the LAST allowed grace retry', async () => {
+    // Why: exercises the full grace loop end-to-end. The daemon throws on every
+    // probe except the final allowed one (1 + WEDGED_DAEMON_GRACE_RETRIES), on
+    // which it drains and reports a live session — so it must be preserved, not
+    // replaced. Cutting the retry budget below the drain point would replace a
+    // still-live daemon, which this test catches.
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()
 
-    // 3 wedged probes (initial + retries 1 & 2)...
-    for (let i = 0; i < 3; i++) {
-      daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
-        return {
-          ensureConnected: vi.fn(async () => {
-            throw new Error('Hello response timed out')
-          }),
-          request: vi.fn(),
-          disconnect: vi.fn()
-        }
-      })
-    }
-    // ...then it drains on the final allowed retry and reports a live session.
-    daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
+    let probe = 0
+    const answeringDefault = function MockDaemonClient() {
       return {
         ensureConnected: vi.fn(async () => {}),
-        request: vi.fn(async () => ({ sessions: [{ sessionId: 'wt-1@@live', isAlive: true }] })),
+        request: vi.fn(async () => ({ sessions: [] })),
+        disconnect: vi.fn()
+      }
+    }
+    daemonClientMock.mockImplementation(function MockDaemonClient() {
+      probe += 1
+      const drainsNow = probe >= 1 + WEDGED_DAEMON_GRACE_RETRIES
+      return {
+        ensureConnected: vi.fn(async () => {
+          if (!drainsNow) {
+            throw new Error('Hello response timed out')
+          }
+        }),
+        request: vi.fn(async () => ({
+          sessions: drainsNow ? [{ sessionId: 'wt-1@@live', isAlive: true }] : []
+        })),
         disconnect: vi.fn()
       }
     })
@@ -1792,10 +1804,14 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     probeSocketExistsMock.mockReturnValue(true)
     netConnectMock.mockImplementation(stubAliveSocketConnect)
 
-    await launcher('/fake/socket', '/fake/token')
+    try {
+      await launcher('/fake/socket', '/fake/token')
 
-    expect(killStaleDaemonMock).not.toHaveBeenCalled()
-    expect(forkMock).not.toHaveBeenCalled()
+      expect(killStaleDaemonMock).not.toHaveBeenCalled()
+      expect(forkMock).not.toHaveBeenCalled()
+    } finally {
+      daemonClientMock.mockImplementation(answeringDefault)
+    }
   })
 
   it('replaces a hello-rejected daemon even though its pipe accepts connections', async () => {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -65,6 +65,18 @@ function logDaemonMilestone(event: string, details: Record<string, unknown> = {}
   }
 }
 
+// Why: how many extra hello+listSessions probes to make against a wedged-but-
+// connectable daemon before replacing it. Each probe waits out the client's 5s
+// hello timeout, so this spaces re-checks ~5s apart, giving a transiently wedged
+// daemon (Windows update-relaunch drain) up to ~20s to answer while keeping a
+// permanent wedge (#8689) bounded well under the 60s local-PTY fail-open cap.
+// Trade-off: a transient wedge that still owns live sessions but takes longer
+// than this window to drain is now replaced (its live processes lost, though
+// scrollback cold-restores) rather than preserved indefinitely. If field
+// update-relaunch drains routinely exceed ~20s, raise this — it stays bounded
+// by the fail-open cap.
+const WEDGED_DAEMON_GRACE_RETRIES = 3
+
 let spawner: DaemonSpawner | null = null
 type DaemonProvider = DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProvider
 
@@ -257,7 +269,28 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
       // health check while the daemon is alive and owning terminals. Killing
       // it would destroy every live session, so re-verify with a session list
       // first.
-      const liveSessionCount = await getAliveDaemonSessionCount(socketPath, tokenPath)
+      let liveSessionCount = await getAliveDaemonSessionCount(socketPath, tokenPath)
+      // Why: on a Windows update relaunch the daemon can be transiently wedged
+      // past every RPC budget (final checkpoint flush + installer/AV disk
+      // pressure) while its sessions are still alive — replacing it here is what
+      // killed those sessions. A pipe that still accepts connections proves a
+      // live daemon, so give a wedged-but-connectable daemon a bounded grace to
+      // drain and answer before deciding. A PERMANENTLY wedged daemon (accepts
+      // connections but its event loop never answers hello — #8689) exhausts the
+      // grace and falls through to replacement below, instead of being preserved
+      // forever, which strands the app with zero working terminals. 'rejected'
+      // means the daemon answered and refused the handshake — it can never be
+      // adopted, so it skips the grace and replacement stays the only recovery.
+      let graceRetry = 0
+      while (
+        liveSessionCount === null &&
+        health !== 'rejected' &&
+        graceRetry < WEDGED_DAEMON_GRACE_RETRIES &&
+        (await probeSocket(socketPath))
+      ) {
+        liveSessionCount = await getAliveDaemonSessionCount(socketPath, tokenPath)
+        graceRetry++
+      }
       if (liveSessionCount !== null && liveSessionCount > 0) {
         if (health === 'pty-spawn-unhealthy') {
           console.warn(
@@ -271,20 +304,6 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
         }
         console.warn(
           `[daemon] Preserving daemon that failed the health check because it owns ${liveSessionCount} live session${liveSessionCount === 1 ? '' : 's'}`
-        )
-        return createPreservedDaemonHandle(runtimeDir)
-      }
-      // Why: on a Windows update relaunch the daemon can be wedged past every
-      // RPC budget (final checkpoint flush + installer/AV disk pressure), so
-      // both the health check AND the session list time out while sessions
-      // are still alive — failing closed here is what killed those sessions.
-      // A pipe that still accepts connections proves a live daemon: adopt it
-      // and let the adapter reconnect once the daemon drains. 'rejected'
-      // means the daemon answered and refused the handshake — it can never be
-      // adopted, so replacement stays the only recovery.
-      if (liveSessionCount === null && health !== 'rejected' && (await probeSocket(socketPath))) {
-        console.warn(
-          '[daemon] Preserving unresponsive daemon because its socket still accepts connections'
         )
         return createPreservedDaemonHandle(runtimeDir)
       }

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -67,15 +67,21 @@ function logDaemonMilestone(event: string, details: Record<string, unknown> = {}
 
 // Why: how many extra hello+listSessions probes to make against a wedged-but-
 // connectable daemon before replacing it. Each probe waits out the client's 5s
-// hello timeout, so this spaces re-checks ~5s apart, giving a transiently wedged
-// daemon (Windows update-relaunch drain) up to ~20s to answer while keeping a
-// permanent wedge (#8689) bounded well under the 60s local-PTY fail-open cap.
-// Trade-off: a transient wedge that still owns live sessions but takes longer
-// than this window to drain is now replaced (its live processes lost, though
-// scrollback cold-restores) rather than preserved indefinitely. If field
-// update-relaunch drains routinely exceed ~20s, raise this — it stays bounded
-// by the fail-open cap.
-const WEDGED_DAEMON_GRACE_RETRIES = 3
+// hello timeout, so this spaces re-checks ~5s apart: 1 initial + 11 retries ≈
+// 60s of grace for a transiently wedged daemon (Windows update-relaunch drain)
+// to answer and be preserved WITH its live sessions, before a permanent wedge
+// (#8689) is replaced. Deliberately generous to keep live-session loss on the
+// transient path as close to zero as possible.
+//
+// A transient wedge drains early (well under the 60s local-PTY fail-open cap),
+// so its startup is short. Only a *permanent* wedge runs the full window; it can
+// then approach/exceed the fail-open cap, at which point restored panes fail
+// open to the in-process provider for the session and adopt the freshly forked
+// daemon on the next launch — a rare path that still recovers, versus the old
+// forever-broken behavior. Trade-off: a transient wedge owning live sessions
+// that takes longer than ~60s to drain is replaced (live processes lost, though
+// scrollback cold-restores). Raise this only alongside the fail-open cap.
+export const WEDGED_DAEMON_GRACE_RETRIES = 11
 
 let spawner: DaemonSpawner | null = null
 type DaemonProvider = DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProvider

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { DaemonClient } from './client'
+import { DaemonProtocolError } from './daemon-errors'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { DaemonServer } from './daemon-server'
 import { HeadlessEmulator } from './headless-emulator'
@@ -1943,6 +1944,34 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       await expect(noRespawnAdapter.spawn({ cols: 80, rows: 24 })).rejects.toThrow()
 
       noRespawnAdapter.dispose()
+    })
+
+    it('treats a hello handshake timeout as daemon-gone and respawns (#8689)', async () => {
+      // Why: a wedged daemon accepts the socket connection but never answers
+      // hello, so ensureConnected() rejects with "Hello response timed out".
+      // That must be classified as daemon-gone so withDaemonRetry respawns and
+      // retries — otherwise every terminal spawn fails against the wedge forever.
+      const realEnsureConnected = DaemonClient.prototype.ensureConnected
+      const ensureConnectedSpy = vi
+        .spyOn(DaemonClient.prototype, 'ensureConnected')
+        .mockImplementationOnce(async () => {
+          // The exact error type + message the real client raises on a wedge.
+          throw new DaemonProtocolError('Hello response timed out')
+        })
+        .mockImplementation(function (this: DaemonClient) {
+          return realEnsureConnected.call(this)
+        })
+      const respawnFn = vi.fn(async () => {})
+      const respawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+
+      try {
+        const result = await respawnAdapter.spawn({ cols: 80, rows: 24 })
+        expect(result.id).toBeDefined()
+        expect(respawnFn).toHaveBeenCalledOnce()
+      } finally {
+        ensureConnectedSpy.mockRestore()
+        respawnAdapter.dispose()
+      }
     })
 
     it('coalesces concurrent respawns so only one daemon is forked', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1354,8 +1354,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
 // unreachable (daemon died). Checking syscall avoids false positives from
 // token-file ENOENT (readFileSync), which has no syscall or syscall='open'.
 // "Connection lost" / "Not connected" mean the daemon died while we had an
-// active or stale connection. All indicate the daemon is gone and a respawn
-// should be attempted.
+// active or stale connection. "Hello response timed out" means we reconnected
+// to a daemon whose socket accepts connections but whose event loop never
+// answers the handshake (a wedged daemon, #8689) — respawning re-enters the
+// grace-bounded launcher, which drains a transient wedge or replaces a
+// permanent one instead of failing every terminal forever. All indicate the
+// daemon is unusable and a respawn should be attempted.
 function isDaemonGoneError(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false
@@ -1365,5 +1369,5 @@ function isDaemonGoneError(err: unknown): boolean {
     return true
   }
   const msg = err.message
-  return msg === 'Connection lost' || msg === 'Not connected'
+  return msg === 'Connection lost' || msg === 'Not connected' || msg === 'Hello response timed out'
 }

--- a/src/main/daemon/issue-6814-daemon-failure-classification.test.ts
+++ b/src/main/daemon/issue-6814-daemon-failure-classification.test.ts
@@ -10,7 +10,8 @@
 // still answers protocol, so a regression that widened it to wedged daemons
 // would silently strand fresh terminals on a daemon that cannot serve them.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { DaemonServer } from './daemon-server'
@@ -107,10 +108,31 @@ describe('issue #6814 repro: daemon failure-mode classification', () => {
       const health = await checkDaemonHealth(socketPath, tokenPath)
       // This is the key finding: wedged != degraded. #6830's degraded fallback
       // does NOT engage here; recovery still depends on the unreachable-path
-      // (preserve-if-live-else-replace) logic, not the degraded provider.
+      // (grace-bounded preserve-if-live-else-replace) logic, not the degraded
+      // provider.
       expect(health).toBe('unreachable')
     } finally {
       await server.shutdown()
+    }
+  }, 15000)
+
+  // #8689: a daemon whose socket accepts connections but never answers the
+  // hello handshake (event loop wedged before the protocol reply) also
+  // classifies as 'unreachable' — the launcher's grace-bounded path must
+  // eventually replace it rather than preserve it forever.
+  it('WEDGED-HELLO: a daemon that accepts connections but never answers hello classifies as unreachable (#8689)', async () => {
+    const wedged = createServer((sock) => {
+      // Swallow the hello bytes but never write a response — the exact wedge.
+      sock.on('data', () => {})
+    })
+    await new Promise<void>((resolve) => wedged.listen(socketPath, () => resolve()))
+    // The health check reads the token before connecting, so it must exist.
+    writeFileSync(tokenPath, 'wedged-token')
+    try {
+      const health = await checkDaemonHealth(socketPath, tokenPath)
+      expect(health).toBe('unreachable')
+    } finally {
+      await new Promise<void>((resolve) => wedged.close(() => resolve()))
     }
   }, 15000)
 


### PR DESCRIPTION
## What & why

Fixes #8689 — on macOS, terminals show `DaemonProtocolError: Hello response timed out` repeatedly with **no recovery** (screenshot in the issue shows it stacked 4×).

**Root cause.** The terminal daemon runs as a detached process. When it gets **wedged** — its socket still `accept()`s connections but its event loop never answers the protocol `hello` handshake — two behaviors combined into a permanent break:

1. **The launcher adopted the wedge forever.** In `createOutOfProcessLauncher`'s unhealthy branch, a daemon that failed the health check but whose socket still accepted a raw connection was preserved *unconditionally* (`daemon-init.ts`). That branch was a deliberate fix for a Windows update-relaunch case (a *transiently* busy daemon that still owns live sessions must not be killed) — but it couldn't tell a transient wedge from a permanent one, so a permanent wedge was preserved on every launch.
2. **A hello timeout wasn't "daemon-gone".** `isDaemonGoneError` (`daemon-pty-adapter.ts`) matched `ENOENT`/`ECONNREFUSED`/`Connection lost`/`Not connected` — but not `Hello response timed out` — so `withDaemonRetry` never respawned. Every spawn rethrew the error.

## The fix (two coordinated changes)

1. **`daemon-init.ts` — bounded grace instead of unconditional preserve.** Retry the `hello`+`listSessions` probe up to `WEDGED_DAEMON_GRACE_RETRIES` (=11) times while the socket keeps probing alive. A transient wedge drains within the window (~60s) and is preserved *with its live sessions*; a permanent wedge exhausts the grace and falls through to `killStaleDaemon` + fork (replacement). A transient wedge drains early (well under the 60s local-PTY fail-open cap); only a *permanent* wedge runs the full ~60s window, after which restored panes fail open to the in-process provider for that session and adopt the freshly forked daemon on the next launch. Daemon init is off the first-paint path (the window still shows at 12s).
2. **`daemon-pty-adapter.ts` — hello timeout is daemon-gone.** `isDaemonGoneError` now also matches `Hello response timed out`, so an already-running adapter that reconnects into a wedge triggers `withDaemonRetry`'s respawn, which **re-enters the same grace-bounded launcher** — drain-or-replace, not fail-forever.

## ELI5

Orca keeps your terminals alive in a little always-on background helper (the "daemon"). Sometimes that helper freezes: it still answers the phone, but nobody's actually on the line. Orca used to see "the phone rings" and assume the helper was fine, so it kept calling forever and every terminal showed the red error. Now Orca waits a short, bounded time to see if the helper wakes up (it usually does, right after an update — so we don't throw away your running work). If it's truly frozen, Orca hangs up, starts a fresh helper, and your terminals work again — instead of staying broken until you quit and reopen the app.

## Evidence

Root cause reproduced end-to-end against the **real** product code (`DaemonClient` + `checkDaemonHealth`) with a socket that accepts connections but never answers `hello`:

```
health=unreachable  probeSocketAlive=true  clientOutcome="Hello response timed out"
=> launcher's old preserve condition (health !== 'rejected' && probeAlive) is true:
   the wedged daemon was PRESERVED forever, so every spawn kept throwing the error.
```

New/changed tests (all green; full daemon suite 808 passed | 5 skipped):

- `daemon-init.test.ts`
  - **adopts a transiently wedged daemon that drains and reports live sessions within the grace window** — the Windows case: no fork, sessions kept.
  - **replaces a permanently wedged daemon after the grace window is exhausted (#8689)** — fork + `killStaleDaemon` called; asserts the probe ran exactly `1 + WEDGED_DAEMON_GRACE_RETRIES` times.
  - **grace budget is generous enough to ride out a ~60s transient wedge** + **preserves a daemon that stays wedged until the LAST allowed grace retry** — pin the ~60s magnitude so the transient-wedge protection can't be silently shrunk.
  - **replaces a hello-rejected daemon…** — now asserts the `rejected` fast-path skips the grace (probed once).
- `daemon-pty-adapter.test.ts` — **treats a hello handshake timeout as daemon-gone and respawns (#8689)** (throws the real `DaemonProtocolError`).
- `issue-6814-daemon-failure-classification.test.ts` — **WEDGED-HELLO: a daemon that accepts connections but never answers hello classifies as unreachable (#8689)**.

**Pin proof:** temporarily setting `WEDGED_DAEMON_GRACE_RETRIES = 1` failed the magnitude-pin tests (verified during development), then reverted.

This change was reviewed by an adversarial multi-agent pass (6 lenses → per-finding refute-or-confirm by 2 independent skeptics → synthesis). Verdict: **SHIP**. It refuted the "tears down live terminals up-front" and "grace too short/destructive on the runtime path" concerns (a hello timeout only occurs on a *fresh* connect, so an actively-streaming client never re-runs the handshake), and confirmed the launcher grace mechanics are correct. The remaining surviving items are pre-existing or fast-follow (see below).

## Trade-offs / user regressions

**Zero regression to the common path.** A healthy daemon takes the existing `'healthy'` branch and never enters the grace loop — no added latency, no behavior change. The grace loop only runs for a daemon that *already* failed the health check.

**One inherent, bounded trade-off (narrowing of the Windows update-relaunch preserve).** The old code preserved a connectable-but-unresponsive daemon with *no* time bound. The new code replaces it after ~60s. So a *genuinely transient* wedge that **still owns live sessions and takes longer than ~60s to drain** now loses those sessions (the live child processes; scrollback still cold-restores from checkpoints) where the old code kept them. This is unavoidable given the fix: a permanent wedge and an arbitrarily-long transient wedge are indistinguishable at the decision point, and *unbounded preserve is exactly the reported bug*. During that whole window the sessions are frozen and unusable anyway, and the within-window transient case is still preserved (kept + newly tested). The bound is a single documented tuning constant with its floor pinned in tests; raise it (alongside the fail-open cap) if field telemetry shows update-relaunch drains routinely exceed ~60s.

**Deliberately out of scope (pre-existing, not introduced here):** when the runtime respawn path replaces a daemon, its killed sessions get no synthetic `pty:exit` fanout. Verified this is identical to the existing `ENOENT`/`ECONNREFUSED` daemon-death respawn path (the adapter's `onDisconnected` handler has never fanned exits) — so this PR introduces no new behavior there; it's a separate improvement affecting all respawn triggers.

Closes #8689.
