### PR TITLE
fix(sidebar): preserve Project Group members under Hide sleeping

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5726,9 +5726,10 @@ const WorktreeList = React.memo(function WorktreeList({
       groupBy,
       repos: visibleReposForRows,
       worktreesByRepo,
+      visibleWorktrees,
       filterRepoIds
     })
-  }, [filterRepoIds, groupBy, visibleReposForRows, worktreesByRepo])
+  }, [filterRepoIds, groupBy, visibleReposForRows, visibleWorktrees, worktreesByRepo])
   const allRepoIds = useMemo(() => repos.map((r) => r.id), [repos])
 
   // Why: buildRows only needs which creates exist and their repo. Subscribe on a

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
@@ -38,6 +38,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           groupBy: 'repo',
           repos: [repo],
           worktreesByRepo: { [repo.id]: [] },
+          visibleWorktrees: [],
           filterRepoIds: []
         })
       )
@@ -51,6 +52,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           groupBy: 'repo',
           repos: [repo],
           worktreesByRepo: {},
+          visibleWorktrees: [],
           filterRepoIds: []
         })
       )
@@ -67,6 +69,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           groupBy: 'repo',
           repos: [selectedRepo, hiddenRepo],
           worktreesByRepo: { [selectedRepo.id]: [], [hiddenRepo.id]: [] },
+          visibleWorktrees: [],
           filterRepoIds: [selectedRepo.id]
         })
       )
@@ -79,6 +82,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         groupBy: 'none',
         repos: [repo],
         worktreesByRepo: { [repo.id]: [] },
+        visibleWorktrees: [],
         filterRepoIds: []
       }).size
     ).toBe(0)
@@ -90,6 +94,39 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         groupBy: 'repo',
         repos: [repo],
         worktreesByRepo: { [repo.id]: [worktree] },
+        visibleWorktrees: [],
+        filterRepoIds: []
+      }).size
+    ).toBe(0)
+  })
+
+  it('keeps grouped repos visible when workspace filters hide all of their rows', () => {
+    const groupedRepo: Repo = { ...repo, projectGroupId: 'group-1' }
+    const groupedWorktree: Worktree = { ...worktree, repoId: groupedRepo.id }
+
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [groupedRepo],
+          worktreesByRepo: { [groupedRepo.id]: [groupedWorktree] },
+          visibleWorktrees: [],
+          filterRepoIds: []
+        })
+      )
+    ).toEqual([groupedRepo.id])
+  })
+
+  it('does not create a grouped repo placeholder when one of its workspaces is visible', () => {
+    const groupedRepo: Repo = { ...repo, projectGroupId: 'group-1' }
+    const groupedWorktree: Worktree = { ...worktree, repoId: groupedRepo.id }
+
+    expect(
+      getEmptyProjectPlaceholderRepoIds({
+        groupBy: 'repo',
+        repos: [groupedRepo],
+        worktreesByRepo: { [groupedRepo.id]: [groupedWorktree] },
+        visibleWorktrees: [groupedWorktree],
         filterRepoIds: []
       }).size
     ).toBe(0)

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
@@ -5,6 +5,7 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
   groupBy: WorktreeGroupBy
   repos: readonly Repo[]
   worktreesByRepo: Readonly<Record<string, readonly Worktree[] | undefined>>
+  visibleWorktrees: readonly Worktree[]
   filterRepoIds: readonly string[]
 }): Set<string> {
   if (args.groupBy !== 'repo') {
@@ -12,12 +13,17 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
   }
 
   const filterSet = args.filterRepoIds.length > 0 ? new Set(args.filterRepoIds) : null
+  const visibleRepoIds = new Set(args.visibleWorktrees.map((worktree) => worktree.repoId))
   const placeholderRepoIds = new Set<string>()
   for (const repo of args.repos) {
     if (filterSet && !filterSet.has(repo.id)) {
       continue
     }
-    if ((args.worktreesByRepo[repo.id]?.length ?? 0) === 0) {
+    const hasNoWorktrees = (args.worktreesByRepo[repo.id]?.length ?? 0) === 0
+    // Why: workspace filters hide cards, but must not rewrite the visible
+    // membership of a persisted Project Group. #8865
+    const isFilteredProjectGroupMember = repo.projectGroupId != null && !visibleRepoIds.has(repo.id)
+    if (hasNoWorktrees || isFilteredProjectGroupMember) {
       placeholderRepoIds.add(repo.id)
     }
   }


### PR DESCRIPTION
## Summary

- Keep every persisted Project Group member visible as a project header when workspace-level filters hide all of its workspace cards.
- Continue hiding non-grouped projects under the existing **Hide sleeping** behavior.
- Continue respecting explicit project filters and host scope.
- Add regression coverage for both the filtered grouped-project case and the visible-workspace case.

Fixes #8865.

## Screenshots

No visual styling change. This is a behavior-only correction to which existing project headers remain in the sidebar row model.

## Testing

- [x] `pnpm lint` — passed under Node 24; existing warnings remain outside the changed files.
- [x] `pnpm typecheck` — node, CLI, and web projects passed under Node 24.
- [ ] `pnpm test` — full repository suite not run; all sidebar tests passed: 172 files, 1435 tests.
- [ ] `pnpm build` — not run; no build, packaging, dependency, or generated-output code changed.
- [x] Added or updated high-quality tests that would catch regressions.

Red/green evidence: the new grouped-project test failed on the prior implementation with `expected [] to deeply equal ['repo-1']`; it passes with this change. The final sidebar test run passed 1435/1435.

## AI Review Report

Reviewed the complete three-file diff after the red/green cycle.

- **Root cause:** verified that `computeVisibleWorktreeIds` removes sleeping workspaces before row construction, while the placeholder selector previously consulted only the raw `worktreesByRepo` collection. A grouped project with existing but fully filtered workspaces therefore had neither a visible workspace row nor a placeholder project row.
- **Scope:** the new placeholder path is gated on `repo.projectGroupId`, so an ungrouped project with filtered workspaces keeps the existing behavior. `filterRepoIds` is still applied first, and host scope is still enforced by `visibleReposForRows` before this selector runs.
- **Visible-workspace parity:** a grouped project with any visible workspace does not receive a redundant placeholder.
- **Memo correctness:** `visibleWorktrees` was added to the selector input and the `useMemo` dependency list, so activity/filter changes recompute the project-header projection.
- **Cross-platform and SSH:** the change is pure renderer-side TypeScript over existing repo/worktree metadata. It adds no shortcuts, labels, path manipulation, shell commands, Git commands, Electron APIs, or platform branches. Local, WSL, SSH, and paired-runtime repos use the same projection path.

No additional changes were needed after review.

## Security Audit

No new security surface. The change adds a set-membership check over already-loaded `Repo` and `Worktree` objects. It introduces no external input parsing, command execution, filesystem/path handling, network or IPC calls, authentication, secrets, dependencies, or persistence writes.

## Notes

- The fix preserves Project Group membership presentation; it does not wake sleeping workspaces or change workspace activity classification.
- Related #4692, #7196, #7353, and #7511 cover different sleep-filter or project-label behavior and are not duplicates of #8865.
