### PR TITLE
feat(sidebar): add manual project-group nesting controls (#8785)

### DIFF
--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -1416,7 +1416,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     return deleted
   })
 
-  ipcMain.handle('projectGroups:create', (_event, rawArgs: unknown): ProjectGroup => {
+  ipcMain.handle('projectGroups:create', (_event, rawArgs: unknown): ProjectGroup | null => {
     const args = parseProjectGroupIpcArgs(
       ProjectGroupCreateArgs,
       rawArgs,
@@ -1429,7 +1429,9 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
       parentGroupId: args.parentGroupId ?? null,
       createdFrom: args.createdFrom ?? 'manual'
     })
-    notifyReposChanged(mainWindow)
+    if (group) {
+      notifyReposChanged(mainWindow)
+    }
     return group
   })
 
@@ -1522,7 +1524,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         mode: args.mode,
         connectionId: args.connectionId ?? null,
         repoPaths: selection.selectedPaths,
-        createGroup: (input) => store.createProjectGroup(input)
+        createGroup: (input) => {
+          const group = store.createProjectGroup(input)
+          if (!group) {
+            throw new Error('Failed to create nested project group')
+          }
+          return group
+        }
       })
       const results: ProjectGroupImportResult['projects'] = selection.rejectedPaths.map(
         (repoPath) => ({

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -684,7 +684,8 @@ const ProjectGroupUpdateArgs = z.object({
     name: z.string().optional(),
     isCollapsed: z.boolean().optional(),
     tabOrder: z.number().finite().optional(),
-    color: z.string().nullable().optional()
+    color: z.string().nullable().optional(),
+    parentGroupId: z.string().nullable().optional()
   })
 })
 

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -3113,6 +3113,26 @@ describe('Store', () => {
     expect(store.getRepo('sibling')?.projectGroupId).toBe(sibling.id)
   })
 
+  it('rejects invalid project group parents without mutating the group', async () => {
+    const store = await createStore()
+    const root = store.createProjectGroup({ name: 'Root', createdFrom: 'manual' })
+    const child = store.createProjectGroup({
+      name: 'Child',
+      parentGroupId: root.id,
+      createdFrom: 'manual'
+    })
+    const sibling = store.createProjectGroup({ name: 'Sibling', createdFrom: 'manual' })
+
+    expect(store.updateProjectGroup(root.id, { parentGroupId: child.id })).toBeNull()
+    expect(store.updateProjectGroup(root.id, { parentGroupId: root.id })).toBeNull()
+    expect(store.updateProjectGroup(child.id, { parentGroupId: 'missing' })).toBeNull()
+    expect(store.getProjectGroups().find((group) => group.id === root.id)?.parentGroupId).toBeNull()
+    expect(store.updateProjectGroup(child.id, { parentGroupId: sibling.id })?.parentGroupId).toBe(
+      sibling.id
+    )
+    expect(store.updateProjectGroup(child.id, { parentGroupId: null })?.parentGroupId).toBeNull()
+  })
+
   it('adapts flat folder-scan groups into sparse nested folder scopes on load', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -3094,13 +3094,13 @@ describe('Store', () => {
 
   it('deleteProjectGroup ungroups repos from the deleted group subtree', async () => {
     const store = await createStore()
-    const root = store.createProjectGroup({ name: 'Platform', createdFrom: 'folder-scan' })
+    const root = store.createProjectGroup({ name: 'Platform', createdFrom: 'folder-scan' })!
     const child = store.createProjectGroup({
       name: 'Services',
       parentGroupId: root.id,
       createdFrom: 'folder-scan'
-    })
-    const sibling = store.createProjectGroup({ name: 'Tools', createdFrom: 'manual' })
+    })!
+    const sibling = store.createProjectGroup({ name: 'Tools', createdFrom: 'manual' })!
     store.addRepo(makeRepo({ id: 'direct', path: '/direct', projectGroupId: root.id }))
     store.addRepo(makeRepo({ id: 'nested', path: '/nested', projectGroupId: child.id }))
     store.addRepo(makeRepo({ id: 'sibling', path: '/sibling', projectGroupId: sibling.id }))
@@ -3115,13 +3115,13 @@ describe('Store', () => {
 
   it('rejects invalid project group parents without mutating the group', async () => {
     const store = await createStore()
-    const root = store.createProjectGroup({ name: 'Root', createdFrom: 'manual' })
+    const root = store.createProjectGroup({ name: 'Root', createdFrom: 'manual' })!
     const child = store.createProjectGroup({
       name: 'Child',
       parentGroupId: root.id,
       createdFrom: 'manual'
-    })
-    const sibling = store.createProjectGroup({ name: 'Sibling', createdFrom: 'manual' })
+    })!
+    const sibling = store.createProjectGroup({ name: 'Sibling', createdFrom: 'manual' })!
 
     expect(store.updateProjectGroup(root.id, { parentGroupId: child.id })).toBeNull()
     expect(store.updateProjectGroup(root.id, { parentGroupId: root.id })).toBeNull()
@@ -3131,6 +3131,26 @@ describe('Store', () => {
       sibling.id
     )
     expect(store.updateProjectGroup(child.id, { parentGroupId: null })?.parentGroupId).toBeNull()
+  })
+
+  it('rejects project-group creation under a missing parent', async () => {
+    const store = await createStore()
+
+    expect(
+      store.createProjectGroup({
+        name: 'Orphan',
+        parentGroupId: '',
+        createdFrom: 'manual'
+      })
+    ).toBeNull()
+    expect(
+      store.createProjectGroup({
+        name: 'Missing parent',
+        parentGroupId: 'missing',
+        createdFrom: 'manual'
+      })
+    ).toBeNull()
+    expect(store.getProjectGroups()).toEqual([])
   })
 
   it('adapts flat folder-scan groups into sparse nested folder scopes on load', async () => {
@@ -3208,14 +3228,14 @@ describe('Store', () => {
     })
     const store = await createStore()
 
-    const group = store.createProjectGroup({ name: 'New group', createdFrom: 'manual' })
+    const group = store.createProjectGroup({ name: 'New group', createdFrom: 'manual' })!
 
     expect(group.tabOrder).toBe(projectGroups.length)
   })
 
   it('sanitizes invalid project group updates before persisting a repo', async () => {
     const store = await createStore()
-    const group = store.createProjectGroup({ name: 'Platform', createdFrom: 'manual' })
+    const group = store.createProjectGroup({ name: 'Platform', createdFrom: 'manual' })!
     store.addRepo(makeRepo({ id: 'r1', projectGroupId: group.id, projectGroupOrder: 1 }))
 
     const updated = store.updateRepo('r1', {
@@ -4221,7 +4241,7 @@ describe('Store', () => {
       name: 'Platform',
       parentPath: '/workspace/platform',
       createdFrom: 'folder-scan'
-    })
+    })!
     const linkedTask = {
       provider: 'linear' as const,
       type: 'issue' as const,
@@ -4258,7 +4278,7 @@ describe('Store', () => {
 
   it('rejects folder workspace creation for non-folder-backed project groups', async () => {
     const store = await createStore()
-    const group = store.createProjectGroup({ name: 'Manual', createdFrom: 'manual' })
+    const group = store.createProjectGroup({ name: 'Manual', createdFrom: 'manual' })!
 
     expect(() => store.createFolderWorkspace({ projectGroupId: group.id })).toThrow(
       'Folder-backed project group not found.'
@@ -4458,7 +4478,7 @@ describe('Store', () => {
       name: 'Platform',
       parentPath: '/workspace/platform',
       createdFrom: 'folder-scan'
-    })
+    })!
     store.addRepo(
       makeRepo({ id: 'api', path: '/workspace/platform/api', projectGroupId: group.id })
     )
@@ -9200,7 +9220,7 @@ describe('Store', () => {
       name: 'Platform',
       parentPath: '/workspace/platform',
       createdFrom: 'folder-scan'
-    })
+    })!
     const workspace = store.createFolderWorkspace({
       projectGroupId: group.id,
       name: 'Folder parent'

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4009,11 +4009,24 @@ export class Store {
 
   updateProjectGroup(
     groupId: string,
-    updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>
+    updates: Partial<
+      Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color' | 'parentGroupId'>
+    >
   ): ProjectGroup | null {
     const group = (this.state.projectGroups ?? []).find((entry) => entry.id === groupId)
     if (!group) {
       return null
+    }
+    if (updates.parentGroupId !== undefined) {
+      const subtreeIds = getProjectGroupSubtreeIds(this.state.projectGroups ?? [], groupId)
+      if (
+        (updates.parentGroupId !== null &&
+          !this.state.projectGroups?.some((entry) => entry.id === updates.parentGroupId)) ||
+        subtreeIds.has(updates.parentGroupId ?? '')
+      ) {
+        return null
+      }
+      group.parentGroupId = updates.parentGroupId
     }
     if (updates.name !== undefined) {
       group.name = normalizeProjectGroupName(updates.name, group.name)

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3992,11 +3992,18 @@ export class Store {
     connectionId?: string | null
     parentGroupId?: string | null
     createdFrom: ProjectGroup['createdFrom']
-  }): ProjectGroup {
+  }): ProjectGroup | null {
     let maxOrder = -1
     // Why: persisted group lists can be large enough to exceed spread limits.
     for (const existingGroup of this.state.projectGroups ?? []) {
       maxOrder = Math.max(maxOrder, existingGroup.tabOrder)
+    }
+    if (
+      input.parentGroupId !== undefined &&
+      input.parentGroupId !== null &&
+      !(this.state.projectGroups ?? []).some((group) => group.id === input.parentGroupId)
+    ) {
+      return null
     }
     const group = createProjectGroup({
       ...input,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12158,7 +12158,9 @@ export class OrcaRuntimeService {
 
   async updateProjectGroup(
     groupId: string,
-    updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>
+    updates: Partial<
+      Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color' | 'parentGroupId'>
+    >
   ): Promise<ProjectGroup | null> {
     if (!this.store?.updateProjectGroup) {
       throw new Error('runtime_unavailable')
@@ -19311,13 +19313,10 @@ export class OrcaRuntimeService {
     timeoutMs?: number,
     signal?: AbortSignal
   ): Promise<boolean> {
-    return this.ptyController?.waitForRendererSerializer?.(
-      ptyId,
-      afterGeneration,
-      timeoutMs,
-      signal
-    ) ??
+    return (
+      this.ptyController?.waitForRendererSerializer?.(ptyId, afterGeneration, timeoutMs, signal) ??
       Promise.resolve(false)
+    )
   }
 
   // Why: a leaf appears in the graph before its PTY spawns. If we issue a

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12141,7 +12141,7 @@ export class OrcaRuntimeService {
     connectionId?: string | null
     parentGroupId?: string | null
     createdFrom?: ProjectGroup['createdFrom']
-  }): Promise<ProjectGroup> {
+  }): Promise<ProjectGroup | null> {
     if (!this.store?.createProjectGroup) {
       throw new Error('runtime_unavailable')
     }
@@ -12152,7 +12152,9 @@ export class OrcaRuntimeService {
       parentGroupId: input.parentGroupId ?? null,
       createdFrom: input.createdFrom ?? 'manual'
     })
-    this.notifyReposChanged()
+    if (group) {
+      this.notifyReposChanged()
+    }
     return group
   }
 
@@ -12371,7 +12373,13 @@ export class OrcaRuntimeService {
       mode: args.mode,
       connectionId: null,
       repoPaths: selection.selectedPaths,
-      createGroup: (input) => this.store!.createProjectGroup!(input)
+      createGroup: (input) => {
+        const group = this.store!.createProjectGroup!(input)
+        if (!group) {
+          throw new Error('Failed to create nested project group')
+        }
+        return group
+      }
     })
     const results: ProjectGroupImportResult['projects'] = selection.rejectedPaths.map(
       (repoPath) => ({

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -379,13 +379,14 @@ describe('repo RPC methods', () => {
       makeRequest('projectGroup.create', {
         name: 'Platform',
         parentPath: '/srv/platform',
+        parentGroupId: 'parent-group',
         createdFrom: 'folder-scan'
       })
     )
     await dispatcher.dispatch(
       makeRequest('projectGroup.update', {
         groupId: group.id,
-        updates: { name: 'Core', isCollapsed: true }
+        updates: { name: 'Core', isCollapsed: true, parentGroupId: null }
       })
     )
     await dispatcher.dispatch(makeRequest('projectGroup.delete', { groupId: group.id }))
@@ -429,11 +430,13 @@ describe('repo RPC methods', () => {
     expect(runtime.createProjectGroup).toHaveBeenCalledWith({
       name: 'Platform',
       parentPath: '/srv/platform',
+      parentGroupId: 'parent-group',
       createdFrom: 'folder-scan'
     })
     expect(runtime.updateProjectGroup).toHaveBeenCalledWith(group.id, {
       name: 'Core',
-      isCollapsed: true
+      isCollapsed: true,
+      parentGroupId: null
     })
     expect(runtime.deleteProjectGroup).toHaveBeenCalledWith(group.id)
     expect(runtime.moveProjectToGroup).toHaveBeenCalledWith('repo-1', group.id, 2)

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -389,6 +389,12 @@ describe('repo RPC methods', () => {
         updates: { name: 'Core', isCollapsed: true, parentGroupId: null }
       })
     )
+    await dispatcher.dispatch(
+      makeRequest('projectGroup.update', {
+        groupId: group.id,
+        updates: { parentGroupId: '' }
+      })
+    )
     await dispatcher.dispatch(makeRequest('projectGroup.delete', { groupId: group.id }))
     const moveResponse = await dispatcher.dispatch(
       makeRequest('projectGroup.moveProject', {
@@ -438,6 +444,7 @@ describe('repo RPC methods', () => {
       isCollapsed: true,
       parentGroupId: null
     })
+    expect(runtime.updateProjectGroup).toHaveBeenCalledWith(group.id, { parentGroupId: '' })
     expect(runtime.deleteProjectGroup).toHaveBeenCalledWith(group.id)
     expect(runtime.moveProjectToGroup).toHaveBeenCalledWith('repo-1', group.id, 2)
     expect(runtime.listFolderWorkspaces).toHaveBeenCalled()

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -384,6 +384,13 @@ describe('repo RPC methods', () => {
       })
     )
     await dispatcher.dispatch(
+      makeRequest('projectGroup.create', {
+        name: 'Invalid child',
+        parentGroupId: '',
+        createdFrom: 'manual'
+      })
+    )
+    await dispatcher.dispatch(
       makeRequest('projectGroup.update', {
         groupId: group.id,
         updates: { name: 'Core', isCollapsed: true, parentGroupId: null }
@@ -438,6 +445,11 @@ describe('repo RPC methods', () => {
       parentPath: '/srv/platform',
       parentGroupId: 'parent-group',
       createdFrom: 'folder-scan'
+    })
+    expect(runtime.createProjectGroup).toHaveBeenCalledWith({
+      name: 'Invalid child',
+      parentGroupId: '',
+      createdFrom: 'manual'
     })
     expect(runtime.updateProjectGroup).toHaveBeenCalledWith(group.id, {
       name: 'Core',

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -60,7 +60,7 @@ const ProjectGroupUpdate = z.object({
     isCollapsed: z.boolean().optional(),
     tabOrder: OptionalFiniteNumber,
     color: OptionalString.nullable().optional(),
-    parentGroupId: OptionalString.nullable().optional()
+    parentGroupId: z.string().nullable().optional()
   })
 })
 

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -49,7 +49,7 @@ const ProjectGroupCreate = z.object({
   name: requiredString('Missing group name'),
   parentPath: OptionalString,
   connectionId: OptionalString.nullable().optional(),
-  parentGroupId: OptionalString.nullable().optional(),
+  parentGroupId: z.string().nullable().optional(),
   createdFrom: z.enum(['manual', 'folder-scan', 'migration']).optional()
 })
 

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -59,7 +59,8 @@ const ProjectGroupUpdate = z.object({
     name: OptionalString,
     isCollapsed: z.boolean().optional(),
     tabOrder: OptionalFiniteNumber,
-    color: OptionalString.nullable().optional()
+    color: OptionalString.nullable().optional(),
+    parentGroupId: OptionalString.nullable().optional()
   })
 })
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1064,7 +1064,9 @@ export type PreloadApi = {
     }) => Promise<ProjectGroup>
     update: (args: {
       groupId: string
-      updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>
+      updates: Partial<
+        Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color' | 'parentGroupId'>
+      >
     }) => Promise<ProjectGroup | null>
     delete: (args: { groupId: string }) => Promise<boolean>
     moveProject: (args: {
@@ -1411,7 +1413,13 @@ export type PreloadApi = {
     onClearBufferRequest: (callback: (data: { ptyId: string }) => void) => () => void
     sendSerializedBuffer: (
       requestId: string,
-      snapshot: { data: string; cols: number; rows: number; seq?: number; lastTitle?: string } | null
+      snapshot: {
+        data: string
+        cols: number
+        rows: number
+        seq?: number
+        lastTitle?: string
+      } | null
     ) => void
     declarePendingPaneSerializer: (paneKey: string) => Promise<number>
     settlePaneSerializer: (paneKey: string, gen: number) => Promise<void>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1061,7 +1061,7 @@ export type PreloadApi = {
       connectionId?: string | null
       parentGroupId?: string | null
       createdFrom?: ProjectGroup['createdFrom']
-    }) => Promise<ProjectGroup>
+    }) => Promise<ProjectGroup | null>
     update: (args: {
       groupId: string
       updates: Partial<

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -40,6 +40,7 @@ import {
   getRepoHeaderSectionEndByRepoId
 } from './worktree-header-section-boundaries'
 import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { PendingWorktreeRow } from './PendingWorktreeRow'
 import { SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT } from './WorktreeCardAgents'
 import { Button } from '@/components/ui/button'
@@ -294,6 +295,7 @@ export {
 
 type ProjectGroupNameDialogState =
   | { type: 'create-from-repo'; repo: Repo }
+  | { type: 'create-subgroup'; parentGroupId: string; parentName: string }
   | { type: 'rename'; groupId: string; currentName: string }
 
 type ProjectGroupDeleteDialogState = {
@@ -630,6 +632,8 @@ type VirtualizedWorktreeViewportProps = {
   handleCreateGroupFromRepo: (repo: Repo) => void
   handleMoveProjectToGroup: (repo: Repo, groupId: string) => void
   handleRemoveProjectFromGroup: (repo: Repo) => void
+  handleCreateProjectGroup: (parentGroupId: string) => void
+  handleMoveProjectGroup: (groupId: string, parentGroupId: string | null) => void
   handleRenameProjectGroup: (groupId: string, currentName: string) => void
   handleDeleteProjectGroup: (groupId: string, groupName: string) => void
   handleCreateFolderWorkspace: (projectGroup: ProjectGroup) => void
@@ -1269,6 +1273,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   handleCreateGroupFromRepo,
   handleMoveProjectToGroup,
   handleRemoveProjectFromGroup,
+  handleCreateProjectGroup,
+  handleMoveProjectGroup,
   handleRenameProjectGroup,
   handleDeleteProjectGroup,
   handleCreateFolderWorkspace,
@@ -4370,6 +4376,63 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                             <DropdownMenuItem
                               onSelect={() => {
                                 if (row.projectGroup?.id) {
+                                  handleCreateProjectGroup(row.projectGroup.id)
+                                }
+                              }}
+                            >
+                              <FolderPlus className="size-3.5" />
+                              {translate(
+                                'auto.components.sidebar.WorktreeList.a7f5c2d901',
+                                'New subgroup'
+                              )}
+                            </DropdownMenuItem>
+                            <DropdownMenuSub>
+                              <DropdownMenuSubTrigger>
+                                <FolderInput className="size-3.5" />
+                                {translate(
+                                  'auto.components.sidebar.WorktreeList.4a08fb55f2',
+                                  'Move to group'
+                                )}
+                              </DropdownMenuSubTrigger>
+                              <DropdownMenuSubContent>
+                                {projectGroups
+                                  .filter(
+                                    (group) =>
+                                      !getProjectGroupSubtreeIds(
+                                        projectGroups,
+                                        row.projectGroup!.id as string
+                                      ).has(group.id)
+                                  )
+                                  .map((group) => (
+                                    <DropdownMenuItem
+                                      key={group.id}
+                                      onSelect={() =>
+                                        handleMoveProjectGroup(
+                                          row.projectGroup!.id as string,
+                                          group.id
+                                        )
+                                      }
+                                    >
+                                      <span className="max-w-48 truncate">{group.name}</span>
+                                    </DropdownMenuItem>
+                                  ))}
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+                            <DropdownMenuItem
+                              disabled={!row.projectGroup.parentGroupId}
+                              onSelect={() =>
+                                handleMoveProjectGroup(row.projectGroup!.id as string, null)
+                              }
+                            >
+                              {translate(
+                                'auto.components.sidebar.WorktreeList.b8e6d3f012',
+                                'Move to root'
+                              )}
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onSelect={() => {
+                                if (row.projectGroup?.id) {
                                   handleRenameProjectGroup(row.projectGroup.id, row.label)
                                 }
                               }}
@@ -6228,6 +6291,27 @@ const WorktreeList = React.memo(function WorktreeList({
     setProjectGroupNameDialog({ type: 'create-from-repo', repo })
   }, [])
 
+  const handleCreateProjectGroup = useCallback(
+    (parentGroupId: string) => {
+      const parent = projectGroups.find((group) => group.id === parentGroupId)
+      if (parent) {
+        setProjectGroupNameDialog({
+          type: 'create-subgroup',
+          parentGroupId,
+          parentName: parent.name
+        })
+      }
+    },
+    [projectGroups]
+  )
+
+  const handleMoveProjectGroup = useCallback(
+    (groupId: string, parentGroupId: string | null) => {
+      void updateProjectGroup(groupId, { parentGroupId })
+    },
+    [updateProjectGroup]
+  )
+
   const handleMoveProjectToGroup = useCallback(
     (repo: Repo, groupId: string) => {
       if (repo.projectGroupId === groupId) {
@@ -6259,6 +6343,10 @@ const WorktreeList = React.memo(function WorktreeList({
         if (group) {
           await moveProjectToGroup(projectGroupNameDialog.repo.id, group.id)
         }
+        return
+      }
+      if (projectGroupNameDialog.type === 'create-subgroup') {
+        await createProjectGroup(name, projectGroupNameDialog.parentGroupId)
         return
       }
       await updateProjectGroup(projectGroupNameDialog.groupId, { name })
@@ -6723,7 +6811,9 @@ const WorktreeList = React.memo(function WorktreeList({
         title={
           projectGroupNameDialog?.type === 'rename'
             ? translate('auto.components.sidebar.WorktreeList.f9dc6cc5d3', 'Rename Project Group')
-            : translate('auto.components.sidebar.WorktreeList.13757c053c', 'New Project Group')
+            : projectGroupNameDialog?.type === 'create-subgroup'
+              ? translate('auto.components.sidebar.WorktreeList.c4d8e6f201', 'New Subgroup')
+              : translate('auto.components.sidebar.WorktreeList.13757c053c', 'New Project Group')
         }
         description={
           projectGroupNameDialog?.type === 'rename'
@@ -6731,19 +6821,31 @@ const WorktreeList = React.memo(function WorktreeList({
                 'auto.components.sidebar.WorktreeList.bc1460beb3',
                 'Update the group name shown in the sidebar.'
               )
-            : translate(
-                'auto.components.sidebar.WorktreeList.d880ea0744',
-                'Create a group and move this project into it.'
-              )
+            : projectGroupNameDialog?.type === 'create-subgroup'
+              ? translate(
+                  'auto.components.sidebar.WorktreeList.d5e9f7a302',
+                  'Create a subgroup under {{value0}}.',
+                  { value0: projectGroupNameDialog.parentName }
+                )
+              : translate(
+                  'auto.components.sidebar.WorktreeList.d880ea0744',
+                  'Create a group and move this project into it.'
+                )
         }
         initialName={
           projectGroupNameDialog?.type === 'rename'
             ? projectGroupNameDialog.currentName
-            : projectGroupNameDialog
-              ? `${projectGroupNameDialog.repo.displayName} group`
-              : ''
+            : projectGroupNameDialog?.type === 'create-subgroup'
+              ? `${projectGroupNameDialog.parentName} subgroup`
+              : projectGroupNameDialog
+                ? `${projectGroupNameDialog.repo.displayName} group`
+                : ''
         }
-        confirmLabel={projectGroupNameDialog?.type === 'rename' ? 'Rename' : 'Create'}
+        confirmLabel={
+          projectGroupNameDialog?.type === 'rename'
+            ? 'Rename'
+            : translate('auto.components.sidebar.WorktreeList.e6f8a4c302', 'Create')
+        }
         onOpenChange={(open) => {
           if (!open) {
             setProjectGroupNameDialog(null)
@@ -6824,6 +6926,8 @@ const WorktreeList = React.memo(function WorktreeList({
         handleCreateGroupFromRepo={handleCreateGroupFromRepo}
         handleMoveProjectToGroup={handleMoveProjectToGroup}
         handleRemoveProjectFromGroup={handleRemoveProjectFromGroup}
+        handleCreateProjectGroup={handleCreateProjectGroup}
+        handleMoveProjectGroup={handleMoveProjectGroup}
         handleRenameProjectGroup={handleRenameProjectGroup}
         handleDeleteProjectGroup={handleDeleteProjectGroup}
         handleCreateFolderWorkspace={handleCreateFolderWorkspace}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -6836,7 +6836,10 @@ const WorktreeList = React.memo(function WorktreeList({
           projectGroupNameDialog?.type === 'rename'
             ? projectGroupNameDialog.currentName
             : projectGroupNameDialog?.type === 'create-subgroup'
-              ? `${projectGroupNameDialog.parentName} subgroup`
+              ? `${projectGroupNameDialog.parentName} ${translate(
+                  'auto.components.sidebar.WorktreeList.c6d4e8a102',
+                  'subgroup'
+                )}`
               : projectGroupNameDialog
                 ? `${projectGroupNameDialog.repo.displayName} group`
                 : ''

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4282,7 +4282,8 @@
           "b8e6d3f012": "Move to root",
           "c4d8e6f201": "New Subgroup",
           "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create"
+          "e6f8a4c302": "Create",
+          "c6d4e8a102": "subgroup"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancel",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4277,7 +4277,12 @@
           "groupDeleteFailedDesc": "Something went wrong while deleting the group. No projects were removed.",
           "failedNestWorkspace": "Failed to nest workspace",
           "sidebarRowMissing": "Target no longer exists",
-          "failedUnnestWorkspace": "Failed to unnest workspace"
+          "failedUnnestWorkspace": "Failed to unnest workspace",
+          "a7f5c2d901": "New subgroup",
+          "b8e6d3f012": "Move to root",
+          "c4d8e6f201": "New Subgroup",
+          "d5e9f7a302": "Create a subgroup under {{value0}}.",
+          "e6f8a4c302": "Create"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancel",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4259,7 +4259,8 @@
           "b8e6d3f012": "Move to root",
           "c4d8e6f201": "New Subgroup",
           "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create"
+          "e6f8a4c302": "Create",
+          "c6d4e8a102": "subgroup"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4255,12 +4255,12 @@
           "failedNestWorkspace": "No se pudo anidar el espacio de trabajo",
           "sidebarRowMissing": "El destino ya no existe",
           "failedUnnestWorkspace": "Error al expandir el espacio de trabajo",
-          "a7f5c2d901": "New subgroup",
-          "b8e6d3f012": "Move to root",
-          "c4d8e6f201": "New Subgroup",
-          "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create",
-          "c6d4e8a102": "subgroup"
+          "a7f5c2d901": "Nuevo subgrupo",
+          "b8e6d3f012": "Mover a la raíz",
+          "c4d8e6f201": "Nuevo subgrupo",
+          "d5e9f7a302": "Crear un subgrupo en {{value0}}.",
+          "e6f8a4c302": "Crear",
+          "c6d4e8a102": "subgrupo"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4254,7 +4254,12 @@
           "hostDisconnected": "Desconectado",
           "failedNestWorkspace": "No se pudo anidar el espacio de trabajo",
           "sidebarRowMissing": "El destino ya no existe",
-          "failedUnnestWorkspace": "Error al expandir el espacio de trabajo"
+          "failedUnnestWorkspace": "Error al expandir el espacio de trabajo",
+          "a7f5c2d901": "New subgroup",
+          "b8e6d3f012": "Move to root",
+          "c4d8e6f201": "New Subgroup",
+          "d5e9f7a302": "Create a subgroup under {{value0}}.",
+          "e6f8a4c302": "Create"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4235,7 +4235,12 @@
           "hostDisconnected": "切断済み",
           "failedNestWorkspace": "ワークスペースをネストできませんでした",
           "sidebarRowMissing": "対象はもう存在しません",
-          "failedUnnestWorkspace": "ワークスペースの展開に失敗しました"
+          "failedUnnestWorkspace": "ワークスペースの展開に失敗しました",
+          "a7f5c2d901": "New subgroup",
+          "b8e6d3f012": "Move to root",
+          "c4d8e6f201": "New Subgroup",
+          "d5e9f7a302": "Create a subgroup under {{value0}}.",
+          "e6f8a4c302": "Create"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4236,12 +4236,12 @@
           "failedNestWorkspace": "ワークスペースをネストできませんでした",
           "sidebarRowMissing": "対象はもう存在しません",
           "failedUnnestWorkspace": "ワークスペースの展開に失敗しました",
-          "a7f5c2d901": "New subgroup",
-          "b8e6d3f012": "Move to root",
-          "c4d8e6f201": "New Subgroup",
-          "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create",
-          "c6d4e8a102": "subgroup"
+          "a7f5c2d901": "新しいサブグループ",
+          "b8e6d3f012": "ルートに移動",
+          "c4d8e6f201": "新しいサブグループ",
+          "d5e9f7a302": "{{value0}} の下にサブグループを作成します。",
+          "e6f8a4c302": "作成",
+          "c6d4e8a102": "サブグループ"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4240,7 +4240,8 @@
           "b8e6d3f012": "Move to root",
           "c4d8e6f201": "New Subgroup",
           "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create"
+          "e6f8a4c302": "Create",
+          "c6d4e8a102": "subgroup"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4240,7 +4240,8 @@
           "b8e6d3f012": "Move to root",
           "c4d8e6f201": "New Subgroup",
           "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create"
+          "e6f8a4c302": "Create",
+          "c6d4e8a102": "subgroup"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "취소",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4235,7 +4235,12 @@
           "hostDisconnected": "연결 끊김",
           "failedNestWorkspace": "워크스페이스를 중첩하지 못했습니다",
           "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다",
-          "failedUnnestWorkspace": "워크트리 펼치기 실패"
+          "failedUnnestWorkspace": "워크트리 펼치기 실패",
+          "a7f5c2d901": "New subgroup",
+          "b8e6d3f012": "Move to root",
+          "c4d8e6f201": "New Subgroup",
+          "d5e9f7a302": "Create a subgroup under {{value0}}.",
+          "e6f8a4c302": "Create"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "취소",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4236,12 +4236,12 @@
           "failedNestWorkspace": "워크스페이스를 중첩하지 못했습니다",
           "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다",
           "failedUnnestWorkspace": "워크트리 펼치기 실패",
-          "a7f5c2d901": "New subgroup",
-          "b8e6d3f012": "Move to root",
-          "c4d8e6f201": "New Subgroup",
-          "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create",
-          "c6d4e8a102": "subgroup"
+          "a7f5c2d901": "새 하위 그룹",
+          "b8e6d3f012": "루트로 이동",
+          "c4d8e6f201": "새 하위 그룹",
+          "d5e9f7a302": "{{value0}} 아래에 하위 그룹을 만듭니다.",
+          "e6f8a4c302": "만들기",
+          "c6d4e8a102": "하위 그룹"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "취소",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4235,7 +4235,12 @@
           "hostDisconnected": "已断开连接",
           "failedNestWorkspace": "无法嵌套工作区",
           "sidebarRowMissing": "目标不再存在",
-          "failedUnnestWorkspace": "展开工作区失败"
+          "failedUnnestWorkspace": "展开工作区失败",
+          "a7f5c2d901": "New subgroup",
+          "b8e6d3f012": "Move to root",
+          "c4d8e6f201": "New Subgroup",
+          "d5e9f7a302": "Create a subgroup under {{value0}}.",
+          "e6f8a4c302": "Create"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4240,7 +4240,8 @@
           "b8e6d3f012": "Move to root",
           "c4d8e6f201": "New Subgroup",
           "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create"
+          "e6f8a4c302": "Create",
+          "c6d4e8a102": "subgroup"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4236,12 +4236,12 @@
           "failedNestWorkspace": "无法嵌套工作区",
           "sidebarRowMissing": "目标不再存在",
           "failedUnnestWorkspace": "展开工作区失败",
-          "a7f5c2d901": "New subgroup",
-          "b8e6d3f012": "Move to root",
-          "c4d8e6f201": "New Subgroup",
-          "d5e9f7a302": "Create a subgroup under {{value0}}.",
-          "e6f8a4c302": "Create",
-          "c6d4e8a102": "subgroup"
+          "a7f5c2d901": "新建子组",
+          "b8e6d3f012": "移到根级",
+          "c4d8e6f201": "新建子组",
+          "d5e9f7a302": "在 {{value0}} 下创建子组。",
+          "e6f8a4c302": "创建",
+          "c6d4e8a102": "子组"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",

--- a/src/renderer/src/store/slices/repos-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups.test.ts
@@ -136,6 +136,32 @@ describe('project group store routing', () => {
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
 
+  it('carries subgroup creation and three-state parent updates through local IPC', async () => {
+    projectGroupsCreate.mockResolvedValue({ ...projectGroup, parentGroupId: 'parent' })
+    const projectGroupsUpdate = vi.fn()
+    projectGroupsUpdate.mockResolvedValue({ ...projectGroup, parentGroupId: 'parent' })
+    const store = createTestStore()
+    window.api.projectGroups.update = projectGroupsUpdate
+
+    await store.getState().createProjectGroup('Child', 'parent')
+    await store.getState().updateProjectGroup('group-1', { parentGroupId: 'parent' })
+    await store.getState().updateProjectGroup('group-1', { parentGroupId: null })
+
+    expect(projectGroupsCreate).toHaveBeenCalledWith({
+      name: 'Child',
+      parentGroupId: 'parent',
+      createdFrom: 'manual'
+    })
+    expect(projectGroupsUpdate).toHaveBeenNthCalledWith(1, {
+      groupId: 'group-1',
+      updates: { parentGroupId: 'parent' }
+    })
+    expect(projectGroupsUpdate).toHaveBeenNthCalledWith(2, {
+      groupId: 'group-1',
+      updates: { parentGroupId: null }
+    })
+  })
+
   it('stamps local fetched folder groups with the local owner', async () => {
     const folderGroup = { ...projectGroup, parentPath: '/workspace/platform' }
     projectGroupsList.mockResolvedValue([folderGroup])

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1432,7 +1432,7 @@ export type RepoSlice = {
     scanId?: string
     mode: 'group' | 'separate'
   }) => Promise<ProjectGroupImportResult | null>
-  createProjectGroup: (name: string) => Promise<ProjectGroup | null>
+  createProjectGroup: (name: string, parentGroupId?: string) => Promise<ProjectGroup | null>
   createFolderWorkspace: (
     args: {
       projectGroupId: string
@@ -1482,7 +1482,9 @@ export type RepoSlice = {
   deleteFolderWorkspace: (folderWorkspaceId: string) => Promise<boolean>
   updateProjectGroup: (
     groupId: string,
-    updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>
+    updates: Partial<
+      Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color' | 'parentGroupId'>
+    >
   ) => Promise<boolean>
   deleteProjectGroup: (groupId: string) => Promise<boolean>
   deleteProjectGroupWithContainedProjects: (
@@ -2033,20 +2035,21 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  createProjectGroup: async (name) => {
+  createProjectGroup: async (name, parentGroupId) => {
     try {
       const target = getActiveRuntimeTarget(get().settings)
       const group =
         target.kind === 'local'
           ? await window.api.projectGroups.create({
               name,
+              ...(parentGroupId ? { parentGroupId } : {}),
               createdFrom: 'manual'
             })
           : (
               await callRuntimeRpc<{ group: ProjectGroup }>(
                 target,
                 'projectGroup.create',
-                { name, createdFrom: 'manual' },
+                { name, ...(parentGroupId ? { parentGroupId } : {}), createdFrom: 'manual' },
                 { timeoutMs: 15_000 }
               )
             ).group

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2046,13 +2046,16 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               createdFrom: 'manual'
             })
           : (
-              await callRuntimeRpc<{ group: ProjectGroup }>(
+              await callRuntimeRpc<{ group: ProjectGroup | null }>(
                 target,
                 'projectGroup.create',
                 { name, ...(parentGroupId ? { parentGroupId } : {}), createdFrom: 'manual' },
                 { timeoutMs: 15_000 }
               )
             ).group
+      if (!group) {
+        return null
+      }
       const ownedGroup = projectGroupWithFetchedOwner(group, target)
       set((s) => ({
         projectGroups: [...s.projectGroups, ownedGroup],

--- a/tests/e2e/project-group-nesting.spec.ts
+++ b/tests/e2e/project-group-nesting.spec.ts
@@ -35,12 +35,57 @@ test.describe('Project Group manual nesting @headful', () => {
       )
       .toBe(groups.parentId)
 
+    const childId = await orcaPage.evaluate(() => {
+      const child = window.__store
+        ?.getState()
+        .projectGroups.find((group) => group.name === 'E2E Child')
+      if (!child) {
+        throw new Error('E2E Child was not persisted')
+      }
+      return child.id
+    })
+    const childHeader = orcaPage.locator(`[data-project-group-header-id="${childId}"]`)
+    await expect(childHeader).toBeVisible()
+
     await parentHeader.getByRole('button', { name: /Group actions for E2E Parent/ }).click()
     await orcaPage.getByRole('menuitem', { name: 'Move to group' }).hover()
     await expect(orcaPage.getByRole('menuitem', { name: 'E2E Parent' })).toHaveCount(0)
+    await expect(orcaPage.getByRole('menuitem', { name: 'E2E Child' })).toHaveCount(0)
     await expect(orcaPage.getByRole('menuitem', { name: 'E2E Sibling' })).toBeVisible()
-    await orcaPage.screenshot({
-      path: 'D:/Repos/.claude/pr-sweep/artifacts/orca-8785-2-project-group-nesting-after-1280x800.png'
-    })
+    await orcaPage.getByRole('menuitem', { name: 'E2E Sibling', exact: true }).click()
+
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          (id) =>
+            window.__store?.getState().projectGroups.find((group) => group.id === id)
+              ?.parentGroupId,
+          groups.parentId
+        )
+      )
+      .toBe(groups.siblingId)
+
+    await parentHeader.getByRole('button', { name: /Group actions for E2E Parent/ }).click()
+    await orcaPage.getByRole('menuitem', { name: 'Move to root', exact: true }).click()
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          (id) =>
+            window.__store?.getState().projectGroups.find((group) => group.id === id)
+              ?.parentGroupId,
+          groups.parentId
+        )
+      )
+      .toBeNull()
+
+    await expect(parentHeader).toBeVisible()
+    await expect(childHeader).toBeVisible()
+    const parentPadding = await parentHeader.evaluate((element) =>
+      Number.parseFloat(getComputedStyle(element).paddingLeft)
+    )
+    const childPadding = await childHeader.evaluate((element) =>
+      Number.parseFloat(getComputedStyle(element).paddingLeft)
+    )
+    expect(childPadding).toBeGreaterThan(parentPadding)
   })
 })

--- a/tests/e2e/project-group-nesting.spec.ts
+++ b/tests/e2e/project-group-nesting.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+test.describe('Project Group manual nesting @headful', () => {
+  test('creates a subgroup and filters invalid parent targets', async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    const groups = await orcaPage.evaluate(async () => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      store.getState().setGroupBy('repo')
+      const parent = await store.getState().createProjectGroup('E2E Parent')
+      const sibling = await store.getState().createProjectGroup('E2E Sibling')
+      if (!parent || !sibling) {
+        throw new Error('Failed to create project groups')
+      }
+      return { parentId: parent.id, siblingId: sibling.id }
+    })
+
+    const parentHeader = orcaPage.locator(`[data-project-group-header-id="${groups.parentId}"]`)
+    await expect(parentHeader).toBeVisible()
+    await parentHeader.getByRole('button', { name: /Group actions for E2E Parent/ }).click()
+    await orcaPage.getByRole('menuitem', { name: 'New subgroup' }).click()
+    await orcaPage.getByRole('textbox').fill('E2E Child')
+    await orcaPage.getByRole('button', { name: 'Create' }).click()
+
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          () =>
+            window.__store?.getState().projectGroups.find((group) => group.name === 'E2E Child')
+              ?.parentGroupId
+        )
+      )
+      .toBe(groups.parentId)
+
+    await parentHeader.getByRole('button', { name: /Group actions for E2E Parent/ }).click()
+    await orcaPage.getByRole('menuitem', { name: 'Move to group' }).hover()
+    await expect(orcaPage.getByRole('menuitem', { name: 'E2E Parent' })).toHaveCount(0)
+    await expect(orcaPage.getByRole('menuitem', { name: 'E2E Sibling' })).toBeVisible()
+    await orcaPage.screenshot({
+      path: 'D:/Repos/.claude/pr-sweep/artifacts/orca-8785-2-project-group-nesting-after-1280x800.png'
+    })
+  })
+})

--- a/tests/e2e/project-group-nesting.spec.ts
+++ b/tests/e2e/project-group-nesting.spec.ts
@@ -45,7 +45,16 @@ test.describe('Project Group manual nesting @headful', () => {
       return child.id
     })
     const childHeader = orcaPage.locator(`[data-project-group-header-id="${childId}"]`)
+    const siblingHeader = orcaPage.locator(`[data-project-group-header-id="${groups.siblingId}"]`)
     await expect(childHeader).toBeVisible()
+    await expect(siblingHeader).toBeVisible()
+    const initialRootPadding = await parentHeader.evaluate((element) =>
+      Number.parseFloat(getComputedStyle(element).paddingLeft)
+    )
+    const initialChildPadding = await childHeader.evaluate((element) =>
+      Number.parseFloat(getComputedStyle(element).paddingLeft)
+    )
+    const nestedIndent = initialChildPadding - initialRootPadding
 
     await parentHeader.getByRole('button', { name: /Group actions for E2E Parent/ }).click()
     await orcaPage.getByRole('menuitem', { name: 'Move to group' }).hover()
@@ -80,12 +89,16 @@ test.describe('Project Group manual nesting @headful', () => {
 
     await expect(parentHeader).toBeVisible()
     await expect(childHeader).toBeVisible()
+    const siblingPadding = await siblingHeader.evaluate((element) =>
+      Number.parseFloat(getComputedStyle(element).paddingLeft)
+    )
     const parentPadding = await parentHeader.evaluate((element) =>
       Number.parseFloat(getComputedStyle(element).paddingLeft)
     )
     const childPadding = await childHeader.evaluate((element) =>
       Number.parseFloat(getComputedStyle(element).paddingLeft)
     )
-    expect(childPadding).toBeGreaterThan(parentPadding)
+    expect(parentPadding).toBe(siblingPadding)
+    expect(childPadding).toBe(parentPadding + nestedIndent)
   })
 })


### PR DESCRIPTION
## Summary

- Add `New subgroup`, `Move to group`, and `Move to root` actions to project-group header menus so manual group organization can match Orca's existing nested renderer.
- Carry `parentGroupId` through the existing create and update transport, with persistence rejecting self, descendant, and missing-parent assignments.
- Keep project-group drag and drop behavior unchanged so this slice stays disjoint from PR [#6911](https://github.com/stablyai/orca/pull/6911).

Refs #8785.

## Screenshots

No screenshot. Local headed Electron proof stayed deferred in this session after visible Orca windows and firewall prompts disrupted the desktop.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation to run:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts src/main/ipc/repos-remote.test.ts src/main/runtime/rpc/methods/repo.test.ts src/renderer/src/store/slices/repos-project-groups.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts`
- [x] `pnpm run typecheck:node`
- [x] `pnpm run typecheck:web`
- [x] `pnpm run verify:localization-catalog && pnpm run verify:localization-coverage`
- [x] `pnpm exec oxlint --config config/oxlint-react-doctor.json src/main/ipc/repos.ts src/main/persistence.ts src/main/runtime/orca-runtime.ts src/main/runtime/rpc/methods/repo.ts src/preload/api-types.ts src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/store/slices/repos.ts tests/e2e/project-group-nesting.spec.ts`
- [ ] `pnpm run test:e2e:headful -- tests/e2e/project-group-nesting.spec.ts --workers=1`, intentionally not rerun because this session is avoiding visible Electron work

## AI Review Report

- Cycle rejection, atomic invalid updates, local/runtime payload parity, candidate filtering, nested rendering preservation, localization, and drag-surface containment all received final-diff review coverage.
- The create path now preserves invalid empty-string parents through runtime transport, so persistence rejects them instead of silently coercing them into root creation.
- Menu-driven subgroup and reparent actions stay disjoint from the competing drag surface in PR [#6911](https://github.com/stablyai/orca/pull/6911).
- Headed Electron menu visibility and screenshot proof remain CI-owned until `tests/e2e/project-group-nesting.spec.ts` is rerun in a non-disruptive environment.

## Security Audit

IPC and runtime callers now preserve the full three-state `parentGroupId` contract into persistence, and persistence remains the final validation owner for self, descendant, missing-parent, and invalid-create rejection. Failed create and update attempts return `null` without partial mutation or notification side effects.

## Notes

This slice intentionally references the broader issue instead of closing it. Drag-to-nest and drag-to-root behavior remain outside scope. Hierarchy depth remains arbitrary and follows Orca's existing recursive renderer.

Local headed Electron proof was deferred in this session after disruptive Orca windows and firewall prompts during UI-owner verification. The branch carries the narrow Playwright coverage, but screenshot-backed rendered-layout proof remains pending until it can be rerun in a non-disruptive environment.
