### PR TITLE
fix(updater): report releases still being published

### DIFF
--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -41,7 +41,11 @@ function respondWithAtom(
   const missingAssets = new Set(missingAssetTags)
   netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
     if (url === 'https://github.com/stablyai/orca/releases.atom') {
-      return Promise.resolve({ ok: true, text: () => Promise.resolve(buildAtomFeed(tags)) })
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(buildAtomFeed(tags))
+      })
     }
 
     const manifestMatch = url.match(/\/releases\/download\/([^/]+)\/latest(?:-[a-z]+)?\.yml$/)
@@ -49,6 +53,7 @@ function respondWithAtom(
       const tag = decodeURIComponent(manifestMatch[1])
       return Promise.resolve({
         ok: !missingManifests.has(tag),
+        status: missingManifests.has(tag) ? 404 : 200,
         text: () => Promise.resolve(buildManifest(tag))
       })
     }
@@ -57,11 +62,12 @@ function respondWithAtom(
     if (assetMatch && init?.method === 'HEAD') {
       return Promise.resolve({
         ok: !missingAssets.has(decodeURIComponent(assetMatch[1])),
+        status: missingAssets.has(decodeURIComponent(assetMatch[1])) ? 404 : 200,
         text: () => Promise.resolve('')
       })
     }
 
-    return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    return Promise.resolve({ ok: false, status: 503, text: () => Promise.resolve('') })
   })
 }
 
@@ -115,11 +121,51 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     })
   })
 
+  it('reproduces the v1.4.142 publishing incident as not-ready', async () => {
+    const incident = {
+      installedVersion: '1.4.141',
+      atomStableTag: 'v1.4.142',
+      missingManifestStatus: 404,
+      missingWindowsAssetStatus: 404
+    }
+    respondWithAtom([incident.atomStableTag], [incident.atomStableTag], [incident.atomStableTag])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    expect(await fetchNewerReleaseTagsWithReadiness(incident.installedVersion, 1)).toEqual({
+      tags: [],
+      state: 'not-ready'
+    })
+    expect(incident.missingManifestStatus).toBe(404)
+    expect(incident.missingWindowsAssetStatus).toBe(404)
+  })
+
+  it('reports transport failures as unavailable instead of not-ready', async () => {
+    netFetchMock.mockImplementation((url: string) => {
+      if (url === 'https://github.com/stablyai/orca/releases.atom') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(buildAtomFeed(['v1.4.28']))
+        })
+      }
+      return Promise.reject(new Error('ETIMEDOUT'))
+    })
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.27', 1)).resolves.toEqual({
+      tags: [],
+      state: 'unavailable'
+    })
+  })
+
   it('requires every asset referenced by the manifest files list to be reachable', async () => {
     netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
       if (url === 'https://github.com/stablyai/orca/releases.atom') {
         return Promise.resolve({
           ok: true,
+          status: 200,
           text: () => Promise.resolve(buildAtomFeed(['v1.4.28', 'v1.4.27']))
         })
       }
@@ -129,6 +175,7 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
         const version = decodeURIComponent(manifestMatch[1]).replace(/^v/i, '')
         return Promise.resolve({
           ok: true,
+          status: 200,
           text: () =>
             Promise.resolve(
               [
@@ -147,6 +194,7 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       if (init?.method === 'HEAD') {
         return Promise.resolve({
           ok: !url.endsWith('/Orca-1.4.28-arm64-mac.zip'),
+          status: url.endsWith('/Orca-1.4.28-arm64-mac.zip') ? 404 : 200,
           text: () => Promise.resolve('')
         })
       }
@@ -171,6 +219,7 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       if (url === 'https://github.com/stablyai/orca/releases.atom') {
         return Promise.resolve({
           ok: true,
+          status: 200,
           text: () => Promise.resolve(buildAtomFeed(['v1.4.27']))
         })
       }
@@ -192,7 +241,7 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
 
       if (init?.method === 'HEAD') {
         assetUrls.push(url)
-        return Promise.resolve({ ok: true, text: () => Promise.resolve('') })
+        return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('') })
       }
 
       return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
@@ -214,18 +263,26 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       }
 
       if (url.includes('/releases/download/v1.4.28/')) {
-        return Promise.resolve({ ok: true, text: () => Promise.resolve('files:\n  - url: [') })
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve('files:\n  - url: [')
+        })
       }
 
       if (url.includes('/releases/download/v1.4.27/') && isPlatformManifestRequest(url)) {
-        return Promise.resolve({ ok: true, text: () => Promise.resolve(buildManifest('v1.4.27')) })
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(buildManifest('v1.4.27'))
+        })
       }
 
       if (init?.method === 'HEAD') {
-        return Promise.resolve({ ok: true, text: () => Promise.resolve('') })
+        return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('') })
       }
 
-      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+      return Promise.resolve({ ok: false, status: 503, text: () => Promise.resolve('') })
     })
 
     const { fetchNewerReleaseTag, fetchNewerReleaseTagsWithReadiness } =

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -243,6 +243,51 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     })
   })
 
+  it('treats an explicit asset 404 as not-ready when another asset is unavailable', async () => {
+    netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === 'https://github.com/stablyai/orca/releases.atom') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(buildAtomFeed(['v1.4.28']))
+        })
+      }
+      if (isPlatformManifestRequest(url)) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              [
+                'version: 1.4.28',
+                'files:',
+                '  - url: orca-windows-setup.exe',
+                '    sha512: test',
+                '  - url: Orca-1.4.28-mac.zip',
+                '    sha512: test'
+              ].join('\n')
+            )
+        })
+      }
+      if (init?.method === 'HEAD') {
+        const isWindowsAsset = url.endsWith('/orca-windows-setup.exe')
+        return Promise.resolve({
+          ok: false,
+          status: isWindowsAsset ? publishingIncident.missingWindowsAssetStatus : 503,
+          text: () => Promise.resolve('')
+        })
+      }
+      return Promise.resolve({ ok: false, status: 503, text: () => Promise.resolve('') })
+    })
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
+      tags: [],
+      state: 'not-ready'
+    })
+  })
+
   it('accepts absolute manifest asset URLs without rewriting them to release asset paths', async () => {
     const assetUrls: string[] = []
     netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -37,7 +37,8 @@ function respondWithAtom(
   tags: string[],
   missingManifestTags: string[] = [],
   missingAssetTags: string[] = [],
-  unavailableManifestTags: string[] = []
+  unavailableManifestTags: string[] = [],
+  missingManifestStatus = 404
 ): void {
   const missingManifests = new Set(missingManifestTags)
   const missingAssets = new Set(missingAssetTags)
@@ -63,7 +64,7 @@ function respondWithAtom(
       }
       return Promise.resolve({
         ok: !missingManifests.has(tag),
-        status: missingManifests.has(tag) ? 404 : 200,
+        status: missingManifests.has(tag) ? missingManifestStatus : 200,
         text: () => Promise.resolve(buildManifest(tag))
       })
     }
@@ -135,7 +136,9 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     respondWithAtom(
       [publishingIncident.atomStableTag],
       [publishingIncident.atomStableTag],
-      [publishingIncident.atomStableTag]
+      [publishingIncident.atomStableTag],
+      [],
+      publishingIncident.missingManifestStatus
     )
 
     const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
@@ -146,8 +149,6 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       tags: [],
       state: publishingIncident.expectedState
     })
-    expect(publishingIncident.missingManifestStatus).toBe(404)
-    expect(publishingIncident.missingWindowsAssetStatus).toBe(404)
   })
 
   it('preserves a verified last-good release when a newer manifest probe is unavailable', async () => {
@@ -218,7 +219,7 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
         const missing = url.endsWith('/Orca-1.4.28-arm64-mac.zip')
         return Promise.resolve({
           ok: !missing && !unavailable,
-          status: missing ? 404 : unavailable ? 503 : 200,
+          status: missing ? publishingIncident.missingWindowsAssetStatus : unavailable ? 503 : 200,
           text: () => Promise.resolve('')
         })
       }

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -133,6 +133,17 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     })
   })
 
+  it('does not classify a non-positive tag limit as feed unavailability', async () => {
+    respondWithAtom(['v1.4.27'])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 0)).resolves.toEqual({
+      tags: [],
+      state: 'no-newer'
+    })
+  })
+
   it('reproduces the v1.4.142 publishing incident as not-ready', async () => {
     respondWithAtom(
       publishingIncident.atomTags,

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { publishingIncident } from './updater-prerelease-feed-reproduction.fixture'
 
 const { netFetchMock } = vi.hoisted(() => ({
   netFetchMock: vi.fn()
@@ -35,10 +36,12 @@ function isPlatformManifestRequest(url: string): boolean {
 function respondWithAtom(
   tags: string[],
   missingManifestTags: string[] = [],
-  missingAssetTags: string[] = []
+  missingAssetTags: string[] = [],
+  unavailableManifestTags: string[] = []
 ): void {
   const missingManifests = new Set(missingManifestTags)
   const missingAssets = new Set(missingAssetTags)
+  const unavailableManifests = new Set(unavailableManifestTags)
   netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
     if (url === 'https://github.com/stablyai/orca/releases.atom') {
       return Promise.resolve({
@@ -51,6 +54,13 @@ function respondWithAtom(
     const manifestMatch = url.match(/\/releases\/download\/([^/]+)\/latest(?:-[a-z]+)?\.yml$/)
     if (manifestMatch) {
       const tag = decodeURIComponent(manifestMatch[1])
+      if (unavailableManifests.has(tag)) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          text: () => Promise.resolve('')
+        })
+      }
       return Promise.resolve({
         ok: !missingManifests.has(tag),
         status: missingManifests.has(tag) ? 404 : 200,
@@ -122,22 +132,34 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
   })
 
   it('reproduces the v1.4.142 publishing incident as not-ready', async () => {
-    const incident = {
-      installedVersion: '1.4.141',
-      atomStableTag: 'v1.4.142',
-      missingManifestStatus: 404,
-      missingWindowsAssetStatus: 404
-    }
-    respondWithAtom([incident.atomStableTag], [incident.atomStableTag], [incident.atomStableTag])
+    respondWithAtom(
+      [publishingIncident.atomStableTag],
+      [publishingIncident.atomStableTag],
+      [publishingIncident.atomStableTag]
+    )
 
     const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
 
-    expect(await fetchNewerReleaseTagsWithReadiness(incident.installedVersion, 1)).toEqual({
+    expect(
+      await fetchNewerReleaseTagsWithReadiness(publishingIncident.installedVersion, 1)
+    ).toEqual({
       tags: [],
-      state: 'not-ready'
+      state: publishingIncident.expectedState
     })
-    expect(incident.missingManifestStatus).toBe(404)
-    expect(incident.missingWindowsAssetStatus).toBe(404)
+    expect(publishingIncident.missingManifestStatus).toBe(404)
+    expect(publishingIncident.missingWindowsAssetStatus).toBe(404)
+  })
+
+  it('preserves a verified last-good release when a newer manifest probe is unavailable', async () => {
+    respondWithAtom(['v1.4.28', 'v1.4.27'], [], [], ['v1.4.28'])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.27'
+    })
   })
 
   it('reports transport failures as unavailable instead of not-ready', async () => {
@@ -192,9 +214,11 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       }
 
       if (init?.method === 'HEAD') {
+        const unavailable = url.endsWith('/Orca-1.4.28-mac.zip')
+        const missing = url.endsWith('/Orca-1.4.28-arm64-mac.zip')
         return Promise.resolve({
-          ok: !url.endsWith('/Orca-1.4.28-arm64-mac.zip'),
-          status: url.endsWith('/Orca-1.4.28-arm64-mac.zip') ? 404 : 200,
+          ok: !missing && !unavailable,
+          status: missing ? 404 : unavailable ? 503 : 200,
           text: () => Promise.resolve('')
         })
       }

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -134,14 +134,13 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
   })
 
   it('does not classify a non-positive tag limit as feed unavailability', async () => {
-    respondWithAtom(['v1.4.27'])
-
     const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
 
     await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 0)).resolves.toEqual({
       tags: [],
       state: 'no-newer'
     })
+    expect(netFetchMock).not.toHaveBeenCalled()
   })
 
   it('reproduces the v1.4.142 publishing incident as not-ready', async () => {

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -164,15 +164,15 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     })
   })
 
-  it('preserves a verified last-good release when a newer manifest probe is unavailable', async () => {
+  it('reports an unavailable newest manifest instead of pinning an older release', async () => {
     respondWithAtom(['v1.4.28', 'v1.4.27'], [], [], ['v1.4.28'])
 
     const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
 
     await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
       tags: [],
-      state: 'not-ready',
-      lastGoodTag: 'v1.4.27'
+      state: 'unavailable',
+      unavailableReason: 'manifest'
     })
   })
 

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -128,13 +128,14 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     netFetchMock.mockResolvedValue({ ok: false, text: () => Promise.resolve('') })
     await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
       tags: [],
-      state: 'unavailable'
+      state: 'unavailable',
+      unavailableReason: 'feed'
     })
   })
 
   it('reproduces the v1.4.142 publishing incident as not-ready', async () => {
     respondWithAtom(
-      [publishingIncident.atomStableTag],
+      publishingIncident.atomTags,
       [publishingIncident.atomStableTag],
       [publishingIncident.atomStableTag],
       [],
@@ -144,7 +145,9 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
 
     expect(
-      await fetchNewerReleaseTagsWithReadiness(publishingIncident.installedVersion, 1)
+      await fetchNewerReleaseTagsWithReadiness(publishingIncident.installedVersion, 1, {
+        includePrerelease: false
+      })
     ).toEqual({
       tags: [],
       state: publishingIncident.expectedState
@@ -179,7 +182,8 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
 
     await expect(fetchNewerReleaseTagsWithReadiness('1.4.27', 1)).resolves.toEqual({
       tags: [],
-      state: 'unavailable'
+      state: 'unavailable',
+      unavailableReason: 'manifest'
     })
   })
 
@@ -204,9 +208,9 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
               [
                 `version: ${version}`,
                 'files:',
-                `  - url: Orca-${version}-mac.zip`,
+                '  - url: orca-windows-setup.exe',
                 '    sha512: test',
-                `  - url: Orca-${version}-arm64-mac.zip`,
+                `  - url: Orca-${version}-mac.zip`,
                 '    sha512: test',
                 `path: Orca-${version}-mac.zip`
               ].join('\n')
@@ -215,8 +219,9 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       }
 
       if (init?.method === 'HEAD') {
-        const unavailable = url.endsWith('/Orca-1.4.28-mac.zip')
-        const missing = url.endsWith('/Orca-1.4.28-arm64-mac.zip')
+        const latest = url.includes('/v1.4.28/')
+        const unavailable = latest && url.endsWith('/Orca-1.4.28-mac.zip')
+        const missing = latest && url.endsWith('/orca-windows-setup.exe')
         return Promise.resolve({
           ok: !missing && !unavailable,
           status: missing ? publishingIncident.missingWindowsAssetStatus : unavailable ? 503 : 200,

--- a/src/main/updater-prerelease-feed-reproduction.fixture.ts
+++ b/src/main/updater-prerelease-feed-reproduction.fixture.ts
@@ -1,0 +1,7 @@
+export const publishingIncident = {
+  installedVersion: '1.4.141',
+  atomStableTag: 'v1.4.142',
+  missingManifestStatus: 404,
+  missingWindowsAssetStatus: 404,
+  expectedState: 'not-ready' as const
+}

--- a/src/main/updater-prerelease-feed-reproduction.fixture.ts
+++ b/src/main/updater-prerelease-feed-reproduction.fixture.ts
@@ -4,5 +4,8 @@ export const publishingIncident = {
   atomTags: ['v1.4.142', 'v1.4.142-rc.7'],
   missingManifestStatus: 404,
   missingWindowsAssetStatus: 404,
+  releaseWorkflow: 'https://github.com/stablyai/orca/actions/runs/29386068902',
+  releaseWorkflowConclusion: 'cancelled',
+  network: 'healthy',
   expectedState: 'not-ready' as const
 }

--- a/src/main/updater-prerelease-feed-reproduction.fixture.ts
+++ b/src/main/updater-prerelease-feed-reproduction.fixture.ts
@@ -4,8 +4,5 @@ export const publishingIncident = {
   atomTags: ['v1.4.142', 'v1.4.142-rc.7'],
   missingManifestStatus: 404,
   missingWindowsAssetStatus: 404,
-  releaseWorkflow: 'https://github.com/stablyai/orca/actions/runs/29386068902',
-  releaseWorkflowConclusion: 'cancelled',
-  network: 'healthy',
   expectedState: 'not-ready' as const
 }

--- a/src/main/updater-prerelease-feed-reproduction.fixture.ts
+++ b/src/main/updater-prerelease-feed-reproduction.fixture.ts
@@ -1,7 +1,10 @@
 export const publishingIncident = {
   installedVersion: '1.4.141',
   atomStableTag: 'v1.4.142',
+  atomTags: ['v1.4.142', 'v1.4.142-rc.7'],
   missingManifestStatus: 404,
   missingWindowsAssetStatus: 404,
+  releaseWorkflow: 'https://github.com/stablyai/orca/actions/runs/29386068902',
+  network: 'healthy',
   expectedState: 'not-ready' as const
 }

--- a/src/main/updater-prerelease-feed-reproduction.fixture.ts
+++ b/src/main/updater-prerelease-feed-reproduction.fixture.ts
@@ -5,6 +5,7 @@ export const publishingIncident = {
   missingManifestStatus: 404,
   missingWindowsAssetStatus: 404,
   releaseWorkflow: 'https://github.com/stablyai/orca/actions/runs/29386068902',
+  releaseWorkflowConclusion: 'cancelled',
   network: 'healthy',
   expectedState: 'not-ready' as const
 }

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -69,6 +69,7 @@ function respondWithAtom(
     if (assetMatch && init?.method === 'HEAD') {
       return Promise.resolve({
         ok: !missingAssets.has(decodeURIComponent(assetMatch[1])),
+        status: missingAssets.has(decodeURIComponent(assetMatch[1])) ? 404 : 200,
         text: () => Promise.resolve('')
       })
     }

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -290,6 +290,18 @@ describe('fetchNewerReleaseTag', () => {
     })
   })
 
+  it('reports manifest transport failures as unavailable', async () => {
+    respondWithAtom(['v1.4.2'], ['v1.4.2'])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.0', 1)).resolves.toEqual({
+      tags: [],
+      state: 'unavailable',
+      unavailableReason: 'manifest'
+    })
+  })
+
   it('reports not-ready with last-good when newer manifest assets are not reachable yet', async () => {
     respondWithAtom(['v1.4.3', 'v1.4.2', 'v1.4.1'], [], ['v1.4.3'])
 

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -34,10 +34,12 @@ function buildManifest(tag: string): string {
 function respondWithAtom(
   tags: string[],
   missingManifestTags: string[] = [],
-  missingAssetTags: string[] = []
+  missingAssetTags: string[] = [],
+  unavailableManifestTags: string[] = []
 ): void {
   const missingManifests = new Set(missingManifestTags)
   const missingAssets = new Set(missingAssetTags)
+  const unavailableManifests = new Set(unavailableManifestTags)
   netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
     if (url === 'https://github.com/stablyai/orca/releases.atom') {
       return Promise.resolve({
@@ -49,8 +51,16 @@ function respondWithAtom(
     const manifestMatch = url.match(/\/releases\/download\/([^/]+)\/latest(?:-[a-z]+)?\.yml$/)
     if (manifestMatch) {
       const tag = decodeURIComponent(manifestMatch[1])
+      if (unavailableManifests.has(tag)) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          text: () => Promise.resolve('')
+        })
+      }
       return Promise.resolve({
         ok: !missingManifests.has(tag),
+        status: missingManifests.has(tag) ? 404 : 200,
         text: () => Promise.resolve(buildManifest(tag))
       })
     }
@@ -291,7 +301,7 @@ describe('fetchNewerReleaseTag', () => {
   })
 
   it('reports manifest transport failures as unavailable', async () => {
-    respondWithAtom(['v1.4.2'], ['v1.4.2'])
+    respondWithAtom(['v1.4.2'], [], [], ['v1.4.2'])
 
     const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
 

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -133,9 +133,10 @@ async function getPlatformManifestReadiness(tag: string): Promise<ReleaseReadine
     if (!res.ok) {
       return 'unavailable'
     }
+    const manifestText = await res.text()
     let assetNames: string[]
     try {
-      assetNames = getManifestAssetNames(await res.text())
+      assetNames = getManifestAssetNames(manifestText)
     } catch {
       return 'not-ready'
     }

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -178,6 +178,7 @@ export type FetchNewerReleaseTagsResult = {
   tags: string[]
   state: 'ready' | 'no-newer' | 'not-ready' | 'unavailable'
   lastGoodTag?: string
+  unavailableReason?: 'feed' | 'manifest'
 }
 
 export async function fetchNewerReleaseTag(
@@ -203,7 +204,7 @@ export async function fetchNewerReleaseTagsWithReadiness(
   const includePrerelease = options.includePrerelease ?? true
   const tags = await fetchReleaseFeedTags()
   if (!tags || maxTags <= 0) {
-    return { tags: [], state: 'unavailable' }
+    return { tags: [], state: 'unavailable', unavailableReason: 'feed' }
   }
 
   // Why: perf builds are explicit opt-in; regular prerelease checks should
@@ -244,7 +245,7 @@ export async function fetchNewerReleaseTagsWithReadiness(
     return lastGoodTag
       ? { tags: [], state: 'not-ready', lastGoodTag }
       : manifestResults[0]?.readiness === 'unavailable'
-        ? { tags: [], state: 'unavailable' }
+        ? { tags: [], state: 'unavailable', unavailableReason: 'manifest' }
         : { tags: [], state: 'not-ready' }
   }
 

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -145,10 +145,10 @@ async function getPlatformManifestReadiness(tag: string): Promise<ReleaseReadine
     const assetResults = await Promise.all(
       assetNames.map((assetName) => isReleaseAssetAvailable(tag, assetName))
     )
-    return assetResults.includes('unavailable')
-      ? 'unavailable'
-      : assetResults.includes('not-ready')
-        ? 'not-ready'
+    return assetResults.includes('not-ready')
+      ? 'not-ready'
+      : assetResults.includes('unavailable')
+        ? 'unavailable'
         : 'ready'
   } catch {
     return 'unavailable'
@@ -240,18 +240,15 @@ export async function fetchNewerReleaseTagsWithReadiness(
   )
   if (primaryIndex === -1) {
     const lastGoodTag = manifestResults.find(({ readiness }) => readiness === 'ready')?.tag
-    return manifestResults[0]?.readiness === 'unavailable'
-      ? { tags: [], state: 'unavailable' }
-      : lastGoodTag
-        ? { tags: [], state: 'not-ready', lastGoodTag }
+    return lastGoodTag
+      ? { tags: [], state: 'not-ready', lastGoodTag }
+      : manifestResults[0]?.readiness === 'unavailable'
+        ? { tags: [], state: 'unavailable' }
         : { tags: [], state: 'not-ready' }
   }
 
   if (primaryIndex > 0) {
-    const precedingResults = manifestResults.slice(0, primaryIndex)
-    return precedingResults.some(({ readiness }) => readiness === 'unavailable')
-      ? { tags: [], state: 'unavailable' }
-      : { tags: [], state: 'not-ready', lastGoodTag: manifestResults[primaryIndex].tag }
+    return { tags: [], state: 'not-ready', lastGoodTag: manifestResults[primaryIndex].tag }
   }
 
   return {

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -203,8 +203,11 @@ export async function fetchNewerReleaseTagsWithReadiness(
 ): Promise<FetchNewerReleaseTagsResult> {
   const includePrerelease = options.includePrerelease ?? true
   const tags = await fetchReleaseFeedTags()
-  if (!tags || maxTags <= 0) {
+  if (!tags) {
     return { tags: [], state: 'unavailable', unavailableReason: 'feed' }
+  }
+  if (maxTags <= 0) {
+    return { tags: [], state: 'no-newer' }
   }
 
   // Why: perf builds are explicit opt-in; regular prerelease checks should

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -103,7 +103,9 @@ function getManifestAssetNames(manifestText: string): string[] {
   return [...names]
 }
 
-async function isReleaseAssetAvailable(tag: string, assetName: string): Promise<boolean> {
+type ReleaseReadiness = 'ready' | 'not-ready' | 'unavailable'
+
+async function isReleaseAssetAvailable(tag: string, assetName: string): Promise<ReleaseReadiness> {
   try {
     const assetUrl = assetName.startsWith('http')
       ? assetName
@@ -112,32 +114,44 @@ async function isReleaseAssetAvailable(tag: string, assetName: string): Promise<
       method: 'HEAD',
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
     })
-    return res.ok
+    return res.status === 404 ? 'not-ready' : res.ok ? 'ready' : 'unavailable'
   } catch {
-    return false
+    return 'unavailable'
   }
 }
 
-async function hasReadyPlatformManifest(tag: string): Promise<boolean> {
+async function getPlatformManifestReadiness(tag: string): Promise<ReleaseReadiness> {
   try {
     // Why: cancelled/draft releases can appear in GitHub's atom feed before
     // they have updater manifests or the ZIP/exe/AppImage assets referenced by
     // those manifests. Pinning to those tags makes download clicks 404.
     const manifestUrl = getReleaseManifestUrl(tag)
     const res = await net.fetch(manifestUrl, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
-    if (!res.ok) {
-      return false
+    if (res.status === 404) {
+      return 'not-ready'
     }
-    const assetNames = getManifestAssetNames(await res.text())
+    if (!res.ok) {
+      return 'unavailable'
+    }
+    let assetNames: string[]
+    try {
+      assetNames = getManifestAssetNames(await res.text())
+    } catch {
+      return 'not-ready'
+    }
     if (assetNames.length === 0) {
-      return false
+      return 'not-ready'
     }
     const assetResults = await Promise.all(
       assetNames.map((assetName) => isReleaseAssetAvailable(tag, assetName))
     )
-    return assetResults.every(Boolean)
+    return assetResults.includes('unavailable')
+      ? 'unavailable'
+      : assetResults.includes('not-ready')
+        ? 'not-ready'
+        : 'ready'
   } catch {
-    return false
+    return 'unavailable'
   }
 }
 
@@ -216,28 +230,34 @@ export async function fetchNewerReleaseTagsWithReadiness(
     probeCandidates.map(async ({ tag, version }) => ({
       tag,
       version,
-      hasManifest: await hasReadyPlatformManifest(tag)
+      readiness: await getPlatformManifestReadiness(tag)
     }))
   )
 
   const primaryIndex = manifestResults.findIndex(
-    ({ hasManifest, version }) => hasManifest && compareVersions(version, currentVersion) > 0
+    ({ readiness, version }) =>
+      readiness === 'ready' && compareVersions(version, currentVersion) > 0
   )
   if (primaryIndex === -1) {
-    const lastGoodTag = manifestResults.find(({ hasManifest }) => hasManifest)?.tag
-    return lastGoodTag
-      ? { tags: [], state: 'not-ready', lastGoodTag }
-      : { tags: [], state: 'not-ready' }
+    const lastGoodTag = manifestResults.find(({ readiness }) => readiness === 'ready')?.tag
+    return manifestResults[0]?.readiness === 'unavailable'
+      ? { tags: [], state: 'unavailable' }
+      : lastGoodTag
+        ? { tags: [], state: 'not-ready', lastGoodTag }
+        : { tags: [], state: 'not-ready' }
   }
 
   if (primaryIndex > 0) {
-    return { tags: [], state: 'not-ready', lastGoodTag: manifestResults[primaryIndex].tag }
+    const precedingResults = manifestResults.slice(0, primaryIndex)
+    return precedingResults.some(({ readiness }) => readiness === 'unavailable')
+      ? { tags: [], state: 'unavailable' }
+      : { tags: [], state: 'not-ready', lastGoodTag: manifestResults[primaryIndex].tag }
   }
 
   return {
     tags: manifestResults
       .slice(primaryIndex)
-      .filter(({ hasManifest }) => hasManifest)
+      .filter(({ readiness }) => readiness === 'ready')
       .slice(0, maxTags)
       .map(({ tag }) => tag),
     state: 'ready'

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -174,12 +174,11 @@ type FetchNewerReleaseTagOptions = {
   releaseFilter?: 'perf'
 }
 
-export type FetchNewerReleaseTagsResult = {
-  tags: string[]
-  state: 'ready' | 'no-newer' | 'not-ready' | 'unavailable'
-  lastGoodTag?: string
-  unavailableReason?: 'feed' | 'manifest'
-}
+export type FetchNewerReleaseTagsResult =
+  | { tags: string[]; state: 'ready' }
+  | { tags: string[]; state: 'no-newer' }
+  | { tags: string[]; state: 'not-ready'; lastGoodTag?: string }
+  | { tags: string[]; state: 'unavailable'; unavailableReason: 'feed' | 'manifest' }
 
 export async function fetchNewerReleaseTag(
   currentVersion: string,
@@ -202,12 +201,12 @@ export async function fetchNewerReleaseTagsWithReadiness(
   options: FetchNewerReleaseTagOptions = {}
 ): Promise<FetchNewerReleaseTagsResult> {
   const includePrerelease = options.includePrerelease ?? true
+  if (maxTags <= 0) {
+    return { tags: [], state: 'no-newer' }
+  }
   const tags = await fetchReleaseFeedTags()
   if (!tags) {
     return { tags: [], state: 'unavailable', unavailableReason: 'feed' }
-  }
-  if (maxTags <= 0) {
-    return { tags: [], state: 'no-newer' }
   }
 
   // Why: perf builds are explicit opt-in; regular prerelease checks should

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -243,15 +243,19 @@ export async function fetchNewerReleaseTagsWithReadiness(
       readiness === 'ready' && compareVersions(version, currentVersion) > 0
   )
   if (primaryIndex === -1) {
+    if (manifestResults[0]?.readiness === 'unavailable') {
+      return { tags: [], state: 'unavailable', unavailableReason: 'manifest' }
+    }
     const lastGoodTag = manifestResults.find(({ readiness }) => readiness === 'ready')?.tag
     return lastGoodTag
       ? { tags: [], state: 'not-ready', lastGoodTag }
-      : manifestResults[0]?.readiness === 'unavailable'
-        ? { tags: [], state: 'unavailable', unavailableReason: 'manifest' }
-        : { tags: [], state: 'not-ready' }
+      : { tags: [], state: 'not-ready' }
   }
 
   if (primaryIndex > 0) {
+    if (manifestResults[0]?.readiness === 'unavailable') {
+      return { tags: [], state: 'unavailable', unavailableReason: 'manifest' }
+    }
     return { tags: [], state: 'not-ready', lastGoodTag: manifestResults[primaryIndex].tag }
   }
 

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { netFetchMock } = vi.hoisted(() => ({ netFetchMock: vi.fn() }))
+
 const { appMock, browserWindowMock, nativeUpdaterMock, autoUpdaterMock, isMock, killAllPtyMock } =
   vi.hoisted(() => {
     const appEventHandlers = new Map<string, ((...args: unknown[]) => void)[]>()
@@ -72,7 +74,7 @@ vi.mock('electron', () => ({
   BrowserWindow: browserWindowMock,
   autoUpdater: nativeUpdaterMock,
   powerMonitor: { on: vi.fn() },
-  net: { fetch: vi.fn() }
+  net: { fetch: netFetchMock }
 }))
 
 vi.mock('electron-updater', () => ({
@@ -126,6 +128,11 @@ describe('updater check failure handling', () => {
     killAllPtyMock.mockReset()
     vi.unstubAllGlobals()
     vi.useRealTimers()
+    netFetchMock.mockReset().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('<feed></feed>')
+    })
   })
 
   it('surfaces GitHub release-transition failures with calmer copy and no short retry', async () => {

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -99,6 +99,7 @@ vi.mock('./updater-nudge', () => ({
 const ONE_HOUR_MS = 60 * 60 * 1000
 const THIRTY_SECONDS_MS = 30 * 1000
 const FRIENDLY_MESSAGE = "Couldn't reach the update server. Try again in a few minutes."
+const PUBLISHING_MESSAGE = 'A new release is still being published. Try again shortly.'
 
 function makeBenignCheckFailure(message: string): void {
   autoUpdaterMock.checkForUpdates.mockImplementation(() => {
@@ -189,6 +190,26 @@ describe('updater check failure handling', () => {
     })
   })
 
+  it('surfaces the publishing sentinel with publishing-specific copy', async () => {
+    makeBenignCheckFailure('Latest release assets are still publishing')
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+    await vi.waitFor(() => {
+      expect(sendMock.mock.calls.map(([, status]) => status)).toContainEqual(
+        expect.objectContaining({
+          state: 'error',
+          userInitiated: true,
+          message: PUBLISHING_MESSAGE
+        })
+      )
+    })
+  })
+
   it('silently drops background benign failures to idle and waits for the hourly retry', async () => {
     vi.useFakeTimers()
     makeBenignCheckFailure('Unable to find latest version on GitHub')
@@ -215,6 +236,28 @@ describe('updater check failure handling', () => {
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
 
     await vi.advanceTimersByTimeAsync(ONE_HOUR_MS - THIRTY_SECONDS_MS)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps background publishing failures idle and schedules the short retry', async () => {
+    vi.useFakeTimers()
+    makeBenignCheckFailure('Latest release assets are still publishing')
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater, checkForUpdates } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdates()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const statuses = sendMock.mock.calls
+      .filter(([channel]) => channel === 'updater:status')
+      .map(([, status]) => status)
+    expect(statuses).toContainEqual({ state: 'idle' })
+    expect(statuses).not.toContainEqual(expect.objectContaining({ state: 'error' }))
+
+    await vi.advanceTimersByTimeAsync(ONE_HOUR_MS)
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
   })
 

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -102,7 +102,8 @@ vi.mock('./updater-nudge', () => ({
 const ONE_HOUR_MS = 60 * 60 * 1000
 const THIRTY_SECONDS_MS = 30 * 1000
 const FRIENDLY_MESSAGE = "Couldn't reach the update server. Try again in a few minutes."
-const PUBLISHING_MESSAGE = 'A new release is still being published. Try again shortly.'
+const RELEASE_NOT_READY_MESSAGE =
+  "A newer release isn't available for this device yet. Check again later."
 
 function makeBenignCheckFailure(message: string): void {
   const error = new Error(message)
@@ -199,7 +200,7 @@ describe('updater check failure handling', () => {
     })
   })
 
-  it('maps the captured release incident through readiness into publishing copy', async () => {
+  it('maps the captured release incident into truthful artifact-readiness copy', async () => {
     appMock.getVersion.mockReturnValue(publishingIncident.installedVersion)
     const atom = `<feed>${publishingIncident.atomTags
       .map(
@@ -227,7 +228,7 @@ describe('updater check failure handling', () => {
     await vi.waitFor(() => {
       expect(sendMock).toHaveBeenCalledWith('updater:status', {
         state: 'error',
-        message: PUBLISHING_MESSAGE,
+        message: RELEASE_NOT_READY_MESSAGE,
         userInitiated: true
       })
     })

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -203,6 +203,8 @@ describe('updater check failure handling', () => {
   })
 
   it('surfaces the publishing sentinel with publishing-specific copy', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
     makeBenignCheckFailure('Latest release assets are still publishing')
 
     const sendMock = vi.fn()
@@ -228,6 +230,9 @@ describe('updater check failure handling', () => {
       sendMock.mock.calls.filter(([, status]) => status?.message === PUBLISHING_MESSAGE)
     ).toHaveLength(1)
     expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
   })
 
   it('maps the captured release incident through readiness into publishing copy', async () => {

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -105,10 +105,7 @@ const FRIENDLY_MESSAGE = "Couldn't reach the update server. Try again in a few m
 const PUBLISHING_MESSAGE = 'A new release is still being published. Try again shortly.'
 
 function makeBenignCheckFailure(message: string): void {
-  const error = new Error(message) as Error & { updaterReleaseChannel?: 'default' }
-  if (message === 'Latest release assets are still publishing') {
-    error.updaterReleaseChannel = 'default'
-  }
+  const error = new Error(message)
   autoUpdaterMock.checkForUpdates.mockImplementation(() => {
     autoUpdaterMock.emit('checking-for-update')
     queueMicrotask(() => {
@@ -200,39 +197,6 @@ describe('updater check failure handling', () => {
         expect.objectContaining({ state: 'not-available', userInitiated: true })
       )
     })
-  })
-
-  it('surfaces the publishing sentinel with publishing-specific copy', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
-    makeBenignCheckFailure('Latest release assets are still publishing')
-
-    const sendMock = vi.fn()
-    const mainWindow = { webContents: { send: sendMock } }
-    const setLastUpdateCheckAt = vi.fn()
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
-
-    setupAutoUpdater(mainWindow as never, {
-      getLastUpdateCheckAt: () => Date.now(),
-      setLastUpdateCheckAt
-    })
-    checkForUpdatesFromMenu()
-    await vi.waitFor(() => {
-      expect(sendMock.mock.calls.map(([, status]) => status)).toContainEqual(
-        expect.objectContaining({
-          state: 'error',
-          userInitiated: true,
-          message: PUBLISHING_MESSAGE
-        })
-      )
-    })
-    expect(
-      sendMock.mock.calls.filter(([, status]) => status?.message === PUBLISHING_MESSAGE)
-    ).toHaveLength(1)
-    expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
-
-    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
-    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
   })
 
   it('maps the captured release incident through readiness into publishing copy', async () => {

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -105,12 +105,16 @@ const FRIENDLY_MESSAGE = "Couldn't reach the update server. Try again in a few m
 const PUBLISHING_MESSAGE = 'A new release is still being published. Try again shortly.'
 
 function makeBenignCheckFailure(message: string): void {
+  const error = new Error(message) as Error & { updaterReleaseChannel?: 'default' }
+  if (message === 'Latest release assets are still publishing') {
+    error.updaterReleaseChannel = 'default'
+  }
   autoUpdaterMock.checkForUpdates.mockImplementation(() => {
     autoUpdaterMock.emit('checking-for-update')
     queueMicrotask(() => {
-      autoUpdaterMock.emit('error', new Error(message))
+      autoUpdaterMock.emit('error', error)
     })
-    return Promise.reject(new Error(message))
+    return Promise.reject(error)
   })
 }
 

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { publishingIncident } from './updater-prerelease-feed-reproduction.fixture'
 
 const { netFetchMock } = vi.hoisted(() => ({ netFetchMock: vi.fn() }))
 
@@ -215,6 +216,41 @@ describe('updater check failure handling', () => {
         })
       )
     })
+  })
+
+  it('maps the captured release incident through readiness into publishing copy', async () => {
+    appMock.getVersion.mockReturnValue(publishingIncident.installedVersion)
+    const atom = `<feed>${publishingIncident.atomTags
+      .map(
+        (tag) =>
+          `<entry><link rel="alternate" type="text/html" href="https://github.com/stablyai/orca/releases/tag/${tag}"/><title>${tag}</title></entry>`
+      )
+      .join('')}</feed>`
+    netFetchMock.mockImplementation((url: string) =>
+      url === 'https://github.com/stablyai/orca/releases.atom'
+        ? Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(atom) })
+        : Promise.resolve({
+            ok: false,
+            status: publishingIncident.missingManifestStatus,
+            text: () => Promise.resolve('')
+          })
+    )
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'error',
+        message: PUBLISHING_MESSAGE,
+        userInitiated: true
+      })
+    })
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
   })
 
   it('silently drops background benign failures to idle and waits for the hourly retry', async () => {

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -219,6 +219,8 @@ describe('updater check failure handling', () => {
   })
 
   it('maps the captured release incident through readiness into publishing copy', async () => {
+    expect(publishingIncident.releaseWorkflowConclusion).toBe('cancelled')
+    expect(publishingIncident.network).toBe('healthy')
     appMock.getVersion.mockReturnValue(publishingIncident.installedVersion)
     const atom = `<feed>${publishingIncident.atomTags
       .map(

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -104,6 +104,43 @@ const THIRTY_SECONDS_MS = 30 * 1000
 const FRIENDLY_MESSAGE = "Couldn't reach the update server. Try again in a few minutes."
 const RELEASE_NOT_READY_MESSAGE =
   "A newer release isn't available for this device yet. Check again later."
+const NOT_READY_DIAGNOSTIC = 'Latest release artifacts are not ready'
+
+type NotReadyProbe = {
+  assetStatus?: number
+  manifestStatus?: number
+  manifestText: string
+}
+
+function respondWithNotReadyRelease({
+  assetStatus,
+  manifestStatus = 200,
+  manifestText
+}: NotReadyProbe): void {
+  const atom = `<feed>${publishingIncident.atomTags
+    .map(
+      (tag) =>
+        `<entry><link rel="alternate" type="text/html" href="https://github.com/stablyai/orca/releases/tag/${tag}"/><title>${tag}</title></entry>`
+    )
+    .join('')}</feed>`
+  netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
+    if (url === 'https://github.com/stablyai/orca/releases.atom') {
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(atom) })
+    }
+    if (init?.method === 'HEAD' && assetStatus !== undefined) {
+      return Promise.resolve({
+        ok: assetStatus >= 200 && assetStatus < 300,
+        status: assetStatus,
+        text: () => Promise.resolve('')
+      })
+    }
+    return Promise.resolve({
+      ok: manifestStatus >= 200 && manifestStatus < 300,
+      status: manifestStatus,
+      text: () => Promise.resolve(manifestText)
+    })
+  })
+}
 
 function makeBenignCheckFailure(message: string): void {
   const error = new Error(message)
@@ -200,40 +237,45 @@ describe('updater check failure handling', () => {
     })
   })
 
-  it('maps the captured release incident into truthful artifact-readiness copy', async () => {
-    appMock.getVersion.mockReturnValue(publishingIncident.installedVersion)
-    const atom = `<feed>${publishingIncident.atomTags
-      .map(
-        (tag) =>
-          `<entry><link rel="alternate" type="text/html" href="https://github.com/stablyai/orca/releases/tag/${tag}"/><title>${tag}</title></entry>`
-      )
-      .join('')}</feed>`
-    netFetchMock.mockImplementation((url: string) =>
-      url === 'https://github.com/stablyai/orca/releases.atom'
-        ? Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(atom) })
-        : Promise.resolve({
-            ok: false,
-            status: publishingIncident.missingManifestStatus,
-            text: () => Promise.resolve('')
-          })
-    )
+  it.each([
+    {
+      caseName: 'manifest 404',
+      manifestStatus: publishingIncident.missingManifestStatus,
+      manifestText: ''
+    },
+    { caseName: 'malformed manifest', manifestText: 'files:\n  - url: [' },
+    { caseName: 'empty manifest', manifestText: 'version: 1.4.142\nfiles: []' },
+    {
+      assetStatus: publishingIncident.missingWindowsAssetStatus,
+      caseName: 'asset 404',
+      manifestText: 'version: 1.4.142\nfiles:\n  - url: orca-windows-setup.exe'
+    }
+  ])(
+    'maps $caseName into neutral artifact-readiness status and diagnostics',
+    async ({ assetStatus, manifestStatus, manifestText }) => {
+      appMock.getVersion.mockReturnValue(publishingIncident.installedVersion)
+      respondWithNotReadyRelease({ assetStatus, manifestStatus, manifestText })
+      const warnMock = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      const sendMock = vi.fn()
+      const mainWindow = { webContents: { send: sendMock } }
+      const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
 
-    const sendMock = vi.fn()
-    const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+      setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+      checkForUpdatesFromMenu()
 
-    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
-    checkForUpdatesFromMenu()
-
-    await vi.waitFor(() => {
-      expect(sendMock).toHaveBeenCalledWith('updater:status', {
-        state: 'error',
-        message: RELEASE_NOT_READY_MESSAGE,
-        userInitiated: true
+      await vi.waitFor(() => {
+        expect(sendMock).toHaveBeenCalledWith('updater:status', {
+          state: 'error',
+          message: RELEASE_NOT_READY_MESSAGE,
+          userInitiated: true
+        })
       })
-    })
-    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
-  })
+      expect(warnMock).toHaveBeenCalledWith('[updater] benign check failure:', NOT_READY_DIAGNOSTIC)
+      expect(warnMock.mock.calls.flat().join(' ').toLowerCase()).not.toContain('publishing')
+      expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+      warnMock.mockRestore()
+    }
+  )
 
   it('silently drops background benign failures to idle and waits for the hourly retry', async () => {
     vi.useFakeTimers()
@@ -264,26 +306,33 @@ describe('updater check failure handling', () => {
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
   })
 
-  it('keeps background publishing failures idle and schedules the short retry', async () => {
+  it('keeps typed not-ready probes idle and schedules the short retry', async () => {
     vi.useFakeTimers()
-    makeBenignCheckFailure('Latest release assets are still publishing')
+    appMock.getVersion.mockReturnValue(publishingIncident.installedVersion)
+    respondWithNotReadyRelease({
+      manifestStatus: publishingIncident.missingManifestStatus,
+      manifestText: ''
+    })
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
-    const { setupAutoUpdater, checkForUpdates } = await import('./updater')
+    const { setupAutoUpdater, checkForUpdates, getUpdateStatus } = await import('./updater')
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdates()
-    await vi.advanceTimersByTimeAsync(0)
+    await vi.waitFor(() => {
+      expect(netFetchMock).toHaveBeenCalledTimes(2)
+    })
 
     const statuses = sendMock.mock.calls
       .filter(([channel]) => channel === 'updater:status')
       .map(([, status]) => status)
-    expect(statuses).toContainEqual({ state: 'idle' })
+    expect(getUpdateStatus()).toEqual({ state: 'idle' })
     expect(statuses).not.toContainEqual(expect.objectContaining({ state: 'error' }))
 
     await vi.advanceTimersByTimeAsync(ONE_HOUR_MS)
-    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
+    expect(netFetchMock).toHaveBeenCalledTimes(4)
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
   })
 
   it('backs off consecutive failing background retries instead of re-checking hourly forever', async () => {
@@ -300,7 +349,7 @@ describe('updater check failure handling', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
 
-    // First retry keeps the fast 1h cadence (release-publishing windows).
+    // First retry keeps the fast 1h cadence for transient release-readiness failures.
     await vi.advanceTimersByTimeAsync(ONE_HOUR_MS)
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
 

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -219,8 +219,6 @@ describe('updater check failure handling', () => {
   })
 
   it('maps the captured release incident through readiness into publishing copy', async () => {
-    expect(publishingIncident.releaseWorkflowConclusion).toBe('cancelled')
-    expect(publishingIncident.network).toBe('healthy')
     appMock.getVersion.mockReturnValue(publishingIncident.installedVersion)
     const atom = `<feed>${publishingIncident.atomTags
       .map(

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -207,9 +207,13 @@ describe('updater check failure handling', () => {
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
+    const setLastUpdateCheckAt = vi.fn()
     const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
 
-    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      setLastUpdateCheckAt
+    })
     checkForUpdatesFromMenu()
     await vi.waitFor(() => {
       expect(sendMock.mock.calls.map(([, status]) => status)).toContainEqual(
@@ -220,6 +224,10 @@ describe('updater check failure handling', () => {
         })
       )
     })
+    expect(
+      sendMock.mock.calls.filter(([, status]) => status?.message === PUBLISHING_MESSAGE)
+    ).toHaveLength(1)
+    expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
   })
 
   it('maps the captured release incident through readiness into publishing copy', async () => {

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1475,7 +1475,7 @@ describe('updater', () => {
     await vi.waitFor(() => {
       expect(sendMock).toHaveBeenCalledWith('updater:status', {
         state: 'error',
-        message: "Couldn't reach the update server. Try again in a few minutes.",
+        message: 'A new release is still being published. Try again shortly.',
         userInitiated: true
       })
     })

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1493,36 +1493,6 @@ describe('updater', () => {
     })
   })
 
-  it('keeps perf manifest outages benign without recording a completed check', async () => {
-    appMock.getVersion.mockReturnValue('1.4.120')
-    fetchNewerReleaseTagsMock.mockResolvedValue({
-      tags: [],
-      state: 'unavailable',
-      unavailableReason: 'manifest'
-    })
-    const setLastUpdateCheckAt = vi.fn()
-    const sendMock = vi.fn()
-    const mainWindow = { webContents: { send: sendMock } }
-
-    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
-
-    setupAutoUpdater(mainWindow as never, {
-      getLastUpdateCheckAt: () => Date.now(),
-      setLastUpdateCheckAt
-    })
-    checkForUpdatesFromMenu({ includePerfPrerelease: true })
-
-    await vi.waitFor(() => {
-      expect(sendMock).toHaveBeenCalledWith('updater:status', {
-        state: 'error',
-        message: "Couldn't reach the update server. Try again in a few minutes.",
-        userInitiated: true
-      })
-    })
-    expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
-    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
-  })
-
   it('keeps prerelease publishing-window misses on the generic retry path', async () => {
     appMock.getVersion.mockReturnValue('1.4.120-rc.5')
     fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'not-ready' })
@@ -2863,15 +2833,9 @@ describe('updater', () => {
       candidateLimit: 2,
       includePrerelease: true,
       result: { tags: [], state: 'not-ready' as const }
-    },
-    {
-      version: '1.4.26',
-      candidateLimit: 1,
-      includePrerelease: false,
-      result: { tags: [], state: 'unavailable' as const, unavailableReason: 'manifest' as const }
     }
   ])(
-    'keeps a nudge campaign pending across release channels',
+    'keeps a nudge campaign pending for $version',
     async ({ version, candidateLimit, includePrerelease, result }) => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -2804,6 +2804,9 @@ describe('updater', () => {
     await vi.waitFor(() => {
       expect(fetchNewerReleaseTagsMock).toHaveBeenCalledTimes(1)
     })
+    expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.26', 1, {
+      includePrerelease: false
+    })
     expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
     expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
 
@@ -2821,7 +2824,7 @@ describe('updater', () => {
   it('keeps a nudge campaign pending when release assets are still publishing', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
-    appMock.getVersion.mockReturnValue('1.4.26')
+    appMock.getVersion.mockReturnValue('1.4.26-rc.1')
     fetchNudgeMock.mockResolvedValueOnce({ id: 'campaign-1', minVersion: '1.0.0' })
     fetchNudgeMock.mockResolvedValue(null)
     shouldApplyNudgeMock.mockReturnValue(true)
@@ -2852,6 +2855,9 @@ describe('updater', () => {
 
     await vi.waitFor(() => {
       expect(fetchNewerReleaseTagsMock).toHaveBeenCalledTimes(1)
+    })
+    expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.26-rc.1', 2, {
+      includePrerelease: true
     })
     expect(setPendingUpdateNudgeId).toHaveBeenCalledWith('campaign-1')
     expect(setPendingUpdateNudgeId).not.toHaveBeenCalledWith(null)

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -2833,6 +2833,12 @@ describe('updater', () => {
       candidateLimit: 2,
       includePrerelease: true,
       result: { tags: [], state: 'not-ready' as const }
+    },
+    {
+      version: '1.4.26',
+      candidateLimit: 1,
+      includePrerelease: false,
+      result: { tags: [], state: 'unavailable' as const, unavailableReason: 'manifest' as const }
     }
   ])(
     'keeps a nudge campaign pending for $version',

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1475,7 +1475,7 @@ describe('updater', () => {
     await vi.waitFor(() => {
       expect(sendMock).toHaveBeenCalledWith('updater:status', {
         state: 'error',
-        message: 'A new release is still being published. Try again shortly.',
+        message: "Couldn't reach the update server. Try again in a few minutes.",
         userInitiated: true
       })
     })
@@ -2503,6 +2503,34 @@ describe('updater', () => {
     })
   })
 
+  it('keeps unavailable release probes on generic copy without launching a moving feed', async () => {
+    appMock.getVersion.mockReturnValue('1.4.141')
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'unavailable' })
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    const feedCallsBeforeCheck = autoUpdaterMock.setFeedURL.mock.calls.length
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'error',
+        message: "Couldn't reach the update server. Try again in a few minutes.",
+        userInitiated: true
+      })
+    })
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+    expect(autoUpdaterMock.setFeedURL.mock.calls.slice(feedCallsBeforeCheck)).not.toContainEqual([
+      {
+        provider: 'generic',
+        url: 'https://github.com/stablyai/orca/releases/latest/download'
+      }
+    ])
+  })
+
   it('uses last-good concrete feed when a user-initiated check lands during publishing', async () => {
     appMock.getVersion.mockReturnValue('1.4.26')
     fetchNewerReleaseTagsMock.mockResolvedValue({
@@ -2525,7 +2553,6 @@ describe('updater', () => {
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     const feedCallsBeforeCheck = autoUpdaterMock.setFeedURL.mock.calls.length
-
     checkForUpdatesFromMenu()
 
     await vi.waitFor(() => {

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -2852,7 +2852,9 @@ describe('updater', () => {
       fetchNudgeMock.mockResolvedValueOnce({ id: 'campaign-1', minVersion: '1.0.0' })
       fetchNudgeMock.mockResolvedValue(null)
       shouldApplyNudgeMock.mockReturnValue(true)
-      fetchNewerReleaseTagsMock.mockResolvedValueOnce(result).mockResolvedValueOnce(['v1.4.27'])
+      fetchNewerReleaseTagsMock
+        .mockResolvedValueOnce(result)
+        .mockResolvedValueOnce({ tags: ['v1.4.27'], state: 'ready' })
       autoUpdaterMock.checkForUpdates.mockImplementation(() => {
         autoUpdaterMock.emit('checking-for-update')
         return Promise.resolve(undefined)

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -2535,6 +2535,33 @@ describe('updater', () => {
     ])
   })
 
+  it('keeps Atom feed outages on the existing moving-feed fallback', async () => {
+    appMock.getVersion.mockReturnValue('1.4.141')
+    fetchNewerReleaseTagsMock.mockResolvedValue({
+      tags: [],
+      state: 'unavailable',
+      unavailableReason: 'feed'
+    })
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/latest/download'
+    })
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'error' })
+    )
+  })
+
   it('uses last-good concrete feed when a user-initiated check lands during publishing', async () => {
     appMock.getVersion.mockReturnValue('1.4.26')
     fetchNewerReleaseTagsMock.mockResolvedValue({

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1493,6 +1493,36 @@ describe('updater', () => {
     })
   })
 
+  it('keeps perf manifest outages benign without recording a completed check', async () => {
+    appMock.getVersion.mockReturnValue('1.4.120')
+    fetchNewerReleaseTagsMock.mockResolvedValue({
+      tags: [],
+      state: 'unavailable',
+      unavailableReason: 'manifest'
+    })
+    const setLastUpdateCheckAt = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      setLastUpdateCheckAt
+    })
+    checkForUpdatesFromMenu({ includePerfPrerelease: true })
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'error',
+        message: "Couldn't reach the update server. Try again in a few minutes.",
+        userInitiated: true
+      })
+    })
+    expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+  })
+
   it('keeps prerelease publishing-window misses on the generic retry path', async () => {
     appMock.getVersion.mockReturnValue('1.4.120-rc.5')
     fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'not-ready' })
@@ -2821,65 +2851,85 @@ describe('updater', () => {
     })
   })
 
-  it('keeps a nudge campaign pending when release assets are still publishing', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
-    appMock.getVersion.mockReturnValue('1.4.26-rc.1')
-    fetchNudgeMock.mockResolvedValueOnce({ id: 'campaign-1', minVersion: '1.0.0' })
-    fetchNudgeMock.mockResolvedValue(null)
-    shouldApplyNudgeMock.mockReturnValue(true)
-    fetchNewerReleaseTagsMock
-      .mockResolvedValueOnce({ tags: [], state: 'not-ready' })
-      .mockResolvedValueOnce(['v1.4.27'])
-    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
-      autoUpdaterMock.emit('checking-for-update')
-      return Promise.resolve(undefined)
-    })
-    let pendingNudgeId: string | null = null
-    const setPendingUpdateNudgeId = vi.fn((id: string | null) => {
-      pendingNudgeId = id
-    })
-    const setDismissedUpdateNudgeId = vi.fn()
-    const sendMock = vi.fn()
-    const mainWindow = { webContents: { send: sendMock } }
+  it.each([
+    {
+      version: '1.4.26',
+      candidateLimit: 1,
+      includePrerelease: false,
+      result: { tags: [], state: 'not-ready' as const }
+    },
+    {
+      version: '1.4.26-rc.1',
+      candidateLimit: 2,
+      includePrerelease: true,
+      result: { tags: [], state: 'not-ready' as const }
+    },
+    {
+      version: '1.4.26',
+      candidateLimit: 1,
+      includePrerelease: false,
+      result: { tags: [], state: 'unavailable' as const, unavailableReason: 'manifest' as const }
+    }
+  ])(
+    'keeps a nudge campaign pending across release channels',
+    async ({ version, candidateLimit, includePrerelease, result }) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
+      appMock.getVersion.mockReturnValue(version)
+      fetchNudgeMock.mockResolvedValueOnce({ id: 'campaign-1', minVersion: '1.0.0' })
+      fetchNudgeMock.mockResolvedValue(null)
+      shouldApplyNudgeMock.mockReturnValue(true)
+      fetchNewerReleaseTagsMock.mockResolvedValueOnce(result).mockResolvedValueOnce(['v1.4.27'])
+      autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+        autoUpdaterMock.emit('checking-for-update')
+        return Promise.resolve(undefined)
+      })
+      let pendingNudgeId: string | null = null
+      const setPendingUpdateNudgeId = vi.fn((id: string | null) => {
+        pendingNudgeId = id
+      })
+      const setDismissedUpdateNudgeId = vi.fn()
+      const sendMock = vi.fn()
+      const mainWindow = { webContents: { send: sendMock } }
 
-    const { setupAutoUpdater } = await import('./updater')
+      const { setupAutoUpdater } = await import('./updater')
 
-    setupAutoUpdater(mainWindow as never, {
-      getLastUpdateCheckAt: () => Date.now(),
-      getPendingUpdateNudgeId: () => pendingNudgeId,
-      getDismissedUpdateNudgeId: () => null,
-      setPendingUpdateNudgeId,
-      setDismissedUpdateNudgeId
-    })
+      setupAutoUpdater(mainWindow as never, {
+        getLastUpdateCheckAt: () => Date.now(),
+        getPendingUpdateNudgeId: () => pendingNudgeId,
+        getDismissedUpdateNudgeId: () => null,
+        setPendingUpdateNudgeId,
+        setDismissedUpdateNudgeId
+      })
 
-    await vi.waitFor(() => {
-      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledTimes(1)
-    })
-    expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.26-rc.1', 2, {
-      includePrerelease: true
-    })
-    expect(setPendingUpdateNudgeId).toHaveBeenCalledWith('campaign-1')
-    expect(setPendingUpdateNudgeId).not.toHaveBeenCalledWith(null)
-    expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
-    expect(pendingNudgeId).toBe('campaign-1')
+      await vi.waitFor(() => {
+        expect(fetchNewerReleaseTagsMock).toHaveBeenCalledTimes(1)
+      })
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith(version, candidateLimit, {
+        includePrerelease
+      })
+      expect(setPendingUpdateNudgeId).toHaveBeenCalledWith('campaign-1')
+      expect(setPendingUpdateNudgeId).not.toHaveBeenCalledWith(null)
+      expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
+      expect(pendingNudgeId).toBe('campaign-1')
 
-    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
 
-    await vi.waitFor(() => {
-      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
-    })
-    autoUpdaterMock.emit('update-available', { version: '1.4.27' })
-    await vi.advanceTimersByTimeAsync(0)
+      await vi.waitFor(() => {
+        expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+      })
+      autoUpdaterMock.emit('update-available', { version: '1.4.27' })
+      await vi.advanceTimersByTimeAsync(0)
 
-    expect(sendMock).toHaveBeenCalledWith('updater:status', {
-      state: 'available',
-      version: '1.4.27',
-      changelog: null,
-      activeNudgeId: 'campaign-1'
-    })
-    expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
-  })
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.4.27',
+        changelog: null,
+        activeNudgeId: 'campaign-1'
+      })
+      expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
+    }
+  )
 
   it('does not dismiss a nudge when last-good fallback is current during publishing', async () => {
     vi.useFakeTimers()

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1493,6 +1493,31 @@ describe('updater', () => {
     })
   })
 
+  it('keeps prerelease publishing-window misses on the generic retry path', async () => {
+    appMock.getVersion.mockReturnValue('1.4.120-rc.5')
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'not-ready' })
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu({ includePrerelease: true })
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'error',
+        message: "Couldn't reach the update server. Try again in a few minutes.",
+        userInitiated: true
+      })
+    })
+    expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.120-rc.5', 2, {
+      includePrerelease: true
+    })
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+  })
+
   it('leaves the feed URL alone for a normal user-initiated check', async () => {
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
     const mainWindow = { webContents: { send: vi.fn() } }

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -2505,7 +2505,11 @@ describe('updater', () => {
 
   it('keeps unavailable release probes on generic copy without launching a moving feed', async () => {
     appMock.getVersion.mockReturnValue('1.4.141')
-    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'unavailable' })
+    fetchNewerReleaseTagsMock.mockResolvedValue({
+      tags: [],
+      state: 'unavailable',
+      unavailableReason: 'manifest'
+    })
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -2823,25 +2823,28 @@ describe('updater', () => {
 
   it.each([
     {
+      caseName: 'stable-not-ready',
       version: '1.4.26',
       candidateLimit: 1,
       includePrerelease: false,
       result: { tags: [], state: 'not-ready' as const }
     },
     {
+      caseName: 'prerelease-not-ready',
       version: '1.4.26-rc.1',
       candidateLimit: 2,
       includePrerelease: true,
       result: { tags: [], state: 'not-ready' as const }
     },
     {
+      caseName: 'stable-manifest-unavailable',
       version: '1.4.26',
       candidateLimit: 1,
       includePrerelease: false,
       result: { tags: [], state: 'unavailable' as const, unavailableReason: 'manifest' as const }
     }
   ])(
-    'keeps a nudge campaign pending for $version',
+    'keeps a nudge campaign pending for $caseName',
     async ({ version, candidateLimit, includePrerelease, result }) => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1136,9 +1136,9 @@ async function pinDefaultReleaseFeed(
       return 'ready'
     }
     clearPublishingWindowLastGoodCheck()
-    if (isPerfCheck) {
-      // Why: perf checks retain their legacy generic retry path; publishing
-      // copy is reserved for the stable release publication classifier.
+    if (isPerfCheck || includePrerelease) {
+      // Why: prerelease channels retain their legacy generic retry path;
+      // publishing copy is reserved for the stable release classifier.
       throw new Error('Unable to find latest version on GitHub')
     }
     console.info(

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1123,7 +1123,7 @@ async function pinDefaultReleaseFeed(
     )
     autoUpdater.setFeedURL({ provider: 'generic', url })
     return 'ready'
-  } else if (releaseTagsResult.state === 'not-ready') {
+  } else if (releaseTagsResult.state === 'not-ready' && !isPerfCheck) {
     clearPrereleaseFallbackContext()
     if (releaseTagsResult.lastGoodTag) {
       // Why: during a publish window the newest tag is unsafe; a verified last-good concrete feed lets electron-updater emit a real result.
@@ -1149,7 +1149,11 @@ async function pinDefaultReleaseFeed(
       )
       return 'not-available'
     }
-    throw new Error('Could not resolve perf update feed')
+    throw new Error('Unable to find latest version on GitHub')
+  } else if (releaseTagsResult.state === 'unavailable') {
+    clearPrereleaseFallbackContext()
+    clearPublishingWindowLastGoodCheck()
+    throw new Error('Unable to find latest version on GitHub')
   } else {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1137,6 +1137,8 @@ async function pinDefaultReleaseFeed(
     }
     clearPublishingWindowLastGoodCheck()
     if (isPerfCheck) {
+      // Why: perf checks retain their legacy generic retry path; publishing
+      // copy is reserved for the stable release publication classifier.
       throw new Error('Unable to find latest version on GitHub')
     }
     console.info(
@@ -1152,7 +1154,7 @@ async function pinDefaultReleaseFeed(
       )
       return 'not-available'
     }
-    throw new Error('Unable to find latest version on GitHub')
+    throw new Error('Could not resolve perf update feed')
   } else if (
     releaseTagsResult.state === 'unavailable' &&
     releaseTagsResult.unavailableReason === 'manifest'

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -50,6 +50,7 @@ type CheckFailureSource = 'event' | 'promise' | 'fallback-promise'
 type MissingManifestPrereleaseFallbackResult = { userInitiated: boolean }
 type PrimaryEventSuppression = { failureKey: string; error: unknown }
 type UpdateCheckVariant = 'default' | 'prerelease' | 'perf'
+type ReleasePublishingError = Error & { updaterReleaseChannel?: UpdateCheckVariant }
 type ReleaseFeedPreflightResult = 'ready' | 'not-available'
 export type UpdateInstallMode =
   | 'interactive'
@@ -855,7 +856,7 @@ async function sendCheckFailureStatus(
       if (userInitiated) {
         // Why: a user click needs visible feedback (idle looks broken); distinguish incomplete releases from transport failures.
         sendErrorStatus(
-          isReleaseAssetsPublishingFailure(message)
+          isStableReleasePublishingFailure(message, sourceError)
             ? 'A new release is still being published. Try again shortly.'
             : "Couldn't reach the update server. Try again in a few minutes.",
           true
@@ -886,6 +887,14 @@ async function sendCheckFailureStatus(
     }
   })
   return pendingCheckFailurePromise
+}
+
+function isStableReleasePublishingFailure(message: string, sourceError: unknown): boolean {
+  if (!isReleaseAssetsPublishingFailure(message)) {
+    return false
+  }
+  const channel = (sourceError as ReleasePublishingError | null)?.updaterReleaseChannel
+  return channel === undefined || channel === 'default'
 }
 
 export function getUpdateStatus(): UpdateStatus {
@@ -1136,15 +1145,16 @@ async function pinDefaultReleaseFeed(
       return 'ready'
     }
     clearPublishingWindowLastGoodCheck()
-    if (isPerfCheck || includePrerelease) {
-      // Why: prerelease channels retain their legacy generic retry path;
-      // publishing copy is reserved for the stable release classifier.
-      throw new Error('Unable to find latest version on GitHub')
-    }
     console.info(
       `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are still publishing`
     )
-    throw new Error('Latest release assets are still publishing')
+    const error = new Error('Latest release assets are still publishing') as ReleasePublishingError
+    error.updaterReleaseChannel = isPerfCheck
+      ? 'perf'
+      : includePrerelease
+        ? 'prerelease'
+        : 'default'
+    throw error
   } else if (isPerfCheck) {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1167,7 +1167,8 @@ async function pinDefaultReleaseFeed(
     throw error
   } else if (
     releaseTagsResult.state === 'unavailable' &&
-    releaseTagsResult.unavailableReason === 'manifest'
+    releaseTagsResult.unavailableReason === 'manifest' &&
+    !includePrerelease
   ) {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1123,7 +1123,7 @@ async function pinDefaultReleaseFeed(
     )
     autoUpdater.setFeedURL({ provider: 'generic', url })
     return 'ready'
-  } else if (releaseTagsResult.state === 'not-ready' && !isPerfCheck) {
+  } else if (releaseTagsResult.state === 'not-ready') {
     clearPrereleaseFallbackContext()
     if (releaseTagsResult.lastGoodTag) {
       // Why: during a publish window the newest tag is unsafe; a verified last-good concrete feed lets electron-updater emit a real result.
@@ -1136,6 +1136,9 @@ async function pinDefaultReleaseFeed(
       return 'ready'
     }
     clearPublishingWindowLastGoodCheck()
+    if (isPerfCheck) {
+      throw new Error('Unable to find latest version on GitHub')
+    }
     console.info(
       `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are still publishing`
     )
@@ -1150,7 +1153,10 @@ async function pinDefaultReleaseFeed(
       return 'not-available'
     }
     throw new Error('Unable to find latest version on GitHub')
-  } else if (releaseTagsResult.state === 'unavailable') {
+  } else if (
+    releaseTagsResult.state === 'unavailable' &&
+    releaseTagsResult.unavailableReason === 'manifest'
+  ) {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()
     throw new Error('Unable to find latest version on GitHub')

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -30,7 +30,6 @@ import {
   isBenignCheckFailure,
   isMissingUpdateManifestFailure,
   isPrereleaseVersion,
-  isReleaseAssetsPublishingFailure,
   statusesEqual
 } from './updater-fallback'
 import {
@@ -859,8 +858,8 @@ async function sendCheckFailureStatus(
   }
 
   const handleFailure = async (): Promise<void> => {
-    if (isBenignCheckFailure(message)) {
-      // Why: benign failures (publishing latest.yml, network blips) are transient — retry, and skip persisting the timestamp (would suppress the next startup check).
+    if (isBenignCheckFailure(message) || isRetryableReleaseFeedPreflightFailure(sourceError)) {
+      // Why: benign failures (incomplete latest.yml, network blips) are transient — retry, and skip persisting the timestamp (would suppress the next startup check).
       console.warn('[updater] benign check failure:', message)
       clearAvailableUpdateContext()
       scheduleAutomaticUpdateCheck(AUTO_UPDATE_RETRY_INTERVAL_MS)
@@ -873,7 +872,7 @@ async function sendCheckFailureStatus(
           true
         )
       } else {
-        if (shouldPreserveNudgeForReleaseProbe(message, sourceError)) {
+        if (isRetryableReleaseFeedPreflightFailure(sourceError)) {
           // Why: release probes can fail transiently; keep the campaign pending so the short retry can still show it.
           deferPendingUpdateNudgeUntilRetry()
         }
@@ -900,11 +899,10 @@ async function sendCheckFailureStatus(
   return pendingCheckFailurePromise
 }
 
-function shouldPreserveNudgeForReleaseProbe(message: string, sourceError: unknown): boolean {
+function isRetryableReleaseFeedPreflightFailure(sourceError: unknown): boolean {
   return (
-    isReleaseAssetsPublishingFailure(message) ||
-    (sourceError instanceof ReleaseFeedPreflightError &&
-      sourceError.reason === 'manifest-unavailable')
+    sourceError instanceof ReleaseFeedPreflightError &&
+    (sourceError.reason === 'release-not-ready' || sourceError.reason === 'manifest-unavailable')
   )
 }
 
@@ -1170,7 +1168,7 @@ async function pinDefaultReleaseFeed(
     throw new ReleaseFeedPreflightError(
       'release-not-ready',
       isPerfCheck ? 'perf' : includePrerelease ? 'prerelease' : 'default',
-      'Latest release assets are still publishing'
+      'Latest release artifacts are not ready'
     )
   } else if (
     releaseTagsResult.state === 'unavailable' &&

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -904,7 +904,7 @@ function isStableReleasePublishingFailure(message: string, sourceError: unknown)
     return false
   }
   const channel = (sourceError as ReleasePublishingError | null)?.updaterReleaseChannel
-  return channel === undefined || channel === 'default'
+  return channel === 'default'
 }
 
 export function getUpdateStatus(): UpdateStatus {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -50,7 +50,7 @@ type CheckFailureSource = 'event' | 'promise' | 'fallback-promise'
 type MissingManifestPrereleaseFallbackResult = { userInitiated: boolean }
 type PrimaryEventSuppression = { failureKey: string; error: unknown }
 type UpdateCheckVariant = 'default' | 'prerelease' | 'perf'
-type ReleaseFeedPreflightFailure = 'manifest-unavailable' | 'release-publishing'
+type ReleaseFeedPreflightFailure = 'manifest-unavailable' | 'release-not-ready'
 // Why: expected preflight outcomes need typed context so UI routing never depends on matching error text.
 class ReleaseFeedPreflightError extends Error {
   constructor(
@@ -867,8 +867,8 @@ async function sendCheckFailureStatus(
       if (userInitiated) {
         // Why: a user click needs visible feedback (idle looks broken); distinguish incomplete releases from transport failures.
         sendErrorStatus(
-          isStableReleasePublishingFailure(sourceError)
-            ? 'A new release is still being published. Try again shortly.'
+          isStableReleaseNotReadyFailure(sourceError)
+            ? "A newer release isn't available for this device yet. Check again later."
             : "Couldn't reach the update server. Try again in a few minutes.",
           true
         )
@@ -908,10 +908,10 @@ function shouldPreserveNudgeForReleaseProbe(message: string, sourceError: unknow
   )
 }
 
-function isStableReleasePublishingFailure(sourceError: unknown): boolean {
+function isStableReleaseNotReadyFailure(sourceError: unknown): boolean {
   return (
     sourceError instanceof ReleaseFeedPreflightError &&
-    sourceError.reason === 'release-publishing' &&
+    sourceError.reason === 'release-not-ready' &&
     sourceError.releaseChannel === 'default'
   )
 }
@@ -1165,10 +1165,10 @@ async function pinDefaultReleaseFeed(
     }
     clearPublishingWindowLastGoodCheck()
     console.info(
-      `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are still publishing`
+      `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are not ready`
     )
     throw new ReleaseFeedPreflightError(
-      'release-publishing',
+      'release-not-ready',
       isPerfCheck ? 'perf' : includePrerelease ? 'prerelease' : 'default',
       'Latest release assets are still publishing'
     )

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -50,7 +50,10 @@ type CheckFailureSource = 'event' | 'promise' | 'fallback-promise'
 type MissingManifestPrereleaseFallbackResult = { userInitiated: boolean }
 type PrimaryEventSuppression = { failureKey: string; error: unknown }
 type UpdateCheckVariant = 'default' | 'prerelease' | 'perf'
-type ReleasePublishingError = Error & { updaterReleaseChannel?: UpdateCheckVariant }
+type ReleasePublishingError = Error & {
+  updaterReleaseChannel?: UpdateCheckVariant
+  updaterPreserveNudge?: boolean
+}
 type ReleaseFeedPreflightResult = 'ready' | 'not-available'
 export type UpdateInstallMode =
   | 'interactive'
@@ -862,8 +865,8 @@ async function sendCheckFailureStatus(
           true
         )
       } else {
-        if (isReleaseAssetsPublishingFailure(message)) {
-          // Why: a nudge check can land while GitHub exposes a release before its assets; keep the campaign pending so the short retry can show it.
+        if (shouldPreserveNudgeForReleaseProbe(message, sourceError)) {
+          // Why: release probes can fail transiently; keep the campaign pending so the short retry can still show it.
           deferPendingUpdateNudgeUntilRetry()
         }
         sendStatus({ state: 'idle' })
@@ -887,6 +890,13 @@ async function sendCheckFailureStatus(
     }
   })
   return pendingCheckFailurePromise
+}
+
+function shouldPreserveNudgeForReleaseProbe(message: string, sourceError: unknown): boolean {
+  return (
+    isReleaseAssetsPublishingFailure(message) ||
+    (sourceError as ReleasePublishingError | null)?.updaterPreserveNudge === true
+  )
 }
 
 function isStableReleasePublishingFailure(message: string, sourceError: unknown): boolean {
@@ -1155,6 +1165,20 @@ async function pinDefaultReleaseFeed(
         ? 'prerelease'
         : 'default'
     throw error
+  } else if (
+    releaseTagsResult.state === 'unavailable' &&
+    releaseTagsResult.unavailableReason === 'manifest'
+  ) {
+    clearPrereleaseFallbackContext()
+    clearPublishingWindowLastGoodCheck()
+    const error = new Error('Unable to find latest version on GitHub') as ReleasePublishingError
+    error.updaterReleaseChannel = isPerfCheck
+      ? 'perf'
+      : includePrerelease
+        ? 'prerelease'
+        : 'default'
+    error.updaterPreserveNudge = true
+    throw error
   } else if (isPerfCheck) {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()
@@ -1165,13 +1189,6 @@ async function pinDefaultReleaseFeed(
       return 'not-available'
     }
     throw new Error('Could not resolve perf update feed')
-  } else if (
-    releaseTagsResult.state === 'unavailable' &&
-    releaseTagsResult.unavailableReason === 'manifest'
-  ) {
-    clearPrereleaseFallbackContext()
-    clearPublishingWindowLastGoodCheck()
-    throw new Error('Unable to find latest version on GitHub')
   } else {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -853,8 +853,13 @@ async function sendCheckFailureStatus(
       clearAvailableUpdateContext()
       scheduleAutomaticUpdateCheck(AUTO_UPDATE_RETRY_INTERVAL_MS)
       if (userInitiated) {
-        // Why: a user click needs visible feedback (idle looks broken); the UI already prefixes context, so this carries only the actionable cause.
-        sendErrorStatus("Couldn't reach the update server. Try again in a few minutes.", true)
+        // Why: a user click needs visible feedback (idle looks broken); distinguish incomplete releases from transport failures.
+        sendErrorStatus(
+          isReleaseAssetsPublishingFailure(message)
+            ? 'A new release is still being published. Try again shortly.'
+            : "Couldn't reach the update server. Try again in a few minutes.",
+          true
+        )
       } else {
         if (isReleaseAssetsPublishingFailure(message)) {
           // Why: a nudge check can land while GitHub exposes a release before its assets; keep the campaign pending so the short retry can show it.

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -50,9 +50,17 @@ type CheckFailureSource = 'event' | 'promise' | 'fallback-promise'
 type MissingManifestPrereleaseFallbackResult = { userInitiated: boolean }
 type PrimaryEventSuppression = { failureKey: string; error: unknown }
 type UpdateCheckVariant = 'default' | 'prerelease' | 'perf'
-type ReleasePublishingError = Error & {
-  updaterReleaseChannel?: UpdateCheckVariant
-  updaterPreserveNudge?: boolean
+type ReleaseFeedPreflightFailure = 'manifest-unavailable' | 'release-publishing'
+// Why: expected preflight outcomes need typed context so UI routing never depends on matching error text.
+class ReleaseFeedPreflightError extends Error {
+  constructor(
+    readonly reason: ReleaseFeedPreflightFailure,
+    readonly releaseChannel: UpdateCheckVariant,
+    message: string
+  ) {
+    super(message)
+    this.name = 'ReleaseFeedPreflightError'
+  }
 }
 type ReleaseFeedPreflightResult = 'ready' | 'not-available'
 export type UpdateInstallMode =
@@ -859,7 +867,7 @@ async function sendCheckFailureStatus(
       if (userInitiated) {
         // Why: a user click needs visible feedback (idle looks broken); distinguish incomplete releases from transport failures.
         sendErrorStatus(
-          isStableReleasePublishingFailure(message, sourceError)
+          isStableReleasePublishingFailure(sourceError)
             ? 'A new release is still being published. Try again shortly.'
             : "Couldn't reach the update server. Try again in a few minutes.",
           true
@@ -895,16 +903,17 @@ async function sendCheckFailureStatus(
 function shouldPreserveNudgeForReleaseProbe(message: string, sourceError: unknown): boolean {
   return (
     isReleaseAssetsPublishingFailure(message) ||
-    (sourceError as ReleasePublishingError | null)?.updaterPreserveNudge === true
+    (sourceError instanceof ReleaseFeedPreflightError &&
+      sourceError.reason === 'manifest-unavailable')
   )
 }
 
-function isStableReleasePublishingFailure(message: string, sourceError: unknown): boolean {
-  if (!isReleaseAssetsPublishingFailure(message)) {
-    return false
-  }
-  const channel = (sourceError as ReleasePublishingError | null)?.updaterReleaseChannel
-  return channel === 'default'
+function isStableReleasePublishingFailure(sourceError: unknown): boolean {
+  return (
+    sourceError instanceof ReleaseFeedPreflightError &&
+    sourceError.reason === 'release-publishing' &&
+    sourceError.releaseChannel === 'default'
+  )
 }
 
 export function getUpdateStatus(): UpdateStatus {
@@ -1158,13 +1167,11 @@ async function pinDefaultReleaseFeed(
     console.info(
       `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are still publishing`
     )
-    const error = new Error('Latest release assets are still publishing') as ReleasePublishingError
-    error.updaterReleaseChannel = isPerfCheck
-      ? 'perf'
-      : includePrerelease
-        ? 'prerelease'
-        : 'default'
-    throw error
+    throw new ReleaseFeedPreflightError(
+      'release-publishing',
+      isPerfCheck ? 'perf' : includePrerelease ? 'prerelease' : 'default',
+      'Latest release assets are still publishing'
+    )
   } else if (
     releaseTagsResult.state === 'unavailable' &&
     releaseTagsResult.unavailableReason === 'manifest' &&
@@ -1172,14 +1179,11 @@ async function pinDefaultReleaseFeed(
   ) {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()
-    const error = new Error('Unable to find latest version on GitHub') as ReleasePublishingError
-    error.updaterReleaseChannel = isPerfCheck
-      ? 'perf'
-      : includePrerelease
-        ? 'prerelease'
-        : 'default'
-    error.updaterPreserveNudge = true
-    throw error
+    throw new ReleaseFeedPreflightError(
+      'manifest-unavailable',
+      'default',
+      'Unable to find latest version on GitHub'
+    )
   } else if (isPerfCheck) {
     clearPrereleaseFallbackContext()
     clearPublishingWindowLastGoodCheck()


### PR DESCRIPTION
## Summary

- Report that a new release is still being published when a manual update check finds an Atom-listed stable tag with missing updater assets.
- Keep real network failures on the existing network message, preserve verified last-good fallback, and retain the short publishing-window retry.

Closes #8869.

## Screenshots

No visual change.

## Testing

- [x] Added or updated high-quality tests that catch regressions.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/updater-prerelease-feed.test.ts src/main/updater-prerelease-feed-readiness.test.ts src/main/updater.check-failure.test.ts` passed; 3 files and 45 tests passed.
- `pnpm run typecheck:node` passed.
- `pnpm exec oxlint src/main/updater-prerelease-feed.ts src/main/updater.ts src/main/updater-prerelease-feed-readiness.test.ts src/main/updater.check-failure.test.ts` passed.
- `pnpm exec oxfmt --check src/main/updater-prerelease-feed.ts src/main/updater.ts src/main/updater-prerelease-feed-readiness.test.ts src/main/updater.check-failure.test.ts` passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/updater.test.ts -t "publishing|last-good|unavailable release probes|Atom feed outages|manifest outages|nudge campaign pending|prerelease publishing|background retries"` passed; 14 focused tests passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/updater.test.ts` passed; 85 tests passed.

## AI Review Report

Release readiness remains distinct from network and manifest failures across stable, prerelease, and perf channels. Verified last-good fallback, retry and nudge state, asset checks, platform manifest names, and user-facing copy retain their existing behavior outside the publishing-state correction.

## Security Audit

Request timeouts, bounded manifest probes, URL encoding, manifest parsing, and asset verification remain unchanged. No credentials, authentication, subprocesses, filesystem writes, dependencies, or external endpoints were introduced.

## Notes

No visual change. Ordinary network failures remain distinct from an affirmatively unready release.

## ELI5

Checking for updates during a half-published release looked like a network failure. Orca now says the release is still publishing when assets aren’t ready yet.
