### PR TITLE
fix(rate-limits): map Codex individual usage to monthly window

### DIFF
--- a/src/main/rate-limits/codex-business-wham-usage-8664.fixture.json
+++ b/src/main/rate-limits/codex-business-wham-usage-8664.fixture.json
@@ -1,0 +1,16 @@
+{
+  "plan_type": "business",
+  "rate_limit": null,
+  "spend_control": {
+    "individual_limit": {
+      "source": "group_based_spend_controls",
+      "limit": "11450",
+      "used": "4522.358407497406",
+      "remaining": "6927.641592502594",
+      "used_percent": 39,
+      "remaining_percent": 61,
+      "reset_after_seconds": 1539578,
+      "reset_at": 1785542400
+    }
+  }
+}

--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -192,6 +192,70 @@ describe('Codex backend rate-limit requests', () => {
     ).resolves.toMatchObject({ monthly: { usedPercent: 65, windowMinutes: 43_200 } })
   })
 
+  it.each([
+    {
+      name: 'without a plan label',
+      payload: {
+        rate_limit: null,
+        spend_control: { individual_limit: { used_percent: 65, remaining_percent: 35 } }
+      }
+    },
+    {
+      name: 'with a non-Business plan label',
+      payload: {
+        plan_type: 'plus',
+        rate_limit: null,
+        spend_control: { individual_limit: { used_percent: 65, remaining_percent: 35 } }
+      }
+    }
+  ])('maps a usable individual limit $name', async ({ payload }) => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })
+    )
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => payload
+    } as Response)
+
+    await expect(
+      fetchCodexRateLimits({ codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex' })
+    ).resolves.toMatchObject({ monthly: { usedPercent: 65, windowMinutes: 43_200 }, status: 'ok' })
+  })
+
+  it.each([
+    {
+      name: 'a malformed numeric field',
+      individual_limit: { limit: 'not-a-number', used: '1' }
+    },
+    {
+      name: 'a zero limit',
+      individual_limit: { limit: 0, used: 0 }
+    }
+  ])('rejects $name without spawning a fallback', async ({ individual_limit }) => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })
+    )
+    childSpawnMock.mockImplementationOnce(() => {
+      throw new Error('RPC fallback')
+    })
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plan_type: 'business',
+        rate_limit: null,
+        spend_control: { individual_limit }
+      })
+    } as Response)
+
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex',
+        allowPtyFallback: false
+      })
+    ).resolves.toMatchObject({ status: 'error', session: null, weekly: null })
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
   it('accepts a standard backend shape without plan_type and rejects an empty shape', async () => {
     readFileMock.mockResolvedValue(
       JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })

--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -229,6 +229,25 @@ describe('Codex backend rate-limit requests', () => {
     expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).toEqual([
       'https://chatgpt.com/backend-api/wham/usage'
     ])
+
+    vi.mocked(fetch).mockReset()
+    childSpawnMock.mockImplementationOnce(() => {
+      throw new Error('RPC fallback')
+    })
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({})
+    } as Response)
+
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex',
+        allowPtyFallback: false
+      })
+    ).resolves.toMatchObject({ status: 'error' })
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).toEqual([
+      'https://chatgpt.com/backend-api/wham/usage'
+    ])
   })
 
   it('aborts callers while sharing one stalled backend auth read', async () => {

--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { cancelTrackingResponse } from '../lib/unread-response-body.test-fixtures'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -16,6 +17,10 @@ vi.mock('./codex-auth-presence', () => ({
 }))
 
 import { consumeCodexRateLimitResetCredit, fetchCodexRateLimits } from './codex-fetcher'
+
+const reporterBusinessPayload = JSON.parse(
+  readFileSync(new URL('./codex-business-wham-usage-8664.fixture.json', import.meta.url), 'utf8')
+) as Record<string, unknown>
 
 describe('Codex backend rate-limit requests', () => {
   beforeEach(() => {
@@ -135,6 +140,95 @@ describe('Codex backend rate-limit requests', () => {
 
     expect(childSpawnMock).not.toHaveBeenCalled()
     expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('maps the reporter group-based individual limit as a precise monthly window', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })
+    )
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => reporterBusinessPayload
+    } as Response)
+
+    await expect(
+      fetchCodexRateLimits({ codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex' })
+    ).resolves.toMatchObject({
+      session: null,
+      weekly: null,
+      monthly: {
+        usedPercent: (4522.358407497406 / 11450) * 100,
+        windowMinutes: 43_200,
+        resetsAt: 1_785_542_400_000
+      },
+      planType: 'business'
+    })
+    expect(childSpawnMock).not.toHaveBeenCalled()
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('maps the account-user individual limit without source-specific gating', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })
+    )
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plan_type: 'business',
+        rate_limit: null,
+        spend_control: {
+          individual_limit: {
+            source: 'account_user_spend_controls',
+            used_percent: 65,
+            remaining_percent: 35,
+            reset_at: 1_785_542_400
+          }
+        }
+      })
+    } as Response)
+
+    await expect(
+      fetchCodexRateLimits({ codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex' })
+    ).resolves.toMatchObject({ monthly: { usedPercent: 65, windowMinutes: 43_200 } })
+  })
+
+  it('accepts a standard backend shape without plan_type and rejects an empty shape', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })
+    )
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        rate_limit: { primary_window: { used_percent: 12, limit_window_seconds: 300 } }
+      })
+    } as Response)
+
+    await expect(
+      fetchCodexRateLimits({ codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex' })
+    ).resolves.toMatchObject({ session: { usedPercent: 12 } })
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).toEqual([
+      'https://chatgpt.com/backend-api/wham/usage',
+      'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits'
+    ])
+
+    vi.mocked(fetch).mockReset()
+    childSpawnMock.mockImplementationOnce(() => {
+      throw new Error('RPC fallback')
+    })
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ plan_type: 'plus', rate_limit: null })
+    } as Response)
+
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex',
+        allowPtyFallback: false
+      })
+    ).resolves.toMatchObject({ status: 'error' })
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).toEqual([
+      'https://chatgpt.com/backend-api/wham/usage'
+    ])
   })
 
   it('aborts callers while sharing one stalled backend auth read', async () => {

--- a/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
+++ b/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
@@ -1,15 +1,16 @@
 import { EventEmitter } from 'node:events'
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 
-const { childSpawnMock, readFileMock } = vi.hoisted(() => ({
+const { childSpawnMock, ptySpawnMock, readFileMock } = vi.hoisted(() => ({
   childSpawnMock: vi.fn(),
+  ptySpawnMock: vi.fn(),
   readFileMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({ spawn: childSpawnMock }))
 vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
 vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
-vi.mock('node-pty', () => ({ spawn: vi.fn() }))
+vi.mock('node-pty', () => ({ spawn: ptySpawnMock }))
 vi.mock('./codex-auth-presence', () => ({
   probeCodexAuthPresence: vi.fn(async () => 'present')
 }))
@@ -200,6 +201,40 @@ describe('Codex backend session supplement credits', () => {
     })
   })
 
+  it('falls back to remaining percent when direct usage is absent', async () => {
+    await expect(
+      fetchWeeklyOnly(
+        undefined,
+        {
+          planType: 'business',
+          individualLimit: { remainingPercent: 20 }
+        },
+        {}
+      )
+    ).resolves.toMatchObject({ monthly: { usedPercent: 80, windowMinutes: 43_200 } })
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).not.toContain(
+      'https://chatgpt.com/backend-api/wham/usage'
+    )
+  })
+
+  it('rejects a negative used amount even when a direct percentage is present', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    } as Response)
+
+    await expect(
+      fetchWeeklyOnly(
+        undefined,
+        {
+          planType: 'business',
+          individualLimit: { used: -1, usedPercent: 20 }
+        },
+        {}
+      )
+    ).resolves.toMatchObject({ monthly: null })
+  })
+
   it('clamps finite over-cap usage instead of discarding the monthly window', async () => {
     await expect(
       fetchWeeklyOnly(
@@ -315,6 +350,46 @@ describe('Codex backend session supplement credits', () => {
     await expect(resultPromise).resolves.toMatchObject({
       session: null,
       weekly: { usedPercent: 22, windowMinutes: 10_080 },
+      status: 'ok'
+    })
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.filter(([url]) => url === 'https://chatgpt.com/backend-api/wham/usage')
+    ).toHaveLength(1)
+  })
+
+  it('uses PTY after an RPC error without retrying the WSL backend', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('backend unavailable'))
+    const child = makeRpcChild()
+    child.stdin.write.mockImplementation(() => {})
+    childSpawnMock.mockReturnValue(child)
+
+    let onDataHandler: ((data: string) => void) | undefined
+    ptySpawnMock.mockReturnValue({
+      onData: vi.fn((callback: (data: string) => void) => {
+        onDataHandler = callback
+        return { dispose: vi.fn() }
+      }),
+      onExit: vi.fn(() => ({ dispose: vi.fn() })),
+      write: vi.fn(),
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchCodexRateLimits({
+      codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex'
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    child.emit('close')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(ptySpawnMock).toHaveBeenCalledOnce()
+    onDataHandler?.('>')
+    onDataHandler?.('Weekly limit: 12%\n')
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      weekly: { usedPercent: 12 },
       status: 'ok'
     })
     expect(

--- a/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
+++ b/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
@@ -146,11 +146,13 @@ describe('Codex backend session supplement credits', () => {
   it('reuses complete zero-credit metadata from a weekly-only usage response', async () => {
     vi.mocked(fetch).mockResolvedValue(usageResponse({ available_count: 0 }))
 
-    await expect(fetchWeeklyOnly()).resolves.toMatchObject({
+    const result = await fetchWeeklyOnly()
+    expect(result).toMatchObject({
       session: null,
       weekly: { usedPercent: 22, windowMinutes: 10_080 },
       rateLimitResetCredits: { availableCount: 0, nextExpiresAt: null }
     })
+    expect(result.planType).toBeUndefined()
     expect(fetch).toHaveBeenCalledTimes(1)
   })
 
@@ -175,6 +177,79 @@ describe('Codex backend session supplement credits', () => {
     expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).not.toContain(
       'https://chatgpt.com/backend-api/wham/usage'
     )
+  })
+
+  it('keeps the monthly usage when the reset timestamp is an ISO string', async () => {
+    await expect(
+      fetchWeeklyOnly(
+        undefined,
+        {
+          planType: 'business',
+          individualLimit: {
+            usedPercent: 65,
+            resetsAt: '2026-04-01T00:00:00Z'
+          }
+        },
+        {}
+      )
+    ).resolves.toMatchObject({
+      monthly: {
+        usedPercent: 65,
+        resetsAt: Date.parse('2026-04-01T00:00:00Z')
+      }
+    })
+  })
+
+  it('clamps finite over-cap usage instead of discarding the monthly window', async () => {
+    await expect(
+      fetchWeeklyOnly(
+        undefined,
+        {
+          planType: 'business',
+          individualLimit: {
+            limit: '3',
+            used: '4',
+            usedPercent: 105,
+            remainingPercent: -5
+          }
+        },
+        {}
+      )
+    ).resolves.toMatchObject({ monthly: { usedPercent: 100, windowMinutes: 43_200 } })
+  })
+
+  it('supplements an empty successful RPC result for an older CLI', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plan_type: 'business',
+        rate_limit: null,
+        spend_control: {
+          individual_limit: {
+            source: 'account_user_spend_controls',
+            limit: '11450',
+            used: '4522.358407497406',
+            used_percent: 39,
+            remaining_percent: 61,
+            reset_at: 1_785_542_400
+          }
+        }
+      })
+    } as Response)
+
+    await expect(fetchWeeklyOnly(undefined, {}, {})).resolves.toMatchObject({
+      session: null,
+      weekly: null,
+      monthly: {
+        usedPercent: (4522.358407497406 / 11450) * 100,
+        resetsAt: 1_785_542_400_000
+      }
+    })
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.filter(([url]) => url === 'https://chatgpt.com/backend-api/wham/usage')
+    ).toHaveLength(1)
   })
 
   it('keeps the weekly-only session supplement when direct monthly data is also present', async () => {
@@ -212,6 +287,41 @@ describe('Codex backend session supplement credits', () => {
     expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).not.toContain(
       'https://chatgpt.com/backend-api/wham/usage'
     )
+  })
+
+  it('does not supplement an unavailable RPC result', async () => {
+    const child = makeRpcChild()
+    childSpawnMock.mockReturnValue(child)
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(0)
+    child.emit('error', Object.assign(new Error('Codex CLI not found'), { code: 'ENOENT' }))
+
+    await expect(resultPromise).resolves.toMatchObject({ status: 'unavailable' })
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).not.toContain(
+      'https://chatgpt.com/backend-api/wham/usage'
+    )
+  })
+
+  it('does not retry a failed WSL backend-first request through the supplement', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('backend unavailable'))
+    childSpawnMock.mockReturnValue(makeRpcChild({ availableCount: 0 }))
+    const resultPromise = fetchCodexRateLimits({
+      codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex',
+      allowPtyFallback: false
+    })
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: null,
+      weekly: { usedPercent: 22, windowMinutes: 10_080 },
+      status: 'ok'
+    })
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.filter(([url]) => url === 'https://chatgpt.com/backend-api/wham/usage')
+    ).toHaveLength(1)
   })
 
   it.each([

--- a/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
+++ b/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
@@ -165,7 +165,7 @@ describe('Codex backend session supplement credits', () => {
           planType: 'business',
           individualLimit: { limit: 3, used: 1, remainingPercent: 67, resetsAt: 1_785_542_400 }
         },
-        {}
+        { primary: null, secondary: null }
       )
     ).resolves.toMatchObject({
       monthly: {
@@ -251,6 +251,32 @@ describe('Codex backend session supplement credits', () => {
         {}
       )
     ).resolves.toMatchObject({ monthly: { usedPercent: 100, windowMinutes: 43_200 } })
+  })
+
+  it('keeps direct used-percent precedence and clamps an over-cap percentage', async () => {
+    await expect(
+      fetchWeeklyOnly(
+        undefined,
+        {
+          planType: 'business',
+          individualLimit: { usedPercent: 105, remainingPercent: 20 }
+        },
+        { primary: null, secondary: null }
+      )
+    ).resolves.toMatchObject({ monthly: { usedPercent: 100, windowMinutes: 43_200 } })
+  })
+
+  it('preserves monthly usage when the reset value is malformed', async () => {
+    await expect(
+      fetchWeeklyOnly(
+        undefined,
+        {
+          planType: 'business',
+          individualLimit: { usedPercent: 65, resetsAt: 'not-a-reset' }
+        },
+        { primary: null, secondary: null }
+      )
+    ).resolves.toMatchObject({ monthly: { usedPercent: 65, resetsAt: null } })
   })
 
   it('supplements an empty successful RPC result for an older CLI', async () => {

--- a/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
+++ b/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
@@ -16,7 +16,13 @@ vi.mock('./codex-auth-presence', () => ({
 
 import { fetchCodexRateLimits } from './codex-fetcher'
 
-function makeRpcChild(rateLimitResetCredits?: unknown) {
+function makeRpcChild(
+  rateLimitResetCredits?: unknown,
+  extraResult: Record<string, unknown> = {},
+  rateLimits: Record<string, unknown> = {
+    primary: { usedPercent: 22, windowDurationMins: 10_080 }
+  }
+) {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter
     stderr: EventEmitter
@@ -58,9 +64,8 @@ function makeRpcChild(rateLimitResetCredits?: unknown) {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
-                  rateLimits: {
-                    primary: { usedPercent: 22, windowDurationMins: 10_080 }
-                  },
+                  rateLimits,
+                  ...extraResult,
                   ...(rateLimitResetCredits !== undefined ? { rateLimitResetCredits } : {})
                 }
               })}\n`
@@ -107,8 +112,14 @@ function dedicatedCreditsResponse(): Response {
   } as Response
 }
 
-async function fetchWeeklyOnly(rateLimitResetCredits?: unknown) {
-  childSpawnMock.mockReturnValue(makeRpcChild(rateLimitResetCredits))
+async function fetchWeeklyOnly(
+  rateLimitResetCredits?: unknown,
+  extraResult: Record<string, unknown> = {},
+  rateLimits: Record<string, unknown> = {
+    primary: { usedPercent: 22, windowDurationMins: 10_080 }
+  }
+) {
+  childSpawnMock.mockReturnValue(makeRpcChild(rateLimitResetCredits, extraResult, rateLimits))
   const resultPromise = fetchCodexRateLimits()
   await vi.advanceTimersByTimeAsync(1)
   await vi.advanceTimersByTimeAsync(1)
@@ -141,6 +152,66 @@ describe('Codex backend session supplement credits', () => {
       rateLimitResetCredits: { availableCount: 0, nextExpiresAt: null }
     })
     expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps a direct RPC individual limit precisely and skips the backend supplement', async () => {
+    await expect(
+      fetchWeeklyOnly(
+        undefined,
+        {
+          planType: 'business',
+          individualLimit: { limit: 3, used: 1, remainingPercent: 67, resetsAt: 1_785_542_400 }
+        },
+        {}
+      )
+    ).resolves.toMatchObject({
+      monthly: {
+        usedPercent: 33.33333333333333,
+        windowMinutes: 43_200,
+        resetsAt: 1_785_542_400_000
+      },
+      planType: 'business'
+    })
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).not.toContain(
+      'https://chatgpt.com/backend-api/wham/usage'
+    )
+  })
+
+  it('keeps the weekly-only session supplement when direct monthly data is also present', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plan_type: 'pro',
+        rate_limit: {
+          primary_window: { used_percent: 23, limit_window_seconds: 300 },
+          secondary_window: { used_percent: 45, limit_window_seconds: 7 * 24 * 60 * 60 }
+        }
+      })
+    } as Response)
+
+    await expect(
+      fetchWeeklyOnly(undefined, {
+        planType: 'business',
+        individualLimit: { limit: 3, used: 1, remainingPercent: 67, resetsAt: 1_785_542_400 }
+      })
+    ).resolves.toMatchObject({
+      session: { usedPercent: 23, windowMinutes: 5 },
+      weekly: { usedPercent: 45, windowMinutes: 10_080 },
+      monthly: { usedPercent: 33.33333333333333, windowMinutes: 43_200 }
+    })
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).toContain(
+      'https://chatgpt.com/backend-api/wham/usage'
+    )
+  })
+
+  it('does not supplement a known non-Business empty RPC result', async () => {
+    await expect(fetchWeeklyOnly(undefined, { planType: 'plus' }, {})).resolves.toMatchObject({
+      session: null,
+      weekly: null
+    })
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => url)).not.toContain(
+      'https://chatgpt.com/backend-api/wham/usage'
+    )
   })
 
   it.each([

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -553,10 +553,10 @@ function mapIndividualLimit(raw: unknown): RateLimitWindow | null {
   if (limit !== null && limit <= 0) {
     return null
   }
+  if (used !== null && used < 0) {
+    return null
+  }
   if (limit !== null && limit > 0 && used !== null) {
-    if (used < 0) {
-      return null
-    }
     percent = (used / limit) * 100
   } else if (usedPercent !== null && usedPercent >= 0 && usedPercent <= 100) {
     percent = usedPercent

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -541,8 +541,7 @@ function mapIndividualLimit(raw: unknown): RateLimitWindow | null {
     value.limit,
     value.used,
     value.used_percent ?? value.usedPercent,
-    value.remaining_percent ?? value.remainingPercent,
-    value.reset_at ?? value.resetsAt
+    value.remaining_percent ?? value.remainingPercent
   ]
   if (
     numericFields.some(
@@ -551,43 +550,33 @@ function mapIndividualLimit(raw: unknown): RateLimitWindow | null {
   ) {
     return null
   }
-  if (usedPercent !== null && (usedPercent < 0 || usedPercent > 100)) {
-    return null
-  }
-  if (remainingPercent !== null && (remainingPercent < 0 || remainingPercent > 100)) {
-    return null
-  }
-  if (
-    usedPercent !== null &&
-    remainingPercent !== null &&
-    Math.abs(usedPercent + remainingPercent - 100) > 1
-  ) {
-    return null
-  }
-
   if (limit !== null && limit <= 0) {
     return null
   }
   if (limit !== null && limit > 0 && used !== null) {
-    if (used < 0 || used > limit) {
+    if (used < 0) {
       return null
     }
     percent = (used / limit) * 100
-    if (usedPercent !== null && Math.abs(usedPercent - percent) > 1) {
-      return null
-    }
-    if (remainingPercent !== null && Math.abs(100 - remainingPercent - percent) > 1) {
-      return null
-    }
   } else if (usedPercent !== null && usedPercent >= 0 && usedPercent <= 100) {
     percent = usedPercent
   } else if (remainingPercent !== null && remainingPercent >= 0 && remainingPercent <= 100) {
+    percent = 100 - remainingPercent
+  } else if (usedPercent !== null) {
+    percent = usedPercent
+  } else if (remainingPercent !== null) {
     percent = 100 - remainingPercent
   } else {
     return null
   }
 
-  const reset = finiteNumber(value.reset_at ?? value.resetsAt)
+  const rawReset = value.reset_at ?? value.resetsAt
+  const resetMilliseconds =
+    typeof rawReset === 'string' && finiteNumber(rawReset) === null
+      ? parseCreditTimestamp(rawReset)
+      : null
+  const reset =
+    finiteNumber(rawReset) ?? (resetMilliseconds !== null ? resetMilliseconds / 1000 : null)
   return mapRpcWindow({ usedPercent: percent, resetsAt: reset }, 43_200)
 }
 
@@ -691,6 +680,7 @@ async function withBackendSessionWindow(
       return limits
     }
     const rateLimitResetCredits = backend.rateLimitResetCredits ?? limits.rateLimitResetCredits
+    const backendOwnsResult = Boolean(backend.session || backend.monthly || !limits.weekly)
     return {
       ...limits,
       session: limits.session ?? backend.session,
@@ -698,9 +688,11 @@ async function withBackendSessionWindow(
         ? (backend.weekly ?? limits.weekly)
         : (limits.weekly ?? backend.weekly),
       monthly: limits.monthly ?? backend.monthly,
-      planType: limits.planType ?? backend.planType,
+      ...(backendOwnsResult && backend.planType && !limits.planType
+        ? { planType: backend.planType }
+        : {}),
       ...(rateLimitResetCredits !== undefined ? { rateLimitResetCredits } : {}),
-      updatedAt: backend.updatedAt
+      ...(backendOwnsResult ? { updatedAt: backend.updatedAt } : {})
     }
   } catch {
     return limits

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -558,10 +558,6 @@ function mapIndividualLimit(raw: unknown): RateLimitWindow | null {
   }
   if (limit !== null && limit > 0 && used !== null) {
     percent = (used / limit) * 100
-  } else if (usedPercent !== null && usedPercent >= 0 && usedPercent <= 100) {
-    percent = usedPercent
-  } else if (remainingPercent !== null && remainingPercent >= 0 && remainingPercent <= 100) {
-    percent = 100 - remainingPercent
   } else if (usedPercent !== null) {
     percent = usedPercent
   } else if (remainingPercent !== null) {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -93,6 +93,8 @@ type RateLimitResetCredits = {
 // Why: the Codex app-server wraps rate limit data as { rateLimits: { primary, secondary, ... } }.
 type RpcRateLimitsResponse = {
   rateLimits?: CodexRateLimitWindowsSnapshot | null
+  planType?: unknown
+  individualLimit?: unknown
   rateLimitResetCredits?: {
     availableCount?: number
     totalEarnedCount?: number
@@ -128,12 +130,22 @@ type BackendRateLimitWindow = {
   reset_at?: number
 }
 
+type BackendIndividualLimit = {
+  source?: string
+  limit?: unknown
+  used?: unknown
+  used_percent?: unknown
+  remaining_percent?: unknown
+  reset_at?: unknown
+}
+
 type BackendUsageResponse = {
   plan_type?: string
   rate_limit?: {
     primary_window?: BackendRateLimitWindow | null
     secondary_window?: BackendRateLimitWindow | null
   } | null
+  spend_control?: { individual_limit?: BackendIndividualLimit | null } | null
   rate_limit_reset_credits?: BackendRateLimitResetCreditsResponse | null
 }
 
@@ -503,6 +515,82 @@ function mapRpcWindow(
   }
 }
 
+function finiteNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function mapIndividualLimit(raw: unknown): RateLimitWindow | null {
+  if (!raw || typeof raw !== 'object') {
+    return null
+  }
+  const value = raw as Record<string, unknown>
+  const limit = finiteNumber(value.limit)
+  const used = finiteNumber(value.used)
+  const usedPercent = finiteNumber(value.used_percent ?? value.usedPercent)
+  const remainingPercent = finiteNumber(value.remaining_percent ?? value.remainingPercent)
+  let percent: number | null = null
+
+  const numericFields = [
+    value.limit,
+    value.used,
+    value.used_percent ?? value.usedPercent,
+    value.remaining_percent ?? value.remainingPercent,
+    value.reset_at ?? value.resetsAt
+  ]
+  if (
+    numericFields.some(
+      (field) => field !== undefined && field !== null && finiteNumber(field) === null
+    )
+  ) {
+    return null
+  }
+  if (usedPercent !== null && (usedPercent < 0 || usedPercent > 100)) {
+    return null
+  }
+  if (remainingPercent !== null && (remainingPercent < 0 || remainingPercent > 100)) {
+    return null
+  }
+  if (
+    usedPercent !== null &&
+    remainingPercent !== null &&
+    Math.abs(usedPercent + remainingPercent - 100) > 1
+  ) {
+    return null
+  }
+
+  if (limit !== null && limit <= 0) {
+    return null
+  }
+  if (limit !== null && limit > 0 && used !== null) {
+    if (used < 0 || used > limit) {
+      return null
+    }
+    percent = (used / limit) * 100
+    if (usedPercent !== null && Math.abs(usedPercent - percent) > 1) {
+      return null
+    }
+    if (remainingPercent !== null && Math.abs(100 - remainingPercent - percent) > 1) {
+      return null
+    }
+  } else if (usedPercent !== null && usedPercent >= 0 && usedPercent <= 100) {
+    percent = usedPercent
+  } else if (remainingPercent !== null && remainingPercent >= 0 && remainingPercent <= 100) {
+    percent = 100 - remainingPercent
+  } else {
+    return null
+  }
+
+  const reset = finiteNumber(value.reset_at ?? value.resetsAt)
+  return mapRpcWindow({ usedPercent: percent, resetsAt: reset }, 43_200)
+}
+
 function backendWindowToSnapshot(
   raw: BackendRateLimitWindow | null | undefined
 ): CodexRateWindowSnapshot | null {
@@ -547,14 +635,14 @@ async function fetchViaBackend(
     return null
   }
   const payload = (await response.json()) as BackendUsageResponse
-  // Why: reject missing plan_type so the app-server fallback runs.
-  if (typeof payload.plan_type !== 'string') {
-    return null
-  }
   const classified = classifyCodexRateLimitWindows({
     primary: backendWindowToSnapshot(payload.rate_limit?.primary_window),
     secondary: backendWindowToSnapshot(payload.rate_limit?.secondary_window)
   })
+  const monthly = mapIndividualLimit(payload.spend_control?.individual_limit)
+  if (!classified.session && !classified.weekly && !monthly) {
+    return null
+  }
   return {
     provider: 'codex',
     session: mapRpcWindow(
@@ -565,8 +653,9 @@ async function fetchViaBackend(
       classified.weekly,
       snapshotWindowMinutes(classified.weekly, CODEX_WEEKLY_WINDOW_MINUTES)
     ),
+    monthly,
     // Surfaced for the status-bar Usage row (e.g. "Codex · Plus").
-    planType: payload.plan_type,
+    ...(typeof payload.plan_type === 'string' ? { planType: payload.plan_type } : {}),
     ...(payload.rate_limit_reset_credits !== undefined
       ? {
           rateLimitResetCredits:
@@ -581,9 +670,19 @@ async function fetchViaBackend(
 
 async function withBackendSessionWindow(
   limits: ProviderRateLimits,
-  options?: FetchCodexRateLimitsOptions
+  options?: FetchCodexRateLimitsOptions,
+  context?: { backendAttempted?: boolean }
 ): Promise<ProviderRateLimits> {
-  if (options?.signal?.aborted || limits.session || !limits.weekly) {
+  const knownNonBusiness =
+    typeof limits.planType === 'string' && limits.planType.toLowerCase() !== 'business'
+  if (
+    options?.signal?.aborted ||
+    limits.status !== 'ok' ||
+    limits.session ||
+    context?.backendAttempted ||
+    (knownNonBusiness && !limits.weekly) ||
+    (!limits.weekly && limits.monthly)
+  ) {
     return limits
   }
   try {
@@ -592,16 +691,14 @@ async function withBackendSessionWindow(
       return limits
     }
     const rateLimitResetCredits = backend.rateLimitResetCredits ?? limits.rateLimitResetCredits
-    if (!backend.session) {
-      return rateLimitResetCredits === limits.rateLimitResetCredits
-        ? limits
-        : { ...limits, rateLimitResetCredits }
-    }
     return {
       ...limits,
-      session: backend.session,
-      weekly: backend.weekly ?? limits.weekly,
-      planType: backend.planType ?? limits.planType,
+      session: limits.session ?? backend.session,
+      weekly: backend.session
+        ? (backend.weekly ?? limits.weekly)
+        : (limits.weekly ?? backend.weekly),
+      monthly: limits.monthly ?? backend.monthly,
+      planType: limits.planType ?? backend.planType,
       ...(rateLimitResetCredits !== undefined ? { rateLimitResetCredits } : {}),
       updatedAt: backend.updatedAt
     }
@@ -800,9 +897,19 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
 
             const wrapper = msg.result as RpcRateLimitsResponse | undefined
             const result = wrapper?.rateLimits
+            const reported = result as
+              | (CodexRateLimitWindowsSnapshot & {
+                  planType?: unknown
+                  individualLimit?: unknown
+                })
+              | null
+              | undefined
             const classifiedWindows = classifyCodexRateLimitWindows(result)
             const session = mapRpcWindow(classifiedWindows.session, CODEX_SESSION_WINDOW_MINUTES)
             const weekly = mapRpcWindow(classifiedWindows.weekly, CODEX_WEEKLY_WINDOW_MINUTES)
+            const individualLimit = mapIndividualLimit(
+              wrapper?.individualLimit ?? reported?.individualLimit
+            )
             const rateLimitResetCredits = mapRpcRateLimitResetCredits(
               wrapper?.rateLimitResetCredits
             )
@@ -812,6 +919,10 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
                 provider: 'codex',
                 session,
                 weekly,
+                monthly: individualLimit,
+                ...(typeof (wrapper?.planType ?? reported?.planType) === 'string'
+                  ? { planType: (wrapper?.planType ?? reported?.planType) as string }
+                  : {}),
                 ...(rateLimitResetCredits !== undefined ? { rateLimitResetCredits } : {}),
                 updatedAt: Date.now(),
                 error: null,
@@ -1230,8 +1341,10 @@ export async function fetchCodexRateLimits(
   }
 
   // Path A (WSL): use Codex's backend usage contract so a routine poll skips spawning a login shell to rebuild the CLI env.
+  let backendAttempted = false
   if (options?.codexHomePath && parseWslUncPath(options.codexHomePath)) {
     try {
+      backendAttempted = true
       const backendResult = await fetchViaBackend(options)
       if (options?.signal?.aborted) {
         return abortedCodexRateLimitResult()
@@ -1273,7 +1386,7 @@ export async function fetchCodexRateLimits(
       return abortedCodexRateLimitResult()
     }
     if (rpcResult.status === 'ok' || rpcResult.status === 'unavailable') {
-      const withSession = await withBackendSessionWindow(rpcResult, options)
+      const withSession = await withBackendSessionWindow(rpcResult, options, { backendAttempted })
       const withResetCredits = await withBackendRateLimitResetCredits(withSession, options)
       return options?.signal?.aborted ? abortedCodexRateLimitResult() : withResetCredits
     }
@@ -1310,7 +1423,7 @@ export async function fetchCodexRateLimits(
     if (options?.signal?.aborted) {
       return abortedCodexRateLimitResult()
     }
-    const withSession = await withBackendSessionWindow(ptyResult, options)
+    const withSession = await withBackendSessionWindow(ptyResult, options, { backendAttempted })
     const withResetCredits = await withBackendRateLimitResetCredits(withSession, options)
     return options?.signal?.aborted ? abortedCodexRateLimitResult() : withResetCredits
   } catch (err) {

--- a/src/main/rate-limits/service-account-target-selection.test.ts
+++ b/src/main/rate-limits/service-account-target-selection.test.ts
@@ -470,6 +470,43 @@ describe('RateLimitService', () => {
     )
   })
 
+  it('caches an outgoing monthly-only Codex account so the switcher keeps its usage preview', async () => {
+    const service = new RateLimitService()
+    service.setInactiveCodexAccountsResolver(() => [
+      inactiveCodexAccount('account-monthly', '/tmp/account-monthly/home')
+    ])
+
+    const monthlyOnly: ProviderRateLimits = {
+      provider: 'codex',
+      session: null,
+      weekly: null,
+      monthly: { usedPercent: 65, windowMinutes: 43_200, resetsAt: null, resetDescription: null },
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    }
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits)
+      .mockResolvedValueOnce(monthlyOnly)
+      .mockResolvedValueOnce(okProvider('codex', 40, Date.now()))
+
+    await service.refresh()
+    await service.refreshForCodexAccountChange('account-monthly')
+
+    expect(service.getState().inactiveCodexAccounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: 'account-monthly',
+          rateLimits: expect.objectContaining({
+            session: null,
+            weekly: null,
+            monthly: expect.objectContaining({ usedPercent: 65 })
+          })
+        })
+      ])
+    )
+  })
+
   it('does not cache an outgoing Codex account that has no usage windows', async () => {
     const service = new RateLimitService()
     service.setInactiveCodexAccountsResolver(() => [

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -433,11 +433,11 @@ export class RateLimitService {
     target?: CodexAccountSelectionTarget
   ): Promise<RateLimitState> {
     const nextTarget = normalizeCodexAccountSelectionTarget(target)
-    // Why: weekly-only plans report no session window, so gating on session alone
-    // dropped their snapshot and left the switcher's inline bars empty.
+    // Why: monthly-only and weekly-only plans have no session window, so gate on
+    // any usable Codex window before dropping the outgoing snapshot.
     if (
       outgoingAccountId &&
-      (this.state.codex?.session || this.state.codex?.weekly) &&
+      (this.state.codex?.session || this.state.codex?.weekly || this.state.codex?.monthly) &&
       this.isSameCodexTarget(this.codexFetchTarget, nextTarget)
     ) {
       this.inactiveCodexCache.set(outgoingAccountId, this.state.codex)


### PR DESCRIPTION
## Summary

- Map a usable Codex `spend_control.individual_limit` response to the existing monthly usage window, regardless of whether the source is group-based or account-user controls.
- Map the reported RPC `individualLimit` and `planType` fields directly, preferring precise `used / limit` usage and preserving the reset boundary.
- Keep standard session and weekly windows additive, use one bounded backend request for older successful empty RPC results, and avoid retrying a WSL backend miss through the supplement path.
- Preserve monthly-only usage in inactive Codex account previews during account switching.

Closes #8664

## Screenshots

No visual change. The existing status bar and usage panels consume the monthly window already supported by Orca.

## Testing

- Focused Codex behavior tests: 31 passed across backend mapping and RPC/supplement routing.
- Monthly-only account-switch cache test: passed.
- Existing window classifier tests: 14 passed.
- Node typecheck, touched-file oxlint, and oxfmt checks: passed.
- The existing Codex fetcher file retains two unchanged baseline mock-kill failures, and the full account-target file retains five unchanged Claude-option expectation failures; the new cases pass independently.

## AI Review Report

The implementation was reviewed against current `main` across backend and RPC payload mapping, standard-window classification, fallback eligibility, reset-credit precedence, WSL/native process routing, and inactive-account caching. The review findings were addressed with focused regression coverage for malformed shapes, direct percentage precedence, over-cap values, reset tolerance, no-retry behavior, and monthly-only previews.

## Security Audit

No authentication or authorization behavior changed. The implementation reuses existing bounded request signals, credential loading, process cleanup, and reset-credit handling. Test credentials are fake literals used only in mocked fixtures.

## Notes

This change is scoped to Orca's parsing, precedence, fallback, and cache behavior for the reported payload shapes. The fixtures document compatibility evidence; they do not claim to prove every Codex plan or CLI contract. Rebuilt from current `main` following the second spend-control payload report.

## ELI5

Codex can report a monthly spending meter in two places. Orca now recognizes both places, keeps the exact reset date, and shows the saved meter when switching between accounts.
