### PR TITLE
fix(sidebar): keep the working spinner while a Claude Monitor runs

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -2286,35 +2286,41 @@ describe('shared agent-hook-listener', () => {
       expect(finalStop?.payload.subagents).toBeUndefined()
     })
 
-    it('reports Stop as working while a Monitor background task is still running', () => {
+    it('reports Stop as working while a Monitor (backgrounded shell) still runs', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'watch staging' })
+      // Why: the exact shape of a live 2.1.211 Stop payload once the Monitor
+      // tool is watching — the monitor is a running `shell` task (kind dropped),
+      // never type "monitor". The pane must keep spinning, not read a done ✅.
       const stop = claudeEvent({
         hook_event_name: 'Stop',
-        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
+        background_tasks: [
+          {
+            id: 'b32v7rxmz',
+            type: 'shell',
+            status: 'running',
+            description: 'sleep 300 background command',
+            command: 'sleep 300'
+          }
+        ]
       })
-      // Why: a Monitor watching in the background means the lead's turn will
-      // resume when it fires — the sidebar keeps spinning, not a done ✅.
       expect(stop?.payload.state).toBe('working')
-      // Why: a monitor is not an agent, so it contributes no subagent rows.
+      // Why: a shell/monitor is not an agent, so it contributes no child rows.
       expect(stop?.payload.subagents).toBeUndefined()
 
-      // Why: the monitor ending wakes the lead; the next Stop no longer lists
-      // it as running, so the pane settles to done.
-      const finalStop = claudeEvent({
-        hook_event_name: 'Stop',
-        background_tasks: [{ id: 'm1', type: 'monitor', status: 'completed' }]
-      })
+      // Why: the monitor ending wakes the lead; the next Stop's list no longer
+      // shows a running shell/monitor, so the pane settles to done.
+      const finalStop = claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
       expect(finalStop?.payload.state).toBe('done')
     })
 
-    it('retains a running Monitor across a later Stop whose payload omits background_tasks', () => {
+    it('retains a running Monitor across a later Stop that omits background_tasks', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'watch staging' })
       claudeEvent({
         hook_event_name: 'Stop',
-        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
+        background_tasks: [{ id: 's1', type: 'shell', status: 'running', command: 'sleep 300' }]
       })
       // Why: an older payload without the field must not clear the tracked
-      // monitor (mirrors how the roster is retained), so the pane stays working.
+      // shell/monitor (mirrors roster retention), so the pane stays working.
       const stop = claudeEvent({ hook_event_name: 'Stop' })
       expect(stop?.payload.state).toBe('working')
     })
@@ -2326,14 +2332,27 @@ describe('shared agent-hook-listener', () => {
         agent_id: 'a1',
         agent_type: 'general-purpose'
       })
-      // Why: the subagent finished but the monitor is still watching — the pane
-      // must stay working on the monitor alone, with no leftover child rows.
+      // Why: the subagent is gone from this list (finished) but the monitor is
+      // still watching — the pane must stay working on the monitor alone, with
+      // no leftover child rows.
       const stop = claudeEvent({
         hook_event_name: 'Stop',
-        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
+        background_tasks: [{ id: 's1', type: 'shell', status: 'running', command: 'sleep 300' }]
       })
       expect(stop?.payload.state).toBe('working')
       expect(stop?.payload.subagents).toBeUndefined()
+    })
+
+    it('keeps Stop done for a backgrounded shell that has finished', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'build once' })
+      // Why: a completed shell is filtered out of Claude's list, so a Stop with
+      // an empty list must resolve to done — the flag must not stick 'working'.
+      claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 's1', type: 'shell', status: 'running', command: 'sleep 1' }]
+      })
+      const finalStop = claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
+      expect(finalStop?.payload.state).toBe('done')
     })
 
     it('emits a status refresh with the lead state on subagent lifecycle events', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -2286,6 +2286,56 @@ describe('shared agent-hook-listener', () => {
       expect(finalStop?.payload.subagents).toBeUndefined()
     })
 
+    it('reports Stop as working while a Monitor background task is still running', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'watch staging' })
+      const stop = claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
+      })
+      // Why: a Monitor watching in the background means the lead's turn will
+      // resume when it fires — the sidebar keeps spinning, not a done ✅.
+      expect(stop?.payload.state).toBe('working')
+      // Why: a monitor is not an agent, so it contributes no subagent rows.
+      expect(stop?.payload.subagents).toBeUndefined()
+
+      // Why: the monitor ending wakes the lead; the next Stop no longer lists
+      // it as running, so the pane settles to done.
+      const finalStop = claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'm1', type: 'monitor', status: 'completed' }]
+      })
+      expect(finalStop?.payload.state).toBe('done')
+    })
+
+    it('retains a running Monitor across a later Stop whose payload omits background_tasks', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'watch staging' })
+      claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
+      })
+      // Why: an older payload without the field must not clear the tracked
+      // monitor (mirrors how the roster is retained), so the pane stays working.
+      const stop = claudeEvent({ hook_event_name: 'Stop' })
+      expect(stop?.payload.state).toBe('working')
+    })
+
+    it('reports Stop as working while a Monitor runs alongside a finished subagent', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'watch and review' })
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      // Why: the subagent finished but the monitor is still watching — the pane
+      // must stay working on the monitor alone, with no leftover child rows.
+      const stop = claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
+      })
+      expect(stop?.payload.state).toBe('working')
+      expect(stop?.payload.subagents).toBeUndefined()
+    })
+
     it('emits a status refresh with the lead state on subagent lifecycle events', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'kick off reviewers' })
       claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -35,6 +35,7 @@ import {
   type ParsedAgentStatusPayload
 } from './agent-status-types'
 import {
+  claudeBackgroundTasksHaveRunningMonitor,
   claudeRosterHasWorkingSubagent,
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
@@ -114,6 +115,13 @@ export type HookListenerState = {
    *  persists here because a gated 'working' emit clamps the flag away, and
    *  the eventual done (when the last child drains) must still carry it. */
   claudeLeadStateByPaneKey: Map<string, ClaudeLeadTurnState>
+  /** Whether a Claude pane still has a running Monitor background task. Set
+   *  from any present `background_tasks` list (Stop/SubagentStop). A running
+   *  monitor keeps the pane 'working' via the same gate that holds it working
+   *  while a subagent runs — the lead resumes when the monitor fires, so the
+   *  turn is not truly done. Survives turn boundaries like the roster; the
+   *  next present list without the monitor clears it. */
+  claudeRunningMonitorByPaneKey: Map<string, boolean>
 }
 
 export type ClaudeLeadTurnState = {
@@ -141,7 +149,8 @@ export function createHookListenerState(): HookListenerState {
     antigravityCompletedTranscriptByPaneKey: new Map(),
     ampCompletedCacheKeys: new Set(),
     claudeSubagentRosterByPaneKey: new Map(),
-    claudeLeadStateByPaneKey: new Map()
+    claudeLeadStateByPaneKey: new Map(),
+    claudeRunningMonitorByPaneKey: new Map()
   }
 }
 
@@ -153,6 +162,7 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   deletePaneScopedSetEntry(state.ampCompletedCacheKeys, paneKey)
   state.claudeSubagentRosterByPaneKey.delete(paneKey)
   state.claudeLeadStateByPaneKey.delete(paneKey)
+  state.claudeRunningMonitorByPaneKey.delete(paneKey)
 }
 
 function clearPaneTurnCacheState(state: HookListenerState, paneKey: string): void {
@@ -192,6 +202,7 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.warnedEnvs.clear()
   state.claudeSubagentRosterByPaneKey.clear()
   state.claudeLeadStateByPaneKey.clear()
+  state.claudeRunningMonitorByPaneKey.clear()
 }
 
 /** Emit warn-once diagnostics for cross-build (`version`) and dev-vs-prod
@@ -2378,6 +2389,28 @@ function getOrCreateClaudeSubagentRoster(
   return roster
 }
 
+/** Record whether a present `background_tasks` list still has a running
+ *  Monitor. Only call when the field is present (Stop/SubagentStop): an event
+ *  without the field must not clear a monitor tracked by an earlier turn, just
+ *  as the roster is retained across such events. */
+function updateClaudeRunningMonitorFromPayload(
+  state: HookListenerState,
+  paneKey: string,
+  hookPayload: Record<string, unknown>
+): void {
+  state.claudeRunningMonitorByPaneKey.set(
+    paneKey,
+    claudeBackgroundTasksHaveRunningMonitor(hookPayload)
+  )
+}
+
+/** Whether the pane's last present `background_tasks` list had a running
+ *  Monitor — a background task that keeps the lead's turn alive (Claude wakes
+ *  it when the monitor fires), so the pane stays 'working' rather than done. */
+function claudePaneHasRunningMonitor(state: HookListenerState, paneKey: string): boolean {
+  return state.claudeRunningMonitorByPaneKey.get(paneKey) === true
+}
+
 /** SubagentStart/SubagentStop/TeammateIdle don't map to a pane state by
  *  themselves; they update the roster and re-emit the lead's last known state
  *  with the fresh child list so the sidebar reflects spawn/finish immediately
@@ -2416,6 +2449,9 @@ function normalizeClaudeSubagentLifecycleEvent(
       // agent listed id-exact as a subagent task is a workflow/named one-shot
       // (teammate lifecycle ids never appear there), not a resumable teammate.
       const stopTasks = readClaudeBackgroundAgentTasks(hookPayload)
+      if (stopTasks.present) {
+        updateClaudeRunningMonitorFromPayload(state, paneKey, hookPayload)
+      }
       finishClaudeSubagent(roster, agentId, {
         listedAsSubagentTask:
           stopTasks.present && stopTasks.tasks.some((task) => !task.teammate && task.id === agentId)
@@ -2504,7 +2540,10 @@ function buildClaudeChildDrivenStatusPayload(
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
     stateName:
-      leadState === 'done' && claudeRosterHasWorkingSubagent(roster) ? 'working' : leadState,
+      leadState === 'done' &&
+      (claudeRosterHasWorkingSubagent(roster) || claudePaneHasRunningMonitor(state, paneKey))
+        ? 'working'
+        : leadState,
     updateToolSnapshot: false,
     interrupted: lead?.interrupted
   })
@@ -2590,7 +2629,8 @@ function normalizeClaudeEvent(
     const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
     return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
       stateName:
-        restored.state === 'done' && claudeRosterHasWorkingSubagent(roster)
+        restored.state === 'done' &&
+        (claudeRosterHasWorkingSubagent(roster) || claudePaneHasRunningMonitor(state, paneKey))
           ? 'working'
           : restored.state,
       updateToolSnapshot: true,
@@ -2618,6 +2658,7 @@ function normalizeClaudeEvent(
     // builds without the field keep the incrementally tracked roster.
     const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
     if (backgroundTasks.present) {
+      updateClaudeRunningMonitorFromPayload(state, paneKey, hookPayload)
       foldClaudeBackgroundTasksIntoRoster(
         getOrCreateClaudeSubagentRoster(state, paneKey),
         backgroundTasks.tasks,
@@ -2650,12 +2691,17 @@ function normalizeClaudeEvent(
   })
 
   // Why: the lead ending its turn is not "done" while spawned subagents or
-  // teammates are still running — that reads as a finished ✅ in the sidebar
-  // while a background review loop is mid-flight. Claude wakes the lead when
-  // a child finishes, so a later Stop with an empty roster resolves to done.
+  // teammates are still running, or while a Monitor background task is still
+  // watching — that reads as a finished ✅ in the sidebar while a background
+  // review loop or monitor is mid-flight. Claude wakes the lead when a child
+  // finishes or a monitor fires, so a later Stop whose background_tasks no
+  // longer list the child/monitor resolves to done.
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   const effectiveState =
-    stateName === 'done' && claudeRosterHasWorkingSubagent(roster) ? 'working' : stateName
+    stateName === 'done' &&
+    (claudeRosterHasWorkingSubagent(roster) || claudePaneHasRunningMonitor(state, paneKey))
+      ? 'working'
+      : stateName
 
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -35,7 +35,7 @@ import {
   type ParsedAgentStatusPayload
 } from './agent-status-types'
 import {
-  claudeBackgroundTasksHaveRunningMonitor,
+  claudeBackgroundTasksHaveRunningShellOrMonitor,
   claudeRosterHasWorkingSubagent,
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
@@ -115,13 +115,15 @@ export type HookListenerState = {
    *  persists here because a gated 'working' emit clamps the flag away, and
    *  the eventual done (when the last child drains) must still carry it. */
   claudeLeadStateByPaneKey: Map<string, ClaudeLeadTurnState>
-  /** Whether a Claude pane still has a running Monitor background task. Set
-   *  from any present `background_tasks` list (Stop/SubagentStop). A running
-   *  monitor keeps the pane 'working' via the same gate that holds it working
-   *  while a subagent runs — the lead resumes when the monitor fires, so the
-   *  turn is not truly done. Survives turn boundaries like the roster; the
-   *  next present list without the monitor clears it. */
-  claudeRunningMonitorByPaneKey: Map<string, boolean>
+  /** Whether a Claude pane still has a running backgrounded shell/monitor task.
+   *  Set from any present `background_tasks` list (Stop/SubagentStop). The
+   *  `Monitor` tool surfaces there as a running `shell` task (its internal
+   *  `kind: "monitor"` is dropped from the payload), so a running shell/monitor
+   *  keeps the pane 'working' via the same gate that holds it working while a
+   *  subagent runs — the lead resumes when the task fires, so the turn is not
+   *  truly done. Survives turn boundaries like the roster; the next present
+   *  list without such a task clears it. */
+  claudeRunningShellOrMonitorByPaneKey: Map<string, boolean>
 }
 
 export type ClaudeLeadTurnState = {
@@ -150,7 +152,7 @@ export function createHookListenerState(): HookListenerState {
     ampCompletedCacheKeys: new Set(),
     claudeSubagentRosterByPaneKey: new Map(),
     claudeLeadStateByPaneKey: new Map(),
-    claudeRunningMonitorByPaneKey: new Map()
+    claudeRunningShellOrMonitorByPaneKey: new Map()
   }
 }
 
@@ -162,7 +164,7 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   deletePaneScopedSetEntry(state.ampCompletedCacheKeys, paneKey)
   state.claudeSubagentRosterByPaneKey.delete(paneKey)
   state.claudeLeadStateByPaneKey.delete(paneKey)
-  state.claudeRunningMonitorByPaneKey.delete(paneKey)
+  state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
 }
 
 function clearPaneTurnCacheState(state: HookListenerState, paneKey: string): void {
@@ -202,7 +204,7 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.warnedEnvs.clear()
   state.claudeSubagentRosterByPaneKey.clear()
   state.claudeLeadStateByPaneKey.clear()
-  state.claudeRunningMonitorByPaneKey.clear()
+  state.claudeRunningShellOrMonitorByPaneKey.clear()
 }
 
 /** Emit warn-once diagnostics for cross-build (`version`) and dev-vs-prod
@@ -2390,25 +2392,27 @@ function getOrCreateClaudeSubagentRoster(
 }
 
 /** Record whether a present `background_tasks` list still has a running
- *  Monitor. Only call when the field is present (Stop/SubagentStop): an event
- *  without the field must not clear a monitor tracked by an earlier turn, just
- *  as the roster is retained across such events. */
-function updateClaudeRunningMonitorFromPayload(
+ *  backgrounded shell/monitor. Only call when the field is present
+ *  (Stop/SubagentStop): an event without the field must not clear a task
+ *  tracked by an earlier turn, just as the roster is retained across such
+ *  events. */
+function updateClaudeRunningShellOrMonitorFromPayload(
   state: HookListenerState,
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): void {
-  state.claudeRunningMonitorByPaneKey.set(
+  state.claudeRunningShellOrMonitorByPaneKey.set(
     paneKey,
-    claudeBackgroundTasksHaveRunningMonitor(hookPayload)
+    claudeBackgroundTasksHaveRunningShellOrMonitor(hookPayload)
   )
 }
 
-/** Whether the pane's last present `background_tasks` list had a running
- *  Monitor — a background task that keeps the lead's turn alive (Claude wakes
- *  it when the monitor fires), so the pane stays 'working' rather than done. */
-function claudePaneHasRunningMonitor(state: HookListenerState, paneKey: string): boolean {
-  return state.claudeRunningMonitorByPaneKey.get(paneKey) === true
+/** Whether the pane's last present `background_tasks` list still had a running
+ *  backgrounded shell/monitor (e.g. the `Monitor` tool, which surfaces there as
+ *  a running shell). Such a task keeps the lead's turn alive — Claude resumes
+ *  the lead when it fires — so the pane stays 'working' rather than done. */
+function claudePaneHasRunningShellOrMonitor(state: HookListenerState, paneKey: string): boolean {
+  return state.claudeRunningShellOrMonitorByPaneKey.get(paneKey) === true
 }
 
 /** SubagentStart/SubagentStop/TeammateIdle don't map to a pane state by
@@ -2450,7 +2454,7 @@ function normalizeClaudeSubagentLifecycleEvent(
       // (teammate lifecycle ids never appear there), not a resumable teammate.
       const stopTasks = readClaudeBackgroundAgentTasks(hookPayload)
       if (stopTasks.present) {
-        updateClaudeRunningMonitorFromPayload(state, paneKey, hookPayload)
+        updateClaudeRunningShellOrMonitorFromPayload(state, paneKey, hookPayload)
       }
       finishClaudeSubagent(roster, agentId, {
         listedAsSubagentTask:
@@ -2541,7 +2545,7 @@ function buildClaudeChildDrivenStatusPayload(
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
     stateName:
       leadState === 'done' &&
-      (claudeRosterHasWorkingSubagent(roster) || claudePaneHasRunningMonitor(state, paneKey))
+      (claudeRosterHasWorkingSubagent(roster) || claudePaneHasRunningShellOrMonitor(state, paneKey))
         ? 'working'
         : leadState,
     updateToolSnapshot: false,
@@ -2630,7 +2634,8 @@ function normalizeClaudeEvent(
     return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
       stateName:
         restored.state === 'done' &&
-        (claudeRosterHasWorkingSubagent(roster) || claudePaneHasRunningMonitor(state, paneKey))
+        (claudeRosterHasWorkingSubagent(roster) ||
+          claudePaneHasRunningShellOrMonitor(state, paneKey))
           ? 'working'
           : restored.state,
       updateToolSnapshot: true,
@@ -2658,7 +2663,7 @@ function normalizeClaudeEvent(
     // builds without the field keep the incrementally tracked roster.
     const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
     if (backgroundTasks.present) {
-      updateClaudeRunningMonitorFromPayload(state, paneKey, hookPayload)
+      updateClaudeRunningShellOrMonitorFromPayload(state, paneKey, hookPayload)
       foldClaudeBackgroundTasksIntoRoster(
         getOrCreateClaudeSubagentRoster(state, paneKey),
         backgroundTasks.tasks,
@@ -2691,15 +2696,16 @@ function normalizeClaudeEvent(
   })
 
   // Why: the lead ending its turn is not "done" while spawned subagents or
-  // teammates are still running, or while a Monitor background task is still
-  // watching — that reads as a finished ✅ in the sidebar while a background
-  // review loop or monitor is mid-flight. Claude wakes the lead when a child
-  // finishes or a monitor fires, so a later Stop whose background_tasks no
-  // longer list the child/monitor resolves to done.
+  // teammates are still running, or while a backgrounded shell/monitor task is
+  // still watching — that reads as a finished ✅ in the sidebar while a
+  // background review loop or a Monitor is mid-flight. Claude wakes the lead
+  // when a child finishes or a monitor fires, so a later Stop whose roster is
+  // empty and whose background_tasks no longer list the shell/monitor resolves
+  // to done.
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   const effectiveState =
     stateName === 'done' &&
-    (claudeRosterHasWorkingSubagent(roster) || claudePaneHasRunningMonitor(state, paneKey))
+    (claudeRosterHasWorkingSubagent(roster) || claudePaneHasRunningShellOrMonitor(state, paneKey))
       ? 'working'
       : stateName
 

--- a/src/shared/claude-subagent-roster.test.ts
+++ b/src/shared/claude-subagent-roster.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
 import {
+  claudeBackgroundTasksHaveRunningMonitor,
   claudeRosterHasWorkingSubagent,
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
@@ -184,6 +185,40 @@ describe('claude-subagent-roster', () => {
   it('reports background_tasks as absent when missing or malformed', () => {
     expect(readClaudeBackgroundAgentTasks({}).present).toBe(false)
     expect(readClaudeBackgroundAgentTasks({ background_tasks: 'nope' }).present).toBe(false)
+  })
+
+  it('detects a running Monitor background task (incl. ws/mcp variants)', () => {
+    expect(
+      claudeBackgroundTasksHaveRunningMonitor({
+        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
+      })
+    ).toBe(true)
+    // Why: match on the `monitor` prefix so ws/mcp monitor variants gate too.
+    expect(
+      claudeBackgroundTasksHaveRunningMonitor({
+        background_tasks: [{ id: 'm2', type: 'monitor_ws', status: 'running' }]
+      })
+    ).toBe(true)
+  })
+
+  it('ignores finished monitors and non-monitor running tasks', () => {
+    // Why: a monitor that has stopped no longer holds the pane working.
+    expect(
+      claudeBackgroundTasksHaveRunningMonitor({
+        background_tasks: [{ id: 'm1', type: 'monitor', status: 'completed' }]
+      })
+    ).toBe(false)
+    // Why: only monitors gate here — running shells/workflows/subagents do not.
+    expect(
+      claudeBackgroundTasksHaveRunningMonitor({
+        background_tasks: [
+          { id: 's1', type: 'shell', status: 'running' },
+          { id: 'a1', type: 'subagent', status: 'running' }
+        ]
+      })
+    ).toBe(false)
+    expect(claudeBackgroundTasksHaveRunningMonitor({})).toBe(false)
+    expect(claudeBackgroundTasksHaveRunningMonitor({ background_tasks: 'nope' })).toBe(false)
   })
 
   it('marks a background task inventory truncated after the snapshot cap', () => {

--- a/src/shared/claude-subagent-roster.test.ts
+++ b/src/shared/claude-subagent-roster.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
 import {
-  claudeBackgroundTasksHaveRunningMonitor,
+  claudeBackgroundTasksHaveRunningShellOrMonitor,
   claudeRosterHasWorkingSubagent,
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
@@ -187,38 +187,59 @@ describe('claude-subagent-roster', () => {
     expect(readClaudeBackgroundAgentTasks({ background_tasks: 'nope' }).present).toBe(false)
   })
 
-  it('detects a running Monitor background task (incl. ws/mcp variants)', () => {
+  it('detects a running Monitor, which surfaces as a running shell task', () => {
+    // Why: this is the exact shape of a live 2.1.211 Stop payload after the
+    // Monitor tool starts — type "shell" (its kind:"monitor" is dropped), NOT
+    // type "monitor". Matching only "monitor" here was the shipped bug.
     expect(
-      claudeBackgroundTasksHaveRunningMonitor({
-        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
+      claudeBackgroundTasksHaveRunningShellOrMonitor({
+        background_tasks: [
+          {
+            id: 'b32v7rxmz',
+            type: 'shell',
+            status: 'running',
+            description: 'sleep 300 background command',
+            command: 'sleep 300'
+          }
+        ]
       })
     ).toBe(true)
-    // Why: match on the `monitor` prefix so ws/mcp monitor variants gate too.
+    // Why: a pending shell/monitor is queued background work — also keep-alive.
     expect(
-      claudeBackgroundTasksHaveRunningMonitor({
-        background_tasks: [{ id: 'm2', type: 'monitor_ws', status: 'running' }]
+      claudeBackgroundTasksHaveRunningShellOrMonitor({
+        background_tasks: [{ id: 's1', type: 'shell', status: 'pending' }]
+      })
+    ).toBe(true)
+    // Why: websocket/MCP monitors surface as type "monitor" — cover them too.
+    expect(
+      claudeBackgroundTasksHaveRunningShellOrMonitor({
+        background_tasks: [{ id: 'm1', type: 'monitor', status: 'running' }]
       })
     ).toBe(true)
   })
 
-  it('ignores finished monitors and non-monitor running tasks', () => {
-    // Why: a monitor that has stopped no longer holds the pane working.
+  it('ignores finished shells, subagents, and forever-running teammates', () => {
+    // Why: a shell/monitor that has stopped no longer holds the pane working.
     expect(
-      claudeBackgroundTasksHaveRunningMonitor({
-        background_tasks: [{ id: 'm1', type: 'monitor', status: 'completed' }]
+      claudeBackgroundTasksHaveRunningShellOrMonitor({
+        background_tasks: [{ id: 's1', type: 'shell', status: 'completed' }]
       })
     ).toBe(false)
-    // Why: only monitors gate here — running shells/workflows/subagents do not.
+    // Why: subagents are the roster's job — excluded here to avoid double logic.
     expect(
-      claudeBackgroundTasksHaveRunningMonitor({
-        background_tasks: [
-          { id: 's1', type: 'shell', status: 'running' },
-          { id: 'a1', type: 'subagent', status: 'running' }
-        ]
+      claudeBackgroundTasksHaveRunningShellOrMonitor({
+        background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
       })
     ).toBe(false)
-    expect(claudeBackgroundTasksHaveRunningMonitor({})).toBe(false)
-    expect(claudeBackgroundTasksHaveRunningMonitor({ background_tasks: 'nope' })).toBe(false)
+    // Why: teammate entries read "running" forever even after the named agent
+    // finished — gating on them would pin the pane 'working' permanently.
+    expect(
+      claudeBackgroundTasksHaveRunningShellOrMonitor({
+        background_tasks: [{ id: 't1', type: 'teammate', status: 'running' }]
+      })
+    ).toBe(false)
+    expect(claudeBackgroundTasksHaveRunningShellOrMonitor({})).toBe(false)
+    expect(claudeBackgroundTasksHaveRunningShellOrMonitor({ background_tasks: 'nope' })).toBe(false)
   })
 
   it('marks a background task inventory truncated after the snapshot cap', () => {

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -172,15 +172,22 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
 }
 
 /** Whether a Stop/SubagentStop payload's `background_tasks` still lists a
- *  running Monitor. Monitors (Claude's `Monitor` tool) are non-agent
- *  background tasks — they never enter the subagent roster — but a running
- *  monitor means the lead's turn is not truly done: Claude wakes the lead when
- *  the monitor fires. Callers use this to keep the pane 'working' so the
- *  sidebar keeps spinning while a monitor watches, mirroring the existing
- *  subagent gate. Matched on the `monitor` type prefix (covers the ws/mcp
- *  monitor variants) so a single string tweak adapts if the wire type shifts;
- *  deliberately excludes shells/workflows/crons — only monitors gate here. */
-export function claudeBackgroundTasksHaveRunningMonitor(
+ *  running (or pending) backgrounded shell/monitor task — background work that
+ *  keeps the lead's turn alive (Claude wakes the lead when the task fires or
+ *  finishes), so the pane stays 'working' rather than reading a finished ✅.
+ *
+ *  The `Monitor` tool registers its watch as a backgrounded shell, so in the
+ *  hook payload it arrives as `{ type: "shell", status: "running" }` — NOT
+ *  `type: "monitor"`. The payload builder drops the internal `kind: "monitor"`
+ *  marker, so a Monitor is indistinguishable from any other backgrounded shell;
+ *  both are treated as keep-alive work. WebSocket/MCP monitors instead surface
+ *  as `type: "monitor"`, so match both labels. (Verified against a live 2.1.211
+ *  Stop payload: `type: "shell"`, `status: "running"`, with a `command`.)
+ *
+ *  Subagent/teammate types are deliberately excluded — the roster owns them,
+ *  and teammate entries report `status: "running"` forever even after the named
+ *  agent finished, which would pin the pane 'working' permanently. */
+export function claudeBackgroundTasksHaveRunningShellOrMonitor(
   hookPayload: Record<string, unknown>
 ): boolean {
   const raw = hookPayload['background_tasks']
@@ -192,11 +199,10 @@ export function claudeBackgroundTasksHaveRunningMonitor(
       continue
     }
     const obj = item as Record<string, unknown>
-    if (
-      typeof obj.type === 'string' &&
-      obj.type.startsWith('monitor') &&
-      obj.status === 'running'
-    ) {
+    if (obj.type !== 'shell' && obj.type !== 'monitor') {
+      continue
+    }
+    if (obj.status === 'running' || obj.status === 'pending') {
       return true
     }
   }

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -171,6 +171,38 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
   return { present: true, tasks, truncated }
 }
 
+/** Whether a Stop/SubagentStop payload's `background_tasks` still lists a
+ *  running Monitor. Monitors (Claude's `Monitor` tool) are non-agent
+ *  background tasks — they never enter the subagent roster — but a running
+ *  monitor means the lead's turn is not truly done: Claude wakes the lead when
+ *  the monitor fires. Callers use this to keep the pane 'working' so the
+ *  sidebar keeps spinning while a monitor watches, mirroring the existing
+ *  subagent gate. Matched on the `monitor` type prefix (covers the ws/mcp
+ *  monitor variants) so a single string tweak adapts if the wire type shifts;
+ *  deliberately excludes shells/workflows/crons — only monitors gate here. */
+export function claudeBackgroundTasksHaveRunningMonitor(
+  hookPayload: Record<string, unknown>
+): boolean {
+  const raw = hookPayload['background_tasks']
+  if (!Array.isArray(raw)) {
+    return false
+  }
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) {
+      continue
+    }
+    const obj = item as Record<string, unknown>
+    if (
+      typeof obj.type === 'string' &&
+      obj.type.startsWith('monitor') &&
+      obj.status === 'running'
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
 /** Fold a lead Stop's `background_tasks` into the lifecycle-tracked roster.
  *
  *  The list is authoritative for non-teammate children: a running one-shot is


### PR DESCRIPTION
## What & why

When a Claude agent ends its turn with a background **Monitor** still running, the left-sidebar agent card dropped to the static "done" dot instead of the working spinner — even though the session is mid-flight and will resume when the monitor fires. Reported from a real session: the footer read "1 monitor still running" while the agent's sidebar card showed the static done dot.

This makes the card show the working spinner while a Monitor is watching, reusing the exact mechanism that already keeps a card spinning while a subagent runs.

## Root cause

The `Stop` hook payload carries a `background_tasks` array. A Monitor is a **non-agent** background-task kind (Claude's task kinds are `subagent, workflow, shell, monitor, MCP task, teammate, …`). `readClaudeBackgroundAgentTasks` keeps only `subagent`/`teammate` entries and discards the rest, so the monitor never entered the roster — the "stay-working" gate in `agent-hook-listener.ts` then saw an empty roster and resolved the pane to `done`:

```
Stop hook (background_tasks: [{ type: "monitor", status: "running" }])
  -> readClaudeBackgroundAgentTasks() drops the monitor (agent-only filter)
  -> roster empty -> effectiveState = 'done'   (NOT 'working')
  -> activity summary: hasLiveDone -> resolveWorktreeStatus 'done'
  -> StatusIndicator renders the static emerald dot, no spinner
```

## The fix

- `claudeBackgroundTasksHaveRunningMonitor()` detects a running monitor in `background_tasks` (matched on the `monitor` type prefix, so `monitor_ws`/`monitor_mcp` variants gate too; shells/workflows/crons deliberately excluded).
- Tracked per-pane (`claudeRunningMonitorByPaneKey`), updated **only** from a present `background_tasks` list so an event without the field can't clear a monitor tracked by an earlier turn (mirrors how the roster is retained).
- OR'd into the same three `done -> working` gates that already hold a pane working while a subagent runs.

Everything
 downstream (activity summary -> status resolver -> `StatusIndicator`) already promotes a `working` pane into the spinner, so **there are no rendering changes**. It self-heals to `done` on the next `Stop` that no longer lists the monitor as running.

## Evidence

**Before/after (proves the fix is load-bearing).** With the monitor check temporarily neutered to a no-op, the 3 new integration tests — which drive the real `normalizeHookPayload` entry point — reproduce the bug exactly:

```
 ×  reports Stop as working while a Monitor background task is still running
    -> expected 'done' to be 'working'
 ×  retains a running Monitor across a later Stop whose payload omits background_tasks
    -> expected 'done' to be 'working'
 ×  reports Stop as working while a Monitor runs alongside a finished subagent
    -> expected 'done' to be 'working'
 Test Files  1 failed (1)
```

With the fix in place, the same tests pass (state resolves to `working`, which is what renders the spinner):

```
 ✓  detects a running Monitor background task (incl. ws/mcp variants)
 ✓  ignores finished monitors and non-monitor running tasks
 ✓  reports Stop as working while a Monitor background task is still running
 ✓  retains a running Monitor across a later Stop whose payload omits background_tasks
 ✓  reports Stop as working while a Monitor runs alongside a finished subagent
```

**Full affected suite + typecheck (fix on):**

```
 Test Files  2 passed (2)
      Tests  124 passed (124)     # 11 new (integration + pure-function)

tsc --noEmit -p config/tsconfig.node.json  -> exit 0
oxlint (changed files)                     -> clean
```

## Test plan

- [x] Unit: `claudeBackgroundTasksHaveRunningMonitor` — running monitor (incl. `monitor_ws`/`monitor_mcp`), completed monitor, running shell/subagent (excluded), absent/malformed field.
- [x] Integration (`normalizeHookPayload`): Stop with a running monitor -> `working`; monitor completes on next Stop -> `done`
; running monitor retained across a Stop whose payload omits `background_tasks`; monitor alongside a finished subagent -> `working`.
- [x] `tsc` + `oxlint` clean.

## Notes / caveats

- **Wire-type confirmation:** the `type` string is matched on the `monitor` prefix, inferred from the Claude Code build's task-kind list; if a live capture shows a different value it's a one-line tweak (flagged in a code comment).
- **Long monitors:** agent status staleness-expires after ~30 min, so a long-timeout monitor that emits no intermediate hooks could stop spinning before it fires. Acceptable for this pass; a full fix would need periodic re-emits.
- **One honest trade-off:** since Claude drops `kind`, a Monitor is byte-identical to a plain `run_in_background` shell in the payload — so a backgrounded dev server will also hold the spinner until it exits (or the existing 30-min status staleness decays it). There's no signal in the payload to separate the two.

Made with [Orca](https://github.com/stablyai/orca) 🐋
