### PR TITLE
fix(codex): make Windows hooks portable across session shells

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -21,6 +21,7 @@ import {
   hookDefinitionHasManagedCommand,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsCrossShellHookCommand,
   wrapWindowsCmdHookCommand,
   wrapWindowsGitBashHookCommand,
   wrapWindowsHookCommand,
@@ -481,6 +482,22 @@ describe('wrapWindowsCmdHookCommand', () => {
   it('falls back to the encoded launcher when cmd.exe would split or expand the path', () => {
     const scriptPath = 'C:\\Users\\Jane Doe\\%ORCA_TEST%\\codex-hook.cmd'
     const command = wrapWindowsCmdHookCommand(scriptPath)
+    expect(command).toMatch(qualifiedWindowsPowerShellCommand)
+    expect(decodeWindowsHookCommand(command)).toBe(expectedDecodedWindowsHookCommand(scriptPath))
+  })
+})
+
+describe('wrapWindowsCrossShellHookCommand', () => {
+  it('uses a forward-slash direct path when every supported Windows shell can parse it', () => {
+    expect(
+      wrapWindowsCrossShellHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd')
+    ).toBe('C:/Users/alice/.orca/agent-hooks/codex-hook.cmd')
+  })
+
+  it('falls back to the encoded launcher when the path needs shell quoting', () => {
+    const scriptPath = 'C:\\Users\\Jane Doe\\.orca\\agent-hooks\\codex-hook.cmd'
+    const command = wrapWindowsCrossShellHookCommand(scriptPath)
+
     expect(command).toMatch(qualifiedWindowsPowerShellCommand)
     expect(decodeWindowsHookCommand(command)).toBe(expectedDecodedWindowsHookCommand(scriptPath))
   })

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -189,6 +189,13 @@ export function wrapWindowsCmdHookCommand(scriptPath: string): string {
 
 export const WINDOWS_GIT_BASH_SAFE_PATH = /^[A-Za-z0-9_.:/~-]+$/
 
+export function wrapWindowsCrossShellHookCommand(scriptPath: string): string {
+  const shellPath = scriptPath.replaceAll('\\', '/')
+  // Why: Windows hook hosts may use CMD, PowerShell, or Git Bash. Installers
+  // publish scripts first, so a safe direct path avoids another interpreter.
+  return WINDOWS_GIT_BASH_SAFE_PATH.test(shellPath) ? shellPath : wrapWindowsHookCommand(scriptPath)
+}
+
 export function wrapWindowsGitBashHookCommand(scriptPath: string): string {
   const bashPath = scriptPath.replaceAll('\\', '/')
   // Why: Claude's Git Bash runner can execute a forward-slash .cmd directly;

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -16,7 +16,11 @@ import { join } from 'node:path'
 import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { createManagedCommandMatcher, wrapPosixHookCommand } from '../agent-hooks/installer-utils'
+import {
+  createManagedCommandMatcher,
+  wrapPosixHookCommand,
+  wrapWindowsCrossShellHookCommand
+} from '../agent-hooks/installer-utils'
 import { computeTrustedHash, upsertHookTrustEntriesInContent } from './config-toml-trust'
 
 const { getPathMock, homedirMock } = vi.hoisted(() => ({
@@ -261,7 +265,7 @@ describe('CodexHookService', () => {
 
       const command = hooksConfig.hooks.Stop?.[0]?.hooks?.[0]?.command ?? ''
       expect(command).toBe(
-        join(tmpHome, '.orca', 'agent-hooks', 'codex-hook.cmd').replaceAll('\\', '/')
+        wrapWindowsCrossShellHookCommand(join(tmpHome, '.orca', 'agent-hooks', 'codex-hook.cmd'))
       )
 
       const result = spawnSync('powershell.exe', ['-NoProfile', '-Command', command], {

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -13,7 +13,7 @@ import {
 import { homedir, tmpdir } from 'node:os'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { createManagedCommandMatcher, wrapPosixHookCommand } from '../agent-hooks/installer-utils'
@@ -246,11 +246,10 @@ describe('CodexHookService', () => {
     }
   )
 
-  // Why: the common case — a profile path with no spaces or cmd metacharacters
-  // — must launch the .cmd directly with no PowerShell, restoring the pre-#6078
-  // speed that Codex 0.140's synchronous "Running <event> hook" rows expose.
+  // Why: Codex runs hooks through the session shell, which may be PowerShell;
+  // a CMD-only guard fails before the managed script can drain stdin.
   it.skipIf(process.platform !== 'win32')(
-    'launches the managed .cmd directly when the profile path is cmd-safe',
+    'runs a shell-safe managed hook through PowerShell without a shell syntax failure',
     () => {
       const status = new CodexHookService().install()
       expect(status.state).toBe('installed')
@@ -260,16 +259,23 @@ describe('CodexHookService', () => {
         readFileSync(join(managedCodexHome, 'hooks.json'), 'utf-8')
       ) as { hooks: Record<string, { hooks?: { command?: string }[] }[]> }
 
-      // Why: the temp home is normally cmd-safe; guard so a runner whose tmpdir
-      // holds an exotic character still asserts the correct (fallback) branch.
       const command = hooksConfig.hooks.Stop?.[0]?.hooks?.[0]?.command ?? ''
-      const cmdSafe = /^[A-Za-z0-9_.:\\~-]+$/.test(join(tmpHome, '.orca', 'agent-hooks'))
-      if (cmdSafe) {
-        expect(command).not.toMatch(/powershell/i)
-        expect(command).toMatch(/\\agent-hooks\\codex-hook\.cmd$/)
-      } else {
-        expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
-      }
+      expect(command).toBe(
+        join(tmpHome, '.orca', 'agent-hooks', 'codex-hook.cmd').replaceAll('\\', '/')
+      )
+
+      const result = spawnSync('powershell.exe', ['-NoProfile', '-Command', command], {
+        env: {
+          ...process.env,
+          ORCA_AGENT_HOOK_ENDPOINT: '',
+          ORCA_AGENT_HOOK_PORT: '',
+          ORCA_AGENT_HOOK_TOKEN: '',
+          ORCA_PANE_KEY: ''
+        },
+        input: Buffer.alloc(1_000_000, 'x')
+      })
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(0)
     }
   )
 

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -13,7 +13,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
-  wrapWindowsCmdHookCommand,
+  wrapWindowsCrossShellHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -131,8 +131,10 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
+  // Why: Codex runs hooks through the session shell, which can be PowerShell
+  // or Git Bash on Windows; use a command all supported shells can parse.
   return process.platform === 'win32'
-    ? wrapWindowsCmdHookCommand(scriptPath)
+    ? wrapWindowsCrossShellHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
 }
 


### PR DESCRIPTION
## Summary

- fix Orca-managed Codex hooks failing with exit code 1 when Windows Codex runs them through PowerShell
- register shell-safe `.cmd` paths with forward slashes so CMD, PowerShell, and Git Bash can all execute the same command
- keep the encoded PowerShell fallback for paths that contain spaces or shell metacharacters
- add an installed-config regression that sends a 1 MB hook payload through PowerShell and requires a clean exit

This fixes the Windows regression introduced by #8430. That change replaced the direct Codex hook path with a CMD-only `if exist (...)` guard, but Codex uses the configured session shell when present. PowerShell therefore rejected the hook before Orca's script could read stdin.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — not run in full; targeted Oxlint passed for all four changed files
- [ ] `pnpm typecheck` — not run in full; `pnpm run typecheck:node` passed
- [ ] `pnpm test` — not run in full; focused Vitest run passed 30 tests across the Codex service and cross-shell launcher
- [ ] `pnpm build` — not run
- [x] Added or updated high-quality tests that would catch regressions

Additional verification:

- installed Codex hook command executed successfully with a 1 MB stdin payload through Windows PowerShell
- the generated direct command was exercised successfully under CMD, Windows PowerShell, and Git for Windows Bash
- targeted Oxfmt check passed
- `pnpm run check:max-lines-ratchet` passed
- `git diff --check` passed

A broader managed-hook lifecycle run reached two unchanged failures in the existing CMD-only fast-path tests on this machine (`more.com`/Node stdin EOF and missing-script exit 1). The fixed Codex installer no longer uses that CMD-only launcher.

## AI Review Report

The review traced Codex hook discovery, trust hashing, and command execution through the current upstream implementation. It confirmed that Windows hooks default to `cmd.exe` only when no session shell is configured; otherwise Codex executes them through the active shell. That made the existing CMD-only guard invalid for Orca sessions hosted by PowerShell.

Main risks checked:

- **Shell compatibility:** verified the chosen forward-slash `.cmd` command under CMD, Windows PowerShell, and Git Bash. Paths that are not safe to execute unquoted retain Orca's existing encoded launcher.
- **Performance:** rejected an initial always-encoded PowerShell approach after measuring roughly 2.3 seconds of added startup time per hook on this machine. The final safe-path branch starts no additional interpreter.
- **Trust and cleanup:** Codex trust entries continue to hash the exact installed command, and the managed-command matcher already recognizes both direct forward-slash paths and encoded fallback commands.
- **Cross-platform:** the new command is selected only under `process.platform === 'win32'`. macOS/Linux local hooks, WSL runtime hooks, and SSH remote hooks keep their existing POSIX launchers unchanged.
- **Agent scope:** only Codex switches away from the CMD-specific helper. Antigravity and Devin behavior is unchanged.
- **UI/Electron:** no renderer, shortcut, label, layout, or Electron IPC behavior changed.

No additional correctness changes were needed after review.

## Security Audit

- No dependency, network endpoint, auth flow, IPC channel, or secret handling changed.
- The direct command is allowed only when the normalized path matches the existing strict shell-safe allowlist. Spaces, quotes, `%`, `^`, `&`, parentheses, Unicode, and other potentially ambiguous characters fall back to the encoded PowerShell launcher.
- The managed script path still comes from Orca's controlled `~/.orca/agent-hooks` location and is written atomically before `hooks.json` is published.
- WSL and SSH commands remain host-scoped and use POSIX paths; no Windows path is sent to a remote host.

No security follow-up is required.

## Notes

- If the managed `.cmd` is manually deleted after Orca publishes `hooks.json`, a shell-safe direct entry can report a missing hook until Orca's installer repairs it. Normal install, upgrade, dev/prod switching, and removal flows write the shared script before publishing configuration, so they do not create that state.
- X handle: not provided.