### PR TITLE
fix: preserve scroll position when switching OMP file tabs (#8715)

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -534,18 +534,23 @@ function FileReader({
   title,
   relativePath,
   language,
-  diffCommentActions
+  diffCommentActions,
+  initialScrollOffset,
+  onScrollOffsetChange
 }: {
   doc: FileDocState | undefined
   title: string
   relativePath: string
   language?: string
   diffCommentActions?: DiffCommentActions
+  initialScrollOffset?: number
+  onScrollOffsetChange?: (offset: number) => void
 }) {
   const syntaxLanguage = useMemo(
     () => resolveMobileSyntaxLanguage(relativePath || title, language),
     [language, relativePath, title]
   )
+  const filePreviewScrollRef = useRef<ScrollView>(null)
   const [fileSyntax, setFileSyntax] = useState<FileSyntaxState | null>(null)
   const [diffSyntax, setDiffSyntax] = useState<DiffSyntaxState | null>(null)
   const [activeCommentLine, setActiveCommentLine] = useState<number | null>(null)
@@ -667,6 +672,14 @@ function FileReader({
     return () => clearTimeout(timer)
   }, [doc, syntaxLanguage])
 
+  useEffect(() => {
+    // Why: FileReader remounts on every tab switch (see fileScrollOffsetsRef in
+    // the parent), so restore the saved offset once this tab's content is ready.
+    if (doc?.status === 'ready' && initialScrollOffset) {
+      filePreviewScrollRef.current?.scrollTo({ y: initialScrollOffset, animated: false })
+    }
+  }, [doc?.status, initialScrollOffset])
+
   if (!doc || doc.status === 'loading') {
     return (
       <View style={styles.markdownState}>
@@ -773,8 +786,11 @@ function FileReader({
   const renderSourceText = (content: string) => (
     <View style={styles.markdownEditor}>
       <ScrollView
+        ref={filePreviewScrollRef}
         style={styles.filePreviewScroll}
         contentContainerStyle={styles.filePreviewContent}
+        onScroll={(e) => onScrollOffsetChange?.(e.nativeEvent.contentOffset.y)}
+        scrollEventThrottle={16}
       >
         <Text selectable style={styles.filePreviewText} accessibilityLabel={`${title} preview`}>
           <MobileSyntaxSegments
@@ -924,6 +940,9 @@ export default function SessionScreen() {
   const [markdownDocs, setMarkdownDocs] = useState<Map<string, MarkdownDocState>>(new Map())
   const markdownDocsRef = useRef<Map<string, MarkdownDocState>>(new Map())
   const [fileDocs, setFileDocs] = useState<Map<string, FileDocState>>(new Map())
+  // FileReader unmounts on every tab switch (conditional render below), so its
+  // ScrollView loses scroll position; remember it per tab id here instead.
+  const fileScrollOffsetsRef = useRef<Map<string, number>>(new Map())
   const [diffComments, setDiffComments] = useState<DiffComment[]>([])
   const diffCommentsRef = useRef<DiffComment[]>([])
   const [diffCommentBusy, setDiffCommentBusy] = useState(false)
@@ -4780,6 +4799,10 @@ export default function SessionScreen() {
                   title={activeFileTab.title || 'File'}
                   relativePath={activeFileTab.relativePath}
                   language={activeFileTab.language}
+                  initialScrollOffset={fileScrollOffsetsRef.current.get(activeFileTab.id) ?? 0}
+                  onScrollOffsetChange={(offset) => {
+                    fileScrollOffsetsRef.current.set(activeFileTab.id, offset)
+                  }}
                   diffCommentActions={
                     activeFileTab.diffSource === 'staged' || activeFileTab.diffSource === 'unstaged'
                       ? {

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -4795,6 +4795,7 @@ export default function SessionScreen() {
             ) : activeFileTab ? (
               <View style={styles.markdownFrame}>
                 <FileReader
+                  key={activeFileTab.id}
                   doc={fileDocs.get(activeFileTab.id)}
                   title={activeFileTab.title || 'File'}
                   relativePath={activeFileTab.relativePath}


### PR DESCRIPTION
## Summary

Adds a `key={activeFileTab.id}` prop to the `FileReader` usage in the session screen so React remounts it on every file tab switch. Without the key, React reuses the same component instance when switching between two file tabs (same component type, same tree position), which meant the scroll offset restoration added in the previous commit only fired on the very first mount and not on subsequent tab switches. This closes the gap flagged in review on the original scroll-position PR.

## Screenshots

No visual change. The behavior only affects scroll position handling when switching between open file tabs.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` (mobile has no build script; this change is scoped to `mobile/app/h/[hostId]/session/[worktreeId].tsx` and does not touch the desktop Electron build)
- [x] Manually traced the remount path: keying by `activeFileTab.id` forces `FileReader` to unmount and remount on tab switch, so the existing `useEffect` that seeks to `initialScrollOffset` on `doc?.status === 'ready'` now runs for every tab instead of only the first one rendered

Ran from `mobile/`: 238 test files passed (1679 tests, 2 skipped), lint and typecheck both clean.

## AI Review Report

Reviewed the diff for correctness and side effects of adding the key prop. The main risk was whether keying would cause unnecessary remounts elsewhere in the tree, but the key is scoped to `FileReader` itself, so no other components in `SessionScreen` are affected. Confirmed the fix does not change behavior on macOS, Linux, or Windows since it is a pure React reconciliation change with no platform-specific APIs, shortcuts, paths, or shell calls involved.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes in this diff. The change is limited to a React `key` prop derived from an already-trusted internal tab id.

## Notes

No platform-specific behavior. Applies equally on macOS, Linux, and Windows since it is pure React state/reconciliation logic in the mobile app.

## ELI5

Switching between open file tabs forgot your scroll position. Each file tab remounts cleanly so scroll restore runs every time you switch.
