### PR TITLE
Fix PR checks sticking to a stale linked PR after a terminal branch switch

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -926,7 +926,11 @@ describe('getPRForBranch', () => {
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
     expect(outcome).toMatchObject({
       kind: 'found',
-      pr: { number: 6012, confirmedContainedHeadOid: 'cccc3333cccc3333' }
+      pr: {
+        number: 6012,
+        headRefName: 'fix-hibernation-wake',
+        confirmedContainedHeadOid: 'cccc3333cccc3333'
+      }
     })
   })
 

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -3214,6 +3214,7 @@ export async function getPRForBranchOutcome(
         ...(confirmedContainedHeadOid ? { confirmedContainedHeadOid } : {}),
         ...(headDivergedFromMergedPRAtOid ? { headDivergedFromMergedPRAtOid } : {}),
         ...(data.baseRefName ? { baseRefName: data.baseRefName } : {}),
+        ...(data.headRefName ? { headRefName: data.headRefName } : {}),
         prRepo: dataRepo ?? undefined,
         headRepo: dataHeadRepo ?? undefined,
         conflictSummary

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -2225,6 +2225,71 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     expect(store.getState().prCache[`${repoId}::${branch}`]).toBeUndefined()
   })
 
+  it('unlinks a stale open PR and re-resolves the current branch with one follow-up lookup', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/current'
+    const worktreeId = 'wt-stale-open-pr'
+    const stalePR = makePR({
+      number: 12,
+      title: 'Stale linked PR',
+      headSha: 'old-head',
+      headRefName: 'feature/old'
+    })
+    const currentPR = makePR({
+      number: 13,
+      title: 'Current branch PR',
+      headSha: 'current-head',
+      headRefName: branch
+    })
+    const updateWorktreeMeta = installLinkedPRClearStub(store, {
+      repoId,
+      repoPath,
+      branch,
+      worktree: makePRRefreshWorktree({
+        id: worktreeId,
+        repoId,
+        branch,
+        head: 'current-head',
+        linkedPR: 12
+      })
+    })
+    mockApi.gh.refreshPRNow
+      .mockResolvedValueOnce({ kind: 'found', pr: stalePR, fetchedAt: 2 })
+      .mockResolvedValueOnce({ kind: 'found', pr: currentPR, fetchedAt: 3 })
+
+    await expect(
+      store.getState().fetchPRForBranch(repoPath, branch, {
+        force: true,
+        repoId,
+        worktreeId,
+        linkedPRNumber: 12
+      })
+    ).resolves.toEqual(stalePR)
+
+    await vi.waitFor(() => {
+      expect(mockApi.gh.refreshPRNow).toHaveBeenCalledTimes(2)
+      expect(store.getState().prCache[`${repoId}::${branch}`]?.data).toEqual(currentPR)
+    })
+    expect(updateWorktreeMeta).toHaveBeenCalledWith(
+      worktreeId,
+      { linkedPR: null },
+      {
+        suppressHostedReviewRefresh: true,
+        shouldApply: expect.any(Function)
+      }
+    )
+    expect(mockApi.gh.refreshPRNow.mock.calls[1]?.[0]).toMatchObject({
+      candidate: expect.objectContaining({
+        branch,
+        linkedPRNumber: null,
+        worktreeId
+      })
+    })
+    expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBeNull()
+  })
+
   it('clears a linked merged PR on a fresh cache hit that already carries a head-scoped divergence signal', async () => {
     const store = createTestStore()
     const repoPath = '/repo'

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -3295,6 +3295,58 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     expect(worktreeIdReads).toBe(0)
   })
 
+  it('indexes worktrees once for a coordinator outcome with many linked aliases', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/shared'
+    let worktreeIdReads = 0
+    const worktrees = Array.from({ length: 100 }, (_, index) => {
+      const worktree = makePRRefreshWorktree({
+        id: `wt-${index}`,
+        repoId,
+        branch,
+        head: 'shared-head',
+        linkedPR: 12
+      })
+      Object.defineProperty(worktree, 'id', {
+        enumerable: true,
+        get: () => {
+          worktreeIdReads += 1
+          return `wt-${index}`
+        }
+      })
+      return worktree
+    })
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: { [repoId]: worktrees }
+    } as unknown as Partial<AppState>)
+    worktreeIdReads = 0
+
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 1,
+      reason: 'swr',
+      aliases: worktrees.map((_, index) => ({
+        cacheKey: `${repoId}::${branch}::${index}`,
+        repoPath,
+        repoId,
+        branch,
+        worktreeId: `wt-${index}`,
+        linkedPRNumber: 12,
+        currentHeadOid: 'shared-head'
+      })),
+      outcome: {
+        kind: 'found',
+        pr: makePR({ number: 12, state: 'open', headSha: 'shared-head', headRefName: branch }),
+        fetchedAt: 2
+      }
+    })
+
+    // One read per stored row proves aliases share the event-local index.
+    expect(worktreeIdReads).toBe(worktrees.length)
+  })
+
   it('does not unlink from a branch-mismatched outcome rejected by the sequence gate', () => {
     const store = createTestStore()
     const repoPath = '/repo'

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -3127,6 +3127,287 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBeNull()
   })
 
+  it('clears a branch-mismatched linked open PR from an accepted coordinator event', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/current'
+    const worktreeId = 'wt-coordinator-open-mismatch'
+    const cacheKey = `${repoId}::${branch}`
+    const worktree = makePRRefreshWorktree({
+      id: worktreeId,
+      repoId,
+      branch,
+      head: 'current-head',
+      linkedPR: 12
+    })
+    const updateWorktreeMeta = installLinkedPRClearStub(store, {
+      repoId,
+      repoPath,
+      branch,
+      worktree
+    })
+
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 1,
+      reason: 'swr',
+      aliases: [
+        {
+          cacheKey,
+          repoPath,
+          repoId,
+          branch,
+          worktreeId,
+          linkedPRNumber: 12,
+          currentHeadOid: 'current-head'
+        }
+      ],
+      outcome: {
+        kind: 'found',
+        pr: makePR({ number: 12, state: 'open', headSha: 'old-head', headRefName: 'feature/old' }),
+        fetchedAt: 2
+      }
+    })
+
+    expect(updateWorktreeMeta).toHaveBeenCalledWith(
+      worktreeId,
+      { linkedPR: null },
+      { shouldApply: expect.any(Function) }
+    )
+    expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBeNull()
+  })
+
+  it('does not scan worktrees for a found coordinator outcome without a durable PR link', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/unlinked'
+    let worktreeIdReads = 0
+    const worktrees = Array.from({ length: 100 }, (_, index) => {
+      const worktree = makePRRefreshWorktree({
+        id: `wt-${index}`,
+        repoId,
+        branch: `feature/${index}`,
+        head: `head-${index}`,
+        linkedPR: null
+      })
+      Object.defineProperty(worktree, 'id', {
+        enumerable: true,
+        get: () => {
+          worktreeIdReads += 1
+          return `wt-${index}`
+        }
+      })
+      return worktree
+    })
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: { [repoId]: worktrees }
+    } as unknown as Partial<AppState>)
+    worktreeIdReads = 0
+
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 1,
+      reason: 'swr',
+      aliases: [
+        {
+          cacheKey: `${repoId}::${branch}`,
+          repoPath,
+          repoId,
+          branch,
+          worktreeId: 'wt-0',
+          linkedPRNumber: null,
+          currentHeadOid: 'head-0'
+        }
+      ],
+      outcome: {
+        kind: 'found',
+        pr: makePR({ number: 12, state: 'open', headRefName: branch }),
+        fetchedAt: 2
+      }
+    })
+
+    expect(worktreeIdReads).toBe(0)
+  })
+
+  it('does not unlink from a branch-mismatched outcome rejected by the sequence gate', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/current'
+    const worktreeId = 'wt-coordinator-stale-sequence'
+    const cacheKey = `${repoId}::${branch}`
+    const worktree = makePRRefreshWorktree({
+      id: worktreeId,
+      repoId,
+      branch,
+      head: 'current-head',
+      linkedPR: 12
+    })
+    const updateWorktreeMeta = installLinkedPRClearStub(store, {
+      repoId,
+      repoPath,
+      branch,
+      worktree
+    })
+    const aliases = [
+      {
+        cacheKey,
+        repoPath,
+        repoId,
+        branch,
+        worktreeId,
+        linkedPRNumber: 12,
+        currentHeadOid: 'current-head'
+      }
+    ]
+
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 2,
+      reason: 'swr',
+      aliases,
+      outcome: {
+        kind: 'found',
+        pr: makePR({ number: 12, state: 'open', headRefName: branch }),
+        fetchedAt: 3
+      }
+    })
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 1,
+      reason: 'swr',
+      aliases,
+      outcome: {
+        kind: 'found',
+        pr: makePR({ number: 12, state: 'open', headSha: 'old-head', headRefName: 'feature/old' }),
+        fetchedAt: 4
+      }
+    })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBe(12)
+    expect(store.getState().prRefreshSequences[cacheKey]).toBe(2)
+  })
+
+  it('does not unlink an ambiguous worktree id shared by multiple hosts', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/current'
+    const worktreeId = 'repo-1::/same/path'
+    const cacheKey = `${repoId}::${branch}`
+    const updateWorktreeMeta = vi.fn()
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        [repoId]: [
+          makePRRefreshWorktree({
+            id: worktreeId,
+            repoId,
+            branch,
+            head: 'local-head',
+            linkedPR: 12,
+            hostId: 'local'
+          }),
+          makePRRefreshWorktree({
+            id: worktreeId,
+            repoId,
+            branch,
+            head: 'ssh-head',
+            linkedPR: 12,
+            hostId: 'ssh:ssh-1'
+          })
+        ]
+      },
+      updateWorktreeMeta
+    } as unknown as Partial<AppState>)
+
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 1,
+      reason: 'swr',
+      aliases: [
+        {
+          cacheKey,
+          repoPath,
+          repoId,
+          branch,
+          worktreeId,
+          linkedPRNumber: 12,
+          currentHeadOid: 'local-head'
+        }
+      ],
+      outcome: {
+        kind: 'found',
+        pr: makePR({ number: 12, state: 'open', headSha: 'old-head', headRefName: 'feature/old' }),
+        fetchedAt: 2
+      }
+    })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo[repoId]).toHaveLength(2)
+    expect(
+      store.getState().worktreesByRepo[repoId]?.every((worktree) => worktree.linkedPR === 12)
+    ).toBe(true)
+  })
+
+  it('does not let an old-host coordinator event unlink a row now owned by another host', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/current'
+    const worktreeId = 'repo-1::/same/path'
+    const cacheKey = `ssh:ssh-1::${repoId}::${branch}`
+    const updateWorktreeMeta = vi.fn()
+    store.setState({
+      repos: [
+        {
+          id: repoId,
+          path: repoPath,
+          name: 'repo',
+          kind: 'git',
+          connectionId: 'ssh-2'
+        }
+      ],
+      worktreesByRepo: {
+        [repoId]: [
+          makePRRefreshWorktree({
+            id: worktreeId,
+            repoId,
+            branch,
+            head: 'ssh-2-head',
+            linkedPR: 12,
+            hostId: 'ssh:ssh-2'
+          })
+        ]
+      },
+      updateWorktreeMeta
+    } as unknown as Partial<AppState>)
+
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 1,
+      reason: 'swr',
+      aliases: [
+        {
+          cacheKey,
+          repoPath,
+          repoId,
+          branch,
+          worktreeId,
+          linkedPRNumber: 12,
+          currentHeadOid: 'old-host-head',
+          executionHostId: 'ssh:ssh-1'
+        }
+      ],
+      outcome: {
+        kind: 'found',
+        pr: makePR({ number: 12, state: 'open', headSha: 'old-head', headRefName: 'feature/old' }),
+        fetchedAt: 2
+      }
+    })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo[repoId]?.[0]?.linkedPR).toBe(12)
+  })
+
   it('does not clear a linked merged PR from a coordinator refresh event without a request head', () => {
     const store = createTestStore()
     const repoPath = '/repo'
@@ -6555,6 +6836,12 @@ describe('shouldClearBranchMismatchedLinkedOpenPR', () => {
     expect(shouldClearBranchMismatchedLinkedOpenPR(baseArgs)).toBe(true)
   })
 
+  it('clears when the mismatched linked PR is a draft', () => {
+    expect(
+      shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, pr: basePR({ state: 'draft' }) })
+    ).toBe(true)
+  })
+
   it('strips refs/heads/ from the worktree branch before comparing', () => {
     expect(
       shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, branch: 'refs/heads/feature-one' })
@@ -6582,7 +6869,7 @@ describe('shouldClearBranchMismatchedLinkedOpenPR', () => {
     )
   })
 
-  it('only applies to open PRs', () => {
+  it('only applies to active PRs', () => {
     expect(
       shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, pr: basePR({ state: 'merged' }) })
     ).toBe(false)
@@ -6600,6 +6887,9 @@ describe('shouldClearBranchMismatchedLinkedOpenPR', () => {
     ).toBe(false)
     // Detached HEAD reports an empty branch; there is no mismatch to act on.
     expect(shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, branch: '' })).toBe(false)
+    expect(shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, requestHeadOid: null })).toBe(
+      false
+    )
   })
 
   it('ignores lookups that resolved a different PR than the link', () => {

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -13,6 +13,7 @@ import {
   prChecksCacheSuffix,
   prCommentsCacheSuffix,
   projectViewCacheKey,
+  shouldClearBranchMismatchedLinkedOpenPR,
   workItemsCacheKey
 } from './github'
 import { createHostedReviewSlice } from './hosted-review'
@@ -6524,5 +6525,90 @@ describe('IssueSourceIndicator suppression', () => {
     expect(itemMarkup).toContain('up/r')
     expect(itemMarkup).toContain('Issue from')
     expect(itemMarkup).not.toContain('Issues from')
+  })
+})
+
+describe('shouldClearBranchMismatchedLinkedOpenPR', () => {
+  const basePR = (overrides: Partial<PRInfo> = {}): PRInfo =>
+    ({
+      number: 20,
+      title: 'Sample PR',
+      state: 'open',
+      url: 'https://github.com/o/r/pull/20',
+      checksStatus: 'success',
+      updatedAt: '2026-01-01T00:00:00Z',
+      mergeable: 'MERGEABLE',
+      headSha: 'prhead',
+      headRefName: 'feature-one',
+      ...overrides
+    }) as PRInfo
+
+  const baseArgs = {
+    pr: basePR(),
+    linkedPRNumber: 20,
+    branch: 'feature-two',
+    requestHeadOid: 'otherhead',
+    pushTargetBranch: null
+  }
+
+  it('clears when an open linked PR heads a different branch than the worktree', () => {
+    expect(shouldClearBranchMismatchedLinkedOpenPR(baseArgs)).toBe(true)
+  })
+
+  it('strips refs/heads/ from the worktree branch before comparing', () => {
+    expect(
+      shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, branch: 'refs/heads/feature-one' })
+    ).toBe(false)
+    expect(
+      shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, branch: 'refs/heads/feature-two' })
+    ).toBe(true)
+  })
+
+  it('keeps the link when the branch matches the PR head', () => {
+    expect(shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, branch: 'feature-one' })).toBe(
+      false
+    )
+  })
+
+  it('keeps the link when the push target routes to the PR head branch', () => {
+    expect(
+      shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, pushTargetBranch: 'feature-one' })
+    ).toBe(false)
+  })
+
+  it('keeps the link when the worktree HEAD is the PR head commit', () => {
+    expect(shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, requestHeadOid: 'prhead' })).toBe(
+      false
+    )
+  })
+
+  it('only applies to open PRs', () => {
+    expect(
+      shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, pr: basePR({ state: 'merged' }) })
+    ).toBe(false)
+    expect(
+      shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, pr: basePR({ state: 'closed' }) })
+    ).toBe(false)
+  })
+
+  it('requires a known PR head branch and a current branch', () => {
+    expect(
+      shouldClearBranchMismatchedLinkedOpenPR({
+        ...baseArgs,
+        pr: basePR({ headRefName: undefined })
+      })
+    ).toBe(false)
+    // Detached HEAD reports an empty branch; there is no mismatch to act on.
+    expect(shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, branch: '' })).toBe(false)
+  })
+
+  it('ignores lookups that resolved a different PR than the link', () => {
+    expect(
+      shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, pr: basePR({ number: 21 }) })
+    ).toBe(false)
+    expect(shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, pr: null })).toBe(false)
+    expect(shouldClearBranchMismatchedLinkedOpenPR({ ...baseArgs, linkedPRNumber: null })).toBe(
+      false
+    )
   })
 })

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -3281,6 +3281,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               options.worktreeId,
               { linkedPR: null },
               {
+                // Why: the branch-scoped PR refetch below updates both GitHub
+                // caches; the generic metadata refresh would duplicate provider work.
+                suppressHostedReviewRefresh: true,
                 shouldApply: () =>
                   shouldApplyBranchMismatchedLinkedPRClear({
                     worktree:

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -994,25 +994,51 @@ function findWorktreeById(state: AppState, worktreeId: string): Worktree | null 
   return null
 }
 
+type WorktreeLookupEntry = {
+  first: Worktree
+  unique: Worktree | null
+}
+
+type WorktreeLookupIndex = {
+  byId: Map<string, WorktreeLookupEntry>
+  repoHostIdsByRepoId: Map<string, Set<string>>
+}
+
+function buildWorktreeLookupIndex(state: AppState): WorktreeLookupIndex {
+  const byId = new Map<string, WorktreeLookupEntry>()
+  for (const worktrees of Object.values(state.worktreesByRepo)) {
+    for (const worktree of worktrees) {
+      const worktreeId = worktree.id
+      const existing = byId.get(worktreeId)
+      if (existing) {
+        existing.unique = null
+      } else {
+        byId.set(worktreeId, { first: worktree, unique: worktree })
+      }
+    }
+  }
+
+  const repoHostIdsByRepoId = new Map<string, Set<string>>()
+  for (const repo of state.repos ?? []) {
+    let hostIds = repoHostIdsByRepoId.get(repo.id)
+    if (!hostIds) {
+      hostIds = new Set<string>()
+      repoHostIdsByRepoId.set(repo.id, hostIds)
+    }
+    hostIds.add(getRepoExecutionHostId(repo))
+  }
+  return { byId, repoHostIdsByRepoId }
+}
+
 function findUniqueWorktreeById(
   state: AppState,
   worktreeId: string,
-  executionHostId?: string
+  executionHostId?: string,
+  lookupIndex = buildWorktreeLookupIndex(state)
 ): Worktree | null {
-  let match: Worktree | null = null
-  for (const worktrees of Object.values(state.worktreesByRepo)) {
-    for (const worktree of worktrees) {
-      if (worktree.id !== worktreeId) {
-        continue
-      }
-      if (match) {
-        // Why: metadata persistence is keyed only by worktree id. If two hosts
-        // own that id, a destructive linked-PR clear cannot be routed safely.
-        return null
-      }
-      match = worktree
-    }
-  }
+  const match = lookupIndex.byId.get(worktreeId)?.unique ?? null
+  // Why: metadata persistence is keyed only by worktree id. If two hosts own
+  // that id, the index marks it non-unique and destructive clears fail closed.
   if (!match || executionHostId === undefined) {
     return match
   }
@@ -1021,13 +1047,9 @@ function findUniqueWorktreeById(
   if (explicitWorktreeHostId) {
     return explicitWorktreeHostId === expectedHostId ? match : null
   }
-  const repoHostIds = new Set(
-    state.repos
-      .filter((repo) => repo.id === match.repoId)
-      .map((repo) => getRepoExecutionHostId(repo))
-  )
+  const repoHostIds = lookupIndex.repoHostIdsByRepoId.get(match.repoId)
   // Pre-host persisted rows are safe only when their repo has one unambiguous owner.
-  if (repoHostIds.size !== 1 || !repoHostIds.has(expectedHostId)) {
+  if (!repoHostIds || repoHostIds.size !== 1 || !repoHostIds.has(expectedHostId)) {
     return null
   }
   return match
@@ -1036,12 +1058,16 @@ function findUniqueWorktreeById(
 function isStaleExactLinkedPRLookup(
   state: AppState,
   worktreeId: string | undefined,
-  linkedPRNumber: number | null | undefined
+  linkedPRNumber: number | null | undefined,
+  lookupIndex?: WorktreeLookupIndex
 ): boolean {
   if (!worktreeId || linkedPRNumber == null) {
     return false
   }
-  return findWorktreeById(state, worktreeId)?.linkedPR !== linkedPRNumber
+  const worktree = lookupIndex
+    ? (lookupIndex.byId.get(worktreeId)?.first ?? null)
+    : findWorktreeById(state, worktreeId)
+  return worktree?.linkedPR !== linkedPRNumber
 }
 
 function shouldClearDivergedLinkedMergedPR(args: {
@@ -4044,6 +4070,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     }[] = []
     let didUpdatePRCache = false
     set((s) => {
+      let linkedWorktreeLookupIndex: WorktreeLookupIndex | undefined
       const nextSequences = { ...s.prRefreshSequences }
       const prunedStates = pruneExpiredPRRefreshStates(s.prRefreshStates)
       const nextStates = { ...prunedStates }
@@ -4156,17 +4183,30 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                   return pr
                 })()
               : null
+          const linkedPRNumber = alias.linkedPRNumber ?? null
+          // Why: one coordinator outcome can fan out to many linked aliases.
+          // Build one lazy index instead of rescanning all worktrees per alias.
+          const worktreeLookupIndex =
+            alias.worktreeId && linkedPRNumber != null
+              ? (linkedWorktreeLookupIndex ??= buildWorktreeLookupIndex(s))
+              : undefined
           // Why: queued local refreshes may finish after the user unlinks an
           // exact PR; those older results must not restore the manual-link UI.
-          if (isStaleExactLinkedPRLookup(s, alias.worktreeId, alias.linkedPRNumber)) {
+          if (
+            isStaleExactLinkedPRLookup(s, alias.worktreeId, linkedPRNumber, worktreeLookupIndex)
+          ) {
             continue
           }
           if (event.outcome.kind === 'found' && alias.worktreeId) {
-            const linkedPRNumber = alias.linkedPRNumber ?? null
             const requestHeadOid = alias.currentHeadOid ?? null
             const worktree =
               linkedPRNumber != null
-                ? findUniqueWorktreeById(s, alias.worktreeId, aliasExecutionHostId)
+                ? findUniqueWorktreeById(
+                    s,
+                    alias.worktreeId,
+                    aliasExecutionHostId,
+                    worktreeLookupIndex
+                  )
                 : null
             // Why: only an event that won the sequence gate above owns metadata
             // side effects; rejected late outcomes must not unlink a newer PR.

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -994,6 +994,45 @@ function findWorktreeById(state: AppState, worktreeId: string): Worktree | null 
   return null
 }
 
+function findUniqueWorktreeById(
+  state: AppState,
+  worktreeId: string,
+  executionHostId?: string
+): Worktree | null {
+  let match: Worktree | null = null
+  for (const worktrees of Object.values(state.worktreesByRepo)) {
+    for (const worktree of worktrees) {
+      if (worktree.id !== worktreeId) {
+        continue
+      }
+      if (match) {
+        // Why: metadata persistence is keyed only by worktree id. If two hosts
+        // own that id, a destructive linked-PR clear cannot be routed safely.
+        return null
+      }
+      match = worktree
+    }
+  }
+  if (!match || executionHostId === undefined) {
+    return match
+  }
+  const expectedHostId = normalizeExecutionHostId(executionHostId) ?? LOCAL_EXECUTION_HOST_ID
+  const explicitWorktreeHostId = normalizeExecutionHostId(match.hostId)
+  if (explicitWorktreeHostId) {
+    return explicitWorktreeHostId === expectedHostId ? match : null
+  }
+  const repoHostIds = new Set(
+    state.repos
+      .filter((repo) => repo.id === match.repoId)
+      .map((repo) => getRepoExecutionHostId(repo))
+  )
+  // Pre-host persisted rows are safe only when their repo has one unambiguous owner.
+  if (repoHostIds.size !== 1 || !repoHostIds.has(expectedHostId)) {
+    return null
+  }
+  return match
+}
+
 function isStaleExactLinkedPRLookup(
   state: AppState,
   worktreeId: string | undefined,
@@ -1044,8 +1083,8 @@ function shouldApplyDivergedLinkedPRClear(args: {
 }
 
 // Why: a linked PR is a branch-scoped hint. When a lookup returns the linked
-// OPEN PR while the worktree sits on a different branch — and neither the push
-// target nor the worktree HEAD still points at the PR head — the link is stale
+// open or draft PR while the worktree sits on a different branch — and neither
+// the push target nor the worktree HEAD still points at the PR head — the link is stale
 // (a branch switch whose identity-path clear was missed) and would otherwise
 // pin Checks to the previous branch's PR on every refresh.
 export function shouldClearBranchMismatchedLinkedOpenPR(args: {
@@ -1061,29 +1100,35 @@ export function shouldClearBranchMismatchedLinkedOpenPR(args: {
   return (
     linkedPRNumber != null &&
     pr?.number === linkedPRNumber &&
-    pr.state === 'open' &&
+    // Draft reviews are open PRs too; their distinct renderer state must not
+    // leave the same stale durable link permanently wedged after a branch switch.
+    (pr.state === 'open' || pr.state === 'draft') &&
+    requestHeadOid !== null &&
     headRefName !== '' &&
     currentBranch !== '' &&
     headRefName !== currentBranch &&
     (pushTargetBranch === null || pushTargetBranch !== headRefName) &&
     // A worktree parked on the PR's own head commit is the same line of work
     // (e.g. a PR checkout under a renamed local branch); keep the link.
-    !(pr.headSha != null && requestHeadOid !== null && pr.headSha === requestHeadOid)
+    !(pr.headSha != null && pr.headSha === requestHeadOid)
   )
 }
 
 function shouldApplyBranchMismatchedLinkedPRClear(args: {
-  worktree: Pick<Worktree, 'linkedPR' | 'branch' | 'isBare' | 'isArchived'> | undefined
+  worktree: Pick<Worktree, 'linkedPR' | 'branch' | 'head' | 'isBare' | 'isArchived'> | undefined
   linkedPRNumber: number
   branch: string
+  requestHeadOid: string | null
 }): boolean {
-  const { worktree, linkedPRNumber, branch } = args
+  const { worktree, linkedPRNumber, branch, requestHeadOid } = args
   return (
     Boolean(worktree) &&
+    requestHeadOid !== null &&
     worktree?.linkedPR === linkedPRNumber &&
     // Branch-scoped: only clear while the worktree is still on the branch the
     // mismatch was computed against; a newer switch gets its own validation.
     worktree.branch.replace(/^refs\/heads\//, '') === branch.replace(/^refs\/heads\//, '') &&
+    worktree.head === requestHeadOid &&
     worktree.isBare !== true &&
     worktree.isArchived !== true
   )
@@ -1361,17 +1406,23 @@ function shouldPreserveExistingPRForFallbackMiss(args: {
   fallbackPRNumber?: number | null
   fallbackPRSource?: GitHubPRFallbackSource | null
 }): boolean {
+  if (
+    args.nextPR !== null ||
+    args.linkedPRNumber != null ||
+    args.currentPR?.state !== 'merged' ||
+    typeof args.currentPR.headSha !== 'string' ||
+    args.currentPR.headSha.length === 0
+  ) {
+    return false
+  }
+  // Why: the common found/non-merged paths do not depend on worktree state.
+  // Gate the global lookup so batched refresh aliases do not multiply full scans.
   const worktree = args.worktreeId ? findWorktreeById(args.state, args.worktreeId) : null
   const worktreeHead = worktree?.head
   // Why: merged branch PRs are only safe to keep when cached PR metadata still
   // matches the commit this stored worktree is actually on — exactly, or via a
   // head confirmed to be part of the merged PR.
   const preservesMergedPRForCurrentHead =
-    args.nextPR === null &&
-    args.linkedPRNumber == null &&
-    args.currentPR?.state === 'merged' &&
-    typeof args.currentPR.headSha === 'string' &&
-    args.currentPR.headSha.length > 0 &&
     typeof worktreeHead === 'string' &&
     worktreeHead.length > 0 &&
     (args.currentPR.headSha === worktreeHead ||
@@ -3179,8 +3230,17 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           if (didUpdatePRCache) {
             debouncedSaveCache(get())
           }
+          const linkedPRWorktree =
+            options?.worktreeId && linkedPRNumber != null
+              ? findUniqueWorktreeById(
+                  get(),
+                  options.worktreeId,
+                  repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+                )
+              : null
           if (
             options?.worktreeId &&
+            linkedPRWorktree &&
             linkedPRNumber != null &&
             shouldClearDivergedLinkedMergedPR({ pr, linkedPRNumber, requestHeadOid })
           ) {
@@ -3190,9 +3250,14 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               options.worktreeId,
               { linkedPR: null },
               {
-                shouldApply: (worktree) =>
+                shouldApply: () =>
                   shouldApplyDivergedLinkedPRClear({
-                    worktree,
+                    worktree:
+                      findUniqueWorktreeById(
+                        get(),
+                        options.worktreeId!,
+                        repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+                      ) ?? undefined,
                     linkedPRNumber,
                     branch,
                     requestHeadOid
@@ -3202,22 +3267,32 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           }
           if (
             options?.worktreeId &&
+            linkedPRWorktree &&
             linkedPRNumber != null &&
             shouldClearBranchMismatchedLinkedOpenPR({
               pr,
               linkedPRNumber,
               branch,
               requestHeadOid,
-              pushTargetBranch:
-                findWorktreeById(get(), options.worktreeId)?.pushTarget?.branchName ?? null
+              pushTargetBranch: linkedPRWorktree.pushTarget?.branchName ?? null
             })
           ) {
             void get().updateWorktreeMeta(
               options.worktreeId,
               { linkedPR: null },
               {
-                shouldApply: (worktree) =>
-                  shouldApplyBranchMismatchedLinkedPRClear({ worktree, linkedPRNumber, branch })
+                shouldApply: () =>
+                  shouldApplyBranchMismatchedLinkedPRClear({
+                    worktree:
+                      findUniqueWorktreeById(
+                        get(),
+                        options.worktreeId!,
+                        repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+                      ) ?? undefined,
+                    linkedPRNumber,
+                    branch,
+                    requestHeadOid
+                  })
               }
             )
             // Re-resolve by branch right away so visible Checks recover on this
@@ -3955,48 +4030,15 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       linkedPRNumber: number
       branch: string
       requestHeadOid: string | null
+      executionHostId: string
     }[] = []
     const branchMismatchedLinkedPRClears: {
       worktreeId: string
       linkedPRNumber: number
       branch: string
+      requestHeadOid: string | null
+      executionHostId: string
     }[] = []
-    if (event.outcome?.kind === 'found') {
-      const pr = event.outcome.pr
-      for (const alias of event.aliases) {
-        const linkedPRNumber = alias.linkedPRNumber ?? null
-        const requestHeadOid = alias.currentHeadOid ?? null
-        if (!alias.worktreeId || linkedPRNumber == null) {
-          continue
-        }
-        if (shouldClearDivergedLinkedMergedPR({ pr, linkedPRNumber, requestHeadOid })) {
-          divergedLinkedPRClears.push({
-            worktreeId: alias.worktreeId,
-            linkedPRNumber,
-            branch: alias.branch,
-            requestHeadOid
-          })
-        } else if (
-          shouldClearBranchMismatchedLinkedOpenPR({
-            pr,
-            linkedPRNumber,
-            branch: alias.branch,
-            requestHeadOid,
-            pushTargetBranch:
-              findWorktreeById(get(), alias.worktreeId)?.pushTarget?.branchName ?? null
-          })
-        ) {
-          // Why: the background PR coordinator also refreshes with the durable
-          // link; without this clear a stale-linked worktree never re-resolves
-          // by branch on its own.
-          branchMismatchedLinkedPRClears.push({
-            worktreeId: alias.worktreeId,
-            linkedPRNumber,
-            branch: alias.branch
-          })
-        }
-      }
-    }
     let didUpdatePRCache = false
     set((s) => {
       const nextSequences = { ...s.prRefreshSequences }
@@ -4116,6 +4158,51 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           if (isStaleExactLinkedPRLookup(s, alias.worktreeId, alias.linkedPRNumber)) {
             continue
           }
+          if (event.outcome.kind === 'found' && alias.worktreeId) {
+            const linkedPRNumber = alias.linkedPRNumber ?? null
+            const requestHeadOid = alias.currentHeadOid ?? null
+            const worktree =
+              linkedPRNumber != null
+                ? findUniqueWorktreeById(s, alias.worktreeId, aliasExecutionHostId)
+                : null
+            // Why: only an event that won the sequence gate above owns metadata
+            // side effects; rejected late outcomes must not unlink a newer PR.
+            if (
+              worktree &&
+              linkedPRNumber != null &&
+              shouldClearDivergedLinkedMergedPR({
+                pr: event.outcome.pr,
+                linkedPRNumber,
+                requestHeadOid
+              })
+            ) {
+              divergedLinkedPRClears.push({
+                worktreeId: alias.worktreeId,
+                linkedPRNumber,
+                branch: alias.branch,
+                requestHeadOid,
+                executionHostId: aliasExecutionHostId
+              })
+            } else if (
+              worktree &&
+              linkedPRNumber != null &&
+              shouldClearBranchMismatchedLinkedOpenPR({
+                pr: event.outcome.pr,
+                linkedPRNumber,
+                branch: alias.branch,
+                requestHeadOid,
+                pushTargetBranch: worktree.pushTarget?.branchName ?? null
+              })
+            ) {
+              branchMismatchedLinkedPRClears.push({
+                worktreeId: alias.worktreeId,
+                linkedPRNumber,
+                branch: alias.branch,
+                requestHeadOid,
+                executionHostId: aliasExecutionHostId
+              })
+            }
+          }
           const nextCaches = applyGitHubPRResultToCaches({
             prCache: nextPRCache,
             hostedReviewCache: nextHostedReviewCache,
@@ -4198,9 +4285,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         clear.worktreeId,
         { linkedPR: null },
         {
-          shouldApply: (worktree) =>
+          shouldApply: () =>
             shouldApplyDivergedLinkedPRClear({
-              worktree,
+              worktree:
+                findUniqueWorktreeById(get(), clear.worktreeId, clear.executionHostId) ?? undefined,
               linkedPRNumber: clear.linkedPRNumber,
               branch: clear.branch,
               requestHeadOid: clear.requestHeadOid
@@ -4213,11 +4301,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         clear.worktreeId,
         { linkedPR: null },
         {
-          shouldApply: (worktree) =>
+          shouldApply: () =>
             shouldApplyBranchMismatchedLinkedPRClear({
-              worktree,
+              worktree:
+                findUniqueWorktreeById(get(), clear.worktreeId, clear.executionHostId) ?? undefined,
               linkedPRNumber: clear.linkedPRNumber,
-              branch: clear.branch
+              branch: clear.branch,
+              requestHeadOid: clear.requestHeadOid
             })
         }
       )

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1043,6 +1043,52 @@ function shouldApplyDivergedLinkedPRClear(args: {
   )
 }
 
+// Why: a linked PR is a branch-scoped hint. When a lookup returns the linked
+// OPEN PR while the worktree sits on a different branch — and neither the push
+// target nor the worktree HEAD still points at the PR head — the link is stale
+// (a branch switch whose identity-path clear was missed) and would otherwise
+// pin Checks to the previous branch's PR on every refresh.
+export function shouldClearBranchMismatchedLinkedOpenPR(args: {
+  pr: PRInfo | null
+  linkedPRNumber: number | null
+  branch: string
+  requestHeadOid: string | null
+  pushTargetBranch: string | null
+}): boolean {
+  const { pr, linkedPRNumber, branch, requestHeadOid, pushTargetBranch } = args
+  const headRefName = pr?.headRefName?.trim() ?? ''
+  const currentBranch = branch.replace(/^refs\/heads\//, '').trim()
+  return (
+    linkedPRNumber != null &&
+    pr?.number === linkedPRNumber &&
+    pr.state === 'open' &&
+    headRefName !== '' &&
+    currentBranch !== '' &&
+    headRefName !== currentBranch &&
+    (pushTargetBranch === null || pushTargetBranch !== headRefName) &&
+    // A worktree parked on the PR's own head commit is the same line of work
+    // (e.g. a PR checkout under a renamed local branch); keep the link.
+    !(pr.headSha != null && requestHeadOid !== null && pr.headSha === requestHeadOid)
+  )
+}
+
+function shouldApplyBranchMismatchedLinkedPRClear(args: {
+  worktree: Pick<Worktree, 'linkedPR' | 'branch' | 'isBare' | 'isArchived'> | undefined
+  linkedPRNumber: number
+  branch: string
+}): boolean {
+  const { worktree, linkedPRNumber, branch } = args
+  return (
+    Boolean(worktree) &&
+    worktree?.linkedPR === linkedPRNumber &&
+    // Branch-scoped: only clear while the worktree is still on the branch the
+    // mismatch was computed against; a newer switch gets its own validation.
+    worktree.branch.replace(/^refs\/heads\//, '') === branch.replace(/^refs\/heads\//, '') &&
+    worktree.isBare !== true &&
+    worktree.isArchived !== true
+  )
+}
+
 function buildPRRefreshCandidate(
   state: AppState,
   worktree: Worktree,
@@ -3154,6 +3200,34 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               }
             )
           }
+          if (
+            options?.worktreeId &&
+            linkedPRNumber != null &&
+            shouldClearBranchMismatchedLinkedOpenPR({
+              pr,
+              linkedPRNumber,
+              branch,
+              requestHeadOid,
+              pushTargetBranch:
+                findWorktreeById(get(), options.worktreeId)?.pushTarget?.branchName ?? null
+            })
+          ) {
+            void get().updateWorktreeMeta(
+              options.worktreeId,
+              { linkedPR: null },
+              {
+                shouldApply: (worktree) =>
+                  shouldApplyBranchMismatchedLinkedPRClear({ worktree, linkedPRNumber, branch })
+              }
+            )
+            // Re-resolve by branch right away so visible Checks recover on this
+            // refresh instead of keeping the stale linked PR cached.
+            void get().fetchPRForBranch(repoPath, branch, {
+              force: true,
+              repoId,
+              worktreeId: options.worktreeId
+            })
+          }
         }
         if (
           shouldPreserveExistingPRForFallbackMiss({
@@ -3882,21 +3956,43 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       branch: string
       requestHeadOid: string | null
     }[] = []
+    const branchMismatchedLinkedPRClears: {
+      worktreeId: string
+      linkedPRNumber: number
+      branch: string
+    }[] = []
     if (event.outcome?.kind === 'found') {
       const pr = event.outcome.pr
       for (const alias of event.aliases) {
         const linkedPRNumber = alias.linkedPRNumber ?? null
         const requestHeadOid = alias.currentHeadOid ?? null
-        if (
-          alias.worktreeId &&
-          linkedPRNumber != null &&
-          shouldClearDivergedLinkedMergedPR({ pr, linkedPRNumber, requestHeadOid })
-        ) {
+        if (!alias.worktreeId || linkedPRNumber == null) {
+          continue
+        }
+        if (shouldClearDivergedLinkedMergedPR({ pr, linkedPRNumber, requestHeadOid })) {
           divergedLinkedPRClears.push({
             worktreeId: alias.worktreeId,
             linkedPRNumber,
             branch: alias.branch,
             requestHeadOid
+          })
+        } else if (
+          shouldClearBranchMismatchedLinkedOpenPR({
+            pr,
+            linkedPRNumber,
+            branch: alias.branch,
+            requestHeadOid,
+            pushTargetBranch:
+              findWorktreeById(get(), alias.worktreeId)?.pushTarget?.branchName ?? null
+          })
+        ) {
+          // Why: the background PR coordinator also refreshes with the durable
+          // link; without this clear a stale-linked worktree never re-resolves
+          // by branch on its own.
+          branchMismatchedLinkedPRClears.push({
+            worktreeId: alias.worktreeId,
+            linkedPRNumber,
+            branch: alias.branch
           })
         }
       }
@@ -4108,6 +4204,20 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               linkedPRNumber: clear.linkedPRNumber,
               branch: clear.branch,
               requestHeadOid: clear.requestHeadOid
+            })
+        }
+      )
+    }
+    for (const clear of branchMismatchedLinkedPRClears) {
+      void get().updateWorktreeMeta(
+        clear.worktreeId,
+        { linkedPR: null },
+        {
+          shouldApply: (worktree) =>
+            shouldApplyBranchMismatchedLinkedPRClear({
+              worktree,
+              linkedPRNumber: clear.linkedPRNumber,
+              branch: clear.branch
             })
         }
       )

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -42,6 +42,8 @@ export type WorktreeMetaUpdateGuard = (worktree: Worktree | DetectedWorktree | u
 
 export type WorktreeMetaUpdateOptions = {
   shouldApply?: WorktreeMetaUpdateGuard
+  /** Skip the automatic review refetch when the caller owns an equivalent refresh. */
+  suppressHostedReviewRefresh?: boolean
 }
 
 export type WorktreeRenameRequest = {

--- a/src/renderer/src/store/slices/worktree-listing-branch-switch.test.ts
+++ b/src/renderer/src/store/slices/worktree-listing-branch-switch.test.ts
@@ -27,14 +27,24 @@ function makeWorktree(overrides: Partial<Worktree> & { id: string }): Worktree {
 }
 
 const hasLinkedPR = (worktree: Worktree): boolean => worktree.linkedPR != null
+const matchesAnyHost = (): boolean => true
 
 describe('routeListingBranchSwitchesThroughGitIdentity', () => {
   it('routes a listing-observed branch switch through updateWorktreeGitIdentity', () => {
     const updateWorktreeGitIdentity = vi.fn()
+    const current = [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })]
 
     routeListingBranchSwitchesThroughGitIdentity({
-      current: [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })],
-      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-two', head: 'def456' }],
+      requestStarted: current,
+      current,
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/path/wt1',
+          branch: 'refs/heads/feature-two',
+          head: 'def456'
+        })
+      ],
+      matchesRefreshHost: matchesAnyHost,
       hasBranchScopedReviewContext: hasLinkedPR,
       updateWorktreeGitIdentity
     })
@@ -48,10 +58,19 @@ describe('routeListingBranchSwitchesThroughGitIdentity', () => {
 
   it('does nothing when the branch is unchanged', () => {
     const updateWorktreeGitIdentity = vi.fn()
+    const current = [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })]
 
     routeListingBranchSwitchesThroughGitIdentity({
-      current: [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })],
-      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-one', head: 'def456' }],
+      requestStarted: current,
+      current,
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/path/wt1',
+          branch: 'refs/heads/feature-one',
+          head: 'def456'
+        })
+      ],
+      matchesRefreshHost: matchesAnyHost,
       hasBranchScopedReviewContext: hasLinkedPR,
       updateWorktreeGitIdentity
     })
@@ -61,10 +80,19 @@ describe('routeListingBranchSwitchesThroughGitIdentity', () => {
 
   it('skips entries without branch-scoped review context (stale-refetch protection)', () => {
     const updateWorktreeGitIdentity = vi.fn()
+    const current = [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: null })]
 
     routeListingBranchSwitchesThroughGitIdentity({
-      current: [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: null })],
-      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-two', head: 'def456' }],
+      requestStarted: current,
+      current,
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/path/wt1',
+          branch: 'refs/heads/feature-two',
+          head: 'def456'
+        })
+      ],
+      matchesRefreshHost: matchesAnyHost,
       hasBranchScopedReviewContext: hasLinkedPR,
       updateWorktreeGitIdentity
     })
@@ -74,10 +102,19 @@ describe('routeListingBranchSwitchesThroughGitIdentity', () => {
 
   it('skips incoming worktrees with no current entry (cold hydration)', () => {
     const updateWorktreeGitIdentity = vi.fn()
+    const current = [makeWorktree({ id: 'repo1::/path/other', linkedPR: 101 })]
 
     routeListingBranchSwitchesThroughGitIdentity({
-      current: [makeWorktree({ id: 'repo1::/path/other', linkedPR: 101 })],
-      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-two', head: 'def456' }],
+      requestStarted: current,
+      current,
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/path/wt1',
+          branch: 'refs/heads/feature-two',
+          head: 'def456'
+        })
+      ],
+      matchesRefreshHost: matchesAnyHost,
       hasBranchScopedReviewContext: hasLinkedPR,
       updateWorktreeGitIdentity
     })
@@ -89,8 +126,16 @@ describe('routeListingBranchSwitchesThroughGitIdentity', () => {
     const updateWorktreeGitIdentity = vi.fn()
 
     routeListingBranchSwitchesThroughGitIdentity({
+      requestStarted: undefined,
       current: undefined,
-      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-two', head: 'def456' }],
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/path/wt1',
+          branch: 'refs/heads/feature-two',
+          head: 'def456'
+        })
+      ],
+      matchesRefreshHost: matchesAnyHost,
       hasBranchScopedReviewContext: hasLinkedPR,
       updateWorktreeGitIdentity
     })
@@ -100,10 +145,13 @@ describe('routeListingBranchSwitchesThroughGitIdentity', () => {
 
   it('maps an empty listing branch to the explicit detached-HEAD signal', () => {
     const updateWorktreeGitIdentity = vi.fn()
+    const current = [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })]
 
     routeListingBranchSwitchesThroughGitIdentity({
-      current: [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })],
-      incoming: [{ id: 'repo1::/path/wt1', branch: '', head: 'def456' }],
+      requestStarted: current,
+      current,
+      incoming: [makeWorktree({ id: 'repo1::/path/wt1', branch: '', head: 'def456' })],
+      matchesRefreshHost: matchesAnyHost,
       hasBranchScopedReviewContext: hasLinkedPR,
       updateWorktreeGitIdentity
     })
@@ -112,5 +160,115 @@ describe('routeListingBranchSwitchesThroughGitIdentity', () => {
       head: 'def456',
       branch: null
     })
+  })
+
+  it('rejects a listing response when the branch changed again after the request started', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+    const current = [
+      makeWorktree({
+        id: 'repo1::/path/wt1',
+        branch: 'refs/heads/feature-three',
+        head: 'newest-head',
+        linkedPR: 303
+      })
+    ]
+
+    const reconciled = routeListingBranchSwitchesThroughGitIdentity({
+      requestStarted: [
+        makeWorktree({
+          id: 'repo1::/path/wt1',
+          branch: 'refs/heads/feature-one',
+          linkedPR: 101
+        })
+      ],
+      current,
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/path/wt1',
+          branch: 'refs/heads/feature-two',
+          head: 'stale-head'
+        })
+      ],
+      matchesRefreshHost: matchesAnyHost,
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).not.toHaveBeenCalled()
+    expect(reconciled).toEqual(current)
+  })
+
+  it('preserves a manual relink made while the listing request was in flight', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+    const requestStarted = [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })]
+    const current = [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 303 })]
+
+    const reconciled = routeListingBranchSwitchesThroughGitIdentity({
+      requestStarted,
+      current,
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/path/wt1',
+          branch: 'refs/heads/feature-two',
+          head: 'stale-head',
+          linkedPR: 101
+        })
+      ],
+      matchesRefreshHost: matchesAnyHost,
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).not.toHaveBeenCalled()
+    expect(reconciled).toEqual(current)
+  })
+
+  it('fails closed when the same worktree id belongs to multiple execution hosts', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+    const requestStarted = [
+      makeWorktree({ id: 'repo1::/same/path', hostId: 'local', linkedPR: 101 }),
+      makeWorktree({ id: 'repo1::/same/path', hostId: 'ssh:ssh-1', linkedPR: 202 })
+    ]
+
+    routeListingBranchSwitchesThroughGitIdentity({
+      requestStarted,
+      current: requestStarted,
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/same/path',
+          branch: 'refs/heads/feature-two',
+          head: 'remote-head'
+        })
+      ],
+      matchesRefreshHost: matchesAnyHost,
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).not.toHaveBeenCalled()
+  })
+
+  it('does not route an old-host response through a row now owned by another host', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+
+    routeListingBranchSwitchesThroughGitIdentity({
+      requestStarted: [
+        makeWorktree({ id: 'repo1::/same/path', hostId: 'ssh:ssh-1', linkedPR: 101 })
+      ],
+      current: [makeWorktree({ id: 'repo1::/same/path', hostId: 'ssh:ssh-2', linkedPR: 202 })],
+      incoming: [
+        makeWorktree({
+          id: 'repo1::/same/path',
+          hostId: 'ssh:ssh-1',
+          branch: 'refs/heads/feature-two',
+          head: 'old-host-head'
+        })
+      ],
+      matchesRefreshHost: (worktree) => worktree.hostId === 'ssh:ssh-1',
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/store/slices/worktree-listing-branch-switch.test.ts
+++ b/src/renderer/src/store/slices/worktree-listing-branch-switch.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import { routeListingBranchSwitchesThroughGitIdentity } from './worktree-listing-branch-switch'
+
+function makeWorktree(overrides: Partial<Worktree> & { id: string }): Worktree {
+  return {
+    repoId: 'repo1',
+    path: '/path/wt',
+    head: 'abc123',
+    branch: 'refs/heads/feature-one',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'feature-one',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+const hasLinkedPR = (worktree: Worktree): boolean => worktree.linkedPR != null
+
+describe('routeListingBranchSwitchesThroughGitIdentity', () => {
+  it('routes a listing-observed branch switch through updateWorktreeGitIdentity', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+
+    routeListingBranchSwitchesThroughGitIdentity({
+      current: [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })],
+      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-two', head: 'def456' }],
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).toHaveBeenCalledTimes(1)
+    expect(updateWorktreeGitIdentity).toHaveBeenCalledWith('repo1::/path/wt1', {
+      head: 'def456',
+      branch: 'refs/heads/feature-two'
+    })
+  })
+
+  it('does nothing when the branch is unchanged', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+
+    routeListingBranchSwitchesThroughGitIdentity({
+      current: [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })],
+      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-one', head: 'def456' }],
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).not.toHaveBeenCalled()
+  })
+
+  it('skips entries without branch-scoped review context (stale-refetch protection)', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+
+    routeListingBranchSwitchesThroughGitIdentity({
+      current: [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: null })],
+      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-two', head: 'def456' }],
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).not.toHaveBeenCalled()
+  })
+
+  it('skips incoming worktrees with no current entry (cold hydration)', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+
+    routeListingBranchSwitchesThroughGitIdentity({
+      current: [makeWorktree({ id: 'repo1::/path/other', linkedPR: 101 })],
+      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-two', head: 'def456' }],
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when there is no current list', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+
+    routeListingBranchSwitchesThroughGitIdentity({
+      current: undefined,
+      incoming: [{ id: 'repo1::/path/wt1', branch: 'refs/heads/feature-two', head: 'def456' }],
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).not.toHaveBeenCalled()
+  })
+
+  it('maps an empty listing branch to the explicit detached-HEAD signal', () => {
+    const updateWorktreeGitIdentity = vi.fn()
+
+    routeListingBranchSwitchesThroughGitIdentity({
+      current: [makeWorktree({ id: 'repo1::/path/wt1', linkedPR: 101 })],
+      incoming: [{ id: 'repo1::/path/wt1', branch: '', head: 'def456' }],
+      hasBranchScopedReviewContext: hasLinkedPR,
+      updateWorktreeGitIdentity
+    })
+
+    expect(updateWorktreeGitIdentity).toHaveBeenCalledWith('repo1::/path/wt1', {
+      head: 'def456',
+      branch: null
+    })
+  })
+})

--- a/src/renderer/src/store/slices/worktree-listing-branch-switch.ts
+++ b/src/renderer/src/store/slices/worktree-listing-branch-switch.ts
@@ -1,0 +1,50 @@
+import type { Worktree } from '../../../../shared/types'
+
+/**
+ * Route branch switches observed by a worktree-listing refresh through
+ * `updateWorktreeGitIdentity` before the listing is merged into the store.
+ *
+ * Why: a terminal branch switch is observed by two independent refresh paths —
+ * the git-status identity path (which clears branch-scoped review links) and
+ * the worktree-listing path (which rehydrates persisted metadata, including a
+ * now-stale linked PR, alongside the new branch). If the listing merge lands
+ * first, the identity path sees no branch change and never clears, leaving
+ * Checks pinned to the previous branch's PR. Applying the identity update
+ * first makes the link clear happen no matter which path wins the race.
+ *
+ * Only entries that still carry branch-scoped review context are routed: when
+ * there is nothing to clear the plain merge already applies the new branch,
+ * and skipping the rest preserves the stale-refetch protection where an old
+ * listing row must not roll back a newer branch identity.
+ */
+export function routeListingBranchSwitchesThroughGitIdentity(args: {
+  current: readonly Worktree[] | undefined
+  incoming: readonly Pick<Worktree, 'id' | 'branch' | 'head'>[]
+  hasBranchScopedReviewContext: (worktree: Worktree) => boolean
+  updateWorktreeGitIdentity: (
+    worktreeId: string,
+    identity: { head?: string; branch?: string | null }
+  ) => void
+}): void {
+  const { current, incoming, hasBranchScopedReviewContext, updateWorktreeGitIdentity } = args
+  if (!current?.length) {
+    return
+  }
+  const currentById = new Map(current.map((worktree) => [worktree.id, worktree]))
+  for (const worktree of incoming) {
+    const existing = currentById.get(worktree.id)
+    if (
+      !existing ||
+      existing.branch === worktree.branch ||
+      !hasBranchScopedReviewContext(existing)
+    ) {
+      continue
+    }
+    updateWorktreeGitIdentity(worktree.id, {
+      head: worktree.head,
+      // Empty branch means detached HEAD in listing results; null is the
+      // explicit detached signal expected by updateWorktreeGitIdentity.
+      branch: worktree.branch === '' ? null : worktree.branch
+    })
+  }
+}

--- a/src/renderer/src/store/slices/worktree-listing-branch-switch.ts
+++ b/src/renderer/src/store/slices/worktree-listing-branch-switch.ts
@@ -1,5 +1,31 @@
 import type { Worktree } from '../../../../shared/types'
 
+function indexUnambiguousWorktrees(
+  worktrees: readonly Worktree[],
+  include?: (worktree: Worktree) => boolean
+): Map<string, Worktree | null> {
+  const byId = new Map<string, Worktree | null>()
+  for (const worktree of worktrees) {
+    if (include && !include(worktree)) {
+      continue
+    }
+    byId.set(worktree.id, byId.has(worktree.id) ? null : worktree)
+  }
+  return byId
+}
+
+function branchScopedReviewContextMatches(left: Worktree, right: Worktree): boolean {
+  return (
+    left.linkedPR === right.linkedPR &&
+    left.linkedGitLabMR === right.linkedGitLabMR &&
+    left.linkedBitbucketPR === right.linkedBitbucketPR &&
+    left.linkedAzureDevOpsPR === right.linkedAzureDevOpsPR &&
+    left.linkedGiteaPR === right.linkedGiteaPR &&
+    left.pushTarget?.remoteName === right.pushTarget?.remoteName &&
+    left.pushTarget?.branchName === right.pushTarget?.branchName
+  )
+}
+
 /**
  * Route branch switches observed by a worktree-listing refresh through
  * `updateWorktreeGitIdentity` before the listing is merged into the store.
@@ -18,22 +44,52 @@ import type { Worktree } from '../../../../shared/types'
  * listing row must not roll back a newer branch identity.
  */
 export function routeListingBranchSwitchesThroughGitIdentity(args: {
+  requestStarted: readonly Worktree[] | undefined
   current: readonly Worktree[] | undefined
-  incoming: readonly Pick<Worktree, 'id' | 'branch' | 'head'>[]
+  incoming: Worktree[]
+  matchesRefreshHost: (worktree: Worktree) => boolean
   hasBranchScopedReviewContext: (worktree: Worktree) => boolean
   updateWorktreeGitIdentity: (
     worktreeId: string,
     identity: { head?: string; branch?: string | null }
   ) => void
-}): void {
-  const { current, incoming, hasBranchScopedReviewContext, updateWorktreeGitIdentity } = args
-  if (!current?.length) {
-    return
+}): Worktree[] {
+  const {
+    requestStarted,
+    current,
+    incoming,
+    matchesRefreshHost,
+    hasBranchScopedReviewContext,
+    updateWorktreeGitIdentity
+  } = args
+  if (!requestStarted?.length || !current?.length) {
+    return incoming
   }
-  const currentById = new Map(current.map((worktree) => [worktree.id, worktree]))
-  for (const worktree of incoming) {
-    const existing = currentById.get(worktree.id)
+
+  const allLatestById = indexUnambiguousWorktrees(current)
+  const startedById = indexUnambiguousWorktrees(requestStarted, matchesRefreshHost)
+  const latestById = indexUnambiguousWorktrees(current, matchesRefreshHost)
+  let reconciled: Worktree[] | null = null
+  for (const [index, worktree] of incoming.entries()) {
+    const requestStartedWorktree = startedById.get(worktree.id)
+    const existing = latestById.get(worktree.id)
+    const isAmbiguousAcrossHosts = allLatestById.get(worktree.id) === null
     if (
+      requestStartedWorktree &&
+      existing &&
+      (existing.branch !== requestStartedWorktree.branch ||
+        existing.head !== requestStartedWorktree.head ||
+        !branchScopedReviewContextMatches(existing, requestStartedWorktree))
+    ) {
+      // Why: rejecting the clear alone is insufficient; preserve the newer row
+      // so the subsequent listing merge cannot roll its branch and metadata back.
+      reconciled ??= [...incoming]
+      reconciled[index] = existing
+      continue
+    }
+    if (
+      isAmbiguousAcrossHosts ||
+      !requestStartedWorktree ||
       !existing ||
       existing.branch === worktree.branch ||
       !hasBranchScopedReviewContext(existing)
@@ -47,4 +103,5 @@ export function routeListingBranchSwitchesThroughGitIdentity(args: {
       branch: worktree.branch === '' ? null : worktree.branch
     })
   }
+  return reconciled ?? incoming
 }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -4474,6 +4474,40 @@ describe('worktree remote runtime mutations', () => {
     expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toBeUndefined()
   })
 
+  it('skips duplicate hosted-review work when the unlinking caller owns the refresh', async () => {
+    const store = createTestStore()
+    const fetchHostedReviewForBranch = vi.fn().mockResolvedValue(null)
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      branch: 'refs/heads/review-branch',
+      linkedPR: 2548,
+      pushTarget: { remoteName: 'fork', branchName: 'owner/old-pr' }
+    })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] },
+      fetchHostedReviewForBranch
+    } as Partial<AppState>)
+
+    await store
+      .getState()
+      .updateWorktreeMeta(wt.id, { linkedPR: null }, { suppressHostedReviewRefresh: true })
+
+    expect(fetchHostedReviewForBranch).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { linkedPR: null, pushTarget: undefined }
+    })
+    expect(store.getState().worktreesByRepo.repo1[0]).toMatchObject({
+      linkedPR: null,
+      pushTarget: undefined
+    })
+  })
+
   it('clears an older GitHub link and target when replacing it with a GitLab MR', async () => {
     const store = createTestStore()
     const oldPushTarget = { remoteName: 'fork', branchName: 'owner/old-pr' }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -450,6 +450,47 @@ describe('fetchWorktrees', () => {
     })
   })
 
+  it('does not merge a stale listing row over a newer branch and review link', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/path/wt1'
+    const requestStarted = makeWorktree({
+      id: worktreeId,
+      repoId: 'repo1',
+      path: '/path/wt1',
+      branch: 'refs/heads/feature-one',
+      head: 'first-head',
+      linkedPR: 101
+    })
+    const staleResponse = makeWorktree({
+      ...requestStarted,
+      branch: 'refs/heads/feature-two',
+      head: 'stale-head',
+      linkedPR: 202
+    })
+    let resolveListing!: (worktrees: Worktree[]) => void
+    const listing = new Promise<Worktree[]>((resolve) => {
+      resolveListing = resolve
+    })
+    worktreeListMock.mockReturnValueOnce(listing)
+    store.setState({ worktreesByRepo: { repo1: [requestStarted] } } as Partial<AppState>)
+
+    const refresh = store.getState().fetchWorktrees('repo1')
+    await vi.waitFor(() => expect(worktreeListMock).toHaveBeenCalledTimes(1))
+    const latest = makeWorktree({
+      ...requestStarted,
+      branch: 'refs/heads/feature-three',
+      head: 'latest-head',
+      linkedPR: 303
+    })
+    store.setState({ worktreesByRepo: { repo1: [latest] } } as Partial<AppState>)
+    resolveListing([staleResponse])
+
+    await refresh
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([latest])
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+  })
+
   it('updates the repo entry when only the persisted base ref changes', async () => {
     const store = createTestStore()
     const existing = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -409,6 +409,47 @@ describe('fetchWorktrees', () => {
     expect(store.getState().sortEpoch).toBe(8)
   })
 
+  it('clears branch-scoped linked reviews when the listing observes a branch switch', async () => {
+    const store = createTestStore()
+    const existing = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      branch: 'refs/heads/feature-one',
+      linkedPR: 101,
+      pushTarget: { remoteName: 'origin', branchName: 'feature-one' }
+    })
+    // Persisted metadata still carries the stale link when the listing refresh
+    // is the first path to observe the terminal branch switch.
+    const refreshed = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      branch: 'refs/heads/feature-two',
+      head: 'def456',
+      linkedPR: 101,
+      pushTarget: { remoteName: 'origin', branchName: 'feature-one' }
+    })
+
+    mockApi.worktrees.list.mockResolvedValue([refreshed])
+    store.setState({ worktreesByRepo: { repo1: [existing] } } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(store.getState().worktreesByRepo.repo1[0]).toMatchObject({
+      branch: 'refs/heads/feature-two',
+      head: 'def456',
+      linkedPR: null,
+      pushTarget: undefined
+    })
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: 'repo1::/path/wt1',
+      updates: expect.objectContaining({ linkedPR: null, pushTarget: undefined })
+    })
+  })
+
   it('updates the repo entry when only the persisted base ref changes', async () => {
     const store = createTestStore()
     const existing = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -3967,7 +3967,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
     try {
       await persistWorktreeMeta(settingsForWorktreeOwner(get(), worktreeId), worktreeId, enriched)
-      if (reviewRepo && reviewBranch && typeof get().fetchHostedReviewForBranch === 'function') {
+      if (
+        !options?.suppressHostedReviewRefresh &&
+        reviewRepo &&
+        reviewBranch &&
+        typeof get().fetchHostedReviewForBranch === 'function'
+      ) {
         // Why: the old cache entry may have been populated by the previous
         // provider link. Refetch against the post-update links so stale lookups
         // cannot keep showing the removed review.

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2327,6 +2327,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   fetchWorktrees: async (repoId, options) => {
     try {
       const ownerState = get()
+      const requestStartedWorktrees = ownerState.worktreesByRepo[repoId]
       const hostId = repoHostId(ownerState, repoId)
       const ownerWasMissingAtStart = !ownerState.repos.some((repo) => repo.id === repoId)
       const setup = getProjectHostSetupForRepoHost(ownerState, repoId, hostId)
@@ -2338,13 +2339,19 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       if (options?.requireAuthoritative && !detected.authoritative) {
         return false
       }
-      const incoming = toVisibleWorktrees(detected, hostId, setup)
-      routeListingBranchSwitchesThroughGitIdentity({
-        current: get().worktreesByRepo[repoId],
-        incoming,
-        hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
-        updateWorktreeGitIdentity: get().updateWorktreeGitIdentity
-      })
+      let incoming = toVisibleWorktrees(detected, hostId, setup)
+      const latestState = get()
+      if (repoHasExecutionHost(latestState, repoId, hostId, ownerWasMissingAtStart)) {
+        const matchOptions = worktreeHostMatchOptions(latestState, repoId, hostId)
+        incoming = routeListingBranchSwitchesThroughGitIdentity({
+          requestStarted: requestStartedWorktrees,
+          current: latestState.worktreesByRepo[repoId],
+          incoming,
+          matchesRefreshHost: (worktree) => worktreeMatchesHost(worktree, hostId, matchOptions),
+          hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
+          updateWorktreeGitIdentity: latestState.updateWorktreeGitIdentity
+        })
+      }
       const current = get().worktreesByRepo[repoId]
       const worktrees = sanitizeHostedReviewLinksForBranchClears(incoming, current)
       const currentMatchOptions = worktreeHostMatchOptions(get(), repoId, hostId)
@@ -2482,20 +2489,28 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     if (get().hasHydratedWorktreePurge) {
       await mapReposForWorktreeRefresh(repos, async (r) => {
         try {
+          const requestStartedState = get()
+          const requestStartedWorktrees = requestStartedState.worktreesByRepo[r.id]
           const hostId = getRepoExecutionHostId(r)
-          const setup = getProjectHostSetupForRepoHost(get(), r.id, hostId)
-          const settings = settingsForKnownRepoOwner(get().settings, r)
+          const setup = getProjectHostSetupForRepoHost(requestStartedState, r.id, hostId)
+          const settings = settingsForKnownRepoOwner(requestStartedState.settings, r)
           const detected = await listDetectedWorktreesForRepoCoalesced(settings, r.id, {
             executionHostId: hostId,
             reuseRecentCompatibilityFailure: true
           })
-          const incoming = toVisibleWorktrees(detected, hostId, setup)
-          routeListingBranchSwitchesThroughGitIdentity({
-            current: get().worktreesByRepo[r.id],
-            incoming,
-            hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
-            updateWorktreeGitIdentity: get().updateWorktreeGitIdentity
-          })
+          let incoming = toVisibleWorktrees(detected, hostId, setup)
+          const latestState = get()
+          if (repoHasExecutionHost(latestState, r.id, hostId, false)) {
+            const matchOptions = worktreeHostMatchOptions(latestState, r.id, hostId)
+            incoming = routeListingBranchSwitchesThroughGitIdentity({
+              requestStarted: requestStartedWorktrees,
+              current: latestState.worktreesByRepo[r.id],
+              incoming,
+              matchesRefreshHost: (worktree) => worktreeMatchesHost(worktree, hostId, matchOptions),
+              hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
+              updateWorktreeGitIdentity: latestState.updateWorktreeGitIdentity
+            })
+          }
           const worktrees = sanitizeHostedReviewLinksForBranchClears(
             incoming,
             get().worktreesByRepo[r.id]
@@ -2568,20 +2583,28 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         | { repoId: string; ok: false }
       > => {
         try {
+          const requestStartedState = get()
+          const requestStartedWorktrees = requestStartedState.worktreesByRepo[r.id]
           const hostId = getRepoExecutionHostId(r)
-          const setup = getProjectHostSetupForRepoHost(get(), r.id, hostId)
+          const setup = getProjectHostSetupForRepoHost(requestStartedState, r.id, hostId)
           const detected = await listDetectedWorktreesForRepoCoalesced(
-            settingsForKnownRepoOwner(get().settings, r),
+            settingsForKnownRepoOwner(requestStartedState.settings, r),
             r.id,
             { executionHostId: hostId, reuseRecentCompatibilityFailure: true }
           )
-          const incoming = toVisibleWorktrees(detected, hostId, setup)
-          routeListingBranchSwitchesThroughGitIdentity({
-            current: get().worktreesByRepo[r.id],
-            incoming,
-            hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
-            updateWorktreeGitIdentity: get().updateWorktreeGitIdentity
-          })
+          let incoming = toVisibleWorktrees(detected, hostId, setup)
+          const latestState = get()
+          if (repoHasExecutionHost(latestState, r.id, hostId, false)) {
+            const matchOptions = worktreeHostMatchOptions(latestState, r.id, hostId)
+            incoming = routeListingBranchSwitchesThroughGitIdentity({
+              requestStarted: requestStartedWorktrees,
+              current: latestState.worktreesByRepo[r.id],
+              incoming,
+              matchesRefreshHost: (worktree) => worktreeMatchesHost(worktree, hostId, matchOptions),
+              hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
+              updateWorktreeGitIdentity: latestState.updateWorktreeGitIdentity
+            })
+          }
           const current = get().worktreesByRepo[r.id]
           const list = sanitizeHostedReviewLinksForBranchClears(incoming, current)
           const currentMatchOptions = worktreeHostMatchOptions(get(), r.id, hostId)

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -38,6 +38,7 @@ import {
 } from '../../runtime/runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
 import { getHostedReviewCacheKey, refreshHostedReviewCard } from './hosted-review'
+import { routeListingBranchSwitchesThroughGitIdentity } from './worktree-listing-branch-switch'
 import { isPositiveHostedReviewNumber } from '../../../../shared/hosted-review'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from './github-cache-key'
 import { moveFocusToRendererBeforeFocusedWebviewHidden } from './browser-webview-cleanup'
@@ -2337,11 +2338,15 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       if (options?.requireAuthoritative && !detected.authoritative) {
         return false
       }
+      const incoming = toVisibleWorktrees(detected, hostId, setup)
+      routeListingBranchSwitchesThroughGitIdentity({
+        current: get().worktreesByRepo[repoId],
+        incoming,
+        hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
+        updateWorktreeGitIdentity: get().updateWorktreeGitIdentity
+      })
       const current = get().worktreesByRepo[repoId]
-      const worktrees = sanitizeHostedReviewLinksForBranchClears(
-        toVisibleWorktrees(detected, hostId, setup),
-        current
-      )
+      const worktrees = sanitizeHostedReviewLinksForBranchClears(incoming, current)
       const currentMatchOptions = worktreeHostMatchOptions(get(), repoId, hostId)
       const currentForHost = (current ?? []).filter((worktree) =>
         worktreeMatchesHost(worktree, hostId, currentMatchOptions)
@@ -2484,8 +2489,15 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             executionHostId: hostId,
             reuseRecentCompatibilityFailure: true
           })
+          const incoming = toVisibleWorktrees(detected, hostId, setup)
+          routeListingBranchSwitchesThroughGitIdentity({
+            current: get().worktreesByRepo[r.id],
+            incoming,
+            hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
+            updateWorktreeGitIdentity: get().updateWorktreeGitIdentity
+          })
           const worktrees = sanitizeHostedReviewLinksForBranchClears(
-            toVisibleWorktrees(detected, hostId, setup),
+            incoming,
             get().worktreesByRepo[r.id]
           )
           set((s) => {
@@ -2563,11 +2575,15 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             r.id,
             { executionHostId: hostId, reuseRecentCompatibilityFailure: true }
           )
+          const incoming = toVisibleWorktrees(detected, hostId, setup)
+          routeListingBranchSwitchesThroughGitIdentity({
+            current: get().worktreesByRepo[r.id],
+            incoming,
+            hasBranchScopedReviewContext: hasBranchScopedHostedReviewContext,
+            updateWorktreeGitIdentity: get().updateWorktreeGitIdentity
+          })
           const current = get().worktreesByRepo[r.id]
-          const list = sanitizeHostedReviewLinksForBranchClears(
-            toVisibleWorktrees(detected, hostId, setup),
-            current
-          )
+          const list = sanitizeHostedReviewLinksForBranchClears(incoming, current)
           const currentMatchOptions = worktreeHostMatchOptions(get(), r.id, hostId)
           const currentForHost = (current ?? []).filter((worktree) =>
             worktreeMatchesHost(worktree, hostId, currentMatchOptions)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1166,6 +1166,9 @@ export type PRInfo = {
   headDivergedFromMergedPRAtOid?: string
   /** Target branch name for PR-created worktree compare-base repair. */
   baseRefName?: string
+  /** PR head branch name. Lets linked-PR consumers detect that the worktree
+   *  has switched to a different branch and the durable link is stale. */
+  headRefName?: string
   prRepo?: GitHubRepositoryIdentity
   headRepo?: GitHubRepositoryIdentity
   conflictSummary?: PRConflictSummary


### PR DESCRIPTION
## Problem

When an agent (or any terminal command) switches branches inside a workspace, the PR checks panel keeps showing the previous branch's PR, and the panel's Refresh button does not recover. Reproduced live against demo-project PRs #19/#20.

## Root cause

A workspace's `linkedPR` is a branch-scoped hint (persisted when a PR URL appears in terminal output, e.g. after `gh pr create`), but the lookup that consumes it is exact-by-number and ignores the branch. Two refresh paths race when a terminal switches branches:

- the **git-status identity path** (`updateWorktreeGitIdentity`) clears branch-scoped review links and tombstones the clear, and
- the **worktree-listing path** (`fetchWorktrees` / `fetchAllWorktrees`) rehydrates the new branch together with the stale persisted link, clearing nothing.

If the listing merge applies first, the identity path early-returns (branch already matches) and the clear never runs. `git worktree list` is much faster than `git status`, so on real repos the listing almost always wins — the wedge is effectively deterministic. From then on every refresh (including the Refresh button) re-fetches the linked old PR by number and caches it under the *new* branch's cache key, permanently.

## Fix

**Prevention** — new `worktree-listing-branch-switch.ts`: listing refreshes route observed branch switches through `updateWorktreeGitIdentity` before merging, so the existing clear/tombstone machinery runs regardless of which path wins the race. Gated on the entry still carrying branch-scoped review context, so a stale listing row cannot roll back a newer branch identity (covered by the existing stale-refetch protection tests). Wired into all three listing-hydration sites; clears all provider links (GitHub/GitLab/Bitbucket/Azure DevOps/Gitea) via the shared machinery.

**Recovery** — heals wedges persisted by earlier builds: `PRInfo` now carries `headRefName`, and a fetch that returns the linked **open** PR whose head branch matches neither the current branch, nor the workspace push target, nor the worktree HEAD commit clears the durable link and immediately re-resolves by branch. Wired into `fetchPRForBranch` and the background refresh coordinator, mirroring the existing merged-PR divergence clear. The push-target and HEAD guards keep legitimate links for fork PRs and PR checkouts under renamed local branches.

## Verification

- Live in the dev app: forced the previously-losing ordering (listing applies the branch first) → link now clears and the panel flips to the new branch's PR; manufactured a persisted wedge (workspace on one branch, linked to the other branch's PR) → a single Refresh click unlinks and re-resolves correctly.
- Unit: new pure-helper tests, a `fetchWorktrees` regression test (stale link cleared when the listing observes the switch), and predicate tests for the mismatch clear. Full store-slice suite passes (1,721 tests), plus typecheck, oxlint, and the max-lines ratchet.