### PR TITLE
fix(crash-reporting): coalesce repeated renderer error breadcrumbs

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -55,27 +55,30 @@ describe('crash breadcrumb store', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'))
 
-    recordCoalescedCrashBreadcrumb({
+    const first = recordCoalescedCrashBreadcrumb({
       name: 'agent_state_changed',
       data: { agentType: 'claude', state: 'working' },
       coalesceKey: 'agent:claude:working',
       minIntervalMs: 30_000
     })
     vi.advanceTimersByTime(1_000)
-    recordCoalescedCrashBreadcrumb({
+    const suppressed = recordCoalescedCrashBreadcrumb({
       name: 'agent_state_changed',
       data: { agentType: 'claude', state: 'working' },
       coalesceKey: 'agent:claude:working',
       minIntervalMs: 30_000
     })
     vi.advanceTimersByTime(30_000)
-    recordCoalescedCrashBreadcrumb({
+    const resumed = recordCoalescedCrashBreadcrumb({
       name: 'agent_state_changed',
       data: { agentType: 'claude', state: 'working' },
       coalesceKey: 'agent:claude:working',
       minIntervalMs: 30_000
     })
 
+    expect(first).toEqual({ suppressedSinceLast: 0 })
+    expect(suppressed).toBeUndefined()
+    expect(resumed).toEqual({ suppressedSinceLast: 1 })
     expect(getCrashBreadcrumbSnapshot().map((entry) => entry.data)).toEqual([
       { agentType: 'claude', state: 'working' },
       { agentType: 'claude', state: 'working', suppressedSinceLast: 1 }

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -41,12 +41,12 @@ export function recordCoalescedCrashBreadcrumb({
   data?: CrashReportBreadcrumbData
   coalesceKey: string
   minIntervalMs: number
-}): void {
+}): { suppressedSinceLast: number } | undefined {
   const now = Date.now()
   const previous = coalescedBreadcrumbs.get(coalesceKey)
   if (previous && now - previous.recordedAt < minIntervalMs) {
     previous.suppressed += 1
-    return
+    return undefined
   }
 
   // Drop entries past their suppression window (they can no longer coalesce
@@ -66,10 +66,9 @@ export function recordCoalescedCrashBreadcrumb({
     }
     coalescedBreadcrumbs.delete(oldest.value)
   }
-  recordCrashBreadcrumb(
-    name,
-    previous?.suppressed ? { ...data, suppressedSinceLast: previous.suppressed } : data
-  )
+  const suppressedSinceLast = previous?.suppressed ?? 0
+  recordCrashBreadcrumb(name, suppressedSinceLast > 0 ? { ...data, suppressedSinceLast } : data)
+  return { suppressedSinceLast }
 }
 
 export function getCrashBreadcrumbSnapshot(): CrashReportBreadcrumb[] {

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  listeners,
+  recordCoalescedCrashBreadcrumbMock,
+  recordCrashBreadcrumbMock,
+  spanEndMock,
+  startSpanMock
+} = vi.hoisted(() => {
+  const spanEndMock = vi.fn()
+  return {
+    listeners: new Map<string, (_event: unknown, args?: unknown) => void>(),
+    recordCoalescedCrashBreadcrumbMock: vi.fn(),
+    recordCrashBreadcrumbMock: vi.fn(),
+    spanEndMock,
+    startSpanMock: vi.fn(() => ({
+      traceId: 'trace-id',
+      spanId: 'span-id',
+      setAttribute: vi.fn(),
+      addEvent: vi.fn(),
+      fail: vi.fn(),
+      interrupt: vi.fn(),
+      end: spanEndMock
+    }))
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.2.3-test' },
+  clipboard: { writeText: vi.fn() },
+  ipcMain: {
+    removeHandler: vi.fn(),
+    handle: vi.fn(),
+    removeAllListeners: vi.fn((channel: string) => listeners.delete(channel)),
+    on: vi.fn((channel: string, listener: (_event: unknown, args?: unknown) => void) => {
+      listeners.set(channel, listener)
+    })
+  }
+}))
+
+vi.mock('./feedback', () => ({
+  submitFeedback: vi.fn()
+}))
+
+vi.mock('../crash-reporting/crash-breadcrumb-store', () => ({
+  getCrashBreadcrumbSnapshot: vi.fn(() => []),
+  recordCoalescedCrashBreadcrumb: (...args: unknown[]) =>
+    recordCoalescedCrashBreadcrumbMock(...args),
+  recordCrashBreadcrumb: (...args: unknown[]) => recordCrashBreadcrumbMock(...args)
+}))
+
+vi.mock('../observability', () => ({
+  collectDiagnosticBundle: vi.fn(),
+  getDiagnosticsStatus: vi.fn()
+}))
+
+vi.mock('../observability/diagnostic-upload-endpoint', () => ({
+  resolveDiagnosticOrcaChannel: vi.fn()
+}))
+
+vi.mock('../observability/tracer', () => ({
+  startSpan: startSpanMock
+}))
+
+import { registerCrashReportingHandlers } from './crash-reporting'
+
+function registerHandlersWithStubStore(): void {
+  registerCrashReportingHandlers({
+    getLatestPending: vi.fn(),
+    getById: vi.fn(),
+    dismiss: vi.fn(),
+    markSent: vi.fn(),
+    listRecent: vi.fn(),
+    record: vi.fn(),
+    formatDiagnosticText: vi.fn()
+  } as never)
+}
+
+function emitRendererBreadcrumb(args: unknown): void {
+  listeners.get('crashReports:recordBreadcrumb')?.(null, args)
+}
+
+describe('renderer breadcrumb IPC routing', () => {
+  beforeEach(() => {
+    listeners.clear()
+    recordCoalescedCrashBreadcrumbMock.mockReset()
+    recordCrashBreadcrumbMock.mockReset()
+    startSpanMock.mockClear()
+    spanEndMock.mockClear()
+    registerHandlersWithStubStore()
+  })
+
+  it('sanitizes and coalesces renderer error breadcrumbs', () => {
+    emitRendererBreadcrumb({
+      name: 'renderer_error',
+      data: {
+        message: 'boom',
+        count: 2,
+        ok: true,
+        empty: null,
+        badNumber: Number.POSITIVE_INFINITY,
+        object: { ignored: true }
+      }
+    })
+
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
+      name: 'renderer_error',
+      data: { message: 'boom', count: 2, ok: true, empty: null },
+      coalesceKey: 'renderer_error:boom',
+      minIntervalMs: 30_000
+    })
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(startSpanMock).toHaveBeenCalledWith('renderer.breadcrumb', {
+      attributes: {
+        kind: 'crash-breadcrumb',
+        'breadcrumb.name': 'renderer_error',
+        'breadcrumb.data': { message: 'boom', count: 2, ok: true, empty: null }
+      }
+    })
+    expect(spanEndMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces renderer rejection breadcrumbs by reason message', () => {
+    emitRendererBreadcrumb({
+      name: 'renderer_unhandled_rejection',
+      data: { reasonType: 'string', reasonMessage: 'Remote connection dropped/reconnecting' }
+    })
+
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
+      name: 'renderer_unhandled_rejection',
+      data: { reasonType: 'string', reasonMessage: 'Remote connection dropped/reconnecting' },
+      coalesceKey: 'renderer_unhandled_rejection:Remote connection dropped/reconnecting',
+      minIntervalMs: 30_000
+    })
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+  })
+
+  it('records non-error renderer breadcrumbs without coalescing', () => {
+    emitRendererBreadcrumb({ name: 'renderer_bootstrap_started', data: { dev: true } })
+
+    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith('renderer_bootstrap_started', {
+      dev: true
+    })
+    expect(recordCoalescedCrashBreadcrumbMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores renderer breadcrumbs without a string name', () => {
+    emitRendererBreadcrumb({ name: 123, data: { message: 'boom' } })
+
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(recordCoalescedCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(startSpanMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -107,7 +107,7 @@ describe('renderer breadcrumb IPC routing', () => {
     expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
       name: 'renderer_error',
       data: { message: 'boom', count: 2, ok: true, empty: null },
-      coalesceKey: 'renderer_error:boom',
+      coalesceKey: expect.stringContaining('boom'),
       minIntervalMs: 30_000
     })
     expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
@@ -130,7 +130,7 @@ describe('renderer breadcrumb IPC routing', () => {
     expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
       name: 'renderer_unhandled_rejection',
       data: { reasonType: 'string', reasonMessage: 'Remote connection dropped/reconnecting' },
-      coalesceKey: 'renderer_unhandled_rejection:Remote connection dropped/reconnecting',
+      coalesceKey: expect.stringContaining('Remote connection dropped/reconnecting'),
       minIntervalMs: 30_000
     })
     expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
@@ -144,9 +144,41 @@ describe('renderer breadcrumb IPC routing', () => {
     expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
       name: 'renderer_error',
       data: { message },
-      coalesceKey: `renderer_error:${message}`,
+      coalesceKey: expect.stringContaining(message),
       minIntervalMs: 30_000
     })
+  })
+
+  it('does not coalesce same-message errors from different source sites', () => {
+    emitRendererBreadcrumb({
+      name: 'renderer_error',
+      data: { message: 'boom', filename: 'file:///first.js', lineno: 10, colno: 2 }
+    })
+    emitRendererBreadcrumb({
+      name: 'renderer_error',
+      data: { message: 'boom', filename: 'file:///second.js', lineno: 20, colno: 4 }
+    })
+
+    const [first, second] = recordCoalescedCrashBreadcrumbMock.mock.calls.map(
+      ([args]) => args.coalesceKey
+    )
+    expect(first).not.toBe(second)
+  })
+
+  it('does not coalesce same-message rejections from different stacks', () => {
+    emitRendererBreadcrumb({
+      name: 'renderer_unhandled_rejection',
+      data: { reasonMessage: 'boom', reasonStack: 'Error: boom\n at first' }
+    })
+    emitRendererBreadcrumb({
+      name: 'renderer_unhandled_rejection',
+      data: { reasonMessage: 'boom', reasonStack: 'Error: boom\n at second' }
+    })
+
+    const [first, second] = recordCoalescedCrashBreadcrumbMock.mock.calls.map(
+      ([args]) => args.coalesceKey
+    )
+    expect(first).not.toBe(second)
   })
 
   it('records message-less errors without coalescing unrelated failures', () => {
@@ -171,7 +203,7 @@ describe('renderer breadcrumb IPC routing', () => {
     expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
       name: 'renderer_error',
       data: { message: '', errorMessage: 'fallback failure' },
-      coalesceKey: 'renderer_error:fallback failure',
+      coalesceKey: expect.stringContaining('fallback failure'),
       minIntervalMs: 30_000
     })
   })

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -136,6 +136,46 @@ describe('renderer breadcrumb IPC routing', () => {
     expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
   })
 
+  it('keeps the full sanitized message in the coalesce key', () => {
+    const message = `${'same-prefix-'.repeat(12)}distinct-tail`
+
+    emitRendererBreadcrumb({ name: 'renderer_error', data: { message } })
+
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
+      name: 'renderer_error',
+      data: { message },
+      coalesceKey: `renderer_error:${message}`,
+      minIntervalMs: 30_000
+    })
+  })
+
+  it('records message-less errors without coalescing unrelated failures', () => {
+    emitRendererBreadcrumb({
+      name: 'renderer_unhandled_rejection',
+      data: { reasonType: 'Object' }
+    })
+
+    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith('renderer_unhandled_rejection', {
+      reasonType: 'Object'
+    })
+    expect(recordCoalescedCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(startSpanMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the Error object message when an error event has no message', () => {
+    emitRendererBreadcrumb({
+      name: 'renderer_error',
+      data: { message: '', errorMessage: 'fallback failure' }
+    })
+
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith({
+      name: 'renderer_error',
+      data: { message: '', errorMessage: 'fallback failure' },
+      coalesceKey: 'renderer_error:fallback failure',
+      minIntervalMs: 30_000
+    })
+  })
+
   it('does not emit durable trace spans for errors suppressed by coalescing', () => {
     recordCoalescedCrashBreadcrumbMock
       .mockReturnValueOnce({ suppressedSinceLast: 0 })

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -84,6 +84,7 @@ describe('renderer breadcrumb IPC routing', () => {
   beforeEach(() => {
     listeners.clear()
     recordCoalescedCrashBreadcrumbMock.mockReset()
+    recordCoalescedCrashBreadcrumbMock.mockReturnValue({ suppressedSinceLast: 0 })
     recordCrashBreadcrumbMock.mockReset()
     startSpanMock.mockClear()
     spanEndMock.mockClear()
@@ -133,6 +134,34 @@ describe('renderer breadcrumb IPC routing', () => {
       minIntervalMs: 30_000
     })
     expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+  })
+
+  it('does not emit durable trace spans for errors suppressed by coalescing', () => {
+    recordCoalescedCrashBreadcrumbMock
+      .mockReturnValueOnce({ suppressedSinceLast: 0 })
+      .mockReturnValue(undefined)
+
+    for (let index = 0; index < 1_000; index += 1) {
+      emitRendererBreadcrumb({ name: 'renderer_error', data: { message: 'storm' } })
+    }
+
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledTimes(1_000)
+    expect(startSpanMock).toHaveBeenCalledTimes(1)
+    expect(spanEndMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('includes the suppressed count when durable tracing resumes', () => {
+    recordCoalescedCrashBreadcrumbMock.mockReturnValueOnce({ suppressedSinceLast: 999 })
+
+    emitRendererBreadcrumb({ name: 'renderer_error', data: { message: 'storm' } })
+
+    expect(startSpanMock).toHaveBeenCalledWith('renderer.breadcrumb', {
+      attributes: {
+        kind: 'crash-breadcrumb',
+        'breadcrumb.name': 'renderer_error',
+        'breadcrumb.data': { message: 'storm', suppressedSinceLast: 999 }
+      }
+    })
   })
 
   it('records non-error renderer breadcrumbs without coalescing', () => {

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -57,6 +57,8 @@ vi.mock('./feedback', () => ({
 
 vi.mock('../crash-reporting/crash-breadcrumb-store', () => ({
   getCrashBreadcrumbSnapshot: vi.fn(() => []),
+  // Renderer breadcrumb routing is covered in crash-reporting-renderer-breadcrumbs.test.ts.
+  recordCoalescedCrashBreadcrumb: vi.fn(),
   recordCrashBreadcrumb: (...args: unknown[]) => recordCrashBreadcrumbMock(...args)
 }))
 
@@ -781,69 +783,5 @@ describe('registerCrashReportingHandlers', () => {
     })
 
     expect(recordMock).toHaveBeenCalledTimes(261)
-  })
-
-  it('records sanitized renderer breadcrumbs', () => {
-    registerCrashReportingHandlers({
-      getLatestPending: vi.fn(),
-      getById: vi.fn(),
-      dismiss: vi.fn(),
-      markSent: vi.fn(),
-      listRecent: vi.fn(),
-      record: vi.fn(),
-      formatDiagnosticText: vi.fn()
-    } as never)
-
-    listeners.get('crashReports:recordBreadcrumb')?.(null, {
-      name: 'renderer_error',
-      data: {
-        message: 'boom',
-        count: 2,
-        ok: true,
-        empty: null,
-        badNumber: Number.POSITIVE_INFINITY,
-        object: { ignored: true }
-      }
-    })
-
-    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith('renderer_error', {
-      message: 'boom',
-      count: 2,
-      ok: true,
-      empty: null
-    })
-    expect(startSpanMock).toHaveBeenCalledWith('renderer.breadcrumb', {
-      attributes: {
-        kind: 'crash-breadcrumb',
-        'breadcrumb.name': 'renderer_error',
-        'breadcrumb.data': {
-          message: 'boom',
-          count: 2,
-          ok: true,
-          empty: null
-        }
-      }
-    })
-    expect(spanEndMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('ignores renderer breadcrumbs without a string name', () => {
-    registerCrashReportingHandlers({
-      getLatestPending: vi.fn(),
-      getById: vi.fn(),
-      dismiss: vi.fn(),
-      markSent: vi.fn(),
-      listRecent: vi.fn(),
-      record: vi.fn(),
-      formatDiagnosticText: vi.fn()
-    } as never)
-
-    listeners.get('crashReports:recordBreadcrumb')?.(null, {
-      name: 123,
-      data: { message: 'boom' }
-    })
-
-    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
-    expect(startSpanMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -344,7 +344,26 @@ function rendererErrorBreadcrumbCoalesceKey(
         : undefined
   // Why: message-less failures have no stable identity, so grouping them could
   // erase unrelated crash evidence. Sanitization already caps messages at 240 chars.
-  return message ? `${name}:${message}` : undefined
+  if (!message) {
+    return undefined
+  }
+
+  // Why: common messages such as "Script error" or "Cannot read properties"
+  // can come from unrelated sites. Include sanitized source evidence so one
+  // failure cannot suppress the breadcrumb for another.
+  const sourceIdentity =
+    name === 'renderer_error'
+      ? [
+          data?.errorStack,
+          data?.filename,
+          data?.lineno,
+          data?.colno,
+          data?.errorType,
+          data?.errorName,
+          data?.errorMessage
+        ]
+      : [data?.reasonStack, data?.reasonType, data?.reasonName]
+  return JSON.stringify([name, message, ...sourceIdentity])
 }
 
 export function registerCrashReportingHandlers(store: CrashReportStore): void {

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -19,6 +19,7 @@ import { submitFeedback } from './feedback'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
 import {
   getCrashBreadcrumbSnapshot,
+  recordCoalescedCrashBreadcrumb,
   recordCrashBreadcrumb
 } from '../crash-reporting/crash-breadcrumb-store'
 import { startSpan } from '../observability/tracer'
@@ -319,6 +320,26 @@ function buildUncapturedCrashReportText(
   )
 }
 
+// Why: a repeating renderer error (e.g. a ResizeObserver or SSH-rejection
+// storm, #8260) can flush the whole fixed-size breadcrumb ring in seconds,
+// erasing the pre-crash trail. Coalesce repeats into one entry that carries a
+// suppressed count instead.
+const COALESCED_RENDERER_ERROR_BREADCRUMB_NAMES = new Set([
+  'renderer_error',
+  'renderer_unhandled_rejection'
+])
+const RENDERER_ERROR_BREADCRUMB_COALESCE_MS = 30_000
+const RENDERER_ERROR_BREADCRUMB_KEY_MAX_LENGTH = 120
+
+function rendererErrorBreadcrumbCoalesceKey(
+  name: string,
+  data: CrashReportBreadcrumbData | undefined
+): string {
+  const message = data?.message ?? data?.reasonMessage
+  const messageText = typeof message === 'string' ? message : ''
+  return `${name}:${messageText}`.slice(0, RENDERER_ERROR_BREADCRUMB_KEY_MAX_LENGTH)
+}
+
 export function registerCrashReportingHandlers(store: CrashReportStore): void {
   ipcMain.removeHandler('crashReports:getLatestPending')
   ipcMain.handle('crashReports:getLatestPending', () => getLatestPendingReport(store))
@@ -346,7 +367,16 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
         return
       }
       const data = sanitizeRendererBreadcrumbData(args.data)
-      recordCrashBreadcrumb(args.name, data)
+      if (COALESCED_RENDERER_ERROR_BREADCRUMB_NAMES.has(args.name)) {
+        recordCoalescedCrashBreadcrumb({
+          name: args.name,
+          data,
+          coalesceKey: rendererErrorBreadcrumbCoalesceKey(args.name, data),
+          minIntervalMs: RENDERER_ERROR_BREADCRUMB_COALESCE_MS
+        })
+      } else {
+        recordCrashBreadcrumb(args.name, data)
+      }
       recordRendererBreadcrumbTrace(args.name, data)
     }
   )

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -368,16 +368,26 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
       }
       const data = sanitizeRendererBreadcrumbData(args.data)
       if (COALESCED_RENDERER_ERROR_BREADCRUMB_NAMES.has(args.name)) {
-        recordCoalescedCrashBreadcrumb({
+        const coalesceResult = recordCoalescedCrashBreadcrumb({
           name: args.name,
           data,
           coalesceKey: rendererErrorBreadcrumbCoalesceKey(args.name, data),
           minIntervalMs: RENDERER_ERROR_BREADCRUMB_COALESCE_MS
         })
+        // Why: tracing every suppressed duplicate would preserve the same
+        // serialization and disk churn that breadcrumb coalescing removes.
+        if (coalesceResult) {
+          recordRendererBreadcrumbTrace(
+            args.name,
+            coalesceResult.suppressedSinceLast > 0
+              ? { ...data, suppressedSinceLast: coalesceResult.suppressedSinceLast }
+              : data
+          )
+        }
       } else {
         recordCrashBreadcrumb(args.name, data)
+        recordRendererBreadcrumbTrace(args.name, data)
       }
-      recordRendererBreadcrumbTrace(args.name, data)
     }
   )
 

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -329,15 +329,22 @@ const COALESCED_RENDERER_ERROR_BREADCRUMB_NAMES = new Set([
   'renderer_unhandled_rejection'
 ])
 const RENDERER_ERROR_BREADCRUMB_COALESCE_MS = 30_000
-const RENDERER_ERROR_BREADCRUMB_KEY_MAX_LENGTH = 120
 
 function rendererErrorBreadcrumbCoalesceKey(
   name: string,
   data: CrashReportBreadcrumbData | undefined
-): string {
-  const message = data?.message ?? data?.reasonMessage
-  const messageText = typeof message === 'string' ? message : ''
-  return `${name}:${messageText}`.slice(0, RENDERER_ERROR_BREADCRUMB_KEY_MAX_LENGTH)
+): string | undefined {
+  const primaryMessage = name === 'renderer_error' ? data?.message : data?.reasonMessage
+  const fallbackMessage = name === 'renderer_error' ? data?.errorMessage : undefined
+  const message =
+    typeof primaryMessage === 'string' && primaryMessage.length > 0
+      ? primaryMessage
+      : typeof fallbackMessage === 'string' && fallbackMessage.length > 0
+        ? fallbackMessage
+        : undefined
+  // Why: message-less failures have no stable identity, so grouping them could
+  // erase unrelated crash evidence. Sanitization already caps messages at 240 chars.
+  return message ? `${name}:${message}` : undefined
 }
 
 export function registerCrashReportingHandlers(store: CrashReportStore): void {
@@ -368,10 +375,16 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
       }
       const data = sanitizeRendererBreadcrumbData(args.data)
       if (COALESCED_RENDERER_ERROR_BREADCRUMB_NAMES.has(args.name)) {
+        const coalesceKey = rendererErrorBreadcrumbCoalesceKey(args.name, data)
+        if (!coalesceKey) {
+          recordCrashBreadcrumb(args.name, data)
+          recordRendererBreadcrumbTrace(args.name, data)
+          return
+        }
         const coalesceResult = recordCoalescedCrashBreadcrumb({
           name: args.name,
           data,
-          coalesceKey: rendererErrorBreadcrumbCoalesceKey(args.name, data),
+          coalesceKey,
           minIntervalMs: RENDERER_ERROR_BREADCRUMB_COALESCE_MS
         })
         // Why: tracing every suppressed duplicate would preserve the same

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -1232,6 +1232,16 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(shellPathExists).toHaveBeenCalled()
   })
 
+  it('does not invoke the xterm callback twice when the callback throws', async () => {
+    const { provider } = createProviderSetup([makeBufferLine('CLAUDE.md')])
+    const callback = vi.fn(() => {
+      throw new Error('terminal was disposed')
+    })
+
+    provider.provideLinks(1, callback)
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledTimes(1))
+  })
+
   it('shows switch and external-open hint for known worktree root hover', async () => {
     setPlatform('Macintosh')
     storeState.worktreesByRepo = {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -215,29 +215,33 @@ export function createFilePathLinkProvider(
           )
         )
       )
-        .then((resolvedLinks) => {
-          const latestFingerprints = new Set(
-            buildCandidateLogicalLinesForBufferPosition(buffer, bufferLineNumber).map(
-              (logicalLine) => logicalLine.fingerprint
+        .then(
+          (resolvedLinks) => {
+            const latestFingerprints = new Set(
+              buildCandidateLogicalLinesForBufferPosition(buffer, bufferLineNumber).map(
+                (logicalLine) => logicalLine.fingerprint
+              )
             )
-          )
-          const providedLinks = resolvedLinks.filter(
-            (link): link is ProvidedFileLink => link !== null
-          )
-          const links = preferLongestNonOverlappingLinks(providedLinks)
-            .filter(({ logicalLine }) => latestFingerprints.has(logicalLine.fingerprint))
-            .map(({ link }) => link)
-          if (providedLinks.length > 0 && links.length === 0) {
-            return
+            const providedLinks = resolvedLinks.filter(
+              (link): link is ProvidedFileLink => link !== null
+            )
+            const links = preferLongestNonOverlappingLinks(providedLinks)
+              .filter(({ logicalLine }) => latestFingerprints.has(logicalLine.fingerprint))
+              .map(({ link }) => link)
+            if (providedLinks.length > 0 && links.length === 0) {
+              return
+            }
+            callback(links.length > 0 ? links : undefined)
+          },
+          () => {
+            // Why: remote probes reject during SSH teardown; using the rejection
+            // arm avoids treating a consumer callback failure as a probe failure.
+            callback(undefined)
           }
-          callback(links.length > 0 ? links : undefined)
-        })
+        )
         .catch(() => {
-          // Why: remote path-existence probes reject with "Remote connection
-          // dropped/reconnecting" during SSH teardown. Without a catch the
-          // rejected Promise.all is unhandled and the crash-breadcrumb buffer
-          // retains it, growing the renderer heap until it crashes (#8260).
-          callback(undefined)
+          // Link discovery is best-effort; a stale xterm callback must not
+          // recreate the unhandled rejection this path is meant to contain.
         })
     }
   }

--- a/src/renderer/src/lib/crash-diagnostics.test.ts
+++ b/src/renderer/src/lib/crash-diagnostics.test.ts
@@ -125,9 +125,32 @@ describe('renderer crash diagnostics', () => {
       message: 'ResizeObserver loop completed with undelivered notifications.',
       preventDefault
     })
+    listeners.get('error')?.[0]?.({
+      message: 'ResizeObserver loop limit exceeded',
+      preventDefault
+    })
 
-    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(preventDefault).toHaveBeenCalledTimes(2)
     expect(recordBreadcrumbMock).not.toHaveBeenCalled()
+  })
+
+  it('records application errors that only mention a ResizeObserver loop', () => {
+    diagnostics.installRendererCrashDiagnostics()
+    recordBreadcrumbMock.mockClear()
+
+    const preventDefault = vi.fn()
+    listeners.get('error')?.[0]?.({
+      message: 'ResizeObserver loop failed while rendering the terminal',
+      preventDefault
+    })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(recordBreadcrumbMock).toHaveBeenCalledWith({
+      name: 'renderer_error',
+      data: expect.objectContaining({
+        message: 'ResizeObserver loop failed while rendering the terminal'
+      })
+    })
   })
 
   it('disposes global listeners and the memory interval', () => {

--- a/src/renderer/src/lib/crash-diagnostics.ts
+++ b/src/renderer/src/lib/crash-diagnostics.ts
@@ -67,7 +67,11 @@ function recordRendererError(event: ErrorEvent): void {
   // Why: "ResizeObserver loop completed" is a benign, self-resolving Chromium
   // quirk. Recording it fills the breadcrumb buffer and inflates the error
   // count without diagnostic value, contributing to renderer heap growth (#8260).
-  if (/ResizeObserver loop/i.test(event.message)) {
+  if (
+    /^ResizeObserver loop (?:limit exceeded|completed with undelivered notifications)\.?$/i.test(
+      event.message
+    )
+  ) {
     event.preventDefault()
     return
   }


### PR DESCRIPTION
## Summary

Hardens the crash-breadcrumb pipeline against repeated renderer error storms and closes two edge cases in the #8279 guards.

## Problem

The crash-breadcrumb ring holds only 30 events and is snapshotted into crash reports. `renderer_error` and `renderer_unhandled_rejection` previously used the uncoalesced path, so a repeating error could evict the useful pre-crash trail and create one durable trace record per occurrence. The local trace sink serializes these records and flushes them to disk.

## Fix

- Route renderer errors and unhandled rejections with a stable message through `recordCoalescedCrashBreadcrumb` using a 30-second window.
- Key coalescing by the full sanitized message plus sanitized stack/source/type evidence, so unrelated failures with the same generic message cannot suppress each other.
- Suppress duplicate durable trace spans with the same decision; the next recorded span carries `suppressedSinceLast`.
- Keep state bounded: sanitization caps each identity field and the store caps the map at 128 keys.
- Leave message-less failures uncoalesced because they do not have a safe identity; use `errorMessage` when an Error object provides one.
- Handle SSH path-probe rejection separately from xterm callback failures, preventing a throwing/stale callback from being invoked twice or recreating an unhandled rejection.
- Suppress only Chromium's exact benign ResizeObserver messages; application errors that merely mention a ResizeObserver loop remain visible.

## Performance evidence

- A deterministic 1,000-event duplicate storm creates one durable trace span instead of 1,000.
- Suppressed duplicates use the store's O(1) lookup/return path.
- Coalescing state remains capped at 128 keys; no timers, polling, subprocesses, provider scans, or growing buffers are added.

## Terminal reliability contract

- **Invariant (`xterm-addon.boundary-containment`):** rejected remote file probes and throwing/stale xterm callbacks remain pane-scoped, invoke the consumer at most once, and do not escape as unhandled rejections.
- **Failure source:** #8260 and the post-merge review of #8279's SSH teardown guard.
- **Oracle:** renderer-unit tests force a rejected path-existence probe and a throwing xterm callback, then assert an empty-link result or exactly one callback invocation. Source-aware breadcrumb tests also prove same-message failures at different sites retain distinct identities.
- **Gate:** existing experimental, partial `xterm-addon.boundary-containment` gate; its focused command passes with the terminal file-link suite added to the run.
- **Provider/platform coverage:** the containment code is platform-neutral renderer TypeScript. The SSH/remote rejection shape has direct deterministic coverage; local, daemon, WSL, and mobile/relay PTY ownership and I/O paths are unaffected. No live SSH soak or separate Windows/Linux desktop run is claimed here.
- **Performance budget:** one bounded candidate pass and the existing path probes remain; no retry, polling, liveness scan, session listing, startup await, or subprocess work is introduced.
- **Diagnostics:** repeated renderer failures retain a bounded suppressed count and source-aware identity in both the in-memory breadcrumb and resumed durable trace.
- **Residual gaps:** this does not prove the broader rejection-free SSH/xterm heap growth is fixed; that investigation remains in #8655.

## Screenshots

No visual change.

## Testing

- 199 focused crash-reporting, observability, renderer-diagnostics, and terminal-link tests pass after rebasing onto current `main`.
- Full node/CLI/web TypeScript check passes.
- Full lint, switch-exhaustiveness, reliability-gate, max-lines-ratchet, bundled-skill, and localization checks pass.
- Hosted PR verification passed at the prior head on the repository's required Node 24; the pushed review fix triggers a fresh run.

## AI Review Report

- Audited error identity, coalescing bounds, trace serialization, SSH teardown, callback settlement, ResizeObserver classification, cleanup, and source-aware diagnostic preservation.
- Verified macOS/Linux/Windows-neutral behavior; the SSH rejection path has direct regression coverage and no Git/provider behavior changes.
- Fixed false coalescing for long, message-less, and same-message/different-source failures, duplicate callback settlement, and over-broad benign-error suppression.

## Security Audit

- Renderer data is sanitized and secret/path-redacted before it enters a coalescing key or durable trace.
- No new IPC capability, network request, filesystem path, credential handling, or persisted unbounded state is introduced.
- Source-aware keys remain bounded by per-field sanitization and the existing 128-key store cap.

## Notes

This is a follow-up to #8279 / #8260. It protects diagnostic context and removes trace-write amplification, but does not claim to solve the rejection-free SSH/xterm heap growth reported later. That residual terminal-memory investigation is tracked separately in #8655.
