### PR TITLE
fix(native-chat): deliver AskUserQuestion answer by option number, not label (STA-1860)

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -38,15 +38,15 @@ const mocks = {
   cancel: vi.fn<NativeChatInteractiveSend['cancel']>()
 }
 
-function renderCard(): ReturnType<typeof render> {
-  return render(cardElement())
+function renderCard(canSend = true): ReturnType<typeof render> {
+  return render(cardElement(canSend))
 }
 
-function cardElement(): React.JSX.Element {
+function cardElement(canSend = true): React.JSX.Element {
   return (
     <NativeChatInteractiveCard
       paneKey="tab-1:leaf-1"
-      canSend
+      canSend={canSend}
       send={{
         sendAnswer: mocks.sendAnswer,
         sendRaw: mocks.sendRaw,
@@ -92,6 +92,28 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
 
     rendered.unmount()
     expect(mocks.cancelPending).toHaveBeenCalledOnce()
+  })
+
+  it('cancels delayed PTY writes when desktop send authority is lost', () => {
+    mocks.sendAnswer.mockReturnValue(5_000)
+    const rendered = renderCard()
+
+    chooseSpacesAndSubmit()
+    rendered.rerender(cardElement(false))
+
+    expect(mocks.cancelPending).toHaveBeenCalledOnce()
+  })
+
+  it('shows the paced send as busy and freezes the snapshotted answer', () => {
+    mocks.sendAnswer.mockReturnValue(5_000)
+    renderCard()
+
+    chooseSpacesAndSubmit()
+
+    expect(screen.getByRole('button', { name: 'Sending…' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Spaces/ })).toBeDisabled()
+    expect(screen.getByRole('textbox')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled()
   })
 
   it('cancels the old answer sequence when a replacement prompt arrives', () => {

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatInteractiveSend } from './use-native-chat-interactive-send'
+
+const INITIAL_PROMPT = JSON.stringify({
+  questions: [
+    {
+      question: 'Tabs or spaces?',
+      multiSelect: false,
+      options: [{ label: 'Tabs' }, { label: 'Spaces' }]
+    }
+  ]
+})
+
+const storeState = {
+  agentStatusByPaneKey: {
+    'tab-1:leaf-1': {
+      interactivePrompt: INITIAL_PROMPT,
+      toolName: 'AskUserQuestion'
+    }
+  }
+}
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: typeof storeState) => unknown) => selector(storeState)
+}))
+
+import { NativeChatInteractiveCard } from './NativeChatInteractiveCard'
+
+const mocks = {
+  sendAnswer: vi.fn<NativeChatInteractiveSend['sendAnswer']>(),
+  sendRaw: vi.fn<NativeChatInteractiveSend['sendRaw']>(),
+  cancelPending: vi.fn<NativeChatInteractiveSend['cancelPending']>(),
+  cancel: vi.fn<NativeChatInteractiveSend['cancel']>()
+}
+
+function renderCard(): ReturnType<typeof render> {
+  return render(cardElement())
+}
+
+function cardElement(): React.JSX.Element {
+  return (
+    <NativeChatInteractiveCard
+      paneKey="tab-1:leaf-1"
+      canSend
+      send={{
+        sendAnswer: mocks.sendAnswer,
+        sendRaw: mocks.sendRaw,
+        cancelPending: mocks.cancelPending,
+        cancel: mocks.cancel
+      }}
+    />
+  )
+}
+
+function chooseSpacesAndSubmit(): void {
+  fireEvent.click(screen.getByRole('button', { name: /Spaces/ }))
+  fireEvent.click(screen.getByRole('button', { name: 'Send answer' }))
+}
+
+describe('NativeChatInteractiveCard answer lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storeState.agentStatusByPaneKey['tab-1:leaf-1'].interactivePrompt = INITIAL_PROMPT
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('keeps the card retryable when no PTY answer was sent', () => {
+    mocks.sendAnswer.mockReturnValue(0)
+    renderCard()
+
+    chooseSpacesAndSubmit()
+    expect(screen.getByText('Tabs or spaces?')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send answer' }))
+    expect(mocks.sendAnswer).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels delayed PTY writes when the owning card unmounts', () => {
+    mocks.sendAnswer.mockReturnValue(5_000)
+    const rendered = renderCard()
+
+    chooseSpacesAndSubmit()
+    expect(mocks.cancelPending).not.toHaveBeenCalled()
+
+    rendered.unmount()
+    expect(mocks.cancelPending).toHaveBeenCalledOnce()
+  })
+
+  it('cancels the old answer sequence when a replacement prompt arrives', () => {
+    mocks.sendAnswer.mockReturnValue(5_000)
+    const rendered = renderCard()
+    chooseSpacesAndSubmit()
+
+    storeState.agentStatusByPaneKey['tab-1:leaf-1'].interactivePrompt = JSON.stringify({
+      questions: [
+        {
+          question: 'Choose a shell?',
+          multiSelect: false,
+          options: [{ label: 'zsh' }, { label: 'bash' }]
+        }
+      ]
+    })
+    rendered.rerender(cardElement())
+
+    expect(mocks.cancelPending).toHaveBeenCalledOnce()
+    expect(screen.getByText('Choose a shell?')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '../../store'
 import { parseInteractivePrompt } from './native-chat-interactive-prompt'
 import { nativeChatCardDismissKey } from './native-chat-dismiss-key'
@@ -66,8 +66,8 @@ export function NativeChatInteractiveCard({
     setSubmitting(false)
   }, [])
   // A replacement prompt, ownership loss, or unmount must stop both timers and
-  // PTY writes, or the old answer can type into a prompt the desktop no longer owns.
-  useEffect(
+  // PTY writes during commit, before an old answer can type into the new prompt.
+  useLayoutEffect(
     () => () => {
       clearDismissTimer()
       cancelPending()

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
@@ -11,8 +11,8 @@ import type { NativeChatInteractiveSend } from './use-native-chat-interactive-se
  * `interactivePrompt` is present: a question wizard (precedence) or a tool
  * approval. Cleared by the host once the agent moves on, so it disappears
  * automatically. Sends through the composer's verified runtime path (R8/R6):
- * answers as bracketed-paste + Enter; cancel/deny as ESC. Guarded by `canSend`
- * so a mobile presence-lock blocks desktop sends the same way it guards xterm.
+ * answers via agent-specific paste or selector keystrokes; cancel/deny as ESC.
+ * Guarded by `canSend` so a mobile presence-lock blocks desktop sends too.
  *
  * Dismiss-on-answer (mobile parity): the live status lingers after answering —
  * the agent emits a post-tool event carrying the same prompt — so we track the
@@ -56,21 +56,23 @@ export function NativeChatInteractiveCard({
   // vanish mid-send. `submitting` also gates a second submit racing the first.
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const submittingRef = useRef(false)
+  const [submitting, setSubmitting] = useState(false)
   const clearDismissTimer = useCallback((): void => {
     if (dismissTimerRef.current) {
       clearTimeout(dismissTimerRef.current)
       dismissTimerRef.current = null
     }
     submittingRef.current = false
+    setSubmitting(false)
   }, [])
-  // A replacement prompt or unmount must stop both the UI timer and its external
-  // PTY writes, or the old answer can type into the next prompt.
+  // A replacement prompt, ownership loss, or unmount must stop both timers and
+  // PTY writes, or the old answer can type into a prompt the desktop no longer owns.
   useEffect(
     () => () => {
       clearDismissTimer()
       cancelPending()
     },
-    [cardKey, cancelPending, clearDismissTimer]
+    [canSend, cardKey, cancelPending, clearDismissTimer]
   )
 
   // Forget the dismissal once the prompt clears so a fresh prompt can show.
@@ -98,6 +100,7 @@ export function NativeChatInteractiveCard({
       <NativeChatQuestionCard
         key={cardKey ?? 'question'}
         prompt={card.prompt}
+        isSubmitting={submitting}
         answerInputRef={answerInputRef}
         onAnswer={(selections) => {
           if (submittingRef.current) {
@@ -111,12 +114,14 @@ export function NativeChatInteractiveCard({
             submittingRef.current = false
             return
           }
+          setSubmitting(true)
           // Hold the card until the paced write finishes, then mark it answered
           // (which hides it and restores the composer).
           dismissTimerRef.current = setTimeout(() => {
             cancelPending()
             setDismissedKey(cardKey)
             submittingRef.current = false
+            setSubmitting(false)
             dismissTimerRef.current = null
           }, settleMs)
         }}

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '../../store'
 import { parseInteractivePrompt } from './native-chat-interactive-prompt'
 import { nativeChatCardDismissKey } from './native-chat-dismiss-key'
@@ -43,7 +43,7 @@ export function NativeChatInteractiveCard({
   // Thread the sibling `toolName` from the same status entry so the question
   // parser can dispatch through the tool's registered parser (mobile parity).
   const interactiveToolName = useAppStore((s) => s.agentStatusByPaneKey[paneKey]?.toolName ?? null)
-  const { sendAnswer, sendRaw, cancel } = send
+  const { sendAnswer, sendRaw, cancelPending, cancel } = send
 
   const card = useMemo(
     () => parseInteractivePrompt(interactivePrompt, interactiveToolName ?? undefined),
@@ -56,17 +56,22 @@ export function NativeChatInteractiveCard({
   // vanish mid-send. `submitting` also gates a second submit racing the first.
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const submittingRef = useRef(false)
-  const clearDismissTimer = (): void => {
+  const clearDismissTimer = useCallback((): void => {
     if (dismissTimerRef.current) {
       clearTimeout(dismissTimerRef.current)
       dismissTimerRef.current = null
     }
     submittingRef.current = false
-  }
-  // Keyed on cardKey (and unmount): a new prompt can replace the current one
-  // before the settle timer fires, and a stale `submitting` gate would swallow
-  // the new card's first answer.
-  useEffect(() => clearDismissTimer, [cardKey])
+  }, [])
+  // A replacement prompt or unmount must stop both the UI timer and its external
+  // PTY writes, or the old answer can type into the next prompt.
+  useEffect(
+    () => () => {
+      clearDismissTimer()
+      cancelPending()
+    },
+    [cardKey, cancelPending, clearDismissTimer]
+  )
 
   // Forget the dismissal once the prompt clears so a fresh prompt can show.
   const present = card != null
@@ -75,7 +80,7 @@ export function NativeChatInteractiveCard({
       setDismissedKey(null)
       clearDismissTimer()
     }
-  }, [present])
+  }, [present, clearDismissTimer])
 
   // Tell the view when a question card is up so it can hide the composer (this
   // card supplies its own input). Reset on unmount so the composer comes back.
@@ -100,9 +105,16 @@ export function NativeChatInteractiveCard({
           }
           submittingRef.current = true
           const settleMs = sendAnswer(card.prompt, selections)
+          if (settleMs <= 0) {
+            // Keep the actionable card visible when its PTY disappeared between
+            // render and submit; the next live target update can make it retryable.
+            submittingRef.current = false
+            return
+          }
           // Hold the card until the paced write finishes, then mark it answered
           // (which hides it and restores the composer).
           dismissTimerRef.current = setTimeout(() => {
+            cancelPending()
             setDismissedKey(cardKey)
             submittingRef.current = false
             dismissTimerRef.current = null

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx
@@ -94,12 +94,12 @@ export function NativeChatInteractiveCard({
         key={cardKey ?? 'question'}
         prompt={card.prompt}
         answerInputRef={answerInputRef}
-        onAnswer={(text) => {
+        onAnswer={(selections) => {
           if (submittingRef.current) {
             return
           }
           submittingRef.current = true
-          const settleMs = sendAnswer(text)
+          const settleMs = sendAnswer(card.prompt, selections)
           // Hold the card until the paced write finishes, then mark it answered
           // (which hides it and restores the composer).
           dismissTimerRef.current = setTimeout(() => {

--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.test.tsx
@@ -47,6 +47,10 @@ function clickOption(label: string): void {
   click(row, `option ${label}`)
 }
 
+function clickOptionAt(index: number): void {
+  click(container.querySelectorAll('button[aria-pressed]')[index], `option index ${index}`)
+}
+
 function clickAction(text: string): void {
   const button = [...container.querySelectorAll('button')].find(
     (b) => b.textContent?.trim() === text
@@ -91,11 +95,32 @@ describe('NativeChatQuestionCard', () => {
       onAnswer
     )
 
-    clickOption('Apple')
     clickOption('Cherry')
+    clickOption('Apple')
     clickAction('Send answer')
 
     expect(onAnswer).toHaveBeenCalledWith([{ indices: [0, 2], other: '' }])
+  })
+
+  it('keeps duplicate labels distinct by their numbered row', () => {
+    const onAnswer = vi.fn()
+    render(
+      {
+        questions: [
+          {
+            question: 'Which duplicate row?',
+            multiSelect: false,
+            options: [{ label: 'Same' }, { label: 'Same' }]
+          }
+        ]
+      },
+      onAnswer
+    )
+
+    clickOptionAt(1)
+    clickAction('Send answer')
+
+    expect(onAnswer).toHaveBeenCalledWith([{ indices: [1], other: '' }])
   })
 
   it('carries free text through as the other answer', () => {

--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NativeChatQuestionCard } from './NativeChatQuestionCard'
+import type { AskAnswerSelection, AskPrompt } from './native-chat-interactive-prompt'
+
+// The card resolves its own label-keyed selection state into the index-based
+// answer the delivery layer needs. These tests pin that resolution — the exact
+// seam of STA-1860 (a non-first pick must surface as its option INDEX, not the
+// first option / the raw label).
+
+let container: HTMLDivElement
+let root: ReturnType<typeof createRoot>
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function render(prompt: AskPrompt, onAnswer: (s: AskAnswerSelection[]) => void): void {
+  act(() => {
+    root.render(<NativeChatQuestionCard prompt={prompt} onAnswer={onAnswer} onCancel={() => {}} />)
+  })
+}
+
+function click(button: Element | undefined, describe: string): void {
+  if (!button) {
+    throw new Error(`button not found: ${describe}`)
+  }
+  act(() => button.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+}
+
+// Option rows carry a badge number + label, so match them by the label they
+// contain among the aria-pressed selectable rows.
+function clickOption(label: string): void {
+  const row = [...container.querySelectorAll('button[aria-pressed]')].find((b) =>
+    b.textContent?.includes(label)
+  )
+  click(row, `option ${label}`)
+}
+
+function clickAction(text: string): void {
+  const button = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent?.trim() === text
+  )
+  click(button, text)
+}
+
+const tabsOrSpaces: AskPrompt = {
+  questions: [
+    {
+      question: 'Do you prefer tabs or spaces?',
+      header: 'Indent',
+      multiSelect: false,
+      options: [{ label: 'Tabs' }, { label: 'Spaces' }]
+    }
+  ]
+}
+
+describe('NativeChatQuestionCard', () => {
+  it('delivers the SECOND option as index 1, not the default (STA-1860)', () => {
+    const onAnswer = vi.fn()
+    render(tabsOrSpaces, onAnswer)
+
+    clickOption('Spaces')
+    clickAction('Send answer')
+
+    expect(onAnswer).toHaveBeenCalledWith([{ indices: [1], other: '' }])
+  })
+
+  it('delivers a multi-select pick as its option indices', () => {
+    const onAnswer = vi.fn()
+    render(
+      {
+        questions: [
+          {
+            question: 'Which fruits?',
+            multiSelect: true,
+            options: [{ label: 'Apple' }, { label: 'Banana' }, { label: 'Cherry' }]
+          }
+        ]
+      },
+      onAnswer
+    )
+
+    clickOption('Apple')
+    clickOption('Cherry')
+    clickAction('Send answer')
+
+    expect(onAnswer).toHaveBeenCalledWith([{ indices: [0, 2], other: '' }])
+  })
+
+  it('carries free text through as the other answer', () => {
+    const onAnswer = vi.fn()
+    render(tabsOrSpaces, onAnswer)
+
+    const input = container.querySelector('input')!
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(input, 'four spaces')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    clickAction('Send answer')
+
+    expect(onAnswer).toHaveBeenCalledWith([{ indices: [], other: 'four spaces' }])
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
@@ -29,7 +29,9 @@ export function NativeChatQuestionCard({
   answerInputRef
 }: NativeChatQuestionCardProps): React.JSX.Element {
   const [index, setIndex] = useState(0)
-  const [selections, setSelections] = useState<string[][]>(() => prompt.questions.map(() => []))
+  // Keep option identity by index: labels are display text and are not guaranteed
+  // unique, while Claude's selector commits the numbered row (STA-1860).
+  const [selections, setSelections] = useState<number[][]>(() => prompt.questions.map(() => []))
   const [otherText, setOtherText] = useState<string[]>(() => prompt.questions.map(() => ''))
 
   const total = prompt.questions.length
@@ -46,38 +48,30 @@ export function NativeChatQuestionCard({
 
   // The resolved answer for a question: picked labels plus any typed free-text.
   const answerFor = (qi: number, sel = selections, oth = otherText): string => {
-    const picked = sel[qi] ?? []
+    const question = prompt.questions[qi]
+    const picked = (sel[qi] ?? [])
+      .map((optionIndex) => question?.options[optionIndex]?.label ?? '')
+      .filter((label) => label.length > 0)
     const other = (oth[qi] ?? '').trim()
     return [...picked, ...(other ? [other] : [])].join(', ')
   }
 
   const currentAnswered = answerFor(index).length > 0
 
-  // Resolve the card's label-keyed selection state into per-question option
-  // INDICES (in option order) + trimmed free text, the index-based shape the
-  // answer is delivered by (the agent's selector commits by option number, not
-  // by label — STA-1860).
-  const submitAll = (sel: string[][], oth: string[]): void => {
-    const selections: AskAnswerSelection[] = prompt.questions.map((question, i) => {
-      const picked = sel[i] ?? []
-      const indices = question.options.reduce<number[]>((acc, opt, oi) => {
-        if (picked.includes(opt.label)) {
-          acc.push(oi)
-        }
-        return acc
-      }, [])
-      return { indices, other: (oth[i] ?? '').trim() }
+  const submitAll = (sel: number[][], oth: string[]): void => {
+    const resolved: AskAnswerSelection[] = prompt.questions.map((_, i) => {
+      return { indices: [...(sel[i] ?? [])], other: (oth[i] ?? '').trim() }
     })
-    const anyAnswered = selections.some((s) => s.indices.length > 0 || (s.other ?? '').length > 0)
+    const anyAnswered = resolved.some((s) => s.indices.length > 0 || (s.other ?? '').length > 0)
     if (anyAnswered) {
-      onAnswer(selections)
+      onAnswer(resolved)
     }
   }
 
   // Advance to the next question, or submit on the last one — always from an
   // explicit snapshot so a just-committed single-select pick isn't lost to the
   // async setState.
-  const advanceOrSubmit = (sel: string[][], oth: string[]): void => {
+  const advanceOrSubmit = (sel: number[][], oth: string[]): void => {
     if (isLast) {
       submitAll(sel, oth)
     } else {
@@ -88,14 +82,16 @@ export function NativeChatQuestionCard({
   // Selecting only highlights the row; submitting is an explicit step via the
   // trailing Send/Next button. (Auto-submitting on the first click dismissed the
   // card before the user saw any feedback, which read as "nothing happened".)
-  const pickOption = (label: string): void => {
+  const pickOption = (optionIndex: number): void => {
     setSelections((prev) => {
       const next = prev.map((s) => [...s])
       const cur = next[index] ?? []
       if (q.multiSelect) {
-        next[index] = cur.includes(label) ? cur.filter((l) => l !== label) : [...cur, label]
+        next[index] = cur.includes(optionIndex)
+          ? cur.filter((pickedIndex) => pickedIndex !== optionIndex)
+          : [...cur, optionIndex].sort((a, b) => a - b)
       } else {
-        next[index] = cur.includes(label) ? [] : [label]
+        next[index] = cur.includes(optionIndex) ? [] : [optionIndex]
       }
       return next
     })
@@ -177,12 +173,12 @@ export function NativeChatQuestionCard({
           <div className="max-h-[50vh] divide-y divide-border/60 overflow-y-auto border-t border-border scrollbar-sleek">
             {q.options.map((opt, i) => (
               <OptionRow
-                key={opt.label}
+                key={`${i}:${opt.label}`}
                 badge={String(i + 1)}
                 label={opt.label}
                 description={opt.description}
-                selected={(selections[index] ?? []).includes(opt.label)}
-                onSelect={() => pickOption(opt.label)}
+                selected={(selections[index] ?? []).includes(i)}
+                onSelect={() => pickOption(i)}
               />
             ))}
             <div className="flex items-center gap-3 px-3.5 py-2.5">

--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
@@ -6,6 +6,8 @@ import type { AskAnswerSelection, AskPrompt } from './native-chat-interactive-pr
 
 export type NativeChatQuestionCardProps = {
   prompt: AskPrompt
+  /** Whether the snapshotted answer is still being delivered to the agent. */
+  isSubmitting?: boolean
   /** Deliver the chosen answer (per-question option indices + free text). */
   onAnswer: (selections: AskAnswerSelection[]) => void
   /** Dismiss the prompt (sends Escape to the agent). */
@@ -24,6 +26,7 @@ export type NativeChatQuestionCardProps = {
  */
 export function NativeChatQuestionCard({
   prompt,
+  isSubmitting = false,
   onAnswer,
   onCancel,
   answerInputRef
@@ -120,7 +123,7 @@ export function NativeChatQuestionCard({
     // Part of the composer: docked in the bottom input region, matching the
     // composer's width and padding, rendered as the "ask" dialog card directly
     // above the text input. Its free-text row is the answer input.
-    <div className="shrink-0 bg-background">
+    <div className="shrink-0 bg-background" aria-busy={isSubmitting}>
       <div className="mx-auto w-full max-w-4xl px-3 pt-2 pb-4 sm:px-4">
         {total > 1 ? (
           <div className="mb-2 flex gap-1 overflow-x-auto pb-1 scrollbar-sleek">
@@ -128,9 +131,10 @@ export function NativeChatQuestionCard({
               <button
                 key={i}
                 type="button"
+                disabled={isSubmitting}
                 onClick={() => setIndex(i)}
                 className={cn(
-                  'flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs font-medium',
+                  'flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs font-medium disabled:pointer-events-none',
                   i === index
                     ? 'bg-accent text-accent-foreground'
                     : 'text-muted-foreground hover:text-foreground'
@@ -178,6 +182,7 @@ export function NativeChatQuestionCard({
                 label={opt.label}
                 description={opt.description}
                 selected={(selections[index] ?? []).includes(i)}
+                disabled={isSubmitting}
                 onSelect={() => pickOption(i)}
               />
             ))}
@@ -187,6 +192,7 @@ export function NativeChatQuestionCard({
               </span>
               <input
                 ref={answerInputRef}
+                disabled={isSubmitting}
                 value={otherText[index]}
                 onChange={(e) => setOther(index, e.target.value)}
                 onKeyDown={(e) => {
@@ -199,23 +205,26 @@ export function NativeChatQuestionCard({
                   'components.native-chat.question.otherPlaceholder',
                   'Type your answer'
                 )}
-                className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/60"
+                className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/60 disabled:cursor-default disabled:opacity-50"
               />
               <button
                 type="button"
+                disabled={isSubmitting}
                 onClick={() => confirm()}
                 className={cn(
-                  'shrink-0 rounded-md px-3 py-1 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  'w-24 shrink-0 rounded-md px-3 py-1 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-50',
                   currentAnswered
                     ? 'bg-primary text-primary-foreground hover:bg-primary/90'
                     : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                 )}
               >
-                {currentAnswered
-                  ? isLast
-                    ? translate('components.native-chat.question.send', 'Send answer')
-                    : translate('components.native-chat.question.next', 'Next')
-                  : translate('components.native-chat.question.skip', 'Skip')}
+                {isSubmitting
+                  ? translate('components.native-chat.question.sending', 'Sending…')
+                  : currentAnswered
+                    ? isLast
+                      ? translate('components.native-chat.question.send', 'Send answer')
+                      : translate('components.native-chat.question.next', 'Next')
+                    : translate('components.native-chat.question.skip', 'Skip')}
               </button>
             </div>
           </div>
@@ -236,23 +245,26 @@ function OptionRow({
   label,
   description,
   selected,
+  disabled,
   onSelect
 }: {
   badge: string
   label: string
   description?: string
   selected: boolean
+  disabled: boolean
   onSelect: () => void
 }): React.JSX.Element {
   return (
     <button
       type="button"
+      disabled={disabled}
       onClick={onSelect}
       // Selection is otherwise only the visual check/badge swap; expose it to
       // assistive tech.
       aria-pressed={selected}
       className={cn(
-        'flex w-full items-center gap-3 px-3.5 py-2.5 text-left transition-colors',
+        'flex w-full items-center gap-3 px-3.5 py-2.5 text-left transition-colors disabled:pointer-events-none',
         selected ? 'bg-accent' : 'hover:bg-accent'
       )}
     >

--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
@@ -2,12 +2,12 @@ import { useState, type RefObject } from 'react'
 import { Check, Pencil, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
-import { formatAskAnswer, type AskPrompt } from './native-chat-interactive-prompt'
+import type { AskAnswerSelection, AskPrompt } from './native-chat-interactive-prompt'
 
 export type NativeChatQuestionCardProps = {
   prompt: AskPrompt
-  /** Send the formatted answer text to the agent. */
-  onAnswer: (text: string) => void
+  /** Deliver the chosen answer (per-question option indices + free text). */
+  onAnswer: (selections: AskAnswerSelection[]) => void
   /** Dismiss the prompt (sends Escape to the agent). */
   onCancel: () => void
   /** Exposes the free-text row so pane-level Paste can target it while the
@@ -53,15 +53,24 @@ export function NativeChatQuestionCard({
 
   const currentAnswered = answerFor(index).length > 0
 
+  // Resolve the card's label-keyed selection state into per-question option
+  // INDICES (in option order) + trimmed free text, the index-based shape the
+  // answer is delivered by (the agent's selector commits by option number, not
+  // by label — STA-1860).
   const submitAll = (sel: string[][], oth: string[]): void => {
-    const resolved = prompt.questions.map((_, i) => {
+    const selections: AskAnswerSelection[] = prompt.questions.map((question, i) => {
       const picked = sel[i] ?? []
-      const other = (oth[i] ?? '').trim()
-      return [...picked, ...(other ? [other] : [])]
+      const indices = question.options.reduce<number[]>((acc, opt, oi) => {
+        if (picked.includes(opt.label)) {
+          acc.push(oi)
+        }
+        return acc
+      }, [])
+      return { indices, other: (oth[i] ?? '').trim() }
     })
-    const text = formatAskAnswer(prompt, resolved)
-    if (text.length > 0) {
-      onAnswer(text)
+    const anyAnswered = selections.some((s) => s.indices.length > 0 || (s.other ?? '').length > 0)
+    if (anyAnswered) {
+      onAnswer(selections)
     }
   }
 

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildAskAnswerKeys,
   formatAskAnswer,
+  hasAskAnswer,
   parseApprovalFromStatus,
   parseAskFromStatus,
-  parseInteractivePrompt
+  parseInteractivePrompt,
+  type AskPrompt
 } from './native-chat-interactive-prompt'
 
 const ESC = String.fromCharCode(27)
@@ -129,37 +132,119 @@ describe('parseInteractivePrompt', () => {
 })
 
 describe('formatAskAnswer', () => {
-  it('joins selected labels per question, one line each', () => {
-    const prompt = {
+  it('joins selected option labels per question, one line each', () => {
+    const prompt: AskPrompt = {
       questions: [
         { question: 'q1', multiSelect: true, options: [{ label: 'A' }, { label: 'B' }] },
         { question: 'q2', multiSelect: false, options: [{ label: 'C' }] }
       ]
     }
-    expect(formatAskAnswer(prompt, [['A', 'B'], ['C']])).toBe('A, B\nC')
+    expect(formatAskAnswer(prompt, [{ indices: [0, 1] }, { indices: [0] }])).toBe('A, B\nC')
+  })
+
+  it('appends free-text after picked labels', () => {
+    const prompt: AskPrompt = {
+      questions: [{ question: 'q1', multiSelect: true, options: [{ label: 'A' }, { label: 'B' }] }]
+    }
+    expect(formatAskAnswer(prompt, [{ indices: [0], other: '  extra ' }])).toBe('A, extra')
   })
 
   it('preserves empty answers as empty lines so N lines == N questions', () => {
-    const prompt = {
+    const prompt: AskPrompt = {
       questions: [
         { question: 'q1', multiSelect: false, options: [{ label: 'A' }] },
         { question: 'q2', multiSelect: false, options: [{ label: 'B' }] }
       ]
     }
     // Leading blank stays an empty line: '\nB' (2 lines), not 'B'.
-    expect(formatAskAnswer(prompt, [[], ['B']])).toBe('\nB')
+    expect(formatAskAnswer(prompt, [{ indices: [] }, { indices: [0] }])).toBe('\nB')
   })
 
   it('keeps one line per question with a blank middle answer (3 questions)', () => {
-    const prompt = {
+    const prompt: AskPrompt = {
       questions: [
         { question: 'q1', multiSelect: false, options: [{ label: 'A' }] },
         { question: 'q2', multiSelect: false, options: [{ label: 'B' }] },
         { question: 'q3', multiSelect: false, options: [{ label: 'C' }] }
       ]
     }
-    const answer = formatAskAnswer(prompt, [['A'], [], ['C']])
+    const answer = formatAskAnswer(prompt, [{ indices: [0] }, { indices: [] }, { indices: [0] }])
     expect(answer).toBe('A\n\nC')
     expect(answer.split('\n')).toHaveLength(3)
+  })
+})
+
+const single = (options: string[], multiSelect = false): AskPrompt => ({
+  questions: [{ question: 'q', multiSelect, options: options.map((label) => ({ label })) }]
+})
+
+describe('buildAskAnswerKeys', () => {
+  it('single-select: sends the picked option NUMBER (not the label), no trailing Enter', () => {
+    // STA-1860 regression: picking the 2nd option must deliver the 2nd option.
+    // '2' is the selector marker Claude commits on; a label + Enter committed the
+    // highlighted default (option 1) instead.
+    expect(buildAskAnswerKeys(single(['Tabs', 'Spaces']), [{ indices: [1] }])).toEqual([
+      { raw: '2' }
+    ])
+    expect(buildAskAnswerKeys(single(['Apple', 'Banana', 'Cherry']), [{ indices: [2] }])).toEqual([
+      { raw: '3' }
+    ])
+  })
+
+  it('single-select free text: opens "Type something" then types the answer + Enter', () => {
+    expect(
+      buildAskAnswerKeys(single(['Tabs', 'Spaces']), [{ indices: [], other: 'Zebra' }])
+    ).toEqual([{ raw: '3' }, { text: 'Zebra' }, { raw: '\r' }])
+  })
+
+  it('multi-select: toggles each option NUMBER, then steps to Submit and confirms', () => {
+    expect(
+      buildAskAnswerKeys(single(['Apple', 'Banana', 'Cherry'], true), [{ indices: [0, 2] }])
+    ).toEqual([{ raw: '1' }, { raw: '3' }, { raw: '\x1b[C' }, { raw: '\r' }])
+  })
+
+  it('multi-question single-select: option numbers auto-advance, one final submit Enter', () => {
+    const prompt: AskPrompt = {
+      questions: [
+        { question: 'q1', multiSelect: false, options: [{ label: 'Tabs' }, { label: 'Spaces' }] },
+        {
+          question: 'q2',
+          multiSelect: false,
+          options: [{ label: 'Apple' }, { label: 'Banana' }, { label: 'Cherry' }]
+        }
+      ]
+    }
+    expect(buildAskAnswerKeys(prompt, [{ indices: [1] }, { indices: [2] }])).toEqual([
+      { raw: '2' },
+      { raw: '3' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('multi-question: steps past an unanswered question then submits', () => {
+    const prompt: AskPrompt = {
+      questions: [
+        { question: 'q1', multiSelect: false, options: [{ label: 'Tabs' }, { label: 'Spaces' }] },
+        { question: 'q2', multiSelect: false, options: [{ label: 'Apple' }, { label: 'Banana' }] }
+      ]
+    }
+    expect(buildAskAnswerKeys(prompt, [{ indices: [] }, { indices: [1] }])).toEqual([
+      { raw: '\x1b[C' },
+      { raw: '2' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('is empty when nothing is answered', () => {
+    expect(buildAskAnswerKeys(single(['Tabs', 'Spaces']), [{ indices: [] }])).toEqual([])
+  })
+})
+
+describe('hasAskAnswer', () => {
+  it('is true for a picked option or typed text, false when empty', () => {
+    expect(hasAskAnswer(single(['A', 'B']), [{ indices: [1] }])).toBe(true)
+    expect(hasAskAnswer(single(['A', 'B']), [{ indices: [], other: 'x' }])).toBe(true)
+    expect(hasAskAnswer(single(['A', 'B']), [{ indices: [], other: '  ' }])).toBe(false)
+    expect(hasAskAnswer(single(['A', 'B']), [])).toBe(false)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.ts
@@ -190,11 +190,112 @@ export function parseInteractivePrompt(
   return null
 }
 
-/** Build the answer text to send: exactly one line per question, in question
- *  order, each line the selected option label(s) joined by ", ". Empty answers
- *  stay as empty lines (not dropped) so N lines always == N questions — the
- *  per-question Enter stepping counts one Enter per line, so dropping a blank
- *  middle answer would misalign the count and leave the prompt unsubmitted. */
-export function formatAskAnswer(prompt: AskPrompt, selections: string[][]): string {
-  return prompt.questions.map((_, i) => (selections[i] ?? []).join(', ')).join('\n')
+/** One question's chosen answer, normalized for delivery: the selected option
+ *  indices (in option order) plus any free-text "other" answer. Index-based (not
+ *  label text) so the answer can be delivered by the selector's stable option
+ *  number — see `buildAskAnswerKeys`. */
+export type AskAnswerSelection = { indices: number[]; other?: string }
+
+/** A single keystroke group to write to the agent PTY. `raw` bytes (option
+ *  numbers, Enter, arrows) are written verbatim as keystrokes; `text` is a
+ *  free-text answer the caller runs through its paste sanitizer before writing. */
+export type AskAnswerKeyGroup = { raw: string } | { text: string }
+
+/** True when this question is answered (a picked option or typed free text). */
+function isAnswered(sel: AskAnswerSelection | undefined): boolean {
+  return (sel?.indices.length ?? 0) > 0 || (sel?.other ?? '').trim().length > 0
+}
+
+/** The picked labels + trimmed free text for one question, in option order. */
+function answerLabels(question: AskQuestion, sel: AskAnswerSelection | undefined): string[] {
+  const labels = (sel?.indices ?? [])
+    .map((i) => question.options[i]?.label ?? '')
+    .filter((l) => l.length > 0)
+  const other = (sel?.other ?? '').trim()
+  return other ? [...labels, other] : labels
+}
+
+/** Build the human-readable answer text: one line per question, in question
+ *  order, each the selected label(s) + free text joined by ", ". Empty answers
+ *  stay empty lines so N lines always == N questions. Used for agents whose
+ *  question tool commits a pasted answer (not Claude's arrow-navigate selector). */
+export function formatAskAnswer(prompt: AskPrompt, selections: AskAnswerSelection[]): string {
+  return prompt.questions.map((q, i) => answerLabels(q, selections[i]).join(', ')).join('\n')
+}
+
+// Claude's AskUserQuestion is an arrow-navigate selector: a bare Enter commits
+// the HIGHLIGHTED default (the first option), and pasted label text does not move
+// the highlight — so answering by label silently delivered every non-first pick
+// as the first option (STA-1860). Instead we drive the selector by each option's
+// stable 1-based number (which matches the card's badge), the marker it commits
+// on. Right-arrow steps to the next question / the Submit tab. Verified live
+// against Claude Code's TUI; groups are written spaced apart (see the desktop
+// sender) because a navigation keystroke batched with Enter commits before the
+// selector has applied it.
+const ASK_ENTER = '\r'
+const ASK_NEXT_TAB = '\x1b[C'
+
+/** Build the ordered keystroke groups that answer a Claude Code AskUserQuestion.
+ *  Each group is written a step apart so the selector applies it before the next.
+ *
+ *  - single-select pick  → the option number (selects AND commits; in a
+ *    multi-question prompt it auto-advances to the next question)
+ *  - free-text answer    → the "Type something" row number, the text, then Enter
+ *  - multi-select        → each option number TOGGLES its checkbox, then a step
+ *    to the Submit tab
+ *  - a multi-question prompt (and a lone multi-select) finishes on a Submit
+ *    confirmation, so it ends with one Enter
+ *
+ *  (Option counts are ≤ the tool's cap of a few, so single-digit numbers always
+ *  address every row.) */
+export function buildAskAnswerKeys(
+  prompt: AskPrompt,
+  selections: AskAnswerSelection[]
+): AskAnswerKeyGroup[] {
+  const questions = prompt.questions
+  const multiQuestion = questions.length > 1
+  const groups: AskAnswerKeyGroup[] = []
+
+  questions.forEach((q, qi) => {
+    const sel = selections[qi]
+    const other = (sel?.other ?? '').trim()
+    const typeSomething = String(q.options.length + 1)
+
+    if (q.multiSelect) {
+      for (const i of sel?.indices ?? []) {
+        groups.push({ raw: String(i + 1) })
+      }
+      if (other) {
+        groups.push({ raw: typeSomething }, { text: other }, { raw: ASK_ENTER })
+      }
+      // A multi-select never auto-advances; step to the next tab (the Submit tab
+      // when this is the last question).
+      groups.push({ raw: ASK_NEXT_TAB })
+    } else if (other) {
+      // Single-select can only carry one value, so route any answer that
+      // includes free text through the "Type something" row as one string.
+      groups.push(
+        { raw: typeSomething },
+        { text: answerLabels(q, sel).join(', ') },
+        { raw: ASK_ENTER }
+      )
+    } else if ((sel?.indices.length ?? 0) > 0) {
+      groups.push({ raw: String(sel!.indices[0]! + 1) })
+    } else if (multiQuestion) {
+      // Unanswered question in a multi-question prompt: step past it.
+      groups.push({ raw: ASK_NEXT_TAB })
+    }
+  })
+
+  const endsOnSubmitTab =
+    multiQuestion || (questions.length === 1 && questions[0]!.multiSelect === true)
+  if (endsOnSubmitTab && groups.length > 0) {
+    groups.push({ raw: ASK_ENTER })
+  }
+  return groups
+}
+
+/** Whether any question in `selections` carries an answer worth submitting. */
+export function hasAskAnswer(prompt: AskPrompt, selections: AskAnswerSelection[]): boolean {
+  return prompt.questions.some((_, i) => isAnswered(selections[i]))
 }

--- a/src/renderer/src/components/native-chat/native-chat-runtime-send.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-send.test.ts
@@ -11,8 +11,7 @@ import {
   sendNativeChatMessage,
   sendNativeChatMessageWithImageAttachments,
   submitNativeChatPrompt,
-  sendNativeChatAnswer,
-  nativeChatQuestionOffsets,
+  sendNativeChatAskAnswer,
   NATIVE_CHAT_IMAGE_ATTACHMENT_SETTLE_MS,
   NATIVE_CHAT_SUBMIT_DELAY_MS,
   NATIVE_CHAT_QUESTION_STEP_MS,
@@ -153,17 +152,7 @@ describe('empty prompt submit', () => {
   })
 })
 
-describe('nativeChatQuestionOffsets', () => {
-  it('paces each question a full step apart, Enter 500ms after its body', () => {
-    expect(NATIVE_CHAT_QUESTION_STEP_MS).toBe(1000)
-    expect(NATIVE_CHAT_ADVANCE_BUFFER_MS).toBe(500)
-    expect(nativeChatQuestionOffsets(0)).toEqual({ bodyAt: 0, enterAt: 500 })
-    expect(nativeChatQuestionOffsets(1)).toEqual({ bodyAt: 1000, enterAt: 1500 })
-    expect(nativeChatQuestionOffsets(2)).toEqual({ bodyAt: 2000, enterAt: 2500 })
-  })
-})
-
-describe('sendNativeChatAnswer', () => {
+describe('sendNativeChatAskAnswer', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     sendRuntimePtyInput.mockClear()
@@ -172,87 +161,72 @@ describe('sendNativeChatAnswer', () => {
     vi.useRealTimers()
   })
 
-  it('single-line answer behaves exactly like sendNativeChatMessage', () => {
-    sendNativeChatAnswer(SETTINGS, PTY, ['only one'])
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(1)
-    expect(sendRuntimePtyInput).toHaveBeenCalledWith(
-      SETTINGS,
-      PTY,
-      buildNativeChatPasteBytes('only one')
-    )
-    vi.advanceTimersByTime(NATIVE_CHAT_SUBMIT_DELAY_MS)
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(2)
-    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(SETTINGS, PTY, NATIVE_CHAT_SUBMIT)
+  it('paces each keystroke a full step apart (the proven submit gap + advance buffer)', () => {
+    expect(NATIVE_CHAT_QUESTION_STEP_MS).toBe(1000)
+    expect(NATIVE_CHAT_ADVANCE_BUFFER_MS).toBe(500)
   })
 
-  it('multi-line: 3 bodies + 3 Enters in order, each Enter 500ms after its body, next body only after prior Enter+buffer', () => {
-    const lines = ['answer one', 'answer two', 'answer three']
-    const handle = sendNativeChatAnswer(SETTINGS, PTY, lines)
-
-    expect(handle.settleAfterMs).toBe(nativeChatQuestionOffsets(lines.length - 1).enterAt)
-
-    // Nothing fires synchronously: even question 0's body is scheduled (setTimeout 0).
+  it('no writes and 0 settle for an empty keystroke list', () => {
+    const handle = sendNativeChatAskAnswer(SETTINGS, PTY, [])
+    expect(handle.settleAfterMs).toBe(0)
+    vi.runAllTimers()
     expect(sendRuntimePtyInput).toHaveBeenCalledTimes(0)
+  })
 
-    // t=0: question 0 body.
+  it('single option-number keystroke: fires at t=0, settles a submit gap later', () => {
+    // The STA-1860 fix: a lone single-select pick is delivered as the option
+    // NUMBER, with no trailing Enter (the number both selects and commits).
+    const handle = sendNativeChatAskAnswer(SETTINGS, PTY, [{ raw: '2' }])
+    expect(handle.settleAfterMs).toBe(NATIVE_CHAT_SUBMIT_DELAY_MS)
+
+    // Scheduled at t=0 (setTimeout 0), not written synchronously.
+    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(0)
     vi.advanceTimersByTime(0)
     expect(sendRuntimePtyInput).toHaveBeenCalledTimes(1)
-    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(
-      SETTINGS,
-      PTY,
-      buildNativeChatPasteBytes('answer one')
-    )
-
-    // t=500: question 0 Enter (500ms after its body); question 1 body NOT yet.
-    vi.advanceTimersByTime(NATIVE_CHAT_SUBMIT_DELAY_MS)
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(2)
-    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(SETTINGS, PTY, NATIVE_CHAT_SUBMIT)
-
-    // Question 1 body must wait the advance buffer past question 0's Enter.
-    vi.advanceTimersByTime(NATIVE_CHAT_ADVANCE_BUFFER_MS - 1)
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(2)
-
-    // t=800: question 1 body.
-    vi.advanceTimersByTime(1)
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(3)
-    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(
-      SETTINGS,
-      PTY,
-      buildNativeChatPasteBytes('answer two')
-    )
-
-    // t=1300: question 1 Enter.
-    vi.advanceTimersByTime(NATIVE_CHAT_SUBMIT_DELAY_MS)
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(4)
-    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(SETTINGS, PTY, NATIVE_CHAT_SUBMIT)
-
-    // t=1600: question 2 body.
-    vi.advanceTimersByTime(NATIVE_CHAT_ADVANCE_BUFFER_MS)
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(5)
-    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(
-      SETTINGS,
-      PTY,
-      buildNativeChatPasteBytes('answer three')
-    )
-
-    // t=2100: question 2 Enter — the final submit. No trailing writes after.
-    vi.advanceTimersByTime(NATIVE_CHAT_SUBMIT_DELAY_MS)
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(6)
-    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(SETTINGS, PTY, NATIVE_CHAT_SUBMIT)
-
-    // Exactly 3 bodies + 3 Enters; running all timers adds nothing more.
+    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(SETTINGS, PTY, '2')
     vi.runAllTimers()
-    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(6)
+    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(1)
+  })
 
-    // Verify body/Enter ordering across the whole sequence.
+  it('writes each group a step apart; text groups go through the paste framer', () => {
+    const groups = [{ raw: '3' }, { text: 'custom answer' }, { raw: '\r' }]
+    const handle = sendNativeChatAskAnswer(SETTINGS, PTY, groups)
+    expect(handle.settleAfterMs).toBe(
+      2 * NATIVE_CHAT_QUESTION_STEP_MS + NATIVE_CHAT_SUBMIT_DELAY_MS
+    )
+
+    vi.advanceTimersByTime(0)
+    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(SETTINGS, PTY, '3')
+
+    // The next group must wait a full step so the "Type something" row renders.
+    vi.advanceTimersByTime(NATIVE_CHAT_QUESTION_STEP_MS - 1)
+    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1)
+    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(
+      SETTINGS,
+      PTY,
+      buildNativeChatPasteBytes('custom answer')
+    )
+
+    vi.advanceTimersByTime(NATIVE_CHAT_QUESTION_STEP_MS)
+    expect(sendRuntimePtyInput).toHaveBeenLastCalledWith(SETTINGS, PTY, NATIVE_CHAT_SUBMIT)
+
+    vi.runAllTimers()
     const calls = sendRuntimePtyInput.mock.calls.map((c) => c[2])
-    expect(calls).toEqual([
-      buildNativeChatPasteBytes('answer one'),
-      NATIVE_CHAT_SUBMIT,
-      buildNativeChatPasteBytes('answer two'),
-      NATIVE_CHAT_SUBMIT,
-      buildNativeChatPasteBytes('answer three'),
-      NATIVE_CHAT_SUBMIT
+    expect(calls).toEqual(['3', buildNativeChatPasteBytes('custom answer'), NATIVE_CHAT_SUBMIT])
+  })
+
+  it('cancel clears every pending keystroke', () => {
+    const handle = sendNativeChatAskAnswer(SETTINGS, PTY, [
+      { raw: '1' },
+      { raw: '\x1b[C' },
+      { raw: '\r' }
     ])
+    vi.advanceTimersByTime(0)
+    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(1)
+    handle.cancel()
+    vi.runAllTimers()
+    // Only the first keystroke landed; the rest were cancelled.
+    expect(sendRuntimePtyInput).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-runtime-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-send.ts
@@ -4,6 +4,7 @@
 
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import type { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
+import type { AskAnswerKeyGroup } from './native-chat-interactive-prompt'
 import {
   buildNativeChatImagePasteBytes,
   buildNativeChatPasteBytes,
@@ -21,35 +22,20 @@ import {
 export const NATIVE_CHAT_SUBMIT_DELAY_MS = 500
 export const NATIVE_CHAT_IMAGE_ATTACHMENT_SETTLE_MS = 300
 
-// Why: Claude Code's AskUserQuestion is a MULTI-STEP prompt — it renders one
-// question at a time and each Enter advances to the next (the final Enter
-// submits the whole thing). After firing a question's Enter we must let the TUI
-// render the next question before writing its body, or that body lands on the
-// wrong (or no) active question. This buffer is added ON TOP of the body→Enter
-// gap; a previous attempt that spaced Enters only ~350ms apart fired them faster
-// than the next question rendered, leaking answers as fresh prompts. Kept
-// generous so the next step still renders in time on slower machines / under SSH
+// Why: answering Claude's AskUserQuestion is a MULTI-STEP keystroke sequence
+// (select an option, advance to the next question, land on Submit). Each step
+// re-renders the selector, and a keystroke sent before the next step has
+// rendered — or an Enter batched with the navigation before it — lands on the
+// wrong (or no) row. This buffer pads the between-keystroke gap so each step
+// renders first; kept generous so it still holds on slower machines / under SSH
 // round-trip latency, where a tighter cadence misfires the answer.
 export const NATIVE_CHAT_ADVANCE_BUFFER_MS = 500
 
-/** Per-question wall-clock cadence: body→Enter gap plus the advance buffer that
- *  lets the next AskUserQuestion step render before its body is written. */
+/** Wall-clock gap between successive AskUserQuestion keystroke groups: the proven
+ *  pty submit gap plus the advance buffer that lets each selector step render
+ *  before the next keystroke is written. */
 export const NATIVE_CHAT_QUESTION_STEP_MS =
   NATIVE_CHAT_SUBMIT_DELAY_MS + NATIVE_CHAT_ADVANCE_BUFFER_MS
-
-/** Pure scheduling math for a per-question answer sequence. For question index
- *  `i` (0-based) returns the offsets (ms from the start of the send) at which to
- *  write its framed body and its Enter. Body for question 0 fires at 0; each
- *  later question starts a full step after the previous, so its body is never
- *  written until the previous question's Enter has fired plus the advance
- *  buffer. Exactly one Enter per question; the last Enter submits the prompt. */
-export function nativeChatQuestionOffsets(index: number): {
-  bodyAt: number
-  enterAt: number
-} {
-  const bodyAt = index * NATIVE_CHAT_QUESTION_STEP_MS
-  return { bodyAt, enterAt: bodyAt + NATIVE_CHAT_SUBMIT_DELAY_MS }
-}
 
 /** Cancels an in-flight send's pending pty writes (the delayed Enter, and any
  *  later question bodies/Enters). Safe to call after the send completes. */
@@ -131,35 +117,30 @@ export function submitNativeChatPrompt(
 }
 
 /**
- * Send an AskUserQuestion answer that may span multiple questions. Each line is
- * one question's answer (exactly how `formatAskAnswer` builds it). A single line
- * is just `sendNativeChatMessage` (no behavior change). For multiple lines we
- * write each question's framed body then its Enter as a per-question sequence,
- * paced by `NATIVE_CHAT_QUESTION_STEP_MS` so each Enter lands on its own
- * rendered question and the LAST Enter submits — exactly N Enters for N lines,
- * never a trailing one. Returns a cancel handle that clears every pending timer
- * so a detached sequence can't keep writing PTY bytes after unmount/stop.
+ * Answer Claude's AskUserQuestion by writing its keystroke groups (built by
+ * `buildAskAnswerKeys`) to the PTY, one group per `NATIVE_CHAT_QUESTION_STEP_MS`
+ * step so the arrow-navigate selector applies each before the next — a
+ * navigation/number keystroke batched with the Enter that follows would commit
+ * the wrong (default) option. `raw` groups are written verbatim as keystrokes;
+ * `text` groups (a free-text answer) go through the composer's paste framing.
+ * Returns a cancel handle clearing every pending timer so a detached sequence
+ * can't keep writing PTY bytes after unmount/stop.
  */
-export function sendNativeChatAnswer(
+export function sendNativeChatAskAnswer(
   settings: ReturnType<typeof getSettingsForAgentTabRuntimeOwner>,
   ptyId: string,
-  lines: string[]
+  groups: AskAnswerKeyGroup[]
 ): NativeChatSendHandle {
-  if (lines.length <= 1) {
-    return sendNativeChatMessage(settings, ptyId, lines[0] ?? '')
+  if (groups.length === 0) {
+    return { cancel: () => {}, settleAfterMs: 0 }
   }
   const timers: ReturnType<typeof setTimeout>[] = []
-  lines.forEach((line, index) => {
-    const { bodyAt, enterAt } = nativeChatQuestionOffsets(index)
+  groups.forEach((group, index) => {
     timers.push(
       setTimeout(() => {
-        sendRuntimePtyInput(settings, ptyId, buildNativeChatPasteBytes(line))
-      }, bodyAt)
-    )
-    timers.push(
-      setTimeout(() => {
-        sendRuntimePtyInput(settings, ptyId, NATIVE_CHAT_SUBMIT)
-      }, enterAt)
+        const bytes = 'raw' in group ? group.raw : buildNativeChatPasteBytes(group.text)
+        sendRuntimePtyInput(settings, ptyId, bytes)
+      }, index * NATIVE_CHAT_QUESTION_STEP_MS)
     )
   })
   return {
@@ -168,6 +149,7 @@ export function sendNativeChatAnswer(
         clearTimeout(timer)
       }
     },
-    settleAfterMs: nativeChatQuestionOffsets(lines.length - 1).enterAt
+    // Hold the card until the last keystroke has fired and its submit gap passed.
+    settleAfterMs: (groups.length - 1) * NATIVE_CHAT_QUESTION_STEP_MS + NATIVE_CHAT_SUBMIT_DELAY_MS
   }
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
@@ -104,4 +104,14 @@ describe('useNativeChatInteractiveSend', () => {
       '\x1b'
     )
   })
+
+  it('can cancel delayed writes without interrupting the replacement prompt', () => {
+    const { result } = renderHook(() => useNativeChatInteractiveSend('tab-1', 'pty-1', 'claude'))
+
+    act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
+    act(() => result.current.cancelPending())
+
+    expect(mocks.cancel).toHaveBeenCalledOnce()
+    expect(mocks.sendRuntimePtyInput).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   cancel: vi.fn(),
   sendRuntimePtyInput: vi.fn(),
-  sendNativeChatAnswer: vi.fn(),
+  sendNativeChatAskAnswer: vi.fn(),
   sendNativeChatMessage: vi.fn()
 }))
 
@@ -19,18 +19,64 @@ vi.mock('@/lib/agent-paste-draft', () => ({
 }))
 
 vi.mock('./native-chat-runtime-send', () => ({
-  sendNativeChatAnswer: (...args: unknown[]) => mocks.sendNativeChatAnswer(...args),
+  sendNativeChatAskAnswer: (...args: unknown[]) => mocks.sendNativeChatAskAnswer(...args),
   sendNativeChatMessage: (...args: unknown[]) => mocks.sendNativeChatMessage(...args)
 }))
 
 import { useNativeChatInteractiveSend } from './use-native-chat-interactive-send'
+import type { AskPrompt } from './native-chat-interactive-prompt'
+
+const PROMPT: AskPrompt = {
+  questions: [{ question: 'q', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] }]
+}
 
 describe('useNativeChatInteractiveSend', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     const handle = { cancel: mocks.cancel, settleAfterMs: 500 }
-    mocks.sendNativeChatAnswer.mockReturnValue(handle)
+    mocks.sendNativeChatAskAnswer.mockReturnValue(handle)
     mocks.sendNativeChatMessage.mockReturnValue(handle)
+  })
+
+  it('routes a non-Claude answer through the pasted-text send path', () => {
+    const { result } = renderHook(() => useNativeChatInteractiveSend('tab-1', 'pty-1', 'codex'))
+
+    act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
+
+    // Codex commits a pasted answer: label text 'B', not option-number keystrokes.
+    expect(mocks.sendNativeChatMessage).toHaveBeenCalledWith(
+      { terminalTabId: 'tab-1' },
+      'pty-1',
+      'B'
+    )
+    expect(mocks.sendNativeChatAskAnswer).not.toHaveBeenCalled()
+  })
+
+  it('routes a Claude answer through the option-number keystroke path', () => {
+    const { result } = renderHook(() => useNativeChatInteractiveSend('tab-1', 'pty-1', 'claude'))
+
+    act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
+
+    // The 2nd option is delivered as its number '2', not the label 'B' (STA-1860).
+    expect(mocks.sendNativeChatAskAnswer).toHaveBeenCalledWith(
+      { terminalTabId: 'tab-1' },
+      'pty-1',
+      [{ raw: '2' }]
+    )
+    expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when no option is answered', () => {
+    const { result } = renderHook(() => useNativeChatInteractiveSend('tab-1', 'pty-1', 'claude'))
+
+    let settleMs = -1
+    act(() => {
+      settleMs = result.current.sendAnswer(PROMPT, [{ indices: [] }])
+    })
+
+    expect(settleMs).toBe(0)
+    expect(mocks.sendNativeChatAskAnswer).not.toHaveBeenCalled()
+    expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()
   })
 
   it('cancels delayed answer writes when the PTY target changes', () => {
@@ -39,7 +85,7 @@ describe('useNativeChatInteractiveSend', () => {
       { initialProps: { targetPtyId: 'pty-1' as string | null } }
     )
 
-    act(() => result.current.sendAnswer('continue'))
+    act(() => result.current.sendAnswer(PROMPT, [{ indices: [0] }]))
     rerender({ targetPtyId: 'pty-2' })
 
     expect(mocks.cancel).toHaveBeenCalledOnce()
@@ -48,7 +94,7 @@ describe('useNativeChatInteractiveSend', () => {
   it('cancels delayed answer writes before interrupting the active PTY', () => {
     const { result } = renderHook(() => useNativeChatInteractiveSend('tab-1', 'pty-1', 'claude'))
 
-    act(() => result.current.sendAnswer('one\ntwo'))
+    act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
     act(() => result.current.cancel())
 
     expect(mocks.cancel).toHaveBeenCalledOnce()

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
@@ -26,6 +26,8 @@ export type NativeChatInteractiveSend = {
   sendAnswer: (prompt: AskPrompt, selections: AskAnswerSelection[]) => number
   /** Send a raw control string (e.g. an approval option number or ESC) as-is. */
   sendRaw: (raw: string) => void
+  /** Stop delayed writes without interrupting the agent. */
+  cancelPending: () => void
   /** Send ESC to interrupt — cancels a question / denies an approval. */
   cancel: () => void
 }
@@ -94,5 +96,5 @@ export function useNativeChatInteractiveSend(
     sendRaw(ESC)
   }, [cancelInFlight, sendRaw])
 
-  return { sendAnswer, sendRaw, cancel }
+  return { sendAnswer, sendRaw, cancelPending: cancelInFlight, cancel }
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
@@ -3,7 +3,14 @@ import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
 import type { AgentType } from '../../../../shared/native-chat-types'
 import {
-  sendNativeChatAnswer,
+  buildAskAnswerKeys,
+  formatAskAnswer,
+  hasAskAnswer,
+  type AskAnswerSelection,
+  type AskPrompt
+} from './native-chat-interactive-prompt'
+import {
+  sendNativeChatAskAnswer,
   sendNativeChatMessage,
   type NativeChatSendHandle
 } from './native-chat-runtime-send'
@@ -13,10 +20,10 @@ import {
 const ESC = '\x1b'
 
 export type NativeChatInteractiveSend = {
-  /** Send answer text (bracketed-paste wrapped + Enter, like the composer).
-   *  Returns the ms after which every scheduled write has fired (0 if nothing
-   *  was sent) so the caller can keep the card up until the send settles. */
-  sendAnswer: (text: string) => number
+  /** Deliver the answer to an AskUserQuestion prompt. Returns the ms after which
+   *  every scheduled write has fired (0 if nothing was sent) so the caller can
+   *  keep the card up until the send settles. */
+  sendAnswer: (prompt: AskPrompt, selections: AskAnswerSelection[]) => number
   /** Send a raw control string (e.g. an approval option number or ESC) as-is. */
   sendRaw: (raw: string) => void
   /** Send ESC to interrupt — cancels a question / denies an approval. */
@@ -27,9 +34,10 @@ export type NativeChatInteractiveSend = {
  * Reuse the desktop composer's exact send path for the interactive cards:
  * resolve this tab's live ptyId + runtime owner settings, then write bytes via
  * `sendRuntimePtyInput` (which branches local pty:write vs remote runtime RPC,
- * so SSH panes work unchanged). Answers go through `sendNativeChatMessage`
- * (bracketed-paste framed body, then a separate delayed Enter); control strings
- * (option digits, ESC) are written raw so the agent reads them as keystrokes.
+ * so SSH panes work unchanged). Claude's AskUserQuestion answers are delivered
+ * as selector keystrokes (by option number, `sendNativeChatAskAnswer`); other
+ * agents' question tools commit a pasted answer, so those still go through
+ * `sendNativeChatMessage`. Control strings (option digits, ESC) are written raw.
  */
 export function useNativeChatInteractiveSend(
   terminalTabId: string,
@@ -59,27 +67,21 @@ export function useNativeChatInteractiveSend(
   )
 
   const sendAnswer = useCallback(
-    (text: string): number => {
-      if (text.trim() === '') {
-        return 0
-      }
-      if (!targetPtyId) {
+    (prompt: AskPrompt, selections: AskAnswerSelection[]): number => {
+      if (!targetPtyId || !hasAskAnswer(prompt, selections)) {
         return 0
       }
       // Cancel any prior in-flight answer before starting a new one.
       cancelInFlight()
       const settings = getSettingsForAgentTabRuntimeOwner(terminalTabId)
-      // Only Claude's AskUserQuestion is a MULTI-STEP prompt: one question per
-      // step, each Enter advances to the next, the final Enter submits. So a
-      // multi-line answer (one line per question, as `formatAskAnswer` builds
-      // it) is sent as a per-question sequence — body then its own Enter, paced
-      // so each Enter lands on its rendered question and only the last submits.
-      // Other agents (e.g. Codex) submit the whole answer with one Enter, so
-      // gate the stepping on Claude and send a single body + Enter otherwise.
-      const handle =
+      // Claude's AskUserQuestion is an arrow-navigate selector: it commits by the
+      // highlighted option, not a pasted label, so answer it with per-option
+      // keystrokes (by option number), paced so each step renders before the next.
+      // Other agents' question tools commit a pasted answer, so send label text.
+      const handle: NativeChatSendHandle =
         agent === 'claude'
-          ? sendNativeChatAnswer(settings, targetPtyId, text.split('\n'))
-          : sendNativeChatMessage(settings, targetPtyId, text)
+          ? sendNativeChatAskAnswer(settings, targetPtyId, buildAskAnswerKeys(prompt, selections))
+          : sendNativeChatMessage(settings, targetPtyId, formatAskAnswer(prompt, selections))
       inFlightRef.current = handle
       return handle.settleAfterMs
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13133,7 +13133,8 @@
         "cancel": "Cancel",
         "send": "Send answer",
         "next": "Next",
-        "skip": "Skip"
+        "skip": "Skip",
+        "sending": "Sending…"
       },
       "approval": {
         "title": "Allow {{value0}}?",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -13133,7 +13133,8 @@
         "cancel": "Cancelar",
         "send": "Enviar respuesta",
         "next": "Siguiente",
-        "skip": "Omitir"
+        "skip": "Omitir",
+        "sending": "Sending…"
       },
       "approval": {
         "title": "¿Permitir {{value0}}?",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -13134,7 +13134,7 @@
         "send": "Enviar respuesta",
         "next": "Siguiente",
         "skip": "Omitir",
-        "sending": "Sending…"
+        "sending": "Enviando…"
       },
       "approval": {
         "title": "¿Permitir {{value0}}?",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -13133,7 +13133,8 @@
         "cancel": "キャンセル",
         "send": "回答を送信する",
         "next": "次へ",
-        "skip": "スキップ"
+        "skip": "スキップ",
+        "sending": "Sending…"
       },
       "approval": {
         "title": "{{value0}} を許可しますか?",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -13134,7 +13134,7 @@
         "send": "回答を送信する",
         "next": "次へ",
         "skip": "スキップ",
-        "sending": "Sending…"
+        "sending": "送信中…"
       },
       "approval": {
         "title": "{{value0}} を許可しますか?",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -13134,7 +13134,7 @@
         "send": "답변 보내기",
         "next": "다음",
         "skip": "건너뛰기",
-        "sending": "Sending…"
+        "sending": "전송 중…"
       },
       "approval": {
         "title": "{{value0}}을(를) 허용하시겠습니까?",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -13133,7 +13133,8 @@
         "cancel": "취소",
         "send": "답변 보내기",
         "next": "다음",
-        "skip": "건너뛰기"
+        "skip": "건너뛰기",
+        "sending": "Sending…"
       },
       "approval": {
         "title": "{{value0}}을(를) 허용하시겠습니까?",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -13134,7 +13134,7 @@
         "send": "发送回答",
         "next": "下一步",
         "skip": "跳过",
-        "sending": "Sending…"
+        "sending": "正在发送…"
       },
       "approval": {
         "title": "允许 {{value0}}？",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -13133,7 +13133,8 @@
         "cancel": "取消",
         "send": "发送回答",
         "next": "下一步",
-        "skip": "跳过"
+        "skip": "跳过",
+        "sending": "Sending…"
       },
       "approval": {
         "title": "允许 {{value0}}？",


### PR DESCRIPTION
Fixes [STA-1860](https://linear.app/stably/issue/STA-1860/native-chat-askuserquestion-wrong-option-delivered-2nd-question-card) (Bug A). Pre-existing on `main`; independent of the mobile native-chat PR #5824.

## Bug A — wrong option delivered when answering AskUserQuestion

**Repro:** In the desktop native chat view, ask Claude Code to use the AskUserQuestion tool (e.g. options "Tabs" / "Spaces"). Pick **Spaces**, click **Send answer**.
**Before:** the agent receives **Tabs** (the first/default option). Terminal echo: `User answered … → Tabs`.
**After:** the agent receives the selected option (Spaces).

### Root cause

Claude Code's AskUserQuestion is an **arrow-navigate selector**: a bare Enter commits the **highlighted default** (the first option), and pasted label text does **not** move the highlight. The native chat delivered the answer as the option **label text + Enter** (`formatAskAnswer` → `sendNativeChatAnswer`), so the label was ignored and the trailing Enter committed the default. Every non-first pick was silently delivered as the first option.

### Fix

Deliver the answer by each option's stable **1-based number** — the marker the selector actually commits on, which already matches the card's badge number — instead of the label text. Keystrokes are written as separate groups paced one selector-step apart, because a navigation/number keystroke batched with the Enter that follows commits before the selector has applied the move.

Verified against the real Claude Code TUI (v2.1.210); covers every card shape:

| Case | Keystrokes |
|---|---|
| single-select pick | option number (selects + commits) |
| single-select free text | "Type something" number, the text, Enter |
| multi-select | each option number (toggles), right-arrow → Submit, Enter |
| multi-question | per-question number (auto-advances), one final Submit Enter |

Non-Claude agents (whose question tools commit a *pasted* answer) keep the label-text path via `formatAskAnswer`.

### Changes

- `native-chat-interactive-prompt.ts`: `buildAskAnswerKeys` + `AskAnswerSelection` / `AskAnswerKeyGroup` / `hasAskAnswer`; `formatAskAnswer` now takes the same index-based selections (kept for the non-Claude label path).
- `native-chat-runtime-send.ts`: `sendNativeChatAskAnswer` (paced keystroke-group sender) replaces the old label-line `sendNativeChatAnswer` / `nativeChatQuestionOffsets`.
- Card + interactive hook thread structured `{ indices, other }[]` selections instead of pre-joined answer text.

## Verification

- **Live, end-to-end** in a dev Electron build against real Claude Code 2.1.210, through the real native chat card: picked **Spaces** (non-default) → Send answer → Claude's TUI transcript showed `● User answered Claude's questions: · Do you prefer tabs or spaces? → Spaces` and it replied "You prefer **Spaces** for indentation." (Before the fix, the same flow delivered Tabs.)
- Unit + component tests: builder per-shape, paced sender, hook routing (Claude → numbers / others → label), and the card click → `{ indices: [1] }` resolution. Full native-chat suite green (402 tests); `typecheck` clean.

## Bug B (2nd-card render lag) — investigated, not fixed here

Characterized as a **transcript-sync** issue in a separate subsystem, so — per the ticket — this PR ships Bug A and notes Bug B for follow-up. The native chat view renders the conversation from Claude's on-disk transcript JSONL; Claude buffers/flushes it late (in repro, the session's `.jsonl` was never written while running), so the view falls into "Could not load conversation — No transcript found" and the 2nd tool-call turn (and, in that error state, its card) appear only once the transcript syncs — the multi-minute lag. The interactive card's own data (`interactivePrompt`) is hook-driven and populates promptly (verified: a 2nd question surfaced in <30s), so the lag is the transcript-load gate, not the answer/parse path.


## Follow-up: mobile + backcompat (must land on #5824)

**Mobile still has Bug A.** The mobile answer path (`mobile/src/session/use-mobile-native-chat-answer-send.ts` → `sendMobileNativeChatMessage`) still sends the option **label text**, so mobile AskUserQuestion answering delivers the wrong option too. Those files live on PR #5824 (not on `main`), so they can't be fixed here — the mobile port is a follow-up on **#5824**, reconciled with this change once #8840 merges.

**Backcompat is a hard requirement** (desktop and mobile update independently — either can update first). The answer→keystroke building must stay **client-side**: the desktop renderer and the mobile app each build their own keystrokes from the *local* selection and send them over the **existing write-keystrokes / PTY passthrough**. Do **not** add a new RPC method and do **not** move answer-formatting into the desktop runtime/server. That keeps every combination working:

- **new-desktop + old-mobile** — desktop native chat is fixed; mobile answering stays old until mobile updates; the connection is unaffected.
- **old-desktop-runtime + new-mobile** (the critical one) — new mobile builds the number keystrokes and sends them over the unchanged passthrough; the old runtime writes them verbatim → works.

The mobile fix must send **raw keystrokes** (numbers / arrows / Enter), like the permission card's `option.send` — **not** bracketed-paste text.

**This desktop fix already satisfies the constraint.** It is entirely renderer-local (all changes under `src/renderer/src/components/native-chat/`): the keystrokes are built in the renderer (`buildAskAnswerKeys`) and written verbatim via the *existing* `sendRuntimePtyInput` passthrough (local `pty.write` and the remote runtime write RPC are both unchanged). No new RPC/IPC method, no shared-contract change, and no answer-formatting on the runtime/server — so it composes with the mobile port and with an older runtime over SSH/relay.
