### PR TITLE
Prepare mobile 0.0.30

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.27",
+    "version": "0.0.30",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- bump the committed Orca Mobile marketing version to 0.0.30
- prepare a fresh TestFlight train containing the restored-terminal mobile fix from #8768

## Validation
- `jq empty mobile/app.json`
- `git diff --check`
- commit hooks passed

Made with [Orca](https://github.com/stablyai/orca) 🐋
