### PR TITLE
fix(worktrees): align symlinked creation paths with Git

### DIFF
--- a/src/main/ipc/worktree-creation-path.test.ts
+++ b/src/main/ipc/worktree-creation-path.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync, symlinkSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, expect, it, afterEach } from 'vitest'
+import { canonicalizeLocalWorktreeCreationPath } from './worktree-creation-path'
+
+describe('canonicalizeLocalWorktreeCreationPath', () => {
+  const cleanupDirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of cleanupDirs.toReversed()) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+    cleanupDirs.length = 0
+  })
+
+  it('resolves a missing descendant beneath a directory symlink to the real ancestor and preserves the tail', () => {
+    const realRoot = mkdtempSync(join(tmpdir(), 'orca-real-'))
+    const linkRoot = mkdtempSync(join(tmpdir(), 'orca-link-'))
+    cleanupDirs.push(realRoot, linkRoot)
+
+    // Create realRoot/repo as the nearest existing ancestor for the symlink target.
+    mkdirSync(join(realRoot, 'repo'), { recursive: true })
+    const linkPath = join(linkRoot, 'repo-link')
+    symlinkSync(realRoot, linkPath, process.platform === 'win32' ? 'junction' : 'dir')
+
+    // target: <linkRoot>/repo-link/repo/feature  (repo-link is a symlink, feature is missing)
+    const target = join(linkPath, 'repo', 'feature')
+    const result = canonicalizeLocalWorktreeCreationPath(target)
+
+    // The real ancestor is realRoot/repo (exists), and the missing tail is 'feature'.
+    const expected = join(realRoot, 'repo', 'feature')
+    expect(result).toBe(expected)
+  })
+
+  it('returns the target unchanged when it sits beneath a normal canonical existing ancestor', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-canonical-'))
+    cleanupDirs.push(root)
+
+    const target = join(root, 'feature')
+    const result = canonicalizeLocalWorktreeCreationPath(target)
+
+    // root exists, no symlinks involved, path is already canonical.
+    expect(result).toBe(target)
+  })
+
+  it('returns WSL UNC paths unchanged', () => {
+    const winUnc = '\\\\wsl.localhost\\Ubuntu\\home\\dev\\worktrees\\feature'
+    const winDollarUnc = '//wsl$/Ubuntu/home/dev/worktrees/feature'
+
+    expect(canonicalizeLocalWorktreeCreationPath(winUnc)).toBe(winUnc)
+    expect(canonicalizeLocalWorktreeCreationPath(winDollarUnc)).toBe(winDollarUnc)
+  })
+})

--- a/src/main/ipc/worktree-creation-path.ts
+++ b/src/main/ipc/worktree-creation-path.ts
@@ -1,0 +1,53 @@
+import { existsSync, realpathSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+import { isWslUncPath } from '../../shared/wsl-paths'
+
+/**
+ * Best-effort canonicalizer for a local worktree creation path that may not
+ * exist on disk yet.  Walks upward from the not-yet-created target to find
+ * the nearest existing ancestor, resolves it through the OS path layer, and
+ * reattaches the missing tail so symlinks in the parent are normalized away.
+ *
+ * WSL UNC paths are returned unchanged because the host filesystem is not
+ * directly accessible from the Node fs layer.
+ */
+export function canonicalizeLocalWorktreeCreationPath(targetPath: string): string {
+  // Why: WSL UNC paths (\\wsl.localhost\... or //wsl$/...) resolve to a Linux
+  // host that Node cannot reach via the Windows fs layer, so realpath would
+  // always fail.  Skip the entire walk before any filesystem access.
+  if (isWslUncPath(targetPath)) {
+    return targetPath
+  }
+
+  const missingTail: string[] = []
+  let candidate = targetPath
+
+  // Walk upward until we find an existing ancestor or hit the root.
+  while (!existsSync(candidate)) {
+    missingTail.push(basename(candidate))
+    const parent = dirname(candidate)
+    if (parent === candidate) {
+      // Reached root with no existing ancestor; return unchanged.
+      return targetPath
+    }
+    candidate = parent
+  }
+
+  // Canonicalize the existing ancestor.  Prefer native realpath (follows
+  // Windows symlinks correctly); fall back to the generic one if native fails.
+  let canonical: string
+  try {
+    canonical = realpathSync.native(candidate)
+  } catch {
+    try {
+      canonical = realpathSync(candidate)
+    } catch {
+      // Both realpath variants failed; return the original path unchanged.
+      return targetPath
+    }
+  }
+
+  // Rejoin the canonical ancestor with the missing tail in original order.
+  missingTail.reverse()
+  return join(canonical, ...missingTail)
+}

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -100,6 +100,7 @@ import {
   prepareWorktreePushTargetWithExec
 } from './worktree-push-target-setup'
 import { isENOENT, registerWorktreeRootsForRepo } from './filesystem-auth'
+import { canonicalizeLocalWorktreeCreationPath } from './worktree-creation-path'
 import { createWorktreeLinkedPaths } from './worktree-symlinks'
 import { normalizeSparseDirectories } from './sparse-checkout-directories'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
@@ -2279,6 +2280,9 @@ export async function createLocalWorktree(
       computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
       workspaceRoot
     )
+    // Why: Git resolves symlinked ancestors before recording a linked worktree.
+    // Keep Orca's create path aligned with the path returned by `git worktree list`.
+    worktreePath = canonicalizeLocalWorktreeCreationPath(worktreePath)
     if (existsSync(worktreePath)) {
       continue
     }

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -135,6 +135,13 @@ vi.mock('./worktree-logic', async (importOriginal) => {
   }
 })
 
+vi.mock('./worktree-creation-path', () => ({
+  // Why: these Linux-hosted tests exercise Windows string normalization with
+  // paths the host filesystem cannot resolve; canonicalization has focused
+  // real-filesystem coverage in worktree-creation-path.test.ts.
+  canonicalizeLocalWorktreeCreationPath: (targetPath: string) => targetPath
+}))
+
 import { registerWorktreeHandlers } from './worktrees'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => unknown>

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as GitUsernameModule from '../git/git-username'
-import { lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import type { CreateWorktreeResult, GitWorktreeInfo, Worktree } from '../../shared/types'
@@ -887,9 +887,12 @@ describe('registerWorktreeHandlers', () => {
       worktreeBaseRef: null,
       worktreeBasePath: '../worktrees'
     })
+    // Why: use an absolute path so canonicalizeLocalWorktreeCreationPath
+    // does not rebase it against the real filesystem.
+    computeWorktreePathMock.mockReturnValue('/workspace/worktrees/feature')
     listWorktreesMock.mockResolvedValue([
       {
-        path: '../worktrees/feature',
+        path: '/workspace/worktrees/feature',
         head: 'abc123',
         branch: 'feature',
         isBare: false,
@@ -908,17 +911,78 @@ describe('registerWorktreeHandlers', () => {
     })
     expect(addWorktreeMock).toHaveBeenCalledWith(
       '/workspace/repo',
-      '../worktrees/feature',
+      '/workspace/worktrees/feature',
       'feature',
       'origin/main',
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::../worktrees/feature',
+      'repo-1::/workspace/worktrees/feature',
       expect.objectContaining({
         orcaCreationWorkspaceLayout: { path: '../worktrees', nestWorkspaces: false }
       })
     )
+  })
+
+  it('canonicalizes symlinked local paths before Git creation and setup preparation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-create-realpath-'))
+    const canonicalWorkspace = join(root, 'canonical-workspace')
+    const linkedWorkspace = join(root, 'linked-workspace')
+
+    try {
+      await mkdir(canonicalWorkspace)
+      await symlink(
+        canonicalWorkspace,
+        linkedWorkspace,
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+      const requestedWorktreePath = join(linkedWorkspace, 'feature')
+      const canonicalWorktreePath = join(await realpath(canonicalWorkspace), 'feature')
+      computeWorktreePathMock.mockReturnValue(requestedWorktreePath)
+      listWorktreesMock.mockResolvedValue([
+        {
+          path: canonicalWorktreePath,
+          head: 'abc123',
+          branch: 'feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+      loadHooksMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+      getEffectiveHooksMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+      getEffectiveHooksFromConfigMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+      shouldRunSetupForCreateMock.mockReturnValue(true)
+      createSetupRunnerScriptMock.mockReturnValueOnce({
+        runnerScriptPath: '/workspace/repo/.git/orca/setup-runner.sh',
+        envVars: {
+          ORCA_ROOT_PATH: '/workspace/repo',
+          ORCA_WORKTREE_PATH: canonicalWorktreePath
+        }
+      })
+
+      const result = (await handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'feature',
+        setupDecision: 'run'
+      })) as CreateWorktreeResult
+
+      expect(addWorktreeMock).toHaveBeenCalledWith(
+        '/workspace/repo', canonicalWorktreePath, 'feature', 'origin/main', false
+      )
+      expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+        `repo-1::${canonicalWorktreePath}`, expect.any(Object)
+      )
+      expect(loadHooksMock).toHaveBeenCalledWith(canonicalWorktreePath)
+      expect(createSetupRunnerScriptMock).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'repo-1' }), canonicalWorktreePath, 'pnpm install'
+      )
+      expect(result).toMatchObject({
+        worktree: { id: `repo-1::${canonicalWorktreePath}`, path: canonicalWorktreePath },
+        setup: { envVars: { ORCA_ROOT_PATH: '/workspace/repo', ORCA_WORKTREE_PATH: canonicalWorktreePath } }
+      })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('registers local worktree roots immediately after create', async () => {


### PR DESCRIPTION
## Summary

Canonicalizes the worktree creation path so that symlinked ancestors are resolved before passing to Git. This aligns Orca's recorded path with the path that `git worktree list` returns, preventing descriptor mismatches when the parent directory is a symlink.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (local host configuration caused 23 failures in unrelated tests)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New unit tests in `worktree-creation-path.test.ts` cover direct paths, symlinked ancestors, and WSL UNC paths. Integration tests in `worktrees.test.ts` verify that the canonical path is used for Git creation and setup hooks.

## AI Review Report

Reviewed origin/main...HEAD for correctness, path handling, cross-platform behavior, SSH/local behavior, performance, and security. No actionable findings.

The change applies only to local worktree creation. macOS/Linux symlink paths and Windows junction behavior use Node path APIs. WSL UNC paths bypass host filesystem canonicalization. SSH creation remains unchanged. No UI, keyboard, or shell behavior changed.

## Security Audit

Reviewed filesystem and IPC path handling. The canonicalizer resolves only an existing ancestor, preserves the missing tail, and returns the original path when resolution fails. WSL UNC paths avoid inaccessible Windows-host filesystem calls. No command construction, secrets, authentication, dependencies, or network behavior changed.

## Notes

- WSL UNC paths (`\\wsl.localhost\...`, `//wsl$/...`) are returned unchanged because Node cannot resolve them via the filesystem layer.
- The canonicalizer walks upward from the target path to find the nearest existing ancestor, resolves symlinks at that point, then reattaches the missing tail.
- This is used in `createLocalWorktree` before invoking Git and before loading hooks for the worktree path.

## ELI5

Creating a worktree under a symlinked path recorded a different path than Git used. Orca now resolves symlinks first so its records match `git worktree list`.
