### PR TITLE
Confirm before merging a PR/MR from the sidebar strategy dropdown

### DIFF
--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx
@@ -46,14 +46,25 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
   } as Repo
 }
 
-function HookProbe(props: { repo: Repo; onRefreshReview: () => Promise<void> }): null {
+type ProviderOverrides = {
+  review?: HostedReviewActionInfo
+  isGitLab?: boolean
+  shortLabel?: string
+  reviewLabel?: string
+}
+
+function HookProbe(props: {
+  repo: Repo
+  onRefreshReview: () => Promise<void>
+  overrides?: ProviderOverrides
+}): null {
   latest = useHostedReviewActions({
-    review,
+    review: props.overrides?.review ?? review,
     githubPR,
     repo: props.repo,
-    isGitLab: false,
-    shortLabel: 'PR',
-    reviewLabel: 'pull request',
+    isGitLab: props.overrides?.isGitLab ?? false,
+    shortLabel: props.overrides?.shortLabel ?? 'PR',
+    reviewLabel: props.overrides?.reviewLabel ?? 'pull request',
     defaultMergeMethod: 'squash',
     autoMergeAction: null,
     onRefreshReview: props.onRefreshReview
@@ -61,12 +72,16 @@ function HookProbe(props: { repo: Repo; onRefreshReview: () => Promise<void> }):
   return null
 }
 
-async function renderHook(repo: Repo, onRefreshReview = vi.fn().mockResolvedValue(undefined)) {
+async function renderHook(
+  repo: Repo,
+  onRefreshReview = vi.fn().mockResolvedValue(undefined),
+  overrides?: ProviderOverrides
+) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
   await act(async () => {
-    root?.render(createElement(HookProbe, { repo, onRefreshReview }))
+    root?.render(createElement(HookProbe, { repo, onRefreshReview, overrides }))
   })
   return { onRefreshReview }
 }
@@ -139,5 +154,63 @@ describe('useHostedReviewActions', () => {
     })
     expect(runtimeRpcMocks.callRuntimeRpc).not.toHaveBeenCalled()
     expect(onRefreshReview).toHaveBeenCalledTimes(1)
+  })
+
+  it('confirms before merging with the selected strategy label (#7943)', async () => {
+    await renderHook(makeRepo())
+
+    await act(async () => {
+      await latest?.handleMerge('merge')
+    })
+
+    expect(confirmationMocks.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Create merge commit PR #1015?',
+        confirmLabel: 'Create merge commit'
+      })
+    )
+  })
+
+  it('does not merge when the confirmation is cancelled (#7943)', async () => {
+    confirmationMocks.confirm.mockResolvedValue(false)
+    const { onRefreshReview } = await renderHook(makeRepo())
+
+    await act(async () => {
+      await latest?.handleMerge('squash')
+    })
+
+    expect(confirmationMocks.confirm).toHaveBeenCalledTimes(1)
+    expect(window.api.gh.mergePR).not.toHaveBeenCalled()
+    expect(runtimeRpcMocks.callRuntimeRpc).not.toHaveBeenCalled()
+    expect(onRefreshReview).not.toHaveBeenCalled()
+  })
+
+  it('confirms GitLab MR merges with provider-aware copy (#7943)', async () => {
+    await renderHook(makeRepo(), undefined, {
+      review: {
+        provider: 'gitlab',
+        number: 42,
+        state: 'open',
+        status: 'success',
+        mergeable: 'MERGEABLE'
+      },
+      isGitLab: true,
+      shortLabel: 'MR',
+      reviewLabel: 'merge request'
+    })
+
+    await act(async () => {
+      await latest?.handleMerge('squash')
+    })
+
+    expect(confirmationMocks.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Squash and merge MR !42?' })
+    )
+    expect(window.api.gl.mergeMR).toHaveBeenCalledWith({
+      repoPath: '/repo',
+      repoId: 'repo-1',
+      iid: 42,
+      method: 'squash'
+    })
   })
 })

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -5,6 +5,7 @@ import type { GitHubPRAutoMergeAction } from '@/components/github-pr-merge-state
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { PRInfo, Repo } from '../../../../shared/types'
 import type { GitHubPRMergeMethod } from '../../../../shared/types'
+import { GITHUB_PR_MERGE_METHOD_LABELS } from '../../../../shared/github-pr-merge-methods'
 import {
   mergeGitHubHostedReview,
   setGitHubHostedReviewAutoMerge,
@@ -63,6 +64,21 @@ export function useHostedReviewActions({
 
   const handleMerge = useCallback(
     async (method: GitHubPRMergeMethod = defaultMergeMethod) => {
+      // Why: choosing a strategy from the merge dropdown must not merge on its
+      // own — confirm first, matching every other PR/MR merge surface (#7943).
+      const label = GITHUB_PR_MERGE_METHOD_LABELS[method]
+      const confirmed = await confirm({
+        title: `${label} ${shortLabel} ${isGitLab ? '!' : '#'}${review.number}?`,
+        description: translate(
+          'auto.components.right.sidebar.use.hosted.review.actions.e475c29b17',
+          'This will merge the {{value0}}.',
+          { value0: reviewLabel }
+        ),
+        confirmLabel: label
+      })
+      if (!confirmed) {
+        return
+      }
       setMerging(true)
       setActionError(null)
       try {
@@ -90,7 +106,17 @@ export function useHostedReviewActions({
         setMerging(false)
       }
     },
-    [githubPR?.prRepo, isGitLab, defaultMergeMethod, onRefreshReview, repo, review.number]
+    [
+      confirm,
+      githubPR?.prRepo,
+      isGitLab,
+      shortLabel,
+      reviewLabel,
+      defaultMergeMethod,
+      onRefreshReview,
+      repo,
+      review.number
+    ]
   )
 
   const handleAutoMerge = useCallback(async () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9944,6 +9944,13 @@
                   "cfafa92509": "No unresolved conflicts to send."
                 }
               }
+            },
+            "hosted": {
+              "review": {
+                "actions": {
+                  "e475c29b17": "This will merge the {{value0}}."
+                }
+              }
             }
           },
           "fileExplorerOperationOwner": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9944,6 +9944,13 @@
                   "cfafa92509": "No hay conflictos sin resolver para enviar."
                 }
               }
+            },
+            "hosted": {
+              "review": {
+                "actions": {
+                  "e475c29b17": "This will merge the {{value0}}."
+                }
+              }
             }
           },
           "fileExplorerOperationOwner": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9944,6 +9944,13 @@
                   "cfafa92509": "送信する未解決の競合はありません。"
                 }
               }
+            },
+            "hosted": {
+              "review": {
+                "actions": {
+                  "e475c29b17": "This will merge the {{value0}}."
+                }
+              }
             }
           },
           "fileExplorerOperationOwner": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9944,6 +9944,13 @@
                   "cfafa92509": "보낼 해결되지 않은 충돌이 없습니다."
                 }
               }
+            },
+            "hosted": {
+              "review": {
+                "actions": {
+                  "e475c29b17": "This will merge the {{value0}}."
+                }
+              }
             }
           },
           "fileExplorerOperationOwner": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9944,6 +9944,13 @@
                   "cfafa92509": "没有未解决的冲突需要发送。"
                 }
               }
+            },
+            "hosted": {
+              "review": {
+                "actions": {
+                  "e475c29b17": "This will merge the {{value0}}."
+                }
+              }
             }
           },
           "fileExplorerOperationOwner": {


### PR DESCRIPTION
## What changes

In the right-sidebar Checks panel, the PR/MR merge control let you pick a merge
strategy from a dropdown. Selecting a strategy there **merged the PR/MR
immediately, with no confirmation** — so opening the dropdown just to switch
strategy (e.g. Squash → Merge commit) merged on the spot. This adds the missing
confirmation dialog to that surface: selecting a strategy now asks
"Squash and merge PR #N?" (or "… MR !N?") before merging.

## What does NOT change

The merge itself still works when you confirm — this only inserts the
confirmation step. The merge control stays a per-method split button (matching
GitHub's own merge box); it is **not** redesigned into a persistent "selection"
that requires a second, separate merge button. Auto-merge enable/disable and
close/reopen are untouched (close/reopen already confirmed).

## Root cause

The merge split button is rendered by four surfaces. Three —
`PullRequestPage`, `GitHubItemDialog`, `TaskPage` — already gate `handleMerge`
behind a confirmation dialog. The fourth, the right-sidebar hosted-review panel
(`use-hosted-review-actions.ts` `handleMerge`), never got that gate, even though
the close/reopen path in the *same* hook does confirm. So the hosted-review merge
path was the lone un-gated destructive merge, and it is the surface the reporter
hit.

## Design approach

Add the confirmation to `use-hosted-review-actions.ts` `handleMerge`, mirroring
the close/reopen confirm already in that hook. Provider-aware via the hook's
existing `shortLabel`/`reviewLabel`/`isGitLab` params, so it reads
"Squash and merge PR #N?" for GitHub and "Squash and merge MR !N?" for GitLab.
Method label reuses `GITHUB_PR_MERGE_METHOD_LABELS` (the exact label the dropdown
item shows). One provider-neutral locale string was added
("This will merge the {{value0}}.") via the repo's locale-catalog sync.

## Design review

Reviewed against the original report and the three sibling merge surfaces. The
one interpretation to flag: the reporter framed it as "selecting a strategy
should only change the selection." The app's actual design is a per-method merge
action (GitHub merge-box shape), not a two-step select-then-merge; rebuilding
that would diverge from the other three surfaces and GitHub's UX. The minimal,
consistent remedy — already shipped on those surfaces — is the confirmation gate,
so a strategy click can no longer merge without an explicit confirm. Chosen
deliberately.

## Implementation & completeness

Only `handleMerge` changed (plus its `useCallback` deps and the new import). The
merge routing (runtime-host RPC vs desktop IPC vs GitLab `gl.mergeMR`), error
handling, auto-merge, and close/reopen are byte-unchanged. Headline behavior:
**implemented** and live-verified.

## Broad app consistency

Source-of-truth behavior: "selecting a merge method confirms before merging,"
already in `PullRequestPage`/`GitHubItemDialog`/`TaskPage` and the close/reopen
path here. Only the hosted-review merge path disagreed; this PR aligns it and
preserves the other four surfaces. GitLab MRs use the same code path and get the
provider-aware copy.

## Risks / non-goals

- The sidebar **primary** merge button now also confirms (it too merged in one
  click before). This matches the primary buttons on the other three surfaces —
  intended parity, not a regression.
- Non-goals: auto-merge, close/reopen, GitLab merge semantics beyond copy, and
  any redesign of the split button into a stateful selector.

## perf

No hot path touched — one `await confirm()` (an existing shared dialog) before an
existing async IPC on user click. No polling, render churn, new subscriptions, or
startup cost. No measurement needed.

## Code review

Two independent reviewers, same round — both **CLEAN** (no actionable findings).
They verified: confirm-gate correctness, complete `useCallback` deps + `confirm`
referential stability, provider-aware title for GitHub/GitLab, i18n parity across
all five catalogs, no regression to the merge-routing/auto-merge/close-reopen
paths, and that the new tests fail if the fix is reverted.

## Validation

Live A/B in the dev Electron build with a non-destructive intercept (a gh-CLI
shim that blocks and logs every mutation, so no real PR could ever merge):
- **Before (buggy build):** selecting "Squash and merge" fired `gh pr merge
  --squash` immediately, no confirmation.
- **After (this fix):** selecting a strategy shows the confirmation dialog and
  fires no merge; **Cancel** → no merge; **Confirm** → the merge runs (blocked by
  the intercept). The reproduction PR stayed OPEN throughout — every merge
  attempt was blocked.

Tests: `use-hosted-review-actions.test.tsx` — 5/5 pass (added cancel = no merge,
GitHub confirm-label, and a GitLab `MR !N?` variant). Static: web typecheck,
oxlint, and `verify:localization-catalog` all clean.

Fixes #7943
