### PR TITLE
fix(agents): recognize env-prefixed agent relaunches after runtime restart (#8808)

### DIFF
--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -109,6 +109,12 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(resolveAgentForegroundProcess(100, 'node')).resolves.toBe('codex')
   })
 
+  it('recognizes env-prefixed agent relaunches after restart', async () => {
+    mockPs(['101 100 S+   CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet'].join('\n'))
+
+    await expect(resolveAgentForegroundProcess(100, 'zsh')).resolves.toBe('claude')
+  })
+
   it('treats a fresh POSIX snapshot missing the PTY root as unavailable', async () => {
     mockPs('101 999 S+ node /Users/dev/.nvm/versions/node/bin/codex')
 

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -198,6 +198,32 @@ describe('agent process recognition', () => {
     ).toEqual({ agent: 'gemini', processName: 'gemini' })
   })
 
+  it('recognizes agent CLIs prefixed with POSIX env-variable assignments', () => {
+    expect(
+      recognizeAgentProcessFromCommandLine('CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet')
+    ).toEqual({ agent: 'claude', processName: 'claude' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        'TERM=x CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet'
+      )
+    ).toEqual({ agent: 'claude', processName: 'claude' })
+    expect(recognizeAgentProcessFromCommandLine('PYTHONPATH=/opt/lib python3 -m aider')).toEqual({
+      agent: 'aider',
+      processName: 'aider'
+    })
+    expect(
+      recognizeAgentProcessFromCommandLine('CLAUDE_CONFIG_DIR=~/.claude_sub claude -p summarize')
+    ).toBeNull()
+    expect(recognizeAgentProcessFromCommandLine('NODE_ENV=test npm test')).toBeNull()
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        "PROMPT='claude --model sonnet' printf '%s\\n' \"$PROMPT\""
+      )
+    ).toBeNull()
+    expect(recognizeAgentProcessFromCommandLine('BAD-NAME=value claude --model sonnet')).toBeNull()
+    expect(recognizeAgentProcessFromCommandLine('CLAUDE_CONFIG_DIR=~/.claude_sub')).toBeNull()
+  })
+
   it('recognizes only the agent subcommand of the generic Orca CLI', () => {
     expect(recognizeAgentProcessFromCommandLine('orca claude-teams')).toEqual({
       agent: 'claude-agent-teams',

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -69,9 +69,7 @@ for (const [agent, config] of Object.entries(TUI_AGENT_CONFIG) as [
   ]) {
     const normalized = normalizeProcessName(candidate)
     if (normalized) {
-      // Why: claude-agent-teams is an Orca wrapper whose child process is the
-      // real `claude` binary. Do not let wrapper configs overwrite canonical
-      // CLI ownership for the same foreground process name.
+      // Why: preserve canonical `claude` ownership over the claude-agent-teams wrapper.
       if (!PROCESS_TO_AGENT.has(normalized)) {
         PROCESS_TO_AGENT.set(normalized, agent)
       }
@@ -84,8 +82,7 @@ function agentForNormalizedProcess(normalized: string): TuiAgent | undefined {
   if (exact) {
     return exact
   }
-  // Why: node-pty can report Codex's packaged platform binary
-  // (for example codex-aarch64-ap) instead of the launch command.
+  // Why: node-pty can report Codex's packaged platform binary instead of the launch command.
   if (normalized.startsWith('codex-')) {
     return PROCESS_TO_AGENT.get('codex')
   }
@@ -137,6 +134,7 @@ function tokenizeCommandLine(commandLine: string): string[] {
   return tokens
 }
 
+const POSIX_ASSIGNMENT_WORD_RE = /^[A-Za-z_][A-Za-z0-9_]*=/
 function tokenLooksExecutable(token: string, index: number, firstNormalized: string): boolean {
   if (index === 0) {
     return true
@@ -144,17 +142,12 @@ function tokenLooksExecutable(token: string, index: number, firstNormalized: str
   if (!isInterpreterProcessName(firstNormalized)) {
     return false
   }
-  // Why: only inspect interpreter script paths. Prompt text can mention other
-  // agents ("compare opencode vs orca"), and treating every argv token as an
-  // executable would reintroduce the substring-style false identity class that
-  // foreground-process detection is meant to avoid.
+  // Why: inspect interpreter script paths only, so prompt text can't create false identities.
   return token.includes('/') || token.includes('\\') || PROCESS_EXTENSION_RE.test(token)
 }
-
 function isInterpreterProcessName(normalized: string): boolean {
   return STATIC_INTERPRETER_PROCESS_NAMES.has(normalized) || PYTHON_PROCESS_RE.test(normalized)
 }
-
 const isPythonProcessName = (normalized: string): boolean => PYTHON_PROCESS_RE.test(normalized)
 
 const optionName = (token: string): string => token.split('=', 1)[0] ?? ''
@@ -288,11 +281,10 @@ export function recognizeAgentProcessFromCommandLine(
   // one-shot agent can't answer a prompt either.
   options?: { includeHeadlessOneShot?: boolean }
 ): RecognizedAgentProcess | null {
-  if (!commandLine) {
-    return null
-  }
   const keep = options?.includeHeadlessOneShot === true
-  const tokens = tokenizeCommandLine(commandLine)
+  const tokens = tokenizeCommandLine(commandLine ?? '')
+  const firstExecutableIndex = tokens.findIndex((token) => !POSIX_ASSIGNMENT_WORD_RE.test(token))
+  tokens.splice(0, firstExecutableIndex < 0 ? tokens.length : firstExecutableIndex)
   const firstNormalized = normalizeProcessName(tokens[0])
   let direct = recognizeAgentProcess(tokens[0])
   // Why: the generic Orca CLI is not an agent; only this subcommand launches its TUI mode.


### PR DESCRIPTION
## Summary

- Recognize env-prefixed agent relaunches such as `CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet` so injected dispatch recovers after a runtime restart.
- Keep the fix in the shared command-line recognizer, with provider-level regression coverage on the live foreground-process path.

Closes #8808.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-process-recognition.test.ts src/main/providers/agent-foreground-process.test.ts` - passed; 2 files and 48 tests passed.
- `pnpm run typecheck:node` - passed.
- `pnpm exec oxlint src/shared/agent-process-recognition.ts src/shared/agent-process-recognition.test.ts src/main/providers/agent-foreground-process.test.ts` - passed.
- `pnpm exec oxfmt --check src/shared/agent-process-recognition.ts src/shared/agent-process-recognition.test.ts src/main/providers/agent-foreground-process.test.ts` - passed.

## AI Review Report

The final diff skips only contiguous leading tokens matching `^[A-Za-z_][A-Za-z0-9_]*=`, then reuses the existing direct, interpreter, and headless recognition paths. Shared and provider tests cover direct, interpreter, headless, invalid-assignment, assignment-only, and non-agent cases. No provider-local, Windows, tmux, subprocess, I/O, IPC, or UI code changed.

## Security Audit

The change adds no subprocesses, I/O, IPC, or auth surface. It only changes executable-head selection in a flattened command string. Negative-space tests passed for `NODE_ENV=test npm test`, `PROMPT='claude --model sonnet' printf '%s\n' "$PROMPT"`, `BAD-NAME=value claude --model sonnet`, and assignment-only input.

## Notes

This target is intentionally narrower than #7797. It fixes leading assignment words on the current shared recognizer path, not nested-shell or tmux topology gaps.
</content>
