### PR TITLE
feat(space): add a prune action for stale worktree registrations

### DIFF
--- a/src/main/git/prune-worktrees.test.ts
+++ b/src/main/git/prune-worktrees.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RunnerModule from './runner'
+import type * as StatusModule from './status'
+
+const gitExecFileAsyncMock = vi.hoisted(() => vi.fn().mockResolvedValue({ stdout: '', stderr: '' }))
+
+vi.mock('./runner', async (importOriginal) => ({
+  ...(await importOriginal<typeof RunnerModule>()),
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('./status', async (importOriginal) => ({
+  ...(await importOriginal<typeof StatusModule>()),
+  runWithGitReadCacheInvalidation: <T>(run: () => Promise<T>): Promise<T> => run()
+}))
+
+import { pruneWorktrees, WORKTREE_PRUNE_TIMEOUT_MS } from './worktree'
+
+describe('pruneWorktrees', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockClear()
+  })
+
+  it('bounds native and WSL prune commands by default', async () => {
+    await pruneWorktrees('/repo', { wslDistro: 'Ubuntu' })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'prune'], {
+      cwd: '/repo',
+      timeout: WORKTREE_PRUNE_TIMEOUT_MS,
+      wslDistro: 'Ubuntu'
+    })
+    expect(WORKTREE_PRUNE_TIMEOUT_MS).toBeGreaterThan(0)
+  })
+})

--- a/src/main/git/worktree-list-paths.test.ts
+++ b/src/main/git/worktree-list-paths.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, realpath, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { listWorktrees, removeWorktree } from './worktree'
+import { listWorktrees, pruneWorktrees, removeWorktree } from './worktree'
 
 const tempRoots: string[] = []
 
@@ -151,5 +151,26 @@ describe('git worktree paths', () => {
       worktreePath.replaceAll('\\', '/')
     )
     expect(branchExists(repoPath, 'feature/locked-delete')).toBe(true)
+  })
+
+  it('prunes a stale registration while keeping its branch and locked worktrees', async () => {
+    const { repoPath, worktreePath } = await createRepoWithPrunableWorktree()
+    const locked = await createRepoWithLockedDeletedWorktree()
+
+    await pruneWorktrees(repoPath)
+    await pruneWorktrees(locked.repoPath)
+
+    const remaining = await listWorktrees(repoPath)
+    expect(
+      remaining.some(
+        (worktree) => worktree.path.replaceAll('\\', '/') === worktreePath.replaceAll('\\', '/')
+      )
+    ).toBe(false)
+    // Git guarantees the branch and its commits survive a prune.
+    expect(branchExists(repoPath, 'feature/stale')).toBe(true)
+    // A lock shields the registration from prune even with the directory gone.
+    expect(git(locked.repoPath, ['worktree', 'list', '--porcelain'])).toContain(
+      locked.worktreePath.replaceAll('\\', '/')
+    )
   })
 })

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1179,6 +1179,21 @@ export async function moveWorktree(
 /**
  * Remove a worktree.
  */
+export async function pruneWorktrees(
+  repoPath: string,
+  options: GitWorktreeExecOptions = {}
+): Promise<void> {
+  // Why: prune only drops registrations whose directory is gone; git itself
+  // preserves locked registrations, so agent-locked worktrees survive.
+  try {
+    await runWithGitReadCacheInvalidation(() =>
+      gitExecFileAsync(['worktree', 'prune'], gitExecOptions(repoPath, options))
+    )
+  } finally {
+    bumpWorktreeScanGeneration(repoPath)
+  }
+}
+
 export async function removeWorktree(
   repoPath: string,
   worktreePath: string,

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -89,6 +89,7 @@ const PRUNABLE_EXISTENCE_PROBE_CONCURRENCY = 8
 // checkout (mirrors the SYNC runner's cloud-placeholder floor, #7225).
 export const WORKTREE_ADD_TIMEOUT_MS = 180_000
 export const WORKTREE_REMOVAL_PREFLIGHT_TIMEOUT_MS = 30_000
+export const WORKTREE_PRUNE_TIMEOUT_MS = 30_000
 
 function gitExecOptions(
   cwd: string,
@@ -1187,7 +1188,15 @@ export async function pruneWorktrees(
   // preserves locked registrations, so agent-locked worktrees survive.
   try {
     await runWithGitReadCacheInvalidation(() =>
-      gitExecFileAsync(['worktree', 'prune'], gitExecOptions(repoPath, options))
+      gitExecFileAsync(
+        ['worktree', 'prune'],
+        gitExecOptions(repoPath, {
+          ...options,
+          // Why: a wedged filesystem must not leave the Space action disabled indefinitely.
+          timeout:
+            options.timeout && options.timeout > 0 ? options.timeout : WORKTREE_PRUNE_TIMEOUT_MS
+        })
+      )
     )
   } finally {
     bumpWorktreeScanGeneration(repoPath)

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -47,6 +47,7 @@ function createAnalysis(scannedAt: number): WorkspaceSpaceAnalysis {
     worktreeCount: 0,
     scannedWorktreeCount: 0,
     unavailableWorktreeCount: 0,
+    staleRegistrationCount: 0,
     repos: [],
     worktrees: []
   }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -6095,7 +6095,7 @@ describe('registerWorktreeHandlers', () => {
     expect(pruneWorktreesMock).not.toHaveBeenCalled()
   })
 
-  it('fails worktrees:pruneStaleRegistrations clearly when the relay lacks prune support', async () => {
+  it('surfaces the provider error when the relay lacks prune support', async () => {
     const repo = {
       id: 'repo-1',
       path: '/remote/repo',
@@ -6105,15 +6105,16 @@ describe('registerWorktreeHandlers', () => {
       connectionId: 'ssh-1'
     }
     store.getRepos.mockReturnValue([repo])
-    // Why: an already-deployed relay predating git.pruneWorktrees rejects the
-    // RPC with "Method not found"; the error must say what to do instead.
+    const oldRelayError = new Error(
+      'The connected SSH host is running an older Orca relay without worktree prune support. Reconnect to update it, or run `git worktree prune` there.'
+    )
     getSshGitProviderMock.mockReturnValue({
-      pruneWorktrees: vi.fn().mockRejectedValue(new Error('Method not found: git.pruneWorktrees'))
+      pruneWorktrees: vi.fn().mockRejectedValue(oldRelayError)
     })
 
     await expect(
       handlers['worktrees:pruneStaleRegistrations'](null, { repoId: 'repo-1' })
-    ).rejects.toThrow(/older Orca relay/)
+    ).rejects.toBe(oldRelayError)
   })
 
   it('continues shared-host pruning and invalidates stale roots after a host fails', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -27,6 +27,7 @@ const {
   addWorktreeMock,
   addSparseWorktreeMock,
   removeWorktreeMock,
+  pruneWorktreesMock,
   forceDeleteLocalBranchMock,
   resolveLocalGitUsernameMock,
   getBaseRefDefaultMock,
@@ -77,6 +78,7 @@ const {
   addWorktreeMock: vi.fn(),
   addSparseWorktreeMock: vi.fn(),
   removeWorktreeMock: vi.fn(),
+  pruneWorktreesMock: vi.fn(),
   forceDeleteLocalBranchMock: vi.fn(),
   resolveLocalGitUsernameMock: vi.fn(),
   getBaseRefDefaultMock: vi.fn(),
@@ -124,6 +126,7 @@ vi.mock('../git/worktree', () => ({
   addWorktree: addWorktreeMock,
   addSparseWorktree: addSparseWorktreeMock,
   removeWorktree: removeWorktreeMock,
+  pruneWorktrees: pruneWorktreesMock,
   forceDeleteLocalBranch: forceDeleteLocalBranchMock
 }))
 
@@ -6058,6 +6061,55 @@ describe('registerWorktreeHandlers', () => {
 
     expect(listedIds).toContain('repo-1::/workspace/live-wt')
     expect(listedIds).not.toContain('repo-1::/workspace/stale-wt')
+  })
+
+  it('runs git worktree prune for a local repo via worktrees:pruneStaleRegistrations', async () => {
+    pruneWorktreesMock.mockResolvedValue(undefined)
+
+    await handlers['worktrees:pruneStaleRegistrations'](null, { repoId: 'repo-1' })
+
+    expect(pruneWorktreesMock).toHaveBeenCalledWith('/workspace/repo', expect.anything())
+  })
+
+  it('routes worktrees:pruneStaleRegistrations to the SSH provider for remote repos', async () => {
+    const repo = {
+      id: 'repo-1',
+      path: '/remote/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1'
+    }
+    store.getRepos.mockReturnValue([repo])
+    pruneWorktreesMock.mockClear()
+    const providerPrune = vi.fn().mockResolvedValue(undefined)
+    getSshGitProviderMock.mockReturnValue({ pruneWorktrees: providerPrune })
+
+    await handlers['worktrees:pruneStaleRegistrations'](null, { repoId: 'repo-1' })
+
+    expect(providerPrune).toHaveBeenCalledWith('/remote/repo')
+    expect(pruneWorktreesMock).not.toHaveBeenCalled()
+  })
+
+  it('fails worktrees:pruneStaleRegistrations clearly when the relay lacks prune support', async () => {
+    const repo = {
+      id: 'repo-1',
+      path: '/remote/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1'
+    }
+    store.getRepos.mockReturnValue([repo])
+    // Why: an already-deployed relay predating git.pruneWorktrees rejects the
+    // RPC with "Method not found"; the error must say what to do instead.
+    getSshGitProviderMock.mockReturnValue({
+      pruneWorktrees: vi.fn().mockRejectedValue(new Error('Method not found: git.pruneWorktrees'))
+    })
+
+    await expect(
+      handlers['worktrees:pruneStaleRegistrations'](null, { repoId: 'repo-1' })
+    ).rejects.toThrow(/older Orca relay/)
   })
 
   it('limits concurrent repo scans in worktrees:listAll while preserving order', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -256,7 +256,11 @@ import {
   __resetSshWorktreeCreateFetchCacheForTests,
   notifyWorktreesChanged
 } from './worktree-remote'
-import { invalidateAuthorizedRootsCache, resolveRegisteredWorktreePath } from './filesystem-auth'
+import {
+  invalidateAuthorizedRootsCache,
+  registerWorktreeRootsForRepo,
+  resolveRegisteredWorktreePath
+} from './filesystem-auth'
 import {
   __getDetectedWorktreeScanCacheStatsForTests,
   __resetDetectedWorktreeScanCacheForTests,
@@ -6110,6 +6114,55 @@ describe('registerWorktreeHandlers', () => {
     await expect(
       handlers['worktrees:pruneStaleRegistrations'](null, { repoId: 'repo-1' })
     ).rejects.toThrow(/older Orca relay/)
+  })
+
+  it('continues shared-host pruning and invalidates stale roots after a host fails', async () => {
+    const remoteRepo = {
+      id: 'repo-1',
+      path: '/remote/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1'
+    }
+    const localRepo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    store.getRepos.mockReturnValue([remoteRepo, localRepo])
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: localRepo.path,
+        head: 'abc123',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    registerWorktreeRootsForRepo(store as never, localRepo.id, [
+      localRepo.path,
+      '/workspace/stale-wt'
+    ])
+    await expect(
+      resolveRegisteredWorktreePath('/workspace/stale-wt', store as never)
+    ).resolves.toBe('/workspace/stale-wt')
+    getSshGitProviderMock.mockReturnValue({
+      pruneWorktrees: vi.fn().mockRejectedValue(new Error('remote unavailable'))
+    })
+    pruneWorktreesMock.mockResolvedValue(undefined)
+
+    await expect(
+      handlers['worktrees:pruneStaleRegistrations'](null, { repoId: 'repo-1' })
+    ).rejects.toThrow('remote unavailable')
+
+    expect(pruneWorktreesMock).toHaveBeenCalledWith(localRepo.path, expect.anything())
+    expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
+    await expect(
+      resolveRegisteredWorktreePath('/workspace/stale-wt', store as never)
+    ).rejects.toThrow('unknown repository or worktree path')
   })
 
   it('limits concurrent repo scans in worktrees:listAll while preserving order', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -41,6 +41,7 @@ import {
   assertWorktreeCleanForRemoval,
   forceDeleteLocalBranch,
   listWorktreesStrict as listGitWorktreesStrict,
+  pruneWorktrees,
   removeWorktree
 } from '../git/worktree'
 import { gitExecFileAsync } from '../git/runner'
@@ -1003,6 +1004,7 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('worktrees:resolveMrBase')
   ipcMain.removeHandler('worktrees:remove')
   ipcMain.removeHandler('worktrees:forgetLocal')
+  ipcMain.removeHandler('worktrees:pruneStaleRegistrations')
   ipcMain.removeHandler('worktrees:forceDeletePreservedBranch')
   ipcMain.removeHandler('worktrees:updateMeta')
   ipcMain.removeHandler('worktrees:listLineage')
@@ -2018,6 +2020,44 @@ export function registerWorktreeHandlers(
           worktreeRemovalsInFlight.delete(inFlightKey)
         }
       }
+    }
+  )
+
+  // Why: a prunable registration (directory deleted without `git worktree
+  // prune`) is hidden from workspace/Space listings, but it still pins its
+  // branch as checked out. This runs git's own prune, which drops only dead
+  // registrations and never touches locked ones (active agent sessions).
+  ipcMain.handle(
+    'worktrees:pruneStaleRegistrations',
+    async (_event, args: { repoId: string }): Promise<void> => {
+      const repos = store.getRepos().filter((candidate) => candidate.id === args.repoId)
+      if (repos.length === 0) {
+        throw new Error(`Repo not found: ${args.repoId}`)
+      }
+      for (const repo of repos) {
+        if (isFolderRepo(repo)) {
+          continue
+        }
+        if (repo.connectionId) {
+          const provider = requireSshGitProvider(repo.connectionId)
+          try {
+            await provider.pruneWorktrees(repo.path)
+          } catch (error) {
+            // Why: an already-deployed relay predating git.pruneWorktrees
+            // rejects with "Method not found"; surface what to do instead.
+            if (/method not found/i.test(error instanceof Error ? error.message : '')) {
+              throw new Error(
+                'The connected SSH host is running an older Orca relay without worktree prune support. Reconnect to update it, or run `git worktree prune` there.'
+              )
+            }
+            throw error
+          }
+        } else {
+          await pruneWorktrees(repo.path, getLocalProjectWorktreeGitOptions(store, repo))
+        }
+        notifyWorktreesChanged(mainWindow, repo.id)
+      }
+      invalidateAuthorizedRootsCache()
     }
   )
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2050,13 +2050,8 @@ export function registerWorktreeHandlers(
               await pruneWorktrees(repo.path, getLocalProjectWorktreeGitOptions(store, repo))
             }
           } catch (error) {
-            // Why: an already-deployed relay predating git.pruneWorktrees
-            // rejects with "Method not found"; surface what to do instead.
-            firstError ??= /method not found/i.test(error instanceof Error ? error.message : '')
-              ? new Error(
-                  'The connected SSH host is running an older Orca relay without worktree prune support. Reconnect to update it, or run `git worktree prune` there.'
-                )
-              : error
+            // Why: shared project ids can span hosts; attempt every host before surfacing a failure.
+            firstError ??= error
           }
         }
       } finally {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2034,30 +2034,42 @@ export function registerWorktreeHandlers(
       if (repos.length === 0) {
         throw new Error(`Repo not found: ${args.repoId}`)
       }
-      for (const repo of repos) {
-        if (isFolderRepo(repo)) {
-          continue
-        }
-        if (repo.connectionId) {
-          const provider = requireSshGitProvider(repo.connectionId)
+      let firstError: unknown
+      let didAttemptPrune = false
+      try {
+        for (const repo of repos) {
+          if (isFolderRepo(repo)) {
+            continue
+          }
+          didAttemptPrune = true
           try {
-            await provider.pruneWorktrees(repo.path)
+            if (repo.connectionId) {
+              const provider = requireSshGitProvider(repo.connectionId)
+              await provider.pruneWorktrees(repo.path)
+            } else {
+              await pruneWorktrees(repo.path, getLocalProjectWorktreeGitOptions(store, repo))
+            }
           } catch (error) {
             // Why: an already-deployed relay predating git.pruneWorktrees
             // rejects with "Method not found"; surface what to do instead.
-            if (/method not found/i.test(error instanceof Error ? error.message : '')) {
-              throw new Error(
-                'The connected SSH host is running an older Orca relay without worktree prune support. Reconnect to update it, or run `git worktree prune` there.'
-              )
-            }
-            throw error
+            firstError ??= /method not found/i.test(error instanceof Error ? error.message : '')
+              ? new Error(
+                  'The connected SSH host is running an older Orca relay without worktree prune support. Reconnect to update it, or run `git worktree prune` there.'
+                )
+              : error
           }
-        } else {
-          await pruneWorktrees(repo.path, getLocalProjectWorktreeGitOptions(store, repo))
         }
-        notifyWorktreesChanged(mainWindow, repo.id)
+      } finally {
+        // Why: Git may prune one host (or part of one registry) before another host fails.
+        invalidateAuthorizedRootsCache()
       }
-      invalidateAuthorizedRootsCache()
+      if (didAttemptPrune) {
+        // Why: one event invalidates all host views, including partial mutations after a Git error.
+        notifyWorktreesChanged(mainWindow, args.repoId)
+      }
+      if (firstError) {
+        throw firstError
+      }
     }
   )
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1268,6 +1268,31 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('pruneWorktrees sends the narrow prune request', async () => {
+    await provider.pruneWorktrees('/home/user/repo')
+
+    expect(mux.request).toHaveBeenCalledWith('git.pruneWorktrees', {
+      repoPath: '/home/user/repo'
+    })
+  })
+
+  it('pruneWorktrees maps old relays to the reconnect message', async () => {
+    mux.request.mockRejectedValueOnce(
+      Object.assign(new Error('Method not found: git.pruneWorktrees'), { code: -32601 })
+    )
+
+    await expect(provider.pruneWorktrees('/home/user/repo')).rejects.toThrow(
+      'The connected SSH host is running an older Orca relay without worktree prune support. Reconnect to update it, or run `git worktree prune` there.'
+    )
+  })
+
+  it('pruneWorktrees rethrows non-method-not-found errors', async () => {
+    const error = new Error('remote prune failed')
+    mux.request.mockRejectedValueOnce(error)
+
+    await expect(provider.pruneWorktrees('/home/user/repo')).rejects.toBe(error)
+  })
+
   it('worktreeIsClean sends git.worktreeIsClean request', async () => {
     const cleanResult = { clean: false, stdout: '?? scratch.txt\n' }
     mux.request.mockResolvedValue(cleanResult)

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -672,6 +672,12 @@ export class SshGitProvider implements IGitProvider {
     )
   }
 
+  async pruneWorktrees(repoPath: string): Promise<void> {
+    await this.runWithDiffDedupeClear(async () => {
+      await this.mux.request('git.pruneWorktrees', { repoPath })
+    })
+  }
+
   async worktreeIsClean(
     worktreePath: string,
     options: { includeUntracked?: boolean } = {}

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -673,9 +673,19 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async pruneWorktrees(repoPath: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.pruneWorktrees', { repoPath })
-    })
+    try {
+      await this.runWithDiffDedupeClear(async () => {
+        await this.mux.request('git.pruneWorktrees', { repoPath })
+      })
+    } catch (error) {
+      if (isJsonRpcMethodNotFoundError(error)) {
+        // Why: older relays predate the narrow prune RPC; tell the user how to recover.
+        throw new Error(
+          'The connected SSH host is running an older Orca relay without worktree prune support. Reconnect to update it, or run `git worktree prune` there.'
+        )
+      }
+      throw error
+    }
   }
 
   async worktreeIsClean(

--- a/src/main/workspace-space-analysis.test.ts
+++ b/src/main/workspace-space-analysis.test.ts
@@ -165,6 +165,9 @@ describe('analyzeWorkspaceSpace', () => {
     expect(result.worktrees.find((row) => row.path === stalePath)).toBeUndefined()
     expect(result.worktrees.find((row) => row.path === mainPath)?.status).toBe('ok')
     expect(result.repos[0]?.unavailableWorktreeCount).toBe(0)
+    // The omitted registrations stay countable so the page can offer a prune.
+    expect(result.repos[0]?.staleRegistrationCount).toBe(1)
+    expect(result.staleRegistrationCount).toBe(1)
   })
 
   it('reports scan progress as repos and worktrees are scanned', async () => {

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -843,6 +843,7 @@ async function scanRepo(
         worktreeCount: 0,
         scannedWorktreeCount: 0,
         unavailableWorktreeCount: 1,
+        staleRegistrationCount: 0,
         totalSizeBytes: 0,
         reclaimableBytes: 0,
         error: listed.error
@@ -852,7 +853,10 @@ async function scanRepo(
 
   // Why: a prunable registration has no directory to size or reclaim (issue
   // #8389); it would only render a dead "Missing" row with no available
-  // action. Removal flows list worktrees separately and still see it.
+  // action. Count it so the page can offer a prune instead of listing it.
+  const staleRegistrationCount = listed.worktrees.filter(
+    (gitWorktree) => gitWorktree.prunable
+  ).length
   const worktrees = listed.worktrees
     .filter((gitWorktree) => !gitWorktree.prunable)
     .map((gitWorktree) => mergeForSpaceScan(repo, gitWorktree, store))
@@ -910,6 +914,7 @@ async function scanRepo(
       worktreeCount: rows.length,
       scannedWorktreeCount: rows.filter((row) => row.status === 'ok').length,
       unavailableWorktreeCount: rows.filter((row) => row.status !== 'ok').length,
+      staleRegistrationCount,
       totalSizeBytes: rows.reduce((sum, row) => sum + row.sizeBytes, 0),
       reclaimableBytes: rows.reduce((sum, row) => sum + row.reclaimableBytes, 0),
       error: null
@@ -956,6 +961,7 @@ export async function analyzeWorkspaceSpace(
     unavailableWorktreeCount:
       worktrees.filter((row) => row.status !== 'ok').length +
       repos.filter((repo) => repo.error !== null).length,
+    staleRegistrationCount: repos.reduce((sum, repo) => sum + repo.staleRegistrationCount, 0),
     repos,
     worktrees
   }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1183,6 +1183,9 @@ export type PreloadApi = {
       worktreeId: string
       hostId?: ExecutionHostId
     }) => Promise<RemoveWorktreeResult>
+    // Run `git worktree prune` for a repo, dropping stale registrations whose
+    // directory was deleted. Locked registrations are preserved by git.
+    pruneStaleRegistrations: (args: { repoId: string }) => Promise<void>
     forceDeletePreservedBranch: (args: {
       worktreeId: string
       branchName: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -709,6 +709,9 @@ const api = {
 
     forgetLocal: (args) => ipcRenderer.invoke('worktrees:forgetLocal', args),
 
+    pruneStaleRegistrations: (args) =>
+      ipcRenderer.invoke('worktrees:pruneStaleRegistrations', args),
+
     forceDeletePreservedBranch: (args) =>
       ipcRenderer.invoke('worktrees:forceDeletePreservedBranch', args),
 

--- a/src/relay/git-handler-prune-worktrees.test.ts
+++ b/src/relay/git-handler-prune-worktrees.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RelayContext } from './context'
+import { GitHandler } from './git-handler'
+import {
+  createMockDispatcher,
+  type MockDispatcher,
+  type RelayDispatcher
+} from './git-handler-test-setup'
+
+type GitSpyTarget = {
+  git(
+    args: string[],
+    cwd: string,
+    options?: { signal?: AbortSignal }
+  ): Promise<{ stdout: string; stderr: string }>
+}
+
+describe('relay worktree prune', () => {
+  let dispatcher: MockDispatcher
+  let handler: GitHandler
+
+  beforeEach(() => {
+    dispatcher = createMockDispatcher()
+    handler = new GitHandler(dispatcher as unknown as RelayDispatcher, new RelayContext())
+  })
+
+  afterEach(() => {
+    handler.dispose()
+  })
+
+  it('forwards request cancellation to the Git subprocess', async () => {
+    const controller = new AbortController()
+    const gitSpy = vi
+      .spyOn(handler as unknown as GitSpyTarget, 'git')
+      .mockResolvedValue({ stdout: '', stderr: '' })
+
+    await dispatcher.callRequest(
+      'git.pruneWorktrees',
+      { repoPath: '/repo' },
+      { isStale: () => false, signal: controller.signal }
+    )
+
+    expect(gitSpy).toHaveBeenCalledWith(['worktree', 'prune'], '/repo', {
+      signal: controller.signal
+    })
+  })
+})

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -233,7 +233,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
     this.dispatcher.onRequest('git.addWorktree', (p) => this.addWorktree(p))
     this.dispatcher.onRequest('git.removeWorktree', (p) => this.removeWorktree(p))
-    this.dispatcher.onRequest('git.pruneWorktrees', (p) => this.pruneWorktrees(p))
+    this.dispatcher.onRequest('git.pruneWorktrees', (p, context) => this.pruneWorktrees(p, context))
     this.dispatcher.onRequest('git.worktreeIsClean', (p) => this.worktreeIsClean(p))
     this.dispatcher.onRequest('git.refreshLocalBaseRefForWorktreeCreate', (p) =>
       this.refreshLocalBaseRefForWorktreeCreate(p)
@@ -1410,11 +1410,13 @@ export class GitHandler {
       : remove()
   }
 
-  private async pruneWorktrees(params: Record<string, unknown>) {
+  private async pruneWorktrees(params: Record<string, unknown>, context?: RequestContext) {
     const repoPath = params.repoPath as string
     // Why: prune only drops registrations whose directory is gone; git itself
     // preserves locked registrations, so agent-locked worktrees survive.
-    await this.runWithGitReadCacheClear(() => this.git(['worktree', 'prune'], repoPath))
+    await this.runWithGitReadCacheClear(() =>
+      this.git(['worktree', 'prune'], repoPath, { signal: context?.signal })
+    )
     return {}
   }
 

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -233,6 +233,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
     this.dispatcher.onRequest('git.addWorktree', (p) => this.addWorktree(p))
     this.dispatcher.onRequest('git.removeWorktree', (p) => this.removeWorktree(p))
+    this.dispatcher.onRequest('git.pruneWorktrees', (p) => this.pruneWorktrees(p))
     this.dispatcher.onRequest('git.worktreeIsClean', (p) => this.worktreeIsClean(p))
     this.dispatcher.onRequest('git.refreshLocalBaseRefForWorktreeCreate', (p) =>
       this.refreshLocalBaseRefForWorktreeCreate(p)
@@ -1407,6 +1408,14 @@ export class GitHandler {
     return this.watcherRegistry && typeof worktreePath === 'string'
       ? this.watcherRegistry.runWithRemovalFence(expandTilde(worktreePath), remove)
       : remove()
+  }
+
+  private async pruneWorktrees(params: Record<string, unknown>) {
+    const repoPath = params.repoPath as string
+    // Why: prune only drops registrations whose directory is gone; git itself
+    // preserves locked registrations, so agent-locked worktrees survive.
+    await this.runWithGitReadCacheClear(() => this.git(['worktree', 'prune'], repoPath))
+    return {}
   }
 
   private async worktreeIsClean(params: Record<string, unknown>) {

--- a/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
+++ b/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
@@ -1258,7 +1258,7 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
   )
   const [isPruningStale, setIsPruningStale] = useState(false)
   const pruneStale = useCallback((): void => {
-    if (!analysis || isPruningStale) {
+    if (!analysis || isPruningStale || isScanning) {
       return
     }
     const repoIds = analysis.repos
@@ -1289,7 +1289,7 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
       .finally(() => {
         setIsPruningStale(false)
       })
-  }, [analysis, isPruningStale, pruneStaleWorktreeRegistrations])
+  }, [analysis, isPruningStale, isScanning, pruneStaleWorktreeRegistrations])
   const [query, setQuery] = useState('')
   const [onlyDeletable, setOnlyDeletable] = useState(false)
   const [sortKey, setSortKey] = useState<WorkspaceSpaceSortKey>('size')
@@ -1748,7 +1748,7 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
           variant="outline"
           size="sm"
           onClick={isScanning ? cancelScan : refresh}
-          disabled={progress?.state === 'cancelling'}
+          disabled={isPruningStale || progress?.state === 'cancelling'}
           className="w-28 gap-1.5"
         >
           {isScanning ? (
@@ -1829,7 +1829,7 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
             variant="outline"
             size="sm"
             onClick={pruneStale}
-            disabled={isPruningStale}
+            disabled={isPruningStale || isScanning}
             className="gap-1.5"
           >
             {isPruningStale ? (

--- a/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
+++ b/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
@@ -1253,6 +1253,43 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
   const updateWorktreeGitIdentity = useAppStore((state) => state.updateWorktreeGitIdentity)
   const setUpstreamStatus = useAppStore((state) => state.setUpstreamStatus)
   const fetchUpstreamStatus = useAppStore((state) => state.fetchUpstreamStatus)
+  const pruneStaleWorktreeRegistrations = useAppStore(
+    (state) => state.pruneStaleWorktreeRegistrations
+  )
+  const [isPruningStale, setIsPruningStale] = useState(false)
+  const pruneStale = useCallback((): void => {
+    if (!analysis || isPruningStale) {
+      return
+    }
+    const repoIds = analysis.repos
+      .filter((repo) => repo.staleRegistrationCount > 0)
+      .map((repo) => repo.repoId)
+    if (repoIds.length === 0) {
+      return
+    }
+    setIsPruningStale(true)
+    pruneStaleWorktreeRegistrations(repoIds)
+      .then(() => {
+        toast.success(
+          translate(
+            'auto.components.status.bar.WorkspaceSpaceManagerPanel.e1978eea62',
+            'Stale worktree registrations pruned'
+          )
+        )
+      })
+      .catch((error: unknown) => {
+        toast.error(
+          translate(
+            'auto.components.status.bar.WorkspaceSpaceManagerPanel.db0915334e',
+            'Prune failed'
+          ),
+          { description: error instanceof Error ? error.message : String(error) }
+        )
+      })
+      .finally(() => {
+        setIsPruningStale(false)
+      })
+  }, [analysis, isPruningStale, pruneStaleWorktreeRegistrations])
   const [query, setQuery] = useState('')
   const [onlyDeletable, setOnlyDeletable] = useState(false)
   const [sortKey, setSortKey] = useState<WorkspaceSpaceSortKey>('size')
@@ -1770,6 +1807,46 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
               </span>
             </div>
           ))}
+        </div>
+      ) : null}
+
+      {analysis && analysis.staleRegistrationCount > 0 ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+          <div className="flex min-w-0 items-center gap-2">
+            <FileWarning className="size-3.5 shrink-0" />
+            <span className="min-w-0 break-words">
+              {translate(
+                'auto.components.status.bar.WorkspaceSpaceManagerPanel.7edf0a0a79',
+                '{{value0}} stale worktree {{value1}} from deleted directories.',
+                {
+                  value0: analysis.staleRegistrationCount,
+                  value1: analysis.staleRegistrationCount === 1 ? 'registration' : 'registrations'
+                }
+              )}
+            </span>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={pruneStale}
+            disabled={isPruningStale}
+            className="gap-1.5"
+          >
+            {isPruningStale ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="size-3.5" />
+            )}
+            {isPruningStale
+              ? translate(
+                  'auto.components.status.bar.WorkspaceSpaceManagerPanel.7176290b7c',
+                  'Pruning'
+                )
+              : translate(
+                  'auto.components.status.bar.WorkspaceSpaceManagerPanel.322d74038c',
+                  'Prune'
+                )}
+          </Button>
         </div>
       ) : null}
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3171,7 +3171,12 @@
             "0990a63160": "No scanned workspace sizes yet.",
             "977bdf9a36": "No top-level items to show.",
             "131662ac65": "{{value0}} open",
-            "0d1c78d749": "Select {{value0}}"
+            "0d1c78d749": "Select {{value0}}",
+            "e1978eea62": "Stale worktree registrations pruned",
+            "db0915334e": "Prune failed",
+            "7edf0a0a79": "{{value0}} stale worktree {{value1}} from deleted directories.",
+            "7176290b7c": "Pruning",
+            "322d74038c": "Prune"
           },
           "ports": {
             "status": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3171,7 +3171,12 @@
             "0990a63160": "Aún no hay tamaños de espacio de trabajo escaneados.",
             "977bdf9a36": "No hay elementos de nivel superior para mostrar.",
             "131662ac65": "{{value0}} abierto",
-            "0d1c78d749": "Seleccione {{value0}}"
+            "0d1c78d749": "Seleccione {{value0}}",
+            "e1978eea62": "Stale worktree registrations pruned",
+            "db0915334e": "Prune failed",
+            "7edf0a0a79": "{{value0}} stale worktree {{value1}} from deleted directories.",
+            "7176290b7c": "Pruning",
+            "322d74038c": "Prune"
           },
           "ports": {
             "status": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3171,7 +3171,12 @@
             "0990a63160": "スキャンされたワークスペースのサイズはまだありません。",
             "977bdf9a36": "表示するトップレベルの項目はありません。",
             "131662ac65": "{{value0}} オープン",
-            "0d1c78d749": "{{value0}} を選択"
+            "0d1c78d749": "{{value0}} を選択",
+            "e1978eea62": "Stale worktree registrations pruned",
+            "db0915334e": "Prune failed",
+            "7edf0a0a79": "{{value0}} stale worktree {{value1}} from deleted directories.",
+            "7176290b7c": "Pruning",
+            "322d74038c": "Prune"
           },
           "ports": {
             "status": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3171,7 +3171,12 @@
             "0990a63160": "아직 스캔된 워크스페이스 크기가 없습니다.",
             "977bdf9a36": "표시할 최상위 항목이 없습니다.",
             "131662ac65": "{{value0}} 열려 있음",
-            "0d1c78d749": "{{value0}} 선택"
+            "0d1c78d749": "{{value0}} 선택",
+            "e1978eea62": "Stale worktree registrations pruned",
+            "db0915334e": "Prune failed",
+            "7edf0a0a79": "{{value0}} stale worktree {{value1}} from deleted directories.",
+            "7176290b7c": "Pruning",
+            "322d74038c": "Prune"
           },
           "ports": {
             "status": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3171,7 +3171,12 @@
             "0990a63160": "尚无扫描的工作区大小。",
             "977bdf9a36": "没有可显示的顶级项目。",
             "131662ac65": "{{value0}} 打开",
-            "0d1c78d749": "选择 {{value0}}"
+            "0d1c78d749": "选择 {{value0}}",
+            "e1978eea62": "Stale worktree registrations pruned",
+            "db0915334e": "Prune failed",
+            "7edf0a0a79": "{{value0}} stale worktree {{value1}} from deleted directories.",
+            "7176290b7c": "Pruning",
+            "322d74038c": "Prune"
           },
           "ports": {
             "status": {

--- a/src/renderer/src/store/slices/workspace-space.test.ts
+++ b/src/renderer/src/store/slices/workspace-space.test.ts
@@ -21,6 +21,7 @@ function makeAnalysis(): WorkspaceSpaceAnalysis {
     worktreeCount: 2,
     scannedWorktreeCount: 2,
     unavailableWorktreeCount: 0,
+    staleRegistrationCount: 0,
     repos: [
       {
         repoId: 'repo-1',
@@ -30,6 +31,7 @@ function makeAnalysis(): WorkspaceSpaceAnalysis {
         worktreeCount: 2,
         scannedWorktreeCount: 2,
         unavailableWorktreeCount: 0,
+        staleRegistrationCount: 0,
         totalSizeBytes: 300,
         reclaimableBytes: 300,
         error: null

--- a/src/renderer/src/store/slices/workspace-space.test.ts
+++ b/src/renderer/src/store/slices/workspace-space.test.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { WorkspaceSpaceAnalysis } from '../../../../shared/workspace-space-types'
 import type { AppState } from '../types'
 import { createWorkspaceSpaceSlice } from './workspace-space'
@@ -89,6 +89,10 @@ function makeAnalysis(): WorkspaceSpaceAnalysis {
 }
 
 describe('workspace space slice', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('removes deleted worktrees from cached analysis totals', () => {
     const store = createWorkspaceSpaceTestStore()
     store.setState({ workspaceSpaceAnalysis: makeAnalysis() })
@@ -105,5 +109,31 @@ describe('workspace space slice', () => {
       totalSizeBytes: 100,
       reclaimableBytes: 0
     })
+  })
+
+  it('dedupes shared repo ids, continues after failure, and refreshes once', async () => {
+    const failure = new Error('remote unavailable')
+    const pruneStaleRegistrations = vi
+      .fn<(args: { repoId: string }) => Promise<void>>()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(undefined)
+    const analyze = vi.fn().mockResolvedValue({ ok: true, analysis: makeAnalysis() })
+    vi.stubGlobal('window', {
+      api: {
+        worktrees: { pruneStaleRegistrations },
+        workspaceSpace: { analyze }
+      }
+    })
+    const store = createWorkspaceSpaceTestStore()
+
+    await expect(
+      store.getState().pruneStaleWorktreeRegistrations(['repo-1', 'repo-1', 'repo-2'])
+    ).rejects.toBe(failure)
+
+    expect(pruneStaleRegistrations.mock.calls).toEqual([
+      [{ repoId: 'repo-1' }],
+      [{ repoId: 'repo-2' }]
+    ])
+    expect(analyze).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/store/slices/workspace-space.ts
+++ b/src/renderer/src/store/slices/workspace-space.ts
@@ -16,6 +16,7 @@ export type WorkspaceSpaceSlice = {
   cancelWorkspaceSpaceScan: () => Promise<boolean>
   refreshWorkspaceSpace: () => Promise<WorkspaceSpaceAnalysis>
   removeWorkspaceSpaceWorktrees: (worktreeIds: readonly string[]) => void
+  pruneStaleWorktreeRegistrations: (repoIds: readonly string[]) => Promise<void>
 }
 
 function removeDeletedWorktreesFromAnalysis(
@@ -160,5 +161,15 @@ export const createWorkspaceSpaceSlice: StateCreator<AppState, [], [], Workspace
           }
         : state
     )
+  },
+  pruneStaleWorktreeRegistrations: async (repoIds) => {
+    if (repoIds.length === 0) {
+      return
+    }
+    get().recordFeatureInteraction?.('workspace-cleanup')
+    for (const repoId of repoIds) {
+      await window.api.worktrees.pruneStaleRegistrations({ repoId })
+    }
+    await get().refreshWorkspaceSpace()
   }
 })

--- a/src/renderer/src/store/slices/workspace-space.ts
+++ b/src/renderer/src/store/slices/workspace-space.ts
@@ -167,9 +167,23 @@ export const createWorkspaceSpaceSlice: StateCreator<AppState, [], [], Workspace
       return
     }
     get().recordFeatureInteraction?.('workspace-cleanup')
-    for (const repoId of repoIds) {
-      await window.api.worktrees.pruneStaleRegistrations({ repoId })
+    let firstError: unknown
+    // Why: one project id can appear once per host, while IPC already fans that id out to all hosts.
+    for (const repoId of new Set(repoIds)) {
+      try {
+        await window.api.worktrees.pruneStaleRegistrations({ repoId })
+      } catch (error) {
+        firstError ??= error
+      }
     }
-    await get().refreshWorkspaceSpace()
+    try {
+      // Why: successful repos must disappear from the notice even when another host failed.
+      await get().refreshWorkspaceSpace()
+    } catch (error) {
+      firstError ??= error
+    }
+    if (firstError) {
+      throw firstError
+    }
   }
 })

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1437,6 +1437,9 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
     forgetLocal: () => {
       throw new Error('Forgetting a workspace is unavailable in paired web clients.')
     },
+    pruneStaleRegistrations: () => {
+      throw new Error('Pruning stale worktree registrations is unavailable in paired web clients.')
+    },
     forceDeletePreservedBranch: ({ worktreeId, branchName, expectedHead }) =>
       callRuntimeResult<ForceDeleteWorktreeBranchResult>('worktree.forceDeleteBranch', {
         worktree: toRuntimeWorktreeSelector(worktreeId),

--- a/src/shared/workspace-space-types.ts
+++ b/src/shared/workspace-space-types.ts
@@ -46,6 +46,9 @@ export type WorkspaceSpaceRepoSummary = {
   worktreeCount: number
   scannedWorktreeCount: number
   unavailableWorktreeCount: number
+  /** Prunable git registrations (directory deleted without `git worktree
+   *  prune`) omitted from the rows but still reconcilable via prune. */
+  staleRegistrationCount: number
   totalSizeBytes: number
   reclaimableBytes: number
   error: string | null
@@ -58,6 +61,7 @@ export type WorkspaceSpaceAnalysis = {
   worktreeCount: number
   scannedWorktreeCount: number
   unavailableWorktreeCount: number
+  staleRegistrationCount: number
   repos: WorkspaceSpaceRepoSummary[]
   worktrees: WorkspaceSpaceWorktree[]
 }


### PR DESCRIPTION
## Summary

Follow-up to #8409. That PR stopped surfacing **prunable** worktree registrations (git registry entry whose directory was deleted without `git worktree prune`) as live workspaces — including in the Space page, which no longer renders them as dead "Missing" rows. But those registrations still pin their branches as checked out, and there was no in-app way to clean them up.

This adds that affordance. It was flagged on #8409 by a reviewer who hit it on macOS: a reboot cleared 16 worktree directories under `/private/tmp` while their registrations remained, blocking 15 branches, with `git worktree prune` in a terminal the only remedy.

With this change, the Space scan **counts** prunable registrations (instead of only dropping them) and shows a small notice when any exist:

> ⚠ 3 stale worktree registrations from deleted directories.  **[ Prune ]**

**Prune** runs git's own `git worktree prune` for each affected repo. Git only drops registrations whose directory is gone and **preserves locked ones** (Orca locks worktrees for active agent sessions), so nothing live is touched; branches and their commits are untouched by design.


## Screenshots

The new UI is a single notice on the Space page when prunable registrations exist, with a **Prune** button:

![Space stale-registrations notice with Prune button](https://raw.githubusercontent.com/stablyai/orca/pr-assets/8910-space-prune/space-prune-banner-closeup.png)

Full page — notice in context (2 stale registrations here; rows still show only the live worktrees):

![Space page with the stale-registrations notice](https://raw.githubusercontent.com/stablyai/orca/pr-assets/8910-space-prune/space-prune-page.png)

After clicking **Prune** — the notice is gone, git's registry is reconciled, and the pruned branches survive:

![Space page after pruning](https://raw.githubusercontent.com/stablyai/orca/pr-assets/8910-space-prune/space-after-prune.png)

_Captured from a Playwright + Electron run on this branch (rebased onto `main` after #8409 merged)._
## Implementation

- **Scan**: `staleRegistrationCount` added to `WorkspaceSpaceRepoSummary` / `WorkspaceSpaceAnalysis`; the existing prunable filter now counts what it omits.
- **Git op**: `pruneWorktrees()` (local + WSL, read-cache invalidation) and a dedicated relay `git.pruneWorktrees` op for SSH. The generic `git.exec` relay channel is deliberately read-only, so remote prune needs its own op. An older deployed relay that predates it rejects with "Method not found" → the IPC surfaces a clear "reconnect to update, or run `git worktree prune` there" message instead of a protocol error.
- **IPC** `worktrees:pruneStaleRegistrations` prunes every store repo matching the id (multi-host-safe), then notifies worktree-change; the store action refreshes the scan. Web/paired clients get an explicit unsupported-here error, matching the existing `forgetLocal` pattern.
- **UI**: a notice + Prune button styled like the panel's sibling notices, with busy state and success/error toasts.

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` for the touched areas (space analysis, git worktree paths, worktree IPC, store slice, web preload)
- [x] Validated end-to-end in Electron

New coverage:
- Real-git integration: prune removes a stale registration, **keeps its branch**, and **leaves a locked+missing registration intact** (`worktree-list-paths.test.ts`).
- IPC routing: local repo → `pruneWorktrees`; SSH repo → provider; old relay ("Method not found") → clear error (`worktrees.test.ts`).
- Scan counts prunable registrations (`workspace-space-analysis.test.ts`).

**Electron validation**: fixture repo with a live worktree + stale registrations; the banner showed the count, a real click on **Prune** cleared it, git's registry went from N+live to just `main` + live, and every `stale-*` branch survived. Local review screenshots (uncommitted) are under `validation-screenshots/`.

