### PR TITLE
Allow cross-repo parent worktree selection

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeParentPickerPopover.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeParentPickerPopover.test.ts
@@ -91,8 +91,11 @@ describe('selectWorktreeParent', () => {
 
 describe('getWorktreeParentPickerItemValue', () => {
   it('includes workspace-facing fields used by command filtering', () => {
-    expect(getWorktreeParentPickerItemValue(makeWorktree())).toContain('Parent Worktree')
-    expect(getWorktreeParentPickerItemValue(makeWorktree())).toContain('feature/parent')
-    expect(getWorktreeParentPickerItemValue(makeWorktree())).toContain('/workspaces/parent')
+    const value = getWorktreeParentPickerItemValue(makeWorktree(), 'shared-library')
+
+    expect(value).toContain('Parent Worktree')
+    expect(value).toContain('feature/parent')
+    expect(value).toContain('shared-library')
+    expect(value).toContain('/workspaces/parent')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeParentPickerPopover.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeParentPickerPopover.tsx
@@ -39,8 +39,8 @@ function getAnchorRect(anchorElement: HTMLElement | null): AnchorRect | null {
   return anchorElement?.getBoundingClientRect() ?? null
 }
 
-export function getWorktreeParentPickerItemValue(candidate: Worktree): string {
-  return `${candidate.displayName} ${branchDisplayName(candidate.branch)} ${candidate.path}`
+export function getWorktreeParentPickerItemValue(candidate: Worktree, repoName?: string): string {
+  return `${candidate.displayName} ${branchDisplayName(candidate.branch)} ${repoName ?? ''} ${candidate.path}`
 }
 
 export function selectWorktreeParent({
@@ -222,7 +222,10 @@ export function WorktreeParentPickerPopover({
             {candidates.map((candidate) => (
               <CommandItem
                 key={candidate.id}
-                value={getWorktreeParentPickerItemValue(candidate)}
+                value={getWorktreeParentPickerItemValue(
+                  candidate,
+                  repoMap.get(candidate.repoId)?.displayName
+                )}
                 onSelect={() => handleSelect(candidate.id)}
                 className="items-start px-2 py-2"
               >

--- a/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
@@ -28,7 +28,6 @@ export function getEligibleWorktreeParents({
   const childHostId = getWorktreeOwnerHostId(child, repoMap)
   return worktrees.filter(
     (candidate) =>
-      candidate.repoId === child.repoId &&
       childHostId !== null &&
       getWorktreeOwnerHostId(candidate, repoMap) === childHostId &&
       !candidate.isArchived &&

--- a/src/renderer/src/components/sidebar/worktree-parent-eligibility.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-eligibility.test.ts
@@ -159,7 +159,7 @@ describe('canAssignWorktreeParent', () => {
     ).toBe(false)
   })
 
-  it('stays repo-agnostic while the picker candidate filter is repo and host scoped', () => {
+  it('includes eligible worktrees from other repos on the same runtime host', () => {
     const child = makeWorktree('child', 'repo-a')
     const sameRepo = makeWorktree('same-repo', 'repo-a')
     const otherRepo = makeWorktree('other-repo', 'repo-b')
@@ -184,13 +184,13 @@ describe('canAssignWorktreeParent', () => {
           { id: 'repo-b', connectionId: null, executionHostId: 'local' }
         ])
       }).map((worktree) => worktree.id)
-    ).toEqual([sameRepo.id])
+    ).toEqual([sameRepo.id, otherRepo.id])
   })
 
-  it('excludes same-repo candidates owned by a different runtime host', () => {
+  it('excludes cross-repo candidates owned by a different runtime host', () => {
     const child = makeWorktree('child', 'repo-a')
     const sameHost = makeWorktree('same-host', 'repo-a')
-    const otherHost = makeWorktree('other-host', 'repo-a')
+    const otherHost = makeWorktree('other-host', 'repo-b')
     child.hostId = 'runtime:env-a'
     sameHost.hostId = 'runtime:env-a'
     otherHost.hostId = 'runtime:env-b'
@@ -203,7 +203,8 @@ describe('canAssignWorktreeParent', () => {
         lineageById: {},
         worktreeMap: makeMap(worktrees),
         repoMap: makeRepoMap([
-          { id: 'repo-a', connectionId: null, executionHostId: 'runtime:env-a' }
+          { id: 'repo-a', connectionId: null, executionHostId: 'runtime:env-a' },
+          { id: 'repo-b', connectionId: null, executionHostId: 'runtime:env-b' }
         ])
       }).map((worktree) => worktree.id)
     ).toEqual([sameHost.id])

--- a/tests/e2e/worktree-lineage-state.ts
+++ b/tests/e2e/worktree-lineage-state.ts
@@ -1,8 +1,139 @@
 import type { Page } from '@stablyai/playwright-test'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect } from './helpers/orca-app'
 
 export type LineageScenario = {
   parentId: string
   childId: string
+}
+
+export type CrossRepoParentPickerScenario = LineageScenario & {
+  parentName: string
+  parentRepoName: string
+  repoPath: string
+}
+
+function createCrossRepoParentPickerRepo(): string {
+  const repoPath = mkdtempSync(join(tmpdir(), 'orca-e2e-cross-repo-parent-'))
+  execFileSync('git', ['init', '-b', 'main'], { cwd: repoPath })
+  writeFileSync(join(repoPath, 'README.md'), '# Cross-repo parent picker E2E\n')
+  execFileSync(
+    'git',
+    ['-c', 'user.name=Orca E2E', '-c', 'user.email=orca-e2e@example.com', 'add', 'README.md'],
+    { cwd: repoPath }
+  )
+  execFileSync(
+    'git',
+    [
+      '-c',
+      'user.name=Orca E2E',
+      '-c',
+      'user.email=orca-e2e@example.com',
+      'commit',
+      '-m',
+      'initial commit'
+    ],
+    { cwd: repoPath }
+  )
+  return repoPath
+}
+
+export async function removeCrossRepoParentPickerRepo(page: Page, repoPath: string): Promise<void> {
+  await page.evaluate(async (path) => {
+    const store = window.__store
+    const repo = store?.getState().repos.find((candidate) => candidate.path === path)
+    if (repo) {
+      const state = store.getState()
+      const removedWorktreeIds = new Set(
+        (state.worktreesByRepo[repo.id] ?? []).map((worktree) => worktree.id)
+      )
+      const orphanedChildIds = Object.entries(state.worktreeLineageById)
+        .filter(([, lineage]) => removedWorktreeIds.has(lineage.parentWorktreeId))
+        .map(([childId]) => childId)
+      for (const childId of orphanedChildIds) {
+        await store.getState().updateWorktreeLineage(childId, { noParent: true })
+      }
+      await store?.getState().removeProject(repo.id)
+    }
+  }, repoPath)
+  rmSync(repoPath, { force: true, recursive: true })
+}
+
+export async function seedCrossRepoParentPickerScenario(
+  page: Page
+): Promise<CrossRepoParentPickerScenario> {
+  const repoPath = createCrossRepoParentPickerRepo()
+  try {
+    const repoId = await page.evaluate(async (path) => {
+      const result = await window.api.repos.add({ path })
+      if ('error' in result) {
+        throw new Error(result.error)
+      }
+      return result.repo.id
+    }, repoPath)
+
+    let scenario: Omit<CrossRepoParentPickerScenario, 'repoPath'> | null = null
+    await expect
+      .poll(
+        async () => {
+          scenario = await page.evaluate(async (repoId) => {
+            const store = window.__store
+            if (!store) {
+              return null
+            }
+            await store.getState().fetchRepos()
+            const parentRepo = store.getState().repos.find((repo) => repo.id === repoId)
+            if (!parentRepo) {
+              return null
+            }
+            await store.getState().fetchWorktrees(repoId)
+            const next = store.getState()
+            const parent = next.worktreesByRepo[repoId]?.find((worktree) => !worktree.isArchived)
+            const child = Object.entries(next.worktreesByRepo)
+              .filter(([candidateRepoId]) => candidateRepoId !== repoId)
+              .flatMap(([, worktrees]) => worktrees)
+              .find((worktree) => !worktree.isArchived)
+            if (!parent?.instanceId || !child?.instanceId) {
+              return null
+            }
+
+            next.setActiveView('terminal')
+            next.setSidebarOpen(true)
+            next.setGroupBy('none')
+            next.setSortBy('recent')
+            next.setShowActiveOnly(false)
+            next.setShowSleepingWorkspaces(true)
+            next.setHideDefaultBranchWorkspace(false)
+            next.setFilterRepoIds([])
+            next.setActiveWorktree(child.id)
+
+            return {
+              childId: child.id,
+              parentId: parent.id,
+              parentName: parent.displayName,
+              parentRepoName: parentRepo.displayName
+            }
+          }, repoId)
+          return scenario
+        },
+        {
+          timeout: 30_000,
+          message: 'Cross-repo parent picker E2E repo did not load into the renderer'
+        }
+      )
+      .not.toBeNull()
+
+    if (!scenario) {
+      throw new Error('Cross-repo parent picker E2E scenario did not resolve')
+    }
+    return { ...scenario, repoPath }
+  } catch (error) {
+    await removeCrossRepoParentPickerRepo(page, repoPath)
+    throw error
+  }
 }
 
 export async function seedLineageScenario(page: Page): Promise<LineageScenario> {

--- a/tests/e2e/worktree-lineage-state.ts
+++ b/tests/e2e/worktree-lineage-state.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@stablyai/playwright-test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect } from './helpers/orca-app'
@@ -16,8 +17,24 @@ export type CrossRepoParentPickerScenario = LineageScenario & {
   repoPath: string
 }
 
-function createCrossRepoParentPickerRepo(): string {
+type RegisterPostElectronShutdownCleanup = (cleanup: () => Promise<void>) => void
+
+async function removeCrossRepoParentPickerRepoFromDisk(repoPath: string): Promise<void> {
+  await rm(repoPath, {
+    force: true,
+    maxRetries: 5,
+    recursive: true,
+    retryDelay: 250
+  })
+}
+
+function createCrossRepoParentPickerRepo(
+  registerPostElectronShutdownCleanup: RegisterPostElectronShutdownCleanup
+): string {
   const repoPath = mkdtempSync(join(tmpdir(), 'orca-e2e-cross-repo-parent-'))
+  // Why: register immediately so even Git seeding failures clean up, but only
+  // after Electron and its watchers have released the repository on Windows.
+  registerPostElectronShutdownCleanup(() => removeCrossRepoParentPickerRepoFromDisk(repoPath))
   execFileSync('git', ['init', '-b', 'main'], { cwd: repoPath })
   writeFileSync(join(repoPath, 'README.md'), '# Cross-repo parent picker E2E\n')
   execFileSync(
@@ -59,13 +76,13 @@ export async function removeCrossRepoParentPickerRepo(page: Page, repoPath: stri
       await store?.getState().removeProject(repo.id)
     }
   }, repoPath)
-  rmSync(repoPath, { force: true, recursive: true })
 }
 
 export async function seedCrossRepoParentPickerScenario(
-  page: Page
+  page: Page,
+  registerPostElectronShutdownCleanup: RegisterPostElectronShutdownCleanup
 ): Promise<CrossRepoParentPickerScenario> {
-  const repoPath = createCrossRepoParentPickerRepo()
+  const repoPath = createCrossRepoParentPickerRepo(registerPostElectronShutdownCleanup)
   try {
     const repoId = await page.evaluate(async (path) => {
       const result = await window.api.repos.add({ path })

--- a/tests/e2e/worktree-lineage.spec.ts
+++ b/tests/e2e/worktree-lineage.spec.ts
@@ -89,9 +89,12 @@ test.describe('Worktree Lineage', () => {
     await expect(childRow).toBeVisible()
   })
 
-  test('selects and renders a parent worktree from another repo', async ({ orcaPage }) => {
+  test('selects and renders a parent worktree from another repo', async ({
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  }) => {
     const { parentId, childId, parentName, parentRepoName, repoPath } =
-      await seedCrossRepoParentPickerScenario(orcaPage)
+      await seedCrossRepoParentPickerScenario(orcaPage, registerPostElectronShutdownCleanup)
     try {
       const childRow = worktreeOption(orcaPage, childId)
       const parentRow = worktreeOption(orcaPage, parentId)

--- a/tests/e2e/worktree-lineage.spec.ts
+++ b/tests/e2e/worktree-lineage.spec.ts
@@ -3,6 +3,8 @@ import { test, expect } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
   markWorkspaceTerminalSlept,
+  removeCrossRepoParentPickerRepo,
+  seedCrossRepoParentPickerScenario,
   seedLineageScenario,
   seedWorkspaceAgentStatus,
   seedWorkspaceLiveTerminal
@@ -85,6 +87,57 @@ test.describe('Worktree Lineage', () => {
       )
       .toBe(false)
     await expect(childRow).toBeVisible()
+  })
+
+  test('selects and renders a parent worktree from another repo', async ({ orcaPage }) => {
+    const { parentId, childId, parentName, parentRepoName, repoPath } =
+      await seedCrossRepoParentPickerScenario(orcaPage)
+    try {
+      const childRow = worktreeOption(orcaPage, childId)
+      const parentRow = worktreeOption(orcaPage, parentId)
+
+      await expect(parentRow).toBeVisible()
+      await childRow.click({ button: 'right' })
+      await orcaPage.getByRole('menuitem', { name: 'Set Parent Worktree...' }).click()
+
+      const search = orcaPage.getByPlaceholder('Search worktrees...')
+      await expect(search).toBeVisible()
+      await search.fill(parentRepoName)
+
+      const parentOption = orcaPage
+        .locator('[cmdk-root]')
+        .getByRole('option')
+        .filter({ hasText: parentName })
+      await expect(parentOption).toBeVisible()
+      await expect(parentOption).toContainText(parentRepoName)
+      await parentOption.click()
+
+      await expect(parentRow).toBeVisible()
+      await expect(parentRow.getByRole('button', { name: 'Hide 1 child workspace' })).toBeVisible()
+      await expect(childRow).toBeVisible()
+
+      const positions = await orcaPage.evaluate(
+        ({ parentId, childId }) => {
+          const rowFor = (worktreeId: string) =>
+            [...document.querySelectorAll<HTMLElement>('[data-worktree-id]')].find(
+              (element) => element.dataset.worktreeId === worktreeId
+            )
+          const parent = rowFor(parentId)
+          const child = rowFor(childId)
+          return parent && child
+            ? {
+                parentTop: parent.getBoundingClientRect().top,
+                childTop: child.getBoundingClientRect().top
+              }
+            : null
+        },
+        { parentId, childId }
+      )
+      expect(positions).not.toBeNull()
+      expect(positions!.childTop).toBeGreaterThan(positions!.parentTop)
+    } finally {
+      await removeCrossRepoParentPickerRepo(orcaPage, repoPath)
+    }
   })
 
   test('injects filtered parents structurally without showing a parent badge', async ({


### PR DESCRIPTION
## Summary

- Allow the parent-worktree picker to select worktrees from another repository when both worktrees belong to the same runtime host.
- Include repository names in picker search values, so users can find a parent by repository as well as workspace, branch, or path.
- Add unit coverage for same-host versus cross-host eligibility and a real two-repository Electron E2E flow covering search, selection, persistence, and nested sidebar rendering.

The root cause was an explicit `candidate.repoId === child.repoId` eligibility guard in the renderer. The CLI lineage model already supported cross-repository parents. This removes only that repository restriction; existing self-parent, cycle, archived-worktree, current-parent, and cross-host protections remain in place.

Addresses #8886.

## Screenshots
| Video |
| --- |
| <video src="https://github.com/user-attachments/assets/72dbd39b-24d1-43b1-af7e-623bebff0900" controls></video> |

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2,836 files passed, 7 skipped; 30,006 tests passed, 47 skipped
- [x] `pnpm build` — desktop, web, relay, CLI, and native macOS build passed
- [x] Added or updated high-quality tests that would catch regressions

Additional validation:

- Parent-picker unit coverage: 11/11 passed.
- Worktree-lineage Electron E2E: 5/5 passed.
- Lineage plus downstream cleanup/scroll coverage: 8/8 passed.
- New real cross-repository Electron flow passed repeatedly, including within the complete E2E run.
- Full Electron suite was executed: 285 passed, 29 skipped, 11 unrelated failures, and 9 tests did not run after serial-suite aborts. The skipped serial tests were then run explicitly. Deterministic failures were reproduced in an untouched upstream worktree at the same base revision; the new cross-repository test remained green.

## AI Review Report

AI review checked the complete diff and focused on eligibility correctness, cycle prevention, persistence cleanup, UI search behavior, platform boundaries, and regression coverage.

- **Cross-platform:** The production change is renderer-only TypeScript with no shortcuts, labels, filesystem paths, shell behavior, or native Electron APIs added. Behavior is equivalent on macOS, Linux, and Windows. Build and type checks passed; interactive E2E validation ran on macOS.
- **Local / SSH / remote:** Review flagged accidental cross-host lineage as the main risk. The existing owner-host equality guard remains, so cross-repository parents are allowed only on the same local or remote runtime host. A different-host unit case remains blocked. Real local two-repository E2E coverage was added; live SSH UI interaction was not required by this renderer-only change.
- **Agents / integrations / providers:** No agent, integration, git-provider, authentication, or terminal behavior changed.
- **Performance:** Candidate filtering remains a linear pass over loaded worktrees with existing map lookups. Adding one repository-name lookup per rendered candidate is negligible.
- **UI quality:** Verified repository badges remain visible, repository-name search works, selection closes the picker, and the child renders below the selected parent with the child-count control.
- **Review result:** No unresolved issue-specific findings. Optional feature/folder grouping and virtual workspace concepts from the issue remain intentionally out of this focused PR.

## Security Audit

- No new command execution, dependency, IPC, authentication, secret, or network path was introduced.
- User-entered picker search remains local command-menu filtering; no input reaches a shell or backend query.
- Existing host ownership, self-parent, cycle, archive, and lineage-instance checks remain enforced.
- E2E setup creates a disposable local git repository, registers it through the existing IPC API, clears orphaned lineage before removal, and deletes the temporary path during cleanup.
- No follow-up security work identified.

## Notes

- Scope covers proposal 1 from #8886: cross-repository parent selection in the UI.
- Optional feature/folder grouping and the alternative cross-repository workspace concept are better handled as separate design follow-ups.
- X: [@Avichal2205](https://x.com/Avichal2205)

## ELI5

You can pick a parent worktree from another repo on the same host, not only the same repository. Search also includes repo names so cross-repo parent links are easier to find.
