### PR TITLE
feat(mobile): render images inline in PR body/comment markdown

### DIFF
--- a/mobile/src/components/pr-sidebar/CommentMarkdown.tsx
+++ b/mobile/src/components/pr-sidebar/CommentMarkdown.tsx
@@ -165,7 +165,13 @@ function Paragraph({ text, base }: { text: string; base: number }) {
         part.kind === 'image' ? (
           // Key by uri so a changed image (edited/refetched body) remounts and resets
           // the loaded aspect ratio / error state instead of reusing the stale one.
-          <MarkdownImage key={`img-${i}-${part.url}`} uri={part.url} alt={part.alt} base={base} />
+          <MarkdownImage
+            key={`img-${i}-${part.url}`}
+            uri={part.url}
+            alt={part.alt}
+            href={part.href}
+            base={base}
+          />
         ) : (
           <Text
             key={`run-${i}`}
@@ -288,7 +294,11 @@ function InlineTokens({ tokens, base }: { tokens: InlineToken[]; base: number })
           // image can't render, so degrade to a tappable link like a normal link.
           // Standalone paragraph images render as real blocks via <Paragraph>.
           return (
-            <Text key={i} style={styles.link} onPress={() => openMarkdownLink(token.url)}>
+            <Text
+              key={i}
+              style={styles.link}
+              onPress={() => openMarkdownLink(token.href ?? token.url)}
+            >
               {token.alt || token.url}
             </Text>
           )

--- a/mobile/src/components/pr-sidebar/CommentMarkdown.tsx
+++ b/mobile/src/components/pr-sidebar/CommentMarkdown.tsx
@@ -4,9 +4,11 @@ import { ChevronDown, ChevronRight } from 'lucide-react-native'
 import { colors, radii, spacing, typography } from '../../theme/mobile-theme'
 import { MermaidDiagram } from './MermaidDiagram'
 import { isAllowedMarkdownLinkUrl } from './markdown-link-scheme'
+import { MarkdownImage } from './MarkdownImage'
 import {
   parseInline,
   parseMarkdownBlocks,
+  splitInlineImages,
   type CellAlign,
   type InlineToken,
   type MarkdownBlock
@@ -133,12 +135,48 @@ function BlockView({ block, base }: { block: MarkdownBlock; base: number }) {
         </View>
       )
     case 'paragraph':
-      return (
-        <Text style={[styles.paragraph, { fontSize: base, lineHeight: base + 7 }]}>
-          <Inline text={block.text} base={base} />
-        </Text>
-      )
+      return <Paragraph text={block.text} base={base} />
   }
+}
+
+// A paragraph can carry block images (PR screenshots). RN forbids a responsive <Image>
+// inside <Text>, so hoist images into their own blocks and keep the surrounding prose as
+// <Text> runs. The common all-text case still renders as a single <Text>.
+function Paragraph({ text, base }: { text: string; base: number }) {
+  const parts = useMemo(() => {
+    try {
+      return splitInlineImages(parseInline(text))
+    } catch {
+      return [{ kind: 'run' as const, tokens: [{ kind: 'text' as const, text }] }]
+    }
+  }, [text])
+
+  if (parts.length === 1 && parts[0].kind === 'run') {
+    return (
+      <Text style={[styles.paragraph, { fontSize: base, lineHeight: base + 7 }]}>
+        <InlineTokens tokens={parts[0].tokens} base={base} />
+      </Text>
+    )
+  }
+
+  return (
+    <View>
+      {parts.map((part, i) =>
+        part.kind === 'image' ? (
+          // Key by uri so a changed image (edited/refetched body) remounts and resets
+          // the loaded aspect ratio / error state instead of reusing the stale one.
+          <MarkdownImage key={`img-${i}-${part.url}`} uri={part.url} alt={part.alt} base={base} />
+        ) : (
+          <Text
+            key={`run-${i}`}
+            style={[styles.paragraph, { fontSize: base, lineHeight: base + 7 }]}
+          >
+            <InlineTokens tokens={part.tokens} base={base} />
+          </Text>
+        )
+      )}
+    </View>
+  )
 }
 
 function openMarkdownLink(url: string): void {
@@ -210,6 +248,10 @@ function Inline({ text, base }: { text: string; base: number }) {
       return [{ kind: 'text', text }]
     }
   }, [text])
+  return <InlineTokens tokens={tokens} base={base} />
+}
+
+function InlineTokens({ tokens, base }: { tokens: InlineToken[]; base: number }) {
   return (
     <>
       {tokens.map((token, i) => {
@@ -238,6 +280,16 @@ function Inline({ text, base }: { text: string; base: number }) {
           return (
             <Text key={i} style={styles.link} onPress={() => openMarkdownLink(token.url)}>
               {token.text}
+            </Text>
+          )
+        }
+        if (token.kind === 'image') {
+          // Inside a <Text> context (heading, list, quote, table cell) a responsive
+          // image can't render, so degrade to a tappable link like a normal link.
+          // Standalone paragraph images render as real blocks via <Paragraph>.
+          return (
+            <Text key={i} style={styles.link} onPress={() => openMarkdownLink(token.url)}>
+              {token.alt || token.url}
             </Text>
           )
         }

--- a/mobile/src/components/pr-sidebar/MarkdownImage.test.ts
+++ b/mobile/src/components/pr-sidebar/MarkdownImage.test.ts
@@ -1,4 +1,5 @@
 import { createElement } from 'react'
+import { Linking } from 'react-native'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MarkdownImage } from './MarkdownImage'
@@ -31,12 +32,12 @@ function suppressDeprecationWarning(): () => void {
   return () => spy.mockRestore()
 }
 
-function render(uri: string): ReactTestRenderer {
+function render(uri: string, extra?: { href?: string }): ReactTestRenderer {
   let renderer: ReactTestRenderer | null = null
   const restore = suppressDeprecationWarning()
   try {
     act(() => {
-      renderer = create(createElement(MarkdownImage, { uri, alt: 'shot', base: 14 }))
+      renderer = create(createElement(MarkdownImage, { uri, alt: 'shot', base: 14, ...extra }))
     })
   } finally {
     restore()
@@ -76,5 +77,14 @@ describe('MarkdownImage', () => {
     })
     expect(renderer.root.findAllByType('Image')).toHaveLength(0)
     expect(renderer.root.findAllByType('Text')).toHaveLength(1)
+  })
+
+  it('taps a linked image through to its href, not the image url', () => {
+    vi.mocked(Linking.openURL).mockClear()
+    renderer = render('https://x.y/a.png', { href: 'https://x.y/full' })
+    act(() => {
+      renderer?.root.findByType('Pressable').props.onPress()
+    })
+    expect(Linking.openURL).toHaveBeenCalledWith('https://x.y/full')
   })
 })

--- a/mobile/src/components/pr-sidebar/MarkdownImage.test.ts
+++ b/mobile/src/components/pr-sidebar/MarkdownImage.test.ts
@@ -1,0 +1,80 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MarkdownImage } from './MarkdownImage'
+
+vi.mock('react-native', () => ({
+  Image: 'Image',
+  Pressable: 'Pressable',
+  Text: 'Text',
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  Linking: { openURL: vi.fn(() => Promise.resolve()) }
+}))
+
+vi.mock('../../theme/mobile-theme', () => ({
+  colors: { textPrimary: '#fff', bgRaised: '#222' },
+  radii: { row: 6 },
+  spacing: { sm: 8 }
+}))
+
+// The scheme gate (markdown-link-scheme) is intentionally NOT mocked — the point of these
+// tests is that the real allowlist keeps disallowed schemes from ever reaching an <Image>.
+
+function suppressDeprecationWarning(): () => void {
+  const original = console.error
+  const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+      return
+    }
+    original(...args)
+  })
+  return () => spy.mockRestore()
+}
+
+function render(uri: string): ReactTestRenderer {
+  let renderer: ReactTestRenderer | null = null
+  const restore = suppressDeprecationWarning()
+  try {
+    act(() => {
+      renderer = create(createElement(MarkdownImage, { uri, alt: 'shot', base: 14 }))
+    })
+  } finally {
+    restore()
+  }
+  if (!renderer) {
+    throw new Error('MarkdownImage did not render')
+  }
+  return renderer
+}
+
+describe('MarkdownImage', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  afterEach(() => {
+    renderer?.unmount()
+    renderer = null
+    vi.restoreAllMocks()
+  })
+
+  it('renders an <Image> for an allowed http(s) scheme', () => {
+    renderer = render('https://x.y/a.png')
+    expect(renderer.root.findAllByType('Image')).toHaveLength(1)
+    expect(renderer.root.findAllByType('Text')).toHaveLength(0)
+  })
+
+  it('degrades a disallowed scheme to a non-tappable text link (never an <Image>)', () => {
+    renderer = render('data:image/png;base64,AAAA')
+    expect(renderer.root.findAllByType('Image')).toHaveLength(0)
+    // Not tappable: a disallowed scheme must never reach the OS URL handler.
+    expect(renderer.root.findByType('Text').props.onPress).toBeUndefined()
+  })
+
+  it('falls back to a text link when the image fails to load', () => {
+    renderer = render('https://x.y/broken.png')
+    act(() => {
+      renderer?.root.findByType('Image').props.onError()
+    })
+    expect(renderer.root.findAllByType('Image')).toHaveLength(0)
+    expect(renderer.root.findAllByType('Text')).toHaveLength(1)
+  })
+})

--- a/mobile/src/components/pr-sidebar/MarkdownImage.tsx
+++ b/mobile/src/components/pr-sidebar/MarkdownImage.tsx
@@ -7,6 +7,8 @@ type Props = {
   uri: string
   alt: string
   base: number
+  // Outer link target of a linked image `[![alt](uri)](href)`; tapping navigates here.
+  href?: string
 }
 
 function openUri(uri: string): void {
@@ -19,16 +21,18 @@ function openUri(uri: string): void {
 // browser). On load error or a disallowed scheme it degrades to a text link: private-repo
 // attachments (github.com/user-attachments/…) need the user's GitHub session, which the
 // device doesn't have, so they can't load here.
-export function MarkdownImage({ uri, alt, base }: Props) {
+export function MarkdownImage({ uri, alt, base, href }: Props) {
   const [aspectRatio, setAspectRatio] = useState<number | null>(null)
   const [failed, setFailed] = useState(false)
   const allowed = isAllowedMarkdownLinkUrl(uri)
+  // Navigate to the outer link when it's a safe scheme, otherwise the image itself.
+  const target = href && isAllowedMarkdownLinkUrl(href) ? href : uri
 
   if (failed || !allowed) {
     return (
       <Text
         style={[styles.fallback, { fontSize: base }]}
-        onPress={allowed ? () => openUri(uri) : undefined}
+        onPress={isAllowedMarkdownLinkUrl(target) ? () => openUri(target) : undefined}
       >
         {alt || uri}
       </Text>
@@ -36,7 +40,7 @@ export function MarkdownImage({ uri, alt, base }: Props) {
   }
 
   return (
-    <Pressable onPress={() => openUri(uri)} accessibilityRole="imagebutton">
+    <Pressable onPress={() => openUri(target)} accessibilityRole="imagebutton">
       <Image
         source={{ uri }}
         accessibilityLabel={alt || undefined}

--- a/mobile/src/components/pr-sidebar/MarkdownImage.tsx
+++ b/mobile/src/components/pr-sidebar/MarkdownImage.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { Image, Linking, Pressable, StyleSheet, Text } from 'react-native'
+import { colors, radii, spacing } from '../../theme/mobile-theme'
+import { isAllowedMarkdownLinkUrl } from './markdown-link-scheme'
+
+type Props = {
+  uri: string
+  alt: string
+  base: number
+}
+
+function openUri(uri: string): void {
+  void Linking.openURL(uri).catch(() => {})
+}
+
+// Renders a PR-body markdown image inline (screenshots are the common case). Width fills
+// the container and aspectRatio — read from the loaded image — drives the height, so no
+// container measurement is needed. Tapping opens the source (e.g. full-size in the
+// browser). On load error or a disallowed scheme it degrades to a text link: private-repo
+// attachments (github.com/user-attachments/…) need the user's GitHub session, which the
+// device doesn't have, so they can't load here.
+export function MarkdownImage({ uri, alt, base }: Props) {
+  const [aspectRatio, setAspectRatio] = useState<number | null>(null)
+  const [failed, setFailed] = useState(false)
+  const allowed = isAllowedMarkdownLinkUrl(uri)
+
+  if (failed || !allowed) {
+    return (
+      <Text
+        style={[styles.fallback, { fontSize: base }]}
+        onPress={allowed ? () => openUri(uri) : undefined}
+      >
+        {alt || uri}
+      </Text>
+    )
+  }
+
+  return (
+    <Pressable onPress={() => openUri(uri)} accessibilityRole="imagebutton">
+      <Image
+        source={{ uri }}
+        accessibilityLabel={alt || undefined}
+        style={[styles.image, aspectRatio ? { aspectRatio } : styles.imageLoading]}
+        resizeMode="contain"
+        onLoad={(event) => {
+          const { width, height } = event.nativeEvent.source
+          if (width > 0 && height > 0) {
+            setAspectRatio(width / height)
+          }
+        }}
+        onError={() => setFailed(true)}
+      />
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  image: {
+    width: '100%',
+    borderRadius: radii.row,
+    backgroundColor: colors.bgRaised,
+    marginBottom: spacing.sm
+  },
+  // Placeholder height until the natural aspect ratio arrives on first load.
+  imageLoading: { height: 180 },
+  fallback: {
+    color: colors.textPrimary,
+    textDecorationLine: 'underline',
+    marginBottom: spacing.sm
+  }
+})

--- a/mobile/src/components/pr-sidebar/markdown-blocks.test.ts
+++ b/mobile/src/components/pr-sidebar/markdown-blocks.test.ts
@@ -196,9 +196,9 @@ describe('parseInline', () => {
     ])
   })
 
-  it('renders a linked image ([![alt](img)](href)) as the image, dropping the wrapper', () => {
+  it('renders a linked image ([![alt](img)](href)) as the image, keeping the href', () => {
     expect(parseInline('[![shot](https://x.y/a.png)](https://x.y/full.png)')).toEqual([
-      { kind: 'image', alt: 'shot', url: 'https://x.y/a.png' }
+      { kind: 'image', alt: 'shot', url: 'https://x.y/a.png', href: 'https://x.y/full.png' }
     ])
     // A plain link (not wrapping an image) is unaffected.
     expect(parseInline('[docs](https://x.y)')).toEqual([
@@ -228,6 +228,13 @@ describe('splitInlineImages', () => {
     expect(splitInlineImages(tokens)).toEqual([
       { kind: 'image', alt: 'a', url: 'https://x.y/a.png' },
       { kind: 'image', alt: 'b', url: 'https://x.y/b.png' }
+    ])
+  })
+
+  it('preserves the outer href of a linked image when hoisting', () => {
+    const tokens = parseInline('[![a](https://x.y/a.png)](https://x.y/full)')
+    expect(splitInlineImages(tokens)).toEqual([
+      { kind: 'image', alt: 'a', url: 'https://x.y/a.png', href: 'https://x.y/full' }
     ])
   })
 })

--- a/mobile/src/components/pr-sidebar/markdown-blocks.test.ts
+++ b/mobile/src/components/pr-sidebar/markdown-blocks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseInline, parseMarkdownBlocks } from './markdown-blocks'
+import { parseInline, parseMarkdownBlocks, splitInlineImages } from './markdown-blocks'
 
 describe('parseMarkdownBlocks', () => {
   it('classifies headings, fenced code, quotes, lists, hr, and paragraphs', () => {
@@ -170,5 +170,64 @@ describe('parseInline', () => {
 
   it('leaves unbalanced markers as literal text', () => {
     expect(parseInline('a * b')).toEqual([{ kind: 'text', text: 'a * b' }])
+  })
+
+  it('tokenizes images (![alt](url)) without splitting off a stray "!" or a link', () => {
+    expect(parseInline('![shot](https://x.y/a.png)')).toEqual([
+      { kind: 'image', alt: 'shot', url: 'https://x.y/a.png' }
+    ])
+    // Empty alt is valid.
+    expect(parseInline('![](https://x.y/a.png)')).toEqual([
+      { kind: 'image', alt: '', url: 'https://x.y/a.png' }
+    ])
+    // Image surrounded by prose stays an image, not a "!" + link.
+    expect(parseInline('see ![s](https://x.y/a.png) here')).toEqual([
+      { kind: 'text', text: 'see ' },
+      { kind: 'image', alt: 's', url: 'https://x.y/a.png' },
+      { kind: 'text', text: ' here' }
+    ])
+  })
+
+  it('still tokenizes a plain link alongside an image (no regression)', () => {
+    expect(parseInline('![img](https://x.y/a.png) and [link](https://x.y)')).toEqual([
+      { kind: 'image', alt: 'img', url: 'https://x.y/a.png' },
+      { kind: 'text', text: ' and ' },
+      { kind: 'link', text: 'link', url: 'https://x.y' }
+    ])
+  })
+
+  it('renders a linked image ([![alt](img)](href)) as the image, dropping the wrapper', () => {
+    expect(parseInline('[![shot](https://x.y/a.png)](https://x.y/full.png)')).toEqual([
+      { kind: 'image', alt: 'shot', url: 'https://x.y/a.png' }
+    ])
+    // A plain link (not wrapping an image) is unaffected.
+    expect(parseInline('[docs](https://x.y)')).toEqual([
+      { kind: 'link', text: 'docs', url: 'https://x.y' }
+    ])
+  })
+})
+
+describe('splitInlineImages', () => {
+  it('hoists images into their own parts, keeping surrounding prose as runs', () => {
+    const tokens = parseInline('before ![a](https://x.y/a.png) after')
+    expect(splitInlineImages(tokens)).toEqual([
+      { kind: 'run', tokens: [{ kind: 'text', text: 'before ' }] },
+      { kind: 'image', alt: 'a', url: 'https://x.y/a.png' },
+      { kind: 'run', tokens: [{ kind: 'text', text: ' after' }] }
+    ])
+  })
+
+  it('returns a single run when there is no image', () => {
+    expect(splitInlineImages(parseInline('just text'))).toEqual([
+      { kind: 'run', tokens: [{ kind: 'text', text: 'just text' }] }
+    ])
+  })
+
+  it('keeps consecutive images as separate blocks with no empty runs', () => {
+    const tokens = parseInline('![a](https://x.y/a.png)![b](https://x.y/b.png)')
+    expect(splitInlineImages(tokens)).toEqual([
+      { kind: 'image', alt: 'a', url: 'https://x.y/a.png' },
+      { kind: 'image', alt: 'b', url: 'https://x.y/b.png' }
+    ])
   })
 })

--- a/mobile/src/components/pr-sidebar/markdown-blocks.ts
+++ b/mobile/src/components/pr-sidebar/markdown-blocks.ts
@@ -10,6 +10,7 @@ export type InlineToken =
   | { kind: 'italic'; text: string }
   | { kind: 'code'; text: string }
   | { kind: 'link'; text: string; url: string }
+  | { kind: 'image'; alt: string; url: string }
 
 export type CellAlign = 'left' | 'center' | 'right'
 
@@ -232,9 +233,14 @@ function parseAlignRow(line: string): CellAlign[] {
   })
 }
 
-// Inline emphasis/code/link tokenizer. Walks the string once, longest-match first,
+// Inline emphasis/code/link/image tokenizer. Walks the string once, longest-match first,
 // emitting plain-text runs between matches. Unbalanced markers stay literal text.
-const INLINE = /(`[^`]+`)|(\*\*[^*]+\*\*)|(__[^_]+__)|(\*[^*]+\*)|(_[^_]+_)|(\[[^\]]+\]\([^)]+\))/
+// Order matters (leftmost match wins, ties break by alternative order): the linked-image
+// `[![alt](img)](href)` alternative precedes the plain image and link ones so a clickable
+// thumbnail isn't mis-split into a link with a `![alt` label plus literal tail; the plain
+// image `![alt](url)` precedes the link so `![…](…)` isn't split into a stray `!` + link.
+const INLINE =
+  /(`[^`]+`)|(\[!\[[^\]]*\]\([^)]+\)\]\([^)]+\))|(!\[[^\]]*\]\([^)]+\))|(\*\*[^*]+\*\*)|(__[^_]+__)|(\*[^*]+\*)|(_[^_]+_)|(\[[^\]]+\]\([^)]+\))/
 
 export function parseInline(text: string): InlineToken[] {
   const tokens: InlineToken[] = []
@@ -253,7 +259,24 @@ export function parseInline(text: string): InlineToken[] {
       tokens.push({ kind: 'text', text: rest.slice(0, m.index) })
     }
     const token = m[0]
-    if (token.startsWith('`')) {
+    if (token.startsWith('[![')) {
+      // Linked image `[![alt](img)](href)` (a clickable thumbnail): render the image and
+      // drop the outer link wrapper — showing the image is what matters here.
+      const altClose = token.indexOf('](')
+      const urlStart = altClose + 2
+      tokens.push({
+        kind: 'image',
+        alt: token.slice(3, altClose),
+        url: token.slice(urlStart, token.indexOf(')', urlStart))
+      })
+    } else if (token.startsWith('![')) {
+      const close = token.indexOf('](')
+      tokens.push({
+        kind: 'image',
+        alt: token.slice(2, close),
+        url: token.slice(close + 2, -1)
+      })
+    } else if (token.startsWith('`')) {
       tokens.push({ kind: 'code', text: token.slice(1, -1) })
     } else if (token.startsWith('**') || token.startsWith('__')) {
       tokens.push({ kind: 'bold', text: token.slice(2, -2) })
@@ -270,4 +293,34 @@ export function parseInline(text: string): InlineToken[] {
     rest = rest.slice(m.index + token.length)
   }
   return tokens
+}
+
+// A paragraph's inline tokens split into standalone image blocks and runs of the
+// surrounding inline tokens, in order.
+export type ParagraphPart =
+  | { kind: 'image'; alt: string; url: string }
+  | { kind: 'run'; tokens: InlineToken[] }
+
+// Hoists images out of a paragraph's inline flow: RN can't render a responsive <Image>
+// inside <Text>, so the renderer needs images as their own blocks with the surrounding
+// prose preserved as text runs. Pure so it's covered by the parser tests.
+export function splitInlineImages(tokens: InlineToken[]): ParagraphPart[] {
+  const parts: ParagraphPart[] = []
+  let run: InlineToken[] = []
+  const flushRun = (): void => {
+    if (run.length > 0) {
+      parts.push({ kind: 'run', tokens: run })
+      run = []
+    }
+  }
+  for (const token of tokens) {
+    if (token.kind === 'image') {
+      flushRun()
+      parts.push({ kind: 'image', alt: token.alt, url: token.url })
+    } else {
+      run.push(token)
+    }
+  }
+  flushRun()
+  return parts
 }

--- a/mobile/src/components/pr-sidebar/markdown-blocks.ts
+++ b/mobile/src/components/pr-sidebar/markdown-blocks.ts
@@ -10,7 +10,9 @@ export type InlineToken =
   | { kind: 'italic'; text: string }
   | { kind: 'code'; text: string }
   | { kind: 'link'; text: string; url: string }
-  | { kind: 'image'; alt: string; url: string }
+  // `href` is the outer link target of a linked image `[![alt](url)](href)`; absent for a
+  // plain `![alt](url)`. Tapping navigates to `href` when present, else to `url`.
+  | { kind: 'image'; alt: string; url: string; href?: string }
 
 export type CellAlign = 'left' | 'center' | 'right'
 
@@ -261,13 +263,15 @@ export function parseInline(text: string): InlineToken[] {
     const token = m[0]
     if (token.startsWith('[![')) {
       // Linked image `[![alt](img)](href)` (a clickable thumbnail): render the image and
-      // drop the outer link wrapper — showing the image is what matters here.
+      // keep the outer link's href so tapping navigates to it (e.g. a full-size page).
       const altClose = token.indexOf('](')
       const urlStart = altClose + 2
+      const imgUrlEnd = token.indexOf(')', urlStart)
       tokens.push({
         kind: 'image',
         alt: token.slice(3, altClose),
-        url: token.slice(urlStart, token.indexOf(')', urlStart))
+        url: token.slice(urlStart, imgUrlEnd),
+        href: token.slice(imgUrlEnd + 3, -1)
       })
     } else if (token.startsWith('![')) {
       const close = token.indexOf('](')
@@ -298,7 +302,7 @@ export function parseInline(text: string): InlineToken[] {
 // A paragraph's inline tokens split into standalone image blocks and runs of the
 // surrounding inline tokens, in order.
 export type ParagraphPart =
-  | { kind: 'image'; alt: string; url: string }
+  | { kind: 'image'; alt: string; url: string; href?: string }
   | { kind: 'run'; tokens: InlineToken[] }
 
 // Hoists images out of a paragraph's inline flow: RN can't render a responsive <Image>
@@ -316,7 +320,7 @@ export function splitInlineImages(tokens: InlineToken[]): ParagraphPart[] {
   for (const token of tokens) {
     if (token.kind === 'image') {
       flushRun()
-      parts.push({ kind: 'image', alt: token.alt, url: token.url })
+      parts.push({ kind: 'image', alt: token.alt, url: token.url, href: token.href })
     } else {
       run.push(token)
     }


### PR DESCRIPTION
## Summary

In Orca Mobile, the **Pull Request** tab (Source Control) rendered markdown images (`![alt](url)`) in a PR body or comment as a plain text link — a screenshot pasted into a PR description only showed up as underlined text (`!alt`) and opened in the browser on tap, instead of previewing inline. The desktop app already renders these inline.

This teaches the mobile markdown renderer to show images inline, matching desktop:

- The dependency-free inline tokenizer (`markdown-blocks.ts`) now emits an `image` token for `![alt](url)` and for the linked-thumbnail form `[![alt](img)](href)` (renders the image, drops the outer link wrapper).
- A new `MarkdownImage` block fills the available width and derives its height from the loaded image's aspect ratio (no container measurement needed). Tapping it opens the source (e.g. full-size in the browser).
- Standalone paragraph images render as real blocks — React Native can't put a responsive `<Image>` inside `<Text>` — while an image inside a text context (heading / list / quote / table cell) degrades to a tappable link.
- **Graceful fallback:** on load error or a non-`http(s)` scheme it degrades to a text link. For public repos, `github.com/user-attachments/...` URLs 302-redirect to a signed blob served without a cookie, so RN's `<Image>` loads them directly (verified). Private-repo attachments need the user's GitHub session, which the device doesn't have, so they fall back to a link — the same effective behavior as desktop today.

## Screenshots

Rendered in the Orca Mobile Pull Request tab, with a PR body that contains a markdown image:

![Before/after: a markdown image in a PR body — text link vs. rendered inline](https://raw.githubusercontent.com/kaynansc/orca/pr-assets-mobile-pr-inline-images/mobile-pr-body-inline-images.png)

- **Before:** the image shows as an underlined text link (`!Before and after comparison`).
- **After:** the image renders inline as a preview.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` — N/A for the `mobile` package (it has no build script; the **Mobile Checks** CI job runs typecheck/test/lint/format:check, all green locally). `pnpm build:unpack` builds the desktop app, which this mobile-only change doesn't touch.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Also ran `pnpm format:check` (green). New tests: `markdown-blocks.test.ts` covers the image / linked-image tokens and the paragraph split; `MarkdownImage.test.ts` covers the URL-scheme gate and the load-error fallback.

## AI Review Report

Ran a two-axis AI review (repo standards + spec/intent) with parallel sub-agents, then independently re-checked each finding.

- **Cross-platform (macOS / Linux / Windows):** confirmed. This is React Native (iOS/Android); no platform-specific APIs, no hardcoded `metaKey`, no path or shell assumptions. Reuses the existing `mobile-theme` tokens (`colors`/`radii`/`spacing`) rather than inventing values.
- **SSH / remote / private repos:** confirmed. The mobile app fetches PR data via an RPC to the host's authenticated `gh`; image bytes load on the device. Private-repo attachments that require a GitHub session fall back to a link (no regression vs. today; no new host RPC introduced).
- **Flagged & fixed:** (1) `[![alt](img)](href)` clickable thumbnails were mis-tokenized into garbage — now render the image; (2) a loaded image wasn't tappable — now wrapped so it opens the source, matching desktop; (3) `aspectRatio`/error state could persist when a different image lands at the same list index — now keyed by uri so it remounts; (4) `MarkdownImage` had no component tests — added coverage for the scheme gate and the error fallback; (5) tightened a comment that overstated desktop parity.

## Security Audit

- **Untrusted input:** PR/comment markdown is untrusted. Image URLs reuse the existing `isAllowedMarkdownLinkUrl` allowlist (`http:`/`https:`/`mailto:`) before rendering **and** before any `Linking.openURL`, so a `javascript:`/`data:`/`file:` scheme can never reach an `<Image>` source or the OS URL handler — covered by a test. No command execution, no path handling, no secrets, no new dependencies, no IPC changes.

## Notes

- Videos in PR bodies (`.mp4` attachments) are emitted by GitHub as bare autolinks, not `![]()`, so they stay as links (matches desktop).
- Follow-up (out of scope): a host-proxy RPC could fetch authenticated attachment bytes so private-repo images also preview inline.

X (Twitter): @KaynanSampaio1

## ELI5

On mobile, images in PR bodies and comments were only plain links. They now show inline like on desktop so screenshots are visible without opening a browser.
