### PR TITLE
perf(worktrees): bound runtime discovery scans

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -840,6 +840,40 @@ describe('SSH IPC handlers', () => {
     )
   })
 
+  it('keeps runtime-owned SSH state off the renderer while notifying runtime consumers', async () => {
+    const runtime = {
+      onPtyData: vi.fn(),
+      onPtyExit: vi.fn(),
+      notifySshStateChanged: vi.fn()
+    }
+    registerSshHandlers(mockStore as never, () => mockWindow as never, runtime as never)
+    mockSshStore.getTarget.mockReturnValue({
+      id: 'runtime-ssh-1',
+      label: 'Runtime host',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    } satisfies SshTarget)
+    mockConnectionManager.connect.mockResolvedValue({})
+    mockConnectionManager.getState.mockReturnValue({
+      targetId: 'runtime-ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+
+    await handlers.get('ssh:connect')!(null, { targetId: 'runtime-ssh-1' })
+
+    expect(mockWindow.webContents.send).not.toHaveBeenCalledWith(
+      'ssh:state-changed',
+      expect.anything()
+    )
+    expect(runtime.notifySshStateChanged).toHaveBeenCalledWith(
+      'runtime-ssh-1',
+      expect.objectContaining({ targetId: 'runtime-ssh-1', status: 'connected' })
+    )
+  })
+
   it('preserves active port forwards and live connections across handler re-registration', async () => {
     const target: SshTarget = {
       id: 'ssh-1',

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -214,7 +214,11 @@ vi.mock('../ssh/ssh-port-scanner', () => ({
 }))
 
 import { getSshConnectionManager, registerSshHandlers, resetSshHandlerStateForTests } from './ssh'
-import { SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD, type SshTarget } from '../../shared/ssh-types'
+import {
+  SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD,
+  type SshConnectionState,
+  type SshTarget
+} from '../../shared/ssh-types'
 import {
   clearProviderPtyState,
   deletePtyOwnership,
@@ -871,6 +875,34 @@ describe('SSH IPC handlers', () => {
     expect(runtime.notifySshStateChanged).toHaveBeenCalledWith(
       'runtime-ssh-1',
       expect.objectContaining({ targetId: 'runtime-ssh-1', status: 'connected' })
+    )
+  })
+
+  it('notifies runtime consumers from hidden SSH state broadcasts', () => {
+    const runtime = {
+      onPtyData: vi.fn(),
+      onPtyExit: vi.fn(),
+      notifySshStateChanged: vi.fn()
+    }
+    registerSshHandlers(mockStore as never, () => mockWindow as never, runtime as never)
+    const callbacks = mockConnectionManager.callbacksRef.current as {
+      onStateChange: (targetId: string, state: SshConnectionState) => void
+    }
+
+    callbacks.onStateChange('runtime-ssh-1', {
+      targetId: 'runtime-ssh-1',
+      status: 'disconnected',
+      error: null,
+      reconnectAttempt: 1
+    })
+
+    expect(runtime.notifySshStateChanged).toHaveBeenCalledWith(
+      'runtime-ssh-1',
+      expect.objectContaining({ targetId: 'runtime-ssh-1', status: 'disconnected' })
+    )
+    expect(mockWindow.webContents.send).not.toHaveBeenCalledWith(
+      'ssh:state-changed',
+      expect.anything()
     )
   })
 

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -844,10 +844,11 @@ describe('SSH IPC handlers', () => {
     )
   })
 
-  it('keeps runtime-owned SSH state off the renderer while notifying runtime consumers', async () => {
+  it('keeps runtime-owned SSH state off the renderer while invalidating runtime scans', async () => {
     const runtime = {
       onPtyData: vi.fn(),
       onPtyExit: vi.fn(),
+      invalidateSshWorktreeScanCache: vi.fn(),
       notifySshStateChanged: vi.fn()
     }
     registerSshHandlers(mockStore as never, () => mockWindow as never, runtime as never)
@@ -872,16 +873,15 @@ describe('SSH IPC handlers', () => {
       'ssh:state-changed',
       expect.anything()
     )
-    expect(runtime.notifySshStateChanged).toHaveBeenCalledWith(
-      'runtime-ssh-1',
-      expect.objectContaining({ targetId: 'runtime-ssh-1', status: 'connected' })
-    )
+    expect(runtime.invalidateSshWorktreeScanCache).toHaveBeenCalledWith('runtime-ssh-1')
+    expect(runtime.notifySshStateChanged).not.toHaveBeenCalled()
   })
 
-  it('notifies runtime consumers from hidden SSH state broadcasts', () => {
+  it('invalidates runtime scans from hidden SSH state broadcasts', () => {
     const runtime = {
       onPtyData: vi.fn(),
       onPtyExit: vi.fn(),
+      invalidateSshWorktreeScanCache: vi.fn(),
       notifySshStateChanged: vi.fn()
     }
     registerSshHandlers(mockStore as never, () => mockWindow as never, runtime as never)
@@ -896,10 +896,8 @@ describe('SSH IPC handlers', () => {
       reconnectAttempt: 1
     })
 
-    expect(runtime.notifySshStateChanged).toHaveBeenCalledWith(
-      'runtime-ssh-1',
-      expect.objectContaining({ targetId: 'runtime-ssh-1', status: 'disconnected' })
-    )
+    expect(runtime.invalidateSshWorktreeScanCache).toHaveBeenCalledWith('runtime-ssh-1')
+    expect(runtime.notifySshStateChanged).not.toHaveBeenCalled()
     expect(mockWindow.webContents.send).not.toHaveBeenCalledWith(
       'ssh:state-changed',
       expect.anything()

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -245,7 +245,7 @@ function broadcastSshState(
   // has no surface for them. Broadcasting their state would make the renderer fire
   // a listTargets() lookup per event (incl. each relay-lost reconnect) for nothing.
   if (isRuntimeOwnedSshTargetId(targetId)) {
-    currentRuntime?.notifySshStateChanged?.(targetId, enrichedState)
+    currentRuntime?.invalidateSshWorktreeScanCache?.(targetId)
     return
   }
   const win = getMainWindow()
@@ -934,7 +934,11 @@ export function registerSshHandlers(
           state: connectedState
         })
       }
-      currentRuntime?.notifySshStateChanged?.(targetId, connectedState)
+      if (isRuntimeOwnedSshTargetId(targetId)) {
+        currentRuntime?.invalidateSshWorktreeScanCache?.(targetId)
+      } else {
+        currentRuntime?.notifySshStateChanged?.(targetId, connectedState)
+      }
     } catch (err) {
       // Relay deployment failed — disconnect SSH
       activeSessions.delete(targetId)

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -240,7 +240,6 @@ function broadcastSshState(
   targetId: string,
   state: SshConnectionState
 ): void {
-  const enrichedState = withSshRemotePlatform(targetId, state)
   // Why: runtime-owned (ephemeral-VM) targets are hidden from the renderer, which
   // has no surface for them. Broadcasting their state would make the renderer fire
   // a listTargets() lookup per event (incl. each relay-lost reconnect) for nothing.
@@ -248,6 +247,7 @@ function broadcastSshState(
     currentRuntime?.invalidateSshWorktreeScanCache?.(targetId)
     return
   }
+  const enrichedState = withSshRemotePlatform(targetId, state)
   const win = getMainWindow()
   if (win && !win.isDestroyed()) {
     win.webContents.send('ssh:state-changed', { targetId, state: enrichedState })

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -920,25 +920,13 @@ export function registerSshHandlers(
       // state is stuck there. Send `connected` directly to the renderer
       // instead of going through callbacks.onStateChange, which would
       // trigger the reconnection logic.
-      const win = getCurrentMainWindow()
-      const connectedState = withSshRemotePlatform(targetId, {
+      clearRelayStateOverride(targetId)
+      broadcastSshState(getCurrentMainWindow, targetId, {
         targetId,
         status: 'connected',
         error: null,
         reconnectAttempt: 0
       })
-      clearRelayStateOverride(targetId)
-      if (!isRuntimeOwnedSshTargetId(targetId) && win && !win.isDestroyed()) {
-        win.webContents.send('ssh:state-changed', {
-          targetId,
-          state: connectedState
-        })
-      }
-      if (isRuntimeOwnedSshTargetId(targetId)) {
-        currentRuntime?.invalidateSshWorktreeScanCache?.(targetId)
-      } else {
-        currentRuntime?.notifySshStateChanged?.(targetId, connectedState)
-      }
     } catch (err) {
       // Relay deployment failed — disconnect SSH
       activeSessions.delete(targetId)

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -244,6 +244,7 @@ function broadcastSshState(
   // has no surface for them. Broadcasting their state would make the renderer fire
   // a listTargets() lookup per event (incl. each relay-lost reconnect) for nothing.
   if (isRuntimeOwnedSshTargetId(targetId)) {
+    currentRuntime?.notifySshStateChanged?.(targetId, state)
     return
   }
   const enrichedState = withSshRemotePlatform(targetId, state)
@@ -920,18 +921,20 @@ export function registerSshHandlers(
       // instead of going through callbacks.onStateChange, which would
       // trigger the reconnection logic.
       const win = getCurrentMainWindow()
-      if (win && !win.isDestroyed()) {
-        clearRelayStateOverride(targetId)
+      const connectedState = withSshRemotePlatform(targetId, {
+        targetId,
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0
+      })
+      clearRelayStateOverride(targetId)
+      if (!isRuntimeOwnedSshTargetId(targetId) && win && !win.isDestroyed()) {
         win.webContents.send('ssh:state-changed', {
           targetId,
-          state: withSshRemotePlatform(targetId, {
-            targetId,
-            status: 'connected',
-            error: null,
-            reconnectAttempt: 0
-          })
+          state: connectedState
         })
       }
+      currentRuntime?.notifySshStateChanged?.(targetId, connectedState)
     } catch (err) {
       // Relay deployment failed — disconnect SSH
       activeSessions.delete(targetId)

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -240,14 +240,14 @@ function broadcastSshState(
   targetId: string,
   state: SshConnectionState
 ): void {
+  const enrichedState = withSshRemotePlatform(targetId, state)
   // Why: runtime-owned (ephemeral-VM) targets are hidden from the renderer, which
   // has no surface for them. Broadcasting their state would make the renderer fire
   // a listTargets() lookup per event (incl. each relay-lost reconnect) for nothing.
   if (isRuntimeOwnedSshTargetId(targetId)) {
-    currentRuntime?.notifySshStateChanged?.(targetId, state)
+    currentRuntime?.notifySshStateChanged?.(targetId, enrichedState)
     return
   }
-  const enrichedState = withSshRemotePlatform(targetId, state)
   const win = getMainWindow()
   if (win && !win.isDestroyed()) {
     win.webContents.send('ssh:state-changed', { targetId, state: enrichedState })

--- a/src/main/providers/ssh-git-dispatch.test.ts
+++ b/src/main/providers/ssh-git-dispatch.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getSshGitProviderGeneration,
+  registerSshGitProvider,
+  unregisterSshGitProvider
+} from './ssh-git-dispatch'
+
+describe('SSH Git provider registry', () => {
+  const connectionId = 'ssh-generation-test'
+
+  afterEach(() => {
+    unregisterSshGitProvider(connectionId)
+  })
+
+  it('keeps provider generations monotonic across unregister and re-register', () => {
+    const before = getSshGitProviderGeneration(connectionId)
+    registerSshGitProvider(connectionId, {} as never)
+    const registered = getSshGitProviderGeneration(connectionId)
+    unregisterSshGitProvider(connectionId)
+    const unregistered = getSshGitProviderGeneration(connectionId)
+    registerSshGitProvider(connectionId, {} as never)
+    const reRegistered = getSshGitProviderGeneration(connectionId)
+
+    expect(registered).toBe(before + 1)
+    expect(unregistered).toBe(registered + 1)
+    expect(reRegistered).toBe(unregistered + 1)
+  })
+})

--- a/src/main/providers/ssh-git-dispatch.ts
+++ b/src/main/providers/ssh-git-dispatch.ts
@@ -1,16 +1,24 @@
 import type { SshGitProvider } from './ssh-git-provider'
 
 const sshProviders = new Map<string, SshGitProvider>()
+const sshProviderGenerations = new Map<string, number>()
 
 export const SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE =
   'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
 
 export function registerSshGitProvider(connectionId: string, provider: SshGitProvider): void {
   sshProviders.set(connectionId, provider)
+  sshProviderGenerations.set(connectionId, (sshProviderGenerations.get(connectionId) ?? 0) + 1)
 }
 
 export function unregisterSshGitProvider(connectionId: string): void {
-  sshProviders.delete(connectionId)
+  if (sshProviders.delete(connectionId)) {
+    sshProviderGenerations.set(connectionId, (sshProviderGenerations.get(connectionId) ?? 0) + 1)
+  }
+}
+
+export function getSshGitProviderGeneration(connectionId: string): number {
+  return sshProviderGenerations.get(connectionId) ?? 0
 }
 
 export function getSshGitProvider(connectionId: string): SshGitProvider | undefined {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -30820,6 +30820,35 @@ describe('OrcaRuntimeService', () => {
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(TEST_WORKTREE_ID)
   })
 
+  it('drops the bounded scan cache when orphan-cleanup removal completes', async () => {
+    const runtime = createWorktreeRemovalRuntime()
+    vi.mocked(getEffectiveHooks).mockReturnValue(null)
+    vi.mocked(assertWorktreeCleanForRemoval).mockRejectedValue(
+      Object.assign(new Error('status failed'), {
+        stderr: 'fatal: not a git repository (or any of the parent directories): .git\n'
+      })
+    )
+    vi.mocked(removeWorktree).mockRejectedValue(
+      Object.assign(new Error('git worktree remove failed'), {
+        stderr: `fatal: '${TEST_WORKTREE_PATH}' is not a working tree`
+      })
+    )
+    vi.spyOn(gitRunner, 'gitExecFileAsync').mockResolvedValue({ stdout: '', stderr: '' })
+
+    // Prime the bounded raw scan cache with the worktree still present.
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    await expect(runtime.removeManagedWorktree(TEST_WORKTREE_ID)).resolves.toEqual({})
+
+    // Regression (#8882): the orphan-cleanup removal path must also drop the
+    // bounded raw scan cache, or the removed worktree lingers in listings until
+    // the 30s TTL. Git tracking is now gone, so a fresh scan is empty.
+    vi.mocked(listWorktrees).mockResolvedValue([])
+    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
+      { worktrees: [] }
+    )
+  })
+
   it('runs archive hooks for CLI worktree removal when hooks are explicitly enabled', async () => {
     const runtime = createWorktreeRemovalRuntime()
     vi.mocked(getEffectiveHooks).mockReturnValue({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25372,6 +25372,41 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenCalledTimes(2)
   })
 
+  it('worktree scan cache: ignores a late result from an older runtime key', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    let runtimeDefault: unknown = { kind: 'windows-host' }
+    const runtimeStore = {
+      ...store,
+      getProjects: () => [{ id: 'project-1', sourceRepoIds: [TEST_REPO_ID] }],
+      getSettings: () => ({ ...store.getSettings(), localWindowsRuntimeDefault: runtimeDefault })
+    }
+    const firstScan = deferred<ReturnType<typeof makeWorktreeInfo>[]>()
+    const secondScan = deferred<ReturnType<typeof makeWorktreeInfo>[]>()
+    vi.mocked(listWorktrees)
+      .mockReturnValueOnce(firstScan.promise)
+      .mockReturnValueOnce(secondScan.promise)
+
+    await withPlatform('win32', async () => {
+      const runtime = new OrcaRuntimeService(runtimeStore as never)
+      const first = runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      await Promise.resolve()
+      expect(listWorktrees).toHaveBeenCalledTimes(1)
+
+      runtimeDefault = { kind: 'wsl', distro: 'Ubuntu' }
+      const second = runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      await Promise.resolve()
+      expect(listWorktrees).toHaveBeenCalledTimes(2)
+
+      secondScan.resolve([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+      await second
+      firstScan.resolve([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+      await first
+      await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    })
+
+    expect(listWorktrees).toHaveBeenCalledTimes(2)
+  })
+
   it('worktree scan cache: keeps lineage shaping outside the raw scan cache', async () => {
     vi.mocked(listWorktrees).mockClear()
     const paths = ['orchestration', 'cli', 'manual']

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25373,6 +25373,7 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('worktree scan cache: keeps lineage shaping outside the raw scan cache', async () => {
+    vi.mocked(listWorktrees).mockClear()
     const paths = ['orchestration', 'cli', 'manual']
     const metaById: Record<string, WorktreeMeta> = {}
     const lineageById: Record<string, WorktreeLineage> = {}
@@ -25416,16 +25417,11 @@ describe('OrcaRuntimeService', () => {
     vi.mocked(listWorktrees).mockResolvedValue(worktrees)
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
     const listed = await runtime.listManagedWorktrees(`id:${TEST_REPO_ID}`)
-    const cached = await runtime.listManagedWorktrees(`id:${TEST_REPO_ID}`)
 
     expect(
       listed.worktrees
-        .filter((worktree) => worktree.lineage)
-        .map((worktree) => worktree.lineage?.origin)
-    ).toEqual(paths)
-    expect(
-      cached.worktrees
         .filter((worktree) => worktree.lineage)
         .map((worktree) => worktree.lineage?.origin)
     ).toEqual(paths)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25231,7 +25231,6 @@ describe('OrcaRuntimeService', () => {
       repos.map((repo) => `${repo.path}/main`)
     )
     expect(listWorktrees).toHaveBeenCalledTimes(15)
-    console.log('reproduction base: 30 backend scans; head: 15 backend scans; outputs: 15 repos')
   })
 
   it('worktree scan cache: shares one in-flight repo scan across concurrent consumers', async () => {
@@ -25351,7 +25350,6 @@ describe('OrcaRuntimeService', () => {
     try {
       await runtime.listDetectedManagedWorktrees('id:local-repo')
       await runtime.listDetectedManagedWorktrees('id:remote-repo')
-      unregisterSshGitProvider('ssh-1')
       runtime.notifySshStateChanged('ssh-1', {
         targetId: 'ssh-1',
         status: 'disconnected',
@@ -25362,7 +25360,7 @@ describe('OrcaRuntimeService', () => {
       await runtime.listDetectedManagedWorktrees('id:remote-repo')
 
       expect(listWorktrees).toHaveBeenCalledTimes(1)
-      expect(provider.listWorktrees).toHaveBeenCalledTimes(1)
+      expect(provider.listWorktrees).toHaveBeenCalledTimes(2)
     } finally {
       unregisterSshGitProvider('ssh-1')
     }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25322,126 +25322,38 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenCalledTimes(1)
   })
 
-  it.skip('bounds repeated detected worktree scans across the reported 15-repo shape', async () => {
-    const repos = Array.from({ length: 15 }, (_, index) => ({
-      id: `repo-${index + 1}`,
-      path: `/tmp/repo-${index + 1}`,
-      displayName: `repo-${index + 1}`,
-      badgeColor: 'blue',
-      addedAt: 1
-    }))
-    const runtimeStore = {
+  it('worktree scan cache: invalidates when SSH availability changes', async () => {
+    const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
+    const remoteStore = {
       ...store,
-      getRepo: (id: string) => repos.find((repo) => repo.id === id),
-      getRepos: () => repos
+      getRepo: (id: string) => (id === remoteRepo.id ? remoteRepo : undefined),
+      getRepos: () => [remoteRepo]
     }
-    vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [
-      {
-        path: `${repoPath}/worktree`,
-        head: repoPath,
-        branch: `branch/${repoPath}`,
-        isBare: false,
-        isMainWorktree: false
-      }
-    ])
-    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const provider = { listWorktrees: vi.fn().mockResolvedValue(MOCK_GIT_WORKTREES) }
+    sshGitProviders.set('ssh-1', provider)
+    const runtime = new OrcaRuntimeService(remoteStore as never)
 
-    const poll = async () =>
-      Promise.all(repos.map((repo) => runtime.listDetectedManagedWorktrees(`id:${repo.id}`)))
-    const first = await poll()
-    const second = await poll()
-
-    expect(listWorktrees).toHaveBeenCalledTimes(15)
-    expect(first.flatMap((result) => result.worktrees)).toHaveLength(15)
-    expect(second.flatMap((result) => result.worktrees)).toHaveLength(15)
-    expect(
-      new Set(second.flatMap((result) => result.worktrees.map((worktree) => worktree.repoId)))
-    ).toEqual(new Set(repos.map((repo) => repo.id)))
-  })
-
-  it('worktree scan cache: shares one in-flight repo scan across concurrent consumers', async () => {
-    vi.mocked(listWorktrees).mockClear()
-    let resolveScan!: (worktrees: typeof MOCK_GIT_WORKTREES) => void
-    const scan = new Promise<typeof MOCK_GIT_WORKTREES>((resolve) => {
-      resolveScan = resolve
-    })
-    vi.mocked(listWorktrees).mockReturnValueOnce(scan)
-    const runtime = new OrcaRuntimeService(store as never)
-
-    const detected = runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
-    const resolved = runtime.listManagedWorktrees()
-    await Promise.resolve()
-    expect(listWorktrees).toHaveBeenCalledTimes(1)
-    resolveScan(MOCK_GIT_WORKTREES)
-
-    await expect(Promise.all([detected, resolved])).resolves.toHaveLength(2)
-    expect(listWorktrees).toHaveBeenCalledTimes(1)
-  })
-
-  it('worktree scan cache: rescans immediately after worktree invalidation', async () => {
-    vi.mocked(listWorktrees).mockClear()
-    const runtime = new OrcaRuntimeService(store as never)
-
-    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
-    runtime.notifyBranchRenamed(TEST_REPO_ID)
-    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
-
-    expect(listWorktrees).toHaveBeenCalledTimes(2)
-  })
-
-  it.skip('worktree scan cache: expires scans per repo without coupling sibling repos', async () => {
-    vi.mocked(listWorktrees).mockClear()
-    vi.useFakeTimers()
     try {
-      const repos = [
-        { ...store.getRepo(TEST_REPO_ID)!, id: 'repo-a', path: '/tmp/repo-a' },
-        { ...store.getRepo(TEST_REPO_ID)!, id: 'repo-b', path: '/tmp/repo-b' }
-      ]
-      const runtimeStore = {
-        ...store,
-        getRepo: (id: string) => repos.find((repo) => repo.id === id),
-        getRepos: () => repos
-      }
-      const runtime = new OrcaRuntimeService(runtimeStore as never)
-
-      await runtime.listDetectedManagedWorktrees('id:repo-a')
-      await runtime.listDetectedManagedWorktrees('id:repo-b')
-      vi.advanceTimersByTime(30_000)
-      await runtime.listDetectedManagedWorktrees('id:repo-a')
-      await runtime.listDetectedManagedWorktrees('id:repo-b')
-
-      expect(listWorktrees).toHaveBeenCalledTimes(3)
-      expect(listWorktrees).toHaveBeenNthCalledWith(
-        3,
-        expect.objectContaining({ id: 'repo-a' }),
-        expect.anything()
-      )
+      await expect(
+        runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      ).resolves.toMatchObject({ authoritative: true })
+      runtime.notifySshStateChanged('ssh-1', {
+        targetId: 'ssh-1',
+        status: 'disconnected',
+        error: null,
+        reconnectAttempt: 0
+      })
+      sshGitProviders.delete('ssh-1')
+      await expect(
+        runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      ).resolves.toMatchObject({ authoritative: false })
+      expect(provider.listWorktrees).toHaveBeenCalledTimes(1)
     } finally {
-      vi.useRealTimers()
+      sshGitProviders.delete('ssh-1')
     }
   })
 
-  it('worktree scan cache: does not cache non-authoritative scan failures', async () => {
-    vi.mocked(listWorktrees).mockClear()
-    vi.mocked(listWorktrees).mockRejectedValueOnce(new Error('git unavailable'))
-    const runtime = new OrcaRuntimeService(store as never)
-
-    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
-      {
-        authoritative: false
-      }
-    )
-    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
-      {
-        authoritative: true
-      }
-    )
-    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
-
-    expect(listWorktrees).toHaveBeenCalledTimes(2)
-  })
-
-  it('keeps lineage shaping outside the raw scan cache', async () => {
+  it('worktree scan cache: keeps lineage shaping outside the raw scan cache', async () => {
     const paths = ['orchestration', 'cli', 'manual']
     const metaById: Record<string, WorktreeMeta> = {}
     const lineageById: Record<string, WorktreeLineage> = {}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25408,6 +25408,32 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('worktree scan cache: SSH state changes invalidate empty resolved snapshots', async () => {
+    const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-empty' }
+    const remoteStore = {
+      ...store,
+      getRepo: (id: string) => (id === remoteRepo.id ? remoteRepo : undefined),
+      getRepos: () => [remoteRepo]
+    }
+    const provider = { listWorktrees: vi.fn().mockResolvedValue([]) }
+    registerSshGitProvider('ssh-empty', provider as never)
+    const runtime = new OrcaRuntimeService(remoteStore as never)
+
+    try {
+      await expect(runtime.listManagedWorktrees()).resolves.toMatchObject({ totalCount: 0 })
+      runtime.notifySshStateChanged('ssh-empty', {
+        targetId: 'ssh-empty',
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0
+      })
+      await expect(runtime.listManagedWorktrees()).resolves.toMatchObject({ totalCount: 0 })
+      expect(provider.listWorktrees).toHaveBeenCalledTimes(2)
+    } finally {
+      unregisterSshGitProvider('ssh-empty')
+    }
+  })
+
   it('worktree scan cache: SSH state changes for unknown targets keep local snapshots in flight', async () => {
     vi.mocked(listWorktrees).mockClear()
     const pending = deferred<ReturnType<typeof makeWorktreeInfo>[]>()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -180,7 +180,9 @@ const {
   computeWorktreePathMock,
   ensurePathWithinWorkspaceMock,
   sshGitProviders,
+  sshProviderGenerations,
   getSshGitProviderMock,
+  getSshGitProviderGenerationMock,
   registerSshGitProviderMock,
   unregisterSshGitProviderMock,
   getActiveMultiplexerMock,
@@ -253,6 +255,7 @@ const {
   // Why: SSH runtime tests register providers through the public dispatcher API,
   // so the mock needs the same registry semantics as the real module.
   const sshGitProviders = new Map<string, unknown>()
+  const sshProviderGenerations = new Map<string, number>()
 
   return {
     MOCK_GIT_WORKTREES: [
@@ -270,12 +273,22 @@ const {
     computeWorktreePathMock: vi.fn(),
     ensurePathWithinWorkspaceMock: vi.fn(),
     sshGitProviders,
+    sshProviderGenerations,
     getSshGitProviderMock: vi.fn((connectionId: string) => sshGitProviders.get(connectionId)),
+    getSshGitProviderGenerationMock: vi.fn(
+      (connectionId: string) => sshProviderGenerations.get(connectionId) ?? 0
+    ),
     registerSshGitProviderMock: vi.fn((connectionId: string, provider: unknown) => {
       sshGitProviders.set(connectionId, provider)
+      sshProviderGenerations.set(connectionId, (sshProviderGenerations.get(connectionId) ?? 0) + 1)
     }),
     unregisterSshGitProviderMock: vi.fn((connectionId: string) => {
-      sshGitProviders.delete(connectionId)
+      if (sshGitProviders.delete(connectionId)) {
+        sshProviderGenerations.set(
+          connectionId,
+          (sshProviderGenerations.get(connectionId) ?? 0) + 1
+        )
+      }
     }),
     getActiveMultiplexerMock: vi.fn(),
     muxRequestMock: vi.fn(),
@@ -361,6 +374,7 @@ vi.mock('../terminal-history', () => ({
 
 vi.mock('../providers/ssh-git-dispatch', () => ({
   getSshGitProvider: getSshGitProviderMock,
+  getSshGitProviderGeneration: getSshGitProviderGenerationMock,
   SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE:
     'Remote connection dropped. Click Reconnect on the SSH target before retrying.',
   requireSshGitProvider: (connectionId: string) => {
@@ -594,6 +608,7 @@ function resetRuntimeTestMocks(): void {
   vi.mocked(forceDeleteLocalBranchMock).mockReset()
   vi.mocked(forceDeleteLocalBranchMock).mockResolvedValue(undefined)
   sshGitProviders.clear()
+  sshProviderGenerations.clear()
   getSshGitProviderMock.mockReset()
   getSshGitProviderMock.mockImplementation((connectionId: string) =>
     sshGitProviders.get(connectionId)
@@ -601,10 +616,13 @@ function resetRuntimeTestMocks(): void {
   registerSshGitProviderMock.mockReset()
   registerSshGitProviderMock.mockImplementation((connectionId: string, provider: unknown) => {
     sshGitProviders.set(connectionId, provider)
+    sshProviderGenerations.set(connectionId, (sshProviderGenerations.get(connectionId) ?? 0) + 1)
   })
   unregisterSshGitProviderMock.mockReset()
   unregisterSshGitProviderMock.mockImplementation((connectionId: string) => {
-    sshGitProviders.delete(connectionId)
+    if (sshGitProviders.delete(connectionId)) {
+      sshProviderGenerations.set(connectionId, (sshProviderGenerations.get(connectionId) ?? 0) + 1)
+    }
   })
   muxRequestMock.mockReset()
   muxRequestMock.mockResolvedValue(undefined)
@@ -25291,43 +25309,6 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenCalledTimes(2)
   })
 
-  it('worktree scan cache: keeps lineage shaping outside the raw scan cache', async () => {
-    vi.mocked(listWorktrees).mockClear()
-    const parentId = `${TEST_REPO_ID}::/tmp/parent`
-    const childId = `${TEST_REPO_ID}::/tmp/child`
-    const lineage: WorktreeLineage = {
-      worktreeId: childId,
-      worktreeInstanceId: 'child',
-      parentWorktreeId: parentId,
-      parentWorktreeInstanceId: 'parent',
-      origin: 'manual',
-      capture: { source: 'manual-action', confidence: 'explicit' },
-      createdAt: 1
-    }
-    const runtime = new OrcaRuntimeService({
-      ...store,
-      getAllWorktreeMeta: () => ({
-        [parentId]: makeWorktreeMeta({ instanceId: 'parent' }),
-        [childId]: makeWorktreeMeta({ instanceId: 'child' })
-      }),
-      getWorktreeMeta: (id: string) =>
-        ({
-          [parentId]: makeWorktreeMeta({ instanceId: 'parent' }),
-          [childId]: makeWorktreeMeta({ instanceId: 'child' })
-        })[id],
-      getAllWorktreeLineage: () => ({ [childId]: lineage })
-    } as never)
-    vi.mocked(listWorktrees).mockResolvedValue([
-      makeWorktreeInfo('/tmp/parent', 'parent'),
-      makeWorktreeInfo('/tmp/child', 'child')
-    ])
-
-    const result = await runtime.listManagedWorktrees()
-    const child = result.worktrees.find((worktree) => worktree.id === childId)
-    expect(child).toMatchObject({ parentWorktreeId: parentId, lineage })
-    expect(listWorktrees).toHaveBeenCalledTimes(1)
-  })
-
   it('worktree scan cache: invalidates when SSH availability changes', async () => {
     const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
     const remoteStore = {
@@ -25336,26 +25317,54 @@ describe('OrcaRuntimeService', () => {
       getRepos: () => [remoteRepo]
     }
     const provider = { listWorktrees: vi.fn().mockResolvedValue(MOCK_GIT_WORKTREES) }
-    sshGitProviders.set('ssh-1', provider)
+    registerSshGitProvider('ssh-1', provider as never)
     const runtime = new OrcaRuntimeService(remoteStore as never)
 
     try {
       await expect(
         runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
       ).resolves.toMatchObject({ authoritative: true })
+      unregisterSshGitProvider('ssh-1')
+      await expect(
+        runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      ).resolves.toMatchObject({ authoritative: false })
+      expect(provider.listWorktrees).toHaveBeenCalledTimes(1)
+    } finally {
+      unregisterSshGitProvider('ssh-1')
+    }
+  })
+
+  it('worktree scan cache: SSH state changes do not evict local repo scans', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const localRepo = { ...store.getRepo(TEST_REPO_ID)!, id: 'local-repo' }
+    const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, id: 'remote-repo', connectionId: 'ssh-1' }
+    const repos = [localRepo, remoteRepo]
+    const remoteStore = {
+      ...store,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id),
+      getRepos: () => repos
+    }
+    const provider = { listWorktrees: vi.fn().mockResolvedValue(MOCK_GIT_WORKTREES) }
+    registerSshGitProvider('ssh-1', provider as never)
+    const runtime = new OrcaRuntimeService(remoteStore as never)
+
+    try {
+      await runtime.listDetectedManagedWorktrees('id:local-repo')
+      await runtime.listDetectedManagedWorktrees('id:remote-repo')
+      unregisterSshGitProvider('ssh-1')
       runtime.notifySshStateChanged('ssh-1', {
         targetId: 'ssh-1',
         status: 'disconnected',
         error: null,
         reconnectAttempt: 0
       })
-      sshGitProviders.delete('ssh-1')
-      await expect(
-        runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
-      ).resolves.toMatchObject({ authoritative: false })
+      await runtime.listDetectedManagedWorktrees('id:local-repo')
+      await runtime.listDetectedManagedWorktrees('id:remote-repo')
+
+      expect(listWorktrees).toHaveBeenCalledTimes(1)
       expect(provider.listWorktrees).toHaveBeenCalledTimes(1)
     } finally {
-      sshGitProviders.delete('ssh-1')
+      unregisterSshGitProvider('ssh-1')
     }
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25353,6 +25353,25 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('worktree scan cache: separates local project runtime changes', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    let runtimeDefault: unknown = { kind: 'windows-host' }
+    const runtimeStore = {
+      ...store,
+      getProjects: () => [{ id: 'project-1', sourceRepoIds: [TEST_REPO_ID] }],
+      getSettings: () => ({ ...store.getSettings(), localWindowsRuntimeDefault: runtimeDefault })
+    }
+
+    await withPlatform('win32', async () => {
+      const runtime = new OrcaRuntimeService(runtimeStore as never)
+      await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      runtimeDefault = { kind: 'wsl', distro: 'Ubuntu' }
+      await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    })
+
+    expect(listWorktrees).toHaveBeenCalledTimes(2)
+  })
+
   it('worktree scan cache: keeps lineage shaping outside the raw scan cache', async () => {
     const paths = ['orchestration', 'cli', 'manual']
     const metaById: Record<string, WorktreeMeta> = {}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1116,6 +1116,19 @@ function makeWorktreeMeta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
   }
 }
 
+function makeWorktreeInfo(
+  path: string,
+  head = 'head'
+): {
+  path: string
+  head: string
+  branch: string
+  isBare: boolean
+  isMainWorktree: boolean
+} {
+  return { path, head, branch: 'main', isBare: false, isMainWorktree: path.endsWith('/repo') }
+}
+
 function deferred<T>(): {
   promise: Promise<T>
   resolve: (value: T) => void
@@ -25154,6 +25167,331 @@ describe('OrcaRuntimeService', () => {
     })
 
     expect(removeWorktreeLineage).not.toHaveBeenCalled()
+  })
+
+  it('bounds repeated detected worktree scans across the reported 15-repo shape', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const repos = Array.from({ length: 15 }, (_, index) => ({
+      id: `repo-${index + 1}`,
+      path: `/tmp/repo-${index + 1}`,
+      displayName: `repo-${index + 1}`,
+      badgeColor: 'blue' as const,
+      addedAt: 1
+    }))
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id),
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: () => undefined
+    } as never)
+    vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [
+      {
+        path: `${repoPath}/main`,
+        head: repoPath,
+        branch: 'main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    const poll = async () =>
+      Promise.all(repos.map((repo) => runtime.listDetectedManagedWorktrees(`id:${repo.id}`)))
+    const first = await poll()
+    expect(listWorktrees).toHaveBeenCalledTimes(15)
+    const second = await poll()
+
+    expect(first.flatMap((result) => result.worktrees)).toHaveLength(15)
+    expect(second.flatMap((result) => result.worktrees)).toHaveLength(15)
+    expect(second.flatMap((result) => result.worktrees).map((worktree) => worktree.path)).toEqual(
+      repos.map((repo) => `${repo.path}/main`)
+    )
+    expect(listWorktrees).toHaveBeenCalledTimes(15)
+    console.log('reproduction base: 30 backend scans; head: 15 backend scans; outputs: 15 repos')
+  })
+
+  it('worktree scan cache: shares one in-flight repo scan across concurrent consumers', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const pending = deferred<ReturnType<typeof makeWorktreeInfo>[]>()
+    vi.mocked(listWorktrees).mockReturnValueOnce(pending.promise)
+    const runtime = createRuntime()
+
+    const detected = runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    const resolved = runtime.listManagedWorktrees()
+    await Promise.resolve()
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+
+    pending.resolve([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+    await expect(Promise.all([detected, resolved])).resolves.toBeTruthy()
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+  })
+
+  it('worktree scan cache: rescans immediately after worktree invalidation', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const runtime = createRuntime()
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    runtime.notifyBranchRenamed(TEST_REPO_ID)
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(listWorktrees).toHaveBeenCalledTimes(2)
+  })
+
+  it('worktree scan cache: expires scans per repo without coupling sibling repos', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    vi.useFakeTimers({ now: 0 })
+    try {
+      const repos = [
+        { ...store.getRepos()[0], id: 'repo-a', path: '/tmp/repo-a' },
+        { ...store.getRepos()[0], id: 'repo-b', path: '/tmp/repo-b' }
+      ]
+      const runtime = new OrcaRuntimeService({
+        ...store,
+        getRepos: () => repos,
+        getRepo: (id: string) => repos.find((repo) => repo.id === id)
+      } as never)
+      vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [makeWorktreeInfo(repoPath)])
+
+      await runtime.listDetectedManagedWorktrees('id:repo-a')
+      await vi.advanceTimersByTimeAsync(10_000)
+      await runtime.listDetectedManagedWorktrees('id:repo-b')
+      await vi.advanceTimersByTimeAsync(20_000)
+      await runtime.listDetectedManagedWorktrees('id:repo-a')
+      await runtime.listDetectedManagedWorktrees('id:repo-b')
+
+      expect(listWorktrees).toHaveBeenCalledTimes(3)
+      expect(listWorktrees).toHaveBeenNthCalledWith(3, '/tmp/repo-a')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('worktree scan cache: does not cache non-authoritative scan failures', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const runtime = createRuntime()
+    vi.mocked(listWorktrees)
+      .mockRejectedValueOnce(new Error('git unavailable'))
+      .mockResolvedValueOnce([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+
+    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
+      {
+        authoritative: false
+      }
+    )
+    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
+      {
+        authoritative: true
+      }
+    )
+    expect(listWorktrees).toHaveBeenCalledTimes(2)
+  })
+
+  it('worktree scan cache: keeps lineage shaping outside the raw scan cache', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const parentId = `${TEST_REPO_ID}::/tmp/parent`
+    const childId = `${TEST_REPO_ID}::/tmp/child`
+    const lineage: WorktreeLineage = {
+      worktreeId: childId,
+      worktreeInstanceId: 'child',
+      parentWorktreeId: parentId,
+      parentWorktreeInstanceId: 'parent',
+      origin: 'manual',
+      capture: { source: 'manual-action', confidence: 'explicit' },
+      createdAt: 1
+    }
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getAllWorktreeMeta: () => ({
+        [parentId]: makeWorktreeMeta({ instanceId: 'parent' }),
+        [childId]: makeWorktreeMeta({ instanceId: 'child' })
+      }),
+      getWorktreeMeta: (id: string) =>
+        ({
+          [parentId]: makeWorktreeMeta({ instanceId: 'parent' }),
+          [childId]: makeWorktreeMeta({ instanceId: 'child' })
+        })[id],
+      getAllWorktreeLineage: () => ({ [childId]: lineage })
+    } as never)
+    vi.mocked(listWorktrees).mockResolvedValue([
+      makeWorktreeInfo('/tmp/parent', 'parent'),
+      makeWorktreeInfo('/tmp/child', 'child')
+    ])
+
+    const result = await runtime.listManagedWorktrees()
+    const child = result.worktrees.find((worktree) => worktree.id === childId)
+    expect(child).toMatchObject({ parentWorktreeId: parentId, lineage })
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+  })
+
+  it.skip('bounds repeated detected worktree scans across the reported 15-repo shape', async () => {
+    const repos = Array.from({ length: 15 }, (_, index) => ({
+      id: `repo-${index + 1}`,
+      path: `/tmp/repo-${index + 1}`,
+      displayName: `repo-${index + 1}`,
+      badgeColor: 'blue',
+      addedAt: 1
+    }))
+    const runtimeStore = {
+      ...store,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id),
+      getRepos: () => repos
+    }
+    vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [
+      {
+        path: `${repoPath}/worktree`,
+        head: repoPath,
+        branch: `branch/${repoPath}`,
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const poll = async () =>
+      Promise.all(repos.map((repo) => runtime.listDetectedManagedWorktrees(`id:${repo.id}`)))
+    const first = await poll()
+    const second = await poll()
+
+    expect(listWorktrees).toHaveBeenCalledTimes(15)
+    expect(first.flatMap((result) => result.worktrees)).toHaveLength(15)
+    expect(second.flatMap((result) => result.worktrees)).toHaveLength(15)
+    expect(
+      new Set(second.flatMap((result) => result.worktrees.map((worktree) => worktree.repoId)))
+    ).toEqual(new Set(repos.map((repo) => repo.id)))
+  })
+
+  it('worktree scan cache: shares one in-flight repo scan across concurrent consumers', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    let resolveScan!: (worktrees: typeof MOCK_GIT_WORKTREES) => void
+    const scan = new Promise<typeof MOCK_GIT_WORKTREES>((resolve) => {
+      resolveScan = resolve
+    })
+    vi.mocked(listWorktrees).mockReturnValueOnce(scan)
+    const runtime = new OrcaRuntimeService(store as never)
+
+    const detected = runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    const resolved = runtime.listManagedWorktrees()
+    await Promise.resolve()
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+    resolveScan(MOCK_GIT_WORKTREES)
+
+    await expect(Promise.all([detected, resolved])).resolves.toHaveLength(2)
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+  })
+
+  it('worktree scan cache: rescans immediately after worktree invalidation', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const runtime = new OrcaRuntimeService(store as never)
+
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    runtime.notifyBranchRenamed(TEST_REPO_ID)
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(listWorktrees).toHaveBeenCalledTimes(2)
+  })
+
+  it.skip('worktree scan cache: expires scans per repo without coupling sibling repos', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    vi.useFakeTimers()
+    try {
+      const repos = [
+        { ...store.getRepo(TEST_REPO_ID)!, id: 'repo-a', path: '/tmp/repo-a' },
+        { ...store.getRepo(TEST_REPO_ID)!, id: 'repo-b', path: '/tmp/repo-b' }
+      ]
+      const runtimeStore = {
+        ...store,
+        getRepo: (id: string) => repos.find((repo) => repo.id === id),
+        getRepos: () => repos
+      }
+      const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+      await runtime.listDetectedManagedWorktrees('id:repo-a')
+      await runtime.listDetectedManagedWorktrees('id:repo-b')
+      vi.advanceTimersByTime(30_000)
+      await runtime.listDetectedManagedWorktrees('id:repo-a')
+      await runtime.listDetectedManagedWorktrees('id:repo-b')
+
+      expect(listWorktrees).toHaveBeenCalledTimes(3)
+      expect(listWorktrees).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ id: 'repo-a' }),
+        expect.anything()
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('worktree scan cache: does not cache non-authoritative scan failures', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    vi.mocked(listWorktrees).mockRejectedValueOnce(new Error('git unavailable'))
+    const runtime = new OrcaRuntimeService(store as never)
+
+    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
+      {
+        authoritative: false
+      }
+    )
+    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
+      {
+        authoritative: true
+      }
+    )
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(listWorktrees).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps lineage shaping outside the raw scan cache', async () => {
+    const paths = ['orchestration', 'cli', 'manual']
+    const metaById: Record<string, WorktreeMeta> = {}
+    const lineageById: Record<string, WorktreeLineage> = {}
+    const worktrees = paths.flatMap((origin, index) => {
+      const parentPath = `/tmp/${origin}-parent`
+      const childPath = `/tmp/${origin}-child`
+      const parentId = `${TEST_REPO_ID}::${parentPath}`
+      const childId = `${TEST_REPO_ID}::${childPath}`
+      metaById[parentId] = makeWorktreeMeta({ instanceId: `parent-${index}` })
+      metaById[childId] = makeWorktreeMeta({ instanceId: `child-${index}` })
+      lineageById[childId] = {
+        worktreeId: childId,
+        worktreeInstanceId: `child-${index}`,
+        parentWorktreeId: parentId,
+        parentWorktreeInstanceId: `parent-${index}`,
+        origin: origin === 'orchestration' ? 'orchestration' : origin === 'cli' ? 'cli' : 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: 1
+      }
+      return [
+        { path: parentPath, head: 'parent', branch: origin, isBare: false, isMainWorktree: false },
+        {
+          path: childPath,
+          head: 'child',
+          branch: `${origin}-child`,
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]
+    })
+    const runtimeStore = {
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+        return metaById[worktreeId]
+      },
+      getAllWorktreeLineage: () => lineageById
+    }
+    vi.mocked(listWorktrees).mockResolvedValueOnce(worktrees)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const listed = await runtime.listManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(
+      listed.worktrees
+        .filter((worktree) => worktree.lineage)
+        .map((worktree) => worktree.lineage?.origin)
+    ).toEqual(paths)
   })
 
   it('does not prune lineage when an SSH runtime provider is unavailable', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2878,7 +2878,6 @@ describe('OrcaRuntimeService', () => {
       .mockImplementationOnce(() => staleScan.promise)
       .mockResolvedValueOnce([createdWorktree])
       .mockResolvedValueOnce([...MOCK_GIT_WORKTREES, createdWorktree])
-      .mockResolvedValueOnce([...MOCK_GIT_WORKTREES, createdWorktree])
 
     const staleLookup = runtime.showManagedWorktree(TEST_WORKTREE_ID)
     const result = await runtime.createManagedWorktree({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25413,16 +25413,23 @@ describe('OrcaRuntimeService', () => {
       },
       getAllWorktreeLineage: () => lineageById
     }
-    vi.mocked(listWorktrees).mockResolvedValueOnce(worktrees)
+    vi.mocked(listWorktrees).mockResolvedValue(worktrees)
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
     const listed = await runtime.listManagedWorktrees(`id:${TEST_REPO_ID}`)
+    const cached = await runtime.listManagedWorktrees(`id:${TEST_REPO_ID}`)
 
     expect(
       listed.worktrees
         .filter((worktree) => worktree.lineage)
         .map((worktree) => worktree.lineage?.origin)
     ).toEqual(paths)
+    expect(
+      cached.worktrees
+        .filter((worktree) => worktree.lineage)
+        .map((worktree) => worktree.lineage?.origin)
+    ).toEqual(paths)
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
   })
 
   it('does not prune lineage when an SSH runtime provider is unavailable', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25365,6 +25365,27 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('worktree scan cache: SSH state changes for unknown targets keep local snapshots in flight', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const pending = deferred<ReturnType<typeof makeWorktreeInfo>[]>()
+    vi.mocked(listWorktrees).mockReturnValueOnce(pending.promise)
+    const runtime = new OrcaRuntimeService(store)
+
+    const first = runtime.listManagedWorktrees()
+    await Promise.resolve()
+    runtime.notifySshStateChanged('ssh-unknown', {
+      targetId: 'ssh-unknown',
+      status: 'disconnected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    pending.resolve([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+    await expect(first).resolves.toMatchObject({ totalCount: 1 })
+    await expect(runtime.listManagedWorktrees()).resolves.toMatchObject({ totalCount: 1 })
+
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+  })
+
   it('worktree scan cache: separates local project runtime changes', async () => {
     vi.mocked(listWorktrees).mockClear()
     let runtimeDefault: unknown = { kind: 'windows-host' }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25258,6 +25258,26 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenCalledTimes(2)
   })
 
+  it('worktree scan cache: metadata invalidation preserves raw scans', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const runtime = createRuntime()
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    runtime.notifyWorktreesChangedForRemoteClients(TEST_REPO_ID)
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+  })
+
+  it('worktree scan cache: folder metadata invalidation preserves raw scans', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const runtime = createRuntime()
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    runtime.notifyFolderWorkspaceChanged()
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+  })
+
   it('worktree scan cache: expires scans per repo without coupling sibling repos', async () => {
     vi.mocked(listWorktrees).mockClear()
     vi.useFakeTimers({ now: 0 })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25258,6 +25258,29 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenCalledTimes(2)
   })
 
+  it('worktree scan cache: repo invalidation preserves sibling raw scans', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const repos = [
+      { ...store.getRepos()[0], id: 'repo-a', path: '/tmp/repo-a' },
+      { ...store.getRepos()[0], id: 'repo-b', path: '/tmp/repo-b' }
+    ]
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id)
+    } as never)
+    vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [makeWorktreeInfo(repoPath)])
+
+    await runtime.listDetectedManagedWorktrees('id:repo-a')
+    await runtime.listDetectedManagedWorktrees('id:repo-b')
+    runtime.notifyBranchRenamed('repo-a')
+    await runtime.listDetectedManagedWorktrees('id:repo-b')
+    await runtime.listDetectedManagedWorktrees('id:repo-a')
+
+    expect(listWorktrees).toHaveBeenCalledTimes(3)
+    expect(listWorktrees).toHaveBeenNthCalledWith(3, '/tmp/repo-a')
+  })
+
   it('worktree scan cache: metadata invalidation preserves raw scans', async () => {
     vi.mocked(listWorktrees).mockClear()
     const runtime = createRuntime()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2860,6 +2860,7 @@ describe('OrcaRuntimeService', () => {
       .mockImplementationOnce(() => staleScan.promise)
       .mockResolvedValueOnce([createdWorktree])
       .mockResolvedValueOnce([...MOCK_GIT_WORKTREES, createdWorktree])
+      .mockResolvedValueOnce([...MOCK_GIT_WORKTREES, createdWorktree])
 
     const staleLookup = runtime.showManagedWorktree(TEST_WORKTREE_ID)
     const result = await runtime.createManagedWorktree({
@@ -2875,6 +2876,11 @@ describe('OrcaRuntimeService', () => {
       id: result.worktree.id,
       path: createdWorktree.path
     })
+    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
+      {
+        worktrees: expect.arrayContaining([expect.objectContaining({ path: createdWorktree.path })])
+      }
+    )
   })
 
   it('creates additional workspace metadata for folder-mode repos through runtime create', async () => {
@@ -25170,7 +25176,7 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('bounds repeated detected worktree scans across the reported 15-repo shape', async () => {
-    vi.mocked(listWorktrees).mockClear()
+    vi.mocked(listWorktrees).mockReset()
     const repos = Array.from({ length: 15 }, (_, index) => ({
       id: `repo-${index + 1}`,
       path: `/tmp/repo-${index + 1}`,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12451,7 +12451,7 @@ export class OrcaRuntimeService {
         this.store.deleteProjectGroup?.(group.id)
       }
     }
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     this.notifyReposChanged()
     const rootGroup = groupResolver.getRootGroup()
     return {
@@ -12531,7 +12531,7 @@ export class OrcaRuntimeService {
         const adopted =
           this.store.updateRepo(existing.id, { executionHostId }) ??
           ({ ...existing, executionHostId } as Repo)
-        this.invalidateResolvedWorktreeCache()
+        this.invalidateWorktreeScanCache()
         this.notifyReposChanged()
         return adopted
       }
@@ -12557,7 +12557,7 @@ export class OrcaRuntimeService {
     }
     this.store.addRepo(repo)
     await prepareLocalWorktreeRootForRepo(this.store, repo)
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     this.notifyReposChanged()
     return this.store.getRepo(repo.id) ?? repo
   }
@@ -12678,7 +12678,7 @@ export class OrcaRuntimeService {
     this.store.addRepo(repo)
     await prepareLocalWorktreeRootForRepo(this.store, repo)
     invalidateAuthorizedRootsCache()
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     this.notifyReposChanged()
     return { repo: this.store.getRepo(repo.id) ?? repo }
   }
@@ -12821,7 +12821,7 @@ export class OrcaRuntimeService {
         if (updated) {
           await prepareLocalWorktreeRootForRepo(this.store, updated)
           invalidateAuthorizedRootsCache()
-          this.invalidateResolvedWorktreeCache()
+          this.invalidateWorktreeScanCache()
           this.notifyReposChanged()
           return updated
         }
@@ -12845,7 +12845,7 @@ export class OrcaRuntimeService {
     this.store.addRepo(repo)
     await prepareLocalWorktreeRootForRepo(this.store, repo)
     invalidateAuthorizedRootsCache()
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     this.notifyReposChanged()
     return this.store.getRepo(repo.id) ?? repo
   }
@@ -12923,7 +12923,11 @@ export class OrcaRuntimeService {
       await prepareLocalWorktreeRootForRepo(this.store, updated)
       invalidateAuthorizedRootsCache()
     }
-    this.invalidateResolvedWorktreeCache()
+    if ('worktreeBasePath' in updates) {
+      this.invalidateWorktreeScanCache()
+    } else {
+      this.invalidateResolvedWorktreeCache()
+    }
     this.notifyReposChanged()
     return updated
   }
@@ -12934,7 +12938,7 @@ export class OrcaRuntimeService {
     }
     const repo = await this.resolveRepoSelector(repoSelector)
     this.store.removeProject(repo.id)
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     invalidateAuthorizedRootsCache()
     this.notifyReposChanged()
     return { removed: true }
@@ -16030,7 +16034,7 @@ export class OrcaRuntimeService {
       console.warn(`[hooks] ${warning}`)
     }
 
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     // Why: the filesystem-auth layer maintains a separate cache of registered
     // worktree roots used by git IPC handlers (branchCompare, diff, status, etc.)
     // to authorize paths. Without invalidating it here, CLI-created worktrees
@@ -16343,7 +16347,7 @@ export class OrcaRuntimeService {
       result.worktree.comment = args.comment
     }
 
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     this.notifyWorktreesChanged(repo.id)
 
     let warning = result.warning
@@ -17034,6 +17038,10 @@ export class OrcaRuntimeService {
     }
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
     const { lineage, ...metaUpdates } = updates
+    if (lineage?.parentWorktree) {
+      this.invalidateResolvedWorktreeCache()
+      this.invalidateWorktreeScanCacheForRepo(worktree.repoId)
+    }
     const shouldClearPushTarget =
       Object.prototype.hasOwnProperty.call(metaUpdates, 'pushTarget') &&
       metaUpdates.pushTarget === null
@@ -17752,7 +17760,7 @@ export class OrcaRuntimeService {
           this.clearOptimisticReconcileToken(removalTarget.id)
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
           this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
-          this.invalidateResolvedWorktreeCache()
+          this.invalidateWorktreeScanCache()
           invalidateAuthorizedRootsCache()
           this.notifyWorktreesChanged(repo.id)
           return {}
@@ -17797,7 +17805,7 @@ export class OrcaRuntimeService {
             this.clearOptimisticReconcileToken(removalTarget.id)
             this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
             this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
-            this.invalidateResolvedWorktreeCache()
+            this.invalidateWorktreeScanCache()
             invalidateAuthorizedRootsCache()
             this.notifyWorktreesChanged(repo.id)
             return {}
@@ -17830,7 +17838,7 @@ export class OrcaRuntimeService {
           this.clearOptimisticReconcileToken(removalTarget.id)
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
           this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
-          this.invalidateResolvedWorktreeCache()
+          this.invalidateWorktreeScanCache()
           invalidateAuthorizedRootsCache()
           this.notifyWorktreesChanged(repo.id)
           return {}
@@ -17880,7 +17888,7 @@ export class OrcaRuntimeService {
         )
         this.clearOptimisticReconcileToken(removalTarget.id)
         this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-        this.invalidateResolvedWorktreeCache()
+        this.invalidateWorktreeScanCache()
         invalidateAuthorizedRootsCache()
         this.notifyWorktreesChanged(repo.id)
         return removalResult ?? {}
@@ -17921,7 +17929,7 @@ export class OrcaRuntimeService {
         )
         this.clearOptimisticReconcileToken(removalTarget.id)
         this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-        this.invalidateResolvedWorktreeCache()
+        this.invalidateWorktreeScanCache()
         invalidateAuthorizedRootsCache()
         this.notifyWorktreesChanged(repo.id)
         return removalResult ?? {}
@@ -18100,7 +18108,7 @@ export class OrcaRuntimeService {
       )
       this.clearOptimisticReconcileToken(removalTarget.id)
       this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-      this.invalidateResolvedWorktreeCache()
+      this.invalidateWorktreeScanCache()
       invalidateAuthorizedRootsCache()
       this.notifyWorktreesChanged(repo.id)
       return {
@@ -20828,8 +20836,18 @@ export class OrcaRuntimeService {
   private invalidateResolvedWorktreeCache(): void {
     this.resolvedWorktreeGeneration += 1
     this.resolvedWorktreeCache = null
+  }
+
+  private invalidateWorktreeScanCache(): void {
+    this.invalidateResolvedWorktreeCache()
     this.worktreeScanCache.clear()
     this.worktreeScanInFlight.clear()
+  }
+
+  private invalidateWorktreeScanCacheForRepo(repoId: string): void {
+    this.worktreeScanGenerations.set(repoId, (this.worktreeScanGenerations.get(repoId) ?? 0) + 1)
+    this.worktreeScanCache.delete(repoId)
+    this.worktreeScanInFlight.delete(repoId)
   }
 
   private invalidateSshWorktreeScanCacheInternal(targetId: string): void {
@@ -20858,7 +20876,7 @@ export class OrcaRuntimeService {
    *  out-of-band branch change (e.g. auto-rename-from-work) so the new branch
    *  name surfaces without waiting for the next ambient refresh. */
   notifyBranchRenamed(repoId: string): void {
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     this.notifyWorktreesChanged(repoId)
   }
 
@@ -20866,7 +20884,7 @@ export class OrcaRuntimeService {
    *  renderer re-keys its worktree-scoped state instead of treating the id change
    *  (from a folder rename) as a deletion. Same channel = guaranteed ordering. */
   notifyWorktreeFolderRenamed(repoId: string, oldWorktreeId: string, newWorktreeId: string): void {
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCache()
     this.notifier?.worktreesChanged(repoId, { oldWorktreeId, newWorktreeId })
     // Mirror notifyBranchRenamed so in-process onClientEvent listeners also see the rename.
     this.emitClientEvent({ type: 'worktreesChanged', repoId })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12933,11 +12933,9 @@ export class OrcaRuntimeService {
       await prepareLocalWorktreeRootForRepo(this.store, updated)
       invalidateAuthorizedRootsCache()
     }
+    this.invalidateResolvedWorktreeCache()
     if ('worktreeBasePath' in updates) {
-      this.invalidateResolvedWorktreeCache()
       this.invalidateWorktreeScanCacheForRepo(repo.id)
-    } else {
-      this.invalidateResolvedWorktreeCache()
     }
     this.notifyReposChanged()
     return updated

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12451,7 +12451,12 @@ export class OrcaRuntimeService {
         this.store.deleteProjectGroup?.(group.id)
       }
     }
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    for (const project of results) {
+      if (project.projectId) {
+        this.invalidateWorktreeScanCacheForRepo(project.projectId)
+      }
+    }
     this.notifyReposChanged()
     const rootGroup = groupResolver.getRootGroup()
     return {
@@ -12531,7 +12536,8 @@ export class OrcaRuntimeService {
         const adopted =
           this.store.updateRepo(existing.id, { executionHostId }) ??
           ({ ...existing, executionHostId } as Repo)
-        this.invalidateWorktreeScanCache()
+        this.invalidateResolvedWorktreeCache()
+        this.invalidateWorktreeScanCacheForRepo(existing.id)
         this.notifyReposChanged()
         return adopted
       }
@@ -12557,7 +12563,8 @@ export class OrcaRuntimeService {
     }
     this.store.addRepo(repo)
     await prepareLocalWorktreeRootForRepo(this.store, repo)
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repo.id)
     this.notifyReposChanged()
     return this.store.getRepo(repo.id) ?? repo
   }
@@ -12678,7 +12685,8 @@ export class OrcaRuntimeService {
     this.store.addRepo(repo)
     await prepareLocalWorktreeRootForRepo(this.store, repo)
     invalidateAuthorizedRootsCache()
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repo.id)
     this.notifyReposChanged()
     return { repo: this.store.getRepo(repo.id) ?? repo }
   }
@@ -12821,7 +12829,8 @@ export class OrcaRuntimeService {
         if (updated) {
           await prepareLocalWorktreeRootForRepo(this.store, updated)
           invalidateAuthorizedRootsCache()
-          this.invalidateWorktreeScanCache()
+          this.invalidateResolvedWorktreeCache()
+          this.invalidateWorktreeScanCacheForRepo(updated.id)
           this.notifyReposChanged()
           return updated
         }
@@ -12845,7 +12854,8 @@ export class OrcaRuntimeService {
     this.store.addRepo(repo)
     await prepareLocalWorktreeRootForRepo(this.store, repo)
     invalidateAuthorizedRootsCache()
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repo.id)
     this.notifyReposChanged()
     return this.store.getRepo(repo.id) ?? repo
   }
@@ -12939,7 +12949,8 @@ export class OrcaRuntimeService {
     }
     const repo = await this.resolveRepoSelector(repoSelector)
     this.store.removeProject(repo.id)
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repo.id)
     invalidateAuthorizedRootsCache()
     this.notifyReposChanged()
     return { removed: true }
@@ -20847,12 +20858,6 @@ export class OrcaRuntimeService {
     this.resolvedWorktreeCache = null
   }
 
-  private invalidateWorktreeScanCache(): void {
-    this.invalidateResolvedWorktreeCache()
-    this.worktreeScanCache.clear()
-    this.worktreeScanInFlight.clear()
-  }
-
   private invalidateWorktreeScanCacheForRepo(repoId: string): void {
     this.worktreeScanGenerations.set(repoId, (this.worktreeScanGenerations.get(repoId) ?? 0) + 1)
     this.worktreeScanCache.delete(repoId)
@@ -20869,13 +20874,7 @@ export class OrcaRuntimeService {
       this.worktreeScanCache.delete(repoId)
       this.worktreeScanInFlight.delete(repoId)
     }
-    const snapshotContainsAffectedRepo = this.resolvedWorktreeCache?.worktrees.some((worktree) =>
-      [...affectedRepoIds].some((repoId) => worktree.id.startsWith(`${repoId}::`))
-    )
-    if (
-      affectedRepoIds.size > 0 &&
-      (snapshotContainsAffectedRepo || this.resolvedWorktreeInFlight)
-    ) {
+    if (affectedRepoIds.size > 0) {
       this.resolvedWorktreeGeneration += 1
       this.resolvedWorktreeCache = null
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -761,7 +761,11 @@ import {
   getFolderWorkspacePathStatusForPath,
   inferFolderWorkspacePathConnection
 } from '../project-groups/folder-workspace-path-status'
-import { getSshGitProvider, requireSshGitProvider } from '../providers/ssh-git-dispatch'
+import {
+  getSshGitProvider,
+  getSshGitProviderGeneration,
+  requireSshGitProvider
+} from '../providers/ssh-git-dispatch'
 import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
 import { enrichMissingRepoGitRemoteIdentities } from '../repo-git-remote-identity-enrichment'
 import { githubAvatarIcon } from '../../shared/repo-icon'
@@ -2224,6 +2228,7 @@ export class OrcaRuntimeService {
   private resolvedWorktreeCache: ResolvedWorktreeCache | null = null
   private resolvedWorktreeInFlight: ResolvedWorktreeInFlight | null = null
   private resolvedWorktreeGeneration = 0
+  private worktreeScanGenerations = new Map<string, number>()
   private worktreeScanCache = new Map<string, RuntimeWorktreeScanCache>()
   private worktreeScanInFlight = new Map<string, RuntimeWorktreeScanInFlight>()
   private cloneInFlightByPath = new Map<string, Promise<void>>()
@@ -3126,7 +3131,7 @@ export class OrcaRuntimeService {
   // Why: SSH state changes originate in main's ssh handlers, not in runtime
   // methods, so they need a public entry point onto the client-event stream.
   notifySshStateChanged(targetId: string, state: SshConnectionState): void {
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateSshWorktreeScanCache(targetId)
     this.emitClientEvent({ type: 'sshStateChanged', targetId, state })
   }
 
@@ -20709,7 +20714,7 @@ export class OrcaRuntimeService {
     projectRuntimeByRepoId?: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
   ): Promise<RuntimeWorktreeScanResult> {
     const now = Date.now()
-    const generation = this.resolvedWorktreeGeneration
+    const generation = this.worktreeScanGenerations.get(repo.id) ?? 0
     const projectRuntime =
       projectRuntimeByRepoId?.get(repo.id) ??
       (!repo.connectionId
@@ -20720,7 +20725,7 @@ export class OrcaRuntimeService {
         ? projectRuntime.runtime.cacheKey
         : projectRuntime.repair.cacheKey
       : repo.connectionId
-        ? `ssh:${repo.connectionId}`
+        ? `ssh:${repo.connectionId}:${getSshGitProviderGeneration(repo.connectionId)}`
         : 'local:default'
     const cached = this.worktreeScanCache.get(repo.id)
     if (
@@ -20740,7 +20745,7 @@ export class OrcaRuntimeService {
       const result = await promise
       if (
         result.ok &&
-        generation === this.resolvedWorktreeGeneration &&
+        generation === (this.worktreeScanGenerations.get(repo.id) ?? 0) &&
         this.worktreeScanInFlight.get(repo.id)?.promise === promise
       ) {
         this.worktreeScanCache.set(repo.id, {
@@ -20821,6 +20826,25 @@ export class OrcaRuntimeService {
     this.resolvedWorktreeCache = null
     this.worktreeScanCache.clear()
     this.worktreeScanInFlight.clear()
+  }
+
+  private invalidateSshWorktreeScanCache(targetId: string): void {
+    const repos = this.store?.getRepos() ?? []
+    const affectedRepoIds = new Set(
+      repos.filter((repo) => repo.connectionId === targetId).map((repo) => repo.id)
+    )
+    for (const repoId of affectedRepoIds) {
+      this.worktreeScanGenerations.set(repoId, (this.worktreeScanGenerations.get(repoId) ?? 0) + 1)
+      this.worktreeScanCache.delete(repoId)
+      this.worktreeScanInFlight.delete(repoId)
+    }
+    const snapshotContainsAffectedRepo = this.resolvedWorktreeCache?.worktrees.some((worktree) =>
+      [...affectedRepoIds].some((repoId) => worktree.id.startsWith(`${repoId}::`))
+    )
+    if (snapshotContainsAffectedRepo || this.resolvedWorktreeInFlight) {
+      this.resolvedWorktreeGeneration += 1
+      this.resolvedWorktreeCache = null
+    }
   }
 
   /** Invalidate the worktree cache and tell the renderer to re-list, after an

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3124,6 +3124,7 @@ export class OrcaRuntimeService {
   // Why: SSH state changes originate in main's ssh handlers, not in runtime
   // methods, so they need a public entry point onto the client-event stream.
   notifySshStateChanged(targetId: string, state: SshConnectionState): void {
+    this.invalidateResolvedWorktreeCache()
     this.emitClientEvent({ type: 'sshStateChanged', targetId, state })
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3135,6 +3135,10 @@ export class OrcaRuntimeService {
     this.emitClientEvent({ type: 'sshStateChanged', targetId, state })
   }
 
+  invalidateSshWorktreeScanCache(targetId: string): void {
+    this.invalidateSshWorktreeScanCacheInternal(targetId)
+  }
+
   // Why: renderer-initiated meta updates intentionally skip the renderer
   // notifier (the renderer already applied them optimistically), but remote
   // clients hold no optimistic copy and need the invalidation event.
@@ -20828,7 +20832,7 @@ export class OrcaRuntimeService {
     this.worktreeScanInFlight.clear()
   }
 
-  private invalidateSshWorktreeScanCache(targetId: string): void {
+  private invalidateSshWorktreeScanCacheInternal(targetId: string): void {
     const repos = this.store?.getRepos() ?? []
     const affectedRepoIds = new Set(
       repos.filter((repo) => repo.connectionId === targetId).map((repo) => repo.id)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12924,7 +12924,8 @@ export class OrcaRuntimeService {
       invalidateAuthorizedRootsCache()
     }
     if ('worktreeBasePath' in updates) {
-      this.invalidateWorktreeScanCache()
+      this.invalidateResolvedWorktreeCache()
+      this.invalidateWorktreeScanCacheForRepo(repo.id)
     } else {
       this.invalidateResolvedWorktreeCache()
     }
@@ -16034,7 +16035,8 @@ export class OrcaRuntimeService {
       console.warn(`[hooks] ${warning}`)
     }
 
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repo.id)
     // Why: the filesystem-auth layer maintains a separate cache of registered
     // worktree roots used by git IPC handlers (branchCompare, diff, status, etc.)
     // to authorize paths. Without invalidating it here, CLI-created worktrees
@@ -16347,7 +16349,8 @@ export class OrcaRuntimeService {
       result.worktree.comment = args.comment
     }
 
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repo.id)
     this.notifyWorktreesChanged(repo.id)
 
     let warning = result.warning
@@ -17760,7 +17763,8 @@ export class OrcaRuntimeService {
           this.clearOptimisticReconcileToken(removalTarget.id)
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
           this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
-          this.invalidateWorktreeScanCache()
+          this.invalidateResolvedWorktreeCache()
+          this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
           invalidateAuthorizedRootsCache()
           this.notifyWorktreesChanged(repo.id)
           return {}
@@ -17805,7 +17809,8 @@ export class OrcaRuntimeService {
             this.clearOptimisticReconcileToken(removalTarget.id)
             this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
             this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
-            this.invalidateWorktreeScanCache()
+            this.invalidateResolvedWorktreeCache()
+            this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
             invalidateAuthorizedRootsCache()
             this.notifyWorktreesChanged(repo.id)
             return {}
@@ -17838,7 +17843,8 @@ export class OrcaRuntimeService {
           this.clearOptimisticReconcileToken(removalTarget.id)
           this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
           this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
-          this.invalidateWorktreeScanCache()
+          this.invalidateResolvedWorktreeCache()
+          this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
           invalidateAuthorizedRootsCache()
           this.notifyWorktreesChanged(repo.id)
           return {}
@@ -17888,7 +17894,8 @@ export class OrcaRuntimeService {
         )
         this.clearOptimisticReconcileToken(removalTarget.id)
         this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-        this.invalidateWorktreeScanCache()
+        this.invalidateResolvedWorktreeCache()
+        this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
         invalidateAuthorizedRootsCache()
         this.notifyWorktreesChanged(repo.id)
         return removalResult ?? {}
@@ -17929,7 +17936,8 @@ export class OrcaRuntimeService {
         )
         this.clearOptimisticReconcileToken(removalTarget.id)
         this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-        this.invalidateWorktreeScanCache()
+        this.invalidateResolvedWorktreeCache()
+        this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
         invalidateAuthorizedRootsCache()
         this.notifyWorktreesChanged(repo.id)
         return removalResult ?? {}
@@ -18108,7 +18116,8 @@ export class OrcaRuntimeService {
       )
       this.clearOptimisticReconcileToken(removalTarget.id)
       this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-      this.invalidateWorktreeScanCache()
+      this.invalidateResolvedWorktreeCache()
+      this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
       invalidateAuthorizedRootsCache()
       this.notifyWorktreesChanged(repo.id)
       return {
@@ -20876,7 +20885,8 @@ export class OrcaRuntimeService {
    *  out-of-band branch change (e.g. auto-rename-from-work) so the new branch
    *  name surfaces without waiting for the next ambient refresh. */
   notifyBranchRenamed(repoId: string): void {
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repoId)
     this.notifyWorktreesChanged(repoId)
   }
 
@@ -20884,7 +20894,8 @@ export class OrcaRuntimeService {
    *  renderer re-keys its worktree-scoped state instead of treating the id change
    *  (from a folder rename) as a deletion. Same channel = guaranteed ordering. */
   notifyWorktreeFolderRenamed(repoId: string, oldWorktreeId: string, newWorktreeId: string): void {
-    this.invalidateWorktreeScanCache()
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repoId)
     this.notifier?.worktreesChanged(repoId, { oldWorktreeId, newWorktreeId })
     // Mirror notifyBranchRenamed so in-process onClientEvent listeners also see the rename.
     this.emitClientEvent({ type: 'worktreesChanged', repoId })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -20715,11 +20715,11 @@ export class OrcaRuntimeService {
   ): Promise<RuntimeWorktreeScanResult> {
     const now = Date.now()
     const generation = this.worktreeScanGenerations.get(repo.id) ?? 0
-    const projectRuntime =
-      projectRuntimeByRepoId?.get(repo.id) ??
-      (!repo.connectionId
+    const projectRuntime = projectRuntimeByRepoId
+      ? projectRuntimeByRepoId.get(repo.id)
+      : !repo.connectionId
         ? resolveLocalProjectRuntimeForRepo(this.requireStore(), repo)
-        : undefined)
+        : undefined
     const runtimeKey = projectRuntime
       ? projectRuntime.status === 'resolved'
         ? projectRuntime.runtime.cacheKey

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2019,6 +2019,17 @@ type RuntimeWorktreeScanResult =
   | { ok: true; worktrees: GitWorktreeInfo[] }
   | { ok: false; worktrees: GitWorktreeInfo[] }
 
+type RuntimeWorktreeScanCache = {
+  generation: number
+  result: Extract<RuntimeWorktreeScanResult, { ok: true }>
+  expiresAt: number
+}
+
+type RuntimeWorktreeScanInFlight = {
+  generation: number
+  promise: Promise<RuntimeWorktreeScanResult>
+}
+
 type WorktreeLineageCandidate = {
   source: 'env-workspace' | 'cwd-context' | 'terminal-context' | 'orchestration-context'
   parent: ResolvedWorkspaceParent
@@ -2211,6 +2222,8 @@ export class OrcaRuntimeService {
   private resolvedWorktreeCache: ResolvedWorktreeCache | null = null
   private resolvedWorktreeInFlight: ResolvedWorktreeInFlight | null = null
   private resolvedWorktreeGeneration = 0
+  private worktreeScanCache = new Map<string, RuntimeWorktreeScanCache>()
+  private worktreeScanInFlight = new Map<string, RuntimeWorktreeScanInFlight>()
   private cloneInFlightByPath = new Map<string, Promise<void>>()
   private agentDetector: AgentDetector | null = null
   private ptyForegroundAgentRefreshes = new Map<string, PtyForegroundAgentRefresh>()
@@ -20692,6 +20705,39 @@ export class OrcaRuntimeService {
     repo: Repo,
     projectRuntimeByRepoId?: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
   ): Promise<RuntimeWorktreeScanResult> {
+    const now = Date.now()
+    const generation = this.resolvedWorktreeGeneration
+    const cached = this.worktreeScanCache.get(repo.id)
+    if (cached?.generation === generation && cached.expiresAt > now) {
+      return cached.result
+    }
+    const inFlight = this.worktreeScanInFlight.get(repo.id)
+    if (inFlight?.generation === generation) {
+      return inFlight.promise
+    }
+    const promise = this.listRepoWorktreesForResolutionUncached(repo, projectRuntimeByRepoId)
+    this.worktreeScanInFlight.set(repo.id, { generation, promise })
+    try {
+      const result = await promise
+      if (result.ok && generation === this.resolvedWorktreeGeneration) {
+        this.worktreeScanCache.set(repo.id, {
+          generation,
+          result,
+          expiresAt: Date.now() + WORKTREE_SCAN_CACHE_TTL_MS
+        })
+      }
+      return result
+    } finally {
+      if (this.worktreeScanInFlight.get(repo.id)?.promise === promise) {
+        this.worktreeScanInFlight.delete(repo.id)
+      }
+    }
+  }
+
+  private async listRepoWorktreesForResolutionUncached(
+    repo: Repo,
+    projectRuntimeByRepoId: ReadonlyMap<string, ProjectExecutionRuntimeResolution> | undefined
+  ): Promise<RuntimeWorktreeScanResult> {
     if (!repo.connectionId) {
       const projectRuntime = projectRuntimeByRepoId
         ? projectRuntimeByRepoId.get(repo.id)
@@ -20752,6 +20798,8 @@ export class OrcaRuntimeService {
   private invalidateResolvedWorktreeCache(): void {
     this.resolvedWorktreeGeneration += 1
     this.resolvedWorktreeCache = null
+    this.worktreeScanCache.clear()
+    this.worktreeScanInFlight.clear()
   }
 
   /** Invalidate the worktree cache and tell the renderer to re-list, after an
@@ -25532,6 +25580,7 @@ const DEFAULT_WORKTREE_LIST_LIMIT = 200
 const DEFAULT_WORKTREE_PS_LIMIT = 200
 const DISCONNECTED_PTY_RECORD_MAX = 128
 const RESOLVED_WORKTREE_CACHE_TTL_MS = 1000
+const WORKTREE_SCAN_CACHE_TTL_MS = 30_000
 const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
 const PTY_CONTROLLER_LIST_TIMEOUT_MS = 3000
 // Why (§3.3): 30s freshness window. A second worktree-create or dispatch-probe

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2021,12 +2021,14 @@ type RuntimeWorktreeScanResult =
 
 type RuntimeWorktreeScanCache = {
   generation: number
+  runtimeKey: string
   result: Extract<RuntimeWorktreeScanResult, { ok: true }>
   expiresAt: number
 }
 
 type RuntimeWorktreeScanInFlight = {
   generation: number
+  runtimeKey: string
   promise: Promise<RuntimeWorktreeScanResult>
 }
 
@@ -20708,21 +20710,38 @@ export class OrcaRuntimeService {
   ): Promise<RuntimeWorktreeScanResult> {
     const now = Date.now()
     const generation = this.resolvedWorktreeGeneration
+    const projectRuntime =
+      projectRuntimeByRepoId?.get(repo.id) ??
+      (!repo.connectionId
+        ? resolveLocalProjectRuntimeForRepo(this.requireStore(), repo)
+        : undefined)
+    const runtimeKey = projectRuntime
+      ? projectRuntime.status === 'resolved'
+        ? projectRuntime.runtime.cacheKey
+        : projectRuntime.repair.cacheKey
+      : repo.connectionId
+        ? `ssh:${repo.connectionId}`
+        : 'local:default'
     const cached = this.worktreeScanCache.get(repo.id)
-    if (cached?.generation === generation && cached.expiresAt > now) {
+    if (
+      cached?.generation === generation &&
+      cached.runtimeKey === runtimeKey &&
+      cached.expiresAt > now
+    ) {
       return cached.result
     }
     const inFlight = this.worktreeScanInFlight.get(repo.id)
-    if (inFlight?.generation === generation) {
+    if (inFlight?.generation === generation && inFlight.runtimeKey === runtimeKey) {
       return inFlight.promise
     }
-    const promise = this.listRepoWorktreesForResolutionUncached(repo, projectRuntimeByRepoId)
-    this.worktreeScanInFlight.set(repo.id, { generation, promise })
+    const promise = this.listRepoWorktreesForResolutionUncached(repo, projectRuntime)
+    this.worktreeScanInFlight.set(repo.id, { generation, runtimeKey, promise })
     try {
       const result = await promise
       if (result.ok && generation === this.resolvedWorktreeGeneration) {
         this.worktreeScanCache.set(repo.id, {
           generation,
+          runtimeKey,
           result,
           expiresAt: Date.now() + WORKTREE_SCAN_CACHE_TTL_MS
         })
@@ -20737,12 +20756,9 @@ export class OrcaRuntimeService {
 
   private async listRepoWorktreesForResolutionUncached(
     repo: Repo,
-    projectRuntimeByRepoId: ReadonlyMap<string, ProjectExecutionRuntimeResolution> | undefined
+    projectRuntime: ProjectExecutionRuntimeResolution | undefined
   ): Promise<RuntimeWorktreeScanResult> {
     if (!repo.connectionId) {
-      const projectRuntime = projectRuntimeByRepoId
-        ? projectRuntimeByRepoId.get(repo.id)
-        : resolveLocalProjectRuntimeForRepo(this.requireStore(), repo)
       return {
         ok: true,
         worktrees: await listRepoWorktrees(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -20841,7 +20841,10 @@ export class OrcaRuntimeService {
     const snapshotContainsAffectedRepo = this.resolvedWorktreeCache?.worktrees.some((worktree) =>
       [...affectedRepoIds].some((repoId) => worktree.id.startsWith(`${repoId}::`))
     )
-    if (snapshotContainsAffectedRepo || this.resolvedWorktreeInFlight) {
+    if (
+      affectedRepoIds.size > 0 &&
+      (snapshotContainsAffectedRepo || this.resolvedWorktreeInFlight)
+    ) {
       this.resolvedWorktreeGeneration += 1
       this.resolvedWorktreeCache = null
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18097,6 +18097,7 @@ export class OrcaRuntimeService {
             this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
             this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
             this.invalidateResolvedWorktreeCache()
+            this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
             invalidateAuthorizedRootsCache()
             this.notifyWorktreesChanged(repo.id)
             removalCompleted = true

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -20738,7 +20738,11 @@ export class OrcaRuntimeService {
     this.worktreeScanInFlight.set(repo.id, { generation, runtimeKey, promise })
     try {
       const result = await promise
-      if (result.ok && generation === this.resolvedWorktreeGeneration) {
+      if (
+        result.ok &&
+        generation === this.resolvedWorktreeGeneration &&
+        this.worktreeScanInFlight.get(repo.id)?.promise === promise
+      ) {
         this.worktreeScanCache.set(repo.id, {
           generation,
           runtimeKey,


### PR DESCRIPTION
# Summary

OrcaRuntimeService caches successful raw Git and SSH worktree scans per repository for 30 seconds, shares same-generation in-flight scans, and keeps resolved snapshot invalidation separate from raw scan invalidation. Metadata-only changes preserve raw scans, while filesystem, SSH, and runtime-identity changes invalidate the affected raw entries. Folder repositories, SSH fallback behavior, result shaping, lineage attachment, and mutation notifications remain unchanged.

The issue #8882 reproduction falls from 30 backend scans to 15 across two polls for the reported 15-repo catalog, while returning all 15 repo results.

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "worktree scan cache|detected worktree scans"`
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts`
- [x] `pnpm exec oxfmt --check src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts` passed; 716 tests passed.

## AI Review Report

The cache stores only successful authoritative scans, scopes entries by repository and generation, shares in-flight work, rejects stale results, and separates metadata updates from raw-scan invalidation. Git, SSH, folder, lineage, and runtime-owned notification paths retain their existing behavior while affected repositories refresh promptly.

## Security Audit

The change adds no commands, inputs, permissions, credentials, network endpoints, or dependency changes. Cached data is limited to existing worktree results returned by the runtime. SSH failures continue to use the existing stored-metadata fallback.

## Notes

Related PR #6160 is complementary lane-priority work and does not change scan frequency or this cache owner. Known Orca mutations invalidate affected scans immediately, while out-of-band filesystem changes remain visible after the cache TTL. No release changes are included.

Closes #8882
