### PR TITLE
Fix Windows setup sequencing wrapper quoting

### DIFF
--- a/src/shared/hermes-startup-query.ts
+++ b/src/shared/hermes-startup-query.ts
@@ -1,3 +1,4 @@
+import { encodePowerShellCommand } from './powershell-command-encoding'
 import {
   buildShellCommandFromArgv,
   quoteStartupArg,
@@ -13,15 +14,6 @@ const POWERSHELL_QUERY_VARIABLE = 'orcaHermesStartupQuery'
 const POWERSHELL_NATIVE_QUERY_VARIABLE = 'orcaHermesNativeQuery'
 
 export const ORCA_HERMES_STARTUP_QUERY_ENV = 'ORCA_HERMES_STARTUP_QUERY'
-
-function encodePowerShellCommand(command: string): string {
-  let bytes = ''
-  for (let index = 0; index < command.length; index += 1) {
-    const code = command.charCodeAt(index)
-    bytes += String.fromCharCode(code & 0xff, code >>> 8)
-  }
-  return btoa(bytes)
-}
 
 function encodePosixEvalScript(command: string): string {
   return Array.from(

--- a/src/shared/powershell-command-encoding.ts
+++ b/src/shared/powershell-command-encoding.ts
@@ -1,3 +1,11 @@
 export function encodePowerShellCommand(command: string): string {
-  return Buffer.from(command, 'utf16le').toString('base64')
+  // Why: some callers (setup sequencing, Hermes startup) run in the sandboxed
+  // renderer where Node's Buffer is unavailable, so encode the UTF-16LE bytes
+  // PowerShell's -EncodedCommand expects using only renderer-safe globals.
+  let bytes = ''
+  for (let index = 0; index < command.length; index += 1) {
+    const code = command.charCodeAt(index)
+    bytes += String.fromCharCode(code & 0xff, code >>> 8)
+  }
+  return btoa(bytes)
 }

--- a/src/shared/setup-agent-sequencing.test.ts
+++ b/src/shared/setup-agent-sequencing.test.ts
@@ -173,17 +173,21 @@ describe('createSequencedSetupAgentCommands', () => {
       nonce: 'nonce-win',
       waitTimeoutSeconds: 3
     })
+    const startupPowerShell = decodePowerShellScript(result.startupCommand)
 
     expect(result.setupCommand).toContain('cmd.exe /d /s /v:on /c')
-    expect(result.setupCommand).toContain('cmd.exe /c ""C:\\repo\\.git\\orca\\setup-runner.cmd""')
+    expect(result.setupCommand).toContain('cmd.exe /c "C:\\repo\\.git\\orca\\setup-runner.cmd"')
     expect(result.setupCommand).toContain('echo !ORCA_SETUP_NONCE!:!ORCA_SETUP_STATUS!')
     expect(result.startupCommand.match(/powershell\.exe/g)).toHaveLength(1)
-    expect(result.startupCommand).toContain('powershell.exe -NoProfile -ExecutionPolicy Bypass')
-    expect(result.startupCommand).toContain('AddSeconds(3)')
-    expect(result.startupCommand).toContain('!ORCA_SETUP_STATUS!')
-    expect(result.startupCommand).toContain('Timed out waiting for setup before starting agent.')
-    expect(result.startupCommand).toContain('Setup failed; skipping agent startup.')
     expect(result.startupCommand).toContain(
+      'powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand'
+    )
+    expect(startupPowerShell).toContain('AddSeconds(3)')
+    expect(startupPowerShell).toContain('Missing setup marker path.')
+    expect(result.startupCommand).toContain('!ORCA_SETUP_STATUS!')
+    expect(startupPowerShell).toContain('Timed out waiting for setup before starting agent.')
+    expect(startupPowerShell).toContain('Setup failed; skipping agent startup.')
+    expect(startupPowerShell).toContain(
       'Remove-Item -LiteralPath $marker, $tmp -Force -ErrorAction SilentlyContinue'
     )
     expect(result.startupCommand).not.toContain('%ERRORLEVEL%')
@@ -193,12 +197,62 @@ describe('createSequencedSetupAgentCommands', () => {
     expect(result.startupCommand).not.toContain(
       `call !${SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV}!`
     )
-    expect(result.startupCommand).toContain('Invoke-Expression')
+    expect(startupPowerShell).toContain('Invoke-Expression')
     expect(result.startupCommand).not.toContain('fix !PATH! & test')
     expect(result.startupEnv).toEqual({
       [SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]: "codex --model gpt-5 'fix !PATH! & test'"
     })
   })
+
+  it.skipIf(process.platform !== 'win32')(
+    'executes the native Windows setup-to-agent sequence through cmd.exe',
+    async () => {
+      const tempDir = makeTempDir()
+      const runnerScriptPath = join(tempDir, 'setup runner.cmd')
+      const startupScriptPath = join(tempDir, 'agent-startup.cmd')
+      const logPath = join(tempDir, 'sequence.log')
+
+      writeFileSync(
+        runnerScriptPath,
+        ['@echo off', `>> "${logPath}" echo setup-done`, 'exit /b 0'].join('\r\n'),
+        'utf8'
+      )
+      writeFileSync(
+        startupScriptPath,
+        ['@echo off', `>> "${logPath}" echo agent-start`, 'exit /b 0'].join('\r\n'),
+        'utf8'
+      )
+
+      const commands = createSequencedSetupAgentCommands({
+        runnerScriptPath,
+        startupCommand: `cmd.exe /d /s /c "${startupScriptPath}"`,
+        platform: 'windows',
+        nonce: 'windows-sequence',
+        waitTimeoutSeconds: 2
+      })
+
+      const setupExit = await waitForExit(
+        spawnWindowsCommand(tempDir, 'run-setup.cmd', commands.setupCommand)
+      )
+      expect(setupExit).toEqual({ code: 0, stderr: '' })
+      expect(readIfExists(`${runnerScriptPath}.windows-sequence.done`)).toBe(
+        'windows-sequence:0\r\n'
+      )
+
+      const startupExit = await waitForExit(
+        spawnWindowsCommand(
+          tempDir,
+          'run-startup.cmd',
+          commands.startupCommand,
+          commands.startupEnv
+        )
+      )
+
+      expect(startupExit.code).toBe(0)
+      expect(startupExit.stderr).toContain('Waiting for setup to finish before starting agent...')
+      expect(readFileSync(logPath, 'utf8')).toBe('setup-done\r\nagent-start\r\n')
+    }
+  )
 
   it.skipIf(process.platform === 'win32')(
     'ignores stale markers until the matching setup run finishes, even when startup launches first',
@@ -407,6 +461,30 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms)
   })
+}
+
+function spawnWindowsCommand(
+  dir: string,
+  filename: string,
+  command: string,
+  env: Record<string, string> = {}
+): ReturnType<typeof spawn> {
+  const scriptPath = join(dir, filename)
+  // Why: putting the generated command on a batch line exercises cmd.exe's
+  // native parser without Node/libuv adding another argument-quoting layer.
+  writeFileSync(scriptPath, `@echo off\r\n${command}\r\nexit /b %ERRORLEVEL%\r\n`, 'utf8')
+  return spawn('cmd.exe', ['/d', '/s', '/c', scriptPath], {
+    stdio: 'pipe',
+    env: { ...process.env, ...env }
+  })
+}
+
+function decodePowerShellScript(command: string): string {
+  const encoded = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)?.[1]
+  if (!encoded) {
+    throw new Error('Missing PowerShell encoded command')
+  }
+  return Buffer.from(encoded, 'base64').toString('utf16le')
 }
 
 function waitForExit(

--- a/src/shared/setup-agent-sequencing.test.ts
+++ b/src/shared/setup-agent-sequencing.test.ts
@@ -173,30 +173,26 @@ describe('createSequencedSetupAgentCommands', () => {
       nonce: 'nonce-win',
       waitTimeoutSeconds: 3
     })
+    const setupPowerShell = decodePowerShellScript(result.setupCommand)
     const startupPowerShell = decodePowerShellScript(result.startupCommand)
 
-    expect(result.setupCommand).toContain('cmd.exe /d /s /v:on /c')
-    expect(result.setupCommand).toContain('cmd.exe /c "C:\\repo\\.git\\orca\\setup-runner.cmd"')
-    expect(result.setupCommand).toContain('echo !ORCA_SETUP_NONCE!:!ORCA_SETUP_STATUS!')
+    expect(result.setupCommand).toContain(
+      'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand'
+    )
+    expect(setupPowerShell).toContain("$runner = 'C:\\repo\\.git\\orca\\setup-runner.cmd'")
+    expect(setupPowerShell).toContain('$nonce + ":" + $setupStatus')
     expect(result.startupCommand.match(/powershell\.exe/g)).toHaveLength(1)
     expect(result.startupCommand).toContain(
-      'powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand'
+      'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand'
     )
     expect(startupPowerShell).toContain('AddSeconds(3)')
     expect(startupPowerShell).toContain('Missing setup marker path.')
-    expect(result.startupCommand).toContain('!ORCA_SETUP_STATUS!')
     expect(startupPowerShell).toContain('Timed out waiting for setup before starting agent.')
     expect(startupPowerShell).toContain('Setup failed; skipping agent startup.')
     expect(startupPowerShell).toContain(
       'Remove-Item -LiteralPath $marker, $tmp -Force -ErrorAction SilentlyContinue'
     )
     expect(result.startupCommand).not.toContain('%ERRORLEVEL%')
-    expect(result.startupCommand).not.toContain(' & ) else')
-    expect(result.startupCommand).not.toContain('if ""!ORCA_SETUP_STATUS!""==""124""')
-    expect(result.startupCommand).not.toContain('if not ""!ORCA_SETUP_STATUS!""==""0""')
-    expect(result.startupCommand).not.toContain(
-      `call !${SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV}!`
-    )
     expect(startupPowerShell).toContain('Invoke-Expression')
     expect(result.startupCommand).not.toContain('fix !PATH! & test')
     expect(result.startupEnv).toEqual({
@@ -235,7 +231,7 @@ describe('createSequencedSetupAgentCommands', () => {
       const setupExit = await waitForExit(
         spawnWindowsCommand(tempDir, 'run-setup.cmd', commands.setupCommand)
       )
-      expect(setupExit).toEqual({ code: 0, stderr: '' })
+      expect(setupExit.code).toBe(0)
       expect(readIfExists(`${runnerScriptPath}.windows-sequence.done`)).toBe(
         'windows-sequence:0\r\n'
       )

--- a/src/shared/setup-agent-sequencing.test.ts
+++ b/src/shared/setup-agent-sequencing.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -207,7 +207,8 @@ describe('createSequencedSetupAgentCommands', () => {
   it.skipIf(process.platform !== 'win32')(
     'executes the native Windows setup-to-agent sequence through cmd.exe',
     async () => {
-      const tempDir = makeTempDir()
+      const tempDir = join(makeTempDir(), 'path with spaces')
+      mkdirSync(tempDir)
       const runnerScriptPath = join(tempDir, 'setup runner.cmd')
       const startupScriptPath = join(tempDir, 'agent-startup.cmd')
       const logPath = join(tempDir, 'sequence.log')
@@ -225,7 +226,7 @@ describe('createSequencedSetupAgentCommands', () => {
 
       const commands = createSequencedSetupAgentCommands({
         runnerScriptPath,
-        startupCommand: `cmd.exe /d /s /c "${startupScriptPath}"`,
+        startupCommand: `cmd.exe /d /c "${startupScriptPath}"`,
         platform: 'windows',
         nonce: 'windows-sequence',
         waitTimeoutSeconds: 2
@@ -470,10 +471,10 @@ function spawnWindowsCommand(
   env: Record<string, string> = {}
 ): ReturnType<typeof spawn> {
   const scriptPath = join(dir, filename)
-  // Why: putting the generated command on a batch line exercises cmd.exe's
-  // native parser without Node/libuv adding another argument-quoting layer.
+  // Why: /s strips the quotes Node adds for batch paths containing spaces;
+  // argv spawning still exercises cmd.exe's native parser without that loss.
   writeFileSync(scriptPath, `@echo off\r\n${command}\r\nexit /b %ERRORLEVEL%\r\n`, 'utf8')
-  return spawn('cmd.exe', ['/d', '/s', '/c', scriptPath], {
+  return spawn('cmd.exe', ['/d', '/c', scriptPath], {
     stdio: 'pipe',
     env: { ...process.env, ...env }
   })

--- a/src/shared/setup-agent-sequencing.ts
+++ b/src/shared/setup-agent-sequencing.ts
@@ -46,7 +46,11 @@ export function createSequencedSetupAgentCommands(args: {
 
   if (resolution.shell === 'windows') {
     return {
-      setupCommand: buildWindowsSetupCommand(resolution.command, markerPath, nonce),
+      setupCommand: buildWindowsSetupCommand(
+        resolution.runnerScriptPathForShell,
+        markerPath,
+        nonce
+      ),
       startupCommand: buildWindowsStartupCommand(markerPath, nonce, waitTimeoutSeconds),
       startupEnv: {
         [SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]: args.startupCommand
@@ -166,19 +170,32 @@ function hasUnquotedPosixCommandSeparator(command: string): boolean {
   return false
 }
 
-function buildWindowsSetupCommand(setupCommand: string, markerPath: string, nonce: string): string {
-  return wrapCmd([
-    `set "ORCA_SETUP_MARKER=${escapeCmdSetValue(markerPath)}"`,
-    `set "ORCA_SETUP_NONCE=${escapeCmdSetValue(nonce)}"`,
-    'del /f /q "!ORCA_SETUP_MARKER!" "!ORCA_SETUP_MARKER!.tmp" 2>nul',
-    `call ${setupCommand}`,
-    'set "ORCA_SETUP_STATUS=!ERRORLEVEL!"',
-    // Why: separator-adjacent whitespace becomes part of cmd.exe's echo output,
-    // which would fail the startup poller's exact marker parser.
-    'echo !ORCA_SETUP_NONCE!:!ORCA_SETUP_STATUS!>"!ORCA_SETUP_MARKER!.tmp"',
-    'move /y "!ORCA_SETUP_MARKER!.tmp" "!ORCA_SETUP_MARKER!" >nul',
-    'exit /b !ORCA_SETUP_STATUS!'
-  ])
+function buildWindowsSetupCommand(
+  runnerScriptPath: string,
+  markerPath: string,
+  nonce: string
+): string {
+  const script = [
+    `$runner = ${quotePowerShellString(runnerScriptPath)}`,
+    `$marker = ${quotePowerShellString(markerPath)}`,
+    '$tmp = $marker + ".tmp"',
+    `$nonce = ${quotePowerShellString(nonce)}`,
+    'Remove-Item -LiteralPath $marker, $tmp -Force -ErrorAction SilentlyContinue',
+    '$processInfo = [System.Diagnostics.ProcessStartInfo]::new()',
+    '$processInfo.FileName = $env:ComSpec',
+    '$processInfo.Arguments = \'/d /s /v:on /c ""!ORCA_SETUP_RUNNER!""\'',
+    '$processInfo.UseShellExecute = $false',
+    '$processInfo.EnvironmentVariables["ORCA_SETUP_RUNNER"] = $runner',
+    '$process = [System.Diagnostics.Process]::Start($processInfo)',
+    '$process.WaitForExit()',
+    '$setupStatus = $process.ExitCode',
+    '$utf8 = [System.Text.UTF8Encoding]::new($false)',
+    '[System.IO.File]::WriteAllText($tmp, ($nonce + ":" + $setupStatus + [Environment]::NewLine), $utf8)',
+    'Move-Item -LiteralPath $tmp -Destination $marker -Force',
+    'exit $setupStatus'
+  ].join('; ')
+
+  return encodePowerShellInvocation(script)
 }
 
 function buildWindowsStartupCommand(
@@ -190,14 +207,15 @@ function buildWindowsStartupCommand(
   // Why: native Windows setup runners launch through cmd.exe, but PowerShell
   // gives us safe bounded file polling/parsing without a fragile batch label loop.
   const script = [
-    '$marker = $env:ORCA_SETUP_MARKER',
+    `$marker = ${quotePowerShellString(markerPath)}`,
     'if ([string]::IsNullOrWhiteSpace($marker)) {',
     '  [Console]::Error.WriteLine("Missing setup marker path.")',
     '  exit 1',
     '}',
     '$tmp = $marker + ".tmp"',
-    '$nonce = $env:ORCA_SETUP_NONCE',
+    `$nonce = ${quotePowerShellString(nonce)}`,
     `$deadline = (Get-Date).AddSeconds(${timeout})`,
+    '[Console]::Error.WriteLine("Waiting for setup to finish before starting agent...")',
     'while ($true) {',
     '  if (Test-Path -LiteralPath $marker) {',
     '    $content = Get-Content -LiteralPath $marker -TotalCount 1',
@@ -227,23 +245,11 @@ function buildWindowsStartupCommand(
     '}'
   ].join('; ')
 
-  return wrapCmd([
-    `set "ORCA_SETUP_MARKER=${escapeCmdSetValue(markerPath)}"`,
-    `set "ORCA_SETUP_NONCE=${escapeCmdSetValue(nonce)}"`,
-    'echo Waiting for setup to finish before starting agent... 1>&2',
-    `powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellCommand(script)}`,
-    'set "ORCA_SETUP_STATUS=!ERRORLEVEL!"',
-    'exit /b !ORCA_SETUP_STATUS!'
-  ])
+  return encodePowerShellInvocation(script)
 }
 
-function wrapCmd(parts: string[]): string {
-  // Why: /s makes cmd.exe strip exactly this outer quote pair and run the rest
-  // verbatim, so the inner `set "VAR=value"` quotes stay intact instead of being
-  // doubled (which cmd.exe treats as literal characters and breaks assignment).
-  // Joining parts with a bare `&` keeps the marker echo payload free of stray
-  // whitespace.
-  return `cmd.exe /d /s /v:on /c "${parts.join('&')}"`
+function encodePowerShellInvocation(script: string): string {
+  return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellCommand(script)}`
 }
 
 function quotePosixArg(value: string): string {
@@ -253,8 +259,8 @@ function quotePosixArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
-function escapeCmdSetValue(value: string): string {
-  return value.replace(/"/g, '""').replace(/[%!^]/g, (char) => `^${char}`)
+function quotePowerShellString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
 }
 
 export function getSetupAgentSequenceShellForTests(

--- a/src/shared/setup-agent-sequencing.ts
+++ b/src/shared/setup-agent-sequencing.ts
@@ -172,7 +172,9 @@ function buildWindowsSetupCommand(setupCommand: string, markerPath: string, nonc
     'del /f /q "!ORCA_SETUP_MARKER!" "!ORCA_SETUP_MARKER!.tmp" 2>nul',
     `call ${setupCommand}`,
     'set "ORCA_SETUP_STATUS=!ERRORLEVEL!"',
-    '> "!ORCA_SETUP_MARKER!.tmp" echo !ORCA_SETUP_NONCE!:!ORCA_SETUP_STATUS!',
+    // Why: separator-adjacent whitespace becomes part of cmd.exe's echo output,
+    // which would fail the startup poller's exact marker parser.
+    'echo !ORCA_SETUP_NONCE!:!ORCA_SETUP_STATUS!>"!ORCA_SETUP_MARKER!.tmp"',
     'move /y "!ORCA_SETUP_MARKER!.tmp" "!ORCA_SETUP_MARKER!" >nul',
     'exit /b !ORCA_SETUP_STATUS!'
   ])
@@ -188,6 +190,10 @@ function buildWindowsStartupCommand(
   // gives us safe bounded file polling/parsing without a fragile batch label loop.
   const script = [
     '$marker = $env:ORCA_SETUP_MARKER',
+    'if ([string]::IsNullOrWhiteSpace($marker)) {',
+    '  [Console]::Error.WriteLine("Missing setup marker path.")',
+    '  exit 1',
+    '}',
     '$tmp = $marker + ".tmp"',
     '$nonce = $env:ORCA_SETUP_NONCE',
     `$deadline = (Get-Date).AddSeconds(${timeout})`,
@@ -224,14 +230,28 @@ function buildWindowsStartupCommand(
     `set "ORCA_SETUP_MARKER=${escapeCmdSetValue(markerPath)}"`,
     `set "ORCA_SETUP_NONCE=${escapeCmdSetValue(nonce)}"`,
     'echo Waiting for setup to finish before starting agent... 1>&2',
-    `powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ${quoteWindowsArg(script)}`,
+    `powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellScript(script)}`,
     'set "ORCA_SETUP_STATUS=!ERRORLEVEL!"',
     'exit /b !ORCA_SETUP_STATUS!'
   ])
 }
 
 function wrapCmd(parts: string[]): string {
-  return `cmd.exe /d /s /v:on /c ${quoteWindowsArg(parts.join(' & '))}`
+  // Why: /s strips this outer quote pair itself. Doubling the nested quotes
+  // makes cmd.exe treat the quotes in `set "VAR=value"` as literal characters.
+  // Joining without spaces also keeps the setup marker's echo payload exact.
+  return `cmd.exe /d /s /v:on /c "${parts.join('&')}"`
+}
+
+function encodePowerShellScript(script: string): string {
+  // Why: this planner also runs in the sandboxed renderer, where Node's Buffer
+  // is unavailable; PowerShell requires its encoded command as UTF-16LE.
+  let bytes = ''
+  for (let index = 0; index < script.length; index += 1) {
+    const code = script.charCodeAt(index)
+    bytes += String.fromCharCode(code & 0xff, code >>> 8)
+  }
+  return btoa(bytes)
 }
 
 function quotePosixArg(value: string): string {
@@ -239,10 +259,6 @@ function quotePosixArg(value: string): string {
     return value
   }
   return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
-function quoteWindowsArg(value: string): string {
-  return `"${value.replace(/"/g, '""')}"`
 }
 
 function escapeCmdSetValue(value: string): string {

--- a/src/shared/setup-agent-sequencing.ts
+++ b/src/shared/setup-agent-sequencing.ts
@@ -175,6 +175,7 @@ function buildWindowsSetupCommand(
   markerPath: string,
   nonce: string
 ): string {
+  // Why: delayed expansion keeps path metacharacters as data when cmd invokes the batch runner.
   const script = [
     `$runner = ${quotePowerShellString(runnerScriptPath)}`,
     `$marker = ${quotePowerShellString(markerPath)}`,

--- a/src/shared/setup-agent-sequencing.ts
+++ b/src/shared/setup-agent-sequencing.ts
@@ -1,3 +1,4 @@
+import { encodePowerShellCommand } from './powershell-command-encoding'
 import {
   resolveSetupRunnerCommand,
   type SetupRunnerCommandPlatform,
@@ -230,28 +231,19 @@ function buildWindowsStartupCommand(
     `set "ORCA_SETUP_MARKER=${escapeCmdSetValue(markerPath)}"`,
     `set "ORCA_SETUP_NONCE=${escapeCmdSetValue(nonce)}"`,
     'echo Waiting for setup to finish before starting agent... 1>&2',
-    `powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellScript(script)}`,
+    `powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellCommand(script)}`,
     'set "ORCA_SETUP_STATUS=!ERRORLEVEL!"',
     'exit /b !ORCA_SETUP_STATUS!'
   ])
 }
 
 function wrapCmd(parts: string[]): string {
-  // Why: /s strips this outer quote pair itself. Doubling the nested quotes
-  // makes cmd.exe treat the quotes in `set "VAR=value"` as literal characters.
-  // Joining without spaces also keeps the setup marker's echo payload exact.
+  // Why: /s makes cmd.exe strip exactly this outer quote pair and run the rest
+  // verbatim, so the inner `set "VAR=value"` quotes stay intact instead of being
+  // doubled (which cmd.exe treats as literal characters and breaks assignment).
+  // Joining parts with a bare `&` keeps the marker echo payload free of stray
+  // whitespace.
   return `cmd.exe /d /s /v:on /c "${parts.join('&')}"`
-}
-
-function encodePowerShellScript(script: string): string {
-  // Why: this planner also runs in the sandboxed renderer, where Node's Buffer
-  // is unavailable; PowerShell requires its encoded command as UTF-16LE.
-  let bytes = ''
-  for (let index = 0; index < script.length; index += 1) {
-    const code = script.charCodeAt(index)
-    bytes += String.fromCharCode(code & 0xff, code >>> 8)
-  }
-  return btoa(bytes)
 }
 
 function quotePosixArg(value: string): string {

--- a/src/shared/setup-agent-sequencing.windows.test.ts
+++ b/src/shared/setup-agent-sequencing.windows.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -88,6 +88,47 @@ describe.skipIf(process.platform !== 'win32')('Windows setup-agent sequencing', 
     expect(commands.setupCommand).not.toContain(startupCommand)
     expect(commands.startupCommand).not.toContain(startupCommand)
     expect(commands.startupEnv?.[SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]).toBe(startupCommand)
+  })
+
+  it('propagates setup failure without launching the agent', async () => {
+    const tempDir = makeTempDir('failure path & metacharacters!')
+    const runnerScriptPath = join(tempDir, 'setup runner.cmd')
+    const startupScriptPath = join(tempDir, 'agent startup.cmd')
+    const startupLogPath = join(dirname(tempDir), 'agent-started.log')
+
+    writeFileSync(runnerScriptPath, '@echo off\r\nexit /b 37\r\n', 'utf8')
+    writeFileSync(
+      startupScriptPath,
+      `@echo off\r\necho started>"${startupLogPath}"\r\nexit /b 0\r\n`,
+      'utf8'
+    )
+    const commands = createSequencedSetupAgentCommands({
+      runnerScriptPath,
+      startupCommand: `cmd.exe /d /c "${startupScriptPath}"`,
+      platform: 'windows',
+      nonce: 'failed-windows-sequence',
+      waitTimeoutSeconds: 2
+    })
+
+    const setupExit = await waitForExit(
+      spawnWindowsCommand(dirname(tempDir), 'run failed setup.cmd', commands.setupCommand)
+    )
+    expect(setupExit.code).toBe(37)
+    expect(readFileSync(`${runnerScriptPath}.failed-windows-sequence.done`, 'utf8')).toBe(
+      'failed-windows-sequence:37\r\n'
+    )
+
+    const startupExit = await waitForExit(
+      spawnWindowsCommand(
+        dirname(tempDir),
+        'run blocked startup.cmd',
+        commands.startupCommand,
+        commands.startupEnv
+      )
+    )
+    expect(startupExit.code).toBe(37)
+    expect(startupExit.stderr).toContain('Setup failed; skipping agent startup.')
+    expect(existsSync(startupLogPath)).toBe(false)
   })
 })
 

--- a/src/shared/setup-agent-sequencing.windows.test.ts
+++ b/src/shared/setup-agent-sequencing.windows.test.ts
@@ -1,0 +1,133 @@
+import { spawn } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  createSequencedSetupAgentCommands,
+  SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV
+} from './setup-agent-sequencing'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe.skipIf(process.platform !== 'win32')('Windows setup-agent sequencing', () => {
+  it.each([
+    'path with spaces',
+    'ampersand&parentheses(test)',
+    'caret^percent%bang!',
+    "apostrophe's directory",
+    'Unicode-한글-abc'
+  ])('preserves the native runner path in %s', async (directoryName) => {
+    const tempDir = makeTempDir(directoryName)
+    const runnerScriptPath = join(tempDir, 'setup runner.cmd')
+    const startupScriptPath = join(tempDir, 'agent startup.ps1')
+    const logPath = join(dirname(tempDir), 'sequence.log')
+    const prompt = 'spaces & pipe | caret ^ percent % bang ! "quotes" Unicode 한글 trailing\\'
+
+    writeFileSync(
+      runnerScriptPath,
+      ['@echo off', `>> "${logPath}" echo setup-done`, 'exit /b 0'].join('\r\n'),
+      'utf8'
+    )
+    writeFileSync(
+      startupScriptPath,
+      [
+        'param([string]$Value)',
+        '$utf8 = [System.Text.UTF8Encoding]::new($false)',
+        `[System.IO.File]::AppendAllText('${quotePowerShell(logPath)}', $Value + [Environment]::NewLine, $utf8)`
+      ].join('\r\n'),
+      'utf8'
+    )
+
+    const commands = createSequencedSetupAgentCommands({
+      runnerScriptPath,
+      startupCommand: `& '${quotePowerShell(startupScriptPath)}' '${quotePowerShell(prompt)}'`,
+      platform: 'windows',
+      nonce: 'windows-sequence',
+      waitTimeoutSeconds: 2
+    })
+
+    const setupExit = await waitForExit(
+      spawnWindowsCommand(dirname(tempDir), 'run setup.cmd', commands.setupCommand)
+    )
+    expect(setupExit.code).toBe(0)
+    expect(readFileSync(`${runnerScriptPath}.windows-sequence.done`, 'utf8')).toBe(
+      'windows-sequence:0\r\n'
+    )
+
+    const startupExit = await waitForExit(
+      spawnWindowsCommand(
+        dirname(tempDir),
+        'run startup.cmd',
+        commands.startupCommand,
+        commands.startupEnv
+      )
+    )
+    expect(startupExit.code).toBe(0)
+    expect(startupExit.stderr).toContain('Waiting for setup to finish before starting agent...')
+    expect(readFileSync(logPath, 'utf8')).toBe(`setup-done\r\n${prompt}\r\n`)
+  })
+
+  it('keeps the startup command out of generated cmd.exe source', () => {
+    const startupCommand = 'agent --prompt "& | ^ % ! 한글 trailing\\"'
+    const commands = createSequencedSetupAgentCommands({
+      runnerScriptPath: 'C:\\repo\\setup-runner.cmd',
+      startupCommand,
+      platform: 'windows',
+      nonce: 'windows-sequence'
+    })
+
+    expect(commands.setupCommand).not.toContain(startupCommand)
+    expect(commands.startupCommand).not.toContain(startupCommand)
+    expect(commands.startupEnv?.[SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]).toBe(startupCommand)
+  })
+})
+
+function makeTempDir(directoryName: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-setup-sequencing-'))
+  TEMP_DIRS.push(root)
+  const dir = join(root, directoryName)
+  mkdirSync(dir)
+  return dir
+}
+
+function spawnWindowsCommand(
+  dir: string,
+  filename: string,
+  command: string,
+  env: Record<string, string> = {}
+): ReturnType<typeof spawn> {
+  const scriptPath = join(dir, filename)
+  writeFileSync(scriptPath, `@echo off\r\n${command}\r\nexit /b %ERRORLEVEL%\r\n`, 'utf8')
+  return spawn('cmd.exe', ['/d', '/c', scriptPath], {
+    stdio: 'pipe',
+    env: { ...process.env, ...env }
+  })
+}
+
+function quotePowerShell(value: string): string {
+  return value.replace(/'/g, "''")
+}
+
+function waitForExit(
+  child: ReturnType<typeof spawn>
+): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let stderr = ''
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr += chunk.toString()
+    })
+    child.once('error', reject)
+    child.once('close', (code) => {
+      resolve({ code, stderr })
+    })
+  })
+}


### PR DESCRIPTION
## Summary

- preserve standard `set VAR=value` quoting inside the Windows `/s /c` wrapper
- deliver the polling script through PowerShell `-EncodedCommand` and fail fast when the marker path is missing
- write an exact `nonce:status` marker without separator whitespace
- add a Windows-only child-process regression test that executes the setup-to-agent sequence through real batch parsing

Fixes #8787.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (all preceding lint stages passed; the existing localization catalog check reports five missing `UsagePercentageDisplayChangeNotice` keys outside this PR)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (not run in full)
- [ ] `pnpm build` (not run; no build configuration changed)
- [x] Added or updated high-quality tests that would catch regressions

Focused checks:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/setup-agent-sequencing.test.ts src/shared/setup-runner-command.test.ts` — 18 passed, 4 platform-skipped
- `pnpm check:max-lines-ratchet`
- `git diff --check`

## AI Review Report

Reviewed the command at each parser boundary: the interactive shell, outer `cmd.exe /s /c`, nested setup runner, and PowerShell polling process. The review caught two follow-on risks beyond the reported doubled `set` quotes: raw PowerShell quoting broke once the outer cmd quoting was corrected, and separator whitespace produced a marker that failed the exact parser. The implementation now uses a browser-safe UTF-16LE encoded PowerShell payload and an exact marker write. It also verified that the shared planner still runs in the sandboxed renderer without relying on Node `Buffer`.

Cross-platform review confirmed the POSIX/SSH sequencing branch is unchanged. No keyboard shortcuts, labels, UI paths, or Electron platform switches changed; the new process test is Windows-gated and exercises native `cmd.exe` behavior.

## Security Audit

Reviewed command construction, environment-variable propagation, marker path handling, and child-process exit-code propagation. No new external input source, dependency, IPC surface, auth flow, secret handling, or privilege boundary was added. PowerShell code is encoded for parser-safe transport, not treated as a security boundary; startup command execution retains the existing trusted-command behavior.

## Notes

The regression test covers a setup runner path containing spaces and verifies setup completion, exact marker contents, agent launch, and final exit status on Windows. Paths containing delayed-expansion metacharacters such as `!` remain a separate hardening area from the reported doubled-quote failure.

## ELI5

Windows agent setup scripts could mis-quote environment variables and fail before the agent started. Quoting and markers are fixed so the setup-to-agent sequence runs cleanly.
