### PR TITLE
fix(agent-hooks): Windows Grok hook launcher fixes (GROK_HOME cmd parse + Grok-spawnable Claude launcher)

### DIFF
--- a/docs/reference/agent-hook-stdin-lifecycle.md
+++ b/docs/reference/agent-hook-stdin-lifecycle.md
@@ -117,11 +117,15 @@ path. This mirrors POSIX ownership without starting an additional process.
   (argv[0]), not through cmd.exe, so the launcher cannot lead with a cmd builtin
   such as `if` — that argv[0] is unspawnable and fails every hook. A missing
   script therefore surfaces a normal launch failure on this fast path; only
-  launchers that already require a real interpreter (encoded PowerShell, Git
-  Bash) drain a missing script. Paths cmd.exe cannot invoke verbatim fall back to
-  the encoded PowerShell launcher, which owns stdin for the missing case.
-- Claude's Git Bash fast path uses a POSIX file guard and drain while continuing
-  to execute the `.cmd` directly rather than interpreting it as shell source.
+  launchers that already require a real interpreter (encoded PowerShell) drain a
+  missing script. Paths cmd.exe cannot invoke verbatim fall back to the encoded
+  PowerShell launcher, which owns stdin for the missing case.
+- Claude's Git Bash fast path is likewise a bare forward-slash `.cmd` path.
+  Claude Code can execute it under Git Bash; Grok may also load the same
+  `~/.claude/settings.json` command via harness compatibility and must
+  CreateProcess a single spawnable token — a bash `if [ -f … ]` guard fails under
+  cmd/direct spawn. Spaced or metacharacter paths fall back to encoded
+  PowerShell (which drains a missing script).
 - Agent-specific direct launchers, including Antigravity event wrappers and
   Copilot's PowerShell-file command, adopt the same missing-file behavior.
 

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -492,12 +492,16 @@ describe('wrapWindowsCmdHookCommand', () => {
 })
 
 describe('wrapWindowsGitBashHookCommand', () => {
-  it('guards the forward-slash fast path and drains when missing', () => {
+  it('returns a bare forward-slash path for a bash-safe managed script', () => {
+    // Why: Claude Git Bash can run the bare .cmd; Grok compat-loads the same
+    // settings.json command and must CreateProcess a single spawnable token —
+    // not a bash `if [ -f … ]` compound (exit 1 under cmd / direct spawn).
     expect(
       wrapWindowsGitBashHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\claude-hook.cmd')
-    ).toBe(
-      "if [ -f 'C:/Users/alice/.orca/agent-hooks/claude-hook.cmd' ]; then 'C:/Users/alice/.orca/agent-hooks/claude-hook.cmd'; else cat >/dev/null 2>&1 || :; fi"
-    )
+    ).toBe('C:/Users/alice/.orca/agent-hooks/claude-hook.cmd')
+    expect(
+      wrapWindowsGitBashHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\claude-hook.cmd')
+    ).not.toMatch(/^if\b/)
   })
 
   it('falls back to the encoded launcher when bash would split the path', () => {

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -191,11 +191,15 @@ export const WINDOWS_GIT_BASH_SAFE_PATH = /^[A-Za-z0-9_.:/~-]+$/
 
 export function wrapWindowsGitBashHookCommand(scriptPath: string): string {
   const bashPath = scriptPath.replaceAll('\\', '/')
-  // Why: Claude's Git Bash runner can execute a forward-slash .cmd directly;
-  // unsafe paths stay encoded and the fast path gains a missing-file drain.
-  return WINDOWS_GIT_BASH_SAFE_PATH.test(bashPath)
-    ? `if [ -f ${quotePosixShellString(bashPath)} ]; then ${quotePosixShellString(bashPath)}; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
-    : wrapWindowsHookCommand(scriptPath)
+  // Why: Claude's Git Bash runner can execute a forward-slash .cmd directly.
+  // The safe-path fast path must remain a single spawnable token (bare path),
+  // not a bash `if [ -f … ]` compound: Grok (and any CreateProcess-style runner)
+  // loads ~/.claude/settings.json hooks via [compat.claude] and launches the
+  // command without Git Bash, so a bash guard fails every hook with exit 1
+  // ("-f was unexpected"). Same trade-off as wrapWindowsCmdHookCommand / #8737:
+  // missing-script stdin drain lives on the encoded-PowerShell fallback used for
+  // spaced/metacharacter paths.
+  return WINDOWS_GIT_BASH_SAFE_PATH.test(bashPath) ? bashPath : wrapWindowsHookCommand(scriptPath)
 }
 
 export function buildWindowsAgentHookPostCommand(source: AgentHookSource): string {

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -163,7 +163,17 @@ function resolveWindowsTestBash(): string {
   const candidates = [
     join(process.env.ProgramFiles ?? 'C:\\Program Files', 'Git', 'bin', 'bash.exe'),
     join(process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'),
-    'D:\\DevelopmentEnvironment\\Git\\bin\\bash.exe'
+    // Why: derive Git Bash from a Git dir on PATH instead of hardcoding an
+    // install location, so a non-default Git resolves on any Windows dev/CI box.
+    // Cover both the `Git\bin` and `Git\cmd` PATH layouts (bash lives under bin).
+    ...(process.env.PATH ?? '')
+      .split(';')
+      .filter((dir) => /\bgit\b/i.test(dir))
+      .flatMap((dir) => [
+        join(dir, 'bash.exe'),
+        join(dir, '..', 'bin', 'bash.exe'),
+        join(dir, '..', 'usr', 'bin', 'bash.exe')
+      ])
   ]
   for (const candidate of candidates) {
     if (existsSync(candidate)) {
@@ -334,6 +344,81 @@ describe('Windows managed hook stdin structure', () => {
           const result = await runHookProcess(launcher.executable, launcher.args, hookEnvironment())
           expect(result.exitCode, `${launcher.name} exit code`).toBe(0)
           expect(result.stdinErrors, `${launcher.name} stdin errors`).toHaveLength(0)
+        }
+      } finally {
+        homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+        rmSync(home, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform !== 'win32')(
+    'runs the Claude Git Bash safe-path launcher (bare .cmd) under a real Git Bash',
+    async () => {
+      // Why: the Claude/OpenClaude launcher is now a bare forward-slash `.cmd`
+      // so Grok's CreateProcess can spawn it. Grok's native spawn can't be
+      // reproduced from Node (spawn rejects `.cmd` without a shell), but the
+      // primary consumer — Claude's Git Bash runner — must exec the bare `.cmd`
+      // and own stdin. Prove that end to end so a regression in bash `.cmd`
+      // execution can't hide behind the string-shape unit test.
+      const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-gitbash-'))
+      homedirMock.mockReturnValue(home)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+        const claudeScript = join(home, '.orca', 'agent-hooks', 'claude-hook.cmd')
+        const command = wrapWindowsGitBashHookCommand(claudeScript)
+        // A spaced/unsafe temp path would fall back to the encoded PowerShell
+        // launcher (already covered by the matrix above); only assert the bare
+        // `.cmd` contract when the safe fast path is actually in play.
+        if (!/powershell\.exe/i.test(command)) {
+          expect(command).toBe(claudeScript.replaceAll('\\', '/'))
+          const result = await runHookProcess(
+            resolveWindowsTestBash(),
+            ['-c', command],
+            hookEnvironment()
+          )
+          expect(result.exitCode, 'claude git bash bare .cmd exit code').toBe(0)
+          expect(result.stdinErrors, 'claude git bash bare .cmd stdin errors').toHaveLength(0)
+        }
+      } finally {
+        homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+        rmSync(home, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform !== 'win32')(
+    'runs the safe-path launcher under a cmd shell and rejects the old bash compound (Grok compat)',
+    async () => {
+      // Why: Grok's [compat.claude] loads the same settings.json command and
+      // runs it through its Windows shell (cmd/PowerShell), not Git Bash. The
+      // bare forward-slash `.cmd` must run there and own stdin; the pre-fix
+      // `if [ -f … ]` compound fails with "-f was unexpected" under cmd. Lock
+      // both so a revert to the compound form can't slip back.
+      // NB: never model this as spawn(bareCmd, {shell:false}) — Node rejects a
+      // bare `.cmd` with EINVAL, a false negative unrelated to Grok's runtime.
+      const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-grokcompat-'))
+      homedirMock.mockReturnValue(home)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+        const claudeScript = join(home, '.orca', 'agent-hooks', 'claude-hook.cmd')
+        const command = wrapWindowsGitBashHookCommand(claudeScript)
+        if (!/powershell\.exe/i.test(command)) {
+          const forwardSlash = claudeScript.replaceAll('\\', '/')
+          expect(command).toBe(forwardSlash)
+
+          const fixed = await runHookProcess('cmd.exe', ['/d', '/c', command], hookEnvironment())
+          expect(fixed.exitCode, 'bare .cmd under cmd shell exit code').toBe(0)
+          expect(fixed.stdinErrors, 'bare .cmd under cmd shell stdin errors').toHaveLength(0)
+
+          const quoted = `'${forwardSlash}'`
+          const oldCompound = `if [ -f ${quoted} ]; then ${quoted}; else cat >/dev/null 2>&1 || :; fi`
+          const regressed = await runHookProcess(
+            'cmd.exe',
+            ['/d', '/c', oldCompound],
+            hookEnvironment()
+          )
+          expect(regressed.exitCode, 'old bash compound must fail under a cmd spawn').not.toBe(0)
         }
       } finally {
         homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -39,6 +39,7 @@ import { GrokHookService } from '../grok/hook-service'
 import { KimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 import {
+  WINDOWS_GIT_BASH_SAFE_PATH,
   wrapPosixHookCommand,
   wrapWindowsGitBashHookCommand,
   wrapWindowsHookCommand
@@ -181,6 +182,28 @@ function resolveWindowsTestBash(): string {
     }
   }
   return 'bash.exe'
+}
+
+// Why: the Git Bash safe-path tests only exercise the bare `.cmd` fast path when
+// the fixture home is bash-safe (WINDOWS_GIT_BASH_SAFE_PATH). tmpdir() alone can
+// carry spaces/metacharacters (spaced usernames, redirected TEMP), which would
+// silently route to the PowerShell fallback and make those tests vacuously pass.
+// Try each writable root until mkdtemp yields a bash-safe path; '' means no safe
+// root exists here, so the caller skips instead of asserting nothing.
+function mkdtempBashSafe(prefix: string): string {
+  for (const root of [tmpdir(), process.cwd()]) {
+    let dir: string
+    try {
+      dir = mkdtempSync(join(root, prefix))
+    } catch {
+      continue
+    }
+    if (WINDOWS_GIT_BASH_SAFE_PATH.test(dir.replaceAll('\\', '/'))) {
+      return dir
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+  return ''
 }
 
 function runPosixHook(command: string, extraEnv: NodeJS.ProcessEnv = {}): Promise<HookRun> {
@@ -354,32 +377,39 @@ describe('Windows managed hook stdin structure', () => {
 
   it.skipIf(process.platform !== 'win32')(
     'runs the Claude Git Bash safe-path launcher (bare .cmd) under a real Git Bash',
-    async () => {
+    async (ctx) => {
       // Why: the Claude/OpenClaude launcher is now a bare forward-slash `.cmd`
       // so Grok's CreateProcess can spawn it. Grok's native spawn can't be
       // reproduced from Node (spawn rejects `.cmd` without a shell), but the
       // primary consumer — Claude's Git Bash runner — must exec the bare `.cmd`
       // and own stdin. Prove that end to end so a regression in bash `.cmd`
       // execution can't hide behind the string-shape unit test.
-      const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-gitbash-'))
+      const home = mkdtempBashSafe('orca-hook-stdin-gitbash-')
+      if (!home) {
+        // No bash-safe temp root on this host; skip loudly rather than let the
+        // bare `.cmd` assertions never run and pass vacuously (unsafe paths are
+        // already covered by the encoded-fallback matrix above).
+        ctx.skip()
+        return
+      }
       homedirMock.mockReturnValue(home)
       try {
         expect(new ClaudeHookService().install().state).toBe('installed')
         const claudeScript = join(home, '.orca', 'agent-hooks', 'claude-hook.cmd')
         const command = wrapWindowsGitBashHookCommand(claudeScript)
-        // A spaced/unsafe temp path would fall back to the encoded PowerShell
-        // launcher (already covered by the matrix above); only assert the bare
-        // `.cmd` contract when the safe fast path is actually in play.
-        if (!/powershell\.exe/i.test(command)) {
-          expect(command).toBe(claudeScript.replaceAll('\\', '/'))
-          const result = await runHookProcess(
-            resolveWindowsTestBash(),
-            ['-c', command],
-            hookEnvironment()
-          )
-          expect(result.exitCode, 'claude git bash bare .cmd exit code').toBe(0)
-          expect(result.stdinErrors, 'claude git bash bare .cmd stdin errors').toHaveLength(0)
-        }
+        // home is guaranteed bash-safe, so the launcher MUST be the bare
+        // forward-slash `.cmd` fast path, never the PowerShell fallback.
+        expect(command, 'safe path must take the bare .cmd fast path').not.toMatch(
+          /powershell\.exe/i
+        )
+        expect(command).toBe(claudeScript.replaceAll('\\', '/'))
+        const result = await runHookProcess(
+          resolveWindowsTestBash(),
+          ['-c', command],
+          hookEnvironment()
+        )
+        expect(result.exitCode, 'claude git bash bare .cmd exit code').toBe(0)
+        expect(result.stdinErrors, 'claude git bash bare .cmd stdin errors').toHaveLength(0)
       } finally {
         homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
         rmSync(home, { recursive: true, force: true })
@@ -389,7 +419,7 @@ describe('Windows managed hook stdin structure', () => {
 
   it.skipIf(process.platform !== 'win32')(
     'runs the safe-path launcher under a cmd shell and rejects the old bash compound (Grok compat)',
-    async () => {
+    async (ctx) => {
       // Why: Grok's [compat.claude] loads the same settings.json command and
       // runs it through its Windows shell (cmd/PowerShell), not Git Bash. The
       // bare forward-slash `.cmd` must run there and own stdin; the pre-fix
@@ -397,29 +427,38 @@ describe('Windows managed hook stdin structure', () => {
       // both so a revert to the compound form can't slip back.
       // NB: never model this as spawn(bareCmd, {shell:false}) — Node rejects a
       // bare `.cmd` with EINVAL, a false negative unrelated to Grok's runtime.
-      const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-grokcompat-'))
+      const home = mkdtempBashSafe('orca-hook-stdin-grokcompat-')
+      if (!home) {
+        // No bash-safe temp root on this host; skip loudly rather than let the
+        // bare `.cmd` assertions never run and pass vacuously.
+        ctx.skip()
+        return
+      }
       homedirMock.mockReturnValue(home)
       try {
         expect(new ClaudeHookService().install().state).toBe('installed')
         const claudeScript = join(home, '.orca', 'agent-hooks', 'claude-hook.cmd')
         const command = wrapWindowsGitBashHookCommand(claudeScript)
-        if (!/powershell\.exe/i.test(command)) {
-          const forwardSlash = claudeScript.replaceAll('\\', '/')
-          expect(command).toBe(forwardSlash)
+        // home is guaranteed bash-safe, so the launcher MUST be the bare
+        // forward-slash `.cmd` fast path, never the PowerShell fallback.
+        expect(command, 'safe path must take the bare .cmd fast path').not.toMatch(
+          /powershell\.exe/i
+        )
+        const forwardSlash = claudeScript.replaceAll('\\', '/')
+        expect(command).toBe(forwardSlash)
 
-          const fixed = await runHookProcess('cmd.exe', ['/d', '/c', command], hookEnvironment())
-          expect(fixed.exitCode, 'bare .cmd under cmd shell exit code').toBe(0)
-          expect(fixed.stdinErrors, 'bare .cmd under cmd shell stdin errors').toHaveLength(0)
+        const fixed = await runHookProcess('cmd.exe', ['/d', '/c', command], hookEnvironment())
+        expect(fixed.exitCode, 'bare .cmd under cmd shell exit code').toBe(0)
+        expect(fixed.stdinErrors, 'bare .cmd under cmd shell stdin errors').toHaveLength(0)
 
-          const quoted = `'${forwardSlash}'`
-          const oldCompound = `if [ -f ${quoted} ]; then ${quoted}; else cat >/dev/null 2>&1 || :; fi`
-          const regressed = await runHookProcess(
-            'cmd.exe',
-            ['/d', '/c', oldCompound],
-            hookEnvironment()
-          )
-          expect(regressed.exitCode, 'old bash compound must fail under a cmd spawn').not.toBe(0)
-        }
+        const quoted = `'${forwardSlash}'`
+        const oldCompound = `if [ -f ${quoted} ]; then ${quoted}; else cat >/dev/null 2>&1 || :; fi`
+        const regressed = await runHookProcess(
+          'cmd.exe',
+          ['/d', '/c', oldCompound],
+          hookEnvironment()
+        )
+        expect(regressed.exitCode, 'old bash compound must fail under a cmd spawn').not.toBe(0)
       } finally {
         homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
         rmSync(home, { recursive: true, force: true })

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -2,7 +2,7 @@
 // matrix catches an unread early exit without duplicating template assertions.
 import { describe, expect, it, vi } from 'vitest'
 import { spawn } from 'node:child_process'
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
@@ -155,6 +155,24 @@ function hookEnvironment(extraEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   }
 }
 
+/** Prefer a real Git Bash on Windows; Store `bash.exe` stubs often exit 127. */
+function resolveWindowsTestBash(): string {
+  if (process.env.KIMI_SHELL_PATH) {
+    return process.env.KIMI_SHELL_PATH
+  }
+  const candidates = [
+    join(process.env.ProgramFiles ?? 'C:\\Program Files', 'Git', 'bin', 'bash.exe'),
+    join(process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'),
+    'D:\\DevelopmentEnvironment\\Git\\bin\\bash.exe'
+  ]
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return 'bash.exe'
+}
+
 function runPosixHook(command: string, extraEnv: NodeJS.ProcessEnv = {}): Promise<HookRun> {
   return runHookProcess('/bin/sh', ['-c', command], hookEnvironment(extraEnv))
 }
@@ -279,7 +297,7 @@ describe('Windows managed hook stdin structure', () => {
                   'v1.0',
                   'powershell.exe'
                 )
-              : process.env.KIMI_SHELL_PATH || 'bash.exe'
+              : resolveWindowsTestBash()
           const args = fileName.endsWith('.cmd')
             ? ['/d', '/c', scriptPath]
             : fileName.endsWith('.ps1')
@@ -290,27 +308,29 @@ describe('Windows managed hook stdin structure', () => {
           expect(result.stdinErrors, `${fileName} stdin errors`).toHaveLength(0)
         }
 
-        const missingScript = 'C:\\missing\\orca-hook.cmd'
-        // Why: the cmd fast path is intentionally a bare, directly-spawnable .cmd
-        // path (Codex/Antigravity/Devin launch it as argv[0], not via cmd.exe), so
-        // it cannot own stdin for a missing script — a cmd-builtin drain would make
-        // argv[0] unspawnable and fail every hook (#8430 regression). Only launchers
-        // that already require a real interpreter (encoded PowerShell, Git Bash)
-        // drain a missing script; the bare path's missing-script behavior is a
-        // normal launch failure, covered in installer-utils.test.ts.
+        // Why: cmd + Claude Git Bash *safe-path* fast paths are bare, directly
+        // spawnable `.cmd` paths (argv[0] / Grok CreateProcess / Claude Git Bash).
+        // A shell-builtin `if` drain is unspawnable or non-portable (#8430 / Grok
+        // compat loading Claude settings), so missing-script drain lives only on
+        // launchers that already require a real interpreter (encoded PowerShell).
+        // Use a spaced path so wrapWindowsGitBashHookCommand takes that fallback.
+        const missingUnsafeScript = 'C:\\missing path\\orca-hook.cmd'
         const launcherCases = [
           {
             name: 'encoded PowerShell',
             executable: 'cmd.exe',
-            args: ['/d', '/c', wrapWindowsHookCommand(missingScript)]
+            args: ['/d', '/c', wrapWindowsHookCommand(missingUnsafeScript)]
           },
           {
-            name: 'Git Bash fast path',
-            executable: process.env.KIMI_SHELL_PATH || 'bash.exe',
-            args: ['-lc', wrapWindowsGitBashHookCommand(missingScript)]
+            name: 'Git Bash unsafe-path encoded fallback',
+            executable: 'cmd.exe',
+            args: ['/d', '/c', wrapWindowsGitBashHookCommand(missingUnsafeScript)]
           }
         ]
         for (const launcher of launcherCases) {
+          expect(launcher.args[2], `${launcher.name} uses encoded launcher`).toMatch(
+            /powershell\.exe/i
+          )
           const result = await runHookProcess(launcher.executable, launcher.args, hookEnvironment())
           expect(result.exitCode, `${launcher.name} exit code`).toBe(0)
           expect(result.stdinErrors, `${launcher.name} stdin errors`).toHaveLength(0)

--- a/src/main/grok/grok-hook-script.ts
+++ b/src/main/grok/grok-hook-script.ts
@@ -1,0 +1,81 @@
+import { buildWindowsAgentHookPostCommand } from '../agent-hooks/installer-utils'
+import {
+  buildPosixHookPayloadCapture,
+  buildWindowsHookEnvironmentGuardLines,
+  buildWindowsHookStdinDrainEpilogue
+} from '../agent-hooks/hook-stdin-contract'
+
+// Envelope bound shared with the hook listener's grokHome validation; a home
+// longer than this is dropped rather than forwarded.
+export const GROK_HOME_ENVELOPE_MAX_LENGTH = 4096
+
+const WINDOWS_HOOK_PAYLOAD_FORM_LINE = '  --data-urlencode "payload@-" >nul 2>nul'
+
+const WINDOWS_GROK_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('grok').replace(
+  WINDOWS_HOOK_PAYLOAD_FORM_LINE,
+  `  --data-urlencode "grokHome=%ORCA_GROK_HOME%" ^\r\n${WINDOWS_HOOK_PAYLOAD_FORM_LINE}`
+)
+
+export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
+  if (target === 'local' && process.platform === 'win32') {
+    // Why: cmd.exe expands %VAR% before evaluating `if` chains, so
+    // `if defined X if "%X:~-1%"=="\"` still parse-errors when X is empty.
+    // Goto keeps the trailing-backslash check on a line that is only reached
+    // when a non-empty ORCA_GROK_HOME exists (Grok defaults to unset
+    // GROK_HOME / ~/.grok; Orca panes always set PORT/TOKEN/PANE so we do
+    // not early-exit via the stdin drain).
+    const grokHomeReadyLabel = 'orca_grok_home_ready'
+    return [
+      '@echo off',
+      'setlocal',
+      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
+      ...buildWindowsHookEnvironmentGuardLines(),
+      'set "ORCA_GROK_HOME="',
+      `if not defined GROK_HOME goto :${grokHomeReadyLabel}`,
+      'set "ORCA_GROK_HOME=%GROK_HOME%"',
+      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
+      `if not defined ORCA_GROK_HOME goto :${grokHomeReadyLabel}`,
+      // Why: a trailing backslash escapes curl's closing argv quote on Windows,
+      // merging the payload option into grokHome and dropping the hook body.
+      'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',
+      `:${grokHomeReadyLabel}`,
+      WINDOWS_GROK_HOOK_POST_COMMAND,
+      'exit /b 0',
+      ...buildWindowsHookStdinDrainEpilogue(),
+      ''
+    ].join('\r\n')
+  }
+
+  return [
+    '#!/bin/sh',
+    ...buildPosixHookPayloadCapture(),
+    'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
+    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
+    'fi',
+    'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  exit 0',
+    'fi',
+    'grok_home=',
+    `if [ -n "\${GROK_HOME:-}" ] && [ "\${#GROK_HOME}" -le ${GROK_HOME_ENVELOPE_MAX_LENGTH} ]; then`,
+    '  grok_home=$GROK_HOME',
+    'fi',
+    // Timeout caps best-effort hook posts if the local listener stalls.
+    // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
+    // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
+    // command line (EDR command-line false positives). Wire body is identical.
+    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/grok" \\',
+    '  --connect-timeout 0.5 --max-time 1.5 \\',
+    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
+    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
+    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
+    '  --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
+    '  --data-urlencode "launchToken=${ORCA_AGENT_LAUNCH_TOKEN}" \\',
+    '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
+    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
+    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
+    '  --data-urlencode "grokHome=${grok_home}" \\',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    'exit 0',
+    ''
+  ].join('\n')
+}

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawn } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -88,11 +89,17 @@ describe('GrokHookService', () => {
     expect(script).toContain('/hook/grok')
     if (process.platform === 'win32') {
       expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
+      // Why: empty GROK_HOME must not reach the trailing-backslash check.
+      // cmd expands %VAR% before `if` chains, so only a goto-skip is safe.
+      expect(script).toContain('set "ORCA_GROK_HOME="')
+      expect(script).toContain('if not defined GROK_HOME goto :orca_grok_home_ready')
       expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
       expect(script).toContain('%GROK_HOME:~4096,1%')
+      expect(script).toContain('if not defined ORCA_GROK_HOME goto :orca_grok_home_ready')
       expect(script).toContain(
         'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."'
       )
+      expect(script).toContain(':orca_grok_home_ready')
       expect(script).toContain('--data-urlencode "grokHome=%ORCA_GROK_HOME%"')
     } else {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
@@ -191,4 +198,117 @@ describe('GrokHookService', () => {
       )
     ).toBe(true)
   })
+
+  // Why: Orca panes inject ORCA_AGENT_HOOK_* so the script reaches the
+  // GROK_HOME block instead of the stdin-drain early exit. Grok itself
+  // almost never sets GROK_HOME (defaults to ~/.grok). The old script ran
+  // `if "%ORCA_GROK_HOME:~-1%"=="\"` on an empty variable and failed every
+  // hook with "The syntax of the command is incorrect."
+  it.skipIf(process.platform !== 'win32')(
+    'exits 0 with Orca env set and GROK_HOME unset (empty-home cmd parse)',
+    async () => {
+      expect(new GrokHookService().install().state).toBe('installed')
+      const scriptPath = join(homeDir, '.orca', 'agent-hooks', GROK_SCRIPT_FILE_NAME)
+
+      const env: NodeJS.ProcessEnv = {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(
+            ([key]) => !key.startsWith('ORCA_') && key !== 'GROK_HOME'
+          )
+        ),
+        // Why: non-routable port — curl fails closed; the script still exits 0.
+        ORCA_AGENT_HOOK_PORT: '1',
+        ORCA_AGENT_HOOK_TOKEN: 'test-token',
+        ORCA_PANE_KEY: 'test-pane',
+        ORCA_TAB_ID: 'test-tab',
+        ORCA_AGENT_LAUNCH_TOKEN: 'test-launch',
+        ORCA_WORKTREE_ID: 'test-worktree',
+        ORCA_AGENT_HOOK_ENV: 'test',
+        ORCA_AGENT_HOOK_VERSION: '1'
+      }
+      delete env.GROK_HOME
+
+      const result = await new Promise<{ exitCode: number | null; stderr: string }>(
+        (resolve, reject) => {
+          const child = spawn('cmd.exe', ['/d', '/c', scriptPath], {
+            env,
+            stdio: ['pipe', 'ignore', 'pipe']
+          })
+          let stderr = ''
+          const timeout = setTimeout(() => {
+            child.kill('SIGKILL')
+            reject(new Error('grok-hook.cmd timed out'))
+          }, 10_000)
+          child.stderr.on('data', (chunk: Buffer) => {
+            stderr += chunk.toString('utf8')
+          })
+          child.on('error', (error) => {
+            clearTimeout(timeout)
+            reject(error)
+          })
+          child.on('close', (exitCode) => {
+            clearTimeout(timeout)
+            resolve({ exitCode, stderr })
+          })
+          child.stdin.end('{"hookEventName":"pre_tool_use","sessionId":"test"}')
+        }
+      )
+
+      expect(result.exitCode, `stderr=${result.stderr}`).toBe(0)
+      expect(result.stderr).not.toMatch(/syntax of the command is incorrect/i)
+    }
+  )
+
+  it.skipIf(process.platform !== 'win32')(
+    'exits 0 with Orca env set and GROK_HOME trailing backslash',
+    async () => {
+      expect(new GrokHookService().install().state).toBe('installed')
+      const scriptPath = join(homeDir, '.orca', 'agent-hooks', GROK_SCRIPT_FILE_NAME)
+      const grokHome = join(homeDir, 'custom-grok') + '\\'
+
+      const env: NodeJS.ProcessEnv = {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(([key]) => !key.startsWith('ORCA_'))
+        ),
+        GROK_HOME: grokHome,
+        ORCA_AGENT_HOOK_PORT: '1',
+        ORCA_AGENT_HOOK_TOKEN: 'test-token',
+        ORCA_PANE_KEY: 'test-pane',
+        ORCA_TAB_ID: 'test-tab',
+        ORCA_AGENT_LAUNCH_TOKEN: 'test-launch',
+        ORCA_WORKTREE_ID: 'test-worktree',
+        ORCA_AGENT_HOOK_ENV: 'test',
+        ORCA_AGENT_HOOK_VERSION: '1'
+      }
+
+      const result = await new Promise<{ exitCode: number | null; stderr: string }>(
+        (resolve, reject) => {
+          const child = spawn('cmd.exe', ['/d', '/c', scriptPath], {
+            env,
+            stdio: ['pipe', 'ignore', 'pipe']
+          })
+          let stderr = ''
+          const timeout = setTimeout(() => {
+            child.kill('SIGKILL')
+            reject(new Error('grok-hook.cmd timed out'))
+          }, 10_000)
+          child.stderr.on('data', (chunk: Buffer) => {
+            stderr += chunk.toString('utf8')
+          })
+          child.on('error', (error) => {
+            clearTimeout(timeout)
+            reject(error)
+          })
+          child.on('close', (exitCode) => {
+            clearTimeout(timeout)
+            resolve({ exitCode, stderr })
+          })
+          child.stdin.end('{"hookEventName":"pre_tool_use","sessionId":"test"}')
+        }
+      )
+
+      expect(result.exitCode, `stderr=${result.stderr}`).toBe(0)
+      expect(result.stderr).not.toMatch(/syntax of the command is incorrect/i)
+    }
+  )
 })

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -24,15 +24,27 @@ const WINDOWS_POWERSHELL_LAUNCHER =
 
 describe('GrokHookService', () => {
   let homeDir: string
+  let previousGrokHome: string | undefined
 
   beforeEach(() => {
     homeDir = mkdtempSync(join(tmpdir(), 'orca-grok-home-'))
     homedirMock.mockReturnValue(homeDir)
+    // Why: neutralize an ambient GROK_HOME so install() resolves under the
+    // mocked home instead of writing orca-status.json into the developer's real
+    // Grok home (which afterEach never cleans up). Tests that exercise a set
+    // GROK_HOME opt back in explicitly.
+    previousGrokHome = process.env.GROK_HOME
+    delete process.env.GROK_HOME
   })
 
   afterEach(() => {
     vi.clearAllMocks()
     rmSync(homeDir, { recursive: true, force: true })
+    if (previousGrokHome === undefined) {
+      delete process.env.GROK_HOME
+    } else {
+      process.env.GROK_HOME = previousGrokHome
+    }
   })
 
   it('installs a dedicated global Grok hook config and managed script', () => {
@@ -264,7 +276,7 @@ describe('GrokHookService', () => {
     async () => {
       expect(new GrokHookService().install().state).toBe('installed')
       const scriptPath = join(homeDir, '.orca', 'agent-hooks', GROK_SCRIPT_FILE_NAME)
-      const grokHome = join(homeDir, 'custom-grok') + '\\'
+      const grokHome = `${join(homeDir, 'custom-grok')}\\`
 
       const env: NodeJS.ProcessEnv = {
         ...Object.fromEntries(

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -5,7 +5,6 @@ import { resolveGrokHomeDir } from '../../shared/grok-session-paths'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
-  buildWindowsAgentHookPostCommand,
   getSharedManagedScriptPath,
   readHooksJson,
   removeManagedCommands,
@@ -20,19 +19,13 @@ import {
   writeHooksJsonRemote,
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
-import {
-  buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
-} from '../agent-hooks/hook-stdin-contract'
+import { GROK_HOME_ENVELOPE_MAX_LENGTH, getManagedScript } from './grok-hook-script'
 
 // Why: Grok's tool-event matcher is a real regex (see Grok hooks docs). Bare
 // `*` is not a valid "match all" pattern and can fail to load/match, so tool
 // lifecycle hooks never fire. `.*` matches every tool name (same as Command
 // Code's managed hooks).
 const GROK_TOOL_EVENT_MATCHER = '.*'
-const GROK_HOME_ENVELOPE_MAX_LENGTH = 4096
-const WINDOWS_HOOK_PAYLOAD_FORM_LINE = '  --data-urlencode "payload@-" >nul 2>nul'
 
 const GROK_EVENTS = [
   { eventName: 'SessionStart', definition: { hooks: [{ type: 'command', command: '' }] } },
@@ -95,11 +88,6 @@ function hasControlCharacter(value: string): boolean {
   })
 }
 
-const WINDOWS_GROK_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('grok').replace(
-  WINDOWS_HOOK_PAYLOAD_FORM_LINE,
-  `  --data-urlencode "grokHome=%ORCA_GROK_HOME%" ^\r\n${WINDOWS_HOOK_PAYLOAD_FORM_LINE}`
-)
-
 function getManagedScriptFileName(): string {
   return process.platform === 'win32' ? 'grok-hook.cmd' : 'grok-hook.sh'
 }
@@ -112,59 +100,6 @@ function getManagedCommand(scriptPath: string): string {
   return process.platform === 'win32'
     ? wrapWindowsHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
-}
-
-function getManagedScript(target: 'local' | 'posix' = 'local'): string {
-  if (target === 'local' && process.platform === 'win32') {
-    return [
-      '@echo off',
-      'setlocal',
-      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
-      ...buildWindowsHookEnvironmentGuardLines(),
-      'set "ORCA_GROK_HOME=%GROK_HOME%"',
-      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
-      // Why: a trailing backslash escapes curl's closing argv quote on Windows,
-      // merging the payload option into grokHome and dropping the hook body.
-      'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',
-      WINDOWS_GROK_HOOK_POST_COMMAND,
-      'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
-      ''
-    ].join('\r\n')
-  }
-
-  return [
-    '#!/bin/sh',
-    ...buildPosixHookPayloadCapture(),
-    'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
-    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
-    'fi',
-    'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
-    '  exit 0',
-    'fi',
-    'grok_home=',
-    `if [ -n "\${GROK_HOME:-}" ] && [ "\${#GROK_HOME}" -le ${GROK_HOME_ENVELOPE_MAX_LENGTH} ]; then`,
-    '  grok_home=$GROK_HOME',
-    'fi',
-    // Timeout caps best-effort hook posts if the local listener stalls.
-    // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
-    // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
-    // command line (EDR command-line false positives). Wire body is identical.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/grok" \\',
-    '  --connect-timeout 0.5 --max-time 1.5 \\',
-    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
-    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
-    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
-    '  --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
-    '  --data-urlencode "launchToken=${ORCA_AGENT_LAUNCH_TOKEN}" \\',
-    '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
-    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
-    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "grokHome=${grok_home}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
-    'exit 0',
-    ''
-  ].join('\n')
 }
 
 function buildInstalledConfig(


### PR DESCRIPTION
## Summary

Fixes Windows agent-hook launchers so Orca's status hooks fire correctly for Grok (including Grok's `[compat.claude]` mode that loads `~/.claude/settings.json`).

- **`fix(grok)`** — `grok-hook.cmd` always ran a trailing-backslash strip on `ORCA_GROK_HOME`. Because cmd.exe expands `%VAR%` before evaluating `if` chains, an empty `GROK_HOME` (Grok's default) produced *"The syntax of the command is incorrect"* on every hook inside Orca panes. A `goto` now skips the suffix check unless a non-empty `ORCA_GROK_HOME` exists, covering unset / over-4096 / trailing-backslash homes. The Windows `.cmd` + POSIX `.sh` script templates were extracted into `grok-hook-script.ts` to stay under the `oxlint max-lines` gate (per AGENTS.md, no disables).
- **`fix(agent-hooks)`** — the Claude/OpenClaude Windows launcher was an `if [ -f … ]` bash compound. Grok's `[compat.claude]` spawns the same command through its Windows shell (not Git Bash), where that compound fails with *"-f was unexpected"*. It is now a bare forward-slash `.cmd` path (single spawnable token), which runs under both Git Bash (Claude's runner) and a cmd shell (Grok). Missing-script stdin drain stays on the encoded-PowerShell fallback used for spaced/metacharacter paths.
- **`test(agent-hooks)`** — hardening: real-Git-Bash and cmd-shell execution tests for the bare `.cmd`, a regression lock that the old `if [ -f … ]` compound fails under a cmd spawn, PATH-based Git Bash discovery (removed a hardcoded dev path), and suite-level `GROK_HOME` isolation.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — ran `oxlint` on all changed files (clean) + per-commit `lint-staged` (oxlint/oxfmt) passed; full `pnpm lint` deferred to CI.
- [x] `pnpm typecheck` — ran `typecheck:node` (tsc, `config/tsconfig.node.json`), clean. Changes are main-process only; cli/web projects untouched.
- [ ] `pnpm test` — ran the affected suites (`grok/hook-service.test.ts`, `agent-hooks/managed-hook-stdin-lifecycle.test.ts`, `agent-hooks/installer-utils.test.ts`) on Windows, all green; full suite deferred to CI.
- [ ] `pnpm build` — not run locally.
- [x] Added or updated high-quality tests that would catch regressions.

## AI Review Report

Ran a Claude `/code-review` (xhigh) and a Codex review, focused on Windows cmd-batch control-flow, the bare-`.cmd` launcher change, and cross-platform robustness.

**Flagged and resolved:**
- Hardcoded developer-specific Git Bash path in a shared test → replaced with PATH-based discovery (covers `Git\bin` and `Git\cmd` layouts).
- Test isolation: new Windows tests didn't neutralize an ambient `GROK_HOME`, risking `install()` writing outside the mocked home → fixed at the suite level.
- Coverage gap: the bare-`.cmd` spawn was only asserted as a string → added executable tests that run it under real Git Bash **and** a cmd shell, plus a regression lock that the old bash compound fails under cmd. Empirically verified on Windows (`cmd /c` and `bash -c` both exit 0; old compound exits 1 with "-f was unexpected"; note `spawn(bareCmd, {shell:false})` is a Node EINVAL false-negative and is deliberately avoided).
- Codex flagged `hook-service.ts` exceeding the 300-line `max-lines` gate (introduced by the fix) → resolved by extraction, not a disable.

**Cross-platform:** explicitly checked macOS/Linux/Windows/WSL/SSH. The changes are gated on `process.platform === 'win32'`; POSIX, WSL (runs as `linux`), and SSH remote installs use the unchanged `.sh` / `wrapPosixHookCommand` path. Path handling uses a safe-path regex that falls back to the encoded-PowerShell launcher for spaced/metacharacter paths.

## Security Audit

- **Command execution / paths:** launchers spawn managed `.cmd`/`.sh` scripts under `~/.orca/agent-hooks/`; unsafe paths (spaces/metacharacters) fall back to an encoded PowerShell launcher rather than being interpolated raw. Curl/more.com are qualified with `%SystemRoot%\System32\...` to avoid worktree-local hijacks.
- **Input handling:** hook payloads are streamed to curl via stdin (`--data-urlencode payload@-`), keeping tool output off the command line (EDR false-positive avoidance); the `grokHome` field is length-capped (≤4096) and control-char filtered.
- No secrets, auth, or dependency changes. No new IPC surface.

## Notes

- Windows-only launcher behavior; POSIX/WSL/SSH paths are unchanged.
- Trade-off (documented): the Windows Git-Bash safe-path launcher no longer drains stdin for a *missing* managed script — that drain lives on the encoded-PowerShell fallback. Matches the existing `wrapWindowsCmdHookCommand` behavior (#8430).

## ELI5

On Windows, Grok status hooks broke on empty GROK_HOME and Claude-compat mode. Hook launchers are fixed so status reporting works for Grok panes again.
