### PR TITLE
fix(worktrees): force-remove a clean worktree containing an initialised submodule

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -279,6 +279,96 @@ branch refs/heads/main
     expect(getGitCalls()).toContain('git worktree remove --force /repo-feature')
   })
 
+  it('force-retries removal when git refuses a clean worktree containing an initialised submodule', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree list --porcelain#2': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+`
+      },
+      'git worktree remove /repo-feature': {
+        error: new Error('git worktree remove failed'),
+        stderr: 'fatal: working trees containing submodules cannot be moved or removed'
+      },
+      'git status --porcelain --untracked-files=all': { stdout: '' }
+    })
+
+    await removeWorktree('/repo', '/repo-feature')
+
+    const calls = getGitCalls()
+    expectGitCallOrder(
+      calls,
+      'git worktree remove /repo-feature',
+      'git status --porcelain --untracked-files=all'
+    )
+    expectGitCallOrder(
+      calls,
+      'git status --porcelain --untracked-files=all',
+      'git worktree remove --force /repo-feature'
+    )
+    expect(calls).toContain('git branch -d -- feature/test')
+  })
+
+  it('surfaces uncommitted changes instead of force-removing a dirty submodule worktree', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree remove /repo-feature': {
+        error: new Error('git worktree remove failed'),
+        stderr: 'fatal: working trees containing submodules cannot be moved or removed'
+      },
+      'git status --porcelain --untracked-files=all': { stdout: ' M sub\n' }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature')).rejects.toThrow(
+      'Worktree has uncommitted or untracked changes.'
+    )
+    expect(getGitCalls()).not.toContain('git worktree remove --force /repo-feature')
+  })
+
+  it('does not force-retry when the caller already forced removal', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-feature
+HEAD def456
+branch refs/heads/feature/test
+`
+      },
+      'git worktree remove --force /repo-feature': {
+        error: new Error('git worktree remove failed'),
+        stderr: 'fatal: working trees containing submodules cannot be moved or removed'
+      }
+    })
+
+    await expect(removeWorktree('/repo', '/repo-feature', true)).rejects.toThrow()
+    expect(
+      getGitCalls().filter((call) => call === 'git worktree remove --force /repo-feature')
+    ).toHaveLength(1)
+  })
+
   it('rejects a locked worktree with stable app-owned copy before invoking remove', async () => {
     mockGitCommands({
       'git worktree list --porcelain': {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -14,6 +14,7 @@ import type {
   RemoveWorktreeResult
 } from '../../shared/types'
 import { assertWorktreeUnlockedForRemoval } from '../../shared/worktree-removal'
+import { isSubmoduleWorktreeRemovalRefusal } from '../../shared/worktree-submodule-removal'
 import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
 import { parseGitRevListAheadBehindCounts } from '../../shared/git-rev-list-output'
 import { parseWslUncPath } from '../../shared/wsl-paths'
@@ -1150,7 +1151,21 @@ async function performRemoveWorktree(
     args.push('--force')
   }
   args.push(worktreePath)
-  await gitExecFileAsync(args, gitExecOptions(repoPath, options))
+  try {
+    await gitExecFileAsync(args, gitExecOptions(repoPath, options))
+  } catch (error) {
+    if (force || !isSubmoduleWorktreeRemovalRefusal(error)) {
+      throw error
+    }
+    // Why: Git refuses non-force removal of any worktree with an initialised
+    // submodule even when everything is clean. Re-prove cleanliness (parent
+    // status reports dirty submodule content as ` M <sub>`), then --force.
+    await assertWorktreeCleanForRemoval(worktreePath, false, options)
+    await gitExecFileAsync(
+      ['worktree', 'remove', '--force', worktreePath],
+      gitExecOptions(repoPath, options)
+    )
+  }
 
   if (!branchName) {
     return {}

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -196,6 +196,81 @@ describe('removeWorktreeOp', () => {
     ])
   })
 
+  it('force-retries removal when git refuses a clean worktree containing an initialised submodule', async () => {
+    const calls: string[] = []
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args, cwd) => {
+      calls.push(`${cwd}$ ${args.join(' ')}`)
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? worktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: '/repo-feature', branch: 'feature/test' }
+                )
+              : worktreeList({ path: '/repo', branch: 'main' }),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove' && !args.includes('--force')) {
+        throw Object.assign(new Error('git worktree remove failed'), {
+          stderr: 'fatal: working trees containing submodules cannot be moved or removed'
+        })
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+
+    expect(calls).toEqual([
+      '/repo-feature$ rev-parse --git-common-dir',
+      `${resolvedRepoPath()}$ worktree list --porcelain -z`,
+      `${resolvedRepoPath()}$ worktree remove /repo-feature`,
+      '/repo-feature$ status --porcelain --untracked-files=all',
+      `${resolvedRepoPath()}$ worktree remove --force /repo-feature`,
+      `${resolvedRepoPath()}$ branch -d -- feature/test`
+    ])
+  })
+
+  it('surfaces uncommitted changes instead of force-removing a dirty submodule worktree', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove') {
+        throw Object.assign(new Error('git worktree remove failed'), {
+          stderr: 'fatal: working trees containing submodules cannot be moved or removed'
+        })
+      }
+      if (args[0] === 'status') {
+        return { stdout: ' M sub\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+    ).rejects.toThrow('Worktree has uncommitted or untracked changes.')
+    expect(git).not.toHaveBeenCalledWith(
+      ['worktree', 'remove', '--force', '/repo-feature'],
+      expect.any(String)
+    )
+  })
+
   it('preserves the branch (does not throw) when `branch -d` refuses an unmerged branch', async () => {
     let listCount = 0
     const git = vi.fn<GitExec>(async (args) => {

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path'
 import type { RemoveWorktreeResult } from '../shared/types'
 import { assertWorktreeUnlockedForRemoval } from '../shared/worktree-removal'
+import { isSubmoduleWorktreeRemovalRefusal } from '../shared/worktree-submodule-removal'
 import { deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure } from './git-handler-branch-cleanup'
 import type { GitExec } from './git-handler-ops'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
@@ -156,7 +157,23 @@ export async function removeWorktreeOp(
     args.push('--force')
   }
   args.push(worktreePath)
-  await git(args, repoPath)
+  try {
+    await git(args, repoPath)
+  } catch (error) {
+    if (force || !isSubmoduleWorktreeRemovalRefusal(error)) {
+      throw error
+    }
+    // Why: Git refuses non-force removal of any worktree with an initialised
+    // submodule even when everything is clean. Re-prove cleanliness (parent
+    // status reports dirty submodule content as ` M <sub>`), then --force.
+    const { stdout } = await git(['status', '--porcelain', '--untracked-files=all'], worktreePath)
+    if (stdout.trim()) {
+      const dirtyError = new Error('Worktree has uncommitted or untracked changes.')
+      ;(dirtyError as Error & { stdout?: string }).stdout = stdout
+      throw dirtyError
+    }
+    await git(['worktree', 'remove', '--force', worktreePath], repoPath)
+  }
 
   if (!branchName) {
     return {}

--- a/src/shared/worktree-submodule-removal.ts
+++ b/src/shared/worktree-submodule-removal.ts
@@ -1,0 +1,22 @@
+function getErrorText(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    const parts: string[] = []
+    for (const field of ['message', 'stderr', 'stdout'] as const) {
+      const value = (error as Record<string, unknown>)[field]
+      if (typeof value === 'string' && value) {
+        parts.push(value)
+      }
+    }
+    return parts.join('\n')
+  }
+  return String(error)
+}
+
+// Why: `git worktree remove` (non-force) categorically refuses any worktree
+// containing an initialised submodule, even when parent and submodule are
+// fully clean (validate_no_submodules, Git >= 2.17). Callers re-prove
+// cleanliness and retry with --force. Both the local runner and the relay pin
+// English git output (UNTRANSLATED_GIT_OUTPUT_ENV), so text matching is stable.
+export function isSubmoduleWorktreeRemovalRefusal(error: unknown): boolean {
+  return /working trees containing submodules cannot be moved or removed/i.test(getErrorText(error))
+}


### PR DESCRIPTION
Fixes #8670

## Problem

Deleting an Orca workspace fails when its linked worktree contains an initialised submodule, even when both the parent worktree and the submodule are completely clean:

```
Error invoking remote method 'worktrees:remove':
Error: Failed to delete worktree at <worktree-path>.
fatal: working trees containing submodules cannot be moved or removed
```

The worktree stays registered and on disk.

## Root cause

Git categorically refuses non-force `git worktree remove` for any worktree containing an initialised submodule (`validate_no_submodules` in `builtin/worktree.c`, since Git 2.17) — cleanliness doesn't matter. Orca's delete flow proves the worktree is clean via `git status --porcelain --untracked-files=all` and then runs a **non-force** remove, so this always failed. Both the local path (`src/main/git/worktree.ts`) and the SSH relay path (`src/relay/git-handler-worktree-remove.ts`) are affected.

## Fix

When the non-force remove fails with that specific refusal:

1. Re-prove cleanliness with `git status --porcelain --untracked-files=all` in the worktree. This gate covers submodule dirtiness — a submodule with modified content, untracked content, or new commits shows up as ` M <sub>` in the parent's porcelain status (verified empirically).
2. If clean, retry with `git worktree remove --force`.
3. If dirty, throw the existing "Worktree has uncommitted or untracked changes." error (with the status output attached) instead of the cryptic git fatal — no force-delete of user changes, matching the preflight's behavior.

The refusal predicate lives in `src/shared/worktree-submodule-removal.ts` and is shared by both paths. Error-text matching is safe because both the local git runner and the relay pin English git output (`UNTRANSLATED_GIT_OUTPUT_ENV`). A caller that already passed `force` gets no retry (the first attempt already had `--force`).

Compatibility: `git worktree remove` and the refusal message both exist since Git 2.17, below the 2.25 core-workflow baseline; the retry uses no newer syntax, so no capability probe is needed.

## Testing

- New unit tests for both paths: clean submodule worktree → force retry succeeds (and branch cleanup still runs); dirty submodule worktree → refused without `--force`, original files preserved; caller-forced removal → no double retry.
- Full `src/main/git/` + `src/relay/` + worktree IPC suites pass (99 files, 1438 tests).
- Verified end-to-end against a real repo (issue's exact repro: linked worktree + `git submodule update --init`): removal now succeeds and deletes the merged branch; with a dirtied submodule it refuses and leaves all files intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)