### PR TITLE
Keep Agent Session History from freezing the app on huge OpenCode databases

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -182,6 +182,9 @@ export default defineConfig({
           'computer-sidecar': resolve('src/main/computer/sidecar-entry.ts'),
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),
           'warp-theme-parser-worker': resolve('src/main/warp-themes/warp-theme-parser-worker.ts'),
+          'session-scanner-opencode-sqlite-worker-entry': resolve(
+            'src/main/ai-vault/session-scanner-opencode-sqlite-worker-entry.ts'
+          ),
           // Why: forked with ELECTRON_RUN_AS_NODE so @parcel/watcher faults
           // can't take down the main process (issue #7547).
           'parcel-watcher-process-entry': resolve('src/main/ipc/parcel-watcher-process-entry.ts'),

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -5,7 +5,7 @@ import { parseGrokSessionFile } from './session-scanner-grok-parser'
 import { parseMessageGraphSessionFile, parseRovoSessionFile } from './session-scanner-graph-parsers'
 import { parseKimiSessionFile } from './session-scanner-kimi-parser'
 import { splitOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
-import { parseOpenCodeSqliteSession } from './session-scanner-opencode-sqlite'
+import { parseOpenCodeSqliteSessionViaWorker } from './session-scanner-opencode-sqlite-worker-spawn'
 import { parseClaudeSessionFile } from './session-scanner-primary-parsers'
 import { parseGeminiSessionFile } from './session-scanner-gemini-parsers'
 import { parseCodexSessionFile } from './session-scanner-codex-parser'
@@ -47,7 +47,7 @@ export async function parseAgentSessionFile(
       // real filesystem paths and fall through to the JSON parser.
       const sqliteCandidate = splitOpenCodeSqliteCandidate(candidate.file.path)
       if (sqliteCandidate) {
-        return parseOpenCodeSqliteSession({
+        return parseOpenCodeSqliteSessionViaWorker({
           dbPath: sqliteCandidate.dbPath,
           sessionId: sqliteCandidate.sessionId,
           platform

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-bounds.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-bounds.test.ts
@@ -1,0 +1,247 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import Database from '../sqlite/sync-database'
+import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
+import { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
+import { parseOpenCodeSqliteSession } from './session-scanner-opencode-sqlite'
+
+// Part B (#8864) bounds: the discovery list LIMITs sessions before evaluating
+// the message-count subquery, and the preview join reads parts of only the
+// newest 100 messages of a session. These tests pin the observable effects.
+
+let tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs = []
+})
+
+function createTempDb(): { db: Database.Database; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-opencode-bounds-'))
+  tempDirs.push(dir)
+  const path = join(dir, 'opencode.db')
+  return { db: new Database(path), path }
+}
+
+function applySchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      parent_id TEXT,
+      directory TEXT,
+      title TEXT,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      time_archived INTEGER,
+      model TEXT,
+      agent TEXT,
+      cost REAL DEFAULT 0,
+      tokens_input INTEGER DEFAULT 0,
+      tokens_output INTEGER DEFAULT 0,
+      tokens_reasoning INTEGER DEFAULT 0,
+      tokens_cache_read INTEGER DEFAULT 0
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `)
+}
+
+function insertSession(db: Database.Database, id: string, timeUpdated: number): void {
+  db.prepare(
+    `INSERT INTO session (id, project_id, directory, title, time_created, time_updated, agent)
+     VALUES (?, 'proj', '/tmp/w', ?, ?, ?, 'build')`
+  ).run(id, `Session ${id}`, timeUpdated - 1000, timeUpdated)
+}
+
+function insertUserMessage(
+  db: Database.Database,
+  args: { id: string; sessionId: string; timeCreated: number; text: string }
+): void {
+  db.prepare(`INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)`).run(
+    args.id,
+    args.sessionId,
+    args.timeCreated,
+    JSON.stringify({ role: 'user' })
+  )
+  db.prepare(
+    `INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)`
+  ).run(
+    `prt_${args.id}`,
+    args.id,
+    args.sessionId,
+    args.timeCreated,
+    JSON.stringify({ type: 'text', text: args.text })
+  )
+}
+
+function insertMessageWithPart(
+  db: Database.Database,
+  args: {
+    id: string
+    sessionId: string
+    timeCreated: number
+    role: string
+    partType: string
+    text: string
+  }
+): void {
+  db.prepare(`INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)`).run(
+    args.id,
+    args.sessionId,
+    args.timeCreated,
+    JSON.stringify({ role: args.role })
+  )
+  db.prepare(
+    `INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)`
+  ).run(
+    `prt_${args.id}`,
+    args.id,
+    args.sessionId,
+    args.timeCreated,
+    JSON.stringify({ type: args.partType, text: args.text })
+  )
+}
+
+describe('listOpenCodeSqliteSessions — LIMIT-first discovery', () => {
+  it('returns only the newest `limit` sessions by time_updated', async () => {
+    const { db, path } = createTempDb()
+    applySchema(db)
+    for (let i = 0; i < 5; i++) {
+      insertSession(db, `ses_${i}`, 1_777_634_000_000 + i * 1000)
+    }
+    db.close()
+
+    const candidates = await listOpenCodeSqliteSessions({ dbPaths: [path], limit: 2, issues: [] })
+    expect(candidates.map((c) => c.file.path)).toEqual([
+      buildOpenCodeSqliteCandidatePath(path, 'ses_4'),
+      buildOpenCodeSqliteCandidatePath(path, 'ses_3')
+    ])
+  })
+})
+
+describe('parseOpenCodeSqliteSession — bounded preview window', () => {
+  it('surfaces the newest text previews and retains the full message count', async () => {
+    // Positive coverage of preview selection (newest OPENCODE_SQLITE_PREVIEW_LIMIT
+    // by recency) + full-count retention. The window bound itself is pinned by the
+    // discriminating test below (this all-text fixture would pass either way).
+    const { db, path } = createTempDb()
+    applySchema(db)
+    const base = 1_777_634_000_000
+    insertSession(db, 'ses_big', base + 200_000)
+
+    for (let i = 0; i < 105; i++) {
+      insertUserMessage(db, {
+        id: `msg_${String(i).padStart(3, '0')}`,
+        sessionId: 'ses_big',
+        timeCreated: base + i * 100,
+        text: i === 0 ? 'OLDEST_PROMPT' : `recent text ${i}`
+      })
+    }
+    db.close()
+
+    const session = await parseOpenCodeSqliteSession({
+      dbPath: path,
+      sessionId: 'ses_big',
+      platform: 'darwin'
+    })
+    expect(session).not.toBeNull()
+    // Full user/assistant count is retained for display accuracy.
+    expect(session!.messageCount).toBe(105)
+    // The preview surfaces the newest text parts only.
+    expect(session!.previewMessages).toHaveLength(5)
+    const previewText = session!.previewMessages.map((m) => m.text)
+    expect(previewText).not.toContain('OLDEST_PROMPT')
+    expect(previewText).toContain('recent text 104')
+  })
+
+  it('excludes user text whose message falls outside the newest-100 window', async () => {
+    // Discriminating fixture: the newest 100 messages carry only non-text parts,
+    // so the window yields zero previews; the user text lives in older messages
+    // beyond the window. The pre-fix whole-session scan would surface that old
+    // text, so this fails if the 100-message window is reverted.
+    const { db, path } = createTempDb()
+    applySchema(db)
+    const base = 1_777_634_000_000
+    insertSession(db, 'ses_window', base + 500_000)
+
+    // Older-than-window user messages with real text parts.
+    for (let i = 0; i < 3; i++) {
+      insertMessageWithPart(db, {
+        id: `old_${i}`,
+        sessionId: 'ses_window',
+        timeCreated: base + i * 100,
+        role: 'user',
+        partType: 'text',
+        text: `OLD_USER_TEXT_${i}`
+      })
+    }
+    // 100 newer assistant messages whose only part is non-text (tool output), so
+    // they fill the newest-100 window but contribute no preview text.
+    for (let i = 0; i < 100; i++) {
+      insertMessageWithPart(db, {
+        id: `new_${String(i).padStart(3, '0')}`,
+        sessionId: 'ses_window',
+        timeCreated: base + 10_000 + i * 100,
+        role: 'assistant',
+        partType: 'tool',
+        text: `tool output ${i}`
+      })
+    }
+    db.close()
+
+    const session = await parseOpenCodeSqliteSession({
+      dbPath: path,
+      sessionId: 'ses_window',
+      platform: 'darwin'
+    })
+    expect(session).not.toBeNull()
+    // Full user/assistant count is retained (3 user + 100 assistant).
+    expect(session!.messageCount).toBe(103)
+    // The window excludes the old user text; the newest 100 have no text parts.
+    expect(session!.previewMessages).toHaveLength(0)
+    expect(session!.previewMessages.map((m) => m.text)).not.toContain('OLD_USER_TEXT_0')
+  })
+
+  it('counts only user/assistant messages, ignoring tool/system rows', async () => {
+    const { db, path } = createTempDb()
+    applySchema(db)
+    insertSession(db, 'ses_roles', 1_777_634_100_000)
+    insertUserMessage(db, {
+      id: 'msg_user',
+      sessionId: 'ses_roles',
+      timeCreated: 1_777_634_000_100,
+      text: 'hello'
+    })
+    // A tool-role message must not inflate the count.
+    db.prepare(`INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)`).run(
+      'msg_tool',
+      'ses_roles',
+      1_777_634_000_200,
+      JSON.stringify({ role: 'tool' })
+    )
+    db.close()
+
+    const session = await parseOpenCodeSqliteSession({
+      dbPath: path,
+      sessionId: 'ses_roles',
+      platform: 'darwin'
+    })
+    expect(session!.messageCount).toBe(1)
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-bounds.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-bounds.test.ts
@@ -135,6 +135,23 @@ describe('listOpenCodeSqliteSessions — LIMIT-first discovery', () => {
     ])
   })
 
+  it('uses time_created recency when time_updated is not positive', async () => {
+    const { db, path } = createTempDb()
+    applySchema(db)
+    insertSession(db, 'ses_updated', 1_777_634_002_000)
+    db.prepare(
+      `INSERT INTO session (id, project_id, directory, title, time_created, time_updated, agent)
+       VALUES ('ses_created', 'proj', '/tmp/w', 'Created fallback', ?, 0, 'build')`
+    ).run(1_777_634_003_000)
+    db.close()
+
+    const candidates = await listOpenCodeSqliteSessions({ dbPaths: [path], limit: 1, issues: [] })
+    expect(candidates.map((candidate) => candidate.file.path)).toEqual([
+      buildOpenCodeSqliteCandidatePath(path, 'ses_created')
+    ])
+    expect(candidates[0].file.mtimeMs).toBe(1_777_634_003_000)
+  })
+
   it('does not read message payloads that discovery does not use', async () => {
     const { db, path } = createTempDb()
     applySchema(db)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-bounds.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-bounds.test.ts
@@ -2,14 +2,15 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import Database from '../sqlite/sync-database'
 import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
 import { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
 import { parseOpenCodeSqliteSession } from './session-scanner-opencode-sqlite'
 
-// Part B (#8864) bounds: the discovery list LIMITs sessions before evaluating
-// the message-count subquery, and the preview join reads parts of only the
-// newest 100 messages of a session. These tests pin the observable effects.
+// Part B (#8864) bounds: discovery reads only the newest session identities and
+// recency fields, while the preview join reads parts of only the newest 100
+// messages of a session. These tests pin the observable effects.
 
 let tempDirs: string[] = []
 
@@ -132,6 +133,26 @@ describe('listOpenCodeSqliteSessions — LIMIT-first discovery', () => {
       buildOpenCodeSqliteCandidatePath(path, 'ses_4'),
       buildOpenCodeSqliteCandidatePath(path, 'ses_3')
     ])
+  })
+
+  it('does not read message payloads that discovery does not use', async () => {
+    const { db, path } = createTempDb()
+    applySchema(db)
+    insertSession(db, 'ses_candidate', 1_777_634_001_000)
+    db.prepare(`INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)`).run(
+      'msg_malformed',
+      'ses_candidate',
+      1_777_634_000_500,
+      'malformed JSON'
+    )
+    db.close()
+
+    const issues: AiVaultScanIssue[] = []
+    const candidates = await listOpenCodeSqliteSessions({ dbPaths: [path], limit: 10, issues })
+    expect(candidates.map((candidate) => candidate.file.path)).toEqual([
+      buildOpenCodeSqliteCandidatePath(path, 'ses_candidate')
+    ])
+    expect(issues).toEqual([])
   })
 })
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -2,9 +2,22 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { scanAiVaultSessions } from './session-scanner'
 import Database from '../sqlite/sync-database'
+
+// Why: this source-level integration suite has no built worker entry. Keep its
+// SQLite fixtures inline explicitly; production fails closed if the bundle is absent.
+vi.mock('./session-scanner-opencode-sqlite-worker-spawn', async () => {
+  const [{ listOpenCodeSqliteSessions }, { parseOpenCodeSqliteSession }] = await Promise.all([
+    import('./session-scanner-opencode-sqlite-list'),
+    import('./session-scanner-opencode-sqlite')
+  ])
+  return {
+    listOpenCodeSqliteSessionsViaWorker: listOpenCodeSqliteSessions,
+    parseOpenCodeSqliteSessionViaWorker: parseOpenCodeSqliteSession
+  }
+})
 
 let tempRoots: string[] = []
 let tempDbDirs: string[] = []

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
@@ -1,170 +1,19 @@
 import { basename, extname, join } from 'node:path'
-import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import { discoverFiles } from './session-scanner-discovery'
-import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
 import { splitOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
-import type {
-  FileWithMtime,
-  SessionFileCandidate,
-  SessionFileDiscovery
-} from './session-scanner-types'
-import { errorMessage } from './session-scanner-values'
-import SyncDatabase from '../sqlite/sync-database'
-import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
+import { listOpenCodeSqliteSessionsViaWorker } from './session-scanner-opencode-sqlite-worker-spawn'
+import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
 
 // Why: keep the SQLite discovery + dedup layer separate from the parser so
 // each file stays under the max-lines lint rule and the discovery layer can
-// be tested in isolation.
+// be tested in isolation. The SQLite list query + reader now lives in
+// session-scanner-opencode-sqlite-list.ts (re-exported below so existing
+// callers/tests keep importing it from here) and runs on a worker thread.
 
-type SessionRow = {
-  id: string
-  title: string | null
-  directory: string | null
-  time_created: number
-  time_updated: number
-  model_json: string | null
-  agent: string | null
-  tokens_input: number
-  tokens_output: number
-  tokens_reasoning: number
-  tokens_cache_read: number
-  cost: number
-  message_count: number
-}
-
-function openReadonlyDatabase(dbPath: string): SyncDatabase {
-  const db = new SyncDatabase(dbPath, { readonly: true, fileMustExist: true })
-  db.pragma('query_only = ON')
-  return db
-}
-
-function canReadOpenCodeSessions(db: SyncDatabase): boolean {
-  return (
-    tableExists(db, 'session') &&
-    columnExists(db, 'session', 'time_created') &&
-    columnExists(db, 'session', 'time_updated')
-  )
-}
-
-function sessionColumnSelect(db: SyncDatabase, columnName: string): string {
-  return columnExists(db, 'session', columnName) ? `s.${columnName}` : 'NULL'
-}
-
-function canCountOpenCodeMessages(db: SyncDatabase): boolean {
-  return (
-    tableExists(db, 'message') &&
-    columnExists(db, 'message', 'session_id') &&
-    columnExists(db, 'message', 'data')
-  )
-}
-
-function buildSessionListQuery(db: SyncDatabase): string {
-  const modelSelect = sessionColumnSelect(db, 'model')
-  const agentSelect = sessionColumnSelect(db, 'agent')
-  const tokenColumns = ['tokens_input', 'tokens_output', 'tokens_reasoning', 'tokens_cache_read']
-  const tokenSelects = tokenColumns
-    .map((col) => `${columnExists(db, 'session', col) ? `s.${col}` : '0'} AS ${col}`)
-    .join(', ')
-  const costSelect = columnExists(db, 'session', 'cost') ? 's.cost' : '0'
-  const parentIdPredicate = columnExists(db, 'session', 'parent_id')
-    ? 'AND s.parent_id IS NULL'
-    : ''
-  const archivedPredicate = columnExists(db, 'session', 'time_archived')
-    ? 'AND s.time_archived IS NULL'
-    : ''
-  const messageCountSubquery = canCountOpenCodeMessages(db)
-    ? `(SELECT COUNT(*) FROM message m
-        WHERE m.session_id = s.id
-          AND json_extract(m.data, '$.role') IN ('user','assistant'))`
-    : '0'
-
-  return `SELECT s.id,
-                 ${sessionColumnSelect(db, 'title')} AS title,
-                 ${sessionColumnSelect(db, 'directory')} AS directory,
-                 s.time_created,
-                 s.time_updated,
-                 ${modelSelect} AS model_json, ${agentSelect} AS agent,
-                 ${tokenSelects}, ${costSelect} AS cost,
-                 ${messageCountSubquery} AS message_count
-          FROM session s
-          WHERE 1=1 ${parentIdPredicate} ${archivedPredicate}
-          ORDER BY s.time_updated DESC
-          LIMIT ?`
-}
-
-function rowToCandidate(row: SessionRow, dbPath: string): SessionFileCandidate {
-  const mtimeMs =
-    typeof row.time_updated === 'number' && row.time_updated > 0
-      ? row.time_updated
-      : row.time_created
-  return {
-    agent: 'opencode' as AiVaultAgent,
-    file: {
-      path: buildOpenCodeSqliteCandidatePath(dbPath, row.id),
-      mtimeMs,
-      modifiedAt: new Date(mtimeMs).toISOString()
-    },
-    codexHome: null
-  }
-}
-
-function dedupeAndSortSqliteCandidates(candidates: SessionFileCandidate[]): SessionFileCandidate[] {
-  const candidatesBySessionId = new Map<string, SessionFileCandidate>()
-  for (const candidate of candidates) {
-    const parsed = splitOpenCodeSqliteCandidate(candidate.file.path)
-    if (!parsed) {
-      continue
-    }
-    const previous = candidatesBySessionId.get(parsed.sessionId)
-    if (!previous || candidate.file.mtimeMs > previous.file.mtimeMs) {
-      candidatesBySessionId.set(parsed.sessionId, candidate)
-    }
-  }
-  return [...candidatesBySessionId.values()].sort((left, right) => {
-    return right.file.mtimeMs - left.file.mtimeMs
-  })
-}
-
-/**
- * List OpenCode sessions from one or more SQLite databases as synthetic
- * `SessionFileCandidate` entries. Each candidate's file path is a synthetic
- * `<dbPath>#<sessionId>` string that the parser dispatcher routes to
- * `parseOpenCodeSqliteSession`. Databases that lack the `session` table are
- * silently skipped; errors are recorded as scan issues.
- * @param args.dbPaths - Absolute paths to opencode.db files to scan.
- * @param args.limit - Maximum number of sessions to return per database.
- * @param args.issues - Collected scan issues to append errors to.
- * @returns Array of synthetic candidates sorted by `time_updated` DESC.
- */
-export async function listOpenCodeSqliteSessions(args: {
-  dbPaths: readonly string[]
-  limit: number
-  issues: AiVaultScanIssue[]
-}): Promise<SessionFileCandidate[]> {
-  const candidates: SessionFileCandidate[] = []
-  for (const dbPath of args.dbPaths) {
-    let db: SyncDatabase | null = null
-    try {
-      db = openReadonlyDatabase(dbPath)
-      if (!canReadOpenCodeSessions(db)) {
-        continue
-      }
-      const rows = db.prepare(buildSessionListQuery(db)).all(args.limit) as SessionRow[]
-      for (const row of rows) {
-        candidates.push(rowToCandidate(row, dbPath))
-      }
-    } catch (err) {
-      args.issues.push({
-        agent: 'opencode',
-        path: dbPath,
-        message: errorMessage(err)
-      })
-    } finally {
-      db?.close()
-    }
-  }
-  return dedupeAndSortSqliteCandidates(candidates)
-}
+// Re-exported: the pure list reader moved to its own electron-free module so the
+// worker entry can import it without the worker client's Electron dependency.
+export { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
 
 // Why: extract the sessionId from a legacy file path like
 // storage/session/<projectId>/<sessionId>.json. Falls back to the filename
@@ -200,7 +49,9 @@ export async function discoverOpenCodeSessions(args: {
       issues: args.issues,
       extensions: ['.json']
     }),
-    listOpenCodeSqliteSessions({
+    // Why (#8864): the SQLite list leg runs on a worker thread; only this leg
+    // moves off the main thread, the filesystem scan stays inline.
+    listOpenCodeSqliteSessionsViaWorker({
       dbPaths: args.dbPaths,
       limit: args.limitPerAgent,
       issues: args.issues

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-list.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-list.ts
@@ -1,0 +1,162 @@
+import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
+import { splitOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
+import type { SessionFileCandidate } from './session-scanner-types'
+import { errorMessage } from './session-scanner-values'
+import SyncDatabase from '../sqlite/sync-database'
+import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
+
+// Why: the SQLite session-list query + reader lives in its own electron-free
+// module so both the worker entry and the main-thread worker client can import
+// it without pulling in the client's Electron dependency.
+
+type SessionRow = {
+  id: string
+  title: string | null
+  directory: string | null
+  time_created: number
+  time_updated: number
+  model_json: string | null
+  agent: string | null
+  tokens_input: number
+  tokens_output: number
+  tokens_reasoning: number
+  tokens_cache_read: number
+  cost: number
+  message_count: number
+}
+
+function openReadonlyDatabase(dbPath: string): SyncDatabase {
+  const db = new SyncDatabase(dbPath, { readonly: true, fileMustExist: true })
+  db.pragma('query_only = ON')
+  return db
+}
+
+function canReadOpenCodeSessions(db: SyncDatabase): boolean {
+  return (
+    tableExists(db, 'session') &&
+    columnExists(db, 'session', 'time_created') &&
+    columnExists(db, 'session', 'time_updated')
+  )
+}
+
+function sessionColumnSelect(db: SyncDatabase, columnName: string): string {
+  return columnExists(db, 'session', columnName) ? `s.${columnName}` : 'NULL'
+}
+
+function canCountOpenCodeMessages(db: SyncDatabase): boolean {
+  return (
+    tableExists(db, 'message') &&
+    columnExists(db, 'message', 'session_id') &&
+    columnExists(db, 'message', 'data')
+  )
+}
+
+function buildSessionListQuery(db: SyncDatabase): string {
+  const modelSelect = sessionColumnSelect(db, 'model')
+  const agentSelect = sessionColumnSelect(db, 'agent')
+  const tokenColumns = ['tokens_input', 'tokens_output', 'tokens_reasoning', 'tokens_cache_read']
+  const tokenSelects = tokenColumns
+    .map((col) => `${columnExists(db, 'session', col) ? `s.${col}` : '0'} AS ${col}`)
+    .join(', ')
+  const costSelect = columnExists(db, 'session', 'cost') ? 's.cost' : '0'
+  const parentIdPredicate = columnExists(db, 'session', 'parent_id') ? 'AND parent_id IS NULL' : ''
+  const archivedPredicate = columnExists(db, 'session', 'time_archived')
+    ? 'AND time_archived IS NULL'
+    : ''
+  const messageCountSubquery = canCountOpenCodeMessages(db)
+    ? `(SELECT COUNT(*) FROM message m
+        WHERE m.session_id = s.id
+          AND json_extract(m.data, '$.role') IN ('user','assistant'))`
+    : '0'
+
+  // Why (#8864): sort+LIMIT the session rows in an inner subselect first so the
+  // correlated message-count subquery is evaluated only for the returned rows,
+  // not for every session in a multi-GB DB.
+  return `SELECT s.id,
+                 ${sessionColumnSelect(db, 'title')} AS title,
+                 ${sessionColumnSelect(db, 'directory')} AS directory,
+                 s.time_created,
+                 s.time_updated,
+                 ${modelSelect} AS model_json, ${agentSelect} AS agent,
+                 ${tokenSelects}, ${costSelect} AS cost,
+                 ${messageCountSubquery} AS message_count
+          FROM (SELECT * FROM session
+                WHERE 1=1 ${parentIdPredicate} ${archivedPredicate}
+                ORDER BY time_updated DESC
+                LIMIT ?) s`
+}
+
+function rowToCandidate(row: SessionRow, dbPath: string): SessionFileCandidate {
+  const mtimeMs =
+    typeof row.time_updated === 'number' && row.time_updated > 0
+      ? row.time_updated
+      : row.time_created
+  return {
+    agent: 'opencode' as AiVaultAgent,
+    file: {
+      path: buildOpenCodeSqliteCandidatePath(dbPath, row.id),
+      mtimeMs,
+      modifiedAt: new Date(mtimeMs).toISOString()
+    },
+    codexHome: null
+  }
+}
+
+function dedupeAndSortSqliteCandidates(candidates: SessionFileCandidate[]): SessionFileCandidate[] {
+  const candidatesBySessionId = new Map<string, SessionFileCandidate>()
+  for (const candidate of candidates) {
+    const parsed = splitOpenCodeSqliteCandidate(candidate.file.path)
+    if (!parsed) {
+      continue
+    }
+    const previous = candidatesBySessionId.get(parsed.sessionId)
+    if (!previous || candidate.file.mtimeMs > previous.file.mtimeMs) {
+      candidatesBySessionId.set(parsed.sessionId, candidate)
+    }
+  }
+  return [...candidatesBySessionId.values()].sort((left, right) => {
+    return right.file.mtimeMs - left.file.mtimeMs
+  })
+}
+
+/**
+ * List OpenCode sessions from one or more SQLite databases as synthetic
+ * `SessionFileCandidate` entries. Each candidate's file path is a synthetic
+ * `<dbPath>#<sessionId>` string that the parser dispatcher routes to
+ * `parseOpenCodeSqliteSession`. Databases that lack the `session` table are
+ * silently skipped; errors are recorded as scan issues.
+ * @param args.dbPaths - Absolute paths to opencode.db files to scan.
+ * @param args.limit - Maximum number of sessions to return per database.
+ * @param args.issues - Collected scan issues to append errors to.
+ * @returns Array of synthetic candidates sorted by `time_updated` DESC.
+ */
+export async function listOpenCodeSqliteSessions(args: {
+  dbPaths: readonly string[]
+  limit: number
+  issues: AiVaultScanIssue[]
+}): Promise<SessionFileCandidate[]> {
+  const candidates: SessionFileCandidate[] = []
+  for (const dbPath of args.dbPaths) {
+    let db: SyncDatabase | null = null
+    try {
+      db = openReadonlyDatabase(dbPath)
+      if (!canReadOpenCodeSessions(db)) {
+        continue
+      }
+      const rows = db.prepare(buildSessionListQuery(db)).all(args.limit) as SessionRow[]
+      for (const row of rows) {
+        candidates.push(rowToCandidate(row, dbPath))
+      }
+    } catch (err) {
+      args.issues.push({
+        agent: 'opencode',
+        path: dbPath,
+        message: errorMessage(err)
+      })
+    } finally {
+      db?.close()
+    }
+  }
+  return dedupeAndSortSqliteCandidates(candidates)
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-list.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-list.ts
@@ -42,7 +42,7 @@ function buildSessionListQuery(db: SyncDatabase): string {
   return `SELECT id, time_created, time_updated
           FROM session
           WHERE 1=1 ${parentIdPredicate} ${archivedPredicate}
-          ORDER BY time_updated DESC
+          ORDER BY CASE WHEN time_updated > 0 THEN time_updated ELSE time_created END DESC
           LIMIT ?`
 }
 
@@ -88,7 +88,7 @@ function dedupeAndSortSqliteCandidates(candidates: SessionFileCandidate[]): Sess
  * @param args.dbPaths - Absolute paths to opencode.db files to scan.
  * @param args.limit - Maximum number of sessions to return per database.
  * @param args.issues - Collected scan issues to append errors to.
- * @returns Array of synthetic candidates sorted by `time_updated` DESC.
+ * @returns Array of synthetic candidates sorted by effective recency.
  */
 export async function listOpenCodeSqliteSessions(args: {
   dbPaths: readonly string[]

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-list.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-list.ts
@@ -12,18 +12,8 @@ import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
 
 type SessionRow = {
   id: string
-  title: string | null
-  directory: string | null
   time_created: number
   time_updated: number
-  model_json: string | null
-  agent: string | null
-  tokens_input: number
-  tokens_output: number
-  tokens_reasoning: number
-  tokens_cache_read: number
-  cost: number
-  message_count: number
 }
 
 function openReadonlyDatabase(dbPath: string): SyncDatabase {
@@ -40,51 +30,20 @@ function canReadOpenCodeSessions(db: SyncDatabase): boolean {
   )
 }
 
-function sessionColumnSelect(db: SyncDatabase, columnName: string): string {
-  return columnExists(db, 'session', columnName) ? `s.${columnName}` : 'NULL'
-}
-
-function canCountOpenCodeMessages(db: SyncDatabase): boolean {
-  return (
-    tableExists(db, 'message') &&
-    columnExists(db, 'message', 'session_id') &&
-    columnExists(db, 'message', 'data')
-  )
-}
-
 function buildSessionListQuery(db: SyncDatabase): string {
-  const modelSelect = sessionColumnSelect(db, 'model')
-  const agentSelect = sessionColumnSelect(db, 'agent')
-  const tokenColumns = ['tokens_input', 'tokens_output', 'tokens_reasoning', 'tokens_cache_read']
-  const tokenSelects = tokenColumns
-    .map((col) => `${columnExists(db, 'session', col) ? `s.${col}` : '0'} AS ${col}`)
-    .join(', ')
-  const costSelect = columnExists(db, 'session', 'cost') ? 's.cost' : '0'
   const parentIdPredicate = columnExists(db, 'session', 'parent_id') ? 'AND parent_id IS NULL' : ''
   const archivedPredicate = columnExists(db, 'session', 'time_archived')
     ? 'AND time_archived IS NULL'
     : ''
-  const messageCountSubquery = canCountOpenCodeMessages(db)
-    ? `(SELECT COUNT(*) FROM message m
-        WHERE m.session_id = s.id
-          AND json_extract(m.data, '$.role') IN ('user','assistant'))`
-    : '0'
 
-  // Why (#8864): sort+LIMIT the session rows in an inner subselect first so the
-  // correlated message-count subquery is evaluated only for the returned rows,
-  // not for every session in a multi-GB DB.
-  return `SELECT s.id,
-                 ${sessionColumnSelect(db, 'title')} AS title,
-                 ${sessionColumnSelect(db, 'directory')} AS directory,
-                 s.time_created,
-                 s.time_updated,
-                 ${modelSelect} AS model_json, ${agentSelect} AS agent,
-                 ${tokenSelects}, ${costSelect} AS cost,
-                 ${messageCountSubquery} AS message_count
-          FROM (SELECT * FROM session
-                WHERE 1=1 ${parentIdPredicate} ${archivedPredicate}
-                ORDER BY time_updated DESC
-                LIMIT ?) s`
+  // Why (#8864): discovery needs only identity and recency. Reading message
+  // blobs or unused session metadata here repeats expensive work on every
+  // refresh; the parse path loads metadata only for candidates it actually uses.
+  return `SELECT id, time_created, time_updated
+          FROM session
+          WHERE 1=1 ${parentIdPredicate} ${archivedPredicate}
+          ORDER BY time_updated DESC
+          LIMIT ?`
 }
 
 function rowToCandidate(row: SessionRow, dbPath: string): SessionFileCandidate {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -1,0 +1,358 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Worker } from 'node:worker_threads'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import Database from '../sqlite/sync-database'
+import {
+  LIST_TIMEOUT_MS,
+  MAX_CONSECUTIVE_DEATHS,
+  OpenCodeSqliteWorkerClient,
+  PARSE_TIMEOUT_MS
+} from './session-scanner-opencode-sqlite-worker-client'
+import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
+import type {
+  OpenCodeSqliteWorkerRequest,
+  OpenCodeSqliteWorkerResponse
+} from './session-scanner-opencode-sqlite-worker-protocol'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+
+// A worker_threads stand-in the tests drive directly: it records posted requests
+// and lets a test emit message/error/exit without a built worker bundle.
+class FakeWorker {
+  postedRequests: OpenCodeSqliteWorkerRequest[] = []
+  terminated = false
+  unrefed = false
+  private listeners = new Map<string, Set<(arg?: unknown) => void>>()
+
+  on(event: string, listener: (arg?: unknown) => void): this {
+    const set = this.listeners.get(event) ?? new Set()
+    set.add(listener)
+    this.listeners.set(event, set)
+    return this
+  }
+
+  off(event: string, listener: (arg?: unknown) => void): this {
+    this.listeners.get(event)?.delete(listener)
+    return this
+  }
+
+  removeAllListeners(): void {
+    this.listeners.clear()
+  }
+
+  unref(): void {
+    this.unrefed = true
+  }
+
+  async terminate(): Promise<number> {
+    this.terminated = true
+    return 1
+  }
+
+  postMessage(request: OpenCodeSqliteWorkerRequest): void {
+    this.postedRequests.push(request)
+  }
+
+  emit(event: string, arg?: unknown): void {
+    // Copy first: the client removes its listeners synchronously during a fault.
+    for (const listener of Array.from(this.listeners.get(event) ?? [])) {
+      listener(arg)
+    }
+  }
+
+  lastId(): number {
+    const last = this.postedRequests.at(-1)
+    if (!last) {
+      throw new Error('no request posted to fake worker')
+    }
+    return last.id
+  }
+}
+
+function makeFactory(workers: FakeWorker[]): () => Worker {
+  return () => {
+    const worker = new FakeWorker()
+    workers.push(worker)
+    return worker as unknown as Worker
+  }
+}
+
+let tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs = []
+})
+
+function createTempOpenCodeDb(sessionId: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-opencode-worker-'))
+  tempDirs.push(dir)
+  const path = join(dir, 'opencode.db')
+  const db = new Database(path)
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL
+    );
+  `)
+  db.prepare(`INSERT INTO session VALUES (?, 1777634000000, 1777634001000)`).run(sessionId)
+  db.close()
+  return path
+}
+
+describe('OpenCodeSqliteWorkerClient', () => {
+  it('correlates responses by id and ignores stale ids', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+
+    const parsePromise = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    const worker = workers[0]
+    expect(worker).toBeDefined()
+    expect(worker!.unrefed).toBe(true)
+
+    // A response for a different id must not settle the active call.
+    worker!.emit('message', {
+      id: 999,
+      ok: true,
+      value: null
+    } satisfies OpenCodeSqliteWorkerResponse)
+    worker!.emit('message', {
+      id: worker!.lastId(),
+      ok: true,
+      value: { sessionId: 'a' }
+    } satisfies OpenCodeSqliteWorkerResponse)
+
+    await expect(parsePromise).resolves.toEqual({ sessionId: 'a' })
+  })
+
+  it('dispatches one request at a time in FIFO order', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+
+    const first = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    const second = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+    const worker = workers[0]!
+
+    // Only the first is dispatched; the second waits for the active slot.
+    expect(worker.postedRequests).toHaveLength(1)
+    expect(worker.postedRequests[0]).toMatchObject({ kind: 'parse', sessionId: 'a' })
+
+    worker.emit('message', { id: worker.postedRequests[0]!.id, ok: true, value: 'A' })
+    await first
+
+    expect(worker.postedRequests).toHaveLength(2)
+    expect(worker.postedRequests[1]).toMatchObject({ kind: 'parse', sessionId: 'b' })
+    worker.emit('message', { id: worker.postedRequests[1]!.id, ok: true, value: 'B' })
+    await expect(second).resolves.toBe('B')
+    // The worker is reused across serial calls (one persistent worker).
+    expect(workers).toHaveLength(1)
+  })
+
+  it('times out only the active call, then respawns and drains the queue', async () => {
+    vi.useFakeTimers()
+    try {
+      const workers: FakeWorker[] = []
+      const client = new OpenCodeSqliteWorkerClient({
+        workerFactory: makeFactory(workers),
+        log() {}
+      })
+
+      const active = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+      const queued = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+      const activeAssertion = expect(active).rejects.toThrow(/timed out/)
+
+      // The queued call's timer must not have started while it waited, so only
+      // the active call fires at the parse timeout.
+      await vi.advanceTimersByTimeAsync(PARSE_TIMEOUT_MS)
+      await activeAssertion
+
+      // Fault respawns a fresh worker and dispatches the still-queued call.
+      expect(workers).toHaveLength(2)
+      const respawned = workers[1]!
+      expect(respawned.postedRequests).toHaveLength(1)
+      expect(respawned.postedRequests[0]).toMatchObject({ sessionId: 'b' })
+      respawned.emit('message', { id: respawned.lastId(), ok: true, value: 'B' })
+      await expect(queued).resolves.toBe('B')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects only the active call on a worker crash and respawns for the queue', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+
+    const active = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    const queued = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+    const activeAssertion = expect(active).rejects.toThrow(/exited with code/)
+
+    workers[0]!.emit('exit', 1)
+    await activeAssertion
+    expect(workers[0]!.terminated).toBe(true)
+
+    // Exactly one respawn; the queued call drains on the new worker.
+    expect(workers).toHaveLength(2)
+    const respawned = workers[1]!
+    respawned.emit('message', { id: respawned.lastId(), ok: true, value: 'B' })
+    await expect(queued).resolves.toBe('B')
+  })
+
+  it('falls back to the in-process reader when the worker cannot spawn', async () => {
+    const dbPath = createTempOpenCodeDb('ses_inline')
+    const client = new OpenCodeSqliteWorkerClient({
+      workerFactory() {
+        throw new Error('no worker bundle')
+      },
+      log() {}
+    })
+
+    const listIssues: AiVaultScanIssue[] = []
+    const candidates = await client.list({ dbPaths: [dbPath], limit: 10, issues: listIssues })
+    expect(candidates.map((c) => c.file.path)).toEqual([
+      buildOpenCodeSqliteCandidatePath(dbPath, 'ses_inline')
+    ])
+    // Degraded mode surfaces as a scan issue, not only a log.
+    expect(listIssues.some((issue) => /degraded inline mode/.test(issue.message))).toBe(true)
+
+    const session = await client.parse({
+      dbPath,
+      sessionId: 'ses_inline',
+      platform: 'darwin'
+    })
+    expect(session?.sessionId).toBe('ses_inline')
+  })
+
+  it('stops respawning after the consecutive-death cap and fails the rest to issues', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+
+    const pending = Array.from({ length: MAX_CONSECUTIVE_DEATHS + 2 }, (_, i) =>
+      client.parse({ dbPath: `/db#${i}`, sessionId: `s${i}`, platform: 'darwin' })
+    )
+    const settled = pending.map((promise) => expect(promise).rejects.toThrow())
+
+    // Crash every worker as it is spawned; the client respawns up to the cap.
+    for (let i = 0; i < MAX_CONSECUTIVE_DEATHS; i++) {
+      expect(workers[i]).toBeDefined()
+      workers[i]!.emit('error', new Error(`crash ${i}`))
+    }
+
+    await Promise.all(settled)
+    // No respawn past the cap: only MAX_CONSECUTIVE_DEATHS workers were created,
+    // and the queued remainder failed to scan issues rather than looping.
+    expect(workers).toHaveLength(MAX_CONSECUTIVE_DEATHS)
+  })
+
+  it('surfaces a list-leg timeout as a scan issue and returns no candidates', async () => {
+    vi.useFakeTimers()
+    try {
+      const workers: FakeWorker[] = []
+      const client = new OpenCodeSqliteWorkerClient({
+        workerFactory: makeFactory(workers),
+        log() {}
+      })
+      const issues: AiVaultScanIssue[] = []
+      const listPromise = client.list({
+        dbPaths: ['/tmp/opencode.db'],
+        limit: 10,
+        issues
+      })
+      // The list request is dispatched but never answered → it must time out into
+      // a scan issue (not an unbounded stall) and contribute no sessions.
+      await vi.advanceTimersByTimeAsync(LIST_TIMEOUT_MS)
+      await expect(listPromise).resolves.toEqual([])
+      expect(issues).toHaveLength(1)
+      expect(issues[0]!.agent).toBe('opencode')
+      expect(issues[0]!.message).toMatch(/did not complete/)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('self-heals after repeated spawn failures instead of latching inline forever', async () => {
+    const workers: FakeWorker[] = []
+    let failSpawns = true
+    const client = new OpenCodeSqliteWorkerClient({
+      workerFactory() {
+        if (failSpawns) {
+          throw new Error('spawn down')
+        }
+        const worker = new FakeWorker()
+        workers.push(worker)
+        return worker as unknown as Worker
+      },
+      log() {}
+    })
+    const dbPath = createTempOpenCodeDb('ses_heal')
+
+    // Scan 1: both the list leg and a parse fail to spawn (two consecutive
+    // failures) → both fall back inline; no worker is ever created.
+    const firstIssues: AiVaultScanIssue[] = []
+    const first = await client.list({ dbPaths: [dbPath], limit: 10, issues: firstIssues })
+    expect(first.map((c) => c.file.path)).toEqual([
+      buildOpenCodeSqliteCandidatePath(dbPath, 'ses_heal')
+    ])
+    expect(firstIssues.some((issue) => /degraded inline mode/.test(issue.message))).toBe(true)
+    const parsed = await client.parse({ dbPath, sessionId: 'ses_heal', platform: 'darwin' })
+    expect(parsed?.sessionId).toBe('ses_heal')
+    expect(workers).toHaveLength(0)
+
+    // Spawns recover; the next scan must re-probe and use the worker — proving no
+    // spawn failure ever latched the client into permanent main-thread inline mode.
+    failSpawns = false
+    const secondIssues: AiVaultScanIssue[] = []
+    const secondPromise = client.list({ dbPaths: [dbPath], limit: 10, issues: secondIssues })
+    const worker = workers[0]
+    expect(worker).toBeDefined()
+    worker!.emit('message', {
+      id: worker!.lastId(),
+      ok: true,
+      value: { candidates: [], issues: [] }
+    } satisfies OpenCodeSqliteWorkerResponse)
+    await expect(secondPromise).resolves.toEqual([])
+    expect(secondIssues).toHaveLength(0)
+  })
+
+  it('does not carry a worker death from a prior burst into the next scan cap', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+
+    // Burst 1: one parse whose worker dies, then the burst ends (queue empties)
+    // with no success to reset the death counter.
+    const first = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    const firstAssertion = expect(first).rejects.toThrow(/exited with code/)
+    workers[0]!.emit('exit', 1)
+    await firstAssertion
+
+    // Burst 2 from idle: the fresh scan resets the cap, so MAX_CONSECUTIVE_DEATHS
+    // brand-new workers must be spawned before the remainder drains — the carried
+    // death from burst 1 does not count against burst 2.
+    const pending = Array.from({ length: MAX_CONSECUTIVE_DEATHS }, (_, i) =>
+      client.parse({ dbPath: `/db#b${i}`, sessionId: `b${i}`, platform: 'darwin' })
+    )
+    const settled = pending.map((promise) => expect(promise).rejects.toThrow())
+    for (let i = 0; i < MAX_CONSECUTIVE_DEATHS; i++) {
+      workers.at(-1)!.emit('error', new Error(`b-crash ${i}`))
+    }
+    await Promise.all(settled)
+    // One worker from burst 1 plus a fresh worker per allowed death in burst 2.
+    expect(workers).toHaveLength(1 + MAX_CONSECUTIVE_DEATHS)
+  })
+
+  it('reuses the warm worker across a burst without respawning', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+
+    for (let i = 0; i < 3; i++) {
+      const promise = client.parse({ dbPath: `/db#${i}`, sessionId: `s${i}`, platform: 'darwin' })
+      const worker = workers[0]!
+      worker.emit('message', { id: worker.lastId(), ok: true, value: `v${i}` })
+      await expect(promise).resolves.toBe(`v${i}`)
+    }
+    expect(workers).toHaveLength(1)
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -1,16 +1,12 @@
-import { mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import type { Worker } from 'node:worker_threads'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import Database from '../sqlite/sync-database'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  IDLE_TEARDOWN_MS,
   LIST_TIMEOUT_MS,
   MAX_CONSECUTIVE_DEATHS,
   OpenCodeSqliteWorkerClient,
   PARSE_TIMEOUT_MS
 } from './session-scanner-opencode-sqlite-worker-client'
-import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
 import type {
   OpenCodeSqliteWorkerRequest,
   OpenCodeSqliteWorkerResponse
@@ -76,32 +72,6 @@ function makeFactory(workers: FakeWorker[]): () => Worker {
     workers.push(worker)
     return worker as unknown as Worker
   }
-}
-
-let tempDirs: string[] = []
-
-afterEach(() => {
-  for (const dir of tempDirs) {
-    rmSync(dir, { recursive: true, force: true })
-  }
-  tempDirs = []
-})
-
-function createTempOpenCodeDb(sessionId: string): string {
-  const dir = mkdtempSync(join(tmpdir(), 'orca-opencode-worker-'))
-  tempDirs.push(dir)
-  const path = join(dir, 'opencode.db')
-  const db = new Database(path)
-  db.exec(`
-    CREATE TABLE session (
-      id TEXT PRIMARY KEY,
-      time_created INTEGER NOT NULL,
-      time_updated INTEGER NOT NULL
-    );
-  `)
-  db.prepare(`INSERT INTO session VALUES (?, 1777634000000, 1777634001000)`).run(sessionId)
-  db.close()
-  return path
 }
 
 describe('OpenCodeSqliteWorkerClient', () => {
@@ -201,8 +171,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     await expect(queued).resolves.toBe('B')
   })
 
-  it('falls back to the in-process reader when the worker cannot spawn', async () => {
-    const dbPath = createTempOpenCodeDb('ses_inline')
+  it('fails closed instead of running SQLite on the main thread when spawn fails', async () => {
     const client = new OpenCodeSqliteWorkerClient({
       workerFactory() {
         throw new Error('no worker bundle')
@@ -211,19 +180,15 @@ describe('OpenCodeSqliteWorkerClient', () => {
     })
 
     const listIssues: AiVaultScanIssue[] = []
-    const candidates = await client.list({ dbPaths: [dbPath], limit: 10, issues: listIssues })
-    expect(candidates.map((c) => c.file.path)).toEqual([
-      buildOpenCodeSqliteCandidatePath(dbPath, 'ses_inline')
-    ])
-    // Degraded mode surfaces as a scan issue, not only a log.
-    expect(listIssues.some((issue) => /degraded inline mode/.test(issue.message))).toBe(true)
-
-    const session = await client.parse({
-      dbPath,
-      sessionId: 'ses_inline',
-      platform: 'darwin'
-    })
-    expect(session?.sessionId).toBe('ses_inline')
+    await expect(
+      client.list({ dbPaths: ['/tmp/opencode.db'], limit: 10, issues: listIssues })
+    ).resolves.toEqual([])
+    expect(
+      listIssues.some((issue) => /background scanner could not start/.test(issue.message))
+    ).toBe(true)
+    await expect(
+      client.parse({ dbPath: '/tmp/opencode.db', sessionId: 'ses_skipped', platform: 'darwin' })
+    ).rejects.toThrow(/background scanner could not start/)
   })
 
   it('stops respawning after the consecutive-death cap and fails the rest to issues', async () => {
@@ -273,7 +238,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     }
   })
 
-  it('self-heals after repeated spawn failures instead of latching inline forever', async () => {
+  it('self-heals after repeated spawn failures instead of latching unavailable', async () => {
     const workers: FakeWorker[] = []
     let failSpawns = true
     const client = new OpenCodeSqliteWorkerClient({
@@ -287,25 +252,23 @@ describe('OpenCodeSqliteWorkerClient', () => {
       },
       log() {}
     })
-    const dbPath = createTempOpenCodeDb('ses_heal')
-
-    // Scan 1: both the list leg and a parse fail to spawn (two consecutive
-    // failures) → both fall back inline; no worker is ever created.
+    // Scan 1: both calls fail closed, keeping synchronous SQLite off the main
+    // thread. The failure is not latched, so a later scan can still recover.
     const firstIssues: AiVaultScanIssue[] = []
-    const first = await client.list({ dbPaths: [dbPath], limit: 10, issues: firstIssues })
-    expect(first.map((c) => c.file.path)).toEqual([
-      buildOpenCodeSqliteCandidatePath(dbPath, 'ses_heal')
-    ])
-    expect(firstIssues.some((issue) => /degraded inline mode/.test(issue.message))).toBe(true)
-    const parsed = await client.parse({ dbPath, sessionId: 'ses_heal', platform: 'darwin' })
-    expect(parsed?.sessionId).toBe('ses_heal')
+    const first = await client.list({ dbPaths: ['/db'], limit: 10, issues: firstIssues })
+    expect(first).toEqual([])
+    expect(
+      firstIssues.some((issue) => /background scanner could not start/.test(issue.message))
+    ).toBe(true)
+    await expect(
+      client.parse({ dbPath: '/db', sessionId: 'ses_heal', platform: 'darwin' })
+    ).rejects.toThrow(/background scanner could not start/)
     expect(workers).toHaveLength(0)
 
-    // Spawns recover; the next scan must re-probe and use the worker — proving no
-    // spawn failure ever latched the client into permanent main-thread inline mode.
+    // Spawns recover; the next scan must re-probe and use the worker.
     failSpawns = false
     const secondIssues: AiVaultScanIssue[] = []
-    const secondPromise = client.list({ dbPaths: [dbPath], limit: 10, issues: secondIssues })
+    const secondPromise = client.list({ dbPaths: ['/db'], limit: 10, issues: secondIssues })
     const worker = workers[0]
     expect(worker).toBeDefined()
     worker!.emit('message', {
@@ -315,6 +278,45 @@ describe('OpenCodeSqliteWorkerClient', () => {
     } satisfies OpenCodeSqliteWorkerResponse)
     await expect(secondPromise).resolves.toEqual([])
     expect(secondIssues).toHaveLength(0)
+  })
+
+  it('drops a cleanly exited idle worker and respawns on the next request', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+
+    const first = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    workers[0]!.emit('message', { id: workers[0]!.lastId(), ok: true, value: 'A' })
+    await expect(first).resolves.toBe('A')
+    workers[0]!.emit('exit', 0)
+
+    const second = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+    expect(workers).toHaveLength(2)
+    workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'B' })
+    await expect(second).resolves.toBe('B')
+  })
+
+  it('terminates an idle worker and respawns on later work', async () => {
+    vi.useFakeTimers()
+    try {
+      const workers: FakeWorker[] = []
+      const client = new OpenCodeSqliteWorkerClient({
+        workerFactory: makeFactory(workers),
+        log() {}
+      })
+
+      const first = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+      workers[0]!.emit('message', { id: workers[0]!.lastId(), ok: true, value: 'A' })
+      await expect(first).resolves.toBe('A')
+      await vi.advanceTimersByTimeAsync(IDLE_TEARDOWN_MS)
+      expect(workers[0]!.terminated).toBe(true)
+
+      const second = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+      expect(workers).toHaveLength(2)
+      workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'B' })
+      await expect(second).resolves.toBe('B')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not carry a worker death from a prior burst into the next scan cap', async () => {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -1,0 +1,334 @@
+import type { Worker } from 'node:worker_threads'
+import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
+import { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
+import { parseOpenCodeSqliteSession } from './session-scanner-opencode-sqlite'
+import type {
+  OpenCodeSqliteListRequest,
+  OpenCodeSqliteListValue,
+  OpenCodeSqliteParseRequest,
+  OpenCodeSqliteWorkerRequest,
+  OpenCodeSqliteWorkerResponse
+} from './session-scanner-opencode-sqlite-worker-protocol'
+import type { SessionFileCandidate } from './session-scanner-types'
+import { errorMessage } from './session-scanner-values'
+
+// Why (#8864): a lazily-spawned, unref'd worker runs OpenCode SQLite reads off
+// the main-process event loop. Lifecycle (idle teardown, FIFO one-at-a-time
+// dispatch, per-call timeouts, respawn-on-fault) mirrors src/main/speech/
+// stt-service.ts; the inline fallback preserves today's behavior when no worker
+// bundle exists (tests, packaged-file regressions). The default spawn + shared
+// singleton live in session-scanner-opencode-sqlite-worker-spawn.ts.
+
+export const LIST_TIMEOUT_MS = 30_000
+export const PARSE_TIMEOUT_MS = 15_000
+export const IDLE_TEARDOWN_MS = 30_000
+// After this many consecutive worker deaths, fail the remaining queued calls to
+// scan issues instead of respawning so a DB that reliably kills the worker can't
+// spin a crash loop. Reset on any successful response, after draining, and when a
+// fresh scan burst starts from idle (so the cap is per-scan, not process-wide).
+export const MAX_CONSECUTIVE_DEATHS = 3
+
+export type WorkerFactory = () => Worker
+
+// Omit<union, 'id'> collapses to the shared keys, so omit each member and let
+// the client stamp the correlation id.
+type OpenCodeSqliteRequestBody =
+  | Omit<OpenCodeSqliteListRequest, 'id'>
+  | Omit<OpenCodeSqliteParseRequest, 'id'>
+
+type PendingCall = {
+  request: OpenCodeSqliteWorkerRequest
+  timeoutMs: number
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  timer: NodeJS.Timeout | null
+}
+
+// Distinguishes "no worker available at all" (→ inline fallback) from a timeout
+// or crash (→ scan issue), so the routing callers pick the right degraded path.
+class OpenCodeSqliteWorkerUnavailableError extends Error {}
+
+export class OpenCodeSqliteWorkerClient {
+  private worker: Worker | null = null
+  private active: PendingCall | null = null
+  private queue: PendingCall[] = []
+  private idleTimer: NodeJS.Timeout | null = null
+  private consecutiveDeaths = 0
+  private nextId = 1
+  private loggedInlineFallback = false
+  private cleanupWorkerListeners: (() => void) | null = null
+  private readonly workerFactory: WorkerFactory
+  private readonly log: (message: string) => void
+
+  constructor(options: { workerFactory: WorkerFactory; log?: (message: string) => void }) {
+    this.workerFactory = options.workerFactory
+    this.log = options.log ?? ((message) => console.warn(message))
+  }
+
+  async list(args: {
+    dbPaths: readonly string[]
+    limit: number
+    issues: AiVaultScanIssue[]
+  }): Promise<SessionFileCandidate[]> {
+    if (args.dbPaths.length === 0) {
+      return []
+    }
+    try {
+      const value = (await this.dispatch(
+        { kind: 'list', dbPaths: args.dbPaths, limit: args.limit },
+        LIST_TIMEOUT_MS
+      )) as OpenCodeSqliteListValue
+      args.issues.push(...value.issues)
+      return value.candidates
+    } catch (err) {
+      if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
+        return this.runListInline(args)
+      }
+      // Timeout/crash: this storage dir's SQLite DBs contribute no sessions this
+      // scan, surfaced as one scan issue rather than an unbounded stall.
+      args.issues.push({
+        agent: 'opencode',
+        path: args.dbPaths[0] ?? 'opencode.db',
+        message: `OpenCode history scan did not complete: ${errorMessage(err)}`
+      })
+      return []
+    }
+  }
+
+  async parse(args: {
+    dbPath: string
+    sessionId: string
+    platform: NodeJS.Platform
+  }): Promise<AiVaultSession | null> {
+    try {
+      const value = await this.dispatch(
+        { kind: 'parse', dbPath: args.dbPath, sessionId: args.sessionId, platform: args.platform },
+        PARSE_TIMEOUT_MS
+      )
+      return value as AiVaultSession | null
+    } catch (err) {
+      if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
+        return parseOpenCodeSqliteSession(args)
+      }
+      // Reject only this session; the scanner turns the throw into a scan issue.
+      throw err instanceof Error ? err : new Error(String(err))
+    }
+  }
+
+  private async runListInline(args: {
+    dbPaths: readonly string[]
+    limit: number
+    issues: AiVaultScanIssue[]
+  }): Promise<SessionFileCandidate[]> {
+    // Why: running the scan inline reintroduces the main-thread hang on very
+    // large DBs, so surface it through the same per-source scan-issue plumbing
+    // (not only a log) — visible in the panel every scan the worker is
+    // unavailable, instead of silently passing as a slow scan.
+    args.issues.push({
+      agent: 'opencode',
+      path: args.dbPaths[0] ?? 'opencode.db',
+      message:
+        'OpenCode history is running in degraded inline mode (background worker unavailable); very large databases may slow scanning.'
+    })
+    return listOpenCodeSqliteSessions(args)
+  }
+
+  private dispatch(request: OpenCodeSqliteRequestBody, timeoutMs: number): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++
+      // A fresh burst from full idle starts a new scan: clear any death count
+      // carried from a prior scan so the respawn cap can't drain this scan early.
+      if (!this.active && this.queue.length === 0) {
+        this.consecutiveDeaths = 0
+      }
+      this.queue.push({
+        request: { ...request, id } as OpenCodeSqliteWorkerRequest,
+        timeoutMs,
+        resolve,
+        reject,
+        timer: null
+      })
+      this.pump()
+    })
+  }
+
+  private pump(): void {
+    if (this.active || this.queue.length === 0) {
+      return
+    }
+    const worker = this.ensureWorker()
+    if (!worker) {
+      this.failQueuedAsUnavailable()
+      return
+    }
+    const call = this.queue.shift()
+    if (!call) {
+      return
+    }
+    this.active = call
+    this.clearIdleTimer()
+    // Timeout clock starts at dispatch (not enqueue): a batch may enqueue up to
+    // 8 parses at once, and a queue-inclusive timeout would fire falsely.
+    call.timer = setTimeout(() => this.onTimeout(call), call.timeoutMs)
+    call.timer.unref?.()
+    worker.postMessage(call.request)
+  }
+
+  private ensureWorker(): Worker | null {
+    if (this.worker) {
+      return this.worker
+    }
+    try {
+      const worker = this.workerFactory()
+      const onMessage = (response: OpenCodeSqliteWorkerResponse): void => this.onMessage(response)
+      const onError = (error: Error): void => this.onWorkerFault(error)
+      const onExit = (code: number): void => this.onWorkerExit(code)
+      worker.on('message', onMessage)
+      worker.on('error', onError)
+      worker.on('exit', onExit)
+      this.cleanupWorkerListeners = () => {
+        worker.off('message', onMessage)
+        worker.off('error', onError)
+        worker.off('exit', onExit)
+      }
+      // Never keep the app alive for a scan worker.
+      worker.unref?.()
+      this.worker = worker
+      return worker
+    } catch (err) {
+      // No worker (missing bundle / transient spawn failure): this call falls
+      // back inline via failQueuedAsUnavailable. Never latch — the next call
+      // re-probes, so a transient failure self-heals instead of pinning the app
+      // to the main-thread inline path for the session. Log once to avoid spam.
+      if (!this.loggedInlineFallback) {
+        this.loggedInlineFallback = true
+        this.log(`OpenCode SQLite worker unavailable; scanning inline. ${errorMessage(err)}`)
+      }
+      return null
+    }
+  }
+
+  private onMessage(response: OpenCodeSqliteWorkerResponse): void {
+    const call = this.active
+    if (!call || call.request.id !== response.id) {
+      return
+    }
+    this.consecutiveDeaths = 0
+    if (response.ok) {
+      this.settle(call, () => call.resolve(response.value))
+    } else {
+      this.settle(call, () => call.reject(new Error(response.error)))
+    }
+    this.afterSettle()
+  }
+
+  private onTimeout(call: PendingCall): void {
+    if (this.active !== call) {
+      return
+    }
+    this.onWorkerFault(new Error(`OpenCode SQLite worker timed out after ${call.timeoutMs}ms`))
+  }
+
+  private onWorkerExit(code: number): void {
+    if (code === 0 && !this.active) {
+      return
+    }
+    this.onWorkerFault(new Error(`OpenCode SQLite worker exited with code ${code}`))
+  }
+
+  private onWorkerFault(error: Error): void {
+    const failed = this.active
+    this.destroyWorker()
+    this.consecutiveDeaths++
+    if (failed) {
+      this.settle(failed, () => failed.reject(error))
+    }
+    if (this.consecutiveDeaths >= MAX_CONSECUTIVE_DEATHS) {
+      this.drainQueueAfterCrashLoop(error)
+      return
+    }
+    if (this.queue.length > 0) {
+      this.pump()
+    }
+  }
+
+  private drainQueueAfterCrashLoop(error: Error): void {
+    const pending = this.queue
+    this.queue = []
+    this.consecutiveDeaths = 0
+    const drainError = new Error(
+      `OpenCode SQLite worker crashed repeatedly; skipping remaining sessions (${error.message})`
+    )
+    for (const call of pending) {
+      this.settle(call, () => call.reject(drainError))
+    }
+  }
+
+  private failQueuedAsUnavailable(): void {
+    const pending = this.queue
+    this.queue = []
+    for (const call of pending) {
+      this.settle(call, () =>
+        call.reject(new OpenCodeSqliteWorkerUnavailableError('worker spawn failed'))
+      )
+    }
+  }
+
+  private settle(call: PendingCall, run: () => void): void {
+    if (call.timer) {
+      clearTimeout(call.timer)
+      call.timer = null
+    }
+    if (this.active === call) {
+      this.active = null
+    }
+    run()
+  }
+
+  private afterSettle(): void {
+    if (this.queue.length > 0) {
+      this.pump()
+    } else {
+      this.scheduleIdleTeardown()
+    }
+  }
+
+  private scheduleIdleTeardown(): void {
+    this.clearIdleTimer()
+    if (!this.worker) {
+      return
+    }
+    this.idleTimer = setTimeout(() => this.teardownIfIdle(), IDLE_TEARDOWN_MS)
+    this.idleTimer.unref?.()
+  }
+
+  private teardownIfIdle(): void {
+    this.idleTimer = null
+    // Only tear down with nothing active AND nothing queued: a request arriving
+    // as the timer fires must never be lost to a self-exiting worker.
+    if (this.active || this.queue.length > 0) {
+      return
+    }
+    this.destroyWorker()
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer)
+      this.idleTimer = null
+    }
+  }
+
+  private destroyWorker(): void {
+    this.clearIdleTimer()
+    const worker = this.worker
+    this.worker = null
+    if (!worker) {
+      return
+    }
+    this.cleanupWorkerListeners?.()
+    this.cleanupWorkerListeners = null
+    worker.removeAllListeners()
+    void worker.terminate().catch(() => undefined)
+  }
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -48,6 +48,13 @@ type PendingCall = {
 // or crash (→ scan issue), so the routing callers pick the right degraded path.
 class OpenCodeSqliteWorkerUnavailableError extends Error {}
 
+/**
+ * Main-thread bridge that runs OpenCode SQLite reads on a persistent worker
+ * thread. Dispatches one request at a time (FIFO), times each request out from
+ * dispatch, respawns after faults (capped by `MAX_CONSECUTIVE_DEATHS`), tears
+ * the worker down after `IDLE_TEARDOWN_MS` of inactivity, and transparently
+ * falls back to the in-process readers when no worker can be spawned.
+ */
 export class OpenCodeSqliteWorkerClient {
   private worker: Worker | null = null
   private active: PendingCall | null = null
@@ -65,6 +72,14 @@ export class OpenCodeSqliteWorkerClient {
     this.log = options.log ?? ((message) => console.warn(message))
   }
 
+  /**
+   * List session candidates from the given OpenCode databases on the worker.
+   * @param args.dbPaths - Absolute paths to opencode.db files to scan.
+   * @param args.limit - Maximum number of sessions to return per database.
+   * @param args.issues - Collected scan issues (worker issues are merged in).
+   * @returns Synthetic candidates sorted by `time_updated` DESC; empty (with a
+   *   scan issue) when the worker times out or crashes.
+   */
   async list(args: {
     dbPaths: readonly string[]
     limit: number
@@ -95,6 +110,14 @@ export class OpenCodeSqliteWorkerClient {
     }
   }
 
+  /**
+   * Parse a single OpenCode session on the worker.
+   * @param args.dbPath - Absolute path to the opencode.db file.
+   * @param args.sessionId - Primary key in the `session` table.
+   * @param args.platform - Platform used for resume-command generation.
+   * @returns The parsed session, or `null` when it does not exist; rejects on
+   *   worker timeout/crash so the scanner records a per-session scan issue.
+   */
   async parse(args: {
     dbPath: string
     sessionId: string
@@ -230,7 +253,10 @@ export class OpenCodeSqliteWorkerClient {
   }
 
   private onWorkerExit(code: number): void {
-    if (code === 0 && !this.active) {
+    // A clean self-exit is not a death, but the stale handle must be dropped
+    // or the next dispatch would post into the dead worker and stall to timeout.
+    if (code === 0 && !this.active && this.queue.length === 0) {
+      this.destroyWorker()
       return
     }
     this.onWorkerFault(new Error(`OpenCode SQLite worker exited with code ${code}`))

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -1,7 +1,5 @@
 import type { Worker } from 'node:worker_threads'
 import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
-import { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
-import { parseOpenCodeSqliteSession } from './session-scanner-opencode-sqlite'
 import type {
   OpenCodeSqliteListRequest,
   OpenCodeSqliteListValue,
@@ -15,9 +13,8 @@ import { errorMessage } from './session-scanner-values'
 // Why (#8864): a lazily-spawned, unref'd worker runs OpenCode SQLite reads off
 // the main-process event loop. Lifecycle (idle teardown, FIFO one-at-a-time
 // dispatch, per-call timeouts, respawn-on-fault) mirrors src/main/speech/
-// stt-service.ts; the inline fallback preserves today's behavior when no worker
-// bundle exists (tests, packaged-file regressions). The default spawn + shared
-// singleton live in session-scanner-opencode-sqlite-worker-spawn.ts.
+// stt-service.ts. The default spawn + shared singleton live in
+// session-scanner-opencode-sqlite-worker-spawn.ts.
 
 export const LIST_TIMEOUT_MS = 30_000
 export const PARSE_TIMEOUT_MS = 15_000
@@ -44,16 +41,16 @@ type PendingCall = {
   timer: NodeJS.Timeout | null
 }
 
-// Distinguishes "no worker available at all" (→ inline fallback) from a timeout
-// or crash (→ scan issue), so the routing callers pick the right degraded path.
+// Distinguishes "no worker available at all" from a timeout or crash so callers
+// can surface a precise issue while keeping synchronous SQLite off the main thread.
 class OpenCodeSqliteWorkerUnavailableError extends Error {}
 
 /**
  * Main-thread bridge that runs OpenCode SQLite reads on a persistent worker
  * thread. Dispatches one request at a time (FIFO), times each request out from
  * dispatch, respawns after faults (capped by `MAX_CONSECUTIVE_DEATHS`), tears
- * the worker down after `IDLE_TEARDOWN_MS` of inactivity, and transparently
- * falls back to the in-process readers when no worker can be spawned.
+ * the worker down after `IDLE_TEARDOWN_MS` of inactivity, and fails closed when
+ * no worker can be spawned rather than moving SQLite work onto the main thread.
  */
 export class OpenCodeSqliteWorkerClient {
   private worker: Worker | null = null
@@ -62,7 +59,7 @@ export class OpenCodeSqliteWorkerClient {
   private idleTimer: NodeJS.Timeout | null = null
   private consecutiveDeaths = 0
   private nextId = 1
-  private loggedInlineFallback = false
+  private loggedWorkerUnavailable = false
   private cleanupWorkerListeners: (() => void) | null = null
   private readonly workerFactory: WorkerFactory
   private readonly log: (message: string) => void
@@ -78,7 +75,7 @@ export class OpenCodeSqliteWorkerClient {
    * @param args.limit - Maximum number of sessions to return per database.
    * @param args.issues - Collected scan issues (worker issues are merged in).
    * @returns Synthetic candidates sorted by `time_updated` DESC; empty (with a
-   *   scan issue) when the worker times out or crashes.
+   *   scan issue) when the worker is unavailable, times out, or crashes.
    */
   async list(args: {
     dbPaths: readonly string[]
@@ -97,7 +94,13 @@ export class OpenCodeSqliteWorkerClient {
       return value.candidates
     } catch (err) {
       if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
-        return this.runListInline(args)
+        args.issues.push({
+          agent: 'opencode',
+          path: args.dbPaths[0] ?? 'opencode.db',
+          message:
+            'OpenCode history was skipped because its background scanner could not start; the app remains responsive.'
+        })
+        return []
       }
       // Timeout/crash: this storage dir's SQLite DBs contribute no sessions this
       // scan, surfaced as one scan issue rather than an unbounded stall.
@@ -131,29 +134,11 @@ export class OpenCodeSqliteWorkerClient {
       return value as AiVaultSession | null
     } catch (err) {
       if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
-        return parseOpenCodeSqliteSession(args)
+        throw new Error('OpenCode SQLite background scanner could not start.')
       }
       // Reject only this session; the scanner turns the throw into a scan issue.
       throw err instanceof Error ? err : new Error(String(err))
     }
-  }
-
-  private async runListInline(args: {
-    dbPaths: readonly string[]
-    limit: number
-    issues: AiVaultScanIssue[]
-  }): Promise<SessionFileCandidate[]> {
-    // Why: running the scan inline reintroduces the main-thread hang on very
-    // large DBs, so surface it through the same per-source scan-issue plumbing
-    // (not only a log) — visible in the panel every scan the worker is
-    // unavailable, instead of silently passing as a slow scan.
-    args.issues.push({
-      agent: 'opencode',
-      path: args.dbPaths[0] ?? 'opencode.db',
-      message:
-        'OpenCode history is running in degraded inline mode (background worker unavailable); very large databases may slow scanning.'
-    })
-    return listOpenCodeSqliteSessions(args)
   }
 
   private dispatch(request: OpenCodeSqliteRequestBody, timeoutMs: number): Promise<unknown> {
@@ -219,13 +204,12 @@ export class OpenCodeSqliteWorkerClient {
       this.worker = worker
       return worker
     } catch (err) {
-      // No worker (missing bundle / transient spawn failure): this call falls
-      // back inline via failQueuedAsUnavailable. Never latch — the next call
-      // re-probes, so a transient failure self-heals instead of pinning the app
-      // to the main-thread inline path for the session. Log once to avoid spam.
-      if (!this.loggedInlineFallback) {
-        this.loggedInlineFallback = true
-        this.log(`OpenCode SQLite worker unavailable; scanning inline. ${errorMessage(err)}`)
+      // Why (#8864): never fall back to synchronous SQLite reads here; a missing
+      // bundle or resource-exhausted spawn must omit OpenCode history rather than
+      // reintroduce the main-process hang this worker boundary prevents.
+      if (!this.loggedWorkerUnavailable) {
+        this.loggedWorkerUnavailable = true
+        this.log(`OpenCode SQLite worker unavailable; skipping its history. ${errorMessage(err)}`)
       }
       return null
     }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -74,7 +74,7 @@ export class OpenCodeSqliteWorkerClient {
    * @param args.dbPaths - Absolute paths to opencode.db files to scan.
    * @param args.limit - Maximum number of sessions to return per database.
    * @param args.issues - Collected scan issues (worker issues are merged in).
-   * @returns Synthetic candidates sorted by `time_updated` DESC; empty (with a
+   * @returns Synthetic candidates sorted by effective recency; empty (with a
    *   scan issue) when the worker is unavailable, times out, or crashes.
    */
   async list(args: {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-entry.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-entry.ts
@@ -1,0 +1,58 @@
+import { parentPort } from 'node:worker_threads'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
+import { parseOpenCodeSqliteSession } from './session-scanner-opencode-sqlite'
+import type {
+  OpenCodeSqliteWorkerRequest,
+  OpenCodeSqliteWorkerResponse
+} from './session-scanner-opencode-sqlite-worker-protocol'
+
+// Why (#8864): OpenCode SQLite reads use synchronous node:sqlite. Running them
+// on this worker thread keeps the multi-GB-DB scan off the Electron main-process
+// event loop. The client dispatches one request at a time, so this loop stays
+// serial; imports must remain electron-free (see the worker-protocol note).
+
+if (!parentPort) {
+  throw new Error('OpenCode SQLite worker must run with a parent port.')
+}
+const port = parentPort
+
+async function handleRequest(
+  request: OpenCodeSqliteWorkerRequest
+): Promise<OpenCodeSqliteWorkerResponse> {
+  try {
+    if (request.kind === 'list') {
+      const issues: AiVaultScanIssue[] = []
+      const candidates = await listOpenCodeSqliteSessions({
+        dbPaths: request.dbPaths,
+        limit: request.limit,
+        issues
+      })
+      return { id: request.id, ok: true, value: { candidates, issues } }
+    }
+    const session = await parseOpenCodeSqliteSession({
+      dbPath: request.dbPath,
+      sessionId: request.sessionId,
+      platform: request.platform
+    })
+    return { id: request.id, ok: true, value: session }
+  } catch (err) {
+    return { id: request.id, ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+port.on('message', (request: OpenCodeSqliteWorkerRequest) => {
+  void handleRequest(request).then((response) => {
+    try {
+      port.postMessage(response)
+    } catch {
+      // A non-cloneable result would otherwise post nothing and leave the client
+      // waiting out its timeout; fail that request fast instead.
+      port.postMessage({
+        id: request.id,
+        ok: false,
+        error: 'OpenCode SQLite worker result could not be serialized.'
+      })
+    }
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-protocol.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-protocol.ts
@@ -1,0 +1,37 @@
+import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+// Why: request/response shapes shared by the worker entry and the main-thread
+// client. Kept type-only (and electron-free) so importing it into the worker
+// bundle can never pull the client's Electron dependency across the boundary.
+
+export type OpenCodeSqliteListRequest = {
+  id: number
+  kind: 'list'
+  dbPaths: readonly string[]
+  limit: number
+}
+
+export type OpenCodeSqliteParseRequest = {
+  id: number
+  kind: 'parse'
+  dbPath: string
+  sessionId: string
+  platform: NodeJS.Platform
+}
+
+export type OpenCodeSqliteWorkerRequest = OpenCodeSqliteListRequest | OpenCodeSqliteParseRequest
+
+// The list leg returns candidates plus the issues it accumulated; the worker
+// mutates a local array and hands it back so the caller can merge it into the
+// scan's shared issue list.
+export type OpenCodeSqliteListValue = {
+  candidates: SessionFileCandidate[]
+  issues: AiVaultScanIssue[]
+}
+
+export type OpenCodeSqliteParseValue = AiVaultSession | null
+
+export type OpenCodeSqliteWorkerResponse =
+  | { id: number; ok: true; value: unknown }
+  | { id: number; ok: false; error: string }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
@@ -46,6 +46,13 @@ function getSharedClient(): OpenCodeSqliteWorkerClient {
   return sharedClient
 }
 
+/**
+ * List OpenCode SQLite session candidates through the shared worker client.
+ * @param args.dbPaths - Absolute paths to opencode.db files to scan.
+ * @param args.limit - Maximum number of sessions to return per database.
+ * @param args.issues - Collected scan issues to append errors to.
+ * @returns Synthetic candidates sorted by `time_updated` DESC.
+ */
 export function listOpenCodeSqliteSessionsViaWorker(args: {
   dbPaths: readonly string[]
   limit: number
@@ -54,6 +61,13 @@ export function listOpenCodeSqliteSessionsViaWorker(args: {
   return getSharedClient().list(args)
 }
 
+/**
+ * Parse one OpenCode SQLite session through the shared worker client.
+ * @param args.dbPath - Absolute path to the opencode.db file.
+ * @param args.sessionId - Primary key in the `session` table.
+ * @param args.platform - Platform used for resume-command generation.
+ * @returns The parsed session, or `null` when it does not exist.
+ */
 export function parseOpenCodeSqliteSessionViaWorker(args: {
   dbPath: string
   sessionId: string

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
@@ -1,0 +1,63 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { Worker } from 'node:worker_threads'
+import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
+import type { SessionFileCandidate } from './session-scanner-types'
+import { OpenCodeSqliteWorkerClient } from './session-scanner-opencode-sqlite-worker-client'
+
+// Why: resolve the built worker entry + own the process-wide shared client so
+// the client class stays free of Electron (require'd lazily here) and the
+// scanner call sites depend only on the two routing functions below.
+
+function resolveWorkerEntryPath(): string {
+  let app: { isPackaged: boolean } | null = null
+  try {
+    app = require('electron').app ?? null
+  } catch {
+    app = null
+  }
+  if (app?.isPackaged) {
+    return join(
+      process.resourcesPath,
+      'app.asar',
+      'out',
+      'main',
+      'session-scanner-opencode-sqlite-worker-entry.js'
+    )
+  }
+  return join(__dirname, 'session-scanner-opencode-sqlite-worker-entry.js')
+}
+
+function defaultWorkerFactory(): Worker {
+  const workerPath = resolveWorkerEntryPath()
+  // Why: a missing built entry (vitest, packaged-file regression) must throw
+  // synchronously here so the client falls back to inline before it ever waits
+  // on a worker that can never post a result.
+  if (!existsSync(workerPath)) {
+    throw new Error(`OpenCode SQLite worker entry not found: ${workerPath}`)
+  }
+  return new Worker(workerPath)
+}
+
+let sharedClient: OpenCodeSqliteWorkerClient | null = null
+
+function getSharedClient(): OpenCodeSqliteWorkerClient {
+  sharedClient ??= new OpenCodeSqliteWorkerClient({ workerFactory: defaultWorkerFactory })
+  return sharedClient
+}
+
+export function listOpenCodeSqliteSessionsViaWorker(args: {
+  dbPaths: readonly string[]
+  limit: number
+  issues: AiVaultScanIssue[]
+}): Promise<SessionFileCandidate[]> {
+  return getSharedClient().list(args)
+}
+
+export function parseOpenCodeSqliteSessionViaWorker(args: {
+  dbPath: string
+  sessionId: string
+  platform: NodeJS.Platform
+}): Promise<AiVaultSession | null> {
+  return getSharedClient().parse(args)
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
@@ -30,9 +30,8 @@ function resolveWorkerEntryPath(): string {
 
 function defaultWorkerFactory(): Worker {
   const workerPath = resolveWorkerEntryPath()
-  // Why: a missing built entry (vitest, packaged-file regression) must throw
-  // synchronously here so the client falls back to inline before it ever waits
-  // on a worker that can never post a result.
+  // Why: a missing built entry must throw synchronously so the client can fail
+  // closed before it waits on a worker that can never post a result.
   if (!existsSync(workerPath)) {
     throw new Error(`OpenCode SQLite worker entry not found: ${workerPath}`)
   }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
@@ -50,7 +50,7 @@ function getSharedClient(): OpenCodeSqliteWorkerClient {
  * @param args.dbPaths - Absolute paths to opencode.db files to scan.
  * @param args.limit - Maximum number of sessions to return per database.
  * @param args.issues - Collected scan issues to append errors to.
- * @returns Synthetic candidates sorted by `time_updated` DESC.
+ * @returns Synthetic candidates sorted by effective recency.
  */
 export function listOpenCodeSqliteSessionsViaWorker(args: {
   dbPaths: readonly string[]

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.ts
@@ -16,6 +16,12 @@ import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
 // session-scanner-opencode-sqlite-discovery.ts.
 
 const OPENCODE_SQLITE_PREVIEW_LIMIT = 5
+// Why (#8864): a heavy session can hold ~10K parts (25-150 KB tool-output
+// blobs). Join preview parts against only the newest N messages instead of
+// scanning every part of the session, using the real (session_id, time_created,
+// id) index. Bounds the read to those messages' parts; the 15 s parse timeout
+// caps the residual for a single pathological giant part.
+const OPENCODE_SQLITE_PREVIEW_MESSAGE_WINDOW = 100
 
 type SessionRow = {
   id: string
@@ -164,10 +170,12 @@ function buildPreviewQuery(db: SyncDatabase): string | null {
                  p.time_created,
                  json_extract(m.data, '$.summary.title') AS summary_title,
                  json_extract(m.data, '$.summary.body') AS summary_body
-          FROM message m
+          FROM (SELECT id, data FROM message
+                WHERE session_id = ?
+                ORDER BY time_created DESC, id DESC
+                LIMIT ${OPENCODE_SQLITE_PREVIEW_MESSAGE_WINDOW}) m
           JOIN part p ON p.message_id = m.id
-          WHERE m.session_id = ?
-            AND json_extract(m.data, '$.role') IN ('user','assistant')
+          WHERE json_extract(m.data, '$.role') IN ('user','assistant')
             AND json_extract(p.data, '$.type') = 'text'
           ORDER BY p.time_created DESC
           LIMIT ?`


### PR DESCRIPTION
## Summary

Fixes #8864. Opening or refreshing the **Agent Session History** panel no longer freezes the whole app when OpenCode's SQLite database is huge (the reporter's `opencode.db` was **29 GB** with 20+ live `opencode` processes writing to it; every panel open/refresh wedged the main process for tens of seconds to minutes, repeating on each 15 s/focus refresh — a perceived permanent hang).

Root cause (measured on a 22 GB synthetic DB matching the reporter's shape — 7,500 sessions / 100 K messages / 466 K parts / 1.5 M event rows, real OpenCode 1.17.x schema):

1. All OpenCode SQLite reads ran **synchronously (`node:sqlite`) on the Electron main-process event loop**.
2. The discovery query evaluated a correlated `COUNT(*)`+`json_extract` subquery over `message` for **every** session before `LIMIT` (~2.1 s/scan).
3. The preview query JSON-parsed **every part blob of a session** (0.5–1.1 s per heavy session IO-cold, ~250 MB read, up to 1000 sessions/scan).
4. Live writers bump `session.time_updated` continuously → the mtime parse cache missed every refresh → the freeze repeated forever. Measured: **32.8 s continuous main-process block** per scan (warm cache; the reporter's cold/contended DB multiplies this).

Fix:

- **Worker thread**: OpenCode SQLite discovery + parsing run on a persistent `worker_threads` worker (lazy spawn, `unref`'d, idle teardown, FIFO dispatch, per-call timeouts of 30 s list / 15 s parse, crash-loop cap). Faults become per-source scan issues instead of stalls; other providers' results always arrive.
- **Fail-closed worker boundary**: if the worker bundle is missing or spawn fails, OpenCode history is skipped with a visible scan issue instead of running the pathological synchronous read on the main thread. The next scan retries worker startup, so transient failures self-heal without risking another app freeze.
- **Bounded queries**: discovery reads only session identity + recency (no message scan or discarded metadata); previews come from the newest 100 messages per session via OpenCode's `(session_id, time_created, id)` index (~20× read reduction). On an unindexed 500-session / 50,000-message fixture, listing 250 candidates fell from 785 ms to 0.20 ms.

What does **not** change: panel data (titles, previews, message counts, tokens, models, resume/open-log actions), scan cadence, all other providers, mobile (same main-process scan module — it benefits identically). No UI changes, no new settings.

## Screenshots

Live A/B on the 22 GB rig (1 Hz renderer→main IPC ping instrumentation), screenshots posted in the PR conversation (hosted internally because this repo is public):

| | Before | After |
|---|---|---|
| Max main-process IPC ping RTT during forced scan | **32,784 ms** (33 pings queued >1 s; a Playwright UI click timed out at 30 s) | **1 ms** (0 pings >100 ms) |
| Panel | spinner wedged, app frozen | 368–386 OpenCode sessions with previews + counts, zero scan issues (worker-served) |

### Manual Electron validation

Validated this PR’s Electron build against an isolated, unindexed OpenCode fixture with 400 sessions and 100,000 messages (~22 MB). The panel accepted search input while the real scan was running, then populated all 400 matching sessions with message counts and previews. A forced refresh also completed successfully with zero renderer console errors.

**Search remains responsive while the session scan runs**

![Agent Session History remains responsive during scan](https://github.com/user-attachments/assets/b2c4d9f0-fac5-402c-ab18-21a1d0344a7c)

**Completed scan renders 400 matching sessions**

![Agent Session History populated after scan](https://github.com/user-attachments/assets/5328bef3-2aab-4a68-90c1-361d641c6371)

## Testing

- [x] `pnpm lint` (oxlint clean on all changed files)
- [x] `pnpm typecheck` (all three tsconfig projects)
- [x] `pnpm test` (focused: `src/main/ai-vault/` — 26 files, 151/151 green; existing OpenCode/scanner test files unmodified)
- [x] `pnpm build` (electron-vite dev build emits the new worker entry; dev app exercised live)
- [x] Added high-quality regression tests: 17 new discriminating tests — worker-client request correlation, dispatch-time-only timeout, crash → single rejection + respawn + queue drain, spawn failure → fail closed + later self-heal, clean-exit and idle-teardown respawn, crash-loop cap, message-free LIMIT-first discovery, and a bounded-preview fixture proven by placing text parts beyond the 100-message window (fails if the bound is widened).

## AI Review Report

Three review rounds with two reviewers per round plus a perf lane; final round clean. Main risks checked: worker protocol races and timer/promise leaks, respawn-cap semantics, structured-clone safety across the worker boundary, SQL correctness against OpenCode's real indexes, cache-poisoning paths, and unapproved scope narrowing. Seven fixes landed from the loop — most notably removing the production inline fallback entirely: worker-start failures now fail closed (the exact hang cannot return), while later scans still re-probe and self-heal. This is falsification-proven by tests. A stale-worker-handle-after-clean-exit finding from automated review was fixed post-open (clean exits now drop the cached handle instead of stalling the next request to timeout).

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows: `worker_threads` + `node:sqlite` are platform-independent (existing precedent: warp theme parser worker, STT worker), Windows/WSL database paths are passed to the worker exactly as the main thread previously read them (no path-semantics change, `path.join` throughout), no shortcuts/labels/shell behavior touched, and packaged-build path resolution follows the existing `app.isPackaged` worker pattern, with a missing bundle failing closed and surfacing a scan issue.

## Security Audit

- The worker executes only the two pre-existing read paths; databases are opened read-only with `PRAGMA query_only = ON` (unchanged belt-and-suspenders against mutation).
- No new input surfaces: dbPaths come from the same trusted discovery (XDG data dir / WSL homes / env) as before; sessionIds come from the DB itself. The synthetic `<dbPath>#<sessionId>` routing keeps its existing `opencode*.db` basename validation, so renderer-supplied paths cannot be misrouted into the SQLite parser.
- Worker messages are structured-clone data only (no functions/handles); responses are matched by correlation id against the single active request.
- No command execution, no auth/secrets, no new dependencies; the one IPC surface (`aiVault:listSessions`) is unchanged.
- Follow-up flagged: the OpenCode *usage* scanner still reads the same DBs synchronously on the main thread (separate surface, out of scope here).

## Notes

- **Preview window semantics**: previews now come from a session's newest 100 messages; a session whose newest 100 messages contain no text parts shows fewer/no preview lines (previously older text could be found). Judged acceptable for a history-list preview.
- **Timeouts replace "wait forever"**: a DB pathological enough to exceed 30 s (list) / 15 s (parse) degrades to a visible scan issue for that source — a deliberate behavior change.
- **Cold-scan populate latency**: on a pathological cold DB the panel may take tens of seconds to populate (serialized worker parses) — the app stays fully responsive throughout; not a regression (the pre-fix path was also serial, but blocking).
- `worker.terminate()` cannot preempt an in-flight synchronous SQLite read, so a timed-out call may briefly keep reading off-main before the thread dies (bounded, `unref`'d).
- Not exercised live: Windows/WSL (path semantics unchanged), packaged app packaging, SSH (remote scanning never touches this code). The emitted production worker bundle was built and launched directly in a smoke test; missing bundles fail closed.
- Process note (updated): all dedicated verification passes completed. Completeness verification: COMPLETE-WITH-NOTES, zero blockers (recursively traced the worker entry's 81-file import graph as electron-free; confirmed routing completeness, structured-clone safety, and why existing suites stay green). Perf audit: PASS — no code findings; DB handles/caches are not held between worker calls, all timers/queues settle on every fault path, spawn is lazy, and the 30 s idle teardown already exceeds the 15 s scan TTL so refreshes reuse the warm worker; the idle-teardown→respawn and clean-exit→respawn branches now have deterministic lifecycle tests. Independent merge-confidence pass: LAND — a separate agent re-drove the real Refresh button on the 22 GB rig and measured max 1 ms IPC RTT over a 44.5 s cache-invalidated scan window, zero scan issues (worker-served), all 40 heavy sessions rendering with previews.


