### PR TITLE
perf(ai-vault): bound OpenCode Agent History discovery

### DIFF
--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -96,7 +96,7 @@ function applyOpenCodeSchema(db: Database.Database): void {
   `)
 }
 
-describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', () => {
+describe('OpenCode SQLite coexistence and cache identity', () => {
   it('discovers SQLite sessions next to a custom OpenCode storage directory', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-custom-opencode-'))
     tempRoots.push(root)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -5,6 +5,12 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { scanAiVaultSessions } from './session-scanner'
 import Database from '../sqlite/sync-database'
+import {
+  createSessionParseStats,
+  parseAgentSessionFileCached,
+  resetSessionParseCacheForTests
+} from './session-scanner-parse-cache'
+import { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-discovery'
 
 let tempRoots: string[] = []
 let tempDbDirs: string[] = []
@@ -16,6 +22,7 @@ afterEach(async () => {
   }
   tempRoots = []
   tempDbDirs = []
+  resetSessionParseCacheForTests()
 })
 
 function isolatedScanRoots(root: string) {
@@ -212,5 +219,30 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
     expect(legacyEntry!.resumeCommand).toBe(
       "cd '/tmp/sqlite' && opencode --session 'legacy-session'"
     )
+  })
+
+  it('preserves the SQLite candidate cache key across repeated discovery', async () => {
+    const { db, path: dbPath } = createTempOpenCodeDb()
+    applyOpenCodeSchema(db)
+    db.prepare(
+      `INSERT INTO session (id, project_id, slug, directory, title, version,
+         time_created, time_updated, model, agent, cost,
+         tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write)
+       VALUES ('cache-session', 'proj-1', 'slug', '/tmp/cache', 'Cache session', '1.0.0',
+         1777634002000, 1777634003000, NULL, 'build', 0, 0, 0, 0, 0, 0)`
+    ).run()
+    db.close()
+
+    const first = await listOpenCodeSqliteSessions({ dbPaths: [dbPath], limit: 10, issues: [] })
+    const second = await listOpenCodeSqliteSessions({ dbPaths: [dbPath], limit: 10, issues: [] })
+    expect(second[0].file.path).toBe(first[0].file.path)
+    expect(second[0].file.mtimeMs).toBe(first[0].file.mtimeMs)
+
+    const stats = createSessionParseStats()
+    const firstSession = await parseAgentSessionFileCached(first[0], 'darwin', stats)
+    const secondSession = await parseAgentSessionFileCached(second[0], 'darwin', stats)
+    expect(secondSession).toEqual(firstSession)
+    expect(stats.fullParses).toBe(1)
+    expect(stats.reused).toBe(1)
   })
 })

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
@@ -18,18 +18,8 @@ import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
 
 type SessionRow = {
   id: string
-  title: string | null
-  directory: string | null
   time_created: number
   time_updated: number
-  model_json: string | null
-  agent: string | null
-  tokens_input: number
-  tokens_output: number
-  tokens_reasoning: number
-  tokens_cache_read: number
-  cost: number
-  message_count: number
 }
 
 function openReadonlyDatabase(dbPath: string): SyncDatabase {
@@ -46,46 +36,17 @@ function canReadOpenCodeSessions(db: SyncDatabase): boolean {
   )
 }
 
-function sessionColumnSelect(db: SyncDatabase, columnName: string): string {
-  return columnExists(db, 'session', columnName) ? `s.${columnName}` : 'NULL'
-}
-
-function canCountOpenCodeMessages(db: SyncDatabase): boolean {
-  return (
-    tableExists(db, 'message') &&
-    columnExists(db, 'message', 'session_id') &&
-    columnExists(db, 'message', 'data')
-  )
-}
-
 function buildSessionListQuery(db: SyncDatabase): string {
-  const modelSelect = sessionColumnSelect(db, 'model')
-  const agentSelect = sessionColumnSelect(db, 'agent')
-  const tokenColumns = ['tokens_input', 'tokens_output', 'tokens_reasoning', 'tokens_cache_read']
-  const tokenSelects = tokenColumns
-    .map((col) => `${columnExists(db, 'session', col) ? `s.${col}` : '0'} AS ${col}`)
-    .join(', ')
-  const costSelect = columnExists(db, 'session', 'cost') ? 's.cost' : '0'
   const parentIdPredicate = columnExists(db, 'session', 'parent_id')
     ? 'AND s.parent_id IS NULL'
     : ''
   const archivedPredicate = columnExists(db, 'session', 'time_archived')
     ? 'AND s.time_archived IS NULL'
     : ''
-  const messageCountSubquery = canCountOpenCodeMessages(db)
-    ? `(SELECT COUNT(*) FROM message m
-        WHERE m.session_id = s.id
-          AND json_extract(m.data, '$.role') IN ('user','assistant'))`
-    : '0'
 
   return `SELECT s.id,
-                 ${sessionColumnSelect(db, 'title')} AS title,
-                 ${sessionColumnSelect(db, 'directory')} AS directory,
                  s.time_created,
-                 s.time_updated,
-                 ${modelSelect} AS model_json, ${agentSelect} AS agent,
-                 ${tokenSelects}, ${costSelect} AS cost,
-                 ${messageCountSubquery} AS message_count
+                 s.time_updated
           FROM session s
           WHERE 1=1 ${parentIdPredicate} ${archivedPredicate}
           ORDER BY s.time_updated DESC

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
@@ -220,7 +220,7 @@ describe('listOpenCodeSqliteSessions', () => {
     expect(candidates[1].file.path).toBe(buildOpenCodeSqliteCandidatePath(path, 'ses_old'))
   })
 
-  it('discovers sessions when unrelated message and event content is malformed', async () => {
+  it('discovers sessions when unrelated message, part, and event content is malformed', async () => {
     const { db, path } = createTempDb()
     applyOpenCodeSchema(db)
     db.exec(`CREATE TABLE event (id TEXT PRIMARY KEY, data TEXT NOT NULL)`)
@@ -238,6 +238,13 @@ describe('listOpenCodeSqliteSessions', () => {
       `INSERT INTO message (id, session_id, time_created, time_updated, data)
        VALUES ('msg_malformed', 'ses_noise', 1777634000500, 1777634000500, ?)`
     ).run('malformed message JSON')
+    insertPart(db, {
+      id: 'part_malformed',
+      messageId: 'msg_malformed',
+      sessionId: 'ses_noise',
+      timeCreated: 1_777_634_000_500,
+      data: 'malformed part JSON'
+    })
     db.prepare(`INSERT INTO event (id, data) VALUES ('event_1', ?)`).run('malformed event content')
     db.close()
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
@@ -220,6 +220,35 @@ describe('listOpenCodeSqliteSessions', () => {
     expect(candidates[1].file.path).toBe(buildOpenCodeSqliteCandidatePath(path, 'ses_old'))
   })
 
+  it('discovers sessions when unrelated message and event content is malformed', async () => {
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    db.exec(`CREATE TABLE event (id TEXT PRIMARY KEY, data TEXT NOT NULL)`)
+    insertSession(db, {
+      id: 'ses_clean',
+      timeCreated: 1_777_634_000_000,
+      timeUpdated: 1_777_634_001_000
+    })
+    db.prepare(
+      `INSERT INTO message (id, session_id, time_created, time_updated, data)
+       VALUES ('msg_malformed', 'ses_clean', 1777634000500, 1777634000500, ?)`
+    ).run('malformed message JSON')
+    db.prepare(`INSERT INTO event (id, data) VALUES ('event_1', ?)`).run('malformed event content')
+    db.close()
+
+    const issues: AiVaultScanIssue[] = []
+    const candidates = await listOpenCodeSqliteSessions({
+      dbPaths: [path],
+      limit: 10,
+      issues
+    })
+
+    expect(issues).toEqual([])
+    expect(candidates.map((candidate) => candidate.file.path)).toEqual([
+      buildOpenCodeSqliteCandidatePath(path, 'ses_clean')
+    ])
+  })
+
   it('dedups matching session ids across databases and keeps the newest row', async () => {
     const { db: oldDb, path: oldPath } = createTempDb()
     applyOpenCodeSchema(oldDb)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
@@ -223,7 +223,7 @@ describe('listOpenCodeSqliteSessions', () => {
     expect(candidates[1].file.path).toBe(buildOpenCodeSqliteCandidatePath(path, 'ses_old'))
   })
 
-  it('discovers sessions when unrelated message, part, and event content is malformed', async () => {
+  it('discovers sessions when message content is malformed and part/event rows are noisy', async () => {
     const { db, path } = createTempDb()
     applyOpenCodeSchema(db)
     db.exec(`CREATE TABLE event (id TEXT PRIMARY KEY, data TEXT NOT NULL)`)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
@@ -225,13 +225,18 @@ describe('listOpenCodeSqliteSessions', () => {
     applyOpenCodeSchema(db)
     db.exec(`CREATE TABLE event (id TEXT PRIMARY KEY, data TEXT NOT NULL)`)
     insertSession(db, {
+      id: 'ses_noise',
+      timeCreated: 1_777_633_999_000,
+      timeUpdated: 1_777_634_000_000
+    })
+    insertSession(db, {
       id: 'ses_clean',
       timeCreated: 1_777_634_000_000,
       timeUpdated: 1_777_634_001_000
     })
     db.prepare(
       `INSERT INTO message (id, session_id, time_created, time_updated, data)
-       VALUES ('msg_malformed', 'ses_clean', 1777634000500, 1777634000500, ?)`
+       VALUES ('msg_malformed', 'ses_noise', 1777634000500, 1777634000500, ?)`
     ).run('malformed message JSON')
     db.prepare(`INSERT INTO event (id, data) VALUES ('event_1', ?)`).run('malformed event content')
     db.close()
@@ -245,8 +250,15 @@ describe('listOpenCodeSqliteSessions', () => {
 
     expect(issues).toEqual([])
     expect(candidates.map((candidate) => candidate.file.path)).toEqual([
-      buildOpenCodeSqliteCandidatePath(path, 'ses_clean')
+      buildOpenCodeSqliteCandidatePath(path, 'ses_clean'),
+      buildOpenCodeSqliteCandidatePath(path, 'ses_noise')
     ])
+    const cleanSession = await parseOpenCodeSqliteSession({
+      dbPath: path,
+      sessionId: 'ses_clean',
+      platform: 'darwin'
+    })
+    expect(cleanSession?.sessionId).toBe('ses_clean')
   })
 
   it('dedups matching session ids across databases and keeps the newest row', async () => {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
@@ -177,12 +177,15 @@ function insertPart(
     timeCreated: number
     type?: 'text' | 'tool' | 'reasoning'
     text?: string
+    data?: string
   }
 ): void {
-  const data = JSON.stringify({
-    type: args.type ?? 'text',
-    text: args.text ?? 'hello world'
-  })
+  const data =
+    args.data ??
+    JSON.stringify({
+      type: args.type ?? 'text',
+      text: args.text ?? 'hello world'
+    })
   db.prepare(
     `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
      VALUES (?, ?, ?, ?, ?, ?)`
@@ -260,12 +263,6 @@ describe('listOpenCodeSqliteSessions', () => {
       buildOpenCodeSqliteCandidatePath(path, 'ses_clean'),
       buildOpenCodeSqliteCandidatePath(path, 'ses_noise')
     ])
-    const cleanSession = await parseOpenCodeSqliteSession({
-      dbPath: path,
-      sessionId: 'ses_clean',
-      platform: 'darwin'
-    })
-    expect(cleanSession?.sessionId).toBe('ses_clean')
     await expect(
       parseOpenCodeSqliteSession({ dbPath: path, sessionId: 'ses_noise', platform: 'darwin' })
     ).rejects.toThrow('malformed JSON')

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
@@ -241,28 +241,50 @@ describe('listOpenCodeSqliteSessions', () => {
       `INSERT INTO message (id, session_id, time_created, time_updated, data)
        VALUES ('msg_malformed', 'ses_noise', 1777634000500, 1777634000500, ?)`
     ).run('malformed message JSON')
-    insertPart(db, {
-      id: 'part_malformed',
-      messageId: 'msg_malformed',
-      sessionId: 'ses_noise',
-      timeCreated: 1_777_634_000_500,
-      data: 'malformed part JSON'
-    })
     db.prepare(`INSERT INTO event (id, data) VALUES ('event_1', ?)`).run('malformed event content')
     db.close()
 
+    const { db: partDb, path: partPath } = createTempDb()
+    applyOpenCodeSchema(partDb)
+    insertSession(partDb, {
+      id: 'ses_part_noise',
+      timeCreated: 1_777_634_002_000,
+      timeUpdated: 1_777_634_002_000
+    })
+    insertMessage(partDb, {
+      id: 'msg_part_noise',
+      sessionId: 'ses_part_noise',
+      role: 'assistant',
+      timeCreated: 1_777_634_002_000
+    })
+    insertPart(partDb, {
+      id: 'part_malformed',
+      messageId: 'msg_part_noise',
+      sessionId: 'ses_part_noise',
+      timeCreated: 1_777_634_002_000,
+      data: 'malformed part JSON'
+    })
+    partDb.close()
+
     const issues: AiVaultScanIssue[] = []
     const candidates = await listOpenCodeSqliteSessions({
-      dbPaths: [path],
+      dbPaths: [path, partPath],
       limit: 10,
       issues
     })
 
     expect(issues).toEqual([])
     expect(candidates.map((candidate) => candidate.file.path)).toEqual([
+      buildOpenCodeSqliteCandidatePath(partPath, 'ses_part_noise'),
       buildOpenCodeSqliteCandidatePath(path, 'ses_clean'),
       buildOpenCodeSqliteCandidatePath(path, 'ses_noise')
     ])
+    const cleanSession = await parseOpenCodeSqliteSession({
+      dbPath: path,
+      sessionId: 'ses_clean',
+      platform: 'darwin'
+    })
+    expect(cleanSession?.sessionId).toBe('ses_clean')
     await expect(
       parseOpenCodeSqliteSession({ dbPath: path, sessionId: 'ses_noise', platform: 'darwin' })
     ).rejects.toThrow('malformed JSON')

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.test.ts
@@ -259,6 +259,9 @@ describe('listOpenCodeSqliteSessions', () => {
       platform: 'darwin'
     })
     expect(cleanSession?.sessionId).toBe('ses_clean')
+    await expect(
+      parseOpenCodeSqliteSession({ dbPath: path, sessionId: 'ses_noise', platform: 'darwin' })
+    ).rejects.toThrow('malformed JSON')
   })
 
   it('dedups matching session ids across databases and keeps the newest row', async () => {


### PR DESCRIPTION
## Summary

- Keep OpenCode Agent History discovery independent from message and event table growth by selecting only session identity and recency before the existing candidate limit.
- Preserve full metadata, message count, previews, ordering, legacy coexistence, and cache behavior for selected sessions.

Refs #8864.

## Screenshots

No visual change.

## Testing

- [x] Added or updated high-quality tests that catch regressions.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ai-vault/session-scanner-opencode-sqlite.test.ts src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts` passed; 2 files and 16 tests passed.
- `pnpm run typecheck:node` passed.
- `pnpm exec oxlint src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts src/main/ai-vault/session-scanner-opencode-sqlite.test.ts src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts` passed with no diagnostics.
- `pnpm exec oxfmt --check src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts src/main/ai-vault/session-scanner-opencode-sqlite.test.ts src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts` passed.

## AI Review Report

The change removes the discovery projection and correlated message-data count while preserving selected-session parsing, SQLite and legacy deduplication, ordering, read-only access, and cache behavior. Tests cover malformed payloads, selected-session fields, ordering, schema compatibility, child filtering, deduplication, legacy coexistence, and cache reuse. No platform-specific path behavior changed.

## Security Audit

The database remains read-only with `fileMustExist: true` and `PRAGMA query_only = ON`. The change adds no writes, subprocesses, renderer or IPC inputs, dependencies, or secret handling. SQL identifiers remain source-controlled constants, and stored payloads continue through the existing parser.

## Notes

The issue-scale database, WAL, trace, and concurrent-writer workload were unavailable, so this PR makes no issue-scale latency claim. No UI, IPC, release, version, or dependency files change.

## ELI5

OpenCode Agent History could get slower as message tables grew huge. Discovery now loads only session identity and recency first, so the list stays fast.
