### PR TITLE
fix(runtime): surface visible TUI output in terminal read and show

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12591,6 +12591,159 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('surfaces headless alternate-screen output through terminal read without renderer serializer', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData(
+      'pty-1',
+      'shell history\r\n\x1b[?1049h\x1b[2J\x1b[HClaude Code\r\nWorking on fix\r\nTool: Read\r\n',
+      100
+    )
+    await runtime.serializeTerminalBuffer('pty-1', { scrollbackRows: 0 })
+
+    const read = await runtime.readTerminal(terminal.handle)
+
+    expect(read.tail).toEqual(['Claude Code', 'Working on fix', 'Tool: Read'])
+  })
+
+  it('surfaces headless alternate-screen output through terminal show preview', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData(
+      'pty-1',
+      'shell history\r\n\x1b[?1049h\x1b[2J\x1b[HClaude Code\r\nWorking on fix\r\nTool: Read\r\n',
+      100
+    )
+    await runtime.serializeTerminalBuffer('pty-1', { scrollbackRows: 0 })
+
+    const shown = await runtime.showTerminal(terminal.handle)
+
+    expect(shown.preview).toBe('Claude Code\nWorking on fix\nTool: Read')
+  })
+
+  it('uses provider alternate-screen snapshots on the first terminal read call', async () => {
+    const serializeProviderBuffer = vi.fn().mockResolvedValue({
+      data: '\x1b[?1049h\x1b[2J\x1b[HClaude Code\r\nWorking on fix\r\nTool: Read\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', 'shell history\r\n', 100)
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+
+    const read = await runtime.readTerminal(terminal.handle)
+
+    expect(read.tail).toEqual(['Claude Code', 'Working on fix', 'Tool: Read'])
+    expect(serializeProviderBuffer).toHaveBeenCalledWith('pty-1', { scrollbackRows: 0 })
+  })
+
+  it('uses provider alternate-screen snapshots on the first terminal show call', async () => {
+    const serializeProviderBuffer = vi.fn().mockResolvedValue({
+      data: '\x1b[?1049h\x1b[2J\x1b[HClaude Code\r\nWorking on fix\r\nTool: Read\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', 'shell history\r\n', 100)
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+
+    const shown = await runtime.showTerminal(terminal.handle)
+
+    expect(shown.preview).toBe('Claude Code\nWorking on fix\nTool: Read')
+    expect(serializeProviderBuffer).toHaveBeenCalledWith('pty-1', { scrollbackRows: 0 })
+  })
+
+  it('keeps first provider-backed alternate-screen read and show aligned when the retained transcript is empty', async () => {
+    const createRuntime = async () => {
+      const serializeProviderBuffer = vi.fn().mockResolvedValue({
+        data: '\x1b[?1049h\x1b[2J\x1b[HClaude Code\r\nWorking on fix\r\nTool: Read\r\n',
+        cols: 80,
+        rows: 24,
+        seq: 900,
+        source: 'headless',
+        alternateScreen: true
+      })
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null,
+        serializeProviderBuffer,
+        hasRendererSerializer: () => false
+      })
+      syncSinglePty(runtime)
+
+      const [terminal] = (await runtime.listTerminals()).terminals
+      runtime.synchronizePtyOutputSequenceFromProvider(
+        'pty-1',
+        { value: 900, generation: 'continued' },
+        0
+      )
+
+      return { runtime, terminal, serializeProviderBuffer }
+    }
+
+    const readState = await createRuntime()
+    const showState = await createRuntime()
+
+    const read = await readState.runtime.readTerminal(readState.terminal.handle)
+    const shown = await showState.runtime.showTerminal(showState.terminal.handle)
+
+    expect(read.tail).toEqual(['Claude Code', 'Working on fix', 'Tool: Read'])
+    expect(shown.preview).toBe('Claude Code\nWorking on fix\nTool: Read')
+    expect(shown.preview.split('\n')).toEqual(read.tail)
+    expect(readState.serializeProviderBuffer).toHaveBeenCalledWith('pty-1', { scrollbackRows: 0 })
+    expect(showState.serializeProviderBuffer).toHaveBeenCalledWith('pty-1', { scrollbackRows: 0 })
+  })
+
   it('returns renderer visible screen lines through terminal.read RPC JSON result', async () => {
     const serializeBuffer = vi.fn().mockResolvedValue({
       data: '\x1b[?1049hClaude Code\r\nChecking files\r\nWaiting for input\r\n',
@@ -12628,60 +12781,243 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
-  it('does not use renderer visible-screen fallback for cursor transcript reads', async () => {
-    const serializeBuffer = vi.fn().mockResolvedValue({
-      data: 'Visible TUI\n',
+  it('does not use visible-screen fallback for cursor transcript reads', async () => {
+    const serializeProviderBuffer = vi.fn().mockResolvedValue({
+      data: '\x1b[?1049h\x1b[2J\x1b[HVisible TUI\r\n',
       cols: 80,
-      rows: 24
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
     })
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
       write: () => true,
       kill: () => true,
       getForegroundProcess: async () => null,
-      hasRendererSerializer: () => true,
-      serializeBuffer
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
     })
     syncSinglePty(runtime)
 
     const [terminal] = (await runtime.listTerminals()).terminals
-    runtime.onPtyData('pty-1', '   \n', 100)
+    runtime.onPtyData('pty-1', 'shell history\r\n', 100)
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+
+    const read = await runtime.readTerminal(terminal.handle, { cursor: 0 })
+    expect(read.tail).toEqual(['shell history'])
+    expect(serializeProviderBuffer).not.toHaveBeenCalled()
+
+    const shown = await runtime.showTerminal(terminal.handle)
+
+    expect(shown.preview).toBe('Visible TUI')
+    expect(serializeProviderBuffer).toHaveBeenCalledWith('pty-1', { scrollbackRows: 0 })
+  })
+
+  it('does not touch provider snapshots for first cursor reads on provider-preferred PTYs', async () => {
+    const serializeProviderBuffer = vi.fn().mockResolvedValue({
+      data: '\x1b[?1049h\x1b[2J\x1b[HVisible TUI\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
 
     const read = await runtime.readTerminal(terminal.handle, { cursor: 0 })
 
-    expect(read.tail).toEqual([''])
-    expect(serializeBuffer).not.toHaveBeenCalledWith('pty-1', {
+    expect(read.tail).toEqual([])
+    expect(serializeProviderBuffer).not.toHaveBeenCalled()
+  })
+
+  it('keeps normal-screen read and show previews on retained output', async () => {
+    const nonblankSerializeBuffer = vi.fn().mockResolvedValue({
+      data: 'visible screen that should stay unused\r\n',
+      cols: 80,
+      rows: 24
+    })
+    const nonblankRuntime = new OrcaRuntimeService(store)
+    nonblankRuntime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      hasRendererSerializer: () => true,
+      serializeBuffer: nonblankSerializeBuffer
+    })
+    syncSinglePty(nonblankRuntime)
+
+    const [nonblankTerminal] = (await nonblankRuntime.listTerminals()).terminals
+    nonblankRuntime.onPtyData('pty-1', 'shell prompt\r\nstill retained\r\n', 100)
+
+    const nonblankRead = await nonblankRuntime.readTerminal(nonblankTerminal.handle)
+    const nonblankShow = await nonblankRuntime.showTerminal(nonblankTerminal.handle)
+
+    expect(nonblankRead.tail).toEqual(['shell prompt', 'still retained'])
+    expect(nonblankShow.preview).toBe('shell prompt\nstill retained')
+    expect(nonblankSerializeBuffer).not.toHaveBeenCalledWith('pty-1', {
+      scrollbackRows: 0,
+      altScreenForcesZeroRows: false
+    })
+
+    const shortBlankSerializeBuffer = vi.fn().mockResolvedValue({
+      data: 'shell prompt\r\n',
+      cols: 80,
+      rows: 24
+    })
+    const shortBlankRuntime = new OrcaRuntimeService(store)
+    shortBlankRuntime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      hasRendererSerializer: () => true,
+      serializeBuffer: shortBlankSerializeBuffer
+    })
+    syncSinglePty(shortBlankRuntime)
+
+    const [shortBlankTerminal] = (await shortBlankRuntime.listTerminals()).terminals
+    shortBlankRuntime.onPtyData('pty-1', '\n\n', 100)
+
+    const shortBlankRead = await shortBlankRuntime.readTerminal(shortBlankTerminal.handle)
+    const shortBlankShow = await shortBlankRuntime.showTerminal(shortBlankTerminal.handle)
+
+    expect(shortBlankRead.tail).toEqual(['', ''])
+    expect(shortBlankShow.preview).toBe('')
+    expect(shortBlankSerializeBuffer).not.toHaveBeenCalledWith('pty-1', {
       scrollbackRows: 0,
       altScreenForcesZeroRows: false
     })
   })
 
-  it('does not use renderer visible-screen fallback for a short blank shell tail', async () => {
-    const serializeBuffer = vi.fn().mockResolvedValue({
-      data: 'shell prompt\n',
+  it('keeps retained output when visible snapshots are unavailable', async () => {
+    const emptyProviderBuffer = vi.fn().mockResolvedValue({
+      data: '',
       cols: 80,
-      rows: 24
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+    const emptyRuntime = new OrcaRuntimeService(store)
+    emptyRuntime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer: emptyProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(emptyRuntime)
+
+    const [emptyTerminal] = (await emptyRuntime.listTerminals()).terminals
+    emptyRuntime.onPtyData('pty-1', 'shell history\r\n', 100)
+    emptyRuntime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+
+    const emptyRead = await emptyRuntime.readTerminal(emptyTerminal.handle)
+    const emptyShow = await emptyRuntime.showTerminal(emptyTerminal.handle)
+
+    expect(emptyRead.tail).toEqual(['shell history'])
+    expect(emptyShow.preview).toBe('shell history')
+    expect(emptyProviderBuffer).toHaveBeenCalledWith('pty-1', { scrollbackRows: 0 })
+
+    const failingProviderBuffer = vi.fn().mockRejectedValue(new Error('snapshot unavailable'))
+    const failingRuntime = new OrcaRuntimeService(store)
+    failingRuntime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer: failingProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(failingRuntime)
+
+    const [failingTerminal] = (await failingRuntime.listTerminals()).terminals
+    failingRuntime.onPtyData('pty-1', 'shell history\r\n', 100)
+    failingRuntime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+
+    const failingRead = await failingRuntime.readTerminal(failingTerminal.handle)
+    const failingShow = await failingRuntime.showTerminal(failingTerminal.handle)
+
+    expect(failingRead.tail).toEqual(['shell history'])
+    expect(failingShow.preview).toBe('shell history')
+    expect(failingProviderBuffer).toHaveBeenCalled()
+  })
+
+  it('bounds visible-snapshot read and show output', async () => {
+    const visibleLines = [
+      'skip-1',
+      'skip-2',
+      'A'.repeat(49),
+      'B'.repeat(49),
+      'C'.repeat(49),
+      'D'.repeat(49),
+      'E'.repeat(49),
+      'F'.repeat(50)
+    ]
+    const expectedVisibleTail = visibleLines.slice(-6)
+    const expectedPreview = expectedVisibleTail.join('\n')
+    expect(expectedPreview.length).toBe(300)
+
+    const serializeProviderBuffer = vi.fn().mockResolvedValue({
+      data: `\x1b[?1049h\x1b[2J\x1b[H${visibleLines.join('\r\n')}\r\n`,
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
     })
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
       write: () => true,
       kill: () => true,
       getForegroundProcess: async () => null,
-      hasRendererSerializer: () => true,
-      serializeBuffer
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
     })
     syncSinglePty(runtime)
 
     const [terminal] = (await runtime.listTerminals()).terminals
-    runtime.onPtyData('pty-1', '\n\n', 100)
+    runtime.onPtyData('pty-1', 'shell history\r\n', 100)
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
 
-    const read = await runtime.readTerminal(terminal.handle)
+    const read = await runtime.readTerminal(terminal.handle, { limit: 6 })
+    const shown = await runtime.showTerminal(terminal.handle)
 
-    expect(read.tail).toEqual(['', ''])
-    expect(serializeBuffer).not.toHaveBeenCalledWith('pty-1', {
-      scrollbackRows: 0,
-      altScreenForcesZeroRows: false
-    })
+    expect(read.tail).toEqual(expectedVisibleTail)
+    expect(read.returnedLineCount).toBe(6)
+    expect(shown.preview).toBe(expectedPreview)
+    expect(shown.preview.length).toBe(300)
+    expect(shown.preview.split('\n')).toHaveLength(6)
   })
 
   it('trims oversized terminal output bursts without per-line array shifts', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -7378,52 +7378,116 @@ export class OrcaRuntimeService {
     read: RuntimeTerminalRead,
     opts: { cursor?: number; limit?: number } = {}
   ): Promise<RuntimeTerminalRead> {
-    if (!shouldFallbackToVisibleTerminalSnapshot(read, opts)) {
+    if (typeof opts.cursor === 'number') {
       return read
     }
-    const lines = await this.readRendererVisibleSnapshotLines(ptyId)
+    const { snapshot, isAlternateScreen } = await this.prepareVisibleSnapshotFallback(ptyId)
+    if (!shouldFallbackToVisibleTerminalSnapshot(read, opts, isAlternateScreen)) {
+      return read
+    }
+    const lines = await this.readVisibleSnapshotLines(ptyId, snapshot)
     if (lines.length === 0) {
       return read
     }
     return buildVisibleSnapshotReadFallback(read, lines, opts.limit)
   }
 
-  private async readRendererVisibleSnapshotLines(ptyId: string): Promise<string[]> {
-    const controller = this.ptyController
-    if (!controller?.serializeBuffer) {
-      return []
+  // Why: provider-backed PTYs learn alternate-screen state from the provider
+  // snapshot itself on first access, so read/show must be able to reuse it.
+  private async prepareVisibleSnapshotFallback(ptyId: string): Promise<{
+    snapshot: {
+      data: string
+      cols: number
+      rows: number
+      cwd?: string | null
+      lastTitle?: string
+      seq?: number
+      source?: 'headless' | 'renderer'
+      oscLinks?: TerminalOscLinkRange[]
+      alternateScreen?: boolean
+      scrollbackAnsi?: string
+      pendingEscapeTailAnsi?: string
+    } | null
+    isAlternateScreen: boolean
+  }> {
+    const isAlternateScreen = this.isTerminalAlternateScreen(ptyId)
+    if (
+      isAlternateScreen ||
+      !this.providerSnapshotPreferredPtys.has(ptyId) ||
+      this.providerModeTrackersByPtyId.has(ptyId)
+    ) {
+      return { snapshot: null, isAlternateScreen }
     }
-    if (controller.hasRendererSerializer && !controller.hasRendererSerializer(ptyId)) {
-      return []
+    const snapshot = await this.serializeTerminalBuffer(ptyId, { scrollbackRows: 0 })
+    return {
+      snapshot,
+      isAlternateScreen: snapshot?.alternateScreen ?? this.isTerminalAlternateScreen(ptyId)
     }
+  }
+
+  private async readVisibleSnapshotLines(
+    ptyId: string,
+    snapshot: {
+      data: string
+      cols: number
+      rows: number
+      cwd?: string | null
+      lastTitle?: string
+      seq?: number
+      source?: 'headless' | 'renderer'
+      oscLinks?: TerminalOscLinkRange[]
+      alternateScreen?: boolean
+      scrollbackAnsi?: string
+      pendingEscapeTailAnsi?: string
+    } | null = null
+  ): Promise<string[]> {
     try {
-      // Why: raw PTY tails can be whitespace-only while a full-screen TUI is
-      // visibly nonblank in renderer xterm. Ask the renderer for the active
-      // screen instead of reusing the headless transcript path.
-      const snapshot = await controller.serializeBuffer(ptyId, {
-        scrollbackRows: 0,
-        altScreenForcesZeroRows: false
-      })
-      if (!snapshot || snapshot.data.length === 0) {
+      let currentSnapshot =
+        snapshot ?? (await this.serializeTerminalBuffer(ptyId, { scrollbackRows: 0 }))
+      if (!currentSnapshot || currentSnapshot.data.length === 0) {
         return []
       }
-      const emulator = new HeadlessEmulator({
-        cols: snapshot.cols,
-        rows: snapshot.rows,
-        scrollback: 0
-      })
-      try {
-        await emulator.write(snapshot.data)
-        return emulator
-          .getVisibleLines()
-          .map((line) => line.trimEnd())
-          .filter((line) => line.trim().length > 0)
-      } finally {
-        emulator.dispose()
+      const readLines = async (
+        loadedSnapshot: NonNullable<typeof currentSnapshot>
+      ): Promise<string[]> => {
+        const emulator = new HeadlessEmulator({
+          cols: loadedSnapshot.cols,
+          rows: loadedSnapshot.rows,
+          scrollback: 0
+        })
+        try {
+          await emulator.write(`\x1b[2J\x1b[3J\x1b[H${loadedSnapshot.data}`)
+          return emulator
+            .getVisibleLines()
+            .map((line) => line.trimEnd())
+            .filter((line) => line.trim().length > 0)
+        } finally {
+          emulator.dispose()
+        }
       }
+      let lines = await readLines(currentSnapshot)
+      if (lines.length === 0 && currentSnapshot.source !== 'renderer') {
+        const rendererSnapshot = await this.serializeRendererTerminalBuffer(ptyId, {
+          scrollbackRows: 0
+        })
+        if (rendererSnapshot?.data) {
+          currentSnapshot = rendererSnapshot
+          lines = await readLines(currentSnapshot)
+        }
+      }
+      return lines
     } catch {
       return []
     }
+  }
+
+  private async visibleSnapshotPreview(ptyId: string, preview: string): Promise<string> {
+    const { snapshot, isAlternateScreen } = await this.prepareVisibleSnapshotFallback(ptyId)
+    if (!isAlternateScreen) {
+      return preview
+    }
+    const lines = await this.readVisibleSnapshotLines(ptyId, snapshot)
+    return lines.length > 0 ? buildPreview(lines, '') : preview
   }
 
   private async serializeHeadlessTerminalBuffer(
@@ -10528,8 +10592,10 @@ export class OrcaRuntimeService {
     const pty = this.getLivePtyForHandle(handle)
     if (pty) {
       const worktreesById = await this.getResolvedWorktreeMap()
+      const summary = this.buildPtyTerminalSummary(pty.pty, worktreesById)
       return {
-        ...this.buildPtyTerminalSummary(pty.pty, worktreesById),
+        ...summary,
+        preview: await this.visibleSnapshotPreview(pty.pty.ptyId, summary.preview),
         tabId: pty.pty.tabId ?? pty.record.tabId,
         leafId: parsePaneKey(pty.pty.paneKey ?? '')?.leafId ?? pty.record.leafId,
         paneRuntimeId: -1,
@@ -10544,6 +10610,9 @@ export class OrcaRuntimeService {
     const summary = this.buildTerminalSummary(leaf, worktreesById)
     return {
       ...summary,
+      preview: leaf.ptyId
+        ? await this.visibleSnapshotPreview(leaf.ptyId, summary.preview)
+        : summary.preview,
       paneRuntimeId: leaf.paneRuntimeId,
       ptyId: leaf.ptyId,
       rendererGraphEpoch: this.rendererGraphEpoch
@@ -26559,10 +26628,14 @@ function readTerminalTail(args: {
 
 function shouldFallbackToVisibleTerminalSnapshot(
   read: RuntimeTerminalRead,
-  opts: { cursor?: number; limit?: number }
+  opts: { cursor?: number; limit?: number },
+  isAlternateScreen: boolean
 ): boolean {
   if (typeof opts.cursor === 'number') {
     return false
+  }
+  if (isAlternateScreen) {
+    return true
   }
   if (read.tail.length === 0) {
     return false


### PR DESCRIPTION
## Summary

`terminal read` and `terminal show` now surface the visible rows of active full-screen TUIs for provider-backed, headless, SSH, and remote-runtime terminals when no renderer serializer is mounted. First-call alternate-screen reads and previews now stay aligned even when retained transcript history is empty.

The runtime still reuses its existing provider, headless, and renderer snapshot authority, while cursor pagination, normal-screen output, renderer-only blank-tail fallback, and `terminal list` stay on their prior paths.

Closes #8746.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts` - passed, `Test Files 1 passed (1)`, `Tests 709 passed (709)`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "surfaces headless alternate-screen output through terminal read without renderer serializer"` - passed
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "surfaces headless alternate-screen output through terminal show preview"` - passed
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "keeps retained output when visible snapshots are unavailable"` - passed
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "keeps first provider-backed alternate-screen read and show aligned when the retained transcript is empty"` - passed
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "does not touch provider snapshots for first cursor reads on provider-preferred PTYs"` - passed
- `pnpm run typecheck:node` - passed
- `pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts` - passed
- `pnpm exec oxfmt --check src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts` - passed

## AI Review Report

- Adversarial review first caught stale first-call provider fallback behavior, proof drift, and missing alternate-screen coverage, then a second pass caught the empty-retained first-call read/show split and provider-I/O on first cursor reads. The branch fixed those findings before this final clean rerun.
- Final review traced cursor exclusion, first-provider snapshot handling, read/show routing, alternate-screen detection, and provider-mode cleanup across the runtime and RPC terminal consumers.
- Review explicitly checked macOS, Linux, and Windows terminal behavior for local, SSH, headless, and remote-runtime snapshots, plus cursor pagination, output bounds, renderer absence, and provider neutrality.
- No browser, mobile UI, shortcut, path, shell-command, dependency, or Electron code changes were introduced.

## Security Audit

The change only selects and parses terminal snapshot data already available inside the runtime. Review verified bounded read and preview output, fail-open handling for unavailable snapshots, unchanged IPC exposure, and the absence of new command execution, filesystem access, authentication, secret handling, dependency, or renderer-trust risk.

## Notes

`terminal list` keeps its retained preview and does not serialize each listed terminal. Cursor-based reads remain transcript pagination. Full lint, full typecheck, full test, and build remain CI-gated. No UI or Electron code changes.
</content>

## ELI5

`terminal read` / `show` often missed what a full-screen TUI was displaying. They now surface the visible alternate-screen rows for remote and headless terminals.
