### PR TITLE
fix(ssh): resolve complete remote Node/npm toolchains

### DIFF
--- a/config/scripts/run-ssh-node-toolchain-resolution-e2e.mjs
+++ b/config/scripts/run-ssh-node-toolchain-resolution-e2e.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from 'node:child_process'
+
+const rawExtraArgs = process.argv.slice(2)
+const extraArgs = rawExtraArgs[0] === '--' ? rawExtraArgs.slice(1) : rawExtraArgs
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const env = {
+  ...process.env,
+  ORCA_E2E_SSH_DOCKER: '1',
+  ORCA_E2E_SSH_DOCKER_IMAGE: 'ubuntu:24.04'
+}
+const spawnOptions = {
+  stdio: 'inherit',
+  env,
+  // Why: Node's CVE-2024-27980 hardening rejects .cmd spawns without shell on Windows.
+  shell: process.platform === 'win32'
+}
+
+const runtime = spawnSync(pnpm, ['run', 'ensure:electron-runtime'], spawnOptions)
+if (runtime.status !== 0) {
+  process.exit(runtime.status ?? 1)
+}
+
+const result = spawnSync(
+  pnpm,
+  [
+    'exec',
+    'playwright',
+    'test',
+    'tests/e2e/ssh-node-toolchain-resolution.spec.ts',
+    '--config',
+    'tests/playwright.config.ts',
+    '--project',
+    'electron-headless',
+    '--workers=1',
+    ...extraArgs
+  ],
+  spawnOptions
+)
+
+process.exit(result.status ?? 1)

--- a/docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md
+++ b/docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md
@@ -1,0 +1,1416 @@
+# SSH Relay GitHub Release Distribution — Living Implementation Checklist
+
+Date created: 2026-07-14<br>
+Last updated: 2026-07-14<br>
+Current phase: Milestone 0 / Work Package 0 — verification refresh and authorized draft-PR boundary in progress; Milestone 1 runner and per-target Beta rollout policies recorded<br>
+Primary design: [SSH relay GitHub Release plan](./2026-07-14-ssh-relay-github-release-plan.html)<br>
+Motivating issues: [#8450](https://github.com/stablyai/orca/issues/8450), [#1693](https://github.com/stablyai/orca/issues/1693)
+
+## Mandatory Living-Document Protocol
+
+This checklist is part of the implementation, not a planning artifact that may go stale. Every
+agent or engineer working on this project must read it before editing code and update it in the
+same change as the work it records.
+
+- At the start of every implementation session, read this document and confirm the current phase,
+  open decisions, accepted gaps, and existing evidence.
+- Mark the active item with `**In progress — YYYY-MM-DD, owner/agent**` before changing code.
+- Keep only one implementation item marked in progress unless independent PRs are deliberately
+  running in parallel and each names its owner.
+- Do not change `- [ ]` to `- [x]` until the implementation and its required verification are
+  complete.
+- Every completed item must cite an evidence-ledger ID such as `E-ARTIFACT-001` or a merged PR.
+- Record exact commands, runner OS/architecture, commit SHA, result, duration, and artifact link for
+  executable evidence. “Tests passed” is not adequate evidence.
+- Record what a test does **not** prove. Mock coverage must not be presented as live SSH,
+  native-module, release-asset, or platform coverage.
+- If implementation changes the design, update both this checklist and the HTML plan in the same PR
+  before continuing.
+- If a supported tuple lacks required real-environment proof, leave it on a proven legacy path or
+  mark it unsupported. Do not check it off based on cross-compilation or emulation alone.
+- Never use “100% verified” without naming the exact declared matrix and showing that every required
+  cell passed.
+- Preserve unrelated worktree changes. At checklist creation, the existing edits to
+  `ssh-remote-node-resolution.ts` and its test are user-owned issue #8450 work.
+- Before every PR handoff, update Current Status, PR/Work-Package Status, Verification Ledger,
+  Accepted Gaps, and Next Required Action.
+
+## Status Legend
+
+- `- [ ]` — not complete.
+- `- [x]` — complete with linked evidence.
+- `**In progress — date, owner**` — actively being implemented; the checkbox remains unchecked.
+- `BLOCKED:` — cannot proceed without a named decision, authority, runner, credential, or external
+  state. Include the exact unblock condition.
+- `ACCEPTED GAP:` — deliberately not proved yet. Include scope, fallback behavior, owner, and
+  promotion condition.
+
+## Current Status
+
+- Implementation status: Work Package 0 implementation, focused regression proof, and live #8450
+  SSH/PTY proof are complete in the uncommitted worktree (E-M0-UNIT-001, E-M0-LIVE-001).
+- Production behavior: unchanged; Orca embeds relay JavaScript and installs `node-pty` plus
+  `@parcel/watcher` with remote npm.
+- New runtime assets published: none.
+- Bundled runtime enabled: no.
+- Declared supported bundled tuples: none until the baseline and runner decisions below are closed.
+- Validation orchestration: GitHub Actions is the primary runner and evidence surface under
+  E-M1-RUNNER-DECISION-001; exact native labels and representative remote targets remain open.
+- Rollout control: existing per-SSH-target configuration; legacy is the default and the bundled
+  runtime is an explicit per-target Beta opt-in under E-M1-ROLLOUT-DECISION-001.
+- Legacy fallback removal: not authorized.
+- Next required action: resolve or explicitly baseline the unrelated repository-wide lint failure
+  recorded in E-M0-LINT-001, then place Work Package 0 behind its separately authorized commit/PR
+  boundary before closing Milestone 1 decisions. Do not mix artifact-distribution changes into this
+  uncommitted fix.
+
+## Non-Negotiable Invariants
+
+- [ ] The bundled primary path never requires outbound HTTP, npm, a compiler, Python, or a system
+      Node installation on the SSH host.
+- [ ] The desktop downloads the runtime, verifies it locally, and transfers it through the existing
+      authenticated SSH connection.
+- [ ] SSH authentication/connection and relay RPC transport remain unchanged; bootstrap artifact
+      transfer is a separately designed, measured, and gated subsystem.
+- [ ] Every desktop build embeds the exact signed manifest needed to resolve a remote tuple to a
+      content identity while the desktop is offline.
+- [ ] Relay artifacts are built and signed before desktop packaging; app builds and GitHub Release
+      uploads consume the exact same immutable bytes.
+- [ ] No downloaded byte is extracted, transferred, or executed until manifest authenticity,
+      expected tuple, size bounds, and archive SHA-256 are verified at the appropriate boundary.
+- [ ] A completed remote install is immutable and content-addressed. A running old relay is never
+      mutated in place.
+- [ ] Bundled and legacy installs use distinct identities, locks, partial directories, sentinels,
+      and launch generations.
+- [ ] Fallback cannot start until all bundled download, extraction, upload, verification, and launch
+      work is aborted, awaited, and unable to mutate state.
+- [ ] Signature, archive hash/safety, extracted-tree, or native-signature failure fails closed in
+      `auto`: rejected bytes never execute and automatic legacy fallback never starts.
+- [ ] Detected local or remote cache corruption is quarantined and may recover only from freshly
+      verified bundled bytes; failed/unavailable recovery fails closed without automatic legacy.
+- [ ] Local signed-manifest/archive/tree verification plus authenticated SSH transfer into exclusive
+      staging is the pre-execution integrity boundary; bundled Node then hashes the entire staged
+      tree before any completion sentinel is written.
+- [ ] Remote install proof establishes initial transfer/finalization correctness. Warm launch trusts
+      Orca's completed-directory immutability assumption; the sentinel is not ongoing proof against
+      later mutation or a hostile authenticated account that can replace runtime and sentinel.
+- [ ] Platform support is never inferred from an artifact existing. Each enabled tuple requires a
+      real-environment runtime proof.
+- [ ] Unknown or conflicting platform/libc evidence deterministically selects proven legacy
+      behavior; it never guesses an artifact.
+- [ ] Runtime transfer has explicit memory, file-count, concurrency, cancellation, and time budgets.
+- [ ] Bundled mode depends only on the explicitly declared POSIX or Windows bootstrap primitives; it
+      never silently requires remote Node, Python, tar, `sha256sum`, or `shasum`.
+- [ ] Every Node/CVE/runtime/key refresh produces a new desktop tag/build and embedded signed
+      manifest. Old clients remain frozen to their embedded manifest and accepted keys.
+- [ ] Current PTY, watcher, Git, filesystem, streaming, agent-hook, preflight, reconnect, and GC
+      contracts remain intact.
+- [ ] macOS, Linux, and Windows behavior remains behind runtime checks and uses platform-native
+      paths and commands.
+- [ ] No implementation file adds a max-lines disable or vague `helpers`/`utils` module name.
+
+## Milestone 0 — Preserve and Prove the Legacy Safety Net
+
+Goal: land the narrow #8450 correction independently because automatic fallback depends on a
+coherent Node/npm resolver.
+
+Work Package 0 implementation evidence was completed on 2026-07-14 by the Codex implementation
+owner. No relay artifact-distribution behavior is included.
+
+**In progress — 2026-07-14, Codex implementation owner:** refresh the focused/static/live evidence,
+resolve or explicitly baseline the repository lint result, and establish the authorized independent
+draft-PR/CI boundary before any Work Package 1 implementation.
+
+- [x] Confirm the #8450 implementation selects Node and npm from the same bin directory on POSIX.
+      (E-M0-UNIT-001, E-M0-LIVE-001)
+- [x] Confirm Windows selects `node.exe` and `npm.cmd` from one toolchain directory.
+      (E-M0-UNIT-001; mocked Windows command construction, not live Windows)
+- [x] Reject an incomplete system Node and continue to the usable NVM candidate.
+      (E-M0-UNIT-001, E-M0-LIVE-001)
+- [x] Preserve minimum supported Node-version enforcement. (E-M0-UNIT-001)
+- [x] Preserve login-shell, known-path, version-manager, noisy-startup, cancellation, and
+      `MaxSessions=1` behaviors. (E-M0-UNIT-001; live `MaxSessions=1` remains outside this WP0 proof)
+- [x] Add the exact Ubuntu/system-Node-without-npm/NVM-below-`.bashrc`-guard regression fixture.
+      (E-M0-UNIT-001, E-M0-LIVE-001)
+- [x] Add negative tests for Node present/npm missing, npm present/Node too old, mismatched bin
+      directories, and an unusable npm shim. (E-M0-UNIT-001)
+- [x] Run focused resolver and deploy tests and record evidence. (E-M0-UNIT-001)
+- [x] Run a live SSH reproduction matching issue #8450 and record the selected paths and successful
+      relay/PTY launch without recording usernames or home paths in committed evidence.
+      (E-M0-LIVE-001)
+- [ ] Keep this fix in a separate PR or commit from GitHub Release distribution.
+- [x] Document which tuples have a live passing legacy E2E. Fallback is only a support claim for
+      those tuples. (E-M0-LIVE-001)
+
+| Legacy remote tuple                                                               | Client           | Transport                                    | Evidence      | Scope limit                                                       |
+| --------------------------------------------------------------------------------- | ---------------- | -------------------------------------------- | ------------- | ----------------------------------------------------------------- |
+| Ubuntu 24.04 arm64, glibc, system Node 18 without npm, guarded NVM Node 22/npm 10 | macOS 26.2 arm64 | Built-in SSH2 connection + SFTP relay upload | E-M0-LIVE-001 | Does not prove x64, system SSH, Windows, musl, or `MaxSessions=1` |
+
+Completion evidence required: focused red/green tests, live #8450 SSH run, typecheck, lint, and PR
+link.
+
+## Milestone 1 — Close Blocking Product and Support Decisions
+
+No production implementation begins until every blocking item has an owner and decision record.
+
+### Supported runtime baselines
+
+- [ ] Define the oldest supported glibc version.
+- [ ] Define the oldest supported libstdc++/C++ ABI level.
+- [ ] Define the minimum supported Linux kernel.
+- [ ] Define supported musl distribution and musl-version baselines.
+- [ ] Define minimum supported macOS version for x64 and arm64.
+- [ ] Define minimum supported Windows build and OpenSSH/PowerShell baseline.
+- [ ] Decide whether Rosetta-hosted shells select x64, arm64, or legacy based on the actual remote
+      process architecture.
+- [ ] Document currently supported legacy tuples separately from proposed bundled tuples.
+
+### Validation runner and network topology
+
+Decision owner: Codex implementation owner for #8450. Decision authority: worktree owner direction
+on 2026-07-14. GitHub Actions is the primary orchestration and durable evidence surface because it
+can couple target-native build jobs, packaged-client jobs, logs, metrics, and immutable artifacts to
+the exact commit under test without introducing a second release-control plane.
+
+- [x] Use GitHub Actions for the PR, nightly, release, and promotion evidence workflows.
+      (E-M1-RUNNER-DECISION-001)
+- [x] Permit a GitHub-hosted runner to fill a required evidence cell only when it provides real
+      hardware or native virtualization for the declared OS/architecture and the job records the
+      runner label, image/version, architecture, and native-versus-emulated status.
+      (E-M1-RUNNER-DECISION-001)
+- [x] Require a real OpenSSH daemon, the full-size packaged runtime, and the production built-in
+      SSH/SFTP or system-SSH path named by the cell. A mock server, reduced fixture, cross-build,
+      QEMU-only run, or artifact existence cannot fill a live cell. Same-host or native-container
+      targets qualify only when they preserve the declared remote OS/architecture, SSH daemon,
+      primitive, egress, and isolation conditions. (E-M1-RUNNER-DECISION-001)
+- [x] For Layer B cross-family cells, have the GitHub Actions job provision or connect to an
+      ephemeral native SSH target or an approved self-hosted target pool. The remote need not itself
+      be GitHub-hosted, but its image/snapshot identity and teardown result are part of the evidence;
+      do not assume networking between unrelated hosted jobs. (E-M1-RUNNER-DECISION-001)
+- [x] Keep any tuple without an available qualifying native runner or reachable representative
+      remote disabled and on its proven legacy path. (E-M1-RUNNER-DECISION-001)
+- [ ] Inventory the repository's available GitHub-hosted and approved self-hosted runner labels;
+      record which are native, their image/version update policy, capacity, and architecture.
+- [ ] Name and pin the representative POSIX and Windows remote images/snapshots used for Layer B,
+      including their OpenSSH and bootstrap-primitive baselines and network-egress controls.
+- [ ] Select a repeatable GitHub runner class or approved dedicated runner for numeric regression
+      baselines. If hosted-runner variance prevents the Milestone 1 thresholds from being evaluated,
+      use the dedicated runner for the affected metric rather than weakening the threshold.
+
+### Remote bootstrap primitives
+
+- [ ] Define the exact POSIX baseline, including POSIX `sh`, byte-preserving stdin-to-file via `cat`
+      or a proven equivalent, and required `mkdir`/`rm`/`mv`/`chmod`/`test`/`nohup` semantics.
+- [ ] Define the exact Windows OpenSSH, PowerShell, and .NET baseline plus binary file I/O, exclusive
+      staging, atomic rename, permission, and detached-process primitives.
+- [ ] Decide how each required primitive is capability-probed without Node or Python and how probe
+      results are scoped to the remote host/connection.
+- [ ] Define missing-command behavior as compatibility failure, eligible for legacy in `auto` only
+      where that legacy tuple is proven.
+- [ ] Record BusyBox variants whose semantics satisfy the POSIX baseline and disable bundled mode for
+      variants that do not.
+
+### Node runtime ownership
+
+- [ ] Select the bundled Node major/minor/patch and support/EOL policy.
+- [ ] Decide the provenance for each Node binary: unchanged official binary, Orca-built binary, or
+      another documented source.
+- [ ] Decide how musl Node binaries are produced. Do not use an unreviewed unofficial binary source.
+- [ ] Define the Node update cadence and CVE response SLA.
+- [ ] Define refresh identity when only Node, CVE remediation, native code, or a signing key changes.
+      Every refresh must ship through a new desktop tag/build with a newly embedded manifest.
+- [ ] Decide which upstream signatures are preserved and which Orca-built binaries require native
+      signing.
+
+### Trust and signing
+
+- [ ] Choose manifest signature algorithm and library based on existing Orca dependencies and
+      platform availability.
+- [ ] Define canonical manifest serialization byte-for-byte.
+- [ ] Define signing-key creation, storage, protected-environment access, auditability, and least
+      privilege.
+- [ ] Define key IDs, accepted-key embedding, dual-key rotation window, revocation response, and
+      emergency replacement. Revocation and emergency replacement ship through the desktop update
+      path; old clients remain pinned and no mutable freshness lookup is introduced.
+- [ ] Define exact-tag anti-rollback behavior and whether downgrading the desktop may use older
+      manifests.
+- [ ] Decide whether keyless build provenance supplements or replaces any long-lived CI credential.
+- [ ] Define macOS code-signing/notarization requirements for Node, `spawn-helper`, and native
+      modules.
+- [ ] Define Windows Authenticode requirements for Node, `.node`, DLL, and helper executables.
+- [ ] Define WDAC, Gatekeeper, antivirus, and endpoint-protection validation environments.
+
+### Operational budgets and rollout policy
+
+- [ ] Record current legacy cold-install and warm-connect baselines on representative networks.
+- [ ] Set numeric local cache size and eviction budgets.
+- [ ] Set archive compressed-size, expanded-size, file-count, and per-file limits.
+- [ ] Set local download, extraction, transfer, remote verification, launch, cancellation, and total
+      bootstrap time budgets.
+- [ ] Set desktop and remote peak-memory budgets for every transfer path.
+- [ ] Set SFTP concurrency and open-channel limits.
+- [ ] Define acceptable warm-path and cold-path latency regressions numerically.
+- [ ] Define how long legacy fallback remains and the evidence required before narrowing it.
+- [x] Use existing per-SSH-target configuration for rollout control; do not add a rollout backend.
+      This closes the control-mechanism decision, not its implementation.
+      (E-M1-ROLLOUT-DECISION-001)
+- [ ] Decide user-facing behavior when the client is offline, the asset is absent locally, the
+      remote cache is absent, and legacy prerequisites are unavailable.
+
+#### Per-target Beta rollout decision
+
+Decision owner: Codex implementation owner for #8450. Decision authority: worktree owner direction
+on 2026-07-14. The purpose is to gather real-host evidence without changing behavior for existing
+SSH users or making all of a user's hosts depend on one experimental path.
+
+- [x] Keep `legacy` as the persisted and effective default for every existing and newly added SSH
+      target. An absent or unknown configuration value must deserialize conservatively to `legacy`.
+      (E-M1-ROLLOUT-DECISION-001)
+- [x] Expose the bundled-preferred path as a Beta-tagged option on SSH target add and edit surfaces,
+      stored per target rather than as a global experiment. (E-M1-ROLLOUT-DECISION-001)
+- [x] Represent the persisted choice as an extensible mode such as `legacy | bundled-auto`, not a
+      boolean. Keep forced `bundled` as a separate engineering/support diagnostic and do not expose
+      it as the normal Beta choice. Exact schema naming remains an implementation detail.
+      (E-M1-ROLLOUT-DECISION-001)
+- [x] Apply a setting change only to the next connection or explicit reconnect. Never hot-swap the
+      relay underneath a live PTY, watcher, RPC, reconnect, or reattach generation.
+      (E-M1-ROLLOUT-DECISION-001)
+- [x] In Beta mode, allow only classified availability/compatibility failures to enter proven
+      legacy automatically. Integrity/security failures remain fail-closed; recovery is an explicit
+      local action that disables Beta for that target and reconnects through legacy.
+      (E-M1-ROLLOUT-DECISION-001)
+- [x] Require a separate reviewed rollout decision and completed evidence gates before changing the
+      default for any tuple. Shipping the Beta setting does not authorize default-on or legacy
+      removal. (E-M1-ROLLOUT-DECISION-001)
+
+Decision evidence required: reviewed decision record with owners, dates, rationale, and affected
+matrix cells.
+
+## Milestone 2 — Define the Artifact, Manifest, and Identity Contract
+
+Suggested modules are provisional; update this file before choosing different names.
+
+### Manifest schema
+
+- [ ] Add a versioned relay artifact schema in a concrete domain module such as
+      `src/main/ssh/ssh-relay-artifact-schema.ts`.
+- [ ] Include schema version, exact Orca build tag, relay protocol version, runtime content ID,
+      OS, architecture, libc family/version requirements, minimum OS/kernel requirements, Node
+      version, dependency versions, archive name, archive size, expanded size, file count, and
+      archive SHA-256.
+- [ ] Include every runtime file’s relative path, type, size, SHA-256, and required executable mode.
+- [ ] Include signing key ID, signature algorithm/version, creation timestamp, and provenance/SBOM
+      references without making wall-clock time part of runtime identity.
+- [ ] Include target-native code-signing verification attestation, policy/tool identity, and the
+      exact attested byte hashes inside the signed manifest.
+- [ ] Reject duplicate tuple entries, duplicate/case-colliding paths, unsafe Windows names,
+      unsupported schema versions, missing required files, extra native platform packages, and
+      inconsistent aggregate sizes.
+- [ ] Define exact archive naming for stable, RC, and perf builds.
+- [ ] Define exact direct release URL construction. Runtime code must not call the GitHub API or use
+      a mutable `latest` URL.
+
+### Content identity
+
+- [ ] Compute the content identity from canonical full-runtime metadata and file digests, including
+      Node, relay entries, native modules, helper executables, and runtime JavaScript.
+- [ ] Prove changing only Node changes the identity.
+- [ ] Prove changing only `node-pty` changes the identity.
+- [ ] Prove changing only `@parcel/watcher` changes the identity.
+- [ ] Prove changing only `relay-watcher.js` changes the identity.
+- [ ] Prove mode changes for executable files change the identity or are otherwise authenticated.
+- [ ] Prove metadata that should not affect execution does not create nondeterministic identities.
+- [ ] Update remote directory parsing and GC rules for the new mode-qualified identity without
+      breaking legacy directory recognition.
+
+### Archive safety
+
+- [ ] Permit only regular files and explicitly declared directories; reject devices, FIFOs,
+      sockets, hard links, and symlinks unless a separately reviewed safe policy is adopted.
+- [ ] Reject absolute paths, `..`, drive/UNC paths, path separators inappropriate for the local
+      extraction platform, Windows alternate data streams, device names, trailing spaces/dots, and
+      case-fold collisions.
+- [ ] Enforce compressed size, expanded size, file count, nesting depth, and per-file limits before
+      and during extraction.
+- [ ] Verify the extracted tree exactly matches the manifest with no missing or extra files.
+- [ ] Add deterministic schema, identity, canonicalization, URL, and hostile-archive tests.
+
+Completion evidence required: schema and test files, red/green evidence, canonical test vectors,
+and reviewed compatibility contract.
+
+## Milestone 3 — Build Minimal Self-Contained Runtime Archives
+
+Each runtime must contain only the executable closure required by the relay.
+
+- [ ] Replace or extend `config/scripts/build-relay.mjs` without weakening its existing relay and
+      watcher content-hash guarantees.
+- [ ] Add a clearly named runtime assembly script, for example
+      `config/scripts/build-ssh-relay-runtime.mjs`.
+- [ ] Pin Node and verify downloaded source/binary checksums and upstream signatures.
+- [ ] Build Orca’s patched `node-pty@1.1.0` against the exact bundled Node runtime.
+- [ ] Assert Orca-required patched exports/diagnostics exist; do not silently use an upstream
+      prebuild that omits the patch.
+- [ ] Include exactly one compatible `@parcel/watcher@2.5.6` native optional package.
+- [ ] Include relay JavaScript, watcher child, required runtime JavaScript closure, licenses, SBOM,
+      provenance, and runtime metadata.
+- [ ] Exclude package managers, development dependencies, compilers, sources, caches, build
+      directories, and debug symbols unless an approved diagnostics requirement needs them.
+- [ ] Make archive output deterministic or document and isolate unavoidable nondeterminism.
+- [ ] Verify required executable modes before archiving.
+- [ ] Sign native code according to the platform decisions in Milestone 1.
+- [ ] Verify platform-native signatures/policy on target-native runners after signing and before
+      aggregation; attest the exact verified bytes for the signed manifest.
+- [ ] Run local archive inspection and target-runtime smoke before upload.
+
+### Per-tuple build and executable proof
+
+| Runtime tuple     | Build/provenance | Bundled Node | `node-pty` load + real PTY | Watcher events | Oldest baseline | Native trust | Evidence |
+| ----------------- | ---------------- | ------------ | -------------------------- | -------------- | --------------- | ------------ | -------- |
+| linux-x64-glibc   | [ ]              | [ ]          | [ ]                        | [ ]            | [ ]             | [ ]          | —        |
+| linux-arm64-glibc | [ ]              | [ ]          | [ ]                        | [ ]            | [ ]             | [ ]          | —        |
+| linux-x64-musl    | [ ]              | [ ]          | [ ]                        | [ ]            | [ ]             | [ ]          | —        |
+| linux-arm64-musl  | [ ]              | [ ]          | [ ]                        | [ ]            | [ ]             | [ ]          | —        |
+| darwin-x64        | [ ]              | [ ]          | [ ]                        | [ ]            | [ ]             | [ ]          | —        |
+| darwin-arm64      | [ ]              | [ ]          | [ ]                        | [ ]            | [ ]             | [ ]          | —        |
+| win32-x64         | [ ]              | [ ]          | [ ]                        | [ ]            | [ ]             | [ ]          | —        |
+| win32-arm64       | [ ]              | [ ]          | [ ]                        | [ ]            | [ ]             | [ ]          | —        |
+
+Rules:
+
+- [ ] Real hardware or native virtualized execution is required for release promotion. QEMU or
+      cross-compilation may add coverage but cannot fill the evidence column alone.
+- [ ] A tuple without a trustworthy runtime source or real runner stays disabled.
+- [ ] Every archive executes the exact bundled Node, loads both native dependencies, spawns a real
+      PTY, performs input/resize/exit, and observes create/modify/rename/delete watcher events.
+- [ ] Every build records compiler/toolchain/container image digests and runner architecture.
+
+## Milestone 4 — Make Relay Artifacts Prerequisites of Desktop Builds
+
+- [ ] Add target-native runtime build jobs for every enabled tuple; do not treat a cross-build alone
+      as native execution evidence.
+- [ ] Add platform-native signing jobs. Signed macOS and Windows runtime bytes must return as
+      immutable outputs before final hashes are computed.
+- [ ] Add one fail-closed aggregate job that waits for all required native build/signing outputs,
+      validates them, computes final hashes, builds the canonical manifest, and signs it.
+- [ ] Make Linux, Windows, and macOS desktop build jobs depend on the successful aggregate output.
+- [ ] Download the immutable manifest artifact into every desktop build workspace.
+- [ ] Embed the exact signed manifest and accepted public keys in the packaged desktop.
+- [ ] Prove all desktop variants embed byte-identical manifest contents.
+- [ ] Ensure development builds can use a deterministic local unsigned/development manifest without
+      weakening official-build verification.
+- [ ] Upload the exact prebuilt runtime bytes—not rebuilt equivalents—to the same draft GitHub
+      Release as the app.
+- [ ] Aggregate platform job outputs without clobbering or duplicating asset names.
+- [ ] Extend `config/scripts/verify-release-required-assets.mjs` or add a narrowly named relay gate
+      that verifies every enabled asset, manifest, signature, size, and upload state.
+- [ ] Download every draft asset back through the authenticated release API, verify byte identity,
+      and execute the archive before allowing publication.
+- [ ] Confirm stable, RC, and perf tag identities remain exact and cannot cross channels.
+- [ ] Confirm a partial or failed relay build leaves the release draft and blocks publication.
+- [ ] Confirm artifact upload retries do not change signed bytes or silently replace the manifest.
+- [ ] Define bounded retry/timeout behavior for every native build, signing, aggregate, upload, and
+      read-back job; exhaustion must block downstream jobs.
+- [ ] Make manual signing approval absence, denial, or timeout fail closed rather than allowing an
+      unsigned or stale asset through the aggregate.
+- [ ] Rehearse signing-service failure and recovery of the same draft without changing already signed
+      bytes or accidentally publishing it.
+
+Completion evidence required: release workflow tests, a draft rehearsal, read-back hashes, embedded
+manifest extraction from every packaged app, and blocked-publication failure rehearsal.
+
+## Milestone 5 — Implement Desktop Artifact Selection, Download, and Cache
+
+Suggested concrete modules:
+
+- `src/main/ssh/ssh-relay-artifact-selector.ts`
+- `src/main/ssh/ssh-relay-libc-detection.ts`
+- `src/main/ssh/ssh-relay-artifact-download.ts`
+- `src/main/ssh/ssh-relay-artifact-cache.ts`
+- `src/main/ssh/ssh-relay-artifact-extraction.ts`
+
+### Platform and libc selection
+
+- [ ] Reuse current OS/architecture detection without changing supported relay-platform parsing.
+- [ ] Add marked, noise-resistant, no-Node libc probes.
+- [ ] Prefer `getconf GNU_LIBC_VERSION` when present; parse only output following Orca’s marker.
+- [ ] Detect musl through marked `ldd --version` output and known loader paths without treating
+      arbitrary startup text as evidence.
+- [ ] Validate required libc/libstdc++/kernel/OS versions against manifest constraints.
+- [ ] Treat absent, ambiguous, conflicting, or unparseable results as unknown and choose proven
+      legacy behavior in `auto` mode.
+- [ ] Cover GNU coreutils, BusyBox, Alpine, containers, old glibc, Rosetta, Windows, macOS, startup
+      noise, missing commands, localization, cancellation, and `MaxSessions=1`.
+
+### Manifest verification and exact URL resolution
+
+- [ ] Load the embedded manifest for official builds and verify its signature before trusting fields.
+- [ ] Verify the manifest-authenticated target-native attestation and exact byte hashes portably; do
+      not assume a macOS client can run Authenticode tooling or a Windows client can run `codesign`.
+- [ ] Resolve the expected tuple and content ID while fully offline.
+- [ ] Construct the exact `/releases/download/<tag>/<asset>` URL without an API lookup.
+- [ ] Reject redirects that violate the approved GitHub release-asset origin policy.
+- [ ] Ensure authorization, cookies, proxy credentials, and custom headers do not leak across redirect
+      origins.
+- [ ] Use Electron networking that respects supported system proxy and certificate behavior.
+
+### Download and local cache
+
+- [ ] Store archives and extracted trees under an app-owned cache, keyed by signed content identity.
+- [ ] Stream downloads into exclusive temporary files; never buffer a full runtime in memory.
+- [ ] Apply download size and time budgets while streaming.
+- [ ] Verify archive SHA-256 before extraction.
+- [ ] Extract into an exclusive temporary directory with all archive-safety checks from Milestone 2.
+- [ ] Verify the exact expanded tree before atomically publishing the cache entry.
+- [ ] Coordinate cache ownership across multiple Orca processes and windows.
+- [ ] Recover stale download/extraction locks without deleting an active writer.
+- [ ] Never select partial files, partial directories, or entries with a failed verification record.
+- [ ] Re-verify cached metadata and expected identity before use; define when full file rehashing is
+      required.
+- [ ] Implement bounded eviction that never removes an in-use entry.
+- [ ] Handle read-only cache, permission failures, disk full, quota, inode exhaustion, cancellation,
+      crash, corruption, and concurrent download deterministically.
+- [ ] Preserve `ORCA_RELAY_PATH` for explicit development/test use with an official-build safety
+      boundary.
+- [ ] Prefetch only last-known target tuples under an explicit size/network policy; prefetch must not
+      block app startup or a normal connection.
+
+### Required offline/cache cases
+
+| Remote runtime    | Local verified cache | Client internet | Expected bundled behavior                                               | Legacy/error behavior                                        | Evidence |
+| ----------------- | -------------------- | --------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------ | -------- |
+| Present, matching | Any                  | Offline         | Launch remote cache without GitHub                                      | None                                                         | —        |
+| Missing           | Present              | Offline         | Transfer local cache over SSH                                           | None                                                         | —        |
+| Missing           | Missing              | Online          | Download locally, verify, transfer                                      | Fallback only on eligible failure                            | —        |
+| Missing           | Missing              | Offline         | Bundled unavailable                                                     | Proven legacy or precise error                               | —        |
+| Partial/corrupt   | Present              | Offline         | Quarantine remote entry; replace from verified local cache              | Fail closed if verified reinstall fails; no automatic legacy | —        |
+| Missing           | Corrupt              | Online          | Quarantine local entry; redownload and fully verify                     | Fail closed if recovery fails; no automatic legacy           | —        |
+| Missing           | Corrupt              | Offline         | Quarantine and reject corrupt cache                                     | Fail closed; no automatic legacy                             | —        |
+| Corrupt           | Missing              | Any             | Quarantine remote entry; recover only from newly verified bundled bytes | Fail closed if recovery is unavailable/fails                 | —        |
+
+## Milestone 6 — Add Bounded Runtime Transfer for Every SSH Transport
+
+Current behavior must not be assumed adequate for a much larger runtime:
+
+- POSIX system SSH currently streams a tar archive and requires remote `tar`.
+- Windows system SSH currently collects the tree and sends one JSON/base64 package.
+- SFTP currently walks files serially and does not preserve executable modes.
+
+### Shared transfer contract
+
+- [ ] Define one transport-neutral source-tree contract based on the verified manifest.
+- [ ] Pre-scan and reject local source mutation, symlinks, special files, extra files, and path
+      collisions before creating remote files.
+- [ ] Stream files with bounded buffers; prohibit whole-tree memory materialization.
+- [ ] Pass one AbortSignal through enumeration, channel creation, reads, writes, permission repair,
+      and remote cleanup.
+- [ ] Close and await every local stream, SSH channel, child process, SFTP session, and cleanup task
+      on success, failure, cancellation, and timeout.
+- [ ] Track transferred bytes/file counts for progress and bounded diagnostics without logging paths.
+- [ ] Restore every executable mode declared by the manifest, including bundled Node and
+      `spawn-helper`, before validation.
+- [ ] Require exclusive per-file staging so no concurrent writer or launcher can observe a partial
+      file as complete.
+
+### POSIX system SSH
+
+- [ ] Capability-probe remote tar with a narrow cache scoped to the SSH host/connection.
+- [ ] Keep streaming tar as an optional fast path when proven available and compatible.
+- [ ] Add a no-tar bounded file-stream path: frame each manifest file locally, open an authenticated
+      SSH exec channel, and stream raw bytes through stdin into its exclusive staged path using only
+      the declared POSIX shell/file primitives.
+- [ ] Prove the no-tar path does not invoke remote Node, Python, Perl, archive tools, `sha256sum`, or
+      `shasum`.
+- [ ] Preserve remote path quoting and avoid shell injection for spaces and non-ASCII homes.
+- [ ] Verify local and remote tar failures, pipeline failures, and cancellation are all observed and
+      joined.
+- [ ] Fail with a compatibility classification when a required POSIX primitive is missing or has
+      incompatible semantics; do not improvise a text/base64 transfer.
+
+### Windows system SSH
+
+- [ ] Replace whole-tree JSON/base64 buffering with a framed or per-file bounded binary stream.
+- [ ] Implement against the declared PowerShell/.NET baseline using binary stdin/file APIs and
+      exclusive staged paths; do not depend on implicit console text encodings.
+- [ ] Avoid command-line length, PowerShell string, and full-input buffering limits.
+- [ ] Handle case-insensitive collisions, reserved names, long paths, endpoint-protection locks, and
+      partial writes.
+- [ ] Prove binary fidelity without relying on text encoding.
+- [ ] Fail with a compatibility classification when the declared PowerShell/.NET primitives are
+      missing or incompatible.
+
+### SFTP
+
+- [ ] Add bounded concurrency without exceeding restrictive server session/channel limits.
+- [ ] Preserve per-file abortability and close handles deterministically.
+- [ ] Restore modes after upload and verify mode-repair failure is fatal before finalization.
+- [ ] Compare serial and bounded-concurrency behavior on high-latency SSH.
+
+### Transfer validation
+
+- [ ] Test zero-byte, large, many-small-file, and maximum-allowed trees.
+- [ ] Test required-command absence one primitive at a time on POSIX and Windows.
+- [ ] Test supported and unsupported BusyBox command variants, including byte fidelity and exit-code
+      behavior.
+- [ ] Test source mutation and local symlink replacement during upload.
+- [ ] Test network interruption at beginning, middle, final file, permission repair, and sentinel
+      write.
+- [ ] Test local and remote disk full, quota, inode exhaustion, read-only target, noexec target,
+      Windows antivirus lock, and SSH channel closure.
+- [ ] Measure peak RSS, bytes buffered, open file handles, channels, duration, and cancellation
+      settlement against Milestone 1 budgets.
+- [ ] Prove cancelled transfer performs no later writes.
+
+## Milestone 7 — Install, Verify, Launch, Reconnect, and Garbage-Collect
+
+Suggested concrete modules:
+
+- `src/main/ssh/ssh-relay-runtime-transfer.ts`
+- `src/main/ssh/ssh-relay-runtime-validation.ts`
+- `src/main/ssh/ssh-relay-bootstrap-mode.ts`
+
+- [ ] Refactor `ssh-relay-deploy.ts` without adding a max-lines disable; split by domain
+      responsibility where necessary.
+- [ ] Resolve expected bundled content identity before remote install-state probing.
+- [ ] Verify embedded manifest signature, tuple, limits, archive SHA-256, and exact extracted tree on
+      the client before transfer begins.
+- [ ] Use mode-qualified, content-addressed remote directories and locks.
+- [ ] Upload into a mode-qualified partial/staging directory that no launcher or GC can treat as
+      complete.
+- [ ] Treat local verification plus authenticated SSH transfer into exclusive staging as the
+      pre-execution integrity boundary; document that a hostile authenticated account is out of scope.
+- [ ] Do not require a remote hash utility. Run bundled Node from the transferred staging path as the
+      first staged binary execution, verify its exact version, and use it to hash every manifest file.
+- [ ] Compare the complete staged-tree sizes and SHA-256 values before any sentinel or publish step.
+- [ ] Load `node-pty` and `@parcel/watcher` through bundled Node.
+- [ ] Repeat target-native execution/policy probes before finalization; any native-trust failure is an
+      integrity/security failure even though transfer may already have occurred.
+- [ ] Run a minimal real PTY input/resize/exit smoke and watcher event smoke before finalization.
+- [ ] Write structured `.install-complete` contents containing schema, mode, content ID, manifest
+      digest, and validation version; do not use an empty sentinel.
+- [ ] Assert the ordering: full-tree hash comparison, native loads, PTY/watcher smoke, then completion
+      sentinel and atomic publication. No earlier stage may write a success sentinel.
+- [ ] Atomically publish the completed install or otherwise prove no observer can see it as complete
+      before validation finishes.
+- [ ] On warm reconnect, require the expected structured sentinel identity plus required-file
+      presence and signed-manifest size metadata before treating the directory as initially validated.
+- [ ] Do not full-tree rehash every warm launch. Trust the structured initial-install proof under the
+      completed-directory immutability assumption to protect latency; explicitly document that the
+      sentinel is not ongoing proof against post-install filesystem mutation.
+- [ ] Treat any detected warm-cache absence, size/hash mismatch, unexpected file, or changed sentinel
+      as integrity failure: quarantine it, recover only from freshly verified bundled bytes, and fail
+      closed without automatic legacy if recovery cannot complete.
+- [ ] Launch `relay.js` with bundled Node and an environment that cannot accidentally resolve remote
+      user packages ahead of bundled dependencies.
+- [ ] Preserve protocol-handshake and version-mismatch behavior.
+- [ ] Preserve `MaxSessions=1` sequential fallback for probes.
+- [ ] Preserve concurrent install locking, stale-lock recovery, cross-version isolation, reconnect,
+      PTY reattach, watcher isolation, and best-effort GC.
+- [ ] Ensure GC recognizes bundled, legacy, partial, locked, active, and malformed directories and
+      never deletes a live version.
+- [ ] Ensure a failed bundled install never mutates a completed legacy install or running relay.
+- [ ] Confirm primary-path command capture contains no npm, curl, wget, registry, compiler, Python,
+      system-Node, `sha256sum`, or `shasum` invocation.
+
+Completion evidence required: deterministic install/failure tests, built-runtime harness, live SSH
+connect/reconnect/upgrade/downgrade, PTY/watcher proof, and command audit.
+
+## Milestone 8 — Implement a Safe, Explicit Fallback State Machine
+
+Modes:
+
+- `auto`: bundled primary; eligible availability/compatibility failures may use proven legacy.
+- `bundled`: bundled only; fail with exact stage and recovery guidance.
+- `legacy`: current embedded relay plus coherent remote Node/npm behavior.
+
+The public per-target Beta choice maps `bundled-auto` configuration to internal `auto` behavior.
+Missing, unknown, or disabled configuration maps to `legacy`; forced `bundled` remains an
+engineering/support control.
+
+- [ ] Add the versioned per-target runtime-mode field and prove existing, missing, malformed,
+      imported, and newly created target configurations resolve to `legacy` unless explicitly
+      opted in.
+- [ ] Add the Beta-tagged option to SSH target add and edit surfaces using the existing design-system
+      Beta treatment; persist it only for that target.
+- [ ] Prove toggling the option does not mutate or restart a live relay and takes effect only on the
+      next connection or explicit reconnect.
+- [ ] For fail-closed Beta errors, provide an explicit local “disable Beta and reconnect” recovery
+      action that updates the target before starting legacy; never disguise it as automatic fallback.
+- [ ] Record privacy-safe tuple, transport, stage, duration, outcome, and fallback reason under
+      existing telemetry consent without hostname, username, path, command, or target identity.
+
+### State and cancellation
+
+- [ ] Model explicit states for manifest resolution, local-cache lookup, download, extraction,
+      transfer, remote verification, launch, bundled cleanup, legacy bootstrap, and connected.
+- [ ] Give every state a named timeout budget and child AbortSignal derived from one parent.
+- [ ] Replace timeout-only `Promise.race` behavior where underlying deployment can continue after the
+      caller fails.
+- [ ] On eligible bundled failure, abort, close, and await all bundled work before legacy begins.
+- [ ] Invalidate callbacks by generation so late completion cannot write a sentinel, launch a relay,
+      report success, or mutate cache/install state.
+- [ ] Use separate bundled/legacy identities, locks, partial dirs, completion records, and GC rules.
+- [ ] Ensure two simultaneous clients choosing different modes cannot modify one another’s install.
+- [ ] Preserve the original bundled failure and fallback outcome in bounded diagnostics.
+
+### Failure classification
+
+- [ ] Classify GitHub unavailable, client offline, asset missing, approved redirect failure, proxy
+      failure, local cache unavailable, unsupported tuple, and bundled runtime incompatibility.
+- [ ] Classify signature mismatch, archive hash mismatch, unsafe archive, extracted/transferred-tree
+      mismatch, bundled-Node corruption, and native-signature failure as integrity/security failures.
+- [ ] Permit automatic legacy only for explicitly classified availability/compatibility failures and
+      only for remote tuples with current legacy evidence.
+- [ ] Make every integrity/security failure fail closed in `auto`; assert no legacy process, lock,
+      partial directory, or diagnostic “fallback success” is created.
+- [ ] Never execute rejected bytes. Delete/quarantine them according to an explicit policy.
+- [ ] If legacy prerequisites are unproved or fail, return an error that includes bundled stage,
+      fallback stage, actionable recovery, and no sensitive paths.
+- [ ] Forced `bundled` never silently changes mode.
+- [ ] Forced `legacy` never performs a GitHub runtime download.
+
+### Race and fallback proof
+
+- [ ] Timeout during download, extraction, SFTP transfer, system-SSH transfer, chmod, hash, PTY
+      smoke, watcher smoke, sentinel write, and launch.
+- [ ] Cancellation while a sibling connection waits on the bundled lock.
+- [ ] Bundled failure while an old bundled relay remains live.
+- [ ] Bundled failure while legacy install is complete and live.
+- [ ] Legacy failure after bundled cleanup.
+- [ ] App shutdown during every state.
+- [ ] Assert zero post-fallback bundled writes, processes, channels, locks, and callbacks.
+
+## Milestone 9 — Diagnostics, Progress, Support, and Privacy
+
+- [ ] Define stable stage codes for selection, manifest, cache, download, extraction, transfer,
+      permission repair, remote hash, native probe, smoke, launch, fallback, and connected.
+- [ ] Define stable fallback reason codes without embedding remote output, usernames, hostnames, IPs,
+      repository names, or paths.
+- [ ] Preserve exact low-level errors in local diagnostic logs with existing redaction boundaries.
+- [ ] Add aggregate duration/byte/count metrics only through existing authorized diagnostics or
+      telemetry mechanisms; do not imply authorization for a new backend.
+- [ ] Provide progress labels for operations exceeding the style-guide thresholds; avoid flashing
+      progress for warm cache hits.
+- [ ] Keep connection controls disabled immediately while maintaining stable focus.
+- [ ] Document `auto`, `bundled`, and `legacy` support overrides and their intended support use.
+- [ ] Add troubleshooting for client offline, remote offline, missing asset, unsupported tuple,
+      signature failure, noexec home, disk full, proxy, and fallback failure.
+- [ ] Make user-visible wording state facts only after the corresponding stage result exists.
+- [ ] Add tests for diagnostic bounds, redaction, stage ordering, duplicate suppression, and
+      cancellation/fallback reporting.
+
+## Milestone 10 — Deterministic Test and Fault-Injection Coverage
+
+### Schema, selector, and trust
+
+- [ ] Canonical manifest serialization golden vectors.
+- [ ] Valid/invalid signatures, unknown key IDs, rotated keys, revoked keys, wrong tag, rollback, and
+      unsupported schema.
+- [ ] Valid/tampered/missing target-native trust attestations and attested-byte hash mismatches,
+      verified from clients running a different OS than the target tuple.
+- [ ] Every OS/architecture/libc selection plus unknown/conflicting/noisy probes.
+- [ ] Minimum-version boundaries for libc, libstdc++, kernel, macOS, and Windows.
+- [ ] Exact stable/RC/perf URL and channel mapping.
+
+### Cache and download
+
+- [ ] 200 and approved redirects, redirect loop, wrong origin, missing `Location`, 404, 429 with
+      retry policy, 5xx, timeout, proxy auth, certificate failure, truncated body, oversized body,
+      wrong content length, wrong hash, and deleted asset.
+- [ ] Cold, warm, offline, corrupt, partial, concurrent, multi-process, stale-lock, eviction, read-only,
+      permission, local disk full, quota, and inode cases.
+- [ ] Archive traversal, absolute path, symlink/hardlink/device, Windows name/path, case collision,
+      archive bomb, too many files, deep nesting, unexpected file, and source mutation cases.
+- [ ] Assert bad manifest signature, archive hash, archive safety, extracted-tree hash, and native
+      signature each fail closed in `auto` without entering legacy.
+
+### Install and fallback
+
+- [ ] Full identity change and remote-directory change for every executable component.
+- [ ] Lock first acquisition, waiter, concurrent probe, stale recovery, cancellation, and host
+      isolation.
+- [ ] Partial install is never complete; structured sentinel must match expected mode/content/schema.
+- [ ] Transfer corruption is detected before finalization.
+- [ ] Missing remote `sha256sum`/`shasum` still succeeds through bundled-Node full-tree hashing.
+- [ ] Corrupt one uploaded file after transfer and before verification; prove no sentinel is written
+      and no relay launches.
+- [ ] Corrupt or prevent execution of the transferred bundled Node; prove verification fails before
+      sentinel and does not automatically enter legacy as an integrity failure.
+- [ ] Corrupt local and completed remote caches; prove quarantine plus recovery from freshly verified
+      bytes, or fail-closed behavior with zero automatic legacy when recovery is unavailable/fails.
+- [ ] Mutate a warm remote file/sentinel and prove every detected case fails closed. Separately prove
+      an unchanged warm path trusts initial-install proof without a full-tree rehash and meets latency.
+- [ ] Instrument stage ordering and prove tree hash → native loads → PTY/watcher smoke → sentinel →
+      publish/launch with no alternative success path.
+- [ ] Existing legacy and bundled installs never overlap or mutate.
+- [ ] All fallback transition and stale-generation cases from Milestone 8.
+
+### Relay behavior
+
+- [ ] Protocol handshake and frame compatibility.
+- [ ] PTY spawn, attach, input, resize, signal, exit, reconnect, and error mapping.
+- [ ] Filesystem read/write/stat/readdir/search and bulk streaming.
+- [ ] Filesystem watch registration, overflow, cancellation, crash isolation, and recovery.
+- [ ] Git status/diff/blob/worktree/submodule/ignore and response streaming using Git 2.25-compatible
+      commands and existing capability rules.
+- [ ] Agent hooks, managed hook installation, remote CLI, preflight, port scan, subprocess, and aborts.
+- [ ] Grace-period detach/reattach, two clients, app restart, remote restart, upgrade, downgrade, and
+      GC.
+
+## Milestone 11 — Live Platform and Environment Matrix
+
+Use a risk-based two-layer matrix. This does **not** claim every client × remote tuple combination.
+Every required cell must contain one or more evidence IDs rather than a bare checkmark or prose.
+
+### Layer A — every enabled remote tuple across both transport families
+
+Each cell’s evidence must cover a native real runner, no Node/npm/compiler, blocked remote egress,
+PTY, watcher, every relay RPC family, reconnect/upgrade, and eligible legacy fallback. POSIX system
+SSH evidence includes the no-tar path; Windows system SSH is a mandatory distinct path.
+
+| Remote tuple      | Built-in SSH/SFTP evidence ID | System SSH evidence ID | `MaxSessions=1` evidence ID | Baseline/native-policy evidence ID |
+| ----------------- | ----------------------------- | ---------------------- | --------------------------- | ---------------------------------- |
+| linux-x64-glibc   | —                             | —                      | —                           | —                                  |
+| linux-arm64-glibc | —                             | —                      | —                           | —                                  |
+| linux-x64-musl    | —                             | —                      | —                           | —                                  |
+| linux-arm64-musl  | —                             | —                      | —                           | —                                  |
+| darwin-x64        | —                             | —                      | —                           | —                                  |
+| darwin-arm64      | —                             | —                      | —                           | —                                  |
+| win32-x64         | —                             | —                      | —                           | —                                  |
+| win32-arm64       | —                             | —                      | —                           | —                                  |
+
+### Layer B — every supported client against representative remote families
+
+Each supported client OS/architecture must prove resolver/cache behavior and both transfer families
+against representative POSIX and Windows remotes. This layer catches client-specific process,
+filesystem, proxy/certificate, executable-bit, quoting, and cache behavior without pretending to be
+a full Cartesian product.
+
+| Client        | Resolver/cache evidence ID | Built-in → POSIX evidence ID | Built-in → Windows evidence ID | System SSH → POSIX evidence ID | System SSH → Windows evidence ID |
+| ------------- | -------------------------- | ---------------------------- | ------------------------------ | ------------------------------ | -------------------------------- |
+| macOS x64     | —                          | —                            | —                              | —                              | —                                |
+| macOS arm64   | —                          | —                            | —                              | —                              | —                                |
+| Linux x64     | —                          | —                            | —                              | —                              | —                                |
+| Linux arm64   | —                          | —                            | —                              | —                              | —                                |
+| Windows x64   | —                          | —                            | —                              | —                              | —                                |
+| Windows arm64 | —                          | —                            | —                              | —                              | —                                |
+
+- [ ] Define and record the representative POSIX and Windows remotes used by Layer B.
+- [ ] Require Windows remote/system-SSH and `MaxSessions=1` evidence before any Windows remote tuple
+      is enabled.
+- [ ] Reject promotion if any required cell still contains `—`; do not roll up partial evidence into
+      an unsupported “all combinations” claim.
+
+### Required environment variants
+
+- [ ] Exact #8450: system Node without npm plus usable NVM below `.bashrc` non-interactive guard.
+- [ ] No Node, npm, Python, make, compiler, registry, curl, or wget.
+- [ ] No tar, `sha256sum`, or `shasum`; no-tar transfer and bundled-Node verification still succeed.
+- [ ] Remove each required POSIX and Windows bootstrap primitive in turn and verify deterministic
+      compatibility classification.
+- [ ] Remote egress denied at the network layer and audited for attempted connections.
+- [ ] `~/.npmrc` with `ignore-scripts=true`, broken registry, and read-only npm cache.
+- [ ] `MaxSessions=1`, noisy startup, slow SSH, packet interruption, proxy jump, and system SSH.
+- [ ] Spaces, Unicode, long paths, case collisions, restrictive umask, read-only home, noexec home,
+      disk quota, inode exhaustion, and endpoint-protection locks.
+- [ ] Supported and unsupported BusyBox/Alpine primitive variants, old supported glibc boundary,
+      containerized host, Rosetta, Windows OpenSSH, and enterprise native-code policy.
+- [ ] Two Orca clients connecting/installing simultaneously.
+- [ ] Existing live PTY during app/relay upgrade and downgrade.
+- [ ] Remote reboot, app crash/restart, interrupted first install, stale lock, and GC with a live old
+      relay.
+
+## Milestone 12 — Performance and Resource Regression Gates
+
+Baseline measurements must be captured before product behavior changes.
+
+- [ ] Record legacy cold install p50/p95, warm connect p50/p95, transferred bytes, remote CPU/RSS,
+      desktop CPU/RSS, process/channel/file counts, and failure timeout on the same machines used for
+      comparison.
+- [ ] Measure bundled cold download + transfer, local-cache transfer, remote-cache launch, GitHub
+      failure-to-fallback, and client-offline behavior.
+- [ ] Test at 1, 10, and 100 Mbps with 50, 100, and 200 ms latency and defined loss/jitter.
+- [ ] Prove remote-cache warm connect meets the numeric Milestone 1 budget.
+- [ ] Prove local-cache transfer and cold download meet the numeric Milestone 1 budgets.
+- [ ] Prove SFTP and system-SSH transfer peak memory remain bounded by the numeric budgets.
+- [ ] Prove file count does not cause unbounded sequential round trips or channel fanout.
+- [ ] Prove cache verification/eviction does not block Electron startup or the renderer main thread.
+- [ ] Prove failed bundled attempts do not add an unacceptable delay before eligible legacy fallback.
+- [ ] Record before/after results, machine identity, network shaping, commit SHA, command, raw artifact,
+      and statistical interpretation.
+- [ ] Add demotion thresholds for latency, memory, transfer flakes, cache corruption, and fallback
+      delay.
+
+## Milestone 13 — Supply-Chain and Security Completion
+
+- [ ] Write the explicit threat model and trust boundaries.
+- [ ] Generate and publish an SBOM per runtime and aggregate release.
+- [ ] Record build provenance, source revisions, toolchain/container digests, and native signatures.
+- [ ] Verify official Node checksums/signatures before assembly and preserve native trust where
+      possible.
+- [ ] Verify Orca-built native code signatures on target macOS and Windows policies.
+- [ ] Verify target-native attestation generation/read-back, signed-manifest authentication, portable
+      client verification, and pre-finalization target policy probes on exact bytes.
+- [ ] Exercise manifest key rotation and dual-key migration in a release rehearsal.
+- [ ] Exercise compromised/revoked-key response by shipping a new desktop build with newly embedded
+      keys/manifest; prove there is no mutable freshness or `latest` lookup.
+- [ ] Exercise anti-rollback across stable, RC, perf, desktop upgrade, and desktop downgrade.
+- [ ] Add dependency and Node CVE monitoring with a named owner and response SLA.
+- [ ] Exercise an emergency runtime refresh through a new desktop tag/build, embedded manifest,
+      identity, release, download, remote coexistence, and GC; prove an installed old client remains
+      pinned to its original manifest.
+- [ ] Review archive parsing, redirect handling, cache permissions, local TOCTOU, remote quoting,
+      native loading search paths, and diagnostic redaction.
+- [ ] Complete security review before `auto` becomes default for any stable tuple.
+
+## Milestone 14 — Release, Rollout, Rollback, and Fallback Retirement
+
+### Asset-only
+
+- [ ] Publish complete runtime assets and signed manifest without production consumption.
+- [ ] Run read-back, direct public URL, archive execution, and packaged-manifest comparison.
+- [ ] Accumulate build/release flake and duration evidence.
+- [ ] Rehearse native build/signing timeout, bounded retry success/exhaustion, manual approval
+      absence/denial, signing failure, aggregate failure, and recovery of an unpublished draft.
+
+### Per-target Beta — legacy remains default
+
+- [ ] Ship the Beta-tagged per-target option in RC and stable builds with every existing and new
+      target defaulting to `legacy`.
+- [ ] Enable forced `bundled` only for engineering and support diagnostics; normal testers use the
+      per-target `bundled-auto` Beta choice.
+- [ ] Verify diagnostics and support recovery for every failure class.
+- [ ] Run the full enabled tuple matrix and security/performance gates.
+- [ ] Exercise forced `legacy` rollback from the same build.
+- [ ] Accumulate approved privacy-safe Beta usage, success, classified fallback, integrity failure,
+      latency, PTY/watcher, reconnect, and support evidence per exact tuple.
+
+### Future default-on evaluation — separately authorized
+
+- [ ] Obtain a separate reviewed decision before changing any target's default from `legacy`; this
+      issue and the Beta implementation do not authorize that change.
+- [ ] Consider default `auto` only for tuples whose artifact, live matrix, Beta usage, and support
+      evidence are complete.
+- [ ] Require three consecutive RC builds with no unexplained fallback, cache-corruption, PTY,
+      watcher, reconnect, native-policy, or release failures.
+- [ ] Test GitHub outage, client offline, remote offline, missing asset, unsupported tuple, and
+      integrity failure from the packaged RC.
+- [ ] Prove every integrity/security failure in that RC fails closed without automatic legacy.
+- [ ] Confirm non-enabled tuples deterministically retain proven legacy behavior.
+
+### Stable Beta soak
+
+- [ ] Publish the opt-in Beta to stable only after its release-blocking gates pass against exact
+      uploaded bytes; stable publication still leaves every target on `legacy` unless opted in.
+- [ ] Keep automatic legacy fallback for at least the decided number of stable cycles.
+- [ ] Monitor approved privacy-safe success/fallback/error signals and support reports.
+- [ ] Define immediate demotion/rollback signals and owner.
+- [ ] Exercise rollback without deleting live bundled or legacy remote installs.
+- [ ] Do not narrow fallback until every retirement criterion below is satisfied.
+
+### Fallback retirement criteria
+
+- [ ] Every claimed supported tuple has stable real-environment bundled proof.
+- [ ] Both layers of the risk-based client/transport/environment matrix are complete with an evidence
+      ID in every required cell.
+- [ ] Soak duration and release count meet the Milestone 1 policy.
+- [ ] No unexplained fallback remains.
+- [ ] GitHub outage and offline behavior remain acceptable without hidden remote requirements.
+- [ ] Support has a tested downgrade/recovery path for old app versions and old remote installs.
+- [ ] A separate reviewed decision explicitly authorizes removing or narrowing remote npm fallback.
+
+## Proposed PR / Work-Package Split
+
+Update status and evidence as work begins. Do not combine these into one large behavior switch.
+
+| Work package              | Scope                                                                                      | Default behavior change     | Status                                                                       | PR/evidence                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------ | --------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| 0. #8450 legacy fix       | Coherent Node/npm selection and live repro                                                 | Fixes legacy selection only | Implementation/live proof complete; commit/PR boundary and full lint pending | E-M0-UNIT-001, E-M0-LIVE-001, E-M0-STATIC-001, E-M0-LINT-001 |
+| 1. Contract and selectors | Manifest schema, identity, platform/libc selection, hostile inputs                         | None                        | Not started                                                                  | —                                                            |
+| 2. Runtime builds         | Per-tuple assembly, native smoke, SBOM/provenance/signing                                  | None                        | Not started                                                                  | —                                                            |
+| 3. Release publication    | Prerequisite DAG, embedded manifest, draft upload/read-back gates                          | Asset-only                  | Not started                                                                  | —                                                            |
+| 4. Desktop resolver/cache | Verified download, extraction, cache, offline behavior                                     | None/forced mode only       | Not started                                                                  | —                                                            |
+| 5. Transfer/install       | Bounded transports, structured sentinel, bundled launch behind per-target Beta/forced mode | Per-target opt-in only      | Not started                                                                  | —                                                            |
+| 6. Fallback/diagnostics   | Abort-and-join state machine, mode isolation, reason codes, target-mode configuration/UI   | Per-target Beta only        | Not started                                                                  | —                                                            |
+| 7. Live gates/rollout     | Matrix, security, performance, release promotion                                           | Per-tuple staged            | Not started                                                                  | —                                                            |
+
+Every PR must document:
+
+- [ ] Named invariant and motivating issue.
+- [ ] Exact product behavior changed and deliberately unchanged.
+- [ ] Performance-risk inventory and numeric budgets.
+- [ ] Correctness oracle and exact commands.
+- [ ] Platform/provider/transport coverage: covered, unaffected, or accepted gap.
+- [ ] Red/green evidence where a bug or failure contract is added.
+- [ ] Residual gaps and fallback behavior.
+- [ ] Rollback/demotion rule.
+- [ ] Checklist and HTML plan updates.
+- [ ] No unrelated worktree changes included.
+
+## Verification Command Inventory
+
+Do not mark commands passed here until they have actually run on the implementation commit. Add new
+focused commands as their scripts/tests are introduced.
+
+### Existing focused commands
+
+- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-node-resolution.test.ts` (E-M0-UNIT-001)
+- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-native-deps-install.test.ts` (E-M0-UNIT-001)
+- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-versioned-install.test.ts` (E-M0-UNIT-001)
+- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-deploy.test.ts` (E-M0-UNIT-001)
+- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-cross-version-isolation.test.ts` (E-M0-UNIT-001)
+- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-platform-detection.test.ts` (E-M0-UNIT-001)
+- [ ] `pnpm exec vitest run --config config/vitest.config.ts src/relay/pty-handler.test.ts src/relay/fs-handler.test.ts src/relay/subprocess.test.ts`
+- [x] `pnpm run build:relay` (E-M0-LIVE-001)
+- [ ] `node config/scripts/relay-watcher-fault-harness.mjs`
+- [ ] `pnpm run test:e2e:ssh-docker-watcher-isolation`
+- [ ] `pnpm run test:e2e:ssh-docker-perf`
+- [x] `pnpm run typecheck` (E-M0-STATIC-001)
+- [ ] `pnpm run lint`
+- [x] `pnpm run check:max-lines-ratchet` (E-M0-STATIC-001)
+
+BLOCKED: `pnpm run lint` reaches the untouched
+`src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx:31` and fails the type-aware
+switch-exhaustiveness gate for missing `active | inactive` cases (E-M0-LINT-001). The unblock
+condition is a separately owned fix or explicit reviewed baseline for that existing failure; WP0
+must not absorb the unrelated renderer change.
+
+### Milestone 0 commands added
+
+- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts` (E-M0-UNIT-001)
+- [x] `pnpm run test:e2e:ssh-node-toolchain-resolution` (E-M0-LIVE-001)
+
+### Commands/scripts that must be added or formally identified
+
+- [ ] Manifest/schema/identity unit-test command.
+- [ ] Per-tuple runtime assembly command.
+- [ ] Per-tuple archive inspection and native smoke command.
+- [ ] Embedded-manifest extraction/comparison command for every packaged app.
+- [ ] Draft release relay-asset completeness/read-back command.
+- [ ] Release-DAG failure rehearsal covering native signing, aggregate, timeout/retry/manual approval,
+      and recovered draft behavior.
+- [ ] Hostile-archive and cache fault suite.
+- [ ] Full-size transfer memory/cancellation suite for SFTP, POSIX system SSH, and Windows system SSH.
+- [ ] Remote primitive/binary-fidelity suite for missing commands, BusyBox variants, no-tar POSIX,
+      and bounded PowerShell/.NET Windows transfer.
+- [ ] Remote verification-order suite for absent hash tools, corrupt upload, broken bundled Node, and
+      sentinel/publish ordering.
+- [ ] No-Node/no-egress packaged Electron SSH E2E.
+- [ ] Full relay RPC conformance E2E using the packaged runtime.
+- [ ] Upgrade/downgrade/concurrent-client/live-PTY E2E.
+- [ ] macOS Gatekeeper and Windows Authenticode/WDAC/AV rehearsal commands.
+- [ ] Network-shaped cold/warm/fallback performance report.
+- [ ] Manifest key rotation/revocation/anti-rollback rehearsal.
+
+## Verification Evidence Ledger
+
+Append entries; do not rewrite history. If evidence becomes invalid after code or matrix changes,
+mark it superseded and link the replacement.
+
+Required entry format:
+
+```text
+### E-<AREA>-<NNN> — <short title>
+
+- Date:
+- Commit SHA / PR:
+- Runner: <OS, version, architecture, native/emulated>
+- Remote: <OS, version, architecture, libc, relevant restrictions>
+- Transport/network:
+- Exact command:
+- Result: PASS | FAIL | FLAKE | SUPERSEDED
+- Duration and resource metrics:
+- Artifact/log/trace link:
+- Oracle proved:
+- Does not prove:
+- Checklist items satisfied:
+- Follow-up:
+```
+
+### E-PLAN-001 — Initial checklist creation
+
+- Date: 2026-07-14
+- Commit SHA / PR: uncommitted working tree
+- Runner: documentation-only local worktree
+- Remote: not applicable
+- Transport/network: not applicable
+- Exact command:
+
+  ````sh
+  node --input-type=module -e 'import fs from "node:fs"; import path from "node:path"; import { marked } from "marked"; const file="docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md"; const source=fs.readFileSync(file,"utf8"); const html=marked.parse(source); const links=[...source.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map(m=>m[1]).filter(h=>!(/^(https?:|#)/.test(h))); for(const href of links){if(!fs.existsSync(path.resolve(path.dirname(file),href))) throw new Error(`Missing link: ${href}`)} const fences=(source.match(/^```/gm)||[]).length; if(fences%2) throw new Error(`Unbalanced fences: ${fences}`); const open=(source.match(/^- \[ \]/gm)||[]).length; const done=(source.match(/^- \[[xX]\]/gm)||[]).length; if(done) throw new Error(`Unexpected completed boxes: ${done}`); if(!html.includes("type=\"checkbox\"")) throw new Error("Task lists did not render"); console.log(`PASS links=${links.length} fences=${fences} open=${open} complete=${done}`)'
+  ````
+
+- Result: SUPERSEDED after subsequent review-driven plan expansion; originally PASS for document
+  creation only.
+- Duration and resource metrics: 1.0 second; `links=1 fences=2 open=349 complete=0`.
+- Artifact/log/trace link: this file and the linked HTML plan
+- Oracle proved: the living checklist exists and covers implementation, validation, release, and
+  rollback work.
+- Does not prove: any product behavior, artifact build, SSH runtime, platform, security, release, or
+  performance claim.
+- Checklist items satisfied: none of the implementation milestones.
+- Follow-up: replaced by E-PLAN-002; close Milestone 1 decisions before production implementation.
+
+### E-PLAN-002 — Post-round-3 plan validation
+
+- Date: 2026-07-14
+- Commit SHA / PR: uncommitted planning worktree; implementation not started
+- Runner: macOS arm64 local documentation validation
+- Remote: not applicable
+- Transport/network: local file rendering only
+- Exact command:
+
+  ````sh
+  git diff --check
+  node --input-type=module - <<'NODE'
+  import fs from 'node:fs'
+  import path from 'node:path'
+  import { marked } from 'marked'
+  import { parse } from 'parse5'
+  const mdFile = 'docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md'
+  const source = fs.readFileSync(mdFile, 'utf8')
+  const rendered = marked.parse(source)
+  const links = [...source.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map(m => m[1]).filter(h => !/^(https?:|#)/.test(h))
+  for (const href of links) if (!fs.existsSync(path.resolve(path.dirname(mdFile), href))) throw new Error(`Missing link: ${href}`)
+  const fences = (source.match(/^```/gm) || []).length
+  const open = (source.match(/^- \[ \]/gm) || []).length
+  const done = (source.match(/^- \[[xX]\]/gm) || []).length
+  if (fences % 2 || done || !rendered.includes('type="checkbox"')) throw new Error('Invalid Markdown checklist')
+  const html = fs.readFileSync('docs/reference/plans/2026-07-14-ssh-relay-github-release-plan.html', 'utf8')
+  const errors = []
+  parse(html, { onParseError: error => errors.push(error) })
+  const ids = [...html.matchAll(/\bid="([^"]+)"/g)].map(m => m[1])
+  const hrefs = [...html.matchAll(/href="#([^"]+)"/g)].map(m => m[1])
+  if (errors.length || new Set(ids).size !== ids.length || hrefs.some(id => !ids.includes(id))) throw new Error('Invalid HTML plan')
+  console.log({ links: links.length, fences, open, done, htmlIds: ids.length, fragmentLinks: hrefs.length })
+  NODE
+  ````
+
+- Result: SUPERSEDED after the round-4 tuple-status correction; originally PASS for the working-tree
+  artifacts after round-3 findings were resolved.
+- Duration and resource metrics: 7.1 seconds; `links=1 fences=2 open=402 complete=0
+htmlIds=11 fragmentLinks=9`.
+- Artifact/log/trace link: this file, the linked HTML plan, and local screenshots
+  `/tmp/relay-plan-desktop-light.png` and `/tmp/relay-plan-mobile-dark.png`.
+- Oracle proved: Markdown rendered with balanced fences, valid local links, and no prematurely
+  completed implementation boxes; HTML parsed without parse errors, duplicate IDs, or broken
+  fragment links; `git diff --check` passed. HTML SHA-256 was
+  `375659e4ed3c4ec06b8077cae5badf39761ea5d92267612081195d6a027e073f`; the checklist prefix
+  before this ledger was `b599bf0c7ce6ca5ceb6188a153deb3437443f61d8a09069c8dc8dd6f21cdf9ad`.
+- Does not prove: any product behavior, artifact build, SSH runtime, platform, security, release, or
+  performance claim. Visual mobile emulation must be repeated after the final review because the
+  first CLI session relaunched at its default viewport.
+- Checklist items satisfied: none of the implementation milestones.
+- Follow-up: replaced by E-PLAN-003; complete final visual validation before implementation handoff.
+
+### E-PLAN-003 — Post-round-4 static validation
+
+- Date: 2026-07-14
+- Commit SHA / PR: uncommitted planning worktree; implementation not started
+- Runner: macOS arm64 local documentation validation
+- Remote: not applicable
+- Transport/network: local file parsing only
+- Exact command: the exact `git diff --check` and inline `marked`/`parse5` command block recorded in
+  E-PLAN-002, followed by `shasum -a 256` for the HTML and the checklist prefix before this ledger.
+- Result: PASS for current static planning artifacts.
+- Duration and resource metrics: under 1 second; `links=1 fences=2 open=402 complete=0 htmlIds=11
+fragmentLinks=9`.
+- Artifact/log/trace link: this file and the linked HTML plan.
+- Oracle proved: Markdown/HTML structure, links, task-state integrity, fragment IDs, whitespace, and
+  current artifact identity. HTML SHA-256 is
+  `728fa4edcf37e834f064a32308b2901a455402a61016bd7b047b151a75100bf1`; the checklist prefix
+  before this ledger is `b599bf0c7ce6ca5ceb6188a153deb3437443f61d8a09069c8dc8dd6f21cdf9ad`.
+- Does not prove: any product behavior or final visual responsiveness.
+- Checklist items satisfied: none of the implementation milestones.
+- Follow-up: obtain an explicit clean independent review, then run final desktop/mobile visual
+  validation and implementation handoff.
+
+### E-PLAN-004 — Clean review and final visual validation
+
+- Date: 2026-07-14
+- Commit SHA / PR: uncommitted planning worktree; implementation not started
+- Runner: macOS arm64, agent-browser Chromium
+- Remote: not applicable
+- Transport/network: local `file://` rendering
+- Exact command: independent subagent round 5 reviewed both files completely and returned `CLEAN`;
+  agent-browser opened the HTML at 1440×1000 light mode and 390×844 @3x dark/reduced-motion mode,
+  captured screenshots, queried document/table widths and media state, and checked page errors.
+- Result: PASS.
+- Duration and resource metrics: desktop `documentWidth=1440`, no page overflow, both tables
+  `clientWidth=scrollWidth=966`; mobile `documentWidth=390`, no page overflow, table regions scroll
+  internally at `352→363` and `352→505`; dark mode and reduced motion both active; no page errors.
+- Artifact/log/trace link: `/tmp/relay-plan-final-desktop.png` and
+  `/tmp/relay-plan-final-mobile.png` in the handoff machine, plus the round-5 `CLEAN` verdict.
+- Oracle proved: current plan is visually usable at representative desktop/mobile widths, table
+  overflow is contained, dark/reduced-motion media behavior activates, and an independent reviewer
+  found no remaining actionable implementation, regression, security, cross-platform, release,
+  evidence, HTML, or Markdown issue.
+- Does not prove: product implementation or runtime behavior; all implementation checklist boxes
+  remain open until backed by implementation evidence.
+- Checklist items satisfied: planning review/validation only; none of Milestones 0–14.
+- Follow-up: implementation agent must begin at Milestone 0/1, maintain this checklist, and attach
+  evidence before marking any product item complete.
+
+### E-M0-UNIT-001 — Coherent Node/npm resolver and legacy deploy regression suite
+
+- Date: 2026-07-14
+- Commit SHA / PR: `1ef0551bc138724d736583eac788f4183bef07e2` plus uncommitted Work Package 0 changes; no PR created
+- Runner: macOS 26.2 arm64, native; Node v26.0.0 and pnpm 10.24.0 (repository requests Node 24)
+- Remote: local POSIX shell fixture for the guarded-NVM case; mocked Windows PowerShell command
+  construction; no live SSH remote in this entry
+- Transport/network: local Vitest only
+- Exact command:
+
+  ```sh
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-node-resolution.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-native-deps-install.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-versioned-install.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-deploy.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-cross-version-isolation.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-platform-detection.test.ts
+  ```
+
+- Result: PASS; respectively 32/32, 8/8, 16/16, 26/26, 21/21, 1/1, and 6/6 tests
+- Duration and resource metrics: respectively 577 ms, 1.21 s, 634 ms, 538 ms, 642 ms, 546 ms,
+  and 156 ms Vitest duration; resource usage not instrumented
+- Artifact/log/trace link: local command output; source fixtures in
+  `ssh-remote-node-toolchain-resolution.test.ts`
+- Oracle proved: POSIX and Windows probes require colocated Node/npm, Node 18 minimum remains,
+  missing/failing/no-op npm candidates are skipped, guarded NVM is found without sourcing it,
+  startup noise is marker-bounded, non-POSIX login shells receive a `/bin/sh`-wrapped toolchain
+  probe, strict session-limit errors/cancellation remain classified, and the selected NVM bin
+  directory reaches legacy `npm install`.
+- Does not prove: live SSH, live Windows, system SSH, `MaxSessions=1` on a real server, release
+  artifacts, or an executable red run against the pre-fix source. The original #8450 report is the
+  field red observation; these green tests are discriminating but were not run after temporarily
+  reverting user-owned code.
+- Checklist items satisfied: Milestone 0 coherent pairing, negative cases, version enforcement,
+  strategy/cancellation/session-limit preservation, and focused resolver/deploy verification.
+- Follow-up: keep this work package separate; add live Windows or `MaxSessions=1` evidence only if
+  those claims are needed for a later support matrix.
+
+### E-M0-LIVE-001 — Ubuntu 24.04 guarded-NVM relay and PTY reproduction
+
+- Date: 2026-07-14
+- Commit SHA / PR: `1ef0551bc138724d736583eac788f4183bef07e2` plus uncommitted Work Package 0 changes; no PR created
+- Runner: macOS 26.2 arm64 native client; Docker 29.2.1; Electron 43.1.0
+- Remote: Ubuntu 24.04 Linux arm64/glibc container
+  (`sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90`);
+  system Node v18.19.1 with no sibling npm; NVM-layout Node v22.22.3/npm 10.9.8 below a
+  non-interactive `.bashrc` return guard; build-essential and Python present for the legacy native
+  dependency install
+- Transport/network: authenticated built-in SSH2 over Docker loopback; SFTP relay upload; remote
+  registry and Node header egress available for the legacy npm install
+- Exact command:
+
+  ```sh
+  pnpm run test:e2e:ssh-node-toolchain-resolution
+  SKIP_BUILD=1 pnpm run test:e2e:ssh-node-toolchain-resolution
+  ```
+
+- Result: PASS twice; one purpose-named Playwright test passed on each run
+- Duration and resource metrics: fresh Electron/relay build plus E2E 1.8 minutes; repeated E2E 1.2
+  minutes with test evidence `durationMs=62553`; memory/channel/file counts not instrumented for this
+  narrow legacy resolver proof
+- Artifact/log/trace link: local Playwright stdout included
+  `systemNode=v18.19.1 nvmNode=v22.22.3 npm=10.9.8 selected=nvm relayPty=pass`;
+  fixture and runner are checked into this worktree
+- Oracle proved: non-interactive and login-shell PATH both expose the incomplete system Node, the
+  complete NVM directory remains discoverable below the guard, Orca connects, the detached relay's
+  argv[0] is the NVM Node path, and a marker round-trips through a real remote PTY.
+- Does not prove: Linux x64, musl, Windows, macOS remote, system SSH, `MaxSessions=1`, blocked remote
+  egress, absence of build tools, fallback behavior, performance budgets, or bundled runtimes.
+- Checklist items satisfied: Milestone 0 exact live #8450 reproduction and documented passing legacy
+  tuple.
+- Follow-up: keep this evidence scoped to the one declared legacy tuple; do not generalize it into a
+  bundled or cross-platform support claim.
+
+### E-M0-STATIC-001 — Work Package 0 type, format, line-budget, and diff gates
+
+- Date: 2026-07-14
+- Commit SHA / PR: `1ef0551bc138724d736583eac788f4183bef07e2` plus uncommitted Work Package 0 changes
+- Runner: macOS 26.2 arm64 native; Node v26.0.0 and pnpm 10.24.0
+- Remote: not applicable
+- Transport/network: local only
+- Exact command:
+
+  ```sh
+  pnpm run typecheck
+  pnpm exec oxlint src/main/ssh/ssh-remote-node-resolution.ts src/main/ssh/ssh-remote-node-toolchain-probe.ts src/main/ssh/ssh-remote-node-resolution.test.ts src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts src/main/ssh/ssh-relay-native-deps-install.test.ts tests/e2e/helpers/docker-ssh-relay-target.ts tests/e2e/helpers/docker-ssh-relay-processes.ts tests/e2e/ssh-node-toolchain-resolution.spec.ts
+  pnpm exec oxfmt --check src/main/ssh/ssh-remote-node-resolution.ts src/main/ssh/ssh-remote-node-toolchain-probe.ts src/main/ssh/ssh-remote-node-resolution.test.ts src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts src/main/ssh/ssh-relay-native-deps-install.test.ts tests/e2e/helpers/docker-ssh-relay-target.ts tests/e2e/helpers/docker-ssh-relay-processes.ts tests/e2e/ssh-node-toolchain-resolution.spec.ts config/scripts/run-ssh-node-toolchain-resolution-e2e.mjs package.json
+  pnpm run check:max-lines-ratchet
+  git diff --check
+  ```
+
+- Result: PASS
+- Duration and resource metrics: typecheck 7.94 s; formatting check 144 ms; other gates under 1 s;
+  resource usage not instrumented
+- Artifact/log/trace link: local command output
+- Oracle proved: Node/CLI/web TypeScript projects compile, touched TypeScript has no oxlint errors,
+  all touched files are formatted, no new max-lines bypass exists, and the diff has no whitespace
+  errors.
+- Does not prove: repository-wide lint completion; see E-M0-LINT-001.
+- Checklist items satisfied: Milestone 0 typecheck and max-lines/diff handoff gates.
+- Follow-up: resolve or explicitly baseline E-M0-LINT-001 before calling the full lint gate green.
+
+### E-M0-LINT-001 — Repository-wide lint blocked outside Work Package 0
+
+- Date: 2026-07-14
+- Commit SHA / PR: `1ef0551bc138724d736583eac788f4183bef07e2` plus uncommitted Work Package 0 changes
+- Runner: macOS 26.2 arm64 native; Node v26.0.0 and pnpm 10.24.0
+- Remote: not applicable
+- Transport/network: local only
+- Exact command: `pnpm run lint`
+- Result: FAIL after 4.56 s
+- Duration and resource metrics: 4.56 s; resource usage not instrumented
+- Artifact/log/trace link: local lint output
+- Oracle proved: repository-wide oxlint completed with warnings only, then the type-aware
+  switch-exhaustiveness subgate failed at the untouched
+  `src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx:31` because `active | inactive`
+  cases are unhandled.
+- Does not prove: a WP0 lint regression. The failing renderer file is clean in `git status` and is
+  outside this work package; touched-file oxlint passes in E-M0-STATIC-001.
+- Checklist items satisfied: none; the full `pnpm run lint` checkbox remains open.
+- Follow-up: separately fix or explicitly baseline the existing renderer exhaustiveness failure,
+  then rerun the exact full lint command.
+
+### E-M1-RUNNER-DECISION-001 — GitHub Actions validation topology decision
+
+- Date: 2026-07-14
+- Commit SHA / PR: `1ef0551bc138724d736583eac788f4183bef07e2` plus uncommitted planning and Work Package 0 changes
+- Runner: documentation decision in the macOS 26.2 arm64 native worktree
+- Remote: not applicable; exact native runner labels and representative remotes remain open
+- Transport/network: not applicable
+- Exact command: no executable runner command applies to the policy decision; both artifacts were
+  structurally validated by the exact command recorded in E-M1-ROLLOUT-DECISION-001.
+- Result: PASS for recording the user-authorized decision; no runner cell is claimed complete.
+- Duration and resource metrics: not applicable to the decision; shared structural validation took
+  46 ms.
+- Artifact/log/trace link: the Milestone 1 “Validation runner and network topology” section and the
+  HTML “GitHub Actions runner policy” callout
+- Oracle proved: both planning artifacts name GitHub Actions as the primary orchestrator and define
+  when hosted, ephemeral, or self-hosted native execution may fill an evidence cell.
+- Does not prove: availability, capacity, permissions, networking, signing access, native execution,
+  or any live matrix cell for a concrete runner label.
+- Checklist items satisfied: Milestone 1 runner-provider and qualification-policy decisions only.
+- Follow-up: inventory exact labels/images and pin representative POSIX/Windows remotes before
+  claiming any tuple.
+
+### E-M1-ROLLOUT-DECISION-001 — Per-SSH-target Beta with legacy default
+
+- Date: 2026-07-14
+- Commit SHA / PR: `1ef0551bc138724d736583eac788f4183bef07e2` plus uncommitted planning and Work Package 0 changes
+- Runner: macOS 26.2 arm64 native; Node v26.0.0 and pnpm 10.24.0
+- Remote: not applicable; documentation/content validation only
+- Transport/network: local files only
+- Exact command:
+
+  ````sh
+  node --input-type=module - <<'NODE'
+  import fs from 'node:fs'
+  import path from 'node:path'
+  import { marked } from 'marked'
+  import { parse } from 'parse5'
+  const started = performance.now()
+  const mdFile = 'docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md'
+  const htmlFile = 'docs/reference/plans/2026-07-14-ssh-relay-github-release-plan.html'
+  const source = fs.readFileSync(mdFile, 'utf8')
+  const rendered = marked.parse(source)
+  const links = [...source.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map(match => match[1]).filter(href => !/^(https?:|#)/.test(href))
+  for (const href of links) if (!fs.existsSync(path.resolve(path.dirname(mdFile), href))) throw new Error(`Missing link: ${href}`)
+  const fences = (source.match(/^```/gm) || []).length
+  const open = (source.match(/^- \[ \]/gm) || []).length
+  const done = (source.match(/^- \[[xX]\]/gm) || []).length
+  if (fences % 2 || !rendered.includes('type="checkbox"')) throw new Error('Invalid Markdown checklist')
+  const html = fs.readFileSync(htmlFile, 'utf8')
+  const errors = []
+  parse(html, { onParseError: error => errors.push(error) })
+  const ids = [...html.matchAll(/\bid="([^"]+)"/g)].map(match => match[1])
+  const hrefs = [...html.matchAll(/href="#([^"]+)"/g)].map(match => match[1])
+  if (errors.length || new Set(ids).size !== ids.length || hrefs.some(id => !ids.includes(id))) throw new Error('Invalid HTML plan')
+  const requiredMd = ['Per-target Beta rollout decision', 'E-M1-ROLLOUT-DECISION-001', 'missing, malformed,', 'separate reviewed rollout decision']
+  const requiredHtml = ['Per-target Beta contract', 'bundled-auto', 'Future default review']
+  for (const value of requiredMd) if (!source.includes(value)) throw new Error(`Missing checklist contract: ${value}`)
+  for (const value of requiredHtml) if (!html.includes(value)) throw new Error(`Missing HTML contract: ${value}`)
+  console.log(JSON.stringify({ result: 'PASS', links: links.length, fences, open, done, htmlIds: ids.length, fragmentLinks: hrefs.length, durationMs: Math.round(performance.now() - started) }))
+  NODE
+  pnpm exec oxfmt --check docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md docs/reference/plans/2026-07-14-ssh-relay-github-release-plan.html
+  git diff --check
+  ````
+
+- Result: PASS; `links=1 fences=2 open=393 complete=33 htmlIds=11 fragmentLinks=9` and no
+  `git diff --check` findings; both planning artifacts pass `oxfmt --check`.
+- Duration and resource metrics: 46 ms for Markdown/HTML parsing; resource usage not instrumented.
+- Artifact/log/trace link: this checklist and the linked HTML plan
+- Oracle proved: both artifacts record a Beta-tagged per-target opt-in, conservative legacy
+  deserialization, next-connection-only application, classified fallback, explicit fail-closed
+  recovery, and separate authorization before any default change.
+- Does not prove: configuration migration, add/edit UI, Beta badge rendering, live-session
+  preservation, telemetry, fallback behavior, or any bundled runtime execution.
+- Checklist items satisfied: Milestone 1 rollout-control mechanism and per-target Beta policy
+  decisions only; implementation boxes in Milestones 8 and 14 remain open.
+- Follow-up: implement and test the target configuration/UI in its reviewable work package after the
+  Work Package 0 boundary and remaining Milestone 1 blockers are closed.
+
+## Accepted Gaps
+
+No product gap is accepted merely because it appears in this list. Each entry requires explicit
+owner and promotion condition.
+
+| Gap                                            | Current behavior                                                                       | Risk                                          | Owner                              | Promotion/removal condition                                          | Status |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------- | ------ |
+| Bundled runtime not implemented                | Remote Node/npm installer                                                              | #8450/#1693 failure classes remain            | Unassigned                         | Milestones 1–14                                                      | Open   |
+| Bundled support matrix undeclared              | Legacy support only where proven                                                       | Cannot claim tuple coverage                   | Unassigned                         | Baselines and real runners decided                                   | Open   |
+| musl Node provenance undecided                 | Legacy eligibility only                                                                | Untrusted/incompatible binary risk            | Unassigned                         | Reviewed runtime source/build                                        | Open   |
+| Windows arm64 real runner undecided            | Legacy eligibility only                                                                | Cross-build may hide runtime failure          | Unassigned                         | Native runner and full proof                                         | Open   |
+| Linux arm64 real runner undecided              | Existing Docker evidence is not full runtime matrix                                    | Native regression may escape                  | Unassigned                         | Native full-matrix proof                                             | Open   |
+| No numeric perf budgets yet                    | Current legacy behavior                                                                | “No regression” is unmeasurable               | Unassigned                         | Baselines and thresholds recorded                                    | Open   |
+| Signing/key lifecycle undecided                | GitHub app-release trust only                                                          | Relay-specific supply-chain gap               | Unassigned                         | Milestone 1 trust decisions                                          | Open   |
+| Remote bootstrap primitive baselines undecided | Existing transport-specific shell assumptions                                          | Hidden tool dependency or corrupt transfer    | Unassigned                         | Milestone 1 POSIX/Windows decisions and live tests                   | Open   |
+| WP0 commit/PR boundary absent                  | Uncommitted, independently scoped worktree diff                                        | Starting WP1 now would mix review packages    | User authorization required        | Separately authorized WP0 commit/PR or equivalent reviewed boundary  | Open   |
+| Repository-wide lint failure outside WP0       | Touched-file oxlint passes; full lint stops on untouched renderer exhaustiveness error | Required handoff gate cannot be claimed green | Existing renderer owner unassigned | Fix or explicitly baseline E-M0-LINT-001, then rerun `pnpm run lint` | Open   |
+
+## Final Definition of Done
+
+The project is not complete until every applicable item below is checked with evidence IDs.
+
+- [ ] Milestone 0 legacy safety net is merged and live-proven.
+- [ ] All Milestone 1 decisions are closed and reviewed.
+- [ ] Artifact/manifest schema and full-runtime identity are implemented and hostile-input tested.
+- [ ] Every enabled runtime tuple passes build, native, oldest-baseline, trust, and live SSH proofs.
+- [ ] Relay artifacts are immutable prerequisites of every desktop build.
+- [ ] Target-native builds, native signing jobs, and the fail-closed aggregate/manifest job pass all
+      failure and recovered-draft rehearsals before desktop packaging.
+- [ ] Every packaged desktop embeds the exact signed manifest whose bytes are published.
+- [ ] Client download/cache/extraction passes online, offline, proxy, integrity, concurrency, and
+      resource-failure gates.
+- [ ] Every SSH transfer path is bounded, cancellable, no-tar-capable, mode-correct, and full-size
+      tested.
+- [ ] Remote installation uses full-tree verification and a structured, mode-qualified completion
+      record.
+- [ ] Declared POSIX/Windows bootstrap primitives, missing-command behavior, BusyBox variants, and
+      no-remote-hash-tool behavior are live-proven.
+- [ ] The primary path launches with bundled Node and performs no remote npm or HTTP operation.
+- [ ] Fallback aborts and joins bundled work, uses separate state, and is race/failure tested.
+- [ ] Every integrity/security failure fails closed in `auto` without automatic legacy.
+- [ ] The exact online/offline/cache matrix is live-proven.
+- [ ] Every relay RPC family, reconnect, reattach, upgrade, downgrade, concurrent-client, and GC
+      contract passes through the packaged runtime.
+- [ ] Security review, SBOM, provenance, key lifecycle, native signing, CVE ownership, and emergency
+      refresh through a new desktop build/embedded manifest are operational; old clients stay pinned.
+- [ ] Numeric performance and resource budgets pass on the required matrix.
+- [ ] Draft release read-back and public direct-URL behavior pass for exact stable/RC/perf tags.
+- [ ] Three consecutive qualifying RCs pass without unexplained fallback or relay regression.
+- [ ] Stable soak and rollback criteria pass.
+- [ ] Every accepted gap is closed or explicitly retained with owner, fallback, and promotion rule.
+- [ ] HTML plan, this checklist, reliability-gate metadata, troubleshooting docs, and PR evidence are
+      current.
+- [ ] Legacy fallback remains unless a separate reviewed decision authorizes narrowing/removal.
+
+## Next Required Action
+
+Place the implementation/live-proven Milestone 0 diff behind its separately authorized commit/PR
+boundary and resolve or explicitly baseline E-M0-LINT-001. Then assign owners and close Milestone
+1’s support baseline, remote bootstrap primitives, Node provenance/refresh policy, signing
+lifecycle, transfer/resource budgets, and rollout-policy decisions. Do not start a production
+default-path change before those decisions are reflected here.

--- a/docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md
+++ b/docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md
@@ -2,7 +2,7 @@
 
 Date created: 2026-07-14<br>
 Last updated: 2026-07-14<br>
-Current phase: Milestone 0 / Work Package 0 — draft PR #8724 open; GitHub Actions verification in progress; Milestone 1 runner and per-target Beta rollout policies recorded<br>
+Current phase: Milestone 1 decision closure — Work Package 0 is CI-green in draft PR #8724; no bundled-runtime path is enabled; runner and per-target Beta rollout policies are recorded<br>
 Primary design: [SSH relay GitHub Release plan](./2026-07-14-ssh-relay-github-release-plan.html)<br>
 Motivating issues: [#8450](https://github.com/stablyai/orca/issues/8450), [#1693](https://github.com/stablyai/orca/issues/1693)
 
@@ -48,8 +48,10 @@ same change as the work it records.
 ## Current Status
 
 - Implementation status: Work Package 0 is committed at `c4259d94f` on current `main`, with refreshed
-  focused, static, full-lint, and live #8450 SSH/PTY proof (E-M0-UNIT-002, E-M0-STATIC-002,
-  E-M0-LIVE-002). Draft PR [#8724](https://github.com/stablyai/orca/pull/8724) is open; CI is running.
+  focused, static, full-lint, live #8450 SSH/PTY, and GitHub Actions proof (E-M0-UNIT-002,
+  E-M0-STATIC-002, E-M0-LIVE-002, E-M0-CI-001). Draft PR
+  [#8724](https://github.com/stablyai/orca/pull/8724) is open and CI-green at implementation head
+  `94e58d83e`.
 - Production behavior: unchanged; Orca embeds relay JavaScript and installs `node-pty` plus
   `@parcel/watcher` with remote npm.
 - New runtime assets published: none.
@@ -60,9 +62,9 @@ same change as the work it records.
 - Rollout control: existing per-SSH-target configuration; legacy is the default and the bundled
   runtime is an explicit per-target Beta opt-in under E-M1-ROLLOUT-DECISION-001.
 - Legacy fallback removal: not authorized.
-- Next required action: collect and record every required PR #8724 check. Do not add Work Package 1
-  implementation to this PR. After the WP0 CI boundary is green, continue closing Milestone 1
-  decisions and begin the next contract-only package on its own branch/PR boundary.
+- Next required action: close the remaining Milestone 1 baselines, provenance/trust, numeric-budget,
+  and concrete runner/remote decisions. Begin the contract-only package on its own branch/PR
+  boundary; do not add Work Package 1 implementation to PR #8724.
 
 ## Non-Negotiable Invariants
 
@@ -117,9 +119,6 @@ coherent Node/npm resolver.
 Work Package 0 implementation evidence was completed on 2026-07-14 by the Codex implementation
 owner. No relay artifact-distribution behavior is included.
 
-**In progress — 2026-07-14, Codex implementation owner:** collect GitHub Actions evidence for draft
-PR #8724 and keep Work Package 1 implementation outside this branch/PR.
-
 - [x] Confirm the #8450 implementation selects Node and npm from the same bin directory on POSIX.
       (E-M0-UNIT-001, E-M0-UNIT-002, E-M0-LIVE-002)
 - [x] Confirm Windows selects `node.exe` and `npm.cmd` from one toolchain directory.
@@ -155,6 +154,10 @@ link.
 No production implementation begins until every blocking item has an owner and decision record.
 
 ### Supported runtime baselines
+
+**In progress — 2026-07-14, Codex implementation owner:** resolve the baseline, provenance, trust,
+runner/remote, and numeric-budget decisions with authoritative evidence before starting Work Package
+1 implementation on a separate branch/PR boundary.
 
 - [ ] Define the oldest supported glibc version.
 - [ ] Define the oldest supported libstdc++/C++ ABI level.
@@ -923,16 +926,16 @@ Baseline measurements must be captured before product behavior changes.
 
 Update status and evidence as work begins. Do not combine these into one large behavior switch.
 
-| Work package              | Scope                                                                                      | Default behavior change     | Status                                                                       | PR/evidence                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------------ | --------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| 0. #8450 legacy fix       | Coherent Node/npm selection and live repro                                                 | Fixes legacy selection only | Implementation/live proof complete; commit/PR boundary and full lint pending | E-M0-UNIT-001, E-M0-LIVE-001, E-M0-STATIC-001, E-M0-LINT-001 |
-| 1. Contract and selectors | Manifest schema, identity, platform/libc selection, hostile inputs                         | None                        | Not started                                                                  | —                                                            |
-| 2. Runtime builds         | Per-tuple assembly, native smoke, SBOM/provenance/signing                                  | None                        | Not started                                                                  | —                                                            |
-| 3. Release publication    | Prerequisite DAG, embedded manifest, draft upload/read-back gates                          | Asset-only                  | Not started                                                                  | —                                                            |
-| 4. Desktop resolver/cache | Verified download, extraction, cache, offline behavior                                     | None/forced mode only       | Not started                                                                  | —                                                            |
-| 5. Transfer/install       | Bounded transports, structured sentinel, bundled launch behind per-target Beta/forced mode | Per-target opt-in only      | Not started                                                                  | —                                                            |
-| 6. Fallback/diagnostics   | Abort-and-join state machine, mode isolation, reason codes, target-mode configuration/UI   | Per-target Beta only        | Not started                                                                  | —                                                            |
-| 7. Live gates/rollout     | Matrix, security, performance, release promotion                                           | Per-tuple staged            | Not started                                                                  | —                                                            |
+| Work package              | Scope                                                                                      | Default behavior change     | Status                                  | PR/evidence                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------------ | --------------------------- | --------------------------------------- | ----------------------------------------------------------------------- |
+| 0. #8450 legacy fix       | Coherent Node/npm selection and live repro                                                 | Fixes legacy selection only | Complete and CI-green in draft PR #8724 | E-M0-UNIT-002, E-M0-LIVE-002, E-M0-STATIC-002, E-M0-PR-001, E-M0-CI-001 |
+| 1. Contract and selectors | Manifest schema, identity, platform/libc selection, hostile inputs                         | None                        | Not started                             | —                                                                       |
+| 2. Runtime builds         | Per-tuple assembly, native smoke, SBOM/provenance/signing                                  | None                        | Not started                             | —                                                                       |
+| 3. Release publication    | Prerequisite DAG, embedded manifest, draft upload/read-back gates                          | Asset-only                  | Not started                             | —                                                                       |
+| 4. Desktop resolver/cache | Verified download, extraction, cache, offline behavior                                     | None/forced mode only       | Not started                             | —                                                                       |
+| 5. Transfer/install       | Bounded transports, structured sentinel, bundled launch behind per-target Beta/forced mode | Per-target opt-in only      | Not started                             | —                                                                       |
+| 6. Fallback/diagnostics   | Abort-and-join state machine, mode isolation, reason codes, target-mode configuration/UI   | Per-target Beta only        | Not started                             | —                                                                       |
+| 7. Live gates/rollout     | Matrix, security, performance, release promotion                                           | Per-tuple staged            | Not started                             | —                                                                       |
 
 Every PR must document:
 
@@ -965,15 +968,9 @@ focused commands as their scripts/tests are introduced.
 - [ ] `node config/scripts/relay-watcher-fault-harness.mjs`
 - [ ] `pnpm run test:e2e:ssh-docker-watcher-isolation`
 - [ ] `pnpm run test:e2e:ssh-docker-perf`
-- [x] `pnpm run typecheck` (E-M0-STATIC-001)
-- [ ] `pnpm run lint`
-- [x] `pnpm run check:max-lines-ratchet` (E-M0-STATIC-001)
-
-BLOCKED: `pnpm run lint` reaches the untouched
-`src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx:31` and fails the type-aware
-switch-exhaustiveness gate for missing `active | inactive` cases (E-M0-LINT-001). The unblock
-condition is a separately owned fix or explicit reviewed baseline for that existing failure; WP0
-must not absorb the unrelated renderer change.
+- [x] `pnpm run typecheck` (E-M0-STATIC-001, E-M0-STATIC-002, E-M0-CI-001)
+- [x] `pnpm run lint` (E-M0-STATIC-002, E-M0-CI-001)
+- [x] `pnpm run check:max-lines-ratchet` (E-M0-STATIC-001, E-M0-STATIC-002, E-M0-CI-001)
 
 ### Milestone 0 commands added
 
@@ -1387,7 +1384,53 @@ fragmentLinks=9`.
 - Does not prove: CI success, reviewer approval, mergeability after later base changes, or any bundled
   runtime behavior.
 - Checklist items satisfied: Milestone 0 separate commit/PR boundary.
-- Follow-up: append GitHub-hosted runner/check details as E-M0-CI-001 only after completion.
+- Follow-up: GitHub-hosted runner/check details were appended as E-M0-CI-001 after completion.
+
+### E-M0-CI-001 — Draft PR full regression and packaged-app checks
+
+- Date: 2026-07-14
+- Commit SHA / PR: `94e58d83eabfba30b90e9714e91485ba5e3cf8d7`; draft PR
+  [#8724](https://github.com/stablyai/orca/pull/8724)
+- Runner: GitHub-hosted native runners:
+  - `ubuntu-latest` resolved to x64 `ubuntu-24.04` image `20260705.232.1` for verify and Linux
+    golden jobs; runner image provisioner `20260624.560`
+  - `macos-15` resolved to arm64 `macos-15-arm64` image `20260706.0213.1` for the macOS golden job;
+    runner image provisioner `20260624.560`
+- Remote: not applicable; these workflows did not provision or connect to an SSH server
+- Transport/network: GitHub Actions checkout/package-network traffic only; no built-in SFTP or
+  system-SSH relay transport was exercised
+- Exact command:
+
+  ```sh
+  gh run watch 29325885071 --repo stablyai/orca --exit-status
+  gh pr view 8724 --repo stablyai/orca --json url,state,isDraft,headRefOid,baseRefOid,mergeStateStatus,statusCheckRollup
+  gh api repos/stablyai/orca/actions/jobs/87061960266
+  gh api repos/stablyai/orca/actions/jobs/87061960006
+  gh api repos/stablyai/orca/actions/jobs/87061960091
+  gh run view 29325885071 --repo stablyai/orca --job 87061960266 --log
+  gh run view 29325884997 --repo stablyai/orca --job 87061960006 --log
+  gh run view 29325884997 --repo stablyai/orca --job 87061960091 --log
+  ```
+
+- Result: PASS; `verify`, `golden e2e linux experiment`, and `golden e2e mac experiment` all
+  completed successfully on the expected PR head
+- Duration and resource metrics: verify job 13m13s; Linux golden job 4m23s; macOS golden job 5m57s;
+  verify configured a 4 GiB Node heap ceiling but the workflows did not report peak process memory,
+  channels, or file counts
+- Artifact/log/trace link:
+  - verify run/job: https://github.com/stablyai/orca/actions/runs/29325885071/job/87061960266
+  - golden Linux job: https://github.com/stablyai/orca/actions/runs/29325884997/job/87061960006
+  - golden macOS job: https://github.com/stablyai/orca/actions/runs/29325884997/job/87061960091
+- Oracle proved: the PR head passes repository lint, reliability and max-lines gates, typecheck, Git
+  2.25 compatibility, full tests, unpacked-app packaging, packaged CLI smoke, and the existing Linux
+  and macOS golden Electron suites.
+- Does not prove: live SSH, Windows, Linux arm64, musl, system SSH, SFTP bootstrap transfer,
+  `MaxSessions=1`, no-egress remotes, full-size runtime transfer, cancellation/resource budgets, or
+  any bundled-runtime behavior. E-M0-LIVE-002 remains the only live SSH claim for WP0.
+- Checklist items satisfied: Work Package 0 required PR checks, full repository lint, and independent
+  CI boundary.
+- Follow-up: keep PR #8724 limited to WP0; use separate work-package branches and purpose-built SSH
+  workflows for all later tuple claims.
 
 ### E-M1-RUNNER-DECISION-001 — GitHub Actions validation topology decision
 

--- a/docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md
+++ b/docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md
@@ -2,7 +2,7 @@
 
 Date created: 2026-07-14<br>
 Last updated: 2026-07-14<br>
-Current phase: Milestone 0 / Work Package 0 — verification refresh and authorized draft-PR boundary in progress; Milestone 1 runner and per-target Beta rollout policies recorded<br>
+Current phase: Milestone 0 / Work Package 0 — draft PR #8724 open; GitHub Actions verification in progress; Milestone 1 runner and per-target Beta rollout policies recorded<br>
 Primary design: [SSH relay GitHub Release plan](./2026-07-14-ssh-relay-github-release-plan.html)<br>
 Motivating issues: [#8450](https://github.com/stablyai/orca/issues/8450), [#1693](https://github.com/stablyai/orca/issues/1693)
 
@@ -47,8 +47,9 @@ same change as the work it records.
 
 ## Current Status
 
-- Implementation status: Work Package 0 implementation, focused regression proof, and live #8450
-  SSH/PTY proof are complete in the uncommitted worktree (E-M0-UNIT-001, E-M0-LIVE-001).
+- Implementation status: Work Package 0 is committed at `c4259d94f` on current `main`, with refreshed
+  focused, static, full-lint, and live #8450 SSH/PTY proof (E-M0-UNIT-002, E-M0-STATIC-002,
+  E-M0-LIVE-002). Draft PR [#8724](https://github.com/stablyai/orca/pull/8724) is open; CI is running.
 - Production behavior: unchanged; Orca embeds relay JavaScript and installs `node-pty` plus
   `@parcel/watcher` with remote npm.
 - New runtime assets published: none.
@@ -59,10 +60,9 @@ same change as the work it records.
 - Rollout control: existing per-SSH-target configuration; legacy is the default and the bundled
   runtime is an explicit per-target Beta opt-in under E-M1-ROLLOUT-DECISION-001.
 - Legacy fallback removal: not authorized.
-- Next required action: resolve or explicitly baseline the unrelated repository-wide lint failure
-  recorded in E-M0-LINT-001, then place Work Package 0 behind its separately authorized commit/PR
-  boundary before closing Milestone 1 decisions. Do not mix artifact-distribution changes into this
-  uncommitted fix.
+- Next required action: collect and record every required PR #8724 check. Do not add Work Package 1
+  implementation to this PR. After the WP0 CI boundary is green, continue closing Milestone 1
+  decisions and begin the next contract-only package on its own branch/PR boundary.
 
 ## Non-Negotiable Invariants
 
@@ -117,16 +117,15 @@ coherent Node/npm resolver.
 Work Package 0 implementation evidence was completed on 2026-07-14 by the Codex implementation
 owner. No relay artifact-distribution behavior is included.
 
-**In progress — 2026-07-14, Codex implementation owner:** refresh the focused/static/live evidence,
-resolve or explicitly baseline the repository lint result, and establish the authorized independent
-draft-PR/CI boundary before any Work Package 1 implementation.
+**In progress — 2026-07-14, Codex implementation owner:** collect GitHub Actions evidence for draft
+PR #8724 and keep Work Package 1 implementation outside this branch/PR.
 
 - [x] Confirm the #8450 implementation selects Node and npm from the same bin directory on POSIX.
-      (E-M0-UNIT-001, E-M0-LIVE-001)
+      (E-M0-UNIT-001, E-M0-UNIT-002, E-M0-LIVE-002)
 - [x] Confirm Windows selects `node.exe` and `npm.cmd` from one toolchain directory.
       (E-M0-UNIT-001; mocked Windows command construction, not live Windows)
 - [x] Reject an incomplete system Node and continue to the usable NVM candidate.
-      (E-M0-UNIT-001, E-M0-LIVE-001)
+      (E-M0-UNIT-001, E-M0-UNIT-002, E-M0-LIVE-002)
 - [x] Preserve minimum supported Node-version enforcement. (E-M0-UNIT-001)
 - [x] Preserve login-shell, known-path, version-manager, noisy-startup, cancellation, and
       `MaxSessions=1` behaviors. (E-M0-UNIT-001; live `MaxSessions=1` remains outside this WP0 proof)
@@ -134,17 +133,19 @@ draft-PR/CI boundary before any Work Package 1 implementation.
       (E-M0-UNIT-001, E-M0-LIVE-001)
 - [x] Add negative tests for Node present/npm missing, npm present/Node too old, mismatched bin
       directories, and an unusable npm shim. (E-M0-UNIT-001)
-- [x] Run focused resolver and deploy tests and record evidence. (E-M0-UNIT-001)
+- [x] Run focused resolver and deploy tests and record evidence. (E-M0-UNIT-001, E-M0-UNIT-002)
 - [x] Run a live SSH reproduction matching issue #8450 and record the selected paths and successful
       relay/PTY launch without recording usernames or home paths in committed evidence.
-      (E-M0-LIVE-001)
-- [ ] Keep this fix in a separate PR or commit from GitHub Release distribution.
+      (E-M0-LIVE-001, E-M0-LIVE-002)
+- [x] Keep this fix in a separate PR or commit from GitHub Release distribution. The reviewed plan
+      is commit `2b67de870`; WP0 code is the separate commit `c4259d94f` in draft PR #8724.
+      (E-M0-PR-001)
 - [x] Document which tuples have a live passing legacy E2E. Fallback is only a support claim for
       those tuples. (E-M0-LIVE-001)
 
-| Legacy remote tuple                                                               | Client           | Transport                                    | Evidence      | Scope limit                                                       |
-| --------------------------------------------------------------------------------- | ---------------- | -------------------------------------------- | ------------- | ----------------------------------------------------------------- |
-| Ubuntu 24.04 arm64, glibc, system Node 18 without npm, guarded NVM Node 22/npm 10 | macOS 26.2 arm64 | Built-in SSH2 connection + SFTP relay upload | E-M0-LIVE-001 | Does not prove x64, system SSH, Windows, musl, or `MaxSessions=1` |
+| Legacy remote tuple                                                               | Client           | Transport                                    | Evidence                     | Scope limit                                                       |
+| --------------------------------------------------------------------------------- | ---------------- | -------------------------------------------- | ---------------------------- | ----------------------------------------------------------------- |
+| Ubuntu 24.04 arm64, glibc, system Node 18 without npm, guarded NVM Node 22/npm 10 | macOS 26.2 arm64 | Built-in SSH2 connection + SFTP relay upload | E-M0-LIVE-001, E-M0-LIVE-002 | Does not prove x64, system SSH, Windows, musl, or `MaxSessions=1` |
 
 Completion evidence required: focused red/green tests, live #8450 SSH run, typecheck, lint, and PR
 link.
@@ -1261,7 +1262,8 @@ fragmentLinks=9`.
 - Remote: not applicable
 - Transport/network: local only
 - Exact command: `pnpm run lint`
-- Result: FAIL after 4.56 s
+- Result: SUPERSEDED for current PR by E-M0-STATIC-002 after rebasing onto `origin/main`; originally
+  FAIL after 4.56 s
 - Duration and resource metrics: 4.56 s; resource usage not instrumented
 - Artifact/log/trace link: local lint output
 - Oracle proved: repository-wide oxlint completed with warnings only, then the type-aware
@@ -1271,8 +1273,121 @@ fragmentLinks=9`.
 - Does not prove: a WP0 lint regression. The failing renderer file is clean in `git status` and is
   outside this work package; touched-file oxlint passes in E-M0-STATIC-001.
 - Checklist items satisfied: none; the full `pnpm run lint` checkbox remains open.
-- Follow-up: separately fix or explicitly baseline the existing renderer exhaustiveness failure,
-  then rerun the exact full lint command.
+- Follow-up: none for WP0. Upstream `main` added the missing cases before this branch rebased; the
+  full lint command now passes at `c4259d94f` without an authored renderer change in this PR.
+
+### E-M0-UNIT-002 — Rebased Work Package 0 focused regression suites
+
+- Date: 2026-07-14
+- Commit SHA / PR: `c4259d94fccf8d1465280b8e69c22db328710f9e`; draft PR
+  [#8724](https://github.com/stablyai/orca/pull/8724)
+- Runner: macOS 26.2 arm64 native; Node v26.0.0 and pnpm 10.24.0 (repository requests Node 24)
+- Remote: local POSIX fixture and mocked Windows PowerShell command construction; no live SSH remote
+- Transport/network: local Vitest only
+- Exact command:
+
+  ```sh
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-node-resolution.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-native-deps-install.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-versioned-install.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-deploy.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-cross-version-isolation.test.ts
+  pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-platform-detection.test.ts
+  ```
+
+- Result: PASS; respectively 32/32, 8/8, 16/16, 26/26, 21/21, 1/1, and 6/6 tests (110 total)
+- Duration and resource metrics: respectively 461 ms, 1.73 s, 324 ms, 339 ms, 284 ms, 245 ms, and
+  189 ms Vitest duration; 10.52 s aggregate wall time; resource usage not instrumented
+- Artifact/log/trace link: local command output and the exact sources in PR #8724
+- Oracle proved: the focused resolver/deploy contracts from E-M0-UNIT-001 remain green after rebasing
+  onto `9d5173252`, including colocated toolchains, guarded NVM, shell-noise markers, cancellation,
+  session-limit classification, and propagation of the selected bin directory to npm install.
+- Does not prove: live SSH, live Windows, system SSH, a real `MaxSessions=1` server, or bundled runtime
+  behavior.
+- Checklist items satisfied: refreshed Milestone 0 focused regression gate on the exact PR commit.
+- Follow-up: use E-M0-LIVE-002 for the one claimed live tuple and PR CI for additional runner signal.
+
+### E-M0-STATIC-002 — Rebased Work Package 0 full static and repository lint gates
+
+- Date: 2026-07-14
+- Commit SHA / PR: `c4259d94fccf8d1465280b8e69c22db328710f9e`; draft PR
+  [#8724](https://github.com/stablyai/orca/pull/8724)
+- Runner: macOS 26.2 arm64 native; Node v26.0.0 and pnpm 10.24.0 (repository requests Node 24)
+- Remote: not applicable
+- Transport/network: local only
+- Exact command:
+
+  ```sh
+  pnpm run typecheck
+  pnpm run check:max-lines-ratchet
+  pnpm exec oxfmt --check src/main/ssh/ssh-remote-node-resolution.ts src/main/ssh/ssh-remote-node-toolchain-probe.ts src/main/ssh/ssh-remote-node-resolution.test.ts src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts src/main/ssh/ssh-relay-native-deps-install.test.ts tests/e2e/helpers/docker-ssh-relay-target.ts tests/e2e/helpers/docker-ssh-relay-processes.ts tests/e2e/ssh-node-toolchain-resolution.spec.ts config/scripts/run-ssh-node-toolchain-resolution-e2e.mjs package.json docs/reference/plans/2026-07-14-ssh-relay-github-release-implementation-checklist.md docs/reference/plans/2026-07-14-ssh-relay-github-release-plan.html
+  git diff --check
+  pnpm run lint
+  ```
+
+- Result: PASS; typecheck, 355-entry max-lines ratchet, 12-file formatting check, diff check, and the
+  complete repository lint/reliability/localization chain all exited zero
+- Duration and resource metrics: typecheck/max-lines/format/diff group 7.39 s; full lint 14.11 s;
+  resource usage not instrumented
+- Artifact/log/trace link: local command output; exact PR commits
+- Oracle proved: the exact rebased PR commit compiles, adds no line-budget bypass, is formatted, has
+  no tracked whitespace errors, and passes the full repository lint chain. E-M0-LINT-001 is no
+  longer a current blocker; its renderer fix came from upstream `main`, not this PR's authored diff.
+- Does not prove: packaged runtime behavior, live SSH, or GitHub-hosted runner behavior.
+- Checklist items satisfied: Milestone 0 typecheck, full lint, max-lines, format, and diff gates.
+- Follow-up: record the GitHub-hosted `verify` result separately when PR #8724 completes.
+
+### E-M0-LIVE-002 — Rebased Ubuntu 24.04 guarded-NVM relay and PTY reproduction
+
+- Date: 2026-07-14
+- Commit SHA / PR: `c4259d94fccf8d1465280b8e69c22db328710f9e`; draft PR
+  [#8724](https://github.com/stablyai/orca/pull/8724)
+- Runner: macOS 26.2 arm64 native client; Docker 29.2.1; Node v26.0.0; pnpm 10.24.0
+- Remote: Ubuntu 24.04 Linux arm64/glibc container,
+  `ubuntu@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90`;
+  system Node v18.19.1 with no sibling npm; guarded NVM-layout Node v22.22.3/npm 10.9.8
+- Transport/network: authenticated built-in SSH2 over Docker loopback; SFTP relay upload; remote
+  registry and Node-header egress available for the legacy native dependency install
+- Exact command: `pnpm run test:e2e:ssh-node-toolchain-resolution`
+- Result: PASS; one purpose-named Playwright test passed
+- Duration and resource metrics: test oracle `durationMs=144224`; full build plus E2E 3.2 minutes;
+  memory/channel/file counts not instrumented for this narrow legacy resolver proof
+- Artifact/log/trace link: local Playwright stdout recorded
+  `remote=ubuntu-24.04 architecture=arm64 systemNode=v18.19.1 nvmNode=v22.22.3 npm=10.9.8 selected=nvm relayPty=pass durationMs=144224`
+- Oracle proved: the exact rebased app/relay build selects the complete guarded NVM toolchain,
+  launches the detached relay with that Node, and round-trips a marker through a real remote PTY.
+- Does not prove: Linux x64, musl, Windows, macOS remote, system SSH, `MaxSessions=1`, blocked remote
+  egress, fallback behavior, performance budgets, or bundled runtimes.
+- Checklist items satisfied: refreshed Milestone 0 exact live #8450 reproduction on the PR commit.
+- Follow-up: retain this narrow tuple claim and use later matrix work for all broader coverage.
+
+### E-M0-PR-001 — Independent draft PR boundary
+
+- Date: 2026-07-14
+- Commit SHA / PR: plan/checklist `2b67de870120b9a9230cb4464bff39665fa9bb44`; WP0 code
+  `c4259d94fccf8d1465280b8e69c22db328710f9e`; draft PR
+  [#8724](https://github.com/stablyai/orca/pull/8724)
+- Runner: GitHub PR metadata; execution checks still running when recorded
+- Remote: not applicable
+- Transport/network: authenticated Git push and GitHub API
+- Exact command:
+
+  ```sh
+  git push -u origin Jinwoo-H/bug-8450-ssh-node-npm-toolchain
+  gh pr create --repo stablyai/orca --draft --base main --head Jinwoo-H/bug-8450-ssh-node-npm-toolchain
+  gh pr view 8724 --repo stablyai/orca --json number,url,isDraft,state,headRefOid,baseRefOid,mergeStateStatus,statusCheckRollup
+  ```
+
+- Result: PASS for the independent review boundary; PR is open and draft with the expected head/base
+- Duration and resource metrics: push and PR creation 7.1 s; metadata read 0.8 s
+- Artifact/log/trace link: https://github.com/stablyai/orca/pull/8724
+- Oracle proved: reviewed planning artifacts and the WP0 resolver correction are separate commits;
+  no bundled-runtime distribution implementation is present; GitHub Actions checks were triggered.
+- Does not prove: CI success, reviewer approval, mergeability after later base changes, or any bundled
+  runtime behavior.
+- Checklist items satisfied: Milestone 0 separate commit/PR boundary.
+- Follow-up: append GitHub-hosted runner/check details as E-M0-CI-001 only after completion.
 
 ### E-M1-RUNNER-DECISION-001 — GitHub Actions validation topology decision
 

--- a/docs/reference/plans/2026-07-14-ssh-relay-github-release-plan.html
+++ b/docs/reference/plans/2026-07-14-ssh-relay-github-release-plan.html
@@ -1,0 +1,1915 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Implementation and validation plan for distributing Orca's self-contained SSH relay through GitHub Releases."
+    />
+    <title>SSH relay distribution plan · Orca</title>
+    <style>
+      @font-face {
+        font-family: 'Geist';
+        src: url('../../../src/renderer/src/assets/fonts/Geist-Variable.woff2') format('woff2');
+        font-weight: 100 900;
+        font-style: normal;
+        font-display: swap;
+      }
+
+      :root {
+        color-scheme: light dark;
+        --background: #fff;
+        --foreground: #0a0a0a;
+        --card: #fff;
+        --card-foreground: #0a0a0a;
+        --primary: #171717;
+        --primary-foreground: #fafafa;
+        --secondary: #f5f5f5;
+        --secondary-foreground: #171717;
+        --muted: #f5f5f5;
+        --muted-foreground: #737373;
+        --accent: #f5f5f5;
+        --accent-foreground: #171717;
+        --destructive: #e40014;
+        --border: #e5e5e5;
+        --ring: #a1a1a1;
+        --status-success: #15803d;
+        --annotation-highlight: #f59e0b;
+        --radius: 0.625rem;
+        --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        --font-mono:
+          'SF Mono', SFMono-Regular, ui-monospace, 'Cascadia Code', Menlo, Consolas,
+          'Liberation Mono', monospace;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --background: #0a0a0a;
+          --foreground: #fafafa;
+          --card: #171717;
+          --card-foreground: #fafafa;
+          --primary: #e5e5e5;
+          --primary-foreground: #171717;
+          --secondary: #262626;
+          --secondary-foreground: #fafafa;
+          --muted: #262626;
+          --muted-foreground: #a1a1a1;
+          --accent: #404040;
+          --accent-foreground: #fafafa;
+          --destructive: #ff6568;
+          --border: rgb(255 255 255 / 0.07);
+          --ring: #737373;
+          --status-success: #86efac;
+          --annotation-highlight: #fbbf24;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        background: var(--background);
+        color: var(--foreground);
+        font-family: var(--font-sans);
+        font-size: 14px;
+        line-height: 1.55;
+        letter-spacing: 0.01em;
+      }
+
+      a {
+        color: inherit;
+        text-decoration-color: var(--ring);
+        text-underline-offset: 3px;
+      }
+
+      a:hover {
+        text-decoration-color: currentColor;
+      }
+
+      a:focus-visible,
+      summary:focus-visible,
+      .table-wrap:focus-visible {
+        border-radius: calc(var(--radius) * 0.6);
+        outline: 2px solid var(--ring);
+        outline-offset: 3px;
+      }
+
+      code,
+      pre {
+        font-family: var(--font-mono);
+      }
+
+      code {
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 0.6);
+        background: var(--muted);
+        padding: 0.08rem 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .shell {
+        display: grid;
+        grid-template-columns: 248px minmax(0, 1fr);
+        min-height: 100vh;
+      }
+
+      .sidebar {
+        position: sticky;
+        top: 0;
+        height: 100vh;
+        overflow-y: auto;
+        border-right: 1px solid var(--border);
+        background: var(--card);
+        padding: 28px 20px;
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 28px;
+        font-weight: 650;
+      }
+
+      .brand-mark {
+        display: grid;
+        width: 28px;
+        height: 28px;
+        place-items: center;
+        border-radius: calc(var(--radius) * 0.8);
+        background: var(--primary);
+        color: var(--primary-foreground);
+        font-size: 12px;
+        letter-spacing: 0;
+      }
+
+      .eyebrow,
+      .nav-heading,
+      .section-kicker {
+        color: var(--muted-foreground);
+        font-size: 11px;
+        font-weight: 650;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      .nav-heading {
+        margin: 22px 10px 8px;
+      }
+
+      nav a {
+        display: block;
+        border-radius: calc(var(--radius) * 0.8);
+        padding: 7px 10px;
+        color: var(--muted-foreground);
+        font-size: 13px;
+        text-decoration: none;
+      }
+
+      nav a:hover {
+        background: var(--accent);
+        color: var(--accent-foreground);
+      }
+
+      main {
+        width: min(1080px, 100%);
+        margin: 0 auto;
+        padding: 64px 56px 96px;
+      }
+
+      header {
+        padding-bottom: 42px;
+      }
+
+      .meta-row,
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: center;
+      }
+
+      .meta-row {
+        justify-content: space-between;
+        margin-bottom: 26px;
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--secondary);
+        padding: 2px 9px;
+        color: var(--secondary-foreground);
+        font-size: 11px;
+        font-weight: 600;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1 {
+        max-width: 850px;
+        margin-bottom: 18px;
+        font-size: clamp(2.15rem, 5vw, 4.25rem);
+        font-weight: 680;
+        letter-spacing: -0.045em;
+        line-height: 0.98;
+      }
+
+      h2 {
+        margin-bottom: 12px;
+        font-size: 1.55rem;
+        font-weight: 650;
+        letter-spacing: -0.025em;
+        line-height: 1.2;
+      }
+
+      h3 {
+        margin-bottom: 8px;
+        font-size: 1rem;
+        font-weight: 650;
+        letter-spacing: -0.01em;
+      }
+
+      .lede {
+        max-width: 780px;
+        margin-bottom: 24px;
+        color: var(--muted-foreground);
+        font-size: 1.08rem;
+      }
+
+      .decision {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
+        gap: 14px;
+        max-width: 820px;
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 1.4);
+        background: var(--card);
+        padding: 18px;
+      }
+
+      .decision-index,
+      .phase-index {
+        display: grid;
+        width: 30px;
+        height: 30px;
+        flex: 0 0 auto;
+        place-items: center;
+        border-radius: 999px;
+        background: var(--primary);
+        color: var(--primary-foreground);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 700;
+      }
+
+      .decision p,
+      .phase p,
+      .risk p {
+        margin-bottom: 0;
+        color: var(--muted-foreground);
+      }
+
+      section {
+        scroll-margin-top: 28px;
+        border-top: 1px solid var(--border);
+        padding: 52px 0;
+      }
+
+      .section-heading {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(240px, 0.72fr);
+        gap: 40px;
+        align-items: end;
+        margin-bottom: 28px;
+      }
+
+      .section-heading p {
+        margin-bottom: 0;
+        color: var(--muted-foreground);
+      }
+
+      .architecture {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 10px;
+        align-items: stretch;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .architecture-step {
+        position: relative;
+        min-height: 150px;
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 1.4);
+        background: var(--card);
+        padding: 18px;
+      }
+
+      .architecture-step:not(:last-child)::after {
+        position: absolute;
+        z-index: 2;
+        top: 50%;
+        right: -16px;
+        width: 20px;
+        border-top: 1px solid var(--ring);
+        content: '';
+      }
+
+      .architecture-step strong {
+        display: block;
+        margin: 18px 0 7px;
+      }
+
+      .architecture-step p {
+        margin: 0;
+        color: var(--muted-foreground);
+        font-size: 12px;
+      }
+
+      .step-number {
+        color: var(--muted-foreground);
+        font-family: var(--font-mono);
+        font-size: 11px;
+      }
+
+      .callout {
+        margin-top: 18px;
+        border-left: 3px solid var(--annotation-highlight);
+        background: color-mix(in srgb, var(--annotation-highlight) 8%, transparent);
+        padding: 14px 16px;
+      }
+
+      .callout strong {
+        display: block;
+        margin-bottom: 4px;
+      }
+
+      .callout p {
+        margin: 0;
+        color: var(--muted-foreground);
+      }
+
+      .comparison {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+
+      .comparison article,
+      .risk,
+      details {
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 1.4);
+        background: var(--card);
+      }
+
+      .comparison article,
+      .risk {
+        padding: 20px;
+      }
+
+      .comparison ul,
+      .phase ul,
+      .gate-list,
+      .definition-list {
+        margin: 12px 0 0;
+        padding-left: 20px;
+      }
+
+      li + li {
+        margin-top: 7px;
+      }
+
+      .phases {
+        display: grid;
+        gap: 12px;
+      }
+
+      .phase {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) minmax(140px, 0.25fr);
+        gap: 16px;
+        align-items: start;
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 1.4);
+        background: var(--card);
+        padding: 20px;
+      }
+
+      .phase-output {
+        border-left: 1px solid var(--border);
+        padding-left: 16px;
+        color: var(--muted-foreground);
+        font-size: 12px;
+      }
+
+      .phase-output strong {
+        display: block;
+        margin-bottom: 4px;
+        color: var(--foreground);
+      }
+
+      .table-wrap {
+        overflow-x: auto;
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 1.4);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: var(--card);
+        font-size: 13px;
+      }
+
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        white-space: nowrap;
+      }
+
+      th,
+      td {
+        border-bottom: 1px solid var(--border);
+        padding: 13px 14px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        background: var(--muted);
+        color: var(--muted-foreground);
+        font-size: 11px;
+        font-weight: 650;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      tr:last-child td {
+        border-bottom: 0;
+      }
+
+      td:first-child {
+        font-weight: 620;
+      }
+
+      .status-required {
+        color: var(--status-success);
+        font-weight: 650;
+      }
+
+      .status-blocked {
+        color: var(--destructive);
+        font-weight: 650;
+      }
+
+      .artifact-grid,
+      .risk-grid,
+      .gate-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 14px;
+      }
+
+      .artifact {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        border-bottom: 1px solid var(--border);
+        padding: 10px 0;
+      }
+
+      .artifact code {
+        border: 0;
+        background: transparent;
+        padding: 0;
+      }
+
+      details {
+        overflow: hidden;
+      }
+
+      details + details {
+        margin-top: 10px;
+      }
+
+      summary {
+        cursor: pointer;
+        padding: 15px 18px;
+        font-weight: 620;
+      }
+
+      details[open] summary {
+        border-bottom: 1px solid var(--border);
+        background: var(--muted);
+      }
+
+      .details-body {
+        padding: 18px;
+      }
+
+      .details-body p:last-child,
+      .details-body ul:last-child {
+        margin-bottom: 0;
+      }
+
+      .gate {
+        border-top: 2px solid var(--foreground);
+        background: var(--card);
+        padding: 18px 0 0;
+      }
+
+      .subsection-heading {
+        margin-top: 28px;
+      }
+
+      .gate small {
+        color: var(--muted-foreground);
+      }
+
+      .risk strong {
+        display: block;
+        margin-bottom: 7px;
+      }
+
+      .rollout {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 0;
+      }
+
+      .rollout-step {
+        position: relative;
+        border-top: 1px solid var(--ring);
+        padding: 24px 20px 0 0;
+      }
+
+      .rollout-step::before {
+        position: absolute;
+        top: -5px;
+        left: 0;
+        width: 9px;
+        height: 9px;
+        border-radius: 999px;
+        background: var(--foreground);
+        content: '';
+      }
+
+      .rollout-step p {
+        color: var(--muted-foreground);
+        font-size: 12px;
+      }
+
+      .source-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .source-list a {
+        display: inline-flex;
+        min-height: 32px;
+        align-items: center;
+        border: 1px solid var(--border);
+        border-radius: calc(var(--radius) * 0.8);
+        background: var(--card);
+        padding: 5px 10px;
+        text-decoration: none;
+      }
+
+      .source-list a:hover {
+        background: var(--accent);
+      }
+
+      footer {
+        border-top: 1px solid var(--border);
+        padding-top: 28px;
+        color: var(--muted-foreground);
+        font-size: 12px;
+      }
+
+      @media (max-width: 900px) {
+        .shell {
+          display: block;
+        }
+
+        .sidebar {
+          position: static;
+          width: 100%;
+          height: auto;
+          border-right: 0;
+          border-bottom: 1px solid var(--border);
+          padding: 18px 24px;
+        }
+
+        .brand {
+          margin-bottom: 12px;
+        }
+
+        .nav-heading {
+          display: none;
+        }
+
+        nav {
+          display: flex;
+          gap: 4px;
+          overflow-x: auto;
+          padding-bottom: 2px;
+        }
+
+        nav a {
+          flex: 0 0 auto;
+        }
+
+        main {
+          padding: 48px 28px 72px;
+        }
+
+        .section-heading,
+        .architecture,
+        .rollout {
+          grid-template-columns: 1fr 1fr;
+        }
+
+        .architecture-step:not(:last-child)::after {
+          display: none;
+        }
+      }
+
+      @media (max-width: 640px) {
+        main {
+          padding-inline: 18px;
+        }
+
+        .section-heading,
+        .architecture,
+        .comparison,
+        .artifact-grid,
+        .risk-grid,
+        .gate-grid,
+        .rollout {
+          grid-template-columns: 1fr;
+        }
+
+        .phase {
+          grid-template-columns: auto minmax(0, 1fr);
+        }
+
+        .phase-output {
+          grid-column: 2;
+          border-top: 1px solid var(--border);
+          border-left: 0;
+          padding: 12px 0 0;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          scroll-behavior: auto;
+        }
+      }
+
+      @media print {
+        :root {
+          color-scheme: light;
+        }
+
+        .shell {
+          display: block;
+        }
+
+        .sidebar {
+          display: none;
+        }
+
+        main {
+          width: 100%;
+          padding: 0;
+        }
+
+        body {
+          print-color-adjust: exact;
+          -webkit-print-color-adjust: exact;
+        }
+
+        .phase,
+        .risk,
+        .architecture-step,
+        .comparison article,
+        .gate,
+        .rollout-step {
+          break-inside: avoid;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <aside class="sidebar" aria-label="Plan navigation">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">O</span>
+          <span>Orca engineering</span>
+        </div>
+        <div class="nav-heading">Plan</div>
+        <nav aria-label="Plan sections">
+          <a href="#decision">Decision</a>
+          <a href="#architecture">Architecture</a>
+          <a href="#phases">Implementation</a>
+          <a href="#artifacts">Artifacts</a>
+          <a href="#fallback">Fallback</a>
+          <a href="#validation">Validation</a>
+          <a href="#risks">Risks</a>
+          <a href="#rollout">Rollout</a>
+          <a href="#done">Definition of done</a>
+        </nav>
+        <div class="nav-heading">Context</div>
+        <nav aria-label="Related issues">
+          <a href="https://github.com/stablyai/orca/issues/8450">Issue #8450</a>
+          <a href="https://github.com/stablyai/orca/issues/1693">Issue #1693</a>
+        </nav>
+      </aside>
+
+      <main>
+        <header id="decision">
+          <div class="meta-row">
+            <span class="eyebrow">Implementation plan · 14 July 2026</span>
+            <div class="pill-row" role="list" aria-label="Plan status">
+              <span class="pill" role="listitem">Draft</span>
+              <span class="pill" role="listitem">SSH relay</span>
+              <span class="pill" role="listitem">Regression gated</span>
+            </div>
+          </div>
+          <h1>Ship the relay as a verified runtime, not a remote npm project.</h1>
+          <p class="lede">
+            Publish self-contained, platform-specific relay runtimes through the same GitHub Release
+            used by the Orca desktop app. Orca downloads and verifies the matching runtime locally,
+            transfers it over the existing SSH connection, and launches it from an immutable remote
+            cache.
+          </p>
+          <div class="decision">
+            <span class="decision-index" aria-hidden="true">✓</span>
+            <div>
+              <h3>Recommended decision</h3>
+              <p>
+                Make the verified runtime the primary path, keep the existing embedded relay plus
+                remote Node/npm installer as an automatic fallback only for classified availability
+                and compatibility failures, and remove or narrow that fallback only after the
+                complete declared support matrix has passed and soaked. Build and sign relay
+                artifacts before desktop packaging so every app embeds the exact signed
+                tuple-to-content manifest needed for offline remote-cache reuse.
+              </p>
+            </div>
+          </div>
+        </header>
+
+        <section id="architecture">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Target architecture</div>
+              <h2>The SSH host never needs GitHub access.</h2>
+            </div>
+            <p>
+              The desktop owns release access, signature verification, caching, and extraction. SSH
+              authentication/connection and relay RPC transport stay unchanged. Bootstrap artifact
+              transfer is materially redesigned, independently gated, and still travels only through
+              the authenticated SSH connection.
+            </p>
+          </div>
+
+          <ol class="architecture" aria-label="Relay artifact delivery flow">
+            <li class="architecture-step">
+              <span class="step-number">01</span>
+              <strong>GitHub Release</strong>
+              <p>
+                Relay build precedes desktop builds and emits the signed manifest plus exact
+                archives.
+              </p>
+            </li>
+            <li class="architecture-step">
+              <span class="step-number">02</span>
+              <strong>Local cache</strong>
+              <p>
+                Embedded manifest resolves identity offline; downloaded bytes are verified and
+                extracted atomically.
+              </p>
+            </li>
+            <li class="architecture-step">
+              <span class="step-number">03</span>
+              <strong>SSH transfer</strong>
+              <p>Bounded streaming over SFTP or system SSH; remote tar is an optional fast path.</p>
+            </li>
+            <li class="architecture-step">
+              <span class="step-number">04</span>
+              <strong>Remote cache</strong>
+              <p>
+                Match the embedded content ID, verify transferred files once, record proof, then
+                launch.
+              </p>
+            </li>
+          </ol>
+
+          <div class="callout">
+            <strong>What “100% validated” means</strong>
+            <p>
+              Every required cell in the declared two-layer, risk-based matrix has evidence. It does
+              not mean every possible client × SSH server combination. A tuple without
+              real-environment proof stays on the legacy path and is not enabled by default.
+            </p>
+          </div>
+        </section>
+
+        <section id="baseline">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Baseline</div>
+              <h2>Change the dependency boundary without changing relay behavior.</h2>
+            </div>
+            <p>
+              The protocol, SSH authentication/connection, relay RPC transport, immutable install
+              directories, locks, reconnect logic, and garbage collection stay in place. Packaging
+              and bootstrap artifact transfer are the moving parts.
+            </p>
+          </div>
+
+          <div class="comparison">
+            <article>
+              <h3>Today</h3>
+              <ul>
+                <li>Orca embeds platform-neutral relay JavaScript.</li>
+                <li>The remote supplies Node and npm.</li>
+                <li>Remote npm installs <code>node-pty</code> and <code>@parcel/watcher</code>.</li>
+                <li>Linux may require Python, make, a compiler, and registry access.</li>
+                <li>Incomplete Node/npm pairs reproduce issue #8450.</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Target</h3>
+              <ul>
+                <li>GitHub stores a complete, signed relay runtime per tuple.</li>
+                <li>The desktop downloads, verifies, and caches it.</li>
+                <li>
+                  POSIX targets require a declared POSIX <code>sh</code>/byte-stream/file-operation
+                  baseline; Windows targets require a declared PowerShell/.NET baseline.
+                </li>
+                <li>
+                  The authenticated account needs permission to write and execute; Node, Python,
+                  npm, and tar are not prerequisites.
+                </li>
+                <li>Bundled Node loads native modules built against that exact runtime.</li>
+                <li>The existing installer remains available if compatibility probing fails.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section id="phases">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Implementation</div>
+              <h2>Eight reviewable phases, no big-bang switch.</h2>
+            </div>
+            <p>
+              Each phase has an independently testable output. Early phases add evidence and
+              artifacts without changing the default SSH connection path.
+            </p>
+          </div>
+
+          <div class="phases">
+            <article class="phase">
+              <span class="phase-index">0</span>
+              <div>
+                <h3>Stabilize the legacy fallback</h3>
+                <p>
+                  Finish the narrow #8450 change so Node and npm are selected as one coherent
+                  toolchain. Keep it separate from runtime distribution so affected users receive a
+                  small, reviewable fix first.
+                </p>
+              </div>
+              <div class="phase-output">
+                <strong>Output</strong>Legacy bootstrap handles the reported NVM layout.
+              </div>
+            </article>
+
+            <article class="phase">
+              <span class="phase-index">1</span>
+              <div>
+                <h3>Define the runtime contract</h3>
+                <p>
+                  Specify archive layout, manifest schema, platform/libc selection, Node version,
+                  protocol identity, dependency versions, licenses, file modes, support baselines,
+                  and exact POSIX/Windows bootstrap primitives. Hash the full runtime contents
+                  rather than only relay JavaScript.
+                </p>
+              </div>
+              <div class="phase-output">
+                <strong>Output</strong>Versioned schema plus pure selector and identity tests.
+              </div>
+            </article>
+
+            <article class="phase">
+              <span class="phase-index">2</span>
+              <div>
+                <h3>Build self-contained runtimes</h3>
+                <p>
+                  Assemble pinned Node, relay entries, patched <code>node-pty</code>, the exact
+                  <code>@parcel/watcher</code> package, and required JavaScript dependencies on
+                  matching CI environments. Run executable smoke probes before archiving.
+                </p>
+              </div>
+              <div class="phase-output">
+                <strong>Output</strong>Locally verifiable archives for every enabled tuple.
+              </div>
+            </article>
+
+            <article class="phase">
+              <span class="phase-index">3</span>
+              <div>
+                <h3>Sign and publish release assets</h3>
+                <p>
+                  Use target-native relay build jobs plus native signing jobs. A fail-closed
+                  aggregate job waits for every signed macOS/Windows byte, computes final hashes,
+                  signs the canonical manifest, and makes its immutable output a prerequisite of
+                  every desktop packaging job. Upload those exact archives, manifest, and signature
+                  to the existing draft GitHub Release. Extend the required-assets gate to verify
+                  presence, size, signature, manifest coverage, byte identity, and read-back before
+                  publication; timeout, signing failure, exhausted retry, or manual-approval failure
+                  leaves a recoverable draft and blocks every consumer.
+                </p>
+              </div>
+              <div class="phase-output">
+                <strong>Output</strong>Atomic app-and-relay release publication.
+              </div>
+            </article>
+
+            <article class="phase">
+              <span class="phase-index">4</span>
+              <div>
+                <h3>Add the desktop artifact resolver</h3>
+                <p>
+                  Resolve the remote tuple and content ID from the embedded signed manifest, use its
+                  exact build tag and direct release URL, download through Electron networking,
+                  verify before extraction, and atomically populate a content-addressed cache.
+                  Coordinate cache ownership across app processes and preserve
+                  <code>ORCA_RELAY_PATH</code> for development.
+                </p>
+              </div>
+              <div class="phase-output">
+                <strong>Output</strong>Safe cold, warm, concurrent, and offline cache paths.
+              </div>
+            </article>
+
+            <article class="phase">
+              <span class="phase-index">5</span>
+              <div>
+                <h3>Deploy and validate the runtime</h3>
+                <p>
+                  Replace whole-tree buffering and serial-only assumptions with bounded file
+                  streaming: capability-probed tar may accelerate POSIX system SSH, but no-tar file
+                  streaming is required and uses the SSH channel as a byte-preserving stdin stream
+                  into exclusive per-file staging with only the declared shell/file primitives;
+                  Windows uses a bounded binary PowerShell/.NET path and must not materialize the
+                  runtime as one JSON/base64 buffer; SFTP uses bounded concurrency. After locally
+                  verifying signed metadata and archive/tree hashes, transfer through authenticated
+                  SSH, restore every declared executable bit, then execute the transferred bundled
+                  Node to hash the entire staging tree. Verify the full tree, run bundled
+                  Node/native-module and minimal PTY/watcher probes, write a structured
+                  <code>.install-complete</code> containing schema, mode, and digest, atomically
+                  publish the immutable install, and only then launch. Preserve current locks,
+                  reconnect, and garbage collection.
+                </p>
+              </div>
+              <div class="phase-output">
+                <strong>Output</strong>Primary path performs no remote npm or HTTP operation.
+              </div>
+            </article>
+
+            <article class="phase">
+              <span class="phase-index">6</span>
+              <div>
+                <h3>Make fallback explicit and observable</h3>
+                <p>
+                  Add <code>auto</code>, <code>bundled</code>, and <code>legacy</code> modes. The
+                  public Beta is a per-SSH-target <code>bundled-auto</code> choice that maps to
+                  <code>auto</code>; absent or unknown configuration maps to <code>legacy</code>,
+                  and forced <code>bundled</code> remains an engineering/support diagnostic. Record
+                  privacy-safe stage and fallback reason codes in diagnostics, without hostnames,
+                  usernames, or paths. Give every stage a budget and shared AbortSignal. Before
+                  fallback, cancel and await all download, extraction, upload, and probe work.
+                  Bundled and legacy installs use distinct identities, locks, and sentinels so late
+                  work cannot mutate the other mode. Only availability/compatibility failures may
+                  enter proven legacy behavior in <code>auto</code>; signature, hash,
+                  archive-safety, or native-signature failures fail closed without automatic mode
+                  switching.
+                </p>
+              </div>
+              <div class="phase-output">
+                <strong>Output</strong>Automatic recovery plus a support escape hatch.
+              </div>
+            </article>
+
+            <article class="phase">
+              <span class="phase-index">7</span>
+              <div>
+                <h3>Gate rollout by evidence</h3>
+                <p>
+                  Publish assets before consuming them, then progress through opt-in RC, internal
+                  canary, default-on RC, and stable. Enable only tuples with complete live evidence;
+                  keep the fallback through at least two stable cycles.
+                </p>
+              </div>
+              <div class="phase-output">
+                <strong>Output</strong>Reversible rollout with per-tuple promotion.
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section id="artifacts">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Artifact contract</div>
+              <h2>Build for the runtime, architecture, and libc together.</h2>
+            </div>
+            <p>
+              Bundling Node with its native modules removes ABI ambiguity. Linux libc remains a
+              separate compatibility boundary and must be detected before artifact selection.
+            </p>
+          </div>
+
+          <div class="artifact-grid">
+            <div>
+              <div class="artifact">
+                <code>linux-x64-glibc</code><span>Decision-gated candidate</span>
+              </div>
+              <div class="artifact">
+                <code>linux-arm64-glibc</code><span>Decision-gated candidate</span>
+              </div>
+              <div class="artifact">
+                <code>linux-x64-musl</code><span>Gate on runtime source</span>
+              </div>
+              <div class="artifact">
+                <code>linux-arm64-musl</code><span>Gate on real runner</span>
+              </div>
+            </div>
+            <div>
+              <div class="artifact">
+                <code>darwin-x64</code><span>Decision-gated candidate</span>
+              </div>
+              <div class="artifact">
+                <code>darwin-arm64</code><span>Decision-gated candidate</span>
+              </div>
+              <div class="artifact">
+                <code>win32-x64</code><span>Decision-gated candidate</span>
+              </div>
+              <div class="artifact"><code>win32-arm64</code><span>Gate on real runner</span></div>
+            </div>
+          </div>
+
+          <div class="callout">
+            <strong>Promotion rule</strong>
+            <p>
+              Milestone 1 starts with no declared bundled tuples and decides which candidates become
+              enabled. Once enabled, a tuple blocks release if its asset or live proof is missing.
+              Candidates awaiting a trustworthy Node runtime source or real hardware remain
+              supported only if their legacy E2E still proves current behavior. Otherwise they stay
+              ineligible for rollout rather than being silently claimed as supported.
+            </p>
+          </div>
+
+          <details open>
+            <summary>Archive contents</summary>
+            <div class="details-body">
+              <ul>
+                <li>Bundled Node executable pinned to one version.</li>
+                <li><code>relay.js</code> and crash-isolated <code>relay-watcher.js</code>.</li>
+                <li>Orca-patched <code>node-pty@1.1.0</code> built for the bundled runtime.</li>
+                <li>
+                  <code>@parcel/watcher@2.5.6</code> with exactly one native optional package.
+                </li>
+                <li>Runtime metadata, dependency licenses, and a file-level SHA-256 manifest.</li>
+                <li>
+                  No development dependencies, package manager, compiler, source maps, or PDBs
+                  unless explicitly needed for diagnostics.
+                </li>
+              </ul>
+            </div>
+          </details>
+
+          <details open>
+            <summary>Release trust and identity</summary>
+            <div class="details-body">
+              <ul>
+                <li>
+                  The packaged app embeds the signed manifest, exact build tag, and accepted public
+                  keys.
+                </li>
+                <li>
+                  Relay artifacts are immutable inputs to every desktop build, and those exact bytes
+                  are uploaded.
+                </li>
+                <li>
+                  A protected release environment signs canonical, versioned manifest bytes with
+                  narrowly scoped key access.
+                </li>
+                <li>
+                  Define key IDs, dual-sign rotation, revocation response, and exact-tag
+                  anti-rollback before implementation.
+                </li>
+                <li>
+                  Every Node/CVE/runtime/key change ships as a new desktop tag/build with a newly
+                  embedded manifest; old clients stay frozen to their embedded manifest and accepted
+                  keys.
+                </li>
+                <li>
+                  There is no mutable freshness channel or runtime-only <code>latest</code> lookup;
+                  emergency refresh and key response use the normal desktop update path.
+                </li>
+                <li>Archive identity includes every executable and native artifact.</li>
+                <li>
+                  Downloads use <code>/releases/download/&lt;exact-tag&gt;/&lt;asset&gt;</code>,
+                  never a mutable latest URL.
+                </li>
+                <li>
+                  Signature or hash failure rejects and deletes the artifact before any remote
+                  transfer.
+                </li>
+                <li>
+                  Preserve official Node signatures where possible and sign Orca-built macOS and
+                  Windows native code.
+                </li>
+                <li>
+                  Native build/signing jobs verify platform-native trust on native runners and put
+                  the attestation plus exact byte hashes in the signed manifest; clients verify that
+                  portable signed evidence rather than assuming local tooling for a different target
+                  OS.
+                </li>
+                <li>
+                  The target repeats native-policy execution probes before finalization;
+                  native-trust failure at either boundary fails closed.
+                </li>
+              </ul>
+            </div>
+          </details>
+
+          <details open>
+            <summary>Platform and compatibility selection</summary>
+            <div class="details-body">
+              <ul>
+                <li>
+                  Detect Linux libc without Node: prefer marked
+                  <code>getconf GNU_LIBC_VERSION</code>, then parse marked
+                  <code>ldd --version</code> output and musl loader paths.
+                </li>
+                <li>
+                  Treat conflicting, noisy, absent, or unparseable libc evidence as unknown;
+                  <code>auto</code> deterministically selects legacy.
+                </li>
+                <li>
+                  Manifest entries declare minimum glibc or musl, libstdc++, kernel, macOS, and
+                  Windows build requirements.
+                </li>
+                <li>
+                  Probe requirements before download and again by executing bundled Node before
+                  install finalization.
+                </li>
+                <li>
+                  Cover BusyBox, Alpine, old glibc, containers, Rosetta, startup noise, and
+                  ambiguous output in selector and live tests.
+                </li>
+                <li>
+                  Define the exact POSIX baseline: POSIX <code>sh</code>, byte-preserving
+                  stdin-to-file via <code>cat</code> or a proven equivalent, and required
+                  <code>mkdir</code
+                  >/<code>rm</code>/<code>mv</code>/<code>chmod</code>/<code>test</code>/<code
+                    >nohup</code
+                  >
+                  semantics.
+                </li>
+                <li>
+                  Define the exact Windows OpenSSH PowerShell/.NET versions and binary
+                  file/rename/permission/process primitives; missing primitives are an explicit
+                  compatibility result.
+                </li>
+                <li>
+                  The no-tar path needs no Node, Python, or archive program: Orca frames manifest
+                  files locally and streams each file over SSH into exclusive staging.
+                </li>
+              </ul>
+            </div>
+          </details>
+        </section>
+
+        <section id="fallback">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Compatibility</div>
+              <h2>Fallback is part of the design, not an afterthought.</h2>
+            </div>
+            <p>
+              Availability and compatibility failures may use a separately proven legacy path.
+              Signature, hash, archive-safety, extracted-tree, and native-signature failures fail
+              closed in <code>auto</code>; they never trigger an automatic mode switch.
+            </p>
+          </div>
+
+          <div class="table-wrap" role="region" aria-label="Fallback decisions" tabindex="0">
+            <table>
+              <caption class="visually-hidden">
+                Relay runtime fallback decisions and expected user impact
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Condition</th>
+                  <th scope="col">Action</th>
+                  <th scope="col">User impact</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    Previously validated runtime with matching structured sentinel and warm-path
+                    structural checks
+                  </td>
+                  <td>
+                    Trust initial-install proof under the immutable-directory assumption and launch
+                    without a full-tree rehash
+                  </td>
+                  <td>No download, transfer, or npm work</td>
+                </tr>
+                <tr>
+                  <td>Verified local cache hit</td>
+                  <td>Upload and validate</td>
+                  <td>Remote may remain fully offline</td>
+                </tr>
+                <tr>
+                  <td>Detected local or remote cache corruption</td>
+                  <td>
+                    Quarantine it and reinstall only from freshly verified bundled bytes; if
+                    recovery cannot complete, fail closed without automatic legacy
+                  </td>
+                  <td>No corrupted cache is launched or hidden by fallback</td>
+                </tr>
+                <tr>
+                  <td>GitHub timeout, 404, 429, or 5xx</td>
+                  <td>Use legacy path in <code>auto</code> mode</td>
+                  <td>Existing behavior remains available</td>
+                </tr>
+                <tr>
+                  <td>
+                    Unsupported tuple or pre-execution compatibility probe proves the runtime cannot
+                    execute
+                  </td>
+                  <td>Use legacy path and record reason</td>
+                  <td>Current behavior is retained only where the legacy E2E passes</td>
+                </tr>
+                <tr>
+                  <td>
+                    Signature, hash, archive-safety, extracted/transferred-tree, bundled-Node
+                    integrity, or native-signature failure
+                  </td>
+                  <td>
+                    Fail closed, delete or quarantine rejected bytes, and do not start automatic
+                    legacy
+                  </td>
+                  <td>
+                    Security failure is explicit and requires a trusted update or operator-selected
+                    recovery
+                  </td>
+                </tr>
+                <tr>
+                  <td>Forced <code>bundled</code> mode fails</td>
+                  <td>Fail with the exact stage and recovery guidance</td>
+                  <td>No hidden change of requested mode</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <details open>
+            <summary>Fallback state machine</summary>
+            <div class="details-body">
+              <ol>
+                <li>Resolve the tuple and expected content identity from the embedded manifest.</li>
+                <li>
+                  Run bundled stages under one parent AbortController with separate download,
+                  extraction, transfer, and probe budgets.
+                </li>
+                <li>
+                  On an eligible failure, abort the stage, close child processes/channels, and await
+                  every task and cleanup promise.
+                </li>
+                <li>
+                  Confirm no bundled lock or partial writer remains, then start legacy deployment
+                  under a mode-qualified identity and lock.
+                </li>
+                <li>
+                  Ignore late callbacks by generation; they may report diagnostics but cannot write
+                  sentinels, launch, or mutate either install.
+                </li>
+              </ol>
+              <p>
+                Integrity failures, including detected cache mutation, stop before this transition
+                and cannot automatically select legacy. Hostile control of the authenticated remote
+                account is outside the integrity threat model; the remote proof establishes initial
+                transfer/finalization correctness. Warm launches assume Orca's completed directory
+                remains immutable; the sentinel is not ongoing proof against later filesystem
+                mutation. Detected warm-cache mutation fails closed. This does not protect against a
+                remote user who can replace both runtime and sentinel.
+              </p>
+            </div>
+          </details>
+
+          <details open>
+            <summary>Remote verification trust boundary and order</summary>
+            <div class="details-body">
+              <ol>
+                <li>
+                  Verify the embedded signature, tuple, limits, archive SHA-256, and extracted tree
+                  locally.
+                </li>
+                <li>
+                  Transfer only those verified files through authenticated SSH into an exclusive
+                  staging directory.
+                </li>
+                <li>
+                  Do not depend on remote <code>sha256sum</code> or <code>shasum</code>; execute the
+                  transferred bundled Node to hash every staged file and compare the complete
+                  manifest.
+                </li>
+                <li>
+                  Only after full-tree hashing, native probes, and PTY/watcher smoke may Orca write
+                  the structured completion sentinel and publish the install.
+                </li>
+              </ol>
+              <p>
+                Local verification plus authenticated transfer and exclusive staging is the
+                pre-execution integrity boundary. Executing bundled Node is intentionally the first
+                staged binary execution and verifies transfer correctness before completion. A
+                hostile authenticated remote account remains outside scope because it can replace
+                both the runtime and its proof.
+              </p>
+            </div>
+          </details>
+        </section>
+
+        <section id="validation">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Validation</div>
+              <h2>Prove production behavior, failure behavior, and rollback behavior.</h2>
+            </div>
+            <p>
+              Mock tests protect decision logic. Release promotion additionally requires the real
+              archive, real native binaries, a real SSH daemon, and the exact packaged desktop path.
+            </p>
+          </div>
+
+          <div class="table-wrap" role="region" aria-label="Validation matrix" tabindex="0">
+            <table>
+              <caption class="visually-hidden">
+                Required relay validation surfaces, cases, and pass oracles
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Surface</th>
+                  <th scope="col">Required cases</th>
+                  <th scope="col">Oracle</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Build</td>
+                  <td>
+                    Every declared tuple; minimum OS baseline; exact Node and native dependency
+                    versions; SBOM and provenance
+                  </td>
+                  <td>
+                    Archive runs on target, contents match manifest, native signatures pass, no
+                    unexpected platform package remains
+                  </td>
+                </tr>
+                <tr>
+                  <td>Platform selection</td>
+                  <td>
+                    glibc/musl and version probes, BusyBox, Alpine, containers, old glibc, Rosetta,
+                    noisy and conflicting output
+                  </td>
+                  <td>
+                    One compatible tuple is selected, or unknown deterministically selects tested
+                    legacy behavior
+                  </td>
+                </tr>
+                <tr>
+                  <td>Remote environment</td>
+                  <td>
+                    No Node/npm/Python/compiler/tar/hash tools; blocked egress; missing required
+                    primitives; BusyBox; NVM below shell guard; read-only/noexec home; quota and
+                    inode exhaustion
+                  </td>
+                  <td>
+                    Declared POSIX or Windows primitive baselines connect without undeclared tools;
+                    missing primitives and filesystem constraints classify compatibly and never
+                    improvise an untrusted command path
+                  </td>
+                </tr>
+                <tr>
+                  <td>Download and cache</td>
+                  <td>
+                    Redirect and header scoping, proxy, deleted asset, cold/warm/offline cache,
+                    multiple app processes, eviction, permissions, cancellation, timeout,
+                    404/429/5xx, disk full, corruption
+                  </td>
+                  <td>
+                    One verified cache entry or clean availability fallback; corruption is
+                    quarantined and recovered only from freshly verified bytes or fails closed
+                  </td>
+                </tr>
+                <tr>
+                  <td>Archive security</td>
+                  <td>
+                    Bad signature/hash/native signature, wrong tuple, traversal path, absolute path,
+                    symlink escape, oversized expansion
+                  </td>
+                  <td>
+                    Manifest/archive failures are rejected before transfer; native trust is verified
+                    on target-native build/read-back and again by target-policy probes before
+                    finalization; every integrity failure fails closed
+                  </td>
+                </tr>
+                <tr>
+                  <td>SSH deployment</td>
+                  <td>
+                    Full-size runtime over SFTP and POSIX/Windows system SSH; tar/no-tar; no remote
+                    hash tools; corrupted upload; bundled-Node corruption/failure; bounded memory
+                    and concurrency; <code>MaxSessions=1</code>; interrupted upload; stale lock
+                  </td>
+                  <td>
+                    Bundled Node hashes the full staged tree before sentinel write;
+                    corruption/failure leaves no complete install, memory stays in budget, and the
+                    ordering is asserted
+                  </td>
+                </tr>
+                <tr>
+                  <td>PTY and watcher</td>
+                  <td>
+                    Spawn, input, resize, exit, shell environment, create/rename/modify/delete
+                    events, watcher crash
+                  </td>
+                  <td>
+                    Exact PTY bytes and watcher events; relay PID and existing PTY survive watcher
+                    replacement
+                  </td>
+                </tr>
+                <tr>
+                  <td>Relay API conformance</td>
+                  <td>
+                    PTY, Git, filesystem and streaming RPCs, preflight, agent hooks, port scan,
+                    aborts, and protocol handshake
+                  </td>
+                  <td>
+                    The packaged runtime matches existing relay request, response, streaming,
+                    cancellation, and error contracts
+                  </td>
+                </tr>
+                <tr>
+                  <td>Lifecycle and fallback</td>
+                  <td>
+                    Reconnect, PTY reattach, restart, concurrent clients, upgrade, downgrade,
+                    interrupted upgrade, GC, timeout-to-legacy, forced rollback
+                  </td>
+                  <td>
+                    No lost session, protocol drift, late mutation, background process, cross-mode
+                    lock/sentinel use, or deletion of a live version
+                  </td>
+                </tr>
+                <tr>
+                  <td>Performance</td>
+                  <td>Cold and warm paths over 1/10/100 Mbps links and 50–200 ms latency</td>
+                  <td>
+                    Warm path has no meaningful regression; cold p95 does not exceed agreed legacy
+                    baseline
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="callout">
+            <strong>Risk-based matrix, not an implied full Cartesian</strong>
+            <p>
+              Evidence has two layers. Every enabled remote tuple must pass both built-in SFTP and
+              system SSH, including Windows remote/system SSH and <code>MaxSessions=1</code>. Every
+              supported client OS/architecture must separately prove resolver/cache plus both
+              transfer families against representative POSIX and Windows remotes. Each required cell
+              has an evidence ID; untested client × remote combinations are not claimed.
+            </p>
+          </div>
+
+          <div class="callout">
+            <strong>GitHub Actions runner policy</strong>
+            <p>
+              GitHub Actions is the primary orchestration and evidence surface for PR, nightly,
+              release, and promotion gates. A GitHub-hosted runner may fill a required cell only
+              when it provides real hardware or native virtualization for the declared
+              OS/architecture and exercises a real OpenSSH daemon, the full-size packaged runtime,
+              and the production transport named by that cell. Same-host and native-container
+              targets qualify only when they preserve the declared remote, SSH, primitive, egress,
+              and isolation conditions; mocks, reduced fixtures, cross-builds, and QEMU-only runs do
+              not qualify as live evidence.
+            </p>
+            <p>
+              Cross-family client-to-remote cells use workflow-provisioned ephemeral native SSH
+              targets or an approved self-hosted target pool; the remote need not itself be
+              GitHub-hosted. Each job records the runner label and image, native architecture,
+              remote image or snapshot identity, teardown result, commands, metrics, and artifacts.
+              A tuple stays on proven legacy behavior when no qualifying native runner or reachable
+              representative remote is available. Numeric regression comparisons use a repeatable
+              runner class or a dedicated runner when hosted-runner variance would make the agreed
+              threshold inconclusive.
+            </p>
+          </div>
+
+          <h3 class="subsection-heading">Release gates</h3>
+          <div class="gate-grid">
+            <article class="gate">
+              <h3>PR gate</h3>
+              <small>Every change</small>
+              <ul class="gate-list">
+                <li>
+                  Selector, identity, manifest, cache, extraction, fallback, and install fault
+                  tests.
+                </li>
+                <li>Existing SSH relay, PTY, watcher, reconnect, and release contract suites.</li>
+                <li>At least Linux x64 glibc live artifact E2E.</li>
+              </ul>
+            </article>
+            <article class="gate">
+              <h3>Nightly gate</h3>
+              <small>Broad compatibility</small>
+              <ul class="gate-list">
+                <li>All available real remote tuples and both SSH transport families.</li>
+                <li>Network fault matrix and constrained bandwidth/latency runs.</li>
+                <li>Upgrade, downgrade, concurrent install, and remote cache GC soak.</li>
+              </ul>
+            </article>
+            <article class="gate">
+              <h3>Release gate</h3>
+              <small>Blocks publication</small>
+              <ul class="gate-list">
+                <li>
+                  Every enabled archive built, signed, uploaded, downloaded back, and executed.
+                </li>
+                <li>
+                  Target-native build jobs and native signing jobs feed one fail-closed
+                  aggregate/manifest-signing job.
+                </li>
+                <li>
+                  Signed macOS and Windows bytes return before final hashes and manifest signature
+                  are produced.
+                </li>
+                <li>
+                  Every desktop embeds the same signed manifest whose exact bytes and archives are
+                  uploaded.
+                </li>
+                <li>Manifest covers the exact app tag and contains no missing or extra tuple.</li>
+                <li>
+                  Platform-native signatures, SBOM, provenance, and signing-key policy checks pass.
+                </li>
+                <li>Packaged desktop completes the no-Node, no-egress SSH E2E.</li>
+                <li>
+                  Timeout, retry exhaustion, manual-approval failure, signing failure, and
+                  recovered-draft rehearsals all block unsafe publication.
+                </li>
+              </ul>
+            </article>
+            <article class="gate">
+              <h3>Promotion gate</h3>
+              <small>Blocks default-on</small>
+              <ul class="gate-list">
+                <li>Three consecutive RC builds pass without unexplained fallback.</li>
+                <li>No new PTY, watcher, reconnect, or bootstrap regression in canary evidence.</li>
+                <li>
+                  Forced rollback and the legacy E2E pass for every tuple where fallback is claimed.
+                </li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section id="risks">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Risk register</div>
+              <h2>Resolve these before default-on.</h2>
+            </div>
+            <p>
+              The largest risks are compatibility boundaries and release coupling, not the GitHub
+              download itself.
+            </p>
+          </div>
+
+          <div class="risk-grid">
+            <article class="risk">
+              <strong>Linux baseline mismatch</strong>
+              <p>
+                Build against the oldest supported glibc and libstdc++ baseline; run on that exact
+                baseline before promotion.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Untrusted musl runtime source</strong>
+              <p>
+                Do not invent a binary source. Document provenance and updates, or retain legacy
+                mode for musl until Orca can build it.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Native patch drift</strong>
+              <p>
+                Build from Orca’s lockfile and patch set; assert the patched diagnostic exports and
+                real PTY behavior in every artifact.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Missing release assets</strong>
+              <p>
+                Keep releases draft until all relay assets pass read-back verification; publication
+                depends on the completeness job.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Cold-transfer latency</strong>
+              <p>
+                Cache by content, prefetch last-known target tuples after updates, preserve progress
+                stages, and keep a bounded fallback.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Home directory cannot execute binaries</strong>
+              <p>
+                Probe bundled Node before finalizing. Auto mode falls back to the remote runtime
+                path with a precise diagnostic reason.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Release asset tampering</strong>
+              <p>
+                Verify a signed canonical manifest and archive SHA-256 before extraction; never
+                execute or transfer rejected bytes.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Fallback masks defects</strong>
+              <p>
+                Record stage-specific reason codes and require zero unexplained fallback across the
+                RC promotion window.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Bundled Node lifecycle</strong>
+              <p>
+                Own a supported-version/EOL policy, SBOM and provenance, update cadence, and CVE
+                response SLA. Every refresh ships a new desktop build and embedded manifest;
+                installed old clients remain pinned.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Signing-key lifecycle</strong>
+              <p>
+                Specify canonical bytes, protected-environment access, key IDs, dual-key rotation,
+                revocation response through a desktop update, and exact-tag anti-rollback. Do not
+                add mutable freshness lookup.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>OS-native trust controls</strong>
+              <p>
+                Preserve official Node signatures where possible, sign Orca-built native code, and
+                test macOS Gatekeeper plus Windows Authenticode, WDAC, and antivirus behavior.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Large-runtime transfer</strong>
+              <p>
+                Use bounded streaming and cancellation per transport; prohibit whole-tree
+                JSON/base64 buffering and require a no-tar path before default-on.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Fallback races</strong>
+              <p>
+                Abort and join every bundled stage before legacy starts; separate mode identities
+                and reject callbacks from stale generations.
+              </p>
+            </article>
+            <article class="risk">
+              <strong>Ambiguous host detection</strong>
+              <p>
+                Use marked no-Node probes and conservative version checks. Unknown, conflicting, or
+                unsupported results choose proven legacy behavior.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section id="rollout">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Rollout</div>
+              <h2>Publish, observe, enable, then simplify.</h2>
+            </div>
+            <p>
+              Artifact availability lands before production consumption. Every later stage remains
+              reversible from the same app build.
+            </p>
+          </div>
+
+          <div class="rollout">
+            <article class="rollout-step">
+              <h3>Asset-only</h3>
+              <p>Build and publish runtimes, run read-back E2E, leave production on legacy.</p>
+            </article>
+            <article class="rollout-step">
+              <h3>Per-target Beta</h3>
+              <p>
+                Ship a Beta-tagged option on SSH target add/edit surfaces; every existing and new
+                target remains on legacy unless explicitly opted in.
+              </p>
+            </article>
+            <article class="rollout-step">
+              <h3>Stable Beta soak</h3>
+              <p>
+                Gather privacy-safe real-host evidence while the packaged and persisted default
+                remains legacy.
+              </p>
+            </article>
+            <article class="rollout-step">
+              <h3>Future default review</h3>
+              <p>
+                Change a tuple to default-on only through a separate reviewed decision after CI,
+                native-runner, Beta-usage, support, and rollback gates pass.
+              </p>
+            </article>
+          </div>
+
+          <div class="callout">
+            <strong>Per-target Beta contract</strong>
+            <p>
+              Store an extensible runtime mode per SSH target rather than a global boolean. Missing,
+              malformed, imported, existing, and newly created target configuration defaults to
+              <code>legacy</code>. The Beta option selects bundled-preferred
+              <code>auto</code> behavior only for that target and only on its next connection or an
+              explicit reconnect; it never hot-swaps a live PTY, watcher, or relay generation.
+            </p>
+            <p>
+              Classified availability and compatibility failures may enter proven legacy
+              automatically. Integrity and security failures still fail closed, but the local error
+              surface provides an explicit action to disable Beta for that target and reconnect
+              through legacy. Shipping this option does not authorize changing the default or
+              removing legacy behavior.
+            </p>
+          </div>
+        </section>
+
+        <section id="done">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Definition of done</div>
+              <h2>Stable is blocked until every statement is evidence-backed.</h2>
+            </div>
+            <p>
+              These are release criteria, not aspirations. Missing bundled evidence keeps the
+              affected tuple on legacy only when its legacy E2E passes; otherwise Orca must not
+              claim that tuple as supported.
+            </p>
+          </div>
+
+          <div class="comparison">
+            <article>
+              <h3>Functional and compatibility</h3>
+              <ul class="definition-list">
+                <li>Every enabled tuple passes its real-environment artifact E2E.</li>
+                <li>
+                  A host with no Node, npm, compiler, or egress gets working PTYs and file watching.
+                </li>
+                <li>The exact #8450 environment passes bundled and forced-legacy modes.</li>
+                <li>
+                  Reconnect, reattach, upgrade, downgrade, and rollback preserve live sessions.
+                </li>
+                <li>All relay RPC families pass conformance through the packaged runtime.</li>
+                <li>Existing relay, PTY, watcher, Git, and release suites remain green.</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Release and operations</h3>
+              <ul class="definition-list">
+                <li>
+                  Every asset is signed, hashed, uploaded, read back, and executed before
+                  publication.
+                </li>
+                <li>
+                  Every desktop embeds the exact signed manifest used to identify offline remote
+                  caches.
+                </li>
+                <li>
+                  Transfer memory, cancellation, no-tar, permissions, and structured-sentinel gates
+                  pass.
+                </li>
+                <li>No primary-path remote command invokes npm or opens an HTTP connection.</li>
+                <li>GitHub failure falls back without corrupting local or remote cache state.</li>
+                <li>
+                  Every integrity/security failure fails closed in auto and never starts legacy
+                  automatically.
+                </li>
+                <li>
+                  Node lifecycle, SBOM, provenance, key rotation, and native signing policies are
+                  operational.
+                </li>
+                <li>
+                  Each required two-layer matrix cell links an evidence ID; no untested Cartesian
+                  combinations are claimed.
+                </li>
+                <li>
+                  Warm connections show no meaningful latency regression against the recorded
+                  baseline.
+                </li>
+                <li>Three consecutive RCs pass with zero unexplained fallback reasons.</li>
+              </ul>
+            </article>
+          </div>
+
+          <div class="callout">
+            <strong>Stop condition</strong>
+            <p>
+              If a required live runner, trusted runtime source, compatibility baseline, or rollback
+              proof is unavailable, do not declare the tuple bundled-by-default. Continue serving it
+              through the tested legacy path.
+            </p>
+          </div>
+        </section>
+
+        <section id="references">
+          <div class="section-heading">
+            <div>
+              <div class="section-kicker">Repository anchors</div>
+              <h2>Primary implementation touchpoints.</h2>
+            </div>
+            <p>Links are relative so this document remains useful from a local checkout.</p>
+          </div>
+          <ul class="source-list">
+            <li><a href="../../../config/scripts/build-relay.mjs">Relay build</a></li>
+            <li><a href="../../../src/main/ssh/ssh-relay-deploy.ts">SSH deploy</a></li>
+            <li>
+              <a href="../../../src/main/ssh/ssh-relay-versioned-install.ts">Versioned install</a>
+            </li>
+            <li>
+              <a href="../../../src/main/ssh/ssh-remote-platform-detection.ts"
+                >Platform detection</a
+              >
+            </li>
+            <li>
+              <a href="../../../config/scripts/verify-release-required-assets.mjs"
+                >Release asset gate</a
+              >
+            </li>
+            <li><a href="../../../.github/workflows/release-cut.yml">Release workflow</a></li>
+            <li>
+              <a href="../../../tests/e2e/helpers/docker-ssh-relay-target.ts">Live SSH harness</a>
+            </li>
+          </ul>
+        </section>
+
+        <footer>
+          This plan intentionally keeps the current installer available during rollout. “No
+          regressions” is enforced through declared support, executable evidence, automatic
+          fallback, and a tested rollback—not through an untestable claim about every SSH host.
+        </footer>
+      </main>
+    </div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "test:e2e:terminal-perf:html-report": "node config/scripts/generate-terminal-perf-html-report.mjs",
     "test:e2e:ssh-docker-perf": "node config/scripts/run-ssh-docker-perf-e2e.mjs",
     "test:e2e:ssh-docker-watcher-isolation": "node config/scripts/run-ssh-docker-watcher-isolation-e2e.mjs",
+    "test:e2e:ssh-node-toolchain-resolution": "node config/scripts/run-ssh-node-toolchain-resolution-e2e.mjs",
     "test:e2e:source-control-scale": "pnpm run ensure:electron-runtime && npx playwright test tests/e2e/source-control-large-file-count.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
     "win-update-e2e": "node tools/win-update-e2e/run.mjs",
     "test:e2e:ssh-codex-artifacts-repro": "node config/scripts/run-ssh-codex-artifacts-repro-e2e.mjs",

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -238,6 +238,9 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
   }
 
   it('writes a hardcoded package.json BEFORE running npm install', async () => {
+    vi.mocked(resolveRemoteNodePath).mockResolvedValueOnce(
+      '/home/u/.nvm/versions/node/v22.22.0/bin/node'
+    )
     const conn = makeMockConnection(sftpCapture)
     feed(makeExecResponses({ npmInstall: 'ok', probe: 'ok' }))
 
@@ -262,6 +265,9 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
       (c) => c.includes('npm install') && c.includes('node-pty') && c.includes('@parcel/watcher')
     )
     expect(npmInstallIdx).toBeGreaterThanOrEqual(0)
+    expect(execCalls[npmInstallIdx]).toContain(
+      "export PATH='/home/u/.nvm/versions/node/v22.22.0/bin':$PATH"
+    )
     // Pin actual ordering: number of execCommand calls observed at the moment
     // ws.end() ran for package.json must be < the index of `npm install`.
     // Catches a future refactor that fires SFTP-write and npm install via

--- a/src/main/ssh/ssh-remote-node-resolution.test.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.test.ts
@@ -39,6 +39,27 @@ describe('resolveRemoteNodePath', () => {
       .mockResolvedValueOnce('v20.0.0\n') // version check
 
     await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
+
+    expect(execCommandMock.mock.calls[1]![1]).toBe(
+      "printf '%s\\n' '__ORCA_NODE_VERSION__' && '/usr/local/bin/node' --version && printf '%s\\n' '__ORCA_NPM_VERSION__' && PATH='/usr/local/bin':$PATH '/usr/local/bin/npm' --version"
+    )
+    expect(execCommandMock.mock.calls[1]![2]).toEqual({ wrapCommand: true })
+  })
+
+  it('skips an incomplete system Node and selects a complete NVM toolchain', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/usr/bin/node\n/home/u/.nvm/versions/node/v22.22.0/bin/node\n')
+      .mockRejectedValueOnce(new Error('/usr/bin/npm: not found'))
+      .mockResolvedValueOnce('v22.22.0\n11.13.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
+      '/home/u/.nvm/versions/node/v22.22.0/bin/node'
+    )
+
+    expect(execCommandMock.mock.calls[1]![1]).toContain("'/usr/bin/npm' --version")
+    expect(execCommandMock.mock.calls[2]![1]).toContain(
+      "'/home/u/.nvm/versions/node/v22.22.0/bin/npm' --version"
+    )
   })
 
   it('probes mise install directories', async () => {
@@ -220,10 +241,9 @@ describe('resolveRemoteNodePath', () => {
       '/home/u/.nvm/versions/node/v20.11.0/bin/node'
     )
 
-    expect(execCommandMock).toHaveBeenNthCalledWith(3, conn, `'/bin/zsh' -lc 'command -v node'`, {
-      wrapCommand: false,
-      timeoutMs: 8_000
-    })
+    expect(execCommandMock.mock.calls[2]![1]).toMatch(/^'\/bin\/zsh' -lc /)
+    expect(execCommandMock.mock.calls[2]![1]).toContain('__ORCA_NODE_PATH__')
+    expect(execCommandMock.mock.calls[2]![2]).toEqual({ wrapCommand: false, timeoutMs: 8_000 })
   })
 
   it('falls back to the login shell when every path-probe candidate is too old', async () => {
@@ -250,12 +270,10 @@ describe('resolveRemoteNodePath', () => {
 
     await resolveRemoteNodePath(conn)
 
-    expect(execCommandMock).toHaveBeenNthCalledWith(
-      3,
-      conn,
-      `'/usr/bin/fish' -lc 'command -v node'`,
-      { wrapCommand: false, timeoutMs: 8_000 }
-    )
+    expect(execCommandMock.mock.calls[2]![1]).toMatch(/^'\/usr\/bin\/fish' -lc /)
+    expect(execCommandMock.mock.calls[2]![1]).toContain('__ORCA_NODE_PATH__')
+    expect(execCommandMock.mock.calls[2]![2]).toEqual({ wrapCommand: false, timeoutMs: 8_000 })
+    expect(execCommandMock.mock.calls[3]![2]).toEqual({ wrapCommand: true })
   })
 
   it('uses /bin/sh when the remote shell expansion falls back to it', async () => {
@@ -266,10 +284,9 @@ describe('resolveRemoteNodePath', () => {
       .mockResolvedValueOnce('v20.0.0\n')
 
     await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
-    expect(execCommandMock).toHaveBeenNthCalledWith(3, conn, `'/bin/sh' -c 'command -v node'`, {
-      wrapCommand: false,
-      timeoutMs: 8_000
-    })
+    expect(execCommandMock.mock.calls[2]![1]).toMatch(/^'\/bin\/sh' -c /)
+    expect(execCommandMock.mock.calls[2]![1]).toContain('__ORCA_NODE_PATH__')
+    expect(execCommandMock.mock.calls[2]![2]).toEqual({ wrapCommand: false, timeoutMs: 8_000 })
   })
 
   // ── Failure ───────────────────────────────────────────────────────────
@@ -437,5 +454,10 @@ describe('resolveRemoteNodePath', () => {
 
     const discoveryScript = decodePowerShellCommand(execCommandMock.mock.calls[0]![1] as string)
     expect(discoveryScript).not.toMatch(/Write-Output \$path\s+exit 0/)
+    const selectedToolchainProbe = decodePowerShellCommand(
+      execCommandMock.mock.calls[2]![1] as string
+    )
+    expect(selectedToolchainProbe).toContain('C:/Program Files/nodejs/npm.cmd')
+    expect(selectedToolchainProbe).toContain("$env:PATH = 'C:/Program Files/nodejs' + ';'")
   })
 })

--- a/src/main/ssh/ssh-remote-node-resolution.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.ts
@@ -2,23 +2,25 @@ import type { SshConnection } from './ssh-connection'
 import { createSshOperationAbortError, shellEscape } from './ssh-connection-utils'
 import type { RemoteHostPlatform } from './ssh-remote-platform'
 import { isWindowsRemoteHost, normalizeWindowsRemotePath } from './ssh-remote-platform'
-import { powerShellCommand, powerShellLiteral } from './ssh-remote-powershell'
+import { powerShellCommand } from './ssh-remote-powershell'
 import {
   buildPosixNodeInstallGuidance,
   type RemoteNodeResolutionOptions
 } from './ssh-remote-node-install-guidance'
 import { execCommand } from './ssh-relay-deploy-helpers'
+import {
+  buildPosixNodeToolchainProbe,
+  buildWindowsNodeToolchainProbe,
+  nodeToolchainVersionsMeetRequirements
+} from './ssh-remote-node-toolchain-probe'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
-
-// Why: the relay requires Node.js 18+. Version managers like nvm keep every
-// installed version on disk, so a naive "highest version" glob can hand back
-// Node 8/10/12 and crash the relay on launch. Gate every candidate on this.
-const MIN_NODE_MAJOR = 18
 
 // Why: the login-shell fallback catches custom PATH setups in ~/.profile that
 // the path probes don't cover. Interactive configs (conda prompts, etc.) can
 // hang a login shell, so keep this short.
 const LOGIN_SHELL_PROBE_TIMEOUT_MS = 8_000
+const LOGIN_SHELL_MARKER = '__ORCA_LOGIN_SHELL__'
+const NODE_PATH_MARKER = '__ORCA_NODE_PATH__'
 
 export async function resolveRemoteNodePath(
   conn: SshConnection,
@@ -52,7 +54,7 @@ export async function resolveRemoteNodePath(
 // Probe the on-disk install directories of every common Node version manager
 // plus system package-manager locations. Every probe runs unconditionally so
 // a missing directory prints nothing rather than short-circuiting later
-// probes. Returns the first candidate that meets the minimum version.
+// probes. Returns the first candidate with a complete Node/npm toolchain.
 async function tryResolveViaKnownPaths(
   conn: SshConnection,
   options?: RemoteNodeResolutionOptions
@@ -112,7 +114,7 @@ true
         continue
       }
       seen.add(candidate)
-      if (await nodeMeetsVersionRequirement(conn, candidate, options)) {
+      if (await nodeToolchainMeetsRequirements(conn, candidate, options)) {
         console.log(`[ssh-relay] Found node via path probe: ${candidate}`)
         return candidate
       }
@@ -140,25 +142,25 @@ async function tryResolveViaLoginShell(
     // to sh if $SHELL is unset (rare, e.g. restricted accounts).
     const shellResult = await execCommand(
       conn,
-      'echo "${SHELL:-/bin/sh}"',
+      `printf '%s\\n' '${LOGIN_SHELL_MARKER}' "\${SHELL:-/bin/sh}"`,
       commandOptions({ timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS }, options)
     )
-    const shell = shellResult.trim().split('\n')[0]
+    const shell = markedValue(shellResult, LOGIN_SHELL_MARKER)
     if (!shell) {
       return null
     }
 
     const nodePath = await execCommand(
       conn,
-      buildCommandInShell(shell, 'command -v node'),
+      buildCommandInShell(shell, `printf '%s\\n' '${NODE_PATH_MARKER}' && command -v node`),
       commandOptions({ wrapCommand: false, timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS }, options)
     )
-    const candidate = nodePath.trim().split('\n')[0]
+    const candidate = markedValue(nodePath, NODE_PATH_MARKER)
     if (!candidate) {
       return null
     }
 
-    if (await nodeMeetsVersionRequirement(conn, candidate, options)) {
+    if (await nodeToolchainMeetsRequirements(conn, candidate, options)) {
       console.log(`[ssh-relay] Found node via login shell (${shell}): ${candidate}`)
       return candidate
     }
@@ -179,10 +181,12 @@ function buildCommandInShell(shell: string, command: string): string {
   return `${shellEscape(shell)} ${mode} ${shellEscape(command)}`
 }
 
-// Returns true if `nodePath` runs and reports Node >= MIN_NODE_MAJOR.
+// Returns true if `nodePath` runs, reports Node >= MIN_NODE_MAJOR, and has a
+// runnable npm beside it. Relay deployment prepends this same directory before
+// invoking npm, so accepting a looser pairing would recreate #8450.
 // Caches nothing — this runs at most a few times per resolution (one per
 // candidate), and the exec round-trip dominates.
-async function nodeMeetsVersionRequirement(
+async function nodeToolchainMeetsRequirements(
   conn: SshConnection,
   nodePath: string,
   options?: RemoteNodeResolutionOptions
@@ -190,10 +194,12 @@ async function nodeMeetsVersionRequirement(
   try {
     const versionOutput = await execCommand(
       conn,
-      `${shellEscape(nodePath)} --version`,
-      commandOptions({ wrapCommand: false }, options)
+      buildPosixNodeToolchainProbe(nodePath),
+      // Why: the paired probe uses POSIX PATH assignment syntax, which fish
+      // and csh cannot parse when sshd delegates directly to the login shell.
+      commandOptions({ wrapCommand: true }, options)
     )
-    return nodeVersionMeetsRequirement(versionOutput)
+    return nodeToolchainVersionsMeetRequirements(versionOutput)
   } catch (err) {
     if (options?.rethrowSessionLimitErrors && isSshSessionLimitError(err)) {
       throw err
@@ -261,10 +267,10 @@ async function windowsNodeMeetsVersionRequirement(
   try {
     const versionOutput = await execCommand(
       conn,
-      powerShellCommand(`& ${powerShellLiteral(nodePath)} --version`),
+      powerShellCommand(buildWindowsNodeToolchainProbe(nodePath)),
       commandOptions({ wrapCommand: false }, options)
     )
-    return nodeVersionMeetsRequirement(versionOutput)
+    return nodeToolchainVersionsMeetRequirements(versionOutput)
   } catch (err) {
     if (options?.rethrowSessionLimitErrors && isSshSessionLimitError(err)) {
       throw err
@@ -273,13 +279,13 @@ async function windowsNodeMeetsVersionRequirement(
   }
 }
 
-function nodeVersionMeetsRequirement(versionOutput: string): boolean {
-  const match = versionOutput.trim().match(/^v?(\d+)/)
-  if (!match) {
-    return false
+function markedValue(output: string, marker: string): string {
+  const lines = output.split(/\r?\n/)
+  const markerIndex = lines.indexOf(marker)
+  if (markerIndex >= 0) {
+    return lines[markerIndex + 1]?.trim() ?? ''
   }
-  const major = Number.parseInt(match[1]!, 10)
-  return major >= MIN_NODE_MAJOR
+  return output.trim().split(/\r?\n/)[0] ?? ''
 }
 
 async function throwNodeNotFound(

--- a/src/main/ssh/ssh-remote-node-toolchain-probe.ts
+++ b/src/main/ssh/ssh-remote-node-toolchain-probe.ts
@@ -1,0 +1,67 @@
+import { posix as posixPath } from 'node:path'
+import { shellEscape } from './ssh-connection-utils'
+import { powerShellLiteral } from './ssh-remote-powershell'
+
+const MIN_NODE_MAJOR = 18
+const NODE_VERSION_MARKER = '__ORCA_NODE_VERSION__'
+const NPM_VERSION_MARKER = '__ORCA_NPM_VERSION__'
+
+export function buildPosixNodeToolchainProbe(nodePath: string): string {
+  const nodeBinDir = posixPath.dirname(nodePath)
+  const npmPath = posixPath.join(nodeBinDir, 'npm')
+  return [
+    `printf '%s\\n' '${NODE_VERSION_MARKER}'`,
+    `${shellEscape(nodePath)} --version`,
+    `printf '%s\\n' '${NPM_VERSION_MARKER}'`,
+    `PATH=${shellEscape(nodeBinDir)}:$PATH ${shellEscape(npmPath)} --version`
+  ].join(' && ')
+}
+
+export function buildWindowsNodeToolchainProbe(nodePath: string): string {
+  const nodeBinDir = posixPath.dirname(nodePath)
+  const npmPath = posixPath.join(nodeBinDir, 'npm.cmd')
+  return [
+    `if (!(Test-Path -LiteralPath ${powerShellLiteral(npmPath)} -PathType Leaf)) { exit 1 }`,
+    `$env:PATH = ${powerShellLiteral(nodeBinDir)} + ';' + $env:PATH`,
+    `Write-Output ${powerShellLiteral(NODE_VERSION_MARKER)}`,
+    `& ${powerShellLiteral(nodePath)} --version`,
+    'if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }',
+    `Write-Output ${powerShellLiteral(NPM_VERSION_MARKER)}`,
+    `& ${powerShellLiteral(npmPath)} --version`,
+    'exit $LASTEXITCODE'
+  ].join('; ')
+}
+
+export function nodeToolchainVersionsMeetRequirements(versionOutput: string): boolean {
+  const nodeMajor = markedVersionMajor(versionOutput, NODE_VERSION_MARKER)
+  const npmMajor = markedVersionMajor(versionOutput, NPM_VERSION_MARKER)
+  if (versionOutput.includes(NODE_VERSION_MARKER)) {
+    return nodeMajor !== null && nodeMajor >= MIN_NODE_MAJOR && npmMajor !== null
+  }
+
+  // Preserve compatibility with older mocked/proxy output while production
+  // probes use markers to distinguish versions from login-shell noise.
+  const legacyMatch = versionOutput.trim().match(/^v?(\d+)/)
+  if (!legacyMatch) {
+    return false
+  }
+  return Number.parseInt(legacyMatch[1]!, 10) >= MIN_NODE_MAJOR
+}
+
+function markedVersionMajor(output: string, marker: string): number | null {
+  const lines = output.split(/\r?\n/)
+  const markerIndex = lines.indexOf(marker)
+  if (markerIndex < 0) {
+    return null
+  }
+  for (const line of lines.slice(markerIndex + 1)) {
+    if (line.startsWith('__ORCA_')) {
+      return null
+    }
+    const match = line.trim().match(/^v?(\d+)(?:\.\d+){1,2}(?:[-+].*)?$/)
+    if (match) {
+      return Number.parseInt(match[1]!, 10)
+    }
+  }
+  return null
+}

--- a/src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts
+++ b/src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts
@@ -1,0 +1,155 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SshConnection } from './ssh-connection'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+
+const execCommandMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: execCommandMock
+}))
+
+const { resolveRemoteNodePath } = await import('./ssh-remote-node-resolution')
+
+const conn = {} as SshConnection
+const fixtureDirectories: string[] = []
+
+function writeExecutable(filePath: string, output: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, `#!/bin/sh\nprintf '%s\\n' '${output}'\n`)
+  chmodSync(filePath, 0o755)
+}
+
+function decodePowerShellCommand(command: string): string {
+  const encoded = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)?.[1]
+  if (!encoded) {
+    throw new Error(`No encoded PowerShell command found in: ${command}`)
+  }
+  return Buffer.from(encoded, 'base64').toString('utf16le')
+}
+
+describe('remote Node/npm toolchain resolution', () => {
+  beforeEach(() => {
+    execCommandMock.mockReset()
+  })
+
+  afterEach(() => {
+    for (const directory of fixtureDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('reproduces the guarded NVM layout and skips system Node without npm', async () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), 'orca-node-toolchain-'))
+    fixtureDirectories.push(home)
+    const systemBin = path.join(home, 'usr/bin')
+    const systemNode = path.join(systemBin, 'node')
+    const nvmBin = path.join(home, '.nvm/versions/node/v22.22.0/bin')
+    const nvmNode = path.join(nvmBin, 'node')
+
+    writeExecutable(systemNode, 'v18.19.1')
+    writeExecutable(nvmNode, 'v22.22.0')
+    writeExecutable(path.join(nvmBin, 'npm'), '11.13.0')
+    // Why: Ubuntu's non-interactive guard prevents sourcing NVM, so discovery
+    // must inspect the install directory instead of relying on shell startup.
+    writeFileSync(
+      path.join(home, '.bashrc'),
+      'case $- in\n  *i*) ;;\n  *) return;;\nesac\nexport NVM_DIR="$HOME/.nvm"\n'
+    )
+
+    execCommandMock.mockImplementation((_connection, command: string) =>
+      execFileSync('/bin/sh', ['-c', command], {
+        encoding: 'utf8',
+        env: { HOME: home, PATH: `${systemBin}:/usr/bin:/bin`, SHELL: '/bin/bash' },
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    )
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe(nvmNode)
+    expect(execCommandMock.mock.calls[1]![1]).toContain(`${systemBin}/npm`)
+    expect(execCommandMock.mock.calls[2]![1]).toContain(`${nvmBin}/npm`)
+  })
+
+  it('rejects an old Node even when its colocated npm succeeds', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/old/bin/node\n/current/bin/node\n')
+      .mockResolvedValueOnce('v16.20.2\n10.8.2\n')
+      .mockResolvedValueOnce('v22.22.0\n11.13.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/current/bin/node')
+  })
+
+  it('does not pair Node with npm from a different PATH directory', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/system/bin/node\n/nvm/bin/node\n')
+      .mockRejectedValueOnce(new Error('/system/bin/npm: not found'))
+      .mockResolvedValueOnce('v22.22.0\n11.13.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/nvm/bin/node')
+    expect(execCommandMock.mock.calls[1]![1]).toBe(
+      "printf '%s\\n' '__ORCA_NODE_VERSION__' && '/system/bin/node' --version && printf '%s\\n' '__ORCA_NPM_VERSION__' && PATH='/system/bin':$PATH '/system/bin/npm' --version"
+    )
+    expect(execCommandMock.mock.calls[1]![2]).toEqual({ wrapCommand: true })
+  })
+
+  it('skips a colocated npm shim that fails when invoked', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/broken/bin/node\n/usable/bin/node\n')
+      .mockRejectedValueOnce(new Error('npm shim target is missing'))
+      .mockResolvedValueOnce('v20.11.0\n10.5.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usable/bin/node')
+  })
+
+  it('accepts a marked Node version after login-shell startup noise', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/usable/bin/node\n')
+      .mockResolvedValueOnce(
+        'Welcome to the remote host\n__ORCA_NODE_VERSION__\nv20.11.0\n__ORCA_NPM_VERSION__\n10.5.0\n'
+      )
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usable/bin/node')
+  })
+
+  it('ignores startup noise around login-shell and node-path markers', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('\n')
+      .mockResolvedValueOnce('outer banner\n__ORCA_LOGIN_SHELL__\n/usr/bin/fish\n')
+      .mockResolvedValueOnce('fish greeting\n__ORCA_NODE_PATH__\n/usable/bin/node\n')
+      .mockResolvedValueOnce('__ORCA_NODE_VERSION__\nv20.11.0\n__ORCA_NPM_VERSION__\n10.5.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usable/bin/node')
+  })
+
+  it('rejects a zero-exit npm shim without a version', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/broken/bin/node\n/usable/bin/node\n')
+      .mockResolvedValueOnce(
+        '__ORCA_NODE_VERSION__\nv20.11.0\n__ORCA_NPM_VERSION__\nshim did nothing\n'
+      )
+      .mockResolvedValueOnce('__ORCA_NODE_VERSION__\nv20.11.0\n__ORCA_NPM_VERSION__\n10.5.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usable/bin/node')
+  })
+
+  it('skips Windows Node without npm.cmd and keeps probing candidates', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('C:\\incomplete\\node.exe\nC:\\Program Files\\nodejs\\node.exe\n')
+      .mockRejectedValueOnce(new Error('npm.cmd not found'))
+      .mockResolvedValueOnce('v20.11.0\n10.5.0\n')
+
+    await expect(resolveRemoteNodePath(conn, getRemoteHostPlatform('win32-x64'))).resolves.toBe(
+      'C:/Program Files/nodejs/node.exe'
+    )
+
+    const incompleteProbe = decodePowerShellCommand(execCommandMock.mock.calls[1]![1] as string)
+    const selectedProbe = decodePowerShellCommand(execCommandMock.mock.calls[2]![1] as string)
+    expect(incompleteProbe).toContain("Test-Path -LiteralPath 'C:/incomplete/npm.cmd'")
+    expect(selectedProbe).toContain("Write-Output '__ORCA_NODE_VERSION__'")
+    expect(selectedProbe).toContain("Write-Output '__ORCA_NPM_VERSION__'")
+    expect(selectedProbe).toContain("& 'C:/Program Files/nodejs/npm.cmd' --version")
+  })
+})

--- a/tests/e2e/helpers/docker-ssh-relay-processes.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-processes.ts
@@ -45,6 +45,18 @@ for proc in /proc/[0-9]*; do
 done
 `
 
+const LIST_RELAY_NODE_PATHS_COMMAND = `
+for proc in /proc/[0-9]*; do
+  [ -r "$proc/cmdline" ] || continue
+  argv=()
+  mapfile -d '' -t argv < "$proc/cmdline" 2>/dev/null || continue
+  [ "\${argv[1]##*/}" = relay.js ] || continue
+  for arg in "\${argv[@]:2}"; do
+    if [ "$arg" = --detached ]; then printf '%s\\n' "\${argv[0]}"; break; fi
+  done
+done
+`
+
 function parseRelayProcessRows(output: string): RelayProcessRow[] {
   if (!output) {
     return []
@@ -89,6 +101,15 @@ export function readDockerSshRelayProcessSnapshot(
     throw new Error(`Expected one Docker SSH relay process group, found ${groups.length}`)
   }
   return groups[0] ?? null
+}
+
+export function readDockerSshRelayNodePath(target: DockerSshRelayTarget): string | null {
+  const output = execDockerSshRelayTargetCommand(target, LIST_RELAY_NODE_PATHS_COMMAND)
+  const nodePaths = output ? output.split('\n').filter(Boolean) : []
+  if (nodePaths.length > 1) {
+    throw new Error(`Expected one Docker SSH relay, found ${nodePaths.length}`)
+  }
+  return nodePaths[0] ?? null
 }
 
 export function signalDockerSshRelayWatchers(

--- a/tests/e2e/helpers/docker-ssh-relay-target.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-target.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -12,6 +12,15 @@ export type DockerSshRelayTarget = {
   identityFile: string
   port: number
   tempDir: string
+}
+
+export type DockerSshNodeToolchainFixture = {
+  systemNodePath: string
+  systemNodeVersion: string
+  nvmNodePath: string
+  nvmNpmPath: string
+  nodeVersion: string
+  npmVersion: string
 }
 
 const CONTAINER_IMAGE = process.env.ORCA_E2E_SSH_DOCKER_IMAGE ?? 'node:22-bookworm'
@@ -102,6 +111,70 @@ export function writeDockerSshRelayTargetFile(
     target,
     `printf '%s' ${shellQuote(contents)} > ${shellQuote(filePath)}`
   )
+}
+
+export function configureDockerSshNodeToolchainFixture(
+  target: DockerSshRelayTarget
+): DockerSshNodeToolchainFixture {
+  const donorName = `${target.containerName}-node-donor`
+  const runtimeRoot = path.join(target.tempDir, 'node-runtime')
+  const localNode = path.join(runtimeRoot, 'node')
+  const localNpm = path.join(runtimeRoot, 'npm')
+  const donorNodeVersion = run('docker', ['run', '--rm', 'node:22-bookworm', 'node', '--version'])
+  const nvmVersionDir = `/root/.nvm/versions/node/${donorNodeVersion}`
+  const nvmBin = `${nvmVersionDir}/bin`
+  const nvmNodePath = `${nvmBin}/node`
+  const nvmNpmPath = `${nvmBin}/npm`
+
+  mkdirSync(runtimeRoot, { recursive: true })
+  tryRun('docker', ['rm', '-f', donorName])
+  try {
+    run('docker', ['create', '--name', donorName, 'node:22-bookworm'])
+    run('docker', ['cp', `${donorName}:/usr/local/bin/node`, localNode])
+    run('docker', ['cp', `${donorName}:/usr/local/lib/node_modules/npm`, localNpm])
+    execDockerSshRelayTargetCommand(
+      target,
+      [
+        'apt-get update >/tmp/apt-node-update.log',
+        'DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs npm build-essential python3 >/tmp/apt-node-install.log',
+        'rm -f /usr/bin/npm /usr/bin/npx',
+        `mkdir -p ${shellQuote(nvmBin)} ${shellQuote(`${nvmVersionDir}/lib/node_modules`)}`
+      ].join(' && ')
+    )
+    run('docker', ['cp', localNode, `${target.containerName}:${nvmNodePath}`])
+    run('docker', ['cp', localNpm, `${target.containerName}:${nvmVersionDir}/lib/node_modules/npm`])
+    execDockerSshRelayTargetCommand(
+      target,
+      [
+        `chmod 755 ${shellQuote(nvmNodePath)}`,
+        `ln -s ../lib/node_modules/npm/bin/npm-cli.js ${shellQuote(nvmNpmPath)}`,
+        `ln -s ../lib/node_modules/npm/bin/npx-cli.js ${shellQuote(`${nvmBin}/npx`)}`
+      ].join(' && ')
+    )
+    // Why: this is the Ubuntu layout from #8450—the guard hides NVM from
+    // non-interactive startup, while Orca must still discover it on disk.
+    writeDockerSshRelayTargetFile(
+      target,
+      '/root/.bashrc',
+      'case $- in\n  *i*) ;;\n  *) return;;\nesac\n' +
+        `export NVM_DIR="$HOME/.nvm"\nexport PATH="$NVM_DIR/versions/node/${donorNodeVersion}/bin:$PATH"\n`
+    )
+
+    const [systemNodeVersion, nodeVersion, npmVersion] = execDockerSshRelayTargetCommand(
+      target,
+      `/usr/bin/node --version && ${shellQuote(nvmNodePath)} --version && PATH=${shellQuote(nvmBin)}:$PATH ${shellQuote(nvmNpmPath)} --version`
+    ).split('\n')
+    return {
+      systemNodePath: '/usr/bin/node',
+      systemNodeVersion,
+      nvmNodePath,
+      nvmNpmPath,
+      nodeVersion,
+      npmVersion
+    }
+  } finally {
+    tryRun('docker', ['rm', '-f', donorName])
+  }
 }
 
 export function startDockerSshRelayTarget(testInfo: TestInfo): DockerSshRelayTarget {

--- a/tests/e2e/ssh-node-toolchain-resolution.spec.ts
+++ b/tests/e2e/ssh-node-toolchain-resolution.spec.ts
@@ -1,0 +1,107 @@
+import type { Page } from '@stablyai/playwright-test'
+
+import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
+import { readDockerSshRelayNodePath } from './helpers/docker-ssh-relay-processes'
+import {
+  cleanupDockerSshRelayTarget,
+  configureDockerSshNodeToolchainFixture,
+  execDockerSshRelayTargetCommand,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget
+} from './helpers/docker-ssh-relay-target'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  execInTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+
+const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
+
+async function enableTerminalAccessibilityDom(page: Page, ptyId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const pane = Array.from(window.__paneManagers?.values() ?? [])
+      .flatMap((manager) => manager.getPanes?.() ?? [])
+      .find((candidate) => candidate.container.dataset.ptyId === id)
+    if (!pane) {
+      throw new Error(`Terminal pane ${id} is unavailable`)
+    }
+    pane.terminal.options.screenReaderMode = true
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+  }, ptyId)
+  await expect(
+    page.locator(`[data-pty-id=${JSON.stringify(ptyId)}] .xterm-accessibility-tree`)
+  ).toBeAttached({ timeout: 10_000 })
+}
+
+test.describe('SSH Node/npm toolchain resolution', () => {
+  test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run Docker-backed SSH tests.')
+  test.skip(process.platform === 'win32', 'The #8450 fixture requires a POSIX Docker host.')
+
+  test('uses complete guarded NVM toolchain when Ubuntu system Node has no npm', async ({
+    orcaPage
+  }, testInfo) => {
+    test.slow()
+    const startedAt = Date.now()
+    let target: DockerSshRelayTarget | null = null
+    try {
+      target = startDockerSshRelayTarget(testInfo)
+      const fixture = configureDockerSshNodeToolchainFixture(target)
+      const preconditions = execDockerSshRelayTargetCommand(
+        target,
+        [
+          '[ "$(command -v node)" = /usr/bin/node ]',
+          '! command -v npm >/dev/null 2>&1',
+          '[ "$(bash -lc \'command -v node\')" = /usr/bin/node ]',
+          `test -x '${fixture.nvmNodePath}'`,
+          `test -x '${fixture.nvmNpmPath}'`,
+          `printf '%s\\n' '${fixture.systemNodeVersion}' '${fixture.nodeVersion}' '${fixture.npmVersion}'`
+        ].join(' && ')
+      )
+      expect(preconditions.split('\n')).toEqual([
+        fixture.systemNodeVersion,
+        fixture.nodeVersion,
+        fixture.npmVersion
+      ])
+
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      await connectDockerSshRelayTarget(orcaPage, target)
+      await ensureTerminalVisible(orcaPage, 45_000)
+      await waitForActiveTerminalManager(orcaPage, 60_000)
+      const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
+      await enableTerminalAccessibilityDom(orcaPage, ptyId)
+
+      await expect
+        .poll(() => readDockerSshRelayNodePath(target!), {
+          timeout: 30_000,
+          message: 'relay did not launch with the complete NVM Node/npm toolchain'
+        })
+        .toBe(fixture.nvmNodePath)
+
+      const marker = `SSH_NODE_TOOLCHAIN_OK_${Date.now()}`
+      const encodedMarker = Buffer.from(marker).toString('base64')
+      await execInTerminal(
+        orcaPage,
+        ptyId,
+        `printf '%s' '${encodedMarker}' | base64 -d && printf '\\n'`
+      )
+      await expect(
+        orcaPage.locator(`[data-pty-id=${JSON.stringify(ptyId)}] .xterm-accessibility-tree`)
+      ).toContainText(marker, { timeout: 30_000 })
+
+      const evidenceSummary =
+        `remote=ubuntu-24.04 architecture=${process.arch} systemNode=${fixture.systemNodeVersion} ` +
+        `nvmNode=${fixture.nodeVersion} npm=${fixture.npmVersion} selected=nvm ` +
+        `relayPty=pass durationMs=${Date.now() - startedAt}`
+      console.log(`[ssh-node-toolchain-resolution] ${evidenceSummary}`)
+      testInfo.annotations.push({
+        type: 'ssh-node-toolchain-resolution',
+        description: evidenceSummary
+      })
+    } finally {
+      cleanupDockerSshRelayTarget(target)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- require Node and npm to be runnable from the same remote toolchain directory
- skip incomplete system installations and continue to guarded NVM candidates
- preserve login-shell, version-manager, cancellation, and session-limit behavior
- add a live Ubuntu SSH/PTY regression harness for issue #8450
- add the reviewed relay runtime distribution plan and living implementation checklist as a separate documentation commit

Fixes #8450

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-node-resolution.test.ts` (32/32)
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-node-toolchain-resolution.test.ts` (8/8)
- native-deps, versioned-install, deploy, cross-version isolation, and platform-detection focused suites (70/70)
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run check:max-lines-ratchet`
- touched-file `oxfmt --check`
- `pnpm run test:e2e:ssh-node-toolchain-resolution` (Ubuntu 24.04 arm64 Docker SSH, guarded NVM selection, relay launch, PTY round-trip)

## Scope

This draft contains Milestone 0 only. It does not enable or implement bundled relay runtime distribution. Existing SSH relay behavior remains the production path.

Made with [Orca](https://github.com/stablyai/orca) 🐋
