### PR TITLE
fix: link to repo root instead of 404ing /stargazers page

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -26,7 +26,8 @@ type ShortcutItem = {
   action: string
 }
 
-const ORCA_STARGAZERS_URL = 'https://github.com/stablyai/orca/stargazers'
+// Do not deep-link to /stargazers: GitHub 404s that page for users without repo write access.
+const ORCA_GITHUB_URL = 'https://github.com/stablyai/orca'
 
 type StarState = 'loading' | 'starred' | 'not-starred' | 'web-fallback' | 'hidden'
 
@@ -72,7 +73,7 @@ function GitHubStarButton({ hasRepos }: { hasRepos: boolean }): React.JSX.Elemen
       return
     }
     if (state === 'web-fallback') {
-      await window.api.shell.openUrl(ORCA_STARGAZERS_URL)
+      await window.api.shell.openUrl(ORCA_GITHUB_URL)
       return
     }
     if (state !== 'not-starred') {

--- a/src/renderer/src/components/settings/GeneralSupportSection.tsx
+++ b/src/renderer/src/components/settings/GeneralSupportSection.tsx
@@ -9,7 +9,8 @@ import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 
-const ORCA_STARGAZERS_URL = 'https://github.com/stablyai/orca/stargazers'
+// Do not deep-link to /stargazers: GitHub 404s that page for users without repo write access.
+const ORCA_GITHUB_URL = 'https://github.com/stablyai/orca'
 
 type SupportState =
   | 'loading'
@@ -58,7 +59,7 @@ export function GeneralSupportSection({
   const handleStarClick = async (): Promise<void> => {
     if (starState === 'web-fallback') {
       setStarState('opening-github')
-      await window.api.shell.openUrl(ORCA_STARGAZERS_URL)
+      await window.api.shell.openUrl(ORCA_GITHUB_URL)
       if (mountedRef.current) {
         setStarState('web-fallback')
       }


### PR DESCRIPTION
## Summary

Fixes the "Star Orca on GitHub" web-fallback button, which sent users to a page that 404s for anyone without repo write access.

## ELI5

The "star us on GitHub" button opened a page that showed an error for most people. Now it opens the normal Orca repo page, which works for everyone.

## Root cause & fix

The web-fallback star handlers on the Landing screen and General settings linked to `https://github.com/stablyai/orca/stargazers`, a URL that returns a 404 for users without write access to the repo. The fix swaps the hardcoded constant `ORCA_STARGAZERS_URL` for `ORCA_GITHUB_URL` (`https://github.com/stablyai/orca`) in both `Landing.tsx` and `GeneralSupportSection.tsx`. Same button, label, and copy — only the destination URL changes, so the user still lands on a working page and can click Star themselves.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Rebase onto `origin/main` was clean. This was validated by code inspection (no unit tests apply to a static string swap):

- `grep` confirms no remaining `stargazers` URL references (only in explanatory comments).
- Both the constant declaration and its single call site were updated consistently in each file.
- Change is a static string constant swap through `window.api.shell.openUrl` — no logic or control-flow change, and platform-agnostic.
- Author verified `.../stargazers` returns 404 and the repo root returns 200.

Lint clean:

```
npx oxlint src/renderer/src/components/Landing.tsx \
  src/renderer/src/components/settings/GeneralSupportSection.tsx
-> EXIT=0, no warnings/errors
```

## Trade-offs

None — pure fix.

## Regression risk

Effectively zero. The only change is the value of two destination-URL constants; no control flow, no other call sites, and non-affected paths are byte-identical. The open-URL mechanism is untouched, so no platform, SSH, or git-provider behavior is affected.

*Credit to original author @katspaugh. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
