### PR TITLE
Fix Windows Resource Manager memory and CPU attribution

### DIFF
--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import os from 'node:os'
 import type { MemorySnapshotStore } from './collector'
 
 type AppMetricFixture = {
@@ -8,8 +9,9 @@ type AppMetricFixture = {
   memory: { workingSetSize: number }
 }
 
-const { appMetricsMock, execMock, listRegisteredPtysMock } = vi.hoisted(() => ({
+const { appMetricsMock, execFileMock, execMock, listRegisteredPtysMock } = vi.hoisted(() => ({
   appMetricsMock: vi.fn<() => AppMetricFixture[]>(() => []),
+  execFileMock: vi.fn(),
   execMock: vi.fn(),
   listRegisteredPtysMock: vi.fn()
 }))
@@ -22,7 +24,13 @@ vi.mock('electron', () => ({
 
 vi.mock('child_process', () => ({
   exec: (cmd: string, opts: unknown, cb: (err: Error | null, out: { stdout: string }) => void) =>
-    execMock(cmd, opts, cb)
+    execMock(cmd, opts, cb),
+  execFile: (
+    file: string,
+    args: string[],
+    opts: unknown,
+    cb: (err: Error | null, stdout: string, stderr: string) => void
+  ) => execFileMock(file, args, opts, cb)
 }))
 
 vi.mock('./pty-registry', () => ({
@@ -102,48 +110,57 @@ describe('parsePsOutput', () => {
   })
 })
 
-describe('parseWmicOutput', () => {
-  it('emits one row per blank-line-delimited stanza', async () => {
-    const { parseWmicOutput } = await loadCollector()
-    const stdout = [
-      'ParentProcessId=1',
-      'ProcessId=100',
-      'WorkingSetSize=2048',
-      '',
-      'ParentProcessId=100',
-      'ProcessId=200',
-      'WorkingSetSize=1024',
-      ''
-    ].join('\r\n')
+describe('parseWindowsProcessOutput', () => {
+  it('parses tab-delimited CIM process rows', async () => {
+    const { parseWindowsProcessOutput } = await loadCollector()
 
-    const rows = parseWmicOutput(stdout)
-
-    expect(rows).toEqual([
+    expect(parseWindowsProcessOutput('100\t1\t2048\r\n200\t100\t1024')).toEqual([
       { pid: 100, ppid: 1, cpu: 0, memory: 2048 },
       { pid: 200, ppid: 100, cpu: 0, memory: 1024 }
     ])
   })
 
-  it('flushes the final stanza even without a trailing blank line', async () => {
-    const { parseWmicOutput } = await loadCollector()
-    const rows = parseWmicOutput('ProcessId=100\nParentProcessId=1\nWorkingSetSize=512')
-    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 512 }])
+  it('skips malformed rows and clamps invalid memory to zero', async () => {
+    const { parseWindowsProcessOutput } = await loadCollector()
+
+    expect(
+      parseWindowsProcessOutput(
+        [
+          'garbage',
+          'abc\t1\t100',
+          '10\txyz\t100',
+          '0\t0\t100',
+          '-5\t0\t100',
+          '30\t-1\t100',
+          '20\t1\t-50'
+        ].join('\n')
+      )
+    ).toEqual([{ pid: 20, ppid: 1, cpu: 0, memory: 0 }])
+  })
+})
+
+describe('parseTypeperfProcessOutput', () => {
+  it('joins PID, parent PID, and working-set counters by process instance', async () => {
+    const { parseTypeperfProcessOutput } = await loadCollector()
+    const stdout = [
+      '"(PDH-CSV 4.0)","\\\\HOST\\Process(node)\\ID Process","\\\\HOST\\Process(node#1)\\ID Process","\\\\HOST\\Process(node)\\Creating Process ID","\\\\HOST\\Process(node#1)\\Creating Process ID","\\\\HOST\\Process(node)\\Working Set","\\\\HOST\\Process(node#1)\\Working Set"',
+      '"07/15/2026 01:44:54.514","100.000000","200.000000","1.000000","100.000000","2048.000000","4096.000000"'
+    ].join('\r\n')
+
+    expect(parseTypeperfProcessOutput(stdout)).toEqual([
+      { pid: 100, ppid: 1, cpu: 0, memory: 2048 },
+      { pid: 200, ppid: 100, cpu: 0, memory: 4096 }
+    ])
   })
 
-  it('skips stanzas missing pid or ppid', async () => {
-    const { parseWmicOutput } = await loadCollector()
-    // Why: wmic occasionally emits a stanza with only WorkingSetSize set
-    // (e.g. a process that exited mid-query). Dropping such rows avoids
-    // injecting ghost zero-pid entries into the index.
-    const stdout = ['WorkingSetSize=999', '', 'ProcessId=100', 'ParentProcessId=1'].join('\n')
-    const rows = parseWmicOutput(stdout)
-    expect(rows).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 0 }])
-  })
+  it('ignores aggregate and incomplete rows and clamps invalid memory', async () => {
+    const { parseTypeperfProcessOutput } = await loadCollector()
+    const stdout = [
+      '"(PDH-CSV 4.0)","\\\\HOST\\Process(_Total)\\ID Process","\\\\HOST\\Process(cmd)\\ID Process","\\\\HOST\\Process(orphan)\\ID Process","\\\\HOST\\Process(_Total)\\Creating Process ID","\\\\HOST\\Process(cmd)\\Creating Process ID","\\\\HOST\\Process(_Total)\\Working Set","\\\\HOST\\Process(cmd)\\Working Set"',
+      '"time","0.000000","100.000000","200.000000","0.000000","1.000000","999999.000000","-1.000000"'
+    ].join('\r\n')
 
-  it('ignores lines without an equals separator', async () => {
-    const { parseWmicOutput } = await loadCollector()
-    const rows = parseWmicOutput(['garbage line', 'ProcessId=5', 'ParentProcessId=1'].join('\n'))
-    expect(rows).toEqual([{ pid: 5, ppid: 1, cpu: 0, memory: 0 }])
+    expect(parseTypeperfProcessOutput(stdout)).toEqual([{ pid: 100, ppid: 1, cpu: 0, memory: 0 }])
   })
 })
 
@@ -209,21 +226,27 @@ describe('collectSubtree', () => {
 
 describe('collectMemorySnapshot', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
     appMetricsMock.mockReset()
     appMetricsMock.mockReturnValue([])
+    execFileMock.mockReset()
     execMock.mockReset()
     listRegisteredPtysMock.mockReset()
     listRegisteredPtysMock.mockReturnValue([])
   })
 
   function mockPsResponse(stdout: string) {
-    const processStdout = process.platform === 'win32' ? psFixtureToWmic(stdout) : stdout
-    execMock.mockImplementation((_cmd, _opts, cb) =>
-      cb(null, { stdout: processStdout, stderr: '' })
-    )
+    execMock.mockImplementation((_cmd, _opts, cb) => cb(null, { stdout, stderr: '' }))
+    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+      const output =
+        file === 'typeperf.exe'
+          ? psFixtureToTypeperfOutput(stdout)
+          : psFixtureToWindowsProcessOutput(stdout)
+      cb(null, output, '')
+    })
   }
 
-  function psFixtureToWmic(stdout: string): string {
+  function psFixtureToWindowsProcessOutput(stdout: string): string {
     return stdout
       .split('\n')
       .map((line) => line.trim())
@@ -232,13 +255,116 @@ describe('collectMemorySnapshot', () => {
         const [pid, ppid, _cpu, rssKb] = line.split(/\s+/, 4)
         const memory = Number.parseInt(rssKb ?? '', 10)
         return [
-          `ParentProcessId=${ppid ?? ''}`,
-          `ProcessId=${pid ?? ''}`,
-          `WorkingSetSize=${Number.isFinite(memory) && memory > 0 ? memory * 1024 : 0}`
-        ].join('\r\n')
+          pid ?? '',
+          ppid ?? '',
+          Number.isFinite(memory) && memory > 0 ? memory * 1024 : 0
+        ].join('\t')
       })
-      .join('\r\n\r\n')
+      .join('\r\n')
   }
+
+  function psFixtureToTypeperfOutput(stdout: string): string {
+    const rows = stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line, index) => {
+        const [pid, ppid, _cpu, rssKb] = line.split(/\s+/, 4)
+        const memoryKb = Number.parseInt(rssKb ?? '', 10)
+        return {
+          instance: `fixture${index}`,
+          pid: pid ?? '',
+          ppid: ppid ?? '',
+          memory: Number.isFinite(memoryKb) && memoryKb > 0 ? memoryKb * 1024 : 0
+        }
+      })
+    const counterColumns = (counter: string): string[] =>
+      rows.map((row) => `"\\\\HOST\\Process(${row.instance})\\${counter}"`)
+    const valueColumns = (field: 'pid' | 'ppid' | 'memory'): string[] =>
+      rows.map((row) => `"${row[field]}"`)
+
+    return [
+      [
+        '"(PDH-CSV 4.0)"',
+        ...counterColumns('ID Process'),
+        ...counterColumns('Creating Process ID'),
+        ...counterColumns('Working Set')
+      ].join(','),
+      ['"time"', ...valueColumns('pid'), ...valueColumns('ppid'), ...valueColumns('memory')].join(
+        ','
+      )
+    ].join('\r\n')
+  }
+
+  function expectProcessSweepCount(count: number): void {
+    const processMock = os.platform() === 'win32' ? execFileMock : execMock
+    expect(processMock).toHaveBeenCalledTimes(count)
+  }
+
+  it('uses typeperf instead of removed WMIC on Windows', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    mockPsResponse('10 1 0 1024')
+    const { collectMemorySnapshot } = await loadCollector()
+
+    await collectMemorySnapshot(emptyStore)
+
+    expect(execMock).not.toHaveBeenCalled()
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    const [file, args] = execFileMock.mock.calls[0]
+    expect(file).toBe('typeperf.exe')
+    expect(args).toEqual(
+      expect.arrayContaining([
+        '\\Process(*)\\ID Process',
+        '\\Process(*)\\Creating Process ID',
+        '\\Process(*)\\Working Set',
+        '-sc',
+        '1',
+        '-si',
+        '0'
+      ])
+    )
+    expect(execFileMock.mock.calls[0][2]).toMatchObject({
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 5_000,
+      windowsHide: true
+    })
+  })
+
+  it('falls back to PowerShell CIM once and caches that backend', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+      if (file === 'typeperf.exe') {
+        cb(new Error('counter unavailable'), '', '')
+        return
+      }
+      cb(null, '10\t1\t1048576', '')
+    })
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'cim-pty',
+        worktreeId: null,
+        sessionId: null,
+        paneKey: null,
+        pid: 10
+      }
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    const first = await collectMemorySnapshot(emptyStore)
+    const second = await collectMemorySnapshot(emptyStore)
+
+    expect(execFileMock).toHaveBeenCalledTimes(3)
+    expect(execFileMock.mock.calls.map(([file]) => file)).toEqual([
+      'typeperf.exe',
+      'powershell.exe',
+      'powershell.exe'
+    ])
+    expect(execFileMock.mock.calls[1][0]).toBe('powershell.exe')
+    expect(execFileMock.mock.calls[1][1].join(' ')).toContain('Get-CimInstance Win32_Process')
+    expect(execFileMock.mock.calls[1][2]).toMatchObject({ windowsHide: true, timeout: 5_000 })
+    expect(first.worktrees[0].memory).toBe(1048576)
+    expect(second.worktrees[0].memory).toBe(1048576)
+  })
 
   it('coalesces concurrent callers onto a single in-flight sweep', async () => {
     // Why: the collector exists in part to prevent a burst of renderer
@@ -254,7 +380,7 @@ describe('collectMemorySnapshot', () => {
       collectMemorySnapshot(emptyStore)
     ])
 
-    expect(execMock).toHaveBeenCalledTimes(1)
+    expectProcessSweepCount(1)
     // All three callers see the same snapshot object (same promise).
     expect(a).toBe(b)
     expect(b).toBe(c)
@@ -267,7 +393,7 @@ describe('collectMemorySnapshot', () => {
     await collectMemorySnapshot(emptyStore)
     await collectMemorySnapshot(emptyStore)
 
-    expect(execMock).toHaveBeenCalledTimes(2)
+    expectProcessSweepCount(2)
   })
 
   it('uses host process RSS for Electron app metrics when available', async () => {
@@ -388,14 +514,19 @@ describe('collectMemorySnapshot', () => {
     expect(snap.worktrees[0].memory).toBe(2048 * 1024)
   })
 
-  it('returns an empty snapshot when ps fails', async () => {
-    execMock.mockImplementation((_cmd, _opts, cb) => cb(new Error('ps blew up'), { stdout: '' }))
+  it('returns an empty snapshot when process enumeration fails', async () => {
+    execMock.mockImplementation((_cmd, _opts, cb) =>
+      cb(new Error('process enumeration failed'), { stdout: '' })
+    )
+    execFileMock.mockImplementation((_file, _args, _opts, cb) =>
+      cb(new Error('process enumeration failed'), '', '')
+    )
     listRegisteredPtysMock.mockReturnValue([])
 
     const { collectMemorySnapshot } = await loadCollector()
     const snap = await collectMemorySnapshot(emptyStore)
 
-    // ps failure should not surface as a rejected promise or crash the
+    // Enumeration failure should not surface as a rejected promise or crash the
     // renderer; the collector swallows and returns zeros so the UI can
     // render an empty state.
     expect(snap.worktrees).toEqual([])

--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -237,13 +237,24 @@ describe('collectMemorySnapshot', () => {
 
   function mockPsResponse(stdout: string) {
     execMock.mockImplementation((_cmd, _opts, cb) => cb(null, { stdout, stderr: '' }))
-    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+    execFileMock.mockImplementation((file, args, _opts, cb) => {
       const output =
         file === 'typeperf.exe'
           ? psFixtureToTypeperfOutput(stdout)
-          : psFixtureToWindowsProcessOutput(stdout)
+          : args.join(' ').includes('Get-Process')
+            ? psFixtureToWindowsCpuOutput(stdout)
+            : psFixtureToWindowsProcessOutput(stdout)
       cb(null, output, '')
     })
+  }
+
+  function psFixtureToWindowsCpuOutput(stdout: string): string {
+    return stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => `${line.split(/\s+/, 1)[0]}\t0\t1`)
+      .join('\r\n')
   }
 
   function psFixtureToWindowsProcessOutput(stdout: string): string {
@@ -297,8 +308,11 @@ describe('collectMemorySnapshot', () => {
   }
 
   function expectProcessSweepCount(count: number): void {
-    const processMock = os.platform() === 'win32' ? execFileMock : execMock
-    expect(processMock).toHaveBeenCalledTimes(count)
+    if (os.platform() === 'win32') {
+      expect(execFileMock).toHaveBeenCalledTimes(count * 2)
+      return
+    }
+    expect(execMock).toHaveBeenCalledTimes(count)
   }
 
   it('uses typeperf instead of removed WMIC on Windows', async () => {
@@ -309,7 +323,7 @@ describe('collectMemorySnapshot', () => {
     await collectMemorySnapshot(emptyStore)
 
     expect(execMock).not.toHaveBeenCalled()
-    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock).toHaveBeenCalledTimes(2)
     const [file, args] = execFileMock.mock.calls[0]
     expect(file).toBe('typeperf.exe')
     expect(args).toEqual(
@@ -328,16 +342,115 @@ describe('collectMemorySnapshot', () => {
       timeout: 5_000,
       windowsHide: true
     })
+    expect(execFileMock.mock.calls[1][0]).toBe('powershell.exe')
+    expect(execFileMock.mock.calls[1][1].join(' ')).toContain('Get-Process')
+    expect(execFileMock.mock.calls[1][1].join(' ')).toContain('TotalProcessorTime.Ticks')
+  })
+
+  it('attributes Windows process CPU from cumulative time deltas between sweeps', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    vi.spyOn(performance, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(3_000)
+    const cpuOutputs = ['10\t10000000\t638830000000000000', '10\t30000000\t638830000000000000']
+    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+      if (file === 'typeperf.exe') {
+        cb(null, psFixtureToTypeperfOutput('10 1 0 1024'), '')
+        return
+      }
+      if (file === 'powershell.exe') {
+        cb(null, cpuOutputs.shift() ?? '', '')
+        return
+      }
+      cb(new Error(`unexpected executable: ${file}`), '', '')
+    })
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'windows-cpu-pty',
+        worktreeId: 'repo-1::C:\\repo',
+        sessionId: 'session-1',
+        paneKey: 'pane-1',
+        pid: 10
+      }
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    const first = await collectMemorySnapshot(emptyStore)
+    const second = await collectMemorySnapshot(emptyStore)
+
+    expect(first.worktrees[0].sessions[0].cpu).toBe(0)
+    expect(second.worktrees[0].sessions[0].cpu).toBe(100)
+    expect(execFileMock.mock.calls.map(([file]) => file)).toEqual([
+      'typeperf.exe',
+      'powershell.exe',
+      'typeperf.exe',
+      'powershell.exe'
+    ])
+  })
+
+  it('does not attribute prior CPU time after Windows reuses a process id', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    vi.spyOn(performance, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(3_000)
+    const cpuOutputs = ['10\t10000000\t638830000000000000', '10\t30000000\t638830000000000001']
+    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+      if (file === 'typeperf.exe') {
+        cb(null, psFixtureToTypeperfOutput('10 1 0 1024'), '')
+        return
+      }
+      cb(null, cpuOutputs.shift() ?? '', '')
+    })
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'reused-pid-pty',
+        worktreeId: 'repo-1::C:\\repo',
+        sessionId: 'session-1',
+        paneKey: 'pane-1',
+        pid: 10
+      }
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    await collectMemorySnapshot(emptyStore)
+    const second = await collectMemorySnapshot(emptyStore)
+
+    expect(second.worktrees[0].sessions[0].cpu).toBe(0)
+  })
+
+  it('preserves Windows process memory when the CPU sampler fails', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+      if (file === 'typeperf.exe') {
+        cb(null, psFixtureToTypeperfOutput('10 1 0 1024'), '')
+        return
+      }
+      cb(new Error('CPU sampler unavailable'), '', '')
+    })
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'cpu-failure-pty',
+        worktreeId: 'repo-1::C:\\repo',
+        sessionId: 'session-1',
+        paneKey: 'pane-1',
+        pid: 10
+      }
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    const snapshot = await collectMemorySnapshot(emptyStore)
+
+    expect(snapshot.worktrees[0].sessions[0]).toMatchObject({ cpu: 0, memory: 1024 * 1024 })
   })
 
   it('falls back to PowerShell CIM once and caches that backend', async () => {
     vi.spyOn(os, 'platform').mockReturnValue('win32')
-    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+    execFileMock.mockImplementation((file, args, _opts, cb) => {
       if (file === 'typeperf.exe') {
         cb(new Error('counter unavailable'), '', '')
         return
       }
-      cb(null, '10\t1\t1048576', '')
+      cb(
+        null,
+        args.join(' ').includes('Get-Process') ? '10\t0\t638830000000000000' : '10\t1\t1048576',
+        ''
+      )
     })
     listRegisteredPtysMock.mockReturnValue([
       {
@@ -353,15 +466,15 @@ describe('collectMemorySnapshot', () => {
     const first = await collectMemorySnapshot(emptyStore)
     const second = await collectMemorySnapshot(emptyStore)
 
-    expect(execFileMock).toHaveBeenCalledTimes(3)
-    expect(execFileMock.mock.calls.map(([file]) => file)).toEqual([
-      'typeperf.exe',
-      'powershell.exe',
-      'powershell.exe'
-    ])
-    expect(execFileMock.mock.calls[1][0]).toBe('powershell.exe')
-    expect(execFileMock.mock.calls[1][1].join(' ')).toContain('Get-CimInstance Win32_Process')
-    expect(execFileMock.mock.calls[1][2]).toMatchObject({ windowsHide: true, timeout: 5_000 })
+    expect(execFileMock).toHaveBeenCalledTimes(5)
+    const backends = execFileMock.mock.calls.map(([file, args]) =>
+      file === 'typeperf.exe' ? 'typeperf' : args.join(' ').includes('Get-Process') ? 'cpu' : 'cim'
+    )
+    expect(backends).toEqual(['typeperf', 'cpu', 'cim', 'cim', 'cpu'])
+    const cimCall = execFileMock.mock.calls.find(
+      ([file, args]) => file === 'powershell.exe' && args.join(' ').includes('Get-CimInstance')
+    )
+    expect(cimCall?.[2]).toMatchObject({ windowsHide: true, timeout: 5_000 })
     expect(first.worktrees[0].memory).toBe(1048576)
     expect(second.worktrees[0].memory).toBe(1048576)
   })

--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -42,6 +42,11 @@ async function loadCollector() {
   return await import('./collector')
 }
 
+async function loadWindowsProcessResourceCollector() {
+  vi.resetModules()
+  return await import('./windows-process-resource-collector')
+}
+
 const emptyStore = {
   getWorktreeMeta: () => undefined,
   getRepo: () => undefined
@@ -112,7 +117,7 @@ describe('parsePsOutput', () => {
 
 describe('parseWindowsProcessOutput', () => {
   it('parses tab-delimited CIM process rows', async () => {
-    const { parseWindowsProcessOutput } = await loadCollector()
+    const { parseWindowsProcessOutput } = await loadWindowsProcessResourceCollector()
 
     expect(parseWindowsProcessOutput('100\t1\t2048\r\n200\t100\t1024')).toEqual([
       { pid: 100, ppid: 1, cpu: 0, memory: 2048 },
@@ -121,7 +126,7 @@ describe('parseWindowsProcessOutput', () => {
   })
 
   it('skips malformed rows and clamps invalid memory to zero', async () => {
-    const { parseWindowsProcessOutput } = await loadCollector()
+    const { parseWindowsProcessOutput } = await loadWindowsProcessResourceCollector()
 
     expect(
       parseWindowsProcessOutput(
@@ -137,11 +142,19 @@ describe('parseWindowsProcessOutput', () => {
       )
     ).toEqual([{ pid: 20, ppid: 1, cpu: 0, memory: 0 }])
   })
+
+  it('preserves empty CIM field positions instead of shifting CPU ticks into memory', async () => {
+    const { parseWindowsProcessOutput } = await loadWindowsProcessResourceCollector()
+
+    expect(parseWindowsProcessOutput('100\t1\t\t200\t300\t638830000000000000')).toEqual([
+      { pid: 100, ppid: 1, cpu: 0, memory: 0 }
+    ])
+  })
 })
 
 describe('parseTypeperfProcessOutput', () => {
   it('joins PID, parent PID, and working-set counters by process instance', async () => {
-    const { parseTypeperfProcessOutput } = await loadCollector()
+    const { parseTypeperfProcessOutput } = await loadWindowsProcessResourceCollector()
     const stdout = [
       '"(PDH-CSV 4.0)","\\\\HOST\\Process(node)\\ID Process","\\\\HOST\\Process(node#1)\\ID Process","\\\\HOST\\Process(node)\\Creating Process ID","\\\\HOST\\Process(node#1)\\Creating Process ID","\\\\HOST\\Process(node)\\Working Set","\\\\HOST\\Process(node#1)\\Working Set"',
       '"07/15/2026 01:44:54.514","100.000000","200.000000","1.000000","100.000000","2048.000000","4096.000000"'
@@ -154,7 +167,7 @@ describe('parseTypeperfProcessOutput', () => {
   })
 
   it('ignores aggregate and incomplete rows and clamps invalid memory', async () => {
-    const { parseTypeperfProcessOutput } = await loadCollector()
+    const { parseTypeperfProcessOutput } = await loadWindowsProcessResourceCollector()
     const stdout = [
       '"(PDH-CSV 4.0)","\\\\HOST\\Process(_Total)\\ID Process","\\\\HOST\\Process(cmd)\\ID Process","\\\\HOST\\Process(orphan)\\ID Process","\\\\HOST\\Process(_Total)\\Creating Process ID","\\\\HOST\\Process(cmd)\\Creating Process ID","\\\\HOST\\Process(_Total)\\Working Set","\\\\HOST\\Process(cmd)\\Working Set"',
       '"time","0.000000","100.000000","200.000000","0.000000","1.000000","999999.000000","-1.000000"'
@@ -237,24 +250,13 @@ describe('collectMemorySnapshot', () => {
 
   function mockPsResponse(stdout: string) {
     execMock.mockImplementation((_cmd, _opts, cb) => cb(null, { stdout, stderr: '' }))
-    execFileMock.mockImplementation((file, args, _opts, cb) => {
+    execFileMock.mockImplementation((file, _args, _opts, cb) => {
       const output =
         file === 'typeperf.exe'
           ? psFixtureToTypeperfOutput(stdout)
-          : args.join(' ').includes('Get-Process')
-            ? psFixtureToWindowsCpuOutput(stdout)
-            : psFixtureToWindowsProcessOutput(stdout)
+          : psFixtureToWindowsProcessOutput(stdout)
       cb(null, output, '')
     })
-  }
-
-  function psFixtureToWindowsCpuOutput(stdout: string): string {
-    return stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => `${line.split(/\s+/, 1)[0]}\t0\t1`)
-      .join('\r\n')
   }
 
   function psFixtureToWindowsProcessOutput(stdout: string): string {
@@ -268,7 +270,10 @@ describe('collectMemorySnapshot', () => {
         return [
           pid ?? '',
           ppid ?? '',
-          Number.isFinite(memory) && memory > 0 ? memory * 1024 : 0
+          Number.isFinite(memory) && memory > 0 ? memory * 1024 : 0,
+          '0',
+          '0',
+          '1'
         ].join('\t')
       })
       .join('\r\n')
@@ -309,13 +314,13 @@ describe('collectMemorySnapshot', () => {
 
   function expectProcessSweepCount(count: number): void {
     if (os.platform() === 'win32') {
-      expect(execFileMock).toHaveBeenCalledTimes(count * 2)
+      expect(execFileMock).toHaveBeenCalledTimes(count)
       return
     }
     expect(execMock).toHaveBeenCalledTimes(count)
   }
 
-  it('uses typeperf instead of removed WMIC on Windows', async () => {
+  it('uses one CIM process for Windows memory and CPU sampling', async () => {
     vi.spyOn(os, 'platform').mockReturnValue('win32')
     mockPsResponse('10 1 0 1024')
     const { collectMemorySnapshot } = await loadCollector()
@@ -323,45 +328,30 @@ describe('collectMemorySnapshot', () => {
     await collectMemorySnapshot(emptyStore)
 
     expect(execMock).not.toHaveBeenCalled()
-    expect(execFileMock).toHaveBeenCalledTimes(2)
+    expect(execFileMock).toHaveBeenCalledTimes(1)
     const [file, args] = execFileMock.mock.calls[0]
-    expect(file).toBe('typeperf.exe')
-    expect(args).toEqual(
-      expect.arrayContaining([
-        '\\Process(*)\\ID Process',
-        '\\Process(*)\\Creating Process ID',
-        '\\Process(*)\\Working Set',
-        '-sc',
-        '1',
-        '-si',
-        '0'
-      ])
-    )
+    expect(file).toBe('powershell.exe')
+    expect(args.join(' ')).toContain('Get-CimInstance Win32_Process')
+    expect(args.join(' ')).toContain('KernelModeTime')
+    expect(args.join(' ')).toContain('UserModeTime')
+    expect(args.join(' ')).toContain('CreationDate')
     expect(execFileMock.mock.calls[0][2]).toMatchObject({
       maxBuffer: 10 * 1024 * 1024,
       timeout: 5_000,
       windowsHide: true
     })
-    expect(execFileMock.mock.calls[1][0]).toBe('powershell.exe')
-    expect(execFileMock.mock.calls[1][1].join(' ')).toContain('Get-Process')
-    expect(execFileMock.mock.calls[1][1].join(' ')).toContain('TotalProcessorTime.Ticks')
   })
 
   it('attributes Windows process CPU from cumulative time deltas between sweeps', async () => {
     vi.spyOn(os, 'platform').mockReturnValue('win32')
     vi.spyOn(performance, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(3_000)
-    const cpuOutputs = ['10\t10000000\t638830000000000000', '10\t30000000\t638830000000000000']
-    execFileMock.mockImplementation((file, _args, _opts, cb) => {
-      if (file === 'typeperf.exe') {
-        cb(null, psFixtureToTypeperfOutput('10 1 0 1024'), '')
-        return
-      }
-      if (file === 'powershell.exe') {
-        cb(null, cpuOutputs.shift() ?? '', '')
-        return
-      }
-      cb(new Error(`unexpected executable: ${file}`), '', '')
-    })
+    const cpuOutputs = [
+      '10\t1\t1048576\t10000000\t0\t638830000000000000',
+      '10\t1\t1048576\t30000000\t0\t638830000000000000'
+    ]
+    execFileMock.mockImplementation((_file, _args, _opts, cb) =>
+      cb(null, cpuOutputs.shift() ?? '', '')
+    )
     listRegisteredPtysMock.mockReturnValue([
       {
         ptyId: 'windows-cpu-pty',
@@ -379,9 +369,7 @@ describe('collectMemorySnapshot', () => {
     expect(first.worktrees[0].sessions[0].cpu).toBe(0)
     expect(second.worktrees[0].sessions[0].cpu).toBe(100)
     expect(execFileMock.mock.calls.map(([file]) => file)).toEqual([
-      'typeperf.exe',
       'powershell.exe',
-      'typeperf.exe',
       'powershell.exe'
     ])
   })
@@ -389,14 +377,13 @@ describe('collectMemorySnapshot', () => {
   it('does not attribute prior CPU time after Windows reuses a process id', async () => {
     vi.spyOn(os, 'platform').mockReturnValue('win32')
     vi.spyOn(performance, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(3_000)
-    const cpuOutputs = ['10\t10000000\t638830000000000000', '10\t30000000\t638830000000000001']
-    execFileMock.mockImplementation((file, _args, _opts, cb) => {
-      if (file === 'typeperf.exe') {
-        cb(null, psFixtureToTypeperfOutput('10 1 0 1024'), '')
-        return
-      }
+    const cpuOutputs = [
+      '10\t1\t1048576\t10000000\t0\t638830000000000000',
+      '10\t1\t1048576\t30000000\t0\t638830000000000001'
+    ]
+    execFileMock.mockImplementation((_file, _args, _opts, cb) =>
       cb(null, cpuOutputs.shift() ?? '', '')
-    })
+    )
     listRegisteredPtysMock.mockReturnValue([
       {
         ptyId: 'reused-pid-pty',
@@ -414,15 +401,126 @@ describe('collectMemorySnapshot', () => {
     expect(second.worktrees[0].sessions[0].cpu).toBe(0)
   })
 
-  it('preserves Windows process memory when the CPU sampler fails', async () => {
+  it('supports cumulative CPU counters above JavaScript safe integers', async () => {
     vi.spyOn(os, 'platform').mockReturnValue('win32')
-    execFileMock.mockImplementation((file, _args, _opts, cb) => {
-      if (file === 'typeperf.exe') {
-        cb(null, psFixtureToTypeperfOutput('10 1 0 1024'), '')
-        return
+    vi.spyOn(performance, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(3_000)
+    const cpuOutputs = [
+      '10\t1\t1048576\t90071992547409920\t0\t638830000000000000',
+      '10\t1\t1048576\t90071992567409920\t0\t638830000000000000'
+    ]
+    execFileMock.mockImplementation((_file, _args, _opts, cb) =>
+      cb(null, cpuOutputs.shift() ?? '', '')
+    )
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'large-counter-pty',
+        worktreeId: 'repo-1::C:\\repo',
+        sessionId: 'session-1',
+        paneKey: 'pane-1',
+        pid: 10
       }
-      cb(new Error('CPU sampler unavailable'), '', '')
-    })
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    await collectMemorySnapshot(emptyStore)
+    const second = await collectMemorySnapshot(emptyStore)
+
+    expect(second.worktrees[0].sessions[0].cpu).toBe(100)
+  })
+
+  it('keeps the older CPU baseline when forced snapshots are too close together', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_100)
+      .mockReturnValueOnce(3_000)
+    const cpuOutputs = [
+      '10\t1\t1048576\t0\t0\t638830000000000000',
+      '10\t1\t1048576\t1000000\t0\t638830000000000000',
+      '10\t1\t1048576\t20000000\t0\t638830000000000000'
+    ]
+    execFileMock.mockImplementation((_file, _args, _opts, cb) =>
+      cb(null, cpuOutputs.shift() ?? '', '')
+    )
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'short-sample-pty',
+        worktreeId: 'repo-1::C:\\repo',
+        sessionId: 'session-1',
+        paneKey: 'pane-1',
+        pid: 10
+      }
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    await collectMemorySnapshot(emptyStore)
+    const tooSoon = await collectMemorySnapshot(emptyStore)
+    const normalPoll = await collectMemorySnapshot(emptyStore)
+
+    expect(tooSoon.worktrees[0].sessions[0].cpu).toBe(0)
+    expect(normalPoll.worktrees[0].sessions[0].cpu).toBe(100)
+  })
+
+  it('caps impossible Windows CPU deltas at the host core capacity', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    vi.spyOn(os, 'cpus').mockReturnValue([{}, {}] as ReturnType<typeof os.cpus>)
+    vi.spyOn(performance, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(3_000)
+    const cpuOutputs = [
+      '10\t1\t1048576\t0\t0\t638830000000000000',
+      '10\t1\t1048576\t1000000000\t0\t638830000000000000'
+    ]
+    execFileMock.mockImplementation((_file, _args, _opts, cb) =>
+      cb(null, cpuOutputs.shift() ?? '', '')
+    )
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'impossible-cpu-pty',
+        worktreeId: 'repo-1::C:\\repo',
+        sessionId: 'session-1',
+        paneKey: 'pane-1',
+        pid: 10
+      }
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    await collectMemorySnapshot(emptyStore)
+    const capped = await collectMemorySnapshot(emptyStore)
+
+    expect(capped.worktrees[0].sessions[0].cpu).toBe(200)
+  })
+
+  it('warms CPU sampling again after Resource Manager was closed', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    vi.spyOn(performance, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(12_000)
+    const cpuOutputs = [
+      '10\t1\t1048576\t0\t0\t638830000000000000',
+      '10\t1\t1048576\t100000000\t0\t638830000000000000'
+    ]
+    execFileMock.mockImplementation((_file, _args, _opts, cb) =>
+      cb(null, cpuOutputs.shift() ?? '', '')
+    )
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'stale-counter-pty',
+        worktreeId: 'repo-1::C:\\repo',
+        sessionId: 'session-1',
+        paneKey: 'pane-1',
+        pid: 10
+      }
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    await collectMemorySnapshot(emptyStore)
+    const reopened = await collectMemorySnapshot(emptyStore)
+
+    expect(reopened.worktrees[0].sessions[0].cpu).toBe(0)
+  })
+
+  it('preserves Windows process memory when CPU counters are unavailable', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    execFileMock.mockImplementation((_file, _args, _opts, cb) =>
+      cb(null, '10\t1\t1048576\t\t\t638830000000000000', '')
+    )
     listRegisteredPtysMock.mockReturnValue([
       {
         ptyId: 'cpu-failure-pty',
@@ -439,18 +537,14 @@ describe('collectMemorySnapshot', () => {
     expect(snapshot.worktrees[0].sessions[0]).toMatchObject({ cpu: 0, memory: 1024 * 1024 })
   })
 
-  it('falls back to PowerShell CIM once and caches that backend', async () => {
+  it('uses Typeperf during the CIM retry cooldown', async () => {
     vi.spyOn(os, 'platform').mockReturnValue('win32')
-    execFileMock.mockImplementation((file, args, _opts, cb) => {
-      if (file === 'typeperf.exe') {
-        cb(new Error('counter unavailable'), '', '')
+    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+      if (file === 'powershell.exe') {
+        cb(new Error('CIM unavailable'), '', '')
         return
       }
-      cb(
-        null,
-        args.join(' ').includes('Get-Process') ? '10\t0\t638830000000000000' : '10\t1\t1048576',
-        ''
-      )
+      cb(null, psFixtureToTypeperfOutput('10 1 0 1024'), '')
     })
     listRegisteredPtysMock.mockReturnValue([
       {
@@ -466,17 +560,67 @@ describe('collectMemorySnapshot', () => {
     const first = await collectMemorySnapshot(emptyStore)
     const second = await collectMemorySnapshot(emptyStore)
 
-    expect(execFileMock).toHaveBeenCalledTimes(5)
-    const backends = execFileMock.mock.calls.map(([file, args]) =>
-      file === 'typeperf.exe' ? 'typeperf' : args.join(' ').includes('Get-Process') ? 'cpu' : 'cim'
-    )
-    expect(backends).toEqual(['typeperf', 'cpu', 'cim', 'cim', 'cpu'])
-    const cimCall = execFileMock.mock.calls.find(
-      ([file, args]) => file === 'powershell.exe' && args.join(' ').includes('Get-CimInstance')
-    )
-    expect(cimCall?.[2]).toMatchObject({ windowsHide: true, timeout: 5_000 })
+    expect(execFileMock).toHaveBeenCalledTimes(3)
+    expect(execFileMock.mock.calls.map(([file]) => file)).toEqual([
+      'powershell.exe',
+      'typeperf.exe',
+      'typeperf.exe'
+    ])
+    expect(execFileMock.mock.calls[1][2]).toMatchObject({ windowsHide: true, timeout: 5_000 })
     expect(first.worktrees[0].memory).toBe(1048576)
     expect(second.worktrees[0].memory).toBe(1048576)
+  })
+
+  it('retries CIM after fallback and warms CPU sampling before restoring deltas', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(2_000)
+      .mockReturnValueOnce(31_001)
+      .mockReturnValueOnce(32_000)
+      .mockReturnValueOnce(34_000)
+    const cimOutputs = [
+      '10\t1\t1048576\t10000000\t0\t638830000000000000',
+      '10\t1\t1048576\t30000000\t0\t638830000000000000'
+    ]
+    let cimCalls = 0
+    execFileMock.mockImplementation((file, _args, _opts, cb) => {
+      if (file === 'typeperf.exe') {
+        cb(null, psFixtureToTypeperfOutput('10 1 0 1024'), '')
+        return
+      }
+      cimCalls += 1
+      if (cimCalls === 1) {
+        cb(new Error('transient CIM failure'), '', '')
+        return
+      }
+      cb(null, cimOutputs.shift() ?? '', '')
+    })
+    listRegisteredPtysMock.mockReturnValue([
+      {
+        ptyId: 'recovering-cim-pty',
+        worktreeId: 'repo-1::C:\\repo',
+        sessionId: 'session-1',
+        paneKey: 'pane-1',
+        pid: 10
+      }
+    ])
+    const { collectMemorySnapshot } = await loadCollector()
+
+    await collectMemorySnapshot(emptyStore)
+    await collectMemorySnapshot(emptyStore)
+    const warming = await collectMemorySnapshot(emptyStore)
+    const recovered = await collectMemorySnapshot(emptyStore)
+
+    expect(execFileMock.mock.calls.map(([file]) => file)).toEqual([
+      'powershell.exe',
+      'typeperf.exe',
+      'typeperf.exe',
+      'powershell.exe',
+      'powershell.exe'
+    ])
+    expect(warming.worktrees[0].sessions[0].cpu).toBe(0)
+    expect(recovered.worktrees[0].sessions[0].cpu).toBe(100)
   })
 
   it('coalesces concurrent callers onto a single in-flight sweep', async () => {

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -22,6 +22,7 @@
 import { basename } from 'node:path'
 import { exec, execFile } from 'node:child_process'
 import { promisify } from 'node:util'
+import { performance } from 'node:perf_hooks'
 import os from 'node:os'
 import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import {
@@ -46,6 +47,7 @@ export type MemorySnapshotStore = Pick<Store, 'getRepo' | 'getWorktreeMeta'>
 
 let inflight: Promise<MemorySnapshot> | null = null
 let windowsProcessBackend: 'typeperf' | 'cim' = 'typeperf'
+let previousWindowsCpuSample: WindowsCpuSample | null = null
 
 // ─── Public API ─────────────────────────────────────────────────────
 
@@ -85,7 +87,7 @@ const TYPEPERF_MAX_LINE_CHARS = 1024 * 1024
 type ProcRow = {
   pid: number
   ppid: number
-  /** Percent of one core (may exceed 100 on multi-core). 0 on Windows. */
+  /** Percent of one core (may exceed 100 on multi-core). */
   cpu: number
   /** Resident memory in bytes. */
   memory: number
@@ -95,6 +97,16 @@ type ProcRow = {
 type ProcIndex = {
   byPid: Map<number, ProcRow>
   childrenOf: Map<number, number[]>
+}
+
+type WindowsCpuTimes = {
+  cpuTicks: number
+  startTimeId: string
+}
+
+type WindowsCpuSample = {
+  sampledAtMs: number
+  byPid: Map<number, WindowsCpuTimes>
 }
 
 function clampNumber(value: unknown): number {
@@ -234,6 +246,45 @@ export function parsePsOutput(stdout: string): ProcRow[] {
 }
 
 async function enumerateWindows(): Promise<ProcRow[]> {
+  // Why: Typeperf's formatted CPU counter blocks for a rate interval. Sampling
+  // cumulative process time in parallel keeps the existing fast memory path.
+  const [rows, cpuSample] = await Promise.all([
+    enumerateWindowsProcessRows(),
+    enumerateWindowsCpuSample()
+  ])
+  if (!cpuSample) {
+    return rows
+  }
+
+  const previous = previousWindowsCpuSample
+  previousWindowsCpuSample = cpuSample
+  if (!previous) {
+    return rows
+  }
+  const elapsedMs = cpuSample.sampledAtMs - previous.sampledAtMs
+  if (elapsedMs <= 0) {
+    return rows
+  }
+  for (const row of rows) {
+    const currentTimes = cpuSample.byPid.get(row.pid)
+    const previousTimes = previous.byPid.get(row.pid)
+    // Start time distinguishes a live process from a later process that reused
+    // the same PID; counter resets likewise produce a zero sample, not a spike.
+    if (
+      !currentTimes ||
+      !previousTimes ||
+      currentTimes.startTimeId !== previousTimes.startTimeId ||
+      currentTimes.cpuTicks < previousTimes.cpuTicks
+    ) {
+      continue
+    }
+    const cpuMs = (currentTimes.cpuTicks - previousTimes.cpuTicks) / 10_000
+    row.cpu = clampNumber((cpuMs / elapsedMs) * 100)
+  }
+  return rows
+}
+
+async function enumerateWindowsProcessRows(): Promise<ProcRow[]> {
   // Why: WMIC is removed from current Windows releases, while WMI/CIM can be
   // slow or unavailable on otherwise healthy machines. typeperf reads the
   // built-in process counters without WMI and includes the PID, parent PID,
@@ -250,6 +301,48 @@ async function enumerateWindows(): Promise<ProcRow[]> {
     windowsProcessBackend = 'cim'
   }
   return enumerateWindowsWithCim()
+}
+
+async function enumerateWindowsCpuSample(): Promise<WindowsCpuSample | null> {
+  const args = [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    'Get-Process | ForEach-Object { try { [string]::Join([char]9, @($_.Id, $_.TotalProcessorTime.Ticks, $_.StartTime.Ticks)) } catch {} }'
+  ]
+  try {
+    const stdout = await execFileText('powershell.exe', args)
+    return { sampledAtMs: performance.now(), byPid: parseWindowsCpuOutput(stdout) }
+  } catch (err) {
+    console.warn('[memory] PowerShell CPU sampling failed', err)
+    return null
+  }
+}
+
+function parseWindowsCpuOutput(stdout: string): Map<number, WindowsCpuTimes> {
+  const byPid = new Map<number, WindowsCpuTimes>()
+  for (const line of iterateProcessOutputLines(stdout)) {
+    const fields = getProcessOutputFields(line, 3)
+    if (fields.length < 3) {
+      continue
+    }
+    const pid = Number.parseInt(fields[0], 10)
+    const cpuTicks = Number.parseInt(fields[1], 10)
+    const startTimeId = fields[2]
+    if (
+      !Number.isSafeInteger(pid) ||
+      pid <= 0 ||
+      !Number.isSafeInteger(cpuTicks) ||
+      cpuTicks < 0 ||
+      !/^\d+$/.test(startTimeId) ||
+      /^0+$/.test(startTimeId)
+    ) {
+      continue
+    }
+    byPid.set(pid, { cpuTicks, startTimeId })
+  }
+  return byPid
 }
 
 async function enumerateWindowsWithTypeperf(): Promise<ProcRow[]> {

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -1,8 +1,6 @@
-/* eslint-disable max-lines -- Why: the collector's platform-specific
-   enumeration paths (`ps` on Unix, `typeperf`/CIM on Windows) plus the history
-   ring buffer plus the Electron bucketing live together to keep one
-   snapshot's worth of code in one place. Splitting them produces extra
-   modules whose only consumer is this file. */
+/* eslint-disable max-lines -- Why: the collector's host-process index,
+   history ring buffer, Electron bucketing, and worktree attribution live
+   together to keep one snapshot's orchestration in one place. */
 /**
  * Memory dashboard collector.
  *
@@ -10,7 +8,7 @@
  *   - Orca's own Electron processes, via `app.getAppMetrics()`, bucketed
  *     into main / renderer / other.
  *   - Each registered PTY's process subtree, enumerated once from a host-
- *     wide process sweep (`typeperf` with a PowerShell CIM fallback on Windows).
+ *     wide process sweep (PowerShell CIM with a Typeperf fallback on Windows).
  *
  * Memory samples are held in a per-key ring (one key per worktree, plus
  * a reserved app-total key) so the UI can draw a trend sparkline.
@@ -20,9 +18,8 @@
  */
 
 import { basename } from 'node:path'
-import { exec, execFile } from 'node:child_process'
+import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
-import { performance } from 'node:perf_hooks'
 import os from 'node:os'
 import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import {
@@ -40,14 +37,13 @@ import type {
 import type { Store } from '../persistence'
 import { ORPHAN_WORKTREE_ID } from '../../shared/constants'
 import { listRegisteredPtys } from './pty-registry'
+import { enumerateWindowsProcessResources } from './windows-process-resource-collector'
 
 export type MemorySnapshotStore = Pick<Store, 'getRepo' | 'getWorktreeMeta'>
 
 // ─── Module state ───────────────────────────────────────────────────
 
 let inflight: Promise<MemorySnapshot> | null = null
-let windowsProcessBackend: 'typeperf' | 'cim' = 'typeperf'
-let previousWindowsCpuSample: WindowsCpuSample | null = null
 
 // ─── Public API ─────────────────────────────────────────────────────
 
@@ -75,13 +71,6 @@ export async function collectMemorySnapshot(store: MemorySnapshotStore): Promise
 const execAsync = promisify(exec)
 const PS_EXEC_TIMEOUT_MS = 5_000
 const PS_MAX_BUFFER = 10 * 1024 * 1024
-const TYPEPERF_COUNTERS = [
-  '\\Process(*)\\ID Process',
-  '\\Process(*)\\Creating Process ID',
-  '\\Process(*)\\Working Set'
-] as const
-const TYPEPERF_MAX_FIELDS = 8_192
-const TYPEPERF_MAX_LINE_CHARS = 1024 * 1024
 
 /** One row from the host-wide process listing. */
 type ProcRow = {
@@ -97,16 +86,6 @@ type ProcRow = {
 type ProcIndex = {
   byPid: Map<number, ProcRow>
   childrenOf: Map<number, number[]>
-}
-
-type WindowsCpuTimes = {
-  cpuTicks: number
-  startTimeId: string
-}
-
-type WindowsCpuSample = {
-  sampledAtMs: number
-  byPid: Map<number, WindowsCpuTimes>
 }
 
 function clampNumber(value: unknown): number {
@@ -246,292 +225,7 @@ export function parsePsOutput(stdout: string): ProcRow[] {
 }
 
 async function enumerateWindows(): Promise<ProcRow[]> {
-  // Why: Typeperf's formatted CPU counter blocks for a rate interval. Sampling
-  // cumulative process time in parallel keeps the existing fast memory path.
-  const [rows, cpuSample] = await Promise.all([
-    enumerateWindowsProcessRows(),
-    enumerateWindowsCpuSample()
-  ])
-  if (!cpuSample) {
-    return rows
-  }
-
-  const previous = previousWindowsCpuSample
-  previousWindowsCpuSample = cpuSample
-  if (!previous) {
-    return rows
-  }
-  const elapsedMs = cpuSample.sampledAtMs - previous.sampledAtMs
-  if (elapsedMs <= 0) {
-    return rows
-  }
-  for (const row of rows) {
-    const currentTimes = cpuSample.byPid.get(row.pid)
-    const previousTimes = previous.byPid.get(row.pid)
-    // Start time distinguishes a live process from a later process that reused
-    // the same PID; counter resets likewise produce a zero sample, not a spike.
-    if (
-      !currentTimes ||
-      !previousTimes ||
-      currentTimes.startTimeId !== previousTimes.startTimeId ||
-      currentTimes.cpuTicks < previousTimes.cpuTicks
-    ) {
-      continue
-    }
-    const cpuMs = (currentTimes.cpuTicks - previousTimes.cpuTicks) / 10_000
-    row.cpu = clampNumber((cpuMs / elapsedMs) * 100)
-  }
-  return rows
-}
-
-async function enumerateWindowsProcessRows(): Promise<ProcRow[]> {
-  // Why: WMIC is removed from current Windows releases, while WMI/CIM can be
-  // slow or unavailable on otherwise healthy machines. typeperf reads the
-  // built-in process counters without WMI and includes the PID, parent PID,
-  // and working set needed for subtree attribution. CIM remains a locale-
-  // independent fallback when localized counter names make typeperf fail.
-  if (windowsProcessBackend === 'typeperf') {
-    const typeperfRows = await enumerateWindowsWithTypeperf()
-    if (typeperfRows.length > 0) {
-      return typeperfRows
-    }
-    // Counter names are localized on some Windows installations. Once the
-    // probe fails, avoid spawning and warning about it on every two-second
-    // Resource Manager poll; CIM remains the backend until app restart.
-    windowsProcessBackend = 'cim'
-  }
-  return enumerateWindowsWithCim()
-}
-
-async function enumerateWindowsCpuSample(): Promise<WindowsCpuSample | null> {
-  const args = [
-    '-NoLogo',
-    '-NoProfile',
-    '-NonInteractive',
-    '-Command',
-    'Get-Process | ForEach-Object { try { [string]::Join([char]9, @($_.Id, $_.TotalProcessorTime.Ticks, $_.StartTime.Ticks)) } catch {} }'
-  ]
-  try {
-    const stdout = await execFileText('powershell.exe', args)
-    return { sampledAtMs: performance.now(), byPid: parseWindowsCpuOutput(stdout) }
-  } catch (err) {
-    console.warn('[memory] PowerShell CPU sampling failed', err)
-    return null
-  }
-}
-
-function parseWindowsCpuOutput(stdout: string): Map<number, WindowsCpuTimes> {
-  const byPid = new Map<number, WindowsCpuTimes>()
-  for (const line of iterateProcessOutputLines(stdout)) {
-    const fields = getProcessOutputFields(line, 3)
-    if (fields.length < 3) {
-      continue
-    }
-    const pid = Number.parseInt(fields[0], 10)
-    const cpuTicks = Number.parseInt(fields[1], 10)
-    const startTimeId = fields[2]
-    if (
-      !Number.isSafeInteger(pid) ||
-      pid <= 0 ||
-      !Number.isSafeInteger(cpuTicks) ||
-      cpuTicks < 0 ||
-      !/^\d+$/.test(startTimeId) ||
-      /^0+$/.test(startTimeId)
-    ) {
-      continue
-    }
-    byPid.set(pid, { cpuTicks, startTimeId })
-  }
-  return byPid
-}
-
-async function enumerateWindowsWithTypeperf(): Promise<ProcRow[]> {
-  try {
-    // `-si 0` asks for the first sample immediately; the default one-second
-    // interval would consume half of Resource Manager's two-second poll cycle.
-    const stdout = await execFileText('typeperf.exe', [
-      ...TYPEPERF_COUNTERS,
-      '-sc',
-      '1',
-      '-si',
-      '0'
-    ])
-    return parseTypeperfProcessOutput(stdout)
-  } catch (err) {
-    console.warn('[memory] typeperf process enumeration failed; falling back to CIM', err)
-    return []
-  }
-}
-
-async function enumerateWindowsWithCim(): Promise<ProcRow[]> {
-  const args = [
-    '-NoLogo',
-    '-NoProfile',
-    '-NonInteractive',
-    '-Command',
-    'Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,WorkingSetSize | ForEach-Object { [string]::Join([char]9, @($_.ProcessId, $_.ParentProcessId, $_.WorkingSetSize)) }'
-  ]
-  try {
-    const stdout = await execFileText('powershell.exe', args)
-    return parseWindowsProcessOutput(stdout)
-  } catch (err) {
-    console.warn('[memory] PowerShell process enumeration failed', err)
-    return []
-  }
-}
-
-function execFileText(file: string, args: string[]): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    execFile(
-      file,
-      args,
-      {
-        encoding: 'utf8',
-        maxBuffer: PS_MAX_BUFFER,
-        timeout: PS_EXEC_TIMEOUT_MS,
-        windowsHide: true
-      },
-      (err, output) => {
-        if (err) {
-          reject(err)
-          return
-        }
-        resolve(String(output))
-      }
-    )
-  })
-}
-
-type TypeperfProcessFields = {
-  pid?: number
-  ppid?: number
-  memory?: number
-}
-
-/** Exported for tests: parses one CSV sample from Windows `typeperf`. */
-export function parseTypeperfProcessOutput(stdout: string): ProcRow[] {
-  let headers: string[] | null = null
-  let values: string[] | null = null
-
-  for (const line of iterateProcessOutputLines(stdout)) {
-    if (!line || line.length > TYPEPERF_MAX_LINE_CHARS) {
-      continue
-    }
-    const fields = parseTypeperfCsvLine(line)
-    if (!headers && fields[0]?.startsWith('(PDH-CSV')) {
-      headers = fields
-      continue
-    }
-    if (headers && fields.length === headers.length) {
-      values = fields
-      break
-    }
-  }
-
-  if (!headers || !values) {
-    return []
-  }
-
-  const byInstance = new Map<string, TypeperfProcessFields>()
-  for (let index = 1; index < headers.length; index += 1) {
-    const path = parseTypeperfCounterPath(headers[index])
-    if (!path || path.instance === '_Total') {
-      continue
-    }
-    const value = Number.parseFloat(values[index])
-    if (!Number.isFinite(value)) {
-      continue
-    }
-    const row = byInstance.get(path.instance) ?? {}
-    if (path.counter === 'ID Process') {
-      row.pid = Math.trunc(value)
-    } else if (path.counter === 'Creating Process ID') {
-      row.ppid = Math.trunc(value)
-    } else if (path.counter === 'Working Set') {
-      row.memory = value
-    }
-    byInstance.set(path.instance, row)
-  }
-
-  const rows: ProcRow[] = []
-  for (const row of byInstance.values()) {
-    if (row.pid === undefined || row.pid <= 0 || row.ppid === undefined || row.ppid < 0) {
-      continue
-    }
-    rows.push({
-      pid: row.pid,
-      ppid: row.ppid,
-      cpu: 0,
-      memory: row.memory !== undefined && row.memory > 0 ? row.memory : 0
-    })
-  }
-  return rows
-}
-
-function parseTypeperfCounterPath(path: string): { instance: string; counter: string } | null {
-  const processStart = path.lastIndexOf('\\Process(')
-  const counterStart = path.lastIndexOf(')\\')
-  if (processStart < 0 || counterStart <= processStart + 9) {
-    return null
-  }
-  return {
-    instance: path.slice(processStart + 9, counterStart),
-    counter: path.slice(counterStart + 2)
-  }
-}
-
-function parseTypeperfCsvLine(line: string): string[] {
-  const fields: string[] = []
-  let value = ''
-  let quoted = false
-
-  for (let index = 0; index < line.length; index += 1) {
-    const char = line[index]
-    if (char === '"') {
-      if (quoted && line[index + 1] === '"') {
-        value += '"'
-        index += 1
-      } else {
-        quoted = !quoted
-      }
-      continue
-    }
-    if (char === ',' && !quoted) {
-      fields.push(value)
-      value = ''
-      if (fields.length >= TYPEPERF_MAX_FIELDS) {
-        return []
-      }
-      continue
-    }
-    value += char
-  }
-  fields.push(value)
-  return fields
-}
-
-/** Exported for tests: parses tab-delimited PowerShell CIM process rows. */
-export function parseWindowsProcessOutput(stdout: string): ProcRow[] {
-  const rows: ProcRow[] = []
-  for (const line of iterateProcessOutputLines(stdout)) {
-    const fields = getProcessOutputFields(line, 3)
-    if (fields.length < 3) {
-      continue
-    }
-    const pid = Number.parseInt(fields[0], 10)
-    const ppid = Number.parseInt(fields[1], 10)
-    const memory = Number.parseInt(fields[2], 10)
-    if (Number.isNaN(pid) || pid <= 0 || Number.isNaN(ppid) || ppid < 0) {
-      continue
-    }
-    rows.push({
-      pid,
-      ppid,
-      cpu: 0,
-      memory: Number.isFinite(memory) && memory > 0 ? memory : 0
-    })
-  }
-  return rows
+  return enumerateWindowsProcessResources()
 }
 /** Walk every descendant PID of `root`, inclusive. Exported for tests. */
 export function collectSubtree(index: ProcIndex, root: number): number[] {

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: the collector's platform-specific
-   enumeration paths (`ps` on Unix, `wmic` on Windows) plus the history
+   enumeration paths (`ps` on Unix, `typeperf`/CIM on Windows) plus the history
    ring buffer plus the Electron bucketing live together to keep one
    snapshot's worth of code in one place. Splitting them produces extra
    modules whose only consumer is this file. */
@@ -10,7 +10,7 @@
  *   - Orca's own Electron processes, via `app.getAppMetrics()`, bucketed
  *     into main / renderer / other.
  *   - Each registered PTY's process subtree, enumerated once from a host-
- *     wide `ps` sweep (`wmic` on Windows).
+ *     wide process sweep (`typeperf` with a PowerShell CIM fallback on Windows).
  *
  * Memory samples are held in a per-key ring (one key per worktree, plus
  * a reserved app-total key) so the UI can draw a trend sparkline.
@@ -20,7 +20,7 @@
  */
 
 import { basename } from 'node:path'
-import { exec } from 'node:child_process'
+import { exec, execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import os from 'node:os'
 import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
@@ -45,6 +45,7 @@ export type MemorySnapshotStore = Pick<Store, 'getRepo' | 'getWorktreeMeta'>
 // ─── Module state ───────────────────────────────────────────────────
 
 let inflight: Promise<MemorySnapshot> | null = null
+let windowsProcessBackend: 'typeperf' | 'cim' = 'typeperf'
 
 // ─── Public API ─────────────────────────────────────────────────────
 
@@ -72,6 +73,13 @@ export async function collectMemorySnapshot(store: MemorySnapshotStore): Promise
 const execAsync = promisify(exec)
 const PS_EXEC_TIMEOUT_MS = 5_000
 const PS_MAX_BUFFER = 10 * 1024 * 1024
+const TYPEPERF_COUNTERS = [
+  '\\Process(*)\\ID Process',
+  '\\Process(*)\\Creating Process ID',
+  '\\Process(*)\\Working Set'
+] as const
+const TYPEPERF_MAX_FIELDS = 8_192
+const TYPEPERF_MAX_LINE_CHARS = 1024 * 1024
 
 /** One row from the host-wide process listing. */
 type ProcRow = {
@@ -83,7 +91,7 @@ type ProcRow = {
   memory: number
 }
 
-/** Indexed view of a single `ps`/`wmic` sweep. */
+/** Indexed view of a single host process sweep. */
 type ProcIndex = {
   byPid: Map<number, ProcRow>
   childrenOf: Map<number, number[]>
@@ -226,69 +234,212 @@ export function parsePsOutput(stdout: string): ProcRow[] {
 }
 
 async function enumerateWindows(): Promise<ProcRow[]> {
-  // Why: `wmic` ships with stock Windows and emits a plain, tab-separated
-  // table without the CSV-quoting edge cases PowerShell's ConvertTo-Csv
-  // introduces. CPU% would require delta sampling between two queries; for
-  // v1 we report 0% on Windows — memory attribution is the primary signal.
+  // Why: WMIC is removed from current Windows releases, while WMI/CIM can be
+  // slow or unavailable on otherwise healthy machines. typeperf reads the
+  // built-in process counters without WMI and includes the PID, parent PID,
+  // and working set needed for subtree attribution. CIM remains a locale-
+  // independent fallback when localized counter names make typeperf fail.
+  if (windowsProcessBackend === 'typeperf') {
+    const typeperfRows = await enumerateWindowsWithTypeperf()
+    if (typeperfRows.length > 0) {
+      return typeperfRows
+    }
+    // Counter names are localized on some Windows installations. Once the
+    // probe fails, avoid spawning and warning about it on every two-second
+    // Resource Manager poll; CIM remains the backend until app restart.
+    windowsProcessBackend = 'cim'
+  }
+  return enumerateWindowsWithCim()
+}
+
+async function enumerateWindowsWithTypeperf(): Promise<ProcRow[]> {
   try {
-    const { stdout } = await execAsync(
-      'wmic process get ProcessId,ParentProcessId,WorkingSetSize /format:value',
-      { maxBuffer: PS_MAX_BUFFER, timeout: PS_EXEC_TIMEOUT_MS }
-    )
-    return parseWmicOutput(stdout)
+    // `-si 0` asks for the first sample immediately; the default one-second
+    // interval would consume half of Resource Manager's two-second poll cycle.
+    const stdout = await execFileText('typeperf.exe', [
+      ...TYPEPERF_COUNTERS,
+      '-sc',
+      '1',
+      '-si',
+      '0'
+    ])
+    return parseTypeperfProcessOutput(stdout)
   } catch (err) {
-    console.warn('[memory] wmic enumeration failed', err)
+    console.warn('[memory] typeperf process enumeration failed; falling back to CIM', err)
     return []
   }
 }
 
-/** Exported for tests: parses `wmic /format:value` stanza output. */
-export function parseWmicOutput(stdout: string): ProcRow[] {
-  // wmic /format:value emits stanzas of `Key=Value` lines separated by blank
-  // lines. We accumulate a record until a blank line, then flush.
+async function enumerateWindowsWithCim(): Promise<ProcRow[]> {
+  const args = [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    'Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,WorkingSetSize | ForEach-Object { [string]::Join([char]9, @($_.ProcessId, $_.ParentProcessId, $_.WorkingSetSize)) }'
+  ]
+  try {
+    const stdout = await execFileText('powershell.exe', args)
+    return parseWindowsProcessOutput(stdout)
+  } catch (err) {
+    console.warn('[memory] PowerShell process enumeration failed', err)
+    return []
+  }
+}
+
+function execFileText(file: string, args: string[]): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      {
+        encoding: 'utf8',
+        maxBuffer: PS_MAX_BUFFER,
+        timeout: PS_EXEC_TIMEOUT_MS,
+        windowsHide: true
+      },
+      (err, output) => {
+        if (err) {
+          reject(err)
+          return
+        }
+        resolve(String(output))
+      }
+    )
+  })
+}
+
+type TypeperfProcessFields = {
+  pid?: number
+  ppid?: number
+  memory?: number
+}
+
+/** Exported for tests: parses one CSV sample from Windows `typeperf`. */
+export function parseTypeperfProcessOutput(stdout: string): ProcRow[] {
+  let headers: string[] | null = null
+  let values: string[] | null = null
+
+  for (const line of iterateProcessOutputLines(stdout)) {
+    if (!line || line.length > TYPEPERF_MAX_LINE_CHARS) {
+      continue
+    }
+    const fields = parseTypeperfCsvLine(line)
+    if (!headers && fields[0]?.startsWith('(PDH-CSV')) {
+      headers = fields
+      continue
+    }
+    if (headers && fields.length === headers.length) {
+      values = fields
+      break
+    }
+  }
+
+  if (!headers || !values) {
+    return []
+  }
+
+  const byInstance = new Map<string, TypeperfProcessFields>()
+  for (let index = 1; index < headers.length; index += 1) {
+    const path = parseTypeperfCounterPath(headers[index])
+    if (!path || path.instance === '_Total') {
+      continue
+    }
+    const value = Number.parseFloat(values[index])
+    if (!Number.isFinite(value)) {
+      continue
+    }
+    const row = byInstance.get(path.instance) ?? {}
+    if (path.counter === 'ID Process') {
+      row.pid = Math.trunc(value)
+    } else if (path.counter === 'Creating Process ID') {
+      row.ppid = Math.trunc(value)
+    } else if (path.counter === 'Working Set') {
+      row.memory = value
+    }
+    byInstance.set(path.instance, row)
+  }
+
   const rows: ProcRow[] = []
-  let pid = Number.NaN
-  let ppid = Number.NaN
-  let ws = Number.NaN
-
-  const flush = (): void => {
-    if (!Number.isNaN(pid) && !Number.isNaN(ppid)) {
-      rows.push({
-        pid,
-        ppid,
-        cpu: 0,
-        memory: Number.isFinite(ws) && ws > 0 ? ws : 0
-      })
-    }
-    pid = Number.NaN
-    ppid = Number.NaN
-    ws = Number.NaN
-  }
-
-  for (const raw of stdout.split(/\r?\n/)) {
-    const line = raw.trim()
-    if (line.length === 0) {
-      flush()
+  for (const row of byInstance.values()) {
+    if (row.pid === undefined || row.pid <= 0 || row.ppid === undefined || row.ppid < 0) {
       continue
     }
-    const eq = line.indexOf('=')
-    if (eq < 0) {
-      continue
-    }
-    const key = line.slice(0, eq)
-    const value = line.slice(eq + 1)
-    if (key === 'ProcessId') {
-      pid = Number.parseInt(value, 10)
-    } else if (key === 'ParentProcessId') {
-      ppid = Number.parseInt(value, 10)
-    } else if (key === 'WorkingSetSize') {
-      ws = Number.parseInt(value, 10)
-    }
+    rows.push({
+      pid: row.pid,
+      ppid: row.ppid,
+      cpu: 0,
+      memory: row.memory !== undefined && row.memory > 0 ? row.memory : 0
+    })
   }
-  flush()
   return rows
 }
 
+function parseTypeperfCounterPath(path: string): { instance: string; counter: string } | null {
+  const processStart = path.lastIndexOf('\\Process(')
+  const counterStart = path.lastIndexOf(')\\')
+  if (processStart < 0 || counterStart <= processStart + 9) {
+    return null
+  }
+  return {
+    instance: path.slice(processStart + 9, counterStart),
+    counter: path.slice(counterStart + 2)
+  }
+}
+
+function parseTypeperfCsvLine(line: string): string[] {
+  const fields: string[] = []
+  let value = ''
+  let quoted = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    if (char === '"') {
+      if (quoted && line[index + 1] === '"') {
+        value += '"'
+        index += 1
+      } else {
+        quoted = !quoted
+      }
+      continue
+    }
+    if (char === ',' && !quoted) {
+      fields.push(value)
+      value = ''
+      if (fields.length >= TYPEPERF_MAX_FIELDS) {
+        return []
+      }
+      continue
+    }
+    value += char
+  }
+  fields.push(value)
+  return fields
+}
+
+/** Exported for tests: parses tab-delimited PowerShell CIM process rows. */
+export function parseWindowsProcessOutput(stdout: string): ProcRow[] {
+  const rows: ProcRow[] = []
+  for (const line of iterateProcessOutputLines(stdout)) {
+    const fields = getProcessOutputFields(line, 3)
+    if (fields.length < 3) {
+      continue
+    }
+    const pid = Number.parseInt(fields[0], 10)
+    const ppid = Number.parseInt(fields[1], 10)
+    const memory = Number.parseInt(fields[2], 10)
+    if (Number.isNaN(pid) || pid <= 0 || Number.isNaN(ppid) || ppid < 0) {
+      continue
+    }
+    rows.push({
+      pid,
+      ppid,
+      cpu: 0,
+      memory: Number.isFinite(memory) && memory > 0 ? memory : 0
+    })
+  }
+  return rows
+}
 /** Walk every descendant PID of `root`, inclusive. Exported for tests. */
 export function collectSubtree(index: ProcIndex, root: number): number[] {
   const result: number[] = []

--- a/src/main/memory/windows-process-resource-collector.ts
+++ b/src/main/memory/windows-process-resource-collector.ts
@@ -1,0 +1,341 @@
+import { execFile } from 'node:child_process'
+import os from 'node:os'
+import { performance } from 'node:perf_hooks'
+import {
+  iterateProcessOutputLines,
+  PROCESS_OUTPUT_FIELD_SCAN_MAX_CHARS
+} from '../../shared/process-output-field-scanner'
+
+const PROCESS_QUERY_TIMEOUT_MS = 5_000
+const PROCESS_QUERY_MAX_BUFFER = 10 * 1024 * 1024
+const TYPEPERF_COUNTERS = [
+  '\\Process(*)\\ID Process',
+  '\\Process(*)\\Creating Process ID',
+  '\\Process(*)\\Working Set'
+] as const
+const TYPEPERF_MAX_FIELDS = 8_192
+const TYPEPERF_MAX_LINE_CHARS = 1024 * 1024
+const CPU_MIN_SAMPLE_MS = 250
+const CPU_STALE_AFTER_MS = 10_000
+const HUNDRED_NS_TICKS_PER_MS = 10_000
+const CIM_RETRY_AFTER_MS = 30_000
+
+export type WindowsProcessResourceRow = {
+  pid: number
+  ppid: number
+  /** Percent of one core (may exceed 100 on multi-core). */
+  cpu: number
+  /** Resident memory in bytes. */
+  memory: number
+}
+
+type WindowsCpuTimes = {
+  cpuTicks: bigint
+  startTimeId: string
+}
+
+type WindowsProcessSample = {
+  sampledAtMs: number
+  rows: WindowsProcessResourceRow[]
+  cpuByPid: Map<number, WindowsCpuTimes>
+}
+
+type ParsedWindowsProcessSample = Omit<WindowsProcessSample, 'sampledAtMs'>
+
+type TypeperfProcessFields = {
+  pid?: number
+  ppid?: number
+  memory?: number
+}
+
+let processBackend: 'cim' | 'typeperf' = 'cim'
+let previousCpuSample: WindowsProcessSample | null = null
+let retryCimAtMs = 0
+
+export async function enumerateWindowsProcessResources(): Promise<WindowsProcessResourceRow[]> {
+  // Why: one CIM sweep supplies both resource values and process identity,
+  // avoiding a second host-wide PowerShell process on every open-popover poll.
+  if (processBackend === 'typeperf') {
+    if (performance.now() < retryCimAtMs) {
+      return enumerateWindowsWithTypeperf()
+    }
+    processBackend = 'cim'
+  }
+
+  const sample = await enumerateWindowsWithCim()
+  if (sample) {
+    return applyWindowsCpuSample(sample)
+  }
+  // Why: avoid repeating a blocked CIM timeout every two-second poll while
+  // still recovering CPU attribution after a transient PowerShell failure.
+  processBackend = 'typeperf'
+  retryCimAtMs = performance.now() + CIM_RETRY_AFTER_MS
+  previousCpuSample = null
+  return enumerateWindowsWithTypeperf()
+}
+
+function applyWindowsCpuSample(sample: WindowsProcessSample): WindowsProcessResourceRow[] {
+  const previous = previousCpuSample
+  if (!previous) {
+    previousCpuSample = sample
+    return sample.rows
+  }
+  const elapsedMs = sample.sampledAtMs - previous.sampledAtMs
+  if (elapsedMs < CPU_MIN_SAMPLE_MS) {
+    // Why: forced snapshots can land too close together for a stable rate.
+    // Keep the older baseline so the next normal poll spans a useful interval.
+    return sample.rows
+  }
+  previousCpuSample = sample
+  if (elapsedMs > CPU_STALE_AFTER_MS) {
+    // Why: closing Resource Manager or sleeping the machine leaves a stale
+    // baseline whose long-term average is not the current CPU usage.
+    return sample.rows
+  }
+
+  const maxProcessCpu = Math.max(1, os.cpus().length) * 100
+  for (const row of sample.rows) {
+    const currentTimes = sample.cpuByPid.get(row.pid)
+    const previousTimes = previous.cpuByPid.get(row.pid)
+    // Why: process start time prevents a recycled PID from inheriting the old
+    // process's cumulative CPU time; counter resets likewise warm up again.
+    if (
+      !currentTimes ||
+      !previousTimes ||
+      currentTimes.startTimeId !== previousTimes.startTimeId ||
+      currentTimes.cpuTicks < previousTimes.cpuTicks
+    ) {
+      continue
+    }
+    const cpuMs = Number(currentTimes.cpuTicks - previousTimes.cpuTicks) / HUNDRED_NS_TICKS_PER_MS
+    row.cpu = Math.min(maxProcessCpu, nonNegativeNumber((cpuMs / elapsedMs) * 100))
+  }
+  return sample.rows
+}
+
+async function enumerateWindowsWithCim(): Promise<WindowsProcessSample | null> {
+  const args = [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue'; " +
+      'Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,WorkingSetSize,KernelModeTime,UserModeTime,CreationDate | ' +
+      'ForEach-Object { try { [string]::Join([char]9, @($_.ProcessId, $_.ParentProcessId, $_.WorkingSetSize, [string]$_.KernelModeTime, [string]$_.UserModeTime, $_.CreationDate.ToUniversalTime().Ticks)) } catch {} }'
+  ]
+  try {
+    const stdout = await execFileText('powershell.exe', args)
+    const parsed = parseWindowsProcessSample(stdout)
+    return parsed.rows.length > 0 ? { ...parsed, sampledAtMs: performance.now() } : null
+  } catch (err) {
+    console.warn('[memory] PowerShell process enumeration failed; falling back to typeperf', err)
+    return null
+  }
+}
+
+async function enumerateWindowsWithTypeperf(): Promise<WindowsProcessResourceRow[]> {
+  try {
+    // Why: an immediate sample keeps the memory-only fallback inside the
+    // Resource Manager's two-second poll interval without inventing CPU rates.
+    const stdout = await execFileText('typeperf.exe', [
+      ...TYPEPERF_COUNTERS,
+      '-sc',
+      '1',
+      '-si',
+      '0'
+    ])
+    return parseTypeperfProcessOutput(stdout)
+  } catch (err) {
+    console.warn('[memory] typeperf process enumeration failed', err)
+    return []
+  }
+}
+
+function execFileText(file: string, args: string[]): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      {
+        encoding: 'utf8',
+        maxBuffer: PROCESS_QUERY_MAX_BUFFER,
+        timeout: PROCESS_QUERY_TIMEOUT_MS,
+        windowsHide: true
+      },
+      (err, output) => {
+        if (err) {
+          reject(err)
+          return
+        }
+        resolve(String(output))
+      }
+    )
+  })
+}
+
+function parseWindowsProcessSample(stdout: string): ParsedWindowsProcessSample {
+  const rows: WindowsProcessResourceRow[] = []
+  const cpuByPid = new Map<number, WindowsCpuTimes>()
+  for (const line of iterateProcessOutputLines(stdout)) {
+    const fields = parseCimTabFields(line)
+    if (fields.length < 3) {
+      continue
+    }
+    const pid = Number.parseInt(fields[0], 10)
+    const ppid = Number.parseInt(fields[1], 10)
+    const memory = Number.parseInt(fields[2], 10)
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !Number.isSafeInteger(ppid) || ppid < 0) {
+      continue
+    }
+    rows.push({
+      pid,
+      ppid,
+      cpu: 0,
+      memory: Number.isFinite(memory) && memory > 0 ? memory : 0
+    })
+
+    const kernelTicks = parseUnsignedBigInt(fields[3])
+    const userTicks = parseUnsignedBigInt(fields[4])
+    const startTimeId = fields[5] ?? ''
+    if (
+      kernelTicks !== null &&
+      userTicks !== null &&
+      /^\d+$/.test(startTimeId) &&
+      !/^0+$/.test(startTimeId)
+    ) {
+      cpuByPid.set(pid, { cpuTicks: kernelTicks + userTicks, startTimeId })
+    }
+  }
+  return { rows, cpuByPid }
+}
+
+function parseCimTabFields(line: string): string[] {
+  // Why: CIM serializes null properties as empty tab fields; collapsing
+  // whitespace would shift CPU counters into the working-set column.
+  if (line.length > PROCESS_OUTPUT_FIELD_SCAN_MAX_CHARS) {
+    return []
+  }
+  return line.split('\t', 6).map((field) => field.trim())
+}
+
+/** Parse tab-delimited PowerShell CIM process rows without deriving CPU deltas. */
+export function parseWindowsProcessOutput(stdout: string): WindowsProcessResourceRow[] {
+  return parseWindowsProcessSample(stdout).rows
+}
+
+/** Parse one CSV sample from Windows Typeperf. */
+export function parseTypeperfProcessOutput(stdout: string): WindowsProcessResourceRow[] {
+  let headers: string[] | null = null
+  let values: string[] | null = null
+
+  for (const line of iterateProcessOutputLines(stdout)) {
+    if (!line || line.length > TYPEPERF_MAX_LINE_CHARS) {
+      continue
+    }
+    const fields = parseTypeperfCsvLine(line)
+    if (!headers && fields[0]?.startsWith('(PDH-CSV')) {
+      headers = fields
+      continue
+    }
+    if (headers && fields.length === headers.length) {
+      values = fields
+      break
+    }
+  }
+
+  if (!headers || !values) {
+    return []
+  }
+
+  const byInstance = new Map<string, TypeperfProcessFields>()
+  for (let index = 1; index < headers.length; index += 1) {
+    const path = parseTypeperfCounterPath(headers[index])
+    if (!path || path.instance === '_Total') {
+      continue
+    }
+    const value = Number.parseFloat(values[index])
+    if (!Number.isFinite(value)) {
+      continue
+    }
+    const row = byInstance.get(path.instance) ?? {}
+    if (path.counter === 'ID Process') {
+      row.pid = Math.trunc(value)
+    } else if (path.counter === 'Creating Process ID') {
+      row.ppid = Math.trunc(value)
+    } else if (path.counter === 'Working Set') {
+      row.memory = value
+    }
+    byInstance.set(path.instance, row)
+  }
+
+  const rows: WindowsProcessResourceRow[] = []
+  for (const row of byInstance.values()) {
+    if (row.pid === undefined || row.pid <= 0 || row.ppid === undefined || row.ppid < 0) {
+      continue
+    }
+    rows.push({
+      pid: row.pid,
+      ppid: row.ppid,
+      cpu: 0,
+      memory: row.memory !== undefined && row.memory > 0 ? row.memory : 0
+    })
+  }
+  return rows
+}
+
+function parseTypeperfCounterPath(path: string): { instance: string; counter: string } | null {
+  const processStart = path.lastIndexOf('\\Process(')
+  const counterStart = path.lastIndexOf(')\\')
+  if (processStart < 0 || counterStart <= processStart + 9) {
+    return null
+  }
+  return {
+    instance: path.slice(processStart + 9, counterStart),
+    counter: path.slice(counterStart + 2)
+  }
+}
+
+function parseTypeperfCsvLine(line: string): string[] {
+  const fields: string[] = []
+  let value = ''
+  let quoted = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    if (char === '"') {
+      if (quoted && line[index + 1] === '"') {
+        value += '"'
+        index += 1
+      } else {
+        quoted = !quoted
+      }
+      continue
+    }
+    if (char === ',' && !quoted) {
+      fields.push(value)
+      value = ''
+      if (fields.length >= TYPEPERF_MAX_FIELDS) {
+        return []
+      }
+      continue
+    }
+    value += char
+  }
+  fields.push(value)
+  return fields
+}
+
+function parseUnsignedBigInt(value: string | undefined): bigint | null {
+  if (!value || !/^\d+$/.test(value)) {
+    return null
+  }
+  try {
+    return BigInt(value)
+  } catch {
+    return null
+  }
+}
+
+function nonNegativeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0
+}


### PR DESCRIPTION
## Summary

- restore Windows Resource Manager memory and CPU attribution on systems where `wmic.exe` is unavailable
- collect PID, parent PID, working set, cumulative kernel/user CPU ticks, and process creation identity with one PowerShell CIM process per healthy Resource Manager poll
- fall back to `typeperf.exe` for memory only after a failed CIM sample, retry CIM after a bounded 30-second cooldown, and warm a fresh CPU baseline on recovery
- protect CPU deltas against PID reuse, unsafe integer conversion, too-short sample intervals, stale samples, and values above the host-core capacity
- keep the existing macOS/Linux, SSH/runtime-host, history, and process-subtree behavior unchanged

Windows 11 25H2 removes WMIC, so the previous collector could return an empty process index and local PTY subtrees would resolve to 0 KB. The Windows collector also hardcoded process CPU to zero, leaving every terminal at 0.0% even while busy.

Microsoft reference: [WMIC removal in Windows 11 25H2](https://learn.microsoft.com/en-us/windows/whats-new/whats-new-windows-11-version-25h2).

## Performance and resilience

- healthy sampling launches exactly one Resource Manager PowerShell child per poll
- aggregate child CPU per poll measured at approximately 191 ms, down from approximately 391 ms for the earlier two-process implementation
- CIM output parsing preserves empty tab-separated fields and bounds input size
- a CIM timeout may delay one recovery poll by the existing five-second timeout, at most once per 30-second cooldown
- the separate foreground-process scanner remains independent because it has a different payload and freshness requirement

## Screenshots / live verification

No UI code or layout changed. Live Electron validation on Windows showed:

- a busy terminal at approximately 99.7-100% CPU and 152 MB memory
- backing-store attribution of 100.305% CPU and 161,075,200 bytes for the busy session
- CPU returning to 0 after the workload completed while memory remained populated
- at most one concurrent Resource Manager OS sample
- no renderer console errors, clipping, overlap, or layout regressions

## Testing

- [x] 31/31 Windows collector tests
- [x] 59/59 affected tests across collector and Resource Manager consumers
- [x] TypeScript typecheck
- [x] touched-file Oxlint, maximum-lines ratchet, reliability gates, and staged-diff checks
- [x] live Electron golden-path validation on Windows

The full `pnpm lint` command remains blocked by an unrelated pre-existing non-exhaustive switch in `src/renderer/src/components/skills/skill-freshness-group.tsx:101`; touched files pass lint.

## Implementation notes

- `execFile` launches only constant in-box executable names and arguments; no user-controlled shell command is constructed.
- child windows are hidden and retain bounded timeouts and output caps
- CPU counters and creation identities remain `bigint`/strings because Windows tick values can exceed JavaScript's safe integer range
- the first CPU observation, and the first observation after CIM recovery, intentionally reports zero because no comparable prior cumulative sample exists
- malformed, aggregate, negative, and incomplete rows are dropped or clamped without shifting later fields

PR #9048 independently implements overlapping Windows resource sampling inside a broader lifecycle/status refactor. This PR remains the focused collector fix with targeted tests and live Windows verification.

## AI review / security

Three review rounds and two fix rounds covered platform isolation, local versus remote behavior, process invocation, PID reuse, parser bounds, failure recovery, polling cost, and test portability. No auth, secrets, IPC contracts, dependencies, filesystem writes, or network access were added.

X: [@thecalendre](https://x.com/thecalendre)