### PR TITLE
feat(source-control): add in-place markdown preview to diff view (#8708)

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.test.tsx
@@ -216,4 +216,49 @@ describe('EditorContent', () => {
     expect(html).toContain('changed on disk')
     expect(html).toContain('Previewing the modified version of this diff')
   })
+
+  it('renders modified markdown preview in the Changes surface', () => {
+    const activeFile = createOpenFile({
+      id: '/repo/notes.md',
+      filePath: '/repo/notes.md',
+      relativePath: 'notes.md',
+      language: 'markdown',
+      isDirty: true
+    })
+    const html = renderToStaticMarkup(
+      <EditorContent
+        activeFile={activeFile}
+        viewStateScopeId={activeFile.id}
+        fileContents={{ [activeFile.id]: { content: '# modified', isBinary: false } }}
+        diffContents={{
+          [activeFile.id]: {
+            kind: 'text',
+            originalContent: '# original',
+            modifiedContent: '# modified'
+          } as never
+        }}
+        editBuffers={{}}
+        openFiles={[activeFile]}
+        worktreeEntries={[]}
+        resolvedLanguage="markdown"
+        isMarkdown
+        isMermaid={false}
+        isCsv={false}
+        isNotebook={false}
+        mdViewMode="preview"
+        isChangesMode
+        sideBySide={false}
+        pendingEditorReveal={null}
+        handleContentChange={vi.fn()}
+        handleContentChangeForFile={vi.fn()}
+        handleDirtyStateHint={vi.fn()}
+        handleSave={vi.fn()}
+        handleSaveForFile={vi.fn()}
+        reloadContent={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('Previewing the modified version of this diff')
+    expect(html).not.toContain('ChangesModeView')
+  })
 })

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -791,6 +791,40 @@ export function EditorContent({
         />
       ) : null
     if (isChangesMode) {
+      const changesDiff = diffContents[activeFile.id]
+      if (
+        isMarkdown &&
+        mdViewMode === 'preview' &&
+        changesDiff?.kind === 'text' &&
+        changesDiff.largeDiffRenderLimit?.limited !== true
+      ) {
+        return (
+          <div className="flex h-full min-h-0 flex-col">
+            {externalChangeBanner}
+            <div className="border-b border-border/60 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              {translate(
+                'auto.components.editor.EditorContent.9640d1d3db',
+                'Previewing the modified version of this diff. Switch to source mode to inspect changes.'
+              )}
+            </div>
+            <div className="min-h-0 flex-1">
+              <MarkdownPreview
+                key={viewStateScopeId}
+                content={editBuffers[activeFile.id] ?? fc.content}
+                filePath={activeFile.filePath}
+                sourceFileId={activeFile.id}
+                sourceWorktreeId={activeFile.worktreeId}
+                sourceRuntimeEnvironmentId={activeFile.runtimeEnvironmentId}
+                scrollCacheKey={`${diffViewStateKey}:preview`}
+                showTableOfContents={showMarkdownTableOfContents}
+                onCloseTableOfContents={onCloseMarkdownTableOfContents}
+                markdownAnnotationsEnabled={markdownAnnotationsEnabled}
+                {...md.previewProps}
+              />
+            </div>
+          </div>
+        )
+      }
       const changesView = (
         <ChangesModeView
           activeFile={activeFile}

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -803,8 +803,8 @@ export function EditorContent({
             {externalChangeBanner}
             <div className="border-b border-border/60 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
               {translate(
-                'auto.components.editor.EditorContent.9640d1d3db',
-                'Previewing the modified version of this diff. Switch to source mode to inspect changes.'
+                'auto.components.editor.EditorContent.changesPreviewNotice',
+                'Previewing the modified version of this diff. Switch to Changes mode to inspect changes.'
               )}
             </div>
             <div className="min-h-0 flex-1">

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -241,6 +241,7 @@ function EditorPanelInner({
   const model = getEditorPanelRenderModel({
     activeFile,
     fileContents,
+    diffContents,
     editorDrafts,
     gitStatusEntries,
     gitBranchEntries,
@@ -287,6 +288,13 @@ function EditorPanelInner({
     }
     if (next === 'changes') {
       setEditorViewMode(fileId, 'changes')
+      if (model.mdViewMode === 'preview') {
+        setMarkdownViewMode(fileId, 'source')
+      }
+      return
+    }
+    if (next === 'preview' && isChangesMode && model.isMarkdown) {
+      setMarkdownViewMode(fileId, 'preview')
       return
     }
     setEditorViewMode(fileId, 'edit')

--- a/src/renderer/src/components/editor/editor-panel-render-model.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.test.ts
@@ -29,6 +29,7 @@ function textContent(overrides: Partial<FileContent> = {}): FileContent {
 function renderModel(args: {
   activeFile?: OpenFile
   fileContents?: Record<string, FileContent>
+  diffContents?: Record<string, unknown>
   editorDrafts?: Record<string, string>
   markdownViewMode?: Record<string, 'source' | 'rich' | 'preview'>
   isChangesMode?: boolean
@@ -38,6 +39,7 @@ function renderModel(args: {
   return getEditorPanelRenderModel({
     activeFile,
     fileContents: args.fileContents ?? { '/repo/README.md': textContent() },
+    diffContents: args.diffContents as never,
     editorDrafts: args.editorDrafts ?? {},
     gitStatusEntries: args.gitStatusByWorktree?.[activeFile.worktreeId],
     gitBranchEntries: undefined,
@@ -205,5 +207,52 @@ describe('getEditorPanelRenderModel markdown export affordance', () => {
         fileContents: { [preview.id]: textContent({ isBinary: true }) }
       }).canExportMarkdownToPdf
     ).toBe(false)
+  })
+})
+
+describe('getEditorPanelRenderModel markdown diff preview gating', () => {
+  it('keeps preview available for renderable direct markdown diffs', () => {
+    const activeFile = markdownFile({
+      id: 'diff:/repo/README.md',
+      mode: 'diff',
+      diffSource: 'unstaged'
+    } as Partial<OpenFile>)
+    const model = renderModel({
+      activeFile,
+      fileContents: {},
+      diffContents: {
+        [activeFile.id]: {
+          kind: 'text',
+          originalContent: '# before',
+          modifiedContent: '# after',
+          largeDiffRenderLimit: { limited: false }
+        }
+      }
+    })
+
+    expect(model.availableEditorToggleModes).toEqual(['source', 'rich', 'preview'])
+    expect(model.hasViewModeToggle).toBe(true)
+  })
+
+  it('removes preview for render-limited direct markdown diffs', () => {
+    const activeFile = markdownFile({
+      id: 'diff:/repo/README.md',
+      mode: 'diff',
+      diffSource: 'unstaged'
+    } as Partial<OpenFile>)
+    const model = renderModel({
+      activeFile,
+      fileContents: {},
+      diffContents: {
+        [activeFile.id]: {
+          kind: 'text',
+          originalContent: '# before',
+          modifiedContent: '# after',
+          largeDiffRenderLimit: { limited: true }
+        }
+      }
+    })
+
+    expect(model.availableEditorToggleModes).toEqual(['source', 'rich'])
   })
 })

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -64,6 +64,9 @@ export function getEditorPanelRenderModel({
   // to a plain source rendering here.
   const rawReadOnly = activeFile.mode === 'edit' && activeFile.readOnly === true
   const viewerLanguage = rawReadOnly ? 'plaintext' : resolvedLanguage
+  const isMarkdownFile =
+    !rawReadOnly && (viewerLanguage === 'markdown' || /\.markdown$/i.test(activeFile.relativePath))
+  const markdownLanguage = isMarkdownFile ? 'markdown' : viewerLanguage
   const worktreeEntries = gitStatusEntries ?? []
   const branchEntries = gitBranchEntries ?? []
   const matchingWorktreeEntry =
@@ -86,22 +89,24 @@ export function getEditorPanelRenderModel({
     matchingWorktreeEntry,
     matchingBranchEntry
   )
+  const changesDiff = diffContents?.[activeFile.id]
+  const canRenderMarkdownDiffPreview =
+    changesDiff?.kind === 'text' && changesDiff.largeDiffRenderLimit?.limited !== true
   const baseMarkdownViewModes = getMarkdownViewModes({
-    language: viewerLanguage,
+    language: markdownLanguage,
     mode: activeFile.mode,
     diffSource: activeFile.diffSource
   })
-  const changesDiff = diffContents?.[activeFile.id]
   const markdownViewModes =
-    isChangesMode &&
-    viewerLanguage === 'markdown' &&
-    changesDiff?.kind === 'text' &&
-    changesDiff.largeDiffRenderLimit?.limited !== true
+    isChangesMode && isMarkdownFile && canRenderMarkdownDiffPreview
       ? [...baseMarkdownViewModes, ...(['preview'] as const)]
-      : baseMarkdownViewModes
+      : baseMarkdownViewModes.filter(
+          (mode) =>
+            mode !== 'preview' || (activeFile.mode !== 'diff' && canRenderMarkdownDiffPreview)
+        )
   const hasViewModeToggle = markdownViewModes.length > 0
   const defaultMarkdownViewMode = getDefaultMarkdownViewMode({
-    language: viewerLanguage,
+    language: markdownLanguage,
     mode: activeFile.mode,
     diffSource: activeFile.diffSource
   })
@@ -113,7 +118,7 @@ export function getEditorPanelRenderModel({
       ? storedMarkdownViewMode
       : defaultMarkdownViewMode
   const editorToggleModes = getEditorToggleModes({
-    language: viewerLanguage,
+    language: markdownLanguage,
     mode: activeFile.mode,
     diffSource: activeFile.diffSource,
     isChangesMode: markdownViewModes.includes('preview')
@@ -163,7 +168,7 @@ export function getEditorPanelRenderModel({
     worktreeEntries,
     resolvedLanguage,
     openFileState,
-    isMarkdown: viewerLanguage === 'markdown',
+    isMarkdown: isMarkdownFile,
     isMermaid: viewerLanguage === 'mermaid',
     isCsv: viewerLanguage === 'csv' || viewerLanguage === 'tsv',
     isNotebook: viewerLanguage === 'notebook',
@@ -182,10 +187,9 @@ export function getEditorPanelRenderModel({
     shouldShowMarkdownExportAction,
     canExportMarkdownToPdf,
     canShowMarkdownTableOfContents:
-      viewerLanguage === 'markdown' &&
-      (hasViewModeToggle || activeFile.mode === 'markdown-preview'),
+      isMarkdownFile && (hasViewModeToggle || activeFile.mode === 'markdown-preview'),
     canShowMarkdownPreview: canOpenMarkdownPreview({
-      language: viewerLanguage,
+      language: markdownLanguage,
       mode: activeFile.mode,
       diffSource: activeFile.diffSource
     })

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -100,10 +100,7 @@ export function getEditorPanelRenderModel({
   const markdownViewModes =
     isChangesMode && isMarkdownFile && canRenderMarkdownDiffPreview
       ? [...baseMarkdownViewModes, ...(['preview'] as const)]
-      : baseMarkdownViewModes.filter(
-          (mode) =>
-            mode !== 'preview' || (activeFile.mode !== 'diff' && canRenderMarkdownDiffPreview)
-        )
+      : baseMarkdownViewModes.filter((mode) => mode !== 'preview' || canRenderMarkdownDiffPreview)
   const hasViewModeToggle = markdownViewModes.length > 0
   const defaultMarkdownViewMode = getDefaultMarkdownViewMode({
     language: markdownLanguage,
@@ -126,9 +123,11 @@ export function getEditorPanelRenderModel({
   const isBinaryEditSurface =
     activeFile.mode === 'edit' && fileContents[activeFile.id]?.isBinary === true
   const availableEditorToggleModes =
-    isBinaryEditSurface || !canUseChangesModeForFile(activeFile)
-      ? editorToggleModes.filter((mode) => mode !== 'changes')
-      : editorToggleModes
+    activeFile.mode !== 'edit'
+      ? [...markdownViewModes]
+      : isBinaryEditSurface || !canUseChangesModeForFile(activeFile)
+        ? editorToggleModes.filter((mode) => mode !== 'changes')
+        : editorToggleModes
   const effectiveToggleValue: EditorToggleValue =
     isChangesMode && mdViewMode !== 'preview' ? 'changes' : hasViewModeToggle ? mdViewMode : 'edit'
   const inlineMarkdownContent =

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -10,7 +10,7 @@ import {
 } from './markdown-preview-controls'
 import { getEditorHeaderOpenFileState } from './editor-header'
 import type { EditorToggleValue } from './EditorViewToggle'
-import type { FileContent } from './editor-panel-content-types'
+import type { DiffContent, FileContent } from './editor-panel-content-types'
 import { canUseChangesModeForFile } from './editor-panel-file-mode'
 import { getMarkdownRenderMode } from './markdown-render-mode'
 import { getMarkdownRichModeUnsupportedMessage } from './markdown-rich-mode'
@@ -21,6 +21,7 @@ type StoreState = ReturnType<typeof useAppStore.getState>
 type EditorPanelRenderModelParams = {
   activeFile: OpenFile
   fileContents: Record<string, FileContent>
+  diffContents?: Record<string, DiffContent>
   editorDrafts: StoreState['editorDrafts']
   gitStatusEntries: StoreState['gitStatusByWorktree'][string] | undefined
   gitBranchEntries: StoreState['gitBranchChangesByWorktree'][string] | undefined
@@ -31,6 +32,7 @@ type EditorPanelRenderModelParams = {
 export function getEditorPanelRenderModel({
   activeFile,
   fileContents,
+  diffContents,
   editorDrafts,
   gitStatusEntries,
   gitBranchEntries,
@@ -84,11 +86,19 @@ export function getEditorPanelRenderModel({
     matchingWorktreeEntry,
     matchingBranchEntry
   )
-  const markdownViewModes = getMarkdownViewModes({
+  const baseMarkdownViewModes = getMarkdownViewModes({
     language: viewerLanguage,
     mode: activeFile.mode,
     diffSource: activeFile.diffSource
   })
+  const changesDiff = diffContents?.[activeFile.id]
+  const markdownViewModes =
+    isChangesMode &&
+    viewerLanguage === 'markdown' &&
+    changesDiff?.kind === 'text' &&
+    changesDiff.largeDiffRenderLimit?.limited !== true
+      ? [...baseMarkdownViewModes, ...(['preview'] as const)]
+      : baseMarkdownViewModes
   const hasViewModeToggle = markdownViewModes.length > 0
   const defaultMarkdownViewMode = getDefaultMarkdownViewMode({
     language: viewerLanguage,
@@ -105,7 +115,8 @@ export function getEditorPanelRenderModel({
   const editorToggleModes = getEditorToggleModes({
     language: viewerLanguage,
     mode: activeFile.mode,
-    diffSource: activeFile.diffSource
+    diffSource: activeFile.diffSource,
+    isChangesMode: markdownViewModes.includes('preview')
   })
   const isBinaryEditSurface =
     activeFile.mode === 'edit' && fileContents[activeFile.id]?.isBinary === true
@@ -113,11 +124,8 @@ export function getEditorPanelRenderModel({
     isBinaryEditSurface || !canUseChangesModeForFile(activeFile)
       ? editorToggleModes.filter((mode) => mode !== 'changes')
       : editorToggleModes
-  const effectiveToggleValue: EditorToggleValue = isChangesMode
-    ? 'changes'
-    : hasViewModeToggle
-      ? mdViewMode
-      : 'edit'
+  const effectiveToggleValue: EditorToggleValue =
+    isChangesMode && mdViewMode !== 'preview' ? 'changes' : hasViewModeToggle ? mdViewMode : 'edit'
   const inlineMarkdownContent =
     activeFile.mode === 'edit'
       ? (editorDrafts[activeFile.id] ?? fileContents[activeFile.id]?.content ?? null)

--- a/src/renderer/src/components/editor/markdown-preview-controls.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-controls.test.ts
@@ -17,14 +17,31 @@ describe('getMarkdownViewModes', () => {
     ).toEqual(['source', 'rich'])
   })
 
-  it('offers source and rich for single-file markdown diffs', () => {
+  it('offers source, rich, and preview for single-file markdown diffs', () => {
     expect(
       getMarkdownViewModes({
         language: 'markdown',
         mode: 'diff',
         diffSource: 'unstaged'
       })
-    ).toEqual(['source', 'rich'])
+    ).toEqual(['source', 'rich', 'preview'])
+  })
+
+  it('offers preview in markdown Changes mode but not for adjacent source files', () => {
+    expect(
+      getEditorToggleModes({
+        language: 'markdown',
+        mode: 'edit',
+        isChangesMode: true
+      })
+    ).toEqual(['source', 'rich', 'preview', 'changes'])
+    expect(
+      getEditorToggleModes({
+        language: 'typescript',
+        mode: 'edit',
+        isChangesMode: true
+      })
+    ).toEqual(['edit', 'changes'])
   })
 
   it('does not offer preview for mermaid edit tabs', () => {

--- a/src/renderer/src/components/editor/markdown-preview-controls.ts
+++ b/src/renderer/src/components/editor/markdown-preview-controls.ts
@@ -4,10 +4,15 @@ import type { EditorToggleValue } from './EditorViewToggle'
 
 type MarkdownPreviewTarget = Pick<OpenFile, 'mode' | 'diffSource'> & {
   language: string
+  isChangesMode?: boolean
 }
 
 const MARKDOWN_EDIT_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
-const MARKDOWN_DIFF_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
+const MARKDOWN_DIFF_VIEW_MODES = [
+  'source',
+  'rich',
+  'preview'
+] as const satisfies readonly MarkdownViewMode[]
 const MERMAID_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
 const CSV_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
 const NOTEBOOK_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
@@ -32,7 +37,11 @@ export function getEditorToggleModes(target: MarkdownPreviewTarget): readonly Ed
   }
   const languageModes = getMarkdownViewModes(target)
   if (languageModes.length > 0) {
-    return [...languageModes, 'changes']
+    return [
+      ...languageModes,
+      ...(target.isChangesMode && target.language === 'markdown' ? (['preview'] as const) : []),
+      'changes'
+    ]
   }
   return CODE_EDIT_TOGGLE_MODES
 }

--- a/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { joinPath } from '@/lib/path'
 import type {
   GitBranchChangeEntry,
   GitBranchCompareSummary,
@@ -381,6 +382,43 @@ describe('SourceControl preview row opens', () => {
       '/repo/wt',
       expect.objectContaining({ path: 'src/conflict.ts' }),
       'typescript',
+      { targetGroupId: undefined, preview: true }
+    )
+  })
+
+  it('canonicalizes .markdown rows for both unstaged and staged opens', () => {
+    const expectedGuidePath = joinPath(mocks.activeWorktree.path, 'docs/guide.markdown')
+    const expectedStagedPath = joinPath(mocks.activeWorktree.path, 'docs/staged.markdown')
+    resetState({
+      gitStatusByWorktree: {
+        [mocks.activeWorktree.id]: [
+          gitEntry({ path: 'docs/guide.markdown' }),
+          gitEntry({ path: 'docs/staged.markdown', area: 'staged' })
+        ]
+      }
+    })
+    renderSourceControl()
+
+    clickUncommitted('docs/guide.markdown')
+    clickUncommitted('docs/staged.markdown')
+
+    expect(mocks.calls.openFile).toHaveBeenCalledWith(
+      {
+        filePath: expectedGuidePath,
+        relativePath: 'docs/guide.markdown',
+        worktreeId: mocks.activeWorktree.id,
+        language: 'markdown',
+        mode: 'edit'
+      },
+      { targetGroupId: undefined, preview: true }
+    )
+    expect(mocks.state.setEditorViewMode).toHaveBeenCalledWith(expectedGuidePath, 'changes')
+    expect(mocks.calls.openDiff).toHaveBeenCalledWith(
+      mocks.activeWorktree.id,
+      expectedStagedPath,
+      'docs/staged.markdown',
+      'markdown',
+      true,
       { targetGroupId: undefined, preview: true }
     )
   })

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -4449,7 +4449,7 @@ function SourceControlInner(): React.JSX.Element {
         })
         return
       }
-      const language = detectLanguage(entry.path)
+      const language = /\.markdown$/i.test(entry.path) ? 'markdown' : detectLanguage(entry.path)
       const filePath = joinPath(worktreePath, entry.path)
       // Why: unstaged markdown diffs open as a normal edit tab in Changes
       // view mode rather than a dedicated diff tab. This unifies sidebar
@@ -4459,16 +4459,13 @@ function SourceControlInner(): React.JSX.Element {
       // staged content is not what the editor would be editing. Non-markdown
       // files keep the existing diff-tab flow until the diff-tab type is
       // eventually collapsed (see reviews/changes-view-mode-plan.md §"Follow-up").
-      if (
-        (language === 'markdown' || /\.markdown$/i.test(entry.path)) &&
-        entry.area === 'unstaged'
-      ) {
+      if (language === 'markdown' && entry.area === 'unstaged') {
         openFile(
           {
             filePath,
             relativePath: entry.path,
             worktreeId: activeWorktreeId,
-            language: 'markdown',
+            language,
             mode: 'edit'
           },
           { targetGroupId, preview: openAsPreview }

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -4459,13 +4459,16 @@ function SourceControlInner(): React.JSX.Element {
       // staged content is not what the editor would be editing. Non-markdown
       // files keep the existing diff-tab flow until the diff-tab type is
       // eventually collapsed (see reviews/changes-view-mode-plan.md §"Follow-up").
-      if (language === 'markdown' && entry.area === 'unstaged') {
+      if (
+        (language === 'markdown' || /\.markdown$/i.test(entry.path)) &&
+        entry.area === 'unstaged'
+      ) {
         openFile(
           {
             filePath,
             relativePath: entry.path,
             worktreeId: activeWorktreeId,
-            language,
+            language: 'markdown',
             mode: 'edit'
           },
           { targetGroupId, preview: openAsPreview }

--- a/tests/e2e/markdown-diff-preview.spec.ts
+++ b/tests/e2e/markdown-diff-preview.spec.ts
@@ -1,0 +1,49 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+test('renders the modified markdown side from the diff toolbar Preview toggle', async ({
+  orcaPage,
+  testRepoPath
+}) => {
+  await waitForSessionReady(orcaPage)
+  const worktreeId = await waitForActiveWorktree(orcaPage)
+  const relativePath = 'README.md'
+  const filePath = path.join(testRepoPath, relativePath)
+  const originalContent = readFileSync(filePath, 'utf8')
+  const heading = `Markdown diff preview ${Date.now()}`
+
+  try {
+    writeFileSync(filePath, `# ${heading}\n\nRendered from the modified diff side.\n`)
+
+    await orcaPage.evaluate(
+      ({ worktreeId: targetWorktreeId, targetFilePath, targetRelativePath }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('window.__store is not available')
+        }
+        store
+          .getState()
+          .openDiff(targetWorktreeId, targetFilePath, targetRelativePath, 'markdown', false)
+      },
+      { worktreeId, targetFilePath: filePath, targetRelativePath: relativePath }
+    )
+
+    await expect(orcaPage.locator('.editor-header-path')).toContainText(relativePath, {
+      timeout: 20_000
+    })
+    const previewToggle = orcaPage.locator('button[aria-label="Preview"]')
+    await expect(previewToggle).toBeVisible({ timeout: 20_000 })
+    await previewToggle.click()
+
+    await expect(orcaPage.getByRole('heading', { name: heading, level: 1 })).toBeVisible({
+      timeout: 20_000
+    })
+    await expect(
+      orcaPage.getByText('Previewing the modified version of this diff', { exact: false })
+    ).toBeVisible()
+  } finally {
+    writeFileSync(filePath, originalContent)
+  }
+})


### PR DESCRIPTION
## Summary

Markdown files in the editor diff and Changes surfaces now expose an in-place Preview mode when the rendered path is available. Source Control sends a canonical markdown-family language through both unstaged Changes and staged diff entry, including `.markdown` rows. Preview renders the modified markdown content with the existing modified-side notice; selecting Changes returns to raw diff inspection. Non-markdown files, render-limited markdown diffs, and the separate `openMarkdownPreview()` tab flow retain their existing behavior.

## Screenshots

No screenshot. This change adds a Preview mode in the diff view for markdown files.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-preview-controls.test.ts src/renderer/src/components/editor/EditorContent.test.tsx src/renderer/src/components/editor/editor-panel-render-model.test.ts`
- [x] `pnpm run typecheck:web`
- [ ] `pnpm run test:e2e -- tests/e2e/markdown-diff-preview.spec.ts`

## AI Review Report

- macOS, Linux, and Windows behavior: mode selection is renderer-only and uses existing markdown language detection.
- SSH, remote, and local behavior: no path, runtime, or transport code changed.
- Provider neutrality: no provider or model code changed.
- Performance: preview remains gated by the existing large-diff render limit and uses the existing lazy `MarkdownPreview` renderer.
- UI quality: the existing modified-side notice, direct-diff gating, and Changes-surface diff escape remain aligned on the markdown-only preview path.
- Residual risk: headed Electron toolbar and pane behavior is not covered by this PR's local runs and is left to CI.

## Security Audit

No new filesystem, process, IPC, network, or HTML sanitization paths were added. Preview reuses the existing markdown renderer and existing diff content supplied by the editor state.

## Notes

Source Control branch selection remains unchanged while language metadata is normalized before staged and unstaged routing.

Closes #8708.

## ELI5

Markdown files in source-control diffs can switch to an in-place Preview of the modified content. You still get the raw diff when you want it; non-markdown files are unchanged.
