### PR TITLE
Add mobile notification opt-in onboarding

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -178,6 +178,10 @@ export default function RootLayout() {
           <Stack.Screen name="pair-scan" options={{ headerShown: false }} />
           <Stack.Screen name="pair" options={{ headerShown: false }} />
           <Stack.Screen name="pair-confirm" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="notification-opt-in"
+            options={{ headerShown: false, presentation: 'modal', gestureEnabled: false }}
+          />
           <Stack.Screen name="settings" options={{ headerShown: false }} />
           <Stack.Screen name="terminal-settings" options={{ headerShown: false }} />
           <Stack.Screen name="browser-settings" options={{ headerShown: false }} />

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -36,6 +36,7 @@ import {
 } from '../src/transport/client-context'
 import { classifyConnection } from '../src/transport/connection-health'
 import { subscribeToDesktopNotifications } from '../src/notifications/mobile-notifications'
+import { shouldPresentNotificationOptIn } from '../src/notifications/notification-opt-in-gate'
 import type { ConnectionState, HostProfile } from '../src/transport/types'
 import { triggerMediumImpact } from '../src/platform/haptics'
 import { OrcaLogo } from '../src/components/OrcaLogo'
@@ -317,6 +318,7 @@ export default function HomeScreen() {
   const [lastVisited, setLastVisited] = useState<{ hostId: string; worktreeId: string } | null>(
     null
   )
+  const notificationOptInCheckedRef = useRef(false)
 
   // Why: read shared clients from the per-host store. Replaces the prior
   // pattern of opening N independent WebSockets here. See
@@ -395,9 +397,18 @@ export default function HomeScreen() {
   useFocusEffect(
     useCallback(() => {
       let stale = false
-      void loadHosts().then((h) => {
-        if (!stale) {
-          setHosts(h)
+      void loadHosts().then(async (h) => {
+        if (stale) {
+          return
+        }
+        setHosts(h)
+        if (h.length === 0 || notificationOptInCheckedRef.current) {
+          return
+        }
+        notificationOptInCheckedRef.current = true
+        const showNotificationOptIn = await shouldPresentNotificationOptIn()
+        if (!stale && showNotificationOptIn) {
+          router.replace('/notification-opt-in')
         }
       })
       void AsyncStorage.getItem('orca:last-visited-worktree').then((raw) => {
@@ -419,7 +430,7 @@ export default function HomeScreen() {
       return () => {
         stale = true
       }
-    }, [])
+    }, [router])
   )
 
   const sortedHosts = useMemo(

--- a/mobile/app/notification-opt-in.tsx
+++ b/mobile/app/notification-opt-in.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useState } from 'react'
+import { ActivityIndicator, BackHandler, Pressable, StyleSheet, Text, View } from 'react-native'
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { BellRing } from 'lucide-react-native'
+import { OrcaLogo } from '../src/components/OrcaLogo'
+import { ensureNotificationPermissions } from '../src/notifications/mobile-notifications'
+import { savePushNotificationsEnabled } from '../src/storage/preferences'
+import { colors, radii, spacing, typography } from '../src/theme/mobile-theme'
+
+export default function NotificationOptInScreen() {
+  const router = useRouter()
+  const params = useLocalSearchParams<{ hostId?: string | string[] }>()
+  const hostId = Array.isArray(params.hostId) ? params.hostId[0] : params.hostId
+  const [busyChoice, setBusyChoice] = useState<'enable' | 'skip' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Why: this one-time screen requires an explicit Enable or Not now choice;
+  // disabling back gestures alone would still leave Android hardware back open.
+  useFocusEffect(
+    useCallback(() => {
+      const subscription = BackHandler.addEventListener('hardwareBackPress', () => true)
+      return () => subscription.remove()
+    }, [])
+  )
+
+  const continueToApp = useCallback(() => {
+    router.replace(hostId ? `/h/${hostId}` : '/')
+  }, [hostId, router])
+
+  const choose = useCallback(
+    async (choice: 'enable' | 'skip') => {
+      if (busyChoice) {
+        return
+      }
+      setBusyChoice(choice)
+      setError(null)
+      try {
+        const enabled = choice === 'enable' ? await ensureNotificationPermissions() : false
+        await savePushNotificationsEnabled(enabled)
+        continueToApp()
+      } catch {
+        setError('Notification settings could not be updated. Try again.')
+        setBusyChoice(null)
+      }
+    },
+    [busyChoice, continueToApp]
+  )
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.brandRow}>
+        <OrcaLogo size={22} />
+        <Text style={styles.brandName}>Orca</Text>
+      </View>
+
+      <View style={styles.content}>
+        <View style={styles.iconSurface}>
+          <BellRing size={30} color={colors.textPrimary} />
+        </View>
+        <Text style={styles.eyebrow}>Notifications</Text>
+        <Text style={styles.title}>Stay updated while away</Text>
+        <Text style={styles.body}>
+          Get notified on this device when an agent needs your input or finishes a task.
+        </Text>
+      </View>
+
+      <View style={styles.footer}>
+        {error ? (
+          <Text style={styles.error} accessibilityRole="alert">
+            {error}
+          </Text>
+        ) : null}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Enable agent notifications"
+          disabled={busyChoice !== null}
+          style={({ pressed }) => [
+            styles.primaryButton,
+            pressed && styles.buttonPressed,
+            busyChoice !== null && styles.buttonDisabled
+          ]}
+          onPress={() => void choose('enable')}
+        >
+          {busyChoice === 'enable' ? (
+            <ActivityIndicator color={colors.bgBase} />
+          ) : (
+            <Text style={styles.primaryButtonText}>Enable notifications</Text>
+          )}
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          disabled={busyChoice !== null}
+          style={({ pressed }) => [
+            styles.secondaryButton,
+            pressed && styles.buttonPressed,
+            busyChoice !== null && styles.buttonDisabled
+          ]}
+          onPress={() => void choose('skip')}
+        >
+          {busyChoice === 'skip' ? (
+            <ActivityIndicator color={colors.textSecondary} />
+          ) : (
+            <Text style={styles.secondaryButtonText}>Not now</Text>
+          )}
+        </Pressable>
+        <Text style={styles.footerNote}>You can change this any time in Settings.</Text>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgBase,
+    paddingHorizontal: spacing.xl
+  },
+  brandRow: {
+    minHeight: 52,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm
+  },
+  brandName: {
+    color: colors.textPrimary,
+    fontSize: 17,
+    fontWeight: '700'
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingBottom: spacing.xl
+  },
+  iconSurface: {
+    width: 64,
+    height: 64,
+    borderRadius: radii.card,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgRaised,
+    marginBottom: spacing.xl
+  },
+  eyebrow: {
+    color: colors.textMuted,
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.55,
+    textTransform: 'uppercase',
+    marginBottom: spacing.sm
+  },
+  title: {
+    maxWidth: 420,
+    color: colors.textPrimary,
+    fontSize: 26,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    textAlign: 'center'
+  },
+  body: {
+    maxWidth: 420,
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    lineHeight: 21,
+    textAlign: 'center',
+    marginTop: spacing.md
+  },
+  footer: {
+    width: '100%',
+    maxWidth: 420,
+    alignSelf: 'center',
+    paddingBottom: spacing.lg
+  },
+  primaryButton: {
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.button,
+    backgroundColor: colors.surfaceBright
+  },
+  primaryButtonText: {
+    color: colors.bgBase,
+    fontSize: typography.bodySize,
+    fontWeight: '600'
+  },
+  secondaryButton: {
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.button,
+    marginTop: spacing.xs
+  },
+  secondaryButtonText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize,
+    fontWeight: '500'
+  },
+  buttonPressed: {
+    opacity: 0.72
+  },
+  buttonDisabled: {
+    opacity: 0.58
+  },
+  footerNote: {
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    lineHeight: 18,
+    textAlign: 'center',
+    marginTop: spacing.sm
+  },
+  error: {
+    color: colors.statusRed,
+    fontSize: typography.metaSize,
+    lineHeight: 18,
+    textAlign: 'center',
+    marginBottom: spacing.sm
+  }
+})

--- a/mobile/app/notifications.tsx
+++ b/mobile/app/notifications.tsx
@@ -69,7 +69,7 @@ export default function NotificationsScreen() {
   const notificationsBlocked = permissionState.status === 'denied'
   const hint = notificationsBlocked
     ? 'Notifications are disabled in system settings.'
-    : 'Receive notifications when an agent task completes on your desktop.'
+    : 'Get notified on this device when an agent needs your input or finishes a task.'
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
@@ -82,7 +82,7 @@ export default function NotificationsScreen() {
 
       <View style={styles.section}>
         <View style={styles.row}>
-          <Text style={styles.rowLabel}>Push Notifications</Text>
+          <Text style={styles.rowLabel}>Agent notifications</Text>
           <Switch
             value={switchEnabled}
             disabled={notificationsBlocked}

--- a/mobile/app/pair-confirm.tsx
+++ b/mobile/app/pair-confirm.tsx
@@ -11,6 +11,7 @@ import {
 import type { ConnectionLogEntry } from '../src/transport/types'
 import { colors, spacing, radii, typography } from '../src/theme/mobile-theme'
 import { ConnectionLog } from '../src/components/ConnectionLog'
+import { shouldPresentNotificationOptIn } from '../src/notifications/notification-opt-in-gate'
 
 type Status = 'awaiting-confirm' | 'connecting' | 'error'
 
@@ -103,7 +104,15 @@ export default function PairConfirmScreen() {
       if (!mountedRef.current || !attemptIsCurrent) {
         return
       }
-      router.replace(`/h/${hostId}`)
+      const showNotificationOptIn = await shouldPresentNotificationOptIn()
+      if (!mountedRef.current) {
+        return
+      }
+      router.replace(
+        showNotificationOptIn
+          ? { pathname: '/notification-opt-in', params: { hostId } }
+          : `/h/${hostId}`
+      )
     } catch (err) {
       const timedOut = attempt.timedOut
       const attemptIsCurrent = activePairingAttemptRef.current === attempt

--- a/mobile/app/pair-scan.tsx
+++ b/mobile/app/pair-scan.tsx
@@ -21,6 +21,7 @@ import type { ConnectionLogEntry, PairingOffer } from '../src/transport/types'
 import { colors, spacing, radii, typography } from '../src/theme/mobile-theme'
 import { TextInputModal } from '../src/components/TextInputModal'
 import { ConnectionLog } from '../src/components/ConnectionLog'
+import { shouldPresentNotificationOptIn } from '../src/notifications/notification-opt-in-gate'
 
 // Why: see pair-confirm.tsx — cap initial-pair "Connecting…" so a broken
 // route surfaces as a real error with the log visible instead of a
@@ -147,7 +148,15 @@ export default function PairScanScreen() {
       if (!mountedRef.current || !attemptIsCurrent) {
         return
       }
-      router.replace(`/h/${hostId}`)
+      const showNotificationOptIn = await shouldPresentNotificationOptIn()
+      if (!mountedRef.current) {
+        return
+      }
+      router.replace(
+        showNotificationOptIn
+          ? { pathname: '/notification-opt-in', params: { hostId } }
+          : `/h/${hostId}`
+      )
     } catch (err) {
       const timedOut = attempt.timedOut
       const attemptIsCurrent = activePairingAttemptRef.current === attempt

--- a/mobile/src/notifications/notification-opt-in-gate.test.ts
+++ b/mobile/src/notifications/notification-opt-in-gate.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  readPushNotificationsPreference,
+  savePushNotificationsEnabled
+} from '../storage/preferences'
+import { getNotificationPermissionState } from './mobile-notifications'
+import { shouldPresentNotificationOptIn } from './notification-opt-in-gate'
+
+vi.mock('../storage/preferences', () => ({
+  readPushNotificationsPreference: vi.fn(),
+  savePushNotificationsEnabled: vi.fn()
+}))
+
+vi.mock('./mobile-notifications', () => ({
+  getNotificationPermissionState: vi.fn()
+}))
+
+describe('notification opt-in gate', () => {
+  beforeEach(() => {
+    vi.mocked(readPushNotificationsPreference).mockReset()
+    vi.mocked(savePushNotificationsEnabled).mockReset()
+    vi.mocked(getNotificationPermissionState).mockReset()
+  })
+
+  it('presents only when the local preference and system decision are both unset', async () => {
+    vi.mocked(readPushNotificationsPreference).mockResolvedValue({ value: null, loaded: true })
+    vi.mocked(getNotificationPermissionState).mockResolvedValue({
+      granted: false,
+      status: 'undetermined',
+      canAskAgain: true
+    })
+
+    await expect(shouldPresentNotificationOptIn()).resolves.toBe(true)
+    expect(savePushNotificationsEnabled).not.toHaveBeenCalled()
+  })
+
+  it.each([true, false])('preserves an existing %s mobile preference', async (value) => {
+    vi.mocked(readPushNotificationsPreference).mockResolvedValue({ value, loaded: true })
+
+    await expect(shouldPresentNotificationOptIn()).resolves.toBe(false)
+    expect(getNotificationPermissionState).not.toHaveBeenCalled()
+  })
+
+  it('adopts existing system authorization without prompting', async () => {
+    vi.mocked(readPushNotificationsPreference).mockResolvedValue({ value: null, loaded: true })
+    vi.mocked(getNotificationPermissionState).mockResolvedValue({
+      granted: true,
+      status: 'granted',
+      canAskAgain: true
+    })
+
+    await expect(shouldPresentNotificationOptIn()).resolves.toBe(false)
+    expect(savePushNotificationsEnabled).toHaveBeenCalledWith(true)
+  })
+
+  it('skips the gate when iOS has already denied permission', async () => {
+    vi.mocked(readPushNotificationsPreference).mockResolvedValue({ value: null, loaded: true })
+    vi.mocked(getNotificationPermissionState).mockResolvedValue({
+      granted: false,
+      status: 'denied',
+      canAskAgain: false
+    })
+
+    await expect(shouldPresentNotificationOptIn()).resolves.toBe(false)
+    expect(savePushNotificationsEnabled).toHaveBeenCalledWith(false)
+  })
+
+  it('does not block startup when storage or permission checks fail', async () => {
+    vi.mocked(readPushNotificationsPreference).mockResolvedValue({ value: null, loaded: false })
+    await expect(shouldPresentNotificationOptIn()).resolves.toBe(false)
+
+    vi.mocked(readPushNotificationsPreference).mockResolvedValue({ value: null, loaded: true })
+    vi.mocked(getNotificationPermissionState).mockRejectedValue(new Error('unavailable'))
+    await expect(shouldPresentNotificationOptIn()).resolves.toBe(false)
+  })
+})

--- a/mobile/src/notifications/notification-opt-in-gate.ts
+++ b/mobile/src/notifications/notification-opt-in-gate.ts
@@ -1,0 +1,33 @@
+import {
+  readPushNotificationsPreference,
+  savePushNotificationsEnabled
+} from '../storage/preferences'
+import { getNotificationPermissionState } from './mobile-notifications'
+
+export async function shouldPresentNotificationOptIn(): Promise<boolean> {
+  const preference = await readPushNotificationsPreference()
+  if (!preference.loaded || preference.value !== null) {
+    return false
+  }
+
+  try {
+    const permission = await getNotificationPermissionState()
+    if (permission.granted) {
+      // Why: an already-authorized device should inherit the useful default
+      // without seeing an onboarding decision it has effectively made.
+      await savePushNotificationsEnabled(true)
+      return false
+    }
+    if (permission.status === 'denied' || !permission.canAskAgain) {
+      // Why: iOS cannot show its authorization prompt again, so a blocking
+      // onboarding screen would be a dead end; Settings remains the recovery.
+      await savePushNotificationsEnabled(false)
+      return false
+    }
+    return permission.status === 'undetermined'
+  } catch {
+    // Why: permission or persistence failures must not trap startup behind a
+    // decision screen whose result cannot be applied reliably.
+    return false
+  }
+}

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -10,11 +10,14 @@ import {
   clampHostSidebarWidth,
   loadDisabledTerminalLiveInputHandles,
   loadHostSidebarWidth,
+  loadPushNotificationsEnabled,
   loadTerminalAutocompleteEnabled,
   loadTerminalLinkOpenMode,
+  readPushNotificationsPreference,
   readDisabledTerminalLiveInputHandlesPreference,
   saveDisabledTerminalLiveInputHandles,
   saveHostSidebarWidth,
+  savePushNotificationsEnabled,
   saveTerminalAutocompleteEnabled,
   saveTerminalLinkOpenMode
 } from './preferences'
@@ -25,6 +28,46 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
     setItem: vi.fn()
   }
 }))
+
+describe('push notification preference', () => {
+  beforeEach(() => {
+    vi.mocked(AsyncStorage.getItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockReset()
+  })
+
+  it('distinguishes an unset preference from an explicit disabled choice', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(null)
+    await expect(readPushNotificationsPreference()).resolves.toEqual({
+      value: null,
+      loaded: true
+    })
+    await expect(loadPushNotificationsEnabled()).resolves.toBe(false)
+
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue('false')
+    await expect(readPushNotificationsPreference()).resolves.toEqual({
+      value: false,
+      loaded: true
+    })
+  })
+
+  it('reports storage failures without enabling notifications', async () => {
+    vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
+
+    await expect(readPushNotificationsPreference()).resolves.toEqual({
+      value: null,
+      loaded: false
+    })
+    await expect(loadPushNotificationsEnabled()).resolves.toBe(false)
+  })
+
+  it('persists the onboarding decision in the existing mobile toggle', async () => {
+    await savePushNotificationsEnabled(true)
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('orca:pushNotificationsEnabled', 'true')
+
+    await savePushNotificationsEnabled(false)
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('orca:pushNotificationsEnabled', 'false')
+  })
+})
 
 describe('terminal autocomplete preference', () => {
   beforeEach(() => {

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -3,21 +3,27 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 const PINS_PREFIX = 'orca:pins:'
 const NOTIF_KEY = 'orca:pushNotificationsEnabled'
 
-// Why: default-off so the iOS notification permission prompt never
-// fires until the user explicitly opts in via Settings → Notifications.
-// Apple's review guideline 4.5.4 and HIG both prefer user-initiated
-// permission prompts; default-on would fire the prompt the moment the
-// desktop sent its first notification, which can read as unsolicited.
-export async function loadPushNotificationsEnabled(): Promise<boolean> {
+export type PushNotificationsPreference = {
+  readonly value: boolean | null
+  readonly loaded: boolean
+}
+
+// Why: null distinguishes people who have never made the one-time onboarding
+// decision from people who explicitly chose Not now or disabled notifications.
+export async function readPushNotificationsPreference(): Promise<PushNotificationsPreference> {
   try {
     const raw = await AsyncStorage.getItem(NOTIF_KEY)
-    if (raw === null) {
-      return false
-    }
-    return raw === 'true'
+    return { value: raw === null ? null : raw === 'true', loaded: true }
   } catch {
-    return false
+    return { value: null, loaded: false }
   }
+}
+
+// Why: default-off prevents background notification events from opening the
+// system prompt; only the onboarding CTA or Settings switch requests permission.
+export async function loadPushNotificationsEnabled(): Promise<boolean> {
+  const preference = await readPushNotificationsPreference()
+  return preference.value ?? false
 }
 
 export async function savePushNotificationsEnabled(enabled: boolean): Promise<void> {

--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -899,7 +899,7 @@ describe('registerNotificationHandlers', () => {
     expect(dispatchMobileNotification).not.toHaveBeenCalled()
   })
 
-  it('does not dispatch mobile notifications for focused active-worktree notifications', async () => {
+  it('dispatches one mobile notification when the active worktree is focused on desktop', async () => {
     getAllWindowsMock.mockReturnValue([
       {
         isDestroyed: () => false,
@@ -922,17 +922,25 @@ describe('registerNotificationHandlers', () => {
     )
 
     const handler = getDispatchHandler()
-    expect(
-      await handler(
-        {},
-        { source: 'agent-task-complete', worktreeId: 'repo::wt1', isActiveWorktree: true }
-      )
-    ).toEqual({
+    const focusedNotification = {
+      source: 'agent-task-complete' as const,
+      worktreeId: 'repo::wt1',
+      isActiveWorktree: true
+    }
+    expect(await handler({}, focusedNotification)).toEqual({
+      delivered: false,
+      reason: 'suppressed-focus'
+    })
+    expect(await handler({}, focusedNotification)).toEqual({
       delivered: false,
       reason: 'suppressed-focus'
     })
 
-    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+    expect(dispatchMobileNotification).toHaveBeenCalledTimes(1)
+    expect(dispatchMobileNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'agent-task-complete', worktreeId: 'repo::wt1' })
+    )
+    expect(notificationCtorMock).not.toHaveBeenCalled()
   })
 
   it('does not dispatch mobile notifications for cooldown-suppressed bursts', async () => {

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -312,8 +312,24 @@ function pruneRecentNotifications(recentNotifications: Map<string, number>, now:
   }
 }
 
+function reserveNotificationCooldown(
+  recentNotifications: Map<string, number>,
+  dedupeKey: string,
+  now: number
+): boolean {
+  const lastSentAt = recentNotifications.get(dedupeKey) ?? 0
+  if (now - lastSentAt < NOTIFICATION_COOLDOWN_MS) {
+    return false
+  }
+  recentNotifications.delete(dedupeKey)
+  recentNotifications.set(dedupeKey, now)
+  pruneRecentNotifications(recentNotifications, now)
+  return true
+}
+
 export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntimeService): void {
-  const recentNotifications = new Map<string, number>()
+  const recentDesktopNotifications = new Map<string, number>()
+  const recentMobileNotifications = new Map<string, number>()
   // Why: handler registration marks a fresh session — permission evidence
   // from a previous registration must not leak into the new one.
   lastObservedDeliveryOutcome = null
@@ -441,6 +457,24 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
         return { delivered: false, reason: 'source-disabled' }
       }
 
+      const notificationOptions = buildNotificationOptions(args)
+
+      // Why: desktop focus only means this computer has the worktree visible;
+      // the paired phone may be locked or elsewhere and still needs the alert.
+      if (runtime && args.source !== 'test') {
+        const dedupeKey = args.worktreeId ?? args.worktreeLabel ?? 'global'
+        if (reserveNotificationCooldown(recentMobileNotifications, dedupeKey, Date.now())) {
+          runtime.dispatchMobileNotification({
+            type: 'notification',
+            source: args.source,
+            title: notificationOptions.title,
+            body: notificationOptions.body,
+            worktreeId: args.worktreeId,
+            ...(args.notificationId ? { notificationId: args.notificationId } : {})
+          })
+        }
+      }
+
       const browserWindow =
         BrowserWindow.getAllWindows().find((window) => !window.isDestroyed()) ?? null
       if (
@@ -458,33 +492,9 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
         // Dedupe by worktree, not by source — an agent finishing and a terminal bell
         // often fire within the same data chunk so only the first one should surface.
         const dedupeKey = args.worktreeId ?? args.worktreeLabel ?? 'global'
-        const now = Date.now()
-        const lastSentAt = recentNotifications.get(dedupeKey) ?? 0
-        if (now - lastSentAt < NOTIFICATION_COOLDOWN_MS) {
+        if (!reserveNotificationCooldown(recentDesktopNotifications, dedupeKey, Date.now())) {
           return { delivered: false, reason: 'cooldown' }
         }
-        recentNotifications.delete(dedupeKey)
-        recentNotifications.set(dedupeKey, now)
-
-        // Why: a storm across many worktrees should not make every
-        // notification dispatch scan an ever-growing cooldown table.
-        pruneRecentNotifications(recentNotifications, now)
-      }
-
-      const notificationOptions = buildNotificationOptions(args)
-
-      // Why: paired mobile clients should follow the same user-facing
-      // notification gates as desktop delivery, while still working on hosts
-      // where Electron native notifications are unavailable.
-      if (runtime && args.source !== 'test') {
-        runtime.dispatchMobileNotification({
-          type: 'notification',
-          source: args.source,
-          title: notificationOptions.title,
-          body: notificationOptions.body,
-          worktreeId: args.worktreeId,
-          ...(args.notificationId ? { notificationId: args.notificationId } : {})
-        })
       }
 
       if (!Notification.isSupported()) {


### PR DESCRIPTION
## Summary

- add a one-time mobile notification decision after pairing and for existing paired users without a saved preference
- request native notification permission only after the user taps Enable notifications, while preserving explicit opt-outs and denied system state
- keep mobile agent alerts flowing when desktop focus suppresses the corresponding desktop notification
- clarify the mobile Settings label and description

## Mixed-version compatibility

- desktop updated first: the existing mobile event contract remains compatible; already opted-in users immediately benefit from focused-worktree delivery, while default-off users remain off until they update mobile or enable notifications manually
- mobile updated first: onboarding and preference persistence work with the older desktop; focused-worktree alerts retain the old suppression behavior until desktop is updated, then begin working without another prompt or migration
- the notification event schema and mobile preference key are unchanged, and explicit opt-outs remain preserved in either update order

## Testing

- mobile test suite: 1,688 passed, 2 skipped
- mobile TypeScript and lint
- main notification IPC tests: 56 passed
- root TypeScript and max-lines ratchet
- iOS Simulator QA on BlankTermQA: rendered the custom Orca modal, opened the native iOS notification prompt from the CTA, allowed notifications, persisted the mobile toggle, and returned to a live paired terminal

## Tracking

- [STA-1869](https://linear.app/stably/issue/STA-1869/improve-visibility-and-default-state-of-mobile-push-notifications)

Simulator screenshots are attached in a PR comment.