### PR TITLE
fix(cmd-j): put keyboard focus on the destination's active surface after jump

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1307,7 +1307,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       if (target.kind === 'terminal') {
         focusTerminalTabSurface(target.tabId, target.leafId)
       } else if (target.kind === 'editor') {
-        focusEditorTabSurface()
+        focusEditorTabSurface(target.groupId)
       } else {
         focusFallbackSurface()
       }

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -36,6 +36,13 @@ import { getLiveAgentStatusByWorktreeId, isInactiveWorkspace } from '@/lib/workt
 import { orderEmptyQueryWorktrees } from '@/lib/order-empty-query-worktrees'
 import StatusIndicator from '@/components/sidebar/StatusIndicator'
 import { cn } from '@/lib/utils'
+import { focusEditorTabSurface } from '@/lib/focus-editor-tab-surface'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import {
+  beginActiveSurfaceFocus,
+  isActiveSurfaceFocusCurrent
+} from '@/lib/active-surface-focus-generation'
+import { resolveWorktreeActiveSurfaceFocus } from '@/lib/worktree-active-surface-focus'
 import { getWorktreeStatus, getWorktreeStatusLabel } from '@/lib/worktree-status'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
@@ -1154,6 +1161,11 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
   useEffect(() => {
     if (visible && !wasVisibleRef.current) {
+      // Reopening Cmd-J means the user is navigating again: supersede any still-
+      // running focus retry from a prior jump so it can't later steal focus off
+      // whatever this navigation lands on — including the browser/simulator/
+      // settings paths that don't run their own focus routine to bump the token.
+      beginActiveSurfaceFocus()
       recordFeatureInteraction('cmd-j')
       createLookupGuard.invalidate()
       activeGroupSnapshotRef.current = captureCmdJActiveGroupSnapshot(
@@ -1245,16 +1257,26 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
   const focusFallbackSurface = useCallback(() => {
     cancelFallbackFocusFrames()
+    const token = beginActiveSurfaceFocus()
     fallbackFocusOuterFrameRef.current = requestAnimationFrame(() => {
       fallbackFocusOuterFrameRef.current = null
       fallbackFocusInnerFrameRef.current = requestAnimationFrame(() => {
         fallbackFocusInnerFrameRef.current = null
+        // Bail if a newer navigation superseded this fallback (shared token) so
+        // a late frame can't yank focus back off the newer destination.
+        if (!isActiveSurfaceFocusCurrent(token)) {
+          return
+        }
         const xterm = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
         if (xterm) {
           xterm.focus()
           return
         }
-        const monaco = document.querySelector('.monaco-editor textarea') as HTMLElement | null
+        // Monaco 0.52+ replaces the editing textarea with `.native-edit-context`;
+        // match both so this last-resort path still lands on an editor surface.
+        const monaco = document.querySelector(
+          '.monaco-editor .native-edit-context, .monaco-editor textarea.inputarea'
+        ) as HTMLElement | null
         if (monaco) {
           monaco.focus()
         }
@@ -1272,6 +1294,25 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       )
     },
     []
+  )
+
+  // Why: focus the given workspace's active tab surface, scoped to its actual
+  // terminal tab/leaf or editor. The generic fallback grabs the first xterm in
+  // the DOM, which races the modal teardown and often lands on a hidden
+  // workspace's surface, leaving the cursor unfocused — both on jump (Enter) and
+  // on dismiss (Esc).
+  const focusWorktreeActiveSurface = useCallback(
+    (worktreeId: string) => {
+      const target = resolveWorktreeActiveSurfaceFocus(useAppStore.getState(), worktreeId)
+      if (target.kind === 'terminal') {
+        focusTerminalTabSurface(target.tabId, target.leafId)
+      } else if (target.kind === 'editor') {
+        focusEditorTabSurface()
+      } else {
+        focusFallbackSurface()
+      }
+    },
+    [focusFallbackSurface]
   )
 
   const handleOpenChange = useCallback(
@@ -1294,10 +1335,10 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         return
       }
       if (previousWorktreeIdRef.current) {
-        focusFallbackSurface()
+        focusWorktreeActiveSurface(previousWorktreeIdRef.current)
       }
     },
-    [closeModal, focusFallbackSurface, requestBrowserFocus]
+    [closeModal, focusWorktreeActiveSurface, requestBrowserFocus]
   )
 
   const handleSelectWorktree = useCallback(
@@ -1314,9 +1355,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       skipRestoreFocusRef.current = true
       closeModal()
       setSelectedItemId('')
-      focusFallbackSurface()
+      focusWorktreeActiveSurface(worktreeId)
     },
-    [closeModal, focusFallbackSurface, recordFeatureInteraction]
+    [closeModal, focusWorktreeActiveSurface, recordFeatureInteraction]
   )
 
   const handleSelectBrowserPage = useCallback(
@@ -1473,12 +1514,12 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         return
       }
       if (previousWorktreeIdRef.current) {
-        focusFallbackSurface()
+        focusWorktreeActiveSurface(previousWorktreeIdRef.current)
       }
     },
     [
       closeModal,
-      focusFallbackSurface,
+      focusWorktreeActiveSurface,
       recordFeatureInteraction,
       requestBrowserFocus,
       revealSidebarRow

--- a/src/renderer/src/lib/active-surface-focus-generation.test.ts
+++ b/src/renderer/src/lib/active-surface-focus-generation.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import {
+  beginActiveSurfaceFocus,
+  isActiveSurfaceFocusCurrent
+} from './active-surface-focus-generation'
+
+describe('active-surface-focus-generation', () => {
+  it('keeps the most recent token current and supersedes older ones', () => {
+    const first = beginActiveSurfaceFocus()
+    expect(isActiveSurfaceFocusCurrent(first)).toBe(true)
+
+    const second = beginActiveSurfaceFocus()
+    // A newer request supersedes the earlier one.
+    expect(isActiveSurfaceFocusCurrent(first)).toBe(false)
+    expect(isActiveSurfaceFocusCurrent(second)).toBe(true)
+  })
+
+  it('hands out strictly increasing tokens', () => {
+    const a = beginActiveSurfaceFocus()
+    const b = beginActiveSurfaceFocus()
+    expect(b).toBeGreaterThan(a)
+  })
+})

--- a/src/renderer/src/lib/active-surface-focus-generation.ts
+++ b/src/renderer/src/lib/active-surface-focus-generation.ts
@@ -1,0 +1,21 @@
+// Cmd-J focus routines run asynchronously across animation frames — the editor
+// path retries for ~0.5s while a lazy Monaco chunk mounts, the terminal path
+// double-rAFs for the xterm commit. Without coordination, a still-running loop
+// from an earlier navigation can land focus on the previous destination after a
+// newer jump already focused its surface (e.g. a stale editor retry stealing
+// focus from a freshly-focused terminal). This shared, monotonically increasing
+// token lets each async focus request detect that a newer request — for ANY
+// surface type — has superseded it and bail. Living in its own module keeps the
+// per-surface focus modules free of cross-imports (no dependency cycle).
+let generation = 0
+
+// Call at the start of a focus request; the returned token identifies it.
+export function beginActiveSurfaceFocus(): number {
+  generation += 1
+  return generation
+}
+
+// True while `token` is still the most recent focus request.
+export function isActiveSurfaceFocusCurrent(token: number): boolean {
+  return token === generation
+}

--- a/src/renderer/src/lib/focus-editor-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-editor-tab-surface.test.ts
@@ -126,6 +126,24 @@ describe('focusEditorTabSurface', () => {
     expect(editor.focus).toHaveBeenCalled()
   })
 
+  it('scopes focus to the given split group and skips a sibling group editor', () => {
+    flushAnimationFrames()
+    const inGroup = laidOutElement()
+    const sibling = laidOutElement()
+    stubDocument(
+      {
+        '[data-tab-group-body-id="group-7"] .monaco-editor .native-edit-context': [inGroup],
+        '.monaco-editor .native-edit-context': [sibling]
+      },
+      inGroup
+    )
+
+    focusEditorTabSurface('group-7')
+
+    expect(inGroup.focus).toHaveBeenCalled()
+    expect(sibling.focus).not.toHaveBeenCalled()
+  })
+
   it('does not focus anything while an inline tab rename input is open', () => {
     flushAnimationFrames()
     const editor = laidOutElement()

--- a/src/renderer/src/lib/focus-editor-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-editor-tab-surface.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { focusEditorTabSurface } from './focus-editor-tab-surface'
+import { beginActiveSurfaceFocus } from './active-surface-focus-generation'
+
+const MARKDOWN_EDITOR_SELECTOR =
+  '.rich-markdown-editor-shell .rich-markdown-editor[contenteditable="true"]'
+const RENAME_INPUT_SELECTOR = '[data-tab-rename-input="true"]'
+
+type FakeElement = {
+  focus: ReturnType<typeof vi.fn>
+  getClientRects: () => { length: number }
+  contains: (other: unknown) => boolean
+  closest: (selector: string) => unknown
+}
+
+function laidOutElement(): FakeElement {
+  const element: FakeElement = {
+    focus: vi.fn(),
+    getClientRects: () => ({ length: 1 }),
+    contains: () => false,
+    closest: () => null
+  }
+  return element
+}
+
+function hiddenElement(): FakeElement {
+  return {
+    focus: vi.fn(),
+    getClientRects: () => ({ length: 0 }),
+    contains: () => false,
+    closest: () => null
+  }
+}
+
+// A laid-out `.native-edit-context` living in the read-only original (left) pane
+// of a Monaco diff editor: `closest('.editor.original')` resolves to a node.
+function diffOriginalElement(): FakeElement {
+  return {
+    focus: vi.fn(),
+    getClientRects: () => ({ length: 1 }),
+    contains: () => false,
+    closest: (selector: string) => (selector === '.editor.original' ? {} : null)
+  }
+}
+
+function nodeList(elements: FakeElement[]): { length: number; item: (index: number) => unknown } {
+  return { length: elements.length, item: (index: number) => elements[index] ?? null }
+}
+
+describe('focusEditorTabSurface', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function flushAnimationFrames(): void {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  }
+
+  function stubDocument(
+    bySelector: Record<string, FakeElement[]>,
+    activeElement: FakeElement | null,
+    renameInput: FakeElement | null = null
+  ): ReturnType<typeof vi.fn> {
+    const querySelectorAll = vi.fn((selector: string) => nodeList(bySelector[selector] ?? []))
+    const querySelector = vi.fn((selector: string) =>
+      selector === RENAME_INPUT_SELECTOR ? renameInput : null
+    )
+    vi.stubGlobal('document', {
+      querySelectorAll,
+      querySelector,
+      get activeElement() {
+        return activeElement
+      }
+    })
+    return querySelectorAll
+  }
+
+  it('focuses the visible monaco editor textarea', () => {
+    flushAnimationFrames()
+    const textarea = laidOutElement()
+    stubDocument({ '.monaco-editor .native-edit-context': [textarea] }, textarea)
+
+    focusEditorTabSurface()
+
+    expect(textarea.focus).toHaveBeenCalled()
+  })
+
+  it('skips a display:none editor from a background workspace', () => {
+    flushAnimationFrames()
+    const hidden = hiddenElement()
+    const visible = laidOutElement()
+    stubDocument({ '.monaco-editor .native-edit-context': [hidden, visible] }, visible)
+
+    focusEditorTabSurface()
+
+    expect(hidden.focus).not.toHaveBeenCalled()
+    expect(visible.focus).toHaveBeenCalled()
+  })
+
+  it('skips the read-only original pane of a diff and focuses the modified pane', () => {
+    flushAnimationFrames()
+    // DOM order in a Monaco diff: original (read-only, left) precedes modified.
+    const original = diffOriginalElement()
+    const modified = laidOutElement()
+    stubDocument({ '.monaco-editor .native-edit-context': [original, modified] }, modified)
+
+    focusEditorTabSurface()
+
+    expect(original.focus).not.toHaveBeenCalled()
+    expect(modified.focus).toHaveBeenCalled()
+  })
+
+  it('falls back to the shell-scoped rich markdown editor when no monaco textarea exists', () => {
+    flushAnimationFrames()
+    const editor = laidOutElement()
+    // Selector is scoped to `.rich-markdown-editor-shell` so a visible PR/Linear
+    // comment composer (bare `.rich-markdown-editor`) can never win.
+    stubDocument({ [MARKDOWN_EDITOR_SELECTOR]: [editor] }, editor)
+
+    focusEditorTabSurface()
+
+    expect(editor.focus).toHaveBeenCalled()
+  })
+
+  it('does not focus anything while an inline tab rename input is open', () => {
+    flushAnimationFrames()
+    const editor = laidOutElement()
+    const renameInput = laidOutElement()
+    stubDocument({ '.monaco-editor .native-edit-context': [editor] }, editor, renameInput)
+
+    focusEditorTabSurface()
+
+    // Focusing the editor would blur-commit the open rename; the guard bails.
+    expect(editor.focus).not.toHaveBeenCalled()
+  })
+
+  it('aborts a pending retry once a newer focus request supersedes it', () => {
+    const textarea = laidOutElement()
+    let mounted = false
+    const querySelectorAll = vi.fn((selector: string) =>
+      nodeList(selector === '.monaco-editor .native-edit-context' && mounted ? [textarea] : [])
+    )
+    vi.stubGlobal('document', {
+      querySelectorAll,
+      querySelector: vi.fn(() => null),
+      get activeElement() {
+        return mounted ? textarea : null
+      }
+    })
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    focusEditorTabSurface()
+    // First frame: editor still mounting, another frame queued.
+    frames.shift()?.(0)
+    expect(frames).toHaveLength(1)
+
+    // A newer navigation (e.g. a terminal jump) supersedes this request, then the
+    // editor finally mounts. The stale loop must NOT steal focus back.
+    beginActiveSurfaceFocus()
+    mounted = true
+    frames.shift()?.(0)
+    expect(textarea.focus).not.toHaveBeenCalled()
+  })
+
+  it('never queries or focuses a terminal surface', () => {
+    flushAnimationFrames()
+    const querySelectorAll = stubDocument({}, null)
+
+    focusEditorTabSurface()
+
+    // Why: the editor path must never fall through to '.xterm-helper-textarea',
+    // otherwise an editor tab would steal focus onto a hidden terminal.
+    for (const call of querySelectorAll.mock.calls) {
+      expect(call[0]).not.toBe('.xterm-helper-textarea')
+    }
+  })
+
+  it('retries on later frames while the lazy editor is still mounting', () => {
+    const textarea = laidOutElement()
+    let mounted = false
+    const querySelectorAll = vi.fn((selector: string) =>
+      nodeList(selector === '.monaco-editor .native-edit-context' && mounted ? [textarea] : [])
+    )
+    vi.stubGlobal('document', {
+      querySelectorAll,
+      querySelector: vi.fn(() => null),
+      get activeElement() {
+        return mounted ? textarea : null
+      }
+    })
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    focusEditorTabSurface()
+    // First frame: editor not mounted yet — nothing focused, another frame queued.
+    frames.shift()?.(0)
+    expect(textarea.focus).not.toHaveBeenCalled()
+    expect(frames).toHaveLength(1)
+
+    // Editor mounts; next frame focuses it.
+    mounted = true
+    frames.shift()?.(0)
+    expect(textarea.focus).toHaveBeenCalled()
+  })
+
+  it('cancels a pending focus frame when a newer focus request starts', () => {
+    const cancelAnimationFrame = vi.fn()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 9)
+    )
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)
+    vi.stubGlobal('document', {
+      querySelectorAll: vi.fn((_selector: string) => nodeList([]))
+    })
+
+    focusEditorTabSurface()
+    focusEditorTabSurface()
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(9)
+  })
+})

--- a/src/renderer/src/lib/focus-editor-tab-surface.ts
+++ b/src/renderer/src/lib/focus-editor-tab-surface.ts
@@ -13,6 +13,10 @@ import {
  *    no-op. We skip any surface that is not laid out (zero client rects, i.e.
  *    display:none) so focus lands on the destination workspace's visible
  *    editor — never a hidden one, and never a terminal.
+ *  - A worktree can show several side-by-side split groups, each rendering its
+ *    own editor. When a group id is given we scope the query to that group's
+ *    `[data-tab-group-body-id]` so focus lands on the destination tab's pane, not
+ *    the first visible editor in DOM order (mirrors the terminal leaf scoping).
  */
 // Monaco 0.52+ swaps the editing textarea for a focusable `.native-edit-context`
 // div (Electron always has EditContext); never target the bare `textarea`, which
@@ -46,6 +50,16 @@ function cancelPendingFocusFrame(): void {
   pendingFocusFrameId = null
 }
 
+function cssAttributeString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+// Prefix that scopes a selector to a specific tab group's body, or '' (whole
+// document) when no group is known.
+function groupScopePrefix(groupId: string | null | undefined): string {
+  return groupId ? `[data-tab-group-body-id="${cssAttributeString(groupId)}"] ` : ''
+}
+
 function isLaidOut(element: HTMLElement): boolean {
   // display:none (an inactive, warm workspace) yields zero client rects; a
   // visible editor — even Monaco's zero-size hidden input — yields at least one.
@@ -61,9 +75,9 @@ function isReadOnlyDiffOriginal(element: HTMLElement): boolean {
   return element.closest('.editor.original') !== null
 }
 
-function focusVisibleEditorSurface(): boolean {
+function focusVisibleEditorSurface(scopePrefix: string): boolean {
   for (const selector of EDITOR_FOCUS_SELECTORS) {
-    const candidates = document.querySelectorAll(selector)
+    const candidates = document.querySelectorAll(scopePrefix + selector)
     for (let index = 0; index < candidates.length; index++) {
       const element = candidates.item(index) as HTMLElement | null
       if (!element || !isLaidOut(element) || isReadOnlyDiffOriginal(element)) {
@@ -78,8 +92,11 @@ function focusVisibleEditorSurface(): boolean {
   return false
 }
 
-export function focusEditorTabSurface(): void {
+// `groupId` scopes focus to a specific split group's editor; omit it (or pass
+// null) to target the first visible editor anywhere in the active workspace.
+export function focusEditorTabSurface(groupId?: string | null): void {
   cancelPendingFocusFrame()
+  const scopePrefix = groupScopePrefix(groupId)
   const token = beginActiveSurfaceFocus()
   let attempts = 0
   const attempt = (): void => {
@@ -93,7 +110,7 @@ export function focusEditorTabSurface(): void {
     if (document.querySelector(TAB_RENAME_INPUT_SELECTOR)) {
       return
     }
-    if (focusVisibleEditorSurface()) {
+    if (focusVisibleEditorSurface(scopePrefix)) {
       return
     }
     attempts += 1

--- a/src/renderer/src/lib/focus-editor-tab-surface.ts
+++ b/src/renderer/src/lib/focus-editor-tab-surface.ts
@@ -1,0 +1,105 @@
+import {
+  beginActiveSurfaceFocus,
+  isActiveSurfaceFocusCurrent
+} from '@/lib/active-surface-focus-generation'
+
+/**
+ * Move keyboard focus into the editor surface for a freshly-activated editor
+ * tab. Parallels focus-terminal-tab-surface, but editors need extra care:
+ *  - Monaco is lazy-loaded behind Suspense, so on a cold tab its DOM is not
+ *    present within a frame or two — we retry across a short frame budget.
+ *  - Inactive workspaces stay mounted but display:none, so a background
+ *    workspace's editor input is still in the DOM; focusing it is a silent
+ *    no-op. We skip any surface that is not laid out (zero client rects, i.e.
+ *    display:none) so focus lands on the destination workspace's visible
+ *    editor — never a hidden one, and never a terminal.
+ */
+// Monaco 0.52+ swaps the editing textarea for a focusable `.native-edit-context`
+// div (Electron always has EditContext); never target the bare `textarea`, which
+// also matches Monaco's tabindex=-1 `.ime-text-area`. The editable markdown
+// selector is shell-scoped because the bare `.rich-markdown-editor` class is also
+// worn by the GitHub/Linear comment composers; `.markdown-preview` is read-only,
+// so it stays unscoped.
+const EDITOR_FOCUS_SELECTORS = [
+  '.monaco-editor .native-edit-context',
+  '.monaco-editor textarea.inputarea',
+  '.rich-markdown-editor-shell .rich-markdown-editor[contenteditable="true"]',
+  '.markdown-preview'
+]
+
+// Why: an inline tab rename mounts its own input; if a queued focus frame runs
+// while it is open, focusing the editor blurs the input and commits the rename
+// closed. Parallels the guard in focus-terminal-tab-surface (same shared marker,
+// worn by both terminal and editor tabs).
+const TAB_RENAME_INPUT_SELECTOR = '[data-tab-rename-input="true"]'
+
+// ~0.5s at 60fps: long enough to cover the lazy Monaco chunk mounting on a cold
+// tab, short enough that a stale request never fights a newer navigation.
+const MAX_FOCUS_ATTEMPTS = 30
+
+let pendingFocusFrameId: number | null = null
+
+function cancelPendingFocusFrame(): void {
+  if (pendingFocusFrameId !== null && typeof cancelAnimationFrame === 'function') {
+    cancelAnimationFrame(pendingFocusFrameId)
+  }
+  pendingFocusFrameId = null
+}
+
+function isLaidOut(element: HTMLElement): boolean {
+  // display:none (an inactive, warm workspace) yields zero client rects; a
+  // visible editor — even Monaco's zero-size hidden input — yields at least one.
+  return element.getClientRects().length > 0
+}
+
+function isReadOnlyDiffOriginal(element: HTMLElement): boolean {
+  // Why: Monaco renders a diff as two editors — `.editor.original` (left,
+  // read-only "before") and `.editor.modified` (right, editable "after"). Both
+  // expose a laid-out `.native-edit-context` and the original comes first in the
+  // DOM, so a naive first-match parks the caret on the read-only side and typing
+  // goes nowhere. Skip it so focus lands on the editable modified pane.
+  return element.closest('.editor.original') !== null
+}
+
+function focusVisibleEditorSurface(): boolean {
+  for (const selector of EDITOR_FOCUS_SELECTORS) {
+    const candidates = document.querySelectorAll(selector)
+    for (let index = 0; index < candidates.length; index++) {
+      const element = candidates.item(index) as HTMLElement | null
+      if (!element || !isLaidOut(element) || isReadOnlyDiffOriginal(element)) {
+        continue
+      }
+      element.focus()
+      if (document.activeElement === element || element.contains(document.activeElement)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export function focusEditorTabSurface(): void {
+  cancelPendingFocusFrame()
+  const token = beginActiveSurfaceFocus()
+  let attempts = 0
+  const attempt = (): void => {
+    pendingFocusFrameId = null
+    // Bail if a newer navigation (terminal/editor/fallback) has superseded us —
+    // otherwise this stale loop could steal focus from the newer destination.
+    if (!isActiveSurfaceFocusCurrent(token)) {
+      return
+    }
+    // Don't fight an open inline tab rename; focusing would blur-commit it.
+    if (document.querySelector(TAB_RENAME_INPUT_SELECTOR)) {
+      return
+    }
+    if (focusVisibleEditorSurface()) {
+      return
+    }
+    attempts += 1
+    if (attempts < MAX_FOCUS_ATTEMPTS) {
+      pendingFocusFrameId = requestAnimationFrame(attempt)
+    }
+  }
+  pendingFocusFrameId = requestAnimationFrame(attempt)
+}

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -1,9 +1,20 @@
+import {
+  beginActiveSurfaceFocus,
+  isActiveSurfaceFocusCurrent
+} from '@/lib/active-surface-focus-generation'
+
 /**
  * Move keyboard focus into the xterm instance for a freshly-mounted terminal
  * tab. Handles the two-step race where React must first mount the new
  * TerminalPane/xterm before the hidden .xterm-helper-textarea exists —
  * double-rAF waits for that commit so focus lands on the new tab instead of
  * whatever surface (menu trigger, body, previous tab) just relinquished it.
+ *
+ * Unlike focus-editor-tab-surface this has no multi-frame retry budget: two
+ * frames cover the local xterm commit, but a cold/still-connecting destination
+ * (notably a remote SSH workspace whose PTY hasn't attached) may miss it and get
+ * no focus — an accepted trade-off, since "no focus" is recoverable and beats the
+ * pre-fix bug of focusing the *previous* workspace's xterm.
  */
 function cssAttributeString(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
@@ -31,10 +42,16 @@ function canUseSinglePaneStaleLeafFallback(tabId: string, leafId: string): boole
 
 export function focusTerminalTabSurface(tabId: string, leafId?: string | null): void {
   cancelPendingFocusFrames()
+  const token = beginActiveSurfaceFocus()
   const firstFrameId = requestAnimationFrame(() => {
     pendingFocusFrameIds = pendingFocusFrameIds.filter((frameId) => frameId !== firstFrameId)
     const secondFrameId = requestAnimationFrame(() => {
       pendingFocusFrameIds = pendingFocusFrameIds.filter((frameId) => frameId !== secondFrameId)
+      // Bail if a newer navigation superseded this one (see the shared token
+      // module) — otherwise a late frame could refocus the previous destination.
+      if (!isActiveSurfaceFocusCurrent(token)) {
+        return
+      }
       // Why: this can be queued before inline tab rename mounts. If it runs
       // afterward, focusing xterm blurs the rename input and commits it closed.
       if (document.querySelector('[data-tab-rename-input="true"]')) {

--- a/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
@@ -242,7 +242,8 @@ describe('activateWorkspaceTabPaletteResult', () => {
     expect(mocks.store.activateTab).toHaveBeenLastCalledWith('diff-tab-1')
     expect(mocks.store.setActiveTabType).toHaveBeenCalledWith('editor')
     expect(mocks.focusTerminalTabSurface).not.toHaveBeenCalled()
-    expect(mocks.focusEditorTabSurface).toHaveBeenCalledTimes(1)
+    // Scoped to the tab's group so a split layout focuses the destination pane.
+    expect(mocks.focusEditorTabSurface).toHaveBeenCalledWith('group-2')
   })
 
   it.each([

--- a/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => {
     openFiles: { id: string; worktreeId: string }[]
     repos: unknown[]
     settings: Record<string, unknown>
+    terminalLayoutsByTabId: Record<string, { activeLeafId: string | null }>
     activeGroupIdByWorktree: Record<string, string>
     focusGroup: ReturnType<typeof vi.fn>
     activateTab: ReturnType<typeof vi.fn>
@@ -49,6 +50,7 @@ const mocks = vi.hoisted(() => {
     openFiles: [],
     repos: [],
     settings: {},
+    terminalLayoutsByTabId: {},
     activeGroupIdByWorktree: { 'wt-1': 'group-1' },
     focusGroup: vi.fn(),
     activateTab: vi.fn(),
@@ -61,6 +63,7 @@ const mocks = vi.hoisted(() => {
     activateAndRevealWorktree: vi.fn(),
     activateWebRuntimeSessionTab: vi.fn(),
     focusTerminalTabSurface: vi.fn(),
+    focusEditorTabSurface: vi.fn(),
     getRuntimeEnvironmentIdForWorktree: vi.fn(),
     isWebRuntimeSessionActive: vi.fn()
   }
@@ -74,6 +77,10 @@ vi.mock('@/store', () => ({
 
 vi.mock('@/lib/focus-terminal-tab-surface', () => ({
   focusTerminalTabSurface: mocks.focusTerminalTabSurface
+}))
+
+vi.mock('@/lib/focus-editor-tab-surface', () => ({
+  focusEditorTabSurface: mocks.focusEditorTabSurface
 }))
 
 vi.mock('@/lib/worktree-runtime-owner', () => ({
@@ -146,6 +153,7 @@ function resetStore(): void {
     ]
   }
   mocks.store.openFiles = []
+  mocks.store.terminalLayoutsByTabId = {}
 }
 
 describe('activateWorkspaceTabPaletteResult', () => {
@@ -165,7 +173,16 @@ describe('activateWorkspaceTabPaletteResult', () => {
     expect(mocks.store.activateTab).toHaveBeenCalledWith('unified-terminal-1')
     expect(mocks.store.setActiveTab).toHaveBeenCalledWith('terminal-1')
     expect(mocks.store.setActiveTabType).toHaveBeenCalledWith('terminal')
-    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1')
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', null)
+    expect(mocks.focusEditorTabSurface).not.toHaveBeenCalled()
+  })
+
+  it('focuses the active leaf when the terminal tab has a persisted layout', () => {
+    mocks.store.terminalLayoutsByTabId = { 'terminal-1': { activeLeafId: 'leaf-9' } }
+
+    expect(activateWorkspaceTabPaletteResult(makeResult())).toEqual({ status: 'activated' })
+
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', 'leaf-9')
   })
 
   it('uses the web-runtime terminal activation path when active', () => {
@@ -225,6 +242,7 @@ describe('activateWorkspaceTabPaletteResult', () => {
     expect(mocks.store.activateTab).toHaveBeenLastCalledWith('diff-tab-1')
     expect(mocks.store.setActiveTabType).toHaveBeenCalledWith('editor')
     expect(mocks.focusTerminalTabSurface).not.toHaveBeenCalled()
+    expect(mocks.focusEditorTabSurface).toHaveBeenCalledTimes(1)
   })
 
   it.each([

--- a/src/renderer/src/lib/workspace-tab-palette-activation.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.ts
@@ -115,7 +115,8 @@ export function activateWorkspaceTabPaletteResult(
   state.setActiveTabType('editor')
   // Why: mirror the terminal branch — without an explicit focus the editor tab
   // opens with the cursor unfocused, since the Cmd+J modal teardown races the
-  // destination editor mount. See focus-editor-tab-surface.
-  focusEditorTabSurface()
+  // destination editor mount. Scope to the tab's group so a split layout focuses
+  // the destination pane, not a sibling. See focus-editor-tab-surface.
+  focusEditorTabSurface(result.groupId)
   return { status: 'activated' }
 }

--- a/src/renderer/src/lib/workspace-tab-palette-activation.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.ts
@@ -1,3 +1,4 @@
+import { focusEditorTabSurface } from '@/lib/focus-editor-tab-surface'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import {
@@ -105,11 +106,16 @@ export function activateWorkspaceTabPaletteResult(
     }
     state.setActiveTab(result.entityId)
     state.setActiveTabType('terminal')
-    focusTerminalTabSurface(result.entityId)
+    const leafId = state.terminalLayoutsByTabId[result.entityId]?.activeLeafId ?? null
+    focusTerminalTabSurface(result.entityId, leafId)
     return { status: 'activated' }
   }
 
   state.setActiveFile(result.entityId)
   state.setActiveTabType('editor')
+  // Why: mirror the terminal branch — without an explicit focus the editor tab
+  // opens with the cursor unfocused, since the Cmd+J modal teardown races the
+  // destination editor mount. See focus-editor-tab-surface.
+  focusEditorTabSurface()
   return { status: 'activated' }
 }

--- a/src/renderer/src/lib/worktree-active-surface-focus.test.ts
+++ b/src/renderer/src/lib/worktree-active-surface-focus.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorktreeActiveSurfaceFocus } from './worktree-active-surface-focus'
+
+type State = Parameters<typeof resolveWorktreeActiveSurfaceFocus>[0]
+
+function makeState(overrides: Partial<State> = {}): State {
+  return {
+    activeTabIdByWorktree: {},
+    activeTabTypeByWorktree: {},
+    terminalLayoutsByTabId: {},
+    ...overrides
+  } as State
+}
+
+describe('resolveWorktreeActiveSurfaceFocus', () => {
+  it('routes an active terminal tab to its persisted active leaf', () => {
+    const state = makeState({
+      activeTabIdByWorktree: { 'wt-1': 'terminal-1' },
+      activeTabTypeByWorktree: { 'wt-1': 'terminal' },
+      terminalLayoutsByTabId: { 'terminal-1': { activeLeafId: 'leaf-9' } as never }
+    })
+
+    expect(resolveWorktreeActiveSurfaceFocus(state, 'wt-1')).toEqual({
+      kind: 'terminal',
+      tabId: 'terminal-1',
+      leafId: 'leaf-9'
+    })
+  })
+
+  it('routes a terminal tab with no persisted layout to a null leaf', () => {
+    const state = makeState({
+      activeTabIdByWorktree: { 'wt-1': 'terminal-1' },
+      activeTabTypeByWorktree: { 'wt-1': 'terminal' }
+    })
+
+    expect(resolveWorktreeActiveSurfaceFocus(state, 'wt-1')).toEqual({
+      kind: 'terminal',
+      tabId: 'terminal-1',
+      leafId: null
+    })
+  })
+
+  it('routes an editor tab to the editor surface', () => {
+    const state = makeState({
+      activeTabIdByWorktree: { 'wt-1': 'file-1' },
+      activeTabTypeByWorktree: { 'wt-1': 'editor' }
+    })
+
+    expect(resolveWorktreeActiveSurfaceFocus(state, 'wt-1')).toEqual({ kind: 'editor' })
+  })
+
+  it('falls back when the tab type is terminal but the tab id is missing', () => {
+    const state = makeState({ activeTabTypeByWorktree: { 'wt-1': 'terminal' } })
+
+    expect(resolveWorktreeActiveSurfaceFocus(state, 'wt-1')).toEqual({ kind: 'fallback' })
+  })
+
+  it('falls back for browser / simulator / unknown active tab types', () => {
+    const state = makeState({
+      activeTabIdByWorktree: { 'wt-1': 'page-1' },
+      activeTabTypeByWorktree: { 'wt-1': 'browser' as never }
+    })
+
+    expect(resolveWorktreeActiveSurfaceFocus(state, 'wt-1')).toEqual({ kind: 'fallback' })
+    expect(resolveWorktreeActiveSurfaceFocus(makeState(), 'unknown-wt')).toEqual({
+      kind: 'fallback'
+    })
+  })
+})

--- a/src/renderer/src/lib/worktree-active-surface-focus.test.ts
+++ b/src/renderer/src/lib/worktree-active-surface-focus.test.ts
@@ -8,6 +8,7 @@ function makeState(overrides: Partial<State> = {}): State {
     activeTabIdByWorktree: {},
     activeTabTypeByWorktree: {},
     terminalLayoutsByTabId: {},
+    activeGroupIdByWorktree: {},
     ...overrides
   } as State
 }
@@ -40,13 +41,29 @@ describe('resolveWorktreeActiveSurfaceFocus', () => {
     })
   })
 
-  it('routes an editor tab to the editor surface', () => {
+  it('routes an editor tab to its active split group', () => {
+    const state = makeState({
+      activeTabIdByWorktree: { 'wt-1': 'file-1' },
+      activeTabTypeByWorktree: { 'wt-1': 'editor' },
+      activeGroupIdByWorktree: { 'wt-1': 'group-7' }
+    })
+
+    expect(resolveWorktreeActiveSurfaceFocus(state, 'wt-1')).toEqual({
+      kind: 'editor',
+      groupId: 'group-7'
+    })
+  })
+
+  it('routes an editor tab with no known active group to a null group', () => {
     const state = makeState({
       activeTabIdByWorktree: { 'wt-1': 'file-1' },
       activeTabTypeByWorktree: { 'wt-1': 'editor' }
     })
 
-    expect(resolveWorktreeActiveSurfaceFocus(state, 'wt-1')).toEqual({ kind: 'editor' })
+    expect(resolveWorktreeActiveSurfaceFocus(state, 'wt-1')).toEqual({
+      kind: 'editor',
+      groupId: null
+    })
   })
 
   it('falls back when the tab type is terminal but the tab id is missing', () => {

--- a/src/renderer/src/lib/worktree-active-surface-focus.ts
+++ b/src/renderer/src/lib/worktree-active-surface-focus.ts
@@ -3,12 +3,15 @@ import type { AppState } from '@/store/types'
 // Which surface a Cmd-J destination workspace should hand keyboard focus to.
 export type WorktreeActiveSurfaceFocusTarget =
   | { kind: 'terminal'; tabId: string; leafId: string | null }
-  | { kind: 'editor' }
+  | { kind: 'editor'; groupId: string | null }
   | { kind: 'fallback' }
 
 type WorktreeActiveSurfaceFocusState = Pick<
   AppState,
-  'activeTabIdByWorktree' | 'activeTabTypeByWorktree' | 'terminalLayoutsByTabId'
+  | 'activeTabIdByWorktree'
+  | 'activeTabTypeByWorktree'
+  | 'terminalLayoutsByTabId'
+  | 'activeGroupIdByWorktree'
 >
 
 // Why: decide the focus target purely from store state so the routing (active
@@ -27,7 +30,7 @@ export function resolveWorktreeActiveSurfaceFocus(
     return { kind: 'terminal', tabId, leafId }
   }
   if (tabType === 'editor') {
-    return { kind: 'editor' }
+    return { kind: 'editor', groupId: state.activeGroupIdByWorktree[worktreeId] ?? null }
   }
   return { kind: 'fallback' }
 }

--- a/src/renderer/src/lib/worktree-active-surface-focus.ts
+++ b/src/renderer/src/lib/worktree-active-surface-focus.ts
@@ -1,0 +1,33 @@
+import type { AppState } from '@/store/types'
+
+// Which surface a Cmd-J destination workspace should hand keyboard focus to.
+export type WorktreeActiveSurfaceFocusTarget =
+  | { kind: 'terminal'; tabId: string; leafId: string | null }
+  | { kind: 'editor' }
+  | { kind: 'fallback' }
+
+type WorktreeActiveSurfaceFocusState = Pick<
+  AppState,
+  'activeTabIdByWorktree' | 'activeTabTypeByWorktree' | 'terminalLayoutsByTabId'
+>
+
+// Why: decide the focus target purely from store state so the routing (active
+// terminal tab + leaf / editor / generic fallback) stays unit-testable, apart
+// from the DOM-focusing side effects it drives in WorktreeJumpPalette. Anything
+// that is not a known terminal/editor tab (browser, simulator, or missing state)
+// falls through to the generic fallback the caller handles.
+export function resolveWorktreeActiveSurfaceFocus(
+  state: WorktreeActiveSurfaceFocusState,
+  worktreeId: string
+): WorktreeActiveSurfaceFocusTarget {
+  const tabId = state.activeTabIdByWorktree[worktreeId] ?? null
+  const tabType = state.activeTabTypeByWorktree[worktreeId]
+  if (tabId && tabType === 'terminal') {
+    const leafId = state.terminalLayoutsByTabId[tabId]?.activeLeafId ?? null
+    return { kind: 'terminal', tabId, leafId }
+  }
+  if (tabType === 'editor') {
+    return { kind: 'editor' }
+  }
+  return { kind: 'fallback' }
+}


### PR DESCRIPTION
## Summary

Fixes keyboard focus landing on the wrong surface after using the **Cmd-J** worktree/tab jump palette. (Fixes #8903.)

After jumping (Enter) into a workspace the terminal cursor rendered hollow and keystrokes went nowhere, and code/markdown editors opened un-editable; after cancelling (Esc) focus was not reliably restored to the surface you were on.

**Root cause:** the palette restored focus with a generic fallback that grabbed the *first* `.xterm-helper-textarea` in the DOM. Because inactive workspaces stay mounted (`display:none`), that "first xterm" was often a *hidden* workspace's terminal, and the fallback also raced the modal's teardown/close animation — so focus landed on a hidden or wrong surface, or nothing at all.

**Fix:** route focus to the *destination workspace's actual active surface*, chosen from store state instead of DOM guesswork.

- `resolveWorktreeActiveSurfaceFocus(state, worktreeId)` (new, pure, unit-tested) reads `activeTabTypeByWorktree` / `activeTabIdByWorktree` / `activeGroupIdByWorktree` / `terminalLayoutsByTabId` and returns a terminal / editor / fallback target. `WorktreeJumpPalette` dispatches the matching focus routine on both jump and cancel.
- **Terminal** → `focusTerminalTabSurface(tabId, leafId)`, now leaf-scoped so a split-pane terminal focuses the persisted active leaf.
- **Editor** → `focusEditorTabSurface(groupId)` (new module), scoped to the destination tab's split group. Handles Monaco's lazy Suspense mount (retries across ~0.5s of animation frames), the Monaco 0.52+ `.native-edit-context` element, skipping the read-only diff `.editor.original` pane, skipping `display:none` workspaces via `getClientRects()`, and scoping the markdown selector to `.rich-markdown-editor-shell` so PR/Linear comment composers don't win.
- Shared monotonic-token cancellation (`active-surface-focus-generation`, new) so a stale editor retry loop can't steal focus from a newer navigation, and the editor path bails while an inline tab-rename input is open.

**Deferred / out of scope:** browser & simulator jump destinations still use the generic fallback on Enter (Esc already restores browser focus); `useModalReturnFocus`'s unscoped markdown selector is left for a separate cleanup. See commit messages for the full list.

## Screenshots

This is a focus/interaction fix with no visual change to rendered UI. Before/after screen recordings (the bug, and the fixed behavior) are attached to the linked issue #8903.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — the 27 tests added/updated by this PR pass. (The suite has 32 pre-existing failures in unrelated sidebar / browser-pane / PR-comment files that fail identically on clean `main` without this change; they stem from a local Node engine mismatch, not this PR.)
- [x] `pnpm build` — desktop + native build succeed (Swift deprecation warnings only)
- [x] Added high-quality regression tests

New/updated Vitest coverage:
- `focus-editor-tab-surface.test.ts` — focuses the visible Monaco input; skips a `display:none` background editor; skips the read-only diff original and focuses the modified pane; scopes to the destination split group (a sibling-group editor is not focused); falls back to the shell-scoped markdown editor; retries while Monaco mounts; bails while a tab-rename input is open; aborts once superseded.
- `worktree-active-surface-focus.test.ts` — routing for terminal-with-leaf, terminal-without-leaf, editor (with group id), and browser/simulator/unknown → fallback.
- `active-surface-focus-generation.test.ts` — monotonic supersede semantics.
- `workspace-tab-palette-activation.test.ts` — terminal activation asserts exact `(tabId, leafId)`; editor path asserts `focusEditorTabSurface(groupId)`.

Manual: drove the running app over the Electron remote-debug port and asserted `document.activeElement` for terminal, split-pane terminal, Monaco editor, diff (editable pane), markdown rich editor, Esc-restore, and the open-tab path.

## AI Review Report

Reviewed with an AI coding agent across the required dimensions:

- **Cross-platform (macOS/Linux/Windows):** no `metaKey`/path/shell hardcoding introduced; the change is DOM/store logic that is platform-agnostic. The Cmd-J trigger itself is unchanged. No Electron platform-specific branches touched.
- **SSH / remote / local:** flagged and documented — terminal focus has no multi-frame retry budget, so a cold/still-connecting **remote SSH** PTY can miss the focus window and receive no focus. Accepted as strictly better than the prior bug (focusing the *previous* workspace's xterm) and recoverable by a click/keypress; a bounded retry can follow if it proves common.
- **Agent / integration compatibility:** focus resolution reads generic workspace store state (tab type, active tab/group, terminal layout), not agent- or provider-specific fields; works the same for any CLI agent surface.
- **Performance:** no hot-path work added; focus routines run once per palette action, use bounded `requestAnimationFrame` retries, and self-cancel via the monotonic token.
- **UI quality:** no visual change; corrects interaction correctness. Verified terminal/editor/diff/markdown cases in-app.
- **Security:** see below.

Fixed during review: an earlier version focused the read-only diff pane (now skips `.editor.original`); editor query is now scoped to the destination split group so keystrokes can't reach a sibling pane's file.

## Security Audit

Low risk. The change only resolves and calls `.focus()` on DOM elements already mounted in the renderer, selected via `querySelector` on static class/attribute selectors (`data-tab-group-body-id` from store-owned ids). No new IPC, no command execution, no path handling, no network, no secrets, no user-supplied strings interpolated into selectors (group ids are store-generated). No new dependencies. No follow-up security work identified.

## Notes

- Rebased onto latest `main`; no conflicts.
- Remote/SSH caveat (terminal cold-PTY focus miss) documented above and in the commit message.
- Deferred items (browser/simulator Enter-path focus, `useModalReturnFocus` selector scoping) are called out as follow-ups.
- X (Twitter) handle: @debay
