### PR TITLE
Resolve host-split repo owners by worktree path for hostless worktrees (#8484 follow-up)

### DIFF
--- a/src/renderer/src/lib/resolved-worktree-execution-host.test.ts
+++ b/src/renderer/src/lib/resolved-worktree-execution-host.test.ts
@@ -43,6 +43,32 @@ describe('getResolvedExecutionHostIdForWorktree', () => {
     )
   })
 
+  it('resolves hostless host-split worktrees by their own path, not repo record order (#8484)', () => {
+    const hostSplitState: WorktreeRuntimeOwnerState = {
+      repos: [
+        {
+          id: 'proj',
+          connectionId: null,
+          executionHostId: 'runtime:env-1',
+          path: '/srv/proj'
+        },
+        { id: 'proj', connectionId: null, executionHostId: 'local', path: '/Users/me/proj' }
+      ],
+      worktreesByRepo: {
+        proj: [
+          { id: 'proj::/Users/me/proj-wt', repoId: 'proj' },
+          { id: 'proj::/srv/proj-wt', repoId: 'proj' }
+        ]
+      }
+    }
+    expect(getResolvedExecutionHostIdForWorktree(hostSplitState, 'proj::/Users/me/proj-wt')).toBe(
+      'local'
+    )
+    expect(getResolvedExecutionHostIdForWorktree(hostSplitState, 'proj::/srv/proj-wt')).toBe(
+      'runtime:env-1'
+    )
+  })
+
   it('keeps missing folder catalogs unresolved but honors restored runtime ownership', () => {
     expect(getResolvedExecutionHostIdForWorktree({}, 'folder:missing')).toBeNull()
     expect(

--- a/src/renderer/src/lib/resolved-worktree-execution-host.ts
+++ b/src/renderer/src/lib/resolved-worktree-execution-host.ts
@@ -9,9 +9,9 @@ import { folderWorkspaceKey, parseWorkspaceKey } from '../../../shared/workspace
 import {
   findIndexedFolderWorkspaceOwner,
   findIndexedProjectGroupOwner,
-  findIndexedRepoOwner,
   findIndexedWorktreeOwner
 } from './worktree-runtime-owner-index'
+import { findRepoOwnerRecordForWorktree } from './worktree-runtime-owner-repo-match'
 import type { WorktreeRuntimeOwnerState } from './worktree-runtime-owner'
 
 function getResolvedFolderHost(
@@ -65,7 +65,7 @@ export function getResolvedExecutionHostIdForWorktree(
   if (!worktree) {
     return null
   }
-  const repo = findIndexedRepoOwner(state.repos, worktree.repoId)
+  const repo = findRepoOwnerRecordForWorktree(state.repos, worktreeId, worktree.repoId)
   if (!repo) {
     return null
   }

--- a/src/renderer/src/lib/worktree-runtime-owner-host-split.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-host-split.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getExecutionHostIdForWorktree,
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree,
+  type WorktreeRuntimeOwnerState
+} from './worktree-runtime-owner'
+
+// Regression guard for the #8484 residual (follow-up to #8509): the same
+// project registered on BOTH local desktop and a paired runtime keeps several
+// repo records under one repoId. A worktree with no explicit hostId (legacy /
+// pre-project-host metadata) must resolve its owner from its own filesystem
+// path — not from whichever same-id repo record happens to be indexed first,
+// which makes routing depend on record order.
+const LOCAL_WORKTREE = 'proj::/Users/me/GitHub/.orca-worktrees/proj-wt'
+const RUNTIME_WORKTREE = 'proj::/home/user/orca-worktrees/proj-wt'
+
+function buildHostSplitState(
+  activeRuntimeEnvironmentId: string | null,
+  repoOrder: 'local-first' | 'runtime-first' | 'legacy-first'
+): WorktreeRuntimeOwnerState {
+  const localRepo = {
+    id: 'proj',
+    connectionId: null,
+    executionHostId: 'local' as const,
+    path: '/Users/me/GitHub/proj'
+  }
+  const runtimeRepo = {
+    id: 'proj',
+    connectionId: null,
+    executionHostId: 'runtime:env-1' as const,
+    path: '/home/user/proj'
+  }
+  const legacyRepo = { id: 'proj', connectionId: null, executionHostId: null, path: '' }
+  const repos =
+    repoOrder === 'local-first'
+      ? [localRepo, runtimeRepo]
+      : repoOrder === 'runtime-first'
+        ? [runtimeRepo, localRepo]
+        : [legacyRepo, localRepo, runtimeRepo]
+  return {
+    settings: { activeRuntimeEnvironmentId },
+    repos,
+    worktreesByRepo: {
+      proj: [
+        { id: LOCAL_WORKTREE, repoId: 'proj' },
+        { id: RUNTIME_WORKTREE, repoId: 'proj' }
+      ]
+    }
+  }
+}
+
+describe('#8484 host-split owner resolution for hostless worktrees', () => {
+  it('explicit owner resolution does not depend on repo record order', () => {
+    for (const order of ['local-first', 'runtime-first'] as const) {
+      const state = buildHostSplitState('env-1', order)
+      expect(getExplicitRuntimeEnvironmentIdForWorktree(state, LOCAL_WORKTREE)).toBeNull()
+      expect(getExplicitRuntimeEnvironmentIdForWorktree(state, RUNTIME_WORKTREE)).toBe('env-1')
+    }
+  })
+
+  it('routes each host-split worktree by its own path while the runtime is default', () => {
+    const state = buildHostSplitState('env-1', 'runtime-first')
+    expect(getRuntimeEnvironmentIdForWorktree(state, LOCAL_WORKTREE)).toBeNull()
+    expect(getExecutionHostIdForWorktree(state, LOCAL_WORKTREE)).toBe('local')
+    expect(getRuntimeEnvironmentIdForWorktree(state, RUNTIME_WORKTREE)).toBe('env-1')
+    expect(getExecutionHostIdForWorktree(state, RUNTIME_WORKTREE)).toBe('runtime:env-1')
+  })
+
+  it('routes each host-split worktree by its own path while local is default', () => {
+    const state = buildHostSplitState(null, 'local-first')
+    expect(getRuntimeEnvironmentIdForWorktree(state, LOCAL_WORKTREE)).toBeNull()
+    expect(getRuntimeEnvironmentIdForWorktree(state, RUNTIME_WORKTREE)).toBe('env-1')
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(state, RUNTIME_WORKTREE)).toBe('env-1')
+  })
+
+  it('still resolves both worktrees past a legacy null-host record for the same repoId', () => {
+    const state = buildHostSplitState('env-1', 'legacy-first')
+    expect(getRuntimeEnvironmentIdForWorktree(state, LOCAL_WORKTREE)).toBeNull()
+    expect(getExecutionHostIdForWorktree(state, LOCAL_WORKTREE)).toBe('local')
+    expect(getRuntimeEnvironmentIdForWorktree(state, RUNTIME_WORKTREE)).toBe('env-1')
+  })
+
+  it('an explicit worktree hostId still wins over path inference', () => {
+    const state = buildHostSplitState('env-1', 'local-first')
+    const withHostId: WorktreeRuntimeOwnerState = {
+      ...state,
+      worktreesByRepo: {
+        proj: [
+          { id: LOCAL_WORKTREE, repoId: 'proj', hostId: 'runtime:env-1' },
+          { id: RUNTIME_WORKTREE, repoId: 'proj', hostId: 'local' }
+        ]
+      }
+    }
+    expect(getRuntimeEnvironmentIdForWorktree(withHostId, LOCAL_WORKTREE)).toBe('env-1')
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(withHostId, LOCAL_WORKTREE)).toBe('env-1')
+    expect(getRuntimeEnvironmentIdForWorktree(withHostId, RUNTIME_WORKTREE)).toBeNull()
+  })
+
+  it('a cross-host path tie keeps the prior first-indexed resolution', () => {
+    // Both hosts registered under the same absolute path (e.g. a self-paired
+    // runtime on one machine): scores tie, so behavior must not change.
+    const state: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: null },
+      repos: [
+        { id: 'proj', connectionId: null, executionHostId: 'local', path: '/data/proj' },
+        { id: 'proj', connectionId: null, executionHostId: 'runtime:env-1', path: '/data/proj' }
+      ],
+      worktreesByRepo: { proj: [{ id: 'proj::/data/proj-wt', repoId: 'proj' }] }
+    }
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(state, 'proj::/data/proj-wt')).toBeNull()
+    expect(getExecutionHostIdForWorktree(state, 'proj::/data/proj-wt')).toBe('local')
+  })
+
+  it('single-host repos resolve exactly as before', () => {
+    const state: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: 'focused-env' },
+      repos: [{ id: 'solo', connectionId: null, executionHostId: 'runtime:solo-env' }],
+      worktreesByRepo: { solo: [{ id: 'solo::/srv/solo-wt', repoId: 'solo' }] }
+    }
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(state, 'solo::/srv/solo-wt')).toBe('solo-env')
+    expect(getRuntimeEnvironmentIdForWorktree(state, 'solo::/srv/solo-wt')).toBe('solo-env')
+  })
+})

--- a/src/renderer/src/lib/worktree-runtime-owner-index.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.ts
@@ -1,7 +1,8 @@
 import type { FolderWorkspace, ProjectGroup, Repo, Worktree } from '../../../shared/types'
 
 type WorktreeOwnerRecord = Pick<Worktree, 'id' | 'repoId' | 'hostId'>
-type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> &
+  Partial<Pick<Repo, 'path'>>
 type FolderWorkspaceOwnerRecord = Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'>
 type ProjectGroupOwnerRecord = Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>
 
@@ -11,9 +12,11 @@ const worktreeOwnerIndexCache = new WeakMap<
   Record<string, readonly WorktreeOwnerRecord[]>,
   ReadonlyMap<string, WorktreeOwnerRecord>
 >()
+// Why: a project shared across hosts has several repo records under one id, so
+// the repo index groups every record per id (built once per immutable array).
 const repoOwnerIndexCache = new WeakMap<
   readonly RepoOwnerRecord[],
-  ReadonlyMap<string, RepoOwnerRecord>
+  ReadonlyMap<string, readonly RepoOwnerRecord[]>
 >()
 const folderWorkspaceOwnerIndexCache = new WeakMap<
   readonly FolderWorkspaceOwnerRecord[],
@@ -72,11 +75,36 @@ export function findIndexedWorktreeOwner(
   return index.get(worktreeId) ?? null
 }
 
-export function findIndexedRepoOwner(
+function getRepoOwnerIndex(
+  repos: readonly RepoOwnerRecord[]
+): ReadonlyMap<string, readonly RepoOwnerRecord[]> {
+  let index = repoOwnerIndexCache.get(repos)
+  if (!index) {
+    const next = new Map<string, RepoOwnerRecord[]>()
+    for (const record of repos) {
+      const recordId = record.id
+      const existing = next.get(recordId)
+      if (existing) {
+        existing.push(record)
+      } else {
+        next.set(recordId, [record])
+      }
+    }
+    index = next
+    repoOwnerIndexCache.set(repos, index)
+  }
+  return index
+}
+
+export function findIndexedRepoOwners(
   repos: readonly RepoOwnerRecord[] | undefined,
   repoId: string
-): RepoOwnerRecord | null {
-  return findIndexedOwnerRecord(repos, repoId, repoOwnerIndexCache)
+): readonly RepoOwnerRecord[] {
+  if (!repos) {
+    return []
+  }
+  // The first entry preserves the prior Array.find "first matching id" behavior.
+  return getRepoOwnerIndex(repos).get(repoId) ?? []
 }
 
 export function findIndexedFolderWorkspaceOwner(

--- a/src/renderer/src/lib/worktree-runtime-owner-repo-match.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-repo-match.ts
@@ -1,0 +1,54 @@
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import type { Repo } from '../../../shared/types'
+import { splitWorktreeId } from '../../../shared/worktree-id'
+import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
+import { findIndexedRepoOwners } from './worktree-runtime-owner-index'
+
+type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> &
+  Partial<Pick<Repo, 'path'>>
+
+function countSharedPathSegments(repoPath: string, worktreePath: string): number {
+  const repoSegments = normalizeRuntimePathForComparison(repoPath).split('/').filter(Boolean)
+  const worktreeSegments = normalizeRuntimePathForComparison(worktreePath)
+    .split('/')
+    .filter(Boolean)
+  let shared = 0
+  const limit = Math.min(repoSegments.length, worktreeSegments.length)
+  while (shared < limit && repoSegments[shared] === worktreeSegments[shared]) {
+    shared += 1
+  }
+  return shared
+}
+
+// Why: one project can be registered on both local and a paired runtime under a
+// shared repoId (#8484). When a worktree carries no explicit hostId, resolve the
+// owning repo record by the worktree's own filesystem path so it routes to the
+// host that owns it, not the first-indexed record or the global default runtime.
+export function findRepoOwnerRecordForWorktree(
+  repos: readonly RepoOwnerRecord[] | undefined,
+  worktreeId: string,
+  repoId: string
+): RepoOwnerRecord | null {
+  const matches = findIndexedRepoOwners(repos, repoId)
+  if (matches.length <= 1) {
+    return matches[0] ?? null
+  }
+  const worktreePath = splitWorktreeId(worktreeId)?.worktreePath?.trim()
+  if (worktreePath) {
+    const scored = matches
+      .map((repo) => ({
+        repo,
+        score: repo.path?.trim() ? countSharedPathSegments(repo.path, worktreePath) : 0
+      }))
+      .filter((entry) => entry.score > 0)
+    const topScore = scored.reduce((max, entry) => Math.max(max, entry.score), 0)
+    const leaders = scored.filter((entry) => entry.score === topScore)
+    const leaderHostIds = new Set(leaders.map((entry) => getRepoExecutionHostId(entry.repo)))
+    // Only trust the path match when it points at a single host; a cross-host
+    // tie stays ambiguous and defers to the prior first-indexed behavior.
+    if (leaders.length > 0 && leaderHostIds.size === 1) {
+      return leaders[0].repo
+    }
+  }
+  return matches[0] ?? null
+}

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -17,14 +17,15 @@ import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
 import {
   findIndexedFolderWorkspaceOwner,
   findIndexedProjectGroupOwner,
-  findIndexedRepoOwner as findRepoRecord,
   findIndexedWorktreeOwner as findWorktreeRecord
 } from './worktree-runtime-owner-index'
+import { findRepoOwnerRecordForWorktree } from './worktree-runtime-owner-repo-match'
 
 type RuntimeExecutionHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
 
 export type WorktreeRuntimeOwnerState = {
-  repos?: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
+  repos?: readonly (Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> &
+    Partial<Pick<Repo, 'path'>>)[]
   settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
   worktreesByRepo?: Record<string, readonly Pick<Worktree, 'id' | 'repoId' | 'hostId'>[]>
   folderWorkspaces?: readonly Pick<FolderWorkspace, 'id' | 'projectGroupId' | 'connectionId'>[]
@@ -170,7 +171,7 @@ export function getRuntimeEnvironmentIdForWorktree(
     return worktreeRuntimeEnvironmentId
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = findRepoRecord(state.repos, repoId)
+  const repo = findRepoOwnerRecordForWorktree(state.repos, worktreeId, repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
@@ -198,7 +199,7 @@ export function getExplicitRuntimeEnvironmentIdForWorktree(
     return getExplicitRuntimeEnvironmentIdFromHost(worktree.hostId)
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = findRepoRecord(state.repos, repoId)
+  const repo = findRepoOwnerRecordForWorktree(state.repos, worktreeId, repoId)
   if (!repo) {
     return null
   }
@@ -264,7 +265,7 @@ export function getExecutionHostIdForWorktree(
     return worktreeHostId
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = findRepoRecord(state.repos, repoId)
+  const repo = findRepoOwnerRecordForWorktree(state.repos, worktreeId, repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     return getRepoExecutionHostId(repo)

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -536,6 +536,39 @@ describe('createEditorSlice openDiff', () => {
     )
   })
 
+  it('routes host-split hostless worktree diffs by their own paths, not repo record order (#8484)', () => {
+    const store = createEditorStore()
+    // Same project on local + a paired runtime under one repoId; the runtime
+    // record indexes first and neither worktree carries a hostId (legacy
+    // metadata). Each diff must resolve its owner from the worktree's path.
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as AppState['settings'],
+      repos: [
+        { id: 'proj', executionHostId: 'runtime:env-1', path: '/srv/proj' },
+        { id: 'proj', executionHostId: 'local', path: '/Users/me/proj' }
+      ] as unknown as AppState['repos'],
+      worktreesByRepo: {
+        proj: [
+          { id: 'proj::/Users/me/proj-wt', repoId: 'proj' },
+          { id: 'proj::/srv/proj-wt', repoId: 'proj' }
+        ]
+      } as unknown as AppState['worktreesByRepo']
+    })
+
+    store
+      .getState()
+      .openDiff('proj::/Users/me/proj-wt', '/Users/me/proj-wt/a.ts', 'a.ts', 'typescript', false)
+    store
+      .getState()
+      .openDiff('proj::/srv/proj-wt', '/srv/proj-wt/a.ts', 'a.ts', 'typescript', false)
+
+    const byWorktree = Object.fromEntries(
+      store.getState().openFiles.map((file) => [file.worktreeId, file.runtimeEnvironmentId])
+    )
+    expect(byWorktree['proj::/Users/me/proj-wt']).toBeNull()
+    expect(byWorktree['proj::/srv/proj-wt']).toBe('env-1')
+  })
+
   it('keeps an SSH-owned worktree diff off the focused runtime so it routes via its connection', () => {
     const store = createEditorStore()
     // An SSH worktree is owned by its connection, not the focused runtime. Its


### PR DESCRIPTION
## Summary

Follow-up hardening to #8509 / #8484. #8509 correctly routes diffs by the worktree's **explicit** owner (`getExplicitRuntimeEnvironmentIdForWorktree(...) ?? null`), but a worktree with **no `hostId`** (legacy / pre-project-host metadata) still resolves its owning repo through the host-blind first-by-id index. A project registered on **both** local and a paired runtime keeps several repo records under one `repoId`, so which host such a worktree routes to depends on **record order**:

- runtime-record-first → a legacy **local** worktree's diff stamps the runtime env → `RuntimeRpcCallError: selector_not_found`
- local-record-first → a legacy **runtime** worktree's diff is forced to a local read → `fs:readFile` access denied

The same host-blind lookup also backs `getResolvedExecutionHostIdForWorktree` (terminal host resolution in `Terminal.tsx`) and the runtime-owner resolvers used by terminals, browser panes, and tabs — so the defect is broader than diffs.

### Fix

- New `worktree-runtime-owner-repo-match.ts`: when a hostless worktree's `repoId` spans multiple host records, pick the owning record by the worktree's **own filesystem path** (longest shared path-segment prefix via the existing `normalizeRuntimePathForComparison`). A cross-host tie stays ambiguous and keeps the prior first-indexed behavior; an explicit worktree `hostId` always wins; single-host repos resolve **byte-for-byte as before** (`matches.length <= 1 → matches[0]`).
- `worktree-runtime-owner-index.ts`: repo index becomes group-aware (records-per-id, built once per immutable array) so the single-host fast path stays O(1) — the existing indexed-reads perf guard still passes unchanged. The now-unused `findIndexedRepoOwner` is removed.
- Wired through all four resolvers: `getRuntimeEnvironmentIdForWorktree`, `getExplicitRuntimeEnvironmentIdForWorktree`, `getExecutionHostIdForWorktree`, and `getResolvedExecutionHostIdForWorktree`.
- No changes to `editor.ts` — #8509's diff-routing semantics are kept as-is; this PR only makes the owner resolution underneath it host-aware.

## Screenshots

No visual change — owner-resolution fix beneath existing routing. The user-visible effect is that legacy (hostless-metadata) worktrees in a project shared across local + a paired runtime route diffs/terminals to their own host regardless of repo record order.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (all three projects)
- [x] `pnpm test` — ran the directly-affected surface (`src/renderer/src/lib/`, editor, repos*, terminals, browser, tabs, diffComments, `runtime/`): 3,267 tests green. Full suite in CI.
- [x] Added high-quality regression tests that fail without the fix:
  - `worktree-runtime-owner-host-split.test.ts` — **4 of 7 cases fail on current main** (proving the residual bug), including order-independence of `getExplicitRuntimeEnvironmentIdForWorktree` (the #8509 diff entry point); also covers `hostId`-wins-over-path, cross-host path-tie parity, and single-host no-change.
  - `editor.test.ts` — an `openDiff` store-level case proving composition with #8509's null-forcing routing: hostless local worktree stamps `null`, hostless runtime worktree stamps its env, with runtime-record-first ordering (fails on main without this fix — verified by stashing the lib changes).
  - `resolved-worktree-execution-host.test.ts` — host-split case for the terminal-host resolver.

## AI Review Report

This PR ports the surviving pieces of the closed #8601 (whose diff-layer half was superseded by #8509), re-verified against current main. The prior `/code-review high` pass over this code flagged: (1) dead `findIndexedRepoOwner` after the swap — removed here (main gained a new consumer, `resolved-worktree-execution-host.ts`, which this PR converts to the host-aware helper, keeping the export dead); (2) the cross-host path-tie limitation — now covered by an explicit test asserting parity with prior behavior. Verified cross-file: all `findIndexedRepoOwner` consumers converted; the perf-guard test for indexed owner reads passes unchanged.

**Cross-platform (macOS/Linux/Windows):** path comparison uses the shared `normalizeRuntimePathForComparison` (separator normalization + Windows drive-letter lower-casing) and splits only after normalization — no hardcoded separators. SSH-owned repos resolve via `connectionId` exactly as before (explicitly tested); runtime paths are POSIX. No shortcuts, labels, or shell behavior touched.

## Security Audit

Low risk. Pure in-renderer owner resolution — no new input handling, command execution, secrets, auth, or IPC surface. Paths are compared (segment prefix), never executed or read; the resolved owner only selects an already-authorized IPC/RPC channel. No dependency changes.

## Notes

- The prior branch's live Electron/CDP validation proved the resolver-level routing decision in a running dev build (local → `null`, runtime → its env, with runtime as global default). Not re-run for this port; the logic is identical and the composition with #8509 is covered by the store-level test.
- Related: #8484 (issue), #8509 (diff routing by explicit owner), #8601 (closed predecessor), #8566 (shared-`repo.id`-across-hosts model), #6440/#6562/#6942 (prior remote routing fixes).
