### PR TITLE
fix(sidebar): map header drags to the nearest boundary slot instead of a dead zone

### DIFF
--- a/src/renderer/src/components/sidebar/project-group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag.ts
@@ -67,7 +67,8 @@ export function useProjectGroupHeaderDrag({
         containerTop: containerRect.top,
         scrollTop: container.scrollTop,
         rects: session.headerRects,
-        sidebarProjectGroupHeaderIds: session.sidebarProjectGroupHeaderIds
+        sidebarProjectGroupHeaderIds: session.sidebarProjectGroupHeaderIds,
+        contentBottom: container.scrollHeight
       })
     },
     []

--- a/src/renderer/src/components/sidebar/project-group-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drop.test.ts
@@ -168,10 +168,40 @@ describe('computeProjectGroupHeaderDropPreview', () => {
       scrollTop: 0,
       sidebarProjectGroupHeaderIds: ['a', 'b', 'c'],
       rects: [
-        { groupId: 'c', bucketKey: 'root', headerIndex: 2, top: 300, bottom: 328, sectionBottom: 380 }
+        {
+          groupId: 'c',
+          bucketKey: 'root',
+          headerIndex: 2,
+          top: 300,
+          bottom: 328,
+          sectionBottom: 380
+        }
       ],
       // Estimate ends at 380 but the list renders to 340; 360 is below content.
       contentBottom: 340
+    })
+
+    expect(preview).toBeNull()
+  })
+
+  it('rejects an edge-zone final drop below measured content when the estimate overshoots', () => {
+    const preview = computeProjectGroupHeaderDropPreview({
+      pointerY: 389,
+      containerTop: 0,
+      scrollTop: 0,
+      sidebarProjectGroupHeaderIds: ['a', 'b', 'c'],
+      rects: [
+        {
+          groupId: 'c',
+          bucketKey: 'root',
+          headerIndex: 2,
+          top: 300,
+          bottom: 328,
+          sectionBottom: 380
+        }
+      ],
+      // 389 crosses the estimated final boundary but remains below real content.
+      contentBottom: 350
     })
 
     expect(preview).toBeNull()
@@ -184,7 +214,14 @@ describe('computeProjectGroupHeaderDropPreview', () => {
       scrollTop: 0,
       sidebarProjectGroupHeaderIds: ['a', 'b', 'c'],
       rects: [
-        { groupId: 'c', bucketKey: 'root', headerIndex: 2, top: 300, bottom: 328, sectionBottom: 380 }
+        {
+          groupId: 'c',
+          bucketKey: 'root',
+          headerIndex: 2,
+          top: 300,
+          bottom: 328,
+          sectionBottom: 380
+        }
       ],
       contentBottom: 340
     })

--- a/src/renderer/src/components/sidebar/project-group-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drop.test.ts
@@ -137,7 +137,9 @@ describe('computeProjectGroupHeaderDropPreview', () => {
     expect(preview).toEqual({ dropIndex: 1, dropIndicatorY: 96 })
   })
 
-  it('does not create a drop slot inside an expanded Project Group section', () => {
+  it('snaps a drop inside the last expanded Project Group section to its bottom boundary', () => {
+    const INDICATOR_GAP = 4
+    const sectionBottom = 380
     const preview = computeProjectGroupHeaderDropPreview({
       pointerY: 350,
       containerTop: 0,
@@ -150,12 +152,44 @@ describe('computeProjectGroupHeaderDropPreview', () => {
           headerIndex: 2,
           top: 300,
           bottom: 328,
-          sectionBottom: 380
+          sectionBottom
         }
       ]
     })
 
+    // Only boundary available is 'c's section bottom → drop after 'c' (slot 3).
+    expect(preview).toEqual({ dropIndex: 3, dropIndicatorY: sectionBottom + INDICATOR_GAP })
+  })
+
+  it('rejects a drop below the measured content when the estimated section overshoots', () => {
+    const preview = computeProjectGroupHeaderDropPreview({
+      pointerY: 360,
+      containerTop: 0,
+      scrollTop: 0,
+      sidebarProjectGroupHeaderIds: ['a', 'b', 'c'],
+      rects: [
+        { groupId: 'c', bucketKey: 'root', headerIndex: 2, top: 300, bottom: 328, sectionBottom: 380 }
+      ],
+      // Estimate ends at 380 but the list renders to 340; 360 is below content.
+      contentBottom: 340
+    })
+
     expect(preview).toBeNull()
+  })
+
+  it('snaps a within-content drop even when the estimated section overshoots', () => {
+    const preview = computeProjectGroupHeaderDropPreview({
+      pointerY: 335,
+      containerTop: 0,
+      scrollTop: 0,
+      sidebarProjectGroupHeaderIds: ['a', 'b', 'c'],
+      rects: [
+        { groupId: 'c', bucketKey: 'root', headerIndex: 2, top: 300, bottom: 328, sectionBottom: 380 }
+      ],
+      contentBottom: 340
+    })
+
+    expect(preview).toEqual({ dropIndex: 3, dropIndicatorY: 384 })
   })
 
   it('uses the whole Project Group section for the final boundary slot', () => {

--- a/src/renderer/src/components/sidebar/project-group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drop.ts
@@ -184,6 +184,7 @@ export function computeProjectGroupHeaderDropPreview(args: {
   scrollTop: number
   rects: readonly ProjectGroupHeaderDragRect[]
   sidebarProjectGroupHeaderIds: readonly string[]
+  contentBottom?: number
 }): ProjectGroupHeaderDropPreview | null {
   const { rects, sidebarProjectGroupHeaderIds } = args
   return computeWorktreeSidebarHeaderDropPreview({
@@ -192,6 +193,7 @@ export function computeProjectGroupHeaderDropPreview(args: {
     scrollTop: args.scrollTop,
     rects,
     headerCount: sidebarProjectGroupHeaderIds.length,
-    getId: (rect) => rect.groupId
+    getId: (rect) => rect.groupId,
+    contentBottom: args.contentBottom
   })
 }

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -72,13 +72,13 @@ export function useRepoHeaderDrag({
       if (!session || !container) {
         return null
       }
-      const containerRect = container.getBoundingClientRect()
       return computeProjectHeaderDropPreview({
         pointerY,
-        containerTop: containerRect.top,
+        containerTop: container.getBoundingClientRect().top,
         scrollTop: container.scrollTop,
         rects: session.headerRects,
-        sidebarRepoHeaderIds: session.sidebarRepoHeaderIds
+        sidebarRepoHeaderIds: session.sidebarRepoHeaderIds,
+        contentBottom: container.scrollHeight
       })
     },
     []

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -285,6 +285,12 @@ describe('computeProjectHeaderDropPreview', () => {
       expect(lastPreview(360, 340)).toBeNull()
     })
 
+    it('rejects an edge-zone final drop below measured content when the estimate overshoots', () => {
+      // 389 crosses the estimated final boundary (380 + 8px padding) while still
+      // sitting below the measured list end, so the content bound must win.
+      expect(lastPreview(389, 350)).toBeNull()
+    })
+
     it('still snaps within the measured content when the estimate overshoots', () => {
       // 335 is inside the real last section (ends at 340) → drop after 'c'.
       expect(lastPreview(335, 340)).toEqual({

--- a/src/renderer/src/components/sidebar/project-header-drop.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.test.ts
@@ -139,7 +139,9 @@ describe('computeProjectHeaderDropPreview', () => {
     expect(preview).toEqual({ dropIndex: 3, dropIndicatorY: 383 })
   })
 
-  it('does not create a drop slot inside an expanded project section', () => {
+  it('snaps a drop inside the last expanded project section to its bottom boundary', () => {
+    const INDICATOR_GAP = 4
+    const sectionBottom = 380
     const preview = computeProjectHeaderDropPreview({
       pointerY: 350,
       containerTop: 0,
@@ -152,15 +154,18 @@ describe('computeProjectHeaderDropPreview', () => {
           headerIndex: 2,
           top: 300,
           bottom: 328,
-          sectionBottom: 380
+          sectionBottom
         }
       ]
     })
 
-    expect(preview).toBeNull()
+    // Only boundary available is 'c's section bottom → drop after 'c' (slot 3).
+    expect(preview).toEqual({ dropIndex: 3, dropIndicatorY: sectionBottom + INDICATOR_GAP })
   })
 
-  it('does not create a drop slot in the contents between sibling project headers', () => {
+  it('snaps a drop between sibling project headers to the nearer boundary', () => {
+    const INDICATOR_GAP = 4
+    const nextHeaderTop = 220
     const preview = computeProjectHeaderDropPreview({
       pointerY: 150,
       containerTop: 0,
@@ -173,13 +178,129 @@ describe('computeProjectHeaderDropPreview', () => {
           headerIndex: 0,
           top: 100,
           bottom: 128,
-          sectionBottom: 220
+          sectionBottom: nextHeaderTop
         },
-        { repoId: 'b', bucketKey: 'ungrouped', headerIndex: 1, top: 220, bottom: 248 }
+        { repoId: 'b', bucketKey: 'ungrouped', headerIndex: 1, top: nextHeaderTop, bottom: 248 }
       ]
     })
 
-    expect(preview).toBeNull()
+    // pointerY 150 sits in 'a's body; nearer boundary is 'b's top (216 vs 224).
+    expect(preview).toEqual({ dropIndex: 1, dropIndicatorY: nextHeaderTop - INDICATOR_GAP })
+  })
+
+  describe('nearest-boundary choice across an interior gap', () => {
+    // The gap models estimate-vs-actual drift: sectionBottom is an estimated
+    // row offset (worktree-header-section-boundaries.ts, no virtualizer gap:6 or
+    // measured sizes) while the next header's top is actual vItem.start geometry,
+    // so they diverge in tall sections. Near the real boundary the pointer snaps
+    // to actual geometry (beforeNext); the estimate governs only deep-body drops.
+    const INDICATOR_GAP = 4
+    const prevSectionBottom = 200
+    const nextHeaderTop = 240
+    const sectionBottomSlotY = prevSectionBottom + INDICATOR_GAP // 204
+    const nextHeaderSlotY = nextHeaderTop - INDICATOR_GAP // 236
+    const midpointY = (sectionBottomSlotY + nextHeaderSlotY) / 2 // 220
+    const gapRects = [
+      {
+        repoId: 'a',
+        bucketKey: 'ungrouped',
+        headerIndex: 0,
+        top: 100,
+        bottom: 128,
+        sectionBottom: prevSectionBottom
+      },
+      {
+        repoId: 'b',
+        bucketKey: 'ungrouped',
+        headerIndex: 1,
+        top: nextHeaderTop,
+        bottom: 268,
+        sectionBottom: 340
+      }
+    ] as const
+
+    it('snaps to the previous section bottom when the pointer is nearer to it', () => {
+      const preview = computeProjectHeaderDropPreview({
+        pointerY: sectionBottomSlotY + 1, // 205, closer to 204 than 236
+        containerTop: 0,
+        scrollTop: 0,
+        sidebarRepoHeaderIds: ['a', 'b'],
+        rects: gapRects.map((rect) => ({ ...rect }))
+      })
+
+      expect(preview).toEqual({ dropIndex: 1, dropIndicatorY: sectionBottomSlotY })
+    })
+
+    it('snaps to the next header top when the pointer is nearer to it', () => {
+      const preview = computeProjectHeaderDropPreview({
+        pointerY: nextHeaderSlotY - 1, // 235, closer to 236 than 204
+        containerTop: 0,
+        scrollTop: 0,
+        sidebarRepoHeaderIds: ['a', 'b'],
+        rects: gapRects.map((rect) => ({ ...rect }))
+      })
+
+      expect(preview).toEqual({ dropIndex: 1, dropIndicatorY: nextHeaderSlotY })
+    })
+
+    it('breaks the midpoint tie toward the next header boundary', () => {
+      const preview = computeProjectHeaderDropPreview({
+        pointerY: midpointY, // 220, equidistant → next header wins
+        containerTop: 0,
+        scrollTop: 0,
+        sidebarRepoHeaderIds: ['a', 'b'],
+        rects: gapRects.map((rect) => ({ ...rect }))
+      })
+
+      expect(preview).toEqual({ dropIndex: 1, dropIndicatorY: nextHeaderSlotY })
+    })
+  })
+
+  describe('content bound for the last section', () => {
+    const INDICATOR_GAP = 4
+    const estimatedSectionBottom = 380
+    const lastRects = [
+      {
+        repoId: 'c',
+        bucketKey: 'ungrouped',
+        headerIndex: 2,
+        top: 300,
+        bottom: 328,
+        sectionBottom: estimatedSectionBottom
+      }
+    ] as const
+    const lastPreview = (pointerY: number, contentBottom: number) =>
+      computeProjectHeaderDropPreview({
+        pointerY,
+        containerTop: 0,
+        scrollTop: 0,
+        sidebarRepoHeaderIds: ['a', 'b', 'c'],
+        rects: lastRects.map((rect) => ({ ...rect })),
+        contentBottom
+      })
+
+    it('rejects a drop below the measured content when the estimate overshoots', () => {
+      // Estimate says the section ends at 380, but the list actually renders to
+      // 340; a pointer at 360 is below real content → no fabricated final slot.
+      expect(lastPreview(360, 340)).toBeNull()
+    })
+
+    it('still snaps within the measured content when the estimate overshoots', () => {
+      // 335 is inside the real last section (ends at 340) → drop after 'c'.
+      expect(lastPreview(335, 340)).toEqual({
+        dropIndex: 3,
+        dropIndicatorY: estimatedSectionBottom + INDICATOR_GAP
+      })
+    })
+
+    it('snaps within the measured content when actual content undershoots the estimate', () => {
+      // Real content taller than the estimate (420 > 380): a 360 drop is well
+      // inside the section → still snaps to the final slot.
+      expect(lastPreview(360, 420)).toEqual({
+        dropIndex: 3,
+        dropIndicatorY: estimatedSectionBottom + INDICATOR_GAP
+      })
+    })
   })
 })
 

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -184,6 +184,7 @@ export function computeProjectHeaderDropPreview(args: {
   scrollTop: number
   rects: readonly ProjectHeaderDragRect[]
   sidebarRepoHeaderIds: readonly string[]
+  contentBottom?: number
 }): ProjectHeaderDropPreview | null {
   const { rects, sidebarRepoHeaderIds } = args
   return computeWorktreeSidebarHeaderDropPreview({
@@ -192,7 +193,8 @@ export function computeProjectHeaderDropPreview(args: {
     scrollTop: args.scrollTop,
     rects,
     headerCount: sidebarRepoHeaderIds.length,
-    getId: (rect) => rect.repoId
+    getId: (rect) => rect.repoId,
+    contentBottom: args.contentBottom
   })
 }
 

--- a/src/renderer/src/components/sidebar/worktree-sidebar-header-drop-preview.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-header-drop-preview.ts
@@ -34,6 +34,11 @@ export function computeWorktreeSidebarHeaderDropPreview<
   }
 
   const localY = args.pointerY - args.containerTop + args.scrollTop
+  // Why: every preview branch, including estimated edge slots, must stay
+  // inside the measured list content rather than fabricate a reorder below it.
+  if (args.contentBottom !== undefined && localY > args.contentBottom) {
+    return null
+  }
   const first = args.rects[0]!
   const last = args.rects.at(-1)!
   const lastBoundaryBottom = Math.max(last.bottom, last.sectionBottom ?? last.bottom)
@@ -78,13 +83,6 @@ export function computeWorktreeSidebarHeaderDropPreview<
       dropIndex,
       dropIndicatorY: Math.max(args.scrollTop, indicatorY)
     }
-  }
-
-  // Below the measured list end there is no real section body, only the last
-  // rect's estimated sectionBottom overshooting the content. Return null (as the
-  // parent did) rather than snapping a phantom final-slot drop there.
-  if (args.contentBottom !== undefined && localY > args.contentBottom) {
-    return null
   }
 
   // localY is in a section body or interior gap, not a header band. Snap to the

--- a/src/renderer/src/components/sidebar/worktree-sidebar-header-drop-preview.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-header-drop-preview.ts
@@ -23,6 +23,11 @@ export function computeWorktreeSidebarHeaderDropPreview<
   rects: readonly TRect[]
   headerCount: number
   getId: (rect: TRect) => string
+  // Measured scroll-content height (same coordinate space as localY and the
+  // virtualizer-derived rect tops). Bounds the interior snap so it cannot
+  // fabricate a slot below the real list end. Optional: geometry-only unit
+  // tests omit it; live drags always pass container.scrollHeight.
+  contentBottom?: number
 }): WorktreeSidebarHeaderDropPreview | null {
   if (args.rects.length === 0 || args.headerCount === 0) {
     return null
@@ -59,21 +64,81 @@ export function computeWorktreeSidebarHeaderDropPreview<
   }
 
   const hoveredRect = args.rects.find((rect) => localY >= rect.top && localY <= rect.bottom)
-  if (!hoveredRect) {
+  if (hoveredRect) {
+    const mid = (hoveredRect.top + hoveredRect.bottom) / 2
+    const dropIndex = localY < mid ? hoveredRect.headerIndex : hoveredRect.headerIndex + 1
+    const nextRect =
+      localY < mid ? hoveredRect : args.rects.find((rect) => rect.headerIndex >= dropIndex)
+    const indicatorY = nextRect
+      ? Math.max(0, nextRect.top - INDICATOR_GAP_PX)
+      : Math.max(hoveredRect.bottom, hoveredRect.sectionBottom ?? hoveredRect.bottom) +
+        INDICATOR_GAP_PX
+
+    return {
+      dropIndex,
+      dropIndicatorY: Math.max(args.scrollTop, indicatorY)
+    }
+  }
+
+  // Below the measured list end there is no real section body, only the last
+  // rect's estimated sectionBottom overshooting the content. Return null (as the
+  // parent did) rather than snapping a phantom final-slot drop there.
+  if (args.contentBottom !== undefined && localY > args.contentBottom) {
     return null
   }
 
-  const mid = (hoveredRect.top + hoveredRect.bottom) / 2
-  const dropIndex = localY < mid ? hoveredRect.headerIndex : hoveredRect.headerIndex + 1
-  const nextRect =
-    localY < mid ? hoveredRect : args.rects.find((rect) => rect.headerIndex >= dropIndex)
-  const indicatorY = nextRect
-    ? Math.max(0, nextRect.top - INDICATOR_GAP_PX)
-    : Math.max(hoveredRect.bottom, hoveredRect.sectionBottom ?? hoveredRect.bottom) +
-      INDICATOR_GAP_PX
-
-  return {
-    dropIndex,
-    dropIndicatorY: Math.max(args.scrollTop, indicatorY)
+  // localY is in a section body or interior gap, not a header band. Snap to the
+  // nearer boundary slot instead of returning null: this interior dead zone was
+  // accidental scope of 22d5989ed (#6609 only required correct reorder indices),
+  // and vanishing here makes the drop a silent no-op.
+  const boundary = pickNearestHeaderBoundarySlot(args.rects, localY)
+  if (!boundary) {
+    return null
   }
+  return {
+    dropIndex: boundary.dropIndex,
+    dropIndicatorY: Math.max(args.scrollTop, boundary.indicatorY)
+  }
+}
+
+type WorktreeSidebarHeaderBoundarySlot = {
+  dropIndex: number
+  indicatorY: number
+}
+
+function pickNearestHeaderBoundarySlot(
+  rects: readonly WorktreeSidebarHeaderDragRect[],
+  localY: number
+): WorktreeSidebarHeaderBoundarySlot | null {
+  let prevRect: WorktreeSidebarHeaderDragRect | undefined
+  let nextRect: WorktreeSidebarHeaderDragRect | undefined
+  for (const rect of rects) {
+    if (rect.top <= localY) {
+      prevRect = rect
+    } else if (nextRect === undefined) {
+      nextRect = rect
+    }
+  }
+
+  const afterPrev: WorktreeSidebarHeaderBoundarySlot | null = prevRect
+    ? {
+        dropIndex: prevRect.headerIndex + 1,
+        indicatorY:
+          Math.max(prevRect.bottom, prevRect.sectionBottom ?? prevRect.bottom) + INDICATOR_GAP_PX
+      }
+    : null
+  const beforeNext: WorktreeSidebarHeaderBoundarySlot | null = nextRect
+    ? { dropIndex: nextRect.headerIndex, indicatorY: Math.max(0, nextRect.top - INDICATOR_GAP_PX) }
+    : null
+
+  if (!afterPrev) {
+    return beforeNext
+  }
+  if (!beforeNext) {
+    return afterPrev
+  }
+  // Ties (localY at the span midpoint) resolve to the next header's boundary.
+  return Math.abs(localY - beforeNext.indicatorY) <= Math.abs(localY - afterPrev.indicatorY)
+    ? beforeNext
+    : afterPrev
 }

--- a/tests/e2e/project-group-manual-sort.spec.ts
+++ b/tests/e2e/project-group-manual-sort.spec.ts
@@ -300,7 +300,7 @@ test.describe('Project Group manual sorting', () => {
       .toEqual([projects.alphaId, projects.charlieId, projects.bravoId])
   })
 
-  test('dropping a project over another project body does not reorder projects', async ({
+  test('dropping a project over another project body snaps to that section boundary', async ({
     orcaPage
   }) => {
     await waitForSessionReady(orcaPage)
@@ -314,6 +314,10 @@ test.describe('Project Group manual sorting', () => {
       })
       .toEqual([projects.alphaId, projects.bravoId, projects.charlieId])
 
+    // Dragging alpha into bravo's expanded body drops the pointer 32px below
+    // bravo's header. Both nearest boundaries (bravo's section bottom and
+    // charlie's top) map to the slot after bravo, so alpha lands between bravo
+    // and charlie deterministically regardless of the exact section height.
     await dragProjectIntoProjectBody({
       page: orcaPage,
       draggedProjectId: projects.alphaId,
@@ -323,9 +327,9 @@ test.describe('Project Group manual sorting', () => {
     await expect
       .poll(() => getProjectHeaderOrder(orcaPage, projects), {
         timeout: 12_000,
-        message: 'Dropping on a project body should not persist a project reorder'
+        message: 'Dropping into a project body should snap to the nearest boundary slot'
       })
-      .toEqual([projects.alphaId, projects.bravoId, projects.charlieId])
+      .toEqual([projects.bravoId, projects.alphaId, projects.charlieId])
   })
 
   test('dragging a duplicate-ranked Project Group header reorders the visible headers', async ({


### PR DESCRIPTION
## Summary

Fixes #8879. Since 22d5989ed, dragging a **project header** or **Project Group header** only produced a drop indicator while the pointer was inside another header's own ~28px strip; over expanded section bodies — most of the sidebar — the preview returned `null`, the indicator unmounted, and releasing was a silent no-op. Precise reordering with expanded sections was nearly impossible.

`computeWorktreeSidebarHeaderDropPreview` now maps a pointer in a section body or interior gap to the **nearest boundary slot** (previous section's bottom vs next header's top, midpoint rule; ties resolve toward the next header). The indicator follows the pointer through the whole list, and drops land where the indicator shows — `dropIndex` is derived from the same slot that positions the line, for both header consumers.

Guard against fabricated drops: the **measured** content bound (`container.scrollHeight`, same coordinate space as the virtualizer-measured header tops) is applied up front to **every** branch, so a pointer below the actually-rendered list still cancels exactly like before. This also tightens the pre-existing edge-zone/final-boundary path — an overshoot final drop that lands below real content now cancels too (regression test added); that path's internal slot logic is otherwise unchanged. #6609's reorder-index fix (sibling reindexing) is untouched; that issue never asked for a dead zone — the same commit even accepts `sectionBottom + gap` for the final boundary slot, so the interior dead zone was accidental scope.

Out of scope (documented in #8879): the `Math.max(scrollTop, …)` indicator clamp divergence, and replacing the estimator-based per-section boundaries with measured offsets (pre-existing, shared with the final-boundary path — see Notes).

## Screenshots

UI behavior change (drop indicator tracking). No recording attached: the semantics are pinned by the unit suites (including the short-list differential regression added in 0788d5ad8) and the rewritten e2e spec in CI.

## Testing

- [x] `pnpm lint` — oxlint clean on all 8 touched files (one hook refactored to stay under the max-lines cap rather than bumping it); full lint chain deferred to CI
- [x] `pnpm typecheck` — node, cli, and web tsconfigs all pass
- [x] `pnpm test` — all 17 sidebar drag/drop suites: 118 passed (focused trio: 49); full suite deferred to CI
- [ ] `pnpm build` / e2e — deferred to CI (no quick single-spec e2e path; the rewritten spec's expected order is derived from `commitProjectHeaderDragDrop`'s ungrouped path and is boundary-choice-independent at the drag target used)
- [x] Added or updated high-quality tests that would catch regressions

Test coverage: the three previous expect-`null` pins are flipped to nearest-boundary assertions; new cases pin both boundary choices across an interior gap and the midpoint tie; a content-bound group pins **both drift directions** of the estimated section end (overshoot: pointer below measured content → `null`; within measured content → still snaps), for both the project-header and project-group-header consumers; the pinned final-boundary tests and the in-band header behavior stay byte-identical.

## AI Review Report

Two adversarial Codex rounds (`gpt-5.6-sol`, read-only sandbox). Round 1 surfaced a concern about the estimated `sectionBottom`; adjudicated with a full evidence chain: the per-section boundary estimator (`worktree-header-section-boundaries.ts`) omits the virtualizer's 6px inter-row gap and measured sizes, but it is pre-existing shared infrastructure — the new snap consumes it byte-identically to two shipped paths, committed `dropIndex` is a pure row-model integer classified against **measured** header tops (drift-immune), and near boundaries the nearest-boundary choice self-corrects to measured geometry. Round 2 found one high-severity real defect in the first draft: with estimate **overshoot**, a pointer below the actually-rendered list could be classified "inside" and commit a reorder where the parent returned `null`. Fixed exactly per the reviewer's recommendation — an authoritative measured content bound rejects such points before snapping — with tests for both drift directions and both consumers. Cross-platform: pure renderer pointer-geometry; no platform APIs, shortcuts, or paths touched.

## Security Audit

Renderer-only pointer-geometry logic. No input handling, IPC, command execution, path handling, auth, secrets, or dependency changes. The one security-adjacent failure mode — converting an outside-the-list release (cancel intent) into a persistent reorder — was caught in review and is now bounded by measured content height with regression tests.

## Notes

- Cosmetic residual (pre-existing): for drops deep inside a very tall last section, the indicator **line** can render a few px off the true boundary because the shared per-section estimator undershoots by ~6px per row; the committed slot is unaffected. A proper fix should replace the estimator with measured offsets across all three consumers at once (preview snap, in-band bottom-half, final-boundary path) — happy to file that as a follow-up if maintainers want it.
- The rewritten e2e ("dropping a project over another project body snaps to that section boundary", expected order `[bravo, alpha, charlie]`) encodes the new WYSIWYG semantics; the old test pinned the accidental no-op.

