### PR TITLE
fix(runtime): reconcile re-paired host identities

### DIFF
--- a/src/cli/runtime/environments.test.ts
+++ b/src/cli/runtime/environments.test.ts
@@ -11,12 +11,16 @@ import {
   resolveEnvironmentPairingOffer
 } from './environments'
 
-function pairingCode(endpoint = 'ws://127.0.0.1:6768'): string {
+function pairingCode(
+  endpoint = 'ws://127.0.0.1:6768',
+  key = 1,
+  deviceToken = 'device-token'
+): string {
   return encodePairingOffer({
     v: 2,
     endpoint,
-    deviceToken: 'device-token',
-    publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64')
+    deviceToken,
+    publicKeyB64: Buffer.from(new Uint8Array(32).fill(key)).toString('base64')
   })
 }
 
@@ -71,7 +75,7 @@ describe('CLI runtime environments', () => {
     expect(() =>
       addEnvironmentFromPairingCode(userDataPath, {
         name: 'workstation',
-        pairingCode: pairingCode('ws://127.0.0.1:2222'),
+        pairingCode: pairingCode('ws://127.0.0.1:2222', 2),
         now: 200
       })
     ).toThrow('A server named "workstation" already exists.')
@@ -80,5 +84,25 @@ describe('CLI runtime environments', () => {
       'ws://127.0.0.1:1111'
     )
     expect(listEnvironments(userDataPath)[0]?.id).toBe(first.id)
+  })
+
+  it('reuses a saved identity when the pinned key is paired again', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-env-store-'))
+    const first = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'workstation',
+      pairingCode: pairingCode('ws://127.0.0.1:1111', 1, 'old-token'),
+      now: 100
+    })
+    const second = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'renamed workstation',
+      pairingCode: pairingCode('ws://127.0.0.1:2222', 1, 'new-token'),
+      now: 200
+    })
+
+    expect(second).toMatchObject({ id: first.id, name: 'workstation', updatedAt: 200 })
+    expect(resolveEnvironmentPairingOffer(userDataPath, first.id)).toMatchObject({
+      endpoint: 'ws://127.0.0.1:2222',
+      deviceToken: 'new-token'
+    })
   })
 })

--- a/src/main/ipc/runtime-environments.test.ts
+++ b/src/main/ipc/runtime-environments.test.ts
@@ -193,6 +193,31 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     expect(await list(null, undefined)).toEqual([])
   })
 
+  it('returns the canonical redacted environment on same-key desktop re-pair', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+    const first = await add(null, { name: 'desk', pairingCode: pairingCode() })
+    const second = await add(null, {
+      name: 'renamed-desk',
+      pairingCode: pairingCode('ws://127.0.0.1:7777')
+    })
+
+    expect(second.environment).toMatchObject({
+      id: first.environment.id,
+      name: first.environment.name
+    })
+    expect(JSON.stringify(second)).not.toContain('device-token')
+    expect(JSON.stringify(second)).not.toContain('publicKeyB64')
+    const list = handler<undefined, { id: string; name: string }[]>('runtimeEnvironments:list')
+    expect(await list(null, undefined)).toMatchObject([
+      { id: first.environment.id, name: first.environment.name }
+    ])
+  })
+
   it('disconnects a saved runtime without removing it', async () => {
     registerRuntimeEnvironmentHandlers(store as never)
 

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -134,10 +134,7 @@ describe('runtime environment store', () => {
       ],
       preferredEndpointId: 'ws-legacy-id'
     }
-    raw.environments = [
-      { ...oldest, updatedAt: 400, lastUsedAt: 400, runtimeId: 'old-runtime' },
-      newest
-    ]
+    raw.environments = [{ ...oldest, updatedAt: 400, lastUsedAt: 400, runtimeId: null }, newest]
     writeFileSync(getEnvironmentStorePath(userDataPath), JSON.stringify(raw))
 
     const environments = listEnvironments(userDataPath)
@@ -148,7 +145,7 @@ describe('runtime environment store', () => {
       createdAt: 100,
       updatedAt: 400,
       lastUsedAt: 400,
-      runtimeId: 'old-runtime',
+      runtimeId: null,
       endpoints: [
         { endpoint: 'ws://127.0.0.1:7777', deviceToken: 'new-token', id: `ws-${oldest.id}` }
       ]

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -207,6 +207,15 @@ describe('runtime environment store', () => {
     expect(readFileSync(getEnvironmentStorePath(userDataPath), 'utf8')).toBe(invalid)
   })
 
+  it('does not rewrite a schema-invalid environment store during reconciliation', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    const invalid = JSON.stringify({ version: 1, environments: [{}] })
+    writeFileSync(getEnvironmentStorePath(userDataPath), invalid)
+    expect(() => listEnvironments(userDataPath)).toThrow(RuntimeEnvironmentStoreError)
+    expect(readFileSync(getEnvironmentStorePath(userDataPath), 'utf8')).toBe(invalid)
+  })
+
   it('persists immediately when the runtimeId changes within the throttle window', () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
     tempDirs.push(userDataPath)

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -135,7 +135,7 @@ describe('runtime environment store', () => {
       preferredEndpointId: 'ws-legacy-id'
     }
     raw.environments = [
-      { ...oldest, updatedAt: 150, lastUsedAt: 250, runtimeId: 'old-runtime' },
+      { ...oldest, updatedAt: 400, lastUsedAt: 400, runtimeId: 'old-runtime' },
       newest
     ]
     writeFileSync(getEnvironmentStorePath(userDataPath), JSON.stringify(raw))
@@ -146,8 +146,8 @@ describe('runtime environment store', () => {
       id: oldest.id,
       name: oldest.name,
       createdAt: 100,
-      updatedAt: 300,
-      lastUsedAt: 250,
+      updatedAt: 400,
+      lastUsedAt: 400,
       runtimeId: 'old-runtime',
       endpoints: [
         { endpoint: 'ws://127.0.0.1:7777', deviceToken: 'new-token', id: `ws-${oldest.id}` }

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -6,16 +6,21 @@ import { encodePairingOffer } from './pairing'
 import {
   RuntimeEnvironmentStoreError,
   addEnvironmentFromPairingCode,
+  getEnvironmentStorePath,
   listEnvironments,
   markEnvironmentUsed
 } from './runtime-environment-store'
 
-function pairingCode(endpoint = 'ws://127.0.0.1:6768'): string {
+function pairingCode(
+  endpoint = 'ws://127.0.0.1:6768',
+  key = 1,
+  deviceToken = 'device-token'
+): string {
   return encodePairingOffer({
     v: 2,
     endpoint,
-    deviceToken: 'device-token',
-    publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64')
+    deviceToken,
+    publicKeyB64: Buffer.from(new Uint8Array(32).fill(key)).toString('base64')
   })
 }
 
@@ -49,7 +54,7 @@ describe('runtime environment store', () => {
     expect(() =>
       addEnvironmentFromPairingCode(userDataPath, {
         name: 'dev box',
-        pairingCode: pairingCode('ws://192.0.2.10:6768')
+        pairingCode: pairingCode('ws://192.0.2.10:6768', 2)
       })
     ).toThrow(RuntimeEnvironmentStoreError)
     expect(listEnvironments(userDataPath)).toEqual([first])
@@ -77,6 +82,129 @@ describe('runtime environment store', () => {
     // Once the throttle window elapses, it persists again.
     markEnvironmentUsed(userDataPath, env.id, { runtimeId: 'runtime-1', now: 61_000 })
     expect(listEnvironments(userDataPath)[0]!.lastUsedAt).toBe(61_000)
+  })
+
+  it('reuses the pinned host identity on manual re-pair', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    const first = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'original name',
+      pairingCode: pairingCode('ws://127.0.0.1:6768', 1, 'old-token'),
+      now: 100
+    })
+
+    const second = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'new name',
+      pairingCode: pairingCode('ws://127.0.0.1:7777', 1, 'new-token'),
+      now: 200
+    })
+
+    expect(second).toMatchObject({ id: first.id, name: first.name, createdAt: 100, updatedAt: 200 })
+    expect(second.endpoints[0]).toMatchObject({
+      endpoint: 'ws://127.0.0.1:7777',
+      deviceToken: 'new-token'
+    })
+    expect(listEnvironments(userDataPath)).toHaveLength(1)
+  })
+
+  it('collapses legacy manual duplicates before listing', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    const oldest = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'oldest',
+      pairingCode: pairingCode('ws://127.0.0.1:6768', 1, 'old-token'),
+      now: 100
+    })
+    const raw = JSON.parse(readFileSync(getEnvironmentStorePath(userDataPath), 'utf8'))
+    const newest = {
+      ...oldest,
+      id: 'legacy-id',
+      name: 'newest',
+      createdAt: 200,
+      updatedAt: 300,
+      lastUsedAt: 200,
+      runtimeId: 'new-runtime',
+      endpoints: [
+        {
+          ...oldest.endpoints[0],
+          id: 'ws-legacy-id',
+          endpoint: 'ws://127.0.0.1:7777',
+          deviceToken: 'new-token'
+        }
+      ],
+      preferredEndpointId: 'ws-legacy-id'
+    }
+    raw.environments = [
+      { ...oldest, updatedAt: 150, lastUsedAt: 250, runtimeId: 'old-runtime' },
+      newest
+    ]
+    writeFileSync(getEnvironmentStorePath(userDataPath), JSON.stringify(raw))
+
+    const environments = listEnvironments(userDataPath)
+    expect(environments).toHaveLength(1)
+    expect(environments[0]).toMatchObject({
+      id: oldest.id,
+      name: oldest.name,
+      createdAt: 100,
+      updatedAt: 300,
+      lastUsedAt: 250,
+      runtimeId: 'old-runtime',
+      endpoints: [
+        { endpoint: 'ws://127.0.0.1:7777', deviceToken: 'new-token', id: `ws-${oldest.id}` }
+      ]
+    })
+    expect(
+      JSON.parse(readFileSync(getEnvironmentStorePath(userDataPath), 'utf8')).environments
+    ).toHaveLength(1)
+  })
+
+  it('keeps distinct keys separate even when endpoints match', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    addEnvironmentFromPairingCode(userDataPath, {
+      name: 'first',
+      pairingCode: pairingCode(undefined, 1)
+    })
+    addEnvironmentFromPairingCode(userDataPath, {
+      name: 'second',
+      pairingCode: pairingCode(undefined, 2)
+    })
+    expect(listEnvironments(userDataPath)).toHaveLength(2)
+    expect(() =>
+      addEnvironmentFromPairingCode(userDataPath, {
+        name: 'first',
+        pairingCode: pairingCode(undefined, 3)
+      })
+    ).toThrow('A server named "first" already exists.')
+  })
+
+  it('does not reconcile ephemeral VM records into manual hosts', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    const manual = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'manual',
+      pairingCode: pairingCode(undefined, 1)
+    })
+    const ephemeral = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'vm',
+      pairingCode: pairingCode(undefined, 1),
+      source: 'ephemeral-vm'
+    })
+    expect(listEnvironments(userDataPath)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: manual.id }),
+        expect.objectContaining({ id: ephemeral.id, source: 'ephemeral-vm' })
+      ])
+    )
+  })
+
+  it('does not rewrite an invalid environment store during reconciliation', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    const invalid = '{ invalid json'
+    writeFileSync(getEnvironmentStorePath(userDataPath), invalid)
+    expect(() => listEnvironments(userDataPath)).toThrow(RuntimeEnvironmentStoreError)
+    expect(readFileSync(getEnvironmentStorePath(userDataPath), 'utf8')).toBe(invalid)
   })
 
   it('persists immediately when the runtimeId changes within the throttle window', () => {

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -10,7 +10,8 @@ import {
   RuntimeEnvironmentStoreSchema,
   type KnownRuntimeEnvironment,
   type RuntimeEnvironmentSource,
-  type RuntimeEnvironmentStore
+  type RuntimeEnvironmentStore,
+  isUserManagedRuntimeEnvironment
 } from './runtime-environments'
 
 const ENVIRONMENTS_FILE = 'orca-environments.json'
@@ -48,6 +49,39 @@ export function addEnvironmentFromPairingCode(
   }
   const store = readEnvironmentStore(userDataPath)
   const now = args.now ?? Date.now()
+  const source = args.source
+  const incomingKey = offer.publicKeyB64
+  const existingByKey =
+    source === 'ephemeral-vm'
+      ? undefined
+      : store.environments.find(
+          (entry) =>
+            isUserManagedRuntimeEnvironment(entry) &&
+            getPreferredPairingOffer(entry).publicKeyB64 === incomingKey
+        )
+  if (existingByKey) {
+    const environment = createEnvironmentFromPairingOffer({
+      id: existingByKey.id,
+      name: existingByKey.name,
+      now: existingByKey.createdAt,
+      offer,
+      runtimeId: existingByKey.runtimeId,
+      ...(existingByKey.source ? { source: existingByKey.source } : {})
+    })
+    const next = {
+      ...environment,
+      createdAt: existingByKey.createdAt,
+      updatedAt: now,
+      lastUsedAt: existingByKey.lastUsedAt
+    }
+    writeEnvironmentStore(userDataPath, {
+      version: 1,
+      environments: store.environments
+        .map((entry) => (entry.id === existingByKey.id ? next : entry))
+        .sort((a, b) => a.name.localeCompare(b.name))
+    })
+    return next
+  }
   const existing = store.environments.find((entry) => entry.name === args.name)
   if (existing) {
     throw new RuntimeEnvironmentStoreError(
@@ -61,7 +95,7 @@ export function addEnvironmentFromPairingCode(
     now,
     offer,
     runtimeId: null,
-    ...(args.source ? { source: args.source } : {})
+    ...(source ? { source } : {})
   })
   const next = {
     version: 1 as const,
@@ -199,17 +233,80 @@ function readEnvironmentStore(userDataPath: string): RuntimeEnvironmentStore {
   try {
     hardenExistingSecureFile(path)
     const parsed = RuntimeEnvironmentStoreSchema.parse(JSON.parse(readFileSync(path, 'utf8')))
-    return {
+    const store: RuntimeEnvironmentStore = {
       version: 1,
       environments: parsed.environments
         .map((entry) => KnownRuntimeEnvironmentSchema.parse(entry))
         .sort((a, b) => a.name.localeCompare(b.name))
     }
+    const normalized = normalizeManualEnvironments(store)
+    if (normalized !== store) {
+      writeEnvironmentStore(userDataPath, normalized)
+    }
+    return normalized
   } catch {
     throw new RuntimeEnvironmentStoreError(
       'runtime_error',
       `Could not read Orca environments at ${path}; the file is invalid.`
     )
+  }
+}
+
+function normalizeManualEnvironments(store: RuntimeEnvironmentStore): RuntimeEnvironmentStore {
+  const groups = new Map<string, KnownRuntimeEnvironment[]>()
+  for (const environment of store.environments) {
+    if (!isUserManagedRuntimeEnvironment(environment)) {
+      continue
+    }
+    const key = getPreferredPairingOffer(environment).publicKeyB64
+    const group = groups.get(key) ?? []
+    group.push(environment)
+    groups.set(key, group)
+  }
+
+  const duplicates = [...groups.values()].filter((group) => group.length > 1)
+  if (duplicates.length === 0) {
+    return store
+  }
+
+  const removedIds = new Set<string>()
+  const replacements = new Map<string, KnownRuntimeEnvironment>()
+  for (const group of duplicates) {
+    const ordered = [...group].sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+    const canonical = ordered[0]!
+    for (const entry of ordered.slice(1)) {
+      removedIds.add(entry.id)
+    }
+    const freshest = [...group].sort(
+      (a, b) => b.updatedAt - a.updatedAt || b.id.localeCompare(a.id)
+    )[0]!
+    const freshestUse = [...group]
+      .filter((entry) => entry.lastUsedAt != null)
+      .sort((a, b) => b.lastUsedAt! - a.lastUsedAt! || b.id.localeCompare(a.id))[0]
+    const endpoints = freshest.endpoints.map((endpoint, index) => ({
+      ...endpoint,
+      id: index === 0 ? `ws-${canonical.id}` : `ws-${canonical.id}-${index}`
+    }))
+    const preferredIndex = Math.max(
+      0,
+      freshest.endpoints.findIndex((entry) => entry.id === freshest.preferredEndpointId)
+    )
+    replacements.set(canonical.id, {
+      ...canonical,
+      endpoints,
+      preferredEndpointId: endpoints[preferredIndex]!.id,
+      updatedAt: Math.max(...group.map((entry) => entry.updatedAt)),
+      lastUsedAt: freshestUse?.lastUsedAt ?? null,
+      runtimeId: freshestUse?.runtimeId ?? canonical.runtimeId
+    })
+  }
+
+  return {
+    version: 1 as const,
+    environments: store.environments
+      .filter((entry) => !removedIds.has(entry.id))
+      .map((entry) => replacements.get(entry.id) ?? entry)
+      .sort((a, b) => a.name.localeCompare(b.name))
   }
 }
 

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -295,7 +295,7 @@ function normalizeManualEnvironments(store: RuntimeEnvironmentStore): RuntimeEnv
       preferredEndpointId: endpoints[preferredIndex]!.id,
       updatedAt: Math.max(...group.map((entry) => entry.updatedAt)),
       lastUsedAt: freshestUse?.lastUsedAt ?? null,
-      runtimeId: freshestUse?.runtimeId ?? canonical.runtimeId
+      runtimeId: freshestUse ? freshestUse.runtimeId : canonical.runtimeId
     })
   }
 

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -277,19 +277,17 @@ function normalizeManualEnvironments(store: RuntimeEnvironmentStore): RuntimeEnv
     for (const entry of ordered.slice(1)) {
       removedIds.add(entry.id)
     }
-    const freshest = [...group].sort(
-      (a, b) => b.updatedAt - a.updatedAt || b.id.localeCompare(a.id)
-    )[0]!
     const freshestUse = [...group]
       .filter((entry) => entry.lastUsedAt != null)
       .sort((a, b) => b.lastUsedAt! - a.lastUsedAt! || b.id.localeCompare(a.id))[0]
-    const endpoints = freshest.endpoints.map((endpoint, index) => ({
+    const newestPairing = ordered.at(-1)!
+    const endpoints = newestPairing.endpoints.map((endpoint, index) => ({
       ...endpoint,
       id: index === 0 ? `ws-${canonical.id}` : `ws-${canonical.id}-${index}`
     }))
     const preferredIndex = Math.max(
       0,
-      freshest.endpoints.findIndex((entry) => entry.id === freshest.preferredEndpointId)
+      newestPairing.endpoints.findIndex((entry) => entry.id === newestPairing.preferredEndpointId)
     )
     replacements.set(canonical.id, {
       ...canonical,


### PR DESCRIPTION
# fix(runtime): reconcile re-paired host identities

## Summary

Re-pairing a manual runtime host now reuses the canonical environment ID and name for the authenticated pinned public key. Legacy same-key manual duplicates normalize to the oldest identity, select connection credentials from the newest pairing independently of later usage timestamps, and merge freshness fields. Distinct keys, same-name conflicts, and ephemeral VM records retain their existing boundaries.

Desktop IPC and CLI ingress return the canonical redacted identity. Renderer worktree IDs, grouping, and row identity remain unchanged.

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/runtime-environment-store.test.ts src/cli/runtime/environments.test.ts src/main/ipc/runtime-environments.test.ts`
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint src/shared/runtime-environment-store.ts src/shared/runtime-environment-store.test.ts src/cli/runtime/environments.test.ts && pnpm exec oxfmt --check src/shared/runtime-environment-store.ts src/shared/runtime-environment-store.test.ts src/cli/runtime/environments.test.ts`

Focused result: 3 files passed, 43 tests passed, 1 skipped.

## AI Review Report

Same-key reconciliation preserves canonical identity while selecting the newest pairing credentials and independently merging usage metadata, including an explicit null runtime ID. CLI and desktop IPC ingress return the canonical redacted identity. Malformed and schema-invalid stores fail closed without rewriting their bytes. Distinct keys and ephemeral VM records remain separate.

## Security Audit

The pinned public key remains inside the runtime environment reconciliation path and is excluded from renderer state, IPC responses, CLI output, and logs. Existing pairing parsing, schema validation, secure-file hardening, and token redaction remain unchanged. Distinct keys cannot merge through endpoint or name inference.

## Notes

No renderer code changes. The change is limited to persisted environment reconciliation and desktop and CLI ingress.

Closes #8881

## ELI5

Re-pairing the same remote host could create duplicate environment identities. Orca now reuses the canonical ID for that key and merges credentials cleanly.
