### PR TITLE
feat(browser): keep annotations across page navigation

### DIFF
--- a/config/scripts/browser-annotation-page-identity-fidelity.test.mjs
+++ b/config/scripts/browser-annotation-page-identity-fidelity.test.mjs
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { clampGrabPayload } from '../../src/main/browser/browser-grab-payload'
+import { browserAnnotationDocumentKey } from '../../src/renderer/src/components/browser-pane/browser-annotation-page-identity'
+
+function annotation(url) {
+  return {
+    id: 'sample',
+    browserPageId: 'page-1',
+    comment: 'comment',
+    intent: 'change',
+    priority: 'important',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    payload: {
+      page: {
+        sanitizedUrl: url,
+        title: 'Page',
+        viewportWidth: 1280,
+        viewportHeight: 720,
+        scrollX: 0,
+        scrollY: 0,
+        devicePixelRatio: 1,
+        capturedAt: '2026-01-01T00:00:00.000Z'
+      },
+      target: {
+        tagName: 'button',
+        selector: '#button',
+        textSnippet: 'sample',
+        htmlSnippet: '<button />',
+        attributes: {},
+        accessibility: {
+          role: 'button',
+          accessibleName: 'sample',
+          ariaLabel: null,
+          ariaLabelledBy: null
+        },
+        rectViewport: { x: 1, y: 2, width: 3, height: 4 },
+        rectPage: { x: 5, y: 6, width: 7, height: 8 },
+        computedStyles: {
+          display: 'block',
+          position: 'static',
+          width: '3px',
+          height: '4px',
+          margin: '0',
+          padding: '0',
+          color: 'black',
+          backgroundColor: 'white',
+          border: '0',
+          borderRadius: '0',
+          fontFamily: 'sans-serif',
+          fontSize: '16px',
+          fontWeight: '400',
+          lineHeight: 'normal',
+          textAlign: 'left',
+          zIndex: 'auto'
+        }
+      },
+      nearbyText: [],
+      ancestorPath: [],
+      screenshot: null
+    }
+  }
+}
+
+function clampedDocumentKey(rawUrl) {
+  const sample = annotation('https://example.com/base')
+  return (
+    clampGrabPayload({
+      ...sample.payload,
+      page: { ...sample.payload.page, sanitizedUrl: rawUrl }
+    })?.page.sanitizedUrl || null
+  )
+}
+
+describe('browser annotation document identity fidelity', () => {
+  it('matches the main clamp across supported and rejected URLs', () => {
+    const cases = [
+      'https://example.com/docs?token=redacted#section',
+      'https://example.com/docs#section',
+      'file:///C:/Repos/orca/README.md?token=redacted#section',
+      'about:blank',
+      'data:text/html,',
+      'blob:https://example.com/123',
+      'not a url'
+    ]
+
+    for (const rawUrl of cases) {
+      expect(browserAnnotationDocumentKey(annotation(rawUrl))).toBe(clampedDocumentKey(rawUrl))
+    }
+  })
+})

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -108,10 +108,17 @@ import {
   type BrowserGrabScreenshot,
   type BrowserPageAnnotation
 } from '../../../../shared/browser-grab-types'
-import { BROWSER_ANNOTATION_VIEWPORT_MESSAGE_PREFIX } from '../../../../shared/browser-annotation-viewport-bridge'
+import {
+  BROWSER_ANNOTATION_MARKERS_MESSAGE_PREFIX,
+  BROWSER_ANNOTATION_VIEWPORT_MESSAGE_PREFIX
+} from '../../../../shared/browser-annotation-viewport-bridge'
 import { useGrabMode } from './useGrabMode'
 import { formatGrabPayloadAsText } from './GrabConfirmationSheet'
 import { formatBrowserAnnotationsAsMarkdown } from './browser-annotation-output'
+import {
+  isBrowserAnnotationOnDocument,
+  selectBrowserAnnotationMarkers
+} from './browser-annotation-page-identity'
 import { isEditableKeyboardTarget } from './browser-keyboard'
 import { getBrowserPagesForWorkspace } from './browser-pane-page-selection'
 import BrowserAddressBar from './BrowserAddressBar'
@@ -2901,8 +2908,6 @@ function BrowserPagePane({
   const deleteBrowserPageAnnotation = useAppStore((s) => s.deleteBrowserPageAnnotation)
   const clearBrowserPageAnnotations = useAppStore((s) => s.clearBrowserPageAnnotations)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
-  const clearBrowserPageAnnotationsRef = useRef(clearBrowserPageAnnotations)
-  clearBrowserPageAnnotationsRef.current = clearBrowserPageAnnotations
   const createBrowserTab = useAppStore((s) => s.createBrowserTab)
   const consumeAddressBarFocusRequest = useAppStore((s) => s.consumeAddressBarFocusRequest)
   const browserSessionProfiles = useAppStore((s) => s.browserSessionProfiles)
@@ -3648,13 +3653,10 @@ function BrowserPagePane({
     const pendingAnnotationPayload = pendingAnnotationPayloadRef.current
     // Why: existing annotation badges are rendered in the guest process for
     // compositor-smooth scroll; only the pending dialog needs viewport messages.
-    const markers = browserAnnotationsRef.current.map((annotation, index) => ({
-      id: annotation.id,
-      index,
-      isFixed: annotation.payload.target.isFixed === true,
-      rectPage: annotation.payload.target.rectPage,
-      rectViewport: annotation.payload.target.rectViewport
-    }))
+    const markers = selectBrowserAnnotationMarkers(
+      browserAnnotationsRef.current,
+      browserTabUrlRef.current
+    )
     const enabled = isActiveRef.current && (pendingAnnotationPayload !== null || markers.length > 0)
     void window.api.browser
       .setAnnotationViewportBridge({
@@ -3781,9 +3783,6 @@ function BrowserPagePane({
     }
 
     const handleDidStartLoading = (): void => {
-      // Why: reloads replace the document without changing URL, invalidating
-      // captured element rects and DOM context just like navigation does.
-      clearBrowserPageAnnotationsRef.current(browserTab.id)
       setPendingAnnotationPayload(null)
       setBrowserOverlayViewport({ scrollX: 0, scrollY: 0, version: 0 })
       if (!trackNextLoadingEventRef.current) {
@@ -3844,6 +3843,7 @@ function BrowserPagePane({
       }
       trackNextLoadingEventRef.current = false
       activeLoadFailureRef.current = null
+      browserTabUrlRef.current = browserModelUrl
       lastKnownWebviewUrlRef.current =
         normalizeBrowserNavigationUrl(browserModelUrl) ?? browserModelUrl
       rememberLiveBrowserUrl(browserTab.id, browserModelUrl)
@@ -3866,6 +3866,7 @@ function BrowserPagePane({
         canGoForward: webview.canGoForward(),
         loadError: null
       })
+      syncBrowserAnnotationViewportBridge()
     }
 
     const handleDidNavigate = (event: { url?: string; isMainFrame?: boolean }): void => {
@@ -3877,6 +3878,7 @@ function BrowserPagePane({
         return
       }
       const browserModelUrl = redactKagiSessionToken(currentUrl)
+      browserTabUrlRef.current = browserModelUrl
       lastKnownWebviewUrlRef.current =
         normalizeBrowserNavigationUrl(browserModelUrl) ?? browserModelUrl
       rememberLiveBrowserUrl(browserTab.id, browserModelUrl)
@@ -3890,6 +3892,7 @@ function BrowserPagePane({
         canGoBack: webview.canGoBack(),
         canGoForward: webview.canGoForward()
       })
+      syncBrowserAnnotationViewportBridge()
     }
 
     const handleTitleUpdate = (event: { title?: string }): void => {
@@ -3943,24 +3946,31 @@ function BrowserPagePane({
     const handleAnnotationViewportMessage = (event: { message?: string }): void => {
       const message = typeof event.message === 'string' ? event.message : ''
       const prefix = `${BROWSER_ANNOTATION_VIEWPORT_MESSAGE_PREFIX}${annotationViewportBridgeTokenRef.current}:`
-      if (!message.startsWith(prefix)) {
-        return
-      }
+      const markerPrefix = `${BROWSER_ANNOTATION_MARKERS_MESSAGE_PREFIX}${annotationViewportBridgeTokenRef.current}:`
       try {
-        const next = JSON.parse(message.slice(prefix.length)) as {
-          scrollX?: unknown
-          scrollY?: unknown
-        }
-        const scrollX =
-          typeof next.scrollX === 'number' && Number.isFinite(next.scrollX) ? next.scrollX : 0
-        const scrollY =
-          typeof next.scrollY === 'number' && Number.isFinite(next.scrollY) ? next.scrollY : 0
-        setBrowserOverlayViewport((current) => {
-          if (current.scrollX === scrollX && current.scrollY === scrollY) {
-            return current.version === 0 ? { ...current, version: 1 } : current
+        if (message.startsWith(prefix)) {
+          const next = JSON.parse(message.slice(prefix.length)) as {
+            scrollX?: unknown
+            scrollY?: unknown
           }
-          return { scrollX, scrollY, version: current.version + 1 }
-        })
+          const scrollX =
+            typeof next.scrollX === 'number' && Number.isFinite(next.scrollX) ? next.scrollX : 0
+          const scrollY =
+            typeof next.scrollY === 'number' && Number.isFinite(next.scrollY) ? next.scrollY : 0
+          setBrowserOverlayViewport((current) => {
+            if (current.scrollX === scrollX && current.scrollY === scrollY) {
+              return current.version === 0 ? { ...current, version: 1 } : current
+            }
+            return { scrollX, scrollY, version: current.version + 1 }
+          })
+          return
+        }
+        if (message.startsWith(markerPrefix)) {
+          const next = JSON.parse(message.slice(markerPrefix.length))
+          if (Array.isArray(next) && next.every((markerId) => typeof markerId === 'string')) {
+            webview.setAttribute('data-orca-browser-annotation-marker-ids', JSON.stringify(next))
+          }
+        }
       } catch {
         // Ignore unrelated or malformed guest console output.
       }
@@ -3970,6 +3980,7 @@ function BrowserPagePane({
     webview.addEventListener('focus', dismissAddressBarSuggestions)
     webview.addEventListener('did-start-loading', handleDidStartLoading)
     webview.addEventListener('did-stop-loading', handleDidStopLoading)
+    webview.setAttribute('data-orca-browser-annotation-marker-ids', '[]')
     // Why: separate handler registered only on 'did-navigate' (full page loads),
     // NOT on 'did-navigate-in-page'. The shared handleDidNavigate is registered
     // on both events, so adding find-close logic there would also close on SPA
@@ -4070,8 +4081,9 @@ function BrowserPagePane({
   useEffect(() => {
     syncBrowserAnnotationViewportBridge()
   }, [
-    browserAnnotations.length,
+    browserAnnotations,
     browserTab.id,
+    browserTab.url,
     isActive,
     pendingAnnotationPayload,
     syncBrowserAnnotationViewportBridge
@@ -5717,42 +5729,55 @@ function BrowserPagePane({
                     </Tooltip>
                   </div>
                   <div className="scrollbar-sleek min-h-0 flex-1 overflow-auto p-1.5">
-                    {browserAnnotations.map((annotation, index) => (
-                      <div
-                        key={annotation.id}
-                        className="group flex gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent focus-within:bg-accent"
-                      >
-                        <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
-                          {index + 1}
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <div className="truncate font-medium text-foreground">
-                            {annotation.payload.target.accessibility.accessibleName ||
-                              annotation.payload.target.textSnippet ||
-                              annotation.payload.target.tagName}
+                    {browserAnnotations.map((annotation, index) =>
+                      (() => {
+                        const onCurrentDocument = isBrowserAnnotationOnDocument(
+                          annotation,
+                          browserTab.url
+                        )
+                        return (
+                          <div
+                            key={annotation.id}
+                            className="group flex gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent focus-within:bg-accent"
+                          >
+                            <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
+                              {index + 1}
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate font-medium text-foreground">
+                                {annotation.payload.target.accessibility.accessibleName ||
+                                  annotation.payload.target.textSnippet ||
+                                  annotation.payload.target.tagName}
+                              </div>
+                              <div className="mt-0.5 line-clamp-2 text-muted-foreground">
+                                {annotation.comment}
+                              </div>
+                              <div className="mt-1 text-[11px] text-muted-foreground">
+                                <span>{annotation.intent}</span>
+                                {!onCurrentDocument ? (
+                                  <span className="ml-2 truncate">
+                                    {annotation.payload.page.sanitizedUrl}
+                                  </span>
+                                ) : null}
+                              </div>
+                            </div>
+                            <Button
+                              size="icon-xs"
+                              variant="ghost"
+                              className="can-hover:opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
+                              onClick={() => handleDeleteBrowserAnnotation(annotation.id)}
+                              aria-label={translate(
+                                'auto.components.browser.pane.BrowserPane.f2d0c22d67',
+                                'Delete annotation {{value0}}',
+                                { value0: index + 1 }
+                              )}
+                            >
+                              <Trash2 className="size-3" />
+                            </Button>
                           </div>
-                          <div className="mt-0.5 line-clamp-2 text-muted-foreground">
-                            {annotation.comment}
-                          </div>
-                          <div className="mt-1 text-[11px] text-muted-foreground">
-                            <span>{annotation.intent}</span>
-                          </div>
-                        </div>
-                        <Button
-                          size="icon-xs"
-                          variant="ghost"
-                          className="can-hover:opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
-                          onClick={() => handleDeleteBrowserAnnotation(annotation.id)}
-                          aria-label={translate(
-                            'auto.components.browser.pane.BrowserPane.f2d0c22d67',
-                            'Delete annotation {{value0}}',
-                            { value0: index + 1 }
-                          )}
-                        >
-                          <Trash2 className="size-3" />
-                        </Button>
-                      </div>
-                    ))}
+                        )
+                      })()
+                    )}
                   </div>
                 </div>
               ) : null}

--- a/src/renderer/src/components/browser-pane/browser-annotation-output.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-annotation-output.test.ts
@@ -78,6 +78,41 @@ function makeAnnotation(overrides?: Partial<BrowserPageAnnotation>): BrowserPage
 }
 
 describe('formatBrowserAnnotationsAsMarkdown', () => {
+  it('groups annotations by captured document', () => {
+    const first = makeAnnotation()
+    const second = makeAnnotation({
+      id: 'annotation-2',
+      payload: {
+        ...first.payload,
+        page: { ...first.payload.page, sanitizedUrl: 'https://example.com/settings' }
+      }
+    })
+    const markdown = formatBrowserAnnotationsAsMarkdown([first, second])
+
+    expect(markdown).toContain('## Design Feedback: /pricing')
+    expect(markdown).toContain('## Design Feedback: /settings')
+    expect(markdown).toContain('**URL:** https://example.com/pricing')
+    expect(markdown).toContain('**URL:** https://example.com/settings')
+    expect(markdown.match(/### 1\./g)).toHaveLength(2)
+  })
+
+  it('retains empty captured URLs as a current-page output group', () => {
+    const first = makeAnnotation()
+    const markdown = formatBrowserAnnotationsAsMarkdown([
+      makeAnnotation({
+        id: 'annotation-empty',
+        comment: 'Keep this unsupported-page feedback in the output.',
+        payload: {
+          ...first.payload,
+          page: { ...first.payload.page, sanitizedUrl: '' }
+        }
+      })
+    ])
+
+    expect(markdown).toContain('## Design Feedback: current page')
+    expect(markdown).toContain('Keep this unsupported-page feedback in the output.')
+  })
+
   it('includes agent-useful selectors, source, react tree, styles, and feedback', () => {
     const markdown = formatBrowserAnnotationsAsMarkdown([makeAnnotation()])
 

--- a/src/renderer/src/components/browser-pane/browser-annotation-output.ts
+++ b/src/renderer/src/components/browser-pane/browser-annotation-output.ts
@@ -3,6 +3,7 @@ import type {
   BrowserGrabPayload,
   BrowserPageAnnotation
 } from '../../../../shared/browser-grab-types'
+import { groupBrowserAnnotationsByDocument } from './browser-annotation-page-identity'
 
 function formatPageHeading(payload: BrowserGrabPayload): string {
   try {
@@ -152,12 +153,12 @@ function inlineCode(content: string): string {
   return `${marker}${padding}${content}${padding}${marker}`
 }
 
-export function formatBrowserAnnotationsAsMarkdown(annotations: BrowserPageAnnotation[]): string {
-  if (annotations.length === 0) {
+function formatBrowserAnnotationGroup(annotations: BrowserPageAnnotation[]): string {
+  const firstAnnotation = annotations[0]
+  if (!firstAnnotation) {
     return ''
   }
 
-  const firstAnnotation = annotations[0]
   const first = firstAnnotation.payload
   const lines: string[] = [
     `## Design Feedback: ${formatPageHeading(first)}`,
@@ -225,4 +226,12 @@ export function formatBrowserAnnotationsAsMarkdown(annotations: BrowserPageAnnot
   })
 
   return lines.join('\n').trimEnd()
+}
+
+export function formatBrowserAnnotationsAsMarkdown(annotations: BrowserPageAnnotation[]): string {
+  const groups = groupBrowserAnnotationsByDocument(annotations)
+  if (groups.length === 0) {
+    return ''
+  }
+  return groups.map(formatBrowserAnnotationGroup).join('\n\n')
 }

--- a/src/renderer/src/components/browser-pane/browser-annotation-page-identity.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-annotation-page-identity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import type { BrowserPageAnnotation } from '../../../../shared/browser-grab-types'
+import {
+  browserAnnotationDocumentKey,
+  groupBrowserAnnotationsByDocument,
+  isBrowserAnnotationOnDocument,
+  selectBrowserAnnotationMarkers
+} from './browser-annotation-page-identity'
+
+function annotation(id: string, url: string): BrowserPageAnnotation {
+  return {
+    id,
+    browserPageId: 'page-1',
+    comment: 'comment',
+    intent: 'change',
+    priority: 'important',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    payload: {
+      page: {
+        sanitizedUrl: url,
+        title: 'Page',
+        viewportWidth: 1280,
+        viewportHeight: 720,
+        scrollX: 0,
+        scrollY: 0,
+        devicePixelRatio: 1,
+        capturedAt: '2026-01-01T00:00:00.000Z'
+      },
+      target: {
+        tagName: 'button',
+        selector: '#button',
+        textSnippet: id,
+        htmlSnippet: '<button />',
+        attributes: {},
+        accessibility: {
+          role: 'button',
+          accessibleName: id,
+          ariaLabel: null,
+          ariaLabelledBy: null
+        },
+        rectViewport: { x: 1, y: 2, width: 3, height: 4 },
+        rectPage: { x: 5, y: 6, width: 7, height: 8 },
+        computedStyles: {
+          display: 'block',
+          position: 'static',
+          width: '3px',
+          height: '4px',
+          margin: '0',
+          padding: '0',
+          color: 'black',
+          backgroundColor: 'white',
+          border: '0',
+          borderRadius: '0',
+          fontFamily: 'sans-serif',
+          fontSize: '16px',
+          fontWeight: '400',
+          lineHeight: 'normal',
+          textAlign: 'left',
+          zIndex: 'auto'
+        }
+      },
+      nearbyText: [],
+      ancestorPath: [],
+      screenshot: null
+    }
+  }
+}
+
+describe('browser annotation document identity', () => {
+  it('matches query and fragment changes but filters a different page', () => {
+    const current = annotation('current', 'https://example.com/docs?token=redacted#section')
+    expect(isBrowserAnnotationOnDocument(current, 'https://example.com/docs?other=1#new')).toBe(
+      true
+    )
+    expect(isBrowserAnnotationOnDocument(current, 'https://example.com/settings')).toBe(false)
+  })
+
+  it('preserves full-queue indexes and restores markers when navigating back', () => {
+    const annotations = [
+      annotation('a', 'https://example.com/a'),
+      annotation('b', 'https://example.com/b'),
+      annotation('a-2', 'https://example.com/a')
+    ]
+    expect(selectBrowserAnnotationMarkers(annotations, 'https://example.com/b')).toEqual([
+      expect.objectContaining({ id: 'b', index: 1 })
+    ])
+    expect(selectBrowserAnnotationMarkers(annotations, 'https://example.com/a')).toEqual([
+      expect.objectContaining({ id: 'a', index: 0 }),
+      expect.objectContaining({ id: 'a-2', index: 2 })
+    ])
+  })
+
+  it('fails closed for invalid live URLs and groups empty captured keys in first appearance order', () => {
+    const empty = annotation('empty', '')
+    const first = annotation('first', 'https://example.com/a')
+    const second = annotation('second', 'https://example.com/b')
+    expect(selectBrowserAnnotationMarkers([first], 'javascript:alert(1)')).toEqual([])
+    expect(
+      groupBrowserAnnotationsByDocument([
+        empty,
+        first,
+        second,
+        annotation('empty-2', ''),
+        annotation('third', 'https://example.com/a')
+      ]).map((group) => group.map(({ id }) => id))
+    ).toEqual([['empty', 'empty-2'], ['first', 'third'], ['second']])
+  })
+
+  it('matches about:blank and rejects empty captured keys', () => {
+    expect(browserAnnotationDocumentKey(annotation('blank', 'about:blank'))).toBe('about:blank')
+    expect(browserAnnotationDocumentKey(annotation('empty', ''))).toBeNull()
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-annotation-page-identity.ts
+++ b/src/renderer/src/components/browser-pane/browser-annotation-page-identity.ts
@@ -1,0 +1,79 @@
+import type { BrowserPageAnnotation } from '../../../../shared/browser-grab-types'
+
+const SUPPORTED_PROTOCOLS = new Set(['http:', 'https:', 'file:'])
+
+export type BrowserAnnotationMarker = {
+  id: string
+  index: number
+  isFixed: boolean
+  rectPage: BrowserPageAnnotation['payload']['target']['rectPage']
+  rectViewport: BrowserPageAnnotation['payload']['target']['rectViewport']
+}
+
+function documentKey(rawUrl: string): string | null {
+  if (!rawUrl) {
+    return null
+  }
+  if (rawUrl === 'about:blank') {
+    return 'about:blank'
+  }
+  try {
+    const url = new URL(rawUrl)
+    if (!SUPPORTED_PROTOCOLS.has(url.protocol)) {
+      return null
+    }
+    url.search = ''
+    url.hash = ''
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+export function browserAnnotationDocumentKey(annotation: BrowserPageAnnotation): string | null {
+  return documentKey(annotation.payload.page.sanitizedUrl)
+}
+
+export function isBrowserAnnotationOnDocument(
+  annotation: BrowserPageAnnotation,
+  activeUrl: string
+): boolean {
+  const capturedKey = browserAnnotationDocumentKey(annotation)
+  const activeKey = documentKey(activeUrl)
+  return capturedKey !== null && activeKey !== null && capturedKey === activeKey
+}
+
+export function selectBrowserAnnotationMarkers(
+  annotations: BrowserPageAnnotation[],
+  activeUrl: string
+): BrowserAnnotationMarker[] {
+  return annotations.flatMap((annotation, index) =>
+    isBrowserAnnotationOnDocument(annotation, activeUrl)
+      ? [
+          {
+            id: annotation.id,
+            index,
+            isFixed: annotation.payload.target.isFixed === true,
+            rectPage: annotation.payload.target.rectPage,
+            rectViewport: annotation.payload.target.rectViewport
+          }
+        ]
+      : []
+  )
+}
+
+export function groupBrowserAnnotationsByDocument(
+  annotations: BrowserPageAnnotation[]
+): BrowserPageAnnotation[][] {
+  const groups = new Map<string, BrowserPageAnnotation[]>()
+  for (const annotation of annotations) {
+    const key = browserAnnotationDocumentKey(annotation) ?? ''
+    const group = groups.get(key)
+    if (group) {
+      group.push(annotation)
+    } else {
+      groups.set(key, [annotation])
+    }
+  }
+  return [...groups.values()]
+}

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -164,7 +164,7 @@ describe('createBrowserSlice annotations', () => {
     expect(store.getState().recordFeatureInteraction).toHaveBeenCalledWith('browser-tab-created')
   })
 
-  it('clears page annotations when the browser page URL changes', () => {
+  it('keeps page annotations across navigation and loading', () => {
     const store = createTestStore()
     const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
     const pageId = tab.activePageId
@@ -177,7 +177,66 @@ describe('createBrowserSlice annotations', () => {
 
     store.getState().setBrowserPageUrl(pageId, 'https://example.com/next')
 
+    expect(store.getState().browserAnnotationsByPageId[pageId]).toHaveLength(1)
+    expect(store.getState().browserAnnotationsByPageId[pageId]?.[0]?.payload).toEqual(
+      expect.objectContaining({
+        page: expect.objectContaining({ sanitizedUrl: 'https://example.com' })
+      })
+    )
+  })
+
+  it('keeps explicit annotation lifecycle boundaries', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
+    const pageId = tab.activePageId
+    if (!pageId) {
+      throw new Error('Expected a new browser page')
+    }
+
+    const seeded = makeAnnotation(pageId, 'annotation-0')
+    store.getState().addBrowserPageAnnotation({
+      ...seeded,
+      comment: 'a'.repeat(GRAB_BUDGET.annotationCommentMaxLength + 10),
+      payload: {
+        ...seeded.payload,
+        page: {
+          ...seeded.payload.page,
+          sanitizedUrl: 'https://example.com/path?token=secret#fragment'
+        },
+        screenshot: {
+          mimeType: 'image/png',
+          dataUrl: 'data:image/png;base64,abc',
+          width: 1,
+          height: 1
+        }
+      } as unknown as BrowserPageAnnotation['payload']
+    })
+
+    let annotations = store.getState().browserAnnotationsByPageId[pageId] ?? []
+    expect(annotations[0]?.comment).toHaveLength(GRAB_BUDGET.annotationCommentMaxLength)
+    expect(annotations[0]?.payload.screenshot).toBeNull()
+
+    store.getState().addBrowserPageAnnotation(makeAnnotation(pageId, 'delete-me'))
+    store.getState().deleteBrowserPageAnnotation(pageId, 'delete-me')
+    expect(store.getState().browserAnnotationsByPageId[pageId]?.map(({ id }) => id)).toEqual([
+      'annotation-0'
+    ])
+
+    store.getState().setBrowserPageUrl(pageId, 'https://kagi.com/search?q=orca&token=secret')
+    expect(
+      store.getState().browserPagesByWorkspace[tab.id]?.find((page) => page.id === pageId)?.url
+    ).toBe('https://kagi.com/search?q=orca')
+
+    store.getState().clearBrowserPageAnnotations(pageId)
     expect(store.getState().browserAnnotationsByPageId[pageId]).toBeUndefined()
+
+    for (let index = 0; index < GRAB_BUDGET.annotationsMaxPerPage + 3; index++) {
+      store.getState().addBrowserPageAnnotation(makeAnnotation(pageId, `annotation-${index}`))
+    }
+
+    annotations = store.getState().browserAnnotationsByPageId[pageId] ?? []
+    expect(annotations).toHaveLength(GRAB_BUDGET.annotationsMaxPerPage)
+    expect(annotations[0]?.id).toBe('annotation-3')
   })
 
   it('creates inactive browser unified tabs without stealing the visible tab', () => {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -1381,9 +1381,6 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       if (!workspace) {
         return s
       }
-      // Why: annotations point at DOM coordinates from one loaded document.
-      // A real URL change invalidates those markers and copied context.
-      const shouldClearAnnotations = normalizeUrl(page.url) !== nextUrl
       const nextPages = (s.browserPagesByWorkspace[workspace.id] ?? []).map((entry) =>
         entry.id === pageId
           ? {
@@ -1396,12 +1393,6 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           : entry
       )
       const nextWorkspace = mirrorWorkspaceFromActivePage(workspace, nextPages)
-      const nextBrowserAnnotationsByPageId = shouldClearAnnotations
-        ? { ...s.browserAnnotationsByPageId }
-        : s.browserAnnotationsByPageId
-      if (shouldClearAnnotations) {
-        delete nextBrowserAnnotationsByPageId[pageId]
-      }
       return {
         browserPagesByWorkspace: {
           ...s.browserPagesByWorkspace,
@@ -1412,10 +1403,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
           [workspace.worktreeId]: (s.browserTabsByWorktree[workspace.worktreeId] ?? []).map((tab) =>
             tab.id === workspace.id ? nextWorkspace : tab
           )
-        },
-        ...(shouldClearAnnotations
-          ? { browserAnnotationsByPageId: nextBrowserAnnotationsByPageId }
-          : {})
+        }
       }
     })
   },

--- a/src/shared/browser-annotation-viewport-bridge.test.ts
+++ b/src/shared/browser-annotation-viewport-bridge.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  BROWSER_ANNOTATION_MARKERS_MESSAGE_PREFIX,
+  buildBrowserAnnotationViewportBridgeScript
+} from './browser-annotation-viewport-bridge'
+
+describe('browser annotation viewport bridge disable path', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+    delete (window as typeof window & { __orcaBrowserAnnotationViewportBridge?: unknown })
+      .__orcaBrowserAnnotationViewportBridge
+  })
+
+  it('clears emitted marker ids and removes the existing overlay when disabled', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    ;(
+      window as typeof window & {
+        __orcaBrowserAnnotationViewportBridge?: {
+          host: HTMLDivElement
+          markerElements: Map<string, HTMLSpanElement>
+          markers: unknown[]
+          raf: number
+          requestUpdate: () => void
+          shadowRoot: null
+        }
+      }
+    ).__orcaBrowserAnnotationViewportBridge = {
+      host,
+      markerElements: new Map(),
+      markers: [],
+      raf: 0,
+      requestUpdate: () => {},
+      shadowRoot: null
+    }
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    const script = buildBrowserAnnotationViewportBridgeScript({
+      enabled: false,
+      emitViewport: false,
+      markers: [],
+      token: 'abcdefghijklmnop'
+    })
+
+    expect(() => window.eval(script)).not.toThrow()
+    expect(debugSpy).toHaveBeenCalledWith(
+      `${BROWSER_ANNOTATION_MARKERS_MESSAGE_PREFIX}abcdefghijklmnop:[]`
+    )
+    expect(document.body.contains(host)).toBe(false)
+    expect(
+      (window as typeof window & { __orcaBrowserAnnotationViewportBridge?: unknown })
+        .__orcaBrowserAnnotationViewportBridge
+    ).toBeUndefined()
+  })
+})

--- a/src/shared/browser-annotation-viewport-bridge.ts
+++ b/src/shared/browser-annotation-viewport-bridge.ts
@@ -25,6 +25,7 @@ export type BrowserAnnotationViewportBridgeOptions = {
 
 export const BROWSER_ANNOTATION_VIEWPORT_BRIDGE_WORLD_ID = 1207
 export const BROWSER_ANNOTATION_VIEWPORT_MESSAGE_PREFIX = '__orca_annotation_viewport__:'
+export const BROWSER_ANNOTATION_MARKERS_MESSAGE_PREFIX = '__orca_annotation_markers__:'
 
 export function isValidBrowserAnnotationViewportBridgeToken(value: unknown): value is string {
   return typeof value === 'string' && /^[a-zA-Z0-9_-]{16,80}$/.test(value)
@@ -91,6 +92,7 @@ export function buildBrowserAnnotationViewportBridgeScript({
   const markers = ${JSON.stringify(markers)};
   const token = ${JSON.stringify(token)};
   const prefix = ${JSON.stringify(BROWSER_ANNOTATION_VIEWPORT_MESSAGE_PREFIX)};
+  const markerPrefix = ${JSON.stringify(BROWSER_ANNOTATION_MARKERS_MESSAGE_PREFIX)};
   const stateKey = '__orcaBrowserAnnotationViewportBridge';
   const hostAttribute = 'data-orca-browser-annotation-overlay';
   const markerSize = 24;
@@ -114,8 +116,15 @@ export function buildBrowserAnnotationViewportBridgeScript({
     removeOverlay(state);
   };
 
+  const emitMarkerIds = (markerIds) => {
+    try {
+      console.debug(markerPrefix + token + ':' + JSON.stringify(markerIds));
+    } catch (e) {}
+  };
+
   const existing = globalThis[stateKey];
   if (!enabled) {
+    emitMarkerIds([]);
     cleanup(existing);
     delete globalThis[stateKey];
     return true;
@@ -160,6 +169,7 @@ export function buildBrowserAnnotationViewportBridgeScript({
   const updateMarkers = (state, nextMarkers) => {
     state.markers = Array.isArray(nextMarkers) ? nextMarkers : [];
     if (state.markers.length === 0) {
+      emitMarkerIds([]);
       removeOverlay(state);
       state.host = null;
       state.shadowRoot = null;
@@ -186,6 +196,7 @@ export function buildBrowserAnnotationViewportBridgeScript({
         state.markerElements.delete(id);
       }
     });
+    emitMarkerIds(state.markers.map((marker) => marker.id));
   };
 
   const positionMarkers = (state) => {

--- a/tests/e2e/browser-tab.spec.ts
+++ b/tests/e2e/browser-tab.spec.ts
@@ -25,6 +25,14 @@ type CreatedBrowserTab = {
   pageId: string | null
 }
 
+type BrowserAnnotationSeed = {
+  id: string
+  comment: string
+  url: string
+  title: string
+  label: string
+}
+
 async function createBrowserTab(
   page: Parameters<typeof getActiveWorktreeId>[0],
   worktreeId: string,
@@ -153,6 +161,47 @@ async function readBrowserInputValue(
   }, browserTabId)
 }
 
+async function readBrowserAnnotationOverlayCount(
+  page: Parameters<typeof getActiveWorktreeId>[0],
+  browserTabId: string
+): Promise<number> {
+  return page.evaluate(async (targetBrowserTabId) => {
+    const slot = [...document.querySelectorAll('[data-browser-overlay-tab-id]')].find(
+      (candidate) => candidate.getAttribute('data-browser-overlay-tab-id') === targetBrowserTabId
+    )
+    const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+    return webview
+      ? await webview.executeJavaScript(
+          'document.querySelectorAll("[data-orca-browser-annotation-overlay]").length'
+        )
+      : -1
+  }, browserTabId)
+}
+
+async function readBrowserAnnotationMarkerIds(
+  page: Parameters<typeof getActiveWorktreeId>[0],
+  browserTabId: string
+): Promise<string[] | null> {
+  return page.evaluate((targetBrowserTabId) => {
+    const slot = [...document.querySelectorAll('[data-browser-overlay-tab-id]')].find(
+      (candidate) => candidate.getAttribute('data-browser-overlay-tab-id') === targetBrowserTabId
+    )
+    const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+    const rawMarkerIds = webview?.getAttribute('data-orca-browser-annotation-marker-ids')
+    if (!rawMarkerIds) {
+      return null
+    }
+    try {
+      const markerIds = JSON.parse(rawMarkerIds)
+      return Array.isArray(markerIds) && markerIds.every((markerId) => typeof markerId === 'string')
+        ? markerIds
+        : null
+    } catch {
+      return null
+    }
+  }, browserTabId)
+}
+
 async function writeBrowserInputValue(
   page: Parameters<typeof getActiveWorktreeId>[0],
   browserTabId: string,
@@ -181,6 +230,81 @@ async function writeBrowserInputValue(
   await expect
     .poll(async () => readBrowserInputValue(page, browserTabId), { timeout: 5_000 })
     .toBe(value)
+}
+
+async function addBrowserAnnotations(
+  page: Parameters<typeof getActiveWorktreeId>[0],
+  pageId: string,
+  annotations: BrowserAnnotationSeed[]
+): Promise<void> {
+  await page.evaluate(
+    ({ targetPageId, targetAnnotations }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Browser store is unavailable')
+      }
+
+      for (const annotation of targetAnnotations) {
+        store.getState().addBrowserPageAnnotation({
+          id: annotation.id,
+          browserPageId: targetPageId,
+          comment: annotation.comment,
+          intent: 'change',
+          priority: 'important',
+          createdAt: new Date().toISOString(),
+          payload: {
+            page: {
+              sanitizedUrl: annotation.url,
+              title: annotation.title,
+              viewportWidth: 1280,
+              viewportHeight: 720,
+              scrollX: 0,
+              scrollY: 0,
+              devicePixelRatio: 1,
+              capturedAt: new Date().toISOString()
+            },
+            target: {
+              tagName: 'button',
+              selector: '#q',
+              textSnippet: annotation.label,
+              htmlSnippet: '<input id="q">',
+              attributes: {},
+              accessibility: {
+                role: 'textbox',
+                accessibleName: `${annotation.label} marker`,
+                ariaLabel: null,
+                ariaLabelledBy: null
+              },
+              rectViewport: { x: 10, y: 10, width: 100, height: 30 },
+              rectPage: { x: 10, y: 10, width: 100, height: 30 },
+              computedStyles: {
+                display: 'block',
+                position: 'static',
+                width: '100px',
+                height: '30px',
+                margin: '0',
+                padding: '0',
+                color: 'black',
+                backgroundColor: 'white',
+                border: '0',
+                borderRadius: '0',
+                fontFamily: 'sans-serif',
+                fontSize: '16px',
+                fontWeight: '400',
+                lineHeight: 'normal',
+                textAlign: 'left',
+                zIndex: 'auto'
+              }
+            },
+            nearbyText: [],
+            ancestorPath: [],
+            screenshot: null
+          }
+        })
+      }
+    },
+    { targetPageId: pageId, targetAnnotations: annotations }
+  )
 }
 
 test.describe('Browser Tab', () => {
@@ -298,6 +422,129 @@ test.describe('Browser Tab', () => {
         .toBe('second typed value')
     } finally {
       await formServer.close()
+    }
+  })
+
+  test('browser annotations survive navigation without stale guest markers', async ({
+    orcaPage
+  }, testInfo) => {
+    const server = await startBrowserFormServer()
+    try {
+      const worktreeId = (await getActiveWorktreeId(orcaPage))!
+      const pageA = server.url('Page A')
+      const pageB = server.url('Page B')
+      const browserTab = await createBrowserTab(orcaPage, worktreeId, pageA, 'Annotations')
+      expect(browserTab?.id).toBeTruthy()
+      expect(browserTab?.pageId).toBeTruthy()
+      const pageAAnnotations = Array.from({ length: 20 }, (_, index) => ({
+        id: `page-a-annotation-${index}`,
+        comment: `Page A feedback ${index}`,
+        url: pageA,
+        title: 'Page A',
+        label: `Page A ${index}`
+      }))
+      const pageBAnnotationId = 'page-b-annotation'
+
+      await addBrowserAnnotations(orcaPage, browserTab!.pageId!, pageAAnnotations)
+      await expect
+        .poll(
+          async () =>
+            orcaPage.evaluate(
+              (targetPageId) =>
+                window.__store?.getState().browserAnnotationsByPageId[targetPageId]?.length ?? -1,
+              browserTab!.pageId
+            ),
+          { timeout: 5_000 }
+        )
+        .toBe(20)
+      await expect(orcaPage.locator('body')).toContainText('Page A feedback 19')
+      await expect
+        .poll(async () => readBrowserAnnotationMarkerIds(orcaPage, browserTab!.id))
+        .toEqual(pageAAnnotations.map(({ id }) => id))
+      await expect
+        .poll(async () => readBrowserAnnotationOverlayCount(orcaPage, browserTab!.id))
+        .toBe(1)
+
+      await orcaPage.evaluate(
+        async ({ targetBrowserTabId, targetUrl }) => {
+          const slot = [...document.querySelectorAll('[data-browser-overlay-tab-id]')].find(
+            (candidate) =>
+              candidate.getAttribute('data-browser-overlay-tab-id') === targetBrowserTabId
+          )
+          const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+          if (!webview) {
+            throw new Error('Missing browser webview')
+          }
+          await webview.executeJavaScript(`location.href = ${JSON.stringify(targetUrl)}`)
+        },
+        { targetBrowserTabId: browserTab!.id, targetUrl: pageB }
+      )
+      await expect
+        .poll(async () =>
+          orcaPage.evaluate(async (targetBrowserTabId) => {
+            const slot = [...document.querySelectorAll('[data-browser-overlay-tab-id]')].find(
+              (candidate) =>
+                candidate.getAttribute('data-browser-overlay-tab-id') === targetBrowserTabId
+            )
+            const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+            return webview ? await webview.executeJavaScript('window.location.href') : null
+          }, browserTab!.id)
+        )
+        .toBe(pageB)
+      await expect(orcaPage.locator('body')).toContainText('Page A feedback 19')
+      await expect
+        .poll(async () => readBrowserAnnotationOverlayCount(orcaPage, browserTab!.id))
+        .toBe(0)
+      await addBrowserAnnotations(orcaPage, browserTab!.pageId!, [
+        {
+          id: pageBAnnotationId,
+          comment: 'Page B feedback',
+          url: pageB,
+          title: 'Page B',
+          label: 'Page B'
+        }
+      ])
+      await expect
+        .poll(
+          async () =>
+            orcaPage.evaluate(
+              (targetPageId) =>
+                window.__store?.getState().browserAnnotationsByPageId[targetPageId]?.length ?? -1,
+              browserTab!.pageId
+            ),
+          { timeout: 5_000 }
+        )
+        .toBe(20)
+      await expect
+        .poll(
+          async () =>
+            orcaPage.evaluate(
+              ({ targetPageId, targetAnnotationId }) =>
+                (window.__store?.getState().browserAnnotationsByPageId[targetPageId] ?? []).some(
+                  ({ id }) => id === targetAnnotationId
+                ),
+              { targetPageId: browserTab!.pageId, targetAnnotationId: pageBAnnotationId }
+            ),
+          { timeout: 5_000 }
+        )
+        .toBe(true)
+      await expect(orcaPage.locator('body')).toContainText('Page A feedback 19')
+      await expect(orcaPage.locator('body')).toContainText('Page B feedback')
+      await expect
+        .poll(async () => readBrowserAnnotationMarkerIds(orcaPage, browserTab!.id))
+        .toEqual([pageBAnnotationId])
+      await expect
+        .poll(async () => readBrowserAnnotationOverlayCount(orcaPage, browserTab!.id))
+        .toBe(1)
+      await orcaPage.screenshot({
+        path: testInfo.outputPath('browser-annotations-after-navigation.png')
+      })
+      await testInfo.attach('browser-annotations-after-navigation.png', {
+        path: testInfo.outputPath('browser-annotations-after-navigation.png'),
+        contentType: 'image/png'
+      })
+    } finally {
+      await server.close()
     }
   })
 


### PR DESCRIPTION
## Summary

Closes #8687.

Browser annotations now remain attached to their browser page across URL changes and load starts. Renderer document-identity helpers keep retained annotations visible in the tray and copied or sent output, keep empty captured-key annotations in a current-page output group, and project guest markers only for the active captured document while retaining full-queue indexes. The viewport bridge now resynchronizes both on live navigation commits and when a capped retained queue swaps entries without changing length, so page-A markers clear at the page-B commit and a new page-B annotation still paints even when the per-page queue stays at `20`. Explicit deletion, clearing, page/workspace cleanup, hydration reset, worktree cleanup, URL normalization, redaction, payload sanitization, and the per-page cap remain unchanged.

## Screenshots

Captured and attached `browser-annotations-after-navigation.png` from the focused Electron test. It exercises the cap boundary with 20 retained Page-A rows, proves the guest overlay count drops to `0` at the page-B commit, then adds a Page-B row without changing queue length; the guest bridge marker signal still passed with only the current Page-B marker present.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Coverage
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/browser.test.ts src/renderer/src/components/browser-pane/browser-annotation-page-identity.test.ts src/renderer/src/components/browser-pane/browser-annotation-output.test.ts config/scripts/browser-annotation-page-identity-fidelity.test.mjs --reporter=verbose` passed, 4 files and 43 tests.
- `pnpm run test:e2e -- tests/e2e/browser-tab.spec.ts -g "browser annotations survive navigation without stale guest markers" --reporter=line --workers=1` passed, kept the retained queue capped at `20` across the Page-B add, and attached `browser-annotations-after-navigation.png`.
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-annotation-viewport-bridge.test.ts --reporter=verbose` passed, 1 file and 1 test, and proved the disable path emits `[]`, removes the overlay host, and clears bridge state without throwing.
- `pnpm run typecheck:web` passed.
- Explicit changed-file `oxlint` passed.
- `pnpm exec oxfmt --check` passed for all changed repository files, including the shared bridge script and its disable-path regression test.
- Direct `oxlint --config config/oxlint-react-doctor.json` passed for all changed files. The wrapper `pnpm run lint:react-doctor:changed` was attempted but failed before linting because Node could not spawn `pnpm.cmd` with Windows `EINVAL`.

## AI Review Report

- Scope: renderer-local annotation retention, document-key filtering, cap-boundary bridge resynchronization, shared bridge disable-path teardown, tray context, mixed-page output including empty captured-key fallback, the clamp-fidelity harness, and focused Electron proof.
- Focused Electron proof now reads exact guest marker ids from the bridge signal when markers exist, and uses the actual guest overlay element count when the replacement page should be empty.
- macOS, Linux, Windows, SSH, remote/local, and provider-neutral behavior: no remote browser protocol or shared type changes; remote browser behavior remains outside the local Electron marker projection.
- Performance: marker selection is a bounded linear scan of the existing maximum-20 page queue; output grouping is a bounded linear scan.
- UI quality: retained rows keep existing numbering, actions, scrolling, and styling; only the captured URL metadata is added for off-document rows, and unsupported captured URLs stay visible under the existing current-page heading.
- Security: captured URLs remain main-process-clamped and sanitized; renderer identity accepts only `http:`, `https:`, `file:`, and `about:blank` as matchable document keys, and strips query and fragment components from supported keys.

## Security Audit

No new dependency, IPC surface, shared field, URL write path, or persistence format was added. The helper fails closed for unsupported or empty live URLs, compares sanitized document keys, and does not expose query strings or fragments as document identity. Existing main-process URL clamping, Kagi redaction, payload sanitization, screenshot removal, and annotation budget enforcement remain active.

## Notes

The React-doctor wrapper has a Windows process-spawn issue in this environment; its underlying configured oxlint command passed. The focused Electron proof ran headless, exercised the same-length capped-queue transition, and retained the screenshot as test output.

## ELI5

Browser annotations no longer vanish when the page navigates. Notes stay attached to the page and reappear correctly after loads.
