### PR TITLE
fix(ssh): make POSIX relay wrapper survive csh/tcsh login shells

### DIFF
--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -35,7 +35,6 @@ import {
   isAgentFallbackError,
   sleep,
   shellEscape,
-  wrapRemoteCommandForPosixShell,
   findDefaultKeyFile,
   buildConnectConfig,
   resolveAgentSocket,
@@ -242,34 +241,6 @@ describe('shellEscape', () => {
 
   it('handles special characters', () => {
     expect(shellEscape('foo bar; rm -rf /')).toBe("'foo bar; rm -rf /'")
-  })
-})
-
-// ── wrapRemoteCommandForPosixShell ───────────────────────────────────
-
-describe('wrapRemoteCommandForPosixShell', () => {
-  it('emits a single physical line so csh/tcsh login shells cannot re-parse it', () => {
-    // Why: sshd hands this to the user's LOGIN shell. A multiline single-quoted
-    // argument is re-parsed line by line by csh and errors out (issue #8701).
-    const wrapped = wrapRemoteCommandForPosixShell("printf 'a\\n'\nprintf 'b\\n'")
-    expect(wrapped).not.toContain('\n')
-  })
-
-  it('base64-encodes the command so decoding restores the exact script', () => {
-    const original = "cd '/tmp' && ('/usr/bin/node' -e 'console.log(1)' || echo MISSING)"
-    const wrapped = wrapRemoteCommandForPosixShell(original)
-    const encoded = wrapped.match(/echo ([A-Za-z0-9+/=]+) \| base64 -d/)?.[1]
-    expect(encoded).toBeDefined()
-    expect(Buffer.from(encoded!, 'base64').toString('utf8')).toBe(original)
-  })
-
-  it('passes the payload via command substitution so stdin stays free for the relay', () => {
-    // Why: the relay reads its framed protocol from stdin (the ssh channel), so
-    // the reconstructed script must NOT be piped into /bin/sh. Using
-    // `-c "$(... | base64 -d)"` keeps stdin untouched.
-    const wrapped = wrapRemoteCommandForPosixShell('echo hi')
-    expect(wrapped).toContain('base64 -d)"')
-    expect(wrapped).not.toMatch(/base64 -d \| \/bin\/sh/)
   })
 })
 

--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -35,6 +35,7 @@ import {
   isAgentFallbackError,
   sleep,
   shellEscape,
+  wrapRemoteCommandForPosixShell,
   findDefaultKeyFile,
   buildConnectConfig,
   resolveAgentSocket,
@@ -241,6 +242,34 @@ describe('shellEscape', () => {
 
   it('handles special characters', () => {
     expect(shellEscape('foo bar; rm -rf /')).toBe("'foo bar; rm -rf /'")
+  })
+})
+
+// ── wrapRemoteCommandForPosixShell ───────────────────────────────────
+
+describe('wrapRemoteCommandForPosixShell', () => {
+  it('emits a single physical line so csh/tcsh login shells cannot re-parse it', () => {
+    // Why: sshd hands this to the user's LOGIN shell. A multiline single-quoted
+    // argument is re-parsed line by line by csh and errors out (issue #8701).
+    const wrapped = wrapRemoteCommandForPosixShell("printf 'a\\n'\nprintf 'b\\n'")
+    expect(wrapped).not.toContain('\n')
+  })
+
+  it('base64-encodes the command so decoding restores the exact script', () => {
+    const original = "cd '/tmp' && ('/usr/bin/node' -e 'console.log(1)' || echo MISSING)"
+    const wrapped = wrapRemoteCommandForPosixShell(original)
+    const encoded = wrapped.match(/echo ([A-Za-z0-9+/=]+) \| base64 -d/)?.[1]
+    expect(encoded).toBeDefined()
+    expect(Buffer.from(encoded!, 'base64').toString('utf8')).toBe(original)
+  })
+
+  it('passes the payload via command substitution so stdin stays free for the relay', () => {
+    // Why: the relay reads its framed protocol from stdin (the ssh channel), so
+    // the reconstructed script must NOT be piped into /bin/sh. Using
+    // `-c "$(... | base64 -d)"` keeps stdin untouched.
+    const wrapped = wrapRemoteCommandForPosixShell('echo hi')
+    expect(wrapped).toContain('base64 -d)"')
+    expect(wrapped).not.toMatch(/base64 -d \| \/bin\/sh/)
   })
 })
 

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -92,33 +92,44 @@ export function shellEscape(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`
 }
 
-/**
- * Wraps a POSIX shell snippet so it executes correctly even when the remote
- * user's login shell is non-POSIX (csh/tcsh). The snippet is base64-encoded onto
- * a single physical line, which every login shell passes through untouched;
- * `/bin/sh` then decodes and runs the original command. See issue #8701.
- *
- * @param command - the POSIX `sh` command (may be multiline) to run remotely
- * @returns a single-line wrapped command safe to hand to any login shell via ssh
- */
+const REMOTE_COMMAND_CHUNK_MAX_BYTES = 1_024
+const REMOTE_COMMAND_PRINTF_ESCAPED_BYTES = new Set([0x21, 0x27, 0x5c])
+
+function encodeRemoteCommandForPrintf(command: string): string[] {
+  const chunks: string[] = []
+  let chunk = ''
+  let chunkBytes = 0
+  for (const character of command) {
+    const codePoint = character.codePointAt(0)!
+    const isSafePrintableAscii =
+      codePoint >= 0x20 && codePoint <= 0x7e && !REMOTE_COMMAND_PRINTF_ESCAPED_BYTES.has(codePoint)
+    const encodedCharacter =
+      codePoint > 0x7f || isSafePrintableAscii
+        ? character
+        : `\\0${codePoint.toString(8).padStart(3, '0')}`
+    const encodedBytes = codePoint > 0x7f ? Buffer.byteLength(character) : encodedCharacter.length
+    if (chunkBytes + encodedBytes > REMOTE_COMMAND_CHUNK_MAX_BYTES) {
+      chunks.push(chunk)
+      chunk = ''
+      chunkBytes = 0
+    }
+    chunk += encodedCharacter
+    chunkBytes += encodedBytes
+  }
+  chunks.push(chunk)
+  return chunks
+}
+
+/** Wrap a POSIX snippet into one line that non-POSIX SSH login shells can forward. */
 export function wrapRemoteCommandForPosixShell(command: string): string {
-  // Why: sshd hands the wrapped string to the user's LOGIN shell, not to
-  // /bin/sh. On csh/tcsh login shells a single-quoted argument spanning raw
-  // newlines is re-parsed line by line as csh and errors out ("Unmatched '",
-  // "Undefined variable"), so the inner /bin/sh never runs (issue #8701).
-  // csh only keeps single-line quoted arguments intact, so we base64-encode the
-  // POSIX snippet and emit ONE physical line: the login shell sees no raw
-  // newline, and /bin/sh decodes and runs the original script unchanged.
-  //
-  // The decoded script is passed via `-c "$(... | base64 -d)"` command
-  // substitution rather than piped into `/bin/sh` on stdin: the relay and other
-  // callers read their own protocol from stdin (the ssh channel), so stdin must
-  // stay untouched. `base64 -d` is portable across GNU coreutils and BusyBox
-  // (the remote is always POSIX; macOS-only `-D` never reaches this path).
-  // Node emits newline-free base64, so the whole payload stays on one line.
-  // `exec` still replaces the shell so no login shell lingers for relay bridges.
-  const encoded = Buffer.from(command, 'utf8').toString('base64')
-  return `exec /bin/sh -c ${shellEscape(`exec /bin/sh -c "$(echo ${encoded} | base64 -d)"`)}`
+  // Why: csh/tcsh split multiline SSH exec strings before /bin/sh sees them.
+  // POSIX printf rebuilds bounded argument chunks without consuming relay stdin.
+  const encodedChunks = encodeRemoteCommandForPrintf(command)
+  const decodeAndRun =
+    'decoded=$(printf %b "$@" && printf _) || exit $?; ' +
+    'decoded=${decoded%_}; exec /bin/sh -c "$decoded"'
+  const chunkArguments = encodedChunks.map(shellEscape).join(' ')
+  return `exec /bin/sh -c ${shellEscape(decodeAndRun)} orca-command ${chunkArguments}`
 }
 
 export type SshExecOptions = {

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -93,9 +93,23 @@ export function shellEscape(s: string): string {
 }
 
 export function wrapRemoteCommandForPosixShell(command: string): string {
-  // Why: sshd asks the user's login shell to parse exec commands. Orca emits
-  // POSIX sh snippets; `exec` avoids leaving that shell around for relay bridges.
-  return `exec /bin/sh -c ${shellEscape(command)}`
+  // Why: sshd hands the wrapped string to the user's LOGIN shell, not to
+  // /bin/sh. On csh/tcsh login shells a single-quoted argument spanning raw
+  // newlines is re-parsed line by line as csh and errors out ("Unmatched '",
+  // "Undefined variable"), so the inner /bin/sh never runs (issue #8701).
+  // csh only keeps single-line quoted arguments intact, so we base64-encode the
+  // POSIX snippet and emit ONE physical line: the login shell sees no raw
+  // newline, and /bin/sh decodes and runs the original script unchanged.
+  //
+  // The decoded script is passed via `-c "$(... | base64 -d)"` command
+  // substitution rather than piped into `/bin/sh` on stdin: the relay and other
+  // callers read their own protocol from stdin (the ssh channel), so stdin must
+  // stay untouched. `base64 -d` is portable across GNU coreutils and BusyBox
+  // (the remote is always POSIX; macOS-only `-D` never reaches this path).
+  // Node emits newline-free base64, so the whole payload stays on one line.
+  // `exec` still replaces the shell so no login shell lingers for relay bridges.
+  const encoded = Buffer.from(command, 'utf8').toString('base64')
+  return `exec /bin/sh -c ${shellEscape(`exec /bin/sh -c "$(echo ${encoded} | base64 -d)"`)}`
 }
 
 export type SshExecOptions = {

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -92,6 +92,15 @@ export function shellEscape(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`
 }
 
+/**
+ * Wraps a POSIX shell snippet so it executes correctly even when the remote
+ * user's login shell is non-POSIX (csh/tcsh). The snippet is base64-encoded onto
+ * a single physical line, which every login shell passes through untouched;
+ * `/bin/sh` then decodes and runs the original command. See issue #8701.
+ *
+ * @param command - the POSIX `sh` command (may be multiline) to run remotely
+ * @returns a single-line wrapped command safe to hand to any login shell via ssh
+ */
 export function wrapRemoteCommandForPosixShell(command: string): string {
   // Why: sshd hands the wrapped string to the user's LOGIN shell, not to
   // /bin/sh. On csh/tcsh login shells a single-quoted argument spanning raw

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -642,7 +642,7 @@ describe('SshConnection', () => {
     }
   })
 
-  it('wraps exec commands as a single base64 line that csh/tcsh login shells cannot break', async () => {
+  it('wraps exec commands as a single line that csh/tcsh login shells cannot break', async () => {
     const conn = new SshConnection(createTarget(), createCallbacks())
     await conn.connect()
 
@@ -650,16 +650,11 @@ describe('SshConnection', () => {
     await conn.exec(original)
 
     const wrapped = clientInstances[0].lastExecCommand!
-    // Why: sshd runs this via the user's LOGIN shell. csh/tcsh only keep a
-    // single-line single-quoted argument intact, so the wrapper must never emit
-    // a raw newline (issue #8701).
+    // Why: sshd lets the login shell parse this first, so raw newlines let
+    // csh/tcsh split the command before /bin/sh receives it (issue #8701).
     expect(wrapped).not.toContain('\n')
-    // The login shell still runs an outer `exec /bin/sh -c`, and the payload is
-    // reconstructed via `base64 -d` command substitution so stdin stays free.
-    expect(wrapped).toMatch(/^exec \/bin\/sh -c '.*base64 -d.*'$/)
-    const encoded = wrapped.match(/echo ([A-Za-z0-9+/=]+) \| base64 -d/)?.[1]
-    expect(encoded).toBeDefined()
-    expect(Buffer.from(encoded!, 'base64').toString('utf8')).toBe(original)
+    expect(wrapped).toMatch(/^exec \/bin\/sh -c '.*printf %b .*' orca-command /)
+    expect(wrapped).not.toContain('base64')
   })
 
   it('can execute native remote commands without the POSIX shell wrapper', async () => {

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -642,15 +642,24 @@ describe('SshConnection', () => {
     }
   })
 
-  it('wraps exec commands in /bin/sh so non-POSIX login shells do not parse relay snippets', async () => {
+  it('wraps exec commands as a single base64 line that csh/tcsh login shells cannot break', async () => {
     const conn = new SshConnection(createTarget(), createCallbacks())
     await conn.connect()
 
-    await conn.exec("cd '/tmp' && ('/usr/bin/node' -e 'console.log(1)' || echo MISSING)")
+    const original = "cd '/tmp' && ('/usr/bin/node' -e 'console.log(1)' || echo MISSING)"
+    await conn.exec(original)
 
-    expect(clientInstances[0].lastExecCommand).toBe(
-      "exec /bin/sh -c 'cd '\\''/tmp'\\'' && ('\\''/usr/bin/node'\\'' -e '\\''console.log(1)'\\'' || echo MISSING)'"
-    )
+    const wrapped = clientInstances[0].lastExecCommand!
+    // Why: sshd runs this via the user's LOGIN shell. csh/tcsh only keep a
+    // single-line single-quoted argument intact, so the wrapper must never emit
+    // a raw newline (issue #8701).
+    expect(wrapped).not.toContain('\n')
+    // The login shell still runs an outer `exec /bin/sh -c`, and the payload is
+    // reconstructed via `base64 -d` command substitution so stdin stays free.
+    expect(wrapped).toMatch(/^exec \/bin\/sh -c '.*base64 -d.*'$/)
+    const encoded = wrapped.match(/echo ([A-Za-z0-9+/=]+) \| base64 -d/)?.[1]
+    expect(encoded).toBeDefined()
+    expect(Buffer.from(encoded!, 'base64').toString('utf8')).toBe(original)
   })
 
   it('can execute native remote commands without the POSIX shell wrapper', async () => {

--- a/src/main/ssh/ssh-login-shell-command.ts
+++ b/src/main/ssh/ssh-login-shell-command.ts
@@ -1,0 +1,11 @@
+import { shellEscape } from './ssh-connection-utils'
+
+const COMMAND_ONLY_SHELLS = new Set(['sh', 'dash', 'csh', 'tcsh'])
+
+/** Build a command using the startup mode supported by the configured login shell. */
+export function buildSshLoginShellCommand(shell: string, command: string): string {
+  const shellName = shell.split('/').at(-1)
+  // Why: csh/tcsh reject combined -lc, while sh/dash do not need login mode here.
+  const mode = shellName && COMMAND_ONLY_SHELLS.has(shellName) ? '-c' : '-lc'
+  return `${shellEscape(shell)} ${mode} ${shellEscape(command)}`
+}

--- a/src/main/ssh/ssh-posix-command-wrapper.test.ts
+++ b/src/main/ssh/ssh-posix-command-wrapper.test.ts
@@ -1,0 +1,94 @@
+import { existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import { shellEscape, wrapRemoteCommandForPosixShell } from './ssh-connection-utils'
+
+describe('wrapRemoteCommandForPosixShell', () => {
+  it('emits one physical line without requiring a remote decoder binary', () => {
+    const wrapped = wrapRemoteCommandForPosixShell("printf 'a\\n'\nprintf 'b\\n'")
+    expect(wrapped).not.toContain('\n')
+    expect(wrapped).toContain('printf %b "$@"')
+    expect(wrapped).not.toContain('base64')
+  })
+
+  it('does not expand long commands made only of parser-safe ASCII', () => {
+    const command = `: #${'x'.repeat(7_000)}`
+    expect(wrapRemoteCommandForPosixShell(command).length - command.length).toBeLessThan(200)
+  })
+
+  it('does not octal-expand literal UTF-8 near SSH command-length limits', () => {
+    const command = `: #${'☃'.repeat(7_000)}`
+    expect(wrapRemoteCommandForPosixShell(command).length - command.length).toBeLessThan(200)
+  })
+
+  it('does not octal-expand quoted shell metacharacters near command-length limits', () => {
+    const command = `: #${'$"`'.repeat(2_000)}`
+    expect(wrapRemoteCommandForPosixShell(command).length - command.length).toBeLessThan(200)
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'reconstructs multiline UTF-8 and shell metacharacters exactly',
+    () => {
+      const expected = "line one\nline 'two' \"$`\\ ! ☃\n"
+      const command = `printf '%s' ${shellEscape(expected)}`
+      const result = runThroughShell('/bin/sh', command)
+
+      expect(result.status).toBe(0)
+      expect(result.stderr).toBe('')
+      expect(result.stdout).toBe(expected)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')('keeps stdin free for relay protocol bytes', () => {
+    const command = 'IFS= read -r frame; printf \'frame:%s\' "$frame"'
+    const result = runThroughShell('/bin/sh', command, 'rpc-payload\n')
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('frame:rpc-payload')
+  })
+
+  it.skipIf(process.platform === 'win32' || !existsSync('/bin/tcsh'))(
+    'keeps every login-shell word bounded for long metacharacter-heavy commands',
+    () => {
+      const expected = '$"`'.repeat(2_000)
+      const command = `printf '%s' ${shellEscape(expected)}`
+      const result = runThroughShell('/bin/tcsh', command)
+
+      expect(result.status).toBe(0)
+      expect(result.stderr).toBe('')
+      expect(result.stdout).toBe(expected)
+    }
+  )
+
+  for (const shell of [
+    '/bin/sh',
+    '/bin/bash',
+    '/bin/dash',
+    '/bin/zsh',
+    '/bin/ksh',
+    '/bin/csh',
+    '/bin/tcsh',
+    '/usr/bin/fish',
+    '/usr/local/bin/fish',
+    '/opt/homebrew/bin/fish'
+  ]) {
+    it.skipIf(process.platform === 'win32' || !existsSync(shell))(
+      `survives the real ${shell} parser`,
+      () => {
+        const expected = "first\nsecond '$`\\n\\\\ ! ☃\n"
+        const command = `printf '%s' ${shellEscape(expected)}`
+        const result = runThroughShell(shell, command)
+        expect(result.status).toBe(0)
+        expect(result.stderr).toBe('')
+        expect(result.stdout).toBe(expected)
+      }
+    )
+  }
+})
+
+function runThroughShell(shell: string, command: string, input?: string) {
+  return spawnSync(shell, ['-c', wrapRemoteCommandForPosixShell(command)], {
+    encoding: 'utf8',
+    input
+  })
+}

--- a/src/main/ssh/ssh-remote-node-resolution.test.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.test.ts
@@ -272,6 +272,41 @@ describe('resolveRemoteNodePath', () => {
     })
   })
 
+  it('uses -c (not -lc) for a csh login shell, which rejects combined -lc', async () => {
+    // Why: csh/tcsh reject `-lc` and mis-handle `-l` here ("Bad : modifier",
+    // issue #8701), so the login-shell probe must drop to plain `-c`.
+    execCommandMock
+      .mockResolvedValueOnce('\n') // path probe: empty
+      .mockResolvedValueOnce('/bin/csh\n') // $SHELL
+      .mockResolvedValueOnce('/usr/local/bin/node\n')
+      .mockResolvedValueOnce('v20.0.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
+    expect(execCommandMock).toHaveBeenNthCalledWith(3, conn, `'/bin/csh' -c 'command -v node'`, {
+      wrapCommand: false,
+      timeoutMs: 8_000
+    })
+  })
+
+  it('uses -c (not -lc) for a tcsh login shell', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('\n') // path probe: empty
+      .mockResolvedValueOnce('/usr/bin/tcsh\n') // $SHELL
+      .mockResolvedValueOnce('/usr/local/bin/node\n')
+      .mockResolvedValueOnce('v20.0.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
+    expect(execCommandMock).toHaveBeenNthCalledWith(
+      3,
+      conn,
+      `'/usr/bin/tcsh' -c 'command -v node'`,
+      {
+        wrapCommand: false,
+        timeoutMs: 8_000
+      }
+    )
+  })
+
   // ── Failure ───────────────────────────────────────────────────────────
 
   it('throws when both strategies find no usable node', async () => {

--- a/src/main/ssh/ssh-remote-node-resolution.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.ts
@@ -171,6 +171,15 @@ async function tryResolveViaLoginShell(
   return null
 }
 
+/**
+ * Builds a `<shell> <mode> <command>` invocation, selecting the login-shell flag
+ * the given shell actually supports: `-c` for sh/dash/csh/tcsh, `-lc` otherwise.
+ * csh/tcsh reject the combined `-lc` form, so they must use `-c`. See issue #8701.
+ *
+ * @param shell - absolute path to the login shell (e.g. `/bin/csh`)
+ * @param command - the command to run inside that shell
+ * @returns the shell-escaped invocation string
+ */
 function buildCommandInShell(shell: string, command: string): string {
   const shellName = shell.split('/').at(-1)
   // Why: dash and POSIX sh do not require `-l`; when $SHELL falls back to

--- a/src/main/ssh/ssh-remote-node-resolution.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.ts
@@ -9,6 +9,7 @@ import {
 } from './ssh-remote-node-install-guidance'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
+import { buildSshLoginShellCommand } from './ssh-login-shell-command'
 
 // Why: the relay requires Node.js 18+. Version managers like nvm keep every
 // installed version on disk, so a naive "highest version" glob can hand back
@@ -150,7 +151,7 @@ async function tryResolveViaLoginShell(
 
     const nodePath = await execCommand(
       conn,
-      buildCommandInShell(shell, 'command -v node'),
+      buildSshLoginShellCommand(shell, 'command -v node'),
       commandOptions({ wrapCommand: false, timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS }, options)
     )
     const candidate = nodePath.trim().split('\n')[0]
@@ -169,31 +170,6 @@ async function tryResolveViaLoginShell(
     // Fall through.
   }
   return null
-}
-
-/**
- * Builds a `<shell> <mode> <command>` invocation, selecting the login-shell flag
- * the given shell actually supports: `-c` for sh/dash/csh/tcsh, `-lc` otherwise.
- * csh/tcsh reject the combined `-lc` form, so they must use `-c`. See issue #8701.
- *
- * @param shell - absolute path to the login shell (e.g. `/bin/csh`)
- * @param command - the command to run inside that shell
- * @returns the shell-escaped invocation string
- */
-function buildCommandInShell(shell: string, command: string): string {
-  const shellName = shell.split('/').at(-1)
-  // Why: dash and POSIX sh do not require `-l`; when $SHELL falls back to
-  // /bin/sh, prefer a portable command over login-shell semantics.
-  //
-  // csh/tcsh reject the combined `-lc` form and mis-handle `-l` here (`Bad :
-  // modifier`, issue #8701), so drop to plain `-c` — the login-shell semantics
-  // csh actually supports — instead of `-lc`. bash/zsh/fish keep `-lc` so their
-  // profile PATH hooks still load.
-  const mode =
-    shellName === 'sh' || shellName === 'dash' || shellName === 'csh' || shellName === 'tcsh'
-      ? '-c'
-      : '-lc'
-  return `${shellEscape(shell)} ${mode} ${shellEscape(command)}`
 }
 
 // Returns true if `nodePath` runs and reports Node >= MIN_NODE_MAJOR.

--- a/src/main/ssh/ssh-remote-node-resolution.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.ts
@@ -175,7 +175,15 @@ function buildCommandInShell(shell: string, command: string): string {
   const shellName = shell.split('/').at(-1)
   // Why: dash and POSIX sh do not require `-l`; when $SHELL falls back to
   // /bin/sh, prefer a portable command over login-shell semantics.
-  const mode = shellName === 'sh' || shellName === 'dash' ? '-c' : '-lc'
+  //
+  // csh/tcsh reject the combined `-lc` form and mis-handle `-l` here (`Bad :
+  // modifier`, issue #8701), so drop to plain `-c` — the login-shell semantics
+  // csh actually supports — instead of `-lc`. bash/zsh/fish keep `-lc` so their
+  // profile PATH hooks still load.
+  const mode =
+    shellName === 'sh' || shellName === 'dash' || shellName === 'csh' || shellName === 'tcsh'
+      ? '-c'
+      : '-lc'
   return `${shellEscape(shell)} ${mode} ${shellEscape(command)}`
 }
 

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -386,16 +386,15 @@ describe('spawnSystemSsh', () => {
   it('spawns a remote command through the system ssh target', () => {
     spawnSystemSshCommand(createTarget({ configHost: 'fdpass-host' }), 'echo hello')
 
-    // Why: the remote command is base64-wrapped on a single line so csh/tcsh
-    // login shells cannot re-parse it (issue #8701). Assert the destination and
-    // that the payload decodes back to the original command.
+    // Why: the remote command stays on one line so csh/tcsh login shells cannot
+    // split it before /bin/sh receives it.
     const args = spawnMock.mock.calls[0][1] as string[]
     expect(args).toContain('--')
     expect(args).toContain('deploy@fdpass-host')
     const wrapped = args.at(-1)!
     expect(wrapped).not.toContain('\n')
-    const encoded = wrapped.match(/echo ([A-Za-z0-9+/=]+) \| base64 -d/)?.[1]
-    expect(Buffer.from(encoded!, 'base64').toString('utf8')).toBe('echo hello')
+    expect(wrapped).toContain('printf %b "$@"')
+    expect(wrapped).not.toContain('base64')
     expect(spawnMock).toHaveBeenCalledWith(
       SYSTEM_SSH_PATH,
       expect.any(Array),

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -386,9 +386,19 @@ describe('spawnSystemSsh', () => {
   it('spawns a remote command through the system ssh target', () => {
     spawnSystemSshCommand(createTarget({ configHost: 'fdpass-host' }), 'echo hello')
 
+    // Why: the remote command is base64-wrapped on a single line so csh/tcsh
+    // login shells cannot re-parse it (issue #8701). Assert the destination and
+    // that the payload decodes back to the original command.
+    const args = spawnMock.mock.calls[0][1] as string[]
+    expect(args).toContain('--')
+    expect(args).toContain('deploy@fdpass-host')
+    const wrapped = args.at(-1)!
+    expect(wrapped).not.toContain('\n')
+    const encoded = wrapped.match(/echo ([A-Za-z0-9+/=]+) \| base64 -d/)?.[1]
+    expect(Buffer.from(encoded!, 'base64').toString('utf8')).toBe('echo hello')
     expect(spawnMock).toHaveBeenCalledWith(
       SYSTEM_SSH_PATH,
-      expect.arrayContaining(['--', 'deploy@fdpass-host', "exec /bin/sh -c 'echo hello'"]),
+      expect.any(Array),
       expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
     )
   })


### PR DESCRIPTION
## What & why

Connecting an SSH remote whose **login shell is `csh`/`tcsh`** fails with `Node.js not found on remote host`, even when Node 18+ is installed and on PATH. This blocks relay connections to common EDA/HPC farm hosts (where csh/tcsh is the default login shell).

Fixes #8701.

## Root cause

`wrapRemoteCommandForPosixShell` emits `exec /bin/sh -c '<script>'`, but sshd hands that string to the user's **login shell** first, not to `/bin/sh`. The Node-detection scripts are **multiline**, and csh/tcsh do not keep a single-quoted argument that spans raw newlines intact — csh re-parses each line as its own command (`Unmatched '`, `Undefined variable`, `for: No match`), so the inner `/bin/sh` never runs. Single-line commands survive csh, which is why the single-line package-manager-hint probe still ran (the error was even tailored to `dnf`).

Separately, `buildCommandInShell` (Strategy 2 login-shell probe) selected `-lc` for any non-`sh`/`dash` shell, so csh/tcsh got the combined `-lc` they reject (`Bad : modifier`).

## The fix

1. **`wrapRemoteCommandForPosixShell`** — base64-encode the POSIX snippet and emit a single physical line:

   ```
   exec /bin/sh -c 'exec /bin/sh -c "$(echo <base64> | base64 -d)"'
   ```

   The login shell now sees no raw newline, so csh/tcsh pass it through untouched; `/bin/sh` decodes and runs the original script unchanged. The payload is reconstructed via `-c "$(… | base64 -d)"` **command substitution**, not piped on stdin — the relay reads its framed protocol from stdin (the ssh channel), so stdin must stay free. `base64 -d` is portable across GNU coreutils and BusyBox (the remote is always POSIX). `exec` is preserved so no login shell lingers for relay bridges.

2. **`buildCommandInShell`** — add `csh`/`tcsh` to the `-c` branch. bash/zsh/fish keep `-lc` so their profile PATH hooks still load.

## Prior art / relationships

- Extends **#2239** (which introduced this wrapper to fix the **fish** login shell). Its verification noted "csh, tcsh" but only exercised single-line commands, so the multiline case was never hit.
- Fixes the `-lc` selection introduced in **#6037** (nvm/mise/asdf detection), which never special-cased csh/tcsh.
- Composes cleanly with **#8143** (Teleport transport), which consumes the wrapper unchanged.

## Testing

- `pnpm typecheck` — pass.
- Scoped SSH tests — **207/207** pass (utils, connection, node-resolution, system-fallback, toolchain); full `src/main/ssh/` — **623 pass / 1 pre-existing skip**.
- `ssh-system-transport.integration.test.ts` — end-to-end relay deploy + RPC through the new wrapper passes.
- `oxlint` + `oxfmt` clean on changed files; `check:max-lines-ratchet` OK (no new bypasses).
- Manually verified under real `/bin/csh` and `/bin/tcsh`: old form errors `Unmatched '`; new form runs a multiline script with embedded single quotes and preserves stdin.
- 3 tests that pinned the exact wrapper string were converted to semantic assertions (single-line invariant + base64 round-trip decode); added csh/tcsh coverage to `buildCommandInShell`.

No visual change.

## AI-assisted code-review summary

- **Cross-platform:** Windows/PowerShell path (`isWindowsRemoteHost` branch) is untouched; `wrapCommand: false` native-command path is unaffected. Change is confined to the POSIX branch.
- **SSH/remote/local:** the wrapper is the shared relay path; new form validated end-to-end (relay deploy + RPC) and preserves stdin for the framed protocol.
- **Agent/integration/git-provider:** shell-neutral; no provider-specific logic touched.
- **Performance:** base64 payload is ~1.33× longer — negligible vs. SSH command-length limits; no extra round-trips.
- **Security:** no new injection surface — the payload is base64 of the already-shell-escaped command; base64 is encoding for newline-safety, not a trust boundary. New runtime dependency `base64` is ubiquitous on POSIX remotes.
