### PR TITLE
ci(computer-e2e): run native-smoke vitest with the shared config

### DIFF
--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -75,8 +75,12 @@ jobs:
           npm install -g node-gyp@11.5.0
           echo "npm_config_node_gyp=$(npm root -g)/node-gyp/bin/node-gyp.js" >> "$GITHUB_ENV"
       - run: pnpm install --frozen-lockfile
+      # Why: without --config, bare vitest ignores config/vitest.config.ts (there
+      # is no root config) and falls back to the 5s default timeout with no
+      # Windows worker cap, so the real csc.exe launcher-compile tests time out
+      # on hosted Windows. Use the shared config so this job matches pnpm test.
       - run: >-
-          pnpm vitest run
+          pnpm vitest run --config config/vitest.config.ts
           config/scripts/build-windows-cli-launcher.test.mjs
           src/main/ssh/ssh-remote-cli-launcher.test.ts
           config/scripts/computer-e2e-workflow.test.mjs


### PR DESCRIPTION
## Problem

The `native-smoke (windows-latest)` job in `computer-e2e.yml` has been intermittently failing PR CI with:

```
Error: Test timed out in 5000ms.
 ❯ config/scripts/build-windows-cli-launcher.test.mjs:29:3
 ❯ src/main/ssh/ssh-remote-cli-launcher.test.ts:55:3
```

Both failing tests spawn the real `csc.exe` to compile a native Windows launcher. Cold `csc.exe` startup on hosted Windows runners is highly variable — observed **1.4s → 7.4s** across recent runs (~5× swing).

## Root cause

The step ran **bare `pnpm vitest run <files>`** with no `--config`. There is no root-level `vitest.config.ts`/`vite.config.ts` in this repo (the only one is `config/vitest.config.ts`), so bare vitest silently fell back to its **built-in defaults**: a `5000ms` testTimeout (exactly the error) and no Windows `maxWorkers: 4` cap. Every other vitest invocation in the repo (`pnpm test`, `pr.yml`) passes `--config config/vitest.config.ts` — this smoke step was the lone outlier.

## Fix

Pass `--config config/vitest.config.ts` to the native-smoke vitest run, matching how the rest of the repo runs its tests. That applies the shared `testTimeout: 30_000` **and** the Windows `maxWorkers: 4` cap (less CPU contention during the concurrent compiles → lower variance, the real driver of the flake). Positional file args still filter to just the listed files.

`#8897`'s earlier per-test `{ timeout: 15_000 }` stopgap (via the `itWindows` helper in both test files) is left in place as harmless defense-in-depth against a future config-less invocation.

## Verification

- Ran the exact new invocation locally: `config/vitest.config.ts` loads, the listed files run, and the win32-only compile tests correctly skip on macOS — positional filtering + config resolution both work.
- `pr.yml` already uses this exact `--config … <positional files>` pattern (git-compat step), so it's a proven shape.
- All 33 files in this job already run under `pnpm test` with this config, so they're known-compatible with its `define`/aliases.