### PR TITLE
feat(cli): add project group create/list/add/rm commands

### DIFF
--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -23,6 +23,10 @@ export {
 } from './computer-format'
 export type { ComputerActionFollowUpTarget } from './computer-format'
 export {
+  formatProjectGroupAddResult,
+  formatProjectGroupCreateResult,
+  formatProjectGroupDeleteResult,
+  formatProjectGroupList,
   formatProjectHostSetupCreateResult,
   formatProjectHostSetupDeleteResult,
   formatProjectHostSetupList,

--- a/src/cli/handlers/project.test.ts
+++ b/src/cli/handlers/project.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PROJECT_HANDLERS } from './project'
+import type { HandlerContext } from '../dispatch'
+import type { RuntimeClient } from '../runtime-client'
+
+describe('project group CLI handlers', () => {
+  const callMock = vi.fn()
+  const client = { call: callMock } as unknown as RuntimeClient
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  function run(command: string, flags: Record<string, string | boolean>): Promise<void> {
+    const ctx: HandlerContext = {
+      flags: new Map(Object.entries(flags)),
+      client,
+      cwd: '/tmp/repo',
+      json: false,
+      rawArgs: []
+    }
+    return PROJECT_HANDLERS[command](ctx)
+  }
+
+  beforeEach(() => {
+    callMock.mockReset()
+    callMock.mockResolvedValue({ result: {} })
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  it('create calls projectGroup.create with name and parentPath', async () => {
+    callMock.mockResolvedValue({
+      result: { group: { id: 'grp-1', name: 'frontend', parentPath: null } }
+    })
+    await run('project group create', { name: 'frontend' })
+    expect(callMock).toHaveBeenCalledWith('projectGroup.create', {
+      name: 'frontend',
+      parentPath: undefined
+    })
+  })
+
+  it('create forwards --parent-path when provided', async () => {
+    callMock.mockResolvedValue({
+      result: { group: { id: 'grp-1', name: 'child', parentPath: '/tmp/umbrella' } }
+    })
+    await run('project group create', { name: 'child', 'parent-path': '/tmp/umbrella' })
+    expect(callMock).toHaveBeenCalledWith('projectGroup.create', {
+      name: 'child',
+      parentPath: '/tmp/umbrella'
+    })
+  })
+
+  it('create rejects a missing name', async () => {
+    await expect(run('project group create', {})).rejects.toThrow()
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('list calls projectGroup.list', async () => {
+    callMock.mockResolvedValue({ result: { groups: [] } })
+    await run('project group list', {})
+    expect(callMock).toHaveBeenCalledWith('projectGroup.list')
+  })
+
+  it('add with --repo calls projectGroup.moveProject with the repo selector', async () => {
+    callMock.mockResolvedValue({ result: { repo: { id: 'repo-1', projectGroupId: 'grp-1' } } })
+    await run('project group add', { repo: 'web', group: 'grp-1' })
+    expect(callMock).toHaveBeenCalledWith('projectGroup.moveProject', {
+      repo: 'web',
+      groupId: 'grp-1'
+    })
+  })
+
+  it('add with --project resolves the ready host setup to a repo selector', async () => {
+    callMock.mockImplementation((method: string) => {
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          result: {
+            setups: [
+              {
+                id: 's1',
+                projectId: 'github:x/y',
+                hostId: 'local',
+                setupState: 'ready',
+                repoId: 'r9'
+              }
+            ]
+          }
+        })
+      }
+      return Promise.resolve({ result: { repo: { id: 'r9', projectGroupId: 'grp-1' } } })
+    })
+    await run('project group add', { project: 'github:x/y', group: 'grp-1' })
+    expect(callMock).toHaveBeenCalledWith('projectGroup.moveProject', {
+      repo: 'id:r9',
+      groupId: 'grp-1'
+    })
+  })
+
+  it('add rejects when no project selector is given', async () => {
+    await expect(run('project group add', { group: 'grp-1' })).rejects.toThrow()
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('add rejects --repo combined with --project', async () => {
+    await expect(
+      run('project group add', { repo: 'web', project: 'github:x/y', group: 'grp-1' })
+    ).rejects.toThrow()
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('rm calls projectGroup.delete with groupId', async () => {
+    callMock.mockResolvedValue({ result: { deleted: true } })
+    await run('project group rm', { group: 'grp-1' })
+    expect(callMock).toHaveBeenCalledWith('projectGroup.delete', { groupId: 'grp-1' })
+  })
+
+  it('rm rejects a missing --group', async () => {
+    await expect(run('project group rm', {})).rejects.toThrow()
+    expect(callMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/handlers/project.ts
+++ b/src/cli/handlers/project.ts
@@ -1,5 +1,6 @@
 import type {
   Project,
+  ProjectGroup,
   ProjectHostSetup,
   ProjectHostSetupCloneArgs,
   ProjectHostSetupCreateArgs,
@@ -9,10 +10,15 @@ import type {
   ProjectHostSetupResult,
   ProjectHostSetupUpdateArgs,
   ProjectHostSetupUpdateResult,
+  Repo,
   RepoKind
 } from '../../shared/types'
 import type { CommandHandler } from '../dispatch'
 import {
+  formatProjectGroupAddResult,
+  formatProjectGroupCreateResult,
+  formatProjectGroupDeleteResult,
+  formatProjectGroupList,
   formatProjectHostSetupCreateResult,
   formatProjectHostSetupDeleteResult,
   formatProjectHostSetupList,
@@ -24,6 +30,11 @@ import {
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
 import { resolveRepoPathArgument } from '../repo-path-arguments'
 import { RuntimeClientError } from '../runtime-client'
+import type { RuntimeClient } from '../runtime-client'
+import {
+  assertWorkspaceTargetFlagsCompatible,
+  resolveProjectCreateRepoSelector
+} from '../worktree-project-target'
 
 function getOptionalRepoKind(flags: Map<string, string | boolean>): RepoKind | undefined {
   const kind = getOptionalStringFlag(flags, 'kind')
@@ -141,7 +152,57 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
       }
     )
     printResult(result, json, formatProjectHostSetupDeleteResult)
+  },
+  'project group create': async ({ flags, client, json }) => {
+    const result = await client.call<{ group: ProjectGroup }>('projectGroup.create', {
+      name: getRequiredStringFlag(flags, 'name'),
+      parentPath: getOptionalStringFlag(flags, 'parent-path')
+    })
+    printResult(result, json, formatProjectGroupCreateResult)
+  },
+  'project group list': async ({ client, json }) => {
+    const result = await client.call<{ groups: ProjectGroup[] }>('projectGroup.list')
+    printResult(result, json, formatProjectGroupList)
+  },
+  'project group add': async ({ flags, client, json }) => {
+    assertWorkspaceTargetFlagsCompatible(flags)
+    const groupId = getRequiredStringFlag(flags, 'group')
+    const repo = await resolveProjectGroupTargetRepo(flags, client)
+    const result = await client.call<{ repo: Repo }>('projectGroup.moveProject', {
+      repo,
+      groupId
+    })
+    printResult(result, json, formatProjectGroupAddResult)
+  },
+  'project group rm': async ({ flags, client, json }) => {
+    const result = await client.call<{ deleted: boolean }>('projectGroup.delete', {
+      groupId: getRequiredStringFlag(flags, 'group')
+    })
+    printResult(result, json, formatProjectGroupDeleteResult)
   }
+}
+
+/**
+ * Resolve the repo a `project group add` should move, accepting the same
+ * selector forms as `orca worktree create`: a project target (--project with
+ * optional --host, or --project-host-setup) or a direct --repo selector.
+ */
+async function resolveProjectGroupTargetRepo(
+  flags: Map<string, string | boolean>,
+  client: RuntimeClient
+): Promise<string> {
+  const projectRepoSelector = await resolveProjectCreateRepoSelector(flags, client)
+  if (projectRepoSelector) {
+    return projectRepoSelector
+  }
+  const explicitRepo = getOptionalStringFlag(flags, 'repo')
+  if (explicitRepo) {
+    return explicitRepo
+  }
+  throw new RuntimeClientError(
+    'invalid_argument',
+    'Missing project selector. Pass --project <id> [--host <host-id>], --project-host-setup <id>, or --repo <selector>.'
+  )
 }
 
 function getOptionalSetupState(

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -48,6 +48,10 @@ Projects:
   project setup-create      Create independent project host setup metadata
   project setup-update      Update project host setup metadata
   project setup-delete      Remove a project host setup
+  project group create      Create a project group for organizing the sidebar
+  project group list        List project groups
+  project group add         Add a project to a project group
+  project group rm          Delete a project group
 
 Repos:
   repo list                 List repos registered in Orca
@@ -232,6 +236,10 @@ Common Commands:
   orca project setup-create --project <id> --host <host-id> [--setup-id <id>] [--path <path>] [--kind git|folder] [--display-name <name>] [--worktree-base-path <path>] [--git-username <name>] [--state ready|not-set-up|setting-up|error|unsupported] [--method imported-existing-folder|cloned|provisioned] [--json]
   orca project setup-update --setup <setup-id> [--display-name <name>] [--path <path>] [--worktree-base-path <path>] [--git-username <name>] [--kind git|folder] [--state ready|not-set-up|setting-up|error|unsupported] [--method legacy-repo|imported-existing-folder|cloned|provisioned] [--json]
   orca project setup-delete --setup <setup-id> [--json]
+  orca project group create <name> [--parent-path <path>] [--json]
+  orca project group list [--json]
+  orca project group add (--project <id> [--host <host-id>] | --project-host-setup <id> | --repo <selector>) --group <id> [--json]
+  orca project group rm --group <id> [--json]
   orca repo list [--json]
   orca repo add --path <path> [--json]
   orca repo show --repo <selector> [--json]
@@ -484,6 +492,7 @@ export function formatFlagHelp(flag: string): string {
     title: '--title <text>         Custom title for the terminal tab (omit to reset)',
     enter: '--enter                Append Enter after sending text',
     force: '--force                Force worktree removal when supported',
+    group: '--group <id>           Project group id',
     focus: '--focus                Reveal the created terminal session in Orca',
     for: '--for exit|tui-idle    Wait condition to satisfy',
     'from-element-index': '--from-element-index <n> Source element index from get-app-state',
@@ -504,6 +513,7 @@ export function formatFlagHelp(flag: string): string {
     'no-parent': '--no-parent            Force no parent lineage for unrelated work',
     'no-screenshot': '--no-screenshot       Skip screenshot capture after the operation',
     pages: '--pages <n>           Number of scroll pages',
+    'parent-path': '--parent-path <path>   Parent folder path for the project group',
     'parent-worktree':
       '--parent-worktree <selector> Parent worktree selector such as id:<repo-id>::<path>, branch:<branch>, issue:<number>, path:<path>, or active/current',
     path: '--path <path>          Path argument for the command',

--- a/src/cli/project-format.test.ts
+++ b/src/cli/project-format.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectGroup, Repo } from '../shared/types'
+import {
+  formatProjectGroupAddResult,
+  formatProjectGroupCreateResult,
+  formatProjectGroupDeleteResult,
+  formatProjectGroupList
+} from './project-format'
+
+function makeGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'grp-1',
+    name: 'frontend',
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  }
+}
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/tmp/repo',
+    displayName: 'repo',
+    badgeColor: '#000',
+    addedAt: 0,
+    ...overrides
+  }
+}
+
+describe('project-format project groups', () => {
+  it('lists groups with their parent path', () => {
+    const output = formatProjectGroupList({
+      groups: [makeGroup(), makeGroup({ id: 'grp-2', name: 'child', parentPath: '/tmp/umbrella' })]
+    })
+    expect(output).toBe('grp-1  frontend  parent:none\ngrp-2  child  parent:/tmp/umbrella')
+  })
+
+  it('reports when there are no groups', () => {
+    expect(formatProjectGroupList({ groups: [] })).toBe('No project groups found.')
+  })
+
+  it('formats a created group', () => {
+    expect(formatProjectGroupCreateResult({ group: makeGroup() })).toBe(
+      'grp-1  frontend  parent:none'
+    )
+  })
+
+  it('surfaces the repo actual resulting group after add', () => {
+    expect(formatProjectGroupAddResult({ repo: makeRepo({ projectGroupId: 'grp-1' }) })).toBe(
+      'repo: repo-1  group:grp-1'
+    )
+  })
+
+  it('shows no group when the move ungrouped the repo', () => {
+    expect(formatProjectGroupAddResult({ repo: makeRepo({ projectGroupId: null }) })).toBe(
+      'repo: repo-1  group:none'
+    )
+  })
+
+  it('reports delete outcomes', () => {
+    expect(formatProjectGroupDeleteResult({ deleted: true })).toBe('deleted')
+    expect(formatProjectGroupDeleteResult({ deleted: false })).toBe('not found')
+  })
+})

--- a/src/cli/project-format.ts
+++ b/src/cli/project-format.ts
@@ -1,10 +1,12 @@
 import type {
   Project,
+  ProjectGroup,
   ProjectHostSetup,
   ProjectHostSetupCreateResult,
   ProjectHostSetupDeleteResult,
   ProjectHostSetupResult,
-  ProjectHostSetupUpdateResult
+  ProjectHostSetupUpdateResult,
+  Repo
 } from '../shared/types'
 
 export function formatProjectList(result: { projects: Project[] }): string {
@@ -77,4 +79,33 @@ function formatProjectHostSetupResultFields(
     `method: ${setup.setupMethod}`,
     `repoId: ${repoId ?? 'none'}`
   ].join('\n')
+}
+
+/** Render the `project group list` result as one line per group. */
+export function formatProjectGroupList(result: { groups: ProjectGroup[] }): string {
+  if (result.groups.length === 0) {
+    return 'No project groups found.'
+  }
+  return result.groups.map(formatProjectGroupLine).join('\n')
+}
+
+/** Render the group returned by `project group create`. */
+export function formatProjectGroupCreateResult(result: { group: ProjectGroup }): string {
+  return formatProjectGroupLine(result.group)
+}
+
+/** Render the outcome of `project group add` (the moved repo and its group). */
+export function formatProjectGroupAddResult(result: { repo: Repo }): string {
+  // Why: moveProjectToGroup silently ungroups when the group id does not exist,
+  // so surface the repo's actual resulting group rather than the requested one.
+  return `repo: ${result.repo.id}  group:${result.repo.projectGroupId ?? 'none'}`
+}
+
+/** Render whether `project group rm` deleted a group. */
+export function formatProjectGroupDeleteResult(result: { deleted: boolean }): string {
+  return result.deleted ? 'deleted' : 'not found'
+}
+
+function formatProjectGroupLine(group: ProjectGroup): string {
+  return `${group.id}  ${group.name}  parent:${group.parentPath ?? 'none'}`
 }

--- a/src/cli/specs/project.ts
+++ b/src/cli/specs/project.ts
@@ -110,5 +110,51 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
       'Repo-backed setups remove the registered repo compatibility record.'
     ],
     examples: ['orca project setup-delete --setup github:stablyai/orca::gpu --json']
+  },
+  {
+    path: ['project', 'group', 'create'],
+    summary: 'Create a project group for organizing the sidebar',
+    usage: 'orca project group create <name> [--parent-path <path>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'name', 'parent-path'],
+    positionalArgs: ['name'],
+    notes: [
+      'Groups let headless workflows organize an otherwise flat project list (e.g. an umbrella repo plus its child repos).'
+    ],
+    examples: ['orca project group create frontend', 'orca project group create frontend --json']
+  },
+  {
+    path: ['project', 'group', 'list'],
+    summary: 'List project groups',
+    usage: 'orca project group list [--json]',
+    allowedFlags: [...GLOBAL_FLAGS],
+    examples: ['orca project group list', 'orca project group list --json']
+  },
+  {
+    path: ['project', 'group', 'add'],
+    summary: 'Add a project to a project group',
+    usage:
+      'orca project group add (--project <id> [--host <host-id>] | --project-host-setup <id> | --repo <selector>) --group <id> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'project', 'host', 'project-host-setup', 'repo', 'group'],
+    notes: [
+      'Select the project the same way as `orca worktree create`: --project (with --host to disambiguate a project set up on several hosts), --project-host-setup, or a direct --repo selector.',
+      'Choose either --repo or the project target flags, not both.'
+    ],
+    examples: [
+      'orca project group add --project github:stablyai/orca --group 1f3c...',
+      'orca project group add --project github:stablyai/orca --host local --group 1f3c... --json',
+      'orca project group add --repo id:9a2b... --group 1f3c...'
+    ]
+  },
+  {
+    path: ['project', 'group', 'rm'],
+    summary: 'Delete a project group',
+    usage: 'orca project group rm --group <id> [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'group'],
+    destructive: true,
+    notes: ['Repos in the group are ungrouped, not deleted.'],
+    examples: [
+      'orca project group rm --group 1f3c...',
+      'orca project group rm --group 1f3c... --json'
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Adds a CLI surface for **project groups** so headless / agent-orchestration workflows can organize the project list without the desktop UI:

```
orca project group create <name> [--parent-path <path>] [--json]
orca project group list [--json]
orca project group add (--project <id> [--host <host-id>] | --project-host-setup <id> | --repo <selector>) --group <id> [--json]
orca project group rm --group <id> [--json]
```

Closes #8766.

As the issue notes, this is mostly a **surfacing task**: the data model, store mutations, and runtime RPC methods (`projectGroup.create` / `.moveProject` / `.delete` / `.list`) already exist in `src/main/runtime/rpc/methods/repo.ts` and back the desktop IPC handlers. Only the CLI layer (specs, handlers, help, formatters, tests) was missing, so this PR touches **CLI files only** — no `src/main` change. The mutation methods are already reachable from the CLI because `MOBILE_RPC_METHOD_ALLOWLIST` in `runtime-rpc.ts` gates only `device.scope === 'mobile'`; other CLI-only methods (`projectHostSetup.*`) are likewise absent from it.

`add` selects the project the **same way as `orca worktree create`**, reusing `resolveProjectCreateRepoSelector` and `assertWorkspaceTargetFlagsCompatible` so `--project`/`--host`/`--project-host-setup`/`--repo` behave consistently across the CLI. It surfaces the repo's *actual* resulting group because `moveProject` silently ungroups a repo when the target group id does not exist.

## Screenshots

No visual change (CLI-only).

## Testing

- [x] `pnpm lint` (oxlint clean on changed files; lint-staged hook green on commit)
- [x] `pnpm typecheck` (`typecheck:cli` passes)
- [x] `pnpm test` (registry-parity, vocabulary-policy, and new `handlers/project.test.ts` + `project-format.test.ts` green)
- [ ] `pnpm build` (full desktop build not run; `build:cli` compiled and exercised — see below)
- [x] Added tests that would catch regressions (arg→RPC mapping incl. `--project` resolution and `--repo`/`--project` mutual-exclusion; required-flag errors; all four formatters)

Built the CLI (`build:cli`) and exercised it end-to-end against a live runtime, **net-zero** (created a marked test group, moved a repo in via both `--repo` and `--project --host`, moved it back, deleted the group; state fully restored):

- Happy: `create` → `list` (text + `--json`) → `add --project github:… --host local` and `add --repo id:…` (repo's `projectGroupId` updated) → `rm` (`deleted`).
- Error paths, all clean: unknown repo → `repo_not_found`; `--repo` + `--project` together → `Choose either --repo or project target flags, not both.`; `--host` without `--project` → `--host requires --project …`; no selector → `Missing project selector …`; missing `--group`/`--name` → `Missing required --<flag>`; `rm` on a nonexistent group → `not found`.

## AI Review Report

An independent adversarial AI review was run against the diff before opening this PR (fresh context, tasked to *refute* correctness). Main risks checked and cleared: RPC-method arg shapes vs. the zod schemas in `repo.ts`; the mobile-allowlist reachability reasoning; registry parity (spec↔handler); positional-arg folding for `create <name>`; vocabulary policy (`create`/`list`/`add`/`rm`); and `formatProjectGroupAddResult`'s silent-ungroup behavior against the real store. Verdict: **APPROVE, no blockers**; the two nits it raised (missing `--help` descriptions for `--group`/`--parent-path`, and a missing `rm` required-flag test) are fixed in this PR. CodeRabbit's automated pass reported **no actionable code comments**.

Cross-platform: the change adds no keyboard shortcuts, no shortcut labels, and no filesystem path construction in CLI code — flags are forwarded to existing runtime RPCs. `--parent-path` is passed through verbatim to the same store method the desktop UI already uses, so path semantics match the existing platform-aware runtime handling. No Electron-specific surfaces are touched.

## Security Audit

- **Input handling**: all flags are forwarded to existing runtime RPC methods whose params are validated by the existing zod schemas (`ProjectGroupCreate`, `ProjectGroupMoveProject`, `ProjectGroupSelector`) — this PR adds no new parsing of untrusted input.
- **Command execution**: none — no shell/process execution is introduced.
- **Path handling**: `--parent-path` is passed unchanged to the pre-existing `createProjectGroup` store method (same path the desktop UI uses); no new filesystem access or path joining in CLI code.
- **Auth / secrets / dependencies**: no auth changes, no secrets touched, no new dependencies.
- **IPC / RPC**: reuses already-registered RPC methods over the existing local runtime socket; no new endpoint and no change to the mobile allowlist (mutations stay off the mobile surface). No follow-up needed.

## Notes

- No `src/main` changes — the runtime RPC already existed; this is a pure CLI surfacing change.
- `add` deliberately mirrors `worktree create`'s project-selection flags for consistency; a project set up on multiple hosts is disambiguated with `--host`.
- Marked `rm` as `destructive: true` (repos in the group are ungrouped, not deleted), consistent with `project setup-delete`.

## ELI5

Project groups can be created, listed, filled, and removed from the CLI. Agents and scripts can organize projects without opening the desktop UI.
