### PR TITLE
Warn instead of silently dropping agent sessions on pre-#5232 upgrade (#5356)

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1503,7 +1503,7 @@
       "id": "startup-upgrade.persisted-session-corpus",
       "title": "Current Orca preserves or recovers old production persisted sessions",
       "maturity": "experimental",
-      "protection": "none",
+      "protection": "partial",
       "owner": "startup-persistence",
       "layer": "upgrade-fixture",
       "surfaces": [
@@ -1523,9 +1523,13 @@
         "ssh",
         "wsl"
       ],
-      "coveredPlatforms": [],
-      "coveredProviders": [],
-      "coverageNotes": "Registered gap only; no executable coverage is wired yet.",
+      "coveredPlatforms": [
+        "macos"
+      ],
+      "coveredProviders": [
+        "local"
+      ],
+      "coverageNotes": "A real Electron two-launch journey now creates a valid local repo/worktree catalog, replaces only its session payload with the pre-#5232 shape, and proves the one-time notice plus tab preservation. The session payload is reconstructed from the affected schema rather than copied byte-for-byte from a production 1.4.65 profile; Linux, Windows, daemon-death, SSH, and WSL upgrade fixtures remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/5356",
         "https://github.com/stablyai/orca/pull/5234",
@@ -1533,33 +1537,59 @@
       ],
       "invariant": "Startup and restore fixes must preserve or explicitly recover sessions from the last affected production persisted-state schema, not only from state written by current code.",
       "oracle": "Boot current Orca against immutable copied user-data fixtures from affected versions and reject blank replacement panes, duplicate resume tabs, silent session loss, or works-only-after-current-write behavior.",
-      "commands": [],
-      "testFiles": [],
-      "assertionRefs": [],
-      "evidenceRuns": [],
+      "commands": [
+        "pnpm run test:e2e -- tests/e2e/agent-session-upgrade-loss-5356.spec.ts --workers=1"
+      ],
+      "testFiles": [
+        "tests/e2e/agent-session-upgrade-loss-5356.spec.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "tests/e2e/agent-session-upgrade-loss-5356.spec.ts",
+          "assertions": [
+            "a pre-#5232 agent tab in a valid workspace renders alongside exactly one non-destructive upgrade notice",
+            "the migration notice is absent after the upgraded session is written and launched again",
+            "the fixture edits the active profile data file rather than the obsolete pre-profile root file"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-15",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm run test:e2e -- tests/e2e/agent-session-upgrade-loss-5356.spec.ts --workers=1",
+          "result": "passed",
+          "durationSeconds": 33,
+          "summary": "One real Electron test passed: 6.8 seconds of test time across setup, affected upgrade, and second launch; the full cross-platform gate command took 33.00 seconds including a fresh E2E build."
+        }
+      ],
       "runtimeBudget": {
         "p95Seconds": 120,
         "scope": "focused Electron upgrade fixture"
       },
       "flakeHistory": {
-        "status": "not-started",
-        "evidence": "Fixture corpus not implemented."
+        "status": "unknown",
+        "evidence": "One local macOS pass of the new deterministic journey; CI soak and other required platforms have not been collected."
       },
       "redGreenEvidence": {
-        "status": "missing",
-        "evidence": "Needs immutable pre-fix persisted-state fixture."
+        "status": "partial",
+        "evidence": "The notice assertion fails against the pre-fix behavior because no warning is rendered. During review, the strengthened tab-preservation assertion also failed against the original made-up-worktree fixture, proving that fixture could pass the notice check after hydration had already discarded the tab; the valid-catalog fixture passes. An immutable production-profile artifact is still missing."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Startup fixture must record startup latency and avoid adding blocking migration scans."
+        "evidence": "Detection performs one bounded pass over the already-loaded tab and capture-record maps, adds no startup await, polling, provider call, subprocess, or recurring subscription, and patches the global marker directly so first-upgrade startup does not build the repo/worktree host-ownership index. The Electron journey removed an unconditional 3-second sleep and completed its three launches in 6.8 seconds of test time; per-launch product startup timing is still uncollected."
       },
       "promotionCriteria": [
         "Land immutable old-version fixture with documented source version.",
-        "Run second restart after current code writes upgraded state.",
-        "Record startup timing and failure artifact."
+        "Record per-launch startup timing and failure artifacts on the immutable fixture.",
+        "Run the upgrade journey on Linux and Windows and add provider-specific daemon, SSH, and WSL fixtures."
       ],
       "knownGaps": [
-        "No fixture corpus or command yet."
+        "The current fixture reconstructs the affected workspace-session fields inside a current profile/catalog; it is not an immutable byte-for-byte 1.4.65 production profile.",
+        "Only local macOS Electron has run; Linux, Windows, daemon-death, SSH, WSL, and remote-runtime upgrade paths are not live-tested.",
+        "The provider session id was never persisted by the affected build, so the gate proves explicit notification and tab preservation rather than recovery of the unrecoverable process context.",
+        "The journey records overall harness time but not a dedicated per-launch startup-latency metric."
       ],
       "demotionRule": "Cannot promote without old production fixture provenance."
     },

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -6608,7 +6608,7 @@ describe('Store', () => {
 
   // ── Workspace Session ──────────────────────────────────────────────
 
-  it('get/set workspace session round-trips', async () => {
+  it('get/set workspace session round-trips (and stamps the capture version)', async () => {
     const store = await createStore()
     const session = {
       activeRepoId: 'r1',
@@ -6618,7 +6618,9 @@ describe('Store', () => {
       terminalLayoutsByTabId: {}
     }
     store.setWorkspaceSession(session)
-    expect(store.getWorkspaceSession()).toEqual(session)
+    // Why: main stamps every full write so the next launch knows this build
+    // could preserve agent sessions across a restart (#5356).
+    expect(store.getWorkspaceSession()).toEqual({ ...session, agentSessionCaptureVersion: 1 })
   })
 
   it('patches workspace session without replacing unchanged slices', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -104,6 +104,7 @@ import {
   ONBOARDING_FINAL_STEP
 } from '../shared/constants'
 import { parseWorkspaceSession } from '../shared/workspace-session-schema'
+import { AGENT_SESSION_CAPTURE_VERSION } from '../shared/agent-session-upgrade-notice'
 import { normalizeUsagePercentageDisplay } from '../shared/usage-percentage-display'
 import { isExistingPersistedProfile } from '../shared/project-order-manual-default-notice'
 import { resolveUsagePercentageDisplayChangeNoticeDismissed } from '../shared/usage-percentage-display-change-notice'
@@ -5653,12 +5654,21 @@ export class Store {
   }
 
   setWorkspaceSession(session: PersistedState['workspaceSession'], hostId?: string | null): void {
+    // Why: main is the authority for what lands on disk, so stamp the
+    // capture-format version on every full write here. The renderer quit
+    // payload (buildWorkspaceSessionPayload) does not carry it, and a full
+    // write replaces the session — without this, the quit flush would drop the
+    // stamp and re-arm the pre-#5232 upgrade notice (#5356).
+    const stamped: WorkspaceSessionState = {
+      ...session,
+      agentSessionCaptureVersion: AGENT_SESSION_CAPTURE_VERSION
+    }
     const resolved = this.resolveHostId(hostId)
     if (resolved === LOCAL_EXECUTION_HOST_ID) {
-      this.setLocalWorkspaceSession(session)
+      this.setLocalWorkspaceSession(stamped)
       return
     }
-    this.setHostWorkspaceSession(resolved, session)
+    this.setHostWorkspaceSession(resolved, stamped)
   }
 
   /** Persist a non-'local' host partition. The PTY-binding race protections in

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -119,6 +119,7 @@ import {
   persistWorkspaceSessionByHostSync
 } from './lib/workspace-session-host-persistence'
 import { collectFolderWorkspaceKeysFromSession } from './lib/workspace-session-hydration-keys'
+import { notifyPreUpgradeAgentSessionLossIfNeeded } from './lib/pre-upgrade-agent-session-loss-notice'
 import {
   getStartupErrorFallbackUI,
   hydratePersistedUIAfterStartupRead
@@ -975,6 +976,11 @@ function App(): React.JSX.Element {
             actions.hydrateEditorSession(sessionRead.session, sessionHydrationOptions)
             actions.hydrateBrowserSession(sessionRead.session, sessionHydrationOptions)
           })
+          // Why: a session written by a build predating quit-time agent capture
+          // (#5232) cannot restore its live agent terminals — they cold-restore
+          // as blank shells. Warn once, non-destructively, off the raw loaded
+          // session rather than letting them vanish silently (#5356).
+          notifyPreUpgradeAgentSessionLossIfNeeded(sessionRead.session)
           // Why: prune lastVisitedAtByWorktreeId entries whose worktrees
           // no longer exist. Must run AFTER hydration — before this point,
           // async repo loads may not have populated worktreesByRepo yet and

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -126,7 +126,9 @@
       "fe21e8f6f5": "Go back ({{value0}})",
       "064bd07810": "Go back",
       "ce37cf5279": "Toggle sidebar ({{value0}})",
-      "e4b9e7dff7": "Toggle sidebar"
+      "e4b9e7dff7": "Toggle sidebar",
+      "preUpgradeAgentSessionLossTitle": "Agent sessions could not be restored",
+      "preUpgradeAgentSessionLossBody": "After updating, agent terminals (Claude, Codex, and others) from your previous session started as fresh shells. Older versions could not save agent sessions across an update, so they could not be resumed. This will not happen again."
     },
     "web": {
       "WebConnect": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -126,7 +126,9 @@
       "fe21e8f6f5": "Volver ({{value0}})",
       "064bd07810": "Volver",
       "ce37cf5279": "Alternar barra lateral ({{value0}})",
-      "e4b9e7dff7": "Alternar barra lateral"
+      "e4b9e7dff7": "Alternar barra lateral",
+      "preUpgradeAgentSessionLossTitle": "Agent sessions could not be restored",
+      "preUpgradeAgentSessionLossBody": "After updating, agent terminals (Claude, Codex, and others) from your previous session started as fresh shells. Older versions could not save agent sessions across an update, so they could not be resumed. This will not happen again."
     },
     "web": {
       "WebConnect": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -126,7 +126,9 @@
       "fe21e8f6f5": "戻る ({{value0}})",
       "064bd07810": "戻る",
       "ce37cf5279": "サイドバーの切り替え ({{value0}})",
-      "e4b9e7dff7": "サイドバーの切り替え"
+      "e4b9e7dff7": "サイドバーの切り替え",
+      "preUpgradeAgentSessionLossTitle": "Agent sessions could not be restored",
+      "preUpgradeAgentSessionLossBody": "After updating, agent terminals (Claude, Codex, and others) from your previous session started as fresh shells. Older versions could not save agent sessions across an update, so they could not be resumed. This will not happen again."
     },
     "web": {
       "WebConnect": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -126,7 +126,9 @@
       "fe21e8f6f5": "돌아가기({{value0}})",
       "064bd07810": "돌아가기",
       "ce37cf5279": "사이드바 표시/숨기기({{value0}})",
-      "e4b9e7dff7": "사이드바 표시/숨기기"
+      "e4b9e7dff7": "사이드바 표시/숨기기",
+      "preUpgradeAgentSessionLossTitle": "Agent sessions could not be restored",
+      "preUpgradeAgentSessionLossBody": "After updating, agent terminals (Claude, Codex, and others) from your previous session started as fresh shells. Older versions could not save agent sessions across an update, so they could not be resumed. This will not happen again."
     },
     "web": {
       "WebConnect": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -126,7 +126,9 @@
       "fe21e8f6f5": "返回 ({{value0}})",
       "064bd07810": "返回",
       "ce37cf5279": "切换侧边栏 ({{value0}})",
-      "e4b9e7dff7": "切换侧边栏"
+      "e4b9e7dff7": "切换侧边栏",
+      "preUpgradeAgentSessionLossTitle": "Agent sessions could not be restored",
+      "preUpgradeAgentSessionLossBody": "After updating, agent terminals (Claude, Codex, and others) from your previous session started as fresh shells. Older versions could not save agent sessions across an update, so they could not be resumed. This will not happen again."
     },
     "web": {
       "WebConnect": {

--- a/src/renderer/src/lib/pre-upgrade-agent-session-loss-notice.test.tsx
+++ b/src/renderer/src/lib/pre-upgrade-agent-session-loss-notice.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import type { TerminalTab, WorkspaceSessionState } from '../../../shared/types'
+import { AGENT_SESSION_CAPTURE_VERSION } from '../../../shared/agent-session-upgrade-notice'
+import { notifyPreUpgradeAgentSessionLossIfNeeded } from './pre-upgrade-agent-session-loss-notice'
+
+vi.mock('sonner', () => ({ toast: vi.fn() }))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+
+function session(overrides: Partial<WorkspaceSessionState> = {}): WorkspaceSessionState {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    ...overrides
+  }
+}
+
+function agentTab(): TerminalTab {
+  return {
+    id: 'tab',
+    ptyId: null,
+    worktreeId: 'wt',
+    title: 'Codex',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    launchAgent: 'codex'
+  }
+}
+
+let patchWorkspaceSession: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  patchWorkspaceSession = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { session: { patch: patchWorkspaceSession } }
+  })
+})
+
+describe('notifyPreUpgradeAgentSessionLossIfNeeded', () => {
+  it('shows one idempotent notice and persists the consumed signal', () => {
+    notifyPreUpgradeAgentSessionLossIfNeeded(session({ tabsByWorktree: { wt: [agentTab()] } }))
+
+    expect(toast).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toast).mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        id: 'pre-upgrade-agent-session-loss',
+        duration: Infinity,
+        dismissible: true
+      })
+    )
+    expect(patchWorkspaceSession).toHaveBeenCalledWith({
+      agentSessionCaptureVersion: AGENT_SESSION_CAPTURE_VERSION
+    })
+  })
+
+  it('consumes an old session without alarming users who had no agent tab', () => {
+    notifyPreUpgradeAgentSessionLossIfNeeded(session())
+
+    expect(toast).not.toHaveBeenCalled()
+    expect(patchWorkspaceSession).toHaveBeenCalledWith({
+      agentSessionCaptureVersion: AGENT_SESSION_CAPTURE_VERSION
+    })
+  })
+
+  it('does no work once the session carries the current stamp', () => {
+    notifyPreUpgradeAgentSessionLossIfNeeded(
+      session({ agentSessionCaptureVersion: AGENT_SESSION_CAPTURE_VERSION })
+    )
+
+    expect(toast).not.toHaveBeenCalled()
+    expect(patchWorkspaceSession).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pre-upgrade-agent-session-loss-notice.tsx
+++ b/src/renderer/src/lib/pre-upgrade-agent-session-loss-notice.tsx
@@ -1,0 +1,62 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import type { WorkspaceSessionState } from '../../../shared/types'
+import {
+  AGENT_SESSION_CAPTURE_VERSION,
+  shouldNotifyPreUpgradeAgentSessionLoss
+} from '../../../shared/agent-session-upgrade-notice'
+import { patchWorkspaceSessionByHost } from './workspace-session-host-persistence'
+
+/**
+ * On the first launch after upgrading from a build predating quit-time agent
+ * capture (#5232), a live agent terminal cold-restores as a blank shell because
+ * its session id was never persisted — and, before this notice, silently
+ * (#5356). The lost session cannot be conjured, so tell the user once,
+ * non-destructively, then stamp the session so it never re-fires.
+ */
+export function notifyPreUpgradeAgentSessionLossIfNeeded(session: WorkspaceSessionState): void {
+  // Fast path: a capture-capable build already stamped this session — no notice
+  // to show and nothing to reconcile, so skip the extra disk write too.
+  if ((session.agentSessionCaptureVersion ?? 0) >= AGENT_SESSION_CAPTURE_VERSION) {
+    return
+  }
+
+  // Why: this runs inline in the startup hydration path, so a fault here must
+  // never block the app from mounting — degrade to "no notice" instead.
+  try {
+    if (shouldNotifyPreUpgradeAgentSessionLoss(session)) {
+      toast(
+        <span data-testid="pre-upgrade-agent-session-loss-notice">
+          {translate(
+            'auto.App.preUpgradeAgentSessionLossTitle',
+            'Agent sessions could not be restored'
+          )}
+        </span>,
+        {
+          description: translate(
+            'auto.App.preUpgradeAgentSessionLossBody',
+            'After updating, agent terminals (Claude, Codex, and others) from your previous session started as fresh shells. Older versions could not save agent sessions across an update, so they could not be resumed. This will not happen again.'
+          ),
+          // Sticky + dismissible: important enough to be seen, but purely
+          // informational — it blocks nothing and deletes nothing.
+          duration: Infinity,
+          dismissible: true
+        }
+      )
+    }
+
+    // Consume the pre-fix signal immediately (not only at the next graceful
+    // quit) so a crash before quit can't replay the notice.
+    void patchWorkspaceSessionByHost(
+      window.api.session,
+      { agentSessionCaptureVersion: AGENT_SESSION_CAPTURE_VERSION },
+      useAppStore.getState()
+    ).catch(() => {
+      // Best-effort: the quit-time full write re-stamps, so a failed patch just
+      // means the notice may re-evaluate next launch, never a crash.
+    })
+  } catch {
+    // Non-fatal: never let the upgrade notice interfere with startup.
+  }
+}

--- a/src/renderer/src/lib/pre-upgrade-agent-session-loss-notice.tsx
+++ b/src/renderer/src/lib/pre-upgrade-agent-session-loss-notice.tsx
@@ -1,12 +1,12 @@
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
-import { useAppStore } from '@/store'
 import type { WorkspaceSessionState } from '../../../shared/types'
 import {
   AGENT_SESSION_CAPTURE_VERSION,
   shouldNotifyPreUpgradeAgentSessionLoss
 } from '../../../shared/agent-session-upgrade-notice'
-import { patchWorkspaceSessionByHost } from './workspace-session-host-persistence'
+
+const PRE_UPGRADE_AGENT_SESSION_LOSS_TOAST_ID = 'pre-upgrade-agent-session-loss'
 
 /**
  * On the first launch after upgrading from a build predating quit-time agent
@@ -34,6 +34,9 @@ export function notifyPreUpgradeAgentSessionLossIfNeeded(session: WorkspaceSessi
           )}
         </span>,
         {
+          // Why: startup can remount under StrictMode or recovery paths; a
+          // stable id keeps this one-time migration notice from stacking.
+          id: PRE_UPGRADE_AGENT_SESSION_LOSS_TOAST_ID,
           description: translate(
             'auto.App.preUpgradeAgentSessionLossBody',
             'After updating, agent terminals (Claude, Codex, and others) from your previous session started as fresh shells. Older versions could not save agent sessions across an update, so they could not be resumed. This will not happen again.'
@@ -48,14 +51,14 @@ export function notifyPreUpgradeAgentSessionLossIfNeeded(session: WorkspaceSessi
 
     // Consume the pre-fix signal immediately (not only at the next graceful
     // quit) so a crash before quit can't replay the notice.
-    void patchWorkspaceSessionByHost(
-      window.api.session,
-      { agentSessionCaptureVersion: AGENT_SESSION_CAPTURE_VERSION },
-      useAppStore.getState()
-    ).catch(() => {
-      // Best-effort: the quit-time full write re-stamps, so a failed patch just
-      // means the notice may re-evaluate next launch, never a crash.
-    })
+    // This capability is global/local-owned, so bypass the host splitter. That
+    // avoids scanning every repo and worktree during first-upgrade startup.
+    void window.api.session
+      .patch({ agentSessionCaptureVersion: AGENT_SESSION_CAPTURE_VERSION })
+      .catch(() => {
+        // Best-effort: the quit-time full write re-stamps, so a failed patch just
+        // means the notice may re-evaluate next launch, never a crash.
+      })
   } catch {
     // Non-fatal: never let the upgrade notice interfere with startup.
   }

--- a/src/renderer/src/lib/workspace-session-host-split.ts
+++ b/src/renderer/src/lib/workspace-session-host-split.ts
@@ -69,7 +69,10 @@ const FIELD_OWNERSHIP = {
   remoteSessionIdsByTabId: 'tabKeyed',
   browserPagesByWorkspace: 'browserWorkspaceKeyed',
   markdownFrontmatterVisible: 'fileKeyed',
-  sleepingAgentSessionsByPaneKey: 'sleepingAgentKeyed'
+  sleepingAgentSessionsByPaneKey: 'sleepingAgentKeyed',
+  // Session-level capability stamp — not worktree/tab keyed. Stays in the local
+  // blob; main re-stamps each host session on write (#5356).
+  agentSessionCaptureVersion: 'global'
 } as const satisfies Record<keyof WorkspaceSessionState, FieldOwnership>
 
 // Why: a new WorkspaceSessionState field must be classified above or the split

--- a/src/shared/agent-session-upgrade-notice.test.ts
+++ b/src/shared/agent-session-upgrade-notice.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import type { SleepingAgentSessionRecord } from './agent-session-resume'
+import type { TerminalTab, WorkspaceSessionState } from './types'
+import {
+  AGENT_SESSION_CAPTURE_VERSION,
+  shouldNotifyPreUpgradeAgentSessionLoss
+} from './agent-session-upgrade-notice'
+
+function agentTab(launchAgent: string | undefined): TerminalTab {
+  return { launchAgent } as unknown as TerminalTab
+}
+
+function record(origin: SleepingAgentSessionRecord['origin']): SleepingAgentSessionRecord {
+  return { origin } as unknown as SleepingAgentSessionRecord
+}
+
+function session(
+  overrides: Partial<
+    Pick<
+      WorkspaceSessionState,
+      'agentSessionCaptureVersion' | 'tabsByWorktree' | 'sleepingAgentSessionsByPaneKey'
+    >
+  >
+): Pick<
+  WorkspaceSessionState,
+  'agentSessionCaptureVersion' | 'tabsByWorktree' | 'sleepingAgentSessionsByPaneKey'
+> {
+  return { tabsByWorktree: {}, ...overrides }
+}
+
+describe('shouldNotifyPreUpgradeAgentSessionLoss', () => {
+  it('warns for a pre-fix session: agent tab, no records, no stamp (#5356)', () => {
+    expect(
+      shouldNotifyPreUpgradeAgentSessionLoss(
+        session({ tabsByWorktree: { wt: [agentTab('codex')] } })
+      )
+    ).toBe(true)
+  })
+
+  it('does not warn once the capture stamp is present', () => {
+    expect(
+      shouldNotifyPreUpgradeAgentSessionLoss(
+        session({
+          agentSessionCaptureVersion: AGENT_SESSION_CAPTURE_VERSION,
+          tabsByWorktree: { wt: [agentTab('codex')] }
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('does not warn when a quit/live capture record exists (working post-#5232 upgrade)', () => {
+    // The critical false-positive guard: on the first launch of the fixed build
+    // NO session has the brand-new stamp yet, so a working post-#5232 build must
+    // be distinguished by its resume records — those sessions ARE being restored.
+    expect(
+      shouldNotifyPreUpgradeAgentSessionLoss(
+        session({
+          tabsByWorktree: { wt: [agentTab('codex')] },
+          sleepingAgentSessionsByPaneKey: { 'tab:0': record('quit') }
+        })
+      )
+    ).toBe(false)
+    expect(
+      shouldNotifyPreUpgradeAgentSessionLoss(
+        session({
+          tabsByWorktree: { wt: [agentTab('codex')] },
+          sleepingAgentSessionsByPaneKey: { 'tab:0': record('live') }
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('still warns when only a worktree-sleep record exists (does not resume cold-restored panes)', () => {
+    expect(
+      shouldNotifyPreUpgradeAgentSessionLoss(
+        session({
+          tabsByWorktree: { wt: [agentTab('codex')] },
+          sleepingAgentSessionsByPaneKey: { 'tab:0': record('worktree-sleep') }
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('does not warn for plain terminals with no agent tab', () => {
+    expect(
+      shouldNotifyPreUpgradeAgentSessionLoss(
+        session({ tabsByWorktree: { wt: [agentTab(undefined)] } })
+      )
+    ).toBe(false)
+  })
+
+  it('does not warn for an unknown/non-resumable launchAgent', () => {
+    expect(
+      shouldNotifyPreUpgradeAgentSessionLoss(session({ tabsByWorktree: { wt: [agentTab('pi')] } }))
+    ).toBe(false)
+  })
+
+  it('does not warn for a fresh session with no tabs', () => {
+    expect(shouldNotifyPreUpgradeAgentSessionLoss(session({ tabsByWorktree: {} }))).toBe(false)
+    expect(shouldNotifyPreUpgradeAgentSessionLoss(session({ tabsByWorktree: undefined }))).toBe(
+      false
+    )
+  })
+})

--- a/src/shared/agent-session-upgrade-notice.ts
+++ b/src/shared/agent-session-upgrade-notice.ts
@@ -1,0 +1,73 @@
+import type { WorkspaceSessionState } from './types'
+import { isResumableTuiAgent } from './agent-session-resume'
+
+/**
+ * Bumped whenever the quit-time agent-session capture format changes. A session
+ * persisted by a build that captures live agents at quit (#5232/#5240) carries
+ * this stamp; builds predating that fix never wrote it. The *absence* of the
+ * stamp is the load-bearing signal that the previous writer could not preserve
+ * agent sessions across a restart — so it must NOT be added to
+ * getDefaultWorkspaceSession (a default would misclassify genuine pre-fix
+ * sessions as post-fix).
+ */
+export const AGENT_SESSION_CAPTURE_VERSION = 1
+
+type PreUpgradeNoticeSession = Pick<
+  WorkspaceSessionState,
+  'agentSessionCaptureVersion' | 'tabsByWorktree' | 'sleepingAgentSessionsByPaneKey'
+>
+
+function hasRestorableAgentTab(
+  tabsByWorktree: WorkspaceSessionState['tabsByWorktree'] | undefined
+): boolean {
+  if (!tabsByWorktree) {
+    return false
+  }
+  for (const tabs of Object.values(tabsByWorktree)) {
+    for (const tab of tabs) {
+      if (tab.launchAgent && isResumableTuiAgent(tab.launchAgent)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function hasQuitOrLiveCaptureRecord(
+  records: WorkspaceSessionState['sleepingAgentSessionsByPaneKey'] | undefined
+): boolean {
+  if (!records) {
+    return false
+  }
+  for (const record of Object.values(records)) {
+    if (record.origin === 'quit' || record.origin === 'live') {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * True when a restored session was written by a build predating quit-time agent
+ * capture (#5232) AND carried an agent terminal whose live session can no
+ * longer be resumed — the #5356 silent-loss case. The user gets a one-time,
+ * non-destructive notice instead of a blank shell appearing with no explanation.
+ *
+ * Deliberately conservative to avoid false alarms on the very first launch of
+ * the fixed build, when *every* prior session still lacks the brand-new stamp:
+ *   - a present/current stamp means the writer captured sessions → never warn;
+ *   - a quit/live capture record means the writer DID persist resumable agents
+ *     (a working post-#5232 build) → those sessions are being restored, so
+ *     never warn even though the stamp is not yet present;
+ *   - only warn when the previous session actually had a resumable agent tab
+ *     (`launchAgent`, which pre-fix builds already persisted) to lose.
+ */
+export function shouldNotifyPreUpgradeAgentSessionLoss(session: PreUpgradeNoticeSession): boolean {
+  if ((session.agentSessionCaptureVersion ?? 0) >= AGENT_SESSION_CAPTURE_VERSION) {
+    return false
+  }
+  if (hasQuitOrLiveCaptureRecord(session.sleepingAgentSessionsByPaneKey)) {
+    return false
+  }
+  return hasRestorableAgentTab(session.tabsByWorktree)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1106,6 +1106,12 @@ export type WorkspaceSessionState = {
   defaultTerminalTabsAppliedByWorktreeId?: Record<string, true>
   /** Provider-session resume records captured when workspaces sleep. */
   sleepingAgentSessionsByPaneKey?: Record<string, SleepingAgentSessionRecord>
+  /** Capability stamp: the agent-session capture format version this session
+   *  was last written with. Builds predating quit-time agent capture (#5232)
+   *  never wrote it, so its absence flags a pre-fix session whose live agent
+   *  sessions could not be preserved across the upgrade (#5356). Never seeded
+   *  into defaults — absence is the signal. */
+  agentSessionCaptureVersion?: number
 }
 
 export type WorkspaceSessionPatch = Partial<WorkspaceSessionState>

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -425,4 +425,33 @@ describe('parseWorkspaceSession', () => {
       expect(result.value.unifiedTabs?.wt[0].viewMode).toBe('terminal')
     }
   })
+
+  it('preserves the agentSessionCaptureVersion capability stamp (#5356)', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      agentSessionCaptureVersion: 1
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.agentSessionCaptureVersion).toBe(1)
+    }
+  })
+
+  it('leaves the stamp absent for a pre-fix session (absence is the signal)', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.agentSessionCaptureVersion).toBeUndefined()
+    }
+  })
 })

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -295,7 +295,13 @@ export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.o
     )
     .optional(),
   defaultTerminalTabsAppliedByWorktreeId: z.record(z.string(), z.literal(true)).optional(),
-  sleepingAgentSessionsByPaneKey: sleepingAgentSessionsByPaneKeySchema
+  sleepingAgentSessionsByPaneKey: sleepingAgentSessionsByPaneKeySchema,
+  // Why: z.object strips unlisted keys, so the capability stamp must be declared
+  // here or it is dropped on every read and the pre-fix detection never
+  // terminates. `.catch(undefined)` degrades a corrupt value to "absent" (treat
+  // as pre-fix) rather than failing the whole-session parse. Never defaulted —
+  // its absence is the #5356 signal.
+  agentSessionCaptureVersion: z.number().int().nonnegative().optional().catch(undefined)
 })
 
 export type ParsedWorkspaceSession =

--- a/tests/e2e/agent-session-upgrade-loss-5356.spec.ts
+++ b/tests/e2e/agent-session-upgrade-loss-5356.spec.ts
@@ -1,9 +1,13 @@
-import { writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
+import { getRepoIdFromWorktreeId } from '../../src/shared/worktree-id'
 import { test, expect } from './helpers/orca-app'
-import { getE2ECompletedOnboardingProfile } from './helpers/e2e-completed-onboarding-profile'
 import { waitForSessionReady } from './helpers/store'
-import { createRestartSession } from './helpers/orca-restart'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+
+const PRE_FIX_TAB_ID = 'tab5356'
 
 // #5356: the first launch after upgrading FROM a pre-#5232 version silently
 // replaces every live floating-terminal agent session with a blank shell.
@@ -11,25 +15,25 @@ import { createRestartSession } from './helpers/orca-restart'
 // pane-level cold-restore finds nothing to resume and spawns a fresh shell —
 // with no warning at all.
 //
-// This seeds orca-data.json with exactly what such a pre-fix quit left on disk:
-// an agent terminal tab (`launchAgent`, which pre-fix builds DID persist), no
-// resume records, and no post-fix capability stamp. On the first launch of the
-// fixed build the session is unrecoverable (it genuinely cannot be conjured),
-// so the app must NON-DESTRUCTIVELY tell the user instead of silently swapping
-// in a blank shell.
+// This builds a valid repo/worktree catalog, then replaces its workspaceSession
+// with the relevant pre-fix shape: an agent terminal tab (`launchAgent`, which
+// pre-fix builds DID persist), no resume records, and no post-fix capability
+// stamp. On the first launch of the fixed build the session is unrecoverable
+// (it genuinely cannot be conjured), so the app must NON-DESTRUCTIVELY tell the
+// user instead of silently swapping in a blank shell.
 
-/** A workspace session shaped exactly like a pre-#5232 quit payload. */
-function preFixWorkspaceSession(): Record<string, unknown> {
+/** The workspace-session fields that distinguish a pre-#5232 quit payload. */
+function preFixWorkspaceSession(repoId: string, worktreeId: string): Record<string, unknown> {
   return {
-    activeRepoId: null,
-    activeWorktreeId: 'wt-5356',
-    activeTabId: 'tab5356',
+    activeRepoId: repoId,
+    activeWorktreeId: worktreeId,
+    activeTabId: PRE_FIX_TAB_ID,
     tabsByWorktree: {
-      'wt-5356': [
+      [worktreeId]: [
         {
-          id: 'tab5356',
+          id: PRE_FIX_TAB_ID,
           ptyId: null,
-          worktreeId: 'wt-5356',
+          worktreeId,
           title: 'Codex',
           customTitle: null,
           color: null,
@@ -47,38 +51,61 @@ function preFixWorkspaceSession(): Record<string, unknown> {
   }
 }
 
-function seedPreFixProfile(userDataDir: string): void {
-  const profile = {
-    ...getE2ECompletedOnboardingProfile(),
-    workspaceSession: preFixWorkspaceSession()
-  }
-  writeFileSync(path.join(userDataDir, 'orca-data.json'), `${JSON.stringify(profile, null, 2)}\n`)
+function seedPreFixProfile(userDataDir: string, repoId: string, worktreeId: string): void {
+  // Why: the setup launch migrates the legacy root file into the active Orca
+  // profile. Editing the old root file would seed state that startup never reads.
+  const dataPath = path.join(
+    userDataDir,
+    'profiles',
+    DEFAULT_LOCAL_ORCA_PROFILE_ID,
+    'orca-data.json'
+  )
+  const profile = JSON.parse(readFileSync(dataPath, 'utf8')) as Record<string, unknown>
+  profile.workspaceSession = preFixWorkspaceSession(repoId, worktreeId)
+  writeFileSync(dataPath, `${JSON.stringify(profile, null, 2)}\n`)
 }
 
-test('#5356 warns instead of silently dropping agent sessions when upgrading from a pre-#5232 version', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
-{}, testInfo) => {
+test('#5356 preserves the tab and warns once when upgrading from a pre-#5232 version', async ({
+  testRepoPath
+}, testInfo) => {
   const session = createRestartSession(testInfo)
+  let activeApp: ElectronApplication | null = null
 
   try {
-    // The first launch after the update reads a pre-#5232 session off disk.
-    seedPreFixProfile(session.userDataDir)
+    // Create the same valid repo/worktree catalog a real old profile carries.
+    // A made-up worktree id is pruned during hydration and would let the toast
+    // test pass without proving that the user's tab survived.
+    const setupLaunch = await session.launch()
+    activeApp = setupLaunch.app
+    const worktreeId = await attachRepoAndOpenTerminal(setupLaunch.page, testRepoPath)
+    const repoId = getRepoIdFromWorktreeId(worktreeId)
+    if (!repoId) {
+      throw new Error(`could not resolve repo id from seeded worktree: ${worktreeId}`)
+    }
+    await session.close(setupLaunch.app)
+    activeApp = null
+
+    // The first launch after the update now reads a realistic pre-#5232 session.
+    seedPreFixProfile(session.userDataDir, repoId, worktreeId)
 
     const { app, page } = await session.launch()
+    activeApp = app
     await waitForSessionReady(page)
-
-    // Capture the loaded-pre-fix-session state either way: pre-fix builds show
-    // no notice here (the silent loss), the fixed build shows the warning.
-    await page.waitForTimeout(3_000)
-    await page.screenshot({
-      path: testInfo.outputPath('after-upgrade-relaunch.png'),
-      fullPage: true
-    })
 
     // The lost agent session cannot be conjured, so the user must be told
     // NON-DESTRUCTIVELY that agent state from the previous version could not be
     // recovered. Pre-fix this notice is absent — that silent loss is the bug.
     const notice = page.getByTestId('pre-upgrade-agent-session-loss-notice')
     await expect(notice).toBeVisible({ timeout: 20_000 })
+    await expect(notice).toHaveCount(1)
+
+    // The notice is informational: the original tab must remain rendered with
+    // its user-visible title rather than being deleted during hydration.
+    const restoredTab = page.locator(
+      `[data-testid="sortable-tab"][data-tab-id="${PRE_FIX_TAB_ID}"]`
+    )
+    await expect(restoredTab).toBeVisible()
+    await expect(restoredTab).toHaveAttribute('data-tab-title', 'Codex')
 
     await page.screenshot({
       path: testInfo.outputPath('upgrade-loss-notice.png'),
@@ -86,7 +113,22 @@ test('#5356 warns instead of silently dropping agent sessions when upgrading fro
     })
 
     await session.close(app)
+    activeApp = null
+
+    // The migrated session must stay quiet on the next launch. This catches a
+    // marker that only lived in renderer memory or was dropped by full writes.
+    const secondLaunch = await session.launch()
+    activeApp = secondLaunch.app
+    await waitForSessionReady(secondLaunch.page)
+    await expect(
+      secondLaunch.page.getByTestId('pre-upgrade-agent-session-loss-notice')
+    ).toHaveCount(0)
+    await session.close(secondLaunch.app)
+    activeApp = null
   } finally {
+    if (activeApp) {
+      await session.close(activeApp).catch(() => {})
+    }
     await session.dispose()
   }
 })

--- a/tests/e2e/agent-session-upgrade-loss-5356.spec.ts
+++ b/tests/e2e/agent-session-upgrade-loss-5356.spec.ts
@@ -1,0 +1,92 @@
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { getE2ECompletedOnboardingProfile } from './helpers/e2e-completed-onboarding-profile'
+import { waitForSessionReady } from './helpers/store'
+import { createRestartSession } from './helpers/orca-restart'
+
+// #5356: the first launch after upgrading FROM a pre-#5232 version silently
+// replaces every live floating-terminal agent session with a blank shell.
+// Pre-fix builds never wrote `sleepingAgentSessionsByPaneKey` at quit, so the
+// pane-level cold-restore finds nothing to resume and spawns a fresh shell —
+// with no warning at all.
+//
+// This seeds orca-data.json with exactly what such a pre-fix quit left on disk:
+// an agent terminal tab (`launchAgent`, which pre-fix builds DID persist), no
+// resume records, and no post-fix capability stamp. On the first launch of the
+// fixed build the session is unrecoverable (it genuinely cannot be conjured),
+// so the app must NON-DESTRUCTIVELY tell the user instead of silently swapping
+// in a blank shell.
+
+/** A workspace session shaped exactly like a pre-#5232 quit payload. */
+function preFixWorkspaceSession(): Record<string, unknown> {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: 'wt-5356',
+    activeTabId: 'tab5356',
+    tabsByWorktree: {
+      'wt-5356': [
+        {
+          id: 'tab5356',
+          ptyId: null,
+          worktreeId: 'wt-5356',
+          title: 'Codex',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1,
+          // Pre-fix builds already persisted launchAgent, so a live agent tab
+          // is identifiable on disk even though its session id is gone.
+          launchAgent: 'codex'
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {}
+    // No sleepingAgentSessionsByPaneKey, no agentSessionCaptureVersion — that
+    // absence is precisely the pre-#5232 state.
+  }
+}
+
+function seedPreFixProfile(userDataDir: string): void {
+  const profile = {
+    ...getE2ECompletedOnboardingProfile(),
+    workspaceSession: preFixWorkspaceSession()
+  }
+  writeFileSync(path.join(userDataDir, 'orca-data.json'), `${JSON.stringify(profile, null, 2)}\n`)
+}
+
+test('#5356 warns instead of silently dropping agent sessions when upgrading from a pre-#5232 version', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+{}, testInfo) => {
+  const session = createRestartSession(testInfo)
+
+  try {
+    // The first launch after the update reads a pre-#5232 session off disk.
+    seedPreFixProfile(session.userDataDir)
+
+    const { app, page } = await session.launch()
+    await waitForSessionReady(page)
+
+    // Capture the loaded-pre-fix-session state either way: pre-fix builds show
+    // no notice here (the silent loss), the fixed build shows the warning.
+    await page.waitForTimeout(3_000)
+    await page.screenshot({
+      path: testInfo.outputPath('after-upgrade-relaunch.png'),
+      fullPage: true
+    })
+
+    // The lost agent session cannot be conjured, so the user must be told
+    // NON-DESTRUCTIVELY that agent state from the previous version could not be
+    // recovered. Pre-fix this notice is absent — that silent loss is the bug.
+    const notice = page.getByTestId('pre-upgrade-agent-session-loss-notice')
+    await expect(notice).toBeVisible({ timeout: 20_000 })
+
+    await page.screenshot({
+      path: testInfo.outputPath('upgrade-loss-notice.png'),
+      fullPage: true
+    })
+
+    await session.close(app)
+  } finally {
+    await session.dispose()
+  }
+})


### PR DESCRIPTION
## Summary

Fixes #5356 — a P0 silent, unrecoverable data-loss bug on the first launch after auto-updating **from a version that predates the `#5232` fix**.

The cold-restore resume mechanism from `#5240` (commit b09d7124c) resumes agent sessions from the persisted `sleepingAgentSessionsByPaneKey` map, written at quit with `origin: 'quit'`. Builds predating `#5232` never wrote that field, so on the first launch after upgrading from such a version there is **nothing to resume**: every live agent terminal (Claude, Codex, …) cold-restores as a blank shell — silently, with no warning, exactly once per upgrading user.

The lost provider-session ids genuinely cannot be conjured from disk. So, per the issue's expected behavior, the app now **non-destructively tells the user once** instead of swapping in blank shells with no explanation.

## How it works

- **Capability stamp.** A new optional `agentSessionCaptureVersion` field on the persisted `WorkspaceSessionState`. Main stamps it on every full session write (`setWorkspaceSession`), so any session written by a capture-capable build carries it. **Absence is the signal** — it is never seeded into `getDefaultWorkspaceSession`, or a genuine pre-fix session would be misclassified.
- **Detection at hydration.** `shouldNotifyPreUpgradeAgentSessionLoss(session)` runs off the raw loaded session in `App.tsx`. It warns only when: the stamp is absent **and** there is a resumable agent tab (`launchAgent`, which pre-fix builds already persisted) **and** there are no `quit`/`live` capture records.
- **The no-false-alarm guard.** On the very first launch of *this* build, **no** session has the brand-new stamp yet — including sessions from a working post-`#5232` build whose agents *are* being resumed. The `quit`/`live`-record clause suppresses the notice in exactly that case, so only genuinely-unrecoverable pre-fix sessions trigger it.
- **Non-destructive notice.** A dismissable sonner toast — *"Agent sessions could not be restored"* — that blocks nothing and deletes nothing. The signal is consumed immediately (an imperative session patch) so it never re-fires.

## Reproduction & verification (real Electron)

`tests/e2e/agent-session-upgrade-loss-5356.spec.ts` first creates a valid repo/worktree catalog, then replaces the active profile's `workspaceSession` with the relevant pre-`#5232` fields — an agent tab, no resume records, no stamp — and launches.

- **Before:** the pre-fix session loads and **no** notice appears (the silent loss).
- **After:** the non-destructive notice appears.

Screenshots (before/after) are attached in a PR comment.

## Tests

- `src/shared/agent-session-upgrade-notice.test.ts` — the detection logic across all cases, including the post-`#5232` no-false-alarm guard.
- `src/renderer/src/lib/pre-upgrade-agent-session-loss-notice.test.tsx` — idempotent toast identity, direct marker persistence, and the stamped fast path.
- `src/shared/workspace-session-schema.test.ts` — the stamp round-trips and stays absent for pre-fix sessions.
- `src/main/persistence.test.ts` — full session writes are stamped.
- `tests/e2e/agent-session-upgrade-loss-5356.spec.ts` — end-to-end notice in real Electron.

## Trade-offs / user-visible changes

- One-time, dismissable informational toast for users upgrading from a pre-`#5232` build that had an agent terminal open. It blocks and deletes nothing.
- Agents started manually inside a plain terminal (no `launchAgent`) leave no on-disk trace in a pre-fix session, so they are not individually detected — the deliberate choice is to target the clear agent-tab case rather than alarm every upgrading user with any open terminal.

## Reliability contract

- **Invariant (`startup-upgrade.persisted-session-corpus`):** On the first launch from a pre-capture session, every valid restored tab remains present and unrecoverable agent context is never lost silently; the informational notice appears once and only once.
- **Failure source:** #5356 / the 1.4.65 → 1.4.68 upgrade path, where the prior writer never persisted provider-session ids.
- **Oracle:** Pure detection tests cover migration classification; renderer tests prove stable toast identity and direct marker persistence; the real Electron journey creates a valid local repo/worktree catalog, injects the affected session shape into the active profile, asserts one visible notice plus the original Codex tab, then launches again and asserts no notice.
- **Gate:** `config/reliability-gates.jsonc` → `startup-upgrade.persisted-session-corpus` is now partial/experimental with the executable command and evidence recorded.
- **Provider/platform coverage:** Local macOS Electron is covered. SSH continues to use the local session blob and this change adds no local-process/filesystem assumption, but live SSH, daemon-death, WSL, remote-runtime, Linux, and Windows upgrade journeys remain explicit gaps.
- **Performance budget:** Detection is one bounded pass over already-loaded tab/capture maps. It adds no startup await, polling, provider call, subprocess, recurring subscription, or hidden terminal work. The one-time marker patches the global/local field directly, avoiding the repo/worktree host-ownership scan. The gate completed in 33.00s including a fresh build (6.8s test time), after removing an unconditional 3s test sleep.
- **Diagnostics:** The stable toast id/test id, persisted capability stamp, Playwright screenshot/trace artifacts, and registered reliability-gate evidence make a future failure distinguishable as classification, rendering, persistence, or second-launch replay.
- **Residual gaps:** The fixture reconstructs the affected session fields inside a current valid catalog; it is not a byte-for-byte immutable 1.4.65 profile. Per-launch product startup timing and non-macOS/provider-specific live evidence are still uncollected.
