### PR TITLE
Prevent adding the same Claude account twice

### DIFF
--- a/src/main/claude-accounts/claude-duplicate-account.test.ts
+++ b/src/main/claude-accounts/claude-duplicate-account.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import type { ClaudeManagedAccount } from '../../shared/types'
+import {
+  findDuplicateClaudeAccount,
+  type ClaudeAccountIdentityCandidate
+} from './claude-duplicate-account'
+
+function makeAccount(overrides: Partial<ClaudeManagedAccount> = {}): ClaudeManagedAccount {
+  return {
+    id: 'existing-account',
+    email: 'host@x.com',
+    managedAuthPath: '/managed/existing-account/auth',
+    authMethod: 'subscription-oauth',
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeCandidate(
+  overrides: Partial<ClaudeAccountIdentityCandidate> = {}
+): ClaudeAccountIdentityCandidate {
+  return {
+    email: 'host@x.com',
+    organizationUuid: null,
+    managedAuthRuntime: 'host',
+    wslDistro: null,
+    ...overrides
+  }
+}
+
+describe('findDuplicateClaudeAccount', () => {
+  it('returns the existing account on an exact host match', () => {
+    const account = makeAccount({ managedAuthRuntime: 'host', organizationUuid: null })
+    expect(findDuplicateClaudeAccount([account], makeCandidate())?.id).toBe('existing-account')
+  })
+
+  it('returns null when the organization differs', () => {
+    const account = makeAccount({ managedAuthRuntime: 'host', organizationUuid: 'org-A' })
+    expect(
+      findDuplicateClaudeAccount([account], makeCandidate({ organizationUuid: 'org-B' }))
+    ).toBe(null)
+  })
+
+  it('returns null when a wsl candidate is compared against a host account', () => {
+    const account = makeAccount({ managedAuthRuntime: 'host', organizationUuid: 'org-A' })
+    expect(
+      findDuplicateClaudeAccount(
+        [account],
+        makeCandidate({ organizationUuid: 'org-A', managedAuthRuntime: 'wsl', wslDistro: 'Ubuntu' })
+      )
+    ).toBe(null)
+  })
+
+  it('returns null when both are wsl but on different distros', () => {
+    const account = makeAccount({
+      managedAuthRuntime: 'wsl',
+      wslDistro: 'Ubuntu',
+      organizationUuid: 'org-A'
+    })
+    expect(
+      findDuplicateClaudeAccount(
+        [account],
+        makeCandidate({ organizationUuid: 'org-A', managedAuthRuntime: 'wsl', wslDistro: 'Debian' })
+      )
+    ).toBe(null)
+  })
+
+  it('returns the account when both are wsl on the same distro', () => {
+    const account = makeAccount({
+      managedAuthRuntime: 'wsl',
+      wslDistro: 'Ubuntu',
+      organizationUuid: 'org-A'
+    })
+    expect(
+      findDuplicateClaudeAccount(
+        [account],
+        makeCandidate({ organizationUuid: 'org-A', managedAuthRuntime: 'wsl', wslDistro: 'Ubuntu' })
+      )?.id
+    ).toBe('existing-account')
+  })
+
+  it('matches a legacy account with undefined runtime against a host candidate', () => {
+    // managedAuthRuntime omitted → undefined normalizes to 'host'.
+    const account = makeAccount({ organizationUuid: null })
+    expect(findDuplicateClaudeAccount([account], makeCandidate())?.id).toBe('existing-account')
+  })
+
+  it('treats an existing undefined org as equal to a candidate null org', () => {
+    // organizationUuid omitted → undefined, candidate is explicit null.
+    const account = makeAccount({ managedAuthRuntime: 'host' })
+    expect(
+      findDuplicateClaudeAccount([account], makeCandidate({ organizationUuid: null }))?.id
+    ).toBe('existing-account')
+  })
+
+  it('matches when the email differs only by case and whitespace', () => {
+    const account = makeAccount({ managedAuthRuntime: 'host', email: 'Host@X.com ' })
+    expect(findDuplicateClaudeAccount([account], makeCandidate({ email: 'host@x.com' }))?.id).toBe(
+      'existing-account'
+    )
+  })
+
+  it('returns null when the candidate email is null', () => {
+    const account = makeAccount({ managedAuthRuntime: 'host' })
+    expect(findDuplicateClaudeAccount([account], makeCandidate({ email: null }))).toBe(null)
+  })
+
+  it('returns null for an empty accounts array', () => {
+    expect(findDuplicateClaudeAccount([], makeCandidate())).toBe(null)
+  })
+})

--- a/src/main/claude-accounts/claude-duplicate-account.ts
+++ b/src/main/claude-accounts/claude-duplicate-account.ts
@@ -1,0 +1,55 @@
+import type { ClaudeManagedAccount } from '../../shared/types'
+import { getClaudeWslSelectionKey } from './runtime-selection'
+
+export type ClaudeAccountIdentityCandidate = {
+  email: string | null
+  organizationUuid: string | null
+  managedAuthRuntime: 'host' | 'wsl'
+  wslDistro: string | null
+}
+
+function normalizeEmail(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().toLowerCase()
+  return trimmed ? trimmed : null
+}
+
+function normalizeOrganizationUuid(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function runtimeScopeKey(
+  runtime: 'host' | 'wsl' | undefined,
+  wslDistro: string | null | undefined
+): string {
+  // Why: accounts persisted before the runtime fields existed have
+  // managedAuthRuntime === undefined; treat that as 'host' so a new host add
+  // still matches them (#6616). WSL folds through the same distro-bucket key
+  // runtime-selection.ts uses, so a distro compares equal to its own bucket.
+  const normalizedRuntime = runtime ?? 'host'
+  return normalizedRuntime === 'wsl' ? `wsl:${getClaudeWslSelectionKey(wslDistro)}` : 'host'
+}
+
+// Why: the same Claude email can legitimately belong to two organizations, and
+// host vs WSL (and each WSL distro) keep separate managed-auth stores — so a
+// duplicate is only a match on email + organization + runtime scope, each side
+// normalized so a legacy/undefined field cannot dodge the check (#6616).
+export function findDuplicateClaudeAccount(
+  accounts: readonly ClaudeManagedAccount[],
+  candidate: ClaudeAccountIdentityCandidate
+): ClaudeManagedAccount | null {
+  const email = normalizeEmail(candidate.email)
+  if (!email) {
+    return null
+  }
+  const organizationUuid = normalizeOrganizationUuid(candidate.organizationUuid)
+  const scope = runtimeScopeKey(candidate.managedAuthRuntime, candidate.wslDistro)
+  return (
+    accounts.find(
+      (account) =>
+        normalizeEmail(account.email) === email &&
+        normalizeOrganizationUuid(account.organizationUuid) === organizationUuid &&
+        runtimeScopeKey(account.managedAuthRuntime, account.wslDistro) === scope
+    ) ?? null
+  )
+}

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- test suite covers Claude capture and rollback edge cases */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
@@ -669,6 +669,156 @@ describe('ClaudeAccountService credential capture', () => {
     expect(rateLimits.evictInactiveClaudeCache).toHaveBeenCalledWith(
       settings.claudeManagedAccounts[1].id
     )
+  })
+
+  it('rejects adding a Claude account whose identity already exists', async () => {
+    setPlatform('linux')
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const existingAuthPath = join(tempDir, 'claude-accounts', 'existing-account', 'auth')
+    mkdirSync(existingAuthPath, { recursive: true })
+    const existingMarkerPath = join(existingAuthPath, '.orca-managed-claude-auth')
+    writeFileSync(existingMarkerPath, 'existing-account\n', 'utf-8')
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'existing-account',
+          email: 'new@example.com',
+          managedAuthPath: existingAuthPath,
+          managedAuthRuntime: 'host',
+          wslDistro: null,
+          wslLinuxAuthPath: null,
+          authMethod: 'subscription-oauth',
+          organizationUuid: null,
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'existing-account',
+      activeClaudeManagedAccountIdsByRuntime: { host: 'existing-account', wsl: {} }
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      syncForCurrentSelection: vi.fn(async () => {}),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+    }
+    const rateLimits = {
+      evictInactiveClaudeCache: vi.fn(),
+      refreshForClaudeAccountChange: vi.fn(async () => ({ accounts: [], activeAccountId: null }))
+    }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: string | null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: null, organizationName: null }
+    }))
+
+    await expect(service.addAccount({ runtime: 'host' })).rejects.toThrow(
+      'This Claude account is already added.'
+    )
+
+    expect(settings.claudeManagedAccounts).toHaveLength(1)
+    expect(readFileSync(existingMarkerPath, 'utf-8')).toBe('existing-account\n')
+    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).toHaveBeenCalled()
+    // The rejected add's throwaway managed-auth dir must be cleaned up, leaving
+    // only the pre-existing account's dir behind.
+    expect(readdirSync(join(tempDir, 'claude-accounts')).sort()).toEqual(['existing-account'])
+  })
+
+  it('adds a Claude account with the same email under a different organization', async () => {
+    setPlatform('linux')
+    tempDir = '/tmp/orca-claude-service-test'
+    rmSync(tempDir, { recursive: true, force: true })
+    const existingAuthPath = join(tempDir, 'claude-accounts', 'existing-account', 'auth')
+    mkdirSync(existingAuthPath, { recursive: true })
+    writeFileSync(
+      join(existingAuthPath, '.orca-managed-claude-auth'),
+      'existing-account\n',
+      'utf-8'
+    )
+    let settings = {
+      claudeManagedAccounts: [
+        {
+          id: 'existing-account',
+          email: 'new@example.com',
+          managedAuthPath: existingAuthPath,
+          managedAuthRuntime: 'host',
+          wslDistro: null,
+          wslLinuxAuthPath: null,
+          authMethod: 'subscription-oauth',
+          organizationUuid: 'org-A',
+          organizationName: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeClaudeManagedAccountId: 'existing-account',
+      activeClaudeManagedAccountIdsByRuntime: { host: 'existing-account', wsl: {} }
+    }
+    const store = {
+      getSettings: vi.fn(() => settings),
+      updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+        settings = { ...settings, ...updates }
+        return settings
+      })
+    }
+    const runtimeAuth = {
+      clearLastWrittenCredentialsJson: vi.fn(),
+      syncForCurrentSelection: vi.fn(async () => {}),
+      forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {})
+    }
+    const rateLimits = {
+      evictInactiveClaudeCache: vi.fn(),
+      refreshForClaudeAccountChange: vi.fn(async () => ({ accounts: [], activeAccountId: null }))
+    }
+    const { ClaudeAccountService } = await import('./service')
+    const service = new ClaudeAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeAuth as never
+    )
+    ;(
+      service as unknown as {
+        runClaudeLoginAndCapture(): Promise<{
+          credentialsJson: string
+          oauthAccount: unknown
+          identity: { email: string; organizationUuid: string | null; organizationName: null }
+        }>
+      }
+    ).runClaudeLoginAndCapture = vi.fn(async () => ({
+      credentialsJson: '{"new":true}\n',
+      oauthAccount: { newOauth: true },
+      identity: { email: 'new@example.com', organizationUuid: 'org-B', organizationName: null }
+    }))
+
+    await service.addAccount({ runtime: 'host' })
+
+    expect(settings.claudeManagedAccounts).toHaveLength(2)
+    expect(settings.claudeManagedAccounts[1].email).toBe('new@example.com')
+    expect(settings.claudeManagedAccounts[1].organizationUuid).toBe('org-B')
   })
 
   it('switches the active Claude account while PTYs are live', async () => {

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -741,7 +741,10 @@ describe('ClaudeAccountService credential capture', () => {
 
     expect(settings.claudeManagedAccounts).toHaveLength(1)
     expect(readFileSync(existingMarkerPath, 'utf-8')).toBe('existing-account\n')
-    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).toHaveBeenCalled()
+    // The guard fires before credentials/settings change, so rollback I/O
+    // would only add latency and could mask the duplicate error.
+    expect(store.updateSettings).not.toHaveBeenCalled()
+    expect(runtimeAuth.forceMaterializeCurrentSelectionForRollback).not.toHaveBeenCalled()
     // The rejected add's throwaway managed-auth dir must be cleaned up, leaving
     // only the pre-existing account's dir behind.
     expect(readdirSync(join(tempDir, 'claude-accounts')).sort()).toEqual(['existing-account'])

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -30,6 +30,7 @@ import {
   writeManagedClaudeKeychainCredentials
 } from './keychain'
 import { beginClaudeAuthSwitch, endClaudeAuthSwitch } from './live-pty-gate'
+import { findDuplicateClaudeAccount } from './claude-duplicate-account'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { toWindowsWslPath } from '../wsl'
 import { buildEncodedWslBashCommand } from '../wsl-bash-command'
@@ -144,6 +145,19 @@ export class ClaudeAccountService {
       const captured = await this.runClaudeLoginAndCapture(managedAuth)
       if (!captured.identity.email) {
         throw new Error('Claude login completed, but Orca could not resolve the account email.')
+      }
+      // Why: re-adding the same identity would create a duplicate row that
+      // confuses account selection and rate-limit tracking (#6616). The per-row
+      // Re-authenticate action already covers users who want to refresh creds.
+      if (
+        findDuplicateClaudeAccount(previousSettings.claudeManagedAccounts, {
+          email: captured.identity.email,
+          organizationUuid: captured.identity.organizationUuid,
+          managedAuthRuntime: managedAuth.managedAuthRuntime,
+          wslDistro: managedAuth.wslDistro
+        })
+      ) {
+        throw new Error('This Claude account is already added.')
       }
       await this.writeManagedAuth(accountId, managedAuthPath, captured)
 

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -140,15 +140,15 @@ export class ClaudeAccountService {
     const managedAuth = this.createManagedAuthDir(accountId, target)
     const { managedAuthPath } = managedAuth
     const previousSettings = this.store.getSettings()
+    let duplicateIdentityFound = false
 
     try {
       const captured = await this.runClaudeLoginAndCapture(managedAuth)
       if (!captured.identity.email) {
         throw new Error('Claude login completed, but Orca could not resolve the account email.')
       }
-      // Why: re-adding the same identity would create a duplicate row that
-      // confuses account selection and rate-limit tracking (#6616). The per-row
-      // Re-authenticate action already covers users who want to refresh creds.
+      // Why: duplicate rows confuse account selection and rate-limit tracking;
+      // the per-row Re-authenticate action already refreshes credentials.
       if (
         findDuplicateClaudeAccount(previousSettings.claudeManagedAccounts, {
           email: captured.identity.email,
@@ -157,6 +157,7 @@ export class ClaudeAccountService {
           wslDistro: managedAuth.wslDistro
         })
       ) {
+        duplicateIdentityFound = true
         throw new Error('This Claude account is already added.')
       }
       await this.writeManagedAuth(accountId, managedAuthPath, captured)
@@ -187,8 +188,12 @@ export class ClaudeAccountService {
       this.rateLimits.evictInactiveClaudeCache(accountId)
       return this.getSnapshot()
     } catch (error) {
-      this.restoreClaudeSettings(previousSettings)
-      await this.runtimeAuth.forceMaterializeCurrentSelectionForRollback()
+      // Duplicate detection precedes every credential/settings write, so only
+      // its throwaway auth directory needs cleanup.
+      if (!duplicateIdentityFound) {
+        this.restoreClaudeSettings(previousSettings)
+        await this.runtimeAuth.forceMaterializeCurrentSelectionForRollback()
+      }
       await this.safeRemoveManagedAuth(accountId, managedAuthPath)
       throw error
     }


### PR DESCRIPTION
## What changes

Adding the **same** Claude subscription twice in Settings → AI Provider Accounts no longer creates a duplicate row. When you click **Add Account** and complete the login as an account that is already in the list, Orca now rejects the add with a clear message — "This Claude account is already added." — and leaves the existing row untouched.

Fixes #6616.

## What does not change

- A genuinely new account still adds normally.
- The **same email under a different organization** is still addable (those are distinct accounts).
- Host and WSL (and each WSL distro) still keep independent accounts — the same subscription can be added once per runtime, because each runtime has its own managed-auth store.
- No retroactive cleanup of accounts that are *already* duplicated in a user's settings; this only prevents *new* duplicates. Existing duplicates can still be removed with the per-row **Remove** button.

## Design

`ClaudeAccountService.doAddAccount` (`src/main/claude-accounts/service.ts`) unconditionally appended the captured account with no identity check — the root cause. The fix adds a guard immediately after the login capture and before the account is persisted: if the captured identity matches an existing managed account, it throws, and the pre-existing rollback path (`restoreClaudeSettings` + `safeRemoveManagedAuth`) cleans up the throwaway auth dir.

Identity matching lives in a new pure module `src/main/claude-accounts/claude-duplicate-account.ts` (`findDuplicateClaudeAccount`) so it is unit-testable and does not grow the already-large service file. Two accounts are "the same" only when **email + organizationUuid + runtime scope** all match:

- **email + organizationUuid** (not email alone): the same Claude email can legitimately belong to two organizations.
- **runtime scope** (`managedAuthRuntime` + `wslDistro`, folded through the existing `getClaudeWslSelectionKey`): host vs WSL vs each distro are separate auth contexts.
- Both sides are normalized (email lower/trim, org trim, `undefined` runtime → `host`, `undefined`/`null` org folded together) so an account persisted by an **older Orca build** — before the runtime fields existed — still matches a fresh host add. Without that normalization the exact duplicate would slip through on macOS, which is the reporter's platform.

Blocking (rather than silently folding the add into a re-authentication of the existing account) was the deliberate choice: it matches the reporter's expectation ("it shouldn't let us do it"), keeps the diff small and self-contained, and avoids a hidden credential mutation the user didn't ask for — the per-row **Re-authenticate** action already exists for that.

## Design review

Reviewed against the original issue via an adversarial design pass. It caught one real correctness gap in the first draft: a naive `managedAuthRuntime === 'host'` comparison would fail to match a legacy account whose `managedAuthRuntime` is `undefined`, silently under-blocking the exact duplicate on macOS. The identity key was updated to normalize both sides (and reuse `getClaudeWslSelectionKey` for WSL bucketing) to close that.

## Implementation and deviations

Three product edits, no deviations from the reviewed design: the new pure matcher, the guard in `doAddAccount`, and tests. No renderer change is needed — the thrown message propagates through the existing IPC → `getClaudeAccountErrorDescription` → toast path intact.

## Completeness / headline behavior

**Headline behavior: implemented.** The production `doAddAccount` path executes the guard; verified live in the running app (not just tests) — see Validation below.

## Broad app consistency

- Source-of-truth surface is the Claude section of AccountsPane; the error surfaces through the same `toast.error(...)` path every other Claude account action already uses, so no new UI or copy pattern is introduced.
- The **Codex** provider has the same unguarded append shape in `codex-accounts/service.ts`, and the per-row **Re-authenticate** flow for Claude is likewise unguarded. Both are intentionally **out of scope** for #6616 (which is specifically the Claude "Add twice" flow) and are noted as follow-up candidates rather than folded in, to keep this PR on one thing.

## Risks, ambiguities, non-goals

- **Post-login detection**: identity is only knowable after the OAuth login completes, so the "already added" rejection lands after the user signs in. Unavoidable — there is no earlier point to check who they are. Accepted.
- **Non-goals**: retroactive de-duplication of existing dupes; Codex duplicates; the re-authenticate path.
- **Fail-open edge**: if the same account captured an org UUID on one add and none on another, the two would not match and a duplicate could slip through — accepted as strictly safer than email-only matching, which would falsely merge two legitimate same-email organizations.

## Performance

Trivial surface: a synchronous `Array.find` over `claudeManagedAccounts` (a handful of entries), run once per manual **Add Account** click after a multi-second interactive login. No hot path, polling, render churn, or startup cost. No measurement warranted.

## Code review

Two independent adversarial reviewers ran on the diff (correctness/security lens and simplification/edge-case/cross-platform lens). Both returned clean — no P0/P1/P2 findings — after independently tracing the macOS host case, the legacy-`undefined` normalization, the scoped cleanup on rejection, TOCTOU safety (the add runs inside the serialized mutation queue), and error propagation to the toast. One test-rigor nit (assert the throwaway dir is actually removed) was applied.

## Validation

- **Targeted unit tests: 35/35 pass** — `claude-duplicate-account.test.ts` (11 cases incl. legacy-undefined runtime, undefined-vs-null org, case/whitespace, host-vs-WSL, per-distro) and two new `service.test.ts` integration tests (duplicate rejected + list stays length 1 + throwaway dir cleaned up + rollback ran; same email different org still appends).
- **Full `pnpm run typecheck` (node + cli + web): clean.**
- **`oxlint` on changed files: clean.**
- **Live Electron validation (real Settings UI, stubbed `claude` CLI returning a fixed identity):**
  - *Before the fix:* clicking **Add Account** twice produced **two identical rows** (same email + organization).
  - *After the fix:* first add succeeds (one row); the second add completes the login, is **blocked**, the list **stays at one row**, and the toast shows "This Claude account is already added." The main-process log confirms the throw.
  Before/after screenshots were captured during validation.

## Not merged

Opened for review; unmerged.
