### PR TITLE
fix(ui): let a caller's max-width override DialogContent's default cap

### DIFF
--- a/src/renderer/src/components/ui/dialog-content-class.test.ts
+++ b/src/renderer/src/components/ui/dialog-content-class.test.ts
@@ -33,6 +33,18 @@ describe('resolveDialogContentClassName', () => {
     expect(cls).not.toContain('sm:max-w-lg')
   })
 
+  it('keeps the default below a later responsive override', () => {
+    const cls = resolveDialogContentClassName('md:max-w-2xl')
+    expect(cls).toContain('sm:max-w-lg')
+    expect(cls).toContain('md:max-w-2xl')
+  })
+
+  it('does not treat a descendant max-width as a dialog width override', () => {
+    const cls = resolveDialogContentClassName('[&_pre]:max-w-full')
+    expect(cls).toContain('sm:max-w-lg')
+    expect(cls).toContain('[&_pre]:max-w-full')
+  })
+
   it('preserves an intentionally uncapped (max-w-none) dialog', () => {
     const cls = resolveDialogContentClassName('max-w-none sm:max-w-none')
     expect(cls).toContain('max-w-none')
@@ -43,6 +55,12 @@ describe('resolveDialogContentClassName', () => {
   it('respects an important max-width override', () => {
     const cls = resolveDialogContentClassName('!max-w-[360px]')
     expect(cls).toContain('!max-w-[360px]')
+    expect(cls).not.toContain('sm:max-w-lg')
+  })
+
+  it('respects Tailwind v4 suffix-important max-width overrides', () => {
+    const cls = resolveDialogContentClassName('max-w-[360px]!')
+    expect(cls).toContain('max-w-[360px]!')
     expect(cls).not.toContain('sm:max-w-lg')
   })
 

--- a/src/renderer/src/components/ui/dialog-content-class.test.ts
+++ b/src/renderer/src/components/ui/dialog-content-class.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { resolveDialogContentClassName } from './dialog-content-class'
+
+describe('resolveDialogContentClassName', () => {
+  it('applies the default sm:max-w-lg cap when the caller passes no className', () => {
+    const cls = resolveDialogContentClassName()
+    expect(cls).toContain('sm:max-w-lg')
+    expect(cls).toContain('max-w-[calc(100%-2rem)]')
+  })
+
+  it('keeps the default cap when the caller className has no max-width', () => {
+    const cls = resolveDialogContentClassName('gap-0 p-0')
+    expect(cls).toContain('sm:max-w-lg')
+  })
+
+  it('lets a bare max-w override win at every breakpoint by dropping the default', () => {
+    const cls = resolveDialogContentClassName('max-w-md')
+    expect(cls).toContain('max-w-md')
+    // The bug: without dropping the sm:-scoped default, it out-specifies the
+    // caller's bare max-w at >=sm and the modal stays 32rem wide.
+    expect(cls).not.toContain('sm:max-w-lg')
+  })
+
+  it('honors a custom pixel max-width', () => {
+    const cls = resolveDialogContentClassName('max-w-[360px]')
+    expect(cls).toContain('max-w-[360px]')
+    expect(cls).not.toContain('sm:max-w-lg')
+  })
+
+  it('keeps an sm:-scoped override and drops the redundant default', () => {
+    const cls = resolveDialogContentClassName('sm:max-w-2xl')
+    expect(cls).toContain('sm:max-w-2xl')
+    expect(cls).not.toContain('sm:max-w-lg')
+  })
+
+  it('preserves an intentionally uncapped (max-w-none) dialog', () => {
+    const cls = resolveDialogContentClassName('max-w-none sm:max-w-none')
+    expect(cls).toContain('max-w-none')
+    expect(cls).toContain('sm:max-w-none')
+    expect(cls).not.toContain('sm:max-w-lg')
+  })
+
+  it('respects an important max-width override', () => {
+    const cls = resolveDialogContentClassName('!max-w-[360px]')
+    expect(cls).toContain('!max-w-[360px]')
+    expect(cls).not.toContain('sm:max-w-lg')
+  })
+
+  it('appends caller layout classes after the base', () => {
+    const cls = resolveDialogContentClassName('gap-4 p-0 sm:max-w-[520px]')
+    expect(cls).toContain('gap-4')
+    expect(cls).toContain('p-0')
+    expect(cls).toContain('sm:max-w-[520px]')
+  })
+})

--- a/src/renderer/src/components/ui/dialog-content-class.ts
+++ b/src/renderer/src/components/ui/dialog-content-class.ts
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils'
+
+// Why: bg-background in dark mode is the same color as the canvas, and
+// border-border/50 is ~3.5% white over that canvas — both invisible. A
+// translucent surface, solid 14% border, dual shadow, and 2xl backdrop blur
+// match the dropdown-menu recipe (which already works) and read clearly in both
+// light and dark mode.
+const DIALOG_CONTENT_BASE_CLASS =
+  'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-black/14 bg-background/96 p-6 text-foreground shadow-[0_20px_60px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl duration-200 outline-none dark:border-white/14 dark:bg-[rgba(23,23,23,0.96)] dark:shadow-[0_24px_72px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.06)] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95'
+
+/** The default desktop width cap. Applied only when the caller sets no
+ *  max-width of their own (see resolveDialogContentClassName). */
+const DIALOG_CONTENT_DEFAULT_MAX_WIDTH = 'sm:max-w-lg'
+
+/** Matches a Tailwind `max-w-*` utility in a className string, with or without a
+ *  variant prefix (`sm:`) or important (`!`) modifier. */
+const CALLER_MAX_WIDTH = /(?:^|[\s:!])max-w-/
+
+/**
+ * Compose the DialogContent className.
+ *
+ * The default cap is `sm:max-w-lg`, but because it is scoped to the `sm`
+ * breakpoint, a caller's unprefixed `max-w-*` lands in a different responsive
+ * bucket and tailwind-merge keeps both — so the default silently wins at ≥sm and
+ * the caller's width is ignored on desktop. Applying the default only when the
+ * caller has not set their own max-width lets a bare `className="max-w-md"` win
+ * at every breakpoint, while leaving callers that pass no width (default cap) or
+ * an `sm:`-prefixed width (already overrode the default) byte-for-byte unchanged.
+ */
+export function resolveDialogContentClassName(className?: string): string {
+  const hasCallerMaxWidth = className ? CALLER_MAX_WIDTH.test(className) : false
+  return cn(
+    DIALOG_CONTENT_BASE_CLASS,
+    !hasCallerMaxWidth && DIALOG_CONTENT_DEFAULT_MAX_WIDTH,
+    className
+  )
+}

--- a/src/renderer/src/components/ui/dialog-content-class.ts
+++ b/src/renderer/src/components/ui/dialog-content-class.ts
@@ -1,37 +1,21 @@
 import { cn } from '@/lib/utils'
 
-// Why: bg-background in dark mode is the same color as the canvas, and
-// border-border/50 is ~3.5% white over that canvas — both invisible. A
-// translucent surface, solid 14% border, dual shadow, and 2xl backdrop blur
-// match the dropdown-menu recipe (which already works) and read clearly in both
-// light and dark mode.
+// The translucent surface and stronger border/shadow keep dialogs distinct from
+// the same-color dark canvas, matching the established dropdown treatment.
 const DIALOG_CONTENT_BASE_CLASS =
   'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-black/14 bg-background/96 p-6 text-foreground shadow-[0_20px_60px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl duration-200 outline-none dark:border-white/14 dark:bg-[rgba(23,23,23,0.96)] dark:shadow-[0_24px_72px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.06)] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95'
 
-/** The default desktop width cap. Applied only when the caller sets no
- *  max-width of their own (see resolveDialogContentClassName). */
 const DIALOG_CONTENT_DEFAULT_MAX_WIDTH = 'sm:max-w-lg'
 
-/** Matches a Tailwind `max-w-*` utility in a className string, with or without a
- *  variant prefix (`sm:`) or important (`!`) modifier. */
-const CALLER_MAX_WIDTH = /(?:^|[\s:!])max-w-/
+const CALLER_UNSCOPED_MAX_WIDTH = /(?:^|\s)!?max-w-/
 
-/**
- * Compose the DialogContent className.
- *
- * The default cap is `sm:max-w-lg`, but because it is scoped to the `sm`
- * breakpoint, a caller's unprefixed `max-w-*` lands in a different responsive
- * bucket and tailwind-merge keeps both — so the default silently wins at ≥sm and
- * the caller's width is ignored on desktop. Applying the default only when the
- * caller has not set their own max-width lets a bare `className="max-w-md"` win
- * at every breakpoint, while leaving callers that pass no width (default cap) or
- * an `sm:`-prefixed width (already overrode the default) byte-for-byte unchanged.
- */
+// Bare widths must replace the responsive default across breakpoints; scoped
+// widths keep the default outside their own responsive or selector scope.
 export function resolveDialogContentClassName(className?: string): string {
-  const hasCallerMaxWidth = className ? CALLER_MAX_WIDTH.test(className) : false
+  const hasUnscopedCallerMaxWidth = className ? CALLER_UNSCOPED_MAX_WIDTH.test(className) : false
   return cn(
     DIALOG_CONTENT_BASE_CLASS,
-    !hasCallerMaxWidth && DIALOG_CONTENT_DEFAULT_MAX_WIDTH,
+    !hasUnscopedCallerMaxWidth && DIALOG_CONTENT_DEFAULT_MAX_WIDTH,
     className
   )
 }

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -5,6 +5,7 @@ import { XIcon } from 'lucide-react'
 import { Dialog as DialogPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { resolveDialogContentClassName } from '@/components/ui/dialog-content-class'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 
@@ -58,15 +59,7 @@ function DialogContent({
       <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
-        // Why: bg-background in dark mode is the same color as the canvas, and
-        // border-border/50 is ~3.5% white over that canvas — both invisible.
-        // A translucent surface, solid 14% border, dual shadow, and 2xl backdrop
-        // blur match the dropdown-menu recipe (which already works) and read
-        // clearly in both light and dark mode.
-        className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-black/14 bg-background/96 p-6 text-foreground shadow-[0_20px_60px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl duration-200 outline-none dark:border-white/14 dark:bg-[rgba(23,23,23,0.96)] dark:shadow-[0_24px_72px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.06)] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
-          className
-        )}
+        className={resolveDialogContentClassName(className)}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary

`DialogContent` bakes a default width cap of `sm:max-w-lg` into its base class. Because that default is scoped to the `sm` breakpoint, a caller that overrides the width with a **bare** `max-w-*` (e.g. `className="max-w-md"`) lands in a *different* responsive bucket — tailwind-merge keeps both classes, and the `sm:`-scoped default out-specifies the caller's bare value at ≥640px. The result: the override silently only applies below `sm`, and the modal renders at 32rem (512px) on desktop regardless of what the caller asked for.

This was noticed on #8490 / #8491 (the SSH credential prompt asks for `max-w-[360px]` but renders ~512px), but it's not specific to that dialog. Across the renderer, **~20 dialogs pass a bare `max-w-*`** and are silently widened to 512px on desktop, while **69 already work around it** by using an `sm:`-prefixed value.

## ELI5

Every dialog comes with a default “do not grow wider than 512px” rule for desktop screens. Some dialogs, including the SSH credential prompt, ask to be narrower—but their rule was being ignored on desktop because the default rule took priority.

This change skips that default when a dialog provides its own all-screen width, so the SSH prompt stays at its intended 360px. Width rules that apply only at particular screen sizes still keep the default everywhere else.

## Screenshots

Full Orca window captured at a 1728px viewport with a synthetic demo SSH prompt; no real host or credential data is shown.

| Before — default cap wins (512px) | After — caller width is honored (360px) |
|---|---|
| ![Before: SSH credential dialog incorrectly rendered at 512px](https://github.com/stablyai/orca/blob/2a934922d3ce1ec0b8fffe72ca0c53b25602cc38/pr-8905-before-full.png?raw=true) | ![After: SSH credential dialog correctly rendered at 360px](https://github.com/stablyai/orca/blob/2a934922d3ce1ec0b8fffe72ca0c53b25602cc38/pr-8905-after-full.png?raw=true) |

## Fix

Apply the default cap unless the caller sets an **unscoped** max-width. Bare overrides win at every breakpoint; scoped overrides retain the default outside their scope, and `sm:` overrides still replace it in the same responsive bucket.

- The class-composition is extracted into a small, pure, unit-tested helper (`dialog-content-class.ts`), mirroring the existing `popover-content-ref.ts` pattern.
- Provably **behavior-preserving** for every currently-correct consumer (verified by composing the class both ways):
  - no override → still `sm:max-w-lg` (unchanged),
  - `sm:`-prefixed override → identical output (the default was already overridden),
  - `max-w-none` → still uncapped (unchanged).
- **Fixes** the ~20 bare-`max-w` consumers (e.g. `DeleteWorktreeDialog` md, `CloseTerminalDialog` sm, `SshPassphraseDialog` 360px), which now honor their intended width on desktop.

### Why the primitive, not a consumer sweep
Fixing the ~20 callers to add `sm:` prefixes would be mechanical, match the existing convention, and leave the footgun in place for the next `max-w-md`. Fixing the primitive removes the footgun once — a bare `max-w-*` on a dialog now simply does what it says — with a smaller, single-point diff.

## Scope / non-goals
- Purely a width-cap fix. No change to overlay, z-index, animation, or default (unspecified-width) dialogs.
- Bare-`max-w` dialogs still lose their mobile side-inset (their bare `max-w` clobbers the base `max-w-[calc(100%-2rem)]`) — that's pre-existing and unchanged here; the visible desktop-width issue is what this addresses.

## Testing
- `pnpm typecheck`, `pnpm lint` — clean.
- New unit suite `dialog-content-class.test.ts` (11 cases) pins the behavior for default / bare / `sm:`-prefixed / `max-w-none` / important overrides. It fails if the conditional default is reverted.
- Composed the class both ways offline for every consumer category: `sm:`-prefixed and `max-w-none` and no-override callers produce **byte-identical** output; only bare-`max-w` callers change.
- Electron (viewport 1728px, well above `sm`), measured `offsetWidth` of the live dialog element:
  - **Affected** — `SshPassphraseDialog` (`max-w-[360px]`): **512px → 360px**, and `sm:max-w-lg` is no longer in its class list.
  - **Unaffected control** — Add Project dialog (`sm:max-w-lg`): **512px, unchanged** (`sm:max-w-lg` still present).




