### PR TITLE
fix(pty): wait for zsh line-init before agent startup

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -378,16 +378,21 @@ describePosix('daemon shell-ready launch config', () => {
   )
 
   itWithZsh(
-    'still runs user add-zle-hook-widget line-init hooks after the marker',
+    'waits for user add-zle-hook-widget line-init hooks before emitting the marker',
     async () => {
       const { getShellReadyLaunchConfig } = await importFreshShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
       const tempHome = mkdtempSync(join(tmpdir(), 'orca-zsh-azhw-'))
-      const userHookOutput = 'ORCA-TEST-USER-HOOK'
+      const userHookStarted = 'ORCA-TEST-USER-HOOK-STARTED'
+      const userHookFinished = 'ORCA-TEST-USER-HOOK-FINISHED'
       writeFileSync(
         join(tempHome, '.zshrc'),
         [
-          `__orca_test_line_init_hook() { printf "${userHookOutput}" }`,
+          '__orca_test_line_init_hook() {',
+          `  printf "${userHookStarted}"`,
+          '  sleep 0.1',
+          `  printf "${userHookFinished}"`,
+          '}',
           'autoload -Uz add-zle-hook-widget',
           'zle -N __orca_test_line_init_hook',
           'add-zle-hook-widget line-init __orca_test_line_init_hook',
@@ -399,14 +404,15 @@ describePosix('daemon shell-ready launch config', () => {
           tempHome,
           wrapperZdotdir: config.env.ZDOTDIR,
           isDone: (current) =>
-            current.includes(SHELL_READY_MARKER_OUTPUT) && current.includes(userHookOutput)
+            current.includes(SHELL_READY_MARKER_OUTPUT) && current.includes(userHookFinished)
         })
         // Why: the marker widget chains to the previously installed widget, so
-        // an azhw dispatcher registered by user config must keep dispatching.
+        // a slow azhw dispatcher must finish before Orca can safely type input.
         expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
-        expect(output).toContain(userHookOutput)
-        expect(output.indexOf(SHELL_READY_MARKER_OUTPUT)).toBeLessThan(
-          output.indexOf(userHookOutput)
+        expect(output).toContain(userHookStarted)
+        expect(output).toContain(userHookFinished)
+        expect(output.indexOf(userHookFinished)).toBeLessThan(
+          output.indexOf(SHELL_READY_MARKER_OUTPUT)
         )
       } finally {
         rmSync(tempHome, { recursive: true, force: true })
@@ -445,8 +451,8 @@ describePosix('daemon shell-ready launch config', () => {
         })
         expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
         expect(output).toContain(userHookOutput)
-        expect(output.indexOf(SHELL_READY_MARKER_OUTPUT)).toBeLessThan(
-          output.indexOf(userHookOutput)
+        expect(output.indexOf(userHookOutput)).toBeLessThan(
+          output.indexOf(SHELL_READY_MARKER_OUTPUT)
         )
         // Why: idempotent — the marker must fire exactly once per prompt, not
         // duplicated by the second registration.

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -130,8 +130,8 @@ fi
 // when an earlier hook exits non-zero, and a pre-existing raw user widget
 // (e.g. oh-my-zsh vi-mode without VI_MODE_SET_CURSOR) is preserved as the
 // first hook and fails — silently suppressing the marker and stalling every
-// startup command on the pre-ready timeout. Instead, own zle-line-init: emit
-// the marker first, then chain to whatever widget was installed before.
+// startup command on the pre-ready timeout. Instead, own zle-line-init, run
+// the prior widget ourselves, then emit the marker even if that widget fails.
 export function getZshShellReadyMarkerRegistrationBlock(escapedMarker: string): string {
   return `if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
   # Why: capture the prior zle-line-init so the marker chains to it. On a
@@ -148,12 +148,13 @@ export function getZshShellReadyMarkerRegistrationBlock(escapedMarker: string): 
     __orca_prev_line_init_fn=""
   fi
   __orca_prompt_mark() {
-    printf "${escapedMarker}"
     # Why: call the prior hook as a plain function, not an aliased widget, so
-    # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
+    # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers. Readiness
+    # comes afterward because a slow hook means zle cannot accept input yet.
     if [[ -n "\${__orca_prev_line_init_fn:-}" ]]; then
-      "\${__orca_prev_line_init_fn}" "$@"
+      "\${__orca_prev_line_init_fn}" "$@" || true
     fi
+    printf "${escapedMarker}"
   }
   zle -N zle-line-init __orca_prompt_mark
 fi


### PR DESCRIPTION
## Summary

- emit Orca’s zsh shell-ready marker only after the preserved user `zle-line-init` hook finishes
- continue emitting readiness when that hook returns nonzero
- cover delayed hooks and repeated wrapper registration with real zsh/node-pty integration tests

## Problem

`orca worktree create --agent codex --prompt ...` could occasionally leave a multiline agent command pasted into zsh but unsubmitted, especially while repository setup was running in parallel. Orca emitted its ready marker at the beginning of `zle-line-init`, then ran the user’s existing line-init hook. The terminal host could therefore inject the command while zsh was still initializing its editor.

## ELI5

Orca was hearing “the terminal is ready” before zsh had finished getting ready. It could type the Codex command during that small gap, where zsh displayed it but did not reliably run it. Orca now waits until zsh’s existing startup hook is finished before typing.

## Evidence

Before the fix, the integration assertion showed the user hook completing after Orca’s readiness marker (output indexes 177 vs. 154). The updated test adds a deliberately delayed line-init hook and proves it completes before readiness is emitted. The existing nonzero-hook regression continues to pass.

## Trade-offs

Agent startup now waits for the user’s line-init hook to return. Normal hooks add no meaningful delay. A deliberately slow hook delays startup by its own runtime, which is required because zsh cannot safely accept input until that hook finishes. A permanently hung hook already prevents the interactive shell itself from becoming usable.

## Validation

- 195 tests across daemon, local PTY, relay, terminal-host, and session startup suites
- real zsh/node-pty integration coverage with a delayed line-init hook
- targeted Oxlint
- Node TypeScript check
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋
