### PR TITLE
fix(terminal): filter stale Windows Codex focus reports after turns

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -16541,9 +16541,15 @@ describe('connectPanePty', () => {
         expect(deps.dispatchNotification).toHaveBeenCalledWith(expectedNotification)
       }
       expect(pane.terminal.write).toHaveBeenCalledWith(
-        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?1004l`,
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
         expect.any(Function)
       )
+      transport.sendInput.mockClear()
+      sendTerminalInputThroughPane(pane, '\x1b[I')
+      sendTerminalInputThroughPane(pane, '\x7f')
+      expect(transport.sendInput).toHaveBeenCalledTimes(2)
+      expect(transport.sendInput).toHaveBeenNthCalledWith(1, '\x1b[I')
+      expect(transport.sendInput).toHaveBeenLastCalledWith('\x7f')
     } finally {
       restoreUserAgent()
     }
@@ -16745,7 +16751,7 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('resets stale keyboard and focus-reporting state when a native Windows agent becomes idle', async () => {
+  it('resets stale keyboard state when a native Windows agent becomes idle', async () => {
     const restoreUserAgent = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     )
@@ -16770,7 +16776,7 @@ describe('connectPanePty', () => {
       idleHandler('* Codex done')
 
       expect(pane.terminal.write).toHaveBeenCalledWith(
-        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?1004l`,
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
         expect.any(Function)
       )
     } finally {
@@ -16815,12 +16821,73 @@ describe('connectPanePty', () => {
         `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
         expect.any(Function)
       )
+      transport.sendInput.mockClear()
+      sendTerminalInputThroughPane(pane, '\x1b[I')
+      expect(transport.sendInput).toHaveBeenCalledWith('\x1b[I')
     } finally {
       restoreUserAgent()
     }
   })
 
-  it('resets stale keyboard and focus-reporting state when native Windows hook status reaches done', async () => {
+  it.each([
+    {
+      name: 'WSL',
+      configure: (): void => {
+        mockStoreState.tabsByWorktree = {
+          'wt-1': [{ id: 'tab-1', ptyId: null, shellOverride: 'wsl.exe' }]
+        }
+      }
+    },
+    {
+      name: 'remote runtime',
+      configure: (): void => {
+        mockStoreState.repos = [
+          {
+            id: 'repo1',
+            connectionId: null,
+            displayName: 'orca',
+            executionHostId: 'runtime:owner-runtime'
+          }
+        ]
+      }
+    }
+  ])(
+    'keeps $name focus reports and idle reset remote-safe on Windows clients',
+    async ({ configure }) => {
+      const restoreUserAgent = temporarilySetNavigatorUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+      )
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+
+      try {
+        configure()
+        const pane = createPane(1)
+        connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+
+        const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
+          | ((title: string) => void)
+          | undefined
+        if (!idleHandler) {
+          throw new Error('Expected onAgentBecameIdle to be registered')
+        }
+        idleHandler('* Codex done')
+
+        expect(pane.terminal.write).toHaveBeenCalledWith(
+          RESET_TERMINAL_CURSOR_STYLE,
+          expect.any(Function)
+        )
+        transport.sendInput.mockClear()
+        sendTerminalInputThroughPane(pane, '\x1b[I')
+        expect(transport.sendInput).toHaveBeenCalledWith('\x1b[I')
+      } finally {
+        restoreUserAgent()
+      }
+    }
+  )
+
+  it('resets stale keyboard state when native Windows hook status reaches done', async () => {
     const restoreUserAgent = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     )
@@ -16848,7 +16915,7 @@ describe('connectPanePty', () => {
       notifyStoreSubscribers()
       expect(pane.terminal.write).not.toHaveBeenCalled()
 
-      mockStoreState.agentStatusByPaneKey[paneKey] = {
+      const doneStatus = {
         state: 'done',
         prompt: 'ship it',
         updatedAt: Date.now(),
@@ -16857,12 +16924,117 @@ describe('connectPanePty', () => {
         paneKey,
         stateHistory: []
       }
+      mockStoreState.agentStatusByPaneKey[paneKey] = doneStatus
       notifyStoreSubscribers()
 
       expect(pane.terminal.write).toHaveBeenCalledWith(
-        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?1004l`,
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
         expect.any(Function)
       )
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
+  it('drops only focus reports while native Windows Codex is done and resumes them when working', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const pane = createPane(1)
+      pane.terminal.modes.sendFocusMode = true
+      const doneStatus = {
+        state: 'done',
+        prompt: 'ship it',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'codex',
+        paneKey,
+        stateHistory: []
+      }
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = doneStatus
+      notifyStoreSubscribers()
+      const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
+        | ((title: string) => void)
+        | undefined
+      idleHandler?.('* Codex done')
+      transport.sendInput.mockClear()
+
+      sendTerminalInputThroughPane(pane, '\x1b[O')
+      sendTerminalInputThroughPane(pane, '\x1b[I')
+      expect(transport.sendInput).not.toHaveBeenCalled()
+
+      sendTerminalInputThroughPane(pane, '\x7f')
+      sendTerminalInputThroughPane(pane, 'x')
+      expect(transport.sendInput).toHaveBeenNthCalledWith(1, '\x7f')
+      expect(transport.sendInput).toHaveBeenNthCalledWith(2, 'x')
+      expect(pane.terminal.modes.sendFocusMode).toBe(true)
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        ...doneStatus,
+        state: 'working'
+      }
+      notifyStoreSubscribers()
+      transport.sendInput.mockClear()
+
+      sendTerminalInputThroughPane(pane, '\x1b[I')
+      expect(transport.sendInput).toHaveBeenCalledWith('\x1b[I')
+      expect(pane.terminal.modes.sendFocusMode).toBe(true)
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        ...doneStatus,
+        state: 'waiting'
+      }
+      notifyStoreSubscribers()
+      transport.sendInput.mockClear()
+      sendTerminalInputThroughPane(pane, '\x1b[O')
+      expect(transport.sendInput).toHaveBeenCalledWith('\x1b[O')
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
+  it('keeps focus reports enabled for native Windows Cursor completion', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const pane = createPane(1)
+      pane.terminal.modes.sendFocusMode = true
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'done',
+        prompt: 'ship it',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'cursor',
+        paneKey,
+        stateHistory: []
+      }
+      notifyStoreSubscribers()
+      transport.sendInput.mockClear()
+
+      sendTerminalInputThroughPane(pane, '\x1b[O')
+      sendTerminalInputThroughPane(pane, '\x1b[I')
+
+      expect(transport.sendInput).toHaveBeenNthCalledWith(1, '\x1b[O')
+      expect(transport.sendInput).toHaveBeenNthCalledWith(2, '\x1b[I')
+      expect(pane.terminal.modes.sendFocusMode).toBe(true)
     } finally {
       restoreUserAgent()
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -16541,7 +16541,7 @@ describe('connectPanePty', () => {
         expect(deps.dispatchNotification).toHaveBeenCalledWith(expectedNotification)
       }
       expect(pane.terminal.write).toHaveBeenCalledWith(
-        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?1004l`,
         expect.any(Function)
       )
     } finally {
@@ -16745,7 +16745,7 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('resets stale Kitty keyboard state when a native Windows agent becomes idle', async () => {
+  it('resets stale keyboard and focus-reporting state when a native Windows agent becomes idle', async () => {
     const restoreUserAgent = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     )
@@ -16770,7 +16770,7 @@ describe('connectPanePty', () => {
       idleHandler('* Codex done')
 
       expect(pane.terminal.write).toHaveBeenCalledWith(
-        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?1004l`,
         expect.any(Function)
       )
     } finally {
@@ -16820,7 +16820,7 @@ describe('connectPanePty', () => {
     }
   })
 
-  it('resets stale Kitty keyboard state when native Windows hook status reaches done', async () => {
+  it('resets stale keyboard and focus-reporting state when native Windows hook status reaches done', async () => {
     const restoreUserAgent = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     )
@@ -16860,7 +16860,7 @@ describe('connectPanePty', () => {
       notifyStoreSubscribers()
 
       expect(pane.terminal.write).toHaveBeenCalledWith(
-        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`,
+        `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}\x1b[?1004l`,
         expect.any(Function)
       )
     } finally {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3056,9 +3056,9 @@ export function connectPanePty(
     executionHostId
   })
   if (isNativeWindowsConpty) {
-    // Why: completed Windows ConPTY agent turns can leave xterm's renderer-side
-    // Kitty encoder enabled; clearing it restores plain Backspace/Enter input.
-    idleAgentTerminalModeReset = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`
+    // Why: Windows ConPTY agent turns can leave renderer keyboard/focus modes
+    // armed after completion, corrupting plain input with encoded or CSI bytes.
+    idleAgentTerminalModeReset = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}${FOCUS_REPORTING_DISABLE_SEQUENCE}`
   }
   const shouldApplyNativeWindowsRewriteRefresh = isNativeWindowsConpty
   const shouldApplyWindowsRendererUnicodeRefresh = CLIENT_PLATFORM === 'win32'

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -283,6 +283,7 @@ const SYNCHRONIZED_OUTPUT_MARKER_TAIL_CHARS = SYNCHRONIZED_OUTPUT_START_SEQUENCE
 const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
 const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
 const TERMINAL_FOCUS_IN_SEQUENCE = '\x1b[I'
+const TERMINAL_FOCUS_OUT_SEQUENCE = '\x1b[O'
 const FOCUS_REPORTING_DISABLE_SEQUENCE = '\x1b[?1004l'
 const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const SHIFT_ENTER_RECONFIRM_IDLE_MS = 350
@@ -1002,6 +1003,15 @@ export function connectPanePty(
   // exists. Start with the shared scheduler, then switch to the PTY writer
   // below so hidden-tab resets keep backlog-recovery callbacks and byte order.
   let idleAgentTerminalModeReset = RESET_TERMINAL_CURSOR_STYLE
+  let suppressNativeWindowsIdleCodexFocusReports = false
+  const setFocusReportSuppressionForAgentCompletion = (
+    title: string | undefined,
+    agentType: AgentType | undefined
+  ): void => {
+    const titleAgentType = resolveCommittedTitleAgentType(title ?? '')
+    suppressNativeWindowsIdleCodexFocusReports =
+      agentType && agentType !== 'unknown' ? agentType === 'codex' : titleAgentType === 'codex'
+  }
   let queueAgentIdleTerminalModeReset = (): void => {
     if (disposed) {
       return
@@ -1399,6 +1409,7 @@ export function connectPanePty(
     ) {
       deps.setCacheTimerStartedAt(cacheKey, Date.now())
     }
+    setFocusReportSuppressionForAgentCompletion(title, agentType)
     queueAgentIdleTerminalModeReset()
   }
   const preserveSuppressedTitleSideEffects = (
@@ -1410,6 +1421,7 @@ export function connectPanePty(
       agentType: activeHookStatus.agentType
     }
     if (activeHookStatus.state === 'waiting' || activeHookStatus.state === 'blocked') {
+      suppressNativeWindowsIdleCodexFocusReports = false
       queueAgentIdleTerminalModeReset()
     }
   }
@@ -1438,6 +1450,7 @@ export function connectPanePty(
       return
     }
     if (payload.state === 'waiting' || payload.state === 'blocked') {
+      suppressNativeWindowsIdleCodexFocusReports = false
       queueAgentIdleTerminalModeReset()
     }
   }
@@ -2204,6 +2217,10 @@ export function connectPanePty(
       if (meta?.terminalIdleConfirmed === true) {
         // Why: an agent can crash before its done hook; confirmed process death
         // must still restore cursor and native Windows Kitty keyboard modes.
+        const currentAgentStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]
+        if (!isFreshNonDoneAgentStatus(currentAgentStatus)) {
+          setFocusReportSuppressionForAgentCompletion(title, meta.agentStatus?.agentType)
+        }
         queueAgentIdleTerminalModeReset()
       }
       scheduleAgentTaskCompleteNotification(title, {
@@ -2971,6 +2988,9 @@ export function connectPanePty(
     if (isClaudeAgent(title) && (settings === null || settings.promptCacheTimerEnabled)) {
       deps.setCacheTimerStartedAt(cacheKey, Date.now())
     }
+    if (detectAgentStatusFromTitle(title) === 'idle') {
+      setFocusReportSuppressionForAgentCompletion(title, activeHookStatus?.agentType)
+    }
     if (syncAgentTaskCompleteTrackingEnabled()) {
       agentCompletionCoordinator.observeClassifiedTitleCompletion(title)
     }
@@ -2979,6 +2999,7 @@ export function connectPanePty(
     queueAgentIdleTerminalModeReset()
   }
   const onAgentBecameWorking = (): void => {
+    suppressNativeWindowsIdleCodexFocusReports = false
     clearSuppressedTitleSideEffects()
     if (syncAgentTaskCompleteTrackingEnabled()) {
       requiresFreshWorkingForAgentTaskCompleteNotification = false
@@ -3056,9 +3077,9 @@ export function connectPanePty(
     executionHostId
   })
   if (isNativeWindowsConpty) {
-    // Why: Windows ConPTY agent turns can leave renderer keyboard/focus modes
-    // armed after completion, corrupting plain input with encoded or CSI bytes.
-    idleAgentTerminalModeReset = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}${FOCUS_REPORTING_DISABLE_SEQUENCE}`
+    // Why: Windows ConPTY agent turns can leave renderer keyboard modes armed
+    // after completion, corrupting plain input with encoded bytes.
+    idleAgentTerminalModeReset = `${RESET_TERMINAL_CURSOR_STYLE}${RESET_KITTY_KEYBOARD_PROTOCOL}`
   }
   const shouldApplyNativeWindowsRewriteRefresh = isNativeWindowsConpty
   const shouldApplyWindowsRendererUnicodeRefresh = CLIENT_PLATFORM === 'win32'
@@ -3066,10 +3087,20 @@ export function connectPanePty(
   let lastAgentStatusState = state.agentStatusByPaneKey[cacheKey]?.state
   let unsubscribeWindowsDoneTerminalModeReset: (() => void) | null = null
   if (isNativeWindowsConpty) {
+    const initialAgentStatus = state.agentStatusByPaneKey[cacheKey]
+    if (initialAgentStatus?.state === 'done') {
+      setFocusReportSuppressionForAgentCompletion(undefined, initialAgentStatus.agentType)
+    }
     unsubscribeWindowsDoneTerminalModeReset = useAppStore.subscribe((nextState) => {
-      const nextAgentStatusState = nextState.agentStatusByPaneKey[cacheKey]?.state
-      if (lastAgentStatusState !== 'done' && nextAgentStatusState === 'done') {
-        queueAgentIdleTerminalModeReset()
+      const nextAgentStatus = nextState.agentStatusByPaneKey[cacheKey]
+      const nextAgentStatusState = nextAgentStatus?.state
+      if (nextAgentStatusState === 'done') {
+        setFocusReportSuppressionForAgentCompletion(undefined, nextAgentStatus.agentType)
+        if (lastAgentStatusState !== 'done') {
+          queueAgentIdleTerminalModeReset()
+        }
+      } else if (nextAgentStatusState) {
+        suppressNativeWindowsIdleCodexFocusReports = false
       }
       lastAgentStatusState = nextAgentStatusState
     })
@@ -3443,6 +3474,15 @@ export function connectPanePty(
     // explicit Take back action owns restoring desktop input and dimensions.
     if (currentPtyId && isPtyLocked(currentPtyId)) {
       clearPendingTerminalInputIntent()
+      return
+    }
+    if (
+      isNativeWindowsConpty &&
+      suppressNativeWindowsIdleCodexFocusReports &&
+      (data === TERMINAL_FOCUS_IN_SEQUENCE || data === TERMINAL_FOCUS_OUT_SEQUENCE)
+    ) {
+      // Why: Codex can leave focus reporting armed after a Windows turn, but
+      // disabling the mode would permanently silence focus events on resume.
       return
     }
     // Why: xterm answers CPR/DSR/DA queries natively through this same onData


### PR DESCRIPTION
## Summary

- filter exact xterm focus-out/focus-in reports only while native-Windows Codex is idle/done
- preserve the live TUI's focus-reporting mode so resumed turns and focus-driven cursor unparking keep working
- retain the existing native Windows Kitty keyboard cleanup while leaving Cursor, SSH, WSL, and remote-runtime focus behavior unchanged

## Root cause

The affected native Windows ConPTY session showed literal `[O[I` fragments while typing. Those are xterm focus-out/focus-in reports (`ESC [ O` / `ESC [ I`) reaching an idle Codex composer as input. The daemon snapshot confirmed Kitty keyboard flags were already `0`, while focus reporting remained armed (`?1004h`). DOM focus churn could therefore perturb the composer, making Backspace appear to insert spaces and causing typed text to jump.

## Fix

When Orca has authoritative completion evidence for Codex in a local native Windows ConPTY pane, it drops only the exact focus report input bytes. Backspace, text, terminal query replies, and all other input continue normally. The suppression clears as soon as Codex returns to working/waiting/blocked, and xterm's `sendFocusMode` is never mutated.

An adversarial review caught that the initial `?1004l` approach was too broad: the shared idle reset also runs for permission/waiting states and delayed live-agent reattach cleanup. Disabling the mode there could permanently mute focus for a still-running TUI because agents commonly arm it only at startup. This PR now preserves that mode instead.

## Validation

- `pnpm test -- src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 429 passed
- `pnpm run typecheck:web` — passed
- focused `oxlint` — passed
- focused `oxfmt --check` — passed
- `pnpm run check:max-lines-ratchet` — passed
- behavioral coverage verifies both focus reports are filtered only for completed native-Windows Codex, Backspace/text pass through, next-turn focus delivery resumes, Cursor is preserved, and SSH/WSL/remote-runtime paths remain unchanged

## Risk

Narrowly scoped to exact `ESC[I` / `ESC[O` input while a local native-Windows Codex pane is classified idle/done. The terminal mode remains owned by the TUI, avoiding behavior changes for resumed turns and focus-driven cursor handling.