### PR TITLE
fix(gitea): share and cache the /pulls scan so card refreshes can't hammer a self-hosted forge

### DIFF
--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -137,6 +137,40 @@ describe('Gitea client', () => {
     expect(listCalls).toBe(1)
   })
 
+  it('does not let an in-flight scan re-cache results from before an invalidation', async () => {
+    let releaseFirstScan!: () => void
+    const firstScanGate = new Promise<void>((resolve) => {
+      releaseFirstScan = resolve
+    })
+    let listCalls = 0
+    const fetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url)
+      if (parsed.pathname.endsWith('/status')) {
+        return Response.json({ state: 'success' })
+      }
+      listCalls++
+      if (listCalls === 1) {
+        // First scan is in flight (pre-create listing) when the invalidation lands.
+        await firstScanGate
+        return Response.json([giteaPr(7, 'feature/old')])
+      }
+      return Response.json([giteaPr(7, 'feature/old'), giteaPr(8, 'feature/new')])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const staleScanRead = getGiteaPullRequestForBranch('/repo', 'feature/old')
+    const { invalidateGiteaPullRequestScanForRepo, getGiteaRepoSlug } = await import('./client')
+    const repo = await getGiteaRepoSlug('/repo')
+    invalidateGiteaPullRequestScanForRepo(repo!)
+    releaseFirstScan()
+    await staleScanRead
+
+    await expect(getGiteaPullRequestForBranch('/repo', 'feature/new')).resolves.toMatchObject({
+      number: 8
+    })
+    expect(listCalls).toBe(2)
+  })
+
   it('uses an API base URL override for subpath or non-standard deployments', async () => {
     process.env.ORCA_GITEA_API_BASE_URL = 'https://git.example.com/code'
     const fetchMock = vi.fn(async (url: string | URL) => {

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -14,7 +14,11 @@ import {
   normalizeGiteaApiBaseUrl
 } from './client'
 import { _resetGiteaRepoRefCache } from './repository-ref'
-import { _resetGiteaPullRequestScanCache } from './pull-request-scan-cache'
+import {
+  _getGiteaPullRequestScanCacheSize,
+  _resetGiteaPullRequestScanCache,
+  scanGiteaPullRequests
+} from './pull-request-scan-cache'
 
 const OLD_ENV = process.env
 
@@ -135,6 +139,68 @@ describe('Gitea client', () => {
     await getGiteaPullRequestForBranch('/repo', 'no-pr-branch')
 
     expect(listCalls).toBe(1)
+  })
+
+  it('retries a failed /pulls scan after only the short failure cooldown', async () => {
+    vi.useFakeTimers()
+    try {
+      let listCalls = 0
+      const fetchMock = vi.fn(async (url: string) => {
+        const parsed = new URL(url)
+        if (parsed.pathname.endsWith('/status')) {
+          return Response.json({ state: 'success' })
+        }
+        listCalls++
+        return listCalls === 1
+          ? Response.json({ message: 'temporary failure' }, { status: 503 })
+          : Response.json([giteaPr()])
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(getGiteaPullRequestForBranch('/repo', 'feature/gitea')).resolves.toBeNull()
+      await expect(getGiteaPullRequestForBranch('/repo', 'feature/gitea')).resolves.toBeNull()
+      expect(listCalls).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(3_001)
+      await expect(getGiteaPullRequestForBranch('/repo', 'feature/gitea')).resolves.toMatchObject({
+        number: 7
+      })
+      expect(listCalls).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('expires successful scans and bounds retained repository listings', async () => {
+    vi.useFakeTimers()
+    try {
+      let listCalls = 0
+      const fetchMock = vi.fn(async (url: string) => {
+        const parsed = new URL(url)
+        if (parsed.pathname.endsWith('/status')) {
+          return Response.json({ state: 'success' })
+        }
+        listCalls++
+        return Response.json([giteaPr()])
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      await getGiteaPullRequestForBranch('/repo', 'feature/gitea')
+      expect(_getGiteaPullRequestScanCacheSize()).toBe(1)
+      await vi.advanceTimersByTimeAsync(30_001)
+      expect(_getGiteaPullRequestScanCacheSize()).toBe(0)
+      await getGiteaPullRequestForBranch('/repo', 'feature/gitea')
+      expect(listCalls).toBe(2)
+
+      await Promise.all(
+        Array.from({ length: 40 }, (_, index) =>
+          scanGiteaPullRequests(`repo-${index}`, async () => [], 50, 5)
+        )
+      )
+      expect(_getGiteaPullRequestScanCacheSize()).toBe(32)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not let an in-flight scan re-cache results from before an invalidation', async () => {

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -14,6 +14,7 @@ import {
   normalizeGiteaApiBaseUrl
 } from './client'
 import { _resetGiteaRepoRefCache } from './repository-ref'
+import { _resetGiteaPullRequestScanCache } from './pull-request-scan-cache'
 
 const OLD_ENV = process.env
 
@@ -44,6 +45,7 @@ describe('Gitea client', () => {
       stderr: ''
     })
     _resetGiteaRepoRefCache()
+    _resetGiteaPullRequestScanCache()
     vi.unstubAllGlobals()
   })
 
@@ -90,6 +92,49 @@ describe('Gitea client', () => {
     expect(listUrl.searchParams.get('sort')).toBe('recentupdate')
     expect(listUrl.searchParams.get('page')).toBe('1')
     expect(listUrl.searchParams.get('limit')).toBe('50')
+  })
+
+  it('shares one /pulls scan across concurrent branch lookups (#8807)', async () => {
+    let listCalls = 0
+    const fetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url)
+      if (parsed.pathname.endsWith('/status')) {
+        return Response.json({ state: 'success' })
+      }
+      listCalls++
+      return Response.json([giteaPr(7, 'feature/a'), giteaPr(8, 'feature/b')])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const [a, b, missing] = await Promise.all([
+      getGiteaPullRequestForBranch('/repo', 'feature/a'),
+      getGiteaPullRequestForBranch('/repo', 'feature/b'),
+      getGiteaPullRequestForBranch('/repo', 'feature/none')
+    ])
+
+    expect(a?.number).toBe(7)
+    expect(b?.number).toBe(8)
+    expect(missing).toBeNull()
+    expect(listCalls).toBe(1)
+  })
+
+  it('reuses the cached /pulls scan for lookups inside the TTL', async () => {
+    let listCalls = 0
+    const fetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url)
+      if (parsed.pathname.endsWith('/status')) {
+        return Response.json({ state: 'success' })
+      }
+      listCalls++
+      return Response.json([giteaPr()])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getGiteaPullRequestForBranch('/repo', 'feature/gitea')
+    await getGiteaPullRequestForBranch('/repo', 'feature/gitea')
+    await getGiteaPullRequestForBranch('/repo', 'no-pr-branch')
+
+    expect(listCalls).toBe(1)
   })
 
   it('uses an API base URL override for subpath or non-standard deployments', async () => {

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -6,12 +6,17 @@ import {
   type RawGiteaPullRequest
 } from './pull-request-mappers'
 import { getGiteaRepoRef, type GiteaRepoRef } from './repository-ref'
+import { invalidateGiteaPullRequestScan, scanGiteaPullRequests } from './pull-request-scan-cache'
 import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
 
 const REQUEST_TIMEOUT_MS = 5000
+// Why: self-hosted Forgejo can take ~5s to serve one /pulls page (it loads
+// reviewer data per PR). The default 5s cap aborted responses right as they
+// completed, so the work was discarded and retried on the next refresh (#8807).
+const PULL_REQUEST_LIST_TIMEOUT_MS = 15_000
 const PULL_REQUEST_PAGE_LIMIT = 50
 const MAX_PULL_REQUEST_PAGES = 5
 
@@ -102,6 +107,16 @@ function requestJson<T>(
 
 function encodedRepoPath(repo: GiteaRepoRef): string {
   return `${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}`
+}
+
+function giteaPullRequestScanKey(repo: GiteaRepoRef): string {
+  return `${configuredApiBaseUrl(repo)}/${encodedRepoPath(repo)}`
+}
+
+/** Invalidate the shared /pulls scan after Orca itself creates a PR so the
+ *  next worktree-card refresh sees it instead of a cached miss. */
+export function invalidateGiteaPullRequestScanForRepo(repo: GiteaRepoRef): void {
+  invalidateGiteaPullRequestScan(giteaPullRequestScanKey(repo))
 }
 
 async function getCommitStatus(
@@ -227,26 +242,24 @@ export async function getGiteaPullRequestForBranch(
   }
 
   if (branchName) {
-    for (let page = 1; page <= MAX_PULL_REQUEST_PAGES; page++) {
-      const list = await requestJson<RawGiteaPullRequest[]>(
-        repo,
-        `/repos/${encodedRepoPath(repo)}/pulls`,
-        {
+    const pullRequests = await scanGiteaPullRequests(
+      giteaPullRequestScanKey(repo),
+      (page) =>
+        requestJson<RawGiteaPullRequest[]>(repo, `/repos/${encodedRepoPath(repo)}/pulls`, {
           searchParams: {
             state: 'all',
             sort: 'recentupdate',
             page,
             limit: PULL_REQUEST_PAGE_LIMIT
-          }
-        }
-      )
-      const raw = list?.find((item) => matchesBranch(item, branchName))
-      if (raw) {
-        return normalizePullRequest(repo, raw)
-      }
-      if (!list || list.length < PULL_REQUEST_PAGE_LIMIT) {
-        break
-      }
+          },
+          timeoutMs: PULL_REQUEST_LIST_TIMEOUT_MS
+        }),
+      PULL_REQUEST_PAGE_LIMIT,
+      MAX_PULL_REQUEST_PAGES
+    )
+    const raw = pullRequests.find((item) => matchesBranch(item, branchName))
+    if (raw) {
+      return normalizePullRequest(repo, raw)
     }
   }
 

--- a/src/main/gitea/pull-request-creation.ts
+++ b/src/main/gitea/pull-request-creation.ts
@@ -8,7 +8,7 @@ import {
   requestHostedReviewJson
 } from '../source-control/hosted-review-api-request'
 import { readHostedPullRequestTemplate } from '../source-control/pull-request-template'
-import { getGiteaPullRequestForBranch } from './client'
+import { getGiteaPullRequestForBranch, invalidateGiteaPullRequestScanForRepo } from './client'
 import { mapGiteaPullRequest, type RawGiteaPullRequest } from './pull-request-mappers'
 import { getGiteaRepoRef, type GiteaRepoRef } from './repository-ref'
 
@@ -105,6 +105,12 @@ async function findExistingPullRequest(
   head: string,
   connectionId?: string | null
 ): Promise<{ number: number; url: string } | null> {
+  // Why: only called after a create attempt, which may have just mutated the
+  // remote — a cached /pulls scan from before the POST would miss the new PR.
+  const repo = await getGiteaRepoRef(repoPath, connectionId)
+  if (repo) {
+    invalidateGiteaPullRequestScanForRepo(repo)
+  }
   const existing = await getGiteaPullRequestForBranch(repoPath, head, null, connectionId)
   return existing ? { number: existing.number, url: existing.url } : null
 }
@@ -177,6 +183,7 @@ export async function createGiteaPullRequest(
     )
     const created = mapGiteaPullRequest(raw, 'neutral')
     if (created) {
+      invalidateGiteaPullRequestScanForRepo(repo)
       return { ok: true, number: created.number, url: created.url }
     }
     const found = await findExistingPullRequest(repoPath, head, connectionId).catch(() => null)

--- a/src/main/gitea/pull-request-scan-cache.ts
+++ b/src/main/gitea/pull-request-scan-cache.ts
@@ -1,0 +1,71 @@
+import type { RawGiteaPullRequest } from './pull-request-mappers'
+
+export type GiteaPullRequestPageFetcher = (page: number) => Promise<RawGiteaPullRequest[] | null>
+
+type GiteaPullRequestScanEntry = {
+  fetchedAt: number
+  pullRequests: RawGiteaPullRequest[]
+}
+
+// Why: long enough to absorb a push-event burst that refreshes every worktree
+// card at once, short enough that a PR opened outside Orca shows up promptly.
+const SCAN_TTL_MS = 30_000
+
+const scanCache = new Map<string, GiteaPullRequestScanEntry>()
+const inFlightScans = new Map<string, Promise<RawGiteaPullRequest[]>>()
+
+/**
+ * Why: every worktree card resolves its branch by paginating the same
+ * /repos/{repo}/pulls listing — Gitea/Forgejo have no head-branch filter.
+ * Self-hosted forges serve that endpoint slowly, and a push event refreshes
+ * all cards at once, so per-card scans multiplied one page walk into hundreds
+ * of requests and OOM-killed a small Forgejo pod (#8807). All concurrent
+ * callers share one in-flight scan per repo, and the result is cached briefly
+ * so a burst costs a single page walk.
+ */
+export async function scanGiteaPullRequests(
+  repoKey: string,
+  fetchPage: GiteaPullRequestPageFetcher,
+  pageLimit: number,
+  maxPages: number
+): Promise<RawGiteaPullRequest[]> {
+  const cached = scanCache.get(repoKey)
+  if (cached && Date.now() - cached.fetchedAt < SCAN_TTL_MS) {
+    return cached.pullRequests
+  }
+  const running = inFlightScans.get(repoKey)
+  if (running) {
+    return running
+  }
+  const scan = (async () => {
+    const pullRequests: RawGiteaPullRequest[] = []
+    for (let page = 1; page <= maxPages; page++) {
+      const list = await fetchPage(page)
+      if (list) {
+        pullRequests.push(...list)
+      }
+      if (!list || list.length < pageLimit) {
+        break
+      }
+    }
+    scanCache.set(repoKey, { fetchedAt: Date.now(), pullRequests })
+    return pullRequests
+  })()
+  inFlightScans.set(repoKey, scan)
+  try {
+    return await scan
+  } finally {
+    inFlightScans.delete(repoKey)
+  }
+}
+
+/** Drop the cached scan after a mutation Orca itself performed (PR create),
+ *  so the next card refresh sees the new PR instead of a stale miss. */
+export function invalidateGiteaPullRequestScan(repoKey: string): void {
+  scanCache.delete(repoKey)
+}
+
+export function _resetGiteaPullRequestScanCache(): void {
+  scanCache.clear()
+  inFlightScans.clear()
+}

--- a/src/main/gitea/pull-request-scan-cache.ts
+++ b/src/main/gitea/pull-request-scan-cache.ts
@@ -13,6 +13,10 @@ const SCAN_TTL_MS = 30_000
 
 const scanCache = new Map<string, GiteaPullRequestScanEntry>()
 const inFlightScans = new Map<string, Promise<RawGiteaPullRequest[]>>()
+// Why: an invalidation (PR just created) must also defeat a scan already in
+// flight — otherwise that scan finishes afterwards and re-caches a listing
+// from before the mutation, hiding the new PR for a full TTL.
+const scanGenerations = new Map<string, number>()
 
 /**
  * Why: every worktree card resolves its branch by paginating the same
@@ -37,6 +41,7 @@ export async function scanGiteaPullRequests(
   if (running) {
     return running
   }
+  const generation = scanGenerations.get(repoKey) ?? 0
   const scan = (async () => {
     const pullRequests: RawGiteaPullRequest[] = []
     for (let page = 1; page <= maxPages; page++) {
@@ -48,14 +53,18 @@ export async function scanGiteaPullRequests(
         break
       }
     }
-    scanCache.set(repoKey, { fetchedAt: Date.now(), pullRequests })
+    if ((scanGenerations.get(repoKey) ?? 0) === generation) {
+      scanCache.set(repoKey, { fetchedAt: Date.now(), pullRequests })
+    }
     return pullRequests
   })()
   inFlightScans.set(repoKey, scan)
   try {
     return await scan
   } finally {
-    inFlightScans.delete(repoKey)
+    if (inFlightScans.get(repoKey) === scan) {
+      inFlightScans.delete(repoKey)
+    }
   }
 }
 
@@ -63,9 +72,12 @@ export async function scanGiteaPullRequests(
  *  so the next card refresh sees the new PR instead of a stale miss. */
 export function invalidateGiteaPullRequestScan(repoKey: string): void {
   scanCache.delete(repoKey)
+  inFlightScans.delete(repoKey)
+  scanGenerations.set(repoKey, (scanGenerations.get(repoKey) ?? 0) + 1)
 }
 
 export function _resetGiteaPullRequestScanCache(): void {
   scanCache.clear()
   inFlightScans.clear()
+  scanGenerations.clear()
 }

--- a/src/main/gitea/pull-request-scan-cache.ts
+++ b/src/main/gitea/pull-request-scan-cache.ts
@@ -3,13 +3,20 @@ import type { RawGiteaPullRequest } from './pull-request-mappers'
 export type GiteaPullRequestPageFetcher = (page: number) => Promise<RawGiteaPullRequest[] | null>
 
 type GiteaPullRequestScanEntry = {
-  fetchedAt: number
+  expiresAt: number
+  expirationTimer: ReturnType<typeof setTimeout>
   pullRequests: RawGiteaPullRequest[]
 }
 
 // Why: long enough to absorb a push-event burst that refreshes every worktree
 // card at once, short enough that a PR opened outside Orca shows up promptly.
 const SCAN_TTL_MS = 30_000
+// Why: a short failure cooldown still coalesces rapid card retries without
+// turning a transient outage into a 30-second authoritative "no PR" result.
+const FAILED_SCAN_RETRY_MS = 3_000
+// Why: each entry can retain hundreds of full PR payloads, so TTL alone is not
+// enough protection when many repositories are opened during one app session.
+const MAX_SCAN_CACHE_ENTRIES = 32
 
 const scanCache = new Map<string, GiteaPullRequestScanEntry>()
 const inFlightScans = new Map<string, Promise<RawGiteaPullRequest[]>>()
@@ -17,6 +24,55 @@ const inFlightScans = new Map<string, Promise<RawGiteaPullRequest[]>>()
 // flight — otherwise that scan finishes afterwards and re-caches a listing
 // from before the mutation, hiding the new PR for a full TTL.
 const scanGenerations = new Map<string, number>()
+const activeScanCounts = new Map<string, number>()
+
+function removeScanCacheEntry(repoKey: string, expected?: GiteaPullRequestScanEntry): void {
+  const entry = scanCache.get(repoKey)
+  if (!entry || (expected && entry !== expected)) {
+    return
+  }
+  clearTimeout(entry.expirationTimer)
+  scanCache.delete(repoKey)
+}
+
+function rememberScanCacheEntry(
+  repoKey: string,
+  pullRequests: RawGiteaPullRequest[],
+  ttlMs: number
+): void {
+  removeScanCacheEntry(repoKey)
+  let entry!: GiteaPullRequestScanEntry
+  const expirationTimer = setTimeout(() => removeScanCacheEntry(repoKey, entry), ttlMs)
+  expirationTimer.unref()
+  entry = {
+    expiresAt: Date.now() + ttlMs,
+    expirationTimer,
+    pullRequests
+  }
+  scanCache.set(repoKey, entry)
+  while (scanCache.size > MAX_SCAN_CACHE_ENTRIES) {
+    const oldestKey = scanCache.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    removeScanCacheEntry(oldestKey)
+  }
+}
+
+function reusableScanCacheEntry(repoKey: string): GiteaPullRequestScanEntry | null {
+  const entry = scanCache.get(repoKey)
+  if (!entry) {
+    return null
+  }
+  if (Date.now() >= entry.expiresAt) {
+    removeScanCacheEntry(repoKey, entry)
+    return null
+  }
+  // Keep the cap useful for users actively switching among several repositories.
+  scanCache.delete(repoKey)
+  scanCache.set(repoKey, entry)
+  return entry
+}
 
 /**
  * Why: every worktree card resolves its branch by paginating the same
@@ -33,8 +89,8 @@ export async function scanGiteaPullRequests(
   pageLimit: number,
   maxPages: number
 ): Promise<RawGiteaPullRequest[]> {
-  const cached = scanCache.get(repoKey)
-  if (cached && Date.now() - cached.fetchedAt < SCAN_TTL_MS) {
+  const cached = reusableScanCacheEntry(repoKey)
+  if (cached) {
     return cached.pullRequests
   }
   const running = inFlightScans.get(repoKey)
@@ -42,19 +98,23 @@ export async function scanGiteaPullRequests(
     return running
   }
   const generation = scanGenerations.get(repoKey) ?? 0
+  activeScanCounts.set(repoKey, (activeScanCounts.get(repoKey) ?? 0) + 1)
   const scan = (async () => {
     const pullRequests: RawGiteaPullRequest[] = []
+    let completed = true
     for (let page = 1; page <= maxPages; page++) {
       const list = await fetchPage(page)
-      if (list) {
-        pullRequests.push(...list)
+      if (!list) {
+        completed = false
+        break
       }
-      if (!list || list.length < pageLimit) {
+      pullRequests.push(...list)
+      if (list.length < pageLimit) {
         break
       }
     }
     if ((scanGenerations.get(repoKey) ?? 0) === generation) {
-      scanCache.set(repoKey, { fetchedAt: Date.now(), pullRequests })
+      rememberScanCacheEntry(repoKey, pullRequests, completed ? SCAN_TTL_MS : FAILED_SCAN_RETRY_MS)
     }
     return pullRequests
   })()
@@ -65,19 +125,37 @@ export async function scanGiteaPullRequests(
     if (inFlightScans.get(repoKey) === scan) {
       inFlightScans.delete(repoKey)
     }
+    const activeScans = (activeScanCounts.get(repoKey) ?? 1) - 1
+    if (activeScans > 0) {
+      activeScanCounts.set(repoKey, activeScans)
+    } else {
+      activeScanCounts.delete(repoKey)
+      scanGenerations.delete(repoKey)
+    }
   }
 }
 
 /** Drop the cached scan after a mutation Orca itself performed (PR create),
  *  so the next card refresh sees the new PR instead of a stale miss. */
 export function invalidateGiteaPullRequestScan(repoKey: string): void {
-  scanCache.delete(repoKey)
+  removeScanCacheEntry(repoKey)
   inFlightScans.delete(repoKey)
-  scanGenerations.set(repoKey, (scanGenerations.get(repoKey) ?? 0) + 1)
+  if ((activeScanCounts.get(repoKey) ?? 0) > 0) {
+    scanGenerations.set(repoKey, (scanGenerations.get(repoKey) ?? 0) + 1)
+  } else {
+    scanGenerations.delete(repoKey)
+  }
 }
 
 export function _resetGiteaPullRequestScanCache(): void {
-  scanCache.clear()
+  for (const repoKey of scanCache.keys()) {
+    removeScanCacheEntry(repoKey)
+  }
   inFlightScans.clear()
   scanGenerations.clear()
+  activeScanCounts.clear()
+}
+
+export function _getGiteaPullRequestScanCacheSize(): number {
+  return scanCache.size
 }


### PR DESCRIPTION
## Summary

Fixes #8807.

Each worktree card resolved its branch to a PR by independently paginating the repo's full `/pulls` listing (`state=all`, up to `MAX_PULL_REQUEST_PAGES = 5`) with a 5s timeout. Gitea/Forgejo have no head-branch filter, a self-hosted Forgejo takes ~5s per page (reviewer data is loaded per PR), and a push event refreshes every card at once — one repo became hundreds of near-simultaneous requests whose responses were aborted right as they completed, and the burst OOM-killed the reporter's 512Mi Forgejo pod.

## Fix

- **One shared scan per repo** (`pull-request-scan-cache.ts`): concurrent branch lookups await the same in-flight page walk, and the result is cached for 30s. A burst that refreshes N worktree cards now costs a single page walk instead of N.
- **Negative results are cached too**: a branch with no PR no longer rescans all 5 pages on every card refresh within the TTL.
- **List timeout raised to 15s** (other requests keep the 5s cap), so slow-but-successful pages are used instead of discarded and retried — the reporter observed Orca cancelling right as Forgejo finished.
- **Cache invalidation on PR creation**: after Orca creates a PR (and before the post-create `findExistingPullRequest` fallback), the scan is invalidated so the new PR is visible immediately rather than after the TTL.

The issue's remaining suggestion (`state=open` first with a lazy `state=all` fallback for merged detection) is noted as a possible follow-up; with the shared cache the marginal win is much smaller and it would double requests for merged-PR branches.

## Testing

- New tests: three concurrent branch lookups (hit, hit, miss) issue exactly one list request; repeat lookups within the TTL issue none.
- `vitest run src/main/gitea/` — 30 tests pass; `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)