### PR TITLE
fix(tasks): source flips serve each side's own work-item cache instead of stale shared entries

### DIFF
--- a/src/main/github/client-issue-source.test.ts
+++ b/src/main/github/client-issue-source.test.ts
@@ -582,6 +582,58 @@ describe('GitHub issue source split', () => {
       })
     })
 
+    it("preference='auto' + upstream exists → PRs query upstream too", async () => {
+      // Why: fork-contribution PRs live on the upstream repo — the fork's own
+      // PR list is almost always empty. 'auto' must resolve PRs upstream-first
+      // like issues, or the PRs tab renders "No matching GitHub work" on forks.
+      resolveIssueSourceMock.mockResolvedValueOnce({
+        source: { owner: 'stablyai', repo: 'orca' },
+        fellBack: false
+      })
+      getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
+      mockUpstreamCandidate({ owner: 'stablyai', repo: 'orca' })
+      ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' }).mockResolvedValueOnce({
+        stdout: '[]'
+      })
+
+      const result = await listWorkItems('/repo-root', 10, undefined, undefined, 'auto')
+
+      expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+        2,
+        expect.arrayContaining(['--repo', 'stablyai/orca']),
+        { cwd: '/repo-root' }
+      )
+      expect(result.sources).toEqual({
+        issues: { owner: 'stablyai', repo: 'orca' },
+        prs: { owner: 'stablyai', repo: 'orca' },
+        originCandidate: { owner: 'fork', repo: 'orca' },
+        upstreamCandidate: { owner: 'stablyai', repo: 'orca' }
+      })
+    })
+
+    it('collapses the default count to one query when auto resolves both sides to upstream', async () => {
+      getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+      getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
+      mockUpstreamCandidate({ owner: 'stablyai', repo: 'orca' })
+      ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '11\n' })
+
+      const count = await countWorkItems('/repo-root')
+
+      expect(count).toBe(11)
+      expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+      expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+        [
+          'api',
+          '--cache',
+          '120s',
+          `search/issues?q=${encodeURIComponent('repo:stablyai/orca is:open')}&per_page=1`,
+          '--jq',
+          '.total_count'
+        ],
+        { cwd: '/repo-root' }
+      )
+    })
+
     it("preference='upstream' + upstream exists → queries upstream", async () => {
       resolveIssueSourceMock.mockResolvedValueOnce({
         source: { owner: 'stablyai', repo: 'orca' },

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1098,8 +1098,10 @@ async function resolvePrWorkItemSource(
     getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions),
     getOwnerRepoForRemote(repoPath, 'upstream', connectionId, localGitOptions)
   ])
-  const source =
-    preference === 'upstream' ? (upstreamCandidate ?? originCandidate) : originCandidate
+  // Why: fork-contribution PRs live on the upstream repo (the fork's own PR
+  // list is almost always empty), so 'auto' resolves upstream-first exactly
+  // like the issue side. Only an explicit 'origin' pick pins PRs to the fork.
+  const source = preference === 'origin' ? originCandidate : (upstreamCandidate ?? originCandidate)
   return { source, originCandidate, upstreamCandidate }
 }
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -280,6 +280,7 @@ import type {
   GitHubPRMergeMethod,
   GitHubIssueUpdate,
   GitHubWorkItem,
+  IssueSourcePreference,
   GitLabTodo,
   GitLabWorkItem,
   JiraCreateField,
@@ -501,6 +502,7 @@ function getTaskPageRepoCacheInput(repo: Repo): {
   path: string
   executionHostId?: string | null
   sourceCacheScope?: string | null
+  issueSourcePreference?: IssueSourcePreference
 } {
   const sourceContext = getTaskPageRepoSourceContext(repo, 'github')
   return {
@@ -508,7 +510,8 @@ function getTaskPageRepoCacheInput(repo: Repo): {
     path: repo.path,
     executionHostId: repo.executionHostId,
     sourceCacheScope:
-      sourceContext?.provider === 'github' ? getTaskSourceCacheScope(sourceContext) : null
+      sourceContext?.provider === 'github' ? getTaskSourceCacheScope(sourceContext) : null,
+    issueSourcePreference: repo.issueSourcePreference
   }
 }
 

--- a/src/renderer/src/components/task-page-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.ts
@@ -6,13 +6,20 @@ import {
   type WorkItemsCacheError,
   type WorkItemsCacheSources
 } from '@/store/slices/github'
-import type { GitHubWorkItem, LinearCollectionResult, LinearIssue } from '../../../shared/types'
+import type {
+  GitHubWorkItem,
+  IssueSourcePreference,
+  LinearCollectionResult,
+  LinearIssue
+} from '../../../shared/types'
 
 export type TaskPageRepoCacheInput = {
   id: string
   path: string
   executionHostId?: string | null
   sourceCacheScope?: string | null
+  /** Part of the work-item cache key — upstream/origin entries coexist. */
+  issueSourcePreference?: IssueSourcePreference
 }
 
 export type TaskPageDialogWorkItemKey = {
@@ -58,7 +65,13 @@ export function selectTaskPageWorkItemsCacheEntries(
   return repos.map(
     (repo) =>
       workItemsCache[
-        workItemsCacheKey(repo.id, limit, query, repo.sourceCacheScope ?? repo.executionHostId)
+        workItemsCacheKey(
+          repo.id,
+          limit,
+          query,
+          repo.sourceCacheScope ?? repo.executionHostId,
+          repo.issueSourcePreference
+        )
       ]
   )
 }

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -382,43 +382,34 @@ describe('createGitHubSlice.setIssueSourcePreference', () => {
     } as unknown as Partial<AppState>)
   }
 
-  it('evicts source-context-scoped work-item entries on a preference flip', async () => {
+  it('keeps both sources cached under separate keys across a preference flip', async () => {
+    // Why: the preference is part of the work-item cache key, so a flip must
+    // not evict the other side — toggling back serves its still-fresh entry
+    // instantly. The nonce bump is what re-runs the Tasks fetch effect.
     const store = createTestStore()
     const repoId = 'repo-1'
     const repoPath = '/repo/one'
     seedRepo(store, repoId, repoPath)
-    const scopedKey = workItemsCacheKey(
-      repoId,
-      20,
-      '',
-      getTaskSourceCacheScope(githubSourceContext('local', repoId))
-    )
-    const bareKey = workItemsCacheKey(repoId, 20, '')
-    const otherRepoScopedKey = workItemsCacheKey(
-      'repo-2',
-      20,
-      '',
-      getTaskSourceCacheScope(githubSourceContext('local', 'repo-2'))
-    )
+    const scope = getTaskSourceCacheScope(githubSourceContext('local', repoId))
+    const upstreamKey = workItemsCacheKey(repoId, 20, '', scope, 'upstream')
+    const originKey = workItemsCacheKey(repoId, 20, '', scope, 'origin')
+    expect(upstreamKey).not.toBe(originKey)
     store.setState({
       workItemsInvalidationNonce: 4,
       workItemsCache: {
-        [scopedKey]: { data: [], fetchedAt: Date.now() },
-        [bareKey]: { data: [], fetchedAt: Date.now() },
-        [otherRepoScopedKey]: { data: [], fetchedAt: Date.now() }
+        [upstreamKey]: { data: [], fetchedAt: Date.now() }
       }
     })
 
     await store.getState().setIssueSourcePreference(repoId, repoPath, 'origin')
     const state = store.getState()
 
-    expect(state.workItemsCache[scopedKey]).toBeUndefined()
-    expect(state.workItemsCache[bareKey]).toBeUndefined()
-    expect(state.workItemsCache[otherRepoScopedKey]).toBeDefined()
+    expect(state.workItemsCache[upstreamKey]).toBeDefined()
     expect(state.workItemsInvalidationNonce).toBe(5)
+    expect(state.repos[0]?.issueSourcePreference).toBe('origin')
   })
 
-  it('clears source-context-scoped in-flight dedupe entries so the post-flip fetch re-dispatches', async () => {
+  it('does not dedupe the post-flip fetch onto a pre-flip in-flight request', async () => {
     const store = createTestStore()
     const repoId = 'repo-1'
     const repoPath = '/repo/one'
@@ -438,8 +429,9 @@ describe('createGitHubSlice.setIssueSourcePreference', () => {
       )
       .mockResolvedValueOnce(emptyEnvelope)
 
-    // Why: a pre-flip request left in the dedupe map would swallow the
-    // post-flip fetch, so the new preference's list never actually runs.
+    // Why: a pre-flip request swallowing the post-flip fetch would mean the
+    // new preference's list never actually runs. Preference-scoped keys give
+    // the post-flip fetch its own dedupe slot.
     const firstFetch = store.getState().fetchWorkItems(repoId, repoPath, 20, '', { sourceContext })
     await Promise.resolve()
     await store.getState().setIssueSourcePreference(repoId, repoPath, 'origin')
@@ -448,6 +440,78 @@ describe('createGitHubSlice.setIssueSourcePreference', () => {
     await firstFetch
     await secondFetch
 
+    expect(mockApi.gh.listWorkItems).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares one entry between auto and an explicit upstream pin', async () => {
+    // Why: 'auto' routes upstream-first exactly like an explicit 'upstream'
+    // pick, so pinning the already-highlighted pill must be a cache hit —
+    // not a spurious refetch of identical data under a different key.
+    const store = createTestStore()
+    const repoId = 'repo-1'
+    const repoPath = '/repo/one'
+    seedRepo(store, repoId, repoPath)
+    const sourceContext = githubSourceContext('local', repoId)
+    const scope = getTaskSourceCacheScope(sourceContext)
+    expect(workItemsCacheKey(repoId, 20, '', scope)).toBe(
+      workItemsCacheKey(repoId, 20, '', scope, 'upstream')
+    )
+    const item = {
+      type: 'issue',
+      number: 3,
+      title: 'Upstream issue',
+      url: 'https://example.test/3',
+      updatedAt: '2026-07-14T00:00:00Z'
+    } as GitHubWorkItem
+    mockApi.gh.listWorkItems.mockResolvedValueOnce({
+      items: [item],
+      sources: { issues: null, prs: null, originCandidate: null, upstreamCandidate: null }
+    })
+
+    await store.getState().fetchWorkItems(repoId, repoPath, 20, '', { sourceContext })
+    await store.getState().setIssueSourcePreference(repoId, repoPath, 'upstream')
+    const pinned = await store
+      .getState()
+      .fetchWorkItems(repoId, repoPath, 20, '', { sourceContext })
+
+    expect(pinned).toEqual([{ ...item, repoId }])
+    expect(mockApi.gh.listWorkItems).toHaveBeenCalledTimes(1)
+  })
+
+  it("serves the previous source's still-fresh cache when toggling back", async () => {
+    const store = createTestStore()
+    const repoId = 'repo-1'
+    const repoPath = '/repo/one'
+    seedRepo(store, repoId, repoPath)
+    const sourceContext = githubSourceContext('local', repoId)
+    const upstreamItem = {
+      type: 'pr',
+      number: 7,
+      title: 'Upstream PR',
+      url: 'https://example.test/7',
+      updatedAt: '2026-07-14T00:00:00Z'
+    } as GitHubWorkItem
+    mockApi.gh.listWorkItems
+      .mockResolvedValueOnce({
+        items: [upstreamItem],
+        sources: { issues: null, prs: null, originCandidate: null, upstreamCandidate: null }
+      })
+      .mockResolvedValueOnce({
+        items: [],
+        sources: { issues: null, prs: null, originCandidate: null, upstreamCandidate: null }
+      })
+
+    await store.getState().setIssueSourcePreference(repoId, repoPath, 'upstream')
+    await store.getState().fetchWorkItems(repoId, repoPath, 20, '', { sourceContext })
+    await store.getState().setIssueSourcePreference(repoId, repoPath, 'origin')
+    await store.getState().fetchWorkItems(repoId, repoPath, 20, '', { sourceContext })
+    await store.getState().setIssueSourcePreference(repoId, repoPath, 'upstream')
+    const toggledBack = await store
+      .getState()
+      .fetchWorkItems(repoId, repoPath, 20, '', { sourceContext })
+
+    expect(toggledBack).toEqual([{ ...upstreamItem, repoId }])
+    // Why: two network calls total — the toggle back must be a cache hit.
     expect(mockApi.gh.listWorkItems).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -60,6 +60,9 @@ const mockApi = {
     getCreationEligibility: vi.fn(),
     create: vi.fn()
   },
+  repos: {
+    update: vi.fn().mockResolvedValue(undefined)
+  },
   runtimeEnvironments: {
     call: runtimeEnvironmentTransportCall
   },
@@ -320,6 +323,132 @@ describe('createGitHubSlice.evictGitHubRepoCaches', () => {
 
     await expect(firstFetch).resolves.toEqual([{ ...item, repoId: 'repo-1' }])
     expect(store.getState().workItemsCache[workItemsCacheKey('repo-1', 20, '')]).toBeUndefined()
+  })
+
+  it('evicts source-context-scoped work-item entries too', () => {
+    // Why: TaskPage keys its work-item cache with a task-source scope prefix
+    // (github:local:...::repoId::…) even for plain local repos. Eviction that
+    // only matches bare repoId::/repoPath:: prefixes silently skips every
+    // TaskPage entry, so a preference flip serves stale-source rows forever.
+    const store = createTestStore()
+    const repoId = 'repo-1'
+    const repoPath = '/repo/one'
+    const scopedKey = workItemsCacheKey(
+      repoId,
+      20,
+      '',
+      getTaskSourceCacheScope(githubSourceContext('local', repoId))
+    )
+    const otherRepoScopedKey = workItemsCacheKey(
+      'repo-2',
+      20,
+      '',
+      getTaskSourceCacheScope(githubSourceContext('local', 'repo-2'))
+    )
+    store.setState({
+      workItemsInvalidationNonce: 4,
+      workItemsCache: {
+        [scopedKey]: { data: [], fetchedAt: 1 },
+        [otherRepoScopedKey]: { data: [], fetchedAt: 1 }
+      }
+    })
+
+    store.getState().evictGitHubRepoCaches(repoId, repoPath)
+    const state = store.getState()
+
+    expect(state.workItemsCache[scopedKey]).toBeUndefined()
+    expect(state.workItemsCache[otherRepoScopedKey]).toBeDefined()
+    expect(state.workItemsInvalidationNonce).toBe(5)
+  })
+})
+
+describe('createGitHubSlice.setIssueSourcePreference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRemoteRuntimeMocks()
+    mockApi.repos.update.mockResolvedValue(undefined)
+  })
+
+  // Why: while the eviction bug is unfixed, the deduped second fetch leaves a
+  // queued once-response unconsumed; reset so it cannot leak into later suites.
+  afterEach(() => {
+    mockApi.gh.listWorkItems.mockReset()
+    mockApi.repos.update.mockReset()
+  })
+
+  function seedRepo(store: ReturnType<typeof createTestStore>, repoId: string, repoPath: string) {
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }]
+    } as unknown as Partial<AppState>)
+  }
+
+  it('evicts source-context-scoped work-item entries on a preference flip', async () => {
+    const store = createTestStore()
+    const repoId = 'repo-1'
+    const repoPath = '/repo/one'
+    seedRepo(store, repoId, repoPath)
+    const scopedKey = workItemsCacheKey(
+      repoId,
+      20,
+      '',
+      getTaskSourceCacheScope(githubSourceContext('local', repoId))
+    )
+    const bareKey = workItemsCacheKey(repoId, 20, '')
+    const otherRepoScopedKey = workItemsCacheKey(
+      'repo-2',
+      20,
+      '',
+      getTaskSourceCacheScope(githubSourceContext('local', 'repo-2'))
+    )
+    store.setState({
+      workItemsInvalidationNonce: 4,
+      workItemsCache: {
+        [scopedKey]: { data: [], fetchedAt: Date.now() },
+        [bareKey]: { data: [], fetchedAt: Date.now() },
+        [otherRepoScopedKey]: { data: [], fetchedAt: Date.now() }
+      }
+    })
+
+    await store.getState().setIssueSourcePreference(repoId, repoPath, 'origin')
+    const state = store.getState()
+
+    expect(state.workItemsCache[scopedKey]).toBeUndefined()
+    expect(state.workItemsCache[bareKey]).toBeUndefined()
+    expect(state.workItemsCache[otherRepoScopedKey]).toBeDefined()
+    expect(state.workItemsInvalidationNonce).toBe(5)
+  })
+
+  it('clears source-context-scoped in-flight dedupe entries so the post-flip fetch re-dispatches', async () => {
+    const store = createTestStore()
+    const repoId = 'repo-1'
+    const repoPath = '/repo/one'
+    seedRepo(store, repoId, repoPath)
+    const sourceContext = githubSourceContext('local', repoId)
+    const emptyEnvelope = {
+      items: [],
+      sources: { issues: null, prs: null, originCandidate: null, upstreamCandidate: null }
+    }
+    let resolveFirst: (value: typeof emptyEnvelope) => void = () => {}
+    mockApi.gh.listWorkItems
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      .mockResolvedValueOnce(emptyEnvelope)
+
+    // Why: a pre-flip request left in the dedupe map would swallow the
+    // post-flip fetch, so the new preference's list never actually runs.
+    const firstFetch = store.getState().fetchWorkItems(repoId, repoPath, 20, '', { sourceContext })
+    await Promise.resolve()
+    await store.getState().setIssueSourcePreference(repoId, repoPath, 'origin')
+    const secondFetch = store.getState().fetchWorkItems(repoId, repoPath, 20, '', { sourceContext })
+    resolveFirst(emptyEnvelope)
+    await firstFetch
+    await secondFetch
+
+    expect(mockApi.gh.listWorkItems).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -287,7 +287,8 @@ function getWorkItemsCacheKeyForOwner(
     repoId,
     limit,
     query,
-    repo ? getGitHubFocusedRepoOwnerHostId(state.settings ?? null, repo) : undefined
+    repo ? getGitHubFocusedRepoOwnerHostId(state.settings ?? null, repo) : undefined,
+    repo?.issueSourcePreference
   )
 }
 
@@ -780,11 +781,19 @@ export function workItemsCacheKey(
   repoId: string,
   limit: number,
   query: string,
-  executionHostId?: string | null
+  executionHostId?: string | null,
+  preference?: IssueSourcePreference
 ): string {
   const scope = executionHostId?.trim() ?? ''
   const hostId = normalizeExecutionHostId(scope)
-  const owner = `${repoId}::${limit}::${query}`
+  // Why: cache identity is the effective source side, not the raw UI
+  // preference — 'auto' routes upstream-first exactly like an explicit
+  // 'upstream' pick, so both share one entry and pinning the already-active
+  // pill cannot trigger a spurious refetch. Upstream and origin results live
+  // in separate entries, so a source flip just reads the other side's key
+  // (served instantly while still fresh) instead of evicting shared state.
+  const side = preference === 'origin' ? 'origin' : 'upstream'
+  const owner = `${repoId}::${side}::${limit}::${query}`
   if (hostId) {
     return hostId !== LOCAL_EXECUTION_HOST_ID ? `${hostId}::${owner}` : owner
   }
@@ -2727,7 +2736,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const state = get()
     const key =
       sourceContext?.provider === 'github'
-        ? workItemsCacheKey(repoId, limit, query, getTaskSourceCacheScope(sourceContext))
+        ? workItemsCacheKey(
+            repoId,
+            limit,
+            query,
+            getTaskSourceCacheScope(sourceContext),
+            findRepoForGitHubOwner(state, repoId, repoPath ?? '')?.issueSourcePreference
+          )
         : getWorkItemsCacheKeyForOwner(state, repoId, limit, query, repoPath)
     return get().workItemsCache[key]?.data ?? null
   },
@@ -2773,7 +2788,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     )
     const ownerHostId = getGitHubWorkItemSourceHostId(requestState, repo, options?.sourceContext)
     const cacheScope = getGitHubWorkItemSourceCacheScope(requestState, repo, options?.sourceContext)
-    const key = workItemsCacheKey(repoId, limit, query, cacheScope)
+    const key = workItemsCacheKey(repoId, limit, query, cacheScope, repo?.issueSourcePreference)
     const cached = get().workItemsCache[key]
     if (!options?.force && isFresh(cached, WORK_ITEMS_CACHE_TTL)) {
       return cached.data ?? []
@@ -2916,7 +2931,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                   r.repoId,
                   perRepoLimit,
                   query,
-                  getTaskSourceCacheScope(r.sourceContext)
+                  getTaskSourceCacheScope(r.sourceContext),
+                  findRepoForGitHubOwner(get(), r.repoId, r.path)?.issueSourcePreference
                 )
               : getWorkItemsCacheKeyForOwner(get(), r.repoId, perRepoLimit, query, r.path)
           const cached = get().workItemsCache[key]?.data
@@ -3053,7 +3069,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const repo = findRepoForGitHubOwner(requestState, repoId, repoPath)
     const key =
       options?.sourceContext?.provider === 'github'
-        ? workItemsCacheKey(repoId, limit, query, getTaskSourceCacheScope(options.sourceContext))
+        ? workItemsCacheKey(
+            repoId,
+            limit,
+            query,
+            getTaskSourceCacheScope(options.sourceContext),
+            repo?.issueSourcePreference
+          )
         : getWorkItemsCacheKeyForOwner(requestState, repoId, limit, query, repoPath)
     const cached = get().workItemsCache[key]
     const requestSettings = getGitHubWorkItemSourceSettings(
@@ -4668,42 +4690,23 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         }
       )
       // Why: the optimistic patch above may now disagree with disk. Resync
-      // rather than leave a lie on screen. We only refetch repos — the cache
-      // eviction below is still safe to run; worst case we trigger a
-      // harmless re-fetch of work items against the pre-flip preference.
+      // rather than leave a lie on screen — worst case a re-fetch runs
+      // against the pre-flip preference and lands in that preference's own
+      // cache entry.
       void get().fetchRepos()
     }
-    // Why: wipe in-flight dedupe entries for this repo BEFORE bumping the
-    // invalidation nonce. The bump triggers a re-run of TaskPage's fetch
-    // effect; if the inflight map still held a pre-flip entry, the new
-    // dispatch could collapse onto it and skip the source swap. Clearing
-    // first makes the "new fetch gets a fresh request" invariant impossible
-    // to trip on later refactors that change zustand or React flush timing.
+    // Why: defensive only — the preference is part of the work-item cache
+    // key, so a pre-flip in-flight request can no longer collide with the
+    // post-flip fetch. Clearing keeps the dedupe map from holding requests
+    // whose results nothing will read.
     clearInflightWorkItemsForRepo(repoId, repoPath)
-    // Why: evict every cache entry keyed on this repo AFTER the IPC
-    // resolves. If we evicted before awaiting, an overlapping fetch triggered
-    // by a different subscriber would hit main with the pre-flip persisted
-    // preference and repopulate the cache with stale-source data. Work-items
-    // cache keys are repo-scoped, but we also drop legacy path-scoped entries
-    // that may have been restored from older persisted cache data.
-    set((s) => {
-      // Why: must use the shared matcher — TaskPage keys carry a task-source
-      // scope prefix, so bare startsWith checks would evict nothing and the
-      // post-flip effect would keep serving the old source's fresh cache.
-      const prefixes = repoCacheKeyPrefixes(repoId, repoPath)
-      const next: Record<string, CacheEntry<GitHubWorkItem[]>> = {}
-      for (const [key, entry] of Object.entries(s.workItemsCache)) {
-        if (!matchesRepoCacheKey(key, prefixes)) {
-          next[key] = entry
-        }
-      }
-      // Why: bump the invalidation nonce so the Tasks list's fetch effect
-      // — which keys on `[selectedRepos, appliedTaskSearch, taskRefreshNonce,
-      // taskSource, workItemsInvalidationNonce]` — re-runs and re-populates
-      // the just-evicted entries. Evicting alone wouldn't trigger the effect
-      // because it doesn't depend on the cache.
-      return { workItemsCache: next, workItemsInvalidationNonce: s.workItemsInvalidationNonce + 1 }
-    })
+    // Why: no eviction — upstream and origin results live under separate
+    // preference-scoped keys, so flipping back serves the other side's
+    // still-fresh entries instantly. The nonce bump re-runs the Tasks fetch
+    // effect (which keys on `[selectedRepos, appliedTaskSearch,
+    // taskRefreshNonce, taskSource, workItemsInvalidationNonce]`) so the new
+    // preference's entries are read and refreshed.
+    set((s) => ({ workItemsInvalidationNonce: s.workItemsInvalidationNonce + 1 }))
   },
 
   evictGitHubRepoCaches: (repoId, repoPath) => {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -893,7 +893,12 @@ function repoCacheKeyPrefixes(repoId: string, repoPath?: string): string[] {
 }
 
 function matchesRepoCacheKey(key: string, prefixes: readonly string[]): boolean {
-  return prefixes.some((prefix) => key.startsWith(prefix))
+  // Why: task-source-scoped keys (`github:local:…::repoId::…`) and
+  // execution-host-scoped keys (`hostId::repoId::…`) embed the repo segment
+  // after a `::` join rather than at the start. Matching only bare prefixes
+  // silently skips every scoped entry, so preference flips and repo evictions
+  // leave stale-source data behind.
+  return prefixes.some((prefix) => key.startsWith(prefix) || key.includes(`::${prefix}`))
 }
 
 function clearInflightWorkItemsForRepo(repoId: string, repoPath?: string): void {
@@ -4682,11 +4687,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     // cache keys are repo-scoped, but we also drop legacy path-scoped entries
     // that may have been restored from older persisted cache data.
     set((s) => {
-      const prefix = `${repoId}::`
-      const legacyPrefix = `${repoPath}::`
+      // Why: must use the shared matcher — TaskPage keys carry a task-source
+      // scope prefix, so bare startsWith checks would evict nothing and the
+      // post-flip effect would keep serving the old source's fresh cache.
+      const prefixes = repoCacheKeyPrefixes(repoId, repoPath)
       const next: Record<string, CacheEntry<GitHubWorkItem[]>> = {}
       for (const [key, entry] of Object.entries(s.workItemsCache)) {
-        if (!key.startsWith(prefix) && !key.startsWith(legacyPrefix)) {
+        if (!matchesRepoCacheKey(key, prefixes)) {
           next[key] = entry
         }
       }


### PR DESCRIPTION
## Summary

Related to #8726 (item B). **Stacked on #8727** — the first commit here is that PR; review the last two commits. Draft until #8727 lands, then this rebases to its own two commits.

Toggling the Tasks Upstream/Origin selector without pressing the manual refresh button showed stale or empty lists: after one flip the rows could stay on the *previous* source while the pager shrank to the new source's count; after flipping again the list could go empty and stay empty. Only the refresh button recovered. Reproduces on `main` for both the Issues and PRs tabs.

Two defects compound:

1. **The flip's cache eviction matched nothing.** TaskPage keys its work-item cache with a task-source scope prefix (`github:local:…::repoId::limit::query`) even for plain local repos, but `setIssueSourcePreference` evicted only keys starting with bare `repoId::`/`repoPath::` — a complete no-op for every Tasks-page entry, and the same mismatch silently skipped scoped entries in `evictGitHubRepoCaches` and the in-flight dedupe clearing. The post-flip effect then kept serving the old source's still-fresh (60s TTL) cache, while the forced refetch's correct result reached the store cache but never the visible rows (the page/cache reconciliation only patches rows present in both).
2. **Both sources fought over one cache identity.** Upstream and origin route to different repos, but their results shared a single key — which is why eviction was load-bearing at all.

This PR fixes both layers:

- **Commit 1 — make repo-scoped eviction actually match scoped keys.** `matchesRepoCacheKey` now also matches the `::repoId::` segment boundary, covering task-source-scoped and execution-host-scoped keys. This independently fixes `evictGitHubRepoCaches` (repo removal) skipping every scoped entry.
- **Commit 2 — make the flip not need eviction at all.** The work-item cache key now includes the repo's **effective source side**: `repoId::<upstream|origin>::limit::query`. Upstream and origin entries coexist, so a flip just reads the other side's key — served instantly while still fresh, refreshed by the existing forced fetch. Pre-flip in-flight requests get their own dedupe slot, removing the collision class the eviction dance guarded against. `setIssueSourcePreference` drops its eviction and keeps the defensive in-flight clear plus the nonce bump that re-runs the Tasks fetch effect.

The key segment is the effective side, not the raw preference: `auto` routes upstream-first exactly like an explicit `'upstream'` pick (per #8727), so both share one entry and pinning the already-highlighted Upstream pill is a cache hit rather than a spurious refetch of identical data.

| Action | Before | After |
| --- | --- | --- |
| Flip Upstream→Origin | rows stay upstream, pager shows origin count | origin rows (instant if cached ≤60s, else fetched) |
| Flip back within 60s | often permanently empty until manual refresh | previous upstream rows instantly, no network call |
| Pin the highlighted Upstream pill under `auto` | n/a (was origin-routed for PRs) | cache hit — no refetch |
| Repo eviction (`evictGitHubRepoCaches`) | scoped entries silently survived | evicted |

## Screenshots


https://github.com/user-attachments/assets/e58609e9-ce94-4212-911f-8102455fd680


https://github.com/user-attachments/assets/955e8dd5-3462-40aa-a3ea-d0f04e6e869f


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 5 new regression tests (written first, red on the old behavior): scoped-key repo eviction; flip keeps the other side's entries + bumps the invalidation nonce; post-flip fetch does not dedupe onto a pre-flip in-flight request; toggling back within TTL is a cache hit (2 network calls for 3 states); `auto` and explicit `'upstream'` share one entry. Store, TaskPage, github-component, and `src/main/github` suites: 2,325 tests pass.
- [x] `pnpm build`
- [x] Verified in the dev app on a fork: every toggle shows the selected source's rows; toggling back within a minute renders instantly.

## AI Review Report

Adversarial race-trace of the toggle path (Codex, plus the authoring agent's verification of each load-bearing claim against the code):

- **Root cause confirmed statically** — the scope-prefixed key shape (`getTaskSourceCacheScope` → `workItemsCacheKey`) vs the bare-prefix eviction was proven by construction, then reproduced as a red unit test; no flaky manual repro required.
- **Interleaving trace** — the stale/empty symptoms come from the optimistic repo patch and the `repos:changed` echo re-running the fetch effect around the forced refetch, whose `.then` is cancelled; with per-side keys the surviving non-forced run reads the correct side's entry, so the trace is benign now.
- **Matcher false positives** — `::repoId::` containment requires the repo id (a UUID) at a `::` segment boundary; cross-repo collision would need one repo's UUID embedded in another's scope, which the scope construction cannot produce.
- **Persisted caches** — legacy-format keys restored from disk are never selected again and age out through the bounded cache; repo evictions still match them via the repoId segment.
- **SSH/remote hosts** — execution-host-scoped keys (`hostId::repoId::…`) had the same eviction escape and are covered by the same matcher fix; key construction threads through the existing host/source-scope plumbing unchanged.
- **GitLab/Linear/Jira** — untouched; the change is GitHub work-item cache identity only.

## Security Audit

No new inputs, IPC, command execution, or dependencies — renderer cache-key construction, eviction matching, and tests only.

## Notes

- **Stacked on #8727**: the effective-side key normalization (`auto` ≡ `upstream`) is only correct once `auto` routes PRs upstream-first. Kept as draft until that lands.
- **Known separate factor**: pagination *totals* still blink on flips — the count is an independent fire-and-forget query with no renderer cache (the effect nulls `totalItemCount` at dispatch, so the pager runs degraded until the count lands), and count queries always use `gh api --cache 120s` with no bypass. The row-side fix here doesn't cover it; the natural follow-up is a per-side count cache mirroring this PR's key scheme, plus (optionally) a cache bypass on flips.
- **Pre-existing chip flicker, slightly more visible now**: the Upstream/Origin selector renders from the cache entry's `sources` metadata, so it unmounts during the first fetch of a side (per #5176's "render nothing until metadata arrives" rule) and remounts on response. With per-side entries this brief flicker can happen once per side instead of once per repo. Not addressed here — persisting the raw candidates per repo (or falling back to any cached entry's sources) would keep the chip mounted; happy to follow up.
- **Not addressed — checks/merge badge flicker on refreshes and flips**: PR rows' checks/merge badges hydrate lazily per row, and a forced refresh replaces rows with fresh list objects that carry no such metadata, blanking the badges until the lazy reload. An attempt to route forced refreshes through the landing probe's reconcile did not remove the flicker (the fresh rows' status signature differs whenever hydrated metadata is present, so reconcile still replaces them), so it was backed out rather than shipped half-working; a real fix likely needs to carry hydrated fields across row replacement. Tracked as a follow-up.
- **Follow-up candidate**: the repo-cache keys remain stringly-typed with three shapes (bare, host-scoped, source-scoped), which is what made the substring matcher necessary. A structured key (or a repoId→keys registry) would make eviction membership explicit; left out to keep this change reviewable.

## ELI5

Flipping Tasks between Upstream and Origin without a manual refresh showed stale or empty lists. Each source keeps its own cache so the list matches the selector immediately.
