### PR TITLE
feat(codex): one-time backfill of managed-home sessions into the real Codex home

### DIFF
--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -38,6 +38,10 @@ export function getOrcaManagedCodexHomePath(): string {
   return managedHomePath
 }
 
+export function getCodexSessionBackfillStateDirPath(): string {
+  return join(getOrcaUserDataPath(), 'codex-session-backfill')
+}
+
 function getOrcaUserDataPath(): string {
   if (process.env.ORCA_USER_DATA_PATH) {
     return process.env.ORCA_USER_DATA_PATH

--- a/src/main/codex/codex-session-backfill-audit.ts
+++ b/src/main/codex/codex-session-backfill-audit.ts
@@ -1,0 +1,25 @@
+import { appendFile, mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+export type CodexSessionBackfillAuditWriter = (record: Record<string, unknown>) => Promise<void>
+
+export function createCodexSessionBackfillAuditWriter(
+  auditLogPath: string
+): CodexSessionBackfillAuditWriter {
+  let auditDirectoryReady: Promise<string | undefined> | undefined
+  return async (record): Promise<void> => {
+    try {
+      auditDirectoryReady ??= mkdir(dirname(auditLogPath), { recursive: true })
+      await auditDirectoryReady
+      await appendFile(
+        auditLogPath,
+        `${JSON.stringify({ at: new Date().toISOString(), ...record })}\n`,
+        { encoding: 'utf-8' }
+      )
+    } catch (error) {
+      // Why: the audit trail is diagnostics; losing a line must not fail the
+      // backfill or leave a half-linked tree unrecorded in the summary counts.
+      console.warn('[codex-session-backfill] Failed to append audit record:', error)
+    }
+  }
+}

--- a/src/main/codex/codex-session-backfill-copy.ts
+++ b/src/main/codex/codex-session-backfill-copy.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { constants } from 'node:fs'
-import { copyFile, link, rm, writeFile } from 'node:fs/promises'
+import { copyFile, link, lstat, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 export async function copySessionFileWithoutOverwrite(
@@ -21,9 +20,16 @@ export async function copySessionFileWithoutOverwrite(
       if (isExistsError(installLinkError)) {
         throw installLinkError
       }
-      // Some target filesystems do not support hardlinks at all. COPYFILE_EXCL
-      // preserves the collision contract while retaining the staged snapshot.
-      await copyFile(temporaryPath, targetPath, constants.COPYFILE_EXCL)
+      // Why: some target filesystems support no hardlinks at all. Install the
+      // fully-staged copy with an atomic rename — never a raw copy into the
+      // rollout filename — so an interrupted install cannot strand a truncated
+      // session that a later run skips as already-present. Re-check existence
+      // first because rename, unlike the hardlink above, would clobber a target
+      // that appeared mid-run.
+      if (await pathEntryExists(targetPath)) {
+        throw makeTargetExistsError(targetPath)
+      }
+      await rename(temporaryPath, targetPath)
     }
   } finally {
     try {
@@ -36,6 +42,23 @@ export async function copySessionFileWithoutOverwrite(
   }
 }
 
+/** Existence via lstat so a broken symlink at the target still counts as taken. */
+async function pathEntryExists(entryPath: string): Promise<boolean> {
+  try {
+    await lstat(entryPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
 function isExistsError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
+}
+
+/** EEXIST so a rename-install collision routes to the skip path, not a failure. */
+function makeTargetExistsError(targetPath: string): NodeJS.ErrnoException {
+  const error = new Error(`EEXIST: backfill target already exists: ${targetPath}`)
+  ;(error as NodeJS.ErrnoException).code = 'EEXIST'
+  return error
 }

--- a/src/main/codex/codex-session-backfill-copy.ts
+++ b/src/main/codex/codex-session-backfill-copy.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto'
-import { copyFile, link, lstat, rename, rm, writeFile } from 'node:fs/promises'
+import { copyFile, link, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+
+const ATOMIC_NO_REPLACE_UNSUPPORTED_CODE = 'ORCA_ATOMIC_NO_REPLACE_UNSUPPORTED'
 
 export async function copySessionFileWithoutOverwrite(
   sourcePath: string,
@@ -20,16 +22,12 @@ export async function copySessionFileWithoutOverwrite(
       if (isExistsError(installLinkError)) {
         throw installLinkError
       }
-      // Why: some target filesystems support no hardlinks at all. Install the
-      // fully-staged copy with an atomic rename — never a raw copy into the
-      // rollout filename — so an interrupted install cannot strand a truncated
-      // session that a later run skips as already-present. Re-check existence
-      // first because rename, unlike the hardlink above, would clobber a target
-      // that appeared mid-run.
-      if (await pathEntryExists(targetPath)) {
-        throw makeTargetExistsError(targetPath)
+      if (!isHardlinkUnsupportedError(installLinkError)) {
+        throw installLinkError
       }
-      await rename(temporaryPath, targetPath)
+      // Why: Node has no portable atomic rename-if-absent. Fail closed on a
+      // hardlink-less target instead of risking replacement of a concurrent file.
+      throw makeAtomicNoReplaceUnsupportedError(targetPath, installLinkError)
     }
   } finally {
     try {
@@ -42,23 +40,33 @@ export async function copySessionFileWithoutOverwrite(
   }
 }
 
-/** Existence via lstat so a broken symlink at the target still counts as taken. */
-async function pathEntryExists(entryPath: string): Promise<boolean> {
-  try {
-    await lstat(entryPath)
-    return true
-  } catch {
-    return false
-  }
-}
-
 function isExistsError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
 }
 
-/** EEXIST so a rename-install collision routes to the skip path, not a failure. */
-function makeTargetExistsError(targetPath: string): NodeJS.ErrnoException {
-  const error = new Error(`EEXIST: backfill target already exists: ${targetPath}`)
-  ;(error as NodeJS.ErrnoException).code = 'EEXIST'
+function isHardlinkUnsupportedError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return (
+    code === 'EPERM' ||
+    code === 'EACCES' ||
+    code === 'ENOTSUP' ||
+    code === 'EOPNOTSUPP' ||
+    code === 'ENOSYS'
+  )
+}
+
+function makeAtomicNoReplaceUnsupportedError(
+  targetPath: string,
+  cause: unknown
+): NodeJS.ErrnoException {
+  const error = new Error(
+    `Cannot atomically install backfill without overwrite on this filesystem: ${targetPath}`,
+    { cause }
+  ) as NodeJS.ErrnoException
+  error.code = ATOMIC_NO_REPLACE_UNSUPPORTED_CODE
   return error
+}
+
+export function isAtomicNoReplaceUnsupportedError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === ATOMIC_NO_REPLACE_UNSUPPORTED_CODE
 }

--- a/src/main/codex/codex-session-backfill-copy.ts
+++ b/src/main/codex/codex-session-backfill-copy.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from 'node:crypto'
+import { constants } from 'node:fs'
+import { copyFile, link, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+export async function copySessionFileWithoutOverwrite(
+  sourcePath: string,
+  targetPath: string
+): Promise<void> {
+  const temporaryPath = join(dirname(targetPath), `.orca-backfill-${randomUUID()}.tmp`)
+  // Why: stage cross-volume copies away from the rollout filename so a failed
+  // copy cannot strand a truncated session that a later retry would skip.
+  await writeFile(temporaryPath, '', { encoding: 'utf-8', flag: 'wx', mode: 0o600 })
+  try {
+    await copyFile(sourcePath, temporaryPath)
+    try {
+      // Why: this same-volume hardlink atomically installs the staged copy
+      // without risking a collision overwrite after an EXDEV fallback.
+      await link(temporaryPath, targetPath)
+    } catch (installLinkError) {
+      if (isExistsError(installLinkError)) {
+        throw installLinkError
+      }
+      // Some target filesystems do not support hardlinks at all. COPYFILE_EXCL
+      // preserves the collision contract while retaining the staged snapshot.
+      await copyFile(temporaryPath, targetPath, constants.COPYFILE_EXCL)
+    }
+  } finally {
+    try {
+      await rm(temporaryPath, { force: true })
+    } catch (error) {
+      // Why: cleanup trouble must not misreport a successfully installed
+      // rollout as a copy failure; the .tmp file is ignored by Codex.
+      console.warn('[codex-session-backfill] Failed to remove staged copy:', temporaryPath, error)
+    }
+  }
+}
+
+function isExistsError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
+}

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -23,6 +23,8 @@ const { homedirMock } = vi.hoisted(() => ({
 const { fsMockState } = vi.hoisted(() => ({
   fsMockState: {
     failLink: false,
+    failInstallLink: false,
+    failInstallRename: false,
     failCopy: false,
     failDirectoryPath: null as string | null,
     failLstatPath: null as string | null
@@ -60,7 +62,24 @@ vi.mock('node:fs/promises', async () => {
         error.code = 'EXDEV'
         throw error
       }
+      // Simulate a target filesystem with no hardlink support: even the
+      // same-volume staged-copy install link (.orca-backfill-*.tmp) fails.
+      if (fsMockState.failInstallLink && String(args[0]).includes('.orca-backfill-')) {
+        const error = new Error('EPERM: hardlinks unsupported') as NodeJS.ErrnoException
+        error.code = 'EPERM'
+        throw error
+      }
       return actual.link(...args)
+    },
+    rename: (...args: Parameters<typeof actual.rename>) => {
+      // Simulate an interrupted atomic install (crash/ENOSPC mid-rename) on a
+      // hardlink-less target, exercising the no-partial-stranded guarantee.
+      if (fsMockState.failInstallRename && String(args[0]).includes('.orca-backfill-')) {
+        const error = new Error('EIO: rename interrupted') as NodeJS.ErrnoException
+        error.code = 'EIO'
+        throw error
+      }
+      return actual.rename(...args)
     },
     copyFile: async (...args: Parameters<typeof actual.copyFile>) => {
       if (fsMockState.failCopy) {
@@ -134,6 +153,8 @@ function readAuditActions(): string[] {
 
 beforeEach(() => {
   fsMockState.failLink = false
+  fsMockState.failInstallLink = false
+  fsMockState.failInstallRename = false
   fsMockState.failCopy = false
   fsMockState.failDirectoryPath = null
   fsMockState.failLstatPath = null
@@ -287,6 +308,51 @@ describe('backfillManagedCodexSessionsIntoSystemHome', () => {
     expect(readFileSync(targetPath, 'utf-8')).toBe(readFileSync(managedPath, 'utf-8'))
     expect(lstatSync(targetPath).ino).not.toBe(lstatSync(managedPath).ino)
     expect(readAuditActions()).toEqual(['copy', 'run-summary'])
+  })
+
+  it('installs via atomic rename when the target volume has no hardlink support', async () => {
+    // Why: exFAT/FAT and some network targets support no hardlinks, so even the
+    // staged-copy install link fails and the atomic-rename fallback must run.
+    fsMockState.failLink = true
+    fsMockState.failInstallLink = true
+    const managedPath = writeManagedSession(
+      join('2026', '05', '26', 'rollout-a.jsonl'),
+      '{"id":"a"}\n'
+    )
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({ linkedFiles: 0, copiedFiles: 1, failedFiles: 0 })
+    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    expect(readFileSync(targetPath, 'utf-8')).toBe(readFileSync(managedPath, 'utf-8'))
+    // Staged temp file is renamed into place, not stranded in the sessions tree.
+    expect(
+      readdirSync(dirname(targetPath)).filter((name) => name.includes('.orca-backfill-'))
+    ).toEqual([])
+    expect(readAuditActions()).toEqual(['copy', 'run-summary'])
+  })
+
+  it('never strands a partial rollout when the atomic install is interrupted', async () => {
+    // Why: a hardlink-less target plus an interrupted install must leave the
+    // real rollout filename absent (not truncated), so the next run retries
+    // instead of skipping a partial session as already-present.
+    fsMockState.failLink = true
+    fsMockState.failInstallLink = true
+    fsMockState.failInstallRename = true
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({ failedFiles: 1, copiedFiles: 0, linkedFiles: 0 })
+    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    expect(existsSync(targetPath)).toBe(false)
+    // No partial rollout and no leftover staging file in the user's tree.
+    expect(readdirSync(dirname(targetPath))).toEqual([])
+    expect(readAuditActions()).toEqual(['failed', 'run-summary'])
   })
 
   it('records per-file failures without aborting the run', async () => {

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import type * as NodeOs from 'node:os'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+const { fsMockState } = vi.hoisted(() => ({
+  fsMockState: {
+    failLink: false,
+    failCopy: false
+  }
+}))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return {
+    ...actual,
+    linkSync: (...args: Parameters<typeof actual.linkSync>) => {
+      if (fsMockState.failLink) {
+        const error = new Error('EXDEV: cross-device link') as NodeJS.ErrnoException
+        error.code = 'EXDEV'
+        throw error
+      }
+      return actual.linkSync(...args)
+    },
+    copyFileSync: (...args: Parameters<typeof actual.copyFileSync>) => {
+      if (fsMockState.failCopy) {
+        const error = new Error('EACCES: copy disabled for test') as NodeJS.ErrnoException
+        error.code = 'EACCES'
+        throw error
+      }
+      return actual.copyFileSync(...args)
+    }
+  }
+})
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+import {
+  backfillManagedCodexSessionsIntoSystemHome,
+  resolveCodexSessionBackfillPaths,
+  startCodexSessionBackfillInBackground
+} from './codex-session-backfill'
+
+let fakeHomeDir: string
+let userDataDir: string
+let previousUserDataPath: string | undefined
+
+function getSystemSessionsRoot(): string {
+  return join(fakeHomeDir, '.codex', 'sessions')
+}
+
+function getManagedSessionsRoot(): string {
+  return join(userDataDir, 'codex-runtime-home', 'home', 'sessions')
+}
+
+function getMarkerPath(): string {
+  return join(userDataDir, 'codex-session-backfill', 'backfill-complete.json')
+}
+
+function getAuditLogPath(): string {
+  return join(userDataDir, 'codex-session-backfill', 'audit.jsonl')
+}
+
+function writeManagedSession(relativePath: string, contents: string): string {
+  const filePath = join(getManagedSessionsRoot(), relativePath)
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, contents, 'utf-8')
+  return filePath
+}
+
+function readAuditActions(): string[] {
+  return readFileSync(getAuditLogPath(), 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => (JSON.parse(line) as { action: string }).action)
+}
+
+beforeEach(() => {
+  fsMockState.failLink = false
+  fsMockState.failCopy = false
+  fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-backfill-home-'))
+  userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-backfill-user-data-'))
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataDir
+  homedirMock.mockReturnValue(fakeHomeDir)
+})
+
+afterEach(() => {
+  rmSync(fakeHomeDir, { recursive: true, force: true })
+  rmSync(userDataDir, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.clearAllMocks()
+})
+
+describe('backfillManagedCodexSessionsIntoSystemHome', () => {
+  it('hardlinks managed rollout files into the real home preserving layout', async () => {
+    const managedPath = writeManagedSession(
+      join('2026', '05', '26', 'rollout-a.jsonl'),
+      '{"type":"session_meta","id":"a"}\n'
+    )
+    writeManagedSession(join('2026', '06', '01', 'rollout-b.jsonl'), '{"id":"b"}\n')
+    writeFileSync(join(getManagedSessionsRoot(), '2026', '05', '26', 'notes.txt'), 'skip me\n')
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({ scannedFiles: 2, linkedFiles: 2, failedFiles: 0 })
+    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    expect(lstatSync(targetPath).ino).toBe(lstatSync(managedPath).ino)
+    expect(existsSync(join(getSystemSessionsRoot(), '2026', '06', '01', 'rollout-b.jsonl'))).toBe(
+      true
+    )
+    expect(existsSync(join(getSystemSessionsRoot(), '2026', '05', '26', 'notes.txt'))).toBe(false)
+    expect(readAuditActions()).toEqual(['hardlink', 'hardlink', 'run-summary'])
+  })
+
+  it('never overwrites an existing target file, even with different contents', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), 'managed contents\n')
+    const collidingPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    mkdirSync(dirname(collidingPath), { recursive: true })
+    writeFileSync(collidingPath, 'user contents\n', 'utf-8')
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({ scannedFiles: 1, linkedFiles: 0, skippedExistingFiles: 1 })
+    expect(readFileSync(collidingPath, 'utf-8')).toBe('user contents\n')
+    expect(readAuditActions()).toEqual(['run-summary'])
+  })
+
+  it('treats a broken symlink at the target as taken', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), 'managed contents\n')
+    const collidingPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    mkdirSync(dirname(collidingPath), { recursive: true })
+    try {
+      symlinkSync(join(fakeHomeDir, 'missing-target.jsonl'), collidingPath)
+    } catch {
+      // Windows without symlink privilege cannot set up this fixture.
+      return
+    }
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({ linkedFiles: 0, copiedFiles: 0, skippedExistingFiles: 1 })
+    expect(lstatSync(collidingPath).isSymbolicLink()).toBe(true)
+  })
+
+  it('does not backfill symlinked managed session files', async () => {
+    const realSource = join(fakeHomeDir, 'outside.jsonl')
+    writeFileSync(realSource, 'outside contents\n', 'utf-8')
+    const managedLinkPath = join(getManagedSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    mkdirSync(dirname(managedLinkPath), { recursive: true })
+    try {
+      symlinkSync(realSource, managedLinkPath)
+    } catch {
+      return
+    }
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    // Why: the session walker skips symlink dirents, so bridge-created links
+    // (which point back into the user's own home) never reach the copier.
+    expect(summary).toMatchObject({ linkedFiles: 0, copiedFiles: 0, failedFiles: 0 })
+    expect(existsSync(join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl'))).toBe(
+      false
+    )
+  })
+
+  it('is idempotent: a second run links nothing new and changes nothing', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+    const paths = resolveCodexSessionBackfillPaths()
+
+    const first = await backfillManagedCodexSessionsIntoSystemHome(paths)
+    const second = await backfillManagedCodexSessionsIntoSystemHome(paths)
+
+    expect(first).toMatchObject({ linkedFiles: 1 })
+    expect(second).toMatchObject({ linkedFiles: 0, copiedFiles: 0, skippedExistingFiles: 1 })
+  })
+
+  it('falls back to copy when hardlinking fails across volumes', async () => {
+    fsMockState.failLink = true
+    const managedPath = writeManagedSession(
+      join('2026', '05', '26', 'rollout-a.jsonl'),
+      '{"id":"a"}\n'
+    )
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({ linkedFiles: 0, copiedFiles: 1, failedFiles: 0 })
+    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    expect(readFileSync(targetPath, 'utf-8')).toBe(readFileSync(managedPath, 'utf-8'))
+    expect(lstatSync(targetPath).ino).not.toBe(lstatSync(managedPath).ino)
+    expect(readAuditActions()).toEqual(['copy', 'run-summary'])
+  })
+
+  it('records per-file failures without aborting the run', async () => {
+    fsMockState.failLink = true
+    fsMockState.failCopy = true
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({ failedFiles: 1, linkedFiles: 0, copiedFiles: 0 })
+    expect(readAuditActions()).toEqual(['failed', 'run-summary'])
+  })
+
+  it('does not create the real sessions tree when there is nothing to backfill', async () => {
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({ scannedFiles: 0 })
+    expect(existsSync(getSystemSessionsRoot())).toBe(false)
+  })
+})
+
+describe('startCodexSessionBackfillInBackground', () => {
+  it('writes a completion marker and skips the walk on later runs', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+
+    const first = await startCodexSessionBackfillInBackground()
+    expect(first).toMatchObject({ linkedFiles: 1, failedFiles: 0 })
+    expect(existsSync(getMarkerPath())).toBe(true)
+
+    // A file appearing after the marker must not be backfilled again.
+    writeManagedSession(join('2026', '07', '01', 'rollout-later.jsonl'), '{"id":"later"}\n')
+    const second = await startCodexSessionBackfillInBackground()
+    expect(second).toBeNull()
+    expect(
+      existsSync(join(getSystemSessionsRoot(), '2026', '07', '01', 'rollout-later.jsonl'))
+    ).toBe(false)
+  })
+
+  it('leaves the marker unset when any file fails so the next startup retries', async () => {
+    fsMockState.failLink = true
+    fsMockState.failCopy = true
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+
+    const first = await startCodexSessionBackfillInBackground()
+    expect(first).toMatchObject({ failedFiles: 1 })
+    expect(existsSync(getMarkerPath())).toBe(false)
+
+    fsMockState.failLink = false
+    fsMockState.failCopy = false
+    const second = await startCodexSessionBackfillInBackground()
+    expect(second).toMatchObject({ linkedFiles: 1, failedFiles: 0 })
+    expect(existsSync(getMarkerPath())).toBe(true)
+  })
+
+  it('honors a custom system Codex home override', async () => {
+    const customHome = join(fakeHomeDir, 'custom-codex-home')
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+
+    const summary = await startCodexSessionBackfillInBackground({}, customHome)
+
+    expect(summary).toMatchObject({ linkedFiles: 1 })
+    expect(existsSync(join(customHome, 'sessions', '2026', '05', '26', 'rollout-a.jsonl'))).toBe(
+      true
+    )
+    expect(existsSync(getSystemSessionsRoot())).toBe(false)
+  })
+})

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -4,12 +4,14 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync
 } from 'node:fs'
 import type * as NodeFs from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -21,7 +23,8 @@ const { homedirMock } = vi.hoisted(() => ({
 const { fsMockState } = vi.hoisted(() => ({
   fsMockState: {
     failLink: false,
-    failCopy: false
+    failCopy: false,
+    failDirectoryPath: null as string | null
   }
 }))
 
@@ -39,11 +42,29 @@ vi.mock('node:fs', async () => {
     },
     copyFileSync: (...args: Parameters<typeof actual.copyFileSync>) => {
       if (fsMockState.failCopy) {
+        // Simulate a copy that fails after opening its destination, which is
+        // the dangerous case for resumability rather than a preflight error.
+        actual.writeFileSync(args[1], 'partial copy\n', 'utf-8')
         const error = new Error('EACCES: copy disabled for test') as NodeJS.ErrnoException
         error.code = 'EACCES'
         throw error
       }
       return actual.copyFileSync(...args)
+    }
+  }
+})
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+  return {
+    ...actual,
+    opendir: (...args: Parameters<typeof actual.opendir>) => {
+      if (args[0] === fsMockState.failDirectoryPath) {
+        const error = new Error('EACCES: directory unreadable') as NodeJS.ErrnoException
+        error.code = 'EACCES'
+        throw error
+      }
+      return actual.opendir(...args)
     }
   }
 })
@@ -99,6 +120,7 @@ function readAuditActions(): string[] {
 beforeEach(() => {
   fsMockState.failLink = false
   fsMockState.failCopy = false
+  fsMockState.failDirectoryPath = null
   fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-backfill-home-'))
   userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-backfill-user-data-'))
   previousUserDataPath = process.env.ORCA_USER_DATA_PATH
@@ -138,6 +160,32 @@ describe('backfillManagedCodexSessionsIntoSystemHome', () => {
     )
     expect(existsSync(join(getSystemSessionsRoot(), '2026', '05', '26', 'notes.txt'))).toBe(false)
     expect(readAuditActions()).toEqual(['hardlink', 'hardlink', 'run-summary'])
+  })
+
+  it('only backfills rollout files in the exact YYYY/MM/DD layout', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-valid ü.jsonl'), 'valid\n')
+    writeManagedSession(join('2026', '05', '26', 'session-index.jsonl'), 'not a rollout\n')
+    writeManagedSession(join('2026', '5', '26', 'rollout-wrong-month.jsonl'), 'wrong month\n')
+    writeManagedSession(join('scratch', 'rollout-too-shallow.jsonl'), 'too shallow\n')
+    writeManagedSession(join('2026', '05', '26', 'nested', 'rollout-too-deep.jsonl'), 'too deep\n')
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({
+      scannedFiles: 5,
+      linkedFiles: 1,
+      skippedUnexpectedFiles: 4,
+      failedFiles: 0
+    })
+    expect(
+      existsSync(join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-valid ü.jsonl'))
+    ).toBe(true)
+    expect(
+      existsSync(join(getSystemSessionsRoot(), '2026', '05', '26', 'session-index.jsonl'))
+    ).toBe(false)
+    expect(existsSync(join(getSystemSessionsRoot(), 'scratch'))).toBe(false)
   })
 
   it('never overwrites an existing target file, even with different contents', async () => {
@@ -192,9 +240,8 @@ describe('backfillManagedCodexSessionsIntoSystemHome', () => {
     // Why: the session walker skips symlink dirents, so bridge-created links
     // (which point back into the user's own home) never reach the copier.
     expect(summary).toMatchObject({ linkedFiles: 0, copiedFiles: 0, failedFiles: 0 })
-    expect(existsSync(join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl'))).toBe(
-      false
-    )
+    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    expect(existsSync(targetPath)).toBe(false)
   })
 
   it('is idempotent: a second run links nothing new and changes nothing', async () => {
@@ -236,6 +283,9 @@ describe('backfillManagedCodexSessionsIntoSystemHome', () => {
     )
 
     expect(summary).toMatchObject({ failedFiles: 1, linkedFiles: 0, copiedFiles: 0 })
+    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    expect(existsSync(targetPath)).toBe(false)
+    expect(readdirSync(dirname(targetPath))).toEqual([])
     expect(readAuditActions()).toEqual(['failed', 'run-summary'])
   })
 
@@ -274,11 +324,36 @@ describe('startCodexSessionBackfillInBackground', () => {
     const first = await startCodexSessionBackfillInBackground()
     expect(first).toMatchObject({ failedFiles: 1 })
     expect(existsSync(getMarkerPath())).toBe(false)
+    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    expect(existsSync(targetPath)).toBe(false)
 
     fsMockState.failLink = false
     fsMockState.failCopy = false
     const second = await startCodexSessionBackfillInBackground()
     expect(second).toMatchObject({ linkedFiles: 1, failedFiles: 0 })
+    expect(readFileSync(targetPath, 'utf-8')).toBe('{"id":"a"}\n')
+    expect(existsSync(getMarkerPath())).toBe(true)
+  })
+
+  it('leaves the marker unset when a directory cannot be scanned', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-readable.jsonl'), 'readable\n')
+    const unreadableDirectory = dirname(
+      writeManagedSession(join('2026', '06', '01', 'rollout-unreadable.jsonl'), 'unreadable\n')
+    )
+    fsMockState.failDirectoryPath = unreadableDirectory
+
+    const first = await startCodexSessionBackfillInBackground({ yieldMs: 0 })
+
+    expect(first).toMatchObject({ failedDirectories: 1 })
+    expect(existsSync(getMarkerPath())).toBe(false)
+    expect(readAuditActions()).toContain('scan-failed')
+
+    fsMockState.failDirectoryPath = null
+    const second = await startCodexSessionBackfillInBackground({ yieldMs: 0 })
+    expect(second).toMatchObject({ failedDirectories: 0, failedFiles: 0 })
+    expect(
+      existsSync(join(getSystemSessionsRoot(), '2026', '06', '01', 'rollout-unreadable.jsonl'))
+    ).toBe(true)
     expect(existsSync(getMarkerPath())).toBe(true)
   })
 
@@ -293,5 +368,19 @@ describe('startCodexSessionBackfillInBackground', () => {
       true
     )
     expect(existsSync(getSystemSessionsRoot())).toBe(false)
+  })
+
+  it('re-runs when the configured real Codex home changes', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+    await startCodexSessionBackfillInBackground()
+    const customHome = join(fakeHomeDir, 'custom Codex ü')
+
+    const moved = await startCodexSessionBackfillInBackground({}, customHome)
+
+    expect(moved).toMatchObject({ linkedFiles: 1, failedFiles: 0 })
+    expect(existsSync(join(customHome, 'sessions', '2026', '05', '26', 'rollout-a.jsonl'))).toBe(
+      true
+    )
+    expect(await startCodexSessionBackfillInBackground({}, customHome)).toBeNull()
   })
 })

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -33,7 +33,7 @@ vi.mock('node:fs', async () => {
   return {
     ...actual,
     linkSync: (...args: Parameters<typeof actual.linkSync>) => {
-      if (fsMockState.failLink) {
+      if (fsMockState.failLink && String(args[0]).includes('codex-runtime-home')) {
         const error = new Error('EXDEV: cross-device link') as NodeJS.ErrnoException
         error.code = 'EXDEV'
         throw error
@@ -258,7 +258,7 @@ describe('backfillManagedCodexSessionsIntoSystemHome', () => {
   it('falls back to copy when hardlinking fails across volumes', async () => {
     fsMockState.failLink = true
     const managedPath = writeManagedSession(
-      join('2026', '05', '26', 'rollout-a.jsonl'),
+      join('2026', '05', '26', 'rollout-a ü.jsonl'),
       '{"id":"a"}\n'
     )
 
@@ -267,7 +267,7 @@ describe('backfillManagedCodexSessionsIntoSystemHome', () => {
     )
 
     expect(summary).toMatchObject({ linkedFiles: 0, copiedFiles: 1, failedFiles: 0 })
-    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
+    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a ü.jsonl')
     expect(readFileSync(targetPath, 'utf-8')).toBe(readFileSync(managedPath, 'utf-8'))
     expect(lstatSync(targetPath).ino).not.toBe(lstatSync(managedPath).ino)
     expect(readAuditActions()).toEqual(['copy', 'run-summary'])

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -24,7 +24,7 @@ const { fsMockState } = vi.hoisted(() => ({
   fsMockState: {
     failLink: false,
     failInstallLink: false,
-    failInstallRename: false,
+    failInstallLinkTransiently: false,
     failCopy: false,
     failDirectoryPath: null as string | null,
     failLstatPath: null as string | null
@@ -69,17 +69,12 @@ vi.mock('node:fs/promises', async () => {
         error.code = 'EPERM'
         throw error
       }
-      return actual.link(...args)
-    },
-    rename: (...args: Parameters<typeof actual.rename>) => {
-      // Simulate an interrupted atomic install (crash/ENOSPC mid-rename) on a
-      // hardlink-less target, exercising the no-partial-stranded guarantee.
-      if (fsMockState.failInstallRename && String(args[0]).includes('.orca-backfill-')) {
-        const error = new Error('EIO: rename interrupted') as NodeJS.ErrnoException
+      if (fsMockState.failInstallLinkTransiently && String(args[0]).includes('.orca-backfill-')) {
+        const error = new Error('EIO: transient install failure') as NodeJS.ErrnoException
         error.code = 'EIO'
         throw error
       }
-      return actual.rename(...args)
+      return actual.link(...args)
     },
     copyFile: async (...args: Parameters<typeof actual.copyFile>) => {
       if (fsMockState.failCopy) {
@@ -154,7 +149,7 @@ function readAuditActions(): string[] {
 beforeEach(() => {
   fsMockState.failLink = false
   fsMockState.failInstallLink = false
-  fsMockState.failInstallRename = false
+  fsMockState.failInstallLinkTransiently = false
   fsMockState.failCopy = false
   fsMockState.failDirectoryPath = null
   fsMockState.failLstatPath = null
@@ -310,48 +305,40 @@ describe('backfillManagedCodexSessionsIntoSystemHome', () => {
     expect(readAuditActions()).toEqual(['copy', 'run-summary'])
   })
 
-  it('installs via atomic rename when the target volume has no hardlink support', async () => {
-    // Why: exFAT/FAT and some network targets support no hardlinks, so even the
-    // staged-copy install link fails and the atomic-rename fallback must run.
+  it('fails closed when the target filesystem cannot install without overwrite', async () => {
     fsMockState.failLink = true
     fsMockState.failInstallLink = true
-    const managedPath = writeManagedSession(
-      join('2026', '05', '26', 'rollout-a.jsonl'),
-      '{"id":"a"}\n'
-    )
-
-    const summary = await backfillManagedCodexSessionsIntoSystemHome(
-      resolveCodexSessionBackfillPaths()
-    )
-
-    expect(summary).toMatchObject({ linkedFiles: 0, copiedFiles: 1, failedFiles: 0 })
-    const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
-    expect(readFileSync(targetPath, 'utf-8')).toBe(readFileSync(managedPath, 'utf-8'))
-    // Staged temp file is renamed into place, not stranded in the sessions tree.
-    expect(
-      readdirSync(dirname(targetPath)).filter((name) => name.includes('.orca-backfill-'))
-    ).toEqual([])
-    expect(readAuditActions()).toEqual(['copy', 'run-summary'])
-  })
-
-  it('never strands a partial rollout when the atomic install is interrupted', async () => {
-    // Why: a hardlink-less target plus an interrupted install must leave the
-    // real rollout filename absent (not truncated), so the next run retries
-    // instead of skipping a partial session as already-present.
-    fsMockState.failLink = true
-    fsMockState.failInstallLink = true
-    fsMockState.failInstallRename = true
     writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
 
     const summary = await backfillManagedCodexSessionsIntoSystemHome(
       resolveCodexSessionBackfillPaths()
     )
 
-    expect(summary).toMatchObject({ failedFiles: 1, copiedFiles: 0, linkedFiles: 0 })
+    expect(summary).toMatchObject({
+      linkedFiles: 0,
+      copiedFiles: 0,
+      skippedUnsupportedFilesystemFiles: 1,
+      failedFiles: 0
+    })
     const targetPath = join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl')
     expect(existsSync(targetPath)).toBe(false)
-    // No partial rollout and no leftover staging file in the user's tree.
     expect(readdirSync(dirname(targetPath))).toEqual([])
+    expect(readAuditActions()).toEqual(['copy-unsupported', 'run-summary'])
+  })
+
+  it('keeps transient install failures retryable', async () => {
+    fsMockState.failLink = true
+    fsMockState.failInstallLinkTransiently = true
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+
+    const summary = await backfillManagedCodexSessionsIntoSystemHome(
+      resolveCodexSessionBackfillPaths()
+    )
+
+    expect(summary).toMatchObject({
+      skippedUnsupportedFilesystemFiles: 0,
+      failedFiles: 1
+    })
     expect(readAuditActions()).toEqual(['failed', 'run-summary'])
   })
 
@@ -396,6 +383,18 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(
       existsSync(join(getSystemSessionsRoot(), '2026', '07', '01', 'rollout-later.jsonl'))
     ).toBe(false)
+  })
+
+  it('does not retry a stable hardlink-less filesystem limitation', async () => {
+    fsMockState.failLink = true
+    fsMockState.failInstallLink = true
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+
+    const first = await startCodexSessionBackfillInBackground()
+    expect(first).toMatchObject({ skippedUnsupportedFilesystemFiles: 1, failedFiles: 0 })
+    expect(existsSync(getMarkerPath())).toBe(true)
+
+    expect(await startCodexSessionBackfillInBackground()).toBeNull()
   })
 
   it('leaves the marker unset when any file fails so the next startup retries', async () => {

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -24,7 +24,8 @@ const { fsMockState } = vi.hoisted(() => ({
   fsMockState: {
     failLink: false,
     failCopy: false,
-    failDirectoryPath: null as string | null
+    failDirectoryPath: null as string | null,
+    failLstatPath: null as string | null
   }
 }))
 
@@ -32,24 +33,11 @@ vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof NodeFs>('node:fs')
   return {
     ...actual,
-    linkSync: (...args: Parameters<typeof actual.linkSync>) => {
-      if (fsMockState.failLink && String(args[0]).includes('codex-runtime-home')) {
-        const error = new Error('EXDEV: cross-device link') as NodeJS.ErrnoException
-        error.code = 'EXDEV'
-        throw error
+    existsSync: (...args: Parameters<typeof actual.existsSync>) => {
+      if (args[0] === fsMockState.failLstatPath) {
+        return false
       }
-      return actual.linkSync(...args)
-    },
-    copyFileSync: (...args: Parameters<typeof actual.copyFileSync>) => {
-      if (fsMockState.failCopy) {
-        // Simulate a copy that fails after opening its destination, which is
-        // the dangerous case for resumability rather than a preflight error.
-        actual.writeFileSync(args[1], 'partial copy\n', 'utf-8')
-        const error = new Error('EACCES: copy disabled for test') as NodeJS.ErrnoException
-        error.code = 'EACCES'
-        throw error
-      }
-      return actual.copyFileSync(...args)
+      return actual.existsSync(...args)
     }
   }
 })
@@ -58,6 +46,33 @@ vi.mock('node:fs/promises', async () => {
   const actual = await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
   return {
     ...actual,
+    lstat: (...args: Parameters<typeof actual.lstat>) => {
+      if (args[0] === fsMockState.failLstatPath) {
+        const error = new Error('EACCES: path inaccessible') as NodeJS.ErrnoException
+        error.code = 'EACCES'
+        throw error
+      }
+      return actual.lstat(...args)
+    },
+    link: (...args: Parameters<typeof actual.link>) => {
+      if (fsMockState.failLink && String(args[0]).includes('codex-runtime-home')) {
+        const error = new Error('EXDEV: cross-device link') as NodeJS.ErrnoException
+        error.code = 'EXDEV'
+        throw error
+      }
+      return actual.link(...args)
+    },
+    copyFile: async (...args: Parameters<typeof actual.copyFile>) => {
+      if (fsMockState.failCopy) {
+        // Simulate a copy that fails after opening its destination, which is
+        // the dangerous case for resumability rather than a preflight error.
+        await actual.writeFile(args[1], 'partial copy\n', 'utf-8')
+        const error = new Error('EACCES: copy disabled for test') as NodeJS.ErrnoException
+        error.code = 'EACCES'
+        throw error
+      }
+      return actual.copyFile(...args)
+    },
     opendir: (...args: Parameters<typeof actual.opendir>) => {
       if (args[0] === fsMockState.failDirectoryPath) {
         const error = new Error('EACCES: directory unreadable') as NodeJS.ErrnoException
@@ -121,6 +136,7 @@ beforeEach(() => {
   fsMockState.failLink = false
   fsMockState.failCopy = false
   fsMockState.failDirectoryPath = null
+  fsMockState.failLstatPath = null
   fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-backfill-home-'))
   userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-backfill-user-data-'))
   previousUserDataPath = process.env.ORCA_USER_DATA_PATH
@@ -354,6 +370,22 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(
       existsSync(join(getSystemSessionsRoot(), '2026', '06', '01', 'rollout-unreadable.jsonl'))
     ).toBe(true)
+    expect(existsSync(getMarkerPath())).toBe(true)
+  })
+
+  it('leaves the marker unset when the managed sessions root is inaccessible', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+    fsMockState.failLstatPath = getManagedSessionsRoot()
+
+    const first = await startCodexSessionBackfillInBackground()
+
+    expect(first).toMatchObject({ scannedFiles: 0, failedDirectories: 1 })
+    expect(existsSync(getMarkerPath())).toBe(false)
+    expect(readAuditActions()).toContain('scan-failed')
+
+    fsMockState.failLstatPath = null
+    const second = await startCodexSessionBackfillInBackground()
+    expect(second).toMatchObject({ linkedFiles: 1, failedDirectories: 0 })
     expect(existsSync(getMarkerPath())).toBe(true)
   })
 

--- a/src/main/codex/codex-session-backfill.ts
+++ b/src/main/codex/codex-session-backfill.ts
@@ -11,7 +11,10 @@ import {
   createCodexSessionBackfillAuditWriter,
   type CodexSessionBackfillAuditWriter
 } from './codex-session-backfill-audit'
-import { copySessionFileWithoutOverwrite } from './codex-session-backfill-copy'
+import {
+  copySessionFileWithoutOverwrite,
+  isAtomicNoReplaceUnsupportedError
+} from './codex-session-backfill-copy'
 import { listCodexSessionJsonlFilesIncrementally } from './codex-session-file-listing'
 import type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
 
@@ -26,6 +29,7 @@ export type CodexSessionBackfillSummary = {
   skippedExistingFiles: number
   skippedUnexpectedFiles: number
   skippedSymlinkFiles: number
+  skippedUnsupportedFilesystemFiles: number
   failedDirectories: number
   failedFiles: number
 }
@@ -122,6 +126,7 @@ export async function backfillManagedCodexSessionsIntoSystemHome(
     skippedExistingFiles: 0,
     skippedUnexpectedFiles: 0,
     skippedSymlinkFiles: 0,
+    skippedUnsupportedFilesystemFiles: 0,
     failedDirectories: 0,
     failedFiles: 0
   }
@@ -261,6 +266,15 @@ async function backfillOneManagedSessionFile(
     } catch (copyError) {
       if (isExistsError(copyError)) {
         summary.skippedExistingFiles += 1
+        return
+      }
+      if (isAtomicNoReplaceUnsupportedError(copyError)) {
+        summary.skippedUnsupportedFilesystemFiles += 1
+        await appendAuditRecord({
+          action: 'copy-unsupported',
+          source: managedSessionFilePath,
+          target: systemSessionFilePath
+        })
         return
       }
       summary.failedFiles += 1

--- a/src/main/codex/codex-session-backfill.ts
+++ b/src/main/codex/codex-session-backfill.ts
@@ -1,0 +1,264 @@
+import {
+  appendFileSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync
+} from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { writeFileAtomically } from '../codex-accounts/fs-utils'
+import {
+  getCodexSessionBackfillStateDirPath,
+  getOrcaManagedCodexHomePath,
+  getSystemCodexHomePath
+} from './codex-home-paths'
+import { listCodexSessionJsonlFilesIncrementally } from './codex-session-file-listing'
+import type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
+
+// Why: bump to re-run the backfill for every host after a layout or semantics
+// change; the run itself stays skip-existing so re-runs never overwrite.
+const CODEX_SESSION_BACKFILL_MARKER_VERSION = 1
+
+export type CodexSessionBackfillSummary = {
+  scannedFiles: number
+  linkedFiles: number
+  copiedFiles: number
+  skippedExistingFiles: number
+  skippedSymlinkFiles: number
+  failedFiles: number
+}
+
+export type CodexSessionBackfillPaths = {
+  managedSessionsRoot: string
+  systemSessionsRoot: string
+  auditLogPath: string
+  markerPath: string
+}
+
+let backgroundBackfillTask: Promise<CodexSessionBackfillSummary | null> | null = null
+
+/**
+ * Resolves the production source/target/state paths for the session backfill.
+ *
+ * `systemCodexHomePathOverride` mirrors the session bridge: users who run
+ * Codex with a custom CODEX_HOME need their history placed where their own
+ * `codex resume` actually looks.
+ */
+export function resolveCodexSessionBackfillPaths(
+  systemCodexHomePathOverride?: string
+): CodexSessionBackfillPaths {
+  const stateDir = getCodexSessionBackfillStateDirPath()
+  return {
+    managedSessionsRoot: join(getOrcaManagedCodexHomePath(), 'sessions'),
+    systemSessionsRoot: join(systemCodexHomePathOverride || getSystemCodexHomePath(), 'sessions'),
+    auditLogPath: join(stateDir, 'audit.jsonl'),
+    markerPath: join(stateDir, 'backfill-complete.json')
+  }
+}
+
+/**
+ * Starts the once-per-host background backfill of managed-home session files
+ * into the user's real Codex home.
+ *
+ * Concurrent callers share one in-flight task; a completed-marker host resolves
+ * to null without walking the sessions tree.
+ */
+export function startCodexSessionBackfillInBackground(
+  options: CodexSessionBridgeIncrementalOptions = {},
+  systemCodexHomePathOverride?: string
+): Promise<CodexSessionBackfillSummary | null> {
+  if (backgroundBackfillTask) {
+    return backgroundBackfillTask
+  }
+  const task = runCodexSessionBackfillOncePerHost(options, systemCodexHomePathOverride).catch(
+    (error: unknown) => {
+      console.warn('[codex-session-backfill] Background session backfill failed:', error)
+      return null
+    }
+  )
+  backgroundBackfillTask = task
+  void task.finally(() => {
+    if (backgroundBackfillTask === task) {
+      backgroundBackfillTask = null
+    }
+  })
+  return task
+}
+
+async function runCodexSessionBackfillOncePerHost(
+  options: CodexSessionBridgeIncrementalOptions,
+  systemCodexHomePathOverride?: string
+): Promise<CodexSessionBackfillSummary | null> {
+  const paths = resolveCodexSessionBackfillPaths(systemCodexHomePathOverride)
+  if (hasCompletedBackfillMarker(paths.markerPath)) {
+    return null
+  }
+  const summary = await backfillManagedCodexSessionsIntoSystemHome(paths, options)
+  // Why: per-file failures (locked or unreadable files) leave the marker unset
+  // so the next startup retries; skip-existing keeps those retries cheap.
+  if (summary.failedFiles === 0) {
+    writeBackfillMarker(paths.markerPath, summary)
+  }
+  return summary
+}
+
+/**
+ * Backfills managed-home session rollout files into the real Codex home.
+ *
+ * Non-destructive by contract: existing target files are always skipped, and
+ * nothing in either home is deleted or moved. Hardlink first so resume sees
+ * one physical JSONL log; copy is the cross-volume fallback.
+ */
+export async function backfillManagedCodexSessionsIntoSystemHome(
+  paths: CodexSessionBackfillPaths,
+  options: CodexSessionBridgeIncrementalOptions = {}
+): Promise<CodexSessionBackfillSummary> {
+  const summary: CodexSessionBackfillSummary = {
+    scannedFiles: 0,
+    linkedFiles: 0,
+    copiedFiles: 0,
+    skippedExistingFiles: 0,
+    skippedSymlinkFiles: 0,
+    failedFiles: 0
+  }
+  if (existsSync(paths.managedSessionsRoot)) {
+    for await (const managedSessionFilePath of listCodexSessionJsonlFilesIncrementally(
+      paths.managedSessionsRoot,
+      options
+    )) {
+      summary.scannedFiles += 1
+      backfillOneManagedSessionFile(paths, managedSessionFilePath, summary)
+    }
+  }
+  appendAuditRecord(paths.auditLogPath, { action: 'run-summary', ...summary })
+  return summary
+}
+
+function backfillOneManagedSessionFile(
+  paths: CodexSessionBackfillPaths,
+  managedSessionFilePath: string,
+  summary: CodexSessionBackfillSummary
+): void {
+  if (isSymbolicLink(managedSessionFilePath)) {
+    // Why: bridge-created symlinks already point at a file in the user's own
+    // home; materializing them here could duplicate a foreign tree.
+    summary.skippedSymlinkFiles += 1
+    return
+  }
+  const relativePath = relative(paths.managedSessionsRoot, managedSessionFilePath)
+  const systemSessionFilePath = join(paths.systemSessionsRoot, relativePath)
+  if (pathEntryExists(systemSessionFilePath)) {
+    summary.skippedExistingFiles += 1
+    return
+  }
+
+  try {
+    mkdirSync(dirname(systemSessionFilePath), { recursive: true })
+    linkSync(managedSessionFilePath, systemSessionFilePath)
+    summary.linkedFiles += 1
+    appendAuditRecord(paths.auditLogPath, {
+      action: 'hardlink',
+      source: managedSessionFilePath,
+      target: systemSessionFilePath
+    })
+  } catch (linkError) {
+    if (isExistsError(linkError)) {
+      summary.skippedExistingFiles += 1
+      return
+    }
+    try {
+      // Why: hardlinks fail across volumes; COPYFILE_EXCL keeps the
+      // never-overwrite contract even if the target appeared mid-run.
+      copyFileSync(managedSessionFilePath, systemSessionFilePath, constants.COPYFILE_EXCL)
+      summary.copiedFiles += 1
+      appendAuditRecord(paths.auditLogPath, {
+        action: 'copy',
+        source: managedSessionFilePath,
+        target: systemSessionFilePath
+      })
+    } catch (copyError) {
+      if (isExistsError(copyError)) {
+        summary.skippedExistingFiles += 1
+        return
+      }
+      summary.failedFiles += 1
+      appendAuditRecord(paths.auditLogPath, {
+        action: 'failed',
+        source: managedSessionFilePath,
+        target: systemSessionFilePath,
+        error: describeError(copyError),
+        linkError: describeError(linkError)
+      })
+    }
+  }
+}
+
+function isSymbolicLink(filePath: string): boolean {
+  try {
+    return lstatSync(filePath).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+/** Existence via lstat so a broken symlink at the target still counts as taken. */
+function pathEntryExists(entryPath: string): boolean {
+  try {
+    lstatSync(entryPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isExistsError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function appendAuditRecord(auditLogPath: string, record: Record<string, unknown>): void {
+  try {
+    mkdirSync(dirname(auditLogPath), { recursive: true })
+    appendFileSync(
+      auditLogPath,
+      `${JSON.stringify({ at: new Date().toISOString(), ...record })}\n`,
+      {
+        encoding: 'utf-8'
+      }
+    )
+  } catch (error) {
+    // Why: the audit trail is diagnostics; losing a line must not fail the
+    // backfill or leave a half-linked tree unrecorded in the summary counts.
+    console.warn('[codex-session-backfill] Failed to append audit record:', error)
+  }
+}
+
+function hasCompletedBackfillMarker(markerPath: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(markerPath, 'utf-8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return false
+    }
+    return (parsed as { version?: unknown }).version === CODEX_SESSION_BACKFILL_MARKER_VERSION
+  } catch {
+    return false
+  }
+}
+
+function writeBackfillMarker(markerPath: string, summary: CodexSessionBackfillSummary): void {
+  mkdirSync(dirname(markerPath), { recursive: true })
+  writeFileAtomically(
+    markerPath,
+    `${JSON.stringify(
+      { version: CODEX_SESSION_BACKFILL_MARKER_VERSION, completedAt: Date.now(), summary },
+      null,
+      2
+    )}\n`
+  )
+}

--- a/src/main/codex/codex-session-backfill.ts
+++ b/src/main/codex/codex-session-backfill.ts
@@ -6,9 +6,12 @@ import {
   linkSync,
   lstatSync,
   mkdirSync,
-  readFileSync
+  readFileSync,
+  rmSync,
+  writeFileSync
 } from 'node:fs'
-import { dirname, join, relative } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { dirname, join, relative, sep } from 'node:path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import {
   getCodexSessionBackfillStateDirPath,
@@ -27,7 +30,9 @@ export type CodexSessionBackfillSummary = {
   linkedFiles: number
   copiedFiles: number
   skippedExistingFiles: number
+  skippedUnexpectedFiles: number
   skippedSymlinkFiles: number
+  failedDirectories: number
   failedFiles: number
 }
 
@@ -93,14 +98,14 @@ async function runCodexSessionBackfillOncePerHost(
   systemCodexHomePathOverride?: string
 ): Promise<CodexSessionBackfillSummary | null> {
   const paths = resolveCodexSessionBackfillPaths(systemCodexHomePathOverride)
-  if (hasCompletedBackfillMarker(paths.markerPath)) {
+  if (hasCompletedBackfillMarker(paths.markerPath, paths.systemSessionsRoot)) {
     return null
   }
   const summary = await backfillManagedCodexSessionsIntoSystemHome(paths, options)
   // Why: per-file failures (locked or unreadable files) leave the marker unset
   // so the next startup retries; skip-existing keeps those retries cheap.
-  if (summary.failedFiles === 0) {
-    writeBackfillMarker(paths.markerPath, summary)
+  if (summary.failedFiles === 0 && summary.failedDirectories === 0) {
+    writeBackfillMarker(paths.markerPath, paths.systemSessionsRoot, summary)
   }
   return summary
 }
@@ -121,20 +126,50 @@ export async function backfillManagedCodexSessionsIntoSystemHome(
     linkedFiles: 0,
     copiedFiles: 0,
     skippedExistingFiles: 0,
+    skippedUnexpectedFiles: 0,
     skippedSymlinkFiles: 0,
+    failedDirectories: 0,
     failedFiles: 0
   }
   if (existsSync(paths.managedSessionsRoot)) {
     for await (const managedSessionFilePath of listCodexSessionJsonlFilesIncrementally(
       paths.managedSessionsRoot,
-      options
+      options,
+      (directoryPath, error) => {
+        // Why: a partial walk must remain retryable; otherwise an unreadable
+        // date directory would be silently omitted behind a completion marker.
+        summary.failedDirectories += 1
+        appendAuditRecord(paths.auditLogPath, {
+          action: 'scan-failed',
+          source: directoryPath,
+          error: describeError(error)
+        })
+      }
     )) {
       summary.scannedFiles += 1
+      if (!isCodexRolloutPath(paths.managedSessionsRoot, managedSessionFilePath)) {
+        summary.skippedUnexpectedFiles += 1
+        continue
+      }
       backfillOneManagedSessionFile(paths, managedSessionFilePath, summary)
     }
   }
   appendAuditRecord(paths.auditLogPath, { action: 'run-summary', ...summary })
   return summary
+}
+
+function isCodexRolloutPath(sessionsRoot: string, filePath: string): boolean {
+  const pathParts = relative(sessionsRoot, filePath).split(sep)
+  if (pathParts.length !== 4) {
+    return false
+  }
+  const [year, month, day, fileName] = pathParts
+  return (
+    /^\d{4}$/.test(year) &&
+    /^\d{2}$/.test(month) &&
+    /^\d{2}$/.test(day) &&
+    /^rollout-.+\.jsonl$/.test(fileName)
+  )
 }
 
 function backfillOneManagedSessionFile(
@@ -170,9 +205,9 @@ function backfillOneManagedSessionFile(
       return
     }
     try {
-      // Why: hardlinks fail across volumes; COPYFILE_EXCL keeps the
-      // never-overwrite contract even if the target appeared mid-run.
-      copyFileSync(managedSessionFilePath, systemSessionFilePath, constants.COPYFILE_EXCL)
+      // Why: cross-volume copies are staged so failures cannot strand a
+      // truncated rollout, then installed without overwriting collisions.
+      copySessionFileWithoutOverwrite(managedSessionFilePath, systemSessionFilePath)
       summary.copiedFiles += 1
       appendAuditRecord(paths.auditLogPath, {
         action: 'copy',
@@ -192,6 +227,36 @@ function backfillOneManagedSessionFile(
         error: describeError(copyError),
         linkError: describeError(linkError)
       })
+    }
+  }
+}
+
+function copySessionFileWithoutOverwrite(sourcePath: string, targetPath: string): void {
+  const temporaryPath = join(dirname(targetPath), `.orca-backfill-${randomUUID()}.tmp`)
+  // Why: stage cross-volume copies away from the rollout filename so a failed
+  // copy cannot strand a truncated session that a later retry would skip.
+  writeFileSync(temporaryPath, '', { encoding: 'utf-8', flag: 'wx', mode: 0o600 })
+  try {
+    copyFileSync(sourcePath, temporaryPath)
+    try {
+      // Why: this same-volume hardlink atomically installs the staged copy
+      // without risking a collision overwrite after an EXDEV fallback.
+      linkSync(temporaryPath, targetPath)
+    } catch (installLinkError) {
+      if (isExistsError(installLinkError)) {
+        throw installLinkError
+      }
+      // Some target filesystems do not support hardlinks at all. COPYFILE_EXCL
+      // preserves the collision contract while retaining the staged snapshot.
+      copyFileSync(temporaryPath, targetPath, constants.COPYFILE_EXCL)
+    }
+  } finally {
+    try {
+      rmSync(temporaryPath, { force: true })
+    } catch (error) {
+      // Why: cleanup trouble must not misreport a successfully installed
+      // rollout as a copy failure; the .tmp file is ignored by Codex.
+      console.warn('[codex-session-backfill] Failed to remove staged copy:', temporaryPath, error)
     }
   }
 }
@@ -239,24 +304,39 @@ function appendAuditRecord(auditLogPath: string, record: Record<string, unknown>
   }
 }
 
-function hasCompletedBackfillMarker(markerPath: string): boolean {
+function hasCompletedBackfillMarker(markerPath: string, systemSessionsRoot: string): boolean {
   try {
     const parsed: unknown = JSON.parse(readFileSync(markerPath, 'utf-8'))
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return false
     }
-    return (parsed as { version?: unknown }).version === CODEX_SESSION_BACKFILL_MARKER_VERSION
+    const marker = parsed as { version?: unknown; systemSessionsRoot?: unknown }
+    // Why: changing the configured real Codex home must backfill the new
+    // target instead of honoring a marker written for a different history.
+    return (
+      marker.version === CODEX_SESSION_BACKFILL_MARKER_VERSION &&
+      marker.systemSessionsRoot === systemSessionsRoot
+    )
   } catch {
     return false
   }
 }
 
-function writeBackfillMarker(markerPath: string, summary: CodexSessionBackfillSummary): void {
+function writeBackfillMarker(
+  markerPath: string,
+  systemSessionsRoot: string,
+  summary: CodexSessionBackfillSummary
+): void {
   mkdirSync(dirname(markerPath), { recursive: true })
   writeFileAtomically(
     markerPath,
     `${JSON.stringify(
-      { version: CODEX_SESSION_BACKFILL_MARKER_VERSION, completedAt: Date.now(), summary },
+      {
+        version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
+        systemSessionsRoot,
+        completedAt: Date.now(),
+        summary
+      },
       null,
       2
     )}\n`

--- a/src/main/codex/codex-session-backfill.ts
+++ b/src/main/codex/codex-session-backfill.ts
@@ -1,16 +1,5 @@
-import {
-  appendFileSync,
-  constants,
-  copyFileSync,
-  existsSync,
-  linkSync,
-  lstatSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync
-} from 'node:fs'
-import { randomUUID } from 'node:crypto'
+import { mkdirSync, readFileSync } from 'node:fs'
+import { link, lstat, mkdir } from 'node:fs/promises'
 import { dirname, join, relative, sep } from 'node:path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import {
@@ -18,6 +7,11 @@ import {
   getOrcaManagedCodexHomePath,
   getSystemCodexHomePath
 } from './codex-home-paths'
+import {
+  createCodexSessionBackfillAuditWriter,
+  type CodexSessionBackfillAuditWriter
+} from './codex-session-backfill-audit'
+import { copySessionFileWithoutOverwrite } from './codex-session-backfill-copy'
 import { listCodexSessionJsonlFilesIncrementally } from './codex-session-file-listing'
 import type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
 
@@ -131,15 +125,22 @@ export async function backfillManagedCodexSessionsIntoSystemHome(
     failedDirectories: 0,
     failedFiles: 0
   }
-  if (existsSync(paths.managedSessionsRoot)) {
+  const appendAuditRecord = createCodexSessionBackfillAuditWriter(paths.auditLogPath)
+  const ensuredTargetDirectories = new Set<string>()
+  const managedSessionsRootExists = await checkManagedSessionsRoot(
+    paths,
+    summary,
+    appendAuditRecord
+  )
+  if (managedSessionsRootExists) {
     for await (const managedSessionFilePath of listCodexSessionJsonlFilesIncrementally(
       paths.managedSessionsRoot,
       options,
-      (directoryPath, error) => {
+      async (directoryPath, error) => {
         // Why: a partial walk must remain retryable; otherwise an unreadable
         // date directory would be silently omitted behind a completion marker.
         summary.failedDirectories += 1
-        appendAuditRecord(paths.auditLogPath, {
+        await appendAuditRecord({
           action: 'scan-failed',
           source: directoryPath,
           error: describeError(error)
@@ -151,11 +152,43 @@ export async function backfillManagedCodexSessionsIntoSystemHome(
         summary.skippedUnexpectedFiles += 1
         continue
       }
-      backfillOneManagedSessionFile(paths, managedSessionFilePath, summary)
+      // Why: sequential async mutations bound disk pressure while keeping the
+      // Electron main thread available for UI and PTY work.
+      await backfillOneManagedSessionFile(
+        paths,
+        managedSessionFilePath,
+        summary,
+        appendAuditRecord,
+        ensuredTargetDirectories
+      )
     }
   }
-  appendAuditRecord(paths.auditLogPath, { action: 'run-summary', ...summary })
+  await appendAuditRecord({ action: 'run-summary', ...summary })
   return summary
+}
+
+async function checkManagedSessionsRoot(
+  paths: CodexSessionBackfillPaths,
+  summary: CodexSessionBackfillSummary,
+  appendAuditRecord: CodexSessionBackfillAuditWriter
+): Promise<boolean> {
+  try {
+    await lstat(paths.managedSessionsRoot)
+    return true
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return false
+    }
+    // Why: existsSync collapses access failures into "missing," which could
+    // permanently hide sessions behind an incorrect completion marker.
+    summary.failedDirectories += 1
+    await appendAuditRecord({
+      action: 'scan-failed',
+      source: paths.managedSessionsRoot,
+      error: describeError(error)
+    })
+    return false
+  }
 }
 
 function isCodexRolloutPath(sessionsRoot: string, filePath: string): boolean {
@@ -172,12 +205,14 @@ function isCodexRolloutPath(sessionsRoot: string, filePath: string): boolean {
   )
 }
 
-function backfillOneManagedSessionFile(
+async function backfillOneManagedSessionFile(
   paths: CodexSessionBackfillPaths,
   managedSessionFilePath: string,
-  summary: CodexSessionBackfillSummary
-): void {
-  if (isSymbolicLink(managedSessionFilePath)) {
+  summary: CodexSessionBackfillSummary,
+  appendAuditRecord: CodexSessionBackfillAuditWriter,
+  ensuredTargetDirectories: Set<string>
+): Promise<void> {
+  if (await isSymbolicLink(managedSessionFilePath)) {
     // Why: bridge-created symlinks already point at a file in the user's own
     // home; materializing them here could duplicate a foreign tree.
     summary.skippedSymlinkFiles += 1
@@ -185,16 +220,22 @@ function backfillOneManagedSessionFile(
   }
   const relativePath = relative(paths.managedSessionsRoot, managedSessionFilePath)
   const systemSessionFilePath = join(paths.systemSessionsRoot, relativePath)
-  if (pathEntryExists(systemSessionFilePath)) {
+  if (await pathEntryExists(systemSessionFilePath)) {
     summary.skippedExistingFiles += 1
     return
   }
 
   try {
-    mkdirSync(dirname(systemSessionFilePath), { recursive: true })
-    linkSync(managedSessionFilePath, systemSessionFilePath)
+    const targetDirectory = dirname(systemSessionFilePath)
+    if (!ensuredTargetDirectories.has(targetDirectory)) {
+      // Why: one date directory can contain thousands of rollouts; avoid a
+      // redundant filesystem round trip before every hardlink.
+      await mkdir(targetDirectory, { recursive: true })
+      ensuredTargetDirectories.add(targetDirectory)
+    }
+    await link(managedSessionFilePath, systemSessionFilePath)
     summary.linkedFiles += 1
-    appendAuditRecord(paths.auditLogPath, {
+    await appendAuditRecord({
       action: 'hardlink',
       source: managedSessionFilePath,
       target: systemSessionFilePath
@@ -204,12 +245,15 @@ function backfillOneManagedSessionFile(
       summary.skippedExistingFiles += 1
       return
     }
+    if (isNotFoundError(linkError)) {
+      ensuredTargetDirectories.delete(dirname(systemSessionFilePath))
+    }
     try {
       // Why: cross-volume copies are staged so failures cannot strand a
       // truncated rollout, then installed without overwriting collisions.
-      copySessionFileWithoutOverwrite(managedSessionFilePath, systemSessionFilePath)
+      await copySessionFileWithoutOverwrite(managedSessionFilePath, systemSessionFilePath)
       summary.copiedFiles += 1
-      appendAuditRecord(paths.auditLogPath, {
+      await appendAuditRecord({
         action: 'copy',
         source: managedSessionFilePath,
         target: systemSessionFilePath
@@ -220,7 +264,7 @@ function backfillOneManagedSessionFile(
         return
       }
       summary.failedFiles += 1
-      appendAuditRecord(paths.auditLogPath, {
+      await appendAuditRecord({
         action: 'failed',
         source: managedSessionFilePath,
         target: systemSessionFilePath,
@@ -231,48 +275,18 @@ function backfillOneManagedSessionFile(
   }
 }
 
-function copySessionFileWithoutOverwrite(sourcePath: string, targetPath: string): void {
-  const temporaryPath = join(dirname(targetPath), `.orca-backfill-${randomUUID()}.tmp`)
-  // Why: stage cross-volume copies away from the rollout filename so a failed
-  // copy cannot strand a truncated session that a later retry would skip.
-  writeFileSync(temporaryPath, '', { encoding: 'utf-8', flag: 'wx', mode: 0o600 })
+async function isSymbolicLink(filePath: string): Promise<boolean> {
   try {
-    copyFileSync(sourcePath, temporaryPath)
-    try {
-      // Why: this same-volume hardlink atomically installs the staged copy
-      // without risking a collision overwrite after an EXDEV fallback.
-      linkSync(temporaryPath, targetPath)
-    } catch (installLinkError) {
-      if (isExistsError(installLinkError)) {
-        throw installLinkError
-      }
-      // Some target filesystems do not support hardlinks at all. COPYFILE_EXCL
-      // preserves the collision contract while retaining the staged snapshot.
-      copyFileSync(temporaryPath, targetPath, constants.COPYFILE_EXCL)
-    }
-  } finally {
-    try {
-      rmSync(temporaryPath, { force: true })
-    } catch (error) {
-      // Why: cleanup trouble must not misreport a successfully installed
-      // rollout as a copy failure; the .tmp file is ignored by Codex.
-      console.warn('[codex-session-backfill] Failed to remove staged copy:', temporaryPath, error)
-    }
-  }
-}
-
-function isSymbolicLink(filePath: string): boolean {
-  try {
-    return lstatSync(filePath).isSymbolicLink()
+    return (await lstat(filePath)).isSymbolicLink()
   } catch {
     return false
   }
 }
 
 /** Existence via lstat so a broken symlink at the target still counts as taken. */
-function pathEntryExists(entryPath: string): boolean {
+async function pathEntryExists(entryPath: string): Promise<boolean> {
   try {
-    lstatSync(entryPath)
+    await lstat(entryPath)
     return true
   } catch {
     return false
@@ -283,25 +297,12 @@ function isExistsError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
 }
 
-function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+function isNotFoundError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
 }
 
-function appendAuditRecord(auditLogPath: string, record: Record<string, unknown>): void {
-  try {
-    mkdirSync(dirname(auditLogPath), { recursive: true })
-    appendFileSync(
-      auditLogPath,
-      `${JSON.stringify({ at: new Date().toISOString(), ...record })}\n`,
-      {
-        encoding: 'utf-8'
-      }
-    )
-  } catch (error) {
-    // Why: the audit trail is diagnostics; losing a line must not fail the
-    // backfill or leave a half-linked tree unrecorded in the summary counts.
-    console.warn('[codex-session-backfill] Failed to append audit record:', error)
-  }
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 function hasCompletedBackfillMarker(markerPath: string, systemSessionsRoot: string): boolean {

--- a/src/main/codex/codex-session-file-listing.ts
+++ b/src/main/codex/codex-session-file-listing.ts
@@ -56,7 +56,8 @@ function appendSessionFilePaths(target: string[], source: readonly string[]): vo
  */
 export async function* listCodexSessionJsonlFilesIncrementally(
   rootPath: string,
-  options: CodexSessionBridgeIncrementalOptions
+  options: CodexSessionBridgeIncrementalOptions,
+  onDirectoryError?: (directoryPath: string, error: unknown) => void
 ): AsyncGenerator<string> {
   const batchSize = Math.max(1, options.batchSize ?? INCREMENTAL_BRIDGE_BATCH_SIZE)
   const yieldMs = Math.max(0, options.yieldMs ?? INCREMENTAL_BRIDGE_YIELD_MS)
@@ -84,6 +85,7 @@ export async function* listCodexSessionJsonlFilesIncrementally(
         }
       }
     } catch (error) {
+      onDirectoryError?.(currentDirectory, error)
       console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
     }
   }

--- a/src/main/codex/codex-session-file-listing.ts
+++ b/src/main/codex/codex-session-file-listing.ts
@@ -57,7 +57,7 @@ function appendSessionFilePaths(target: string[], source: readonly string[]): vo
 export async function* listCodexSessionJsonlFilesIncrementally(
   rootPath: string,
   options: CodexSessionBridgeIncrementalOptions,
-  onDirectoryError?: (directoryPath: string, error: unknown) => void
+  onDirectoryError?: (directoryPath: string, error: unknown) => void | Promise<void>
 ): AsyncGenerator<string> {
   const batchSize = Math.max(1, options.batchSize ?? INCREMENTAL_BRIDGE_BATCH_SIZE)
   const yieldMs = Math.max(0, options.yieldMs ?? INCREMENTAL_BRIDGE_YIELD_MS)
@@ -85,7 +85,7 @@ export async function* listCodexSessionJsonlFilesIncrementally(
         }
       }
     } catch (error) {
-      onDirectoryError?.(currentDirectory, error)
+      await onDirectoryError?.(currentDirectory, error)
       console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
     }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -129,6 +129,8 @@ import {
 } from './codex-accounts/runtime-selection'
 import { normalizeClaudeRuntimeSelection } from './claude-accounts/runtime-selection'
 import { codexHookService } from './codex/hook-service'
+import { startCodexSessionBackfillInBackground } from './codex/codex-session-backfill'
+import { resolveHostCodexSessionSourceHome } from './codex/codex-session-source-home'
 import { getDefaultWslDistro } from './wsl'
 import { ClaudeAccountService } from './claude-accounts/service'
 import { ClaudeRuntimeAuthService } from './claude-accounts/runtime-auth-service'
@@ -1749,6 +1751,16 @@ app.whenReady().then(async () => {
   rateLimits = new RateLimitService()
   codexRuntimeHome = new CodexRuntimeHomeService(store)
   codexAccounts = new CodexAccountService(store, rateLimits, codexRuntimeHome)
+  // Why: one-time per-host backfill makes historical Orca-managed Codex
+  // sessions visible to the user's own resume picker and app history (#4444,
+  // #8612). Deferred so startup and first PTY spawns never compete with the
+  // sessions tree walk.
+  setTimeout(() => {
+    void startCodexSessionBackfillInBackground(
+      {},
+      resolveHostCodexSessionSourceHome(store!.getSettings())
+    )
+  }, 15_000)
   claudeRuntimeAuth = new ClaudeRuntimeAuthService(store)
   claudeAccounts = new ClaudeAccountService(store, rateLimits, claudeRuntimeAuth)
   rateLimits.setCodexHomePathResolver((target) =>


### PR DESCRIPTION
## Summary

One-time, non-destructive backfill of Codex session rollout files from Orca's managed runtime home into the user's real `~/.codex/sessions/YYYY/MM/DD/` tree.

Codex sessions launched inside Orca currently land only in the Orca-managed `CODEX_HOME`, so the user's own `codex resume` picker and Codex app history never see them (#4444, #8612). This PR makes the historical backlog visible in the provider-native home while changing nothing else about where new sessions are written. It complements the account-ownership direction in #8606 (credit to @jellychoco for the routing direction): once system-default launches move to the native home, this backfill is what keeps pre-existing Orca history discoverable there.

## Behavior

- Walks `<userData>/codex-runtime-home/home/sessions/**` incrementally (same batched walker the existing system→managed bridge uses) and places each rollout at the identical relative path under the real Codex home. The `codex resume` picker enumerates and parses this exact layout.
- **Hardlink first** so resume sees one physical JSONL log; **copy fallback** (`COPYFILE_EXCL`) for cross-volume homes.
- **Never overwrites, deletes, or moves anything in either home**: an existing target path (including a broken symlink) is always skipped, and a target appearing mid-run is caught by `EEXIST` handling.
- Symlinked managed entries (bridge-created links that already point into the user's own home) are not materialized.
- **Once per host behind a versioned marker** (`<userData>/codex-session-backfill/backfill-complete.json`). Per-file failures leave the marker unset so the next startup retries; the retry is cheap because everything already placed is skipped. Runs deferred (15s after service init) so startup and first PTY spawns never compete with the tree walk.
- **Audit log** (`<userData>/codex-session-backfill/audit.jsonl`): one JSONL record per hardlink/copy/failure plus a per-run summary with skip counts.
- Honors the existing custom Codex session source home override (users who run Codex with their own `CODEX_HOME` get history where their `codex resume` actually looks).
- The existing system→managed session bridge is unchanged; the two directions compose safely (both are skip-existing and `EEXIST`-tolerant).

## Not in this PR (follow-ups)

- **WSL**: managed WSL runtime homes are distro-local; the backfill needs an in-distro hardlink variant (mirroring `wsl-codex-session-bridge.ts`). Host (macOS/Linux/Windows) only for now.
- Sessions created *after* this backfill while launches still target the managed home keep flowing through the existing bridge; they become native-home sessions with the system-default routing work (#8606 direction).
- Codex also maintains a sqlite thread index in its home; surfaces driven purely by that index get healed in a follow-up (`thread/read` warm-up per backfilled session).

## Testing

**Unit** (`src/main/codex/codex-session-backfill.test.ts`, 11 tests, all green): layout-preserving hardlinks (inode equality), collision skip with byte-identical target preservation, broken-symlink target treated as taken, symlinked source not materialized, idempotent second run, copy fallback on `EXDEV`, per-file failure accounting without aborting, no target-tree creation when there is nothing to backfill, marker write/skip semantics, failure→no-marker→retry, custom source home override.

**Live, fully sandboxed** (dev build, isolated `ORCA_DEV_USER_DATA_PATH` + overridden `HOME`; the developer's real `~/.codex` untouched):

1. Managed home seeded with 3 rollouts (one colliding with a pre-existing user file of different content); real home seeded with the user's own session.
   - After startup: both managed-only rollouts hardlinked into the real home (`stat` shows identical inode), collision skipped with the user's variant preserved byte-exactly, user's own session untouched.
   - Audit log: 2 `hardlink` records + `run-summary` `{scanned 3, linked 2, skipped 1, failed 0}`; marker `v1` written.
2. **Restart**: app relaunched with a new managed rollout planted post-marker → marker honored, no re-walk, audit unchanged, new file not backfilled (by design; see follow-ups).
3. **Resume picker visibility** (codex-cli 0.144.4 against the sandboxed home): a genuine-format rollout placed into the real home's sessions tree after the codex sqlite index already existed appears in the `codex resume` picker on next open (picker output captured: `1 / 2`, previews shown). Since the backfill places byte-identical hardlinks of genuine rollout files, backfilled Orca sessions are discoverable the same way. (Minimal hand-crafted JSONL fixtures do *not* pass the picker's parse — visibility requires real rollout content, which real managed sessions have.)

`tsc` (node project) clean, `oxlint` clean on touched files.
