### PR TITLE
fix: sync desktop tab renames to mobile

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16045,6 +16045,64 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('publishes a desktop custom title over a live pane title to mobile clients', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'RENAMED_TITLE_8705',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: null,
+          paneTitle: 'LIVE_TITLE_8705',
+          title: 'RENAMED_TITLE_8705'
+        }
+      ],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer-rename',
+          snapshotVersion: 1,
+          activeGroupId: null,
+          activeTabId: `tab-1::${leafId}`,
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: `tab-1::${leafId}`,
+              parentTabId: 'tab-1',
+              leafId,
+              title: 'RENAMED_TITLE_8705',
+              customTitle: 'RENAMED_TITLE_8705',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    expect(result.tabs[0]).toEqual(
+      expect.objectContaining({
+        type: 'terminal',
+        title: 'RENAMED_TITLE_8705'
+      })
+    )
+  })
+
   it('suppresses saved mobile agent status when live evidence is the Claude agents screen', async () => {
     const runtime = new OrcaRuntimeService(store)
     const leafId = '11111111-1111-4111-8111-111111111111'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3942,6 +3942,7 @@ export class OrcaRuntimeService {
             parentTabId: tab.id,
             leafId,
             title,
+            customTitle: tab.customTitle,
             ...(ptyId ? { ptyId } : {}),
             ...(tab.startupCwd ? { startupCwd: tab.startupCwd } : {}),
             ...(tab.launchAgent ? { launchAgent: tab.launchAgent } : {}),
@@ -21212,8 +21213,11 @@ export class OrcaRuntimeService {
         : null
       const launchAgent = tab.launchAgent ?? liveLeafPty?.launchAgent ?? pty?.launchAgent ?? null
       const ownerAgent = launchAgent ?? liveLeafPty?.foregroundAgent ?? pty?.foregroundAgent ?? null
+      // Why: live pane/OSC titles remain status evidence, but a user rename is
+      // the display authority and must survive publication to paired clients.
+      const customTitle = tab.customTitle?.trim() || null
       const title = normalizeCompatibleAgentTitleForOwner(
-        leafTitle ?? ptyTitle ?? syncedTab?.title ?? tab.title,
+        customTitle ?? leafTitle ?? ptyTitle ?? syncedTab?.title ?? tab.title,
         ownerAgent
       )
       const liveTitleEvidence = leafTitle ?? ptyTitle

--- a/src/renderer/src/runtime/sync-runtime-graph.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.test.ts
@@ -1379,7 +1379,8 @@ describe('buildMobileSessionTabSnapshots', () => {
     expect(tab).toMatchObject({
       type: 'terminal',
       id: `term-1::${leafId}`,
-      title: 'Pinned'
+      title: 'Pinned',
+      customTitle: 'Pinned'
     })
     expect(tab).not.toHaveProperty('agentStatus')
   })

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -1348,6 +1348,7 @@ function buildMobileTerminalSurfaceTabs(
       type: 'terminal' as const,
       id: mobileTerminalSurfaceId(terminal.id, leafId),
       title,
+      customTitle: terminal.customTitle,
       ...(terminal.quickCommandLabel?.trim()
         ? { quickCommandLabel: terminal.quickCommandLabel.trim() }
         : {}),

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -138,6 +138,9 @@ export type RuntimeMobileSessionTerminalTab = {
   type: 'terminal'
   id: string
   title: string
+  /** User-selected label. Kept separate so live OSC/pane titles can still
+   *  drive agent status without replacing the label shown on paired clients. */
+  customTitle?: string | null
   quickCommandLabel?: string | null
   parentTabId: string
   leafId: string


### PR DESCRIPTION
## Summary

  Fixes #8705.


  Desktop terminal tab renames were not reflected on paired mobile clients when a live PTY/OSC title was
  present.

  This change:

  - preserves the user-selected custom title in mobile session snapshots
  - gives the custom title display priority over live pane and PTY titles
  - keeps live title evidence available for agent-status detection
  - adds regression coverage for desktop-to-mobile tab rename synchronization

  ## Screenshots

  No visual design change.

  The recording below demonstrates a desktop terminal tab rename updating on mobile:
 https://github.com/user-attachments/assets/d66c6879-6671-4c04-a401-763107efaa85



  ## Testing

  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm test`
  - [x] `pnpm build`
  - [x] Added regression tests covering custom-title publication and precedence over live pane titles

  ## AI Review Report

  Reviewed the change for cross-platform compatibility across macOS, Linux, and Windows; local and SSH/remote
  worktrees; supported agents and integrations; performance risk; and UI behavior.

  The change is platform-neutral. It does not introduce or modify keyboard shortcuts, platform-specific labels,
  filesystem paths, shell behavior, or Electron platform-specific behavior.

  The review verified that live PTY/OSC titles remain available for agent-status detection while user-selected
  custom titles remain authoritative for display on paired clients.

  ## Security Audit

  No new command execution, filesystem access, authentication, secrets, dependencies, external input handling,
  or IPC endpoints were introduced.

  The change only carries an existing user-selected title through the runtime snapshot and adjusts display-
  title precedence. No additional security follow-up is required.

  ## Notes

  - Manually verified with Orca desktop on macOS paired with an iPhone.
  - Confirmed that the mobile title updates without restarting the mobile app.
  - No visual design change.
  - X/Twitter: @koushik406

## ELI5

Renaming a terminal on desktop didn’t always show up on the paired phone when a live PTY title existed. Your custom name now wins on mobile while agent-status detection still works.
