### PR TITLE
feat(chat-import): storage, native messaging host, and read-only AI Vault sessions (1/4)

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -9,6 +9,10 @@
     "../src/main/agent-hooks/managed-agent-hook-controls.ts",
     "../src/main/amp/hook-service.ts",
     "../src/main/antigravity/hook-service.ts",
+    "../src/main/chat-import/chat-import-store.ts",
+    "../src/main/chat-import/chat-import-schema.ts",
+    "../src/main/chat-import/chat-import-paths.ts",
+    "../src/main/chat-import/chat-import-db-open.ts",
     "../src/main/claude/hook-settings.ts",
     "../src/main/claude/hook-service.ts",
     "../src/main/codex/codex-config-mirror.ts",
@@ -37,6 +41,7 @@
     "../src/main/kimi/kimi-hook-config-toml.ts",
     "../src/main/openclaude/hook-service.ts",
     "../src/main/runtime/runtime-metadata.ts",
+    "../src/main/sqlite/sync-database.ts",
     "../src/main/win32-utils.ts"
   ],
   "compilerOptions": {

--- a/src/cli/chat-import-host/chat-import-host-argv.test.ts
+++ b/src/cli/chat-import-host/chat-import-host-argv.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { isChatImportHostRun } from './chat-import-host-argv'
+
+describe('isChatImportHostRun', () => {
+  it('recognizes a bare host launch', () => {
+    expect(isChatImportHostRun(['chat-import-host'])).toBe(true)
+  })
+
+  it('recognizes a host launch with the Chrome extension origin appended', () => {
+    expect(isChatImportHostRun(['chat-import-host', 'chrome-extension://abc/'])).toBe(true)
+  })
+
+  it('recognizes a host launch with origin and Windows --parent-window appended', () => {
+    expect(
+      isChatImportHostRun(['chat-import-host', 'chrome-extension://abc/', '--parent-window=12345'])
+    ).toBe(true)
+  })
+
+  it('does not treat `chat-import-host install` as a host run', () => {
+    expect(isChatImportHostRun(['chat-import-host', 'install', '--extension-id', 'x'])).toBe(false)
+  })
+
+  it('does not treat unrelated commands as a host run', () => {
+    expect(isChatImportHostRun(['serve'])).toBe(false)
+  })
+})

--- a/src/cli/chat-import-host/chat-import-host-argv.ts
+++ b/src/cli/chat-import-host/chat-import-host-argv.ts
@@ -1,0 +1,9 @@
+// Why: Chrome launches the native-messaging host with the extension origin
+// (chrome-extension://<id>/) and, on Windows, --parent-window=<handle>
+// appended as positional argv — the CLI's normal parser mistakes the origin
+// for a subcommand and rejects the unknown --parent-window flag, so the host
+// run must be routed before ordinary command parsing. `install` is the one
+// real subcommand and must still go through normal parsing.
+export function isChatImportHostRun(argv: string[]): boolean {
+  return argv[0] === 'chat-import-host' && argv[1] !== 'install'
+}

--- a/src/cli/chat-import-host/chat-import-host-protocol.test.ts
+++ b/src/cli/chat-import-host/chat-import-host-protocol.test.ts
@@ -35,6 +35,30 @@ describe('processChatImportHostMessage', () => {
     expect(listIngestedExternalIds(db, 'CHATGPT')).toEqual(['c1'])
   })
 
+  it.each([
+    [
+      'duplicate idx',
+      [
+        { role: 'USER', idx: 0 },
+        { role: 'AI', idx: 0 }
+      ]
+    ],
+    ['non-integer idx', [{ role: 'USER', idx: 1.5 }]]
+  ])('INGEST rejects a conversation with %s before it reaches SQLite', (_label, messages) => {
+    const db = tempDb()
+    const conv = {
+      source: 'CHATGPT',
+      externalId: 'bad',
+      title: 'T',
+      createdAt: null,
+      updatedAt: null,
+      messages
+    }
+    const res = processChatImportHostMessage(db, JSON.stringify({ type: 'INGEST', conv }), 'now')
+    expect(res).toEqual({ type: 'ERROR', error: 'bad conversation' })
+    expect(listIngestedExternalIds(db, 'CHATGPT')).toEqual([])
+  })
+
   it('INGESTED_IDS returns stored ids for the source', () => {
     const db = tempDb()
     processChatImportHostMessage(

--- a/src/cli/chat-import-host/chat-import-host-protocol.test.ts
+++ b/src/cli/chat-import-host/chat-import-host-protocol.test.ts
@@ -84,4 +84,26 @@ describe('processChatImportHostMessage', () => {
     )
     expect(res.type).toBe('ERROR')
   })
+
+  it('echoes the request _id back on the response', () => {
+    const db = tempDb()
+    const res = processChatImportHostMessage(
+      db,
+      JSON.stringify({ type: 'INGESTED_IDS', source: 'CHATGPT', _id: 42 }),
+      'now'
+    )
+    expect(res).toMatchObject({ type: 'INGESTED_IDS', externalIds: [], _id: 42 })
+  })
+
+  it('responds to PING with PONG (echoing _id)', () => {
+    const db = tempDb()
+    const res = processChatImportHostMessage(db, JSON.stringify({ type: 'PING', _id: 7 }), 'now')
+    expect(res).toEqual({ type: 'PONG', _id: 7 })
+  })
+
+  it('omits _id when the request has none', () => {
+    const db = tempDb()
+    const res = processChatImportHostMessage(db, JSON.stringify({ type: 'PING' }), 'now')
+    expect(res).toEqual({ type: 'PONG' })
+  })
 })

--- a/src/cli/chat-import-host/chat-import-host-protocol.test.ts
+++ b/src/cli/chat-import-host/chat-import-host-protocol.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { openChatImportDbForWrite } from '../../main/chat-import/chat-import-db-open'
+import { listIngestedExternalIds } from '../../main/chat-import/chat-import-store'
+import { processChatImportHostMessage } from './chat-import-host-protocol'
+
+let dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) {
+    rmSync(d, { recursive: true, force: true })
+  }
+  dirs = []
+})
+function tempDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-host-proto-'))
+  dirs.push(dir)
+  return openChatImportDbForWrite(join(dir, 'chats.db'))
+}
+
+describe('processChatImportHostMessage', () => {
+  it('INGEST stores the conversation and returns its id', () => {
+    const db = tempDb()
+    const conv = {
+      source: 'CHATGPT',
+      externalId: 'c1',
+      title: 'T',
+      createdAt: null,
+      updatedAt: null,
+      messages: [{ role: 'USER', idx: 0, text: 'hi', createdAt: null }]
+    }
+    const res = processChatImportHostMessage(db, JSON.stringify({ type: 'INGEST', conv }), 'now')
+    expect(res).toEqual({ type: 'INGEST', ok: true, id: 'CHATGPT/c1' })
+    expect(listIngestedExternalIds(db, 'CHATGPT')).toEqual(['c1'])
+  })
+
+  it('INGESTED_IDS returns stored ids for the source', () => {
+    const db = tempDb()
+    processChatImportHostMessage(
+      db,
+      JSON.stringify({
+        type: 'INGEST',
+        conv: {
+          source: 'CLAUDE',
+          externalId: 'a',
+          title: null,
+          createdAt: null,
+          updatedAt: null,
+          messages: []
+        }
+      }),
+      'now'
+    )
+    const res = processChatImportHostMessage(
+      db,
+      JSON.stringify({ type: 'INGESTED_IDS', source: 'CLAUDE' }),
+      'now'
+    )
+    expect(res).toEqual({ type: 'INGESTED_IDS', externalIds: ['a'] })
+  })
+
+  it('malformed JSON returns an ERROR, not a throw', () => {
+    const db = tempDb()
+    const res = processChatImportHostMessage(db, '{ not json', 'now')
+    expect(res.type).toBe('ERROR')
+  })
+
+  it('unknown type returns an ERROR', () => {
+    const db = tempDb()
+    const res = processChatImportHostMessage(db, JSON.stringify({ type: 'NOPE' }), 'now')
+    expect(res.type).toBe('ERROR')
+  })
+
+  it('INGEST with a bad source returns an ERROR', () => {
+    const db = tempDb()
+    const res = processChatImportHostMessage(
+      db,
+      JSON.stringify({
+        type: 'INGEST',
+        conv: { source: 'FACEBOOK', externalId: 'x', messages: [] }
+      }),
+      'now'
+    )
+    expect(res.type).toBe('ERROR')
+  })
+})

--- a/src/cli/chat-import-host/chat-import-host-protocol.ts
+++ b/src/cli/chat-import-host/chat-import-host-protocol.ts
@@ -7,9 +7,10 @@ import {
 } from '../../main/chat-import/chat-import-store'
 
 export type ChatImportHostResponse =
-  | { type: 'INGESTED_IDS'; externalIds: string[] }
-  | { type: 'INGEST'; ok: true; id: string }
-  | { type: 'ERROR'; error: string }
+  | { type: 'INGESTED_IDS'; externalIds: string[]; _id?: number | string }
+  | { type: 'INGEST'; ok: true; id: string; _id?: number | string }
+  | { type: 'PONG'; _id?: number | string }
+  | { type: 'ERROR'; error: string; _id?: number | string }
 
 const SOURCES: readonly WebChatSource[] = ['CHATGPT', 'CLAUDE', 'GEMINI']
 
@@ -68,22 +69,32 @@ export function processChatImportHostMessage(
     return { type: 'ERROR', error: 'not an object' }
   }
   const request = message as Record<string, unknown>
+  // Why: the extension correlates each response to its request via _id; echo it back.
+  const idField: { _id?: number | string } =
+    typeof request._id === 'number' || typeof request._id === 'string' ? { _id: request._id } : {}
+  const withId = (r: ChatImportHostResponse): ChatImportHostResponse => ({ ...r, ...idField })
   try {
+    if (request.type === 'PING') {
+      return withId({ type: 'PONG' })
+    }
     if (request.type === 'INGESTED_IDS') {
       if (!isSource(request.source)) {
-        return { type: 'ERROR', error: 'bad source' }
+        return withId({ type: 'ERROR', error: 'bad source' })
       }
-      return { type: 'INGESTED_IDS', externalIds: listIngestedExternalIds(db, request.source) }
+      return withId({
+        type: 'INGESTED_IDS',
+        externalIds: listIngestedExternalIds(db, request.source)
+      })
     }
     if (request.type === 'INGEST') {
       const conv = parseConversation(request.conv)
       if (!conv) {
-        return { type: 'ERROR', error: 'bad conversation' }
+        return withId({ type: 'ERROR', error: 'bad conversation' })
       }
-      return { type: 'INGEST', ok: true, id: upsertWebConversation(db, conv, syncedAt) }
+      return withId({ type: 'INGEST', ok: true, id: upsertWebConversation(db, conv, syncedAt) })
     }
-    return { type: 'ERROR', error: `unknown type: ${String(request.type)}` }
+    return withId({ type: 'ERROR', error: `unknown type: ${String(request.type)}` })
   } catch (err) {
-    return { type: 'ERROR', error: err instanceof Error ? err.message : String(err) }
+    return withId({ type: 'ERROR', error: err instanceof Error ? err.message : String(err) })
   }
 }

--- a/src/cli/chat-import-host/chat-import-host-protocol.ts
+++ b/src/cli/chat-import-host/chat-import-host-protocol.ts
@@ -1,0 +1,89 @@
+import type SyncDatabase from '../../main/sqlite/sync-database'
+import {
+  listIngestedExternalIds,
+  upsertWebConversation,
+  type WebChatSource,
+  type WebConversation
+} from '../../main/chat-import/chat-import-store'
+
+export type ChatImportHostResponse =
+  | { type: 'INGESTED_IDS'; externalIds: string[] }
+  | { type: 'INGEST'; ok: true; id: string }
+  | { type: 'ERROR'; error: string }
+
+const SOURCES: readonly WebChatSource[] = ['CHATGPT', 'CLAUDE', 'GEMINI']
+
+function isSource(value: unknown): value is WebChatSource {
+  return typeof value === 'string' && (SOURCES as readonly string[]).includes(value)
+}
+
+// Why: the conv arrives as untrusted JSON from the extension; validate the
+// shape before it reaches SQLite. Only M1 fields (text, no blocks/attachments).
+function parseConversation(value: unknown): WebConversation | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const c = value as Record<string, unknown>
+  if (!isSource(c.source) || typeof c.externalId !== 'string' || !Array.isArray(c.messages)) {
+    return null
+  }
+  const messages: WebConversation['messages'] = []
+  for (const raw of c.messages) {
+    if (!raw || typeof raw !== 'object') {
+      return null
+    }
+    const m = raw as Record<string, unknown>
+    if ((m.role !== 'USER' && m.role !== 'AI') || typeof m.idx !== 'number') {
+      return null
+    }
+    messages.push({
+      role: m.role,
+      idx: m.idx,
+      text: typeof m.text === 'string' ? m.text : null,
+      createdAt: typeof m.createdAt === 'string' ? m.createdAt : null
+    })
+  }
+  return {
+    source: c.source,
+    externalId: c.externalId,
+    title: typeof c.title === 'string' ? c.title : null,
+    createdAt: typeof c.createdAt === 'string' ? c.createdAt : null,
+    updatedAt: typeof c.updatedAt === 'string' ? c.updatedAt : null,
+    messages
+  }
+}
+
+export function processChatImportHostMessage(
+  db: SyncDatabase,
+  rawJson: string,
+  syncedAt: string
+): ChatImportHostResponse {
+  let message: unknown
+  try {
+    message = JSON.parse(rawJson)
+  } catch {
+    return { type: 'ERROR', error: 'invalid JSON' }
+  }
+  if (!message || typeof message !== 'object') {
+    return { type: 'ERROR', error: 'not an object' }
+  }
+  const request = message as Record<string, unknown>
+  try {
+    if (request.type === 'INGESTED_IDS') {
+      if (!isSource(request.source)) {
+        return { type: 'ERROR', error: 'bad source' }
+      }
+      return { type: 'INGESTED_IDS', externalIds: listIngestedExternalIds(db, request.source) }
+    }
+    if (request.type === 'INGEST') {
+      const conv = parseConversation(request.conv)
+      if (!conv) {
+        return { type: 'ERROR', error: 'bad conversation' }
+      }
+      return { type: 'INGEST', ok: true, id: upsertWebConversation(db, conv, syncedAt) }
+    }
+    return { type: 'ERROR', error: `unknown type: ${String(request.type)}` }
+  } catch (err) {
+    return { type: 'ERROR', error: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/src/cli/chat-import-host/chat-import-host-protocol.ts
+++ b/src/cli/chat-import-host/chat-import-host-protocol.ts
@@ -29,17 +29,26 @@ function parseConversation(value: unknown): WebConversation | null {
     return null
   }
   const messages: WebConversation['messages'] = []
+  // Why: idx becomes part of the message primary key (`${convId}#${idx}`), so a
+  // duplicate or non-integer idx would collide mid-insert and leave the
+  // conversation's messages half-replaced.
+  const seenIdx = new Set<number>()
   for (const raw of c.messages) {
     if (!raw || typeof raw !== 'object') {
       return null
     }
     const m = raw as Record<string, unknown>
-    if ((m.role !== 'USER' && m.role !== 'AI') || typeof m.idx !== 'number') {
+    if ((m.role !== 'USER' && m.role !== 'AI') || !Number.isInteger(m.idx)) {
       return null
     }
+    const idx = m.idx as number
+    if (seenIdx.has(idx)) {
+      return null
+    }
+    seenIdx.add(idx)
     messages.push({
       role: m.role,
-      idx: m.idx,
+      idx,
       text: typeof m.text === 'string' ? m.text : null,
       createdAt: typeof m.createdAt === 'string' ? m.createdAt : null
     })

--- a/src/cli/chat-import-host/install-native-messaging-host.test.ts
+++ b/src/cli/chat-import-host/install-native-messaging-host.test.ts
@@ -56,6 +56,33 @@ describe('installNativeMessagingHost (darwin)', () => {
     // launcher invokes the CLI host subcommand
     const launcher = readFileSync(result.launcherPath, 'utf8')
     expect(launcher).toContain('chat-import-host')
+    // ELECTRON_RUN_AS_NODE makes a packaged Electron binary behave like
+    // node; real node ignores the env var, so it's always safe to set.
+    expect(launcher).toContain('ELECTRON_RUN_AS_NODE=1')
+  })
+})
+
+describe('installNativeMessagingHost (linux)', () => {
+  it('writes an executable launcher and a manifest into the Chrome host dir', () => {
+    const home = tempHome()
+    const userData = join(home, '.config', 'orca')
+    const result = installNativeMessagingHost({
+      platform: 'linux',
+      homeDir: home,
+      userDataPath: userData,
+      browser: 'chrome',
+      extensionId: 'abcd',
+      execCommand: { command: '/usr/bin/node', args: ['/app/out/cli/index.js'] },
+      runRegistry: vi.fn()
+    })
+    expect(existsSync(result.launcherPath)).toBe(true)
+    const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8'))
+    expect(manifest.name).toBe(NATIVE_MESSAGING_HOST_NAME)
+    expect(manifest.path).toBe(result.launcherPath)
+    expect(result.manifestPath).toContain(join('.config', 'google-chrome', 'NativeMessagingHosts'))
+    const launcher = readFileSync(result.launcherPath, 'utf8')
+    expect(launcher).toContain('chat-import-host')
+    expect(launcher).toContain('ELECTRON_RUN_AS_NODE=1')
   })
 })
 
@@ -73,9 +100,31 @@ describe('installNativeMessagingHost (win32)', () => {
       runRegistry
     })
     expect(result.launcherPath.endsWith('.cmd')).toBe(true)
+    const launcher = readFileSync(result.launcherPath, 'utf8')
+    expect(launcher).toContain('set ELECTRON_RUN_AS_NODE=1')
     expect(runRegistry).toHaveBeenCalledWith(
       expect.stringContaining(
         `Software\\Google\\Chrome\\NativeMessagingHosts\\${NATIVE_MESSAGING_HOST_NAME}`
+      ),
+      result.manifestPath
+    )
+  })
+
+  it('registers under the Edge registry hive when --browser edge is used', () => {
+    const home = tempHome()
+    const runRegistry = vi.fn()
+    const result = installNativeMessagingHost({
+      platform: 'win32',
+      homeDir: home,
+      userDataPath: join(home, 'AppData', 'Roaming', 'orca'),
+      browser: 'edge',
+      extensionId: 'abcd',
+      execCommand: { command: 'C:\\app\\orca.exe', args: [] },
+      runRegistry
+    })
+    expect(runRegistry).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Software\\Microsoft\\Edge\\NativeMessagingHosts\\${NATIVE_MESSAGING_HOST_NAME}`
       ),
       result.manifestPath
     )

--- a/src/cli/chat-import-host/install-native-messaging-host.test.ts
+++ b/src/cli/chat-import-host/install-native-messaging-host.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  NATIVE_MESSAGING_HOST_NAME,
+  buildNativeMessagingManifest
+} from './native-messaging-manifest'
+import { installNativeMessagingHost } from './install-native-messaging-host'
+
+let dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) {
+    rmSync(d, { recursive: true, force: true })
+  }
+  dirs = []
+})
+function tempHome() {
+  const d = mkdtempSync(join(tmpdir(), 'orca-nmh-'))
+  dirs.push(d)
+  return d
+}
+
+describe('buildNativeMessagingManifest', () => {
+  it('produces a stdio manifest scoped to the extension origin', () => {
+    const m = buildNativeMessagingManifest({ launcherPath: '/x/launch.sh', extensionId: 'abcd' })
+    expect(m).toMatchObject({
+      name: NATIVE_MESSAGING_HOST_NAME,
+      type: 'stdio',
+      path: '/x/launch.sh',
+      allowed_origins: ['chrome-extension://abcd/']
+    })
+  })
+})
+
+describe('installNativeMessagingHost (darwin)', () => {
+  it('writes an executable launcher and a manifest into the Chrome host dir', () => {
+    const home = tempHome()
+    const userData = join(home, 'Library', 'Application Support', 'orca')
+    const result = installNativeMessagingHost({
+      platform: 'darwin',
+      homeDir: home,
+      userDataPath: userData,
+      browser: 'chrome',
+      extensionId: 'abcd',
+      execCommand: { command: '/usr/bin/node', args: ['/app/out/cli/index.js'] },
+      runRegistry: vi.fn()
+    })
+    expect(existsSync(result.launcherPath)).toBe(true)
+    const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8'))
+    expect(manifest.name).toBe(NATIVE_MESSAGING_HOST_NAME)
+    expect(manifest.path).toBe(result.launcherPath)
+    expect(result.manifestPath).toContain(
+      join('Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts')
+    )
+    // launcher invokes the CLI host subcommand
+    const launcher = readFileSync(result.launcherPath, 'utf8')
+    expect(launcher).toContain('chat-import-host')
+  })
+})
+
+describe('installNativeMessagingHost (win32)', () => {
+  it('writes a .cmd launcher and registers the manifest via reg add', () => {
+    const home = tempHome()
+    const runRegistry = vi.fn()
+    const result = installNativeMessagingHost({
+      platform: 'win32',
+      homeDir: home,
+      userDataPath: join(home, 'AppData', 'Roaming', 'orca'),
+      browser: 'chrome',
+      extensionId: 'abcd',
+      execCommand: { command: 'C:\\app\\orca.exe', args: [] },
+      runRegistry
+    })
+    expect(result.launcherPath.endsWith('.cmd')).toBe(true)
+    expect(runRegistry).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Software\\Google\\Chrome\\NativeMessagingHosts\\${NATIVE_MESSAGING_HOST_NAME}`
+      ),
+      result.manifestPath
+    )
+  })
+})

--- a/src/cli/chat-import-host/install-native-messaging-host.ts
+++ b/src/cli/chat-import-host/install-native-messaging-host.ts
@@ -13,7 +13,8 @@ export type InstallOptions = {
   userDataPath: string
   browser: InstallBrowser
   extensionId: string
-  // The command the launcher should exec: dev = node + cli entry, packaged = orca binary.
+  // The command the launcher should exec — always execPath + the CLI entry
+  // script; see resolveHostExecCommand for why there's no dev/packaged split.
   execCommand: { command: string; args: string[] }
   // Injected so Windows registry writes are testable.
   runRegistry: (registryKey: string, manifestPath: string) => void
@@ -30,6 +31,15 @@ const BROWSER_DIR: Record<InstallBrowser, { darwin: string[]; linux: string[] }>
     linux: ['BraveSoftware', 'Brave-Browser']
   },
   chromium: { darwin: ['Chromium'], linux: ['chromium'] }
+}
+
+// Per-browser registry hive under HKCU, mirroring BROWSER_DIR for Windows —
+// each Chromium-based browser reads NativeMessagingHosts from its own hive.
+const WINDOWS_REGISTRY_BASE: Record<InstallBrowser, string> = {
+  chrome: 'Software\\Google\\Chrome',
+  edge: 'Software\\Microsoft\\Edge',
+  brave: 'Software\\BraveSoftware\\Brave-Browser',
+  chromium: 'Software\\Chromium'
 }
 
 function hostDir(options: InstallOptions): string {
@@ -53,17 +63,19 @@ function writeLauncher(options: InstallOptions): string {
   const quotedArgs = options.execCommand.args.map((a) => `"${a}"`).join(' ')
   if (options.platform === 'win32') {
     const launcherPath = join(dir, `${NATIVE_MESSAGING_HOST_NAME}.cmd`)
-    // %* forwards the origin/handle args Chrome appends.
+    // %* forwards the origin/handle args Chrome appends. ELECTRON_RUN_AS_NODE
+    // makes a packaged Electron binary run as plain node; real node ignores
+    // the env var, so setting it unconditionally is safe in dev too.
     writeFileSync(
       launcherPath,
-      `@echo off\r\n"${options.execCommand.command}" ${quotedArgs} chat-import-host %*\r\n`
+      `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${options.execCommand.command}" ${quotedArgs} chat-import-host %*\r\n`
     )
     return launcherPath
   }
   const launcherPath = join(dir, `${NATIVE_MESSAGING_HOST_NAME}.sh`)
   writeFileSync(
     launcherPath,
-    `#!/bin/sh\nexec "${options.execCommand.command}" ${quotedArgs} chat-import-host "$@"\n`
+    `#!/bin/sh\nELECTRON_RUN_AS_NODE=1 exec "${options.execCommand.command}" ${quotedArgs} chat-import-host "$@"\n`
   )
   chmodSync(launcherPath, 0o755)
   return launcherPath
@@ -74,12 +86,13 @@ export function installNativeMessagingHost(options: InstallOptions): InstallResu
   const manifest = buildNativeMessagingManifest({ launcherPath, extensionId: options.extensionId })
 
   if (options.platform === 'win32') {
-    // Windows: manifest lives on disk; the registry value points Chrome at it.
+    // Windows: manifest lives on disk; the registry value under the
+    // browser's own hive points that browser at it.
     const dir = join(options.userDataPath, 'chat-import')
     const manifestPath = join(dir, `${NATIVE_MESSAGING_HOST_NAME}.json`)
     writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
     options.runRegistry(
-      `HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\${NATIVE_MESSAGING_HOST_NAME}`,
+      `HKCU\\${WINDOWS_REGISTRY_BASE[options.browser]}\\NativeMessagingHosts\\${NATIVE_MESSAGING_HOST_NAME}`,
       manifestPath
     )
     return { launcherPath, manifestPath }

--- a/src/cli/chat-import-host/install-native-messaging-host.ts
+++ b/src/cli/chat-import-host/install-native-messaging-host.ts
@@ -1,0 +1,93 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  buildNativeMessagingManifest,
+  NATIVE_MESSAGING_HOST_NAME
+} from './native-messaging-manifest'
+
+export type InstallBrowser = 'chrome' | 'edge' | 'brave' | 'chromium'
+
+export type InstallOptions = {
+  platform: NodeJS.Platform
+  homeDir: string
+  userDataPath: string
+  browser: InstallBrowser
+  extensionId: string
+  // The command the launcher should exec: dev = node + cli entry, packaged = orca binary.
+  execCommand: { command: string; args: string[] }
+  // Injected so Windows registry writes are testable.
+  runRegistry: (registryKey: string, manifestPath: string) => void
+}
+
+export type InstallResult = { launcherPath: string; manifestPath: string }
+
+// Per-browser NativeMessagingHosts directory, relative to the OS config root.
+const BROWSER_DIR: Record<InstallBrowser, { darwin: string[]; linux: string[] }> = {
+  chrome: { darwin: ['Google', 'Chrome'], linux: ['google-chrome'] },
+  edge: { darwin: ['Microsoft Edge'], linux: ['microsoft-edge'] },
+  brave: {
+    darwin: ['BraveSoftware', 'Brave-Browser'],
+    linux: ['BraveSoftware', 'Brave-Browser']
+  },
+  chromium: { darwin: ['Chromium'], linux: ['chromium'] }
+}
+
+function hostDir(options: InstallOptions): string {
+  const seg = BROWSER_DIR[options.browser]
+  if (options.platform === 'darwin') {
+    return join(
+      options.homeDir,
+      'Library',
+      'Application Support',
+      ...seg.darwin,
+      'NativeMessagingHosts'
+    )
+  }
+  // linux
+  return join(options.homeDir, '.config', ...seg.linux, 'NativeMessagingHosts')
+}
+
+function writeLauncher(options: InstallOptions): string {
+  const dir = join(options.userDataPath, 'chat-import')
+  mkdirSync(dir, { recursive: true })
+  const quotedArgs = options.execCommand.args.map((a) => `"${a}"`).join(' ')
+  if (options.platform === 'win32') {
+    const launcherPath = join(dir, `${NATIVE_MESSAGING_HOST_NAME}.cmd`)
+    // %* forwards the origin/handle args Chrome appends.
+    writeFileSync(
+      launcherPath,
+      `@echo off\r\n"${options.execCommand.command}" ${quotedArgs} chat-import-host %*\r\n`
+    )
+    return launcherPath
+  }
+  const launcherPath = join(dir, `${NATIVE_MESSAGING_HOST_NAME}.sh`)
+  writeFileSync(
+    launcherPath,
+    `#!/bin/sh\nexec "${options.execCommand.command}" ${quotedArgs} chat-import-host "$@"\n`
+  )
+  chmodSync(launcherPath, 0o755)
+  return launcherPath
+}
+
+export function installNativeMessagingHost(options: InstallOptions): InstallResult {
+  const launcherPath = writeLauncher(options)
+  const manifest = buildNativeMessagingManifest({ launcherPath, extensionId: options.extensionId })
+
+  if (options.platform === 'win32') {
+    // Windows: manifest lives on disk; the registry value points Chrome at it.
+    const dir = join(options.userDataPath, 'chat-import')
+    const manifestPath = join(dir, `${NATIVE_MESSAGING_HOST_NAME}.json`)
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
+    options.runRegistry(
+      `HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\${NATIVE_MESSAGING_HOST_NAME}`,
+      manifestPath
+    )
+    return { launcherPath, manifestPath }
+  }
+
+  const dir = hostDir(options)
+  mkdirSync(dir, { recursive: true })
+  const manifestPath = join(dir, `${NATIVE_MESSAGING_HOST_NAME}.json`)
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
+  return { launcherPath, manifestPath }
+}

--- a/src/cli/chat-import-host/native-messaging-frame.test.ts
+++ b/src/cli/chat-import-host/native-messaging-frame.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  encodeNativeMessage,
+  NativeMessageDecoder,
+  NativeMessageFrameError,
+  MAX_FRAME_BYTES
+} from './native-messaging-frame'
+
+describe('native messaging framing', () => {
+  it('round-trips a single message', () => {
+    const encoded = encodeNativeMessage({ type: 'INGEST', ok: true })
+    // 4-byte LE length prefix + UTF-8 JSON body.
+    const bodyLen = encoded.readUInt32LE(0)
+    expect(encoded.length).toBe(4 + bodyLen)
+    const decoder = new NativeMessageDecoder()
+    const out = decoder.feed(encoded)
+    expect(out).toHaveLength(1)
+    expect(JSON.parse(out[0])).toEqual({ type: 'INGEST', ok: true })
+  })
+
+  it('reassembles a message split across chunks', () => {
+    const encoded = encodeNativeMessage({ a: 1, b: 'two' })
+    const decoder = new NativeMessageDecoder()
+    expect(decoder.feed(encoded.subarray(0, 3))).toEqual([])
+    expect(decoder.feed(encoded.subarray(3, 6))).toEqual([])
+    const out = decoder.feed(encoded.subarray(6))
+    expect(JSON.parse(out[0])).toEqual({ a: 1, b: 'two' })
+  })
+
+  it('yields multiple messages from one chunk', () => {
+    const buf = Buffer.concat([encodeNativeMessage({ n: 1 }), encodeNativeMessage({ n: 2 })])
+    const out = new NativeMessageDecoder().feed(buf)
+    expect(out.map((s) => JSON.parse(s))).toEqual([{ n: 1 }, { n: 2 }])
+  })
+
+  it('throws on an oversized length prefix', () => {
+    const header = Buffer.alloc(4)
+    header.writeUInt32LE(MAX_FRAME_BYTES + 1, 0)
+    expect(() => new NativeMessageDecoder().feed(header)).toThrow(NativeMessageFrameError)
+  })
+})

--- a/src/cli/chat-import-host/native-messaging-frame.test.ts
+++ b/src/cli/chat-import-host/native-messaging-frame.test.ts
@@ -3,7 +3,8 @@ import {
   encodeNativeMessage,
   NativeMessageDecoder,
   NativeMessageFrameError,
-  MAX_FRAME_BYTES
+  MAX_FRAME_BYTES,
+  MAX_OUTBOUND_FRAME_BYTES
 } from './native-messaging-frame'
 
 describe('native messaging framing', () => {
@@ -37,5 +38,24 @@ describe('native messaging framing', () => {
     const header = Buffer.alloc(4)
     header.writeUInt32LE(MAX_FRAME_BYTES + 1, 0)
     expect(() => new NativeMessageDecoder().feed(header)).toThrow(NativeMessageFrameError)
+  })
+
+  it('carries frames decoded before an oversized one in the same chunk', () => {
+    const bad = Buffer.alloc(4)
+    bad.writeUInt32LE(MAX_FRAME_BYTES + 1, 0)
+    const chunk = Buffer.concat([encodeNativeMessage({ n: 1 }), bad])
+    try {
+      new NativeMessageDecoder().feed(chunk)
+      expect.unreachable('feed should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(NativeMessageFrameError)
+      const frames = (err as NativeMessageFrameError).decodedFrames
+      expect(frames.map((s) => JSON.parse(s))).toEqual([{ n: 1 }])
+    }
+  })
+
+  it('refuses to encode a frame over Chrome’s 1 MB inbound limit', () => {
+    const tooBig = { pad: 'x'.repeat(MAX_OUTBOUND_FRAME_BYTES) }
+    expect(() => encodeNativeMessage(tooBig)).toThrow(NativeMessageFrameError)
   })
 })

--- a/src/cli/chat-import-host/native-messaging-frame.ts
+++ b/src/cli/chat-import-host/native-messaging-frame.ts
@@ -1,0 +1,42 @@
+// Chrome native messaging framing: a 4-byte little-endian length prefix
+// followed by that many bytes of UTF-8 JSON. Args cannot be passed to a
+// native host, so this framing is the only channel.
+const LENGTH_PREFIX_BYTES = 4
+
+// Chrome caps one message at ~1 MB; this ceiling only guards against a
+// corrupt prefix demanding a huge allocation.
+export const MAX_FRAME_BYTES = 64 * 1024 * 1024
+
+export class NativeMessageFrameError extends Error {}
+
+export function encodeNativeMessage(value: unknown): Buffer {
+  const payload = Buffer.from(JSON.stringify(value), 'utf8')
+  const header = Buffer.allocUnsafe(LENGTH_PREFIX_BYTES)
+  header.writeUInt32LE(payload.length, 0)
+  return Buffer.concat([header, payload])
+}
+
+// Streaming decoder: framing lives here, JSON validity is the caller's job
+// (returns raw UTF-8 strings so a malformed body becomes an error response,
+// not a decoder crash).
+export class NativeMessageDecoder {
+  private buffer: Buffer = Buffer.alloc(0)
+
+  feed(chunk: Buffer): string[] {
+    this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk])
+    const messages: string[] = []
+    while (this.buffer.length >= LENGTH_PREFIX_BYTES) {
+      const length = this.buffer.readUInt32LE(0)
+      if (length > MAX_FRAME_BYTES) {
+        throw new NativeMessageFrameError(`frame length ${length} exceeds ${MAX_FRAME_BYTES}`)
+      }
+      if (this.buffer.length < LENGTH_PREFIX_BYTES + length) {
+        break
+      }
+      const payload = this.buffer.subarray(LENGTH_PREFIX_BYTES, LENGTH_PREFIX_BYTES + length)
+      this.buffer = this.buffer.subarray(LENGTH_PREFIX_BYTES + length)
+      messages.push(payload.toString('utf8'))
+    }
+    return messages
+  }
+}

--- a/src/cli/chat-import-host/native-messaging-frame.ts
+++ b/src/cli/chat-import-host/native-messaging-frame.ts
@@ -7,10 +7,28 @@ const LENGTH_PREFIX_BYTES = 4
 // corrupt prefix demanding a huge allocation.
 export const MAX_FRAME_BYTES = 64 * 1024 * 1024
 
-export class NativeMessageFrameError extends Error {}
+// Chrome rejects a host->browser message over 1 MB and drops the connection,
+// so refuse to emit one rather than lose the pipe mid-response.
+export const MAX_OUTBOUND_FRAME_BYTES = 1024 * 1024
+
+export class NativeMessageFrameError extends Error {
+  // Why: frames decoded before the bad one in the same chunk are still valid;
+  // carry them so the caller can act on them before ending the connection.
+  constructor(
+    message: string,
+    readonly decodedFrames: string[] = []
+  ) {
+    super(message)
+  }
+}
 
 export function encodeNativeMessage(value: unknown): Buffer {
   const payload = Buffer.from(JSON.stringify(value), 'utf8')
+  if (payload.length > MAX_OUTBOUND_FRAME_BYTES) {
+    throw new NativeMessageFrameError(
+      `outbound frame ${payload.length} exceeds ${MAX_OUTBOUND_FRAME_BYTES}`
+    )
+  }
   const header = Buffer.allocUnsafe(LENGTH_PREFIX_BYTES)
   header.writeUInt32LE(payload.length, 0)
   return Buffer.concat([header, payload])
@@ -28,7 +46,10 @@ export class NativeMessageDecoder {
     while (this.buffer.length >= LENGTH_PREFIX_BYTES) {
       const length = this.buffer.readUInt32LE(0)
       if (length > MAX_FRAME_BYTES) {
-        throw new NativeMessageFrameError(`frame length ${length} exceeds ${MAX_FRAME_BYTES}`)
+        throw new NativeMessageFrameError(
+          `frame length ${length} exceeds ${MAX_FRAME_BYTES}`,
+          messages
+        )
       }
       if (this.buffer.length < LENGTH_PREFIX_BYTES + length) {
         break

--- a/src/cli/chat-import-host/native-messaging-manifest.ts
+++ b/src/cli/chat-import-host/native-messaging-manifest.ts
@@ -1,0 +1,23 @@
+export const NATIVE_MESSAGING_HOST_NAME = 'com.orca.chatimport'
+
+export type NativeMessagingManifest = {
+  name: string
+  description: string
+  path: string
+  type: 'stdio'
+  allowed_origins: string[]
+}
+
+export function buildNativeMessagingManifest(args: {
+  launcherPath: string
+  extensionId: string
+}): NativeMessagingManifest {
+  return {
+    name: NATIVE_MESSAGING_HOST_NAME,
+    description: 'Orca web chat import native messaging host',
+    path: args.launcherPath,
+    type: 'stdio',
+    // Chrome requires a trailing slash on the extension origin.
+    allowed_origins: [`chrome-extension://${args.extensionId}/`]
+  }
+}

--- a/src/cli/chat-import-host/resolve-host-exec-command.test.ts
+++ b/src/cli/chat-import-host/resolve-host-exec-command.test.ts
@@ -11,25 +11,43 @@ describe('resolveHostExecCommand', () => {
     })
   })
 
-  it('resolves a packaged orca binary to a direct exec with no args', () => {
-    const result = resolveHostExecCommand('/usr/local/bin/orca', '/usr/local/bin/orca')
-    expect(result).toEqual({ command: '/usr/local/bin/orca', args: [] })
+  it('resolves a packaged macOS Electron binary the same way — no packaging branch', () => {
+    // The packaged launcher execs Contents/MacOS/Orca (the Electron binary),
+    // not something named "orca" — this must never be treated as a
+    // direct-exec case, which used to launch the GUI instead of the host.
+    const execPath = '/Applications/Orca.app/Contents/MacOS/Orca'
+    const argv1 = '/Applications/Orca.app/Contents/Resources/app.asar.unpacked/out/cli/index.js'
+    const result = resolveHostExecCommand(execPath, argv1)
+    expect(result).toEqual({ command: execPath, args: [resolve(argv1)] })
   })
 
-  it('treats orca-dev as a packaged binary too', () => {
-    const result = resolveHostExecCommand('/opt/orca/orca-dev', '/opt/orca/orca-dev')
-    expect(result).toEqual({ command: '/opt/orca/orca-dev', args: [] })
+  it('resolves a packaged linux Electron binary named orca-ide the same way', () => {
+    const execPath = '/opt/Orca/orca-ide'
+    const argv1 = '/opt/Orca/resources/app.asar.unpacked/out/cli/index.js'
+    const result = resolveHostExecCommand(execPath, argv1)
+    expect(result).toEqual({ command: execPath, args: [resolve(argv1)] })
   })
 
-  it('is case-insensitive and strips .exe on Windows packaged binaries', () => {
-    const result = resolveHostExecCommand('C:\\Programs\\Orca\\orca.exe', 'ignored')
-    expect(result).toEqual({ command: 'C:\\Programs\\Orca\\orca.exe', args: [] })
+  it('treats a plain "orca" binary name the same as any other execPath', () => {
+    const result = resolveHostExecCommand('/usr/local/bin/orca', 'out/cli/index.js')
+    expect(result).toEqual({
+      command: '/usr/local/bin/orca',
+      args: [resolve('out/cli/index.js')]
+    })
   })
 
   it('resolves a Windows dev (node.exe) process to node + the CLI entry script', () => {
     const result = resolveHostExecCommand('C:\\node\\node.exe', 'out\\cli\\index.js')
     expect(result).toEqual({
       command: 'C:\\node\\node.exe',
+      args: [resolve('out\\cli\\index.js')]
+    })
+  })
+
+  it('resolves a Windows packaged orca.exe the same way — no packaging branch', () => {
+    const result = resolveHostExecCommand('C:\\Programs\\Orca\\orca.exe', 'out\\cli\\index.js')
+    expect(result).toEqual({
+      command: 'C:\\Programs\\Orca\\orca.exe',
       args: [resolve('out\\cli\\index.js')]
     })
   })

--- a/src/cli/chat-import-host/resolve-host-exec-command.test.ts
+++ b/src/cli/chat-import-host/resolve-host-exec-command.test.ts
@@ -1,0 +1,36 @@
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveHostExecCommand } from './resolve-host-exec-command'
+
+describe('resolveHostExecCommand', () => {
+  it('resolves a dev (node) process to node + the CLI entry script', () => {
+    const result = resolveHostExecCommand('/usr/local/bin/node', 'out/cli/index.js')
+    expect(result).toEqual({
+      command: '/usr/local/bin/node',
+      args: [resolve('out/cli/index.js')]
+    })
+  })
+
+  it('resolves a packaged orca binary to a direct exec with no args', () => {
+    const result = resolveHostExecCommand('/usr/local/bin/orca', '/usr/local/bin/orca')
+    expect(result).toEqual({ command: '/usr/local/bin/orca', args: [] })
+  })
+
+  it('treats orca-dev as a packaged binary too', () => {
+    const result = resolveHostExecCommand('/opt/orca/orca-dev', '/opt/orca/orca-dev')
+    expect(result).toEqual({ command: '/opt/orca/orca-dev', args: [] })
+  })
+
+  it('is case-insensitive and strips .exe on Windows packaged binaries', () => {
+    const result = resolveHostExecCommand('C:\\Programs\\Orca\\orca.exe', 'ignored')
+    expect(result).toEqual({ command: 'C:\\Programs\\Orca\\orca.exe', args: [] })
+  })
+
+  it('resolves a Windows dev (node.exe) process to node + the CLI entry script', () => {
+    const result = resolveHostExecCommand('C:\\node\\node.exe', 'out\\cli\\index.js')
+    expect(result).toEqual({
+      command: 'C:\\node\\node.exe',
+      args: [resolve('out\\cli\\index.js')]
+    })
+  })
+})

--- a/src/cli/chat-import-host/resolve-host-exec-command.ts
+++ b/src/cli/chat-import-host/resolve-host-exec-command.ts
@@ -1,0 +1,24 @@
+import { resolve } from 'node:path'
+
+export type HostExecCommand = { command: string; args: string[] }
+
+// Why: execPath can be a Windows-style path even when this runs on a posix
+// dev machine's test suite, so the executable name is split on both
+// separators instead of relying on node:path's platform-specific basename.
+function executableName(execPath: string): string {
+  const segments = execPath.split(/[/\\]/)
+  const fileName = segments.at(-1) ?? ''
+  return fileName.replace(/\.exe$/i, '').toLowerCase()
+}
+
+// Why: the CLI has no Electron `app.isPackaged` signal, so packaging is
+// inferred from the running binary's name — a packaged `orca`/`orca-dev`
+// binary execs directly, while a dev (node) run needs the CLI entry script
+// passed as an argument. This is a heuristic, not a reliable packaging
+// check: see install-native-messaging-host.ts install handler notes.
+export function resolveHostExecCommand(execPath: string, argv1: string): HostExecCommand {
+  if (executableName(execPath).startsWith('orca')) {
+    return { command: execPath, args: [] }
+  }
+  return { command: execPath, args: [resolve(argv1)] }
+}

--- a/src/cli/chat-import-host/resolve-host-exec-command.ts
+++ b/src/cli/chat-import-host/resolve-host-exec-command.ts
@@ -2,23 +2,12 @@ import { resolve } from 'node:path'
 
 export type HostExecCommand = { command: string; args: string[] }
 
-// Why: execPath can be a Windows-style path even when this runs on a posix
-// dev machine's test suite, so the executable name is split on both
-// separators instead of relying on node:path's platform-specific basename.
-function executableName(execPath: string): string {
-  const segments = execPath.split(/[/\\]/)
-  const fileName = segments.at(-1) ?? ''
-  return fileName.replace(/\.exe$/i, '').toLowerCase()
-}
-
-// Why: the CLI has no Electron `app.isPackaged` signal, so packaging is
-// inferred from the running binary's name — a packaged `orca`/`orca-dev`
-// binary execs directly, while a dev (node) run needs the CLI entry script
-// passed as an argument. This is a heuristic, not a reliable packaging
-// check: see install-native-messaging-host.ts install handler notes.
+// Why: dev (execPath = node) and packaged (execPath = the Electron binary,
+// launched with ELECTRON_RUN_AS_NODE=1 by the launcher script) both run the
+// CLI entry script directly, so no packaging heuristic is needed here. A
+// prior name-based heuristic ("orca*" execs directly) misidentified the
+// packaged binary — .../MacOS/Orca — and dropped the CLI entry arg entirely,
+// which made the launcher start the Orca GUI instead of the host process.
 export function resolveHostExecCommand(execPath: string, argv1: string): HostExecCommand {
-  if (executableName(execPath).startsWith('orca')) {
-    return { command: execPath, args: [] }
-  }
   return { command: execPath, args: [resolve(argv1)] }
 }

--- a/src/cli/chat-import-host/run-chat-import-host.test.ts
+++ b/src/cli/chat-import-host/run-chat-import-host.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it } from 'vitest'
+import { encodeNativeMessage, NativeMessageDecoder } from './native-messaging-frame'
+import { runChatImportHost } from './run-chat-import-host'
+
+let dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) {
+    rmSync(d, { recursive: true, force: true })
+  }
+  dirs = []
+})
+
+describe('runChatImportHost', () => {
+  it('reads a framed INGEST and writes a framed response', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-host-run-'))
+    dirs.push(dir)
+    const dbPath = join(dir, 'chats.db')
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const responses: unknown[] = []
+    const decoder = new NativeMessageDecoder()
+    output.on('data', (chunk: Buffer) => {
+      for (const raw of decoder.feed(chunk)) {
+        responses.push(JSON.parse(raw))
+      }
+    })
+
+    const done = runChatImportHost({ input, output, dbPath, now: () => 'now' })
+    input.write(
+      encodeNativeMessage({
+        type: 'INGEST',
+        conv: {
+          source: 'CHATGPT',
+          externalId: 'c1',
+          title: 'T',
+          createdAt: null,
+          updatedAt: null,
+          messages: [{ role: 'USER', idx: 0, text: 'hi', createdAt: null }]
+        }
+      })
+    )
+    input.end()
+    await done
+
+    expect(responses).toEqual([{ type: 'INGEST', ok: true, id: 'CHATGPT/c1' }])
+  })
+})

--- a/src/cli/chat-import-host/run-chat-import-host.test.ts
+++ b/src/cli/chat-import-host/run-chat-import-host.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
 import { afterEach, describe, expect, it } from 'vitest'
-import { encodeNativeMessage, NativeMessageDecoder } from './native-messaging-frame'
+import {
+  encodeNativeMessage,
+  MAX_FRAME_BYTES,
+  NativeMessageDecoder
+} from './native-messaging-frame'
 import { runChatImportHost } from './run-chat-import-host'
 
 let dirs: string[] = []
@@ -47,5 +51,32 @@ describe('runChatImportHost', () => {
     await done
 
     expect(responses).toEqual([{ type: 'INGEST', ok: true, id: 'CHATGPT/c1' }])
+  })
+
+  // Why: an oversized frame throws mid-decode inside the 'data' handler, then the
+  // stream's natural 'end' event fires right after — finish() must not run twice
+  // (double db.close() crashes the host with ERR_INVALID_STATE).
+  it('responds with ERROR and shuts down cleanly on an oversized frame', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-host-run-'))
+    dirs.push(dir)
+    const dbPath = join(dir, 'chats.db')
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const responses: Record<string, unknown>[] = []
+    const decoder = new NativeMessageDecoder()
+    output.on('data', (chunk: Buffer) => {
+      for (const raw of decoder.feed(chunk)) {
+        responses.push(JSON.parse(raw))
+      }
+    })
+
+    const done = runChatImportHost({ input, output, dbPath, now: () => 'now' })
+    const header = Buffer.alloc(4)
+    header.writeUInt32LE(MAX_FRAME_BYTES + 1, 0)
+    input.write(header)
+    input.end()
+
+    await expect(done).resolves.toBeUndefined()
+    expect(responses.some((r) => r.type === 'ERROR')).toBe(true)
   })
 })

--- a/src/cli/chat-import-host/run-chat-import-host.test.ts
+++ b/src/cli/chat-import-host/run-chat-import-host.test.ts
@@ -79,4 +79,38 @@ describe('runChatImportHost', () => {
     await expect(done).resolves.toBeUndefined()
     expect(responses.some((r) => r.type === 'ERROR')).toBe(true)
   })
+
+  // Why: a response can exceed Chrome's 1 MB outbound limit (e.g. a large
+  // INGESTED_IDS list). encodeNativeMessage throws on such a payload; the host
+  // must answer ERROR rather than let the exception crash it mid-'data'.
+  it('responds with ERROR instead of crashing when a response exceeds the outbound limit', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-host-run-'))
+    dirs.push(dir)
+    const dbPath = join(dir, 'chats.db')
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const responses: Record<string, unknown>[] = []
+    const decoder = new NativeMessageDecoder()
+    output.on('data', (chunk: Buffer) => {
+      for (const raw of decoder.feed(chunk)) {
+        responses.push(JSON.parse(raw))
+      }
+    })
+
+    const done = runChatImportHost({ input, output, dbPath, now: () => 'now' })
+    // PING echoes _id back; an oversized _id pushes the PONG response past the
+    // 1 MB outbound limit, so encoding it throws. The inbound frame is built by
+    // hand because encodeNativeMessage itself enforces the outbound cap.
+    const payload = Buffer.from(
+      JSON.stringify({ type: 'PING', _id: 'x'.repeat(1024 * 1024 + 64) }),
+      'utf8'
+    )
+    const header = Buffer.alloc(4)
+    header.writeUInt32LE(payload.length, 0)
+    input.write(Buffer.concat([header, payload]))
+    input.end()
+
+    await expect(done).resolves.toBeUndefined()
+    expect(responses.some((r) => r.type === 'ERROR')).toBe(true)
+  })
 })

--- a/src/cli/chat-import-host/run-chat-import-host.ts
+++ b/src/cli/chat-import-host/run-chat-import-host.ts
@@ -40,7 +40,21 @@ export function runChatImportHost(options: {
       }
     }
     const respond = (raw: string): void => {
-      options.output.write(encodeNativeMessage(processChatImportHostMessage(db, raw, now())))
+      const response = processChatImportHostMessage(db, raw, now())
+      let frame: Buffer
+      try {
+        frame = encodeNativeMessage(response)
+      } catch (err) {
+        // Why: a response can exceed Chrome's 1 MB outbound limit (e.g. a large
+        // INGESTED_IDS list). encodeNativeMessage throws rather than emit a frame
+        // the browser would drop; answer with a small ERROR frame instead of
+        // letting the exception crash the host inside the 'data' listener.
+        frame = encodeNativeMessage({
+          type: 'ERROR',
+          error: err instanceof Error ? err.message : String(err)
+        })
+      }
+      options.output.write(frame)
     }
     options.input.on('data', (chunk: Buffer) => {
       let frames: string[]

--- a/src/cli/chat-import-host/run-chat-import-host.ts
+++ b/src/cli/chat-import-host/run-chat-import-host.ts
@@ -1,0 +1,49 @@
+import { openChatImportDbForWrite } from '../../main/chat-import/chat-import-db-open'
+import { processChatImportHostMessage } from './chat-import-host-protocol'
+import {
+  encodeNativeMessage,
+  NativeMessageDecoder,
+  NativeMessageFrameError
+} from './native-messaging-frame'
+
+// Why: a short-lived native host owns stdin/stdout for one browser session.
+// Streams are injected so tests drive it without real pipes.
+export function runChatImportHost(options: {
+  input: NodeJS.ReadableStream
+  output: NodeJS.WritableStream
+  dbPath: string
+  now?: () => string
+}): Promise<void> {
+  const db = openChatImportDbForWrite(options.dbPath)
+  const decoder = new NativeMessageDecoder()
+  const now = options.now ?? (() => new Date().toISOString())
+
+  return new Promise<void>((resolve, reject) => {
+    const finish = (err?: Error): void => {
+      db.close()
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    }
+    options.input.on('data', (chunk: Buffer) => {
+      let frames: string[]
+      try {
+        frames = decoder.feed(chunk)
+      } catch (err) {
+        // Corrupt framing is unrecoverable for this connection.
+        if (err instanceof NativeMessageFrameError) {
+          options.output.write(encodeNativeMessage({ type: 'ERROR', error: err.message }))
+        }
+        finish(err instanceof Error ? err : new Error(String(err)))
+        return
+      }
+      for (const raw of frames) {
+        options.output.write(encodeNativeMessage(processChatImportHostMessage(db, raw, now())))
+      }
+    })
+    options.input.on('end', () => finish())
+    options.input.on('error', (err) => finish(err instanceof Error ? err : new Error(String(err))))
+  })
+}

--- a/src/cli/chat-import-host/run-chat-import-host.ts
+++ b/src/cli/chat-import-host/run-chat-import-host.ts
@@ -39,6 +39,9 @@ export function runChatImportHost(options: {
         resolve()
       }
     }
+    const respond = (raw: string): void => {
+      options.output.write(encodeNativeMessage(processChatImportHostMessage(db, raw, now())))
+    }
     options.input.on('data', (chunk: Buffer) => {
       let frames: string[]
       try {
@@ -48,6 +51,8 @@ export function runChatImportHost(options: {
           // Corrupt framing is unrecoverable for this connection, but the ERROR
           // frame already told the caller what happened — end cleanly rather
           // than reject, since nothing else went wrong at the process level.
+          // Frames decoded before the bad one are intact, so answer them first.
+          err.decodedFrames.forEach(respond)
           options.output.write(encodeNativeMessage({ type: 'ERROR', error: err.message }))
           finish()
         } else {
@@ -55,9 +60,7 @@ export function runChatImportHost(options: {
         }
         return
       }
-      for (const raw of frames) {
-        options.output.write(encodeNativeMessage(processChatImportHostMessage(db, raw, now())))
-      }
+      frames.forEach(respond)
     })
     options.input.on('end', () => finish())
     options.input.on('error', (err) => finish(err instanceof Error ? err : new Error(String(err))))

--- a/src/cli/chat-import-host/run-chat-import-host.ts
+++ b/src/cli/chat-import-host/run-chat-import-host.ts
@@ -19,7 +19,19 @@ export function runChatImportHost(options: {
   const now = options.now ?? (() => new Date().toISOString())
 
   return new Promise<void>((resolve, reject) => {
+    // Why: 'data' (framing-error branch), 'end', and 'error' can each fire finish()
+    // for the same connection (e.g. an oversized frame throws, then the stream's
+    // natural 'end' follows) — without a guard, a second db.close() throws
+    // ERR_INVALID_STATE and crashes the host.
+    let finished = false
     const finish = (err?: Error): void => {
+      if (finished) {
+        return
+      }
+      finished = true
+      options.input.removeAllListeners('data')
+      options.input.removeAllListeners('end')
+      options.input.removeAllListeners('error')
       db.close()
       if (err) {
         reject(err)
@@ -32,11 +44,15 @@ export function runChatImportHost(options: {
       try {
         frames = decoder.feed(chunk)
       } catch (err) {
-        // Corrupt framing is unrecoverable for this connection.
         if (err instanceof NativeMessageFrameError) {
+          // Corrupt framing is unrecoverable for this connection, but the ERROR
+          // frame already told the caller what happened — end cleanly rather
+          // than reject, since nothing else went wrong at the process level.
           options.output.write(encodeNativeMessage({ type: 'ERROR', error: err.message }))
+          finish()
+        } else {
+          finish(err instanceof Error ? err : new Error(String(err)))
         }
-        finish(err instanceof Error ? err : new Error(String(err)))
         return
       }
       for (const raw of frames) {

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -2,6 +2,7 @@ import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime-client'
 import { CORE_HANDLERS } from './handlers/core'
 import { AUTOMATION_HANDLERS } from './handlers/automations'
+import { CHAT_IMPORT_HOST_HANDLERS } from './handlers/chat-import-host'
 import { PROJECT_HANDLERS } from './handlers/project'
 import { REPO_HANDLERS } from './handlers/repo'
 import { WORKTREE_HANDLERS } from './handlers/worktree'
@@ -41,6 +42,7 @@ function buildHandlers(): Map<string, CommandHandler> {
   const groups = [
     CORE_HANDLERS,
     AUTOMATION_HANDLERS,
+    CHAT_IMPORT_HOST_HANDLERS,
     PROJECT_HANDLERS,
     REPO_HANDLERS,
     WORKTREE_HANDLERS,

--- a/src/cli/handlers/chat-import-host.ts
+++ b/src/cli/handlers/chat-import-host.ts
@@ -1,0 +1,15 @@
+import { chatImportDbPath } from '../../main/chat-import/chat-import-paths'
+import { runChatImportHost } from '../chat-import-host/run-chat-import-host'
+import type { CommandHandler } from '../dispatch'
+
+export const CHAT_IMPORT_HOST_HANDLERS: Record<string, CommandHandler> = {
+  // Why: stdout is the native-messaging channel to the browser, so this
+  // handler must never share it with ordinary CLI logging/JSON output.
+  'chat-import-host': async () => {
+    await runChatImportHost({
+      input: process.stdin,
+      output: process.stdout,
+      dbPath: chatImportDbPath()
+    })
+  }
+}

--- a/src/cli/handlers/chat-import-host.ts
+++ b/src/cli/handlers/chat-import-host.ts
@@ -1,6 +1,70 @@
+import { execFileSync } from 'node:child_process'
+import { homedir } from 'node:os'
 import { chatImportDbPath } from '../../main/chat-import/chat-import-paths'
 import { runChatImportHost } from '../chat-import-host/run-chat-import-host'
+import {
+  installNativeMessagingHost,
+  type InstallBrowser,
+  type InstallResult
+} from '../chat-import-host/install-native-messaging-host'
+import { resolveHostExecCommand } from '../chat-import-host/resolve-host-exec-command'
 import type { CommandHandler } from '../dispatch'
+import { printResult } from '../format'
+import { getDefaultUserDataPath, RuntimeClientError } from '../runtime-client'
+import type { RuntimeRpcSuccess } from '../runtime-client'
+
+const INSTALL_BROWSERS: readonly InstallBrowser[] = ['chrome', 'edge', 'brave', 'chromium']
+
+// Why: HKCU is per-user and needs no elevation; mirrors the reg.exe query
+// pattern in windows-environment-path.ts but for a registry write.
+function runWindowsRegistryAdd(registryKey: string, manifestPath: string): void {
+  execFileSync('reg.exe', ['add', registryKey, '/ve', '/t', 'REG_SZ', '/d', manifestPath, '/f'], {
+    windowsHide: true
+  })
+}
+
+function getInstallBrowser(flags: Map<string, string | boolean>): InstallBrowser {
+  const raw = flags.get('browser')
+  if (raw === undefined) {
+    return 'chrome'
+  }
+  if (typeof raw !== 'string' || !INSTALL_BROWSERS.includes(raw as InstallBrowser)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `--browser must be one of: ${INSTALL_BROWSERS.join(', ')}`
+    )
+  }
+  return raw as InstallBrowser
+}
+
+function getExtensionId(flags: Map<string, string | boolean>): string {
+  const raw = flags.get('extension-id')
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Missing required --extension-id. Open chrome://extensions, copy the loaded extension ID, then pass it with --extension-id.'
+    )
+  }
+  return raw
+}
+
+function localSuccess<TResult>(result: TResult): RuntimeRpcSuccess<TResult> {
+  return {
+    id: 'local',
+    ok: true,
+    result,
+    _meta: { runtimeId: 'local' }
+  }
+}
+
+function formatInstallResult(browser: InstallBrowser, result: InstallResult): string {
+  return [
+    `Installed the chat-import native-messaging host for ${browser}.`,
+    `  launcher: ${result.launcherPath}`,
+    `  manifest: ${result.manifestPath}`,
+    'Reload the extension (chrome://extensions -> Reload) to pick up the new host.'
+  ].join('\n')
+}
 
 export const CHAT_IMPORT_HOST_HANDLERS: Record<string, CommandHandler> = {
   // Why: stdout is the native-messaging channel to the browser, so this
@@ -11,5 +75,22 @@ export const CHAT_IMPORT_HOST_HANDLERS: Record<string, CommandHandler> = {
       output: process.stdout,
       dbPath: chatImportDbPath()
     })
+  },
+  // Why: unlike the host handler above, this is a regular CLI command run
+  // interactively by the user (or the extension's setup flow), so ordinary
+  // stdout logging/JSON output is fine here.
+  'chat-import-host install': async ({ flags, json }) => {
+    const extensionId = getExtensionId(flags)
+    const browser = getInstallBrowser(flags)
+    const result = installNativeMessagingHost({
+      platform: process.platform,
+      homeDir: homedir(),
+      userDataPath: getDefaultUserDataPath(),
+      browser,
+      extensionId,
+      execCommand: resolveHostExecCommand(process.execPath, process.argv[1] ?? ''),
+      runRegistry: runWindowsRegistryAdd
+    })
+    printResult(localSuccess(result), json, (r) => formatInstallResult(browser, r))
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,7 +25,8 @@ function shouldIgnoreRemoteSelection(commandPath: string[]): boolean {
     commandPath[0] === 'serve' ||
     commandPath[0] === 'agent' ||
     commandPath[0] === 'vm' ||
-    commandPath[0] === 'agent-context'
+    commandPath[0] === 'agent-context' ||
+    commandPath[0] === 'chat-import-host'
   )
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import {
   specPaths,
   validateCommandAndFlags
 } from './args'
+import { isChatImportHostRun } from './chat-import-host/chat-import-host-argv'
 import { dispatch } from './dispatch'
 import { reportCliError } from './format'
 import { printHelp } from './help'
@@ -49,6 +50,14 @@ export async function main(
   }
   if (argv[0] === 'claude-teams') {
     await runClaudeTeams(argv.slice(1), cwd)
+    return
+  }
+  // Why: Chrome appends the extension origin (and, on Windows,
+  // --parent-window) to the launch argv, which the normal parser mistakes
+  // for an unknown subcommand/flag — route straight to the handler and skip
+  // parsing those args entirely, mirroring the claude-teams passthrough above.
+  if (isChatImportHostRun(argv)) {
+    await runChatImportHostLaunch(cwd)
     return
   }
   const parsed = normalizeCommandPositionals(COMMAND_SPECS, parseArgs(argv, COMMAND_PATHS))
@@ -122,6 +131,24 @@ async function runClaudeTeams(argv: string[], cwd: string): Promise<void> {
     })
   } catch (error) {
     reportCliError(error, false, { commandPath: ['claude-teams'] })
+    process.exitCode = 1
+  }
+}
+
+async function runChatImportHostLaunch(cwd: string): Promise<void> {
+  try {
+    // Why: the host owns stdin/stdout as the native-messaging channel and
+    // never resolves a remote runtime, so pairing-code/environment selection
+    // must stay suppressed here just like the ordinary dispatch path.
+    const client = new RuntimeClient(undefined, undefined, null, null)
+    await dispatch(['chat-import-host'], {
+      flags: new Map(),
+      client,
+      cwd,
+      json: false
+    })
+  } catch (error) {
+    reportCliError(error, false, { commandPath: ['chat-import-host'] })
     process.exitCode = 1
   }
 }

--- a/src/cli/specs/chat-import-host.ts
+++ b/src/cli/specs/chat-import-host.ts
@@ -8,5 +8,12 @@ export const CHAT_IMPORT_HOST_COMMAND_SPECS: CommandSpec[] = [
     summary: 'Run the browser native-messaging host for web chat import',
     usage: 'orca chat-import-host',
     allowedFlags: []
+  },
+  {
+    path: ['chat-import-host', 'install'],
+    summary: 'Register the native-messaging host manifest so the browser can launch it',
+    usage:
+      'orca chat-import-host install --extension-id <id> [--browser chrome|edge|brave|chromium]',
+    allowedFlags: ['extension-id', 'browser']
   }
 ]

--- a/src/cli/specs/chat-import-host.ts
+++ b/src/cli/specs/chat-import-host.ts
@@ -1,0 +1,12 @@
+import type { CommandSpec } from '../args'
+
+export const CHAT_IMPORT_HOST_COMMAND_SPECS: CommandSpec[] = [
+  {
+    path: ['chat-import-host'],
+    // Why: launched by the browser over stdin/stdout as a native-messaging
+    // host, not meant for interactive/manual invocation.
+    summary: 'Run the browser native-messaging host for web chat import',
+    usage: 'orca chat-import-host',
+    allowedFlags: []
+  }
+]

--- a/src/cli/specs/index.ts
+++ b/src/cli/specs/index.ts
@@ -9,6 +9,7 @@ import { ORCHESTRATION_COMMAND_SPECS } from './orchestration'
 import { COMPUTER_COMMAND_SPECS } from './computer'
 import { ENVIRONMENT_COMMAND_SPECS } from './environment'
 import { AGENT_HOOK_COMMAND_SPECS } from './agent-hooks'
+import { CHAT_IMPORT_HOST_COMMAND_SPECS } from './chat-import-host'
 import { DIAGNOSTICS_COMMAND_SPECS } from './diagnostics'
 import { EMULATOR_COMMAND_SPECS } from './emulator'
 import { INTROSPECTION_COMMAND_SPECS } from './introspection'
@@ -26,6 +27,7 @@ export const COMMAND_SPECS: CommandSpec[] = [
   ...ORCHESTRATION_COMMAND_SPECS,
   ...COMPUTER_COMMAND_SPECS,
   ...AGENT_HOOK_COMMAND_SPECS,
+  ...CHAT_IMPORT_HOST_COMMAND_SPECS,
   ...DIAGNOSTICS_COMMAND_SPECS,
   ...INTROSPECTION_COMMAND_SPECS,
   ...ENVIRONMENT_COMMAND_SPECS,

--- a/src/main/ai-vault/runtime-session-scanner.test.ts
+++ b/src/main/ai-vault/runtime-session-scanner.test.ts
@@ -142,6 +142,7 @@ function session(
     queuedMessageCount: 0,
     subagentTranscriptCount: 0,
     resumeCommand: `codex resume ${sessionId}`,
+    readOnly: false,
     subagent: null
   }
 }

--- a/src/main/ai-vault/runtime-session-scanner.ts
+++ b/src/main/ai-vault/runtime-session-scanner.ts
@@ -76,6 +76,9 @@ const aiVaultListResultSchema = z.object({
       queuedMessageCount: z.number().default(0),
       subagentTranscriptCount: z.number().default(0),
       resumeCommand: z.string(),
+      // The default keeps remote hosts running an older build (no readOnly
+      // field) parseable; pre-web-chat-import sessions were never read-only.
+      readOnly: z.boolean().default(false),
       // The default keeps remote hosts running an older build (no subagent
       // field) parseable; scanned top-level sessions carry null anyway.
       subagent: z

--- a/src/main/ai-vault/session-scanner-accumulator.test.ts
+++ b/src/main/ai-vault/session-scanner-accumulator.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { createAccumulator, finalizeSession } from './session-scanner-accumulator'
+
+describe('finalizeSession readOnly', () => {
+  it('defaults readOnly to false and carries an explicit true through', () => {
+    const base = {
+      agent: 'claude' as const,
+      file: { path: '/x', mtimeMs: 1, modifiedAt: 'z' },
+      sessionId: 's'
+    }
+    const acc = createAccumulator(base)
+    acc.messageCount = 1
+    expect(finalizeSession(acc, 'darwin')?.readOnly).toBe(false)
+
+    const acc2 = createAccumulator(base)
+    acc2.messageCount = 1
+    acc2.readOnly = true
+    expect(finalizeSession(acc2, 'darwin')?.readOnly).toBe(true)
+  })
+})

--- a/src/main/ai-vault/session-scanner-accumulator.ts
+++ b/src/main/ai-vault/session-scanner-accumulator.ts
@@ -43,7 +43,8 @@ export function createAccumulator(args: {
     previewMessages: [],
     queuedMessageCount: 0,
     subagentTranscriptCount: 0,
-    latestTimestampMs: 0
+    latestTimestampMs: 0,
+    readOnly: false
   }
 }
 
@@ -122,6 +123,7 @@ export function finalizeSession(
       platform,
       codexHome: options.codexHome
     }),
+    readOnly: accumulator.readOnly,
     subagent: null
   }
 }

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -10,6 +10,7 @@ import { parseOpenCodeSqliteSession } from './session-scanner-opencode-sqlite'
 import { parseClaudeSessionFile } from './session-scanner-primary-parsers'
 import { parseGeminiSessionFile } from './session-scanner-gemini-parsers'
 import { parseCodexSessionFile } from './session-scanner-codex-parser'
+import { parseWebChatSqliteSession } from './session-scanner-webchat-sqlite'
 import {
   parseCopilotSessionFile,
   parseCursorSessionFile,
@@ -76,5 +77,23 @@ export async function parseAgentSessionFile(
       return parseDevinSessionFile(candidate.file, platform)
     case 'kimi':
       return parseKimiSessionFile(candidate.file, platform)
+    case 'chatgpt':
+    case 'claude-web':
+    case 'gemini-web': {
+      // Why: web candidates carry a synthetic <dbPath>#<source>/<externalId> path
+      // (built by listWebChatCandidates); recover the parts to read the row back.
+      const hashIndex = candidate.file.path.lastIndexOf('#')
+      const dbPath = candidate.file.path.slice(0, hashIndex)
+      const convId = candidate.file.path.slice(hashIndex + 1)
+      const slashIndex = convId.indexOf('/')
+      const source = convId.slice(0, slashIndex)
+      const externalId = convId.slice(slashIndex + 1)
+      return parseWebChatSqliteSession({
+        dbPath,
+        sessionId: externalId,
+        source: source as 'CHATGPT' | 'CLAUDE' | 'GEMINI',
+        platform
+      })
+    }
   }
 }

--- a/src/main/ai-vault/session-scanner-codex-workers.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-workers.test.ts
@@ -122,6 +122,9 @@ describe('scanAiVaultSessions Codex worker sessions', () => {
       droidSessionsDir: join(root, 'droid-sessions'),
       droidProjectsDir: join(root, 'droid-projects'),
       kimiSessionsDir: join(root, 'kimi-sessions'),
+      // Why: keep the scan off the real chat-import chats.db so imported web
+      // chats can't leak into this exact-match assertion.
+      webchatDbPath: join(root, 'webchat', 'chats.db'),
       platform: 'darwin'
     })
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -38,7 +38,10 @@ function isolatedScanRoots(root: string) {
     droidSessionsDir: join(root, 'droid-sessions'),
     droidProjectsDir: join(root, 'droid-projects'),
     kimiSessionsDir: join(root, 'kimi-sessions'),
-    ompSessionsDir: join(root, 'omp-sessions')
+    ompSessionsDir: join(root, 'omp-sessions'),
+    // Why: keep the scan off the real chat-import chats.db (same concern as
+    // opencodeDbPaths above).
+    webchatDbPath: join(root, 'webchat', 'chats.db')
   }
 }
 

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -40,8 +40,9 @@ type SessionParseCacheEntry = {
 // Incremental append-parsing applies only to transcripts that are append-only
 // JSONL line-folds. Whole-JSON documents (grok/rovo/devin/hermes/gemini-json)
 // are rewritten in place, Kimi reads a state doc plus a sibling wire file, and
-// OpenCode reads SQLite rows or a doc plus a message dir — those formats keep
-// unchanged-file reuse only and re-parse whole when they change.
+// OpenCode and web chat (chatgpt/claude-web/gemini-web) read SQLite rows or a
+// doc plus a message dir — those formats keep unchanged-file reuse only and
+// re-parse whole when they change.
 // Returns a factory (not a state) so steady-state resumes, which clone the
 // cached state instead, never pay for a throwaway accumulator.
 function resumableStateFactoryFor(
@@ -76,6 +77,9 @@ function resumableStateFactoryFor(
     case 'kimi':
     case 'opencode':
     case 'rovo':
+    case 'chatgpt':
+    case 'claude-web':
+    case 'gemini-web':
       return null
   }
 }

--- a/src/main/ai-vault/session-scanner-scope.test.ts
+++ b/src/main/ai-vault/session-scanner-scope.test.ts
@@ -34,6 +34,7 @@ function scopedScanOptions(claudeProjectsDir: string, extra: Partial<AiVaultScan
     droidSessionsDir: '/nonexistent/droid',
     droidProjectsDir: '/nonexistent/droid-projects',
     kimiSessionsDir: '/nonexistent/kimi',
+    webchatDbPath: '/nonexistent/webchat',
     ...extra
   } satisfies AiVaultScanOptions
 }

--- a/src/main/ai-vault/session-scanner-test-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-test-fixtures.ts
@@ -1,5 +1,8 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { initChatImportSchema } from '../chat-import/chat-import-schema'
+import { upsertWebConversation, type WebChatSource } from '../chat-import/chat-import-store'
+import SyncDatabase from '../sqlite/sync-database'
 
 export function isolatedScanRoots(root: string) {
   return {
@@ -23,7 +26,10 @@ export function isolatedScanRoots(root: string) {
     ompSessionsDir: join(root, 'omp-sessions'),
     droidSessionsDir: join(root, 'droid-sessions'),
     droidProjectsDir: join(root, 'droid-projects'),
-    kimiSessionsDir: join(root, 'kimi-sessions')
+    kimiSessionsDir: join(root, 'kimi-sessions'),
+    // Why: prevent the webchat scanner from picking up the real chat-import
+    // chats.db (see opencodeDbPaths above for the same concern).
+    webchatDbPath: join(root, 'webchat', 'chats.db')
   }
 }
 
@@ -68,4 +74,36 @@ export function writeAntigravityScannerFixture(
       content: 'Done'
     }
   ])
+}
+
+// [source, externalId, title] — createdAt/updatedAt are synthesized (index-ordered,
+// 2026-05-01) since tests only assert presence/agent/title, not exact timestamps.
+type WebChatConversationSeed = readonly [source: WebChatSource, externalId: string, title: string]
+
+// Why: web chat sessions live in a chat-import SQLite DB, not on the
+// filesystem, so tests that exercise scanAiVaultSessions need a DB seeder
+// instead of writeJsonlFile.
+export async function seedWebChatDb(
+  dbPath: string,
+  conversations: readonly WebChatConversationSeed[]
+): Promise<void> {
+  await mkdir(dirname(dbPath), { recursive: true })
+  const db = new SyncDatabase(dbPath)
+  initChatImportSchema(db)
+  conversations.forEach(([source, externalId, title], index) => {
+    const updatedAt = `2026-05-01T10:${String(10 + index).padStart(2, '0')}:01.000Z`
+    upsertWebConversation(
+      db,
+      {
+        source,
+        externalId,
+        title,
+        createdAt: `2026-05-01T10:${String(10 + index).padStart(2, '0')}:00.000Z`,
+        updatedAt,
+        messages: [{ role: 'USER', idx: 0, text: title, createdAt: null }]
+      },
+      updatedAt
+    )
+  })
+  db.close()
 }

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -30,6 +30,9 @@ export type AiVaultScanOptions = {
   droidSessionsDir?: string
   droidProjectsDir?: string
   kimiSessionsDir?: string
+  // Why: chat-import SQLite DB path for imported web conversations (ChatGPT/
+  // Claude.ai/Gemini). Tests inject a temp DB; unset falls back to chatImportDbPath().
+  webchatDbPath?: string
   limit?: number
   limitPerAgent?: number
   // Active workspace/project paths whose sessions must be included regardless of

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -106,6 +106,7 @@ export type SessionAccumulator = {
   queuedMessageCount: number
   subagentTranscriptCount: number
   latestTimestampMs: number
+  readOnly: boolean
 }
 
 export type CodexUsageSnapshot = {

--- a/src/main/ai-vault/session-scanner-webchat-integration.test.ts
+++ b/src/main/ai-vault/session-scanner-webchat-integration.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import SyncDatabase from '../sqlite/sync-database'
+import { initChatImportSchema } from '../chat-import/chat-import-schema'
+import { upsertWebConversation } from '../chat-import/chat-import-store'
+import { scanAiVaultSessions } from './session-scanner'
+
+let dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) {
+    rmSync(d, { recursive: true, force: true })
+  }
+  dirs = []
+})
+
+describe('scanAiVaultSessions web chat', () => {
+  it('surfaces web conversations as read-only sessions', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-webchat-int-'))
+    dirs.push(dir)
+    const dbPath = join(dir, 'chats.db')
+    const db = new SyncDatabase(dbPath)
+    initChatImportSchema(db)
+    upsertWebConversation(
+      db,
+      {
+        source: 'CHATGPT',
+        externalId: 'c1',
+        title: 'Web title',
+        createdAt: null,
+        updatedAt: '2026-07-05T00:00:00.000Z',
+        messages: [
+          { role: 'USER', idx: 0, text: 'q', createdAt: null },
+          { role: 'AI', idx: 1, text: 'a', createdAt: null }
+        ]
+      },
+      'now'
+    )
+    db.close()
+
+    const result = await scanAiVaultSessions({ platform: 'darwin', webchatDbPath: dbPath })
+    const web = result.sessions.filter((s) => s.agent === 'chatgpt')
+    expect(web).toHaveLength(1)
+    expect(web[0]).toMatchObject({
+      title: 'Web title',
+      readOnly: true,
+      resumeCommand: '',
+      cwd: null,
+      messageCount: 2
+    })
+  })
+})

--- a/src/main/ai-vault/session-scanner-webchat-sources.test.ts
+++ b/src/main/ai-vault/session-scanner-webchat-sources.test.ts
@@ -59,4 +59,29 @@ describe('listWebChatCandidates', () => {
   it('returns empty when the db is missing', () => {
     expect(listWebChatCandidates({ dbPath: '/no/such/chats.db', issues: [] })).toEqual([])
   })
+
+  it('falls back to synced_at for mtimeMs when updated_at and created_at are both null', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-webchat-src-'))
+    dirs.push(dir)
+    const dbPath = join(dir, 'chats.db')
+    const db = new SyncDatabase(dbPath)
+    initChatImportSchema(db)
+    upsertWebConversation(
+      db,
+      {
+        source: 'CHATGPT',
+        externalId: 'c',
+        title: 't3',
+        createdAt: null,
+        updatedAt: null,
+        messages: []
+      },
+      '2026-07-03T00:00:00.000Z'
+    )
+    db.close()
+
+    const cands = listWebChatCandidates({ dbPath, issues: [] })
+    expect(cands).toHaveLength(1)
+    expect(cands[0]?.file.mtimeMs).toBe(Date.parse('2026-07-03T00:00:00.000Z'))
+  })
 })

--- a/src/main/ai-vault/session-scanner-webchat-sources.test.ts
+++ b/src/main/ai-vault/session-scanner-webchat-sources.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import SyncDatabase from '../sqlite/sync-database'
+import { initChatImportSchema } from '../chat-import/chat-import-schema'
+import { upsertWebConversation } from '../chat-import/chat-import-store'
+import { listWebChatCandidates } from './session-scanner-webchat-sources'
+
+let dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) {
+    rmSync(d, { recursive: true, force: true })
+  }
+  dirs = []
+})
+
+describe('listWebChatCandidates', () => {
+  it('lists one candidate per web conversation, agent by source', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-webchat-src-'))
+    dirs.push(dir)
+    const dbPath = join(dir, 'chats.db')
+    const db = new SyncDatabase(dbPath)
+    initChatImportSchema(db)
+    upsertWebConversation(
+      db,
+      {
+        source: 'CHATGPT',
+        externalId: 'a',
+        title: 't',
+        createdAt: null,
+        updatedAt: '2026-07-02T00:00:00.000Z',
+        messages: []
+      },
+      'now'
+    )
+    upsertWebConversation(
+      db,
+      {
+        source: 'GEMINI',
+        externalId: 'b',
+        title: 't2',
+        createdAt: null,
+        updatedAt: '2026-07-01T00:00:00.000Z',
+        messages: []
+      },
+      'now'
+    )
+    db.close()
+
+    const cands = listWebChatCandidates({ dbPath, issues: [] })
+    expect(cands.map((c) => c.agent).sort()).toEqual(['chatgpt', 'gemini-web'])
+    // 최신 updated_at 우선 정렬
+    expect(cands[0]?.agent).toBe('chatgpt')
+    expect(cands[0]?.file.path).toBe(`${dbPath}#CHATGPT/a`)
+    expect(cands.every((c) => c.codexHome === null)).toBe(true)
+  })
+
+  it('returns empty when the db is missing', () => {
+    expect(listWebChatCandidates({ dbPath: '/no/such/chats.db', issues: [] })).toEqual([])
+  })
+})

--- a/src/main/ai-vault/session-scanner-webchat-sources.ts
+++ b/src/main/ai-vault/session-scanner-webchat-sources.ts
@@ -1,0 +1,68 @@
+import { existsSync } from 'node:fs'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import type { SessionFileCandidate } from './session-scanner-types'
+import SyncDatabase from '../sqlite/sync-database'
+import { tableExists } from '../opencode-usage/schema-helpers'
+import { errorMessage } from './session-scanner-values'
+
+const SOURCE_TO_AGENT = { CHATGPT: 'chatgpt', CLAUDE: 'claude-web', GEMINI: 'gemini-web' } as const
+
+type Row = {
+  id: string
+  source: string
+  external_id: string
+  updated_at: string | null
+  created_at: string | null
+}
+
+/**
+ * List one session candidate per imported web conversation, read from the
+ * chat-import SQLite DB. Each candidate's agent is derived from that
+ * conversation's own source column (chatgpt/claude-web/gemini-web can be
+ * mixed in a single DB), and its synthetic path is `<dbPath>#<source>/<externalId>`
+ * so `parseAgentSessionFile` can route it back to `parseWebChatSqliteSession`.
+ */
+export function listWebChatCandidates(args: {
+  dbPath: string
+  issues: AiVaultScanIssue[]
+}): SessionFileCandidate[] {
+  if (!existsSync(args.dbPath)) {
+    return []
+  }
+  let db: SyncDatabase | null = null
+  try {
+    db = new SyncDatabase(args.dbPath, { readonly: true, fileMustExist: true })
+    db.pragma('query_only = ON')
+    if (!tableExists(db, 'conversations')) {
+      return []
+    }
+    const rows = db
+      .prepare(
+        `SELECT id, source, external_id, updated_at, created_at FROM conversations
+         WHERE source IN ('CHATGPT','CLAUDE','GEMINI')
+         ORDER BY COALESCE(updated_at, created_at, synced_at) DESC`
+      )
+      .all() as Row[]
+    return rows
+      .filter(
+        (r): r is Row & { source: keyof typeof SOURCE_TO_AGENT } => r.source in SOURCE_TO_AGENT
+      )
+      .map((r) => {
+        const mtimeMs = Date.parse(r.updated_at ?? r.created_at ?? '') || 0
+        return {
+          agent: SOURCE_TO_AGENT[r.source],
+          file: {
+            path: `${args.dbPath}#${r.id}`,
+            mtimeMs,
+            modifiedAt: mtimeMs ? new Date(mtimeMs).toISOString() : new Date(0).toISOString()
+          },
+          codexHome: null
+        }
+      })
+  } catch (err) {
+    args.issues.push({ agent: 'chatgpt', path: args.dbPath, message: errorMessage(err) })
+    return []
+  } finally {
+    db?.close()
+  }
+}

--- a/src/main/ai-vault/session-scanner-webchat-sources.ts
+++ b/src/main/ai-vault/session-scanner-webchat-sources.ts
@@ -13,6 +13,7 @@ type Row = {
   external_id: string
   updated_at: string | null
   created_at: string | null
+  synced_at: string | null
 }
 
 /**
@@ -38,7 +39,7 @@ export function listWebChatCandidates(args: {
     }
     const rows = db
       .prepare(
-        `SELECT id, source, external_id, updated_at, created_at FROM conversations
+        `SELECT id, source, external_id, updated_at, created_at, synced_at FROM conversations
          WHERE source IN ('CHATGPT','CLAUDE','GEMINI')
          ORDER BY COALESCE(updated_at, created_at, synced_at) DESC`
       )
@@ -48,7 +49,9 @@ export function listWebChatCandidates(args: {
         (r): r is Row & { source: keyof typeof SOURCE_TO_AGENT } => r.source in SOURCE_TO_AGENT
       )
       .map((r) => {
-        const mtimeMs = Date.parse(r.updated_at ?? r.created_at ?? '') || 0
+        // Why: SQL ORDER BY 폴백(updated_at→created_at→synced_at)과 mtimeMs를 일치시켜
+        // 둘 다 null인 대화가 최하위(mtimeMs=0)로 밀려 파싱 전 드롭되지 않게 한다.
+        const mtimeMs = Date.parse(r.updated_at ?? r.created_at ?? r.synced_at ?? '') || 0
         return {
           agent: SOURCE_TO_AGENT[r.source],
           file: {

--- a/src/main/ai-vault/session-scanner-webchat-sqlite.test.ts
+++ b/src/main/ai-vault/session-scanner-webchat-sqlite.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import SyncDatabase from '../sqlite/sync-database'
+import { initChatImportSchema } from '../chat-import/chat-import-schema'
+import { upsertWebConversation } from '../chat-import/chat-import-store'
+import { parseWebChatSqliteSession } from './session-scanner-webchat-sqlite'
+
+let dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) {
+    rmSync(d, { recursive: true, force: true })
+  }
+  dirs = []
+})
+function seed(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-webchat-'))
+  dirs.push(dir)
+  const path = join(dir, 'chats.db')
+  const db = new SyncDatabase(path)
+  initChatImportSchema(db)
+  upsertWebConversation(
+    db,
+    {
+      source: 'CHATGPT',
+      externalId: 'conv1',
+      title: 'My web chat',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:10:00.000Z',
+      messages: [
+        { role: 'USER', idx: 0, text: 'hello', createdAt: null },
+        { role: 'AI', idx: 1, text: 'hi there', createdAt: null }
+      ]
+    },
+    '2026-07-13T00:00:00.000Z'
+  )
+  db.close()
+  return path
+}
+
+describe('parseWebChatSqliteSession', () => {
+  it('maps a web conversation to a read-only AiVaultSession', () => {
+    const path = seed()
+    const s = parseWebChatSqliteSession({
+      dbPath: path,
+      sessionId: 'conv1',
+      source: 'CHATGPT',
+      platform: 'darwin'
+    })
+    expect(s).not.toBeNull()
+    expect(s?.agent).toBe('chatgpt')
+    expect(s?.readOnly).toBe(true)
+    expect(s?.title).toBe('My web chat')
+    expect(s?.resumeCommand).toBe('')
+    expect(s?.cwd).toBeNull()
+    expect(s?.messageCount).toBe(2)
+    expect(s?.previewMessages.map((m) => m.role)).toEqual(['user', 'assistant'])
+    expect(s?.updatedAt).toBe('2026-07-01T00:10:00.000Z')
+  })
+
+  it('returns null when the conversation id is absent', () => {
+    const path = seed()
+    expect(
+      parseWebChatSqliteSession({
+        dbPath: path,
+        sessionId: 'missing',
+        source: 'CHATGPT',
+        platform: 'darwin'
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/ai-vault/session-scanner-webchat-sqlite.ts
+++ b/src/main/ai-vault/session-scanner-webchat-sqlite.ts
@@ -21,7 +21,9 @@ type ConvRow = { title: string | null; created_at: string | null; updated_at: st
 type MsgRow = { role: string; text: string | null; created_at: string | null }
 
 function openReadonly(dbPath: string): SyncDatabase {
-  const db = new SyncDatabase(dbPath, { readonly: true, fileMustExist: true })
+  // Why: query_only (not OS readonly) so we can safely read a WAL-mode DB
+  // written by the native host — an OS-readonly handle can't attach the -shm.
+  const db = new SyncDatabase(dbPath, { fileMustExist: true })
   db.pragma('query_only = ON')
   return db
 }

--- a/src/main/ai-vault/session-scanner-webchat-sqlite.ts
+++ b/src/main/ai-vault/session-scanner-webchat-sqlite.ts
@@ -1,0 +1,82 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { WebChatSource } from '../chat-import/chat-import-store'
+import {
+  addPreviewMessage,
+  createAccumulator,
+  finalizeSession,
+  updateTimeline
+} from './session-scanner-accumulator'
+import { normalizeTitleText } from './session-scanner-values'
+import SyncDatabase from '../sqlite/sync-database'
+import { tableExists } from '../opencode-usage/schema-helpers'
+import { statSync } from 'node:fs'
+
+const SOURCE_TO_AGENT = {
+  CHATGPT: 'chatgpt',
+  CLAUDE: 'claude-web',
+  GEMINI: 'gemini-web'
+} as const
+
+type ConvRow = { title: string | null; created_at: string | null; updated_at: string | null }
+type MsgRow = { role: string; text: string | null; created_at: string | null }
+
+function openReadonly(dbPath: string): SyncDatabase {
+  const db = new SyncDatabase(dbPath, { readonly: true, fileMustExist: true })
+  db.pragma('query_only = ON')
+  return db
+}
+
+export function parseWebChatSqliteSession(args: {
+  dbPath: string
+  sessionId: string
+  source: WebChatSource
+  platform: NodeJS.Platform
+}): AiVaultSession | null {
+  let db: SyncDatabase | null = null
+  try {
+    db = openReadonly(args.dbPath)
+    if (!tableExists(db, 'conversations') || !tableExists(db, 'messages')) {
+      return null
+    }
+    const convId = `${args.source}/${args.sessionId}`
+    const conv = db
+      .prepare('SELECT title, created_at, updated_at FROM conversations WHERE id = ?')
+      .get(convId) as ConvRow | undefined
+    if (!conv) {
+      return null
+    }
+    const mtimeMs = statSync(args.dbPath).mtimeMs
+    const accumulator = createAccumulator({
+      agent: SOURCE_TO_AGENT[args.source],
+      file: {
+        path: `${args.dbPath}#${convId}`,
+        mtimeMs,
+        modifiedAt: new Date(mtimeMs).toISOString()
+      },
+      sessionId: args.sessionId
+    })
+    accumulator.readOnly = true
+    accumulator.title = normalizeTitleText(conv.title ?? '')
+    updateTimeline(accumulator, conv.created_at)
+    updateTimeline(accumulator, conv.updated_at)
+
+    const rows = db
+      .prepare('SELECT role, text, created_at FROM messages WHERE conv_id = ? ORDER BY idx ASC')
+      .all(convId) as MsgRow[]
+    for (const row of rows) {
+      const text = row.text
+      if (!text) {
+        continue
+      }
+      const role = row.role === 'USER' ? 'user' : 'assistant'
+      accumulator.messageCount += 1
+      addPreviewMessage(accumulator, { role, text, timestamp: row.created_at ?? undefined })
+      if (role === 'user' && !accumulator.title) {
+        accumulator.title = normalizeTitleText(text)
+      }
+    }
+    return finalizeSession(accumulator, args.platform)
+  } finally {
+    db?.close()
+  }
+}

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -2,12 +2,11 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { AI_VAULT_AGENTS } from '../../shared/ai-vault-types'
+import { AI_VAULT_AGENTS, WEB_CHAT_AGENTS } from '../../shared/ai-vault-types'
 import { scanAiVaultSessions } from './session-scanner'
 import {
   isolatedScanRoots,
   jsonLines,
-  seedWebChatDb,
   writeAntigravityScannerFixture
 } from './session-scanner-test-fixtures'
 
@@ -726,19 +725,16 @@ describe('scanAiVaultSessions', () => {
       ])
     )
 
-    // Web chat: imported conversations live in a chat-import SQLite DB, one
-    // row per source (chatgpt/claude-web/gemini-web), not on the filesystem.
-    await seedWebChatDb(roots.webchatDbPath, [
-      ['CHATGPT', 'chatgpt-session', 'ChatGPT vault title'],
-      ['CLAUDE', 'claude-web-session', 'Claude web vault title'],
-      ['GEMINI', 'gemini-web-session', 'Gemini web vault title']
-    ])
-
     const result = await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
 
     expect(result.issues).toEqual([])
+    // Web chat sources live in a SQLite DB, not on the filesystem; this
+    // filesystem scan covers the CLI agents. Web chat scanning has its own
+    // suites (session-scanner-webchat-*.test.ts).
+    const webChatAgents: ReadonlySet<string> = new Set(WEB_CHAT_AGENTS)
+    const filesystemAgents = AI_VAULT_AGENTS.filter((agent) => !webChatAgents.has(agent))
     expect(new Set(result.sessions.map((session) => session.agent))).toEqual(
-      new Set(AI_VAULT_AGENTS)
+      new Set(filesystemAgents)
     )
 
     const commandByAgent = new Map(
@@ -777,11 +773,6 @@ describe('scanAiVaultSessions', () => {
     expect(commandByAgent.get('kimi')).toBe(
       "cd '/tmp/kimi' && kimi --session 'session_kimi-session'"
     )
-    // Web chat conversations are read-only imports, not a launchable CLI agent.
-    expect(commandByAgent.get('chatgpt')).toBe('')
-    expect(commandByAgent.get('claude-web')).toBe('')
-    expect(commandByAgent.get('gemini-web')).toBe('')
-
     const ompSession = result.sessions.find((session) => session.agent === 'omp')
     expect(ompSession?.model).toBe('gpt-5.4-mini')
     expect(ompSession?.totalTokens).toBe(160)

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -7,6 +7,7 @@ import { scanAiVaultSessions } from './session-scanner'
 import {
   isolatedScanRoots,
   jsonLines,
+  seedWebChatDb,
   writeAntigravityScannerFixture
 } from './session-scanner-test-fixtures'
 
@@ -725,6 +726,14 @@ describe('scanAiVaultSessions', () => {
       ])
     )
 
+    // Web chat: imported conversations live in a chat-import SQLite DB, one
+    // row per source (chatgpt/claude-web/gemini-web), not on the filesystem.
+    await seedWebChatDb(roots.webchatDbPath, [
+      ['CHATGPT', 'chatgpt-session', 'ChatGPT vault title'],
+      ['CLAUDE', 'claude-web-session', 'Claude web vault title'],
+      ['GEMINI', 'gemini-web-session', 'Gemini web vault title']
+    ])
+
     const result = await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
 
     expect(result.issues).toEqual([])
@@ -768,6 +777,10 @@ describe('scanAiVaultSessions', () => {
     expect(commandByAgent.get('kimi')).toBe(
       "cd '/tmp/kimi' && kimi --session 'session_kimi-session'"
     )
+    // Web chat conversations are read-only imports, not a launchable CLI agent.
+    expect(commandByAgent.get('chatgpt')).toBe('')
+    expect(commandByAgent.get('claude-web')).toBe('')
+    expect(commandByAgent.get('gemini-web')).toBe('')
 
     const ompSession = result.sessions.find((session) => session.agent === 'omp')
     expect(ompSession?.model).toBe('gpt-5.4-mini')

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -30,6 +30,8 @@ import type {
   SessionParseResult
 } from './session-scanner-types'
 import { clampPositiveInteger, errorMessage } from './session-scanner-values'
+import { chatImportDbPath } from '../chat-import/chat-import-paths'
+import { listWebChatCandidates } from './session-scanner-webchat-sources'
 
 const DEFAULT_LIMIT = 1000
 const DEFAULT_SCAN_LIMIT_PER_AGENT = 1000
@@ -63,8 +65,17 @@ export async function scanAiVaultSessions(
     const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(readOptionalTextFile)
     const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
 
-    const candidates = discoveries
-      .flatMap((discovery) =>
+    // Why: unlike file-based discoveries (one agent per rootDir), each web chat
+    // conversation carries its own agent (chatgpt/claude-web/gemini-web), so
+    // listWebChatCandidates builds candidates directly instead of going through
+    // a single-agent SessionFileDiscovery.
+    const webchatCandidates = listWebChatCandidates({
+      dbPath: options.webchatDbPath ?? chatImportDbPath(),
+      issues
+    })
+
+    const candidates = [
+      ...discoveries.flatMap((discovery) =>
         discovery.files.map(
           (file): SessionFileCandidate => ({
             agent: discovery.agent,
@@ -79,8 +90,9 @@ export async function scanAiVaultSessions(
                 : undefined
           })
         )
-      )
-      .sort((left, right) => right.file.mtimeMs - left.file.mtimeMs)
+      ),
+      ...webchatCandidates
+    ].sort((left, right) => right.file.mtimeMs - left.file.mtimeMs)
 
     const parsedSessions = await parseSessionCandidates({
       candidates,

--- a/src/main/chat-import/chat-import-db-open.test.ts
+++ b/src/main/chat-import/chat-import-db-open.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { openChatImportDbForWrite } from './chat-import-db-open'
+import { upsertWebConversation } from './chat-import-store'
+import { parseWebChatSqliteSession } from '../ai-vault/session-scanner-webchat-sqlite'
+
+let dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) {
+    rmSync(d, { recursive: true, force: true })
+  }
+  dirs = []
+})
+
+describe('openChatImportDbForWrite', () => {
+  it('creates missing dirs, enables WAL, and initializes schema', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-webchat-wal-'))
+    dirs.push(dir)
+    const dbPath = join(dir, 'nested', 'chats.db')
+    const db = openChatImportDbForWrite(dbPath)
+    expect(db.pragma('journal_mode', { simple: true })).toBe('wal')
+    upsertWebConversation(
+      db,
+      {
+        source: 'CHATGPT',
+        externalId: 'c1',
+        title: 'WAL title',
+        createdAt: null,
+        updatedAt: '2026-07-05T00:00:00.000Z',
+        messages: [{ role: 'USER', idx: 0, text: 'q', createdAt: null }]
+      },
+      '2026-07-05T00:00:00.000Z'
+    )
+    db.close()
+
+    // The readonly scanner must be able to read a WAL-mode DB.
+    const session = parseWebChatSqliteSession({
+      dbPath,
+      sessionId: 'c1',
+      source: 'CHATGPT',
+      platform: 'darwin'
+    })
+    expect(session?.title).toBe('WAL title')
+    expect(session?.readOnly).toBe(true)
+  })
+})

--- a/src/main/chat-import/chat-import-db-open.ts
+++ b/src/main/chat-import/chat-import-db-open.ts
@@ -1,0 +1,16 @@
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import SyncDatabase from '../sqlite/sync-database'
+import { initChatImportSchema } from './chat-import-schema'
+
+// Why: the native host is a short-lived writer that may run while Orca reads
+// the same DB. WAL lets a reader and the writer coexist; busy_timeout absorbs
+// the brief lock windows. Runs outside Electron, so it creates the dir itself.
+export function openChatImportDbForWrite(dbPath: string): SyncDatabase {
+  mkdirSync(dirname(dbPath), { recursive: true })
+  const db = new SyncDatabase(dbPath)
+  db.pragma('journal_mode = WAL')
+  db.pragma('busy_timeout = 5000')
+  initChatImportSchema(db)
+  return db
+}

--- a/src/main/chat-import/chat-import-db-open.ts
+++ b/src/main/chat-import/chat-import-db-open.ts
@@ -11,6 +11,9 @@ export function openChatImportDbForWrite(dbPath: string): SyncDatabase {
   const db = new SyncDatabase(dbPath)
   db.pragma('journal_mode = WAL')
   db.pragma('busy_timeout = 5000')
+  // Why: SQLite defaults foreign keys off per connection, so the schema's
+  // ON DELETE CASCADE on messages would silently not fire without this.
+  db.pragma('foreign_keys = ON')
   initChatImportSchema(db)
   return db
 }

--- a/src/main/chat-import/chat-import-paths.test.ts
+++ b/src/main/chat-import/chat-import-paths.test.ts
@@ -1,0 +1,11 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { chatImportDbPath } from './chat-import-paths'
+
+describe('chatImportDbPath', () => {
+  it('joins chat-import/chats.db under the given userData path', () => {
+    expect(chatImportDbPath('/tmp/orca-user-data')).toBe(
+      join('/tmp/orca-user-data', 'chat-import', 'chats.db')
+    )
+  })
+})

--- a/src/main/chat-import/chat-import-paths.ts
+++ b/src/main/chat-import/chat-import-paths.ts
@@ -1,0 +1,21 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+// Why: 네이티브 호스트(1b)는 Electron 밖에서도 실행되므로, app.getPath 대신
+// 플랫폼별 userData 규칙을 직접 계산해 CLI/앱이 같은 경로를 쓰게 한다.
+function orcaUserDataPath(): string {
+  if (process.env.ORCA_USER_DATA_PATH) {
+    return process.env.ORCA_USER_DATA_PATH
+  }
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'orca')
+  }
+  if (process.platform === 'win32') {
+    return join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), 'orca')
+  }
+  return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'orca')
+}
+
+export function chatImportDbPath(overrideUserDataPath?: string): string {
+  return join(overrideUserDataPath ?? orcaUserDataPath(), 'chat-import', 'chats.db')
+}

--- a/src/main/chat-import/chat-import-schema.ts
+++ b/src/main/chat-import/chat-import-schema.ts
@@ -1,0 +1,25 @@
+import type SyncDatabase from '../sqlite/sync-database'
+
+// Why: 웹 대화 전용 최소 스키마. 아카이브 앱의 "graph" 네이밍/로컬 전용 컬럼
+// (git/cwd/token)은 제외한다. 1b(네이티브 호스트)가 쓰고, AI Vault 파서가 읽는다.
+export function initChatImportSchema(db: SyncDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS conversations(
+      id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      external_id TEXT NOT NULL,
+      title TEXT,
+      created_at TEXT,
+      updated_at TEXT,
+      synced_at TEXT NOT NULL,
+      UNIQUE(source, external_id));
+    CREATE TABLE IF NOT EXISTS messages(
+      id TEXT PRIMARY KEY,
+      conv_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role TEXT NOT NULL,
+      idx INTEGER NOT NULL,
+      text TEXT,
+      created_at TEXT);
+    PRAGMA user_version = 1;
+  `)
+}

--- a/src/main/chat-import/chat-import-store.test.ts
+++ b/src/main/chat-import/chat-import-store.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import SyncDatabase from '../sqlite/sync-database'
+import { initChatImportSchema } from './chat-import-schema'
+import { upsertWebConversation } from './chat-import-store'
+
+let dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs) {
+    rmSync(d, { recursive: true, force: true })
+  }
+  dirs = []
+})
+function tempDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-chat-import-'))
+  dirs.push(dir)
+  const db = new SyncDatabase(join(dir, 'chats.db'))
+  initChatImportSchema(db)
+  return db
+}
+
+describe('upsertWebConversation', () => {
+  it('inserts a conversation and its messages, returning the composite id', () => {
+    const db = tempDb()
+    const id = upsertWebConversation(
+      db,
+      {
+        source: 'CHATGPT',
+        externalId: 'abc',
+        title: 'Hello',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-01T00:05:00.000Z',
+        messages: [
+          { role: 'USER', idx: 0, text: 'hi', createdAt: null },
+          { role: 'AI', idx: 1, text: 'hello!', createdAt: null }
+        ]
+      },
+      '2026-07-13T00:00:00.000Z'
+    )
+    expect(id).toBe('CHATGPT/abc')
+    const conv = db.prepare('SELECT title, source FROM conversations WHERE id = ?').get(id)
+    expect(conv).toMatchObject({ title: 'Hello', source: 'CHATGPT' })
+    const count = db.prepare('SELECT COUNT(*) AS n FROM messages WHERE conv_id = ?').get(id)
+    expect(count).toMatchObject({ n: 2 })
+    db.close()
+  })
+
+  it('replaces messages on re-upsert (idempotent)', () => {
+    const db = tempDb()
+    const conv = {
+      source: 'CLAUDE' as const,
+      externalId: 'x',
+      title: 't',
+      createdAt: null,
+      updatedAt: null,
+      messages: [{ role: 'USER' as const, idx: 0, text: 'one', createdAt: null }]
+    }
+    upsertWebConversation(db, conv, '2026-07-13T00:00:00.000Z')
+    upsertWebConversation(
+      db,
+      { ...conv, messages: [{ role: 'USER', idx: 0, text: 'two', createdAt: null }] },
+      '2026-07-13T00:01:00.000Z'
+    )
+    const rows = db.prepare('SELECT text FROM messages WHERE conv_id = ?').all('CLAUDE/x')
+    expect(rows).toEqual([{ text: 'two' }])
+    db.close()
+  })
+})

--- a/src/main/chat-import/chat-import-store.test.ts
+++ b/src/main/chat-import/chat-import-store.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import SyncDatabase from '../sqlite/sync-database'
 import { initChatImportSchema } from './chat-import-schema'
-import { upsertWebConversation } from './chat-import-store'
+import { listIngestedExternalIds, upsertWebConversation } from './chat-import-store'
 
 let dirs: string[] = []
 afterEach(() => {
@@ -65,6 +65,51 @@ describe('upsertWebConversation', () => {
     )
     const rows = db.prepare('SELECT text FROM messages WHERE conv_id = ?').all('CLAUDE/x')
     expect(rows).toEqual([{ text: 'two' }])
+    db.close()
+  })
+})
+
+describe('listIngestedExternalIds', () => {
+  it('lists ingested external ids for one source only', () => {
+    const db = tempDb()
+    upsertWebConversation(
+      db,
+      {
+        source: 'CHATGPT',
+        externalId: 'c1',
+        title: 't',
+        createdAt: null,
+        updatedAt: null,
+        messages: []
+      },
+      '2026-07-05T00:00:00.000Z'
+    )
+    upsertWebConversation(
+      db,
+      {
+        source: 'CHATGPT',
+        externalId: 'c2',
+        title: 't',
+        createdAt: null,
+        updatedAt: null,
+        messages: []
+      },
+      '2026-07-05T00:00:00.000Z'
+    )
+    upsertWebConversation(
+      db,
+      {
+        source: 'CLAUDE',
+        externalId: 'x1',
+        title: 't',
+        createdAt: null,
+        updatedAt: null,
+        messages: []
+      },
+      '2026-07-05T00:00:00.000Z'
+    )
+    expect(listIngestedExternalIds(db, 'CHATGPT').sort()).toEqual(['c1', 'c2'])
+    expect(listIngestedExternalIds(db, 'GEMINI')).toEqual([])
     db.close()
   })
 })

--- a/src/main/chat-import/chat-import-store.test.ts
+++ b/src/main/chat-import/chat-import-store.test.ts
@@ -67,6 +67,44 @@ describe('upsertWebConversation', () => {
     expect(rows).toEqual([{ text: 'two' }])
     db.close()
   })
+
+  it('rolls back to the previous messages when an insert fails mid-write', () => {
+    const db = tempDb()
+    const conv = {
+      source: 'CLAUDE' as const,
+      externalId: 'x',
+      title: 'first',
+      createdAt: null,
+      updatedAt: null,
+      messages: [{ role: 'USER' as const, idx: 0, text: 'kept', createdAt: null }]
+    }
+    upsertWebConversation(db, conv, '2026-07-13T00:00:00.000Z')
+
+    // Duplicate idx collides on the `${convId}#${idx}` primary key partway
+    // through the insert loop, after the delete has already run.
+    expect(() =>
+      upsertWebConversation(
+        db,
+        {
+          ...conv,
+          title: 'second',
+          messages: [
+            { role: 'USER', idx: 0, text: 'a', createdAt: null },
+            { role: 'AI', idx: 0, text: 'b', createdAt: null }
+          ]
+        },
+        '2026-07-13T00:01:00.000Z'
+      )
+    ).toThrow()
+
+    expect(db.prepare('SELECT text FROM messages WHERE conv_id = ?').all('CLAUDE/x')).toEqual([
+      { text: 'kept' }
+    ])
+    expect(db.prepare('SELECT title FROM conversations WHERE id = ?').all('CLAUDE/x')).toEqual([
+      { title: 'first' }
+    ])
+    db.close()
+  })
 })
 
 describe('listIngestedExternalIds', () => {

--- a/src/main/chat-import/chat-import-store.ts
+++ b/src/main/chat-import/chat-import-store.ts
@@ -34,3 +34,12 @@ export function upsertWebConversation(
   }
   return id
 }
+
+// Why: the native host asks which conversations it has already stored so the
+// extension can skip re-fetching them (delta sync).
+export function listIngestedExternalIds(db: SyncDatabase, source: WebChatSource): string[] {
+  const rows = db
+    .prepare('SELECT external_id FROM conversations WHERE source = ? ORDER BY external_id')
+    .all(source) as { external_id: string }[]
+  return rows.map((row) => row.external_id)
+}

--- a/src/main/chat-import/chat-import-store.ts
+++ b/src/main/chat-import/chat-import-store.ts
@@ -1,0 +1,36 @@
+import type SyncDatabase from '../sqlite/sync-database'
+
+export type WebChatSource = 'CHATGPT' | 'CLAUDE' | 'GEMINI'
+
+export type WebConversation = {
+  source: WebChatSource
+  externalId: string
+  title: string | null
+  createdAt: string | null
+  updatedAt: string | null
+  messages: { role: 'USER' | 'AI'; idx: number; text: string | null; createdAt: string | null }[]
+}
+
+export function upsertWebConversation(
+  db: SyncDatabase,
+  conv: WebConversation,
+  syncedAt: string
+): string {
+  const id = `${conv.source}/${conv.externalId}`
+  db.prepare(
+    `INSERT INTO conversations (id, source, external_id, title, created_at, updated_at, synced_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       title = excluded.title, created_at = excluded.created_at,
+       updated_at = excluded.updated_at, synced_at = excluded.synced_at`
+  ).run(id, conv.source, conv.externalId, conv.title, conv.createdAt, conv.updatedAt, syncedAt)
+  // Why: 메시지는 멱등하게 전량 교체(대화가 웹에서 이어졌을 수 있음).
+  db.prepare('DELETE FROM messages WHERE conv_id = ?').run(id)
+  const insert = db.prepare(
+    'INSERT INTO messages (id, conv_id, role, idx, text, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+  )
+  for (const m of conv.messages) {
+    insert.run(`${id}#${m.idx}`, id, m.role, m.idx, m.text, m.createdAt)
+  }
+  return id
+}

--- a/src/main/chat-import/chat-import-store.ts
+++ b/src/main/chat-import/chat-import-store.ts
@@ -17,20 +17,30 @@ export function upsertWebConversation(
   syncedAt: string
 ): string {
   const id = `${conv.source}/${conv.externalId}`
-  db.prepare(
-    `INSERT INTO conversations (id, source, external_id, title, created_at, updated_at, synced_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(id) DO UPDATE SET
-       title = excluded.title, created_at = excluded.created_at,
-       updated_at = excluded.updated_at, synced_at = excluded.synced_at`
-  ).run(id, conv.source, conv.externalId, conv.title, conv.createdAt, conv.updatedAt, syncedAt)
-  // Why: 메시지는 멱등하게 전량 교체(대화가 웹에서 이어졌을 수 있음).
-  db.prepare('DELETE FROM messages WHERE conv_id = ?').run(id)
-  const insert = db.prepare(
-    'INSERT INTO messages (id, conv_id, role, idx, text, created_at) VALUES (?, ?, ?, ?, ?, ?)'
-  )
-  for (const m of conv.messages) {
-    insert.run(`${id}#${m.idx}`, id, m.role, m.idx, m.text, m.createdAt)
+  // Why: SyncDatabase has no transaction() wrapper, and the message rows are
+  // deleted before they are reinserted — without this a mid-write failure would
+  // leave the conversation updated but its messages gone or half-replaced.
+  db.exec('BEGIN')
+  try {
+    db.prepare(
+      `INSERT INTO conversations (id, source, external_id, title, created_at, updated_at, synced_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         title = excluded.title, created_at = excluded.created_at,
+         updated_at = excluded.updated_at, synced_at = excluded.synced_at`
+    ).run(id, conv.source, conv.externalId, conv.title, conv.createdAt, conv.updatedAt, syncedAt)
+    // Why: 메시지는 멱등하게 전량 교체(대화가 웹에서 이어졌을 수 있음).
+    db.prepare('DELETE FROM messages WHERE conv_id = ?').run(id)
+    const insert = db.prepare(
+      'INSERT INTO messages (id, conv_id, role, idx, text, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+    )
+    for (const m of conv.messages) {
+      insert.run(`${id}#${m.idx}`, id, m.role, m.idx, m.text, m.createdAt)
+    }
+    db.exec('COMMIT')
+  } catch (err) {
+    db.exec('ROLLBACK')
+    throw err
   }
   return id
 }

--- a/src/main/ipc/ai-vault.test.ts
+++ b/src/main/ipc/ai-vault.test.ts
@@ -324,6 +324,7 @@ function session(
     queuedMessageCount: 0,
     subagentTranscriptCount: 0,
     resumeCommand: `codex resume ${sessionId}`,
+    readOnly: false,
     subagent: null
   }
 }

--- a/src/main/runtime/rpc/methods/ai-vault.test.ts
+++ b/src/main/runtime/rpc/methods/ai-vault.test.ts
@@ -51,6 +51,7 @@ function makeSession(): AiVaultSession {
     queuedMessageCount: 0,
     subagentTranscriptCount: 0,
     resumeCommand: 'claude --resume sess-1',
+    readOnly: false,
     subagent: null
   }
 }

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionDetails.test.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionDetails.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AiVaultSession, AiVaultSubagentListResult } from '../../../../shared/ai-vault-types'
+import { SessionInlineDetails } from './AiVaultSessionDetails'
+
+const listSubagentSessions = vi.fn<(args: unknown) => Promise<AiVaultSubagentListResult>>()
+
+beforeEach(() => {
+  listSubagentSessions.mockReset()
+  listSubagentSessions.mockResolvedValue({ sessions: [], issues: [] })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window.api shim
+  ;(window as any).api = {
+    aiVault: { listSubagentSessions },
+    shell: { openFilePath: vi.fn() }
+  }
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+function makeSession(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
+  return {
+    id: 'local:claude:parent-session:/tmp/parent-session.jsonl',
+    executionHostId: 'local',
+    agent: 'claude',
+    sessionId: 'parent-session',
+    title: 'Parent session',
+    cwd: '/repo',
+    branch: null,
+    model: null,
+    filePath: '/tmp/parent-session.jsonl',
+    codexHome: null,
+    createdAt: null,
+    updatedAt: null,
+    modifiedAt: '2026-07-05T10:00:00.000Z',
+    messageCount: 3,
+    totalTokens: 0,
+    previewMessages: [],
+    queuedMessageCount: 0,
+    subagentTranscriptCount: 0,
+    resumeCommand: 'claude --resume parent-session',
+    readOnly: false,
+    subagent: null,
+    ...overrides
+  }
+}
+
+const resumeActions = {
+  worktree: { worktreeId: 'wt-1', disabled: false },
+  newTab: { worktreeId: 'wt-2', disabled: false }
+}
+
+describe('SessionInlineDetails', () => {
+  it('hides the resume buttons for a read-only session even with resumable content', async () => {
+    const { queryByText } = render(
+      <SessionInlineDetails
+        id="session-1"
+        session={makeSession({ readOnly: true })}
+        worktreeInfo={null}
+        vaultScope="workspace"
+        resumeActions={resumeActions}
+        onResumeInWorktree={vi.fn()}
+        onResumeInNewTab={vi.fn()}
+      />
+    )
+    await act(async () => {})
+
+    expect(queryByText('Resume in Worktree')).toBeNull()
+    expect(queryByText('Resume in New Tab')).toBeNull()
+  })
+
+  it('shows the resume buttons for a resumable, non-read-only session', async () => {
+    const { queryByText } = render(
+      <SessionInlineDetails
+        id="session-2"
+        session={makeSession({ readOnly: false })}
+        worktreeInfo={null}
+        vaultScope="workspace"
+        resumeActions={resumeActions}
+        onResumeInWorktree={vi.fn()}
+        onResumeInNewTab={vi.fn()}
+      />
+    )
+    await act(async () => {})
+
+    expect(queryByText('Resume in Worktree')).not.toBeNull()
+    expect(queryByText('Resume in New Tab')).not.toBeNull()
+  })
+
+  it('still renders the conversation preview for a read-only session', async () => {
+    const { queryByText } = render(
+      <SessionInlineDetails
+        id="session-3"
+        session={makeSession({
+          readOnly: true,
+          previewMessages: [
+            { role: 'user', text: 'Hello from the web chat import', timestamp: null }
+          ]
+        })}
+        worktreeInfo={null}
+        vaultScope="workspace"
+        resumeActions={resumeActions}
+        onResumeInWorktree={vi.fn()}
+        onResumeInNewTab={vi.fn()}
+      />
+    )
+    await act(async () => {})
+
+    expect(queryByText('Latest turns')).not.toBeNull()
+    expect(queryByText('Hello from the web chat import')).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionDetails.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionDetails.tsx
@@ -45,10 +45,11 @@ export function SessionInlineDetails({
   // A zero-turn transcript would resume into an empty conversation, so the plain
   // resume affordances are withheld and a distinct "not saved" state is shown.
   const hasResumableContent = isAiVaultSessionResumableContent(session)
-  const showResumeInWorktree = hasResumableContent && Boolean(resumeActions.worktree.worktreeId)
+  // Why: 읽기전용 웹 대화는 트랜스크립트만 보여주고 CLI 이어하기 어포던스는 전부 숨긴다.
+  const canResume = hasResumableContent && !session.readOnly
+  const showResumeInWorktree = canResume && Boolean(resumeActions.worktree.worktreeId)
   const showResumeInNewTab =
-    hasResumableContent &&
-    (!resumeActions.worktree.worktreeId || Boolean(resumeActions.newTab.worktreeId))
+    canResume && (!resumeActions.worktree.worktreeId || Boolean(resumeActions.newTab.worktreeId))
   const detailTurns = sessionDetailConversationTurns(session, 3)
   const worktreeDisplay = worktreeInfo
 

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.test.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.test.tsx
@@ -41,6 +41,7 @@ function makeSession(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
     queuedMessageCount: 0,
     subagentTranscriptCount: 1,
     resumeCommand: 'claude --resume parent-session',
+    readOnly: false,
     subagent: null,
     ...overrides
   }

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.test.ts
@@ -32,6 +32,7 @@ const SESSION: AiVaultSession = {
   queuedMessageCount: 0,
   subagentTranscriptCount: 0,
   resumeCommand: "codex resume 'target-session'",
+  readOnly: false,
   subagent: null
 }
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane.test.ts
@@ -31,6 +31,7 @@ const baseSession: AiVaultSession = {
   queuedMessageCount: 0,
   subagentTranscriptCount: 0,
   resumeCommand: "codex resume 'session-1'",
+  readOnly: false,
   subagent: null
 }
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-display.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-display.test.ts
@@ -33,6 +33,7 @@ const baseSession: AiVaultSession = {
   queuedMessageCount: 0,
   subagentTranscriptCount: 0,
   resumeCommand: "cd '/Users/ada/repo/app' && codex resume 'session-1'",
+  readOnly: false,
   subagent: null
 }
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
@@ -33,6 +33,7 @@ const baseSession: AiVaultSession = {
   queuedMessageCount: 0,
   subagentTranscriptCount: 0,
   resumeCommand: "cd '/Users/ada/repo/app' && claude --resume 'session-1'",
+  readOnly: false,
   subagent: null
 }
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -16,7 +16,11 @@ import {
   getAiVaultResumeWorkspaceExecutionHostId,
   getAiVaultResumeWorkspaceTargetStatus
 } from '@/lib/ai-vault-resume-target'
-import type { AiVaultAgent, AiVaultSession } from '../../../../shared/ai-vault-types'
+import {
+  isWebChatAgent,
+  type AiVaultAgent,
+  type AiVaultSession
+} from '../../../../shared/ai-vault-types'
 import type { Worktree } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 import { agentLabel } from './ai-vault-session-filters'
@@ -78,6 +82,10 @@ export function useAiVaultSessionLaunchActions({
 
   const handleResume = useCallback(
     (session: AiVaultSession, targetWorktreeId?: string): void => {
+      // Why: 웹 대화는 읽기전용이라 CLI 이어하기 대상이 아니다(UI에서도 숨겨짐).
+      if (isWebChatAgent(session.agent)) {
+        return
+      }
       const targetId = resolveAiVaultSessionLaunchTarget({
         sessionFilePath: session.filePath,
         sessionExecutionHostId: session.executionHostId,

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
@@ -24,6 +24,7 @@ const baseSession: AiVaultSession = {
   queuedMessageCount: 0,
   subagentTranscriptCount: 0,
   resumeCommand: "cd '/Users/ada/orca' && claude --resume 'session-1'",
+  readOnly: false,
   subagent: null
 }
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
@@ -569,8 +569,8 @@ describe('aiVaultSessionResumeLabel', () => {
 })
 
 describe('aiVaultSessionRowResumeGating', () => {
-  const zeroTurnSession = { messageCount: 0, previewMessages: [] }
-  const sessionWithTurns = { messageCount: 3, previewMessages: [] }
+  const zeroTurnSession = { messageCount: 0, previewMessages: [], readOnly: false }
+  const sessionWithTurns = { messageCount: 3, previewMessages: [], readOnly: false }
   const unblocked = { blocked: false }
 
   it('withholds every resume affordance for a zero-turn session', () => {
@@ -594,7 +594,8 @@ describe('aiVaultSessionRowResumeGating', () => {
   it('treats user/assistant previews as resumable content when the turn count is unknown', () => {
     const previewOnlySession = {
       messageCount: 0,
-      previewMessages: [{ role: 'user' as const, text: 'hello', timestamp: null }]
+      previewMessages: [{ role: 'user' as const, text: 'hello', timestamp: null }],
+      readOnly: false
     }
     expect(aiVaultSessionRowResumeGating(previewOnlySession, unblocked)).toEqual({
       resumeDisabled: false,
@@ -606,6 +607,14 @@ describe('aiVaultSessionRowResumeGating', () => {
     expect(aiVaultSessionRowResumeGating(sessionWithTurns, unblocked)).toEqual({
       resumeDisabled: false,
       canCopyResumeCommand: true
+    })
+  })
+
+  it('hides resume and copy affordances for a read-only session even with turns', () => {
+    const readOnlySession = { messageCount: 3, previewMessages: [], readOnly: true }
+    expect(aiVaultSessionRowResumeGating(readOnlySession, unblocked)).toEqual({
+      resumeDisabled: true,
+      canCopyResumeCommand: false
     })
   })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
@@ -208,9 +208,13 @@ function resolveAiVaultResumeTargetState(args: {
 // copying the command stays available for blocked-but-real sessions, so the copy
 // affordance is gated on content alone.
 export function aiVaultSessionRowResumeGating(
-  session: Pick<AiVaultSession, 'messageCount' | 'previewMessages'>,
+  session: Pick<AiVaultSession, 'messageCount' | 'previewMessages' | 'readOnly'>,
   state: Pick<AiVaultSessionResumeState, 'blocked'> | null
 ): { resumeDisabled: boolean; canCopyResumeCommand: boolean } {
+  // Why: 읽기전용 웹 대화는 CLI 이어하기가 불가하고 resume 명령도 없다 — 이어하기·복사 모두 숨김.
+  if (session.readOnly) {
+    return { resumeDisabled: true, canCopyResumeCommand: false }
+  }
   const hasResumableContent = isAiVaultSessionResumableContent(session)
   return {
     resumeDisabled: (state?.blocked ?? true) || !hasResumableContent,

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.test.ts
@@ -34,6 +34,7 @@ const baseSession: AiVaultSession = {
   queuedMessageCount: 0,
   subagentTranscriptCount: 0,
   resumeCommand: "codex resume 'session-1'",
+  readOnly: false,
   subagent: null
 }
 

--- a/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
@@ -13,6 +13,7 @@ import {
   readAiVaultSessionDragData
 } from '@/lib/ai-vault-session-drag'
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
+import { isWebChatAgent } from '../../../../shared/ai-vault-types'
 import { useAppStore } from '@/store'
 import { resolveDropZone } from './tab-drop-zone'
 import type { TabDropZone } from './useTabDragSplit'
@@ -196,6 +197,11 @@ export default function AiVaultSessionDropLayer({
             'This session belongs to a different host. Drop it onto a workspace on the same host.'
           )
         )
+        return true
+      }
+
+      // Why: 웹 대화는 읽기전용이라 CLI 이어하기 대상이 아니다(UI에서도 숨겨짐).
+      if (isWebChatAgent(payload.agent)) {
         return true
       }
 

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -3,6 +3,7 @@ import { ClaudeIcon, DroidIcon, OpenAIIcon } from '@/components/status-bar/icons
 import openClaudeLogoUrl from '../../../../resources/openclaude-logo.png?url'
 import type { TuiAgent } from '../../../shared/types'
 import { getTuiAgentLaunchCommand, TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import type { WebChatAgent } from '../../../shared/ai-vault-types'
 import {
   AgentLetterIcon,
   AiderIcon,
@@ -27,6 +28,18 @@ export type AgentCatalogEntry = {
   faviconDomain?: string
   /** Homepage/install docs URL, sourced from the README agent badge list. */
   homepageUrl: string
+}
+
+// Why: web chat imports aren't launchable CLI agents, so they stay out of the
+// TuiAgent catalog; AgentIcon renders them via their site favicon instead.
+const WEB_CHAT_ICON_DOMAIN: Record<WebChatAgent, string> = {
+  chatgpt: 'chatgpt.com',
+  'claude-web': 'claude.ai',
+  'gemini-web': 'gemini.google.com'
+}
+
+function isWebChatAgentId(agent: TuiAgent | WebChatAgent): agent is WebChatAgent {
+  return agent in WEB_CHAT_ICON_DOMAIN
 }
 
 function getCatalogPlatform(): NodeJS.Platform {
@@ -304,7 +317,7 @@ export function AgentIcon({
   agent,
   size = 14
 }: {
-  agent: TuiAgent | null | undefined
+  agent: TuiAgent | WebChatAgent | null | undefined
   size?: number
 }): React.JSX.Element {
   // Why: render a neutral question-mark glyph when the agent identity is not
@@ -313,6 +326,18 @@ export function AgentIcon({
   // arrived.
   if (!agent) {
     return <AgentLetterIcon letter="?" size={size} />
+  }
+  if (isWebChatAgentId(agent)) {
+    return (
+      <img
+        src={`https://www.google.com/s2/favicons?domain=${WEB_CHAT_ICON_DOMAIN[agent]}&sz=64`}
+        width={size}
+        height={size}
+        alt=""
+        aria-hidden
+        style={{ borderRadius: 2 }}
+      />
+    )
   }
   if (agent === 'claude' || agent === 'claude-agent-teams') {
     return <ClaudeIcon size={size} />

--- a/src/renderer/src/lib/launch-ai-vault-session.ts
+++ b/src/renderer/src/lib/launch-ai-vault-session.ts
@@ -6,7 +6,7 @@ import {
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
-import type { AiVaultAgent } from '../../../shared/ai-vault-types'
+import type { AiVaultAgent, WebChatAgent } from '../../../shared/ai-vault-types'
 import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-resume'
 import type { TabSplitDirection } from '@/store/slices/tabs'
 
@@ -15,7 +15,9 @@ export type LaunchAiVaultSessionInNewTabResult =
   | { tabId: null; groupId?: string; runtimeLaunch: Promise<boolean> }
 
 export function launchAiVaultSessionInNewTab(args: {
-  agent: AiVaultAgent
+  // Why: web chat sessions are read-only and never reach this CLI launcher —
+  // callers must guard with isWebChatAgent before calling.
+  agent: Exclude<AiVaultAgent, WebChatAgent>
   worktreeId: string
   command: string
   env?: Record<string, string>

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -32,6 +32,7 @@ const baseSession: AiVaultSession = {
   queuedMessageCount: 0,
   subagentTranscriptCount: 0,
   resumeCommand: "cd '/Users/ada/repo/app' && claude --resume 'session-1'",
+  readOnly: false,
   subagent: null
 }
 

--- a/src/shared/ai-vault-types.test.ts
+++ b/src/shared/ai-vault-types.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  aiVaultAgentLabel,
   aiVaultSessionRecoverableSignalCount,
+  buildAiVaultResumeCommand,
   isAiVaultSessionRecoverableEmpty,
   isAiVaultSessionResumableContent,
+  isWebChatAgent,
   type AiVaultSessionPreviewMessage
 } from './ai-vault-types'
 
@@ -84,5 +87,27 @@ describe('aiVaultSessionRecoverableSignalCount', () => {
         subagentTranscriptCount: 3
       })
     ).toBe(3)
+  })
+})
+
+describe('web chat agents', () => {
+  it('classifies web chat agents', () => {
+    expect(isWebChatAgent('chatgpt')).toBe(true)
+    expect(isWebChatAgent('claude')).toBe(false)
+  })
+  it('labels web chat agents', () => {
+    expect(aiVaultAgentLabel('chatgpt')).toBe('ChatGPT')
+    expect(aiVaultAgentLabel('claude-web')).toBe('Claude.ai')
+    expect(aiVaultAgentLabel('gemini-web')).toBe('Gemini')
+  })
+  it('produces no resume command for web chat agents (read-only)', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'chatgpt',
+        sessionId: 'abc',
+        cwd: null,
+        platform: 'darwin'
+      })
+    ).toBe('')
   })
 })

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -7,7 +7,8 @@ import {
 import type { TuiAgent } from './types'
 import type { ExecutionHostId, ExecutionHostScope } from './execution-host'
 
-export const AI_VAULT_AGENTS = [
+// Local CLI agents scanned from on-disk transcripts (all TuiAgent).
+const TUI_AI_VAULT_AGENTS = [
   'claude',
   'codex',
   'hermes',
@@ -26,6 +27,13 @@ export const AI_VAULT_AGENTS = [
   'kimi'
 ] as const satisfies readonly TuiAgent[]
 
+// Why: web chat transcripts are imported read-only records, not a launchable
+// CLI agent, so they aren't TuiAgent members.
+export const WEB_CHAT_AGENTS = ['chatgpt', 'claude-web', 'gemini-web'] as const
+export type WebChatAgent = (typeof WEB_CHAT_AGENTS)[number]
+
+export const AI_VAULT_AGENTS = [...TUI_AI_VAULT_AGENTS, ...WEB_CHAT_AGENTS] as const
+
 // Why: the aiVault.listSessions RPC schema CLAMPS scopePaths to this bound
 // (safe: scope paths only widen discovery). Producer-side caps against the same
 // value are optional belt-and-braces, not required for the request to succeed.
@@ -35,6 +43,10 @@ export type AiVaultAgent = (typeof AI_VAULT_AGENTS)[number]
 export type AiVaultScope = 'workspace' | 'project' | 'all'
 export type AiVaultSort = 'updated' | 'created'
 export type AiVaultGroup = 'project' | 'folder' | 'agent'
+
+export function isWebChatAgent(agent: AiVaultAgent): agent is WebChatAgent {
+  return (WEB_CHAT_AGENTS as readonly string[]).includes(agent)
+}
 
 export const AI_VAULT_AGENT_LABELS = {
   claude: 'Claude',
@@ -52,7 +64,10 @@ export const AI_VAULT_AGENT_LABELS = {
   openclaw: 'OpenClaw',
   devin: 'Devin',
   droid: 'Droid',
-  kimi: 'Kimi'
+  kimi: 'Kimi',
+  chatgpt: 'ChatGPT',
+  'claude-web': 'Claude.ai',
+  'gemini-web': 'Gemini'
 } as const satisfies Record<AiVaultAgent, string>
 
 export type AiVaultSessionPreviewMessage = {
@@ -100,6 +115,8 @@ export type AiVaultSession = {
   // recoverable signal for zero-turn sessions.
   subagentTranscriptCount: number
   resumeCommand: string
+  // 읽기 전용 웹 대화는 CLI 이어하기가 없다. 렌더러가 이어하기 UI를 숨긴다.
+  readOnly: boolean
   subagent: AiVaultSessionSubagentInfo | null
 }
 
@@ -184,6 +201,10 @@ export function buildAiVaultResumeCommand(args: {
 }): string {
   const { agent, sessionId, cwd, platform, commandOverride, codexHome, resumeFilePath, shell } =
     args
+  // Why: 웹 대화는 읽기 전용 — CLI 이어하기 명령이 없다(빈 문자열).
+  if (isWebChatAgent(agent)) {
+    return ''
+  }
   const baseCommand = commandOverride?.trim() || defaultAiVaultResumeCommandBase(agent)
   // Why: OMP's `--resume` accepts an absolute transcript path, which resolves
   // regardless of which session-dir root (custom OMP_CODING_AGENT_DIR / WSL
@@ -281,7 +302,7 @@ export function aiVaultAgentLabel(agent: AiVaultAgent): string {
   return AI_VAULT_AGENT_LABELS[agent]
 }
 
-function defaultAiVaultResumeCommandBase(agent: AiVaultAgent): string {
+function defaultAiVaultResumeCommandBase(agent: Exclude<AiVaultAgent, WebChatAgent>): string {
   if (agent === 'cursor') {
     return 'cursor-agent'
   }
@@ -295,7 +316,7 @@ function defaultAiVaultResumeCommandBase(agent: AiVaultAgent): string {
 }
 
 function buildAgentResumeInvocation(
-  agent: AiVaultAgent,
+  agent: Exclude<AiVaultAgent, WebChatAgent>,
   baseCommand: string,
   sessionArg: string
 ): string {


### PR DESCRIPTION
## Summary

Part 1 of 4, split out of #8744 (+10,842 / 186 files). As I noted there — *"Large branch spanning several milestones; happy to split or squash if preferred"* — this is that split.

This slice lands the two ends of the web chat import pipeline that don't need the browser extension: the **storage layer** and the **native messaging host**, plus the **AI Vault read-only session** plumbing that will eventually display imported chats.

The split itself introduced no new code — the first 21 commits are lifted from #8744 unchanged, cut at a self-contained boundary. One follow-up commit (`a207a5efe`) has since been added on top, addressing CodeRabbit's review: an explicit transaction around the conversation/message write, integer + duplicate validation on `idx`, `foreign_keys = ON`, and outbound frame guards.

## What's included

- **Storage** (`src/main/chat-import/`): `chats.db` path resolution, schema + upsert, per-source `external_id` lookup, and a WAL write connection with reader compatibility.
- **AI Vault read-only sessions** (`src/main/ai-vault/`): parses the web chat SQLite into `AiVaultSession`, discovers and routes the new source, splits `AiVaultAgent` out of `TuiAgent` to introduce a web chat agent, and propagates `readOnly` so imported chats aren't treated as resumable CLI sessions.
- **Native messaging host** (`src/cli/chat-import-host/`): `orca chat-import-host` — length-prefixed framing codec, request validation and routing, main loop, `PING` handler, and cross-platform manifest registration (`install`), including Chrome's `origin` / `parent-window` argv.

## What's deliberately not here

The browser extension, settings pane, resume, and attachments follow in PRs 2–4. Without the extension there is no data source yet, so nothing in this PR is reachable by a user — which is what makes the slice reviewable on its own.

Planned stack (each opened as the previous one merges, since I can't push branches to this repo to base them on each other):

1. **this PR** — storage + host + read-only sessions (+1,977)
2. browser extension + settings pane (+2,111)
3. resume web chats as Claude/Codex sessions (+3,053)
4. browser integration UI + attachments (+3,888)

#8744 stays open as the full-context reference until this stack lands. Its tip is the identical commit to the end of PR 4, so the final state is unchanged.

## Screenshots

No visual change in practice. The renderer diff is defensive — the AI Vault icon path and the resume affordance learn about read-only web sessions — but with no extension installed there are no such sessions to render yet.

## Testing

- [x] `pnpm lint` — passes (oxlint, switch-exhaustiveness, 38 reliability gates, max-lines ratchet, localization catalog + coverage)
- [x] `pnpm typecheck` — node, cli, and web projects all pass
- [x] `pnpm test` — 184 tests / 37 files pass across `src/main/ai-vault`, `src/main/chat-import`, and `src/cli/chat-import-host`; full suite not run
- [ ] `pnpm build` — not run
- [x] Added tests: framing codec, host protocol validation, argv parsing, manifest install, host run loop, plus web-chat coverage and `webchatDbPath` isolation in the AI Vault scanner suite

## Notes

- Lint/typecheck/tests were re-run at **this exact commit**, not just at the tip of #8744, to confirm the cut point is self-contained.
- Nothing user-facing ships here; the feature only becomes reachable once PR 2 lands the extension.

## ELI5

Part 1 of web chat import: storage, native messaging host, and read-only AI Vault sessions. This lays the groundwork to later pull ChatGPT/Claude/Gemini chats into Orca.
