### PR TITLE
fix(mobile): dedupe host cards by pinned public key on re-pair (STA-1840)

### DIFF
--- a/mobile/app/pair-confirm.tsx
+++ b/mobile/app/pair-confirm.tsx
@@ -9,6 +9,7 @@ import {
   type PreProfilePairingAttempt
 } from '../src/transport/pre-profile-pairing-coordinator'
 import type { ConnectionLogEntry } from '../src/transport/types'
+import { useCloseHost } from '../src/transport/client-context'
 import { colors, spacing, radii, typography } from '../src/theme/mobile-theme'
 import { ConnectionLog } from '../src/components/ConnectionLog'
 import { shouldPresentNotificationOptIn } from '../src/notifications/notification-opt-in-gate'
@@ -24,6 +25,7 @@ const PAIRING_OVERALL_TIMEOUT_MS = 25_000
 
 export default function PairConfirmScreen() {
   const router = useRouter()
+  const closeHost = useCloseHost()
   const insets = useSafeAreaInsets()
   const params = useLocalSearchParams<{ code?: string }>()
   const [status, setStatus] = useState<Status>('awaiting-confirm')
@@ -104,6 +106,13 @@ export default function PairConfirmScreen() {
       if (!mountedRef.current || !attemptIsCurrent) {
         return
       }
+      // Why: re-pairing the same desktop now reuses its existing host id
+      // (STA-1840 dedup), so a client cached under that id from an earlier
+      // pairing would keep the stale endpoint/relay. Close it so the
+      // destination screen opens a fresh client with the newly-paired
+      // profile — the removeHost() path already refreshes on re-pair, and a
+      // brand-new host has no cached entry so this is a no-op.
+      closeHost(hostId)
       const showNotificationOptIn = await shouldPresentNotificationOptIn()
       if (!mountedRef.current) {
         return

--- a/mobile/app/pair-scan.tsx
+++ b/mobile/app/pair-scan.tsx
@@ -18,6 +18,7 @@ import {
   type PreProfilePairingAttempt
 } from '../src/transport/pre-profile-pairing-coordinator'
 import type { ConnectionLogEntry, PairingOffer } from '../src/transport/types'
+import { useCloseHost } from '../src/transport/client-context'
 import { colors, spacing, radii, typography } from '../src/theme/mobile-theme'
 import { TextInputModal } from '../src/components/TextInputModal'
 import { ConnectionLog } from '../src/components/ConnectionLog'
@@ -43,6 +44,7 @@ function Step({ number, text }: { number: number; text: string }) {
 
 export default function PairScanScreen() {
   const router = useRouter()
+  const closeHost = useCloseHost()
   const insets = useSafeAreaInsets()
   const [permission, requestPermission] = useCameraPermissions()
   const [status, setStatus] = useState<'scanning' | 'connecting' | 'error'>('scanning')
@@ -148,6 +150,13 @@ export default function PairScanScreen() {
       if (!mountedRef.current || !attemptIsCurrent) {
         return
       }
+      // Why: re-pairing the same desktop now reuses its existing host id
+      // (STA-1840 dedup), so a client cached under that id from an earlier
+      // pairing would keep the stale endpoint/relay. Close it so the
+      // destination screen opens a fresh client with the newly-paired
+      // profile — the removeHost() path already refreshes on re-pair, and a
+      // brand-new host has no cached entry so this is a no-op.
+      closeHost(hostId)
       const showNotificationOptIn = await shouldPresentNotificationOptIn()
       if (!mountedRef.current) {
         return

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -34,12 +34,13 @@ vi.mock('./host-credential-cleanup', () => ({
 }))
 
 import {
-  findStoredHostByPublicKey,
   loadHosts,
   MobileRelayUpgradeHostRemovedError,
   removeHost,
   renameHost,
+  resolvePairingHostIdentity,
   resetHostStoreForTests,
+  saveHost,
   saveExistingHostRelayUpgrade,
   updateLastConnected
 } from './host-store'
@@ -86,6 +87,8 @@ describe('host-store list mutations', () => {
     asyncStorageMock.setItem.mockImplementation(async (key: string, raw: string) => {
       if (key === HOSTS_STORAGE_KEY) {
         storedHostsRaw = raw
+      } else if (key === OVERLAY_STORAGE_KEY) {
+        storedOverlayRaw = raw
       }
     })
     secureStoreMock.getItemAsync.mockImplementation(async (key: string) =>
@@ -93,16 +96,87 @@ describe('host-store list mutations', () => {
     )
   })
 
-  it('finds a stored host by its pinned public key (STA-1840 re-pair dedup)', async () => {
-    await expect(findStoredHostByPublicKey(HOST_TWO.publicKeyB64)).resolves.toEqual({
+  it('resolves an existing host by pinned key with one durable read', async () => {
+    await expect(resolvePairingHostIdentity(HOST_TWO.publicKeyB64, 'host-new')).resolves.toEqual({
       id: HOST_TWO.id,
       name: HOST_TWO.name
     })
+    expect(asyncStorageMock.getItem).toHaveBeenCalledOnce()
   })
 
-  it('returns null when no stored host has the public key, or the key is empty', async () => {
-    await expect(findStoredHostByPublicKey('unpaired-key')).resolves.toBeNull()
-    await expect(findStoredHostByPublicKey('')).resolves.toBeNull()
+  it('names a new host from the same durable read used for identity lookup', async () => {
+    await expect(resolvePairingHostIdentity('unpaired-key', 'host-new')).resolves.toEqual({
+      id: 'host-new',
+      name: 'Host 3'
+    })
+    expect(asyncStorageMock.getItem).toHaveBeenCalledOnce()
+  })
+
+  it('fails closed when durable host identity storage is unreadable', async () => {
+    asyncStorageMock.getItem.mockRejectedValueOnce(new Error('storage unavailable'))
+
+    await expect(resolvePairingHostIdentity('key-new', 'host-new')).rejects.toThrow(/unreadable/)
+    expect(asyncStorageMock.setItem).not.toHaveBeenCalled()
+  })
+
+  it('collapses already-persisted duplicates when the desktop is re-paired', async () => {
+    storedHostsRaw = JSON.stringify([
+      HOST_ONE,
+      { ...HOST_TWO, id: 'host-duplicate', publicKeyB64: HOST_ONE.publicKeyB64 }
+    ])
+
+    await saveHost({
+      ...HOST_ONE,
+      endpoint: 'ws://127.0.0.1:3',
+      deviceToken: 'replacement-token'
+    })
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([{ ...HOST_ONE, endpoint: 'ws://127.0.0.1:3' }])
+    expect(scheduleCleanupMock).toHaveBeenCalledWith('host-duplicate', expect.any(Function))
+  })
+
+  it('clears stale relay state when an existing host is re-paired direct-only', async () => {
+    const overlay: MobileRelayHostOverlay = {
+      v: 2,
+      hostId: HOST_ONE.id,
+      endpoints: [
+        { id: 'direct-primary', kind: 'lan', url: HOST_ONE.endpoint },
+        {
+          id: 'relay-primary',
+          kind: 'relay',
+          url: 'wss://relay-c1.onorca.dev/v1/connect/AbCdEf0123_-xyZ9'
+        }
+      ],
+      relayHostId: 'AbCdEf0123_-xyZ9',
+      relay: {
+        v: 1,
+        directorUrl: 'https://relay.onorca.dev',
+        cellUrl: 'https://relay-c1.onorca.dev',
+        assignmentEpoch: 7,
+        relayHostId: 'AbCdEf0123_-xyZ9',
+        e2eeFraming: 2
+      }
+    }
+    storedOverlayRaw = JSON.stringify([overlay])
+
+    await saveHost({ ...HOST_ONE, deviceToken: 'replacement-token' })
+
+    expect(JSON.parse(storedOverlayRaw!)).toEqual([])
+    expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('does not touch relay storage when saving a new direct-only host', async () => {
+    await saveHost({
+      id: 'host-new',
+      name: 'New Host',
+      endpoint: 'ws://127.0.0.1:3',
+      publicKeyB64: 'key-new',
+      deviceToken: 'new-token',
+      lastConnected: 0
+    })
+
+    expect(asyncStorageMock.getItem).not.toHaveBeenCalledWith(OVERLAY_STORAGE_KEY)
+    expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
   })
 
   it('commits the removal when credential cleanup scheduling rejects', async () => {

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -34,6 +34,7 @@ vi.mock('./host-credential-cleanup', () => ({
 }))
 
 import {
+  findStoredHostByPublicKey,
   loadHosts,
   MobileRelayUpgradeHostRemovedError,
   removeHost,
@@ -90,6 +91,18 @@ describe('host-store list mutations', () => {
     secureStoreMock.getItemAsync.mockImplementation(async (key: string) =>
       key.endsWith(HOST_ONE.id) || key.endsWith(HOST_TWO.id) ? `token-${key.at(-1)}` : null
     )
+  })
+
+  it('finds a stored host by its pinned public key (STA-1840 re-pair dedup)', async () => {
+    await expect(findStoredHostByPublicKey(HOST_TWO.publicKeyB64)).resolves.toEqual({
+      id: HOST_TWO.id,
+      name: HOST_TWO.name
+    })
+  })
+
+  it('returns null when no stored host has the public key, or the key is empty', async () => {
+    await expect(findStoredHostByPublicKey('unpaired-key')).resolves.toBeNull()
+    await expect(findStoredHostByPublicKey('')).resolves.toBeNull()
   })
 
   it('commits the removal when credential cleanup scheduling rejects', async () => {

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -15,6 +15,7 @@ import {
 import {
   loadMobileRelayHostOverlayState,
   removeMobileRelayHostOverlay,
+  removeMobileRelayHostOverlays,
   saveMobileRelayHostOverlay
 } from './mobile-relay-host-overlay-store'
 import { deleteMobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
@@ -182,31 +183,18 @@ async function doLoadHosts(): Promise<HostProfile[]> {
   return out
 }
 
-async function loadStoredHosts(): Promise<StoredHostProfile[]> {
-  try {
-    return parseStoredHosts(await AsyncStorage.getItem(STORAGE_KEY)) ?? []
-  } catch {
-    return []
-  }
-}
-
-// Why: re-pairing the same desktop must merge into its existing card, not mint
-// a new host id and duplicate the row (STA-1840). publicKeyB64 is the desktop's
-// pinned identity key — stable across re-pairs, unlike id/endpoint/relay — so
-// it is the right dedup key. Reads the durable stored list (not loadHosts) so a
-// host whose keychain token read is transiently failing still matches and is
-// not duplicated.
-export async function findStoredHostByPublicKey(
-  publicKeyB64: string
-): Promise<{ id: string; name: string } | null> {
-  if (!publicKeyB64) {
-    return null
-  }
-  // Why: settle any in-flight save/remove first so a re-pair racing its own
-  // prior write matches the just-persisted host rather than an empty snapshot.
+export async function resolvePairingHostIdentity(
+  publicKeyB64: string,
+  newHostId: string
+): Promise<{ id: string; name: string }> {
+  // Why: one durable read both preserves an existing identity and names a new host,
+  // avoiding duplicate cards and a second serial storage read before connecting.
   await hostListMutation
-  const match = (await loadStoredHosts()).find((h) => h.publicKeyB64 === publicKeyB64)
-  return match ? { id: match.id, name: match.name } : null
+  const hosts = await readStoredHostsForMutation()
+  const match = hosts.find((host) => host.publicKeyB64 === publicKeyB64)
+  return match
+    ? { id: match.id, name: match.name }
+    : { id: newHostId, name: getNextHostNameFromHosts(hosts) }
 }
 
 async function readStoredHostsForMutation(): Promise<StoredHostProfile[]> {
@@ -261,18 +249,28 @@ export async function saveExistingHostRelayUpgrade(host: HostProfile): Promise<v
 async function persistHost(host: HostProfile, requireExisting: boolean): Promise<void> {
   const validated = HostProfileSchema.parse(host)
   const stored = toStored(validated)
+  const duplicateHostIds = new Set<string>()
+  let updatedExistingHost = false
   await mutateStoredHosts((hosts) => {
     const index = hosts.findIndex((h) => h.id === stored.id)
+    for (const candidate of hosts) {
+      if (candidate.id !== stored.id && candidate.publicKeyB64 === stored.publicKeyB64) {
+        duplicateHostIds.add(candidate.id)
+      }
+    }
     if (index >= 0) {
-      const next = hosts.slice()
-      next[index] = stored
-      return next
+      updatedExistingHost = true
+      // Why: affected installs may already contain duplicate rows; an authoritative
+      // save is the safe point to collapse them to the preserved host id.
+      return hosts
+        .filter(({ id }) => !duplicateHostIds.has(id))
+        .map((candidate) => (candidate.id === stored.id ? stored : candidate))
     }
     if (requireExisting) {
       // Why: an in-flight relay upgrade must not resurrect a host the user removed.
       throw new MobileRelayUpgradeHostRemovedError('mobile relay upgrade host was removed')
     }
-    return [...hosts, stored]
+    return [...hosts.filter(({ id }) => !duplicateHostIds.has(id)), stored]
   })
   // Why: write metadata BEFORE the keychain token so a crash between the two
   // leaves orphaned metadata (which loadHosts skips and removeHost can clean
@@ -289,6 +287,23 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
       relayHostId: validated.relayHostId,
       relay: validated.relay
     })
+  }
+  const overlayRemovalIds = [...duplicateHostIds]
+  if (!validated.endpoints && updatedExistingHost) {
+    overlayRemovalIds.push(stored.id)
+  }
+  if (overlayRemovalIds.length > 0) {
+    // Why: reusing an id for direct-only re-pairing must not retain routing
+    // metadata from the host's previous transport state.
+    await removeMobileRelayHostOverlays(overlayRemovalIds)
+  }
+  for (const duplicateHostId of duplicateHostIds) {
+    tokenCache.delete(duplicateHostId)
+    try {
+      await scheduleHostCredentialCleanup(duplicateHostId, deleteHostCredentials)
+    } catch {
+      // Metadata is already deduplicated; orphan-token recovery is best-effort.
+    }
   }
 }
 
@@ -328,12 +343,6 @@ export async function renameHost(hostId: string, newName: string): Promise<void>
     next[index] = { ...next[index]!, name: newName }
     return next
   })
-}
-
-export async function getNextHostName(): Promise<string> {
-  await hostListMutation
-  const hosts = await loadStoredHosts()
-  return getNextHostNameFromHosts(hosts)
 }
 
 export async function updateLastConnected(hostId: string): Promise<void> {

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -190,6 +190,25 @@ async function loadStoredHosts(): Promise<StoredHostProfile[]> {
   }
 }
 
+// Why: re-pairing the same desktop must merge into its existing card, not mint
+// a new host id and duplicate the row (STA-1840). publicKeyB64 is the desktop's
+// pinned identity key — stable across re-pairs, unlike id/endpoint/relay — so
+// it is the right dedup key. Reads the durable stored list (not loadHosts) so a
+// host whose keychain token read is transiently failing still matches and is
+// not duplicated.
+export async function findStoredHostByPublicKey(
+  publicKeyB64: string
+): Promise<{ id: string; name: string } | null> {
+  if (!publicKeyB64) {
+    return null
+  }
+  // Why: settle any in-flight save/remove first so a re-pair racing its own
+  // prior write matches the just-persisted host rather than an empty snapshot.
+  await hostListMutation
+  const match = (await loadStoredHosts()).find((h) => h.publicKeyB64 === publicKeyB64)
+  return match ? { id: match.id, name: match.name } : null
+}
+
 async function readStoredHostsForMutation(): Promise<StoredHostProfile[]> {
   try {
     const parsed = parseStoredHosts(await AsyncStorage.getItem(STORAGE_KEY))

--- a/mobile/src/transport/mobile-relay-host-overlay-store.test.ts
+++ b/mobile/src/transport/mobile-relay-host-overlay-store.test.ts
@@ -9,6 +9,7 @@ vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStor
 
 import {
   loadMobileRelayHostOverlays,
+  removeMobileRelayHostOverlays,
   resetMobileRelayHostOverlayStoreForTests,
   saveMobileRelayHostOverlay
 } from './mobile-relay-host-overlay-store'
@@ -75,6 +76,26 @@ describe('mobile relay host overlay store', () => {
     stored = '{'
 
     await expect(saveMobileRelayHostOverlay(OVERLAY)).rejects.toThrow(/unreadable/)
+    expect(asyncStorage.setItem).not.toHaveBeenCalled()
+  })
+
+  it('removes requested overlays in one storage write', async () => {
+    const second = { ...OVERLAY, hostId: 'host-2' }
+    stored = JSON.stringify([OVERLAY, second])
+
+    await expect(removeMobileRelayHostOverlays(['host-1', 'host-missing'])).resolves.toBeUndefined()
+
+    expect(JSON.parse(stored!)).toEqual([second])
+    expect(asyncStorage.getItem).toHaveBeenCalledOnce()
+    expect(asyncStorage.setItem).toHaveBeenCalledOnce()
+  })
+
+  it('skips the storage write when no requested overlay exists', async () => {
+    stored = JSON.stringify([OVERLAY])
+
+    await expect(removeMobileRelayHostOverlays(['host-missing'])).resolves.toBeUndefined()
+
+    expect(asyncStorage.getItem).toHaveBeenCalledOnce()
     expect(asyncStorage.setItem).not.toHaveBeenCalled()
   })
 })

--- a/mobile/src/transport/mobile-relay-host-overlay-store.ts
+++ b/mobile/src/transport/mobile-relay-host-overlay-store.ts
@@ -40,7 +40,12 @@ async function mutateOverlays(
 ): Promise<void> {
   const mutation = overlayMutation.then(async () => {
     const current = await readOverlaysForMutation()
-    await AsyncStorage.setItem(OVERLAY_STORAGE_KEY, JSON.stringify(update(current)))
+    const next = update(current)
+    // Why: direct-only saves commonly have no overlay to remove; avoid a full
+    // AsyncStorage write when cleanup leaves the durable list unchanged.
+    if (next !== current) {
+      await AsyncStorage.setItem(OVERLAY_STORAGE_KEY, JSON.stringify(next))
+    }
   })
   overlayMutation = mutation.catch(() => {})
   return mutation
@@ -85,7 +90,22 @@ export async function saveMobileRelayHostOverlay(overlay: MobileRelayHostOverlay
 }
 
 export function removeMobileRelayHostOverlay(hostId: string): Promise<void> {
-  return mutateOverlays((overlays) => overlays.filter((overlay) => overlay.hostId !== hostId))
+  return removeMobileRelayHostOverlays([hostId])
+}
+
+export function removeMobileRelayHostOverlays(hostIds: readonly string[]): Promise<void> {
+  const targets = new Set(hostIds)
+  let removed = false
+  return mutateOverlays((overlays) => {
+    const next = overlays.filter((overlay) => {
+      if (!targets.has(overlay.hostId)) {
+        return true
+      }
+      removed = true
+      return false
+    })
+    return removed ? next : overlays
+  })
 }
 
 /** Test-only: drain the module mutation chain between cases. */

--- a/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
@@ -64,8 +64,10 @@ function dependencies(client: RpcClient, events: string[]) {
     resolveInviteDirector: vi.fn(async () => {
       throw new Error('director unavailable')
     }),
-    getNextHostName: vi.fn(async () => 'Blue Whale'),
-    findExistingHost: vi.fn(async (_publicKeyB64: string) => null),
+    resolveHostIdentity: vi.fn(async (_publicKeyB64: string, hostId: string) => ({
+      id: hostId,
+      name: 'Blue Whale'
+    })),
     saveHost: vi.fn(async (_host: HostProfile) => {
       events.push('save-host')
     }),
@@ -143,8 +145,9 @@ describe('pre-profile pairing coordinator', () => {
     const events: string[] = []
     const client = fakeClient([success({ version: '1.0.0' })])
     const deps = dependencies(client, events)
-    deps.findExistingHost = vi.fn(async (publicKeyB64: string) => {
+    deps.resolveHostIdentity = vi.fn(async (publicKeyB64: string, newHostId: string) => {
       expect(publicKeyB64).toBe(directOffer.publicKeyB64)
+      expect(newHostId).toBe(`host-${now}`)
       return { id: 'host-existing', name: 'Studio Mac' }
     })
 
@@ -163,8 +166,6 @@ describe('pre-profile pairing coordinator', () => {
       publicKeyB64: directOffer.publicKeyB64,
       lastConnected: now
     })
-    // Existing host keeps its name — no fresh name minted.
-    expect(deps.getNextHostName).not.toHaveBeenCalled()
   })
 
   it('journals before connecting and publishes only after authoritative direct install', async () => {

--- a/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
@@ -65,6 +65,7 @@ function dependencies(client: RpcClient, events: string[]) {
       throw new Error('director unavailable')
     }),
     getNextHostName: vi.fn(async () => 'Blue Whale'),
+    findExistingHost: vi.fn(async (_publicKeyB64: string) => null),
     saveHost: vi.fn(async (_host: HostProfile) => {
       events.push('save-host')
     }),
@@ -134,6 +135,36 @@ describe('pre-profile pairing coordinator', () => {
       lastConnected: now
     })
     expect(events).toEqual(['connect', 'save-host'])
+  })
+
+  it('reuses the existing host id and name when re-pairing the same desktop key (no duplicate)', async () => {
+    // STA-1840: re-pairing a desktop already stored under a different id must
+    // merge into that card, not mint a new host-${now} and duplicate the row.
+    const events: string[] = []
+    const client = fakeClient([success({ version: '1.0.0' })])
+    const deps = dependencies(client, events)
+    deps.findExistingHost = vi.fn(async (publicKeyB64: string) => {
+      expect(publicKeyB64).toBe(directOffer.publicKeyB64)
+      return { id: 'host-existing', name: 'Studio Mac' }
+    })
+
+    const attempt = startPreProfilePairing({
+      offer: directOffer,
+      timeoutMs: 5_000,
+      dependencies: deps
+    })
+
+    await expect(attempt.result).resolves.toEqual({ hostId: 'host-existing' })
+    expect(deps.saveHost).toHaveBeenCalledWith({
+      id: 'host-existing',
+      name: 'Studio Mac',
+      endpoint: directOffer.endpoint,
+      deviceToken: directOffer.deviceToken,
+      publicKeyB64: directOffer.publicKeyB64,
+      lastConnected: now
+    })
+    // Existing host keeps its name — no fresh name minted.
+    expect(deps.getNextHostName).not.toHaveBeenCalled()
   })
 
   it('journals before connecting and publishes only after authoritative direct install', async () => {

--- a/mobile/src/transport/pre-profile-pairing-coordinator.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.ts
@@ -6,7 +6,7 @@ import {
   type MobileRelayEndpoint
 } from '../../../src/shared/mobile-relay-credential-contract'
 import { connect, type ConnectOptions } from './rpc-client'
-import { findStoredHostByPublicKey, getNextHostName, saveHost } from './host-store'
+import { resolvePairingHostIdentity, saveHost } from './host-store'
 import type { HostProfile, PairingOffer, RpcResponse } from './types'
 import {
   createMobileRelayPairingJournal,
@@ -39,8 +39,7 @@ type Dependencies = {
   connectDirect: typeof connect
   connectRelay: typeof connectMobileRelayForPairing
   resolveInviteDirector: typeof resolvePairingInviteThroughDirector
-  getNextHostName: typeof getNextHostName
-  findExistingHost: typeof findStoredHostByPublicKey
+  resolveHostIdentity: typeof resolvePairingHostIdentity
   saveHost: typeof saveHost
   saveJournal: typeof saveMobileRelayPairingJournal
   updateJournal: typeof updateMobileRelayPairingJournal
@@ -54,8 +53,7 @@ const defaultDependencies: Dependencies = {
   connectDirect: connect,
   connectRelay: connectMobileRelayForPairing,
   resolveInviteDirector: resolvePairingInviteThroughDirector,
-  getNextHostName,
-  findExistingHost: findStoredHostByPublicKey,
+  resolveHostIdentity: resolvePairingHostIdentity,
   saveHost,
   saveJournal: saveMobileRelayPairingJournal,
   updateJournal: updateMobileRelayPairingJournal,
@@ -132,16 +130,12 @@ async function runPairing(
   isDisposed: () => boolean
 ): Promise<{ hostId: string }> {
   const now = dependencies.now()
-  // Why: if this desktop (by its pinned public key) is already paired, reuse
-  // that host's id and name so the pairing merges into the existing card
-  // instead of minting a fresh host-${now} and duplicating the row (STA-1840).
-  // Every downstream write (journal, credential bundle, saveHost) then keys to
-  // the same id, so persistHost updates in place. A new desktop key falls
-  // through to a fresh id/name.
-  const existing = await dependencies.findExistingHost(offer.publicKeyB64)
-  assertActive(isDisposed)
-  const hostId = existing?.id ?? `host-${now}`
-  const hostName = existing?.name ?? (await dependencies.getNextHostName())
+  // Why: every pairing artifact must share the preserved host id so re-pairing
+  // updates one card instead of publishing a second identity (STA-1840).
+  const { id: hostId, name: hostName } = await dependencies.resolveHostIdentity(
+    offer.publicKeyB64,
+    `host-${now}`
+  )
   assertActive(isDisposed)
   let journal: MobileRelayPairingJournal | null = null
   if (offer.relay && dependencies.platform !== 'web') {

--- a/mobile/src/transport/pre-profile-pairing-coordinator.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.ts
@@ -6,7 +6,7 @@ import {
   type MobileRelayEndpoint
 } from '../../../src/shared/mobile-relay-credential-contract'
 import { connect, type ConnectOptions } from './rpc-client'
-import { getNextHostName, saveHost } from './host-store'
+import { findStoredHostByPublicKey, getNextHostName, saveHost } from './host-store'
 import type { HostProfile, PairingOffer, RpcResponse } from './types'
 import {
   createMobileRelayPairingJournal,
@@ -40,6 +40,7 @@ type Dependencies = {
   connectRelay: typeof connectMobileRelayForPairing
   resolveInviteDirector: typeof resolvePairingInviteThroughDirector
   getNextHostName: typeof getNextHostName
+  findExistingHost: typeof findStoredHostByPublicKey
   saveHost: typeof saveHost
   saveJournal: typeof saveMobileRelayPairingJournal
   updateJournal: typeof updateMobileRelayPairingJournal
@@ -54,6 +55,7 @@ const defaultDependencies: Dependencies = {
   connectRelay: connectMobileRelayForPairing,
   resolveInviteDirector: resolvePairingInviteThroughDirector,
   getNextHostName,
+  findExistingHost: findStoredHostByPublicKey,
   saveHost,
   saveJournal: saveMobileRelayPairingJournal,
   updateJournal: updateMobileRelayPairingJournal,
@@ -130,8 +132,16 @@ async function runPairing(
   isDisposed: () => boolean
 ): Promise<{ hostId: string }> {
   const now = dependencies.now()
-  const hostId = `host-${now}`
-  const hostName = await dependencies.getNextHostName()
+  // Why: if this desktop (by its pinned public key) is already paired, reuse
+  // that host's id and name so the pairing merges into the existing card
+  // instead of minting a fresh host-${now} and duplicating the row (STA-1840).
+  // Every downstream write (journal, credential bundle, saveHost) then keys to
+  // the same id, so persistHost updates in place. A new desktop key falls
+  // through to a fresh id/name.
+  const existing = await dependencies.findExistingHost(offer.publicKeyB64)
+  assertActive(isDisposed)
+  const hostId = existing?.id ?? `host-${now}`
+  const hostName = existing?.name ?? (await dependencies.getNextHostName())
   assertActive(isDisposed)
   let journal: MobileRelayPairingJournal | null = null
   if (offer.relay && dependencies.platform !== 'web') {


### PR DESCRIPTION
## Summary

Re-pairing a desktop that was already paired created a **duplicate host card** on mobile (the STA-1840 "multiple hosts" symptom). The pairing coordinator always minted a fresh `host-${now}` id, and `persistHost` dedups only on that id, so a second row was appended for the same physical desktop. The "connect from anywhere" CTA on an unreachable direct-only host nudges the user to re-scan, which made this reachable in normal use.

Pairing now resolves the durable host identity by the desktop's pinned `publicKeyB64` — the desktop's stable, cryptographically-unique identity key — and **reuses the existing host's id and name** so the pairing merges into the existing card. Every downstream pairing artifact (relay journal, credential bundle, `saveHost`) then keys to the same id. A genuinely new desktop key falls through to a fresh id/name, so distinct desktops still get distinct cards.

## What this fixes (addresses all findings from review)

- **Prevents new duplicates** — reuse the existing id/name by pinned public key.
- **Heals existing duplicates** — an authoritative save collapses any already-stored rows sharing that public key and cleans up the dropped rows' credentials/overlays (users already bitten by the shipped bug are healed on their next re-pair).
- **Refreshes the live client on re-pair** — because re-pair now *reuses* the id, a client cached under that id would otherwise keep the stale endpoint/relay, so a re-pair meant to switch a host onto relay wouldn't take effect until restart. Pairing now closes the host's client on success (`closeHost`) so the destination screen opens a fresh client with the newly-paired profile — mirroring the existing `removeHost()` refresh path. No-op for a brand-new host.
- **Fails closed on unreadable storage** — identity resolution uses one strict durable read; if host storage is unreadable it aborts the pairing instead of falling back to minting another identity (which would duplicate).
- **Clears stale relay routing** — re-pairing a previously-relay host direct-only removes the old relay overlay so the merged card doesn't keep advertising dead relay state.
- **One durable read** for identity + naming, instead of two serial reads before connecting.

## Changes

- `host-store.ts`: `resolvePairingHostIdentity()` (strict single read: reuse existing id/name by public key, else name a new host); `persistHost` collapses same-key duplicate rows and cleans their credentials/overlays; clears the relay overlay on a direct-only save that reuses an id.
- `mobile-relay-host-overlay-store.ts`: batched `removeMobileRelayHostOverlays`; skip the storage write when nothing changed.
- `pre-profile-pairing-coordinator.ts`: resolve the host identity up front and thread it through the whole flow.
- `pair-confirm.tsx` / `pair-scan.tsx`: `closeHost(hostId)` on pairing success so a reused id reconnects on the new profile.

## Screenshots

No visual change — pairing-logic only. Behavior: re-pairing the same desktop updates the one existing row (and reconnects it) instead of adding a second row.

## Testing

- [x] `tsc --noEmit` (mobile) — clean
- [x] `oxlint` / `oxfmt --check` (changed files) — clean
- [x] `vitest run` — **full mobile suite: 242 files, 1,719 passed, 2 skipped**. New/updated cases cover: resolve-by-key with one durable read, name-from-same-read, **fail-closed on unreadable storage**, **collapse already-persisted duplicates**, **clear stale relay on direct-only re-pair**, no-touch on a new direct host, batched/skip-no-op overlay writes.
- [ ] **Not device-verified.** The definitive end-to-end check (pair a desktop → re-scan its QR → confirm one card and that it reconnects on the new endpoint) needs an emulator/physical run. The logic is unit-proven; the live pair→re-pair path is not exercised here.

## Notes

Mobile only — does not touch the desktop build. This is the P1-1 item from the v1.4.142 release audit. It does not address the separate relay-pairing P2s (offer-TTL, recovery-resurrect, clear-after-commit).
