### PR TITLE
fix(recipes): let Codex model args override defaults

### DIFF
--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -216,20 +216,68 @@ describe('planCommitMessageGeneration', () => {
   })
 
   it.each([
-    ['long option', '--model gpt-5.6-luna', ['--model', 'gpt-5.6-luna']],
-    ['short option', '-m gpt-5.6-luna', ['-m', 'gpt-5.6-luna']],
-    ['equals form', '--model=gpt-5.6-luna', ['--model=gpt-5.6-luna']]
-  ])('lets Codex recipe args override the generated model via %s', (_, agentArgs, overrideArgs) => {
+    ['long option', '--model gpt-5.6-luna', ['--model', 'gpt-5.6-luna'], []],
+    ['short option', '-m gpt-5.6-luna', ['-m', 'gpt-5.6-luna'], []],
+    ['equals form', '--model=gpt-5.6-luna', ['--model=gpt-5.6-luna'], []],
+    ['attached short form', '-mgpt-5.6-luna', ['-mgpt-5.6-luna'], []],
+    [
+      'sibling arguments',
+      '--model gpt-5.6-luna --sandbox read-only',
+      ['--model', 'gpt-5.6-luna'],
+      ['--sandbox', 'read-only']
+    ]
+  ])(
+    'lets Codex recipe args override the generated model via %s',
+    (_, agentArgs, overrideArgs, trailingArgs) => {
+      const result = planCommitMessageGeneration(
+        { agentId: 'codex', model: 'gpt-5.4-mini', thinkingLevel: 'medium', agentArgs },
+        'PROMPT'
+      )
+
+      expect(result).toMatchObject({
+        ok: true,
+        plan: {
+          args: [
+            'exec',
+            '--ephemeral',
+            '--skip-git-repo-check',
+            '-s',
+            'read-only',
+            ...overrideArgs,
+            '-c',
+            'model_reasoning_effort=medium',
+            ...trailingArgs
+          ],
+          stdinPayload: 'PROMPT'
+        }
+      })
+    }
+  )
+
+  it('keeps Codex recipe arguments unchanged when they do not override the model', () => {
     const result = planCommitMessageGeneration(
-      { agentId: 'codex', model: 'gpt-5.4-mini', agentArgs },
+      {
+        agentId: 'codex',
+        model: 'gpt-5.4-mini',
+        agentArgs: '--sandbox workspace-write'
+      },
       'PROMPT'
     )
 
     expect(result).toMatchObject({
       ok: true,
       plan: {
-        args: ['exec', '--ephemeral', '--skip-git-repo-check', '-s', 'read-only', ...overrideArgs],
-        stdinPayload: 'PROMPT'
+        args: [
+          'exec',
+          '--ephemeral',
+          '--skip-git-repo-check',
+          '-s',
+          'read-only',
+          '--model',
+          'gpt-5.4-mini',
+          '--sandbox',
+          'workspace-write'
+        ]
       }
     })
   })
@@ -247,7 +295,18 @@ describe('planCommitMessageGeneration', () => {
     expect(result).toMatchObject({
       ok: true,
       plan: {
-        args: expect.arrayContaining(['--model', 'gpt-5.4-mini', '--', '--model', 'literal'])
+        args: [
+          'exec',
+          '--ephemeral',
+          '--skip-git-repo-check',
+          '-s',
+          'read-only',
+          '--model',
+          'gpt-5.4-mini',
+          '--',
+          '--model',
+          'literal'
+        ]
       }
     })
   })

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -215,12 +215,31 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
-  it('appends per-action CLI arguments after the built-in model args for stdin agents', () => {
+  it.each([
+    ['long option', '--model gpt-5.6-luna', ['--model', 'gpt-5.6-luna']],
+    ['short option', '-m gpt-5.6-luna', ['-m', 'gpt-5.6-luna']],
+    ['equals form', '--model=gpt-5.6-luna', ['--model=gpt-5.6-luna']]
+  ])('lets Codex recipe args override the generated model via %s', (_, agentArgs, overrideArgs) => {
+    const result = planCommitMessageGeneration(
+      { agentId: 'codex', model: 'gpt-5.4-mini', agentArgs },
+      'PROMPT'
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        args: ['exec', '--ephemeral', '--skip-git-repo-check', '-s', 'read-only', ...overrideArgs],
+        stdinPayload: 'PROMPT'
+      }
+    })
+  })
+
+  it('keeps the generated Codex model when model-like text follows an option terminator', () => {
     const result = planCommitMessageGeneration(
       {
         agentId: 'codex',
         model: 'gpt-5.4-mini',
-        agentArgs: '--model gpt-5.5 --sandbox read-only'
+        agentArgs: '-- --model literal'
       },
       'PROMPT'
     )
@@ -228,20 +247,7 @@ describe('planCommitMessageGeneration', () => {
     expect(result).toMatchObject({
       ok: true,
       plan: {
-        args: [
-          'exec',
-          '--ephemeral',
-          '--skip-git-repo-check',
-          '-s',
-          'read-only',
-          '--model',
-          'gpt-5.4-mini',
-          '--model',
-          'gpt-5.5',
-          '--sandbox',
-          'read-only'
-        ],
-        stdinPayload: 'PROMPT'
+        args: expect.arrayContaining(['--model', 'gpt-5.4-mini', '--', '--model', 'literal'])
       }
     })
   })

--- a/src/shared/commit-message-plan.ts
+++ b/src/shared/commit-message-plan.ts
@@ -68,6 +68,44 @@ function planAdditionalAgentArgs(
   return { ok: true, args: tokenized.tokens }
 }
 
+const CODEX_MODEL_OPTION_ALIASES = ['--model', '-m'] as const
+
+function matchesOption(token: string, aliases: readonly string[]): boolean {
+  return aliases.some((alias) => token === alias || token.startsWith(`${alias}=`))
+}
+
+function omitGeneratedOptionWhenRecipeOverrides(args: {
+  generatedArgs: string[]
+  recipeArgs: string[]
+  aliases: readonly string[]
+}): string[] {
+  let recipeSuppliesOption = false
+  for (const token of args.recipeArgs) {
+    if (token === '--') {
+      break
+    }
+    if (matchesOption(token, args.aliases)) {
+      recipeSuppliesOption = true
+      break
+    }
+  }
+  if (!recipeSuppliesOption) {
+    return args.generatedArgs
+  }
+
+  const optionIndex = args.generatedArgs.findIndex((token) => matchesOption(token, args.aliases))
+  if (optionIndex === -1) {
+    return args.generatedArgs
+  }
+
+  const optionUsesEquals = args.generatedArgs[optionIndex]?.includes('=') ?? false
+  const deleteCount = optionUsesEquals ? 1 : 2
+  return [
+    ...args.generatedArgs.slice(0, optionIndex),
+    ...args.generatedArgs.slice(optionIndex + deleteCount)
+  ]
+}
+
 function insertAdditionalAgentArgs(args: {
   baseArgs: string[]
   agentArgs: string[]
@@ -164,8 +202,18 @@ export function planCommitMessageGeneration(
   if (!agentArgs.ok) {
     return agentArgs
   }
+  // Why: Codex rejects repeated singleton model flags. Recipe CLI arguments
+  // are the more specific setting, so they replace Orca's generated model.
+  const generatedArgs =
+    input.agentId === 'codex'
+      ? omitGeneratedOptionWhenRecipeOverrides({
+          generatedArgs: baseArgs,
+          recipeArgs: agentArgs.args,
+          aliases: CODEX_MODEL_OPTION_ALIASES
+        })
+      : baseArgs
   const args = insertAdditionalAgentArgs({
-    baseArgs,
+    baseArgs: generatedArgs,
     agentArgs: agentArgs.args,
     promptDelivery: spec.promptDelivery,
     prompt: argvPrompt

--- a/src/shared/commit-message-plan.ts
+++ b/src/shared/commit-message-plan.ts
@@ -71,39 +71,64 @@ function planAdditionalAgentArgs(
 const CODEX_MODEL_OPTION_ALIASES = ['--model', '-m'] as const
 
 function matchesOption(token: string, aliases: readonly string[]): boolean {
-  return aliases.some((alias) => token === alias || token.startsWith(`${alias}=`))
+  return aliases.some(
+    (alias) =>
+      token === alias ||
+      token.startsWith(`${alias}=`) ||
+      (alias.startsWith('-') &&
+        !alias.startsWith('--') &&
+        token.startsWith(alias) &&
+        token.length > alias.length)
+  )
 }
 
-function omitGeneratedOptionWhenRecipeOverrides(args: {
+function findOptionOccurrence(
+  tokens: string[],
+  aliases: readonly string[],
+  stopAtTerminator: boolean
+): { index: number; consumed: number } | null {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    if (stopAtTerminator && token === '--') {
+      break
+    }
+    if (!matchesOption(token, aliases)) {
+      continue
+    }
+    const nextToken = tokens[index + 1]
+    const consumesNext =
+      aliases.includes(token) && nextToken !== undefined && !nextToken.startsWith('-')
+    return { index, consumed: consumesNext ? 2 : 1 }
+  }
+  return null
+}
+
+function applyRecipeOptionOverride(args: {
   generatedArgs: string[]
   recipeArgs: string[]
   aliases: readonly string[]
-}): string[] {
-  let recipeSuppliesOption = false
-  for (const token of args.recipeArgs) {
-    if (token === '--') {
-      break
-    }
-    if (matchesOption(token, args.aliases)) {
-      recipeSuppliesOption = true
-      break
-    }
-  }
-  if (!recipeSuppliesOption) {
-    return args.generatedArgs
+}): { generatedArgs: string[]; recipeArgs: string[] } {
+  const recipeOption = findOptionOccurrence(args.recipeArgs, args.aliases, true)
+  const generatedOption = findOptionOccurrence(args.generatedArgs, args.aliases, false)
+  if (!recipeOption || !generatedOption) {
+    return { generatedArgs: args.generatedArgs, recipeArgs: args.recipeArgs }
   }
 
-  const optionIndex = args.generatedArgs.findIndex((token) => matchesOption(token, args.aliases))
-  if (optionIndex === -1) {
-    return args.generatedArgs
+  const overrideTokens = args.recipeArgs.slice(
+    recipeOption.index,
+    recipeOption.index + recipeOption.consumed
+  )
+  return {
+    generatedArgs: [
+      ...args.generatedArgs.slice(0, generatedOption.index),
+      ...overrideTokens,
+      ...args.generatedArgs.slice(generatedOption.index + generatedOption.consumed)
+    ],
+    recipeArgs: [
+      ...args.recipeArgs.slice(0, recipeOption.index),
+      ...args.recipeArgs.slice(recipeOption.index + recipeOption.consumed)
+    ]
   }
-
-  const optionUsesEquals = args.generatedArgs[optionIndex]?.includes('=') ?? false
-  const deleteCount = optionUsesEquals ? 1 : 2
-  return [
-    ...args.generatedArgs.slice(0, optionIndex),
-    ...args.generatedArgs.slice(optionIndex + deleteCount)
-  ]
 }
 
 function insertAdditionalAgentArgs(args: {
@@ -204,17 +229,17 @@ export function planCommitMessageGeneration(
   }
   // Why: Codex rejects repeated singleton model flags. Recipe CLI arguments
   // are the more specific setting, so they replace Orca's generated model.
-  const generatedArgs =
+  const overriddenArgs =
     input.agentId === 'codex'
-      ? omitGeneratedOptionWhenRecipeOverrides({
+      ? applyRecipeOptionOverride({
           generatedArgs: baseArgs,
           recipeArgs: agentArgs.args,
           aliases: CODEX_MODEL_OPTION_ALIASES
         })
-      : baseArgs
+      : { generatedArgs: baseArgs, recipeArgs: agentArgs.args }
   const args = insertAdditionalAgentArgs({
-    baseArgs: generatedArgs,
-    agentArgs: agentArgs.args,
+    baseArgs: overriddenArgs.generatedArgs,
+    agentArgs: overriddenArgs.recipeArgs,
     promptDelivery: spec.promptDelivery,
     prompt: argvPrompt
   })


### PR DESCRIPTION
## Summary

Fixes #8722 by making a Codex action recipe's model argument override Orca's generated model argument instead of appending a conflicting second singleton option.

Supported recipe forms:

- `--model gpt-5.6-luna`
- `-m gpt-5.6-luna`
- `--model=gpt-5.6-luna`
- `-mgpt-5.6-luna`

The recipe's exact model tokens replace Orca's generated model pair in place, preserving the established position of reasoning config and the relative order of all other recipe arguments.

## Evidence

Before, a recipe with `--model gpt-5.6-luna` produced the equivalent of:

```text
codex exec ... --model gpt-5.5 -c model_reasoning_effort=low --model gpt-5.6-luna
```

Codex rejects that command because `--model` is a singleton.

After this change, the planner emits:

```text
codex exec ... --model gpt-5.6-luna -c model_reasoning_effort=low
```

Regression coverage proves the long, short, equals, attached-short, sibling-argument, no-override, and `--` terminator cases. The focused suite passes 19/19 tests; the full suite passes 29,764 tests with 43 skipped.

## ELI5

Orca used to put two destination labels on the same package: its default model and the recipe's model. Codex refused to guess which label was right. Orca now swaps its own label for the more-specific recipe label, leaving exactly one model while keeping the rest of the package instructions in the same order.

## Trade-offs and user regressions

Expected user regressions: zero.

- Behavior changes only for Codex text-generation recipes that explicitly provide a model option.
- Recipes without a model override produce the same argv as before.
- Other agents, custom commands, and other recipe arguments retain their existing behavior.
- The recipe's exact option spelling is preserved, including `-mVALUE`.
- Tokens after `--` are positional text and do not override the generated model.
- Malformed or repeated model options supplied inside the recipe remain user-owned input; Orca replaces only its own generated default and does not silently rewrite additional user choices.

## Community PR decision

Compared community PR #8740 after this independent PR was opened. #8740's strongest idea was replacing the generated model in place so trailing reasoning configuration stays ordered; that behavior is incorporated here with credit to @xianjianlf2.

This PR is the selected integration path because it is based on current `main`, scopes the `-m` alias to Codex instead of assuming unrelated CLIs share that spelling, and adds coverage for equals syntax, attached short values, `--` termination, sibling arguments, and unchanged no-override behavior.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (29,764 passed, 43 skipped)
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/commit-message-plan.test.ts` (19 passed)
- [x] Added regression coverage that fails on the previous duplicate-model behavior
- [ ] `pnpm build` — not run; this changes pure argv planning with no UI, bundling, native module, or dependency surface

## AI Review Report

An independent adversarial sub-agent reviewed the diff without inspecting community implementations. It checked argv parsing, singleton precedence, malformed values, exact/equals/separated/attached syntax, `--` termination, argument ordering, non-Codex isolation, command injection, and macOS/Linux/Windows/WSL/SSH behavior.

Findings and resolution:

1. **Medium / blocker:** valid Codex `-mVALUE` syntax was not initially recognized and still caused duplicate models. Fixed by recognizing attached values only for short aliases and adding a regression case verified against Codex CLI parsing.
2. **Low / test hardening:** sibling recipe arguments were no longer explicitly covered. Added exact-order coverage for model overrides plus `--sandbox`, and for recipes with no model override.
3. **Follow-up review:** **Go; no blocking findings remain.** The reviewer verified the fixes, in-place replacement, malformed-option behavior, `--` handling, non-Codex isolation, and unchanged security/platform risk.

Cross-platform conclusion: the change operates on already-tokenized argv arrays and adds no shell quoting, paths, shortcuts, labels, or Electron platform branches. It follows the existing macOS, Linux, Windows, WSL, SSH, local, and remote spawn paths.

## Security Audit

No new command-execution surface is added. Recipe CLI arguments were already user-controlled, tokenized without a shell, and passed as argv. The change only replaces Orca's generated model pair with an explicitly supplied recipe model token sequence. No shell evaluation, path handling, auth, secrets, dependency, IPC, network, or permission behavior changes.

## Notes

The override is intentionally scoped to Codex's generated model option to fix the reported failure without changing precedence semantics for unrelated CLIs or singleton flags.
