### PR TITLE
fix(terminal): honor an explicit Option as Alt Off in kitty keyboard panes

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1004,6 +1004,9 @@ export default function TerminalPane({
   const effectiveMacOptionAsAlt = useEffectiveMacOptionAsAlt(settings?.terminalMacOptionAsAlt)
   const macOptionAsAltRef = useRef<MacOptionAsAlt>(effectiveMacOptionAsAlt)
   macOptionAsAltRef.current = effectiveMacOptionAsAlt
+  const optionAsAltIsExplicit = (settings?.terminalMacOptionAsAlt ?? 'auto') !== 'auto'
+  const optionAsAltIsExplicitRef = useRef(optionAsAltIsExplicit)
+  optionAsAltIsExplicitRef.current = optionAsAltIsExplicit
   const onPtyExitRef = useRef(onPtyExit)
   onPtyExitRef.current = onPtyExit
 
@@ -1839,6 +1842,7 @@ export default function TerminalPane({
     searchOpenRef,
     searchStateRef,
     macOptionAsAltRef,
+    optionAsAltIsExplicitRef,
     paneKittyKeyboardModesRef,
     keybindings,
     terminalShortcutPolicy: settings?.terminalShortcutPolicy ?? 'orca-first'

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -49,7 +49,8 @@ export function resolveTerminalKeyboardShortcutAction(
   isKittyKeyboardActivePane: Parameters<typeof resolveTerminalShortcutAction>[7],
   layoutBaseCharacterForCode: Parameters<typeof resolveTerminalShortcutAction>[8],
   getWindowsShiftEnterEncoding: Parameters<typeof resolveTerminalShortcutAction>[9],
-  isWindowsTerminalHost: NonNullable<Parameters<typeof resolveTerminalShortcutAction>[10]>
+  isWindowsTerminalHost: NonNullable<Parameters<typeof resolveTerminalShortcutAction>[10]>,
+  optionAsAltIsExplicit: Parameters<typeof resolveTerminalShortcutAction>[11] = false
 ): ReturnType<typeof resolveTerminalShortcutAction> {
   // Why: keep the host callback required at the production boundary so a
   // caller cannot silently fall back to client-OS byte routing.
@@ -64,7 +65,8 @@ export function resolveTerminalKeyboardShortcutAction(
     isKittyKeyboardActivePane,
     layoutBaseCharacterForCode,
     getWindowsShiftEnterEncoding,
-    isWindowsTerminalHost
+    isWindowsTerminalHost,
+    optionAsAltIsExplicit
   )
 }
 
@@ -201,6 +203,7 @@ type KeyboardHandlersDeps = {
   searchOpenRef: React.RefObject<boolean>
   searchStateRef: React.RefObject<SearchState>
   macOptionAsAltRef: React.RefObject<MacOptionAsAlt>
+  optionAsAltIsExplicitRef: React.RefObject<boolean>
   paneKittyKeyboardModesRef?: React.RefObject<Map<number, TerminalKittyKeyboardModeTracker>>
   keybindings?: KeybindingOverrides
   terminalShortcutPolicy?: TerminalShortcutPolicy
@@ -236,6 +239,7 @@ export function useTerminalKeyboardShortcuts({
   searchOpenRef,
   searchStateRef,
   macOptionAsAltRef,
+  optionAsAltIsExplicitRef,
   paneKittyKeyboardModesRef,
   keybindings,
   terminalShortcutPolicy = 'orca-first'
@@ -392,7 +396,8 @@ export function useTerminalKeyboardShortcuts({
         isKittyKeyboardActivePane,
         getLayoutBaseCharacterForCode,
         getActivePaneWindowsShiftEnterEncoding,
-        isActivePaneWindowsTerminalHost
+        isActivePaneWindowsTerminalHost,
+        optionAsAltIsExplicitRef.current
       )
       if (!action) {
         return
@@ -637,6 +642,7 @@ export function useTerminalKeyboardShortcuts({
     searchOpenRef,
     searchStateRef,
     macOptionAsAltRef,
+    optionAsAltIsExplicitRef,
     paneKittyKeyboardModesRef,
     keybindings,
     terminalShortcutPolicy,

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -684,7 +684,8 @@ describe('kitty keyboard protocol panes', () => {
     input: TerminalShortcutEvent,
     macOptionAsAlt: 'true' | 'false' | 'left' | 'right' = 'false',
     optionKeyLocation = 0,
-    active: () => boolean = kittyActive
+    active: () => boolean = kittyActive,
+    optionAsAltIsExplicit = false
   ) =>
     resolveTerminalShortcutAction(
       input,
@@ -694,8 +695,72 @@ describe('kitty keyboard protocol panes', () => {
       false,
       undefined,
       undefined,
-      active
+      active,
+      undefined,
+      undefined,
+      undefined,
+      optionAsAltIsExplicit
     )
+
+  it('lets explicit Option Off compose punctuation in kitty panes', () => {
+    expect(
+      resolveKitty(event({ key: '{', code: 'Quote', altKey: true }), 'false', 0, kittyActive, true)
+    ).toEqual({ type: 'sendInput', data: '{' })
+  })
+
+  it('keeps auto-resolved Off encoded for kitty panes', () => {
+    expect(resolveKitty(event({ key: '{', code: 'Quote', altKey: true }))).toEqual({
+      type: 'sendInput',
+      data: '\x1b[39;3u'
+    })
+  })
+
+  it('preserves readline and explicit Meta modes with explicit Off', () => {
+    expect(
+      resolveKitty(event({ key: '∫', code: 'KeyB', altKey: true }), 'false', 0, kittyActive, true)
+    ).toEqual({ type: 'sendInput', data: '\x1bb' })
+    expect(
+      resolveKitty(event({ key: '¬', code: 'KeyL', altKey: true }), 'left', 1, kittyActive, true)
+    ).toEqual({ type: 'sendInput', data: '\x1b[108;3u' })
+    expect(
+      resolveKitty(event({ key: '¬', code: 'KeyL', altKey: true }), 'right', 2, kittyActive, true)
+    ).toEqual({ type: 'sendInput', data: '\x1b[108;3u' })
+    expect(
+      resolveKitty(event({ key: '¬', code: 'KeyL', altKey: true }), 'false', 0, kittyInactive, true)
+    ).toBeNull()
+  })
+  it('keeps the compose-side Option key literal in explicit left/right kitty modes', () => {
+    expect(
+      resolveKitty(event({ key: '{', code: 'Quote', altKey: true }), 'left', 2, kittyActive, true)
+    ).toEqual({
+      type: 'sendInput',
+      data: '{'
+    })
+    expect(
+      resolveKitty(event({ key: '{', code: 'Quote', altKey: true }), 'right', 1, kittyActive, true)
+    ).toEqual({
+      type: 'sendInput',
+      data: '{'
+    })
+  })
+
+  it('keeps shifted compose-side Option characters literal in explicit kitty modes', () => {
+    for (const [mode, location] of [
+      ['false', 0],
+      ['left', 2],
+      ['right', 1]
+    ] as const) {
+      expect(
+        resolveKitty(
+          event({ key: '∏', code: 'KeyP', altKey: true, shiftKey: true }),
+          mode,
+          location,
+          kittyActive,
+          true
+        )
+      ).toEqual({ type: 'sendInput', data: '∏' })
+    }
+  })
 
   it('encodes Option+letter as kitty CSI-u with the physical base key in compose mode', () => {
     // macOS composition reports key='π' for Option+P on ABC/compose layouts;
@@ -824,8 +889,7 @@ describe('kitty keyboard protocol panes', () => {
         layoutBaseCharacterForCode
       )
 
-    // AZERTY types M at the physical Semicolon position; the layout map must
-    // win over the US punctuation table so the chord reports alt+m, not alt+;.
+    // AZERTY types M at Semicolon, so the layout map must beat the US table and report alt+m, not alt+;.
     const azerty = (code: string): string | undefined => (code === 'Semicolon' ? 'm' : undefined)
     expect(resolveWithLayout(event({ key: 'µ', code: 'Semicolon', altKey: true }), azerty)).toEqual(
       { type: 'sendInput', data: '\x1b[109;3u' }

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -93,7 +93,8 @@ export function resolveTerminalShortcutAction(
   getWindowsShiftEnterEncoding?: () => WindowsShiftEnterEncoding,
   // Why: keybindings follow the client OS, but terminal byte protocols follow
   // the PTY host. They differ for macOS clients attached to Windows runtimes.
-  isWindowsTerminalHost: () => boolean = () => isWindows
+  isWindowsTerminalHost: () => boolean = () => isWindows,
+  optionAsAltIsExplicit = false
 ): TerminalShortcutAction | null {
   const platform: NodeJS.Platform = isMac ? 'darwin' : isWindows ? 'win32' : 'linux'
   if (!event.repeat) {
@@ -290,18 +291,26 @@ export function resolveTerminalShortcutAction(
   //
   // The handling depends on the macOptionAsAlt setting (mirrors Ghostty):
   // - 'true':  xterm handles all Option as Meta natively; nothing to do here.
-  // - kitty-protocol pane (any other mode): the TUI asked for modifier-accurate
-  //   keys, so every Option chord is encoded as kitty CSI-u with the physical
-  //   base key (Option+P → \x1b[112;3u). Without this, xterm's kitty encoder
-  //   reports the composed codepoint (alt+π), which no TUI binds — the chord
-  //   neither triggers the hotkey nor types the character (issue: OMP Alt+P /
-  //   Alt+M dead on compose layouts). Dead keys are exempt so composition
-  //   (Option+E → ´) keeps working.
+  // - kitty-protocol pane: auto-resolved compose mode and explicit Meta-side
+  //   modes defer to the TUI's modifier-accurate encoding. An explicitly chosen
+  //   compose side keeps literal composed input instead; dead keys are exempt
+  //   so composition (Option+E → ´) keeps working.
   // - 'false': compensate the three most critical readline shortcuts (B/F/D).
   // - 'left'/'right': the designated Option key acts as full Meta (emit Esc+
   //   for any single letter); the other key composes, with B/F/D compensated.
   if (isMac && !event.metaKey && !event.ctrlKey && event.altKey && macOptionAsAlt !== 'true') {
-    if (event.key !== 'Dead' && isKittyKeyboardActivePane?.()) {
+    const isLeftOption = optionKeyLocation === 1
+    const isRightOption = optionKeyLocation === 2
+    const shouldActAsMeta =
+      (macOptionAsAlt === 'left' && isLeftOption) || (macOptionAsAlt === 'right' && isRightOption)
+    const kittyActive = event.key !== 'Dead' && isKittyKeyboardActivePane?.() === true
+    const explicitComposeSide = optionAsAltIsExplicit && !shouldActAsMeta
+    const needsReadlineComposeCompensation =
+      !shouldActAsMeta &&
+      !event.shiftKey &&
+      (event.code === 'KeyB' || event.code === 'KeyF' || event.code === 'KeyD')
+
+    if (kittyActive && !explicitComposeSide) {
       const baseCharacter =
         (event.code ? layoutBaseCharacterForCode?.(event.code) : undefined) ??
         resolveUnshiftedCharacterForCode(event.code)
@@ -313,17 +322,16 @@ export function resolveTerminalShortcutAction(
       }
     }
 
+    if (
+      kittyActive &&
+      explicitComposeSide &&
+      event.key.length === 1 &&
+      !needsReadlineComposeCompensation
+    ) {
+      return { type: 'sendInput', data: event.key }
+    }
+
     if (!event.shiftKey) {
-      // Why: event.location on a character key reports that key's position
-      // (always 0 for standard keys), NOT which modifier is held. The caller
-      // must track the Option key's own keydown location and pass it as
-      // optionKeyLocation.
-      const isLeftOption = optionKeyLocation === 1
-      const isRightOption = optionKeyLocation === 2
-
-      const shouldActAsMeta =
-        (macOptionAsAlt === 'left' && isLeftOption) || (macOptionAsAlt === 'right' && isRightOption)
-
       if (shouldActAsMeta) {
         // Emit Esc+key (e.g. Option+B → \x1bb) for letters, digits, and
         // mapped punctuation.


### PR DESCRIPTION
## Summary

Honor an explicit Terminal → Option as Alt → Off choice when a kitty-protocol application is active. Orca currently sends kitty CSI-u modifier bytes for every mode except On, so a French-PC `AltGr + '` chord becomes `\x1b[39;3u` inside vim instead of composing `{`.

The policy now receives a live explicit-versus-auto discriminator. Explicit compose-side modes send the literal composed character, including shifted chords such as `∏`, before xterm's kitty encoder can rewrite it, while auto-resolved Off retains the existing kitty encoding used by application shortcuts. Readline B/F/D compensation and explicit left/right Meta behavior remain unchanged.

Related work: [#8422](https://github.com/stablyai/orca/pull/8422) addresses composed `@` on the same policy branch. Its sequencing with this general explicit-Off fix is left to maintainers.

Closes #8733.

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/keyboard-layout/detect-option-as-alt.test.ts`
- [x] `pnpm run typecheck:web`
- [x] `pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts src/renderer/src/components/terminal-pane/keyboard-handlers.ts src/renderer/src/components/terminal-pane/TerminalPane.tsx`
- [x] `pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts src/renderer/src/components/terminal-pane/keyboard-handlers.ts src/renderer/src/components/terminal-pane/TerminalPane.tsx`
- [ ] macOS vim reproduction with French-PC layout, unavailable on this Windows workstation
- [ ] `pnpm test`, `pnpm build`, and E2E, not run because this change has no Electron or visual surface changes

The base-first regression run failed with the original synthetic `\x1b[39;3u` output. The head policy suite passed 39 tests. The keyboard-layout suite passed 24 tests.

## AI Review Report

- macOS: the policy remains inside the existing `isMac` guard. The French-PC vim flow is covered at the byte-policy level, but end-to-end confirmation requires the issue reporter or a maintainer on macOS.
- Linux and Windows: the new parameter is optional and the branch remains macOS-only, so non-macOS routing is unchanged.
- SSH, remote, local, and provider behavior: no PTY ownership, transport, provider, or SSH paths changed; the policy only swaps explicit compose-side kitty output from Orca-generated modifier bytes to the literal composed character, including shifted compose-side chords.
- Performance: one boolean ref read is added to the existing keydown path; no new scans, allocations, or subprocesses are introduced.
- UI quality: no visual surface changed.

## Security Audit

The change does not add input sources, permissions, subprocesses, network access, persistence, or shell interpolation. It narrows direct PTY writes to preserve the user's explicit keyboard setting. Existing kitty negotiation, dead-key handling, and B/F/D compensation remain bounded by the existing platform and modifier guards.

## Notes

The macOS end-to-end reality check remains open for `nicoolas25` or a maintainer with a French-PC macOS layout. PR #8422 overlaps the same policy branch, so maintainers should choose sequencing or conflict resolution.
