### PR TITLE
fix(mobile): run orca.yaml archive hook when deleting a worktree

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -695,7 +695,10 @@ export function HostScreen({
       try {
         const response = await client.sendRequest('worktree.rm', {
           worktree: `id:${item.worktreeId}`,
-          force: true
+          force: true,
+          // Runtime RPC gates the orca.yaml archive hook behind runHooks; paired
+          // clients opt in so the teardown script runs on delete (matches web).
+          runHooks: true
         })
         if (!response.ok) {
           setWorktrees((prev) => [...prev, item])

--- a/mobile/src/worktree/mobile-worktree-delete-source.test.ts
+++ b/mobile/src/worktree/mobile-worktree-delete-source.test.ts
@@ -18,8 +18,10 @@ describe('mobile worktree deletion', () => {
       'const handleRemoveHost = useCallback'
     )
 
-    expect(handleDelete).toContain("sendRequest('worktree.rm'")
     // Runtime RPC skips the archive hook unless runHooks is set (parity with web).
-    expect(handleDelete).toContain('runHooks: true')
+    // Bind the flag to the worktree.rm payload so it can't pass on an unrelated match.
+    expect(handleDelete).toMatch(
+      /sendRequest\('worktree\.rm',\s*\{[\s\S]*?runHooks:\s*true[\s\S]*?\}\)/
+    )
   })
 })

--- a/mobile/src/worktree/mobile-worktree-delete-source.test.ts
+++ b/mobile/src/worktree/mobile-worktree-delete-source.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(new URL('../../app/h/[hostId]/index.tsx', import.meta.url), 'utf8')
+
+function sliceBetween(startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('mobile worktree deletion', () => {
+  it('opts into archive hooks so the orca.yaml teardown script runs on delete', () => {
+    const handleDelete = sliceBetween(
+      'const handleDeleteWorktree = useCallback(',
+      'const handleRemoveHost = useCallback'
+    )
+
+    expect(handleDelete).toContain("sendRequest('worktree.rm'")
+    // Runtime RPC skips the archive hook unless runHooks is set (parity with web).
+    expect(handleDelete).toContain('runHooks: true')
+  })
+})


### PR DESCRIPTION
## Summary

On the mobile app, deleting a worktree never ran the user-configured `archive` (teardown) hook from `orca.yaml`.

The mobile delete handler called the `worktree.rm` RPC **without** `runHooks`, so it defaulted to `false`:

```ts
// mobile/app/h/[hostId]/index.tsx
await client.sendRequest('worktree.rm', {
  worktree: `id:${item.worktreeId}`,
  force: true
}) // runHooks omitted -> defaults to false
```

On the runtime side, `removeManagedWorktree` gates the archive hook behind `runHooks` (headless-CLI safety — RPC calls have no renderer trust prompt) and otherwise only logs `archive hook skipped ...; pass --run-hooks to run it`. The paired **web** client already opts in (`runHooks: skipArchive !== true`), so mobile was the only paired client not running the hook — the same user action diverged across platforms.

**Fix:** pass `runHooks: true` from the mobile delete handler, matching the web client's default. Mobile deletion already forces removal with its own confirmation UI, so there is no renderer-trust gap relative to web.

## Screenshots

No visual change (RPC payload only).

## Testing

Ran the `mobile/` package toolchain locally (Node 26, pnpm 10.24.0):

- [x] `pnpm lint` (`oxlint`) — clean, exit 0
- [x] `pnpm typecheck` (`tsc --noEmit`) — clean, exit 0
- [x] `pnpm test` (`vitest run`) — 213 files, 1562 passed / 2 skipped
- [ ] `pnpm build` — n/a: `mobile` build is a native Expo/EAS build, not meaningful for an RPC-payload change
- [x] Added a regression test (`mobile/src/worktree/mobile-worktree-delete-source.test.ts`) binding `runHooks: true` to the `worktree.rm` payload

> One vitest worker (`terminal-webview-tap-routing.test.ts`) errored because `happy-dom` is not declared in `mobile/package.json` — a pre-existing test-infra gap unrelated to this PR and outside the changed files.

## AI Review Report

Reviewed with Claude (Claude Code). Focus areas and findings:

- **Root-cause confirmation:** traced the mobile call (`worktree.rm`) → RPC method (`src/main/runtime/rpc/methods/worktree.ts`) → `removeManagedWorktree` (`src/main/runtime/orca-runtime.ts`), confirming the archive hook is gated on `runHooks` and skipped for the mobile payload, versus the web client which opts in (`src/renderer/src/web/web-preload-api.ts`).
- **Cross-platform (macOS/Linux/Windows):** the change adds a boolean flag to an RPC payload. No `metaKey`/`ctrlKey`, shortcut labels, path separators, or shell/Electron platform branches are touched. The hook itself runs on the host and already handles local/SSH/WSL/Windows in the existing `runHook` / `runRemoteArchiveHook` paths, unchanged by this PR.
- **Test hardening:** CodeRabbit flagged that two independent `toContain` checks didn't bind `runHooks: true` to the `worktree.rm` request; addressed by switching to a single scoped `toMatch`.

## Security Audit

- **Command execution:** this PR makes the mobile delete path run the `orca.yaml` `archive` hook, which executes a user-defined shell script on the host. This is the intended fix and is deliberately in parity with the web paired client, which already passes `runHooks`. The runtime's `runHooks` gate exists for the headless-CLI case (no renderer trust prompt); authenticated paired clients (web today, mobile after this PR) opt in.
- **No new inputs, auth, secrets, path handling, or IPC surfaces** are introduced — only an existing, already-trusted lifecycle hook is now reachable from mobile as it already is from web/desktop.
- **Follow-up:** none required. If the project later wants a mobile "skip archive" affordance (as web exposes via `skipArchive`), that would be an additive UI change on top of this.

## Notes

- Mobile has no "skip archive" toggle, so this unconditionally opts in, matching the web client's default behavior. A future toggle could thread a `skipArchive` option through if desired.
- SSH/remote hosts are covered by the existing `runRemoteArchiveHook` path; this change only flips the flag that reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Deleting a worktree on mobile skipped the `orca.yaml` archive/teardown hook. Mobile delete now runs hooks so cleanup scripts fire like on desktop.
