### PR TITLE
feat(cli): add orca account list and account use

### DIFF
--- a/src/cli/account-format.ts
+++ b/src/cli/account-format.ts
@@ -1,0 +1,18 @@
+import type { ClaudeRateLimitAccountsState } from '../shared/types'
+
+export function formatClaudeAccountList(state: ClaudeRateLimitAccountsState): string {
+  if (state.accounts.length === 0) {
+    return 'No Claude accounts found.'
+  }
+  return state.accounts
+    .map((account) => {
+      const runtime = account.managedAuthRuntime ?? 'host'
+      const activeId =
+        runtime === 'wsl'
+          ? state.activeAccountIdsByRuntime?.wsl?.[account.wslDistro?.trim() || '__default__']
+          : (state.activeAccountIdsByRuntime?.host ?? state.activeAccountId)
+      const active = account.id === activeId ? '* ' : '  '
+      return `${active}${account.id} ${account.email} ${account.authMethod} ${runtime}`
+    })
+    .join('\n')
+}

--- a/src/cli/account-selector.test.ts
+++ b/src/cli/account-selector.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveClaudeAccountId } from './account-selector'
+
+const snapshot = {
+  accounts: [
+    {
+      id: 'personal',
+      email: 'me@example.com',
+      authMethod: 'subscription-oauth' as const,
+      managedAuthRuntime: 'host' as const,
+      createdAt: 0,
+      updatedAt: 0,
+      lastAuthenticatedAt: 0
+    },
+    {
+      id: 'work',
+      email: 'work@example.com',
+      authMethod: 'subscription-oauth' as const,
+      managedAuthRuntime: 'wsl' as const,
+      createdAt: 0,
+      updatedAt: 0,
+      lastAuthenticatedAt: 0
+    }
+  ],
+  activeAccountId: 'personal'
+}
+
+describe('resolveClaudeAccountId', () => {
+  it('prefers exact ids and resolves exact emails case-insensitively', () => {
+    expect(resolveClaudeAccountId(snapshot, 'work')).toBe('work')
+    expect(resolveClaudeAccountId(snapshot, 'WORK@EXAMPLE.COM')).toBe('work')
+  })
+
+  it('returns null for the explicit system-default selector', () => {
+    expect(resolveClaudeAccountId(snapshot, null)).toBeNull()
+  })
+
+  it('rejects unknown selectors', () => {
+    expect(() => resolveClaudeAccountId(snapshot, 'missing')).toThrow(/orca account list/)
+  })
+
+  it('rejects ambiguous email selectors', () => {
+    const ambiguous = {
+      ...snapshot,
+      accounts: [
+        snapshot.accounts[0],
+        { ...snapshot.accounts[1], email: snapshot.accounts[0].email }
+      ]
+    }
+    expect(() => resolveClaudeAccountId(ambiguous, 'ME@EXAMPLE.COM')).toThrow(/multiple accounts/)
+  })
+})

--- a/src/cli/account-selector.ts
+++ b/src/cli/account-selector.ts
@@ -1,0 +1,31 @@
+import type { ClaudeRateLimitAccountsState } from '../shared/types'
+import { RuntimeClientError } from './runtime-client'
+
+export function resolveClaudeAccountId(
+  snapshot: ClaudeRateLimitAccountsState,
+  selector: string | null
+): string | null {
+  if (selector === null) {
+    return null
+  }
+  const idMatch = snapshot.accounts.find((account) => account.id === selector)
+  if (idMatch) {
+    return idMatch.id
+  }
+  const emailMatches = snapshot.accounts.filter(
+    (account) => account.email.toLowerCase() === selector.toLowerCase()
+  )
+  if (emailMatches.length === 1) {
+    return emailMatches[0].id
+  }
+  if (emailMatches.length > 1) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Account selector "${selector}" matches multiple accounts; use an account id.`
+    )
+  }
+  throw new RuntimeClientError(
+    'invalid_argument',
+    `Claude account "${selector}" was not found. Run "orca account list" to see available accounts.`
+  )
+}

--- a/src/cli/agent-context.test.ts
+++ b/src/cli/agent-context.test.ts
@@ -84,6 +84,16 @@ describe('agent-context over the live registry', () => {
     expect(agentContext?.flags).not.toContain('page')
   })
 
+  it('advertises account commands without browser-only flags', () => {
+    const schema = buildAgentContext(COMMAND_SPECS)
+    const accountList = schema.commands.find((command) => command.command === 'account list')
+    const accountUse = schema.commands.find((command) => command.command === 'account use')
+    expect(accountList?.usage).toBe('orca account list [--json]')
+    expect(accountList?.flags).not.toContain('page')
+    expect(accountUse?.flags).toContain('account')
+    expect(accountUse?.flags).not.toContain('page')
+  })
+
   it('marks raw passthrough commands without synthesizing Orca flags', () => {
     const schema = buildAgentContext(COMMAND_SPECS)
     const claudeTeams = schema.commands.find((command) => command.command === 'claude-teams')

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -4,6 +4,7 @@ import type { CommandSpec } from './args'
 import {
   REPEATED_FLAG_SEPARATOR,
   findCommandSpec,
+  isCommandGroup,
   normalizeCommandPositionals,
   parseArgs,
   supportsBrowserPageFlag,
@@ -229,8 +230,19 @@ describe('supportsBrowserPageFlag', () => {
     expect(supportsBrowserPageFlag(['orchestration', 'send'])).toBe(false)
   })
 
+  it('does not expose browser page targeting on account commands', () => {
+    expect(supportsBrowserPageFlag(['account', 'list'])).toBe(false)
+    expect(supportsBrowserPageFlag(['account', 'use'])).toBe(false)
+  })
+
   it('does not expose browser page targeting on local agent discovery', () => {
     expect(supportsBrowserPageFlag(['agent-context'])).toBe(false)
+  })
+})
+
+describe('isCommandGroup', () => {
+  it('treats account as a group command for help routing', () => {
+    expect(isCommandGroup(['account'])).toBe(true)
   })
 })
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -180,6 +180,7 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
       'note',
       'diagnostics',
       'linear',
+      'account',
       'skills',
       'agent-context'
     ].includes(commandPath[0])
@@ -236,6 +237,7 @@ export function isCommandGroup(commandPath: string[]): boolean {
         'environment',
         'diagnostics',
         'linear',
+        'account',
         'skills',
         'vm'
       ].includes(commandPath[0])) ||

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -25,6 +25,7 @@ import { EMULATOR_HANDLERS } from './handlers/emulator'
 import { LINEAR_HANDLERS } from './handlers/linear'
 import { VM_HANDLERS } from './handlers/vm'
 import { SKILL_HANDLERS } from './handlers/skills'
+import { ACCOUNT_HANDLERS } from './handlers/account'
 
 export type HandlerContext = {
   flags: Map<string, string | boolean>
@@ -63,7 +64,8 @@ function buildHandlers(): Map<string, CommandHandler> {
     ENVIRONMENT_HANDLERS,
     LINEAR_HANDLERS,
     VM_HANDLERS,
-    SKILL_HANDLERS
+    SKILL_HANDLERS,
+    ACCOUNT_HANDLERS
   ]
   for (const group of groups) {
     for (const [key, handler] of Object.entries(group)) {

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -4,6 +4,8 @@ import { prepareComputerCliJsonResult } from './computer-format'
 import type { RuntimeRpcFailure, RuntimeRpcSuccess } from './runtime-client'
 import { RuntimeClientError, RuntimeRpcFailureError } from './runtime-client'
 
+export { formatClaudeAccountList } from './account-format'
+
 export {
   formatBrowserProfileList,
   formatScreenshot,

--- a/src/cli/handlers/account.test.ts
+++ b/src/cli/handlers/account.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ACCOUNT_HANDLERS } from './account'
+import type { RuntimeClient } from '../runtime-client'
+
+const state = {
+  accounts: [
+    {
+      id: 'personal',
+      email: 'me@example.com',
+      authMethod: 'subscription-oauth' as const,
+      managedAuthRuntime: 'host' as const,
+      createdAt: 0,
+      updatedAt: 0,
+      lastAuthenticatedAt: 0
+    },
+    {
+      id: 'work',
+      email: 'work@example.com',
+      authMethod: 'subscription-oauth' as const,
+      managedAuthRuntime: 'host' as const,
+      createdAt: 0,
+      updatedAt: 0,
+      lastAuthenticatedAt: 0
+    }
+  ],
+  activeAccountId: 'personal',
+  activeAccountIdsByRuntime: { host: 'personal', wsl: { Ubuntu: 'work' } }
+}
+
+describe('account CLI handlers', () => {
+  const call = vi.fn()
+  const client = { call } as unknown as RuntimeClient
+
+  beforeEach(() => {
+    call.mockReset()
+    vi.spyOn(console, 'log')
+      .mockImplementation(() => {})
+      .mockClear()
+  })
+
+  it('lists accounts and omits credential paths from formatted output', async () => {
+    call.mockResolvedValue({ id: 'list', ok: true, result: { claude: state } })
+    await ACCOUNT_HANDLERS['account list']({
+      flags: new Map(),
+      client,
+      cwd: '/tmp',
+      json: false
+    })
+    expect(call).toHaveBeenCalledWith('accounts.list')
+    expect(vi.mocked(console.log).mock.calls[0][0]).toContain('* personal')
+    expect(vi.mocked(console.log).mock.calls[0][0]).not.toContain('managedAuthPath')
+  })
+
+  it('marks the selected WSL account using its runtime snapshot entry', async () => {
+    const wslState = {
+      ...state,
+      accounts: [
+        state.accounts[0],
+        {
+          id: 'work',
+          email: 'work@example.com',
+          authMethod: 'subscription-oauth' as const,
+          managedAuthRuntime: 'wsl' as const,
+          wslDistro: 'Ubuntu',
+          createdAt: 0,
+          updatedAt: 0,
+          lastAuthenticatedAt: 0
+        }
+      ]
+    }
+    call.mockResolvedValue({ id: 'list', ok: true, result: { claude: wslState } })
+    await ACCOUNT_HANDLERS['account list']({
+      flags: new Map(),
+      client,
+      cwd: '/tmp',
+      json: false
+    })
+    const output = vi.mocked(console.log).mock.calls[0][0] as string
+    expect(output).toContain('* work work@example.com')
+    expect(output).toContain('* personal me@example.com')
+  })
+
+  it('falls back to the legacy host selection when runtime metadata is absent', async () => {
+    const legacyState = {
+      accounts: [
+        {
+          id: 'personal',
+          email: 'me@example.com',
+          authMethod: 'subscription-oauth' as const,
+          createdAt: 0,
+          updatedAt: 0,
+          lastAuthenticatedAt: 0
+        }
+      ],
+      activeAccountId: 'personal'
+    }
+    call.mockResolvedValue({ id: 'list', ok: true, result: { claude: legacyState } })
+    await ACCOUNT_HANDLERS['account list']({
+      flags: new Map(),
+      client,
+      cwd: '/tmp',
+      json: false
+    })
+    expect(vi.mocked(console.log).mock.calls[0][0]).toContain(
+      '* personal me@example.com subscription-oauth host'
+    )
+  })
+
+  it('uses the __default__ WSL selection key when the distro name is blank', async () => {
+    const defaultWslState = {
+      ...state,
+      accounts: [
+        state.accounts[0],
+        {
+          id: 'work',
+          email: 'work@example.com',
+          authMethod: 'subscription-oauth' as const,
+          managedAuthRuntime: 'wsl' as const,
+          wslDistro: '  ',
+          createdAt: 0,
+          updatedAt: 0,
+          lastAuthenticatedAt: 0
+        }
+      ],
+      activeAccountIdsByRuntime: { host: 'personal', wsl: { __default__: 'work' } }
+    }
+    call.mockResolvedValue({ id: 'list', ok: true, result: { claude: defaultWslState } })
+    await ACCOUNT_HANDLERS['account list']({
+      flags: new Map(),
+      client,
+      cwd: '/tmp',
+      json: false
+    })
+    expect(vi.mocked(console.log).mock.calls[0][0]).toContain(
+      '* work work@example.com subscription-oauth wsl'
+    )
+  })
+
+  it('renders an explicit empty state', async () => {
+    call.mockResolvedValue({ id: 'list', ok: true, result: { claude: { ...state, accounts: [] } } })
+    await ACCOUNT_HANDLERS['account list']({
+      flags: new Map(),
+      client,
+      cwd: '/tmp',
+      json: false
+    })
+    expect(vi.mocked(console.log).mock.calls[0][0]).toBe('No Claude accounts found.')
+  })
+
+  it('clears selection with JSON null', async () => {
+    call
+      .mockResolvedValueOnce({ id: 'list', ok: true, result: { claude: state } })
+      .mockResolvedValueOnce({
+        id: 'select',
+        ok: true,
+        result: { ...state, activeAccountId: null }
+      })
+    await ACCOUNT_HANDLERS['account use']({
+      flags: new Map([['account', 'null']]),
+      client,
+      cwd: '/tmp',
+      json: false
+    })
+    expect(call).toHaveBeenNthCalledWith(2, 'accounts.selectClaude', { accountId: null })
+  })
+
+  it.each([true, ''])('rejects a valueless selector before runtime RPC (%s)', async (account) => {
+    await expect(
+      ACCOUNT_HANDLERS['account use']({
+        flags: new Map([['account', account]]),
+        client,
+        cwd: '/tmp',
+        json: false
+      })
+    ).rejects.toMatchObject({ code: 'invalid_argument' })
+    expect(call).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/handlers/account.ts
+++ b/src/cli/handlers/account.ts
@@ -1,0 +1,28 @@
+import type { ClaudeRateLimitAccountsState } from '../../shared/types'
+import type { CommandHandler } from '../dispatch'
+import { formatClaudeAccountList, printResult } from '../format'
+import { getRequiredStringFlag } from '../flags'
+import { resolveClaudeAccountId } from '../account-selector'
+
+type AccountsSnapshot = { claude: ClaudeRateLimitAccountsState }
+
+function accountSelector(flags: Map<string, string | boolean>): string | null {
+  const selector = getRequiredStringFlag(flags, 'account')
+  return selector === 'null' ? null : selector
+}
+
+export const ACCOUNT_HANDLERS: Record<string, CommandHandler> = {
+  'account list': async ({ client, json }) => {
+    const result = await client.call<AccountsSnapshot>('accounts.list')
+    printResult({ ...result, result: result.result.claude }, json, formatClaudeAccountList)
+  },
+  'account use': async ({ flags, client, json }) => {
+    const selector = accountSelector(flags)
+    const snapshot = await client.call<AccountsSnapshot>('accounts.list')
+    const accountId = resolveClaudeAccountId(snapshot.result.claude, selector)
+    const result = await client.call<ClaudeRateLimitAccountsState>('accounts.selectClaude', {
+      accountId
+    })
+    printResult(result, json, formatClaudeAccountList)
+  }
+}

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -229,16 +229,26 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       }
     }
     const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue')
+    const repo = await getCreateRepoSelector(flags, cwdParentWorktree, client)
+    const name = getRequiredStringFlag(flags, 'name')
+    const baseBranch = getOptionalStringFlag(flags, 'base-branch')
+    const linkedIssue = getOptionalNumberFlag(flags, 'issue')
+    const comment = getOptionalStringFlag(flags, 'comment')
+    const runHooks = flags.get('run-hooks') === true
+    const activate = flags.get('activate') === true || runHooks || Boolean(startupAgent)
+    const startupPrompt =
+      startupAgent !== undefined
+        ? (getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? '')
+        : undefined
     const result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', {
-      repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
-      name: getRequiredStringFlag(flags, 'name'),
-      baseBranch: getOptionalStringFlag(flags, 'base-branch'),
-      linkedIssue: getOptionalNumberFlag(flags, 'issue'),
+      repo,
+      name,
+      baseBranch,
+      linkedIssue,
       ...linearIssueLink,
-      comment: getOptionalStringFlag(flags, 'comment'),
-      runHooks: flags.get('run-hooks') === true,
-      activate:
-        flags.get('activate') === true || flags.get('run-hooks') === true || Boolean(startupAgent),
+      comment,
+      runHooks,
+      activate,
       ...(setupDecision ? { setupDecision } : {}),
       parentWorktree: explicitParentWorktree,
       ...(explicitParentWorkspace ? { parentWorkspace: explicitParentWorkspace } : {}),
@@ -249,7 +259,7 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       ...(startupAgent
         ? {
             startupAgent,
-            startupPrompt: getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? ''
+            startupPrompt
           }
         : {})
     })

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -22,6 +22,10 @@ Skills:
   skills list               List version-matched skill guides bundled with this Orca CLI
   skills get                Print a version-matched skill guide as Markdown
 
+Accounts:
+  account list              List managed Claude accounts
+  account use               Select a managed Claude account
+
 Environments:
   environment add           Save a remote Orca runtime from a pairing code
   environment list          List saved remote Orca runtimes
@@ -201,6 +205,8 @@ Common Commands:
   orca status [--json]
   orca diagnostics memory [--json]
   orca agent-context [--json]
+  orca account list [--json]
+  orca account use --account <id|email|null> [--json]
   orca environment add --name <name> --pairing-code <code> [--json]
   orca environment list [--json]
   orca environment show --environment <selector> [--json]
@@ -470,6 +476,8 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
 export function formatFlagHelp(flag: string): string {
   const helpByFlag: Record<string, string> = {
     agent: '--agent <id>          Launch a known TUI agent in the first terminal',
+    account:
+      '--account <id|email|null> Select a managed Claude account or clear the current target',
     'base-branch': '--base-branch <ref>    Base branch/ref to create the worktree from',
     command: '--command <text>       Command to run in the terminal on startup',
     comment: '--comment <text>       Comment stored in Orca metadata',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -314,6 +314,10 @@ describe('orca root help', () => {
     await main([], '/tmp/repo')
 
     expect(logSpy.mock.calls.flat().join('\n')).toContain('agent-context')
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('Accounts:')
+    expect(logSpy.mock.calls.flat().join('\n')).toContain(
+      'account list              List managed Claude accounts'
+    )
     logSpy.mockRestore()
   })
 
@@ -351,6 +355,53 @@ describe('orca root help', () => {
       'orca terminal create --worktree active --command "codex"'
     )
     expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['account --help', ['account', '--help']],
+    ['help account', ['help', 'account']]
+  ])('prints account group help for %s', async (_label, argv) => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(argv, '/tmp/repo')
+
+    const help = String(logSpy.mock.calls[0][0])
+    expect(help).toContain('orca account')
+    expect(help).toContain('list')
+    expect(help).toContain('use')
+    expect(process.exitCode).not.toBe(1)
+    expect(callMock).not.toHaveBeenCalled()
+    logSpy.mockRestore()
+  })
+
+  it.each([
+    ['account list', ['account', 'list', '--page', 'page_123']],
+    ['account use', ['account', 'use', '--account', 'work', '--page', 'page_123']]
+  ])('rejects browser page targeting on %s', async (_label, argv) => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(argv, '/tmp/repo')
+
+    const stderr = errorSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(process.exitCode).toBe(1)
+    expect(stderr).toContain('Unknown flag --page')
+    errorSpy.mockRestore()
+    process.exitCode = 0
+  })
+
+  it('rejects worktree account selection', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      ['worktree', 'create', '--name', 'task', '--agent', 'claude', '--account', 'work'],
+      '/tmp/repo'
+    )
+
+    const stderr = errorSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(process.exitCode).toBe(1)
+    expect(stderr).toContain('Unknown flag --account')
+    errorSpy.mockRestore()
+    process.exitCode = 0
   })
 
   it('progressively discloses Linear commands', async () => {

--- a/src/cli/specs/account.ts
+++ b/src/cli/specs/account.ts
@@ -1,0 +1,17 @@
+import type { CommandSpec } from '../args'
+import { GLOBAL_FLAGS } from '../args'
+
+export const ACCOUNT_COMMAND_SPECS: CommandSpec[] = [
+  {
+    path: ['account', 'list'],
+    summary: 'List managed Claude accounts',
+    usage: 'orca account list [--json]',
+    allowedFlags: [...GLOBAL_FLAGS]
+  },
+  {
+    path: ['account', 'use'],
+    summary: 'Select a managed Claude account',
+    usage: 'orca account use --account <id|email|null> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'account']
+  }
+]

--- a/src/cli/specs/index.ts
+++ b/src/cli/specs/index.ts
@@ -15,6 +15,7 @@ import { INTROSPECTION_COMMAND_SPECS } from './introspection'
 import { LINEAR_COMMAND_SPECS } from './linear'
 import { VM_COMMAND_SPECS } from './vm'
 import { SKILL_COMMAND_SPECS } from './skills'
+import { ACCOUNT_COMMAND_SPECS } from './account'
 
 export const COMMAND_SPECS: CommandSpec[] = [
   ...CORE_COMMAND_SPECS,
@@ -32,5 +33,6 @@ export const COMMAND_SPECS: CommandSpec[] = [
   ...LINEAR_COMMAND_SPECS,
   ...VM_COMMAND_SPECS,
   ...EMULATOR_COMMAND_SPECS,
-  ...SKILL_COMMAND_SPECS
+  ...SKILL_COMMAND_SPECS,
+  ...ACCOUNT_COMMAND_SPECS
 ]


### PR DESCRIPTION
Closes #8770.

## Summary

This adds `orca account list` and `orca account use --account <id|email|null>` on top of the existing managed-account RPCs.

It does not add a spawn-side `--account` flag. The current CLI surface can switch the active managed Claude account, but it cannot target that switch to the same runtime slot a new Claude terminal will launch against on every host/WSL pairing. Exposing `worktree create --account` on top of `accounts.selectClaude` would overstate what the current runtime API guarantees.

The implementation reuses the existing account RPCs. It adds no new RPC, IPC, renderer, store, or runtime-account changes.

The issue asked for `id`, `email`, and `plan`. The account summary type has no `plan` field, so the CLI prints the available summary fields instead.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (not run; focused lint was run)
- [ ] `pnpm typecheck` (not run; `pnpm run typecheck:cli` passed)
- [ ] `pnpm test` (not run; focused Vitest passed)
- [ ] `pnpm build` (not run)
- [x] Focused Vitest: 6 files passed, 216 tests passed, 3 skipped
- [x] `pnpm run typecheck:cli`
- [x] Focused `pnpm exec oxlint` on the changed CLI file set
- [x] Focused `pnpm exec oxfmt --check` on the changed CLI file set

## AI Review Report

- The CLI now exposes the existing `accounts.list` and `accounts.selectClaude` RPCs through `account list` and `account use`.
- Selector resolution is shared, exact, and loud on bad input. Unknown and ambiguous selectors fail with `invalid_argument`.
- `account use` validates `--account` before any runtime RPC, so malformed local input does not trigger a refresh or turn into a runtime-availability error.
- The formatter now covers both the legacy host-only fallback and the blank-distro `__default__` WSL selection key, while still using the runtime-aware selection map when metadata is present.
- `worktree create --account` stays rejected because the current spawn path and account-selection path choose their runtime targets from different inputs.
- No SSH, remote, renderer, Electron, or browser path changed.

## Security Audit

`account list` exposes managed-account ids, emails, auth method, and runtime to the CLI caller. It does not expose `managedAuthPath`, tokens, credentials, or full managed-account records. JSON output remains limited to the Claude account summary state. Selector errors include the requested selector and a command hint, not account credentials.

## Notes

- `accounts.list` is reused as-is, including its refresh path and network latency.
- `account use --account null` sends a clear-selection request.
- Spawn-side account selection remains follow-up work because the current CLI surface lacks a runtime-target-aware selection API.

## ELI5

CLI commands `orca account list` and `orca account use` manage the active Claude account. You can switch accounts from scripts without the Settings UI.
