### PR TITLE
chore(mobile): prepare mobile 0.0.29

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.27",
+    "version": "0.0.29",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
Resyncs the mobile marketing version with App Store Connect.

**Why:** iOS **0.0.29** shipped to TestFlight ([run 29319243526](https://github.com/stablyai/orca/actions/runs/29319243526)) via a `release_version` override — that builds at the given version but does **not** commit it back to the repo. So `app.json` was still `0.0.27`, two trains behind ASC (both `0.0.27` and `0.0.28` are already submitted/released and closed). Left as-is, the next release's auto patch-bump would compute `0.0.27 → 0.0.28`, hit a closed train, and fail fast (as the last several iOS release runs did).

**Change:** bump `expo.version` `0.0.27 → 0.0.29` so the repo matches what shipped and the next release auto-bumps cleanly to `0.0.30`. This is the "Prepare mobile `<version>`" commit the release workflow itself recommends. `buildNumber` is untouched (fastlane derives it from ASC at build time).