### PR TITLE
Prepare mobile 0.0.31

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.30",
+    "version": "0.0.31",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 7
+      "versionCode": 8
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
Bump the committed mobile marketing version to 0.0.31 and Android versionCode to 8 for the terminal restoration release.

Validation:
- `MOBILE_ANDROID_RELEASE_VERSION=0.0.31 MOBILE_ANDROID_PUBLISH_RELEASE=true node mobile/scripts/prepare-android-release.mjs`
- `pnpm --dir mobile exec vitest run src/mobile-release/prepare-android-release-script.test.ts`
- `pnpm --dir mobile exec oxfmt --check app.json`

Made with [Orca](https://github.com/stablyai/orca) 🐋
