### PR TITLE
test(windows): allow native launcher compilation time

### DIFF
--- a/config/scripts/build-windows-cli-launcher.test.mjs
+++ b/config/scripts/build-windows-cli-launcher.test.mjs
@@ -4,9 +4,14 @@ import { dirname, join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 
-const itWindows = process.platform === 'win32' ? it : it.skip
 const itCrossHost = process.platform === 'win32' ? it.skip : it
 const projectRoot = resolve(import.meta.dirname, '../..')
+// Why: cold csc.exe startup exceeds Vitest's 5s unit budget on hosted Windows;
+// keep the larger allowance scoped to the real compiler integration test.
+function itWindows(name, test) {
+  const runner = process.platform === 'win32' ? it : it.skip
+  runner(name, { timeout: 15_000 }, test)
+}
 
 describe('Windows CLI launcher', () => {
   itCrossHost('fails closed when the Windows launcher cannot be compiled on this host', () => {

--- a/src/main/ssh/ssh-remote-cli-launcher.test.ts
+++ b/src/main/ssh/ssh-remote-cli-launcher.test.ts
@@ -7,7 +7,12 @@ import { describe, expect, it } from 'vitest'
 import { createRemoteCliInstallPlan } from './ssh-remote-cli-launcher'
 import { getRemoteHostPlatform } from './ssh-remote-platform'
 
-const itWindows = process.platform === 'win32' ? it : it.skip
+// Why: cold csc.exe startup exceeds Vitest's 5s unit budget on hosted Windows;
+// keep the larger allowance scoped to the real compiler integration test.
+function itWindows(name: string, test: () => void): void {
+  const runner = process.platform === 'win32' ? it : it.skip
+  runner(name, { timeout: 15_000 }, test)
+}
 
 function decodePowerShellCommand(command: string): string {
   const encoded = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)?.[1]


### PR DESCRIPTION
## Summary

- give the two Windows native-launcher compilation tests a 15-second integration-test budget
- keep the 5-second unit-test default everywhere else
- make no production-code changes

## Why

Hosted Windows runners completed the compiler-backed assertions in about 7.4 seconds, then failed because the tests inherited the 5-second unit budget. PR #8706 reproduced the timeout twice on the same SHA, while an earlier run passed, which explains why other PRs can remain green near this threshold.

Failed runs:

- https://github.com/stablyai/orca/actions/runs/29441654134/job/87441890228
- https://github.com/stablyai/orca/actions/runs/29441654134/job/87442826436

## Testing

- `pnpm exec vitest run src/main/ssh/ssh-remote-cli-launcher.test.ts config/scripts/build-windows-cli-launcher.test.mjs`
- `pnpm run typecheck:node`
- `pnpm lint`

## Screenshots

No visual change.
