### PR TITLE
fix: prevent iOS freeze when renaming terminals

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -5336,9 +5336,9 @@ export default function SessionScreen() {
             : []),
           {
             label: 'Rename',
+            closeBeforePress: true,
             onPress: () => {
               const target = actionTarget
-              setActionTarget(null)
               if (target) {
                 setRenameTarget(target)
               }

--- a/mobile/src/session/mobile-terminal-rename-modal-source.test.ts
+++ b/mobile/src/session/mobile-terminal-rename-modal-source.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+  new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
+  'utf8'
+)
+
+describe('mobile terminal rename modal sequencing', () => {
+  it('waits for the terminal action sheet to close before opening rename', () => {
+    expect(source).toMatch(
+      /label: 'Rename',[\s\S]*?closeBeforePress: true,[\s\S]*?setRenameTarget\(target\)/
+    )
+  })
+})


### PR DESCRIPTION



## Summary

Fixes #8889.

Renaming a terminal from the iOS mobile action sheet could leave an invisible native modal window above the session, preventing tabs and other controls from receiving taps.

This change waits for the terminal action sheet to fully dismiss before presenting the rename input. It uses the existing `closeBeforePress` sequencing provided by `ActionSheetModal`.

## Screenshots

No visual design change.

The recording below demonstrates the bug and the expected interaction:

this is example of the bug
https://github.com/user-attachments/assets/1543be07-3ffc-4d5b-9d70-b33d6b5e4d21

this is after the fix

https://github.com/user-attachments/assets/709cbf9f-39e0-47f9-80e5-bb8885da206e


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Desktop/web production build
- [x] Native helper build with ad-hoc local signing
- [x] Added regression coverage requiring terminal rename to use close-before-present modal sequencing
- [x] Manually verified on a physical iPhone with an Orca development client

## AI Review Report

Reviewed the change for iOS native-modal presentation ordering, Android behavior, and desktop compatibility across macOS, Linux, and Windows.

The change uses the existing platform-neutral `ActionSheetModal.closeBeforePress` path. On iOS it prevents overlapping native modal presentation; on Android it only defers opening the rename drawer until the action sheet close animation completes. It does not modify shortcuts, labels, paths, shell behavior, Electron behavior, terminal RPC semantics, or local/SSH/remote worktree handling.

The review also checked supported agents and integrations, rendering performance, and UI behavior. The change adds one deferred callback to a user-triggered rename flow and does not affect hot paths.

## Security Audit

No new command execution, filesystem access, authentication, secrets, dependencies, external input handling, or IPC/RPC endpoints were introduced.

The change only sequences two existing mobile UI modals. No additional security follow-up is required.

## Notes

- Manually verified on iOS 18.6.2 using a physical iPhone.
- No visual design change.
- X/Twitter: @koushik406

## ELI5

Renaming a terminal on iOS could leave an invisible sheet blocking all taps. The rename dialog waits until the action sheet fully closes so the UI stays responsive.
