### PR TITLE
fix(mobile): align host card connection details

### DIFF
--- a/mobile/src/components/MobileHostCard.tsx
+++ b/mobile/src/components/MobileHostCard.tsx
@@ -33,14 +33,16 @@ export function MobileHostCard(props: {
         <Monitor size={20} color={connected ? colors.textPrimary : colors.textSecondary} />
       </View>
       <View style={styles.main}>
-        <Text
-          style={[styles.name, !connected && { color: colors.textSecondary }]}
-          numberOfLines={1}
-        >
-          {props.host.name}
-        </Text>
+        <View style={styles.nameRow}>
+          <Text
+            style={[styles.name, !connected && { color: colors.textSecondary }]}
+            numberOfLines={1}
+          >
+            {props.host.name}
+          </Text>
+          <StatusDot state={props.state} verdict={props.verdict} style={styles.nameStatusDot} />
+        </View>
         <View style={styles.meta}>
-          <StatusDot state={props.state} verdict={props.verdict} />
           <Text style={[styles.metaText, isError && { color: colors.statusRed }]} numberOfLines={1}>
             {verdictDisplayLabel(props.verdict)}
             {connected ? ` · ${mobileConnectionPathLabel(props.path)}` : ''}
@@ -84,12 +86,19 @@ const styles = StyleSheet.create({
     marginRight: 14
   },
   main: { flex: 1, minWidth: 0, marginRight: spacing.sm },
-  name: { color: colors.textPrimary, fontSize: 15, fontWeight: '600', lineHeight: 20 },
-  meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 3, minWidth: 0 },
+  nameRow: { flexDirection: 'row', alignItems: 'center', minWidth: 0 },
+  name: {
+    color: colors.textPrimary,
+    fontSize: 15,
+    fontWeight: '600',
+    lineHeight: 20,
+    flexShrink: 1
+  },
+  nameStatusDot: { marginLeft: spacing.sm, marginRight: 0 },
+  meta: { marginTop: 3, minWidth: 0 },
   metaText: { flex: 1, fontSize: 12, color: colors.textSecondary },
   worktreeMetaText: {
     marginTop: 2,
-    marginLeft: spacing.xl,
     fontSize: 12,
     color: colors.textMuted
   },

--- a/mobile/src/components/StatusDot.tsx
+++ b/mobile/src/components/StatusDot.tsx
@@ -1,4 +1,4 @@
-import { View, StyleSheet } from 'react-native'
+import { View, StyleSheet, type StyleProp, type ViewStyle } from 'react-native'
 import { colors } from '../theme/mobile-theme'
 import type { ConnectionState } from '../transport/types'
 import type { ConnectionVerdict } from '../transport/connection-health'
@@ -19,10 +19,12 @@ const stateColors: Record<ConnectionState, string> = {
 // has escalated to error (red).
 export function StatusDot({
   state,
-  verdict
+  verdict,
+  style
 }: {
   state: ConnectionState
   verdict?: ConnectionVerdict
+  style?: StyleProp<ViewStyle>
 }) {
   const color =
     verdict?.kind === 'unreachable' || verdict?.kind === 'auth-failed'
@@ -30,7 +32,7 @@ export function StatusDot({
       : verdict?.kind === 'warning'
         ? colors.statusAmber
         : (stateColors[state] ?? colors.textMuted)
-  return <View style={[styles.dot, { backgroundColor: color }]} />
+  return <View style={[styles.dot, { backgroundColor: color }, style]} />
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary
- move the connection status dot beside the host name
- left-align the connection and worktree metadata with the host name
- preserve existing status colors and connection behavior

## Verification
- iOS simulator connected-host screenshot
- `pnpm typecheck`
- focused oxlint and formatting checks
- mobile test suite: 1,719 passed, 2 skipped

Made with [Orca](https://github.com/stablyai/orca) 🐋
