### PR TITLE
Add Korean offline speech model (Zipformer, KsponSpeech)

### DIFF
--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -122,6 +122,28 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     modelingUnit: 'cjkchar'
   },
   {
+    id: 'zipformer-korean',
+    label: 'Zipformer Korean',
+    description: 'Korean only. Offline transducer trained on the KsponSpeech corpus.',
+    type: 'transducer',
+    provider: 'local',
+    language: 'ko',
+    sizeBytes: 329_740_690,
+    downloadUrl:
+      'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-korean-2024-06-24.tar.bz2',
+    archiveSha256: '24bd409318f389cd2de0e295eb1acf91f4e8dfcc0d650490dd2a01f5b50d2c77',
+    archiveFormat: 'tar.bz2',
+    files: [
+      'encoder-epoch-99-avg-1.int8.onnx',
+      'decoder-epoch-99-avg-1.onnx',
+      'joiner-epoch-99-avg-1.int8.onnx',
+      'tokens.txt'
+    ],
+    sampleRate: 16000,
+    streaming: false,
+    modelingUnit: 'bpe'
+  },
+  {
     id: 'whisper-tiny',
     label: 'Whisper Tiny',
     description: '90+ languages. Lower accuracy than Parakeet but broadest language coverage.',


### PR DESCRIPTION
## What

Adds the official sherpa-onnx Korean offline transducer model
(`sherpa-onnx-zipformer-korean-2024-06-24`) to the local speech model catalog.

## Why

Orca currently ships no Korean-capable **local** dictation model — the only
options for Korean today are Whisper Tiny (low accuracy) or the cloud OpenAI
models. The dictation engine (sherpa-onnx) already supports offline Zipformer
transducer models, and this model is distributed exactly like every existing
catalog entry (a `.tar.bz2` on the `k2-fsa/sherpa-onnx` `asr-models` release),
so this is a single catalog entry with no engine changes.

## Model details

- Type: offline transducer (`type: 'transducer'`, `streaming: false`)
- Language: Korean, trained on the KsponSpeech corpus (converted from
  `icefall-asr-ksponspeech-zipformer-2024-06-24`)
- Uses the int8 encoder/joiner + fp32 decoder combination from the sherpa-onnx
  int8 decoding example
- Archive: 329,740,690 bytes, sha256
  `24bd409318f389cd2de0e295eb1acf91f4e8dfcc0d650490dd2a01f5b50d2c77`

## Verification

- Download URL, size, and sha256 verified by downloading the live release asset.
- Confirmed the archive extracts (after `--strip-components=1`, as in
  `model-manager.ts`) to the four filenames listed in `files`.
- Field values (`type`, `files`, `modelingUnit`, extraction) checked against the
  `stt-worker` offline-transducer path and `model-manager` expectations.
- Not yet exercised end-to-end in a full Orca build — maintainer smoke-test welcome.

Ref: https://huggingface.co/k2-fsa/sherpa-onnx-zipformer-korean-2024-06-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Adds a real offline Korean speech model for local dictation. Korean voice input no longer has to rely only on weak Whisper Tiny or cloud models.
