### PR TITLE
fix(sidebar): revalidate setup-script prompt when the hook becomes effective (#8752)

### DIFF
--- a/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
+++ b/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
@@ -26,6 +26,7 @@ import {
   type LastVisibleSetupScriptPrompt,
   useSetupScriptPromptProjectContext
 } from './setup-script-prompt-render-state'
+import { useSetupScriptPromptRevalidation } from './useSetupScriptPromptRevalidation'
 import { translate } from '@/i18n/i18n'
 
 type PromptState = SetupScriptPromptInspection
@@ -112,6 +113,14 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
   const handleRetryInspection = useCallback(() => {
     setInspectionRetryKey((value) => value + 1)
   }, [])
+
+  useSetupScriptPromptRevalidation({
+    activeRepo,
+    isDismissed,
+    sidebarOpen,
+    promptState,
+    requestRevalidation: handleRetryInspection
+  })
 
   useEffect(() => {
     if (

--- a/src/renderer/src/components/sidebar/useSetupScriptPromptRevalidation.test.tsx
+++ b/src/renderer/src/components/sidebar/useSetupScriptPromptRevalidation.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { SetupScriptPromptInspection } from '@/lib/setup-script-prompt'
+import type { Repo } from '../../../../shared/types'
+import { useSetupScriptPromptRevalidation } from './useSetupScriptPromptRevalidation'
+
+const GIT_REPO = { id: 'repo-1', kind: 'git' } as unknown as Repo
+
+function missingSetup(repoId: string): SetupScriptPromptInspection {
+  return { status: 'ok', repoId, hasEffectiveSetup: false, hasSharedHooks: true, candidate: null }
+}
+
+function effectiveSetup(repoId: string): SetupScriptPromptInspection {
+  return { status: 'ok', repoId, hasEffectiveSetup: true, hasSharedHooks: true, candidate: null }
+}
+
+type HarnessProps = {
+  activeRepo: Repo | null
+  isDismissed: boolean
+  sidebarOpen: boolean
+  promptState: SetupScriptPromptInspection | null
+  requestRevalidation: () => void
+}
+
+function Harness(props: HarnessProps): null {
+  useSetupScriptPromptRevalidation(props)
+  return null
+}
+
+const roots: Root[] = []
+
+async function render(props: HarnessProps): Promise<(next: HarnessProps) => Promise<void>> {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(<Harness {...props} />)
+  })
+  return async (next: HarnessProps) => {
+    await act(async () => {
+      root.render(<Harness {...next} />)
+    })
+  }
+}
+
+async function dispatchWindowFocus(): Promise<void> {
+  await act(async () => {
+    window.dispatchEvent(new Event('focus'))
+  })
+}
+
+async function setActiveWorktree(worktreeId: string | null): Promise<void> {
+  await act(async () => {
+    useAppStore.setState({ activeWorktreeId: worktreeId })
+  })
+}
+
+describe('useSetupScriptPromptRevalidation', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    useAppStore.setState({ activeWorktreeId: 'worktree-1' })
+  })
+
+  afterEach(() => {
+    roots.splice(0).forEach((root) => act(() => root.unmount()))
+    document.body.replaceChildren()
+    useAppStore.setState({ activeWorktreeId: null })
+    vi.clearAllMocks()
+  })
+
+  it('re-inspects on window focus while the prompt shows no effective setup', async () => {
+    const requestRevalidation = vi.fn()
+    await render({
+      activeRepo: GIT_REPO,
+      isDismissed: false,
+      sidebarOpen: true,
+      promptState: missingSetup('repo-1'),
+      requestRevalidation
+    })
+
+    await dispatchWindowFocus()
+
+    expect(requestRevalidation).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-inspect on window focus once setup is effective', async () => {
+    const requestRevalidation = vi.fn()
+    await render({
+      activeRepo: GIT_REPO,
+      isDismissed: false,
+      sidebarOpen: true,
+      promptState: effectiveSetup('repo-1'),
+      requestRevalidation
+    })
+
+    await dispatchWindowFocus()
+
+    expect(requestRevalidation).not.toHaveBeenCalled()
+  })
+
+  it('does not listen for focus while the sidebar is closed', async () => {
+    const requestRevalidation = vi.fn()
+    await render({
+      activeRepo: GIT_REPO,
+      isDismissed: false,
+      sidebarOpen: false,
+      promptState: missingSetup('repo-1'),
+      requestRevalidation
+    })
+
+    await dispatchWindowFocus()
+
+    expect(requestRevalidation).not.toHaveBeenCalled()
+  })
+
+  it('re-inspects when a worktree activates while the prompt shows no effective setup', async () => {
+    const requestRevalidation = vi.fn()
+    // Mirror the card's real lifecycle: promptState is null on mount, so the
+    // activation effect does not fire until a negative result has been cached.
+    const rerender = await render({
+      activeRepo: GIT_REPO,
+      isDismissed: false,
+      sidebarOpen: true,
+      promptState: null,
+      requestRevalidation
+    })
+    await rerender({
+      activeRepo: GIT_REPO,
+      isDismissed: false,
+      sidebarOpen: true,
+      promptState: missingSetup('repo-1'),
+      requestRevalidation
+    })
+    expect(requestRevalidation).not.toHaveBeenCalled()
+
+    await setActiveWorktree('worktree-2')
+
+    expect(requestRevalidation).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-inspect on worktree activation once setup is effective', async () => {
+    const requestRevalidation = vi.fn()
+    const rerender = await render({
+      activeRepo: GIT_REPO,
+      isDismissed: false,
+      sidebarOpen: true,
+      promptState: null,
+      requestRevalidation
+    })
+    await rerender({
+      activeRepo: GIT_REPO,
+      isDismissed: false,
+      sidebarOpen: true,
+      promptState: effectiveSetup('repo-1'),
+      requestRevalidation
+    })
+
+    await setActiveWorktree('worktree-2')
+
+    expect(requestRevalidation).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/useSetupScriptPromptRevalidation.ts
+++ b/src/renderer/src/components/sidebar/useSetupScriptPromptRevalidation.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react'
+import { useAppStore } from '@/store'
+import type { SetupScriptPromptInspection } from '@/lib/setup-script-prompt'
+import { isGitRepoKind } from '../../../../shared/repo-kind'
+import type { Repo } from '../../../../shared/types'
+
+/**
+ * Re-runs the setup-script prompt inspection when a shared `orca.yaml` setup hook
+ * can have become effective outside SetupScriptPromptCard's reactive inputs, so a
+ * stale "Add a setup script" prompt clears without a full sidebar reopen.
+ */
+export function useSetupScriptPromptRevalidation(input: {
+  activeRepo: Repo | null
+  isDismissed: boolean
+  sidebarOpen: boolean
+  promptState: SetupScriptPromptInspection | null
+  requestRevalidation: () => void
+}): void {
+  const { activeRepo, isDismissed, sidebarOpen, promptState, requestRevalidation } = input
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+
+  // Why: only revalidate while the prompt still shows no effective setup — there is
+  // nothing to clear (and no RPC worth spending, notably over SSH) once it is
+  // configured.
+  const showsMissingSetup =
+    promptState?.status === 'ok' &&
+    promptState.repoId === activeRepo?.id &&
+    !promptState.hasEffectiveSetup
+
+  // Why: orca.yaml is edited on disk or the hook runs in a terminal outside React
+  // state. Re-inspect on window focus so returning to Orca detects it (mirrors
+  // useInstalledAgentSkills' focus revalidation).
+  useEffect(() => {
+    if (
+      !sidebarOpen ||
+      !activeRepo ||
+      !isGitRepoKind(activeRepo) ||
+      isDismissed ||
+      !showsMissingSetup
+    ) {
+      return
+    }
+    window.addEventListener('focus', requestRevalidation)
+    return () => {
+      window.removeEventListener('focus', requestRevalidation)
+    }
+  }, [activeRepo, isDismissed, requestRevalidation, showsMissingSetup, sidebarOpen])
+
+  // Why: the setup hook runs during worktree creation, so activating a worktree in
+  // this repo can make the setup effective after a negative result was cached. Fire
+  // only on an actual activation change, not on mount/remount with a seeded id —
+  // the initial inspection already covers the mounted worktree.
+  const previousWorktreeIdRef = useRef(activeWorktreeId)
+  useEffect(() => {
+    const changed = previousWorktreeIdRef.current !== activeWorktreeId
+    previousWorktreeIdRef.current = activeWorktreeId
+    if (changed && showsMissingSetup) {
+      requestRevalidation()
+    }
+  }, [activeWorktreeId, requestRevalidation, showsMissingSetup])
+}


### PR DESCRIPTION
## Summary

Fixes a stale sidebar **"Add a setup script"** card that stayed visible after the `orca.yaml` setup hook actually became effective, forcing a full sidebar reopen to clear it.

## ELI5

Orca kept nagging you to add a setup script even after you already added one. Now the reminder notices the change and disappears on its own.

## Root cause & fix

The setup-prompt card only re-ran its inspection when a fixed set of inputs changed (`activeRepo`, `settings`, `sidebarOpen`, `isDismissed`, retry key). When a shared `orca.yaml` hook became effective *outside* those inputs — edited on disk or run during worktree creation — the cached result went stale. This PR extracts a `useSetupScriptPromptRevalidation` hook that re-inspects on two triggers: **window focus** and **worktree activation**. Both are gated on `showsMissingSetup` (plus sidebar open, git repo, not dismissed), so no extra RPC fires once setup is effective; the worktree trigger is ref-seeded at mount so it never fires on mount/remount.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Clean rebase onto `origin/main` (base `7ab601487c`).

- Scoped run of `useSetupScriptPromptRevalidation.test.tsx` — **Test Files 1 passed (1), Tests 5 passed (5).**
- The fix file is a new module (no main version to revert), so the hook body was neutralized to a no-op (pre-fix "no revalidation" behavior); the two positive-behavior assertions then failed, proving the test captures the fix:

```
Test Files 1 failed (1), Tests 2 failed | 3 passed (5)
- "re-inspects on window focus while the prompt shows no effective setup"
    AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times (line 87)
- "re-inspects when a worktree activates while the prompt shows no effective setup"
    AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times (line 142)
```

- Restored the real hook → 5 passed.
- `npx oxlint` on both source files → EXIT=0, no warnings/errors. Clean.

## Trade-offs

None — pure fix. The runtime-reconnect trigger is intentionally deferred (window focus covers the common reconnect-after-background case).

## Regression risk

Zero-regression: revalidation is gated on `showsMissingSetup`, so once setup is effective no listener attaches and no RPC fires — no focus/worktree loop, SSH-friendly. The card change is purely additive (one hook call), and `handleRetryInspection` only bumps the existing retry key, driving no new side channels. The "does not re-inspect once effective" and "no listener while sidebar closed" tests prove the gates hold.

*Credit to original author @kaynansc. Validated, rebased, and hardened via automated bug-bash review; original fix design preserved (no additional fix required this session — the RPC hot-path gate was already part of the original fix).*
