### PR TITLE
Separate mobile host card metadata

### DIFF
--- a/mobile/src/components/MobileHostCard.tsx
+++ b/mobile/src/components/MobileHostCard.tsx
@@ -19,6 +19,9 @@ export function MobileHostCard(props: {
 }) {
   const connected = props.state === 'connected'
   const isError = ['warning', 'unreachable', 'auth-failed'].includes(props.verdict.kind)
+  const worktreeSummary = props.worktreeCounts
+    ? `${props.worktreeCounts.total} worktree${props.worktreeCounts.total === 1 ? '' : 's'}${props.worktreeCounts.active > 0 ? ` · ${props.worktreeCounts.active} active` : ''}`
+    : null
   return (
     <Pressable
       style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
@@ -38,14 +41,16 @@ export function MobileHostCard(props: {
         </Text>
         <View style={styles.meta}>
           <StatusDot state={props.state} verdict={props.verdict} />
-          <Text style={[styles.metaText, isError && { color: colors.statusRed }]}>
+          <Text style={[styles.metaText, isError && { color: colors.statusRed }]} numberOfLines={1}>
             {verdictDisplayLabel(props.verdict)}
             {connected ? ` · ${mobileConnectionPathLabel(props.path)}` : ''}
-            {connected && props.worktreeCounts
-              ? ` · ${props.worktreeCounts.total} worktree${props.worktreeCounts.total !== 1 ? 's' : ''}${props.worktreeCounts.active > 0 ? ` · ${props.worktreeCounts.active} active` : ''}`
-              : ''}
           </Text>
         </View>
+        {connected && worktreeSummary ? (
+          <Text style={styles.worktreeMetaText} numberOfLines={1}>
+            {worktreeSummary}
+          </Text>
+        ) : null}
         {props.verdict.kind === 'unreachable' && !props.host.relay ? (
           <Text style={styles.discoveryHint} numberOfLines={2}>
             Update desktop Orca and sign in to connect from anywhere
@@ -80,8 +85,14 @@ const styles = StyleSheet.create({
   },
   main: { flex: 1, minWidth: 0, marginRight: spacing.sm },
   name: { color: colors.textPrimary, fontSize: 15, fontWeight: '600', lineHeight: 20 },
-  meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 3 },
-  metaText: { fontSize: 12, color: colors.textSecondary },
+  meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 3, minWidth: 0 },
+  metaText: { flex: 1, fontSize: 12, color: colors.textSecondary },
+  worktreeMetaText: {
+    marginTop: 2,
+    marginLeft: spacing.xl,
+    fontSize: 12,
+    color: colors.textMuted
+  },
   discoveryHint: {
     marginTop: spacing.xs,
     fontSize: 11,


### PR DESCRIPTION
## What changed

- keep connection state and transport path on one stable line
- move worktree and active counts to a dedicated secondary row
- align the new row beneath the status text and truncate each row independently on narrow screens

## Why

Adding Orca Relay to the connection label made the single metadata string wrap unpredictably when desktop worktree counts were large. Separating connection state from desktop inventory restores a clear hierarchy without shrinking text or hiding the Relay path.

## Validation

- staged-file oxlint and React Doctor lint passed
- staged-file formatting passed
- git diff check passed
- broader typecheck and localization checks intentionally deferred pending product-owner visual approval

Made with [Orca](https://github.com/stablyai/orca) 🐋
